### PR TITLE
feat(core): Add SERVER_UNREACHABLE to SDKErrorCodes

### DIFF
--- a/ts/packages/core/src/errors/SDKErrors.ts
+++ b/ts/packages/core/src/errors/SDKErrors.ts
@@ -2,6 +2,7 @@ import { ComposioError, ComposioErrorOptions } from './ComposioError';
 
 export const SDKErrorCodes = {
   NO_API_KEY_PROVIDED: 'NO_API_KEY_PROVIDED',
+  SERVER_UNREACHABLE: 'SERVER_UNREACHABLE',
 };
 
 export class ComposioNoAPIKeyError extends ComposioError {


### PR DESCRIPTION
When Google Calendar API requests fail with a SERVER_UNREACHABLE error, the composio-core library crashes because the error is not defined in the SDKErrorCodes.

This commit adds the SERVER_UNREACHABLE error code to the SDKErrorCodes object in `ts/packages/core/src/errors/SDKErrors.ts` to prevent the crash.

Closes #1716 