### PR TITLE
feat(core): refactor generic types in MCP

### DIFF
--- a/ts/packages/core/src/composio.ts
+++ b/ts/packages/core/src/composio.ts
@@ -14,7 +14,6 @@ import { checkForLatestVersionFromNPM } from './utils/version';
 import { OpenAIProvider } from './provider/OpenAIProvider';
 import { version } from '../package.json';
 import type { ComposioRequestHeaders } from './types/composio.types';
-import { McpServerGetResponse } from './types/mcp.types';
 import { Files } from './models/Files';
 import { getDefaultHeaders } from './utils/session';
 import { ToolkitVersionParam } from './types/tool.types';
@@ -86,12 +85,6 @@ export type ComposioConfig<
 };
 
 /**
- * Extract the MCP response type from a provider
- */
-type ExtractMcpResponseType<T> =
-  T extends BaseComposioProvider<unknown, unknown, infer TMcp> ? TMcp : McpServerGetResponse;
-
-/**
  * This is the core class for Composio.
  * It is used to initialize the Composio SDK and provide a global configuration.
  */
@@ -123,7 +116,7 @@ export class Composio<
   // connected accounts
   connectedAccounts: ConnectedAccounts;
 
-  mcp: MCP<ExtractMcpResponseType<TProvider>>;
+  mcp: MCP<TProvider>;
 
   /**
    * Creates a new instance of the Composio SDK.


### PR DESCRIPTION
**Draft**

## `mcp-config-manual`

- Start from scratch, on the platform
- Go to "Create MCP Configs" tab, with name `mcp-config-manual`
- Add Toolkit:
  - "Gmail", with Auth Config name "mcp-gmail-manual-1"
    - Add tools: "Fetch Emails", "Get Contacts", "Get Gmail attachment"
  - "Github", with Auth Config name "mcp-github-manual-1"
    - Add tools: "List pull requests"
- Hit "Create MCP"
- Go to "Auth Configs" tab
- Select "mcp-gmail-manual-1"
  - Follow the OAuth flow to connect your Gmail account
  - Hit "Connect Account" with User ID "id-alberto.schiabel@gmail.com"
  - Log in with the Gmail account "alberto.schiabel@gmail.com"
- Select "mcp-github-manual-1"
  - Follow the OAuth flow to connect your Github account
  - Hit "Connect Account" with User ID "id-jkomyno"
  - Log in with the Github account "jkomyno"

Attempting to fetch emails using the SDK with this configuration

```typescript
const mcpConfig = await composio.mcp.getByName('mcp-config-manual')

// 3. Retrieve the MCP server instance for the connected accounts
const urls = await composio.mcp.getServer(mcpConfig.id, 'mcp-manual-1');

// @ts-ignore
const url = urls[0].url;
```

results in the following error:

```sh
✅ Calling tool GMAIL_FETCH_EMAILS
2620 |       const connectedAccounts = await this.client.connectedAccounts.list({
2621 |         user_ids: [userId],
2622 |         toolkit_slugs: [tool.toolkit.slug]
2623 |       });
2624 |       if (connectedAccounts.items.length === 0) {
2625 |         throw new Error("No connected accounts found");
                         ^
error: No connected accounts found
 errorId: "13265111-0ed1-41d2-8ac0-aa7bfc579f8d",

      at getConnectedAccountIdForTool (/Users/jkomyno/work/composio/composio/ts/packages/core/dist/index.js:2625:19)
```

- Go to "MCP Configs" tab
- Create MCP Server with user ID "mcp-manual-1"
- Connect to `mcp-gmail-manual-1`
- Connect to `mcp-github-manual-1`

The resulting output is something like:

```sh
npx @composio/mcp@latest setup \
  "https://apollo.composio.dev/v3/mcp/237c34d4-7e54-4e57-aee4-55b29cc1679d/mcp?user_id=mcp-manual-1" \
  "mcp-config-manual" \
  --client cursor
```

This still results in the same error when running the code above:

```sh
✅ Calling tool GMAIL_FETCH_EMAILS
2620 |       const connectedAccounts = await this.client.connectedAccounts.list({
2621 |         user_ids: [userId],
2622 |         toolkit_slugs: [tool.toolkit.slug]
2623 |       });
2624 |       if (connectedAccounts.items.length === 0) {
2625 |         throw new Error("No connected accounts found");
                         ^
error: No connected accounts found
 errorId: "9dfad7a1-d9d8-4401-881f-995c183de081",

      at getConnectedAccountIdForTool (/Users/jkomyno/work/composio/composio/ts/packages/core/dist/index.js:2625:19)
```
