### PR TITLE
fix: humanize field titles in req/res schema

### DIFF
--- a/python/composio/tools/base/abs.py
+++ b/python/composio/tools/base/abs.py
@@ -65,6 +65,29 @@ def generate_app_id(name: str) -> str:
     )
 
 
+def is_camel_case(title: str) -> bool:
+    """Check if the title is in camel case with the first letter lowercase"""
+    return title == inflection.camelize(title, uppercase_first_letter=False)
+
+
+def replace_titles(properties: t.Dict) -> t.Dict:
+    for field_name, field_properties in properties.items():
+        if "file_uploadable" in field_properties:
+            continue
+
+        # Check if the field name is in camel case,
+        # If yes, convert to snake case, replace _ and titelize
+        if is_camel_case(field_name):
+            field_properties["title"] = inflection.titleize(
+                inflection.underscore(field_name).replace("_", " ")
+            )
+
+        if "properties" in field_properties:
+            replace_titles(field_properties["properties"])
+
+    return properties
+
+
 class InvalidClassDefinition(ComposioSDKError):
     """Raise when a class is not defined properly."""
 
@@ -104,7 +127,7 @@ class _Request(t.Generic[ModelType]):
         if "$defs" in request:
             del request["$defs"]
 
-        properties = request.get("properties", {})
+        properties = replace_titles(request.get("properties", {}))
         for prop in properties.values():
             if prop.get("file_readable", False):
                 prop["oneOf"] = [
@@ -193,7 +216,7 @@ class _Response(t.Generic[ModelType]):
         if "$defs" in schema:
             del schema["$defs"]
 
-        properties = schema.get("properties", {})
+        properties = replace_titles(schema.get("properties", {}))
         for prop in properties.values():
             if prop.get("file_readable", False):
                 prop["oneOf"] = [

--- a/python/composio/tools/base/abs.py
+++ b/python/composio/tools/base/abs.py
@@ -65,7 +65,7 @@ def generate_app_id(name: str) -> str:
     )
 
 
-def replace_titles(properties: t.Dict) -> t.Dict:
+def humanize_titles(properties: t.Dict) -> t.Dict:
     for field_name, field_properties in properties.items():
         if "file_uploadable" in field_properties:
             continue
@@ -76,7 +76,7 @@ def replace_titles(properties: t.Dict) -> t.Dict:
         )
 
         if "properties" in field_properties:
-            replace_titles(field_properties["properties"])
+            humanize_titles(field_properties["properties"])
 
     return properties
 
@@ -120,7 +120,7 @@ class _Request(t.Generic[ModelType]):
         if "$defs" in request:
             del request["$defs"]
 
-        properties = replace_titles(request.get("properties", {}))
+        properties = humanize_titles(request.get("properties", {}))
         for prop in properties.values():
             if prop.get("file_readable", False):
                 prop["oneOf"] = [
@@ -209,7 +209,7 @@ class _Response(t.Generic[ModelType]):
         if "$defs" in schema:
             del schema["$defs"]
 
-        properties = replace_titles(schema.get("properties", {}))
+        properties = humanize_titles(schema.get("properties", {}))
         for prop in properties.values():
             if prop.get("file_readable", False):
                 prop["oneOf"] = [

--- a/python/composio/tools/base/abs.py
+++ b/python/composio/tools/base/abs.py
@@ -65,22 +65,15 @@ def generate_app_id(name: str) -> str:
     )
 
 
-def is_camel_case(title: str) -> bool:
-    """Check if the title is in camel case with the first letter lowercase"""
-    return title == inflection.camelize(title, uppercase_first_letter=False)
-
-
 def replace_titles(properties: t.Dict) -> t.Dict:
     for field_name, field_properties in properties.items():
         if "file_uploadable" in field_properties:
             continue
 
-        # Check if the field name is in camel case,
-        # If yes, convert to snake case, replace _ and titelize
-        if is_camel_case(field_name):
-            field_properties["title"] = inflection.titleize(
-                inflection.underscore(field_name).replace("_", " ")
-            )
+        # Convert to snake case and titelize
+        field_properties["title"] = inflection.titleize(
+            inflection.underscore(field_name).replace("_", " ")
+        )
 
         if "properties" in field_properties:
             replace_titles(field_properties["properties"])

--- a/python/tests/test_tools/test_base/test_abs.py
+++ b/python/tests/test_tools/test_base/test_abs.py
@@ -87,8 +87,9 @@ class TestToolBuilder:
 
     def test_request_titles(self) -> None:
         class TestClassWithFields(BaseModel):
-            baseId: str = Field(..., description="Some random field")
-            user_id: str = Field(..., description="Another random field")
+            camelCase: str = Field(..., description="camel case field")
+            snake_case: str = Field(..., description="snake case field")
+            PascalCase: str = Field(..., description="pascal case field")
 
         class NestedClass(BaseModel):
             nestedField: str = Field(..., description="A nested field")
@@ -103,12 +104,16 @@ class TestToolBuilder:
         schema_with_nested_fields = remove_json_ref(TestNestedClass.model_json_schema())
         empty_schema = remove_json_ref(TestClassWithNoFields.model_json_schema())
         assert (
-            replace_titles(schema_with_fields["properties"])["baseId"]["title"]
-            == "Base Id"
+            replace_titles(schema_with_fields["properties"])["camelCase"]["title"]
+            == "Camel Case"
         )
         assert (
-            replace_titles(schema_with_fields["properties"])["user_id"]["title"]
-            == "User Id"
+            replace_titles(schema_with_fields["properties"])["snake_case"]["title"]
+            == "Snake Case"
+        )
+        assert (
+            replace_titles(schema_with_fields["properties"])["PascalCase"]["title"]
+            == "Pascal Case"
         )
         assert (
             replace_titles(schema_with_nested_fields["properties"])["nestedObject"][

--- a/python/tests/test_tools/test_base/test_abs.py
+++ b/python/tests/test_tools/test_base/test_abs.py
@@ -4,7 +4,7 @@ import re
 from typing import Dict
 
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from composio.tools.base.abs import (
     DEPRECATED_MARKER,
@@ -13,6 +13,7 @@ from composio.tools.base.abs import (
     Tool,
     ToolBuilder,
     action_registry,
+    replace_titles,
     tool_registry,
 )
 
@@ -82,6 +83,27 @@ class TestActionBuilder:
 
 
 class TestToolBuilder:
+
+    def test_request_titles(self) -> None:
+        class TestClassWithFields(BaseModel):
+            baseId: str = Field(..., description="Some random field")
+            user_id: str = Field(..., description="Another random field")
+
+        class TestClassWithNoFields(BaseModel):
+            pass
+
+        schema_with_fields = TestClassWithFields.model_json_schema()
+        empty_schema = TestClassWithNoFields.model_json_schema()
+        assert (
+            replace_titles(schema_with_fields["properties"])["baseId"]["title"]
+            == "Base Id"
+        )
+        assert (
+            replace_titles(schema_with_fields["properties"])["user_id"]["title"]
+            == "User Id"
+        )
+        assert replace_titles(empty_schema["properties"]) == {}
+
     def test_missing_methods(self) -> None:
         with pytest.raises(
             InvalidClassDefinition,


### PR DESCRIPTION
When schema is generated for requests with fields like `baseId: str = Field(..., description="The ID of the base")` will have title `Baseid`. It should be more human readable like `Base Id`

<img width="747" alt="image" src="https://github.com/user-attachments/assets/563e8400-2d27-494b-a87a-69ae06852dc6" />
