### PR TITLE
chore: stash attempt at moving to Zod 4

### DIFF
--- a/fern/tsconfig.typedoc.json
+++ b/fern/tsconfig.typedoc.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "skipLibCheck": true,
     "strict": false,
     "resolveJsonModule": true,

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "turbo": "^2.5.0",
     "typescript-eslint": "^8.31.0",
     "vitest": "^3.1.4",
-    "zod": "^3.24.2"
+    "zod": "^4.1.8"
   },
   "lint-staged": {
     "ts/packages/**/*.{ts,tsx}": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,8 +57,8 @@ importers:
         specifier: ^3.1.4
         version: 3.2.4(@types/node@22.15.32)(@vitest/ui@3.2.4)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.0)
       zod:
-        specifier: ^3.24.2
-        version: 3.25.67
+        specifier: ^4.1.8
+        version: 4.1.8
 
   fern:
     dependencies:
@@ -321,7 +321,7 @@ importers:
         version: 16.5.0
       zod-to-json-schema:
         specifier: ^3.24.5
-        version: 3.24.5(zod@3.25.67)
+        version: 3.24.5(zod@4.1.8)
     devDependencies:
       '@types/bun':
         specifier: ^1.2.9
@@ -365,7 +365,7 @@ importers:
     dependencies:
       '@ai-sdk/openai':
         specifier: ^1.3.16
-        version: 1.3.22(zod@3.25.67)
+        version: 1.3.22(zod@4.1.8)
       '@composio/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -374,10 +374,10 @@ importers:
         version: link:../../packages/providers/mastra
       '@mastra/core':
         specifier: ^0.10.0
-        version: 0.10.6(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@3.25.67)
+        version: 0.10.6(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@4.1.8)
       '@mastra/mcp':
         specifier: ^0.10.3
-        version: 0.10.4(@mastra/core@0.10.6(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@3.25.67))(zod@3.25.67)
+        version: 0.10.4(@mastra/core@0.10.6(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@4.1.8))(zod@4.1.8)
       dotenv:
         specifier: ^16.4.1
         version: 16.5.0
@@ -393,7 +393,7 @@ importers:
     dependencies:
       '@ai-sdk/openai':
         specifier: ^1.3.16
-        version: 1.3.22(zod@3.25.67)
+        version: 1.3.22(zod@4.1.8)
       '@composio/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -402,7 +402,7 @@ importers:
         version: link:../../packages/providers/vercel
       ai:
         specifier: ^4.3.8
-        version: 4.3.16(react@18.3.1)(zod@3.25.67)
+        version: 4.3.16(react@18.3.1)(zod@4.1.8)
     devDependencies:
       '@types/bun':
         specifier: ^1.2.9
@@ -465,7 +465,7 @@ importers:
     dependencies:
       '@ai-sdk/openai':
         specifier: ^1.3.16
-        version: 1.3.22(zod@3.25.67)
+        version: 1.3.22(zod@4.1.8)
       '@composio/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -474,7 +474,7 @@ importers:
         version: link:../../packages/providers/vercel
       ai:
         specifier: ^4.3.8
-        version: 4.3.16(react@18.3.1)(zod@3.25.67)
+        version: 4.3.16(react@18.3.1)(zod@4.1.8)
     devDependencies:
       '@types/bun':
         specifier: ^1.2.9
@@ -493,10 +493,10 @@ importers:
         version: 16.5.0
       openai:
         specifier: ^5.19.1
-        version: 5.19.1(ws@8.18.2)(zod@3.25.67)
+        version: 5.19.1(ws@8.18.2)(zod@4.1.8)
       zod-to-json-schema:
         specifier: ^3.24.5
-        version: 3.24.5(zod@3.25.67)
+        version: 3.24.5(zod@4.1.8)
     devDependencies:
       '@types/bun':
         specifier: ^1.2.9
@@ -525,7 +525,7 @@ importers:
     dependencies:
       '@ai-sdk/openai':
         specifier: ^2.0.16
-        version: 2.0.16(zod@3.25.67)
+        version: 2.0.16(zod@4.1.8)
       '@composio/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -534,7 +534,7 @@ importers:
         version: link:../../packages/providers/vercel
       ai:
         specifier: ^5.0.16
-        version: 5.0.16(zod@3.25.67)
+        version: 5.0.16(zod@4.1.8)
       dotenv:
         specifier: ^16.5.0
         version: 16.5.0
@@ -675,7 +675,7 @@ importers:
         version: 4.1.2
       openai:
         specifier: ^5.16.0
-        version: 5.16.0(ws@8.18.2)(zod@3.25.67)
+        version: 5.16.0(ws@8.18.2)(zod@4.1.8)
       pusher-js:
         specifier: ^8.4.0
         version: 8.4.0
@@ -686,11 +686,11 @@ importers:
         specifier: ^11.1.0
         version: 11.1.0
       zod:
-        specifier: ^3.24.2
-        version: 3.25.67
+        specifier: ^4.1.8
+        version: 4.1.8
       zod-to-json-schema:
         specifier: ^3.24.5
-        version: 3.24.5(zod@3.25.67)
+        version: 3.24.5(zod@4.1.8)
     devDependencies:
       '@types/semver':
         specifier: ^7.7.0
@@ -713,9 +713,6 @@ importers:
       '@types/json-schema':
         specifier: ^7.0.15
         version: 7.0.15
-      zod:
-        specifier: ^3.24.2
-        version: 3.25.67
     devDependencies:
       '@types/node':
         specifier: ^24.0.1
@@ -729,9 +726,9 @@ importers:
       vitest:
         specifier: ^3.1.4
         version: 3.2.4(@types/node@24.0.3)(@vitest/ui@3.2.4)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.0)
-      zod-to-json-schema:
-        specifier: ^3.24.5
-        version: 3.24.5(zod@3.25.67)
+      zod:
+        specifier: ^4.1.8
+        version: 4.1.8
 
   ts/packages/providers/anthropic:
     dependencies:
@@ -810,7 +807,7 @@ importers:
     dependencies:
       '@mastra/core':
         specifier: ^0.13.2
-        version: 0.13.2(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@3.25.67)
+        version: 0.13.2(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@4.1.8)
     devDependencies:
       '@composio/core':
         specifier: workspace:*
@@ -848,7 +845,7 @@ importers:
     dependencies:
       '@openai/agents':
         specifier: ^0.1.1
-        version: 0.1.1(ws@8.18.2)(zod@3.25.67)
+        version: 0.1.1(ws@8.18.2)(zod@4.1.8)
     devDependencies:
       '@composio/core':
         specifier: workspace:*
@@ -870,7 +867,7 @@ importers:
         version: link:../../core
       ai:
         specifier: ^5.0.16
-        version: 5.0.16(zod@3.25.67)
+        version: 5.0.16(zod@4.1.8)
       tsup:
         specifier: ^8.4.0
         version: 8.5.0(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
@@ -7200,6 +7197,9 @@ packages:
   zod@3.25.67:
     resolution: {integrity: sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==}
 
+  zod@4.1.8:
+    resolution: {integrity: sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==}
+
 snapshots:
 
   '@a2a-js/sdk@0.2.5':
@@ -7219,23 +7219,29 @@ snapshots:
       '@ai-sdk/provider-utils': 2.2.8(zod@3.25.67)
       zod: 3.25.67
 
-  '@ai-sdk/gateway@1.0.8(zod@3.25.67)':
+  '@ai-sdk/gateway@1.0.8(zod@4.1.8)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.4(zod@3.25.67)
-      zod: 3.25.67
+      '@ai-sdk/provider-utils': 3.0.4(zod@4.1.8)
+      zod: 4.1.8
 
-  '@ai-sdk/openai@1.3.22(zod@3.25.67)':
+  '@ai-sdk/openai@1.3.22(zod@4.1.8)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.67)
-      zod: 3.25.67
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.1.8)
+      zod: 4.1.8
 
   '@ai-sdk/openai@2.0.16(zod@3.25.67)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
       '@ai-sdk/provider-utils': 3.0.4(zod@3.25.67)
       zod: 3.25.67
+
+  '@ai-sdk/openai@2.0.16(zod@4.1.8)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@ai-sdk/provider-utils': 3.0.4(zod@4.1.8)
+      zod: 4.1.8
 
   '@ai-sdk/provider-utils@2.2.8(zod@3.25.67)':
     dependencies:
@@ -7244,6 +7250,13 @@ snapshots:
       secure-json-parse: 2.7.0
       zod: 3.25.67
 
+  '@ai-sdk/provider-utils@2.2.8(zod@4.1.8)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      nanoid: 3.3.11
+      secure-json-parse: 2.7.0
+      zod: 4.1.8
+
   '@ai-sdk/provider-utils@3.0.4(zod@3.25.67)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
@@ -7251,6 +7264,14 @@ snapshots:
       eventsource-parser: 3.0.3
       zod: 3.25.67
       zod-to-json-schema: 3.24.5(zod@3.25.67)
+
+  '@ai-sdk/provider-utils@3.0.4(zod@4.1.8)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@standard-schema/spec': 1.0.0
+      eventsource-parser: 3.0.3
+      zod: 4.1.8
+      zod-to-json-schema: 3.24.5(zod@4.1.8)
 
   '@ai-sdk/provider@1.1.3':
     dependencies:
@@ -7270,12 +7291,29 @@ snapshots:
     optionalDependencies:
       zod: 3.25.67
 
+  '@ai-sdk/react@1.2.12(react@18.3.1)(zod@4.1.8)':
+    dependencies:
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.1.8)
+      '@ai-sdk/ui-utils': 1.2.11(zod@4.1.8)
+      react: 18.3.1
+      swr: 2.3.3(react@18.3.1)
+      throttleit: 2.1.0
+    optionalDependencies:
+      zod: 4.1.8
+
   '@ai-sdk/ui-utils@1.2.11(zod@3.25.67)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
       '@ai-sdk/provider-utils': 2.2.8(zod@3.25.67)
       zod: 3.25.67
       zod-to-json-schema: 3.24.5(zod@3.25.67)
+
+  '@ai-sdk/ui-utils@1.2.11(zod@4.1.8)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.1.8)
+      zod: 4.1.8
+      zod-to-json-schema: 3.24.5(zod@4.1.8)
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -8790,12 +8828,12 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mastra/core@0.10.6(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@3.25.67)':
+  '@mastra/core@0.10.6(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@4.1.8)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.67)
-      '@ai-sdk/ui-utils': 1.2.11(zod@3.25.67)
-      '@mastra/schema-compat': 0.10.2(ai@4.3.16(react@18.3.1)(zod@3.25.67))(zod@3.25.67)
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.1.8)
+      '@ai-sdk/ui-utils': 1.2.11(zod@4.1.8)
+      '@mastra/schema-compat': 0.10.2(ai@4.3.16(react@18.3.1)(zod@4.1.8))(zod@4.1.8)
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/auto-instrumentations-node': 0.59.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.0.1(@opentelemetry/api@1.9.0))
       '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
@@ -8810,12 +8848,12 @@ snapshots:
       '@opentelemetry/sdk-trace-node': 2.0.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.34.0
       '@sindresorhus/slugify': 2.2.1
-      ai: 4.3.16(react@18.3.1)(zod@3.25.67)
+      ai: 4.3.16(react@18.3.1)(zod@4.1.8)
       cohere-ai: 7.17.1
       date-fns: 3.6.0
       dotenv: 16.6.1
       hono: 4.8.0
-      hono-openapi: 0.4.8(effect@3.16.16)(hono@4.8.0)(openapi-types@12.1.3)(zod@3.25.67)
+      hono-openapi: 0.4.8(effect@3.16.16)(hono@4.8.0)(openapi-types@12.1.3)(zod@4.1.8)
       json-schema: 0.4.0
       json-schema-to-zod: 2.6.1
       pino: 9.7.0
@@ -8823,7 +8861,7 @@ snapshots:
       radash: 12.1.1
       sift: 17.1.3
       xstate: 5.19.4
-      zod: 3.25.67
+      zod: 4.1.8
     transitivePeerDependencies:
       - '@hono/arktype-validator'
       - '@hono/effect-validator'
@@ -8842,13 +8880,13 @@ snapshots:
       - valibot
       - zod-openapi
 
