### PR TITLE
feat: Added remove integration support, added 10mb buffer size while testing JS example

### DIFF
--- a/js/src/cli/apps.ts
+++ b/js/src/cli/apps.ts
@@ -35,7 +35,7 @@ export default class AppsCommand {
     enabled: boolean;
   }): Promise<void> {
     getOpenAPIClient();
-    const onlyShowEnabledApps = options.enabled;
+    const onlyShowEnabledApps = options?.enabled;
     try {
       const { data } = await client.apps.getApps({});
       console.log("Here are the apps you have access to:");

--- a/js/src/cli/integrations.ts
+++ b/js/src/cli/integrations.ts
@@ -16,11 +16,15 @@ export default class ConnectionsCommand {
 
     command
       .description("List all integrations you have created or connected")
-      .option("-a, --active", "Show only active integrations").option('-r, --remove <id>', 'Remove an integration with the given id')
+      .option("-a, --active", "Show only active integrations")
+      .option("-r, --remove <id>", "Remove an integration with the given id")
       .action(this.handleAction.bind(this));
   }
 
-  private async handleAction(options: { active: boolean, remove: string }): Promise<void> {
+  private async handleAction(options: {
+    active: boolean;
+    remove: string;
+  }): Promise<void> {
     getOpenAPIClient();
     const { data, error } = await client.appConnector.listAllConnectors({
       query: options.active ? { status: "ACTIVE" } : {},
@@ -31,15 +35,17 @@ export default class ConnectionsCommand {
       console.log(chalk.red((error as any).message));
       return;
     }
-    const removeIntegrationId = options.remove || '';
+    const removeIntegrationId = options.remove || "";
 
-    if(removeIntegrationId){
-      console.log(chalk.yellow(`Removing integration with id ${removeIntegrationId}`));
+    if (removeIntegrationId) {
+      console.log(
+        chalk.yellow(`Removing integration with id ${removeIntegrationId}`)
+      );
 
       const { error } = await client.appConnector.deleteConnector({
         path: {
-          integrationId: removeIntegrationId
-        }
+          integrationId: removeIntegrationId,
+        },
       });
 
       if (error) {
@@ -47,7 +53,11 @@ export default class ConnectionsCommand {
         return;
       }
 
-      console.log(chalk.green(`Integration with id ${removeIntegrationId} removed successfully!`));
+      console.log(
+        chalk.green(
+          `Integration with id ${removeIntegrationId} removed successfully!`
+        )
+      );
       return;
     }
 
@@ -66,4 +76,3 @@ export default class ConnectionsCommand {
     }
   }
 }
-

--- a/js/src/cli/integrations.ts
+++ b/js/src/cli/integrations.ts
@@ -16,11 +16,11 @@ export default class ConnectionsCommand {
 
     command
       .description("List all integrations you have created or connected")
-      .option("-a, --active", "Show only active integrations")
+      .option("-a, --active", "Show only active integrations").option('-r, --remove <id>', 'Remove an integration with the given id')
       .action(this.handleAction.bind(this));
   }
 
-  private async handleAction(options: { active: boolean }): Promise<void> {
+  private async handleAction(options: { active: boolean, remove: string }): Promise<void> {
     getOpenAPIClient();
     const { data, error } = await client.appConnector.listAllConnectors({
       query: options.active ? { status: "ACTIVE" } : {},
@@ -29,6 +29,25 @@ export default class ConnectionsCommand {
 
     if (error) {
       console.log(chalk.red((error as any).message));
+      return;
+    }
+    const removeIntegrationId = options.remove || '';
+
+    if(removeIntegrationId){
+      console.log(chalk.yellow(`Removing integration with id ${removeIntegrationId}`));
+
+      const { error } = await client.appConnector.deleteConnector({
+        path: {
+          integrationId: removeIntegrationId
+        }
+      });
+
+      if (error) {
+        console.log(chalk.red((error as any).message));
+        return;
+      }
+
+      console.log(chalk.green(`Integration with id ${removeIntegrationId} removed successfully!`));
       return;
     }
 
@@ -47,3 +66,4 @@ export default class ConnectionsCommand {
     }
   }
 }
+

--- a/js/tests/test_examples.test.js
+++ b/js/tests/test_examples.test.js
@@ -44,11 +44,10 @@ describe("E2E Tests for plugin demos and examples", () => {
         env: { ...process.env },
         cwd: example.cwd || process.cwd(),
       };
-
       const { stdout, stderr } = await execFileAsync(
         "node",
         [example.file],
-        options
+        { ...options, maxBuffer: 10 * 1024 * 1024 }
       );
       const output = example.match.type === "stdout" ? stdout : stderr;
       for (const match of example.match.values) {

--- a/js/tests/test_examples.test.js
+++ b/js/tests/test_examples.test.js
@@ -44,11 +44,10 @@ describe("E2E Tests for plugin demos and examples", () => {
         env: { ...process.env },
         cwd: example.cwd || process.cwd(),
       };
-      const { stdout, stderr } = await execFileAsync(
-        "node",
-        [example.file],
-        { ...options, maxBuffer: 10 * 1024 * 1024 }
-      );
+      const { stdout, stderr } = await execFileAsync("node", [example.file], {
+        ...options,
+        maxBuffer: 10 * 1024 * 1024,
+      });
       const output = example.match.type === "stdout" ? stdout : stderr;
       for (const match of example.match.values) {
         expect(output).toContain(match);


### PR DESCRIPTION
1. Added 10mb buffer size while running JS examples
2. Added `--remove` support in integration CLI command
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `--remove <id>` option to `integrations` CLI and increase buffer size for JS tests.
> 
>   - **CLI Enhancements**:
>     - Added `--remove <id>` option to `integrations` command in `integrations.ts` to remove integrations by ID.
>   - **Testing**:
>     - Increased `maxBuffer` size to 10MB in `test_examples.test.js` for JS example tests to handle larger outputs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 3b3fec12d1a19bdfdba292ffc3dde96e7b969968. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->