### PR TITLE
Docs: Tool router docs tiny fix

### DIFF
--- a/fern/snippets/tool-router/python/quick-start.py
+++ b/fern/snippets/tool-router/python/quick-start.py
@@ -8,8 +8,8 @@ session = composio.experimental.tool_router.create_session(
 )
 # Returns:
 # {
-#   'session_id': 'dKDoDWAGUf-hPM-Bw39pJ',
-#   'url': 'https://apollo.composio.dev/v3/mcp/tool-router/dKDoDWAGUf-hPM-Bw39pJ/mcp'
+#   'session_id': '<session_id>',
+#   'url': '<mcp_url>'
 # }
 
 mcpUrl = session['url']

--- a/fern/snippets/tool-router/typescript/quick-start.ts
+++ b/fern/snippets/tool-router/typescript/quick-start.ts
@@ -7,8 +7,8 @@ const userId = 'hey@example.com';
 const session = await composio.experimental.toolRouter.createSession(userId);
 // Returns:
 // {
-//   sessionId: "dKDoDWAGUf-hPM-Bw39pJ",
-//   url: "https://apollo.composio.dev/v3/mcp/tool-router/dKDoDWAGUf-hPM-Bw39pJ/mcp"
+//   sessionId: "<session_id>",
+//   url: "<mcp_url>"
 // }
 
 const mcpUrl = session.url;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces hardcoded example session IDs and URLs with placeholders in Python and TypeScript tool router quick-start snippets.
> 
> - **Docs — Tool Router quick-start snippets**:
>   - **Python (`fern/snippets/tool-router/python/quick-start.py`)**: Replace example `session_id` and `url` values with `<session_id>` and `<mcp_url>` in the returned object comment.
>   - **TypeScript (`fern/snippets/tool-router/typescript/quick-start.ts`)**: Replace example `sessionId` and `url` values with `<session_id>` and `<mcp_url>` in the returned object comment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ae6d1e9bf81bd39ed5cedecf77f843bd83e846d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->