### PR TITLE
chore: remove deprecated notice for entity.execute in python sdk

### DIFF
--- a/python/composio/client/__init__.py
+++ b/python/composio/client/__init__.py
@@ -247,7 +247,6 @@ class Entity:
         self.client = client
         self.id = id
 
-    @deprecated(version="0.5.52", replacement="execute_action")
     def execute(
         self,
         action: Action,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `@deprecated` decorator from `execute()` in `Entity` class in `__init__.py`.
> 
>   - **Behavior**:
>     - Removed `@deprecated` decorator from `execute()` in `Entity` class in `__init__.py`. Previously marked for replacement by `execute_action`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for d61d005dd5f83af3b96458cc0d5db4168917cce5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->