### PR TITLE
feat: add better error messages for wrong callback filters

### DIFF
--- a/docs/introduction/intro/quickstart_3.mdx
+++ b/docs/introduction/intro/quickstart_3.mdx
@@ -115,10 +115,12 @@ Don't forget to set your `COMPOSIO_API_KEY` and `OPENAI_API_KEY` in your environ
 
 <CodeGroup>
 ```python Creating a trigger listener for Gmail
+from composio import Trigger
+
 listener = composio_toolset.create_trigger_listener()
 
 # Triggers when a new event takes place
-@listener.callback(filters={"trigger_name": "gmail_new_gmail_message"})
+@listener.callback(filters={"trigger_name": Trigger.GMAIL_NEW_GMAIL_MESSAGE})
 def callback_function(event):
     # Parse event data and perform actions
     payload = event.payload
@@ -127,7 +129,7 @@ def callback_function(event):
     sender_mail = payload.get("sender")
     print(sender_mail + ":" + message)
 
-listener.listen()
+listener.wait_forever()
 ```
 </CodeGroup>
 

--- a/python/composio/client/enums/base.py
+++ b/python/composio/client/enums/base.py
@@ -310,23 +310,27 @@ class _AnnotatedEnum(t.Generic[EntityType]):
         return t.cast(EntityType, _model_cache[self._slug])
 
     @classmethod
-    def all(cls) -> t.Iterator[te.Self]:
-        """Iterate over available object."""
+    def iter(cls) -> t.Iterator[str]:
+        """Yield the enum names as strings."""
         for name in cls.__annotations__:
             if name == "_deprecated":
                 continue
-            yield cls._create(name=name)
+
+            yield name
 
     @classmethod
-    def _create(cls, name: str) -> te.Self:
-        """Create a `_AnnotatedEnum` class."""
-        return cls(name)
+    def all(cls) -> t.Iterator[te.Self]:
+        """Iterate over available object."""
+        for app_name in cls.iter():
+            yield cls(app_name)
 
     def __str__(self) -> str:
         """String representation."""
-        return t.cast(str, self._slug)
+        return self._slug
 
-    __repr__ = __str__
+    def __repr__(self) -> str:
+        """Developer friendly representation."""
+        return f"{self.__class__.__qualname__}.{self}"
 
     def __eq__(self, other: object) -> bool:
         """Check equivalence of two objects."""

--- a/python/tests/test_client/test_collections.py
+++ b/python/tests/test_client/test_collections.py
@@ -5,12 +5,15 @@ Test collections module.
 from logging import DEBUG
 from unittest import mock
 
+import pytest
+
 from composio.client.collections import (
     Trigger,
     TriggerEventData,
     TriggerSubscription,
     to_trigger_names,
 )
+from composio.exceptions import ComposioSDKError
 from composio.utils import logging
 
 
@@ -137,3 +140,40 @@ def test_trigger_filters(capsys, caplog) -> None:
         subscription.handle_event(event="")
 
     assert "Trigger 1 called from callback 1" in capsys.readouterr().out
+
+
+def test_trigger_filter_errors(capsys, caplog) -> None:
+    """Test trigger callback filters."""
+    sub = TriggerSubscription()
+
+    with pytest.raises(ComposioSDKError) as exc:
+        sub.callback(filters={"app_name": "does_not_exist"})
+
+    assert (
+        exc.value.message
+        == "App 'DOES_NOT_EXIST' does not exist.\n\nRead more here: https://docs.composio.dev/introduction/intro/quickstart_3"
+    )
+
+    with pytest.raises(ComposioSDKError) as exc:
+        sub.callback(filters={"app_name": "hacker_news"})
+
+    assert (
+        exc.value.message
+        == "App 'HACKER_NEWS' does not exist. Did you mean 'HACKERNEWS'?\n\nRead more here: https://docs.composio.dev/introduction/intro/quickstart_3"
+    )
+
+    with pytest.raises(ComposioSDKError) as exc:
+        sub.callback(filters={"triggerName": "gmail_new_gmail_message"})  # type: ignore
+
+    assert (
+        exc.value.message
+        == "Unexpected filter 'triggerName' Did you mean 'trigger_name'?\n\nRead more here: https://docs.composio.dev/introduction/intro/quickstart_3"
+    )
+
+    with pytest.raises(ComposioSDKError) as exc:
+        sub.callback(filters={"trigger_name": "gmail_new_message"})
+
+    assert (
+        exc.value.message
+        == "Trigger 'GMAIL_NEW_MESSAGE' does not exist. Did you mean 'GMAIL_NEW_GMAIL_MESSAGE'?\n\nRead more here: https://docs.composio.dev/introduction/intro/quickstart_3"
+    )


### PR DESCRIPTION
```py
@listener.callback(filters={"app_name": "GNAIL"})
def gmail_callback(event):
    print(event)
```

```console
$ python asd.py
Traceback (most recent call last):
  [...]
  File "/Users/tusharsadhwani/code/composio/python/composio/client/collections.py", line 562, in validate_filters
    raise ComposioSDKError(error_msg + docs_link_msg)
composio.exceptions.ComposioSDKError: App 'GNAIL' does not exist. Did you mean 'GMAIL'?

Read more here: https://docs.composio.dev/introduction/intro/quickstart_3
```