### PR TITLE
More flexible providers

### DIFF
--- a/python/composio/core/models/tools.py
+++ b/python/composio/core/models/tools.py
@@ -290,14 +290,20 @@ class Tools(Resource, t.Generic[TProvider]):
         user_id: t.Optional[str] = None,
     ) -> AgenticProviderExecuteFn:
         """Wrap the execute tool function"""
-        return t.cast(
-            AgenticProviderExecuteFn,
-            functools.partial(
-                self.execute,
-                modifiers=modifiers,
-                user_id=user_id,
-            ),
-        )
+        def wrapper(
+            slug: str,
+            arguments: t.Dict,
+            **kwargs: t.Any,
+        ) -> ToolExecutionResponse:
+            return self.execute(
+                slug=slug,
+                arguments=arguments,
+                modifiers=kwargs.get("modifiers", modifiers),
+                user_id=kwargs.get("user_id", user_id),
+                **{k: v for k, v in kwargs.items() if k not in ["modifiers", "user_id"]},
+            )
+
+        return t.cast(AgenticProviderExecuteFn, wrapper)
 
     def _execute_custom_tool(
         self,

--- a/python/composio/core/provider/agentic.py
+++ b/python/composio/core/provider/agentic.py
@@ -9,9 +9,14 @@ class AgenticProviderExecuteFn(t.Protocol):
         self,
         slug: str,
         arguments: t.Dict,
+        **kwargs: t.Any,
     ) -> t.Dict:
         """
         Execute a wrapped tool by slug, passing an arbitrary input dict.
+        
+        Additional keyword arguments can be passed (e.g., connected_account_id, 
+        user_id, modifiers, etc.) and will be forwarded to the execute method.
+        
         Returns a dict with the following keys:
             - data: The data returned by the tool.
             - error: The error returned by the tool.

--- a/python/composio/core/provider/none_agentic.py
+++ b/python/composio/core/provider/none_agentic.py
@@ -16,9 +16,14 @@ class NoneAgenticProviderExecuteFn(t.Protocol):
         arguments: t.Dict,
         modifiers: t.Optional[Modifiers] = None,
         user_id: t.Optional[str] = None,
+        **kwargs: t.Any,
     ) -> ToolExecutionResponse:
         """
         Execute a wrapped tool by slug, passing an arbitrary input dict.
+        
+        Additional keyword arguments can be passed (e.g., connected_account_id,
+        custom_auth_params, etc.) and will be forwarded to the execute method.
+        
         Returns a dict with the following keys:
             - data: The data returned by the tool.
             - error: The error returned by the tool.


### PR DESCRIPTION
With this, you can now specify what connected_account_id to use in function calls made from providers. For example, if a user has multiple connected accounts for Gmail, it's no possible to choose which one to use for the tool calls.