### PR TITLE
feat(ts/core): support redirect_url in connectedAccounts

### DIFF
--- a/ts/packages/core/src/models/ConnectedAccounts.ts
+++ b/ts/packages/core/src/models/ConnectedAccounts.ts
@@ -8,6 +8,7 @@
 import ComposioClient from '@composio/client';
 import {
   ConnectedAccountDeleteResponse,
+  ConnectedAccountRefreshParams,
   ConnectedAccountRefreshResponse,
   ConnectedAccountUpdateStatusParams,
   ConnectedAccountUpdateStatusResponse,
@@ -23,6 +24,8 @@ import {
   CreateConnectedAccountLinkOptions,
   CreateConnectedAccountLinkOptionsSchema,
   ConnectedAccountStatuses,
+  ConnectedAccountRefreshOptions,
+  ConnectedAccountRefreshOptionsSchema,
 } from '../types/connectedAccounts.types';
 import { ConnectionRequest } from '../types/connectionRequest.types';
 import { createConnectionRequest } from './ConnectionRequest';
@@ -370,8 +373,27 @@ export class ConnectedAccounts {
    * const refreshedAccount = await composio.connectedAccounts.refresh('conn_abc123');
    * ```
    */
-  async refresh(nanoid: string): Promise<ConnectedAccountRefreshResponse> {
-    return this.client.connectedAccounts.refresh(nanoid);
+  async refresh(
+    nanoid: string,
+    options?: ConnectedAccountRefreshOptions
+  ): Promise<ConnectedAccountRefreshResponse> {
+    let params: ConnectedAccountRefreshParams | undefined = undefined;
+
+    if (options) {
+      const parsedOptions = ConnectedAccountRefreshOptionsSchema.safeParse(options);
+      if (!parsedOptions.success) {
+        throw new ValidationError('Failed to parse connected account refresh options', {
+          cause: parsedOptions.error,
+        });
+      }
+
+      params = {
+        body_redirect_url: parsedOptions.data.redirectUrl,
+        validate_credentials: parsedOptions.data.validateCredentials,
+      };
+    }
+
+    return this.client.connectedAccounts.refresh(nanoid, params);
   }
 
   /**

--- a/ts/packages/core/src/types/connectedAccounts.types.ts
+++ b/ts/packages/core/src/types/connectedAccounts.types.ts
@@ -191,3 +191,9 @@ export const CreateConnectedAccountLinkResponseSchema = z.object({
 export type CreateConnectedAccountLinkResponse = z.infer<
   typeof CreateConnectedAccountLinkResponseSchema
 >;
+
+export const ConnectedAccountRefreshOptionsSchema = z.object({
+  redirectUrl: z.string().optional(),
+  validateCredentials: z.boolean().optional(),
+});
+export type ConnectedAccountRefreshOptions = z.infer<typeof ConnectedAccountRefreshOptionsSchema>;

--- a/ts/packages/core/test/connectedAccounts/connectedAccounts.test.ts
+++ b/ts/packages/core/test/connectedAccounts/connectedAccounts.test.ts
@@ -441,7 +441,7 @@ describe('ConnectedAccounts', () => {
   });
 
   describe('refresh', () => {
-    it('should refresh a connected account by nanoid', async () => {
+    it('should refresh a connected account by nanoid without options', async () => {
       const nanoid = 'conn_123';
       const mockResponse = { id: nanoid, refreshed: true };
 
@@ -449,7 +449,83 @@ describe('ConnectedAccounts', () => {
 
       const result = await connectedAccounts.refresh(nanoid);
 
-      expect(extendedMockClient.connectedAccounts.refresh).toHaveBeenCalledWith(nanoid);
+      expect(extendedMockClient.connectedAccounts.refresh).toHaveBeenCalledWith(nanoid, undefined);
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should refresh a connected account with redirectUrl option', async () => {
+      const nanoid = 'conn_123';
+      const redirectUrl = 'https://example.com/oauth/callback';
+      const mockResponse = { id: nanoid, refreshed: true };
+
+      extendedMockClient.connectedAccounts.refresh.mockResolvedValueOnce(mockResponse);
+
+      const result = await connectedAccounts.refresh(nanoid, { redirectUrl });
+
+      expect(extendedMockClient.connectedAccounts.refresh).toHaveBeenCalledWith(nanoid, {
+        body_redirect_url: redirectUrl,
+        validate_credentials: undefined,
+      });
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should refresh a connected account with validateCredentials option', async () => {
+      const nanoid = 'conn_123';
+      const mockResponse = { id: nanoid, refreshed: true };
+
+      extendedMockClient.connectedAccounts.refresh.mockResolvedValueOnce(mockResponse);
+
+      const result = await connectedAccounts.refresh(nanoid, { validateCredentials: true });
+
+      expect(extendedMockClient.connectedAccounts.refresh).toHaveBeenCalledWith(nanoid, {
+        body_redirect_url: undefined,
+        validate_credentials: true,
+      });
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should refresh a connected account with both options', async () => {
+      const nanoid = 'conn_123';
+      const options = {
+        redirectUrl: 'https://example.com/callback',
+        validateCredentials: false,
+      };
+      const mockResponse = { id: nanoid, refreshed: true };
+
+      extendedMockClient.connectedAccounts.refresh.mockResolvedValueOnce(mockResponse);
+
+      const result = await connectedAccounts.refresh(nanoid, options);
+
+      expect(extendedMockClient.connectedAccounts.refresh).toHaveBeenCalledWith(nanoid, {
+        body_redirect_url: options.redirectUrl,
+        validate_credentials: options.validateCredentials,
+      });
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should throw ValidationError for invalid options', async () => {
+      const nanoid = 'conn_123';
+      const invalidOptions = { redirectUrl: 123 };
+
+      await expect(connectedAccounts.refresh(nanoid, invalidOptions as any)).rejects.toThrow(
+        'Failed to parse connected account refresh options'
+      );
+
+      expect(extendedMockClient.connectedAccounts.refresh).not.toHaveBeenCalled();
+    });
+
+    it('should handle empty options object gracefully', async () => {
+      const nanoid = 'conn_123';
+      const mockResponse = { id: nanoid, refreshed: true };
+
+      extendedMockClient.connectedAccounts.refresh.mockResolvedValueOnce(mockResponse);
+
+      const result = await connectedAccounts.refresh(nanoid, {});
+
+      expect(extendedMockClient.connectedAccounts.refresh).toHaveBeenCalledWith(nanoid, {
+        body_redirect_url: undefined,
+        validate_credentials: undefined,
+      });
       expect(result).toEqual(mockResponse);
     });
   });


### PR DESCRIPTION
This PR:
- closes [PLEN-1138](https://linear.app/composio/issue/PLEN-1138/redirect-url-not-working-when-passed-as-query-param-as-well-as-in-body)
- closes [PLEN-1146](https://linear.app/composio/issue/PLEN-1146/support-for-redirect-url-in-ts-sdk)
- supports `redirect_url` in `connectedAccount` in `@composio/core`