### PR TITLE
feat: add support for zod error

### DIFF
--- a/js/src/sdk/index.spec.ts
+++ b/js/src/sdk/index.spec.ts
@@ -61,11 +61,13 @@ describe("Basic SDK spec suite", () => {
       type: "BadRequestError",
       name: "InvalidRequestError",
       message: "Invalid request for apps",
-      errors: [
+      details: [
         {
-          code: "invalid_type",
-          message: "Invalid request for apps",
-          path: ["apps"],
+          property: "triggerConfig",
+          children: [],
+          constraints: {
+            isObject: "triggerConfig must be an object",
+          },
         },
       ],
     });
@@ -78,7 +80,7 @@ describe("Basic SDK spec suite", () => {
       const errorCode = COMPOSIO_SDK_ERROR_CODES.BACKEND.BAD_REQUEST;
       expect(error.errCode).toBe(errorCode);
       expect(error.message).toContain("InvalidRequestError");
-      expect(error.description).toContain(`Validation Errors: {"code`);
+      expect(error.description).toContain(`Validation Errors: {"property":"triggerConfig","children":[],"constraints":{"isObject":"triggerConfig must be an object"}}`);
     }
 
     mock.reset();

--- a/js/src/sdk/index.spec.ts
+++ b/js/src/sdk/index.spec.ts
@@ -61,6 +61,13 @@ describe("Basic SDK spec suite", () => {
       type: "BadRequestError",
       name: "InvalidRequestError",
       message: "Invalid request for apps",
+      errors: [
+        {
+          code: "invalid_type",
+          message: "Invalid request for apps",
+          path: ["apps"],
+        },
+      ],
     });
 
     const client = new Composio({ apiKey: COMPOSIO_API_KEY });
@@ -70,9 +77,8 @@ describe("Basic SDK spec suite", () => {
       const error = e as ComposioError;
       const errorCode = COMPOSIO_SDK_ERROR_CODES.BACKEND.BAD_REQUEST;
       expect(error.errCode).toBe(errorCode);
-      expect(error.message).toContain("InvalidRequestError ");
       expect(error.message).toContain("InvalidRequestError");
-      expect(error.description).toContain("Invalid request for apps");
+      expect(error.description).toContain(`Validation Errors: {"code`);
     }
 
     mock.reset();

--- a/js/src/sdk/index.spec.ts
+++ b/js/src/sdk/index.spec.ts
@@ -80,7 +80,9 @@ describe("Basic SDK spec suite", () => {
       const errorCode = COMPOSIO_SDK_ERROR_CODES.BACKEND.BAD_REQUEST;
       expect(error.errCode).toBe(errorCode);
       expect(error.message).toContain("InvalidRequestError");
-      expect(error.description).toContain(`Validation Errors: {"property":"triggerConfig","children":[],"constraints":{"isObject":"triggerConfig must be an object"}}`);
+      expect(error.description).toContain(
+        `Validation Errors: {"property":"triggerConfig","children":[],"constraints":{"isObject":"triggerConfig must be an object"}}`
+      );
     }
 
     mock.reset();

--- a/js/src/sdk/utils/errors/src/formatter.ts
+++ b/js/src/sdk/utils/errors/src/formatter.ts
@@ -9,6 +9,7 @@ export interface ErrorResponseData {
   type: string;
   name: string;
   message: string;
+  errors?: Record<string, unknown>[] | Record<string, unknown>;
 }
 
 interface ErrorDetails {
@@ -53,13 +54,25 @@ export const getAPIErrorDetails = (
   }
 
   switch (errorCode) {
+    case COMPOSIO_SDK_ERROR_CODES.BACKEND.BAD_REQUEST:
+      const validationErrors = axiosError.response?.data?.errors;
+      const formattedErrors = Array.isArray(validationErrors)
+        ? validationErrors.map((err) => JSON.stringify(err)).join(", ")
+        : JSON.stringify(validationErrors);
+
+      return {
+        message: genericMessage,
+        description: `Validation Errors: ${formattedErrors}`,
+        possibleFix:
+          "Please check the request parameters and ensure they are correct.",
+        metadata,
+      };
     case COMPOSIO_SDK_ERROR_CODES.BACKEND.NOT_FOUND:
     case COMPOSIO_SDK_ERROR_CODES.BACKEND.UNAUTHORIZED:
     case COMPOSIO_SDK_ERROR_CODES.BACKEND.SERVER_ERROR:
     case COMPOSIO_SDK_ERROR_CODES.BACKEND.SERVER_UNAVAILABLE:
     case COMPOSIO_SDK_ERROR_CODES.BACKEND.RATE_LIMIT:
     case COMPOSIO_SDK_ERROR_CODES.BACKEND.UNKNOWN:
-    case COMPOSIO_SDK_ERROR_CODES.BACKEND.BAD_REQUEST:
       return {
         message: genericMessage,
         description: errorMessage || (predefinedError.description as string),

--- a/js/src/sdk/utils/errors/src/formatter.ts
+++ b/js/src/sdk/utils/errors/src/formatter.ts
@@ -9,7 +9,7 @@ export interface ErrorResponseData {
   type: string;
   name: string;
   message: string;
-  errors?: Record<string, unknown>[] | Record<string, unknown>;
+  details?: Record<string, unknown>[] | Record<string, unknown>;
 }
 
 interface ErrorDetails {
@@ -55,7 +55,7 @@ export const getAPIErrorDetails = (
 
   switch (errorCode) {
     case COMPOSIO_SDK_ERROR_CODES.BACKEND.BAD_REQUEST:
-      const validationErrors = axiosError.response?.data?.errors;
+      const validationErrors = axiosError.response?.data?.details;
       const formattedErrors = Array.isArray(validationErrors)
         ? validationErrors.map((err) => JSON.stringify(err)).join(", ")
         : JSON.stringify(validationErrors);


### PR DESCRIPTION
# 🔍 Review Summary 
 ## Release Note

### Purpose
- Refine error handling in the SDK by implementing Zod error formatting.

### Changes

#### Enhancement
- Integrated Zod error formatting for improved error handling within the SDK, enhancing test coverage with a new error structure.
- Revamped `formatter.ts` to format and display validation errors for `BAD_REQUEST` errors, providing clearer error descriptions for debugging and request validation.

### Impact
- Boosts error management in the SDK, aiding in debugging and creating better test cases, while enhancing the overall user experience with more comprehensible error messages. 



<details><summary>Original Description</summary>


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds Zod error formatting for `BAD_REQUEST` errors in `formatter.ts` and updates tests in `index.spec.ts`.
> 
>   - **Behavior**:
>     - Adds Zod error formatting in `getAPIErrorDetails()` in `formatter.ts` for `BAD_REQUEST` errors.
>     - Formats validation errors as JSON strings in error descriptions.
>   - **Tests**:
>     - Updates test case in `index.spec.ts` to check for validation error descriptions containing JSON strings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 6c60dd0ca0bc00a8ef333c5f09996ecf4c8c120d. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

</details>