### PR TITLE
Add TTL based caching to `_cache_from_remote`

### DIFF
--- a/python/composio/client/enums/base.py
+++ b/python/composio/client/enums/base.py
@@ -8,6 +8,7 @@ import typing as t
 import warnings
 from pathlib import Path
 
+import cachetools.func
 import typing_extensions as te
 
 from composio.constants import LOCAL_CACHE_DIRECTORY
@@ -224,6 +225,7 @@ class _AnnotatedEnum(t.Generic[EntityType]):
 
         return None
 
+    @cachetools.func.ttl_cache(maxsize=1, ttl=600)  # 10 minutes
     def _cache_from_remote(self) -> t.Optional[EntityType]:
         if NO_REMOTE_ENUM_FETCHING:
             raise ComposioSDKError(

--- a/python/setup.py
+++ b/python/setup.py
@@ -43,6 +43,8 @@ core_requirements = [
     "jsonref>=1.1.0",
     "inflection>=0.5.1",
     "semver>=2.13.0",
+    "cachetools>=5.5.0",
+    "types-cachetools>=5.5.0",
     # CLI dependencies
     "click",
     "rich>=13.7.1,<14",


### PR DESCRIPTION
This ensures we don't bombard the `_cache_from_remote` API too much.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add TTL-based caching to `_cache_from_remote()` in `base.py` using `cachetools` to reduce API calls.
> 
>   - **Caching**:
>     - Add TTL-based caching to `_cache_from_remote()` in `base.py` using `cachetools.func.ttl_cache` with a 10-minute expiration.
>   - **Dependencies**:
>     - Add `cachetools>=5.5.0` and `types-cachetools>=5.5.0` to `setup.py` dependencies.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 0ce43ccc9e2f4407e110b75d01b0b5dcad770780. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->