### PR TITLE
feat: add support for delegating custom auth to runtime actions

### DIFF
--- a/python/composio/tools/base/runtime.py
+++ b/python/composio/tools/base/runtime.py
@@ -266,20 +266,32 @@ def _get_connected_account(
         return None
 
 
-def _get_auth_params(app: str, entity_id: str) -> t.Optional[t.Dict]:
+def _get_auth_params(app: str, metadata: t.Dict) -> t.Dict:
     try:
         client = Composio.get_latest()
         connected_account = client.connected_accounts.get(
-            connection_id=client.get_entity(entity_id).get_connection(app=app).id
+            connection_id=client.get_entity(metadata["entity_id"])
+            .get_connection(app=app)
+            .id
         )
         connection_params = connected_account.connectionParams
         return {
+            "entity_id": metadata["entity_id"],
             "headers": connection_params.headers,
             "base_url": connection_params.base_url,
             "query_params": connection_params.queryParams,
         }
     except ComposioClientError:
-        return None
+        return {
+            "entity_id": metadata["entity_id"],
+            "subdomain": metadata.pop("subdomain", {}),
+            "headers": metadata.pop("header", {}),
+            "base_url": metadata.pop("base_url", None),
+            "body_params": metadata.pop("body", {}),
+            "path_params": metadata.pop("path", {}),
+            "query_params": metadata.pop("query", {}),
+            **metadata,
+        }
 
 
 def _build_executable_from_args(  # pylint: disable=too-many-statements
@@ -400,9 +412,7 @@ def _build_executable_from_args(  # pylint: disable=too-many-statements
                 _get_connected_account(app=app, entity_id=metadata["entity_id"]) or {}
             )
         if auth_param:
-            kwargs["auth"] = (
-                _get_auth_params(app=app, entity_id=metadata["entity_id"]) or {}
-            )
+            kwargs["auth"] = _get_auth_params(app=app, metadata=metadata)
 
         if request_executor:
             toolset = t.cast("ComposioToolSet", metadata["_toolset"])
@@ -443,7 +453,7 @@ def _build_executable_from_args(  # pylint: disable=too-many-statements
 def _build_executable_from_request_class(f: t.Callable, app: str) -> t.Callable:
     def execute(request: BaseModel, metadata: t.Dict) -> BaseModel:
         """Wrapper for action callable."""
-        auth_data = _get_auth_params(app=app, entity_id=metadata["entity_id"])
+        auth_data = _get_auth_params(app=app, metadata=metadata)
         if auth_data is not None:
             metadata.update(auth_data)
         return f(request, metadata)


### PR DESCRIPTION
# 🔍 Review Summary 
 **Purpose**: Enhance the Composio toolset with custom authentication via metadata for increased runtime flexibility.

**Changes**:

- **Enhancement**: Added metadata-based custom authentication in `runtime.py` and `toolset.py`, enhancing runtime flexibility and execution efficiency.

- **Test**: Developed comprehensive tests in `test_toolset.py` to ensure robust functionality and seamless integration of new authentication methods.

**Impact**: These updates improve user experience with customizable authentication and enhance toolset reliability through rigorous testing. 



<details><summary>Original Description</summary>


<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for delegating custom authentication to runtime actions in `ComposioToolSet`.
> 
>   - **Behavior**:
>     - `_get_auth_params()` in `runtime.py` now accepts `metadata` instead of `entity_id` and handles additional metadata fields.
>     - `execute()` in `runtime.py` updated to use new `_get_auth_params()` signature.
>     - `ComposioToolSet` in `toolset.py` now supports custom auth for runtime actions via `_get_custom_params_for_runtime_action()`.
>   - **Functions**:
>     - Added `_get_custom_params_for_runtime_action()` and `_get_custom_params_for_local_action()` in `toolset.py` to handle custom auth parameters.
>   - **Tests**:
>     - Added `test_custom_auth_runtime_tool()` in `test_toolset.py` to verify custom auth delegation to runtime actions.
>     - Updated existing tests to reflect changes in auth parameter handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 79527830f69ab2ed83baea3e12ad58b357e9fb3c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

</details>