### PR TITLE
added exclude none in serialiser

### DIFF
--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -289,10 +289,10 @@ class ComposioToolSet(WithLogger):
             return param  # type: ignore
 
         if isinstance(param, BaseModel):
-            return param.model_dump_json()  # type: ignore
+            return param.model_dump_json(exclude_none=True)  # type: ignore
 
         if isinstance(param, V1BaseModel):
-            return param.dict()  # type: ignore
+            return param.dict(exclude_none=True)  # type: ignore
 
         if isinstance(param, list):
             return [self._serialize_execute_params(p) for p in param]  # type: ignore


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed an issue in `_serialize_execute_params` method where `None` values were not being excluded during JSON serialization.
- Updated `model_dump_json` and `dict` method calls to include `exclude_none=True` parameter.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>toolset.py</strong><dd><code>Exclude `None` values in JSON serialization for models</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/composio/tools/toolset.py

<li>Updated <code>_serialize_execute_params</code> method to exclude <code>None</code> values in <br>JSON serialization.<br> <li> Modified <code>model_dump_json</code> and <code>dict</code> methods to use <code>exclude_none=True</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/ComposioHQ/composio/pull/343/files#diff-89b5c0aec15f01eb54ad26f78731b68f650e438a443378282b436df85abde51d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

