### PR TITLE
fix: don't require API key for local tools

### DIFF
--- a/python/composio/client/collections.py
+++ b/python/composio/client/collections.py
@@ -1539,7 +1539,7 @@ class Logs(Collection[LogRecord]):
     def push(self, record: t.Dict) -> None:
         """Push logs to composio."""
         # TODO: handle this better
-        if self.client._api_key is None:
+        if self.client._api_key is None:  # pylint: disable=protected-access
             return
 
         self.client.http.post(url=str(self.endpoint), json=record)

--- a/python/composio/client/collections.py
+++ b/python/composio/client/collections.py
@@ -1538,4 +1538,8 @@ class Logs(Collection[LogRecord]):
 
     def push(self, record: t.Dict) -> None:
         """Push logs to composio."""
+        # TODO: handle this better
+        if self.client._api_key is None:
+            return
+
         self.client.http.post(url=str(self.endpoint), json=record)

--- a/python/composio/tools/env/base.py
+++ b/python/composio/tools/env/base.py
@@ -215,8 +215,10 @@ class RemoteWorkspace(Workspace):
             name=ENV_COMPOSIO_BASE_URL,
             default=config.composio_base_url,
         )
-        self.github_access_token = config.github_access_token or os.environ.get(
-            ENV_GITHUB_ACCESS_TOKEN, "NO_VALUE"
+        self.github_access_token = (
+            config.github_access_token
+            if config.github_access_token is not None
+            else os.environ.get(ENV_GITHUB_ACCESS_TOKEN, "NO_VALUE")
         )
         self.environment.update(
             {

--- a/python/composio/tools/env/base.py
+++ b/python/composio/tools/env/base.py
@@ -160,6 +160,10 @@ class Workspace(WithLogger, ABC):
         self.id = generate_id()
         self.access_token = uuid4().hex.replace("-", "")
         self.persistent = config.persistent
+        self.environment = {
+            **(config.environment or {}),
+            ENV_ACCESS_TOKEN: self.access_token,
+        }
 
     def __str__(self) -> str:
         """String representation."""

--- a/python/composio/tools/env/base.py
+++ b/python/composio/tools/env/base.py
@@ -218,14 +218,15 @@ class RemoteWorkspace(Workspace):
         self.github_access_token = config.github_access_token or os.environ.get(
             ENV_GITHUB_ACCESS_TOKEN, "NO_VALUE"
         )
-        self.environment = {
-            **(config.environment or {}),
-            ENV_COMPOSIO_API_KEY: self.composio_api_key,
-            ENV_COMPOSIO_BASE_URL: self.composio_base_url,
-            ENV_GITHUB_ACCESS_TOKEN: self.github_access_token,
-            f"_COMPOSIO_{ENV_GITHUB_ACCESS_TOKEN}": self.github_access_token,
-            ENV_ACCESS_TOKEN: self.access_token,
-        }
+        self.environment.update(
+            {
+                ENV_COMPOSIO_API_KEY: self.composio_api_key,
+                ENV_COMPOSIO_BASE_URL: self.composio_base_url,
+                ENV_GITHUB_ACCESS_TOKEN: self.github_access_token,
+                f"_COMPOSIO_{ENV_GITHUB_ACCESS_TOKEN}": self.github_access_token,
+                ENV_ACCESS_TOKEN: self.access_token,
+            }
+        )
 
     def _request(
         self,

--- a/python/composio/tools/env/base.py
+++ b/python/composio/tools/env/base.py
@@ -159,25 +159,6 @@ class Workspace(WithLogger, ABC):
         super().__init__()
         self.id = generate_id()
         self.access_token = uuid4().hex.replace("-", "")
-        self.composio_api_key = _read_env_var(
-            name=ENV_COMPOSIO_API_KEY,
-            default=config.composio_api_key,
-        )
-        self.composio_base_url = _read_env_var(
-            name=ENV_COMPOSIO_BASE_URL,
-            default=config.composio_base_url,
-        )
-        self.github_access_token = config.github_access_token or os.environ.get(
-            ENV_GITHUB_ACCESS_TOKEN, "NO_VALUE"
-        )
-        self.environment = {
-            **(config.environment or {}),
-            ENV_COMPOSIO_API_KEY: self.composio_api_key,
-            ENV_COMPOSIO_BASE_URL: self.composio_base_url,
-            ENV_GITHUB_ACCESS_TOKEN: self.github_access_token,
-            f"_COMPOSIO_{ENV_GITHUB_ACCESS_TOKEN}": self.github_access_token,
-            ENV_ACCESS_TOKEN: self.access_token,
-        }
         self.persistent = config.persistent
 
     def __str__(self) -> str:
@@ -219,6 +200,28 @@ class Workspace(WithLogger, ABC):
 
 class RemoteWorkspace(Workspace):
     """Remote workspace client."""
+
+    def __init__(self, config: WorkspaceConfigType):
+        super().__init__(config)
+        self.composio_api_key = _read_env_var(
+            name=ENV_COMPOSIO_API_KEY,
+            default=config.composio_api_key,
+        )
+        self.composio_base_url = _read_env_var(
+            name=ENV_COMPOSIO_BASE_URL,
+            default=config.composio_base_url,
+        )
+        self.github_access_token = config.github_access_token or os.environ.get(
+            ENV_GITHUB_ACCESS_TOKEN, "NO_VALUE"
+        )
+        self.environment = {
+            **(config.environment or {}),
+            ENV_COMPOSIO_API_KEY: self.composio_api_key,
+            ENV_COMPOSIO_BASE_URL: self.composio_base_url,
+            ENV_GITHUB_ACCESS_TOKEN: self.github_access_token,
+            f"_COMPOSIO_{ENV_GITHUB_ACCESS_TOKEN}": self.github_access_token,
+            ENV_ACCESS_TOKEN: self.access_token,
+        }
 
     def _request(
         self,

--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -421,7 +421,9 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
             try:
                 workspace_config.composio_api_key = self.api_key
             except ApiKeyNotProvidedError:
-                pass
+                warnings.warn(
+                    "Running without a Composio API key", UserWarning, stacklevel=2
+                )
 
         if workspace_config.composio_base_url is None:
             workspace_config.composio_base_url = self._base_url

--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -359,9 +359,6 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
 
     def _try_get_github_access_token_for_current_entity(self) -> t.Optional[str]:
         """Try and get github access token for current entiry."""
-        if self._api_key is None:
-            return None
-
         from_env = os.environ.get(f"_COMPOSIO_{ENV_GITHUB_ACCESS_TOKEN}")
         if from_env is not None:
             self.logger.debug("Using composio github access token")
@@ -429,7 +426,10 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
         if workspace_config.composio_base_url is None:
             workspace_config.composio_base_url = self._base_url
 
-        if workspace_config.github_access_token is None:
+        if (
+            workspace_config.github_access_token is None
+            and workspace_config.composio_api_key is not None
+        ):
             workspace_config.github_access_token = (
                 self._try_get_github_access_token_for_current_entity()
             )

--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -1005,12 +1005,11 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
         if not apps and not actions and not tags:
             return
 
-        if self._workspace is not None:
-            self.workspace.check_for_missing_dependencies(
-                apps=apps,
-                actions=actions,
-                tags=tags,
-            )
+        self.workspace.check_for_missing_dependencies(
+            apps=apps,
+            actions=actions,
+            tags=tags,
+        )
 
     def get_action_schemas(
         self,

--- a/python/tests/test_tools/test_env/test_base.py
+++ b/python/tests/test_tools/test_env/test_base.py
@@ -9,16 +9,16 @@ import pytest
 from composio.client.enums import Action, ActionType, AppType, TagType
 from composio.exceptions import ComposioSDKError
 from composio.tools.env.base import (
+    RemoteWorkspace,
     SessionFactory,
     Sessionable,
-    Workspace,
     WorkspaceConfigType,
 )
 from composio.tools.env.id import generate_id
 
 
-def test_workspace() -> None:
-    class TestWorkspace(Workspace):
+def test_remote_workspace() -> None:
+    class TestRemoteWorkspace(RemoteWorkspace):
         def check_for_missing_dependencies(
             self,
             apps: t.Optional[t.Sequence[AppType]] = None,
@@ -46,7 +46,7 @@ def test_workspace() -> None:
         ComposioSDKError,
         match="Please provide value for `COMPOSIO_API_KEY`",
     ):
-        _ = TestWorkspace(config=WorkspaceConfigType())
+        _ = TestRemoteWorkspace(config=WorkspaceConfigType())
 
 
 def test_sessionable() -> None:

--- a/python/tests/test_tools/test_toolset.py
+++ b/python/tests/test_tools/test_toolset.py
@@ -154,6 +154,19 @@ class TestConnectedAccountProvider:
             )
 
 
+def test_api_key_missing() -> None:
+    toolset = ComposioToolSet()
+    toolset._api_key = None  # pylint: disable=protected-access
+    with pytest.raises(
+        ApiKeyNotProvidedError,
+        match=(
+            "API Key not provided, either provide API key or export it as "
+            "`COMPOSIO_API_KEY` or run `composio login`"
+        ),
+    ):
+        _ = toolset.execute_action(Action.HACKERNEWS_GET_FRONTPAGE, {})
+
+
 def test_processors(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test the `processors` field in `ComposioToolSet` constructor."""
     preprocessor_called = postprocessor_called = False

--- a/python/tests/test_tools/test_toolset.py
+++ b/python/tests/test_tools/test_toolset.py
@@ -3,6 +3,7 @@ Test composio toolset.
 """
 
 import logging
+import os
 import re
 import typing as t
 from unittest import mock
@@ -154,9 +155,9 @@ class TestConnectedAccountProvider:
             )
 
 
-def test_api_key_missing() -> None:
+def test_api_key_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("COMPOSIO_API_KEY", "")
     toolset = ComposioToolSet()
-    toolset._api_key = None  # pylint: disable=protected-access
     with pytest.raises(
         ApiKeyNotProvidedError,
         match=(

--- a/python/tests/test_tools/test_toolset.py
+++ b/python/tests/test_tools/test_toolset.py
@@ -154,19 +154,6 @@ class TestConnectedAccountProvider:
             )
 
 
-def test_api_key_missing() -> None:
-    toolset = ComposioToolSet()
-    toolset._api_key = None  # pylint: disable=protected-access
-    with pytest.raises(
-        ApiKeyNotProvidedError,
-        match=(
-            "API Key not provided, either provide API key or export it as "
-            "`COMPOSIO_API_KEY` or run `composio login`"
-        ),
-    ):
-        _ = toolset.workspace
-
-
 def test_processors(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test the `processors` field in `ComposioToolSet` constructor."""
     preprocessor_called = postprocessor_called = False

--- a/python/tests/test_tools/test_toolset.py
+++ b/python/tests/test_tools/test_toolset.py
@@ -3,7 +3,6 @@ Test composio toolset.
 """
 
 import logging
-import os
 import re
 import typing as t
 from unittest import mock


### PR DESCRIPTION
Make the Composio API key and GitHub token check mandatory only for remote workspaces in local actions, not for host workspace.


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Make API key checks optional for local tools by updating `RemoteWorkspace` and `ComposioToolSet`, with test adjustments in `test_base.py` and `test_toolset.py`.
> 
>   - **Behavior**:
>     - `RemoteWorkspace` in `base.py` initializes `composio_api_key`, `composio_base_url`, and `github_access_token`, removing these from `Workspace`.
>     - `ComposioToolSet` in `toolset.py` handles missing API keys in `workspace` property and `_try_get_github_access_token_for_current_entity` method.
>   - **Tests**:
>     - Update `test_remote_workspace()` in `test_base.py` to reflect changes in `RemoteWorkspace` initialization.
>     - Remove `test_api_key_missing()` in `test_toolset.py` as API key is no longer mandatory for local tools.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 369d41bc20460001b8947f85361d242309e30829. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->

