### PR TITLE
Fix multi entity api key

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -105,4 +105,9 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_TECH_WEBHOOK }}
           SLACK_TITLE: "Example Tests Failed"
           SLACK_MSG_AUTHOR: ${{ inputs.author || github.actor }}
-          SLACK_MESSAGE: ${{ inputs.commit_message || github.event.head_commit.message }}
+          SLACK_MESSAGE: "<@viraj> ${{ inputs.commit_message || github.event.head_commit.message }}"
+          SLACK_LINK_NAMES: "true"
+          SLACK_COLOR: "failure"
+          SLACK_USERNAME: "GitHub Actions Bot"
+          SLACK_ICON_EMOJI: ":x:"
+          SLACK_FOOTER: "Failed Example Tests | GitHub Actions"

--- a/python/composio/client/__init__.py
+++ b/python/composio/client/__init__.py
@@ -406,6 +406,8 @@ class Entity:
         app = self.client.apps.get(name=app_name)
         timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
         if integration is None and auth_mode is not None:
+            if "OAUTH" not in auth_mode:
+                use_composio_auth = False
             integration = self.client.integrations.create(
                 app_id=app.appId,
                 name=f"{app_name}_{timestamp}",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix `initiate_connection()` in `__init__.py` to handle non-OAUTH `auth_mode` and update Slack notifications in `examples.yml`.
> 
>   - **Behavior**:
>     - In `initiate_connection()` in `__init__.py`, set `use_composio_auth` to `False` if `auth_mode` does not contain 'OAUTH'.
>   - **GitHub Actions**:
>     - Update Slack notification settings in `examples.yml` to include `SLACK_LINK_NAMES`, `SLACK_COLOR`, `SLACK_USERNAME`, `SLACK_ICON_EMOJI`, and `SLACK_FOOTER`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SamparkAI%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 6cc5f9c9f8dd01b7bd8ee1219e561b320256e544. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->