### PR TITLE
feat: return value from _handle_callback for playground

### DIFF
--- a/python/composio/client/collections.py
+++ b/python/composio/client/collections.py
@@ -497,7 +497,7 @@ class TriggerSubscription(logging.WithLogger):
         callback: TriggerCallback,
         data: TriggerEventData,
         filters: _TriggerEventFilters,
-    ) -> None:
+    ) -> t.Any:
         """Handle callback."""
         for name, check in (
             ("app_name", data.appName),
@@ -518,7 +518,7 @@ class TriggerSubscription(logging.WithLogger):
             return
 
         try:
-            callback(data)
+            return callback(data)
         except BaseException:
             self.logger.info(
                 f"Erorr executing `{callback.__name__}` for "

--- a/python/composio/client/collections.py
+++ b/python/composio/client/collections.py
@@ -515,7 +515,7 @@ class TriggerSubscription(logging.WithLogger):
                 f"Skipping `{callback.__name__}` since "
                 f"`{name}` filter does not match the event metadata",
             )
-            return
+            return None
 
         try:
             return callback(data)
@@ -525,6 +525,7 @@ class TriggerSubscription(logging.WithLogger):
                 f"event `{data.metadata.triggerName}` "
                 f"with error:\n {traceback.format_exc()}"
             )
+            return None
 
     def _parse_payload(self, event: str) -> t.Optional[TriggerEventData]:
         """Parse event payload."""


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Changed the return type of `_handle_callback` method from `None` to `t.Any`.
- Modified the `_handle_callback` method to return the result of the `callback` function.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>collections.py</strong><dd><code>Modify `_handle_callback` to return callback result</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/composio/client/collections.py

<li>Changed the return type of <code>_handle_callback</code> method from <code>None</code> to <code>t.Any</code>.<br> <li> Modified the method to return the result of the <code>callback</code> function.<br>


</details>


  </td>
  <td><a href="https://github.com/ComposioHQ/composio/pull/313/files#diff-4bae1393a4b5e1f07b5b87855fed9d56811d949225a47921cad5d4cc75c71e13">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

