### PR TITLE
ci: ensure older tests get cancelled on new commit

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -17,6 +17,9 @@ jobs:
         os: [ubuntu-latest]
         python-version: ["3.10"]
     timeout-minutes: 10
+    concurrency:
+      group: 'test:common:${{ github.ref }}'
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -42,6 +45,9 @@ jobs:
         os: [ubuntu-latest]
         python-version: ["3.10"]
     timeout-minutes: 30
+    concurrency:
+      group: 'test:common:${{ github.ref }}'
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -77,6 +83,9 @@ jobs:
         os: [ubuntu-latest]
         python-version: ["3.9", "3.10", "3.11"]
     timeout-minutes: 20
+    concurrency:
+      group: 'test:common:${{ github.ref }}'
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: ["3.10"]
     timeout-minutes: 10
     concurrency:
-      group: 'test:common:${{ github.ref }}'
+      group: 'test:lock-check:${{ github.ref }}'
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -46,7 +46,7 @@ jobs:
         python-version: ["3.10"]
     timeout-minutes: 30
     concurrency:
-      group: 'test:common:${{ github.ref }}'
+      group: 'test:linter_checks:${{ github.ref }}'
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -84,7 +84,7 @@ jobs:
         python-version: ["3.9", "3.10", "3.11"]
     timeout-minutes: 20
     concurrency:
-      group: 'test:common:${{ github.ref }}'
+      group: 'test:common:${{ matrix.python-version }}:${{ github.ref }}'
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add concurrency control to GitHub Actions workflows to cancel older runs on new commits in `common.yml`.
> 
>   - **Concurrency Control**:
>     - Added `concurrency` to `lock_check`, `linter_checks`, and `test` jobs in `common.yml`.
>     - Uses `group: 'test:common:${{ github.ref }}'` to group jobs by branch.
>     - `cancel-in-progress: true` ensures older runs are cancelled on new commits.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 0fb65d6833c232b1d9354bda4ef76f31207ed509. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->