### PR TITLE
Fumadocs: refine dark theme and hover styles

### DIFF
--- a/fumadocs/app/global.css
+++ b/fumadocs/app/global.css
@@ -123,15 +123,15 @@
 }
 
 .dark {
-  --composio-sidebar: #252220;
+  --composio-sidebar: #131211;
 
   /* Fumadocs overrides - Dark */
-  --color-fd-background: #1a1815;
+  --color-fd-background: #131211;
   --color-fd-foreground: #e8e4e0;
-  --color-fd-muted: #2a2725;
+  --color-fd-muted: #1e1d1c;
   --color-fd-muted-foreground: #a8a29e; /* Improved contrast */
-  --color-fd-border: #3d3935;
-  --color-fd-card: #1a1815;
+  --color-fd-border: #2c2a28;
+  --color-fd-card: #131211;
   --color-fd-card-foreground: #e8e4e0;
   --color-fd-popover: #252220;
   --color-fd-popover-foreground: #e8e4e0;
@@ -157,7 +157,7 @@
   --accent: oklch(0.269 0 0);
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
+  --border: oklch(1 0 0 / 5%);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.556 0 0);
   --chart-1: oklch(0.488 0.243 264.376);
@@ -306,7 +306,7 @@ a:focus-visible {
    ========================================================================== */
 
 [data-card]:hover {
-  border-color: var(--composio-orange);
+  border-color: color-mix(in srgb, var(--composio-orange) 50%, transparent);
 }
 
 [data-fumadocs-tabs] [data-state="active"] {

--- a/fumadocs/components/provider-card.tsx
+++ b/fumadocs/components/provider-card.tsx
@@ -16,7 +16,7 @@ export function ProviderCard({ name, href, logo, icon, languages }: ProviderCard
   return (
     <Link
       href={href}
-      className="flex items-center gap-5 rounded-lg border border-fd-border bg-fd-card p-5 transition-all hover:bg-fd-accent/50 hover:border-[var(--composio-orange)]/50"
+      className="flex items-center gap-5 rounded-lg border border-fd-border bg-fd-card p-5 transition-all hover:bg-fd-accent/50 hover:border-[color-mix(in_srgb,var(--composio-orange)_50%,transparent)]"
     >
       <div className="flex h-12 w-12 shrink-0 items-center justify-center">
         {logo ? (

--- a/fumadocs/components/provider-card.tsx
+++ b/fumadocs/components/provider-card.tsx
@@ -16,7 +16,7 @@ export function ProviderCard({ name, href, logo, icon, languages }: ProviderCard
   return (
     <Link
       href={href}
-      className="flex items-center gap-5 rounded-lg border border-fd-border bg-fd-card p-5 transition-all hover:bg-fd-accent/50 hover:border-orange-500"
+      className="flex items-center gap-5 rounded-lg border border-fd-border bg-fd-card p-5 transition-all hover:bg-fd-accent/50 hover:border-[var(--composio-orange)]/50"
     >
       <div className="flex h-12 w-12 shrink-0 items-center justify-center">
         {logo ? (

--- a/fumadocs/components/ui/tabs.tsx
+++ b/fumadocs/components/ui/tabs.tsx
@@ -57,7 +57,7 @@ function TabsContent({
   return (
     <TabsPrimitive.Content
       data-slot="tabs-content"
-      className={cn("flex-1 outline-none", className)}
+      className={cn("flex-1 outline-none bg-muted!", className)}
       {...props}
     />
   )

--- a/fumadocs/components/ui/tabs.tsx
+++ b/fumadocs/components/ui/tabs.tsx
@@ -57,7 +57,7 @@ function TabsContent({
   return (
     <TabsPrimitive.Content
       data-slot="tabs-content"
-      className={cn("flex-1 outline-none bg-muted!", className)}
+      className={cn("flex-1 outline-none", className)}
       {...props}
     />
   )

--- a/fumadocs/content/docs/index.mdx
+++ b/fumadocs/content/docs/index.mdx
@@ -46,7 +46,7 @@ Single MCP server and Tool that can search, authenticate, and execute across all
   />
 </Cards>
 
-<Tabs defaultValue="python" className="my-6">
+<Tabs defaultValue="python" id="quickstart-tabs" className="my-6">
   <TabsList>
     <TabsTrigger value="python">Python</TabsTrigger>
     <TabsTrigger value="typescript">TypeScript</TabsTrigger>


### PR DESCRIPTION
Updates Fumadocs styling:

- Tweaks dark-mode color tokens for background/muted/border/card
- Refines card hover border color to use the Composio accent token
- Adds a muted background to tabs content
