### PR TITLE
Convert jsonref to dict and dump using json package

### DIFF
--- a/python/composio/tools/base/abs.py
+++ b/python/composio/tools/base/abs.py
@@ -34,14 +34,25 @@ tool_registry: ToolRegistry = {"runtime": {}, "local": {}, "api": {}}
 action_registry: ActionsRegistry = {"runtime": {}, "local": {}, "api": {}}
 trigger_registry: TriggersRegistry = {"runtime": {}, "local": {}, "api": {}}
 
+def convert_json_ref_to_dict(obj):
+    """ Recursively convert jsonref.JsonRef objects to plain dicts. """
+    if isinstance(obj, jsonref.JsonRef):
+        obj = dict(obj)  # Convert JsonRef to dict
+    elif isinstance(obj, dict):
+        obj = {key: convert_json_ref_to_dict(value) for key, value in obj.items()}
+    elif isinstance(obj, list):
+        obj = [convert_json_ref_to_dict(item) for item in obj]
+    return obj
 
 def remove_json_ref(data: t.Dict) -> t.Dict:
     return json.loads(
-        jsonref.dumps(
-            jsonref.replace_refs(
-                obj=data,
-                lazy_load=False,
-                merge_props=True,
+        json.dumps(
+            convert_json_ref_to_dict(
+                jsonref.replace_refs(
+                    obj=data,
+                    lazy_load=False,
+                    merge_props=True,
+                )
             ),
             indent=2,
         )

--- a/python/composio/tools/base/abs.py
+++ b/python/composio/tools/base/abs.py
@@ -48,11 +48,20 @@ def convert_json_ref_to_dict(obj: t.Any) -> t.Any:
 
 def remove_json_ref(data: t.Dict) -> t.Dict:
     try:
-        return convert_json_ref_to_dict(
-            jsonref.replace_refs(
-                obj=data,
-                lazy_load=False,
-                merge_props=True,
+        # Fix potential double deserialization
+        # Challenges: Can't use jsonref.dumps as it is adding back refs
+        # Also can't use json.dumps as it can't work on some objects
+        # Can potentially just do convert_json_ref_to_dict but it can miss some native edge cases
+        return json.loads(
+            json.dumps(
+                convert_json_ref_to_dict(
+                    jsonref.replace_refs(
+                        obj=data,
+                        lazy_load=False,
+                        merge_props=True,
+                    )
+                ),
+                indent=2,
             )
         )
     except (json.JSONDecodeError, TypeError) as e:


### PR DESCRIPTION
### Description

Playing around with the documentation for [configuring tools](https://docs.composio.dev/patterns/tools/use-tools/configure-tools) led me to a failure in composio python sdk.
It complained about resolving the json of response schema.
Pasting the json below for ref.
The issue can easily be repro-ed by running that example.

```
{
  "properties": {
    "data": {
      "$ref": "#/$defs/ImageAnalyserResponse",
      "description": "Data from the action execution"
    },
    "successful": {
      "description": "Whether or not the action execution was successful or not",
      "title": "Successful",
      "type": "boolean"
    },
    "error": {
      "anyOf": [
        {
          "type": "string"
        },
        {
          "type": "null"
        }
      ],
      "default": null,
      "description": "Error if any occurred during the execution of the action",
      "title": "Error"
    }
  },
  "required": [
    "data",
    "successful"
  ],
  "title": "ImageAnalyserResponseWrapper",
  "type": "object"
}
```

<img width="1434" alt="Screenshot 2025-02-20 at 4 51 40 PM" src="https://github.com/user-attachments/assets/785cd0f5-3a89-45be-9ea2-e3b0eef0a656" />


After investigating, learned that after resolving refs, when we try to do `jsonrefs.dumps()`, we add back the unresolved data into the object, which is very unintuitive.

### Testing

Have run the same example from [configuring tools](https://docs.composio.dev/patterns/tools/use-tools/configure-tools) documentation and verified my fix.

<img width="1436" alt="Screenshot 2025-02-20 at 4 52 34 PM" src="https://github.com/user-attachments/assets/9f72d5ce-53a5-4adb-8ace-877809b9b139" />

### Taking it further

There are two more places where we do jsonref.dumps() in the `action.py`.
Probably worth investigating if this fix is needed there too.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes JSON reference resolution issue in `remove_json_ref()` by converting `jsonref.JsonRef` to dictionaries in `abs.py`.
> 
>   - **Behavior**:
>     - Fixes issue with JSON reference resolution in `remove_json_ref()` in `abs.py` by converting `jsonref.JsonRef` objects to plain dictionaries before dumping.
>     - Introduces `convert_json_ref_to_dict()` to recursively convert `jsonref.JsonRef` objects to dictionaries.
>   - **Functions**:
>     - `remove_json_ref()` now uses `json.dumps()` instead of `jsonref.dumps()` to avoid reintroducing unresolved data.
>     - `convert_json_ref_to_dict()` handles `jsonref.JsonRef`, `dict`, and `list` types.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for b824d05cc7410b77b3d9d88235d51260c93ea10f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

