### PR TITLE
feat: add `check_connected_accounts` flag on `get_tools`

### DIFF
--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -154,8 +154,6 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
         output_dir: t.Optional[Path] = None,
         verbosity_level: t.Optional[int] = None,
         connected_account_ids: t.Optional[t.Dict[AppType, str]] = None,
-        *,  # TODO: move all keyword args below this `*` in a future release
-        check_connected_accounts: bool = True,
         **kwargs: t.Any,
     ) -> None:
         """
@@ -279,13 +277,8 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
         self.logger.debug("Loading local tools")
         load_local_tools()
 
-        self._check_connected_accounts = check_connected_accounts
-        self._connected_account_ids = (
-            self._validating_connection_ids(
-                connected_account_ids=connected_account_ids or {}
-            )
-            if self._check_connected_accounts
-            else {}
+        self._connected_account_ids = self._validating_connection_ids(
+            connected_account_ids=connected_account_ids or {}
         )
 
     def _validating_connection_ids(
@@ -754,6 +747,8 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
         apps: t.Optional[t.Sequence[AppType]] = None,
         actions: t.Optional[t.Sequence[ActionType]] = None,
         tags: t.Optional[t.Sequence[TagType]] = None,
+        *,
+        check_connected_accounts: bool = True,
     ) -> t.List[ActionModel]:
         runtime_actions = t.cast(
             t.List[t.Type[LocalAction]],
@@ -790,7 +785,7 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
                 actions=remote_actions,
                 tags=tags,
             )
-            if self._check_connected_accounts:
+            if check_connected_accounts:
                 for item in remote_items:
                     self.check_connected_account(action=item.name)
             else:

--- a/python/plugins/camel/composio_camel/toolset.py
+++ b/python/plugins/camel/composio_camel/toolset.py
@@ -154,6 +154,7 @@ class ComposioToolSet(
         entity_id: t.Optional[str] = None,
         *,
         processors: t.Optional[ProcessorsType] = None,
+        check_connected_accounts: bool = True,
     ) -> t.List[OpenAIFunction]:
         """
         Get composio tools wrapped as Camel `OpenAIFunction` objects.
@@ -180,5 +181,10 @@ class ComposioToolSet(
                 ).model_dump(),
                 entity_id=entity_id,
             )
-            for schema in self.get_action_schemas(actions=actions, apps=apps, tags=tags)
+            for schema in self.get_action_schemas(
+                actions=actions,
+                apps=apps,
+                tags=tags,
+                check_connected_accounts=check_connected_accounts,
+            )
         ]

--- a/python/plugins/claude/composio_claude/toolset.py
+++ b/python/plugins/claude/composio_claude/toolset.py
@@ -97,6 +97,7 @@ class ComposioToolSet(
         tags: t.Optional[t.List[TagType]] = None,
         *,
         processors: t.Optional[ProcessorsType] = None,
+        check_connected_accounts: bool = True,
     ) -> t.List[ToolParam]:
         """
         Get composio tools wrapped as OpenAI `ChatCompletionToolParam` objects.
@@ -121,7 +122,12 @@ class ComposioToolSet(
                     ),
                 ).model_dump()
             )
-            for schema in self.get_action_schemas(actions=actions, apps=apps, tags=tags)
+            for schema in self.get_action_schemas(
+                actions=actions,
+                apps=apps,
+                tags=tags,
+                check_connected_accounts=check_connected_accounts,
+            )
         ]
 
     def execute_tool_call(

--- a/python/plugins/griptape/composio_griptape/toolset.py
+++ b/python/plugins/griptape/composio_griptape/toolset.py
@@ -138,6 +138,7 @@ class ComposioToolSet(
         entity_id: t.Optional[str] = None,
         *,
         processors: t.Optional[ProcessorsType] = None,
+        check_connected_accounts: bool = True,
     ) -> t.List[BaseTool]:
         """
         Get composio tools wrapped as GripTape `BaseTool` type objects.
@@ -159,5 +160,10 @@ class ComposioToolSet(
                 ),
                 entity_id=entity_id,
             )
-            for tool in self.get_action_schemas(actions=actions, apps=apps, tags=tags)
+            for tool in self.get_action_schemas(
+                actions=actions,
+                apps=apps,
+                tags=tags,
+                check_connected_accounts=check_connected_accounts,
+            )
         ]

