### PR TITLE
feat: add support for checkRequest actions override in openai

### DIFF
--- a/python/plugins/openai/composio_openai/toolset.py
+++ b/python/plugins/openai/composio_openai/toolset.py
@@ -176,6 +176,7 @@ class ComposioToolSet(
         self,
         tool_call: ChatCompletionMessageToolCall,
         entity_id: t.Optional[str] = None,
+        check_requested_actions: bool = True,
     ) -> t.Dict:
         """
         Execute a tool call.
@@ -188,13 +189,14 @@ class ComposioToolSet(
             action=tool_call.function.name,
             params=json.loads(tool_call.function.arguments),
             entity_id=entity_id or self.entity_id,
-            _check_requested_actions=True,
+            _check_requested_actions=check_requested_actions,
         )
 
     def handle_tool_calls(
         self,
         response: ChatCompletion,
         entity_id: t.Optional[str] = None,
+        check_requested_actions: bool = True,
     ) -> t.List[t.Dict]:
         """
         Handle tool calls from OpenAI chat completion object.
@@ -214,6 +216,7 @@ class ComposioToolSet(
                             self.execute_tool_call(
                                 tool_call=tool_call,
                                 entity_id=entity_id or self.entity_id,
+                                check_requested_actions=check_requested_actions,
                             )
                         )
         return outputs
@@ -222,6 +225,7 @@ class ComposioToolSet(
         self,
         run: Run,
         entity_id: t.Optional[str] = None,
+        check_requested_actions: bool = True,
     ) -> t.List:
         """Wait and handle assistant function calls"""
         tool_outputs = []
@@ -231,6 +235,7 @@ class ComposioToolSet(
             tool_response = self.execute_tool_call(
                 tool_call=t.cast(ChatCompletionMessageToolCall, tool_call),
                 entity_id=entity_id or self.entity_id,
+                check_requested_actions=check_requested_actions,
             )
             tool_output = {
                 "tool_call_id": tool_call.id,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `check_requested_actions` parameter to allow overriding action checks in `execute_tool_call()`, `handle_tool_calls()`, and `handle_assistant_tool_calls()` in `toolset.py`.
> 
>   - **Behavior**:
>     - Add `check_requested_actions` parameter to `execute_tool_call()`, `handle_tool_calls()`, and `handle_assistant_tool_calls()` in `toolset.py`.
>     - Allows overriding the default behavior of checking requested actions during tool execution.
>   - **Functions**:
>     - `execute_tool_call()`: Executes tool call with optional action check.
>     - `handle_tool_calls()`: Handles tool calls with optional action check.
>     - `handle_assistant_tool_calls()`: Handles assistant tool calls with optional action check.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for ab6146e076a0c6f4c3ee305da169cba587f2492b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->