### PR TITLE
Python: Fix responses execute tool call type error

### DIFF
--- a/python/composio/core/provider/_openai_responses.py
+++ b/python/composio/core/provider/_openai_responses.py
@@ -9,9 +9,6 @@ import typing as t
 
 from openai.types.responses.response import Response
 from openai.types.responses.response_output_item import ResponseFunctionToolCall
-from openai.types.chat.chat_completion_message_tool_call import (
-    ChatCompletionMessageToolCall,
-)
 
 from composio.core.provider import NonAgenticProvider
 from composio.types import Modifiers, Tool, ToolExecutionResponse
@@ -42,7 +39,7 @@ class OpenAIResponsesProvider(
     def execute_tool_call(
         self,
         user_id: str,
-        tool_call: t.Union[ChatCompletionMessageToolCall, ResponseFunctionToolCall],
+        tool_call: t.Union[ResponseFunctionToolCall],
         modifiers: t.Optional[Modifiers] = None,
     ) -> ToolExecutionResponse:
         """Execute a tool call from the Responses API.

--- a/python/composio/core/provider/_openai_responses.py
+++ b/python/composio/core/provider/_openai_responses.py
@@ -49,12 +49,8 @@ class OpenAIResponsesProvider(
         :param modifiers: Optional modifiers for tool execution.
         :return: Object containing output data from the tool call.
         """
-        if isinstance(tool_call, ChatCompletionMessageToolCall):
-            slug = tool_call.function.name
-            arguments = json.loads(tool_call.function.arguments)
-        else:  # ResponseFunctionToolCall
-            slug = tool_call.name
-            arguments = json.loads(tool_call.arguments)
+        slug = tool_call.name
+        arguments = json.loads(tool_call.arguments)
 
         return self.execute_tool(
             slug=slug,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Narrow execute_tool_call to only handle ResponseFunctionToolCall and simplify logic by removing ChatCompletionMessageToolCall support.
> 
> - **OpenAI Responses provider (`python/composio/core/provider/_openai_responses.py`)**:
>   - Narrow `execute_tool_call` to accept only `ResponseFunctionToolCall` and simplify slug/argument parsing.
>   - Remove `ChatCompletionMessageToolCall` import and related branching logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b9a7f595d8074c46666d2f151ccc2f2f48fad23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->