### PR TITLE
chore: unpin pydantic

### DIFF
--- a/python/composio/server/api.py
+++ b/python/composio/server/api.py
@@ -80,15 +80,15 @@ class ExecuteActionRequest(BaseModel):
         ...,
         description="Parameters for executing the request.",
     )
-    metadata: t.Dict = Field(
+    metadata: t.Optional[t.Dict] = Field(
         None,
         description="Metadata for executing action.",
     )
-    entity_id: str = Field(
+    entity_id: t.Optional[str] = Field(
         None,
         description="Entity ID associated with the account.",
     )
-    connected_account_id: str = Field(
+    connected_account_id: t.Optional[str] = Field(
         None,
         description="Connection ID to use for executing the action.",
     )

--- a/python/composio/tools/local/anthropic_computer_use/actions/bash.py
+++ b/python/composio/tools/local/anthropic_computer_use/actions/bash.py
@@ -16,7 +16,7 @@ class BashRequest(BaseModel):
         ...,
         description="Bash command to be executed.",
     )
-    session_id: str = Field(
+    session_id: t.Optional[str] = Field(
         default=None,
         description=(
             "ID of the bash session where this command will be executed. "

--- a/python/composio/tools/local/anthropic_computer_use/actions/text_editor.py
+++ b/python/composio/tools/local/anthropic_computer_use/actions/text_editor.py
@@ -47,7 +47,7 @@ class TextEditorResponse(BaseFileResponse):
     """Response from text editor operations."""
 
     output: str = Field(..., description="The output of the operation")
-    error: str = Field(default=None, description="Error message, if any")
+    error: t.Optional[str] = Field(default=None, description="Error message, if any")
 
 
 class TextEditor(LocalAction[TextEditorRequest, TextEditorResponse]):

--- a/python/composio/tools/local/clickup/actions/add_dependency.py
+++ b/python/composio/tools/local/clickup/actions/add_dependency.py
@@ -13,7 +13,7 @@ class AddDependencyRequest(BaseModel):
         alias="task_id",
         description="This is the task which is waiting on or blocking another task.",
     )
-    custom_task_ids: bool = Field(
+    custom_task_ids: t.Optional[bool] = Field(
         default=None,
         alias="custom_task_ids",
         description=(
@@ -21,7 +21,7 @@ class AddDependencyRequest(BaseModel):
             "be `true`. "
         ),
     )
-    team_id: int = Field(
+    team_id: t.Optional[int] = Field(
         default=None,
         alias="team_id",
         description=(
@@ -29,12 +29,12 @@ class AddDependencyRequest(BaseModel):
             "`custom_task_ids=true&team_id=123`. "
         ),
     )
-    depends_on: str = Field(
+    depends_on: t.Optional[str] = Field(
         default=None,
         alias="depends_on",
         description="Depends On",
     )
-    depedency_of: str = Field(
+    depedency_of: t.Optional[str] = Field(
         default=None,
         alias="depedency_of",
         description="Dependency Of",

--- a/python/composio/tools/local/clickup/actions/add_guest_to_folder.py
+++ b/python/composio/tools/local/clickup/actions/add_guest_to_folder.py
@@ -18,7 +18,7 @@ class AddGuestToFolderRequest(BaseModel):
         alias="guest_id",
         description="",
     )
-    include_shared: bool = Field(
+    include_shared: t.Optional[bool] = Field(
         default=None,
         alias="include_shared",
         description=(

--- a/python/composio/tools/local/clickup/actions/add_guest_to_list.py
+++ b/python/composio/tools/local/clickup/actions/add_guest_to_list.py
@@ -18,7 +18,7 @@ class AddGuestToListRequest(BaseModel):
         alias="guest_id",
         description="",
     )
-    include_shared: bool = Field(
+    include_shared: t.Optional[bool] = Field(
         default=None,
         alias="include_shared",
         description=(

--- a/python/composio/tools/local/clickup/actions/add_guest_to_task.py
+++ b/python/composio/tools/local/clickup/actions/add_guest_to_task.py
@@ -18,7 +18,7 @@ class AddGuestToTaskRequest(BaseModel):
         alias="guest_id",
         description="",
     )
-    include_shared: bool = Field(
+    include_shared: t.Optional[bool] = Field(
         default=None,
         alias="include_shared",
         description=(
@@ -26,7 +26,7 @@ class AddGuestToTaskRequest(BaseModel):
             "to `false`. By default this parameter is set to `true`. "
         ),
     )
-    custom_task_ids: bool = Field(
+    custom_task_ids: t.Optional[bool] = Field(
         default=None,
         alias="custom_task_ids",
         description=(
@@ -34,7 +34,7 @@ class AddGuestToTaskRequest(BaseModel):
             "be `true`. "
         ),
     )
-    team_id: int = Field(
+    team_id: t.Optional[int] = Field(
         default=None,
         alias="team_id",
         description=(

--- a/python/composio/tools/local/clickup/actions/add_tag_to_task.py
+++ b/python/composio/tools/local/clickup/actions/add_tag_to_task.py
@@ -18,7 +18,7 @@ class AddTagToTaskRequest(BaseModel):
         alias="tag_name",
         description="",
     )
-    custom_task_ids: bool = Field(
+    custom_task_ids: t.Optional[bool] = Field(
         default=None,
         alias="custom_task_ids",
         description=(
@@ -26,7 +26,7 @@ class AddTagToTaskRequest(BaseModel):
             "be `true`. "
         ),
     )
-    team_id: int = Field(
+    team_id: t.Optional[int] = Field(
         default=None,
         alias="team_id",
         description=(

--- a/python/composio/tools/local/clickup/actions/add_task_link.py
+++ b/python/composio/tools/local/clickup/actions/add_task_link.py
@@ -18,7 +18,7 @@ class AddTaskLinkRequest(BaseModel):
         alias="links_to",
         description="",
     )
-    custom_task_ids: bool = Field(
+    custom_task_ids: t.Optional[bool] = Field(
         default=None,
         alias="custom_task_ids",
         description=(
@@ -26,7 +26,7 @@ class AddTaskLinkRequest(BaseModel):
             "be `true`. "
         ),
     )
-    team_id: int = Field(
+    team_id: t.Optional[int] = Field(
         default=None,
         alias="team_id",
         description=(

--- a/python/composio/tools/local/clickup/actions/create_a_time_entry.py
+++ b/python/composio/tools/local/clickup/actions/create_a_time_entry.py
@@ -13,7 +13,7 @@ class CreateATimeEntryRequest(BaseModel):
         alias="team_Id",
         description="Team ID (Workspace)",
     )
-    custom_task_ids: bool = Field(
+    custom_task_ids: t.Optional[bool] = Field(
         default=None,
         alias="custom_task_ids",
         description=(
@@ -21,7 +21,7 @@ class CreateATimeEntryRequest(BaseModel):
             "be `true`. "
         ),
     )
-    team_id: int = Field(
+    team_id: t.Optional[int] = Field(
         default=None,
         alias="team_id",
         description=(
@@ -29,12 +29,12 @@ class CreateATimeEntryRequest(BaseModel):
             "`custom_task_ids=true&team_id=123`. "
         ),
     )
-    tags: t.List[dict] = Field(
+    tags: t.Optional[t.List[dict]] = Field(
         default=None,
         alias="tags",
         description="Users on the Business Plan and above can include a time tracking label.",
     )
-    description: str = Field(
+    description: t.Optional[str] = Field(
         default=None,
         alias="description",
         description="Description",
@@ -44,17 +44,17 @@ class CreateATimeEntryRequest(BaseModel):
         alias="start",
         description="Start",
     )
-    stop: int = Field(
+    stop: t.Optional[int] = Field(
         default=None,
         alias="stop",
         description="The `duration` parameter can be used instead of the `stop` parameter. ",
     )
-    end: int = Field(
+    end: t.Optional[int] = Field(
         default=None,
         alias="end",
         description="End",
     )
-    billable: bool = Field(
+    billable: t.Optional[bool] = Field(
         default=None,
         alias="billable",
         description="Billable",
@@ -67,7 +67,7 @@ class CreateATimeEntryRequest(BaseModel):
             "The `stop` parameter can be used instead of the `duration` parameter. "
         ),
     )
-    assignee: int = Field(
+    assignee: t.Optional[int] = Field(
         default=None,
         alias="assignee",
         description=(
@@ -75,7 +75,7 @@ class CreateATimeEntryRequest(BaseModel):
             "only include their own user id. "
         ),
     )
-    tid: str = Field(
+    tid: t.Optional[str] = Field(
         default=None,
         alias="tid",
         description="Tid",

--- a/python/composio/tools/local/clickup/actions/create_checklist.py
+++ b/python/composio/tools/local/clickup/actions/create_checklist.py
@@ -13,7 +13,7 @@ class CreateChecklistRequest(BaseModel):
         alias="task_id",
         description="",
     )
-    custom_task_ids: bool = Field(
+    custom_task_ids: t.Optional[bool] = Field(
         default=None,
         alias="custom_task_ids",
         description=(
@@ -21,7 +21,7 @@ class CreateChecklistRequest(BaseModel):
             "be `true`. "
         ),
     )
-    team_id: int = Field(
+    team_id: t.Optional[int] = Field(
         default=None,
         alias="team_id",
         description=(

--- a/python/composio/tools/local/clickup/actions/create_checklist_item.py
+++ b/python/composio/tools/local/clickup/actions/create_checklist_item.py
@@ -13,12 +13,12 @@ class CreateChecklistItemRequest(BaseModel):
         alias="checklist_id",
         description="b8a8-48d8-a0c6-b4200788a683 (uuid)",
     )
-    name: str = Field(
+    name: t.Optional[str] = Field(
         default=None,
         alias="name",
         description="Name",
     )
-    assignee: int = Field(
+    assignee: t.Optional[int] = Field(
         default=None,
         alias="assignee",
         description="Assignee",

--- a/python/composio/tools/local/clickup/actions/create_folderless_list.py
+++ b/python/composio/tools/local/clickup/actions/create_folderless_list.py
@@ -18,32 +18,32 @@ class CreateFolderlessListRequest(BaseModel):
         alias="name",
         description="Name",
     )
-    content: str = Field(
+    content: t.Optional[str] = Field(
         default=None,
         alias="content",
         description="Content",
     )
-    due_date: int = Field(
+    due_date: t.Optional[int] = Field(
         default=None,
         alias="due_date",
         description="Due Date",
     )
-    due_date_time: bool = Field(
+    due_date_time: t.Optional[bool] = Field(
         default=None,
         alias="due_date_time",
         description="Due Date Time",
     )
-    priority: int = Field(
+    priority: t.Optional[int] = Field(
         default=None,
         alias="priority",
         description="Priority",
     )
-    assignee: int = Field(
+    assignee: t.Optional[int] = Field(
         default=None,
         alias="assignee",
         description="Include a `user_id` to add a List owner.",
     )
-    status: str = Field(
+    status: t.Optional[str] = Field(
         default=None,
         alias="status",
         description=(

--- a/python/composio/tools/local/clickup/actions/create_list.py
+++ b/python/composio/tools/local/clickup/actions/create_list.py
@@ -18,32 +18,32 @@ class CreateListRequest(BaseModel):
         alias="name",
         description="Name",
     )
-    content: str = Field(
+    content: t.Optional[str] = Field(
         default=None,
         alias="content",
         description="Content",
     )
-    due_date: int = Field(
+    due_date: t.Optional[int] = Field(
         default=None,
         alias="due_date",
         description="Due Date",
     )
-    due_date_time: bool = Field(
+    due_date_time: t.Optional[bool] = Field(
         default=None,
         alias="due_date_time",
         description="Due Date Time",
     )
-    priority: int = Field(
+    priority: t.Optional[int] = Field(
         default=None,
         alias="priority",
         description="Priority",
     )
-    assignee: int = Field(
+    assignee: t.Optional[int] = Field(
         default=None,
         alias="assignee",
         description="Include a `user_id` to assign this List.",
     )
-    status: str = Field(
+    status: t.Optional[str] = Field(
         default=None,
         alias="status",
         description=(

--- a/python/composio/tools/local/clickup/actions/create_task.py
+++ b/python/composio/tools/local/clickup/actions/create_task.py
@@ -13,7 +13,7 @@ class CreateTaskRequest(BaseModel):
         alias="list_id",
         description="",
     )
-    custom_task_ids: bool = Field(
+    custom_task_ids: t.Optional[bool] = Field(
         default=None,
         alias="custom_task_ids",
         description=(
@@ -21,7 +21,7 @@ class CreateTaskRequest(BaseModel):
             "be `true`. "
         ),
     )
-    team_id: int = Field(
+    team_id: t.Optional[int] = Field(
         default=None,
         alias="team_id",
         description=(
@@ -29,12 +29,12 @@ class CreateTaskRequest(BaseModel):
             "`custom_task_ids=true&team_id=123`. "
         ),
     )
-    tags: t.List[str] = Field(
+    tags: t.Optional[t.List[str]] = Field(
         default=None,
         alias="tags",
         description="",
     )
-    description: str = Field(
+    description: t.Optional[str] = Field(
         default=None,
         alias="description",
         description="Description",
@@ -44,47 +44,47 @@ class CreateTaskRequest(BaseModel):
         alias="name",
         description="Name",
     )
-    assignees: t.List[int] = Field(
+    assignees: t.Optional[t.List[int]] = Field(
         default=None,
         alias="assignees",
         description="",
     )
-    status: str = Field(
+    status: t.Optional[str] = Field(
         default=None,
         alias="status",
         description="Status",
     )
-    priority: int = Field(
+    priority: t.Optional[int] = Field(
         default=None,
         alias="priority",
         description="Priority",
     )
-    due_date: int = Field(
+    due_date: t.Optional[int] = Field(
         default=None,
         alias="due_date",
         description="Due Date",
     )
-    due_date_time: bool = Field(
+    due_date_time: t.Optional[bool] = Field(
         default=None,
         alias="due_date_time",
         description="Due Date Time",
     )
-    time_estimate: int = Field(
+    time_estimate: t.Optional[int] = Field(
         default=None,
         alias="time_estimate",
         description="Time Estimate",
     )
-    start_date: int = Field(
+    start_date: t.Optional[int] = Field(
         default=None,
         alias="start_date",
         description="Start Date",
     )
-    start_date_time: bool = Field(
+    start_date_time: t.Optional[bool] = Field(
         default=None,
         alias="start_date_time",
         description="Start Date Time",
     )
-    notify_all: bool = Field(
+    notify_all: t.Optional[bool] = Field(
         default=None,
         alias="notify_all",
         description=(
@@ -92,7 +92,7 @@ class CreateTaskRequest(BaseModel):
             "the creator of the comment. "
         ),
     )
-    parent: str = Field(
+    parent: t.Optional[str] = Field(
         default=None,
         alias="parent",
         description=(
@@ -101,12 +101,12 @@ class CreateTaskRequest(BaseModel):
             "in the path parameter. "
         ),
     )
-    links_to: str = Field(
+    links_to: t.Optional[str] = Field(
         default=None,
         alias="links_to",
         description="Include a task ID to create a linked dependency with your new task.",
     )
-    check_required_custom_fields: bool = Field(
+    check_required_custom_fields: t.Optional[bool] = Field(
         default=None,
         alias="check_required_custom_fields",
         description=(
@@ -115,12 +115,12 @@ class CreateTaskRequest(BaseModel):
             "true`. "
         ),
     )
-    custom_fields: t.List[dict] = Field(
+    custom_fields: t.Optional[t.List[dict]] = Field(
         default=None,
         alias="custom_fields",
         description="[Filter by Custom Fields.](https://clickup.com/api)",
     )
-    custom_item_id: int = Field(
+    custom_item_id: t.Optional[int] = Field(
         default=None,
         alias="custom_item_id",
         description=(

--- a/python/composio/tools/local/clickup/actions/create_task_attachment.py
+++ b/python/composio/tools/local/clickup/actions/create_task_attachment.py
@@ -13,7 +13,7 @@ class CreateTaskAttachmentRequest(BaseModel):
         alias="task_id",
         description="",
     )
-    custom_task_ids: bool = Field(
+    custom_task_ids: t.Optional[bool] = Field(
         default=None,
         alias="custom_task_ids",
         description=(
@@ -21,7 +21,7 @@ class CreateTaskAttachmentRequest(BaseModel):
             "be `true`. "
         ),
     )
-    team_id: int = Field(
+    team_id: t.Optional[int] = Field(
         default=None,
         alias="team_id",
         description=(

--- a/python/composio/tools/local/clickup/actions/create_task_comment.py
+++ b/python/composio/tools/local/clickup/actions/create_task_comment.py
@@ -13,7 +13,7 @@ class CreateTaskCommentRequest(BaseModel):
         alias="task_id",
         description="",
     )
-    custom_task_ids: bool = Field(
+    custom_task_ids: t.Optional[bool] = Field(
         default=None,
         alias="custom_task_ids",
         description=(
@@ -21,7 +21,7 @@ class CreateTaskCommentRequest(BaseModel):
             "be `true`. "
         ),
     )
-    team_id: int = Field(
+    team_id: t.Optional[int] = Field(
         default=None,
         alias="team_id",
         description=(

--- a/python/composio/tools/local/clickup/actions/create_webhook.py
+++ b/python/composio/tools/local/clickup/actions/create_webhook.py
@@ -23,22 +23,22 @@ class CreateWebhookRequest(BaseModel):
         alias="events",
         description="Events",
     )
-    space_id: int = Field(
+    space_id: t.Optional[int] = Field(
         default=None,
         alias="space_id",
         description="Space Id",
     )
-    folder_id: int = Field(
+    folder_id: t.Optional[int] = Field(
         default=None,
         alias="folder_id",
         description="Folder Id",
     )
-    list_id: int = Field(
+    list_id: t.Optional[int] = Field(
         default=None,
         alias="list_id",
         description="List Id",
     )
-    task_id: str = Field(
+    task_id: t.Optional[str] = Field(
         default=None,
         alias="task_id",
         description="Task Id",

--- a/python/composio/tools/local/clickup/actions/delete_dependency.py
+++ b/python/composio/tools/local/clickup/actions/delete_dependency.py
@@ -23,7 +23,7 @@ class DeleteDependencyRequest(BaseModel):
         alias="dependency_of",
         description="",
     )
-    custom_task_ids: bool = Field(
+    custom_task_ids: t.Optional[bool] = Field(
         default=None,
         alias="custom_task_ids",
         description=(
@@ -31,7 +31,7 @@ class DeleteDependencyRequest(BaseModel):
             "be `true`. "
         ),
     )
-    team_id: int = Field(
+    team_id: t.Optional[int] = Field(
         default=None,
         alias="team_id",
         description=(

--- a/python/composio/tools/local/clickup/actions/delete_task.py
+++ b/python/composio/tools/local/clickup/actions/delete_task.py
@@ -13,7 +13,7 @@ class DeleteTaskRequest(BaseModel):
         alias="task_id",
         description="",
     )
-    custom_task_ids: bool = Field(
+    custom_task_ids: t.Optional[bool] = Field(
         default=None,
         alias="custom_task_ids",
         description=(
@@ -21,7 +21,7 @@ class DeleteTaskRequest(BaseModel):
             "be `true`. "
         ),
     )
-    team_id: int = Field(
+    team_id: t.Optional[int] = Field(
         default=None,
         alias="team_id",
         description=(

--- a/python/composio/tools/local/clickup/actions/delete_task_link.py
+++ b/python/composio/tools/local/clickup/actions/delete_task_link.py
@@ -18,7 +18,7 @@ class DeleteTaskLinkRequest(BaseModel):
         alias="links_to",
         description="",
     )
-    custom_task_ids: bool = Field(
+    custom_task_ids: t.Optional[bool] = Field(
         default=None,
         alias="custom_task_ids",
         description=(
@@ -26,7 +26,7 @@ class DeleteTaskLinkRequest(BaseModel):
             "be `true`. "
         ),
     )
-    team_id: int = Field(
+    team_id: t.Optional[int] = Field(
         default=None,
         alias="team_id",
         description=(

--- a/python/composio/tools/local/clickup/actions/delete_time_tracked.py
+++ b/python/composio/tools/local/clickup/actions/delete_time_tracked.py
@@ -18,7 +18,7 @@ class DeleteTimeTrackedRequest(BaseModel):
         alias="interval_id",
         description="",
     )
-    custom_task_ids: bool = Field(
+    custom_task_ids: t.Optional[bool] = Field(
         default=None,
         alias="custom_task_ids",
         description=(
@@ -26,7 +26,7 @@ class DeleteTimeTrackedRequest(BaseModel):
             "be `true`. "
         ),
     )
-    team_id: int = Field(
+    team_id: t.Optional[int] = Field(
         default=None,
         alias="team_id",
         description=(

--- a/python/composio/tools/local/clickup/actions/edit_checklist.py
+++ b/python/composio/tools/local/clickup/actions/edit_checklist.py
@@ -13,12 +13,12 @@ class EditChecklistRequest(BaseModel):
         alias="checklist_id",
         description="b8a8-48d8-a0c6-b4200788a683 (uuid)",
     )
-    name: str = Field(
+    name: t.Optional[str] = Field(
         default=None,
         alias="name",
         description="Name",
     )
-    position: int = Field(
+    position: t.Optional[int] = Field(
         default=None,
         alias="position",
         description=(

--- a/python/composio/tools/local/clickup/actions/edit_checklist_item.py
+++ b/python/composio/tools/local/clickup/actions/edit_checklist_item.py
@@ -18,22 +18,22 @@ class EditChecklistItemRequest(BaseModel):
         alias="checklist_item_id",
         description="e491-47f5-9fd8-d1dc4cedcc6f (uuid)",
     )
-    name: str = Field(
+    name: t.Optional[str] = Field(
         default=None,
         alias="name",
         description="Name",
     )
-    assignee: str = Field(
+    assignee: t.Optional[str] = Field(
         default=None,
         alias="assignee",
         description="Assignee",
     )
-    resolved: bool = Field(
+    resolved: t.Optional[bool] = Field(
         default=None,
         alias="resolved",
         description="Resolved",
     )
-    parent: str = Field(
+    parent: t.Optional[str] = Field(
         default=None,
         alias="parent",
         description=(

--- a/python/composio/tools/local/clickup/actions/edit_time_tracked.py
+++ b/python/composio/tools/local/clickup/actions/edit_time_tracked.py
@@ -18,7 +18,7 @@ class EditTimeTrackedRequest(BaseModel):
         alias="interval_id",
         description="",
     )
-    custom_task_ids: bool = Field(
+    custom_task_ids: t.Optional[bool] = Field(
         default=None,
         alias="custom_task_ids",
         description=(
@@ -26,7 +26,7 @@ class EditTimeTrackedRequest(BaseModel):
             "be `true`. "
         ),
     )
-    team_id: int = Field(
+    team_id: t.Optional[int] = Field(
         default=None,
         alias="team_id",
         description=(

--- a/python/composio/tools/local/clickup/actions/get_bulk_tasks_time_in_status.py
+++ b/python/composio/tools/local/clickup/actions/get_bulk_tasks_time_in_status.py
@@ -16,7 +16,7 @@ class GetBulkTasksTimeInStatusRequest(BaseModel):
             "ids per request. For example: `task_ids=3cuh&task_ids=g4fs` "
         ),
     )
-    custom_task_ids: bool = Field(
+    custom_task_ids: t.Optional[bool] = Field(
         default=None,
         alias="custom_task_ids",
         description=(
@@ -24,7 +24,7 @@ class GetBulkTasksTimeInStatusRequest(BaseModel):
             "be `true`. "
         ),
     )
-    team_id: int = Field(
+    team_id: t.Optional[int] = Field(
         default=None,
         alias="team_id",
         description=(

--- a/python/composio/tools/local/clickup/actions/get_chat_view_comments.py
+++ b/python/composio/tools/local/clickup/actions/get_chat_view_comments.py
@@ -13,12 +13,12 @@ class GetChatViewCommentsRequest(BaseModel):
         alias="view_id",
         description="105 (string)",
     )
-    start: int = Field(
+    start: t.Optional[int] = Field(
         default=None,
         alias="start",
         description="Enter the `date` of a Chat view comment using Unix time in milliseconds.",
     )
-    start_id: str = Field(
+    start_id: t.Optional[str] = Field(
         default=None,
         alias="start_id",
         description="Enter the Comment `id` of a Chat view comment.",

--- a/python/composio/tools/local/clickup/actions/get_custom_roles.py
+++ b/python/composio/tools/local/clickup/actions/get_custom_roles.py
@@ -13,7 +13,7 @@ class GetCustomRolesRequest(BaseModel):
         alias="team_id",
         description="",
     )
-    include_members: bool = Field(
+    include_members: t.Optional[bool] = Field(
         default=None,
         alias="include_members",
         description="",

--- a/python/composio/tools/local/clickup/actions/get_filtered_team_tasks.py
+++ b/python/composio/tools/local/clickup/actions/get_filtered_team_tasks.py
@@ -13,12 +13,12 @@ class GetFilteredTeamTasksRequest(BaseModel):
         alias="team_Id",
         description="Team ID (Workspace)",
     )
-    page: int = Field(
+    page: t.Optional[int] = Field(
         default=None,
         alias="page",
         description="Page to fetch (starts at 0).",
     )
-    order_by: str = Field(
+    order_by: t.Optional[str] = Field(
         default=None,
         alias="order_by",
         description=(
@@ -26,34 +26,34 @@ class GetFilteredTeamTasksRequest(BaseModel):
             "  Options include: `id`, `created`, `updated`, and `due_date`. "
         ),
     )
-    reverse: bool = Field(
+    reverse: t.Optional[bool] = Field(
         default=None,
         alias="reverse",
         description="Tasks are displayed in reverse order.",
     )
-    subtasks: bool = Field(
+    subtasks: t.Optional[bool] = Field(
         default=None,
         alias="subtasks",
         description="Include or exclude subtasks. By default, subtasks are excluded.",
     )
-    space_ids: t.List[str] = Field(
+    space_ids: t.Optional[t.List[str]] = Field(
         default=None,
         alias="space_ids",
         description="Filter by Spaces. For example:    `?space_ids[]=1234&space_ids[]=6789`",
     )
-    project_ids: t.List[str] = Field(
+    project_ids: t.Optional[t.List[str]] = Field(
         default=None,
         alias="project_ids",
         description=(
             "Filter by Folders. For example:    `?project_ids[]=1234&project_ids[]=6789` "
         ),
     )
-    list_ids: t.List[str] = Field(
+    list_ids: t.Optional[t.List[str]] = Field(
         default=None,
         alias="list_ids",
         description="Filter by Lists. For example:    `?list_ids[]=1234&list_ids[]=6789`",
     )
-    statuses: t.List[str] = Field(
+    statuses: t.Optional[t.List[str]] = Field(
         default=None,
         alias="statuses",
         description=(
@@ -61,7 +61,7 @@ class GetFilteredTeamTasksRequest(BaseModel):
             "closed tasks, use the `include_closed` parameter.    For example:    `?statuses[]=to%20do&statuses[]=in%20progress` "
         ),
     )
-    include_closed: bool = Field(
+    include_closed: t.Optional[bool] = Field(
         default=None,
         alias="include_closed",
         description=(
@@ -69,14 +69,14 @@ class GetFilteredTeamTasksRequest(BaseModel):
             "closed tasks, use `include_closed: true`. "
         ),
     )
-    assignees: t.List[str] = Field(
+    assignees: t.Optional[t.List[str]] = Field(
         default=None,
         alias="assignees",
         description=(
             'Filter by Assignees using people"s ClickUp user id. For example:    `?assignees[]=1234&assignees[]=5678` '
         ),
     )
-    tags: t.List[str] = Field(
+    tags: t.Optional[t.List[str]] = Field(
         default=None,
         alias="tags",
         description=(
@@ -84,47 +84,47 @@ class GetFilteredTeamTasksRequest(BaseModel):
             "   `?tags[]=tag1&tags[]=this%20tag` "
         ),
     )
-    due_date_gt: int = Field(
+    due_date_gt: t.Optional[int] = Field(
         default=None,
         alias="due_date_gt",
         description="Filter by due date greater than Unix time in milliseconds.",
     )
-    due_date_lt: int = Field(
+    due_date_lt: t.Optional[int] = Field(
         default=None,
         alias="due_date_lt",
         description="Filter by due date less than Unix time in milliseconds.",
     )
-    date_created_gt: int = Field(
+    date_created_gt: t.Optional[int] = Field(
         default=None,
         alias="date_created_gt",
         description="Filter by date created greater than Unix time in milliseconds.",
     )
-    date_created_lt: int = Field(
+    date_created_lt: t.Optional[int] = Field(
         default=None,
         alias="date_created_lt",
         description="Filter by date created less than Unix time in milliseconds.",
     )
-    date_updated_gt: int = Field(
+    date_updated_gt: t.Optional[int] = Field(
         default=None,
         alias="date_updated_gt",
         description="Filter by date updated greater than Unix time in milliseconds.",
     )
-    date_updated_lt: int = Field(
+    date_updated_lt: t.Optional[int] = Field(
         default=None,
         alias="date_updated_lt",
         description="Filter by date updated less than Unix time in milliseconds.",
     )
-    date_done_gt: int = Field(
+    date_done_gt: t.Optional[int] = Field(
         default=None,
         alias="date_done_gt",
         description="Filter by date done greater than Unix time in milliseconds.",
     )
-    date_done_lt: int = Field(
+    date_done_lt: t.Optional[int] = Field(
         default=None,
         alias="date_done_lt",
         description="Filter by date done less than Unix time in milliseconds.",
     )
-    custom_fields: t.List[str] = Field(
+    custom_fields: t.Optional[t.List[str]] = Field(
         default=None,
         alias="custom_fields",
         description=(
@@ -133,7 +133,7 @@ class GetFilteredTeamTasksRequest(BaseModel):
             "  Learn more about [filtering using Custom Fields.](https://clickup.com/api) "
         ),
     )
-    custom_task_ids: bool = Field(
+    custom_task_ids: t.Optional[bool] = Field(
         default=None,
         alias="custom_task_ids",
         description=(
@@ -141,7 +141,7 @@ class GetFilteredTeamTasksRequest(BaseModel):
             "be `true`. "
         ),
     )
-    team_id: int = Field(
+    team_id: t.Optional[int] = Field(
         default=None,
         alias="team_id",
         description=(
@@ -149,19 +149,19 @@ class GetFilteredTeamTasksRequest(BaseModel):
             "`custom_task_ids=true&team_id=123`. "
         ),
     )
-    parent: str = Field(
+    parent: t.Optional[str] = Field(
         default=None,
         alias="parent",
         description="Include the parent task ID to return subtasks.",
     )
-    include_markdown_description: bool = Field(
+    include_markdown_description: t.Optional[bool] = Field(
         default=None,
         alias="include_markdown_description",
         description=(
             "To return task descriptions in Markdown format, use `?include_markdown_description=true`. "
         ),
     )
-    custom_items: t.List[int] = Field(
+    custom_items: t.Optional[t.List[int]] = Field(
         default=None,
         alias="custom_items",
         description=(

--- a/python/composio/tools/local/clickup/actions/get_folderless_lists.py
+++ b/python/composio/tools/local/clickup/actions/get_folderless_lists.py
@@ -13,7 +13,7 @@ class GetFolderlessListsRequest(BaseModel):
         alias="space_id",
         description="",
     )
-    archived: bool = Field(
+    archived: t.Optional[bool] = Field(
         default=None,
         alias="archived",
         description="",

--- a/python/composio/tools/local/clickup/actions/get_folders.py
+++ b/python/composio/tools/local/clickup/actions/get_folders.py
@@ -13,7 +13,7 @@ class GetFoldersRequest(BaseModel):
         alias="space_id",
         description="",
     )
-    archived: bool = Field(
+    archived: t.Optional[bool] = Field(
         default=None,
         alias="archived",
         description="",

--- a/python/composio/tools/local/clickup/actions/get_goals.py
+++ b/python/composio/tools/local/clickup/actions/get_goals.py
@@ -13,7 +13,7 @@ class GetGoalsRequest(BaseModel):
         alias="team_id",
         description="Team ID (Workspace)",
     )
-    include_completed: bool = Field(
+    include_completed: t.Optional[bool] = Field(
         default=None,
         alias="include_completed",
         description="",

--- a/python/composio/tools/local/clickup/actions/get_list_comments.py
+++ b/python/composio/tools/local/clickup/actions/get_list_comments.py
@@ -13,12 +13,12 @@ class GetListCommentsRequest(BaseModel):
         alias="list_id",
         description="",
     )
-    start: int = Field(
+    start: t.Optional[int] = Field(
         default=None,
         alias="start",
         description="Enter the `date` of a List info comment using Unix time in milliseconds.",
     )
-    start_id: str = Field(
+    start_id: t.Optional[str] = Field(
         default=None,
         alias="start_id",
         description="Enter the Comment `id` of a List info comment.",

--- a/python/composio/tools/local/clickup/actions/get_lists.py
+++ b/python/composio/tools/local/clickup/actions/get_lists.py
@@ -13,7 +13,7 @@ class GetListsRequest(BaseModel):
         alias="folder_id",
         description="",
     )
-    archived: bool = Field(
+    archived: t.Optional[bool] = Field(
         default=None,
         alias="archived",
         description="",

--- a/python/composio/tools/local/clickup/actions/get_running_time_entry.py
+++ b/python/composio/tools/local/clickup/actions/get_running_time_entry.py
@@ -13,7 +13,7 @@ class GetRunningTimeEntryRequest(BaseModel):
         alias="team_id",
         description="Team ID (Workspace)",
     )
-    assignee: int = Field(
+    assignee: t.Optional[int] = Field(
         default=None,
         alias="assignee",
         description="user id",

--- a/python/composio/tools/local/clickup/actions/get_singular_time_entry.py
+++ b/python/composio/tools/local/clickup/actions/get_singular_time_entry.py
@@ -21,12 +21,12 @@ class GetSingularTimeEntryRequest(BaseModel):
             "Within a Date Range](https://clickup.com/api) endpoint. "
         ),
     )
-    include_task: bool = Field(
+    include_task: t.Optional[bool] = Field(
         default=None,
         alias="include_task_",
         description="Include task  in the response for time entries associated with tasks.",
     )
-    include_location_names: bool = Field(
+    include_location_names: t.Optional[bool] = Field(
         default=None,
         alias="include_location_names",
         description=(

--- a/python/composio/tools/local/clickup/actions/get_spaces.py
+++ b/python/composio/tools/local/clickup/actions/get_spaces.py
@@ -13,7 +13,7 @@ class GetSpacesRequest(BaseModel):
         alias="team_id",
         description="Team ID (Workspace)",
     )
-    archived: bool = Field(
+    archived: t.Optional[bool] = Field(
         default=None,
         alias="archived",
         description="",

--- a/python/composio/tools/local/clickup/actions/get_task.py
+++ b/python/composio/tools/local/clickup/actions/get_task.py
@@ -13,7 +13,7 @@ class GetTaskRequest(BaseModel):
         alias="task_id",
         description="",
     )
-    custom_task_ids: bool = Field(
+    custom_task_ids: t.Optional[bool] = Field(
         default=None,
         alias="custom_task_ids",
         description=(
@@ -21,7 +21,7 @@ class GetTaskRequest(BaseModel):
             "be `true`. "
         ),
     )
-    team_id: int = Field(
+    team_id: t.Optional[int] = Field(
         default=None,
         alias="team_id",
         description=(
@@ -29,12 +29,12 @@ class GetTaskRequest(BaseModel):
             "`custom_task_ids=true&team_id=123`. "
         ),
     )
-    include_subtasks: bool = Field(
+    include_subtasks: t.Optional[bool] = Field(
         default=None,
         alias="include_subtasks",
         description="Include subtasks, default false",
     )
-    include_markdown_description: bool = Field(
+    include_markdown_description: t.Optional[bool] = Field(
         default=None,
         alias="include_markdown_description",
         description=(

--- a/python/composio/tools/local/clickup/actions/get_task_comments.py
+++ b/python/composio/tools/local/clickup/actions/get_task_comments.py
@@ -13,7 +13,7 @@ class GetTaskCommentsRequest(BaseModel):
         alias="task_id",
         description="",
     )
-    custom_task_ids: bool = Field(
+    custom_task_ids: t.Optional[bool] = Field(
         default=None,
         alias="custom_task_ids",
         description=(
@@ -21,7 +21,7 @@ class GetTaskCommentsRequest(BaseModel):
             "be `true`. "
         ),
     )
-    team_id: int = Field(
+    team_id: t.Optional[int] = Field(
         default=None,
         alias="team_id",
         description=(
@@ -29,12 +29,12 @@ class GetTaskCommentsRequest(BaseModel):
             "`custom_task_ids=true&team_id=123`. "
         ),
     )
-    start: int = Field(
+    start: t.Optional[int] = Field(
         default=None,
         alias="start",
         description="Enter the `date` of a task comment using Unix time in milliseconds.",
     )
-    start_id: str = Field(
+    start_id: t.Optional[str] = Field(
         default=None,
         alias="start_id",
         description="Enter the Comment `id` of a task comment.",

--- a/python/composio/tools/local/clickup/actions/get_task_s_time_in_status.py
+++ b/python/composio/tools/local/clickup/actions/get_task_s_time_in_status.py
@@ -13,7 +13,7 @@ class GetTaskSTimeInStatusRequest(BaseModel):
         alias="task_id",
         description="",
     )
-    custom_task_ids: bool = Field(
+    custom_task_ids: t.Optional[bool] = Field(
         default=None,
         alias="custom_task_ids",
         description=(
@@ -21,7 +21,7 @@ class GetTaskSTimeInStatusRequest(BaseModel):
             "be `true`. "
         ),
     )
-    team_id: int = Field(
+    team_id: t.Optional[int] = Field(
         default=None,
         alias="team_id",
         description=(

--- a/python/composio/tools/local/clickup/actions/get_tasks.py
+++ b/python/composio/tools/local/clickup/actions/get_tasks.py
@@ -18,24 +18,24 @@ class GetTasksRequest(BaseModel):
             "URL. "
         ),
     )
-    archived: bool = Field(
+    archived: t.Optional[bool] = Field(
         default=None,
         alias="archived",
         description="",
     )
-    include_markdown_description: bool = Field(
+    include_markdown_description: t.Optional[bool] = Field(
         default=None,
         alias="include_markdown_description",
         description=(
             "To return task descriptions in Markdown format, use `?include_markdown_description=true`. "
         ),
     )
-    page: int = Field(
+    page: t.Optional[int] = Field(
         default=None,
         alias="page",
         description="Page to fetch (starts at 0).",
     )
-    order_by: str = Field(
+    order_by: t.Optional[str] = Field(
         default=None,
         alias="order_by",
         description=(
@@ -43,17 +43,17 @@ class GetTasksRequest(BaseModel):
             "  Options include: `id`, `created`, `updated`, and `due_date`. "
         ),
     )
-    reverse: bool = Field(
+    reverse: t.Optional[bool] = Field(
         default=None,
         alias="reverse",
         description="Tasks are displayed in reverse order.",
     )
-    subtasks: bool = Field(
+    subtasks: t.Optional[bool] = Field(
         default=None,
         alias="subtasks",
         description="Include or exclude subtasks. By default, subtasks are excluded.",
     )
-    statuses: t.List[str] = Field(
+    statuses: t.Optional[t.List[str]] = Field(
         default=None,
         alias="statuses",
         description=(
@@ -61,7 +61,7 @@ class GetTasksRequest(BaseModel):
             "   For example:    `?statuses[]=to%20do&statuses[]=in%20progress` "
         ),
     )
-    include_closed: bool = Field(
+    include_closed: t.Optional[bool] = Field(
         default=None,
         alias="include_closed",
         description=(
@@ -69,59 +69,59 @@ class GetTasksRequest(BaseModel):
             "closed tasks, use `include_closed: true`. "
         ),
     )
-    assignees: t.List[str] = Field(
+    assignees: t.Optional[t.List[str]] = Field(
         default=None,
         alias="assignees",
         description=(
             "Filter by Assignees. For example:    `?assignees[]=1234&assignees[]=5678` "
         ),
     )
-    tags: t.List[str] = Field(
+    tags: t.Optional[t.List[str]] = Field(
         default=None,
         alias="tags",
         description="Filter by tags. For example:    `?tags[]=tag1&tags[]=this%20tag`",
     )
-    due_date_gt: int = Field(
+    due_date_gt: t.Optional[int] = Field(
         default=None,
         alias="due_date_gt",
         description="Filter by due date greater than Unix time in milliseconds.",
     )
-    due_date_lt: int = Field(
+    due_date_lt: t.Optional[int] = Field(
         default=None,
         alias="due_date_lt",
         description="Filter by due date less than Unix time in milliseconds.",
     )
-    date_created_gt: int = Field(
+    date_created_gt: t.Optional[int] = Field(
         default=None,
         alias="date_created_gt",
         description="Filter by date created greater than Unix time in milliseconds.",
     )
-    date_created_lt: int = Field(
+    date_created_lt: t.Optional[int] = Field(
         default=None,
         alias="date_created_lt",
         description="Filter by date created less than Unix time in milliseconds.",
     )
-    date_updated_gt: int = Field(
+    date_updated_gt: t.Optional[int] = Field(
         default=None,
         alias="date_updated_gt",
         description="Filter by date updated greater than Unix time in milliseconds.",
     )
-    date_updated_lt: int = Field(
+    date_updated_lt: t.Optional[int] = Field(
         default=None,
         alias="date_updated_lt",
         description="Filter by date updated less than Unix time in milliseconds.",
     )
-    date_done_gt: int = Field(
+    date_done_gt: t.Optional[int] = Field(
         default=None,
         alias="date_done_gt",
         description="Filter by date done greater than Unix time in milliseconds.",
     )
-    date_done_lt: int = Field(
+    date_done_lt: t.Optional[int] = Field(
         default=None,
         alias="date_done_lt",
         description="Filter by date done less than Unix time in milliseconds.",
     )
-    custom_fields: t.List[str] = Field(
+    custom_fields: t.Optional[t.List[str]] = Field(
         default=None,
         alias="custom_fields",
         description=(
@@ -131,7 +131,7 @@ class GetTasksRequest(BaseModel):
             "use `custom_field` instead.   Learn more about [filtering using Custom Fields.](https://clickup.com/api) "
         ),
     )
-    custom_items: t.List[int] = Field(
+    custom_items: t.Optional[t.List[int]] = Field(
         default=None,
         alias="custom_items",
         description=(

--- a/python/composio/tools/local/clickup/actions/get_teams.py
+++ b/python/composio/tools/local/clickup/actions/get_teams.py
@@ -8,12 +8,12 @@ from composio.tools.local.clickup.actions.base import OpenAPIAction
 class GetTeamsRequest(BaseModel):
     """Request schema for `GetTeams`"""
 
-    team_id: int = Field(
+    team_id: t.Optional[int] = Field(
         default=None,
         alias="team_id",
         description="Team ID (Workspace)",
     )
-    group_ids: str = Field(
+    group_ids: t.Optional[str] = Field(
         default=None,
         alias="group_ids",
         description=(

--- a/python/composio/tools/local/clickup/actions/get_time_entries_within_a_date_range.py
+++ b/python/composio/tools/local/clickup/actions/get_time_entries_within_a_date_range.py
@@ -13,17 +13,17 @@ class GetTimeEntriesWithinADateRangeRequest(BaseModel):
         alias="team_Id",
         description="Team ID (Workspace)",
     )
-    start_date: int = Field(
+    start_date: t.Optional[int] = Field(
         default=None,
         alias="start_date",
         description="Unix time in milliseconds",
     )
-    end_date: int = Field(
+    end_date: t.Optional[int] = Field(
         default=None,
         alias="end_date",
         description="Unix time in milliseconds",
     )
-    assignee: int = Field(
+    assignee: t.Optional[int] = Field(
         default=None,
         alias="assignee",
         description=(
@@ -32,14 +32,14 @@ class GetTimeEntriesWithinADateRangeRequest(BaseModel):
             "have access to do this.* "
         ),
     )
-    include_task_tags: bool = Field(
+    include_task_tags: t.Optional[bool] = Field(
         default=None,
         alias="include_task_tags",
         description=(
             "Include task tags in the response for time entries associated with tasks. "
         ),
     )
-    include_location_names: bool = Field(
+    include_location_names: t.Optional[bool] = Field(
         default=None,
         alias="include_location_names",
         description=(
@@ -47,27 +47,27 @@ class GetTimeEntriesWithinADateRangeRequest(BaseModel):
             "and `space_id`. "
         ),
     )
-    space_id: int = Field(
+    space_id: t.Optional[int] = Field(
         default=None,
         alias="space_id",
         description="Only include time entries associated with tasks in a specific Space.",
     )
-    folder_id: int = Field(
+    folder_id: t.Optional[int] = Field(
         default=None,
         alias="folder_id",
         description="Only include time entries associated with tasks in a specific Folder.",
     )
-    list_id: int = Field(
+    list_id: t.Optional[int] = Field(
         default=None,
         alias="list_id",
         description="Only include time entries associated with tasks in a specific List.",
     )
-    task_id: str = Field(
+    task_id: t.Optional[str] = Field(
         default=None,
         alias="task_id",
         description="Only include time entries associated with a specific task.",
     )
-    custom_task_ids: bool = Field(
+    custom_task_ids: t.Optional[bool] = Field(
         default=None,
         alias="custom_task_ids",
         description=(
@@ -75,7 +75,7 @@ class GetTimeEntriesWithinADateRangeRequest(BaseModel):
             "be `true`. "
         ),
     )
-    team_id: int = Field(
+    team_id: t.Optional[int] = Field(
         default=None,
         alias="team_id",
         description=(

--- a/python/composio/tools/local/clickup/actions/get_tracked_time.py
+++ b/python/composio/tools/local/clickup/actions/get_tracked_time.py
@@ -13,7 +13,7 @@ class GetTrackedTimeRequest(BaseModel):
         alias="task_id",
         description="",
     )
-    custom_task_ids: bool = Field(
+    custom_task_ids: t.Optional[bool] = Field(
         default=None,
         alias="custom_task_ids",
         description=(
@@ -21,7 +21,7 @@ class GetTrackedTimeRequest(BaseModel):
             "be `true`. "
         ),
     )
-    team_id: int = Field(
+    team_id: t.Optional[int] = Field(
         default=None,
         alias="team_id",
         description=(

--- a/python/composio/tools/local/clickup/actions/invite_user_to_workspace.py
+++ b/python/composio/tools/local/clickup/actions/invite_user_to_workspace.py
@@ -23,7 +23,7 @@ class InviteUserToWorkspaceRequest(BaseModel):
         alias="admin",
         description="Admin",
     )
-    custom_role_id: int = Field(
+    custom_role_id: t.Optional[int] = Field(
         default=None,
         alias="custom_role_id",
         description="Custom Role Id",

--- a/python/composio/tools/local/clickup/actions/remove_custom_field_value.py
+++ b/python/composio/tools/local/clickup/actions/remove_custom_field_value.py
@@ -18,7 +18,7 @@ class RemoveCustomFieldValueRequest(BaseModel):
         alias="field_id",
         description="b8a8-48d8-a0c6-b4200788a683 (uuid)",
     )
-    custom_task_ids: bool = Field(
+    custom_task_ids: t.Optional[bool] = Field(
         default=None,
         alias="custom_task_ids",
         description=(
@@ -26,7 +26,7 @@ class RemoveCustomFieldValueRequest(BaseModel):
             "be `true`. "
         ),
     )
-    team_id: int = Field(
+    team_id: t.Optional[int] = Field(
         default=None,
         alias="team_id",
         description=(

--- a/python/composio/tools/local/clickup/actions/remove_guest_from_folder.py
+++ b/python/composio/tools/local/clickup/actions/remove_guest_from_folder.py
@@ -18,7 +18,7 @@ class RemoveGuestFromFolderRequest(BaseModel):
         alias="guest_id",
         description="",
     )
-    include_shared: bool = Field(
+    include_shared: t.Optional[bool] = Field(
         default=None,
         alias="include_shared",
         description=(

--- a/python/composio/tools/local/clickup/actions/remove_guest_from_list.py
+++ b/python/composio/tools/local/clickup/actions/remove_guest_from_list.py
@@ -18,7 +18,7 @@ class RemoveGuestFromListRequest(BaseModel):
         alias="guest_id",
         description="",
     )
-    include_shared: bool = Field(
+    include_shared: t.Optional[bool] = Field(
         default=None,
         alias="include_shared",
         description=(

--- a/python/composio/tools/local/clickup/actions/remove_guest_from_task.py
+++ b/python/composio/tools/local/clickup/actions/remove_guest_from_task.py
@@ -18,7 +18,7 @@ class RemoveGuestFromTaskRequest(BaseModel):
         alias="guest_id",
         description="",
     )
-    include_shared: bool = Field(
+    include_shared: t.Optional[bool] = Field(
         default=None,
         alias="include_shared",
         description=(
@@ -26,7 +26,7 @@ class RemoveGuestFromTaskRequest(BaseModel):
             "to `false`. By default this parameter is set to `true`. "
         ),
     )
-    custom_task_ids: bool = Field(
+    custom_task_ids: t.Optional[bool] = Field(
         default=None,
         alias="custom_task_ids",
         description=(
@@ -34,7 +34,7 @@ class RemoveGuestFromTaskRequest(BaseModel):
             "be `true`. "
         ),
     )
-    team_id: int = Field(
+    team_id: t.Optional[int] = Field(
         default=None,
         alias="team_id",
         description=(

--- a/python/composio/tools/local/clickup/actions/remove_tag_from_task.py
+++ b/python/composio/tools/local/clickup/actions/remove_tag_from_task.py
@@ -18,7 +18,7 @@ class RemoveTagFromTaskRequest(BaseModel):
         alias="tag_name",
         description="",
     )
-    custom_task_ids: bool = Field(
+    custom_task_ids: t.Optional[bool] = Field(
         default=None,
         alias="custom_task_ids",
         description=(
@@ -26,7 +26,7 @@ class RemoveTagFromTaskRequest(BaseModel):
             "be `true`. "
         ),
     )
-    team_id: int = Field(
+    team_id: t.Optional[int] = Field(
         default=None,
         alias="team_id",
         description=(

--- a/python/composio/tools/local/clickup/actions/set_custom_field_value.py
+++ b/python/composio/tools/local/clickup/actions/set_custom_field_value.py
@@ -21,7 +21,7 @@ class SetCustomFieldValueRequest(BaseModel):
             "to set. "
         ),
     )
-    custom_task_ids: bool = Field(
+    custom_task_ids: t.Optional[bool] = Field(
         default=None,
         alias="custom_task_ids",
         description=(
@@ -29,7 +29,7 @@ class SetCustomFieldValueRequest(BaseModel):
             "`true`. "
         ),
     )
-    team_id: int = Field(
+    team_id: t.Optional[int] = Field(
         default=None,
         alias="team_id",
         description=(

--- a/python/composio/tools/local/clickup/actions/start_a_time_entry.py
+++ b/python/composio/tools/local/clickup/actions/start_a_time_entry.py
@@ -13,7 +13,7 @@ class StartATimeEntryRequest(BaseModel):
         alias="team_Id",
         description="Team ID (Workspace)",
     )
-    custom_task_ids: bool = Field(
+    custom_task_ids: t.Optional[bool] = Field(
         default=None,
         alias="custom_task_ids",
         description=(
@@ -21,7 +21,7 @@ class StartATimeEntryRequest(BaseModel):
             "be `true`. "
         ),
     )
-    team_id: int = Field(
+    team_id: t.Optional[int] = Field(
         default=None,
         alias="team_id",
         description=(
@@ -29,22 +29,22 @@ class StartATimeEntryRequest(BaseModel):
             "`custom_task_ids=true&team_id=123`. "
         ),
     )
-    tags: t.List[dict] = Field(
+    tags: t.Optional[t.List[dict]] = Field(
         default=None,
         alias="tags",
         description="Users on the Business Plan and above can include a time tracking label.",
     )
-    description: str = Field(
+    description: t.Optional[str] = Field(
         default=None,
         alias="description",
         description="Description",
     )
-    tid: str = Field(
+    tid: t.Optional[str] = Field(
         default=None,
         alias="tid",
         description="Tid",
     )
-    billable: bool = Field(
+    billable: t.Optional[bool] = Field(
         default=None,
         alias="billable",
         description="Billable",

--- a/python/composio/tools/local/clickup/actions/track_time.py
+++ b/python/composio/tools/local/clickup/actions/track_time.py
@@ -13,7 +13,7 @@ class TrackTimeRequest(BaseModel):
         alias="task_id",
         description="",
     )
-    custom_task_ids: bool = Field(
+    custom_task_ids: t.Optional[bool] = Field(
         default=None,
         alias="custom_task_ids",
         description=(
@@ -21,7 +21,7 @@ class TrackTimeRequest(BaseModel):
             "be `true`. "
         ),
     )
-    team_id: int = Field(
+    team_id: t.Optional[int] = Field(
         default=None,
         alias="team_id",
         description=(

--- a/python/composio/tools/local/clickup/actions/update_a_time_entry.py
+++ b/python/composio/tools/local/clickup/actions/update_a_time_entry.py
@@ -18,7 +18,7 @@ class UpdateATimeEntryRequest(BaseModel):
         alias="timer_id",
         description="",
     )
-    custom_task_ids: bool = Field(
+    custom_task_ids: t.Optional[bool] = Field(
         default=None,
         alias="custom_task_ids",
         description=(
@@ -31,37 +31,37 @@ class UpdateATimeEntryRequest(BaseModel):
         alias="tags",
         description="Users on the Business Plan and above can include a time tracking label.",
     )
-    description: str = Field(
+    description: t.Optional[str] = Field(
         default=None,
         alias="description",
         description="Description",
     )
-    tag_action: str = Field(
+    tag_action: t.Optional[str] = Field(
         default=None,
         alias="tag_action",
         description="Tag Action",
     )
-    start: int = Field(
+    start: t.Optional[int] = Field(
         default=None,
         alias="start",
         description="When providing `start`, you must also provide `end`.",
     )
-    end: int = Field(
+    end: t.Optional[int] = Field(
         default=None,
         alias="end",
         description="When providing `end`, you must also provide `start`.",
     )
-    tid: str = Field(
+    tid: t.Optional[str] = Field(
         default=None,
         alias="tid",
         description="Tid",
     )
-    billable: bool = Field(
+    billable: t.Optional[bool] = Field(
         default=None,
         alias="billable",
         description="Billable",
     )
-    duration: int = Field(
+    duration: t.Optional[int] = Field(
         default=None,
         alias="duration",
         description="Duration",

--- a/python/composio/tools/local/clickup/actions/update_task.py
+++ b/python/composio/tools/local/clickup/actions/update_task.py
@@ -13,7 +13,7 @@ class UpdateTaskRequest(BaseModel):
         alias="task_id",
         description="",
     )
-    custom_task_ids: bool = Field(
+    custom_task_ids: t.Optional[bool] = Field(
         default=None,
         alias="custom_task_ids",
         description=(
@@ -21,7 +21,7 @@ class UpdateTaskRequest(BaseModel):
             "be `true`. "
         ),
     )
-    team_id: int = Field(
+    team_id: t.Optional[int] = Field(
         default=None,
         alias="team_id",
         description=(
@@ -29,12 +29,12 @@ class UpdateTaskRequest(BaseModel):
             "`custom_task_ids=true&team_id=123`. "
         ),
     )
-    description: str = Field(
+    description: t.Optional[str] = Field(
         default=None,
         alias="description",
         description='To clear the task description, include `Description` with `" "`.',
     )
-    custom_item_id: int = Field(
+    custom_item_id: t.Optional[int] = Field(
         default=None,
         alias="custom_item_id",
         description=(
@@ -44,32 +44,32 @@ class UpdateTaskRequest(BaseModel):
             "such as `2`. "
         ),
     )
-    name: str = Field(
+    name: t.Optional[str] = Field(
         default=None,
         alias="name",
         description="Name",
     )
-    status: str = Field(
+    status: t.Optional[str] = Field(
         default=None,
         alias="status",
         description="Status",
     )
-    priority: int = Field(
+    priority: t.Optional[int] = Field(
         default=None,
         alias="priority",
         description="Priority",
     )
-    due_date: int = Field(
+    due_date: t.Optional[int] = Field(
         default=None,
         alias="due_date",
         description="Due Date",
     )
-    due_date_time: bool = Field(
+    due_date_time: t.Optional[bool] = Field(
         default=None,
         alias="due_date_time",
         description="Due Date Time",
     )
-    parent: str = Field(
+    parent: t.Optional[str] = Field(
         default=None,
         alias="parent",
         description=(
@@ -78,17 +78,17 @@ class UpdateTaskRequest(BaseModel):
             "to `null`. "
         ),
     )
-    time_estimate: int = Field(
+    time_estimate: t.Optional[int] = Field(
         default=None,
         alias="time_estimate",
         description="Time Estimate",
     )
-    start_date: int = Field(
+    start_date: t.Optional[int] = Field(
         default=None,
         alias="start_date",
         description="Start Date",
     )
-    start_date_time: bool = Field(
+    start_date_time: t.Optional[bool] = Field(
         default=None,
         alias="start_date_time",
         description="Start Date Time",
@@ -103,7 +103,7 @@ class UpdateTaskRequest(BaseModel):
         alias="assignees__rem",
         description="",
     )
-    archived: bool = Field(
+    archived: t.Optional[bool] = Field(
         default=None,
         alias="archived",
         description="Archived",

--- a/python/composio/tools/local/clickup/actions/update_team.py
+++ b/python/composio/tools/local/clickup/actions/update_team.py
@@ -13,12 +13,12 @@ class UpdateTeamRequest(BaseModel):
         alias="group_id",
         description="7C73-4002-A6A9-310014852858 (string) - Team ID (user group)",
     )
-    name: str = Field(
+    name: t.Optional[str] = Field(
         default=None,
         alias="name",
         description="Name",
     )
-    handle: str = Field(
+    handle: t.Optional[str] = Field(
         default=None,
         alias="handle",
         description="Handle",

--- a/python/composio/tools/local/embedtool/actions/create_vectorstore.py
+++ b/python/composio/tools/local/embedtool/actions/create_vectorstore.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import List, Type
+from typing import List, Optional, Type
 
 from pydantic import BaseModel, Field
 
@@ -13,7 +13,7 @@ class CreateVectorStoreInputSchema(BaseModel):
 
 class CreateVectorStoreOutputSchema(BaseModel):
     result: str = Field(..., description="Result of the action")
-    error: str = Field(default=None, description="Error message if any")
+    error: Optional[str] = Field(default=None, description="Error message if any")
 
 
 class CreateImageVectorStore(

--- a/python/composio/tools/local/filetool/actions/base_action.py
+++ b/python/composio/tools/local/filetool/actions/base_action.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from typing import Callable, Dict, TypeVar
+from typing import Callable, Dict, Optional, TypeVar
 
 from pydantic import BaseModel, Field
 
@@ -13,8 +13,8 @@ class BaseFileRequest(BaseModel):
 
 
 class BaseFileResponse(BaseModel):
-    error: str = Field(
-        default="",
+    error: Optional[str] = Field(
+        default=None,
         description="Error message if the action failed",
     )
     current_working_directory: str = Field(

--- a/python/composio/tools/local/filetool/actions/create.py
+++ b/python/composio/tools/local/filetool/actions/create.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Optional
 
 from pydantic import Field, field_validator
 
@@ -36,7 +36,7 @@ class CreateFileRequest(BaseFileRequest):
 class CreateFileResponse(BaseFileResponse):
     """Response to create a file or directory."""
 
-    path: str = Field(
+    path: Optional[str] = Field(
         default=None,
         description="Path of the created file or directory.",
     )

--- a/python/composio/tools/local/filetool/actions/edit.py
+++ b/python/composio/tools/local/filetool/actions/edit.py
@@ -49,18 +49,18 @@ class EditFileRequest(BaseFileRequest):
 class EditFileResponse(BaseFileResponse):
     """Response to edit a file."""
 
-    old_text: str = Field(
+    old_text: Optional[str] = Field(
         default=None,
         description=(
             "The updated changes. If the file was not edited, the original file "
             "will be returned."
         ),
     )
-    error: str = Field(
+    error: Optional[str] = Field(
         default=None,
         description="Error message if any",
     )
-    updated_text: str = Field(
+    updated_text: Optional[str] = Field(
         default=None,
         description="The updated text. If the file was not edited, this will be empty.",
     )

--- a/python/composio/tools/local/filetool/actions/edit.py
+++ b/python/composio/tools/local/filetool/actions/edit.py
@@ -13,7 +13,7 @@ from composio.tools.local.filetool.actions.base_action import (
 class EditFileRequest(BaseFileRequest):
     """Request to edit a file."""
 
-    file_path: str = Field(
+    file_path: Optional[str] = Field(
         default=None,
         description=(
             "The path to the file that will be edited. If not provided, "

--- a/python/composio/tools/local/filetool/actions/grep.py
+++ b/python/composio/tools/local/filetool/actions/grep.py
@@ -14,7 +14,7 @@ class SearchWordRequest(BaseFileRequest):
     """Request to search for a word in files."""
 
     word: str = Field(..., description="The term to search for")
-    pattern: str = Field(
+    pattern: t.Optional[str] = Field(
         default=None,
         description="""The file, directory, or glob pattern to search in.
         If not provided, searches in the current working directory.
@@ -31,7 +31,7 @@ class SearchWordRequest(BaseFileRequest):
     case_insensitive: bool = Field(
         default=True, description="If True, perform case-insensitive search"
     )
-    exclude: t.List[str] = Field(
+    exclude: t.Optional[t.List[str]] = Field(
         default=None,
         description="List of directories to exclude from the search",
     )

--- a/python/composio/tools/local/filetool/actions/write.py
+++ b/python/composio/tools/local/filetool/actions/write.py
@@ -1,4 +1,4 @@
-from typing import Dict
+import typing as t
 
 from pydantic import Field
 
@@ -13,7 +13,7 @@ from composio.tools.local.filetool.actions.base_action import (
 class WriteRequest(BaseFileRequest):
     """Request to write a file."""
 
-    file_path: str = Field(
+    file_path: t.Optional[str] = Field(
         default=None,
         description=(
             "The path to the file that will be edited. If not provided, "
@@ -48,7 +48,7 @@ class Write(LocalAction[WriteRequest, WriteResponse]):
     """
 
     @include_cwd  # type: ignore
-    def execute(self, request: WriteRequest, metadata: Dict) -> WriteResponse:
+    def execute(self, request: WriteRequest, metadata: t.Dict) -> WriteResponse:
         try:
             filemanager = self.filemanagers.get(request.file_manager_id)
             (

--- a/python/composio/tools/local/filetool/actions/write.py
+++ b/python/composio/tools/local/filetool/actions/write.py
@@ -51,11 +51,13 @@ class Write(LocalAction[WriteRequest, WriteResponse]):
     def execute(self, request: WriteRequest, metadata: t.Dict) -> WriteResponse:
         try:
             filemanager = self.filemanagers.get(request.file_manager_id)
-            (
+            file = (
                 filemanager.recent
                 if request.file_path is None
                 else filemanager.open(path=request.file_path)
-            ).write(text=request.text)
+            )
+            assert file is not None
+            file.write(text=request.text)
             return WriteResponse()
         except FileNotFoundError as e:
             return WriteResponse(error=f"File not found: {str(e)}")

--- a/python/composio/tools/local/greptile/actions/codequery.py
+++ b/python/composio/tools/local/greptile/actions/codequery.py
@@ -1,6 +1,6 @@
 import json
 import os
-from typing import Dict
+import typing as t
 
 import requests
 from pydantic import BaseModel, Field
@@ -23,7 +23,7 @@ class CodeQueryRequest(BaseModel):
         ...,
         description="The question to ask the mentor",
     )
-    sessionId: str = Field(
+    sessionId: t.Optional[str] = Field(
         default=None,
         description="The session id of the conversation, if you want to continue the conversation with the same mentor. defaults to None",
         examples=["1234567890"],
@@ -43,7 +43,7 @@ class CodeQueryRequest(BaseModel):
         description="The timeout for the Greptile API request. Default is 20 seconds",
         examples=[60, 120, 180],
     )
-    branch: str = Field(
+    branch: t.Optional[str] = Field(
         default=None,
         description="The branch to ask the question about. Default is master, if not specified. Example: main, master",
         examples=["master", "main"],
@@ -67,7 +67,7 @@ class CodeQuery(LocalAction[CodeQueryRequest, CodeQueryResponse]):
 
     _tags = ["code_query"]
 
-    def execute(self, request: CodeQueryRequest, metadata: Dict) -> CodeQueryResponse:
+    def execute(self, request: CodeQueryRequest, metadata: t.Dict) -> CodeQueryResponse:
         token = metadata.get("greptile_token", os.getenv("GREPTILE_TOKEN"))
         if token is None:
             self.logger.error("GREPTILE_TOKEN is not set")

--- a/python/composio/tools/local/shelltool/shell_exec/actions/spawn.py
+++ b/python/composio/tools/local/shelltool/shell_exec/actions/spawn.py
@@ -4,7 +4,7 @@ import shutil
 import subprocess
 import tempfile
 from pathlib import Path
-from typing import Dict
+import typing as t
 
 from pydantic import BaseModel, Field
 
@@ -26,7 +26,7 @@ class SpawnRequest(BaseModel):
             "yarn start",
         ],
     )
-    working_dir: str = Field(
+    working_dir: t.Optional[str] = Field(
         None,
         description=(
             "Directory where this command should be executed, "
@@ -68,7 +68,7 @@ class SpawnProcess(LocalAction[SpawnRequest, SpawnResponse]):
 
     _tags = ["workspace", "shell"]
 
-    def execute(self, request: SpawnRequest, metadata: Dict) -> SpawnResponse:
+    def execute(self, request: SpawnRequest, metadata: t.Dict) -> SpawnResponse:
         """Execute a shell command."""
         _cmd, *args = request.cmd.split(" ")
         cmd = shutil.which(cmd=_cmd)  # type: ignore

--- a/python/composio/tools/local/shelltool/shell_exec/actions/spawn.py
+++ b/python/composio/tools/local/shelltool/shell_exec/actions/spawn.py
@@ -3,8 +3,8 @@
 import shutil
 import subprocess
 import tempfile
-from pathlib import Path
 import typing as t
+from pathlib import Path
 
 from pydantic import BaseModel, Field
 

--- a/python/composio/utils/shared.py
+++ b/python/composio/utils/shared.py
@@ -7,6 +7,7 @@ import uuid
 from inspect import Parameter
 
 from pydantic import BaseModel, Field, create_model
+from pydantic_core import PydanticUndefined
 from pydantic.fields import FieldInfo
 
 from composio.utils.logging import get as get_logger
@@ -133,7 +134,7 @@ def json_schema_to_pydantic_field(
                 json_schema=json_schema,
             ),
         ),
-        Field(
+        Field(  # type: ignore
             description=description,
             examples=examples,
             default=(

--- a/python/composio/utils/shared.py
+++ b/python/composio/utils/shared.py
@@ -7,7 +7,6 @@ import uuid
 from inspect import Parameter
 
 from pydantic import BaseModel, Field, create_model
-from pydantic_core import PydanticUndefined
 from pydantic.fields import FieldInfo
 
 from composio.utils.logging import get as get_logger

--- a/python/setup.py
+++ b/python/setup.py
@@ -38,7 +38,7 @@ core_requirements = [
     "jsonschema>=4.21.1,<5",
     "sentry-sdk>=2.0.0",
     "pysher==1.0.8",
-    "pydantic>=2.6.4,<2.10",
+    "pydantic>=2.6.4",
     "importlib-metadata>=4.8.1",
     "jsonref>=1.1.0",
     "inflection>=0.5.1",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Unpin `pydantic` version in `setup.py` and update type annotations across multiple files for compatibility with newer versions.
> 
>   - **Setup**:
>     - Unpin `pydantic` version in `setup.py`, changing from `pydantic>=2.6.4,<2.10` to `pydantic>=2.6.4`.
>   - **Type Annotations**:
>     - Update type annotations to use `t.Optional` for fields that can be `None` in `api.py`, `bash.py`, and `text_editor.py`.
>     - Similar updates in 50+ other files to ensure compatibility with newer `pydantic` versions.
>   - **Misc**:
>     - Minor import changes in `shared.py` to use `PydanticUndefined`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for aa9bf8b0734d8ae32906faefc38fd7ffa391fed0. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->