### PR TITLE
fix: Filter `&` from tag name

### DIFF
--- a/python/composio/utils/enums.py
+++ b/python/composio/utils/enums.py
@@ -2,7 +2,7 @@
 
 
 def get_enum_key(name: str) -> str:
-    characters_to_replace = [" ", "-", "/", "(", ")", "\\", ":", '"', "'", "."]
+    characters_to_replace = [" ", "-", "/", "(", ")", "\\", ":", '"', "'", ".", "&"]
     for char in characters_to_replace:
         name = name.replace(char, "_")
     return name.upper()

--- a/python/tests/test_tools/test_toolset.py
+++ b/python/tests/test_tools/test_toolset.py
@@ -52,13 +52,11 @@ def test_uninitialize_app() -> None:
     with pytest.raises(
         ComposioSDKError,
         match=(
-            "No connected account found for app `linear`; "
-            "Run `composio add linear` to fix this"
+            "No connected account found for app `attio`; "
+            "Run `composio add attio` to fix this"
         ),
     ):
-        ComposioToolSet().get_action_schemas(
-            actions=[Action.LINEAR_CREATE_LINEAR_ISSUE]
-        )
+        ComposioToolSet().get_action_schemas(actions=[Action.ATTIO_UPDATE_A_LIST])
 
 
 class TestValidateTools:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update `get_enum_key` in `enums.py` to replace `&` with `_` in tag names and modify an error message in `test_toolset.py`.
> 
>   - **Behavior**:
>     - Update `get_enum_key` in `enums.py` to replace `&` with `_` in tag names.
>   - **Tests**:
>     - Update error message in `test_uninitialize_app()` in `test_toolset.py` to use `attio` instead of `linear`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for e3f7265635eae4848919a47ec6abe0104eff3f78. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->