### PR TITLE
fix: Pick latest connected account in get_connection() method

### DIFF
--- a/python/composio/client/__init__.py
+++ b/python/composio/client/__init__.py
@@ -335,7 +335,6 @@ class Entity:
             )
 
         latest_account = None
-        latest_creation_date = datetime.fromtimestamp(0.0)
         connected_accounts = self.client.connected_accounts.get(
             entity_ids=[self.id],
             active=True,
@@ -343,12 +342,8 @@ class Entity:
         app = str(app).lower()
         for connected_account in connected_accounts:
             if app == connected_account.appUniqueId:
-                creation_date = datetime.fromisoformat(
-                    connected_account.createdAt.replace("Z", "+00:00")
-                )
-                if latest_account is None or creation_date < latest_creation_date:
-                    latest_creation_date = creation_date
-                    latest_account = connected_account
+                latest_account = connected_account
+                break
 
         if latest_account is None:
             entity = self.id


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Fixed the `get_connection()` method in the Composio SDK client to correctly select the latest connected account by taking the first matching account instead of comparing creation dates.

- Simplified the logic in `python/composio/client/__init__.py` by removing the datetime comparison and using the first matching account as the latest one.
- Removed unnecessary code that was incorrectly comparing creation dates (it was actually selecting the oldest account, not the latest).
- Added a `break` statement to exit the loop once a matching account is found, improving performance.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->

- Fixed the logic in `get_connection()` method to get the latest connected account ID