### PR TITLE
fix: `COMPOSIO_DISABLE_VERSION_CHECK` not being respected

### DIFF
--- a/python/composio/utils/warnings.py
+++ b/python/composio/utils/warnings.py
@@ -24,17 +24,14 @@ def _fetch_latest_version():
 
 
 def create_latest_version_warning_hook(version: str):
+    if os.environ.get("COMPOSIO_DISABLE_VERSION_CHECK", "false").lower() != "false":
+        return lambda: None
+
     version_thread = threading.Thread(target=_fetch_latest_version, daemon=True)
     version_thread.start()
 
     def latest_version_warning() -> None:
         try:
-            if (
-                os.environ.get("COMPOSIO_DISABLE_VERSION_CHECK", "false").lower()
-                == "true"
-            ):
-                return
-
             version_thread.join(timeout=0.1)
             if _latest_version is None:
                 return


### PR DESCRIPTION
Ensures we don't spawn the background thread to check version if the disable environment flag is set.

Resolves #960 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes issue where `COMPOSIO_DISABLE_VERSION_CHECK` was not preventing version check thread from starting.
> 
>   - **Behavior**:
>     - Prevents version check thread from starting in `create_latest_version_warning_hook()` if `COMPOSIO_DISABLE_VERSION_CHECK` is set to true.
>     - Ensures no version check is performed when the environment variable is set, resolving #960.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 7ef45f947039adbe1e3569d8cd9017e99b8ef0ff. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->