### PR TITLE
fix(docs): Handle invalid OpenAPI nullable schema in fetch script

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -222,9 +222,7 @@
           },
           "input_parameters": {
             "type": "object",
-            "additionalProperties": {
-              "nullable": true
-            },
+            "additionalProperties": {},
             "description": "Schema definition of required input parameters for the tool",
             "example": {
               "repo_name": {
@@ -264,9 +262,7 @@
           },
           "output_parameters": {
             "type": "object",
-            "additionalProperties": {
-              "nullable": true
-            },
+            "additionalProperties": {},
             "description": "Schema definition of return values from the tool",
             "example": {
               "run_id": {
@@ -309,11 +305,6 @@
               "automation",
               "devops"
             ]
-          },
-          "status": {
-            "type": "string",
-            "description": "Lifecycle status of the tool",
-            "example": "active"
           },
           "is_deprecated": {
             "type": "boolean",
@@ -384,7 +375,6 @@
           "output_parameters",
           "scopes",
           "tags",
-          "status",
           "is_deprecated",
           "deprecated"
         ]
@@ -999,9 +989,7 @@
                           },
                           "shared_credentials": {
                             "type": "object",
-                            "additionalProperties": {
-                              "nullable": true
-                            },
+                            "additionalProperties": {},
                             "description": "[EXPERIMENTAL] Shared credentials that will be inherited by all connected accounts using this auth config",
                             "x-experimental": true
                           },
@@ -1119,9 +1107,7 @@
                           },
                           "shared_credentials": {
                             "type": "object",
-                            "additionalProperties": {
-                              "nullable": true
-                            },
+                            "additionalProperties": {},
                             "description": "[EXPERIMENTAL] Shared credentials that will be inherited by all connected accounts using this auth config",
                             "x-experimental": true
                           },
@@ -1430,9 +1416,7 @@
                           },
                           "credentials": {
                             "type": "object",
-                            "additionalProperties": {
-                              "nullable": true
-                            },
+                            "additionalProperties": {},
                             "description": "The authentication credentials (tokens, keys, etc.) - may be partially hidden for security"
                           },
                           "proxy_config": {
@@ -1515,9 +1499,7 @@
                           },
                           "shared_credentials": {
                             "type": "object",
-                            "additionalProperties": {
-                              "nullable": true
-                            },
+                            "additionalProperties": {},
                             "description": "[EXPERIMENTAL] Shared credentials that will be inherited by all connected accounts using this auth config",
                             "x-experimental": true
                           },
@@ -1545,9 +1527,7 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 "description": "Deprecated: Fields expected during connection initialization"
                               }
@@ -1736,9 +1716,7 @@
                     },
                     "credentials": {
                       "type": "object",
-                      "additionalProperties": {
-                        "nullable": true
-                      },
+                      "additionalProperties": {},
                       "description": "The authentication credentials (tokens, keys, etc.) - may be partially hidden for security"
                     },
                     "proxy_config": {
@@ -1821,9 +1799,7 @@
                     },
                     "shared_credentials": {
                       "type": "object",
-                      "additionalProperties": {
-                        "nullable": true
-                      },
+                      "additionalProperties": {},
                       "description": "[EXPERIMENTAL] Shared credentials that will be inherited by all connected accounts using this auth config",
                       "x-experimental": true
                     },
@@ -1851,9 +1827,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "additionalProperties": {
-                              "nullable": true
-                            }
+                            "additionalProperties": {}
                           },
                           "description": "Deprecated: Fields expected during connection initialization"
                         }
@@ -2038,9 +2012,7 @@
                       },
                       "shared_credentials": {
                         "type": "object",
-                        "additionalProperties": {
-                          "nullable": true
-                        },
+                        "additionalProperties": {},
                         "description": "Shared credentials that will be inherited by connected accounts. For eg: this can be used to share the API key for a tool with all connected accounts using this auth config."
                       },
                       "is_enabled_for_tool_router": {
@@ -2103,9 +2075,7 @@
                       },
                       "shared_credentials": {
                         "type": "object",
-                        "additionalProperties": {
-                          "nullable": true
-                        },
+                        "additionalProperties": {},
                         "description": "Shared credentials that will be inherited by connected accounts. For eg: this can be used to share the API key for a tool with all connected accounts using this auth config."
                       },
                       "is_enabled_for_tool_router": {
@@ -2720,9 +2690,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -2822,9 +2790,7 @@
                                           "oauth_token_secret",
                                           "redirectUrl"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -2925,9 +2891,7 @@
                                           "oauth_token",
                                           "oauth_token_secret"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -3014,9 +2978,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -3100,9 +3062,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -3203,9 +3163,7 @@
                                           "oauth_token",
                                           "oauth_token_secret"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       }
                                     ]
                                   }
@@ -3314,9 +3272,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -3422,9 +3378,7 @@
                                           "status",
                                           "redirectUrl"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -3572,9 +3526,7 @@
                                           "status",
                                           "access_token"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -3722,9 +3674,7 @@
                                           "status",
                                           "access_token"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -3820,9 +3770,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -3915,9 +3863,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       }
                                     ]
                                   }
@@ -4017,9 +3963,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -4100,9 +4044,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -4195,9 +4137,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -4290,9 +4230,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       }
                                     ]
                                   }
@@ -4392,9 +4330,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -4475,9 +4411,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -4565,9 +4499,7 @@
                                           "status",
                                           "username"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -4655,9 +4587,7 @@
                                           "status",
                                           "username"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       }
                                     ]
                                   }
@@ -4757,9 +4687,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -4840,9 +4768,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -4927,9 +4853,7 @@
                                           "status",
                                           "token"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -5014,9 +4938,7 @@
                                           "status",
                                           "token"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       }
                                     ]
                                   }
@@ -5116,9 +5038,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -5206,9 +5126,7 @@
                                           "status",
                                           "redirectUrl"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -5293,9 +5211,7 @@
                                           "status",
                                           "credentials_json"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -5380,9 +5296,7 @@
                                           "status",
                                           "credentials_json"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       }
                                     ]
                                   }
@@ -5482,9 +5396,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -5565,9 +5477,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -5648,9 +5558,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -5731,9 +5639,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -5820,9 +5726,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -5906,9 +5810,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       }
                                     ]
                                   }
@@ -6008,9 +5910,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -6091,9 +5991,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -6174,9 +6072,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -6257,9 +6153,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -6346,9 +6240,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -6432,9 +6324,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       }
                                     ]
                                   }
@@ -6534,9 +6424,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -6621,9 +6509,7 @@
                                           "status",
                                           "redirectUrl"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -6712,9 +6598,7 @@
                                           "sessionId",
                                           "devKey"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -6803,9 +6687,7 @@
                                           "sessionId",
                                           "devKey"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -6892,9 +6774,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -6978,9 +6858,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       }
                                     ]
                                   }
@@ -7080,9 +6958,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -7163,9 +7039,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -7254,9 +7128,7 @@
                                           "username",
                                           "password"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -7345,9 +7217,7 @@
                                           "username",
                                           "password"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -7442,9 +7312,7 @@
                                           "username",
                                           "password"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -7536,9 +7404,7 @@
                                           "username",
                                           "password"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       }
                                     ]
                                   }
@@ -7638,9 +7504,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -7721,9 +7585,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -7816,9 +7678,7 @@
                                           "installation_id",
                                           "private_key"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -7911,9 +7771,7 @@
                                           "installation_id",
                                           "private_key"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       }
                                     ]
                                   }
@@ -8013,9 +7871,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -8096,9 +7952,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -8179,9 +8033,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -8262,9 +8114,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -8351,9 +8201,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -8437,9 +8285,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       }
                                     ]
                                   }
@@ -8548,9 +8394,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -8668,9 +8512,7 @@
                                           "client_id",
                                           "redirectUrl"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -8818,9 +8660,7 @@
                                           "client_id",
                                           "access_token"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -8968,9 +8808,7 @@
                                           "client_id",
                                           "access_token"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -9066,9 +8904,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       },
                                       {
                                         "type": "object",
@@ -9161,9 +8997,7 @@
                                         "required": [
                                           "status"
                                         ],
-                                        "additionalProperties": {
-                                          "nullable": true
-                                        }
+                                        "additionalProperties": {}
                                       }
                                     ]
                                   }
