### PR TITLE
fix: don't use deprecated api in toolset

### DIFF
--- a/python/composio/client/__init__.py
+++ b/python/composio/client/__init__.py
@@ -251,6 +251,17 @@ class Entity:
         :param session_id: ID of the current workspace session
         :return: Dictionary containing execution result
         """
+        self._execute(action, params, connected_account_id, session_id, text, auth)
+
+    def _execute(
+        self,
+        action: Action,
+        params: t.Dict,
+        connected_account_id: t.Optional[str] = None,
+        session_id: t.Optional[str] = None,
+        text: t.Optional[str] = None,
+        auth: t.Optional[CustomAuthObject] = None,
+    ) -> t.Dict:
         if action.no_auth:
             return self.client.actions.execute(
                 action=action,

--- a/python/composio/client/__init__.py
+++ b/python/composio/client/__init__.py
@@ -251,7 +251,7 @@ class Entity:
         :param session_id: ID of the current workspace session
         :return: Dictionary containing execution result
         """
-        self._execute(action, params, connected_account_id, session_id, text, auth)
+        return self._execute(action, params, connected_account_id, session_id, text, auth)
 
     def _execute(
         self,

--- a/python/composio/client/__init__.py
+++ b/python/composio/client/__init__.py
@@ -251,7 +251,9 @@ class Entity:
         :param session_id: ID of the current workspace session
         :return: Dictionary containing execution result
         """
-        return self._execute(action, params, connected_account_id, session_id, text, auth)
+        return self._execute(
+            action, params, connected_account_id, session_id, text, auth
+        )
 
     def _execute(
         self,

--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -489,7 +489,7 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
         if auth is None:
             self.check_connected_account(action=action)
 
-        output = self.client.get_entity(id=entity_id).execute(
+        output = self.client.get_entity(id=entity_id)._execute(
             action=action,
             params=params,
             connected_account_id=connected_account_id,

--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -489,7 +489,8 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
         if auth is None:
             self.check_connected_account(action=action)
 
-        output = self.client.get_entity(id=entity_id)._execute(
+        entity = self.client.get_entity(id=entity_id)
+        output = entity._execute(  # pylint: disable=protected-access
             action=action,
             params=params,
             connected_account_id=connected_account_id,


### PR DESCRIPTION
`Entity.execute` is marked as deprecated for the users and will only be used internally in the SDK.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Replace deprecated `Entity.execute` with internal `_execute` method in `toolset.py` and update `Entity` class in `__init__.py`.
> 
>   - **Behavior**:
>     - Replace deprecated `Entity.execute` with `Entity._execute` in `_execute_remote()` in `toolset.py`.
>   - **Functions**:
>     - Add `_execute()` method in `Entity` class in `__init__.py` to handle execution internally.
>   - **Misc**:
>     - Mark `Entity.execute` as deprecated for external use in `__init__.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 76b009b3025fb09c8c5c4fe7661c03c150e93515. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->