### PR TITLE
feat: add support for workspace history

### DIFF
--- a/python/composio/tools/env/base.py
+++ b/python/composio/tools/env/base.py
@@ -41,7 +41,7 @@ class Shell(ABC, WithLogger):
     """Abstract shell session."""
 
     _id: str
-    execute_commands: t.List[dict] = []
+    executed_commands_history: t.List[dict] = []
 
     def sanitize_command(self, cmd: str) -> bytes:
         """Prepare command string."""

--- a/python/composio/tools/env/base.py
+++ b/python/composio/tools/env/base.py
@@ -41,6 +41,7 @@ class Shell(ABC, WithLogger):
     """Abstract shell session."""
 
     _id: str
+    execute_commands: t.List[dict] = []
 
     def sanitize_command(self, cmd: str) -> bytes:
         """Prepare command string."""

--- a/python/composio/tools/env/host/shell.py
+++ b/python/composio/tools/env/host/shell.py
@@ -6,6 +6,7 @@ import select
 import subprocess
 import time
 import typing as t
+from datetime import datetime
 from pathlib import Path
 
 import paramiko
@@ -55,6 +56,7 @@ class HostShell(Shell):
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            shell=True,
             bufsize=1,
         )
         self.logger.debug(
@@ -145,6 +147,12 @@ class HostShell(Shell):
     def exec(self, cmd: str) -> t.Dict:
         """Execute command on container."""
         self._write(cmd=cmd)
+        self.execute_commands.append(
+            {
+                "cmd": cmd,
+                "executed_at": datetime.now(),
+            }
+        )
         return {
             **self._read(cmd=cmd, wait=True),
             EXIT_CODE: self._get_exit_code(),
@@ -244,6 +252,12 @@ class SSHShell(Shell):
     def exec(self, cmd: str, stdin: t.Optional[str] = None) -> t.Dict:
         """Execute a command and return output and exit code."""
         output = ""
+        self.execute_commands.append(
+            {
+                "cmd": cmd,
+                "executed_at": datetime.now(),
+            }
+        )
         for _cmd in cmd.split(" && "):
             self._send(buffer=_cmd, stdin=stdin)
             self._wait(cmd=_cmd)

--- a/python/composio/tools/env/host/shell.py
+++ b/python/composio/tools/env/host/shell.py
@@ -147,7 +147,7 @@ class HostShell(Shell):
     def exec(self, cmd: str) -> t.Dict:
         """Execute command on container."""
         self._write(cmd=cmd)
-        self.execute_commands.append(
+        self.executed_commands_history.append(
             {
                 "cmd": cmd,
                 "executed_at": datetime.now(),
@@ -252,7 +252,7 @@ class SSHShell(Shell):
     def exec(self, cmd: str, stdin: t.Optional[str] = None) -> t.Dict:
         """Execute a command and return output and exit code."""
         output = ""
-        self.execute_commands.append(
+        self.executed_commands_history.append(
             {
                 "cmd": cmd,
                 "executed_at": datetime.now(),

--- a/python/composio/tools/local/shelltool/history_keeper/actions/get_workspace_history.py
+++ b/python/composio/tools/local/shelltool/history_keeper/actions/get_workspace_history.py
@@ -1,8 +1,4 @@
-import os
-import subprocess
-import time
 from datetime import datetime
-from re import L
 
 from pydantic import BaseModel, Field
 
@@ -77,7 +73,9 @@ class GetWorkspaceHistory(
                 executed_time_ago=format_timestamp(command["executed_at"]),
                 command=command["cmd"],
             )
-            for command in shell.executed_commands_history[-request_data.last_n_commands :]
+            for command in shell.executed_commands_history[
+                -request_data.last_n_commands:
+            ]
         ]
         return {
             "workspace_command_history": workspace_command_history,

--- a/python/composio/tools/local/shelltool/history_keeper/actions/get_workspace_history.py
+++ b/python/composio/tools/local/shelltool/history_keeper/actions/get_workspace_history.py
@@ -74,7 +74,7 @@ class GetWorkspaceHistory(
                 command=command["cmd"],
             )
             for command in shell.executed_commands_history[
-                -request_data.last_n_commands:
+                -request_data.last_n_commands :
             ]
         ]
         return {

--- a/python/composio/tools/local/shelltool/history_keeper/actions/get_workspace_history.py
+++ b/python/composio/tools/local/shelltool/history_keeper/actions/get_workspace_history.py
@@ -77,7 +77,7 @@ class GetWorkspaceHistory(
                 executed_time_ago=format_timestamp(command["executed_at"]),
                 command=command["cmd"],
             )
-            for command in shell.execute_commands[-request_data.last_n_commands :]
+            for command in shell.executed_commands_history[-request_data.last_n_commands :]
         ]
         return {
             "workspace_command_history": workspace_command_history,

--- a/python/composio/tools/local/shelltool/history_keeper/actions/get_workspace_history.py
+++ b/python/composio/tools/local/shelltool/history_keeper/actions/get_workspace_history.py
@@ -1,22 +1,65 @@
+from re import L
 from pydantic import BaseModel, Field
 
 from composio.tools.local.base import Action
 from composio.tools.local.shelltool.shell_exec.actions.exec import ShellExecRequest
 from composio.utils.logging import get as get_logger
-
+import subprocess
+import os
+import time
 
 STATUS_RUNNING = "running"
 STATUS_STOPPED = "stopped"
 logger = get_logger("workspace")
 
 
-class GetWorkspaceHistoryRequest(ShellExecRequest):
-    pass
+def get_history_file():
+    zsh_file =  os.path.expanduser('~/.zsh_history')
+    bash_file =  os.path.expanduser('~/.bash_history')
+    fish_file = os.path.expanduser('~/.config/fish/fish_history')
+    try:
+        with open(zsh_file, 'r', encoding='utf-8', errors='replace') as file:
+            return zsh_file
+    except Exception as e:
+        print(f"Failed to get history file: {e}")
+    
+    try:
+        with open(bash_file, 'r', encoding='utf-8', errors='replace') as file:
+            return bash_file
+    except Exception as e:
+        print(f"Failed to get history file: {e}")
+
+    try:
+        with open(fish_file, 'r', encoding='utf-8', errors='replace') as file:
+            return fish_file
+    except Exception as e:
+        print(f"Failed to get fish history file: {e}")
+    
+    return None
+    
+
+def format_timestamp(command_time):
+    current_time = time.time()
+    elapsed_seconds = current_time - float(command_time.replace(': ', '').replace(':0', ''))
+    minutes = int(elapsed_seconds // 60)
+    seconds = int(elapsed_seconds % 60)
+    return f"{minutes} mins {seconds} secs ago"
+
+class GetWorkspaceHistoryRequest(BaseModel):
+    last_n_commands: int = Field(
+        ..., description="Number of last commands to fetch"
+    )
 
 
 class GetWorkspaceHistoryResponse(BaseModel):
-    workspace_history: dict = Field(
+    is_success: bool = Field(
+        ..., description="Whether the history fetch was successful"
+    )
+    workspace_command_history: list[str] = Field(
         ..., description="history of last n commands on the workspace"
+    )
+    error: str = Field(
+        ..., description="Error message if the history fetch was not successful"
     )
 
 
@@ -43,4 +86,26 @@ class GetWorkspaceHistory(
         request_data: GetWorkspaceHistoryRequest,
         authorisation_data: dict,
     ) -> dict:
-        return {}
+        import os
+
+        history_file = '~/.zsh_history'
+        full_path = os.path.expanduser(history_file)
+
+        try:
+            with open(full_path, 'r', encoding='utf-8', errors='replace') as file:
+                history = file.readlines()[-request_data.last_n_commands:]  # Fetch the last n commands based on the request
+            commands = [{
+                "execute_time_ago": format_timestamp(command.split(';')[0]),
+                "command": command.split(';')[1].strip()
+            } for command in history[-2:]]
+            return {
+                "workspace_command_history": commands,
+                "is_success": True
+            }
+        except Exception as e:
+            print(f"Error reading history file: {e}")
+            return {
+                "workspace_command_history": [],
+                "is_success": False,
+                "error": str(e)
+            }

--- a/python/composio/tools/local/shelltool/history_keeper/actions/get_workspace_history.py
+++ b/python/composio/tools/local/shelltool/history_keeper/actions/get_workspace_history.py
@@ -1,61 +1,43 @@
+import os
+import subprocess
+import time
+from datetime import datetime
 from re import L
+
 from pydantic import BaseModel, Field
 
 from composio.tools.local.base import Action
-from composio.tools.local.shelltool.shell_exec.actions.exec import ShellExecRequest
 from composio.utils.logging import get as get_logger
-import subprocess
-import os
-import time
+
 
 STATUS_RUNNING = "running"
 STATUS_STOPPED = "stopped"
 logger = get_logger("workspace")
 
 
-def get_history_file():
-    zsh_file =  os.path.expanduser('~/.zsh_history')
-    bash_file =  os.path.expanduser('~/.bash_history')
-    fish_file = os.path.expanduser('~/.config/fish/fish_history')
-    try:
-        with open(zsh_file, 'r', encoding='utf-8', errors='replace') as file:
-            return zsh_file
-    except Exception as e:
-        print(f"Failed to get history file: {e}")
-    
-    try:
-        with open(bash_file, 'r', encoding='utf-8', errors='replace') as file:
-            return bash_file
-    except Exception as e:
-        print(f"Failed to get history file: {e}")
-
-    try:
-        with open(fish_file, 'r', encoding='utf-8', errors='replace') as file:
-            return fish_file
-    except Exception as e:
-        print(f"Failed to get fish history file: {e}")
-    
-    return None
-    
-
 def format_timestamp(command_time):
-    current_time = time.time()
-    elapsed_seconds = current_time - float(command_time.replace(': ', '').replace(':0', ''))
+    current_time = datetime.now()
+    elapsed_seconds = (current_time - command_time).total_seconds()
     minutes = int(elapsed_seconds // 60)
     seconds = int(elapsed_seconds % 60)
     return f"{minutes} mins {seconds} secs ago"
 
+
+class CommandHistory(BaseModel):
+    executed_time_ago: str = Field(..., description="executed at")
+    command: str = Field(..., description="command")
+
+
 class GetWorkspaceHistoryRequest(BaseModel):
-    last_n_commands: int = Field(
-        ..., description="Number of last commands to fetch"
-    )
+    last_n_commands: int = Field(..., description="Number of last commands to fetch")
+    shell_id: str = Field(..., description="shell id")
 
 
 class GetWorkspaceHistoryResponse(BaseModel):
     is_success: bool = Field(
         ..., description="Whether the history fetch was successful"
     )
-    workspace_command_history: list[str] = Field(
+    workspace_command_history: list[CommandHistory] = Field(
         ..., description="history of last n commands on the workspace"
     )
     error: str = Field(
@@ -86,26 +68,18 @@ class GetWorkspaceHistory(
         request_data: GetWorkspaceHistoryRequest,
         authorisation_data: dict,
     ) -> dict:
-        import os
+        print("execute")
+        print(authorisation_data)
+        shell = authorisation_data.get("workspace").shells.get(id=request_data.shell_id)  # type: ignore
 
-        history_file = '~/.zsh_history'
-        full_path = os.path.expanduser(history_file)
-
-        try:
-            with open(full_path, 'r', encoding='utf-8', errors='replace') as file:
-                history = file.readlines()[-request_data.last_n_commands:]  # Fetch the last n commands based on the request
-            commands = [{
-                "execute_time_ago": format_timestamp(command.split(';')[0]),
-                "command": command.split(';')[1].strip()
-            } for command in history[-2:]]
-            return {
-                "workspace_command_history": commands,
-                "is_success": True
-            }
-        except Exception as e:
-            print(f"Error reading history file: {e}")
-            return {
-                "workspace_command_history": [],
-                "is_success": False,
-                "error": str(e)
-            }
+        workspace_command_history = [
+            CommandHistory(
+                executed_time_ago=format_timestamp(command["executed_at"]),
+                command=command["cmd"],
+            )
+            for command in shell.execute_commands[-request_data.last_n_commands :]
+        ]
+        return {
+            "workspace_command_history": workspace_command_history,
+            "is_success": True,
+        }

--- a/python/swe/examples/crewai_agent/requirements.txt
+++ b/python/swe/examples/crewai_agent/requirements.txt
@@ -1,0 +1,3 @@
+crewai
+langchain_anthropic
+langchain_google_vertexai

--- a/python/tests/test_tools/test_local/test_workspace_history.py
+++ b/python/tests/test_tools/test_local/test_workspace_history.py
@@ -2,8 +2,6 @@
 
 from pathlib import Path
 
-import pytest
-
 from composio import Action, ComposioToolSet
 from composio.tools.env.factory import WorkspaceType
 

--- a/python/tests/test_tools/test_local/test_workspace_history.py
+++ b/python/tests/test_tools/test_local/test_workspace_history.py
@@ -1,0 +1,29 @@
+"""Test workspace tools."""
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from composio import Action, ComposioToolSet
+from composio.tools.env.constants import EXIT_CODE, STDERR, STDOUT
+from composio.tools.env.factory import WorkspaceType
+
+
+
+PATH = Path(__file__).parent
+
+
+def test_workspace_history() -> None:
+    """Test outputs."""
+    toolset = ComposioToolSet(
+        workspace_config=WorkspaceType.Host(),
+    )
+    output = toolset.execute_action(
+        action=Action.HISTORYFETCHERTOOL_GET_WORKSPACE_HISTORY,
+        params={"last_n_commands": 2},
+    )
+
+    assert len(output['workspace_command_history']) > 0, "No commands found in workspace history."
+

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -131,7 +131,7 @@ sections=FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,PLUGINS,PACKAGES,LOCALFOLDER
 max_line_length = 200
 exclude= **/build, **/dist
 per-file-ignores = __init__.py:F401,W503
-ignore = E231, W291, W503
+ignore = E231, W291, W503, E203
 
 [mypy]
 strict_optional = True


### PR DESCRIPTION
**Future consideration**
- Current shell solution won't work with session from 2 different machines. We would need to shell idempotency.
- These command are not available in history of sheel. We will have [explicitly add](https://stackoverflow.com/a/54592986) it but that can have unwanted results. 

**Future upgrades**
- Add status_code and output if needed