### PR TITLE
fix: langgraph-prebuilt required for with langgraph

### DIFF
--- a/python/swe/setup.py
+++ b/python/swe/setup.py
@@ -75,6 +75,7 @@ setup(
         "langgraph": [
             "langchain-aws==0.1.17",
             "langgraph>=0.2.16",
+            "langgraph-prebuilt>=0.1.0",
             "composio_langgraph>=0.5.0,<0.8.0",
             "python-dotenv==1.0.1",
         ]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `langgraph-prebuilt` to `langgraph` extra requirements in `setup.py`.
> 
>   - **Dependencies**:
>     - Added `langgraph-prebuilt>=0.1.0` to `langgraph` extra requirements in `setup.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 717bb67ef63f91a31182b453f4eacbafb280949c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->