### PR TITLE
feat(docs): improve AI-friendly markdown output

### DIFF
--- a/docs/lib/source.ts
+++ b/docs/lib/source.ts
@@ -278,6 +278,18 @@ export function mdxToCleanMarkdown(content: string): string {
   // Clean up excessive newlines
   result = result.replace(/\n{3,}/g, '\n\n');
 
+  // Strip twoslash annotations from code blocks (used for type-checking, not useful for AI)
+  // These include: // ---cut---, // @errors, // ^?, // @noErrors, etc.
+  result = result.replace(/^\/\/\s*---cut---.*$/gm, '');
+  result = result.replace(/^\/\/\s*@errors?:.*$/gm, '');
+  result = result.replace(/^\/\/\s*@noErrors.*$/gm, '');
+  result = result.replace(/^\/\/\s*@filename:.*$/gm, '');
+  result = result.replace(/^\/\/\s*@highlight.*$/gm, '');
+  result = result.replace(/^\/\/\s*\^[\?\!].*$/gm, ''); // ^? and ^! hover annotations
+
+  // Clean up any resulting empty lines in code blocks
+  result = result.replace(/\n{3,}/g, '\n\n');
+
   return result.trim();
 }
 
@@ -314,7 +326,11 @@ ${page.data.description || ''}`;
 
   return `# ${page.data.title} (${page.url})
 
-${cleanContent}`;
+${cleanContent}
+
+---
+
+📚 **More documentation:** [View all docs](https://docs.composio.dev/llms.txt) | [Examples](https://docs.composio.dev/llms.mdx/examples) | [API Reference](https://docs.composio.dev/llms.mdx/reference)`;
 }
 
 export function formatDate(dateStr: string): string {

--- a/docs/lib/source.ts
+++ b/docs/lib/source.ts
@@ -278,19 +278,32 @@ export function mdxToCleanMarkdown(content: string): string {
   // Clean up excessive newlines
   result = result.replace(/\n{3,}/g, '\n\n');
 
-  // Strip twoslash annotations from code blocks (used for type-checking, not useful for AI)
+  // Strip twoslash annotations ONLY inside code blocks (used for type-checking, not useful for AI)
   // These include: // ---cut---, // @errors, // ^?, // @noErrors, etc.
-  result = result.replace(/^\/\/\s*---cut---.*$/gm, '');
-  result = result.replace(/^\/\/\s*@errors?:.*$/gm, '');
-  result = result.replace(/^\/\/\s*@noErrors.*$/gm, '');
-  result = result.replace(/^\/\/\s*@filename:.*$/gm, '');
-  result = result.replace(/^\/\/\s*@highlight.*$/gm, '');
-  result = result.replace(/^\/\/\s*\^[\?\!].*$/gm, ''); // ^? and ^! hover annotations
-
-  // Clean up any resulting empty lines in code blocks
-  result = result.replace(/\n{3,}/g, '\n\n');
+  result = stripTwoslashFromCodeBlocks(result);
 
   return result.trim();
+}
+
+/**
+ * Strip twoslash annotations only from inside code blocks.
+ * This ensures we don't accidentally modify prose content.
+ */
+function stripTwoslashFromCodeBlocks(content: string): string {
+  // Match code blocks: ```lang ... ```
+  return content.replace(/(```[\w]*\n)([\s\S]*?)(```)/g, (match, open, code, close) => {
+    let cleanCode = code;
+    // Remove twoslash directives
+    cleanCode = cleanCode.replace(/^\/\/\s*---cut---.*\n?/gm, '');
+    cleanCode = cleanCode.replace(/^\/\/\s*@errors?:.*\n?/gm, '');
+    cleanCode = cleanCode.replace(/^\/\/\s*@noErrors.*\n?/gm, '');
+    cleanCode = cleanCode.replace(/^\/\/\s*@filename:.*\n?/gm, '');
+    cleanCode = cleanCode.replace(/^\/\/\s*@highlight.*\n?/gm, '');
+    cleanCode = cleanCode.replace(/^\/\/\s*\^[\?\!].*\n?/gm, ''); // ^? and ^! hover annotations
+    // Clean up resulting empty lines at start of code block
+    cleanCode = cleanCode.replace(/^\n+/, '');
+    return open + cleanCode + close;
+  });
 }
 
 export async function getLLMText(page: InferPageType<typeof source>) {


### PR DESCRIPTION
## Summary

- Strip twoslash annotations from code blocks when serving markdown via `Accept: text/markdown` header
- Add navigation footer with links to related docs

## Changes

1. **Strip twoslash annotations** - `// ---cut---`, `// @errors`, `// ^?`, etc. are used for type-checking but not useful for AI agents consuming the docs

2. **Add navigation footer** - Similar to Vercel's changelog, adds links to:
   - `llms.txt` (docs index)
   - Examples
   - API Reference

## Test plan

```bash
# Verify twoslash stripped
curl -H 'Accept: text/markdown' https://docs.composio.dev/docs/tools-direct/connected-accounts | grep -c "---cut---"
# Should return 0

# Verify footer present
curl -H 'Accept: text/markdown' https://docs.composio.dev/docs/quickstart | tail -5
# Should show navigation links
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>67c07b4</u></sup><!-- /BUGBOT_STATUS -->