### PR TITLE
Revert "Docs: Mercury production deploy pipeline added"

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -12,7 +12,7 @@ on:
         default: 'next'
         type: string
   repository_dispatch:
-    types: [apollo-production-deploy, mercury-production-deploy]
+    types: [apollo-production-deploy]
 
 jobs:
   run:
@@ -31,12 +31,7 @@ jobs:
         run: |
           echo "Workflow triggered by: ${{ github.event_name }}"
           if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
-            echo "Repository dispatch action: ${{ github.event.action }}"
-            if [ "${{ github.event.action }}" = "apollo-production-deploy" ]; then
-              echo "Triggered by Apollo production deployment"
-            elif [ "${{ github.event.action }}" = "mercury-production-deploy" ]; then
-              echo "Triggered by Mercury production deployment"
-            fi
+            echo "Triggered by Apollo production deployment"
             echo "Hermes commit: ${{ github.event.client_payload.hermes_commit }}"
             echo "Timestamp: ${{ github.event.client_payload.timestamp }}"
           fi


### PR DESCRIPTION
Reverts ComposioHQ/composio#2164

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Limits docs publish workflow to Apollo repository_dispatch events and simplifies the repository_dispatch logging.
> 
> - **CI/CD — `/.github/workflows/publish_docs.yml`**
>   - Restricts `repository_dispatch` `types` to `apollo-production-deploy` (removes `mercury-production-deploy`).
>   - Simplifies repository dispatch logging to always indicate Apollo deployment when triggered.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0006066db7b27d6a5a2065c16a4f4cdafbe68ecf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->