### PR TITLE
fix: Add redirect for old Fern API reference URLs

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -181,6 +181,14 @@ const config = {
         destination: '/reference',
         permanent: true,
       },
+      // Old Fern API endpoint URLs with kebab-case operationIds
+      // e.g. /api-reference/tools/post-tools-execute-by-tool-slug
+      // proxy.ts handles kebab-to-camelCase conversion
+      {
+        source: '/api-reference/:tag/:operationId',
+        destination: '/reference/api-reference/:tag/:operationId',
+        permanent: true,
+      },
       {
         source: '/api-reference/:path*',
         destination: '/reference/:path*',


### PR DESCRIPTION
## Summary
- Adds redirect for old Fern API reference URLs (e.g. `/api-reference/tools/post-tools-execute-by-tool-slug`)
- These URLs now properly redirect to `/reference/api-reference/:tag/:operationId`
- The existing `proxy.ts` handles kebab-to-camelCase conversion

## Test plan
- [ ] Visit https://docs.composio.dev/api-reference/tools/post-tools-execute-by-tool-slug
- [ ] Verify it redirects to `/reference/api-reference/tools/postToolsExecuteByToolSlug`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)