### PR TITLE
feat: Allow tracing to get log and session id

### DIFF
--- a/python/composio/client/__init__.py
+++ b/python/composio/client/__init__.py
@@ -277,6 +277,7 @@ class Entity:
         session_id: t.Optional[str] = None,
         text: t.Optional[str] = None,
         auth: t.Optional[CustomAuthObject] = None,
+        allow_tracing: bool = False,
     ) -> t.Dict:
         if action.no_auth:
             return self.client.actions.execute(
@@ -285,6 +286,7 @@ class Entity:
                 entity_id=self.id,
                 session_id=session_id,
                 text=text,
+                allow_tracing=allow_tracing,
             )
 
         if auth is not None:
@@ -295,6 +297,7 @@ class Entity:
                 session_id=session_id,
                 text=text,
                 auth=auth,
+                allow_tracing=allow_tracing,
             )
 
         connected_account = self.get_connection(
@@ -310,6 +313,7 @@ class Entity:
             session_id=session_id,
             text=text,
             auth=auth,
+            allow_tracing=allow_tracing,
         )
 
     def get_connection(

--- a/python/composio/client/collections.py
+++ b/python/composio/client/collections.py
@@ -1306,6 +1306,7 @@ class Actions(Collection[ActionModel]):
         session_id: t.Optional[str] = None,
         text: t.Optional[str] = None,
         auth: t.Optional[CustomAuthObject] = None,
+        allow_tracing: bool = False,
     ) -> t.Dict:
         """
         Execute an action on the specified entity with optional connected account.
@@ -1329,6 +1330,7 @@ class Actions(Collection[ActionModel]):
                         "sessionInfo": {
                             "sessionId": session_id,
                         },
+                        "allowTracing": allow_tracing,
                     },
                 )
             ).json()
@@ -1353,6 +1355,7 @@ class Actions(Collection[ActionModel]):
                     "sessionInfo": {
                         "sessionId": session_id,
                     },
+                    "allowTracing": allow_tracing,
                 },
             )
         ).json()

--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -1454,6 +1454,7 @@ class ComposioToolSet(_IntegrationMixin):
         output_dir: t.Optional[Path] = None,
         output_in_file: bool = False,
         verbosity_level: t.Optional[int] = None,
+        allow_tracing: bool = False,
         connected_account_ids: t.Optional[t.Dict[AppType, str]] = None,
         *,
         max_retries: int = 3,
@@ -1580,7 +1581,7 @@ class ComposioToolSet(_IntegrationMixin):
         )
         self.max_retries = max_retries
         self.add_auth = self._custom_auth_helper.add
-
+        self.allow_tracing = allow_tracing
         # To be populated by get_tools(), from within subclasses like composio_openai's Toolset.
         self._requested_actions: t.List[str] = []
 
@@ -1796,6 +1797,7 @@ class ComposioToolSet(_IntegrationMixin):
         connected_account_id: t.Optional[str] = None,
         session_id: t.Optional[str] = None,
         text: t.Optional[str] = None,
+        allow_tracing: bool = False,
     ) -> t.Dict:
         """Execute a remote action."""
         auth = self._custom_auth_helper.get_custom_params_for_remote_execution(
@@ -1813,6 +1815,7 @@ class ComposioToolSet(_IntegrationMixin):
             text=text,
             session_id=session_id,
             connected_account_id=connected_account_id,
+            allow_tracing=allow_tracing,
         )
         output = self._schema_helper.substitute_file_downloads(
             action=action,
@@ -1906,6 +1909,7 @@ class ComposioToolSet(_IntegrationMixin):
                     connected_account_id=connected_account_id,
                     text=text,
                     session_id=self.session_id,
+                    allow_tracing=self.allow_tracing,
                 )
             )
             processed_response = (

--- a/python/tests/test_tools/test_toolset.py
+++ b/python/tests/test_tools/test_toolset.py
@@ -382,6 +382,7 @@ def test_execute_action_param_serialization() -> None:
         connected_account_id=None,
         text=None,
         session_id=mock.ANY,
+        allow_tracing=False,
     )
 
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `allow_tracing` parameter to enable tracing in Composio SDK functions and update tests accordingly.
> 
>   - **Behavior**:
>     - Add `allow_tracing` parameter to `_execute()` in `__init__.py`, `execute()` in `collections.py`, and `execute_action()` in `toolset.py`.
>     - Pass `allow_tracing` through function calls to enable tracing functionality.
>   - **Tests**:
>     - Update `test_execute_action_param_serialization()` in `test_toolset.py` to include `allow_tracing` parameter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 6fd429807868936ff0084b1f627ba3e77098e894. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->