### PR TITLE
docs: fix OAuth2 config format in authentication examples

### DIFF
--- a/docs/content/docs/tools-direct/authenticating-tools.mdx
+++ b/docs/content/docs/tools-direct/authenticating-tools.mdx
@@ -244,7 +244,10 @@ Some services like Zendesk require additional parameters such as `subdomain`:
 connection_request = composio.connected_accounts.initiate(
   user_id=user_id,
   auth_config_id=auth_config_id,
-  config=auth_scheme.oauth2(subdomain="mycompany")  # For mycompany.zendesk.com
+  config={
+    "auth_scheme": "OAUTH2",
+    "val": {"subdomain": "mycompany"}  # For mycompany.zendesk.com
+  }
 )
 ```
   </Tab>

--- a/fern/pages/src/tools-and-triggers/authenticating-tools.mdx
+++ b/fern/pages/src/tools-and-triggers/authenticating-tools.mdx
@@ -218,7 +218,10 @@ Some services like Zendesk require additional parameters such as `subdomain`:
 connection_request = composio.connected_accounts.initiate(
   user_id=user_id,
   auth_config_id=auth_config_id,
-  config=auth_scheme.oauth2(subdomain="mycompany")  # For mycompany.zendesk.com
+  config={
+    "auth_scheme": "OAUTH2",
+    "val": {"subdomain": "mycompany"}  # For mycompany.zendesk.com
+  }
 )
 ```
 


### PR DESCRIPTION
## Summary
The documentation showed incorrect syntax for passing subdomain parameters

The Python examples described [here](https://docs.composio.dev/docs/authenticating-tools#services-with-additional-parameters) doesn't work.


## Changes
- Fixed Python code examples in docs to use correct dict format with `val` field

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [x] Documentation
- [ ] Breaking change

## How Has This Been Tested?
Tested the change with the following script: https://gist.github.com/HareeshBahuleyan/2c9c96054fd93e60749829c855d9c8d1

(Using Atlassian Confluence integration, which requires `subdomain`)

The script returns:
```
# Approach 1
auth_scheme.oauth2(subdomain="mycompany") → TypeError: unexpected keyword argument

# Approach 2
auth_scheme.oauth2({"subdomain": "mycompany"}) → 400 Validation error

# Fixed approach
{"auth_scheme": "OAUTH2", "val": {"subdomain": "mycompany"}} → ✅ Success 
```

## Checklist
- [x] I have read the Code of Conduct and this PR adheres to it
- [NA] I ran linters/tests locally and they passed
- [x] I updated documentation as needed
- [NA] I added tests or explain why not applicable
- [NA] I added a changeset if this change affects published packages

