### PR TITLE
Update sdk headers

### DIFF
--- a/python/composio/client/__init__.py
+++ b/python/composio/client/__init__.py
@@ -4,8 +4,8 @@ This module is a light wrapper around the auto-generated composio client.
 
 import contextvars
 import typing as t
-from uuid import uuid4
 from importlib.metadata import version
+from uuid import uuid4
 
 import typing_extensions as te
 from composio_client import (
@@ -96,7 +96,7 @@ class HttpClient(BaseComposio, WithLogger):
         ctx = self.request_ctx.get()
         request.headers["x-request-id"] = ctx.get("id") or uuid4().hex
         request.headers["x-framework"] = ctx["provider"]
-        request.headers["x-source"] = 'python'
+        request.headers["x-source"] = "python"
         try:
             request.headers["x-sdk-version"] = version("composio")
         except Exception:

--- a/python/tests/test_tool_execution.py
+++ b/python/tests/test_tool_execution.py
@@ -1,11 +1,12 @@
 """Test tool execution with toolkit versions."""
 
-import pytest
 from unittest.mock import Mock, patch
 
+import pytest
+
 from composio.client.types import Tool, tool_list_response
-from composio.core.models.tools import Tools
 from composio.core.models.base import allow_tracking
+from composio.core.models.tools import Tools
 from composio.exceptions import ToolVersionRequiredError
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Injects x-framework, x-source, and x-sdk-version headers and replaces x-framework-provider with x-framework.
> 
> - **Client HTTP headers (`python/composio/client/__init__.py`)**:
>   - Rename `x-framework-provider` to `x-framework`.
>   - Add `x-source: "python"`.
>   - Add `x-sdk-version` resolved via `importlib.metadata.version("composio")` with fallback to `"unknown"`.
>   - Update request interceptor docstring to reflect new headers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b965d0102cd48cd26ea4e723e0d84d22d035889b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->