### PR TITLE
fix: _latest_version and sentry dns internet checks

### DIFF
--- a/python/composio/utils/sentry.py
+++ b/python/composio/utils/sentry.py
@@ -122,10 +122,14 @@ def update_dsn() -> None:
     if data.get("sentry", {}).get("dsn") is not None:
         return
 
-    dsn = fetch_dsn()
-    if dsn is None:
-        return
+    try:
+        dsn = fetch_dsn()
+        if dsn is None:
+            return
 
-    data["sentry"] = {"dsn": dsn}
+        data["sentry"] = {"dsn": dsn}
+    except Exception:  # pylint: disable=broad-except
+        pass
+
     user_file.parent.mkdir(parents=True, exist_ok=True)
     user_file.write_text(json.dumps(data), encoding="utf-8")

--- a/python/composio/utils/warnings.py
+++ b/python/composio/utils/warnings.py
@@ -15,12 +15,15 @@ _latest_version = None
 
 def _fetch_latest_version():
     global _latest_version
-    request = requests.get(COMPOSIO_PYPI_METADATA, timeout=10.0)
-    if request.status_code != 200:
-        return
+    try:
+        request = requests.get(COMPOSIO_PYPI_METADATA, timeout=10.0)
+        if request.status_code != 200:
+            return
 
-    data = request.json()
-    _latest_version = data["info"]["version"]
+        data = request.json()
+        _latest_version = data["info"]["version"]
+    except Exception:  # pylint: disable=broad-except
+        pass
 
 
 def create_latest_version_warning_hook(version: str):


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add exception handling to `update_dsn()` in `sentry.py` and `_fetch_latest_version()` in `warnings.py` to improve robustness.
> 
>   - **Exception Handling**:
>     - Add try-except block in `update_dsn()` in `sentry.py` to handle exceptions during DSN fetching.
>     - Add try-except block in `_fetch_latest_version()` in `warnings.py` to handle exceptions during version fetching.
>   - **Behavior**:
>     - In `sentry.py`, if fetching DSN fails, the function now silently fails without updating the DSN.
>     - In `warnings.py`, if fetching the latest version fails, the function now silently fails without updating `_latest_version`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 1a8c3328b5963dfbba29eae627cbf4f4e05c99a1. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->