### PR TITLE
Chore: Update readme with openai agents example

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,75 @@ The Python SDK offers a Pythonic interface to Composio's services, making it eas
 
 For detailed information about the Python SDK, please refer to the [Python SDK Documentation](/python/README.md).
 
+## Provider Support
+
+The following table shows which AI frameworks and platforms are supported in each SDK:
+
+| Provider | TypeScript | Python |
+|----------|:----------:|:------:|
+| OpenAI | ✅ | ✅ |
+| OpenAI Agents | ✅ | ✅ |
+| Anthropic | ✅ | ✅ |
+| LangChain | ✅ | ✅ |
+| LangGraph | ✅* | ✅ |
+| LlamaIndex | ✅ | ✅ |
+| Vercel AI SDK | ✅ | ❌ |
+| Google Gemini | ✅ | ✅ |
+| Google ADK | ❌ | ✅ |
+| Mastra | ✅ | ❌ |
+| Cloudflare Workers AI | ✅ | ❌ |
+| CrewAI | ❌ | ✅ |
+| AutoGen | ❌ | ✅ |
+
+\* *LangGraph in TypeScript is supported via the `@composio/langchain` package.*
+
+> **Don't see your provider?** Learn how to [build a custom provider](https://docs.composio.dev/sdk/typescript/custom-providers) to integrate with any AI framework.
+
+## Packages
+
+### Core Packages
+
+| Package | Version |
+|---------|---------|
+| **TypeScript** | |
+| [@composio/core](https://www.npmjs.com/package/@composio/core) | ![npm version](https://img.shields.io/npm/v/@composio/core) |
+| **Python** | |
+| [composio](https://pypi.org/project/composio/) | ![PyPI version](https://img.shields.io/pypi/v/composio) |
+
+### Provider Packages
+
+| Package | Version |
+|---------|---------|
+| **TypeScript** | |
+| [@composio/openai](https://www.npmjs.com/package/@composio/openai) | ![npm version](https://img.shields.io/npm/v/@composio/openai) |
+| [@composio/openai-agents](https://www.npmjs.com/package/@composio/openai-agents) | ![npm version](https://img.shields.io/npm/v/@composio/openai-agents) |
+| [@composio/anthropic](https://www.npmjs.com/package/@composio/anthropic) | ![npm version](https://img.shields.io/npm/v/@composio/anthropic) |
+| [@composio/langchain](https://www.npmjs.com/package/@composio/langchain) | ![npm version](https://img.shields.io/npm/v/@composio/langchain) |
+| [@composio/llamaindex](https://www.npmjs.com/package/@composio/llamaindex) | ![npm version](https://img.shields.io/npm/v/@composio/llamaindex) |
+| [@composio/vercel](https://www.npmjs.com/package/@composio/vercel) | ![npm version](https://img.shields.io/npm/v/@composio/vercel) |
+| [@composio/google](https://www.npmjs.com/package/@composio/google) | ![npm version](https://img.shields.io/npm/v/@composio/google) |
+| [@composio/mastra](https://www.npmjs.com/package/@composio/mastra) | ![npm version](https://img.shields.io/npm/v/@composio/mastra) |
+| [@composio/cloudflare](https://www.npmjs.com/package/@composio/cloudflare) | ![npm version](https://img.shields.io/npm/v/@composio/cloudflare) |
+| **Python** | |
+| [composio-openai](https://pypi.org/project/composio-openai/) | ![PyPI version](https://img.shields.io/pypi/v/composio-openai) |
+| [composio-openai-agents](https://pypi.org/project/composio-openai-agents/) | ![PyPI version](https://img.shields.io/pypi/v/composio-openai-agents) |
+| [composio-anthropic](https://pypi.org/project/composio-anthropic/) | ![PyPI version](https://img.shields.io/pypi/v/composio-anthropic) |
+| [composio-langchain](https://pypi.org/project/composio-langchain/) | ![PyPI version](https://img.shields.io/pypi/v/composio-langchain) |
+| [composio-langgraph](https://pypi.org/project/composio-langgraph/) | ![PyPI version](https://img.shields.io/pypi/v/composio-langgraph) |
+| [composio-llamaindex](https://pypi.org/project/composio-llamaindex/) | ![PyPI version](https://img.shields.io/pypi/v/composio-llamaindex) |
+| [composio-crewai](https://pypi.org/project/composio-crewai/) | ![PyPI version](https://img.shields.io/pypi/v/composio-crewai) |
+| [composio-autogen](https://pypi.org/project/composio-autogen/) | ![PyPI version](https://img.shields.io/pypi/v/composio-autogen) |
+| [composio-gemini](https://pypi.org/project/composio-gemini/) | ![PyPI version](https://img.shields.io/pypi/v/composio-gemini) |
+| [composio-google](https://pypi.org/project/composio-google/) | ![PyPI version](https://img.shields.io/pypi/v/composio-google) |
+| [composio-google-adk](https://pypi.org/project/composio-google-adk/) | ![PyPI version](https://img.shields.io/pypi/v/composio-google-adk) |
+
+### Utility Packages
+
+| Package | Version |
+|---------|---------|
+| [@composio/json-schema-to-zod](https://www.npmjs.com/package/@composio/json-schema-to-zod) | ![npm version](https://img.shields.io/npm/v/@composio/json-schema-to-zod) |
+| [@composio/ts-builders](https://www.npmjs.com/package/@composio/ts-builders) | ![npm version](https://img.shields.io/npm/v/@composio/ts-builders) |
+
 _if you are looking for the older sdk, you can find them [here](https://github.com/ComposioHQ/composio/tree/master)_
 
 ## Rube


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Revises README to use OpenAI Agents examples for TS/Python and adds a provider support matrix plus package listings with badges.
> 
> - **README**:
>   - **Examples updated to OpenAI Agents**:
>     - TypeScript: replace `@composio/openai` + OpenAI chat completions with `@composio/openai-agents` and `@openai/agents` (`Agent`, `run`); update install commands, imports, provider (`OpenAIAgentsProvider`), tool retrieval, and result handling.
>     - Python: replace `composio_openai` + OpenAI chat completions with `composio_openai_agents` and `agents` (`Agent`, `Runner.run`); update install commands, imports, provider (`OpenAIAgentsProvider`), and async run example.
>   - **Provider Support**: add table listing supported providers across TypeScript and Python, with note on LangGraph TS support via `@composio/langchain`.
>   - **Packages**: add core, provider, and utility package lists with links and version badges.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08fb52fa9c1800fe075d34ce03c1828b7053a94a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->