### PR TITLE
feat: Added props for controlling tracing

### DIFF
--- a/js/config/getTestConfig.ts
+++ b/js/config/getTestConfig.ts
@@ -1,20 +1,24 @@
-export const env = process.env.TEST_ENV  || "staging"
+export const env = "staging";
 const CURRENT_FILE_DIR = __dirname;
 
 export type BACKEND_CONFIG = {
-    COMPOSIO_API_KEY: string;
-    BACKEND_HERMES_URL: string;
-    drive: {
-        downloadable_file_id: string;
-    }
-}
+  COMPOSIO_API_KEY: string;
+  BACKEND_HERMES_URL: string;
+  drive: {
+    downloadable_file_id: string;
+  };
+};
 
 export const getTestConfig = (): BACKEND_CONFIG => {
-    const path = `${CURRENT_FILE_DIR}/test.config.${env}.json`;
-    try {
-        return JSON.parse(JSON.stringify(require(path))) as unknown as BACKEND_CONFIG;
-    } catch (error) {
-        console.error("Error loading test config file:", error);
-        throw new Error(`Error loading test config file. You  can create test.config.${env}.json file in the config folder.`);
-    }
-}
+  const path = `${CURRENT_FILE_DIR}/test.config.${env}.json`;
+  try {
+    return JSON.parse(
+      JSON.stringify(require(path))
+    ) as unknown as BACKEND_CONFIG;
+  } catch (error) {
+    console.error("Error loading test config file:", error);
+    throw new Error(
+      `Error loading test config file. You  can create test.config.${env}.json file in the config folder.`
+    );
+  }
+};

--- a/js/src/sdk/models/actions.ts
+++ b/js/src/sdk/models/actions.ts
@@ -156,9 +156,13 @@ export class Actions {
           ...parsedData.requestBody,
           sessionInfo: {
             ...(parsedData.requestBody?.sessionInfo || {}),
-            sessionId:
-              parsedData.requestBody?.sessionInfo?.sessionId ||
-              ComposioSDKContext.sessionId,
+            ...(parsedData.requestBody.allowTracing
+              ? {
+                  sessionId:
+                    parsedData.requestBody?.sessionInfo?.sessionId ||
+                    ComposioSDKContext.sessionId,
+                }
+              : {}),
           },
         } as ActionExecutionReqDTO,
         path: {

--- a/js/src/sdk/models/actions.ts
+++ b/js/src/sdk/models/actions.ts
@@ -156,7 +156,7 @@ export class Actions {
           ...parsedData.requestBody,
           sessionInfo: {
             ...(parsedData.requestBody?.sessionInfo || {}),
-            ...(parsedData.requestBody.allowTracing
+            ...(parsedData.requestBody?.allowTracing
               ? {
                   sessionId:
                     parsedData.requestBody?.sessionInfo?.sessionId ||

--- a/js/src/sdk/types/action.ts
+++ b/js/src/sdk/types/action.ts
@@ -42,7 +42,7 @@ export const ZExecuteParams = z.object({
     appName: z.string().optional(),
     text: z.string().optional(),
     authConfig: ZCustomAuthParams.optional(),
-    allowTracing: z.boolean().optional().default(false),
+    allowTracing: z.boolean().optional(),
     sessionInfo: z
       .object({
         sessionId: z.string().optional(),

--- a/js/src/sdk/types/action.ts
+++ b/js/src/sdk/types/action.ts
@@ -42,6 +42,7 @@ export const ZExecuteParams = z.object({
     appName: z.string().optional(),
     text: z.string().optional(),
     authConfig: ZCustomAuthParams.optional(),
+    allowTracing: z.boolean().optional().default(false),
     sessionInfo: z
       .object({
         sessionId: z.string().optional(),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `allowTracing` to control session tracing in `execute()` and hardcodes `env` to "staging" in `getTestConfig.ts`.
> 
>   - **Behavior**:
>     - Adds `allowTracing` boolean to `ZExecuteParams` in `action.ts` to control session tracing.
>     - Modifies `execute()` in `actions.ts` to conditionally include `sessionId` based on `allowTracing`.
>   - **Config**:
>     - Hardcodes `env` to "staging" in `getTestConfig.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 87b6c55020547da8a70c79281a265232e81a323b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->