### PR TITLE
fix: pin dependencies

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -93,8 +93,7 @@ jobs:
           python -m uv pip install --upgrade pip pytest
           python -m uv pip install plugins/${{ matrix.package }}
           python -m uv pip install '.[all]'
-          python -m uv pip install 'numpy<2' python-dotenv
-          python -m uv pip install unstructured
+          python -m uv pip install 'numpy<2' python-dotenv unstructured ag2[openai]
 
           COMPOSIO_BASE_URL=${{ env.COMPOSIO_BASE_URL }} COMPOSIO_API_KEY=${{ env.COMPOSIO_API_KEY }} COMPOSIO_LOGGING_LEVEL='debug' CI=false PLUGIN_TO_TEST=${{ matrix.package }} python -m uv run pytest -vv tests/test_example.py
           COMPOSIO_BASE_URL=${{ env.COMPOSIO_BASE_URL }} COMPOSIO_API_KEY=${{ env.COMPOSIO_API_KEY }} COMPOSIO_LOGGING_LEVEL='debug' CI=false PLUGIN_TO_TEST=${{ matrix.package }} python -m uv run pytest -vv tests/test_load_tools.py

--- a/python/plugins/langgraph/setup.py
+++ b/python/plugins/langgraph/setup.py
@@ -24,7 +24,7 @@ setup(
     python_requires=">=3.9,<4",
     install_requires=[
         "composio_langchain>=0.5.0,<0.8.0",
-        "langgraph",
+        "langgraph<0.3.0",
     ],
     include_package_data=True,
 )


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Pin `langgraph` dependency to `<0.3.0` and add `ag2[openai]` in GitHub workflow dependencies.
> 
>   - **Dependencies**:
>     - Pin `langgraph` to `<0.3.0` in `setup.py`.
>     - Add `ag2[openai]` to the list of installed packages in `.github/workflows/examples.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 48153814b7a0312bdeb367ebd2c6a6c1b15ebb9e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->