### PR TITLE
style(docs): Correct markdown formatting for links

### DIFF
--- a/fern/pages/src/get-started/dev-setup.mdx
+++ b/fern/pages/src/get-started/dev-setup.mdx
@@ -47,7 +47,6 @@ To get the best experience building with Composio, add custom instructions to Cu
 2. Go to "General" → "Rules for AI"
 3. Add the appropriate prompt below based on your language
 
-```md
 Below is a list of Composio documentation. Use your web and fetch capabilities to read the documentation you need.
 [Composio Documentation](https://docs.composio.dev)
 
@@ -75,4 +74,4 @@ Below is a list of Composio documentation. Use your web and fetch capabilities t
 - [Mastra Provider](https://docs.composio.dev/providers/mastra.mdx)
 - [Custom Providers](https://docs.composio.dev/toolsets/custom.mdx)
 
-```
+


### PR DESCRIPTION
This PR addresses a minor formatting issue in the documentation where a list of links was not being rendered as clickable hyperlinks.
The list of Composio documentation links was incorrectly wrapped in a Markdown fenced code block (```). This caused Markdown renderers to treat the content as plain text, preventing the link syntax from being processed and making the links unclickable.
This change removes the surrounding code block, allowing the links to be rendered correctly.