### PR TITLE
chore: fix peer dep issue when using zod-4, causing types to not appear

### DIFF
--- a/.changeset/petite-lamps-cough.md
+++ b/.changeset/petite-lamps-cough.md
@@ -1,0 +1,6 @@
+---
+'@composio/core': patch
+'@composio/json-schema-to-zod': patch
+---
+
+Add zod 4 support via zod/v3 and fix zod schema parsing

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,7 +268,7 @@ importers:
     devDependencies:
       '@cloudflare/vitest-pool-workers':
         specifier: 'catalog:'
-        version: 0.9.2(@cloudflare/workers-types@4.20250917.0)(@vitest/runner@3.2.4)(@vitest/snapshot@3.2.4)(vitest@3.2.4(@types/node@24.6.2)(@vitest/ui@3.2.4)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.1))
+        version: 0.9.2(@cloudflare/workers-types@4.20250917.0)(@vitest/runner@3.2.4)(@vitest/snapshot@3.2.4)(vitest@3.2.4)
       typescript:
         specifier: 'catalog:'
         version: 5.9.2
@@ -384,7 +384,7 @@ importers:
         version: 16.5.0
       zod-to-json-schema:
         specifier: ^3.24.5
-        version: 3.24.5(zod@4.1.9)
+        version: 3.24.5(zod@3.25.76)
     devDependencies:
       '@types/bun':
         specifier: ^1.2.9
@@ -437,13 +437,13 @@ importers:
         version: 0.4.20(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(ws@8.18.2)(zod@3.25.76)
       '@llamaindex/workflow':
         specifier: ^1.1.24
-        version: 1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(@modelcontextprotocol/sdk@1.18.0)(hono@4.9.7)(next@15.3.4)(rxjs@7.8.2)(zod@3.25.76)
+        version: 1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(@modelcontextprotocol/sdk@1.18.0)(hono@4.9.7)(next@15.3.4(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@18.3.1))(react@18.3.1))(rxjs@7.8.2)(zod@3.25.76)
       dotenv:
         specifier: ^16.4.1
         version: 16.6.1
       llamaindex:
         specifier: ^0.12.0
-        version: 0.12.0(@modelcontextprotocol/sdk@1.18.0)(hono@4.9.7)(next@15.3.4)(rxjs@7.8.2)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@3.25.76)
+        version: 0.12.0(@modelcontextprotocol/sdk@1.18.0)(hono@4.9.7)(next@15.3.4(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@18.3.1))(react@18.3.1))(rxjs@7.8.2)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@3.25.76)
     devDependencies:
       '@types/bun':
         specifier: ^1.2.9
@@ -487,7 +487,7 @@ importers:
     dependencies:
       '@ai-sdk/openai':
         specifier: ^2.0.35
-        version: 2.0.35(zod@4.1.9)
+        version: 2.0.35(zod@3.25.76)
       '@composio/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -499,7 +499,7 @@ importers:
         version: 1.18.0
       ai:
         specifier: 'catalog:'
-        version: 5.0.44(zod@4.1.9)
+        version: 5.0.44(zod@3.25.76)
       dotenv:
         specifier: ^16.4.1
         version: 16.6.1
@@ -515,7 +515,7 @@ importers:
     dependencies:
       '@ai-sdk/openai':
         specifier: ^1.3.16
-        version: 1.3.22(zod@4.1.9)
+        version: 1.3.22(zod@3.25.76)
       '@composio/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -524,7 +524,7 @@ importers:
         version: link:../../packages/providers/vercel
       ai:
         specifier: 'catalog:'
-        version: 5.0.44(zod@4.1.9)
+        version: 5.0.44(zod@3.25.76)
     devDependencies:
       '@types/bun':
         specifier: ^1.2.9
@@ -590,7 +590,7 @@ importers:
     dependencies:
       '@ai-sdk/openai':
         specifier: ^1.3.16
-        version: 1.3.22(zod@4.1.9)
+        version: 1.3.22(zod@3.25.76)
       '@composio/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -599,7 +599,7 @@ importers:
         version: link:../../packages/providers/vercel
       ai:
         specifier: 'catalog:'
-        version: 5.0.44(zod@4.1.9)
+        version: 5.0.44(zod@3.25.76)
     devDependencies:
       '@types/bun':
         specifier: ^1.2.9
@@ -618,10 +618,13 @@ importers:
         version: 16.5.0
       openai:
         specifier: ^5.19.1
-        version: 5.19.1(ws@8.18.2)(zod@4.1.9)
+        version: 5.19.1(ws@8.18.2)(zod@3.25.76)
+      zod:
+        specifier: 'catalog:'
+        version: 3.25.76
       zod-to-json-schema:
         specifier: ^3.24.5
-        version: 3.24.5(zod@4.1.9)
+        version: 3.24.5(zod@3.25.76)
     devDependencies:
       '@types/bun':
         specifier: ^1.2.9
@@ -650,7 +653,7 @@ importers:
     dependencies:
       '@ai-sdk/openai':
         specifier: ^2.0.16
-        version: 2.0.16(zod@4.1.9)
+        version: 2.0.16(zod@3.25.76)
       '@composio/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -662,10 +665,13 @@ importers:
         version: 1.18.0
       ai:
         specifier: 'catalog:'
-        version: 5.0.44(zod@4.1.9)
+        version: 5.0.44(zod@3.25.76)
       dotenv:
         specifier: ^16.5.0
         version: 16.5.0
+      zod-to-json-schema:
+        specifier: ^3.24.6
+        version: 3.24.6(zod@3.25.76)
     devDependencies:
       '@types/bun':
         specifier: ^1.2.9
@@ -761,7 +767,7 @@ importers:
         version: 0.85.2(effect@3.16.16)
       '@effect/vitest':
         specifier: ^0.23.8
-        version: 0.23.8(effect@3.16.16)(vitest@3.2.4(@types/node@24.6.2)(@vitest/ui@3.2.4)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.1))
+        version: 0.23.8(effect@3.16.16)(vitest@3.2.4)
       '@types/bun':
         specifier: ^1.2.16
         version: 1.2.16
@@ -870,7 +876,7 @@ importers:
         version: 0.52.0
       '@mastra/mcp':
         specifier: ^0.12.0
-        version: 0.12.0(@mastra/core@0.16.3(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@4.1.9))(@types/json-schema@7.0.15)(zod@4.1.9)
+        version: 0.12.0(@mastra/core@0.16.3(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@3.25.76))(@types/json-schema@7.0.15)(zod@3.25.76)
     devDependencies:
       '@composio/core':
         specifier: workspace:*
@@ -924,7 +930,7 @@ importers:
     dependencies:
       '@langchain/core':
         specifier: ^0.3.63
-        version: 0.3.63(openai@5.20.3(zod@3.25.76))
+        version: 0.3.63(openai@5.20.3(ws@8.18.2)(zod@3.25.76))
     devDependencies:
       '@composio/core':
         specifier: workspace:*
@@ -946,7 +952,7 @@ importers:
     dependencies:
       llamaindex:
         specifier: ^0.12.0
-        version: 0.12.0(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@4.1.9)
+        version: 0.12.0(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@4.1.12)
     devDependencies:
       '@composio/core':
         specifier: workspace:*
