### PR TITLE
fix(docs): Add SEO description fallback for API reference pages

### DIFF
--- a/docs/app/(home)/reference/[[...slug]]/page.tsx
+++ b/docs/app/(home)/reference/[[...slug]]/page.tsx
@@ -92,11 +92,14 @@ export async function generateMetadata({
   const page = referenceSource.getPage(slug);
   if (!page) notFound();
 
-  const ogImage = getOgImageUrl('reference', page.slugs, page.data.title, page.data.description);
+  // Use description if available, otherwise fall back to title for SEO
+  // This handles OpenAPI pages where description may be null in the spec
+  const description = page.data.description || page.data.title;
+  const ogImage = getOgImageUrl('reference', page.slugs, page.data.title, description);
 
   return {
     title: page.data.title,
-    description: page.data.description,
+    description,
     alternates: { canonical: page.url },
     openGraph: { images: [ogImage] },
     twitter: { card: 'summary_large_image', images: [ogImage] },


### PR DESCRIPTION
## Summary
- Adds fallback to use page title when OpenAPI description is null
- Fixes 8 API reference pages that were missing meta descriptions

## Affected endpoints
| Endpoint | Now has description |
|----------|---------------------|
| getAuthConfigs | "List authentication configurations with optional filters" |
| postAuthConfigs | ✅ |
| getConnectedAccounts | "List connected accounts with optional filters" |
| postConnectedAccounts | "Create a new connected account" |
| getTriggerInstancesActive | "Get Trigger Instances Active" |
| postTriggerInstancesBySlugUpsert | ✅ |
| patchTriggerInstancesManageByTriggerId | ✅ |
| deleteTriggerInstancesManageByTriggerId | ✅ |

## Test plan
- [x] Build passes
- [x] Verified meta descriptions now appear on previously missing pages
- [x] Verified pages with existing descriptions still use original description

🤖 Generated with [Claude Code](https://claude.com/claude-code)