### PR TITLE
fix(docs): handle nullable without type in OpenAPI schemas

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -136,6 +136,9 @@
               "code": {
                 "type": "number"
               },
+              "slug": {
+                "type": "string"
+              },
               "status": {
                 "type": "number"
               },
@@ -155,6 +158,7 @@
             "required": [
               "message",
               "code",
+              "slug",
               "status"
             ]
           }
@@ -225,7 +229,8 @@
           "input_parameters": {
             "type": "object",
             "additionalProperties": {
-              "nullable": true
+              "nullable": true,
+              "type": "object"
             },
             "description": "Schema definition of required input parameters for the tool",
             "example": {
@@ -267,7 +272,8 @@
           "output_parameters": {
             "type": "object",
             "additionalProperties": {
-              "nullable": true
+              "nullable": true,
+              "type": "object"
             },
             "description": "Schema definition of return values from the tool",
             "example": {
@@ -900,6 +906,7 @@
     "/api/v3/auth_configs": {
       "post": {
         "summary": "Create new authentication configuration",
+        "description": "Creates a new auth config for a toolkit, allowing you to use your own OAuth credentials or API keys instead of Composio-managed authentication. This is required when you want to use custom OAuth apps (bring your own client ID/secret) or configure specific authentication parameters for a toolkit.",
         "tags": [
           "Auth Configs"
         ],
@@ -1002,9 +1009,15 @@
                           "shared_credentials": {
                             "type": "object",
                             "additionalProperties": {
-                              "nullable": true
+                              "nullable": true,
+                              "type": "object"
                             },
-                            "description": "[EXPERIMENTAL] Shared credentials that will be inherited by all connected accounts using this auth config"
+                            "description": "[EXPERIMENTAL] Shared credentials that will be inherited by all connected accounts using this auth config",
+                            "x-experimental": true
+                          },
+                          "is_enabled_for_tool_router": {
+                            "type": "boolean",
+                            "description": "Whether this auth config is enabled for tool router"
                           }
                         },
                         "required": [
@@ -1076,6 +1089,7 @@
                           },
                           "proxy_config": {
                             "type": "object",
+                            "nullable": true,
                             "properties": {
                               "proxy_url": {
                                 "type": "string",
@@ -1116,9 +1130,15 @@
                           "shared_credentials": {
                             "type": "object",
                             "additionalProperties": {
-                              "nullable": true
+                              "nullable": true,
+                              "type": "object"
                             },
-                            "description": "[EXPERIMENTAL] Shared credentials that will be inherited by all connected accounts using this auth config"
+                            "description": "[EXPERIMENTAL] Shared credentials that will be inherited by all connected accounts using this auth config",
+                            "x-experimental": true
+                          },
+                          "is_enabled_for_tool_router": {
+                            "type": "boolean",
+                            "description": "Whether this auth config is enabled for tool router"
                           }
                         },
                         "required": [
@@ -1245,6 +1265,7 @@
       },
       "get": {
         "summary": "List authentication configurations with optional filters",
+        "description": "Retrieves all auth configs for your project. Auth configs define how users authenticate with external services (OAuth, API keys, etc.). Use filters to find configs for specific toolkits or to distinguish between Composio-managed and custom configurations.",
         "tags": [
           "Auth Configs"
         ],
@@ -1425,12 +1446,14 @@
                           "credentials": {
                             "type": "object",
                             "additionalProperties": {
-                              "nullable": true
+                              "nullable": true,
+                              "type": "object"
                             },
                             "description": "The authentication credentials (tokens, keys, etc.) - may be partially hidden for security"
                           },
                           "proxy_config": {
                             "type": "object",
+                            "nullable": true,
                             "properties": {
                               "proxy_url": {
                                 "type": "string",
@@ -1473,7 +1496,8 @@
                           "expected_input_fields": {
                             "type": "array",
                             "items": {
-                              "nullable": true
+                              "nullable": true,
+                              "type": "object"
                             },
                             "description": "Fields expected during connection initialization"
                           },
@@ -1509,9 +1533,15 @@
                           "shared_credentials": {
                             "type": "object",
                             "additionalProperties": {
-                              "nullable": true
+                              "nullable": true,
+                              "type": "object"
                             },
-                            "description": "[EXPERIMENTAL] Shared credentials that will be inherited by all connected accounts using this auth config"
+                            "description": "[EXPERIMENTAL] Shared credentials that will be inherited by all connected accounts using this auth config",
+                            "x-experimental": true
+                          },
+                          "is_enabled_for_tool_router": {
+                            "type": "boolean",
+                            "description": "Whether this auth config is enabled for tool router"
                           },
                           "deprecated_params": {
                             "type": "object",
@@ -1534,7 +1564,8 @@
                                 "items": {
                                   "type": "object",
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 "description": "Deprecated: Fields expected during connection initialization"
@@ -1728,12 +1759,14 @@
                     "credentials": {
                       "type": "object",
                       "additionalProperties": {
-                        "nullable": true
+                        "nullable": true,
+                        "type": "object"
                       },
                       "description": "The authentication credentials (tokens, keys, etc.) - may be partially hidden for security"
                     },
                     "proxy_config": {
                       "type": "object",
+                      "nullable": true,
                       "properties": {
                         "proxy_url": {
                           "type": "string",
@@ -1776,7 +1809,8 @@
                     "expected_input_fields": {
                       "type": "array",
                       "items": {
-                        "nullable": true
+                        "nullable": true,
+                        "type": "object"
                       },
                       "description": "Fields expected during connection initialization"
                     },
@@ -1812,9 +1846,15 @@
                     "shared_credentials": {
                       "type": "object",
                       "additionalProperties": {
-                        "nullable": true
+                        "nullable": true,
+                        "type": "object"
                       },
-                      "description": "[EXPERIMENTAL] Shared credentials that will be inherited by all connected accounts using this auth config"
+                      "description": "[EXPERIMENTAL] Shared credentials that will be inherited by all connected accounts using this auth config",
+                      "x-experimental": true
+                    },
+                    "is_enabled_for_tool_router": {
+                      "type": "boolean",
+                      "description": "Whether this auth config is enabled for tool router"
                     },
                     "deprecated_params": {
                       "type": "object",
@@ -1837,7 +1877,8 @@
                           "items": {
                             "type": "object",
                             "additionalProperties": {
-                              "nullable": true
+                              "nullable": true,
+                              "type": "object"
                             }
                           },
                           "description": "Deprecated: Fields expected during connection initialization"
@@ -1981,6 +2022,7 @@
                       },
                       "proxy_config": {
                         "type": "object",
+                        "nullable": true,
                         "properties": {
                           "proxy_url": {
                             "type": "string",
@@ -2001,7 +2043,6 @@
                         "items": {
                           "type": "string"
                         },
-                        "default": [],
                         "description": "Use tool_access_config instead. This field will be deprecated in the future.",
                         "deprecated": true
                       },
@@ -2013,7 +2054,6 @@
                             "items": {
                               "type": "string"
                             },
-                            "default": [],
                             "description": "Tools used to generate the minimum required scopes for the auth config (only valid for OAuth). If passed, this will update the scopes."
                           },
                           "tools_available_for_execution": {
@@ -2021,7 +2061,6 @@
                             "items": {
                               "type": "string"
                             },
-                            "default": [],
                             "description": "The actions that the user can perform on the auth config. If passed, this will update the actions that the user can perform on the auth config."
                           }
                         }
@@ -2029,14 +2068,18 @@
                       "shared_credentials": {
                         "type": "object",
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         },
                         "description": "Shared credentials that will be inherited by connected accounts. For eg: this can be used to share the API key for a tool with all connected accounts using this auth config."
+                      },
+                      "is_enabled_for_tool_router": {
+                        "type": "boolean",
+                        "description": "Whether this auth config is enabled for tool router"
                       }
                     },
                     "required": [
-                      "type",
-                      "credentials"
+                      "type"
                     ]
                   },
                   {
@@ -2066,7 +2109,6 @@
                         "items": {
                           "type": "string"
                         },
-                        "default": [],
                         "description": "Use tool_access_config instead. This field will be deprecated in the future.",
                         "deprecated": true
                       },
@@ -2078,7 +2120,6 @@
                             "items": {
                               "type": "string"
                             },
-                            "default": [],
                             "description": "Tools used to generate the minimum required scopes for the auth config (only valid for OAuth). If passed, this will update the scopes."
                           },
                           "tools_available_for_execution": {
@@ -2086,7 +2127,6 @@
                             "items": {
                               "type": "string"
                             },
-                            "default": [],
                             "description": "The actions that the user can perform on the auth config. If passed, this will update the actions that the user can perform on the auth config."
                           }
                         }
@@ -2094,9 +2134,14 @@
                       "shared_credentials": {
                         "type": "object",
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         },
                         "description": "Shared credentials that will be inherited by connected accounts. For eg: this can be used to share the API key for a tool with all connected accounts using this auth config."
+                      },
+                      "is_enabled_for_tool_router": {
+                        "type": "boolean",
+                        "description": "Whether this auth config is enabled for tool router"
                       }
                     },
                     "required": [
@@ -2364,6 +2409,7 @@
     "/api/v3/connected_accounts": {
       "get": {
         "summary": "List connected accounts with optional filters",
+        "description": "Retrieves all connected accounts for your project. Connected accounts represent authenticated user connections to external services (e.g., a user's Gmail account, Slack workspace). Filter by toolkit, status, user ID, or auth config to find specific connections.",
         "tags": [
           "Connected Accounts"
         ],
@@ -2716,7 +2762,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -2818,7 +2865,8 @@
                                           "redirectUrl"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -2921,7 +2969,8 @@
                                           "oauth_token_secret"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -3010,7 +3059,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -3096,7 +3146,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -3199,7 +3250,8 @@
                                           "oauth_token_secret"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       }
                                     ]
@@ -3310,7 +3362,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -3418,7 +3471,8 @@
                                           "redirectUrl"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -3527,7 +3581,8 @@
                                                 "type": "string"
                                               },
                                               {
-                                                "nullable": true
+                                                "nullable": true,
+                                                "type": "object"
                                               }
                                             ]
                                           },
@@ -3543,7 +3598,8 @@
                                                 }
                                               },
                                               {
-                                                "nullable": true
+                                                "nullable": true,
+                                                "type": "object"
                                               }
                                             ]
                                           },
@@ -3568,7 +3624,8 @@
                                           "access_token"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -3677,7 +3734,8 @@
                                                 "type": "string"
                                               },
                                               {
-                                                "nullable": true
+                                                "nullable": true,
+                                                "type": "object"
                                               }
                                             ]
                                           },
@@ -3693,7 +3751,8 @@
                                                 }
                                               },
                                               {
-                                                "nullable": true
+                                                "nullable": true,
+                                                "type": "object"
                                               }
                                             ]
                                           },
@@ -3718,7 +3777,8 @@
                                           "access_token"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -3816,7 +3876,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -3911,7 +3972,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       }
                                     ]
@@ -4013,7 +4075,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -4096,7 +4159,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -4191,7 +4255,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -4286,7 +4351,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       }
                                     ]
@@ -4388,7 +4454,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -4471,7 +4538,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -4561,7 +4629,8 @@
                                           "username"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -4651,7 +4720,8 @@
                                           "username"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       }
                                     ]
@@ -4753,7 +4823,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -4836,7 +4907,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -4923,7 +4995,8 @@
                                           "token"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -5010,7 +5083,8 @@
                                           "token"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       }
                                     ]
@@ -5112,7 +5186,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -5202,7 +5277,8 @@
                                           "redirectUrl"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -5289,7 +5365,8 @@
                                           "credentials_json"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -5376,7 +5453,8 @@
                                           "credentials_json"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       }
                                     ]
@@ -5478,7 +5556,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -5561,7 +5640,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -5644,7 +5724,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -5727,7 +5808,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -5816,7 +5898,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -5902,7 +5985,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       }
                                     ]
@@ -6004,7 +6088,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -6087,7 +6172,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -6170,7 +6256,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -6253,7 +6340,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -6342,7 +6430,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -6428,7 +6517,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       }
                                     ]
@@ -6530,7 +6620,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -6617,7 +6708,8 @@
                                           "redirectUrl"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -6708,7 +6800,8 @@
                                           "devKey"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -6799,7 +6892,8 @@
                                           "devKey"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -6888,7 +6982,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -6974,7 +7069,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       }
                                     ]
