### PR TITLE
feat: add environment to config home directory for serverless environments

### DIFF
--- a/python/composio/cli/context.py
+++ b/python/composio/cli/context.py
@@ -17,7 +17,6 @@ from composio.client import Composio
 from composio.constants import (
     ENV_COMPOSIO_API_KEY,
     LOCAL_CACHE_DIRECTORY,
-    LOCAL_CACHE_DIRECTORY_NAME,
     USER_DATA_FILE_NAME,
 )
 from composio.storage.user import UserData

--- a/python/composio/cli/context.py
+++ b/python/composio/cli/context.py
@@ -16,6 +16,7 @@ from rich.console import Console
 from composio.client import Composio
 from composio.constants import (
     ENV_COMPOSIO_API_KEY,
+    LOCAL_CACHE_DIRECTORY,
     LOCAL_CACHE_DIRECTORY_NAME,
     USER_DATA_FILE_NAME,
 )
@@ -57,7 +58,7 @@ class Context(logging.WithLogger):
     def cache_dir(self) -> Path:
         """Cache directory."""
         if self._cache_dir is None:
-            self._cache_dir = Path.home() / LOCAL_CACHE_DIRECTORY_NAME
+            self._cache_dir = LOCAL_CACHE_DIRECTORY
         if not self._cache_dir.exists():
             self._cache_dir.mkdir(parents=True)
         return self._cache_dir

--- a/python/composio/client/__init__.py
+++ b/python/composio/client/__init__.py
@@ -41,6 +41,7 @@ from composio.client.http import HttpClient
 from composio.constants import (
     DEFAULT_ENTITY_ID,
     ENV_COMPOSIO_API_KEY,
+    LOCAL_CACHE_DIRECTORY,
     LOCAL_CACHE_DIRECTORY_NAME,
     USER_DATA_FILE_NAME,
 )
@@ -99,7 +100,7 @@ class Composio:
     @property
     def api_key(self) -> str:
         if self._api_key is None:
