### PR TITLE
feat(core): add downloadPath config for custom file download location

### DIFF
--- a/ts/packages/core/src/composio.ts
+++ b/ts/packages/core/src/composio.ts
@@ -76,6 +76,18 @@ export type ComposioConfig<
    */
   disableVersionCheck?: boolean;
   /**
+   * Custom directory path for downloading files.
+   * When specified, downloaded files will be saved to this directory instead of the default
+   * `$HOME/.composio/temp_files/` directory.
+   *
+   * This is useful for isolated environments (e.g., sandboxed VMs, containers) where you need
+   * files to be downloaded to a specific location.
+   *
+   * @example '/app/downloads'
+   * @example '/tmp/composio-files'
+   */
+  downloadPath?: string;
+  /**
    * The versions of the toolkits to use for tool execution and retrieval.
    * Omit to use 'latest' for all toolkits.
    *

--- a/ts/packages/core/src/models/Tools.ts
+++ b/ts/packages/core/src/models/Tools.ts
@@ -68,6 +68,7 @@ export class Tools<
   private provider: TProvider;
   private autoUploadDownloadFiles: boolean;
   private toolkitVersions: ToolkitVersionParam;
+  private downloadPath?: string;
 
   constructor(client: ComposioClient, config?: ComposioConfig<TProvider>) {
     if (!client) {
@@ -82,6 +83,7 @@ export class Tools<
     this.provider = config.provider;
     this.autoUploadDownloadFiles = config?.autoUploadDownloadFiles ?? true;
     this.toolkitVersions = config?.toolkitVersions ?? 'latest';
+    this.downloadPath = config?.downloadPath;
     // Bind the execute method to ensure correct 'this' context
     this.execute = this.execute.bind(this);
     // Set the execute method for the provider.
@@ -145,7 +147,9 @@ export class Tools<
    */
   private async applyDefaultSchemaModifiers(tools: Tool[]): Promise<Tool[]> {
     if (this.autoUploadDownloadFiles) {
-      const fileToolModifier = new FileToolModifier(this.client);
+      const fileToolModifier = new FileToolModifier(this.client, {
+        downloadPath: this.downloadPath,
+      });
       return await Promise.all(
         tools.map(tool =>
           fileToolModifier.modifyToolSchema(tool.slug, tool.toolkit?.slug ?? 'unknown', tool)
@@ -180,7 +184,9 @@ export class Tools<
     let modifiedParams = params;
     // if auto upload download files is enabled, upload the files to the Composio API
     if (this.autoUploadDownloadFiles) {
-      const fileToolModifier = new FileToolModifier(this.client);
+      const fileToolModifier = new FileToolModifier(this.client, {
+        downloadPath: this.downloadPath,
+      });
       modifiedParams = await fileToolModifier.fileUploadModifier(tool, {
         toolSlug,
         toolkitSlug,
@@ -226,7 +232,9 @@ export class Tools<
     let modifiedResult = result;
     // if auto upload download files is enabled, download the files from the Composio API
     if (this.autoUploadDownloadFiles) {
-      const fileToolModifier = new FileToolModifier(this.client);
+      const fileToolModifier = new FileToolModifier(this.client, {
+        downloadPath: this.downloadPath,
+      });
       modifiedResult = await fileToolModifier.fileDownloadModifier(tool, {
         toolSlug,
         toolkitSlug,

--- a/ts/packages/core/src/utils/fileUtils.ts
+++ b/ts/packages/core/src/utils/fileUtils.ts
@@ -253,10 +253,16 @@ export const downloadFileFromS3 = async ({
   toolSlug,
   s3Url,
   mimeType,
+  downloadPath,
 }: {
   toolSlug: string;
   s3Url: string;
   mimeType: string;
+  /**
+   * Custom directory path for downloading files.
+   * If provided, files will be saved to this directory instead of the default temp directory.
+   */
+  downloadPath?: string;
 }): Promise<FileDownloadData> => {
   const response = await fetch(s3Url);
   if (!response.ok) {
@@ -266,7 +272,10 @@ export const downloadFileFromS3 = async ({
 
   const extension = getExtensionFromMimeType(mimeType);
   const fileName = generateTimestampedFilename(extension, `${toolSlug}_`);
-  const filePath = saveFile(fileName, Buffer.from(data), true);
+  const filePath = saveFile(fileName, Buffer.from(data), {
+    isTempFile: true,
+    customDir: downloadPath,
+  });
   return {
     name: fileName,
     mimeType: mimeType,
@@ -326,23 +335,60 @@ export const getComposioTempFilesDir = (createDirIfNotExists: boolean = false) =
 };
 
 /**
- * Saves a file to the Composio directory.
+ * Options for saving a file.
+ */
+export type SaveFileOptions = {
+  /**
+   * Whether the file is a temporary file.
+   * @default false
+   */
+  isTempFile?: boolean;
+  /**
+   * Custom directory path for saving the file.
+   * If provided, the file will be saved to this directory instead of the default Composio directory.
+   */
+  customDir?: string;
+};
+
+/**
+ * Saves a file to the Composio directory or a custom directory.
  * @param file - The name of the file to save.
  * @param content - The content of the file to save. Can be a string or Buffer.
- * @param isTempFile - Whether the file is a temporary file.
+ * @param options - Options for saving the file. Can be a boolean for backwards compatibility (isTempFile).
  * @returns The path to the saved file.
  */
-export const saveFile = (file: string, content: string | Buffer, isTempFile: boolean = false) => {
+export const saveFile = (
+  file: string,
+  content: string | Buffer,
+  options: SaveFileOptions | boolean = false
+) => {
   try {
     if (!platform.supportsFileSystem) {
       logger.debug('File system operations are not supported in this runtime environment');
       return null;
     }
-    const composioFilesDir = isTempFile ? getComposioTempFilesDir(true) : getComposioDir(true);
-    if (!composioFilesDir) {
+
+    // Handle backwards compatibility with boolean parameter
+    const opts: SaveFileOptions = typeof options === 'boolean' ? { isTempFile: options } : options;
+    const { isTempFile = false, customDir } = opts;
+
+    // Determine the target directory
+    let targetDir: string | null;
+    if (customDir) {
+      // Use custom directory, create if it doesn't exist
+      if (!platform.existsSync(customDir)) {
+        platform.mkdirSync(customDir);
+      }
+      targetDir = customDir;
+    } else {
+      // Use default Composio directory
+      targetDir = isTempFile ? getComposioTempFilesDir(true) : getComposioDir(true);
+    }
+
+    if (!targetDir) {
       return null;
     }
-    const filePath = platform.joinPath(composioFilesDir, platform.basename(file));
+    const filePath = platform.joinPath(targetDir, platform.basename(file));
 
     logger.info(`Saving file to: ${filePath}`);
 

--- a/ts/packages/core/src/utils/modifiers/FileToolModifier.ts
+++ b/ts/packages/core/src/utils/modifiers/FileToolModifier.ts
@@ -129,7 +129,10 @@ const hydrateFiles = async (
  *     mimeType: "<detected-or-fallback>"
  *   }
  */
-const hydrateDownloads = async (value: unknown, ctx: { toolSlug: string }): Promise<unknown> => {
+const hydrateDownloads = async (
+  value: unknown,
+  ctx: { toolSlug: string; downloadPath?: string }
+): Promise<unknown> => {
   // ─────────────────────────────── 1. direct S3 ref ─────────────────────────
   if (isPlainObject(value) && typeof value.s3url === 'string') {
     const { s3url, mimetype } = value as {
@@ -144,6 +147,7 @@ const hydrateDownloads = async (value: unknown, ctx: { toolSlug: string }): Prom
         toolSlug: ctx.toolSlug,
         s3Url: s3url,
         mimeType: mimetype ?? 'application/octet-stream',
+        downloadPath: ctx.downloadPath,
       });
 
       logger.debug(`Downloaded → ${dl.filePath}`);
@@ -189,9 +193,11 @@ function isPlainObject(val: unknown): val is Record<string, unknown> {
 
 export class FileToolModifier {
   private client: ComposioClient;
+  private downloadPath?: string;
 
-  constructor(client: ComposioClient) {
+  constructor(client: ComposioClient, options?: { downloadPath?: string }) {
     this.client = client;
+    this.downloadPath = options?.downloadPath;
   }
 
   /**
@@ -278,7 +284,10 @@ export class FileToolModifier {
     const { result, toolSlug } = options;
 
     // Walk result.data without mutating the original
-    const dataWithDownloads = await hydrateDownloads(result.data, { toolSlug });
+    const dataWithDownloads = await hydrateDownloads(result.data, {
+      toolSlug,
+      downloadPath: this.downloadPath,
+    });
 
     return { ...result, data: dataWithDownloads as typeof result.data };
   }


### PR DESCRIPTION
## Summary

This PR adds a `downloadPath` configuration option to the Composio SDK, allowing users to specify a custom directory for downloaded files instead of the default `$HOME/.composio/temp_files/` location.

### Use Case

When running Composio in isolated environments (VMs, containers, sandboxes), the default download path may not be accessible or appropriate. This feature allows specifying a custom path that works for the specific deployment environment.

### Changes

- Added `downloadPath` option to `ComposioConfig` interface
- Updated `fileUtils.ts` to accept custom download paths via `saveFile()` and `downloadFileFromS3()`
- Updated `FileToolModifier.ts` to pass through the custom download path
- Updated `Tools.ts` to propagate `downloadPath` to FileToolModifier

### Usage

```typescript
const composio = new Composio({
  apiKey: "your-api-key",
  downloadPath: "/custom/path/for/downloads"
});
```

## Test Plan

- [ ] Verify default behavior unchanged when `downloadPath` not specified
- [ ] Verify files download to custom path when `downloadPath` is specified
- [ ] Verify path creation when custom directory doesn't exist