### PR TITLE
fix: update custom domain in documentation configuration

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1,6 +1,6 @@
 instances:
 - url: v3composio.docs.buildwithfern.com
-  custom-domain: v3.docs.composio.dev
+  custom-domain: docs.composio.dev
   edit-this-page:
     github:
       owner: ComposioHQ


### PR DESCRIPTION
Move domain from v3.docs.composio.dev to docs.composio.dev