### PR TITLE
fix: generate new request ID for every API request

### DIFF
--- a/python/composio/client/http.py
+++ b/python/composio/client/http.py
@@ -41,7 +41,6 @@ class HttpClient(SyncSession, logging.WithLogger):
         self.headers.update(
             {
                 "x-api-key": api_key,
-                "x-request-id": generate_request_id(),
                 "x-source": SOURCE_HEADER,
                 "x-runtime": runtime or DEFAULT_RUNTIME,
                 "x-composio-version": __version__,
@@ -57,6 +56,8 @@ class HttpClient(SyncSession, logging.WithLogger):
             self._logger.debug(
                 f"{method.__name__.upper()} {self.base_url}{url} - {kwargs}"
             )
+            self.headers.update({"x-request-id": generate_request_id()})
+
             retries = 0
             while retries < 3:
                 try:

--- a/python/composio/client/http.py
+++ b/python/composio/client/http.py
@@ -62,7 +62,10 @@ class HttpClient(SyncSession, logging.WithLogger):
                     return method(
                         url=f"{self.base_url}{url}",
                         timeout=self.timeout,
-                        headers={"x-request-id": generate_request_id()},
+                        headers={
+                            **kwargs.pop("headers", {}),
+                            "x-request-id": generate_request_id(),
+                        },
                         **kwargs,
                     )
                 except ReadTimeout:

--- a/python/composio/client/http.py
+++ b/python/composio/client/http.py
@@ -56,7 +56,6 @@ class HttpClient(SyncSession, logging.WithLogger):
             self._logger.debug(
                 f"{method.__name__.upper()} {self.base_url}{url} - {kwargs}"
             )
-            self.headers.update({"x-request-id": generate_request_id()})
 
             retries = 0
             while retries < 3:
@@ -64,6 +63,7 @@ class HttpClient(SyncSession, logging.WithLogger):
                     return method(
                         url=f"{self.base_url}{url}",
                         timeout=self.timeout,
+                        headers={"x-request-id": generate_request_id()},
                         **kwargs,
                     )
                 except ReadTimeout:

--- a/python/composio/client/http.py
+++ b/python/composio/client/http.py
@@ -56,7 +56,6 @@ class HttpClient(SyncSession, logging.WithLogger):
             self._logger.debug(
                 f"{method.__name__.upper()} {self.base_url}{url} - {kwargs}"
             )
-
             retries = 0
             while retries < 3:
                 try:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Move `generate_request_id()` to `request()` in `HttpClient` to ensure unique request IDs for each API request.
> 
>   - **Behavior**:
>     - Move `generate_request_id()` from `__init__` to `request()` in `HttpClient` to ensure a new request ID for each API request.
>   - **Misc**:
>     - Remove `x-request-id` from headers in `__init__` method.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 461fc7719bc71b540d23c691be1fd3c41156e105. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->