### PR TITLE
docs: update dashboard links to platform.composio.dev

### DIFF
--- a/docs/content/docs/using-custom-auth-configuration.mdx
+++ b/docs/content/docs/using-custom-auth-configuration.mdx
@@ -16,7 +16,7 @@ In the [Composio platform](https://platform.composio.dev), go to "All Toolkits" 
 <Step>
 ### Create an auth config
 
-1. Go to **Authentication management** in the [dashboard](https://app.composio.dev)
+1. Go to **Authentication management** in the [dashboard](https://platform.composio.dev)
 2. Click **Create Auth Config**
 3. Select the toolkit
 4. Choose the auth scheme (OAuth2, API Key, etc.)

--- a/docs/content/docs/white-labeling-authentication.mdx
+++ b/docs/content/docs/white-labeling-authentication.mdx
@@ -26,7 +26,7 @@ For step-by-step guides on creating OAuth apps for some toolkits, see [composio.
 <Step>
 ### Create auth config
 
-Create an auth config in the [Composio dashboard](https://app.composio.dev):
+Create an auth config in the [Composio dashboard](https://platform.composio.dev):
 
 1. Go to **Authentication management** → **Create Auth Config**
 2. Select the toolkit (e.g., GitHub)

--- a/docs/content/examples/vercel-chat.mdx
+++ b/docs/content/examples/vercel-chat.mdx
@@ -21,7 +21,7 @@ repository to set up the project locally.
 
 For all the apps you want to connect to the chatbot, you need to create their
 respective auth configs. Learn how to create auth configs [here](/docs/tools-direct/authenticating-tools#creating-an-auth-config).
-Once done, your auth configs will be available in the [Composio dashboard](https://app.composio.dev/integrations).
+Once done, your auth configs will be available in the [Composio dashboard](https://platform.composio.dev/integrations).
 
 
   <img src="/assets/images/examples/auth-configs.png" alt="Auth configs" />

--- a/docs/content/reference/errors.mdx
+++ b/docs/content/reference/errors.mdx
@@ -52,7 +52,7 @@ Composio uses two types of API keys:
 
 | Error | Cause |
 |-------|-------|
-| Invalid API key | The API key is incorrect or revoked. Verify in [Settings](https://app.composio.dev/settings). |
+| Invalid API key | The API key is incorrect or revoked. Verify in [Settings](https://platform.composio.dev/settings). |
 | No authentication provided | The request is missing the `x-api-key` or `x-org-api-key` header. |
 | Invalid organization key | The organization API key is incorrect or revoked. Verify in Organization Settings. |
 | Insufficient permissions | The API key doesn't have access to this resource. |

--- a/docs/lib/layout.shared.tsx
+++ b/docs/lib/layout.shared.tsx
@@ -75,7 +75,7 @@ export function baseOptions(): BaseLayoutProps {
       {
         type: 'button',
         text: 'Dashboard',
-        url: 'https://app.composio.dev',
+        url: 'https://platform.composio.dev',
         external: true,
         secondary: true,
       },


### PR DESCRIPTION
## Summary
- Updates all dashboard links from `app.composio.dev` to `platform.composio.dev`
- Affects navbar Dashboard button and documentation links

## Test plan
- [ ] Verify links redirect correctly to the new platform URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)