### PR TITLE
docs: fix broken hyperlinks in trigger documentation

### DIFF
--- a/fern/pages/src/capabilities/triggers.mdx
+++ b/fern/pages/src/capabilities/triggers.mdx
@@ -17,23 +17,7 @@ Subscribe to real-time events from GitHub, Slack, Gmail, and other services. Com
   >
     Subscribe to events and handle them in your application
   </Card>
-  
-  <Card
-    title="Available triggers"
-    icon="fa-light fa-list"
-    href="/toolkits/all"
-  >
-    Browse triggers by toolkit
-  </Card>
-  
-  <Card
-    title="Triggers API"
-    icon="fa-light fa-code"
-    href="/api-reference/triggers"
-  >
-    API reference for trigger operations
-  </Card>
-  
+
   <Card
     title="Slack summarizer example"
     icon="fa-light fa-diagram-project"

--- a/fern/pages/src/tools-and-triggers/using-triggers.mdx
+++ b/fern/pages/src/tools-and-triggers/using-triggers.mdx
@@ -83,7 +83,7 @@ To use a specific toolkit version when creating triggers, configure `toolkitVers
 
 ### Webhooks
 
-The recommended way to subscribe to triggers is through webhooks. Configure your webhook URL in the [Event & Trigger settings](https://platform.composio.dev?next_page=/settings/events).
+The recommended way to subscribe to triggers is through webhooks. Configure your webhook URL in the [Event & Trigger settings](https://platform.composio.dev?next_page=/settings/webhook).
 
 Use a publicly accessible URL where Composio can send event payloads. This endpoint should be able to process incoming POST requests containing the trigger data.
 


### PR DESCRIPTION
Remove cards with invalid hrefs (/toolkits/all, /api-reference/triggers) from triggers capability page and fix webhook settings URL path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary
Explain the motivation and context for this change. Link to any related issues.

Fixes #

## Changes
- 
- 

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [ ] Documentation
- [ ] Breaking change

## How Has This Been Tested?
Describe the tests you ran and instructions so reviewers can reproduce. Include any relevant config/versions.

## Screenshots (if applicable)

## Checklist
- [ ] I have read the Code of Conduct and this PR adheres to it
- [ ] I ran linters/tests locally and they passed
- [ ] I updated documentation as needed
- [ ] I added tests or explain why not applicable
- [ ] I added a changeset if this change affects published packages

## Additional context
