### PR TITLE
fix: added entity id validation while checking fro connected account

### DIFF
--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -1495,8 +1495,14 @@ class ComposioToolSet(_IntegrationMixin):
 
         raise ComposioSDKError(message=f"Invalid connected accounts found: {invalid}")
 
-    def check_connected_account(self, action: ActionType) -> None:
-        """Check if connected account is required and if required it exists or not."""
+    def check_connected_account(
+        self, action: ActionType, entity_ids: t.Optional[t.List[str]] = None
+    ) -> None:
+        """Check if connected account is required and if required it exists or not.
+
+        :param action: The action to check connected account for.
+        :param entity_ids: The list of entity_ids to filter connected accounts by. If None, toolset's entity_id is picked up.
+        """
         action = Action(action)
         if action.no_auth or action.is_runtime:
             return
@@ -1507,7 +1513,9 @@ class ComposioToolSet(_IntegrationMixin):
         if self._connected_accounts is None:
             self._connected_accounts = t.cast(
                 t.List[ConnectedAccountModel],
-                self.client.connected_accounts.get(),
+                self.client.connected_accounts.get(
+                    entity_ids=[self.entity_id] if entity_ids is None else entity_ids
+                ),
             )
 
         if action.app not in [

--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -1510,12 +1510,11 @@ class ComposioToolSet(_IntegrationMixin):
         if self._custom_auth_helper.has_custom_auth(App(action.app)):
             return
 
+        _entity_ids = [self.entity_id] if entity_ids is None else entity_ids
         if self._connected_accounts is None:
             self._connected_accounts = t.cast(
                 t.List[ConnectedAccountModel],
-                self.client.connected_accounts.get(
-                    entity_ids=[self.entity_id] if entity_ids is None else entity_ids
-                ),
+                self.client.connected_accounts.get(entity_ids=_entity_ids),
             )
 
         if action.app not in [
@@ -1524,7 +1523,7 @@ class ComposioToolSet(_IntegrationMixin):
             for connection in self._connected_accounts
         ]:
             raise ComposioSDKError(
-                f"No connected account found for app `{action.app}`; "
+                f"No connected account found for app `{action.app}` for entity ids `{_entity_ids}`; "
                 f"Run `composio add {action.app.lower()}` to fix this"
             )
 


### PR DESCRIPTION
Fixes [ENG-3203](https://linear.app/composio/issue/ENG-3203/fix-check-connected-account-in-composiotoolset). `check_connected_account` method in the toolset, fetches connected accounts across all the entities. This should not be the case, and it should check connected accounts only with the `entity_id` of the `toolset` or with explicitly mentioned ones.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update `check_connected_account` in `toolset.py` to validate connected accounts against specific `entity_ids`, defaulting to toolset's `entity_id` if not provided.
> 
>   - **Behavior**:
>     - Update `check_connected_account` in `toolset.py` to validate connected accounts against specific `entity_ids`.
>     - Adds `entity_ids` parameter to `check_connected_account` to filter connected accounts by entity.
>     - Defaults to toolset's `entity_id` if `entity_ids` is not provided.
>   - **Error Handling**:
>     - Raises `ComposioSDKError` if no connected account is found for the specified `entity_ids`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for cfb3811a1b2bf749c2f7b6f0d4c4943834a57b7f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->