-  '@mastra/core@0.13.2(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@3.25.67)':
+  '@mastra/core@0.13.2(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@4.1.8)':
     dependencies:
       '@a2a-js/sdk': 0.2.5
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.67)
-      '@ai-sdk/ui-utils': 1.2.11(zod@3.25.67)
-      '@mastra/schema-compat': 0.10.7(ai@4.3.16(react@18.3.1)(zod@3.25.67))(zod@3.25.67)
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.1.8)
+      '@ai-sdk/ui-utils': 1.2.11(zod@4.1.8)
+      '@mastra/schema-compat': 0.10.7(ai@4.3.16(react@18.3.1)(zod@4.1.8))(zod@4.1.8)
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/auto-instrumentations-node': 0.62.1(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.0.1(@opentelemetry/api@1.9.0))
       '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
@@ -8863,11 +8901,11 @@ snapshots:
       '@opentelemetry/sdk-trace-node': 2.0.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.36.0
       '@sindresorhus/slugify': 2.2.1
-      ai: 4.3.16(react@18.3.1)(zod@3.25.67)
+      ai: 4.3.16(react@18.3.1)(zod@4.1.8)
       date-fns: 3.6.0
       dotenv: 16.6.1
       hono: 4.9.2
-      hono-openapi: 0.4.8(effect@3.16.16)(hono@4.9.2)(openapi-types@12.1.3)(zod@3.25.67)
+      hono-openapi: 0.4.8(effect@3.16.16)(hono@4.9.2)(openapi-types@12.1.3)(zod@4.1.8)
       json-schema: 0.4.0
       json-schema-to-zod: 2.6.1
       pino: 9.7.0
@@ -8875,8 +8913,8 @@ snapshots:
       radash: 12.1.1
       sift: 17.1.3
       xstate: 5.20.2
-      zod: 3.25.67
-      zod-to-json-schema: 3.24.5(zod@3.25.67)
+      zod: 4.1.8
+      zod-to-json-schema: 3.24.5(zod@4.1.8)
     transitivePeerDependencies:
       - '@hono/arktype-validator'
       - '@hono/effect-validator'
@@ -8894,35 +8932,35 @@ snapshots:
       - valibot
       - zod-openapi
 
-  '@mastra/mcp@0.10.4(@mastra/core@0.10.6(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@3.25.67))(zod@3.25.67)':
+  '@mastra/mcp@0.10.4(@mastra/core@0.10.6(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@4.1.8))(zod@4.1.8)':
     dependencies:
-      '@mastra/core': 0.10.6(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@3.25.67)
+      '@mastra/core': 0.10.6(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@4.1.8)
       '@modelcontextprotocol/sdk': 1.13.0
       date-fns: 4.1.0
       exit-hook: 4.0.0
       fast-deep-equal: 3.1.3
       hono: 4.8.0
       uuid: 11.1.0
-      zod: 3.25.67
+      zod: 4.1.8
       zod-from-json-schema: 0.0.5
     transitivePeerDependencies:
       - supports-color
 
-  '@mastra/schema-compat@0.10.2(ai@4.3.16(react@18.3.1)(zod@3.25.67))(zod@3.25.67)':
+  '@mastra/schema-compat@0.10.2(ai@4.3.16(react@18.3.1)(zod@4.1.8))(zod@4.1.8)':
     dependencies:
-      ai: 4.3.16(react@18.3.1)(zod@3.25.67)
+      ai: 4.3.16(react@18.3.1)(zod@4.1.8)
       json-schema: 0.4.0
-      zod: 3.25.67
+      zod: 4.1.8
       zod-from-json-schema: 0.0.5
-      zod-to-json-schema: 3.24.5(zod@3.25.67)
+      zod-to-json-schema: 3.24.5(zod@4.1.8)
 
-  '@mastra/schema-compat@0.10.7(ai@4.3.16(react@18.3.1)(zod@3.25.67))(zod@3.25.67)':
+  '@mastra/schema-compat@0.10.7(ai@4.3.16(react@18.3.1)(zod@4.1.8))(zod@4.1.8)':
     dependencies:
-      ai: 4.3.16(react@18.3.1)(zod@3.25.67)
+      ai: 4.3.16(react@18.3.1)(zod@4.1.8)
       json-schema: 0.4.0
-      zod: 3.25.67
+      zod: 4.1.8
       zod-from-json-schema: 0.0.5
-      zod-to-json-schema: 3.24.5(zod@3.25.67)
+      zod-to-json-schema: 3.24.5(zod@4.1.8)
 
   '@modelcontextprotocol/sdk@1.13.0':
     dependencies:
@@ -9025,12 +9063,33 @@ snapshots:
       - supports-color
       - ws
 
+  '@openai/agents-core@0.1.1(ws@8.18.2)(zod@4.1.8)':
+    dependencies:
+      debug: 4.4.1(supports-color@10.0.0)
+      openai: 5.19.1(ws@8.18.2)(zod@4.1.8)
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.17.4
+      zod: 4.1.8
+    transitivePeerDependencies:
+      - supports-color
+      - ws
+
   '@openai/agents-openai@0.1.1(ws@8.18.2)(zod@3.25.67)':
     dependencies:
       '@openai/agents-core': 0.1.1(ws@8.18.2)(zod@3.25.67)
       debug: 4.4.1(supports-color@10.0.0)
       openai: 5.19.1(ws@8.18.2)(zod@3.25.67)
       zod: 3.25.67
+    transitivePeerDependencies:
+      - supports-color
+      - ws
+
+  '@openai/agents-openai@0.1.1(ws@8.18.2)(zod@4.1.8)':
+    dependencies:
+      '@openai/agents-core': 0.1.1(ws@8.18.2)(zod@4.1.8)
+      debug: 4.4.1(supports-color@10.0.0)
+      openai: 5.19.1(ws@8.18.2)(zod@4.1.8)
+      zod: 4.1.8
     transitivePeerDependencies:
       - supports-color
       - ws
@@ -9047,6 +9106,18 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@openai/agents-realtime@0.1.1(zod@4.1.8)':
+    dependencies:
+      '@openai/agents-core': 0.1.1(ws@8.18.2)(zod@4.1.8)
+      '@types/ws': 8.18.1
+      debug: 4.4.1(supports-color@10.0.0)
+      ws: 8.18.2
+      zod: 4.1.8
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   '@openai/agents@0.1.1(ws@8.18.2)(zod@3.25.67)':
     dependencies:
       '@openai/agents-core': 0.1.1(ws@8.18.2)(zod@3.25.67)
@@ -9055,6 +9126,20 @@ snapshots:
       debug: 4.4.1(supports-color@10.0.0)
       openai: 5.19.1(ws@8.18.2)(zod@3.25.67)
       zod: 3.25.67
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+
+  '@openai/agents@0.1.1(ws@8.18.2)(zod@4.1.8)':
+    dependencies:
+      '@openai/agents-core': 0.1.1(ws@8.18.2)(zod@4.1.8)
+      '@openai/agents-openai': 0.1.1(ws@8.18.2)(zod@4.1.8)
+      '@openai/agents-realtime': 0.1.1(zod@4.1.8)
+      debug: 4.4.1(supports-color@10.0.0)
+      openai: 5.19.1(ws@8.18.2)(zod@4.1.8)
+      zod: 4.1.8
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -11257,7 +11342,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@24.0.3)(@vitest/ui@3.2.4)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.0)
+      vitest: 3.2.4(@types/node@20.19.1)(@vitest/ui@3.2.4)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.0)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -11311,13 +11396,25 @@ snapshots:
     optionalDependencies:
       react: 18.3.1
 
-  ai@5.0.16(zod@3.25.67):
+  ai@4.3.16(react@18.3.1)(zod@4.1.8):
     dependencies:
-      '@ai-sdk/gateway': 1.0.8(zod@3.25.67)
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.4(zod@3.25.67)
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.1.8)
+      '@ai-sdk/react': 1.2.12(react@18.3.1)(zod@4.1.8)
+      '@ai-sdk/ui-utils': 1.2.11(zod@4.1.8)
       '@opentelemetry/api': 1.9.0
-      zod: 3.25.67
+      jsondiffpatch: 0.6.0
+      zod: 4.1.8
+    optionalDependencies:
+      react: 18.3.1
+
+  ai@5.0.16(zod@4.1.8):
+    dependencies:
+      '@ai-sdk/gateway': 1.0.8(zod@4.1.8)
+      '@ai-sdk/provider': 2.0.0
+      '@ai-sdk/provider-utils': 3.0.4(zod@4.1.8)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.1.8
 
   ajv@6.12.6:
     dependencies:
@@ -12486,23 +12583,23 @@ snapshots:
 
   help-me@5.0.0: {}
 
-  hono-openapi@0.4.8(effect@3.16.16)(hono@4.8.0)(openapi-types@12.1.3)(zod@3.25.67):
+  hono-openapi@0.4.8(effect@3.16.16)(hono@4.8.0)(openapi-types@12.1.3)(zod@4.1.8):
     dependencies:
       json-schema-walker: 2.0.0
       openapi-types: 12.1.3
     optionalDependencies:
       effect: 3.16.16
       hono: 4.8.0
-      zod: 3.25.67
+      zod: 4.1.8
 
-  hono-openapi@0.4.8(effect@3.16.16)(hono@4.9.2)(openapi-types@12.1.3)(zod@3.25.67):
+  hono-openapi@0.4.8(effect@3.16.16)(hono@4.9.2)(openapi-types@12.1.3)(zod@4.1.8):
     dependencies:
       json-schema-walker: 2.0.0
       openapi-types: 12.1.3
     optionalDependencies:
       effect: 3.16.16
       hono: 4.9.2
-      zod: 3.25.67
+      zod: 4.1.8
 
   hono@4.8.0: {}
 
@@ -13153,10 +13250,20 @@ snapshots:
       ws: 8.18.2
       zod: 3.25.67
 
+  openai@5.16.0(ws@8.18.2)(zod@4.1.8):
+    optionalDependencies:
+      ws: 8.18.2
+      zod: 4.1.8
+
   openai@5.19.1(ws@8.18.2)(zod@3.25.67):
     optionalDependencies:
       ws: 8.18.2
       zod: 3.25.67
+
+  openai@5.19.1(ws@8.18.2)(zod@4.1.8):
+    optionalDependencies:
+      ws: 8.18.2
+      zod: 4.1.8
 
   openapi-types@12.1.3: {}
 
@@ -14732,8 +14839,14 @@ snapshots:
     dependencies:
       zod: 3.25.67
 
+  zod-to-json-schema@3.24.5(zod@4.1.8):
+    dependencies:
+      zod: 4.1.8
+
   zod@3.22.3: {}
 
   zod@3.25.32: {}
 
   zod@3.25.67: {}
+
+  zod@4.1.8: {}

--- a/ts/examples/anthropic/tsconfig.json
+++ b/ts/examples/anthropic/tsconfig.json
@@ -8,7 +8,7 @@
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "skipLibCheck": true,
     "resolveJsonModule": true
   },

--- a/ts/examples/connected-accounts/tsconfig.json
+++ b/ts/examples/connected-accounts/tsconfig.json
@@ -8,7 +8,7 @@
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "skipLibCheck": true
   },
   "include": ["src"]

--- a/ts/examples/custom-tools/tsconfig.json
+++ b/ts/examples/custom-tools/tsconfig.json
@@ -8,7 +8,7 @@
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "skipLibCheck": true,
     "resolveJsonModule": true
   },

--- a/ts/examples/error-handling-demo/tsconfig.json
+++ b/ts/examples/error-handling-demo/tsconfig.json
@@ -8,7 +8,7 @@
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "skipLibCheck": true
   },
   "include": ["src"]

--- a/ts/examples/file-handling/tsconfig.json
+++ b/ts/examples/file-handling/tsconfig.json
@@ -8,7 +8,7 @@
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "skipLibCheck": true,
     "resolveJsonModule": true
   },

--- a/ts/examples/google/tsconfig.json
+++ b/ts/examples/google/tsconfig.json
@@ -8,7 +8,7 @@
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "skipLibCheck": true,
     "resolveJsonModule": true
   },

--- a/ts/examples/json-schema-to-zod/tsconfig.json
+++ b/ts/examples/json-schema-to-zod/tsconfig.json
@@ -8,7 +8,7 @@
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "skipLibCheck": true,
     "resolveJsonModule": true
   },

--- a/ts/examples/langchain/tsconfig.json
+++ b/ts/examples/langchain/tsconfig.json
@@ -8,7 +8,7 @@
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "skipLibCheck": true
   },
   "include": ["src"]

--- a/ts/examples/mastra/tsconfig.json
+++ b/ts/examples/mastra/tsconfig.json
@@ -8,7 +8,7 @@
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "skipLibCheck": true,
     "resolveJsonModule": true
   },

