### PR TITLE
Add support for vercel AI SDK v5

### DIFF
--- a/.changeset/swift-tools-unite.md
+++ b/.changeset/swift-tools-unite.md
@@ -1,0 +1,5 @@
+---
+'@composio/vercel': minor
+---
+
+Add support for ai-sdk v5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,7 +116,7 @@ importers:
         version: 4.3.16(react@18.3.1)(zod@3.25.67)
       composio-core:
         specifier: ^0.5.39
-        version: 0.5.39(@ai-sdk/openai@2.0.10(zod@3.25.67))(@cloudflare/workers-types@4.20250619.0)(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(@langchain/openai@0.5.13(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(ws@8.18.2))(ai@4.3.16(react@18.3.1)(zod@3.25.67))(langchain@0.3.28(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(axios@1.10.0)(openai@4.104.0(ws@8.18.2)(zod@3.25.67))(ws@8.18.2))(openai@4.104.0(ws@8.18.2)(zod@3.25.67))
+        version: 0.5.39(@ai-sdk/openai@2.0.16(zod@3.25.67))(@cloudflare/workers-types@4.20250619.0)(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(@langchain/openai@0.5.13(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(ws@8.18.2))(ai@4.3.16(react@18.3.1)(zod@3.25.67))(langchain@0.3.28(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(axios@1.10.0)(openai@4.104.0(ws@8.18.2)(zod@3.25.67))(ws@8.18.2))(openai@4.104.0(ws@8.18.2)(zod@3.25.67))
       hono:
         specifier: ^4.7.11
         version: 4.8.0
@@ -502,8 +502,8 @@ importers:
   ts/examples/vercel:
     dependencies:
       '@ai-sdk/openai':
-        specifier: ^1.3.16
-        version: 1.3.22(zod@3.25.67)
+        specifier: ^2.0.16
+        version: 2.0.16(zod@3.25.67)
       '@composio/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -511,8 +511,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/providers/vercel
       ai:
-        specifier: ^4.3.8
-        version: 4.3.16(react@18.3.1)(zod@3.25.67)
+        specifier: ^5.0.16
+        version: 5.0.16(zod@3.25.67)
       dotenv:
         specifier: ^16.5.0
         version: 16.5.0
@@ -823,14 +823,13 @@ importers:
         version: 3.2.4(@types/node@24.0.3)(@vitest/ui@3.2.4)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.0)
 
   ts/packages/providers/vercel:
-    dependencies:
-      ai:
-        specifier: ^4.3.8
-        version: 4.3.16(react@18.3.1)(zod@3.25.67)
     devDependencies:
       '@composio/core':
         specifier: workspace:*
         version: link:../../core
+      ai:
+        specifier: ^5.0.16
+        version: 5.0.16(zod@3.25.67)
       tsup:
         specifier: ^8.4.0
         version: 8.5.0(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
@@ -872,14 +871,20 @@ packages:
     peerDependencies:
       zod: ^3.0.0
 
+  '@ai-sdk/gateway@1.0.8':
+    resolution: {integrity: sha512-yiHYz0bAHEvhL+fSUBI2dNmyj0LOI8zw5qrYpa4gp1ojPgZq/7T1WXoIWRmVdjQwvT4PzSmRKLtbMPfz+umgfw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4
+
   '@ai-sdk/openai@1.3.22':
     resolution: {integrity: sha512-QwA+2EkG0QyjVR+7h6FE7iOu2ivNqAVMm9UJZkVxxTk5OIq5fFJDTEI/zICEMuHImTTXR2JjsL6EirJ28Jc4cw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.0.0
 
-  '@ai-sdk/openai@2.0.10':
-    resolution: {integrity: sha512-vnB6Jk2Qb245fajaWjG3q6N0QQy/uej7kZ0QR9xxq09x++3Tx/UPOcgAKMhFFA2fnuGpkFSRKoiDCyp/E3RARQ==}
+  '@ai-sdk/openai@2.0.16':
+    resolution: {integrity: sha512-Boe715q4SkSJedFfAtbP0yuo8DmF9iYElAaDH2g4YgqJqqkskIJJx4hlCYGMMk1eMesRrB2NqZvtOeyTZ/u4fA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4
@@ -890,8 +895,8 @@ packages:
     peerDependencies:
       zod: ^3.23.8
 
-  '@ai-sdk/provider-utils@3.0.1':
-    resolution: {integrity: sha512-/iP1sKc6UdJgGH98OCly7sWJKv+J9G47PnTjIj40IJMUQKwDrUMyf7zOOfRtPwSuNifYhSoJQ4s1WltI65gJ/g==}
+  '@ai-sdk/provider-utils@3.0.4':
+    resolution: {integrity: sha512-/3Z6lfUp8r+ewFd9yzHkCmPlMOJUXup2Sx3aoUyrdXLhOmAfHRl6Z4lDbIdV0uvw/QYoBcVLJnvXN7ncYeS3uQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4
@@ -3963,6 +3968,12 @@ packages:
     peerDependenciesMeta:
       react:
         optional: true
+
+  ai@5.0.16:
+    resolution: {integrity: sha512-shrrGo0i1cd3y8+/W9KpnRexqUpOgQ6Qj0yccKr4fQz4lMP6yKejNxAkOyaUYOqkM0OYovAYa6kyNxzZNdEUOw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4
 
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
@@ -7145,16 +7156,22 @@ snapshots:
       '@ai-sdk/provider-utils': 2.2.8(zod@3.25.67)
       zod: 3.25.67
 
+  '@ai-sdk/gateway@1.0.8(zod@3.25.67)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@ai-sdk/provider-utils': 3.0.4(zod@3.25.67)
+      zod: 3.25.67
+
   '@ai-sdk/openai@1.3.22(zod@3.25.67)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
       '@ai-sdk/provider-utils': 2.2.8(zod@3.25.67)
       zod: 3.25.67
 
-  '@ai-sdk/openai@2.0.10(zod@3.25.67)':
+  '@ai-sdk/openai@2.0.16(zod@3.25.67)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.1(zod@3.25.67)
+      '@ai-sdk/provider-utils': 3.0.4(zod@3.25.67)
       zod: 3.25.67
 
   '@ai-sdk/provider-utils@2.2.8(zod@3.25.67)':
@@ -7164,7 +7181,7 @@ snapshots:
       secure-json-parse: 2.7.0
       zod: 3.25.67
 
-  '@ai-sdk/provider-utils@3.0.1(zod@3.25.67)':
+  '@ai-sdk/provider-utils@3.0.4(zod@3.25.67)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
       '@standard-schema/spec': 1.0.0
@@ -8013,7 +8030,7 @@ snapshots:
     dependencies:
       '@effect/experimental': 0.49.2(@effect/platform@0.85.2(effect@3.16.16))(effect@3.16.16)
       '@effect/platform': 0.85.2(effect@3.16.16)
-      '@opentelemetry/semantic-conventions': 1.34.0
+      '@opentelemetry/semantic-conventions': 1.36.0
       effect: 3.16.16
       uuid: 11.1.0
 
@@ -11200,6 +11217,14 @@ snapshots:
     optionalDependencies:
       react: 18.3.1
 
+  ai@5.0.16(zod@3.25.67):
+    dependencies:
+      '@ai-sdk/gateway': 1.0.8(zod@3.25.67)
+      '@ai-sdk/provider': 2.0.0
+      '@ai-sdk/provider-utils': 3.0.4(zod@3.25.67)
+      '@opentelemetry/api': 1.9.0
+      zod: 3.25.67
+
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -11537,9 +11562,9 @@ snapshots:
       has-own-prop: 2.0.0
       repeat-string: 1.6.1
 
-  composio-core@0.5.39(@ai-sdk/openai@2.0.10(zod@3.25.67))(@cloudflare/workers-types@4.20250619.0)(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(@langchain/openai@0.5.13(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(ws@8.18.2))(ai@4.3.16(react@18.3.1)(zod@3.25.67))(langchain@0.3.28(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(axios@1.10.0)(openai@4.104.0(ws@8.18.2)(zod@3.25.67))(ws@8.18.2))(openai@4.104.0(ws@8.18.2)(zod@3.25.67)):
+  composio-core@0.5.39(@ai-sdk/openai@2.0.16(zod@3.25.67))(@cloudflare/workers-types@4.20250619.0)(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(@langchain/openai@0.5.13(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(ws@8.18.2))(ai@4.3.16(react@18.3.1)(zod@3.25.67))(langchain@0.3.28(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(axios@1.10.0)(openai@4.104.0(ws@8.18.2)(zod@3.25.67))(ws@8.18.2))(openai@4.104.0(ws@8.18.2)(zod@3.25.67)):
     dependencies:
-      '@ai-sdk/openai': 2.0.10(zod@3.25.67)
+      '@ai-sdk/openai': 2.0.16(zod@3.25.67)
       '@cloudflare/workers-types': 4.20250619.0
       '@composio/mcp': 1.0.3-0
       '@hey-api/client-axios': 0.2.12(axios@1.10.0)

--- a/ts/examples/vercel/package.json
+++ b/ts/examples/vercel/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "clean": "git clean -xdf node_modules",
     "start": "bun src/index.ts",
+    "start:stream": "bun src/stream.ts",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],
@@ -14,10 +15,10 @@
   "license": "ISC",
   "packageManager": "pnpm@10.8.0",
   "dependencies": {
-    "@ai-sdk/openai": "^1.3.16",
+    "@ai-sdk/openai": "^2.0.16",
     "@composio/core": "workspace:*",
     "@composio/vercel": "workspace:*",
-    "ai": "^4.3.8",
+    "ai": "^5.0.16",
     "dotenv": "^16.5.0"
   },
   "devDependencies": {

--- a/ts/packages/providers/vercel/package.json
+++ b/ts/packages/providers/vercel/package.json
@@ -31,13 +31,14 @@
   "packageManager": "pnpm@10.8.0",
   "peerDependencies": {
     "@composio/core": "0.1.44",
-    "ai": "^4.3.8"
+    "ai": "^5.0.16"
   },
   "devDependencies": {
     "@composio/core": "workspace:*",
     "tsup": "^8.4.0",
     "typescript": "^5.8.3",
-    "vitest": "^3.1.4"
+    "vitest": "^3.1.4",
+    "ai": "^5.0.16"
   },
   "gitHead": "4fae6e54d5c150fba955cc5fa314281da5a1e064"
 }

--- a/ts/packages/providers/vercel/src/index.ts
+++ b/ts/packages/providers/vercel/src/index.ts
@@ -20,7 +20,7 @@ import {
   jsonSchemaToZodSchema,
 } from '@composio/core';
 import type { Tool as VercelTool } from 'ai';
-import { jsonSchema, tool } from 'ai';
+import { tool } from 'ai';
 
 export type VercelToolCollection = Record<string, VercelTool>;
 export class VercelProvider extends BaseAgenticProvider<VercelToolCollection, VercelTool> {

--- a/ts/packages/providers/vercel/src/index.ts
+++ b/ts/packages/providers/vercel/src/index.ts
@@ -17,6 +17,7 @@ import {
   McpUrlResponse,
   McpServerGetResponse,
   removeNonRequiredProperties,
+  jsonSchemaToZodSchema,
 } from '@composio/core';
 import type { Tool as VercelTool } from 'ai';
 import { jsonSchema, tool } from 'ai';
@@ -114,9 +115,11 @@ export class VercelProvider extends BaseAgenticProvider<VercelToolCollection, Ve
           )
         : (inputParams ?? {});
 
+    const inputParametersSchema = jsonSchemaToZodSchema(parameters);
+
     return tool({
       description: composioTool.description,
-      parameters: jsonSchema(parameters),
+      inputSchema: inputParametersSchema,
       execute: async params => {
         const input = typeof params === 'string' ? JSON.parse(params) : params;
         return await executeTool(composioTool.slug, input);

--- a/ts/packages/providers/vercel/test/vercel.test.ts
+++ b/ts/packages/providers/vercel/test/vercel.test.ts
@@ -6,7 +6,7 @@ import { jsonSchema, tool } from 'ai';
 // Define an interface for our mocked Vercel tool
 interface MockedVercelTool {
   description: string;
-  parameters: any;
+  inputSchema: any;
   execute: Function;
   _isMockedVercelTool: boolean;
 }
@@ -80,11 +80,11 @@ describe('VercelProvider', () => {
 
       expect(tool).toHaveBeenCalledWith({
         description: mockTool.description,
-        parameters: mockTool.inputParameters,
+        inputSchema: expect.any(Object), // Now it's a Zod schema object
         execute: expect.any(Function),
       });
 
-      expect(jsonSchema).toHaveBeenCalledWith(mockTool.inputParameters);
+      // jsonSchema is no longer called since we use Zod schemas directly
       expect(wrapped._isMockedVercelTool).toBe(true);
     });
 
@@ -99,7 +99,12 @@ describe('VercelProvider', () => {
         mockExecuteToolFn
       ) as unknown as MockedVercelTool;
 
-      expect(jsonSchema).toHaveBeenCalledWith({});
+      // Verify that tool was called with an empty object converted to Zod schema
+      expect(tool).toHaveBeenCalledWith({
+        description: toolWithoutParams.description,
+        inputSchema: expect.any(Object), // Should be a Zod schema for empty object
+        execute: expect.any(Function),
+      });
       expect(wrapped._isMockedVercelTool).toBe(true);
     });
 
@@ -144,12 +149,12 @@ describe('VercelProvider', () => {
       expect(tool).toHaveBeenCalledTimes(2);
       expect(tool).toHaveBeenCalledWith({
         description: mockTool.description,
-        parameters: mockTool.inputParameters,
+        inputSchema: expect.any(Object), // Now it's a Zod schema object
         execute: expect.any(Function),
       });
       expect(tool).toHaveBeenCalledWith({
         description: anotherTool.description,
-        parameters: anotherTool.inputParameters,
+        inputSchema: expect.any(Object), // Now it's a Zod schema object
         execute: expect.any(Function),
       });
     });
@@ -203,7 +208,7 @@ describe('VercelProvider', () => {
 
       // Verify the wrapped tool has the expected structure
       expect(wrapped).toHaveProperty('description');
-      expect(wrapped).toHaveProperty('parameters');
+      expect(wrapped).toHaveProperty('inputSchema'); // Changed from 'parameters' to 'inputSchema'
       expect(wrapped).toHaveProperty('execute');
 
       // The tool should be compatible with Vercel AI SDK's expected structure

--- a/ts/packages/providers/vercel/test/vercel.test.ts
+++ b/ts/packages/providers/vercel/test/vercel.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { VercelProvider } from '../src';
 import { Tool } from '@composio/core';
-import { jsonSchema, tool } from 'ai';
+import { tool } from 'ai';
 
 // Define an interface for our mocked Vercel tool
 interface MockedVercelTool {


### PR DESCRIPTION
- Bumps package versions of AI SDK from v4 to v5 in vercel provider
- Uses zod schemas instead of json schemas in vercel provider
- Bumps the sdk version