### PR TITLE
Bump python packages for release

### DIFF
--- a/python/providers/anthropic/pyproject.toml
+++ b/python/providers/anthropic/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio-anthropic"
-version = "0.8.19"
+version = "0.8.20"
 description = "Use Composio to get an array of tools with your Anthropic LLMs."
 readme = "README.md"
 requires-python = ">=3.10,<4"

--- a/python/providers/anthropic/setup.py
+++ b/python/providers/anthropic/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 
 setup(
     name="composio_anthropic",
-    version="0.8.19",
+    version="0.8.20",
     author="Composio",
     author_email="tech@composio.dev",
     description="Use Composio to get an array of tools with your Anthropic LLMs.",

--- a/python/providers/autogen/pyproject.toml
+++ b/python/providers/autogen/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio-autogen"
-version = "0.8.19"
+version = "0.8.20"
 description = "Use Composio to get an array of tools with your autogen agent."
 readme = "README.md"
 requires-python = ">=3.9,<4"

--- a/python/providers/autogen/setup.py
+++ b/python/providers/autogen/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 
 setup(
     name="composio_autogen",
-    version="0.8.19",
+    version="0.8.20",
     author="Composio",
     author_email="tech@composio.dev",
     description="Use Composio to get an array of tools with your Autogen agent.",

--- a/python/providers/crewai/pyproject.toml
+++ b/python/providers/crewai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio-crewai"
-version = "0.8.19"
+version = "0.8.20"
 description = "Use Composio to get an array of tools with your CrewAI agent."
 readme = "README.md"
 requires-python = ">=3.9,<4"

--- a/python/providers/crewai/setup.py
+++ b/python/providers/crewai/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 setup(
     name="composio_crewai",
-    version="0.8.19",
+    version="0.8.20",
     author="Composio",
     author_email="tech@composio.dev",
     description="Use Composio to get an array of tools with your CrewAI agent.",

--- a/python/providers/gemini/pyproject.toml
+++ b/python/providers/gemini/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio-gemini"
-version = "0.8.19"
+version = "0.8.20"
 description = "Use Composio to get an array of tools with your Gemini agent."
 readme = "README.md"
 requires-python = ">=3.9,<4"

--- a/python/providers/gemini/setup.py
+++ b/python/providers/gemini/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 
 setup(
     name="composio_gemini",
-    version="0.8.19",
+    version="0.8.20",
     author="Composio",
     author_email="tech@composio.dev",
     description="Use Composio to get an array of tools with your Gemini agent.",

--- a/python/providers/google/pyproject.toml
+++ b/python/providers/google/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio-google"
-version = "0.8.19"
+version = "0.8.20"
 description = "Use Composio to get an array of tools with your Google AI Python Gemini model."
 readme = "README.md"
 requires-python = ">=3.9,<4"

--- a/python/providers/google/setup.py
+++ b/python/providers/google/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 
 setup(
     name="composio_google",
-    version="0.8.19",
+    version="0.8.20",
     author="Composio",
     author_email="tech@composio.dev",
     description="Use Composio to get an array of tools with your Google AI Python Gemini model.",

--- a/python/providers/google_adk/pyproject.toml
+++ b/python/providers/google_adk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio-google-adk"
-version = "0.8.19"
+version = "0.8.20"
 description = "Use Composio to get an array of tools with your Google AI Python Gemini model."
 readme = "README.md"
 requires-python = ">=3.9,<4"

--- a/python/providers/google_adk/setup.py
+++ b/python/providers/google_adk/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 
 setup(
     name="composio_google_adk",
-    version="0.8.19",
+    version="0.8.20",
     author="Composio",
     author_email="tech@composio.dev",
     description="Use Composio to get an array of tools with your Google AI Python Gemini model.",

--- a/python/providers/langchain/pyproject.toml
+++ b/python/providers/langchain/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio-langchain"
-version = "0.8.19"
+version = "0.8.20"
 description = "Use Composio to get an array of tools with your Langchain agent."
 readme = "README.md"
 requires-python = ">=3.9,<4"

--- a/python/providers/langchain/setup.py
+++ b/python/providers/langchain/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 
 setup(
     name="composio_langchain",
-    version="0.8.19",
+    version="0.8.20",
     author="composio",
     author_email="tech@composio.dev",
     description="Use Composio to get an array of tools with your Langchain agent.",

--- a/python/providers/langgraph/pyproject.toml
+++ b/python/providers/langgraph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio-langgraph"
-version = "0.8.19"
+version = "0.8.20"
 description = "Use Composio to get array of tools with LangGraph Agent Workflows."
 readme = "README.md"
 requires-python = ">=3.9,<4"

--- a/python/providers/langgraph/setup.py
+++ b/python/providers/langgraph/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 
 setup(
     name="composio_langgraph",
-    version="0.8.19",
+    version="0.8.20",
     author="composio",
     author_email="tech@composio.dev",
     description="Use Composio to get array of tools with LangGraph Agent Workflows",

--- a/python/providers/llamaindex/pyproject.toml
+++ b/python/providers/llamaindex/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio-llamaindex"
-version = "0.8.19"
+version = "0.8.20"
 description = "Use Composio to get array of tools with LlamaIndex Agent Workflows."
 readme = "README.md"
 requires-python = ">=3.9,<4"

--- a/python/providers/llamaindex/setup.py
+++ b/python/providers/llamaindex/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 
 setup(
     name="composio_llamaindex",
-    version="0.8.19",
+    version="0.8.20",
     author="composio",
     author_email="tech@composio.dev",
     description="Use Composio to get array of tools with LlamaIndex Agent Workflows",

--- a/python/providers/openai/pyproject.toml
+++ b/python/providers/openai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio-openai"
-version = "0.8.19"
+version = "0.8.20"
 description = "Use Composio to get an array of tools with your OpenAI Function Call."
 readme = "README.md"
 requires-python = ">=3.9,<4"

--- a/python/providers/openai/setup.py
+++ b/python/providers/openai/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 
 setup(
     name="composio_openai",
-    version="0.8.19",
+    version="0.8.20",
     author="Composio",
     author_email="tech@composio.dev",
     description="Use Composio to get an array of tools with your OpenAI Function Call.",

--- a/python/providers/openai_agents/pyproject.toml
+++ b/python/providers/openai_agents/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio-openai-agents"
-version = "0.8.19"
+version = "0.8.20"
 description = "Use Composio to get array of strongly typed tools for OpenAI Agents"
 readme = "README.md"
 requires-python = ">=3.9,<4"

--- a/python/providers/openai_agents/setup.py
+++ b/python/providers/openai_agents/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="composio_openai_agents",
-    version="0.8.19",
+    version="0.8.20",
     author="Composio",
     author_email="tech@composio.dev",
     description="Use Composio to get array of strongly typed tools for OpenAI Agents",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio"
-version = "0.8.19"
+version = "0.8.20"
 description = "SDK for integrating Composio with your applications."
 readme = "README.md"
 requires-python = ">=3.10,<4"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps core SDK and all provider packages to version 0.8.20 for release.
> 
> - **Release version bump to `0.8.20`**:
>   - Core: `python/pyproject.toml` (`composio`).
>   - Providers (`pyproject.toml` and `setup.py`): `anthropic`, `autogen`, `crewai`, `gemini`, `google`, `google_adk`, `langchain`, `langgraph`, `llamaindex`, `openai`, `openai_agents`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f93a111288a7601a293bcc98547bc604fd9e9d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->