### PR TITLE
fix: validate `connected_account_params` in `initiate_connection`

### DIFF
--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -1433,10 +1433,14 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
                 integration_id = integration.id
 
         connected_account_params = connected_account_params or {}
-        expected_params = self.get_expected_params_for_user(auth_scheme=auth_scheme, integration_id=integration_id)["expected_params"]
+        expected_params = self.get_expected_params_for_user(
+            auth_scheme=auth_scheme, integration_id=integration_id
+        )["expected_params"]
         required_params = [param for param in expected_params if param.required]
         unavailable_params = [
-            param.name for param in required_params if param.name not in connected_account_params
+            param.name
+            for param in required_params
+            if param.name not in connected_account_params
         ]
         if unavailable_params:
             raise ComposioSDKError(

--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -1432,6 +1432,22 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
                 )
                 integration_id = integration.id
 
+        connected_account_params = connected_account_params or {}
+        expected_params = self.get_expected_params_for_user(auth_scheme=auth_scheme, integration_id=integration_id)["expected_params"]
+        required_params = [param for param in expected_params if param.required]
+        unavailable_params = [
+            param.name for param in required_params if param.name not in connected_account_params
+        ]
+        if unavailable_params:
+            raise ComposioSDKError(
+                f"Expected 'connected_account_params' to provide these params: {unavailable_params}"
+            )
+
+        # Populate defaults in the connected_account_params
+        for param in expected_params:
+            if param.default is not None and param.name not in connected_account_params:
+                connected_account_params[param.name] = param.default
+
         return self.client.connected_accounts.initiate(
             integration_id=integration_id,
             entity_id=entity_id or self.entity_id,
@@ -1457,11 +1473,6 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
         auth_fields = self.fetch_expected_integration_params(
             app=app_data, auth_scheme=auth_scheme
         )
-        # Populate defaults in the auth_config
-        for field in auth_fields:
-            if field.default is not None and field.name not in auth_config:
-                auth_config[field.name] = field.default
-
         required_fields = [field for field in auth_fields if field.required]
         unavailable_fields = [
             field.name for field in required_fields if field.name not in auth_config
@@ -1470,6 +1481,11 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
             raise ComposioSDKError(
                 f"Expected 'auth_config' to provide these fields: {unavailable_fields}"
             ) from None
+
+        # Populate defaults in the auth_config
+        for field in auth_fields:
+            if field.default is not None and field.name not in auth_config:
+                auth_config[field.name] = field.default
 
         return auth_config, False
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance `initiate_connection` by validating and populating defaults for `connected_account_params`, and refactor `_validate_auth_config` to populate defaults post-validation.
> 
>   - **Behavior**:
>     - Validate `connected_account_params` in `initiate_connection()` to ensure all required parameters are provided.
>     - Populate default values for missing parameters in `connected_account_params` in `initiate_connection()`.
>   - **Refactoring**:
>     - Move default population for `auth_config` in `_validate_auth_config()` to occur after validation of required fields.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for becaa08c7e23c96008d0c3a7469fdddd16ea9b0c. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->