### PR TITLE
fix: create local cache if running `App.all()` on a fresh install

### DIFF
--- a/python/composio/client/enums/enum.py
+++ b/python/composio/client/enums/enum.py
@@ -97,7 +97,9 @@ class Enum(t.Generic[DataT]):
         # If we try to fetch Actions.iter() with local caching disabled
         # for example, we'd get here.
         if not path.exists():
+            # pylint: disable=import-outside-toplevel
             from composio.client import Composio
+            # pylint: disable=import-outside-toplevel
             from composio.client.utils import check_cache_refresh
 
             check_cache_refresh(Composio.get_latest())

--- a/python/composio/client/enums/enum.py
+++ b/python/composio/client/enums/enum.py
@@ -99,6 +99,7 @@ class Enum(t.Generic[DataT]):
         if not path.exists():
             # pylint: disable=import-outside-toplevel
             from composio.client import Composio
+
             # pylint: disable=import-outside-toplevel
             from composio.client.utils import check_cache_refresh
 

--- a/python/composio/client/enums/enum.py
+++ b/python/composio/client/enums/enum.py
@@ -97,7 +97,12 @@ class Enum(t.Generic[DataT]):
         # If we try to fetch Actions.iter() with local caching disabled
         # for example, we'd get here.
         if not path.exists():
-            return
+            from composio.client import Composio
+            from composio.client.utils import check_cache_refresh
+
+            check_cache_refresh(Composio.get_latest())
+            if not path.exists():
+                return
 
         yield from os.listdir(path)
 

--- a/python/composio/client/utils.py
+++ b/python/composio/client/utils.py
@@ -220,7 +220,7 @@ def check_cache_refresh(client: Composio) -> None:
     """
     if NO_CACHE_REFRESH:
         return
-    
+
     if enums.base.ACTIONS_CACHE.exists():
         first_file = next(enums.base.ACTIONS_CACHE.iterdir(), None)
         if first_file is not None:

--- a/python/composio/client/utils.py
+++ b/python/composio/client/utils.py
@@ -1,4 +1,5 @@
 import json
+import os
 import typing as t
 
 from composio.client import Composio, enums
@@ -13,6 +14,8 @@ EnumModels = t.Union[AppModel, ActionModel, TriggerModel]
 
 
 logger = get_logger(__name__)
+
+NO_CACHE_REFRESH = os.getenv("COMPOSIO_NO_CACHE_REFRESH", "false") == "true"
 
 
 def filter_non_beta_items(items: t.Sequence[EnumModels]) -> t.List:
@@ -215,6 +218,9 @@ def check_cache_refresh(client: Composio) -> None:
     SDK version, and didn't come from the API. We need to start storing the data
     from the API and invalidate the cache if the data is not already stored.
     """
+    if NO_CACHE_REFRESH:
+        return
+    
     if enums.base.ACTIONS_CACHE.exists():
         first_file = next(enums.base.ACTIONS_CACHE.iterdir(), None)
         if first_file is not None:

--- a/python/composio/tools/local/sqltool/actions/sql_query.py
+++ b/python/composio/tools/local/sqltool/actions/sql_query.py
@@ -61,7 +61,7 @@ class SqlQuery(LocalAction[SqlQueryRequest, SqlQueryResponse]):
             raise ValueError(f"Error: Database file '{db_path}' does not exist.")
         with sqlite3.connect(db_path) as connection:
             cursor = connection.cursor()
