### PR TITLE
feat: show friendly error if trigger is not enabled on your account

### DIFF
--- a/python/composio/cli/triggers.py
+++ b/python/composio/cli/triggers.py
@@ -23,7 +23,7 @@ class TriggersExamples(HelpfulCmdBase, DYMGroup):
         + click.style("              # List all triggers\n", fg="black"),
         click.style("composio triggers --active", fg="green")
         + click.style("     # List only active triggers\n", fg="black"),
-        click.style("composio triggers enable ATTIO_LIST_TASKS", fg="green")
+        click.style("composio triggers enable SLACK_RECEIVE_MESSAGE", fg="green")
         + click.style("   # Enable a trigger\n", fg="black"),
         click.style("composio triggers --id 12345", fg="green")
         + click.style("   # List trigger with specific ID\n", fg="black"),

--- a/python/composio/client/__init__.py
+++ b/python/composio/client/__init__.py
@@ -10,7 +10,6 @@ from pathlib import Path
 
 import requests
 
-from composio.client.base import BaseClient
 from composio.client.collections import (
     Actions,
     ActiveTriggerModel,
@@ -52,9 +51,10 @@ _valid_keys: t.Set[str] = set()
 _clients: t.List["Composio"] = []
 
 
-class Composio(BaseClient):
+class Composio:
     """Composio SDK Client."""
 
+    local: t.Any
     _api_key: t.Optional[str] = None
     _http: t.Optional[HttpClient] = None
 

--- a/python/composio/client/base.py
+++ b/python/composio/client/base.py
@@ -10,6 +10,7 @@ from composio.client.endpoints import Endpoint
 from composio.client.exceptions import HTTPError, NoItemsFound
 from composio.utils import logging
 
+
 if t.TYPE_CHECKING:
     from composio.client import Composio
 

--- a/python/composio/client/base.py
+++ b/python/composio/client/base.py
@@ -8,9 +8,10 @@ import requests
 
 from composio.client.endpoints import Endpoint
 from composio.client.exceptions import HTTPError, NoItemsFound
-from composio.client.http import HttpClient
 from composio.utils import logging
 
+if t.TYPE_CHECKING:
+    from composio.client import Composio
 
 ModelType = t.TypeVar("ModelType")
 CollectionType = t.TypeVar("CollectionType", list, dict)
@@ -24,7 +25,7 @@ class Collection(t.Generic[ModelType], logging.WithLogger):
 
     _list_key: str = "items"
 
-    def __init__(self, client: "BaseClient") -> None:
+    def __init__(self, client: "Composio") -> None:
         """Initialize connected accounts models namespace."""
         logging.WithLogger.__init__(self)
         self.client = client
@@ -74,11 +75,3 @@ class Collection(t.Generic[ModelType], logging.WithLogger):
             message=f"Received invalid data object: {request.content.decode()}",
             status_code=request.status_code,
         )
-
-
-class BaseClient:
-    """Composio client abstraction."""
-
-    http: HttpClient
-    local: t.Any
-    api_key: str

--- a/python/composio/client/collections.py
+++ b/python/composio/client/collections.py
@@ -36,6 +36,7 @@ from composio.client.exceptions import ComposioClientError, ComposioSDKError
 from composio.constants import PUSHER_CLUSTER, PUSHER_KEY
 from composio.utils import logging
 
+
 if t.TYPE_CHECKING:
     from composio.client import Composio
 

--- a/python/composio/client/collections.py
+++ b/python/composio/client/collections.py
@@ -20,7 +20,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from pysher.channel import Channel as PusherChannel
 from pysher.connection import Connection as PusherConnection
 
