### PR TITLE
fix: auto get connected accounts in entity.execute()

### DIFF
--- a/js/src/sdk/client/services.gen.ts
+++ b/js/src/sdk/client/services.gen.ts
@@ -58,6 +58,7 @@ export const listAllConnections = (data: ListAllConnectionsData = {}, config: ty
     url: '/v1/connectedAccounts',
     query: {
         user_uuid: data.user_uuid,
+        appNames: data.appNames?.join(','),
         page: data.page,
         pageSize: data.pageSize,
         integrationId: data.integrationId

--- a/js/src/sdk/client/types.gen.ts
+++ b/js/src/sdk/client/types.gen.ts
@@ -95,6 +95,16 @@ export type ListAllConnectionsData = {
     user_uuid?: string;
 
     /**
+     * Filter by using specific app names, seperated by comma
+     */
+    appNames?: string[];
+
+    /**
+     * Filter by using specific status, seperated by comma
+     */
+    status?: string;
+
+    /**
      * Page number to fetch
      */
     page?: number;

--- a/js/src/sdk/index.ts
+++ b/js/src/sdk/index.ts
@@ -139,7 +139,9 @@ export class Entity {
             });
         } else {
             const connectedAccounts = await this.client.connectedAccounts.list({
-                user_uuid: this.id
+                user_uuid: this.id,
+                appNames: [action.appKey!],
+                status: 'ACTIVE'
             });
             if (connectedAccounts.items!.length === 0) {
                 throw new Error('No connected account found');


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added `appNames` query parameter to the `listAllConnections` function in `services.gen.ts`.
- Added `appNames` and `status` fields to `ListAllConnectionsData` type in `types.gen.ts`.
- Updated `Entity.execute` method to include `appNames` and `status` filters when listing connected accounts in `index.ts`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>services.gen.ts</strong><dd><code>Add `appNames` query parameter to listAllConnections function</code></dd></summary>
<hr>

js/src/sdk/client/services.gen.ts

<li>Added <code>appNames</code> query parameter to the <code>listAllConnections</code> function.<br>


</details>


  </td>
  <td><a href="https://github.com/ComposioHQ/composio/pull/269/files#diff-7943597be0769230c63ff83ba74782cdb97a074709e51fb46c262c49b53c3541">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>types.gen.ts</strong><dd><code>Add `appNames` and `status` fields to ListAllConnectionsData type</code></dd></summary>
<hr>

js/src/sdk/client/types.gen.ts

<li>Added <code>appNames</code> and <code>status</code> fields to <code>ListAllConnectionsData</code> type.<br>


</details>


  </td>
  <td><a href="https://github.com/ComposioHQ/composio/pull/269/files#diff-3ab01407d70ffe2309b373f8828a40883c35a389afdb0122fb626dafaf39b56d">+10/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Update Entity.execute to filter connected accounts by appNames and </code><br><code>status</code></dd></summary>
<hr>

js/src/sdk/index.ts

<li>Updated <code>Entity.execute</code> method to include <code>appNames</code> and <code>status</code> filters <br>when listing connected accounts.<br>


</details>


  </td>
  <td><a href="https://github.com/ComposioHQ/composio/pull/269/files#diff-de82114af414fc4b45690c3f12d436b62d6270bd11e7b985bc37de196609651e">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

