### PR TITLE
[FIX] feat: make the file downloadable path configurable

### DIFF
--- a/python/composio/core/models/_files.py
+++ b/python/composio/core/models/_files.py
@@ -294,7 +294,7 @@ class FileHelper(WithLogger):
             if self._is_file_downloadable(schema=params[_param]):
                 request[_param] = str(
                     FileDownloadable(**request[_param]).download(
-                        LOCAL_OUTPUT_FILE_DIRECTORY / tool.toolkit.slug / tool.slug
+                        self._outdir / tool.toolkit.slug / tool.slug
                     )
                 )
                 continue


### PR DESCRIPTION
downloadable path was not working correctly due to the directory not being passed to `FileDownloadable.download()`