### PR TITLE
Pass scope for oauth

### DIFF
--- a/python/composio/cli/add.py
+++ b/python/composio/cli/add.py
@@ -240,6 +240,7 @@ def add_integration(
         app_name=name,
         no_browser=no_browser,
         integration=integration,
+        scopes=scopes,
     )
 
 
@@ -264,12 +265,14 @@ def _handle_oauth(
     app_name: str,
     no_browser: bool = False,
     integration: t.Optional[IntegrationModel] = None,
+    scopes: t.Optional[t.Tuple[str, ...]] = None,
 ) -> None:
     """Handle basic auth."""
     connection = entity.initiate_connection(
         app_name=app_name.lower(),
         redirect_url=get_web_url(path="redirect"),
         integration=integration,
+        auth_config=_get_auth_config(scopes=scopes),
     )
     if not no_browser:
         webbrowser.open(


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Enhanced the `add_integration` function to accept and pass `scopes` parameter.
- Modified `_handle_oauth` function to handle `scopes` and pass it to `_get_auth_config`.
- Ensured OAuth scopes are properly integrated into the connection initiation process.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>add.py</strong><dd><code>Add support for OAuth scopes in integration functions</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/composio/cli/add.py

<li>Added <code>scopes</code> parameter to <code>add_integration</code> and <code>_handle_oauth</code> functions.<br> <li> Updated <code>_handle_oauth</code> to pass <code>scopes</code> to <code>_get_auth_config</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/ComposioHQ/composio/pull/347/files#diff-81ec0bffc6a41cf112d6e13aaf2faba926086272436c26d342ad4e05de75cf24">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

