### PR TITLE
fix: limit number of characters on every plugin

### DIFF
--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -145,9 +145,11 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
 
     def __init_subclass__(
         cls,
+        *args: t.Any,
         runtime: t.Optional[str] = None,
         description_char_limit: t.Optional[int] = None,
         action_name_char_limit: t.Optional[int] = None,
+        **kwargs: t.Any,
     ) -> None:
         if runtime is None:
             warnings.warn(
@@ -161,6 +163,10 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
             )
         cls._description_char_limit = description_char_limit or 1024
         cls._action_name_char_limit = action_name_char_limit
+        if len(args) > 0 or len(kwargs) > 0:
+            warnings.warn(
+                f"Composio toolset subclass initializer got extra {args=} and {kwargs=}"
+            )
 
     def __init__(
         self,

--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -79,6 +79,8 @@ MetadataType = t.Dict[_KeyType, t.Dict]
 ParamType = t.TypeVar("ParamType")
 ProcessorType = te.Literal["pre", "post", "schema"]
 
+_IS_CI: t.Optional[bool] = None
+
 
 class IntegrationParams(te.TypedDict):
 
@@ -107,6 +109,13 @@ def _check_agentops() -> bool:
     import agentops  # pylint: disable=import-outside-toplevel # type: ignore
 
     return agentops.get_api_key() is not None
+
+
+def _is_ci():
+    global _IS_CI
+    if _IS_CI is None:
+        _IS_CI = os.environ.get("CI") == "true"
+    return _IS_CI
 
 
 def _record_action_if_available(func: t.Callable[P, T]) -> t.Callable[P, T]:
@@ -164,9 +173,12 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
         cls._description_char_limit = description_char_limit or 1024
         cls._action_name_char_limit = action_name_char_limit
         if len(args) > 0 or len(kwargs) > 0:
-            warnings.warn(
+            error = (
                 f"Composio toolset subclass initializer got extra {args=} and {kwargs=}"
             )
+            if _is_ci():
+                raise RuntimeError(error)
+            warnings.warn(error)
 
     def __init__(
         self,

--- a/python/plugins/autogen/composio_autogen/toolset.py
+++ b/python/plugins/autogen/composio_autogen/toolset.py
@@ -16,6 +16,7 @@ class ComposioToolSet(
     BaseComposioToolSet,
     runtime="autogen",
     description_char_limit=1024,
+    action_name_char_limit=64,
 ):
     """
     Composio toolset for autogen framework.

--- a/python/plugins/camel/composio_camel/toolset.py
+++ b/python/plugins/camel/composio_camel/toolset.py
@@ -23,6 +23,7 @@ class ComposioToolSet(
     BaseComposioToolSet,
     runtime="camel",
     description_char_limit=1024,
+    action_name_char_limit=64,
 ):
     """
     Composio toolset for OpenAI framework.

--- a/python/plugins/claude/composio_claude/toolset.py
+++ b/python/plugins/claude/composio_claude/toolset.py
@@ -27,6 +27,7 @@ class ComposioToolSet(
     BaseComposioToolSet,
     runtime="claude",
     description_char_limit=1024,
+    action_name_char_limit=64,
 ):
     """
     Composio toolset for Anthropic Claude platform.

--- a/python/plugins/crew_ai/composio_crewai/toolset.py
+++ b/python/plugins/crew_ai/composio_crewai/toolset.py
@@ -12,6 +12,7 @@ if _CURRENT_VERSION < _BREAKING_VERSION:
         Base,
         runtime="crewai",
         description_char_limit=1024,
+        action_name_char_limit=64,
     ):
         pass
 
@@ -33,6 +34,7 @@ else:
         BaseComposioToolSet,
         runtime="crewai",
         description_char_limit=1024,
+        action_name_char_limit=64,
     ):
         """
         Composio toolset for CrewiAI framework.

--- a/python/plugins/google/composio_google/toolset.py
+++ b/python/plugins/google/composio_google/toolset.py
@@ -24,6 +24,7 @@ class ComposioToolset(
     BaseComposioToolSet,
     runtime="google_ai",
     description_char_limit=1024,
+    action_name_char_limit=64,
 ):
     """
     Composio toolset for Google AI Python Gemini framework.

--- a/python/plugins/griptape/composio_griptape/toolset.py
+++ b/python/plugins/griptape/composio_griptape/toolset.py
@@ -19,6 +19,7 @@ class ComposioToolSet(
     BaseComposioToolSet,
     runtime="griptape",
     description_char_limit=1024,
+    action_name_char_limit=64,
 ):
     """
     Composio toolset wrapper for Griptape framework.

--- a/python/plugins/julep/composio_julep/toolset.py
+++ b/python/plugins/julep/composio_julep/toolset.py
@@ -13,6 +13,7 @@ class ComposioToolSet(
     BaseComposioToolSet,
     runtime="julep",
     description_char_limit=1024,
+    action_name_char_limit=64,
 ):
     """
     Composio toolset wrapper for Julep framework.

--- a/python/plugins/langgraph/composio_langgraph/toolset.py
+++ b/python/plugins/langgraph/composio_langgraph/toolset.py
@@ -5,6 +5,7 @@ class ComposioToolSet(
     BaseComposioToolSet,
     runtime="langgraph",
     description_char_limit=1024,
+    action_name_char_limit=64,
 ):
     """
     Composio toolset for LangGraph framework.

--- a/python/plugins/llamaindex/composio_llamaindex/toolset.py
+++ b/python/plugins/llamaindex/composio_llamaindex/toolset.py
@@ -16,6 +16,7 @@ class ComposioToolSet(
     BaseComposioToolSet,
     runtime="llamaindex",
     description_char_limit=1024,
+    action_name_char_limit=64,
 ):
     """
     Composio toolset for LlamaIndex framework.

--- a/python/plugins/lyzr/composio_lyzr/toolset.py
+++ b/python/plugins/lyzr/composio_lyzr/toolset.py
@@ -22,6 +22,7 @@ class ComposioToolSet(
     BaseComposioToolSet,
     runtime="lyzr",
     description_char_limit=1024,
+    action_name_char_limit=64,
 ):
     """
     Composio toolset for Lyzr framework.

--- a/python/plugins/openai/composio_openai/toolset.py
+++ b/python/plugins/openai/composio_openai/toolset.py
@@ -27,6 +27,7 @@ class ComposioToolSet(
     BaseComposioToolSet,
     runtime="openai",
     description_char_limit=1024,
+    action_name_char_limit=64,
 ):
     """
     Composio toolset for OpenAI framework.

--- a/python/plugins/phidata/composio_phidata/toolset.py
+++ b/python/plugins/phidata/composio_phidata/toolset.py
@@ -19,6 +19,7 @@ class ComposioToolSet(
     BaseComposioToolSet,
     runtime="phidata",
     description_char_limit=1024,
+    action_name_char_limit=64,
 ):
     """
     Composio toolset for Phidata framework.

--- a/python/plugins/praisonai/composio_praisonai/toolset.py
+++ b/python/plugins/praisonai/composio_praisonai/toolset.py
@@ -21,6 +21,7 @@ class ComposioToolSet(
     BaseComposioToolSet,
     runtime="praisonai",
     description_char_limit=1024,
+    action_name_char_limit=64,
 ):
     """
     Composio toolset for PraisonAI framework.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces a 64-character limit for action names in `ComposioToolSet` across multiple plugins and adds a warning for extra arguments in subclass initializers.
> 
>   - **Behavior**:
>     - Adds `action_name_char_limit` parameter to `ComposioToolSet` in `toolset.py` to limit action names to 64 characters.
>     - Applies 64 character limit to action names in `composio_autogen/toolset.py`, `composio_camel/toolset.py`, and `composio_claude/toolset.py`.
>   - **Warnings**:
>     - Adds warning for extra arguments in `__init_subclass__` in `toolset.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 3723865a89280554a0c6b7342e9103b2a1168e5b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->