### PR TITLE
fix: add response payload of config params & trigger events

### DIFF
--- a/docs/patterns/triggers/triggers.mdx
+++ b/docs/patterns/triggers/triggers.mdx
@@ -10,8 +10,14 @@ You can enable a trigger by specifying the trigger enum, available on the [dashb
 <Tabs>
 <Tab title="CLI">
 <Steps>
+<Step title="Get Config Parameters">
+View the required configuration parameters for enabling a trigger by using the show command. For example, this will display what parameters are needed for Github's new star event trigger:
+```Bash
+composio triggers show GITHUB_STAR_ADDED_EVENT
+```
+</Step>
 <Step title="Enable Trigger">
-You need to pass the trigger enum to enable a trigger.
+You need to pass the trigger enum to enable a trigger & you'll be prompted to enter the required parameters.
 ```Bash
 composio triggers enable GITHUB_STAR_ADDED_EVENT
 ``` 
@@ -38,6 +44,24 @@ toolset = ComposioToolSet()
 
 trigger_schema = toolset.get_trigger("GITHUB_STAR_ADDED_EVENT")
 print(trigger_schema.config)
+```
+
+Response:
+```json
+properties={
+  'owner': TriggerConfigPropertyModel(description='Owner of the repository',
+  title='Owner',
+  type='string'),
+  'repo': TriggerConfigPropertyModel(description='Repository name',
+  title='Repo',
+  type='string')
+}
+title='WebhookConfigSchema'
+type='object'
+required=[
+  'owner',
+  'repo'
+]
 ```
 </Step>
 <Step title="Enable Trigger">
@@ -157,4 +181,16 @@ toolset.triggers.subscribe(
 ```
 </Tab>
 </Tabs>
+Trigger event payload when the repository composio is starred:
+```json
+payload={
+  'action': 'created',
+  'starred_at': '2024-12-11T15:31:26Z',
+  'repository_id': 861033276,
+  'repository_name': 'composio',
+  'repository_url': 'https://github.com/composioHQ/composio/',
+  'starred_by': 'abhishekpatil4',
+  'triggerName': 'GITHUB_STAR_ADDED_EVENT'
+}
+```
 <Tip>To learn how to configure and use your own webhooks for listening to triggers, visit our [Webhooks Guide](/patterns/triggers/webhooks).</Tip>


### PR DESCRIPTION
Fixes: ENG-2852
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updates `triggers.mdx` to include configuration parameter retrieval and trigger event payload examples for GitHub star events.
> 
>   - **Documentation**:
>     - Adds a step to retrieve configuration parameters for triggers using `composio triggers show` in `triggers.mdx`.
>     - Updates the enable trigger step to include a prompt for required parameters in `triggers.mdx`.
>     - Adds example JSON response for configuration parameters in Python section of `triggers.mdx`.
>     - Adds example JSON payload for GitHub star event trigger in `triggers.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 4d3312fdf146557a021629e49a88d4590c78b628. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->