### PR TITLE
chore: run pyupgrade

### DIFF
--- a/python/composio/cli/add.py
+++ b/python/composio/cli/add.py
@@ -286,7 +286,7 @@ def _handle_oauth(
 
     if scopes is not None:
         if auth_config.get("scopes") is not None:
-            scopes = tuple(set([*auth_config["scopes"].split(","), *scopes]))
+            scopes = tuple({*auth_config["scopes"].split(","), *scopes})
         auth_config["scopes"] = ",".join(scopes)
 
     connection = entity.initiate_connection(

--- a/python/composio/client/enums/_app.py
+++ b/python/composio/client/enums/_app.py
@@ -305,5 +305,5 @@ class App(_AnnotatedEnum[AppData], path=APPS_CACHE):
                 continue
             if len(tags) == 0:
                 yield action
-            if any((tag in action.tags for tag in tags)):
+            if any(tag in action.tags for tag in tags):
                 yield action

--- a/python/composio/core/cls/catch_all_exceptions.py
+++ b/python/composio/core/cls/catch_all_exceptions.py
@@ -14,7 +14,7 @@ def CatchAllExceptions(cls, handler):
 
             try:
                 # pylint: disable=super-with-arguments
-                return super(Cls, self).make_context(
+                return super().make_context(
                     info_name, args, parent=parent, **extra
                 )
                 # pylint: enable=super-with-arguments
@@ -32,7 +32,7 @@ def CatchAllExceptions(cls, handler):
         def invoke(self, ctx):
             try:
                 # pylint: disable=super-with-arguments
-                return super(Cls, self).invoke(ctx)
+                return super().invoke(ctx)
                 # pylint: enable=super-with-arguments
             except Exception as exc:
                 # call the handler

--- a/python/composio/core/cls/catch_all_exceptions.py
+++ b/python/composio/core/cls/catch_all_exceptions.py
@@ -14,9 +14,7 @@ def CatchAllExceptions(cls, handler):
 
             try:
                 # pylint: disable=super-with-arguments
-                return super().make_context(
-                    info_name, args, parent=parent, **extra
-                )
+                return super().make_context(info_name, args, parent=parent, **extra)
                 # pylint: enable=super-with-arguments
             except Exception as exc:
                 # call the handler

--- a/python/composio/server/api.py
+++ b/python/composio/server/api.py
@@ -259,8 +259,7 @@ def create_app() -> FastAPI:
         if len(request.dependencies) > 0:
             process = subprocess.run(
                 args=["pip", "install", *request.dependencies],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+                capture_output=True,
             )
             if process.returncode != 0:
                 raise RuntimeError(

--- a/python/composio/tools/base/abs.py
+++ b/python/composio/tools/base/abs.py
@@ -126,9 +126,9 @@ class _Request(t.Generic[ModelType]):
                     ] += f" Note: choose value only from following options - {prop['enum']}"
 
             if "anyOf" in prop:
-                typedef, *_ = [
+                typedef, *_ = (
                     td for td in prop["anyOf"] if td.get("type", "null") != "null"
-                ]
+                )
                 prop["type"] = typedef["type"]
 
         request["properties"] = properties

--- a/python/composio/tools/env/docker/scripts/__init__.py
+++ b/python/composio/tools/env/docker/scripts/__init__.py
@@ -121,13 +121,11 @@ def get_shell_env() -> ShellEnvironment:
             filetype = "utility"
         else:
             raise ValueError(
-                (
                     f"Non-shell script file {file} does not start with "
                     "shebang.\nEither add a shebang (#!) or change the "
                     "file extension to .sh if you want to source it.\n"
                     "You can override this behavior by adding an underscore "
                     "to the file name (e.g. _utils.py)."
-                )
             )
         formatted.append(
             CommandFile(

--- a/python/composio/tools/env/docker/scripts/__init__.py
+++ b/python/composio/tools/env/docker/scripts/__init__.py
@@ -121,11 +121,11 @@ def get_shell_env() -> ShellEnvironment:
             filetype = "utility"
         else:
             raise ValueError(
-                    f"Non-shell script file {file} does not start with "
-                    "shebang.\nEither add a shebang (#!) or change the "
-                    "file extension to .sh if you want to source it.\n"
-                    "You can override this behavior by adding an underscore "
-                    "to the file name (e.g. _utils.py)."
+                f"Non-shell script file {file} does not start with "
+                "shebang.\nEither add a shebang (#!) or change the "
+                "file extension to .sh if you want to source it.\n"
+                "You can override this behavior by adding an underscore "
+                "to the file name (e.g. _utils.py)."
             )
         formatted.append(
             CommandFile(

--- a/python/composio/tools/env/filemanager/file.py
+++ b/python/composio/tools/env/filemanager/file.py
@@ -408,14 +408,14 @@ class File(WithLogger):
                 return file_name, line_number, column_number, error_code, error_message
             return "", "", "", "", error
 
-        before_errors = set(
+        before_errors = {
             (error_code, error_message)
             for _, _, _, error_code, error_message in map(parse_lint_error, before)
-        )
-        after_errors = set(
+        }
+        after_errors = {
             (error_code, error_message)
             for _, _, _, error_code, error_message in map(parse_lint_error, after)
-        )
+        }
 
         new_errors = after_errors - before_errors
         return [

--- a/python/composio/tools/env/host/shell.py
+++ b/python/composio/tools/env/host/shell.py
@@ -97,8 +97,7 @@ class HostShell(Shell):
 
         output = subprocess.run(  # pylint: disable=subprocess-run-check
             ["ps", "-e"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
         ).stdout.decode()
         return all(_cmd.lstrip().rstrip() not in output for _cmd in cmd.split("&&"))
 
@@ -210,12 +209,12 @@ class SSHShell(Shell):
     def _send(self, buffer: str, stdin: t.Optional[str] = None) -> None:
         """Send buffer to shell."""
         if stdin is None:
-            self.channel.sendall(f"{buffer}\n".encode("utf-8"))
+            self.channel.sendall(f"{buffer}\n".encode())
             time.sleep(0.05)
             return
 
-        self.channel.send(f"{buffer}\n".encode("utf-8"))
-        self.channel.sendall(f"{stdin}\n".encode("utf-8"))
+        self.channel.send(f"{buffer}\n".encode())
+        self.channel.sendall(f"{stdin}\n".encode())
         time.sleep(0.05)
 
     def _read(self) -> str:

--- a/python/composio/tools/local/anthropic_computer_use/actions/computer.py
+++ b/python/composio/tools/local/anthropic_computer_use/actions/computer.py
@@ -335,8 +335,7 @@ class Computer(LocalAction[ComputerRequest, ComputerResponse]):
         """Run shell command and return result with optional screenshot."""
         proc = subprocess.run(
             shlex.split(command),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             check=True,
         )
         base64_image = None

--- a/python/composio/tools/local/base/utils/grep_utils.py
+++ b/python/composio/tools/local/base/utils/grep_utils.py
@@ -36,7 +36,7 @@ def get_files_excluding_gitignore(root_path, no_gitignore=False, file_patterns=N
     import pathspec  # TODO: simplify import  # pylint: disable=C0415
 
     if gitignore:
-        with open(gitignore, "r", encoding="utf-8") as f:
+        with open(gitignore, encoding="utf-8") as f:
             spec = pathspec.PathSpec.from_lines("gitwildmatch", f)
     else:
         spec = pathspec.PathSpec.from_lines("gitwildmatch", [])
@@ -103,7 +103,7 @@ def grep_util(
 def process_file(filename, pattern, encoding, ignore_case, color, verbose, line_number):
     file_results = []
     try:
-        with open(filename, "r", encoding=encoding) as f:
+        with open(filename, encoding=encoding) as f:
             content = f.read()
     except UnicodeDecodeError:
         return file_results

--- a/python/composio/tools/local/base/utils/queries/__init__.py
+++ b/python/composio/tools/local/base/utils/queries/__init__.py
@@ -8,7 +8,7 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 c_tags_query_path = os.path.join(current_dir, "tree-sitter-c-tags.scm")
 
 # Read the contents of the .scm file
-with open(c_tags_query_path, "r", encoding="utf-8") as f:
+with open(c_tags_query_path, encoding="utf-8") as f:
     c_tags_query = f.read()
 
 # Export the query

--- a/python/composio/tools/local/base/utils/repomap.py
+++ b/python/composio/tools/local/base/utils/repomap.py
@@ -250,7 +250,7 @@ class RepoMap:
         query_scm = scm_fname.read_text()
 
         # Parse code
-        with open(fname, "r", encoding="utf-8") as file:
+        with open(fname, encoding="utf-8") as file:
             code = file.read().strip()
 
         if not code:
@@ -396,7 +396,7 @@ class RepoMap:
 
         # If no references, use definitions as references
         if not references:
-            references = dict((k, list(v)) for k, v in defines.items())
+            references = {k: list(v) for k, v in defines.items()}
 
         idents = set(defines.keys()).intersection(set(references.keys()))
 
@@ -449,11 +449,11 @@ class RepoMap:
             if fname not in chat_rel_fnames:
                 ranked_tags.extend(definitions.get((fname, ident), []))
 
-        rel_other_fnames_without_tags = set(
+        rel_other_fnames_without_tags = {
             get_rel_fname(self.root, fname) for fname in other_fnames
-        )
+        }
 
-        fnames_already_included = set(rt[0] for rt in ranked_tags)
+        fnames_already_included = {rt[0] for rt in ranked_tags}
 
         # Add remaining files to ranked tags
         top_rank = sorted(
@@ -536,7 +536,7 @@ class RepoMap:
             return self.tree_cache[key]
 
         # use python to read the file
-        with open(abs_fname, "r", encoding="utf-8") as file:
+        with open(abs_fname, encoding="utf-8") as file:
             code = file.read()
         if not code.endswith("\n"):
             code += "\n"

--- a/python/composio/tools/local/codeanalysis/actions/base_action.py
+++ b/python/composio/tools/local/codeanalysis/actions/base_action.py
@@ -23,7 +23,7 @@ class BaseCodeAnalysisAction:
                 f"FQDN cache file not found: {self.fqdn_cache_file}"
             )
 
-        with open(self.fqdn_cache_file, "r", encoding="utf-8") as f:
+        with open(self.fqdn_cache_file, encoding="utf-8") as f:
             self.all_fqdns_df = json.load(f)
 
         self.fqdn_index = {

--- a/python/composio/tools/local/codeanalysis/actions/create_codemap.py
+++ b/python/composio/tools/local/codeanalysis/actions/create_codemap.py
@@ -154,7 +154,7 @@ class CreateCodeMap(LocalAction[CreateCodeMapRequest, CreateCodeMapResponse]):
         for file in tqdm(
             python_files, total=len(python_files), desc="Processing files"
         ):
-            with open(file, "r", encoding="utf-8") as f:
+            with open(file, encoding="utf-8") as f:
                 file_content = f.read()
 
             chunk, metadata, id = chunking.chunk(
@@ -308,5 +308,5 @@ class CreateCodeMap(LocalAction[CreateCodeMapRequest, CreateCodeMapResponse]):
         status_file = Path(repo_path) / ".indexing_status.json"
         if not status_file.exists():
             return {"status": Status.NOT_STARTED}
-        with open(status_file, "r", encoding="utf-8") as f:
+        with open(status_file, encoding="utf-8") as f:
             return json.load(f)

--- a/python/composio/tools/local/codeanalysis/lsp_helper.py
+++ b/python/composio/tools/local/codeanalysis/lsp_helper.py
@@ -464,7 +464,7 @@ def fetch_relevant_elem(
             f"No elements found for FQDN '{fqdn_use}' with expected type '{expected_type}'"
         )
 
-    if len(set(name.type for name in all_names)) != 1:
+    if len({name.type for name in all_names}) != 1:
         raise ValueError(f"Multiple types found for FQDN '{fqdn_use}'")
 
     entity_class_map = {"class": ClassObj, "function": FunctionObj}
@@ -475,7 +475,7 @@ def fetch_relevant_elem(
     original_contents = {}
     for name in all_names:
         file_path = os.path.normpath(os.path.abspath(name.module_path))
-        with open(file_path, "r", encoding="utf-8") as fp:
+        with open(file_path, encoding="utf-8") as fp:
             original_contents[file_path] = fp.read()
 
     entity_objs = [
@@ -634,7 +634,7 @@ class ClassObj(EntityObj):
         """
         new_script_obj = fetch_script_obj_for_file_in_repo(global_path, repo_dir)
 
-        with open(global_path, "r") as fd:
+        with open(global_path) as fd:
             all_lines = fd.readlines()
 
         line_id = len(all_lines)
@@ -677,7 +677,7 @@ class ClassObj(EntityObj):
             _class_obj.goto_obj
         )
 
-        with open(_class_obj.global_path, "r", encoding="utf-8") as fp:
+        with open(_class_obj.global_path, encoding="utf-8") as fp:
             _original_file_content = fp.read()
 
         _class_completion_file_new_content = (
@@ -978,7 +978,7 @@ class FunctionObj(EntityObj):
             self.parent_class_defined_location,
         ) = self.find_parent_details(self.goto_obj)
 
-        with open(self.global_path, "r") as file:
+        with open(self.global_path) as file:
             source_lines = file.readlines()
         func_body_starting_line = self.goto_obj.get_definition_start_position()[0]
         self.func_decorators = self.get_decorators(
@@ -1143,7 +1143,7 @@ def fetch_node_definition_body(
         if file_path is None:
             file_path = str(node_get_obj.module_path)
 
-        with open(file_path, "r") as file:
+        with open(file_path) as file:
             lines = file.readlines()
 
         extracted_content_lines = lines[start_line : end_line + 1]  # noqa: E203

--- a/python/composio/tools/local/codeanalysis/tool_utils.py
+++ b/python/composio/tools/local/codeanalysis/tool_utils.py
@@ -71,7 +71,7 @@ def find_python_files(
         readable_files = []
         for file in python_files:
             try:
-                with open(file, "r", encoding="utf-8") as f:
+                with open(file, encoding="utf-8") as f:
                     f.read()
                 readable_files.append(file)
             except Exception:

--- a/python/composio/tools/local/codeanalysis/tree_sitter_related.py
+++ b/python/composio/tools/local/codeanalysis/tree_sitter_related.py
@@ -126,7 +126,7 @@ def fetch_nodes_of_type(file_path: str, types_allowed: List[str]) -> List[Dict]:
         List[Dict]: A list of dictionaries containing node details.
     """
     parser = get_parser("python")
-    with open(file_path, "r", encoding="utf-8") as file:
+    with open(file_path, encoding="utf-8") as file:
         test_code_str = file.read()
 
     root_node = fetch_tree(parser, test_code_str).root_node
@@ -192,7 +192,7 @@ def fetch_class_and_function_nodes_defn_identifiers(file_path: str) -> List[Dict
     )
 
     # Read the code from the file
-    with open(file_path, "r", encoding="utf-8") as file:
+    with open(file_path, encoding="utf-8") as file:
         file_body = file.read()
 
     # Find the identifier nodes in the children of the definition nodes
@@ -227,7 +227,7 @@ def find_left_side_identifiers_of_assignments(file_path: str) -> List[Dict]:
     wanted_definition_nodes = fetch_nodes_of_type(file_path, ["assignment"])
 
     # Read the code from the file
-    with open(file_path, "r", encoding="utf-8") as file:
+    with open(file_path, encoding="utf-8") as file:
         file_body = file.read()
 
     identifier_nodes = []

--- a/python/composio/tools/local/filetool/actions/git_repo_tree.py
+++ b/python/composio/tools/local/filetool/actions/git_repo_tree.py
@@ -74,9 +74,9 @@ class GitRepoTree(LocalAction[GitRepoTreeRequest, GitRepoTreeResponse]):
             )
 
         try:
-            with open(tree_file_path, "r", encoding="utf-8") as f:
+            with open(tree_file_path, encoding="utf-8") as f:
                 tree_content = f.read()
-        except IOError as e:
+        except OSError as e:
             return GitRepoTreeResponse(
                 success=False, message=f"Error reading git_repo_tree.txt: {str(e)}"
             )

--- a/python/composio/tools/local/filetool/actions/grep.py
+++ b/python/composio/tools/local/filetool/actions/grep.py
@@ -110,5 +110,5 @@ class SearchWord(LocalAction[SearchWordRequest, SearchWordResponse]):
             )
         except PermissionError as e:
             return SearchWordResponse(error=f"Permission denied: {str(e)}")
-        except IOError as e:
+        except OSError as e:
             return SearchWordResponse(error=f"Error reading files: {str(e)}")

--- a/python/composio/tools/local/filetool/actions/open.py
+++ b/python/composio/tools/local/filetool/actions/open.py
@@ -68,5 +68,5 @@ class OpenFile(LocalAction[OpenFileRequest, OpenFileResponse]):
             raise ExecutionFailed(f"Cannot open a directory: {str(e)}") from e
         except PermissionError as e:
             raise ExecutionFailed(f"Permission denied: {str(e)}") from e
-        except IOError as e:
+        except OSError as e:
             raise ExecutionFailed(f"Error reading file: {str(e)}") from e


### PR DESCRIPTION
Ran `pyupgrade ./python/composio --py38-plus`
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Modernize Python codebase to Python 3.8+ using `pyupgrade`, updating syntax and simplifying code across multiple files.
> 
>   - **Syntax Modernization**:
>     - Replaced `set([...])` with `{...}` in `add.py`, `file.py`, and `lsp_helper.py`.
>     - Replaced `super(ClassName, self)` with `super()` in `catch_all_exceptions.py`.
>     - Replaced `subprocess.PIPE` with `capture_output=True` in `api.py`, `shell.py`, and `computer.py`.
>     - Removed `encoding="utf-8"` from `open()` calls where default is sufficient in `grep_utils.py`, `queries/__init__.py`, and `repomap.py`.
>     - Replaced `IOError` with `OSError` in `git_repo_tree.py` and `grep.py`.
>   - **Miscellaneous**:
>     - Minor refactoring and simplification of list comprehensions and tuple unpacking in `abs.py` and `lsp_helper.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for ee758933e307aefdef81c794e082f215d37899c2. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->