### PR TITLE
fix: no auth flag delegation

### DIFF
--- a/python/composio/tools/base/abs.py
+++ b/python/composio/tools/base/abs.py
@@ -397,13 +397,14 @@ class ToolBuilder:
         setattr(obj, "_triggers", getattr(obj, "_triggers", {}))
 
     @staticmethod
-    def setup_children(obj: t.Type["Tool"]) -> None:
+    def setup_children(obj: t.Type["Tool"], no_auth: bool = False) -> None:
         if obj.gid not in action_registry:
             action_registry[obj.gid] = {}
 
         for action in obj.actions():
             action.tool = obj.name
             action.enum = f"{obj.enum}_{action.name.upper()}"
+            action.no_auth = no_auth
             if obj.requires is not None:
                 action.requires = list(set(obj.requires + (action.requires or [])))
             obj._actions[action.enum] = action  # pylint: disable=protected-access

--- a/python/composio/tools/base/local.py
+++ b/python/composio/tools/base/local.py
@@ -79,6 +79,7 @@ class LocalToolMeta(type):
         )
         ToolBuilder.setup_children(
             obj=cls,  # type: ignore
+            no_auth=True,
         )
 
         if autoload:

--- a/python/tests/test_tools/test_base/test_abs.py
+++ b/python/tests/test_tools/test_base/test_abs.py
@@ -146,11 +146,12 @@ class TestToolBuilder:
 
         ToolBuilder.validate(obj=SomeTool, name="SomeTool", methods=("actions",))
         ToolBuilder.set_metadata(obj=SomeTool)
-        ToolBuilder.setup_children(obj=SomeTool)
+        ToolBuilder.setup_children(obj=SomeTool, no_auth=True)
 
         SomeTool.register()
 
         assert SomeAction.enum == "SOME_TOOL_SOME_ACTION"
+        assert SomeAction.no_auth is True
         assert isinstance(tool_registry["local"][SomeTool.enum], SomeTool)
         assert action_registry["local"][SomeAction.enum] is SomeAction
 


### PR DESCRIPTION
# 🔍 Review Summary 
 ### Purpose
- Enhance tool setup flexibility by allowing configuration without authentication.

### Changes
- **Enhancement**: Added a `no_auth` flag to the tool setup process, modifying `setup_children` in `abs.py` and applying it in `local.py`.
- **Test**: Developed tests to ensure the `no_auth` flag functions correctly.

### Impact
- Simplifies tool configuration by removing authentication requirements, improving user experience. 



<details><summary>Original Description</summary>


<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `no_auth` flag to `setup_children()` in `ToolBuilder` and update `LocalToolMeta` to use it, with corresponding test updates.
> 
>   - **Behavior**:
>     - Add `no_auth` parameter to `setup_children()` in `abs.py` to set `action.no_auth`.
>     - Update `LocalToolMeta` in `local.py` to call `setup_children()` with `no_auth=True`.
>   - **Tests**:
>     - Update `test_setup_children()` in `test_abs.py` to assert `SomeAction.no_auth is True`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 88400ccf97c817ed1a4f969b5d488ffc1662e1e1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

</details>