### PR TITLE
Fix release workflows

### DIFF
--- a/.github/workflows/ts.release.yml
+++ b/.github/workflows/ts.release.yml
@@ -4,9 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches: [next]
-    paths:
-      - "ts/**"
-
+    
 env:
   GITHUB_ACCESS_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes the path filter from the TS release workflow so it triggers on any push to the next branch.
> 
> - **CI**:
>   - **TS SDK Release Workflow** (`.github/workflows/ts.release.yml`):
>     - Remove `paths: ["ts/**"]` filter from `push` trigger to run on any push to `next`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e22551975dcf2399ef66e276a23c9a84c3177c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->