### PR TITLE
chore: update calendly links in Py SDK logs

### DIFF
--- a/python/composio/utils/__init__.py
+++ b/python/composio/utils/__init__.py
@@ -36,7 +36,7 @@ def help_msg() -> str:
             + blue("    Talk to us on Intercom: ")
             + "https://composio.dev\n"
             + blue("    Book a call with us: ")
-            + "https://calendly.com/soham-composio/30min\n"
+            + "https://composio.dev/redirect?url=https://calendly.com/composiohq/support?utm_source=py-sdk-logs&utm_campaign=calendly\n"
             + "If you need to debug this error, "
             + green("set `COMPOSIO_LOGGING_LEVEL=debug`")
             + "."
@@ -48,6 +48,6 @@ def help_msg() -> str:
         "    On Discord: https://dub.composio.dev/discord\n"
         "    On Email: tech@composio.dev\n"
         "    Talk to us on Intercom: https://composio.dev\n"
-        "    Book a call with us: https://calendly.com/soham-composio/30min\n"
+        "    Book a call with us: https://composio.dev/redirect?url=https://calendly.com/composiohq/support?utm_source=py-sdk-logs&utm_campaign=calendly\n"
         "If you need to debug this error, set `COMPOSIO_LOGGING_LEVEL=debug`."
     )


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update Calendly link in `help_msg()` in `__init__.py` to use a redirect URL with UTM parameters.
> 
>   - **Behavior**:
>     - Update Calendly link in `help_msg()` in `__init__.py` to use a redirect URL with UTM parameters for tracking.
>     - Affects both TTY and non-TTY outputs in `help_msg()`.
>   - **Misc**:
>     - No other functional changes or additions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 54145da8d594e53aed570f1d5473e36bfa017b58. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->