### PR TITLE
fix(docs): add custom metadata for reference index page

### DIFF
--- a/docs/app/(home)/reference/[[...slug]]/page.tsx
+++ b/docs/app/(home)/reference/[[...slug]]/page.tsx
@@ -72,6 +72,19 @@ export async function generateMetadata({
   params: Promise<{ slug?: string[] }>;
 }): Promise<Metadata> {
   const { slug } = await params;
+
+  // Index page - show custom metadata
+  if (!slug || slug.length === 0) {
+    const ogImage = getOgImageUrl('reference', [], 'API Reference', 'REST API and SDK reference for Composio');
+    return {
+      title: 'API Reference',
+      description: 'REST API and SDK reference for Composio',
+      alternates: { canonical: '/reference' },
+      openGraph: { images: [ogImage] },
+      twitter: { card: 'summary_large_image', images: [ogImage] },
+    };
+  }
+
   const page = referenceSource.getPage(slug);
   if (!page) notFound();
 

--- a/docs/app/og/reference/[...slug]/route.tsx
+++ b/docs/app/og/reference/[...slug]/route.tsx
@@ -10,7 +10,24 @@ export async function GET(
   { params }: { params: Promise<{ slug: string[] }> },
 ) {
   const { slug } = await params;
-  const page = referenceSource.getPage(slug.slice(0, -1));
+  const pageSlug = slug.slice(0, -1); // Remove 'image.png'
+
+  // Index page
+  if (pageSlug.length === 0) {
+    return new ImageResponse(
+      <DefaultImage
+        title="API Reference"
+        description="REST API and SDK reference for Composio"
+        site="Composio"
+      />,
+      {
+        width: 1200,
+        height: 630,
+      },
+    );
+  }
+
+  const page = referenceSource.getPage(pageSlug);
   if (!page) notFound();
 
   return new ImageResponse(
@@ -27,7 +44,13 @@ export async function GET(
 }
 
 export function generateStaticParams() {
-  return referenceSource.getPages().map((page) => ({
+  // Index page
+  const indexParam = { slug: ['image.png'] };
+
+  // All reference pages
+  const pageParams = referenceSource.getPages().map((page) => ({
     slug: [...page.slugs, 'image.png'],
   }));
+
+  return [indexParam, ...pageParams];
 }

--- a/docs/lib/source.ts
+++ b/docs/lib/source.ts
@@ -57,7 +57,8 @@ export function getOgImageUrl(section: string, slugs: string[], title?: string, 
   if (title) params.set('title', title);
   if (description) params.set('description', description);
   const query = params.toString() ? `?${params.toString()}` : '';
-  return `/og/${section}/${slugs.join('/')}/image.png${query}`;
+  const slugPath = slugs.length > 0 ? `${slugs.join('/')}/` : '';
+  return `/og/${section}/${slugPath}image.png${query}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

The `/reference` page was showing "Overview" metadata from the first child page instead of proper index page metadata.

## Changes

- Add custom metadata for `/reference` index: "API Reference"
- Update OG image route to handle index page

## Before
- Title: "Overview"
- Description: "Authentication and getting started..."

## After
- Title: "API Reference"
- Description: "REST API and SDK reference for Composio"

🤖 Generated with [Claude Code](https://claude.ai/code)