### PR TITLE
Add support for injecting request executor in the runtime tool

### DIFF
--- a/python/composio/tools/env/base.py
+++ b/python/composio/tools/env/base.py
@@ -319,6 +319,7 @@ class RemoteWorkspace(Workspace):
         if action.is_runtime:
             self._upload(action=action)
 
+        _ = metadata.pop("_toolset", None)
         request = self._request(
             method="post",
             endpoint=f"/actions/execute/{action.slug}",

--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -466,6 +466,8 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
         entity_id: t.Optional[str] = None,
     ) -> t.Dict:
         """Execute a local action."""
+        metadata = metadata or {}
+        metadata["_toolset"] = self
         response = self.workspace.execute_action(
             action=action,
             request_data=params,

--- a/python/swe/tests/test_benchmark.py
+++ b/python/swe/tests/test_benchmark.py
@@ -32,9 +32,7 @@ class TestIntegration:
         client = docker.from_env()
         dockerfile_path = os.path.join(os.path.dirname(__file__), "test_docker")
         logger.info(f"Building Docker image from path: {dockerfile_path}")
-        image, build_logs = client.images.build(
-            path=dockerfile_path, tag=cls.image_name, rm=True
-        )
+        client.images.build(path=dockerfile_path, tag=cls.image_name, rm=True)
         logger.info("Docker image built successfully.")
 
     def test_setup_workspace(self):

--- a/python/swe/tests/test_docker/Dockerfile
+++ b/python/swe/tests/test_docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM composio/composio:latest
 
 # Install dependencies
-RUN apt install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
+RUN apt update && apt install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
     libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
     xz-utils tk-dev libffi-dev liblzma-dev
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for injecting a request executor in the runtime tool by modifying `runtime.py` and `toolset.py`.
> 
>   - **Behavior**:
>     - Add `execute_request` argument in `_build_executable_from_args()` in `runtime.py` to inject request executor.
>     - Modify `execute_action()` in `toolset.py` to include toolset instance in metadata for request execution.
>   - **Functions**:
>     - Add `execute_request` function in `execute()` in `runtime.py` to handle endpoint, method, body, and parameters.
>   - **Misc**:
>     - Import `CustomAuthParameter` in `runtime.py` for request execution.
>     - Remove unused variable `build_logs` in `test_benchmark.py`.
>     - Add `apt update` before installing dependencies in `Dockerfile`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 3b8abbfa006aa13b399ad32fd61f63bf8ce169b6. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->