### PR TITLE
fix: `str(ENUM)` should just stringify the slug

### DIFF
--- a/python/composio/client/enums/enum.py
+++ b/python/composio/client/enums/enum.py
@@ -77,6 +77,9 @@ class Enum(t.Generic[DataT]):
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}.{self.slug}"
 
+    def __str__(self) -> str:
+        return self.slug
+
     def __eq__(self, other: object) -> bool:
         if isinstance(other, Enum):
             return self.slug == other.slug

--- a/python/tests/test_client/test_enum.py
+++ b/python/tests/test_client/test_enum.py
@@ -117,6 +117,7 @@ def test_tag_enum() -> None:
 def test_app_enum() -> None:
     """Test `App` enum."""
     assert App.GITHUB == "GITHUB"
+    assert str(App.GITHUB) == "GITHUB"
     assert not App.GITHUB.is_local
     assert App("OUTLOOK") == App.OUTLOOK
     assert App("gmail") == App.GMAIL

--- a/python/tests/test_tools/test_toolset.py
+++ b/python/tests/test_tools/test_toolset.py
@@ -120,7 +120,7 @@ class TestConnectedAccountProvider:
         with pytest.raises(
             ComposioSDKError,
             match=re.escape(
-                f"Invalid connected accounts found: [('App.GITHUB', '{self.connected_account}')]"
+                f"Invalid connected accounts found: [('GITHUB', '{self.connected_account}')]"
             ),
         ):
             ComposioToolSet(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `__str__` method to `Enum` class to return `slug`, with corresponding test.
> 
>   - **Behavior**:
>     - Add `__str__` method to `Enum` class in `enum.py` to return `self.slug`.
>   - **Tests**:
>     - Add test in `test_enum.py` to assert `str(App.GITHUB) == "GITHUB"`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 477cd811dfe99b251cf1f628a1417821f5c97b1e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->