### PR TITLE
docs: add page feedback widget and API

### DIFF
--- a/fumadocs/app/api/feedback/route.ts
+++ b/fumadocs/app/api/feedback/route.ts
@@ -1,0 +1,166 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+/**
+ * Maximum payload size (10KB)
+ */
+const MAX_PAYLOAD_SIZE = 10000;
+
+/**
+ * Maximum field lengths
+ */
+const MAX_PAGE_ID_LENGTH = 500;
+const MAX_COMMENT_LENGTH = 5000;
+const MAX_TIMESTAMP_LENGTH = 50;
+
+/**
+ * Validate ISO timestamp format
+ */
+function isValidTimestamp(str: string): boolean {
+  if (typeof str !== 'string' || str.length > MAX_TIMESTAMP_LENGTH) return false;
+  const date = new Date(str);
+  return !isNaN(date.getTime());
+}
+
+/**
+ * Sanitize string input
+ */
+function sanitizeString(str: unknown, maxLength: number): string | null {
+  if (typeof str !== 'string') return null;
+  if (str.length > maxLength) return null;
+  // Remove null bytes and control characters
+  return str.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F]/g, '');
+}
+
+/**
+ * API route to collect page feedback
+ *
+ * Security:
+ * - Validates payload size
+ * - Validates all field types and lengths
+ * - Sanitizes string inputs
+ */
+export async function POST(request: NextRequest) {
+  try {
+    // Check payload size
+    const contentLength = request.headers.get('content-length');
+    if (contentLength && parseInt(contentLength, 10) > MAX_PAYLOAD_SIZE) {
+      return NextResponse.json(
+        { error: 'Payload too large' },
+        { status: 413 }
+      );
+    }
+
+    // Parse JSON with size limit
+    let data: unknown;
+    try {
+      const text = await request.text();
+      if (text.length > MAX_PAYLOAD_SIZE) {
+        return NextResponse.json(
+          { error: 'Payload too large' },
+          { status: 413 }
+        );
+      }
+      data = JSON.parse(text);
+    } catch {
+      return NextResponse.json(
+        { error: 'Invalid JSON' },
+        { status: 400 }
+      );
+    }
+
+    // Validate data is an object
+    if (!data || typeof data !== 'object' || Array.isArray(data)) {
+      return NextResponse.json(
+        { error: 'Invalid request body' },
+        { status: 400 }
+      );
+    }
+
+    const body = data as Record<string, unknown>;
+
+    // Validate pageId
+    const pageId = sanitizeString(body.pageId, MAX_PAGE_ID_LENGTH);
+    if (!pageId) {
+      return NextResponse.json(
+        { error: 'Invalid or missing pageId' },
+        { status: 400 }
+      );
+    }
+
+    // Validate helpful (must be boolean or null)
+    const helpful = body.helpful;
+    if (helpful !== null && typeof helpful !== 'boolean') {
+      return NextResponse.json(
+        { error: 'Invalid helpful value (must be boolean or null)' },
+        { status: 400 }
+      );
+    }
+
+    // Validate comment (optional)
+    let comment: string | null = null;
+    if (body.comment !== undefined && body.comment !== null) {
+      comment = sanitizeString(body.comment, MAX_COMMENT_LENGTH);
+      if (comment === null) {
+        return NextResponse.json(
+          { error: 'Invalid comment' },
+          { status: 400 }
+        );
+      }
+    }
+
+    // Validate timestamp
+    const timestamp = body.timestamp;
+    if (typeof timestamp !== 'string' || !isValidTimestamp(timestamp)) {
+      return NextResponse.json(
+        { error: 'Invalid timestamp' },
+        { status: 400 }
+      );
+    }
+
+    // Log feedback (replace with your preferred storage/analytics)
+    console.log('[Feedback]', {
+      pageId,
+      helpful,
+      comment: comment || null,
+      timestamp,
+    });
+
+    // TODO: Integrate with your preferred analytics/storage:
+    //
+    // Option 1: Posthog
+    // await posthog.capture({
+    //   distinctId: 'anonymous',
+    //   event: 'docs_feedback',
+    //   properties: { pageId, helpful, comment, timestamp },
+    // });
+    //
+    // Option 2: Slack webhook
+    // if (process.env.SLACK_WEBHOOK_URL) {
+    //   await fetch(process.env.SLACK_WEBHOOK_URL, {
+    //     method: 'POST',
+    //     headers: { 'Content-Type': 'application/json' },
+    //     body: JSON.stringify({
+    //       text: `Docs feedback: ${helpful ? '👍' : '👎'} on ${pageId}`,
+    //       attachments: comment ? [{ text: comment }] : [],
+    //     }),
+    //   });
+    // }
+    //
+    // Option 3: Database (e.g., Supabase)
+    // await supabase.from('feedback').insert({ pageId, helpful, comment, timestamp });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('[Feedback] Error:', error);
+    return NextResponse.json(
+      { error: 'Failed to process feedback' },
+      { status: 500 }
+    );
+  }
+}
+
+// Health check
+export async function GET() {
+  return NextResponse.json({ status: 'ok', endpoint: 'feedback' });
+}