@@ -9178,9 +9012,7 @@
                           },
                           "data": {
                             "type": "object",
-                            "additionalProperties": {
-                              "nullable": true
-                            },
+                            "additionalProperties": {},
                             "description": "This is deprecated, use `state` instead",
                             "deprecated": true
                           },
@@ -9436,9 +9268,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -9538,9 +9368,7 @@
                                       "oauth_token_secret",
                                       "redirectUrl"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -9641,9 +9469,7 @@
                                       "oauth_token",
                                       "oauth_token_secret"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -9730,9 +9556,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -9816,9 +9640,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -9919,9 +9741,7 @@
                                       "oauth_token",
                                       "oauth_token_secret"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   }
                                 ]
                               }
@@ -10030,9 +9850,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -10138,9 +9956,7 @@
                                       "status",
                                       "redirectUrl"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -10288,9 +10104,7 @@
                                       "status",
                                       "access_token"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -10438,9 +10252,7 @@
                                       "status",
                                       "access_token"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -10536,9 +10348,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -10631,9 +10441,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   }
                                 ]
                               }
@@ -10733,9 +10541,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -10816,9 +10622,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -10911,9 +10715,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -11006,9 +10808,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   }
                                 ]
                               }
@@ -11108,9 +10908,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -11191,9 +10989,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -11281,9 +11077,7 @@
                                       "status",
                                       "username"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -11371,9 +11165,7 @@
                                       "status",
                                       "username"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   }
                                 ]
                               }
@@ -11473,9 +11265,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -11556,9 +11346,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -11643,9 +11431,7 @@
                                       "status",
                                       "token"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -11730,9 +11516,7 @@
                                       "status",
                                       "token"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   }
                                 ]
                               }
@@ -11832,9 +11616,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -11922,9 +11704,7 @@
                                       "status",
                                       "redirectUrl"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -12009,9 +11789,7 @@
                                       "status",
                                       "credentials_json"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -12096,9 +11874,7 @@
                                       "status",
                                       "credentials_json"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   }
                                 ]
                               }
@@ -12198,9 +11974,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -12281,9 +12055,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -12364,9 +12136,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -12447,9 +12217,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -12536,9 +12304,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -12622,9 +12388,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   }
                                 ]
                               }
@@ -12724,9 +12488,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -12807,9 +12569,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -12890,9 +12650,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -12973,9 +12731,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -13062,9 +12818,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -13148,9 +12902,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   }
                                 ]
                               }
@@ -13250,9 +13002,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -13337,9 +13087,7 @@
                                       "status",
                                       "redirectUrl"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -13428,9 +13176,7 @@
                                       "sessionId",
                                       "devKey"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -13519,9 +13265,7 @@
                                       "sessionId",
                                       "devKey"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -13608,9 +13352,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -13694,9 +13436,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   }
                                 ]
                               }
@@ -13796,9 +13536,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -13879,9 +13617,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -13970,9 +13706,7 @@
                                       "username",
                                       "password"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -14061,9 +13795,7 @@
                                       "username",
                                       "password"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -14158,9 +13890,7 @@
                                       "username",
                                       "password"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -14252,9 +13982,7 @@
                                       "username",
                                       "password"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   }
                                 ]
                               }
@@ -14354,9 +14082,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -14437,9 +14163,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -14532,9 +14256,7 @@
                                       "installation_id",
                                       "private_key"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -14627,9 +14349,7 @@
                                       "installation_id",
                                       "private_key"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   }
                                 ]
                               }
@@ -14729,9 +14449,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -14812,9 +14530,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -14895,9 +14611,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -14978,9 +14692,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -15067,9 +14779,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -15153,9 +14863,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   }
                                 ]
                               }
@@ -15264,9 +14972,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -15384,9 +15090,7 @@
                                       "client_id",
                                       "redirectUrl"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -15534,9 +15238,7 @@
                                       "client_id",
                                       "access_token"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -15684,9 +15386,7 @@
                                       "client_id",
                                       "access_token"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -15782,9 +15482,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   },
                                   {
                                     "type": "object",
@@ -15877,9 +15575,7 @@
                                     "required": [
                                       "status"
                                     ],
-                                    "additionalProperties": {
-                                      "nullable": true
-                                    }
+                                    "additionalProperties": {}
                                   }
                                 ]
                               }
@@ -15894,9 +15590,7 @@
                       },
                       "data": {
                         "type": "object",
-                        "additionalProperties": {
-                          "nullable": true
-                        },
+                        "additionalProperties": {},
                         "description": "DEPRECATED: This parameter will be removed in a future version. Please use state instead.",
                         "deprecated": true
                       },
@@ -16044,9 +15738,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -16146,9 +15838,7 @@
                                     "oauth_token_secret",
                                     "redirectUrl"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -16249,9 +15939,7 @@
                                     "oauth_token",
                                     "oauth_token_secret"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -16338,9 +16026,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -16424,9 +16110,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -16527,9 +16211,7 @@
                                     "oauth_token",
                                     "oauth_token_secret"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 }
                               ]
                             }
@@ -16638,9 +16320,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -16746,9 +16426,7 @@
                                     "status",
                                     "redirectUrl"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -16896,9 +16574,7 @@
                                     "status",
                                     "access_token"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -17046,9 +16722,7 @@
                                     "status",
                                     "access_token"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -17144,9 +16818,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -17239,9 +16911,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 }
                               ]
                             }
@@ -17341,9 +17011,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -17424,9 +17092,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -17519,9 +17185,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -17614,9 +17278,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 }
                               ]
                             }
@@ -17716,9 +17378,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -17799,9 +17459,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -17889,9 +17547,7 @@
                                     "status",
                                     "username"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -17979,9 +17635,7 @@
                                     "status",
                                     "username"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 }
                               ]
                             }
@@ -18081,9 +17735,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -18164,9 +17816,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -18251,9 +17901,7 @@
                                     "status",
                                     "token"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -18338,9 +17986,7 @@
                                     "status",
                                     "token"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 }
                               ]
                             }
@@ -18440,9 +18086,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -18530,9 +18174,7 @@
                                     "status",
                                     "redirectUrl"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -18617,9 +18259,7 @@
                                     "status",
                                     "credentials_json"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -18704,9 +18344,7 @@
                                     "status",
                                     "credentials_json"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 }
                               ]
                             }
@@ -18806,9 +18444,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -18889,9 +18525,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -18972,9 +18606,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -19055,9 +18687,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -19144,9 +18774,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -19230,9 +18858,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 }
                               ]
                             }
@@ -19332,9 +18958,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -19415,9 +19039,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -19498,9 +19120,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -19581,9 +19201,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -19670,9 +19288,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -19756,9 +19372,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 }
                               ]
                             }
@@ -19858,9 +19472,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -19945,9 +19557,7 @@
                                     "status",
                                     "redirectUrl"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -20036,9 +19646,7 @@
                                     "sessionId",
                                     "devKey"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -20127,9 +19735,7 @@
                                     "sessionId",
                                     "devKey"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -20216,9 +19822,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -20302,9 +19906,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 }
                               ]
                             }
@@ -20404,9 +20006,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -20487,9 +20087,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -20578,9 +20176,7 @@
                                     "username",
                                     "password"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -20669,9 +20265,7 @@
                                     "username",
                                     "password"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -20766,9 +20360,7 @@
                                     "username",
                                     "password"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -20860,9 +20452,7 @@
                                     "username",
                                     "password"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 }
                               ]
                             }
@@ -20962,9 +20552,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -21045,9 +20633,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -21140,9 +20726,7 @@
                                     "installation_id",
                                     "private_key"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -21235,9 +20819,7 @@
                                     "installation_id",
                                     "private_key"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 }
                               ]
                             }
@@ -21337,9 +20919,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -21420,9 +21000,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -21503,9 +21081,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -21586,9 +21162,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -21675,9 +21249,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -21761,9 +21333,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 }
                               ]
                             }
@@ -21872,9 +21442,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -21992,9 +21560,7 @@
                                     "client_id",
                                     "redirectUrl"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -22142,9 +21708,7 @@
                                     "client_id",
                                     "access_token"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -22292,9 +21856,7 @@
                                     "client_id",
                                     "access_token"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -22390,9 +21952,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -22485,9 +22045,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 }
                               ]
                             }
@@ -22838,9 +22396,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -22940,9 +22496,7 @@
                                     "oauth_token_secret",
                                     "redirectUrl"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -23043,9 +22597,7 @@
                                     "oauth_token",
                                     "oauth_token_secret"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -23132,9 +22684,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -23218,9 +22768,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -23321,9 +22869,7 @@
                                     "oauth_token",
                                     "oauth_token_secret"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 }
                               ]
                             }
