### PR TITLE
fix: added allow tracing param

### DIFF
--- a/js/src/sdk/models/actions.ts
+++ b/js/src/sdk/models/actions.ts
@@ -156,14 +156,11 @@ export class Actions {
           ...parsedData.requestBody,
           sessionInfo: {
             ...(parsedData.requestBody?.sessionInfo || {}),
-            ...(parsedData.requestBody?.allowTracing
-              ? {
-                  sessionId:
-                    parsedData.requestBody?.sessionInfo?.sessionId ||
-                    ComposioSDKContext.sessionId,
-                }
-              : {}),
+            sessionId:
+              parsedData.requestBody?.sessionInfo?.sessionId ||
+              ComposioSDKContext.sessionId,
           },
+          allowTracing: parsedData.requestBody?.allowTracing || false,
         } as ActionExecutionReqDTO,
         path: {
           actionId: parsedData.actionName,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Ensure `allowTracing` is always included in `Actions.execute()` request body, defaulting to `false`.
> 
>   - **Behavior**:
>     - In `Actions.execute()`, always include `allowTracing` in the request body, defaulting to `false` if not provided.
>     - Removes conditional logic for `sessionId` based on `allowTracing`.
>   - **Misc**:
>     - Simplifies request body construction in `Actions.execute()` by removing unnecessary conditional logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for b6aed0e96b8d84d0973d08639e21bfab64546d9a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->