### PR TITLE
docs: add Workbench concept page

### DIFF
--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -8,6 +8,7 @@
     "users-and-sessions",
     "authentication",
     "tools-and-toolkits",
+    "workbench",
     "triggers",
     "---Getting Started---",
     "configuring-sessions",

--- a/docs/content/docs/tools-and-toolkits.mdx
+++ b/docs/content/docs/tools-and-toolkits.mdx
@@ -15,7 +15,7 @@ When you create a session, your agent gets these 5 meta tools:
 | `COMPOSIO_SEARCH_TOOLS` | Discover relevant tools across 800+ apps |
 | `COMPOSIO_MANAGE_CONNECTIONS` | Handle OAuth and API key authentication |
 | `COMPOSIO_MULTI_EXECUTE_TOOL` | Execute up to 20 tools in parallel |
-| `COMPOSIO_REMOTE_WORKBENCH` | Run Python code in a persistent sandbox |
+| `COMPOSIO_REMOTE_WORKBENCH` | Run Python code in a [persistent sandbox](/docs/workbench) |
 | `COMPOSIO_REMOTE_BASH_TOOL` | Execute bash commands for file and data processing |
 
 Meta tool calls in a session are correlated using a `session_id`, allowing them to share context. The tools can also store useful information (like IDs and relationships discovered during execution) in memory for subsequent calls.
@@ -54,7 +54,7 @@ Done. (For large results, agent can use REMOTE_WORKBENCH to process)
 
 For most tasks, `COMPOSIO_MULTI_EXECUTE_TOOL` returns results directly. But when dealing with large responses or bulk operations, your agent uses the workbench tools:
 
-- **`COMPOSIO_REMOTE_WORKBENCH`** - Run Python code in a persistent sandbox. Use for bulk operations (e.g., labeling 100 emails), complex data transformations, or when results need further analysis with helper functions like `invoke_llm`.
+- **`COMPOSIO_REMOTE_WORKBENCH`** - Run Python code in a [persistent sandbox](/docs/workbench). Use for bulk operations (e.g., labeling 100 emails), complex data transformations, or when results need further analysis with helper functions like `invoke_llm`.
 
 - **`COMPOSIO_REMOTE_BASH_TOOL`** - Execute bash commands for simpler file operations and data extraction using tools like `jq`, `awk`, `sed`, and `grep`.
 

--- a/docs/content/docs/users-and-sessions.mdx
+++ b/docs/content/docs/users-and-sessions.mdx
@@ -97,6 +97,7 @@ const toolkits = await session.toolkits();
 </Tab>
 </Tabs>
 
-For details on enabling toolkits, setting auth configs, and using session methods:
-
-<Card icon={<BookOpen />} title="Configuring Sessions" href="/docs/configuring-sessions" description="Enable toolkits, set auth configs, and select connected accounts" />
+<Cards>
+  <Card icon={<BookOpen />} title="Configuring Sessions" href="/docs/configuring-sessions" description="Enable toolkits, set auth configs, and select connected accounts" />
+  <Card icon={<BookOpen />} title="Workbench" href="/docs/workbench" description="Write and run code in a persistent sandbox" />
+</Cards>

--- a/docs/content/docs/workbench.mdx
+++ b/docs/content/docs/workbench.mdx
@@ -43,15 +43,13 @@ These functions are pre-initialized in every sandbox:
 | `web_search` | Search the web and return results for research or data enrichment |
 | `smart_file_extract` | Extract text from PDFs, images, and other file formats in the sandbox |
 
-### Pre-installed libraries
+### Libraries
 
-The sandbox has these libraries pre-installed:
+Common packages like pandas, numpy, matplotlib, Pillow, PyTorch, and reportlab are pre-installed. Beyond these, the workbench maintains a list of supported packages and their dependencies. If the agent uses a package that isn't already installed, the workbench attempts to install it automatically.
 
-- **Data analysis**: pandas, numpy, matplotlib
-- **Image processing**: Pillow, OpenCV, scikit-image
-- **Machine learning**: PyTorch
-- **Document handling**: python-docx, pdfplumber, reportlab, pandoc
-- **Standard tools**: requests, json, csv, and the Python standard library
+### Error correction
+
+The workbench corrects common mistakes in the code your agent generates. For example, if a script accesses `result["apiKey"]` but the actual field name is `api_key`, the workbench resolves the mismatch instead of failing.
 
 ### Persistent state
 

