### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/python/providers/autogen/pyproject.toml
+++ b/python/providers/autogen/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "pyautogen>=0.2.19",
+    "ag2>=0.2.19",
     "flaml==2.2.0",
     "autogen_core>=0.4.0",
     "autogen_agentchat>=0.4.0"

--- a/python/providers/autogen/setup.py
+++ b/python/providers/autogen/setup.py
@@ -22,7 +22,7 @@ setup(
     ],
     python_requires=">=3.9,<4",
     install_requires=[
-        "pyautogen>=0.2.19",
+        "ag2>=0.2.19",
         "flaml==2.2.0",
         "autogen_core>=0.4.0",
         "autogen_agentchat>=0.4.0",


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using AG2! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!


---
## EntelligenceAI PR Summary 
 This PR updates the autogen provider's dependencies to use the 'ag2' package instead of 'pyautogen'.
- Replaced 'pyautogen>=0.2.19' with 'ag2>=0.2.19' in pyproject.toml and setup.py
- No other code or configuration changes 

