### PR TITLE
docs: add re-auth guidance for expired connections

### DIFF
--- a/docs/content/docs/common-faq.mdx
+++ b/docs/content/docs/common-faq.mdx
@@ -96,6 +96,24 @@ Pass a `callbackUrl` when calling `link()`, `initiate()`, or `session.authorize(
 You can include your own query parameters in the callback URL (e.g., `?user_id=user_123&source=onboarding`) to carry context through the flow. Composio preserves them. See [sessions](/docs/authenticating-users/manually-authenticating#redirecting-users-after-authentication) or [direct tool setup](/docs/tools-direct/authenticating-tools#redirecting-users-after-authentication).
 </Accordion>
 
+<Accordion title="How do I use my own API key for a toolkit instead of asking each user for theirs?">
+For toolkits that require API keys (like Tavily, Perplexity, or ImgBB), you can create connections on behalf of your users by passing your own API key through `connectedAccounts.initiate()`. This way, your users get access to the service without needing to provide their own credentials.
+
+Create an auth config for the toolkit, then call `initiate()` with your API key and each user's ID:
+
+```python
+connection = composio.connected_accounts.initiate(
+  user_id="user_123",
+  auth_config_id="your_auth_config_id",
+  config={
+    "auth_scheme": "API_KEY", "val": {"api_key": "your_own_api_key"}
+  }
+)
+```
+
+Each user gets their own connected account scoped to their `user_id`, but they all share your API key under the hood. See [API key connections](/docs/tools-direct/authenticating-tools#api-key-connections) for the full setup.
+</Accordion>
+
 <Accordion title="Can Composio be self-hosted?">
 Yes, Composio supports self-hosting on the Enterprise plan. See [pricing](https://composio.dev/pricing) for details or [talk to us](https://calendly.com/composiohq/enterprise).
 </Accordion>

--- a/docs/content/docs/common-faq.mdx
+++ b/docs/content/docs/common-faq.mdx
@@ -115,8 +115,10 @@ connection = composio.connected_accounts.initiate(
   </Tab>
   <Tab value="TypeScript">
 ```typescript
-import { AuthScheme } from '@composio/core';
+import { Composio, AuthScheme } from '@composio/core';
 
+declare const composio: Composio;
+// ---cut---
 const connection = await composio.connectedAccounts.initiate('user_123', 'your_auth_config_id', {
   config: AuthScheme.APIKey({
     api_key: 'your_own_api_key',

--- a/docs/content/docs/common-faq.mdx
+++ b/docs/content/docs/common-faq.mdx
@@ -101,6 +101,8 @@ For toolkits that require API keys (like Tavily, Perplexity, or ImgBB), you can 
 
 Create an auth config for the toolkit, then call `initiate()` with your API key and each user's ID:
 
+<Tabs groupId="language" items={['Python', 'TypeScript']} persist>
+  <Tab value="Python">
 ```python
 connection = composio.connected_accounts.initiate(
   user_id="user_123",
@@ -110,6 +112,19 @@ connection = composio.connected_accounts.initiate(
   }
 )
 ```
+  </Tab>
+  <Tab value="TypeScript">
+```typescript
+import { AuthScheme } from '@composio/core';
+
+const connection = await composio.connectedAccounts.initiate('user_123', 'your_auth_config_id', {
+  config: AuthScheme.APIKey({
+    api_key: 'your_own_api_key',
+  }),
+});
+```
+  </Tab>
+</Tabs>
 
 Each user gets their own connected account scoped to their `user_id`, but they all share your API key under the hood. See [API key connections](/docs/tools-direct/authenticating-tools#api-key-connections) for the full setup.
 </Accordion>

--- a/docs/content/docs/tools-direct/authenticating-tools.mdx
+++ b/docs/content/docs/tools-direct/authenticating-tools.mdx
@@ -410,7 +410,7 @@ After creating a connection, it will have one of the following statuses that ind
 |--------|---------------|------------|
 | **ACTIVE** | Connection is working. Tools can be executed. | Nothing — you're good. |
 | **INITIATED** | OAuth flow started but the user hasn't completed authentication yet. Auto-expires after 10 minutes. | Redirect the user to the Connect Link to finish authentication. |
-| **EXPIRED** | Credentials are no longer valid and Composio cannot refresh them automatically. See [common causes](#why-connections-expire) below. | [Subscribe to expiry events](/docs/subscribing-to-connection-expiry-events) to detect this proactively. |
+| **EXPIRED** | Credentials are no longer valid and Composio cannot refresh them automatically. See [common causes](#why-connections-expire) below. | [Subscribe to expiry events](/docs/subscribing-to-connection-expiry-events) to detect this proactively, and [re-authenticate the user](/docs/subscribing-to-connection-expiry-events#re-authenticate-the-user) to refresh the connection. |
 | **FAILED** | The authentication attempt did not succeed. Common causes: user denied consent during OAuth, invalid authorization code, or misconfigured auth config. | Check the `status_reason` field for details and retry the connection. |
 | **INACTIVE** | Manually disabled via the API. The connection is preserved but cannot be used to execute tools. | Re-enable it via the API or dashboard to restore access. |
 


### PR DESCRIPTION
## Summary
- Updated the connection status table to mention re-authenticating users as a fix for expired connections, alongside subscribing to expiry events

## Test plan
- [ ] Verify the table renders correctly on the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)