### PR TITLE
fix: avoid duplicate input in basic auth

### DIFF
--- a/python/composio/cli/add.py
+++ b/python/composio/cli/add.py
@@ -324,12 +324,13 @@ def _handle_basic_auth(
     labels: t.Optional[t.List] = None,
 ) -> None:
     """Handle basic auth."""
+    auth_config = _collect_input_fields(
+        fields=auth_scheme.fields,
+    )
     connection = entity.initiate_connection(
         app_name=app_name.lower(),
         auth_mode=auth_mode,
-        auth_config=_collect_input_fields(
-            fields=auth_scheme.fields,
-        ),
+        auth_config=auth_config,
         integration=integration,
         use_composio_auth=False,
         force_new_integration=True,
@@ -337,9 +338,7 @@ def _handle_basic_auth(
     )
     connection.save_user_access_data(
         client=client,
-        field_inputs=_collect_input_fields(
-            fields=auth_scheme.fields,
-        ),
+        field_inputs=auth_config,
         entity_id=entity.id,
     )
     click.echo(


### PR DESCRIPTION
`_collect_input_fields` takes user input, we should only be calling it once.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix duplicate input collection in `_handle_basic_auth` by reusing `auth_config` in `add.py`.
> 
>   - **Behavior**:
>     - In `_handle_basic_auth` in `add.py`, `_collect_input_fields` is now called once and its result is reused for `auth_config` and `field_inputs`.
>   - **Functions**:
>     - `_handle_basic_auth` now stores the result of `_collect_input_fields` in `auth_config` and reuses it, preventing duplicate input collection.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for db48d787ceefb98abd942f512f380ed0a61fa44b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->