### PR TITLE
feat(ts/cli): env var toolkit version override

### DIFF
--- a/ts/packages/cli/.cursor/rules/composio-clients.mdc
+++ b/ts/packages/cli/.cursor/rules/composio-clients.mdc
@@ -1,0 +1,73 @@
+---
+description: Rule for keeping composio-clients.ts and composio-clients-cached.ts in sync
+globs:
+  - "src/services/composio-clients.ts"
+  - "src/services/composio-clients-cached.ts"
+alwaysApply: true
+---
+
+# ComposioClients Service Sync Rule
+
+## Critical Requirement
+
+When modifying `src/services/composio-clients.ts`, you MUST also update `src/services/composio-clients-cached.ts`.
+
+## Why This Matters
+
+The `ComposioToolkitsRepositoryCached` in `composio-clients-cached.ts` is a Layer wrapper that provides file-based caching around `ComposioToolkitsRepository`. It must implement the EXACT SAME interface.
+
+If you add, remove, or modify methods in `ComposioToolkitsRepository`, the cached layer will:
+- **Fail at runtime** if a method is missing
+- **Behave incorrectly** if method signatures don't match
+- **Cause type errors** if the interface is out of sync
+
+## Checklist When Modifying composio-clients.ts
+
+1. [ ] **New method added?** → Add corresponding entry in `ComposioToolkitsRepositoryCached`
+   - Decide if it should be cached or passthrough
+   - Validation methods: usually passthrough (no caching)
+   - Data fetch methods: usually cached
+
+2. [ ] **Method signature changed?** → Update in both files
+
+3. [ ] **Method removed?** → Remove from both files
+
+4. [ ] **New error type added?** → Export from both files if needed
+
+## Example: Adding a New Method
+
+**In composio-clients.ts:**
+```typescript
+export class ComposioToolkitsRepository extends Effect.Service<ComposioToolkitsRepository>()(...) {
+  // ...
+  newMethod: (arg: string) => Effect.Effect<Result, Error>,
+}
+```
+
+**In composio-clients-cached.ts:**
+```typescript
+return ComposioToolkitsRepository.make({
+  // ... existing methods ...
+
+  // For passthrough (no caching):
+  newMethod: arg => underlyingRepository.newMethod(arg),
+
+  // OR for cached:
+  newMethod: arg => createCachedEffect(
+    'new-method.json',
+    decoder,
+    encoder,
+    underlyingRepository.newMethod(arg)
+  ),
+});
+```
+
+## Testing
+
+After modifying either file, run:
+```bash
+pnpm build:packages
+pnpm test
+```
+
+Build errors or failing tests often indicate a sync issue between these files.

--- a/ts/packages/cli/src/commands/py/commands/py.generate.cmd.ts
+++ b/ts/packages/cli/src/commands/py/commands/py.generate.cmd.ts
@@ -13,6 +13,7 @@ import {
   getToolkitVersionOverrides,
   type ToolkitVersionOverrides,
 } from 'src/effects/toolkit-version-overrides';
