### PR TITLE
fix: Composio login command

### DIFF
--- a/js/src/env/docker/workspace.ts
+++ b/js/src/env/docker/workspace.ts
@@ -5,6 +5,7 @@ import type Docker from "dockerode";
 import type CliProgress from "cli-progress";
 import { IWorkspaceConfig, WorkspaceConfig } from "../config";
 import logger from "../../utils/logger";
+import { getComposioDir } from "../../sdk/utils/fileUtils";
 
 const ENV_COMPOSIO_DEV_MODE = "COMPOSIO_DEV_MODE";
 const ENV_COMPOSIO_SWE_AGENT = "COMPOSIO_SWE_AGENT";
@@ -96,7 +97,7 @@ export class DockerWorkspace extends RemoteWorkspace {
       const os = require("node:os");
 
       const COMPOSIO_PATH = path.resolve(__dirname, "../../../../python/");
-      const COMPOSIO_CACHE = path.join(os.homedir(), ".composio");
+      const COMPOSIO_CACHE = getComposioDir(false);
 
       volumeBindings.push(
         ...[

--- a/js/src/sdk/base.toolset.ts
+++ b/js/src/sdk/base.toolset.ts
@@ -62,7 +62,7 @@ const fileProcessor = ({
   const fileData = toolResponse.data.response_data.file;
   const { name, content } = fileData as { name: string; content: string };
   const file_name_prefix = `${action}_${Date.now()}`;
-  const filePath = saveFile(file_name_prefix, content);
+  const filePath = saveFile(file_name_prefix, content, true);
 
   // @ts-ignore
   delete toolResponse.data.response_data.file;

--- a/js/src/sdk/utils/cli.ts
+++ b/js/src/sdk/utils/cli.ts
@@ -13,5 +13,5 @@ export function setCliConfig(apiKey: string, baseUrl: string) {
     userData.base_url = baseUrl;
   }
 
-  saveFile(userDataPath(), userData);
+  saveFile(userDataPath(), JSON.stringify(userData));
 }

--- a/js/src/sdk/utils/config.ts
+++ b/js/src/sdk/utils/config.ts
@@ -23,7 +23,7 @@ declare module "axios" {
 
 // File path helpers
 export const userDataPath = () =>
-  path.join(os.homedir(), LOCAL_CACHE_DIRECTORY_NAME, USER_DATA_FILE_NAME);
+  path.join(os.homedir(), LOCAL_CACHE_DIRECTORY_NAME, 'files', USER_DATA_FILE_NAME);
 export const getUserDataJson = () => {
   try {
     const data = fs.readFileSync(userDataPath(), "utf8");

--- a/js/src/sdk/utils/config.ts
+++ b/js/src/sdk/utils/config.ts
@@ -23,7 +23,12 @@ declare module "axios" {
 
 // File path helpers
 export const userDataPath = () =>
-  path.join(os.homedir(), LOCAL_CACHE_DIRECTORY_NAME, 'files', USER_DATA_FILE_NAME);
+  path.join(
+    os.homedir(),
+    LOCAL_CACHE_DIRECTORY_NAME,
+    "files",
+    USER_DATA_FILE_NAME
+  );
 export const getUserDataJson = () => {
   try {
     const data = fs.readFileSync(userDataPath(), "utf8");

--- a/js/src/sdk/utils/config.ts
+++ b/js/src/sdk/utils/config.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
 import {
-  LOCAL_CACHE_DIRECTORY_NAME,
+  COMPOSIO_DIR,
   USER_DATA_FILE_NAME,
   DEFAULT_BASE_URL,
 } from "./constants";
@@ -23,12 +23,8 @@ declare module "axios" {
 
 // File path helpers
 export const userDataPath = () =>
-  path.join(
-    os.homedir(),
-    LOCAL_CACHE_DIRECTORY_NAME,
-    "files",
-    USER_DATA_FILE_NAME
-  );
+  path.join(os.homedir(), COMPOSIO_DIR, USER_DATA_FILE_NAME);
+
 export const getUserDataJson = () => {
   try {
     const data = fs.readFileSync(userDataPath(), "utf8");

--- a/js/src/sdk/utils/constants.ts
+++ b/js/src/sdk/utils/constants.ts
@@ -1,6 +1,7 @@
 // Constants
-export const LOCAL_CACHE_DIRECTORY_NAME = ".composio";
+export const COMPOSIO_DIR = ".composio";
 export const USER_DATA_FILE_NAME = "user_data.json";
+export const TEMP_FILES_DIRECTORY_NAME = "files";
 export const DEFAULT_BASE_URL = "https://backend.composio.dev";
 
 export const TELEMETRY_URL = "https://app.composio.dev";

--- a/js/src/sdk/utils/fileUtils.ts
+++ b/js/src/sdk/utils/fileUtils.ts
@@ -9,7 +9,7 @@ import { COMPOSIO_DIR, TEMP_FILES_DIRECTORY_NAME } from "./constants";
  * @param createDirIfNotExists - Whether to create the directory if it doesn't exist.
  * @returns The path to the Composio directory.
  */
-export const getComposioDir = (createDirIfNotExists: boolean = true) => {
+export const getComposioDir = (createDirIfNotExists: boolean = false) => {
   const composioDir = path.join(os.homedir(), COMPOSIO_DIR);
   if (createDirIfNotExists && !fs.existsSync(composioDir)) {
     fs.mkdirSync(composioDir, { recursive: true });
@@ -23,7 +23,7 @@ export const getComposioDir = (createDirIfNotExists: boolean = true) => {
  * @returns The path to the Composio temporary files directory.
  */
 export const getComposioTempFilesDir = (
-  createDirIfNotExists: boolean = true
+  createDirIfNotExists: boolean = false
 ) => {
   const composioFilesDir = path.join(
     os.homedir(),

--- a/js/src/sdk/utils/fileUtils.ts
+++ b/js/src/sdk/utils/fileUtils.ts
@@ -2,25 +2,55 @@ import * as path from "path";
 import * as os from "os";
 
 import * as fs from "fs";
+import { COMPOSIO_DIR, TEMP_FILES_DIRECTORY_NAME } from "./constants";
 
-export const getComposioDir = () => {
-  const composioDir = path.join(os.homedir(), ".composio");
-  if (!fs.existsSync(composioDir)) {
+/**
+ * Gets the Composio directory.
+ * @param createDirIfNotExists - Whether to create the directory if it doesn't exist.
+ * @returns The path to the Composio directory.
+ */
+export const getComposioDir = (createDirIfNotExists: boolean = true) => {
+  const composioDir = path.join(os.homedir(), COMPOSIO_DIR);
+  if (createDirIfNotExists && !fs.existsSync(composioDir)) {
     fs.mkdirSync(composioDir, { recursive: true });
   }
   return composioDir;
 };
 
-export const getComposioFilesDir = () => {
-  const composioFilesDir = path.join(os.homedir(), ".composio", "files");
-  if (!fs.existsSync(composioFilesDir)) {
+/**
+ * Gets the Composio temporary files directory.
+ * @param createDirIfNotExists - Whether to create the directory if it doesn't exist.
+ * @returns The path to the Composio temporary files directory.
+ */
+export const getComposioTempFilesDir = (
+  createDirIfNotExists: boolean = true
+) => {
+  const composioFilesDir = path.join(
+    os.homedir(),
+    COMPOSIO_DIR,
+    TEMP_FILES_DIRECTORY_NAME
+  );
+  if (createDirIfNotExists && !fs.existsSync(composioFilesDir)) {
     fs.mkdirSync(composioFilesDir, { recursive: true });
   }
   return composioFilesDir;
 };
 
-export const saveFile = (file: string, content: string) => {
-  const composioFilesDir = getComposioFilesDir();
+/**
+ * Saves a file to the Composio directory.
+ * @param file - The name of the file to save.
+ * @param content - The content of the file to save. Should be a string.
+ * @param isTempFile - Whether the file is a temporary file.
+ * @returns The path to the saved file.
+ */
+export const saveFile = (
+  file: string,
+  content: string,
+  isTempFile: boolean = false
+) => {
+  const composioFilesDir = isTempFile
+    ? getComposioTempFilesDir(true)
+    : getComposioDir(true);
   const filePath = path.join(composioFilesDir, path.basename(file));
   fs.writeFileSync(filePath, content);
 

--- a/js/src/sdk/utils/fileUtils.ts
+++ b/js/src/sdk/utils/fileUtils.ts
@@ -21,7 +21,7 @@ export const getComposioFilesDir = () => {
 
 export const saveFile = (file: string, content: string) => {
   const composioFilesDir = getComposioFilesDir();
-  const filePath = `${composioFilesDir}/${file}`;
+  const filePath = path.join(composioFilesDir, path.basename(file));
   fs.writeFileSync(filePath, content);
 
   return filePath;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes Composio CLI login command by stringifying user data and correcting file paths in `cli.ts`, `config.ts`, and `fileUtils.ts`.
> 
>   - **Behavior**:
>     - Fix `setCliConfig()` in `cli.ts` to stringify `userData` before saving.
>     - Update `userDataPath()` in `config.ts` to include 'files' directory in path.
>     - Modify `saveFile()` in `fileUtils.ts` to use `path.join()` for file path construction.
>   - **Functions**:
>     - `getComposioDir()` and `getComposioTempFilesDir()` in `fileUtils.ts` now optionally create directories if they don't exist.
>     - `saveFile()` in `fileUtils.ts` now accepts a `isTempFile` parameter to determine the directory for saving files.
>   - **Constants**:
>     - Rename `LOCAL_CACHE_DIRECTORY_NAME` to `COMPOSIO_DIR` in `constants.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for b2cbbdc8ad49cb8ba3c524b422ce7a04dde697ad. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->