### PR TITLE
Add Composio logo link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 
 <div align="center">
-
+<a href="https://app.composio.dev/?utm_source=Social&utm_medium=Github&utm_campaign=2025-11&utm_content=composio">
 <img src="https://raw.githubusercontent.com/ComposioHQ/composio/next/public/cover.png" alt="Composio Logo" width="auto" height="auto" style="margin-bottom: 20px;"/>
-
+</a>
 
 # Composio SDK
 


### PR DESCRIPTION
Added a link to the Composio logo in the README.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wraps the README cover image in an anchor linking to app.composio.dev with UTM parameters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 358e41b97777ff366bb821754a32e665f29f20d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->