--- a/python/plugins/langchain/composio_langchain/toolset.py
+++ b/python/plugins/langchain/composio_langchain/toolset.py
@@ -157,6 +157,7 @@ class ComposioToolSet(
         entity_id: t.Optional[str] = None,
         *,
         processors: t.Optional[ProcessorsType] = None,
+        check_connected_accounts: bool = True,
     ) -> t.Sequence[StructuredTool]:
         """
         Get composio tools wrapped as Langchain StructuredTool objects.
@@ -178,5 +179,10 @@ class ComposioToolSet(
                 ),
                 entity_id=entity_id or self.entity_id,
             )
-            for tool in self.get_action_schemas(actions=actions, apps=apps, tags=tags)
+            for tool in self.get_action_schemas(
+                actions=actions,
+                apps=apps,
+                tags=tags,
+                check_connected_accounts=check_connected_accounts,
+            )
         ]

--- a/python/plugins/llamaindex/composio_llamaindex/toolset.py
+++ b/python/plugins/llamaindex/composio_llamaindex/toolset.py
@@ -134,6 +134,7 @@ class ComposioToolSet(
         entity_id: t.Optional[str] = None,
         *,
         processors: t.Optional[ProcessorsType] = None,
+        check_connected_accounts: bool = True,
     ) -> t.Sequence[FunctionTool]:
         """
         Get composio tools wrapped as LlamaIndex FunctionTool objects.
@@ -155,5 +156,10 @@ class ComposioToolSet(
                 ),
                 entity_id=entity_id or self.entity_id,
             )
-            for tool in self.get_action_schemas(actions=actions, apps=apps, tags=tags)
+            for tool in self.get_action_schemas(
+                actions=actions,
+                apps=apps,
+                tags=tags,
+                check_connected_accounts=check_connected_accounts,
+            )
         ]

--- a/python/plugins/lyzr/composio_lyzr/toolset.py
+++ b/python/plugins/lyzr/composio_lyzr/toolset.py
@@ -95,6 +95,7 @@ class ComposioToolSet(
         entity_id: t.Optional[str] = None,
         *,
         processors: t.Optional[ProcessorsType] = None,
+        check_connected_accounts: bool = True,
     ) -> t.List[Tool]:
         """
         Get composio tools wrapped as Lyzr `Tool` objects.
@@ -114,5 +115,10 @@ class ComposioToolSet(
                 schema=schema.model_dump(exclude_none=True),
                 entity_id=entity_id or self.entity_id,
             )
-            for schema in self.get_action_schemas(actions=actions, apps=apps, tags=tags)
+            for schema in self.get_action_schemas(
+                actions=actions,
+                apps=apps,
+                tags=tags,
+                check_connected_accounts=check_connected_accounts,
+            )
         ]

--- a/python/plugins/openai/composio_openai/toolset.py
+++ b/python/plugins/openai/composio_openai/toolset.py
@@ -104,6 +104,7 @@ class ComposioToolSet(
         tags: t.Optional[t.List[TagType]] = None,
         *,
         processors: t.Optional[ProcessorsType] = None,
+        check_connected_accounts: bool = True,
     ) -> t.List[ChatCompletionToolParam]:
         """
         Get composio tools wrapped as OpenAI `ChatCompletionToolParam` objects.
@@ -128,7 +129,12 @@ class ComposioToolSet(
                     ),
                 ).model_dump()
             )
-            for schema in self.get_action_schemas(actions=actions, apps=apps, tags=tags)
+            for schema in self.get_action_schemas(
+                actions=actions,
+                apps=apps,
+                tags=tags,
+                check_connected_accounts=check_connected_accounts,
+            )
         ]
 
     def get_realtime_tools(

--- a/python/plugins/phidata/composio_phidata/toolset.py
+++ b/python/plugins/phidata/composio_phidata/toolset.py
@@ -71,6 +71,7 @@ class ComposioToolSet(
         tags: t.Optional[t.List[TagType]] = None,
         *,
         processors: t.Optional[ProcessorsType] = None,
+        check_connected_accounts: bool = True,
     ) -> t.List[Function]:
         """
         Get composio tools wrapped as Lyzr `Function` objects.
@@ -91,5 +92,10 @@ class ComposioToolSet(
                 ),
                 entity_id=self.entity_id,
             )
-            for schema in self.get_action_schemas(actions=actions, apps=apps, tags=tags)
+            for schema in self.get_action_schemas(
+                actions=actions,
+                apps=apps,
+                tags=tags,
+                check_connected_accounts=check_connected_accounts,
+            )
         ]

--- a/python/plugins/praisonai/composio_praisonai/toolset.py
+++ b/python/plugins/praisonai/composio_praisonai/toolset.py
@@ -190,6 +190,7 @@ class ComposioToolSet(
         entity_id: t.Optional[str] = None,
         *,
         processors: t.Optional[ProcessorsType] = None,
+        check_connected_accounts: bool = True,
     ) -> t.List[str]:
         """
         Get composio tools written as ParisonAi supported tools.
@@ -209,5 +210,10 @@ class ComposioToolSet(
                 schema=tool.model_dump(exclude_none=True),
                 entity_id=entity_id or self.entity_id,
             )
-            for tool in self.get_action_schemas(actions=actions, apps=apps, tags=tags)
+            for tool in self.get_action_schemas(
+                actions=actions,
+                apps=apps,
+                tags=tags,
+                check_connected_accounts=check_connected_accounts,
+            )
         ]

