### PR TITLE
docs: add FAQ page

### DIFF
--- a/docs/content/docs/common-faq.mdx
+++ b/docs/content/docs/common-faq.mdx
@@ -25,7 +25,7 @@ If you don't have an agent, you can [execute tools directly](/docs/tools-direct/
 </Accordion>
 
 <Accordion title="Where can I see all available toolkits?">
-You can browse all toolkits on the [Toolkits page](/toolkits) in the docs or in the [Composio dashboard](https://platform.composio.dev/sushmitha_workspace/demo/marketplace). Both list every supported app along with available auth schemes and tools.
+You can browse all toolkits on the [Toolkits page](/toolkits) in the docs or in the [Composio dashboard](https://platform.composio.dev?next_page=/marketplace). Both list every supported app along with available auth schemes and tools.
 </Accordion>
 
 <Accordion title="The tool I need doesn't exist. How do I request one?">
@@ -85,13 +85,13 @@ See [Connected accounts](/docs/auth-configuration/connected-accounts#get-account
 </Accordion>
 
 <Accordion title="Where can I find execution logs?">
-Every tool execution is logged in the [Composio dashboard](https://platform.composio.dev) under **Logs > Tools**. Each execution response includes a `log_id` you can use to look up detailed request and response data. Trigger delivery attempts are logged separately under **Logs > Triggers**.
+Every tool execution is logged in the [Composio dashboard](https://platform.composio.dev?next_page=/logs/tools) under **Logs > Tools**. Each execution response includes a `log_id` you can use to look up detailed request and response data. Trigger delivery attempts are logged separately under **Logs > Triggers**.
 
 See [Troubleshooting tools](/docs/troubleshooting/tools) for how to use logs to debug failed executions.
 </Accordion>
 
 <Accordion title="Can Composio be self-hosted?">
-Yes, Composio supports self-hosting on the Enterprise plan. See [pricing](https://composio.dev/pricing) for details or [book a call](https://composio.dev/contact-sales) with the team.
+Yes, Composio supports self-hosting on the Enterprise plan. See [pricing](https://composio.dev/pricing) for details or [talk to us](https://calendly.com/composiohq/enterprise).
 </Accordion>
 
 </Accordions>

--- a/docs/content/docs/faq.mdx
+++ b/docs/content/docs/faq.mdx
@@ -1,17 +1,91 @@
 ---
-title: FAQ
+title: General FAQs
 description: Frequently asked questions about Composio
 keywords: [faq, questions, help, common questions]
 ---
 
 <Accordions>
 
+<Accordion title="Can I white label Composio's auth screens?">
+Yes. By default, OAuth consent screens show "Composio" as the app name. If you create an auth config with your own OAuth client ID and secret, users will see your app's name and logo instead.
+
+You can also proxy the OAuth redirect through your own domain so users never see `backend.composio.dev` in the URL bar. See [White-labeling authentication](/docs/white-labeling-authentication).
+</Accordion>
+
+<Accordion title="What is the difference between a tool and a toolkit?">
+A **toolkit** is a collection of related tools grouped by app, for example the GitHub toolkit or the Gmail toolkit. A **tool** is a single action within a toolkit, like `GITHUB_CREATE_ISSUE` or `GMAIL_SEND_EMAIL`.
+
+You connect to toolkits (via OAuth or API keys), and then execute individual tools within them. See [Tools and toolkits](/docs/tools-and-toolkits).
+</Accordion>
+
+<Accordion title="Do I need an AI agent to use Composio?">
+No. If you're building an AI agent, Composio can give it [meta tools](/docs/quickstart) that handle tool discovery and execution automatically, or you can [fetch specific tools](/docs/tools-direct/fetching-tools) and pass them to your agent directly.
+
+If you don't have an agent, you can [execute tools directly](/docs/tools-direct/executing-tools#direct-tool-execution) from any backend.
+</Accordion>
+
+<Accordion title="Where can I see all available toolkits?">
+You can browse all toolkits on the [Toolkits page](/toolkits) in the docs or in the [Composio dashboard](https://platform.composio.dev/sushmitha_workspace/demo/marketplace). Both list every supported app along with available auth schemes and tools.
+</Accordion>
+
+<Accordion title="The tool I need doesn't exist. How do I request one?">
+You can request new tools or toolkits on the [tool request board](https://request.composio.dev/boards/tool-requests). The team reviews requests regularly.
+</Accordion>
+
+<Accordion title="What is User ID and how should I use it?">
+The User ID is how Composio identifies your end users. It maps each user to their connected accounts and sessions. Use any unique identifier from your system, like an email, database ID, or UUID.
+
+When you create a session with `composio.create(user_id="user_123")`, all connected accounts and tool executions are scoped to that user. See [Users and sessions](/docs/users-and-sessions).
+</Accordion>
+
+<Accordion title="What is an auth config?">
+An auth config is a blueprint that defines how authentication works for a toolkit. It specifies the auth method (OAuth2, API Key, etc.), the scopes to request, and the credentials to use.
+
+If you're using sessions with meta tools (`composio.create()`), you don't need to create auth configs yourself. When a user connects to a toolkit, Composio automatically uses a default auth config with managed credentials. The agent handles the entire flow through `COMPOSIO_MANAGE_CONNECTIONS`.
+
+You only need to create auth configs manually when you're [executing tools directly](/docs/tools-direct/authenticating-tools), want to [use your own OAuth app](/docs/white-labeling-authentication), need [custom scopes](/docs/auth-configuration/custom-auth-configs), or are working with a toolkit that doesn't have Composio-managed auth. See [Authentication](/docs/authentication) for the full overview.
+</Accordion>
+
+<Accordion title="What authentication types does Composio support?">
+Composio supports **OAuth2**, **OAuth1**, **API Key**, **Bearer Token**, and **Basic Auth**. Most toolkits use OAuth2. Each toolkit defines which auth types it supports. You can see the available schemes when creating an auth config in the dashboard.
+
+For toolkits with Composio-managed auth, you don't need to configure anything. For toolkits without it, you'll need to create a [custom auth config](/docs/using-custom-auth-configuration). See [Authentication](/docs/authentication) for the full overview.
+</Accordion>
+
+<Accordion title="How do I work with toolkit versions?">
+Composio toolkits are versioned using date-based identifiers (e.g., `20251027_00`). You can pin versions at SDK initialization or per tool execution to keep behavior consistent across deployments.
+
+This applies to direct tool execution only. Sessions with meta tools always use the latest version. See [Toolkit versioning](/docs/tools-direct/toolkit-versioning).
+</Accordion>
+
+<Accordion title="Can a user connect multiple accounts for the same app?">
+Yes. For example, a user can connect both a personal and work Gmail account. Call `session.authorize()` multiple times for the same toolkit. Each session uses the most recently connected account by default, but you can pin a specific account when creating the session.
+
+For direct tool execution, use `initiate()` with `allow_multiple: true` and pass the `connected_account_id` when executing. See [Managing multiple connected accounts](/docs/managing-multiple-connected-accounts).
+</Accordion>
+
+<Accordion title="How does token refresh work?">
+Composio automatically refreshes OAuth tokens before they expire. You don't need to handle this yourself.
+
+If a refresh fails permanently (e.g., the user revoked access or the OAuth app was deleted), the connection status changes to `EXPIRED`. You can [subscribe to expiry events](/docs/subscribing-to-connection-expiry-events) to detect this and prompt users to re-authenticate. See [Connection statuses](/docs/tools-direct/authenticating-tools#connection-statuses) for more details.
+</Accordion>
+
+<Accordion title="Does Composio support triggers?">
+Yes. Triggers let you listen for events from connected apps, like a new email in Gmail, a new issue in GitHub, or a new message in Slack. When the event fires, Composio sends a webhook to your endpoint with the event payload.
+
+See [Triggers](/docs/triggers) for setup and [Subscribing to triggers](/docs/setting-up-triggers/subscribing-to-events) for receiving events.
+</Accordion>
+
 <Accordion title="Why are my connected account secrets showing `abcd...` or `REDACTED`?">
 Connected account secrets are masked by default for security. The API returns the first 4 characters followed by `...` (e.g., `gho_...`). Values shorter than 4 characters show as `REDACTED`.
 
-To disable masking, go to **Settings → Project Settings → Project Configuration** and turn off "Mask Connected Account Secrets", or use the [Patch Project Config](/rest-api/projects/patch-org-project-config) API.
+To disable masking, go to **Settings → Project Settings → Project Configuration** and turn off "Mask Connected Account Secrets", or use the Patch Project Config API.
 
 See [Credential masking](/docs/auth-configuration/connected-accounts#credential-masking) for full details.
+</Accordion>
+
+<Accordion title="Can Composio be self-hosted?">
+Yes, Composio supports self-hosting on the Enterprise plan. See [pricing](https://composio.dev/pricing) for details or [book a call](https://composio.dev/contact-sales) with the team.
 </Accordion>
 
 </Accordions>

--- a/docs/content/docs/faq.mdx
+++ b/docs/content/docs/faq.mdx
@@ -81,7 +81,13 @@ Connected account secrets are masked by default for security. The API returns th
 
 To disable masking, go to **Settings → Project Settings → Project Configuration** and turn off "Mask Connected Account Secrets", or use the Patch Project Config API.
 
-See [Credential masking](/docs/auth-configuration/connected-accounts#credential-masking) for full details.
+See [Connected accounts](/docs/auth-configuration/connected-accounts#get-account-credentials) for full details.
+</Accordion>
+
+<Accordion title="Where can I find execution logs?">
+Every tool execution is logged in the [Composio dashboard](https://platform.composio.dev) under **Logs > Tools**. Each execution response includes a `log_id` you can use to look up detailed request and response data. Trigger delivery attempts are logged separately under **Logs > Triggers**.
+
+See [Troubleshooting tools](/docs/troubleshooting/tools) for how to use logs to debug failed executions.
 </Accordion>
 
 <Accordion title="Can Composio be self-hosted?">

--- a/docs/content/docs/faq.mdx
+++ b/docs/content/docs/faq.mdx
@@ -1,0 +1,17 @@
+---
+title: FAQ
+description: Frequently asked questions about Composio
+keywords: [faq, questions, help, common questions]
+---
+
+<Accordions>
+
+<Accordion title="Why are my connected account secrets showing `abcd...` or `REDACTED`?">
+Connected account secrets are masked by default for security. The API returns the first 4 characters followed by `...` (e.g., `gho_...`). Values shorter than 4 characters show as `REDACTED`.
+
+To disable masking, go to **Settings → Project Settings → Project Configuration** and turn off "Mask Connected Account Secrets", or use the [Patch Project Config](/rest-api/projects/patch-org-project-config) API.
+
+See [Credential masking](/docs/auth-configuration/connected-accounts#credential-masking) for full details.
+</Accordion>
+
+</Accordions>

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -27,6 +27,7 @@
     "tools-direct",
     "auth-configuration",
     "---Resources---",
+    "faq",
     "debugging-info",
     "migration-guide",
     "troubleshooting"

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -27,7 +27,7 @@
     "tools-direct",
     "auth-configuration",
     "---Resources---",
-    "faq",
+    "common-faq",
     "debugging-info",
     "migration-guide",
     "troubleshooting"


### PR DESCRIPTION
## Summary
- Adds a new **FAQ** page under Resources with accordion-style Q&A
- Starts with one question: "Why are my connected account secrets showing `abcd...` or `REDACTED`?"
- More questions will be added before merging

## Test plan
- [ ] `bun run build` passes
- [ ] Navigate to `/docs/faq` and verify accordion renders correctly
- [ ] Verify link to credential masking section works

🤖 Generated with [Claude Code](https://claude.com/claude-code)