### PR TITLE
perf(docs): Use static toolkits.json data to speed up builds

### DIFF
--- a/docs/app/(home)/toolkits/[[...slug]]/page.tsx
+++ b/docs/app/(home)/toolkits/[[...slug]]/page.tsx
@@ -7,82 +7,11 @@ import { PageActions } from '@/components/page-actions';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
 import type { Metadata } from 'next';
-import type { Toolkit, Tool } from '@/types/toolkit';
+import type { Toolkit } from '@/types/toolkit';
 
-const API_BASE = process.env.COMPOSIO_API_BASE || 'https://backend.composio.dev/api/v3';
-const API_KEY = process.env.COMPOSIO_API_KEY;
-
-// Fetch detailed tool info from Composio API (server-side only)
-// Returns null on failure, empty array if toolkit has no tools
-async function fetchDetailedTools(toolkitSlug: string): Promise<Tool[] | null> {
-  if (!API_KEY) {
-    console.warn('[Toolkits] COMPOSIO_API_KEY not set, skipping detailed tool fetch');
-    return null;
-  }
-
-  try {
-    const response = await fetch(
-      `${API_BASE}/tools?toolkit_slug=${toolkitSlug.toUpperCase()}&limit=1000`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          'x-api-key': API_KEY,
-        },
-        next: { revalidate: 3600 }, // Cache for 1 hour
-      }
-    );
-
-    if (!response.ok) {
-      console.warn(`[Toolkits] Failed to fetch tools for ${toolkitSlug}: ${response.status}`);
-      return null;
-    }
-
-    const data = await response.json();
-    const rawItems = data.items || data;
-    const items = Array.isArray(rawItems) ? rawItems : [];
-
-    return items.filter((tool: any) => tool && typeof tool === 'object').map((tool: any) => {
-      // Extract parameters from JSON Schema format
-      const inputSchema = tool.input_parameters || tool.parameters;
-      const outputSchema = tool.output_parameters || tool.response;
-
-      // Get properties and required array from JSON Schema
-      const inputProps = inputSchema?.properties || inputSchema;
-      const inputRequired = inputSchema?.required || [];
-      const outputProps = outputSchema?.properties || outputSchema;
-      const outputRequired = outputSchema?.required || [];
-
-      // Add required flag to each property based on the required array
-      const processParams = (props: any, requiredList: string[]) => {
-        if (!props || typeof props !== 'object') return undefined;
-        const result: Record<string, any> = {};
-        for (const [key, value] of Object.entries(props)) {
-          if (typeof value === 'object' && value !== null) {
-            result[key] = {
-              ...(value as object),
-              required: requiredList.includes(key),
-            };
-          }
-        }
-        return Object.keys(result).length > 0 ? result : undefined;
-      };
-
-      return {
-        slug: tool.slug || '',
-        name: tool.name || tool.display_name || tool.slug || '',
-        description: tool.description || '',
-        input_parameters: processParams(inputProps, inputRequired),
-        output_parameters: processParams(outputProps, outputRequired),
-        scopes: tool.scopes || undefined,
-        tags: tool.tags || undefined,
-        is_deprecated: tool.is_deprecated || false,
-      };
-    });
-  } catch (error) {
-    console.error(`[Toolkits] Error fetching detailed tools for ${toolkitSlug}:`, error);
-    return null;
-  }
-}
+// Use static data from toolkits.json during build to avoid slow API calls
+// The pre-generated JSON already contains tool details from scripts/generate-toolkits.ts
+// This significantly speeds up build time (avoids 3MB+ API responses per toolkit)
 
 async function getToolkits(): Promise<Toolkit[]> {
   const filePath = join(process.cwd(), 'public/data/toolkits.json');
@@ -204,16 +133,10 @@ export default async function ToolkitsPage({ params }: { params: Promise<{ slug?
     const toolkit = toolkits.find((t) => t.slug === toolkitSlug);
 
     if (toolkit) {
-      // Fetch detailed tool info from API (includes input/output params)
-      const detailedTools = await fetchDetailedTools(toolkitSlug);
-
-      // Use detailed tools if fetch succeeded, otherwise fall back to static data
-      const tools = detailedTools !== null ? detailedTools : toolkit.tools;
-
       return (
         <ToolkitDetail
           toolkit={toolkit}
-          tools={tools}
+          tools={toolkit.tools}
           triggers={toolkit.triggers}
           path={`/toolkits/${toolkit.slug}`}
         />


### PR DESCRIPTION
## Summary

- Remove `fetchDetailedTools()` API calls during build
- Use pre-generated `toolkits.json` data instead

## Problem

During build, the toolkits page was making API calls for each toolkit to fetch detailed tool info. Some toolkits (like DATABRICKS) return 3MB+ responses that can't be cached by Next.js:

```
Failed to set Next.js data cache for https://backend.composio.dev/api/v3/tools?toolkit_slug=DATABRICKS&limit=1000, items over 2MB can not be cached (3035882 bytes)
```

This caused very slow builds on Vercel.

## Solution

The `public/data/toolkits.json` file (generated by `scripts/generate-toolkits.ts`) already contains all tool details. By using this static data instead of making API calls, we eliminate the cache issues and significantly speed up builds.

## Test plan

- [ ] Verify build completes faster
- [ ] Verify toolkit pages still display tool details correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)