### PR TITLE
ci: run every 12 hours, and tag me on failure

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -1,5 +1,8 @@
 name: main_workflow
 on:
+  # Run a cron job every 12 hours
+  schedule:
+    - cron: '0 */12 * * *'
   push:
     branches:
       - master

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -104,6 +104,19 @@ jobs:
         uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Slack Notification on Failure
+        if: ${{ failure() && github.ref == 'refs/heads/master' && !contains(github.event.head_commit.message, 'release') && !contains(github.event.head_commit.message, 'Release') && !inputs.dont_notify }}
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_TECH_WEBHOOK }}
+          SLACK_TITLE: "Example Tests Failed"
+          SLACK_MSG_AUTHOR: ${{ inputs.author || github.actor }}
+          SLACK_MESSAGE: "<@viraj> <@tushar sadhwani> ${{ inputs.commit_message || github.event.head_commit.message }}"
+          SLACK_LINK_NAMES: "true"
+          SLACK_COLOR: "failure"
+          SLACK_USERNAME: "GitHub Actions Bot"
+          SLACK_ICON_EMOJI: ":x:"
+          SLACK_FOOTER: "Failed Example Tests | GitHub Actions"
 
   swe:
     defaults:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,6 +1,9 @@
 name: Example Tests
 
 on:
+  # Run a cron job every 12 hours
+  schedule:
+    - cron: '0 */12 * * *'
   workflow_call:
     inputs:
       working-directory:
@@ -102,7 +105,7 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_TECH_WEBHOOK }}
           SLACK_TITLE: "Example Tests Failed"
           SLACK_MSG_AUTHOR: ${{ inputs.author || github.actor }}
-          SLACK_MESSAGE: "<@viraj> <@kaavee> ${{ inputs.commit_message || github.event.head_commit.message }}"
+          SLACK_MESSAGE: "<@viraj> <@tushar sadhwani> ${{ inputs.commit_message || github.event.head_commit.message }}"
           SLACK_LINK_NAMES: "true"
           SLACK_COLOR: "failure"
           SLACK_USERNAME: "GitHub Actions Bot"


### PR DESCRIPTION
# 🔍 Review Summary 
 ### Purpose
- Introduce automated tests through scheduled GitHub Actions workflows.
- Improve communication of test failures by modifying Slack notification settings.

### Changes

#### New Feature
- **Automated Testing**: 
  - Added a cron job in the GitHub Actions workflow to automate test execution every 12 hours in both `common.yml` and `examples.yml` files.

#### Enhancement
- **Slack Notifications**:
  - Updated Slack notification settings to tag specific users when tests fail, excluding release commits, in both `common.yml` and `examples.yml` files.

### Impact
- **CI/CD Pipeline Reliability**:
  - Enhances the reliability and responsiveness of the CI/CD pipeline by automating test runs.
- **Improved Communication**:
  - Enhances communication on failures for prompt resolution by notifying specific users. 



<details><summary>Original Description</summary>

No existing description found

</details>