### PR TITLE
fix: Makefile bin/sh compatibility (wsl)

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -92,7 +92,7 @@ format-and-check:
 
 .PHONY: env
 env: clean
-	if [[ "$$VIRTUAL_ENV" == "" ]];\
+	if [ -z "$$VIRTUAL_ENV"];\
 	then\
 		pipenv --rm;\
 		pipenv --clear;\


### PR DESCRIPTION
### Problem 
Was facing this error while running ``` make env``` in wsl
![image](https://github.com/user-attachments/assets/003094f5-e46e-413e-bd84-2fb263c95b16)
 

```
if [[ -z "$$VIRTUAL_ENV" ]]; then \
        echo "No virtual environment is active"; \
```
The original code used the [[ ... ]] syntax for checking if the VIRTUAL_ENV variable was empty, but [[ ... ]] is a Bash-specific feature and wasn't being interpreted correctly in the Makefile's default shell (/bin/sh).

### Change:

Replaced [[ ... ]] with [ ... ] to ensure compatibility with /bin/sh.
The -z flag is used to check if the VIRTUAL_ENV variable is either empty or undefined (i.e., a zero-length or null string).