-            cache_dir = Path.home() / LOCAL_CACHE_DIRECTORY_NAME
+            cache_dir = LOCAL_CACHE_DIRECTORY
             user_data_path = cache_dir / USER_DATA_FILE_NAME
             user_data = (
                 UserData.load(path=user_data_path) if user_data_path.exists() else None

--- a/python/composio/constants.py
+++ b/python/composio/constants.py
@@ -26,9 +26,14 @@ LOCAL_CACHE_DIRECTORY_NAME = ".composio"
 Local cache directory name for composio CLI
 """
 
-LOCAL_CACHE_DIRECTORY = (
-    Path.home() if Path.home().exists() else Path.cwd()
-) / LOCAL_CACHE_DIRECTORY_NAME
+COMPOSIO_HOME_DIRECTORY = (
+    Path(str(os.environ.get("COMPOSIO_HOME")))
+    if os.environ.get("COMPOSIO_HOME")
+    else (Path.home() if Path.home().exists() else Path.cwd())
+)
+
+LOCAL_CACHE_DIRECTORY = COMPOSIO_HOME_DIRECTORY / LOCAL_CACHE_DIRECTORY_NAME
+
 """
 Path to local caching directory.
 """

--- a/python/composio/tools/env/docker/workspace.py
+++ b/python/composio/tools/env/docker/workspace.py
@@ -9,6 +9,7 @@ import typing as t
 from dataclasses import dataclass
 from pathlib import Path
 
+from composio.constants import LOCAL_CACHE_DIRECTORY
 from composio.exceptions import ComposioSDKError
 from composio.tools.env.base import RemoteWorkspace, WorkspaceConfigType
 from composio.tools.env.constants import (
@@ -35,7 +36,7 @@ except ImportError:
 
 
 COMPOSIO_PATH = Path(__file__).parent.parent.parent.parent.parent.resolve()
-COMPOSIO_CACHE = Path.home() / ".composio"
+COMPOSIO_CACHE = LOCAL_CACHE_DIRECTORY
 CONTAINER_DEV_VOLUMES = {
     COMPOSIO_PATH: {
         "bind": "/opt/composio-core",

--- a/python/composio/tools/local/browsertool/actions/base_action.py
+++ b/python/composio/tools/local/browsertool/actions/base_action.py
@@ -2,12 +2,11 @@ import random
 import string
 from abc import abstractmethod
 from enum import Enum
-from pathlib import Path
 from typing import Dict, Optional
 
-from composio.constants import COMPOSIO_HOME_DIRECTORY
 from pydantic import BaseModel, Field
 
+from composio.constants import COMPOSIO_HOME_DIRECTORY
 from composio.tools.base.local import ActionRequest, ActionResponse, LocalAction
 from composio.tools.env.browsermanager.manager import BrowserManager
 

--- a/python/composio/tools/local/browsertool/actions/base_action.py
+++ b/python/composio/tools/local/browsertool/actions/base_action.py
@@ -5,6 +5,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Dict, Optional
 
+from composio.constants import COMPOSIO_HOME_DIRECTORY
 from pydantic import BaseModel, Field
 
 from composio.tools.base.local import ActionRequest, ActionResponse, LocalAction
@@ -174,7 +175,7 @@ class BaseBrowserAction(LocalAction[ActionRequest, ActionResponse], abs=True):
             )
 
     def _take_screenshot(self, browser_manager: BrowserManager, prefix: str) -> str:
-        home_dir = Path.home()
+        home_dir = COMPOSIO_HOME_DIRECTORY
         browser_media_dir = home_dir / ".browser_media"
         browser_media_dir.mkdir(parents=True, exist_ok=True)
         random_string = "".join(random.choices(string.ascii_lowercase, k=6))

--- a/python/composio/tools/local/browsertool/actions/get_screenshot.py
+++ b/python/composio/tools/local/browsertool/actions/get_screenshot.py
@@ -6,6 +6,7 @@ import random
 import string
 from pathlib import Path
 
+from composio.constants import COMPOSIO_HOME_DIRECTORY
 from pydantic import Field
 
 from composio.tools.env.browsermanager.manager import BrowserManager
@@ -65,7 +66,7 @@ class GetScreenshot(BaseBrowserAction[GetScreenshotRequest, GetScreenshotRespons
         """Execute the screenshot action."""
         try:
             if not request.output_path or request.output_path == "":
-                home_dir = Path.home()
+                home_dir = COMPOSIO_HOME_DIRECTORY
                 browser_media_dir = home_dir / ".browser_media"
                 browser_media_dir.mkdir(parents=True, exist_ok=True)
                 random_string = "".join(random.choices(string.ascii_lowercase, k=6))

--- a/python/composio/tools/local/browsertool/actions/get_screenshot.py
+++ b/python/composio/tools/local/browsertool/actions/get_screenshot.py
@@ -6,9 +6,9 @@ import random
 import string
 from pathlib import Path
 
-from composio.constants import COMPOSIO_HOME_DIRECTORY
 from pydantic import Field
 
+from composio.constants import COMPOSIO_HOME_DIRECTORY
 from composio.tools.env.browsermanager.manager import BrowserManager
 from composio.tools.local.browsertool.actions.base_action import (
     BaseBrowserAction,

--- a/python/composio/tools/local/codeanalysis/constants.py
+++ b/python/composio/tools/local/codeanalysis/constants.py
@@ -1,8 +1,10 @@
 import os
 from pathlib import Path
 
+from composio.constants import LOCAL_CACHE_DIRECTORY
 
-CODE_MAP_CACHE = os.path.join(Path.home(), ".composio/tmp")
+
+CODE_MAP_CACHE = os.path.join(LOCAL_CACHE_DIRECTORY, "tmp")
 FQDN_FILE = "fqdn_cache.json"
 DEEPLAKE_FOLDER = "deeplake"
 EMBEDDER = "sentence-transformers/all-mpnet-base-v2"

--- a/python/composio/tools/local/codeanalysis/constants.py
+++ b/python/composio/tools/local/codeanalysis/constants.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 
 from composio.constants import LOCAL_CACHE_DIRECTORY
 

--- a/python/composio/tools/local/embedtool/actions/create_vectorstore.py
+++ b/python/composio/tools/local/embedtool/actions/create_vectorstore.py
@@ -2,9 +2,9 @@ import os
 from pathlib import Path
 from typing import List, Optional, Type
 
-from composio.constants import LOCAL_CACHE_DIRECTORY
 from pydantic import BaseModel, Field
 
+from composio.constants import LOCAL_CACHE_DIRECTORY
 from composio.tools.base.local import LocalAction
 
 

--- a/python/composio/tools/local/embedtool/actions/create_vectorstore.py
+++ b/python/composio/tools/local/embedtool/actions/create_vectorstore.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 from typing import List, Optional, Type
 
+from composio.constants import LOCAL_CACHE_DIRECTORY
 from pydantic import BaseModel, Field
 
 from composio.tools.base.local import LocalAction
@@ -56,7 +57,7 @@ class CreateImageVectorStore(
         from chromadb.utils import embedding_functions  # pylint: disable=C0415
 
         image_collection_name = Path(request.folder_path).name + "_images"
-        index_storage_path = Path.home() / ".composio" / "image_index_storage"
+        index_storage_path = LOCAL_CACHE_DIRECTORY / "image_index_storage"
         index_storage_path.mkdir(parents=True, exist_ok=True)
 
         # Initialize Chroma client

--- a/python/composio/tools/local/embedtool/actions/query_vectorstore.py
+++ b/python/composio/tools/local/embedtool/actions/query_vectorstore.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 
-from composio.constants import LOCAL_CACHE_DIRECTORY
 from pydantic import BaseModel, Field
 
+from composio.constants import LOCAL_CACHE_DIRECTORY
 from composio.tools.base.local import LocalAction
 
 

--- a/python/composio/tools/local/embedtool/actions/query_vectorstore.py
+++ b/python/composio/tools/local/embedtool/actions/query_vectorstore.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from composio.constants import LOCAL_CACHE_DIRECTORY
 from pydantic import BaseModel, Field
 
 from composio.tools.base.local import LocalAction
@@ -46,7 +47,7 @@ class QueryImageVectorStore(
         from chromadb.utils import embedding_functions  # pylint: disable=C0415
 
         image_collection_name = Path(request.indexed_directory).name + "_images"
-        index_storage_path = Path.home() / ".composio" / "image_index_storage"
+        index_storage_path = LOCAL_CACHE_DIRECTORY / "image_index_storage"
         chroma_client = chromadb.PersistentClient(path=str(index_storage_path))
         chroma_collection = chroma_client.get_collection(image_collection_name)
 

--- a/python/composio/utils/sentry.py
+++ b/python/composio/utils/sentry.py
@@ -9,6 +9,7 @@ import typing as t
 from functools import cache
 from pathlib import Path
 
+from composio.constants import LOCAL_CACHE_DIRECTORY
 import requests
 import sentry_sdk
 import sentry_sdk.integrations.argv
@@ -35,7 +36,7 @@ def fetch_dsn() -> t.Optional[str]:
 
 
 def get_sentry_config() -> t.Optional[t.Dict]:
-    user_file = Path.home() / ".composio" / "user_data.json"
+    user_file = LOCAL_CACHE_DIRECTORY / "user_data.json"
     if not user_file.exists():
         update_dsn()
 
@@ -110,7 +111,7 @@ def init():
 
 @atexit.register
 def update_dsn() -> None:
-    user_file = Path.home() / ".composio" / "user_data.json"
+    user_file = LOCAL_CACHE_DIRECTORY / "user_data.json"
     if user_file.exists():
         try:
             data = json.loads(user_file.read_text(encoding="utf-8"))

--- a/python/composio/utils/sentry.py
+++ b/python/composio/utils/sentry.py
@@ -7,9 +7,7 @@ import traceback
 import types
 import typing as t
 from functools import cache
-from pathlib import Path
 
-from composio.constants import LOCAL_CACHE_DIRECTORY
 import requests
 import sentry_sdk
 import sentry_sdk.integrations.argv
@@ -22,6 +20,8 @@ import sentry_sdk.integrations.modules
 import sentry_sdk.integrations.stdlib
 import sentry_sdk.integrations.threading
 import sentry_sdk.types
+
+from composio.constants import LOCAL_CACHE_DIRECTORY
 
 
 @cache

--- a/python/plugins/smolagent/smol_demo.py
+++ b/python/plugins/smolagent/smol_demo.py
@@ -11,6 +11,6 @@ tools = composio_toolset.get_tools(
     actions=[Action.GITHUB_STAR_A_REPOSITORY_FOR_THE_AUTHENTICATED_USER],
 )
 # Create agent with Composio tools
-agent = CodeAgent(tools=tools, model=HfApiModel())# type: ignore[import-untyped]
+agent = CodeAgent(tools=tools, model=HfApiModel())  # type: ignore[import-untyped]
 
 agent.run("Star the composiohq/composio repo")

--- a/python/swe/dockerfiles/create_index.py
+++ b/python/swe/dockerfiles/create_index.py
@@ -5,10 +5,10 @@ import typing as t
 from pathlib import Path
 
 import click
-from composio.constants import LOCAL_CACHE_DIRECTORY
 from swebench import get_eval_refs
 
 from composio import Action, ComposioToolSet
+from composio.constants import LOCAL_CACHE_DIRECTORY
 from composio.utils.logging import WithLogger
 
 

--- a/python/swe/dockerfiles/create_index.py
+++ b/python/swe/dockerfiles/create_index.py
@@ -5,6 +5,7 @@ import typing as t
 from pathlib import Path
 
 import click
+from composio.constants import LOCAL_CACHE_DIRECTORY
 from swebench import get_eval_refs
 
 from composio import Action, ComposioToolSet
@@ -81,7 +82,7 @@ class IndexGenerator(WithLogger):
             action=Action.CODE_ANALYSIS_TOOL_CREATE_CODE_MAP,
             params={"dir_to_index_path": str(outdir / outname)},
         )
-        with open(f"{Path.home()}/.composio/tmp/{outname}/fqdn_cache.json") as f:
+        with open(f"{LOCAL_CACHE_DIRECTORY}/tmp/{outname}/fqdn_cache.json") as f:
             fqdn_index = json.load(f)
             for k, v in fqdn_index.items():
                 if len(v) >= 1:
@@ -103,7 +104,7 @@ class IndexGenerator(WithLogger):
         # DEEPLAKE_PATH.mkdir(exist_ok=True, parents=True)
         if not DEEPLAKE_PATH.exists():
             shutil.copytree(
-                f"{Path.home()}/.composio/tmp/{outname}/deeplake",
+                f"{LOCAL_CACHE_DIRECTORY}/tmp/{outname}/deeplake",
                 DEEPLAKE_PATH,
             )
 

--- a/python/swe/swekit/benchmark/run_evaluation.py
+++ b/python/swe/swekit/benchmark/run_evaluation.py
@@ -6,12 +6,12 @@ import traceback
 import typing as t
 from pathlib import Path
 
-from composio.constants import LOCAL_CACHE_DIRECTORY
 from pydantic import BaseModel, Field
 from swebench.harness.test_spec import make_test_spec
 from tqdm import tqdm
 
 from composio import WorkspaceConfigType, WorkspaceFactory, WorkspaceType
+from composio.constants import LOCAL_CACHE_DIRECTORY
 from composio.utils.logging import WithLogger
 
 from swekit.benchmark.utils import (
@@ -20,7 +20,7 @@ from swekit.benchmark.utils import (
     get_score,
     setup_workspace,
 )
-from swekit.config.constants import LOCAL_CACHE_DIRECTORY_NAME, LOGS_DIR
+from swekit.config.constants import LOGS_DIR
 from swekit.config.store import IssueConfig
 
 

--- a/python/swe/swekit/benchmark/run_evaluation.py
+++ b/python/swe/swekit/benchmark/run_evaluation.py
@@ -6,6 +6,7 @@ import traceback
 import typing as t
 from pathlib import Path
 
+from composio.constants import LOCAL_CACHE_DIRECTORY
 from pydantic import BaseModel, Field
 from swebench.harness.test_spec import make_test_spec
 from tqdm import tqdm
@@ -26,8 +27,7 @@ from swekit.config.store import IssueConfig
 def _get_logs_dir() -> Path:
     """Logs dir factory."""
     return (
-        Path.home()
-        / LOCAL_CACHE_DIRECTORY_NAME
+        LOCAL_CACHE_DIRECTORY
         / LOGS_DIR
         / (
             str(int(datetime.datetime.now().timestamp()))

--- a/python/swe/swekit/config/context.py
+++ b/python/swe/swekit/config/context.py
@@ -7,17 +7,17 @@ from functools import update_wrapper
 from pathlib import Path
 
 import click
-from composio.constants import LOCAL_CACHE_DIRECTORY
 import typing_extensions as te
 from click.globals import get_current_context as get_click_context
 from rich.console import Console
+
+from composio.constants import LOCAL_CACHE_DIRECTORY
 
 from swekit.config.constants import (
     ISSUE_CONFIG_PATH,
     KEY_API_KEY,
     KEY_AZURE_ENDPOINT,
     KEY_MODEL_ENV,
-    LOCAL_CACHE_DIRECTORY_NAME,
     LOGS_DIR,
     MODEL_ENV_AZURE,
     MODEL_ENV_OPENAI,

--- a/python/swe/swekit/config/context.py
+++ b/python/swe/swekit/config/context.py
@@ -7,6 +7,7 @@ from functools import update_wrapper
 from pathlib import Path
 
 import click
+from composio.constants import LOCAL_CACHE_DIRECTORY
 import typing_extensions as te
 from click.globals import get_current_context as get_click_context
 from rich.console import Console
@@ -57,7 +58,7 @@ class Context:
     def cache_dir(self) -> Path:
         """Cache directory."""
         if self._cache_dir is None:
-            self._cache_dir = Path.home() / LOCAL_CACHE_DIRECTORY_NAME
+            self._cache_dir = LOCAL_CACHE_DIRECTORY
         if not self._cache_dir.exists():
             self._cache_dir.mkdir(parents=True)
         return self._cache_dir


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `COMPOSIO_HOME` environment variable to specify custom home directory, updating cache directory logic across modules.
> 
>   - **Environment Variable**:
>     - Introduces `COMPOSIO_HOME` to specify a custom home directory for serverless environments in `constants.py`.
>     - Updates `COMPOSIO_HOME_DIRECTORY` to use `COMPOSIO_HOME` if set, otherwise defaults to `Path.home()` or `Path.cwd()`.
>   - **Cache Directory**:
>     - Replaces `Path.home() / LOCAL_CACHE_DIRECTORY_NAME` with `LOCAL_CACHE_DIRECTORY` in `context.py`, `client/__init__.py`, and `docker/workspace.py`.
>     - Updates cache directory usage in `base_action.py`, `get_screenshot.py`, `constants.py`, `create_vectorstore.py`, `query_vectorstore.py`, `sentry.py`, `create_index.py`, `run_evaluation.py`, and `context.py` to use `LOCAL_CACHE_DIRECTORY`.
>   - **Miscellaneous**:
>     - Fixes minor formatting issue in `smol_demo.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 66aafbc03e54eef60b2070b4b6fd02e4235c374e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->