### PR TITLE
fix: Allow manual execute action for any action

### DIFF
--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -1086,9 +1086,6 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
 
         if _populate_requested:
             action_names = [item.name for item in items]
-            if self._requested_actions is None:
-                self._requested_actions = []
-
             self._requested_actions += action_names
 
         return items

--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -328,7 +328,7 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
 
         # To be populated by get_tools(), from within subclasses like
         # composio_openai's Toolset.
-        self._requested_actions: t.Optional[t.List[str]] = None
+        self._requested_actions: t.List[str] = []
 
     def _validating_connection_ids(
         self,
@@ -848,6 +848,7 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
         text: t.Optional[str] = None,
         *,
         processors: t.Optional[ProcessorsType] = None,
+        _check_requested_actions: bool = False,
     ) -> t.Dict:
         """
         Execute an action on a given entity.
@@ -861,10 +862,7 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
         :return: Output object from the function call
         """
         action = Action(action)
-        if (
-            self._requested_actions is not None
-            and action.slug not in self._requested_actions
-        ):
+        if _check_requested_actions and action.slug not in self._requested_actions:
             raise ComposioSDKError(
                 f"Action {action.slug} is being called, but was never requested by the toolset. "
                 "Make sure that the actions you are trying to execute are requested in your "

--- a/python/plugins/autogen/composio_autogen/toolset.py
+++ b/python/plugins/autogen/composio_autogen/toolset.py
@@ -121,6 +121,7 @@ class ComposioToolSet(
                 action=Action(value=name),
                 params=kwargs,
                 entity_id=entity_id or self.entity_id,
+                _check_requested_actions=True,
             )
 
         function = types.FunctionType(

--- a/python/plugins/autogen/composio_autogen/toolset.py
+++ b/python/plugins/autogen/composio_autogen/toolset.py
@@ -43,7 +43,12 @@ class ComposioToolSet(
         :param entity_id: Entity ID to use for executing function calls.
         """
         self.validate_tools(apps=apps, actions=actions, tags=tags)
-        schemas = self.get_action_schemas(actions=actions, apps=apps, tags=tags)
+        schemas = self.get_action_schemas(
+            actions=actions,
+            apps=apps,
+            tags=tags,
+            _poplate_requested=True,
+        )
         for schema in schemas:
             self._register_schema_to_autogen(
                 schema=schema.model_dump(

--- a/python/plugins/autogen/composio_autogen/toolset.py
+++ b/python/plugins/autogen/composio_autogen/toolset.py
@@ -47,7 +47,7 @@ class ComposioToolSet(
             actions=actions,
             apps=apps,
             tags=tags,
-            _poplate_requested=True,
+            _populate_requested=True,
         )
         for schema in schemas:
             self._register_schema_to_autogen(

--- a/python/plugins/camel/composio_camel/toolset.py
+++ b/python/plugins/camel/composio_camel/toolset.py
@@ -126,6 +126,7 @@ class ComposioToolSet(
                 action=Action(value=name),
                 params=kwargs,
                 entity_id=entity_id or self.entity_id,
+                _check_requested_actions=True,
             )
 
         return OpenAIFunction(

--- a/python/plugins/claude/composio_claude/toolset.py
+++ b/python/plugins/claude/composio_claude/toolset.py
@@ -161,6 +161,7 @@ class ComposioToolSet(
             action=Action(value=tool_call.name),
             params=t.cast(t.Dict, tool_call.input),
             entity_id=entity_id or self.entity_id,
+            _check_requested_actions=True,
         )
 
     def handle_tool_calls(

--- a/python/plugins/crew_ai/composio_crewai/toolset.py
+++ b/python/plugins/crew_ai/composio_crewai/toolset.py
@@ -104,6 +104,7 @@ else:
                     action=Action(value=action),
                     params=kwargs,
                     entity_id=entity_id or self.entity_id,
+                    _check_requested_actions=True,
                 )
 
             class Wrapper(BaseTool):

--- a/python/plugins/google/composio_google/toolset.py
+++ b/python/plugins/google/composio_google/toolset.py
@@ -160,7 +160,10 @@ class ComposioToolset(
                     ),
                 )
                 for tool in self.get_action_schemas(
-                    actions=actions, apps=apps, tags=tags, _poplate_requested=True
+                    actions=actions,
+                    apps=apps,
+                    tags=tags,
+                    _populate_requested=True,
                 )
             ]
         )

--- a/python/plugins/google/composio_google/toolset.py
+++ b/python/plugins/google/composio_google/toolset.py
@@ -160,7 +160,7 @@ class ComposioToolset(
                     ),
                 )
                 for tool in self.get_action_schemas(
-                    actions=actions, apps=apps, tags=tags
+                    actions=actions, apps=apps, tags=tags, _poplate_requested=True
                 )
             ]
         )

--- a/python/plugins/griptape/composio_griptape/toolset.py
+++ b/python/plugins/griptape/composio_griptape/toolset.py
@@ -86,6 +86,7 @@ class ComposioToolSet(
                 action=Action(value=name),
                 params=params,
                 entity_id=entity_id or self.entity_id,
+                _check_requested_actions=True,
             )
 
         class GripTapeTool(BaseTool):

--- a/python/plugins/julep/composio_julep/toolset.py
+++ b/python/plugins/julep/composio_julep/toolset.py
@@ -46,6 +46,7 @@ class ComposioToolSet(
                                 action=Action(value=tool_function["name"]),
                                 params=json.loads(tool_function["arguments"]),
                                 entity_id=entity_id or self.entity_id,
+                                _check_requested_actions=True,
                             )
                         )
                     except json.JSONDecodeError:

--- a/python/plugins/langchain/composio_langchain/toolset.py
+++ b/python/plugins/langchain/composio_langchain/toolset.py
@@ -88,6 +88,7 @@ class ComposioToolSet(
                 action=action,
                 params=kwargs,
                 entity_id=entity_id or self.entity_id,
+                _check_requested_actions=True,
             )
 
         action_func = types.FunctionType(

--- a/python/plugins/llamaindex/composio_llamaindex/toolset.py
+++ b/python/plugins/llamaindex/composio_llamaindex/toolset.py
@@ -74,6 +74,7 @@ class ComposioToolSet(
                 action=Action(value=action),
                 params=kwargs,
                 entity_id=entity_id or self.entity_id,
+                _check_requested_actions=True,
             )
 
         action_func = types.FunctionType(

--- a/python/plugins/lyzr/composio_lyzr/toolset.py
+++ b/python/plugins/lyzr/composio_lyzr/toolset.py
@@ -47,6 +47,7 @@ class ComposioToolSet(
                 action=Action(value=name),
                 params=kwargs,
                 entity_id=entity_id or self.entity_id,
+                _check_requested_actions=True,
             )
 
         action_func = types.FunctionType(

--- a/python/plugins/openai/composio_openai/toolset.py
+++ b/python/plugins/openai/composio_openai/toolset.py
@@ -188,6 +188,7 @@ class ComposioToolSet(
             action=tool_call.function.name,
             params=json.loads(tool_call.function.arguments),
             entity_id=entity_id or self.entity_id,
+            _check_requested_actions=True,
         )
 
     def handle_tool_calls(

--- a/python/plugins/phidata/composio_phidata/toolset.py
+++ b/python/plugins/phidata/composio_phidata/toolset.py
@@ -57,6 +57,7 @@ class ComposioToolSet(
                     action=Action(value=name),
                     params=kwargs,
                     entity_id=entity_id or self.entity_id,
+                    _check_requested_actions=True,
                 )
             )
 

--- a/python/plugins/praisonai/composio_praisonai/toolset.py
+++ b/python/plugins/praisonai/composio_praisonai/toolset.py
@@ -79,6 +79,7 @@ class ComposioToolSet(
             action=Action(value=tool_identifier),
             params=params,
             entity_id=self.entity_id,
+            _check_requested_actions=True,
         )
 
     def _process_basetool(

--- a/python/tests/test_tools/test_toolset.py
+++ b/python/tests/test_tools/test_toolset.py
@@ -543,7 +543,12 @@ def test_invalid_handle_tool_calls() -> None:
     toolset.get_tools(actions=[Action.GMAIL_FETCH_EMAILS])
     with pytest.raises(ComposioSDKError) as exc:
         with mock.patch.object(toolset, "_execute_remote"):
-            toolset.execute_action(Action.HACKERNEWS_GET_FRONTPAGE, {})
+            toolset.execute_action(
+                Action.HACKERNEWS_GET_FRONTPAGE,
+                {},
+                # This is passed as True by all tools
+                _check_requested_actions=True,
+            )
 
     assert (
         "Action HACKERNEWS_GET_FRONTPAGE is being called, but was never requested by the toolset."
@@ -553,9 +558,15 @@ def test_invalid_handle_tool_calls() -> None:
     # Ensure it does NOT fail if a subsequent get_tools added that action
     toolset.get_tools(actions=[Action.HACKERNEWS_GET_FRONTPAGE])
     with mock.patch.object(toolset, "_execute_remote"):
-        toolset.execute_action(Action.HACKERNEWS_GET_FRONTPAGE, {})
+        toolset.execute_action(
+            Action.HACKERNEWS_GET_FRONTPAGE,
+            {},
+            # This is passed as True by all tools
+            _check_requested_actions=True,
+        )
 
-    # Ensure it DOES NOT fail if get_tools is never called
+    # Ensure it DOES NOT fail if execute_action is called manually, not by a tool
     toolset = LangchainToolSet()
+    toolset.get_tools(actions=[Action.GMAIL_FETCH_EMAILS])
     with mock.patch.object(toolset, "_execute_remote"):
         toolset.execute_action(Action.HACKERNEWS_GET_FRONTPAGE, {})


### PR DESCRIPTION
In the last release, we started blocking ALL execute_action calls on toolsets that used `get_tools()` to request tools. This chanage avoids blocking manually made execute_action calls.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces `_check_requested_actions` flag in `toolset.py` to allow manual `execute_action` calls without checks, updating related files and tests.
> 
>   - **Behavior**:
>     - Introduces `_check_requested_actions` flag in `execute_action()` in `toolset.py` to allow manual calls without checks.
>     - Updates `execute_action()` calls in `composio_autogen/toolset.py`, `composio_camel/toolset.py`, and 10 other files to set `_check_requested_actions=True`.
>   - **Initialization**:
>     - Initializes `_requested_actions` as an empty list in `toolset.py`.
>   - **Tests**:
>     - Updates `test_invalid_handle_tool_calls()` in `test_toolset.py` to test manual `execute_action()` calls without `_check_requested_actions` flag.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 58b6e3861bdab311cda81f5b1b029324e3a4bfbb. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->