### PR TITLE
Fix trigger subscribe example snippets

### DIFF
--- a/fern/snippets/triggers/python/trigger-subscription.py
+++ b/fern/snippets/triggers/python/trigger-subscription.py
@@ -12,4 +12,6 @@ def handle_github_commit(data):
     print(f"New commit detected: {data}")
     # Add your custom logic here
 
+# listen for events on the trigger
+subscription.wait_forever()
 # Note: For production use, set up webhooks instead


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add `subscription.wait_forever()` to the Python trigger subscription example to continuously listen for events.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15059cc8a507c3c9ec469172277b517f344e524e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->