### PR TITLE
Clean description before generating schema

### DIFF
--- a/python/composio/tools/base/abs.py
+++ b/python/composio/tools/base/abs.py
@@ -229,8 +229,8 @@ class ActionBuilder:
         if getattr(getattr(obj, "execute"), "__isabstractmethod__", False):
             raise InvalidClassDefinition(f"Please implement {name}.execute")
 
-    @staticmethod
-    def set_metadata(obj: t.Type["Action"]) -> None:
+    @classmethod
+    def set_metadata(cls, obj: t.Type["Action"]) -> None:
         setattr(obj, "file", getattr(obj, "file", Path(inspect.getfile(obj))))
         setattr(obj, "name", getattr(obj, "name", inflection.underscore(obj.__name__)))
         setattr(
@@ -250,13 +250,21 @@ class ActionBuilder:
         setattr(
             obj,
             "description",
-            (obj.__doc__ or obj.display_name).lstrip().rstrip(),
+            cls._get_description(obj),
         )
         description, *_ = obj.description.split("<<DEPRECATED", maxsplit=1)
         if len(description) > 1024:
             raise InvalidClassDefinition(
                 f"Description for action `{obj.__name__}` contains more than 1024 characters"
             )
+
+    @staticmethod
+    def _get_description(obj) -> str:
+        return (
+            (obj.__doc__ if obj.__doc__ else inflection.titleize(obj.display_name))
+            .replace("\n    ", " ")
+            .strip()
+        )
 
 
 class ActionMeta(type):
@@ -320,21 +328,16 @@ class Action(
     @classmethod
     def _generate_schema(cls) -> None:
         """Generate action schema."""
-        description = (
-            cls.__doc__.lstrip().rstrip()
-            if cls.__doc__
-            else inflection.titleize(cls.display_name)
-        )
         cls._schema = {
             "name": cls.name,
             "enum": cls.enum,
             "appName": cls.tool,
             "appId": generate_app_id(cls.tool),
             "tags": cls.tags(),
-            "displayName": cls.display_name,
-            "description": description,
-            "parameters": cls.request.schema(),
             "response": cls.response.schema(),
+            "parameters": cls.request.schema(),
+            "displayName": cls.display_name,
+            "description": cls.description,
         }
 
     @classmethod


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Clean descriptions in `ActionBuilder` before generating schema using `_get_description` method.
> 
>   - **Behavior**:
>     - `ActionBuilder.set_metadata` now uses `ActionBuilder._get_description` to clean descriptions by removing newlines and tabs.
>     - `ActionMeta._generate_schema` now uses `cls.description` instead of cleaning `cls.__doc__` directly.
>   - **Methods**:
>     - Add `ActionBuilder._get_description` to clean description strings by replacing newlines with spaces and removing tabs.
>   - **Misc**:
>     - Change `set_metadata` from `staticmethod` to `classmethod` in `ActionBuilder`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 056239736d4ea8d6fea7daa41b7afc9517f54ea0. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->