### PR TITLE
Add integration by id function

### DIFF
--- a/python/composio/client/collections.py
+++ b/python/composio/client/collections.py
@@ -1098,3 +1098,18 @@ class Integrations(Collection[IntegrationModel]):
             )
         )
         return IntegrationModel(**response.json())
+
+    def get_by_id(
+        self,
+        integration_id: str,
+    ) -> IntegrationModel:
+        """
+        Get an integration by its ID.
+
+        :param integration_id: Integration ID string.
+        :return: Integration model.
+        """
+        response = self._raise_if_required(
+            self.client.http.get(url=str(self.endpoint / integration_id))
+        )
+        return IntegrationModel(**response.json())


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added a new method `get_by_id` in `python/composio/client/collections.py` to retrieve an integration by its ID.
- Included a docstring to describe the new method's parameters and return type.
- Utilized the existing `_raise_if_required` method to handle HTTP response errors.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>collections.py</strong><dd><code>Add method to retrieve integration by ID</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/composio/client/collections.py

<li>Added a new method <code>get_by_id</code> to retrieve an integration by its ID.<br> <li> Included a docstring for the new method.<br> <li> Utilized the existing <code>_raise_if_required</code> method for error handling.<br>


</details>


  </td>
  <td><a href="https://github.com/ComposioHQ/composio/pull/299/files#diff-4bae1393a4b5e1f07b5b87855fed9d56811d949225a47921cad5d4cc75c71e13">+15/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

