### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/python/composio/cli/actions.py
+++ b/python/composio/cli/actions.py
@@ -102,7 +102,7 @@ def _actions(
 
     if use_case is not None and len(apps) == 0:
         raise click.ClickException(
-            "To search by a use case you need to specify atleast one app name."
+            "To search by a use case you need to specify at least one app name."
         )
 
     context.console.print("[green]Showing all actions[/green]")

--- a/python/composio/cli/add.py
+++ b/python/composio/cli/add.py
@@ -53,7 +53,7 @@ class AddIntegrationExamples(HelpfulCmd):
     "-i",
     "--integration-id",
     type=str,
-    help="Specify intgration ID to use existing integration",
+    help="Specify integration ID to use existing integration",
 )
 @click.option(
     "-a",

--- a/python/composio/cli/context.py
+++ b/python/composio/cli/context.py
@@ -151,7 +151,7 @@ def login_required(f: t.Callable[te.Concatenate[P], R]) -> t.Callable[P, R]:
     if _context is None:
         _context = Context()
 
-    def wapper(*args: P.args, **kwargs: P.kwargs) -> R:
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         if (
             not t.cast(Context, _context).is_logged_in()
             and not t.cast(Context, _context).using_api_key_from_env()
@@ -161,7 +161,7 @@ def login_required(f: t.Callable[te.Concatenate[P], R]) -> t.Callable[P, R]:
             )
         return f(*args, **kwargs)
 
-    return update_wrapper(wapper, f)
+    return update_wrapper(wrapper, f)
 
 
 def ensure_login(f: t.Callable[te.Concatenate[P], R]) -> t.Callable[P, R]:
@@ -170,7 +170,7 @@ def ensure_login(f: t.Callable[te.Concatenate[P], R]) -> t.Callable[P, R]:
     if _context is None:
         _context = Context()
 
-    def wapper(*args: P.args, **kwargs: P.kwargs) -> R:
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         if (
             not t.cast(Context, _context).is_logged_in()
             and not t.cast(Context, _context).using_api_key_from_env()
@@ -178,7 +178,7 @@ def ensure_login(f: t.Callable[te.Concatenate[P], R]) -> t.Callable[P, R]:
             login(context=_context)
         return f(*args, **kwargs)
 
-    return update_wrapper(wapper, f)
+    return update_wrapper(wrapper, f)
 
 
 def login(

--- a/python/composio/client/base.py
+++ b/python/composio/client/base.py
@@ -25,7 +25,7 @@ class Collection(t.Generic[ModelType], logging.WithLogger):
     _list_key: str = "items"
 
     def __init__(self, client: "BaseClient") -> None:
-        """Initialize conntected accounts models namespace."""
+        """Initialize connected accounts models namespace."""
         logging.WithLogger.__init__(self)
         self.client = client
 
@@ -50,7 +50,7 @@ class Collection(t.Generic[ModelType], logging.WithLogger):
         return response
 
     def _raise_if_empty(self, collection: CollectionType) -> CollectionType:
-        """Raise if provided colleciton is empty."""
+        """Raise if provided collection is empty."""
         if len(collection) > 0:
             return collection
         raise NoItemsFound(message="No items found")

--- a/python/composio/client/collections.py
+++ b/python/composio/client/collections.py
@@ -188,16 +188,16 @@ class ConnectedAccounts(Collection[ConnectedAccountModel]):
             )
             return self.model(**response.json())
 
-        quries = {}
+        queries = {}
         if len(entity_ids) > 0:
-            quries["user_uuid"] = ",".join(entity_ids)
+            queries["user_uuid"] = ",".join(entity_ids)
 
         if active:
-            quries["showActiveOnly"] = "true"
+            queries["showActiveOnly"] = "true"
 
         response = self._raise_if_required(
             self.client.http.get(
-                url=str(self.endpoint(queries=quries)),
+                url=str(self.endpoint(queries=queries)),
             )
         )
         return [self.model(**account) for account in response.json().get("items", [])]
@@ -209,7 +209,7 @@ class ConnectedAccounts(Collection[ConnectedAccountModel]):
         params: t.Optional[t.Dict] = None,
         redirect_url: t.Optional[str] = None,
     ) -> ConnectionRequestModel:
-        """Initiate a new connected accont."""
+        """Initiate a new connected account."""
         response = self._raise_if_required(
             response=self.client.http.post(
                 url=str(self.endpoint),
@@ -401,7 +401,7 @@ class TriggerModel(BaseModel):
 class SuccessExecuteActionResponseModel(BaseModel):
     """Success execute action response data model."""
 
-    successfull: bool
+    successful: bool
     data: t.Dict
     error: t.Optional[str] = None
 
@@ -517,7 +517,7 @@ class TriggerSubscription(logging.WithLogger):
             return callback(data)
         except BaseException:
             self.logger.info(
-                f"Erorr executing `{callback.__name__}` for "
+                f"Error executing `{callback.__name__}` for "
                 f"event `{data.metadata.triggerName}` "
                 f"with error:\n {traceback.format_exc()}"
             )
@@ -854,7 +854,7 @@ class Actions(Collection[ActionModel]):
         :param actions: Filter by the list of Actions.
         :param apps: Filter by the list of Apps.
         :param tags: Filter by the list of given Tags.
-        :param limit: Limit the numnber of actions to a specific number.
+        :param limit: Limit the number of actions to a specific number.
         :param use_case: Filter by use case.
         :param allow_all: Allow querying all of the actions for a specific
                         app

--- a/python/composio/client/enums/base.py
+++ b/python/composio/client/enums/base.py
@@ -36,9 +36,9 @@ class EnumStringNotFound(ComposioSDKError):
 
 
 class SentinalObject:
-    """Sentinal object."""
+    """Sentinel object."""
 
-    sentinal = None
+    sentinel = None
 
 
 class TagData(LocalStorage):
@@ -121,7 +121,7 @@ class _AnnotatedEnum(t.Generic[EntityType]):
         warn: bool = True,
     ) -> None:
         """Create an Enum"""
-        if hasattr(value, "sentinal"):
+        if hasattr(value, "sentinel"):
             self._slug = value.enum  # type: ignore
             return
 
@@ -291,7 +291,7 @@ class _AnnotatedEnum(t.Generic[EntityType]):
         return t.cast(str, self._slug)
 
     def __eq__(self, other: object) -> bool:
-        """Check equivilance of two objects."""
+        """Check equivalence of two objects."""
         if not isinstance(other, (str, _AnnotatedEnum)):
             return NotImplemented
         return str(self) == str(other)

--- a/python/composio/server/api.py
+++ b/python/composio/server/api.py
@@ -85,7 +85,7 @@ class ExecuteActionRequest(BaseModel):
     )
     entity_id: str = Field(
         None,
-        description="Entity ID assosiated with the account.",
+        description="Entity ID associated with the account.",
     )
     connected_account_id: str = Field(
         None,

--- a/python/composio/storage/base.py
+++ b/python/composio/storage/base.py
@@ -32,7 +32,7 @@ class LocalStorage(BaseModel):
     ```
 
     Note:
-        When derriving from the `LocalStorage` class, `path` needs to be
+        When deriving from the `LocalStorage` class, `path` needs to be
         defined as a class variable.
     """
 

--- a/python/composio/tools/base/abs.py
+++ b/python/composio/tools/base/abs.py
@@ -68,7 +68,7 @@ class ExecuteResponse(BaseModel):
 
 class _Attributes:
     name: str
-    """Name represenation."""
+    """Name representation."""
 
     enum: str
     """Enum key."""
@@ -162,7 +162,7 @@ class _Response(t.Generic[ModelType]):
             )
             error: t.Optional[str] = Field(
                 None,
-                description="Error if any occured during the execution of the action",
+                description="Error if any occurred during the execution of the action",
             )
 
         return t.cast(t.Type[BaseModel], wrapper)

--- a/python/composio/tools/base/local.py
+++ b/python/composio/tools/base/local.py
@@ -178,14 +178,14 @@ class LocalToolMixin(Tool):
             return {
                 "data": response.model_dump(),
                 "error": None,
-                "successfull": True,
+                "successful": True,
             }
         except ExecutionFailed as e:
             self.logger.error(f"Error executing `{action}`: {e}")
             return {
                 "data": None,
                 "error": e.message,
-                "successfull": False,
+                "successful": False,
                 **e.extra,
             }
         except Exception as e:
@@ -194,7 +194,7 @@ class LocalToolMixin(Tool):
             return {
                 "data": None,
                 "error": str(e),
-                "successfull": False,
+                "successful": False,
             }
 
 

--- a/python/composio/tools/env/base.py
+++ b/python/composio/tools/env/base.py
@@ -269,7 +269,7 @@ class RemoteWorkspace(Workspace):
             return
 
         self.logger.debug(
-            f"Succesfully uploaded: {action.slug} - {response}",
+            f"Successfully uploaded: {action.slug} - {response}",
         )
         return
 

--- a/python/composio/tools/env/filemanager/manager.py
+++ b/python/composio/tools/env/filemanager/manager.py
@@ -315,7 +315,7 @@ class FileManager(Sessionable):
         depth: int,
         exclude: t.List[Path],
     ) -> str:
-        """Auxialiary method for creating working directory tree recursively."""
+        """Auxiliary method for creating working directory tree recursively."""
         if (depth != -1 and level > depth) or directory in exclude:
             return ""
 

--- a/python/composio/tools/local/base/tool.py
+++ b/python/composio/tools/local/base/tool.py
@@ -4,7 +4,7 @@ from .action import Action
 
 
 class Tool:
-    """Asbtraction for local tools."""
+    """Abstraction for local tools."""
 
     @property
     def name(self) -> str:

--- a/python/composio/tools/local/clickup/actions/add_dependency.py
+++ b/python/composio/tools/local/clickup/actions/add_dependency.py
@@ -37,7 +37,7 @@ class AddDependencyRequest(BaseModel):
     depedency_of: str = Field(
         default=None,
         alias="depedency_of",
-        description="Depedency Of",
+        description="Dependency Of",
     )
 
 

--- a/python/composio/tools/local/clickup/actions/get_bulk_tasks_time_in_status.py
+++ b/python/composio/tools/local/clickup/actions/get_bulk_tasks_time_in_status.py
@@ -12,7 +12,7 @@ class GetBulkTasksTimeInStatusRequest(BaseModel):
         ...,
         alias="task_ids",
         description=(
-            "Include this paramater once per `task_id`. You can include up to 100 task "
+            "Include this parameter once per `task_id`. You can include up to 100 task "
             "ids per request. For example: `task_ids=3cuh&task_ids=g4fs` "
         ),
     )

--- a/python/composio/tools/local/clickup/actions/get_filtered_team_tasks.py
+++ b/python/composio/tools/local/clickup/actions/get_filtered_team_tasks.py
@@ -65,7 +65,7 @@ class GetFilteredTeamTasksRequest(BaseModel):
         default=None,
         alias="include_closed",
         description=(
-            "Include or excluse closed tasks. By default, they are excluded.   To include "
+            "Include or exclude closed tasks. By default, they are excluded.   To include "
             "closed tasks, use `include_closed: true`. "
         ),
     )

--- a/python/composio/tools/local/clickup/actions/get_spaces.py
+++ b/python/composio/tools/local/clickup/actions/get_spaces.py
@@ -28,7 +28,7 @@ class GetSpacesResponse(BaseModel):
 
 class GetSpaces(OpenAPIAction):
     """
-    View the Spaces avialable in a Workspace. You can only get member info in
+    View the Spaces available in a Workspace. You can only get member info in
     private Spaces.
     """
 
@@ -53,7 +53,7 @@ class GetSpaces(OpenAPIAction):
 
 class spaces_get_space_details(OpenAPIAction):
     """
-    View the Spaces avialable in a Workspace. You can only get member info in
+    View the Spaces available in a Workspace. You can only get member info in
     private Spaces.<<DEPRECATED use get_spaces>>
     """
 

--- a/python/composio/tools/local/clickup/actions/get_tasks.py
+++ b/python/composio/tools/local/clickup/actions/get_tasks.py
@@ -65,7 +65,7 @@ class GetTasksRequest(BaseModel):
         default=None,
         alias="include_closed",
         description=(
-            "Include or excluse closed tasks. By default, they are excluded.   To include "
+            "Include or exclude closed tasks. By default, they are excluded.   To include "
             "closed tasks, use `include_closed: true`. "
         ),
     )

--- a/python/composio/tools/local/clickup/actions/update_comment.py
+++ b/python/composio/tools/local/clickup/actions/update_comment.py
@@ -38,7 +38,7 @@ class UpdateCommentResponse(BaseModel):
 
 class UpdateComment(OpenAPIAction):
     """
-    Replace the content of a task commment, assign a comment, and mark a comment
+    Replace the content of a task comment, assign a comment, and mark a comment
     as resolved.
     """
 

--- a/python/composio/tools/local/filetool/actions/write.py
+++ b/python/composio/tools/local/filetool/actions/write.py
@@ -42,7 +42,7 @@ class Write(LocalAction[WriteRequest, WriteResponse]):
 
     Note:
         This action will replace the existing content in the the file,
-    and completetly rewrite the file, if you want to edit a specific portion
+    and completely rewrite the file, if you want to edit a specific portion
     of the file use `edit` tool instead.
     """
 

--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -395,7 +395,7 @@ class ComposioToolSet(WithLogger):
         file_name_prefix: str,
         success_response_model: SuccessExecuteActionResponseModel,
     ) -> dict:
-        execution_status = success_response_model.successfull
+        execution_status = success_response_model.successful
         resp_data = success_response_model.data
 
         for key, val in resp_data.items():

--- a/python/composio/utils/logging.py
+++ b/python/composio/utils/logging.py
@@ -44,7 +44,7 @@ _LEVELS: t.Dict[LogLevel, int] = {
 
 
 def _parse_log_level_from_env(default: int) -> int:
-    """Parse log level from environent."""
+    """Parse log level from environment."""
     level = os.environ.get(ENV_COMPOSIO_LOGGING_LEVEL)
     if level is None:
         return default

--- a/python/composio/utils/shared.py
+++ b/python/composio/utils/shared.py
@@ -21,7 +21,7 @@ PYDANTIC_TYPE_TO_PYTHON_TYPE = {
     "null": t.Optional[t.Any],
 }
 
-# Should be depricated,
+# Should be deprecated,
 # required values will always be provided by users
 # Non-required values are nullable(None) if default value not provided.
 FALLBACK_VALUES = {
@@ -234,7 +234,7 @@ def pydantic_model_from_param_schema(param_schema: t.Dict) -> t.Type:
 
 def get_signature_format_from_schema_params(schema_params: t.Dict) -> t.List[Parameter]:
     """
-    Get function paramters signature(with pydantic field definition as default values)
+    Get function parameters signature(with pydantic field definition as default values)
     from schema parameters. Works like:
 
     def demo_function(
@@ -242,7 +242,7 @@ def get_signature_format_from_schema_params(schema_params: t.Dict) -> t.List[Par
         repo: str),
     )
 
-    :param schema_params: A dictionary object containing schema params, with keys [properties, required ect.].
+    :param schema_params: A dictionary object containing schema params, with keys [properties, required etc.].
     :return: List of required and optional parameters
 
     Output Format:
@@ -307,7 +307,7 @@ def get_pydantic_signature_format_from_schema_params(
     schema_params: t.Dict,
 ) -> t.List[Parameter]:
     """
-    Get function paramters signature(with pydantic field definition as default values)
+    Get function parameters signature(with pydantic field definition as default values)
     from schema parameters. Works like:
 
     def demo_function(
@@ -315,7 +315,7 @@ def get_pydantic_signature_format_from_schema_params(
         repo: str=Field(..., description='The name of the repository without the `.git` extension.'),
     )
 
-    :param schema_params: A dictionary object containing schema params, with keys [properties, required ect.].
+    :param schema_params: A dictionary object containing schema params, with keys [properties, required etc.].
     :return: List of required and optional parameters
 
     Example Output Format:

--- a/python/composio/utils/url.py
+++ b/python/composio/utils/url.py
@@ -26,7 +26,7 @@ def get_web_url(path: str) -> str:
     if web_url is None:
         raise ValueError(
             f"Incorrect format for base_url: {base_url}. "
-            "Format should be on of follwing {"
+            "Format should be on of following {"
             f"{BASE_URL_PROD}, "
             f"{BASE_URL_STAGING}, "
             f"{BASE_URL_LOCAL}"

--- a/python/examples/Podcast_summarizer_Agents/config/agents.yaml
+++ b/python/examples/Podcast_summarizer_Agents/config/agents.yaml
@@ -4,7 +4,7 @@ Transcriber_summarizer:
   goal: >
     provide the summary of a Youtube Podcast {youtube_url}.
   backstory: >
-    You are an expert in sumarizing long text content into great meaningful summaries.
+    You are an expert in summarizing long text content into great meaningful summaries.
 
 slack_messenger:
   role: >

--- a/python/examples/calendar_agent/main.py
+++ b/python/examples/calendar_agent/main.py
@@ -19,7 +19,7 @@ llm = ChatOpenAI(model="gpt-4o")
 composio_toolset = ComposioToolSet()
 tools = composio_toolset.get_tools(apps=[App.GOOGLECALENDAR])
 
-# Retreive the current date and time
+# Retrieve the current date and time
 date = datetime.today().strftime("%Y-%m-%d")
 timezone = datetime.now().astimezone().tzinfo
 

--- a/python/examples/calendar_agent/setup.sh
+++ b/python/examples/calendar_agent/setup.sh
@@ -14,7 +14,7 @@ echo "Installing libraries from requirements.txt..."
 pip install -r requirements.txt
 
 # Login to your account
-echo "Login to your Composio acount"
+echo "Login to your Composio account"
 composio login
 
 # Add calendar tool

--- a/python/examples/code_execution_agent/crewai_ci_chart.py
+++ b/python/examples/code_execution_agent/crewai_ci_chart.py
@@ -14,7 +14,7 @@ while True:
 
     code_interpreter_agent = Agent(
         role="Python Code Interpreter Agent",
-        goal=f"""Run I a code to get acheive a task given by the user""",
+        goal=f"""Run I a code to get achieve a task given by the user""",
         backstory="""You are an agent that helps users run Python code.""",
         verbose=True,
         tools=code_interpreter_tools,
@@ -23,7 +23,7 @@ while True:
     )
 
     code_interpreter_task = Task(
-        description=f"""Run Python code to get acheive a task - {main_task}""",
+        description=f"""Run Python code to get achieve a task - {main_task}""",
         expected_output=f"""Python code executed successfully. The result of the task is returned - {main_task}""",
         agent=code_interpreter_agent,
     )

--- a/python/examples/competitor_researcher/setup.sh
+++ b/python/examples/competitor_researcher/setup.sh
@@ -13,7 +13,7 @@ echo "Installing libraries from requirements.txt..."
 pip install -r requirements.txt
 
 # Login to your account
-echo "Login to your Composio acount"
+echo "Login to your Composio account"
 composio login
 
 # Add notion tool

--- a/python/examples/human_in_the_loop/AI_PM_agent/main.py
+++ b/python/examples/human_in_the_loop/AI_PM_agent/main.py
@@ -67,7 +67,7 @@ agent = FunctionCallingAgentWorker(
 # Callback function for handling new messages in a Slack channel
 @slack_listener.callback(filters={"trigger_name": "slackbot_receive_message"})
 def callback_new_message(event: TriggerEventData) -> None:
-    print("Recieved new messsage")
+    print("Received new message")
     payload = event.payload
     user_id = payload.get("user", "")
 

--- a/python/examples/human_in_the_loop/AI_PM_agent/setup.sh
+++ b/python/examples/human_in_the_loop/AI_PM_agent/setup.sh
@@ -13,7 +13,7 @@ echo "Installing libraries from requirements.txt..."
 pip install -r requirements.txt
 
 # Login to your account
-echo "Login to your Composio acount"
+echo "Login to your Composio account"
 composio login
 
 # Add trello tool

--- a/python/examples/investment_analysis/setup.sh
+++ b/python/examples/investment_analysis/setup.sh
@@ -13,7 +13,7 @@ echo "Installing libraries from requirements.txt..."
 pip install -r requirements.txt
 
 # Login to your account
-echo "Login to your Composio acount"
+echo "Login to your Composio account"
 composio login
 
 # Add trello tool

--- a/python/examples/news_summary/setup.sh
+++ b/python/examples/news_summary/setup.sh
@@ -13,7 +13,7 @@ echo "Installing libraries from requirements.txt..."
 pip install -r requirements.txt
 
 # Login to your account
-echo "Login to your Composio acount"
+echo "Login to your Composio account"
 composio login
 
 # Add trello tool

--- a/python/examples/newsletter_summarizer/main.py
+++ b/python/examples/newsletter_summarizer/main.py
@@ -20,7 +20,7 @@ llm = ChatGroq(model="llama3.1-70b-versatile", stop_sequences=["\n\n"])
 # Define the Email Fetcher Agent
 email_fetcher_agent = Agent(
     role="Email Fetcher Agent",
-    goal="Fetch recent newsletter emails from the inbox. Please look for labels 'newsletter' only for last 7 days. Don't add any other unncessary filters.",
+    goal="Fetch recent newsletter emails from the inbox. Please look for labels 'newsletter' only for last 7 days. Don't add any other unnecessary filters.",
     verbose=True,
     memory=True,
     backstory=f"You are an expert in retrieving and organizing email content, with a keen eye for identifying relevant newsletters. Today's date is {datetime.now().strftime('%B %d, %Y')}. You are writing an email to a reader who is interested in the stock market and trading.",

--- a/python/examples/pr_agent/pr_agent_autogen/setup.sh
+++ b/python/examples/pr_agent/pr_agent_autogen/setup.sh
@@ -13,7 +13,7 @@ echo "Installing libraries from requirements.txt..."
 pip install -r requirements.txt
 
 # Login to your account
-echo "Login to your Composio acount"
+echo "Login to your Composio account"
 composio login
 
 # Add trello tool

--- a/python/examples/pr_agent/pr_agent_crewai/setup.sh
+++ b/python/examples/pr_agent/pr_agent_crewai/setup.sh
@@ -13,7 +13,7 @@ echo "Installing libraries from requirements.txt..."
 pip install -r requirements.txt
 
 # Login to your account
-echo "Login to your Composio acount"
+echo "Login to your Composio account"
 composio login
 
 # Add trello tool

--- a/python/examples/pr_agent/pr_agent_langchain/setup.sh
+++ b/python/examples/pr_agent/pr_agent_langchain/setup.sh
@@ -13,7 +13,7 @@ echo "Installing libraries from requirements.txt..."
 pip install -r requirements.txt
 
 # Login to your account
-echo "Login to your Composio acount"
+echo "Login to your Composio account"
 composio login
 
 # Add trello tool

--- a/python/examples/pr_agent/pr_agent_llama_index/setup.sh
+++ b/python/examples/pr_agent/pr_agent_llama_index/setup.sh
@@ -13,7 +13,7 @@ echo "Installing libraries from requirements.txt..."
 pip install -r requirements.txt
 
 # Login to your account
-echo "Login to your Composio acount"
+echo "Login to your Composio account"
 composio login
 
 # Add trello tool

--- a/python/examples/pr_agent/pr_agent_openai/main.py
+++ b/python/examples/pr_agent/pr_agent_openai/main.py
@@ -32,7 +32,7 @@ code_review_assistant_prompt = (
 composio_toolset = ComposioToolSet()
 pr_agent_tools = composio_toolset.get_actions(
     actions=[
-        Action.GITHUB_GET_CODE_CHANGES_IN_PR,  # For a given PR it get's all the changes
+        Action.GITHUB_GET_CODE_CHANGES_IN_PR,  # For a given PR it gets all the changes
         Action.GITHUB_PULLS_CREATE_REVIEW_COMMENT,  # For a given PR it creates a comment
         Action.GITHUB_ISSUES_CREATE,  # If required, allows you to create issues on github
         Action.SLACKBOT_CHAT_POST_MESSAGE,  # Send a message to slack using app

--- a/python/examples/pr_agent/pr_agent_openai/setup.sh
+++ b/python/examples/pr_agent/pr_agent_openai/setup.sh
@@ -13,7 +13,7 @@ echo "Installing libraries from requirements.txt..."
 pip install -r requirements.txt
 
 # Login to your account
-echo "Login to your Composio acount"
+echo "Login to your Composio account"
 composio login
 
 # Add trello tool

--- a/python/examples/research_assistant/research_assistant_camelai/setup.sh
+++ b/python/examples/research_assistant/research_assistant_camelai/setup.sh
@@ -13,7 +13,7 @@ echo "Installing libraries from requirements.txt..."
 pip install -r requirements.txt
 
 # Login to your account
-echo "Login to your Composio acount"
+echo "Login to your Composio account"
 composio login
 
 # Add trello tool

--- a/python/examples/research_assistant/research_assistant_crewai/setup.sh
+++ b/python/examples/research_assistant/research_assistant_crewai/setup.sh
@@ -13,7 +13,7 @@ echo "Installing libraries from requirements.txt..."
 pip install -r requirements.txt
 
 # Login to your account
-echo "Login to your Composio acount"
+echo "Login to your Composio account"
 composio login
 
 # Add trello tool

--- a/python/examples/research_assistant/research_assistant_praisonai/setup.sh
+++ b/python/examples/research_assistant/research_assistant_praisonai/setup.sh
@@ -13,7 +13,7 @@ echo "Installing libraries from requirements.txt..."
 pip install -r requirements.txt
 
 # Login to your account
-echo "Login to your Composio acount"
+echo "Login to your Composio account"
 composio login
 
 # Add trello tool

--- a/python/examples/runtime_tools/langchain_math.py
+++ b/python/examples/runtime_tools/langchain_math.py
@@ -25,7 +25,7 @@ prompt = hub.pull("hwchase17/openai-functions-agent")
 
 # Get All the tools
 tools = ComposioToolSet().get_actions(actions=[multiply])
-task = "Calculate the forumula 445*669*8886"
+task = "Calculate the formula 445*669*8886"
 
 agent = create_openai_functions_agent(llm, tools, prompt)
 agent_executor = AgentExecutor(agent=agent, tools=tools, verbose=True)

--- a/python/examples/scheduler_agent/scheduler_agent_autogen/setup.sh
+++ b/python/examples/scheduler_agent/scheduler_agent_autogen/setup.sh
@@ -13,7 +13,7 @@ echo "Installing libraries from requirements.txt..."
 pip install -r requirements.txt
 
 # Login to your account
-echo "Login to your Composio acount"
+echo "Login to your Composio account"
 composio login
 
 # Add trello tool

--- a/python/examples/scheduler_agent/scheduler_agent_crewai/setup.sh
+++ b/python/examples/scheduler_agent/scheduler_agent_crewai/setup.sh
@@ -13,7 +13,7 @@ echo "Installing libraries from requirements.txt..."
 pip install -r requirements.txt
 
 # Login to your account
-echo "Login to your Composio acount"
+echo "Login to your Composio account"
 composio login
 
 # Add trello tool

--- a/python/examples/scheduler_agent/scheduler_agent_langchain/setup.sh
+++ b/python/examples/scheduler_agent/scheduler_agent_langchain/setup.sh
@@ -13,7 +13,7 @@ echo "Installing libraries from requirements.txt..."
 pip install -r requirements.txt
 
 # Login to your account
-echo "Login to your Composio acount"
+echo "Login to your Composio account"
 composio login
 
 # Add trello tool

--- a/python/examples/scheduler_agent/scheduler_agent_langgraph/setup.sh
+++ b/python/examples/scheduler_agent/scheduler_agent_langgraph/setup.sh
@@ -13,7 +13,7 @@ echo "Installing libraries from requirements.txt..."
 pip install -r requirements.txt
 
 # Login to your account
-echo "Login to your Composio acount"
+echo "Login to your Composio account"
 composio login
 
 # Add trello tool

--- a/python/examples/scheduler_agent/scheduler_agent_llamaindex/setup.sh
+++ b/python/examples/scheduler_agent/scheduler_agent_llamaindex/setup.sh
@@ -13,7 +13,7 @@ echo "Installing libraries from requirements.txt..."
 pip install -r requirements.txt
 
 # Login to your account
-echo "Login to your Composio acount"
+echo "Login to your Composio account"
 composio login
 
 # Add trello tool

--- a/python/examples/scheduler_agent/scheduler_agent_phidata/setup.sh
+++ b/python/examples/scheduler_agent/scheduler_agent_phidata/setup.sh
@@ -13,7 +13,7 @@ echo "Installing libraries from requirements.txt..."
 pip install -r requirements.txt
 
 # Login to your account
-echo "Login to your Composio acount"
+echo "Login to your Composio account"
 composio login
 
 # Add trello tool

--- a/python/examples/slack_bot_agent/slack_agent_autogen/setup.sh
+++ b/python/examples/slack_bot_agent/slack_agent_autogen/setup.sh
@@ -13,7 +13,7 @@ echo "Installing libraries from requirements.txt..."
 pip install -r requirements.txt
 
 # Login to your account
-echo "Login to your Composio acount"
+echo "Login to your Composio account"
 composio login
 
 # Add trello tool

--- a/python/examples/slack_bot_agent/slack_agent_autogen/slack_agent_autogen.py
+++ b/python/examples/slack_bot_agent/slack_agent_autogen/slack_agent_autogen.py
@@ -62,7 +62,7 @@ listener = composio_toolset.create_trigger_listener()
 # Callback function for handling new messages in a Slack channel
 @listener.callback(filters={"trigger_name": "slackbot_receive_message"})
 def callback_new_message(event: TriggerEventData) -> None:
-    print("Recieved new messsage")
+    print("Received new message")
     payload = event.payload
     user_id = payload.get("user", "")
 

--- a/python/examples/slack_bot_agent/slack_agent_crewai/setup.sh
+++ b/python/examples/slack_bot_agent/slack_agent_crewai/setup.sh
@@ -13,7 +13,7 @@ echo "Installing libraries from requirements.txt..."
 pip install -r requirements.txt
 
 # Login to your account
-echo "Login to your Composio acount"
+echo "Login to your Composio account"
 composio login
 
 # Add trello tool

--- a/python/examples/slack_bot_agent/slack_agent_crewai/slack_agent_crewai.py
+++ b/python/examples/slack_bot_agent/slack_agent_crewai/slack_agent_crewai.py
@@ -57,7 +57,7 @@ crew = Crew(agents=[crewai_agent], tasks=[task], verbose=2)
 # Callback function for handling new messages in a Slack channel
 @listener.callback(filters={"trigger_name": "slackbot_receive_message"})
 def callback_new_message(event: TriggerEventData) -> None:
-    print("Recieved new messsage")
+    print("Received new message")
     payload = event.payload
     user_id = payload.get("user", "")
 

--- a/python/examples/slack_bot_agent/slack_agent_langchain/setup.sh
+++ b/python/examples/slack_bot_agent/slack_agent_langchain/setup.sh
@@ -13,7 +13,7 @@ echo "Installing libraries from requirements.txt..."
 pip install -r requirements.txt
 
 # Login to your account
-echo "Login to your Composio acount"
+echo "Login to your Composio account"
 composio login
 
 # Add trello tool

--- a/python/examples/slack_bot_agent/slack_agent_langchain/slack_agent_langchain.py
+++ b/python/examples/slack_bot_agent/slack_agent_langchain/slack_agent_langchain.py
@@ -42,7 +42,7 @@ agent_executor = AgentExecutor(agent=query_agent, tools=composio_tools, verbose=
 # Callback function for handling new messages in a Slack channel
 @listener.callback(filters={"trigger_name": "slackbot_receive_message"})
 def callback_new_message(event: TriggerEventData) -> None:
-    print("Recieved new messsage")
+    print("Received new message")
     payload = event.payload
     user_id = payload.get("user", "")
 

--- a/python/examples/slack_bot_agent/slack_agent_llamaindex/setup.sh
+++ b/python/examples/slack_bot_agent/slack_agent_llamaindex/setup.sh
@@ -13,7 +13,7 @@ echo "Installing libraries from requirements.txt..."
 pip install -r requirements.txt
 
 # Login to your account
-echo "Login to your Composio acount"
+echo "Login to your Composio account"
 composio login
 
 # Add trello tool

--- a/python/examples/slack_bot_agent/slack_agent_llamaindex/slack_agent_llamaindex.py
+++ b/python/examples/slack_bot_agent/slack_agent_llamaindex/slack_agent_llamaindex.py
@@ -57,7 +57,7 @@ agent = FunctionCallingAgentWorker(
 # Callback function for handling new messages in a Slack channel
 @listener.callback(filters={"trigger_name": "slackbot_receive_message"})
 def callback_new_message(event: TriggerEventData) -> None:
-    print("Recieved new messsage")
+    print("Received new message")
     payload = event.payload
     user_id = payload.get("user", "")
 

--- a/python/examples/slack_bot_agent/slack_agent_ollama/main.py
+++ b/python/examples/slack_bot_agent/slack_agent_ollama/main.py
@@ -44,7 +44,7 @@ def main(inputs):
     # Callback function for handling new messages in a Slack channel
     @listener.callback(filters={"trigger_name": "slackbot_receive_message"})
     def callback_new_message(event: TriggerEventData) -> None:
-        print("Recieved new messsage")
+        print("Received new message")
         payload = event.payload
         user_id = payload.get("user", "")
 

--- a/python/examples/slack_bot_agent/slack_agent_ollama/setup.sh
+++ b/python/examples/slack_bot_agent/slack_agent_ollama/setup.sh
@@ -13,7 +13,7 @@ echo "Installing libraries from requirements.txt..."
 pip install -r requirements.txt
 
 # Login to your account
-echo "Login to your Composio acount"
+echo "Login to your Composio account"
 composio login
 
 # Add trello tool

--- a/python/examples/slack_bot_agent/slack_agent_openai/setup.sh
+++ b/python/examples/slack_bot_agent/slack_agent_openai/setup.sh
@@ -13,7 +13,7 @@ echo "Installing libraries from requirements.txt..."
 pip install -r requirements.txt
 
 # Login to your account
-echo "Login to your Composio acount"
+echo "Login to your Composio account"
 composio login
 
 # Add trello tool

--- a/python/examples/slack_bot_agent/slack_agent_openai/slack_agent_openai.py
+++ b/python/examples/slack_bot_agent/slack_agent_openai/slack_agent_openai.py
@@ -84,7 +84,7 @@ def process_message(event: TriggerEventData, is_new_message: bool) -> None:
         is_new_message (bool): Whether this is a new message or part of a thread.
     """
     # Extract message details from the event payload
-    print("Recieved new messsage")
+    print("Received new message")
     payload = event.payload
     user_id = payload.get("user", "")
 

--- a/python/examples/slack_calendar_agent/agents.py
+++ b/python/examples/slack_calendar_agent/agents.py
@@ -18,7 +18,7 @@ composio_toolset = ComposioToolSet()
 tools = composio_toolset.get_actions(actions=[Action.GOOGLECALENDAR_CREATE_EVENT,
 Action.GOOGLECALENDAR_DELETE_EVENT, Action.GOOGLECALENDAR_REMOVE_ATTENDEE])
 
-# Retreive the current date and time
+# Retrieve the current date and time
 date = datetime.today().strftime("%Y-%m-%d")
 timezone = datetime.now().astimezone().tzinfo
 
@@ -26,9 +26,9 @@ prefix_messages = [
   ChatMessage(
       role="system",
       content=(
-          f"You are now a calender integration agent. You will try to execute the given task utilizing Google Calendar toools.\
+          f"You are now a calendar integration agent. You will try to execute the given task utilizing Google Calendar toools.\
            Today's date is {date} (it's in YYYY-MM-DD format). Write start and end time in appropriate format for\
-            example 12pm as 'YYYY-MM-DDT12:00:00'. Infer date of event from the message. Fill the date part accordingly. Please remeber the current date to be {date}. Always add Google Meet event.\
+            example 12pm as 'YYYY-MM-DDT12:00:00'. Infer date of event from the message. Fill the date part accordingly. Please remember the current date to be {date}. Always add Google Meet event.\
             Always send the mail to attendees.\
             Always write correct time mentioned in the request. Always return the html link of the meeting after execution. Remember the time-zone is {timezone}."
       ),

--- a/python/examples/slack_calendar_agent/main.py
+++ b/python/examples/slack_calendar_agent/main.py
@@ -12,7 +12,7 @@ from agents import agent
 BOT_ID = os.environ["BOT_ID"]
 
 toolset = ComposioToolSet()
-listner = toolset.create_trigger_listener()
+listener = toolset.create_trigger_listener()
 
 composio_client = Composio(api_key=os.getenv("COMPOSIO_API_KEY"))
 entity = composio_client.get_entity("default")
@@ -72,7 +72,7 @@ def run_agent(text: str, channel: str) -> Tuple[str, int]:
     return "Agent run completed", 200
 
 
-@listner.callback(filters={"trigger_name": "slackbot_receive_message"})
+@listener.callback(filters={"trigger_name": "slackbot_receive_message"})
 def event_handler(event: TriggerEventData) -> Tuple:
     message = event.payload['event']['text']
     channel = event.payload['event']['channel']
@@ -81,5 +81,5 @@ def event_handler(event: TriggerEventData) -> Tuple:
 
     return run_agent(message, channel)
 
-print("Subcription created!")
-listner.listen()
+print("Subscription created!")
+listener.listen()

--- a/python/examples/slack_calendar_agent/setup.sh
+++ b/python/examples/slack_calendar_agent/setup.sh
@@ -16,7 +16,7 @@ echo "Installing dependencies..."
 poetry install
 
 # Login to your account
-echo "Login to your Composio acount"
+echo "Login to your Composio account"
 poetry run composio login
 
 # Copy env backup to .env file

--- a/python/examples/sql_agent/sql_agent_plotter_crewai/main.py
+++ b/python/examples/sql_agent/sql_agent_plotter_crewai/main.py
@@ -22,7 +22,7 @@ while True:
 
     code_interpreter_agent = Agent(
         role="Python Code Interpreter Agent",
-        goal=f"""Run I a code to get acheive a task given by the user""",
+        goal=f"""Run I a code to get achieve a task given by the user""",
         backstory="""You are an agent that helps users run Python code.""",
         verbose=True,
         tools=code_interpreter_tools,
@@ -31,14 +31,14 @@ while True:
     )
 
     code_interpreter_task = Task(
-        description=f"""Run Python code to get acheive a task - {main_task}""",
+        description=f"""Run Python code to get achieve a task - {main_task}""",
         expected_output=f"""Python code executed successfully. The result of the task is returned - {main_task}""",
         agent=code_interpreter_agent,
     )
 
     sql_agent = Agent(
         role="SQL Agent",
-        goal=f"""Run SQL queries to get acheive a task given by the user""",
+        goal=f"""Run SQL queries to get achieve a task given by the user""",
         backstory=(
             "You are an agent that helps users run SQL queries. "
             "Connect to the local SQlite DB at connection string = company.db"
@@ -53,7 +53,7 @@ while True:
     )
 
     sql_task = Task(
-        description=f"""Run SQL queries to get acheive a task - {main_task}""",
+        description=f"""Run SQL queries to get achieve a task - {main_task}""",
         expected_output=f"""SQL queries executed successfully. The result of the task is returned - {main_task}""",
         agent=sql_agent,
     )

--- a/python/examples/sql_agent/sql_agent_plotter_llama_index/main.py
+++ b/python/examples/sql_agent/sql_agent_plotter_llama_index/main.py
@@ -34,7 +34,7 @@ agent = FunctionCallingAgentWorker(
 ).as_agent()
 
 human_description = "The database to use is company.db"
-human_input = "Query the table MOCK_DATA for all rows and plot a graph between first names and salary by using code interpretor"
+human_input = "Query the table MOCK_DATA for all rows and plot a graph between first names and salary by using code interpreter"
 response = agent.chat(
     "Database description =" + human_description + "Task to perform:" + human_input
 )

--- a/python/plugins/camel/composio_camel/toolset.py
+++ b/python/plugins/camel/composio_camel/toolset.py
@@ -100,7 +100,7 @@ class ComposioToolSet(
         ):
             raise ValueError(
                 "Separate `entity_id` can not be provided during "
-                "intialization and handling tool calls"
+                "initialization and handling tool calls"
             )
         if self.entity_id != DEFAULT_ENTITY_ID:
             entity_id = self.entity_id

--- a/python/plugins/claude/composio_claude/toolset.py
+++ b/python/plugins/claude/composio_claude/toolset.py
@@ -66,7 +66,7 @@ class ComposioToolset(
         ):
             raise ValueError(
                 "separate `entity_id` can not be provided during "
-                "intialization and handelling tool calls"
+                "initialization and handelling tool calls"
             )
         if self.entity_id != DEFAULT_ENTITY_ID:
             entity_id = self.entity_id

--- a/python/plugins/julep/julep_demo.py
+++ b/python/plugins/julep/julep_demo.py
@@ -25,7 +25,7 @@ client = Client(
 # Retrieve tools
 composio_tools = composio_toolset.get_tools(apps=[App.GITHUB])
 
-# Define assitant
+# Define assistant
 name = "Jessica"
 about = (
     "Jessica is a forward-thinking tech entrepreneur with a sharp "

--- a/python/plugins/openai/composio_openai/toolset.py
+++ b/python/plugins/openai/composio_openai/toolset.py
@@ -78,7 +78,7 @@ class ComposioToolSet(
         ):
             raise ValueError(
                 "separate `entity_id` can not be provided during "
-                "intialization and handelling tool calls"
+                "initialization and handelling tool calls"
             )
         if self.entity_id != DEFAULT_ENTITY_ID:
             entity_id = self.entity_id
@@ -175,7 +175,7 @@ class ComposioToolSet(
         run: Run,
         entity_id: t.Optional[str] = None,
     ) -> t.List:
-        """Wait and handle assisant function calls"""
+        """Wait and handle assistant function calls"""
         tool_outputs = []
         for tool_call in t.cast(
             RequiredAction, run.required_action
@@ -198,7 +198,7 @@ class ComposioToolSet(
         thread: Thread,
         entity_id: t.Optional[str] = None,
     ) -> Run:
-        """Wait and handle assisant function calls"""
+        """Wait and handle assistant function calls"""
         thread_object = thread
         while run.status in ("queued", "in_progress", "requires_action"):
             if run.status == "requires_action":

--- a/python/plugins/openai/openai_assistant_demo.py
+++ b/python/plugins/openai/openai_assistant_demo.py
@@ -52,7 +52,7 @@ message = openai_client.beta.threads.messages.create(
     content=my_task,
 )
 
-# Execute Agent with intergrations
+# Execute Agent with integrations
 run = openai_client.beta.threads.runs.create(
     thread_id=thread.id,
     assistant_id=assistant.id,

--- a/python/plugins/praisonai/README.md
+++ b/python/plugins/praisonai/README.md
@@ -55,7 +55,7 @@ This step involves configuring and executing the agent to carry out actions, suc
 ```python
 agent_yaml = """
 framework: "crewai"
-topic: "Github Mangement"
+topic: "Github Management"
 
 roles:
   developer:

--- a/python/plugins/praisonai/composio_praisonai/toolset.py
+++ b/python/plugins/praisonai/composio_praisonai/toolset.py
@@ -115,7 +115,7 @@ class ComposioToolSet(
         entity_id: t.Optional[str] = None,
     ) -> str:
         """
-        Generats PraisonAI tools from Composio Actions
+        Generates PraisonAI tools from Composio Actions
 
         :param action_name: Identifier for the tool action.
         :param tool_name: Name of the tool class.

--- a/python/plugins/praisonai/praisonai_demo.py
+++ b/python/plugins/praisonai/praisonai_demo.py
@@ -18,7 +18,7 @@ print(tool_section_str)
 agent_yaml = (
     """
 framework: "crewai"
-topic: "Github Mangement"
+topic: "Github Management"
 
 roles:
   developer:

--- a/python/swe/README.md
+++ b/python/swe/README.md
@@ -212,7 +212,7 @@ The workspace environment contains following environment variables by default
 - `GITHUB_ACCESS_TOKEN`: Github access token for the agent.
 - `ACCESS_TOKEN`: Access token for composio tooling server.
 
-If you want to provide addional environment configuration you can use `environment` argument when creating a workspace configuration.
+If you want to provide additional environment configuration you can use `environment` argument when creating a workspace configuration.
 
 ```python
 composio_toolset = ComposioToolSet(

--- a/python/swe/dockerfiles/templates/Dockerfile.swe
+++ b/python/swe/dockerfiles/templates/Dockerfile.swe
@@ -19,14 +19,14 @@ RUN git fetch --depth 1 origin {{ basecommit}}
 RUN git checkout {{ basecommit}}
 
 {% if dependencies -%}
-# Install dependecies
+# Install dependencies
 RUN /home/user/.dev/bin/python -m pip install {{ dependencies }} || echo "$?"
 
 {% endif -%}
 
 
 {% if requirements -%}
-# Install dependecies
+# Install dependencies
 COPY requirements.txt _requirements.txt
 
 # Install from requirements.txt

--- a/python/swe/examples/crewai_agent/inputs.py
+++ b/python/swe/examples/crewai_agent/inputs.py
@@ -67,7 +67,7 @@ def from_github() -> t.Tuple[str, str]:
     return (
         f"{owner}/{name}",
         read_user_input(
-            prompt="Enter github issue ID or descrption or path to the file containing description",
+            prompt="Enter github issue ID or description or path to the file containing description",
             metavar="github issue",
             validator=_create_github_issue_validator(
                 owner=owner,

--- a/python/swe/examples/llama_agent/inputs.py
+++ b/python/swe/examples/llama_agent/inputs.py
@@ -67,7 +67,7 @@ def from_github() -> t.Tuple[str, str]:
     return (
         f"{owner}/{name}",
         read_user_input(
-            prompt="Enter github issue ID or descrption or path to the file containing description",
+            prompt="Enter github issue ID or description or path to the file containing description",
             metavar="github issue",
             validator=_create_github_issue_validator(
                 owner=owner,

--- a/python/swe/swekit/benchmark/docker_utils/docker_file_generator/const.py
+++ b/python/swe/swekit/benchmark/docker_utils/docker_file_generator/const.py
@@ -576,7 +576,7 @@ MAP_VERSION_TO_INSTALL_PYLINT.update(
     {
         k: {
             **MAP_VERSION_TO_INSTALL_PYLINT[k],
-            "pip_packages": ["astroid==3.0.0a6", "pytest"],
+            "pip_packages": ["asteroid==3.0.0a6", "pytest"],
         }
         for k in ["3.0"]
     }
@@ -751,7 +751,7 @@ MAP_VERSION_TO_INSTALL_PYDICOM.update(
 
 MAP_VERSION_TO_INSTALL_HUMANEVAL = {k: {"python": "3.9"} for k in ["1.0"]}
 
-# Constants - Task Instance Instllation Environment
+# Constants - Task Instance Installation Environment
 MAP_VERSION_TO_INSTALL = {
     "astropy/astropy": MAP_VERSION_TO_INSTALL_ASTROPY,
     "django/django": MAP_VERSION_TO_INSTALL_DJANGO,
@@ -763,7 +763,7 @@ MAP_VERSION_TO_INSTALL = {
     "pvlib/pvlib-python": MAP_VERSION_TO_INSTALL_PVLIB,
     "pydata/xarray": MAP_VERSION_TO_INSTALL_XARRAY,
     "pydicom/pydicom": MAP_VERSION_TO_INSTALL_PYDICOM,
-    "pylint-dev/astroid": MAP_VERSION_TO_INSTALL_ASTROID,
+    "pylint-dev/asteroid": MAP_VERSION_TO_INSTALL_ASTROID,
     "pylint-dev/pylint": MAP_VERSION_TO_INSTALL_PYLINT,
     "pytest-dev/pytest": MAP_VERSION_TO_INSTALL_PYTEST,
     "pyvista/pyvista": MAP_VERSION_TO_INSTALL_PYVISTA,
@@ -791,7 +791,7 @@ MAP_REPO_TO_TEST_FRAMEWORK = {
     "pvlib/pvlib-python": TEST_PYTEST,
     "pydata/xarray": TEST_PYTEST,
     "pydicom/pydicom": TEST_PYTEST_SKIP_NO_HEADER,
-    "pylint-dev/astroid": TEST_PYTEST,
+    "pylint-dev/asteroid": TEST_PYTEST,
     "pylint-dev/pylint": TEST_PYTEST,
     "pytest-dev/pytest": "pytest -rA",
     "pyvista/pyvista": TEST_PYTEST,

--- a/python/swe/swekit/benchmark/docker_utils/docker_file_generator/docker_file_generator.py
+++ b/python/swe/swekit/benchmark/docker_utils/docker_file_generator/docker_file_generator.py
@@ -484,7 +484,7 @@ class DockerGeneratorArgs(BaseModel):
     prediction_path: str = Field(..., description="Path to predictions file")
     docker_dir: str = Field(..., description="Path to docker directory")
     is_testbed: bool = Field(
-        default=False, description="if dockerfile needs to be genrated for testbed"
+        default=False, description="if dockerfile needs to be generated for testbed"
     )
 
 

--- a/python/swe/swekit/scaffold/templates/llamaindex/inputs.template
+++ b/python/swe/swekit/scaffold/templates/llamaindex/inputs.template
@@ -67,7 +67,7 @@ def from_github() -> t.Tuple[str, str]:
     return (
         f"{owner}/{name}",
         read_user_input(
-            prompt="Enter github issue ID or descrption or path to the file containing description",
+            prompt="Enter github issue ID or description or path to the file containing description",
             metavar="github issue",
             validator=_create_github_issue_validator(
                 owner=owner,

--- a/python/tests/test_tools/test_base/test_local.py
+++ b/python/tests/test_tools/test_base/test_local.py
@@ -50,5 +50,5 @@ class TestLocalTool:
             },
         )
 
-        assert not response["successfull"]
+        assert not response["successful"]
         assert "Following fields are missing: {'name'}" in response["error"]

--- a/python/tests/test_tools/test_base/test_runtime.py
+++ b/python/tests/test_tools/test_base/test_runtime.py
@@ -49,11 +49,11 @@ def test_docstring_args() -> None:
     assert tool.gid == "runtime"
 
     response = tool.execute(action=multiply.enum, params={"a": 1, "b": 2})
-    assert not response["successfull"]
+    assert not response["successful"]
     assert "Following fields are missing: {'c'}" in response["error"]
 
     response = tool.execute(action=multiply.enum, params={"a": 1, "b": 2, "c": 3})
-    assert response["successfull"]
+    assert response["successful"]
     assert response["error"] is None
     assert response["data"]["result"] == 6
 
@@ -61,7 +61,7 @@ def test_docstring_args() -> None:
 def test_annotated_args() -> None:
     @action(toolname="math")
     def square(
-        number: te.Annotated[int, "Number to calculcate square"]
+        number: te.Annotated[int, "Number to calculate square"]
     ) -> te.Annotated[int, "Square of a number"]:
         """Calculate square of a number"""
         return number**2
@@ -70,7 +70,7 @@ def test_annotated_args() -> None:
         "properties": {
             "number": {
                 "default": None,
-                "description": "Number to calculcate square",
+                "description": "Number to calculate square",
                 "title": "Number",
                 "type": "integer",
             }
@@ -119,7 +119,7 @@ def test_tool_namespace() -> None:
 
     @action(toolname="maths")
     def square(
-        number: te.Annotated[int, "Number to calculcate square"]
+        number: te.Annotated[int, "Number to calculate square"]
     ) -> te.Annotated[int, "Square of a number"]:
         """Calculate square of a number"""
         return number**2

--- a/python/tests/test_tools/test_env/test_factory.py
+++ b/python/tests/test_tools/test_env/test_factory.py
@@ -39,7 +39,7 @@ class BaseFactoryTest:
             metadata={},
         )
 
-        assert response["successfull"]
+        assert response["successful"]
         assert "stdout" in response["data"]
         assert response["data"]["exit_code"] == 0
 
@@ -50,7 +50,7 @@ class BaseFactoryTest:
             metadata={},
         )
 
-        assert response["successfull"]
+        assert response["successful"]
         assert response["data"]["output"] == "Cow says: Hello, World!"
 
 

--- a/python/tests/test_tools/test_toolset.py
+++ b/python/tests/test_tools/test_toolset.py
@@ -39,7 +39,7 @@ def test_find_actions_by_tags() -> None:
 
 
 def test_uninitialize_app() -> None:
-    """Test if the usage of an app without connected account raises erorr or not."""
+    """Test if the usage of an app without connected account raises error or not."""
     with pytest.raises(
         ComposioSDKError,
         match=(

--- a/python/tests/test_utils/test_url.py
+++ b/python/tests/test_utils/test_url.py
@@ -19,7 +19,7 @@ def test_get_web_url() -> None:
     ), pytest.raises(
         ValueError,
         match=(
-            "Incorrect format for base_url: http://url. Format should be on of follwing {https://backend.composio.dev/api, https://staging-backend.composio.dev/api, http://localhost:9900/api}"
+            "Incorrect format for base_url: http://url. Format should be on of following {https://backend.composio.dev/api, https://staging-backend.composio.dev/api, http://localhost:9900/api}"
         ),
     ):
         get_web_url("/url")


### PR DESCRIPTION
https://pypi.org/project/codespell

% `codespell --ignore-words-list=assertin,astroid,ist,socio-economic,te,thirdparty --skip="*.js,*.mdx,*.mjs,*-lock.*"`
```
./python/plugins/claude/composio_claude/toolset.py:69: intialization ==> initialization
./python/plugins/camel/composio_camel/toolset.py:103: intialization ==> initialization
./python/plugins/praisonai/README.md:58: Mangement ==> Management
./python/plugins/praisonai/praisonai_demo.py:21: Mangement ==> Management
./python/plugins/praisonai/composio_praisonai/toolset.py:118: Generats ==> Generates
./python/plugins/julep/julep_demo.py:28: assitant ==> assistant
./python/plugins/openai/openai_assistant_demo.py:55: intergrations ==> integrations
./python/plugins/openai/composio_openai/toolset.py:81: intialization ==> initialization
./python/plugins/openai/composio_openai/toolset.py:178: assisant ==> assistant
./python/plugins/openai/composio_openai/toolset.py:201: assisant ==> assistant
./python/tests/test_tools/test_toolset.py:42: erorr ==> error
./python/tests/test_tools/test_base/test_local.py:51: successfull ==> successful
./python/tests/test_tools/test_base/test_runtime.py:52: successfull ==> successful
./python/tests/test_tools/test_base/test_runtime.py:56: successfull ==> successful
./python/tests/test_tools/test_base/test_runtime.py:64: calculcate ==> calculate
./python/tests/test_tools/test_base/test_runtime.py:73: calculcate ==> calculate
./python/tests/test_tools/test_base/test_runtime.py:122: calculcate ==> calculate
./python/tests/test_tools/test_env/test_factory.py:42: successfull ==> successful
./python/tests/test_tools/test_env/test_factory.py:53: successfull ==> successful
./python/tests/test_utils/test_url.py:22: follwing ==> following
./python/swe/README.md:215: addional ==> additional
./python/swe/swekit/benchmark/docker_utils/docker_file_generator/const.py:754: Instllation ==> Installation, Instillation
./python/swe/swekit/benchmark/docker_utils/docker_file_generator/docker_file_generator.py:487: genrated ==> generated
./python/swe/swekit/scaffold/templates/llamaindex/inputs.template:70: descrption ==> description
./python/swe/examples/llama_agent/inputs.py:70: descrption ==> description
./python/swe/examples/crewai_agent/inputs.py:70: descrption ==> description
./python/swe/dockerfiles/templates/Dockerfile.swe:22: dependecies ==> dependencies
./python/swe/dockerfiles/templates/Dockerfile.swe:29: dependecies ==> dependencies
./python/examples/research_assistant/research_assistant_camelai/setup.sh:16: acount ==> account
./python/examples/research_assistant/research_assistant_crewai/setup.sh:16: acount ==> account
./python/examples/research_assistant/research_assistant_praisonai/setup.sh:16: acount ==> account
./python/examples/news_summary/setup.sh:16: acount ==> account
./python/examples/human_in_the_loop/main.py:70: Recieved ==> Received
./python/examples/human_in_the_loop/main.py:70: messsage ==> message
./python/examples/human_in_the_loop/setup.sh:16: acount ==> account
./python/examples/newsletter_summarizer/main.py:23: unncessary ==> unnecessary
./python/examples/competitor_researcher/setup.sh:16: acount ==> account
./python/examples/runtime_tools/langchain_math.py:28: forumula ==> formula
./python/examples/pr_agent/pr_agent_llama_index/setup.sh:16: acount ==> account
./python/examples/pr_agent/pr_agent_autogen/setup.sh:16: acount ==> account
./python/examples/pr_agent/pr_agent_openai/main.py:35: get's ==> gets
./python/examples/pr_agent/pr_agent_openai/setup.sh:16: acount ==> account
./python/examples/pr_agent/pr_agent_langchain/setup.sh:16: acount ==> account
./python/examples/pr_agent/pr_agent_crewai/setup.sh:16: acount ==> account
./python/examples/code_execution_agent/crewai_ci_chart.py:17: acheive ==> achieve
./python/examples/code_execution_agent/crewai_ci_chart.py:26: acheive ==> achieve
./python/examples/investment_analysis/setup.sh:16: acount ==> account
./python/examples/calendar_agent/main.py:22: Retreive ==> Retrieve
./python/examples/calendar_agent/setup.sh:17: acount ==> account
./python/examples/Podcast_summarizer_Agents/config/agents.yaml:7: sumarizing ==> summarizing
./python/examples/scheduler_agent/scheduler_agent_llamaindex/setup.sh:16: acount ==> account
./python/examples/scheduler_agent/scheduler_agent_crewai/setup.sh:16: acount ==> account
./python/examples/scheduler_agent/scheduler_agent_langgraph/setup.sh:16: acount ==> account
./python/examples/scheduler_agent/scheduler_agent_langchain/setup.sh:16: acount ==> account
./python/examples/scheduler_agent/scheduler_agent_phidata/setup.sh:16: acount ==> account
./python/examples/scheduler_agent/scheduler_agent_autogen/setup.sh:16: acount ==> account
./python/examples/sql_agent/sql_agent_plotter_llama_index/main.py:37: interpretor ==> interpreter
./python/examples/sql_agent/sql_agent_plotter_crewai/main.py:25: acheive ==> achieve
./python/examples/sql_agent/sql_agent_plotter_crewai/main.py:34: acheive ==> achieve
./python/examples/sql_agent/sql_agent_plotter_crewai/main.py:41: acheive ==> achieve
./python/examples/sql_agent/sql_agent_plotter_crewai/main.py:56: acheive ==> achieve
./python/examples/slack_bot_agent/slack_agent_openai/setup.sh:16: acount ==> account
./python/examples/slack_bot_agent/slack_agent_openai/slack_agent_openai.py:87: Recieved ==> Received
./python/examples/slack_bot_agent/slack_agent_openai/slack_agent_openai.py:87: messsage ==> message
./python/examples/slack_bot_agent/slack_agent_ollama/main.py:47: Recieved ==> Received
./python/examples/slack_bot_agent/slack_agent_ollama/main.py:47: messsage ==> message
./python/examples/slack_bot_agent/slack_agent_ollama/setup.sh:16: acount ==> account
./python/examples/slack_bot_agent/slack_agent_langchain/setup.sh:16: acount ==> account
./python/examples/slack_bot_agent/slack_agent_langchain/slack_agent_langchain.py:45: Recieved ==> Received
./python/examples/slack_bot_agent/slack_agent_langchain/slack_agent_langchain.py:45: messsage ==> message
./python/examples/slack_bot_agent/slack_agent_autogen/setup.sh:16: acount ==> account
./python/examples/slack_bot_agent/slack_agent_autogen/slack_agent_autogen.py:65: Recieved ==> Received
./python/examples/slack_bot_agent/slack_agent_autogen/slack_agent_autogen.py:65: messsage ==> message
./python/examples/slack_bot_agent/slack_agent_llamaindex/setup.sh:16: acount ==> account
./python/examples/slack_bot_agent/slack_agent_llamaindex/slack_agent_llamaindex.py:60: Recieved ==> Received
./python/examples/slack_bot_agent/slack_agent_llamaindex/slack_agent_llamaindex.py:60: messsage ==> message
./python/examples/slack_bot_agent/slack_agent_crewai/setup.sh:16: acount ==> account
./python/examples/slack_bot_agent/slack_agent_crewai/slack_agent_crewai.py:60: Recieved ==> Received
./python/examples/slack_bot_agent/slack_agent_crewai/slack_agent_crewai.py:60: messsage ==> message
./python/examples/slack_calendar_agent/agents.py:21: Retreive ==> Retrieve
./python/examples/slack_calendar_agent/agents.py:29: calender ==> calendar
./python/examples/slack_calendar_agent/agents.py:31: remeber ==> remember
./python/examples/slack_calendar_agent/main.py:15: listner ==> listener
./python/examples/slack_calendar_agent/main.py:75: listner ==> listener
./python/examples/slack_calendar_agent/main.py:84: Subcription ==> Subscription
./python/examples/slack_calendar_agent/main.py:85: listner ==> listener
./python/examples/slack_calendar_agent/setup.sh:19: acount ==> account
./python/composio/tools/toolset.py:398: successfull ==> successful
./python/composio/tools/local/clickup/actions/add_dependency.py:40: Depedency ==> Dependency
./python/composio/tools/local/clickup/actions/get_bulk_tasks_time_in_status.py:15: paramater ==> parameter
./python/composio/tools/local/clickup/actions/get_filtered_team_tasks.py:68: excluse ==> exclude, excuse, exclusive
./python/composio/tools/local/clickup/actions/get_spaces.py:31: avialable ==> available
./python/composio/tools/local/clickup/actions/get_spaces.py:56: avialable ==> available
./python/composio/tools/local/clickup/actions/get_tasks.py:68: excluse ==> exclude, excuse, exclusive
./python/composio/tools/local/clickup/actions/update_comment.py:41: commment ==> comment
./python/composio/tools/local/filetool/actions/write.py:45: completetly ==> completely
./python/composio/tools/local/base/tool.py:7: Asbtraction ==> Abstraction
./python/composio/tools/env/base.py:272: Succesfully ==> Successfully
./python/composio/tools/env/filemanager/manager.py:318: Auxialiary ==> Auxiliary
./python/composio/tools/base/abs.py:71: represenation ==> representation
./python/composio/tools/base/abs.py:162: occured ==> occurred
./python/composio/tools/base/local.py:173: successfull ==> successful
./python/composio/tools/base/local.py:180: successfull ==> successful
./python/composio/tools/base/local.py:189: successfull ==> successful
./python/composio/server/api.py:88: assosiated ==> associated
./python/composio/utils/logging.py:47: environent ==> environment
./python/composio/utils/shared.py:24: depricated ==> deprecated
./python/composio/utils/shared.py:237: paramters ==> parameters
./python/composio/utils/shared.py:245: ect ==> etc
./python/composio/utils/shared.py:310: paramters ==> parameters
./python/composio/utils/shared.py:318: ect ==> etc
./python/composio/utils/url.py:29: follwing ==> following
./python/composio/cli/actions.py:105: atleast ==> at least
./python/composio/cli/add.py:56: intgration ==> integration
./python/composio/cli/context.py:154: wapper ==> wrapper
./python/composio/cli/context.py:164: wapper ==> wrapper
./python/composio/cli/context.py:173: wapper ==> wrapper
./python/composio/cli/context.py:181: wapper ==> wrapper
./python/composio/storage/base.py:35: derriving ==> deriving
./python/composio/client/base.py:28: conntected ==> connected
./python/composio/client/base.py:53: colleciton ==> collection
./python/composio/client/collections.py:191: quries ==> queries
./python/composio/client/collections.py:193: quries ==> queries
./python/composio/client/collections.py:196: quries ==> queries
./python/composio/client/collections.py:200: quries ==> queries
./python/composio/client/collections.py:212: accont ==> account
./python/composio/client/collections.py:404: successfull ==> successful
./python/composio/client/collections.py:520: Erorr ==> Error
./python/composio/client/collections.py:857: numnber ==> number
./python/composio/client/enums/base.py:39: Sentinal ==> Sentinel
./python/composio/client/enums/base.py:41: sentinal ==> sentinel
./python/composio/client/enums/base.py:124: sentinal ==> sentinel
./python/composio/client/enums/base.py:294: equivilance ==> equivalence
```
% `codespell --ignore-words-list=assertin,astroid,ist,socio-economic,te,thirdparty --skip="*.js,*.mdx,*.mjs,*-lock.*" --write-changes`