### PR TITLE
feat: Support requesting `connected_account` in custom action

### DIFF
--- a/python/composio/tools/base/runtime.py
+++ b/python/composio/tools/base/runtime.py
@@ -253,7 +253,9 @@ def _parse_docstring(
     return header, params, returns
 
 
-def _get_connected_account(app: str, entity_id: str) -> t.Optional[ConnectedAccountModel]:
+def _get_connected_account(
+    app: str, entity_id: str
+) -> t.Optional[ConnectedAccountModel]:
     try:
         client = Composio.get_latest()
         connected_account = client.connected_accounts.get(
@@ -262,6 +264,7 @@ def _get_connected_account(app: str, entity_id: str) -> t.Optional[ConnectedAcco
         return connected_account
     except ComposioClientError:
         return None
+
 
 def _get_auth_params(app: str, entity_id: str) -> t.Optional[t.Dict]:
     try:

--- a/python/composio/tools/base/runtime.py
+++ b/python/composio/tools/base/runtime.py
@@ -9,7 +9,7 @@ import typing_extensions as te
 from pydantic import BaseModel, Field
 
 from composio import Composio
-from composio.client.collections import CustomAuthParameter
+from composio.client.collections import ConnectedAccountModel, CustomAuthParameter
 from composio.client.enums.base import ActionData, SentinalObject, add_runtime_action
 from composio.client.exceptions import ComposioClientError
 from composio.exceptions import ComposioSDKError
@@ -253,12 +253,23 @@ def _parse_docstring(
     return header, params, returns
 
 
+def _get_connected_account(app: str, entity_id: str) -> t.Optional[ConnectedAccountModel]:
+    try:
+        client = Composio.get_latest()
+        connected_account = client.connected_accounts.get(
+            connection_id=client.get_entity(entity_id).get_connection(app=app).id
+        )
+        return connected_account
+    except ComposioClientError:
+        return None
+
 def _get_auth_params(app: str, entity_id: str) -> t.Optional[t.Dict]:
     try:
         client = Composio.get_latest()
-        connection_params = client.connected_accounts.get(
+        connected_account = client.connected_accounts.get(
             connection_id=client.get_entity(entity_id).get_connection(app=app).id
-        ).connectionParams
+        )
+        connection_params = connected_account.connectionParams
         return {
             "headers": connection_params.headers,
             "base_url": connection_params.base_url,
@@ -303,7 +314,8 @@ def _build_executable_from_args(  # pylint: disable=too-many-statements
     }
 
     shell_argument = None
-    auth_params = False
+    auth_param = False
+    connected_account_param = False
     request_executor = False
     if "return" not in argspec.annotations:
         raise InvalidRuntimeAction(
@@ -316,7 +328,11 @@ def _build_executable_from_args(  # pylint: disable=too-many-statements
             continue
 
         if arg == "auth":
-            auth_params = True
+            auth_param = True
+            continue
+
+        if arg == "connected_account":
+            connected_account_param = True
             continue
 
         if arg == "execute_request":
@@ -376,7 +392,11 @@ def _build_executable_from_args(  # pylint: disable=too-many-statements
         if shell_argument is not None:
             kwargs[shell_argument] = metadata["workspace"].shells.recent
 
-        if auth_params > 0:
+        if connected_account_param:
+            kwargs["connected_account"] = (
+                _get_connected_account(app=app, entity_id=metadata["entity_id"]) or {}
+            )
+        if auth_param:
             kwargs["auth"] = (
                 _get_auth_params(app=app, entity_id=metadata["entity_id"]) or {}
             )


### PR DESCRIPTION
It can be used like this:

```python
from composio.client.collections import ConnectedAccountModel
from composio import ComposioToolSet, action

toolset = ComposioToolSet()


@action(toolname="gmail")
def get_gmail_access_token(connected_account: ConnectedAccountModel) -> str:
    """
    Get the access token for the user's Gmail account

    :return token: The access token for the user's Gmail account 
    """
    return connected_account.connectionParams.access_token


result = toolset.execute_action(
    action=get_gmail_access_token,
    params={},
)
print("Got access token:", result["data"]["token"])
```

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds support for `connected_account` parameter in custom actions by modifying `execute()` and `_build_executable_from_args()` in `runtime.py`.
> 
>   - **Behavior**:
>     - Support for `connected_account` parameter in custom actions added in `execute()` and `_build_executable_from_args()` in `runtime.py`.
>     - Introduces `_get_connected_account()` to fetch connected account details.
>   - **Imports**:
>     - Import `ConnectedAccountModel` in `runtime.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for b1626af896d5904f7c9aa238546b3a0483cd74b8. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->