### PR TITLE
docs: add trust center link to FAQ

### DIFF
--- a/docs/content/docs/common-faq.mdx
+++ b/docs/content/docs/common-faq.mdx
@@ -131,6 +131,10 @@ const connection = await composio.connectedAccounts.initiate('user_123', 'your_a
 Each user gets their own connected account scoped to their `user_id`, but they all share your API key under the hood. See [API key connections](/docs/tools-direct/authenticating-tools#api-key-connections) for the full setup.
 </Accordion>
 
+<Accordion title="Is Composio secure? Where can I find compliance details?">
+Yes. Composio is SOC 2 Type II compliant and follows industry-standard security practices for data handling, encryption, and access control. Visit the [Composio Trust Center](https://trust.composio.dev/) for detailed compliance reports, security policies, and certifications.
+</Accordion>
+
 <Accordion title="Can Composio be self-hosted?">
 Yes, Composio supports self-hosting on the Enterprise plan. See [pricing](https://composio.dev/pricing) for details or [talk to us](https://calendly.com/composiohq/enterprise).
 </Accordion>


### PR DESCRIPTION
## Summary
- Adds a new FAQ entry "Is Composio secure?" linking to the [Trust Center](https://trust.composio.dev/)
- Addresses [PLEN-1569](https://linear.app/composio/issue/PLEN-1569/docshackathon-feedback-add-security-and-privacy-trust-page) (partially)

## Test plan
- [ ] Verify FAQ renders correctly on dev server
- [ ] Confirm trust center link resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)