@@ -1900,138 +1906,163 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm64@1.1.0':
     resolution: {integrity: sha512-IVfGJa7gjChDET1dK9SekxFFdflarnUB8PwW8aGwEoF3oAsSDuNUTYS+SKDOyOJxQyDC1aPFMuRYLoDInyV9Ew==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.1.0':
     resolution: {integrity: sha512-s8BAd0lwUIvYCJyRdFqvsj+BJIpDBSxs6ivrOPm/R7piTs5UIwY5OjXrP2bqXC9/moGsyRa37eYWYCOGVXxVrA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.1.0':
     resolution: {integrity: sha512-tiXxFZFbhnkWE2LA8oQj7KYR+bWBkiV2nilRldT7bqoEZ4HiDOcePr9wVDAZPi/Id5fT1oY9iGnDq20cwUz8lQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.1.0':
     resolution: {integrity: sha512-xukSwvhguw7COyzvmjydRb3x/09+21HykyapcZchiCUkTThEQEOMtBj9UhkaBRLuBrgLFzQ2wbxdeCCJW/jgJA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.1.0':
     resolution: {integrity: sha512-yRj2+reB8iMg9W5sULM3S74jVS7zqSzHG3Ol/twnAAkAhnGQnpjj6e4ayUz7V+FpKypwgs82xbRdYtchTTUB+Q==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.1.0':
     resolution: {integrity: sha512-jYZdG+whg0MDK+q2COKbYidaqW/WTz0cc1E+tMAusiDygrM4ypmSCjOJPmFTvHHJ8j/6cAGyeDWZOsK06tP33w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.1.0':
     resolution: {integrity: sha512-wK7SBdwrAiycjXdkPnGCPLjYb9lD4l6Ze2gSdAGVZrEL05AOUJESWU2lhlC+Ffn5/G+VKuSm6zzbQSzFX/P65A==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm64@0.34.2':
     resolution: {integrity: sha512-D8n8wgWmPDakc83LORcfJepdOSN6MvWNzzz2ux0MnIbOqdieRZwVYY32zxVx+IFUT8er5KPcyU3XXsn+GzG/0Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.2':
     resolution: {integrity: sha512-0DZzkvuEOqQUP9mo2kjjKNok5AmnOr1jB2XYjkaoNRwpAYMDzRmAqUIa1nRi58S2WswqSfPOWLNOr0FDT3H5RQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.2':
     resolution: {integrity: sha512-EGZ1xwhBI7dNISwxjChqBGELCWMGDvmxZXKjQRuqMrakhO8QoMgqCrdjnAqJq/CScxfRn+Bb7suXBElKQpPDiw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.2':
     resolution: {integrity: sha512-sD7J+h5nFLMMmOXYH4DD9UtSNBD05tWSSdWAcEyzqW8Cn5UxXvsHAxmxSesYUsTOBmUnjtxghKDl15EvfqLFbQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-arm64@0.34.2':
     resolution: {integrity: sha512-NEE2vQ6wcxYav1/A22OOxoSOGiKnNmDzCYFOZ949xFmrWZOVII1Bp3NqVVpvj+3UeHMFyN5eP/V5hzViQ5CZNA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.2':
     resolution: {integrity: sha512-DOYMrDm5E6/8bm/yQLCWyuDJwUnlevR8xtF8bs+gjZ7cyUNYXiSf/E8Kp0Ss5xasIaXSHzb888V1BE4i1hFhAA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -2386,24 +2417,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.3.4':
     resolution: {integrity: sha512-wFyZ7X470YJQtpKot4xCY3gpdn8lE9nTlldG07/kJYexCUpX1piX+MBfZdvulo+t1yADFVEuzFfVHfklfEx8kw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.3.4':
     resolution: {integrity: sha512-gEbH9rv9o7I12qPyvZNVTyP/PWKqOp8clvnoYZQiX800KkqsaJZuOXkWgMa7ANCCh/oEN2ZQheh3yH8/kWPSEg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.3.4':
     resolution: {integrity: sha512-Cf8sr0ufuC/nu/yQ76AnarbSAXcwG/wj+1xFPNbyNo8ltA6kw5d5YqO8kQuwVIxk13SBdtgXrNyom3ZosHAy4A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.3.4':
     resolution: {integrity: sha512-ay5+qADDN3rwRbRpEhTOreOn1OyJIXS60tg9WMYTWCy3fB6rGoyjLVxc4dR9PYjEdR2iDYsaF5h03NA+XuYPQQ==}
@@ -2967,36 +3002,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.1':
     resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.1':
     resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.1':
     resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.1':
     resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.1':
     resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.1':
     resolution: {integrity: sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==}
@@ -3110,56 +3151,67 @@ packages:
     resolution: {integrity: sha512-gTJ/JnnjCMc15uwB10TTATBEhK9meBIY+gXP4s0sHD1zHOaIh4Dmy1X9wup18IiY9tTNk5gJc4yx9ctj/fjrIw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.43.0':
     resolution: {integrity: sha512-ZJ3gZynL1LDSIvRfz0qXtTNs56n5DI2Mq+WACWZ7yGHFUEirHBRt7fyIk0NsCKhmRhn7WAcjgSkSVVxKlPNFFw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.43.0':
     resolution: {integrity: sha512-8FnkipasmOOSSlfucGYEu58U8cxEdhziKjPD2FIa0ONVMxvl/hmONtX/7y4vGjdUhjcTHlKlDhw3H9t98fPvyA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.43.0':
     resolution: {integrity: sha512-KPPyAdlcIZ6S9C3S2cndXDkV0Bb1OSMsX0Eelr2Bay4EsF9yi9u9uzc9RniK3mcUGCLhWY9oLr6er80P5DE6XA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.43.0':
     resolution: {integrity: sha512-HPGDIH0/ZzAZjvtlXj6g+KDQ9ZMHfSP553za7o2Odegb/BEfwJcR0Sw0RLNpQ9nC6Gy8s+3mSS9xjZ0n3rhcYg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.43.0':
     resolution: {integrity: sha512-gEmwbOws4U4GLAJDhhtSPWPXUzDfMRedT3hFMyRAvM9Mrnj+dJIFIeL7otsv2WF3D7GrV0GIewW0y28dOYWkmw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.43.0':
     resolution: {integrity: sha512-XXKvo2e+wFtXZF/9xoWohHg+MuRnvO29TI5Hqe9xwN5uN8NKUYy7tXUG3EZAlfchufNCTHNGjEx7uN78KsBo0g==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.43.0':
     resolution: {integrity: sha512-ruf3hPWhjw6uDFsOAzmbNIvlXFXlBQ4nk57Sec8E8rUxs/AI4HD6xmiiasOOx/3QxS2f5eQMKTAwk7KHwpzr/Q==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.43.0':
     resolution: {integrity: sha512-QmNIAqDiEMEvFV15rsSnjoSmO0+eJLoKRD9EAa9rrYNwO/XRCtOGM3A5A0X+wmG+XRrw9Fxdsw+LnyYiZWWcVw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.43.0':
     resolution: {integrity: sha512-jAHr/S0iiBtFyzjhOkAics/2SrXE092qyqEg96e90L3t9Op8OTzS6+IX0Fy5wCt2+KqeHAkti+eitV0wvblEoQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.43.0':
     resolution: {integrity: sha512-3yATWgdeXyuHtBhrLt98w+5fKurdqvs8B53LaoKD7P7H7FKOONLsBVMNl9ghPQZQuYcceV5CDyPfyfGpMWD9mQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.43.0':
     resolution: {integrity: sha512-wVzXp2qDSCOpcBCT5WRWLmpJRIzv23valvcTwMHEobkjippNf+C3ys/+wf07poPkeNix0paTNemB2XrHr2TnGw==}
@@ -6735,8 +6787,8 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.1.9:
-    resolution: {integrity: sha512-HI32jTq0AUAC125z30E8bQNz0RQ+9Uc+4J7V97gLYjZVKRjeydPgGt6dvQzFrav7MYOUGFqqOGiHpA/fdbd0cQ==}
+  zod@4.1.12:
+    resolution: {integrity: sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==}
 
 snapshots:
 
@@ -6763,23 +6815,11 @@ snapshots:
       '@ai-sdk/provider-utils': 3.0.7(zod@3.25.76)
       zod: 3.25.76
 
-  '@ai-sdk/gateway@1.0.15(zod@4.1.9)':
-    dependencies:
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.7(zod@4.1.9)
-      zod: 4.1.9
-
   '@ai-sdk/gateway@1.0.23(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
       '@ai-sdk/provider-utils': 3.0.9(zod@3.25.76)
       zod: 3.25.76
-
-  '@ai-sdk/gateway@1.0.23(zod@4.1.9)':
-    dependencies:
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.9(zod@4.1.9)
-      zod: 4.1.9
 
   '@ai-sdk/openai@1.3.22(zod@3.25.76)':
     dependencies:
@@ -6787,29 +6827,17 @@ snapshots:
       '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
       zod: 3.25.76
 
-  '@ai-sdk/openai@1.3.22(zod@4.1.9)':
-    dependencies:
-      '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@4.1.9)
-      zod: 4.1.9
-
-  '@ai-sdk/openai@2.0.16(zod@4.1.9)':
+  '@ai-sdk/openai@2.0.16(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.4(zod@4.1.9)
-      zod: 4.1.9
+      '@ai-sdk/provider-utils': 3.0.4(zod@3.25.76)
+      zod: 3.25.76
 
   '@ai-sdk/openai@2.0.35(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
       '@ai-sdk/provider-utils': 3.0.9(zod@3.25.76)
       zod: 3.25.76
-
-  '@ai-sdk/openai@2.0.35(zod@4.1.9)':
-    dependencies:
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.9(zod@4.1.9)
-      zod: 4.1.9
 
   '@ai-sdk/provider-utils@2.2.8(zod@3.25.76)':
     dependencies:
@@ -6818,20 +6846,13 @@ snapshots:
       secure-json-parse: 2.7.0
       zod: 3.25.76
 
-  '@ai-sdk/provider-utils@2.2.8(zod@4.1.9)':
-    dependencies:
-      '@ai-sdk/provider': 1.1.3
-      nanoid: 3.3.11
-      secure-json-parse: 2.7.0
-      zod: 4.1.9
-
-  '@ai-sdk/provider-utils@3.0.4(zod@4.1.9)':
+  '@ai-sdk/provider-utils@3.0.4(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
       '@standard-schema/spec': 1.0.0
       eventsource-parser: 3.0.3
-      zod: 4.1.9
-      zod-to-json-schema: 3.24.6(zod@4.1.9)
+      zod: 3.25.76
+      zod-to-json-schema: 3.24.6(zod@3.25.76)
 
   '@ai-sdk/provider-utils@3.0.5(zod@3.25.76)':
     dependencies:
@@ -6841,14 +6862,6 @@ snapshots:
       zod: 3.25.76
       zod-to-json-schema: 3.24.6(zod@3.25.76)
 
-  '@ai-sdk/provider-utils@3.0.5(zod@4.1.9)':
-    dependencies:
-      '@ai-sdk/provider': 2.0.0
-      '@standard-schema/spec': 1.0.0
-      eventsource-parser: 3.0.6
-      zod: 4.1.9
-      zod-to-json-schema: 3.24.6(zod@4.1.9)
-
   '@ai-sdk/provider-utils@3.0.7(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
@@ -6856,26 +6869,12 @@ snapshots:
       eventsource-parser: 3.0.6
       zod: 3.25.76
 
-  '@ai-sdk/provider-utils@3.0.7(zod@4.1.9)':
-    dependencies:
-      '@ai-sdk/provider': 2.0.0
-      '@standard-schema/spec': 1.0.0
-      eventsource-parser: 3.0.6
-      zod: 4.1.9
-
   '@ai-sdk/provider-utils@3.0.9(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
       '@standard-schema/spec': 1.0.0
       eventsource-parser: 3.0.6
       zod: 3.25.76
-
-  '@ai-sdk/provider-utils@3.0.9(zod@4.1.9)':
-    dependencies:
-      '@ai-sdk/provider': 2.0.0
-      '@standard-schema/spec': 1.0.0
-      eventsource-parser: 3.0.6
-      zod: 4.1.9
 
   '@ai-sdk/provider@1.1.3':
     dependencies:
@@ -6895,29 +6894,12 @@ snapshots:
     optionalDependencies:
       zod: 3.25.76
 
-  '@ai-sdk/react@1.2.12(react@18.3.1)(zod@4.1.9)':
-    dependencies:
-      '@ai-sdk/provider-utils': 2.2.8(zod@4.1.9)
-      '@ai-sdk/ui-utils': 1.2.11(zod@4.1.9)
-      react: 18.3.1
-      swr: 2.3.3(react@18.3.1)
-      throttleit: 2.1.0
-    optionalDependencies:
-      zod: 4.1.9
-
   '@ai-sdk/ui-utils@1.2.11(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
       '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
       zod: 3.25.76
       zod-to-json-schema: 3.24.6(zod@3.25.76)
-
-  '@ai-sdk/ui-utils@1.2.11(zod@4.1.9)':
-    dependencies:
-      '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@4.1.9)
-      zod: 4.1.9
-      zod-to-json-schema: 3.24.6(zod@4.1.9)
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -7126,7 +7108,7 @@ snapshots:
     optionalDependencies:
       workerd: 1.20250913.0
 
-  '@cloudflare/vitest-pool-workers@0.9.2(@cloudflare/workers-types@4.20250917.0)(@vitest/runner@3.2.4)(@vitest/snapshot@3.2.4)(vitest@3.2.4(@types/node@24.6.2)(@vitest/ui@3.2.4)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.1))':
+  '@cloudflare/vitest-pool-workers@0.9.2(@cloudflare/workers-types@4.20250917.0)(@vitest/runner@3.2.4)(@vitest/snapshot@3.2.4)(vitest@3.2.4)':
     dependencies:
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -7280,7 +7262,7 @@ snapshots:
     dependencies:
       effect: 3.16.16
 
-  '@effect/vitest@0.23.8(effect@3.16.16)(vitest@3.2.4(@types/node@24.6.2)(@vitest/ui@3.2.4)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.1))':
+  '@effect/vitest@0.23.8(effect@3.16.16)(vitest@3.2.4)':
     dependencies:
       effect: 3.16.16
       vitest: 3.2.4(@types/node@24.6.2)(@vitest/ui@3.2.4)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.1)
@@ -7494,9 +7476,9 @@ snapshots:
       '@eslint/core': 0.15.0
       levn: 0.4.1
 
-  '@finom/zod-to-json-schema@3.24.11(zod@4.1.9)':
+  '@finom/zod-to-json-schema@3.24.11(zod@4.1.12)':
     dependencies:
-      zod: 4.1.9
+      zod: 4.1.12
 
   '@gerrit0/mini-shiki@3.6.0':
     dependencies:
@@ -7875,14 +7857,14 @@ snapshots:
     transitivePeerDependencies:
       - openai
 
-  '@langchain/core@0.3.63(openai@5.20.3(zod@3.25.76))':
+  '@langchain/core@0.3.63(openai@5.20.3(ws@8.18.2)(zod@3.25.76))':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.20
-      langsmith: 0.3.33(openai@5.20.3(zod@3.25.76))
+      langsmith: 0.3.33(openai@5.20.3(ws@8.18.2)(zod@3.25.76))
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -7978,11 +7960,11 @@ snapshots:
 
   '@llamaindex/core@0.6.22':
     dependencies:
-      '@finom/zod-to-json-schema': 3.24.11(zod@4.1.9)
+      '@finom/zod-to-json-schema': 3.24.11(zod@4.1.12)
       '@llamaindex/env': 0.1.30
       '@types/node': 24.6.2
       magic-bytes.js: 1.12.1
-      zod: 4.1.9
+      zod: 4.1.12
     transitivePeerDependencies:
       - '@huggingface/transformers'
       - gpt-tokenizer
@@ -8018,7 +8000,7 @@ snapshots:
       rxjs: 7.8.2
       zod: 3.25.76
 
-  '@llamaindex/workflow-core@1.3.3(@modelcontextprotocol/sdk@1.18.0)(hono@4.9.7)(next@15.3.4)(rxjs@7.8.2)(zod@3.25.76)':
+  '@llamaindex/workflow-core@1.3.3(@modelcontextprotocol/sdk@1.18.0)(hono@4.9.7)(next@15.3.4(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@18.3.1))(react@18.3.1))(rxjs@7.8.2)(zod@3.25.76)':
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.18.0
       hono: 4.9.7
@@ -8026,9 +8008,9 @@ snapshots:
       rxjs: 7.8.2
       zod: 3.25.76
 
-  '@llamaindex/workflow-core@1.3.3(zod@4.1.9)':
+  '@llamaindex/workflow-core@1.3.3(zod@4.1.12)':
     optionalDependencies:
-      zod: 4.1.9
+      zod: 4.1.12
 
   '@llamaindex/workflow@1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(@modelcontextprotocol/sdk@1.18.0)(hono@4.8.0)(next@15.3.4(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@18.3.1))(react@18.3.1))(rxjs@7.8.2)(zod@3.25.76)':
     dependencies:
@@ -8043,11 +8025,11 @@ snapshots:
       - rxjs
       - zod
 
-  '@llamaindex/workflow@1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(@modelcontextprotocol/sdk@1.18.0)(hono@4.9.7)(next@15.3.4)(rxjs@7.8.2)(zod@3.25.76)':
+  '@llamaindex/workflow@1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(@modelcontextprotocol/sdk@1.18.0)(hono@4.9.7)(next@15.3.4(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@18.3.1))(react@18.3.1))(rxjs@7.8.2)(zod@3.25.76)':
     dependencies:
       '@llamaindex/core': 0.6.22
       '@llamaindex/env': 0.1.30
-      '@llamaindex/workflow-core': 1.3.3(@modelcontextprotocol/sdk@1.18.0)(hono@4.9.7)(next@15.3.4)(rxjs@7.8.2)(zod@3.25.76)
+      '@llamaindex/workflow-core': 1.3.3(@modelcontextprotocol/sdk@1.18.0)(hono@4.9.7)(next@15.3.4(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@18.3.1))(react@18.3.1))(rxjs@7.8.2)(zod@3.25.76)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - hono
@@ -8056,11 +8038,11 @@ snapshots:
       - rxjs
       - zod
 
-  '@llamaindex/workflow@1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(zod@4.1.9)':
+  '@llamaindex/workflow@1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(zod@4.1.12)':
     dependencies:
       '@llamaindex/core': 0.6.22
       '@llamaindex/env': 0.1.30
-      '@llamaindex/workflow-core': 1.3.3(zod@4.1.9)
+      '@llamaindex/workflow-core': 1.3.3(zod@4.1.12)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - hono
@@ -8142,63 +8124,6 @@ snapshots:
       - valibot
       - zod-openapi
 
-  '@mastra/core@0.16.3(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@4.1.9)':
-    dependencies:
-      '@a2a-js/sdk': 0.2.5
-      '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@4.1.9)
-      '@ai-sdk/provider-utils-v5': '@ai-sdk/provider-utils@3.0.5(zod@4.1.9)'
-      '@ai-sdk/provider-v5': '@ai-sdk/provider@2.0.0'
-      '@ai-sdk/ui-utils': 1.2.11(zod@4.1.9)
-      '@mastra/schema-compat': 0.11.3(ai@4.3.19(react@18.3.1)(zod@4.1.9))(zod@4.1.9)
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/auto-instrumentations-node': 0.62.1(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.0.1(@opentelemetry/api@1.9.0))
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-trace-otlp-grpc': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-trace-otlp-http': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-exporter-base': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-transformer': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-metrics': 2.0.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-node': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-node': 2.0.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.36.0
-      '@sindresorhus/slugify': 2.2.1
-      ai: 4.3.19(react@18.3.1)(zod@4.1.9)
-      ai-v5: ai@5.0.28(zod@4.1.9)
-      date-fns: 3.6.0
-      dotenv: 16.6.1
-      hono: 4.9.7
-      hono-openapi: 0.4.8(effect@3.16.16)(hono@4.9.7)(openapi-types@12.1.3)(zod@4.1.9)
-      js-tiktoken: 1.0.20
-      json-schema: 0.4.0
-      json-schema-to-zod: 2.6.1
-      p-map: 7.0.3
-      pino: 9.7.0
-      pino-pretty: 13.0.0
-      radash: 12.1.1
-      sift: 17.1.3
-      xstate: 5.20.2
-      zod: 4.1.9
-      zod-to-json-schema: 3.24.6(zod@4.1.9)
-    transitivePeerDependencies:
-      - '@hono/arktype-validator'
-      - '@hono/effect-validator'
-      - '@hono/typebox-validator'
-      - '@hono/valibot-validator'
-      - '@hono/zod-validator'
-      - '@sinclair/typebox'
-      - '@valibot/to-json-schema'
-      - arktype
-      - effect
-      - encoding
-      - openapi-types
-      - react
-      - supports-color
-      - valibot
-      - zod-openapi
-
   '@mastra/mcp@0.12.0(@mastra/core@0.16.3(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@3.25.76))(@types/json-schema@7.0.15)(zod@3.25.76)':
     dependencies:
       '@apidevtools/json-schema-ref-parser': 14.2.1(@types/json-schema@7.0.15)
@@ -8215,22 +8140,6 @@ snapshots:
       - '@types/json-schema'
       - supports-color
 
-  '@mastra/mcp@0.12.0(@mastra/core@0.16.3(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@4.1.9))(@types/json-schema@7.0.15)(zod@4.1.9)':
-    dependencies:
-      '@apidevtools/json-schema-ref-parser': 14.2.1(@types/json-schema@7.0.15)
-      '@mastra/core': 0.16.3(effect@3.16.16)(openapi-types@12.1.3)(react@18.3.1)(zod@4.1.9)
-      '@modelcontextprotocol/sdk': 1.18.0
-      date-fns: 4.1.0
-      exit-hook: 4.0.0
-      fast-deep-equal: 3.1.3
-      uuid: 11.1.0
-      zod: 4.1.9
-      zod-from-json-schema: 0.5.0
-      zod-from-json-schema-v3: zod-from-json-schema@0.0.5
-    transitivePeerDependencies:
-      - '@types/json-schema'
-      - supports-color
-
   '@mastra/schema-compat@0.11.3(ai@4.3.19(react@18.3.1)(zod@3.25.76))(zod@3.25.76)':
     dependencies:
       ai: 4.3.19(react@18.3.1)(zod@3.25.76)
@@ -8239,15 +8148,6 @@ snapshots:
       zod-from-json-schema: 0.5.0
       zod-from-json-schema-v3: zod-from-json-schema@0.0.5
       zod-to-json-schema: 3.24.6(zod@3.25.76)
-
-  '@mastra/schema-compat@0.11.3(ai@4.3.19(react@18.3.1)(zod@4.1.9))(zod@4.1.9)':
-    dependencies:
-      ai: 4.3.19(react@18.3.1)(zod@4.1.9)
-      json-schema: 0.4.0
-      zod: 4.1.9
-      zod-from-json-schema: 0.5.0
-      zod-from-json-schema-v3: zod-from-json-schema@0.0.5
-      zod-to-json-schema: 3.24.6(zod@4.1.9)
 
   '@modelcontextprotocol/sdk@1.18.0':
     dependencies:
@@ -9630,14 +9530,6 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@6.3.5(@types/node@20.19.1)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.0))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.17
-    optionalDependencies:
-      vite: 6.3.5(@types/node@20.19.1)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.0)
-
   '@vitest/mocker@3.2.4(vite@6.3.5(@types/node@22.15.32)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -9645,22 +9537,6 @@ snapshots:
       magic-string: 0.30.17
     optionalDependencies:
       vite: 6.3.5(@types/node@22.15.32)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.1)
-
-  '@vitest/mocker@3.2.4(vite@6.3.5(@types/node@24.0.3)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.1))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.17
-    optionalDependencies:
-      vite: 6.3.5(@types/node@24.0.3)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.1)
-
-  '@vitest/mocker@3.2.4(vite@6.3.5(@types/node@24.6.2)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.1))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.17
-    optionalDependencies:
-      vite: 6.3.5(@types/node@24.6.2)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.1)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -9691,7 +9567,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@24.6.2)(@vitest/ui@3.2.4)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.1)
+      vitest: 3.2.4(@types/node@22.15.32)(@vitest/ui@3.2.4)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.1)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -9745,18 +9621,6 @@ snapshots:
     optionalDependencies:
       react: 18.3.1
 
-  ai@4.3.19(react@18.3.1)(zod@4.1.9):
-    dependencies:
-      '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@4.1.9)
-      '@ai-sdk/react': 1.2.12(react@18.3.1)(zod@4.1.9)
-      '@ai-sdk/ui-utils': 1.2.11(zod@4.1.9)
-      '@opentelemetry/api': 1.9.0
-      jsondiffpatch: 0.6.0
-      zod: 4.1.9
-    optionalDependencies:
-      react: 18.3.1
-
   ai@5.0.28(zod@3.25.76):
     dependencies:
       '@ai-sdk/gateway': 1.0.15(zod@3.25.76)
@@ -9765,14 +9629,6 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       zod: 3.25.76
 
-  ai@5.0.28(zod@4.1.9):
-    dependencies:
-      '@ai-sdk/gateway': 1.0.15(zod@4.1.9)
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.7(zod@4.1.9)
-      '@opentelemetry/api': 1.9.0
-      zod: 4.1.9
-
   ai@5.0.44(zod@3.25.76):
     dependencies:
       '@ai-sdk/gateway': 1.0.23(zod@3.25.76)
@@ -9780,14 +9636,6 @@ snapshots:
       '@ai-sdk/provider-utils': 3.0.9(zod@3.25.76)
       '@opentelemetry/api': 1.9.0
       zod: 3.25.76
-
-  ai@5.0.44(zod@4.1.9):
-    dependencies:
-      '@ai-sdk/gateway': 1.0.23(zod@4.1.9)
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.9(zod@4.1.9)
-      '@opentelemetry/api': 1.9.0
-      zod: 4.1.9
 
   ajv@6.12.6:
     dependencies:
@@ -10117,7 +9965,7 @@ snapshots:
       resolve-package-path: 4.0.3
       uuid: 10.0.0
       zod: 3.25.76
-      zod-to-json-schema: 3.24.5(zod@3.25.76)
+      zod-to-json-schema: 3.24.6(zod@3.25.76)
     transitivePeerDependencies:
       - debug
 
@@ -10937,15 +10785,6 @@ snapshots:
       hono: 4.9.7
       zod: 3.25.76
 
-  hono-openapi@0.4.8(effect@3.16.16)(hono@4.9.7)(openapi-types@12.1.3)(zod@4.1.9):
-    dependencies:
-      json-schema-walker: 2.0.0
-      openapi-types: 12.1.3
-    optionalDependencies:
-      effect: 3.16.16
-      hono: 4.9.7
-      zod: 4.1.9
-
   hono@4.8.0: {}
 
   hono@4.9.7: {}
@@ -11233,7 +11072,7 @@ snapshots:
     optionalDependencies:
       openai: 4.104.0(ws@8.18.2)(zod@3.25.76)
 
-  langsmith@0.3.33(openai@5.20.3(zod@3.25.76)):
+  langsmith@0.3.33(openai@5.20.3(ws@8.18.2)(zod@3.25.76)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 4.1.2
@@ -11299,12 +11138,12 @@ snapshots:
       rfdc: 1.4.1
       wrap-ansi: 9.0.0
 
-  llamaindex@0.12.0(@modelcontextprotocol/sdk@1.18.0)(hono@4.9.7)(next@15.3.4)(rxjs@7.8.2)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@3.25.76):
+  llamaindex@0.12.0(@modelcontextprotocol/sdk@1.18.0)(hono@4.9.7)(next@15.3.4(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@18.3.1))(react@18.3.1))(rxjs@7.8.2)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@3.25.76):
     dependencies:
       '@llamaindex/core': 0.6.22
       '@llamaindex/env': 0.1.30
       '@llamaindex/node-parser': 2.0.22(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)
-      '@llamaindex/workflow': 1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(@modelcontextprotocol/sdk@1.18.0)(hono@4.9.7)(next@15.3.4)(rxjs@7.8.2)(zod@3.25.76)
+      '@llamaindex/workflow': 1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(@modelcontextprotocol/sdk@1.18.0)(hono@4.9.7)(next@15.3.4(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@18.3.1))(react@18.3.1))(rxjs@7.8.2)(zod@3.25.76)
       '@types/lodash': 4.17.20
       '@types/node': 24.6.2
       lodash: 4.17.21
@@ -11321,12 +11160,12 @@ snapshots:
       - web-tree-sitter
       - zod
 
-  llamaindex@0.12.0(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@4.1.9):
+  llamaindex@0.12.0(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@4.1.12):
     dependencies:
       '@llamaindex/core': 0.6.22
       '@llamaindex/env': 0.1.30
       '@llamaindex/node-parser': 2.0.22(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)
-      '@llamaindex/workflow': 1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(zod@4.1.9)
+      '@llamaindex/workflow': 1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(zod@4.1.12)
       '@types/lodash': 4.17.20
       '@types/node': 24.6.2
       lodash: 4.17.21
@@ -11663,10 +11502,10 @@ snapshots:
       ws: 8.18.2
       zod: 3.25.76
 
-  openai@5.19.1(ws@8.18.2)(zod@4.1.9):
+  openai@5.19.1(ws@8.18.2)(zod@3.25.76):
     optionalDependencies:
       ws: 8.18.2
-      zod: 4.1.9
+      zod: 3.25.76
 
   openai@5.20.3(ws@8.18.2)(zod@3.25.76):
     optionalDependencies:
@@ -12954,7 +12793,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@20.19.1)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.0))
+      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@22.15.32)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.1))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -13038,7 +12877,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@24.0.3)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.1))
+      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@22.15.32)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.1))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -13080,7 +12919,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@24.6.2)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.1))
+      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@22.15.32)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.1))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -13271,23 +13110,15 @@ snapshots:
 
   zod-from-json-schema@0.5.0:
     dependencies:
