### PR TITLE
fix: remove chat w repo/docs

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -70,10 +70,6 @@
     {
       "name": "All Tools",
       "url": "https://composio.dev/tools"
-    },
-    {
-      "name": "Chat with Repo",
-      "url": "https://dub.composio.dev/composio-chat-with-repo"
     }
   ],
   "navigation": [


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove "Chat with Repo" link from `docs/mint.json`.
> 
>   - **Behavior**:
>     - Removed "Chat with Repo" link from `docs/mint.json`, which pointed to `https://dub.composio.dev/composio-chat-with-repo`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 0456a68ee6d2cf6c26e74f54dea4f2ba0f120228. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->