### PR TITLE
fix: avoid returning unrelated enum type from `_cache_from_local`

### DIFF
--- a/python/composio/client/enums/base.py
+++ b/python/composio/client/enums/base.py
@@ -188,36 +188,39 @@ class _AnnotatedEnum(t.Generic[EntityType]):
 
         load_local_tools()
 
-        for gid, actions in action_registry.items():
-            if self._slug in actions:
-                action = actions[self._slug]
-                _model_cache[self._slug] = ActionData(
-                    name=action.name,
-                    app=action.tool,
-                    tags=action.tags(),
-                    no_auth=action.no_auth,
-                    is_local=gid in ("runtime", "local"),
-                    path=self._path / self._slug,
-                )
-                return _model_cache[self._slug]  # type: ignore
+        if self._model is ActionData:
+            for gid, actions in action_registry.items():
+                if self._slug in actions:
+                    action = actions[self._slug]
+                    _model_cache[self._slug] = ActionData(
+                        name=action.name,
+                        app=action.tool,
+                        tags=action.tags(),
+                        no_auth=action.no_auth,
+                        is_local=gid in ("runtime", "local"),
+                        path=self._path / self._slug,
+                    )
+                    return _model_cache[self._slug]  # type: ignore
 
-        for gid, tools in tool_registry.items():
-            if self._slug in tools:
-                _model_cache[self._slug] = AppData(
-                    name=tools[self._slug].name,
-                    is_local=gid in ("runtime", "local"),
-                    path=self._path / self._slug,
-                )
-                return _model_cache[self._slug]  # type: ignore
+        if self._model is AppData:
+            for gid, tools in tool_registry.items():
+                if self._slug in tools:
+                    _model_cache[self._slug] = AppData(
+                        name=tools[self._slug].name,
+                        is_local=gid in ("runtime", "local"),
+                        path=self._path / self._slug,
+                    )
+                    return _model_cache[self._slug]  # type: ignore
 
-        for gid, triggers in trigger_registry.items():
-            if self._slug in triggers:
-                _model_cache[self._slug] = TriggerData(
-                    name=triggers[self._slug].name,
-                    app=triggers[self._slug].tool,
-                    path=self._path / self._slug,
-                )
-                return _model_cache[self._slug]  # type: ignore
+        if self._model is TriggerData:
+            for gid, triggers in trigger_registry.items():
+                if self._slug in triggers:
+                    _model_cache[self._slug] = TriggerData(
+                        name=triggers[self._slug].name,
+                        app=triggers[self._slug].tool,
+                        path=self._path / self._slug,
+                    )
+                    return _model_cache[self._slug]  # type: ignore
 
         return None
 


### PR DESCRIPTION
If an `App` named `FOO` is already loaded in `sys.modules`, then if we try to do `Action("FOO")` or `Trigger("FOO")`, it will try to load that enum from cache, and return the `App` enum object instead.

This check avoids that error.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes bug in `_cache_from_local` in `base.py` to ensure correct enum type is returned by checking `self._model`.
> 
>   - **Behavior**:
>     - Fixes bug in `_cache_from_local` in `base.py` to prevent returning incorrect enum type when `App` is already loaded in `sys.modules`.
>     - Adds checks for `self._model` to ensure correct enum type (`ActionData`, `AppData`, `TriggerData`) is returned.
>   - **Misc**:
>     - No changes to external interfaces or additional functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for a134cc640e0f563b6f3c804d397a2a09388a43bc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->