### PR TITLE
Add Valyu Search Toolkit Integration

### DIFF
--- a/docs/content/changelog/02-03-26.mdx
+++ b/docs/content/changelog/02-03-26.mdx
@@ -49,7 +49,7 @@ clickup, linear
 canva, figma
 
 ##### Data & Analytics
-ahrefs, airtable, apify, exa, pplx, serpapi, tavily
+ahrefs, airtable, apify, exa, pplx, serpapi, tavily, valyu
 
 ##### Email & Calendar
 calendly, outlook

--- a/docs/content/changelog/12-10-25.mdx
+++ b/docs/content/changelog/12-10-25.mdx
@@ -42,7 +42,7 @@ clickup, linear
 canva, figma
 
 #### Data & Analytics
-ahrefs, airtable, apify, exa, pplx, serpapi, tavily
+ahrefs, airtable, apify, exa, pplx, serpapi, tavily, valyu
 
 #### Email & Calendar
 calendly, outlook

--- a/docs/public/data/toolkits-list.json
+++ b/docs/public/data/toolkits-list.json
@@ -1390,6 +1390,44 @@
     ]
   },
   {
+    "slug": "valyu",
+    "name": "Valyu",
+    "logo": "https://logos.composio.dev/api/valyu",
+    "description": "Valyu provides AI-powered search and research APIs, offering real-time search across web, academic, medical, and financial sources, content extraction, AI-generated answers with citations, and comprehensive deep research reports",
+    "category": "analytics & data",
+    "authSchemes": [
+      "API_KEY"
+    ],
+    "toolCount": 4,
+    "triggerCount": 0,
+    "version": "20260127_00",
+    "authConfigDetails": [
+      {
+        "mode": "API_KEY",
+        "name": "valyu_scheme",
+        "fields": {
+          "auth_config_creation": {
+            "required": [],
+            "optional": []
+          },
+          "connected_account_initiation": {
+            "required": [
+              {
+                "name": "generic_api_key",
+                "displayName": "API Key",
+                "type": "string",
+                "description": "API key for accessing Valyu's services",
+                "required": true,
+                "default": null
+              }
+            ],
+            "optional": []
+          }
+        }
+      }
+    ]
+  },
+  {
     "slug": "youtube",
     "name": "YouTube",
     "logo": "https://logos.composio.dev/api/youtube",

--- a/docs/public/data/toolkits.json
+++ b/docs/public/data/toolkits.json
@@ -10755,6 +10755,67 @@
     ]
   },
   {
+    "slug": "valyu",
+    "name": "Valyu",
+    "logo": "https://logos.composio.dev/api/valyu",
+    "description": "Valyu provides AI-powered search and research APIs, offering real-time search across web, academic, medical, and financial sources, content extraction, AI-generated answers with citations, and comprehensive deep research reports",
+    "category": "analytics & data",
+    "authSchemes": [
+      "API_KEY"
+    ],
+    "toolCount": 4,
+    "triggerCount": 0,
+    "version": "20260127_00",
+    "tools": [
+      {
+        "slug": "VALYU_SEARCH",
+        "name": "Valyu Search",
+        "description": "Perform real-time search across web, academic, medical, transportation, and financial sources using the Valyu API."
+      },
+      {
+        "slug": "VALYU_ANSWER",
+        "name": "Valyu Answer",
+        "description": "Get AI-powered answers with citations from Valyu's knowledge base and search results."
+      },
+      {
+        "slug": "VALYU_CONTENTS",
+        "name": "Valyu Contents",
+        "description": "Extract and retrieve content from URLs using Valyu's content extraction API."
+      },
+      {
+        "slug": "VALYU_DEEP_RESEARCH",
+        "name": "Valyu Deep Research",
+        "description": "Generate comprehensive deep research reports on any topic using Valyu's async research API."
+      }
+    ],
+    "triggers": [],
+    "authConfigDetails": [
+      {
+        "mode": "API_KEY",
+        "name": "valyu_scheme",
+        "fields": {
+          "auth_config_creation": {
+            "required": [],
+            "optional": []
+          },
+          "connected_account_initiation": {
+            "required": [
+              {
+                "name": "generic_api_key",
+                "displayName": "API Key",
+                "type": "string",
+                "description": "API key for accessing Valyu's services",
+                "required": true,
+                "default": null
+              }
+            ],
+            "optional": []
+          }
+        }
+      }
+    ]
+  },
+  {
     "slug": "youtube",
     "name": "YouTube",
     "logo": "https://logos.composio.dev/api/youtube",

--- a/fern/pages/src/changelog/01-07-26.md
+++ b/fern/pages/src/changelog/01-07-26.md
@@ -69,7 +69,7 @@ chmeetings, discord, helpdesk, helpwise, missive, slack, textit
 basecamp, clicksend, clientary, dart, fibery, monday, notion, onedesk, productboard, rocketlane, todoist
 
 ### Developer Tools & APIs
-algolia, anonyflow, api_ninjas, api_sports, apify, appdrag, backendless, browserless, bubble, cloudconvert, cloudinary, cloudlayer, convertapi, databricks, datadog, datarobot, deepseek, deployhq, digital_ocean, docmosis, docugenerate, encodian, gitea, gitlab, globalping, groqcloud, hookdeck, hyperbrowser, imgbb, imgix, kibana, neutrino, npm, openai, openrouter, parsera, parseur, phantombuster, pinecone, prismic, procfu, replicate, scrape_do, serpapi, shotstack, snowflake, supabase, tavily, v0, vercel, writer, zenrows
+algolia, anonyflow, api_ninjas, api_sports, apify, appdrag, backendless, browserless, bubble, cloudconvert, cloudinary, cloudlayer, convertapi, databricks, datadog, datarobot, deepseek, deployhq, digital_ocean, docmosis, docugenerate, encodian, gitea, gitlab, globalping, groqcloud, hookdeck, hyperbrowser, imgbb, imgix, kibana, neutrino, npm, openai, openrouter, parsera, parseur, phantombuster, pinecone, prismic, procfu, replicate, scrape_do, serpapi, shotstack, snowflake, supabase, tavily, valyu, v0, vercel, writer, zenrows
 
 ### E-commerce & Payments
 brex, btcpay_server, coupa, flutterwave, gift_up, lemon_squeezy, quaderno, ramp, shopify, stripe, zoho_invoice

--- a/fern/pages/src/changelog/12-10-25.md
+++ b/fern/pages/src/changelog/12-10-25.md
@@ -37,7 +37,7 @@ clickup, linear
 canva, figma
 
 ### Data & Analytics
-ahrefs, airtable, apify, exa, pplx, serpapi, tavily
+ahrefs, airtable, apify, exa, pplx, serpapi, tavily, valyu
 
 ### Email & Calendar
 calendly, outlook

--- a/ts/packages/cli/test/__mocks__/toolkits.json
+++ b/ts/packages/cli/test/__mocks__/toolkits.json
@@ -8106,6 +8106,20 @@
     "no_auth": false
   },
   {
+    "name": "Valyu",
+    "slug": "valyu",
+    "auth_schemes": ["API_KEY"],
+    "composio_managed_auth_schemes": [],
+    "is_local_toolkit": false,
+    "meta": {
+      "description": "Valyu provides AI-powered search and research APIs, offering real-time search across web, academic, medical, and financial sources, content extraction, AI-generated answers with citations, and comprehensive deep research reports",
+      "categories": [{ "id": "analytics-&-data", "name": "analytics & data" }],
+      "created_at": "2026-02-03T00:00:00.000Z",
+      "updated_at": "2026-02-03T00:00:00.000Z"
+    },
+    "no_auth": false
+  },
+  {
     "name": "Venly",
     "slug": "venly",
     "auth_schemes": ["API_KEY"],


### PR DESCRIPTION
Add Valyu to the toolkits catalog with support for AI-powered search and research APIs.

## What's included

Valyu provides:
- Real-time search across web, academic, medical, health sciences and financial sources
- Content extraction from URLs
- AI-generated answers with citations
- Comprehensive deep research reports

## Changes

- Added toolkit entries to `toolkits-list.json` and `toolkits.json`
- Included 4 tools: VALYU_SEARCH, VALYU_ANSWER, VALYU_CONTENTS, VALYU_DEEP_RESEARCH
- Updated changelog files to list Valyu in Data & Analytics category
- Added test mock for CLI tests

