### PR TITLE
docs: replace 'integration' with 'toolkits' in docs copy

### DIFF
--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -29,7 +29,7 @@ Composio powers 800+ toolkits, tool search, context management, authentication, 
     icon={<Wrench />}
     title="Toolkits"
     href="/toolkits"
-    description="Browse 800+ integrations"
+    description="Browse 800+ toolkits"
   />
 </Cards>
 

--- a/docs/content/docs/providers/custom-providers/python.mdx
+++ b/docs/content/docs/providers/custom-providers/python.mdx
@@ -3,14 +3,14 @@ title: Python Custom Provider
 description: Learn how to create custom providers for any AI framework in Python
 ---
 
-This guide shows how to create custom providers for the Composio Python SDK. Custom providers enable integration with different AI frameworks and platforms.
+This guide shows how to create custom providers for the Composio Python SDK. Custom providers enable compatibility with different AI frameworks and platforms.
 
 ## Provider architecture
 
 The Composio SDK uses a provider architecture to adapt tools for different AI frameworks. The provider handles:
 
 1. **Tool format transformation**: Converting Composio tools into formats compatible with specific AI platforms
-2. **Platform-specific integration**: Providing helper methods for seamless integration
+2. **Platform-specific compatibility**: Providing helper methods for seamless compatibility
 
 ## Types of providers
 

--- a/docs/content/docs/providers/custom-providers/typescript.mdx
+++ b/docs/content/docs/providers/custom-providers/typescript.mdx
@@ -3,7 +3,7 @@ title: TypeScript Custom Provider
 description: Learn how to create custom providers for any AI platform in TypeScript
 ---
 
-This guide provides a comprehensive walkthrough of creating custom providers for the Composio TypeScript SDK, enabling integration with different AI frameworks and platforms.
+This guide provides a comprehensive walkthrough of creating custom providers for the Composio TypeScript SDK, enabling compatibility with different AI frameworks and platforms.
 
 ## Provider Architecture
 
@@ -11,7 +11,7 @@ The Composio SDK uses a provider architecture to adapt tools for different AI fr
 
 1. **Tool Format Transformation**: Converting Composio tools into formats compatible with specific AI platforms
 2. **Tool Execution**: Managing the flow of tool execution and results
-3. **Platform-Specific Integration**: Providing helper methods for seamless integration
+3. **Platform-Specific Compatibility**: Providing helper methods for seamless compatibility
 
 ## Types of Providers
 

--- a/docs/content/docs/providers/openai.mdx
+++ b/docs/content/docs/providers/openai.mdx
@@ -30,7 +30,7 @@ Read more about it in the [OpenAI documentation](https://platform.openai.com/doc
 
 <Callout>
 Before executing any tools that require authentication (like Gmail), you'll need to:
-1. [Create an Auth Configuration](/docs/authenticating-tools#creating-an-auth-config) for your integration
+1. [Create an Auth Configuration](/docs/authenticating-tools#creating-an-auth-config) for your app
 2. [Set up a Connected Account](/docs/authenticating-tools#connecting-an-account) for the user.
 </Callout>
 
@@ -118,7 +118,7 @@ The OpenAI Chat Provider is the default provider used by Composio SDK, but you c
 
 <Callout>
 Before executing any tools that require authentication (like Gmail), you'll need to:
-1. [Create an Auth Configuration](/docs/authenticating-tools#creating-an-auth-config) for your integration
+1. [Create an Auth Configuration](/docs/authenticating-tools#creating-an-auth-config) for your app
 2. [Set up a Connected Account](/docs/authenticating-tools#connecting-an-account) for the user.
 </Callout>
 

--- a/docs/content/docs/tools-direct/authenticating-tools.mdx
+++ b/docs/content/docs/tools-direct/authenticating-tools.mdx
@@ -33,7 +33,7 @@ Each toolkit supports different authentication methods such as **OAuth**, **API 
 ### Configure scopes
 
 Depending on your authentication method, you may need to configure scopes:
-- **OAuth2**: Configure scopes for what data and actions your integration can access.
+- **OAuth2**: Configure scopes for what data and actions your app can access.
 - **API Key/Bearer Token**: Permissions are typically fixed based on the key's access level.
 </Step>
 
@@ -86,7 +86,7 @@ You should create multiple auth configs for the same toolkit when you need:
 
 With an auth config created, you're ready to authenticate your users!
 
-You can either use [**Connect Link**](#hosted-authentication-connect-link) for a hosted authentication flow, or use [**Direct SDK Integration**](#direct-sdk-integration).
+You can either use [**Connect Link**](#hosted-authentication-connect-link) for a hosted authentication flow, or use [**Direct SDK Setup**](#direct-sdk-setup).
 
 <Callout>
 User authentication requires a User ID - a unique identifier that groups connected accounts together. Learn more about [User Management](/docs/user-management) to understand how to structure User IDs for your application.
@@ -162,7 +162,7 @@ These settings will apply to all authentication flows using Connect Link, provid
 For complete white-labeling including OAuth consent screens (removing Composio's domain), see [Custom Auth Configs - White-labeling](/docs/custom-auth-configs#white-labeling-the-oauth-consent-screen).
 </Callout>
 
-### Direct SDK Integration
+### Direct SDK Setup
 
 **Choose the section below that matches your toolkit's authentication method:**
 


### PR DESCRIPTION
## Summary
- Replace noun and verb uses of "integration/integrations" with appropriate alternatives ("toolkits", "app", "compatibility", "setup") across main documentation pages
- Aligns docs copy with Composio's preferred terminology
- Changelogs, migration guides, examples, and reference docs are left unchanged

## Changes
- `docs/content/docs/index.mdx` — "Browse 800+ integrations" → "Browse 800+ toolkits"
- `docs/content/docs/tools-direct/authenticating-tools.mdx` — "your integration" → "your app", "Direct SDK Integration" → "Direct SDK Setup"
- `docs/content/docs/providers/openai.mdx` — "for your integration" → "for your app" (2 occurrences)
- `docs/content/docs/providers/custom-providers/python.mdx` — "integration" → "compatibility"
- `docs/content/docs/providers/custom-providers/typescript.mdx` — "integration" → "compatibility"

## Test plan
- [ ] Verify docs build successfully
- [ ] Spot-check affected pages for correct wording
- [ ] Confirm anchor link `#direct-sdk-setup` works on authenticating-tools page

🤖 Generated with [Claude Code](https://claude.com/claude-code)