### PR TITLE
feat: allow injection of custom auth for local tools

### DIFF
--- a/python/composio/client/collections.py
+++ b/python/composio/client/collections.py
@@ -1037,7 +1037,7 @@ class ActionModel(BaseModel):
     description: t.Optional[str] = None
 
 
-ParamPlacement = t.Literal["header", "path", "query", "subdomain"]
+ParamPlacement = t.Literal["header", "path", "query", "subdomain", "metadata"]
 
 
 class CustomAuthParameter(te.TypedDict):
@@ -1357,6 +1357,11 @@ class Actions(Collection[ActionModel]):
             {"in": d["in_"], "name": d["name"], "value": d["value"]}
             for d in data["parameters"]
         ]
+        for param in data["parameters"]:
+            if param["in"] == "metadata":
+                raise ComposioClientError(
+                    f"Param placement cannot be 'metadata' for remote action execution: {param}"
+                )
         return data
 
     def search_for_a_task(

--- a/python/composio/tools/local/filetool/actions/git_clone.py
+++ b/python/composio/tools/local/filetool/actions/git_clone.py
@@ -23,11 +23,17 @@ def git_reset_cmd(commit_id: str) -> str:
     return " && ".join(reset_commands)
 
 
-def git_clone_cmd(repo: str, commit_id: str) -> str:
+def git_clone_cmd(
+    repo: str,
+    commit_id: str,
+    github_access_token: t.Optional[str] = None,
+) -> str:
     """Commands to clone github repository."""
     # repo is in the format of "composiohq/composio" or "django/django"
     repo_name = repo.split("/")[-1]
-    github_access_token = os.environ.get("GITHUB_ACCESS_TOKEN", "").strip()
+    github_access_token = (
+        github_access_token or os.environ.get("GITHUB_ACCESS_TOKEN", "").strip()
+    )
 
     if not github_access_token and os.environ.get("ALLOW_CLONE_WITHOUT_REPO") != "true":
         raise RuntimeError("Cannot clone github repository without github access token")
@@ -111,7 +117,13 @@ class GitClone(LocalAction[GitCloneRequest, GitCloneResponse]):
         command = (
             git_reset_cmd(request.commit_id)
             if request.just_reset
-            else git_clone_cmd(request.repo_name, request.commit_id)
+            else git_clone_cmd(
+                request.repo_name,
+                request.commit_id,
+                github_access_token=metadata.get(
+                    "github-access-token",
+                ),
+            )
         )
         current_dir = filemanager.current_dir()
         if pathlib.Path(current_dir, ".git").exists() and not request.just_reset:

--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -482,6 +482,19 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
         """Execute a local action."""
         metadata = metadata or {}
         metadata["_toolset"] = self
+        custom_auth = self._custom_auth.get(App(action.app))
+        if custom_auth is not None:
+            invalid_auth = []
+            for param in custom_auth.parameters:
+                if param["in_"] == "metadata":
+                    metadata[param["name"]] = param["value"]
+                    continue
+                invalid_auth.append(param)
+            if len(invalid_auth) > 0:
+                raise ComposioSDKError(
+                    f"Invalid custom auth found for {action.app}: {invalid_auth}"
+                )
+
         response = self.workspace.execute_action(
             action=action,
             request_data=params,


### PR DESCRIPTION
# 🔍 Review Summary 
 ### Release Note

**Purpose**:
- Enhance security and robustness of the Composio framework.

**Changes**:

- **Enhancement**: 
  - Introduced an optional GitHub access token in the `git_clone` function for flexible authentication.

- **Bug Fix**: 
  - Added validation to prevent invalid parameter placements in `metadata` for remote actions.

- **New Feature**: 
  - Enabled custom authentication parameters injection into metadata with error handling.

**Impact**:
- Improves user experience by offering flexible authentication and ensuring error-free local actions, strengthening system security and reliability. 



<details><summary>Original Description</summary>


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhance Composio framework with flexible custom authentication handling and validation improvements.
> 
>   - **Behavior**:
>     - Extend `ParamPlacement` in `collections.py` to include `metadata`.
>     - Update `_serialize_auth()` in `collections.py` to raise an error if `metadata` is used for remote actions.
>     - Modify `git_clone_cmd()` in `git_clone.py` to accept `github_access_token` as an argument.
>     - Update `execute()` in `git_clone.py` to pass `github_access_token` from `metadata`.
>     - Enhance `_execute_local()` in `toolset.py` to inject custom auth parameters into `metadata` if `in_` is `metadata`.
>   - **Misc**:
>     - Add error handling for invalid custom auth in `_execute_local()` in `toolset.py`.
>     - Add tests for custom auth handling in `test_toolset.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 5dc452ac13a0b2340fb39cff7f83b37414f78785. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

</details>