@@ -7076,7 +7172,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -7159,7 +7256,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -7250,7 +7348,8 @@
                                           "password"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -7341,7 +7440,8 @@
                                           "password"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -7438,7 +7538,8 @@
                                           "password"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -7532,7 +7633,8 @@
                                           "password"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       }
                                     ]
@@ -7634,7 +7736,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -7717,7 +7820,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -7812,7 +7916,8 @@
                                           "private_key"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -7907,7 +8012,8 @@
                                           "private_key"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       }
                                     ]
@@ -8009,7 +8115,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -8092,7 +8199,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -8175,7 +8283,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -8258,7 +8367,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -8347,7 +8457,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -8433,7 +8544,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       }
                                     ]
@@ -8544,7 +8656,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -8664,7 +8777,8 @@
                                           "redirectUrl"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -8781,7 +8895,8 @@
                                                 "type": "string"
                                               },
                                               {
-                                                "nullable": true
+                                                "nullable": true,
+                                                "type": "object"
                                               }
                                             ]
                                           },
@@ -8797,7 +8912,8 @@
                                                 }
                                               },
                                               {
-                                                "nullable": true
+                                                "nullable": true,
+                                                "type": "object"
                                               }
                                             ]
                                           },
@@ -8814,7 +8930,8 @@
                                           "access_token"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -8931,7 +9048,8 @@
                                                 "type": "string"
                                               },
                                               {
-                                                "nullable": true
+                                                "nullable": true,
+                                                "type": "object"
                                               }
                                             ]
                                           },
@@ -8947,7 +9065,8 @@
                                                 }
                                               },
                                               {
-                                                "nullable": true
+                                                "nullable": true,
+                                                "type": "object"
                                               }
                                             ]
                                           },
@@ -8964,7 +9083,8 @@
                                           "access_token"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -9062,7 +9182,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       },
                                       {
@@ -9157,7 +9278,8 @@
                                           "status"
                                         ],
                                         "additionalProperties": {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       }
                                     ]
@@ -9174,7 +9296,8 @@
                           "data": {
                             "type": "object",
                             "additionalProperties": {
-                              "nullable": true
+                              "nullable": true,
+                              "type": "object"
                             },
                             "description": "This is deprecated, use `state` instead",
                             "deprecated": true
@@ -9308,6 +9431,7 @@
       },
       "post": {
         "summary": "Create a new connected account",
+        "description": "Initiates a new connection to an external service for a user. For OAuth-based toolkits, this returns a redirect URL to complete authentication. For API key-based toolkits, provide the credentials directly in the request body. Use the `user_id` field to associate the connection with a specific user in your system.",
         "tags": [
           "Connected Accounts"
         ],
@@ -9435,7 +9559,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -9537,7 +9662,8 @@
                                       "redirectUrl"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -9640,7 +9766,8 @@
                                       "oauth_token_secret"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -9729,7 +9856,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -9815,7 +9943,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -9918,7 +10047,8 @@
                                       "oauth_token_secret"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   }
                                 ]
@@ -10029,7 +10159,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -10137,7 +10268,8 @@
                                       "redirectUrl"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -10246,7 +10378,8 @@
                                             "type": "string"
                                           },
                                           {
-                                            "nullable": true
+                                            "nullable": true,
+                                            "type": "object"
                                           }
                                         ]
                                       },
@@ -10262,7 +10395,8 @@
                                             }
                                           },
                                           {
-                                            "nullable": true
+                                            "nullable": true,
+                                            "type": "object"
                                           }
                                         ]
                                       },
@@ -10287,7 +10421,8 @@
                                       "access_token"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -10396,7 +10531,8 @@
                                             "type": "string"
                                           },
                                           {
-                                            "nullable": true
+                                            "nullable": true,
+                                            "type": "object"
                                           }
                                         ]
                                       },
@@ -10412,7 +10548,8 @@
                                             }
                                           },
                                           {
-                                            "nullable": true
+                                            "nullable": true,
+                                            "type": "object"
                                           }
                                         ]
                                       },
@@ -10437,7 +10574,8 @@
                                       "access_token"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -10535,7 +10673,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -10630,7 +10769,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   }
                                 ]
@@ -10732,7 +10872,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -10815,7 +10956,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -10910,7 +11052,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -11005,7 +11148,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   }
                                 ]
@@ -11107,7 +11251,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -11190,7 +11335,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -11280,7 +11426,8 @@
                                       "username"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -11370,7 +11517,8 @@
                                       "username"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   }
                                 ]
@@ -11472,7 +11620,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -11555,7 +11704,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -11642,7 +11792,8 @@
                                       "token"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -11729,7 +11880,8 @@
                                       "token"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   }
                                 ]
@@ -11831,7 +11983,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -11921,7 +12074,8 @@
                                       "redirectUrl"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -12008,7 +12162,8 @@
                                       "credentials_json"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -12095,7 +12250,8 @@
                                       "credentials_json"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   }
                                 ]
@@ -12197,7 +12353,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -12280,7 +12437,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -12363,7 +12521,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -12446,7 +12605,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -12535,7 +12695,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -12621,7 +12782,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   }
                                 ]
@@ -12723,7 +12885,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -12806,7 +12969,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -12889,7 +13053,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -12972,7 +13137,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -13061,7 +13227,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -13147,7 +13314,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   }
                                 ]
@@ -13249,7 +13417,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -13336,7 +13505,8 @@
                                       "redirectUrl"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -13427,7 +13597,8 @@
                                       "devKey"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -13518,7 +13689,8 @@
                                       "devKey"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -13607,7 +13779,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -13693,7 +13866,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   }
                                 ]
@@ -13795,7 +13969,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -13878,7 +14053,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -13969,7 +14145,8 @@
                                       "password"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -14060,7 +14237,8 @@
                                       "password"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -14157,7 +14335,8 @@
                                       "password"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -14251,7 +14430,8 @@
                                       "password"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   }
                                 ]
@@ -14353,7 +14533,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -14436,7 +14617,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -14531,7 +14713,8 @@
                                       "private_key"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -14626,7 +14809,8 @@
                                       "private_key"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   }
                                 ]
@@ -14728,7 +14912,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -14811,7 +14996,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -14894,7 +15080,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -14977,7 +15164,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -15066,7 +15254,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -15152,7 +15341,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   }
                                 ]
@@ -15263,7 +15453,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -15383,7 +15574,8 @@
                                       "redirectUrl"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -15500,7 +15692,8 @@
                                             "type": "string"
                                           },
                                           {
-                                            "nullable": true
+                                            "nullable": true,
+                                            "type": "object"
                                           }
                                         ]
                                       },
@@ -15516,7 +15709,8 @@
                                             }
                                           },
                                           {
-                                            "nullable": true
+                                            "nullable": true,
+                                            "type": "object"
                                           }
                                         ]
                                       },
@@ -15533,7 +15727,8 @@
                                       "access_token"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -15650,7 +15845,8 @@
                                             "type": "string"
                                           },
                                           {
-                                            "nullable": true
+                                            "nullable": true,
+                                            "type": "object"
                                           }
                                         ]
                                       },
@@ -15666,7 +15862,8 @@
                                             }
                                           },
                                           {
-                                            "nullable": true
+                                            "nullable": true,
+                                            "type": "object"
                                           }
                                         ]
                                       },
@@ -15683,7 +15880,8 @@
                                       "access_token"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -15781,7 +15979,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   },
                                   {
@@ -15876,7 +16075,8 @@
                                       "status"
                                     ],
                                     "additionalProperties": {
-                                      "nullable": true
+                                      "nullable": true,
+                                      "type": "object"
                                     }
                                   }
                                 ]
@@ -15893,7 +16093,8 @@
                       "data": {
                         "type": "object",
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         },
                         "description": "DEPRECATED: This parameter will be removed in a future version. Please use state instead.",
                         "deprecated": true
@@ -15925,7 +16126,8 @@
                   "validate_credentials": {
                     "type": "boolean",
                     "default": false,
-                    "description": "[EXPERIMENTAL] Whether to validate the provided credentials, validates only for API Key Auth scheme"
+                    "description": "[EXPERIMENTAL] Whether to validate the provided credentials, validates only for API Key Auth scheme",
+                    "x-experimental": true
                   }
                 },
                 "required": [
@@ -16042,7 +16244,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -16144,7 +16347,8 @@
                                     "redirectUrl"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -16247,7 +16451,8 @@
                                     "oauth_token_secret"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -16336,7 +16541,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -16422,7 +16628,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -16525,7 +16732,8 @@
                                     "oauth_token_secret"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 }
                               ]
@@ -16636,7 +16844,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -16744,7 +16953,8 @@
                                     "redirectUrl"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -16853,7 +17063,8 @@
                                           "type": "string"
                                         },
                                         {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       ]
                                     },
@@ -16869,7 +17080,8 @@
                                           }
                                         },
                                         {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       ]
                                     },
@@ -16894,7 +17106,8 @@
                                     "access_token"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -17003,7 +17216,8 @@
                                           "type": "string"
                                         },
                                         {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       ]
                                     },
@@ -17019,7 +17233,8 @@
                                           }
                                         },
                                         {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       ]
                                     },
@@ -17044,7 +17259,8 @@
                                     "access_token"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -17142,7 +17358,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -17237,7 +17454,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 }
                               ]
@@ -17339,7 +17557,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -17422,7 +17641,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -17517,7 +17737,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -17612,7 +17833,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 }
                               ]
@@ -17714,7 +17936,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -17797,7 +18020,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -17887,7 +18111,8 @@
                                     "username"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -17977,7 +18202,8 @@
                                     "username"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 }
                               ]
@@ -18079,7 +18305,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -18162,7 +18389,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -18249,7 +18477,8 @@
                                     "token"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -18336,7 +18565,8 @@
                                     "token"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 }
                               ]
@@ -18438,7 +18668,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -18528,7 +18759,8 @@
                                     "redirectUrl"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -18615,7 +18847,8 @@
                                     "credentials_json"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -18702,7 +18935,8 @@
                                     "credentials_json"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 }
                               ]
@@ -18804,7 +19038,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -18887,7 +19122,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -18970,7 +19206,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -19053,7 +19290,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -19142,7 +19380,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -19228,7 +19467,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 }
                               ]
@@ -19330,7 +19570,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -19413,7 +19654,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -19496,7 +19738,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -19579,7 +19822,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -19668,7 +19912,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -19754,7 +19999,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 }
                               ]
@@ -19856,7 +20102,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -19943,7 +20190,8 @@
                                     "redirectUrl"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -20034,7 +20282,8 @@
                                     "devKey"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -20125,7 +20374,8 @@
                                     "devKey"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -20214,7 +20464,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -20300,7 +20551,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 }
                               ]
@@ -20402,7 +20654,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -20485,7 +20738,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -20576,7 +20830,8 @@
                                     "password"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -20667,7 +20922,8 @@
                                     "password"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -20764,7 +21020,8 @@
                                     "password"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -20858,7 +21115,8 @@
                                     "password"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 }
                               ]
@@ -20960,7 +21218,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -21043,7 +21302,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -21138,7 +21398,8 @@
                                     "private_key"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -21233,7 +21494,8 @@
                                     "private_key"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 }
                               ]
@@ -21335,7 +21597,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -21418,7 +21681,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -21501,7 +21765,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -21584,7 +21849,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -21673,7 +21939,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -21759,7 +22026,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 }
                               ]
@@ -21870,7 +22138,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -21990,7 +22259,8 @@
                                     "redirectUrl"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -22107,7 +22377,8 @@
                                           "type": "string"
                                         },
                                         {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       ]
                                     },
@@ -22123,7 +22394,8 @@
                                           }
                                         },
                                         {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       ]
                                     },
@@ -22140,7 +22412,8 @@
                                     "access_token"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -22257,7 +22530,8 @@
                                           "type": "string"
                                         },
                                         {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       ]
                                     },
@@ -22273,7 +22547,8 @@
                                           }
                                         },
                                         {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       ]
                                     },
@@ -22290,7 +22565,8 @@
                                     "access_token"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -22388,7 +22664,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -22483,7 +22760,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 }
                               ]
@@ -22839,7 +23117,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -22941,7 +23220,8 @@
                                     "redirectUrl"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -23044,7 +23324,8 @@
                                     "oauth_token_secret"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -23133,7 +23414,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -23219,7 +23501,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -23322,7 +23605,8 @@
                                     "oauth_token_secret"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 }
                               ]
@@ -23433,7 +23717,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -23541,7 +23826,8 @@
                                     "redirectUrl"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -23650,7 +23936,8 @@
                                           "type": "string"
                                         },
                                         {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       ]
                                     },
