### PR TITLE
chore: re-enable sentry integrations

### DIFF
--- a/python/composio/utils/sentry.py
+++ b/python/composio/utils/sentry.py
@@ -10,15 +10,15 @@ from pathlib import Path
 
 import requests
 import sentry_sdk
-import sentry_sdk.integrations.atexit
 import sentry_sdk.integrations.argv
+import sentry_sdk.integrations.atexit
 import sentry_sdk.integrations.dedupe
 import sentry_sdk.integrations.excepthook
+import sentry_sdk.integrations.fastapi
 import sentry_sdk.integrations.logging
 import sentry_sdk.integrations.modules
 import sentry_sdk.integrations.stdlib
 import sentry_sdk.integrations.threading
-import sentry_sdk.integrations.fastapi
 import sentry_sdk.types
 
 

--- a/python/composio/utils/sentry.py
+++ b/python/composio/utils/sentry.py
@@ -60,8 +60,7 @@ def filter_sentry_errors(
     for frm in traceback.format_tb(trb):
         if "site-packages/composio" in frm:
             return event
-    # return None
-    return event
+    return None
 
 
 def init():

--- a/python/composio/utils/sentry.py
+++ b/python/composio/utils/sentry.py
@@ -10,8 +10,15 @@ from pathlib import Path
 
 import requests
 import sentry_sdk
-import sentry_sdk.integrations
 import sentry_sdk.integrations.atexit
+import sentry_sdk.integrations.argv
+import sentry_sdk.integrations.dedupe
+import sentry_sdk.integrations.excepthook
+import sentry_sdk.integrations.logging
+import sentry_sdk.integrations.modules
+import sentry_sdk.integrations.stdlib
+import sentry_sdk.integrations.threading
+import sentry_sdk.integrations.fastapi
 import sentry_sdk.types
 
 
@@ -53,7 +60,8 @@ def filter_sentry_errors(
     for frm in traceback.format_tb(trb):
         if "site-packages/composio" in frm:
             return event
-    return None
+    # return None
+    return event
 
 
 def init():
@@ -75,15 +83,23 @@ def init():
         before_send=filter_sentry_errors,
         default_integrations=False,
         integrations=[
+            sentry_sdk.integrations.argv.ArgvIntegration(),
             sentry_sdk.integrations.atexit.AtexitIntegration(
-                callback=lambda x, y: None
-            )  # suppress atexit message
+                callback=lambda x, y: None,
+            ),  # suppress atexit message
+            sentry_sdk.integrations.dedupe.DedupeIntegration(),
+            sentry_sdk.integrations.excepthook.ExcepthookIntegration(),
+            sentry_sdk.integrations.fastapi.FastApiIntegration(),
+            sentry_sdk.integrations.logging.LoggingIntegration(),
+            sentry_sdk.integrations.modules.ModulesIntegration(),
+            sentry_sdk.integrations.stdlib.StdlibIntegration(),
+            sentry_sdk.integrations.threading.ThreadingIntegration(),
         ],
     )
 
 
 @atexit.register
-def update_dns() -> None:
+def update_dsn() -> None:
     user_file = Path.home() / ".composio" / "user_data.json"
     if not user_file.exists():
         return


### PR DESCRIPTION
Re-enables various default sentry integrations (especially `excepthook` which is responsible for most exception logging).
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Re-enables multiple Sentry integrations and modifies `filter_sentry_errors()` to always return events.
> 
>   - **Sentry Integrations**:
>     - Re-enables `excepthook`, `argv`, `dedupe`, `logging`, `modules`, `stdlib`, `threading`, and `fastapi` integrations in `init()`.
>   - **Functions**:
>     - Modifies `filter_sentry_errors()` to always return the event instead of `None`.
>     - Fixes typo in `update_dsn()` function name.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for a4cea6965887170bf62f87a500d3808d951bc035. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->