### PR TITLE
perf(docs): Optimize image and video loading performance

### DIFF
--- a/docs/components/figure.tsx
+++ b/docs/components/figure.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useState } from 'react';
+import Image from 'next/image';
 import Zoom from 'react-medium-image-zoom';
 import 'react-medium-image-zoom/dist/styles.css';
 import { cn } from '@/lib/utils';
@@ -23,22 +25,32 @@ const sizeClasses: Record<FigureSize, string> = {
   full: 'max-w-full',    // Full-width diagrams
 };
 
+const sizesAttr: Record<FigureSize, string> = {
+  sm: '(max-width: 300px) 100vw, 300px',
+  md: '(max-width: 500px) 100vw, 500px',
+  lg: '(max-width: 700px) 100vw, 700px',
+  full: '(max-width: 768px) 100vw, (max-width: 1200px) 70vw, 900px',
+};
+
 export function Figure({ src, alt, caption, size = 'full', className, width, height }: FigureProps) {
+  const [isLoaded, setIsLoaded] = useState(false);
   const isConstrained = size !== 'full';
 
   return (
     <figure className={cn('my-8', isConstrained && 'flex flex-col items-center', className)}>
-      <Zoom>
-        <img
+      <Zoom zoomImg={{ src }}>
+        <Image
           src={src}
           alt={alt}
-          width={width}
-          height={height}
-          loading="lazy"
+          width={width || 1200}
+          height={height || 800}
+          sizes={sizesAttr[size]}
+          onLoad={() => setIsLoaded(true)}
           className={cn(
-            'rounded-lg border border-fd-border',
+            'rounded-lg border border-fd-border transition-opacity duration-300',
+            isLoaded ? 'opacity-100' : 'opacity-0',
             sizeClasses[size],
-            isConstrained ? 'w-auto' : 'w-full'
+            isConstrained ? 'w-auto h-auto' : 'w-full h-auto'
           )}
         />
       </Zoom>

--- a/docs/components/figure.tsx
+++ b/docs/components/figure.tsx
@@ -16,6 +16,8 @@ interface FigureProps {
   className?: string;
   width?: number;
   height?: number;
+  /** Set to true for above-the-fold images to prioritize LCP */
+  priority?: boolean;
 }
 
 const sizeClasses: Record<FigureSize, string> = {
@@ -25,16 +27,26 @@ const sizeClasses: Record<FigureSize, string> = {
   full: 'max-w-full',    // Full-width diagrams
 };
 
-const sizesAttr: Record<FigureSize, string> = {
-  sm: '(max-width: 300px) 100vw, 300px',
-  md: '(max-width: 500px) 100vw, 500px',
-  lg: '(max-width: 700px) 100vw, 700px',
-  full: '(max-width: 768px) 100vw, (max-width: 1200px) 70vw, 900px',
+// Default dimensions per size to minimize CLS
+const defaultDimensions: Record<FigureSize, { width: number; height: number }> = {
+  sm: { width: 300, height: 200 },
+  md: { width: 500, height: 333 },
+  lg: { width: 700, height: 467 },
+  full: { width: 900, height: 600 },
 };
 
-export function Figure({ src, alt, caption, size = 'full', className, width, height }: FigureProps) {
+// Responsive sizes for optimal image loading
+const sizesAttr: Record<FigureSize, string> = {
+  sm: '(max-width: 640px) 100vw, 300px',
+  md: '(max-width: 640px) 100vw, 500px',
+  lg: '(max-width: 640px) 100vw, (max-width: 768px) 90vw, 700px',
+  full: '(max-width: 640px) 100vw, (max-width: 1024px) 90vw, min(900px, 70vw)',
+};
+
+export function Figure({ src, alt, caption, size = 'full', className, width, height, priority = false }: FigureProps) {
   const [isLoaded, setIsLoaded] = useState(false);
   const isConstrained = size !== 'full';
+  const dimensions = defaultDimensions[size];
 
   return (
     <figure className={cn('my-8', isConstrained && 'flex flex-col items-center', className)}>
@@ -42,9 +54,10 @@ export function Figure({ src, alt, caption, size = 'full', className, width, hei
         <Image
           src={src}
           alt={alt}
-          width={width || 1200}
-          height={height || 800}
+          width={width || dimensions.width}
+          height={height || dimensions.height}
           sizes={sizesAttr[size]}
+          priority={priority}
           onLoad={() => setIsLoaded(true)}
           className={cn(
             'rounded-lg border border-fd-border transition-opacity duration-300',

--- a/docs/components/figure.tsx
+++ b/docs/components/figure.tsx
@@ -48,6 +48,9 @@ export function Figure({ src, alt, caption, size = 'full', className, width, hei
   const isConstrained = size !== 'full';
   const dimensions = defaultDimensions[size];
 
+  // Show image on load or error (so broken images are visible for debugging)
+  const handleReady = () => setIsLoaded(true);
+
   return (
     <figure className={cn('my-8', isConstrained && 'flex flex-col items-center', className)}>
       <Zoom zoomImg={{ src }}>
@@ -58,7 +61,8 @@ export function Figure({ src, alt, caption, size = 'full', className, width, hei
           height={height || dimensions.height}
           sizes={sizesAttr[size]}
           priority={priority}
-          onLoad={() => setIsLoaded(true)}
+          onLoad={handleReady}
+          onError={handleReady}
           className={cn(
             'rounded-lg border border-fd-border transition-opacity duration-300',
             isLoaded ? 'opacity-100' : 'opacity-0',

--- a/docs/components/video.tsx
+++ b/docs/components/video.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { cn } from '@/lib/utils';
 
 interface VideoProps {

--- a/docs/content/docs/authentication.mdx
+++ b/docs/content/docs/authentication.mdx
@@ -6,7 +6,7 @@ keywords: [connect link, oauth, auth config]
 
 Composio simplifies authentication with Connect Links: hosted pages where users securely connect their accounts.
 
-<video src="/images/connect-link-auth-flow-recording.mp4" autoPlay loop muted playsInline className="rounded-lg border" />
+<Video src="/images/connect-link-auth-flow-recording.mp4" autoPlay />
 
 ## In-chat authentication
 

--- a/docs/content/reference/index.mdx
+++ b/docs/content/reference/index.mdx
@@ -17,9 +17,7 @@ Include your API key in the `x-api-key` header.
 2. Navigate to **Settings**
 3. In **Project Settings**, copy the key from the **API Keys** section
 
-<video autoPlay loop muted playsInline controls width="100%">
-  <source src="/videos/fetch-project-key.mp4" type="video/mp4" />
-</video>
+<Video src="/videos/fetch-project-key.mp4" autoPlay />
 
 ### Organization API Key
 
@@ -31,6 +29,4 @@ For organization-level access, use the `x-org-api-key` header.
 2. Navigate to **Organization Settings** → **General Settings**
 3. Copy the token under **Organization Access Tokens**
 
-<video autoPlay loop muted playsInline controls width="100%">
-  <source src="/videos/fetch-org-key.mp4" type="video/mp4" />
-</video>
+<Video src="/videos/fetch-org-key.mp4" autoPlay />

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -11,6 +11,13 @@ const config = {
   turbopack: {
     root: __dirname,
   },
+  images: {
+    // Enable modern image formats for better compression
+    formats: ['image/avif', 'image/webp'],
+    // Responsive breakpoints for srcset generation
+    deviceSizes: [640, 750, 828, 1080, 1200, 1920],
+    imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
+  },
   async rewrites() {
     return [
       // Serve markdown for AI agents: /any/path.md → /llms.mdx/any/path


### PR DESCRIPTION
## Summary
- **Figure component**: Switched to Next.js Image with smooth fade-in transition (300ms opacity)
- **Video component**: Simplified to thin wrapper for consistency across docs
- **next.config.mjs**: Enabled AVIF/WebP auto-conversion with responsive device sizes
- **MDX standardization**: All videos now use `<Video>` component

## What this improves
- Images auto-convert to WebP/AVIF (30-50% smaller files)
- Images fade in smoothly instead of popping
- Consistent video styling across all pages
- Proper responsive `sizes` attribute for optimal image loading

## Test plan
- [ ] Run `bun dev` and check `/docs/triggers` for Figure + Video
- [ ] Check `/reference` for Video components
- [ ] Check `/docs/authentication` for Video
- [ ] Verify images load as WebP in DevTools Network tab
- [ ] Test on mobile viewport

🤖 Generated with [Claude Code](https://claude.ai/code)