### PR TITLE
fix(docs): Add redirects for /triggers, /features/*, /docs/how-tools-work

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -211,6 +211,16 @@ const config = {
         permanent: true,
       },
       {
+        source: '/triggers',
+        destination: '/docs/triggers',
+        permanent: true,
+      },
+      {
+        source: '/features/:path*',
+        destination: '/docs',
+        permanent: true,
+      },
+      {
         source: '/docs/mcp-quickstart',
         destination: '/docs/single-toolkit-mcp',
         permanent: true,

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -221,8 +221,13 @@ const config = {
         permanent: true,
       },
       {
-        source: '/features/:path*',
-        destination: '/docs',
+        source: '/features/authentication',
+        destination: '/docs/authentication',
+        permanent: true,
+      },
+      {
+        source: '/features/triggers',
+        destination: '/docs/triggers',
         permanent: true,
       },
       {

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -216,6 +216,11 @@ const config = {
         permanent: true,
       },
       {
+        source: '/docs/how-tools-work',
+        destination: '/docs/tools-and-toolkits',
+        permanent: true,
+      },
+      {
         source: '/features/:path*',
         destination: '/docs',
         permanent: true,


### PR DESCRIPTION
## Summary

Follow-up to #2598. Adds redirects for additional 404s found from AI agent traffic:

- `/triggers` → `/docs/triggers`
- `/docs/how-tools-work` → `/docs/tools-and-toolkits`
- `/features/authentication` → `/docs/authentication`
- `/features/triggers` → `/docs/triggers`

Uses specific paths instead of wildcards to avoid blocking future pages.

## Test plan
- [ ] Verify `docs.composio.dev/triggers` redirects to `/docs/triggers`
- [ ] Verify `docs.composio.dev/docs/how-tools-work` redirects to `/docs/tools-and-toolkits`
- [ ] Verify `docs.composio.dev/features/authentication` redirects to `/docs/authentication`

🤖 Generated with [Claude Code](https://claude.com/claude-code)