### PR TITLE
Make req and resp any

### DIFF
--- a/python/composio/client/collections.py
+++ b/python/composio/client/collections.py
@@ -962,7 +962,7 @@ class Actions(Collection[ActionModel]):
         for param, value in params.items():
             file_readable = False
             if isinstance(action_req_schema[param], dict):
-                file_readable = action_req_schema[param].get('file_readable', False)
+                file_readable = action_req_schema[param].get("file_readable", False)
             if file_readable and isinstance(value, str) and os.path.isfile(value):
                 with open(value, "rb") as file:
                     file_content = file.read()

--- a/python/composio/client/collections.py
+++ b/python/composio/client/collections.py
@@ -758,40 +758,20 @@ class ActiveTriggers(Collection[ActiveTriggerModel]):
         return self._raise_if_empty(super().get(queries=queries))
 
 
-class ActionParameterPropertyModel(BaseModel):
-    """Action parameter data model."""
-
-    examples: t.Optional[t.List] = None
-    description: t.Optional[str] = None
-    title: t.Optional[str] = None
-    type: t.Optional[str] = None
-    oneOf: t.Optional[t.List["ActionParameterPropertyModel"]] = None
-    file_readable: t.Optional[bool] = False
-
-
 class ActionParametersModel(BaseModel):
     """Action parameter data models."""
 
-    properties: t.Dict[str, ActionParameterPropertyModel]
+    properties: t.Dict[str, t.Any]
     title: str
     type: str
 
     required: t.Optional[t.List[str]] = None
 
 
-class ActionResponsePropertyModel(BaseModel):
-    """Action response data model."""
-
-    description: t.Optional[str] = None
-    examples: t.Optional[t.List] = None
-    title: t.Optional[str] = None
-    type: t.Optional[str] = None
-
-
 class ActionResponseModel(BaseModel):
     """Action response data model."""
 
-    properties: t.Dict[str, ActionResponsePropertyModel]
+    properties: t.Dict[str, t.Any]
     title: str
     type: str
 
@@ -980,7 +960,9 @@ class Actions(Collection[ActionModel]):
         action_req_schema = action_model.parameters.properties
         modified_params = {}
         for param, value in params.items():
-            file_readable = action_req_schema[param].file_readable or False
+            file_readable = False
+            if isinstance(action_req_schema[param], dict):
+                file_readable = action_req_schema[param].get('file_readable', False)
             if file_readable and isinstance(value, str) and os.path.isfile(value):
                 with open(value, "rb") as file:
                     file_content = file.read()

--- a/python/composio/tools/__init__.py
+++ b/python/composio/tools/__init__.py
@@ -140,7 +140,7 @@ class ComposioToolSet:
             )
             return output_modified
         except Exception as e:
-            print(f"Error checking file response: {e}")
+            pass
         return output
 
     def _save_files(self, file_name_prefix: str, output: dict) -> dict:

--- a/python/composio/tools/__init__.py
+++ b/python/composio/tools/__init__.py
@@ -139,7 +139,7 @@ class ComposioToolSet:
                 output,
             )
             return output_modified
-        except Exception as e:
+        except Exception:
             pass
         return output
 


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Generalized the `ActionParametersModel` and `ActionResponseModel` by changing the `properties` field to accept any type (`t.Any`).
- Removed the `ActionParameterPropertyModel` and `ActionResponsePropertyModel` classes as they are no longer needed.
- Updated the `execute` method to correctly handle the `file_readable` property when `properties` is a dictionary.
- Suppressed error messages in the `execute_action` method by replacing the print statement with `pass`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>collections.py</strong><dd><code>Generalize action parameter and response models</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
python/composio/client/collections.py

<li>Changed <code>ActionParametersModel</code> and <code>ActionResponseModel</code> to use <code>t.Any</code> for <br><code>properties</code> instead of specific models.<br> <li> Removed <code>ActionParameterPropertyModel</code> and <code>ActionResponsePropertyModel</code> <br>classes.<br> <li> Updated <code>execute</code> method to handle <code>file_readable</code> property correctly when <br><code>properties</code> is a dictionary.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ComposioHQ/composio/pull/197/files#diff-4bae1393a4b5e1f07b5b87855fed9d56811d949225a47921cad5d4cc75c71e13">+5/-23</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Suppress error messages in execute_action method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
python/composio/tools/__init__.py

<li>Replaced error print statement with <code>pass</code> in <code>execute_action</code> method.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ComposioHQ/composio/pull/197/files#diff-83a61c9fc92e7ac84b32fda7f1c86de48b59968e393eb1ad93e87dfaad0f68fc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