--- a/docs/content/docs/workbench.mdx
+++ b/docs/content/docs/workbench.mdx
@@ -1,0 +1,83 @@
+---
+title: Workbench
+description: A persistent Python sandbox for writing code, calling tools programmatically, and processing data
+keywords: [workbench, sandbox, remote execution, bulk operations, data processing]
+---
+
+The workbench is a persistent Python sandbox where your agent can write and execute code. It has access to all Composio tools programmatically, plus helper functions for calling LLMs, uploading files, and making API requests. State persists across calls within a session. The `COMPOSIO_REMOTE_BASH_TOOL` meta tool also runs commands in the same sandbox.
+
+<Callout>
+The workbench is part of the meta tools system. It's available when you create sessions, not when [executing tools directly](/docs/tools-direct/executing-tools).
+</Callout>
+
+## Where it fits
+
+Your agent starts with `SEARCH_TOOLS` to find the right tools, then uses `MULTI_EXECUTE` for straightforward calls. When the task involves bulk operations, data transformations, or multi-step logic, the agent uses `COMPOSIO_REMOTE_WORKBENCH` instead.
+
+```mermaid
+graph TD
+    U["Triage my emails, label urgent ones, log to a Google Sheet"] --> S["1. SEARCH_TOOLS"]
+    S --> M["2. MULTI_EXECUTE"]
+    M --> W["3. REMOTE_WORKBENCH"]
+    W --> D["Done"]
+
+    S -.- S1["Discovers Gmail and Sheets tools"]:::annotation
+    M -.- M1["Fetches unread emails"]:::annotation
+    W -.- W1["Classifies, labels, and logs to sheet in parallel"]:::annotation
+
+    classDef annotation stroke-dasharray: 5 5
+```
+
+## What the sandbox provides
+
+### Built-in helpers
+
+These functions are pre-initialized in every sandbox:
+
+| Helper | What it does |
+|--------|-------------|
+| `run_composio_tool` | Execute any Composio tool (e.g., `GMAIL_SEND_EMAIL`, `SLACK_SEND_MESSAGE`) and get structured results |
+| `invoke_llm` | Call an LLM for classification, summarization, content generation, or data extraction |
+| `upload_local_file` | Upload generated files (reports, CSVs, images) to cloud storage and get a download URL |
+| `proxy_execute` | Make direct API calls to connected services when no pre-built tool exists |
+| `web_search` | Search the web and return results for research or data enrichment |
+| `smart_file_extract` | Extract text from PDFs, images, and other file formats in the sandbox |
+
+### Pre-installed libraries
+
+The sandbox has these libraries pre-installed:
+
+- **Data analysis**: pandas, numpy, matplotlib
+- **Image processing**: Pillow, OpenCV, scikit-image
+- **Machine learning**: PyTorch
+- **Document handling**: python-docx, pdfplumber, reportlab, pandoc
+- **Standard tools**: requests, json, csv, and the Python standard library
+
+### Persistent state
+
+The sandbox runs as a persistent Jupyter notebook. Variables, imports, files, and in-memory state from one call are available in the next.
+
+## Common patterns
+
+### Bulk operations across apps
+
+Some tasks touch hundreds of items across services. Say you need to triage 150 unread emails. The agent writes a workbench script: classify each email with `invoke_llm`, apply Gmail labels with `run_composio_tool`, and log results to a Google sheet.
+
+### Data analysis and reporting
+
+The agent can chain tools inside the sandbox. Fetch GitHub activity, aggregate with pandas, chart with matplotlib, summarize with `invoke_llm`, upload a PDF with `upload_local_file`.
+
+### Multi-step workflows
+
+The sandbox preserves variables and files across calls. The agent can paginate through records, transform them, and write to a destination over multiple calls.
+
+## Related
+
+<Cards>
+  <Card icon={<Blocks />} title="Tools and toolkits" href="/docs/tools-and-toolkits">
+    How meta tools discover, authenticate, and execute tools at runtime
+  </Card>
+  <Card icon={<BookOpen />} title="Browse toolkits" href="/toolkits">
+    Explore all available toolkits
+  </Card>
+</Cards>


### PR DESCRIPTION
## Summary
- Adds a dedicated concept page for the Workbench (`content/docs/workbench.mdx`) explaining the persistent Python sandbox, built-in helpers, pre-installed libraries, and common patterns
- Adds `workbench` to sidebar under Core Concepts after tools-and-toolkits
- Links to the workbench page from tools-and-toolkits (meta tools table + processing large results section) and users-and-sessions
- Includes a mermaid diagram showing where the workbench fits in the meta tools flow

## Test plan
- [x] `bun run build` passes
- [ ] Visual check on localhost: page renders, mermaid diagram displays, light/dark mode
- [ ] Sidebar shows Workbench under Core Concepts
- [ ] Links from tools-and-toolkits and users-and-sessions work

🤖 Generated with [Claude Code](https://claude.com/claude-code)