### PR TITLE
Update Dependabot schedule to run weekly on Fridays

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@
 #Currently set to run every Friday at 06:30 UTC/12:00 IST
 version: 2
 updates:
-  - package-ecosystem: "pnpm"
+  - package-ecosystem: "npm"
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Summary
Adds dependabot schedule weekly on Friday 6:30 UTC

## Changes
- Adds dependabot pull request automatically.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor/Chore
- [ ] Documentation
- [ ] Breaking change

## How Has This Been Tested?
Not applicable. It'll raise the pull request when needed.
## Screenshots (if applicable)
NA.
## Checklist
- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed
- [x] I updated documentation as needed
- [x] I added tests or explain why not applicable
- [ ] I added a changeset if this change affects published packages

## Additional context