@@ -23432,9 +22978,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -23540,9 +23084,7 @@
                                     "status",
                                     "redirectUrl"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -23690,9 +23232,7 @@
                                     "status",
                                     "access_token"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -23840,9 +23380,7 @@
                                     "status",
                                     "access_token"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -23938,9 +23476,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -24033,9 +23569,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 }
                               ]
                             }
@@ -24135,9 +23669,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -24218,9 +23750,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -24313,9 +23843,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -24408,9 +23936,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 }
                               ]
                             }
@@ -24510,9 +24036,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -24593,9 +24117,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -24683,9 +24205,7 @@
                                     "status",
                                     "username"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -24773,9 +24293,7 @@
                                     "status",
                                     "username"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 }
                               ]
                             }
@@ -24875,9 +24393,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -24958,9 +24474,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -25045,9 +24559,7 @@
                                     "status",
                                     "token"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -25132,9 +24644,7 @@
                                     "status",
                                     "token"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 }
                               ]
                             }
@@ -25234,9 +24744,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -25324,9 +24832,7 @@
                                     "status",
                                     "redirectUrl"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -25411,9 +24917,7 @@
                                     "status",
                                     "credentials_json"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -25498,9 +25002,7 @@
                                     "status",
                                     "credentials_json"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 }
                               ]
                             }
@@ -25600,9 +25102,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -25683,9 +25183,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -25766,9 +25264,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -25849,9 +25345,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -25938,9 +25432,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -26024,9 +25516,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 }
                               ]
                             }
@@ -26126,9 +25616,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -26209,9 +25697,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -26292,9 +25778,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -26375,9 +25859,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -26464,9 +25946,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -26550,9 +26030,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 }
                               ]
                             }
@@ -26652,9 +26130,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -26739,9 +26215,7 @@
                                     "status",
                                     "redirectUrl"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -26830,9 +26304,7 @@
                                     "sessionId",
                                     "devKey"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -26921,9 +26393,7 @@
                                     "sessionId",
                                     "devKey"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -27010,9 +26480,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -27096,9 +26564,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 }
                               ]
                             }
@@ -27198,9 +26664,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -27281,9 +26745,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -27372,9 +26834,7 @@
                                     "username",
                                     "password"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -27463,9 +26923,7 @@
                                     "username",
                                     "password"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -27560,9 +27018,7 @@
                                     "username",
                                     "password"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -27654,9 +27110,7 @@
                                     "username",
                                     "password"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 }
                               ]
                             }
@@ -27756,9 +27210,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -27839,9 +27291,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -27934,9 +27384,7 @@
                                     "installation_id",
                                     "private_key"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -28029,9 +27477,7 @@
                                     "installation_id",
                                     "private_key"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 }
                               ]
                             }
@@ -28131,9 +27577,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -28214,9 +27658,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -28297,9 +27739,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -28380,9 +27820,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -28469,9 +27907,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -28555,9 +27991,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 }
                               ]
                             }
@@ -28666,9 +28100,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -28786,9 +28218,7 @@
                                     "client_id",
                                     "redirectUrl"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -28936,9 +28366,7 @@
                                     "client_id",
                                     "access_token"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -29086,9 +28514,7 @@
                                     "client_id",
                                     "access_token"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -29184,9 +28610,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "object",
@@ -29279,9 +28703,7 @@
                                   "required": [
                                     "status"
                                   ],
-                                  "additionalProperties": {
-                                    "nullable": true
-                                  }
+                                  "additionalProperties": {}
                                 }
                               ]
                             }
@@ -29296,9 +28718,7 @@
                     },
                     "data": {
                       "type": "object",
-                      "additionalProperties": {
-                        "nullable": true
-                      },
+                      "additionalProperties": {},
                       "description": "This is deprecated, use `state` instead",
                       "deprecated": true
                     },
@@ -29339,9 +28759,7 @@
                     },
                     "params": {
                       "type": "object",
-                      "additionalProperties": {
-                        "nullable": true
-                      },
+                      "additionalProperties": {},
                       "description": "The initialization data of the connection, including configuration parameters",
                       "deprecated": true
                     }
