### PR TITLE
feat: add s3 url support

### DIFF
--- a/js/src/sdk/base.toolset.spec.ts
+++ b/js/src/sdk/base.toolset.spec.ts
@@ -186,17 +186,19 @@ describe("ComposioToolSet class tests", () => {
   });
 
   it.skip("should execute downloadable file action", async () => {
-    const ACTION_NAME = "GOOGLEDRIVE_PARSE_FILE";
+    const ACTION_NAME = "GOOGLEDRIVE_DOWNLOAD_FILE";
     const executionResult = await toolset.executeAction({
       action: ACTION_NAME,
       params: {
-        file_id: testConfig.drive.downloadable_file_id,
+        file_id: testConfig.drive.downloadable_file_id
       },
       entityId: "default",
     });
 
     // @ts-ignore
     expect(executionResult.data.file.uri.length).toBeGreaterThan(0);
+    // @ts-ignore
+    expect(executionResult.data.file.s3Url.length).toBeGreaterThan(0);
   });
 
   it("should get tools with usecase limit", async () => {

--- a/js/src/sdk/base.toolset.spec.ts
+++ b/js/src/sdk/base.toolset.spec.ts
@@ -185,20 +185,23 @@ describe("ComposioToolSet class tests", () => {
     expect(executionResult.data).toBeDefined();
   });
 
-  it("should execute downloadable file action", async () => {
+  it.skip("should execute downloadable file action", async () => {
     const ACTION_NAME = "GOOGLEDRIVE_DOWNLOAD_FILE";
     const executionResult = await toolset.executeAction({
       action: ACTION_NAME,
       params: {
-        file_id: testConfig.drive.downloadable_file_id
+        file_id: testConfig.drive.downloadable_file_id,
       },
       entityId: "default",
     });
 
-    // @ts-ignore
-    expect(executionResult.data.file.uri.length).toBeGreaterThan(0);
-    // @ts-ignore
-    expect(executionResult.data.file.s3url.length).toBeGreaterThan(0);
+    const fileData = executionResult.data.file as {
+      uri: string;
+      s3url: string;
+    };
+
+    expect(fileData.uri.length).toBeGreaterThan(0);
+    expect(fileData.s3url.length).toBeGreaterThan(0);
   });
 
   it("should get tools with usecase limit", async () => {

--- a/js/src/sdk/base.toolset.spec.ts
+++ b/js/src/sdk/base.toolset.spec.ts
@@ -185,7 +185,7 @@ describe("ComposioToolSet class tests", () => {
     expect(executionResult.data).toBeDefined();
   });
 
-  it.skip("should execute downloadable file action", async () => {
+  it("should execute downloadable file action", async () => {
     const ACTION_NAME = "GOOGLEDRIVE_DOWNLOAD_FILE";
     const executionResult = await toolset.executeAction({
       action: ACTION_NAME,
@@ -198,7 +198,7 @@ describe("ComposioToolSet class tests", () => {
     // @ts-ignore
     expect(executionResult.data.file.uri.length).toBeGreaterThan(0);
     // @ts-ignore
-    expect(executionResult.data.file.s3Url.length).toBeGreaterThan(0);
+    expect(executionResult.data.file.s3url.length).toBeGreaterThan(0);
   });
 
   it("should get tools with usecase limit", async () => {

--- a/js/src/sdk/utils/processor/file.ts
+++ b/js/src/sdk/utils/processor/file.ts
@@ -81,6 +81,7 @@ export const FILE_DOWNLOADABLE_PROCESSOR: TPostProcessor = async ({
 
     result.data[key] = {
       uri: downloadedFile.filePath,
+      s3Url: fileData.s3url,
       mimeType: downloadedFile.mimeType,
     };
   }

--- a/js/src/sdk/utils/processor/file.ts
+++ b/js/src/sdk/utils/processor/file.ts
@@ -81,7 +81,7 @@ export const FILE_DOWNLOADABLE_PROCESSOR: TPostProcessor = async ({
 
     result.data[key] = {
       uri: downloadedFile.filePath,
-      s3Url: fileData.s3url,
+      s3url: fileData.s3url,
       mimeType: downloadedFile.mimeType,
     };
   }


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add S3 URL support in file processing and update tests to verify S3 URL presence.
> 
>   - **Behavior**:
>     - Adds S3 URL support in `FILE_DOWNLOADABLE_PROCESSOR` in `file.ts` by including `s3url` in the result data.
>     - Updates test in `base.toolset.spec.ts` to check for `s3url` in `GOOGLEDRIVE_DOWNLOAD_FILE` action.
>   - **Tests**:
>     - Unskips and modifies test for `GOOGLEDRIVE_DOWNLOAD_FILE` action in `base.toolset.spec.ts` to verify `s3url` presence.
>   - **Misc**:
>     - Minor changes in `base.toolset.spec.ts` to rename `GOOGLEDRIVE_PARSE_FILE` to `GOOGLEDRIVE_DOWNLOAD_FILE`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 27e3b40f756a0ee2e77b9395d4fd3f35bc3cc5b2. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<img width="944" alt="Screenshot 2025-03-19 at 2 40 22 PM" src="https://github.com/user-attachments/assets/f79846e6-8a18-4533-b5f8-4260058a528d" />



