### PR TITLE
Docs: Tool router add session format to docs

### DIFF
--- a/fern/snippets/tool-router/python/quick-start.py
+++ b/fern/snippets/tool-router/python/quick-start.py
@@ -6,5 +6,10 @@ userId = "hey@example.com"
 session = composio.experimental.tool_router.create_session(
     user_id=userId,
 )
+# Returns:
+# {
+#   'session_id': 'dKDoDWAGUf-hPM-Bw39pJ',
+#   'url': 'https://apollo.composio.dev/v3/mcp/tool-router/dKDoDWAGUf-hPM-Bw39pJ/mcp'
+# }
 
 mcpUrl = session['url']

--- a/fern/snippets/tool-router/typescript/quick-start.ts
+++ b/fern/snippets/tool-router/typescript/quick-start.ts
@@ -5,5 +5,10 @@ const userId = 'hey@example.com';
 
 // Access the experimental ToolRouter
 const session = await composio.experimental.toolRouter.createSession(userId);
+// Returns:
+// {
+//   sessionId: "dKDoDWAGUf-hPM-Bw39pJ",
+//   url: "https://apollo.composio.dev/v3/mcp/tool-router/dKDoDWAGUf-hPM-Bw39pJ/mcp"
+// }
 
 const mcpUrl = session.url;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add commented examples of the tool router session return object (sessionId/session_id and url) to Python and TypeScript quick-start snippets.
> 
> - **Docs — Tool Router Quick-start Snippets**:
>   - **Python (`fern/snippets/tool-router/python/quick-start.py`)**: Add commented example of session response showing `session_id` and `url`.
>   - **TypeScript (`fern/snippets/tool-router/typescript/quick-start.ts`)**: Add commented example of session response showing `sessionId` and `url`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7cdc530c5c5ee4e5591eadf4acf2e86d0d9eed62. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->