### PR TITLE
Fix non-agentic tool execution

### DIFF
--- a/python/composio/core/models/tools.py
+++ b/python/composio/core/models/tools.py
@@ -190,8 +190,15 @@ class Tools(Resource, t.Generic[TProvider]):
             t.cast(NonAgenticProvider, self.provider).set_execute_tool_fn(
                 t.cast(
                     NoneAgenticProviderExecuteFn,
-                    self.execute,
-                )
+                    functools.partial(
+                        self.execute,
+                        # Dangerously skip version check for non-agentic tool execution
+                        # via providers (e.g. OpenAI tool calling). This mirrors the
+                        # behavior used for agentic providers in `_wrap_execute_tool`
+                        # and keeps manual `tools.execute(...)` calls strict by default.
+                        dangerously_skip_version_check=True,
+                    ),
+                ),
             )
             return t.cast(NonAgenticProvider, self.provider).wrap_tools(
                 tools=tools_list


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Non-agentic providers now execute tools via a partial that skips version checks, aligning with agentic behavior while keeping direct calls strict.
> 
> - **Core tools (`python/composio/core/models/tools.py`)**:
>   - **Non-agentic providers**: `set_execute_tool_fn` now passes `functools.partial(self.execute, dangerously_skip_version_check=True)` to skip version checks during provider-invoked executions, mirroring `_wrap_execute_tool` behavior for agentic providers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b758589e8e82bebd89e19bf79c9bc7dcdb98072c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->