### PR TITLE
chore(cli): rename barrel object created by "composio ts generate" from `composio` to `Toolkits`

### DIFF
--- a/ts/packages/cli/src/generation/typescript/generate-index-source.ts
+++ b/ts/packages/cli/src/generation/typescript/generate-index-source.ts
@@ -27,6 +27,8 @@ import * as ts from '@composio/ts-builders';
 import { pipe, Record, Array as Arr } from 'effect';
 import type { ToolkitIndex } from 'src/generation/create-toolkit-index';
 
+const BARREL_OBJECT_NAME = 'Toolkits';
+
 type GenerateTypeScriptIndexMapSourceParams = {
   banner: string;
   emitSingleFile: boolean;
@@ -83,7 +85,9 @@ export function generateTypeScriptIndexMapSource(params: GenerateTypeScriptIndex
     indexMapFile.add(
       ts
         .moduleExport(
-          ts.constDeclaration('composio').setValue(ts.objectValue().addMultiple(indexMapEntries))
+          ts
+            .constDeclaration(BARREL_OBJECT_NAME)
+            .setValue(ts.objectValue().addMultiple(indexMapEntries))
         )
         .setDocComment(ts.docComment('Map of Composio toolkits to actions.'))
     );
@@ -130,12 +134,12 @@ export function generateToolsByToolkitType(): string {
         ts
           .typeDeclaration(
             'ToolsByToolkit',
-            ts.typeOfType(ts.keyType(ts.namedType('composio'), ts.namedType('Toolkit')))
+            ts.typeOfType(ts.keyType(ts.namedType(BARREL_OBJECT_NAME), ts.namedType('$Toolkit')))
           )
           .addGenericParameter(
             ts
-              .genericParameter('Toolkit')
-              .extends(ts.keyOfType(ts.typeOfType(ts.namedType('composio'))))
+              .genericParameter('$Toolkit')
+              .extends(ts.keyOfType(ts.typeOfType(ts.namedType(BARREL_OBJECT_NAME))))
           )
       )
       .setDocComment(doc)

--- a/ts/packages/cli/test/__fixtures__/python-project-with-composio-core/uv.lock
+++ b/ts/packages/cli/test/__fixtures__/python-project-with-composio-core/uv.lock
@@ -1,0 +1,8 @@
+version = 1
+revision = 2
+requires-python = ">=3.12, <4"
+
+[[package]]
+name = "python-project-with-composio-core"
+version = "0.1.0"
+source = { virtual = "." }

--- a/ts/packages/cli/test/__fixtures__/typescript-project-with-composio-core/src/index.js
+++ b/ts/packages/cli/test/__fixtures__/typescript-project-with-composio-core/src/index.js
@@ -1,4 +1,4 @@
-import { composio } from '@composio/core/generated';
+import { Toolkits } from '@composio/core/generated';
 
 console.log('Test: Using generated Composio types');
-console.log(composio.GMAIL.tools.CREATE_EMAIL_DRAFT);
+console.log(Toolkits.GMAIL.tools.CREATE_EMAIL_DRAFT);

--- a/ts/packages/cli/test/src/commands/ts/ts.generate.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/ts/ts.generate.cmd.test.ts
@@ -96,7 +96,7 @@ describe('CLI: composio ts generate', () => {
                 /**
                  * Map of Composio toolkits to actions.
                  */
-                export const composio = {
+                export const Toolkits = {
                   GMAIL: GMAIL,
                   SLACK: SLACK,
                 }
@@ -115,7 +115,7 @@ describe('CLI: composio ts generate', () => {
                 /**
                  * Given a toolkit, returns the tools available for that toolkit.
                  */
-                export type ToolsByToolkit<Toolkit extends keyof (typeof composio)> = typeof composio[Toolkit]
+                export type ToolsByToolkit<$Toolkit extends keyof (typeof Toolkits)> = typeof Toolkits[$Toolkit]
 
                 "
               `);
@@ -133,10 +133,10 @@ describe('CLI: composio ts generate', () => {
               const testSourceCodePath = path.join(cwd, 'src', 'index.js');
               const testSourceCode = yield* fs.readFileString(testSourceCodePath);
               expect(testSourceCode).toMatchInlineSnapshot(`
-                "import { composio } from '@composio/core/generated';
+                "import { Toolkits } from '@composio/core/generated';
 
                 console.log('Test: Using generated Composio types');
-                console.log(composio.GMAIL.tools.CREATE_EMAIL_DRAFT);
+                console.log(Toolkits.GMAIL.tools.CREATE_EMAIL_DRAFT);
                 "
               `);
 
@@ -205,7 +205,7 @@ describe('CLI: composio ts generate', () => {
                 /**
                  * Map of Composio toolkits to actions.
                  */
-                export const composio = {
+                export const Toolkits = {
                   GMAIL: GMAIL,
                   SLACK: SLACK,
                 }
@@ -224,7 +224,7 @@ describe('CLI: composio ts generate', () => {
                 /**
                  * Given a toolkit, returns the tools available for that toolkit.
                  */
-                export type ToolsByToolkit<Toolkit extends keyof (typeof composio)> = typeof composio[Toolkit]
+                export type ToolsByToolkit<$Toolkit extends keyof (typeof Toolkits)> = typeof Toolkits[$Toolkit]
 
                 "
               `);
@@ -381,7 +381,7 @@ describe('CLI: composio ts generate', () => {
               /**
                * Map of Composio toolkits to actions.
                */
-              export const composio = {
+              export const Toolkits = {
                 GMAIL: GMAIL,
                 SLACK: SLACK,
               }
@@ -400,7 +400,7 @@ describe('CLI: composio ts generate', () => {
               /**
                * Given a toolkit, returns the tools available for that toolkit.
                */
-              export type ToolsByToolkit<Toolkit extends keyof (typeof composio)> = typeof composio[Toolkit]
+              export type ToolsByToolkit<$Toolkit extends keyof (typeof Toolkits)> = typeof Toolkits[$Toolkit]
 
               "
             `);

--- a/ts/packages/cli/test/src/generation/typescript/generate-index-source.test.ts
+++ b/ts/packages/cli/test/src/generation/typescript/generate-index-source.test.ts
@@ -31,7 +31,7 @@ describe('generateTypeScriptToolkitSources', () => {
           "/**
            * Map of Composio toolkits to actions.
            */
-          export const composio = {}
+          export const Toolkits = {}
 
           /**
            * Type declarations
@@ -45,7 +45,7 @@ describe('generateTypeScriptToolkitSources', () => {
           /**
            * Given a toolkit, returns the tools available for that toolkit.
            */
-          export type ToolsByToolkit<Toolkit extends keyof (typeof composio)> = typeof composio[Toolkit]
+          export type ToolsByToolkit<$Toolkit extends keyof (typeof Toolkits)> = typeof Toolkits[$Toolkit]
 
           "
         `);
@@ -74,7 +74,7 @@ describe('generateTypeScriptToolkitSources', () => {
           "/**
            * Map of Composio toolkits to actions.
            */
-          export const composio = {
+          export const Toolkits = {
             SLACK: SLACK,
           }
 
@@ -91,7 +91,7 @@ describe('generateTypeScriptToolkitSources', () => {
           /**
            * Given a toolkit, returns the tools available for that toolkit.
            */
-          export type ToolsByToolkit<Toolkit extends keyof (typeof composio)> = typeof composio[Toolkit]
+          export type ToolsByToolkit<$Toolkit extends keyof (typeof Toolkits)> = typeof Toolkits[$Toolkit]
 
           "
         `);
@@ -122,7 +122,7 @@ describe('generateTypeScriptToolkitSources', () => {
           "/**
            * Map of Composio toolkits to actions.
            */
-          export const composio = {
+          export const Toolkits = {
             GMAIL: GMAIL,
             SLACK: SLACK,
           }
@@ -141,7 +141,7 @@ describe('generateTypeScriptToolkitSources', () => {
           /**
            * Given a toolkit, returns the tools available for that toolkit.
            */
-          export type ToolsByToolkit<Toolkit extends keyof (typeof composio)> = typeof composio[Toolkit]
+          export type ToolsByToolkit<$Toolkit extends keyof (typeof Toolkits)> = typeof Toolkits[$Toolkit]
 
           "
         `);
@@ -179,7 +179,7 @@ describe('generateTypeScriptToolkitSources', () => {
           /**
            * Map of Composio toolkits to actions.
            */
-          export const composio = {}
+          export const Toolkits = {}
 
           /**
            * Type declarations
@@ -193,7 +193,7 @@ describe('generateTypeScriptToolkitSources', () => {
           /**
            * Given a toolkit, returns the tools available for that toolkit.
            */
-          export type ToolsByToolkit<Toolkit extends keyof (typeof composio)> = typeof composio[Toolkit]
+          export type ToolsByToolkit<$Toolkit extends keyof (typeof Toolkits)> = typeof Toolkits[$Toolkit]
 
           "
         `);
@@ -228,7 +228,7 @@ describe('generateTypeScriptToolkitSources', () => {
           /**
            * Map of Composio toolkits to actions.
            */
-          export const composio = {
+          export const Toolkits = {
             SLACK: SLACK,
           }
 
@@ -245,7 +245,7 @@ describe('generateTypeScriptToolkitSources', () => {
           /**
            * Given a toolkit, returns the tools available for that toolkit.
            */
-          export type ToolsByToolkit<Toolkit extends keyof (typeof composio)> = typeof composio[Toolkit]
+          export type ToolsByToolkit<$Toolkit extends keyof (typeof Toolkits)> = typeof Toolkits[$Toolkit]
 
           "
         `);
@@ -283,7 +283,7 @@ describe('generateTypeScriptToolkitSources', () => {
           /**
            * Map of Composio toolkits to actions.
            */
-          export const composio = {
+          export const Toolkits = {
             GMAIL: GMAIL,
             SLACK: SLACK,
           }
@@ -302,7 +302,7 @@ describe('generateTypeScriptToolkitSources', () => {
           /**
            * Given a toolkit, returns the tools available for that toolkit.
            */
-          export type ToolsByToolkit<Toolkit extends keyof (typeof composio)> = typeof composio[Toolkit]
+          export type ToolsByToolkit<$Toolkit extends keyof (typeof Toolkits)> = typeof Toolkits[$Toolkit]
 
           "
         `);

--- a/ts/packages/cli/test/src/generation/typescript/generate.test.ts
+++ b/ts/packages/cli/test/src/generation/typescript/generate.test.ts
@@ -40,7 +40,7 @@ describe('generateTypeScriptSources', () => {
           /**
            * Map of Composio toolkits to actions.
            */
-          export const composio = {}
+          export const Toolkits = {}
 
           /**
            * Type declarations
@@ -54,7 +54,7 @@ describe('generateTypeScriptSources', () => {
           /**
            * Given a toolkit, returns the tools available for that toolkit.
            */
-          export type ToolsByToolkit<Toolkit extends keyof (typeof composio)> = typeof composio[Toolkit]
+          export type ToolsByToolkit<$Toolkit extends keyof (typeof Toolkits)> = typeof Toolkits[$Toolkit]
 
           "
         `);
@@ -105,7 +105,7 @@ describe('generateTypeScriptSources', () => {
           /**
            * Map of Composio toolkits to actions.
            */
-          export const composio = {
+          export const Toolkits = {
             SLACK: SLACK,
           }
 
@@ -122,7 +122,7 @@ describe('generateTypeScriptSources', () => {
           /**
            * Given a toolkit, returns the tools available for that toolkit.
            */
-          export type ToolsByToolkit<Toolkit extends keyof (typeof composio)> = typeof composio[Toolkit]
+          export type ToolsByToolkit<$Toolkit extends keyof (typeof Toolkits)> = typeof Toolkits[$Toolkit]
 
           "
         `);
@@ -175,7 +175,7 @@ describe('generateTypeScriptSources', () => {
           /**
            * Map of Composio toolkits to actions.
            */
-          export const composio = {
+          export const Toolkits = {
             SLACK: SLACK,
           }
 
@@ -192,7 +192,7 @@ describe('generateTypeScriptSources', () => {
           /**
            * Given a toolkit, returns the tools available for that toolkit.
            */
-          export type ToolsByToolkit<Toolkit extends keyof (typeof composio)> = typeof composio[Toolkit]
+          export type ToolsByToolkit<$Toolkit extends keyof (typeof Toolkits)> = typeof Toolkits[$Toolkit]
 
           "
         `);


### PR DESCRIPTION
In practice:

```diff
- import { composio } from '@composio/core/generated';
+ import { Toolkits } from '@composio/core/generated';

- console.log(composio.GMAIL.tools.CREATE_EMAIL_DRAFT);
+ console.log(Toolkits.GMAIL.tools.CREATE_EMAIL_DRAFT);
```