### PR TITLE
Added langgraph integration

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "composio-core",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "",
   "main": "lib/src/index.js",
   "scripts": {

--- a/js/src/frameworks/langchain.ts
+++ b/js/src/frameworks/langchain.ts
@@ -20,12 +20,13 @@ export class LangchainToolSet extends BaseComposioToolSet {
             baseUrl?: Optional<string>,
             entityId?: string,
             workspaceConfig?: WorkspaceConfig
+            runtime?: string
         }={}
     ) {
         super(
             config.apiKey || null,
             config.baseUrl || COMPOSIO_BASE_URL,
-            LangchainToolSet.FRAMEWORK_NAME,
+            config?.runtime || LangchainToolSet.FRAMEWORK_NAME,
             config.entityId || LangchainToolSet.DEFAULT_ENTITY_ID,
             config.workspaceConfig || Workspace.Host()
         );
@@ -48,7 +49,7 @@ export class LangchainToolSet extends BaseComposioToolSet {
 
         const parameters = jsonSchemaToModel(schema["parameters"]);
 
-        // @TODO: Add escriiption an othjer stuff here
+        // @TODO: Add escriiption an other stuff here
 
         return new DynamicStructuredTool({
             name: action,

--- a/js/src/frameworks/langgraph.spec.ts
+++ b/js/src/frameworks/langgraph.spec.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect, beforeAll } from "@jest/globals";
+import { z } from "zod";
+import { getTestConfig } from "../../config/getTestConfig";
+import { LanggraphToolSet } from "./langgraph";
+
+
+// Langgraph extens langchain class, all the properties are same
+describe("Apps class tests", () => {
+    it("getools", async () => {
+        let langgraphToolSet = new LanggraphToolSet({
+            apiKey: getTestConfig().COMPOSIO_API_KEY,
+            baseUrl: getTestConfig().BACKEND_HERMES_URL,
+        });
+        const tools = await langgraphToolSet.getTools({
+            apps: ["github"],
+        });
+        expect(tools).toBeInstanceOf(Array);
+    });
+})

--- a/js/src/frameworks/langgraph.spec.ts
+++ b/js/src/frameworks/langgraph.spec.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect, beforeAll } from "@jest/globals";
 import { z } from "zod";
 import { getTestConfig } from "../../config/getTestConfig";
-import { LanggraphToolSet } from "./langgraph";
+import { LangGraphToolSet } from "./langgraph";
 
 
-// Langgraph extens langchain class, all the properties are same
+// LangGraph extens langchain class, all the properties are same
 describe("Apps class tests", () => {
     it("getools", async () => {
-        let langgraphToolSet = new LanggraphToolSet({
+        let langgraphToolSet = new LangGraphToolSet({
             apiKey: getTestConfig().COMPOSIO_API_KEY,
             baseUrl: getTestConfig().BACKEND_HERMES_URL,
         });

--- a/js/src/frameworks/langgraph.ts
+++ b/js/src/frameworks/langgraph.ts
@@ -1,0 +1,32 @@
+import { LangchainToolSet as BaseComposioToolSet } from "./langchain";
+import { COMPOSIO_BASE_URL } from "../sdk/client/core/OpenAPI";
+import type { Optional } from "../sdk/types";
+import { WorkspaceConfig } from "../env/config";
+import { Workspace } from "../env";
+
+export class LanggraphToolSet extends BaseComposioToolSet {
+  /**
+   * Composio toolset for Langgraph framework.
+   *
+   */
+
+  static FRAMEWORK_NAME = "langgraph";
+  static DEFAULT_ENTITY_ID = "default";
+
+  constructor(
+    config: {
+      apiKey?: Optional<string>;
+      baseUrl?: Optional<string>;
+      entityId?: string;
+      workspaceConfig?: WorkspaceConfig;
+    } = {}
+  ) {
+    super({
+      apiKey: config.apiKey || null,
+      baseUrl: config.baseUrl || COMPOSIO_BASE_URL,
+      entityId: config.entityId || LanggraphToolSet.DEFAULT_ENTITY_ID,
+      workspaceConfig: config.workspaceConfig || Workspace.Host(),
+      runtime: LanggraphToolSet.FRAMEWORK_NAME,
+    });
+  }
+}

--- a/js/src/frameworks/langgraph.ts
+++ b/js/src/frameworks/langgraph.ts
@@ -4,13 +4,13 @@ import type { Optional } from "../sdk/types";
 import { WorkspaceConfig } from "../env/config";
 import { Workspace } from "../env";
 
-export class LanggraphToolSet extends BaseComposioToolSet {
+export class LangGraphToolSet extends BaseComposioToolSet {
   /**
    * Composio toolset for Langgraph framework.
    *
    */
 
-  static FRAMEWORK_NAME = "langgraph";
+  static FRAMEWORK_NAME = "langGraph";
   static DEFAULT_ENTITY_ID = "default";
 
   constructor(
@@ -24,9 +24,9 @@ export class LanggraphToolSet extends BaseComposioToolSet {
     super({
       apiKey: config.apiKey || null,
       baseUrl: config.baseUrl || COMPOSIO_BASE_URL,
-      entityId: config.entityId || LanggraphToolSet.DEFAULT_ENTITY_ID,
+      entityId: config.entityId || LangGraphToolSet.DEFAULT_ENTITY_ID,
       workspaceConfig: config.workspaceConfig || Workspace.Host(),
-      runtime: LanggraphToolSet.FRAMEWORK_NAME,
+      runtime: LangGraphToolSet.FRAMEWORK_NAME,
     });
   }
 }

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -3,8 +3,10 @@ import { LangchainToolSet } from "./frameworks/langchain";
 import { OpenAIToolSet } from "./frameworks/openai";
 import { CloudflareToolSet } from "./frameworks/cloudflare";
 import { VercelAIToolSet } from "./frameworks/vercel";
+import { LanggraphToolSet } from "./frameworks/langgraph";
 import { Workspace } from "./env/";
 
 const { APPS,ACTIONS } = require("./constants");
 
-export { Composio, LangchainToolSet, OpenAIToolSet, CloudflareToolSet, VercelAIToolSet, Workspace,APPS,ACTIONS };
+export { Composio, LangchainToolSet, OpenAIToolSet, CloudflareToolSet, VercelAIToolSet, Workspace ,APPS, ACTIONS, LanggraphToolSet };
+

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -3,10 +3,10 @@ import { LangchainToolSet } from "./frameworks/langchain";
 import { OpenAIToolSet } from "./frameworks/openai";
 import { CloudflareToolSet } from "./frameworks/cloudflare";
 import { VercelAIToolSet } from "./frameworks/vercel";
-import { LanggraphToolSet } from "./frameworks/langgraph";
+import { LangGraphToolSet } from "./frameworks/langgraph";
 import { Workspace } from "./env/";
 
 const { APPS,ACTIONS } = require("./constants");
 
-export { Composio, LangchainToolSet, OpenAIToolSet, CloudflareToolSet, VercelAIToolSet, Workspace ,APPS, ACTIONS, LanggraphToolSet };
+export { Composio, LangchainToolSet, OpenAIToolSet, CloudflareToolSet, VercelAIToolSet, Workspace ,APPS, ACTIONS, LangGraphToolSet };
 


### PR DESCRIPTION
Added langgraph support in composio
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Added `LangGraphToolSet` class extending `LangchainToolSet`, with tests and updated exports.
> 
>   - **Integration**:
>     - Added `LangGraphToolSet` class in `langgraph.ts`, extending `LangchainToolSet`.
>     - `LangGraphToolSet` uses `langGraph` as `runtime` and defaults to `COMPOSIO_BASE_URL` and `default` entity ID.
>   - **Testing**:
>     - Added `langgraph.spec.ts` to test `LangGraphToolSet` instantiation and `getTools()` method.
>   - **Exports**:
>     - Updated `index.ts` to export `LangGraphToolSet`.
>   - **Misc**:
>     - Updated version in `package.json` to `0.3.2`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 67732d46f4108a282ee086f3c1b3c0243b8e2b5c. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->