### PR TITLE
docs: add navigation and linking components

### DIFF
--- a/fumadocs/components/github-edit-link.tsx
+++ b/fumadocs/components/github-edit-link.tsx
@@ -1,0 +1,89 @@
+import { Pencil } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface GitHubEditLinkProps {
+  /**
+   * Path to the file in the repository
+   * e.g., 'content/docs/quickstart.mdx'
+   */
+  filePath: string;
+  /**
+   * GitHub repository (owner/repo format)
+   * @default 'composiohq/composio'
+   */
+  repo?: string;
+  /**
+   * Branch name
+   * @default 'next'
+   */
+  branch?: string;
+  /**
+   * Custom class name
+   */
+  className?: string;
+}
+
+/**
+ * GitHub edit link component
+ *
+ * Links to the source file on GitHub for easy contributions.
+ * Follows the pattern used by Stripe, Vercel, and other
+ * developer-focused documentation sites.
+ *
+ * Usage:
+ * ```tsx
+ * <GitHubEditLink filePath="content/docs/quickstart.mdx" />
+ * ```
+ */
+export function GitHubEditLink({
+  filePath,
+  repo = 'composiohq/composio',
+  branch = 'next',
+  className,
+}: GitHubEditLinkProps) {
+  // Construct the edit URL
+  // Format: https://github.com/{owner}/{repo}/edit/{branch}/fumadocs/{filePath}
+  const editUrl = `https://github.com/${repo}/edit/${branch}/fumadocs/${filePath}`;
+
+  return (
+    <a
+      href={editUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="Edit this page on GitHub (opens in new tab)"
+      className={cn(
+        'inline-flex items-center gap-2 text-sm text-muted-foreground',
+        'hover:text-foreground transition-colors mb-4',
+        className
+      )}
+    >
+      <Pencil className="size-4" aria-hidden="true" />
+      Edit this page on GitHub
+    </a>
+  );
+}
+
+/**
+ * Compact variant for inline use
+ */
+export function GitHubEditLinkCompact({
+  filePath,
+  repo = 'composiohq/composio',
+  branch = 'next',
+}: GitHubEditLinkProps) {
+  const editUrl = `https://github.com/${repo}/edit/${branch}/fumadocs/${filePath}`;
+
+  return (
+    <a
+      href={editUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+      title="Edit this page on GitHub"
+      aria-label="Edit this page on GitHub (opens in new tab)"
+    >
+      <Pencil className="size-3.5" aria-hidden="true" />
+      <span className="sr-only">Edit on GitHub</span>
+    </a>
+  );
+}

--- a/fumadocs/components/heading-anchor.tsx
+++ b/fumadocs/components/heading-anchor.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import * as React from 'react';
+import { Link2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
+
+interface HeadingAnchorProps {
+  id?: string;
+  level: HeadingLevel;
+  children: React.ReactNode;
+  className?: string;
+}
+
+// Mapping of heading levels to components
+const HeadingTags = {
+  1: 'h1',
+  2: 'h2',
+  3: 'h3',
+  4: 'h4',
+  5: 'h5',
+  6: 'h6',
+} as const;
+
+/**
+ * Heading component with anchor link support
+ *
+ * Features:
+ * - Stable anchor IDs for deep linking
+ * - Hover-reveal link icon
+ * - Click to copy URL with hash
+ * - Scroll offset for fixed header
+ * - Accessible: aria-label, focus states
+ *
+ * Usage:
+ * ```tsx
+ * <HeadingAnchor level={2} id="getting-started">
+ *   Getting Started
+ * </HeadingAnchor>
+ * ```
+ */
+export function HeadingAnchor({
+  id,
+  level,
+  children,
+  className,
+}: HeadingAnchorProps) {
+  const [copied, setCopied] = React.useState(false);
+  const Tag = HeadingTags[level];
+
+  // Generate ID from children if not provided
+  const headingId = id || generateId(children);
+
+  const handleCopyLink = async (e: React.MouseEvent) => {
+    e.preventDefault();
+
+    const url = `${window.location.origin}${window.location.pathname}#${headingId}`;
+
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(url);
+      } else {
+        // Fallback for browsers without clipboard API
+        const textarea = document.createElement('textarea');
+        textarea.value = url;
+        textarea.style.position = 'fixed';
+        textarea.style.opacity = '0';
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textarea);
+      }
+
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Navigate to the anchor as fallback
+      window.location.hash = headingId;
+    }
+  };
+
+  return (
+    <Tag
+      id={headingId}
+      className={cn(
+        'group relative scroll-mt-20',
+        className
+      )}
+    >
+      {children}
+      <a
+        href={`#${headingId}`}
+        onClick={handleCopyLink}
+        className={cn(
+          'ml-2 inline-flex items-center opacity-0 transition-opacity',
+          'group-hover:opacity-100 focus:opacity-100',
+          'text-muted-foreground hover:text-foreground',
+          'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded'
+        )}
+        aria-label={copied ? 'Link copied!' : `Link to ${getTextContent(children)}`}
+      >
+        {copied ? (
+          <span className="text-xs text-green-600 dark:text-green-400">Copied!</span>
+        ) : (
+          <Link2 className="size-4" />
+        )}
+      </a>
+    </Tag>
+  );
+}
+
+/**
+ * Generate a URL-safe ID from heading content
+ */
+function generateId(children: React.ReactNode): string {
+  const text = getTextContent(children);
+  const id = text
+    .toLowerCase()
+    .trim() // Remove leading/trailing whitespace first
+    .replace(/[^\w\s-]/g, '') // Remove special chars
+    .replace(/\s+/g, '-') // Spaces to hyphens
+    .replace(/-+/g, '-') // Collapse multiple hyphens
+    .replace(/^-+|-+$/g, ''); // Remove leading/trailing hyphens
+
+  // Fallback for empty IDs (e.g., emoji-only headings)
+  return id || `heading-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/**
+ * Extract text content from React children
+ */
+function getTextContent(children: React.ReactNode): string {
+  if (typeof children === 'string') return children;
+  if (typeof children === 'number') return String(children);
+  if (Array.isArray(children)) {
+    return children.map(getTextContent).join('');
+  }
+  if (React.isValidElement(children)) {
+    const props = children.props as { children?: React.ReactNode };
+    if (props.children) {
+      return getTextContent(props.children);
+    }
+  }
+  return '';
+}
+
+/**
+ * Pre-configured heading components for MDX
+ */
+export const H1 = (props: Omit<HeadingAnchorProps, 'level'>) => (
+  <HeadingAnchor level={1} {...props} />
+);
+export const H2 = (props: Omit<HeadingAnchorProps, 'level'>) => (
+  <HeadingAnchor level={2} {...props} />
+);
+export const H3 = (props: Omit<HeadingAnchorProps, 'level'>) => (
+  <HeadingAnchor level={3} {...props} />
+);
+export const H4 = (props: Omit<HeadingAnchorProps, 'level'>) => (
+  <HeadingAnchor level={4} {...props} />
+);
+export const H5 = (props: Omit<HeadingAnchorProps, 'level'>) => (
+  <HeadingAnchor level={5} {...props} />
+);
+export const H6 = (props: Omit<HeadingAnchorProps, 'level'>) => (
+  <HeadingAnchor level={6} {...props} />
+);

--- a/fumadocs/components/related-pages.tsx
+++ b/fumadocs/components/related-pages.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import * as React from 'react';
+import Link from 'next/link';
+import { ArrowRight, BookOpen } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface RelatedPage {
+  /**
+   * Page title
+   */
+  title: string;
+  /**
+   * Page URL
+   */
+  href: string;
+  /**
+   * Optional description
+   */
+  description?: string;
+}
+
+interface RelatedPagesProps {
+  /**
+   * Array of related pages to display
+   */
+  pages: RelatedPage[];
+  /**
+   * Section title
+   * @default "Related Guides"
+   */
+  title?: string;
+  /**
+   * Additional CSS classes
+   */
+  className?: string;
+}
+
+/**
+ * Related pages component for cross-linking documentation
+ *
+ * Displays a list of related guides at the bottom of a page
+ * to help users discover relevant content.
+ *
+ * Usage in MDX:
+ * ```mdx
+ * <RelatedPages
+ *   pages={[
+ *     { title: "Authentication", href: "/docs/authentication" },
+ *     { title: "API Reference", href: "/reference" },
+ *   ]}
+ * />
+ * ```
+ *
+ * Or with descriptions:
+ * ```mdx
+ * <RelatedPages
+ *   title="Continue Learning"
+ *   pages={[
+ *     {
+ *       title: "Authentication",
+ *       href: "/docs/authentication",
+ *       description: "Learn how to authenticate users"
+ *     },
+ *   ]}
+ * />
+ * ```
+ */
+export function RelatedPages({
+  pages,
+  title = 'Related Guides',
+  className,
+}: RelatedPagesProps) {
+  if (!pages || pages.length === 0) {
+    return null;
+  }
+
+  return (
+    <section
+      className={cn(
+        'related-pages mt-12 pt-8 border-t border-fd-border',
+        className
+      )}
+      aria-labelledby="related-pages-heading"
+    >
+      <h2
+        id="related-pages-heading"
+        className="flex items-center gap-2 mb-4 text-lg font-semibold text-fd-foreground"
+      >
+        <BookOpen className="w-5 h-5 text-fd-muted-foreground" />
+        {title}
+      </h2>
+
+      <ul className="grid gap-3 sm:grid-cols-2">
+        {pages.map((page) => (
+          <li key={page.href}>
+            <Link
+              href={page.href}
+              className={cn(
+                'group flex items-start gap-3 p-4 rounded-lg',
+                'border border-fd-border bg-fd-card',
+                'hover:border-composio-orange/50 hover:bg-fd-accent/50',
+                'transition-colors'
+              )}
+            >
+              <div className="flex-1 min-w-0">
+                <p className="font-medium text-fd-foreground group-hover:text-composio-orange transition-colors">
+                  {page.title}
+                </p>
+                {page.description && (
+                  <p className="mt-1 text-sm text-fd-muted-foreground line-clamp-2">
+                    {page.description}
+                  </p>
+                )}
+              </div>
+              <ArrowRight
+                className={cn(
+                  'w-4 h-4 mt-1 text-fd-muted-foreground',
+                  'group-hover:text-composio-orange group-hover:translate-x-0.5',
+                  'transition-all'
+                )}
+              />
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+/**
+ * Simple inline link list for related content
+ */
+export function RelatedLinks({
+  pages,
+  title = 'See also',
+  className,
+}: RelatedPagesProps) {
+  if (!pages || pages.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={cn('related-links my-4', className)}>
+      <span className="text-sm font-medium text-fd-muted-foreground">
+        {title}:{' '}
+      </span>
+      {pages.map((page, index) => (
+        <React.Fragment key={page.href}>
+          <Link
+            href={page.href}
+            className="text-sm text-composio-orange hover:underline"
+          >
+            {page.title}
+          </Link>
+          {index < pages.length - 1 && (
+            <span className="text-fd-muted-foreground">, </span>
+          )}
+        </React.Fragment>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- `heading-anchor.tsx` - Linkable headings with hover anchor links and copy-to-clipboard
- `github-edit-link.tsx` - "Edit on GitHub" links for each page
- `related-pages.tsx` - Related pages section for cross-linking

## Test plan
- [ ] Headings show anchor link on hover
- [ ] Clicking anchor copies URL to clipboard
- [ ] Related pages render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)