@@ -23666,7 +23953,8 @@
                                           }
                                         },
                                         {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       ]
                                     },
@@ -23691,7 +23979,8 @@
                                     "access_token"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -23800,7 +24089,8 @@
                                           "type": "string"
                                         },
                                         {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       ]
                                     },
@@ -23816,7 +24106,8 @@
                                           }
                                         },
                                         {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       ]
                                     },
@@ -23841,7 +24132,8 @@
                                     "access_token"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -23939,7 +24231,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -24034,7 +24327,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 }
                               ]
@@ -24136,7 +24430,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -24219,7 +24514,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -24314,7 +24610,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -24409,7 +24706,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 }
                               ]
@@ -24511,7 +24809,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -24594,7 +24893,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -24684,7 +24984,8 @@
                                     "username"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -24774,7 +25075,8 @@
                                     "username"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 }
                               ]
@@ -24876,7 +25178,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -24959,7 +25262,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -25046,7 +25350,8 @@
                                     "token"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -25133,7 +25438,8 @@
                                     "token"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 }
                               ]
@@ -25235,7 +25541,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -25325,7 +25632,8 @@
                                     "redirectUrl"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -25412,7 +25720,8 @@
                                     "credentials_json"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -25499,7 +25808,8 @@
                                     "credentials_json"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 }
                               ]
@@ -25601,7 +25911,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -25684,7 +25995,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -25767,7 +26079,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -25850,7 +26163,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -25939,7 +26253,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -26025,7 +26340,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 }
                               ]
@@ -26127,7 +26443,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -26210,7 +26527,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -26293,7 +26611,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -26376,7 +26695,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -26465,7 +26785,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -26551,7 +26872,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 }
                               ]
@@ -26653,7 +26975,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -26740,7 +27063,8 @@
                                     "redirectUrl"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -26831,7 +27155,8 @@
                                     "devKey"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -26922,7 +27247,8 @@
                                     "devKey"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -27011,7 +27337,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -27097,7 +27424,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 }
                               ]
@@ -27199,7 +27527,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -27282,7 +27611,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -27373,7 +27703,8 @@
                                     "password"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -27464,7 +27795,8 @@
                                     "password"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -27561,7 +27893,8 @@
                                     "password"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -27655,7 +27988,8 @@
                                     "password"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 }
                               ]
@@ -27757,7 +28091,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -27840,7 +28175,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -27935,7 +28271,8 @@
                                     "private_key"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -28030,7 +28367,8 @@
                                     "private_key"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 }
                               ]
@@ -28132,7 +28470,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -28215,7 +28554,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -28298,7 +28638,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -28381,7 +28722,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -28470,7 +28812,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -28556,7 +28899,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 }
                               ]
@@ -28667,7 +29011,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -28787,7 +29132,8 @@
                                     "redirectUrl"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -28904,7 +29250,8 @@
                                           "type": "string"
                                         },
                                         {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       ]
                                     },
@@ -28920,7 +29267,8 @@
                                           }
                                         },
                                         {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       ]
                                     },
@@ -28937,7 +29285,8 @@
                                     "access_token"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -29054,7 +29403,8 @@
                                           "type": "string"
                                         },
                                         {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       ]
                                     },
@@ -29070,7 +29420,8 @@
                                           }
                                         },
                                         {
-                                          "nullable": true
+                                          "nullable": true,
+                                          "type": "object"
                                         }
                                       ]
                                     },
@@ -29087,7 +29438,8 @@
                                     "access_token"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -29185,7 +29537,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 },
                                 {
@@ -29280,7 +29633,8 @@
                                     "status"
                                   ],
                                   "additionalProperties": {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 }
                               ]
@@ -29297,7 +29651,8 @@
                     "data": {
                       "type": "object",
                       "additionalProperties": {
-                        "nullable": true
+                        "nullable": true,
+                        "type": "object"
                       },
                       "description": "This is deprecated, use `state` instead",
                       "deprecated": true
@@ -29340,7 +29695,8 @@
                     "params": {
                       "type": "object",
                       "additionalProperties": {
-                        "nullable": true
+                        "nullable": true,
+                        "type": "object"
                       },
                       "description": "The initialization data of the connection, including configuration parameters",
                       "deprecated": true
@@ -29709,7 +30065,8 @@
                   "validate_credentials": {
                     "type": "boolean",
                     "default": false,
-                    "description": "[EXPERIMENTAL] Whether to validate the provided credentials, validates only for API Key Auth scheme"
+                    "description": "[EXPERIMENTAL] Whether to validate the provided credentials, validates only for API Key Auth scheme",
+                    "x-experimental": true
                   }
                 }
               }
@@ -29933,7 +30290,8 @@
                           }
                         },
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -30028,7 +30386,8 @@
                           "redirectUrl"
                         ],
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -30124,7 +30483,8 @@
                           "oauth_token_secret"
                         ],
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -30204,7 +30564,8 @@
                           }
                         },
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -30281,7 +30642,8 @@
                           }
                         },
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -30377,7 +30739,8 @@
                           "oauth_token_secret"
                         ],
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -30460,7 +30823,8 @@
                           }
                         },
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -30561,7 +30925,8 @@
                           "redirectUrl"
                         ],
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -30664,7 +31029,8 @@
                                 "type": "string"
                               },
                               {
-                                "nullable": true
+                                "nullable": true,
+                                "type": "object"
                               }
                             ]
                           },
@@ -30680,7 +31046,8 @@
                                 }
                               },
                               {
-                                "nullable": true
+                                "nullable": true,
+                                "type": "object"
                               }
                             ]
                           },
@@ -30704,7 +31071,8 @@
                           "access_token"
                         ],
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -30807,7 +31175,8 @@
                                 "type": "string"
                               },
                               {
-                                "nullable": true
+                                "nullable": true,
+                                "type": "object"
                               }
                             ]
                           },
@@ -30823,7 +31192,8 @@
                                 }
                               },
                               {
-                                "nullable": true
+                                "nullable": true,
+                                "type": "object"
                               }
                             ]
                           },
