### PR TITLE
fix: improve cli and installation sections

### DIFF
--- a/fern/getting-started/installation.mdx
+++ b/fern/getting-started/installation.mdx
@@ -9,32 +9,37 @@ Composio provides Python and TypeScript SDKs as well as plugins with other LLM f
 <Tabs>
   <Tab title="Python">
 Before installing the SDK, ensure you have Python 3.8+.
-  {/* <Tabs> */}
-  {/* <Tab title='uv'> */}
   <Steps>
-  <Step title="Install uv">
-    ```bash
-curl -LsSf https://astral.sh/uv/install.sh | sh
-    ```
-    </Step>
-    <Step title="Install Composio">
+  <Step title="Install Composio">
+  <CodeGroup>
+  <CodeBlock title="uv">
     ```bash
     uv add composio_core composio_openai
     ```
-  {/* </Tab> */}
-  {/* <Tab title='pip'>
+  </CodeBlock>
+  <CodeBlock title="pip">
     ```bash
-    pip install composio_core
+    pip install composio_core composio_openai
     ```
-  </Tab> */}
-  {/* </Tabs> */}
+  </CodeBlock>
+  </CodeGroup>
   </Step>
   <Step title="Install the relevant plugin">
     Depending on what LLM framework you're using, you'll need to install the relevant plugin.
+    <CodeGroup>
+    <CodeBlock title="pip">
+    ```bash
+    pip install composio_crewai      # For CrewAI
+    pip install composio_langchain   # For LangChain
+    ```
+    </CodeBlock>
+    <CodeBlock title="uv">
     ```bash
     uv add composio_crewai      # For CrewAI
     uv add composio_langchain   # For LangChain
     ```
+    </CodeBlock>
+    </CodeGroup>
     </Step>
     </Steps>
   </Tab>
@@ -42,25 +47,29 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 Before installing the SDK, ensure you have NodeJS 16+.
   <Steps>
   <Step title="Install Composio">
-  <Tabs>
-  <Tab title='pnpm'>
-  ```bash
-  pnpm install composio-core
-  ```
-  </Tab>
-  <Tab title='npm'>
+  <CodeGroup>
+  <CodeBlock title="npm">
     ```bash
     npm install composio-core
     ```
-  </Tab>
-  <Tab title='yarn'>
+  </CodeBlock>
+  <CodeBlock title="pnpm">
+  ```bash
+  pnpm add composio-core
+  ```
+  <CodeBlock title="bun">
+    ```bash
+    bun add composio-core
+    ```
+  </CodeBlock>
+  </CodeBlock>
+  <CodeBlock title="yarn">
     ```bash
     yarn add composio-core
     ```
-  </Tab>
-  </Tabs>
+  </CodeBlock>
+  </CodeGroup>
   </Step>
-    > The package includes TypeScript type definitions out of the box.
   <Step title="Plugins">
   The TS package comes installed with support for:
   - [LangChain JS](/frameworks/javascript/langchain)

--- a/fern/getting-started/installation.mdx
+++ b/fern/getting-started/installation.mdx
@@ -41,6 +41,12 @@ Before installing the SDK, ensure you have Python 3.8+.
     </CodeBlock>
     </CodeGroup>
     </Step>
+    <Step title="Post Installation">
+  On new installations, you'll need to generate the SDK types. If you encounter errors related to missing "metadata," it likely means you need to update your types.
+    ```bash
+    composio apps generate-types
+    ```
+    </Step>
     </Steps>
   </Tab>
   <Tab title="TypeScript">

--- a/fern/getting-started/quickstart.mdx
+++ b/fern/getting-started/quickstart.mdx
@@ -20,34 +20,18 @@ Once done, you can generate the API key through the dashboard or command-line to
 
 <Tabs>
 <Tab title="CLI">
+<Warning>Ensure you have [installed Composio](/getting-started/installation)</Warning>
 <Steps>
 <Step title="Login">
-<Tabs>
-<Tab title="Python">
-
-<Warning>Ensure you have `uv` installed!</Warning>
-
 ```bash
-uvx --from composio-core composio login
+composio login
 ```
 
-To view the API key;
+To view the API key:
 
 ```bash
-uvx --from composio-core composio whoami
+composio whoami
 ```
-</Tab>
-<Tab title="Node">
-```bash
-npx composio-core login
-```
-To view the API key;
-
-```bash
-npx composio-core whoami
-```
-</Tab>
-</Tabs>
 </Step>
 <Step title="Store the API Key">
 When building, store the API key in an `.env` file.
@@ -97,18 +81,11 @@ preferred method:
 <Tab title="CLI">
 Add GitHub integration through the CLI.
 
-<CodeGroup>
-```uvx uvx
-uvx --from composio-core composio add github
+```bash
+composio add github
 ```
-```npx npx
-npx composio-core add github
-```
-</CodeGroup>
 Follow the instructions in the CLI to authenticate and connect your GitHub account.
 </Tab>
-Follow the instructions in the CLI to authenticate and connect your GitHub
-account.
 
 <Tab title="Dashboard">
 Head over to the [GitHub App](https://app.composio.dev/app/github).

--- a/fern/triggers/triggers.mdx
+++ b/fern/triggers/triggers.mdx
@@ -77,14 +77,9 @@ console.log(res.status);
 </Tab>
 <Tab title="CLI">
 In the command-line run:
-<CodeGroup>
-```uvx uvx
-uvx --from composio-core composio triggers add SLACK_RECEIVE_MESSAGE
+```bash
+composio triggers add SLACK_RECEIVE_MESSAGE
 ```
-```npx npx
-npx composio-core triggers add SLACK_RECEIVE_MESSAGE
-```
-</CodeGroup>
 </Tab>
 <Tab title="Dashboard">
 Head to the [Slack app](https://app.composio.dev/app/slack) in the dashboard and enable the "New Message Recieved" trigger


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Simplified CLI commands and improved installation instructions for Composio in documentation files.
> 
>   - **CLI Commands**:
>     - Simplified CLI commands by removing `uvx` and `npx` prefixes in `quickstart.mdx` and `triggers.mdx`.
>     - Updated commands to use `composio` directly for login, API key retrieval, GitHub integration, and trigger addition.
>   - **Installation Instructions**:
>     - Updated `installation.mdx` to include `CodeGroup` and `CodeBlock` for better clarity between `uv` and `pip` installation methods.
>     - Added post-installation step for generating SDK types in `installation.mdx`.
>   - **Miscellaneous**:
>     - Added warnings and notes in `quickstart.mdx` to ensure Composio is installed before proceeding with CLI steps.
>     - Removed redundant tabs and streamlined instructions in `quickstart.mdx` and `triggers.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ComposioHQ%2Fcomposio&utm_source=github&utm_medium=referral)<sup> for c1e6615bd71a10de6dfec0dfa86c5a6e8c34f502. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->