### PR TITLE
fix: pin pydantic version to less than 2.10.0

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -38,7 +38,7 @@ core_requirements = [
     "jsonschema>=4.21.1,<5",
     "sentry-sdk>=2.0.0",
     "pysher==1.0.8",
-    "pydantic>=2.6.4",
+    "pydantic>=2.6.4,<2.10.0",
     "importlib-metadata>=4.8.1",
     "jsonref>=1.1.0",
     "inflection>=0.5.1",


### PR DESCRIPTION
Breaking change in pydantic version 2.10.0.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Pin `pydantic` version to `<2.10.0` in `setup.py` to avoid breaking changes.
> 
>   - **Dependencies**:
>     - Pin `pydantic` version to `>=2.6.4,<2.10.0` in `setup.py` to avoid breaking changes introduced in version 2.10.0.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 71c8773ce43f7e5ca6b35dcb3b3fabfef4e8ba7f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->