### PR TITLE
docs: copy heading anchor link on click

### DIFF
--- a/docs/components/heading.tsx
+++ b/docs/components/heading.tsx
@@ -31,7 +31,7 @@ function HeadingAnchor({ id, children }: { id: string; children: React.ReactNode
 
   const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault();
-    const url = `${window.location.origin}${window.location.pathname}#${id}`;
+    const url = `${window.location.origin}${window.location.pathname}${window.location.search}#${id}`;
     window.history.replaceState(null, '', `#${id}`);
     navigator.clipboard.writeText(url).then(() => {
       setCopied(true);

--- a/docs/components/heading.tsx
+++ b/docs/components/heading.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { cn } from '@fumadocs/ui/cn';
+import { Link, Check } from 'lucide-react';
+import { useState, type ComponentPropsWithoutRef } from 'react';
+
+type HeadingProps = ComponentPropsWithoutRef<'h1'> & {
+  as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+};
+
+export function Heading({ as, className, ...props }: HeadingProps) {
+  const As = as ?? 'h1';
+
+  if (!props.id) return <As className={className} {...props} />;
+
+  return (
+    <As
+      className={cn(
+        'flex scroll-m-28 flex-row items-center gap-2',
+        className,
+      )}
+      {...props}
+    >
+      <HeadingAnchor id={props.id}>{props.children}</HeadingAnchor>
+    </As>
+  );
+}
+
+function HeadingAnchor({ id, children }: { id: string; children: React.ReactNode }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+    const url = `${window.location.origin}${window.location.pathname}#${id}`;
+    window.history.replaceState(null, '', `#${id}`);
+    navigator.clipboard.writeText(url).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return (
+    <>
+      <a data-card="" href={`#${id}`} className="peer" onClick={handleClick}>
+        {children}
+      </a>
+      {copied ? (
+        <Check
+          aria-hidden
+          className="size-3.5 shrink-0 text-green-500 transition-opacity"
+        />
+      ) : (
+        <Link
+          aria-hidden
+          className="size-3.5 shrink-0 text-fd-muted-foreground opacity-0 transition-opacity peer-hover:opacity-100"
+        />
+      )}
+    </>
+  );
+}

--- a/docs/components/heading.tsx
+++ b/docs/components/heading.tsx
@@ -29,19 +29,37 @@ export function Heading({ as, className, ...props }: HeadingProps) {
 function HeadingAnchor({ id, children }: { id: string; children: React.ReactNode }) {
   const [copied, setCopied] = useState(false);
 
-  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
-    e.preventDefault();
+  const copyLink = () => {
     const url = `${window.location.origin}${window.location.pathname}${window.location.search}#${id}`;
     window.history.replaceState(null, '', `#${id}`);
     navigator.clipboard.writeText(url).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
-    });
+    }).catch(() => {});
+  };
+
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+    copyLink();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLAnchorElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      copyLink();
+    }
   };
 
   return (
     <>
-      <a data-card="" href={`#${id}`} className="peer" onClick={handleClick}>
+      <a
+        data-card=""
+        href={`#${id}`}
+        className="peer"
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+        aria-label={`Copy link to ${id} section`}
+      >
         {children}
       </a>
       {copied ? (

--- a/docs/mdx-components.tsx
+++ b/docs/mdx-components.tsx
@@ -1,5 +1,6 @@
 import defaultMdxComponents from 'fumadocs-ui/mdx';
 import type { MDXComponents } from 'mdx/types';
+import { Heading } from '@/components/heading';
 import { YouTube } from '@/components/youtube';
 import { Tabs, Tab, TabsList, TabsTrigger, TabsContent } from 'fumadocs-ui/components/tabs';
 import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
@@ -35,6 +36,9 @@ import {
 export function getMDXComponents(components?: MDXComponents): MDXComponents {
   return {
     ...defaultMdxComponents,
+    h2: (props) => <Heading as="h2" {...props} />,
+    h3: (props) => <Heading as="h3" {...props} />,
+    h4: (props) => <Heading as="h4" {...props} />,
     img: (props) => <ImageZoom {...(props as any)} />,
     YouTube,
     Tabs,


### PR DESCRIPTION
## Summary
- Clicking a section heading now copies the full URL with anchor to clipboard
- Shows a green checkmark confirmation for 2 seconds after copying
- Overrides default Fumadocs heading behavior for h2/h3/h4

## Test plan
- [ ] Click any section heading on a docs page
- [ ] Verify URL is copied to clipboard
- [ ] Verify checkmark appears briefly then reverts to link icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)