### PR TITLE
fix(fumadocs): only deploy when fumadocs files change

### DIFF
--- a/fumadocs/vercel.json
+++ b/fumadocs/vercel.json
@@ -1,5 +1,6 @@
 {
   "installCommand": "bun install",
   "buildCommand": "bun run build",
-  "framework": "nextjs"
+  "framework": "nextjs",
+  "ignoreCommand": "git diff HEAD^ HEAD --quiet ."
 }


### PR DESCRIPTION
## Summary
- Adds `ignoreCommand` to `vercel.json` to skip deployments when no files in the fumadocs directory have changed
- This prevents unnecessary deployments when PRs only modify other parts of the monorepo (e.g., `/ts/`, `/python/`, `/fern/`)

## How it works
The command `git diff HEAD^ HEAD --quiet .` checks if any files in the current directory (fumadocs) changed:
- Exit code 0 (no changes) → Vercel skips the build
- Exit code 1 (changes found) → Vercel proceeds with the build

## Test plan
- [ ] Verify PRs with only fumadocs changes trigger deployment
- [ ] Verify PRs with no fumadocs changes skip deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)