### PR TITLE
fix: use newer pnpm in ci and always respect lockfile

### DIFF
--- a/.github/workflows/release_js_sdk.yml
+++ b/.github/workflows/release_js_sdk.yml
@@ -26,9 +26,9 @@ jobs:
         node-version: '20'
         registry-url: 'https://registry.npmjs.org'
     - name: Install dependencies
-      run: npm install -g pnpm@8.15.7
+      run: npm install -g pnpm
     - name: Install packages in js folder
-      run: pnpm install
+      run: pnpm install --frozen-lockfile
 
     - name: Set publishing config
       run: pnpm config set '//registry.npmjs.org/:_authToken' "${NODE_AUTH_TOKEN}"

--- a/.github/workflows/run_js_test.yml
+++ b/.github/workflows/run_js_test.yml
@@ -26,9 +26,9 @@ jobs:
       with:
         node-version: '20'
     - name: Install dependencies
-      run: npm install -g pnpm@8.15.7
+      run: npm install -g pnpm
     - name: Install packages in js folder
-      run: cd js && pnpm install
+      run: cd js && pnpm install --frozen-lockfile
     - name: pnpm build
       run: cd js && pnpm build
     - name: run test


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update CI workflows to use the latest `pnpm` and enforce lockfile consistency with `--frozen-lockfile`.
> 
>   - **CI Workflows**:
>     - In `release_js_sdk.yml` and `run_js_test.yml`, update `pnpm` installation to use the latest version instead of a specific version (`8.15.7`).
>     - Add `--frozen-lockfile` flag to `pnpm install` commands to ensure lockfile consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for a4e77e39b83c826f9500b70ca72fa63a0dc38cb4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->