--- a/ts/examples/modifiers/tsconfig.json
+++ b/ts/examples/modifiers/tsconfig.json
@@ -8,7 +8,7 @@
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "skipLibCheck": true
   },
   "include": ["src"]

--- a/ts/examples/openai/tsconfig.json
+++ b/ts/examples/openai/tsconfig.json
@@ -8,7 +8,7 @@
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "skipLibCheck": true
   },
   "include": ["src"]

--- a/ts/examples/session-management/tsconfig.json
+++ b/ts/examples/session-management/tsconfig.json
@@ -8,7 +8,7 @@
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "skipLibCheck": true,
     "resolveJsonModule": true
   },

--- a/ts/examples/toolkits/tsconfig.json
+++ b/ts/examples/toolkits/tsconfig.json
@@ -8,7 +8,7 @@
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "skipLibCheck": true
   },
   "include": ["src"]

--- a/ts/examples/tools/tsconfig.json
+++ b/ts/examples/tools/tsconfig.json
@@ -8,7 +8,7 @@
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "skipLibCheck": true,
     "resolveJsonModule": true
   },

--- a/ts/examples/triggers/tsconfig.json
+++ b/ts/examples/triggers/tsconfig.json
@@ -8,7 +8,7 @@
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "skipLibCheck": true,
     "resolveJsonModule": true
   },

--- a/ts/examples/vercel/tsconfig.json
+++ b/ts/examples/vercel/tsconfig.json
@@ -8,7 +8,7 @@
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "skipLibCheck": true
   },
   "include": ["src"]

--- a/ts/examples/versioning/tsconfig.json
+++ b/ts/examples/versioning/tsconfig.json
@@ -8,7 +8,7 @@
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "skipLibCheck": true,
     "resolveJsonModule": true
   },

--- a/ts/packages/cli/test/__fixtures__/typescript-project-with-composio-core/tsconfig.json
+++ b/ts/packages/cli/test/__fixtures__/typescript-project-with-composio-core/tsconfig.json
@@ -11,7 +11,7 @@
     },
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "skipLibCheck": true,
     "resolveJsonModule": true
   },

--- a/ts/packages/cli/test/__fixtures__/typescript-project/tsconfig.json
+++ b/ts/packages/cli/test/__fixtures__/typescript-project/tsconfig.json
@@ -11,7 +11,7 @@
     },
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "skipLibCheck": true,
     "resolveJsonModule": true
   },

--- a/ts/packages/cli/tsconfig.options.json
+++ b/ts/packages/cli/tsconfig.options.json
@@ -8,7 +8,7 @@
     "rootDir": ".",
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "skipLibCheck": true,
     "resolveJsonModule": true,
     "pretty": true,

--- a/ts/packages/core/package.json
+++ b/ts/packages/core/package.json
@@ -52,7 +52,7 @@
     "pusher-js": "^8.4.0",
     "semver": "^7.7.2",
     "uuid": "^11.1.0",
-    "zod": "^3.24.2",
+    "zod": "^4.1.8",
     "zod-to-json-schema": "^3.24.5"
   },
   "gitHead": "4fae6e54d5c150fba955cc5fa314281da5a1e064"

--- a/ts/packages/core/tsconfig.json
+++ b/ts/packages/core/tsconfig.json
@@ -8,7 +8,7 @@
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "skipLibCheck": true,
     "resolveJsonModule": true
   },

--- a/ts/packages/json-schema-to-zod/package.json
+++ b/ts/packages/json-schema-to-zod/package.json
@@ -34,10 +34,12 @@
     "tsup": "^8.4.0",
     "typescript": "^5.8.3",
     "vitest": "^3.1.4",
-    "zod-to-json-schema": "^3.24.5"
+    "zod": "^4.1.8"
   },
   "dependencies": {
-    "@types/json-schema": "^7.0.15",
-    "zod": "^3.24.2"
+    "@types/json-schema": "^7.0.15"
+  },
+  "peerDependencies": {
+    "zod": "^3.25.0 || ^4.0.0"
   }
 }

--- a/ts/packages/json-schema-to-zod/src/json-schema-to-zod.ts
+++ b/ts/packages/json-schema-to-zod/src/json-schema-to-zod.ts
@@ -1,4 +1,4 @@
-import type { z } from 'zod';
+import { $ZodType } from 'zod/v4/core';
 
 import { parseSchema } from './parsers/parse-schema';
 import type { JsonSchemaToZodOptions, JsonSchema } from './types';