@@ -29921,9 +29339,7 @@
                             "type": "string"
                           }
                         },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -30016,9 +29432,7 @@
                           "oauth_token_secret",
                           "redirectUrl"
                         ],
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -30112,9 +29526,7 @@
                           "oauth_token",
                           "oauth_token_secret"
                         ],
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -30192,9 +29604,7 @@
                             "type": "string"
                           }
                         },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -30269,9 +29679,7 @@
                             "type": "string"
                           }
                         },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -30365,9 +29773,7 @@
                           "oauth_token",
                           "oauth_token_secret"
                         ],
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -30448,9 +29854,7 @@
                             "description": "Whether to return the redirect url without shortening"
                           }
                         },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -30549,9 +29953,7 @@
                         "required": [
                           "redirectUrl"
                         ],
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -30692,9 +30094,7 @@
                         "required": [
                           "access_token"
                         ],
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -30835,9 +30235,7 @@
                         "required": [
                           "access_token"
                         ],
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -30924,9 +30322,7 @@
                             "type": "string"
                           }
                         },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -31010,9 +30406,7 @@
                             "type": "string"
                           }
                         },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -31084,9 +30478,7 @@
                             "type": "string"
                           }
                         },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -31158,95 +30550,7 @@
                             "type": "string"
                           }
                         },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "subdomain": {
-                            "type": "string"
-                          },
-                          "your-domain": {
-                            "type": "string"
-                          },
-                          "region": {
-                            "type": "string"
-                          },
-                          "shop": {
-                            "type": "string"
-                          },
-                          "account_url": {
-                            "type": "string"
-                          },
-                          "COMPANYDOMAIN": {
-                            "type": "string"
-                          },
-                          "extension": {
-                            "type": "string"
-                          },
-                          "form_api_base_url": {
-                            "type": "string"
-                          },
-                          "instanceEndpoint": {
-                            "type": "string"
-                          },
-                          "api_url": {
-                            "type": "string"
-                          },
-                          "borneo_dashboard_url": {
-                            "type": "string"
-                          },
-                          "proxy_username": {
-                            "type": "string"
-                          },
-                          "proxy_password": {
-                            "type": "string"
-                          },
-                          "domain": {
-                            "type": "string"
-                          },
-                          "version": {
-                            "type": "string"
-                          },
-                          "dc": {
-                            "type": "string"
-                          },
-                          "site_name": {
-                            "type": "string"
-                          },
-                          "instanceName": {
-                            "type": "string"
-                          },
-                          "account_id": {
-                            "type": "string"
-                          },
-                          "your_server": {
-                            "type": "string"
-                          },
-                          "server_location": {
-                            "type": "string"
-                          },
-                          "base_url": {
-                            "type": "string"
-                          },
-                          "generic_api_key": {
-                            "type": "string"
-                          },
-                          "api_key": {
-                            "type": "string"
-                          },
-                          "bearer_token": {
-                            "type": "string"
-                          },
-                          "basic_encoded": {
-                            "type": "string"
-                          }
-                        },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -31330,9 +30634,91 @@
                             "type": "string"
                           }
                         },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "subdomain": {
+                            "type": "string"
+                          },
+                          "your-domain": {
+                            "type": "string"
+                          },
+                          "region": {
+                            "type": "string"
+                          },
+                          "shop": {
+                            "type": "string"
+                          },
+                          "account_url": {
+                            "type": "string"
+                          },
+                          "COMPANYDOMAIN": {
+                            "type": "string"
+                          },
+                          "extension": {
+                            "type": "string"
+                          },
+                          "form_api_base_url": {
+                            "type": "string"
+                          },
+                          "instanceEndpoint": {
+                            "type": "string"
+                          },
+                          "api_url": {
+                            "type": "string"
+                          },
+                          "borneo_dashboard_url": {
+                            "type": "string"
+                          },
+                          "proxy_username": {
+                            "type": "string"
+                          },
+                          "proxy_password": {
+                            "type": "string"
+                          },
+                          "domain": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "string"
+                          },
+                          "dc": {
+                            "type": "string"
+                          },
+                          "site_name": {
+                            "type": "string"
+                          },
+                          "instanceName": {
+                            "type": "string"
+                          },
+                          "account_id": {
+                            "type": "string"
+                          },
+                          "your_server": {
+                            "type": "string"
+                          },
+                          "server_location": {
+                            "type": "string"
+                          },
+                          "base_url": {
+                            "type": "string"
+                          },
+                          "generic_api_key": {
+                            "type": "string"
+                          },
+                          "api_key": {
+                            "type": "string"
+                          },
+                          "bearer_token": {
+                            "type": "string"
+                          },
+                          "basic_encoded": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -31404,9 +30790,7 @@
                             "type": "string"
                           }
                         },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -31478,9 +30862,7 @@
                             "type": "string"
                           }
                         },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -31561,9 +30943,7 @@
                         "required": [
                           "username"
                         ],
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -31644,9 +31024,7 @@
                         "required": [
                           "username"
                         ],
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -31718,9 +31096,7 @@
                             "type": "string"
                           }
                         },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -31792,89 +31168,7 @@
                             "type": "string"
                           }
                         },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "subdomain": {
-                            "type": "string"
-                          },
-                          "your-domain": {
-                            "type": "string"
-                          },
-                          "region": {
-                            "type": "string"
-                          },
-                          "shop": {
-                            "type": "string"
-                          },
-                          "account_url": {
-                            "type": "string"
-                          },
-                          "COMPANYDOMAIN": {
-                            "type": "string"
-                          },
-                          "extension": {
-                            "type": "string"
-                          },
-                          "form_api_base_url": {
-                            "type": "string"
-                          },
-                          "instanceEndpoint": {
-                            "type": "string"
-                          },
-                          "api_url": {
-                            "type": "string"
-                          },
-                          "borneo_dashboard_url": {
-                            "type": "string"
-                          },
-                          "proxy_username": {
-                            "type": "string"
-                          },
-                          "proxy_password": {
-                            "type": "string"
-                          },
-                          "domain": {
-                            "type": "string"
-                          },
-                          "version": {
-                            "type": "string"
-                          },
-                          "dc": {
-                            "type": "string"
-                          },
-                          "site_name": {
-                            "type": "string"
-                          },
-                          "instanceName": {
-                            "type": "string"
-                          },
-                          "account_id": {
-                            "type": "string"
-                          },
-                          "your_server": {
-                            "type": "string"
-                          },
-                          "server_location": {
-                            "type": "string"
-                          },
-                          "base_url": {
-                            "type": "string"
-                          },
-                          "token": {
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "token"
-                        ],
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -31952,9 +31246,85 @@
                         "required": [
                           "token"
                         ],
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "subdomain": {
+                            "type": "string"
+                          },
+                          "your-domain": {
+                            "type": "string"
+                          },
+                          "region": {
+                            "type": "string"
+                          },
+                          "shop": {
+                            "type": "string"
+                          },
+                          "account_url": {
+                            "type": "string"
+                          },
+                          "COMPANYDOMAIN": {
+                            "type": "string"
+                          },
+                          "extension": {
+                            "type": "string"
+                          },
+                          "form_api_base_url": {
+                            "type": "string"
+                          },
+                          "instanceEndpoint": {
+                            "type": "string"
+                          },
+                          "api_url": {
+                            "type": "string"
+                          },
+                          "borneo_dashboard_url": {
+                            "type": "string"
+                          },
+                          "proxy_username": {
+                            "type": "string"
+                          },
+                          "proxy_password": {
+                            "type": "string"
+                          },
+                          "domain": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "string"
+                          },
+                          "dc": {
+                            "type": "string"
+                          },
+                          "site_name": {
+                            "type": "string"
+                          },
+                          "instanceName": {
+                            "type": "string"
+                          },
+                          "account_id": {
+                            "type": "string"
+                          },
+                          "your_server": {
+                            "type": "string"
+                          },
+                          "server_location": {
+                            "type": "string"
+                          },
+                          "base_url": {
+                            "type": "string"
+                          },
+                          "token": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "token"
+                        ],
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -32026,9 +31396,7 @@
                             "type": "string"
                           }
                         },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -32109,9 +31477,7 @@
                         "required": [
                           "redirectUrl"
                         ],
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -32189,9 +31555,7 @@
                         "required": [
                           "credentials_json"
                         ],
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -32269,9 +31633,7 @@
                         "required": [
                           "credentials_json"
                         ],
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -32343,9 +31705,7 @@
                             "type": "string"
                           }
                         },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -32417,9 +31777,7 @@
                             "type": "string"
                           }
                         },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -32491,9 +31849,7 @@
                             "type": "string"
                           }
                         },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -32565,462 +31921,7 @@
                             "type": "string"
                           }
                         },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "subdomain": {
-                            "type": "string"
-                          },
-                          "your-domain": {
-                            "type": "string"
-                          },
-                          "region": {
-                            "type": "string"
-                          },
-                          "shop": {
-                            "type": "string"
-                          },
-                          "account_url": {
-                            "type": "string"
-                          },
-                          "COMPANYDOMAIN": {
-                            "type": "string"
-                          },
-                          "extension": {
-                            "type": "string"
-                          },
-                          "form_api_base_url": {
-                            "type": "string"
-                          },
-                          "instanceEndpoint": {
-                            "type": "string"
-                          },
-                          "api_url": {
-                            "type": "string"
-                          },
-                          "borneo_dashboard_url": {
-                            "type": "string"
-                          },
-                          "proxy_username": {
-                            "type": "string"
-                          },
-                          "proxy_password": {
-                            "type": "string"
-                          },
-                          "domain": {
-                            "type": "string"
-                          },
-                          "version": {
-                            "type": "string"
-                          },
-                          "dc": {
-                            "type": "string"
-                          },
-                          "site_name": {
-                            "type": "string"
-                          },
-                          "instanceName": {
-                            "type": "string"
-                          },
-                          "account_id": {
-                            "type": "string"
-                          },
-                          "your_server": {
-                            "type": "string"
-                          },
-                          "server_location": {
-                            "type": "string"
-                          },
-                          "base_url": {
-                            "type": "string"
-                          },
-                          "error": {
-                            "type": "string"
-                          },
-                          "error_description": {
-                            "type": "string"
-                          }
-                        },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "subdomain": {
-                            "type": "string"
-                          },
-                          "your-domain": {
-                            "type": "string"
-                          },
-                          "region": {
-                            "type": "string"
-                          },
-                          "shop": {
-                            "type": "string"
-                          },
-                          "account_url": {
-                            "type": "string"
-                          },
-                          "COMPANYDOMAIN": {
-                            "type": "string"
-                          },
-                          "extension": {
-                            "type": "string"
-                          },
-                          "form_api_base_url": {
-                            "type": "string"
-                          },
-                          "instanceEndpoint": {
-                            "type": "string"
-                          },
-                          "api_url": {
-                            "type": "string"
-                          },
-                          "borneo_dashboard_url": {
-                            "type": "string"
-                          },
-                          "proxy_username": {
-                            "type": "string"
-                          },
-                          "proxy_password": {
-                            "type": "string"
-                          },
-                          "domain": {
-                            "type": "string"
-                          },
-                          "version": {
-                            "type": "string"
-                          },
-                          "dc": {
-                            "type": "string"
-                          },
-                          "site_name": {
-                            "type": "string"
-                          },
-                          "instanceName": {
-                            "type": "string"
-                          },
-                          "account_id": {
-                            "type": "string"
-                          },
-                          "your_server": {
-                            "type": "string"
-                          },
-                          "server_location": {
-                            "type": "string"
-                          },
-                          "base_url": {
-                            "type": "string"
-                          },
-                          "expired_at": {
-                            "type": "string"
-                          }
-                        },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "subdomain": {
-                            "type": "string"
-                          },
-                          "your-domain": {
-                            "type": "string"
-                          },
-                          "region": {
-                            "type": "string"
-                          },
-                          "shop": {
-                            "type": "string"
-                          },
-                          "account_url": {
-                            "type": "string"
-                          },
-                          "COMPANYDOMAIN": {
-                            "type": "string"
-                          },
-                          "extension": {
-                            "type": "string"
-                          },
-                          "form_api_base_url": {
-                            "type": "string"
-                          },
-                          "instanceEndpoint": {
-                            "type": "string"
-                          },
-                          "api_url": {
-                            "type": "string"
-                          },
-                          "borneo_dashboard_url": {
-                            "type": "string"
-                          },
-                          "proxy_username": {
-                            "type": "string"
-                          },
-                          "proxy_password": {
-                            "type": "string"
-                          },
-                          "domain": {
-                            "type": "string"
-                          },
-                          "version": {
-                            "type": "string"
-                          },
-                          "dc": {
-                            "type": "string"
-                          },
-                          "site_name": {
-                            "type": "string"
-                          },
-                          "instanceName": {
-                            "type": "string"
-                          },
-                          "account_id": {
-                            "type": "string"
-                          },
-                          "your_server": {
-                            "type": "string"
-                          },
-                          "server_location": {
-                            "type": "string"
-                          },
-                          "base_url": {
-                            "type": "string"
-                          }
-                        },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "subdomain": {
-                            "type": "string"
-                          },
-                          "your-domain": {
-                            "type": "string"
-                          },
-                          "region": {
-                            "type": "string"
-                          },
-                          "shop": {
-                            "type": "string"
-                          },
-                          "account_url": {
-                            "type": "string"
-                          },
-                          "COMPANYDOMAIN": {
-                            "type": "string"
-                          },
-                          "extension": {
-                            "type": "string"
-                          },
-                          "form_api_base_url": {
-                            "type": "string"
-                          },
-                          "instanceEndpoint": {
-                            "type": "string"
-                          },
-                          "api_url": {
-                            "type": "string"
-                          },
-                          "borneo_dashboard_url": {
-                            "type": "string"
-                          },
-                          "proxy_username": {
-                            "type": "string"
-                          },
-                          "proxy_password": {
-                            "type": "string"
-                          },
-                          "domain": {
-                            "type": "string"
-                          },
-                          "version": {
-                            "type": "string"
-                          },
-                          "dc": {
-                            "type": "string"
-                          },
-                          "site_name": {
-                            "type": "string"
-                          },
-                          "instanceName": {
-                            "type": "string"
-                          },
-                          "account_id": {
-                            "type": "string"
-                          },
-                          "your_server": {
-                            "type": "string"
-                          },
-                          "server_location": {
-                            "type": "string"
-                          },
-                          "base_url": {
-                            "type": "string"
-                          }
-                        },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "subdomain": {
-                            "type": "string"
-                          },
-                          "your-domain": {
-                            "type": "string"
-                          },
-                          "region": {
-                            "type": "string"
-                          },
-                          "shop": {
-                            "type": "string"
-                          },
-                          "account_url": {
-                            "type": "string"
-                          },
-                          "COMPANYDOMAIN": {
-                            "type": "string"
-                          },
-                          "extension": {
-                            "type": "string"
-                          },
-                          "form_api_base_url": {
-                            "type": "string"
-                          },
-                          "instanceEndpoint": {
-                            "type": "string"
-                          },
-                          "api_url": {
-                            "type": "string"
-                          },
-                          "borneo_dashboard_url": {
-                            "type": "string"
-                          },
-                          "proxy_username": {
-                            "type": "string"
-                          },
-                          "proxy_password": {
-                            "type": "string"
-                          },
-                          "domain": {
-                            "type": "string"
-                          },
-                          "version": {
-                            "type": "string"
-                          },
-                          "dc": {
-                            "type": "string"
-                          },
-                          "site_name": {
-                            "type": "string"
-                          },
-                          "instanceName": {
-                            "type": "string"
-                          },
-                          "account_id": {
-                            "type": "string"
-                          },
-                          "your_server": {
-                            "type": "string"
-                          },
-                          "server_location": {
-                            "type": "string"
-                          },
-                          "base_url": {
-                            "type": "string"
-                          }
-                        },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "subdomain": {
-                            "type": "string"
-                          },
-                          "your-domain": {
-                            "type": "string"
-                          },
-                          "region": {
-                            "type": "string"
-                          },
-                          "shop": {
-                            "type": "string"
-                          },
-                          "account_url": {
-                            "type": "string"
-                          },
-                          "COMPANYDOMAIN": {
-                            "type": "string"
-                          },
-                          "extension": {
-                            "type": "string"
-                          },
-                          "form_api_base_url": {
-                            "type": "string"
-                          },
-                          "instanceEndpoint": {
-                            "type": "string"
-                          },
-                          "api_url": {
-                            "type": "string"
-                          },
-                          "borneo_dashboard_url": {
-                            "type": "string"
-                          },
-                          "proxy_username": {
-                            "type": "string"
-                          },
-                          "proxy_password": {
-                            "type": "string"
-                          },
-                          "domain": {
-                            "type": "string"
-                          },
-                          "version": {
-                            "type": "string"
-                          },
-                          "dc": {
-                            "type": "string"
-                          },
-                          "site_name": {
-                            "type": "string"
-                          },
-                          "instanceName": {
-                            "type": "string"
-                          },
-                          "account_id": {
-                            "type": "string"
-                          },
-                          "your_server": {
-                            "type": "string"
-                          },
-                          "server_location": {
-                            "type": "string"
-                          },
-                          "base_url": {
-                            "type": "string"
-                          }
-                        },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -33098,9 +31999,7 @@
                             "type": "string"
                           }
                         },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -33175,9 +32074,7 @@
                             "type": "string"
                           }
                         },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -33249,9 +32146,448 @@
                             "type": "string"
                           }
                         },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "subdomain": {
+                            "type": "string"
+                          },
+                          "your-domain": {
+                            "type": "string"
+                          },
+                          "region": {
+                            "type": "string"
+                          },
+                          "shop": {
+                            "type": "string"
+                          },
+                          "account_url": {
+                            "type": "string"
+                          },
+                          "COMPANYDOMAIN": {
+                            "type": "string"
+                          },
+                          "extension": {
+                            "type": "string"
+                          },
+                          "form_api_base_url": {
+                            "type": "string"
+                          },
+                          "instanceEndpoint": {
+                            "type": "string"
+                          },
+                          "api_url": {
+                            "type": "string"
+                          },
+                          "borneo_dashboard_url": {
+                            "type": "string"
+                          },
+                          "proxy_username": {
+                            "type": "string"
+                          },
+                          "proxy_password": {
+                            "type": "string"
+                          },
+                          "domain": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "string"
+                          },
+                          "dc": {
+                            "type": "string"
+                          },
+                          "site_name": {
+                            "type": "string"
+                          },
+                          "instanceName": {
+                            "type": "string"
+                          },
+                          "account_id": {
+                            "type": "string"
+                          },
+                          "your_server": {
+                            "type": "string"
+                          },
+                          "server_location": {
+                            "type": "string"
+                          },
+                          "base_url": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": {}
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "subdomain": {
+                            "type": "string"
+                          },
+                          "your-domain": {
+                            "type": "string"
+                          },
+                          "region": {
+                            "type": "string"
+                          },
+                          "shop": {
+                            "type": "string"
+                          },
+                          "account_url": {
+                            "type": "string"
+                          },
+                          "COMPANYDOMAIN": {
+                            "type": "string"
+                          },
+                          "extension": {
+                            "type": "string"
+                          },
+                          "form_api_base_url": {
+                            "type": "string"
+                          },
+                          "instanceEndpoint": {
+                            "type": "string"
+                          },
+                          "api_url": {
+                            "type": "string"
+                          },
+                          "borneo_dashboard_url": {
+                            "type": "string"
+                          },
+                          "proxy_username": {
+                            "type": "string"
+                          },
+                          "proxy_password": {
+                            "type": "string"
+                          },
+                          "domain": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "string"
+                          },
+                          "dc": {
+                            "type": "string"
+                          },
+                          "site_name": {
+                            "type": "string"
+                          },
+                          "instanceName": {
+                            "type": "string"
+                          },
+                          "account_id": {
+                            "type": "string"
+                          },
+                          "your_server": {
+                            "type": "string"
+                          },
+                          "server_location": {
+                            "type": "string"
+                          },
+                          "base_url": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": {}
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "subdomain": {
+                            "type": "string"
+                          },
+                          "your-domain": {
+                            "type": "string"
+                          },
+                          "region": {
+                            "type": "string"
+                          },
+                          "shop": {
+                            "type": "string"
+                          },
+                          "account_url": {
+                            "type": "string"
+                          },
+                          "COMPANYDOMAIN": {
+                            "type": "string"
+                          },
+                          "extension": {
+                            "type": "string"
+                          },
+                          "form_api_base_url": {
+                            "type": "string"
+                          },
+                          "instanceEndpoint": {
+                            "type": "string"
+                          },
+                          "api_url": {
+                            "type": "string"
+                          },
+                          "borneo_dashboard_url": {
+                            "type": "string"
+                          },
+                          "proxy_username": {
+                            "type": "string"
+                          },
+                          "proxy_password": {
+                            "type": "string"
+                          },
+                          "domain": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "string"
+                          },
+                          "dc": {
+                            "type": "string"
+                          },
+                          "site_name": {
+                            "type": "string"
+                          },
+                          "instanceName": {
+                            "type": "string"
+                          },
+                          "account_id": {
+                            "type": "string"
+                          },
+                          "your_server": {
+                            "type": "string"
+                          },
+                          "server_location": {
+                            "type": "string"
+                          },
+                          "base_url": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": {}
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "subdomain": {
+                            "type": "string"
+                          },
+                          "your-domain": {
+                            "type": "string"
+                          },
+                          "region": {
+                            "type": "string"
+                          },
+                          "shop": {
+                            "type": "string"
+                          },
+                          "account_url": {
+                            "type": "string"
+                          },
+                          "COMPANYDOMAIN": {
+                            "type": "string"
+                          },
+                          "extension": {
+                            "type": "string"
+                          },
+                          "form_api_base_url": {
+                            "type": "string"
+                          },
+                          "instanceEndpoint": {
+                            "type": "string"
+                          },
+                          "api_url": {
+                            "type": "string"
+                          },
+                          "borneo_dashboard_url": {
+                            "type": "string"
+                          },
+                          "proxy_username": {
+                            "type": "string"
+                          },
+                          "proxy_password": {
+                            "type": "string"
+                          },
+                          "domain": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "string"
+                          },
+                          "dc": {
+                            "type": "string"
+                          },
+                          "site_name": {
+                            "type": "string"
+                          },
+                          "instanceName": {
+                            "type": "string"
+                          },
+                          "account_id": {
+                            "type": "string"
+                          },
+                          "your_server": {
+                            "type": "string"
+                          },
+                          "server_location": {
+                            "type": "string"
+                          },
+                          "base_url": {
+                            "type": "string"
+                          },
+                          "error": {
+                            "type": "string"
+                          },
+                          "error_description": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": {}
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "subdomain": {
+                            "type": "string"
+                          },
+                          "your-domain": {
+                            "type": "string"
+                          },
+                          "region": {
+                            "type": "string"
+                          },
+                          "shop": {
+                            "type": "string"
+                          },
+                          "account_url": {
+                            "type": "string"
+                          },
+                          "COMPANYDOMAIN": {
+                            "type": "string"
+                          },
+                          "extension": {
+                            "type": "string"
+                          },
+                          "form_api_base_url": {
+                            "type": "string"
+                          },
+                          "instanceEndpoint": {
+                            "type": "string"
+                          },
+                          "api_url": {
+                            "type": "string"
+                          },
+                          "borneo_dashboard_url": {
+                            "type": "string"
+                          },
+                          "proxy_username": {
+                            "type": "string"
+                          },
+                          "proxy_password": {
+                            "type": "string"
+                          },
+                          "domain": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "string"
+                          },
+                          "dc": {
+                            "type": "string"
+                          },
+                          "site_name": {
+                            "type": "string"
+                          },
+                          "instanceName": {
+                            "type": "string"
+                          },
+                          "account_id": {
+                            "type": "string"
+                          },
+                          "your_server": {
+                            "type": "string"
+                          },
+                          "server_location": {
+                            "type": "string"
+                          },
+                          "base_url": {
+                            "type": "string"
+                          },
+                          "expired_at": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": {}
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "subdomain": {
+                            "type": "string"
+                          },
+                          "your-domain": {
+                            "type": "string"
+                          },
+                          "region": {
+                            "type": "string"
+                          },
+                          "shop": {
+                            "type": "string"
+                          },
+                          "account_url": {
+                            "type": "string"
+                          },
+                          "COMPANYDOMAIN": {
+                            "type": "string"
+                          },
+                          "extension": {
+                            "type": "string"
+                          },
+                          "form_api_base_url": {
+                            "type": "string"
+                          },
+                          "instanceEndpoint": {
+                            "type": "string"
+                          },
+                          "api_url": {
+                            "type": "string"
+                          },
+                          "borneo_dashboard_url": {
+                            "type": "string"
+                          },
+                          "proxy_username": {
+                            "type": "string"
+                          },
+                          "proxy_password": {
+                            "type": "string"
+                          },
+                          "domain": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "string"
+                          },
+                          "dc": {
+                            "type": "string"
+                          },
+                          "site_name": {
+                            "type": "string"
+                          },
+                          "instanceName": {
+                            "type": "string"
+                          },
+                          "account_id": {
+                            "type": "string"
+                          },
+                          "your_server": {
+                            "type": "string"
+                          },
+                          "server_location": {
+                            "type": "string"
+                          },
+                          "base_url": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -33329,9 +32665,7 @@
                         "required": [
                           "redirectUrl"
                         ],
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -33413,9 +32747,7 @@
                           "sessionId",
                           "devKey"
                         ],
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -33497,9 +32829,7 @@
                           "sessionId",
                           "devKey"
                         ],
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -33577,9 +32907,7 @@
                             "type": "string"
                           }
                         },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -33654,9 +32982,7 @@
                             "type": "string"
                           }
                         },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -33728,9 +33054,7 @@
                             "type": "string"
                           }
                         },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -33802,93 +33126,7 @@
                             "type": "string"
                           }
                         },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "subdomain": {
-                            "type": "string"
-                          },
-                          "your-domain": {
-                            "type": "string"
-                          },
-                          "region": {
-                            "type": "string"
-                          },
-                          "shop": {
-                            "type": "string"
-                          },
-                          "account_url": {
-                            "type": "string"
-                          },
-                          "COMPANYDOMAIN": {
-                            "type": "string"
-                          },
-                          "extension": {
-                            "type": "string"
-                          },
-                          "form_api_base_url": {
-                            "type": "string"
-                          },
-                          "instanceEndpoint": {
-                            "type": "string"
-                          },
-                          "api_url": {
-                            "type": "string"
-                          },
-                          "borneo_dashboard_url": {
-                            "type": "string"
-                          },
-                          "proxy_username": {
-                            "type": "string"
-                          },
-                          "proxy_password": {
-                            "type": "string"
-                          },
-                          "domain": {
-                            "type": "string"
-                          },
-                          "version": {
-                            "type": "string"
-                          },
-                          "dc": {
-                            "type": "string"
-                          },
-                          "site_name": {
-                            "type": "string"
-                          },
-                          "instanceName": {
-                            "type": "string"
-                          },
-                          "account_id": {
-                            "type": "string"
-                          },
-                          "your_server": {
-                            "type": "string"
-                          },
-                          "server_location": {
-                            "type": "string"
-                          },
-                          "base_url": {
-                            "type": "string"
-                          },
-                          "username": {
-                            "type": "string"
-                          },
-                          "password": {
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "username",
-                          "password"
-                        ],
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -33970,9 +33208,89 @@
                           "username",
                           "password"
                         ],
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "subdomain": {
+                            "type": "string"
+                          },
+                          "your-domain": {
+                            "type": "string"
+                          },
+                          "region": {
+                            "type": "string"
+                          },
+                          "shop": {
+                            "type": "string"
+                          },
+                          "account_url": {
+                            "type": "string"
+                          },
+                          "COMPANYDOMAIN": {
+                            "type": "string"
+                          },
+                          "extension": {
+                            "type": "string"
+                          },
+                          "form_api_base_url": {
+                            "type": "string"
+                          },
+                          "instanceEndpoint": {
+                            "type": "string"
+                          },
+                          "api_url": {
+                            "type": "string"
+                          },
+                          "borneo_dashboard_url": {
+                            "type": "string"
+                          },
+                          "proxy_username": {
+                            "type": "string"
+                          },
+                          "proxy_password": {
+                            "type": "string"
+                          },
+                          "domain": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "string"
+                          },
+                          "dc": {
+                            "type": "string"
+                          },
+                          "site_name": {
+                            "type": "string"
+                          },
+                          "instanceName": {
+                            "type": "string"
+                          },
+                          "account_id": {
+                            "type": "string"
+                          },
+                          "your_server": {
+                            "type": "string"
+                          },
+                          "server_location": {
+                            "type": "string"
+                          },
+                          "base_url": {
+                            "type": "string"
+                          },
+                          "username": {
+                            "type": "string"
+                          },
+                          "password": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "username",
+                          "password"
+                        ],
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -34060,9 +33378,7 @@
                           "username",
                           "password"
                         ],
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -34147,9 +33463,7 @@
                           "username",
                           "password"
                         ],
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -34221,9 +33535,7 @@
                             "type": "string"
                           }
                         },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -34295,9 +33607,7 @@
                             "type": "string"
                           }
                         },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -34383,9 +33693,7 @@
                           "installation_id",
                           "private_key"
                         ],
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -34471,9 +33779,7 @@
                           "installation_id",
                           "private_key"
                         ],
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -34545,9 +33851,7 @@
                             "type": "string"
                           }
                         },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -34619,9 +33923,7 @@
                             "type": "string"
                           }
                         },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -34693,9 +33995,7 @@
                             "type": "string"
                           }
                         },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -34767,9 +34067,7 @@
                             "type": "string"
                           }
                         },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -34847,9 +34145,7 @@
                             "type": "string"
                           }
                         },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -34924,9 +34220,7 @@
                             "type": "string"
                           }
                         },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -35007,9 +34301,7 @@
                             "description": "Whether to return the redirect url without shortening"
                           }
                         },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -35120,9 +34412,7 @@
                           "client_id",
                           "redirectUrl"
                         ],
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -35263,9 +34553,7 @@
                           "client_id",
                           "access_token"
                         ],
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -35406,9 +34694,7 @@
                           "client_id",
                           "access_token"
                         ],
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -35495,9 +34781,7 @@
                             "type": "string"
                           }
                         },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       },
                       {
                         "type": "object",
@@ -35581,9 +34865,7 @@
                             "type": "string"
                           }
                         },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
