### PR TITLE
chore: increase timeout limit to 20 minutes

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -76,7 +76,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.9", "3.10", "3.11"]
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Prevents timeouts for `tests` group.