### PR TITLE
docs(changelog): sync January 2026 changelogs from fern

### DIFF
--- a/docs/content/changelog/01-14-26-auth-config-patch-semantics.mdx
+++ b/docs/content/changelog/01-14-26-auth-config-patch-semantics.mdx
@@ -1,0 +1,192 @@
+---
+title: "True PATCH Semantics for Auth Config Updates"
+date: "2026-01-14"
+---
+
+## Version Information
+
+### TypeScript/JavaScript
+- Package: `@composio/core` and provider packages
+- Version: `0.5.1`+
+
+### Python
+- Package: `composio-core` and provider packages
+- Version: `0.10.7`+
+
+---
+
+The `PATCH /api/v3/auth_configs/{id}` endpoint now implements proper partial update semantics. Previously, omitting fields would clear them (behaving like PUT). Now, omitted fields are preserved—only explicitly provided fields are modified.
+
+<Callout type="warn">
+**Breaking Change**: If you relied on omitting fields to clear them, you must now explicitly send `null` or `[]`. See [Migration Guide](#migration-guide) below.
+</Callout>
+
+## What Changed
+
+| Field                         | Before (Buggy)           | After (Correct)                   |
+| ----------------------------- | ------------------------ | --------------------------------- |
+| `credentials`                 | Required on every update | Optional—merged with existing     |
+| `tool_access_config`          | Reset to `{}` if omitted | Preserved if omitted              |
+| `scopes` (type: default)      | Cleared if omitted       | Preserved if omitted              |
+| `restrict_to_following_tools` | Reset to `[]` if omitted | Preserved if omitted              |
+
+<Callout type="info">
+**Merge Behavior**: The `credentials` object is merged—send only the fields you want to change, and existing fields are preserved.
+</Callout>
+
+## New Capabilities
+
+### Rotate a Single Credential Field
+
+Update just `client_secret` without resending `client_id` or other fields:
+
+<Tabs groupId="language" items={['Python', 'TypeScript']} persist>
+<Tab value="Python">
+```python
+from composio import Composio
+
+composio = Composio()
+
+# Only send the field you want to update - other credentials are preserved
+composio.auth_configs.update(
+    "ac_yourAuthConfigId",
+    options={
+        "type": "custom",
+        "credentials": {
+            "client_secret": "new_rotated_secret",
+        },
+    },
+)
+```
+</Tab>
+<Tab value="TypeScript">
+```typescript
+import { Composio } from "@composio/core";
+
+const composio = new Composio();
+
+// Only send the field you want to update - other credentials are preserved
+await composio.authConfigs.update("ac_yourAuthConfigId", {
+  type: "custom",
+  credentials: {
+    client_secret: "new_rotated_secret",
+  },
+});
+```
+</Tab>
+</Tabs>
+
+### Update Tool Restrictions Without Touching Credentials
+
+Previously, this would fail because `credentials` was required. Now it works:
+
+<Tabs groupId="language" items={['Python', 'TypeScript']} persist>
+<Tab value="Python">
+```python
+from composio import Composio
+
+composio = Composio()
+
+# Update tool restrictions - credentials are automatically preserved
+composio.auth_configs.update(
+    "ac_yourAuthConfigId",
+    options={
+        "type": "custom",
+        "tool_access_config": {
+            "tools_available_for_execution": ["GMAIL_SEND_EMAIL", "GMAIL_READ_EMAIL"],
+        },
+    },
+)
+```
+</Tab>
+<Tab value="TypeScript">
+```typescript
+import { Composio } from "@composio/core";
+
+const composio = new Composio();
+
+// Note: TypeScript SDK currently requires credentials for custom type updates
+await composio.authConfigs.update("ac_yourAuthConfigId", {
+  type: "custom",
+  credentials: {
+    // Include existing credentials when using TS SDK
+  },
+  toolAccessConfig: {
+    toolsAvailableForExecution: ["GMAIL_SEND_EMAIL", "GMAIL_READ_EMAIL"],
+  },
+});
+```
+</Tab>
+</Tabs>
+
+## Migration Guide
+
+### Am I Affected?
+
+**Yes**, if your code relied on omitting fields to clear them.
+
+**No**, if you always send complete payloads or only use PATCH to update specific fields.
+
+### How to Clear Fields Explicitly
+
+| To Clear             | Python SDK                                                    | TypeScript SDK                                         |
+| -------------------- | ------------------------------------------------------------- | ------------------------------------------------------ |
+| `tool_access_config` | `"tool_access_config": {"tools_available_for_execution": []}` | `toolAccessConfig: { toolsAvailableForExecution: [] }` |
+| `scopes` (default)   | `"scopes": ""`                                                | `scopes: ""` (via HTTP API)                            |
+
+<Tabs groupId="language" items={['Python', 'TypeScript']} persist>
+<Tab value="Python">
+```python
+from composio import Composio
+
+composio = Composio()
+
+# Explicitly clear tool restrictions with empty array
+composio.auth_configs.update(
+    "ac_yourAuthConfigId",
+    options={
+        "type": "custom",
+        "tool_access_config": {
+            "tools_available_for_execution": [],
+        },
+    },
+)
+```
+</Tab>
+<Tab value="TypeScript">
+```typescript
+import { Composio } from "@composio/core";
+
+const composio = new Composio();
+
+// Explicitly clear tool restrictions with empty array
+await composio.authConfigs.update("ac_yourAuthConfigId", {
+  type: "custom",
+  credentials: {
+    // Include existing credentials when using TS SDK
+  },
+  toolAccessConfig: {
+    toolsAvailableForExecution: [],
+  },
+});
+```
+</Tab>
+</Tabs>
+
+### Raw HTTP API
+
+For users calling the API directly:
+
+```bash
+# Rotate single credential
+curl -X PATCH "https://backend.composio.dev/api/v3/auth_configs/{id}" \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"type": "custom", "credentials": {"client_secret": "new_secret"}}'
+
+# Clear tool restrictions
+curl -X PATCH "https://backend.composio.dev/api/v3/auth_configs/{id}" \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"type": "custom", "tool_access_config": {"tools_available_for_execution": []}}'
+```

--- a/docs/content/changelog/01-20-26-file-modifier-anyof-support.mdx
+++ b/docs/content/changelog/01-20-26-file-modifier-anyof-support.mdx
@@ -27,49 +27,55 @@ We recommend updating to version `0.5.3` (TypeScript) or `0.10.8` (Python) or la
 
 File properties inside `anyOf`, `oneOf`, or `allOf` were not detected:
 
-```typescript
-// This schema's file_uploadable was NOT being processed
-inputParameters: {
-  type: 'object',
-  properties: {
-    fileInput: {
-      anyOf: [
-        {
-          type: 'string',
-          file_uploadable: true  // ❌ Not detected
-        },
-        {
-          type: 'null'
-        }
-      ]
+```json
+{
+  "inputParameters": {
+    "type": "object",
+    "properties": {
+      "fileInput": {
+        "anyOf": [
+          {
+            "type": "string",
+            "file_uploadable": true
+          },
+          {
+            "type": "null"
+          }
+        ]
+      }
     }
   }
 }
 ```
+
+This schema's `file_uploadable` was **not** being processed.
 
 ### After (Fixed)
 
 File properties are now correctly detected and processed at any nesting level:
 
-```typescript
-// Now properly detected and transformed
-inputParameters: {
-  type: 'object',
-  properties: {
-    fileInput: {
-      anyOf: [
-        {
-          type: 'string',
-          file_uploadable: true  // ✅ Detected and processed
-        },
-        {
-          type: 'null'
-        }
-      ]
+```json
+{
+  "inputParameters": {
+    "type": "object",
+    "properties": {
+      "fileInput": {
+        "anyOf": [
+          {
+            "type": "string",
+            "file_uploadable": true
+          },
+          {
+            "type": "null"
+          }
+        ]
+      }
     }
   }
 }
 ```
+
+Now properly detected and processed.
 
 ## Affected Scenarios
 

--- a/docs/content/changelog/01-20-26-file-modifier-anyof-support.mdx
+++ b/docs/content/changelog/01-20-26-file-modifier-anyof-support.mdx
@@ -1,0 +1,147 @@
+---
+title: "[Critical] File Upload/Download Fixes for anyOf, oneOf, and allOf Schemas"
+date: "2026-01-20"
+---
+
+## Version Information
+
+### TypeScript/JavaScript
+- Package: `@composio/core` and provider packages
+- Version: `0.5.3`+
+
+### Python
+- Package: `composio` and provider packages
+- Version: `0.10.8`+
+
+---
+
+The file handling modifiers now properly handle `file_uploadable` and `file_downloadable` properties nested within `anyOf`, `oneOf`, and `allOf` JSON Schema declarations. Previously, only direct child properties (and partial `allOf` support) were detected for file upload/download transformations.
+
+<Callout type="info">
+We recommend updating to version `0.5.3` (TypeScript) or `0.10.8` (Python) or later to ensure file uploads and downloads work correctly with tools that use union or intersection types in their schemas.
+</Callout>
+
+## What Changed
+
+### Before (Bug)
+
+File properties inside `anyOf`, `oneOf`, or `allOf` were not detected:
+
+```typescript
+// This schema's file_uploadable was NOT being processed
+inputParameters: {
+  type: 'object',
+  properties: {
+    fileInput: {
+      anyOf: [
+        {
+          type: 'string',
+          file_uploadable: true  // ❌ Not detected
+        },
+        {
+          type: 'null'
+        }
+      ]
+    }
+  }
+}
+```
+
+### After (Fixed)
+
+File properties are now correctly detected and processed at any nesting level:
+
+```typescript
+// Now properly detected and transformed
+inputParameters: {
+  type: 'object',
+  properties: {
+    fileInput: {
+      anyOf: [
+        {
+          type: 'string',
+          file_uploadable: true  // ✅ Detected and processed
+        },
+        {
+          type: 'null'
+        }
+      ]
+    }
+  }
+}
+```
+
+## Affected Scenarios
+
+| Scenario | Before | After |
+|----------|--------|-------|
+| `file_uploadable` in `anyOf` | Not detected | Works |
+| `file_uploadable` in `oneOf` | Not detected | Works |
+| `file_uploadable` in `allOf` | Not detected | Works |
+| `file_downloadable` in `anyOf` | Not detected | Works |
+| `file_downloadable` in `oneOf` | Not detected | Works |
+| `file_downloadable` in `allOf` | Not detected | Works |
+| Nested objects inside union types | Not detected | Works |
+| Array items with union types | Not detected | Works |
+
+## How to Update
+
+### TypeScript/JavaScript
+
+<Tabs groupId="package-manager" items={['npm', 'pnpm', 'yarn']} persist>
+<Tab value="npm">
+```bash
+npm update @composio/core@latest
+```
+</Tab>
+<Tab value="pnpm">
+```bash
+pnpm update @composio/core@latest
+```
+</Tab>
+<Tab value="yarn">
+```bash
+yarn upgrade @composio/core@latest
+```
+</Tab>
+</Tabs>
+
+### Python
+
+<Tabs groupId="python-package-manager" items={['pip', 'uv', 'poetry']} persist>
+<Tab value="pip">
+```bash
+pip install --upgrade composio
+```
+</Tab>
+<Tab value="uv">
+```bash
+uv pip install --upgrade composio
+```
+</Tab>
+<Tab value="poetry">
+```bash
+poetry update composio
+```
+</Tab>
+</Tabs>
+
+## Backward Compatibility
+
+This release is fully backward compatible:
+
+- All existing code continues to work without modifications
+- No migration required
+- File upload/download for direct properties continues to work as before
+- The fix only adds support for previously unsupported schema patterns
+
+## Impact Summary
+
+| Change | Runtime Breaking | TypeScript Breaking | Migration Required |
+|--------|------------------|---------------------|-------------------|
+| `anyOf` support for file uploads | No | No | No |
+| `oneOf` support for file uploads | No | No | No |
+| `allOf` support for file uploads | No | No | No |
+| `anyOf` support for file downloads | No | No | No |
+| `oneOf` support for file downloads | No | No | No |
+| `allOf` support for file downloads | No | No | No |

--- a/docs/content/changelog/01-20-26-file-modifier-anyof-support.mdx
+++ b/docs/content/changelog/01-20-26-file-modifier-anyof-support.mdx
@@ -27,55 +27,51 @@ We recommend updating to version `0.5.3` (TypeScript) or `0.10.8` (Python) or la
 
 File properties inside `anyOf`, `oneOf`, or `allOf` were not detected:
 
-```json
-{
-  "inputParameters": {
-    "type": "object",
-    "properties": {
-      "fileInput": {
-        "anyOf": [
-          {
-            "type": "string",
-            "file_uploadable": true
-          },
-          {
-            "type": "null"
-          }
-        ]
-      }
+```typescript
+// @noErrors
+// This schema's file_uploadable was NOT being processed
+inputParameters: {
+  type: 'object',
+  properties: {
+    fileInput: {
+      anyOf: [
+        {
+          type: 'string',
+          file_uploadable: true  // ❌ Not detected
+        },
+        {
+          type: 'null'
+        }
+      ]
     }
   }
 }
 ```
-
-This schema's `file_uploadable` was **not** being processed.
 
 ### After (Fixed)
 
 File properties are now correctly detected and processed at any nesting level:
 
-```json
-{
-  "inputParameters": {
-    "type": "object",
-    "properties": {
-      "fileInput": {
-        "anyOf": [
-          {
-            "type": "string",
-            "file_uploadable": true
-          },
-          {
-            "type": "null"
-          }
-        ]
-      }
+```typescript
+// @noErrors
+// Now properly detected and transformed
+inputParameters: {
+  type: 'object',
+  properties: {
+    fileInput: {
+      anyOf: [
+        {
+          type: 'string',
+          file_uploadable: true  // ✅ Detected and processed
+        },
+        {
+          type: 'null'
+        }
+      ]
     }
   }
 }
 ```
-
-Now properly detected and processed.
 
 ## Affected Scenarios
 

--- a/docs/content/changelog/01-20-26-file-ttl.mdx
+++ b/docs/content/changelog/01-20-26-file-ttl.mdx
@@ -1,0 +1,59 @@
+---
+title: "File handling in tool execution now uses presigned URLs"
+date: "2026-01-20"
+---
+
+## Summary
+
+Files involved in tool execution are now shared via presigned URLs with a default TTL (time-to-live) of 1 hour. You can customize the file TTL through your project configuration.
+
+## What changed
+
+When tools return files (images, documents, exports, etc.), these files are now delivered as presigned URLs with a configurable TTL instead of non-expiring URLs. This provides:
+
+- **Automatic cleanup** - Files expire after the configured TTL
+- **Configurable retention** - Adjust file availability based on your application's needs
+
+## Default behavior
+
+All files returned from tool execution now have a **1 hour TTL** by default. After this period, the presigned URLs expire and files are no longer accessible.
+
+## Configuring file TTL
+
+You can adjust the file TTL to match your application's needs.
+
+### Via Dashboard
+
+1. Navigate to **Project Settings** in your Composio dashboard
+2. Find the **File TTL** configuration option
+3. Set your desired TTL value
+
+### Via API
+
+Use the [Update Project Config API](https://docs.composio.dev/rest-api/projects/patch-org-project-config) to programmatically configure the file TTL:
+
+```bash
+curl -X PATCH "https://backend.composio.dev/api/v3/org/projects/config" \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "fileTtl": 3600
+  }'
+```
+
+## Impact
+
+| Aspect | Before | After |
+|--------|--------|-------|
+| File delivery | Non-expiring URLs | Presigned URLs with TTL |
+| Default expiry | None | 1 hour |
+| TTL customization | Not available | Configurable via project settings |
+
+## Migration
+
+No code changes are required. Your existing integrations will continue to receive file URLs as before, but these URLs will now expire after the configured TTL.
+
+If your application stores or caches file URLs for later use, ensure you handle URL expiration appropriately by either:
+- Downloading files before the TTL expires
+- Re-executing the tool to obtain fresh URLs when needed
+- Increasing the TTL via project settings to match your retention requirements


### PR DESCRIPTION
## Summary
- Syncs 3 missing changelog entries from fern to fumadocs
- Converts fern components (`<Warning>`, `<Note>`, `<CodeBlocks>`) to fumadocs equivalents (`<Callout>`, `<Tabs>`)

## Changelogs Added
- **01-14-26**: Auth config PATCH semantics fix (breaking change)
- **01-20-26**: File modifier anyOf/oneOf/allOf support (critical bug fix)
- **01-20-26**: File TTL with presigned URLs

## Test plan
- [ ] Verify changelog pages render correctly at `/docs/changelog`
- [ ] Check Callout and Tabs components display properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)