+                        "additionalProperties": {}
                       }
                     ],
                     "description": "Optional data to pre-fill connection fields with default values"
@@ -36918,11 +36200,6 @@
                             "description": "When true, this toolkit can be used without authentication",
                             "example": false
                           },
-                          "status": {
-                            "type": "string",
-                            "description": "Lifecycle status of the toolkit",
-                            "example": "active"
-                          },
                           "deprecated": {
                             "$ref": "#/components/schemas/DeprecatedToolkitInfo"
                           },
@@ -37021,7 +36298,6 @@
                           "slug",
                           "name",
                           "is_local_toolkit",
-                          "status",
                           "deprecated",
                           "meta"
                         ],
@@ -37266,11 +36542,6 @@
                       "type": "boolean",
                       "description": "Indicates if this toolkit is currently enabled and available for use",
                       "example": true
-                    },
-                    "status": {
-                      "type": "string",
-                      "description": "Lifecycle status of the toolkit",
-                      "example": "active"
                     },
                     "composio_managed_auth_schemes": {
                       "type": "array",
@@ -37647,9 +36918,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "additionalProperties": {
-                              "nullable": true
-                            }
+                            "additionalProperties": {}
                           }
                         }
                       },
@@ -37663,7 +36932,6 @@
                     "slug",
                     "name",
                     "enabled",
