### PR TITLE
fix: don't initialize workspace for remote actions

### DIFF
--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -17,7 +17,6 @@ from functools import wraps
 from importlib.util import find_spec
 from pathlib import Path
 
-from flask import session
 import typing_extensions as te
 from pydantic import BaseModel
 

--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -252,6 +252,9 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
             "use `logging_level` argument or "
             "`COMPOSIO_LOGGING_LEVEL` change this"
         )
+
+        self.session_id = workspace_id or uuid.uuid4().hex
+
         self.entity_id = entity_id
         self.output_in_file = output_in_file
         self.output_dir = (
@@ -758,7 +761,7 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
                 entity_id=entity_id or self.entity_id,
                 connected_account_id=connected_account_id,
                 text=text,
-                session_id=uuid.uuid4().hex,
+                session_id=self.session_id,
             )
         )
         response = (

--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -10,12 +10,14 @@ import json
 import os
 import time
 import typing as t
+import uuid
 import warnings
 from datetime import datetime
 from functools import wraps
 from importlib.util import find_spec
 from pathlib import Path
 
+from flask import session
 import typing_extensions as te
 from pydantic import BaseModel
 
@@ -757,7 +759,7 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
                 entity_id=entity_id or self.entity_id,
                 connected_account_id=connected_account_id,
                 text=text,
-                session_id=self.workspace.id,
+                session_id=uuid.uuid4().hex,
             )
         )
         response = (


### PR DESCRIPTION
The self.workspace.id being used in _execute_remote() is likely a copy-paste error. We should be generating and sending a session ID instead.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes potential error in `_execute_remote()` by using a generated `session_id` instead of `self.workspace.id`.
> 
>   - **Behavior**:
>     - Fixes potential error in `_execute_remote()` by replacing `self.workspace.id` with `self.session_id`.
>     - Generates `session_id` using `uuid.uuid4().hex` if `workspace_id` is not provided in `__init__()`.
>   - **Imports**:
>     - Adds `import uuid` to support session ID generation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for aa4b6fe58df705bd5cf9ee1a4ce1f858c8fb9659. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->