### PR TITLE
fix: use `sed -i.bak` instead of plain `sed`

### DIFF
--- a/python/examples/image_search/image_search_autogen/setup.sh
+++ b/python/examples/image_search/image_search_autogen/setup.sh
@@ -24,8 +24,13 @@ fi
 # Prompt the user to enter the OPENAI_API_KEY
 read -p "Enter your OPENAI_API_KEY: " OPENAI_API_KEY
 
-# Update the .env file with the entered OPENAI_API_KEY
-sed -i "s/^OPENAI_API_KEY=.*$/OPENAI_API_KEY=$OPENAI_API_KEY/" .env
+# Update or add the OPENAI_API_KEY line
+if grep -qE "^OPENAI_API_KEY" .env; then
+    sed -i.bak "s/^OPENAI_API_KEY.*/OPENAI_API_KEY = $OPENAI_API_KEY/" .env && rm .env.bak
+else
+    echo "OPENAI_API_KEY = $OPENAI_API_KEY # add your openai key here" >> .env
+fi
+
 
 echo "OPENAI_API_KEY has been set in the .env file"
 

--- a/python/examples/image_search/image_search_crewai/setup.sh
+++ b/python/examples/image_search/image_search_crewai/setup.sh
@@ -24,8 +24,13 @@ fi
 # Prompt the user to enter the OPENAI_API_KEY
 read -p "Enter your OPENAI_API_KEY: " OPENAI_API_KEY
 
-# Update the .env file with the entered OPENAI_API_KEY
-sed -i "s/^OPENAI_API_KEY=.*$/OPENAI_API_KEY=$OPENAI_API_KEY/" .env
+# Update or add the OPENAI_API_KEY line
+if grep -qE "^OPENAI_API_KEY" .env; then
+    sed -i.bak "s/^OPENAI_API_KEY.*/OPENAI_API_KEY = $OPENAI_API_KEY/" .env && rm .env.bak
+else
+    echo "OPENAI_API_KEY = $OPENAI_API_KEY # add your openai key here" >> .env
+fi
+
 
 echo "OPENAI_API_KEY has been set in the .env file"
 

--- a/python/examples/image_search/image_search_langchain/setup.sh
+++ b/python/examples/image_search/image_search_langchain/setup.sh
@@ -24,8 +24,13 @@ fi
 # Prompt the user to enter the OPENAI_API_KEY
 read -p "Enter your OPENAI_API_KEY: " OPENAI_API_KEY
 
-# Update the .env file with the entered OPENAI_API_KEY
-sed -i "s/^OPENAI_API_KEY=.*$/OPENAI_API_KEY=$OPENAI_API_KEY/" .env
+# Update or add the OPENAI_API_KEY line
+if grep -qE "^OPENAI_API_KEY" .env; then
+    sed -i.bak "s/^OPENAI_API_KEY.*/OPENAI_API_KEY = $OPENAI_API_KEY/" .env && rm .env.bak
+else
+    echo "OPENAI_API_KEY = $OPENAI_API_KEY # add your openai key here" >> .env
+fi
+
 
 echo "OPENAI_API_KEY has been set in the .env file"
 

--- a/python/examples/image_search/image_search_langgraph/setup.sh
+++ b/python/examples/image_search/image_search_langgraph/setup.sh
@@ -24,8 +24,13 @@ fi
 # Prompt the user to enter the OPENAI_API_KEY
 read -p "Enter your OPENAI_API_KEY: " OPENAI_API_KEY
 
-# Update the .env file with the entered OPENAI_API_KEY
-sed -i "s/^OPENAI_API_KEY=.*$/OPENAI_API_KEY=$OPENAI_API_KEY/" .env
+# Update or add the OPENAI_API_KEY line
+if grep -qE "^OPENAI_API_KEY" .env; then
+    sed -i.bak "s/^OPENAI_API_KEY.*/OPENAI_API_KEY = $OPENAI_API_KEY/" .env && rm .env.bak
+else
+    echo "OPENAI_API_KEY = $OPENAI_API_KEY # add your openai key here" >> .env
+fi
+
 
 echo "OPENAI_API_KEY has been set in the .env file"
 

--- a/python/examples/image_search/image_search_llamaindex/setup.sh
+++ b/python/examples/image_search/image_search_llamaindex/setup.sh
@@ -24,8 +24,13 @@ fi
 # Prompt the user to enter the OPENAI_API_KEY
 read -p "Enter your OPENAI_API_KEY: " OPENAI_API_KEY
 
