### PR TITLE
Fix phidata plugin to right format

### DIFF
--- a/python/plugins/phidata/composio_phidata/toolset.py
+++ b/python/plugins/phidata/composio_phidata/toolset.py
@@ -5,17 +5,28 @@ PhiData tool spec.
 import json
 import typing as t
 import warnings
-from inspect import Parameter, Signature
+from inspect import Signature
 
 import typing_extensions as te
 from phi.tools.toolkit import Toolkit
 from pydantic import validate_call
+from typing_extensions import Protocol
 
 from composio import Action, ActionType, AppType
 from composio import ComposioToolSet as BaseComposioToolSet
 from composio import TagType
 from composio.tools.toolset import ProcessorsType
 from composio.utils import help_msg, shared
+
+
+class ToolFunction(Protocol):
+    """Protocol for tool functions with required attributes."""
+
+    __signature__: Signature
+    __annotations__: t.Dict[str, t.Any]
+    __doc__: str
+
+    def __call__(self, *args: t.Any, **kwargs: t.Any) -> str: ...
 
 
 class ComposioToolSet(
@@ -66,9 +77,12 @@ class ComposioToolSet(
                 )
             )
 
+        # Cast the function to our Protocol type to satisfy mypy
+        func = t.cast(ToolFunction, function_template)
+
         # Apply the signature and annotations to the function
-        function_template.__signature__ = sig
-        function_template.__annotations__ = annotations
+        func.__signature__ = sig
+        func.__annotations__ = annotations
 
         # Format docstring in Phidata standard format
         docstring_parts = [description, "\nArgs:"]
@@ -81,10 +95,10 @@ class ComposioToolSet(
         docstring_parts.append(
             "\nReturns:\n    str: JSON string containing the function execution result"
         )
-        function_template.__doc__ = "\n".join(docstring_parts)
+        func.__doc__ = "\n".join(docstring_parts)
 
         # Register the function with the toolkit
-        toolkit.register(function_template)
+        toolkit.register(func)
 
         return toolkit
 

--- a/python/plugins/phidata/composio_phidata/toolset.py
+++ b/python/plugins/phidata/composio_phidata/toolset.py
@@ -44,11 +44,9 @@ class ComposioToolSet(
 
         @validate_call
         def function(**kwargs: t.Any) -> str:
-            """Composio tool wrapped as Phidata `Function`.
-
+            """
             Args:
                 **kwargs: Function parameters based on the schema
-
             Returns:
                 str: JSON string containing the function execution result
             """
@@ -61,15 +59,16 @@ class ComposioToolSet(
                 )
             )
 
-        # Set function docstring from schema
-        param_docs = []
+        # Format docstring in Phidata standard format
+        docstring_parts = [description, "\nArgs:"]
         if "properties" in parameters:
             for param_name, param_info in parameters["properties"].items():
                 param_desc = param_info.get("description", "No description available")
                 param_type = param_info.get("type", "any")
-                param_docs.append(f":param {param_name}: {param_desc} ({param_type})")
-
-        function.__doc__ = f"{description}\n\n" + "\n".join(param_docs)
+                docstring_parts.append(f"    {param_name} ({param_type}): {param_desc}")
+        
+        docstring_parts.append("\nReturns:\n    str: JSON string containing the function execution result")
+        function.__doc__ = "\n".join(docstring_parts)
 
         # Register the function with the toolkit
         toolkit.register(function)

--- a/python/plugins/phidata/phidata_demo.py
+++ b/python/plugins/phidata/phidata_demo.py
@@ -1,10 +1,12 @@
 from composio_phidata import Action, ComposioToolSet
-from phi.agent import Agent
+from phi.assistant import Assistant
 
 
 toolset = ComposioToolSet()
-composio_tools = toolset.get_tools(actions=[Action.GOOGLECALENDAR_CREATE_EVENT])
+composio_tools = toolset.get_tools(
+    actions=[Action.GITHUB_STAR_A_REPOSITORY_FOR_THE_AUTHENTICATED_USER]
+)
 
-print(composio_tools)
-agent = Agent(tools=composio_tools, show_tool_calls=True)
-agent.print_response("Create a new meeting at monday 08:00.")
+assistant = Assistant(tools=composio_tools, show_tool_calls=True)
+
+assistant.print_response("Can you start composiohq/composio repo?")

--- a/python/plugins/phidata/phidata_demo.py
+++ b/python/plugins/phidata/phidata_demo.py
@@ -1,12 +1,12 @@
 from composio_phidata import Action, ComposioToolSet
-from phi.assistant import Assistant
+from phi.agent import Agent
 
 
 toolset = ComposioToolSet()
 composio_tools = toolset.get_tools(
-    actions=[Action.GITHUB_STAR_A_REPOSITORY_FOR_THE_AUTHENTICATED_USER]
+    actions=[Action.GOOGLECALENDAR_CREATE_EVENT]
 )
 
-assistant = Assistant(tools=composio_tools, show_tool_calls=True)
-
-assistant.print_response("Can you start composiohq/composio repo?")
+print(composio_tools)
+agent = Agent(tools=composio_tools, show_tool_calls=True)
+agent.print_response("Create a new meeting at monday 08:00.")

--- a/python/plugins/phidata/phidata_demo.py
+++ b/python/plugins/phidata/phidata_demo.py
@@ -3,9 +3,7 @@ from phi.agent import Agent
 
 
 toolset = ComposioToolSet()
-composio_tools = toolset.get_tools(
-    actions=[Action.GOOGLECALENDAR_CREATE_EVENT]
-)
+composio_tools = toolset.get_tools(actions=[Action.GOOGLECALENDAR_CREATE_EVENT])
 
 print(composio_tools)
 agent = Agent(tools=composio_tools, show_tool_calls=True)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor `ComposioToolSet` in `toolset.py` to use `ToolFunction` protocol for function signature and docstring formatting.
> 
>   - **Protocols**:
>     - Introduce `ToolFunction` protocol to define required attributes for tool functions.
>   - **Function Wrapping**:
>     - Refactor `_wrap_tool` in `toolset.py` to use `ToolFunction` for function signature and annotations.
>     - Use `shared.get_signature_format_from_schema_params` to derive function parameters.
>     - Format function docstring to Phidata standard, including parameter and return type descriptions.
>   - **Misc**:
>     - Register functions with `Toolkit` using the new protocol.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 59ebd70feb327b77f28ff873f4705cccf12d6613. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->