### PR TITLE
docs: content improvements - Skills, quickstart updates, deprecations

### DIFF
--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -35,10 +35,16 @@ Composio powers 800+ toolkits, tool search, context management, authentication, 
 
 ## For AI tools
 
-You can access the entire Composio documentation in Markdown format at:
-
 - [composio.dev/llms.txt](/llms.txt) - Documentation index with links
 - [composio.dev/llms-full.txt](/llms-full.txt) - Complete documentation in one file
+
+### Skills
+
+```bash
+npx skills add composiohq/skills
+```
+
+[View on Skills.sh](https://skills.sh/composiohq/skills/composio-tool-router) · [GitHub](https://github.com/composiohq/skills)
 
 ## Providers
 

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -873,16 +873,3 @@ readline.close();
 
 </QuickstartFlow>
 
-## Next steps
-
-<Cards>
-  <Card title="Session management" href="/docs/users-and-sessions">
-    Learn about users, sessions, and how they work.
-  </Card>
-  <Card title="Tools and toolkits" href="/docs/tools-and-toolkits">
-    Learn about tools, toolkits, and how to configure them.
-  </Card>
-  <Card title="Manual authentication" href="/docs/authenticating-users/manually-authenticating">
-    Customise the authentication flow for your users.
-  </Card>
-</Cards>

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -364,7 +364,7 @@ import asyncio
 from dotenv import load_dotenv
 from composio import Composio
 from composio_claude_agent_sdk import ClaudeAgentSDKProvider
-from claude_agent_sdk import ClaudeSDKClient, ClaudeAgentOptions, create_sdk_mcp_server
+from claude_agent_sdk import ClaudeSDKClient, ClaudeAgentOptions, create_sdk_mcp_server, AssistantMessage, TextBlock
 
 load_dotenv()
 
@@ -395,8 +395,11 @@ async def main():
 
             await client.query(user_input)
             print("Claude: ", end="")
-            async for msg in client.receive_response():
-                print(msg, end="", flush=True)
+            async for message in client.receive_response():
+                if isinstance(message, AssistantMessage):
+                    for block in message.content:
+                        if isinstance(block, TextBlock):
+                            print(block.text, end="", flush=True)
             print()
 
 asyncio.run(main())

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -69,7 +69,7 @@ tools = session.tools()
 agent = Agent(
     name="Personal Assistant",
     instructions="You are a helpful personal assistant. Use Composio tools to take action.",
-    model="gpt-4.1",
+    model="gpt-5",
     tools=tools,
 )
 
@@ -117,7 +117,7 @@ const tools = await session.tools();
 const agent = new Agent({
   name: "Personal Assistant",
   instructions: "You are a helpful personal assistant. Use Composio tools to take action.",
-  model: "gpt-4.1",
+  model: "gpt-5",
   tools,
 });
 
@@ -213,7 +213,7 @@ session = composio.create(user_id=user_id)
 agent = Agent(
     name="Personal Assistant",
     instructions="You are a helpful personal assistant. Use Composio tools to take action.",
-    model="gpt-4.1",
+    model="gpt-5",
     tools=[
         HostedMCPTool(
             tool_config={
@@ -269,7 +269,7 @@ const session = await composio.create(userId);
 const agent = new Agent({
   name: "Personal Assistant",
   instructions: "You are a helpful personal assistant. Use Composio tools to take action.",
-  model: "gpt-4.1",
+  model: "gpt-5",
   tools: [
     hostedMcpTool({
       serverLabel: "composio",
@@ -429,8 +429,14 @@ const customServer = createSdkMcpServer({
 
 const readline = createInterface({ input: process.stdin, output: process.stdout });
 
-console.log("Assistant ready! Type 'exit' to quit.");
-
+console.log(`
+What task would you like me to help you with?
+I can use tools like Gmail, GitHub, Linear, Notion, and more.
+(Type 'exit' to exit)
+Example tasks:
+    - 'Summarize my emails from today'
+    - 'List all open issues on the composio github repository and create a Google Sheet with the issues'
+`);
 let isFirstQuery = true;
 const options = {
   mcpServers: { composio: customServer },

--- a/docs/content/docs/single-toolkit-mcp.mdx
+++ b/docs/content/docs/single-toolkit-mcp.mdx
@@ -2,6 +2,7 @@
 title: Single Toolkit MCP
 description: Create MCP servers for specific toolkits
 keywords: [mcp, model context protocol, single toolkit]
+deprecated: true
 ---
 
 <Callout type="info">


### PR DESCRIPTION
## Summary

- Add Skills section under "For AI tools" on welcome page with `npx skills add composiohq/skills`
- Remove "Next steps" section from quickstart (cleaner ending)
- Mark single-toolkit-mcp.mdx as deprecated
- Update OpenAI models from gpt-4.1 to gpt-5 in quickstart
- Fix Claude Agent SDK native example with proper message handling (AssistantMessage, TextBlock)
- Add expanded welcome message to Claude Agent SDK TypeScript example

## Test plan

- [ ] Verify Skills section renders correctly on welcome page
- [ ] Verify quickstart ends cleanly without "Next steps"
- [ ] Verify deprecated tag on single-toolkit-mcp (if Fumadocs supports it)
- [ ] Verify code examples are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)