-                    "status",
                     "is_local_toolkit",
                     "meta",
                     "deprecated"
@@ -38283,11 +37551,6 @@
                             "description": "When true, this toolkit can be used without authentication",
                             "example": false
                           },
-                          "status": {
-                            "type": "string",
-                            "description": "Lifecycle status of the toolkit",
-                            "example": "active"
-                          },
                           "deprecated": {
                             "$ref": "#/components/schemas/DeprecatedToolkitInfo"
                           },
@@ -38386,7 +37649,6 @@
                           "slug",
                           "name",
                           "is_local_toolkit",
-                          "status",
                           "deprecated",
                           "meta"
                         ],
@@ -38556,9 +37818,7 @@
                       },
                       "body": {
                         "type": "object",
-                        "additionalProperties": {
-                          "nullable": true
-                        },
+                        "additionalProperties": {},
                         "description": "The body to be sent to the endpoint for authentication. This is a JSON object. Note: This is very rarely needed and is only required by very few apps."
                       }
                     },
@@ -38727,9 +37987,7 @@
                             "required": [
                               "access_token"
                             ],
-                            "additionalProperties": {
-                              "nullable": true
-                            }
+                            "additionalProperties": {}
                           }
                         },
                         "required": [
@@ -38889,9 +38147,7 @@
                               "client_id",
                               "access_token"
                             ],
