### PR TITLE
fix(fumadocs): skip Vercel builds when fumadocs unchanged

### DIFF
--- a/fumadocs/vercel.json
+++ b/fumadocs/vercel.json
@@ -1,5 +1,6 @@
 {
   "installCommand": "bun install",
   "buildCommand": "bun run build",
-  "framework": "nextjs"
+  "framework": "nextjs",
+  "ignoreCommand": "git diff ${VERCEL_GIT_PREVIOUS_SHA:-HEAD^} HEAD --quiet -- ."
 }


### PR DESCRIPTION
## Summary
- Add `ignoreCommand` to `fumadocs/vercel.json` to skip Vercel builds when there are no changes in the fumadocs directory
- Prevents unnecessary preview and production builds when changes are made to other parts of the monorepo

## How it works
The command `git diff HEAD^ HEAD --quiet -- .` compares the previous commit with the current commit for files in the fumadocs directory:
- Exit code 0 (no changes) → Vercel **skips** the build
- Exit code 1 (changes found) → Vercel **proceeds** with the build

## Test plan
- [ ] Verify builds are skipped when pushing changes outside fumadocs
- [ ] Verify builds proceed when pushing changes to fumadocs

🤖 Generated with [Claude Code](https://claude.ai/code)