### PR TITLE
feat(docs): Add Playground link to navbar

### DIFF
--- a/docs/lib/layout.shared.tsx
+++ b/docs/lib/layout.shared.tsx
@@ -50,6 +50,11 @@ export function baseOptions(): BaseLayoutProps {
         active: 'nested-url',
       },
       {
+        text: 'Playground',
+        url: 'https://platform.composio.dev/auth?next_page=%2Ftool-router&utm_source=docs&utm_medium=navbar&utm_campaign=tool_router',
+        external: true,
+      },
+      {
         text: 'Examples',
         url: '/examples',
         active: 'nested-url',


### PR DESCRIPTION
## Summary
- Adds a "Playground" external link to the top navigation bar pointing to `https://platform.composio.dev`
- Positioned between "Reference" and "Examples"

## Nav order after change
Docs | Toolkits | Reference | **Playground** | Examples | GitHub | Dashboard

## Test plan
- [ ] Verify Playground link appears in navbar on preview deploy
- [ ] Verify link opens platform.composio.dev in new tab
- [ ] Verify other nav links still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)