### PR TITLE
Fix: Update dependencies for Llamaindex

### DIFF
--- a/ts/packages/providers/llamaindex/package.json
+++ b/ts/packages/providers/llamaindex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/llamaindex",
-  "version": "0.1.53",
+  "version": "0.1.52",
   "description": "Agentic Provider for llamaindex in Composio SDK",
   "main": "src/index.ts",
   "type": "module",


### PR DESCRIPTION
Updates llamaindex to use latest version of `@composio/core`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pins @composio/core peer dependency to 0.1.53 for @composio/llamaindex and sets package version to 0.1.52.
> 
> - **Dependencies**:
>   - Pin `peerDependencies.@composio/core` to `0.1.53` in `ts/packages/providers/llamaindex/package.json`.
> - **Package metadata**:
>   - Set `version` to `0.1.52`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd121f7ba283302701cbdf3d918bfe0f899338e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->