### PR TITLE
feat(cli): add `composio generate --toolkits [toolkits]` support, for both `ts` and `py`

### DIFF
--- a/ts/packages/cli/src/commands/generate.cmd.ts
+++ b/ts/packages/cli/src/commands/generate.cmd.ts
@@ -18,17 +18,24 @@ export const typeTools = Options.boolean('type-tools').pipe(
   )
 );
 
+export const toolkitsOpt = Options.text('toolkits').pipe(
+  Options.repeated,
+  Options.withDescription(
+    'Filter output to only include the specified toolkits. Can be specified multiple times (e.g., --toolkits gmail --toolkits slack)'
+  )
+);
+
 /**
  * @example
  * ```bash
  * composio generate <command>
  * ```
  */
-export const generateCmd = Command.make('generate', { outputOpt, typeTools }).pipe(
+export const generateCmd = Command.make('generate', { outputOpt, typeTools, toolkitsOpt }).pipe(
   Command.withDescription(
     'Updates the local type stubs with the latest app data, automatically detecting the language of the project in the current working directory (TypeScript | Python).'
   ),
-  Command.withHandler(({ outputOpt, typeTools }) =>
+  Command.withHandler(({ outputOpt, typeTools, toolkitsOpt }) =>
     Effect.gen(function* () {
       const process = yield* NodeProcess;
       const cwd = process.cwd;
@@ -41,9 +48,15 @@ export const generateCmd = Command.make('generate', { outputOpt, typeTools }).pi
       // Redirect to either `ts generate` or `py generate` commands
       yield* Match.value(envLang).pipe(
         Match.when('TypeScript', () =>
-          generateTypescriptTypeStubs({ outputOpt, compact: false, transpiled: false, typeTools })
+          generateTypescriptTypeStubs({
+            outputOpt,
+            compact: false,
+            transpiled: false,
+            typeTools,
+            toolkitsOpt,
+          })
         ),
-        Match.when('Python', () => generatePythonTypeStubs({ outputOpt })),
+        Match.when('Python', () => generatePythonTypeStubs({ outputOpt, toolkitsOpt })),
         Match.exhaustive
       );
     })

--- a/ts/packages/cli/src/services/composio-clients-cached.ts
+++ b/ts/packages/cli/src/services/composio-clients-cached.ts
@@ -161,6 +161,12 @@ export const ComposioToolkitsRepositoryCached = Layer.effect(
           underlyingRepository.getTools(limit)
         );
       },
+
+      // These methods don't need caching as they operate on already fetched data
+      // or perform validation that should always be fresh
+      validateToolkits: toolkitSlugs => underlyingRepository.validateToolkits(toolkitSlugs),
+      filterToolkitsBySlugs: (toolkits, toolkitSlugs) =>
+        underlyingRepository.filterToolkitsBySlugs(toolkits, toolkitSlugs),
     });
   })
 ).pipe(

--- a/ts/packages/cli/test/src/commands/$default.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/$default.cmd.test.ts
@@ -58,25 +58,25 @@ describe('CLI: composio', () => {
 
           [0;1mCOMMANDS[0m
 
-            - version                                                                               Display your account information.
+            - version                                                                                                  Display your account information.
 
-            - upgrade                                                                               Upgrade your Composio CLI to the latest available version.
+            - upgrade                                                                                                  Upgrade your Composio CLI to the latest available version.
 
-            - whoami                                                                                Display your account information.
+            - whoami                                                                                                   Display your account information.
 
-            - login [--no-browser]                                                                  Log in to the Composio SDK.
+            - login [--no-browser]                                                                                     Log in to the Composio SDK.
 
-            - logout                                                                                Log out from the Composio SDK.
+            - logout                                                                                                   Log out from the Composio SDK.
 
-            - generate [(-o, --output-dir directory)] [--type-tools]                                Updates the local type stubs with the latest app data, automatically detecting the language of the project in the current working directory (TypeScript | Python).
+            - generate [(-o, --output-dir directory)] [--type-tools] --toolkits text...                                Updates the local type stubs with the latest app data, automatically detecting the language of the project in the current working directory (TypeScript | Python).
 
-            - py                                                                                    Handle Python projects.
+            - py                                                                                                       Handle Python projects.
 
-            - py generate [(-o, --output-dir directory)]                                            Updates the local type stubs with the latest app data.
+            - py generate [(-o, --output-dir directory)] --toolkits text...                                            Updates the local type stubs with the latest app data.
 
-            - ts                                                                                    Handle TypeScript projects.
+            - ts                                                                                                       Handle TypeScript projects.
 
-            - ts generate [(-o, --output-dir directory)] [--compact] [--transpiled] [--type-tools]  Updates the local type stubs with the latest app data.
+            - ts generate [(-o, --output-dir directory)] [--compact] [--transpiled] [--type-tools] --toolkits text...  Updates the local type stubs with the latest app data.
           "
         `);
       })

--- a/ts/packages/cli/test/src/commands/generate.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/generate.cmd.test.ts
@@ -1,9 +1,31 @@
+import path from 'node:path';
 import { describe, expect, layer } from '@effect/vitest';
 import { Effect } from 'effect';
+import { FileSystem } from '@effect/platform';
 import { NodeProcess } from 'src/services/node-process';
 import { cli, TestLive, MockConsole } from 'test/__utils__';
+import { makeTestToolkits } from 'test/__utils__/models/toolkits';
+import { TRIGGER_TYPES_GMAIL } from 'test/__mocks__/trigger-types-gmail';
+import { TOOLS_TYPES_GMAIL } from 'test/__mocks__/tools-types-gmail';
+import type { TestLiveInput } from 'test/__utils__/services/test-layer';
 
 describe('CLI: composio generate', () => {
+  const appClientData = {
+    toolkits: makeTestToolkits([
+      {
+        name: 'Gmail',
+        slug: 'gmail',
+      },
+      {
+        name: 'Slack',
+        slug: 'slack',
+      },
+    ]),
+    tools: [...TOOLS_TYPES_GMAIL.slice(0, 3)],
+    triggerTypes: [...TRIGGER_TYPES_GMAIL.slice(0, 3)],
+    triggerTypesAsEnums: [...TRIGGER_TYPES_GMAIL.slice(0, 3).map(triggerType => triggerType.slug)],
+  } satisfies TestLiveInput['toolkitsData'];
+
   layer(
     TestLive({
       fixture: 'python-project',
@@ -39,6 +61,72 @@ describe('CLI: composio generate', () => {
         const output = lines.join('\n');
         expect(output).toContain('Project type detected: TypeScript');
       })
+    );
+  });
+
+  layer(
+    TestLive({
+      fixture: 'typescript-project',
+      toolkitsData: appClientData,
+    })
+  )(it => {
+    it.scoped(
+      '[Given] TypeScript project with --toolkits [Then] it filters output to specified toolkits',
+      () =>
+        Effect.gen(function* () {
+          const process = yield* NodeProcess;
+          const cwd = process.cwd;
+          const fs = yield* FileSystem.FileSystem;
+          const outputDir = path.join(cwd, '.generated', 'composio-filtered');
+
+          const args = ['generate', '--toolkits', 'gmail', '--output-dir', outputDir];
+          yield* cli(args);
+
+          const lines = yield* MockConsole.getLines();
+          const output = lines.join('\n');
+          expect(output).toContain('Project type detected: TypeScript');
+          expect(output).toContain('Filtering to 1 toolkit(s): gmail');
+
+          // Check generated files - only gmail.ts should exist
+          const files = yield* fs.readDirectory(outputDir);
+          const fileNames = files.map(file => path.basename(file));
+
+          expect(fileNames).toContain('gmail.ts');
+          expect(fileNames).not.toContain('slack.ts');
+        })
+    );
+  });
+
+  layer(
+    TestLive({
+      fixture: 'python-project',
+      toolkitsData: appClientData,
+    })
+  )(it => {
+    it.scoped(
+      '[Given] Python project with --toolkits [Then] it filters output to specified toolkits',
+      () =>
+        Effect.gen(function* () {
+          const process = yield* NodeProcess;
+          const cwd = process.cwd;
+          const fs = yield* FileSystem.FileSystem;
+          const outputDir = path.join(cwd, '.generated', 'composio-filtered');
+
+          const args = ['generate', '--toolkits', 'gmail', '--output-dir', outputDir];
+          yield* cli(args);
+
+          const lines = yield* MockConsole.getLines();
+          const output = lines.join('\n');
+          expect(output).toContain('Project type detected: Python');
+          expect(output).toContain('Filtering to 1 toolkit(s): gmail');
+
+          // Check generated files - only gmail.py should exist
+          const files = yield* fs.readDirectory(outputDir);
+          const fileNames = files.map(file => path.basename(file));
+
+          expect(fileNames).toContain('gmail.py');
+          expect(fileNames).not.toContain('slack.py');
+        })
     );
   });
 });


### PR DESCRIPTION
This PR:
- contributes to [PLEN-765](https://linear.app/composio/issue/PLEN-765/refine-clis-generated-output-based-on-toolkits-filter)
- adds `composio generate --toolkits [toolkits]` and related tests
- adds `composio ts generate --toolkits [toolkits]` and related tests
- adds `composio py generate --toolkits [toolkits]` and related tests