### PR TITLE
fix: limit action name chars

### DIFF
--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -135,12 +135,14 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
 
     _runtime: str = "composio"
     _description_char_limit: int = 1024
+    _action_name_char_limit: t.Optional[int] = None
     _log_ingester_client: t.Optional[LogIngester] = None
 
     def __init_subclass__(
         cls,
         runtime: t.Optional[str] = None,
         description_char_limit: t.Optional[int] = None,
+        action_name_char_limit: t.Optional[int] = None,
     ) -> None:
         if runtime is None:
             warnings.warn(
@@ -153,6 +155,7 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
                 f"description_char_limit is not set on {cls.__name__}, using 1024 as default"
             )
         cls._description_char_limit = description_char_limit or 1024
+        cls._action_name_char_limit = action_name_char_limit
 
     def __init__(
         self,
@@ -983,6 +986,8 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
             action=Action(action_item.name.upper()),
             properties=action_item.parameters.properties,
         )
+        if self._action_name_char_limit is not None:
+            action_item.name = action_item.name[: self._action_name_char_limit]
         return action_item
 
     def create_trigger_listener(self, timeout: float = 15.0) -> TriggerSubscription:

--- a/python/plugins/langchain/composio_langchain/toolset.py
+++ b/python/plugins/langchain/composio_langchain/toolset.py
@@ -29,6 +29,7 @@ class ComposioToolSet(
     BaseComposioToolSet,
     runtime="langchain",
     description_char_limit=1024,
+    action_name_char_limit=64,
 ):
     """
     Composio toolset for Langchain framework.

--- a/python/tests/test_example.py
+++ b/python/tests/test_example.py
@@ -143,7 +143,8 @@ EXAMPLES = {
         "file": EXAMPLES_PATH
         / "quickstarters"
         / "sql_agent"
-        / "sql_agent_plotter_crewai" / "run_issue.py",
+        / "sql_agent_plotter_crewai"
+        / "run_issue.py",
         "match": {
             "type": "stdout",
             "values": ["composio_output/CODEINTERPRETER_GET_FILE_CMD_default_"],

--- a/python/tests/test_tools/test_toolset.py
+++ b/python/tests/test_tools/test_toolset.py
@@ -4,6 +4,7 @@ Test composio toolset.
 
 import logging
 import re
+import typing as t
 from unittest import mock
 
 import pytest
@@ -328,3 +329,64 @@ def test_execute_action_param_serialization() -> None:
         text=None,
         session_id=mock.ANY,
     )
+
+
+class TestSubclassInit:
+
+    def test_runtime(self):
+
+        class SomeToolsetExtention(ComposioToolSet):
+            pass
+
+        assert (
+            SomeToolsetExtention._runtime  # pylint: disable=protected-access
+            == "composio"
+        )
+
+        class SomeOtherToolsetExtention(ComposioToolSet, runtime="some_toolset"):
+            pass
+
+        assert (
+            SomeOtherToolsetExtention._runtime  # pylint: disable=protected-access
+            == "some_toolset"
+        )
+
+    def test_description_char_limit(self) -> None:
+
+        char_limit = 512
+        (schema,) = ComposioToolSet().get_action_schemas(
+            actions=[
+                Action.FILETOOL_GIT_CLONE,
+            ]
+        )
+        assert len(t.cast(str, schema.description)) > char_limit
+
+        class SomeToolsetExtention(ComposioToolSet, description_char_limit=char_limit):
+            pass
+
+        (schema,) = SomeToolsetExtention().get_action_schemas(
+            actions=[
+                Action.FILETOOL_GIT_CLONE,
+            ]
+        )
+        assert len(t.cast(str, schema.description)) == char_limit
+
+    def test_action_name_char_limit(self) -> None:
+
+        char_limit = 12
+        (schema,) = ComposioToolSet().get_action_schemas(
+            actions=[
+                Action.FILETOOL_GIT_CLONE,
+            ]
+        )
+        assert len(t.cast(str, schema.name)) > char_limit
+
+        class SomeToolsetExtention(ComposioToolSet, action_name_char_limit=char_limit):
+            pass
+
+        (schema,) = SomeToolsetExtention().get_action_schemas(
+            actions=[
+                Action.FILETOOL_GIT_CLONE,
+            ]
+        )
+        assert len(t.cast(str, schema.name)) == char_limit


### PR DESCRIPTION
# 🔍 Review Summary 
 ### Release Note

**Purpose**:
- Enhance the Composio toolset by introducing a character limit feature for action names.

**Changes**:
- **New Feature**: Added a character limit for action names to prevent exceeding specified lengths.
- **Enhancement**: Optimized initialization to support the new character limit feature.
- **Test**: Updated test suite to verify correct initialization and enforcement of character limits.
- **Style**: Improved test file path formatting for better readability.

**Impact**:
- Streamlines user interactions, ensuring action names are concise, enhancing readability, reliability, and ease of use. 



<details><summary>Original Description</summary>

This PR updates base toolset to allow limiting number of characters for action name in a schema

fixes: ENG-2917
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds character limit for action names in `ComposioToolSet`, with default set in Langchain integration and tests added.
> 
>   - **Behavior**:
>     - Adds `_action_name_char_limit` to `ComposioToolSet` in `toolset.py` to limit action name length.
>     - Truncates action names in `_process_schema()` if limit is set.
>   - **Langchain Integration**:
>     - Sets default `action_name_char_limit` to 64 in `composio_langchain/toolset.py`.
>   - **Tests**:
>     - Adds `test_action_name_char_limit()` in `test_toolset.py` to verify action name truncation.
>     - Updates `TestSubclassInit` to include action name limit tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 3eb8a683d2de0697cb7b275470a6c08ef0321eb7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

</details>