### PR TITLE
Fix CORS issues in API reference playground

### DIFF
--- a/docs/app/api/proxy/route.ts
+++ b/docs/app/api/proxy/route.ts
@@ -20,6 +20,8 @@ export async function PATCH(request: NextRequest) {
   return handleProxy(request);
 }
 
+const ALLOWED_HOST = 'backend.composio.dev';
+
 async function handleProxy(request: NextRequest) {
   try {
     const url = new URL(request.url);
@@ -27,6 +29,22 @@ async function handleProxy(request: NextRequest) {
 
     if (!targetUrl) {
       return NextResponse.json({ error: 'Missing url parameter' }, { status: 400 });
+    }
+
+    // Validate the target URL to prevent SSRF
+    let parsedTarget: URL;
+    try {
+      parsedTarget = new URL(targetUrl);
+    } catch {
+      return NextResponse.json({ error: 'Invalid URL' }, { status: 400 });
+    }
+
+    if (parsedTarget.hostname !== ALLOWED_HOST) {
+      return NextResponse.json({ error: 'URL not allowed' }, { status: 403 });
+    }
+
+    if (parsedTarget.protocol !== 'https:') {
+      return NextResponse.json({ error: 'Only HTTPS allowed' }, { status: 403 });
     }
 
     // Get request body for non-GET requests

--- a/docs/app/api/proxy/route.ts
+++ b/docs/app/api/proxy/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(request: NextRequest) {
+  return handleProxy(request);
+}
+
+export async function GET(request: NextRequest) {
+  return handleProxy(request);
+}
+
+export async function PUT(request: NextRequest) {
+  return handleProxy(request);
+}
+
+export async function DELETE(request: NextRequest) {
+  return handleProxy(request);
+}
+
+export async function PATCH(request: NextRequest) {
+  return handleProxy(request);
+}
+
+async function handleProxy(request: NextRequest) {
+  try {
+    const url = new URL(request.url);
+    const targetUrl = url.searchParams.get('url');
+
+    if (!targetUrl) {
+      return NextResponse.json({ error: 'Missing url parameter' }, { status: 400 });
+    }
+
+    // Get request body for non-GET requests
+    let body: string | undefined;
+    if (request.method !== 'GET' && request.method !== 'HEAD') {
+      body = await request.text();
+    }
+
+    // Forward headers (excluding host and other problematic headers)
+    const headers = new Headers();
+    request.headers.forEach((value, key) => {
+      const lowerKey = key.toLowerCase();
+      if (!['host', 'connection', 'content-length'].includes(lowerKey)) {
+        headers.set(key, value);
+      }
+    });
+
+    const response = await fetch(targetUrl, {
+      method: request.method,
+      headers,
+      body,
+    });
+
+    const responseBody = await response.text();
+
+    return new NextResponse(responseBody, {
+      status: response.status,
+      headers: {
+        'Content-Type': response.headers.get('Content-Type') || 'application/json',
+        'Access-Control-Allow-Origin': '*',
+      },
+    });
+  } catch (error) {
+    console.error('Proxy error:', error);
+    return NextResponse.json(
+      { error: 'Proxy request failed' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function OPTIONS() {
+  return new NextResponse(null, {
+    status: 200,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, PATCH, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization, x-api-key',
+    },
+  });
+}

--- a/docs/components/api-page.client.tsx
+++ b/docs/components/api-page.client.tsx
@@ -1,4 +1,6 @@
 'use client';
 import { defineClientConfig } from 'fumadocs-openapi/ui/client';
 
-export default defineClientConfig({});
+export default defineClientConfig({
+  proxyUrl: '/api/proxy',
+});

--- a/docs/components/api-page.client.tsx
+++ b/docs/components/api-page.client.tsx
@@ -1,6 +1,4 @@
 'use client';
 import { defineClientConfig } from 'fumadocs-openapi/ui/client';
 
-export default defineClientConfig({
-  proxyUrl: '/api/proxy',
-});
+export default defineClientConfig({});

--- a/docs/lib/openapi.ts
+++ b/docs/lib/openapi.ts
@@ -4,4 +4,5 @@ import { createOpenAPI } from 'fumadocs-openapi/server';
 // Run `bun run scripts/fetch-openapi.ts` to update the spec
 export const openapi = createOpenAPI({
   input: ['./public/openapi.json'],
+  proxyUrl: '/api/proxy',
 });


### PR DESCRIPTION
## Summary
- Add API proxy route at `/api/proxy` to forward requests and avoid CORS issues
- Configure fumadocs-openapi client to use the proxy

This fixes the issue where testing APIs in the reference playground failed due to CORS restrictions.

## Test plan
- [ ] Navigate to API reference page
- [ ] Try executing an API call in the playground
- [ ] Verify no CORS errors occur

🤖 Generated with [Claude Code](https://claude.com/claude-code)