### PR TITLE
docs: fix flaky processor example

### DIFF
--- a/docs/patterns/tools/use-tools/processing-actions.mdx
+++ b/docs/patterns/tools/use-tools/processing-actions.mdx
@@ -50,12 +50,13 @@ Coming Soon
 </CodeGroup>
 </Step>
 <Step title="Define a Custom Function to Modify Schema">
-This function will be used to modify the schema of the `LINEAR_CREATE_LINEAR_ISSUE` action, here we are modifying the description for the parameters `project_id` & `team_id` to not required, later in the program we will pass these values as inputs to the action. The technical term for this is **Action-level Schema Processing**.
+This function will be used to modify the schema of the `LINEAR_CREATE_LINEAR_ISSUE` action, we get rid of the parameters `project_id` and `team_id`, later in the program we will pass these values as inputs to the action manually. The technical term for this is **Action-level Schema Processing**.
 <CodeGroup>
 ```python Python
 def linear_schema_processor(schema: dict) -> dict:
-    schema['project_id']['description'] = schema['project_id']['description'].replace('is required', 'not required')
-    schema['team_id']['description'] = schema['team_id']['description'].replace('is required', 'not required')
+    # This way the agent doesn't expect a project and team ID to run the action
+    del schema['project_id']
+    del schema['team_id']
     return schema
 ```
 ```javascript JavaScript


### PR DESCRIPTION
This docs example was flaky before, by making sure the agent cannot see the non-required fields we ensure it never fails on schema check.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `linear_schema_processor()` in `processing-actions.mdx` to remove `project_id` and `team_id` from the schema for stability.
> 
>   - **Behavior**:
>     - Modify `linear_schema_processor()` in `processing-actions.mdx` to delete `project_id` and `team_id` from the schema instead of marking them as not required.
>   - **Documentation**:
>     - Update description in `processing-actions.mdx` to reflect the removal of `project_id` and `team_id` parameters from the schema.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for cc268629cc558dcb3a2d14315fcf9a29a2a94874. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->