### PR TITLE
docs: add llms.txt routes for AI content

### DIFF
--- a/fumadocs/app/llms-full.txt/route.ts
+++ b/fumadocs/app/llms-full.txt/route.ts
@@ -1,25 +1,106 @@
-import { source } from '@/lib/source';
+import {
+  source,
+  toolRouterSource,
+  referenceSource,
+  examplesSource,
+} from '@/lib/source';
+import type { InferPageType } from 'fumadocs-core/source';
 
 export const revalidate = false;
 
+type Page = InferPageType<typeof source>;
+
+async function getPageContent(page: Page): Promise<string> {
+  try {
+    const processed = await page.data.getText('processed');
+    const url = `https://composio.dev${page.url}`;
+    return `# ${page.data.title}
+
+URL: ${url}
+${page.data.description ? `Description: ${page.data.description}` : ''}
+
+${processed}`;
+  } catch {
+    return `# ${page.data.title}\n\n${page.data.description || ''}`;
+  }
+}
+
 export async function GET() {
   try {
-    const pages = source.getPages();
+    const docsPages = source.getPages();
+    const toolRouterPages = toolRouterSource.getPages();
+    const referencePages = referenceSource.getPages();
+    const examplesPages = examplesSource.getPages();
+
     const results: string[] = [];
 
-    for (const page of pages) {
-      try {
-        const processed = await page.data.getText('processed');
-        results.push(`# ${page.data.title}\n\n${processed}`);
-      } catch {
-        // Fallback to basic info if getText fails
-        results.push(`# ${page.data.title}\n\n${page.data.description || ''}`);
-      }
+    // Header
+    results.push(`# Composio Documentation (Full)
+
+> This is the complete Composio documentation optimized for LLMs and AI agents.
+> Generated at: ${new Date().toISOString()}
+
+Composio is the simplest way to connect AI agents to external tools and services.
+Connect 250+ tools to your AI agents with a single SDK.
+
+---
+
+## Table of Contents
+
+1. Main Documentation (${docsPages.length} pages)
+2. Tool Router (${toolRouterPages.length} pages)
+3. Examples (${examplesPages.length} pages)
+4. API Reference (${referencePages.length} pages)
+
+---
+
+# SECTION 1: MAIN DOCUMENTATION
+
+`);
+
+    // Main docs
+    for (const page of docsPages) {
+      const content = await getPageContent(page as Page);
+      results.push(content);
+      results.push('\n---\n');
     }
 
-    return new Response(results.join('\n\n'), {
+    results.push('\n# SECTION 2: TOOL ROUTER\n\n');
+
+    // Tool Router docs
+    for (const page of toolRouterPages) {
+      const content = await getPageContent(page as Page);
+      results.push(content);
+      results.push('\n---\n');
+    }
+
+    results.push('\n# SECTION 3: EXAMPLES\n\n');
+
+    // Examples
+    for (const page of examplesPages) {
+      const content = await getPageContent(page as Page);
+      results.push(content);
+      results.push('\n---\n');
+    }
+
+    results.push('\n# SECTION 4: API REFERENCE\n\n');
+
+    // API Reference (limit to avoid massive file)
+    const refPages = referencePages.slice(0, 50);
+    for (const page of refPages) {
+      const content = await getPageContent(page as Page);
+      results.push(content);
+      results.push('\n---\n');
+    }
+
+    if (referencePages.length > 50) {
+      results.push(`\n... ${referencePages.length - 50} more reference pages available at https://composio.dev/reference\n`);
+    }
+
+    return new Response(results.join('\n'), {
       headers: {
         'Content-Type': 'text/plain; charset=utf-8',
+        'Cache-Control': 'public, max-age=3600, s-maxage=3600',
       },
     });
   } catch (error) {

--- a/fumadocs/app/llms.txt/route.ts
+++ b/fumadocs/app/llms.txt/route.ts
@@ -1,27 +1,66 @@
-import { source } from '@/lib/source';
+import {
+  source,
+  toolRouterSource,
+  referenceSource,
+  examplesSource,
+} from '@/lib/source';
 
 export const revalidate = false;
 
 export async function GET() {
   try {
-    const pages = source.getPages();
+    const docsPages = source.getPages();
+    const toolRouterPages = toolRouterSource.getPages();
+    const referencePages = referenceSource.getPages();
+    const examplesPages = examplesSource.getPages();
 
     const index = `# Composio Documentation
 
-> Composio is the simplest way to connect AI agents to external tools and services.
+> Composio is the simplest way to connect AI agents to external tools and services. Connect 250+ tools to your AI agents with a single SDK.
 
-## Docs
+## Overview
 
-${pages.map((page) => `- [${page.data.title}](https://composio.dev${page.url}): ${page.data.description || ''}`).join('\n')}
+Composio provides:
+- **Tools & Toolkits**: Pre-built integrations for GitHub, Slack, Gmail, and 250+ more services
+- **Authentication**: Managed OAuth, API keys, and custom auth flows
+- **Tool Router**: Route requests to the right tools automatically
+- **MCP Support**: Model Context Protocol integration for AI assistants
+
+## Getting Started
+
+- [Quickstart Guide](https://composio.dev/docs/quickstart): Get started with Composio in 5 minutes
+- [Capabilities Overview](https://composio.dev/docs/capabilities): Learn what Composio can do
+
+## Documentation Sections
+
+### Main Docs
+${docsPages.map((page) => `- [${page.data.title}](https://composio.dev${page.url}): ${page.data.description || ''}`).join('\n')}
+
+### Tool Router
+${toolRouterPages.map((page) => `- [${page.data.title}](https://composio.dev${page.url}): ${page.data.description || ''}`).join('\n')}
+
+### API & SDK Reference
+${referencePages.slice(0, 20).map((page) => `- [${page.data.title}](https://composio.dev${page.url}): ${page.data.description || ''}`).join('\n')}
+${referencePages.length > 20 ? `\n... and ${referencePages.length - 20} more reference pages` : ''}
+
+### Examples
+${examplesPages.map((page) => `- [${page.data.title}](https://composio.dev${page.url}): ${page.data.description || ''}`).join('\n')}
 
 ## Full Documentation
 
-For the complete documentation in a single file, see: https://composio.dev/llms-full.txt
+For the complete documentation content in a single file (optimized for LLMs), see: https://composio.dev/llms-full.txt
+
+## Resources
+
+- **GitHub**: https://github.com/composiohq/composio
+- **Dashboard**: https://app.composio.dev
+- **Discord**: https://discord.gg/composio
 `;
 
     return new Response(index, {
       headers: {
         'Content-Type': 'text/plain; charset=utf-8',
+        'Cache-Control': 'public, max-age=3600, s-maxage=3600',
       },
     });
   } catch (error) {


### PR DESCRIPTION
## Summary
- Adds `/llms.txt` route for concise documentation index
- Adds `/llms-full.txt` route for complete documentation content

These routes enable AI agents and LLMs to efficiently consume documentation.

## Test plan
- [ ] Visit `/llms.txt` - should return text index
- [ ] Visit `/llms-full.txt` - should return full docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)