### PR TITLE
feat: support custom actions in vercel toolkit (with type safety improvements)

### DIFF
--- a/js/src/frameworks/vercel.spec.ts
+++ b/js/src/frameworks/vercel.spec.ts
@@ -1,9 +1,12 @@
 import { beforeAll, describe, expect, it } from "@jest/globals";
+import { z } from "zod";
 import { getTestConfig } from "../../config/getTestConfig";
 import { VercelAIToolSet } from "./vercel";
+import type { CreateActionOptions } from "../sdk/actionRegistry";
 
 describe("Apps class tests", () => {
   let vercelAIToolSet: VercelAIToolSet;
+
   beforeAll(() => {
     vercelAIToolSet = new VercelAIToolSet({
       apiKey: getTestConfig().COMPOSIO_API_KEY,
@@ -25,4 +28,52 @@ describe("Apps class tests", () => {
     });
     expect(Object.keys(tools).length).toBe(1);
   });
+
+  describe("custom actions", () => {
+    let customAction: Awaited<ReturnType<typeof vercelAIToolSet.createAction>>;
+    let tools: Awaited<ReturnType<typeof vercelAIToolSet.getTools>>;
+
+    beforeAll(async () => {
+      const params = z.object({
+        owner: z.string().describe("The owner of the repository"),
+        repo: z.string().describe("The name of the repository without the `.git` extension."),
+      })
+
+
+      customAction = await vercelAIToolSet.createAction({
+        actionName: "starRepositoryCustomAction",
+        toolName: "github",
+        description: "Star A Github Repository For Given `Repo` And `Owner`",
+        inputParams: params,
+        callback: async (
+          inputParams,
+        ) => ({ successful: true, data: inputParams })
+      })
+
+      tools = await vercelAIToolSet.getTools({
+        actions: ["starRepositoryCustomAction"],
+      });
+
+    });
+
+    it("check if custom actions are coming", async () => {
+      expect(Object.keys(tools).length).toBe(1);
+      expect(tools).toHaveProperty(customAction.name, tools[customAction.name]);
+    });
+
+    it("check if custom actions are executing", async () => {
+      const res = await vercelAIToolSet.executeAction({
+        action: customAction.name,
+        params: {
+          owner: "composioHQ",
+          repo: "composio"
+        },
+      })
+      expect(res.successful).toBe(true);
+      expect(res.data).toHaveProperty("owner", "composioHQ");
+      expect(res.data).toHaveProperty("repo", "composio");
+    });
+  })
+
+
 });

--- a/js/src/sdk/actionRegistry.ts
+++ b/js/src/sdk/actionRegistry.ts
@@ -18,13 +18,25 @@ type RawExecuteRequestParam = {
   };
 };
 
-export type CreateActionOptions = {
+
+type ValidParameters = ZodObject<{ [key: string]: ZodString | ZodOptional<ZodString> }>
+export type Parameters = ValidParameters | z.ZodObject<{}>
+
+type inferParameters<PARAMETERS extends Parameters> =
+  PARAMETERS extends ValidParameters
+  ? z.infer<PARAMETERS>
+  : z.infer<z.ZodObject<{}>>
+
+
+export type CreateActionOptions<
+  P extends Parameters = z.ZodObject<{}>
+> = {
   actionName?: string;
   toolName?: string;
   description?: string;
-  inputParams: ZodObject<{ [key: string]: ZodString | ZodOptional<ZodString> }>;
+  inputParams?: P;
   callback: (
-    inputParams: Record<string, string>,
+    inputParams: inferParameters<P>,
     authCredentials: Record<string, string> | undefined,
     executeRequest: (
       data: RawExecuteRequestParam
@@ -50,7 +62,10 @@ export class ActionRegistry {
   client: Composio;
   customActions: Map<
     string,
-    { metadata: CreateActionOptions; schema: Record<string, unknown> }
+    {
+      metadata: CreateActionOptions;
+      schema: Record<string, unknown>
+    }
   >;
 
   constructor(client: Composio) {
@@ -58,7 +73,8 @@ export class ActionRegistry {
     this.customActions = new Map();
   }
 
-  async createAction(options: CreateActionOptions): Promise<RawActionData> {
+
+  async createAction<P extends Parameters = z.ZodObject<{}>>(options: CreateActionOptions<P>): Promise<RawActionData> {
     const { callback } = options;
     if (typeof callback !== "function") {
       throw new Error("Callback must be a function");
@@ -67,7 +83,7 @@ export class ActionRegistry {
       throw new Error("You must provide actionName for this action");
     }
     if (!options.inputParams) {
-      options.inputParams = z.object({});
+      options.inputParams = z.object({}) as P
     }
     const params = options.inputParams;
     const actionName = options.actionName || callback.name || "";

--- a/js/src/sdk/base.toolset.ts
+++ b/js/src/sdk/base.toolset.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z, ZodObject } from "zod";
 import { Composio } from "../sdk";
 import {
   RawActionData,
@@ -10,7 +10,7 @@ import {
 } from "../types/base_toolset";
 import type { Optional, Sequence } from "../types/util";
 import { getEnvVariable } from "../utils/shared";
-import { ActionRegistry, CreateActionOptions } from "./actionRegistry";
+import { ActionRegistry, CreateActionOptions, Parameters } from "./actionRegistry";
 import { ActionExecutionResDto } from "./client/types.gen";
 import { ActionExecuteResponse, Actions } from "./models/actions";
 import { ActiveTriggers } from "./models/activeTriggers";
@@ -54,10 +54,10 @@ export class ComposioToolSet {
     post: TPostProcessor[];
     schema: TSchemaProcessor[];
   } = {
-    pre: [fileInputProcessor],
-    post: [fileResponseProcessor],
-    schema: [fileSchemaProcessor],
-  };
+      pre: [fileInputProcessor],
+      post: [fileResponseProcessor],
+      schema: [fileSchemaProcessor],
+    };
 
   private userDefinedProcessors: {
     pre?: TPreProcessor;
@@ -172,8 +172,8 @@ export class ComposioToolSet {
     });
   }
 
-  async createAction(options: CreateActionOptions) {
-    return this.userActionRegistry.createAction(options);
+  async createAction<P extends Parameters = z.ZodObject<{}>>(options: CreateActionOptions<P>) {
+    return this.userActionRegistry.createAction<P>(options);
   }
 
   private isCustomAction(action: string) {


### PR DESCRIPTION
This PR introduces two small enhancements:

**Generics-Based Inference in `createAction`**

- Refactors the `createAction` function to accept a generic parameter P (extending a Zod schema type)
- `inputParams` in the callback are now automatically inferred based on the provided Zod schema, reducing manual type annotations.

**Inclusion of Custom Actions in Vercel Toolkit’s `getTools`**
- Updates the Vercel toolkit to include custom actions when calling `getTools`,
- Previously, getTools did not include custom actions, preventing them from being automatically included in the generated toolset used with the Vercel AI SDK. With this update, custom actions are now part of the toolkit, making them seamlessly available for integration.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance `createAction` with generics-based inference and integrate custom actions into Vercel Toolkit's `getTools`.
> 
>   - **Generics-Based Inference in `createAction`**:
>     - Refactor `createAction` in `actionRegistry.ts` to accept a generic parameter `P` extending a Zod schema type.
>     - `inputParams` in the callback are inferred based on the provided Zod schema.
>   - **Inclusion of Custom Actions in Vercel Toolkit’s `getTools`**:
>     - Update `getTools` in `vercel.ts` to include custom actions.
>     - Modify `getToolsSchema` in `base.toolset.ts` to filter and include custom actions.
>   - **Tests**:
>     - Add tests in `vercel.spec.ts` to verify inclusion and execution of custom actions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for b5aac360484bb62ed54bc6045b633e28ddc6fde7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->