### PR TITLE
feat(cli): improve CLI errors

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -511,6 +511,9 @@ importers:
 
   ts/packages/cli:
     dependencies:
+      '@clack/prompts':
+        specifier: 1.0.0-alpha.1
+        version: 1.0.0-alpha.1
       '@composio/client':
         specifier: 0.1.0-alpha.29
         version: 0.1.0-alpha.29
@@ -547,6 +550,9 @@ importers:
       open:
         specifier: ^10.2.0
         version: 10.2.0
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
       semver:
         specifier: ^7.7.2
         version: 7.7.2
@@ -1087,6 +1093,12 @@ packages:
 
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+
+  '@clack/core@1.0.0-alpha.1':
+    resolution: {integrity: sha512-rFbCU83JnN7l3W1nfgCqqme4ZZvTTgsiKQ6FM0l+r0P+o2eJpExcocBUWUIwnDzL76Aca9VhUdWmB2MbUv+Qyg==}
+
+  '@clack/prompts@1.0.0-alpha.1':
+    resolution: {integrity: sha512-07MNT0OsxjKOcyVfX8KhXBhJiyUbDP1vuIAcHc+nx5v93MJO23pX3X/k3bWz6T3rpM9dgWPq90i4Jq7gZAyMbw==}
 
   '@cloudflare/kv-asset-handler@0.4.0':
     resolution: {integrity: sha512-+tv3z+SPp+gqTIcImN9o0hqE9xyfQjI1XD9pL6NuKjua9B1y7mNYv0S9cP+QEbA4ppVgGZEmKOvHX5G5Ei1CVA==}
@@ -5750,6 +5762,9 @@ packages:
     resolution: {integrity: sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A==}
     engines: {node: '>=18'}
 
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -7096,6 +7111,17 @@ snapshots:
       fs-extra: 7.0.1
       human-id: 4.1.1
       prettier: 2.8.8
+
+  '@clack/core@1.0.0-alpha.1':
+    dependencies:
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.0.0-alpha.1':
+    dependencies:
+      '@clack/core': 1.0.0-alpha.1
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
 
   '@cloudflare/kv-asset-handler@0.4.0':
     dependencies:
@@ -9590,6 +9616,14 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
+  '@vitest/mocker@3.2.4(vite@6.3.5(@types/node@20.19.1)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.0))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 6.3.5(@types/node@20.19.1)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.0)
+
   '@vitest/mocker@3.2.4(vite@6.3.5(@types/node@22.15.32)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.0))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -9597,6 +9631,14 @@ snapshots:
       magic-string: 0.30.17
     optionalDependencies:
       vite: 6.3.5(@types/node@22.15.32)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.0)
+
+  '@vitest/mocker@3.2.4(vite@6.3.5(@types/node@24.0.3)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.0))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 6.3.5(@types/node@24.0.3)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -9627,7 +9669,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@22.15.32)(@vitest/ui@3.2.4)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.0)
+      vitest: 3.2.4(@types/node@24.0.3)(@vitest/ui@3.2.4)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.0)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -12131,6 +12173,8 @@ snapshots:
       mrmime: 2.0.1
       totalist: 3.0.1
 
+  sisteransi@1.0.5: {}
+
   slash@3.0.0: {}
 
   slice-ansi@5.0.0:
@@ -12689,7 +12733,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@22.15.32)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.0))
+      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@20.19.1)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -12773,7 +12817,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@22.15.32)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.0))
+      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@24.0.3)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4

--- a/ts/packages/cli/package.json
+++ b/ts/packages/cli/package.json
@@ -54,6 +54,7 @@
     "vitest": "^3.2.4"
   },
   "dependencies": {
+    "@clack/prompts": "1.0.0-alpha.1",
     "@composio/client": "0.1.0-alpha.29",
     "@composio/core": "workspace:*",
     "@composio/ts-builders": "workspace:*",
@@ -66,6 +67,7 @@
     "effect-errors": "^1.10.11",
     "indent-string": "^5.0.0",
     "open": "^10.2.0",
+    "picocolors": "^1.1.1",
     "semver": "^7.7.2",
     "superjson": "^2.2.2"
   },

--- a/ts/packages/cli/src/models/tools.ts
+++ b/ts/packages/cli/src/models/tools.ts
@@ -1,10 +1,17 @@
 import { Brand, Schema } from 'effect';
 import { JSONTransformSchema } from './utils/json-transform-schema';
+import { extractActual } from './utils/extract-actual';
 
