### PR TITLE
fix: use `exists` flag to avoid duplicate uploads

### DIFF
--- a/python/composio/client/collections.py
+++ b/python/composio/client/collections.py
@@ -1068,6 +1068,7 @@ class CreateUploadURLResponse(BaseModel):
     id: str = Field(..., description="ID of the file")
     url: str = Field(..., description="Onetime upload URL")
     key: str = Field(..., description="S3 upload location")
+    exists: bool = Field(False, description="If the file already exists on S3")
 
 
 class Actions(Collection[ActionModel]):

--- a/python/composio/client/files.py
+++ b/python/composio/client/files.py
@@ -64,7 +64,7 @@ class FileUploadable(BaseModel):
             mimetype=mimetype,
             md5=get_md5(file=file),
         )
-        if not upload(url=s3meta.url, file=file):
+        if not s3meta.exists and not upload(url=s3meta.url, file=file):
             raise ComposioSDKError(f"Error uploading file: {file}")
 
         return cls(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `exists` flag to `CreateUploadURLResponse` to prevent duplicate file uploads by checking existence before upload in `files.py`.
> 
>   - **Behavior**:
>     - Add `exists` flag to `CreateUploadURLResponse` in `collections.py` to indicate if a file already exists on S3.
>     - Modify `from_path()` in `files.py` to check `exists` flag before uploading a file to avoid duplicates.
>   - **Models**:
>     - Update `CreateUploadURLResponse` model in `collections.py` to include `exists` flag.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 8513aa911feff67e9c61f9d493052cec86ec1706. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->