### PR TITLE
feat: add global level tracing

### DIFF
--- a/js/src/sdk/index.ts
+++ b/js/src/sdk/index.ts
@@ -53,9 +53,15 @@ export class Composio {
    * @param {string} [config.apiKey] - The API key for authenticating with the Composio backend. Can also be set locally in an environment variable.
    * @param {string} [config.baseUrl] - The base URL for the Composio backend. By default, it is set to the production URL.
    * @param {string} [config.runtime] - The runtime environment for the SDK.
+   * @param {boolean} [config.allowTracing] - Whether to allow tracing for the SDK.
    */
   constructor(
-    config: { apiKey?: string; baseUrl?: string; runtime?: string } = {}
+    config: {
+      apiKey?: string;
+      baseUrl?: string;
+      runtime?: string;
+      allowTracing?: boolean;
+    } = {}
   ) {
     // Parse the base URL and API key, falling back to environment variables or defaults if not provided
     const { baseURL: baseURLParsed, apiKey: apiKeyParsed } = getSDKConfig(
@@ -73,6 +79,7 @@ export class Composio {
     ComposioSDKContext.baseURL = baseURLParsed;
     ComposioSDKContext.frameworkRuntime = config?.runtime;
     ComposioSDKContext.composioVersion = COMPOSIO_VERSION;
+    ComposioSDKContext.allowTracing = config?.allowTracing;
 
     TELEMETRY_LOGGER.manualTelemetry(TELEMETRY_EVENTS.SDK_INITIALIZED, {});
 

--- a/js/src/sdk/models/actions.ts
+++ b/js/src/sdk/models/actions.ts
@@ -160,7 +160,7 @@ export class Actions {
               parsedData.requestBody?.sessionInfo?.sessionId ||
               ComposioSDKContext.sessionId,
           },
-          allowTracing: parsedData.requestBody?.allowTracing || false,
+          allowTracing: Boolean(ComposioSDKContext?.allowTracing),
         } as ActionExecutionReqDTO,
         path: {
           actionId: parsedData.actionName,

--- a/js/src/sdk/utils/composioContext.ts
+++ b/js/src/sdk/utils/composioContext.ts
@@ -12,6 +12,7 @@ class ComposioSDKContext {
   static source?: string = "javascript";
   static composioVersion?: string;
   static sessionId?: string;
+  static allowTracing?: boolean;
 }
 
 export default ComposioSDKContext;


### PR DESCRIPTION
1. Added global level tracing
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add global level tracing feature to Composio SDK with `allowTracing` option in `Composio` constructor and update `Actions` class to utilize it.
> 
>   - **Behavior**:
>     - Add `allowTracing` option to `Composio` constructor in `index.ts` for enabling tracing.
>     - Store `allowTracing` in `ComposioSDKContext` in `composioContext.ts`.
>     - Update `Actions.execute()` in `actions.ts` to use `allowTracing` from `ComposioSDKContext`.
>   - **Misc**:
>     - Update `ActionExecutionReqDTO` in `actions.ts` to include `allowTracing` flag.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for b424a693e7859cb96d1c30010e6cc4dddb0cb592. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->