### PR TITLE
fix: create parent folders when creating the cache folders

### DIFF
--- a/python/composio/cli/apps.py
+++ b/python/composio/cli/apps.py
@@ -143,6 +143,7 @@ def _update_apps(apps: t.List[AppModel]) -> None:
     """Create App enum class."""
     app_names = []
     enums.base.APPS_CACHE.mkdir(
+        parents=True,
         exist_ok=True,
     )
     for app in apps:
@@ -176,7 +177,7 @@ def _update_apps(apps: t.List[AppModel]) -> None:
 
 def _update_actions(apps: t.List[AppModel], actions: t.List[ActionModel]) -> None:
     """Get Action enum."""
-    enums.base.ACTIONS_CACHE.mkdir(exist_ok=True)
+    enums.base.ACTIONS_CACHE.mkdir(parents=True, exist_ok=True)
     deprecated = {}
     action_names = []
     for app in sorted(apps, key=lambda x: x.key):
@@ -231,7 +232,7 @@ def _update_actions(apps: t.List[AppModel], actions: t.List[ActionModel]) -> Non
 
 def _update_tags(apps: t.List[AppModel], actions: t.List[ActionModel]) -> None:
     """Create Tag enum class."""
-    enums.base.TAGS_CACHE.mkdir(exist_ok=True)
+    enums.base.TAGS_CACHE.mkdir(parents=True, exist_ok=True)
     tag_map: t.Dict[str, t.Set[str]] = {}
     for app in apps:
         app_name = app.key


### PR DESCRIPTION
SDK was failing when trying to create `~/.composio/apps` folder when `~/.composio` folder did not exist. The fix for that is to allow `Path.mkdir()` to create the parent folders that don't exist, by passing `parents=True`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes SDK directory creation issue by ensuring parent directories are created for cache folders in `apps.py`.
> 
>   - **Behavior**:
>     - Fixes issue where SDK failed to create `~/.composio/apps` if `~/.composio` did not exist.
>     - Updates `mkdir` calls in `_update_apps()`, `_update_actions()`, and `_update_tags()` to use `parents=True`.
>   - **Functions**:
>     - `_update_apps()`: Ensures `APPS_CACHE` directory creation with parent directories.
>     - `_update_actions()`: Ensures `ACTIONS_CACHE` directory creation with parent directories.
>     - `_update_tags()`: Ensures `TAGS_CACHE` directory creation with parent directories.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SamparkAI%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 4b833f3b1ccf270d8ec8fa320cdbc0367d13964a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->