### PR TITLE
fix(docs): use StepTitle to keep step titles out of TOC

### DIFF
--- a/docs/content/docs/auth-configuration/custom-auth-configs.mdx
+++ b/docs/content/docs/auth-configuration/custom-auth-configs.mdx
@@ -41,7 +41,7 @@ However, getting OAuth approvals takes time, so Composio provides a default deve
 
 <Steps>
 <Step>
-### Generate the OAuth Client ID and Client Secret
+<StepTitle>Generate the OAuth Client ID and Client Secret</StepTitle>
 
 To set up a custom OAuth config, you'll need the OAuth Client ID and Client Secret.
 
@@ -60,7 +60,7 @@ Examples for Google and GitHub:
 </Step>
 
 <Step>
-### Set the Authorized Redirect URI
+<StepTitle>Set the Authorized Redirect URI</StepTitle>
 
 When creating your OAuth app, make sure to configure the Authorized Redirect URI to point to the Composio callback URL below:
 
@@ -70,7 +70,7 @@ https://backend.composio.dev/api/v3/toolkits/auth/callback
 </Step>
 
 <Step>
-### Create the auth config
+<StepTitle>Create the auth config</StepTitle>
 
 Once you have the OAuth credentials, you can add them to the auth config in the dashboard.
 
@@ -131,7 +131,7 @@ To remediate this:
 
 <Steps>
 <Step>
-### Set the Authorized Redirect URI
+<StepTitle>Set the Authorized Redirect URI</StepTitle>
 
 Specify the Authorized Redirect URI to your own domain in the OAuth configuration.
 For example:
@@ -141,7 +141,7 @@ https://yourdomain.com/api/composio-redirect
 </Step>
 
 <Step>
-### Create a redirect logic
+<StepTitle>Create a redirect logic</StepTitle>
 
 Create a redirect logic, either through your DNS or in your application to redirect that endpoint to `https://backend.composio.dev/api/v3/toolkits/auth/callback`
 
@@ -204,7 +204,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
 </Step>
 
 <Step>
-### Create the auth config
+<StepTitle>Create the auth config</StepTitle>
 
 Specify your custom redirect URI in the auth config settings!
 

--- a/docs/content/docs/migration-guide/tool-router-beta.mdx
+++ b/docs/content/docs/migration-guide/tool-router-beta.mdx
@@ -10,7 +10,7 @@ The stable version includes improved session management, multiple configuring op
 
 <Steps>
 <Step>
-### Upgrade composio package
+<StepTitle>Upgrade composio package</StepTitle>
 
 Upgrade to the latest stable version:
 
@@ -29,7 +29,7 @@ npm install @composio/core@latest
 </Step>
 
 <Step>
-### Update session creation
+<StepTitle>Update session creation</StepTitle>
 
 <Tabs groupId="language" items={['Python', 'TypeScript']} persist>
 <Tab value="Python">
@@ -59,7 +59,7 @@ const session = await composio.create('user_123');
 </Step>
 
 <Step>
-### Moving users (optional)
+<StepTitle>Moving users (optional)</StepTitle>
 
 If you have existing users on tool router and you don't want them to authenticate again:
 - Tool Router will auto-detect auth configs and connected accounts it created (from the beta version).
