### PR TITLE
docs: make accordions linkable with auto-generated IDs

### DIFF
--- a/docs/app/global.css
+++ b/docs/app/global.css
@@ -526,7 +526,8 @@ p.text-fd-muted-foreground.not-prose:has(> code.text-xs) {
   opacity: 0;
   transition: opacity 150ms;
 }
-[data-accordion-value]:hover button[aria-label="Copy Link"] {
+[data-accordion-value]:hover button[aria-label="Copy Link"],
+[data-accordion-value]:focus-within button[aria-label="Copy Link"] {
   opacity: 1;
 }
 

--- a/docs/app/global.css
+++ b/docs/app/global.css
@@ -521,6 +521,15 @@ p.text-fd-muted-foreground.not-prose:has(> code.text-xs) {
   --color-fd-primary: var(--composio-orange);
 }
 
+/* Accordion copy-link button: hidden by default, visible on hover */
+[data-accordion-value] button[aria-label="Copy Link"] {
+  opacity: 0;
+  transition: opacity 150ms;
+}
+[data-accordion-value]:hover button[aria-label="Copy Link"] {
+  opacity: 1;
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/docs/app/global.css
+++ b/docs/app/global.css
@@ -530,6 +530,11 @@ p.text-fd-muted-foreground.not-prose:has(> code.text-xs) {
 [data-accordion-value]:focus-within button[aria-label="Copy Link"] {
   opacity: 1;
 }
+/* Green check feedback on copy (matches heading anchor style) */
+[data-accordion-value] button[aria-label="Copy Link"]:has(.lucide-check) {
+  opacity: 1;
+  color: var(--color-green-500);
+}
 
 @layer base {
   * {

--- a/docs/components/toolkits/auth-details-section.tsx
+++ b/docs/components/toolkits/auth-details-section.tsx
@@ -2,7 +2,8 @@
 
 import { Key } from 'lucide-react';
 import { TypeTable } from 'fumadocs-ui/components/type-table';
-import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
+import { Accordions } from 'fumadocs-ui/components/accordion';
+import { Accordion } from '@/mdx-components';
 import type { AuthConfigDetail, AuthConfigField } from '@/types/toolkit';
 
 interface AuthDetailsSectionProps {

--- a/docs/components/toolkits/auth-details-section.tsx
+++ b/docs/components/toolkits/auth-details-section.tsx
@@ -2,8 +2,7 @@
 
 import { Key } from 'lucide-react';
 import { TypeTable } from 'fumadocs-ui/components/type-table';
-import { Accordions } from 'fumadocs-ui/components/accordion';
-import { Accordion } from '@/mdx-components';
+import { Accordion, Accordions } from '@/mdx-components';
 import type { AuthConfigDetail, AuthConfigField } from '@/types/toolkit';
 
 interface AuthDetailsSectionProps {

--- a/docs/components/toolkits/faq-section.tsx
+++ b/docs/components/toolkits/faq-section.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { HelpCircle } from 'lucide-react';
-import { Accordions } from 'fumadocs-ui/components/accordion';
-import { Accordion } from '@/mdx-components';
+import { Accordion, Accordions } from '@/mdx-components';
 
 export interface FaqItem {
   question: string;

--- a/docs/components/toolkits/faq-section.tsx
+++ b/docs/components/toolkits/faq-section.tsx
@@ -23,7 +23,7 @@ export function FaqSection({ faq }: FaqSectionProps) {
       </h2>
       <Accordions type="single">
         {faq.map((item) => (
-          <Accordion key={item.question} title={item.question}>
+          <Accordion key={item.question} title={item.question} id={item.question.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '')}>
             <div
               className="prose prose-sm prose-fd max-w-none text-fd-muted-foreground"
               dangerouslySetInnerHTML={{ __html: item.answer }}

--- a/docs/components/toolkits/faq-section.tsx
+++ b/docs/components/toolkits/faq-section.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { HelpCircle } from 'lucide-react';
-import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
-import { slugify } from '@/lib/utils';
+import { Accordions } from 'fumadocs-ui/components/accordion';
+import { Accordion } from '@/mdx-components';
 
 export interface FaqItem {
   question: string;
@@ -24,7 +24,7 @@ export function FaqSection({ faq }: FaqSectionProps) {
       </h2>
       <Accordions type="single">
         {faq.map((item) => (
-          <Accordion key={item.question} title={item.question} id={slugify(item.question)}>
+          <Accordion key={item.question} title={item.question}>
             <div
               className="prose prose-sm prose-fd max-w-none text-fd-muted-foreground"
               dangerouslySetInnerHTML={{ __html: item.answer }}

--- a/docs/components/toolkits/faq-section.tsx
+++ b/docs/components/toolkits/faq-section.tsx
@@ -2,6 +2,7 @@
 
 import { HelpCircle } from 'lucide-react';
 import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
+import { slugify } from '@/lib/utils';
 
 export interface FaqItem {
   question: string;
@@ -23,7 +24,7 @@ export function FaqSection({ faq }: FaqSectionProps) {
       </h2>
       <Accordions type="single">
         {faq.map((item) => (
-          <Accordion key={item.question} title={item.question} id={item.question.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '')}>
+          <Accordion key={item.question} title={item.question} id={slugify(item.question)}>
             <div
               className="prose prose-sm prose-fd max-w-none text-fd-muted-foreground"
               dangerouslySetInnerHTML={{ __html: item.answer }}

--- a/docs/lib/utils.ts
+++ b/docs/lib/utils.ts
@@ -4,7 +4,3 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
-
-export function slugify(text: string): string {
-  return text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
-}

--- a/docs/lib/utils.ts
+++ b/docs/lib/utils.ts
@@ -4,3 +4,7 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function slugify(text: string): string {
+  return text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+}

--- a/docs/mdx-components.tsx
+++ b/docs/mdx-components.tsx
@@ -3,7 +3,8 @@ import type { MDXComponents } from 'mdx/types';
 import { Heading } from '@/components/heading';
 import { YouTube } from '@/components/youtube';
 import { Tabs, Tab, TabsList, TabsTrigger, TabsContent } from 'fumadocs-ui/components/tabs';
-import { Accordion as BaseAccordion, Accordions } from 'fumadocs-ui/components/accordion';
+import { Accordion as BaseAccordion, Accordions as BaseAccordions } from 'fumadocs-ui/components/accordion';
+export { BaseAccordions as Accordions };
 import type { ComponentProps } from 'react';
 function slugify(text: string): string {
   return text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
@@ -56,7 +57,7 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     TabsTrigger,
     TabsContent,
     Accordion,
-    Accordions,
+    Accordions: BaseAccordions,
     Callout,
     Step,
     Steps,

--- a/docs/mdx-components.tsx
+++ b/docs/mdx-components.tsx
@@ -1,18 +1,14 @@
 import defaultMdxComponents from 'fumadocs-ui/mdx';
 import type { MDXComponents } from 'mdx/types';
-import { Heading } from '@/components/heading';
-import { YouTube } from '@/components/youtube';
-import { Tabs, Tab, TabsList, TabsTrigger, TabsContent } from 'fumadocs-ui/components/tabs';
-import { Accordion as BaseAccordion, Accordions as BaseAccordions } from 'fumadocs-ui/components/accordion';
-export { BaseAccordions as Accordions };
 import type { ComponentProps } from 'react';
-function slugify(text: string): string {
-  return text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
-}
+import { Accordion as BaseAccordion, Accordions } from 'fumadocs-ui/components/accordion';
+import { Tabs, Tab, TabsList, TabsTrigger, TabsContent } from 'fumadocs-ui/components/tabs';
 import { Callout } from 'fumadocs-ui/components/callout';
 import { Step, Steps } from 'fumadocs-ui/components/steps';
 import { Card, Cards } from 'fumadocs-ui/components/card';
 import { ImageZoom } from 'fumadocs-ui/components/image-zoom';
+import { Heading } from '@/components/heading';
+import { YouTube } from '@/components/youtube';
 import { ProviderCard, ProviderGrid } from '@/components/provider-card';
 import { FrameworkSelector, QuickstartFlow, FrameworkOption } from '@/components/quickstart';
 import { IntegrationTabs, IntegrationContent } from '@/components/quickstart/integration-tabs';
@@ -23,8 +19,9 @@ import { Video } from '@/components/video';
 import { CapabilityCard, CapabilityList } from '@/components/capability-card';
 import { ToolkitsLanding } from '@/components/toolkits/toolkits-landing';
 import { Mermaid } from '@/components/mermaid';
-import { ShieldCheck, Route as RouteIcon } from 'lucide-react';
 import {
+  ShieldCheck,
+  Route as RouteIcon,
   Key,
   Wrench,
   Database,
@@ -39,9 +36,15 @@ import {
   BookOpen,
 } from 'lucide-react';
 
+function slugify(text: string): string {
+  return text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+}
+
 export function Accordion({ id, title, ...props }: ComponentProps<typeof BaseAccordion>) {
   return <BaseAccordion id={id ?? (typeof title === 'string' ? slugify(title) : undefined)} title={title} {...props} />;
 }
+
+export { Accordions };
 
 export function getMDXComponents(components?: MDXComponents): MDXComponents {
   return {
@@ -57,7 +60,7 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     TabsTrigger,
     TabsContent,
     Accordion,
-    Accordions: BaseAccordions,
+    Accordions,
     Callout,
     Step,
     Steps,
@@ -79,7 +82,7 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     ToolkitsLanding,
     Mermaid,
     StepTitle,
-    // Lucide icons - available globally in MDX without imports
+    // Lucide icons
     ShieldCheck,
     RouteIcon,
     Key,

--- a/docs/mdx-components.tsx
+++ b/docs/mdx-components.tsx
@@ -1,10 +1,13 @@
 import defaultMdxComponents from 'fumadocs-ui/mdx';
 import type { MDXComponents } from 'mdx/types';
-import type { ComponentProps } from 'react';
 import { Heading } from '@/components/heading';
 import { YouTube } from '@/components/youtube';
 import { Tabs, Tab, TabsList, TabsTrigger, TabsContent } from 'fumadocs-ui/components/tabs';
 import { Accordion as BaseAccordion, Accordions } from 'fumadocs-ui/components/accordion';
+import type { ComponentProps } from 'react';
+function slugify(text: string): string {
+  return text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+}
 import { Callout } from 'fumadocs-ui/components/callout';
 import { Step, Steps } from 'fumadocs-ui/components/steps';
 import { Card, Cards } from 'fumadocs-ui/components/card';
@@ -19,7 +22,6 @@ import { Video } from '@/components/video';
 import { CapabilityCard, CapabilityList } from '@/components/capability-card';
 import { ToolkitsLanding } from '@/components/toolkits/toolkits-landing';
 import { Mermaid } from '@/components/mermaid';
-import { slugify } from '@/lib/utils';
 import { ShieldCheck, Route as RouteIcon } from 'lucide-react';
 import {
   Key,
@@ -36,7 +38,7 @@ import {
   BookOpen,
 } from 'lucide-react';
 
-function Accordion({ id, title, ...props }: ComponentProps<typeof BaseAccordion>) {
+export function Accordion({ id, title, ...props }: ComponentProps<typeof BaseAccordion>) {
   return <BaseAccordion id={id ?? (typeof title === 'string' ? slugify(title) : undefined)} title={title} {...props} />;
 }
 

--- a/docs/mdx-components.tsx
+++ b/docs/mdx-components.tsx
@@ -3,7 +3,16 @@ import type { MDXComponents } from 'mdx/types';
 import { Heading } from '@/components/heading';
 import { YouTube } from '@/components/youtube';
 import { Tabs, Tab, TabsList, TabsTrigger, TabsContent } from 'fumadocs-ui/components/tabs';
-import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
+import { Accordion as BaseAccordion, Accordions } from 'fumadocs-ui/components/accordion';
+import type { ComponentProps } from 'react';
+
+function slugify(text: string): string {
+  return text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+}
+
+function Accordion({ id, title, ...props }: ComponentProps<typeof BaseAccordion>) {
+  return <BaseAccordion id={id ?? (typeof title === 'string' ? slugify(title) : undefined)} title={title} {...props} />;
+}
 import { Callout } from 'fumadocs-ui/components/callout';
 import { Step, Steps } from 'fumadocs-ui/components/steps';
 import { Card, Cards } from 'fumadocs-ui/components/card';

--- a/docs/mdx-components.tsx
+++ b/docs/mdx-components.tsx
@@ -1,18 +1,10 @@
 import defaultMdxComponents from 'fumadocs-ui/mdx';
 import type { MDXComponents } from 'mdx/types';
+import type { ComponentProps } from 'react';
 import { Heading } from '@/components/heading';
 import { YouTube } from '@/components/youtube';
 import { Tabs, Tab, TabsList, TabsTrigger, TabsContent } from 'fumadocs-ui/components/tabs';
 import { Accordion as BaseAccordion, Accordions } from 'fumadocs-ui/components/accordion';
-import type { ComponentProps } from 'react';
-
-function slugify(text: string): string {
-  return text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
-}
-
-function Accordion({ id, title, ...props }: ComponentProps<typeof BaseAccordion>) {
-  return <BaseAccordion id={id ?? (typeof title === 'string' ? slugify(title) : undefined)} title={title} {...props} />;
-}
 import { Callout } from 'fumadocs-ui/components/callout';
 import { Step, Steps } from 'fumadocs-ui/components/steps';
 import { Card, Cards } from 'fumadocs-ui/components/card';
@@ -27,6 +19,7 @@ import { Video } from '@/components/video';
 import { CapabilityCard, CapabilityList } from '@/components/capability-card';
 import { ToolkitsLanding } from '@/components/toolkits/toolkits-landing';
 import { Mermaid } from '@/components/mermaid';
+import { slugify } from '@/lib/utils';
 import { ShieldCheck, Route as RouteIcon } from 'lucide-react';
 import {
   Key,
@@ -42,6 +35,10 @@ import {
   Palette,
   BookOpen,
 } from 'lucide-react';
+
+function Accordion({ id, title, ...props }: ComponentProps<typeof BaseAccordion>) {
+  return <BaseAccordion id={id ?? (typeof title === 'string' ? slugify(title) : undefined)} title={title} {...props} />;
+}
 
 export function getMDXComponents(components?: MDXComponents): MDXComponents {
   return {


### PR DESCRIPTION
## Summary
- Wraps the fumadocs `Accordion` component to auto-generate an `id` from the title, making every accordion deep-linkable via URL hash (e.g., `/docs/common-faq#what-is-an-auth-config`)
- Adds CSS to hide the copy-link icon by default and show it on hover, matching heading anchor behavior
- Also applies auto-generated IDs to the dynamic `FaqSection` component used on toolkit pages

## Test plan
- [ ] `bun run build` passes
- [ ] Visit any page with accordions, hover an accordion title to see the link icon
- [ ] Click link icon, verify URL hash is copied
- [ ] Navigate to a page with `#accordion-id` hash, verify accordion auto-opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)