### PR TITLE
chore: update changelog and bump to 0.8.11

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the Composio Python SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.11] - 2025-09-10
+
+### Added
+- **Composio Connect Link Support**: New link() method for creating external authentication links
+  - Added `link()` method to ConnectedAccounts class for generating user authentication links
+  - Support for callback URL redirection after authentication
+  - Enhanced user experience with external link-based authentication flow
+  - Includes comprehensive documentation and usage examples
+
+### Fixed
+- **Documentation**: Fixed typo in connected account creation function docstring
+  - Corrected "coneected" to "connected" in function documentation
+
 ## [0.8.10] - 2024-12-19
 
 ### Added

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio"
-version = "0.8.10"
+version = "0.8.11"
 description = "SDK for integrating Composio with your applications."
 readme = "README.md"
 requires-python = ">=3.10,<4"

--- a/uv.lock
+++ b/uv.lock
@@ -468,7 +468,7 @@ wheels = [
 
 [[package]]
 name = "composio"
-version = "0.8.10"
+version = "0.8.11"
 source = { virtual = "python" }
 dependencies = [
     { name = "composio-client" },


### PR DESCRIPTION
Add the auth link feature to the Python SDK. 

The previous release was a no-op since the versions weren't updated. Still getting the hang of the process and will keep a checklist for the future.