-export const Tool = Schema.String;
+export const Tool = Schema.String.annotations({ identifier: 'Tool' });
 export type Tool = Schema.Schema.Type<typeof Tool>;
 
-export const Tools = Schema.Array(Tool);
+export const Tools = Schema.Array(Tool).annotations({
+  identifier: 'Array<Tool>',
+  message: issue => ({
+    message: `Expected an array of strings, got ${extractActual(issue)}`,
+    override: true,
+  }),
+});
 export type Tools = Schema.Schema.Type<typeof Tools>;
 
 export const ToolsJSON = JSONTransformSchema(Tools);

--- a/ts/packages/cli/src/models/trigger-types.ts
+++ b/ts/packages/cli/src/models/trigger-types.ts
@@ -1,10 +1,18 @@
 import { Brand, Schema } from 'effect';
 import { JSONTransformSchema } from './utils/json-transform-schema';
+import { extractActual } from './utils/extract-actual';
 
-export const TriggerType = Schema.String;
+export const TriggerType = Schema.String.annotations({ identifier: 'TriggerType' });
 export type TriggerType = Schema.Schema.Type<typeof TriggerType>;
 
-export const TriggerTypes = Schema.Array(TriggerType);
+export const TriggerTypes = Schema.Array(TriggerType).annotations({
+  identifier: 'Array<TriggerType>',
+  title: 'TriggerTypes',
+  message: issue => ({
+    message: `Expected an array of strings, got ${extractActual(issue)}`,
+    override: true,
+  }),
+});
 export type TriggerTypes = Schema.Schema.Type<typeof TriggerTypes>;
 
 export const TriggerTypesJSON = JSONTransformSchema(TriggerTypes);

--- a/ts/packages/cli/src/models/utils/extract-actual.ts
+++ b/ts/packages/cli/src/models/utils/extract-actual.ts
@@ -1,0 +1,13 @@
+import type { ParseIssue } from 'effect/ParseResult';
+
+export function extractActual({ actual }: ParseIssue, cap = 50) {
+  // Cap the length of the actual value to 30 characters
+  let str = undefined;
+
+  if (typeof actual === 'object') {
+    str = JSON.stringify(actual);
+  }
+
+  str = String(actual);
+  return str.slice(0, cap) + (str.length > cap ? '...' : '');
+}

--- a/ts/packages/cli/src/services/utils/pretty-error.ts
+++ b/ts/packages/cli/src/services/utils/pretty-error.ts
@@ -1,0 +1,33 @@
+import colors from 'picocolors';
+import { S_BAR, S_BAR_H, unicodeOr } from '@clack/prompts';
+
+const S_CORNER_TOP_LEFT = unicodeOr('╭', '+');
+const S_CORNER_BOTTOM_LEFT = unicodeOr('╰', '+');
+
+export function renderPrettyError(errorLines: Array<[key: string, value: unknown]>): string {
+  return renderPrettyErrorGen(errorLines).toArray().join('\n');
+}
+
+function* renderPrettyErrorGen(
+  errorLines: Array<[key: string, value: unknown]>
+): Generator<string, void, unknown> {
+  if (errorLines.length === 0) {
+    yield '';
+  } else if (errorLines.length <= 2) {
+    for (const [key, value] of errorLines) {
+      yield `${colors.gray(S_BAR)}  ${colors.blueBright(key)}: ${value}`;
+    }
+  } else if (errorLines.length > 2) {
+    for (let i = 0; i < errorLines.length; i++) {
+      const [key, value] = errorLines[i];
+
+      if (i === 0) {
+        yield `${colors.gray(`${S_CORNER_TOP_LEFT}${S_BAR_H}`)} ${colors.blueBright(key)}: ${value}`;
+      } else if (i === errorLines.length - 1) {
+        yield `${colors.gray(`${S_CORNER_BOTTOM_LEFT}${S_BAR_H}`)} ${colors.blueBright(key)}: ${value}`;
+      } else {
+        yield `${colors.gray(S_BAR)}  ${colors.blueBright(key)}: ${value}`;
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR:
- builds on top of https://github.com/ComposioHQ/composio/pull/1771 (merge that first!)
- improves the visualization of major CLI errors messages, reducing confusion
- when available, we display the error coming from Composio's backend, formatted in a human-friendly fashion

<img width="544" height="274" alt="Screenshot 2025-07-23 at 5 26 28 AM" src="https://github.com/user-attachments/assets/ddd4616f-6102-4dec-bf18-2358dbd79d92" />