-                            "additionalProperties": {
-                              "nullable": true
-                            }
+                            "additionalProperties": {}
                           }
                         },
                         "required": [
@@ -38994,9 +38250,7 @@
                                 "type": "string"
                               }
                             },
-                            "additionalProperties": {
-                              "nullable": true
-                            }
+                            "additionalProperties": {}
                           }
                         },
                         "required": [
@@ -39097,9 +38351,7 @@
                               "username",
                               "password"
                             ],
-                            "additionalProperties": {
-                              "nullable": true
-                            }
+                            "additionalProperties": {}
                           }
                         },
                         "required": [
@@ -39199,9 +38451,7 @@
                             "required": [
                               "username"
                             ],
-                            "additionalProperties": {
-                              "nullable": true
-                            }
+                            "additionalProperties": {}
                           }
                         },
                         "required": [
@@ -39298,9 +38548,7 @@
                             "required": [
                               "token"
                             ],
-                            "additionalProperties": {
-                              "nullable": true
-                            }
+                            "additionalProperties": {}
                           }
                         },
                         "required": [
@@ -39413,9 +38661,7 @@
                               "oauth_token",
                               "oauth_token_secret"
                             ],
-                            "additionalProperties": {
-                              "nullable": true
-                            }
+                            "additionalProperties": {}
                           }
                         },
                         "required": [
@@ -39506,9 +38752,7 @@
                                 "type": "string"
                               }
                             },
-                            "additionalProperties": {
-                              "nullable": true
-                            }
+                            "additionalProperties": {}
                           }
                         },
                         "required": [
@@ -39613,9 +38857,7 @@
                               "installation_id",
                               "private_key"
                             ],
-                            "additionalProperties": {
-                              "nullable": true
-                            }
+                            "additionalProperties": {}
                           }
                         },
                         "required": [
@@ -39712,9 +38954,7 @@
                             "required": [
                               "credentials_json"
                             ],
-                            "additionalProperties": {
-                              "nullable": true
-                            }
+                            "additionalProperties": {}
                           }
                         },
                         "required": [
@@ -39735,9 +38975,7 @@
                   },
                   "arguments": {
                     "type": "object",
-                    "additionalProperties": {
-                      "nullable": true
-                    },
+                    "additionalProperties": {},
                     "description": "Key-value pairs of arguments required by the tool (mutually exclusive with text)",
                     "example": {
                       "repository": "octocat/Hello-World",
@@ -39774,9 +39012,7 @@
                   "properties": {
                     "data": {
                       "type": "object",
-                      "additionalProperties": {
-                        "nullable": true
-                      },
+                      "additionalProperties": {},
                       "description": "Tool execution output data that varies based on the specific tool",
                       "example": {
                         "run_id": 12345678,
@@ -40009,9 +39245,7 @@
                   "properties": {
                     "arguments": {
                       "type": "object",
-                      "additionalProperties": {
-                        "nullable": true
-                      },
+                      "additionalProperties": {},
                       "description": "Key-value pairs of arguments required by the tool to accomplish the described task",
                       "example": {
                         "repository": "octocat/Hello-World",
@@ -40383,9 +39617,7 @@
                             "required": [
                               "access_token"
                             ],
-                            "additionalProperties": {
-                              "nullable": true
-                            }
+                            "additionalProperties": {}
                           }
                         },
                         "required": [
@@ -40545,9 +39777,7 @@
                               "client_id",
                               "access_token"
                             ],
-                            "additionalProperties": {
-                              "nullable": true
-                            }
+                            "additionalProperties": {}
                           }
                         },
                         "required": [
@@ -40650,9 +39880,7 @@
                                 "type": "string"
                               }
                             },
-                            "additionalProperties": {
-                              "nullable": true
-                            }
+                            "additionalProperties": {}
                           }
                         },
                         "required": [
@@ -40753,9 +39981,7 @@
                               "username",
                               "password"
                             ],
-                            "additionalProperties": {
-                              "nullable": true
-                            }
+                            "additionalProperties": {}
                           }
                         },
                         "required": [
@@ -40855,9 +40081,7 @@
                             "required": [
                               "username"
                             ],
-                            "additionalProperties": {
-                              "nullable": true
-                            }
+                            "additionalProperties": {}
                           }
                         },
                         "required": [
@@ -40954,9 +40178,7 @@
                             "required": [
                               "token"
                             ],
-                            "additionalProperties": {
-                              "nullable": true
-                            }
+                            "additionalProperties": {}
                           }
                         },
                         "required": [
@@ -41069,9 +40291,7 @@
                               "oauth_token",
                               "oauth_token_secret"
                             ],
