### PR TITLE
docs: add AI-native documentation guideline

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -57,3 +57,7 @@ Detailed documentation for Claude is organized in `.claude/`:
 5. **Toolkits data** - `public/data/toolkits.json` must exist; errors are thrown, not ignored.
 
 6. **Test on mobile** - Fumadocs nav differs on mobile. Avoid assumptions about horizontal layout.
+
+## AI-Native Documentation
+
+**Prefer cURL over "click"** - Most docs traffic comes from AI crawlers. When documenting API interactions, prefer showing cURL commands over UI instructions like "click this button" or "navigate to settings". cURL is machine-readable and can be directly executed by AI agents.


### PR DESCRIPTION
## Summary
- Add "AI-Native Documentation" section to docs CLAUDE.md
- Guidance to prefer cURL commands over UI "click" instructions when documenting API interactions

This makes documentation more useful for AI agents that increasingly consume docs to help users. cURL is machine-readable and can be directly executed by AI agents, while "click this button" instructions are not actionable.

## Test plan
- [x] Verify CLAUDE.md renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)