-from composio.client.base import BaseClient, Collection
+from composio.client.base import Collection
 from composio.client.endpoints import v1, v2
 from composio.client.enums import (
     Action,
@@ -36,12 +36,15 @@ from composio.client.exceptions import ComposioClientError, ComposioSDKError
 from composio.constants import PUSHER_CLUSTER, PUSHER_KEY
 from composio.utils import logging
 
+if t.TYPE_CHECKING:
+    from composio.client import Composio
+
 
 def to_trigger_names(
     triggers: t.Union[t.List[str], t.List[Trigger], t.List[TriggerType]],
 ) -> str:
     """Get trigger names as a string."""
-    return ",".join([Trigger(trigger).name for trigger in triggers])
+    return ",".join([Trigger(trigger).slug for trigger in triggers])
 
 
 class AuthConnectionParamsModel(BaseModel):
@@ -94,7 +97,7 @@ class ConnectionRequestModel(BaseModel):
 
     def save_user_access_data(
         self,
-        client: BaseClient,
+        client: "Composio",
         field_inputs: t.Dict,
         redirect_url: t.Optional[str] = None,
         entity_id: t.Optional[str] = None,
@@ -116,7 +119,7 @@ class ConnectionRequestModel(BaseModel):
 
     def wait_until_active(
         self,
-        client: BaseClient,
+        client: "Composio",
         timeout=60,
     ) -> "ConnectedAccountModel":
         start_time = time.time()
@@ -508,16 +511,16 @@ class TriggerSubscription(logging.WithLogger):
     _connection: PusherConnection
     _alive: bool
 
-    def __init__(self) -> None:
+    def __init__(self, client: "Composio") -> None:
         """Initialize subscription object."""
         logging.WithLogger.__init__(self)
+        self.client = client
         self._alive = False
         self._chunks: t.Dict[str, t.Dict[int, str]] = {}
         self._callbacks: t.List[t.Tuple[TriggerCallback, _TriggerEventFilters]] = []
 
-    @staticmethod
-    def validate_filters(filters: _TriggerEventFilters):
-        docs_link_msg = "\n\nRead more here: https://docs.composio.dev/introduction/intro/quickstart_3"
+    def validate_filters(self, filters: _TriggerEventFilters):
+        docs_link_msg = "\nRead more here: https://docs.composio.dev/introduction/intro/quickstart_3"
         if not isinstance(filters, dict):
             raise ComposioSDKError(
                 "Expected filters to be a dictionary" + docs_link_msg
@@ -549,17 +552,30 @@ class TriggerSubscription(logging.WithLogger):
                 # Our enums are in uppercase but we accept lowercase ones too.
                 value = value.upper()
 
+                # Ensure the app exists
                 app_names = list(App.iter())
-                if value in app_names:
-                    continue
+                if value not in app_names:
+                    error_msg = f"App {value!r} does not exist."
+                    possible_values = difflib.get_close_matches(value, app_names, n=1)
+                    if possible_values:
+                        (possible_value,) = possible_values
+                        error_msg += f" Did you mean {possible_value!r}?"
 
-                error_msg = f"App {value!r} does not exist."
-                possible_values = difflib.get_close_matches(value, app_names, n=1)
-                if possible_values:
-                    (possible_value,) = possible_values
-                    error_msg += f" Did you mean {possible_value!r}?"
+                    raise ComposioSDKError(error_msg + docs_link_msg)
 
-                raise ComposioSDKError(error_msg + docs_link_msg)
+                # Ensure at least one of the app's triggers are enabled on the account.
+                active_triggers = [
+                    trigger.triggerName for trigger in self.client.active_triggers.get()
+                ]
+                apps_for_triggers = {
+                    Trigger(trigger).app.upper() for trigger in active_triggers
+                }
+                if value not in apps_for_triggers:
+                    error_msg = (
+                        f"App {value!r} has no triggers enabled on your account.\n"
+                        "Find the possible triggers by running `composio triggers`."
+                    )
+                    raise ComposioSDKError(error_msg + docs_link_msg)
 
             # Validate trigger name
             if filter == "trigger_name":
@@ -574,17 +590,29 @@ class TriggerSubscription(logging.WithLogger):
                 # Our enums are in uppercase but we accept lowercase ones too.
                 value = value.upper()
 
+                # Ensure the trigger exists
                 trigger_names = list(Trigger.iter())
-                if value in trigger_names:
-                    continue
+                if value not in trigger_names:
+                    error_msg = f"Trigger {value!r} does not exist."
+                    possible_values = difflib.get_close_matches(
+                        value, trigger_names, n=1
+                    )
+                    if possible_values:
+                        (possible_value,) = possible_values
+                        error_msg += f" Did you mean {possible_value!r}?"
 
-                error_msg = f"Trigger {value!r} does not exist."
-                possible_values = difflib.get_close_matches(value, trigger_names, n=1)
-                if possible_values:
-                    (possible_value,) = possible_values
-                    error_msg += f" Did you mean {possible_value!r}?"
+                    raise ComposioSDKError(error_msg + docs_link_msg)
 
-                raise ComposioSDKError(error_msg + docs_link_msg)
+                # Ensure the trigger is added on your account
+                active_triggers = [
+                    trigger.triggerName for trigger in self.client.active_triggers.get()
+                ]
+                if value not in active_triggers:
+                    error_msg = (
+                        f"Trigger {value!r} is not active on your account.\nEnable"
+                        f" the trigger by doing `composio triggers enable {value}`."
+                    )
+                    raise ComposioSDKError(error_msg + docs_link_msg)
 
     def callback(
         self,
@@ -717,13 +745,14 @@ class TriggerSubscription(logging.WithLogger):
 class _PusherClient(logging.WithLogger):
     """Pusher client for Composio SDK."""
 
-    def __init__(self, client_id: str, base_url: str, api_key: str) -> None:
+    def __init__(self, client_id: str, client: "Composio") -> None:
         """Initialize pusher client."""
         super().__init__()
         self.client_id = client_id
-        self.base_url = base_url
-        self.api_key = api_key
-        self.subscription = TriggerSubscription()
+        self.client = client
+        self.api_key = self.client.api_key
+        self.base_url = self.client.http.base_url
+        self.subscription = TriggerSubscription(client=self.client)
 
     def _get_connection_handler(
         self,
@@ -817,7 +846,7 @@ class Triggers(Collection[TriggerModel]):
     endpoint = v1.triggers
     callbacks: CallbackCollection
 
-    def __init__(self, client: BaseClient) -> None:
+    def __init__(self, client: "Composio") -> None:
         """Initialize triggers collections."""
         super().__init__(client)
         self.callbacks = CallbackCollection(
@@ -891,8 +920,7 @@ class Triggers(Collection[TriggerModel]):
 
         pusher = _PusherClient(
             client_id=client_id,
-            base_url=self.client.http.base_url,
-            api_key=self.client.api_key,
+            client=self.client,
         )
         return pusher.connect(
             timeout=timeout,

--- a/python/composio/client/collections.py
+++ b/python/composio/client/collections.py
@@ -609,7 +609,7 @@ class TriggerSubscription(logging.WithLogger):
                 ]
                 if value not in active_triggers:
                     error_msg = (
-                        f"Trigger {value!r} is not active on your account.\nEnable"
+                        f"Trigger {value!r} is not enabled on your account.\nEnable"
                         f" the trigger by doing `composio triggers enable {value}`."
                     )
                     raise ComposioSDKError(error_msg + docs_link_msg)

--- a/python/tests/test_client/test_collections.py
+++ b/python/tests/test_client/test_collections.py
@@ -193,7 +193,7 @@ def test_trigger_filter_errors_not_enabled(monkeypatch: pytest.MonkeyPatch) -> N
             id=name, connectionId=name, triggerName=name, triggerConfig={}
         )
 
-    # Ensure trigger is active on the account
+    # Ensure trigger is enabled on the account
     monkeypatch.setattr(
         client.active_triggers,
         "get",
@@ -207,10 +207,10 @@ def test_trigger_filter_errors_not_enabled(monkeypatch: pytest.MonkeyPatch) -> N
 
     assert (
         exc.value.message
-        == "Trigger 'GMAIL_NEW_GMAIL_MESSAGE' is not active on your account.\nEnable the trigger by doing `composio triggers enable GMAIL_NEW_GMAIL_MESSAGE`.\nRead more here: https://docs.composio.dev/introduction/intro/quickstart_3"
+        == "Trigger 'GMAIL_NEW_GMAIL_MESSAGE' is not enabled on your account.\nEnable the trigger by doing `composio triggers enable GMAIL_NEW_GMAIL_MESSAGE`.\nRead more here: https://docs.composio.dev/introduction/intro/quickstart_3"
     )
 
-    # Ensure the app being enabled has at least one active trigger on the account
+    # Ensure the app being enabled has at least one enabled trigger on the account
     monkeypatch.setattr(
         client.active_triggers,
         "get",

--- a/python/tests/test_client/test_collections.py
+++ b/python/tests/test_client/test_collections.py
@@ -3,17 +3,15 @@ Test collections module.
 """
 
 from logging import DEBUG
-import random
 from unittest import mock
 
-from composio.client import Composio
 import pytest
 
+from composio.client import Composio
 from composio.client.collections import (
-    AppModel,
+    ActiveTriggerModel,
     Trigger,
     TriggerEventData,
-    ActiveTriggerModel,
     TriggerSubscription,
     to_trigger_names,
 )
@@ -207,7 +205,8 @@ def test_trigger_filter_errors_not_enabled(monkeypatch: pytest.MonkeyPatch) -> N
 
     assert (
         exc.value.message
-        == "Trigger 'GMAIL_NEW_GMAIL_MESSAGE' is not enabled on your account.\nEnable the trigger by doing `composio triggers enable GMAIL_NEW_GMAIL_MESSAGE`.\nRead more here: https://docs.composio.dev/introduction/intro/quickstart_3"
+        == "Trigger 'GMAIL_NEW_GMAIL_MESSAGE' is not enabled on your account.\n"
+        "Enable the trigger by doing `composio triggers enable GMAIL_NEW_GMAIL_MESSAGE`.\nRead more here: https://docs.composio.dev/introduction/intro/quickstart_3"
     )
 
     # Ensure the app being enabled has at least one enabled trigger on the account


### PR DESCRIPTION
Shows error messages for these two cases:

- If you try to add a trigger listener for a trigger that's not active on your account:
  ```console
  Trigger 'GMAIL_NEW_GMAIL_MESSAGE' is not enabled on your account.
  Enable the trigger by doing `composio triggers enable GMAIL_NEW_GMAIL_MESSAGE`.
  Read more here: https://docs.composio.dev/introduction/intro/quickstart_3
  ```

- If you try to add a trigger listener for an app which has NO active triggers on your account:
   ```console
  App 'GMAIL' has no triggers enabled on your account.
  Find the possible triggers by running `composio triggers`.
  Read more here: https://docs.composio.dev/introduction/intro/quickstart_3
  ```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds user-friendly error messages for disabled triggers and apps with no enabled triggers in `TriggerSubscription`, with corresponding tests.
> 
>   - **Behavior**:
>     - Adds error messages in `TriggerSubscription.validate_filters()` for when a trigger is not enabled or an app has no enabled triggers on the account.
>     - Provides guidance on enabling triggers and finding possible triggers.
>   - **Tests**:
>     - Adds `test_trigger_filter_errors_not_enabled()` in `test_collections.py` to verify new error messages for disabled triggers and apps with no enabled triggers.
>   - **Misc**:
>     - Minor change in `triggers.py` example command from `ATTIO_LIST_TASKS` to `SLACK_RECEIVE_MESSAGE`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 7108e98961694c39f488e8f81720809f337f1842. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->