### PR TITLE
feat: Move SDK reference docs to deepwiki.com

### DIFF
--- a/.github/workflows/preview_docs.yml
+++ b/.github/workflows/preview_docs.yml
@@ -3,71 +3,57 @@ name: Preview Docs
 on:
   pull_request:
     paths:
-      - 'fern/**'
+      - "fern/**"
 
 jobs:
-    run:
-        runs-on: ubuntu-latest
-        permissions: write-all
-        defaults:
-          run:
-            working-directory: ./fern
+  run:
+    runs-on: ubuntu-latest
+    permissions: write-all
+    defaults:
+      run:
+        working-directory: ./fern
+    env:
+      COMPOSIO_API_KEY: ${{ inputs.api_key || secrets.COMPOSIO_API_KEY_PROD }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Install Python Dependencies
+        run: |
+          uv sync
+          uv run composio apps generate-types
+
+      - name: Generate Tool Documentation
+        run: uv run generators/tool_doc_generator/main.py --workers 10
+
+      - name: Install Fern
+        run: npm install -g fern-api
+
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Pull Latest OpenAPI Specification
+        run: bash scripts/pull-openapi-spec.sh
+
+      - name: Generate preview URL
+        id: generate-docs
         env:
-            COMPOSIO_API_KEY: ${{ inputs.api_key || secrets.COMPOSIO_API_KEY_PROD }}
+          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+        run: |
+          OUTPUT=$(fern generate --docs --preview 2>&1) || true
+          echo "$OUTPUT"
+          URL=$(echo "$OUTPUT" | grep -oP 'Published docs to \K.*(?= \()')
+          echo "Preview URL: $URL"
+          echo "🌿 Preview your docs: $URL" > preview_url.txt
 
-        steps:
-            - name: Checkout repository
-              uses: actions/checkout@v4
-
-            - name: Install uv
-              uses: astral-sh/setup-uv@v5
-
-            - name: Set up Python
-              run: uv python install
-
-            - name: Install Python Dependencies
-              run: |
-                uv sync
-                uv run composio apps generate-types
-
-            - name: Generate Python SDK documentation
-              run: uv run generators/api_doc_generator/generate_api_docs.py -s ../python/composio/ -o sdk/
-
-            - name: Setup Bun
-              uses: oven-sh/setup-bun@v1
-              with:
-                bun-version: latest
-
-            - name: Install TypeDoc dependencies
-              run: bun install typedoc typedoc-plugin-markdown
-
-            - name: Generate TypeScript SDK documentation
-              run: bun run typedoc --plugin typedoc-plugin-markdown ../js/src/index.ts ../js/src/sdk/index.ts --out ./sdk/composio/js --skipErrorChecking
-
-            - name: Generate Tool Documentation
-              run: uv run generators/tool_doc_generator/main.py --workers 10
-
-            - name: Install Fern
-              run: npm install -g fern-api
-
-            - name: Install jq
-              run: sudo apt-get update && sudo apt-get install -y jq
-
-            - name: Pull Latest OpenAPI Specification
-              run: bash scripts/pull-openapi-spec.sh
-
-            - name: Generate preview URL
-              id: generate-docs
-              env:
-                  FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
-              run: |
-                  OUTPUT=$(fern generate --docs --preview 2>&1) || true
-                  echo "$OUTPUT"
-                  URL=$(echo "$OUTPUT" | grep -oP 'Published docs to \K.*(?= \()')
-                  echo "Preview URL: $URL"
-                  echo "🌿 Preview your docs: $URL" > preview_url.txt
-
-            - name: Comment URL in PR
-              uses: thollander/actions-comment-pull-request@v2.4.3
-              with:
-                  filePath: fern/preview_url.txt
+      - name: Comment URL in PR
+        uses: thollander/actions-comment-pull-request@v2.4.3
+        with:
+          filePath: fern/preview_url.txt

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -3,7 +3,7 @@ name: Publish Docs
 on:
   push:
     branches:
-     - master
+      - master
 
 jobs:
   run:
@@ -13,7 +13,7 @@ jobs:
       run:
         working-directory: ./fern
     env:
-        COMPOSIO_API_KEY: ${{ inputs.api_key || secrets.COMPOSIO_API_KEY_PROD }}
+      COMPOSIO_API_KEY: ${{ inputs.api_key || secrets.COMPOSIO_API_KEY_PROD }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -31,17 +31,6 @@ jobs:
 
       - name: Generate Python SDK documentation
         run: uv run generators/api_doc_generator/generate_api_docs.py -s ../python/composio/ -o sdk/
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
-        with:
-          bun-version: latest
-
-      - name: Install TypeDoc dependencies
-        run: bun install typedoc typedoc-plugin-markdown
-
-      - name: Generate TypeScript SDK documentation
-        run: bun run typedoc --plugin typedoc-plugin-markdown ../js/src/index.ts ../js/src/sdk/index.ts --out ./sdk/composio/js --skipErrorChecking
 
       - name: Generate Tool Documentation
         run: uv run generators/tool_doc_generator/main.py --workers 10

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ A team member will be assigned to review your pull requests. All tests are run a
 
 If you want to contribute, start working through the codebase, navigate to the GitHub `issues` tab and start looking through interesting issues. If you are not sure of where to start, then start by trying one of the smaller/easier issues here i.e. issues with the `good first issue` label and then take a look at the issues with the `contributions welcome` label. These are issues that we believe are particularly well suited for outside contributions, often because we probably won't get to them right now. If you decide to start on an issue, leave a comment so that other people know that you're working on it. If you want to help out, but not alone, use the issue comment thread to coordinate.
 
-*Note:* When opening a PR make sure you open the PR against `development` and not the `master` branch.
+_Note:_ When opening a PR make sure you open the PR against `development` and not the `master` branch.
 
 ## Development setup
 
@@ -35,15 +35,15 @@ If you want to contribute, start working through the codebase, navigate to the G
 
       # Install uv
       pip install uv
-      
+
       # Create and activate virtual environment
       uv venv
       source .venv/bin/activate  # On Windows: .venv\Scripts\activate
-      
+
       # Install dependencies
       uv pip install -e .
       uv pip install -e python/swe
-      
+
       # Install plugins as needed
       uv pip install -e python/plugins/autogen
       uv pip install -e python/plugins/claude
@@ -55,7 +55,7 @@ If you want to contribute, start working through the codebase, navigate to the G
       uv pip install -e python/plugins/lyzr
       uv pip install -e python/plugins/openai
 
-##  For a clean PR run checks in the following order before pushing the code on a PR
+## For a clean PR run checks in the following order before pushing the code on a PR
 
 - make clean
 - make format-code
@@ -80,46 +80,41 @@ To contribute to the documentation:
 1. Make sure you have Node.js installed on your system.
 
 2. Setup dependencies:
-   
+
    a. Install `uv` (required for generating Tool & Python documentation):
+
    ```bash
     curl -LsSf https://astral.sh/uv/install.sh | sh
    ```
-   b. Install Bun (required for TypeScript documentation):
-   ```bash
-   curl -fsSL https://bun.sh/install | bash
-   ```
-   c. Install dependencies:
-   ```bash
-   bun install typedoc typedoc-plugin-markdown
-   ```
-   d. Generate SDK documentation:
-   ```bash
-   cd fern/ && make sdk-generate
-   ```
-   e. Generate Tool documentation:
+
+   b. Generate Tool documentation:
+
    ```bash
    make tools-generate
    ```
-   
-   f. Install Fern globally:
+
+   c. Install Fern globally:
+
    ```bash
    npm install -g fern-api
    ```
 
 3. Start the docs server from the project root:
+
    ```bash
    make docs-dev
-   # or 
+   # or
    # fern docs dev
    ```
 
 4. View and edit docs at http://localhost:3000
 
 5. Before submitting your PR, check for broken links:
+
    ```bash
    fern docs broken-links
    ```
+
    This will ensure your documentation changes don't introduce any broken references.
 
 6. When you're happy with your changes, create a PR.

--- a/fern/Makefile
+++ b/fern/Makefile
@@ -3,19 +3,13 @@
 # Generate API docs and run the docs server
 docs: sdk-generate docs-dev
 
-# Generate API documentation
-sdk-generate:
-	@echo "Generating API documentation..."
-	uv run generators/api_doc_generator/generate_api_docs.py -s ../python/composio/ -o sdk/
-	bun run typedoc --plugin typedoc-plugin-markdown ../js/src/index.ts ../js/src/sdk/index.ts --out ./sdk/composio/js --skipErrorChecking
-
 # Generate Tool documentation
 tools-generate:
 	@echo "Generating Tool documentation..."
 	uv run generators/tool_doc_generator/main.py --workers 10
 
 # Run the docs development server
-docs-generate: sdk-generate tools-generate
+docs-generate: tools-generate
 
 # Run fern local server
 docs-dev:

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -37,7 +37,8 @@ typography:
         weight: 600
         style: normal
 announcement:
-  message: '⚠️ Deprecating the initiate connection API! Check out the <a href="/changelog/api-v-3-migration">changelog</a>
+  message:
+    '⚠️ Deprecating the initiate connection API! Check out the <a href="/changelog/api-v-3-migration">changelog</a>
     to learn more.'
 
 layout:
@@ -171,7 +172,7 @@ tabs:
     icon: map
   sdk-reference:
     display-name: SDK Reference
-    slug: sdk-reference
+    href: https://deepwiki.com/ComposioHQ/composio
     icon: code
   api-reference:
     display-name: API Reference
@@ -349,95 +350,6 @@ navigation:
         paginated: true
         skip-slug: true
   - tab: sdk-reference
-    layout:
-      - section: Python
-        contents:
-          - section: Tools
-            contents:
-              - page: Overview
-                path: sdk/composio/python/composio/tools/index.mdx
-                hidden: true
-              - section: Core
-                contents:
-                  - page: Schema
-                    path: sdk/composio/python/composio/tools/schema.mdx
-                  - page: Toolset
-                    path: sdk/composio/python/composio/tools/toolset.mdx
-          - section: Client
-            contents:
-              - page: Overview
-                path: sdk/composio/python/composio/client/index.mdx
-              - section: Components
-                contents:
-                  - page: Base Client
-                    path: sdk/composio/python/composio/client/base.mdx
-                  - page: HTTP Client
-                    path: sdk/composio/python/composio/client/http.mdx
-                  - page: Collections
-                    path: sdk/composio/python/composio/client/collections.mdx
-                  - page: Files
-                    path: sdk/composio/python/composio/client/files.mdx
-                  - page: Utils
-                    path: sdk/composio/python/composio/client/utils.mdx
-          - section: Storage
-            contents:
-              - page: Overview
-                path: sdk/composio/python/composio/storage/index.mdx
-              - section: Components
-                contents:
-                  - page: Base Storage
-                    path: sdk/composio/python/composio/storage/base.mdx
-                  - page: User Storage
-                    path: sdk/composio/python/composio/storage/user.mdx
-      - section: TypeScript
-        contents:
-          - page: Overview
-            path: sdk/composio/js/modules.mdx
-          - section: SDK
-            contents:
-              - page: Overview
-                path: sdk/composio/js/sdk/README.mdx
-              - section: Classes
-                contents:
-                  - page: Composio
-                    path: sdk/composio/js/sdk/classes/Composio.mdx
-              - section: Types
-                contents:
-                  - page: ComposioInputFieldsParams
-                    path: sdk/composio/js/sdk/type-aliases/ComposioInputFieldsParams.mdx
-                  - page: ComposioInputFieldsRes
-                    path: sdk/composio/js/sdk/type-aliases/ComposioInputFieldsRes.mdx
-          - section: Index
-            contents:
-              - page: Overview
-                path: sdk/composio/js/index/README.mdx
-              - section: Classes
-                contents:
-                  - page: VercelAIToolSet
-                    path: sdk/composio/js/index/classes/VercelAIToolSet.mdx
-                  - page: OpenAIToolSet
-                    path: sdk/composio/js/index/classes/OpenAIToolSet.mdx
-                  - page: LangGraphToolSet
-                    path: sdk/composio/js/index/classes/LangGraphToolSet.mdx
-                  - page: LangchainToolSet
-                    path: sdk/composio/js/index/classes/LangchainToolSet.mdx
-                  - page: ComposioToolSet
-                    path: sdk/composio/js/index/classes/ComposioToolSet.mdx
-                  - page: ConnectionRequest
-                    path: sdk/composio/js/index/classes/ConnectionRequest.mdx
-                  - page: CloudflareToolSet
-                    path: sdk/composio/js/index/classes/CloudflareToolSet.mdx
-                  - page: ComposioError
-                    path: sdk/composio/js/index/classes/ComposioError.mdx
-              - section: Variables
-                contents:
-                  - page: COMPOSIO_SDK_ERROR_CODES
-                    path: sdk/composio/js/index/variables/COMPOSIO_SDK_ERROR_CODES.mdx
-                  - page: ACTIONS
-                    path: sdk/composio/js/index/variables/ACTIONS.mdx
-                  - page: APPS
-                    path: sdk/composio/js/index/variables/APPS.mdx
-
   - tab: tools
     layout:
       - section: Tools

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,2 +1,3 @@
 .composio.lock
 agentops.log
+debugs/

--- a/python/CLAUDE.md
+++ b/python/CLAUDE.md
@@ -1,0 +1,74 @@
+# Release Process for Python Package (RC Version)
+
+## Manual Release Process
+
+1. **Update Version**: Use the bump script to update to desired RC version
+   ```bash
+   python scripts/bump.py --pre
+   ```
+   This will:
+   - Update the version in `__version__.py`
+   - Update `setup.py` with the new version
+   - Update dependency references in files
+   - Update Dockerfiles that reference the package
+
+2. **Create Branch and PR**: 
+   ```bash
+   git checkout -b release/v0.7.16-rc.X
+   git add .
+   git commit -m "Bump version to 0.7.16-rc.X"
+   ```
+
+3. **Update CHANGELOG.md**: Add release notes for the RC version
+
+4. **Review and Merge PR**: After review, merge the PR to master
+
+5. **Create GitHub Release**: Create a new release with the RC tag (v0.7.16-rc.X)
+   
+   Using GitHub CLI:
+   ```bash
+   # Create a new tag if it doesn't exist
+   git tag v0.7.16-rc.X
+   git push origin v0.7.16-rc.X
+   
+   # Create a release from the tag
+   gh release create v0.7.16-rc.X --title "v0.7.16-rc.X" --notes "Release notes for this RC version" --prerelease
+   ```
+   
+   Alternatively via GitHub web interface:
+   1. Go to the repository on GitHub
+   2. Click on "Releases" in the right sidebar
+   3. Click "Draft a new release"
+   4. Enter the tag version (e.g., v0.7.16-rc.X)
+   5. Fill in the release title and description
+   6. Check "This is a pre-release" for RC versions
+   7. Click "Publish release"
+
+## Manual Publishing (if needed)
+
+- **Test Publish to TestPyPI**:
+  ```bash
+  make test-publish
+  ```
+  (Requires `PYPI_PASSWORD` environment variable)
+
+- **Publish to PyPI**:
+  ```bash
+  make publish
+  ```
+  (Requires `PYPI_PASSWORD` environment variable)
+
+## Automated Publishing
+
+The GitHub workflow (`release.yaml`) automatically handles publishing when a new GitHub release is created, including:
+
+- Publishing core Python package to PyPI
+- Publishing plugin packages to PyPI
+- Publishing SWE toolkit to PyPI
+- Building CLI executables for multiple platforms
+- Publishing Docker images
+- Publishing E2B template
+
+## Version Format
+
+RC versions follow the format: `X.Y.Z-rc.N` where N is incremented for each new RC.


### PR DESCRIPTION
Remove self-hosted TypeScript and Python SDK docs generation in favor of linking to documentation hosted on deepwiki.com. Update GitHub workflows and documentation configuration accordingly.