--- a/fumadocs/components/feedback.tsx
+++ b/fumadocs/components/feedback.tsx
@@ -1,0 +1,253 @@
+'use client';
+
+import * as React from 'react';
+import { ThumbsUp, ThumbsDown, MessageSquare, X, Send } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface FeedbackProps {
+  /**
+   * The page URL or identifier for tracking
+   */
+  pageId?: string;
+  /**
+   * Custom class name
+   */
+  className?: string;
+  /**
+   * Callback when feedback is submitted
+   */
+  onSubmit?: (data: FeedbackData) => void;
+}
+
+interface FeedbackData {
+  pageId: string;
+  helpful: boolean | null;
+  comment?: string;
+  timestamp: string;
+}
+
+type FeedbackState = 'initial' | 'helpful' | 'not-helpful' | 'submitted';
+
+/**
+ * Feedback widget for documentation pages
+ *
+ * Features:
+ * - Thumbs up/down rating
+ * - Optional comment for negative feedback
+ * - Persists to prevent duplicate submissions
+ * - Sends data to /api/feedback endpoint
+ *
+ * Usage in MDX:
+ * ```mdx
+ * <Feedback />
+ * ```
+ *
+ * Or in a layout:
+ * ```tsx
+ * <Feedback pageId={page.url} />
+ * ```
+ */
+export function Feedback({ pageId, className, onSubmit }: FeedbackProps) {
+  const [state, setState] = React.useState<FeedbackState>('initial');
+  const [comment, setComment] = React.useState('');
+  const [showComment, setShowComment] = React.useState(false);
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const [resolvedPageId, setResolvedPageId] = React.useState(pageId || '');
+
+  // Resolve page ID from URL on mount (avoid hydration mismatch)
+  React.useEffect(() => {
+    if (!pageId) {
+      setResolvedPageId(window.location.pathname);
+    }
+  }, [pageId]);
+
+  const currentPageId = resolvedPageId;
+
+  // Check if already submitted (wrapped in try-catch for private browsing)
+  React.useEffect(() => {
+    if (!currentPageId) return;
+    try {
+      const submitted = localStorage.getItem(`feedback-${currentPageId}`);
+      if (submitted) {
+        setState('submitted');
+      }
+    } catch {
+      // localStorage not available (private browsing)
+    }
+  }, [currentPageId]);
+
+  const submitFeedback = async (helpful: boolean, feedbackComment?: string) => {
+    const data: FeedbackData = {
+      pageId: currentPageId,
+      helpful,
+      comment: feedbackComment,
+      timestamp: new Date().toISOString(),
+    };
+
+    // Call custom handler if provided
+    if (onSubmit) {
+      onSubmit(data);
+    }
+
+    // Send to API
+    try {
+      await fetch('/api/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+    } catch (error) {
+      // Silently fail - feedback is non-critical
+      console.warn('[Feedback] Failed to submit:', error);
+    }
+
+    // Mark as submitted in localStorage (wrapped in try-catch for private browsing)
+    try {
+      localStorage.setItem(`feedback-${currentPageId}`, 'true');
+    } catch {
+      // localStorage not available (private browsing)
+    }
+
+    setState('submitted');
+    setShowComment(false);
+  };
+
+  const handleHelpful = async () => {
+    // Set visual state first, then submit
+    setState('helpful');
+    await submitFeedback(true);
+  };
+
+  const handleNotHelpful = () => {
+    setState('not-helpful');
+    setShowComment(true);
+  };
+
+  const textareaId = `feedback-comment-${currentPageId.replace(/\//g, '-')}`;
+
+  const handleSubmitComment = async () => {
+    if (isSubmitting) return;
+    setIsSubmitting(true);
+    await submitFeedback(false, comment);
+  };
+
+  if (state === 'submitted') {
+    return (
+      <div
+        className={cn(
+          'flex items-center gap-2 text-sm text-muted-foreground py-4 border-t mt-8',
+          className
+        )}
+      >
+        <span className="text-green-600 dark:text-green-400">✓</span>
+        Thank you for your feedback!
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col gap-3 py-4 border-t mt-8',
+        className
+      )}
+    >
+      <div className="flex items-center gap-4">
+        <span className="text-sm text-muted-foreground">
+          Was this page helpful?
+        </span>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={handleHelpful}
+            disabled={state !== 'initial'}
+            className={cn(
+              'inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md',
+              'border border-border hover:border-green-500 hover:text-green-600',
+              'transition-colors disabled:opacity-50 disabled:cursor-not-allowed',
+              state === 'helpful' && 'border-green-500 text-green-600 bg-green-50 dark:bg-green-950'
+            )}
+            aria-label="Yes, this page was helpful"
+          >
+            <ThumbsUp className="size-4" />
+            Yes
+          </button>
+          <button
+            onClick={handleNotHelpful}
+            disabled={state !== 'initial'}
+            className={cn(
+              'inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md',
+              'border border-border hover:border-red-500 hover:text-red-600',
+              'transition-colors disabled:opacity-50 disabled:cursor-not-allowed',
+              state === 'not-helpful' && 'border-red-500 text-red-600 bg-red-50 dark:bg-red-950'
+            )}
+            aria-label="No, this page was not helpful"
+          >
+            <ThumbsDown className="size-4" />
+            No
+          </button>
+        </div>
+      </div>
+
+      {/* Comment form for negative feedback */}
+      {showComment && (
+        <div className="flex flex-col gap-2 animate-in slide-in-from-top-2">
+          <label htmlFor={textareaId} className="text-sm text-muted-foreground">
+            How can we improve this page?
+          </label>
+          <div className="flex gap-2">
+            <textarea
+              id={textareaId}
+              value={comment}
+              onChange={(e) => setComment(e.target.value)}
+              placeholder="Tell us what could be better..."
+              disabled={isSubmitting}
+              className={cn(
+                'flex-1 min-h-[80px] px-3 py-2 text-sm rounded-md',
+                'border border-border bg-background',
+                'focus:outline-none focus:ring-2 focus:ring-ring',
+                'resize-none'
+              )}
+            />
+          </div>
+          <div className="flex gap-2 justify-end">
+            <button
+              onClick={() => {
+                setShowComment(false);
+                setState('initial');
+              }}
+              disabled={isSubmitting}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md border border-border hover:bg-accent transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <X className="size-4" />
+              Cancel
+            </button>
+            <button
+              onClick={handleSubmitComment}
+              disabled={isSubmitting}
+              className={cn(
+                'inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md',
+                'bg-primary text-primary-foreground hover:opacity-90 transition-opacity',
+                'disabled:opacity-50 disabled:cursor-not-allowed'
+              )}
+            >
+              <Send className="size-4" />
+              {isSubmitting ? 'Submitting...' : 'Submit'}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Inline feedback trigger (smaller, for embedding in content)
+ */
+export function FeedbackInline({ pageId }: { pageId?: string }) {
+  return (
+    <Feedback
+      pageId={pageId}
+      className="border-none mt-0 pt-0"
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- `feedback.tsx` - Thumbs up/down feedback widget with optional comments
- `api/feedback/route.ts` - API endpoint for collecting page feedback

Features:
- Prevents duplicate submissions via localStorage
- Shows submitting state during API call
- Collects page ID, rating, and optional comment

## Test plan
- [ ] Widget appears at bottom of docs pages
- [ ] Clicking Yes/No sends feedback
- [ ] Comment form appears for "No" feedback
- [ ] Duplicate submissions are prevented

🤖 Generated with [Claude Code](https://claude.com/claude-code)