### PR TITLE
fix(core): pass refresh_url as parameter to @composio/client

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,11 +10,6 @@ packages:
   - ts/packages/providers/*
   - ts/packages/ts-builders
   - ts/packages/wrappers/*
-  # DEPRECATED: fern docs - now using /docs with Fumadocs
-  # - fern
-  # - fern/llms-txt-worker
-  # - fern/pages/examples/*
-  # - fern/snippets/*
 
 catalog:
   '@ai-sdk/openai': ^3.0.19

--- a/ts/packages/core/src/models/ConnectedAccounts.ts
+++ b/ts/packages/core/src/models/ConnectedAccounts.ts
@@ -389,7 +389,7 @@ export class ConnectedAccounts {
       }
 
       params = {
-        body_redirect_url: parsedOptions.data.redirectUrl,
+        query_redirect_url: parsedOptions.data.redirectUrl,
         validate_credentials: parsedOptions.data.validateCredentials,
       };
     }

--- a/ts/packages/core/test/connectedAccounts/connectedAccounts.test.ts
+++ b/ts/packages/core/test/connectedAccounts/connectedAccounts.test.ts
@@ -509,7 +509,7 @@ describe('ConnectedAccounts', () => {
       const result = await connectedAccounts.refresh(nanoid, { redirectUrl });
 
       expect(extendedMockClient.connectedAccounts.refresh).toHaveBeenCalledWith(nanoid, {
-        body_redirect_url: redirectUrl,
+        query_redirect_url: redirectUrl,
         validate_credentials: undefined,
       });
       expect(result).toEqual(mockResponse);
@@ -524,7 +524,7 @@ describe('ConnectedAccounts', () => {
       const result = await connectedAccounts.refresh(nanoid, { validateCredentials: true });
 
       expect(extendedMockClient.connectedAccounts.refresh).toHaveBeenCalledWith(nanoid, {
-        body_redirect_url: undefined,
+        query_redirect_url: undefined,
         validate_credentials: true,
       });
       expect(result).toEqual(mockResponse);
@@ -543,7 +543,7 @@ describe('ConnectedAccounts', () => {
       const result = await connectedAccounts.refresh(nanoid, options);
 
       expect(extendedMockClient.connectedAccounts.refresh).toHaveBeenCalledWith(nanoid, {
-        body_redirect_url: options.redirectUrl,
+        query_redirect_url: options.redirectUrl,
         validate_credentials: options.validateCredentials,
       });
       expect(result).toEqual(mockResponse);
@@ -569,7 +569,7 @@ describe('ConnectedAccounts', () => {
       const result = await connectedAccounts.refresh(nanoid, {});
 
       expect(extendedMockClient.connectedAccounts.refresh).toHaveBeenCalledWith(nanoid, {
-        body_redirect_url: undefined,
+        query_redirect_url: undefined,
         validate_credentials: undefined,
       });
       expect(result).toEqual(mockResponse);


### PR DESCRIPTION
This PR:
- closes [PLEN-1474](https://linear.app/composio/issue/PLEN-1474/redirecturl-not-working-in-composiocore-connectedaccountsrefresh)
- fixes the way `refresh_url` is passed to `@composio/client` (it's be a query string, not a body parameter)