### PR TITLE
Docs: Add connected account status docs

### DIFF
--- a/fern/pages/src/tool-calling/authenticating-tools.mdx
+++ b/fern/pages/src/tool-calling/authenticating-tools.mdx
@@ -377,13 +377,13 @@ You can check the status of a connected account programmatically:
   src="fern/snippets/tool-calling/python/checking-connection-status.py"
   title="Python"
   startLine={5}
-  endLine={15}
+  endLine={16}
 />
 <SnippetCode
   src="fern/snippets/tool-calling/typescript/checking-connection-status.ts"
   title="Typescript"
   startLine={5}
-  endLine={16}
+  endLine={17}
 />
 </CodeGroup>
 

--- a/fern/snippets/tool-calling/python/checking-connection-status.py
+++ b/fern/snippets/tool-calling/python/checking-connection-status.py
@@ -6,10 +6,11 @@ composio = Composio(api_key="your_api_key")
 connected_account = composio.connected_accounts.get("your_connected_account_id")
 print(f"Status: {connected_account.status}")
 
-# Filter connections by user_id and auth_config_id
+# Filter connections by user_id, auth_config_id, and status (only active accounts)
 filtered_connections = composio.connected_accounts.list(
     user_ids=["user_123"],
-    auth_config_ids=["your_auth_config_id"]
+    auth_config_ids=["your_auth_config_id"],
+    statuses=["ACTIVE"]
 )
 for connection in filtered_connections.items:
     print(f"{connection.id}: {connection.status}")

--- a/fern/snippets/tool-calling/typescript/checking-connection-status.ts
+++ b/fern/snippets/tool-calling/typescript/checking-connection-status.ts
@@ -6,10 +6,11 @@ const composio = new Composio({ apiKey: 'your_api_key' });
 const connectedAccount = await composio.connectedAccounts.get('your_connected_account_id');
 console.log(`Status: ${connectedAccount.status}`);
 
-// Filter connections by user_id and auth_config_id
+// Filter connections by user_id, auth_config_id, and status (only active accounts)
 const filteredConnections = await composio.connectedAccounts.list({
   userIds: ['user_123'],
-  authConfigIds: ['your_auth_config_id']
+  authConfigIds: ['your_auth_config_id'],
+  statuses: ['ACTIVE']
 });
 filteredConnections.items.forEach(connection => {
   console.log(`${connection.id}: ${connection.status}`);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Documents connection statuses and adds Python/TypeScript examples for checking and filtering connected account statuses.
> 
> - **Docs (tool-calling)**:
>   - Add **Connection Statuses** section in `pages/src/tool-calling/authenticating-tools.mdx` with status table and guidance.
>   - Add "Checking Connection Status" subsection referencing new code snippets.
>   - Note that only `ACTIVE` connections can execute tools.
> - **Examples**:
>   - New Python snippet `snippets/tool-calling/python/checking-connection-status.py` to fetch a connected account and list filtered active connections.
>   - New TypeScript snippet `snippets/tool-calling/typescript/checking-connection-status.ts` with equivalent functionality.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43fde69babe51074e918805226030e2d323b79e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->