### PR TITLE
fix: link to v3 docs

### DIFF
--- a/fern/changelogs/overview.mdx
+++ b/fern/changelogs/overview.mdx
@@ -13,7 +13,7 @@ Keep up-to-date with the latest releases, deprecations, and announcements.
 
 We have released the V3 SDKs for Python and Node.js. These SDKs provide foundational access to the V3 API endpoints.
 
-They are available in preview, you can learn more about them [here](https://v3.composio.dev) and how to migrate at https://v3.docs.composio.dev/docs/migration
+They are available in preview, you can learn more about them [here](https://v3.docs.composio.dev) and how to migrate at https://v3.docs.composio.dev/docs/migration
 
 These new SDKs come almost fully formed, we do not expect many breaking changes to them but are releasing them in a preview state to get feedback and make necessary changes before locking them in.
 

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -40,7 +40,7 @@ typography:
         weight: 600
         style: normal
 announcement:
-  message: '🎉 Our next generation of SDK are now available in preview. <a href="https://v3.composio.dev">Try them out now</a>!'
+  message: '🎉 Our next generation of SDK are now available in preview. <a href="https://v3.docs.composio.dev">Try them out now</a>!'
 
 layout:
   tabs-placement: header

--- a/fern/getting-started/welcome.mdx
+++ b/fern/getting-started/welcome.mdx
@@ -6,7 +6,7 @@ hide-nav-links: true
 <Card 
     title='🎉 Our next generation of SDK are now available in preview. Try them out now!' 
     icon='sparkles' 
-    href='https://v3.composio.dev'
+    href='https://v3.docs.composio.dev'
 >
 Our next generation of SDK are now available in preview. Try them out now!
 </Card>


### PR DESCRIPTION
### TL;DR

Updated links to V3 SDK documentation to consistently point to v3.docs.composio.dev.

### What changed?

- Updated all references to the V3 SDK documentation from `v3.composio.dev` to `v3.docs.composio.dev`