### PR TITLE
fix: encoding

### DIFF
--- a/js/src/sdk/utils/fileUtils.ts
+++ b/js/src/sdk/utils/fileUtils.ts
@@ -65,7 +65,6 @@ export const saveFile = (
   isTempFile: boolean = false
 ) => {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const path = require("path");
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const fs = require("fs");
@@ -73,7 +72,12 @@ export const saveFile = (
       ? getComposioTempFilesDir(true)
       : getComposioDir(true);
     const filePath = path.join(composioFilesDir, path.basename(file));
-    fs.writeFileSync(filePath, content);
+
+    if (Buffer.isBuffer(content)) {
+      fs.writeFileSync(filePath, content);
+    } else {
+      fs.writeFileSync(filePath, content, "utf8");
+    }
 
     return filePath;
   } catch (_error) {

--- a/js/src/sdk/utils/processor/fileUtils.ts
+++ b/js/src/sdk/utils/processor/fileUtils.ts
@@ -104,7 +104,6 @@ export const getFileDataAfterUploadingToS3 = async (
     s3key: s3key,
   };
 };
-
 export const downloadFileFromS3 = async ({
   actionName,
   s3Url,
@@ -114,7 +113,9 @@ export const downloadFileFromS3 = async ({
   s3Url: string;
   mimeType: string;
 }) => {
-  const response = await axios.get(s3Url);
+  const response = await axios.get(s3Url, {
+    responseType: "arraybuffer",
+  });
 
   const extension = mimeType.split("/")[1] || "txt";
   const fileName = `${actionName}_${Date.now()}.${extension}`;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix encoding issues in `saveFile` and `downloadFileFromS3` by handling buffer and string content correctly.
> 
>   - **Behavior**:
>     - In `saveFile` in `fileUtils.ts`, added check for `Buffer.isBuffer(content)` to write files with correct encoding (binary or utf8).
>     - In `downloadFileFromS3` in `processor/fileUtils.ts`, set `responseType: "arraybuffer"` for axios request to handle binary data correctly.
>   - **Misc**:
>     - Removed unnecessary eslint-disable comments in `fileUtils.ts` and `processor/fileUtils.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for f4abe435516248572bf48bd0bacf03447e4501c7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->