### PR TITLE
chore: add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/python @angrybayblade @tushar-composio

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 /python @angrybayblade @tushar-composio
+/js @himanshu-dixit @plxity

--- a/python/tests/test_cli/test_add.py
+++ b/python/tests/test_cli/test_add.py
@@ -20,8 +20,7 @@ class TestComposioAdd(BaseCliTest):
 
     def test_add_github(self) -> None:
         """Test `composio add` with no-auth."""
-        self.run("add", "github", input="Y")
-
+        self.run("add", "github", input="n")
         self.assert_stdout_regex(
             match=re.compile(
                 "Do you want to replace the existing connection?|Adding integration..."


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `.github/CODEOWNERS` file and modify input in `test_add_github` test case.
> 
>   - **CODEOWNERS**:
>     - Adds `.github/CODEOWNERS` file.
>     - Specifies `@angrybayblade` and `@tushar-composio` as code owners for `/python` directory.
>     - Specifies `@himanshu-dixit` and `@plxity` as code owners for `/js` directory.
>   - **Tests**:
>     - Modifies `test_add_github` in `test_add.py` to change input from 'Y' to 'n'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 0bdc2211b077d1ee2b8cd72664e162148d6c566c. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->