### PR TITLE
feat: add versioned actions usages to docs

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -110,7 +110,8 @@
               ]
             },
             "patterns/tools/custom-integration",
-            "patterns/tools/serve-tools"
+            "patterns/tools/serve-tools",
+            "patterns/tools/versioning"
       ]
     },
     {

--- a/docs/patterns/tools/versioning.mdx
+++ b/docs/patterns/tools/versioning.mdx
@@ -1,0 +1,56 @@
+---
+title: "Action Versioning"
+sidebarTitle: "Action Versioning"
+description: "Learn how to use versioned actions in Composio"
+---
+
+Composio supports semantic versioning for actions to ensure stable and consistent interfaces. This guide explains how version specifiers work and how to use them in your applications.
+
+## Versioning Policies
+
+Composio follows semantic versioning principles:
+
+- **Minor Version Changes** (0_1 → 0_2)
+  - Non-breaking interface changes
+  - Examples: Adding optional parameters, extending functionality
+  - Backward compatible with previous minor versions
+
+- **Major Version Changes** (0_3 → 1_0)
+  - Breaking interface changes
+  - Examples: Action deprecation or replacement, Changes in required parameters, Changes in parameter types or formats
+  - May require updates to existing code
+
+## Version Specifiers
+
+Composio provides several ways to specify which version of an action you want to use:
+
+- `latest` - Uses the most recent version available. For example, if an action has versions 0_1, 0_2, 0_3, 1_0, and 1_1, `latest` will resolve to `1_1`.
+- `latest:base` - Uses the latest version before a major version change. Using the same example versions, `latest:base` would resolve to `0_3`.
+- `x_y` - Explicitly specify major (x) and minor (y) versions, like `0_1` or `1_0`.
+
+## Using Versions in Code
+
+Here's how to specify versions when using Composio:
+
+<CodeGroup>
+```python Python {7,10,13}
+from composio_langchain import ComposioToolSet, Action
+
+# Initialize toolset
+toolset = ComposioToolSet()
+
+# Use latest base version (default)
+tools = toolset.get_tools(actions=[Action.GITHUB_META_ROOT @ "latest:base"])
+
+# Use latest version
+tools = toolset.get_tools(actions=[Action.GITHUB_META_ROOT @ "latest"])
+
+# Use specific version
+tools = toolset.get_tools(actions=[Action.GITHUB_META_ROOT @ "0_1"])
+```
+``` javascript JavaScript
+coming soon!
+```
+</CodeGroup>
+
+<Info>If no version is specified it defaults to `latest:base`</Info>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds documentation for action versioning in Composio, detailing semantic versioning policies, version specifiers, and usage examples.
> 
>   - **Documentation**:
>     - Adds `versioning.mdx` to document action versioning in Composio, covering semantic versioning policies, version specifiers, and usage examples in Python.
>     - Updates `mint.json` to include `patterns/tools/versioning` in the navigation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for c085d2878c2c0da42e3e69dc7085ab01445f24df. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->