### PR TITLE
feat: move from async and use http or https module

### DIFF
--- a/js/src/sdk/utils/errors/index.ts
+++ b/js/src/sdk/utils/errors/index.ts
@@ -22,7 +22,7 @@ export async function logError(payload: ErrorPayload) {
   }
   try {
     const isBrowser = typeof window !== "undefined";
-    const reportingPayload = await generateReportingPayload(payload);
+    const reportingPayload = generateReportingPayload(payload);
     const reqPayload = {
       data: reportingPayload,
       url: `${TELEMETRY_URL}/api/sdk_metrics/error`,
@@ -43,7 +43,7 @@ export async function logError(payload: ErrorPayload) {
   }
 }
 
-async function generateReportingPayload(payload: ErrorPayload) {
+function generateReportingPayload(payload: ErrorPayload) {
   const { apiKey, baseURL, composioVersion, frameworkRuntime, source } =
     ComposioSDKContext;
   const {


### PR DESCRIPTION
- Don't move to async loop because process closes
- use http/https module based on protocol
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Switch from async loop to synchronous HTTP/HTTPS module usage in `sendProcessReq` and update related functions.
> 
>   - **Behavior**:
>     - `sendProcessReq` in `external.ts` now uses `http` or `https` modules based on URL protocol instead of async loop.
>     - `generateReportingPayload` in `index.ts` is no longer async, aligning with synchronous HTTP request handling.
>   - **Functions**:
>     - `sendProcessReq` and `sendBrowserReq` in `external.ts` updated to handle HTTP requests synchronously.
>   - **Misc**:
>     - Removed async keyword from `generateReportingPayload` in `index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 005ede860653b2ca4bebc518749deb5edd2cc4b9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->