-# Update the .env file with the entered OPENAI_API_KEY
-sed -i "s/^OPENAI_API_KEY=.*$/OPENAI_API_KEY=$OPENAI_API_KEY/" .env
+# Update or add the OPENAI_API_KEY line
+if grep -qE "^OPENAI_API_KEY" .env; then
+    sed -i.bak "s/^OPENAI_API_KEY.*/OPENAI_API_KEY = $OPENAI_API_KEY/" .env && rm .env.bak
+else
+    echo "OPENAI_API_KEY = $OPENAI_API_KEY # add your openai key here" >> .env
+fi
+
 
 echo "OPENAI_API_KEY has been set in the .env file"
 

--- a/python/examples/sql_agent/setup.sh
+++ b/python/examples/sql_agent/setup.sh
@@ -24,8 +24,13 @@ fi
 # Prompt the user to enter the OPENAI_API_KEY
 read -p "Enter your OPENAI_API_KEY: " OPENAI_API_KEY
 
-# Update the .env file with the entered OPENAI_API_KEY
-sed -i "s/^OPENAI_API_KEY=.*$/OPENAI_API_KEY=$OPENAI_API_KEY/" .env
+# Update or add the OPENAI_API_KEY line
+if grep -qE "^OPENAI_API_KEY" .env; then
+    sed -i.bak "s/^OPENAI_API_KEY.*/OPENAI_API_KEY = $OPENAI_API_KEY/" .env && rm .env.bak
+else
+    echo "OPENAI_API_KEY = $OPENAI_API_KEY # add your openai key here" >> .env
+fi
+
 
 echo "OPENAI_API_KEY has been set in the .env file"
 

--- a/python/examples/sql_agent/sql_agent_plotter_crewai/setup.sh
+++ b/python/examples/sql_agent/sql_agent_plotter_crewai/setup.sh
@@ -24,8 +24,13 @@ fi
 # Prompt the user to enter the OPENAI_API_KEY
 read -p "Enter your OPENAI_API_KEY: " OPENAI_API_KEY
 
-# Update the .env file with the entered OPENAI_API_KEY
-sed -i "s/^OPENAI_API_KEY=.*$/OPENAI_API_KEY=$OPENAI_API_KEY/" .env
+# Update or add the OPENAI_API_KEY line
+if grep -qE "^OPENAI_API_KEY" .env; then
+    sed -i.bak "s/^OPENAI_API_KEY.*/OPENAI_API_KEY = $OPENAI_API_KEY/" .env && rm .env.bak
+else
+    echo "OPENAI_API_KEY = $OPENAI_API_KEY # add your openai key here" >> .env
+fi
+
 
 echo "OPENAI_API_KEY has been set in the .env file"
 

--- a/python/examples/sql_agent/sql_agent_plotter_langchain/setup.sh
+++ b/python/examples/sql_agent/sql_agent_plotter_langchain/setup.sh
@@ -24,8 +24,13 @@ fi
 # Prompt the user to enter the OPENAI_API_KEY
 read -p "Enter your OPENAI_API_KEY: " OPENAI_API_KEY
 
-# Update the .env file with the entered OPENAI_API_KEY
-sed -i "s/^OPENAI_API_KEY=.*$/OPENAI_API_KEY=$OPENAI_API_KEY/" .env
+# Update or add the OPENAI_API_KEY line
+if grep -qE "^OPENAI_API_KEY" .env; then
+    sed -i.bak "s/^OPENAI_API_KEY.*/OPENAI_API_KEY = $OPENAI_API_KEY/" .env && rm .env.bak
+else
+    echo "OPENAI_API_KEY = $OPENAI_API_KEY # add your openai key here" >> .env
+fi
+
 
 echo "OPENAI_API_KEY has been set in the .env file"
 

--- a/python/examples/sql_agent/sql_agent_plotter_llama_index/setup.sh
+++ b/python/examples/sql_agent/sql_agent_plotter_llama_index/setup.sh
@@ -24,8 +24,13 @@ fi
 # Prompt the user to enter the OPENAI_API_KEY
 read -p "Enter your OPENAI_API_KEY: " OPENAI_API_KEY
 
-# Update the .env file with the entered OPENAI_API_KEY
-sed -i "s/^OPENAI_API_KEY=.*$/OPENAI_API_KEY=$OPENAI_API_KEY/" .env
+# Update or add the OPENAI_API_KEY line
+if grep -qE "^OPENAI_API_KEY" .env; then
+    sed -i.bak "s/^OPENAI_API_KEY.*/OPENAI_API_KEY = $OPENAI_API_KEY/" .env && rm .env.bak
+else
+    echo "OPENAI_API_KEY = $OPENAI_API_KEY # add your openai key here" >> .env
+fi
+
 
 echo "OPENAI_API_KEY has been set in the .env file"
 


### PR DESCRIPTION
- `sed` command is differently implemented in both mac and linux.
- mac has BSD utility while linux has GNU utility.
- New approach will work on both

Fixes issue #465 