### PR TITLE
docs: improve Claude review bot guidelines for Fumadocs

### DIFF
--- a/.github/workflows/claude-code-doc-review.yml
+++ b/.github/workflows/claude-code-doc-review.yml
@@ -3,9 +3,12 @@ name: Claude Docs Review
 on:
   pull_request:
     types: [ opened, synchronize ]
-    # Run on docs changes (new Fumadocs system)
+    # Run on docs changes (content, components, styles)
     paths:
     - "docs/content/**/*.mdx"
+    - "docs/components/**/*.tsx"
+    - "docs/app/**/*.tsx"
+    - "docs/app/**/*.css"
 jobs:
   claude-review:
     # Optional: Filter by PR author
@@ -47,8 +50,10 @@ jobs:
 
           ## Documentation Structure
 
-          - Content lives in `docs/content/**/*.mdx`
-          - Design tokens in `docs/app/global.css` (use `--composio-orange`, `--composio-sidebar`)
+          - Content: `docs/content/**/*.mdx`
+          - Components: `docs/components/**/*.tsx`
+          - App routes: `docs/app/**/*.tsx`
+          - Design tokens: `docs/app/global.css` (use `--composio-orange`, `--composio-sidebar`)
           - MDX components available globally: `Tabs`, `Callout`, `Steps`, `Cards`, `Accordion`, etc.
 
           ## Critical Technical Rules
@@ -72,9 +77,45 @@ jobs:
              - Code examples: Use `<Tabs>` for multi-language snippets
              - No emojis in changelog entries
 
+          ## Component Review (for .tsx files)
+
+          When reviewing component files, verify:
+          - Component renders correctly (no runtime errors)
+          - Props are properly typed
+          - Accessibility: proper aria labels, semantic HTML, keyboard navigation
+          - Responsive design: works on mobile and desktop
+          - No hardcoded strings that should be props
+          - Consistent with existing component patterns in `docs/components/`
+
+          ## MDX Rendering Quality
+
+          - Frontmatter is valid YAML with required fields (`title`, `description`)
+          - MDX components are properly closed and nested
+          - Code blocks have correct language identifiers
+          - Links are valid (no broken internal links)
+          - Images have alt text
+          - Tables render correctly (proper markdown table syntax)
+
+          ## SEO Requirements
+
+          Every MDX page MUST have proper SEO:
+          - **title**: Concise, descriptive (50-60 chars ideal)
+          - **description**: Compelling summary for search results (150-160 chars ideal)
+          - **Headings**: One H1 only (from title), logical H2/H3 hierarchy
+          - **Internal links**: Link to related docs where relevant
+          - **URL structure**: Clean, descriptive slugs (from file path)
+
+          For toolkit/integration pages:
+          - Include the toolkit name in title and description
+          - Describe what users can do with the integration
+          - Link to authentication and usage sections
+
           ## Review Focus
 
           - **Code validity**: Will TypeScript examples compile?
+          - **Component quality**: Are components accessible and responsive?
+          - **MDX rendering**: Will the markdown render correctly?
+          - **SEO**: Does the page have good title, description, and heading structure?
           - **Clarity**: Is the content clear and scannable?
           - **Accuracy**: Are technical details correct?
           - **Consistency**: Does tone match existing docs?

--- a/.github/workflows/claude-code-doc-review.yml
+++ b/.github/workflows/claude-code-doc-review.yml
@@ -42,13 +42,45 @@ jobs:
           REPO: ${{ github.repository }}
           PR NUMBER: ${{ github.event.pull_request.number }}
 
-          Please review this pull request for documentation changes and provide feedback on:
-          - Grammar and spelling
-          - Clarity and readability
-          - Consistency and tone
-          - Proper adherence to the documentation style guide in `docs/CLAUDE.md`
+          You are reviewing documentation for Composio, built with Fumadocs (https://fumadocs.dev/).
+          Read `docs/CLAUDE.md` and `docs/.claude/` for complete style guidelines.
 
-          Be constructive and helpful in your feedback.
+          ## Documentation Structure
+
+          - Content lives in `docs/content/**/*.mdx`
+          - Design tokens in `docs/app/global.css` (use `--composio-orange`, `--composio-sidebar`)
+          - MDX components available globally: `Tabs`, `Callout`, `Steps`, `Cards`, `Accordion`, etc.
+
+          ## Critical Technical Rules
+
+          1. **TypeScript code blocks are type-checked at build time**
+             - All TS/TSX code must compile. Invalid code fails the build.
+             - Use `// ---cut---` to hide setup code (imports, declarations) from output
+             - Use `// @noErrors` only when necessary for partial snippets
+             - Prefer SDK-exported types over inline type annotations
+
+          2. **CSS variables must use full names**
+             - ✓ `var(--composio-orange)`
+             - ✗ `var(--orange)`
+
+          3. **Changelog frontmatter**
+             - Date format: `YYYY-MM-DD` (e.g., `2025-01-28`)
+             - Required fields: `title`, `date`
+
+          4. **MDX components**
+             - Breaking changes: `<Callout type="warn">` with before/after code
+             - Code examples: Use `<Tabs>` for multi-language snippets
+             - No emojis in changelog entries
+
+          ## Review Focus
+
+          - **Code validity**: Will TypeScript examples compile?
+          - **Clarity**: Is the content clear and scannable?
+          - **Accuracy**: Are technical details correct?
+          - **Consistency**: Does tone match existing docs?
+          - **Mobile**: Avoid CSS that assumes horizontal nav layout
+
+          Be constructive. Suggest specific improvements, not vague feedback.
         # Optional: Customize review based on file types
         # direct_prompt: |
         #   Review this PR focusing on:


### PR DESCRIPTION
## Summary
- Updated the Claude docs review workflow with comprehensive guidelines for the Fumadocs documentation system
- Added documentation structure context (content paths, design tokens)
- Included critical technical rules (Twoslash type-checking, CSS variables, changelog format)
- Specified MDX component usage patterns
- Defined clear review focus areas
- Referenced `docs/CLAUDE.md` and `docs/.claude/` for complete guidelines

## Changes
The review bot prompt now includes:
- **Documentation Structure**: Where content lives, design tokens, available MDX components
- **Critical Technical Rules**: TypeScript code blocks are type-checked, CSS variable naming, changelog frontmatter format
- **Review Focus**: Code validity, clarity, accuracy, consistency, mobile compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)