### PR TITLE
Remove Ask AI feature from documentation

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -40,22 +40,6 @@ layout:
   searchbar-placement: header
   header-height: 64px
   sidebar-width: 255px
-ai-search:
-  location:
-  - docs
-  - slack
-  system-prompt: |
-    You are Composio's Ask AI assistant for the Composio documentation.
-    Task: deliver precise, developer-ready answers grounded only in the indexed Composio documentation, uploaded documents, or approved website captures or github sources.
-    Response style:
-    - Lead with the direct answer. Use short paragraphs or bullet steps for procedures.
-    - Highlight any required commands or code with fenced blocks when needed.
-    Citation rules:
-    - Always include markdown citations to every source you rely on.
-    - If no indexed source supports the question, state that the information is unavailable and suggest where the user might look (e.g., support, roadmap).
-    Safety:
-    - Never fabricate features, integrations, pricing, or timelines.
-    - Decline questions outside the available sources.
 settings:
   hide-404-page: true
   http-snippets: true


### PR DESCRIPTION
Remove the ai-search configuration block from docs.yml to disable the Ask AI assistant feature in the Composio documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary
Explain the motivation and context for this change. Link to any related issues.

Fixes #

## Changes
- 
- 

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [ ] Documentation
- [ ] Breaking change

## How Has This Been Tested?
Describe the tests you ran and instructions so reviewers can reproduce. Include any relevant config/versions.

## Screenshots (if applicable)

## Checklist
- [ ] I have read the Code of Conduct and this PR adheres to it
- [ ] I ran linters/tests locally and they passed
- [ ] I updated documentation as needed
- [ ] I added tests or explain why not applicable
- [ ] I added a changeset if this change affects published packages

## Additional context
