### PR TITLE
fix: missing of available auth schemes 

### DIFF
--- a/python/composio/client/collections.py
+++ b/python/composio/client/collections.py
@@ -44,11 +44,20 @@ from composio.utils.shared import generate_request_id
 
 if t.TYPE_CHECKING:
     from composio.client import Composio
-
-ALL_AUTH_SCHEMES = ("OAUTH2", "OAUTH1", "API_KEY", "BASIC", "BEARER_TOKEN", "NO_AUTH")
-AUTH_SCHEME_WITH_INITIATE = ("OAUTH2", "OAUTH1", "API_KEY", "BASIC", "BEARER_TOKEN")
+ALL_AUTH_SCHEMES = (
+    "OAUTH2", "OAUTH1", "API_KEY", "BASIC", "BEARER_TOKEN", 
+    "BASIC_WITH_JWT", "GOOGLE_SERVICE_ACCOUNT", "GOOGLEADS_AUTH", 
+    "NO_AUTH", "COMPOSIO_LINK", "CALCOM_AUTH"
+)
+AUTH_SCHEME_WITH_INITIATE = (
+    "OAUTH2", "OAUTH1", "API_KEY", "BASIC", "BEARER_TOKEN", 
+    "BASIC_WITH_JWT", "GOOGLE_SERVICE_ACCOUNT", "GOOGLEADS_AUTH", 
+    "COMPOSIO_LINK", "CALCOM_AUTH"
+)
 AuthSchemeType = t.Literal[
-    "OAUTH2", "OAUTH1", "API_KEY", "BASIC", "BEARER_TOKEN", "BASIC_WITH_JWT", "NO_AUTH"
+    "OAUTH2", "OAUTH1", "API_KEY", "BASIC", "BEARER_TOKEN", 
+    "BASIC_WITH_JWT", "GOOGLE_SERVICE_ACCOUNT", "GOOGLEADS_AUTH", 
+    "NO_AUTH", "COMPOSIO_LINK", "CALCOM_AUTH"
 ]
 
 
@@ -354,7 +363,6 @@ class Apps(Collection[AppModel]):
                         url=str(self.endpoint / name),
                     )
                 ).json()
-            )
 
         return super().get(queries={})
 
@@ -1563,7 +1571,6 @@ class Integrations(Collection[IntegrationModel]):
                 **self._raise_if_required(
                     self.client.http.get(url=str(self.endpoint / id))
                 ).json()
-            )
 
         quries = {}
         if page_size is not None:

--- a/python/composio/client/collections.py
+++ b/python/composio/client/collections.py
@@ -45,19 +45,42 @@ from composio.utils.shared import generate_request_id
 if t.TYPE_CHECKING:
     from composio.client import Composio
 ALL_AUTH_SCHEMES = (
-    "OAUTH2", "OAUTH1", "API_KEY", "BASIC", "BEARER_TOKEN", 
-    "BASIC_WITH_JWT", "GOOGLE_SERVICE_ACCOUNT", "GOOGLEADS_AUTH", 
-    "NO_AUTH", "COMPOSIO_LINK", "CALCOM_AUTH"
+    "OAUTH2",
+    "OAUTH1",
+    "API_KEY",
+    "BASIC",
+    "BEARER_TOKEN",
+    "BASIC_WITH_JWT",
+    "GOOGLE_SERVICE_ACCOUNT",
+    "GOOGLEADS_AUTH",
+    "NO_AUTH",
+    "COMPOSIO_LINK",
+    "CALCOM_AUTH",
 )
 AUTH_SCHEME_WITH_INITIATE = (
-    "OAUTH2", "OAUTH1", "API_KEY", "BASIC", "BEARER_TOKEN", 
-    "BASIC_WITH_JWT", "GOOGLE_SERVICE_ACCOUNT", "GOOGLEADS_AUTH", 
-    "COMPOSIO_LINK", "CALCOM_AUTH"
+    "OAUTH2",
+    "OAUTH1",
+    "API_KEY",
+    "BASIC",
+    "BEARER_TOKEN",
+    "BASIC_WITH_JWT",
+    "GOOGLE_SERVICE_ACCOUNT",
+    "GOOGLEADS_AUTH",
+    "COMPOSIO_LINK",
+    "CALCOM_AUTH",
 )
 AuthSchemeType = t.Literal[
-    "OAUTH2", "OAUTH1", "API_KEY", "BASIC", "BEARER_TOKEN", 
-    "BASIC_WITH_JWT", "GOOGLE_SERVICE_ACCOUNT", "GOOGLEADS_AUTH", 
-    "NO_AUTH", "COMPOSIO_LINK", "CALCOM_AUTH"
+    "OAUTH2",
+    "OAUTH1",
+    "API_KEY",
+    "BASIC",
+    "BEARER_TOKEN",
+    "BASIC_WITH_JWT",
+    "GOOGLE_SERVICE_ACCOUNT",
+    "GOOGLEADS_AUTH",
+    "NO_AUTH",
+    "COMPOSIO_LINK",
+    "CALCOM_AUTH",
 ]
 
 
@@ -363,7 +386,7 @@ class Apps(Collection[AppModel]):
                         url=str(self.endpoint / name),
                     )
                 ).json()
-
+            )
         return super().get(queries={})
 
 
@@ -1571,7 +1594,7 @@ class Integrations(Collection[IntegrationModel]):
                 **self._raise_if_required(
                     self.client.http.get(url=str(self.endpoint / id))
                 ).json()
-
+            )
         quries = {}
         if page_size is not None:
             quries["pageSize"] = json.dumps(page_size)


### PR DESCRIPTION
Some auth schemes are a part of hermes but are being blocked by the SDK when trying to initiate a connection through it

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Added new authentication schemes to `ALL_AUTH_SCHEMES`, `AUTH_SCHEME_WITH_INITIATE`, and `AuthSchemeType` in `collections.py`.
> 
>   - **Auth Schemes**:
>     - Added `BASIC_WITH_JWT`, `GOOGLE_SERVICE_ACCOUNT`, `GOOGLEADS_AUTH`, `COMPOSIO_LINK`, `CALCOM_AUTH` to `ALL_AUTH_SCHEMES` and `AUTH_SCHEME_WITH_INITIATE` in `collections.py`.
>     - Updated `AuthSchemeType` to include the new schemes.
>   - **Misc**:
>     - Removed redundant closing parenthesis in `get()` method in `collections.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 78eda9141d76d6e23337178af99b72f18696e4be. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->