### PR TITLE
chore: migrate away from pydantic v1

### DIFF
--- a/python/composio/utils/shared.py
+++ b/python/composio/utils/shared.py
@@ -5,8 +5,8 @@ Shared utils.
 import typing as t
 from inspect import Parameter
 
-from pydantic.v1 import BaseModel, Field, create_model
-from pydantic.v1.fields import FieldInfo
+from pydantic import BaseModel, Field, create_model
+from pydantic.fields import FieldInfo
 
 from composio.utils.logging import get as get_logger
 

--- a/python/tests/test_tools/test_toolset.py
+++ b/python/tests/test_tools/test_toolset.py
@@ -237,6 +237,9 @@ def test_processors_on_get_tools(monkeypatch: pytest.MonkeyPatch) -> None:
     toolset = LangchainToolSet()
     monkeypatch.setattr(toolset, "_execute_remote", lambda **_: {})
 
-    toolset.get_tools(processors={"post": {Action.COMPOSIO_LIST_APPS: postprocess}})
-    toolset.execute_action(Action.COMPOSIO_LIST_APPS, {})
+    toolset.get_tools(
+        actions=[Action.COMPOSIO_ENABLE_TRIGGER],
+        processors={"post": {Action.COMPOSIO_ENABLE_TRIGGER: postprocess}},
+    )
+    toolset.execute_action(Action.COMPOSIO_ENABLE_TRIGGER, {})
     assert postprocessor_called

--- a/python/tests/test_utils/test_shared.py
+++ b/python/tests/test_utils/test_shared.py
@@ -4,6 +4,9 @@ Test shared module.
 
 from inspect import Parameter
 
+import pydantic
+import pytest
+
 from composio.utils import shared
 
 
@@ -50,7 +53,7 @@ def test_json_schema_to_pydantic_field() -> None:
 
     # Check the output
     assert result[0] == "owner"
-    assert result[1] == str
+    assert result[1] is str
     assert result[2].description == "The account owner of the repository."
     assert result[2].default == ...
 
@@ -79,8 +82,8 @@ def test_json_schema_to_fields_dict() -> None:
     assert len(result) == 2
     assert "owner" in result
     assert "repo" in result
-    assert result["owner"][0] == str
-    assert result["repo"][0] == str
+    assert result["owner"][0] is str
+    assert result["repo"][0] is str
     assert result["owner"][1].description == "The account owner of the repository."
     assert (
         result["repo"][1].description
@@ -88,3 +91,63 @@ def test_json_schema_to_fields_dict() -> None:
     )
     assert result["owner"][1].default == ...
     assert result["repo"][1].default is None
+
+
+def test_pydantic_model_from_param_schema() -> None:
+    schema = {
+        "description": "Request to get a Foo Bar.",
+        "properties": {
+            "id": {
+                "default": "",
+                "description": "ID of the file manager where the file will be opened, if not provided the recent file manager will be used to execute the action",
+                "title": "Id",
+                "type": "string",
+            },
+            "foo": {
+                "default": "",
+                "description": "The foo that we need",
+                "title": "Foo",
+                "type": "string",
+            },
+            "attr": {
+                "description": "List of attributes.",
+                "items": {"type": "string"},
+                "title": "Attr",
+                "type": "array",
+            },
+            "attrmap": {
+                "description": "List of attributes.",
+                "properties": {
+                    "attr": {
+                        "description": "List of attributes.",
+                        "items": {"type": "string"},
+                        "title": "Attr",
+                        "type": "array",
+                    }
+                },
+                "title": "Attr",
+                "type": "object",
+            },
+        },
+        "required": ["attr"],
+        "title": "FooBarRequest",
+        "type": "object",
+    }
+    model = shared.pydantic_model_from_param_schema(schema)
+
+    # Happy case:
+    model(attr=["xyz", "abc"])
+    attrs = ["xyz", "list of stuff"]
+    model(attr=attrs, attrmap={"attr": attrs})
+
+    # Sad cases:
+    with pytest.raises(pydantic.ValidationError):
+        model(attr=[123])
+    with pytest.raises(pydantic.ValidationError):
+        model(attr="foo")
+    with pytest.raises(pydantic.ValidationError):
+        model()
+    with pytest.raises(pydantic.ValidationError):
+        model(attr=attrs, attrmap=None)
+    with pytest.raises(pydantic.ValidationError):
+        model(attr=attrs, attrmap=["list directly"])

--- a/python/tests/test_utils/test_shared.py
+++ b/python/tests/test_utils/test_shared.py
@@ -6,6 +6,7 @@ from inspect import Parameter
 
 import pydantic
 import pytest
+from pydantic_core import PydanticUndefined
 
 from composio.utils import shared
 
@@ -55,7 +56,7 @@ def test_json_schema_to_pydantic_field() -> None:
     assert result[0] == "owner"
     assert result[1] is str
     assert result[2].description == "The account owner of the repository."
-    assert result[2].default == ...
+    assert result[2].default == PydanticUndefined
 
 
 def test_json_schema_to_fields_dict() -> None:
@@ -89,7 +90,7 @@ def test_json_schema_to_fields_dict() -> None:
         result["repo"][1].description
         == "The name of the repository without the `.git` extension."
     )
-    assert result["owner"][1].default == ...
+    assert result["owner"][1].default == PydanticUndefined
     assert result["repo"][1].default is None
 
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Migrate from Pydantic v1 to v2, updating imports in `shared.py` and modifying a test case in `test_toolset.py`.
> 
>   - **Migration**:
>     - Update imports in `shared.py` to use Pydantic v2 (`pydantic` instead of `pydantic.v1`).
>   - **Tests**:
>     - Modify `test_processors_on_get_tools` in `test_toolset.py` to use `Action.COMPOSIO_ENABLE_TRIGGER` instead of `Action.COMPOSIO_LIST_APPS`.
>     - Update `test_shared.py` to use `PydanticUndefined` for default values in tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SamparkAI%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 138df3842b08f2722785eadd40e2924f6676c3d2. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->