### PR TITLE
feat(docs): Add sitemap.xml with all pages

### DIFF
--- a/docs/app/sitemap.ts
+++ b/docs/app/sitemap.ts
@@ -49,9 +49,10 @@ export default function sitemap(): MetadataRoute.Sitemap {
     url: `${baseUrl}/toolkits/${toolkit.slug}`,
   }));
 
-  // Changelog pages
-  const changelogPages = [...changelogEntries].map((entry) => ({
-    url: `${baseUrl}${dateToChangelogUrl(entry.date)}`,
+  // Changelog pages (deduplicate by date since multiple entries can share the same date)
+  const uniqueChangelogDates = [...new Set([...changelogEntries].map((entry) => entry.date))];
+  const changelogPages = uniqueChangelogDates.map((date) => ({
+    url: `${baseUrl}${dateToChangelogUrl(date)}`,
   }));
 
   return [

--- a/docs/app/sitemap.ts
+++ b/docs/app/sitemap.ts
@@ -1,7 +1,14 @@
 import type { MetadataRoute } from 'next';
 import { readFileSync } from 'fs';
 import { join } from 'path';
-import { source, referenceSource, examplesSource, toolkitsSource } from '@/lib/source';
+import {
+  source,
+  referenceSource,
+  examplesSource,
+  toolkitsSource,
+  changelogEntries,
+  dateToChangelogUrl,
+} from '@/lib/source';
 
 const baseUrl = 'https://docs.composio.dev';
 
@@ -42,12 +49,19 @@ export default function sitemap(): MetadataRoute.Sitemap {
     url: `${baseUrl}/toolkits/${toolkit.slug}`,
   }));
 
+  // Changelog pages
+  const changelogPages = [...changelogEntries].map((entry) => ({
+    url: `${baseUrl}${dateToChangelogUrl(entry.date)}`,
+  }));
+
   return [
     { url: baseUrl },
+    { url: `${baseUrl}/docs/changelog` },
     ...docsPages,
     ...referencePages,
     ...examplesPages,
     ...toolkitsMdxPages,
     ...toolkitsJsonPages,
+    ...changelogPages,
   ];
 }

--- a/docs/app/sitemap.ts
+++ b/docs/app/sitemap.ts
@@ -1,7 +1,23 @@
 import type { MetadataRoute } from 'next';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import { source, referenceSource, examplesSource, toolkitsSource } from '@/lib/source';
 
 const baseUrl = 'https://docs.composio.dev';
+
+interface Toolkit {
+  slug: string;
+}
+
+function getToolkitsFromJson(): Toolkit[] {
+  try {
+    const filePath = join(process.cwd(), 'public/data/toolkits.json');
+    const data = readFileSync(filePath, 'utf-8');
+    return JSON.parse(data) as Toolkit[];
+  } catch {
+    return [];
+  }
+}
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const docsPages = source.getPages().map((page) => ({
@@ -16,8 +32,14 @@ export default function sitemap(): MetadataRoute.Sitemap {
     url: `${baseUrl}${page.url}`,
   }));
 
-  const toolkitsPages = toolkitsSource.getPages().map((page) => ({
+  // MDX toolkit pages
+  const toolkitsMdxPages = toolkitsSource.getPages().map((page) => ({
     url: `${baseUrl}${page.url}`,
+  }));
+
+  // JSON toolkit pages (dynamically generated from toolkits.json)
+  const toolkitsJsonPages = getToolkitsFromJson().map((toolkit) => ({
+    url: `${baseUrl}/toolkits/${toolkit.slug}`,
   }));
 
   return [
@@ -25,6 +47,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     ...docsPages,
     ...referencePages,
     ...examplesPages,
-    ...toolkitsPages,
+    ...toolkitsMdxPages,
+    ...toolkitsJsonPages,
   ];
 }

--- a/docs/app/sitemap.ts
+++ b/docs/app/sitemap.ts
@@ -17,12 +17,30 @@ interface Toolkit {
 }
 
 function getToolkitsFromJson(): Toolkit[] {
+  const filePath = join(process.cwd(), 'public/data/toolkits.json');
+
   try {
-    const filePath = join(process.cwd(), 'public/data/toolkits.json');
     const data = readFileSync(filePath, 'utf-8');
-    return JSON.parse(data) as Toolkit[];
-  } catch {
-    return [];
+    const toolkits = JSON.parse(data) as Toolkit[];
+
+    if (!Array.isArray(toolkits)) {
+      throw new Error('toolkits.json must contain an array');
+    }
+
+    if (toolkits.length === 0) {
+      console.warn('[Sitemap] Warning: toolkits.json is empty - toolkit pages will be missing from sitemap');
+    }
+
+    return toolkits;
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err.code === 'ENOENT') {
+      throw new Error(`[Sitemap] Toolkits data file not found: ${filePath}`);
+    }
+    if (error instanceof SyntaxError) {
+      throw new Error(`[Sitemap] Invalid JSON in toolkits.json: ${error.message}`);
+    }
+    throw error;
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds automatic sitemap.xml generation for SEO
- Includes all page types:
  - Docs pages
  - SDK reference pages
  - API reference pages
  - Examples
  - All 800+ toolkit pages (from toolkits.json)

After merge, `docs.composio.dev/sitemap.xml` will be available for search engine indexing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)