### PR TITLE
Fix: Treating params as array instead of object in Proxy Execute

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -22,6 +22,7 @@
     "modern-parents-bake",
     "modern-webs-admire",
     "polite-suits-accept",
+    "red-pigs-cross",
     "slimy-showers-burn",
     "sour-ravens-behave",
     "tame-jobs-train",

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -28,6 +28,7 @@
     "tasty-suns-check",
     "thick-keys-work",
     "wide-mugs-add",
+    "yellow-mangos-kneel",
     "young-waves-study"
   ]
 }

--- a/.changeset/red-pigs-cross.md
+++ b/.changeset/red-pigs-cross.md
@@ -1,0 +1,13 @@
+---
+'@composio/core': patch
+'@composio/anthropic': patch
+'@composio/cloudflare': patch
+'@composio/google': patch
+'@composio/langchain': patch
+'@composio/mastra': patch
+'@composio/openai': patch
+'@composio/openai-agents': patch
+'@composio/vercel': patch
+---
+
+Update deps

--- a/.changeset/yellow-mangos-kneel.md
+++ b/.changeset/yellow-mangos-kneel.md
@@ -1,0 +1,13 @@
+---
+'@composio/core': patch
+'@composio/anthropic': patch
+'@composio/cloudflare': patch
+'@composio/google': patch
+'@composio/langchain': patch
+'@composio/mastra': patch
+'@composio/openai': patch
+'@composio/openai-agents': patch
+'@composio/vercel': patch
+---
+
+Fix proxy execute params and bump langchain packages

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,10 +92,10 @@ importers:
         version: link:../ts/packages/providers/vercel
       '@langchain/langgraph':
         specifier: ^0.2.72