-                            "additionalProperties": {
-                              "nullable": true
-                            }
+                            "additionalProperties": {}
                           }
                         },
                         "required": [
@@ -41162,9 +40382,7 @@
                                 "type": "string"
                               }
                             },
-                            "additionalProperties": {
-                              "nullable": true
-                            }
+                            "additionalProperties": {}
                           }
                         },
                         "required": [
@@ -41269,9 +40487,7 @@
                               "installation_id",
                               "private_key"
                             ],
-                            "additionalProperties": {
-                              "nullable": true
-                            }
+                            "additionalProperties": {}
                           }
                         },
                         "required": [
@@ -41368,9 +40584,7 @@
                             "required": [
                               "credentials_json"
                             ],
-                            "additionalProperties": {
-                              "nullable": true
-                            }
+                            "additionalProperties": {}
                           }
                         },
                         "required": [
@@ -41600,9 +40814,7 @@
                   },
                   "triggerConfig": {
                     "type": "object",
-                    "additionalProperties": {
-                      "nullable": true
-                    },
+                    "additionalProperties": {},
                     "description": "DEPRECATED: This parameter will be removed in a future version. Please use trigger_config instead.",
                     "deprecated": true
                   },
@@ -41613,9 +40825,7 @@
                   },
                   "trigger_config": {
                     "type": "object",
-                    "additionalProperties": {
-                      "nullable": true
-                    },
+                    "additionalProperties": {},
                     "description": "Trigger configuration"
                   },
                   "version": {
@@ -42059,16 +41269,12 @@
                           },
                           "trigger_config": {
                             "type": "object",
-                            "additionalProperties": {
-                              "nullable": true
-                            },
+                            "additionalProperties": {},
                             "description": "Configuration for the trigger"
                           },
                           "state": {
                             "type": "object",
-                            "additionalProperties": {
-                              "nullable": true
-                            },
+                            "additionalProperties": {},
                             "description": "State of the trigger instance"
                           },
                           "updated_at": {
@@ -42103,9 +41309,7 @@
                           },
                           "triggerConfig": {
                             "type": "object",
-                            "additionalProperties": {
-                              "nullable": true
-                            },
+                            "additionalProperties": {},
                             "description": "DEPRECATED: This parameter will be removed in a future version. Please use trigger_config instead.",
                             "deprecated": true
                           },
@@ -42643,9 +41847,7 @@
                     },
                     "config": {
                       "type": "object",
-                      "additionalProperties": {
-                        "nullable": true
-                      },
+                      "additionalProperties": {},
                       "description": "Configuration schema required to set up this trigger",
                       "example": {
                         "channel_id": {
@@ -42664,9 +41866,7 @@
                     },
                     "payload": {
                       "type": "object",
-                      "additionalProperties": {
-                        "nullable": true
-                      },
+                      "additionalProperties": {},
                       "description": "Schema of the data payload this trigger will deliver when it fires",
                       "example": {
                         "message": {
@@ -42688,11 +41888,6 @@
                       "type": "string",
                       "description": "Version of the trigger type",
                       "example": "20250930_00"
-                    },
-                    "status": {
-                      "type": "string",
-                      "description": "Lifecycle status of the trigger",
-                      "example": "active"
                     }
                   },
                   "required": [
@@ -42704,8 +41899,7 @@
                     "toolkit",
                     "config",
                     "payload",
-                    "version",
-                    "status"
+                    "version"
                   ]
                 }
               }
@@ -42912,9 +42106,7 @@
                           },
                           "config": {
                             "type": "object",
-                            "additionalProperties": {
-                              "nullable": true
-                            },
+                            "additionalProperties": {},
                             "description": "Configuration schema required to set up this trigger",
                             "example": {
                               "channel_id": {
@@ -42933,9 +42125,7 @@
                           },
                           "payload": {
                             "type": "object",
-                            "additionalProperties": {
-                              "nullable": true
-                            },
+                            "additionalProperties": {},
                             "description": "Schema of the data payload this trigger will deliver when it fires",
                             "example": {
                               "message": {
@@ -42957,11 +42147,6 @@
                             "type": "string",
                             "description": "Version of the trigger type",
                             "example": "20250930_00"
-                          },
-                          "status": {
-                            "type": "string",
-                            "description": "Lifecycle status of the trigger",
-                            "example": "active"
                           }
                         },
                         "required": [
@@ -42973,8 +42158,7 @@
                           "toolkit",
                           "config",
                           "payload",
-                          "version",
-                          "status"
+                          "version"
                         ]
                       }
                     },
@@ -47106,9 +46290,7 @@
                   },
                   "arguments": {
                     "type": "object",
-                    "additionalProperties": {
-                      "nullable": true
-                    },
+                    "additionalProperties": {},
                     "default": {},
                     "description": "The arguments required by the tool",
                     "example": {
@@ -47138,9 +46320,7 @@
                   "properties": {
                     "data": {
                       "type": "object",
-                      "additionalProperties": {
-                        "nullable": true
-                      },
+                      "additionalProperties": {},
                       "description": "The data returned by the tool execution",
                       "example": {
                         "message": "Hello, World!",
@@ -47271,9 +46451,7 @@
                   },
                   "arguments": {
                     "type": "object",
-                    "additionalProperties": {
-                      "nullable": true
-                    },
+                    "additionalProperties": {},
                     "default": {},
                     "description": "The arguments required by the meta tool",
                     "example": {
@@ -47301,9 +46479,7 @@
                   "properties": {
                     "data": {
                       "type": "object",
-                      "additionalProperties": {
-                        "nullable": true
-                      },
+                      "additionalProperties": {},
                       "description": "The data returned by the tool execution",
                       "example": {
                         "message": "Hello, World!",

--- a/docs/scripts/fetch-openapi.mjs
+++ b/docs/scripts/fetch-openapi.mjs
@@ -108,10 +108,23 @@ async function fetchAndFilterSpec() {
   console.log(`Removed ${removedCount} endpoints/operations`);
   console.log(`Final spec has ${Object.keys(filteredPaths).length} paths`);
 
+  // Fix invalid OpenAPI: "nullable" without "type" is not valid in OpenAPI 3.0
+  // Transform {"nullable": true} to {} (allows any type)
+  const specString = JSON.stringify(spec);
+  const fixedSpecString = specString.replace(
+    /"additionalProperties":\s*\{\s*"nullable":\s*true\s*\}/g,
+    '"additionalProperties": {}'
+  );
+  const fixedSpec = JSON.parse(fixedSpecString);
+  const fixCount = (specString.match(/"additionalProperties":\s*\{\s*"nullable":\s*true\s*\}/g) || []).length;
+  if (fixCount > 0) {
+    console.log(`Fixed ${fixCount} invalid additionalProperties schemas (nullable without type)`);
+  }
+
   // Write to public directory for fumadocs to fetch
   const __dirname = dirname(fileURLToPath(import.meta.url));
   const outputPath = join(__dirname, '../public/openapi.json');
-  writeFileSync(outputPath, JSON.stringify(spec, null, 2));
+  writeFileSync(outputPath, JSON.stringify(fixedSpec, null, 2));
 
   console.log(`Written to ${outputPath}`);
 }


### PR DESCRIPTION
## Summary

- Fixes 500 error on `/reference` API docs page caused by invalid OpenAPI schema
- The backend API spec has ~394 instances of `additionalProperties: { nullable: true }` which is invalid OpenAPI 3.0
- `nullable` requires a `type` field per the [OpenAPI 3.0 spec](https://swagger.io/docs/specification/v3_0/data-models/data-types/)

## Fix

Transform invalid schemas to `additionalProperties: {}` (any type allowed) during the fetch process in `scripts/fetch-openapi.mjs`.

## Root Cause

The backend API spec at `backend.composio.dev/api/v3/openapi.json` generates invalid schemas. The proper long-term fix should be in the backend spec generation.

## Test plan

- [x] Run `bun run scripts/fetch-openapi.mjs` - should report fixing ~394 schemas
- [x] Run `bun run dev` and visit `/reference` - should load without 500 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)