### PR TITLE
fix: VercelAIToolset toolset

### DIFF
--- a/js/src/frameworks/vercel.ts
+++ b/js/src/frameworks/vercel.ts
@@ -39,7 +39,7 @@ export class VercelAIToolSet extends BaseComposioToolSet {
     });
   }
 
-  private generateVercelTool(schema: RawActionData) {
+  private generateVercelTool(schema: RawActionData, entityId: Optional<string> = null) {
     return tool({
       description: schema.description,
       // @ts-ignore the type are JSONSchemV7. Internally it's resolved
@@ -50,7 +50,7 @@ export class VercelAIToolSet extends BaseComposioToolSet {
             name: schema.name,
             arguments: JSON.stringify(params),
           },
-          this.entityId
+          entityId || this.entityId
         );
       },
     });
@@ -99,7 +99,7 @@ export class VercelAIToolSet extends BaseComposioToolSet {
 
     const tools: { [key: string]: CoreTool } = {};
     actionsList.forEach((actionSchema) => {
-      tools[actionSchema.name!] = this.generateVercelTool(actionSchema);
+      tools[actionSchema.name!] = this.generateVercelTool(actionSchema, entityId);
     });
 
     return tools;

--- a/js/src/frameworks/vercel.ts
+++ b/js/src/frameworks/vercel.ts
@@ -39,7 +39,10 @@ export class VercelAIToolSet extends BaseComposioToolSet {
     });
   }
 
-  private generateVercelTool(schema: RawActionData, entityId: Optional<string> = null) {
+  private generateVercelTool(
+    schema: RawActionData,
+    entityId: Optional<string> = null
+  ) {
     return tool({
       description: schema.description,
       // @ts-ignore the type are JSONSchemV7. Internally it's resolved
@@ -99,7 +102,10 @@ export class VercelAIToolSet extends BaseComposioToolSet {
 
     const tools: { [key: string]: CoreTool } = {};
     actionsList.forEach((actionSchema) => {
-      tools[actionSchema.name!] = this.generateVercelTool(actionSchema, entityId);
+      tools[actionSchema.name!] = this.generateVercelTool(
+        actionSchema,
+        entityId
+      );
     });
 
     return tools;


### PR DESCRIPTION
- Fixed getTools() to use the passed entityId
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `entityId` handling in `generateVercelTool` and `getTools` in `vercel.ts`.
> 
>   - **Behavior**:
>     - Fixes `generateVercelTool` in `vercel.ts` to use the passed `entityId` if provided, otherwise defaults to `this.entityId`.
>     - Updates `getTools` in `vercel.ts` to pass `entityId` to `generateVercelTool`.
>   - **Misc**:
>     - No changes to other files or functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 1451269792691d944c0bf4308dcabf6c4eee8d12. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->