@@ -6,7 +6,7 @@ import type { JsonSchemaToZodOptions, JsonSchema } from './types';
 export const jsonSchemaToZod = (
   schema: JsonSchema,
   options: JsonSchemaToZodOptions = {}
-): z.ZodType => {
+): $ZodType => {
   return parseSchema(schema, {
     path: [],
     seen: new Map(),

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-all-of.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-all-of.ts
@@ -1,4 +1,5 @@
-import { z } from 'zod';
+import * as z from 'zod';
+import type { $ZodType } from 'zod/v4/core';
 
 import { parseSchema } from './parse-schema';
 import type { JsonSchemaObject, JsonSchema, Refs } from '../types';
@@ -7,40 +8,40 @@ import { half } from '../utils/half';
 const originalIndex = Symbol('Original index');
 
 const ensureOriginalIndex = (arr: JsonSchema[]) => {
-	const newArr = [];
+  const newArr = [];
 
-	for (let i = 0; i < arr.length; i++) {
-		const item = arr[i];
-		if (typeof item === 'boolean') {
-			newArr.push(item ? { [originalIndex]: i } : { [originalIndex]: i, not: {} });
-		} else if (originalIndex in item) {
-			return arr;
-		} else {
-			newArr.push({ ...item, [originalIndex]: i });
-		}
-	}
+  for (let i = 0; i < arr.length; i++) {
+    const item = arr[i];
+    if (typeof item === 'boolean') {
+      newArr.push(item ? { [originalIndex]: i } : { [originalIndex]: i, not: {} });
+    } else if (originalIndex in item) {
+      return arr;
+    } else {
+      newArr.push({ ...item, [originalIndex]: i });
+    }
+  }
 
-	return newArr;
+  return newArr;
 };
 
 export function parseAllOf(
-	jsonSchema: JsonSchemaObject & { allOf: JsonSchema[] },
-	refs: Refs,
-): z.ZodTypeAny {
-	if (jsonSchema.allOf.length === 0) {
-		return z.never();
-	}
+  jsonSchema: JsonSchemaObject & { allOf: JsonSchema[] },
+  refs: Refs
+): $ZodType {
+  if (jsonSchema.allOf.length === 0) {
+    return z.NEVER;
+  }
 
-	if (jsonSchema.allOf.length === 1) {
-		const item = jsonSchema.allOf[0];
+  if (jsonSchema.allOf.length === 1) {
+    const item = jsonSchema.allOf[0];
 
-		return parseSchema(item, {
-			...refs,
-			path: [...refs.path, 'allOf', (item as never)[originalIndex]],
-		});
-	}
+    return parseSchema(item, {
+      ...refs,
+      path: [...refs.path, 'allOf', (item as never)[originalIndex]],
+    });
+  }
 
-	const [left, right] = half(ensureOriginalIndex(jsonSchema.allOf));
+  const [left, right] = half(ensureOriginalIndex(jsonSchema.allOf));
 
-	return z.intersection(parseAllOf({ allOf: left }, refs), parseAllOf({ allOf: right }, refs));
+  return z.intersection(parseAllOf({ allOf: left }, refs), parseAllOf({ allOf: right }, refs));
 }

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-any-of.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-any-of.ts
@@ -1,19 +1,20 @@
-import { z } from 'zod';
+import { $ZodType } from 'zod/v4/core';
+import * as z from 'zod';
 
 import { parseSchema } from './parse-schema';
 import type { JsonSchemaObject, JsonSchema, Refs } from '../types';
 
 export const parseAnyOf = (jsonSchema: JsonSchemaObject & { anyOf: JsonSchema[] }, refs: Refs) => {
-	return jsonSchema.anyOf.length
-		? jsonSchema.anyOf.length === 1
-			? parseSchema(jsonSchema.anyOf[0], {
-					...refs,
-					path: [...refs.path, 'anyOf', 0],
-				})
-			: z.union(
-					jsonSchema.anyOf.map((schema, i) =>
-						parseSchema(schema, { ...refs, path: [...refs.path, 'anyOf', i] }),
-					) as [z.ZodTypeAny, z.ZodTypeAny],
-				)
-		: z.any();
+  return jsonSchema.anyOf.length
+    ? jsonSchema.anyOf.length === 1
+      ? parseSchema(jsonSchema.anyOf[0], {
+          ...refs,
+          path: [...refs.path, 'anyOf', 0],
+        })
+      : z.union(
+          jsonSchema.anyOf.map((schema, i) =>
+            parseSchema(schema, { ...refs, path: [...refs.path, 'anyOf', i] })
+          ) as [$ZodType, $ZodType]
+        )
+    : z.any();
 };

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-array.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-array.ts
@@ -1,4 +1,5 @@
-import { z } from 'zod';
+import { $ZodType } from 'zod/v4/core';
+import * as z from 'zod';
 
 import { parseSchema } from './parse-schema';
 import type { JsonSchemaObject, Refs, JsonSchema } from '../types';
@@ -62,7 +63,7 @@ export const parseArray = (jsonSchema: JsonSchemaObject & { type: 'array' }, ref
     return z.tuple(
       jsonSchema.items.map((v, i) =>
         parseSchema(v, { ...refs, path: [...refs.path, 'items', i] })
-      ) as [z.ZodTypeAny]
+      ) as [$ZodType]
     );
   }
 

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-boolean.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-boolean.ts
@@ -1,7 +1,7 @@
-import { z } from 'zod';
+import * as z from 'zod';
 
 import type { JsonSchemaObject } from '../types';
 
 export const parseBoolean = (_jsonSchema: JsonSchemaObject & { type: 'boolean' }) => {
-	return z.boolean();
+  return z.boolean();
 };

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-const.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-const.ts
@@ -1,7 +1,7 @@
-import { z } from 'zod';
+import * as z from 'zod';
 
 import type { JsonSchemaObject, Serializable } from '../types';
 
 export const parseConst = (jsonSchema: JsonSchemaObject & { const: Serializable }) => {
-	return z.literal(jsonSchema.const as z.Primitive);
+  return z.literal(jsonSchema.const as z.Primitive);
 };

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-default.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-default.ts
@@ -1,7 +1,7 @@
-import { z } from 'zod';
+import * as z from 'zod';
 
 import type { JsonSchemaObject } from '../types';
 
 export const parseDefault = (_jsonSchema: JsonSchemaObject) => {
-	return z.any();
+  return z.any();
 };

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-enum.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-enum.ts
@@ -1,25 +1,22 @@
-import { z } from 'zod';
+import * as z from 'zod';
 
 import type { JsonSchemaObject, Serializable } from '../types';
 
 export const parseEnum = (jsonSchema: JsonSchemaObject & { enum: Serializable[] }) => {
-	if (jsonSchema.enum.length === 0) {
-		return z.never();
-	}
+  if (jsonSchema.enum.length === 0) {
+    return z.never();
+  }
 
-	if (jsonSchema.enum.length === 1) {
-		// union does not work when there is only one element
-		return z.literal(jsonSchema.enum[0] as z.Primitive);
-	}
+  if (jsonSchema.enum.length === 1) {
+    // union does not work when there is only one element
+    return z.literal(jsonSchema.enum[0] as z.Primitive);
+  }
 
-	if (jsonSchema.enum.every((x) => typeof x === 'string')) {
-		return z.enum(jsonSchema.enum as [string]);
-	}
+  if (jsonSchema.enum.every(x => typeof x === 'string')) {
+    return z.enum(jsonSchema.enum as [string]);
+  }
 
-	return z.union(
-		jsonSchema.enum.map((x) => z.literal(x as z.Primitive)) as unknown as [
-			z.ZodTypeAny,
-			z.ZodTypeAny,
-		],
-	);
+  return z.union(
+    jsonSchema.enum.map(x => z.literal(x as z.Primitive)) as unknown as [z.ZodTypeAny, z.ZodTypeAny]
+  );
 };

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-if-then-else.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-if-then-else.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { parseSchema } from './parse-schema';
 import type { JsonSchemaObject, JsonSchema, Refs } from '../types';

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-multiple-type.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-multiple-type.ts
@@ -1,16 +1,16 @@
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { parseSchema } from './parse-schema';
 import type { JsonSchema, JsonSchemaObject, Refs } from '../types';
 
 export const parseMultipleType = (
-	jsonSchema: JsonSchemaObject & { type: string[] },
-	refs: Refs,
+  jsonSchema: JsonSchemaObject & { type: string[] },
+  refs: Refs
 ) => {
-	return z.union(
-		jsonSchema.type.map((type) => parseSchema({ ...jsonSchema, type } as JsonSchema, refs)) as [
-			z.ZodTypeAny,
-			z.ZodTypeAny,
-		],
-	);
+  return z.union(
+    jsonSchema.type.map(type => parseSchema({ ...jsonSchema, type } as JsonSchema, refs)) as [
+      z.ZodTypeAny,
+      z.ZodTypeAny,
+    ]
+  );
 };

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-not.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-not.ts
@@ -1,15 +1,15 @@
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { parseSchema } from './parse-schema';
 import type { JsonSchemaObject, JsonSchema, Refs } from '../types';
 
 export const parseNot = (jsonSchema: JsonSchemaObject & { not: JsonSchema }, refs: Refs) => {
-	return z.any().refine(
-		(value) =>
-			!parseSchema(jsonSchema.not, {
-				...refs,
-				path: [...refs.path, 'not'],
-			}).safeParse(value).success,
-		'Invalid input: Should NOT be valid against schema',
-	);
+  return z.any().refine(
+    value =>
+      !parseSchema(jsonSchema.not, {
+        ...refs,
+        path: [...refs.path, 'not'],
+      }).safeParse(value).success,
+    'Invalid input: Should NOT be valid against schema'
+  );
 };

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-null.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-null.ts
@@ -1,7 +1,7 @@
-import { z } from 'zod';
+import * as z from 'zod';
 
 import type { JsonSchemaObject } from '../types';
 
 export const parseNull = (_jsonSchema: JsonSchemaObject & { type: 'null' }) => {
-	return z.null();
+  return z.null();
 };

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-number.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-number.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import * as z from 'zod';
 
 import type { JsonSchemaObject } from '../types';
 import { extendSchemaWithMessage } from '../utils/extend-schema';

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-object.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-object.ts
@@ -61,16 +61,16 @@ function parseObjectProperties(objectSchema: JsonSchemaObject & { type: 'object'
 
         if (hasAnyOfWithNull || hasOneOfWithNull || isNullable) {
           // The schema already handles null through anyOf/oneOf/nullable, just make it optional with default
-          properties[key] = propZodSchema.optional().default(null);
+          properties[key] = z.optional(propZodSchema).default(null);
         } else {
           // Make the field nullable with the null default
-          properties[key] = propZodSchema.nullable().optional().default(null);
+          properties[key] = z.nullable(z.optional(propZodSchema)).default(null);
         }
       } else {
-        properties[key] = propZodSchema.optional().default(propJsonSchema.default);
+        properties[key] = z.optional(propZodSchema).default(propJsonSchema.default);
       }
     } else {
-      properties[key] = required ? propZodSchema : propZodSchema.optional();
+      properties[key] = required ? propZodSchema : z.optional(propZodSchema);
     }
   }
 
@@ -188,7 +188,11 @@ export function parseObject(
         output = propertiesSchema.passthrough();
       } else {
         // Check if propertiesSchema is an empty object
-        const isEmptyObject = Object.keys(propertiesSchema._def.shape()).length === 0;
+        const shape =
+          '_zod' in propertiesSchema
+            ? propertiesSchema._zod.def.shape
+            : propertiesSchema._def.shape();
+        const isEmptyObject = Object.keys(shape).length === 0;
         if (isEmptyObject) {
           output = propertiesSchema.passthrough();
         } else {

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-one-of.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-one-of.ts
@@ -1,41 +1,42 @@
-import { z } from 'zod';
+import { $ZodError } from 'zod/v4/core';
+import * as z from 'zod';
 
 import { parseSchema } from './parse-schema';
 import type { JsonSchemaObject, JsonSchema, Refs } from '../types';
 
 export const parseOneOf = (jsonSchema: JsonSchemaObject & { oneOf: JsonSchema[] }, refs: Refs) => {
-	if (!jsonSchema.oneOf.length) {
-		return z.any();
-	}
+  if (!jsonSchema.oneOf.length) {
+    return z.any();
+  }
 
-	if (jsonSchema.oneOf.length === 1) {
-		return parseSchema(jsonSchema.oneOf[0], {
-			...refs,
-			path: [...refs.path, 'oneOf', 0],
-		});
-	}
+  if (jsonSchema.oneOf.length === 1) {
+    return parseSchema(jsonSchema.oneOf[0], {
+      ...refs,
+      path: [...refs.path, 'oneOf', 0],
+    });
+  }
 
-	return z.any().superRefine((x, ctx) => {
-		const schemas = jsonSchema.oneOf.map((schema, i) =>
-			parseSchema(schema, {
-				...refs,
-				path: [...refs.path, 'oneOf', i],
-			}),
-		);
+  return z.any().superRefine((x, ctx) => {
+    const schemas = jsonSchema.oneOf.map((schema, i) =>
+      parseSchema(schema, {
+        ...refs,
+        path: [...refs.path, 'oneOf', i],
+      })
+    );
 
-		const unionErrors = schemas.reduce<z.ZodError[]>(
-			(errors, schema) =>
-				((result) => (result.error ? [...errors, result.error] : errors))(schema.safeParse(x)),
-			[],
-		);
+    const unionErrors = schemas.reduce<$ZodError[]>(
+      (errors, schema) =>
+        (result => (result.error ? [...errors, result.error] : errors))(z.safeParse(schema, x)),
+      []
+    );
 
-		if (schemas.length - unionErrors.length !== 1) {
-			ctx.addIssue({
-				path: ctx.path,
-				code: 'invalid_union',
-				unionErrors,
-				message: 'Invalid input: Should pass single schema',
-			});
-		}
-	});
+    if (schemas.length - unionErrors.length !== 1) {
+      ctx.addIssue({
+        path: ctx.path,
+        code: 'invalid_union',
+        unionErrors,
+        message: 'Invalid input: Should pass single schema',
+      });
+    }
+  });
 };

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-string.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-string.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import * as z from 'zod';
 
 import type { JsonSchemaObject } from '../types';
 import { extendSchemaWithMessage } from '../utils/extend-schema';
@@ -11,11 +11,11 @@ export const parseString = (jsonSchema: JsonSchemaObject & { type: 'string' }) =
       case 'email':
         return zs.email(errorMsg);
       case 'ip':
-        return zs.ip(errorMsg);
+        return zs.ipv4(errorMsg);
       case 'ipv4':
-        return zs.ip({ version: 'v4', message: errorMsg });
+        return zs.ipv4({ message: errorMsg });
       case 'ipv6':
-        return zs.ip({ version: 'v6', message: errorMsg });
+        return zs.ipv6({ message: errorMsg });
       case 'uri':
         return zs.url(errorMsg);
       case 'uuid':

--- a/ts/packages/json-schema-to-zod/src/types.ts
+++ b/ts/packages/json-schema-to-zod/src/types.ts
@@ -1,4 +1,4 @@
-import type { ZodTypeAny } from 'zod';
+import type { $ZodType } from 'zod/v4/core';
 import type { JSONSchema7 } from 'json-schema';
 
 export type Serializable =
@@ -11,8 +11,8 @@ export type Serializable =
 
 export type JsonSchema = JsonSchemaObject | boolean;
 export type JsonSchemaObject = JSONSchema7;
-export type ParserSelector = (schema: JsonSchemaObject, refs: Refs) => ZodTypeAny;
-export type ParserOverride = (schema: JsonSchemaObject, refs: Refs) => ZodTypeAny | undefined;
+export type ParserSelector = (schema: JsonSchemaObject, refs: Refs) => $ZodType;
+export type ParserOverride = (schema: JsonSchemaObject, refs: Refs) => $ZodType | undefined;
 
 export type JsonSchemaToZodOptions = {
   withoutDefaults?: boolean;
@@ -23,5 +23,5 @@ export type JsonSchemaToZodOptions = {
 
 export type Refs = JsonSchemaToZodOptions & {
   path: Array<string | number>;
-  seen: Map<object | boolean, { n: number; r: ZodTypeAny | undefined }>;
+  seen: Map<object | boolean, { n: number; r: $ZodType | undefined }>;
 };

--- a/ts/packages/json-schema-to-zod/src/utils/extend-schema.ts
+++ b/ts/packages/json-schema-to-zod/src/utils/extend-schema.ts
@@ -1,9 +1,9 @@
-import type { z } from 'zod';
+import type { $ZodType } from 'zod/v4/core';
 
 import type { JsonSchemaObject } from '../types';
 
 export function extendSchemaWithMessage<
-  TZod extends z.ZodTypeAny,
+  TZod extends $ZodType,
   TJson extends JsonSchemaObject,
   TKey extends keyof TJson,
 >(

--- a/ts/packages/json-schema-to-zod/test/comprehensive-edge-case-tests.ts
+++ b/ts/packages/json-schema-to-zod/test/comprehensive-edge-case-tests.ts
@@ -1,5 +1,5 @@
+import { toJSONSchema } from 'zod/v4/core';
 import { jsonSchemaToZod } from '../src/json-schema-to-zod';
-import zodToJsonSchema from 'zod-to-json-schema';
 import type { JsonSchema } from '../src/types';
 
 console.log('=== Testing Complex Schema Edge Cases ===\n');
@@ -52,7 +52,7 @@ console.log('Original schema:');
 console.log(JSON.stringify(originalAnyOfSchema, null, 2));
 
 const zodSchema1 = jsonSchemaToZod(originalAnyOfSchema);
-const backToJson1 = zodToJsonSchema(zodSchema1, { target: 'jsonSchema7' });
+const backToJson1 = toJSONSchema(zodSchema1, { target: 'jsonSchema7' });
 
 console.log('\nConverted back to JSON:');
 console.log(JSON.stringify(backToJson1, null, 2));
@@ -130,7 +130,7 @@ console.log('Original schema:');
 console.log(JSON.stringify(arrayUnionSchema, null, 2));
 
 const zodSchema2 = jsonSchemaToZod(arrayUnionSchema);
-const backToJson2 = zodToJsonSchema(zodSchema2, { target: 'jsonSchema7' });
+const backToJson2 = toJSONSchema(zodSchema2, { target: 'jsonSchema7' });
 
 console.log('\nConverted back to JSON:');
 console.log(JSON.stringify(backToJson2, null, 2));
@@ -229,7 +229,7 @@ console.log('Original schema:');
 console.log(JSON.stringify(complexNestedSchema, null, 2));
 
 const zodSchema3 = jsonSchemaToZod(complexNestedSchema);
-const backToJson3 = zodToJsonSchema(zodSchema3, { target: 'jsonSchema7' });
+const backToJson3 = toJSONSchema(zodSchema3, { target: 'jsonSchema7' });
 
 console.log('\nConverted back to JSON:');
 console.log(JSON.stringify(backToJson3, null, 2));

--- a/ts/packages/json-schema-to-zod/test/json-to-zod.test.ts
+++ b/ts/packages/json-schema-to-zod/test/json-to-zod.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { z } from 'zod';
-import zodToJsonSchema from 'zod-to-json-schema';
+import * as z from 'zod/v4/core';
 import { jsonSchemaToZod } from '../src/json-schema-to-zod';
 import type { JsonSchema } from '../src/types';
+import { $ZodType } from 'zod/v4/core';
 
 describe('jsonSchemaToZod', () => {
   describe('Basic Types', () => {
@@ -11,9 +11,9 @@ describe('jsonSchemaToZod', () => {
         type: 'string',
       };
       const zodSchema = jsonSchemaToZod(schema);
-      expect(zodSchema).toBeInstanceOf(z.ZodString);
-      expect(zodSchema.parse('test')).toBe('test');
-      expect(() => zodSchema.parse(123)).toThrow();
+      expect(zodSchema).toBeInstanceOf(z.$ZodString);
+      expect(z.parse(zodSchema, 'test')).toBe('test');
+      expect(() => z.parse(zodSchema, 123)).toThrow();
     });
 
     it('should convert number schema', () => {
@@ -21,9 +21,9 @@ describe('jsonSchemaToZod', () => {
         type: 'number',
       };
       const zodSchema = jsonSchemaToZod(schema);
-      expect(zodSchema).toBeInstanceOf(z.ZodNumber);
-      expect(zodSchema.parse(123)).toBe(123);
-      expect(() => zodSchema.parse('123')).toThrow();
+      expect(zodSchema).toBeInstanceOf(z.$ZodNumber);
+      expect(z.parse(zodSchema, 123)).toBe(123);
+      expect(() => z.parse(zodSchema, '123')).toThrow();
     });
 
     it('should convert integer schema', () => {
@@ -31,8 +31,8 @@ describe('jsonSchemaToZod', () => {
         type: 'integer',
       };
       const zodSchema = jsonSchemaToZod(schema);
-      expect(zodSchema.parse(123)).toBe(123);
-      expect(() => zodSchema.parse(123.45)).toThrow();
+      expect(z.parse(zodSchema, 123)).toBe(123);
+      expect(() => z.parse(zodSchema, 123.45)).toThrow();
     });
 
     it('should convert boolean schema', () => {
@@ -40,9 +40,9 @@ describe('jsonSchemaToZod', () => {
         type: 'boolean',
       };
       const zodSchema = jsonSchemaToZod(schema);
-      expect(zodSchema).toBeInstanceOf(z.ZodBoolean);
-      expect(zodSchema.parse(true)).toBe(true);
-      expect(() => zodSchema.parse('true')).toThrow();
+      expect(zodSchema).toBeInstanceOf(z.$ZodBoolean);
+      expect(z.parse(zodSchema, true)).toBe(true);
+      expect(() => z.parse(zodSchema, 'true')).toThrow();
     });
 
     it('should convert null schema', () => {
@@ -50,9 +50,9 @@ describe('jsonSchemaToZod', () => {
         type: 'null',
       };
       const zodSchema = jsonSchemaToZod(schema);
-      expect(zodSchema).toBeInstanceOf(z.ZodNull);
-      expect(zodSchema.parse(null)).toBe(null);
-      expect(() => zodSchema.parse(undefined)).toThrow();
+      expect(zodSchema).toBeInstanceOf(z.$ZodNull);
+      expect(z.parse(zodSchema, null)).toBe(null);
+      expect(() => z.parse(zodSchema, undefined)).toThrow();
     });
   });
 
@@ -63,8 +63,8 @@ describe('jsonSchemaToZod', () => {
         format: 'email',
       };
       const zodSchema = jsonSchemaToZod(schema);
-      expect(zodSchema.parse('test@example.com')).toBe('test@example.com');
-      expect(() => zodSchema.parse('invalid-email')).toThrow();
+      expect(z.parse(zodSchema, 'test@example.com')).toBe('test@example.com');
+      expect(() => z.parse(zodSchema, 'invalid-email')).toThrow();
     });
 
     it('should validate date-time format', () => {
@@ -73,8 +73,8 @@ describe('jsonSchemaToZod', () => {
         format: 'date-time',
       };
       const zodSchema = jsonSchemaToZod(schema);
-      expect(zodSchema.parse('2024-03-20T12:00:00Z')).toBe('2024-03-20T12:00:00Z');
-      expect(() => zodSchema.parse('invalid-date')).toThrow();
+      expect(z.parse(zodSchema, '2024-03-20T12:00:00Z')).toBe('2024-03-20T12:00:00Z');
+      expect(() => z.parse(zodSchema, 'invalid-date')).toThrow();
     });
 
     it('should validate uuid format', () => {
@@ -83,10 +83,10 @@ describe('jsonSchemaToZod', () => {
         format: 'uuid',
       };
       const zodSchema = jsonSchemaToZod(schema);
-      expect(zodSchema.parse('123e4567-e89b-12d3-a456-426614174000')).toBe(
+      expect(z.parse(zodSchema, '123e4567-e89b-12d3-a456-426614174000')).toBe(
         '123e4567-e89b-12d3-a456-426614174000'
       );
-      expect(() => zodSchema.parse('invalid-uuid')).toThrow();
+      expect(() => z.parse(zodSchema, 'invalid-uuid')).toThrow();
     });
   });
 
@@ -98,9 +98,9 @@ describe('jsonSchemaToZod', () => {
         maximum: 100,
       };
       const zodSchema = jsonSchemaToZod(schema);
-      expect(zodSchema.parse(50)).toBe(50);
-      expect(() => zodSchema.parse(-1)).toThrow();
-      expect(() => zodSchema.parse(101)).toThrow();
+      expect(z.parse(zodSchema, 50)).toBe(50);
+      expect(() => z.parse(zodSchema, -1)).toThrow();
+      expect(() => z.parse(zodSchema, 101)).toThrow();
     });
 
     it('should validate exclusive minimum and maximum', () => {
@@ -110,9 +110,9 @@ describe('jsonSchemaToZod', () => {
         exclusiveMaximum: 100,
       };
       const zodSchema = jsonSchemaToZod(schema);
-      expect(zodSchema.parse(50)).toBe(50);
-      expect(() => zodSchema.parse(0)).toThrow();
-      expect(() => zodSchema.parse(100)).toThrow();
+      expect(z.parse(zodSchema, 50)).toBe(50);
+      expect(() => z.parse(zodSchema, 0)).toThrow();
+      expect(() => z.parse(zodSchema, 100)).toThrow();
     });
 
     it('should validate multipleOf', () => {
@@ -121,8 +121,8 @@ describe('jsonSchemaToZod', () => {
         multipleOf: 5,
       };
       const zodSchema = jsonSchemaToZod(schema);
-      expect(zodSchema.parse(15)).toBe(15);
-      expect(() => zodSchema.parse(17)).toThrow();
+      expect(z.parse(zodSchema, 15)).toBe(15);
+      expect(() => z.parse(zodSchema, 17)).toThrow();
     });
 
     it('should handle generic min and max properties for numbers', () => {
@@ -132,9 +132,9 @@ describe('jsonSchemaToZod', () => {
         max: 100,
       } as any;
       const zodSchema = jsonSchemaToZod(schema);
-      expect(zodSchema.parse(50)).toBe(50);
-      expect(() => zodSchema.parse(-1)).toThrow();
-      expect(() => zodSchema.parse(101)).toThrow();
+      expect(z.parse(zodSchema, 50)).toBe(50);
+      expect(() => z.parse(zodSchema, -1)).toThrow();
+      expect(() => z.parse(zodSchema, 101)).toThrow();
     });
 
     it('should prioritize minimum/maximum over min/max for numbers', () => {
@@ -146,11 +146,11 @@ describe('jsonSchemaToZod', () => {
         max: 100,
       } as any;
       const zodSchema = jsonSchemaToZod(schema);
-      expect(zodSchema.parse(50)).toBe(50);
-      expect(zodSchema.parse(10)).toBe(10);
-      expect(zodSchema.parse(90)).toBe(90);
-      expect(() => zodSchema.parse(5)).toThrow(); // Uses minimum (10), not min (0)
-      expect(() => zodSchema.parse(95)).toThrow(); // Uses maximum (90), not max (100)
+      expect(z.parse(zodSchema, 50)).toBe(50);
+      expect(z.parse(zodSchema, 10)).toBe(10);
+      expect(z.parse(zodSchema, 90)).toBe(90);
+      expect(() => z.parse(zodSchema, 5)).toThrow(); // Uses minimum (10), not min (0)
+      expect(() => z.parse(zodSchema, 95)).toThrow(); // Uses maximum (90), not max (100)
     });
   });
 
@@ -162,9 +162,9 @@ describe('jsonSchemaToZod', () => {
         max: 10,
       } as any;
       const zodSchema = jsonSchemaToZod(schema);
-      expect(zodSchema.parse('hello')).toBe('hello');
-      expect(() => zodSchema.parse('hi')).toThrow();
-      expect(() => zodSchema.parse('this is too long')).toThrow();
+      expect(z.parse(zodSchema, 'hello')).toBe('hello');
+      expect(() => z.parse(zodSchema, 'hi')).toThrow();
+      expect(() => z.parse(zodSchema, 'this is too long')).toThrow();
     });
 
     it('should prioritize minLength/maxLength over min/max for strings', () => {
@@ -176,10 +176,10 @@ describe('jsonSchemaToZod', () => {
         max: 10,
       } as any;
       const zodSchema = jsonSchemaToZod(schema);
-      expect(zodSchema.parse('hello')).toBe('hello');
-      expect(zodSchema.parse('testing')).toBe('testing');
-      expect(() => zodSchema.parse('test')).toThrow(); // Uses minLength (5), not min (3)
-      expect(() => zodSchema.parse('toolongstring')).toThrow(); // Uses maxLength (8), not max (10)
+      expect(z.parse(zodSchema, 'hello')).toBe('hello');
+      expect(z.parse(zodSchema, 'testing')).toBe('testing');
+      expect(() => z.parse(zodSchema, 'test')).toThrow(); // Uses minLength (5), not min (3)
+      expect(() => z.parse(zodSchema, 'toolongstring')).toThrow(); // Uses maxLength (8), not max (10)
     });
   });
 
@@ -194,9 +194,9 @@ describe('jsonSchemaToZod', () => {
         required: ['name'],
       };
       const zodSchema = jsonSchemaToZod(schema);
-      expect(zodSchema.parse({ name: 'John', age: 30 })).toEqual({ name: 'John', age: 30 });
-      expect(zodSchema.parse({ name: 'John' })).toEqual({ name: 'John' });
-      expect(() => zodSchema.parse({ age: 30 })).toThrow();
+      expect(z.parse(zodSchema, { name: 'John', age: 30 })).toEqual({ name: 'John', age: 30 });
+      expect(z.parse(zodSchema, { name: 'John' })).toEqual({ name: 'John' });
+      expect(() => z.parse(zodSchema, { age: 30 })).toThrow();
     });
 
     it('should validate additional properties when set to false', () => {
@@ -208,8 +208,8 @@ describe('jsonSchemaToZod', () => {
         additionalProperties: false,
       };
       const zodSchema = jsonSchemaToZod(schema);
-      expect(zodSchema.parse({ name: 'John' })).toEqual({ name: 'John' });
-      expect(() => zodSchema.parse({ name: 'John', extra: 'field' })).toThrow();
+      expect(z.parse(zodSchema, { name: 'John' })).toEqual({ name: 'John' });
+      expect(() => z.parse(zodSchema, { name: 'John', extra: 'field' })).toThrow();
     });
 
     it('should allow any additional properties when set to true', () => {
@@ -221,12 +221,12 @@ describe('jsonSchemaToZod', () => {
         additionalProperties: true,
       };
       const zodSchema = jsonSchemaToZod(schema);
-      expect(zodSchema.parse({ name: 'John' })).toEqual({ name: 'John' });
-      expect(zodSchema.parse({ name: 'John', extra: 'field' })).toEqual({
+      expect(z.parse(zodSchema, { name: 'John' })).toEqual({ name: 'John' });
+      expect(z.parse(zodSchema, { name: 'John', extra: 'field' })).toEqual({
         name: 'John',
         extra: 'field',
       });
-      expect(zodSchema.parse({ name: 'John', age: 30, city: 'NYC' })).toEqual({
+      expect(z.parse(zodSchema, { name: 'John', age: 30, city: 'NYC' })).toEqual({
         name: 'John',
         age: 30,
         city: 'NYC',
@@ -242,12 +242,12 @@ describe('jsonSchemaToZod', () => {
         additionalProperties: { type: 'number' },
       };
       const zodSchema = jsonSchemaToZod(schema);
-      expect(zodSchema.parse({ name: 'John' })).toEqual({ name: 'John' });
-      expect(zodSchema.parse({ name: 'John', age: 30 })).toEqual({
+      expect(z.parse(zodSchema, { name: 'John' })).toEqual({ name: 'John' });
+      expect(z.parse(zodSchema, { name: 'John', age: 30 })).toEqual({
         name: 'John',
         age: 30,
       });
-      expect(() => zodSchema.parse({ name: 'John', extra: 'field' })).toThrow();
+      expect(() => z.parse(zodSchema, { name: 'John', extra: 'field' })).toThrow();
     });
 
     it('should validate additional properties with complex schema', () => {
@@ -267,7 +267,7 @@ describe('jsonSchemaToZod', () => {
       };
       const zodSchema = jsonSchemaToZod(schema);
       expect(
-        zodSchema.parse({
+        z.parse(zodSchema, {
           name: 'John',
           metadata: { value: 'test', count: 5 },
         })
@@ -276,7 +276,7 @@ describe('jsonSchemaToZod', () => {
         metadata: { value: 'test', count: 5 },
       });
       expect(
-        zodSchema.parse({
+        z.parse(zodSchema, {
           name: 'John',
           metadata: { value: 'test' },
         })
@@ -285,7 +285,7 @@ describe('jsonSchemaToZod', () => {
         metadata: { value: 'test' },
       });
       expect(() =>
-        zodSchema.parse({
+        z.parse(zodSchema, {
           name: 'John',
           metadata: { count: 5 }, // missing required 'value'
         })
@@ -300,8 +300,8 @@ describe('jsonSchemaToZod', () => {
         },
       };
       const zodSchema = jsonSchemaToZod(schema);
-      expect(zodSchema.parse({ name: 'John' })).toEqual({ name: 'John' });
-      expect(zodSchema.parse({ name: 'John', extra: 'field' })).toEqual({
+      expect(z.parse(zodSchema, { name: 'John' })).toEqual({ name: 'John' });
+      expect(z.parse(zodSchema, { name: 'John', extra: 'field' })).toEqual({
         name: 'John',
         extra: 'field',
       });
@@ -321,11 +321,11 @@ describe('jsonSchemaToZod', () => {
       const zodSchema = jsonSchemaToZod(schema);
 
       // Should allow defined properties
-      expect(zodSchema.parse({ name: 'John' })).toEqual({ name: 'John' });
+      expect(z.parse(zodSchema, { name: 'John' })).toEqual({ name: 'John' });
 
       // Should allow pattern properties
       expect(
-        zodSchema.parse({
+        z.parse(zodSchema, {
           name: 'John',
           prefix_test: 'value',
         })
@@ -336,7 +336,7 @@ describe('jsonSchemaToZod', () => {
 
       // Should allow additional properties matching the schema
       expect(
-        zodSchema.parse({
+        z.parse(zodSchema, {
           name: 'John',
           age: 30,
         })
@@ -347,7 +347,7 @@ describe('jsonSchemaToZod', () => {
 
       // Should reject additional properties not matching the schema
       expect(() =>
-        zodSchema.parse({
+        z.parse(zodSchema, {
           name: 'John',
           extra: 'field', // string, but additionalProperties expects number
         })
@@ -360,12 +360,12 @@ describe('jsonSchemaToZod', () => {
         additionalProperties: { type: 'string' },
       };
       const zodSchema = jsonSchemaToZod(schema);
-      expect(zodSchema.parse({})).toEqual({});
-      expect(zodSchema.parse({ key1: 'value1', key2: 'value2' })).toEqual({
+      expect(z.parse(zodSchema, {})).toEqual({});
+      expect(z.parse(zodSchema, { key1: 'value1', key2: 'value2' })).toEqual({
         key1: 'value1',
         key2: 'value2',
       });
-      expect(() => zodSchema.parse({ key1: 123 })).toThrow();
+      expect(() => z.parse(zodSchema, { key1: 123 })).toThrow();
     });
 
     it('should handle additionalProperties: false with patternProperties', () => {
@@ -381,9 +381,9 @@ describe('jsonSchemaToZod', () => {
       };
       const zodSchema = jsonSchemaToZod(schema);
 
-      expect(zodSchema.parse({ name: 'John' })).toEqual({ name: 'John' });
+      expect(z.parse(zodSchema, { name: 'John' })).toEqual({ name: 'John' });
       expect(
-        zodSchema.parse({
+        z.parse(zodSchema, {
           name: 'John',
           prefix_test: 'value',
         })
@@ -394,7 +394,7 @@ describe('jsonSchemaToZod', () => {
 
       // Should reject properties that don't match patterns or defined properties
       expect(() =>
-        zodSchema.parse({
+        z.parse(zodSchema, {
           name: 'John',
           extra: 'field',
         })
@@ -407,8 +407,8 @@ describe('jsonSchemaToZod', () => {
         additionalProperties: true,
       };
       const zodSchema = jsonSchemaToZod(schema);
-      expect(zodSchema.parse({})).toEqual({});
-      expect(zodSchema.parse({ any: 'value', another: 123 })).toEqual({
+      expect(z.parse(zodSchema, {})).toEqual({});
+      expect(z.parse(zodSchema, { any: 'value', another: 123 })).toEqual({
         any: 'value',
         another: 123,
       });
@@ -420,8 +420,8 @@ describe('jsonSchemaToZod', () => {
         additionalProperties: false,
       };
       const zodSchema = jsonSchemaToZod(schema);
-      expect(zodSchema.parse({})).toEqual({});
-      expect(() => zodSchema.parse({ any: 'value' })).toThrow();
+      expect(z.parse(zodSchema, {})).toEqual({});
+      expect(() => z.parse(zodSchema, { any: 'value' })).toThrow();
     });
 
     it('should handle nested additionalProperties', () => {
@@ -441,7 +441,7 @@ describe('jsonSchemaToZod', () => {
       const zodSchema = jsonSchemaToZod(schema);
 
       expect(
-        zodSchema.parse({
+        z.parse(zodSchema, {
           config: { name: 'test', timeout: 5000 },
           env: 'production',
         })
@@ -452,14 +452,14 @@ describe('jsonSchemaToZod', () => {
 
       // Should reject nested additional properties that don't match schema
       expect(() =>
-        zodSchema.parse({
+        z.parse(zodSchema, {
           config: { name: 'test', timeout: 'invalid' }, // should be number
         })
       ).toThrow();
 
       // Should reject top-level additional properties that don't match schema
       expect(() =>
-        zodSchema.parse({
+        z.parse(zodSchema, {
           config: { name: 'test' },
           count: 123, // should be string
         })
@@ -474,11 +474,11 @@ describe('jsonSchemaToZod', () => {
         },
       };
       const zodSchema = jsonSchemaToZod(schema);
-      expect(zodSchema.parse({ prefix_one: 'value1', prefix_two: 'value2' })).toEqual({
+      expect(z.parse(zodSchema, { prefix_one: 'value1', prefix_two: 'value2' })).toEqual({
         prefix_one: 'value1',
         prefix_two: 'value2',
       });
-      expect(() => zodSchema.parse({ prefix_one: 123 })).toThrow();
+      expect(() => z.parse(zodSchema, { prefix_one: 123 })).toThrow();
     });
   });
 
@@ -489,8 +489,8 @@ describe('jsonSchemaToZod', () => {
         items: { type: 'string' },
       };
       const zodSchema = jsonSchemaToZod(schema);
-      expect(zodSchema.parse(['one', 'two'])).toEqual(['one', 'two']);
-      expect(() => zodSchema.parse(['one', 2])).toThrow();
+      expect(z.parse(zodSchema, ['one', 'two'])).toEqual(['one', 'two']);
+      expect(() => z.parse(zodSchema, ['one', 2])).toThrow();
     });
 
     it('should validate tuple items', () => {
@@ -499,8 +499,8 @@ describe('jsonSchemaToZod', () => {
         items: [{ type: 'string' }, { type: 'number' }],
       };
       const zodSchema = jsonSchemaToZod(schema);
-      expect(zodSchema.parse(['test', 123])).toEqual(['test', 123]);
-      expect(() => zodSchema.parse(['test', 'wrong'])).toThrow();
+      expect(z.parse(zodSchema, ['test', 123])).toEqual(['test', 123]);
+      expect(() => z.parse(zodSchema, ['test', 'wrong'])).toThrow();
     });
 
     it('should validate array length', () => {
@@ -511,10 +511,10 @@ describe('jsonSchemaToZod', () => {
         maxItems: 3,
       };
       const zodSchema = jsonSchemaToZod(schema);
-      expect(zodSchema.parse(['one'])).toEqual(['one']);
-      expect(zodSchema.parse(['one', 'two', 'three'])).toEqual(['one', 'two', 'three']);
-      expect(() => zodSchema.parse([])).toThrow();
-      expect(() => zodSchema.parse(['one', 'two', 'three', 'four'])).toThrow();
+      expect(z.parse(zodSchema, ['one'])).toEqual(['one']);
+      expect(z.parse(zodSchema, ['one', 'two', 'three'])).toEqual(['one', 'two', 'three']);
+      expect(() => z.parse(zodSchema, [])).toThrow();
+      expect(() => z.parse(zodSchema, ['one', 'two', 'three', 'four'])).toThrow();
     });
 
     it('should handle generic min and max properties for arrays', () => {
@@ -525,10 +525,10 @@ describe('jsonSchemaToZod', () => {
         max: 3,
       } as any;
       const zodSchema = jsonSchemaToZod(schema);
-      expect(zodSchema.parse(['one'])).toEqual(['one']);
-      expect(zodSchema.parse(['one', 'two', 'three'])).toEqual(['one', 'two', 'three']);
-      expect(() => zodSchema.parse([])).toThrow();
-      expect(() => zodSchema.parse(['one', 'two', 'three', 'four'])).toThrow();
+      expect(z.parse(zodSchema, ['one'])).toEqual(['one']);
+      expect(z.parse(zodSchema, ['one', 'two', 'three'])).toEqual(['one', 'two', 'three']);
+      expect(() => z.parse(zodSchema, [])).toThrow();
+      expect(() => z.parse(zodSchema, ['one', 'two', 'three', 'four'])).toThrow();
     });
 
     it('should prioritize minItems/maxItems over min/max for arrays', () => {
@@ -541,15 +541,15 @@ describe('jsonSchemaToZod', () => {
         max: 3,
       } as any;
       const zodSchema = jsonSchemaToZod(schema);
-      expect(zodSchema.parse(['one', 'two'])).toEqual(['one', 'two']);
-      expect(zodSchema.parse(['one', 'two', 'three', 'four'])).toEqual([
+      expect(z.parse(zodSchema, ['one', 'two'])).toEqual(['one', 'two']);
+      expect(z.parse(zodSchema, ['one', 'two', 'three', 'four'])).toEqual([
         'one',
         'two',
         'three',
         'four',
       ]);
-      expect(() => zodSchema.parse(['one'])).toThrow(); // Uses minItems (2), not min (1)
-      expect(() => zodSchema.parse(['one', 'two', 'three', 'four', 'five'])).toThrow(); // Uses maxItems (4), not max (3)
+      expect(() => z.parse(zodSchema, ['one'])).toThrow(); // Uses minItems (2), not min (1)
+      expect(() => z.parse(zodSchema, ['one', 'two', 'three', 'four', 'five'])).toThrow(); // Uses maxItems (4), not max (3)
     });
 
     it('should handle arrays with anyOf patterns', () => {
@@ -569,13 +569,13 @@ describe('jsonSchemaToZod', () => {
       const zodSchema = jsonSchemaToZod(schema);
 
       // Should accept string arrays
-      expect(zodSchema.parse(['hello', 'world'])).toEqual(['hello', 'world']);
+      expect(z.parse(zodSchema, ['hello', 'world'])).toEqual(['hello', 'world']);
 
       // Should accept number arrays
-      expect(zodSchema.parse([1, 2, 3])).toEqual([1, 2, 3]);
+      expect(z.parse(zodSchema, [1, 2, 3])).toEqual([1, 2, 3]);
 
       // Should accept mixed arrays (union of item types)
-      expect(zodSchema.parse(['hello', 123])).toEqual(['hello', 123]);
+      expect(z.parse(zodSchema, ['hello', 123])).toEqual(['hello', 123]);
     });
 
     it('should handle arrays with anyOf at top level without explicit types', () => {
@@ -593,10 +593,10 @@ describe('jsonSchemaToZod', () => {
       const zodSchema = jsonSchemaToZod(schema);
 
       // Should accept string arrays
-      expect(zodSchema.parse(['hello', 'world'])).toEqual(['hello', 'world']);
+      expect(z.parse(zodSchema, ['hello', 'world'])).toEqual(['hello', 'world']);
 
       // Should accept number arrays
-      expect(zodSchema.parse([1, 2, 3])).toEqual([1, 2, 3]);
+      expect(z.parse(zodSchema, [1, 2, 3])).toEqual([1, 2, 3]);
     });
 
     it('should handle arrays with object items having default null', () => {
@@ -614,13 +614,13 @@ describe('jsonSchemaToZod', () => {
       const zodSchema = jsonSchemaToZod(schema);
 
       // Should apply default null for missing status
-      expect(zodSchema.parse([{ name: 'test1' }, { name: 'test2', status: 'active' }])).toEqual([
+      expect(z.parse(zodSchema, [{ name: 'test1' }, { name: 'test2', status: 'active' }])).toEqual([
         { name: 'test1', status: null },
         { name: 'test2', status: 'active' },
       ]);
 
       // Should fail for missing required field
-      expect(() => zodSchema.parse([{ status: 'active' }])).toThrow();
+      expect(() => z.parse(zodSchema, [{ status: 'active' }])).toThrow();
     });
 
     it('should handle nested arrays', () => {
@@ -634,7 +634,7 @@ describe('jsonSchemaToZod', () => {
       const zodSchema = jsonSchemaToZod(schema);
 
       expect(
-        zodSchema.parse([
+        z.parse(zodSchema, [
           [1, 2],
           [3, 4, 5],
         ])
@@ -642,7 +642,7 @@ describe('jsonSchemaToZod', () => {
         [1, 2],
         [3, 4, 5],
       ]);
-      expect(() => zodSchema.parse([['string', 2]])).toThrow();
+      expect(() => z.parse(zodSchema, [['string', 2]])).toThrow();
     });
   });
 
@@ -653,8 +653,8 @@ describe('jsonSchemaToZod', () => {
         enum: ['one', 'two', 'three'],
       };
       const zodSchema = jsonSchemaToZod(schema);
-      expect(zodSchema.parse('one')).toBe('one');
-      expect(() => zodSchema.parse('four')).toThrow();
+      expect(z.parse(zodSchema, 'one')).toBe('one');
+      expect(() => z.parse(zodSchema, 'four')).toThrow();
     });
 
     it('should validate mixed type enums', () => {
@@ -662,10 +662,10 @@ describe('jsonSchemaToZod', () => {
         enum: ['string', 123, true],
       };
       const zodSchema = jsonSchemaToZod(schema);
-      expect(zodSchema.parse('string')).toBe('string');
-      expect(zodSchema.parse(123)).toBe(123);
-      expect(zodSchema.parse(true)).toBe(true);
-      expect(() => zodSchema.parse('invalid')).toThrow();
+      expect(z.parse(zodSchema, 'string')).toBe('string');
+      expect(z.parse(zodSchema, 123)).toBe(123);
+      expect(z.parse(zodSchema, true)).toBe(true);
+      expect(() => z.parse(zodSchema, 'invalid')).toThrow();
     });
   });
 
@@ -675,9 +675,9 @@ describe('jsonSchemaToZod', () => {
         anyOf: [{ type: 'string' }, { type: 'number' }],
       };
       const zodSchema = jsonSchemaToZod(schema);
-      expect(zodSchema.parse('test')).toBe('test');
-      expect(zodSchema.parse(123)).toBe(123);
-      expect(() => zodSchema.parse(true)).toThrow();
+      expect(z.parse(zodSchema, 'test')).toBe('test');
+      expect(z.parse(zodSchema, 123)).toBe(123);
+      expect(() => z.parse(zodSchema, true)).toThrow();
     });
 
     it('should validate oneOf', () => {
@@ -688,9 +688,9 @@ describe('jsonSchemaToZod', () => {
         ],
       };
       const zodSchema = jsonSchemaToZod(schema);
-      expect(zodSchema.parse(1)).toBe(1);
-      expect(zodSchema.parse(-1)).toBe(-1);
-      expect(() => zodSchema.parse(0)).toThrow(); // Should fail as 0 matches both schemas
+      expect(z.parse(zodSchema, 1)).toBe(1);
+      expect(z.parse(zodSchema, -1)).toBe(-1);
+      expect(() => z.parse(zodSchema, 0)).toThrow(); // Should fail as 0 matches both schemas
     });
 
     it('should validate allOf', () => {
@@ -701,9 +701,9 @@ describe('jsonSchemaToZod', () => {
         ],
       };
       const zodSchema = jsonSchemaToZod(schema);
-      expect(zodSchema.parse(50)).toBe(50);
-      expect(() => zodSchema.parse(-1)).toThrow();
-      expect(() => zodSchema.parse(101)).toThrow();
+      expect(z.parse(zodSchema, 50)).toBe(50);
+      expect(() => z.parse(zodSchema, -1)).toThrow();
+      expect(() => z.parse(zodSchema, 101)).toThrow();
     });
   });
 
@@ -745,9 +745,9 @@ describe('jsonSchemaToZod', () => {
         },
       };
 
-      expect(zodSchema.parse(validData)).toEqual(validData);
+      expect(z.parse(zodSchema, validData)).toEqual(validData);
       expect(() =>
-        zodSchema.parse({
+        z.parse(zodSchema, {
           user: {
             name: 'John Doe',
             contacts: [{ type: 'invalid', value: 'test' }],
@@ -786,13 +786,13 @@ describe('jsonSchemaToZod', () => {
       expect(zodSchema.description).toBe('A user profile object');
 
       // Test required fields
-      expect(() => zodSchema.parse({})).toThrow();
-      expect(() => zodSchema.parse({ username: 'test' })).toThrow();
-      expect(() => zodSchema.parse({ email: 'test@example.com' })).toThrow();
+      expect(() => z.parse(zodSchema, {})).toThrow();
+      expect(() => z.parse(zodSchema, { username: 'test' })).toThrow();
+      expect(() => z.parse(zodSchema, { email: 'test@example.com' })).toThrow();
 
       // Valid data should pass
       expect(
-        zodSchema.parse({
+        z.parse(zodSchema, {
           username: 'testuser',
           email: 'test@example.com',
         })
@@ -803,7 +803,7 @@ describe('jsonSchemaToZod', () => {
 
       // Optional field should be allowed to be missing
       expect(
-        zodSchema.parse({
+        z.parse(zodSchema, {
           username: 'testuser',
           email: 'test@example.com',
         })
@@ -839,43 +839,43 @@ describe('jsonSchemaToZod', () => {
       const zodSchema = jsonSchemaToZod(schema);
 
       // Test property with type
-      expect(zodSchema.parse({ withType: 'test' })).toEqual({
+      expect(z.parse(zodSchema, { withType: 'test' })).toEqual({
         withType: 'test',
         withoutType: 'default value',
       });
-      expect(() => zodSchema.parse({ withType: 123 })).toThrow();
+      expect(() => z.parse(zodSchema, { withType: 123 })).toThrow();
 
       // Test property without type (should accept any value)
-      expect(zodSchema.parse({ withoutType: 'string value' })).toEqual({
+      expect(z.parse(zodSchema, { withoutType: 'string value' })).toEqual({
         withoutType: 'string value', // Override default
       });
-      expect(zodSchema.parse({ withoutType: 123 })).toEqual({
+      expect(z.parse(zodSchema, { withoutType: 123 })).toEqual({
         withoutType: 123, // Override default
       });
-      expect(zodSchema.parse({ withoutType: { nested: true } })).toEqual({
+      expect(z.parse(zodSchema, { withoutType: { nested: true } })).toEqual({
         withoutType: { nested: true }, // Override default
       });
 
       // Test property with anyOf but no direct type
-      expect(zodSchema.parse({ withAnyOf: 'string value' })).toEqual({
+      expect(z.parse(zodSchema, { withAnyOf: 'string value' })).toEqual({
         withAnyOf: 'string value',
         withoutType: 'default value', // Default value is included
       });
-      expect(zodSchema.parse({ withAnyOf: 123 })).toEqual({
+      expect(z.parse(zodSchema, { withAnyOf: 123 })).toEqual({
         withAnyOf: 123,
         withoutType: 'default value', // Default value is included
       });
-      expect(() => zodSchema.parse({ withAnyOf: true })).toThrow();
+      expect(() => z.parse(zodSchema, { withAnyOf: true })).toThrow();
 
       // Test property with enum but no type
-      expect(zodSchema.parse({ withEnum: 'one' })).toEqual({
+      expect(z.parse(zodSchema, { withEnum: 'one' })).toEqual({
         withEnum: 'one',
         withoutType: 'default value', // Default value is included
       });
-      expect(() => zodSchema.parse({ withEnum: 'invalid' })).toThrow();
+      expect(() => z.parse(zodSchema, { withEnum: 'invalid' })).toThrow();
 
       // Test that default value is included when property is missing
-      expect(zodSchema.parse({})).toEqual({
+      expect(z.parse(zodSchema, {})).toEqual({
         withoutType: 'default value',
       });
     });
@@ -903,14 +903,14 @@ describe('jsonSchemaToZod', () => {
       const zodSchema = jsonSchemaToZod(schema);
 
       // Test default values for top-level property
-      expect(zodSchema.parse({})).toEqual({
+      expect(z.parse(zodSchema, {})).toEqual({
         name: 'Anonymous',
         settings: { theme: 'light' },
       });
 
       // Test that defaults don't override provided values
       expect(
-        zodSchema.parse({
+        z.parse(zodSchema, {
           name: 'John',
           settings: {
             theme: 'dark',
@@ -948,25 +948,25 @@ describe('jsonSchemaToZod', () => {
       const zodSchema = jsonSchemaToZod(schema);
 
       // Test with required field only - should include null default
-      expect(zodSchema.parse({ name: 'John' })).toEqual({
+      expect(z.parse(zodSchema, { name: 'John' })).toEqual({
         name: 'John',
         status: null,
       });
 
       // Test with status explicitly set to null
-      expect(zodSchema.parse({ name: 'John', status: null })).toEqual({
+      expect(z.parse(zodSchema, { name: 'John', status: null })).toEqual({
         name: 'John',
         status: null,
       });
 
       // Test with status set to a string value
-      expect(zodSchema.parse({ name: 'John', status: 'active' })).toEqual({
+      expect(z.parse(zodSchema, { name: 'John', status: 'active' })).toEqual({
         name: 'John',
         status: 'active',
       });
 
       // Test that required field validation still works
-      expect(() => zodSchema.parse({})).toThrow();
+      expect(() => z.parse(zodSchema, {})).toThrow();
     });
 
     it('should transform GetUserRequest schema correctly', () => {
@@ -989,16 +989,17 @@ describe('jsonSchemaToZod', () => {
       expect(zodSchema.description).toBe('GetUserRequest');
 
       // Test required field validation
-      expect(() => zodSchema.parse({})).toThrow();
-      expect(() => zodSchema.parse({ username: 123 })).toThrow();
+      expect(() => z.parse(zodSchema, {})).toThrow();
+      expect(() => z.parse(zodSchema, { username: 123 })).toThrow();
 
       // Test valid data
-      expect(zodSchema.parse({ username: 'testuser' })).toEqual({
+      expect(z.parse(zodSchema, { username: 'testuser' })).toEqual({
         username: 'testuser',
       });
 
       // Test property description
-      const shape = (zodSchema as any)._def.shape();
+      // @ts-ignore
+      const shape = (zodSchema as $ZodType)._zod.def.shape;
       expect(shape.username.description).toBe('The username of the Hacker News user to retrieve.');
     });
 
@@ -1117,7 +1118,7 @@ describe('jsonSchemaToZod', () => {
     // Helper function to test round-trip conversion
     const testRoundTrip = (originalSchema: JsonSchema, expectedAdditionalProperties: any) => {
       const zodSchema = jsonSchemaToZod(originalSchema);
-      const convertedBack = zodToJsonSchema(zodSchema, { target: 'jsonSchema7' }) as any;
+      const convertedBack = z.toJSONSchema(zodSchema, { target: 'draft-7' }) as any;
 
       // Remove $schema field for comparison
       const { $schema, ...cleanConverted } = convertedBack;
@@ -1144,8 +1145,11 @@ describe('jsonSchemaToZod', () => {
       expect(convertedBack.properties).toEqual({});
 
       // Test parsing behavior
-      expect(zodSchema.parse({})).toEqual({});
-      expect(zodSchema.parse({ any: 'value', number: 123 })).toEqual({ any: 'value', number: 123 });
+      expect(z.parse(zodSchema, {})).toEqual({});
+      expect(z.parse(zodSchema, { any: 'value', number: 123 })).toEqual({
+        any: 'value',
+        number: 123,
+      });
     });
 
     it('should preserve additionalProperties: true for objects with properties', () => {
@@ -1167,8 +1171,8 @@ describe('jsonSchemaToZod', () => {
       expect(convertedBack.required).toEqual(['name']);
 
       // Test parsing behavior
-      expect(zodSchema.parse({ name: 'John' })).toEqual({ name: 'John' });
-      expect(zodSchema.parse({ name: 'John', age: 30, extra: 'field' })).toEqual({
+      expect(z.parse(zodSchema, { name: 'John' })).toEqual({ name: 'John' });
+      expect(z.parse(zodSchema, { name: 'John', age: 30, extra: 'field' })).toEqual({
         name: 'John',
         age: 30,
         extra: 'field',
@@ -1182,7 +1186,7 @@ describe('jsonSchemaToZod', () => {
       };
 
       const zodSchema = jsonSchemaToZod(schema);
-      const convertedBack = zodToJsonSchema(zodSchema, { target: 'jsonSchema7' }) as any;
+      const convertedBack = z.toJSONSchema(zodSchema, { target: 'draft-7' }) as any;
 
       // Note: zod-to-json-schema may convert z.object({}).strict() to { not: {} }
       // which is semantically equivalent to additionalProperties: false
@@ -1193,8 +1197,8 @@ describe('jsonSchemaToZod', () => {
       expect(convertedBack.type).toBe('object');
 
       // Test parsing behavior - this is the most important part
-      expect(zodSchema.parse({})).toEqual({});
-      expect(() => zodSchema.parse({ extra: 'field' })).toThrow();
+      expect(z.parse(zodSchema, {})).toEqual({});
+      expect(() => z.parse(zodSchema, { extra: 'field' })).toThrow();
     });
 
     it('should preserve additionalProperties: false for objects with properties', () => {
@@ -1207,14 +1211,14 @@ describe('jsonSchemaToZod', () => {
       };
 
       const zodSchema = jsonSchemaToZod(schema);
-      const convertedBack = zodToJsonSchema(zodSchema, { target: 'jsonSchema7' }) as any;
+      const convertedBack = z.toJSONSchema(zodSchema, { target: 'draft-7' }) as any;
 
       expect(convertedBack.additionalProperties).toBe(false);
       expect(convertedBack.properties).toBeDefined();
 
       // Test parsing behavior
-      expect(zodSchema.parse({ name: 'John' })).toEqual({ name: 'John' });
-      expect(() => zodSchema.parse({ name: 'John', extra: 'field' })).toThrow();
+      expect(z.parse(zodSchema, { name: 'John' })).toEqual({ name: 'John' });
+      expect(() => z.parse(zodSchema, { name: 'John', extra: 'field' })).toThrow();
     });
 
     it('should handle additionalProperties with empty schema {}', () => {
@@ -1227,15 +1231,15 @@ describe('jsonSchemaToZod', () => {
       };
 
       const zodSchema = jsonSchemaToZod(schema);
-      const convertedBack = zodToJsonSchema(zodSchema, { target: 'jsonSchema7' }) as any;
+      const convertedBack = z.toJSONSchema(zodSchema, { target: 'draft-7' }) as any;
 
       // Empty schema {} should remain as {} (not become true)
       expect(convertedBack.additionalProperties).toEqual({});
       expect(convertedBack.properties).toBeDefined();
 
       // Test parsing behavior - should allow any additional properties
-      expect(zodSchema.parse({ name: 'John' })).toEqual({ name: 'John' });
-      expect(zodSchema.parse({ name: 'John', extra: 'field', number: 123 })).toEqual({
+      expect(z.parse(zodSchema, { name: 'John' })).toEqual({ name: 'John' });
+      expect(z.parse(zodSchema, { name: 'John', extra: 'field', number: 123 })).toEqual({
         name: 'John',
         extra: 'field',
         number: 123,
@@ -1252,15 +1256,15 @@ describe('jsonSchemaToZod', () => {
       };
 
       const zodSchema = jsonSchemaToZod(schema);
-      const convertedBack = zodToJsonSchema(zodSchema, { target: 'jsonSchema7' }) as any;
+      const convertedBack = z.toJSONSchema(zodSchema, { target: 'draft-7' }) as any;
 
       expect(convertedBack.additionalProperties).toEqual({ type: 'number' });
       expect(convertedBack.properties).toBeDefined();
 
       // Test parsing behavior
-      expect(zodSchema.parse({ name: 'John' })).toEqual({ name: 'John' });
-      expect(zodSchema.parse({ name: 'John', age: 30 })).toEqual({ name: 'John', age: 30 });
-      expect(() => zodSchema.parse({ name: 'John', extra: 'field' })).toThrow();
+      expect(z.parse(zodSchema, { name: 'John' })).toEqual({ name: 'John' });
+      expect(z.parse(zodSchema, { name: 'John', age: 30 })).toEqual({ name: 'John', age: 30 });
+      expect(() => z.parse(zodSchema, { name: 'John', extra: 'field' })).toThrow();
     });
 
     it('should handle additionalProperties with complex schema', () => {
@@ -1280,7 +1284,7 @@ describe('jsonSchemaToZod', () => {
       };
 
       const zodSchema = jsonSchemaToZod(schema);
-      const convertedBack = zodToJsonSchema(zodSchema, { target: 'jsonSchema7' }) as any;
+      const convertedBack = z.toJSONSchema(zodSchema, { target: 'draft-7' }) as any;
 
       expect(convertedBack.additionalProperties).toEqual({
         type: 'object',
@@ -1293,12 +1297,12 @@ describe('jsonSchemaToZod', () => {
       });
 
       // Test parsing behavior
-      expect(zodSchema.parse({ name: 'John' })).toEqual({ name: 'John' });
-      expect(zodSchema.parse({ name: 'John', meta: { value: 'test', count: 5 } })).toEqual({
+      expect(z.parse(zodSchema, { name: 'John' })).toEqual({ name: 'John' });
+      expect(z.parse(zodSchema, { name: 'John', meta: { value: 'test', count: 5 } })).toEqual({
         name: 'John',
         meta: { value: 'test', count: 5 },
       });
-      expect(() => zodSchema.parse({ name: 'John', meta: { count: 5 } })).toThrow(); // missing required 'value'
+      expect(() => z.parse(zodSchema, { name: 'John', meta: { count: 5 } })).toThrow(); // missing required 'value'
     });
 
     it('should handle objects with no properties and additionalProperties undefined (default behavior)', () => {
@@ -1307,15 +1311,18 @@ describe('jsonSchemaToZod', () => {
       };
 
       const zodSchema = jsonSchemaToZod(schema);
-      const convertedBack = zodToJsonSchema(zodSchema, { target: 'jsonSchema7' }) as any;
+      const convertedBack = z.toJSONSchema(zodSchema, { target: 'draft-7' }) as any;
 
       // When additionalProperties is undefined, it should default to true behavior
       expect(convertedBack.additionalProperties).toBe(true);
       expect(convertedBack.type).toBe('object');
 
       // Test parsing behavior - should allow any additional properties
-      expect(zodSchema.parse({})).toEqual({});
-      expect(zodSchema.parse({ any: 'value', number: 123 })).toEqual({ any: 'value', number: 123 });
+      expect(z.parse(zodSchema, {})).toEqual({});
+      expect(z.parse(zodSchema, { any: 'value', number: 123 })).toEqual({
+        any: 'value',
+        number: 123,
+      });
     });
 
     it('should handle objects with properties and additionalProperties undefined (default behavior)', () => {
@@ -1327,15 +1334,15 @@ describe('jsonSchemaToZod', () => {
       };
 
       const zodSchema = jsonSchemaToZod(schema);
-      const convertedBack = zodToJsonSchema(zodSchema, { target: 'jsonSchema7' }) as any;
+      const convertedBack = z.toJSONSchema(zodSchema, { target: 'draft-7', io: 'input' }) as any;
 
       // When additionalProperties is undefined, it should default to true behavior
       expect(convertedBack.additionalProperties).toBe(true);
       expect(convertedBack.properties).toBeDefined();
 
       // Test parsing behavior - should allow any additional properties
-      expect(zodSchema.parse({ name: 'John' })).toEqual({ name: 'John' });
-      expect(zodSchema.parse({ name: 'John', extra: 'field' })).toEqual({
+      expect(z.parse(zodSchema, { name: 'John' })).toEqual({ name: 'John' });
+      expect(z.parse(zodSchema, { name: 'John', extra: 'field' })).toEqual({
         name: 'John',
         extra: 'field',
       });
@@ -1364,7 +1371,7 @@ describe('jsonSchemaToZod', () => {
       };
 
       const zodSchema = jsonSchemaToZod(schema);
-      const convertedBack = zodToJsonSchema(zodSchema, { target: 'jsonSchema7' }) as any;
+      const convertedBack = z.toJSONSchema(zodSchema, { target: 'draft-7' }) as any;
 
       expect(convertedBack.additionalProperties).toEqual({ type: 'string' });
       expect(convertedBack.properties?.strictChild).toBeDefined();
@@ -1376,17 +1383,17 @@ describe('jsonSchemaToZod', () => {
         flexibleChild: { age: 30, extra: 'allowed' },
         extraString: 'this should be a string',
       };
-      expect(zodSchema.parse(validData)).toEqual(validData);
+      expect(z.parse(zodSchema, validData)).toEqual(validData);
 
       // Test invalid cases
       expect(() =>
-        zodSchema.parse({
+        z.parse(zodSchema, {
           strictChild: { name: 'John', extra: 'not allowed' },
         })
       ).toThrow();
 
       expect(() =>
-        zodSchema.parse({
+        z.parse(zodSchema, {
           extraNumber: 123, // should be string according to additionalProperties
         })
       ).toThrow();

--- a/ts/packages/json-schema-to-zod/tsconfig.json
+++ b/ts/packages/json-schema-to-zod/tsconfig.json
@@ -7,7 +7,7 @@
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "skipLibCheck": true,
     "resolveJsonModule": true
   },

--- a/ts/packages/providers/anthropic/tsconfig.json
+++ b/ts/packages/providers/anthropic/tsconfig.json
@@ -8,7 +8,7 @@
     "outDir": "./dist",
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "skipLibCheck": true,
     "resolveJsonModule": true
   },

--- a/ts/packages/providers/cloudflare/tsconfig.json
+++ b/ts/packages/providers/cloudflare/tsconfig.json
@@ -8,7 +8,7 @@
     "outDir": "./dist",
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "skipLibCheck": true,
     "resolveJsonModule": true
   },

--- a/ts/packages/providers/google/tsconfig.json
+++ b/ts/packages/providers/google/tsconfig.json
@@ -8,7 +8,7 @@
     "outDir": "./dist",
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "skipLibCheck": true,
     "resolveJsonModule": true
   },

--- a/ts/packages/providers/langchain/tsconfig.json
+++ b/ts/packages/providers/langchain/tsconfig.json
@@ -8,7 +8,7 @@
     "outDir": "./dist",
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "skipLibCheck": true,
     "resolveJsonModule": true
   },

--- a/ts/packages/providers/mastra/tsconfig.json
+++ b/ts/packages/providers/mastra/tsconfig.json
@@ -8,7 +8,7 @@
     "outDir": "./dist",
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "skipLibCheck": true,
     "resolveJsonModule": true
   },

--- a/ts/packages/providers/openai-agents/tsconfig.json
+++ b/ts/packages/providers/openai-agents/tsconfig.json
@@ -8,7 +8,7 @@
     "outDir": "./dist",
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "skipLibCheck": true,
     "resolveJsonModule": true
   },

--- a/ts/packages/providers/openai/tsconfig.json
+++ b/ts/packages/providers/openai/tsconfig.json
@@ -8,7 +8,7 @@
     "outDir": "./dist",
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "skipLibCheck": true
   },
   "include": ["src"]

--- a/ts/packages/providers/vercel/tsconfig.json
+++ b/ts/packages/providers/vercel/tsconfig.json
@@ -8,7 +8,7 @@
     "outDir": "./dist",
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "skipLibCheck": true,
     "resolveJsonModule": true
   },

--- a/ts/packages/ts-builders/tsconfig.options.json
+++ b/ts/packages/ts-builders/tsconfig.options.json
@@ -8,7 +8,7 @@
     "rootDir": ".",
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "skipLibCheck": true,
     "resolveJsonModule": true,
     "verbatimModuleSyntax": true,

--- a/ts/scripts/create-example.sh
+++ b/ts/scripts/create-example.sh
@@ -60,7 +60,7 @@ cat > "$EXAMPLE_PATH/tsconfig.json" << EOL
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "skipLibCheck": true,
     "resolveJsonModule": true
   },

--- a/ts/scripts/create-provider.sh
+++ b/ts/scripts/create-provider.sh
@@ -75,7 +75,7 @@ cat > "$TOOLSET_PATH/tsconfig.json" << EOL
     "outDir": "./dist",
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "skipLibCheck": true,
     "resolveJsonModule": true
   },


### PR DESCRIPTION
**Draft**

This is a stash attempt of moving to Zod 4.
I kinda got nerd-sniped into this because I kept getting Zod-induced errors when trying to run Composio SDK's examples.
(some additional context can be found at [this link](https://github.com/vercel/ai/issues/8103#issuecomment-3279085247).)

`@composio/json-schema-to-zod` currently has 7 failing tests out of 61, with no clear way to clear them all without breaking the existing `additionalProperties` decoding logic.

This PR also updated tsconfig's `moduleResolution` from `node` -> `bundler`.