@@ -30847,7 +31217,8 @@
                           "access_token"
                         ],
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -30936,7 +31307,8 @@
                           }
                         },
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -31022,7 +31394,8 @@
                           }
                         },
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -31096,7 +31469,8 @@
                           }
                         },
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -31170,93 +31544,8 @@
                           }
                         },
                         "additionalProperties": {
-                          "nullable": true
-                        }
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "subdomain": {
-                            "type": "string"
-                          },
-                          "your-domain": {
-                            "type": "string"
-                          },
-                          "region": {
-                            "type": "string"
-                          },
-                          "shop": {
-                            "type": "string"
-                          },
-                          "account_url": {
-                            "type": "string"
-                          },
-                          "COMPANYDOMAIN": {
-                            "type": "string"
-                          },
-                          "extension": {
-                            "type": "string"
-                          },
-                          "form_api_base_url": {
-                            "type": "string"
-                          },
-                          "instanceEndpoint": {
-                            "type": "string"
-                          },
-                          "api_url": {
-                            "type": "string"
-                          },
-                          "borneo_dashboard_url": {
-                            "type": "string"
-                          },
-                          "proxy_username": {
-                            "type": "string"
-                          },
-                          "proxy_password": {
-                            "type": "string"
-                          },
-                          "domain": {
-                            "type": "string"
-                          },
-                          "version": {
-                            "type": "string"
-                          },
-                          "dc": {
-                            "type": "string"
-                          },
-                          "site_name": {
-                            "type": "string"
-                          },
-                          "instanceName": {
-                            "type": "string"
-                          },
-                          "account_id": {
-                            "type": "string"
-                          },
-                          "your_server": {
-                            "type": "string"
-                          },
-                          "server_location": {
-                            "type": "string"
-                          },
-                          "base_url": {
-                            "type": "string"
-                          },
-                          "generic_api_key": {
-                            "type": "string"
-                          },
-                          "api_key": {
-                            "type": "string"
-                          },
-                          "bearer_token": {
-                            "type": "string"
-                          },
-                          "basic_encoded": {
-                            "type": "string"
-                          }
-                        },
-                        "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -31342,7 +31631,95 @@
                           }
                         },
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "subdomain": {
+                            "type": "string"
+                          },
+                          "your-domain": {
+                            "type": "string"
+                          },
+                          "region": {
+                            "type": "string"
+                          },
+                          "shop": {
+                            "type": "string"
+                          },
+                          "account_url": {
+                            "type": "string"
+                          },
+                          "COMPANYDOMAIN": {
+                            "type": "string"
+                          },
+                          "extension": {
+                            "type": "string"
+                          },
+                          "form_api_base_url": {
+                            "type": "string"
+                          },
+                          "instanceEndpoint": {
+                            "type": "string"
+                          },
+                          "api_url": {
+                            "type": "string"
+                          },
+                          "borneo_dashboard_url": {
+                            "type": "string"
+                          },
+                          "proxy_username": {
+                            "type": "string"
+                          },
+                          "proxy_password": {
+                            "type": "string"
+                          },
+                          "domain": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "string"
+                          },
+                          "dc": {
+                            "type": "string"
+                          },
+                          "site_name": {
+                            "type": "string"
+                          },
+                          "instanceName": {
+                            "type": "string"
+                          },
+                          "account_id": {
+                            "type": "string"
+                          },
+                          "your_server": {
+                            "type": "string"
+                          },
+                          "server_location": {
+                            "type": "string"
+                          },
+                          "base_url": {
+                            "type": "string"
+                          },
+                          "generic_api_key": {
+                            "type": "string"
+                          },
+                          "api_key": {
+                            "type": "string"
+                          },
+                          "bearer_token": {
+                            "type": "string"
+                          },
+                          "basic_encoded": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": {
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -31416,7 +31793,8 @@
                           }
                         },
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -31490,7 +31868,8 @@
                           }
                         },
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -31573,7 +31952,8 @@
                           "username"
                         ],
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -31656,7 +32036,8 @@
                           "username"
                         ],
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -31730,7 +32111,8 @@
                           }
                         },
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -31804,87 +32186,8 @@
                           }
                         },
                         "additionalProperties": {
-                          "nullable": true
-                        }
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "subdomain": {
-                            "type": "string"
-                          },
-                          "your-domain": {
-                            "type": "string"
-                          },
-                          "region": {
-                            "type": "string"
-                          },
-                          "shop": {
-                            "type": "string"
-                          },
-                          "account_url": {
-                            "type": "string"
-                          },
-                          "COMPANYDOMAIN": {
-                            "type": "string"
-                          },
-                          "extension": {
-                            "type": "string"
-                          },
-                          "form_api_base_url": {
-                            "type": "string"
-                          },
-                          "instanceEndpoint": {
-                            "type": "string"
-                          },
-                          "api_url": {
-                            "type": "string"
-                          },
-                          "borneo_dashboard_url": {
-                            "type": "string"
-                          },
-                          "proxy_username": {
-                            "type": "string"
-                          },
-                          "proxy_password": {
-                            "type": "string"
-                          },
-                          "domain": {
-                            "type": "string"
-                          },
-                          "version": {
-                            "type": "string"
-                          },
-                          "dc": {
-                            "type": "string"
-                          },
-                          "site_name": {
-                            "type": "string"
-                          },
-                          "instanceName": {
-                            "type": "string"
-                          },
-                          "account_id": {
-                            "type": "string"
-                          },
-                          "your_server": {
-                            "type": "string"
-                          },
-                          "server_location": {
-                            "type": "string"
-                          },
-                          "base_url": {
-                            "type": "string"
-                          },
-                          "token": {
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "token"
-                        ],
-                        "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -31964,7 +32267,89 @@
                           "token"
                         ],
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "subdomain": {
+                            "type": "string"
+                          },
+                          "your-domain": {
+                            "type": "string"
+                          },
+                          "region": {
+                            "type": "string"
+                          },
+                          "shop": {
+                            "type": "string"
+                          },
+                          "account_url": {
+                            "type": "string"
+                          },
+                          "COMPANYDOMAIN": {
+                            "type": "string"
+                          },
+                          "extension": {
+                            "type": "string"
+                          },
+                          "form_api_base_url": {
+                            "type": "string"
+                          },
+                          "instanceEndpoint": {
+                            "type": "string"
+                          },
+                          "api_url": {
+                            "type": "string"
+                          },
+                          "borneo_dashboard_url": {
+                            "type": "string"
+                          },
+                          "proxy_username": {
+                            "type": "string"
+                          },
+                          "proxy_password": {
+                            "type": "string"
+                          },
+                          "domain": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "string"
+                          },
+                          "dc": {
+                            "type": "string"
+                          },
+                          "site_name": {
+                            "type": "string"
+                          },
+                          "instanceName": {
+                            "type": "string"
+                          },
+                          "account_id": {
+                            "type": "string"
+                          },
+                          "your_server": {
+                            "type": "string"
+                          },
+                          "server_location": {
+                            "type": "string"
+                          },
+                          "base_url": {
+                            "type": "string"
+                          },
+                          "token": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "token"
+                        ],
+                        "additionalProperties": {
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -32038,7 +32423,8 @@
                           }
                         },
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -32121,7 +32507,8 @@
                           "redirectUrl"
                         ],
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -32201,7 +32588,8 @@
                           "credentials_json"
                         ],
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -32281,7 +32669,8 @@
                           "credentials_json"
                         ],
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -32355,7 +32744,8 @@
                           }
                         },
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -32429,7 +32819,8 @@
                           }
                         },
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -32503,7 +32894,8 @@
                           }
                         },
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -32577,460 +32969,8 @@
                           }
                         },
                         "additionalProperties": {
-                          "nullable": true
-                        }
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "subdomain": {
-                            "type": "string"
-                          },
-                          "your-domain": {
-                            "type": "string"
-                          },
-                          "region": {
-                            "type": "string"
-                          },
-                          "shop": {
-                            "type": "string"
-                          },
-                          "account_url": {
-                            "type": "string"
-                          },
-                          "COMPANYDOMAIN": {
-                            "type": "string"
-                          },
-                          "extension": {
-                            "type": "string"
-                          },
-                          "form_api_base_url": {
-                            "type": "string"
-                          },
-                          "instanceEndpoint": {
-                            "type": "string"
-                          },
-                          "api_url": {
-                            "type": "string"
-                          },
-                          "borneo_dashboard_url": {
-                            "type": "string"
-                          },
-                          "proxy_username": {
-                            "type": "string"
-                          },
-                          "proxy_password": {
-                            "type": "string"
-                          },
-                          "domain": {
-                            "type": "string"
-                          },
-                          "version": {
-                            "type": "string"
-                          },
-                          "dc": {
-                            "type": "string"
-                          },
-                          "site_name": {
-                            "type": "string"
-                          },
-                          "instanceName": {
-                            "type": "string"
-                          },
-                          "account_id": {
-                            "type": "string"
-                          },
-                          "your_server": {
-                            "type": "string"
-                          },
-                          "server_location": {
-                            "type": "string"
-                          },
-                          "base_url": {
-                            "type": "string"
-                          },
-                          "error": {
-                            "type": "string"
-                          },
-                          "error_description": {
-                            "type": "string"
-                          }
-                        },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "subdomain": {
-                            "type": "string"
-                          },
-                          "your-domain": {
-                            "type": "string"
-                          },
-                          "region": {
-                            "type": "string"
-                          },
-                          "shop": {
-                            "type": "string"
-                          },
-                          "account_url": {
-                            "type": "string"
-                          },
-                          "COMPANYDOMAIN": {
-                            "type": "string"
-                          },
-                          "extension": {
-                            "type": "string"
-                          },
-                          "form_api_base_url": {
-                            "type": "string"
-                          },
-                          "instanceEndpoint": {
-                            "type": "string"
-                          },
-                          "api_url": {
-                            "type": "string"
-                          },
-                          "borneo_dashboard_url": {
-                            "type": "string"
-                          },
-                          "proxy_username": {
-                            "type": "string"
-                          },
-                          "proxy_password": {
-                            "type": "string"
-                          },
-                          "domain": {
-                            "type": "string"
-                          },
-                          "version": {
-                            "type": "string"
-                          },
-                          "dc": {
-                            "type": "string"
-                          },
-                          "site_name": {
-                            "type": "string"
-                          },
-                          "instanceName": {
-                            "type": "string"
-                          },
-                          "account_id": {
-                            "type": "string"
-                          },
-                          "your_server": {
-                            "type": "string"
-                          },
-                          "server_location": {
-                            "type": "string"
-                          },
-                          "base_url": {
-                            "type": "string"
-                          },
-                          "expired_at": {
-                            "type": "string"
-                          }
-                        },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "subdomain": {
-                            "type": "string"
-                          },
-                          "your-domain": {
-                            "type": "string"
-                          },
-                          "region": {
-                            "type": "string"
-                          },
-                          "shop": {
-                            "type": "string"
-                          },
-                          "account_url": {
-                            "type": "string"
-                          },
-                          "COMPANYDOMAIN": {
-                            "type": "string"
-                          },
-                          "extension": {
-                            "type": "string"
-                          },
-                          "form_api_base_url": {
-                            "type": "string"
-                          },
-                          "instanceEndpoint": {
-                            "type": "string"
-                          },
-                          "api_url": {
-                            "type": "string"
-                          },
-                          "borneo_dashboard_url": {
-                            "type": "string"
-                          },
-                          "proxy_username": {
-                            "type": "string"
-                          },
-                          "proxy_password": {
-                            "type": "string"
-                          },
-                          "domain": {
-                            "type": "string"
-                          },
-                          "version": {
-                            "type": "string"
-                          },
-                          "dc": {
-                            "type": "string"
-                          },
-                          "site_name": {
-                            "type": "string"
-                          },
-                          "instanceName": {
-                            "type": "string"
-                          },
-                          "account_id": {
-                            "type": "string"
-                          },
-                          "your_server": {
-                            "type": "string"
-                          },
-                          "server_location": {
-                            "type": "string"
-                          },
-                          "base_url": {
-                            "type": "string"
-                          }
-                        },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "subdomain": {
-                            "type": "string"
-                          },
-                          "your-domain": {
-                            "type": "string"
-                          },
-                          "region": {
-                            "type": "string"
-                          },
-                          "shop": {
-                            "type": "string"
-                          },
-                          "account_url": {
-                            "type": "string"
-                          },
-                          "COMPANYDOMAIN": {
-                            "type": "string"
-                          },
-                          "extension": {
-                            "type": "string"
-                          },
-                          "form_api_base_url": {
-                            "type": "string"
-                          },
-                          "instanceEndpoint": {
-                            "type": "string"
-                          },
-                          "api_url": {
-                            "type": "string"
-                          },
-                          "borneo_dashboard_url": {
-                            "type": "string"
-                          },
-                          "proxy_username": {
-                            "type": "string"
-                          },
-                          "proxy_password": {
-                            "type": "string"
-                          },
-                          "domain": {
-                            "type": "string"
-                          },
-                          "version": {
-                            "type": "string"
-                          },
-                          "dc": {
-                            "type": "string"
-                          },
-                          "site_name": {
-                            "type": "string"
-                          },
-                          "instanceName": {
-                            "type": "string"
-                          },
-                          "account_id": {
-                            "type": "string"
-                          },
-                          "your_server": {
-                            "type": "string"
-                          },
-                          "server_location": {
-                            "type": "string"
-                          },
-                          "base_url": {
-                            "type": "string"
-                          }
-                        },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "subdomain": {
-                            "type": "string"
-                          },
-                          "your-domain": {
-                            "type": "string"
-                          },
-                          "region": {
-                            "type": "string"
-                          },
-                          "shop": {
-                            "type": "string"
-                          },
-                          "account_url": {
-                            "type": "string"
-                          },
-                          "COMPANYDOMAIN": {
-                            "type": "string"
-                          },
-                          "extension": {
-                            "type": "string"
-                          },
-                          "form_api_base_url": {
-                            "type": "string"
-                          },
-                          "instanceEndpoint": {
-                            "type": "string"
-                          },
-                          "api_url": {
-                            "type": "string"
-                          },
-                          "borneo_dashboard_url": {
-                            "type": "string"
-                          },
-                          "proxy_username": {
-                            "type": "string"
-                          },
-                          "proxy_password": {
-                            "type": "string"
-                          },
-                          "domain": {
-                            "type": "string"
-                          },
-                          "version": {
-                            "type": "string"
-                          },
-                          "dc": {
-                            "type": "string"
-                          },
-                          "site_name": {
-                            "type": "string"
-                          },
-                          "instanceName": {
-                            "type": "string"
-                          },
-                          "account_id": {
-                            "type": "string"
-                          },
-                          "your_server": {
-                            "type": "string"
-                          },
-                          "server_location": {
-                            "type": "string"
-                          },
-                          "base_url": {
-                            "type": "string"
-                          }
-                        },
-                        "additionalProperties": {
-                          "nullable": true
-                        }
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "subdomain": {
-                            "type": "string"
-                          },
-                          "your-domain": {
-                            "type": "string"
-                          },
-                          "region": {
-                            "type": "string"
-                          },
-                          "shop": {
-                            "type": "string"
-                          },
-                          "account_url": {
-                            "type": "string"
-                          },
-                          "COMPANYDOMAIN": {
-                            "type": "string"
-                          },
-                          "extension": {
-                            "type": "string"
-                          },
-                          "form_api_base_url": {
-                            "type": "string"
-                          },
-                          "instanceEndpoint": {
-                            "type": "string"
-                          },
-                          "api_url": {
-                            "type": "string"
-                          },
-                          "borneo_dashboard_url": {
-                            "type": "string"
-                          },
-                          "proxy_username": {
-                            "type": "string"
-                          },
-                          "proxy_password": {
-                            "type": "string"
-                          },
-                          "domain": {
-                            "type": "string"
-                          },
-                          "version": {
-                            "type": "string"
-                          },
-                          "dc": {
-                            "type": "string"
-                          },
-                          "site_name": {
-                            "type": "string"
-                          },
-                          "instanceName": {
-                            "type": "string"
-                          },
-                          "account_id": {
-                            "type": "string"
-                          },
-                          "your_server": {
-                            "type": "string"
-                          },
-                          "server_location": {
-                            "type": "string"
-                          },
-                          "base_url": {
-                            "type": "string"
-                          }
-                        },
-                        "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -33110,7 +33050,8 @@
                           }
                         },
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -33187,7 +33128,8 @@
                           }
                         },
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -33261,7 +33203,467 @@
                           }
                         },
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "subdomain": {
+                            "type": "string"
+                          },
+                          "your-domain": {
+                            "type": "string"
+                          },
+                          "region": {
+                            "type": "string"
+                          },
+                          "shop": {
+                            "type": "string"
+                          },
+                          "account_url": {
+                            "type": "string"
+                          },
+                          "COMPANYDOMAIN": {
+                            "type": "string"
+                          },
+                          "extension": {
+                            "type": "string"
+                          },
+                          "form_api_base_url": {
+                            "type": "string"
+                          },
+                          "instanceEndpoint": {
+                            "type": "string"
+                          },
+                          "api_url": {
+                            "type": "string"
+                          },
+                          "borneo_dashboard_url": {
+                            "type": "string"
+                          },
+                          "proxy_username": {
+                            "type": "string"
+                          },
+                          "proxy_password": {
+                            "type": "string"
+                          },
+                          "domain": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "string"
+                          },
+                          "dc": {
+                            "type": "string"
+                          },
+                          "site_name": {
+                            "type": "string"
+                          },
+                          "instanceName": {
+                            "type": "string"
+                          },
+                          "account_id": {
+                            "type": "string"
+                          },
+                          "your_server": {
+                            "type": "string"
+                          },
+                          "server_location": {
+                            "type": "string"
+                          },
+                          "base_url": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": {
+                          "nullable": true,
+                          "type": "object"
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "subdomain": {
+                            "type": "string"
+                          },
+                          "your-domain": {
+                            "type": "string"
+                          },
+                          "region": {
+                            "type": "string"
+                          },
+                          "shop": {
+                            "type": "string"
+                          },
+                          "account_url": {
+                            "type": "string"
+                          },
+                          "COMPANYDOMAIN": {
+                            "type": "string"
+                          },
+                          "extension": {
+                            "type": "string"
+                          },
+                          "form_api_base_url": {
+                            "type": "string"
+                          },
+                          "instanceEndpoint": {
+                            "type": "string"
+                          },
+                          "api_url": {
+                            "type": "string"
+                          },
+                          "borneo_dashboard_url": {
+                            "type": "string"
+                          },
+                          "proxy_username": {
+                            "type": "string"
+                          },
+                          "proxy_password": {
+                            "type": "string"
+                          },
+                          "domain": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "string"
+                          },
+                          "dc": {
+                            "type": "string"
+                          },
+                          "site_name": {
+                            "type": "string"
+                          },
+                          "instanceName": {
+                            "type": "string"
+                          },
+                          "account_id": {
+                            "type": "string"
+                          },
+                          "your_server": {
+                            "type": "string"
+                          },
+                          "server_location": {
+                            "type": "string"
+                          },
+                          "base_url": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": {
+                          "nullable": true,
+                          "type": "object"
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "subdomain": {
+                            "type": "string"
+                          },
+                          "your-domain": {
+                            "type": "string"
+                          },
+                          "region": {
+                            "type": "string"
+                          },
+                          "shop": {
+                            "type": "string"
+                          },
+                          "account_url": {
+                            "type": "string"
+                          },
+                          "COMPANYDOMAIN": {
+                            "type": "string"
+                          },
+                          "extension": {
+                            "type": "string"
+                          },
+                          "form_api_base_url": {
+                            "type": "string"
+                          },
+                          "instanceEndpoint": {
+                            "type": "string"
+                          },
+                          "api_url": {
+                            "type": "string"
+                          },
+                          "borneo_dashboard_url": {
+                            "type": "string"
+                          },
+                          "proxy_username": {
+                            "type": "string"
+                          },
+                          "proxy_password": {
+                            "type": "string"
+                          },
+                          "domain": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "string"
+                          },
+                          "dc": {
+                            "type": "string"
+                          },
+                          "site_name": {
+                            "type": "string"
+                          },
+                          "instanceName": {
+                            "type": "string"
+                          },
+                          "account_id": {
+                            "type": "string"
+                          },
+                          "your_server": {
+                            "type": "string"
+                          },
+                          "server_location": {
+                            "type": "string"
+                          },
+                          "base_url": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": {
+                          "nullable": true,
+                          "type": "object"
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "subdomain": {
+                            "type": "string"
+                          },
+                          "your-domain": {
+                            "type": "string"
+                          },
+                          "region": {
+                            "type": "string"
+                          },
+                          "shop": {
+                            "type": "string"
+                          },
+                          "account_url": {
+                            "type": "string"
+                          },
+                          "COMPANYDOMAIN": {
+                            "type": "string"
+                          },
+                          "extension": {
+                            "type": "string"
+                          },
+                          "form_api_base_url": {
+                            "type": "string"
+                          },
+                          "instanceEndpoint": {
+                            "type": "string"
+                          },
+                          "api_url": {
+                            "type": "string"
+                          },
+                          "borneo_dashboard_url": {
+                            "type": "string"
+                          },
+                          "proxy_username": {
+                            "type": "string"
+                          },
+                          "proxy_password": {
+                            "type": "string"
+                          },
+                          "domain": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "string"
+                          },
+                          "dc": {
+                            "type": "string"
+                          },
+                          "site_name": {
+                            "type": "string"
+                          },
+                          "instanceName": {
+                            "type": "string"
+                          },
+                          "account_id": {
+                            "type": "string"
+                          },
+                          "your_server": {
+                            "type": "string"
+                          },
+                          "server_location": {
+                            "type": "string"
+                          },
+                          "base_url": {
+                            "type": "string"
+                          },
+                          "error": {
+                            "type": "string"
+                          },
+                          "error_description": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": {
+                          "nullable": true,
+                          "type": "object"
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "subdomain": {
+                            "type": "string"
+                          },
+                          "your-domain": {
+                            "type": "string"
+                          },
+                          "region": {
+                            "type": "string"
+                          },
+                          "shop": {
+                            "type": "string"
+                          },
+                          "account_url": {
+                            "type": "string"
+                          },
+                          "COMPANYDOMAIN": {
+                            "type": "string"
+                          },
+                          "extension": {
+                            "type": "string"
+                          },
+                          "form_api_base_url": {
+                            "type": "string"
+                          },
+                          "instanceEndpoint": {
+                            "type": "string"
+                          },
+                          "api_url": {
+                            "type": "string"
+                          },
+                          "borneo_dashboard_url": {
+                            "type": "string"
+                          },
+                          "proxy_username": {
+                            "type": "string"
+                          },
+                          "proxy_password": {
+                            "type": "string"
+                          },
+                          "domain": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "string"
+                          },
+                          "dc": {
+                            "type": "string"
+                          },
+                          "site_name": {
+                            "type": "string"
+                          },
+                          "instanceName": {
+                            "type": "string"
+                          },
+                          "account_id": {
+                            "type": "string"
+                          },
+                          "your_server": {
+                            "type": "string"
+                          },
+                          "server_location": {
+                            "type": "string"
+                          },
+                          "base_url": {
+                            "type": "string"
+                          },
+                          "expired_at": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": {
+                          "nullable": true,
+                          "type": "object"
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "subdomain": {
+                            "type": "string"
+                          },
+                          "your-domain": {
+                            "type": "string"
+                          },
+                          "region": {
+                            "type": "string"
+                          },
+                          "shop": {
+                            "type": "string"
+                          },
+                          "account_url": {
+                            "type": "string"
+                          },
+                          "COMPANYDOMAIN": {
+                            "type": "string"
+                          },
+                          "extension": {
+                            "type": "string"
+                          },
+                          "form_api_base_url": {
+                            "type": "string"
+                          },
+                          "instanceEndpoint": {
+                            "type": "string"
+                          },
+                          "api_url": {
+                            "type": "string"
+                          },
+                          "borneo_dashboard_url": {
+                            "type": "string"
+                          },
+                          "proxy_username": {
+                            "type": "string"
+                          },
+                          "proxy_password": {
+                            "type": "string"
+                          },
+                          "domain": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "string"
+                          },
+                          "dc": {
+                            "type": "string"
+                          },
+                          "site_name": {
+                            "type": "string"
+                          },
+                          "instanceName": {
+                            "type": "string"
+                          },
+                          "account_id": {
+                            "type": "string"
+                          },
+                          "your_server": {
+                            "type": "string"
+                          },
+                          "server_location": {
+                            "type": "string"
+                          },
+                          "base_url": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": {
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -33341,7 +33743,8 @@
                           "redirectUrl"
                         ],
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -33425,7 +33828,8 @@
                           "devKey"
                         ],
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -33509,7 +33913,8 @@
                           "devKey"
                         ],
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -33589,7 +33994,8 @@
                           }
                         },
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -33666,7 +34072,8 @@
                           }
                         },
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -33740,7 +34147,8 @@
                           }
                         },
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -33814,91 +34222,8 @@
                           }
                         },
                         "additionalProperties": {
-                          "nullable": true
-                        }
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "subdomain": {
-                            "type": "string"
-                          },
-                          "your-domain": {
-                            "type": "string"
-                          },
-                          "region": {
-                            "type": "string"
-                          },
-                          "shop": {
-                            "type": "string"
-                          },
-                          "account_url": {
-                            "type": "string"
-                          },
-                          "COMPANYDOMAIN": {
-                            "type": "string"
-                          },
-                          "extension": {
-                            "type": "string"
-                          },
-                          "form_api_base_url": {
-                            "type": "string"
-                          },
-                          "instanceEndpoint": {
-                            "type": "string"
-                          },
-                          "api_url": {
-                            "type": "string"
-                          },
-                          "borneo_dashboard_url": {
-                            "type": "string"
-                          },
-                          "proxy_username": {
-                            "type": "string"
-                          },
-                          "proxy_password": {
-                            "type": "string"
-                          },
-                          "domain": {
-                            "type": "string"
-                          },
-                          "version": {
-                            "type": "string"
-                          },
-                          "dc": {
-                            "type": "string"
-                          },
-                          "site_name": {
-                            "type": "string"
-                          },
-                          "instanceName": {
-                            "type": "string"
-                          },
-                          "account_id": {
-                            "type": "string"
-                          },
-                          "your_server": {
-                            "type": "string"
-                          },
-                          "server_location": {
-                            "type": "string"
-                          },
-                          "base_url": {
-                            "type": "string"
-                          },
-                          "username": {
-                            "type": "string"
-                          },
-                          "password": {
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "username",
-                          "password"
-                        ],
-                        "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -33982,7 +34307,93 @@
                           "password"
                         ],
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "subdomain": {
+                            "type": "string"
+                          },
+                          "your-domain": {
+                            "type": "string"
+                          },
+                          "region": {
+                            "type": "string"
+                          },
+                          "shop": {
+                            "type": "string"
+                          },
+                          "account_url": {
+                            "type": "string"
+                          },
+                          "COMPANYDOMAIN": {
+                            "type": "string"
+                          },
+                          "extension": {
+                            "type": "string"
+                          },
+                          "form_api_base_url": {
+                            "type": "string"
+                          },
+                          "instanceEndpoint": {
+                            "type": "string"
+                          },
+                          "api_url": {
+                            "type": "string"
+                          },
+                          "borneo_dashboard_url": {
+                            "type": "string"
+                          },
+                          "proxy_username": {
+                            "type": "string"
+                          },
+                          "proxy_password": {
+                            "type": "string"
+                          },
+                          "domain": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "string"
+                          },
+                          "dc": {
+                            "type": "string"
+                          },
+                          "site_name": {
+                            "type": "string"
+                          },
+                          "instanceName": {
+                            "type": "string"
+                          },
+                          "account_id": {
+                            "type": "string"
+                          },
+                          "your_server": {
+                            "type": "string"
+                          },
+                          "server_location": {
+                            "type": "string"
+                          },
+                          "base_url": {
+                            "type": "string"
+                          },
+                          "username": {
+                            "type": "string"
+                          },
+                          "password": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "username",
+                          "password"
+                        ],
+                        "additionalProperties": {
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -34072,7 +34483,8 @@
                           "password"
                         ],
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -34159,7 +34571,8 @@
                           "password"
                         ],
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -34233,7 +34646,8 @@
                           }
                         },
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -34307,7 +34721,8 @@
                           }
                         },
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -34395,7 +34810,8 @@
                           "private_key"
                         ],
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -34483,7 +34899,8 @@
                           "private_key"
                         ],
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -34557,7 +34974,8 @@
                           }
                         },
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -34631,7 +35049,8 @@
                           }
                         },
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -34705,7 +35124,8 @@
                           }
                         },
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -34779,7 +35199,8 @@
                           }
                         },
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -34859,7 +35280,8 @@
                           }
                         },
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -34936,7 +35358,8 @@
                           }
                         },
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -35019,7 +35442,8 @@
                           }
                         },
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -35132,7 +35556,8 @@
                           "redirectUrl"
                         ],
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -35243,7 +35668,8 @@
                                 "type": "string"
                               },
                               {
-                                "nullable": true
+                                "nullable": true,
+                                "type": "object"
                               }
                             ]
                           },
