### PR TITLE
Add checks for custom action type annotations

### DIFF
--- a/python/composio/tools/base/runtime.py
+++ b/python/composio/tools/base/runtime.py
@@ -273,6 +273,12 @@ def _build_executable_from_args(  # pylint: disable=too-many-statements
 ) -> t.Tuple[t.Callable, t.Type[BaseModel], t.Type[BaseModel], bool]:
     """Build execute action from function arguments."""
     argspec = inspect.getfullargspec(f)
+    missing_annot = set(argspec.args) - set(argspec.annotations)
+    if len(missing_annot) > 0:
+        raise InvalidRuntimeAction(
+            message=f"Following arguments are missing type annotations: {missing_annot}"
+        )
+
     defaults = dict(
         zip(
             reversed(argspec.annotations),
@@ -294,6 +300,7 @@ def _build_executable_from_args(  # pylint: disable=too-many-statements
     response_schema: t.Dict[str, t.Any] = {
         "__annotations__": {},
     }
+
     shell_argument = None
     auth_params = False
     request_executor = False

--- a/python/tests/test_tools/test_base/test_runtime.py
+++ b/python/tests/test_tools/test_base/test_runtime.py
@@ -1,5 +1,7 @@
 """Test runtime decorator."""
 
+import re
+
 import pytest
 import typing_extensions as te
 from pydantic import BaseModel, Field
@@ -151,3 +153,25 @@ def test_tool_namespace() -> None:
     assert len(actions) == 2
     assert square in actions
     assert inverse in actions
+
+
+def test_untyped_param() -> None:
+    """Test if error is raised if a param is missing type annotation."""
+    with pytest.raises(
+        InvalidRuntimeAction,
+        match=re.escape(
+            "Following arguments are missing type annotations: {'execute_request'}"
+        ),
+    ):
+
+        # pylint: disable=unused-argument
+        @action(toolname="github")
+        def list_prs(owner: str, repo: str, execute_request) -> list[str]:
+            """
+            List PRs for a repo
+
+            :param owner: Owner
+            :param repo: Repository
+            :return repositories: Repositories
+            """
+            return []


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a check for missing type annotations in `_build_executable_from_args` and a corresponding test in `test_runtime.py`.
> 
>   - **Behavior**:
>     - Adds a check in `_build_executable_from_args` in `runtime.py` to raise `InvalidRuntimeAction` if any function argument is missing a type annotation.
>   - **Tests**:
>     - Adds `test_untyped_param` in `test_runtime.py` to verify that `InvalidRuntimeAction` is raised for missing type annotations in function arguments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 435d9061a2ec377b9ad32ccf4a13c3828e331d4e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->