-            cursor.execute(request.query, {})
+            cursor.execute(request.query)
             response_data = [list(row) for row in cursor.fetchall()]
             connection.commit()
         return SqlQueryResponse(

--- a/python/composio/tools/local/sqltool/actions/sql_query.py
+++ b/python/composio/tools/local/sqltool/actions/sql_query.py
@@ -1,8 +1,8 @@
 import sqlite3
-import sqlalchemy
 from pathlib import Path
 from typing import Dict
 
+import sqlalchemy
 from pydantic import BaseModel, Field
 
 from composio.tools.base.local import LocalAction

--- a/python/composio/tools/local/sqltool/actions/sql_query.py
+++ b/python/composio/tools/local/sqltool/actions/sql_query.py
@@ -45,8 +45,8 @@ class SqlQuery(LocalAction[SqlQueryRequest, SqlQueryResponse]):
         try:
             if self._is_sqlite_connection(request.connection_string):
                 return self._execute_sqlite(request)
-            else:
-                return self._execute_remote(request)
+
+            return self._execute_remote(request)
         except sqlite3.Error as e:
             raise ValueError(f"SQLite database error: {str(e)}") from e
         except sqlalchemy.exc.SQLAlchemyError as e:

--- a/python/composio/tools/local/sqltool/actions/sql_query.py
+++ b/python/composio/tools/local/sqltool/actions/sql_query.py
@@ -2,7 +2,6 @@ import sqlite3
 from pathlib import Path
 from typing import Dict
 
-import sqlalchemy
 from pydantic import BaseModel, Field
 
 from composio.tools.base.local import LocalAction
@@ -42,6 +41,8 @@ class SqlQuery(LocalAction[SqlQueryRequest, SqlQueryResponse]):
 
     def execute(self, request: SqlQueryRequest, metadata: Dict) -> SqlQueryResponse:
         """Execute SQL query for either SQLite or remote databases"""
+        import sqlalchemy.exc  # pylint: disable=import-outside-toplevel
+
         try:
             if self._is_sqlite_connection(request.connection_string):
                 return self._execute_sqlite(request)
@@ -71,6 +72,8 @@ class SqlQuery(LocalAction[SqlQueryRequest, SqlQueryResponse]):
 
     def _execute_remote(self, request: SqlQueryRequest) -> SqlQueryResponse:
         """Execute query for remote databases"""
+        import sqlalchemy  # pylint: disable=import-outside-toplevel
+
         engine = sqlalchemy.create_engine(
             request.connection_string,
             pool_size=5,

--- a/python/composio/tools/local/sqltool/tool.py
+++ b/python/composio/tools/local/sqltool/tool.py
@@ -12,6 +12,8 @@ class Sqltool(LocalTool, autoload=True):
 
     logo = "https://raw.githubusercontent.com/ComposioHQ/composio/master/python/docs/imgs/logos/sqltool.png"
 
+    requires = ["sqlalchemy>=2.0"]
+
     @classmethod
     def actions(cls) -> list[Type[LocalAction]]:
         return [SqlQuery]

--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -80,9 +80,6 @@ ParamType = t.TypeVar("ParamType")
 ProcessorType = te.Literal["pre", "post", "schema"]
 
 
-NO_CACHE_REFRESH = os.environ.get("COMPOSIO_NO_CACHE_REFRESH", "false") == "true"
-
-
 class IntegrationParams(te.TypedDict):
 
     integration_id: str
@@ -374,8 +371,7 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
                 base_url=self._base_url,
                 runtime=self._runtime,
             )
-            if not NO_CACHE_REFRESH:
-                check_cache_refresh(self._remote_client)
+            check_cache_refresh(self._remote_client)
 
         self._remote_client.local = self._local_client
         return self._remote_client

--- a/python/setup.py
+++ b/python/setup.py
@@ -43,7 +43,6 @@ core_requirements = [
     "jsonref>=1.1.0",
     "inflection>=0.5.1",
     "semver>=2.13.0",
-    "SQLAlchemy>=2.0.36",
     # CLI dependencies
     "click",
     "rich>=13.7.1,<14",

--- a/python/setup.py
+++ b/python/setup.py
@@ -43,6 +43,7 @@ core_requirements = [
     "jsonref>=1.1.0",
     "inflection>=0.5.1",
     "semver>=2.13.0",
+    "SQLAlchemy>=2.0.36",
     # CLI dependencies
     "click",
     "rich>=13.7.1,<14",

--- a/python/tests/test_tools/test_toolset.py
+++ b/python/tests/test_tools/test_toolset.py
@@ -46,7 +46,7 @@ def test_find_actions_by_tags() -> None:
         App.SLACK, App.GITHUB, tags=["important"]
     ):
         assert "important" in action.tags
-        assert action.app in ("github", "slack", "slackbot")
+        assert action.app in ("GITHUB", "SLACK", "SLACKBOT")
 
 
 def test_uninitialize_app() -> None:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Ensure cache creation on fresh installs by modifying `iter()` in `enum.py` and introducing `NO_CACHE_REFRESH` flag in `utils.py`.
> 
>   - **Behavior**:
>     - `iter()` in `enum.py` now calls `check_cache_refresh()` if cache path doesn't exist, ensuring cache creation on fresh installs.
>     - Introduces `NO_CACHE_REFRESH` flag in `utils.py` to skip cache refresh if set.
>   - **Code Cleanup**:
>     - Removes redundant `NO_CACHE_REFRESH` definition from `toolset.py`.
>   - **Dependencies**:
>     - Adds `SQLAlchemy>=2.0.36` to `setup.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for d35b1e8fc7467d02096971b217e9869180322f01. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->