@@ -35259,7 +35685,8 @@
                                 }
                               },
                               {
-                                "nullable": true
+                                "nullable": true,
+                                "type": "object"
                               }
                             ]
                           },
@@ -35275,7 +35702,8 @@
                           "access_token"
                         ],
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -35386,7 +35814,8 @@
                                 "type": "string"
                               },
                               {
-                                "nullable": true
+                                "nullable": true,
+                                "type": "object"
                               }
                             ]
                           },
@@ -35402,7 +35831,8 @@
                                 }
                               },
                               {
-                                "nullable": true
+                                "nullable": true,
+                                "type": "object"
                               }
                             ]
                           },
@@ -35418,7 +35848,8 @@
                           "access_token"
                         ],
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -35507,7 +35938,8 @@
                           }
                         },
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       },
                       {
@@ -35593,7 +36025,8 @@
                           }
                         },
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         }
                       }
                     ],
@@ -35752,6 +36185,15 @@
                     },
                     "require_mcp_api_key": {
                       "type": "boolean"
+                    },
+                    "is_composio_link_enabled_for_managed_auth": {
+                      "type": "boolean",
+                      "description": "Whether to enable composio link for managed authentication. This key will be deprecated in the future. Please don't use this key."
+                    },
+                    "signed_url_file_expiry_in_seconds": {
+                      "type": "number",
+                      "minimum": 1,
+                      "maximum": 86400
                     }
                   },
                   "required": [
@@ -35847,6 +36289,15 @@
                   },
                   "require_mcp_api_key": {
                     "type": "boolean"
+                  },
+                  "is_composio_link_enabled_for_managed_auth": {
+                    "type": "boolean",
+                    "description": "Whether to enable composio link for managed authentication. This key will be deprecated in the future. Please don't use this key."
+                  },
+                  "signed_url_file_expiry_in_seconds": {
+                    "type": "number",
+                    "minimum": 1,
+                    "maximum": 86400
                   }
                 }
               },
