### PR TITLE
Fix: Disable sessionId if allowTracking is set to false

### DIFF
--- a/js/src/sdk/index.ts
+++ b/js/src/sdk/index.ts
@@ -61,7 +61,7 @@ export class Composio {
       baseUrl?: string;
       runtime?: string;
       allowTracing?: boolean;
-    } = { allowTracing: true }
+    } = {}
   ) {
     // Parse the base URL and API key, falling back to environment variables or defaults if not provided
     const { baseURL: baseURLParsed, apiKey: apiKeyParsed } = getSDKConfig(
@@ -79,8 +79,9 @@ export class Composio {
     ComposioSDKContext.frameworkRuntime = config?.runtime;
     ComposioSDKContext.composioVersion = COMPOSIO_VERSION;
     ComposioSDKContext.allowTracing = config?.allowTracing;
-    // if only allowTracing is true, generate a sessionId
-    ComposioSDKContext.sessionId = config?.allowTracing ? getUUID() : undefined;
+    // by default, generate a sessionId unless allowTracing is explicitly set to false
+    ComposioSDKContext.sessionId =
+      config?.allowTracing !== false ? getUUID() : undefined;
 
     TELEMETRY_LOGGER.manualTelemetry(TELEMETRY_EVENTS.SDK_INITIALIZED, {});
 

--- a/js/src/sdk/index.ts
+++ b/js/src/sdk/index.ts
@@ -61,7 +61,7 @@ export class Composio {
       baseUrl?: string;
       runtime?: string;
       allowTracing?: boolean;
-    } = {}
+    } = { allowTracing: true }
   ) {
     // Parse the base URL and API key, falling back to environment variables or defaults if not provided
     const { baseURL: baseURLParsed, apiKey: apiKeyParsed } = getSDKConfig(

--- a/js/src/sdk/index.ts
+++ b/js/src/sdk/index.ts
@@ -75,11 +75,12 @@ export class Composio {
       );
     }
     ComposioSDKContext.apiKey = apiKeyParsed;
-    ComposioSDKContext.sessionId = getUUID();
     ComposioSDKContext.baseURL = baseURLParsed;
     ComposioSDKContext.frameworkRuntime = config?.runtime;
     ComposioSDKContext.composioVersion = COMPOSIO_VERSION;
     ComposioSDKContext.allowTracing = config?.allowTracing;
+    // if only allowTracing is true, generate a sessionId
+    ComposioSDKContext.sessionId = config?.allowTracing ? getUUID() : undefined;
 
     TELEMETRY_LOGGER.manualTelemetry(TELEMETRY_EVENTS.SDK_INITIALIZED, {});
 


### PR DESCRIPTION
Currently the allowTracing flag has no impact on the sessionId. This PR fixes it by preventing generating sessionId if the `allowTracing` flag is explicitly set to false .