### PR TITLE
fix: use npx instead of bunx for TypeDoc in generate-docs script

### DIFF
--- a/ts/packages/core/scripts/generate-docs.ts
+++ b/ts/packages/core/scripts/generate-docs.ts
@@ -709,7 +709,7 @@ async function runTypeDoc(): Promise<TypeDocProject> {
   console.log(`  Found ${entryPoints.length} entry points`);
 
   const cmd = [
-    'bunx typedoc',
+    'npx typedoc',
     '--json',
     TEMP_JSON,
     '--tsconfig',


### PR DESCRIPTION
CI environments don't have bun installed, causing the generate:docs script to fail with "bunx: not found". Using npx works universally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary
Explain the motivation and context for this change. Link to any related issues.

Fixes #

## Changes
- 
- 

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [ ] Documentation
- [ ] Breaking change

## How Has This Been Tested?
Describe the tests you ran and instructions so reviewers can reproduce. Include any relevant config/versions.

## Screenshots (if applicable)

## Checklist
- [ ] I have read the Code of Conduct and this PR adheres to it
- [ ] I ran linters/tests locally and they passed
- [ ] I updated documentation as needed
- [ ] I added tests or explain why not applicable
- [ ] I added a changeset if this change affects published packages

## Additional context
