### PR TITLE
fix(docs): remove category filter from toolkits page

### DIFF
--- a/docs/components/toolkits/toolkits-landing.tsx
+++ b/docs/components/toolkits/toolkits-landing.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo } from 'react';
 import Link from 'next/link';
-import { Search, ChevronDown, Sparkles, ArrowRight, Wrench, Zap, Copy, Check, ExternalLink, Grip } from 'lucide-react';
+import { Search, Sparkles, ArrowRight, Wrench, Zap, Copy, Check, ExternalLink, Grip } from 'lucide-react';
 import toolkitsData from '@/public/data/toolkits-list.json';
 import type { ToolkitSummary } from '@/types/toolkit';
 
@@ -20,11 +20,6 @@ const POPULAR_SLUGS = [
   'supabase',
   'hubspot',
 ];
-
-// Get unique categories
-const categories = Array.from(
-  new Set(toolkits.map((t) => t.category).filter(Boolean))
-).sort() as string[];
 
 function ToolkitIcon({ toolkit }: { toolkit: ToolkitSummary }) {
   return (
@@ -93,7 +88,6 @@ function ToolkitRow({ toolkit }: { toolkit: ToolkitSummary }) {
 
 export function ToolkitsLanding() {
   const [search, setSearch] = useState('');
-  const [category, setCategory] = useState<string>('all');
 
   // Get popular toolkits
   const popularToolkits = useMemo(() => {
@@ -103,25 +97,15 @@ export function ToolkitsLanding() {
   }, []);
 
   const filteredToolkits = useMemo(() => {
-    let result = toolkits;
+    if (!search) return toolkits;
 
-    // Filter by category
-    if (category !== 'all') {
-      result = result.filter((t) => t.category === category);
-    }
-
-    // Filter by search (name and slug only)
-    if (search) {
-      const searchLower = search.toLowerCase();
-      result = result.filter(
-        (toolkit) =>
-          toolkit.name.toLowerCase().includes(searchLower) ||
-          toolkit.slug.toLowerCase().includes(searchLower)
-      );
-    }
-
-    return result;
-  }, [search, category]);
+    const searchLower = search.toLowerCase();
+    return toolkits.filter(
+      (toolkit) =>
+        toolkit.name.toLowerCase().includes(searchLower) ||
+        toolkit.slug.toLowerCase().includes(searchLower)
+    );
+  }, [search]);
 
   // Group by first letter (numbers at end)
   const groupedToolkits = useMemo(() => {
@@ -196,51 +180,29 @@ export function ToolkitsLanding() {
         <ArrowRight className="h-4 w-4 shrink-0 text-fd-muted-foreground transition-transform group-hover:translate-x-1 group-hover:text-orange-500" />
       </Link>
 
-      {/* Filters */}
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-        {/* Search */}
-        <div className="relative flex-1">
-          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-fd-muted-foreground" aria-hidden="true" />
-          <input
-            type="text"
-            name="toolkit-search"
-            aria-label="Search toolkits"
-            placeholder="Search toolkits…"
-            autoComplete="off"
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            className="h-10 w-full rounded-lg border border-fd-border bg-fd-background pl-10 pr-4 text-sm text-fd-foreground placeholder:text-fd-muted-foreground focus:outline-none focus-visible:border-orange-500/50 focus-visible:ring-2 focus-visible:ring-orange-500/20"
-          />
-        </div>
-
-        {/* Category dropdown */}
-        <div className="relative w-full sm:w-auto">
-          <select
-            value={category}
-            onChange={(e) => setCategory(e.target.value)}
-            aria-label="Filter by category"
-            className="h-10 w-full appearance-none rounded-lg border border-fd-border bg-fd-background pl-4 pr-10 text-sm text-fd-foreground focus:outline-none focus-visible:border-orange-500/50 focus-visible:ring-2 focus-visible:ring-orange-500/20 sm:w-auto"
-          >
-            <option value="all">All categories</option>
-            {categories.map((cat) => (
-              <option key={cat} value={cat}>
-                {cat.charAt(0).toUpperCase() + cat.slice(1)}
-              </option>
-            ))}
-          </select>
-          <ChevronDown className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-fd-muted-foreground" />
-        </div>
+      {/* Search */}
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-fd-muted-foreground" aria-hidden="true" />
+        <input
+          type="text"
+          name="toolkit-search"
+          aria-label="Search toolkits"
+          placeholder="Search toolkits…"
+          autoComplete="off"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="h-10 w-full rounded-lg border border-fd-border bg-fd-background pl-10 pr-4 text-sm text-fd-foreground placeholder:text-fd-muted-foreground focus:outline-none focus-visible:border-orange-500/50 focus-visible:ring-2 focus-visible:ring-orange-500/20"
+        />
       </div>
 
       {/* Results count */}
       <p className="text-sm text-fd-muted-foreground">
         {filteredToolkits.length} toolkit{filteredToolkits.length !== 1 ? 's' : ''}
-        {category !== 'all' && ` in ${category}`}
         {search && ` matching "${search}"`}
       </p>
 
-      {/* Popular Toolkits - only show when no filters */}
-      {!search && category === 'all' && popularToolkits.length > 0 && (
+      {/* Popular Toolkits - only show when no search */}
+      {!search && popularToolkits.length > 0 && (
         <div>
           <h2 className="mb-2 text-sm font-semibold text-fd-muted-foreground">Popular</h2>
           <div className="divide-y divide-fd-border">
@@ -269,13 +231,10 @@ export function ToolkitsLanding() {
         <div className="py-12 text-center">
           <p className="text-fd-muted-foreground">No toolkits found.</p>
           <button
-            onClick={() => {
-              setSearch('');
-              setCategory('all');
-            }}
+            onClick={() => setSearch('')}
             className="mt-2 text-sm text-fd-primary hover:underline"
           >
-            Clear filters
+            Clear search
           </button>
         </div>
       )}


### PR DESCRIPTION
## Summary
- Removes the category filter dropdown from the toolkits landing page
- Simplifies the UI to only have search functionality
- Categories were not being used effectively and added unnecessary complexity

## Changes
- Removed `ChevronDown` import
- Removed `categories` constant and `category` state
- Simplified `filteredToolkits` to only filter by search term
- Removed category dropdown UI component
- Changed "Clear filters" button to "Clear search"

🤖 Generated with [Claude Code](https://claude.com/claude-code)