### PR TITLE
fix(docs): add additional OpenAPI validation fixes

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "version": "3.0.0",
     "title": "Composio Platform API",
-    "description": "",
+    "description": "API for managing tools, toolkits, connected accounts, and authentication configurations in Composio.",
     "contact": {
       "name": "Composio Support",
       "url": "https://composio.dev/support",
@@ -47156,7 +47156,11 @@
                 "type": "string"
               },
               "description": "Filter toolkits by specific slugs (comma-separated). Overrides session toolkit configuration if provided.",
-              "example": "gmail,slack,github"
+              "example": [
+                "gmail",
+                "slack",
+                "github"
+              ]
             },
             "required": false,
             "description": "Optional comma-separated list of toolkit slugs to filter by. If provided, only these toolkits will be returned, overriding the session configuration.",

--- a/docs/scripts/fetch-openapi.mjs
+++ b/docs/scripts/fetch-openapi.mjs
@@ -149,6 +149,36 @@ async function fetchAndFilterSpec() {
     console.log(`Fixed ${nullableFixCount} schemas with nullable but no type`);
   }
 
+  // Fix empty info.description
+  if (spec.info && !spec.info.description) {
+    spec.info.description = 'API for managing tools, toolkits, connected accounts, and authentication configurations in Composio.';
+    console.log('Added missing info.description');
+  }
+
+  // Fix example type mismatches (string examples for array types)
+  let exampleFixCount = 0;
+  const fixExampleTypes = (obj) => {
+    if (!obj || typeof obj !== 'object') return;
+
+    // Fix array type with string example (comma-separated values)
+    if (obj.type === 'array' && typeof obj.example === 'string' && obj.example.includes(',')) {
+      obj.example = obj.example.split(',').map(s => s.trim());
+      exampleFixCount++;
+    }
+
+    for (const [key, val] of Object.entries(obj)) {
+      if (Array.isArray(val)) {
+        val.forEach((item) => fixExampleTypes(item));
+      } else if (typeof val === 'object') {
+        fixExampleTypes(val);
+      }
+    }
+  };
+  fixExampleTypes(spec);
+  if (exampleFixCount > 0) {
+    console.log(`Fixed ${exampleFixCount} example type mismatches`);
+  }
+
   // Write to public directory for fumadocs to fetch
   const __dirname = dirname(fileURLToPath(import.meta.url));
   const outputPath = join(__dirname, '../public/openapi.json');


### PR DESCRIPTION
## Summary
Follow-up to #2526 with additional OpenAPI schema fixes discovered during comprehensive audit.

## Changes

### 1. Fix empty `info.description`
The API spec had an empty description field which could cause issues in documentation generators.
```json
// Before
"description": ""

// After
"description": "API for managing tools, toolkits, connected accounts, and authentication configurations in Composio."
```

### 2. Fix example type mismatches
The `toolkits` parameter has `type: array` but the example was a comma-separated string:
```json
// Before
"type": "array",
"example": "gmail,slack,github"

// After  
"type": "array",
"example": ["gmail", "slack", "github"]
```

## Validation
Ran comprehensive audit script checking for:
- nullable without type
- empty strings/descriptions
- array without items
- empty enums
- invalid $refs
- empty oneOf/anyOf/allOf
- invalid required fields
- missing operationIds
- response schemas
- default/example type mismatches
- circular references
- and more...

**Result: 0 critical, 0 warnings, 0 info**

## Test plan
- [x] Regenerate openapi.json
- [x] Run audit script - all checks pass
- [ ] Verify API reference pages load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)