### PR TITLE
Fix gql imports

### DIFF
--- a/python/composio/tools/env/flyio/client.py
+++ b/python/composio/tools/env/flyio/client.py
@@ -5,8 +5,6 @@ import time
 import typing as t
 import uuid
 
-import gql
-import gql.transport
 import typing_extensions as te
 
 from composio.tools.env.constants import DEFAULT_IMAGE
@@ -14,6 +12,8 @@ from composio.utils.logging import WithLogger
 
 
 try:
+    import gql
+    import gql.transport
     import requests
     from gql.transport.requests import RequestsHTTPTransport
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Move `gql` imports inside a try-except block in `client.py` to handle missing modules gracefully.
> 
>   - **Imports**:
>     - Move `gql` and `gql.transport` imports inside a try-except block in `client.py` to handle `ModuleNotFoundError` gracefully.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SamparkAI%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 6756b98dbdf08ed70c541238e417d8089efe78aa. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->