@@ -35894,6 +36345,15 @@
                     },
                     "require_mcp_api_key": {
                       "type": "boolean"
+                    },
+                    "is_composio_link_enabled_for_managed_auth": {
+                      "type": "boolean",
+                      "description": "Whether to enable composio link for managed authentication. This key will be deprecated in the future. Please don't use this key."
+                    },
+                    "signed_url_file_expiry_in_seconds": {
+                      "type": "number",
+                      "minimum": 1,
+                      "maximum": 86400
                     }
                   },
                   "required": [
@@ -36005,6 +36465,15 @@
                       },
                       "require_mcp_api_key": {
                         "type": "boolean"
+                      },
+                      "is_composio_link_enabled_for_managed_auth": {
+                        "type": "boolean",
+                        "description": "Whether to enable composio link for managed authentication. This key will be deprecated in the future. Please don't use this key."
+                      },
+                      "signed_url_file_expiry_in_seconds": {
+                        "type": "number",
+                        "minimum": 1,
+                        "maximum": 86400
                       }
                     },
                     "required": [
@@ -36496,6 +36965,16 @@
               }
             }
           },
+          "404": {
+            "description": "Not found. The specified project does not exist or you do not have access to it.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Internal server error. An unexpected error occurred while processing the request.",
             "content": {
@@ -36581,6 +37060,16 @@
           },
           "403": {
             "description": "Forbidden. You do not have permission to delete this project.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found. The specified project does not exist or has already been deleted.",
             "content": {
               "application/json": {
                 "schema": {
@@ -36695,6 +37184,16 @@
           },
           "401": {
             "description": "Unauthorized. Authentication is required or the provided credentials are invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found. The specified project does not exist or you do not have access to it.",
             "content": {
               "application/json": {
                 "schema": {
@@ -37578,6 +38077,11 @@
                       "type": "string",
                       "description": "Endpoint to get the current user"
                     },
+                    "get_current_user_endpoint_method": {
+                      "type": "string",
+                      "description": "HTTP method to use when calling the get current user endpoint (e.g., GET, POST)",
+                      "example": "GET"
+                    },
                     "deprecated": {
                       "type": "object",
                       "properties": {
@@ -37592,7 +38096,8 @@
                           "items": {
                             "type": "object",
                             "additionalProperties": {
-                              "nullable": true
+                              "nullable": true,
+                              "type": "object"
                             }
                           }
                         }
@@ -38019,8 +38524,7 @@
             "required": false,
             "description": "Optional version of the tool to retrieve",
             "name": "version",
-            "in": "query",
-            "deprecated": true
+            "in": "query"
           },
           {
             "schema": {
@@ -38509,7 +39013,8 @@
                       "body": {
                         "type": "object",
                         "additionalProperties": {
-                          "nullable": true
+                          "nullable": true,
+                          "type": "object"
                         },
                         "description": "The body to be sent to the endpoint for authentication. This is a JSON object. Note: This is very rarely needed and is only required by very few apps."
                       }
@@ -38640,7 +39145,8 @@
                                     "type": "string"
                                   },
                                   {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 ]
                               },
@@ -38656,7 +39162,8 @@
                                     }
                                   },
                                   {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 ]
                               },
@@ -38680,7 +39187,8 @@
                               "access_token"
                             ],
                             "additionalProperties": {
-                              "nullable": true
+                              "nullable": true,
+                              "type": "object"
                             }
                           }
                         },
@@ -38810,7 +39318,8 @@
                                     "type": "string"
                                   },
                                   {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 ]
                               },
@@ -38826,7 +39335,8 @@
                                     }
                                   },
                                   {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 ]
                               },
@@ -38842,7 +39352,8 @@
                               "access_token"
                             ],
                             "additionalProperties": {
-                              "nullable": true
+                              "nullable": true,
+                              "type": "object"
                             }
                           }
                         },
@@ -38947,7 +39458,8 @@
                               }
                             },
                             "additionalProperties": {
-                              "nullable": true
+                              "nullable": true,
+                              "type": "object"
                             }
                           }
                         },
@@ -39050,7 +39562,8 @@
                               "password"
                             ],
                             "additionalProperties": {
-                              "nullable": true
+                              "nullable": true,
+                              "type": "object"
                             }
                           }
                         },
@@ -39152,7 +39665,8 @@
                               "username"
                             ],
                             "additionalProperties": {
-                              "nullable": true
+                              "nullable": true,
+                              "type": "object"
                             }
                           }
                         },
@@ -39251,7 +39765,8 @@
                               "token"
                             ],
                             "additionalProperties": {
-                              "nullable": true
+                              "nullable": true,
+                              "type": "object"
                             }
                           }
                         },
@@ -39366,7 +39881,8 @@
                               "oauth_token_secret"
                             ],
                             "additionalProperties": {
-                              "nullable": true
+                              "nullable": true,
+                              "type": "object"
                             }
                           }
                         },
@@ -39459,7 +39975,8 @@
                               }
                             },
                             "additionalProperties": {
-                              "nullable": true
+                              "nullable": true,
+                              "type": "object"
                             }
                           }
                         },
@@ -39566,7 +40083,8 @@
                               "private_key"
                             ],
                             "additionalProperties": {
-                              "nullable": true
+                              "nullable": true,
+                              "type": "object"
                             }
                           }
                         },
@@ -39665,7 +40183,8 @@
                               "credentials_json"
                             ],
                             "additionalProperties": {
-                              "nullable": true
+                              "nullable": true,
+                              "type": "object"
                             }
                           }
                         },
@@ -39688,7 +40207,8 @@
                   "arguments": {
                     "type": "object",
                     "additionalProperties": {
-                      "nullable": true
+                      "nullable": true,
+                      "type": "object"
                     },
                     "description": "Key-value pairs of arguments required by the tool (mutually exclusive with text)",
                     "example": {
@@ -39727,7 +40247,8 @@
                     "data": {
                       "type": "object",
                       "additionalProperties": {
-                        "nullable": true
+                        "nullable": true,
+                        "type": "object"
                       },
                       "description": "Tool execution output data that varies based on the specific tool",
                       "example": {
@@ -39753,7 +40274,8 @@
                       "example": {
                         "session_id": "session-12345",
                         "expires_at": "2023-01-01T13:00:00Z"
-                      }
+                      },
+                      "type": "object"
                     },
                     "log_id": {
                       "type": "string",
@@ -39812,6 +40334,16 @@
           },
           "410": {
             "description": "Gone - Tool has been deprecated and is no longer available",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Payload too large - Request or response payload exceeds size limits",
             "content": {
               "application/json": {
                 "schema": {
@@ -39955,7 +40487,8 @@
                     "arguments": {
                       "type": "object",
                       "additionalProperties": {
-                        "nullable": true
+                        "nullable": true,
+                        "type": "object"
                       },
                       "description": "Key-value pairs of arguments required by the tool to accomplish the described task",
                       "example": {
@@ -40092,7 +40625,8 @@
                     "example": {
                       "name": "New Resource",
                       "description": "This is a new resource"
-                    }
+                    },
+                    "type": "object"
                   },
                   "binary_body": {
                     "anyOf": [
@@ -40131,7 +40665,7 @@
                         ]
                       }
                     ],
-                    "description": "Binary body to send. For binary upload via URL: use {url: \"https://...\", contentType?: \"...\"}. For binary upload via base64: use {base64: \"...\", contentType?: \"...\"}."
+                    "description": "Binary body to send. For binary upload via URL: use {url: \"https://...\", content_type?: \"...\"}. For binary upload via base64: use {base64: \"...\", content_type?: \"...\"}."
                   },
                   "parameters": {
                     "type": "array",
@@ -40292,7 +40826,8 @@
                                     "type": "string"
                                   },
                                   {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 ]
                               },
@@ -40308,7 +40843,8 @@
                                     }
                                   },
                                   {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 ]
                               },
@@ -40332,7 +40868,8 @@
                               "access_token"
                             ],
                             "additionalProperties": {
-                              "nullable": true
+                              "nullable": true,
+                              "type": "object"
                             }
                           }
                         },
@@ -40462,7 +40999,8 @@
                                     "type": "string"
                                   },
                                   {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 ]
                               },
@@ -40478,7 +41016,8 @@
                                     }
                                   },
                                   {
-                                    "nullable": true
+                                    "nullable": true,
+                                    "type": "object"
                                   }
                                 ]
                               },
@@ -40494,7 +41033,8 @@
                               "access_token"
                             ],
                             "additionalProperties": {
-                              "nullable": true
+                              "nullable": true,
+                              "type": "object"
                             }
                           }
                         },
@@ -40599,7 +41139,8 @@
                               }
                             },
                             "additionalProperties": {
-                              "nullable": true
+                              "nullable": true,
+                              "type": "object"
                             }
                           }
                         },
@@ -40702,7 +41243,8 @@
                               "password"
                             ],
                             "additionalProperties": {
-                              "nullable": true
+                              "nullable": true,
+                              "type": "object"
                             }
                           }
                         },
@@ -40804,7 +41346,8 @@
                               "username"
                             ],
                             "additionalProperties": {
-                              "nullable": true
+                              "nullable": true,
+                              "type": "object"
                             }
                           }
                         },
@@ -40903,7 +41446,8 @@
                               "token"
                             ],
                             "additionalProperties": {
-                              "nullable": true
+                              "nullable": true,
+                              "type": "object"
                             }
                           }
                         },
@@ -41018,7 +41562,8 @@
                               "oauth_token_secret"
                             ],
                             "additionalProperties": {
-                              "nullable": true
+                              "nullable": true,
+                              "type": "object"
                             }
                           }
                         },
@@ -41111,7 +41656,8 @@
                               }
                             },
                             "additionalProperties": {
-                              "nullable": true
+                              "nullable": true,
+                              "type": "object"
                             }
                           }
                         },
@@ -41218,7 +41764,8 @@
                               "private_key"
                             ],
                             "additionalProperties": {
-                              "nullable": true
+                              "nullable": true,
+                              "type": "object"
                             }
                           }
                         },
@@ -41317,7 +41864,8 @@
                               "credentials_json"
                             ],
                             "additionalProperties": {
-                              "nullable": true
+                              "nullable": true,
+                              "type": "object"
                             }
                           }
                         },
@@ -41354,7 +41902,8 @@
                         "id": "123",
                         "name": "Resource Name",
                         "created_at": "2023-01-01T00:00:00Z"
-                      }
+                      },
+                      "type": "object"
                     },
                     "binary_data": {
                       "type": "object",
@@ -41513,6 +42062,8 @@
     },
     "/api/v3/trigger_instances/{slug}/upsert": {
       "post": {
+        "summary": "Create or update a trigger",
+        "description": "Creates a new trigger instance or updates an existing one with the same configuration. Triggers listen for events from external services (webhooks or polling) and can invoke your workflows. If a matching trigger already exists and is disabled, it will be re-enabled. Requires a connected account ID to associate the trigger with a specific user connection.",
         "tags": [
           "Triggers"
         ],
@@ -41529,10 +42080,10 @@
           {
             "schema": {
               "type": "string",
-              "description": "The slug of the trigger instance"
+              "description": "The slug of the trigger instance. Case-insensitive (internally normalized to uppercase)."
             },
             "required": true,
-            "description": "The slug of the trigger instance",
+            "description": "The slug of the trigger instance. Case-insensitive (internally normalized to uppercase).",
             "name": "slug",
             "in": "path"
           }
@@ -41552,7 +42103,8 @@
                   "triggerConfig": {
                     "type": "object",
                     "additionalProperties": {
-                      "nullable": true
+                      "nullable": true,
+                      "type": "object"
                     },
                     "description": "DEPRECATED: This parameter will be removed in a future version. Please use trigger_config instead.",
                     "deprecated": true
@@ -41565,7 +42117,8 @@
                   "trigger_config": {
                     "type": "object",
                     "additionalProperties": {
-                      "nullable": true
+                      "nullable": true,
+                      "type": "object"
                     },
                     "description": "Trigger configuration"
                   },
@@ -41587,7 +42140,8 @@
                         }
                       },
                       {
-                        "nullable": true
+                        "nullable": true,
+                        "type": "object"
                       }
                     ],
                     "description": "Toolkit version specification. Supports \"latest\" string or a record mapping toolkit slugs to specific versions.",
