### PR TITLE
feat: changelog for tool listing

### DIFF
--- a/fern/pages/src/changelog/10-28-25.md
+++ b/fern/pages/src/changelog/10-28-25.md
@@ -1,7 +1,9 @@
 ## Tools Listing Now Requires Filters for Better Performance
 
 ### Summary
-Due to the increased scale in the number of tools and their versions powered by Composio, listing tools now requires passing specific filters to ensure optimal performance and relevant results.
+Due to the increased scale in the number of tools and their versions powered by Composio, listing tools now requires passing specific filters to ensure optimal performance and relevant results. This is an **API-level change** that affects all tool listing operations.
+
+> 📖 **API Reference**: See the complete documentation at [List tools by filters](https://docs.composio.dev/api-reference/tools/get-tools)
 
 ### Key Changes
 
@@ -16,7 +18,9 @@ Going forward, listing tools requires one of the following filters:
 **After:** At least one filter parameter is required when listing tools:
 
 ### Breaking Changes
-⚠️ **Breaking Change**: Listing tools without any filter parameters will now return an error. Users must specify at least one of:
+⚠️ **Breaking Change**: This API-level change means that listing tools without any filter parameters will now return an error. As noted in the [API documentation](https://docs.composio.dev/api-reference/tools/get-tools): *"Unfiltered queries will be rejected as the list can be too big."*
+
+Users must specify at least one of:
 1. `toolkit_slug` parameter
 2. `tool_slugs` parameter  
 3. `search` parameter


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a changelog entry documenting the breaking API change requiring filters for listing tools.
> 
> - **Docs**:
>   - **Changelog**: Add `fern/pages/src/changelog/10-28-25.md` detailing an API-level breaking change.
>     - Listing tools now requires at least one filter (`toolkit_slug`, `tool_slugs`, or `search`).
>     - Notes behavior change (unfiltered queries now rejected) and links to API reference.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e0f13ef75eedb16dd29ef0091c53c75da82e6f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->