### PR TITLE
fix: failing js test

### DIFF
--- a/js/src/sdk/models/apps.spec.ts
+++ b/js/src/sdk/models/apps.spec.ts
@@ -52,7 +52,7 @@ describe("Apps class tests", () => {
         const OAUTH2_SCHEME = "OAUTH2";
         expect(inputFields.availableAuthSchemes).toContain(OAUTH2_SCHEME);
         expect(inputFields.authSchemes[OAUTH2_SCHEME].expected_from_user).toEqual(["client_id", "client_secret"]);
-        expect(inputFields.authSchemes[OAUTH2_SCHEME].optional_fields).toEqual(["scopes"]);
+        expect(inputFields.authSchemes[OAUTH2_SCHEME].optional_fields).toEqual(["oauth_redirect_uri", "scopes"]);
         expect(inputFields.authSchemes[OAUTH2_SCHEME].required_fields).toEqual(["shop"]);
     });
 
@@ -61,7 +61,7 @@ describe("Apps class tests", () => {
         const requiredParams = await apps.getRequiredParamsForAuthScheme("shopify", OAUTH2_SCHEME);
         expect(requiredParams).toEqual({
             required_fields: ["shop"],
-            optional_fields: ["scopes"],
+            optional_fields: ["oauth_redirect_uri", "scopes"],
             expected_from_user: ["client_id", "client_secret"]
         });
     });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix failing test in `apps.spec.ts` by including `oauth_redirect_uri` in OAUTH2 scheme's optional fields.
> 
>   - **Tests**:
>     - Update `apps.spec.ts` to include `oauth_redirect_uri` in `optional_fields` for OAUTH2 scheme in two test cases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 824eb054739ee5f45e63ab37f17e714394f88bd3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->