### PR TITLE
fix(cli): fix type errors, add typecheck scripts

### DIFF
--- a/ts/packages/cli/package.json
+++ b/ts/packages/cli/package.json
@@ -26,14 +26,14 @@
     "cli": "bun run src/bin.ts",
     "build:bin": "bun run ./scripts/build-binary.ts",
     "install:bin": "bun run ./scripts/install-binary.ts ./dist/composio",
-    "prebuild": "bun run typecheck",
+    "prebuild": "pnpm run typecheck",
     "build": "tsup",
     "bin": "./dist/composio",
     "test": "vitest run",
-    "prepublishOnly": "bun run build && bun run build:bin",
+    "prepublishOnly": "pnpm run build && pnpm run build:bin",
     "typecheck:src": "tsc --noEmit -p ./tsconfig.src.json",
     "typecheck:test": "tsc --noEmit -p ./tsconfig.test.json",
-    "typecheck": "bun run typecheck:src && bun run typecheck:test"
+    "typecheck": "pnpm run typecheck:src && pnpm run typecheck:test"
   },
   "keywords": [
     "composio",

--- a/ts/packages/cli/package.json
+++ b/ts/packages/cli/package.json
@@ -26,10 +26,14 @@
     "cli": "bun run src/bin.ts",
     "build:bin": "bun run ./scripts/build-binary.ts",
     "install:bin": "bun run ./scripts/install-binary.ts ./dist/composio",
+    "prebuild": "bun run typecheck",
     "build": "tsup",
     "bin": "./dist/composio",
     "test": "vitest run",
-    "prepublishOnly": "pnpm build && pnpm build:bin"
+    "prepublishOnly": "bun run build && bun run build:bin",
+    "typecheck:src": "tsc --noEmit -p ./tsconfig.src.json",
+    "typecheck:test": "tsc --noEmit -p ./tsconfig.test.json",
+    "typecheck": "bun run typecheck:src && bun run typecheck:test"
   },
   "keywords": [
     "composio",

--- a/ts/packages/cli/src/generation/typescript/generate-index-source.ts
+++ b/ts/packages/cli/src/generation/typescript/generate-index-source.ts
@@ -29,7 +29,7 @@ import type { ToolkitIndex } from 'src/generation/create-toolkit-index';
 
 const BARREL_OBJECT_NAME = 'Toolkits';
 
-type GenerateTypeScriptIndexMapSourceParams = {
+export type GenerateTypeScriptIndexMapSourceParams = {
   banner: string;
   emitSingleFile: boolean;
   importExtension: 'ts' | 'js';

--- a/ts/packages/cli/test/src/generation/typescript/generate-index-source.test.ts
+++ b/ts/packages/cli/test/src/generation/typescript/generate-index-source.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { generateIndexSource } from 'src/generation/typescript/generate-index-source';
+import {
+  generateIndexSource,
+  type GenerateTypeScriptIndexMapSourceParams,
+} from 'src/generation/typescript/generate-index-source';
 import { createToolkitIndex } from 'src/generation/create-toolkit-index';
 import { makeTestToolkits } from 'test/__utils__/models/toolkits';
 import { assertTypeScriptIsValid } from 'test/__utils__/typescript-compiler';
@@ -7,9 +10,10 @@ import { assertTypeScriptIsValid } from 'test/__utils__/typescript-compiler';
 describe('generateTypeScriptToolkitSources', () => {
   describe('with a single emitted file', () => {
     const _params = {
-      outputDir: '<cwd>',
       emitSingleFile: true,
-    };
+      banner: '<BANNER>',
+      importExtension: 'ts' as const,
+    } satisfies GenerateTypeScriptIndexMapSourceParams;
 
     describe('with banner', () => {
       const params = {
@@ -151,8 +155,9 @@ describe('generateTypeScriptToolkitSources', () => {
 
   describe('with multiple emitted files', () => {
     const _params = {
-      outputDir: '<cwd>',
       emitSingleFile: false,
+      banner: '<BANNER>',
+      importExtension: 'ts' as const,
     };
 
     describe('with banner', () => {
@@ -223,7 +228,7 @@ describe('generateTypeScriptToolkitSources', () => {
            * Some banner that will appear in a comment
            */
 
-          import { SLACK } from "./slack.undefined"
+          import { SLACK } from "./slack.ts"
 
           /**
            * Map of Composio toolkits to actions.
@@ -277,8 +282,8 @@ describe('generateTypeScriptToolkitSources', () => {
            * Some banner that will appear in a comment
            */
 
-          import { GMAIL } from "./gmail.undefined"
-          import { SLACK } from "./slack.undefined"
+          import { GMAIL } from "./gmail.ts"
+          import { SLACK } from "./slack.ts"
 
           /**
            * Map of Composio toolkits to actions.

--- a/ts/packages/cli/test/src/generation/typescript/generate-toolkit-source.test.ts
+++ b/ts/packages/cli/test/src/generation/typescript/generate-toolkit-source.test.ts
@@ -5,16 +5,8 @@ import { makeTestToolkits } from 'test/__utils__/models/toolkits';
 
 describe('generateTypeScriptToolkitSources', () => {
   describe('with a single emitted file', () => {
-    const _params = {
-      outputDir: '<cwd>',
-      emitSingleFile: true,
-    };
-
     describe('with banner', () => {
-      const params = {
-        ..._params,
-        banner: 'Some banner that will appear in a comment',
-      };
+      const banner = 'Some banner that will appear in a comment';
 
       it('[Given] empty toolkits, tools, triggerTypes [Then] it returns an empty array', () => {
         const index = createToolkitIndex({
@@ -23,7 +15,7 @@ describe('generateTypeScriptToolkitSources', () => {
           triggerTypes: [],
         });
 
-        const sources = generateTypeScriptToolkitSources(params)(index);
+        const sources = generateTypeScriptToolkitSources(banner)(index);
 
         expect(sources).toEqual([]);
       });
@@ -42,7 +34,7 @@ describe('generateTypeScriptToolkitSources', () => {
           triggerTypes: [],
         });
 
-        const sources = generateTypeScriptToolkitSources(params)(index);
+        const sources = generateTypeScriptToolkitSources(banner)(index);
         expect(sources).toHaveLength(1);
         expect(sources[0]).toHaveLength(2);
         expect(sources[0][0]).toBe('slack.ts');
@@ -77,120 +69,7 @@ describe('generateTypeScriptToolkitSources', () => {
           triggerTypes: ['GMAIL_NEW_GMAIL_MESSAGE'],
         });
 
-        const sources = generateTypeScriptToolkitSources(params)(index);
-        expect(sources).toHaveLength(2);
-
-        expect(sources[0]).toHaveLength(2);
-        expect(sources[0][0]).toBe('gmail.ts');
-        expect(sources[0][1]).toMatchInlineSnapshot(`
-          "/**
-           * Map of Composio's GMAIL toolkit.
-           */
-          export const GMAIL = {
-            slug: "gmail",
-            tools: {
-              CREATE_EMAIL_DRAFT: "GMAIL_CREATE_EMAIL_DRAFT",
-              DELETE_MESSAGE: "GMAIL_DELETE_MESSAGE",
-              FETCH_EMAILS: "GMAIL_FETCH_EMAILS",
-            },
-            triggerTypes: {
-              NEW_GMAIL_MESSAGE: "GMAIL_NEW_GMAIL_MESSAGE",
-            },
-          }
-          "
-        `);
-
-        expect(sources[1]).toHaveLength(2);
-        expect(sources[1][0]).toBe('slack.ts');
-        expect(sources[1][1]).toMatchInlineSnapshot(`
-          "/**
-           * Map of Composio's SLACK toolkit.
-           */
-          export const SLACK = {
-            slug: "slack",
-            tools: {},
-            triggerTypes: {},
-          }
-          "
-        `);
-      });
-    });
-  });
-
-  describe('with multiple emitted files', () => {
-    const _params = {
-      outputDir: '<cwd>',
-      emitSingleFile: false,
-    };
-
-    describe('with banner', () => {
-      const params = {
-        ..._params,
-        banner: 'Some banner that will appear in a comment',
-      };
-
-      it('[Given] empty toolkits, tools, triggerTypes [Then] it returns an empty array', () => {
-        const index = createToolkitIndex({
-          toolkits: [],
-          tools: [],
-          triggerTypes: [],
-        });
-
-        const sources = generateTypeScriptToolkitSources(params)(index);
-
-        expect(sources).toEqual([]);
-      });
-
-      it('[Given] a single toolkit with no tools or triggerTypes [Then] it returns a single toolkit source file', () => {
-        const toolkits = makeTestToolkits([
-          {
-            name: 'Slack Helper',
-            slug: 'slack',
-          },
-        ]);
-
-        const index = createToolkitIndex({
-          toolkits,
-          tools: [],
-          triggerTypes: [],
-        });
-
-        const sources = generateTypeScriptToolkitSources(params)(index);
-        expect(sources).toHaveLength(1);
-        expect(sources[0]).toHaveLength(2);
-        expect(sources[0][0]).toBe('slack.ts');
-        expect(sources[0][1]).toMatchInlineSnapshot(`
-          "/**
-           * Map of Composio's SLACK toolkit.
-           */
-          export const SLACK = {
-            slug: "slack",
-            tools: {},
-            triggerTypes: {},
-          }
-          "
-        `);
-      });
-
-      it('[Given] toolkits with tools and triggerTypes [Then] it returns a TypeScript source file for each toolkit + the index map', () => {
-        const toolkits = makeTestToolkits([
-          {
-            name: 'Gmail',
-            slug: 'gmail',
-          },
-          {
-            name: 'Slack Helper',
-            slug: 'slack',
-          },
-        ]);
-
-        const index = createToolkitIndex({
-          toolkits,
-          tools: ['GMAIL_CREATE_EMAIL_DRAFT', 'GMAIL_DELETE_MESSAGE', 'GMAIL_FETCH_EMAILS'],
-          triggerTypes: ['GMAIL_NEW_GMAIL_MESSAGE'],
-        });
-
-        const sources = generateTypeScriptToolkitSources(params)(index);
+        const sources = generateTypeScriptToolkitSources(banner)(index);
         expect(sources).toHaveLength(2);
 
         expect(sources[0]).toHaveLength(2);

--- a/ts/packages/cli/tsconfig.json
+++ b/ts/packages/cli/tsconfig.json
@@ -10,5 +10,5 @@
     },
     "types": ["@types/bun", "vitest/importMeta"]
   },
-  "include": ["src", "test", "scripts"]
+  "include": ["src/**/*", "test/**/*", "scripts/**/*", "package.json"]
 }

--- a/ts/packages/cli/tsconfig.options.json
+++ b/ts/packages/cli/tsconfig.options.json
@@ -11,7 +11,6 @@
     "moduleResolution": "node",
     "skipLibCheck": true,
     "resolveJsonModule": true,
-    "verbatimModuleSyntax": true,
     "pretty": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
@@ -23,6 +22,5 @@
       }
     ]
   },
-  "include": ["src"],
-  "exclude": ["**/dist", "test/__fixtures__/**"]
+  "exclude": ["node_modules", "**/dist"]
 }

--- a/ts/packages/cli/tsconfig.src.json
+++ b/ts/packages/cli/tsconfig.src.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "./tsconfig.options.json",
+  "references": [
+    {
+      "path": "../core"
+    }
+  ],
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": ".",
@@ -9,5 +14,6 @@
     },
     "types": ["@types/bun"]
   },
-  "include": ["src"]
+  "include": ["src/**/*", "package.json"],
+  "exclude": ["node_modules", "../../../node_modules", "**/dist", "test/__fixtures__/**"]
 }

--- a/ts/packages/cli/tsconfig.test.json
+++ b/ts/packages/cli/tsconfig.test.json
@@ -1,12 +1,19 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "./tsconfig.options.json",
+  "references": [
+    {
+      "path": "../core"
+    }
+  ],
   "compilerOptions": {
     "rootDir": ".",
     "paths": {
       "src/*": ["./src/*"],
       "test/*": ["./test/*"]
-    }
+    },
+    "types": ["@types/bun", "vitest/importMeta"]
   },
-  "include": ["test"]
+  "include": ["src/**/*", "test/**/*", "package.json"],
+  "exclude": ["node_modules", "../../../node_modules", "**/dist", "test/__fixtures__/**"]
 }

--- a/ts/packages/core/tsconfig.build.json
+++ b/ts/packages/core/tsconfig.build.json
@@ -1,0 +1,7 @@
+// https://github.com/egoist/tsup/issues/571#issuecomment-1760052931
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false
+  }
+}

--- a/ts/packages/core/tsconfig.json
+++ b/ts/packages/core/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "composite": true,
     "target": "ESNext",
     "module": "ESNext",
     "declaration": true,
@@ -11,5 +12,5 @@
     "skipLibCheck": true,
     "resolveJsonModule": true
   },
-  "include": ["src"]
+  "include": ["src/**/*.ts"]
 }

--- a/ts/packages/core/tsup.config.ts
+++ b/ts/packages/core/tsup.config.ts
@@ -7,4 +7,5 @@ export default defineConfig({
   clean: true,
   minify: false,
   outDir: 'dist',
+  tsconfig: './tsconfig.build.json',
 });


### PR DESCRIPTION
This PR:
- fixes existing type errors in tests
- adds `typecheck`, `typecheck:src`, `typecheck:test` tests
  - this required introducing `composite: true` in `@composio/core`'s `tsconfig.json` file
  - ...which in turn required a workaround due to a bug in `tsup`'s internals: https://github.com/egoist/tsup/issues/571#issuecomment-1760052931