### PR TITLE
fix: use app filter when fetching integrations for `initiate_connection`

### DIFF
--- a/python/composio/client/collections.py
+++ b/python/composio/client/collections.py
@@ -1491,13 +1491,28 @@ class Integrations(Collection[IntegrationModel]):
         self.client.http.delete(url=str(self.endpoint / id))
 
     @t.overload  # type: ignore
-    def get(self) -> t.List[IntegrationModel]: ...
+    def get(
+        self,
+        *,
+        page_size: t.Optional[int] = None,
+        page: t.Optional[int] = None,
+        app_id: t.Optional[str] = None,
+        app_name: t.Optional[str] = None,
+        show_disabled: t.Optional[bool] = None,
+    ) -> t.List[IntegrationModel]: ...
 
     @t.overload
     def get(self, id: t.Optional[str] = None) -> IntegrationModel: ...
 
     def get(
-        self, id: t.Optional[str] = None
+        self,
+        id: t.Optional[str] = None,
+        *,
+        page_size: t.Optional[int] = None,
+        page: t.Optional[int] = None,
+        app_id: t.Optional[str] = None,
+        app_name: t.Optional[str] = None,
+        show_disabled: t.Optional[bool] = None,
     ) -> t.Union[t.List[IntegrationModel], IntegrationModel]:
         if id is not None:
             return IntegrationModel(
@@ -1505,7 +1520,24 @@ class Integrations(Collection[IntegrationModel]):
                     self.client.http.get(url=str(self.endpoint / id))
                 ).json()
             )
-        return super().get({})
+
+        quries = {}
+        if page_size is not None:
+            quries["pageSize"] = json.dumps(page_size)
+
+        if page is not None:
+            quries["page"] = json.dumps(page)
+
+        if app_id is not None:
+            quries["appId"] = app_id
+
+        if app_name is not None:
+            quries["appName"] = app_name
+
+        if show_disabled is not None:
+            quries["showDisabled"] = json.dumps(show_disabled)
+
+        return super().get(queries=quries)
 
     @te.deprecated("`get_id` is deprecated, use `get(id=id)`")
     def get_by_id(

--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -1341,8 +1341,12 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
         self,
         app: t.Optional[AppType] = None,
         auth_scheme: t.Optional[AuthSchemeType] = None,
+        fetch_disabled: bool = False,
     ) -> t.List[IntegrationModel]:
-        integrations = self.client.integrations.get()
+        integrations = self.client.integrations.get(
+            show_disabled=fetch_disabled,
+            page_size=999,
+        )
         if app is not None:
             app = str(app).lower()
             integrations = [i for i in integrations if i.appName.lower() == app]
@@ -1350,7 +1354,7 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
         if auth_scheme is not None:
             integrations = [i for i in integrations if i.authScheme == auth_scheme]
 
-        return integrations
+        return sorted(integrations, key=lambda x: x.createdAt)
 
     def get_connected_account(self, id: str) -> ConnectedAccountModel:
         return self.client.connected_accounts.get(connection_id=id)
@@ -1405,10 +1409,7 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
         app: AppType,
         auth_scheme: t.Optional[str] = None,
     ) -> IntegrationModel:
-        for integration in sorted(
-            self.get_integrations(app=app),
-            key=lambda x: x.createdAt,
-        ):
+        for integration in reversed(self.get_integrations(app=app)):
             if integration.appName.lower() == str(app).lower():
                 if (
                     auth_scheme is not None

--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -1405,7 +1405,10 @@ class ComposioToolSet(WithLogger):  # pylint: disable=too-many-public-methods
         app: AppType,
         auth_scheme: t.Optional[str] = None,
     ) -> IntegrationModel:
-        for integration in sorted(self.get_integrations(), key=lambda x: x.createdAt):
+        for integration in sorted(
+            self.get_integrations(app=app),
+            key=lambda x: x.createdAt,
+        ):
             if integration.appName.lower() == str(app).lower():
                 if (
                     auth_scheme is not None


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance integration fetching with new filters in `collections.py` and update `toolset.py` to utilize these filters for improved integration handling.
> 
>   - **Behavior**:
>     - Enhance `get` method in `collections.py` to support filtering by `app_id`, `app_name`, and `show_disabled`.
>     - Update `get_integrations` in `toolset.py` to use new filters, sorting results by `createdAt`.
>   - **Functions**:
>     - Modify `get` in `collections.py` to accept `page_size`, `page`, `app_id`, `app_name`, `show_disabled` as optional parameters.
>     - Update `_get_integration_for_app` in `toolset.py` to use filtered integrations list.
>   - **Misc**:
>     - Sort integrations by `createdAt` in `get_integrations` in `toolset.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 618a440910ae73c6cab0f0f0f02026a7ba8e8a53. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->