### PR TITLE
fix: session ID delegation

### DIFF
--- a/python/composio/client/collections.py
+++ b/python/composio/client/collections.py
@@ -1319,6 +1319,9 @@ class Actions(Collection[ActionModel]):
                     "input": modified_params,
                     "text": text,
                     "authConfig": self._serialize_auth(auth=auth),
+                    "sessionInfo": {
+                        "sessionId": session_id,
+                    },
                 },
             )
         ).json()

--- a/python/composio/client/http.py
+++ b/python/composio/client/http.py
@@ -53,8 +53,9 @@ class HttpClient(SyncSession, logging.WithLogger):
 
         def request(url: str, **kwargs: t.Any) -> t.Any:
             """Perform HTTP request."""
+            rid = generate_request_id()
             self._logger.debug(
-                f"{method.__name__.upper()} {self.base_url}{url} - {kwargs}"
+                f"[{rid}] {method.__name__.upper()} {self.base_url}{url} - {kwargs}"
             )
             retries = 0
             while retries < 3:
@@ -64,7 +65,7 @@ class HttpClient(SyncSession, logging.WithLogger):
                         timeout=self.timeout,
                         headers={
                             **kwargs.pop("headers", {}),
-                            "x-request-id": generate_request_id(),
+                            "x-request-id": rid,
                         },
                         **kwargs,
                     )


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add session ID handling to action execution and improve request ID consistency in HTTP client logging.
> 
>   - **Behavior**:
>     - Add `sessionInfo` with `sessionId` to `execute()` in `collections.py` for action execution.
>     - Use a consistent request ID (`rid`) for logging and headers in `_wrap()` in `http.py`.
>   - **Misc**:
>     - Minor logging format change in `http.py` to include request ID in debug logs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 293f9b2f3961e0a0f76b66ab9717a98bf45f05ae. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->