### PR TITLE
fix: Better error message if no active triggers exist on account

### DIFF
--- a/python/composio/client/base.py
+++ b/python/composio/client/base.py
@@ -51,12 +51,6 @@ class Collection(t.Generic[ModelType], logging.WithLogger):
             )
         return response
 
-    def _raise_if_empty(self, collection: CollectionType) -> CollectionType:
-        """Raise if provided collection is empty."""
-        if len(collection) > 0:
-            return collection
-        raise NoItemsFound(message="No items found")
-
     def get(self, queries: t.Optional[t.Dict[str, str]] = None) -> t.List[ModelType]:
         """List available models."""
         request = self._raise_if_required(

--- a/python/composio/client/base.py
+++ b/python/composio/client/base.py
@@ -7,7 +7,7 @@ import typing as t
 import requests
 
 from composio.client.endpoints import Endpoint
-from composio.client.exceptions import HTTPError, NoItemsFound
+from composio.client.exceptions import HTTPError
 from composio.utils import logging
 
 

--- a/python/composio/client/collections.py
+++ b/python/composio/client/collections.py
@@ -983,7 +983,7 @@ class ActiveTriggers(Collection[ActiveTriggerModel]):
             queries["integrationIds"] = ",".join(integration_ids)
         if len(trigger_names) > 0:
             queries["triggerNames"] = to_trigger_names(trigger_names)
-        return self._raise_if_empty(super().get(queries=queries))
+        return super().get(queries=queries)
 
 
 def _check_file_uploadable(param_field: dict) -> bool:


### PR DESCRIPTION
When an account has ZERO active triggers and we try to use one, Instead of:

```
composio.client.NoItemsFound: No Items Found
```

Now we get:

```
composio.exceptions.ComposioSDKError: Trigger 'ASANA_TASK_TRIGGER' is not enabled on your account.
Enable the trigger by doing `composio triggers enable ASANA_TASK_TRIGGER`.
Read more here: https://docs.composio.dev/introduction/intro/quickstart_3
```

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Improves error handling by removing `_raise_if_empty` and updating `ActiveTriggers.get()` to return an empty list instead of raising an error when no active triggers are found.
> 
>   - **Behavior**:
>     - Removes `_raise_if_empty` function from `base.py`.
>     - `ActiveTriggers.get()` in `collections.py` no longer raises `NoItemsFound` error when no active triggers are found, returns empty list instead.
>   - **Error Handling**:
>     - Improves error message for missing active triggers, suggesting enabling the trigger and providing a documentation link.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for c7c4e7614e0dd3507a033121adcdd44591286cd9. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->