+import { validateToolkitVersionOverrides } from 'src/effects/validate-toolkit-versions';
 
 export const outputOpt = Options.optional(
   Options.directory('output-dir', {
@@ -32,7 +33,10 @@ export const toolkitsOpt = Options.text('toolkits').pipe(
 
 const _pyCmd$Generate = Command.make('generate', { outputOpt, toolkitsOpt }).pipe(
   Command.withDescription(
-    'Generate Python type stubs for toolkits, tools, and triggers from the Composio API'
+    'Generate Python type stubs for toolkits, tools, and triggers from the Composio API.\n\n' +
+      'Environment Variables:\n' +
+      '  COMPOSIO_TOOLKIT_VERSION_<TOOLKIT>  Override toolkit version (e.g., COMPOSIO_TOOLKIT_VERSION_GMAIL=20250901_00)\n' +
+      '                                      Use "latest" or unset to use the latest version.'
   )
 );
 
@@ -65,19 +69,22 @@ export function generatePythonTypeStubs({
     // Read toolkit version overrides from environment variables
     const versionOverrides = yield* getToolkitVersionOverrides;
 
-    // Log detected overrides for debugging
-    if (versionOverrides.size > 0) {
-      yield* Console.log('Detected toolkit version overrides:');
-      for (const [toolkit, version] of versionOverrides) {
-        yield* Console.log(`  - ${toolkit}: ${version}`);
-      }
-    }
+    // Validate toolkit slugs if specified
+    const hasToolkitsFilter = Array.isNonEmptyArray(toolkitsOpt);
+    const toolkitSlugsFilter = hasToolkitsFilter ? toolkitsOpt.map(s => s.toLowerCase()) : null;
+
+    // Validate toolkit version overrides before fetching data
+    // This will log detected overrides, validate them against API, and warn about unused ones
+    const { validatedOverrides } = yield* validateToolkitVersionOverrides({
+      versionOverrides,
+      toolkitSlugsFilter,
+      client,
+    });
 
     // Fetch data from Composio API
     yield* Console.log('Fetching latest data from Composio API. This may take a while...');
 
-    // Validate toolkit slugs if specified
-    const hasToolkitsFilter = Array.isNonEmptyArray(toolkitsOpt);
+    // Validate toolkit slugs if specified (separate from version validation)
     const validatedToolkitSlugs = hasToolkitsFilter
       ? yield* client
           .validateToolkits(toolkitsOpt)
@@ -115,10 +122,10 @@ export function generatePythonTypeStubs({
       );
     }
 
-    // Build version map for toolkits being generated
+    // Build version map for toolkits being generated (using validated overrides)
     const versionMap: ToolkitVersionOverrides = new Map();
     for (const toolkit of toolkits) {
-      const version = versionOverrides.get(toolkit.slug.toLowerCase() as Lowercase<string>);
+      const version = validatedOverrides.get(toolkit.slug.toLowerCase() as Lowercase<string>);
       if (version && version !== 'latest') {
         versionMap.set(toolkit.slug.toLowerCase() as Lowercase<string>, version);
       }

--- a/ts/packages/cli/src/commands/py/commands/py.generate.cmd.ts
+++ b/ts/packages/cli/src/commands/py/commands/py.generate.cmd.ts
@@ -9,6 +9,10 @@ import { createToolkitIndex } from 'src/generation/create-toolkit-index';
 import { pyFindComposioCoreGenerated } from 'src/effects/find-composio-core-generated';
 import { BANNER } from 'src/generation/constants';
 import { generatePythonSources } from 'src/generation/python/generate';
+import {
+  getToolkitVersionOverrides,
+  type ToolkitVersionOverrides,
+} from 'src/effects/toolkit-version-overrides';
 
 export const outputOpt = Options.optional(
   Options.directory('output-dir', {
@@ -58,6 +62,17 @@ export function generatePythonTypeStubs({
     yield* Effect.log(`Writing type stubs to ${outputDir}...`);
     yield* fs.makeDirectory(outputDir, { recursive: true });
 
+    // Read toolkit version overrides from environment variables
+    const versionOverrides = yield* getToolkitVersionOverrides;
+
+    // Log detected overrides for debugging
+    if (versionOverrides.size > 0) {
+      yield* Console.log('Detected toolkit version overrides:');
+      for (const [toolkit, version] of versionOverrides) {
+        yield* Console.log(`  - ${toolkit}: ${version}`);
+      }
+    }
+
     // Fetch data from Composio API
     yield* Console.log('Fetching latest data from Composio API. This may take a while...');
 
@@ -100,9 +115,18 @@ export function generatePythonTypeStubs({
       );
     }
 
+    // Build version map for toolkits being generated
+    const versionMap: ToolkitVersionOverrides = new Map();
+    for (const toolkit of toolkits) {
+      const version = versionOverrides.get(toolkit.slug.toLowerCase() as Lowercase<string>);
+      if (version && version !== 'latest') {
+        versionMap.set(toolkit.slug.toLowerCase() as Lowercase<string>, version);
+      }
+    }
+
     const typeableTools = { withTypes: false as const, tools };
 
-    const index = createToolkitIndex({ toolkits, typeableTools, triggerTypes });
+    const index = createToolkitIndex({ toolkits, typeableTools, triggerTypes, versionMap });
 
     // Generate Python sources
     const sources = generatePythonSources({

--- a/ts/packages/cli/src/commands/ts/commands/ts.generate.cmd.ts
+++ b/ts/packages/cli/src/commands/ts/commands/ts.generate.cmd.ts
@@ -35,8 +35,10 @@ import type { Tool, ToolsAsEnums } from 'src/models/tools';
 import {
   getToolkitVersionOverrides,
   buildToolkitVersionSpecs,
+  buildVersionMapFromSpecs,
   type ToolkitVersionOverrides,
 } from 'src/effects/toolkit-version-overrides';
+import { validateToolkitVersionOverrides } from 'src/effects/validate-toolkit-versions';
 
 export const outputOpt = Options.optional(
   Options.directory('output-dir', {
@@ -79,7 +81,10 @@ const _tsCmd$Generate = Command.make('generate', {
   toolkitsOpt,
 }).pipe(
   Command.withDescription(
-    'Generate TypeScript types for toolkits, tools, and triggers from the Composio API'
+    'Generate TypeScript types for toolkits, tools, and triggers from the Composio API.\n\n' +
+      'Environment Variables:\n' +
+      '  COMPOSIO_TOOLKIT_VERSION_<TOOLKIT>  Override toolkit version (e.g., COMPOSIO_TOOLKIT_VERSION_GMAIL=20250901_00)\n' +
+      '                                      Use "latest" or unset to use the latest version.'
   )
 );
 
@@ -113,12 +118,7 @@ function fetchFilteredData(
     const versionSpecs = buildToolkitVersionSpecs(slugs, versionOverrides);
 
     // Build the version map (only includes non-'latest' versions from the filtered toolkits)
-    const versionMap: ToolkitVersionOverrides = new Map();
-    for (const spec of versionSpecs) {
-      if (spec.toolkitVersion !== 'latest') {
-        versionMap.set(spec.toolkitSlug, spec.toolkitVersion);
-      }
-    }
+    const versionMap = buildVersionMapFromSpecs(versionSpecs);
 
     const [filteredToolkits, filteredTriggerTypes, filteredTypeableTools] = yield* Effect.all(
       [
@@ -249,12 +249,7 @@ function fetchAllDataWithOverrides(
     const versionSpecs = buildToolkitVersionSpecs(allSlugs, versionOverrides);
 
     // Build the version map (only includes non-'latest' versions)
-    const versionMap: ToolkitVersionOverrides = new Map();
-    for (const spec of versionSpecs) {
-      if (spec.toolkitVersion !== 'latest') {
-        versionMap.set(spec.toolkitSlug, spec.toolkitVersion);
-      }
-    }
+    const versionMap = buildVersionMapFromSpecs(versionSpecs);
 
     // 3. Fetch trigger types and tools in parallel
     const [allTriggerTypes, allTypeableTools] = yield* Effect.all(
@@ -377,23 +372,23 @@ export function generateTypescriptTypeStubs({
     // Read toolkit version overrides from environment variables
     const versionOverrides = yield* getToolkitVersionOverrides;
 
-    // Log detected overrides for debugging
-    if (versionOverrides.size > 0) {
-      yield* Console.log('Detected toolkit version overrides:');
-      for (const [toolkit, version] of versionOverrides) {
-        yield* Console.log(`  - ${toolkit}: ${version}`);
-      }
-    }
-
     // Normalize toolkit slugs if specified (lowercase for API filtering)
     const toolkitSlugsFilter = Array.isNonEmptyArray(toolkitsOpt)
       ? toolkitsOpt.map(s => s.toLowerCase())
       : null;
 
+    // Validate toolkit version overrides before fetching data
+    // This will log detected overrides, validate them against API, and warn about unused ones
+    const { validatedOverrides } = yield* validateToolkitVersionOverrides({
+      versionOverrides,
+      toolkitSlugsFilter,
+      client,
+    });
+
     // Fetch data using two distinct strategies based on whether --toolkits filter is provided
     const { toolkits, triggerTypes, typeableTools, versionMap } = yield* toolkitSlugsFilter !== null
-      ? fetchFilteredData(client, toolkitSlugsFilter, typeTools, versionOverrides)
-      : fetchAllData(client, typeTools, versionOverrides);
+      ? fetchFilteredData(client, toolkitSlugsFilter, typeTools, validatedOverrides)
+      : fetchAllData(client, typeTools, validatedOverrides);
 
     yield* Console.log('Writing TypeScript type stubs to disk...');
     const index = createToolkitIndex({ toolkits, typeableTools, triggerTypes, versionMap });

--- a/ts/packages/cli/src/commands/ts/commands/ts.generate.cmd.ts
+++ b/ts/packages/cli/src/commands/ts/commands/ts.generate.cmd.ts
@@ -32,6 +32,11 @@ import { BANNER } from 'src/generation/constants';
 import type { Toolkit } from 'src/models/toolkits';
 import type { TriggerType } from 'src/models/trigger-types';
 import type { Tool, ToolsAsEnums } from 'src/models/tools';
+import {
+  getToolkitVersionOverrides,
+  buildToolkitVersionSpecs,
+  type ToolkitVersionOverrides,
+} from 'src/effects/toolkit-version-overrides';
 
 export const outputOpt = Options.optional(
   Options.directory('output-dir', {
@@ -87,6 +92,8 @@ type FetchResult = {
   typeableTools:
     | { withTypes: true; tools: ReadonlyArray<Tool> }
     | { withTypes: false; tools: ToolsAsEnums };
+  /** Map of lowercase toolkit slug to version (only includes non-'latest' versions) */
+  versionMap: ToolkitVersionOverrides;
 };
 
 /**
@@ -96,10 +103,22 @@ type FetchResult = {
 function fetchFilteredData(
   client: ComposioToolkitsRepository,
   slugs: ReadonlyArray<string>,
-  typeTools: boolean
+  typeTools: boolean,
+  versionOverrides: ToolkitVersionOverrides
 ): Effect.Effect<FetchResult, Error, never> {
   return Effect.gen(function* () {
     yield* Console.log(`Fetching data for ${slugs.length} toolkit(s): ${slugs.join(', ')}...`);
+
+    // Build version specs for each requested toolkit
+    const versionSpecs = buildToolkitVersionSpecs(slugs, versionOverrides);
+
+    // Build the version map (only includes non-'latest' versions from the filtered toolkits)
+    const versionMap: ToolkitVersionOverrides = new Map();
+    for (const spec of versionSpecs) {
+      if (spec.toolkitVersion !== 'latest') {
+        versionMap.set(spec.toolkitSlug, spec.toolkitVersion);
+      }
+    }
 
     const [filteredToolkits, filteredTriggerTypes, filteredTypeableTools] = yield* Effect.all(
       [
@@ -123,16 +142,17 @@ function fetchFilteredData(
         Effect.logDebug(`Fetching trigger types for ${slugs.length} toolkit(s)...`).pipe(
           Effect.flatMap(() => client.getTriggerTypes(slugs))
         ),
-        // Fetch tools for the specified toolkits
+        // Fetch tools for the specified toolkits (with version support when using --type-tools)
         Match.value(typeTools).pipe(
           Match.when(true, withTypes =>
             Effect.logDebug(`Fetching tools with schemas for ${slugs.length} toolkit(s)...`).pipe(
-              Effect.flatMap(() => client.getTools(slugs)),
+              Effect.flatMap(() => client.getToolsByVersionSpecs(versionSpecs)),
               Effect.map(tools => ({ withTypes, tools }))
             )
           ),
           Match.when(false, withTypes =>
             // Use filtered getTools() and extract slugs - more efficient than fetching ALL enums
+            // Note: When not using --type-tools, version overrides don't affect the output
             Effect.logDebug(`Fetching tool names for ${slugs.length} toolkit(s)...`).pipe(
               Effect.flatMap(() => client.getTools(slugs)),
               Effect.map(tools => ({
@@ -155,21 +175,20 @@ function fetchFilteredData(
       toolkits: filteredToolkits,
       triggerTypes: filteredTriggerTypes,
       typeableTools: filteredTypeableTools,
+      versionMap,
     };
   });
 }
 
 /**
- * Fetches all toolkit data when no --toolkits filter is provided.
- * Fetches everything from the API.
+ * Fast path for fetching all toolkit data when no version overrides are specified.
+ * Fetches everything in parallel without version-specific handling.
  */
-function fetchAllData(
+function fetchAllDataFastPath(
   client: ComposioToolkitsRepository,
   typeTools: boolean
 ): Effect.Effect<FetchResult, Error, never> {
   return Effect.gen(function* () {
-    yield* Console.log('Fetching all toolkits, tools, and triggers from Composio API...');
-
     // Fetch all data in parallel
     // Note: getToolsAsEnums is only called when typeTools === false
     const [allToolkits, allTriggerTypes, allTypeableTools] = yield* Effect.all(
@@ -205,7 +224,92 @@ function fetchAllData(
       toolkits: allToolkits,
       triggerTypes: allTriggerTypes,
       typeableTools: allTypeableTools,
+      versionMap: new Map() as ToolkitVersionOverrides,
     };
+  });
+}
+
+/**
+ * Fetches all toolkit data with version overrides applied.
+ * First fetches toolkit metadata, then fetches tools with version-specific handling.
+ */
+function fetchAllDataWithOverrides(
+  client: ComposioToolkitsRepository,
+  typeTools: boolean,
+  versionOverrides: ToolkitVersionOverrides
+): Effect.Effect<FetchResult, Error, never> {
+  return Effect.gen(function* () {
+    // 1. First fetch all toolkit metadata to know what's available
+    const allToolkits = yield* Effect.logDebug('Fetching all toolkits...').pipe(
+      Effect.flatMap(() => client.getToolkits())
+    );
+    const allSlugs = allToolkits.map(t => t.slug);
+
+    // 2. Build version specs (overridden toolkits get specific version, rest get 'latest')
+    const versionSpecs = buildToolkitVersionSpecs(allSlugs, versionOverrides);
+
+    // Build the version map (only includes non-'latest' versions)
+    const versionMap: ToolkitVersionOverrides = new Map();
+    for (const spec of versionSpecs) {
+      if (spec.toolkitVersion !== 'latest') {
+        versionMap.set(spec.toolkitSlug, spec.toolkitVersion);
+      }
+    }
+
+    // 3. Fetch trigger types and tools in parallel
+    const [allTriggerTypes, allTypeableTools] = yield* Effect.all(
+      [
+        Effect.logDebug('Fetching all trigger types...').pipe(
+          Effect.flatMap(() => client.getTriggerTypes())
+        ),
+        Match.value(typeTools).pipe(
+          Match.when(true, withTypes =>
+            Effect.logDebug('Fetching all tools with schemas (with version overrides)...').pipe(
+              Effect.flatMap(() => client.getToolsByVersionSpecs(versionSpecs)),
+              Effect.map(tools => ({ withTypes, tools }))
+            )
+          ),
+          Match.when(false, withTypes =>
+            // When not using --type-tools, version overrides don't affect the output
+            Effect.logDebug('Fetching all tool names...').pipe(
+              Effect.flatMap(() => client.getToolsAsEnums()),
+              Effect.map(tools => ({ withTypes, tools }))
+            )
+          ),
+          Match.exhaustive
+        ),
+      ],
+      { concurrency: 'unbounded' }
+    );
+
+    yield* Console.log(`Found ${allToolkits.length} toolkit(s)`);
+
+    return {
+      toolkits: allToolkits,
+      triggerTypes: allTriggerTypes,
+      typeableTools: allTypeableTools,
+      versionMap,
+    };
+  });
+}
+
+/**
+ * Fetches all toolkit data when no --toolkits filter is provided.
+ * Delegates to fast path or override-aware path based on version overrides.
+ */
+function fetchAllData(
+  client: ComposioToolkitsRepository,
+  typeTools: boolean,
+  versionOverrides: ToolkitVersionOverrides
+): Effect.Effect<FetchResult, Error, never> {
+  return Effect.gen(function* () {
+    yield* Console.log('Fetching all toolkits, tools, and triggers from Composio API...');
+
+    if (versionOverrides.size === 0) {
+      return yield* fetchAllDataFastPath(client, typeTools);
+    }
+
+    return yield* fetchAllDataWithOverrides(client, typeTools, versionOverrides);
   });
 }
 
@@ -270,18 +374,29 @@ export function generateTypescriptTypeStubs({
     yield* Effect.log(`Writing type stubs to ${outputDir}...`);
     yield* fs.makeDirectory(outputDir, { recursive: true });
 
+    // Read toolkit version overrides from environment variables
+    const versionOverrides = yield* getToolkitVersionOverrides;
+
+    // Log detected overrides for debugging
+    if (versionOverrides.size > 0) {
+      yield* Console.log('Detected toolkit version overrides:');
+      for (const [toolkit, version] of versionOverrides) {
+        yield* Console.log(`  - ${toolkit}: ${version}`);
+      }
+    }
+
     // Normalize toolkit slugs if specified (lowercase for API filtering)
     const toolkitSlugsFilter = Array.isNonEmptyArray(toolkitsOpt)
       ? toolkitsOpt.map(s => s.toLowerCase())
       : null;
 
     // Fetch data using two distinct strategies based on whether --toolkits filter is provided
-    const { toolkits, triggerTypes, typeableTools } = yield* toolkitSlugsFilter !== null
-      ? fetchFilteredData(client, toolkitSlugsFilter, typeTools)
-      : fetchAllData(client, typeTools);
+    const { toolkits, triggerTypes, typeableTools, versionMap } = yield* toolkitSlugsFilter !== null
+      ? fetchFilteredData(client, toolkitSlugsFilter, typeTools, versionOverrides)
+      : fetchAllData(client, typeTools, versionOverrides);
 
     yield* Console.log('Writing TypeScript type stubs to disk...');
-    const index = createToolkitIndex({ toolkits, typeableTools, triggerTypes });
+    const index = createToolkitIndex({ toolkits, typeableTools, triggerTypes, versionMap });
 
     // Generate TypeScript sources
     const sources = yield* generateTypeScriptSources({

--- a/ts/packages/cli/src/effects/toolkit-version-overrides.ts
+++ b/ts/packages/cli/src/effects/toolkit-version-overrides.ts
@@ -1,0 +1,112 @@
+import { Config, ConfigError, Effect, HashMap, Option, pipe, String } from 'effect';
+import { BaseConfigProviderLive } from 'src/services/config';
+
+/**
+ * Represents a toolkit with its version specification.
+ * The `toolkitSlug` is guaranteed to be lowercase at the type level.
+ */
+export interface ToolkitVersionSpec {
+  readonly toolkitSlug: Lowercase<string>;
+  readonly toolkitVersion: string;
+}
+
+/**
+ * Config that reads COMPOSIO_TOOLKIT_VERSION_<TOOLKIT>=<version> env vars.
+ * Uses Effect's Config.hashMap with Config.nested to read all env vars
+ * `COMPOSIO_TOOLKIT_VERSION_${TOOLKIT}` with a wildcard suffix.
+ *
+ * @example
+ * // Given: COMPOSIO_TOOLKIT_VERSION_GMAIL=20250901_00
+ * // Returns: HashMap { "GMAIL" => "20250901_00" }
+ */
+export const TOOLKIT_VERSION_OVERRIDES_CONFIG = pipe(
+  Config.hashMap(Config.string()),
+  Config.nested('VERSION'),
+  Config.nested('TOOLKIT'),
+  Config.nested('COMPOSIO'),
+  Config.option // Optional, so missing env vars don't fail the config
+);
+
+/**
+ * Map type with lowercase toolkit slugs as keys.
+ */
+export type ToolkitVersionOverrides = Map<Lowercase<string>, string>;
+
+/**
+ * Reads toolkit version overrides from environment variables.
+ *
+ * Uses Effect's Config system to read env vars matching the pattern
+ * COMPOSIO_TOOLKIT_VERSION_<TOOLKIT>=<version>.
+ *
+ * This function uses `BaseConfigProviderLive` directly (bypassing `extendConfigProvider`)
+ * to correctly parse the nested path structure of the environment variable names.
+ *
+ * @returns Effect that yields a Map<Lowercase<string>, string> where keys are lowercase toolkit slugs
+ *          and values are version strings
+ *
+ * @example
+ * // Given: COMPOSIO_TOOLKIT_VERSION_GMAIL=20250901_00
+ * // Returns: Map { "gmail" => "20250901_00" }
+ */
+export const getToolkitVersionOverrides: Effect.Effect<
+  ToolkitVersionOverrides,
+  ConfigError.ConfigError
+> = Effect.gen(function* () {
+  const maybeOverrides = yield* TOOLKIT_VERSION_OVERRIDES_CONFIG;
+
+  return Option.match(maybeOverrides, {
+    onNone: () => new Map<Lowercase<string>, string>(),
+    onSome: hashMap => {
+      const result = new Map<Lowercase<string>, string>();
+      for (const [key, value] of HashMap.toEntries(hashMap)) {
+        // Normalize toolkit name to lowercase and skip 'latest' values
+        if (value && value !== 'latest') {
+          result.set(String.toLowerCase(key), value);
+        }
+      }
+      return result;
+    },
+  });
+}).pipe(Effect.withConfigProvider(BaseConfigProviderLive));
+
+/**
+ * Builds an array of ToolkitVersionSpec from toolkit slugs and version overrides.
+ *
+ * @example
+ * // Given slugs: ['gmail', 'slack', 'github']
+ * // Given overrides: Map { "gmail" => "20250901_00" }
+ * // Returns: [
+ * //   { toolkitSlug: 'gmail', toolkitVersion: '20250901_00' },
+ * //   { toolkitSlug: 'slack', toolkitVersion: 'latest' },
+ * //   { toolkitSlug: 'github', toolkitVersion: 'latest' }
+ * // ]
+ */
+export const buildToolkitVersionSpecs = (
+  toolkitSlugs: ReadonlyArray<string>,
+  overrides: ToolkitVersionOverrides
+): ReadonlyArray<ToolkitVersionSpec> =>
+  toolkitSlugs.map(slug => {
+    const normalizedSlug = String.toLowerCase(slug);
+    return {
+      toolkitSlug: normalizedSlug,
+      toolkitVersion: overrides.get(normalizedSlug) ?? 'latest',
+    };
+  });
+
+/**
+ * Groups ToolkitVersionSpecs by version for efficient API batching.
+ *
+ * @example
+ * // Given specs with mixed versions
+ * // Returns: Map { "20250901_00" => ["gmail"], "latest" => ["slack", "github"] }
+ */
+export const groupByVersion = (
+  specs: ReadonlyArray<ToolkitVersionSpec>
+): Map<string, Lowercase<string>[]> => {
+  const grouped = new Map<string, Lowercase<string>[]>();
+  for (const spec of specs) {
+    const existing = grouped.get(spec.toolkitVersion) ?? [];
+    grouped.set(spec.toolkitVersion, [...existing, spec.toolkitSlug]);
+  }
+  return grouped;
+};

--- a/ts/packages/cli/src/effects/toolkit-version-overrides.ts
+++ b/ts/packages/cli/src/effects/toolkit-version-overrides.ts
@@ -33,6 +33,32 @@ export const TOOLKIT_VERSION_OVERRIDES_CONFIG = pipe(
 export type ToolkitVersionOverrides = Map<Lowercase<string>, string>;
 
 /**
+ * Regex pattern for valid version strings.
+ * Only allows: alphanumeric characters (a-z, A-Z, 0-9), hyphens, underscores, and dots.
+ */
+const VALID_VERSION_PATTERN = /^[a-zA-Z0-9._-]+$/;
+
+/**
+ * Sanitizes a version string by removing invalid characters.
+ * Only keeps: alphanumeric characters (a-z, A-Z, 0-9), hyphens, underscores, and dots.
+ *
+ * @param version - The version string to sanitize
+ * @returns The sanitized version string, or null if it becomes empty after sanitization
+ */
+export const sanitizeVersionString = (version: string): string | null => {
+  // If the version already matches the valid pattern, return as-is
+  if (VALID_VERSION_PATTERN.test(version)) {
+    return version;
+  }
+
+  // Remove invalid characters
+  const sanitized = version.replace(/[^a-zA-Z0-9._-]/g, '');
+
+  // Return null if the sanitized version is empty
+  return sanitized.length > 0 ? sanitized : null;
+};
+
+/**
  * Reads toolkit version overrides from environment variables.
  *
  * Uses Effect's Config system to read env vars matching the pattern
@@ -61,7 +87,11 @@ export const getToolkitVersionOverrides: Effect.Effect<
       for (const [key, value] of HashMap.toEntries(hashMap)) {
         // Normalize toolkit name to lowercase and skip 'latest' values
         if (value && value !== 'latest') {
-          result.set(String.toLowerCase(key), value);
+          // Sanitize version string to only allow valid characters
+          const sanitizedVersion = sanitizeVersionString(value);
+          if (sanitizedVersion) {
+            result.set(String.toLowerCase(key), sanitizedVersion);
+          }
         }
       }
       return result;
@@ -105,8 +135,32 @@ export const groupByVersion = (
 ): Map<string, Lowercase<string>[]> => {
   const grouped = new Map<string, Lowercase<string>[]>();
   for (const spec of specs) {
-    const existing = grouped.get(spec.toolkitVersion) ?? [];
-    grouped.set(spec.toolkitVersion, [...existing, spec.toolkitSlug]);
+    const existing = grouped.get(spec.toolkitVersion);
+    if (existing) {
+      existing.push(spec.toolkitSlug);
+    } else {
+      grouped.set(spec.toolkitVersion, [spec.toolkitSlug]);
+    }
   }
   return grouped;
+};
+
+/**
+ * Builds a ToolkitVersionOverrides map from version specs, excluding 'latest' versions.
+ * This is the single source of truth for building version maps from specs.
+ *
+ * @example
+ * // Given specs: [{ toolkitSlug: 'gmail', toolkitVersion: '20250901_00' }, { toolkitSlug: 'slack', toolkitVersion: 'latest' }]
+ * // Returns: Map { "gmail" => "20250901_00" }
+ */
+export const buildVersionMapFromSpecs = (
+  specs: ReadonlyArray<ToolkitVersionSpec>
+): ToolkitVersionOverrides => {
+  const versionMap = new Map<Lowercase<string>, string>();
+  for (const spec of specs) {
+    if (spec.toolkitVersion !== 'latest') {
+      versionMap.set(spec.toolkitSlug, spec.toolkitVersion);
+    }
+  }
+  return versionMap;
 };

--- a/ts/packages/cli/src/effects/validate-toolkit-versions.ts
+++ b/ts/packages/cli/src/effects/validate-toolkit-versions.ts
@@ -1,0 +1,190 @@
+import { Console, Effect } from 'effect';
+import colors from 'picocolors';
+import { S_BAR, unicodeOr } from '@clack/prompts';
+import type {
+  ComposioToolkitsRepository,
+  InvalidVersionDetail,
+} from 'src/services/composio-clients';
+import type { ToolkitVersionOverrides } from './toolkit-version-overrides';
+
+/**
+ * Custom error class for invalid toolkit versions that preserves structured data.
+ * This allows consumers to access both the human-readable message and the machine-readable data.
+ */
+export class InvalidToolkitVersionsValidationError extends Error {
+  readonly invalidVersions: ReadonlyArray<InvalidVersionDetail>;
+
+  constructor(invalidVersions: ReadonlyArray<InvalidVersionDetail>) {
+    super(formatInvalidVersionsError(invalidVersions));
+    this.name = 'InvalidToolkitVersionsValidationError';
+    this.invalidVersions = invalidVersions;
+  }
+
+  /**
+   * Returns a JSON-serializable representation of the error for programmatic access.
+   */
+  toJSON(): { error: string; invalidVersions: ReadonlyArray<InvalidVersionDetail> } {
+    return {
+      error: this.name,
+      invalidVersions: this.invalidVersions,
+    };
+  }
+}
+
+const MAX_VERSIONS_TO_SHOW = 5;
+const S_CORNER_TOP_LEFT = unicodeOr('╭', '+');
+const S_CORNER_BOTTOM_LEFT = unicodeOr('╰', '+');
+const S_STEP_ERROR = unicodeOr('▲', 'x');
+
+/**
+ * Formats an InvalidToolkitVersionsError into a user-friendly error message.
+ *
+ * NOTE: We avoid using `: ` (colon-space) in the error message because effect-errors
+ * splits on that pattern and converts the result to an array, which then renders
+ * with commas instead of colons when converted back to string.
+ */
+export function formatInvalidVersionsError(
+  invalidVersions: ReadonlyArray<InvalidVersionDetail>
+): string {
+  const lines: string[] = [];
+
+  // Header
+  lines.push(
+    `${colors.red(S_STEP_ERROR)} ${colors.red('Invalid toolkit version override')}${invalidVersions.length > 1 ? 's' : ''}`
+  );
+  lines.push('');
+
+  for (let i = 0; i < invalidVersions.length; i++) {
+    const { toolkit, requestedVersion, availableVersions } = invalidVersions[i];
+    const isLast = i === invalidVersions.length - 1;
+    const connector = isLast ? S_CORNER_BOTTOM_LEFT : S_BAR;
+
+    // Toolkit header with version
+    lines.push(
+      `${colors.gray(connector)} ${colors.cyan(toolkit.toUpperCase())} ${colors.dim('→')} version ${colors.yellow(`"${requestedVersion}"`)} ${colors.red('not found')}`
+    );
+
+    // Available versions (use → instead of : to avoid effect-errors split issue)
+    if (availableVersions.length === 0) {
+      lines.push(
+        `${colors.gray(isLast ? ' ' : S_BAR)}   ${colors.dim('No versions available (toolkit may not support versioning)')}`
+      );
+    } else {
+      const versionsToShow = availableVersions.slice(0, MAX_VERSIONS_TO_SHOW);
+      const remaining = availableVersions.length - MAX_VERSIONS_TO_SHOW;
+
+      let versionList = versionsToShow.map(v => colors.green(v)).join(colors.dim(', '));
+      if (remaining > 0) {
+        versionList += colors.dim(` (+${remaining} more)`);
+      }
+
+      lines.push(
+        `${colors.gray(isLast ? ' ' : S_BAR)}   ${colors.dim('Available →')} ${versionList}`
+      );
+    }
+
+    // Tip (use → instead of : to avoid effect-errors split issue)
+    const envVarName = `COMPOSIO_TOOLKIT_VERSION_${toolkit.toUpperCase()}`;
+    lines.push(
+      `${colors.gray(isLast ? ' ' : S_BAR)}   ${colors.dim('Tip →')} Use ${colors.cyan('"latest"')} or unset ${colors.cyan(envVarName)}`
+    );
+
+    // Add spacing between toolkits (except for the last one)
+    if (!isLast) {
+      lines.push(colors.gray(S_BAR));
+    }
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Options for validateToolkitVersionOverrides
+ */
+export interface ValidateVersionsOptions {
+  /** Map of toolkit slug to requested version */
+  readonly versionOverrides: ToolkitVersionOverrides;
+  /** Optional array of toolkit slugs to filter (from --toolkits flag) */
+  readonly toolkitSlugsFilter: ReadonlyArray<string> | null;
+  /** The ComposioToolkitsRepository client */
+  readonly client: ComposioToolkitsRepository;
+}
+
+/**
+ * Result of version validation
+ */
+export interface ValidateVersionsResult {
+  /** The validated overrides (only includes relevant toolkits) */
+  readonly validatedOverrides: ToolkitVersionOverrides;
+}
+
+/**
+ * Validates toolkit version overrides before fetching data.
+ *
+ * This function should be called early in the generate command flow,
+ * before any tool/trigger data is fetched. It will:
+ * 1. Log detected version overrides
+ * 2. Validate versions against the API's available_versions
+ * 3. Warn about unused overrides (when --toolkits filter excludes them)
+ * 4. Fail with a descriptive error if any versions are invalid
+ *
+ * @example
+ * ```typescript
+ * const { validatedOverrides } = yield* validateToolkitVersionOverrides({
+ *   versionOverrides,
+ *   toolkitSlugsFilter,
+ *   client,
+ * });
+ * ```
+ */
+export const validateToolkitVersionOverrides = ({
+  versionOverrides,
+  toolkitSlugsFilter,
+  client,
+}: ValidateVersionsOptions): Effect.Effect<ValidateVersionsResult, Error> =>
+  Effect.gen(function* () {
+    // Skip if no overrides
+    if (versionOverrides.size === 0) {
+      return { validatedOverrides: versionOverrides };
+    }
+
+    // Log detected overrides
+    yield* Console.log('Detected toolkit version overrides:');
+    for (const [toolkit, version] of versionOverrides) {
+      yield* Console.log(`  - ${toolkit}: ${version}`);
+    }
+
+    yield* Console.log('Validating toolkit version overrides...');
+
+    const { validatedOverrides, warnings } = yield* client
+      .validateToolkitVersions(versionOverrides, toolkitSlugsFilter ?? undefined)
+      .pipe(
+        Effect.catchTag('services/InvalidToolkitVersionsError', error =>
+          Effect.fail(new InvalidToolkitVersionsValidationError(error.invalidVersions))
+        ),
+        Effect.catchTag('services/InvalidToolkitsError', error =>
+          Effect.fail(
+            new Error(
+              `Invalid toolkit(s) in version overrides: ${error.invalidToolkits.join(', ')}. ` +
+                `Check that the toolkit slug is correct (e.g., COMPOSIO_TOOLKIT_VERSION_GMAIL, not COMPOSIO_TOOLKIT_VERSION_GMAL).`
+            )
+          )
+        ),
+        Effect.catchTag('services/HttpServerError', error =>
+          Effect.fail(new Error(`Failed to validate toolkit versions: ${error.cause}`))
+        ),
+        Effect.catchTag('services/HttpDecodingError', error =>
+          Effect.fail(new Error(`Failed to decode toolkit response: ${error.cause}`))
+        ),
+        Effect.catchTag('NoSuchElementException', () =>
+          Effect.fail(new Error('API client not initialized'))
+        )
+      );
+
+    // Log warnings for unused overrides
+    for (const warning of warnings) {
+      yield* Console.warn(`Warning: ${warning}`);
+    }
+
+    return { validatedOverrides };
+  });

--- a/ts/packages/cli/src/effects/validate-toolkit-versions.ts
+++ b/ts/packages/cli/src/effects/validate-toolkit-versions.ts
@@ -32,7 +32,6 @@ export class InvalidToolkitVersionsValidationError extends Error {
 }
 
 const MAX_VERSIONS_TO_SHOW = 5;
-const S_CORNER_TOP_LEFT = unicodeOr('╭', '+');
 const S_CORNER_BOTTOM_LEFT = unicodeOr('╰', '+');
 const S_STEP_ERROR = unicodeOr('▲', 'x');
 

--- a/ts/packages/cli/src/generation/create-toolkit-index.ts
+++ b/ts/packages/cli/src/generation/create-toolkit-index.ts
@@ -3,6 +3,7 @@ import type { Simplify } from 'effect/Types';
 import { Toolkit, Toolkits, ToolkitName } from 'src/models/toolkits';
 import { ToolsAsEnums, Tools, ToolAsEnum, Tool } from 'src/models/tools';
 import { TriggerType, TriggerTypes } from 'src/models/trigger-types';
+import type { ToolkitVersionOverrides } from 'src/effects/toolkit-version-overrides';
 
 const startsWith =
   <const P extends string>(prefix: P) =>
@@ -13,10 +14,14 @@ interface CreateToolkitIndexInput {
   toolkits: Toolkits; // e.g., [ { slug: 'gmail', ... }]
   typeableTools: { withTypes: false; tools: ToolsAsEnums } | { withTypes: true; tools: Tools }; // e.g., [ 'GMAIL_SEND_EMAIL' ] | [ { slug: 'GMAIL_SEND_EMAIL', ... } ]
   triggerTypes: TriggerTypes; // e.g., [ { slug: 'GMAIL_NEW_EMAIL', ... } ]
+  /** Map of lowercase toolkit slug to version (only includes non-'latest' versions) */
+  versionMap?: ToolkitVersionOverrides;
 }
 
 export type ToolkitIndexData = Simplify<{
   slug: string;
+  /** Version override for this toolkit (only present if not 'latest') */
+  version?: string;
   typeableTools:
     | { withTypes: false; value: Record<`${ToolkitName}_${string}`, ToolAsEnum> }
     | { withTypes: true; value: Record<`${ToolkitName}_${string}`, Tool> };
@@ -31,6 +36,8 @@ export type ToolkitIndex = Record<ToolkitName, ToolkitIndexData>;
  * which is found by looking at the prefix of the tool or trigger type.
  */
 export function createToolkitIndex(input: CreateToolkitIndexInput): Simplify<ToolkitIndex> {
+  const { versionMap } = input;
+
   return pipe(
     input,
     groupByToolkits,
@@ -39,6 +46,9 @@ export function createToolkitIndex(input: CreateToolkitIndexInput): Simplify<Too
       const stripPrefix = String.slice(key.length + 1);
 
       const { slug } = value.toolkit;
+
+      // Look up version override for this toolkit (lowercase key lookup)
+      const version = versionMap?.get(String.toLowerCase(slug));
 
       const typeableTools = Match.value(value.typeableTools).pipe(
         Match.when({ withTypes: true }, ({ withTypes, tools }) => {
@@ -64,6 +74,8 @@ export function createToolkitIndex(input: CreateToolkitIndexInput): Simplify<Too
         key,
         {
           slug,
+          // Only include version if it's not 'latest' (i.e., was overridden)
+          ...(version ? { version } : {}),
           typeableTools,
           triggerTypes: Record.fromEntries(triggerTypes),
         },

--- a/ts/packages/cli/src/generation/python/generate-toolkit-sources.ts
+++ b/ts/packages/cli/src/generation/python/generate-toolkit-sources.ts
@@ -154,8 +154,11 @@ function generatePythonToolkitSource(banner: string) {
       return `${spacePad}pass`;
     };
 
-    const filesource = `# ${banner}.
+    // Build version comment if version override was used
+    const versionComment = toolkit.version ? `# @toolkit-version: ${toolkit.version}\n` : '';
 
+    const filesource = `# ${banner}.
+${versionComment}
 class ${toolkitName}:
     """Map of Composio's ${toolkitName} toolkit."""
 

--- a/ts/packages/cli/src/generation/typescript/generate-toolkit-sources.ts
+++ b/ts/packages/cli/src/generation/typescript/generate-toolkit-sources.ts
@@ -34,6 +34,66 @@ import {
   GenerateTypeFromJsonSchemaError,
 } from './generate-type-from-json-schema';
 
+function addToolkitToolInputsTypeMap(
+  file: ReturnType<typeof ts.file>,
+  toolkitName: ToolkitName,
+  typeableToolsValue: Record<string, unknown>
+) {
+  const toolInputTypeEntries = pipe(
+    typeableToolsValue,
+    Record.map((_, toolName) =>
+      ts.property(toolName, ts.namedType(`${toolkitName}_${toolName}_INPUT`))
+    ),
+    Record.toEntries,
+    Arr.map(([_, value]) => value)
+  );
+
+  const doc = ts.docComment(
+    `Type map of all available tool input types for toolkit "${toolkitName}".`
+  );
+
+  file.add(
+    ts
+      .moduleExport(
+        ts.typeDeclaration(
+          `${toolkitName}_TOOL_INPUTS`,
+          ts.objectType().addMultiple(toolInputTypeEntries)
+        )
+      )
+      .setDocComment(doc)
+  );
+}
+
+function addToolkitToolOutputsTypeMap(
+  file: ReturnType<typeof ts.file>,
+  toolkitName: ToolkitName,
+  typeableToolsValue: Record<string, unknown>
+) {
+  const toolOutputTypeEntries = pipe(
+    typeableToolsValue,
+    Record.map((_, toolName) =>
+      ts.property(toolName, ts.namedType(`${toolkitName}_${toolName}_OUTPUT`))
+    ),
+    Record.toEntries,
+    Arr.map(([_, value]) => value)
+  );
+
+  const doc = ts.docComment(
+    `Type map of all available tool input types for toolkit "${toolkitName}".`
+  );
+
+  file.add(
+    ts
+      .moduleExport(
+        ts.typeDeclaration(
+          `${toolkitName}_TOOL_OUTPUTS`,
+          ts.objectType().addMultiple(toolOutputTypeEntries)
+        )
+      )
+      .setDocComment(doc)
+  );
+}
+
 function jsValueToTsValue(value: unknown): ts.ValueBuilder {
   if (value === null) {
     return ts.namedValue('null');
@@ -78,7 +138,7 @@ function jsValueToTsValue(value: unknown): ts.ValueBuilder {
 /**
  * Generates a TypeScript object literal for a trigger type
  */
-function generateTriggerTypeObjectValue(triggerType: TriggerType): ts.ValueBuilder {
+function _generateTriggerTypeObjectValue(triggerType: TriggerType): ts.ValueBuilder {
   return ts
     .objectValue()
     .add(ts.propertyValue('slug', ts.stringLiteral(triggerType.slug).asValue()))
@@ -116,11 +176,16 @@ export function generateTypeScriptToolkitSources(banner: string) {
 function generateTypeScriptToolkitSource(_banner: string) {
   return (
     toolkitName: ToolkitName,
-    { slug, typeableTools, triggerTypes }: ToolkitIndexData
+    { slug, version, typeableTools, triggerTypes }: ToolkitIndexData
   ): Effect.Effect<SourceFile, GenerateTypeFromJsonSchemaError, never> => {
     return Effect.gen(function* () {
       const filename = `${slug}.ts`;
       const file = ts.file();
+
+      // Add toolkit version comment if a version override was used
+      if (version) {
+        file.add(ts.docSectionComment(`/* @toolkit-version: ${version} */`));
+      }
 
       // add `import { type TriggerEvent } from "@composio/core"`, if there are trigger types
       if (Object.keys(triggerTypes).length > 0) {
@@ -156,69 +221,29 @@ function generateTypeScriptToolkitSource(_banner: string) {
           file.add(
             ts
               .typeDeclaration(tool.slug, toolInputType)
-              .setDocComment(ts.docComment(`Type of ${toolkitName}'s ${tool.slug} tool input.`))
+              .setDocComment(
+                ts.docComment(
+                  `Type of ${toolkitName}'s ${tool.slug} tool input.${version ? `\n@toolkit-version: ${version}` : ''}`
+                )
+              )
           );
 
           file.add(
             ts
               .typeDeclaration(tool.slug, toolOutputType)
-              .setDocComment(ts.docComment(`Type of ${toolkitName}'s ${tool.slug} tool output.`))
+              .setDocComment(
+                ts.docComment(
+                  `Type of ${toolkitName}'s ${tool.slug} tool output.${version ? `\n@toolkit-version: ${version}` : ''}`
+                )
+              )
           );
         }
 
         // write the map of input tool types
-        {
-          const toolInputTypeEntries = pipe(
-            typeableTools.value,
-            Record.map((_, toolName) =>
-              ts.property(toolName, ts.namedType(`${toolkitName}_${toolName}_INPUT`))
-            ),
-            Record.toEntries,
-            Arr.map(([_, value]) => value)
-          );
-
-          const doc = ts.docComment(
-            `Type map of all available tool input types for toolkit "${toolkitName}".`
-          );
-
-          file.add(
-            ts
-              .moduleExport(
-                ts.typeDeclaration(
-                  `${toolkitName}_TOOL_INPUTS`,
-                  ts.objectType().addMultiple(toolInputTypeEntries)
-                )
-              )
-              .setDocComment(doc)
-          );
-        }
+        addToolkitToolInputsTypeMap(file, toolkitName, typeableTools.value);
 
         // write the map of output tool types
-        {
-          const toolOutputTypeEntries = pipe(
-            typeableTools.value,
-            Record.map((_, toolName) =>
-              ts.property(toolName, ts.namedType(`${toolkitName}_${toolName}_OUTPUT`))
-            ),
-            Record.toEntries,
-            Arr.map(([_, value]) => value)
-          );
-
-          const doc = ts.docComment(
-            `Type map of all available tool input types for toolkit "${toolkitName}".`
-          );
-
-          file.add(
-            ts
-              .moduleExport(
-                ts.typeDeclaration(
-                  `${toolkitName}_TOOL_OUTPUTS`,
-                  ts.objectType().addMultiple(toolOutputTypeEntries)
-                )
-              )
-              .setDocComment(doc)
-          );
-        }
+        addToolkitToolOutputsTypeMap(file, toolkitName, typeableTools.value);
       }
 
       file.add(
@@ -288,7 +313,11 @@ function generateTypeScriptToolkitSource(_banner: string) {
               .constDeclaration(toolValueDeclaration.name as string)
               .setValue(toolValueDeclaration.value)
           )
-          .setDocComment(ts.docComment(`Map of Composio's ${toolValueDeclaration.name} toolkit.`))
+          .setDocComment(
+            ts.docComment(
+              `Map of Composio's ${toolValueDeclaration.name} toolkit.${version ? `\n@toolkit-version: ${version}` : ''}`
+            )
+          )
       );
 
       // write the map of trigger payload types

--- a/ts/packages/cli/src/models/toolkits.ts
+++ b/ts/packages/cli/src/models/toolkits.ts
@@ -12,6 +12,7 @@ export const Toolkit = Schema.Struct({
     categories: Schema.Array(Schema.Unknown),
     created_at: Schema.DateTimeUtc, // "2024-05-03T11:44:32.061Z"
     updated_at: Schema.DateTimeUtc, // "2024-05-03T11:44:32.061Z"
+    available_versions: Schema.optionalWith(Schema.Array(Schema.String), { default: () => [] }),
   }),
   no_auth: Schema.Boolean,
 }).annotations({ identifier: 'Toolkit' });

--- a/ts/packages/cli/src/services/composio-clients-cached.ts
+++ b/ts/packages/cli/src/services/composio-clients-cached.ts
@@ -5,6 +5,7 @@ import { BunFileSystem } from '@effect/platform-bun';
 import { setupCacheDir } from 'src/effects/setup-cache-dir';
 import { FORCE_CONFIG } from 'src/effects/force-config';
 import { ComposioToolkitsRepository, InvalidToolkitsError } from './composio-clients';
+import type { ToolkitVersionSpec } from 'src/effects/toolkit-version-overrides';
 import { NodeOs } from './node-os';
 import { toolkitsFromJSON, toolkitsToJSON, type Toolkits } from 'src/models/toolkits';
 import {
@@ -215,6 +216,14 @@ export const ComposioToolkitsRepositoryCached = Layer.effect(
           underlyingRepository.getTools(toolkitSlugs),
           cacheFilter
         );
+      },
+
+      // Version-specific tools bypass cache because:
+      // 1. Different versions = different cache keys needed
+      // 2. Version-specific data shouldn't pollute the main cache
+      // The cache is mainly useful for 'latest' during repeated dev iterations.
+      getToolsByVersionSpecs: (specs: ReadonlyArray<ToolkitVersionSpec>) => {
+        return underlyingRepository.getToolsByVersionSpecs(specs);
       },
 
       // These methods don't need caching as they operate on already fetched data

--- a/ts/packages/cli/src/services/composio-clients-cached.ts
+++ b/ts/packages/cli/src/services/composio-clients-cached.ts
@@ -232,6 +232,12 @@ export const ComposioToolkitsRepositoryCached = Layer.effect(
       validateToolkits: toolkitSlugs => underlyingRepository.validateToolkits(toolkitSlugs),
       filterToolkitsBySlugs: (toolkits, toolkitSlugs) =>
         underlyingRepository.filterToolkitsBySlugs(toolkits, toolkitSlugs),
+      // Version validation should NOT be cached because:
+      // 1. available_versions can change frequently as new versions are released
+      // 2. Validation should always reflect the current API state
+      // 3. Caching validation results could cause false positives/negatives
+      validateToolkitVersions: (overrides, relevantToolkits) =>
+        underlyingRepository.validateToolkitVersions(overrides, relevantToolkits),
     });
   })
 ).pipe(

--- a/ts/packages/cli/src/services/composio-clients.ts
+++ b/ts/packages/cli/src/services/composio-clients.ts
@@ -15,6 +15,7 @@ import {
 import { Composio as _RawComposioClient, APIPromise } from '@composio/client';
 import { Toolkit, Toolkits } from 'src/models/toolkits';
 import { ToolsAsEnums, Tools, Tool } from 'src/models/tools';
+import { groupByVersion, type ToolkitVersionSpec } from 'src/effects/toolkit-version-overrides';
 import { Session, RetrievedSession } from 'src/models/session';
 import { TriggerType, TriggerTypes, TriggerTypesAsEnums } from 'src/models/trigger-types';
 import { ComposioUserContext, ComposioUserContextLive } from './user-context';
@@ -510,22 +511,54 @@ export class ComposioClientLive extends Effect.Service<ComposioClientLive>()(
             ),
           /**
            * Retrieve a list of tools, automatically handling pagination.
-           * @param toolkitSlugs - Optional array of toolkit slugs to filter by
+           * It always fetches the latest version of tools for each toolkit.
+           * For more granular toolkit version control, use `listByVersionSpecs`.
+           * @param toolkitSlugs - Array of toolkit slugs to filter by
            */
-          list: (toolkitSlugs?: ReadonlyArray<string>) =>
+          list: (toolkitSlugs: ReadonlyArray<string>) =>
             withMetrics(
               callClientWithPagination(
                 clientSingleton,
                 (client, cursor, limit) =>
                   client.tools.list({
                     cursor,
-                    toolkit_slug: toolkitSlugs?.length ? toolkitSlugs.join(',') : undefined,
+                    toolkit_slug: toolkitSlugs.length > 0 ? toolkitSlugs.join(',') : undefined,
                     toolkit_versions: 'latest',
                     limit,
                   }),
                 ToolsResponse
               )
             ),
+          /**
+           * Retrieve tools for multiple toolkits, grouped by version.
+           * Makes separate API calls for each version group, then merges results.
+           * @param specs - Array of toolkit version specifications
+           */
+          listByVersionSpecs: (specs: ReadonlyArray<ToolkitVersionSpec>) =>
+            Effect.gen(function* () {
+              const grouped = groupByVersion(specs);
+              const allTools: Tool[] = [];
+
+              for (const [version, slugs] of grouped) {
+                // Fetch all toolkits with same version in one call
+                const response = yield* withMetrics(
+                  callClientWithPagination(
+                    clientSingleton,
+                    (client, cursor, limit) =>
+                      client.tools.list({
+                        cursor,
+                        toolkit_slug: slugs.join(','),
+                        toolkit_versions: version,
+                        limit,
+                      }),
+                    ToolsResponse
+                  )
+                );
+                allTools.push(...response.items);
+              }
+
+              return { items: allTools };
+            }),
         },
         triggersTypes: {
           /**
@@ -655,7 +688,24 @@ export class ComposioToolkitsRepository extends Effect.Service<ComposioToolkitsR
          * @param toolkitSlugs - Optional array of toolkit slugs to filter by
          */
         getTools: (toolkitSlugs?: ReadonlyArray<string>) =>
-          client.tools.list(toolkitSlugs).pipe(
+          client.tools.list(toolkitSlugs ?? []).pipe(
+            Effect.map(response => response.items),
+            Effect.flatMap(
+              Effect.fn(function* (tools) {
+                // Sort apps by slug.
+                // TODO: make sure this happens on the server-side.
+                const orderBySlug = Order.mapInput(Order.string, (app: Tool) => app.slug);
+                return Array.sort(tools, orderBySlug) as ReadonlyArray<Tool>;
+              })
+            )
+          ),
+        /**
+         * Fetches tools with per-toolkit version support.
+         * Groups toolkits by version and makes separate API calls for each group.
+         * @param specs - Array of { toolkitSlug, toolkitVersion } specifications
+         */
+        getToolsByVersionSpecs: (specs: ReadonlyArray<ToolkitVersionSpec>) =>
+          client.tools.listByVersionSpecs(specs).pipe(
             Effect.map(response => response.items),
             Effect.flatMap(
               Effect.fn(function* (tools) {

--- a/ts/packages/cli/src/services/composio-clients.ts
+++ b/ts/packages/cli/src/services/composio-clients.ts
@@ -15,7 +15,11 @@ import {
 import { Composio as _RawComposioClient, APIPromise } from '@composio/client';
 import { Toolkit, Toolkits } from 'src/models/toolkits';
 import { ToolsAsEnums, Tools, Tool } from 'src/models/tools';
-import { groupByVersion, type ToolkitVersionSpec } from 'src/effects/toolkit-version-overrides';
+import {
+  groupByVersion,
+  type ToolkitVersionSpec,
+  type ToolkitVersionOverrides,
+} from 'src/effects/toolkit-version-overrides';
 import { Session, RetrievedSession } from 'src/models/session';
 import { TriggerType, TriggerTypes, TriggerTypesAsEnums } from 'src/models/trigger-types';
 import { ComposioUserContext, ComposioUserContextLive } from './user-context';
@@ -43,6 +47,24 @@ export class InvalidToolkitsError extends Data.TaggedError('services/InvalidTool
 }> {}
 
 /**
+ * Details about a single invalid version override.
+ */
+export interface InvalidVersionDetail {
+  readonly toolkit: string;
+  readonly requestedVersion: string;
+  readonly availableVersions: ReadonlyArray<string>;
+}
+
+/**
+ * Error thrown when one or more toolkit version overrides are invalid.
+ */
+export class InvalidToolkitVersionsError extends Data.TaggedError(
+  'services/InvalidToolkitVersionsError'
+)<{
+  readonly invalidVersions: ReadonlyArray<InvalidVersionDetail>;
+}> {}
+
+/**
  * Error thrown when a HTTP response doesn't match the expected response schema.
  */
 export class HttpDecodingError extends Data.TaggedError('services/HttpDecodingError')<{
@@ -50,6 +72,131 @@ export class HttpDecodingError extends Data.TaggedError('services/HttpDecodingEr
 }> {}
 
 export type HttpError = HttpServerError | HttpDecodingError;
+
+const validateToolkitVersionsImpl = (
+  client: {
+    toolkits: {
+      retrieve: (slug: string) => Effect.Effect<Toolkit, HttpError | NoSuchElementException, never>;
+    };
+  },
+  overrides: ToolkitVersionOverrides,
+  relevantToolkits?: ReadonlyArray<string>
+): Effect.Effect<
+  {
+    validatedOverrides: ToolkitVersionOverrides;
+    warnings: ReadonlyArray<string>;
+  },
+  InvalidToolkitVersionsError | InvalidToolkitsError | HttpError | NoSuchElementException
+> =>
+  Effect.gen(function* () {
+    const determineOverridesToValidate = (
+      overrides: ToolkitVersionOverrides,
+      relevantToolkits?: ReadonlyArray<string>
+    ): {
+      overridesToValidate: Array<[toolkit: string, requestedVersion: string]>;
+      warnings: Array<string>;
+    } => {
+      const warnings: string[] = [];
+      const overridesToValidate: Array<[toolkit: string, requestedVersion: string]> = [];
+
+      if (relevantToolkits) {
+        const relevantSet = new Set(relevantToolkits.map(s => String.toLowerCase(s)));
+
+        for (const [toolkit, version] of overrides) {
+          if (relevantSet.has(toolkit)) {
+            overridesToValidate.push([toolkit, version]);
+          } else {
+            warnings.push(
+              `Version override for "${toolkit}" will be ignored (toolkit not in --toolkits filter)`
+            );
+          }
+        }
+      } else {
+        overridesToValidate.push(...overrides.entries());
+      }
+
+      return { overridesToValidate, warnings };
+    };
+
+    const fetchToolkitVersionValidationResults = (
+      overridesToValidate: ReadonlyArray<[toolkit: string, requestedVersion: string]>
+    ): Effect.Effect<
+      ReadonlyArray<{
+        toolkit: string;
+        requestedVersion: string;
+        availableVersions: ReadonlyArray<string>;
+        isValid: boolean;
+      }>,
+      InvalidToolkitsError | HttpError | NoSuchElementException
+    > =>
+      Effect.all(
+        overridesToValidate.map(([toolkit, requestedVersion]) =>
+          client.toolkits.retrieve(toolkit).pipe(
+            Effect.map(toolkitData => ({
+              toolkit,
+              requestedVersion,
+              availableVersions: toolkitData.meta.available_versions,
+              isValid: toolkitData.meta.available_versions.includes(requestedVersion),
+            })),
+            Effect.catchTag('services/HttpServerError', e =>
+              Effect.if(e.status === 404, {
+                onTrue: () =>
+                  Effect.fail(
+                    new InvalidToolkitsError({
+                      invalidToolkits: [toolkit],
+                      availableToolkits: [],
+                    })
+                  ),
+                onFalse: () => Effect.fail(e),
+              })
+            )
+          )
+        ),
+        { concurrency: MAX_CONCURRENT_REQUESTS_PER_ENDPOINT }
+      );
+
+    const collectInvalidVersions = (
+      validationResults: ReadonlyArray<{
+        toolkit: string;
+        requestedVersion: string;
+        availableVersions: ReadonlyArray<string>;
+        isValid: boolean;
+      }>
+    ): ReadonlyArray<InvalidVersionDetail> =>
+      validationResults
+        .filter(result => !result.isValid)
+        .map(result => ({
+          toolkit: result.toolkit,
+          requestedVersion: result.requestedVersion,
+          availableVersions: result.availableVersions,
+        }));
+
+    if (overrides.size === 0) {
+      return { validatedOverrides: overrides, warnings: [] as ReadonlyArray<string> };
+    }
+
+    const { overridesToValidate, warnings } = determineOverridesToValidate(
+      overrides,
+      relevantToolkits
+    );
+
+    if (overridesToValidate.length === 0) {
+      return {
+        validatedOverrides: new Map() as ToolkitVersionOverrides,
+        warnings: warnings as ReadonlyArray<string>,
+      };
+    }
+
+    const validationResults = yield* fetchToolkitVersionValidationResults(overridesToValidate);
+    const invalidVersions = collectInvalidVersions(validationResults);
+
+    if (invalidVersions.length > 0) {
+      return yield* Effect.fail(new InvalidToolkitVersionsError({ invalidVersions }));
+    }
+
+    const validatedOverrides = new Map(overridesToValidate) as ToolkitVersionOverrides;
+    return { validatedOverrides, warnings: warnings as ReadonlyArray<string> };
+  });
 
 /**
  * Response schemas
@@ -82,6 +229,7 @@ export const ToolkitRetrieveResponse = Schema.Struct({
     categories: Schema.optionalWith(Schema.Array(Schema.Unknown), { default: () => [] }),
     created_at: Schema.DateTimeUtc,
     updated_at: Schema.DateTimeUtc,
+    available_versions: Schema.optionalWith(Schema.Array(Schema.String), { default: () => [] }),
   }),
 }).annotations({ identifier: 'ToolkitRetrieveResponse' });
 export type ToolkitRetrieveResponse = Schema.Schema.Type<typeof ToolkitRetrieveResponse>;
@@ -531,32 +679,36 @@ export class ComposioClientLive extends Effect.Service<ComposioClientLive>()(
             ),
           /**
            * Retrieve tools for multiple toolkits, grouped by version.
-           * Makes separate API calls for each version group, then merges results.
+           * Makes parallel API calls for each version group, then merges results.
            * @param specs - Array of toolkit version specifications
            */
           listByVersionSpecs: (specs: ReadonlyArray<ToolkitVersionSpec>) =>
             Effect.gen(function* () {
               const grouped = groupByVersion(specs);
-              const allTools: Tool[] = [];
+              const versionGroups = [...grouped.entries()];
 
-              for (const [version, slugs] of grouped) {
-                // Fetch all toolkits with same version in one call
-                const response = yield* withMetrics(
-                  callClientWithPagination(
-                    clientSingleton,
-                    (client, cursor, limit) =>
-                      client.tools.list({
-                        cursor,
-                        toolkit_slug: slugs.join(','),
-                        toolkit_versions: version,
-                        limit,
-                      }),
-                    ToolsResponse
+              // Fetch all version groups in parallel with bounded concurrency
+              const responses = yield* Effect.all(
+                versionGroups.map(([version, slugs]) =>
+                  withMetrics(
+                    callClientWithPagination(
+                      clientSingleton,
+                      (client, cursor, limit) =>
+                        client.tools.list({
+                          cursor,
+                          toolkit_slug: slugs.join(','),
+                          toolkit_versions: version,
+                          limit,
+                        }),
+                      ToolsResponse
+                    )
                   )
-                );
-                allTools.push(...response.items);
-              }
+                ),
+                { concurrency: MAX_CONCURRENT_REQUESTS_PER_ENDPOINT }
+              );
 
+              // Merge all tools from all version groups
+              const allTools = responses.flatMap(response => response.items);
               return { items: allTools };
             }),
         },
@@ -781,6 +933,24 @@ export class ComposioToolkitsRepository extends Effect.Service<ComposioToolkitsR
           const normalizedSlugs = new Set(toolkitSlugs.map(slug => String.toLowerCase(slug)));
           return toolkits.filter(toolkit => normalizedSlugs.has(String.toLowerCase(toolkit.slug)));
         },
+        /**
+         * Validates that the requested toolkit versions exist in the API's available_versions.
+         * Makes parallel API calls to fetch toolkit metadata for validation.
+         *
+         * @param overrides - Map of toolkit slug to requested version
+         * @param relevantToolkits - Optional array of toolkit slugs to validate (if --toolkits filter is used)
+         * @returns Effect that succeeds with the validated overrides and warnings, or fails with InvalidToolkitVersionsError
+         */
+        validateToolkitVersions: (
+          overrides: ToolkitVersionOverrides,
+          relevantToolkits?: ReadonlyArray<string>
+        ): Effect.Effect<
+          {
+            validatedOverrides: ToolkitVersionOverrides;
+            warnings: ReadonlyArray<string>;
+          },
+          InvalidToolkitVersionsError | InvalidToolkitsError | HttpError | NoSuchElementException
+        > => validateToolkitVersionsImpl(client, overrides, relevantToolkits),
       };
     }),
     dependencies: [ComposioClientLive.Default],

--- a/ts/packages/cli/test/__utils__/services/test-layer.ts
+++ b/ts/packages/cli/test/__utils__/services/test-layer.ts
@@ -23,7 +23,10 @@ import {
   ComposioSessionRepository,
   ComposioToolkitsRepository,
   InvalidToolkitsError,
+  InvalidToolkitVersionsError,
+  type InvalidVersionDetail,
 } from 'src/services/composio-clients';
+import type { ToolkitVersionOverrides } from 'src/effects/toolkit-version-overrides';
 import { EnvLangDetector } from 'src/services/env-lang-detector';
 import { JsPackageManagerDetector } from 'src/services/js-package-manager-detector';
 import type { Tools } from 'src/models/tools';
@@ -159,6 +162,55 @@ export const TestLayer = (input?: TestLiveInput) =>
             prefixes.some(p => t.slug.toUpperCase().startsWith(p))
           );
           return Effect.succeed(tools);
+        },
+        validateToolkitVersions: (
+          overrides: ToolkitVersionOverrides,
+          relevantToolkits?: ReadonlyArray<string>
+        ) => {
+          // Mock implementation that validates against test fixture
+          const invalidVersions: InvalidVersionDetail[] = [];
+          const warnings: string[] = [];
+
+          for (const [toolkit, version] of overrides) {
+            // Check if toolkit should be validated
+            if (relevantToolkits && !relevantToolkits.map(s => s.toLowerCase()).includes(toolkit)) {
+              warnings.push(`Version override for "${toolkit}" will be ignored`);
+              continue;
+            }
+
+            // Check if toolkit exists in the fixture
+            const toolkitExists = toolkitsData.toolkits.some(
+              t => String.toLowerCase(t.slug) === toolkit
+            );
+
+            if (!toolkitExists) {
+              return Effect.fail(
+                new InvalidToolkitsError({
+                  invalidToolkits: [toolkit],
+                  availableToolkits: toolkitsData.toolkits.map(t => t.slug),
+                })
+              );
+            }
+
+            // Mock: only accept 'latest' or versions matching pattern YYYYMMDD_NN
+            const validPattern = /^\d{8}_\d{2}$/;
+            if (version !== 'latest' && !validPattern.test(version)) {
+              invalidVersions.push({
+                toolkit,
+                requestedVersion: version,
+                availableVersions: ['20250901_00', '20250815_00', '20250710_00'],
+              });
+            }
+          }
+
+          if (invalidVersions.length > 0) {
+            return Effect.fail(new InvalidToolkitVersionsError({ invalidVersions }));
+          }
+
+          return Effect.succeed({
+            validatedOverrides: overrides,
+            warnings: warnings as ReadonlyArray<string>,
+          });
         },
       })
     );

--- a/ts/packages/cli/test/__utils__/services/test-layer.ts
+++ b/ts/packages/cli/test/__utils__/services/test-layer.ts
@@ -28,6 +28,7 @@ import { EnvLangDetector } from 'src/services/env-lang-detector';
 import { JsPackageManagerDetector } from 'src/services/js-package-manager-detector';
 import type { Tools } from 'src/models/tools';
 import type { TriggerTypes, TriggerTypesAsEnums } from 'src/models/trigger-types';
+import type { ToolkitVersionSpec } from 'src/effects/toolkit-version-overrides';
 import { ComposioUserContextLive } from 'src/services/user-context';
 import { UpgradeBinary } from 'src/services/upgrade-binary';
 import { NodeOs } from 'src/services/node-os';
@@ -149,6 +150,15 @@ export const TestLayer = (input?: TestLiveInput) =>
         filterToolkitsBySlugs: (toolkits, toolkitSlugs) => {
           const normalizedSlugs = new Set(toolkitSlugs.map(slug => String.toLowerCase(slug)));
           return toolkits.filter(toolkit => normalizedSlugs.has(String.toLowerCase(toolkit.slug)));
+        },
+        getToolsByVersionSpecs: (specs: ReadonlyArray<ToolkitVersionSpec>) => {
+          // Filter tools based on toolkit slugs from specs
+          const toolkitSlugs = specs.map(s => s.toolkitSlug.toUpperCase());
+          const prefixes = toolkitSlugs.map(s => `${s}_`);
+          const tools = toolkitsData.tools.filter(t =>
+            prefixes.some(p => t.slug.toUpperCase().startsWith(p))
+          );
+          return Effect.succeed(tools);
         },
       })
     );

--- a/ts/packages/cli/test/src/commands/$default.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/$default.cmd.test.ts
@@ -72,11 +72,19 @@ describe('CLI: composio', () => {
 
             - py                                                                                                       Handle Python projects.
 
-            - py generate [(-o, --output-dir directory)] --toolkits text...                                            Generate Python type stubs for toolkits, tools, and triggers from the Composio API
+            - py generate [(-o, --output-dir directory)] --toolkits text...                                            Generate Python type stubs for toolkits, tools, and triggers from the Composio API.
+
+          Environment Variables:
+            COMPOSIO_TOOLKIT_VERSION_<TOOLKIT>  Override toolkit version (e.g., COMPOSIO_TOOLKIT_VERSION_GMAIL=20250901_00)
+                                                Use "latest" or unset to use the latest version.
 
             - ts                                                                                                       Handle TypeScript projects.
 
-            - ts generate [(-o, --output-dir directory)] [--compact] [--transpiled] [--type-tools] --toolkits text...  Generate TypeScript types for toolkits, tools, and triggers from the Composio API
+            - ts generate [(-o, --output-dir directory)] [--compact] [--transpiled] [--type-tools] --toolkits text...  Generate TypeScript types for toolkits, tools, and triggers from the Composio API.
+
+          Environment Variables:
+            COMPOSIO_TOOLKIT_VERSION_<TOOLKIT>  Override toolkit version (e.g., COMPOSIO_TOOLKIT_VERSION_GMAIL=20250901_00)
+                                                Use "latest" or unset to use the latest version.
           "
         `);
       })

--- a/ts/packages/cli/test/src/commands/py/py.generate.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/py/py.generate.cmd.test.ts
@@ -390,5 +390,133 @@ describe('CLI: composio py generate', () => {
         })
       );
     });
+
+    describe('[Given] COMPOSIO_TOOLKIT_VERSION_* env vars', () => {
+      it.scoped(
+        '[Given] COMPOSIO_TOOLKIT_VERSION_GMAIL env var [Then] it adds version comment to generated file',
+        () =>
+          Effect.gen(function* () {
+            const { vi } = yield* Effect.promise(() => import('vitest'));
+            vi.stubEnv('COMPOSIO_TOOLKIT_VERSION_GMAIL', '20250901_00');
+
+            const process = yield* NodeProcess;
+            const cwd = process.cwd;
+            const fs = yield* FileSystem.FileSystem;
+            const outputDir = path.join(cwd, '.generated', 'composio-py-version');
+
+            const args = ['py', 'generate', '--output-dir', outputDir];
+            yield* cli(args);
+
+            // Check that gmail.py contains the version comment
+            const gmailSourceCode = yield* fs.readFileString(path.join(outputDir, 'gmail.py'));
+            expect(gmailSourceCode).toContain('# @toolkit-version: 20250901_00');
+
+            // Check that slack.py does NOT contain a version comment
+            const slackSourceCode = yield* fs.readFileString(path.join(outputDir, 'slack.py'));
+            expect(slackSourceCode).not.toContain('@toolkit-version');
+
+            vi.unstubAllEnvs();
+          })
+      );
+
+      it.scoped(
+        '[Given] multiple COMPOSIO_TOOLKIT_VERSION_* env vars [Then] it adds version comments to both generated files',
+        () =>
+          Effect.gen(function* () {
+            const { vi } = yield* Effect.promise(() => import('vitest'));
+            vi.stubEnv('COMPOSIO_TOOLKIT_VERSION_GMAIL', '20250901_00');
+            vi.stubEnv('COMPOSIO_TOOLKIT_VERSION_SLACK', '20250815_00');
+
+            const process = yield* NodeProcess;
+            const cwd = process.cwd;
+            const fs = yield* FileSystem.FileSystem;
+            const outputDir = path.join(cwd, '.generated', 'composio-py-multi-version');
+
+            const args = ['py', 'generate', '--output-dir', outputDir];
+            yield* cli(args);
+
+            const gmailSourceCode = yield* fs.readFileString(path.join(outputDir, 'gmail.py'));
+            expect(gmailSourceCode).toContain('# @toolkit-version: 20250901_00');
+
+            const slackSourceCode = yield* fs.readFileString(path.join(outputDir, 'slack.py'));
+            expect(slackSourceCode).toContain('# @toolkit-version: 20250815_00');
+
+            vi.unstubAllEnvs();
+          })
+      );
+
+      it.scoped(
+        '[Given] COMPOSIO_TOOLKIT_VERSION_GMAIL=latest [Then] it treats same as no override (no version comment)',
+        () =>
+          Effect.gen(function* () {
+            const { vi } = yield* Effect.promise(() => import('vitest'));
+            vi.stubEnv('COMPOSIO_TOOLKIT_VERSION_GMAIL', 'latest');
+
+            const process = yield* NodeProcess;
+            const cwd = process.cwd;
+            const fs = yield* FileSystem.FileSystem;
+            const outputDir = path.join(cwd, '.generated', 'composio-py-latest');
+
+            const args = ['py', 'generate', '--output-dir', outputDir];
+            yield* cli(args);
+
+            const gmailSourceCode = yield* fs.readFileString(path.join(outputDir, 'gmail.py'));
+            expect(gmailSourceCode).not.toContain('@toolkit-version');
+
+            vi.unstubAllEnvs();
+          })
+      );
+
+      it.scoped(
+        '[Given] --toolkits gmail and COMPOSIO_TOOLKIT_VERSION_SLACK env var [Then] it ignores env var for non-requested toolkit',
+        () =>
+          Effect.gen(function* () {
+            const { vi } = yield* Effect.promise(() => import('vitest'));
+            vi.stubEnv('COMPOSIO_TOOLKIT_VERSION_SLACK', '20250815_00');
+
+            const process = yield* NodeProcess;
+            const cwd = process.cwd;
+            const fs = yield* FileSystem.FileSystem;
+            const outputDir = path.join(cwd, '.generated', 'composio-py-filtered-env');
+
+            const args = ['py', 'generate', '--toolkits', 'gmail', '--output-dir', outputDir];
+            yield* cli(args);
+
+            // Only gmail.py should exist
+            const files = yield* fs.readDirectory(outputDir);
+            const fileNames = files.map(file => path.basename(file));
+            expect(fileNames).toContain('gmail.py');
+            expect(fileNames).not.toContain('slack.py');
+
+            // gmail.py should NOT have version comment
+            const gmailSourceCode = yield* fs.readFileString(path.join(outputDir, 'gmail.py'));
+            expect(gmailSourceCode).not.toContain('@toolkit-version');
+
+            vi.unstubAllEnvs();
+          })
+      );
+
+      it.scoped(
+        '[Given] --toolkits gmail and COMPOSIO_TOOLKIT_VERSION_GMAIL env var [Then] it applies version override to filtered toolkit',
+        () =>
+          Effect.gen(function* () {
+            const { vi } = yield* Effect.promise(() => import('vitest'));
+            vi.stubEnv('COMPOSIO_TOOLKIT_VERSION_GMAIL', '20250901_00');
+
+            const process = yield* NodeProcess;
+            const cwd = process.cwd;
+            const fs = yield* FileSystem.FileSystem;
+            const outputDir = path.join(cwd, '.generated', 'composio-py-filtered-version');
+
+            const args = ['py', 'generate', '--toolkits', 'gmail', '--output-dir', outputDir];
+            yield* cli(args);
+
+            const gmailSourceCode = yield* fs.readFileString(path.join(outputDir, 'gmail.py'));
+            expect(gmailSourceCode).toContain('# @toolkit-version: 20250901_00');
+
+            vi.unstubAllEnvs();
+          })
+      );
+    });
   });
 });

--- a/ts/packages/cli/test/src/commands/ts/ts.generate.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/ts/ts.generate.cmd.test.ts
@@ -1057,6 +1057,194 @@ describe('CLI: composio ts generate', () => {
       });
     });
 
+    describe('[Given] COMPOSIO_TOOLKIT_VERSION_* env vars', () => {
+      layer(
+        TestLive({
+          fixture: 'typescript-project-with-composio-core',
+          toolkitsData: appClientData,
+        })
+      )(it => {
+        it.scoped(
+          '[Given] --type-tools and COMPOSIO_TOOLKIT_VERSION_GMAIL env var [Then] it adds version comment to generated file',
+          () =>
+            Effect.gen(function* () {
+              const { vi } = yield* Effect.promise(() => import('vitest'));
+              vi.stubEnv('COMPOSIO_TOOLKIT_VERSION_GMAIL', '20250901_00');
+
+              const process = yield* NodeProcess;
+              const cwd = process.cwd;
+              const fs = yield* FileSystem.FileSystem;
+              const outputDir = path.join(cwd, 'generated-version-override');
+
+              const args = ['ts', 'generate', '--type-tools', '--output-dir', outputDir];
+              yield* cli(args);
+
+              // Check that gmail.ts contains the version comment
+              const gmailSourceCode = yield* fs.readFileString(path.join(outputDir, 'gmail.ts'));
+              expect(gmailSourceCode).toContain('@toolkit-version: 20250901_00');
+
+              // Check that slack.ts does NOT contain a version comment (no override for it)
+              const slackSourceCode = yield* fs.readFileString(path.join(outputDir, 'slack.ts'));
+              expect(slackSourceCode).not.toContain('@toolkit-version');
+
+              vi.unstubAllEnvs();
+            })
+        );
+
+        it.scoped(
+          '[Given] --type-tools and multiple COMPOSIO_TOOLKIT_VERSION_* env vars [Then] it adds version comments to both generated files',
+          () =>
+            Effect.gen(function* () {
+              const { vi } = yield* Effect.promise(() => import('vitest'));
+              vi.stubEnv('COMPOSIO_TOOLKIT_VERSION_GMAIL', '20250901_00');
+              vi.stubEnv('COMPOSIO_TOOLKIT_VERSION_SLACK', '20250815_00');
+
+              const process = yield* NodeProcess;
+              const cwd = process.cwd;
+              const fs = yield* FileSystem.FileSystem;
+              const outputDir = path.join(cwd, 'generated-multi-version-override');
+
+              const args = ['ts', 'generate', '--type-tools', '--output-dir', outputDir];
+              yield* cli(args);
+
+              // Check that gmail.ts contains the version comment
+              const gmailSourceCode = yield* fs.readFileString(path.join(outputDir, 'gmail.ts'));
+              expect(gmailSourceCode).toContain('@toolkit-version: 20250901_00');
+
+              // Check that slack.ts contains the version comment
+              const slackSourceCode = yield* fs.readFileString(path.join(outputDir, 'slack.ts'));
+              expect(slackSourceCode).toContain('@toolkit-version: 20250815_00');
+
+              vi.unstubAllEnvs();
+            })
+        );
+
+        it.scoped(
+          '[Given] --type-tools and COMPOSIO_TOOLKIT_VERSION_GMAIL=latest [Then] it treats same as no override (no version comment)',
+          () =>
+            Effect.gen(function* () {
+              const { vi } = yield* Effect.promise(() => import('vitest'));
+              vi.stubEnv('COMPOSIO_TOOLKIT_VERSION_GMAIL', 'latest');
+
+              const process = yield* NodeProcess;
+              const cwd = process.cwd;
+              const fs = yield* FileSystem.FileSystem;
+              const outputDir = path.join(cwd, 'generated-latest-version');
+
+              const args = ['ts', 'generate', '--type-tools', '--output-dir', outputDir];
+              yield* cli(args);
+
+              // Check that gmail.ts does NOT contain a version comment
+              const gmailSourceCode = yield* fs.readFileString(path.join(outputDir, 'gmail.ts'));
+              expect(gmailSourceCode).not.toContain('@toolkit-version');
+
+              vi.unstubAllEnvs();
+            })
+        );
+
+        it.scoped(
+          '[Given] --toolkits gmail and COMPOSIO_TOOLKIT_VERSION_SLACK env var [Then] it ignores env var for non-requested toolkit',
+          () =>
+            Effect.gen(function* () {
+              const { vi } = yield* Effect.promise(() => import('vitest'));
+              // Set env var for SLACK, but only request GMAIL toolkit
+              vi.stubEnv('COMPOSIO_TOOLKIT_VERSION_SLACK', '20250815_00');
+
+              const process = yield* NodeProcess;
+              const cwd = process.cwd;
+              const fs = yield* FileSystem.FileSystem;
+              const outputDir = path.join(cwd, 'generated-filtered-env-ignored');
+
+              const args = [
+                'ts',
+                'generate',
+                '--type-tools',
+                '--toolkits',
+                'gmail',
+                '--output-dir',
+                outputDir,
+              ];
+              yield* cli(args);
+
+              // Check generated files - only gmail.ts should exist
+              const files = yield* fs.readDirectory(outputDir);
+              const fileNames = files.map(file => path.basename(file));
+              expect(fileNames).toContain('gmail.ts');
+              expect(fileNames).toContain('index.ts');
+              expect(fileNames).not.toContain('slack.ts');
+
+              // gmail.ts should NOT have version comment (no GMAIL override set)
+              const gmailSourceCode = yield* fs.readFileString(path.join(outputDir, 'gmail.ts'));
+              expect(gmailSourceCode).not.toContain('@toolkit-version');
+
+              vi.unstubAllEnvs();
+            })
+        );
+
+        it.scoped(
+          '[Given] --toolkits gmail and COMPOSIO_TOOLKIT_VERSION_GMAIL env var [Then] it applies version override to filtered toolkit',
+          () =>
+            Effect.gen(function* () {
+              const { vi } = yield* Effect.promise(() => import('vitest'));
+              vi.stubEnv('COMPOSIO_TOOLKIT_VERSION_GMAIL', '20250901_00');
+
+              const process = yield* NodeProcess;
+              const cwd = process.cwd;
+              const fs = yield* FileSystem.FileSystem;
+              const outputDir = path.join(cwd, 'generated-filtered-with-version');
+
+              const args = [
+                'ts',
+                'generate',
+                '--type-tools',
+                '--toolkits',
+                'gmail',
+                '--output-dir',
+                outputDir,
+              ];
+              yield* cli(args);
+
+              // Check generated files - only gmail.ts should exist
+              const files = yield* fs.readDirectory(outputDir);
+              const fileNames = files.map(file => path.basename(file));
+              expect(fileNames).toContain('gmail.ts');
+              expect(fileNames).not.toContain('slack.ts');
+
+              // gmail.ts should have version comment
+              const gmailSourceCode = yield* fs.readFileString(path.join(outputDir, 'gmail.ts'));
+              expect(gmailSourceCode).toContain('@toolkit-version: 20250901_00');
+
+              vi.unstubAllEnvs();
+            })
+        );
+
+        it.scoped(
+          '[Given] no --type-tools and COMPOSIO_TOOLKIT_VERSION_GMAIL env var [Then] it still adds version comment for documentation purposes',
+          () =>
+            Effect.gen(function* () {
+              const { vi } = yield* Effect.promise(() => import('vitest'));
+              vi.stubEnv('COMPOSIO_TOOLKIT_VERSION_GMAIL', '20250901_00');
+
+              const process = yield* NodeProcess;
+              const cwd = process.cwd;
+              const fs = yield* FileSystem.FileSystem;
+              const outputDir = path.join(cwd, 'generated-no-type-tools');
+
+              // Note: no --type-tools flag
+              const args = ['ts', 'generate', '--output-dir', outputDir];
+              yield* cli(args);
+
+              // Version comment is still added for documentation purposes,
+              // even though the version override only affects tool schema fetching with --type-tools
+              const gmailSourceCode = yield* fs.readFileString(path.join(outputDir, 'gmail.ts'));
+              expect(gmailSourceCode).toContain('@toolkit-version: 20250901_00');
+
+              vi.unstubAllEnvs();
+            })
+        );
+      });
+    });
+
     describe('[Given] `@composio/core` not installed', () => {
       layer(
         TestLive({

--- a/ts/packages/cli/test/src/effects/toolkit-version-overrides.test.ts
+++ b/ts/packages/cli/test/src/effects/toolkit-version-overrides.test.ts
@@ -4,6 +4,8 @@ import {
   getToolkitVersionOverrides,
   buildToolkitVersionSpecs,
   groupByVersion,
+  sanitizeVersionString,
+  buildVersionMapFromSpecs,
   type ToolkitVersionOverrides,
   type ToolkitVersionSpec,
 } from 'src/effects/toolkit-version-overrides';
@@ -201,5 +203,101 @@ describe('toolkit-version-overrides', () => {
 
       expect(grouped.get('latest')).toEqual(['gmail', 'slack', 'github', 'notion']);
     });
+  });
+
+  describe('sanitizeVersionString', () => {
+    it('should return valid version strings unchanged', () => {
+      expect(sanitizeVersionString('20250901_00')).toBe('20250901_00');
+      expect(sanitizeVersionString('v1.2.3')).toBe('v1.2.3');
+      expect(sanitizeVersionString('latest')).toBe('latest');
+      expect(sanitizeVersionString('1.0.0-beta.1')).toBe('1.0.0-beta.1');
+    });
+
+    it('should remove invalid characters', () => {
+      expect(sanitizeVersionString('20250901_00!')).toBe('20250901_00');
+      expect(sanitizeVersionString('version@123')).toBe('version123');
+      expect(sanitizeVersionString('v1.2.3#tag')).toBe('v1.2.3tag');
+    });
+
+    it('should handle unicode and special characters', () => {
+      expect(sanitizeVersionString('版本1.0')).toBe('1.0');
+      expect(sanitizeVersionString('v1.0\n\t')).toBe('v1.0');
+      expect(sanitizeVersionString('$version$')).toBe('version');
+    });
+
+    it('should return null for empty or all-invalid strings', () => {
+      expect(sanitizeVersionString('')).toBe(null);
+      expect(sanitizeVersionString('$$$')).toBe(null);
+      expect(sanitizeVersionString('   ')).toBe(null);
+    });
+
+    it('should allow alphanumeric, hyphens, underscores, and dots', () => {
+      expect(sanitizeVersionString('abc-123_456.789')).toBe('abc-123_456.789');
+      expect(sanitizeVersionString('ABC-XYZ_000.999')).toBe('ABC-XYZ_000.999');
+    });
+  });
+
+  describe('buildVersionMapFromSpecs', () => {
+    it('should build version map excluding latest versions', () => {
+      const specs: ToolkitVersionSpec[] = [
+        { toolkitSlug: 'gmail', toolkitVersion: '20250901_00' },
+        { toolkitSlug: 'slack', toolkitVersion: 'latest' },
+        { toolkitSlug: 'github', toolkitVersion: '20250815_00' },
+      ];
+      const versionMap = buildVersionMapFromSpecs(specs);
+
+      expect(versionMap.size).toBe(2);
+      expect(versionMap.get('gmail')).toBe('20250901_00');
+      expect(versionMap.get('github')).toBe('20250815_00');
+      expect(versionMap.has('slack')).toBe(false);
+    });
+
+    it('should return empty map when all versions are latest', () => {
+      const specs: ToolkitVersionSpec[] = [
+        { toolkitSlug: 'gmail', toolkitVersion: 'latest' },
+        { toolkitSlug: 'slack', toolkitVersion: 'latest' },
+      ];
+      const versionMap = buildVersionMapFromSpecs(specs);
+
+      expect(versionMap.size).toBe(0);
+    });
+
+    it('should return empty map for empty specs', () => {
+      const versionMap = buildVersionMapFromSpecs([]);
+      expect(versionMap.size).toBe(0);
+    });
+
+    it('should include all non-latest versions', () => {
+      const specs: ToolkitVersionSpec[] = [
+        { toolkitSlug: 'gmail', toolkitVersion: '20250901_00' },
+        { toolkitSlug: 'slack', toolkitVersion: '20250815_00' },
+        { toolkitSlug: 'github', toolkitVersion: '20250710_00' },
+      ];
+      const versionMap = buildVersionMapFromSpecs(specs);
+
+      expect(versionMap.size).toBe(3);
+      expect(versionMap.get('gmail')).toBe('20250901_00');
+      expect(versionMap.get('slack')).toBe('20250815_00');
+      expect(versionMap.get('github')).toBe('20250710_00');
+    });
+  });
+
+  describe('getToolkitVersionOverrides with sanitization', () => {
+    it.effect('should sanitize version strings with invalid characters', () =>
+      Effect.gen(function* () {
+        vi.stubEnv('COMPOSIO_TOOLKIT_VERSION_GMAIL', '20250901_00!@#');
+        const result = yield* getToolkitVersionOverrides;
+        expect(result.get('gmail')).toBe('20250901_00');
+        expect(result.size).toBe(1);
+      })
+    );
+
+    it.effect('should ignore version strings that become empty after sanitization', () =>
+      Effect.gen(function* () {
+        vi.stubEnv('COMPOSIO_TOOLKIT_VERSION_GMAIL', '$$$');
+        const result = yield* getToolkitVersionOverrides;
+        expect(result.size).toBe(0);
+      })
+    );
   });
 });

--- a/ts/packages/cli/test/src/effects/toolkit-version-overrides.test.ts
+++ b/ts/packages/cli/test/src/effects/toolkit-version-overrides.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, afterEach } from '@effect/vitest';
+import { Effect } from 'effect';
+import {
+  getToolkitVersionOverrides,
+  buildToolkitVersionSpecs,
+  groupByVersion,
+  type ToolkitVersionOverrides,
+  type ToolkitVersionSpec,
+} from 'src/effects/toolkit-version-overrides';
+
+describe('toolkit-version-overrides', () => {
+  afterEach(() => {
+    // Clean up env vars after each test
+    vi.unstubAllEnvs();
+  });
+
+  describe('getToolkitVersionOverrides', () => {
+    it.effect('should return empty map when no env vars set', () =>
+      Effect.gen(function* () {
+        const result = yield* getToolkitVersionOverrides;
+        expect(result.size).toBe(0);
+      })
+    );
+
+    it.effect('should parse single env var with COMPOSIO_ prefix', () =>
+      Effect.gen(function* () {
+        vi.stubEnv('COMPOSIO_TOOLKIT_VERSION_GMAIL', '20250901_00');
+        const result = yield* getToolkitVersionOverrides;
+        expect(result.get('gmail')).toBe('20250901_00');
+        expect(result.size).toBe(1);
+      })
+    );
+
+    it.effect('should parse multiple env vars', () =>
+      Effect.gen(function* () {
+        vi.stubEnv('COMPOSIO_TOOLKIT_VERSION_GMAIL', '20250901_00');
+        vi.stubEnv('COMPOSIO_TOOLKIT_VERSION_SLACK', '20250815_00');
+        const result = yield* getToolkitVersionOverrides;
+        expect(result.get('gmail')).toBe('20250901_00');
+        expect(result.get('slack')).toBe('20250815_00');
+        expect(result.size).toBe(2);
+      })
+    );
+
+    it.effect('should lowercase toolkit name from env var', () =>
+      Effect.gen(function* () {
+        vi.stubEnv('COMPOSIO_TOOLKIT_VERSION_GMAIL', '20250901_00');
+        const result = yield* getToolkitVersionOverrides;
+        expect(result.has('gmail')).toBe(true);
+        // Cast to bypass type check - we're testing runtime behavior that uppercase keys are not stored
+        expect(result.has('GMAIL' as Lowercase<string>)).toBe(false);
+      })
+    );
+
+    it.effect('should ignore "latest" as explicit value', () =>
+      Effect.gen(function* () {
+        vi.stubEnv('COMPOSIO_TOOLKIT_VERSION_GMAIL', 'latest');
+        const result = yield* getToolkitVersionOverrides;
+        expect(result.size).toBe(0);
+      })
+    );
+
+    it.effect('should ignore empty string values', () =>
+      Effect.gen(function* () {
+        vi.stubEnv('COMPOSIO_TOOLKIT_VERSION_GMAIL', '');
+        const result = yield* getToolkitVersionOverrides;
+        expect(result.size).toBe(0);
+      })
+    );
+
+    it.effect('should not read env vars without COMPOSIO_ prefix', () =>
+      Effect.gen(function* () {
+        vi.stubEnv('TOOLKIT_VERSION_GMAIL', '20250901_00');
+        const result = yield* getToolkitVersionOverrides;
+        expect(result.size).toBe(0);
+      })
+    );
+
+    it.effect('should handle mixed valid and invalid entries', () =>
+      Effect.gen(function* () {
+        vi.stubEnv('COMPOSIO_TOOLKIT_VERSION_GMAIL', '20250901_00');
+        vi.stubEnv('COMPOSIO_TOOLKIT_VERSION_SLACK', 'latest'); // Should be ignored
+        vi.stubEnv('COMPOSIO_TOOLKIT_VERSION_GITHUB', ''); // Should be ignored
+        vi.stubEnv('COMPOSIO_TOOLKIT_VERSION_NOTION', '20250815_00');
+        const result = yield* getToolkitVersionOverrides;
+        expect(result.size).toBe(2);
+        expect(result.get('gmail')).toBe('20250901_00');
+        expect(result.get('notion')).toBe('20250815_00');
+      })
+    );
+  });
+
+  describe('buildToolkitVersionSpecs', () => {
+    it('should apply overrides to matching toolkits', () => {
+      const overrides: ToolkitVersionOverrides = new Map([['gmail', '20250901_00']]);
+      const specs = buildToolkitVersionSpecs(['gmail', 'slack'], overrides);
+
+      expect(specs).toEqual([
+        { toolkitSlug: 'gmail', toolkitVersion: '20250901_00' },
+        { toolkitSlug: 'slack', toolkitVersion: 'latest' },
+      ]);
+    });
+
+    it('should handle case-insensitive matching', () => {
+      const overrides: ToolkitVersionOverrides = new Map([['gmail', '20250901_00']]);
+      const specs = buildToolkitVersionSpecs(['GMAIL', 'Slack'], overrides);
+
+      expect(specs).toEqual([
+        { toolkitSlug: 'gmail', toolkitVersion: '20250901_00' },
+        { toolkitSlug: 'slack', toolkitVersion: 'latest' },
+      ]);
+    });
+
+    it('should return all latest when no overrides', () => {
+      const overrides: ToolkitVersionOverrides = new Map();
+      const specs = buildToolkitVersionSpecs(['gmail', 'slack', 'github'], overrides);
+
+      expect(specs).toEqual([
+        { toolkitSlug: 'gmail', toolkitVersion: 'latest' },
+        { toolkitSlug: 'slack', toolkitVersion: 'latest' },
+        { toolkitSlug: 'github', toolkitVersion: 'latest' },
+      ]);
+    });
+
+    it('should handle multiple overrides', () => {
+      const overrides: ToolkitVersionOverrides = new Map([
+        ['gmail', '20250901_00'],
+        ['slack', '20250815_00'],
+      ]);
+      const specs = buildToolkitVersionSpecs(['gmail', 'slack', 'github'], overrides);
+
+      expect(specs).toEqual([
+        { toolkitSlug: 'gmail', toolkitVersion: '20250901_00' },
+        { toolkitSlug: 'slack', toolkitVersion: '20250815_00' },
+        { toolkitSlug: 'github', toolkitVersion: 'latest' },
+      ]);
+    });
+
+    it('should handle empty slug array', () => {
+      const overrides: ToolkitVersionOverrides = new Map([['gmail', '20250901_00']]);
+      const specs = buildToolkitVersionSpecs([], overrides);
+
+      expect(specs).toEqual([]);
+    });
+  });
+
+  describe('groupByVersion', () => {
+    it('should group toolkits by version', () => {
+      const specs: ToolkitVersionSpec[] = [
+        { toolkitSlug: 'gmail', toolkitVersion: '20250901_00' },
+        { toolkitSlug: 'slack', toolkitVersion: 'latest' },
+        { toolkitSlug: 'github', toolkitVersion: '20250901_00' },
+      ];
+      const grouped = groupByVersion(specs);
+
+      expect(grouped.get('20250901_00')).toEqual(['gmail', 'github']);
+      expect(grouped.get('latest')).toEqual(['slack']);
+      expect(grouped.size).toBe(2);
+    });
+
+    it('should handle all same version', () => {
+      const specs: ToolkitVersionSpec[] = [
+        { toolkitSlug: 'gmail', toolkitVersion: 'latest' },
+        { toolkitSlug: 'slack', toolkitVersion: 'latest' },
+      ];
+      const grouped = groupByVersion(specs);
+
+      expect(grouped.size).toBe(1);
+      expect(grouped.get('latest')).toEqual(['gmail', 'slack']);
+    });
+
+    it('should handle all different versions', () => {
+      const specs: ToolkitVersionSpec[] = [
+        { toolkitSlug: 'gmail', toolkitVersion: '20250901_00' },
+        { toolkitSlug: 'slack', toolkitVersion: '20250815_00' },
+        { toolkitSlug: 'github', toolkitVersion: '20250710_00' },
+      ];
+      const grouped = groupByVersion(specs);
+
+      expect(grouped.size).toBe(3);
+      expect(grouped.get('20250901_00')).toEqual(['gmail']);
+      expect(grouped.get('20250815_00')).toEqual(['slack']);
+      expect(grouped.get('20250710_00')).toEqual(['github']);
+    });
+
+    it('should handle empty specs array', () => {
+      const specs: ToolkitVersionSpec[] = [];
+      const grouped = groupByVersion(specs);
+
+      expect(grouped.size).toBe(0);
+    });
+
+    it('should preserve order within version groups', () => {
+      const specs: ToolkitVersionSpec[] = [
+        { toolkitSlug: 'gmail', toolkitVersion: 'latest' },
+        { toolkitSlug: 'slack', toolkitVersion: 'latest' },
+        { toolkitSlug: 'github', toolkitVersion: 'latest' },
+        { toolkitSlug: 'notion', toolkitVersion: 'latest' },
+      ];
+      const grouped = groupByVersion(specs);
+
+      expect(grouped.get('latest')).toEqual(['gmail', 'slack', 'github', 'notion']);
+    });
+  });
+});

--- a/ts/packages/cli/test/src/generation/python/generate-toolkit-source.test.ts
+++ b/ts/packages/cli/test/src/generation/python/generate-toolkit-source.test.ts
@@ -6,6 +6,7 @@ import { makeTestToolkits } from 'test/__utils__/models/toolkits';
 import { assertPythonIsValid } from 'test/__utils__/python-compiler';
 import { TRIGGER_TYPES_GMAIL } from 'test/__mocks__/trigger-types-gmail';
 import { TOOLS_GMAIL } from 'test/__mocks__/tools-gmail';
+import { TOOLS_TYPES_GMAIL } from 'test/__mocks__/tools-types-gmail';
 
 describe('generatePythonToolkitSources', () => {
   it('[Given] empty toolkits, tools, triggerTypes [Then] it returns an empty array', () => {
@@ -253,5 +254,271 @@ describe('generatePythonToolkitSources', () => {
     `);
 
     assertPythonIsValid({ files: Object.fromEntries(sources) });
+  });
+
+  describe('[Given] versionMap with toolkit version overrides', () => {
+    describe('without type tools', () => {
+      it('[Given] a toolkit with version override [Then] it includes version comment in generated file', () => {
+        const toolkits = makeTestToolkits([
+          {
+            name: 'Gmail',
+            slug: 'gmail',
+          },
+        ]);
+
+        const versionMap = new Map([['gmail', '20250901_00']]) as Map<Lowercase<string>, string>;
+
+        const index = createToolkitIndex({
+          toolkits,
+          typeableTools: { withTypes: false, tools: [] },
+          triggerTypes: [],
+          versionMap,
+        });
+
+        const sources = generatePythonToolkitSources(BANNER)(index);
+        expect(sources).toHaveLength(1);
+        expect(sources[0][0]).toBe('gmail.py');
+        expect(sources[0][1]).toContain('# @toolkit-version: 20250901_00');
+
+        assertPythonIsValid({ files: Object.fromEntries(sources) });
+      });
+
+      it('[Given] multiple toolkits with different version overrides [Then] each file includes its version comment', () => {
+        const toolkits = makeTestToolkits([
+          {
+            name: 'Gmail',
+            slug: 'gmail',
+          },
+          {
+            name: 'Slack Helper',
+            slug: 'slack',
+          },
+        ]);
+
+        const versionMap = new Map([
+          ['gmail', '20250901_00'],
+          ['slack', '20250815_00'],
+        ]) as Map<Lowercase<string>, string>;
+
+        const index = createToolkitIndex({
+          toolkits,
+          typeableTools: { withTypes: false, tools: [] },
+          triggerTypes: [],
+          versionMap,
+        });
+
+        const sources = generatePythonToolkitSources(BANNER)(index);
+        expect(sources).toHaveLength(2);
+
+        // Gmail should have its version comment
+        expect(sources[0][0]).toBe('gmail.py');
+        expect(sources[0][1]).toContain('# @toolkit-version: 20250901_00');
+
+        // Slack should have its version comment
+        expect(sources[1][0]).toBe('slack.py');
+        expect(sources[1][1]).toContain('# @toolkit-version: 20250815_00');
+
+        assertPythonIsValid({ files: Object.fromEntries(sources) });
+      });
+
+      it('[Given] only some toolkits with version override [Then] only those files include version comment', () => {
+        const toolkits = makeTestToolkits([
+          {
+            name: 'Gmail',
+            slug: 'gmail',
+          },
+          {
+            name: 'Slack Helper',
+            slug: 'slack',
+          },
+        ]);
+
+        // Only gmail has a version override
+        const versionMap = new Map([['gmail', '20250901_00']]) as Map<Lowercase<string>, string>;
+
+        const index = createToolkitIndex({
+          toolkits,
+          typeableTools: { withTypes: false, tools: [] },
+          triggerTypes: [],
+          versionMap,
+        });
+
+        const sources = generatePythonToolkitSources(BANNER)(index);
+        expect(sources).toHaveLength(2);
+
+        // Gmail should have version comment
+        expect(sources[0][0]).toBe('gmail.py');
+        expect(sources[0][1]).toContain('# @toolkit-version: 20250901_00');
+
+        // Slack should NOT have version comment
+        expect(sources[1][0]).toBe('slack.py');
+        expect(sources[1][1]).not.toContain('@toolkit-version');
+
+        assertPythonIsValid({ files: Object.fromEntries(sources) });
+      });
+
+      it('[Given] empty versionMap [Then] no files include version comment', () => {
+        const toolkits = makeTestToolkits([
+          {
+            name: 'Gmail',
+            slug: 'gmail',
+          },
+        ]);
+
+        const versionMap = new Map() as Map<Lowercase<string>, string>;
+
+        const index = createToolkitIndex({
+          toolkits,
+          typeableTools: { withTypes: false, tools: [] },
+          triggerTypes: [],
+          versionMap,
+        });
+
+        const sources = generatePythonToolkitSources(BANNER)(index);
+        expect(sources).toHaveLength(1);
+        expect(sources[0][0]).toBe('gmail.py');
+        expect(sources[0][1]).not.toContain('@toolkit-version');
+
+        assertPythonIsValid({ files: Object.fromEntries(sources) });
+      });
+    });
+
+    describe('with type tools', () => {
+      it('[Given] a toolkit with version override [Then] it includes version comment in generated file', () => {
+        const toolkits = makeTestToolkits([
+          {
+            name: 'Gmail',
+            slug: 'gmail',
+          },
+        ]);
+
+        const versionMap = new Map([['gmail', '20250901_00']]) as Map<Lowercase<string>, string>;
+
+        const index = createToolkitIndex({
+          toolkits,
+          typeableTools: {
+            withTypes: true,
+            tools: [...TOOLS_TYPES_GMAIL.slice(0, 1)],
+          },
+          triggerTypes: [],
+          versionMap,
+        });
+
+        const sources = generatePythonToolkitSources(BANNER)(index);
+        expect(sources).toHaveLength(1);
+        expect(sources[0][0]).toBe('gmail.py');
+        expect(sources[0][1]).toContain('# @toolkit-version: 20250901_00');
+
+        assertPythonIsValid({ files: Object.fromEntries(sources) });
+      });
+
+      it('[Given] multiple toolkits with different version overrides [Then] each file includes its version comment', () => {
+        const toolkits = makeTestToolkits([
+          {
+            name: 'Gmail',
+            slug: 'gmail',
+          },
+          {
+            name: 'Slack Helper',
+            slug: 'slack',
+          },
+        ]);
+
+        const versionMap = new Map([
+          ['gmail', '20250901_00'],
+          ['slack', '20250815_00'],
+        ]) as Map<Lowercase<string>, string>;
+
+        const index = createToolkitIndex({
+          toolkits,
+          typeableTools: {
+            withTypes: true,
+            tools: [...TOOLS_TYPES_GMAIL.slice(0, 1)],
+          },
+          triggerTypes: [],
+          versionMap,
+        });
+
+        const sources = generatePythonToolkitSources(BANNER)(index);
+        expect(sources).toHaveLength(2);
+
+        // Gmail should have its version comment
+        expect(sources[0][0]).toBe('gmail.py');
+        expect(sources[0][1]).toContain('# @toolkit-version: 20250901_00');
+
+        // Slack should have its version comment
+        expect(sources[1][0]).toBe('slack.py');
+        expect(sources[1][1]).toContain('# @toolkit-version: 20250815_00');
+
+        assertPythonIsValid({ files: Object.fromEntries(sources) });
+      });
+
+      it('[Given] only some toolkits with version override [Then] only those files include version comment', () => {
+        const toolkits = makeTestToolkits([
+          {
+            name: 'Gmail',
+            slug: 'gmail',
+          },
+          {
+            name: 'Slack Helper',
+            slug: 'slack',
+          },
+        ]);
+
+        // Only gmail has a version override
+        const versionMap = new Map([['gmail', '20250901_00']]) as Map<Lowercase<string>, string>;
+
+        const index = createToolkitIndex({
+          toolkits,
+          typeableTools: {
+            withTypes: true,
+            tools: [...TOOLS_TYPES_GMAIL.slice(0, 1)],
+          },
+          triggerTypes: [],
+          versionMap,
+        });
+
+        const sources = generatePythonToolkitSources(BANNER)(index);
+        expect(sources).toHaveLength(2);
+
+        // Gmail should have version comment
+        expect(sources[0][0]).toBe('gmail.py');
+        expect(sources[0][1]).toContain('# @toolkit-version: 20250901_00');
+
+        // Slack should NOT have version comment
+        expect(sources[1][0]).toBe('slack.py');
+        expect(sources[1][1]).not.toContain('@toolkit-version');
+
+        assertPythonIsValid({ files: Object.fromEntries(sources) });
+      });
+
+      it('[Given] empty versionMap [Then] no files include version comment', () => {
+        const toolkits = makeTestToolkits([
+          {
+            name: 'Gmail',
+            slug: 'gmail',
+          },
+        ]);
+
+        const versionMap = new Map() as Map<Lowercase<string>, string>;
+
+        const index = createToolkitIndex({
+          toolkits,
+          typeableTools: {
+            withTypes: true,
+            tools: [...TOOLS_TYPES_GMAIL.slice(0, 1)],
+          },
+          triggerTypes: [],
+          versionMap,
+        });
+
+        const sources = generatePythonToolkitSources(BANNER)(index);
+        expect(sources).toHaveLength(1);
+        expect(sources[0][0]).toBe('gmail.py');
+        expect(sources[0][1]).not.toContain('@toolkit-version');
+
+        assertPythonIsValid({ files: Object.fromEntries(sources) });
+      });
+    });
   });
 });

--- a/ts/packages/cli/test/src/generation/typescript/__snapshots__/generate-toolkit-source.test.ts.snap
+++ b/ts/packages/cli/test/src/generation/typescript/__snapshots__/generate-toolkit-source.test.ts.snap
@@ -1,0 +1,237 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`generateTypeScriptToolkitSources > with a single emitted file > with banner > [Given] versionMap with toolkit version overrides > with type tools > [Given] multiple toolkits with different version overrides [Then] each file includes its version comment 1`] = `
+"/* @toolkit-version: 20250901_00 */
+
+
+// --------------- //
+//    Tool types   //
+// --------------- //
+
+
+
+/**
+ * Type map of all available tool input types for toolkit "GMAIL".
+ */
+export type GMAIL_TOOL_INPUTS = {}
+
+/**
+ * Type map of all available tool input types for toolkit "GMAIL".
+ */
+export type GMAIL_TOOL_OUTPUTS = {}
+
+// ------------------- //
+//    Trigger types    //
+// ------------------- //
+
+
+
+/**
+ * Map of Composio's GMAIL toolkit.
+ * @toolkit-version: 20250901_00
+ */
+export const GMAIL = {
+  slug: "gmail",
+  tools: {},
+  triggerTypes: {},
+}
+
+/**
+ * Type map of all available trigger payloads for toolkit "GMAIL".
+ */
+export type GMAIL_TRIGGER_PAYLOADS = {}
+
+/**
+ * Type map of all available trigger events for toolkit "GMAIL".
+ */
+export type GMAIL_TRIGGER_EVENTS = {}
+"
+`;
+
+exports[`generateTypeScriptToolkitSources > with a single emitted file > with banner > [Given] versionMap with toolkit version overrides > with type tools > [Given] multiple toolkits with different version overrides [Then] each file includes its version comment 2`] = `
+"/* @toolkit-version: 20250815_00 */
+
+
+// --------------- //
+//    Tool types   //
+// --------------- //
+
+
+
+/**
+ * Type of GITHUB's GITHUB_ACCEPT_A_REPOSITORY_INVITATION tool input.
+ * @toolkit-version: 20250815_00
+ */
+type GITHUB_ACCEPT_A_REPOSITORY_INVITATION_INPUT = {
+  /**
+   * Invitation Id
+   * @description Unique identifier of the repository invitation. Obtain by listing pending invitations for the authenticated user.
+   * @example 12345
+   * @example 67890
+   */
+  invitation_id?: number;
+};
+
+/**
+ * Type of GITHUB's GITHUB_ACCEPT_A_REPOSITORY_INVITATION tool output.
+ * @toolkit-version: 20250815_00
+ */
+type GITHUB_ACCEPT_A_REPOSITORY_INVITATION_OUTPUT = {
+  /**
+   * Data
+   * @description GitHub API response. Usually empty for a successful acceptance (HTTP 204 No Content status).
+   */
+  data?: {
+      [key: string]: unknown;
+  };
+  /**
+   * Error
+   * @description Error if any occurred during the execution of the action
+   * @default null
+   */
+  error: string | null;
+  /**
+   * Successful
+   * @description Whether or not the action execution was successful or not
+   */
+  successful?: boolean;
+};
+
+/**
+ * Type map of all available tool input types for toolkit "GITHUB".
+ */
+export type GITHUB_TOOL_INPUTS = {
+  ACCEPT_A_REPOSITORY_INVITATION: GITHUB_ACCEPT_A_REPOSITORY_INVITATION_INPUT
+}
+
+/**
+ * Type map of all available tool input types for toolkit "GITHUB".
+ */
+export type GITHUB_TOOL_OUTPUTS = {
+  ACCEPT_A_REPOSITORY_INVITATION: GITHUB_ACCEPT_A_REPOSITORY_INVITATION_OUTPUT
+}
+
+// ------------------- //
+//    Trigger types    //
+// ------------------- //
+
+
+
+/**
+ * Map of Composio's GITHUB toolkit.
+ * @toolkit-version: 20250815_00
+ */
+export const GITHUB = {
+  slug: "github",
+  tools: {
+    /**
+     * Accepts a pending repository invitation that has been issued to the authenticated user.
+     */
+    ACCEPT_A_REPOSITORY_INVITATION: "GITHUB_ACCEPT_A_REPOSITORY_INVITATION",
+  },
+  triggerTypes: {},
+}
+
+/**
+ * Type map of all available trigger payloads for toolkit "GITHUB".
+ */
+export type GITHUB_TRIGGER_PAYLOADS = {}
+
+/**
+ * Type map of all available trigger events for toolkit "GITHUB".
+ */
+export type GITHUB_TRIGGER_EVENTS = {}
+"
+`;
+
+exports[`generateTypeScriptToolkitSources > with a single emitted file > with banner > [Given] versionMap with toolkit version overrides > without type tools > [Given] multiple toolkits with different version overrides [Then] each file includes its version comment 1`] = `
+"/* @toolkit-version: 20250901_00 */
+
+
+// ------------------- //
+//    Trigger types    //
+// ------------------- //
+
+
+
+/**
+ * Map of Composio's GMAIL toolkit.
+ * @toolkit-version: 20250901_00
+ */
+export const GMAIL = {
+  slug: "gmail",
+  tools: {},
+  triggerTypes: {},
+}
+
+/**
+ * Type map of all available trigger payloads for toolkit "GMAIL".
+ */
+export type GMAIL_TRIGGER_PAYLOADS = {}
+
+/**
+ * Type map of all available trigger events for toolkit "GMAIL".
+ */
+export type GMAIL_TRIGGER_EVENTS = {}
+"
+`;
+
+exports[`generateTypeScriptToolkitSources > with a single emitted file > with banner > [Given] versionMap with toolkit version overrides > without type tools > [Given] multiple toolkits with different version overrides [Then] each file includes its version comment 2`] = `
+"/* @toolkit-version: 20250815_00 */
+
+
+// ------------------- //
+//    Trigger types    //
+// ------------------- //
+
+
+
+/**
+ * Map of Composio's SLACK toolkit.
+ * @toolkit-version: 20250815_00
+ */
+export const SLACK = {
+  slug: "slack",
+  tools: {},
+  triggerTypes: {},
+}
+
+/**
+ * Type map of all available trigger payloads for toolkit "SLACK".
+ */
+export type SLACK_TRIGGER_PAYLOADS = {}
+
+/**
+ * Type map of all available trigger events for toolkit "SLACK".
+ */
+export type SLACK_TRIGGER_EVENTS = {}
+"
+`;
+
+exports[`generateTypeScriptToolkitSources > with a single emitted file > with banner > [Given] versionMap with toolkit version overrides > without type tools > [Given] only some toolkits with version override [Then] only those files include version comment 1`] = `
+"// ------------------- //
+//    Trigger types    //
+// ------------------- //
+
+
+
+/**
+ * Map of Composio's SLACK toolkit.
+ */
+export const SLACK = {
+  slug: "slack",
+  tools: {},
+  triggerTypes: {},
+}
+
+/**
+ * Type map of all available trigger payloads for toolkit "SLACK".
+ */
+export type SLACK_TRIGGER_PAYLOADS = {}
+
+/**
+ * Type map of all available trigger events for toolkit "SLACK".
+ */
+export type SLACK_TRIGGER_EVENTS = {}
+"
+`;

--- a/ts/packages/cli/test/src/generation/typescript/generate-toolkit-source.test.ts
+++ b/ts/packages/cli/test/src/generation/typescript/generate-toolkit-source.test.ts
@@ -1356,6 +1356,297 @@ describe('generateTypeScriptToolkitSources', () => {
           })
         );
       });
+
+      describe('[Given] versionMap with toolkit version overrides', () => {
+        describe('without type tools', () => {
+          it.effect(
+            '[Given] a toolkit with version override [Then] it includes version comment in generated file',
+            Effect.fn(function* () {
+              const toolkits = makeTestToolkits([
+                {
+                  name: 'Gmail',
+                  slug: 'gmail',
+                },
+              ]);
+
+              const versionMap = new Map([['gmail', '20250901_00']]) as Map<
+                Lowercase<string>,
+                string
+              >;
+
+              const index = createToolkitIndex({
+                toolkits,
+                typeableTools: { withTypes: false, tools: [] },
+                triggerTypes: [],
+                versionMap,
+              });
+
+              const sources = yield* generateTypeScriptToolkitSources(banner)(index);
+              expect(sources).toHaveLength(1);
+              expect(sources[0][0]).toBe('gmail.ts');
+              expect(sources[0][1]).toContain('@toolkit-version: 20250901_00');
+            })
+          );
+
+          it.effect(
+            '[Given] multiple toolkits with different version overrides [Then] each file includes its version comment',
+            Effect.fn(function* () {
+              const toolkits = makeTestToolkits([
+                {
+                  name: 'Gmail',
+                  slug: 'gmail',
+                },
+                {
+                  name: 'Slack Helper',
+                  slug: 'slack',
+                },
+              ]);
+
+              const versionMap = new Map([
+                ['gmail', '20250901_00'],
+                ['slack', '20250815_00'],
+              ]) as Map<Lowercase<string>, string>;
+
+              const index = createToolkitIndex({
+                toolkits,
+                typeableTools: { withTypes: false, tools: [] },
+                triggerTypes: [],
+                versionMap,
+              });
+
+              const sources = yield* generateTypeScriptToolkitSources(banner)(index);
+              expect(sources).toHaveLength(2);
+
+              // Gmail should have its version comment
+              expect(sources[0][0]).toBe('gmail.ts');
+              expect(sources[0][1]).toContain('@toolkit-version: 20250901_00');
+              expect(sources[0][1]).toMatchSnapshot();
+
+              // Slack should have its version comment
+              expect(sources[1][0]).toBe('slack.ts');
+              expect(sources[1][1]).toContain('@toolkit-version: 20250815_00');
+              expect(sources[1][1]).toMatchSnapshot();
+            })
+          );
+
+          it.effect(
+            '[Given] only some toolkits with version override [Then] only those files include version comment',
+            Effect.fn(function* () {
+              const toolkits = makeTestToolkits([
+                {
+                  name: 'Gmail',
+                  slug: 'gmail',
+                },
+                {
+                  name: 'Slack Helper',
+                  slug: 'slack',
+                },
+              ]);
+
+              // Only gmail has a version override
+              const versionMap = new Map([['gmail', '20250901_00']]) as Map<
+                Lowercase<string>,
+                string
+              >;
+
+              const index = createToolkitIndex({
+                toolkits,
+                typeableTools: { withTypes: false, tools: [] },
+                triggerTypes: [],
+                versionMap,
+              });
+
+              const sources = yield* generateTypeScriptToolkitSources(banner)(index);
+              expect(sources).toHaveLength(2);
+
+              // Gmail should have version comment
+              expect(sources[0][0]).toBe('gmail.ts');
+              expect(sources[0][1]).toContain('@toolkit-version: 20250901_00');
+
+              // Slack should NOT have version comment
+              expect(sources[1][0]).toBe('slack.ts');
+              expect(sources[1][1]).not.toContain('@toolkit-version');
+              expect(sources[1][1]).toMatchSnapshot();
+            })
+          );
+
+          it.effect(
+            '[Given] empty versionMap [Then] no files include version comment',
+            Effect.fn(function* () {
+              const toolkits = makeTestToolkits([
+                {
+                  name: 'Gmail',
+                  slug: 'gmail',
+                },
+              ]);
+
+              const versionMap = new Map() as Map<Lowercase<string>, string>;
+
+              const index = createToolkitIndex({
+                toolkits,
+                typeableTools: { withTypes: false, tools: [] },
+                triggerTypes: [],
+                versionMap,
+              });
+
+              const sources = yield* generateTypeScriptToolkitSources(banner)(index);
+              expect(sources).toHaveLength(1);
+              expect(sources[0][0]).toBe('gmail.ts');
+              expect(sources[0][1]).not.toContain('@toolkit-version');
+            })
+          );
+        });
+
+        describe('with type tools', () => {
+          it.effect(
+            '[Given] a toolkit with version override [Then] it includes version comment in generated file',
+            Effect.fn(function* () {
+              const toolkits = makeTestToolkits([
+                {
+                  name: 'Gmail',
+                  slug: 'gmail',
+                },
+              ]);
+
+              const versionMap = new Map([['gmail', '20250901_00']]) as Map<
+                Lowercase<string>,
+                string
+              >;
+
+              const index = createToolkitIndex({
+                toolkits,
+                typeableTools: {
+                  withTypes: true,
+                  tools: [...TOOLS_TYPES_GMAIL.slice(0, 1)],
+                },
+                triggerTypes: [],
+                versionMap,
+              });
+
+              const sources = yield* generateTypeScriptToolkitSources(banner)(index);
+              expect(sources).toHaveLength(1);
+              expect(sources[0][0]).toBe('gmail.ts');
+              expect(sources[0][1]).toContain('@toolkit-version: 20250901_00');
+            })
+          );
+
+          it.effect(
+            '[Given] multiple toolkits with different version overrides [Then] each file includes its version comment',
+            Effect.fn(function* () {
+              const toolkits = makeTestToolkits([
+                {
+                  name: 'Gmail',
+                  slug: 'gmail',
+                },
+                {
+                  name: 'Github',
+                  slug: 'github',
+                },
+              ]);
+
+              const versionMap = new Map([
+                ['gmail', '20250901_00'],
+                ['github', '20250815_00'],
+              ]) as Map<Lowercase<string>, string>;
+
+              const index = createToolkitIndex({
+                toolkits,
+                typeableTools: {
+                  withTypes: true,
+                  tools: [...TOOLS_TYPES_GMAIL.slice(0, 1), ...TOOLS_TYPES_GITHUB.slice(0, 1)],
+                },
+                triggerTypes: [],
+                versionMap,
+              });
+
+              const sources = yield* generateTypeScriptToolkitSources(banner)(index);
+              expect(sources).toHaveLength(2);
+
+              // Gmail should have its version comment
+              expect(sources[0][0]).toBe('gmail.ts');
+              expect(sources[0][1]).toContain('@toolkit-version: 20250901_00');
+              expect(sources[0][1]).toMatchSnapshot();
+
+              // Github should have its version comment
+              expect(sources[1][0]).toBe('github.ts');
+              expect(sources[1][1]).toContain('@toolkit-version: 20250815_00');
+              expect(sources[1][1]).toMatchSnapshot();
+            })
+          );
+
+          it.effect(
+            '[Given] only some toolkits with version override [Then] only those files include version comment',
+            Effect.fn(function* () {
+              const toolkits = makeTestToolkits([
+                {
+                  name: 'Gmail',
+                  slug: 'gmail',
+                },
+                {
+                  name: 'Github',
+                  slug: 'github',
+                },
+              ]);
+
+              // Only gmail has a version override
+              const versionMap = new Map([['gmail', '20250901_00']]) as Map<
+                Lowercase<string>,
+                string
+              >;
+
+              const index = createToolkitIndex({
+                toolkits,
+                typeableTools: {
+                  withTypes: true,
+                  tools: [...TOOLS_TYPES_GMAIL.slice(0, 1), ...TOOLS_TYPES_GITHUB.slice(0, 1)],
+                },
+                triggerTypes: [],
+                versionMap,
+              });
+
+              const sources = yield* generateTypeScriptToolkitSources(banner)(index);
+              expect(sources).toHaveLength(2);
+
+              // Gmail should have version comment
+              expect(sources[0][0]).toBe('gmail.ts');
+              expect(sources[0][1]).toContain('@toolkit-version: 20250901_00');
+
+              // Github should NOT have version comment
+              expect(sources[1][0]).toBe('github.ts');
+              expect(sources[1][1]).not.toContain('@toolkit-version');
+            })
+          );
+
+          it.effect(
+            '[Given] empty versionMap [Then] no files include version comment',
+            Effect.fn(function* () {
+              const toolkits = makeTestToolkits([
+                {
+                  name: 'Gmail',
+                  slug: 'gmail',
+                },
+              ]);
+
+              const versionMap = new Map() as Map<Lowercase<string>, string>;
+
+              const index = createToolkitIndex({
+                toolkits,
+                typeableTools: {
+                  withTypes: true,
+                  tools: [...TOOLS_TYPES_GMAIL.slice(0, 1)],
+                },
+                triggerTypes: [],
+                versionMap,
+              });
+
+              const sources = yield* generateTypeScriptToolkitSources(banner)(index);
+              expect(sources).toHaveLength(1);
+              expect(sources[0][0]).toBe('gmail.ts');
+              expect(sources[0][1]).not.toContain('@toolkit-version');
+            })
+          );
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
This PR:
- closes [PLEN-1201](https://linear.app/composio/issue/PLEN-1201/cli-optionally-allow-specific-toolkit-version-via-env-vars)
- adds support for `COMPOSIO_TOOLKIT_VERSION_$TOOLKIT=$TOOLKIT_VERSION` to `composio generate`, `composio ts generate`, `composio py generate`
- validates toolkit versions, so that when an invalid toolkit or non-existing version is chosen by the user, they are alerted
-  when using a custom version, this is annotated in the generated source code as `@toolkit-version: YYYYDDMM_XY`, e.g.,
  ```ts
  /**
   * Type of GITHUB's GITHUB_ACCEPT_A_REPOSITORY_INVITATION tool input.
   * @toolkit-version: 20250815_00
   */
  type GITHUB_ACCEPT_A_REPOSITORY_INVITATION_INPUT = {
    /**
     * Invitation Id
     * @description Unique identifier of the repository invitation. Obtain by listing pending invitations for the authenticated user.
     * @example 12345
     * @example 67890
     */
    invitation_id?: number;
  };
  ```

---

Example toolkit version validation:

```sh
❯ COMPOSIO_TOOLKIT_VERSION_GMAIL=20250901_00 \
  COMPOSIO_TOOLKIT_VERSION_ENTELLIGENCE=20251208_00 \
  composio ts generate \
  --toolkits entelligence \
  --toolkits gmail \
  --type-tools \
  --output-dir ./generated
[17:38:38.929] INFO (#12): Writing type stubs to ./generated-mixed...
Detected toolkit version overrides:
  - gmail: 20250901_00
  - entelligence: 20251208_00
Validating toolkit version overrides...

💥  InvalidToolkitVersionsValidationError  • ▲ Invalid toolkit version override

╰ GMAIL → "20250901_00" not found
    Available → 20260127_00, 20260126_00, 20260122_00, 20260119_00, 20260115_00 (+45 more)
    Tip → Use "latest" or unset COMPOSIO_TOOLKIT_VERSION_GMAIL 

◯
╰─ composio-cli
   ~ 883ms
     name: @composio/cli
     filename: src/bin.ts 
 
```