### PR TITLE
fix: removed crewai plugin compatibility upper limit

### DIFF
--- a/python/plugins/crew_ai/setup.py
+++ b/python/plugins/crew_ai/setup.py
@@ -24,7 +24,7 @@ setup(
     python_requires=">=3.9,<4",
     install_requires=[
         "composio_langchain>=0.5.50,<=0.5.52-rc.2",
-        "crewai>=0.51.0,<=0.75.0",
+        "crewai>=0.51.0",
     ],
     include_package_data=True,
 )


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removed upper version limit for `crewai` in `setup.py` to allow versions `>=0.51.0`.
> 
>   - **Dependencies**:
>     - Removed upper version limit for `crewai` in `install_requires` in `setup.py`. Now allows versions `>=0.51.0`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 839397d4f7c10ad76e952e03a6a1b3044b4d02ef. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->