### PR TITLE
docs: Add common queries to troubleshooting page

### DIFF
--- a/docs/content/docs/troubleshooting/index.mdx
+++ b/docs/content/docs/troubleshooting/index.mdx
@@ -7,7 +7,49 @@ import { Bug, Brain, Sparkles, MessageCircle, MessageSquare, BookOpen, Mail, Ale
 
 This section is designed to help you quickly identify and resolve common issues encountered with Composio.
 
-Some quick links:
+## Common queries
+
+<Accordions>
+
+<Accordion title="How do I find the log ID for a failed tool execution?">
+Every tool execution response includes a `log_id` field. You can also find it in the [dashboard logs](https://platform.composio.dev?next_page=/logs/tools) under **Logs > Tools**. Use this ID when reporting issues to support.
+
+See [Troubleshooting tools](/docs/troubleshooting/tools#reporting-tool-issues) for more details.
+</Accordion>
+
+<Accordion title="How do I find my auth config ID or connected account ID?">
+Go to the [dashboard](https://platform.composio.dev) and navigate to **Auth Configs** for your auth config ID, or **Connected Accounts** for the connected account ID. Both IDs are visible in the detail view of each entry.
+
+See [Troubleshooting authentication](/docs/troubleshooting/authentication#reporting-authentication-issues) for screenshots.
+</Accordion>
+
+<Accordion title="How do I find my MCP server ID?">
+Your MCP server ID is the UUID in the server URL (e.g., `https://backend.composio.dev/v3/mcp/<UUID>/mcp`). You can also find it in the [dashboard](https://platform.composio.dev) under your MCP server's detail page.
+
+See [Troubleshooting MCP](/docs/troubleshooting/mcp#reporting-mcp-issues) for a visual guide.
+</Accordion>
+
+<Accordion title="How do I get the request ID for API debugging?">
+Add an `x-request-id` header with a UUID to your API request. This lets support trace your exact request in server logs.
+
+```bash
+curl 'https://backend.composio.dev/api/v3/tools' \
+  -H 'x-api-key: YOUR_API_KEY' \
+  -H 'x-request-id: YOUR_UUID_HERE'
+```
+
+Generate a UUID at [uuidgenerator.net](https://www.uuidgenerator.net/). See [Troubleshooting API](/docs/troubleshooting/api#reporting-api-issues).
+</Accordion>
+
+<Accordion title="How do I find the trigger ID for a trigger instance?">
+Go to the [dashboard](https://platform.composio.dev) and navigate to **Active Triggers**. The trigger ID is shown for each trigger instance.
+
+See [Troubleshooting triggers](/docs/troubleshooting/triggers#reporting-issues) for a screenshot.
+</Accordion>
+
+</Accordions>
+
+## Quick links
 
 <Cards>
   <Card title="Errors Reference" href="/reference/errors" icon={<AlertCircle />}>

--- a/docs/content/docs/troubleshooting/meta.json
+++ b/docs/content/docs/troubleshooting/meta.json
@@ -1,7 +1,6 @@
 {
   "title": "Troubleshooting",
   "pages": [
-    "index",
     "api",
     "authentication",
     "cli",


### PR DESCRIPTION
## Summary
- Adds a "Common queries" accordion section to the troubleshooting landing page with how-tos for finding log IDs, auth config IDs, MCP server IDs, request IDs, and trigger IDs
- Fixes duplicate "Troubleshooting" sidebar entry by removing `"index"` from `meta.json`
- Renames "Some quick links" to "Quick links"

Closes PLEN-459

## Test plan
- [ ] Verify troubleshooting page renders correctly with accordions
- [ ] Verify sidebar no longer shows duplicate "Troubleshooting" entry
- [ ] Verify all links in accordion answers resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)