### PR TITLE
Usage for auth_scheme on `get_expected_params_for_user`

### DIFF
--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -1111,14 +1111,27 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
             "expected_params": integration.expectedInputFields,
         }
 
-    def _get_integration_for_app(self, app: AppType) -> IntegrationModel:
+    def _get_integration_for_app(
+        self,
+        app: AppType,
+        auth_scheme: t.Optional[str] = None,
+    ) -> IntegrationModel:
         for integration in sorted(self.get_integrations(), key=lambda x: x.createdAt):
             if integration.appName.lower() == str(app).lower():
+                if (
+                    auth_scheme is not None
+                    and integration.authScheme.lower() != auth_scheme.lower()
+                ):
+                    continue
                 return self.get_integration(id=integration.id)
         raise ValueError(f"No integration found for `{app}`")
 
-    def _get_expected_params_from_app(self, app: AppType) -> IntegrationParams:
-        integration = self._get_integration_for_app(app=app)
+    def _get_expected_params_from_app(
+        self,
+        app: AppType,
+        auth_scheme: t.Optional[str] = None,
+    ) -> IntegrationParams:
+        integration = self._get_integration_for_app(app=app, auth_scheme=auth_scheme)
         return {
             "integration_id": integration.id,
             "auth_scheme": integration.authScheme,
@@ -1157,7 +1170,16 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
         """
         # If `integration_id` is provided, use it to fetch the params
         if integration_id is not None:
-            return self._get_expected_params_from_integration_id(id=integration_id)
+            response = self._get_expected_params_from_integration_id(id=integration_id)
+            if auth_scheme is not None and response["auth_scheme"] != auth_scheme:
+                raise ComposioSDKError(
+                    message=(
+                        "Auth scheme does not match provided integration ID, "
+                        f"auth scheme assosiated with integration ID {response['auth_scheme']} "
+                        f"auth scheme provided {auth_scheme}"
+                    )
+                )
+            return response
 
         if app is None:
             raise ComposioSDKError(
@@ -1167,7 +1189,7 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
         try:
             # Check if integration is available for an app, and if available
             # return params from that integration
-            return self._get_expected_params_from_app(app=app)
+            return self._get_expected_params_from_app(app=app, auth_scheme=auth_scheme)
         except ValueError:
             pass
 
@@ -1193,9 +1215,9 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
 
         raise ComposioSDKError(
             message=(
-                f"No existing integration found for `{str(app)}`, "
-                "Please create an integration and use the ID to "
-                "fetch the expected params."
+                f"No existing integration found for `{str(app)}`, with auth "
+                f"scheme {auth_scheme} Please create an integration and use the"
+                " ID to fetch the expected params."
             )
         )
 

--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -1175,7 +1175,7 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
                 raise ComposioSDKError(
                     message=(
                         "Auth scheme does not match provided integration ID, "
-                        f"auth scheme assosiated with integration ID {response['auth_scheme']} "
+                        f"auth scheme associated with integration ID {response['auth_scheme']} "
                         f"auth scheme provided {auth_scheme}"
                     )
                 )

--- a/python/plugins/langgraph/langgraph_demo_toolnode.py
+++ b/python/plugins/langgraph/langgraph_demo_toolnode.py
@@ -8,9 +8,9 @@ from composio_langgraph import Action, ComposioToolSet
 
 
 composio_toolset = ComposioToolSet()
-tools = composio_toolset.get_actions(
+tools = composio_toolset.get_tools(
     actions=[
-        Action.GITHUB_ACTIVITY_STAR_REPO_FOR_AUTHENTICATED_USER,
+        Action.GITHUB_STAR_A_REPOSITORY_FOR_THE_AUTHENTICATED_USER,
         Action.GITHUB_USERS_GET_AUTHENTICATED,
     ]
 )


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance `ComposioToolSet` to support `auth_scheme` filtering in integration parameter retrieval and update action usage in `langgraph_demo_toolnode.py`.
> 
>   - **Behavior**:
>     - `get_expected_params_for_user()` in `toolset.py` now checks `auth_scheme` against `integration_id` and raises `ComposioSDKError` if they don't match.
>     - `_get_integration_for_app()` and `_get_expected_params_from_app()` in `toolset.py` now accept `auth_scheme` to filter integrations.
>   - **Misc**:
>     - Renames `get_actions` to `get_tools` and `GITHUB_ACTIVITY_STAR_REPO_FOR_AUTHENTICATED_USER` to `GITHUB_STAR_A_REPOSITORY_FOR_THE_AUTHENTICATED_USER` in `langgraph_demo_toolnode.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SamparkAI%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 64f518eba217e9719821e0615f439f5f295f3584. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->