### PR TITLE
Add `execute_request` method

### DIFF
--- a/python/composio/client/collections.py
+++ b/python/composio/client/collections.py
@@ -1239,6 +1239,32 @@ class Actions(Collection[ActionModel]):
             )
         ).json()
 
+    def request(
+        self,
+        connection_id: str,
+        endpoint: str,
+        method: str,
+        body: t.Optional[t.Dict] = None,
+        parameters: t.Optional[t.List[CustomAuthParameter]] = None,
+    ) -> t.Dict:
+        return self.client.http.post(
+            url=str(self.endpoint / "proxy"),
+            json={
+                "connectedAccountId": connection_id,
+                "body": body,
+                "method": method.upper(),
+                "endpoint": endpoint,
+                "parameters": [
+                    {
+                        "in": param["in_"],
+                        "name": param["name"],
+                        "value": param["value"],
+                    }
+                    for param in parameters or []
+                ],
+            },
+        ).json()
+
     @staticmethod
     def _serialize_auth(auth: t.Optional[CustomAuthObject]) -> t.Optional[t.Dict]:
         if auth is None:

--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -786,9 +786,9 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
         self,
         endpoint: str,
         method: str,
+        *,
         body: t.Optional[t.Dict] = None,
         parameters: t.Optional[t.List[CustomAuthParameter]] = None,
-        *,
         connection_id: t.Optional[str] = None,
     ) -> t.Dict:
         pass
@@ -798,9 +798,9 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
         self,
         endpoint: str,
         method: str,
+        *,
         body: t.Optional[t.Dict] = None,
         parameters: t.Optional[t.List[CustomAuthParameter]] = None,
-        *,
         app: t.Optional[AppType] = None,
     ) -> t.Dict:
         pass
@@ -809,9 +809,9 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
         self,
         endpoint: str,
         method: str,
+        *,
         body: t.Optional[t.Dict] = None,
         parameters: t.Optional[t.List[CustomAuthParameter]] = None,
-        *,
         connection_id: t.Optional[str] = None,
         app: t.Optional[AppType] = None,
     ) -> t.Dict:

--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -815,6 +815,19 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
         connection_id: t.Optional[str] = None,
         app: t.Optional[AppType] = None,
     ) -> t.Dict:
+        """
+        Execute a proxy request to a connected account.
+
+        :param endpoint: API endpoint to call
+        :param method: HTTP method to use (GET, POST, etc.)
+        :param body: Request body data
+        :param parameters: Additional auth parameters
+        :param connection_id: ID of the connected account
+        :param app: App type to use for connection lookup
+
+        :returns: Response from the proxy request
+        :raises: ComposioSDKError: If neither connection_id nor app is provided
+        """
         if app is not None and connection_id is None:
             connection_id = (
                 self.get_entity(id=self.entity_id).get_connection(app=app).id
@@ -825,13 +838,18 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
                 "Please provide connection id or app name to execute a request"
             )
 
-        return self.client.actions.request(
+        self.logger.info(
+            f"Executing request to {endpoint} with method={method}, connection_id={connection_id}"
+        )
+        response = self.client.actions.request(
             connection_id=connection_id,
             body=body,
             method=method,
             endpoint=endpoint,
             parameters=parameters,
         )
+        self.logger.info(f"Got {response=}")
+        return response
 
     def validate_tools(
         self,

--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -781,6 +781,58 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
         self.logger.info(f"Got {response=} from {action=} with {params=}")
         return response
 
+    @t.overload
+    def execute_request(
+        self,
+        endpoint: str,
+        method: str,
+        body: t.Optional[t.Dict] = None,
+        parameters: t.Optional[t.List[CustomAuthParameter]] = None,
+        *,
+        connection_id: t.Optional[str] = None,
+    ) -> t.Dict:
+        pass
+
+    @t.overload
+    def execute_request(
+        self,
+        endpoint: str,
+        method: str,
+        body: t.Optional[t.Dict] = None,
+        parameters: t.Optional[t.List[CustomAuthParameter]] = None,
+        *,
+        app: t.Optional[AppType] = None,
+    ) -> t.Dict:
+        pass
+
+    def execute_request(
+        self,
+        endpoint: str,
+        method: str,
+        body: t.Optional[t.Dict] = None,
+        parameters: t.Optional[t.List[CustomAuthParameter]] = None,
+        *,
+        connection_id: t.Optional[str] = None,
+        app: t.Optional[AppType] = None,
+    ) -> t.Dict:
+        if app is not None and connection_id is None:
+            connection_id = (
+                self.get_entity(id=self.entity_id).get_connection(app=app).id
+            )
+
+        if connection_id is None:
+            raise ComposioSDKError(
+                "Please provide connection id or app name to execute a request"
+            )
+
+        return self.client.actions.request(
+            connection_id=connection_id,
+            body=body,
+            method=method,
+            endpoint=endpoint,
+            parameters=parameters,
+        )
+
     def validate_tools(
         self,
         apps: t.Optional[t.Sequence[AppType]] = None,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `execute_request` method to `ComposioToolSet` for executing HTTP requests with specified parameters.
> 
>   - **New Method**:
>     - Adds `execute_request` method to `ComposioToolSet` in `toolset.py`.
>     - Supports executing HTTP requests with `endpoint`, `method`, `body`, `parameters`, and either `connection_id` or `app`.
>     - Raises `ComposioSDKError` if neither `connection_id` nor `app` is provided.
>   - **Integration**:
>     - Utilizes `request` method from `collections.py` to perform HTTP requests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 2a89e0cd92ffed12f7137afa53b7305fe65d08dd. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->