### PR TITLE
fix: docs connections redirect url

### DIFF
--- a/docs/introduction/intro/basic.mdx
+++ b/docs/introduction/intro/basic.mdx
@@ -20,7 +20,7 @@ Now that you've seen how to use triggers, you can explore the following resource
 <Card title="Tools" href="../../patterns/tools/what-are-tools">
 Checkout our toolset of 250+ LLM ready tools to build powerful AI applications
 </Card>
-<Card title="Connections" href="patterns/Auth/connected_account">
+<Card title="Connections" href="../../patterns/Auth/connected_account">
 Learn how to create and manage connections for your users
 </Card>
 <Card title="Compatible Agentic Frameworks" href="/framework/autogen">

--- a/docs/introduction/intro/overview.mdx
+++ b/docs/introduction/intro/overview.mdx
@@ -37,7 +37,7 @@ Get started with these resources:
 <Card title="Tools" href="../../patterns/tools/what-are-tools">
 Checkout our toolset of 250+ LLM ready tools to build powerful AI applications
 </Card>
-<Card title="Connections" href="patterns/Auth/connected_account">
+<Card title="Connections" href="../../patterns/Auth/connected_account">
 Learn how to create and manage connections for your users
 </Card>
 <Card title="Kits" href="../../swekit/introduction">

--- a/docs/introduction/intro/quickstart-tools.mdx
+++ b/docs/introduction/intro/quickstart-tools.mdx
@@ -187,7 +187,7 @@ Now that you've seen how to use tools, you can explore the following resources:
 <Card title="Tools" href="../../patterns/tools/what-are-tools">
 Checkout our toolset of 250+ LLM ready tools to build powerful AI applications
 </Card>
-<Card title="Connections" href="patterns/Auth/connected_account">
+<Card title="Connections" href="../../patterns/Auth/connected_account">
 Learn how to create and manage connections for your users
 </Card>
 <Card title="Compatible Agentic Frameworks" href="/framework/autogen">

--- a/docs/introduction/intro/quickstart-triggers.mdx
+++ b/docs/introduction/intro/quickstart-triggers.mdx
@@ -233,7 +233,7 @@ Now that you've seen how to use triggers, you can explore the following resource
 <Card title="Tools" href="../../patterns/tools/what-are-tools">
 Checkout our toolset of 250+ LLM ready tools to build powerful AI applications
 </Card>
-<Card title="Connections" href="patterns/Auth/connected_account">
+<Card title="Connections" href="../../patterns/Auth/connected_account">
 Learn how to create and manage connections for your users
 </Card>
 <Card title="Compatible Agentic Frameworks" href="/framework/autogen">


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix relative URL for 'Connections' card in multiple documentation files to ensure correct redirection.
> 
>   - **Documentation**:
>     - Fix relative URL for 'Connections' card in `basic.mdx`, `overview.mdx`, `quickstart-tools.mdx`, and `quickstart-triggers.mdx` to `../../patterns/Auth/connected_account`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for f396495f618a82b9fd00c879362dff918badd385. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->