-        version: 0.2.74(@langchain/core@0.3.59(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(react@18.3.1)(zod-to-json-schema@3.24.5(zod@3.25.67))
+        version: 0.2.74(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(react@18.3.1)(zod-to-json-schema@3.24.5(zod@3.25.67))
       '@langchain/openai':
         specifier: ^0.5.10
-        version: 0.5.13(@langchain/core@0.3.59(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(ws@8.18.2)
+        version: 0.5.13(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(ws@8.18.2)
       '@types/convict':
         specifier: ^6.1.6
         version: 6.1.6
@@ -116,7 +116,7 @@ importers:
         version: 4.3.16(react@18.3.1)(zod@3.25.67)
       composio-core:
         specifier: ^0.5.39
-        version: 0.5.39(@ai-sdk/openai@1.3.22(zod@3.25.67))(@cloudflare/workers-types@4.20250619.0)(@langchain/core@0.3.59(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(@langchain/openai@0.5.13(@langchain/core@0.3.59(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(ws@8.18.2))(ai@4.3.16(react@18.3.1)(zod@3.25.67))(langchain@0.3.28(@langchain/core@0.3.59(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(axios@1.10.0)(openai@4.104.0(ws@8.18.2)(zod@3.25.67))(ws@8.18.2))(openai@4.104.0(ws@8.18.2)(zod@3.25.67))
+        version: 0.5.39(@ai-sdk/openai@1.3.22(zod@3.25.67))(@cloudflare/workers-types@4.20250619.0)(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(@langchain/openai@0.5.13(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(ws@8.18.2))(ai@4.3.16(react@18.3.1)(zod@3.25.67))(langchain@0.3.28(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(axios@1.10.0)(openai@4.104.0(ws@8.18.2)(zod@3.25.67))(ws@8.18.2))(openai@4.104.0(ws@8.18.2)(zod@3.25.67))
       hono:
         specifier: ^4.7.11
         version: 4.8.0
@@ -308,14 +308,14 @@ importers:
         specifier: workspace:*
         version: link:../../packages/providers/langchain
       '@langchain/core':
-        specifier: ^0.3.56
-        version: 0.3.59(openai@4.104.0(ws@8.18.2)(zod@3.25.67))
+        specifier: ^0.3.63
+        version: 0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67))
       '@langchain/langgraph':
-        specifier: ^0.2.72
-        version: 0.2.74(@langchain/core@0.3.59(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(react@18.3.1)(zod-to-json-schema@3.24.5(zod@3.25.67))
+        specifier: ^0.3.8
+        version: 0.3.8(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(react-dom@19.1.0(react@18.3.1))(react@18.3.1)(zod-to-json-schema@3.24.5(zod@3.25.67))
       '@langchain/openai':
-        specifier: ^0.5.10
-        version: 0.5.13(@langchain/core@0.3.59(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(ws@8.18.2)
+        specifier: ^0.6.1
+        version: 0.6.1(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(ws@8.18.2)
       dotenv:
         specifier: ^16.5.0
         version: 16.5.0
@@ -707,8 +707,8 @@ importers:
   ts/packages/providers/langchain:
     dependencies:
       '@langchain/core':
-        specifier: ^0.3.44
-        version: 0.3.58(openai@5.5.1(ws@8.18.2)(zod@3.25.67))
+        specifier: ^0.3.63
+        version: 0.3.63(openai@5.5.1(ws@8.18.2)(zod@3.25.67))
     devDependencies:
       '@composio/core':
         specifier: workspace:*
@@ -1977,12 +1977,8 @@ packages:
   '@jsdevtools/ono@7.1.3':
     resolution: {integrity: sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==}
 
-  '@langchain/core@0.3.58':
-    resolution: {integrity: sha512-HLkOtVofgBHefaUae/+2fLNkpMLzEjHSavTmUF0YC7bDa5NPIZGlP80CGrSFXAeJ+WCPd8rIK8K/p6AW94inUQ==}
-    engines: {node: '>=18'}
-
-  '@langchain/core@0.3.59':
-    resolution: {integrity: sha512-YAvnx0z3A8z5MvyjZzjC9ZxXZYM20ivFdUeLzANSPCoPCNIQ1/EppWP82RI24PcmWkNtuXsFVaj5juWiIpZvxg==}
+  '@langchain/core@0.3.63':
+    resolution: {integrity: sha512-CQfyu4WgwizUhSc1YsDDzzHga6WVhLqeuAyCD4VpGAPa3k3QI+H0b3ECFr/WjJMw0amMtHtfgPWMa1tS7P7qVg==}
     engines: {node: '>=18'}
 
   '@langchain/langgraph-checkpoint@0.0.18':
@@ -2002,6 +1998,20 @@ packages:
       react:
         optional: true
 
+  '@langchain/langgraph-sdk@0.0.95':
+    resolution: {integrity: sha512-nfchDZUTJMTS4AtH5NyEhoGLUyhVQqBSm8liK0ApHc/PQhSlW7qumfsF85E+utnqWKWgdc9osSKl5jDff4j/HA==}
+    peerDependencies:
+      '@langchain/core': '>=0.2.31 <0.4.0'
+      react: ^18 || ^19
+      react-dom: ^18 || ^19
+    peerDependenciesMeta:
+      '@langchain/core':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   '@langchain/langgraph@0.2.74':
     resolution: {integrity: sha512-oHpEi5sTZTPaeZX1UnzfM2OAJ21QGQrwReTV6+QnX7h8nDCBzhtipAw1cK616S+X8zpcVOjgOtJuaJhXa4mN8w==}
     engines: {node: '>=18'}
@@ -2012,8 +2022,24 @@ packages:
       zod-to-json-schema:
         optional: true
 
+  '@langchain/langgraph@0.3.8':
+    resolution: {integrity: sha512-JOtYNMa7BixzXrAtV76x1lS2+Blt4WLcbFUWwtiEqTMzwNg00fSvUQ6FaPeootL66iYamg67AVq12PerqMrelw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/core': '>=0.3.58 < 0.4.0'
+      zod-to-json-schema: ^3.x
+    peerDependenciesMeta:
+      zod-to-json-schema:
+        optional: true
+
   '@langchain/openai@0.5.13':
     resolution: {integrity: sha512-t5UsO7XYE+DBQlXQ21QK74Y+LH4It20wnENrmueNvxIWTn0nHDIGVmO6wo4rJxbmOOPRQ4l/oAxGRnYU8B8v6w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/core': '>=0.3.58 <0.4.0'
+
+  '@langchain/openai@0.6.1':
+    resolution: {integrity: sha512-jm8MzMEjAKPReYma4Lewb9vGnocKbhoClqPuRTxtKPDgqQ5yJWSisNy4iZO/a1d6ag/7MnxwKMjVsJdy1cBsxw==}
     engines: {node: '>=18'}
     peerDependencies:
       '@langchain/core': '>=0.3.58 <0.4.0'
@@ -4621,14 +4647,6 @@ packages:
       peggy:
         optional: true
       typeorm:
-        optional: true
-
-  langsmith@0.3.31:
-    resolution: {integrity: sha512-9lwuLZuN3tXFYQ6eMg0rmbBw7oxQo4bu1NYeylbjz27bOdG1XB9XNoxaiIArkK4ciLdOIOhPMBXP4bkvZOgHRw==}
-    peerDependencies:
-      openai: '*'
-    peerDependenciesMeta:
-      openai:
         optional: true
 
   langsmith@0.3.33:
@@ -7585,24 +7603,7 @@ snapshots:
 
   '@jsdevtools/ono@7.1.3': {}
 
-  '@langchain/core@0.3.58(openai@5.5.1(ws@8.18.2)(zod@3.25.67))':
-    dependencies:
-      '@cfworker/json-schema': 4.1.1
-      ansi-styles: 5.2.0
-      camelcase: 6.3.0
-      decamelize: 1.2.0
-      js-tiktoken: 1.0.20
-      langsmith: 0.3.31(openai@5.5.1(ws@8.18.2)(zod@3.25.67))
-      mustache: 4.2.0
-      p-queue: 6.6.2
-      p-retry: 4.6.2
-      uuid: 10.0.0
-      zod: 3.25.67
-      zod-to-json-schema: 3.24.5(zod@3.25.67)
-    transitivePeerDependencies:
-      - openai
-
-  '@langchain/core@0.3.59(openai@4.104.0(ws@8.18.2)(zod@3.25.67))':
+  '@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67))':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       ansi-styles: 5.2.0
@@ -7619,26 +7620,54 @@ snapshots:
     transitivePeerDependencies:
       - openai
 
-  '@langchain/langgraph-checkpoint@0.0.18(@langchain/core@0.3.59(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))':
+  '@langchain/core@0.3.63(openai@5.5.1(ws@8.18.2)(zod@3.25.67))':
     dependencies:
-      '@langchain/core': 0.3.59(openai@4.104.0(ws@8.18.2)(zod@3.25.67))
+      '@cfworker/json-schema': 4.1.1
+      ansi-styles: 5.2.0
+      camelcase: 6.3.0
+      decamelize: 1.2.0
+      js-tiktoken: 1.0.20
+      langsmith: 0.3.33(openai@5.5.1(ws@8.18.2)(zod@3.25.67))
+      mustache: 4.2.0
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      uuid: 10.0.0
+      zod: 3.25.67
+      zod-to-json-schema: 3.24.5(zod@3.25.67)
+    transitivePeerDependencies:
+      - openai
+
+  '@langchain/langgraph-checkpoint@0.0.18(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))':
+    dependencies:
+      '@langchain/core': 0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67))
       uuid: 10.0.0
 
-  '@langchain/langgraph-sdk@0.0.84(@langchain/core@0.3.59(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(react@18.3.1)':
+  '@langchain/langgraph-sdk@0.0.84(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(react@18.3.1)':
     dependencies:
       '@types/json-schema': 7.0.15
       p-queue: 6.6.2
       p-retry: 4.6.2
       uuid: 9.0.1
     optionalDependencies:
-      '@langchain/core': 0.3.59(openai@4.104.0(ws@8.18.2)(zod@3.25.67))
+      '@langchain/core': 0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67))
       react: 18.3.1
 
-  '@langchain/langgraph@0.2.74(@langchain/core@0.3.59(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(react@18.3.1)(zod-to-json-schema@3.24.5(zod@3.25.67))':
+  '@langchain/langgraph-sdk@0.0.95(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(react-dom@19.1.0(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@langchain/core': 0.3.59(openai@4.104.0(ws@8.18.2)(zod@3.25.67))
-      '@langchain/langgraph-checkpoint': 0.0.18(@langchain/core@0.3.59(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))
-      '@langchain/langgraph-sdk': 0.0.84(@langchain/core@0.3.59(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(react@18.3.1)
+      '@types/json-schema': 7.0.15
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      uuid: 9.0.1
+    optionalDependencies:
+      '@langchain/core': 0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67))
+      react: 18.3.1
+      react-dom: 19.1.0(react@18.3.1)
+
+  '@langchain/langgraph@0.2.74(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(react@18.3.1)(zod-to-json-schema@3.24.5(zod@3.25.67))':
+    dependencies:
+      '@langchain/core': 0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67))
+      '@langchain/langgraph-checkpoint': 0.0.18(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))
+      '@langchain/langgraph-sdk': 0.0.84(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(react@18.3.1)
       uuid: 10.0.0
       zod: 3.25.67
     optionalDependencies:
@@ -7646,9 +7675,22 @@ snapshots:
     transitivePeerDependencies:
       - react
 
-  '@langchain/openai@0.5.13(@langchain/core@0.3.59(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(ws@8.18.2)':
+  '@langchain/langgraph@0.3.8(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(react-dom@19.1.0(react@18.3.1))(react@18.3.1)(zod-to-json-schema@3.24.5(zod@3.25.67))':
     dependencies:
-      '@langchain/core': 0.3.59(openai@4.104.0(ws@8.18.2)(zod@3.25.67))
+      '@langchain/core': 0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67))
+      '@langchain/langgraph-checkpoint': 0.0.18(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))
+      '@langchain/langgraph-sdk': 0.0.95(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(react-dom@19.1.0(react@18.3.1))(react@18.3.1)
+      uuid: 10.0.0
+      zod: 3.25.67
+    optionalDependencies:
+      zod-to-json-schema: 3.24.5(zod@3.25.67)
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@langchain/openai@0.5.13(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(ws@8.18.2)':
+    dependencies:
+      '@langchain/core': 0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67))
       js-tiktoken: 1.0.20
       openai: 4.104.0(ws@8.18.2)(zod@3.25.32)
       zod: 3.25.32
@@ -7656,9 +7698,18 @@ snapshots:
       - encoding
       - ws
 
-  '@langchain/textsplitters@0.1.0(@langchain/core@0.3.59(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))':
+  '@langchain/openai@0.6.1(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(ws@8.18.2)':
     dependencies:
-      '@langchain/core': 0.3.59(openai@4.104.0(ws@8.18.2)(zod@3.25.67))
+      '@langchain/core': 0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67))
+      js-tiktoken: 1.0.20
+      openai: 5.5.1(ws@8.18.2)(zod@3.25.67)
+      zod: 3.25.67
+    transitivePeerDependencies:
+      - ws
+
+  '@langchain/textsplitters@0.1.0(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))':
+    dependencies:
+      '@langchain/core': 0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67))
       js-tiktoken: 1.0.20
 
   '@manypkg/find-root@1.1.0':
@@ -9681,21 +9732,21 @@ snapshots:
       has-own-prop: 2.0.0
       repeat-string: 1.6.1
 
-  composio-core@0.5.39(@ai-sdk/openai@1.3.22(zod@3.25.67))(@cloudflare/workers-types@4.20250619.0)(@langchain/core@0.3.59(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(@langchain/openai@0.5.13(@langchain/core@0.3.59(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(ws@8.18.2))(ai@4.3.16(react@18.3.1)(zod@3.25.67))(langchain@0.3.28(@langchain/core@0.3.59(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(axios@1.10.0)(openai@4.104.0(ws@8.18.2)(zod@3.25.67))(ws@8.18.2))(openai@4.104.0(ws@8.18.2)(zod@3.25.67)):
+  composio-core@0.5.39(@ai-sdk/openai@1.3.22(zod@3.25.67))(@cloudflare/workers-types@4.20250619.0)(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(@langchain/openai@0.5.13(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(ws@8.18.2))(ai@4.3.16(react@18.3.1)(zod@3.25.67))(langchain@0.3.28(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(axios@1.10.0)(openai@4.104.0(ws@8.18.2)(zod@3.25.67))(ws@8.18.2))(openai@4.104.0(ws@8.18.2)(zod@3.25.67)):
     dependencies:
       '@ai-sdk/openai': 1.3.22(zod@3.25.67)
       '@cloudflare/workers-types': 4.20250619.0
       '@composio/mcp': 1.0.3-0
       '@hey-api/client-axios': 0.2.12(axios@1.10.0)
-      '@langchain/core': 0.3.59(openai@4.104.0(ws@8.18.2)(zod@3.25.67))
-      '@langchain/openai': 0.5.13(@langchain/core@0.3.59(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(ws@8.18.2)
+      '@langchain/core': 0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67))
+      '@langchain/openai': 0.5.13(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(ws@8.18.2)
       ai: 4.3.16(react@18.3.1)(zod@3.25.67)
       axios: 1.10.0
       chalk: 4.1.2
       cli-progress: 3.12.0
       commander: 12.1.0
       inquirer: 10.2.2
-      langchain: 0.3.28(@langchain/core@0.3.59(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(axios@1.10.0)(openai@4.104.0(ws@8.18.2)(zod@3.25.67))(ws@8.18.2)
+      langchain: 0.3.28(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(axios@1.10.0)(openai@4.104.0(ws@8.18.2)(zod@3.25.67))(ws@8.18.2)
       open: 8.4.2
       openai: 4.104.0(ws@8.18.2)(zod@3.25.67)
       pusher-js: 8.4.0-rc2
@@ -10645,11 +10696,11 @@ snapshots:
 
   kind-of@6.0.3: {}
 
-  langchain@0.3.28(@langchain/core@0.3.59(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(axios@1.10.0)(openai@4.104.0(ws@8.18.2)(zod@3.25.67))(ws@8.18.2):
+  langchain@0.3.28(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(axios@1.10.0)(openai@4.104.0(ws@8.18.2)(zod@3.25.67))(ws@8.18.2):
     dependencies:
-      '@langchain/core': 0.3.59(openai@4.104.0(ws@8.18.2)(zod@3.25.67))
-      '@langchain/openai': 0.5.13(@langchain/core@0.3.59(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(ws@8.18.2)
-      '@langchain/textsplitters': 0.1.0(@langchain/core@0.3.59(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))
+      '@langchain/core': 0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67))
+      '@langchain/openai': 0.5.13(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(ws@8.18.2)
+      '@langchain/textsplitters': 0.1.0(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))
       js-tiktoken: 1.0.20
       js-yaml: 4.1.0
       jsonpointer: 5.0.1
@@ -10666,18 +10717,6 @@ snapshots:
       - openai
       - ws
 
-  langsmith@0.3.31(openai@5.5.1(ws@8.18.2)(zod@3.25.67)):
-    dependencies:
-      '@types/uuid': 10.0.0
-      chalk: 4.1.2
-      console-table-printer: 2.14.3
-      p-queue: 6.6.2
-      p-retry: 4.6.2
-      semver: 7.7.2
-      uuid: 10.0.0
-    optionalDependencies:
-      openai: 5.5.1(ws@8.18.2)(zod@3.25.67)
-
   langsmith@0.3.33(openai@4.104.0(ws@8.18.2)(zod@3.25.67)):
     dependencies:
       '@types/uuid': 10.0.0
@@ -10689,6 +10728,18 @@ snapshots:
       uuid: 10.0.0
     optionalDependencies:
       openai: 4.104.0(ws@8.18.2)(zod@3.25.67)
+
+  langsmith@0.3.33(openai@5.5.1(ws@8.18.2)(zod@3.25.67)):
+    dependencies:
+      '@types/uuid': 10.0.0
+      chalk: 4.1.2
+      console-table-printer: 2.14.3
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      semver: 7.7.2
+      uuid: 10.0.0
+    optionalDependencies:
+      openai: 5.5.1(ws@8.18.2)(zod@3.25.67)
 
   levn@0.4.1:
     dependencies:

--- a/ts/examples/langchain/package.json
+++ b/ts/examples/langchain/package.json
@@ -16,9 +16,9 @@
   "dependencies": {
     "@composio/core": "workspace:*",
     "@composio/langchain": "workspace:*",
-    "@langchain/core": "^0.3.56",
-    "@langchain/langgraph": "^0.2.72",
-    "@langchain/openai": "^0.5.10",
+    "@langchain/core": "^0.3.63",
+    "@langchain/langgraph": "^0.3.8",
+    "@langchain/openai": "^0.6.1",
     "dotenv": "^16.5.0",
     "openai": "^4.94.0"
   },

--- a/ts/packages/core/CHANGELOG.md
+++ b/ts/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @composio/core
 
+## 0.1.36-next.12
+
+### Patch Changes
+
+- Update deps
+
 ## 0.1.36-next.11
 
 ### Patch Changes

--- a/ts/packages/core/CHANGELOG.md
+++ b/ts/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @composio/core
 
+## 0.1.36-next.11
+
+### Patch Changes
+
+- Fix proxy execute params and bump langchain packages
+
 ## 0.1.36-next.10
 
 ### Patch Changes

--- a/ts/packages/core/package.json
+++ b/ts/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/core",
-  "version": "0.1.36-next.10",
+  "version": "0.1.36-next.11",
   "description": "",
   "main": "src/index.ts",
   "type": "module",

--- a/ts/packages/core/package.json
+++ b/ts/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/core",
-  "version": "0.1.36-next.11",
+  "version": "0.1.36-next.12",
   "description": "",
   "main": "src/index.ts",
   "type": "module",

--- a/ts/packages/core/src/models/Tools.ts
+++ b/ts/packages/core/src/models/Tools.ts
@@ -876,8 +876,8 @@ export class Tools<
 
     if (toolProxyParams.data.parameters) {
       parameters.push(
-        ...Object.entries(toolProxyParams.data.parameters).map(([key, value]) => ({
-          name: key,
+        ...(toolProxyParams.data.parameters ?? []).map(value => ({
+          name: value.name,
           type: value.in === 'header' ? parameterTypes.header : parameterTypes.query,
           value: value.value.toString(),
         }))

--- a/ts/packages/providers/anthropic/CHANGELOG.md
+++ b/ts/packages/providers/anthropic/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @composio/anthropic
 
+## 0.1.36-next.12
+
+### Patch Changes
+
+- Update deps
+- Updated dependencies
+  - @composio/core@0.1.36-next.12
+
 ## 0.1.36-next.11
 
 ### Patch Changes

--- a/ts/packages/providers/anthropic/CHANGELOG.md
+++ b/ts/packages/providers/anthropic/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @composio/anthropic
 
+## 0.1.36-next.11
+
+### Patch Changes
+
+- Fix proxy execute params and bump langchain packages
+- Updated dependencies
+  - @composio/core@0.1.36-next.11
+
 ## 0.1.36-next.10
 
 ### Patch Changes

--- a/ts/packages/providers/anthropic/package.json
+++ b/ts/packages/providers/anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/anthropic",
-  "version": "0.1.36-next.10",
+  "version": "0.1.36-next.11",
   "description": "Non-Agentic Provider for Anthropic in Composio SDK",
   "main": "src/index.ts",
   "type": "module",
@@ -35,7 +35,7 @@
   "packageManager": "pnpm@10.8.0",
   "peerDependencies": {
     "@anthropic-ai/sdk": "^0.52.0",
-    "@composio/core": "0.1.36-next.10"
+    "@composio/core": "0.1.36-next.11"
   },
   "devDependencies": {
     "@composio/core": "workspace:*",

--- a/ts/packages/providers/anthropic/package.json
+++ b/ts/packages/providers/anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/anthropic",
-  "version": "0.1.36-next.11",
+  "version": "0.1.36-next.12",
   "description": "Non-Agentic Provider for Anthropic in Composio SDK",
   "main": "src/index.ts",
   "type": "module",
@@ -35,7 +35,7 @@
   "packageManager": "pnpm@10.8.0",
   "peerDependencies": {
     "@anthropic-ai/sdk": "^0.52.0",
-    "@composio/core": "0.1.36-next.11"
+    "@composio/core": "0.1.36-next.12"
   },
   "devDependencies": {
     "@composio/core": "workspace:*",

--- a/ts/packages/providers/cloudflare/CHANGELOG.md
+++ b/ts/packages/providers/cloudflare/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @composio/cloudflare
 
+## 0.1.36-next.11
+
+### Patch Changes
+
+- Fix proxy execute params and bump langchain packages
+- Updated dependencies
+  - @composio/core@0.1.36-next.11
+
 ## 0.1.36-next.10
 
 ### Patch Changes

--- a/ts/packages/providers/cloudflare/CHANGELOG.md
+++ b/ts/packages/providers/cloudflare/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @composio/cloudflare
 
+## 0.1.36-next.12
+
+### Patch Changes
+
+- Update deps
+- Updated dependencies
+  - @composio/core@0.1.36-next.12
+
 ## 0.1.36-next.11
 
 ### Patch Changes

--- a/ts/packages/providers/cloudflare/package.json
+++ b/ts/packages/providers/cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/cloudflare",
-  "version": "0.1.36-next.11",
+  "version": "0.1.36-next.12",
   "description": "",
   "main": "src/index.ts",
   "type": "module",
@@ -31,7 +31,7 @@
   "packageManager": "pnpm@10.8.0",
   "peerDependencies": {
     "@cloudflare/workers-types": "^4.20250416.0",
-    "@composio/core": "0.1.36-next.11"
+    "@composio/core": "0.1.36-next.12"
   },
   "devDependencies": {
     "@composio/core": "workspace:*",

--- a/ts/packages/providers/cloudflare/package.json
+++ b/ts/packages/providers/cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/cloudflare",
-  "version": "0.1.36-next.10",
+  "version": "0.1.36-next.11",
   "description": "",
   "main": "src/index.ts",
   "type": "module",
@@ -31,7 +31,7 @@
   "packageManager": "pnpm@10.8.0",
   "peerDependencies": {
     "@cloudflare/workers-types": "^4.20250416.0",
-    "@composio/core": "0.1.36-next.10"
+    "@composio/core": "0.1.36-next.11"
   },
   "devDependencies": {
     "@composio/core": "workspace:*",

--- a/ts/packages/providers/google/CHANGELOG.md
+++ b/ts/packages/providers/google/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @composio/google
 
+## 0.1.36-next.12
+
+### Patch Changes
+
+- Update deps
+- Updated dependencies
+  - @composio/core@0.1.36-next.12
+
 ## 0.1.36-next.11
 
 ### Patch Changes

--- a/ts/packages/providers/google/CHANGELOG.md
+++ b/ts/packages/providers/google/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @composio/google
 
+## 0.1.36-next.11
+
+### Patch Changes
+
+- Fix proxy execute params and bump langchain packages
+- Updated dependencies
+  - @composio/core@0.1.36-next.11
+
 ## 0.1.36-next.10
 
 ### Patch Changes

--- a/ts/packages/providers/google/package.json
+++ b/ts/packages/providers/google/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/google",
-  "version": "0.1.36-next.10",
+  "version": "0.1.36-next.11",
   "description": "Google GenAI Provider for Composio SDK",
   "main": "src/index.ts",
   "type": "module",
@@ -36,7 +36,7 @@
   "license": "ISC",
   "packageManager": "pnpm@10.8.0",
   "peerDependencies": {
-    "@composio/core": "0.1.36-next.10",
+    "@composio/core": "0.1.36-next.11",
     "@google/genai": "^1.1.0"
   },
   "devDependencies": {

--- a/ts/packages/providers/google/package.json
+++ b/ts/packages/providers/google/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/google",
-  "version": "0.1.36-next.11",
+  "version": "0.1.36-next.12",
   "description": "Google GenAI Provider for Composio SDK",
   "main": "src/index.ts",
   "type": "module",
@@ -36,7 +36,7 @@
   "license": "ISC",
   "packageManager": "pnpm@10.8.0",
   "peerDependencies": {
-    "@composio/core": "0.1.36-next.11",
+    "@composio/core": "0.1.36-next.12",
     "@google/genai": "^1.1.0"
   },
   "devDependencies": {

--- a/ts/packages/providers/langchain/CHANGELOG.md
+++ b/ts/packages/providers/langchain/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @composio/langchain
 
+## 0.1.36-next.11
+
+### Patch Changes
+
+- Fix proxy execute params and bump langchain packages
+- Updated dependencies
+  - @composio/core@0.1.36-next.11
+
 ## 0.1.36-next.10
 
 ### Patch Changes

--- a/ts/packages/providers/langchain/CHANGELOG.md
+++ b/ts/packages/providers/langchain/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @composio/langchain
 
+## 0.1.36-next.12
+
+### Patch Changes
+
+- Update deps
+- Updated dependencies
+  - @composio/core@0.1.36-next.12
+
 ## 0.1.36-next.11
 
 ### Patch Changes

--- a/ts/packages/providers/langchain/package.json
+++ b/ts/packages/providers/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/langchain",
-  "version": "0.1.36-next.10",
+  "version": "0.1.36-next.11",
   "description": "",
   "main": "dist/index.js",
   "type": "module",
@@ -30,7 +30,7 @@
   "license": "ISC",
   "packageManager": "pnpm@10.8.0",
   "peerDependencies": {
-    "@composio/core": "0.1.36-next.10",
+    "@composio/core": "0.1.36-next.11",
     "@langchain/core": "^0.3.63"
   },
   "devDependencies": {

--- a/ts/packages/providers/langchain/package.json
+++ b/ts/packages/providers/langchain/package.json
@@ -31,7 +31,7 @@
   "packageManager": "pnpm@10.8.0",
   "peerDependencies": {
     "@composio/core": "0.1.36-next.10",
-    "@langchain/core": "^0.3.44"
+    "@langchain/core": "^0.3.63"
   },
   "devDependencies": {
     "@composio/core": "workspace:*",

--- a/ts/packages/providers/langchain/package.json
+++ b/ts/packages/providers/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/langchain",
-  "version": "0.1.36-next.11",
+  "version": "0.1.36-next.12",
   "description": "",
   "main": "dist/index.js",
   "type": "module",
@@ -30,7 +30,7 @@
   "license": "ISC",
   "packageManager": "pnpm@10.8.0",
   "peerDependencies": {
-    "@composio/core": "0.1.36-next.11",
+    "@composio/core": "0.1.36-next.12",
     "@langchain/core": "^0.3.63"
   },
   "devDependencies": {

--- a/ts/packages/providers/mastra/CHANGELOG.md
+++ b/ts/packages/providers/mastra/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @composio/mastra
 
+## 0.1.36-next.12
+
+### Patch Changes
+
+- Update deps
+- Updated dependencies
+  - @composio/core@0.1.36-next.12
+
 ## 0.1.36-next.11
 
 ### Patch Changes

--- a/ts/packages/providers/mastra/CHANGELOG.md
+++ b/ts/packages/providers/mastra/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @composio/mastra
 
+## 0.1.36-next.11
+
+### Patch Changes
+
+- Fix proxy execute params and bump langchain packages
+- Updated dependencies
+  - @composio/core@0.1.36-next.11
+
 ## 0.1.36-next.10
 
 ### Patch Changes

--- a/ts/packages/providers/mastra/package.json
+++ b/ts/packages/providers/mastra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/mastra",
-  "version": "0.1.36-next.10",
+  "version": "0.1.36-next.11",
   "description": "Agentic Provider for mastra in Composio SDK",
   "main": "src/index.ts",
   "type": "module",
@@ -34,7 +34,7 @@
   "license": "ISC",
   "packageManager": "pnpm@10.8.0",
   "peerDependencies": {
-    "@composio/core": "0.1.36-next.10",
+    "@composio/core": "0.1.36-next.11",
     "@mastra/core": "^0.10.0"
   },
   "devDependencies": {

--- a/ts/packages/providers/mastra/package.json
+++ b/ts/packages/providers/mastra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/mastra",
-  "version": "0.1.36-next.11",
+  "version": "0.1.36-next.12",
   "description": "Agentic Provider for mastra in Composio SDK",
   "main": "src/index.ts",
   "type": "module",
@@ -34,7 +34,7 @@
   "license": "ISC",
   "packageManager": "pnpm@10.8.0",
   "peerDependencies": {
-    "@composio/core": "0.1.36-next.11",
+    "@composio/core": "0.1.36-next.12",
     "@mastra/core": "^0.10.0"
   },
   "devDependencies": {

--- a/ts/packages/providers/openai-agents/CHANGELOG.md
+++ b/ts/packages/providers/openai-agents/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @composio/vercel
 
+## 0.1.36-next.12
+
+### Patch Changes
+
+- Update deps
+- Updated dependencies
+  - @composio/core@0.1.36-next.12
+
 ## 0.1.36-next.11
 
 ### Patch Changes

--- a/ts/packages/providers/openai-agents/CHANGELOG.md
+++ b/ts/packages/providers/openai-agents/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @composio/vercel
 
+## 0.1.36-next.11
+
+### Patch Changes
+
+- Fix proxy execute params and bump langchain packages
+- Updated dependencies
+  - @composio/core@0.1.36-next.11
+
 ## 0.1.36-next.10
 
 ### Patch Changes

--- a/ts/packages/providers/openai-agents/package.json
+++ b/ts/packages/providers/openai-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/openai-agents",
-  "version": "0.1.36-next.11",
+  "version": "0.1.36-next.12",
   "description": "",
   "main": "src/index.ts",
   "type": "module",
@@ -30,7 +30,7 @@
   "license": "ISC",
   "packageManager": "pnpm@10.8.0",
   "peerDependencies": {
-    "@composio/core": "0.1.36-next.11",
+    "@composio/core": "0.1.36-next.12",
     "@openai/agents": "^0.0.7"
   },
   "devDependencies": {

--- a/ts/packages/providers/openai-agents/package.json
+++ b/ts/packages/providers/openai-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/openai-agents",
-  "version": "0.1.36-next.10",
+  "version": "0.1.36-next.11",
   "description": "",
   "main": "src/index.ts",
   "type": "module",
@@ -30,7 +30,7 @@
   "license": "ISC",
   "packageManager": "pnpm@10.8.0",
   "peerDependencies": {
-    "@composio/core": "0.1.36-next.10",
+    "@composio/core": "0.1.36-next.11",
     "@openai/agents": "^0.0.7"
   },
   "devDependencies": {

--- a/ts/packages/providers/openai/CHANGELOG.md
+++ b/ts/packages/providers/openai/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @composio/openai
 
+## 0.1.36-next.11
+
+### Patch Changes
+
+- Fix proxy execute params and bump langchain packages
+- Updated dependencies
+  - @composio/core@0.1.36-next.11
+
 ## 0.1.36-next.10
 
 ### Patch Changes

--- a/ts/packages/providers/openai/CHANGELOG.md
+++ b/ts/packages/providers/openai/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @composio/openai
 
+## 0.1.36-next.12
+
+### Patch Changes
+
+- Update deps
+- Updated dependencies
+  - @composio/core@0.1.36-next.12
+
 ## 0.1.36-next.11
 
 ### Patch Changes

--- a/ts/packages/providers/openai/package.json
+++ b/ts/packages/providers/openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/openai",
-  "version": "0.1.36-next.11",
+  "version": "0.1.36-next.12",
   "description": "",
   "main": "src/index.ts",
   "type": "module",
@@ -30,7 +30,7 @@
   "license": "ISC",
   "packageManager": "pnpm@10.8.0",
   "peerDependencies": {
-    "@composio/core": "0.1.36-next.11",
+    "@composio/core": "0.1.36-next.12",
     "openai": "^4.3.8"
   },
   "devDependencies": {

--- a/ts/packages/providers/openai/package.json
+++ b/ts/packages/providers/openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/openai",
-  "version": "0.1.36-next.10",
+  "version": "0.1.36-next.11",
   "description": "",
   "main": "src/index.ts",
   "type": "module",
@@ -30,7 +30,7 @@
   "license": "ISC",
   "packageManager": "pnpm@10.8.0",
   "peerDependencies": {
-    "@composio/core": "0.1.36-next.10",
+    "@composio/core": "0.1.36-next.11",
     "openai": "^4.3.8"
   },
   "devDependencies": {

--- a/ts/packages/providers/vercel/CHANGELOG.md
+++ b/ts/packages/providers/vercel/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @composio/vercel
 
+## 0.1.36-next.12
+
+### Patch Changes
+
+- Update deps
+- Updated dependencies
+  - @composio/core@0.1.36-next.12
+
 ## 0.1.36-next.11
 
 ### Patch Changes

--- a/ts/packages/providers/vercel/CHANGELOG.md
+++ b/ts/packages/providers/vercel/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @composio/vercel
 
+## 0.1.36-next.11
+
+### Patch Changes
+
+- Fix proxy execute params and bump langchain packages
+- Updated dependencies
+  - @composio/core@0.1.36-next.11
+
 ## 0.1.36-next.10
 
 ### Patch Changes

--- a/ts/packages/providers/vercel/package.json
+++ b/ts/packages/providers/vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/vercel",
-  "version": "0.1.36-next.10",
+  "version": "0.1.36-next.11",
   "description": "",
   "main": "src/index.ts",
   "type": "module",
@@ -30,7 +30,7 @@
   "license": "ISC",
   "packageManager": "pnpm@10.8.0",
   "peerDependencies": {
-    "@composio/core": "0.1.36-next.10",
+    "@composio/core": "0.1.36-next.11",
     "ai": "^4.3.8"
   },
   "devDependencies": {

--- a/ts/packages/providers/vercel/package.json
+++ b/ts/packages/providers/vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/vercel",
-  "version": "0.1.36-next.11",
+  "version": "0.1.36-next.12",
   "description": "",
   "main": "src/index.ts",
   "type": "module",
@@ -30,7 +30,7 @@
   "license": "ISC",
   "packageManager": "pnpm@10.8.0",
   "peerDependencies": {
-    "@composio/core": "0.1.36-next.11",
+    "@composio/core": "0.1.36-next.12",
     "ai": "^4.3.8"
   },
   "devDependencies": {


### PR DESCRIPTION
- Fix proxy execute params [used to be treated as objects instead of arrays]
- Chore Bump langchain package versions