### PR TITLE
fix(docs): fix search API 500 error

### DIFF
--- a/docs/app/api/search/route.ts
+++ b/docs/app/api/search/route.ts
@@ -1,47 +1,27 @@
 import {
   source,
   toolRouterSource,
-  referenceSource,
   examplesSource,
   toolkitsSource,
 } from '@/lib/source';
 import { createSearchAPI } from 'fumadocs-core/search/server';
-import { NextResponse } from 'next/server';
 
-function getSearchIndexes() {
-  const allPages = [
-    ...source.getPages(),
-    ...toolRouterSource.getPages(),
-    ...referenceSource.getPages(),
-    ...examplesSource.getPages(),
-    ...toolkitsSource.getPages(),
-  ];
+// Note: referenceSource excluded temporarily - it includes OpenAPI pages
+// that cause issues with top-level await in serverless environments
+const allPages = [
+  ...source.getPages(),
+  ...toolRouterSource.getPages(),
+  ...examplesSource.getPages(),
+  ...toolkitsSource.getPages(),
+];
 
-  return allPages.map((page) => ({
+export const { GET } = createSearchAPI('advanced', {
+  indexes: allPages.map((page) => ({
     id: page.url,
     title: page.data.title ?? 'Untitled',
     description: page.data.description,
     url: page.url,
     structuredData: page.data.structuredData,
     keywords: 'keywords' in page.data ? page.data.keywords : undefined,
-  }));
-}
-
-let searchHandler: ReturnType<typeof createSearchAPI>['GET'] | null = null;
-
-export async function GET(request: Request) {
-  try {
-    if (!searchHandler) {
-      const indexes = getSearchIndexes();
-      const api = createSearchAPI('advanced', { indexes });
-      searchHandler = api.GET;
-    }
-    return searchHandler(request);
-  } catch (error) {
-    console.error('Search API error:', error);
-    return NextResponse.json(
-      { error: 'Search failed', message: String(error) },
-      { status: 500 }
-    );
-  }
-}
+  })),
+});

--- a/docs/app/api/search/route.ts
+++ b/docs/app/api/search/route.ts
@@ -1,15 +1,36 @@
-import {
-  source,
-  toolRouterSource,
-  examplesSource,
-  toolkitsSource,
-} from '@/lib/source';
+// Use direct imports from collections to avoid top-level await in lib/source.ts
+import { docs, toolRouter, examples, toolkits } from 'fumadocs-mdx:collections/server';
 import { createSearchAPI } from 'fumadocs-core/search/server';
+import { loader } from 'fumadocs-core/source';
+import { lucideIconsPlugin } from 'fumadocs-core/source/lucide-icons';
 
-// Note: referenceSource excluded temporarily - it includes OpenAPI pages
-// that cause issues with top-level await in serverless environments
+// Create loaders directly here to avoid the problematic lib/source.ts import
+const docsSource = loader({
+  baseUrl: '/docs',
+  source: docs.toFumadocsSource(),
+  plugins: [lucideIconsPlugin()],
+});
+
+const toolRouterSource = loader({
+  baseUrl: '/tool-router',
+  source: toolRouter.toFumadocsSource(),
+  plugins: [lucideIconsPlugin()],
+});
+
+const examplesSource = loader({
+  baseUrl: '/examples',
+  source: examples.toFumadocsSource(),
+  plugins: [lucideIconsPlugin()],
+});
+
+const toolkitsSource = loader({
+  baseUrl: '/toolkits',
+  source: toolkits.toFumadocsSource(),
+  plugins: [lucideIconsPlugin()],
+});
+
 const allPages = [
-  ...source.getPages(),
+  ...docsSource.getPages(),
   ...toolRouterSource.getPages(),
   ...examplesSource.getPages(),
   ...toolkitsSource.getPages(),


### PR DESCRIPTION
## Summary

Fixes the search API returning 500 errors in production by excluding `referenceSource` from the search index.

### Root Cause

The `referenceSource` includes OpenAPI-generated pages that use a top-level `await` in `lib/source.ts`. This causes module initialization failures in Vercel's serverless environment.

### Changes

- Removed `referenceSource` from search indexing (temporary fix)
- Search now indexes: docs, tool-router, examples, toolkits

### Follow-up

Need to properly fix by making the OpenAPI source loading lazy or pre-generating the search index at build time. This will restore API reference pages to search results.

## Test plan

- [ ] Verify search works on preview deployment: `curl "<preview-url>/api/search?query=github"`
- [ ] Verify search UI works in the docs site