### PR TITLE
fix: pin autogen and langgraph-prebuilt

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -94,7 +94,7 @@ jobs:
           python -m uv pip install plugins/${{ matrix.package }}
           python -m uv pip install '.[all]'
           python -m uv pip install 'numpy<2' python-dotenv
-          python -m uv pip install unstructured
+          python -m uv pip unstructured ag2[openai] 'langgraph-prebuilt>=0.1.0'
 
           COMPOSIO_BASE_URL=${{ env.COMPOSIO_BASE_URL }} COMPOSIO_API_KEY=${{ env.COMPOSIO_API_KEY }} COMPOSIO_LOGGING_LEVEL='debug' CI=false PLUGIN_TO_TEST=${{ matrix.package }} python -m uv run pytest -vv tests/test_example.py
           COMPOSIO_BASE_URL=${{ env.COMPOSIO_BASE_URL }} COMPOSIO_API_KEY=${{ env.COMPOSIO_API_KEY }} COMPOSIO_LOGGING_LEVEL='debug' CI=false PLUGIN_TO_TEST=${{ matrix.package }} python -m uv run pytest -vv tests/test_load_tools.py


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Pins `langgraph-prebuilt` to `>=0.1.0` and adds `ag2[openai]` in `examples.yml`.
> 
>   - **Dependencies**:
>     - Pins `langgraph-prebuilt` to version `>=0.1.0` in `examples.yml`.
>     - Adds `ag2[openai]` to the list of installed packages in `examples.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 000e2b2a27709ae85cdbdf6a96abe72a17f9315f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->