### PR TITLE
chore: changelog for query params in mcp urls

### DIFF
--- a/fern/pages/src/changelog/11-05-25.md
+++ b/fern/pages/src/changelog/11-05-25.md
@@ -18,9 +18,11 @@ This change ensures that:
 
 ## Impact on Existing Projects
 
-**For existing projects**: We understand the importance of backward compatibility. While we've sent email notifications to project owners about upgrading their MCP URLs, **this is not a breaking change**. Your existing integrations will continue to work without interruption.
+**For existing projects**: We understand the importance of backward compatibility. While we've sent email notifications to project owners about upgrading their MCP URLs, your existing integrations will continue to work until **January 15th, 2026**.
 
-We strongly recommend updating your MCP URLs to include these parameters for enhanced security.
+**Important**: After January 15th, 2026, MCP URLs without `user_id` or `connected_account_id` query parameters will no longer be supported. Please ensure you update your MCP URLs before this date to avoid service disruption.
+
+**Note**: If your MCP URLs already include either `user_id` or `connected_account_id` query parameters, no action is required—you can safely ignore this notice.
 
 ## Implementation Example
 


### PR DESCRIPTION
Changelog for query params in MCP URLs.
https://www.notion.so/composio/user_id-query-param-in-Platform-MCP-URLs-29bf261a6dfe8067b455f177d5510a0c?source=copy_link

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a changelog entry detailing new MCP URL requirements to include `user_id` or `connected_account_id`, with examples, migration steps, and a deprecation date of Jan 15, 2026.
> 
> - **Changelog** (`fern/pages/src/changelog/11-05-25.md`):
>   - Introduces stricter MCP URL requirements: must include `user_id` or `connected_account_id` for new projects.
>   - Documents deprecation timeline: URLs without these params unsupported after Jan 15, 2026.
>   - Provides before/after URL examples and a concise migration guide.
>   - Links to user management docs and MCP docs for further guidance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8220d5076dc6a5043f5b8492c5fca0d0f5ef4c5b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->