--- a/python/tests/test_tools/test_toolset.py
+++ b/python/tests/test_tools/test_toolset.py
@@ -242,7 +242,7 @@ def test_processors_on_get_tools(monkeypatch: pytest.MonkeyPatch) -> None:
     assert postprocessor_called
 
 
-def test_check_connected_accounts_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_check_connected_accounts_flag() -> None:
     """Test the `check_connected_accounts` flag on `ComposioToolSet()`."""
 
     # Ensure `check_connected_account()` gets called by default

--- a/python/tests/test_tools/test_toolset.py
+++ b/python/tests/test_tools/test_toolset.py
@@ -254,5 +254,9 @@ def test_check_connected_accounts_flag() -> None:
     # Ensure `check_connected_account()` DOES NOT get called when the flag is set
     toolset = LangchainToolSet(check_connected_accounts=False)
     with mock.patch.object(toolset, "check_connected_account") as mocked:
-        toolset.get_tools(actions=[Action.GMAIL_FETCH_EMAILS])
+        with pytest.warns(
+            UserWarning,
+            match="Not verifying connected accounts for apps.",
+        ):
+            toolset.get_tools(actions=[Action.GMAIL_FETCH_EMAILS])
         mocked.assert_not_called()

--- a/python/tests/test_tools/test_toolset.py
+++ b/python/tests/test_tools/test_toolset.py
@@ -240,3 +240,19 @@ def test_processors_on_get_tools(monkeypatch: pytest.MonkeyPatch) -> None:
     toolset.get_tools(processors={"post": {Action.COMPOSIO_LIST_APPS: postprocess}})
     toolset.execute_action(Action.COMPOSIO_LIST_APPS, {})
     assert postprocessor_called
+
+
+def test_check_connected_accounts_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test the `check_connected_accounts` flag on `ComposioToolSet()`."""
+
+    # Ensure `check_connected_account()` gets called by default
+    toolset = LangchainToolSet()
+    with mock.patch.object(toolset, "check_connected_account") as mocked:
+        toolset.get_tools(actions=[Action.GMAIL_FETCH_EMAILS])
+        mocked.assert_called_once()
+
+    # Ensure `check_connected_account()` DOES NOT get called when the flag is set
+    toolset = LangchainToolSet(check_connected_accounts=False)
+    with mock.patch.object(toolset, "check_connected_account") as mocked:
+        toolset.get_tools(actions=[Action.GMAIL_FETCH_EMAILS])
+        mocked.assert_not_called()

--- a/python/tests/test_tools/test_toolset.py
+++ b/python/tests/test_tools/test_toolset.py
@@ -243,20 +243,22 @@ def test_processors_on_get_tools(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_check_connected_accounts_flag() -> None:
-    """Test the `check_connected_accounts` flag on `ComposioToolSet()`."""
+    """Test the `check_connected_accounts` flag on `get_tools()`."""
 
-    # Ensure `check_connected_account()` gets called by default
     toolset = LangchainToolSet()
+    # Ensure `check_connected_account()` gets called by default
     with mock.patch.object(toolset, "check_connected_account") as mocked:
         toolset.get_tools(actions=[Action.GMAIL_FETCH_EMAILS])
         mocked.assert_called_once()
 
     # Ensure `check_connected_account()` DOES NOT get called when the flag is set
-    toolset = LangchainToolSet(check_connected_accounts=False)
     with mock.patch.object(toolset, "check_connected_account") as mocked:
         with pytest.warns(
             UserWarning,
             match="Not verifying connected accounts for apps.",
         ):
-            toolset.get_tools(actions=[Action.GMAIL_FETCH_EMAILS])
+            toolset.get_tools(
+                actions=[Action.GMAIL_FETCH_EMAILS],
+                check_connected_accounts=False,
+            )
         mocked.assert_not_called()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `check_connected_accounts` flag to `ComposioToolSet` to control connected account validation, with tests and warnings if disabled.
> 
>   - **Behavior**:
>     - Add `check_connected_accounts` flag to `ComposioToolSet` constructor to control connected account validation.
>     - If `check_connected_accounts` is `False`, skips validation in `_validating_connection_ids()` and `get_action_schemas()`.
>     - Warns if `check_connected_accounts` is `False` in `get_action_schemas()`.
>   - **Tests**:
>     - Add `test_check_connected_accounts_flag` in `test_toolset.py` to verify behavior of `check_connected_accounts` flag.
>   - **Misc**:
>     - Minor formatting changes in `_serialize_execute_params()` in `toolset.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SamparkAI%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 0a8ce00dfd91e6f0916a29c12643ade5d2395657. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->