### PR TITLE
fix: KeyError in file download recursive substitution

### DIFF
--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -688,7 +688,7 @@ class SchemaHelper(WithLogger):
                 ).model_dump()
                 continue
 
-            if isinstance(request[_param], dict) and params[_param]["type"] == "object":
+            if isinstance(request[_param], dict) and params[_param].get("type") == "object":
                 request[_param] = self._substitute_file_uploads_recursively(
                     schema=params[_param],
                     request=request[_param],
@@ -741,7 +741,7 @@ class SchemaHelper(WithLogger):
                 )
                 continue
 
-            if isinstance(request[_param], dict) and params[_param]["type"] == "object":
+            if isinstance(request[_param], dict) and params[_param].get("type") == "object":
                 request[_param] = self._substitute_file_downloads_recursively(
                     schema=params[_param],
                     request=request[_param],

--- a/python/composio/tools/toolset.py
+++ b/python/composio/tools/toolset.py
@@ -688,7 +688,10 @@ class SchemaHelper(WithLogger):
                 ).model_dump()
                 continue
 
-            if isinstance(request[_param], dict) and params[_param].get("type") == "object":
+            if (
+                isinstance(request[_param], dict)
+                and params[_param].get("type") == "object"
+            ):
                 request[_param] = self._substitute_file_uploads_recursively(
                     schema=params[_param],
                     request=request[_param],
@@ -741,7 +744,10 @@ class SchemaHelper(WithLogger):
                 )
                 continue
 
-            if isinstance(request[_param], dict) and params[_param].get("type") == "object":
+            if (
+                isinstance(request[_param], dict)
+                and params[_param].get("type") == "object"
+            ):
                 request[_param] = self._substitute_file_downloads_recursively(
                     schema=params[_param],
                     request=request[_param],


### PR DESCRIPTION
fixes: TOO-140 (https://linear.app/composio/issue/TOO-140/direct-tool-execution-error)

Issue
When processing nested parameters in the _substitute_file_downloads_recursively method, the code assumes all parameters in the schema have a "type" field. This causes a KeyError: 'type' exception when encountering parameters without this field, breaking the file download substitution process.

Solution 
Replace direct dictionary access with the .get() method to safely handle cases where the "type" field is missing