### PR TITLE
fix: Add redirect for /getting-started/welcome

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -38,6 +38,16 @@ const config = {
         permanent: true,
       },
       {
+        source: '/getting-started/welcome',
+        destination: '/docs',
+        permanent: true,
+      },
+      {
+        source: '/getting-started/:path*',
+        destination: '/docs',
+        permanent: true,
+      },
+      {
         source: '/tool-router',
         destination: '/docs/quickstart',
         permanent: true,


### PR DESCRIPTION
## Summary
- Adds redirect for `/getting-started/welcome` → `/docs`
- Adds catch-all redirect for `/getting-started/*` → `/docs`

Fixes broken link: https://docs.composio.dev/getting-started/welcome

🤖 Generated with [Claude Code](https://claude.com/claude-code)