### PR TITLE
docs:Fixed broken embedded links in migration guide

### DIFF
--- a/fern/pages/src/migration-guide.mdx
+++ b/fern/pages/src/migration-guide.mdx
@@ -91,7 +91,7 @@ All operations are now scoped to a user ID, including:
 
 This change provides explicit specification of the user for whom the action is being performed. When a user may have multiple accounts (such as work and personal Gmail connections), you can use the more specific connected account ID.
 
-### Replacing ToolSets with [Providers](/get-started/providers)
+### Replacing ToolSets with [Providers](/docs/providers)
 
 We have deprecated "toolsets" in favor of "providers". This change allows Composio to provide deeper standardization for tool implementation across different frameworks.
 
@@ -133,7 +133,7 @@ The SDK structure is now framework-agnostic and includes the OpenAI provider out
 
 You can now use the same tools across any framework with our unified interface, or create custom toolsets for frameworks we don't yet support.
 
-Read more about [providers in our documentation](/get-started/providers) and explore the [complete list of available providers](/providers).
+Read more about [providers in our documentation](/docs/providers) and explore the [complete list of available providers](/providers/openai).
 
 ### Fetching and filtering tools
 
@@ -454,7 +454,7 @@ Creating auth configs programmatically in the current SDK:
 />
 </CodeGroup>
 
-For using custom authentication credentials, refer to the [Programmatic Auth Configs](/programmatic-auth-configs#using-custom-auth) documentation.
+For using custom authentication credentials, refer to the [Programmatic Auth Configs](/docs/programmatic-auth-configs) documentation.
 
 <Note>The callback URL for creating custom OAuth configs is now `https://backend.composio.dev/api/v3/toolkits/auth/callback`. The previous URL was `https://backend.composio.dev/api/v1/auth-apps/add`.</Note>
 


### PR DESCRIPTION
In reference to issue #2002 .

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes broken links in the migration guide, updating provider and programmatic auth config URLs to the correct /docs and providers/openai paths.
> 
> - **Docs**:
>   - Update provider docs link in `fern/pages/src/migration-guide.mdx` from `/get-started/providers` to `/docs/providers`.
>   - Update "Read more" links: providers to `/docs/providers` and providers list to `/providers/openai`.
>   - Update Programmatic Auth Configs link to `/docs/programmatic-auth-configs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 269cfd4823d737fd2a810949839c15b4352722ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->