### PR TITLE
docs: add MDX content API with markdown conversion

### DIFF
--- a/fumadocs/app/api/mdx-content/[...path]/route.ts
+++ b/fumadocs/app/api/mdx-content/[...path]/route.ts
@@ -1,0 +1,145 @@
+import { NextResponse } from 'next/server';
+import {
+  source,
+  toolRouterSource,
+  referenceSource,
+  examplesSource,
+} from '@/lib/source';
+import {
+  validatePathSegments,
+  escapeYaml,
+  VALID_PATH_PREFIXES,
+  type ValidPrefix,
+} from '@/lib/path-validation';
+import { convertMdxToMarkdown } from '@/lib/mdx-to-markdown';
+
+/**
+ * Source mapping for each prefix
+ * Uses a more permissive type since referenceSource includes OpenAPI pages
+ */
+const SOURCE_MAP = {
+  '/docs': source,
+  '/tool-router': toolRouterSource,
+  '/reference': referenceSource,
+  '/examples': examplesSource,
+} as const;
+
+/**
+ * API route to serve raw MDX content as pure Markdown for AI agents.
+ *
+ * URL: /api/mdx-content/docs/quickstart
+ * Also accessible via: /docs/quickstart.mdx (through proxy.ts)
+ *
+ * Returns: Pure markdown text (JSX components converted to markdown)
+ *
+ * Security:
+ * - Validates paths to prevent traversal attacks
+ * - Escapes YAML frontmatter to prevent injection
+ * - Only serves content from known sources
+ */
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ path: string[] }> }
+) {
+  const { path: pathSegments } = await params;
+  const validation = validatePathSegments(pathSegments);
+
+  if (!validation.valid) {
+    return NextResponse.json(
+      { error: validation.error },
+      { status: 400 }
+    );
+  }
+
+  const { path, prefix } = validation;
+
+  try {
+    const sourceLoader = SOURCE_MAP[prefix];
+    if (!sourceLoader) {
+      return NextResponse.json(
+        { error: 'Invalid source' },
+        { status: 400 }
+      );
+    }
+
+    // Get slugs by removing the prefix
+    const slugs = path.split('/').filter(Boolean).slice(1);
+    const page = sourceLoader.getPage(slugs);
+
+    if (!page) {
+      return NextResponse.json(
+        { error: 'Page not found' },
+        { status: 404 }
+      );
+    }
+
+    // Check if page supports getText (MDX pages only, not OpenAPI)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const pageData = page.data as any;
+
+    if (typeof pageData.getText !== 'function') {
+      return NextResponse.json(
+        { error: 'Content not available for this page type' },
+        { status: 400 }
+      );
+    }
+
+    // Get the processed markdown content with timeout
+    let rawContent: string;
+    try {
+      const contentPromise = pageData.getText('processed');
+      const timeoutPromise = new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('Content retrieval timeout')), 10000)
+      );
+      rawContent = await Promise.race([contentPromise, timeoutPromise]);
+    } catch (textError) {
+      // getText may fail if includeProcessedMarkdown is not enabled
+      const msg = textError instanceof Error ? textError.message : 'Unknown error';
+      if (msg.includes('includeProcessedMarkdown')) {
+        return NextResponse.json(
+          { error: 'Raw markdown export is not enabled for this source' },
+          { status: 400 }
+        );
+      }
+      if (msg === 'Content retrieval timeout') {
+        return NextResponse.json(
+          { error: 'Request timeout' },
+          { status: 504 }
+        );
+      }
+      throw textError;
+    }
+
+    // Convert MDX with JSX components to pure markdown
+    const pureMarkdown = convertMdxToMarkdown(rawContent);
+
+    // Build safe YAML frontmatter
+    const title = pageData.title || 'Untitled';
+    const description = pageData.description || '';
+    const pageUrl = page.url || path;
+
+    const mdxContent = `---
+title: ${escapeYaml(title)}
+description: ${escapeYaml(description)}
+url: https://composio.dev${pageUrl}
+---
+
+${pureMarkdown}`;
+
+    return new NextResponse(mdxContent, {
+      headers: {
+        'Content-Type': 'text/markdown; charset=utf-8',
+        'Cache-Control': 'public, max-age=3600, s-maxage=3600',
+        'X-Content-Type-Options': 'nosniff',
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    console.error('[mdx-content] Error:', message);
+
+    return NextResponse.json(
+      { error: 'Failed to retrieve content' },
+      { status: 500 }
+    );
+  }
+}

--- a/fumadocs/lib/mdx-to-markdown.ts
+++ b/fumadocs/lib/mdx-to-markdown.ts
@@ -1,0 +1,273 @@
+/**
+ * MDX to Markdown Converter
+ *
+ * Converts MDX content with JSX components to pure markdown
+ * for AI agents that cannot parse JSX syntax.
+ */
+
+/**
+ * Extract text content from between JSX tags
+ */
+function extractContent(jsx: string): string {
+  // Remove self-closing tags
+  let result = jsx.replace(/<[A-Z][^>]*\/>/g, '');
+
+  // Remove opening and closing tags but keep content
+  result = result.replace(/<\/?[A-Z][a-zA-Z]*[^>]*>/g, '');
+
+  return result.trim();
+}
+
+/**
+ * Convert <Tab> content to markdown section
+ */
+function convertTabToMarkdown(tabMatch: string): string {
+  // Extract value attribute
+  const valueMatch = tabMatch.match(/value="([^"]+)"/);
+  const label = valueMatch ? valueMatch[1] : 'Option';
+
+  // Extract content between <Tab> tags
+  const contentMatch = tabMatch.match(/<Tab[^>]*>([\s\S]*?)<\/Tab>/);
+  const content = contentMatch ? contentMatch[1].trim() : '';
+
+  return `**${label}:**\n\n${content}`;
+}
+
+/**
+ * Convert <Tabs> component to markdown sections
+ */
+function convertTabs(mdx: string): string {
+  // Match <Tabs ...>...</Tabs> including nested content
+  const tabsRegex = /<Tabs[^>]*>([\s\S]*?)<\/Tabs>/g;
+
+  return mdx.replace(tabsRegex, (match, content) => {
+    // Find all <Tab> elements
+    const tabRegex = /<Tab[^>]*>[\s\S]*?<\/Tab>/g;
+    const tabs = content.match(tabRegex) || [];
+
+    if (tabs.length === 0) {
+      return extractContent(content);
+    }
+
+    // Convert each tab to a markdown section
+    const sections = tabs.map(convertTabToMarkdown);
+    return sections.join('\n\n---\n\n');
+  });
+}
+
+/**
+ * Extract attribute value from JSX tag string
+ */
+function extractAttribute(tag: string, attr: string): string | null {
+  const regex = new RegExp(`${attr}="([^"]*)"`, 'i');
+  const match = tag.match(regex);
+  return match ? match[1] : null;
+}
+
+/**
+ * Convert <Callout> component to blockquote
+ */
+function convertCallouts(mdx: string): string {
+  // Match <Callout ...>...</Callout> - captures full tag and content
+  const calloutRegex = /<Callout([^>]*)>([\s\S]*?)<\/Callout>/g;
+
+  return mdx.replace(calloutRegex, (match, attrs, content) => {
+    // Extract attributes in any order
+    const title = extractAttribute(attrs, 'title');
+    const type = extractAttribute(attrs, 'type');
+    const prefix = title || type || 'Note';
+    const cleanContent = extractContent(content).replace(/\n/g, '\n> ');
+    return `> **${prefix}:** ${cleanContent}\n`;
+  });
+}
+
+/**
+ * Convert <Card> component to list item
+ */
+function convertCard(cardMatch: string): string {
+  const titleMatch = cardMatch.match(/title="([^"]+)"/);
+  const hrefMatch = cardMatch.match(/href="([^"]+)"/);
+  const descMatch = cardMatch.match(/description="([^"]+)"/);
+
+  const title = titleMatch ? titleMatch[1] : '';
+  const href = hrefMatch ? hrefMatch[1] : '';
+  const desc = descMatch ? descMatch[1] : '';
+
+  if (href) {
+    return `- [${title}](${href})${desc ? ` - ${desc}` : ''}`;
+  }
+  return `- **${title}**${desc ? `: ${desc}` : ''}`;
+}
+
+/**
+ * Convert <Cards> component to bullet list
+ */
+function convertCards(mdx: string): string {
+  const cardsRegex = /<Cards>([\s\S]*?)<\/Cards>/g;
+
+  return mdx.replace(cardsRegex, (match, content) => {
+    // Find all <Card> elements
+    const cardRegex = /<Card[^>]*(?:\/>|>[\s\S]*?<\/Card>)/g;
+    const cards = content.match(cardRegex) || [];
+
+    if (cards.length === 0) {
+      return extractContent(content);
+    }
+
+    return cards.map(convertCard).join('\n');
+  });
+}
+
+/**
+ * Convert <Steps> and <Step> to numbered list
+ */
+function convertSteps(mdx: string): string {
+  const stepsRegex = /<Steps>([\s\S]*?)<\/Steps>/g;
+
+  return mdx.replace(stepsRegex, (match, content) => {
+    const stepRegex = /<Step[^>]*>([\s\S]*?)<\/Step>/g;
+    const steps: string[] = [];
+    let stepMatch;
+    let index = 1;
+
+    while ((stepMatch = stepRegex.exec(content)) !== null) {
+      const stepContent = extractContent(stepMatch[1]).trim();
+      steps.push(`${index}. ${stepContent.replace(/\n/g, '\n   ')}`);
+      index++;
+    }
+
+    return steps.join('\n\n');
+  });
+}
+
+/**
+ * Convert <Accordion> and <AccordionItem> to sections
+ */
+function convertAccordions(mdx: string): string {
+  const accordionRegex = /<Accordion[^>]*>([\s\S]*?)<\/Accordion>/g;
+
+  return mdx.replace(accordionRegex, (match, content) => {
+    // Match AccordionItem or Accordions - captures attributes and content separately
+    const itemRegex = /<Accordions?(?:Item)?([^>]*)>([\s\S]*?)<\/Accordions?(?:Item)?>/g;
+    let result = '';
+    let itemMatch;
+
+    while ((itemMatch = itemRegex.exec(content)) !== null) {
+      const attrs = itemMatch[1];
+      const title = extractAttribute(attrs, 'title') || 'Section';
+      const itemContent = extractContent(itemMatch[2]).trim();
+      result += `\n### ${title}\n\n${itemContent}\n`;
+    }
+
+    return result || extractContent(content);
+  });
+}
+
+/**
+ * Convert <YouTube> embeds to links
+ * Uses extractAttribute to handle attributes in any order
+ */
+function convertYouTube(mdx: string): string {
+  const ytRegex = /<YouTube([^>]*)\/?>/g;
+
+  return mdx.replace(ytRegex, (match, attrs) => {
+    const id = extractAttribute(attrs, 'id');
+    const title = extractAttribute(attrs, 'title') || 'Video';
+    if (!id) return match; // Keep original if no id
+    return `[${title}](https://www.youtube.com/watch?v=${id})`;
+  });
+}
+
+/**
+ * Convert <Video> embeds to links
+ * Uses extractAttribute to handle attributes in any order
+ */
+function convertVideo(mdx: string): string {
+  const videoRegex = /<Video([^>]*)\/?>/g;
+
+  return mdx.replace(videoRegex, (match, attrs) => {
+    const src = extractAttribute(attrs, 'src');
+    const title = extractAttribute(attrs, 'title') || 'Video';
+    if (!src) return match; // Keep original if no src
+    return `[${title}](${src})`;
+  });
+}
+
+/**
+ * Convert provider-specific components
+ * Uses extractAttribute to handle attributes in any order
+ */
+function convertProviderCards(mdx: string): string {
+  // Convert <ProviderGrid>
+  let result = mdx.replace(/<ProviderGrid>([\s\S]*?)<\/ProviderGrid>/g, (match, content) => {
+    return content;
+  });
+
+  // Convert <ProviderCard>
+  result = result.replace(
+    /<ProviderCard([^>]*)\/?>/g,
+    (match, attrs) => {
+      const name = extractAttribute(attrs, 'name');
+      const href = extractAttribute(attrs, 'href');
+      // Extract languages from {["ts", "py"]} format
+      const langMatch = attrs.match(/languages=\{?\[([^\]]+)\]/);
+      const langs = langMatch ? ` (${langMatch[1].replace(/["']/g, '').trim()})` : '';
+      if (!name || !href) return match; // Keep original if missing required attrs
+      return `- [${name}](${href})${langs}`;
+    }
+  );
+
+  return result;
+}
+
+/**
+ * Strip remaining JSX components that weren't converted
+ */
+function stripRemainingJsx(mdx: string): string {
+  // Remove self-closing JSX tags like <Icon />, <Component />
+  let result = mdx.replace(/<[A-Z][a-zA-Z]*[^>]*\/>/g, '');
+
+  // Remove JSX opening and closing tags but keep inner content
+  // This handles cases like <SomeComponent>content</SomeComponent>
+  result = result.replace(/<\/?[A-Z][a-zA-Z]*[^>]*>/g, '');
+
+  return result;
+}
+
+/**
+ * Clean up extra whitespace and empty lines
+ */
+function cleanupWhitespace(mdx: string): string {
+  return mdx
+    // Replace multiple newlines with max 2
+    .replace(/\n{3,}/g, '\n\n')
+    // Remove trailing whitespace on lines
+    .replace(/[ \t]+$/gm, '')
+    // Trim the whole document
+    .trim();
+}
+
+/**
+ * Main conversion function: MDX with JSX components to pure Markdown
+ */
+export function convertMdxToMarkdown(mdx: string): string {
+  let result = mdx;
+
+  // Convert specific components in order of complexity
+  result = convertTabs(result);
+  result = convertCallouts(result);
+  result = convertCards(result);
+  result = convertSteps(result);
+  result = convertAccordions(result);
+  result = convertYouTube(result);
+  result = convertVideo(result);
+  result = convertProviderCards(result);
+
+  // Strip any remaining JSX
+  result = stripRemainingJsx(result);
+
+  // Clean up whitespace
+  result = cleanupWhitespace(result);
+
+  return result;
+}

