### PR TITLE
fix(docs): use async getReferenceSource for OpenAPI pages

### DIFF
--- a/docs/app/(home)/reference/[[...slug]]/page.tsx
+++ b/docs/app/(home)/reference/[[...slug]]/page.tsx
@@ -1,5 +1,5 @@
 import type { ComponentType } from 'react';
-import { referenceSource, getOgImageUrl } from '@/lib/source';
+import { getReferenceSource, getOgImageUrl } from '@/lib/source';
 import { APIPage } from '@/components/api-page';
 import {
   DocsBody,
@@ -25,6 +25,7 @@ export default async function Page({
   params: Promise<{ slug?: string[] }>;
 }) {
   const { slug } = await params;
+  const referenceSource = await getReferenceSource();
   const page = referenceSource.getPage(slug);
   if (!page) notFound();
 
@@ -62,7 +63,8 @@ export default async function Page({
   );
 }
 
-export function generateStaticParams() {
+export async function generateStaticParams() {
+  const referenceSource = await getReferenceSource();
   return referenceSource.generateParams();
 }
 
@@ -85,6 +87,7 @@ export async function generateMetadata({
     };
   }
 
+  const referenceSource = await getReferenceSource();
   const page = referenceSource.getPage(slug);
   if (!page) notFound();
 

--- a/docs/app/(home)/reference/layout.tsx
+++ b/docs/app/(home)/reference/layout.tsx
@@ -1,4 +1,19 @@
-import { referenceSource } from '@/lib/source';
-import { createDocsLayout } from '@/lib/create-docs-layout';
+import { getReferenceSource } from '@/lib/source';
+import { DocsLayout } from 'fumadocs-ui/layouts/docs';
+import type { ReactNode } from 'react';
 
-export default createDocsLayout(referenceSource);
+export default async function Layout({ children }: { children: ReactNode }) {
+  const referenceSource = await getReferenceSource();
+
+  return (
+    <DocsLayout
+      tree={referenceSource.pageTree}
+      nav={{ enabled: true, title: null }}
+      searchToggle={{ enabled: false }}
+      sidebar={{ collapsible: false, footer: null, tabs: false }}
+      themeSwitch={{ enabled: false }}
+    >
+      {children}
+    </DocsLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- Fixes API reference pages not loading (404 errors)
- The reference page was using the synchronous `referenceSource` which only includes MDX pages
- This switches to the async `getReferenceSource()` to include OpenAPI-generated API reference pages

## Changes
- Update `page.tsx` to use `getReferenceSource()` 
- Update `layout.tsx` to be async and use `getReferenceSource()`

## Test plan
- [ ] Visit `/reference` and verify sidebar shows API reference section
- [ ] Click on an API reference endpoint and verify it loads

🤖 Generated with [Claude Code](https://claude.ai/code)