### PR TITLE
Docs: Open ai ts provider version

### DIFF
--- a/fern/snippets/providers/typescript/openai.ts
+++ b/fern/snippets/providers/typescript/openai.ts
@@ -4,7 +4,10 @@ import { OpenAIProvider } from '@composio/openai';
 
 // Initialize Composio client with OpenAI Provider
 const composio = new Composio({ 
-    provider: new OpenAIProvider(), 
+    provider: new OpenAIProvider(),
+    toolkitVersions: {
+        gmail: "20251111_00"
+    } 
 });
 
 const openai = new OpenAI();

--- a/fern/snippets/providers/typescript/openairesponses.ts
+++ b/fern/snippets/providers/typescript/openairesponses.ts
@@ -4,7 +4,10 @@ import { OpenAIResponsesProvider } from '@composio/openai';
 
 // Initialize Composio client with OpenAI Provider
 const composio = new Composio({ 
-    provider: new OpenAIResponsesProvider(), 
+    provider: new OpenAIResponsesProvider(),
+    toolkitVersions: {
+        gmail: "20251111_00"
+    }
 });
 const openai = new OpenAI({});
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Set explicit Gmail toolkit version in TypeScript OpenAI provider snippets.
> 
> - **Docs / TypeScript snippets**:
>   - Update `fern/snippets/providers/typescript/openai.ts` to pass `toolkitVersions` with `gmail: "20251111_00"` when initializing `Composio` with `OpenAIProvider`.
>   - Update `fern/snippets/providers/typescript/openairesponses.ts` to pass `toolkitVersions` with `gmail: "20251111_00"` when initializing `Composio` with `OpenAIResponsesProvider`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba12f10b87f0b8956aec6442d2ecedfb7291e1c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->