### PR TITLE
feat(docs): Add sitemap.xml generation

### DIFF
--- a/docs/app/sitemap.ts
+++ b/docs/app/sitemap.ts
@@ -1,0 +1,34 @@
+import type { MetadataRoute } from 'next';
+import { source, referenceSource, examplesSource, toolkitsSource } from '@/lib/source';
+
+const baseUrl = 'https://docs.composio.dev';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const docsPages = source.getPages().map((page) => ({
+    url: `${baseUrl}${page.url}`,
+    lastModified: page.data.lastModified ?? new Date(),
+  }));
+
+  const referencePages = referenceSource.getPages().map((page) => ({
+    url: `${baseUrl}${page.url}`,
+    lastModified: page.data.lastModified ?? new Date(),
+  }));
+
+  const examplesPages = examplesSource.getPages().map((page) => ({
+    url: `${baseUrl}${page.url}`,
+    lastModified: page.data.lastModified ?? new Date(),
+  }));
+
+  const toolkitsPages = toolkitsSource.getPages().map((page) => ({
+    url: `${baseUrl}${page.url}`,
+    lastModified: page.data.lastModified ?? new Date(),
+  }));
+
+  return [
+    { url: baseUrl, lastModified: new Date() },
+    ...docsPages,
+    ...referencePages,
+    ...examplesPages,
+    ...toolkitsPages,
+  ];
+}


### PR DESCRIPTION
## Summary
- Adds automatic sitemap.xml generation for SEO
- Includes all docs, reference, examples, and toolkits pages
- Generated at build time via Next.js sitemap convention

After merge, `docs.composio.dev/sitemap.xml` will be available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)