### PR TITLE
feat(cli): introduce lazy config check

### DIFF
--- a/ts/packages/cli/src/services/user-config.ts
+++ b/ts/packages/cli/src/services/user-config.ts
@@ -36,7 +36,6 @@ const ConfigProviderLive = Effect.gen(function* () {
   const cacheDir = yield* setupCacheDir;
   const jsonUserConfigPath = path.join(cacheDir, constants.USER_CONFIG_FILE_NAME);
   const configProviderFromUserFile = yield* configProviderFromLazyJson(jsonUserConfigPath);
-  // const configProviderFromUserFile = yield* configProviderFromLazyJson('/tmp');
 
   // start by reading from env vars
   const configProvider = ConfigProvider.fromEnv()


### PR DESCRIPTION
We don't need to read the app `Config` (`process.env.COMPOSIO_*` vars or `~/.composio/user_data.json`) for simple commands that don't use the client, like `composio version`.