### PR TITLE
feat: v1 to v2 shift

### DIFF
--- a/python/composio/client/collections.py
+++ b/python/composio/client/collections.py
@@ -1531,9 +1531,7 @@ class Integrations(Collection[IntegrationModel]):
     def remove(self, id: str) -> None:
         self.client.http.delete(url=str(self.endpoint / id))
 
-    def delete(self, id: str) -> int:
-        response = self.client.http.delete(url=str(self.endpoint / id))
-        return response.status_code
+
 
     @t.overload  # type: ignore
     def get(

--- a/python/composio/client/collections.py
+++ b/python/composio/client/collections.py
@@ -1529,7 +1529,11 @@ class Integrations(Collection[IntegrationModel]):
         return IntegrationModel(**response.json())
 
     def remove(self, id: str) -> None:
+        self.client.http.delete(url=str(self.endpoint / id))
+
+    def delete(self, id: str) -> int:
         response = self.client.http.delete(url=str(self.endpoint / id))
+        return response.status_code
 
     @t.overload  # type: ignore
     def get(

--- a/python/composio/client/collections.py
+++ b/python/composio/client/collections.py
@@ -1529,7 +1529,7 @@ class Integrations(Collection[IntegrationModel]):
         return IntegrationModel(**response.json())
 
     def remove(self, id: str) -> None:
-        self.client.http.delete(url=str(self.endpoint / id))
+        response = self.client.http.delete(url=str(self.endpoint / id))
 
     @t.overload  # type: ignore
     def get(

--- a/python/composio/client/collections.py
+++ b/python/composio/client/collections.py
@@ -1528,9 +1528,8 @@ class Integrations(Collection[IntegrationModel]):
         )
         return IntegrationModel(**response.json())
 
-    def remove(self, id: str) -> int:
-        response = self.client.http.delete(url=str(self.endpoint / id))
-        return response.status_code
+    def remove(self, id: str) -> None:
+        self.client.http.delete(url=str(self.endpoint / id))
 
     @t.overload  # type: ignore
     def get(

--- a/python/composio/client/collections.py
+++ b/python/composio/client/collections.py
@@ -1528,8 +1528,9 @@ class Integrations(Collection[IntegrationModel]):
         )
         return IntegrationModel(**response.json())
 
-    def remove(self, id: str) -> None:
-        self.client.http.delete(url=str(self.endpoint / id))
+    def remove(self, id: str) -> int:
+        response = self.client.http.delete(url=str(self.endpoint / id))
+        return response.status_code
 
     @t.overload  # type: ignore
     def get(


### PR DESCRIPTION
This is just a draft PR to check why tests are failing on the original v1->v2 shift PR.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add two blank lines in `collections.py` after `remove()` function.
> 
>   - **Misc**:
>     - Add two blank lines in `collections.py` after `remove()` function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 6c79e0fdb76d4dcd656e3b1d613bc1b20c559d75. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->