### PR TITLE
chore: remove unused AsyncHttpClient

### DIFF
--- a/python/composio/client/http.py
+++ b/python/composio/client/http.py
@@ -3,9 +3,7 @@ Http client implementation for Composio SDK
 """
 
 import typing as t
-from asyncio import AbstractEventLoop
 
-from aiohttp import ClientSession as AsyncSession
 from requests import ReadTimeout
 from requests import Session as SyncSession
 

--- a/python/composio/client/http.py
+++ b/python/composio/client/http.py
@@ -18,57 +18,6 @@ SOURCE_HEADER = "python_sdk"
 DEFAULT_REQUEST_TIMEOUT = 60.0
 
 
-class AsyncHttpClient(AsyncSession, logging.WithLogger):
-    """Async HTTP client for Composio"""
-
-    def __init__(
-        self,
-        base_url: str,
-        api_key: str,
-        runtime: t.Optional[str] = None,
-        loop: t.Optional[AbstractEventLoop] = None,
-        timeout: t.Optional[float] = None,
-    ) -> None:
-        """
-        Initialize async client channel for Composio API
-
-        :param base_url: Base URL for Composio API
-        :param api_key: API key for Composio API
-        :param runtime: Runtime specifier
-        :param timeout: Request timeout
-        :param loop: Event for execution requests
-        """
-        AsyncSession.__init__(
-            self,
-            loop=loop,
-            headers={
-                "x-api-key": api_key,
-                "x-source": SOURCE_HEADER,
-                "x-runtime": runtime or DEFAULT_RUNTIME,
-            },
-        )
-        logging.WithLogger.__init__(self)
-        self.base_url = base_url
-        self._request_timeout = timeout or DEFAULT_REQUEST_TIMEOUT
-
-    def _wrap(self, method: t.Callable) -> t.Callable:
-        """Wrap http request."""
-
-        def request(url: str, **kwargs: t.Any) -> t.Any:
-            """Perform HTTP request."""
-            self._logger.debug(
-                f"{method.__name__.upper()} {self.base_url}{url} - {kwargs}"
-            )
-            return method(url=f"{self.base_url}{url}", **kwargs)
-
-        return request
-
-    def __getattribute__(self, name: str) -> t.Any:
-        if name in ("get", "post", "put", "delete", "patch"):
-            return self._wrap(super().__getattribute__(name))
-        return super().__getattribute__(name)
-
-
 class HttpClient(SyncSession, logging.WithLogger):
     """Async HTTP client for Composio"""
 

--- a/python/composio/client/http.py
+++ b/python/composio/client/http.py
@@ -17,7 +17,7 @@ DEFAULT_REQUEST_TIMEOUT = 60.0
 
 
 class HttpClient(SyncSession, logging.WithLogger):
-    """Async HTTP client for Composio"""
+    """HTTP client for Composio"""
 
     def __init__(
         self,


### PR DESCRIPTION
Also gets rid of this Deprecation Warning:

```
../lib/python3.12/site-packages/composio/client/http.py:21
  ../lib/python3.12/site-packages/composio/client/http.py:21: DeprecationWarning: Inheritance class AsyncHttpClient from ClientSession is discouraged
    class AsyncHttpClient(AsyncSession, logging.WithLogger):
```
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove unused `AsyncHttpClient` class from `http.py` to resolve deprecation warning.
> 
>   - **Removal**:
>     - Remove `AsyncHttpClient` class from `http.py`.
>   - **Warnings**:
>     - Resolves deprecation warning related to `AsyncHttpClient` inheriting from `ClientSession`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for be1a2c4fab8e24cc4863a7deb229d7070411ca7b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->