### PR TITLE
chore: add js bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/js-bug.yaml
+++ b/.github/ISSUE_TEMPLATE/js-bug.yaml
@@ -1,0 +1,82 @@
+name: Js Bug Report
+description: File a bug report for Js SDK.
+title: "Error: "
+labels: ["bug", "triage", "javascript"]
+projects: ["composiohq/composio"]
+assignees:
+  - utkarsh-dixit
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: input
+    id: node-version
+    attributes:
+      label: Node.js Version
+      description: Please provide the Node.js version you're using
+      placeholder: ex. 16.15.1, 18.12.0
+    validations:
+      required: true
+  - type: input
+    id: npm-version
+    attributes:
+      label: Package Manager & Version
+      description: Which package manager and version are you using?
+      placeholder: ex. npm 8.19.2, yarn 1.22.19, pnpm 7.14.0
+    validations:
+      required: true
+  - type: input
+    id: os-name
+    attributes:
+      label: Operating system
+      description: Name of the operating system
+      placeholder: ex. windows, ubuntu-22.04, macos
+    validations:
+      required: false
+  - type: input
+    id: browser
+    attributes:
+      label: Browser (if applicable)
+      description: Browser and version if this is a browser-related issue
+      placeholder: ex. Chrome 106, Firefox 105, Safari 16
+    validations:
+      required: false
+  - type: textarea
+    id: error
+    attributes:
+      label: Error
+      description: Error log, please provide entire error message and stack trace.
+      placeholder: Tell us what you see!
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce this issue?
+      placeholder: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: List relevant dependencies from your package.json
+      placeholder: Paste your package.json dependencies or the output of `npm list --depth=0`
+      render: json
+    validations:
+      required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/ComposioHQ/composio/blob/master/CODE_OF_CONDUCT.md). 
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true 

--- a/.github/ISSUE_TEMPLATE/py-bug.yaml
+++ b/.github/ISSUE_TEMPLATE/py-bug.yaml
@@ -1,7 +1,7 @@
 name: Python Bug Report
 description: File a bug report.
 title: "Error: "
-labels: ["bug", "triage"]
+labels: ["bug", "triage", "python"]
 projects: ["composiohq/composio"]
 assignees:
   - angrybayblade


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a JavaScript bug report template and renames the Python bug report template for clarity.
> 
>   - **New Template**:
>     - Adds `js-bug.yaml` for JavaScript bug reports with fields for Node.js version, package manager, OS, browser, error, reproduction steps, and dependencies.
>     - Includes a mandatory Code of Conduct agreement.
>   - **Renames**:
>     - Renames `bug.yaml` to `py-bug.yaml` for Python bug reports.
>     - Adds 'python' label to the Python bug report template.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for 2e7f400c3d48e5f35b42968359ae0515825a29a1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->