### PR TITLE
docs: update premium tools page to match pricing

### DIFF
--- a/docs/content/docs/troubleshooting/index.mdx
+++ b/docs/content/docs/troubleshooting/index.mdx
@@ -13,9 +13,6 @@ Some quick links:
   <Card title="Errors Reference" href="/reference/errors" icon={<AlertCircle />}>
     HTTP status codes and how to resolve common errors.
   </Card>
-</Cards>
-
-<Cards>
   <Card title="Report issues" href="https://github.com/ComposioHQ/composio/issues/new?labels=bug" icon={<Bug />}>
     Found a bug? Please create a Github issue!
   </Card>

--- a/docs/content/toolkits/premium-tools.mdx
+++ b/docs/content/toolkits/premium-tools.mdx
@@ -13,18 +13,24 @@ This is a quick overview of premium tools, what they are, how they are priced, w
 
 Premium tools are essential tool calls that cost us more to run, normally paying for more premium services or longer running tasks.
 
-Think something like `E2B` or `Firecrawl`, these are not really comparable to a `GMAIL_SEND_EMAIL` call.
+Think something like `E2B` or `Perplexity`, these are not really comparable to a `GMAIL_SEND_EMAIL` call.
 
 These types of tools are separated out so we can price both of them competitively.
 
-This is the current list of premium tools, more will be added over time and this list might change in the future.
+Premium tools include:
 
-- [Composio Search](/toolkits/composio_search)
-- [Code Interpreter (E2B)](/toolkits/codeinterpreter)
-- [Firecrawl](/toolkits/firecrawl)
-- [Perplexity](/toolkits/perplexityai)
-- [Exa](/toolkits/exa)
-- [SerpAPI](/toolkits/serpapi)
+- Search APIs (Google, Bing, Perplexity, etc.)
+  - [Composio Search](/toolkits/composio_search)
+  - [Perplexity](/toolkits/perplexityai)
+  - [Exa](/toolkits/exa)
+  - [SerpAPI](/toolkits/serpapi)
+- Code execution environments (E2B)
+  - [Code Interpreter (E2B)](/toolkits/codeinterpreter)
+- Web scraping & data extraction
+- AI/ML model inference
+- Document processing & OCR
+- Advanced data transformations
+- Compute-intensive operations
 
 ## How are premium tools priced?
 
@@ -33,7 +39,7 @@ As a rough guide, they are priced at 3x the cost of a standard tool call — the
 | Plan | Included Standard Tool Calls | Included Premium Tool Calls | Usage Based Standard Tool Calls | Usage Based Premium Tool Calls |
 |------|------------------------------|-----------------------------|---------------------------------|--------------------------------|
 | Totally Free | 20k | 1k | – | – |
-| Ridiculously Cheap | 250k | 5k | $0.299/1k | $0.897/1k |
+| Ridiculously Cheap | 200k | 5k | $0.299/1k | $0.897/1k |
 | Serious Business | 2M | 50k | $0.249/1k | $0.747/1k |
 | Enterprise | Flexible | Flexible | Flexible | Flexible |
 
@@ -47,10 +53,9 @@ If you need more than the default limits, please [contact us](mailto:billing@com
 
 | Spending Tier | Standard Tool Calls Rate Limit | Premium Tool Calls Rate Limit |
 |---------------|--------------------------------|-------------------------------|
-| Free | 1,000/hour | 100/hour |
-| Ridiculously Cheap | 100,000/hour | 10,000/hour |
-| Serious Business | 100,000/hour | 10,000/hour |
-| Enterprise | Flexible | Flexible |
+| Free | 100/min | 1,000/hour |
+| Paid | 5,000/min | 10,000/hour |
+| Enterprise | Custom | Custom |
 
 ## Feedback on premium tools
 


### PR DESCRIPTION
## Summary
- Remove Firecrawl from premium tools list (no longer a premium tool)
- Update standard tool call count for Ridiculously Cheap plan (250k → 200k)
- Update rate limits table to match pricing page values
- Reorganize premium tools into categories with specific toolkit examples
- Simplify rate limit tiers to Free/Paid/Enterprise

## Context
Addresses SUP-250 - Premium tools docs were out of sync with the pricing page.

## Test plan
- [ ] Verify premium tools page renders correctly
- [ ] Check that pricing/rate limit values match https://composio.dev/pricing

🤖 Generated with [Claude Code](https://claude.com/claude-code)