--- a/fumadocs/lib/path-validation.ts
+++ b/fumadocs/lib/path-validation.ts
@@ -1,0 +1,231 @@
+/**
+ * Path Validation Module
+ *
+ * Unified path validation for both proxy.ts and API routes.
+ * Prevents path traversal and injection attacks.
+ */
+
+/**
+ * Valid path prefixes for content access.
+ * Used by both proxy and API routes.
+ */
+export const VALID_PATH_PREFIXES = [
+  '/docs',
+  '/tool-router',
+  '/reference',
+  '/examples',
+] as const;
+
+export type ValidPrefix = (typeof VALID_PATH_PREFIXES)[number];
+
+/**
+ * Result type for path validation
+ */
+export type ValidationResult =
+  | { valid: true; path: string; prefix: ValidPrefix }
+  | { valid: false; error: string };
+
+/**
+ * Fully decode a URL-encoded string, handling double/triple encoding.
+ * Returns null if decoding fails (invalid encoding).
+ */
+function fullyDecode(str: string): string | null {
+  let decoded = str;
+  let previous = '';
+
+  try {
+    // Keep decoding until no more changes (handles double/triple encoding)
+    // Limit iterations to prevent infinite loops
+    let iterations = 0;
+    const maxIterations = 5;
+
+    while (decoded !== previous && iterations < maxIterations) {
+      previous = decoded;
+      decoded = decodeURIComponent(decoded);
+      iterations++;
+    }
+
+    return decoded;
+  } catch {
+    // Invalid URL encoding
+    return null;
+  }
+}
+
+/**
+ * Check for path traversal patterns
+ */
+function hasTraversalPattern(path: string): boolean {
+  // Check various forms of path traversal
+  const traversalPatterns = [
+    '..', // Direct traversal
+    '\\.\\.',  // Escaped dots (regex pattern not literal)
+    '\0', // Null byte
+  ];
+
+  // Check for exact patterns
+  for (const pattern of traversalPatterns) {
+    if (path.includes(pattern)) {
+      return true;
+    }
+  }
+
+  // Check for unicode variants of dots and slashes
+  const unicodeDots = [
+    '\u002e', // .
+    '\u2024', // One dot leader
+    '\u2025', // Two dot leader
+    '\ufe52', // Small full stop
+    '\uff0e', // Fullwidth full stop
+  ];
+
+  // Check if two consecutive unicode dots exist
+  for (let i = 0; i < path.length - 1; i++) {
+    if (unicodeDots.includes(path[i]) && unicodeDots.includes(path[i + 1])) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Validate and sanitize a path for content access.
+ *
+ * Security measures:
+ * - Full URL decoding (handles double encoding)
+ * - Unicode normalization (NFC)
+ * - Path traversal detection
+ * - Prefix validation
+ *
+ * @param path - The path to validate
+ * @returns Validation result with sanitized path or error
+ */
+export function validatePath(path: string | null | undefined): ValidationResult {
+  // Null/empty check
+  if (!path || typeof path !== 'string') {
+    return { valid: false, error: 'Path is required' };
+  }
+
+  // Length check (prevent DoS with extremely long paths)
+  if (path.length > 1000) {
+    return { valid: false, error: 'Path too long' };
+  }
+
+  // Fully decode the path (handles %2e, %252e, etc.)
+  const decoded = fullyDecode(path);
+  if (decoded === null) {
+    return { valid: false, error: 'Invalid path encoding' };
+  }
+
+  // Normalize unicode to NFC form
+  const normalized = decoded.normalize('NFC');
+
+  // Check for path traversal patterns
+  if (hasTraversalPattern(normalized)) {
+    return { valid: false, error: 'Invalid path' };
+  }
+
+  // Normalize slashes and case for prefix checking
+  const cleanPath = normalized
+    .replace(/\\/g, '/') // Convert backslashes
+    .replace(/\/+/g, '/'); // Remove duplicate slashes
+
+  const lowerPath = cleanPath.toLowerCase();
+
+  // Find matching prefix with boundary check
+  // Ensures /docsextra doesn't match /docs - must be exact or followed by /
+  const matchedPrefix = VALID_PATH_PREFIXES.find((prefix) => {
+    if (!lowerPath.startsWith(prefix)) return false;
+    // Check boundary: path must equal prefix or have / after it
+    return lowerPath.length === prefix.length || lowerPath[prefix.length] === '/';
+  });
+
+  if (!matchedPrefix) {
+    return { valid: false, error: 'Invalid path prefix' };
+  }
+
+  // Return the cleaned (but not lowercased) path
+  return {
+    valid: true,
+    path: cleanPath,
+    prefix: matchedPrefix,
+  };
+}
+
+/**
+ * Validate path segments from Next.js dynamic route.
+ * Reconstructs path and validates.
+ *
+ * @param segments - Array of path segments from [...path]
+ * @returns Validation result
+ */
+export function validatePathSegments(
+  segments: string[] | null | undefined
+): ValidationResult {
+  if (!segments || !Array.isArray(segments) || segments.length === 0) {
+    return { valid: false, error: 'Path segments required' };
+  }
+
+  // Check segment count (prevent DoS)
+  if (segments.length > 20) {
+    return { valid: false, error: 'Too many path segments' };
+  }
+
+  // Reconstruct path from segments
+  const path = '/' + segments.join('/');
+
+  return validatePath(path);
+}
+
+/**
+ * YAML reserved words that must be quoted to prevent type coercion.
+ * These are interpreted as boolean/null in YAML 1.1 and some parsers.
+ */
+const YAML_RESERVED_WORDS = new Set([
+  // Boolean values (case variations)
+  'true', 'false', 'yes', 'no', 'on', 'off',
+  'True', 'False', 'Yes', 'No', 'On', 'Off',
+  'TRUE', 'FALSE', 'YES', 'NO', 'ON', 'OFF',
+  // Null values
+  'null', 'Null', 'NULL', '~',
+]);
+
+/**
+ * Escape a string for safe use in YAML frontmatter.
+ * Handles special characters, newlines, reserved words, and numbers.
+ */
+export function escapeYaml(str: string): string {
+  if (!str) return '""';
+
+  // Check for special characters that need escaping
+  const hasSpecialChars = /[:\n\r"'\\@&*#!|>[\]{},%?`]/.test(str);
+
+  // Check if it's a YAML reserved word
+  const isReservedWord = YAML_RESERVED_WORDS.has(str);
+
+  // Check if it looks like a number (would be parsed as number instead of string)
+  // Matches: integers, floats, scientific notation, hex, octal, infinity
+  const looksLikeNumber = /^[-+]?(?:\d+\.?\d*|\d*\.?\d+)(?:[eE][-+]?\d+)?$/.test(str) ||
+    /^0[xX][0-9a-fA-F]+$/.test(str) || // hex
+    /^0[oO]?[0-7]+$/.test(str) || // octal
+    /^[-+]?(?:\.inf|\.Inf|\.INF)$/.test(str) || // infinity
+    /^(?:\.nan|\.NaN|\.NAN)$/.test(str); // NaN
+
+  // Check if starts with special indicator characters
+  const startsWithIndicator = /^[-?:,[\]{}#&*!|>'"%@`]/.test(str);
+
+  if (!hasSpecialChars && !isReservedWord && !looksLikeNumber && !startsWithIndicator) {
+    return str;
+  }
+
+  // Escape special characters
+  const escaped = str
+    .replace(/\\/g, '\\\\') // Backslashes first
+    .replace(/"/g, '\\"') // Double quotes
+    .replace(/\n/g, '\\n') // Newlines
+    .replace(/\r/g, '\\r') // Carriage returns
+    .replace(/\t/g, '\\t'); // Tabs
+
+  return `"${escaped}"`;
+}

--- a/fumadocs/proxy.ts
+++ b/fumadocs/proxy.ts
@@ -1,0 +1,92 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { validatePath, VALID_PATH_PREFIXES } from '@/lib/path-validation';
+
+/**
+ * Content negotiation proxy for AI agents (Next.js 16)
+ *
+ * Allows AI agents to request raw MDX content (converted to pure markdown) by:
+ * 1. Appending .md or .mdx to the URL (e.g., /docs/quickstart.md)
+ * 2. Using Accept header: text/markdown or text/x-markdown
+ *
+ * Security:
+ * - Uses unified path validation from lib/path-validation.ts
+ * - Validates paths to prevent traversal attacks
+ * - Handles double encoding, unicode normalization
+ */
+export function proxy(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // Check if requesting .md extension
+  if (pathname.endsWith('.md') || pathname.endsWith('.MD')) {
+    const basePath = pathname.slice(0, -3); // Remove .md
+    const validation = validatePath(basePath);
+
+    if (!validation.valid) {
+      return new NextResponse(validation.error, { status: 400 });
+    }
+
+    // Rewrite to path-based API route: /api/mdx-content/docs/quickstart
+    const rewriteUrl = new URL(`/api/mdx-content${validation.path}`, request.url);
+    return NextResponse.rewrite(rewriteUrl);
+  }
+
+  // Check if requesting .mdx extension
+  if (pathname.endsWith('.mdx') || pathname.endsWith('.MDX')) {
+    const basePath = pathname.slice(0, -4); // Remove .mdx
+    const validation = validatePath(basePath);
+
+    if (!validation.valid) {
+      return new NextResponse(validation.error, { status: 400 });
+    }
+
+    // Rewrite to path-based API route: /api/mdx-content/docs/quickstart
+    const rewriteUrl = new URL(`/api/mdx-content${validation.path}`, request.url);
+    return NextResponse.rewrite(rewriteUrl);
+  }
+
+  // Check Accept header for markdown preference
+  const acceptHeader = request.headers.get('accept') || '';
+  const prefersMarkdown =
+    acceptHeader.includes('text/markdown') ||
+    acceptHeader.includes('text/x-markdown') ||
+    acceptHeader.includes('text/mdx');
+
+  if (prefersMarkdown) {
+    const validation = validatePath(pathname);
+
+    if (validation.valid) {
+      // Rewrite to path-based API route
+      const rewriteUrl = new URL(`/api/mdx-content${validation.path}`, request.url);
+      return NextResponse.rewrite(rewriteUrl);
+    }
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  // Match documentation paths (including index pages, .md and .mdx requests)
+  matcher: [
+    // Index pages
+    '/docs',
+    '/tool-router',
+    '/reference',
+    '/examples',
+    // Index .md requests (e.g., /docs.md)
+    '/docs.md',
+    '/tool-router.md',
+    '/reference.md',
+    '/examples.md',
+    // Index .mdx requests (e.g., /docs.mdx)
+    '/docs.mdx',
+    '/tool-router.mdx',
+    '/reference.mdx',
+    '/examples.mdx',
+    // Nested paths
+    '/docs/:path*',
+    '/tool-router/:path*',
+    '/reference/:path*',
+    '/examples/:path*',
+  ],
+};


### PR DESCRIPTION
## Summary
- `/api/mdx-content/[...path]` - API for MDX to markdown conversion
- `lib/mdx-to-markdown.ts` - Converter handling callouts, code blocks, etc.
- `lib/path-validation.ts` - Security validation for paths
- `proxy.ts` - Middleware for Accept header content negotiation

Enables AI agents to request markdown via `Accept: text/markdown` header.

## Test plan
- [ ] Request `/api/mdx-content/docs/quickstart` - should return markdown
- [ ] Test Accept header negotiation with curl

🤖 Generated with [Claude Code](https://claude.com/claude-code)