@@ -99,7 +99,7 @@ const session = await composio.create('user_123',
 </Step>
 
 <Step>
-### Explore new capabilities
+<StepTitle>Explore new capabilities</StepTitle>
 
 Check out these new features available in the stable version:
 

--- a/docs/content/docs/tools-direct/authenticating-tools.mdx
+++ b/docs/content/docs/tools-direct/authenticating-tools.mdx
@@ -18,19 +18,19 @@ An **Auth Config** is a blueprint that defines how authentication works for a to
 
 <Steps>
 <Step>
-### Selecting a toolkit
+<StepTitle>Selecting a toolkit</StepTitle>
 
 Navigate to [Auth Configs](https://platform.composio.dev?next_page=%2Fauth-configs) tab in your dashboard and click "**Create Auth Config**". Find and select the toolkit you want to integrate (e.g., **Gmail**, **Slack**, **GitHub**).
 </Step>
 
 <Step>
-### Selecting the Authentication method
+<StepTitle>Selecting the Authentication method</StepTitle>
 
 Each toolkit supports different authentication methods such as **OAuth**, **API Key**, **Bearer Token**. Select from the available options for your toolkit.
 </Step>
 
 <Step>
-### Configure scopes
+<StepTitle>Configure scopes</StepTitle>
 
 Depending on your authentication method, you may need to configure scopes:
 - **OAuth2**: Configure scopes for what data and actions your app can access.
@@ -38,7 +38,7 @@ Depending on your authentication method, you may need to configure scopes:
 </Step>
 
 <Step>
-### Authentication Management
+<StepTitle>Authentication Management</StepTitle>
 
 **For OAuth toolkits:**
 - **Development/Testing**: Use Composio's managed authentication (no setup required)
@@ -54,7 +54,7 @@ Want to remove Composio branding from OAuth screens? See [Custom Auth Configs](/
 </Step>
 
 <Step>
-### You are all set!
+<StepTitle>You are all set!</StepTitle>
 
 Click "**Create Auth Configuration**" button and you have completed your first step! Now you can move ahead to authenticating your users by [Connecting an Account](#connecting-an-account).
 </Step>

--- a/docs/content/docs/using-custom-auth-configuration.mdx
+++ b/docs/content/docs/using-custom-auth-configuration.mdx
@@ -8,13 +8,13 @@ Some toolkits don't have Composio managed authentication and require you to prov
 
 <Steps>
 <Step>
-### Check if a toolkit needs custom credentials
+<StepTitle>Check if a toolkit needs custom credentials</StepTitle>
 
 In the [Composio platform](https://platform.composio.dev), go to "All Toolkits" and select the toolkit. If it shows no Composio managed auth schemes, you'll need to create an auth config.
 </Step>
 
 <Step>
-### Create an auth config
+<StepTitle>Create an auth config</StepTitle>
 
 1. Go to **Authentication management** in the [dashboard](https://platform.composio.dev)
 2. Click **Create Auth Config**
@@ -31,7 +31,7 @@ For detailed instructions on getting credentials for specific toolkits, see [Cus
 </Step>
 
 <Step>
-### Use in your session
+<StepTitle>Use in your session</StepTitle>
 
 Pass your auth config ID when creating a session:
 

--- a/docs/content/docs/white-labeling-authentication.mdx
+++ b/docs/content/docs/white-labeling-authentication.mdx
@@ -10,7 +10,7 @@ By default, OAuth screens show Composio's branding. With white-labeling, they'll
 
 <Steps>
 <Step>
-### Create an OAuth app
+<StepTitle>Create an OAuth app</StepTitle>
 
 Create a developer app in the toolkit's developer portal. You'll need the client ID and client secret. Set the callback URL to:
 
@@ -24,7 +24,7 @@ For step-by-step guides on creating OAuth apps for some toolkits, see [composio.
 </Step>
 
 <Step>
-### Create auth config
+<StepTitle>Create auth config</StepTitle>
 
 Create an auth config in the [Composio dashboard](https://platform.composio.dev):
 
@@ -43,7 +43,7 @@ For detailed instructions with screenshots, see [Custom auth configs](/docs/auth
 </Step>
 
 <Step>
-### Use in your session
+<StepTitle>Use in your session</StepTitle>
 
 Pass your auth config ID in the session:
 


### PR DESCRIPTION
## Summary

- Replaced `### heading` inside `<Step>` with `<StepTitle>` across all docs pages
- Markdown headings inside steps were leaking into the table of contents, cluttering the sidebar
- `<StepTitle>` renders the same visually but is excluded from TOC extraction
- Also converts cleanly to `#### Title` in the `.md` version for AI crawlers

### Files fixed

| File | Steps fixed |
|------|-------------|
| `tools-direct/authenticating-tools.mdx` | 5 |
| `using-custom-auth-configuration.mdx` | 3 |
| `auth-configuration/custom-auth-configs.mdx` | 6 |
| `white-labeling-authentication.mdx` | 3 |
| `migration-guide/tool-router-beta.mdx` | 4 |

`quickstart.mdx` already used `<StepTitle>` — no change needed.

## Test plan

- [ ] Verify step titles no longer appear in the TOC on affected pages
- [ ] Verify steps still render correctly with numbered styling
- [ ] Confirm no build errors (`bun run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)