### PR TITLE
fix(docs): Fix broken internal links across documentation

### DIFF
--- a/docs/content/changelog/11-05-25.mdx
+++ b/docs/content/changelog/11-05-25.mdx
@@ -54,7 +54,7 @@ If you're using an existing project and want to adopt this security enhancement:
 3. Update your application code to pass the appropriate identifier
 4. Test the updated URLs in your development environment
 
-For more details on choosing the right user identifiers for your application, see our [User Management documentation](https://docs.composio.dev/docs/user-management).
+For more details on choosing the right user identifiers for your application, see our [User Management documentation](/docs/users-and-sessions).
 
 ### Questions?
 

--- a/docs/content/changelog/11-10-25.mdx
+++ b/docs/content/changelog/11-10-25.mdx
@@ -129,4 +129,4 @@ const composio = new Composio({
 const trigger = await composio.triggers.create('user', 'GITHUB_COMMIT_EVENT', {...});
 ```
 
-For more details on toolkit versioning, see the [Toolkit Versioning documentation](/docs/toolkit-versioning).
+For more details on toolkit versioning, see the [Toolkit Versioning documentation](/docs/tools-direct/toolkit-versioning).

--- a/docs/content/changelog/12-03-25.mdx
+++ b/docs/content/changelog/12-03-25.mdx
@@ -23,4 +23,4 @@ This is a **non-breaking change**. Your existing integrations and completed conn
 
 ### Questions?
 
-If you have any questions about this change, please reach out to our support team or check our [Connected Accounts documentation](https://docs.composio.dev/docs/connected-accounts).
+If you have any questions about this change, please reach out to our support team or check our [Connected Accounts documentation](/docs/auth-configuration/connected-accounts).

--- a/docs/content/changelog/12-09-25.mdx
+++ b/docs/content/changelog/12-09-25.mdx
@@ -31,7 +31,7 @@ To continue using these applications with Composio:
 
 1. **Create Developer Accounts**: Register for developer accounts on the platforms you need
 2. **Generate API Credentials**: Create OAuth apps following each platform's documentation
-3. **Configure in Composio**: Add your credentials to Composio using [custom auth configs](https://docs.composio.dev/docs/custom-auth-configs)
+3. **Configure in Composio**: Add your credentials to Composio using [custom auth configs](/docs/auth-configuration/custom-auth-configs)
 4. **Test Your Integration**: Test your integration with the new credentials
 
 <Callout>

--- a/docs/content/changelog/12-10-25.mdx
+++ b/docs/content/changelog/12-10-25.mdx
@@ -4,7 +4,7 @@ description: "57 toolkits now return strongly typed objects instead of generic r
 date: "2025-12-10"
 ---
 
-We've updated many toolkits so their outputs are now strongly typed objects instead of a generic `response_data` blob, meaning tools like Outlook, HubSpot, Notion, etc. now return well-shaped, documented fields you can rely on directly in your code and agents. These improvements apply to the latest toolkit versions—see our [toolkit versioning docs](https://docs.composio.dev/docs/toolkit-versioning) for how versions are managed.
+We've updated many toolkits so their outputs are now strongly typed objects instead of a generic `response_data` blob, meaning tools like Outlook, HubSpot, Notion, etc. now return well-shaped, documented fields you can rely on directly in your code and agents. These improvements apply to the latest toolkit versions—see our [toolkit versioning docs](/docs/tools-direct/toolkit-versioning) for how versions are managed.
 
 <Callout type="warn">
 **Breaking Change for `latest` Version**

--- a/docs/content/docs/auth-configuration/connected-accounts.mdx
+++ b/docs/content/docs/auth-configuration/connected-accounts.mdx
@@ -4,7 +4,7 @@ description: Manage and monitor user connections to toolkits
 keywords: [list accounts, refresh token, disable, delete account]
 ---
 
-Connected accounts are authenticated connections between your users and toolkits. After users authenticate (see [Authenticating tools](/docs/authenticating-tools)), you can manage these accounts throughout their lifecycle.
+Connected accounts are authenticated connections between your users and toolkits. After users authenticate (see [Authenticating tools](/docs/tools-direct/authenticating-tools)), you can manage these accounts throughout their lifecycle.
 
 Composio automatically handles token refresh and credential management. This guide covers manual operations: listing, retrieving, refreshing, enabling, disabling, and deleting accounts.
 
@@ -225,7 +225,7 @@ Deletion is permanent. Users must re-authenticate to reconnect.
 Users can connect multiple accounts for the same toolkit (e.g., personal and work Gmail).
 
 <Callout type="info">
-Use `link()` for creating accounts, as it provides hosted authentication and allows multiple accounts by default. See [Connect Link authentication](/docs/authenticating-tools#hosted-authentication-connect-link).
+Use `link()` for creating accounts, as it provides hosted authentication and allows multiple accounts by default. See [Connect Link authentication](/docs/tools-direct/authenticating-tools#hosted-authentication-connect-link).
 </Callout>
 
 <Tabs groupId="language" items={['Python', 'TypeScript']} persist>

--- a/docs/content/docs/auth-configuration/custom-auth-params.mdx
+++ b/docs/content/docs/auth-configuration/custom-auth-params.mdx
@@ -98,7 +98,7 @@ Execute the tool using the custom authentication modifier. The `beforeExecute` h
 
 Following is an example of how to execute a tool with a custom authentication modifier for Completion Providers.
 
-For Agentic Providers, read about [Modifying tool inputs](/docs/modify-tool-behavior/before-execution-modifiers).
+For Agentic Providers, read about [Modifying tool inputs](/docs/tools-direct/modify-tool-behavior/before-execution-modifiers).
 
 <Tabs groupId="language" items={['Python', 'TypeScript']} persist>
   <Tab value="Python">

--- a/docs/content/docs/auth-configuration/custom-auth-params.mdx
+++ b/docs/content/docs/auth-configuration/custom-auth-params.mdx
@@ -33,7 +33,7 @@ const composio = new Composio({
 
 Define a function that modifies authentication parameters for specific toolkits. This function checks the toolkit name and adds custom authentication headers when needed.
 
-<Card title="This is a Before Execute Modifier!" href="/docs/modify-tool-behavior/before-execution-modifiers">
+<Card title="This is a Before Execute Modifier!" href="/docs/tools-direct/modify-tool-behavior/before-execution-modifiers">
 Before Execute Modifiers are a way to modify the parameters of a tool before it is executed. In this case, they are useful for adding custom authentication headers or parameters to a tool.
 </Card>
 

--- a/docs/content/docs/authenticating-users/manually-authenticating.mdx
+++ b/docs/content/docs/authenticating-users/manually-authenticating.mdx
@@ -10,7 +10,7 @@ Manual authentication lets you connect users to toolkits outside of the chat flo
 
 ## Authorize a toolkit
 
-Use `session.authorize()` to generate a [Connect Link](/docs/authenticating-tools#hosted-authentication-connect-link) URL, redirect the user, and wait for them to complete:
+Use `session.authorize()` to generate a [Connect Link](/docs/tools-direct/authenticating-tools#hosted-authentication-connect-link) URL, redirect the user, and wait for them to complete:
 
 <Tabs groupId="language" items={['Python', 'TypeScript']} persist>
 <Tab value="Python">

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -87,7 +87,7 @@ Composio works with any AI framework. Pick your preferred SDK:
   <Card
     icon={<Palette />}
     title="White Labeling"
-    href="/docs/guides/white-labeling-authentication"
+    href="/docs/white-labeling-authentication"
     description="Customize auth screens with your branding"
   />
 </Cards>

--- a/docs/content/docs/managing-multiple-connected-accounts.mdx
+++ b/docs/content/docs/managing-multiple-connected-accounts.mdx
@@ -110,7 +110,7 @@ const session2 = await composio.create("user_123", {
 
 ## Listing all user accounts
 
-To list all accounts a user has connected (not just the active one), see [List accounts](/docs/connected-accounts#list-accounts).
+To list all accounts a user has connected (not just the active one), see [List accounts](/docs/auth-configuration/connected-accounts#list-accounts).
 
 ## Viewing session's active account
 

--- a/docs/content/docs/migration-guide/new-sdk.mdx
+++ b/docs/content/docs/migration-guide/new-sdk.mdx
@@ -463,7 +463,7 @@ console.log(JSON.stringify(tools, null, 2));
 
 #### Before Modifiers
 
-The following example shows creating and using a before modifier for a Chat Completion provider. For agentic frameworks, view the [complete before modifier documentation](/docs/modify-tool-behavior/before-execution-modifiers):
+The following example shows creating and using a before modifier for a Chat Completion provider. For agentic frameworks, view the [complete before modifier documentation](/docs/tools-direct/modify-tool-behavior/before-execution-modifiers):
 
 <Tabs groupId="language" items={['Python (current)', 'TypeScript (current)']} persist>
   <Tab value="Python (current)">
@@ -507,7 +507,7 @@ const result_1 = await composio.tools.execute(
 
 #### After Modifiers
 
-The following example shows creating and using an after modifier for a Chat Completion provider. For agentic frameworks, view the [complete after modifier documentation](/docs/modify-tool-behavior/after-execution-modifiers):
+The following example shows creating and using an after modifier for a Chat Completion provider. For agentic frameworks, view the [complete after modifier documentation](/docs/tools-direct/modify-tool-behavior/after-execution-modifiers):
 
 <Tabs groupId="language" items={['Python (current)', 'TypeScript (current)']} persist>
   <Tab value="Python (current)">
@@ -557,7 +557,7 @@ const result_2 = await composio.tools.execute(
 
 ### Custom Tools
 
-The SDK continues to support custom tools. [Creating tools from your methods](/docs/custom-tools#creating-a-custom-tool) remains possible. We recommend reviewing the [detailed custom tools documentation](/docs/custom-tools#creating-a-custom-tool) for more information.
+The SDK continues to support custom tools. [Creating tools from your methods](/docs/tools-direct/custom-tools#creating-a-custom-tool) remains possible. We recommend reviewing the [detailed custom tools documentation](/docs/tools-direct/custom-tools#creating-a-custom-tool) for more information.
 
 Due to changes in the SDK architecture, creating custom tools that use Composio's managed authentication has been modified. In the previous SDK, you could create a custom tool as follows:
 
@@ -705,7 +705,7 @@ const tool = await composio.tools.createCustomTool({
   </Tab>
 </Tabs>
 
-For more information, including executing custom tools and defining custom headers and query parameters, refer to the [Custom Tools](/docs/custom-tools) documentation.
+For more information, including executing custom tools and defining custom headers and query parameters, refer to the [Custom Tools](/docs/tools-direct/custom-tools) documentation.
 
 ### Auth configs (formerly integrations)
 
@@ -721,7 +721,7 @@ Auth configs now use nano IDs instead of UUIDs:
 
 We recommend storing auth config nano IDs in your database for connecting users to the appropriate auth configuration.
 
-For most use cases, you will create auth configs through the dashboard, and this process remains unchanged. Read more about [creating auth configs](/docs/authenticating-tools#creating-an-auth-config) and [customizing auth configs](/docs/custom-auth-configs).
+For most use cases, you will create auth configs through the dashboard, and this process remains unchanged. Read more about [creating auth configs](/docs/tools-direct/authenticating-tools#creating-an-auth-config) and [customizing auth configs](/docs/auth-configuration/custom-auth-configs).
 
 Creating auth configs programmatically in the previous SDK:
 
@@ -820,7 +820,7 @@ console.log(authConfig);
   </Tab>
 </Tabs>
 
-For using custom authentication credentials, refer to the [Programmatic Auth Configs](/docs/programmatic-auth-configs) documentation.
+For using custom authentication credentials, refer to the [Programmatic Auth Configs](/docs/auth-configuration/programmatic-auth-configs) documentation.
 
 <Callout type="info">
 The callback URL for creating custom OAuth configs is now `https://backend.composio.dev/api/v3/toolkits/auth/callback`. The previous URL was `https://backend.composio.dev/api/v1/auth-apps/add`.

--- a/docs/content/docs/migration-guide/tool-router-beta.mdx
+++ b/docs/content/docs/migration-guide/tool-router-beta.mdx
@@ -64,7 +64,7 @@ const session = await composio.create('user_123');
 If you have existing users on tool router and you don't want them to authenticate again:
 - Tool Router will auto-detect auth configs and connected accounts it created (from the beta version).
 - If you have custom auth configs (not created by Tool Router):
-    - Search for the Auth config for that connected account. See [Connected Accounts](/docs/connected-accounts) to fetch existing accounts programmatically.
+    - Search for the Auth config for that connected account. See [Connected Accounts](/docs/auth-configuration/connected-accounts) to fetch existing accounts programmatically.
     - While creating a session configure to use this Auth config.
     - You need to repeat this for each toolkit you want to enable for that session.
 
@@ -105,9 +105,9 @@ Check out these new features available in the stable version:
 
 - **[Native tools](/docs/providers/openai-agents)**: Use Tool Router with any AI framework
 - **Better [session](/docs/users-and-sessions) and [auth](/docs/authentication) config**
-- **[Multi-account support](/docs/guides/managing-multiple-connected-accounts)**: Manage multiple accounts per user seamlessly
+- **[Multi-account support](/docs/managing-multiple-connected-accounts)**: Manage multiple accounts per user seamlessly
 - **[Manual authentication](/docs/authenticating-users/manually-authenticating)**: Control when and how users authenticate
-- **[Custom auth](/docs/guides/using-custom-auth-configuration)**: Support for toolkits that don't have composio managed auth
-- **[White labeling](/docs/guides/white-labeling-authentication)**: Customize authentication screens with your branding
+- **[Custom auth](/docs/using-custom-auth-configuration)**: Support for toolkits that don't have composio managed auth
+- **[White labeling](/docs/white-labeling-authentication)**: Customize authentication screens with your branding
 </Step>
 </Steps>

--- a/docs/content/docs/migration-guide/toolkit-versioning.mdx
+++ b/docs/content/docs/migration-guide/toolkit-versioning.mdx
@@ -158,4 +158,4 @@ The `dangerouslySkipVersionCheck` flag is only for migration or debugging. Never
 
 ## Next steps
 
-For complete documentation on toolkit versioning, including best practices and advanced configuration, see [Toolkit versioning](/docs/toolkit-versioning).
+For complete documentation on toolkit versioning, including best practices and advanced configuration, see [Toolkit versioning](/docs/tools-direct/toolkit-versioning).

--- a/docs/content/docs/providers/openai.mdx
+++ b/docs/content/docs/providers/openai.mdx
@@ -30,8 +30,8 @@ Read more about it in the [OpenAI documentation](https://platform.openai.com/doc
 
 <Callout>
 Before executing any tools that require authentication (like Gmail), you'll need to:
-1. [Create an Auth Configuration](/docs/authenticating-tools#creating-an-auth-config) for your app
-2. [Set up a Connected Account](/docs/authenticating-tools#connecting-an-account) for the user.
+1. [Create an Auth Configuration](/docs/tools-direct/authenticating-tools#creating-an-auth-config) for your app
+2. [Set up a Connected Account](/docs/tools-direct/authenticating-tools#connecting-an-account) for the user.
 </Callout>
 
 <Tabs items={["Python", "TypeScript"]}>
@@ -118,8 +118,8 @@ The OpenAI Chat Provider is the default provider used by Composio SDK, but you c
 
 <Callout>
 Before executing any tools that require authentication (like Gmail), you'll need to:
-1. [Create an Auth Configuration](/docs/authenticating-tools#creating-an-auth-config) for your app
-2. [Set up a Connected Account](/docs/authenticating-tools#connecting-an-account) for the user.
+1. [Create an Auth Configuration](/docs/tools-direct/authenticating-tools#creating-an-auth-config) for your app
+2. [Set up a Connected Account](/docs/tools-direct/authenticating-tools#connecting-an-account) for the user.
 </Callout>
 
 <Tabs items={["Python", "TypeScript"]}>

--- a/docs/content/docs/tools-direct/authenticating-tools.mdx
+++ b/docs/content/docs/tools-direct/authenticating-tools.mdx
@@ -49,7 +49,7 @@ Depending on your authentication method, you may need to configure scopes:
 You must provide your own credentials regardless of environment.
 
 <Callout type="info">
-Want to remove Composio branding from OAuth screens? See [Custom Auth Configs](/docs/custom-auth-configs#white-labeling-the-oauth-consent-screen) for white-labeling options.
+Want to remove Composio branding from OAuth screens? See [Custom Auth Configs](/docs/auth-configuration/custom-auth-configs#white-labeling-the-oauth-consent-screen) for white-labeling options.
 </Callout>
 </Step>
 
@@ -77,7 +77,7 @@ You should create multiple auth configs for the same toolkit when you need:
   <Card title="Programmatic creation" href="/docs/programmatic-auth-configs">
     For managing auth configs across multiple projects, you can create them programmatically via the API
   </Card>
-  <Card title="Production white-labeling" href="/docs/custom-auth-configs#white-labeling-the-oauth-consent-screen">
+  <Card title="Production white-labeling" href="/docs/auth-configuration/custom-auth-configs#white-labeling-the-oauth-consent-screen">
     Remove Composio branding from OAuth screens for a fully white-labeled authentication experience
   </Card>
 </Cards>
@@ -89,7 +89,7 @@ With an auth config created, you're ready to authenticate your users!
 You can either use [**Connect Link**](#hosted-authentication-connect-link) for a hosted authentication flow, or use [**Direct SDK Setup**](#direct-sdk-setup).
 
 <Callout>
-User authentication requires a User ID - a unique identifier that groups connected accounts together. Learn more about [User Management](/docs/user-management) to understand how to structure User IDs for your application.
+User authentication requires a User ID - a unique identifier that groups connected accounts together. Learn more about [User Management](/docs/users-and-sessions) to understand how to structure User IDs for your application.
 </Callout>
 
 **Choose the section below that matches your toolkit's authentication method:**
@@ -159,7 +159,7 @@ By default, users will see a Composio-branded authentication experience when con
 These settings will apply to all authentication flows using Connect Link, providing a white-labeled experience that maintains your brand identity throughout the authentication process.
 
 <Callout>
-For complete white-labeling including OAuth consent screens (removing Composio's domain), see [Custom Auth Configs - White-labeling](/docs/custom-auth-configs#white-labeling-the-oauth-consent-screen).
+For complete white-labeling including OAuth consent screens (removing Composio's domain), see [Custom Auth Configs - White-labeling](/docs/auth-configuration/custom-auth-configs#white-labeling-the-oauth-consent-screen).
 </Callout>
 
 ### Direct SDK Setup
@@ -381,7 +381,7 @@ Composio also supports a wide range of other auth schemas:
 For any of these methods, [fetch the config parameter](#fetching-the-required-config-parameters-for-an-auth-config) to determine the exact fields required. Every toolkit has its own requirements, and understanding these is essential for successfully creating connections.
 </Callout>
 
-Learn how to [Manage connected accounts](/docs/connected-accounts) after users authenticate.
+Learn how to [Manage connected accounts](/docs/auth-configuration/connected-accounts) after users authenticate.
 
 ## Connection Statuses
 
@@ -493,4 +493,4 @@ Only connections with **ACTIVE** status can be used to execute tools. If a conne
 
 ## Next Step
 
-With authentication set up, you can now fetch and execute tools. See [Executing Tools](/docs/executing-tools) to get started.
+With authentication set up, you can now fetch and execute tools. See [Executing Tools](/docs/tools-direct/executing-tools) to get started.

--- a/docs/content/docs/tools-direct/authenticating-tools.mdx
+++ b/docs/content/docs/tools-direct/authenticating-tools.mdx
@@ -74,7 +74,7 @@ You should create multiple auth configs for the same toolkit when you need:
 - **Different permission levels** - Limiting actions for specific use cases
 
 <Cards>
-  <Card title="Programmatic creation" href="/docs/programmatic-auth-configs">
+  <Card title="Programmatic creation" href="/docs/auth-configuration/programmatic-auth-configs">
     For managing auth configs across multiple projects, you can create them programmatically via the API
   </Card>
   <Card title="Production white-labeling" href="/docs/auth-configuration/custom-auth-configs#white-labeling-the-oauth-consent-screen">

--- a/docs/content/docs/tools-direct/executing-tools.mdx
+++ b/docs/content/docs/tools-direct/executing-tools.mdx
@@ -9,7 +9,7 @@ LLMs on their own can only do generation. Tool calling changes that by letting t
 In Composio, every **tool** is a single API action—fully described with schema, parameters, and return type. Tools live inside **toolkits** like Gmail, Slack, or GitHub, and Composio handles authentication and user scoping.
 
 <Callout type="info">
-**User Scoping**: All tools are scoped to a specific user - that's why every example includes a `user_id`. Learn how to structure User IDs in [User Management](/docs/user-management). Each user must authenticate with their respective services (Gmail, Calendar, etc.) - see [Authentication](/docs/authenticating-tools).
+**User Scoping**: All tools are scoped to a specific user - that's why every example includes a `user_id`. Learn how to structure User IDs in [User Management](/docs/users-and-sessions). Each user must authenticate with their respective services (Gmail, Calendar, etc.) - see [Authentication](/docs/tools-direct/authenticating-tools).
 </Callout>
 
 ## Using Chat Completions
@@ -238,7 +238,7 @@ console.log('GitHub stargazers:', JSON.stringify(result, null, 2));
 </Tabs>
 
 <Callout>
-The examples above configure toolkit versions at SDK initialization. You can also pass versions per-execution or use environment variables. See [toolkit versioning](/docs/toolkit-versioning) for all configuration options.
+The examples above configure toolkit versions at SDK initialization. You can also pass versions per-execution or use environment variables. See [toolkit versioning](/docs/tools-direct/toolkit-versioning) for all configuration options.
 </Callout>
 
 ### Proxy Execute
@@ -292,7 +292,7 @@ console.log(data);
 </Tabs>
 
 <Callout type="info">
-Need an API that isn't supported by any Composio toolkit, or want to extend an existing one? Learn how to [create custom tools](/docs/custom-tools).
+Need an API that isn't supported by any Composio toolkit, or want to extend an existing one? Learn how to [create custom tools](/docs/tools-direct/custom-tools).
 </Callout>
 
 ## Automatic File Handling

--- a/docs/content/docs/tools-direct/fetching-tools.mdx
+++ b/docs/content/docs/tools-direct/fetching-tools.mdx
@@ -30,7 +30,7 @@ const tools = await composio.tools.get(userId, {
   </Tab>
 </Tabs>
 
-Returns top 20 tools by default. Tools require a `user_id` because they're scoped to authenticated accounts. See [User management](/docs/user-management) and [Authentication](/docs/authenticating-tools).
+Returns top 20 tools by default. Tools require a `user_id` because they're scoped to authenticated accounts. See [User management](/docs/users-and-sessions) and [Authentication](/docs/tools-direct/authenticating-tools).
 
 ## Tool schemas
 
@@ -234,5 +234,5 @@ const toolkitSearchRaw = await composio.tools.getRawComposioTools({
 </Tabs>
 
 <Callout type="info">
-Use specific toolkit versions in production to prevent breaking changes. See [toolkit versioning](/docs/toolkit-versioning).
+Use specific toolkit versions in production to prevent breaking changes. See [toolkit versioning](/docs/tools-direct/toolkit-versioning).
 </Callout>

--- a/docs/content/docs/triggers.mdx
+++ b/docs/content/docs/triggers.mdx
@@ -11,7 +11,7 @@ Each event is delivered as a structured payload to your webhook endpoint (via we
 <Figure src="/images/triggers.png" alt="Triggers Overview" caption="Triggers through Composio" />
 
 <Callout type="info" title="Prerequisites">
-Before proceeding, ensure you've created an [auth config](/docs/authenticating-tools#creating-an-auth-config) and [established a connection](/docs/authenticating-tools#hosted-authentication-connect-link) to an app (e.g., Slack, GitHub). Triggers are scoped to specific users - learn about [User Management](/docs/user-management) for guidance on structuring User IDs.
+Before proceeding, ensure you've created an [auth config](/docs/tools-direct/authenticating-tools#creating-an-auth-config) and [established a connection](/docs/tools-direct/authenticating-tools#hosted-authentication-connect-link) to an app (e.g., Slack, GitHub). Triggers are scoped to specific users - learn about [User Management](/docs/users-and-sessions) for guidance on structuring User IDs.
 </Callout>
 
 ## Creating a trigger
@@ -92,7 +92,7 @@ console.log(`Trigger created: ${trigger.triggerId}`);
 </Tabs>
 
 <Callout>
-To use a specific toolkit version when creating triggers, configure `toolkitVersions` during initialization. See [Toolkit Versioning](/docs/toolkit-versioning) for more details.
+To use a specific toolkit version when creating triggers, configure `toolkitVersions` during initialization. See [Toolkit Versioning](/docs/tools-direct/toolkit-versioning) for more details.
 </Callout>
 
 ## Subscribing to triggers

--- a/docs/content/docs/using-custom-auth-configuration.mdx
+++ b/docs/content/docs/using-custom-auth-configuration.mdx
@@ -26,7 +26,7 @@ In the [Composio platform](https://platform.composio.dev), go to "All Toolkits" 
 Copy the auth config ID (e.g., `ac_1234abcd`).
 
 <Callout type="info">
-For detailed instructions on getting credentials for specific toolkits, see [Custom auth configs](/docs/custom-auth-configs).
+For detailed instructions on getting credentials for specific toolkits, see [Custom auth configs](/docs/auth-configuration/custom-auth-configs).
 </Callout>
 </Step>
 

--- a/docs/content/docs/white-labeling-authentication.mdx
+++ b/docs/content/docs/white-labeling-authentication.mdx
@@ -38,7 +38,7 @@ Create an auth config in the [Composio dashboard](https://app.composio.dev):
 Copy the auth config ID (e.g., `ac_1234abcd`).
 
 <Callout type="info">
-For detailed instructions with screenshots, see [Custom auth configs](/docs/custom-auth-configs).
+For detailed instructions with screenshots, see [Custom auth configs](/docs/auth-configuration/custom-auth-configs).
 </Callout>
 </Step>
 

--- a/docs/content/examples/vercel-chat.mdx
+++ b/docs/content/examples/vercel-chat.mdx
@@ -20,7 +20,7 @@ repository to set up the project locally.
 ## Creating auth configs
 
 For all the apps you want to connect to the chatbot, you need to create their
-respective auth configs. Learn how to create auth configs [here](/docs/authenticating-tools#creating-an-auth-config).
+respective auth configs. Learn how to create auth configs [here](/docs/tools-direct/authenticating-tools#creating-an-auth-config).
 Once done, your auth configs will be available in the [Composio dashboard](https://app.composio.dev/integrations).
 
 


### PR DESCRIPTION
## Summary

Fixes broken internal links that were pointing to non-existent paths across the documentation.

## Link Mappings

| Broken Link | Fixed To |
|-------------|----------|
| `/docs/authenticating-tools` | `/docs/tools-direct/authenticating-tools` |
| `/docs/user-management` | `/docs/users-and-sessions` |
| `/docs/toolkit-versioning` | `/docs/tools-direct/toolkit-versioning` |
| `/docs/custom-auth-configs` | `/docs/auth-configuration/custom-auth-configs` |
| `/docs/connected-accounts` | `/docs/auth-configuration/connected-accounts` |
| `/docs/custom-tools` | `/docs/tools-direct/custom-tools` |
| `/docs/executing-tools` | `/docs/tools-direct/executing-tools` |
| `/docs/programmatic-auth-configs` | `/docs/auth-configuration/programmatic-auth-configs` |
| `/docs/modify-tool-behavior/*` | `/docs/tools-direct/modify-tool-behavior/*` |
| `/docs/guides/*` | `/docs/*` (removed guides/ prefix) |

## Files Updated (18)

**Docs:**
- `content/docs/triggers.mdx`
- `content/docs/auth-configuration/connected-accounts.mdx`
- `content/docs/auth-configuration/custom-auth-params.mdx`
- `content/docs/tools-direct/fetching-tools.mdx`
- `content/docs/tools-direct/executing-tools.mdx`
- `content/docs/tools-direct/authenticating-tools.mdx`
- `content/docs/providers/openai.mdx`
- `content/docs/migration-guide/new-sdk.mdx`
- `content/docs/migration-guide/toolkit-versioning.mdx`
- `content/docs/migration-guide/tool-router-beta.mdx`
- `content/docs/authenticating-users/manually-authenticating.mdx`
- `content/docs/managing-multiple-connected-accounts.mdx`
- `content/docs/using-custom-auth-configuration.mdx`
- `content/docs/white-labeling-authentication.mdx`

**Examples:**
- `content/examples/vercel-chat.mdx`

**Changelog:**
- `content/changelog/11-10-25.mdx`
- `content/changelog/12-03-25.mdx`
- `content/changelog/12-09-25.mdx`

Fixes PLEN-995

## Test plan

- [ ] Verify links work in deployed preview

🤖 Generated with [Claude Code](https://claude.ai/code)