### PR TITLE
fix: cachedir writability check

### DIFF
--- a/python/composio/cli/context.py
+++ b/python/composio/cli/context.py
@@ -16,7 +16,7 @@ from rich.console import Console
 from composio.client import Composio
 from composio.constants import (
     ENV_COMPOSIO_API_KEY,
-    LOCAL_CACHE_DIRECTORY_NAME,
+    LOCAL_CACHE_DIRECTORY,
     USER_DATA_FILE_NAME,
 )
 from composio.storage.user import UserData
@@ -57,7 +57,7 @@ class Context(logging.WithLogger):
     def cache_dir(self) -> Path:
         """Cache directory."""
         if self._cache_dir is None:
-            self._cache_dir = Path.home() / LOCAL_CACHE_DIRECTORY_NAME
+            self._cache_dir = LOCAL_CACHE_DIRECTORY
         if not self._cache_dir.exists():
             self._cache_dir.mkdir(parents=True)
         return self._cache_dir

--- a/python/composio/client/__init__.py
+++ b/python/composio/client/__init__.py
@@ -6,7 +6,6 @@ import os
 import sys
 import typing as t
 from datetime import datetime
-from pathlib import Path
 
 import requests
 
@@ -41,7 +40,7 @@ from composio.client.http import HttpClient
 from composio.constants import (
     DEFAULT_ENTITY_ID,
     ENV_COMPOSIO_API_KEY,
-    LOCAL_CACHE_DIRECTORY_NAME,
+    LOCAL_CACHE_DIRECTORY,
     USER_DATA_FILE_NAME,
 )
 from composio.exceptions import ApiKeyNotProvidedError
@@ -99,8 +98,7 @@ class Composio:
     @property
     def api_key(self) -> str:
         if self._api_key is None:
-            cache_dir = Path.home() / LOCAL_CACHE_DIRECTORY_NAME
-            user_data_path = cache_dir / USER_DATA_FILE_NAME
+            user_data_path = LOCAL_CACHE_DIRECTORY / USER_DATA_FILE_NAME
             user_data = (
                 UserData.load(path=user_data_path) if user_data_path.exists() else None
             )

--- a/python/composio/constants.py
+++ b/python/composio/constants.py
@@ -26,12 +26,38 @@ LOCAL_CACHE_DIRECTORY_NAME = ".composio"
 Local cache directory name for composio CLI
 """
 
+LOCAL_CACHE_DIRECTORY_NAME = ".composio"
+"""
+Local cache directory name for composio CLI
+"""
+
+ENV_LOCAL_CACHE_DIRECTORY = "COMPOSIO_CACHE_DIR"
+"""
+Environment to set the composio caching directory.
+"""
+
+_cache_dir = os.environ.get(ENV_LOCAL_CACHE_DIRECTORY)
+
 LOCAL_CACHE_DIRECTORY = (
-    Path.home() if Path.home().exists() else Path.cwd()
-) / LOCAL_CACHE_DIRECTORY_NAME
+    Path(_cache_dir)
+    if _cache_dir is not None
+    else (Path.home() / LOCAL_CACHE_DIRECTORY_NAME)
+)
 """
 Path to local caching directory.
 """
+
+try:
+    LOCAL_CACHE_DIRECTORY.mkdir(parents=True, exist_ok=True)
+    if not os.access(LOCAL_CACHE_DIRECTORY, os.W_OK):
+        raise OSError
+except OSError as e:
+    raise RuntimeError(
+        f"Cache directory {LOCAL_CACHE_DIRECTORY} is not writable please "
+        f"provide a path that is writable using {ENV_LOCAL_CACHE_DIRECTORY} "
+        "environment variable."
+    ) from e
+
 
 LOCAL_OUTPUT_FILE_DIRECTORY_NAME = "output"
 """

--- a/python/composio/tools/env/docker/workspace.py
+++ b/python/composio/tools/env/docker/workspace.py
@@ -9,6 +9,7 @@ import typing as t
 from dataclasses import dataclass
 from pathlib import Path
 
