### PR TITLE
fix(core): loosen V3 webhook schema to accept any composio.* event type

### DIFF
--- a/python/composio/core/models/triggers.py
+++ b/python/composio/core/models/triggers.py
@@ -126,7 +126,7 @@ class WebhookPayloadV3(te.TypedDict):
 
     id: str
     timestamp: str
-    type: t.Literal["composio.trigger.message"]
+    type: str  # Any composio.* event type (e.g., 'composio.trigger.message', 'composio.connected_account.expired')
     metadata: WebhookPayloadV3Metadata
     data: t.Dict[str, t.Any]
 
@@ -1074,7 +1074,7 @@ class Triggers(Resource):
                 f"Failed to parse webhook payload as JSON: {e}"
             ) from e
 
-        # Try V3 first (has 'type' === 'composio.trigger.message' and 'metadata')
+        # Try V3 first (has 'type' starting with 'composio.' and 'metadata')
         # Validate metadata is a dict with all required fields (matching TypeScript's zod schema)
         v3_metadata = data.get("metadata") if isinstance(data, dict) else None
         v3_metadata_valid = (
@@ -1086,9 +1086,11 @@ class Triggers(Resource):
             and "auth_config_id" in v3_metadata
             and "user_id" in v3_metadata
         )
+        v3_type = data.get("type", "") if isinstance(data, dict) else ""
         if (
             isinstance(data, dict)
-            and data.get("type") == "composio.trigger.message"
+            and isinstance(v3_type, str)
+            and v3_type.startswith("composio.")
             and v3_metadata_valid
             and "id" in data
             and "data" in data

--- a/python/tests/test_triggers.py
+++ b/python/tests/test_triggers.py
@@ -575,6 +575,46 @@ class TestVerifyWebhook:
             result["payload"]["metadata"]["connected_account"]["user_id"] == "user-456"
         )
 
+    def test_verify_webhook_v3_non_trigger_event_type(
+        self, triggers, test_secret, test_webhook_id, test_timestamp
+    ):
+        """Test V3 payload with non-trigger event type is detected as V3, not V2.
+
+        This is a regression test for PLEN-1397: V3 payloads with event types
+        other than 'composio.trigger.message' should still be detected as V3.
+        """
+        # V3 payload with a different event type
+        payload_dict = {
+            "id": "msg_abc123",
+            "timestamp": "2024-01-01T00:00:00Z",
+            "type": "composio.connected_account.expired",  # Not 'composio.trigger.message'
+            "metadata": {
+                "log_id": "log-123",
+                "trigger_slug": "",
+                "trigger_id": "",
+                "connected_account_id": "conn-123",
+                "auth_config_id": "auth-123",
+                "user_id": "user-456",
+            },
+            "data": {"reason": "token_expired"},
+        }
+        payload = json.dumps(payload_dict)
+        signature = self.create_signature(
+            test_webhook_id, test_timestamp, payload, test_secret
+        )
+
+        result = triggers.verify_webhook(
+            id=test_webhook_id,
+            payload=payload,
+            signature=signature,
+            timestamp=test_timestamp,
+            secret=test_secret,
+        )
+
+        # Should be detected as V3, not fall back to V2
+        assert result["version"] == WebhookVersion.V3
+        assert result["raw_payload"] == payload_dict
+
     # Successful verification with V2 payload
 
     def test_verify_webhook_v2_payload(

--- a/ts/packages/core/src/types/triggers.types.ts
+++ b/ts/packages/core/src/types/triggers.types.ts
@@ -231,15 +231,19 @@ export type WebhookPayloadV2 = z.infer<typeof WebhookPayloadV2Schema>;
 export const WebhookPayloadV3Schema = z.object({
   id: z.string(),
   timestamp: z.string(),
-  type: z.literal('composio.trigger.message'),
-  metadata: z.object({
-    log_id: z.string(),
-    trigger_slug: z.string(),
-    trigger_id: z.string(),
-    connected_account_id: z.string(),
-    auth_config_id: z.string(),
-    user_id: z.string(),
+  type: z.string().refine(val => val.startsWith('composio.'), {
+    message: "V3 event type must start with 'composio.'",
   }),
+  metadata: z
+    .object({
+      log_id: z.string(),
+      trigger_slug: z.string(),
+      trigger_id: z.string(),
+      connected_account_id: z.string(),
+      auth_config_id: z.string(),
+      user_id: z.string(),
+    })
+    .passthrough(),
   data: z.record(z.unknown()),
 });
 export type WebhookPayloadV3 = z.infer<typeof WebhookPayloadV3Schema>;

--- a/ts/packages/core/test/models/verifyWebhook.test.ts
+++ b/ts/packages/core/test/models/verifyWebhook.test.ts
@@ -160,6 +160,38 @@ describe('Triggers.verifyWebhook', () => {
         status: 'ACTIVE',
       });
     });
+
+    it('should detect V3 payload with non-trigger event type (e.g., connected_account.expired)', async () => {
+      // This test verifies the fix for PLEN-1397: V3 payloads with event types other than
+      // 'composio.trigger.message' should still be detected as V3, not fall back to V2
+      const payload = {
+        id: 'msg_abc123',
+        timestamp: new Date().toISOString(),
+        type: 'composio.connected_account.expired', // Not 'composio.trigger.message'
+        metadata: {
+          log_id: 'log-123',
+          trigger_slug: '',
+          trigger_id: '',
+          connected_account_id: 'conn-123',
+          auth_config_id: 'auth-123',
+          user_id: 'user-456',
+        },
+        data: { reason: 'token_expired' },
+      };
+      const payloadStr = JSON.stringify(payload);
+      const signature = createSignature(testWebhookId, testTimestamp, payloadStr, testSecret);
+
+      const result = await triggers.verifyWebhook({
+        payload: payloadStr,
+        signature,
+        secret: testSecret,
+        id: testWebhookId,
+        timestamp: testTimestamp,
+      });
+
+      expect(result.version).toBe(WebhookVersions.V3); // Should be V3, not V2
+      expect(result.rawPayload).toEqual(payload);
+    });
   });
 
   describe('successful verification with V2 payload', () => {


### PR DESCRIPTION
This PR:
- closes [PLEN-1397](https://linear.app/composio/issue/PLEN-1397/verified-webhook-rolled-back-to-v2-format)
- loosens up webhook v3 schema