### PR TITLE
fix: tool name showing as `function_template` in phidata

### DIFF
--- a/python/plugins/phidata/composio_phidata/toolset.py
+++ b/python/plugins/phidata/composio_phidata/toolset.py
@@ -108,7 +108,7 @@ class ComposioToolSet(
     @te.deprecated("Use `ComposioToolSet.get_tools` instead.\n", category=None)
     def get_actions(
         self, actions: t.Sequence[ActionType]
-    ) -> t.List[t.Union[Tool, Toolkit, t.Callable, t.Dict, Function]] | None:
+    ) -> t.List[t.Union[Tool, Toolkit, t.Callable, t.Dict, Function]]:
         """
         Get composio tools wrapped as Phidata `Toolkit` objects.
 
@@ -133,7 +133,7 @@ class ComposioToolSet(
         *,
         processors: t.Optional[ProcessorsType] = None,
         check_connected_accounts: bool = True,
-    ) -> t.List[t.Union[Tool, Toolkit, t.Callable, t.Dict, Function]] | None:
+    ) -> t.List[t.Union[Tool, Toolkit, t.Callable, t.Dict, Function]]:
         """
         Get composio tools wrapped as Phidata `Toolkit` objects.
 

--- a/python/plugins/phidata/composio_phidata/toolset.py
+++ b/python/plugins/phidata/composio_phidata/toolset.py
@@ -8,6 +8,8 @@ import warnings
 from inspect import Signature
 
 import typing_extensions as te
+from phi.tools.function import Function
+from phi.tools.tool import Tool
 from phi.tools.toolkit import Toolkit
 from pydantic import validate_call
 from typing_extensions import Protocol
@@ -83,6 +85,7 @@ class ComposioToolSet(
         # Apply the signature and annotations to the function
         func.__signature__ = sig
         func.__annotations__ = annotations
+        func.__setattr__("__name__", name.lower())
 
         # Format docstring in Phidata standard format
         docstring_parts = [description, "\nArgs:"]
@@ -103,7 +106,9 @@ class ComposioToolSet(
         return toolkit
 
     @te.deprecated("Use `ComposioToolSet.get_tools` instead.\n", category=None)
-    def get_actions(self, actions: t.Sequence[ActionType]) -> t.List[Toolkit]:
+    def get_actions(
+        self, actions: t.Sequence[ActionType]
+    ) -> t.List[t.Union[Tool, Toolkit, t.Callable, t.Dict, Function]] | None:
         """
         Get composio tools wrapped as Phidata `Toolkit` objects.
 
@@ -128,7 +133,7 @@ class ComposioToolSet(
         *,
         processors: t.Optional[ProcessorsType] = None,
         check_connected_accounts: bool = True,
-    ) -> t.List[Toolkit]:
+    ) -> t.List[t.Union[Tool, Toolkit, t.Callable, t.Dict, Function]] | None:
         """
         Get composio tools wrapped as Phidata `Toolkit` objects.
 

--- a/python/plugins/phidata/phidata_demo.py
+++ b/python/plugins/phidata/phidata_demo.py
@@ -7,6 +7,8 @@ composio_tools = toolset.get_tools(
     actions=[Action.GITHUB_STAR_A_REPOSITORY_FOR_THE_AUTHENTICATED_USER]
 )
 
-assistant = Assistant(run_id=None, tools=composio_tools, show_tool_calls=True)
+assistant = Assistant(
+    run_id=None, tools=composio_tools, show_tool_calls=True
+)  # run_id is a mandatory parameter
 
 assistant.print_response("Can you start composiohq/composio repo?")

--- a/python/plugins/phidata/phidata_demo.py
+++ b/python/plugins/phidata/phidata_demo.py
@@ -1,5 +1,5 @@
 from composio_phidata import Action, ComposioToolSet
-from phi.assistant import Assistant
+from phi.assistant.assistant import Assistant
 
 
 toolset = ComposioToolSet()
@@ -7,6 +7,6 @@ composio_tools = toolset.get_tools(
     actions=[Action.GITHUB_STAR_A_REPOSITORY_FOR_THE_AUTHENTICATED_USER]
 )
 
-assistant = Assistant(tools=composio_tools, show_tool_calls=True)
+assistant = Assistant(run_id=None, tools=composio_tools, show_tool_calls=True)
 
 assistant.print_response("Can you start composiohq/composio repo?")


### PR DESCRIPTION
Phidata toolkit was showing composio toolnames as `function_template`. Changed function signature to the lowercase enum to fix this.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix tool name display issue by setting `__name__` to lowercase in `function_template` and update return types in `get_actions` and `get_tools`.
> 
>   - **Behavior**:
>     - Fix tool name display issue by setting `__name__` to lowercase in `function_template` in `toolset.py`.
>     - Update `get_actions` and `get_tools` in `toolset.py` to return `t.List[t.Union[Tool, Toolkit, t.Callable, t.Dict, Function]]`.
>   - **Imports**:
>     - Correct import for `Assistant` in `phidata_demo.py` to `from phi.assistant.assistant import Assistant`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 59f4d77f4148010ed8eca8f504417d44f7b93544. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->