### PR TITLE
docs: add FAQ section to toolkit pages

### DIFF
--- a/docs/.claude/decisions/toolkits.md
+++ b/docs/.claude/decisions/toolkits.md
@@ -192,6 +192,29 @@ Run: `bun run generate:toolkits`
 
 ---
 
+## FAQ Section
+
+### How It Works
+- Per-toolkit FAQ sourced from plain markdown files in `content/toolkit-faq/{toolkit-slug}.md`
+- `##` headings are questions, body text is the answer
+- Markdown is converted to HTML at build time using `remark-parse` + `remark-rehype` + `hast-util-to-html` (all transitive deps from Fumadocs, no new packages)
+- Rendered as Fumadocs `Accordion` components between the Header and Auth Details sections
+- Only shown if a `.md` file exists for that toolkit and has valid Q&A content
+
+### Copy Page / LLM Markdown
+- FAQ content is also included in the `/toolkits/{slug}.md` LLM route output
+- Heading levels are bumped (`##` → `###`) so questions are children of the `## Frequently Asked Questions` section
+
+### No Sitemap Impact
+- FAQ is embedded within existing toolkit pages — no new URLs are created
+- No changes to sitemap or routing
+
+### Adding FAQ Content
+- Create/edit `content/toolkit-faq/{toolkit-slug}.md` — no code changes needed
+- Empty files or files with no valid `##` headings are safely ignored
+
+---
+
 ## Future: CI Hooks
 
 - Trigger docs regeneration from toolkit repo changes

--- a/docs/app/(home)/toolkits/[[...slug]]/page.tsx
+++ b/docs/app/(home)/toolkits/[[...slug]]/page.tsx
@@ -6,8 +6,13 @@ import { ToolkitsLanding } from '@/components/toolkits/toolkits-landing';
 import { PageActions } from '@/components/page-actions';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkRehype from 'remark-rehype';
+import { toHtml } from 'hast-util-to-html';
 import type { Metadata } from 'next';
 import type { Toolkit, Tool, Trigger } from '@/types/toolkit';
+import type { FaqItem } from '@/components/toolkits/faq-section';
 import { processSchema, toolFromApi } from '@/lib/toolkit-schema';
 
 const API_BASE = process.env.COMPOSIO_API_BASE || 'https://backend.composio.dev/api/v3';
@@ -93,6 +98,35 @@ async function fetchDetailedTriggers(toolkitSlug: string, version?: string | nul
     console.error(`[Toolkits] Error fetching detailed triggers for ${toolkitSlug}:`, error);
     return null;
   }
