### PR TITLE
feat(docs): Display enum values in toolkit parameter types

### DIFF
--- a/docs/components/toolkits/toolkit-detail.tsx
+++ b/docs/components/toolkits/toolkit-detail.tsx
@@ -36,6 +36,19 @@ function formatDefault(value: unknown): string | undefined {
   return String(value);
 }
 
+// Format type with enum values if available
+function formatType(param: ParameterSchema): string {
+  let typeStr = param.type || 'string';
+
+  // Include enum values in type display
+  if (param.enum && param.enum.length > 0) {
+    const enumValues = param.enum.map(v => `"${v}"`).join(' | ');
+    typeStr = `${typeStr} (${enumValues})`;
+  }
+
+  return typeStr;
+}
+
 // Convert parameter schema to TypeTable format
 function paramsToTypeTable(params: Record<string, ParameterSchema>): Record<string, {
   type: string;
@@ -52,7 +65,7 @@ function paramsToTypeTable(params: Record<string, ParameterSchema>): Record<stri
 
   for (const [name, param] of Object.entries(params)) {
     result[name] = {
-      type: param.type || 'string',
+      type: formatType(param),
       description: param.description || undefined,
       default: formatDefault(param.default),
       required: param.required,


### PR DESCRIPTION
## Summary
- Add `formatType` function to show enum values alongside parameter types in the toolkit detail page
- Example: `string` becomes `string ("value1" | "value2")` when enum values are present

## Test plan
- [ ] Visit a toolkit page with enum parameters
- [ ] Verify enum values display alongside the type

Generated with [Claude Code](https://claude.ai/code)