@@ -41600,7 +42154,39 @@
         },
         "responses": {
           "200": {
-            "description": "Successfully updated trigger instance",
+            "description": "Successfully upserted trigger instance",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "trigger_id": {
+                      "type": "string",
+                      "description": "ID of the updated trigger"
+                    },
+                    "deprecated": {
+                      "type": "object",
+                      "properties": {
+                        "uuid": {
+                          "type": "string",
+                          "description": "ID of the updated trigger"
+                        }
+                      },
+                      "required": [
+                        "uuid"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "trigger_id",
+                    "deprecated"
+                  ]
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Successfully created trigger instance",
             "content": {
               "application/json": {
                 "schema": {
@@ -41717,6 +42303,8 @@
     },
     "/api/v3/trigger_instances/active": {
       "get": {
+        "summary": "List active triggers",
+        "description": "Retrieves all active trigger instances for your project. Triggers listen for events from connected accounts (e.g., new emails, Slack messages, GitHub commits) and can invoke webhooks or workflows. Use filters to find triggers for specific users, connected accounts, or trigger types.",
         "tags": [
           "Triggers"
         ],
@@ -41730,6 +42318,20 @@
           }
         ],
         "parameters": [
+          {
+            "schema": {
+              "type": "array",
+              "nullable": true,
+              "items": {
+                "type": "string"
+              },
+              "description": "Array of user IDs to filter triggers by"
+            },
+            "required": false,
+            "description": "Array of user IDs to filter triggers by",
+            "name": "user_ids",
+            "in": "query"
+          },
           {
             "schema": {
               "type": "array",
@@ -41782,10 +42384,10 @@
               "items": {
                 "type": "string"
               },
-              "description": "Array of trigger names to filter triggers by"
+              "description": "Array of trigger names to filter triggers by. Case-insensitive (internally normalized to uppercase)."
             },
             "required": false,
-            "description": "Array of trigger names to filter triggers by",
+            "description": "Array of trigger names to filter triggers by. Case-insensitive (internally normalized to uppercase).",
             "name": "trigger_names",
             "in": "query"
           },
@@ -41858,18 +42460,6 @@
             "description": "DEPRECATED: This parameter will be removed in a future version. Please use trigger_names instead.",
             "deprecated": true,
             "name": "triggerNames",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "number",
-              "minimum": 1,
-              "default": 1,
-              "description": "Page number for pagination. Starts from 1."
-            },
-            "required": false,
-            "description": "Page number for pagination. Starts from 1.",
-            "name": "page",
             "in": "query"
           },
           {
@@ -41980,14 +42570,16 @@
                           "trigger_config": {
                             "type": "object",
                             "additionalProperties": {
-                              "nullable": true
+                              "nullable": true,
+                              "type": "object"
                             },
                             "description": "Configuration for the trigger"
                           },
                           "state": {
                             "type": "object",
                             "additionalProperties": {
-                              "nullable": true
+                              "nullable": true,
+                              "type": "object"
                             },
                             "description": "State of the trigger instance"
                           },
@@ -42003,7 +42595,8 @@
                           "disabledAt": {
                             "type": "string",
                             "nullable": true,
-                            "description": "ID of the user who disabled the trigger instance, if applicable"
+                            "description": "DEPRECATED: This parameter will be removed in a future version. Please use disabled_at instead.",
+                            "deprecated": true
                           },
                           "connectedAccountId": {
                             "type": "string",
@@ -42023,7 +42616,8 @@
                           "triggerConfig": {
                             "type": "object",
                             "additionalProperties": {
-                              "nullable": true
+                              "nullable": true,
+                              "type": "object"
                             },
                             "description": "DEPRECATED: This parameter will be removed in a future version. Please use trigger_config instead.",
                             "deprecated": true
@@ -42119,6 +42713,8 @@
     },
     "/api/v3/trigger_instances/manage/{triggerId}": {
       "delete": {
+        "summary": "Delete a trigger",
+        "description": "Permanently deletes a trigger instance. This stops the trigger from listening for events and removes it from your project. Use the PATCH endpoint with status \"disable\" if you want to temporarily pause a trigger instead.",
         "tags": [
           "Triggers"
         ],
@@ -42228,6 +42824,8 @@
         }
       },
       "patch": {
+        "summary": "Enable or disable a trigger",
+        "description": "Updates the status of a trigger instance to enable or disable it. Disabling a trigger pauses event listening without deleting the trigger configuration. Re-enabling restores the trigger to its active state. Use this for temporary maintenance or to control trigger execution.",
         "tags": [
           "Triggers"
         ],
@@ -42464,11 +43062,11 @@
           {
             "schema": {
               "type": "string",
-              "description": "The unique slug identifier for the trigger type",
+              "description": "The unique slug identifier for the trigger type. Case-insensitive (internally normalized to uppercase).",
               "example": "SLACK_NEW_MESSAGE"
             },
             "required": true,
-            "description": "The unique slug identifier for the trigger type",
+            "description": "The unique slug identifier for the trigger type. Case-insensitive (internally normalized to uppercase).",
             "name": "slug",
             "in": "path"
           },
@@ -42575,7 +43173,8 @@
                     "config": {
                       "type": "object",
                       "additionalProperties": {
-                        "nullable": true
+                        "nullable": true,
+                        "type": "object"
                       },
                       "description": "Configuration schema required to set up this trigger",
                       "example": {
@@ -42596,7 +43195,8 @@
                     "payload": {
                       "type": "object",
                       "additionalProperties": {
-                        "nullable": true
+                        "nullable": true,
+                        "type": "object"
                       },
                       "description": "Schema of the data payload this trigger will deliver when it fires",
                       "example": {
@@ -42841,7 +43441,8 @@
                           "config": {
                             "type": "object",
                             "additionalProperties": {
-                              "nullable": true
+                              "nullable": true,
+                              "type": "object"
                             },
                             "description": "Configuration schema required to set up this trigger",
                             "example": {
@@ -42862,7 +43463,8 @@
                           "payload": {
                             "type": "object",
                             "additionalProperties": {
-                              "nullable": true
+                              "nullable": true,
+                              "type": "object"
                             },
                             "description": "Schema of the data payload this trigger will deliver when it fires",
                             "example": {
@@ -45745,6 +46347,16 @@
               }
             }
           },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Internal server error",
             "content": {
@@ -45782,23 +46394,23 @@
                 "properties": {
                   "toolkit_slug": {
                     "type": "string",
-                    "description": "Slug of the app where this file belongs to. Example: \"image-processing\""
+                    "description": "Slug of the app where this file belongs to. Example: \"gmail\", \"slack\", \"github\""
                   },
                   "tool_slug": {
                     "type": "string",
-                    "description": "Slug of the action where this file belongs to. Example: \"resize-image\""
+                    "description": "Slug of the action where this file belongs to. Example: \"GMAIL_SEND_EMAIL\", \"SLACK_UPLOAD_FILE\""
                   },
                   "filename": {
                     "type": "string",
-                    "description": "Name of the original file. Example: \"photo.jpg\""
+                    "description": "Name of the original file. Example: \"quarterly_report.pdf\""
                   },
                   "mimetype": {
                     "type": "string",
-                    "description": "Mime type of the original file. Example: \"image/jpeg\""
+                    "description": "Mime type of the original file. Example: \"application/pdf\", \"image/png\""
                   },
                   "md5": {
                     "type": "string",
-                    "description": "MD5 hash of the file for deduplication and integrity verification. Example: \"d41d8cd98f00b204e9800998ecf8427e\""
+                    "description": "MD5 hash of the file for deduplication and integrity verification. Example: \"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6\""
                   }
                 },
                 "required": [
@@ -45810,13 +46422,49 @@
                 ]
               },
               "examples": {
-                "New Image File": {
+                "Gmail Email Attachment": {
                   "value": {
-                    "toolkit_slug": "image-processing",
-                    "tool_slug": "resize-image",
-                    "filename": "photo.jpg",
-                    "mimetype": "image/jpeg",
-                    "md5": "d41d8cd98f00b204e9800998ecf8427e"
+                    "toolkit_slug": "gmail",
+                    "tool_slug": "GMAIL_SEND_EMAIL",
+                    "filename": "quarterly_report.pdf",
+                    "mimetype": "application/pdf",
+                    "md5": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"
+                  }
+                },
+                "Slack File Upload": {
+                  "value": {
+                    "toolkit_slug": "slack",
+                    "tool_slug": "SLACK_UPLOAD_FILE",
+                    "filename": "meeting_notes.docx",
+                    "mimetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                    "md5": "b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7"
+                  }
+                },
+                "GitHub Issue Screenshot": {
+                  "value": {
+                    "toolkit_slug": "github",
+                    "tool_slug": "GITHUB_CREATE_ISSUE",
+                    "filename": "bug_screenshot.png",
+                    "mimetype": "image/png",
+                    "md5": "c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8"
+                  }
+                },
+                "Notion Page Image": {
+                  "value": {
+                    "toolkit_slug": "notion",
+                    "tool_slug": "NOTION_ADD_PAGE_CONTENT",
+                    "filename": "diagram.svg",
+                    "mimetype": "image/svg+xml",
+                    "md5": "d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9"
+                  }
+                },
+                "Jira Attachment": {
+                  "value": {
+                    "toolkit_slug": "jira",
+                    "tool_slug": "JIRA_ADD_ATTACHMENT",
+                    "filename": "error_logs.txt",
+                    "mimetype": "text/plain",
+                    "md5": "e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0"
                   }
                 }
               }
@@ -45829,163 +46477,57 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "string",
-                          "description": "ID of the request file. Example: \"f1e2d3c4b5a6\""
-                        },
-                        "key": {
-                          "type": "string",
-                          "description": "S3 upload location. Example: \"projects/123/files/photo-1234.jpg\""
-                        },
-                        "existing_url": {
-                          "type": "string",
-                          "description": "URL of the existing request file. Example: \"https://storage.example.com/projects/123/files/photo-1234.jpg\""
-                        },
-                        "existingUrl": {
-                          "type": "string",
-                          "description": "[DEPRECATED] Use existing_url instead. URL of the existing request file. Example: \"https://storage.example.com/projects/123/files/photo-1234.jpg\""
-                        },
-                        "type": {
-                          "type": "string",
-                          "enum": [
-                            "existing"
-                          ],
-                          "description": "Indicates the file already exists and does not need to be uploaded again"
-                        },
-                        "metadata": {
-                          "type": "object",
-                          "properties": {
-                            "storage_backend": {
-                              "type": "string",
-                              "enum": [
-                                "s3",
-                                "azure_blob_storage"
-                              ],
-                              "description": "Storage backend used for the file. If this is azure, use `x-ms-blob-type` header to set the blob type to `BlockBlob` while uploading the file"
-                            }
-                          },
-                          "required": [
-                            "storage_backend"
-                          ]
-                        }
-                      },
-                      "required": [
-                        "id",
-                        "key",
-                        "existing_url",
-                        "existingUrl",
-                        "type",
-                        "metadata"
-                      ]
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "description": "ID of the request file. Example: \"req_file_9mZn4qR8sXwT\""
                     },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "string",
-                          "description": "ID of the request file. Example: \"f1e2d3c4b5a6\""
-                        },
-                        "key": {
-                          "type": "string",
-                          "description": "S3 upload location. Example: \"projects/123/files/photo-1234.jpg\""
-                        },
-                        "new_presigned_url": {
-                          "type": "string",
-                          "description": "Presigned URL for upload. Example: \"https://storage.example.com/projects/123/files/photo-1234.jpg?X-Amz-Algorithm=...\""
-                        },
-                        "newPresignedUrl": {
-                          "type": "string",
-                          "description": "[DEPRECATED] Use new_presigned_url instead. Presigned URL for upload. Example: \"https://storage.example.com/projects/123/files/photo-1234.jpg?X-Amz-Algorithm=...\""
-                        },
-                        "type": {
-                          "type": "string",
-                          "enum": [
-                            "new"
-                          ],
-                          "description": "Indicates this is a new file that needs to be uploaded"
-                        },
-                        "metadata": {
-                          "type": "object",
-                          "properties": {
-                            "storage_backend": {
-                              "type": "string",
-                              "enum": [
-                                "s3",
-                                "azure_blob_storage"
-                              ],
-                              "description": "Storage backend used for the file. If this is azure, use `x-ms-blob-type` header to set the blob type to `BlockBlob` while uploading the file"
-                            }
-                          },
-                          "required": [
-                            "storage_backend"
-                          ]
-                        }
-                      },
-                      "required": [
-                        "id",
-                        "key",
-                        "new_presigned_url",
-                        "newPresignedUrl",
-                        "type",
-                        "metadata"
-                      ]
+                    "key": {
+                      "type": "string",
+                      "description": "Object storage upload location. Example: \"projects/prj_xyz789/requests/slack/SLACK_UPLOAD_FILE/document_9mZn4q.docx\""
                     },
-                    {
+                    "new_presigned_url": {
+                      "type": "string",
+                      "description": "Presigned URL for upload. Example: \"https://storage.composio.dev/projects/prj_xyz789/requests/slack/document_9mZn4q.docx?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Expires=3600...\""
+                    },
+                    "newPresignedUrl": {
+                      "type": "string",
+                      "description": "[DEPRECATED] Use new_presigned_url instead. Presigned URL for upload. Example: \"https://storage.composio.dev/projects/prj_xyz789/requests/slack/document_9mZn4q.docx?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Expires=3600...\"",
+                      "deprecated": true
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "new"
+                      ],
+                      "description": "[DEPRECATED] Indicates this is a new file that needs to be uploaded",
+                      "deprecated": true
+                    },
+                    "metadata": {
                       "type": "object",
                       "properties": {
-                        "id": {
-                          "type": "string",
-                          "description": "ID of the request file. Example: \"f1e2d3c4b5a6\""
-                        },
-                        "key": {
-                          "type": "string",
-                          "description": "S3 upload location. Example: \"projects/123/files/photo-1234.jpg\""
-                        },
-                        "update_presigned_url": {
-                          "type": "string",
-                          "description": "Presigned URL for upload. Example: \"https://storage.example.com/projects/123/files/photo-1234.jpg?X-Amz-Algorithm=...\""
-                        },
-                        "updatePresignedUrl": {
-                          "type": "string",
-                          "description": "[DEPRECATED] Use update_presigned_url instead. Presigned URL for upload. Example: \"https://storage.example.com/projects/123/files/photo-1234.jpg?X-Amz-Algorithm=...\""
-                        },
-                        "type": {
+                        "storage_backend": {
                           "type": "string",
                           "enum": [
-                            "update"
+                            "s3",
+                            "azure_blob_storage"
                           ],
-                          "description": "Indicates this file exists but needs to be updated with a new version"
-                        },
-                        "metadata": {
-                          "type": "object",
-                          "properties": {
-                            "storage_backend": {
-                              "type": "string",
-                              "enum": [
-                                "s3",
-                                "azure_blob_storage"
-                              ],
-                              "description": "Storage backend used for the file. If this is azure, use `x-ms-blob-type` header to set the blob type to `BlockBlob` while uploading the file"
-                            }
-                          },
-                          "required": [
-                            "storage_backend"
-                          ]
+                          "description": "Storage backend used for the file. If this is azure, use `x-ms-blob-type` header to set the blob type to `BlockBlob` while uploading the file"
                         }
                       },
                       "required": [
-                        "id",
-                        "key",
-                        "update_presigned_url",
-                        "updatePresignedUrl",
-                        "type",
-                        "metadata"
+                        "storage_backend"
                       ]
                     }
+                  },
+                  "required": [
+                    "id",
+                    "key",
+                    "new_presigned_url",
+                    "newPresignedUrl",
+                    "type",
+                    "metadata"
                   ]
                 }
               }
@@ -46524,10 +47066,18 @@
                         "format": "uri",
                         "description": "The URL to redirect to after a user completes authentication for a connected account. This allows you to handle the auth callback in your own application.",
                         "example": "https://your-app.com/auth/callback"
+                      },
+                      "enable_wait_for_connections": {
+                        "type": "boolean",
+                        "nullable": true,
+                        "default": false,
+                        "description": "When true, the COMPOSIO_WAIT_FOR_CONNECTIONS tool is available for agents to poll connection status after sharing auth URLs. Default is false (disabled). May not work reliably with GPT models.",
+                        "example": false
                       }
                     },
                     "default": {
-                      "enable": true
+                      "enable": true,
+                      "enable_wait_for_connections": false
                     },
                     "additionalProperties": false,
                     "description": "Configuration for connection management settings"
@@ -46745,6 +47295,26 @@
                     },
                     "additionalProperties": false,
                     "description": "Configuration for workbench behavior"
+                  },
+                  "experimental": {
+                    "type": "object",
+                    "properties": {
+                      "assistive_prompt_config": {
+                        "type": "object",
+                        "properties": {
+                          "user_timezone": {
+                            "type": "string",
+                            "description": "IANA timezone identifier (e.g., 'America/New_York', 'Europe/London'). Used to customize the system prompt with timezone-aware instructions.",
+                            "example": "America/New_York"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "description": "Customize assistive prompt generation (e.g., timezone)."
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "Experimental features - not stable, may be modified or removed in future versions.",
+                    "x-experimental": true
                   }
                 },
                 "required": [
@@ -46980,17 +47550,7 @@
                     "tool_router_tools": {
                       "type": "array",
                       "items": {
-                        "type": "string",
-                        "enum": [
-                          "COMPOSIO_SEARCH_TOOLS",
-                          "COMPOSIO_MULTI_EXECUTE_TOOL",
-                          "COMPOSIO_MANAGE_CONNECTIONS",
-                          "COMPOSIO_REMOTE_WORKBENCH",
-                          "COMPOSIO_REMOTE_BASH_TOOL",
-                          "COMPOSIO_GET_TOOL_SCHEMAS",
-                          "COMPOSIO_UPSERT_RECIPE",
-                          "COMPOSIO_GET_RECIPE"
-                        ]
+                        "type": "string"
                       },
                       "description": "List of available tools in this session"
                     },
@@ -47064,6 +47624,11 @@
                               "type": "string",
                               "format": "uri",
                               "description": "Custom callback URL for connected account auth flows"
+                            },
+                            "enable_wait_for_connections": {
+                              "type": "boolean",
+                              "default": false,
+                              "description": "Enable the COMPOSIO_WAIT_FOR_CONNECTIONS tool for polling connection status. Default false. May not work reliably with GPT models."
                             }
                           },
                           "description": "Manage connections configuration"
@@ -47202,6 +47767,21 @@
                         "user_id"
                       ],
                       "description": "The session configuration including user, toolkits, and overrides"
+                    },
+                    "experimental": {
+                      "type": "object",
+                      "properties": {
+                        "assistive_prompt": {
+                          "type": "string",
+                          "description": "The assistive system prompt to inject into your agent for optimal tool router usage",
+                          "example": "You are an AI agent that completes user tasks by calling Composio ToolRouter meta-tools..."
+                        }
+                      },
+                      "required": [
+                        "assistive_prompt"
+                      ],
+                      "description": "Experimental features including the generated system prompt. Only returned on session creation, not on GET.",
+                      "x-experimental": true
                     }
                   },
                   "required": [
@@ -47305,7 +47885,8 @@
                   "arguments": {
                     "type": "object",
                     "additionalProperties": {
-                      "nullable": true
+                      "nullable": true,
+                      "type": "object"
                     },
                     "default": {},
                     "description": "The arguments required by the tool",
@@ -47337,7 +47918,8 @@
                     "data": {
                       "type": "object",
                       "additionalProperties": {
-                        "nullable": true
+                        "nullable": true,
+                        "type": "object"
                       },
                       "description": "The data returned by the tool execution",
                       "example": {
@@ -47460,6 +48042,7 @@
                       "COMPOSIO_SEARCH_TOOLS",
                       "COMPOSIO_MULTI_EXECUTE_TOOL",
                       "COMPOSIO_MANAGE_CONNECTIONS",
+                      "COMPOSIO_WAIT_FOR_CONNECTIONS",
                       "COMPOSIO_REMOTE_WORKBENCH",
                       "COMPOSIO_REMOTE_BASH_TOOL",
                       "COMPOSIO_GET_TOOL_SCHEMAS",
@@ -47472,7 +48055,8 @@
                   "arguments": {
                     "type": "object",
                     "additionalProperties": {
-                      "nullable": true
+                      "nullable": true,
+                      "type": "object"
                     },
                     "default": {},
                     "description": "The arguments required by the meta tool",
@@ -47502,7 +48086,8 @@
                     "data": {
                       "type": "object",
                       "additionalProperties": {
-                        "nullable": true
+                        "nullable": true,
+                        "type": "object"
                       },
                       "description": "The data returned by the tool execution",
                       "example": {
@@ -47652,17 +48237,7 @@
                     "tool_router_tools": {
                       "type": "array",
                       "items": {
-                        "type": "string",
-                        "enum": [
-                          "COMPOSIO_SEARCH_TOOLS",
-                          "COMPOSIO_MULTI_EXECUTE_TOOL",
-                          "COMPOSIO_MANAGE_CONNECTIONS",
-                          "COMPOSIO_REMOTE_WORKBENCH",
-                          "COMPOSIO_REMOTE_BASH_TOOL",
-                          "COMPOSIO_GET_TOOL_SCHEMAS",
-                          "COMPOSIO_UPSERT_RECIPE",
-                          "COMPOSIO_GET_RECIPE"
-                        ]
+                        "type": "string"
                       },
                       "description": "List of available tools in this session"
                     },
@@ -47736,6 +48311,11 @@
                               "type": "string",
                               "format": "uri",
                               "description": "Custom callback URL for connected account auth flows"
+                            },
+                            "enable_wait_for_connections": {
+                              "type": "boolean",
+                              "default": false,
+                              "description": "Enable the COMPOSIO_WAIT_FOR_CONNECTIONS tool for polling connection status. Default false. May not work reliably with GPT models."
                             }
                           },
                           "description": "Manage connections configuration"
@@ -48213,6 +48793,121 @@
           },
           "500": {
             "description": "Internal server error. An unexpected error occurred while processing the request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/tool_router/session/{session_id}/tools": {
+      "get": {
+        "summary": "List meta tools with schemas for a tool router session",
+        "description": "Returns the meta tools available in a tool router session with their complete schemas. This includes request and response schemas specific to the session context.",
+        "tags": [
+          "Tool Router"
+        ],
+        "operationId": "getToolRouterSessionBySessionIdTools",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "toolRouterSessionId",
+              "description": "Tool router session ID"
+            },
+            "required": false,
+            "description": "Tool router session ID",
+            "name": "session_id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {}
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved meta tools with their complete schemas.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Tool"
+                      },
+                      "description": "List of tools with their complete schemas"
+                    }
+                  },
+                  "required": [
+                    "items"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
             "content": {
               "application/json": {
                 "schema": {

--- a/docs/scripts/fetch-openapi.mjs
+++ b/docs/scripts/fetch-openapi.mjs
@@ -82,6 +82,29 @@ async function fetchAndFilterSpec() {
   console.log(`Removed ${removedCount} endpoints/operations`);
   console.log(`Final spec has ${Object.keys(filteredPaths).length} paths`);
 
+  // Fix invalid OpenAPI: "nullable" without "type" is not valid in OpenAPI 3.0
+  // Transform these to have an empty object (allows any type) or add a sensible type
+  let nullableFixCount = 0;
+  const fixNullableWithoutType = (obj) => {
+    if (!obj || typeof obj !== 'object') return;
+
+    // If this object has nullable: true but no type, $ref, oneOf, anyOf, or allOf
+    if (obj.nullable === true && !obj.type && !obj.$ref && !obj.oneOf && !obj.anyOf && !obj.allOf) {
+      // Add type: object as a sensible default for nullable fields without type
+      obj.type = 'object';
+      nullableFixCount++;
+    }
+
+    // Recurse into all values
+    for (const val of Object.values(obj)) {
+      fixNullableWithoutType(val);
+    }
+  };
+  fixNullableWithoutType(spec);
+  if (nullableFixCount > 0) {
+    console.log(`Fixed ${nullableFixCount} schemas with nullable but no type`);
+  }
+
   // Write to public directory for fumadocs to fetch
   const __dirname = dirname(fileURLToPath(import.meta.url));
   const outputPath = join(__dirname, '../public/openapi.json');


### PR DESCRIPTION
## Summary
- Fixes API reference pages that crash due to invalid OpenAPI 3.0 schemas
- Adds transformation in `fetch-openapi.mjs` to handle properties with `nullable: true` but no `type` field
- Currently fixes 448 schemas in the spec

## Problem
Pages like [/tools/postToolsExecuteProxy](https://docs.composio.dev/reference/api-reference/tools/postToolsExecuteProxy) crash because fumadocs cannot render schemas where properties only have `"nullable": true` without a corresponding type.

Example of invalid schema:
```json
"body": {
  "nullable": true,
  "description": "The request body..."
}
```

## Solution
The fix recursively finds all properties with `nullable: true` but no `type`, `$ref`, `oneOf`, `anyOf`, or `allOf`, and adds `"type": "object"` as a sensible default.

## Test plan
- [x] Regenerate openapi.json and verify the fix is applied
- [ ] Visit the affected page to confirm it loads without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)