### PR TITLE
fix: pusher disconnection should be notified to the user

### DIFF
--- a/python/composio/client/collections.py
+++ b/python/composio/client/collections.py
@@ -18,6 +18,7 @@ import typing_extensions as te
 from pydantic import BaseModel, ConfigDict, Field
 from pysher.channel import Channel as PusherChannel
 from pysher.connection import Connection as PusherConnection
+import websocket
 
 from composio.client.base import BaseClient, Collection
 from composio.client.endpoints import v1, v2
@@ -488,10 +489,10 @@ class _ChunkedTriggerEventData(BaseModel):
 class _TriggerEventFilters(te.TypedDict):
     """Trigger event filterset."""
 
-    app_name: te.NotRequired[str]
+    app_name: te.NotRequired[AppType]
     trigger_id: te.NotRequired[str]
     connection_id: te.NotRequired[str]
-    trigger_name: te.NotRequired[str]
+    trigger_name: te.NotRequired[TriggerType]
     entity_id: te.NotRequired[str]
     integration_id: te.NotRequired[str]
 
@@ -610,6 +611,13 @@ class TriggerSubscription(logging.WithLogger):
         """Check if subscription is live."""
         return self._alive
 
+    def has_errored(self) -> bool:
+        """Check if the connection errored and disconnected."""
+        return (
+            self._connection.socket is not None
+            and not self._connection.socket.has_errored
+        )
+
     def set_alive(self) -> None:
         """Set `_alive` to True."""
         self._alive = True
@@ -621,7 +629,7 @@ class TriggerSubscription(logging.WithLogger):
 
     def wait_forever(self) -> None:
         """Wait infinitely."""
-        while self._alive:
+        while self.is_alive() and not self.has_errored():
             time.sleep(1)
 
     def stop(self) -> None:

--- a/python/composio/client/collections.py
+++ b/python/composio/client/collections.py
@@ -612,10 +612,7 @@ class TriggerSubscription(logging.WithLogger):
 
     def has_errored(self) -> bool:
         """Check if the connection errored and disconnected."""
-        return (
-            self._connection.socket is not None
-            and not self._connection.socket.has_errored
-        )
+        return self._connection.socket is None or self._connection.socket.has_errored
 
     def set_alive(self) -> None:
         """Set `_alive` to True."""

--- a/python/composio/client/collections.py
+++ b/python/composio/client/collections.py
@@ -18,7 +18,6 @@ import typing_extensions as te
 from pydantic import BaseModel, ConfigDict, Field
 from pysher.channel import Channel as PusherChannel
 from pysher.connection import Connection as PusherConnection
-import websocket
 
 from composio.client.base import BaseClient, Collection
 from composio.client.endpoints import v1, v2


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds error detection in `TriggerSubscription` to notify users of Pusher disconnections and updates type definitions in `_TriggerEventFilters`.
> 
>   - **Behavior**:
>     - Adds `has_errored()` method in `TriggerSubscription` to detect Pusher disconnections.
>     - Updates `wait_forever()` in `TriggerSubscription` to stop if `has_errored()` returns true.
>   - **Type Changes**:
>     - Changes `app_name` to `AppType` and `trigger_name` to `TriggerType` in `_TriggerEventFilters`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 39a0eacafc2d963cab6a4ede381cf9dc62143399. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->

### Changes

This should handle disconnection when the websocket connection errors out.

If the network gets disconnected and re-connected, the code doesn't error out, Pysher handles it implicitly.

### Example code:

```python
from composio import ComposioToolSet, Trigger

toolset = ComposioToolSet()
listener = toolset.create_trigger_listener()

@listener.callback(filters={"trigger_name": Trigger.GMAIL_NEW_GMAIL_MESSAGE})
def callback_new_message(event):
    pass

listener.wait_forever()
```

### Output: 
```console
$ python asd.py
[2024-11-18 13:19:11,894][INFO] Logging is set to INFO, use `logging_level` argument or `COMPOSIO_LOGGING_LEVEL` change this
[2024-11-18 13:19:11,967][INFO] Creating trigger subscription
Connection: Message - {"event":"pusher:connection_established","data":"{\"socket_id\":\"797870.10528390\"}"}
Connection: Message - {"event":"pusher:pong","data":"{}"}
Connection: Message - {"event":"pusher_internal:subscription_succeeded","data":"{}","channel":"private-2c519b67-bc75-4f03-94c4-47551377c662_triggers"}
Connection: Message - {"event":"pusher_internal:subscription_count","data":"{\"subscription_count\":1}","channel":"private-2c519b67-bc75-4f03-94c4-47551377c662_triggers"}
Checking pong
Connection: Error - Connection to remote host was lost.
[2024-11-18 13:22:58,809][ERROR] Connection to remote host was lost. - goodbye
Connection: Connection closed
```