### PR TITLE
fix: Use apps filter in advanced use case search

### DIFF
--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -1174,8 +1174,11 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
         :return: A list of actions matching the relevant use case.
         """
         if advanced:
+            app_keys = [str(app) for app in apps]
             actions = []
-            for task in self.client.actions.search_for_a_task(use_case=use_case):
+            for task in self.client.actions.search_for_a_task(
+                apps=app_keys, use_case=use_case
+            ):
                 actions += task.actions
         else:
             actions = list(


### PR DESCRIPTION
# 🔍 Review Summary 
 ### Release Note

**Purpose**:
- Optimizes search functionality by refining searches based on specific applications.

**Changes**:
- **Enhancement**: Improved the `find_actions_by_use_case` method in `toolset.py` with an `apps` filter for more precise search results.

**Impact**:
- Increases specificity and relevance of search results, enhancing user experience and task efficiency. 



<details><summary>Original Description</summary>

`apps` was not being used in advanced use case search, if provided
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `find_actions_by_use_case()` in `toolset.py` to use `apps` filter in advanced search.
> 
>   - **Behavior**:
>     - Fixes `find_actions_by_use_case()` in `toolset.py` to use `apps` filter when `advanced` is true.
>     - Converts `apps` to `app_keys` and passes them to `search_for_a_task()`.
>   - **Misc**:
>     - No changes to non-advanced search behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 168da14014aa613ac40010393117054b80364f47. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

</details>