### PR TITLE
chore: update warning for logs API

### DIFF
--- a/fern/changelogs/overview.mdx
+++ b/fern/changelogs/overview.mdx
@@ -1,12 +1,12 @@
 ---
-title: "Changelog & Updates" # <-- Renamed Title
+title: "Changelog & Updates"
 subtitle: "Tracking changes, deprecations, and migrations for Composio"
 ---
 
 ## Deprecations
 
-<Warning title="Deprecated: V1/V2 Action Log APIs">
-  The **V1/V2 Action Log APIs** (endpoints for fetching historical action execution logs) are now deprecated and will be removed in the future.
+<Warning title="Deprecated: V1/V2 Log APIs">
+  The **V1/V2 Action Log APIs** (endpoints for fetching historical action execution logs) are now deprecated and have been replaced by the **V3 Logs API**.
 
   This is part of our migration to the enhanced V3 API infrastructure. Please transition to the new **V3 Logs API** for improved logging and tracing capabilities to avoid disruption.
 

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -37,8 +37,8 @@ typography:
         weight: 600
         style: normal
 announcement:
-  message: '🆕 Incremental v3 SDK Releases! Check out the <a href="/changelog/api-v-3-migration">changelog</a>
-    for more details.'
+  message: '⚠️ Deprecating the V1 Logs API! Check out the <a href="/changelog/api-v-3-migration">changelog</a>
+    to migrate to the V3 Logs API.'
 
 layout:
   tabs-placement: header


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Updates the warning message and announcement banner to inform users about the deprecation of V1/V2 Log APIs and the need to migrate to V3 Logs API.

- Changed the warning title in `fern/changelogs/overview.mdx` from "Deprecated: V1/V2 Action Log APIs" to "Deprecated: V1/V2 Log APIs" and updated the message to clarify that these APIs have been replaced by the V3 Logs API.
- Updated the announcement banner in `fern/docs.yml` to prominently warn users about the V1 Logs API deprecation instead of promoting incremental V3 SDK releases.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->