### PR TITLE
fix: handle anyOf in tools request schema correctly

### DIFF
--- a/python/composio/tools/base/abs.py
+++ b/python/composio/tools/base/abs.py
@@ -145,10 +145,18 @@ class _Request(t.Generic[ModelType]):
                     ] += f" Note: choose value only from following options - {prop['enum']}"
 
             if "anyOf" in prop:
-                typedef, *_ = [
+                # Find the non-null type definition
+                non_null_types = [
                     td for td in prop["anyOf"] if td.get("type", "null") != "null"
                 ]
-                prop["type"] = typedef["type"]
+                if non_null_types:
+                    typedef = non_null_types[0]
+                    # Remove anyOf and copy all properties from the non-null type
+                    prop.pop("anyOf")
+                    # Update the property with all attributes from the non-null type
+                    prop.update(typedef)
+                    # Add nullable flag to indicate this field can be null
+                    prop["nullable"] = True
 
         request["properties"] = properties
         return request

--- a/python/tests/test_tools/test_base/test_abs.py
+++ b/python/tests/test_tools/test_base/test_abs.py
@@ -1,7 +1,7 @@
 """Test abstractions"""
 
 import re
-from typing import Dict
+from typing import Dict, List, Optional
 
 import pytest
 from pydantic import BaseModel, Field
@@ -170,6 +170,62 @@ class TestToolBuilder:
             ]["title"]
             == "Nested Field Property"
         )
+
+    def test_request_schema_anyof_to_nullable_transformation(self) -> None:
+        """Test that anyOf structures with null are converted to nullable properties."""
+        
+        class Request(BaseModel):
+            # Required field (should not be affected)
+            required_field: str = Field(..., description="A required field")
+            
+            # Optional string (should become nullable)
+            optional_string: Optional[str] = Field(None, description="An optional string")
+            
+            # Optional array (the main case we're fixing)
+            optional_array: Optional[List[str]] = Field(
+                None, 
+                description="An optional array of strings",
+                examples=[["item1", "item2"], []]
+            )
+            
+            # Optional nested object
+            optional_dict: Optional[Dict[str, str]] = Field(
+                None,
+                description="An optional dictionary"
+            )
+
+        class Response(BaseModel):
+            pass
+
+        class TestAction(Action[Request, Response]):
+            def execute(self, request: Request, metadata: Dict) -> Response:
+                return Response()
+
+        request_schema = TestAction.request.schema()
+        properties = request_schema["properties"]
+
+        # Required field should not have nullable or anyOf
+        assert "anyOf" not in properties["required_field"]
+        assert "nullable" not in properties["required_field"]
+        assert properties["required_field"]["type"] == "string"
+
+        # Optional string should be nullable without anyOf
+        assert "anyOf" not in properties["optional_string"]
+        assert properties["optional_string"]["nullable"] is True
+        assert properties["optional_string"]["type"] == "string"
+
+        # Optional array should be nullable array with items, without anyOf
+        assert "anyOf" not in properties["optional_array"]
+        assert properties["optional_array"]["nullable"] is True
+        assert properties["optional_array"]["type"] == "array"
+        assert "items" in properties["optional_array"]
+        assert properties["optional_array"]["items"]["type"] == "string"
+        assert properties["optional_array"]["default"] is None
+
+        # Optional dict should be nullable without anyOf
+        assert "anyOf" not in properties["optional_dict"]
+        assert properties["optional_dict"]["nullable"] is True
+        assert properties["optional_dict"]["type"] == "object"
 
     def test_missing_methods(self) -> None:
         with pytest.raises(


### PR DESCRIPTION
## Fix: Properly Handle Optional Array Fields in JSON Schema Generation

### Problem

Currently, when generating JSON schemas from Pydantic models, fields that are `Optional` arrays (e.g., `attendees: Optional[List[str]]`) are represented using an `anyOf` construct in the schema:

```json
"attendees": {
  "anyOf": [
    { "type": "array", "items": { "type": "string" } },
    { "type": "null" }
  ]
}
```

However, many providers (such as OpenAI) do **not** support `anyOf` for array fields and require a direct array type with a `nullable` flag instead.

### Solution

This PR updates the schema generation logic in the `_Request.schema()` method to:

- Detect properties with `anyOf` containing a non-null type and `null`
- Replace the `anyOf` with the non-null type’s properties
- Add a `nullable: true` flag to indicate the field can be `null`
- Preserve all relevant sub-properties (such as `items` for arrays)

**Example transformation:**

_Before:_
```json
"attendees": {
  "anyOf": [
    { "type": "array", "items": { "type": "string" } },
    { "type": "null" }
  ],
  "default": null,
}
```

_After:_
```json
"attendees": {
  "type": "array",
  "items": { "type": "string" },
  "default": null,
  "nullable": true,
}
```

### Testing

- Added a test to verify that optional array fields are transformed as expected
- Confirmed that the generated schema matches the required format and passes assertions