+}
+
+function markdownToHtml(md: string): string {
+  const tree = unified().use(remarkParse).parse(md);
+  const hast = unified().use(remarkRehype).runSync(tree);
+  return toHtml(hast);
+}
+
+async function readToolkitFaq(slug: string): Promise<FaqItem[] | null> {
+  const filePath = join(process.cwd(), 'content/toolkit-faq', `${slug}.md`);
+  let content: string;
+  try {
+    content = await readFile(filePath, 'utf-8');
+  } catch {
+    return null;
+  }
+
+  const items: FaqItem[] = [];
+  const sections = content.split(/^## /m).filter(Boolean);
+  for (const section of sections) {
+    const newlineIdx = section.indexOf('\n');
+    if (newlineIdx === -1) continue;
+    const question = section.slice(0, newlineIdx).trim();
+    const answerMd = section.slice(newlineIdx + 1).trim();
+    if (question && answerMd) {
+      items.push({ question, answer: markdownToHtml(answerMd) });
+    }
+  }
+  return items.length > 0 ? items : null;
 }
 
 async function getToolkits(): Promise<Toolkit[]> {
@@ -215,10 +249,11 @@ export default async function ToolkitsPage({ params }: { params: Promise<{ slug?
     const toolkit = toolkits.find((t) => t.slug === toolkitSlug);
 
     if (toolkit) {
-      // Fetch detailed tool and trigger info from API (includes input/output params)
-      const [detailedTools, detailedTriggers] = await Promise.all([
+      // Fetch detailed tool/trigger info and FAQ content in parallel
+      const [detailedTools, detailedTriggers, faq] = await Promise.all([
         fetchDetailedTools(toolkitSlug, toolkit.version),
         fetchDetailedTriggers(toolkitSlug, toolkit.version),
+        readToolkitFaq(toolkitSlug),
       ]);
 
       // Use detailed data if fetch succeeded, otherwise fall back to static data
@@ -231,6 +266,7 @@ export default async function ToolkitsPage({ params }: { params: Promise<{ slug?
           tools={tools}
           triggers={triggers}
           path={`/toolkits/${toolkit.slug}`}
+          faq={faq}
         />
       );
     }

--- a/docs/app/llms.mdx/[[...slug]]/route.ts
+++ b/docs/app/llms.mdx/[[...slug]]/route.ts
@@ -604,8 +604,18 @@ function renderParamsMarkdown(params: Record<string, ParameterSchema>): string[]
   return lines;
 }
 
+// Read FAQ markdown for a toolkit (returns raw markdown or null)
+async function readToolkitFaqMarkdown(slug: string): Promise<string | null> {
+  try {
+    const filePath = join(process.cwd(), 'content/toolkit-faq', `${slug}.md`);
+    return await readFile(filePath, 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
 // Generate markdown from toolkit with detailed tools and triggers
-function toolkitToMarkdown(toolkit: Toolkit, detailedTools?: Tool[], detailedTriggers?: Trigger[]): string {
+function toolkitToMarkdown(toolkit: Toolkit, detailedTools?: Tool[], detailedTriggers?: Trigger[], faqMarkdown?: string | null): string {
   const tools = detailedTools || toolkit.tools;
   const triggers = detailedTriggers || toolkit.triggers;
 
@@ -623,6 +633,11 @@ function toolkitToMarkdown(toolkit: Toolkit, detailedTools?: Tool[], detailedTri
 
   if (toolkit.version) {
     lines.push(`- **Version:** ${toolkit.version}`);
+  }
+
+  if (faqMarkdown && faqMarkdown.trim()) {
+    lines.push('', '## Frequently Asked Questions', '');
+    lines.push(faqMarkdown.trim());
   }
 
   if (tools.length > 0) {
@@ -864,17 +879,19 @@ export async function GET(
     if (prefix === 'toolkits' && rest.length === 1) {
       const toolkit = await getToolkit(rest[0]);
       if (toolkit) {
-        // Fetch detailed tool and trigger info from API
-        const [detailedTools, detailedTriggers] = await Promise.all([
+        // Fetch detailed tool/trigger info and FAQ content in parallel
+        const [detailedTools, detailedTriggers, faqMarkdown] = await Promise.all([
           fetchDetailedTools(rest[0]),
           fetchDetailedTriggers(rest[0]),
+          readToolkitFaqMarkdown(rest[0]),
         ]);
 
         return new Response(
           toolkitToMarkdown(
             toolkit,
             detailedTools !== null ? detailedTools : undefined,
-            detailedTriggers !== null ? detailedTriggers : undefined
+            detailedTriggers !== null ? detailedTriggers : undefined,
+            faqMarkdown
           ),
           {
             headers: {

--- a/docs/app/llms.mdx/[[...slug]]/route.ts
+++ b/docs/app/llms.mdx/[[...slug]]/route.ts
@@ -637,7 +637,8 @@ function toolkitToMarkdown(toolkit: Toolkit, detailedTools?: Tool[], detailedTri
 
   if (faqMarkdown && faqMarkdown.trim()) {
     lines.push('', '## Frequently Asked Questions', '');
-    lines.push(faqMarkdown.trim());
+    // Bump ## headings to ### so FAQ questions are children of the FAQ section
+    lines.push(faqMarkdown.trim().replace(/^## /gm, '### '));
   }
 
   if (tools.length > 0) {

--- a/docs/components/toolkits/faq-section.tsx
+++ b/docs/components/toolkits/faq-section.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { HelpCircle } from 'lucide-react';
+import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
+
+export interface FaqItem {
+  question: string;
+  answer: string;
+}
+
+interface FaqSectionProps {
+  faq: FaqItem[];
+}
+
+export function FaqSection({ faq }: FaqSectionProps) {
+  if (!faq || faq.length === 0) return null;
+
+  return (
+    <div className="space-y-3">
+      <h2 className="flex items-center gap-2 text-base font-semibold text-fd-foreground">
+        <HelpCircle className="h-4 w-4" />
+        Frequently Asked Questions
+      </h2>
+      <Accordions type="single">
+        {faq.map((item) => (
+          <Accordion key={item.question} title={item.question}>
+            <div
+              className="prose prose-sm prose-fd max-w-none text-fd-muted-foreground"
+              dangerouslySetInnerHTML={{ __html: item.answer }}
+            />
+          </Accordion>
+        ))}
+      </Accordions>
+    </div>
+  );
+}

--- a/docs/components/toolkits/toolkit-detail.tsx
+++ b/docs/components/toolkits/toolkit-detail.tsx
@@ -8,12 +8,14 @@ import type { Toolkit, Tool, Trigger, ParameterSchema } from '@/types/toolkit';
 import { processSchema } from '@/lib/toolkit-schema';
 import { PageActions } from '@/components/page-actions';
 import { AuthDetailsSection } from '@/components/toolkits/auth-details-section';
+import { FaqSection, type FaqItem } from '@/components/toolkits/faq-section';
 
 interface ToolkitDetailProps {
   toolkit: Toolkit;
   tools: Tool[];
   triggers: Trigger[];
   path: string;
+  faq?: FaqItem[] | null;
 }
 
 function ToolkitIcon({ toolkit }: { toolkit: Toolkit }) {
@@ -239,7 +241,7 @@ function ToolItem({ item, toolkitVersion }: { item: Tool | Trigger; toolkitVersi
   );
 }
 
-export function ToolkitDetail({ toolkit, tools, triggers, path }: ToolkitDetailProps) {
+export function ToolkitDetail({ toolkit, tools, triggers, path, faq }: ToolkitDetailProps) {
   const [copied, setCopied] = useState(false);
   const [versionCopied, setVersionCopied] = useState(false);
   const [toolSearch, setToolSearch] = useState('');
@@ -344,6 +346,9 @@ export function ToolkitDetail({ toolkit, tools, triggers, path }: ToolkitDetailP
             <PageActions path={path} />
           </div>
       </div>
+
+      {/* FAQ */}
+      {faq && faq.length > 0 && <FaqSection faq={faq} />}
 
       {/* Authentication Details */}
       {toolkit.authConfigDetails && toolkit.authConfigDetails.length > 0 && (

--- a/docs/content/toolkit-faq/airtable.md
+++ b/docs/content/toolkit-faq/airtable.md
@@ -1,0 +1,3 @@
+## How do I set up custom OAuth credentials for Airtable?
+
+For a step-by-step guide on creating and configuring your own Airtable OAuth credentials with Composio, see [How to create OAuth credentials for Airtable](https://composio.dev/auth/airtable).

--- a/docs/content/toolkit-faq/asana.md
+++ b/docs/content/toolkit-faq/asana.md
@@ -1,0 +1,3 @@
+## How do I set up custom OAuth credentials for Asana?
+
+For a step-by-step guide on creating and configuring your own Asana OAuth credentials with Composio, see [How to create OAuth credentials for Asana](https://composio.dev/auth/asana).

--- a/docs/content/toolkit-faq/canva.md
+++ b/docs/content/toolkit-faq/canva.md
@@ -1,0 +1,3 @@
+## How do I set up custom OAuth credentials for Canva?
+
+For a step-by-step guide on creating and configuring your own Canva OAuth credentials with Composio, see [How to create OAuth credentials for Canva](https://composio.dev/auth/canva).

--- a/docs/content/toolkit-faq/confluence.md
+++ b/docs/content/toolkit-faq/confluence.md
@@ -1,0 +1,3 @@
+## How do I set up custom OAuth credentials for Confluence?
+
+For a step-by-step guide on creating and configuring your own Confluence OAuth credentials with Composio, see [How to create OAuth credentials for Confluence](https://composio.dev/auth/confluence).

--- a/docs/content/toolkit-faq/dropbox.md
+++ b/docs/content/toolkit-faq/dropbox.md
@@ -1,0 +1,3 @@
+## How do I set up custom OAuth credentials for Dropbox?
+
+For a step-by-step guide on creating and configuring your own Dropbox OAuth credentials with Composio, see [How to create OAuth credentials for Dropbox](https://composio.dev/auth/dropbox).

--- a/docs/content/toolkit-faq/facebook.md
+++ b/docs/content/toolkit-faq/facebook.md
@@ -1,0 +1,3 @@
+## How do I set up custom OAuth credentials for Meta (Facebook)?
+
+For a step-by-step guide on creating and configuring your own Meta (Facebook) OAuth credentials with Composio, see [How to create OAuth credentials for Meta (Facebook)](https://composio.dev/auth/facebook).

--- a/docs/content/toolkit-faq/gitlab.md
+++ b/docs/content/toolkit-faq/gitlab.md
@@ -1,0 +1,3 @@
+## How do I set up custom OAuth credentials for GitLab?
+
+For a step-by-step guide on creating and configuring your own GitLab OAuth credentials with Composio, see [How to create OAuth credentials for GitLab](https://composio.dev/auth/gitlab).

--- a/docs/content/toolkit-faq/gmail.md
+++ b/docs/content/toolkit-faq/gmail.md
@@ -1,0 +1,3 @@
+## How do I set up custom Google OAuth credentials for Gmail?
+
+For a step-by-step guide on creating and configuring your own Google OAuth credentials with Composio, see [How to create OAuth2 credentials for Google Apps](https://composio.dev/auth/googleapps).

--- a/docs/content/toolkit-faq/google_admin.md
+++ b/docs/content/toolkit-faq/google_admin.md
@@ -1,0 +1,3 @@
+## How do I set up custom Google OAuth credentials for Google Admin?
+
+For a step-by-step guide on creating and configuring your own Google OAuth credentials with Composio, see [How to create OAuth2 credentials for Google Apps](https://composio.dev/auth/googleapps).

--- a/docs/content/toolkit-faq/googlecalendar.md
+++ b/docs/content/toolkit-faq/googlecalendar.md
@@ -1,0 +1,3 @@
+## How do I set up custom Google OAuth credentials for Google Calendar?
+
+For a step-by-step guide on creating and configuring your own Google OAuth credentials with Composio, see [How to create OAuth2 credentials for Google Apps](https://composio.dev/auth/googleapps).

--- a/docs/content/toolkit-faq/googledocs.md
+++ b/docs/content/toolkit-faq/googledocs.md
@@ -1,0 +1,3 @@
+## How do I set up custom Google OAuth credentials for Google Docs?
+
+For a step-by-step guide on creating and configuring your own Google OAuth credentials with Composio, see [How to create OAuth2 credentials for Google Apps](https://composio.dev/auth/googleapps).

--- a/docs/content/toolkit-faq/googledrive.md
+++ b/docs/content/toolkit-faq/googledrive.md
@@ -1,0 +1,3 @@
+## How do I set up custom Google OAuth credentials for Google Drive?
+
+For a step-by-step guide on creating and configuring your own Google OAuth credentials with Composio, see [How to create OAuth2 credentials for Google Apps](https://composio.dev/auth/googleapps).

--- a/docs/content/toolkit-faq/googlemeet.md
+++ b/docs/content/toolkit-faq/googlemeet.md
@@ -1,0 +1,3 @@
+## How do I set up custom Google OAuth credentials for Google Meet?
+
+For a step-by-step guide on creating and configuring your own Google OAuth credentials with Composio, see [How to create OAuth2 credentials for Google Apps](https://composio.dev/auth/googleapps).

--- a/docs/content/toolkit-faq/googlesheets.md
+++ b/docs/content/toolkit-faq/googlesheets.md
@@ -1,0 +1,3 @@
+## How do I set up custom Google OAuth credentials for Google Sheets?
+
+For a step-by-step guide on creating and configuring your own Google OAuth credentials with Composio, see [How to create OAuth2 credentials for Google Apps](https://composio.dev/auth/googleapps).

--- a/docs/content/toolkit-faq/googleslides.md
+++ b/docs/content/toolkit-faq/googleslides.md
@@ -1,0 +1,3 @@
+## How do I set up custom Google OAuth credentials for Google Slides?
+
+For a step-by-step guide on creating and configuring your own Google OAuth credentials with Composio, see [How to create OAuth2 credentials for Google Apps](https://composio.dev/auth/googleapps).

--- a/docs/content/toolkit-faq/googletasks.md
+++ b/docs/content/toolkit-faq/googletasks.md
@@ -1,0 +1,3 @@
+## How do I set up custom Google OAuth credentials for Google Tasks?
+
+For a step-by-step guide on creating and configuring your own Google OAuth credentials with Composio, see [How to create OAuth2 credentials for Google Apps](https://composio.dev/auth/googleapps).

--- a/docs/content/toolkit-faq/hubspot.md
+++ b/docs/content/toolkit-faq/hubspot.md
@@ -1,0 +1,3 @@
+## How do I set up custom OAuth credentials for HubSpot?
+
+For a step-by-step guide on creating and configuring your own HubSpot OAuth credentials with Composio, see [How to create OAuth credentials for HubSpot](https://composio.dev/auth/hubspot).

--- a/docs/content/toolkit-faq/instantly.md
+++ b/docs/content/toolkit-faq/instantly.md
@@ -1,0 +1,3 @@
+## How do I set up custom OAuth credentials for Instantly?
+
+For a step-by-step guide on creating and configuring your own Instantly OAuth credentials with Composio, see [How to create OAuth credentials for Instantly](https://composio.dev/auth/instantly).

--- a/docs/content/toolkit-faq/jira.md
+++ b/docs/content/toolkit-faq/jira.md
@@ -1,0 +1,3 @@
+## How do I set up custom OAuth credentials for Jira?
+
+For a step-by-step guide on creating and configuring your own Jira OAuth credentials with Composio, see [How to create OAuth credentials for Jira](https://composio.dev/auth/jira).

--- a/docs/content/toolkit-faq/linkedin.md
+++ b/docs/content/toolkit-faq/linkedin.md
@@ -1,0 +1,3 @@
+## How do I set up custom OAuth credentials for LinkedIn?
+
+For a step-by-step guide on creating and configuring your own LinkedIn OAuth credentials with Composio, see [How to create OAuth credentials for LinkedIn](https://composio.dev/auth/linkedin).

--- a/docs/content/toolkit-faq/monday.md
+++ b/docs/content/toolkit-faq/monday.md
@@ -1,0 +1,19 @@
+## Why is Monday.com OAuth2 not working for my users?
+
+Monday.com requires a workspace admin to install the OAuth2 app before any user in that workspace can authorize their account. If the app is not installed, users will see an authorization error when trying to connect.
+
+## How do I install the Composio OAuth2 app for Monday.com?
+
+A workspace admin needs to visit the following URL and approve the app installation:
+
+`https://auth.monday.com/oauth2/authorize?client_id=96b038435fc029e045f9ba800e66fefa&response_type=install`
+
+Once the admin has installed the app, users in that workspace can authorize their accounts using OAuth2 as usual.
+
+## Do I need to install the app for each user?
+
+No. The admin only needs to install the app once per workspace. After that, any user in the workspace can connect their Monday.com account through Composio's OAuth2 flow.
+
+## How do I set up custom OAuth credentials for Monday.com?
+
+For a step-by-step guide on creating and configuring your own Monday.com OAuth credentials with Composio, see [How to create OAuth2 credentials for Monday](https://composio.dev/auth/monday).

--- a/docs/content/toolkit-faq/outlook.md
+++ b/docs/content/toolkit-faq/outlook.md
@@ -1,0 +1,3 @@
+## How do I set up custom OAuth credentials for Microsoft (Outlook)?
+
+For a step-by-step guide on creating and configuring your own Microsoft (Outlook) OAuth credentials with Composio, see [How to create OAuth credentials for Microsoft (Outlook)](https://composio.dev/auth/outlook).

--- a/docs/content/toolkit-faq/pipedrive.md
+++ b/docs/content/toolkit-faq/pipedrive.md
@@ -1,0 +1,3 @@
+## How do I set up custom OAuth credentials for Pipedrive?
+
+For a step-by-step guide on creating and configuring your own Pipedrive OAuth credentials with Composio, see [How to create OAuth credentials for Pipedrive](https://composio.dev/auth/pipedrive).

--- a/docs/content/toolkit-faq/posthog.md
+++ b/docs/content/toolkit-faq/posthog.md
@@ -1,0 +1,3 @@
+## How do I set up custom OAuth credentials for PostHog?
+
+For a step-by-step guide on creating and configuring your own PostHog OAuth credentials with Composio, see [How to create OAuth credentials for PostHog](https://composio.dev/auth/posthog).

--- a/docs/content/toolkit-faq/salesforce.md
+++ b/docs/content/toolkit-faq/salesforce.md
@@ -1,0 +1,3 @@
+## How do I set up custom OAuth credentials for Salesforce?
+
+For a step-by-step guide on creating and configuring your own Salesforce OAuth credentials with Composio, see [How to create OAuth credentials for Salesforce](https://composio.dev/auth/salesforce).

--- a/docs/content/toolkit-faq/shopify.md
+++ b/docs/content/toolkit-faq/shopify.md
@@ -1,0 +1,3 @@
+## How do I set up custom OAuth credentials for Shopify?
+
+For a step-by-step guide on creating and configuring your own Shopify OAuth credentials with Composio, see [How to create OAuth credentials for Shopify](https://composio.dev/auth/shopify).

--- a/docs/content/toolkit-faq/slack.md
+++ b/docs/content/toolkit-faq/slack.md
@@ -1,0 +1,3 @@
+## How do I set up custom OAuth credentials for Slack?
+
+For a step-by-step guide on creating and configuring your own Slack OAuth credentials with Composio, see [How to create OAuth credentials for Slack](https://composio.dev/auth/slack).

--- a/docs/content/toolkit-faq/snowflake.md
+++ b/docs/content/toolkit-faq/snowflake.md
@@ -1,0 +1,3 @@
+## How do I set up custom OAuth credentials for Snowflake?
+
+For a step-by-step guide on creating and configuring your own Snowflake OAuth credentials with Composio, see [How to create OAuth credentials for Snowflake](https://composio.dev/auth/snowflake).

--- a/docs/content/toolkit-faq/strava.md
+++ b/docs/content/toolkit-faq/strava.md
@@ -1,0 +1,3 @@
+## How do I set up custom OAuth credentials for Strava?
+
+For a step-by-step guide on creating and configuring your own Strava OAuth credentials with Composio, see [How to create OAuth credentials for Strava](https://composio.dev/auth/strava).

--- a/docs/content/toolkit-faq/stripe.md
+++ b/docs/content/toolkit-faq/stripe.md
@@ -1,0 +1,3 @@
+## How do I set up custom OAuth credentials for Stripe?
+
+For a step-by-step guide on creating and configuring your own Stripe OAuth credentials with Composio, see [How to create OAuth credentials for Stripe](https://composio.dev/auth/stripe).

--- a/docs/content/toolkit-faq/xero.md
+++ b/docs/content/toolkit-faq/xero.md
@@ -1,0 +1,3 @@
+## How do I set up custom OAuth credentials for Xero?
+
+For a step-by-step guide on creating and configuring your own Xero OAuth credentials with Composio, see [How to create OAuth credentials for Xero](https://composio.dev/auth/xero).

--- a/docs/content/toolkit-faq/zendesk.md
+++ b/docs/content/toolkit-faq/zendesk.md
@@ -1,0 +1,3 @@
+## How do I set up custom OAuth credentials for Zendesk?
+
+For a step-by-step guide on creating and configuring your own Zendesk OAuth credentials with Composio, see [How to create OAuth credentials for Zendesk](https://composio.dev/auth/zendesk).

--- a/docs/content/toolkit-faq/zoho.md
+++ b/docs/content/toolkit-faq/zoho.md
@@ -1,0 +1,3 @@
+## How do I set up custom OAuth credentials for Zoho CRM?
+
+For a step-by-step guide on creating and configuring your own Zoho CRM OAuth credentials with Composio, see [How to create OAuth credentials for Zoho CRM](https://composio.dev/auth/zoho).

--- a/docs/content/toolkit-faq/zoom.md
+++ b/docs/content/toolkit-faq/zoom.md
@@ -1,0 +1,3 @@
+## How do I set up custom OAuth credentials for Zoom?
+
+For a step-by-step guide on creating and configuring your own Zoom OAuth credentials with Composio, see [How to create OAuth credentials for Zoom](https://composio.dev/auth/zoom).


### PR DESCRIPTION
## Summary
- Adds a per-toolkit FAQ section to toolkit detail pages (`/toolkits/{slug}`)
- FAQ content sourced from static markdown files in `content/toolkit-faq/`
- Renders as accordions between header and auth details sections
- Markdown converted to HTML at build time (remark/rehype — no new deps)
- FAQ content also included in "Copy page" markdown output (LLM route)
- Heading levels bumped (`##` → `###`) in LLM output to preserve document hierarchy
- Includes initial FAQ for 34 toolkits with auth setup guide links
- Monday.com has additional FAQ for OAuth admin app install requirement
- **No sitemap impact** — FAQ is embedded in existing toolkit pages, no new URLs

## How to add FAQ for a toolkit
Create `content/toolkit-faq/{toolkit-slug}.md` using `##` headings as questions:
```md
## Your question here?

Your answer with **bold**, `code`, and [links](https://example.com).
```

## Test plan
- [ ] Visit `/toolkits/gmail` — FAQ accordion renders with working link
- [ ] Visit `/toolkits/monday` — 4 FAQ items with inline code URL
- [ ] Visit `/toolkits/slack` — FAQ accordion with auth guide link
- [ ] Visit a toolkit without FAQ (e.g. `/toolkits/github`) — no FAQ section, no errors
- [ ] "Copy page" on a toolkit with FAQ — FAQ included in markdown output with correct heading hierarchy
- [ ] `bun run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)