### PR TITLE
fix: Removed hard exception for using custom tools without connected accounts

### DIFF
--- a/js/src/sdk/base.toolset.ts
+++ b/js/src/sdk/base.toolset.ts
@@ -31,6 +31,7 @@ import {
   fileResponseProcessor,
   fileSchemaProcessor,
 } from "./utils/processor/file";
+import logger from "../utils/logger";
 
 export type ExecuteActionParams = z.infer<typeof ZExecuteActionParams> & {
   // @deprecated
@@ -246,6 +247,11 @@ export class ComposioToolSet {
           showActiveOnly: true,
         });
         accountId = connectedAccounts?.items[0]?.id;
+      }
+
+      // allows the user to use custom actions and tools without a connected account
+      if (!accountId) {
+        logger.warn("No connected account found for the user. If your custom action requires a connected account, please double check if you have active accounts connected to it.");
       }
 
       return this.userActionRegistry.executeAction(action, params, {

--- a/js/src/sdk/base.toolset.ts
+++ b/js/src/sdk/base.toolset.ts
@@ -248,10 +248,6 @@ export class ComposioToolSet {
         accountId = connectedAccounts?.items[0]?.id;
       }
 
-      if (!accountId) {
-        throw new Error("No connected account found for the user");
-      }
-
       return this.userActionRegistry.executeAction(action, params, {
         entityId: entityId,
         connectionId: accountId,


### PR DESCRIPTION
This fixes the hard error `Error: No connected account found for the user` for users trying to use a custom action / tool that does not require a connected account.

This fix allows the user to use custom actions and tools without a connected account.

This fix only affects the Javascript SDK, and manually tested using Javascript SDK.

This fix only affects the npm package `composio-core`.

I detailed my findings in Discord, you can see it on #support-forum channel titled 'Sample Code in "Build Tools Without Auth" asks for a connected account'
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes hard exception in `ComposioToolSet` for executing custom actions without a connected account in the JavaScript SDK.
> 
>   - **Behavior**:
>     - Removes hard exception for missing connected account in `executeAction` method of `ComposioToolSet` class in `base.toolset.ts`.
>     - Allows execution of custom actions/tools without a connected account.
>   - **Scope**:
>     - Affects only the JavaScript SDK.
>     - Specifically impacts the `composio-core` npm package.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 9104c7f3eb0aa1c192ecfbc9c13c53c62265ca93. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->