### PR TITLE
fix: Execute cli parity

### DIFF
--- a/js/src/cli/execute.ts
+++ b/js/src/cli/execute.ts
@@ -1,0 +1,45 @@
+import { Command } from "commander";
+import client from "../sdk/client/client";
+import chalk from "chalk";
+import { getOpenAPIClient } from "../sdk/utils/config";
+
+export default class ExecuteCommand {
+  private program: Command;
+  constructor(program: Command) {
+    this.program = program;
+    this.program
+      .command("execute <action>")
+      .description("Execute a Composio action")
+      .option("-p, --params <params>", "Action parameters as a JSON string")
+      .action(this.handleAction.bind(this));
+  }
+  private async handleAction(
+    action: string,
+    options: {
+      params?: string;
+    }
+  ): Promise<void> {
+    getOpenAPIClient();
+    const { params } = options;
+    try {
+      const res = await client.actionsV2.executeActionV2({
+        body: params ? JSON.parse(params) : {},
+        path: {
+          actionId: action,
+        },
+      });
+      console.log(
+        chalk.green(
+          "Action executed successfully",
+          JSON.stringify(res?.data?.data, null, 2)
+        )
+      );
+    } catch (error) {
+      console.log(error);
+      console.log(
+        chalk.red(`Error executing action: ${(error as Error).message}`)
+      );
+      return;
+    }
+  }
+}

--- a/js/src/cli/execute.ts
+++ b/js/src/cli/execute.ts
@@ -35,7 +35,6 @@ export default class ExecuteCommand {
         )
       );
     } catch (error) {
-      console.log(error);
       console.log(
         chalk.red(`Error executing action: ${(error as Error).message}`)
       );

--- a/js/src/cli/index.ts
+++ b/js/src/cli/index.ts
@@ -13,6 +13,7 @@ import logout from "./logout";
 import triggers from "./triggers";
 import whoami from "./whoami";
 import actions from "./actions";
+import execute from './execute'
 
 // SDK Imports
 import { TELEMETRY_EVENTS } from "../sdk/utils/telemetry/events";
@@ -30,6 +31,7 @@ new integrations(program);
 new triggers(program);
 new add(program);
 new actions(program);
+new execute(program)
 
 function formatLine(content: string): string {
   return `${content}`;

--- a/js/src/cli/index.ts
+++ b/js/src/cli/index.ts
@@ -13,7 +13,7 @@ import logout from "./logout";
 import triggers from "./triggers";
 import whoami from "./whoami";
 import actions from "./actions";
-import execute from './execute'
+import execute from "./execute";
 
 // SDK Imports
 import { TELEMETRY_EVENTS } from "../sdk/utils/telemetry/events";
@@ -31,7 +31,7 @@ new integrations(program);
 new triggers(program);
 new add(program);
 new actions(program);
-new execute(program)
+new execute(program);
 
 function formatLine(content: string): string {
   return `${content}`;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `execute` command to Composio CLI for executing actions with optional JSON parameters, integrated in `index.ts`.
> 
>   - **New Feature**:
>     - Adds `execute` command to Composio CLI in `execute.ts` for executing actions with optional JSON parameters.
>   - **Integration**:
>     - Integrates `execute` command into CLI in `index.ts` by adding it to the command list.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for dcbe461a4cae93395840056136741ad90d7fd2f6. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->