### PR TITLE
docs: add enhanced code display components

### DIFF
--- a/fumadocs/components/code-block.tsx
+++ b/fumadocs/components/code-block.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import * as React from 'react';
+import { Check, Copy, Terminal } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+/**
+ * Language display names and icons
+ */
+const LANGUAGE_INFO: Record<string, { label: string; color: string }> = {
+  typescript: { label: 'TypeScript', color: 'bg-blue-500' },
+  ts: { label: 'TypeScript', color: 'bg-blue-500' },
+  javascript: { label: 'JavaScript', color: 'bg-yellow-500' },
+  js: { label: 'JavaScript', color: 'bg-yellow-500' },
+  python: { label: 'Python', color: 'bg-green-500' },
+  py: { label: 'Python', color: 'bg-green-500' },
+  bash: { label: 'Bash', color: 'bg-gray-500' },
+  sh: { label: 'Shell', color: 'bg-gray-500' },
+  shell: { label: 'Shell', color: 'bg-gray-500' },
+  json: { label: 'JSON', color: 'bg-orange-500' },
+  yaml: { label: 'YAML', color: 'bg-pink-500' },
+  yml: { label: 'YAML', color: 'bg-pink-500' },
+  markdown: { label: 'Markdown', color: 'bg-purple-500' },
+  md: { label: 'Markdown', color: 'bg-purple-500' },
+  mdx: { label: 'MDX', color: 'bg-purple-500' },
+  css: { label: 'CSS', color: 'bg-blue-400' },
+  html: { label: 'HTML', color: 'bg-red-500' },
+  sql: { label: 'SQL', color: 'bg-cyan-500' },
+  graphql: { label: 'GraphQL', color: 'bg-pink-600' },
+  rust: { label: 'Rust', color: 'bg-orange-600' },
+  go: { label: 'Go', color: 'bg-cyan-600' },
+  java: { label: 'Java', color: 'bg-red-600' },
+  curl: { label: 'cURL', color: 'bg-green-600' },
+  text: { label: 'Text', color: 'bg-gray-400' },
+  plaintext: { label: 'Text', color: 'bg-gray-400' },
+};
+
+interface CodeBlockProps {
+  children: React.ReactNode;
+  className?: string;
+  /**
+   * Language for syntax highlighting (extracted from className)
+   */
+  'data-language'?: string;
+  /**
+   * Optional filename to display
+   */
+  filename?: string;
+  /**
+   * Raw code content for copy functionality
+   */
+  raw?: string;
+}
+
+/**
+ * Enhanced code block with:
+ * - Language label badge
+ * - Copy button with feedback
+ * - Optional filename display
+ * - Consistent styling
+ */
+export function CodeBlock({
+  children,
+  className,
+  'data-language': language,
+  filename,
+  raw,
+}: CodeBlockProps) {
+  const [copied, setCopied] = React.useState(false);
+  const preRef = React.useRef<HTMLPreElement>(null);
+
+  // Extract language from className if not provided
+  const lang = language || extractLanguage(className);
+  const langInfo = lang ? LANGUAGE_INFO[lang.toLowerCase()] : null;
+
+  const handleCopy = async () => {
+    // Get code content from raw prop or from pre element
+    const code = raw || preRef.current?.textContent || '';
+
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(code);
+      } else {
+        // Fallback for browsers without clipboard API
+        const textarea = document.createElement('textarea');
+        textarea.value = code;
+        textarea.style.position = 'fixed';
+        textarea.style.opacity = '0';
+        document.body.appendChild(textarea);
+        textarea.select();
+        const success = document.execCommand('copy');
+        document.body.removeChild(textarea);
+        if (!success) return; // Don't show success if copy failed
+      }
+
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (error) {
+      console.error('Failed to copy:', error);
+    }
+  };
+
+  return (
+    <div className="code-block-wrapper relative group my-4">
+      {/* Header with language label and copy button */}
+      <div className={cn(
+        'flex items-center justify-between px-4 py-2',
+        'bg-fd-muted/50 border-b border-fd-border',
+        'rounded-t-lg'
+      )}>
+        <div className="flex items-center gap-2">
+          {langInfo ? (
+            <>
+              <span className={cn(
+                'w-2 h-2 rounded-full',
+                langInfo.color
+              )} />
+              <span className="text-xs font-medium text-fd-muted-foreground">
+                {langInfo.label}
+              </span>
+            </>
+          ) : (
+            <>
+              <Terminal className="w-3 h-3 text-fd-muted-foreground" />
+              <span className="text-xs font-medium text-fd-muted-foreground">
+                {filename || 'Code'}
+              </span>
+            </>
+          )}
+          {filename && langInfo && (
+            <span className="text-xs text-fd-muted-foreground">
+              {filename}
+            </span>
+          )}
+        </div>
+
+        <button
+          onClick={handleCopy}
+          className={cn(
+            'inline-flex items-center gap-1.5 px-2 py-1 text-xs rounded',
+            'text-fd-muted-foreground hover:text-fd-foreground',
+            'hover:bg-fd-accent transition-colors',
+            'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+          )}
+          aria-label={copied ? 'Copied!' : 'Copy code'}
+        >
+          {copied ? (
+            <>
+              <Check className="w-3 h-3 text-green-500" />
+              <span className="text-green-500">Copied!</span>
+            </>
+          ) : (
+            <>
+              <Copy className="w-3 h-3" />
+              <span>Copy</span>
+            </>
+          )}
+        </button>
+      </div>
+
+      {/* Code content */}
+      <pre
+        ref={preRef}
+        className={cn(
+          'rounded-t-none rounded-b-lg',
+          'overflow-x-auto',
+          className
+        )}
+      >
+        {children}
+      </pre>
+    </div>
+  );
+}
+
+/**
+ * Extract language from className like "language-typescript"
+ */
+function extractLanguage(className?: string): string | null {
+  if (!className) return null;
+  const match = className.match(/language-(\w+)/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Simple pre wrapper that adds copy functionality
+ * Use this as a drop-in replacement for <pre>
+ */
+export function Pre({ children, ...props }: React.ComponentProps<'pre'>) {
+  return (
+    <CodeBlock {...props}>
+      {children}
+    </CodeBlock>
+  );
+}

--- a/fumadocs/components/code-tabs.tsx
+++ b/fumadocs/components/code-tabs.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import * as React from 'react';
+import * as TabsPrimitive from '@radix-ui/react-tabs';
+import { cn } from '@/lib/utils';
+
+/**
+ * Language preference key for localStorage
+ */
+const LANGUAGE_PREFERENCE_KEY = 'composio-preferred-language';
+
+/**
+ * Supported languages with display names and icons
+ */
+const LANGUAGES = {
+  typescript: { label: 'TypeScript', icon: '📘' },
+  python: { label: 'Python', icon: '🐍' },
+  javascript: { label: 'JavaScript', icon: '📒' },
+  curl: { label: 'cURL', icon: '🔧' },
+  bash: { label: 'Bash', icon: '💻' },
+} as const;
+
+type Language = keyof typeof LANGUAGES;
+
+interface CodeTabsProps {
+  children: React.ReactNode;
+  defaultValue?: Language;
+  /**
+   * Whether to persist language preference
+   * @default true
+   */
+  persist?: boolean;
+}
+
+/**
+ * CodeTabs - Language switching tabs for code examples
+ *
+ * Usage in MDX:
+ * ```mdx
+ * <CodeTabs>
+ *   <Tab value="typescript">
+ *     ```typescript
+ *     const composio = new Composio({ apiKey: 'your-key' });
+ *     ```
+ *   </Tab>
+ *   <Tab value="python">
+ *     ```python
+ *     composio = Composio(api_key="your-key")
+ *     ```
+ *   </Tab>
+ * </CodeTabs>
+ * ```
+ */
+export function CodeTabs({
+  children,
+  defaultValue = 'typescript',
+  persist = true,
+}: CodeTabsProps) {
+  // Use null initially to detect mounted state and avoid hydration mismatch
+  const [mounted, setMounted] = React.useState(false);
+  const [value, setValue] = React.useState<string>(defaultValue);
+
+  // Load saved preference on mount (after hydration)
+  React.useEffect(() => {
+    setMounted(true);
+    if (persist) {
+      try {
+        const saved = localStorage.getItem(LANGUAGE_PREFERENCE_KEY);
+        if (saved && saved in LANGUAGES) {
+          setValue(saved);
+        }
+      } catch {
+        // localStorage not available (private browsing)
+      }
+    }
+  }, [persist]);
+
+  // Save preference when changed
+  const handleValueChange = (newValue: string) => {
+    setValue(newValue);
+    if (persist && typeof window !== 'undefined') {
+      try {
+        localStorage.setItem(LANGUAGE_PREFERENCE_KEY, newValue);
+      } catch {
+        // localStorage not available (private browsing)
+      }
+
+      // Sync all CodeTabs on the page
+      window.dispatchEvent(
+        new CustomEvent('composio-language-change', { detail: newValue })
+      );
+    }
+  };
+
+  // Listen for changes from other CodeTabs
+  React.useEffect(() => {
+    if (!persist || !mounted) return;
+
+    const handleLanguageChange = (e: Event) => {
+      const customEvent = e as CustomEvent<string>;
+      if (customEvent.detail && customEvent.detail in LANGUAGES) {
+        setValue(customEvent.detail);
+      }
+    };
+
+    window.addEventListener('composio-language-change', handleLanguageChange);
+    return () => {
+      window.removeEventListener('composio-language-change', handleLanguageChange);
+    };
+  }, [persist, mounted]);
+
+  return (
+    <TabsPrimitive.Root
+      value={value}
+      onValueChange={handleValueChange}
+      className="code-tabs not-prose"
+    >
+      {children}
+    </TabsPrimitive.Root>
+  );
+}
+
+interface CodeTabProps {
+  value: Language;
+  children: React.ReactNode;
+}
+
+/**
+ * Individual tab content for CodeTabs
+ */
+export function CodeTab({ value, children }: CodeTabProps) {
+  return (
+    <TabsPrimitive.Content value={value} className="mt-0">
+      {children}
+    </TabsPrimitive.Content>
+  );
+}
+
+/**
+ * Tabs list with language labels
+ */
+export function CodeTabsList({
+  languages,
+}: {
+  languages: Language[];
+}) {
+  return (
+    <TabsPrimitive.List className={cn(
+      'flex items-center gap-1 border-b border-border mb-2',
+      'overflow-x-auto'
+    )}>
+      {languages.map((lang) => {
+        const info = LANGUAGES[lang] || { label: lang, icon: '📄' };
+        return (
+          <TabsPrimitive.Trigger
+            key={lang}
+            value={lang}
+            className={cn(
+              'inline-flex items-center gap-1.5 px-3 py-1.5 text-sm',
+              'border-b-2 border-transparent -mb-px',
+              'text-muted-foreground hover:text-foreground',
+              'data-[state=active]:border-composio-orange data-[state=active]:text-foreground',
+              'transition-colors focus:outline-none'
+            )}
+          >
+            <span className="text-base">{info.icon}</span>
+            {info.label}
+          </TabsPrimitive.Trigger>
+        );
+      })}
+    </TabsPrimitive.List>
+  );
+}
+
+// Re-export primitives for advanced usage
+export const CodeTabContent = TabsPrimitive.Content;
+export const CodeTabTrigger = TabsPrimitive.Trigger;
+export const CodeTabList = TabsPrimitive.List;

--- a/fumadocs/components/copy-button.tsx
+++ b/fumadocs/components/copy-button.tsx
@@ -1,0 +1,253 @@
+'use client';
+
+import * as React from 'react';
+import { Check, Copy, Key } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+/**
+ * Placeholder patterns to detect in code (for replacement)
+ * Note: /g flag is required for replaceAll behavior
+ */
+const API_KEY_REPLACE_PATTERNS = [
+  /\{\{API_KEY\}\}/g,
+  /\{\{COMPOSIO_API_KEY\}\}/g,
+  /YOUR_API_KEY/g,
+  /your-api-key/g,
+  /COMPOSIO_API_KEY/g,
+  /<your-api-key>/g,
+  /<API_KEY>/g,
+];
+
+/**
+ * Detection patterns (without /g flag to avoid stateful .test() behavior)
+ */
+const API_KEY_DETECT_PATTERNS = [
+  /\{\{API_KEY\}\}/,
+  /\{\{COMPOSIO_API_KEY\}\}/,
+  /YOUR_API_KEY/,
+  /your-api-key/,
+  /COMPOSIO_API_KEY/,
+  /<your-api-key>/,
+  /<API_KEY>/,
+];
+
+interface CopyButtonProps {
+  /**
+   * The code content to copy
+   */
+  code: string;
+  /**
+   * Custom class name
+   */
+  className?: string;
+  /**
+   * Whether to show the "with API key" option
+   */
+  showApiKeyOption?: boolean;
+}
+
+/**
+ * Enhanced copy button with API key substitution
+ *
+ * Features:
+ * - Standard copy functionality
+ * - Detects API key placeholders
+ * - Shows "Copy with API key" option when placeholders detected
+ * - Uses env var NEXT_PUBLIC_COMPOSIO_API_KEY or prompts user
+ *
+ * Usage:
+ * ```tsx
+ * <CopyButton code={codeString} />
+ * ```
+ */
+export function CopyButton({
+  code,
+  className,
+  showApiKeyOption = true,
+}: CopyButtonProps) {
+  const [copied, setCopied] = React.useState(false);
+  const [showMenu, setShowMenu] = React.useState(false);
+
+  // Check if code contains API key placeholders
+  // Uses detection patterns without /g flag to avoid stateful .test() behavior
+  const hasPlaceholders = React.useMemo(() => {
+    return API_KEY_DETECT_PATTERNS.some((pattern) => pattern.test(code));
+  }, [code]);
+
+  // Get API key from env (for demo purposes) or localStorage
+  const getApiKey = React.useCallback(() => {
+    if (typeof window === 'undefined') return null;
+
+    // Check localStorage for user's API key (wrapped in try-catch for private browsing)
+    try {
+      const savedKey = localStorage.getItem('composio-api-key');
+      if (savedKey) return savedKey;
+    } catch {
+      // localStorage not available (private browsing)
+    }
+
+    // Could also check for env var in development
+    return null;
+  }, []);
+
+  const copyToClipboard = async (text: string) => {
+    try {
+      // Modern clipboard API (preferred)
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+        setShowMenu(false);
+        return;
+      }
+
+      // Fallback for browsers without clipboard API
+      const textarea = document.createElement('textarea');
+      textarea.value = text;
+      textarea.style.position = 'fixed';
+      textarea.style.opacity = '0';
+      textarea.style.pointerEvents = 'none';
+      document.body.appendChild(textarea);
+      textarea.select();
+      const success = document.execCommand('copy');
+      document.body.removeChild(textarea);
+
+      if (success) {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      }
+    } catch (error) {
+      console.error('Failed to copy:', error);
+    }
+    setShowMenu(false);
+  };
+
+  const handleCopy = () => {
+    if (hasPlaceholders && showApiKeyOption) {
+      setShowMenu(true);
+    } else {
+      copyToClipboard(code);
+    }
+  };
+
+  const handleCopyPlain = () => {
+    copyToClipboard(code);
+  };
+
+  const handleCopyWithApiKey = () => {
+    const apiKey = getApiKey();
+
+    if (!apiKey) {
+      // Prompt user for API key
+      const key = window.prompt(
+        'Enter your Composio API key:\n(Get it from https://app.composio.dev)',
+        ''
+      );
+      if (key) {
+        // Save to localStorage (wrapped in try-catch for private browsing)
+        try {
+          localStorage.setItem('composio-api-key', key);
+        } catch {
+          // localStorage not available
+        }
+        copyWithKey(key);
+      }
+      return;
+    }
+
+    copyWithKey(apiKey);
+  };
+
+  const copyWithKey = (apiKey: string) => {
+    let processedCode = code;
+    // Uses replacement patterns with /g flag to replace all occurrences
+    // Use function replacement to avoid $ special character interpretation in API keys
+    API_KEY_REPLACE_PATTERNS.forEach((pattern) => {
+      processedCode = processedCode.replace(pattern, () => apiKey);
+    });
+    copyToClipboard(processedCode);
+  };
+
+  return (
+    <div className={cn('relative', className)}>
+      <button
+        onClick={handleCopy}
+        className={cn(
+          'inline-flex items-center justify-center size-8 rounded-md',
+          'text-muted-foreground hover:text-foreground hover:bg-accent',
+          'transition-colors focus:outline-none focus:ring-2 focus:ring-ring'
+        )}
+        aria-label={copied ? 'Copied!' : 'Copy code'}
+      >
+        {copied ? (
+          <Check className="size-4 text-green-500" />
+        ) : (
+          <Copy className="size-4" />
+        )}
+      </button>
+
+      {/* Dropdown menu for API key option */}
+      {showMenu && (
+        <>
+          {/* Backdrop */}
+          <div
+            className="fixed inset-0 z-40"
+            onClick={() => setShowMenu(false)}
+          />
+
+          {/* Menu */}
+          <div
+            className={cn(
+              'absolute right-0 top-full mt-1 z-50',
+              'bg-popover border border-border rounded-md shadow-lg',
+              'py-1 min-w-[180px]',
+              'animate-in slide-in-from-top-2'
+            )}
+          >
+            <button
+              onClick={handleCopyPlain}
+              className={cn(
+                'flex items-center gap-2 w-full px-3 py-2 text-sm',
+                'hover:bg-accent transition-colors text-left'
+              )}
+            >
+              <Copy className="size-4" />
+              Copy as-is
+            </button>
+            <button
+              onClick={handleCopyWithApiKey}
+              className={cn(
+                'flex items-center gap-2 w-full px-3 py-2 text-sm',
+                'hover:bg-accent transition-colors text-left',
+                'text-composio-orange'
+              )}
+            >
+              <Key className="size-4" />
+              Copy with my API key
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Wrapper to detect API key placeholders in code blocks
+ */
+export function CodeBlockWithCopy({
+  children,
+  code,
+}: {
+  children: React.ReactNode;
+  code: string;
+}) {
+  return (
+    <div className="relative group">
+      {children}
+      <div className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity">
+        <CopyButton code={code} />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- `code-block.tsx` - Enhanced code blocks with language labels, copy button, and "Copied!" feedback
- `code-tabs.tsx` - Tabbed code examples with language preference persistence
- `copy-button.tsx` - Smart copy button with API key placeholder substitution

## Test plan
- [ ] Code blocks show language label and copy button
- [ ] Copy button shows "Copied!" feedback
- [ ] API key placeholders get replaced when using "Copy with API key"

🤖 Generated with [Claude Code](https://claude.com/claude-code)