-      zod: 4.1.9
+      zod: 4.1.12
 
   zod-to-json-schema@3.24.5(zod@3.25.76):
     dependencies:
       zod: 3.25.76
 
-  zod-to-json-schema@3.24.5(zod@4.1.9):
-    dependencies:
-      zod: 4.1.9
-
   zod-to-json-schema@3.24.6(zod@3.25.76):
     dependencies:
       zod: 3.25.76
-
-  zod-to-json-schema@3.24.6(zod@4.1.9):
-    dependencies:
-      zod: 4.1.9
 
   zod@3.22.3: {}
 
@@ -13295,4 +13126,4 @@ snapshots:
 
   zod@3.25.76: {}
 
-  zod@4.1.9: {}
+  zod@4.1.12: {}

--- a/ts/examples/tools/package.json
+++ b/ts/examples/tools/package.json
@@ -21,6 +21,7 @@
     "@composio/core": "workspace:*",
     "dotenv": "^16.4.1",
     "openai": "^5.19.1",
+    "zod": "catalog:",
     "zod-to-json-schema": "^3.24.5"
   },
   "devDependencies": {

--- a/ts/examples/tools/src/tool-conversion.ts
+++ b/ts/examples/tools/src/tool-conversion.ts
@@ -1,12 +1,11 @@
 import { Composio, jsonSchemaToZodSchema } from '@composio/core';
-import { nullable, z } from 'zod';
 import zodToJsonSchema from 'zod-to-json-schema';
 
 const composio = new Composio({
   apiKey: process.env.COMPOSIO_API_KEY,
 });
 
-const tool = await composio.tools.getRawComposioToolBySlug('SLACK_SEND_MESSAGE');
+const tool = await composio.tools.getRawComposioToolBySlug('HUBSPOT_CREATE_LINE_ITEMS');
 const inputParams = tool.inputParameters;
 console.log(`---------- Original Input Parameters ----------`);
 console.log(JSON.stringify(inputParams, null, 2));

--- a/ts/examples/vercel/package.json
+++ b/ts/examples/vercel/package.json
@@ -20,7 +20,8 @@
     "@composio/vercel": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.18.0",
     "ai": "catalog:",
-    "dotenv": "^16.5.0"
+    "dotenv": "^16.5.0",
+    "zod-to-json-schema": "^3.24.6"
   },
   "devDependencies": {
     "@types/bun": "^1.2.9",

--- a/ts/examples/vercel/src/index.ts
+++ b/ts/examples/vercel/src/index.ts
@@ -19,7 +19,7 @@ const composio = new Composio({
  * Alternatively, you can use the `composio.getToolBySlug` method
  */
 async function run() {
-  const tools = await composio.tools.get('test-user-id', 'HACKERNEWS_GET_FRONTPAGE', {
+  const tools = await composio.tools.get('test-user-id', 'HUBSPOT_CREATE_LINE_ITEMS', {
     beforeExecute: ({ params, toolSlug }) => {
       console.log(`🔄 Executing ${toolSlug} with params:`, { params });
       return params;
@@ -33,12 +33,14 @@ async function run() {
   const messages: ModelMessage[] = [
     {
       role: MessageRoles.USER,
-      content: 'Summarize the front page of HackerNews',
+      content: 'What tools do you have access to?',
     },
   ];
 
+  // const schema = tools[0].inputSchema;
+
   const { text } = await generateText({
-    model: openai('gpt-4o-mini'),
+    model: openai.responses('gpt-4.1'),
     tools: tools,
     messages,
     stopWhen: stepCountIs(5),

--- a/ts/packages/core/package.json
+++ b/ts/packages/core/package.json
@@ -45,7 +45,7 @@
     "zod": "catalog:"
   },
   "peerDependencies": {
-    "zod": "3.25.76"
+    "zod": ">=3.25.76 <5"
   },
   "dependencies": {
     "@composio/client": "catalog:",

--- a/ts/packages/core/src/errors/ComposioError.ts
+++ b/ts/packages/core/src/errors/ComposioError.ts
@@ -9,7 +9,7 @@
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error}
  */
 import chalk from 'chalk';
-import { ZodError } from 'zod';
+import { ZodError } from 'zod/v3';
 import { BadRequestError } from '@composio/client';
 import logger from '../utils/logger';
 

--- a/ts/packages/core/src/errors/ValidationErrors.ts
+++ b/ts/packages/core/src/errors/ValidationErrors.ts
@@ -1,6 +1,6 @@
 // packages/core/src/errors/ValidationError.ts
 
-import { ZodError } from 'zod';
+import { ZodError } from 'zod/v3';
 import { ComposioError, ComposioErrorOptions } from './ComposioError';
 
 /**

--- a/ts/packages/core/src/services/internal/InternalService.types.ts
+++ b/ts/packages/core/src/services/internal/InternalService.types.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export interface ComposioSDKRealtimeCredentialsResponse {
   pusher_key: string;

--- a/ts/packages/core/src/services/telemetry/TelemetryService.types.ts
+++ b/ts/packages/core/src/services/telemetry/TelemetryService.types.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const TelemetryMetricSourceSchema = z.object({
   host: z

--- a/ts/packages/core/src/types/authConfigs.types.ts
+++ b/ts/packages/core/src/types/authConfigs.types.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const AuthConfigTypes = {
   CUSTOM: 'use_custom_auth',

--- a/ts/packages/core/src/types/connectedAccountAuthStates.types.ts
+++ b/ts/packages/core/src/types/connectedAccountAuthStates.types.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 import { AuthSchemeTypes } from './authConfigs.types';
 
 export const ConnectionStatuses = {

--- a/ts/packages/core/src/types/connectedAccounts.types.ts
+++ b/ts/packages/core/src/types/connectedAccounts.types.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 import { ConnectionDataSchema } from './connectedAccountAuthStates.types';
 
 /**

--- a/ts/packages/core/src/types/customTool.types.ts
+++ b/ts/packages/core/src/types/customTool.types.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 import { Tool, ToolProxyParams } from './tool.types';
 import { ToolExecuteResponse } from '@composio/client/resources/tools';
 import { ConnectionData } from './connectedAccountAuthStates.types';

--- a/ts/packages/core/src/types/mcp.experimental.types.ts
+++ b/ts/packages/core/src/types/mcp.experimental.types.ts
@@ -1,4 +1,4 @@
-import z from 'zod';
+import z from 'zod/v3';
 
 export const MCPServerInstanceSchema = z.object({
   id: z.string(),

--- a/ts/packages/core/src/types/mcp.types.ts
+++ b/ts/packages/core/src/types/mcp.types.ts
@@ -3,7 +3,7 @@ import {
   McpCreateResponse as McpCreateResponseRaw,
   GenerateURLResponse as GenerateURLResponseRaw,
 } from '@composio/client/resources/mcp';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 /**
  * @deprecated

--- a/ts/packages/core/src/types/tool.types.ts
+++ b/ts/packages/core/src/types/tool.types.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 import { CustomConnectionDataSchema } from './connectedAccountAuthStates.types';
 import { TransformToolSchemaModifier } from './modifiers.types';
 

--- a/ts/packages/core/src/types/toolRouter.types.ts
+++ b/ts/packages/core/src/types/toolRouter.types.ts
@@ -1,4 +1,4 @@
-import z from 'zod';
+import z from 'zod/v3';
 
 export const ToolRouterToolkitConfigSchema = z.object({
   toolkit: z.string(),

--- a/ts/packages/core/src/types/toolkit.types.ts
+++ b/ts/packages/core/src/types/toolkit.types.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 import { AuthSchemeEnum } from './authConfigs.types';
 
 /**

--- a/ts/packages/core/src/types/triggers.types.ts
+++ b/ts/packages/core/src/types/triggers.types.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const TriggerStatuses = {
   ENABLE: 'enable',

--- a/ts/packages/core/src/utils/jsonSchema.ts
+++ b/ts/packages/core/src/utils/jsonSchema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 import { JsonSchemaToZodError } from '../errors';
 import { jsonSchemaToZod } from '@composio/json-schema-to-zod';
 

--- a/ts/packages/core/src/utils/transform.ts
+++ b/ts/packages/core/src/utils/transform.ts
@@ -11,7 +11,7 @@
  *   .using((raw) => ({ ... }))
  * ```
  */
-import { ZodTypeAny, z } from 'zod';
+import { ZodTypeAny, z } from 'zod/v3';
 import { ValidationError } from '../errors';
 import { logger } from '..';
 

--- a/ts/packages/core/test/AuthConfigs/authConfigs.test.ts
+++ b/ts/packages/core/test/AuthConfigs/authConfigs.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { AuthConfigs } from '../../src/models/AuthConfigs';
 import ComposioClient from '@composio/client';
 import { ValidationError } from '../../src/errors/ValidationErrors';
-import { ZodError } from 'zod';
+import { ZodError } from 'zod/v3';
 import {
   AuthConfigRetrieveResponse as ComposioAuthConfigRetrieveResponse,
   AuthConfigDeleteResponse,

--- a/ts/packages/core/test/tools/customTools.test.ts
+++ b/ts/packages/core/test/tools/customTools.test.ts
@@ -3,7 +3,7 @@ import { CustomTools } from '../../src/models/CustomTools';
 import { mockClient } from '../utils/mocks/client.mock';
 import { toolMocks } from '../utils/mocks/data.mock';
 import ComposioClient from '@composio/client';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 import { ComposioToolNotFoundError } from '../../src/errors/ToolErrors';
 import { ComposioConnectedAccountNotFoundError } from '../../src/errors/ConnectedAccountsErrors';
 import { ValidationError } from '../../src/errors';

--- a/ts/packages/core/test/utils/mocks/data.mock.ts
+++ b/ts/packages/core/test/utils/mocks/data.mock.ts
@@ -1,5 +1,3 @@
-import { z } from 'zod';
-
 export const toolMocks = {
   rawTool: {
     slug: 'COMPOSIO_TOOL',

--- a/ts/packages/json-schema-to-zod/package.json
+++ b/ts/packages/json-schema-to-zod/package.json
@@ -39,6 +39,6 @@
     "zod": "catalog:"
   },
   "peerDependencies": {
-    "zod": "3.25.76"
+    "zod": ">=3.25.76 <5"
   }
 }

--- a/ts/packages/json-schema-to-zod/src/json-schema-to-zod.ts
+++ b/ts/packages/json-schema-to-zod/src/json-schema-to-zod.ts
@@ -1,4 +1,4 @@
-import type { z } from 'zod';
+import type { z } from 'zod/v3';
 
 import { parseSchema } from './parsers/parse-schema';
 import type { JsonSchemaToZodOptions, JsonSchema } from './types';

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-all-of.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-all-of.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 import { parseSchema } from './parse-schema';
 import type { JsonSchemaObject, JsonSchema, Refs } from '../types';
@@ -7,40 +7,40 @@ import { half } from '../utils/half';
 const originalIndex = Symbol('Original index');
 
 const ensureOriginalIndex = (arr: JsonSchema[]) => {
-	const newArr = [];
+  const newArr = [];
 
-	for (let i = 0; i < arr.length; i++) {
-		const item = arr[i];
-		if (typeof item === 'boolean') {
-			newArr.push(item ? { [originalIndex]: i } : { [originalIndex]: i, not: {} });
-		} else if (originalIndex in item) {
-			return arr;
-		} else {
-			newArr.push({ ...item, [originalIndex]: i });
-		}
-	}
+  for (let i = 0; i < arr.length; i++) {
+    const item = arr[i];
+    if (typeof item === 'boolean') {
+      newArr.push(item ? { [originalIndex]: i } : { [originalIndex]: i, not: {} });
+    } else if (originalIndex in item) {
+      return arr;
+    } else {
+      newArr.push({ ...item, [originalIndex]: i });
+    }
+  }
 
-	return newArr;
+  return newArr;
 };
 
 export function parseAllOf(
-	jsonSchema: JsonSchemaObject & { allOf: JsonSchema[] },
-	refs: Refs,
+  jsonSchema: JsonSchemaObject & { allOf: JsonSchema[] },
+  refs: Refs
 ): z.ZodTypeAny {
-	if (jsonSchema.allOf.length === 0) {
-		return z.never();
-	}
+  if (jsonSchema.allOf.length === 0) {
+    return z.never();
+  }
 
-	if (jsonSchema.allOf.length === 1) {
-		const item = jsonSchema.allOf[0];
+  if (jsonSchema.allOf.length === 1) {
+    const item = jsonSchema.allOf[0];
 
-		return parseSchema(item, {
-			...refs,
-			path: [...refs.path, 'allOf', (item as never)[originalIndex]],
-		});
-	}
+    return parseSchema(item, {
+      ...refs,
+      path: [...refs.path, 'allOf', (item as never)[originalIndex]],
+    });
+  }
 
-	const [left, right] = half(ensureOriginalIndex(jsonSchema.allOf));
+  const [left, right] = half(ensureOriginalIndex(jsonSchema.allOf));
 
-	return z.intersection(parseAllOf({ allOf: left }, refs), parseAllOf({ allOf: right }, refs));
+  return z.intersection(parseAllOf({ allOf: left }, refs), parseAllOf({ allOf: right }, refs));
 }

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-any-of.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-any-of.ts
@@ -1,19 +1,19 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 import { parseSchema } from './parse-schema';
 import type { JsonSchemaObject, JsonSchema, Refs } from '../types';
 
 export const parseAnyOf = (jsonSchema: JsonSchemaObject & { anyOf: JsonSchema[] }, refs: Refs) => {
-	return jsonSchema.anyOf.length
-		? jsonSchema.anyOf.length === 1
-			? parseSchema(jsonSchema.anyOf[0], {
-					...refs,
-					path: [...refs.path, 'anyOf', 0],
-				})
-			: z.union(
-					jsonSchema.anyOf.map((schema, i) =>
-						parseSchema(schema, { ...refs, path: [...refs.path, 'anyOf', i] }),
-					) as [z.ZodTypeAny, z.ZodTypeAny],
-				)
-		: z.any();
+  return jsonSchema.anyOf.length
+    ? jsonSchema.anyOf.length === 1
+      ? parseSchema(jsonSchema.anyOf[0], {
+          ...refs,
+          path: [...refs.path, 'anyOf', 0],
+        })
+      : z.union(
+          jsonSchema.anyOf.map((schema, i) =>
+            parseSchema(schema, { ...refs, path: [...refs.path, 'anyOf', i] })
+          ) as [z.ZodTypeAny, z.ZodTypeAny]
+        )
+    : z.any();
 };

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-array.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-array.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 import { parseSchema } from './parse-schema';
 import type { JsonSchemaObject, Refs, JsonSchema } from '../types';

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-boolean.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-boolean.ts
@@ -1,7 +1,7 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 import type { JsonSchemaObject } from '../types';
 
 export const parseBoolean = (_jsonSchema: JsonSchemaObject & { type: 'boolean' }) => {
-	return z.boolean();
+  return z.boolean();
 };

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-const.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-const.ts
@@ -1,7 +1,7 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 import type { JsonSchemaObject, Serializable } from '../types';
 
 export const parseConst = (jsonSchema: JsonSchemaObject & { const: Serializable }) => {
-	return z.literal(jsonSchema.const as z.Primitive);
+  return z.literal(jsonSchema.const as z.Primitive);
 };

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-default.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-default.ts
@@ -1,7 +1,7 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 import type { JsonSchemaObject } from '../types';
 
 export const parseDefault = (_jsonSchema: JsonSchemaObject) => {
-	return z.any();
+  return z.any();
 };

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-enum.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-enum.ts
@@ -1,25 +1,22 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 import type { JsonSchemaObject, Serializable } from '../types';
 
 export const parseEnum = (jsonSchema: JsonSchemaObject & { enum: Serializable[] }) => {
-	if (jsonSchema.enum.length === 0) {
-		return z.never();
-	}
+  if (jsonSchema.enum.length === 0) {
+    return z.never();
+  }
 
-	if (jsonSchema.enum.length === 1) {
-		// union does not work when there is only one element
-		return z.literal(jsonSchema.enum[0] as z.Primitive);
-	}
+  if (jsonSchema.enum.length === 1) {
+    // union does not work when there is only one element
+    return z.literal(jsonSchema.enum[0] as z.Primitive);
+  }
 
-	if (jsonSchema.enum.every((x) => typeof x === 'string')) {
-		return z.enum(jsonSchema.enum as [string]);
-	}
+  if (jsonSchema.enum.every(x => typeof x === 'string')) {
+    return z.enum(jsonSchema.enum as [string]);
+  }
 
-	return z.union(
-		jsonSchema.enum.map((x) => z.literal(x as z.Primitive)) as unknown as [
-			z.ZodTypeAny,
-			z.ZodTypeAny,
-		],
-	);
+  return z.union(
+    jsonSchema.enum.map(x => z.literal(x as z.Primitive)) as unknown as [z.ZodTypeAny, z.ZodTypeAny]
+  );
 };

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-if-then-else.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-if-then-else.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 import { parseSchema } from './parse-schema';
 import type { JsonSchemaObject, JsonSchema, Refs } from '../types';

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-multiple-type.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-multiple-type.ts
@@ -1,16 +1,16 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 import { parseSchema } from './parse-schema';
 import type { JsonSchema, JsonSchemaObject, Refs } from '../types';
 
 export const parseMultipleType = (
-	jsonSchema: JsonSchemaObject & { type: string[] },
-	refs: Refs,
+  jsonSchema: JsonSchemaObject & { type: string[] },
+  refs: Refs
 ) => {
-	return z.union(
-		jsonSchema.type.map((type) => parseSchema({ ...jsonSchema, type } as JsonSchema, refs)) as [
-			z.ZodTypeAny,
-			z.ZodTypeAny,
-		],
-	);
+  return z.union(
+    jsonSchema.type.map(type => parseSchema({ ...jsonSchema, type } as JsonSchema, refs)) as [
+      z.ZodTypeAny,
+      z.ZodTypeAny,
+    ]
+  );
 };

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-not.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-not.ts
@@ -1,15 +1,15 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 import { parseSchema } from './parse-schema';
 import type { JsonSchemaObject, JsonSchema, Refs } from '../types';
 
 export const parseNot = (jsonSchema: JsonSchemaObject & { not: JsonSchema }, refs: Refs) => {
-	return z.any().refine(
-		(value) =>
-			!parseSchema(jsonSchema.not, {
-				...refs,
-				path: [...refs.path, 'not'],
-			}).safeParse(value).success,
-		'Invalid input: Should NOT be valid against schema',
-	);
+  return z.any().refine(
+    value =>
+      !parseSchema(jsonSchema.not, {
+        ...refs,
+        path: [...refs.path, 'not'],
+      }).safeParse(value).success,
+    'Invalid input: Should NOT be valid against schema'
+  );
 };

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-null.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-null.ts
@@ -1,7 +1,7 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 import type { JsonSchemaObject } from '../types';
 
 export const parseNull = (_jsonSchema: JsonSchemaObject & { type: 'null' }) => {
-	return z.null();
+  return z.null();
 };

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-number.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-number.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 import type { JsonSchemaObject } from '../types';
 import { extendSchemaWithMessage } from '../utils/extend-schema';

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-object.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-object.ts
@@ -9,7 +9,8 @@ import { its } from '../utils/its';
 
 function parseObjectProperties(objectSchema: JsonSchemaObject & { type: 'object' }, refs: Refs) {
   if (!objectSchema.properties) {
-    return undefined;
+    // leave it as an empty object or else this will break openai responses
+    return z.object({});
   }
 
   const propertyKeys = Object.keys(objectSchema.properties);
@@ -187,17 +188,11 @@ export function parseObject(
         // When additionalProperties was explicitly true, use passthrough
         output = propertiesSchema.passthrough();
       } else {
-        // Check if propertiesSchema is an empty object
-        const isEmptyObject = Object.keys(propertiesSchema._def.shape()).length === 0;
-        if (isEmptyObject) {
-          output = propertiesSchema.passthrough();
-        } else {
-          output = propertiesSchema.catchall(additionalProperties);
-        }
+        output = propertiesSchema.catchall(additionalProperties);
       }
     } else {
-      // When additionalProperties is not specified, treat it as true
-      output = propertiesSchema.passthrough();
+      // When additionalProperties is not specified, treat it as false
+      output = propertiesSchema.strict();
     }
   } else {
     if (hasPatternProperties) {

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-object.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-object.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v3';
 
 import { parseAllOf } from './parse-all-of';
 import { parseAnyOf } from './parse-any-of';

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-one-of.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-one-of.ts
@@ -1,41 +1,41 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 import { parseSchema } from './parse-schema';
 import type { JsonSchemaObject, JsonSchema, Refs } from '../types';
 
 export const parseOneOf = (jsonSchema: JsonSchemaObject & { oneOf: JsonSchema[] }, refs: Refs) => {
-	if (!jsonSchema.oneOf.length) {
-		return z.any();
-	}
+  if (!jsonSchema.oneOf.length) {
+    return z.any();
+  }
 
-	if (jsonSchema.oneOf.length === 1) {
-		return parseSchema(jsonSchema.oneOf[0], {
-			...refs,
-			path: [...refs.path, 'oneOf', 0],
-		});
-	}
+  if (jsonSchema.oneOf.length === 1) {
+    return parseSchema(jsonSchema.oneOf[0], {
+      ...refs,
+      path: [...refs.path, 'oneOf', 0],
+    });
+  }
 
-	return z.any().superRefine((x, ctx) => {
-		const schemas = jsonSchema.oneOf.map((schema, i) =>
-			parseSchema(schema, {
-				...refs,
-				path: [...refs.path, 'oneOf', i],
-			}),
-		);
+  return z.any().superRefine((x, ctx) => {
+    const schemas = jsonSchema.oneOf.map((schema, i) =>
+      parseSchema(schema, {
+        ...refs,
+        path: [...refs.path, 'oneOf', i],
+      })
+    );
 
-		const unionErrors = schemas.reduce<z.ZodError[]>(
-			(errors, schema) =>
-				((result) => (result.error ? [...errors, result.error] : errors))(schema.safeParse(x)),
-			[],
-		);
+    const unionErrors = schemas.reduce<z.ZodError[]>(
+      (errors, schema) =>
+        (result => (result.error ? [...errors, result.error] : errors))(schema.safeParse(x)),
+      []
+    );
 
-		if (schemas.length - unionErrors.length !== 1) {
-			ctx.addIssue({
-				path: ctx.path,
-				code: 'invalid_union',
-				unionErrors,
-				message: 'Invalid input: Should pass single schema',
-			});
-		}
-	});
+    if (schemas.length - unionErrors.length !== 1) {
+      ctx.addIssue({
+        path: ctx.path,
+        code: 'invalid_union',
+        unionErrors,
+        message: 'Invalid input: Should pass single schema',
+      });
+    }
+  });
 };

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-schema.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-schema.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v3';
 
 import { parseAllOf } from './parse-all-of';
 import { parseAnyOf } from './parse-any-of';

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-string.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-string.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 import type { JsonSchemaObject } from '../types';
 import { extendSchemaWithMessage } from '../utils/extend-schema';

--- a/ts/packages/json-schema-to-zod/src/types.ts
+++ b/ts/packages/json-schema-to-zod/src/types.ts
@@ -1,4 +1,4 @@
-import type { ZodTypeAny } from 'zod';
+import type { ZodTypeAny } from 'zod/v3';
 import type { JSONSchema7 } from 'json-schema';
 
 export type Serializable =

--- a/ts/packages/json-schema-to-zod/src/utils/extend-schema.ts
+++ b/ts/packages/json-schema-to-zod/src/utils/extend-schema.ts
@@ -1,4 +1,4 @@
-import type { z } from 'zod';
+import type { z } from 'zod/v3';
 
 import type { JsonSchemaObject } from '../types';
 

--- a/ts/packages/json-schema-to-zod/test/json-to-zod.test.ts
+++ b/ts/packages/json-schema-to-zod/test/json-to-zod.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 import zodToJsonSchema from 'zod-to-json-schema';
 import { jsonSchemaToZod } from '../src/json-schema-to-zod';
 import type { JsonSchema } from '../src/types';

--- a/ts/packages/json-schema-to-zod/test/json-to-zod.test.ts
+++ b/ts/packages/json-schema-to-zod/test/json-to-zod.test.ts
@@ -292,7 +292,7 @@ describe('jsonSchemaToZod', () => {
       ).toThrow();
     });
 
-    it('should allow any additional properties when additionalProperties is not specified', () => {
+    it('should reject additional properties when additionalProperties is not specified', () => {
       const schema: JsonSchema = {
         type: 'object',
         properties: {
@@ -301,10 +301,7 @@ describe('jsonSchemaToZod', () => {
       };
       const zodSchema = jsonSchemaToZod(schema);
       expect(zodSchema.parse({ name: 'John' })).toEqual({ name: 'John' });
-      expect(zodSchema.parse({ name: 'John', extra: 'field' })).toEqual({
-        name: 'John',
-        extra: 'field',
-      });
+      expect(() => zodSchema.parse({ name: 'John', extra: 'field' })).toThrow();
     });
 
     it('should handle additionalProperties with patternProperties', () => {
@@ -1289,7 +1286,7 @@ describe('jsonSchemaToZod', () => {
           count: { type: 'number' },
         },
         required: ['value'],
-        additionalProperties: true,
+        additionalProperties: false,
       });
 
       // Test parsing behavior
@@ -1309,13 +1306,13 @@ describe('jsonSchemaToZod', () => {
       const zodSchema = jsonSchemaToZod(schema);
       const convertedBack = zodToJsonSchema(zodSchema, { target: 'jsonSchema7' }) as any;
 
-      // When additionalProperties is undefined, it should default to true behavior
-      expect(convertedBack.additionalProperties).toBe(true);
+      // When additionalProperties is undefined, it should default to false behavior (strict)
+      expect(convertedBack.additionalProperties).toBe(false);
       expect(convertedBack.type).toBe('object');
 
-      // Test parsing behavior - should allow any additional properties
+      // Test parsing behavior - should reject additional properties
       expect(zodSchema.parse({})).toEqual({});
-      expect(zodSchema.parse({ any: 'value', number: 123 })).toEqual({ any: 'value', number: 123 });
+      expect(() => zodSchema.parse({ any: 'value', number: 123 })).toThrow();
     });
 
     it('should handle objects with properties and additionalProperties undefined (default behavior)', () => {
@@ -1329,16 +1326,13 @@ describe('jsonSchemaToZod', () => {
       const zodSchema = jsonSchemaToZod(schema);
       const convertedBack = zodToJsonSchema(zodSchema, { target: 'jsonSchema7' }) as any;
 
-      // When additionalProperties is undefined, it should default to true behavior
-      expect(convertedBack.additionalProperties).toBe(true);
+      // When additionalProperties is undefined, it should default to false behavior (strict)
+      expect(convertedBack.additionalProperties).toBe(false);
       expect(convertedBack.properties).toBeDefined();
 
-      // Test parsing behavior - should allow any additional properties
+      // Test parsing behavior - should reject additional properties
       expect(zodSchema.parse({ name: 'John' })).toEqual({ name: 'John' });
-      expect(zodSchema.parse({ name: 'John', extra: 'field' })).toEqual({
-        name: 'John',
-        extra: 'field',
-      });
+      expect(() => zodSchema.parse({ name: 'John', extra: 'field' })).toThrow();
     });
 
     it('should handle nested objects with different additionalProperties settings', () => {


### PR DESCRIPTION
basically what is happening here is when we bundle the types, the user got

`import z$1, { z } from 'zod'` which worked as long as they were on `zod 3` as we used zod 3, but as people move to zod 4 this broke for users.

before our our zod 4 pr merges, this is a stop-gap that solves the problem for now. even `zod 4` exports `zod/v3` and all zod versions after `zod@3.25` have `zod/v3` so we can use this to allow user to use zod 4 as a peer and still have types

this doesn't just affect tool router, but practically all our types

you can test this in two ways
1. build and see the ` dist/index.d.ts` and the import def
2. use `@composio/core@0.1.54-alpha-zod-4-peer-type-fix` to try it


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Zod 4 compatibility by using `zod/v3`, updates peer ranges, and refines JSON Schema→Zod parsing (stricter `additionalProperties`), with example updates.
> 
> - **Core (`@composio/core`)**:
>   - Migrate all Zod imports to `zod/v3` and handle `ZodError` accordingly.
>   - Relax peer dep to `zod` `>=3.25.76 <5`.
>   - Update tests to use `zod/v3`.
> - **JSON Schema Parser (`@composio/json-schema-to-zod`)**:
>   - Switch to `zod/v3` types/imports.
>   - Change default object behavior when `additionalProperties` is undefined to be strict (`false`) instead of passthrough; always return `z.object({})` when no properties.
>   - Keep metadata/default handling; minor parser cleanups.
>   - Peer dep relaxed to `zod` `>=3.25.76 <5`.
> - **Examples**:
>   - Tools: add `zod` dep; update tool slug and output.
>   - Vercel: add `zod-to-json-schema`; change tool slug, prompt, and OpenAI model API.
> - **Misc**:
>   - Adjust package versions/lockfile to align with Zod 3/4 interop.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 622373655b43a273e93840daa5c8dbebec360977. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->