### PR TITLE
Fix CLI intstallation tests

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -270,8 +270,8 @@ zsh)
     ;;
 bash)
     commands=(
-        "export $install_env=$quoted_install_dir"
-        "export PATH=\"$bin_env:\$PATH\""
+        "export COMPOSIO_INSTALL_DIR=$quoted_install_dir"
+        "export PATH=\"\$COMPOSIO_INSTALL_DIR:\$PATH\""
     )
 
     bash_configs=(
@@ -320,8 +320,8 @@ bash)
 
 *)
     echo 'Manually add the directory to ~/.bashrc (or similar):'
-    info_bold "  export $install_env=$quoted_install_dir"
-    info_bold "  export PATH=\"$bin_env:\$PATH\""
+    info_bold "  export COMPOSIO_INSTALL_DIR=$quoted_install_dir"
+    info_bold "  export PATH=\"\$COMPOSIO_INSTALL_DIR:\$PATH\""
     ;;
 esac
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates bash install steps to export COMPOSIO_INSTALL_DIR and adjust PATH accordingly, replacing previous variable-based exports.
> 
> - **Install script (`install.sh`)**:
>   - **Bash shell config**:
>     - Replace `export $install_env=...` with `export COMPOSIO_INSTALL_DIR=...`.
>     - Replace `export PATH="$bin_env:$PATH"` with `export PATH="$COMPOSIO_INSTALL_DIR:$PATH"`.
>   - **Fallback/manual instructions**:
>     - Mirror the same changes in the default `*)` case instructions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e84829762289cbaef672ebf850046722a6274c7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->