### PR TITLE
fix: correct typo 'recieved' to 'received'

### DIFF
--- a/fern/snippets/providers/typescript/langchain.ts
+++ b/fern/snippets/providers/typescript/langchain.ts
@@ -59,7 +59,7 @@ const app = workflow.compile();
 const finalState = await app.invoke({
   messages: [new HumanMessage('Find the details of the user `pg` on HackerNews')],
 });
-console.log(`✅ Message recieved from the model`);
+console.log(`✅ Message received from the model`);
 console.log(finalState.messages[finalState.messages.length - 1].content);
 
 const nextState = await app.invoke({
@@ -67,5 +67,5 @@ const nextState = await app.invoke({
   // This way it knows we're asking about the weather in NY
   messages: [...finalState.messages, new HumanMessage('what about haxzie')],
 });
-console.log(`✅ Message recieved from the model`);
+console.log(`✅ Message received from the model`);
 console.log(nextState.messages[nextState.messages.length - 1].content);

--- a/ts/examples/cloudflare-wrangler/worker-configuration.d.ts
+++ b/ts/examples/cloudflare-wrangler/worker-configuration.d.ts
@@ -6541,7 +6541,7 @@ declare module "cloudflare:pipelines" {
         protected ctx: ExecutionContext;
         constructor(ctx: ExecutionContext, env: Env);
         /**
-         * run recieves an array of PipelineRecord which can be
+         * run receives an array of PipelineRecord which can be
          * transformed and returned to the pipeline
          * @param records Incoming records from the pipeline to be transformed
          * @param metadata Information about the specific pipeline calling the transformation entrypoint

--- a/ts/examples/langchain/src/index.ts
+++ b/ts/examples/langchain/src/index.ts
@@ -59,7 +59,7 @@ const app = workflow.compile();
 const finalState = await app.invoke({
   messages: [new HumanMessage('Find the details of the user `pg` on HackerNews')],
 });
-console.log(`✅ Message recieved from the model`);
+console.log(`✅ Message received from the model`);
 console.log(finalState.messages[finalState.messages.length - 1].content);
 
 const nextState = await app.invoke({
@@ -67,5 +67,5 @@ const nextState = await app.invoke({
   // This way it knows we're asking about the weather in NY
   messages: [...finalState.messages, new HumanMessage('what about haxzie')],
 });
-console.log(`✅ Message recieved from the model`);
+console.log(`✅ Message received from the model`);
 console.log(nextState.messages[nextState.messages.length - 1].content);


### PR DESCRIPTION
Fixes typo in log messages and documentation where 'recieved' was used instead of 'received'.