+from composio.constants import LOCAL_CACHE_DIRECTORY
 from composio.exceptions import ComposioSDKError
 from composio.tools.env.base import RemoteWorkspace, WorkspaceConfigType
 from composio.tools.env.constants import (
@@ -35,13 +36,12 @@ except ImportError:
 
 
 COMPOSIO_PATH = Path(__file__).parent.parent.parent.parent.parent.resolve()
-COMPOSIO_CACHE = Path.home() / ".composio"
 CONTAINER_DEV_VOLUMES = {
     COMPOSIO_PATH: {
         "bind": "/opt/composio-core",
         "mode": "rw",
     },
-    COMPOSIO_CACHE: {
+    LOCAL_CACHE_DIRECTORY: {
         "bind": "/root/.composio",
         "mode": "rw",
     },

--- a/python/composio/tools/local/browsertool/actions/base_action.py
+++ b/python/composio/tools/local/browsertool/actions/base_action.py
@@ -2,11 +2,11 @@ import random
 import string
 from abc import abstractmethod
 from enum import Enum
-from pathlib import Path
 from typing import Dict, Optional
 
 from pydantic import BaseModel, Field
 
+from composio.constants import LOCAL_CACHE_DIRECTORY
 from composio.tools.base.local import ActionRequest, ActionResponse, LocalAction
 from composio.tools.env.browsermanager.manager import BrowserManager
 
@@ -174,8 +174,7 @@ class BaseBrowserAction(LocalAction[ActionRequest, ActionResponse], abs=True):
             )
 
     def _take_screenshot(self, browser_manager: BrowserManager, prefix: str) -> str:
-        home_dir = Path.home()
-        browser_media_dir = home_dir / ".browser_media"
+        browser_media_dir = LOCAL_CACHE_DIRECTORY / "browser_media"
         browser_media_dir.mkdir(parents=True, exist_ok=True)
         random_string = "".join(random.choices(string.ascii_lowercase, k=6))
         output_path = browser_media_dir / f"{prefix}_screenshot_{random_string}.png"

--- a/python/composio/tools/local/browsertool/actions/get_screenshot.py
+++ b/python/composio/tools/local/browsertool/actions/get_screenshot.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from pydantic import Field
 
+from composio.constants import LOCAL_CACHE_DIRECTORY
 from composio.tools.env.browsermanager.manager import BrowserManager
 from composio.tools.local.browsertool.actions.base_action import (
     BaseBrowserAction,
@@ -65,8 +66,7 @@ class GetScreenshot(BaseBrowserAction[GetScreenshotRequest, GetScreenshotRespons
         """Execute the screenshot action."""
         try:
             if not request.output_path or request.output_path == "":
-                home_dir = Path.home()
-                browser_media_dir = home_dir / ".browser_media"
+                browser_media_dir = LOCAL_CACHE_DIRECTORY / "browser_media"
                 browser_media_dir.mkdir(parents=True, exist_ok=True)
                 random_string = "".join(random.choices(string.ascii_lowercase, k=6))
                 output_path = browser_media_dir / f"screenshot_{random_string}.png"

--- a/python/composio/tools/local/codeanalysis/constants.py
+++ b/python/composio/tools/local/codeanalysis/constants.py
@@ -1,8 +1,7 @@
-import os
-from pathlib import Path
+from composio.constants import LOCAL_CACHE_DIRECTORY
 
 
-CODE_MAP_CACHE = os.path.join(Path.home(), ".composio/tmp")
+CODE_MAP_CACHE = str(LOCAL_CACHE_DIRECTORY / "tmp")
 FQDN_FILE = "fqdn_cache.json"
 DEEPLAKE_FOLDER = "deeplake"
 EMBEDDER = "sentence-transformers/all-mpnet-base-v2"

--- a/python/composio/tools/local/embedtool/actions/create_vectorstore.py
+++ b/python/composio/tools/local/embedtool/actions/create_vectorstore.py
@@ -4,6 +4,7 @@ from typing import List, Optional, Type
 
 from pydantic import BaseModel, Field
 
+from composio.constants import LOCAL_CACHE_DIRECTORY
 from composio.tools.base.local import LocalAction
 
 
@@ -56,7 +57,7 @@ class CreateImageVectorStore(
         from chromadb.utils import embedding_functions  # pylint: disable=C0415
 
         image_collection_name = Path(request.folder_path).name + "_images"
-        index_storage_path = Path.home() / ".composio" / "image_index_storage"
+        index_storage_path = LOCAL_CACHE_DIRECTORY / "image_index_storage"
         index_storage_path.mkdir(parents=True, exist_ok=True)
 
         # Initialize Chroma client

--- a/python/composio/tools/local/embedtool/actions/query_vectorstore.py
+++ b/python/composio/tools/local/embedtool/actions/query_vectorstore.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from pydantic import BaseModel, Field
 
+from composio.constants import LOCAL_CACHE_DIRECTORY
 from composio.tools.base.local import LocalAction
 
 
@@ -46,7 +47,7 @@ class QueryImageVectorStore(
         from chromadb.utils import embedding_functions  # pylint: disable=C0415
 
         image_collection_name = Path(request.indexed_directory).name + "_images"
-        index_storage_path = Path.home() / ".composio" / "image_index_storage"
+        index_storage_path = LOCAL_CACHE_DIRECTORY / "image_index_storage"
         chroma_client = chromadb.PersistentClient(path=str(index_storage_path))
         chroma_collection = chroma_client.get_collection(image_collection_name)
 

--- a/python/composio/utils/sentry.py
+++ b/python/composio/utils/sentry.py
@@ -7,7 +7,6 @@ import traceback
 import types
 import typing as t
 from functools import cache
-from pathlib import Path
 
 import requests
 import sentry_sdk
@@ -22,6 +21,8 @@ import sentry_sdk.integrations.stdlib
 import sentry_sdk.integrations.threading
 import sentry_sdk.types
 
+from composio.constants import LOCAL_CACHE_DIRECTORY
+
 
 @cache
 def fetch_dsn() -> t.Optional[str]:
@@ -35,7 +36,7 @@ def fetch_dsn() -> t.Optional[str]:
 
 
 def get_sentry_config() -> t.Optional[t.Dict]:
-    user_file = Path.home() / ".composio" / "user_data.json"
+    user_file = LOCAL_CACHE_DIRECTORY / "user_data.json"
     if not user_file.exists():
         update_dsn()
 
@@ -110,7 +111,7 @@ def init():
 
 @atexit.register
 def update_dsn() -> None:
-    user_file = Path.home() / ".composio" / "user_data.json"
+    user_file = LOCAL_CACHE_DIRECTORY / "user_data.json"
     if user_file.exists():
         try:
             data = json.loads(user_file.read_text(encoding="utf-8"))

--- a/python/plugins/smolagent/smol_demo.py
+++ b/python/plugins/smolagent/smol_demo.py
@@ -11,6 +11,6 @@ tools = composio_toolset.get_tools(
     actions=[Action.GITHUB_STAR_A_REPOSITORY_FOR_THE_AUTHENTICATED_USER],
 )
 # Create agent with Composio tools
-agent = CodeAgent(tools=tools, model=HfApiModel())# type: ignore[import-untyped]
+agent = CodeAgent(tools=tools, model=HfApiModel())  # type: ignore[import-untyped]
 
 agent.run("Star the composiohq/composio repo")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Improves cache directory handling by adding writability check and environment variable support, refactoring usage across the codebase.
> 
>   - **Behavior**:
>     - Introduces writability check for `LOCAL_CACHE_DIRECTORY` in `constants.py`. Raises `RuntimeError` if not writable.
>     - Allows setting `LOCAL_CACHE_DIRECTORY` via `COMPOSIO_CACHE_DIR` environment variable.
>   - **Refactoring**:
>     - Replaces `Path.home() / LOCAL_CACHE_DIRECTORY_NAME` with `LOCAL_CACHE_DIRECTORY` in `context.py`, `client/__init__.py`, `workspace.py`, `base_action.py`, `get_screenshot.py`, `constants.py`, `create_vectorstore.py`, `query_vectorstore.py`, and `sentry.py`.
>   - **Misc**:
>     - Fixes minor formatting issue in `smol_demo.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for b48848a9996f2d238eaf64d6120998a3432325b1. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->