### PR TITLE
fix: handled unprocessable tool call requests

### DIFF
--- a/python/plugins/claude/composio_claude/toolset.py
+++ b/python/plugins/claude/composio_claude/toolset.py
@@ -3,6 +3,7 @@ import warnings
 
 import typing_extensions as te
 
+from composio.exceptions import ComposioSDKError
 from composio.utils import help_msg
 
 
@@ -166,7 +167,7 @@ class ComposioToolSet(
 
     def handle_tool_calls(
         self,
-        llm_response: ToolsBetaMessage,
+        llm_response: t.Union[dict, ToolsBetaMessage],
         entity_id: t.Optional[str] = None,
     ) -> t.List[t.Dict]:
         """
@@ -177,15 +178,19 @@ class ComposioToolSet(
         :param entity_id: Entity ID to use for executing function calls.
         :return: A list of output objects from the function calls.
         """
+        # Since llm_response can also be a dictionary, we should only proceed
+        # towards action execution if we have the correct type of llm_response
+        if not isinstance(llm_response, (dict, ToolsBetaMessage)):
+            raise ComposioSDKError(
+                "llm_response should be of type `Message` or castable to type `Message`, "
+                f"received object {llm_response} of type {type(llm_response)}"
+            )
+        if isinstance(llm_response, dict):
+            llm_response = ToolsBetaMessage(**llm_response)
+
         outputs = []
         entity_id = self.validate_entity_id(entity_id or self.entity_id)
-        # since llm_response can also be a dictionary, we should only proceed
-        # towards action execution if we have the correct type of llm_response
         llm_response = t.cast(ToolsBetaMessage, llm_response)
-        if not isinstance(llm_response, ToolsBetaMessage):
-            raise ValueError(
-                f"llm_response should be of type `Message` or castable to type `Message`, received object {llm_response} of type {type(llm_response)}"
-            )
         for content in llm_response.content:
             if isinstance(content, (ToolUseBlock, BetaToolUseBlock)):
                 outputs.append(

--- a/python/plugins/claude/composio_claude/toolset.py
+++ b/python/plugins/claude/composio_claude/toolset.py
@@ -190,7 +190,6 @@ class ComposioToolSet(
 
         outputs = []
         entity_id = self.validate_entity_id(entity_id or self.entity_id)
-        llm_response = t.cast(ToolsBetaMessage, llm_response)
         for content in llm_response.content:
             if isinstance(content, (ToolUseBlock, BetaToolUseBlock)):
                 outputs.append(

--- a/python/plugins/claude/composio_claude/toolset.py
+++ b/python/plugins/claude/composio_claude/toolset.py
@@ -179,6 +179,13 @@ class ComposioToolSet(
         """
         outputs = []
         entity_id = self.validate_entity_id(entity_id or self.entity_id)
+        # since llm_response can also be a dictionary, we should only proceed
+        # towards action execution if we have the correct type of llm_response
+        llm_response = t.cast(ToolsBetaMessage, llm_response)
+        if not isinstance(llm_response, ToolsBetaMessage):
+            raise ValueError(
+                f"llm_response should be of type `Message` or castable to type `Message`, received object {llm_response} of type {type(llm_response)}"
+            )
         for content in llm_response.content:
             if isinstance(content, (ToolUseBlock, BetaToolUseBlock)):
                 outputs.append(

--- a/python/tests/test_tools/test_plugins.py
+++ b/python/tests/test_tools/test_plugins.py
@@ -1,9 +1,11 @@
 import composio_llamaindex
+import pytest
 from pydantic import BaseModel
 
 from composio import action
 from composio.client.enums.action import Action
 
+import composio_claude
 import composio_crewai
 import composio_langchain
 import composio_openai
@@ -299,87 +301,121 @@ def test_langchain_toolset() -> None:
 
 
 def test_claude_toolset() -> None:
-    toolset = composio_crewai.ComposioToolSet()
+    toolset = composio_claude.ComposioToolSet()
 
     tools = toolset.get_tools(actions=[create_draft])
     assert len(tools) == 1
 
     tool = tools[0]
-    assert tool.name == "MYTOOL_CREATE_DRAFT"
+    assert tool.get("name") == "MYTOOL_CREATE_DRAFT"
     assert (
-        tool.description
+        tool.get("description")
         # TODO: Thread's properties should be present in the arguments
-        == "Tool Name: MYTOOL_CREATE_DRAFT\nTool Arguments: {'message_body': {'description': 'The content of the draft reply. Please provide a value of type string. This parameter is required.', 'type': 'str'}, 'thread': {'description': 'The thread to which the reply is to be drafted', 'type': 'dict'}}\nTool Description: Create a draft reply to a specific Gmail thread"
+        == "Create a draft reply to a specific Gmail thread"
     )
-    assert tool.args_schema.model_json_schema() == {
+    assert tool.get("input_schema", {}) == {
         "properties": {
             "message_body": {
-                "description": "The content of the draft reply. Please provide a value of type "
-                "string. This parameter is required.",
-                "examples": [],
+                "description": "The content of the draft reply. Please provide a value of type string. This parameter is required.",
                 "title": "Message Body",
                 "type": "string",
             },
             "thread": {
+                "anyOf": [
+                    {
+                        "properties": {"id": {"title": "Id", "type": "string"}},
+                        "required": ["id"],
+                        "title": "Thread",
+                        "type": "object",
+                    },
+                    {"type": "null"},
+                ],
                 "default": None,
                 "description": "The thread to which the reply is to be drafted",
-                "examples": [],
-                "title": "Thread",
-                # TODO: Thread's properties should be present in the schema
                 "type": "object",
             },
         },
-        "required": ["message_body"],
-        # TODO: title should be MYTOOL_CREATE_DRAFT
         "title": "CreateDraftRequest",
         "type": "object",
+        "required": ["message_body"],
     }
 
     tools = toolset.get_tools(actions=[Action.ANTHROPIC_COMPUTER])
     assert len(tools) == 1
 
     tool = tools[0]
-    assert (
-        tool.description
-        == "Tool Name: computer\nTool Arguments: {'action': {'description': 'The action to perform on the computer. Please provide a value of type string. This parameter is required. Please provide a value of type string. This parameter is required. Please provide a value of type string. This parameter is required. Please provide a value of type string. This parameter is required.', 'type': 'str'}, 'text': {'description': 'Text to type or key sequence to press. Please provide a value of type string. Please provide a value of type string. Please provide a value of type string. Please provide a value of type string.', 'type': 'str'}, 'coordinate': {'description': 'X,Y coordinates for mouse actions', 'type': 'list'}}\nTool Description: A Tool That Allows Interaction With The Screen, Keyboard, And Mouse Of The Current Computer. Adapted For Mac Os And Linux."
-    )
-    assert tool.args_schema.model_json_schema() == {
+    assert tool.get("name") == "computer"
+    assert tool.get("input_schema") == {
         "properties": {
             "action": {
-                # TODO: "please provide" and "is required" is there FOUR TIMES
-                "description": "The action to perform on the computer. Please provide a value of "
-                "type string. This parameter is required. Please provide a value "
-                "of type string. This parameter is required. Please provide a "
-                "value of type string. This parameter is required. Please provide "
-                "a value of type string. This parameter is required.",
-                "examples": [],
-                "title": "Action",
+                "description": "The action to perform on the "
+                "computer. Please provide a value of "
+                "type string. This parameter is "
+                "required. Please provide a value of "
+                "type string. This parameter is "
+                "required. Please provide a value of "
+                "type string. This parameter is "
+                "required. Please provide a value of "
+                "type string. This parameter is "
+                "required.",
+                "enum": [
+                    "key",
+                    "type",
+                    "mouse_move",
+                    "left_click",
+                    "left_click_drag",
+                    "right_click",
+                    "middle_click",
+                    "double_click",
+                    "screenshot",
+                    "cursor_position",
+                ],
+                "title": "ActionType",
                 "type": "string",
             },
-            "coordinate": {
-                "default": None,
-                "description": "X,Y coordinates for mouse actions",
-                "examples": [],
-                "items": {},
-                "title": "Coordinate",
-                "type": "array",
-            },
             "text": {
+                "anyOf": [{"type": "string"}, {"type": "null"}],
                 "default": None,
-                # TODO: "please provide" is there FOUR TIMES
-                "description": "Text to type or key sequence to press. Please provide a value of "
-                "type string. Please provide a value of type string. Please "
-                "provide a value of type string. Please provide a value of type string.",
-                "examples": [],
+                "description": "Text to type or key sequence to "
+                "press. Please provide a value of type "
+                "string. Please provide a value of "
+                "type string. Please provide a value "
+                "of type string. Please provide a "
+                "value of type string.",
                 "title": "Text",
                 "type": "string",
             },
+            "coordinate": {
+                "anyOf": [
+                    {
+                        "maxItems": 2,
+                        "minItems": 2,
+                        "prefixItems": [{"type": "integer"}, {"type": "integer"}],
+                        "type": "array",
+                    },
+                    {"type": "null"},
+                ],
+                "default": None,
+                "description": "X,Y coordinates for mouse actions",
+                "title": "Coordinate",
+                "type": "array",
+            },
         },
-        "required": ["action"],
-        # TODO: title should be computer
         "title": "ComputerRequest",
         "type": "object",
+        "required": ["action"],
     }
+
+    # check that objects that cannot be casted into Message type raise an error.
+    random_llm_response = {"some_random_key_from_llm": "some_random_value_from_llm"}
+    with pytest.raises(
+        expected_exception=ValueError,
+        match=(
+            "llm_response should be of type `Message` or castable to type `Message`, "
+            f"received object {random_llm_response} of type {type(random_llm_response)}"
+        ),
+    ):
+        toolset.handle_tool_calls(llm_response=random_llm_response)
 
 
 def test_llamaindex_toolset() -> None:


### PR DESCRIPTION
Fixes [ENG-3617](https://linear.app/composio/issue/ENG-3617/fix-tool-calling-on-claude-plugin). `handle_tool_calls` method accepts `llm_response` of type `Message` from anthropic's API.

But other type of objects can also be passed, and there is not check for that.

This PR adds a check for such situations. If the object passed can be casted to type `Message`, it does that and proceeds else raises a simple yet informative error message.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds type-checking to `handle_tool_calls` in `toolset.py` to ensure `llm_response` is a `dict` or `ToolsBetaMessage`, with tests in `test_plugins.py`.
> 
>   - **Behavior**:
>     - `handle_tool_calls` in `toolset.py` now checks if `llm_response` is a `dict` or `ToolsBetaMessage`.
>     - Raises `ComposioSDKError` if `llm_response` is not castable to `ToolsBetaMessage`.
>     - Casts `llm_response` to `ToolsBetaMessage` if it is a `dict`.
>   - **Tests**:
>     - Added tests in `test_plugins.py` to verify error is raised for invalid `llm_response` types.
>     - Tests ensure `ComposioSDKError` and `ValidationError` are raised appropriately.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 06f6ed11dacd57babc1ae481750476052df3c390. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->