### PR TITLE
docs: fix webhook secret instructions

### DIFF
--- a/docs/content/docs/setting-up-triggers/subscribing-to-events.mdx
+++ b/docs/content/docs/setting-up-triggers/subscribing-to-events.mdx
@@ -25,6 +25,10 @@ curl -X POST https://backend.composio.dev/api/v3/webhook_subscriptions \
   }'
 ```
 
+<Callout type="warn">
+The response includes a `secret` for [verifying webhook signatures](/docs/webhook-verification). This is only returned at creation time or when you [rotate the secret](/reference/api-reference/webhooks/rotate-webhook-subscription-secret). Store it securely.
+</Callout>
+
 ### Handling events
 
 All events arrive at the same endpoint. Route on the `type` field to handle each event type:

--- a/docs/content/docs/webhook-verification.mdx
+++ b/docs/content/docs/webhook-verification.mdx
@@ -11,7 +11,7 @@ Composio signs every webhook request. Always verify signatures in production to 
 The SDK handles signature verification, payload parsing, and version detection (V1, V2, V3).
 
 <Callout>
-Get your webhook secret from [Project Settings > Webhook](https://platform.composio.dev?next_page=/settings/webhook) and store it as `COMPOSIO_WEBHOOK_SECRET`.
+Your webhook secret is returned **only once**: when you [create a webhook subscription](/reference/api-reference/webhooks/create-webhook-subscription) or [rotate the secret](/reference/api-reference/webhooks/rotate-webhook-subscription-secret). If you didn't copy it at creation time, rotate it to get a new one. Store it securely as `COMPOSIO_WEBHOOK_SECRET`.
 </Callout>
 
 <Tabs groupId="language" items={['Python', 'TypeScript']} persist>
@@ -61,7 +61,7 @@ An optional `tolerance` parameter (default: `300` seconds) controls how old a we
 If you are not using the Composio SDK and want to verify signatures manually.
 
 <Callout>
-Get your webhook secret from [Project Settings > Webhook](https://platform.composio.dev?next_page=/settings/webhook) and store it as `COMPOSIO_WEBHOOK_SECRET`.
+Your webhook secret is returned **only once**: when you [create a webhook subscription](/reference/api-reference/webhooks/create-webhook-subscription) or [rotate the secret](/reference/api-reference/webhooks/rotate-webhook-subscription-secret). If you didn't copy it at creation time, rotate it to get a new one. Store it securely as `COMPOSIO_WEBHOOK_SECRET`.
 </Callout>
 
 Every webhook request includes three headers: `webhook-signature`, `webhook-id`, and `webhook-timestamp`. Use these along with the raw request body to verify the signature:


### PR DESCRIPTION
## Summary
- Updated webhook verification docs to stop pointing users to "Project Settings > Webhook" for their secret (that's the deprecated flow)
- Both callouts in `webhook-verification.mdx` now explain the secret is only returned at creation or rotation, with links to the relevant API endpoints
- Added a callout in `subscribing-to-events.mdx` warning users to store the secret from the create subscription response

## Test plan
- [ ] Verify links to `/reference/api-reference/webhooks/create-webhook-subscription` and `/reference/api-reference/webhooks/rotate-webhook-subscription-secret` resolve correctly
- [ ] `bun run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)