### PR TITLE
chore: set `continue-on-error` to false

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -68,7 +68,7 @@ jobs:
     defaults:
       run:
         working-directory: ./python
-    continue-on-error: True
+    continue-on-error: False
     needs:
       - lock_check
     runs-on: ${{ matrix.os }}
@@ -110,7 +110,7 @@ jobs:
     defaults:
       run:
         working-directory: ./python
-    continue-on-error: True
+    continue-on-error: False
     needs:
       - lock_check
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Right now, even if our test step gets cancelled because of a different job failing, it can still end up being marked as passed.

<img width="500" alt="Screenshot 2024-11-21 at 1 37 48 PM" src="https://github.com/user-attachments/assets/06434df6-88fe-4e6f-a420-cc704b8d46b4">

This change fixes that.

### From the docs:

- `continue-on-error`: Prevents a job from failing when a step fails.

We certainly don't want this.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set `continue-on-error: False` in `linter_checks` and `test` jobs to ensure failure on step errors.
> 
>   - **Behavior**:
>     - Set `continue-on-error: False` in `linter_checks` and `test` jobs in `.github/workflows/common.yml` to ensure jobs fail on step failure.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 52ecbdc291911485f98e19d935fc8606179c3e53. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->