### PR TITLE
ci: run example tests on master branch

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -104,6 +104,19 @@ jobs:
         uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Slack Notification on Failure
+        if: ${{ failure() && github.ref == 'refs/heads/master' && !contains(github.event.head_commit.message, 'release') && !contains(github.event.head_commit.message, 'Release') && !inputs.dont_notify }}
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_TECH_WEBHOOK }}
+          SLACK_TITLE: "Example Tests Failed"
+          SLACK_MSG_AUTHOR: ${{ inputs.author || github.actor }}
+          SLACK_MESSAGE: "<@viraj> <@tushar> ${{ inputs.commit_message || github.event.head_commit.message }}"
+          SLACK_LINK_NAMES: "true"
+          SLACK_COLOR: "failure"
+          SLACK_USERNAME: "GitHub Actions Bot"
+          SLACK_ICON_EMOJI: ":x:"
+          SLACK_FOOTER: "Failed Example Tests | GitHub Actions"
 
   swe:
     defaults:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -102,7 +102,7 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_TECH_WEBHOOK }}
           SLACK_TITLE: "Example Tests Failed"
           SLACK_MSG_AUTHOR: ${{ inputs.author || github.actor }}
-          SLACK_MESSAGE: "<@viraj> <@kaavee> ${{ inputs.commit_message || github.event.head_commit.message }}"
+          SLACK_MESSAGE: "<@viraj> <@tushar> ${{ inputs.commit_message || github.event.head_commit.message }}"
           SLACK_LINK_NAMES: "true"
           SLACK_COLOR: "failure"
           SLACK_USERNAME: "GitHub Actions Bot"

--- a/.github/workflows/run_examples.yml
+++ b/.github/workflows/run_examples.yml
@@ -1,6 +1,9 @@
 name: Run Examples Tests
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - master
   pull_request:
     paths:
       - 'python/**'


### PR DESCRIPTION
# 🔍 Review Summary 
 ### Purpose
The primary aim of these updates is to enhance the CI/CD pipeline by integrating a feature that triggers example tests on the master branch and informs team members via Slack notifications when any test fails.

### Changes

- **New Feature**
  - Integrated Slack notifications to alert specific team members when example tests fail on the master branch.

- **Enhancement**
  - Improved the CI/CD pipeline by ensuring trigger conditions for running example tests include pushes to the master branch.

- **Refactor**
  - Updated information in Slack messages to notify different team members upon test failures.

### Impact
These changes are expected to improve the overall efficiency of the development process. The integration of Slack notifications will ensure the right members are notified promptly about failed tests, enabling quicker resolution. Additionally, executing example tests on the master branch will regularly validate the stability of the branch. 



<details><summary>Original Description</summary>

No existing description found

</details>