### PR TITLE
fix(docs): Add redirects for 27 monitored 404 paths

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -323,6 +323,166 @@ const config = {
         destination: '/reference/errors',
         permanent: true,
       },
+      // Old Fern introduction/overview pages
+      {
+        source: '/introduction/intro/overview',
+        destination: '/docs',
+        permanent: true,
+      },
+      {
+        source: '/introduction/intro/quickstart-tools',
+        destination: '/docs/quickstart',
+        permanent: true,
+      },
+      {
+        source: '/introduction/:path*',
+        destination: '/docs',
+        permanent: true,
+      },
+      // Old tool-calling section
+      {
+        source: '/tool-calling/processing-tools',
+        destination: '/docs/tools-direct/executing-tools',
+        permanent: true,
+      },
+      {
+        source: '/tool-calling/introduction',
+        destination: '/docs/tools-and-toolkits',
+        permanent: true,
+      },
+      {
+        source: '/tool-calling/:path*',
+        destination: '/docs/tools-and-toolkits',
+        permanent: true,
+      },
+      // Old framework pages
+      {
+        source: '/framework/crewai',
+        destination: '/docs/providers/crewai',
+        permanent: true,
+      },
+      {
+        source: '/framework/autogen',
+        destination: '/docs/providers',
+        permanent: true,
+      },
+      {
+        source: '/framework/:path*',
+        destination: '/docs/providers',
+        permanent: true,
+      },
+      // Old SDK reference pages
+      {
+        source: '/python-sdk-reference',
+        destination: '/reference',
+        permanent: true,
+      },
+      {
+        source: '/python/introduction',
+        destination: '/docs',
+        permanent: true,
+      },
+      {
+        source: '/python/:path*',
+        destination: '/docs',
+        permanent: true,
+      },
+      // Authentication (bare path without /docs prefix)
+      {
+        source: '/authentication',
+        destination: '/docs/authentication',
+        permanent: true,
+      },
+      // Changelog (bare path without /docs prefix)
+      {
+        source: '/changelog/api-v-3-migration',
+        destination: '/docs/changelog',
+        permanent: true,
+      },
+      {
+        source: '/changelog',
+        destination: '/docs/changelog',
+        permanent: true,
+      },
+      {
+        source: '/changelog/:path*',
+        destination: '/docs/changelog',
+        permanent: true,
+      },
+      // MCP pages
+      {
+        source: '/mcp/overview',
+        destination: '/docs/single-toolkit-mcp',
+        permanent: true,
+      },
+      {
+        source: '/mcp/:path*',
+        destination: '/docs/single-toolkit-mcp',
+        permanent: true,
+      },
+      {
+        source: '/docs/mcp-providers',
+        destination: '/docs/single-toolkit-mcp',
+        permanent: true,
+      },
+      // Patterns section (old Fern)
+      {
+        source: '/patterns/triggers/webhooks',
+        destination: '/docs/triggers',
+        permanent: true,
+      },
+      {
+        source: '/patterns/:path*',
+        destination: '/docs',
+        permanent: true,
+      },
+      // Guides case studies
+      {
+        source: '/guides/casestudy/:path*',
+        destination: '/examples',
+        permanent: true,
+      },
+      // Docs pages that moved or don't exist
+      {
+        source: '/docs/resources/:path*',
+        destination: '/docs',
+        permanent: true,
+      },
+      {
+        source: '/docs/migration',
+        destination: '/docs/migration-guide/tool-router-beta',
+        permanent: true,
+      },
+      {
+        source: '/docs/tools',
+        destination: '/docs/tools-and-toolkits',
+        permanent: true,
+      },
+      {
+        source: '/docs/tool-router/quick-start',
+        destination: '/docs/quickstart',
+        permanent: true,
+      },
+      {
+        source: '/docs/managed-authentication',
+        destination: '/docs/authentication',
+        permanent: true,
+      },
+      {
+        source: '/docs/dev-setup',
+        destination: '/docs/quickstart',
+        permanent: true,
+      },
+      {
+        source: '/docs/providers',
+        destination: '/docs/tools-and-toolkits',
+        permanent: true,
+      },
+      {
+        source: '/docs/providers/custom-providers/my-ai-provider',
+        destination: '/docs/providers/custom-providers/typescript',
+        permanent: true,
+      },
     ];
   },
 };


### PR DESCRIPTION
## Summary
- Adds permanent (301) redirects for 27 old documentation URLs discovered via Datadog 404 monitoring
- Covers old Fern URLs (`/introduction/*`, `/tool-calling/*`, `/framework/*`, `/python/*`, `/patterns/*`, `/changelog/*`, `/mcp/*`) and moved docs pages (`/docs/migration`, `/docs/tools`, `/docs/managed-authentication`, `/docs/dev-setup`, `/docs/providers`, etc.)
- Each redirect maps to the nearest equivalent page in the current documentation

## Redirect mapping

| Old Path | Redirect To |
|---|---|
| `/introduction/intro/overview` | `/docs` |
| `/introduction/intro/quickstart-tools` | `/docs/quickstart` |
| `/introduction/:path*` | `/docs` |
| `/tool-calling/processing-tools` | `/docs/tools-direct/executing-tools` |
| `/tool-calling/introduction` | `/docs/tools-and-toolkits` |
| `/tool-calling/:path*` | `/docs/tools-and-toolkits` |
| `/framework/crewai` | `/docs/providers/crewai` |
| `/framework/autogen` | `/docs/providers` |
| `/framework/:path*` | `/docs/providers` |
| `/python-sdk-reference` | `/reference` |
| `/python/introduction` | `/docs` |
| `/python/:path*` | `/docs` |
| `/authentication` | `/docs/authentication` |
| `/changelog/api-v-3-migration` | `/docs/changelog` |
| `/changelog` | `/docs/changelog` |
| `/changelog/:path*` | `/docs/changelog` |
| `/mcp/overview` | `/docs/single-toolkit-mcp` |
| `/mcp/:path*` | `/docs/single-toolkit-mcp` |
| `/docs/mcp-providers` | `/docs/single-toolkit-mcp` |
| `/patterns/triggers/webhooks` | `/docs/triggers` |
| `/patterns/:path*` | `/docs` |
| `/guides/casestudy/:path*` | `/examples` |
| `/docs/resources/:path*` | `/docs` |
| `/docs/migration` | `/docs/migration-guide/tool-router-beta` |
| `/docs/tools` | `/docs/tools-and-toolkits` |
| `/docs/tool-router/quick-start` | `/docs/quickstart` |
| `/docs/managed-authentication` | `/docs/authentication` |
| `/docs/dev-setup` | `/docs/quickstart` |
| `/docs/providers` | `/docs/tools-and-toolkits` |
| `/docs/providers/custom-providers/my-ai-provider` | `/docs/providers/custom-providers/typescript` |

## Test plan
- [ ] Verify build succeeds on Vercel preview deploy
- [ ] Spot-check redirects by visiting old URLs and confirming 301 to correct destination
- [ ] Confirm no existing pages are accidentally caught by wildcard redirects

🤖 Generated with [Claude Code](https://claude.com/claude-code)