### PR TITLE
feat: switch to createPromptModule

### DIFF
--- a/js/src/cli/add.ts
+++ b/js/src/cli/add.ts
@@ -129,7 +129,8 @@ export default class AddCommand {
   }
 
   async shouldForceConnectionSetup() {
-    const { shouldForce } = await inquirer.prompt([
+    const prompt = inquirer.createPromptModule();
+    const { shouldForce } = await prompt([
       {
         type: "confirm",
         name: "shouldForce",
@@ -263,7 +264,8 @@ export default class AddCommand {
       !skipDefaultConnectorAuth &&
       testConnectors.find((connector) => connector.auth_mode === userAuthMode)
     ) {
-      const { doYouWantToUseComposioAuth } = await inquirer.prompt({
+      const prompt = inquirer.createPromptModule();
+      const { doYouWantToUseComposioAuth } = await prompt({
         type: "confirm",
         name: "doYouWantToUseComposioAuth",
         message: "Do you want to use Composio Auth?",
@@ -275,7 +277,8 @@ export default class AddCommand {
       useComposioAuth = false;
     }
 
-    const { integrationName } = await inquirer.prompt({
+    const prompt = inquirer.createPromptModule();
+    const { integrationName } = await prompt({
       type: "input",
       name: "integrationName",
       message: "Enter the Integration name",
@@ -411,7 +414,8 @@ export default class AddCommand {
         continue;
       }
 
-      const { [field.name]: value } = await inquirer.prompt({
+      const prompt = inquirer.createPromptModule();
+      const { [field.name]: value } = await prompt({
         type: "input",
         name: field.name,
         message: (field.displayName || field.display_name) as string,

--- a/js/src/cli/login.ts
+++ b/js/src/cli/login.ts
@@ -62,7 +62,8 @@ export default class LoginCommand {
   }
 
   private async promptForAuthCode(): Promise<string> {
-    const { authCode } = await inquirer.prompt({
+    const prompt = inquirer.createPromptModule();
+    const { authCode } = await prompt({
       type: "input",
       name: "authCode",
       message: "Enter authentication code:",

--- a/js/src/cli/triggers.ts
+++ b/js/src/cli/triggers.ts
@@ -137,7 +137,8 @@ export class TriggerAdd {
 
     for (const key in properties) {
       if (requiredProperties.includes(key)) {
-        const answer = await inquirer.prompt([
+        const prompt = inquirer.createPromptModule();
+        const answer = await prompt([
           {
             type: "input",
             name: key,


### PR DESCRIPTION
```
  "exports": {
    "./package.json": "./package.json",
    ".": {
      "import": {
        "types": "./dist/esm/index.d.ts",
        "default": "./dist/esm/index.js"
      },
      "require": {
        "types": "./dist/commonjs/index.d.ts",
        "default": "./dist/commonjs/index.js"
      }
    }
  },
  ```
Import of esm and CJS type are different: face. Switch to `inquirer/prompts` later on. 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor CLI commands to use `inquirer.createPromptModule` instead of `inquirer.prompt` for user prompts.
> 
>   - **Refactor**:
>     - Switch from `inquirer.prompt` to `inquirer.createPromptModule` in `add.ts`, `login.ts`, and `triggers.ts`.
>     - Affects methods like `shouldForceConnectionSetup`, `promptForAuthCode`, and `handleAction` in respective files.
>   - **Misc**:
>     - Update `exports` in `package.json` to differentiate between ESM and CJS types.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for c106bc564c7a937cdea2c332f32b82f77040279f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->