### PR TITLE
fix: limitedActions in getTools

### DIFF
--- a/js/src/frameworks/langchain.ts
+++ b/js/src/frameworks/langchain.ts
@@ -77,7 +77,7 @@ export class LangchainToolSet extends BaseComposioToolSet {
       params: { filters, entityId },
     });
 
-    const tools = await this.getToolsSchema(filters, entityId);
+    const tools = await this.getToolsSchema(filters, entityId, filters.integrationId);
     return tools.map((tool) =>
       this._wrapTool(tool as RawActionData, entityId || this.entityId)
     );

--- a/js/src/frameworks/langchain.ts
+++ b/js/src/frameworks/langchain.ts
@@ -77,7 +77,11 @@ export class LangchainToolSet extends BaseComposioToolSet {
       params: { filters, entityId },
     });
 
-    const tools = await this.getToolsSchema(filters, entityId, filters.integrationId);
+    const tools = await this.getToolsSchema(
+      filters,
+      entityId,
+      filters.integrationId
+    );
     return tools.map((tool) =>
       this._wrapTool(tool as RawActionData, entityId || this.entityId)
     );

--- a/js/src/frameworks/openai.ts
+++ b/js/src/frameworks/openai.ts
@@ -43,7 +43,7 @@ export class OpenAIToolSet extends BaseComposioToolSet {
 
   async getTools(
     filters: z.infer<typeof ZToolSchemaFilter>,
-    entityId?: Optional<string>,
+    entityId?: Optional<string>
   ): Promise<Sequence<OpenAI.ChatCompletionTool>> {
     TELEMETRY_LOGGER.manualTelemetry(TELEMETRY_EVENTS.SDK_METHOD_INVOKED, {
       method: "getTools",
@@ -51,7 +51,11 @@ export class OpenAIToolSet extends BaseComposioToolSet {
       params: filters,
     });
 
-    const mainActions = await this.getToolsSchema(filters, entityId, filters.integrationId);
+    const mainActions = await this.getToolsSchema(
+      filters,
+      entityId,
+      filters.integrationId
+    );
     return (
       mainActions.map((action) => {
         const formattedSchema: OpenAI.FunctionDefinition = {

--- a/js/src/frameworks/openai.ts
+++ b/js/src/frameworks/openai.ts
@@ -43,7 +43,7 @@ export class OpenAIToolSet extends BaseComposioToolSet {
 
   async getTools(
     filters: z.infer<typeof ZToolSchemaFilter>,
-    entityId?: Optional<string>
+    entityId?: Optional<string>,
   ): Promise<Sequence<OpenAI.ChatCompletionTool>> {
     TELEMETRY_LOGGER.manualTelemetry(TELEMETRY_EVENTS.SDK_METHOD_INVOKED, {
       method: "getTools",
@@ -51,7 +51,7 @@ export class OpenAIToolSet extends BaseComposioToolSet {
       params: filters,
     });
 
-    const mainActions = await this.getToolsSchema(filters, entityId);
+    const mainActions = await this.getToolsSchema(filters, entityId, filters.integrationId);
     return (
       mainActions.map((action) => {
         const formattedSchema: OpenAI.FunctionDefinition = {

--- a/js/src/frameworks/vercel.ts
+++ b/js/src/frameworks/vercel.ts
@@ -57,15 +57,18 @@ export class VercelAIToolSet extends BaseComposioToolSet {
   }
 
   // change this implementation
-  async getTools(filters: {
-    actions?: Array<string>;
-    apps?: Array<string>;
-    tags?: Optional<Array<string>>;
-    useCase?: Optional<string>;
-    usecaseLimit?: Optional<number>;
-    filterByAvailableApps?: Optional<boolean>;
-    integrationId?: Optional<string>;
-  }, entityId: Optional<string> = null): Promise<{ [key: string]: CoreTool }> {
+  async getTools(
+    filters: {
+      actions?: Array<string>;
+      apps?: Array<string>;
+      tags?: Optional<Array<string>>;
+      useCase?: Optional<string>;
+      usecaseLimit?: Optional<number>;
+      filterByAvailableApps?: Optional<boolean>;
+      integrationId?: Optional<string>;
+    },
+    entityId: Optional<string> = null
+  ): Promise<{ [key: string]: CoreTool }> {
     TELEMETRY_LOGGER.manualTelemetry(TELEMETRY_EVENTS.SDK_METHOD_INVOKED, {
       method: "getTools",
       file: this.fileName,
@@ -81,14 +84,18 @@ export class VercelAIToolSet extends BaseComposioToolSet {
       actions,
     } = ZExecuteToolCallParams.parse(filters);
 
-    const actionsList = await this.getToolsSchema({
-      apps,
-      actions,
-      tags,
-      useCase,
-      useCaseLimit: usecaseLimit,
-      filterByAvailableApps,
-    }, entityId, filters.integrationId);
+    const actionsList = await this.getToolsSchema(
+      {
+        apps,
+        actions,
+        tags,
+        useCase,
+        useCaseLimit: usecaseLimit,
+        filterByAvailableApps,
+      },
+      entityId,
+      filters.integrationId
+    );
 
     const tools: { [key: string]: CoreTool } = {};
     actionsList.forEach((actionSchema) => {

--- a/js/src/frameworks/vercel.ts
+++ b/js/src/frameworks/vercel.ts
@@ -64,7 +64,8 @@ export class VercelAIToolSet extends BaseComposioToolSet {
     useCase?: Optional<string>;
     usecaseLimit?: Optional<number>;
     filterByAvailableApps?: Optional<boolean>;
-  }): Promise<{ [key: string]: CoreTool }> {
+    integrationId?: Optional<string>;
+  }, entityId: Optional<string> = null): Promise<{ [key: string]: CoreTool }> {
     TELEMETRY_LOGGER.manualTelemetry(TELEMETRY_EVENTS.SDK_METHOD_INVOKED, {
       method: "getTools",
       file: this.fileName,
@@ -87,7 +88,7 @@ export class VercelAIToolSet extends BaseComposioToolSet {
       useCase,
       useCaseLimit: usecaseLimit,
       filterByAvailableApps,
-    });
+    }, entityId, filters.integrationId);
 
     const tools: { [key: string]: CoreTool } = {};
     actionsList.forEach((actionSchema) => {

--- a/js/src/sdk/base.toolset.ts
+++ b/js/src/sdk/base.toolset.ts
@@ -168,12 +168,12 @@ export class ComposioToolSet {
         }
       }
     }
-
+    
     const appActions = await this.client.actions.list({
       apps: parsedFilters.apps?.join(","),
       tags: parsedFilters.tags?.join(","),
       useCase: parsedFilters.useCase,
-      actions: parsedFilters.actions?.join(","),
+      actions: actions?.join(","),
       usecaseLimit: parsedFilters.useCaseLimit,
       filterByAvailableApps: parsedFilters.filterByAvailableApps,
     });

--- a/js/src/sdk/base.toolset.ts
+++ b/js/src/sdk/base.toolset.ts
@@ -168,7 +168,7 @@ export class ComposioToolSet {
         }
       }
     }
-    
+
     const appActions = await this.client.actions.list({
       apps: parsedFilters.apps?.join(","),
       tags: parsedFilters.tags?.join(","),

--- a/js/src/types/base_toolset.ts
+++ b/js/src/types/base_toolset.ts
@@ -77,6 +77,7 @@ export const ZToolSchemaFilter = z.object({
   useCase: z.string().optional(),
   useCaseLimit: z.number().optional(),
   filterByAvailableApps: z.boolean().optional(),
+  integrationId: z.string().optional(),
 });
 
 export type TToolSchemaFilter = z.infer<typeof ZToolSchemaFilter>;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `integrationId` to filter actions by `limitedActions` in `getToolsSchema`, updating `getTools` in relevant toolsets.
> 
>   - **Behavior**:
>     - `getToolsSchema` in `base.toolset.ts` now accepts `integrationId` to filter actions by `limitedActions`.
>     - `getTools` in `LangchainToolSet`, `OpenAIToolSet`, and `VercelAIToolSet` updated to pass `integrationId` to `getToolsSchema`.
>   - **Schema**:
>     - Add `integrationId` to `ZToolSchemaFilter` in `base_toolset.ts`.
>   - **Misc**:
>     - Fix `actions` assignment in `getToolsSchema` in `base.toolset.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 7842e1832fc92381fcad36a83b99b5c53f89cd82. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->