### PR TITLE
feat(ts/core): platform-specific file tool modifier

### DIFF
--- a/ts/packages/core/package.json
+++ b/ts/packages/core/package.json
@@ -33,6 +33,18 @@
         "import": "./dist/models/Files.node.mjs",
         "require": "./dist/models/Files.node.cjs"
       }
+    },
+    "#file_tool_modifier": {
+      "workerd": "./dist/utils/modifiers/FileToolModifier.workerd.mjs",
+      "edge-light": "./dist/utils/modifiers/FileToolModifier.workerd.mjs",
+      "node": {
+        "import": "./dist/utils/modifiers/FileToolModifier.node.mjs",
+        "require": "./dist/utils/modifiers/FileToolModifier.node.cjs"
+      },
+      "default": {
+        "import": "./dist/utils/modifiers/FileToolModifier.node.mjs",
+        "require": "./dist/utils/modifiers/FileToolModifier.node.cjs"
+      }
     }
   },
   "exports": {

--- a/ts/packages/core/src/models/Tools.ts
+++ b/ts/packages/core/src/models/Tools.ts
@@ -1,4 +1,5 @@
 import ComposioClient from '@composio/client';
+import { FileToolModifier } from '#file_tool_modifier';
 import {
   Tool,
   ToolExecuteParams,
@@ -48,7 +49,6 @@ import {
 } from '../errors/ToolErrors';
 import { ValidationError } from '../errors/ValidationErrors';
 import { telemetry } from '../telemetry/Telemetry';
-import { FileToolModifier } from '../utils/modifiers/FileToolModifier';
 import { ComposioConfig } from '../composio';
 import { getToolkitVersion } from '../utils/toolkitVersion';
 import { handleToolExecutionError } from '../errors/ToolErrors';

--- a/ts/packages/core/src/utils/fileUtils.ts
+++ b/ts/packages/core/src/utils/fileUtils.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 import ComposioClient from '@composio/client';
 import { COMPOSIO_DIR, TEMP_FILES_DIRECTORY_NAME } from './constants';
 import logger from './logger';

--- a/ts/packages/core/src/utils/modifiers/FileToolModifier.node.ts
+++ b/ts/packages/core/src/utils/modifiers/FileToolModifier.node.ts
@@ -1,139 +1,19 @@
 import {
-  JSONSchemaProperty,
   Tool,
   ToolExecuteParams,
   ToolExecuteResponse,
+  JSONSchemaProperty,
 } from '../../types/tool.types';
 import ComposioClient from '@composio/client';
 import logger from '../logger';
 import { ComposioFileUploadError } from '../../errors/FileModifierErrors';
 import { downloadFileFromS3, getFileDataAfterUploadingToS3 } from '../fileUtils';
-
-/**
- * Transforms a single JSON schema property, recursively handling nested properties,
- * anyOf, oneOf, and allOf.
- */
-const transformSchema = (property: JSONSchemaProperty): JSONSchemaProperty => {
-  if (property.file_uploadable) {
-    // Transform file-uploadable property
-    return {
-      title: property.title,
-      description: property.description,
-      format: 'path',
-      type: 'string',
-      file_uploadable: true,
-    };
-  }
-
-  const newProperty = { ...property };
-
-  if (property.type === 'object' && property.properties) {
-    // Recursively transform nested properties
-    newProperty.properties = transformProperties(property.properties);
-  }
-
-  if (property.anyOf) {
-    newProperty.anyOf = property.anyOf.map(transformSchema);
-  }
-
-  if (property.oneOf) {
-    newProperty.oneOf = property.oneOf.map(transformSchema);
-  }
-
-  if (property.allOf) {
-    newProperty.allOf = property.allOf.map(transformSchema);
-  }
-
-  if (property.items) {
-    if (Array.isArray(property.items)) {
-      newProperty.items = property.items.map(transformSchema);
-    } else {
-      newProperty.items = transformSchema(property.items);
-    }
-  }
-
-  return newProperty;
-};
-
-/**
- * Transforms the properties of the tool schema to include the file upload URL.
- *
- * Attaches the format: 'path' to the properties that are file uploadable for agents.
- *
- * @param properties - The properties of the tool schema.
- * @returns The transformed properties.
- */
-const transformProperties = (properties: JSONSchemaProperty): JSONSchemaProperty => {
-  const newProperties: JSONSchemaProperty = {};
-
-  for (const [key, property] of Object.entries(properties) as [string, JSONSchemaProperty][]) {
-    newProperties[key] = transformSchema(property);
-  }
-
-  return newProperties;
-};
-
-/**
- * Recursively checks if a schema (or any of its variants) contains a specific file property.
- */
-const schemaHasFileProperty = (
-  schema: JSONSchemaProperty | undefined,
-  property: 'file_uploadable' | 'file_downloadable'
-): boolean => {
-  if (!schema) return false;
-  if (schema[property]) return true;
-
-  // Check nested properties
-  if (schema.properties) {
-    for (const prop of Object.values(schema.properties) as JSONSchemaProperty[]) {
-      if (schemaHasFileProperty(prop, property)) return true;
-    }
-  }
-
-  // Check anyOf/oneOf/allOf variants
-  if (schema.anyOf) {
-    for (const variant of schema.anyOf) {
-      if (schemaHasFileProperty(variant, property)) return true;
-    }
-  }
-  if (schema.oneOf) {
-    for (const variant of schema.oneOf) {
-      if (schemaHasFileProperty(variant, property)) return true;
-    }
-  }
-  if (schema.allOf) {
-    for (const variant of schema.allOf) {
-      if (schemaHasFileProperty(variant, property)) return true;
-    }
-  }
-
-  // Check array items
-  if (schema.items) {
-    if (Array.isArray(schema.items)) {
-      for (const item of schema.items) {
-        if (schemaHasFileProperty(item, property)) return true;
-      }
-    } else {
-      if (schemaHasFileProperty(schema.items, property)) return true;
-    }
-  }
-
-  return false;
-};
-
-/**
- * Recursively checks if a schema (or any of its variants) contains file_uploadable properties.
- */
-const schemaHasFileUploadable = (schema: JSONSchemaProperty | undefined): boolean => {
-  return schemaHasFileProperty(schema, 'file_uploadable');
-};
-
-/**
- * Recursively checks if a schema (or any of its variants) contains file_downloadable properties.
- */
-const schemaHasFileDownloadable = (schema: JSONSchemaProperty | undefined): boolean => {
-  return schemaHasFileProperty(schema, 'file_downloadable');
-};
+import {
+  isPlainObject,
+  transformProperties,
+  schemaHasFileUploadable,
+  schemaHasFileDownloadable,
+} from './FileToolModifier.utils.neutral';
 
 /**
  * Recursively walks a runtime value and its matching JSON-Schema node,
@@ -352,11 +232,6 @@ const hydrateDownloads = async (
   return value;
 };
 
-// Small helper to recognise plain objects
-function isPlainObject(val: unknown): val is Record<string, unknown> {
-  return typeof val === 'object' && val !== null && !Array.isArray(val);
-}
-
 export class FileToolModifier {
   private client: ComposioClient;
 
@@ -364,16 +239,6 @@ export class FileToolModifier {
     this.client = client;
   }
 
-  /**
-   * Modifies the tool schema to include the file upload URL.
-   *
-   * @description This modifier is used to upload a file to the Composio platform and replace the file path with the file upload URL.
-   *
-   * @param _toolSlug - The slug of the tool that is being executed.
-   * @param _toolkitSlug - The slug of the toolkit that is being executed.
-   * @param schema - The schema of the tool.
-   * @returns The schema with the file upload URL included.
-   */
   async modifyToolSchema(toolSlug: string, toolkitSlug: string, schema: Tool): Promise<Tool> {
     if (!schema.inputParameters?.properties) {
       return schema;
@@ -390,15 +255,6 @@ export class FileToolModifier {
     };
   }
 
-  /**
-   * Modifies the input parameters to include the file upload URL.
-   *
-   * @description This modifier is used to upload a file to the Composio platform and replace the file path with the file upload URL.
-   *
-   * @param toolSlug - The slug of the tool that is being executed.
-   * @param toolkitSlug - The slug of the toolkit that is being executed.
-   *
-   */
   async fileUploadModifier(
     tool: Tool,
     options: {
@@ -427,17 +283,6 @@ export class FileToolModifier {
     }
   }
 
-  /**
-   * Modifies the result to include the file download URL.
-   *
-   * @description This modifier is used to download a file and
-   *
-   * @param tool - The tool schema containing output parameters.
-   * @param toolSlug - The slug of the tool that is being executed.
-   * @param toolkitSlug - The slug of the toolkit that is being executed.
-   * @param result - The result of the tool execution.
-   * @returns The result with the file download URL included.
-   */
   async fileDownloadModifier(
     tool: Tool,
     options: {

--- a/ts/packages/core/src/utils/modifiers/FileToolModifier.utils.neutral.ts
+++ b/ts/packages/core/src/utils/modifiers/FileToolModifier.utils.neutral.ts
@@ -1,0 +1,132 @@
+import type { JSONSchemaProperty } from '../../types/tool.types';
+
+// Helper function to recognise plain objects
+export function isPlainObject(val: unknown): val is Record<string, unknown> {
+  return typeof val === 'object' && val !== null && !Array.isArray(val);
+}
+
+/**
+ * Transforms a single JSON schema property, recursively handling nested properties,
+ * anyOf, oneOf, and allOf.
+ */
+const transformSchema = (property: JSONSchemaProperty): JSONSchemaProperty => {
+  if (property.file_uploadable) {
+    // Transform file-uploadable property
+    return {
+      title: property.title,
+      description: property.description,
+      format: 'path',
+      type: 'string',
+      file_uploadable: true,
+    };
+  }
+
+  const newProperty = { ...property };
+
+  if (property.type === 'object' && property.properties) {
+    // Recursively transform nested properties
+    newProperty.properties = transformProperties(property.properties);
+  }
+
+  if (property.anyOf) {
+    newProperty.anyOf = property.anyOf.map(transformSchema);
+  }
+
+  if (property.oneOf) {
+    newProperty.oneOf = property.oneOf.map(transformSchema);
+  }
+
+  if (property.allOf) {
+    newProperty.allOf = property.allOf.map(transformSchema);
+  }
+
+  if (property.items) {
+    if (Array.isArray(property.items)) {
+      newProperty.items = property.items.map(transformSchema);
+    } else {
+      newProperty.items = transformSchema(property.items);
+    }
+  }
+
+  return newProperty;
+};
+
+/**
+ * Transforms the properties of the tool schema to include the file upload URL.
+ *
+ * Attaches the format: 'path' to the properties that are file uploadable for agents.
+ *
+ * @param properties - The properties of the tool schema.
+ * @returns The transformed properties.
+ */
+export const transformProperties = (properties: JSONSchemaProperty): JSONSchemaProperty => {
+  const newProperties: JSONSchemaProperty = {};
+
+  for (const [key, property] of Object.entries(properties) as [string, JSONSchemaProperty][]) {
+    newProperties[key] = transformSchema(property);
+  }
+
+  return newProperties;
+};
+
+/**
+ * Recursively checks if a schema (or any of its variants) contains a specific file property.
+ */
+export const schemaHasFileProperty = (
+  schema: JSONSchemaProperty | undefined,
+  property: 'file_uploadable' | 'file_downloadable'
+): boolean => {
+  if (!schema) return false;
+  if (schema[property]) return true;
+
+  // Check nested properties
+  if (schema.properties) {
+    for (const prop of Object.values(schema.properties) as JSONSchemaProperty[]) {
+      if (schemaHasFileProperty(prop, property)) return true;
+    }
+  }
+
+  // Check anyOf/oneOf/allOf variants
+  if (schema.anyOf) {
+    for (const variant of schema.anyOf) {
+      if (schemaHasFileProperty(variant, property)) return true;
+    }
+  }
+  if (schema.oneOf) {
+    for (const variant of schema.oneOf) {
+      if (schemaHasFileProperty(variant, property)) return true;
+    }
+  }
+  if (schema.allOf) {
+    for (const variant of schema.allOf) {
+      if (schemaHasFileProperty(variant, property)) return true;
+    }
+  }
+
+  // Check array items
+  if (schema.items) {
+    if (Array.isArray(schema.items)) {
+      for (const item of schema.items) {
+        if (schemaHasFileProperty(item, property)) return true;
+      }
+    } else {
+      if (schemaHasFileProperty(schema.items, property)) return true;
+    }
+  }
+
+  return false;
+};
+
+/**
+ * Recursively checks if a schema (or any of its variants) contains file_uploadable properties.
+ */
+export const schemaHasFileUploadable = (schema: JSONSchemaProperty | undefined): boolean => {
+  return schemaHasFileProperty(schema, 'file_uploadable');
+};
+
+/**
+ * Recursively checks if a schema (or any of its variants) contains file_downloadable properties.
+ */
+export const schemaHasFileDownloadable = (schema: JSONSchemaProperty | undefined): boolean => {
+  return schemaHasFileProperty(schema, 'file_downloadable');
+};

--- a/ts/packages/core/src/utils/modifiers/FileToolModifier.workerd.ts
+++ b/ts/packages/core/src/utils/modifiers/FileToolModifier.workerd.ts
@@ -1,0 +1,49 @@
+import { Tool, ToolExecuteParams, ToolExecuteResponse } from '../../types/tool.types';
+import ComposioClient from '@composio/client';
+import { transformProperties } from './FileToolModifier.utils.neutral';
+
+const UNSUPPORTED_MESSAGE =
+  'File upload/download modifiers are not available on edge runtimes yet. ' +
+  'Please set `autoUploadDownloadFiles: false` or run Composio in another JS runtime (Node.js / Bun).';
+
+export class FileToolModifier {
+  constructor(_client: ComposioClient) {}
+
+  async modifyToolSchema(toolSlug: string, toolkitSlug: string, schema: Tool): Promise<Tool> {
+    if (!schema.inputParameters?.properties) {
+      return schema;
+    }
+
+    const properties = transformProperties(schema.inputParameters.properties);
+
+    return {
+      ...schema,
+      inputParameters: {
+        ...schema.inputParameters,
+        properties,
+      },
+    };
+  }
+
+  async fileUploadModifier(
+    _tool: Tool,
+    _options: {
+      toolSlug: string;
+      toolkitSlug?: string;
+      params: ToolExecuteParams;
+    }
+  ): Promise<ToolExecuteParams> {
+    throw new Error(UNSUPPORTED_MESSAGE);
+  }
+
+  async fileDownloadModifier(
+    _tool: Tool,
+    _options: {
+      toolSlug: string;
+      toolkitSlug: string;
+      result: ToolExecuteResponse;
+    }
+  ): Promise<ToolExecuteResponse> {
+    throw new Error(UNSUPPORTED_MESSAGE);
+  }
+}

--- a/ts/packages/core/tsconfig.json
+++ b/ts/packages/core/tsconfig.json
@@ -13,7 +13,11 @@
     "resolveJsonModule": true,
     "paths": {
       "#platform": ["./src/platform/node.ts", "./src/platform/workerd.ts"],
-      "#files": ["./src/models/Files.node.ts", "./src/models/Files.workerd.ts"]
+      "#files": ["./src/models/Files.node.ts", "./src/models/Files.workerd.ts"],
+      "#file_tool_modifier": [
+        "./src/utils/modifiers/FileToolModifier.node.ts",
+        "./src/utils/modifiers/FileToolModifier.workerd.ts"
+      ]
     }
   },
   "include": ["src/**/*.ts"]

--- a/ts/packages/core/tsdown.config.ts
+++ b/ts/packages/core/tsdown.config.ts
@@ -7,10 +7,18 @@ export default defineConfig({
   copy: [{ from: 'pack/generated/*', to: '.', flatten: false }],
   entry: [
     'src/index.ts',
+
+    // #platform
     'src/platform/node.ts',
     'src/platform/workerd.ts',
+
+    // #files
     'src/models/Files.node.ts',
     'src/models/Files.workerd.ts',
+
+    // #file_tool_modifier
+    'src/utils/modifiers/FileToolModifier.node.ts',
+    'src/utils/modifiers/FileToolModifier.workerd.ts',
   ],
   attw: {
     ...baseConfig.attw,
@@ -33,5 +41,5 @@ export default defineConfig({
    * We don't want to accidentally bundle `node:*` packages (e.g., `node:module`)
    * as not all of them are available in Cloudflare Workers / Vercel Edge runtimes.
    */
-  external: [...(baseConfig.external ?? []), '#platform', '#files'],
+  external: [...(baseConfig.external ?? []), '#platform', '#files', '#file_tool_modifier'],
 });

--- a/ts/packages/core/vitest.config.ts
+++ b/ts/packages/core/vitest.config.ts
@@ -9,6 +9,10 @@ export default defineConfig({
     alias: {
       '#platform': path.resolve(__dirname, 'src/platform/node.ts'),
       '#files': path.resolve(__dirname, 'src/models/Files.node.ts'),
+      '#file_tool_modifier': path.resolve(
+        __dirname,
+        'src/utils/modifiers/FileToolModifier.node.ts'
+      ),
     },
   },
   test: {


### PR DESCRIPTION
This PR:
- closes [PLEN-1264](https://linear.app/composio/issue/PLEN-1264/refactor-file-tool-modifier-to-be-platform-specific)
- builds on top of https://github.com/ComposioHQ/composio/pull/2436
- provides splits FileToolModifier.ts into two platform-specific implementations, to avoid importing `node:crypto` in the Cloudflare Workers runtime