### PR TITLE
feat(core): experimental `mcp`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,7 +92,7 @@ importers:
         version: link:../ts/packages/providers/vercel
       '@langchain/langgraph':
         specifier: ^0.2.72
-        version: 0.2.74(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(react@18.3.1)(zod-to-json-schema@3.24.5(zod@3.25.67))
+        version: 0.2.74(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(react@18.3.1)(zod-to-json-schema@3.24.6(zod@3.25.67))
       '@langchain/openai':
         specifier: ^0.5.10
         version: 0.5.13(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(ws@8.18.2)
@@ -116,7 +116,7 @@ importers:
         version: 4.3.16(react@18.3.1)(zod@3.25.67)
       composio-core:
         specifier: ^0.5.39
-        version: 0.5.39(@ai-sdk/openai@2.0.16(zod@3.25.67))(@cloudflare/workers-types@4.20250619.0)(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(@langchain/openai@0.5.13(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(ws@8.18.2))(ai@4.3.16(react@18.3.1)(zod@3.25.67))(langchain@0.3.28(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(axios@1.10.0)(openai@4.104.0(ws@8.18.2)(zod@3.25.67))(ws@8.18.2))(openai@4.104.0(ws@8.18.2)(zod@3.25.67))
+        version: 0.5.39(@ai-sdk/openai@2.0.28(zod@3.25.67))(@cloudflare/workers-types@4.20250619.0)(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(@langchain/openai@0.5.13(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(ws@8.18.2))(ai@4.3.16(react@18.3.1)(zod@3.25.67))(langchain@0.3.28(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(axios@1.10.0)(openai@4.104.0(ws@8.18.2)(zod@3.25.67))(ws@8.18.2))(openai@4.104.0(ws@8.18.2)(zod@3.25.67))
       hono:
         specifier: ^4.7.11
         version: 4.8.0
@@ -175,14 +175,20 @@ importers:
   ts/examples/anthropic:
     dependencies:
       '@anthropic-ai/sdk':
-        specifier: ^0.52.0
-        version: 0.52.0
+        specifier: ^0.62.0
+        version: 0.62.0
       '@composio/anthropic':
         specifier: workspace:*
         version: link:../../packages/providers/anthropic
       '@composio/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@composio/mastra':
+        specifier: workspace:^
+        version: link:../../packages/providers/mastra
+      '@mastra/mcp':
+        specifier: ^0.10.3
+        version: 0.10.4(@mastra/core@0.16.3(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@4.1.8))(zod@4.1.8)
       dotenv:
         specifier: ^16.4.1
         version: 16.5.0
@@ -295,8 +301,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/providers/google
       '@google/genai':
-        specifier: ^1.1.0
-        version: 1.5.1(@modelcontextprotocol/sdk@1.17.4)
+        specifier: ^1.19.0
+        version: 1.19.0(@modelcontextprotocol/sdk@1.18.0)
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.18.0
+        version: 1.18.0
       dotenv:
         specifier: ^16.4.1
         version: 16.5.0
@@ -321,7 +330,7 @@ importers:
         version: 16.5.0
       zod-to-json-schema:
         specifier: ^3.24.5
-        version: 3.24.5(zod@3.25.67)
+        version: 3.24.5(zod@4.1.8)
     devDependencies:
       '@types/bun':
         specifier: ^1.2.9
@@ -343,7 +352,7 @@ importers:
         version: 0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67))
       '@langchain/langgraph':
         specifier: ^0.3.8
-        version: 0.3.8(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(react-dom@19.1.0(react@18.3.1))(react@18.3.1)(zod-to-json-schema@3.24.5(zod@3.25.67))
+        version: 0.3.8(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(react-dom@19.1.0(react@18.3.1))(react@18.3.1)(zod-to-json-schema@3.24.6(zod@3.25.67))
       '@langchain/openai':
         specifier: ^0.6.1
         version: 0.6.1(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(ws@8.18.2)
@@ -365,7 +374,7 @@ importers:
     dependencies:
       '@ai-sdk/openai':
         specifier: ^1.3.16
-        version: 1.3.22(zod@3.25.67)
+        version: 1.3.22(zod@4.1.8)
       '@composio/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -373,14 +382,17 @@ importers:
         specifier: workspace:^
         version: link:../../packages/providers/mastra
       '@mastra/core':
-        specifier: ^0.10.0
-        version: 0.10.6(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@3.25.67)
+        specifier: ^0.16.3
+        version: 0.16.3(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@4.1.8)
       '@mastra/mcp':
-        specifier: ^0.10.3
-        version: 0.10.4(@mastra/core@0.10.6(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@3.25.67))(zod@3.25.67)
+        specifier: ^0.12.0
+        version: 0.12.0(@mastra/core@0.16.3(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@4.1.8))(@types/json-schema@7.0.15)(zod@4.1.8)
       dotenv:
         specifier: ^16.4.1
         version: 16.5.0
+      uuid:
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@types/bun':
         specifier: ^1.2.9
@@ -393,7 +405,7 @@ importers:
     dependencies:
       '@ai-sdk/openai':
         specifier: ^1.3.16
-        version: 1.3.22(zod@3.25.67)
+        version: 1.3.22(zod@4.1.8)
       '@composio/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -402,7 +414,7 @@ importers:
         version: link:../../packages/providers/vercel
       ai:
         specifier: ^4.3.8
-        version: 4.3.16(react@18.3.1)(zod@3.25.67)
+        version: 4.3.16(react@18.3.1)(zod@4.1.8)
     devDependencies:
       '@types/bun':
         specifier: ^1.2.9
@@ -413,6 +425,9 @@ importers:
 
   ts/examples/openai:
     dependencies:
+      '@ai-sdk/openai':
+        specifier: ^2.0.28
+        version: 2.0.28(zod@3.25.67)
       '@composio/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -422,12 +437,24 @@ importers:
       '@composio/openai-agents':
         specifier: workspace:*
         version: link:../../packages/providers/openai-agents
+      '@mastra/core':
+        specifier: ^0.10.0
+        version: 0.10.6(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@3.25.67)
+      '@mastra/mcp':
+        specifier: ^0.10.3
+        version: 0.10.4(@mastra/core@0.10.6(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@3.25.67))(zod@3.25.67)
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.18.0
+        version: 1.18.0
       '@openai/agents':
         specifier: ^0.1.1
         version: 0.1.1(ws@8.18.2)(zod@3.25.67)
       dotenv:
         specifier: ^16.4.1
         version: 16.5.0
+      exit-hook:
+        specifier: ^4.0.0
+        version: 4.0.0
       openai:
         specifier: ^5.16.0
         version: 5.16.0(ws@8.18.2)(zod@3.25.67)
@@ -441,6 +468,9 @@ importers:
       '@types/bun':
         specifier: ^1.2.9
         version: 1.2.16
+      '@types/exit-hook':
+        specifier: ^2.2.3
+        version: 2.2.3
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -465,7 +495,7 @@ importers:
     dependencies:
       '@ai-sdk/openai':
         specifier: ^1.3.16
-        version: 1.3.22(zod@3.25.67)
+        version: 1.3.22(zod@4.1.8)
       '@composio/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -474,7 +504,7 @@ importers:
         version: link:../../packages/providers/vercel
       ai:
         specifier: ^4.3.8
-        version: 4.3.16(react@18.3.1)(zod@3.25.67)
+        version: 4.3.16(react@18.3.1)(zod@4.1.8)
     devDependencies:
       '@types/bun':
         specifier: ^1.2.9
@@ -493,10 +523,10 @@ importers:
         version: 16.5.0
       openai:
         specifier: ^5.19.1
-        version: 5.19.1(ws@8.18.2)(zod@3.25.67)
+        version: 5.19.1(ws@8.18.2)(zod@4.1.8)
       zod-to-json-schema:
         specifier: ^3.24.5
-        version: 3.24.5(zod@3.25.67)
+        version: 3.24.5(zod@4.1.8)
     devDependencies:
       '@types/bun':
         specifier: ^1.2.9
@@ -525,16 +555,19 @@ importers:
     dependencies:
       '@ai-sdk/openai':
         specifier: ^2.0.16
-        version: 2.0.16(zod@3.25.67)
+        version: 2.0.16(zod@4.1.8)
       '@composio/core':
         specifier: workspace:*
         version: link:../../packages/core
       '@composio/vercel':
         specifier: workspace:*
         version: link:../../packages/providers/vercel
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.18.0
+        version: 1.18.0
       ai:
-        specifier: ^5.0.16
-        version: 5.0.16(zod@3.25.67)
+        specifier: ^5.0.44
+        version: 5.0.44(zod@4.1.8)
       dotenv:
         specifier: ^16.5.0
         version: 16.5.0
@@ -722,6 +755,9 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.52.0
         version: 0.52.0
+      '@mastra/mcp':
+        specifier: ^0.12.0
+        version: 0.12.0(@mastra/core@0.16.3(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@4.1.8))(@types/json-schema@7.0.15)(zod@4.1.8)
     devDependencies:
       '@composio/core':
         specifier: workspace:*
@@ -759,7 +795,7 @@ importers:
     dependencies:
       '@google/genai':
         specifier: ^1.1.0
-        version: 1.5.1(@modelcontextprotocol/sdk@1.17.4)
+        version: 1.5.1(@modelcontextprotocol/sdk@1.18.0)
     devDependencies:
       '@composio/core':
         specifier: workspace:*
@@ -794,7 +830,10 @@ importers:
     dependencies:
       '@mastra/core':
         specifier: ^0.13.2
-        version: 0.13.2(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@3.25.67)
+        version: 0.13.2(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@4.1.8)
+      '@mastra/mcp':
+        specifier: ^0.12.0
+        version: 0.12.0(@mastra/core@0.13.2(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@4.1.8))(@types/json-schema@7.0.15)(zod@4.1.8)
     devDependencies:
       '@composio/core':
         specifier: workspace:*
@@ -832,7 +871,7 @@ importers:
     dependencies:
       '@openai/agents':
         specifier: ^0.1.1
-        version: 0.1.1(ws@8.18.2)(zod@3.25.67)
+        version: 0.1.1(ws@8.18.2)(zod@4.1.8)
     devDependencies:
       '@composio/core':
         specifier: workspace:*
@@ -853,8 +892,8 @@ importers:
         specifier: workspace:*
         version: link:../../core
       ai:
-        specifier: ^5.0.16
-        version: 5.0.16(zod@3.25.67)
+        specifier: ^5.0.44
+        version: 5.0.44(zod@4.1.8)
       tsup:
         specifier: ^8.4.0
         version: 8.5.0(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
@@ -896,8 +935,14 @@ packages:
     peerDependencies:
       zod: ^3.0.0
 
-  '@ai-sdk/gateway@1.0.8':
-    resolution: {integrity: sha512-yiHYz0bAHEvhL+fSUBI2dNmyj0LOI8zw5qrYpa4gp1ojPgZq/7T1WXoIWRmVdjQwvT4PzSmRKLtbMPfz+umgfw==}
+  '@ai-sdk/gateway@1.0.15':
+    resolution: {integrity: sha512-xySXoQ29+KbGuGfmDnABx+O6vc7Gj7qugmj1kGpn0rW0rQNn6UKUuvscKMzWyv1Uv05GyC1vqHq8ZhEOLfXscQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4
+
+  '@ai-sdk/gateway@1.0.23':
+    resolution: {integrity: sha512-ynV7WxpRK2zWLGkdOtrU2hW22mBVkEYVS3iMg1+ZGmAYSgzCqzC74bfOJZ2GU1UdcrFWUsFI9qAYjsPkd+AebA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4
@@ -914,6 +959,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4
 
+  '@ai-sdk/openai@2.0.28':
+    resolution: {integrity: sha512-Z2mG7PjUKbpT8fMexE6yrorxXVzGHSl3jKF293w2i6s9Dc6X81Gf6Z0OGNnkrftLtW4PXr7RZ/9xoyusBZW4uA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4
+
   '@ai-sdk/provider-utils@2.2.8':
     resolution: {integrity: sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==}
     engines: {node: '>=18'}
@@ -922,6 +973,30 @@ packages:
 
   '@ai-sdk/provider-utils@3.0.4':
     resolution: {integrity: sha512-/3Z6lfUp8r+ewFd9yzHkCmPlMOJUXup2Sx3aoUyrdXLhOmAfHRl6Z4lDbIdV0uvw/QYoBcVLJnvXN7ncYeS3uQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4
+
+  '@ai-sdk/provider-utils@3.0.5':
+    resolution: {integrity: sha512-HliwB/yzufw3iwczbFVE2Fiwf1XqROB/I6ng8EKUsPM5+2wnIa8f4VbljZcDx+grhFrPV+PnRZH7zBqi8WZM7Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4
+
+  '@ai-sdk/provider-utils@3.0.7':
+    resolution: {integrity: sha512-o3BS5/t8KnBL3ubP8k3w77AByOypLm+pkIL/DCw0qKkhDbvhCy+L3hRTGPikpdb8WHcylAeKsjgwOxhj4cqTUA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4
+
+  '@ai-sdk/provider-utils@3.0.8':
+    resolution: {integrity: sha512-cDj1iigu7MW2tgAQeBzOiLhjHOUM9vENsgh4oAVitek0d//WdgfPCsKO3euP7m7LyO/j9a1vr/So+BGNdpFXYw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4
+
+  '@ai-sdk/provider-utils@3.0.9':
+    resolution: {integrity: sha512-Pm571x5efqaI4hf9yW4KsVlDBDme8++UepZRnq+kqVBWWjgvGhQlzU8glaFq0YJEB9kkxZHbRRyVeHoV2sRYaQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4
@@ -958,9 +1033,19 @@ packages:
     resolution: {integrity: sha512-d4c+fg+xy9e46c8+YnrrgIQR45CZlAi7PwdzIfDXDM6ACxEZli1/fxhURsq30ZpMZy6LvSkr41jGq5aF5TD7rQ==}
     hasBin: true
 
+  '@anthropic-ai/sdk@0.62.0':
+    resolution: {integrity: sha512-gT2VFKX0gSp7KJNlav/vzRFjJOPYDZxCJRx7MYUc+fqURc5aS6OI/UJeD2KytJkjsIWv0OOwH1ePc1S5QE2GZw==}
+    hasBin: true
+
   '@apidevtools/json-schema-ref-parser@11.9.3':
     resolution: {integrity: sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==}
     engines: {node: '>= 16'}
+
+  '@apidevtools/json-schema-ref-parser@14.2.1':
+    resolution: {integrity: sha512-HmdFw9CDYqM6B25pqGBpNeLCKvGPlIx1EbLrVL0zPvj50CJQUHyBNBw45Muk0kEIkogo1VZvOKHajdMuAzSxRg==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@types/json-schema': ^7.0.15
 
   '@aws-crypto/crc32@3.0.0':
     resolution: {integrity: sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==}
@@ -1757,6 +1842,15 @@ packages:
   '@gerrit0/mini-shiki@3.6.0':
     resolution: {integrity: sha512-KaeJvPNofTEZR9EzVNp/GQzbQqkGfjiu6k3CXKvhVTX+8OoAKSX/k7qxLKOX3B0yh2XqVAc93rsOu48CGt2Qug==}
 
+  '@google/genai@1.19.0':
+    resolution: {integrity: sha512-mIMV3M/KfzzFA//0fziK472wKBJ1TdJLhozIUJKTPLyTDN1NotU+hyoHW/N0cfrcEWUK20YA0GxCeHC4z0SbMA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.11.4
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+
   '@google/genai@1.5.1':
     resolution: {integrity: sha512-9SKpNo5iqvB622lN3tSCbeuiLGTcStRd+3muOrI9pZMpzfLDc/xC7dWIJd5kK+4AZuY28nsvQmCZe0fPj3JUew==}
     engines: {node: '>=20.0.0'}
@@ -2212,11 +2306,23 @@ packages:
     peerDependencies:
       zod: ^3.0.0
 
+  '@mastra/core@0.16.3':
+    resolution: {integrity: sha512-9dg/39iPk5rADtyscYeYXnYOTnAc6pbeHRBHNqG0TcAlUnlw69Rvnw8ew5H0r0DTnxsoV0gY58sk0WnHAOXTpg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+
   '@mastra/mcp@0.10.4':
     resolution: {integrity: sha512-WAloGPK42TfKNvESpbLv6O6HaSPzbP9zlC/4dh+gHHys88/7oHYLU/9Wb8ME9dRsd8CrC0yJqBdfaIvtCvMI7A==}
     peerDependencies:
       '@mastra/core': ^0.10.2-alpha.0
       zod: ^3.0.0
+
+  '@mastra/mcp@0.12.0':
+    resolution: {integrity: sha512-KODbJ/ztABQrWeIRyDDYM031hMY91gOZZ42wiJQo9JbtX38nXlpcoVSz5Pqm+4WIIDMfz32gcT1V4ie8979C3Q==}
+    peerDependencies:
+      '@mastra/core': '>=0.16.1-0 <0.17.0-0'
+      zod: ^3.25.0 || ^4.0.0
 
   '@mastra/schema-compat@0.10.2':
     resolution: {integrity: sha512-QCPnD0Jd7NJgfVdvNkLPJhqSjyNcA+eaa16N+3kwa+wTBMb6eziWZC1aQNQ6o4T1JVPoo5unVVtL1pqiIgV+tA==}
@@ -2230,12 +2336,14 @@ packages:
       ai: ^4.0.0
       zod: ^3.0.0
 
-  '@modelcontextprotocol/sdk@1.13.0':
-    resolution: {integrity: sha512-P5FZsXU0kY881F6Hbk9GhsYx02/KgWK1DYf7/tyE/1lcFKhDYPQR9iYjhQXJn+Sg6hQleMo3DB7h7+p4wgp2Lw==}
-    engines: {node: '>=18'}
+  '@mastra/schema-compat@0.11.3':
+    resolution: {integrity: sha512-P50JETxpEFilgp3WIpSidr3Jt+JyZzIwzU9EoYZF+JyeTee/QLXVC4cMTCEU+Uj+4GVDV+L2g+qTHEVWcqxsSA==}
+    peerDependencies:
+      ai: ^4.0.0 || ^5.0.0
+      zod: ^3.25.0 || ^4.0.0
 
-  '@modelcontextprotocol/sdk@1.17.4':
-    resolution: {integrity: sha512-zq24hfuAmmlNZvik0FLI58uE5sriN0WWsQzIlYnzSuKDAHFqJtBFrl/LfB1NLgJT5Y7dEBzaX4yAKqOPrcetaw==}
+  '@modelcontextprotocol/sdk@1.18.0':
+    resolution: {integrity: sha512-JvKyB6YwS3quM+88JPR0axeRgvdDu3Pv6mdZUy+w4qVkCzGgumb9bXG/TmtDRQv+671yaofVfXSQmFLlWU5qPQ==}
     engines: {node: '>=18'}
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
@@ -3742,6 +3850,10 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/exit-hook@2.2.3':
+    resolution: {integrity: sha512-mOEr+zymjxJbhxKvVSQ6eZ8iml7aXSXrvghrnpgyGxIC0vb+//G5wUiHZykPWKy05vktUHNCO8sqcohUHdipow==}
+    deprecated: This is a stub types definition. exit-hook provides its own type definitions, so you do not need this installed.
+
   '@types/express-serve-static-core@4.19.6':
     resolution: {integrity: sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==}
 
@@ -4004,8 +4116,24 @@ packages:
       react:
         optional: true
 
-  ai@5.0.16:
-    resolution: {integrity: sha512-shrrGo0i1cd3y8+/W9KpnRexqUpOgQ6Qj0yccKr4fQz4lMP6yKejNxAkOyaUYOqkM0OYovAYa6kyNxzZNdEUOw==}
+  ai@4.3.19:
+    resolution: {integrity: sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      react:
+        optional: true
+
+  ai@5.0.28:
+    resolution: {integrity: sha512-tnybAqoDFzuK6O1NOMHX1d/wH7Eug8y0H4l/Gl6swi8BYGtlTPDjniKnGYzgTpLTdpj7SI3qjZuomz7evph9+w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4
+
+  ai@5.0.44:
+    resolution: {integrity: sha512-l/rdoM4LcRpsRBVvZQBwSU73oNoFGlWj+PcH86QRzxDGJgZqgGItWO0QcKjBNcLDmUjGN1VYd/8J0TAXHJleRQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4
@@ -4715,13 +4843,13 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
-  eventsource-parser@3.0.2:
-    resolution: {integrity: sha512-6RxOBZ/cYgd8usLwsEl+EC09Au/9BcmCKYF2/xbml6DNczf7nv0MQb+7BA2F+li6//I+28VNlQR37XfQtcAJuA==}
-    engines: {node: '>=18.0.0'}
-
   eventsource-parser@3.0.3:
     resolution: {integrity: sha512-nVpZkTMM9rF6AQ9gPJpFsNAMt48wIzB5TQgiTLdHiuO8XEDhUgZEhqKlZWXbIzo9VmJ/HvysHqEaVeD5v9TPvA==}
     engines: {node: '>=20.0.0'}
+
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
 
   eventsource@3.0.7:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
@@ -5116,6 +5244,10 @@ packages:
 
   hono@4.9.2:
     resolution: {integrity: sha512-UG2jXGS/gkLH42l/1uROnwXpkjvvxkl3kpopL3LBo27NuaDPI6xHNfuUSilIHcrBkPfl4y0z6y2ByI455TjNRw==}
+    engines: {node: '>=16.9.0'}
+
+  hono@4.9.7:
+    resolution: {integrity: sha512-t4Te6ERzIaC48W3x4hJmBwgNlLhmiEdEE5ViYb02ffw4ignHNHa5IBtPjmbKstmtKa8X6C35iWwK4HaqvrzG9w==}
     engines: {node: '>=16.9.0'}
 
   http-errors@2.0.0:
@@ -5880,6 +6012,10 @@ packages:
   p-map@2.1.0:
     resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
     engines: {node: '>=6'}
+
+  p-map@7.0.3:
+    resolution: {integrity: sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==}
+    engines: {node: '>=18'}
 
   p-queue@6.6.2:
     resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
@@ -7170,8 +7306,16 @@ packages:
   zod-from-json-schema@0.0.5:
     resolution: {integrity: sha512-zYEoo86M1qpA1Pq6329oSyHLS785z/mTwfr9V1Xf/ZLhuuBGaMlDGu/pDVGVUe4H4oa1EFgWZT53DP0U3oT9CQ==}
 
+  zod-from-json-schema@0.5.0:
+    resolution: {integrity: sha512-W1v1YIoimOJfvuorGGp1QroizLL3jEGELJtgrHiVg/ytxVZdh/BTTVyPypGB7YK30LHrCkkebbjuyHIjBGCEzw==}
+
   zod-to-json-schema@3.24.5:
     resolution: {integrity: sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==}
+    peerDependencies:
+      zod: ^3.24.1
+
+  zod-to-json-schema@3.24.6:
+    resolution: {integrity: sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==}
     peerDependencies:
       zod: ^3.24.1
 
@@ -7183,6 +7327,9 @@ packages:
 
   zod@3.25.67:
     resolution: {integrity: sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==}
+
+  zod@4.1.8:
+    resolution: {integrity: sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==}
 
 snapshots:
 
@@ -7203,22 +7350,34 @@ snapshots:
       '@ai-sdk/provider-utils': 2.2.8(zod@3.25.67)
       zod: 3.25.67
 
-  '@ai-sdk/gateway@1.0.8(zod@3.25.67)':
+  '@ai-sdk/gateway@1.0.15(zod@4.1.8)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.4(zod@3.25.67)
-      zod: 3.25.67
+      '@ai-sdk/provider-utils': 3.0.7(zod@4.1.8)
+      zod: 4.1.8
 
-  '@ai-sdk/openai@1.3.22(zod@3.25.67)':
+  '@ai-sdk/gateway@1.0.23(zod@4.1.8)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@ai-sdk/provider-utils': 3.0.9(zod@4.1.8)
+      zod: 4.1.8
+
+  '@ai-sdk/openai@1.3.22(zod@4.1.8)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.67)
-      zod: 3.25.67
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.1.8)
+      zod: 4.1.8
 
-  '@ai-sdk/openai@2.0.16(zod@3.25.67)':
+  '@ai-sdk/openai@2.0.16(zod@4.1.8)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.4(zod@3.25.67)
+      '@ai-sdk/provider-utils': 3.0.4(zod@4.1.8)
+      zod: 4.1.8
+
+  '@ai-sdk/openai@2.0.28(zod@3.25.67)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@ai-sdk/provider-utils': 3.0.8(zod@3.25.67)
       zod: 3.25.67
 
   '@ai-sdk/provider-utils@2.2.8(zod@3.25.67)':
@@ -7228,13 +7387,49 @@ snapshots:
       secure-json-parse: 2.7.0
       zod: 3.25.67
 
-  '@ai-sdk/provider-utils@3.0.4(zod@3.25.67)':
+  '@ai-sdk/provider-utils@2.2.8(zod@4.1.8)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      nanoid: 3.3.11
+      secure-json-parse: 2.7.0
+      zod: 4.1.8
+
+  '@ai-sdk/provider-utils@3.0.4(zod@4.1.8)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
       '@standard-schema/spec': 1.0.0
       eventsource-parser: 3.0.3
+      zod: 4.1.8
+      zod-to-json-schema: 3.24.5(zod@4.1.8)
+
+  '@ai-sdk/provider-utils@3.0.5(zod@4.1.8)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@standard-schema/spec': 1.0.0
+      eventsource-parser: 3.0.6
+      zod: 4.1.8
+      zod-to-json-schema: 3.24.6(zod@4.1.8)
+
+  '@ai-sdk/provider-utils@3.0.7(zod@4.1.8)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@standard-schema/spec': 1.0.0
+      eventsource-parser: 3.0.6
+      zod: 4.1.8
+
+  '@ai-sdk/provider-utils@3.0.8(zod@3.25.67)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@standard-schema/spec': 1.0.0
+      eventsource-parser: 3.0.6
       zod: 3.25.67
-      zod-to-json-schema: 3.24.5(zod@3.25.67)
+
+  '@ai-sdk/provider-utils@3.0.9(zod@4.1.8)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@standard-schema/spec': 1.0.0
+      eventsource-parser: 3.0.6
+      zod: 4.1.8
 
   '@ai-sdk/provider@1.1.3':
     dependencies:
@@ -7254,6 +7449,16 @@ snapshots:
     optionalDependencies:
       zod: 3.25.67
 
+  '@ai-sdk/react@1.2.12(react@18.3.1)(zod@4.1.8)':
+    dependencies:
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.1.8)
+      '@ai-sdk/ui-utils': 1.2.11(zod@4.1.8)
+      react: 18.3.1
+      swr: 2.3.3(react@18.3.1)
+      throttleit: 2.1.0
+    optionalDependencies:
+      zod: 4.1.8
+
   '@ai-sdk/ui-utils@1.2.11(zod@3.25.67)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
@@ -7261,13 +7466,27 @@ snapshots:
       zod: 3.25.67
       zod-to-json-schema: 3.24.5(zod@3.25.67)
 
+  '@ai-sdk/ui-utils@1.2.11(zod@4.1.8)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.1.8)
+      zod: 4.1.8
+      zod-to-json-schema: 3.24.5(zod@4.1.8)
+
   '@alloc/quick-lru@5.2.0': {}
 
   '@anthropic-ai/sdk@0.52.0': {}
 
+  '@anthropic-ai/sdk@0.62.0': {}
+
   '@apidevtools/json-schema-ref-parser@11.9.3':
     dependencies:
       '@jsdevtools/ono': 7.1.3
+      '@types/json-schema': 7.0.15
+      js-yaml: 4.1.0
+
+  '@apidevtools/json-schema-ref-parser@14.2.1(@types/json-schema@7.0.15)':
+    dependencies:
       '@types/json-schema': 7.0.15
       js-yaml: 4.1.0
 
@@ -8309,14 +8528,26 @@ snapshots:
       '@shikijs/types': 3.6.0
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@google/genai@1.5.1(@modelcontextprotocol/sdk@1.17.4)':
+  '@google/genai@1.19.0(@modelcontextprotocol/sdk@1.18.0)':
+    dependencies:
+      google-auth-library: 9.15.1
+      ws: 8.18.2
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.18.0
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@google/genai@1.5.1(@modelcontextprotocol/sdk@1.18.0)':
     dependencies:
       google-auth-library: 9.15.1
       ws: 8.18.2
       zod: 3.25.67
       zod-to-json-schema: 3.24.5(zod@3.25.67)
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.17.4
+      '@modelcontextprotocol/sdk': 1.18.0
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -8709,7 +8940,7 @@ snapshots:
       react: 18.3.1
       react-dom: 19.1.0(react@18.3.1)
 
-  '@langchain/langgraph@0.2.74(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(react@18.3.1)(zod-to-json-schema@3.24.5(zod@3.25.67))':
+  '@langchain/langgraph@0.2.74(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(react@18.3.1)(zod-to-json-schema@3.24.6(zod@3.25.67))':
     dependencies:
       '@langchain/core': 0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67))
       '@langchain/langgraph-checkpoint': 0.0.18(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))
@@ -8717,11 +8948,11 @@ snapshots:
       uuid: 10.0.0
       zod: 3.25.67
     optionalDependencies:
-      zod-to-json-schema: 3.24.5(zod@3.25.67)
+      zod-to-json-schema: 3.24.6(zod@3.25.67)
     transitivePeerDependencies:
       - react
 
-  '@langchain/langgraph@0.3.8(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(react-dom@19.1.0(react@18.3.1))(react@18.3.1)(zod-to-json-schema@3.24.5(zod@3.25.67))':
+  '@langchain/langgraph@0.3.8(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(react-dom@19.1.0(react@18.3.1))(react@18.3.1)(zod-to-json-schema@3.24.6(zod@3.25.67))':
     dependencies:
       '@langchain/core': 0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67))
       '@langchain/langgraph-checkpoint': 0.0.18(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))
@@ -8729,7 +8960,7 @@ snapshots:
       uuid: 10.0.0
       zod: 3.25.67
     optionalDependencies:
-      zod-to-json-schema: 3.24.5(zod@3.25.67)
+      zod-to-json-schema: 3.24.6(zod@3.25.67)
     transitivePeerDependencies:
       - react
       - react-dom
@@ -8826,13 +9057,13 @@ snapshots:
       - valibot
       - zod-openapi
 
-  '@mastra/core@0.13.2(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@3.25.67)':
+  '@mastra/core@0.13.2(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@4.1.8)':
     dependencies:
       '@a2a-js/sdk': 0.2.5
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.67)
-      '@ai-sdk/ui-utils': 1.2.11(zod@3.25.67)
-      '@mastra/schema-compat': 0.10.7(ai@4.3.16(react@18.3.1)(zod@3.25.67))(zod@3.25.67)
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.1.8)
+      '@ai-sdk/ui-utils': 1.2.11(zod@4.1.8)
+      '@mastra/schema-compat': 0.10.7(ai@4.3.19(react@18.3.1)(zod@4.1.8))(zod@4.1.8)
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/auto-instrumentations-node': 0.62.1(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.0.1(@opentelemetry/api@1.9.0))
       '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
@@ -8847,11 +9078,11 @@ snapshots:
       '@opentelemetry/sdk-trace-node': 2.0.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.36.0
       '@sindresorhus/slugify': 2.2.1
-      ai: 4.3.16(react@18.3.1)(zod@3.25.67)
+      ai: 4.3.19(react@18.3.1)(zod@4.1.8)
       date-fns: 3.6.0
       dotenv: 16.6.1
-      hono: 4.9.2
-      hono-openapi: 0.4.8(effect@3.16.16)(hono@4.9.2)(openapi-types@12.1.3)(zod@3.25.67)
+      hono: 4.9.7
+      hono-openapi: 0.4.8(effect@3.16.16)(hono@4.9.7)(openapi-types@12.1.3)(zod@4.1.8)
       json-schema: 0.4.0
       json-schema-to-zod: 2.6.1
       pino: 9.7.0
@@ -8859,8 +9090,65 @@ snapshots:
       radash: 12.1.1
       sift: 17.1.3
       xstate: 5.20.2
-      zod: 3.25.67
-      zod-to-json-schema: 3.24.5(zod@3.25.67)
+      zod: 4.1.8
+      zod-to-json-schema: 3.24.6(zod@4.1.8)
+    transitivePeerDependencies:
+      - '@hono/arktype-validator'
+      - '@hono/effect-validator'
+      - '@hono/typebox-validator'
+      - '@hono/valibot-validator'
+      - '@hono/zod-validator'
+      - '@sinclair/typebox'
+      - '@valibot/to-json-schema'
+      - arktype
+      - effect
+      - encoding
+      - openapi-types
+      - react
+      - supports-color
+      - valibot
+      - zod-openapi
+
+  '@mastra/core@0.16.3(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@4.1.8)':
+    dependencies:
+      '@a2a-js/sdk': 0.2.5
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.1.8)
+      '@ai-sdk/provider-utils-v5': '@ai-sdk/provider-utils@3.0.5(zod@4.1.8)'
+      '@ai-sdk/provider-v5': '@ai-sdk/provider@2.0.0'
+      '@ai-sdk/ui-utils': 1.2.11(zod@4.1.8)
+      '@mastra/schema-compat': 0.11.3(ai@4.3.19(react@18.3.1)(zod@4.1.8))(zod@4.1.8)
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/auto-instrumentations-node': 0.62.1(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.0.1(@opentelemetry/api@1.9.0))
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-grpc': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-http': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-node': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-node': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.36.0
+      '@sindresorhus/slugify': 2.2.1
+      ai: 4.3.19(react@18.3.1)(zod@4.1.8)
+      ai-v5: ai@5.0.28(zod@4.1.8)
+      date-fns: 3.6.0
+      dotenv: 16.6.1
+      hono: 4.9.7
+      hono-openapi: 0.4.8(effect@3.16.16)(hono@4.9.7)(openapi-types@12.1.3)(zod@4.1.8)
+      js-tiktoken: 1.0.20
+      json-schema: 0.4.0
+      json-schema-to-zod: 2.6.1
+      p-map: 7.0.3
+      pino: 9.7.0
+      pino-pretty: 13.0.0
+      radash: 12.1.1
+      sift: 17.1.3
+      xstate: 5.20.2
+      zod: 4.1.8
+      zod-to-json-schema: 3.24.6(zod@4.1.8)
     transitivePeerDependencies:
       - '@hono/arktype-validator'
       - '@hono/effect-validator'
@@ -8881,15 +9169,61 @@ snapshots:
   '@mastra/mcp@0.10.4(@mastra/core@0.10.6(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@3.25.67))(zod@3.25.67)':
     dependencies:
       '@mastra/core': 0.10.6(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@3.25.67)
-      '@modelcontextprotocol/sdk': 1.13.0
+      '@modelcontextprotocol/sdk': 1.18.0
       date-fns: 4.1.0
       exit-hook: 4.0.0
       fast-deep-equal: 3.1.3
-      hono: 4.8.0
+      hono: 4.9.2
       uuid: 11.1.0
       zod: 3.25.67
       zod-from-json-schema: 0.0.5
     transitivePeerDependencies:
+      - supports-color
+
+  '@mastra/mcp@0.10.4(@mastra/core@0.16.3(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@4.1.8))(zod@4.1.8)':
+    dependencies:
+      '@mastra/core': 0.16.3(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@4.1.8)
+      '@modelcontextprotocol/sdk': 1.18.0
+      date-fns: 4.1.0
+      exit-hook: 4.0.0
+      fast-deep-equal: 3.1.3
+      hono: 4.9.2
+      uuid: 11.1.0
+      zod: 4.1.8
+      zod-from-json-schema: 0.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@mastra/mcp@0.12.0(@mastra/core@0.13.2(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@4.1.8))(@types/json-schema@7.0.15)(zod@4.1.8)':
+    dependencies:
+      '@apidevtools/json-schema-ref-parser': 14.2.1(@types/json-schema@7.0.15)
+      '@mastra/core': 0.13.2(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@4.1.8)
+      '@modelcontextprotocol/sdk': 1.18.0
+      date-fns: 4.1.0
+      exit-hook: 4.0.0
+      fast-deep-equal: 3.1.3
+      uuid: 11.1.0
+      zod: 4.1.8
+      zod-from-json-schema: 0.5.0
+      zod-from-json-schema-v3: zod-from-json-schema@0.0.5
+    transitivePeerDependencies:
+      - '@types/json-schema'
+      - supports-color
+
+  '@mastra/mcp@0.12.0(@mastra/core@0.16.3(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@4.1.8))(@types/json-schema@7.0.15)(zod@4.1.8)':
+    dependencies:
+      '@apidevtools/json-schema-ref-parser': 14.2.1(@types/json-schema@7.0.15)
+      '@mastra/core': 0.16.3(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@4.1.8)
+      '@modelcontextprotocol/sdk': 1.18.0
+      date-fns: 4.1.0
+      exit-hook: 4.0.0
+      fast-deep-equal: 3.1.3
+      uuid: 11.1.0
+      zod: 4.1.8
+      zod-from-json-schema: 0.5.0
+      zod-from-json-schema-v3: zod-from-json-schema@0.0.5
+    transitivePeerDependencies:
+      - '@types/json-schema'
       - supports-color
 
   '@mastra/schema-compat@0.10.2(ai@4.3.16(react@18.3.1)(zod@3.25.67))(zod@3.25.67)':
@@ -8900,47 +9234,39 @@ snapshots:
       zod-from-json-schema: 0.0.5
       zod-to-json-schema: 3.24.5(zod@3.25.67)
 
-  '@mastra/schema-compat@0.10.7(ai@4.3.16(react@18.3.1)(zod@3.25.67))(zod@3.25.67)':
+  '@mastra/schema-compat@0.10.7(ai@4.3.19(react@18.3.1)(zod@4.1.8))(zod@4.1.8)':
     dependencies:
-      ai: 4.3.16(react@18.3.1)(zod@3.25.67)
+      ai: 4.3.19(react@18.3.1)(zod@4.1.8)
       json-schema: 0.4.0
-      zod: 3.25.67
+      zod: 4.1.8
       zod-from-json-schema: 0.0.5
-      zod-to-json-schema: 3.24.5(zod@3.25.67)
+      zod-to-json-schema: 3.24.6(zod@4.1.8)
 
-  '@modelcontextprotocol/sdk@1.13.0':
+  '@mastra/schema-compat@0.11.3(ai@4.3.19(react@18.3.1)(zod@4.1.8))(zod@4.1.8)':
+    dependencies:
+      ai: 4.3.19(react@18.3.1)(zod@4.1.8)
+      json-schema: 0.4.0
+      zod: 4.1.8
+      zod-from-json-schema: 0.5.0
+      zod-from-json-schema-v3: zod-from-json-schema@0.0.5
+      zod-to-json-schema: 3.24.6(zod@4.1.8)
+
+  '@modelcontextprotocol/sdk@1.18.0':
     dependencies:
       ajv: 6.12.6
       content-type: 1.0.5
       cors: 2.8.5
       cross-spawn: 7.0.6
       eventsource: 3.0.7
+      eventsource-parser: 3.0.6
       express: 5.1.0
       express-rate-limit: 7.5.0(express@5.1.0)
       pkce-challenge: 5.0.0
       raw-body: 3.0.0
       zod: 3.25.67
-      zod-to-json-schema: 3.24.5(zod@3.25.67)
+      zod-to-json-schema: 3.24.6(zod@3.25.67)
     transitivePeerDependencies:
       - supports-color
-
-  '@modelcontextprotocol/sdk@1.17.4':
-    dependencies:
-      ajv: 6.12.6
-      content-type: 1.0.5
-      cors: 2.8.5
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.0.3
-      express: 5.1.0
-      express-rate-limit: 7.5.0(express@5.1.0)
-      pkce-challenge: 5.0.0
-      raw-body: 3.0.0
-      zod: 3.25.67
-      zod-to-json-schema: 3.24.5(zod@3.25.67)
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     optional: true
@@ -9003,8 +9329,19 @@ snapshots:
       debug: 4.4.1(supports-color@10.0.0)
       openai: 5.19.1(ws@8.18.2)(zod@3.25.67)
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.17.4
+      '@modelcontextprotocol/sdk': 1.18.0
       zod: 3.25.67
+    transitivePeerDependencies:
+      - supports-color
+      - ws
+
+  '@openai/agents-core@0.1.1(ws@8.18.2)(zod@4.1.8)':
+    dependencies:
+      debug: 4.4.1(supports-color@10.0.0)
+      openai: 5.19.1(ws@8.18.2)(zod@4.1.8)
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.18.0
+      zod: 4.1.8
     transitivePeerDependencies:
       - supports-color
       - ws
@@ -9015,6 +9352,16 @@ snapshots:
       debug: 4.4.1(supports-color@10.0.0)
       openai: 5.19.1(ws@8.18.2)(zod@3.25.67)
       zod: 3.25.67
+    transitivePeerDependencies:
+      - supports-color
+      - ws
+
+  '@openai/agents-openai@0.1.1(ws@8.18.2)(zod@4.1.8)':
+    dependencies:
+      '@openai/agents-core': 0.1.1(ws@8.18.2)(zod@4.1.8)
+      debug: 4.4.1(supports-color@10.0.0)
+      openai: 5.19.1(ws@8.18.2)(zod@4.1.8)
+      zod: 4.1.8
     transitivePeerDependencies:
       - supports-color
       - ws
@@ -9031,6 +9378,18 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@openai/agents-realtime@0.1.1(zod@4.1.8)':
+    dependencies:
+      '@openai/agents-core': 0.1.1(ws@8.18.2)(zod@4.1.8)
+      '@types/ws': 8.18.1
+      debug: 4.4.1(supports-color@10.0.0)
+      ws: 8.18.2
+      zod: 4.1.8
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   '@openai/agents@0.1.1(ws@8.18.2)(zod@3.25.67)':
     dependencies:
       '@openai/agents-core': 0.1.1(ws@8.18.2)(zod@3.25.67)
@@ -9039,6 +9398,20 @@ snapshots:
       debug: 4.4.1(supports-color@10.0.0)
       openai: 5.19.1(ws@8.18.2)(zod@3.25.67)
       zod: 3.25.67
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+
+  '@openai/agents@0.1.1(ws@8.18.2)(zod@4.1.8)':
+    dependencies:
+      '@openai/agents-core': 0.1.1(ws@8.18.2)(zod@4.1.8)
+      '@openai/agents-openai': 0.1.1(ws@8.18.2)(zod@4.1.8)
+      '@openai/agents-realtime': 0.1.1(zod@4.1.8)
+      debug: 4.4.1(supports-color@10.0.0)
+      openai: 5.19.1(ws@8.18.2)(zod@4.1.8)
+      zod: 4.1.8
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -10950,6 +11323,10 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/exit-hook@2.2.3':
+    dependencies:
+      exit-hook: 4.0.0
+
   '@types/express-serve-static-core@4.19.6':
     dependencies:
       '@types/node': 24.0.3
@@ -11279,13 +11656,45 @@ snapshots:
     optionalDependencies:
       react: 18.3.1
 
-  ai@5.0.16(zod@3.25.67):
+  ai@4.3.16(react@18.3.1)(zod@4.1.8):
     dependencies:
-      '@ai-sdk/gateway': 1.0.8(zod@3.25.67)
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.4(zod@3.25.67)
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.1.8)
+      '@ai-sdk/react': 1.2.12(react@18.3.1)(zod@4.1.8)
+      '@ai-sdk/ui-utils': 1.2.11(zod@4.1.8)
       '@opentelemetry/api': 1.9.0
-      zod: 3.25.67
+      jsondiffpatch: 0.6.0
+      zod: 4.1.8
+    optionalDependencies:
+      react: 18.3.1
+
+  ai@4.3.19(react@18.3.1)(zod@4.1.8):
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.1.8)
+      '@ai-sdk/react': 1.2.12(react@18.3.1)(zod@4.1.8)
+      '@ai-sdk/ui-utils': 1.2.11(zod@4.1.8)
+      '@opentelemetry/api': 1.9.0
+      jsondiffpatch: 0.6.0
+      zod: 4.1.8
+    optionalDependencies:
+      react: 18.3.1
+
+  ai@5.0.28(zod@4.1.8):
+    dependencies:
+      '@ai-sdk/gateway': 1.0.15(zod@4.1.8)
+      '@ai-sdk/provider': 2.0.0
+      '@ai-sdk/provider-utils': 3.0.7(zod@4.1.8)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.1.8
+
+  ai@5.0.44(zod@4.1.8):
+    dependencies:
+      '@ai-sdk/gateway': 1.0.23(zod@4.1.8)
+      '@ai-sdk/provider': 2.0.0
+      '@ai-sdk/provider-utils': 3.0.9(zod@4.1.8)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.1.8
 
   ajv@6.12.6:
     dependencies:
@@ -11624,9 +12033,9 @@ snapshots:
       has-own-prop: 2.0.0
       repeat-string: 1.6.1
 
-  composio-core@0.5.39(@ai-sdk/openai@2.0.16(zod@3.25.67))(@cloudflare/workers-types@4.20250619.0)(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(@langchain/openai@0.5.13(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(ws@8.18.2))(ai@4.3.16(react@18.3.1)(zod@3.25.67))(langchain@0.3.28(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(axios@1.10.0)(openai@4.104.0(ws@8.18.2)(zod@3.25.67))(ws@8.18.2))(openai@4.104.0(ws@8.18.2)(zod@3.25.67)):
+  composio-core@0.5.39(@ai-sdk/openai@2.0.28(zod@3.25.67))(@cloudflare/workers-types@4.20250619.0)(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(@langchain/openai@0.5.13(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(ws@8.18.2))(ai@4.3.16(react@18.3.1)(zod@3.25.67))(langchain@0.3.28(@langchain/core@0.3.63(openai@4.104.0(ws@8.18.2)(zod@3.25.67)))(axios@1.10.0)(openai@4.104.0(ws@8.18.2)(zod@3.25.67))(ws@8.18.2))(openai@4.104.0(ws@8.18.2)(zod@3.25.67)):
     dependencies:
-      '@ai-sdk/openai': 2.0.16(zod@3.25.67)
+      '@ai-sdk/openai': 2.0.28(zod@3.25.67)
       '@cloudflare/workers-types': 4.20250619.0
       '@composio/mcp': 1.0.3-0
       '@hey-api/client-axios': 0.2.12(axios@1.10.0)
@@ -12030,13 +12439,13 @@ snapshots:
 
   events@3.3.0: {}
 
-  eventsource-parser@3.0.2: {}
-
   eventsource-parser@3.0.3: {}
+
+  eventsource-parser@3.0.6: {}
 
   eventsource@3.0.7:
     dependencies:
-      eventsource-parser: 3.0.2
+      eventsource-parser: 3.0.6
 
   execa@8.0.1:
     dependencies:
@@ -12463,18 +12872,20 @@ snapshots:
       hono: 4.8.0
       zod: 3.25.67
 
-  hono-openapi@0.4.8(effect@3.16.16)(hono@4.9.2)(openapi-types@12.1.3)(zod@3.25.67):
+  hono-openapi@0.4.8(effect@3.16.16)(hono@4.9.7)(openapi-types@12.1.3)(zod@4.1.8):
     dependencies:
       json-schema-walker: 2.0.0
       openapi-types: 12.1.3
     optionalDependencies:
       effect: 3.16.16
-      hono: 4.9.2
-      zod: 3.25.67
+      hono: 4.9.7
+      zod: 4.1.8
 
   hono@4.8.0: {}
 
   hono@4.9.2: {}
+
+  hono@4.9.7: {}
 
   http-errors@2.0.0:
     dependencies:
@@ -13126,6 +13537,11 @@ snapshots:
       ws: 8.18.2
       zod: 3.25.67
 
+  openai@5.19.1(ws@8.18.2)(zod@4.1.8):
+    optionalDependencies:
+      ws: 8.18.2
+      zod: 4.1.8
+
   openapi-types@12.1.3: {}
 
   openapi-typescript@7.8.0(typescript@5.8.3):
@@ -13174,6 +13590,8 @@ snapshots:
       p-limit: 3.1.0
 
   p-map@2.1.0: {}
+
+  p-map@7.0.3: {}
 
   p-queue@6.6.2:
     dependencies:
@@ -13936,7 +14354,7 @@ snapshots:
 
   supergateway@2.8.3:
     dependencies:
-      '@modelcontextprotocol/sdk': 1.13.0
+      '@modelcontextprotocol/sdk': 1.18.0
       body-parser: 1.20.3
       cors: 2.8.5
       express: 4.21.2
@@ -14696,12 +15114,30 @@ snapshots:
     dependencies:
       zod: 3.25.67
 
+  zod-from-json-schema@0.5.0:
+    dependencies:
+      zod: 4.1.8
+
   zod-to-json-schema@3.24.5(zod@3.25.67):
     dependencies:
       zod: 3.25.67
+
+  zod-to-json-schema@3.24.5(zod@4.1.8):
+    dependencies:
+      zod: 4.1.8
+
+  zod-to-json-schema@3.24.6(zod@3.25.67):
+    dependencies:
+      zod: 3.25.67
+
+  zod-to-json-schema@3.24.6(zod@4.1.8):
+    dependencies:
+      zod: 4.1.8
 
   zod@3.22.3: {}
 
   zod@3.25.32: {}
 
   zod@3.25.67: {}
+
+  zod@4.1.8: {}

--- a/ts/packages/core/src/composio.ts
+++ b/ts/packages/core/src/composio.ts
@@ -5,7 +5,7 @@ import { Toolkits } from './models/Toolkits';
 import { Triggers } from './models/Triggers';
 import { AuthConfigs } from './models/AuthConfigs';
 import { ConnectedAccounts } from './models/ConnectedAccounts';
-import { MCP } from './models/MCP';
+import { ExperimentalMCP, MCP } from './models/MCP';
 import { telemetry } from './telemetry/Telemetry';
 import { getSDKConfig } from './utils/sdk';
 import logger from './utils/logger';
@@ -14,12 +14,26 @@ import { checkForLatestVersionFromNPM } from './utils/version';
 import { OpenAIProvider } from './provider/OpenAIProvider';
 import { version } from '../package.json';
 import type { ComposioRequestHeaders } from './types/composio.types';
-import { McpServerGetResponse } from './types/mcp.types';
 import { Files } from './models/Files';
-import { getDefaultHeaders, getSessionHeaders } from './utils/session';
+import { getDefaultHeaders } from './utils/session';
+import { MCPConfig } from './models/MCPConfig'
+
+/**
+ * The experimental configuration options for the Composio SDK.
+ */
+type ExperimentalConfig = {
+  /**
+   * Enable experimental MCP (Model Control Protocol) features.
+   * More precisely:
+   * - Exposes `composio.mcpConfig.*` methods to manage MCP configurations.
+   * - Exposes `composio.mcp.experimental.*` methods to interact with MCP servers.
+   * @default undefined (disabled)
+   */
+  mcp?: boolean;
+};
 
 export type ComposioConfig<
-  TProvider extends BaseComposioProvider<unknown, unknown, unknown> = OpenAIProvider,
+  TProvider extends BaseComposioProvider<unknown, unknown, /* TMcpResponse */ unknown, /* TMcpExperimentalResponse */ unknown> = OpenAIProvider,
 > = {
   /**
    * The API key for the Composio API.
@@ -73,26 +87,35 @@ export type ComposioConfig<
    * @default false
    */
   disableVersionCheck?: boolean;
-};
 
-/**
- * Extract the MCP response type from a provider
- */
-type ExtractMcpResponseType<T> =
-  T extends BaseComposioProvider<unknown, unknown, infer TMcp> ? TMcp : McpServerGetResponse;
+  /**
+   * Experimental configuration options for the Composio SDK.
+   * These options may enable features that are not yet stable and may change in future releases.
+   * 
+   * @example
+   * ```typescript
+   * const composio = new Composio({
+   *   experimental: {
+   *     mcp: true,
+   *   },
+   * });
+   * ```
+   */
+  experimental?: ExperimentalConfig;
+};
 
 /**
  * This is the core class for Composio.
  * It is used to initialize the Composio SDK and provide a global configuration.
  */
 export class Composio<
-  TProvider extends BaseComposioProvider<unknown, unknown, unknown> = OpenAIProvider,
+  TProvider extends BaseComposioProvider<unknown, unknown, unknown, unknown> = OpenAIProvider,
 > {
   /**
    * The Composio API client.
    * @type {ComposioClient}
    */
-  private client: ComposioClient;
+  protected client: ComposioClient;
 
   /**
    * The configuration for the Composio SDK.
@@ -113,7 +136,7 @@ export class Composio<
   // connected accounts
   connectedAccounts: ConnectedAccounts;
 
-  mcp: MCP<ExtractMcpResponseType<TProvider>>;
+  mcp: MCP<TProvider>;
 
   /**
    * Creates a new instance of the Composio SDK.
@@ -185,6 +208,7 @@ export class Composio<
     this.tools = new Tools(this.client, this.provider, {
       autoUploadDownloadFiles: config?.autoUploadDownloadFiles ?? true,
     });
+
     this.mcp = new MCP(this.client, this.provider);
 
     this.toolkits = new Toolkits(this.client);
@@ -272,4 +296,29 @@ export class Composio<
       defaultHeaders: sessionHeaders,
     });
   }
+}
+
+class ComposioWithExperimentalMCP<TProvider extends BaseComposioProvider<unknown, unknown, unknown, unknown> = OpenAIProvider> extends Composio<TProvider> {
+  mcp: ExperimentalMCP<TProvider>;
+  mcpConfig: MCPConfig<TProvider>;
+  
+  constructor(config?: ComposioConfig<TProvider>) {
+    super(config);
+    this.mcp = new ExperimentalMCP(this.client, this.provider);
+    this.mcpConfig = new MCPConfig(this.mcp);
+  }
+}
+
+/**
+ * Creates a new instance of the Composio SDK.
+ * This factory function enables type-safe access to experimental Composio features.
+ */
+export function create<TProvider extends BaseComposioProvider<unknown, unknown, unknown, unknown> = OpenAIProvider>(config: { experimental: { mcp: true } } & ComposioConfig<TProvider>): ComposioWithExperimentalMCP<TProvider>;
+export function create<TProvider extends BaseComposioProvider<unknown, unknown, unknown, unknown> = OpenAIProvider>(config?: ComposioConfig<TProvider>): Composio<TProvider>;
+export function create<TProvider extends BaseComposioProvider<unknown, unknown, unknown, unknown> = OpenAIProvider>(config?: ComposioConfig<TProvider>) {
+  if (config?.experimental?.mcp === true) {
+    return new ComposioWithExperimentalMCP(config)
+  }
+
+  return new Composio(config)
 }

--- a/ts/packages/core/src/composio.ts
+++ b/ts/packages/core/src/composio.ts
@@ -16,7 +16,7 @@ import { version } from '../package.json';
 import type { ComposioRequestHeaders } from './types/composio.types';
 import { Files } from './models/Files';
 import { getDefaultHeaders } from './utils/session';
-import { MCPConfig } from './models/MCPConfig'
+import { MCPConfig } from './models/MCPConfig';
 
 /**
  * The experimental configuration options for the Composio SDK.
@@ -33,7 +33,12 @@ type ExperimentalConfig = {
 };
 
 export type ComposioConfig<
-  TProvider extends BaseComposioProvider<unknown, unknown, /* TMcpResponse */ unknown, /* TMcpExperimentalResponse */ unknown> = OpenAIProvider,
+  TProvider extends BaseComposioProvider<
+    unknown,
+    unknown,
+    /* TMcpResponse */ unknown,
+    /* TMcpExperimentalResponse */ unknown
+  > = OpenAIProvider,
 > = {
   /**
    * The API key for the Composio API.
@@ -91,7 +96,7 @@ export type ComposioConfig<
   /**
    * Experimental configuration options for the Composio SDK.
    * These options may enable features that are not yet stable and may change in future releases.
-   * 
+   *
    * @example
    * ```typescript
    * const composio = new Composio({
@@ -298,10 +303,12 @@ export class Composio<
   }
 }
 
-class ComposioWithExperimentalMCP<TProvider extends BaseComposioProvider<unknown, unknown, unknown, unknown> = OpenAIProvider> extends Composio<TProvider> {
+class ComposioWithExperimentalMCP<
+  TProvider extends BaseComposioProvider<unknown, unknown, unknown, unknown> = OpenAIProvider,
+> extends Composio<TProvider> {
   mcp: ExperimentalMCP<TProvider>;
   mcpConfig: MCPConfig<TProvider>;
-  
+
   constructor(config?: ComposioConfig<TProvider>) {
     super(config);
     this.mcp = new ExperimentalMCP(this.client, this.provider);
@@ -313,12 +320,20 @@ class ComposioWithExperimentalMCP<TProvider extends BaseComposioProvider<unknown
  * Creates a new instance of the Composio SDK.
  * This factory function enables type-safe access to experimental Composio features.
  */
-export function create<TProvider extends BaseComposioProvider<unknown, unknown, unknown, unknown> = OpenAIProvider>(config: { experimental: { mcp: true } } & ComposioConfig<TProvider>): ComposioWithExperimentalMCP<TProvider>;
-export function create<TProvider extends BaseComposioProvider<unknown, unknown, unknown, unknown> = OpenAIProvider>(config?: ComposioConfig<TProvider>): Composio<TProvider>;
-export function create<TProvider extends BaseComposioProvider<unknown, unknown, unknown, unknown> = OpenAIProvider>(config?: ComposioConfig<TProvider>) {
+export function create<
+  TProvider extends BaseComposioProvider<unknown, unknown, unknown, unknown> = OpenAIProvider,
+>(
+  config: { experimental: { mcp: true } } & ComposioConfig<TProvider>
+): ComposioWithExperimentalMCP<TProvider>;
+export function create<
+  TProvider extends BaseComposioProvider<unknown, unknown, unknown, unknown> = OpenAIProvider,
+>(config?: ComposioConfig<TProvider>): Composio<TProvider>;
+export function create<
+  TProvider extends BaseComposioProvider<unknown, unknown, unknown, unknown> = OpenAIProvider,
+>(config?: ComposioConfig<TProvider>) {
   if (config?.experimental?.mcp === true) {
-    return new ComposioWithExperimentalMCP(config)
+    return new ComposioWithExperimentalMCP(config);
   }
 
-  return new Composio(config)
+  return new Composio(config);
 }

--- a/ts/packages/core/src/index.ts
+++ b/ts/packages/core/src/index.ts
@@ -1,5 +1,5 @@
 // Core exports
-export { Composio } from './composio';
+export { Composio, create } from './composio';
 export { OpenAIProvider } from './provider/OpenAIProvider';
 export { ComposioProvider } from './provider/ComposioProvider';
 export { BaseNonAgenticProvider, BaseAgenticProvider } from './provider/BaseProvider';

--- a/ts/packages/core/src/models/MCP.ts
+++ b/ts/packages/core/src/models/MCP.ts
@@ -48,15 +48,37 @@ import { ToolkitAuthFieldsResponse } from '../types/toolkit.types';
 import { ConnectionRequest } from '../types/connectionRequest.types';
 
 /**
+ * Extract the MCP response type from a provider.
+ */
+type ExtractMcpResponseType<T> =
+  T extends BaseComposioProvider<unknown, unknown, infer TMcp, unknown>
+    ? TMcp
+    : /* @default */ McpServerGetResponse;
+
+/**
+ * Extract the experimental MCP response type from a provider.
+ */
+type ExtractExperimentalMcpResponseType<T> =
+  T extends BaseComposioProvider<unknown, unknown, unknown, infer TMcpExperimental>
+    ? TMcpExperimental
+    : /* @default */ McpServerGetResponse;
+
+/**
  * MCP (Model Control Protocol) class
  * Handles MCP server operations
  */
-export class MCP<T = McpServerGetResponse> {
+export class MCP<TProvider extends BaseComposioProvider<unknown, unknown, unknown, unknown>> {
   private client: ComposioClient;
-  private provider?: BaseComposioProvider<unknown, unknown, unknown>;
   private toolkits: Toolkits;
+  protected provider: TProvider;
 
-  constructor(client: ComposioClient, provider?: BaseComposioProvider<unknown, unknown, unknown>) {
+  // Trick to store types derived from a generic parameter inside the class.
+  // It's similar to `using type` declarations in C++.
+  // See: https://stackoverflow.com/questions/76017389/type-or-interface-inside-class-in-typescript.
+  declare readonly TMcpResponse: ExtractMcpResponseType<TProvider>;
+  declare readonly TMcpExperimentalResponse: ExtractExperimentalMcpResponseType<TProvider>;
+
+  constructor(client: ComposioClient, provider: TProvider) {
     this.client = client;
     this.provider = provider;
     this.toolkits = new Toolkits(client);
@@ -97,7 +119,7 @@ export class MCP<T = McpServerGetResponse> {
    * @param {Object} params.options - Server creation options
    * @param {string} params.options.name - Unique name for the MCP server
    * @param {boolean} [params.options.isChatAuth] - Whether to use chat-based authentication
-   * @returns {Promise<McpServerCreateResponse<T>>} Created server details with instance getter
+   * @returns {Promise<McpServerCreateResponse<TMcpResponse>>} Created server details with instance getter
    *
    * @example
    * ```typescript
@@ -127,7 +149,7 @@ export class MCP<T = McpServerGetResponse> {
     options: {
       isChatAuth?: boolean;
     }
-  ): Promise<McpServerCreateResponse<T>> {
+  ): Promise<McpServerCreateResponse<typeof this.TMcpResponse>> {
     // Validate inputs using Zod schemas
     if (!serverConfig || serverConfig.length === 0) {
       throw new ValidationError('At least one auth config is required', {});
@@ -184,12 +206,12 @@ export class MCP<T = McpServerGetResponse> {
       return {
         ...camelCaseResponse,
         toolkits,
-        getServer: async (params: MCPGetServerParams): Promise<T> => {
+        getServer: async (params: MCPGetServerParams): Promise<typeof this.TMcpResponse> => {
           return this.getServer(camelCaseResponse.id, params.userId || '', {
             isChatAuth: options.isChatAuth,
           });
         },
-      } as McpServerCreateResponse<T>;
+      } as McpServerCreateResponse<typeof this.TMcpResponse>;
     } catch (error) {
       // If error is not about server not found, re-throw it
       if (error instanceof ValidationError && !error.message.includes('not found')) {
@@ -236,13 +258,13 @@ export class MCP<T = McpServerGetResponse> {
     return {
       ...camelCaseResponse,
       toolkits,
-      getServer: async (params: MCPGetServerParams): Promise<T> => {
+      getServer: async (params: MCPGetServerParams): Promise<typeof this.TMcpResponse> => {
         // Delegate to the standalone getServer method
         return this.getServer(camelCaseResponse.id, params.userId || '', {
           isChatAuth: options.isChatAuth,
         });
       },
-    } as McpServerCreateResponse<T>;
+    } as McpServerCreateResponse<typeof this.TMcpResponse>;
   }
 
   /**
@@ -414,7 +436,7 @@ export class MCP<T = McpServerGetResponse> {
    * @param {Object} [options] - Additional options for server configuration
    * @param {string[]} [options.limitTools] - Subset of tools to limit (from MCP config)
    * @param {boolean} [options.isChatAuth] - Whether to use chat-based authentication
-   * @returns {Promise<T>} Transformed server URLs in provider-specific format
+   * @returns {Promise<TMcpResponse>} Transformed server URLs in provider-specific format
    *
    * @example
    * ```typescript
@@ -435,7 +457,7 @@ export class MCP<T = McpServerGetResponse> {
       limitTools?: string[];
       isChatAuth?: boolean;
     }
-  ): Promise<T> {
+  ): Promise<typeof this.TMcpResponse> {
     // Get server details first
     const serverDetails = await this.get(serverId);
 
@@ -760,7 +782,7 @@ export class MCP<T = McpServerGetResponse> {
     connectedAccountIds?: string[],
     userIds?: string[],
     toolkits?: string[]
-  ): T {
+  ): typeof this.TMcpResponse {
     // Check if provider has a custom transform method
     if (this.provider && typeof this.provider.wrapMcpServerResponse === 'function') {
       // Convert to array of name and url based on connected accounts or user ids
@@ -786,8 +808,10 @@ export class MCP<T = McpServerGetResponse> {
       }
 
       const transformed = this.provider.wrapMcpServerResponse(snakeCaseData);
-      return transformed as T;
+      return transformed as typeof this.TMcpResponse;
     }
+
+    const self = this;
 
     // Default transformation
     if (connectedAccountIds?.length && data.connectedAccountUrls) {
@@ -795,18 +819,18 @@ export class MCP<T = McpServerGetResponse> {
         url: new URL(url),
         name: `${serverName}-${connectedAccountIds[index]}`,
         toolkit: toolkits?.[index],
-      })) as T;
+      })) as typeof self.TMcpResponse;
     } else if (userIds?.length && data.userIdsUrl) {
       return data.userIdsUrl.map((url: string, index: number) => ({
         url: new URL(url),
         name: `${serverName}-${userIds[index]}`,
         toolkit: toolkits?.[index],
-      })) as T;
+      })) as typeof self.TMcpResponse;
     }
     return {
       url: new URL(data.mcpUrl),
       name: serverName,
-    } as T;
+    } as typeof self.TMcpResponse;
   }
 
   /**
@@ -858,5 +882,48 @@ export class MCP<T = McpServerGetResponse> {
 
     // Get the full server details using the server ID
     return this.get(servers[0].id);
+  }
+}
+
+/**
+ * MCP (Model Control Protocol) class
+ * Handles MCP server operations.
+ * When `config.experimental.mcp` is enabled, this class augments the features of `composio.mcp`.
+ */
+export class ExperimentalMCP<TProvider extends BaseComposioProvider<unknown, unknown, unknown, unknown>> extends MCP<TProvider> {
+  constructor(client: ComposioClient, provider: TProvider) {
+    super(client, provider);
+  }
+
+  experimental = {
+    /**
+     * Get server URLs for an existing MCP server.
+     * The response is wrapped according to the provider's specifications.
+     */
+    getServer: async (
+      mcpConfigurationId: string,
+      userId: string,
+      options?: {
+        limitTools?: string[];
+        isChatAuth?: boolean;
+      }
+    ) => this.getServer(mcpConfigurationId, userId, options)
+      .then(res => {
+        // TODO: investigate why this cast is needed in the first place.
+        // Without it, this type is always inferred as `unknown`.
+        return this.provider.wrapMcpServers(res) as typeof this.TMcpExperimentalResponse;
+      }),
+
+    /**
+     * Get server URLs for an existing MCP server.
+     */
+    _getServerRaw: async (
+      mcpConfigurationId: string,
+      userId: string,
+      options?: {
+        limitTools?: string[];
+        isChatAuth?: boolean;
+      }
+    ) => await this.getServer(mcpConfigurationId, userId, options),
   }
 }

--- a/ts/packages/core/src/models/MCP.ts
+++ b/ts/packages/core/src/models/MCP.ts
@@ -811,6 +811,7 @@ export class MCP<TProvider extends BaseComposioProvider<unknown, unknown, unknow
       return transformed as typeof this.TMcpResponse;
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this;
 
     // Default transformation
@@ -890,7 +891,9 @@ export class MCP<TProvider extends BaseComposioProvider<unknown, unknown, unknow
  * Handles MCP server operations.
  * When `config.experimental.mcp` is enabled, this class augments the features of `composio.mcp`.
  */
-export class ExperimentalMCP<TProvider extends BaseComposioProvider<unknown, unknown, unknown, unknown>> extends MCP<TProvider> {
+export class ExperimentalMCP<
+  TProvider extends BaseComposioProvider<unknown, unknown, unknown, unknown>,
+> extends MCP<TProvider> {
   constructor(client: ComposioClient, provider: TProvider) {
     super(client, provider);
   }
@@ -907,8 +910,8 @@ export class ExperimentalMCP<TProvider extends BaseComposioProvider<unknown, unk
         limitTools?: string[];
         isChatAuth?: boolean;
       }
-    ) => this.getServer(mcpConfigurationId, userId, options)
-      .then(res => {
+    ) =>
+      this.getServer(mcpConfigurationId, userId, options).then(res => {
         // TODO: investigate why this cast is needed in the first place.
         // Without it, this type is always inferred as `unknown`.
         return this.provider.wrapMcpServers(res) as typeof this.TMcpExperimentalResponse;
@@ -925,5 +928,5 @@ export class ExperimentalMCP<TProvider extends BaseComposioProvider<unknown, unk
         isChatAuth?: boolean;
       }
     ) => await this.getServer(mcpConfigurationId, userId, options),
-  }
+  };
 }

--- a/ts/packages/core/src/models/MCPConfig.ts
+++ b/ts/packages/core/src/models/MCPConfig.ts
@@ -1,0 +1,79 @@
+import type { BaseComposioProvider } from '../provider/BaseProvider';
+import type { McpServerCreateResponse, McpRetrieveResponse } from '../types/mcp.types';
+import type { MCP } from './MCP';
+
+/**
+ * MCPConfig (Model Control Protocol Config) class
+ * Handles CRUD operations related to MCP configurations.
+ */
+export class MCPConfig<TProvider extends BaseComposioProvider<unknown, unknown, unknown, unknown>> {
+  constructor(private mcp: MCP<TProvider>) {
+    
+  }
+
+  /**
+   * Create a new MCP configuration.
+   * @param {Object} params - Parameters for creating the MCP configuration
+   * @param {Array} params.authConfig - Array of auth configurations with id and allowed tools
+   * @param {Object} params.options - Configuration options
+   * @param {string} params.options.name - Unique name for the MCP configuration
+   * @param {boolean} [params.options.isChatAuth] - Whether to use chat-based authentication
+   * @returns {Promise<McpServerCreateResponse<T>>} Created server details with instance getter
+   *
+   * @example
+   * ```typescript
+   * const server = await composio.mcpConfig.create("personal-mcp-server", [
+   *     {
+   *       authConfigId: "ac_xyz",
+   *       allowedTools: ["GMAIL_FETCH_EMAILS", "SLACK_SEND_MESSAGE"]
+   *     }
+   *   ],
+   *   {
+   *     isChatAuth: true
+   *   }
+   * });
+   * ```
+   */
+  async create(
+    name: string,
+    serverConfig: Array<{
+      authConfigId: string;
+      allowedTools: string[];
+    }>,
+    options: {
+      isChatAuth?: boolean;
+    }
+  ): Promise<McpServerCreateResponse<typeof this.mcp.TMcpResponse>> {
+    return this.mcp.create(name, serverConfig, options);
+  }
+
+  /**
+   * Get details of a specific MCP config by name
+   * @param {string} configName - Config name
+   * @returns {Promise<McpRetrieveResponse>} Server details
+   * @throws {ValidationError} If no MCP Config found with the given name
+   * @throws {ValidationError} If multiple MCP Configs found with the same name
+   *
+   * @example
+   * ```typescript
+   * const mcpConfig = await composio.mcpConfig.getByName('my-gmail-server');
+   * ```
+   */
+  async getByName(configName: string): Promise<McpRetrieveResponse> {
+    return this.mcp.getByName(configName);
+  }
+
+  /**
+   * Get details of a specific MCP Config
+   * @param {string} configId - Config UUID
+   * @returns {Promise<McpRetrieveResponse>} Config details
+   *
+   * @example
+   * ```typescript
+   * const mcpConfig = await composio.mcpConfig.get('config-uuid');
+   * ```
+   */
+  async get(configId: string): Promise<McpRetrieveResponse> {
+    return this.mcp.get(configId);
+  }
+}

--- a/ts/packages/core/src/models/MCPConfig.ts
+++ b/ts/packages/core/src/models/MCPConfig.ts
@@ -7,9 +7,7 @@ import type { MCP } from './MCP';
  * Handles CRUD operations related to MCP configurations.
  */
 export class MCPConfig<TProvider extends BaseComposioProvider<unknown, unknown, unknown, unknown>> {
-  constructor(private mcp: MCP<TProvider>) {
-    
-  }
+  constructor(private mcp: MCP<TProvider>) {}
 
   /**
    * Create a new MCP configuration.

--- a/ts/packages/core/src/models/Tools.ts
+++ b/ts/packages/core/src/models/Tools.ts
@@ -53,7 +53,7 @@ import { AuthSchemeTypes } from '../types/authConfigs.types';
 export class Tools<
   TToolCollection,
   TTool,
-  TProvider extends BaseComposioProvider<TToolCollection, TTool, unknown>,
+  TProvider extends BaseComposioProvider<TToolCollection, TTool, unknown, unknown>,
 > {
   private client: ComposioClient;
   private readonly customTools: CustomTools;

--- a/ts/packages/core/src/provider/BaseProvider.ts
+++ b/ts/packages/core/src/provider/BaseProvider.ts
@@ -9,7 +9,10 @@ import { McpUrlResponse, McpServerGetResponse } from '../types/mcp.types';
  * Base class for all providers.
  * This class is not meant to be used directly, but rather to be extended by different provider implementations.
  */
-abstract class BaseProvider<TMcpResponse = McpServerGetResponse, TMcpExperimentalResponse = McpServerGetResponse> {
+abstract class BaseProvider<
+  TMcpResponse = McpServerGetResponse,
+  TMcpExperimentalResponse = McpServerGetResponse,
+> {
   /**
    * @public
    * The name of the provider.
@@ -139,6 +142,11 @@ export abstract class BaseAgenticProvider<
  * Base type for all providers.
  * This type is used to infer the type of the provider from the provider implementation.
  */
-export type BaseComposioProvider<TToolCollection, TTool, TMcpResponse = McpServerGetResponse, TMcpExperimentalResponse = McpServerGetResponse> =
+export type BaseComposioProvider<
+  TToolCollection,
+  TTool,
+  TMcpResponse = McpServerGetResponse,
+  TMcpExperimentalResponse = McpServerGetResponse,
+> =
   | BaseNonAgenticProvider<TToolCollection, TTool, TMcpResponse, TMcpExperimentalResponse>
   | BaseAgenticProvider<TToolCollection, TTool, TMcpResponse, TMcpExperimentalResponse>;

--- a/ts/packages/core/src/provider/BaseProvider.ts
+++ b/ts/packages/core/src/provider/BaseProvider.ts
@@ -9,7 +9,7 @@ import { McpUrlResponse, McpServerGetResponse } from '../types/mcp.types';
  * Base class for all providers.
  * This class is not meant to be used directly, but rather to be extended by different provider implementations.
  */
-abstract class BaseProvider<TMcpResponse = McpServerGetResponse> {
+abstract class BaseProvider<TMcpResponse = McpServerGetResponse, TMcpExperimentalResponse = McpServerGetResponse> {
   /**
    * @public
    * The name of the provider.
@@ -60,16 +60,22 @@ abstract class BaseProvider<TMcpResponse = McpServerGetResponse> {
 
   /**
    * @public
+   * @deprecated: Will be removed in a future version, once the `experimental.mcp` flag is stabilized. Use `wrapMcpServers` instead.
    * Optional method to transform MCP URL response into provider-specific format.
    * Providers can override this method to define custom transformation logic
    * for MCP server responses.
    *
    * @param data - The MCP URL response data
-   * @param serverName - Name of the MCP server
 
    * @returns Transformed response in provider-specific format, or undefined to use default transformation
    */
   wrapMcpServerResponse?(data: McpUrlResponse): TMcpResponse;
+
+  /**
+   * This method replaces `wrapMcpServerResponse` when Composio's config contains has the
+   * `experimental.mcp` flag enabled.
+   */
+  abstract wrapMcpServers(data: TMcpResponse): TMcpExperimentalResponse;
 }
 
 /**
@@ -81,7 +87,8 @@ export abstract class BaseNonAgenticProvider<
   TToolCollection,
   TTool,
   TMcpResponse = McpServerGetResponse,
-> extends BaseProvider<TMcpResponse> {
+  TMcpExperimentalResponse = McpServerGetResponse,
+> extends BaseProvider<TMcpResponse, TMcpExperimentalResponse> {
   override readonly _isAgentic = false;
 
   /**
@@ -107,7 +114,8 @@ export abstract class BaseAgenticProvider<
   TToolCollection,
   TTool,
   TMcpResponse = McpServerGetResponse,
-> extends BaseProvider<TMcpResponse> {
+  TMcpExperimentalResponse = McpServerGetResponse,
+> extends BaseProvider<TMcpResponse, TMcpExperimentalResponse> {
   override readonly _isAgentic = true;
 
   /**
@@ -131,6 +139,6 @@ export abstract class BaseAgenticProvider<
  * Base type for all providers.
  * This type is used to infer the type of the provider from the provider implementation.
  */
-export type BaseComposioProvider<TToolCollection, TTool, TMcpResponse = McpServerGetResponse> =
-  | BaseNonAgenticProvider<TToolCollection, TTool, TMcpResponse>
-  | BaseAgenticProvider<TToolCollection, TTool, TMcpResponse>;
+export type BaseComposioProvider<TToolCollection, TTool, TMcpResponse = McpServerGetResponse, TMcpExperimentalResponse = McpServerGetResponse> =
+  | BaseNonAgenticProvider<TToolCollection, TTool, TMcpResponse, TMcpExperimentalResponse>
+  | BaseAgenticProvider<TToolCollection, TTool, TMcpResponse, TMcpExperimentalResponse>;

--- a/ts/packages/core/src/provider/ComposioProvider.ts
+++ b/ts/packages/core/src/provider/ComposioProvider.ts
@@ -1,4 +1,4 @@
-import { McpServerGetResponse } from '../types/mcp.types'
+import { McpServerGetResponse } from '../types/mcp.types';
 import { Tool } from '../types/tool.types';
 import { BaseNonAgenticProvider } from './BaseProvider';
 

--- a/ts/packages/core/src/provider/ComposioProvider.ts
+++ b/ts/packages/core/src/provider/ComposioProvider.ts
@@ -1,3 +1,4 @@
+import { McpServerGetResponse } from '../types/mcp.types'
 import { Tool } from '../types/tool.types';
 import { BaseNonAgenticProvider } from './BaseProvider';
 
@@ -16,6 +17,10 @@ export class ComposioProvider extends BaseNonAgenticProvider<Array<CustomTool>, 
 
   constructor() {
     super();
+  }
+
+  override wrapMcpServers(data: McpServerGetResponse) {
+    return data;
   }
 
   wrapTool = (tool: Tool): CustomTool => {

--- a/ts/packages/core/src/provider/OpenAIProvider.ts
+++ b/ts/packages/core/src/provider/OpenAIProvider.ts
@@ -19,7 +19,11 @@ import { McpUrlResponse, McpServerGetResponse } from '../types/mcp.types';
 export type OpenAiTool = OpenAI.ChatCompletionTool;
 export type OpenAiToolCollection = Array<OpenAiTool>;
 
-export class OpenAIProvider extends BaseNonAgenticProvider<OpenAiToolCollection, OpenAiTool, McpServerGetResponse> {
+export class OpenAIProvider extends BaseNonAgenticProvider<
+  OpenAiToolCollection,
+  OpenAiTool,
+  McpServerGetResponse
+> {
   readonly name = 'openai';
 
   /**

--- a/ts/packages/core/src/provider/OpenAIProvider.ts
+++ b/ts/packages/core/src/provider/OpenAIProvider.ts
@@ -19,7 +19,7 @@ import { McpUrlResponse, McpServerGetResponse } from '../types/mcp.types';
 export type OpenAiTool = OpenAI.ChatCompletionTool;
 export type OpenAiToolCollection = Array<OpenAiTool>;
 
-export class OpenAIProvider extends BaseNonAgenticProvider<OpenAiToolCollection, OpenAiTool> {
+export class OpenAIProvider extends BaseNonAgenticProvider<OpenAiToolCollection, OpenAiTool, McpServerGetResponse> {
   readonly name = 'openai';
 
   /**
@@ -58,6 +58,10 @@ export class OpenAIProvider extends BaseNonAgenticProvider<OpenAiToolCollection,
       url: new URL(item.url),
       name: item.name,
     }));
+  }
+
+  override wrapMcpServers(servers: McpServerGetResponse): McpServerGetResponse {
+    return servers;
   }
 
   /**

--- a/ts/packages/core/src/utils/session.ts
+++ b/ts/packages/core/src/utils/session.ts
@@ -1,10 +1,9 @@
 import { BaseComposioProvider } from '../provider/BaseProvider';
 import { version } from '../../package.json';
-import { ComposioConfig } from '../composio';
 import { ComposioRequestHeaders } from '../types/composio.types';
 
 export function getSessionHeaders(
-  provider: BaseComposioProvider<unknown, unknown, unknown> | undefined
+  provider: BaseComposioProvider<unknown, unknown, unknown, unknown> | undefined
 ) {
   return {
     'x-source': provider?.name || '@composio/core',
@@ -15,7 +14,7 @@ export function getSessionHeaders(
 
 export const getDefaultHeaders = (
   headers: ComposioRequestHeaders | undefined,
-  provider: BaseComposioProvider<unknown, unknown, unknown> | undefined
+  provider: BaseComposioProvider<unknown, unknown, unknown, unknown> | undefined
 ) => {
   const sessionHeaders = getSessionHeaders(provider);
   return {

--- a/ts/packages/providers/anthropic/package.json
+++ b/ts/packages/providers/anthropic/package.json
@@ -35,7 +35,8 @@
   "packageManager": "pnpm@10.8.0",
   "peerDependencies": {
     "@anthropic-ai/sdk": "^0.52.0",
-    "@composio/core": "0.1.51"
+    "@composio/core": "0.1.51",
+    "@mastra/mcp": "^0.12.0"
   },
   "devDependencies": {
     "@composio/core": "workspace:*",

--- a/ts/packages/providers/anthropic/src/index.ts
+++ b/ts/packages/providers/anthropic/src/index.ts
@@ -20,7 +20,10 @@ import Anthropic from '@anthropic-ai/sdk';
 import { type MastraMCPServerDefinition } from '@mastra/mcp';
 import { AnthropicTool, InputSchema } from './types';
 
-export function wrapTools(servers: AnthropicMcpServerGetResponse, tools: Record<string, ComposioTool>): Array<AnthropicTool> {
+export function wrapTools(
+  servers: AnthropicMcpServerGetResponse,
+  tools: Record<string, ComposioTool>
+): Array<AnthropicTool> {
   const prefixes = servers.map(({ name }) => name);
 
   function removePrefix(str: string): string {
@@ -42,8 +45,8 @@ export function wrapTools(servers: AnthropicMcpServerGetResponse, tools: Record<
         type: 'object',
       },
       type: 'custom',
-    }
-  })
+    };
+  });
 }
 
 export type AnthropicMcpServerGetResponse = {
@@ -165,10 +168,7 @@ export class AnthropicProvider extends BaseNonAgenticProvider<
    */
   override wrapMcpServers(servers: AnthropicMcpServerGetResponse) {
     return Object.fromEntries(
-      servers.map(({ name, url }) => [
-        name,
-        { url: new URL(url) }
-      ])
+      servers.map(({ name, url }) => [name, { url: new URL(url) }])
     ) satisfies Record<string, MastraMCPServerDefinition>;
   }
 

--- a/ts/packages/providers/cloudflare/src/index.ts
+++ b/ts/packages/providers/cloudflare/src/index.ts
@@ -24,7 +24,9 @@ type AiToolCollection = Record<string, AiTextGenerationToolInput>;
 
 export class CloudflareProvider extends BaseNonAgenticProvider<
   AiToolCollection,
-  AiTextGenerationToolInput
+  AiTextGenerationToolInput,
+  McpServerGetResponse,
+  McpServerGetResponse
 > {
   readonly name = 'cloudflare';
 
@@ -65,6 +67,10 @@ export class CloudflareProvider extends BaseNonAgenticProvider<
       url: new URL(item.url),
       name: item.name,
     })) as McpServerGetResponse;
+  }
+
+  override wrapMcpServers(data: McpServerGetResponse): McpServerGetResponse {
+    return data;
   }
 
   /**

--- a/ts/packages/providers/google/src/index.ts
+++ b/ts/packages/providers/google/src/index.ts
@@ -43,7 +43,12 @@ export type GoogleGenAIToolCollection = GoogleTool[];
  * Google GenAI Provider for Composio SDK
  * Implements the BaseNonAgenticProvider to wrap Composio tools for use with Google's GenAI API
  */
-export class GoogleProvider extends BaseNonAgenticProvider<GoogleGenAIToolCollection, GoogleTool, McpServerGetResponse, URL> {
+export class GoogleProvider extends BaseNonAgenticProvider<
+  GoogleGenAIToolCollection,
+  GoogleTool,
+  McpServerGetResponse,
+  URL
+> {
   readonly name = 'google';
 
   /**

--- a/ts/packages/providers/google/src/index.ts
+++ b/ts/packages/providers/google/src/index.ts
@@ -15,6 +15,7 @@ import {
   ExecuteToolFnOptions,
   McpUrlResponse,
   McpServerGetResponse,
+  McpServerUrlInfo,
 } from '@composio/core';
 import { FunctionDeclaration, Schema } from '@google/genai';
 
@@ -42,7 +43,7 @@ export type GoogleGenAIToolCollection = GoogleTool[];
  * Google GenAI Provider for Composio SDK
  * Implements the BaseNonAgenticProvider to wrap Composio tools for use with Google's GenAI API
  */
-export class GoogleProvider extends BaseNonAgenticProvider<GoogleGenAIToolCollection, GoogleTool> {
+export class GoogleProvider extends BaseNonAgenticProvider<GoogleGenAIToolCollection, GoogleTool, McpServerGetResponse, URL> {
   readonly name = 'google';
 
   /**
@@ -84,6 +85,22 @@ export class GoogleProvider extends BaseNonAgenticProvider<GoogleGenAIToolCollec
       url: new URL(item.url),
       name: item.name,
     })) as McpServerGetResponse;
+  }
+
+  override wrapMcpServers(servers: McpServerGetResponse): URL {
+    function wrapMcpServer(server: McpServerUrlInfo) {
+      return server.url;
+    }
+
+    if (Array.isArray(servers)) {
+      if (servers.length === 0) {
+        throw new Error('No servers found');
+      }
+
+      return wrapMcpServer(servers[0]);
+    }
+
+    return wrapMcpServer(servers);
   }
 
   /**

--- a/ts/packages/providers/langchain/src/index.ts
+++ b/ts/packages/providers/langchain/src/index.ts
@@ -22,7 +22,9 @@ import { DynamicStructuredTool } from '@langchain/core/tools';
 export type LangChainToolCollection = Array<DynamicStructuredTool>;
 export class LangchainProvider extends BaseAgenticProvider<
   LangChainToolCollection,
-  DynamicStructuredTool
+  DynamicStructuredTool,
+  McpServerGetResponse,
+  McpServerGetResponse
 > {
   readonly name = 'langchain';
 
@@ -65,6 +67,10 @@ export class LangchainProvider extends BaseAgenticProvider<
       url: new URL(item.url),
       name: item.name,
     })) as McpServerGetResponse;
+  }
+
+  override wrapMcpServers(data: McpServerGetResponse): McpServerGetResponse {
+    return data;
   }
 
   /**

--- a/ts/packages/providers/mastra/package.json
+++ b/ts/packages/providers/mastra/package.json
@@ -35,7 +35,8 @@
   "packageManager": "pnpm@10.8.0",
   "peerDependencies": {
     "@composio/core": "0.1.51",
-    "@mastra/core": "^0.13.2"
+    "@mastra/core": "^0.16.2",
+    "@mastra/mcp": "^0.12.0"
   },
   "devDependencies": {
     "@composio/core": "workspace:*",

--- a/ts/packages/providers/mastra/src/index.ts
+++ b/ts/packages/providers/mastra/src/index.ts
@@ -80,10 +80,7 @@ export class MastraProvider extends BaseAgenticProvider<
 
   override wrapMcpServers(urls: MastraUrlMap) {
     return Object.fromEntries(
-      Object.entries(urls).map(([key, value]) => [
-        key,
-        { url: new URL(value.url) }
-      ])
+      Object.entries(urls).map(([key, value]) => [key, { url: new URL(value.url) }])
     ) satisfies Record<string, MastraMCPServerDefinition>;
   }
 

--- a/ts/packages/providers/openai-agents/src/index.ts
+++ b/ts/packages/providers/openai-agents/src/index.ts
@@ -90,11 +90,11 @@ export class OpenAIAgentsProvider extends BaseAgenticProvider<
       return hostedMcpTool({
         serverLabel: removePrefix(name),
         serverUrl: url.toString(),
-      })
+      });
     }
 
     if (Array.isArray(servers)) {
-      return servers.map(server => wrapMcpServer(server))
+      return servers.map(server => wrapMcpServer(server));
     }
 
     return [wrapMcpServer(servers)];

--- a/ts/packages/providers/openai-agents/src/index.ts
+++ b/ts/packages/providers/openai-agents/src/index.ts
@@ -16,14 +16,18 @@ import {
   ExecuteToolFn,
   McpUrlResponse,
   McpServerGetResponse,
+  McpServerUrlInfo,
 } from '@composio/core';
-import type { Tool as OpenAIAgentTool } from '@openai/agents';
-import { tool as createOpenAIAgentTool } from '@openai/agents';
+import type { HostedMCPTool, Tool as OpenAIAgentTool } from '@openai/agents';
+import { tool as createOpenAIAgentTool, hostedMcpTool } from '@openai/agents';
 
 type OpenAIAgentsToolCollection = Array<OpenAIAgentTool>;
+type TMcpExperimentalResponse = Array<HostedMCPTool<unknown>>;
 export class OpenAIAgentsProvider extends BaseAgenticProvider<
   OpenAIAgentsToolCollection,
-  OpenAIAgentTool
+  OpenAIAgentTool,
+  McpServerGetResponse,
+  TMcpExperimentalResponse
 > {
   readonly name = 'openai-agents';
   private strict: boolean | null;
@@ -68,6 +72,32 @@ export class OpenAIAgentsProvider extends BaseAgenticProvider<
       url: new URL(item.url),
       name: item.name,
     })) as McpServerGetResponse;
+  }
+
+  override wrapMcpServers(servers: McpServerGetResponse): TMcpExperimentalResponse {
+    const prefixes = Object.keys(servers);
+
+    function removePrefix(str: string): string {
+      for (const prefix of prefixes) {
+        if (str.startsWith(prefix)) {
+          return str.slice(prefix.length + 1);
+        }
+      }
+      return str;
+    }
+
+    function wrapMcpServer({ name, url }: McpServerUrlInfo) {
+      return hostedMcpTool({
+        serverLabel: removePrefix(name),
+        serverUrl: url.toString(),
+      })
+    }
+
+    if (Array.isArray(servers)) {
+      return servers.map(server => wrapMcpServer(server))
+    }
+
+    return [wrapMcpServer(servers)];
   }
 
   /**

--- a/ts/packages/providers/openai/src/OpenAIResponsesProvider.ts
+++ b/ts/packages/providers/openai/src/OpenAIResponsesProvider.ts
@@ -42,6 +42,7 @@ export interface OpenAIMcpServerResponse {
 export class OpenAIResponsesProvider extends BaseNonAgenticProvider<
   OpenAiToolCollection,
   OpenAiTool,
+  OpenAiMcpTool[],
   OpenAiMcpTool[]
 > {
   readonly name = 'openai';
@@ -93,6 +94,10 @@ export class OpenAIResponsesProvider extends BaseNonAgenticProvider<
       server_url: item.url,
       require_approval: 'never',
     }));
+  }
+
+  override wrapMcpServers(servers: OpenAiMcpTool[]): OpenAiMcpTool[] {
+    return servers;
   }
 
   /**

--- a/ts/packages/providers/vercel/package.json
+++ b/ts/packages/providers/vercel/package.json
@@ -31,14 +31,14 @@
   "packageManager": "pnpm@10.8.0",
   "peerDependencies": {
     "@composio/core": "0.1.51",
-    "ai": "^5.0.16"
+    "ai": "^5.0.44"
   },
   "devDependencies": {
     "@composio/core": "workspace:*",
     "tsup": "^8.4.0",
     "typescript": "^5.8.3",
     "vitest": "^3.1.4",
-    "ai": "^5.0.16"
+    "ai": "^5.0.44"
   },
   "gitHead": "4fae6e54d5c150fba955cc5fa314281da5a1e064"
 }

--- a/ts/packages/providers/vercel/src/index.ts
+++ b/ts/packages/providers/vercel/src/index.ts
@@ -24,7 +24,12 @@ import type { Tool as VercelTool } from 'ai';
 import { tool } from 'ai';
 
 export type VercelToolCollection = Record<string, VercelTool>;
-export class VercelProvider extends BaseAgenticProvider<VercelToolCollection, VercelTool, McpUrlResponse, URL> {
+export class VercelProvider extends BaseAgenticProvider<
+  VercelToolCollection,
+  VercelTool,
+  McpUrlResponse,
+  URL
+> {
   readonly name = 'vercel';
   private strict: boolean | null;
   /**
@@ -137,7 +142,7 @@ export class VercelProvider extends BaseAgenticProvider<VercelToolCollection, Ve
     return tool({
       description: composioTool.description,
       inputSchema: inputParametersSchema,
-      
+
       execute: async params => {
         const input = typeof params === 'string' ? JSON.parse(params) : params;
         return await executeTool(composioTool.slug, input);


### PR DESCRIPTION
# TL/DR

This PR:
- introduces `experimental.mcp` config in `ComposioConfig`, expanding `@composio/core` to introduce an alternative MCP API
- refactors the existing Composio Providers accordingly
- updates Composio's MCP examples accordingly

## `experimental.mcp`

Compare:

**Before**

```typescript
import { Composio } from '@composio/core';
import type { McpServerGetResponse, McpServerUrlInfo } from '@composio/core';
import { GoogleProvider } from '@composio/google';

import { GoogleGenAI, mcpToTool } from '@google/genai';
import { Client as MCPClient } from '@modelcontextprotocol/sdk/client/index.js';
import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';

// 1. Initialize Composio.
const provider = new GoogleProvider();
const composio = new Composio({
  apiKey: process.env.COMPOSIO_API_KEY,
  provider,
});

// 2. Retrieve an existing MCP config by name.
const mcpConfigName = 'gmail-mcp-1757920370827';
const mcpConfig = await composio.mcp.getByName(mcpConfigName);

// 3. Retrieve an object of MCP server URLs from the given MCP config.
const userId = 'alberto.schiabel@gmail.com';
const servers = await composio.mcp.getServer(mcpConfig.id, userId);

function wrapMcpServers(servers: McpServerGetResponse): URL {
  function wrapMcpServer(server: McpServerUrlInfo) {
    return server.url;
  }

  if (Array.isArray(servers)) {
    if (servers.length === 0) {
      throw new Error('No servers found');
    }

    return wrapMcpServer(servers[0]);
  }

  return wrapMcpServer(servers);
}

// 4. Transform the MCP server URLs into something that can be used by the MCP client of choice
const mcp = wrapMcpServers(servers);

// 5. Initialize the MCP client.
const mcpTransport = new SSEClientTransport(mcp);
const mcpClient = new MCPClient({
  name: 'composio-mcp-client',
  version: '1.0.0',
});
await mcpClient.connect(mcpTransport);

function wrapTools(client: MCPClient) {
  return [mcpToTool(client)];
}

// 6. Extract the tools from the MCP client.
const tools = wrapTools(mcpClient);

// 7. Initialize the Provider-specific agent.
const gemini = new GoogleGenAI({
  apiKey: process.env.GEMINI_API_KEY,
});

// 8. Pass `tools` to the Provider-specific agent.
const stream = await gemini.models.generateContentStream({
  model: 'gemini-2.5-flash',
  contents: `TODO: system prompt and rules`,
  config: {
    tools,
  },
});

// 9. Consume stream...
```

**After**

```typescript
import { create as createComposio } from '@composio/core';
import { GoogleProvider } from '@composio/google';

import { GoogleGenAI, mcpToTool } from '@google/genai';
import { Client as MCPClient } from '@modelcontextprotocol/sdk/client/index.js';
import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';

// 1. Initialize Composio with `experimental.mcp: true`.
const provider = new GoogleProvider();
const composio = createComposio({
  apiKey: process.env.COMPOSIO_API_KEY,
  provider,
  experimental: {
    mcp: true,
  },
});

// 2. Retrieve an existing MCP config by name.
const mcpConfigName = 'gmail-mcp-1757920370827';
const mcpConfig = await composio.mcpConfig.getByName(mcpConfigName);

// 3. Retrieve an `mcp` object having the shape needed by the Provider-specific `MCP` client already.
const userId = 'alberto.schiabel@gmail.com';
const mcp = await composio.mcp.experimental.getServer(mcpConfig.id, userId);

// 4. Initialize the MCP client.
const mcpTransport = new SSEClientTransport(mcp);
const mcpClient = new MCPClient({
  name: 'composio-mcp-client',
  version: '1.0.0',
});
await mcpClient.connect(mcpTransport);

function wrapTools(client: MCPClient) {
  return [mcpToTool(client)];
}

// 5. Extract the tools from the MCP client.
const tools = wrapTools(mcpClient);

// 6. Initialize the Provider-specific agent.
const gemini = new GoogleGenAI({
  apiKey: process.env.GEMINI_API_KEY,
});

// 7. Pass `tools` to the Provider-specific agent.
const stream = await gemini.models.generateContentStream({
  model: 'gemini-2.5-flash',
  contents: `TODO: system prompt and rules`,
  config: {
    tools,
  },
});

// 8. Consume stream...
```