### PR TITLE
fix: version warning setup

### DIFF
--- a/js/bump_version.sh
+++ b/js/bump_version.sh
@@ -20,6 +20,7 @@ sed -i.bak "s/\"version\": \"$current_version\"/\"version\": \"$new_version\"/" 
 # Update version in package.json  
 sed -i.bak "s/\"version\": \"$current_version_pkg\"/\"version\": \"$new_version\"/" package.json && rm package.json.bak
 
+echo "Updating version in src/constants.js"
 # Update version in src/constants.js
 sed -i.bak "s/COMPOSIO_VERSION = \`$current_version\`/COMPOSIO_VERSION = \`$new_version\`/" src/constants.js && rm src/constants.js.bak
 

--- a/js/package.dist.json
+++ b/js/package.dist.json
@@ -1,6 +1,6 @@
 {
   "name": "composio-core",
-  "version": "0.5.25",
+  "version": "0.5.0",
   "description": "",
   "main": "index.js",
   "scripts": {},

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "composio-core",
-  "version": "0.5.25",
+  "version": "0.5.0",
   "description": "",
   "main": "dist/index.js",
   "browser": {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes version setup by updating version numbers in `package.json`, `package.dist.json`, and `src/constants.js`.
> 
>   - **Version Management**:
>     - Updates version in `package.json` and `package.dist.json` from `0.5.25` to `0.5.0`.
>     - Adds echo statement in `bump_version.sh` to indicate version update in `src/constants.js`.
>     - Updates version in `src/constants.js` using `sed` command in `bump_version.sh`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 82f3c903e218eee1fe6e989129452221a83d1bef. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->