### PR TITLE
feat: get_agent_instruction method added to toolset

### DIFF
--- a/python/plugins/openai/openai_demo.py
+++ b/python/plugins/openai/openai_demo.py
@@ -3,7 +3,7 @@ OpenAI demo.
 """
 
 import dotenv
-from composio_openai import App, ComposioToolSet
+from composio_openai import Action, App, ComposioToolSet
 from openai import OpenAI
 
 
@@ -19,9 +19,16 @@ task = "Star a repo SamparkAI/composio_sdk on GitHub"
 
 # Get GitHub tools that are pre-configured
 tools = composio_toolset.get_tools(apps=[App.GITHUB])
-# from pprint import pprint
-# pprint(tools)
-# print(tools)
+
+# Extension of system prompt(Not using at this moment)
+_ = composio_toolset.get_agent_instructions(
+    apps=[App.GMAIL],
+    actions=[
+        Action.GITHUB_ACTIONS_ADD_CUSTOM_LABELS_TO_SELF_HOSTED_RUNNER_FOR_ORG,
+        Action.ASANA_ALLOCATIONS_DELETE_ALLOCATION_BY_ID
+    ]
+)
+
 # Get response from the LLM
 response = openai_client.chat.completions.create(
     model="gpt-4-turbo-preview",

--- a/python/plugins/openai/openai_demo.py
+++ b/python/plugins/openai/openai_demo.py
@@ -25,8 +25,8 @@ _ = composio_toolset.get_agent_instructions(
     apps=[App.GMAIL],
     actions=[
         Action.GITHUB_ACTIONS_ADD_CUSTOM_LABELS_TO_SELF_HOSTED_RUNNER_FOR_ORG,
-        Action.ASANA_ALLOCATIONS_DELETE_ALLOCATION_BY_ID
-    ]
+        Action.ASANA_ALLOCATIONS_DELETE_ALLOCATION_BY_ID,
+    ],
 )
 
 # Get response from the LLM


### PR DESCRIPTION
Example Usage:

```
composio_toolset.get_agent_instructions(
    apps=[App.GMAIL],
    actions=[
        Action.GITHUB_ACTIONS_ADD_CUSTOM_LABELS_TO_SELF_HOSTED_RUNNER_FOR_ORG,
        Action.ASANA_ALLOCATIONS_DELETE_ALLOCATION_BY_ID
    ]
)
```
> You have various tools, among which for interacting with **gmail** you might use gmail_send_email, gmail_create_email_draft, gmail_add_label_to_email, gmail_list_labels, gmail_reply_to_thread, gmail_fetch_emails_with_label, gmail_fetch_last_three_messages, gmail_fetch_message_by_thread_id and gmail_find_email_id tools, for interacting with **asana** you might use asana_allocations_delete_allocation_by_id tools, for interacting with **github** you might use github_actions_add_custom_labels_to_self_hosted_runner_for_org tools. Whichever tool is useful to execute your task, use that with proper parameters.