### PR TITLE
Make tools proxy fail if wrong params

### DIFF
--- a/python/composio/core/models/tools.py
+++ b/python/composio/core/models/tools.py
@@ -489,16 +489,22 @@ class Tools(Resource, t.Generic[TProvider]):
         body: t.Optional[object] = None,
         connected_account_id: t.Optional[str] = None,
         parameters: t.Optional[t.List[tool_proxy_params.Parameter]] = None,
-        custom_connection_data: t.Optional[tool_proxy_params.CustomConnectionData] = None,
+        custom_connection_data: t.Optional[
+            tool_proxy_params.CustomConnectionData
+        ] = None,
     ) -> tool_proxy_response.ToolProxyResponse:
         """Proxy a tool call to the Composio API"""
         return self._client.tools.proxy(
             endpoint=endpoint,
             method=method,
             body=body if body is not None else omit,
-            connected_account_id=connected_account_id if connected_account_id is not None else omit,
+            connected_account_id=connected_account_id
+            if connected_account_id is not None
+            else omit,
             parameters=parameters if parameters is not None else omit,
-            custom_connection_data=custom_connection_data if custom_connection_data is not None else omit,
+            custom_connection_data=custom_connection_data
+            if custom_connection_data is not None
+            else omit,
         )
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replace kwargs-based `Tools.proxy` with explicit, strictly typed parameters and omit None values when forwarding to the API.
> 
> - **Python SDK**:
>   - Update `Tools.proxy` to take explicit params: `endpoint`, `method` (HTTP verb literal), and optional `body`, `connected_account_id`, `parameters`, `custom_connection_data`; forward `None` as `omit`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3d3912713b0c3b2aef6fb2e29510aef2357ea57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->