### PR TITLE
fix(python/core): use "important" tag when querying tools list

### DIFF
--- a/python/composio/core/models/tools.py
+++ b/python/composio/core/models/tools.py
@@ -132,7 +132,7 @@ class Tools(Resource, t.Generic[TProvider]):
                     self._client.tools.list(
                         tool_slugs=",".join(tools),
                         toolkit_versions=none_to_omit(self._toolkit_versions),
-                        important=True,
+                        important="true",
                     ).items
                 )
 
@@ -145,7 +145,7 @@ class Tools(Resource, t.Generic[TProvider]):
                     scopes=scopes,
                     limit=limit,
                     toolkit_versions=none_to_omit(self._toolkit_versions),
-                    important=True,
+                    important="true",
                 ).items
             )
         return tools_list

--- a/python/composio/core/models/tools.py
+++ b/python/composio/core/models/tools.py
@@ -132,6 +132,7 @@ class Tools(Resource, t.Generic[TProvider]):
                     self._client.tools.list(
                         tool_slugs=",".join(tools),
                         toolkit_versions=none_to_omit(self._toolkit_versions),
+                        important=True,
                     ).items
                 )
 
@@ -144,6 +145,7 @@ class Tools(Resource, t.Generic[TProvider]):
                     scopes=scopes,
                     limit=limit,
                     toolkit_versions=none_to_omit(self._toolkit_versions),
+                    important=True,
                 ).items
             )
         return tools_list


### PR DESCRIPTION
This PR:
- fixes the `composio.tools.get(user_id=user_id, toolkits=["GMAIL"])` command used in https://docs.composio.dev/docs/quickstart, so that the `GMAIL_FETCH_EMAILS ` tool is retrieved
- sets `important=True` to calls to `self._client.tools.list`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Passes `important="true"` when listing tools to filter to important tools in both slug and toolkit/search paths.
> 
> - **Python core**:
>   - In `python/composio/core/models/tools.py`, `get_raw_composio_tools` now passes `important="true"` to `self._client.tools.list` for both slug-based and toolkit/search queries, filtering to important tools.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1abbeb5a63e6fb0a614e21c6b53ff426a660b5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->