### PR TITLE
chore: remove Error checking file response print statement

### DIFF
--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -194,7 +194,7 @@ class ComposioToolSet(WithLogger):
                 f"{action.name}_{entity_id}_{time.time()}", output
             )
             return output_modified
-        except Exception as e:
+        except Exception:
             pass
         return output
 

--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -195,7 +195,7 @@ class ComposioToolSet(WithLogger):
             )
             return output_modified
         except Exception as e:
-            print(f"Error checking file response: {e}")
+            pass
         return output
 
     def _save_var_files(self, file_name_prefix: str, output: dict) -> dict:


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Removed the print statement for error checking in the `_execute_remote` method of `toolset.py`.
- Replaced the print statement with `pass` to handle exceptions silently.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>toolset.py</strong><dd><code>Remove error checking print statement in `_execute_remote` method</code></dd></summary>
<hr>

python/composio/tools/toolset.py

<li>Removed print statement for error checking in <code>_execute_remote</code> method.<br> <li> Replaced print statement with <code>pass</code> to handle exceptions silently.<br>


</details>


  </td>
  <td><a href="https://github.com/ComposioHQ/composio/pull/323/files#diff-89b5c0aec15f01eb54ad26f78731b68f650e438a443378282b436df85abde51d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

