### PR TITLE
fix: add init in utils

### DIFF
--- a/composio/cli/__init__.py
+++ b/composio/cli/__init__.py
@@ -16,6 +16,7 @@ from composio.cli.logout import _logout
 from composio.cli.triggers import _triggers
 from composio.cli.whoami import _whoami
 from composio.core.cls.did_you_mean import DYMGroup
+from composio.cli.utils import HelpfulCmdBase
 
 
 class HelpDYMGroup(DYMGroup):

--- a/composio/cli/utils/__init__.py
+++ b/composio/cli/utils/__init__.py
@@ -1,0 +1,1 @@
+from .helpfulcmd import HelpfulCmdBase


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added `HelpfulCmdBase` import in `composio/cli/__init__.py` to enhance CLI functionality.
- Introduced `HelpfulCmdBase` in `composio/cli/utils/__init__.py` for better modularization.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Import `HelpfulCmdBase` in CLI initialization.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
composio/cli/__init__.py

- Imported `HelpfulCmdBase` from `composio.cli.utils`.



</details>
    

  </td>
  <td><a href="https://github.com/ComposioHQ/composio/pull/116/files#diff-8673a267670e10eac352c3a1cf5fcdbb1dd3c8f1ed12ebb9b5126b1836d45e36">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Add `HelpfulCmdBase` import in utils initialization.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
composio/cli/utils/__init__.py

- Added import statement for `HelpfulCmdBase` from `helpfulcmd`.



</details>
    

  </td>
  <td><a href="https://github.com/ComposioHQ/composio/pull/116/files#diff-51bc133f3aea9b6c43e373e171ee46f67bb56dc2e3366c4f4705864fa6c35068">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

