### PR TITLE
chore(turbo): add dependency for llms build task in turbo.json

### DIFF
--- a/fern/turbo.json
+++ b/fern/turbo.json
@@ -3,8 +3,8 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "dependsOn": ["api:pull", "add-og", "snippets:build", "tools:generate", "sdkdocs", "llms:build"],
-      "outputs": ["apis/openapi.yml", "apis/openapi-mcp.json", "pages/dist/**", "tools/**", "llms-txt/public/llms.txt"],
+      "dependsOn": ["api:pull", "add-og", "snippets:build", "tools:generate", "sdkdocs"],
+      "outputs": ["apis/openapi.yml", "apis/openapi-mcp.json", "pages/dist/**", "tools/**"],
       "cache": true
     },
     
@@ -80,6 +80,7 @@
     },
     
     "llms:build": {
+      "dependsOn": ["build"],
       "outputs": ["llms-txt/public/llms.txt"],
       "inputs": ["docs.yml", "pages/**/*.mdx", "pages/**/*.md", "tools/**/*.mdx", "scripts/build-llms-txt.ts"],
       "cache": true


### PR DESCRIPTION
- Added "dependsOn" for the "llms:build" task to ensure it runs after the "build" task.