### PR TITLE
chore: disable default sentry integrations

### DIFF
--- a/python/composio/utils/sentry.py
+++ b/python/composio/utils/sentry.py
@@ -73,6 +73,7 @@ def init():
         profiles_sample_rate=sentry_config.get("profiles_sample_rate", 1.0),
         debug=False,
         before_send=filter_sentry_errors,
+        default_integrations=False,
         integrations=[
             sentry_sdk.integrations.atexit.AtexitIntegration(
                 callback=lambda x, y: None


### PR DESCRIPTION
When we do:

```python
import composio
```

If the user is logged in, `composio` initializes Sentry. Sentry has a `cohere` integration that is enabled by default, that imports `cohere` which imports `sagemaker` which tries to create a `boto3` connection to `s3` by default. This is very slow.

To work around this, we can either disable the `cohere` integration, or just disable all default integrations if they are unused, which is what I'm doing.

This made the import time go from 6 seconds to 0.4 seconds on my local machine.

Resolves ENG-1367

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Disables default Sentry integrations in `sentry.py` to improve `composio` import time.
> 
>   - **Behavior**:
>     - Disables all default Sentry integrations in `init()` function in `sentry.py` by setting `default_integrations=False`.
>     - Reduces import time of `composio` from 6 seconds to 0.4 seconds by preventing unnecessary imports and connections.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SamparkAI%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for ea5719e25ed4cb0a8c9b805b864bb679691036e2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->