### PR TITLE
fix(docs): Fix duplicate TOC entries in quickstart page

### DIFF
--- a/docs/components/step-title.tsx
+++ b/docs/components/step-title.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from 'react';
+
+interface StepTitleProps {
+  children: ReactNode;
+}
+
+/**
+ * A visual heading for Steps that doesn't appear in the Table of Contents.
+ * Use this instead of ### headings inside <Step> when you have multiple
+ * tabs/frameworks that would otherwise duplicate TOC entries.
+ */
+export function StepTitle({ children }: StepTitleProps) {
+  return (
+    <div className="font-semibold text-lg text-fd-foreground mb-3">
+      {children}
+    </div>
+  );
+}

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -15,7 +15,7 @@ Build your first AI agent with Composio Tools.
 
 <Steps>
 <Step>
-### Install
+<StepTitle>Install</StepTitle>
 
 <Tabs groupId="language" items={['Python', 'TypeScript']} persist>
 <Tab value="Python">
@@ -32,7 +32,7 @@ npm install @composio/core @composio/openai-agents @openai/agents
 </Step>
 
 <Step>
-### Configure API Keys
+<StepTitle>Configure API Keys</StepTitle>
 
 <Callout type="info">
 Get your `COMPOSIO_API_KEY` from [Settings](https://platform.composio.dev/settings) and `OPENAI_API_KEY` from [OpenAI](https://platform.openai.com/api-keys).
@@ -45,7 +45,7 @@ OPENAI_API_KEY=your_openai_api_key
 </Step>
 
 <Step>
-### Create session and run agent
+<StepTitle>Create session and run agent</StepTitle>
 
 <Tabs groupId="language" items={['Python', 'TypeScript']} persist>
 <Tab value="Python">
@@ -161,7 +161,7 @@ readline.close();
 
 <Steps>
 <Step>
-### Install
+<StepTitle>Install</StepTitle>
 
 <Tabs groupId="language" items={['Python', 'TypeScript']} persist>
 <Tab value="Python">
@@ -178,7 +178,7 @@ npm install dotenv @composio/core @openai/agents zod@3
 </Step>
 
 <Step>
-### Configure API Keys
+<StepTitle>Configure API Keys</StepTitle>
 
 <Callout type="info">
 Get your `COMPOSIO_API_KEY` from [Settings](https://platform.composio.dev/settings) and `OPENAI_API_KEY` from [OpenAI](https://platform.openai.com/api-keys).
@@ -191,7 +191,7 @@ OPENAI_API_KEY=your_openai_api_key
 </Step>
 
 <Step>
-### Create session and run agent
+<StepTitle>Create session and run agent</StepTitle>
 
 <Tabs groupId="language" items={['Python', 'TypeScript']} persist>
 <Tab value="Python">
@@ -325,7 +325,7 @@ readline.close();
 
 <Steps>
 <Step>
-### Install
+<StepTitle>Install</StepTitle>
 
 <Tabs groupId="language" items={['Python', 'TypeScript']} persist>
 <Tab value="Python">
@@ -342,7 +342,7 @@ npm install dotenv @composio/core @composio/claude-agent-sdk @anthropic-ai/claud
 </Step>
 
 <Step>
-### Configure API Keys
+<StepTitle>Configure API Keys</StepTitle>
 
 <Callout type="info">
 Get your `COMPOSIO_API_KEY` from [Settings](https://platform.composio.dev/settings) and `ANTHROPIC_API_KEY` from [Anthropic](https://console.anthropic.com/settings/keys).
@@ -355,7 +355,7 @@ ANTHROPIC_API_KEY=your_anthropic_api_key
 </Step>
 
 <Step>
-### Create session and run agent
+<StepTitle>Create session and run agent</StepTitle>
 
 <Tabs groupId="language" items={['Python', 'TypeScript']} persist>
 <Tab value="Python">
@@ -475,7 +475,7 @@ readline.close();
 
 <Steps>
 <Step>
-### Install
+<StepTitle>Install</StepTitle>
 
 <Tabs groupId="language" items={['Python', 'TypeScript']} persist>
 <Tab value="Python">
@@ -492,7 +492,7 @@ npm install dotenv @composio/core @anthropic-ai/claude-agent-sdk
 </Step>
 
 <Step>
-### Configure API Keys
+<StepTitle>Configure API Keys</StepTitle>
 
 <Callout type="info">
 Get your `COMPOSIO_API_KEY` from [Settings](https://platform.composio.dev/settings) and `ANTHROPIC_API_KEY` from [Anthropic](https://console.anthropic.com/settings/keys).
@@ -505,7 +505,7 @@ ANTHROPIC_API_KEY=your_anthropic_api_key
 </Step>
 
 <Step>
-### Create session and run agent
+<StepTitle>Create session and run agent</StepTitle>
 
 <Tabs groupId="language" items={['Python', 'TypeScript']} persist>
 <Tab value="Python">
@@ -673,7 +673,7 @@ readline.close();
 
 <Steps>
 <Step>
-### Install
+<StepTitle>Install</StepTitle>
 
 ```bash
 npm install @composio/core @composio/vercel ai @ai-sdk/anthropic
@@ -681,7 +681,7 @@ npm install @composio/core @composio/vercel ai @ai-sdk/anthropic
 </Step>
 
 <Step>
-### Configure API Keys
+<StepTitle>Configure API Keys</StepTitle>
 
 <Callout type="info">
 Get your `COMPOSIO_API_KEY` from [Settings](https://platform.composio.dev/settings) and `ANTHROPIC_API_KEY` from [Anthropic](https://console.anthropic.com/settings/keys).
@@ -694,7 +694,7 @@ ANTHROPIC_API_KEY=your_anthropic_api_key
 </Step>
 
 <Step>
-### Create session and run agent
+<StepTitle>Create session and run agent</StepTitle>
 
 ```typescript
 // @noErrors
@@ -772,7 +772,7 @@ readline.close();
 
 <Steps>
 <Step>
-### Install
+<StepTitle>Install</StepTitle>
 
 ```bash
 npm install dotenv @composio/core ai @ai-sdk/anthropic @ai-sdk/mcp
@@ -780,7 +780,7 @@ npm install dotenv @composio/core ai @ai-sdk/anthropic @ai-sdk/mcp
 </Step>
 
 <Step>
-### Configure API Keys
+<StepTitle>Configure API Keys</StepTitle>
 
 <Callout type="info">
 Get your `COMPOSIO_API_KEY` from [Settings](https://platform.composio.dev/settings) and `ANTHROPIC_API_KEY` from [Anthropic](https://console.anthropic.com/settings/keys).
@@ -793,7 +793,7 @@ ANTHROPIC_API_KEY=your_anthropic_api_key
 </Step>
 
 <Step>
-### Create session and run agent
+<StepTitle>Create session and run agent</StepTitle>
 
 ```typescript
 // @noErrors

--- a/docs/mdx-components.tsx
+++ b/docs/mdx-components.tsx
@@ -12,6 +12,7 @@ import { FrameworkSelector, QuickstartFlow, FrameworkOption } from '@/components
 import { IntegrationTabs, IntegrationContent } from '@/components/quickstart/integration-tabs';
 import { ToolTypeFlow, ToolTypeOption } from '@/components/tool-type-selector';
 import { Figure } from '@/components/figure';
+import { StepTitle } from '@/components/step-title';
 import { Video } from '@/components/video';
 import { CapabilityCard, CapabilityList } from '@/components/capability-card';
 import { ToolkitsLanding } from '@/components/toolkits/toolkits-landing';
@@ -62,6 +63,7 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     CapabilityCard,
     CapabilityList,
     ToolkitsLanding,
+    StepTitle,
     // Lucide icons - available globally in MDX without imports
     ShieldCheck,
     RouteIcon,


### PR DESCRIPTION
## Summary
- Creates a new `StepTitle` component that renders visually like a heading but uses a `div` element
- Replaces `### Install`, `### Configure API Keys`, and `### Create session and run agent` headings inside `<Step>` tags with `<StepTitle>` 
- This prevents fumadocs from extracting these headings into the Table of Contents

## Problem
The quickstart page has multiple framework tabs (OpenAI Agents, Claude Agent SDK, Vercel AI) each with Native/MCP variants. Each variant has the same step headings, causing 12+ duplicate entries in the TOC sidebar (as shown in screenshot).

## Test plan
- [x] Build passes locally
- [ ] Verify TOC on quickstart page shows only page-level headings
- [ ] Verify step titles still display correctly inside Steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)