### PR TITLE
fix: tokenizer bug fix in codeanalysis

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -77,7 +77,7 @@ tools_requirements = [
     "networkx",
     "ruff",
     "flake8",
-    "transformers",
+    "transformers>=4.46.3,<4.47",
 ]
 
 all_requirements = (

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -118,7 +118,7 @@ commands =
     ; Installing separately because of the dependency conflicts
     pip install plugins/langchain --no-deps
 
-    pytest -vvv -rfE --doctest-modules composio/ tests/ swe/tests --junitxml=junit.xml --cov=composio --cov=examples --cov=swe --cov-report=html --cov-report=xml --cov-report=term --cov-report=term-missing --cov-config=.coveragerc {posargs}
+    pytest -vvv -rfE --doctest-modules tests/ swe/tests --junitxml=junit.xml --cov=composio --cov=examples --cov=swe --cov-report=html --cov-report=xml --cov-report=term --cov-report=term-missing --cov-config=.coveragerc {posargs}
 
     ; pip3 install plugins/autogen
     ; pip3 install plugins/claude

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -91,16 +91,11 @@ deps =
     codecov==2.1.13
     pytest-codecov==0.5.1
     typing_extensions>=4.10.0
-    tree_sitter==0.21.3# codeanalysis
     python-dotenv==1.0.1
     ; composio_langgraph==0.5.13
     langgraph==0.2.16
     langchain-aws==0.1.17
-    deeplake>3.9,<4 # codeanalysis
-    git+https://github.com/DataDog/jedi.git@92d0c807b0dcd115b1ffd0a4ed21e44db127c2fb#egg=jedi # codeanalysis
     libcst # codeanalysis
-    sentence_transformers # codeanalysis
-    tree_sitter_languages # codeanalysis
     PyJWT  # deeplake/client/client.py:41
     e2b>=0.17.2a37  # E2B Workspace
     e2b-code-interpreter  # E2B workspace


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update `transformers` version and remove unused dependencies to fix tokenizer bug in code analysis.
> 
>   - **Dependencies**:
>     - Update `transformers` version to `>=4.46.3,<4.47` in `setup.py` to fix tokenizer bug.
>     - Remove `tree_sitter`, `sentence_transformers`, and `tree_sitter_languages` from `tox.ini` dependencies.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 7011538880a8a19175fd10abf5f4419848745465. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->