### PR TITLE
docs: re-enable API playground

### DIFF
--- a/docs/.claude/context/api-reference.md
+++ b/docs/.claude/context/api-reference.md
@@ -24,7 +24,7 @@ We replace fumadocs-openapi's default popover-based schema rendering with Stripe
 - Returns `null` for `#/components/schemas/Error` to hide redundant error schemas
 - Passes `isResponse` flag (derived from `readOnly`/`writeOnly`) to hide "Required" labels on response fields
 - `generateTypeScriptSchema: false` disables the TypeScript Definitions copy box
-- `playground: { enabled: false }` disables the API playground (disabled because the OpenAPI spec has issues like kitchen-sink schemas that make the playground unusable)
+- `playground: { enabled: true }` enables the interactive API playground (requests are proxied through `/api/proxy`)
 
 ### `schema-generator.tsx`
 - Server component that walks OpenAPI schemas into a normalized `SchemaUIGeneratedData` structure

--- a/docs/components/api-page.tsx
+++ b/docs/components/api-page.tsx
@@ -7,7 +7,7 @@ import { CustomSchemaUI } from './custom-schema-ui';
 export const APIPage = createAPIPage(openapi, {
   client,
   generateTypeScriptSchema: false,
-  playground: { enabled: false },
+  playground: { enabled: true },
   schemaUI: {
     render: (options, ctx) => {
       // Skip rendering the shared Error schema on error responses -


### PR DESCRIPTION
## Summary
- Re-enables the interactive API playground on API reference pages (`playground: { enabled: true }`)
- Updates internal Claude context docs to reflect the change

## Test plan
- [ ] Run `bun run dev` and navigate to an API reference endpoint (e.g. `/reference/api-reference/tools/execute-a-tool`)
- [ ] Confirm the playground panel appears with parameter inputs, "Send" button, and response preview
- [ ] Test sending a request through the CORS proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)