### PR TITLE
fix: propagate default values from trigger config

### DIFF
--- a/python/composio/cli/triggers.py
+++ b/python/composio/cli/triggers.py
@@ -159,6 +159,15 @@ def _enable_trigger(context: Context, name: str) -> None:
 
     config = {}
     properties = trigger.config.properties or {}
+    # Populate default values for optional fields
+    config.update(
+        {
+            field: field_props.default
+            for field, field_props in properties.items()
+            if field_props.default is not None
+        }
+    )
+
     for field in trigger.config.required or []:
         field_props = properties[field]
         field_title = field_props.title or field

--- a/python/composio/client/collections.py
+++ b/python/composio/client/collections.py
@@ -386,7 +386,7 @@ class TriggerConfigPropertyModel(BaseModel):
 
     description: str
     title: str
-    default: t.Any
+    default: t.Any = None
 
     type: t.Optional[str] = None
 

--- a/python/composio/client/collections.py
+++ b/python/composio/client/collections.py
@@ -386,6 +386,7 @@ class TriggerConfigPropertyModel(BaseModel):
 
     description: str
     title: str
+    default: t.Any
 
     type: t.Optional[str] = None
 


### PR DESCRIPTION
the `TriggerModel`'s that are defined for triggers in the backend have `properties`, and each property may have a `default` field which we were ignoring in the SDK. Now we store that in the `TriggerConfig` object, and also add the default values into the config that we send in the request to activate a new trigger.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Propagate default values from trigger configurations to ensure correct trigger activation in the SDK.
> 
>   - **Behavior**:
>     - Populate default values for optional fields in `config` in `_enable_trigger()` in `triggers.py`.
>     - Include default values in trigger activation request.
>   - **Models**:
>     - Add `default` field to `TriggerConfigPropertyModel` in `collections.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for d119692a7947ff2808320795fdd47cf96f14ea88. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->