### PR TITLE
chore: separate CLI dependencies and entry points

### DIFF
--- a/python/composio-cli/README.md
+++ b/python/composio-cli/README.md
@@ -1,0 +1,28 @@
+# Composio CLI
+
+Command line interface for the Composio platform.
+
+## Installation
+
+```bash
+pip install composio-cli
+```
+
+## Usage
+
+After installation, you can use the `composio` command:
+
+```bash
+composio --help          # Display help information
+composio add github      # Add an integration to your account
+composio login          # Log in to your Composio account
+```
+
+## Requirements
+
+- Python 3.8 or higher
+- composio_core package
+
+## License
+
+Apache License 2.0

--- a/python/composio-cli/composio_cli/__init__.py
+++ b/python/composio-cli/composio_cli/__init__.py
@@ -1,0 +1,5 @@
+"""
+Composio CLI package.
+"""
+
+__version__ = "0.7.2"  # Keep in sync with setup.py

--- a/python/composio-cli/composio_cli/cli.py
+++ b/python/composio-cli/composio_cli/cli.py
@@ -1,0 +1,89 @@
+"""
+Composio CLI Tool.
+"""
+
+import typing as t
+
+import click
+from composio import __version__
+from composio.core.cls.catch_all_exceptions import CatchAllExceptions, handle_exceptions
+from composio.core.cls.did_you_mean import DYMGroup
+from composio.utils import logging
+
+# These imports will be updated once we move the command modules
+from composio.cli.actions import _actions
+from composio.cli.add import _add
+from composio.cli.apps import _apps
+from composio.cli.connections import _connections
+from composio.cli.execute import _execute
+from composio.cli.integrations import _integrations
+from composio.cli.login import _login
+from composio.cli.logout import _logout
+from composio.cli.serve import _serve
+from composio.cli.triggers import _triggers
+from composio.cli.utils.params import EnumParam
+from composio.cli.whoami import _whoami
+
+
+class HelpDYMGroup(DYMGroup):
+    def format_help(self, ctx, formatter):
+        formatter.write("\n")
+
+        super().format_help(ctx, formatter)
+
+        formatter.write("\n📙 Examples:\n\n")
+
+        formatter.write(
+            click.style("composio --help", fg="green")
+            + click.style("          # Display help information\n", fg="black")
+        )
+        formatter.write(
+            click.style("composio add github", fg="green")
+            + click.style("      # Add an integration to your account\n", fg="black")
+        )
+        formatter.write(
+            click.style("composio login", fg="green")
+            + click.style("           # Log in to your Composio account\n", fg="black")
+        )
+
+
+@click.group(
+    name="composio",
+    cls=CatchAllExceptions(
+        HelpDYMGroup,
+        handler=handle_exceptions,
+    ),
+)
+@click.help_option(
+    "-h",
+    "-help",
+    "--help",
+)
+@click.version_option(
+    version=__version__,
+)
+@click.option(
+    "-v",
+    "level",
+    help="Specify logging verbosity level.",
+    type=EnumParam(cls=logging.LogLevel),
+)
+def composio(level: t.Optional[logging.LogLevel] = None) -> None:
+    """
+    🔗 Composio CLI Tool.
+    """
+    if level is not None:
+        logging.setup(level=level)
+
+
+composio.add_command(_add)
+composio.add_command(_apps)
+composio.add_command(_login)
+composio.add_command(_logout)
+composio.add_command(_whoami)
+composio.add_command(_actions)
+composio.add_command(_triggers)
+composio.add_command(_integrations)
+composio.add_command(_connections)
+composio.add_command(_execute)
+composio.add_command(_serve)

--- a/python/composio-cli/setup.py
+++ b/python/composio-cli/setup.py
@@ -1,0 +1,41 @@
+"""
+Setup configuration for composio CLI.
+"""
+
+from pathlib import Path
+from setuptools import setup, find_packages
+
+# Read README for long description
+README = Path(__file__).parent / "README.md"
+long_description = README.read_text(encoding="utf-8") if README.exists() else ""
+
+setup(
+    name="composio-cli",
+    version="0.7.2",  # Keeping in sync with core for now
+    author="Utkarsh",
+    author_email="utkarsh@composio.dev",
+    description="Command line interface for Composio platform",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/composiohq/composio",
+    packages=find_packages(),
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Developers",
+    ],
+    python_requires=">=3.8",
+    install_requires=[
+        "composio_core>=0.7.2",  # Core package dependency
+        "click",
+        "rich>=13.7.1,<14",
+        "pyperclip>=1.8.2,<2",
+    ],
+    entry_points={
+        "console_scripts": [
+            "composio=composio_cli.cli:composio",
+        ],
+    },
+)

--- a/python/setup.py
+++ b/python/setup.py
@@ -43,10 +43,10 @@ core_requirements = [
     "jsonref>=1.1.0",
     "inflection>=0.5.1",
     "semver>=2.13.0",
-    # CLI dependencies
-    "click",
-    "rich>=13.7.1,<14",
-    "pyperclip>=1.8.2,<2",
+    # Removing CLI dependencies
+    # "click",
+    # "rich>=13.7.1,<14",
+    # "pyperclip>=1.8.2,<2",
     # Workspace dependencies
     "paramiko>=3.4.1",  # Host workspace
     # Tooling server dependencies
@@ -103,11 +103,12 @@ setup(
     ],
     python_requires=">=3.9,<4",
     packages=find_packages(include=["composio*"]),
-    entry_points={
-        "console_scripts": [
-            "composio=composio.cli:composio",
-        ],
-    },
+    # Removing CLI entry point
+    # entry_points={
+    #     "console_scripts": [
+    #         "composio=composio.cli:composio",
+    #     ],
+    # },
     install_requires=core_requirements,
     extras_require={
         "all": all_requirements,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Separate CLI dependencies and entry points into a new `composio-cli` package, updating setup configurations accordingly.
> 
>   - **New CLI Package**:
>     - Adds `composio-cli` package with `README.md`, `__init__.py`, `cli.py`, and `setup.py`.
>     - `cli.py` defines the `composio` command with subcommands like `_add`, `_login`, `_logout`, etc.
>   - **Setup Configuration**:
>     - `python/composio-cli/setup.py` specifies dependencies: `composio_core`, `click`, `rich`, `pyperclip`.
>     - Adds entry point for `composio` command in `composio-cli`.
>   - **Core Package Changes**:
>     - Removes CLI dependencies (`click`, `rich`, `pyperclip`) from `python/setup.py`.
>     - Removes CLI entry point from `python/setup.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 6d31c73e202dad1743d7e6c3e0d1adf1563135b3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->