### PR TITLE
fix: allow auto reconnection in pusher client

### DIFF
--- a/python/composio/client/collections.py
+++ b/python/composio/client/collections.py
@@ -830,6 +830,7 @@ class _PusherClient(logging.WithLogger):
                 "x-api-key": self.api_key,
                 "x-request-id": generate_request_id(),
             },
+            auto_sub=True,
         )
 
         # Patch pusher logger


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enable automatic channel subscription in `_PusherClient.connect()` by setting `auto_sub=True`.
> 
>   - **Behavior**:
>     - Adds `auto_sub=True` to the `pysher.Pusher` initialization in `_PusherClient.connect()` to enable automatic channel subscription upon connection.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 52af13041bf70264ff78bb7f7c3cbb51f7ea72da. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->