### PR TITLE
fix: connected account bugfix

### DIFF
--- a/python/composio/client/__init__.py
+++ b/python/composio/client/__init__.py
@@ -342,7 +342,7 @@ class Entity:
                 creation_date = datetime.fromisoformat(
                     connected_account.createdAt.replace("Z", "+00:00")
                 )
-                if latest_account is None or creation_date > latest_creation_date:
+                if latest_account is None or creation_date < latest_creation_date:
                     latest_creation_date = creation_date
                     latest_account = connected_account
 


### PR DESCRIPTION
Earlier the toolset picked the first connected account. Now, it picks the latest connected account
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes logic in `get_connection` method to select the latest connected account by creation date.
> 
>   - **Bug Fix**:
>     - Corrects logic in `get_connection` method of `Entity` class in `__init__.py` to select the latest connected account by creation date.
>     - Changes comparison operator from `>` to `<` to ensure the latest account is selected.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for d1bacc68b45fdb9bc3bfc22a593695bc7327910d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->