### PR TITLE
Docs: Mercury production deploy pipeline added

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -12,7 +12,7 @@ on:
         default: 'next'
         type: string
   repository_dispatch:
-    types: [apollo-production-deploy]
+    types: [apollo-production-deploy, mercury-production-deploy]
 
 jobs:
   run:
@@ -31,7 +31,12 @@ jobs:
         run: |
           echo "Workflow triggered by: ${{ github.event_name }}"
           if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
-            echo "Triggered by Apollo production deployment"
+            echo "Repository dispatch action: ${{ github.event.action }}"
+            if [ "${{ github.event.action }}" = "apollo-production-deploy" ]; then
+              echo "Triggered by Apollo production deployment"
+            elif [ "${{ github.event.action }}" = "mercury-production-deploy" ]; then
+              echo "Triggered by Mercury production deployment"
+            fi
             echo "Hermes commit: ${{ github.event.client_payload.hermes_commit }}"
             echo "Timestamp: ${{ github.event.client_payload.timestamp }}"
           fi


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `mercury-production-deploy` as a `repository_dispatch` trigger and enhances logging of dispatch action in the docs publish workflow.
> 
> - **CI/CD – Docs Publish Workflow (`.github/workflows/publish_docs.yml`)**:
>   - **Triggers**: Extend `repository_dispatch` `types` to include `mercury-production-deploy` alongside `apollo-production-deploy`.
>   - **Logging**: Print `github.event.action` and conditionally log when triggered by `apollo-production-deploy` or `mercury-production-deploy`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df959d9331e245f79e8a50078c9456493c0dfb39. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->