### PR TITLE
Fix multi app use case search on python SDK

### DIFF
--- a/python/composio/client/collections.py
+++ b/python/composio/client/collections.py
@@ -1016,11 +1016,6 @@ class Actions(Collection[ActionModel]):
 
         queries: t.Dict[str, str] = {}
         if use_case is not None and use_case != "":
-            if len(apps) != 1:
-                raise ComposioClientError(
-                    "Error retrieving Actions, Use case "
-                    "should be provided with exactly one app."
-                )
             queries["useCase"] = use_case
 
         if len(apps) > 0:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removed restriction in `get` function of `Actions` class in `collections.py` that raised an error if `use_case` was provided with more than one app.
> 
>   - **Behavior**:
>     - Removed restriction in `get` function of `Actions` class in `collections.py` that raised an error if `use_case` was provided with more than one app.
>   - **Misc**:
>     - Removed error handling for multiple apps with `use_case` in `collections.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for fd194381fe697150fd2e672e3c978dede8240fba. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->