### PR TITLE
feat: add `toolset.get_connected_accounts()`

### DIFF
--- a/python/composio/client/collections.py
+++ b/python/composio/client/collections.py
@@ -155,8 +155,7 @@ class ConnectedAccounts(Collection[ConnectedAccountModel]):
         """
         Get a list of connected accounts
 
-        :param connection_id: ID of the connection to filter by
-        :return: Connected account
+        :return: List of Connected accounts
         """
 
     @t.overload  # type: ignore

--- a/python/composio/client/collections.py
+++ b/python/composio/client/collections.py
@@ -153,7 +153,7 @@ class ConnectedAccounts(Collection[ConnectedAccountModel]):
     @t.overload  # type: ignore
     def get(self) -> t.List[ConnectedAccountModel]:
         """
-        Get a list of connected accounts
+        Get all connected accounts
 
         :return: List of Connected accounts
         """

--- a/python/composio/client/collections.py
+++ b/python/composio/client/collections.py
@@ -151,7 +151,16 @@ class ConnectedAccounts(Collection[ConnectedAccountModel]):
     endpoint = v1 / "connectedAccounts"
 
     @t.overload  # type: ignore
-    def get(self, connection_id: t.Optional[str] = None) -> ConnectedAccountModel:
+    def get(self) -> t.List[ConnectedAccountModel]:
+        """
+        Get an account by connection ID
+
+        :param connection_id: ID of the connection to filter by
+        :return: Connected account
+        """
+
+    @t.overload  # type: ignore
+    def get(self, connection_id: str) -> ConnectedAccountModel:
         """
         Get an account by connection ID
 

--- a/python/composio/client/collections.py
+++ b/python/composio/client/collections.py
@@ -153,7 +153,7 @@ class ConnectedAccounts(Collection[ConnectedAccountModel]):
     @t.overload  # type: ignore
     def get(self) -> t.List[ConnectedAccountModel]:
         """
-        Get an account by connection ID
+        Get a list of connected accounts
 
         :param connection_id: ID of the connection to filter by
         :return: Connected account

--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -1071,6 +1071,9 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
     def get_connected_account(self, id: str) -> ConnectedAccountModel:
         return self.client.connected_accounts.get(connection_id=id)
 
+    def get_connected_accounts(self) -> t.List[ConnectedAccountModel]:
+        return self.client.connected_accounts.get()
+
     def get_entity(self, id: t.Optional[str] = None) -> Entity:
         """Get entity object for given ID."""
         return self.client.get_entity(id=id or self.entity_id)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `get_connected_accounts()` to `ComposioToolSet` and modify `ConnectedAccounts.get()` to retrieve all connected accounts.
> 
>   - **Behavior**:
>     - Add `get_connected_accounts()` method to `ComposioToolSet` in `toolset.py` to retrieve all connected accounts.
>     - Modify `get()` method in `ConnectedAccounts` in `collections.py` to support retrieving a list of connected accounts without a `connection_id`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SamparkAI%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 6b1b8bcacc344c39c01a8e06b680182baf8739c4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->