### PR TITLE
fix: entity id validation in check_conn_acc

### DIFF
--- a/python/composio/client/collections.py
+++ b/python/composio/client/collections.py
@@ -30,7 +30,7 @@ from composio.client.enums import (
     Trigger,
     TriggerType,
 )
-from composio.constants import PUSHER_CLUSTER, PUSHER_KEY
+from composio.constants import DEFAULT_ENTITY_ID, PUSHER_CLUSTER, PUSHER_KEY
 from composio.exceptions import (
     ErrorFetchingResource,
     InvalidParams,
@@ -92,7 +92,7 @@ class ConnectedAccountModel(BaseModel):
     connectionParams: AuthConnectionParamsModel
 
     clientUniqueUserId: t.Optional[str] = None
-    entityId: t.Optional[str] = None
+    entityId: t.Optional[str] = DEFAULT_ENTITY_ID
 
     # Override arbitrary model config.
     model_config: ConfigDict = ConfigDict(  # type: ignore

--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -1659,7 +1659,9 @@ class ComposioToolSet(_IntegrationMixin):
             return valid
         raise InvalidConnectedAccount(f"Invalid connected accounts found: {invalid}")
 
-    def check_connected_account(self, action: ActionType) -> None:
+    def check_connected_account(
+        self, action: ActionType, entity_id: t.Optional[str] = None
+    ) -> None:
         """Check if connected account is required and if required it exists or not."""
         action = Action(action)
         if action.no_auth or action.is_runtime:
@@ -1677,6 +1679,7 @@ class ComposioToolSet(_IntegrationMixin):
         if action.app not in [
             connection.appUniqueId.upper()  # Normalize app names/ids coming from API
             for connection in self._connected_accounts
+            if connection.clientUniqueUserId == entity_id
         ]:
             raise ConnectedAccountNotFoundError(
                 f"No connected account found for app `{action.app}`; "
@@ -1790,7 +1793,7 @@ class ComposioToolSet(_IntegrationMixin):
             action=action
         )
         if auth is None:
-            self.check_connected_account(action=action)
+            self.check_connected_account(action=action, entity_id=entity_id)
 
         output = self.client.get_entity(  # pylint: disable=protected-access
             id=entity_id

--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -1675,12 +1675,19 @@ class ComposioToolSet(_IntegrationMixin):
                 t.List[ConnectedAccountModel],
                 self.client.connected_accounts.get(),
             )
+        if entity_id is not None:
+            _conns = [
+                connection.appUniqueId.upper()  # Normalize app names/ids coming from API
+                for connection in self._connected_accounts
+                if connection.clientUniqueUserId == entity_id
+            ]
+        else:
+            _conns = [
+                connection.appUniqueId.upper()  # Normalize app names/ids coming from API
+                for connection in self._connected_accounts
+            ]
 
-        if action.app not in [
-            connection.appUniqueId.upper()  # Normalize app names/ids coming from API
-            for connection in self._connected_accounts
-            # if connection.clientUniqueUserId == entity_id
-        ]:
+        if action.app not in _conns:
             raise ConnectedAccountNotFoundError(
                 f"No connected account found for app `{action.app}`; "
                 f"Run `composio add {action.app.lower()}` to fix this"

--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -1675,19 +1675,12 @@ class ComposioToolSet(_IntegrationMixin):
                 t.List[ConnectedAccountModel],
                 self.client.connected_accounts.get(),
             )
-        if entity_id is not None:
-            _conns = [
-                connection.appUniqueId.upper()  # Normalize app names/ids coming from API
-                for connection in self._connected_accounts
-                if connection.clientUniqueUserId == entity_id
-            ]
-        else:
-            _conns = [
-                connection.appUniqueId.upper()  # Normalize app names/ids coming from API
-                for connection in self._connected_accounts
-            ]
 
-        if action.app not in _conns:
+        if action.app not in [
+            connection.appUniqueId.upper()  # Normalize app names/ids coming from API
+            for connection in self._connected_accounts
+            if entity_id is None or connection.clientUniqueUserId == entity_id
+        ]:
             raise ConnectedAccountNotFoundError(
                 f"No connected account found for app `{action.app}`; "
                 f"Run `composio add {action.app.lower()}` to fix this"

--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -1679,7 +1679,7 @@ class ComposioToolSet(_IntegrationMixin):
         if action.app not in [
             connection.appUniqueId.upper()  # Normalize app names/ids coming from API
             for connection in self._connected_accounts
-            if connection.clientUniqueUserId == entity_id
+            # if connection.clientUniqueUserId == entity_id
         ]:
             raise ConnectedAccountNotFoundError(
                 f"No connected account found for app `{action.app}`; "

--- a/python/tests/test_example.py
+++ b/python/tests/test_example.py
@@ -200,7 +200,7 @@ EXAMPLES = {
 
 
 @pytest.mark.skipif(
-    condition=os.environ.get("CI", "false") == "true",
+    condition=os.environ.get("CI", "true") == "false",
     reason="Testing in CI will lead to too much LLM API usage",
 )
 @pytest.mark.parametrize("example_name, example", EXAMPLES.items())

--- a/python/tests/test_example.py
+++ b/python/tests/test_example.py
@@ -200,7 +200,7 @@ EXAMPLES = {
 
 
 @pytest.mark.skipif(
-    condition=os.environ.get("CI", "true") == "false",
+    condition=os.environ.get("CI", "false") == "true",
     reason="Testing in CI will lead to too much LLM API usage",
 )
 @pytest.mark.parametrize("example_name, example", EXAMPLES.items())


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix entity ID validation in `check_connected_account` by setting default entity ID and updating logic to include entity ID checks.
> 
>   - **Behavior**:
>     - Set `entityId` to `DEFAULT_ENTITY_ID` in `ConnectedAccountModel` in `collections.py`.
>     - Update `check_connected_account` in `toolset.py` to accept `entity_id` as an optional parameter and use it to filter connected accounts.
>   - **Functions**:
>     - Modify `_execute_remote` in `toolset.py` to pass `entity_id` to `check_connected_account`.
>   - **Constants**:
>     - Import `DEFAULT_ENTITY_ID` from `constants.py` in `collections.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 0a52c3cdd3ee49df3fb6e37807839971efce088d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->