### PR TITLE
fix(cli): repair binary installation pipeline and harden release process

### DIFF
--- a/.github/scripts/check-action-repos.sh
+++ b/.github/scripts/check-action-repos.sh
@@ -111,8 +111,6 @@ check_remote() {
 }
 
 for u in "${USES[@]}"; do
-  # Ignore reusable workflows here: they also use `uses:` but are `./.github/workflows/x.yml` or `owner/repo/.github/workflows/x.yml@ref`
-  # If you want to validate those too, add logic similar to check_local/check_remote for workflow files.
   if [[ "$u" == docker://* ]]; then
     echo "SKIP (docker image): $u"
     continue
@@ -131,5 +129,30 @@ for u in "${USES[@]}"; do
 
   echo "WARN: unrecognized uses format: $u"
 done
+
+# Validate reusable workflow references (job-level `uses:`)
+mapfile -t WORKFLOW_REFS < <(
+  yq -r '
+    .jobs[]? |
+    select(has("uses")) |
+    .uses
+  ' .github/workflows/*.yml .github/workflows/*.yaml 2>/dev/null \
+  | sed '/^null$/d' \
+  | sort -u
+)
+
+if [[ ${#WORKFLOW_REFS[@]} -gt 0 ]]; then
+  echo ""
+  echo "Found ${#WORKFLOW_REFS[@]} unique reusable workflow references"
+
+  for ref in "${WORKFLOW_REFS[@]}"; do
+    if [[ "$ref" == ./.github/workflows/* ]]; then
+      if [[ ! -f "$ref" ]]; then
+        echo "ERROR: reusable workflow file does not exist: $ref"
+        fail=1
+      fi
+    fi
+  done
+fi
 
 exit $fail

--- a/.github/workflows/build-cli-binaries.yml
+++ b/.github/workflows/build-cli-binaries.yml
@@ -112,7 +112,7 @@ jobs:
     name: Test Installation
     needs: build-binaries
     if: always() && !cancelled() && (startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch')
-    uses: ./.github/workflows/test-installation.yml
+    uses: ./.github/workflows/cli.test-installation.yml
     with:
       version: ${{ inputs.version || github.ref_name }}
 

--- a/.github/workflows/build-cli-binaries.yml
+++ b/.github/workflows/build-cli-binaries.yml
@@ -3,11 +3,11 @@ name: Build CLI Binaries
 on:
   push:
     tags:
-      - 'v*'
+      - 'cli-v*'
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to build (e.g., v1.0.0)'
+        description: 'Version to build (e.g., cli-v0.1.25)'
         required: false
         default: 'dev'
 
@@ -93,25 +93,78 @@ jobs:
             ts/packages/cli/dist/binaries/${{ matrix.artifact }}.zip
           retention-days: 7
 
-      - name: Create Release
+      - name: Upload to draft release
         if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}
-          name: ${{ github.event_name == 'workflow_dispatch' && format('CLI {0} (Manual Build)', inputs.version) || github.ref_name }}
+          name: ${{ github.event_name == 'workflow_dispatch' && format('CLI {0} (Manual Build)', inputs.version) || format('CLI {0}', github.ref_name) }}
           files: |
             ts/packages/cli/dist/binaries/${{ matrix.artifact }}.zip
-          draft: false
-          prerelease: ${{ github.event_name == 'workflow_dispatch' || contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
+          draft: true
+          prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
           generate_release_notes: true
-          make_latest: ${{ github.event_name != 'workflow_dispatch' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  validate-and-publish:
+    name: Validate Assets & Publish Release
+    needs: build-binaries
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+
+    env:
+      TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}
+
+    steps:
+      - name: Validate all platform assets are present
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Checking release assets for $TAG..."
+
+          EXPECTED_ASSETS=(
+            "composio-linux-x64.zip"
+            "composio-linux-aarch64.zip"
+            "composio-darwin-x64.zip"
+            "composio-darwin-aarch64.zip"
+          )
+
+          ACTUAL_ASSETS=$(gh release view "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json assets --jq '.assets[].name')
+
+          MISSING=0
+          for expected in "${EXPECTED_ASSETS[@]}"; do
+            if echo "$ACTUAL_ASSETS" | grep -qF "$expected"; then
+              echo "OK: $expected"
+            else
+              echo "MISSING: $expected"
+              MISSING=1
+            fi
+          done
+
+          if [ "$MISSING" -eq 1 ]; then
+            echo "::error::Release $TAG is incomplete. Not publishing."
+            exit 1
+          fi
+
+          echo "All expected assets present."
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release edit "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --draft=false \
+            --latest
+          echo "Release $TAG published successfully"
+
   test-installation:
     name: Test Installation
-    needs: build-binaries
-    if: always() && !cancelled() && (startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch')
+    needs: validate-and-publish
+    if: always() && !cancelled() && needs.validate-and-publish.result == 'success'
     uses: ./.github/workflows/cli.test-installation.yml
     with:
       version: ${{ inputs.version || github.ref_name }}
@@ -169,7 +222,7 @@ jobs:
           ## Supported Platforms
 
           - Linux x64
-          - Linux ARM64  
+          - Linux ARM64
           - macOS x64 (Intel)
           - macOS ARM64 (Apple Silicon)
 

--- a/.github/workflows/build-cli-binaries.yml
+++ b/.github/workflows/build-cli-binaries.yml
@@ -24,10 +24,10 @@ jobs:
           - runner: ubuntu-latest
             platform: linux-x64
             artifact: composio-linux-x64
-          - runner: depot-ubuntu-24.04-arm
+          - runner: ubuntu-24.04-arm
             platform: linux-aarch64
             artifact: composio-linux-aarch64
-          - runner: macos-13 # Intel Mac
+          - runner: macos-15-intel # Intel Mac
             platform: darwin-x64
             artifact: composio-darwin-x64
           - runner: macos-latest # Apple Silicon Mac

--- a/.github/workflows/cli.test-installation.yml
+++ b/.github/workflows/cli.test-installation.yml
@@ -3,11 +3,11 @@ name: Test Installation
 on:
   push:
     tags:
-      - 'v*'
+      - 'cli-v*'
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to test (e.g., v1.0.0)'
+        description: 'Version to test (e.g., cli-v0.1.25)'
         required: false
         default: 'latest'
   workflow_call:

--- a/.github/workflows/cli.test-installation.yml
+++ b/.github/workflows/cli.test-installation.yml
@@ -37,22 +37,22 @@ jobs:
             name: 'Ubuntu Latest x64'
             shell: bash
 
-          # Ubuntu ARM64 versions (using Depot)
-          - os: depot-ubuntu-24.04-arm
+          # Ubuntu ARM64 versions
+          - os: ubuntu-24.04-arm
             name: 'Ubuntu 24.04 ARM64'
             shell: bash
-          - os: depot-ubuntu-22.04-arm
+          - os: ubuntu-22.04-arm
             name: 'Ubuntu 22.04 ARM64'
             shell: bash
-          - os: depot-ubuntu-22.04-arm
+          - os: ubuntu-22.04-arm
             name: 'Ubuntu 22.04 ARM64 (zsh)'
             shell: zsh
 
           # macOS versions
-          - os: macos-13
+          - os: macos-15-intel
             name: 'macOS 13 (Ventura)'
             shell: bash
-          - os: macos-13
+          - os: macos-15-intel
             name: 'macOS 13 (zsh)'
             shell: zsh
           - os: macos-14
@@ -348,10 +348,10 @@ jobs:
           - os: ubuntu-latest
             arch: x64
             expected: 'Linux x64'
-          - os: depot-ubuntu-24.04-arm
+          - os: ubuntu-24.04-arm
             arch: arm64
             expected: 'Linux ARM64'
-          - os: macos-13
+          - os: macos-15-intel
             arch: x64
             expected: 'macOS x64'
           - os: macos-latest

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,15 @@
+name: Lint Workflows
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run actionlint
+        uses: rhysd/action-actionlint@v1

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -12,4 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run actionlint
-        uses: rhysd/action-actionlint@v1
+        uses: docker://rhysd/actionlint:latest
+        with:
+          args: -color

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -11,7 +11,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Collect changed workflow files
+        id: changed
+        run: |
+          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+
+          files=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" -- \
+            '.github/workflows/*.yml' \
+            '.github/workflows/*.yaml' \
+            '.github/actions/**/action.yml' \
+            '.github/actions/**/action.yaml')
+
+          files="${files//$'\n'/ }"
+          echo "files=$files" >> "$GITHUB_OUTPUT"
+
       - name: Run actionlint
+        if: steps.changed.outputs.files != ''
         uses: docker://rhysd/actionlint:latest
         with:
-          args: -color
+          args: -color -shellcheck= ${{ steps.changed.outputs.files }}
+
+      - name: No changed workflow files
+        if: steps.changed.outputs.files == ''
+        run: echo "No workflow/action changes detected. Skipping actionlint."

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,15 +11,16 @@ curl -fsSL https://raw.githubusercontent.com/ComposioHQ/composio/main/install.sh
 
 ### Install specific version
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ComposioHQ/composio/main/install.sh | bash -s -- v0.1.24
+curl -fsSL https://raw.githubusercontent.com/ComposioHQ/composio/main/install.sh | bash -s -- cli-v0.1.25
 ```
 
 ### What the install script does:
 - Detects your platform and architecture automatically
-- Downloads the appropriate binary from GitHub releases
-- Installs to `~/.composio/bin/composio`
+- Queries GitHub Releases API for the latest CLI release with matching binary assets
+- Downloads the appropriate binary (falls back to previous releases if latest is incomplete)
+- Installs to `~/.composio/composio`
 - Updates your shell configuration (.bashrc, .zshrc, or .config/fish/config.fish)
-- Adds the binary to your PATH
+- Adds the install directory to your PATH
 
 ## Manual Installation
 
@@ -110,7 +111,7 @@ composio --help
 ### Permission Denied
 If you get permission errors:
 ```bash
-chmod +x ~/.composio/bin/composio
+chmod +x ~/.composio/composio
 ```
 
 ### Command Not Found
@@ -135,12 +136,12 @@ If `composio` is not found after installation:
 
 3. **Check if the binary exists:**
    ```bash
-   ls -la ~/.composio/bin/composio
+   ls -la ~/.composio/composio
    ```
 
 4. **Manually add to PATH:**
    ```bash
-   export PATH="$HOME/.composio/bin:$PATH"
+   export PATH="$HOME/.composio:$PATH"
    ```
 
 ### Download Failures
@@ -175,22 +176,29 @@ rm -rf ~/.composio
 # Remove from shell configuration
 # Edit ~/.bashrc, ~/.zshrc, or ~/.config/fish/config.fish
 # and remove the lines that were added by the installer:
-# export COMPOSIO_INSTALL="$HOME/.composio"
-# export PATH="$COMPOSIO_INSTALL/bin:$PATH"
+# export COMPOSIO_INSTALL_DIR="$HOME/.composio"
+# export PATH="$COMPOSIO_INSTALL_DIR:$PATH"
 ```
 
 ## Environment Variables
 
 The installer respects these environment variables:
 
-- `COMPOSIO_INSTALL` - Installation directory (default: `~/.composio`)
-- `GITHUB` - GitHub base URL (default: `https://github.com`)
+- `COMPOSIO_INSTALL_DIR` - Installation directory (default: `~/.composio`)
+- `COMPOSIO_GITHUB_URL` - GitHub base URL (default: `https://github.com`)
+- `COMPOSIO_GITHUB_OWNER` - Repository owner (default: `ComposioHQ`)
+- `COMPOSIO_GITHUB_REPO` - Repository name (default: `composio`)
+- `COMPOSIO_GITHUB_API` - GitHub API base URL (default: `https://api.github.com`)
 
 Example:
 ```bash
-export COMPOSIO_INSTALL="/usr/local"
+export COMPOSIO_INSTALL_DIR="/usr/local"
 curl -fsSL https://raw.githubusercontent.com/ComposioHQ/composio/main/install.sh | bash
 ```
+
+## Release Channels
+
+CLI binary releases use `cli-v*` tags (e.g., `cli-v0.1.25`), separate from SDK package releases which use `v*` tags. The installer automatically selects the latest CLI release with matching platform assets. See [CLI Release Policy](docs/cli-release-policy.md) for details.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ console.log(JSON.stringify(result.finalOutput, null, 2));
 // will return the response from the agent with data from HACKERNEWS API.
 ```
 
+### CLI Binary Installation
+
+Install the standalone CLI binary (no Node.js required):
+
+```bash
+curl -fsSL https://composio.dev/install | bash
+```
+
+See [CLI Release Policy](docs/cli-release-policy.md) for details on release channels and supported platforms.
+
 ### Python SDK Installation
 
 ```bash

--- a/docs/cli-release-policy.md
+++ b/docs/cli-release-policy.md
@@ -1,0 +1,52 @@
+# CLI Binary Release Policy
+
+This document defines what makes a Composio CLI binary release installable via `curl -fsSL https://composio.dev/install | bash`.
+
+## Release Tags
+
+CLI binary releases use a dedicated tag namespace to decouple from SDK package releases:
+
+| Tag pattern | Purpose | Example |
+|---|---|---|
+| `cli-v*` | CLI binary releases | `cli-v0.1.25` |
+| `@composio/core@*` | TypeScript SDK packages (npm) | `@composio/core@0.6.3` |
+| `v*` | Legacy SDK version tags | `v0.11.1` |
+
+Only `cli-v*` tagged releases are considered for CLI binary installation.
+
+## Required Assets
+
+A CLI release is considered **complete** when all four platform binaries are present:
+
+| Asset | Platform |
+|---|---|
+| `composio-linux-x64.zip` | Linux x86_64 |
+| `composio-linux-aarch64.zip` | Linux ARM64 |
+| `composio-darwin-x64.zip` | macOS Intel |
+| `composio-darwin-aarch64.zip` | macOS Apple Silicon |
+
+## "Latest" Criteria
+
+The installer selects the most recent `cli-v*` release that:
+
+1. Is not a draft
+2. Is not a prerelease
+3. Contains the matching `composio-{target}.zip` asset for the user's platform
+
+If the newest release is missing assets, the installer falls back to the next most recent release that satisfies all criteria.
+
+## Build Workflow
+
+CLI binaries are built by `.github/workflows/build-cli-binaries.yml`:
+
+- **Trigger:** Push to `cli-v*` tags, or manual `workflow_dispatch`
+- **Process:** Builds on 4 platform matrix, creates draft release, validates all assets present, then publishes
+- **Testing:** `.github/workflows/cli.test-installation.yml` runs the installer across 11+ OS/shell combinations after binaries are uploaded
+
+## Manual Backfill
+
+To rebuild binaries for an existing release:
+
+```bash
+gh workflow run build-cli-binaries.yml -f version=cli-v0.1.25
+```

--- a/install.sh
+++ b/install.sh
@@ -63,7 +63,7 @@ command -v curl >/dev/null ||
     error 'curl is required to install Composio CLI'
 
 if [[ $# -gt 1 ]]; then
-    error 'Too many arguments, only 1 is allowed. You can specify a specific version to install. (e.g. "v0.1.24")'
+    error 'Too many arguments, only 1 is allowed. You can specify a version to install. (e.g. "cli-v0.1.25" or "v0.1.25")'
 fi
 
 # Determine platform and architecture
@@ -108,40 +108,56 @@ github_repo="$COMPOSIO_GITHUB_URL/$COMPOSIO_GITHUB_OWNER/$COMPOSIO_GITHUB_REPO"
 
 exe_name=composio
 
+COMPOSIO_GITHUB_API=${COMPOSIO_GITHUB_API-"https://api.github.com"}
+releases_api="$COMPOSIO_GITHUB_API/repos/$COMPOSIO_GITHUB_OWNER/$COMPOSIO_GITHUB_REPO/releases"
+asset_name="composio-$target.zip"
+
+# Check if a release asset exists via HTTP HEAD
+check_asset() {
+    local tag="$1"
+    local uri="$github_repo/releases/download/$tag/$asset_name"
+    local status
+    status=$(curl -sL -o /dev/null -w "%{http_code}" --head "$uri" 2>/dev/null) || true
+    [[ "$status" = "200" || "$status" = "302" ]]
+}
+
 # Determine version to install
 if [[ $# = 0 ]]; then
-    info "Finding latest CLI release..."
-    
-    # Get the latest version tag using OS-specific grep patterns
-    case $platform in
-    'Darwin'*)
-        # BSD/MacOS: Use extended regex with -E
-        version=$(git ls-remote --tags "$github_repo" \
-            | awk -F'/' '{print $3}' \
-            | grep -E "^v\d+\.\d+\.\d+.*" \
-            | sort -V \
-            | tail -n1)
-        ;;
-    *)
-        # Unix/Linux: Use Perl-compatible regex with -P
-        version=$(git ls-remote --tags "$github_repo" \
-            | awk -F'/' '{print $3}' \
-            | grep -P "^v\d+\.\d+\.\d+.*" \
-            | sort -V \
-            | tail -n1)
-        ;;
-    esac
-    
-    if [[ -z "$version" ]]; then
-        error "Failed to determine the latest version. Please specify a version manually."
+    info "Finding latest CLI release with $asset_name..."
+
+    # Query GitHub Releases API for recent releases
+    # Try cli-v* releases first, then fall back to v* for backwards compatibility
+    release_tags=$(curl -sL "$releases_api?per_page=20" \
+        | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p') || true
+
+    if [[ -z "$release_tags" ]]; then
+        error "Failed to query GitHub Releases API. Please specify a version manually."
     fi
-    
+
+    version=""
+    for tag in $release_tags; do
+        # Prefer cli-v* tags, but also accept v* during migration
+        case "$tag" in
+            cli-v* | v[0-9]*)
+                if check_asset "$tag"; then
+                    version="$tag"
+                    break
+                fi
+                info "Release $tag missing $asset_name, trying previous..."
+                ;;
+        esac
+    done
+
+    if [[ -z "$version" ]]; then
+        error "No release found with $asset_name in the last 20 releases. Please specify a version manually or install via npm: npm install -g @composio/cli"
+    fi
+
     info "Found latest version: $version"
-    
-    composio_uri="$github_repo/releases/download/$version/composio-$target.zip"
+    composio_uri="$github_repo/releases/download/$version/$asset_name"
 else
     version=$1
-    composio_uri="$github_repo/releases/download/$version/composio-$target.zip"
+    # Accept both vX.Y.Z and cli-vX.Y.Z formats
+    composio_uri="$github_repo/releases/download/$version/$asset_name"
 fi
 
 info "Installing Composio CLI $version for $target"
@@ -156,7 +172,7 @@ fi
 
 # Download
 info "Downloading Composio CLI..."
-curl --fail --location --progress-bar --output "$exe.zip" "$composio_uri" ||
+curl --proto '=https' --tlsv1.2 --fail --location --progress-bar --output "$exe.zip" "$composio_uri" ||
     error "Failed to download Composio CLI from \"$composio_uri\""
 
 # Extract

--- a/ts/e2e-tests/_utils/src/const.ts
+++ b/ts/e2e-tests/_utils/src/const.ts
@@ -17,6 +17,10 @@ export const WELL_KNOWN_DENO_VERSIONS = ['2.6.7', 'current'] as const;
 
 export const TIMEOUTS = {
   DEFAULT: 5_000,
-  LLM_SHORT: 15_000,
+  /** Timeout for Docker image build operations (ensureNodeImage, ensureDenoImage). */
+  DOCKER: 600_000,
+  /** Timeout for running a fixture inside a Docker container (runFixture, runCmd). */
+  RUN_FIXTURE: 15_000,
+  LLM_SHORT: 30_000,
   LLM_LONG: 60_000,
 } as const;

--- a/ts/e2e-tests/_utils/src/image-lifecycle.ts
+++ b/ts/e2e-tests/_utils/src/image-lifecycle.ts
@@ -118,6 +118,26 @@ function labelsToArgs(labels: Record<string, string> = {}): string[] {
 }
 
 /**
+ * Returns true when a Docker build failed only because another parallel process
+ * already created the same image tag.
+ */
+function isImageAlreadyExistsError(output: string): boolean {
+  return /already exists/i.test(output);
+}
+
+/**
+ * Handles parallel Docker build races by re-checking image existence.
+ */
+async function resolveImageBuildRace(imageTag: string, repoRoot: string, output: string): Promise<boolean> {
+  if (!isImageAlreadyExistsError(output)) {
+    return false;
+  }
+
+  const inspect = await exec('docker', ['image', 'inspect', imageTag], { cwd: repoRoot });
+  return inspect.exitCode === 0;
+}
+
+/**
  * Executes a command and captures stdout/stderr using Bun shell.
  */
 async function exec(cmd: string, args: string[], options: ExecOptions = {}): Promise<ExecResult> {
@@ -202,6 +222,11 @@ export async function ensureNodeImage(
 
   const built = await exec('docker', buildArgs, { cwd: repoRoot });
   if (built.exitCode !== 0) {
+    const combinedOutput = `${built.stderr}\n${built.stdout}`;
+    if (await resolveImageBuildRace(imageTag, repoRoot, combinedOutput)) {
+      return imageTag;
+    }
+
     const err = new Error(`Failed to build Docker image ${imageTag}`);
     (err as Error & { cause: Error }).cause = new Error(built.stderr || built.stdout);
     throw err;
@@ -366,6 +391,11 @@ export async function ensureDenoImage(
 
   const built = await exec('docker', buildArgs, { cwd: repoRoot });
   if (built.exitCode !== 0) {
+    const combinedOutput = `${built.stderr}\n${built.stdout}`;
+    if (await resolveImageBuildRace(imageTag, repoRoot, combinedOutput)) {
+      return imageTag;
+    }
+
     const err = new Error(`Failed to build Docker image ${imageTag}`);
     (err as Error & { cause: Error }).cause = new Error(built.stderr || built.stdout);
     throw err;

--- a/ts/e2e-tests/_utils/src/image-lifecycle.ts
+++ b/ts/e2e-tests/_utils/src/image-lifecycle.ts
@@ -117,25 +117,6 @@ function labelsToArgs(labels: Record<string, string> = {}): string[] {
   return args;
 }
 
-/**
- * Returns true when a Docker build failed only because another parallel process
- * already created the same image tag.
- */
-function isImageAlreadyExistsError(output: string): boolean {
-  return /already exists/i.test(output);
-}
-
-/**
- * Handles parallel Docker build races by re-checking image existence.
- */
-async function resolveImageBuildRace(imageTag: string, repoRoot: string, output: string): Promise<boolean> {
-  if (!isImageAlreadyExistsError(output)) {
-    return false;
-  }
-
-  const inspect = await exec('docker', ['image', 'inspect', imageTag], { cwd: repoRoot });
-  return inspect.exitCode === 0;
-}
 
 /**
  * Executes a command and captures stdout/stderr using Bun shell.
@@ -222,10 +203,6 @@ export async function ensureNodeImage(
 
   const built = await exec('docker', buildArgs, { cwd: repoRoot });
   if (built.exitCode !== 0) {
-    const combinedOutput = `${built.stderr}\n${built.stdout}`;
-    if (await resolveImageBuildRace(imageTag, repoRoot, combinedOutput)) {
-      return imageTag;
-    }
 
     const err = new Error(`Failed to build Docker image ${imageTag}`);
     (err as Error & { cause: Error }).cause = new Error(built.stderr || built.stdout);
@@ -391,10 +368,6 @@ export async function ensureDenoImage(
 
   const built = await exec('docker', buildArgs, { cwd: repoRoot });
   if (built.exitCode !== 0) {
-    const combinedOutput = `${built.stderr}\n${built.stdout}`;
-    if (await resolveImageBuildRace(imageTag, repoRoot, combinedOutput)) {
-      return imageTag;
-    }
 
     const err = new Error(`Failed to build Docker image ${imageTag}`);
     (err as Error & { cause: Error }).cause = new Error(built.stderr || built.stdout);

--- a/ts/e2e-tests/_utils/src/runner.ts
+++ b/ts/e2e-tests/_utils/src/runner.ts
@@ -15,7 +15,7 @@ import type {
 } from './types';
 import { getRepoRoot, resolveNodeVersionMetaList, resolveDenoVersionMetaList } from './config';
 import { ensureNodeImage, runNodeContainer, ensureDenoImage, runDenoContainer } from './image-lifecycle';
-import { WELL_KNOWN_ENV_VARS } from './const';
+import { WELL_KNOWN_ENV_VARS, TIMEOUTS } from './const';
 import { createVolume, generateVolumeName, initializeVolumeOwnership, removeVolume } from './volume';
 
 // ============================================================================
@@ -688,7 +688,7 @@ export function runE2E(config: RunE2EInternalConfig): void {
         beforeAll(async () => {
           const imageTag = await ensureNodeImage(nodeVersionMeta.value, { repoRoot });
           executors = createNodeDockerExecutors(config, nodeVersionMeta.value, imageTag, repoRoot, logManager);
-        }, 600_000);
+        }, TIMEOUTS.DOCKER);
 
         defineTests({
           runtime: 'node',
@@ -732,7 +732,7 @@ export function runE2E(config: RunE2EInternalConfig): void {
         beforeAll(async () => {
           const imageTag = await ensureDenoImage(denoVersionMeta.value, { repoRoot });
           executors = createDenoDockerExecutors(config, denoVersionMeta.value, imageTag, repoRoot, logManager);
-        }, 600_000);
+        }, TIMEOUTS.DOCKER);
 
         defineTests({
           runtime: 'deno',

--- a/ts/e2e-tests/runtimes/deno/esm-basic/e2e.test.ts
+++ b/ts/e2e-tests/runtimes/deno/esm-basic/e2e.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { e2e, type E2ETestResult } from '@e2e-tests/utils';
+import { TIMEOUTS } from '@e2e-tests/utils/const';
 import { describe, it, expect, beforeAll } from 'bun:test';
 
 e2e(import.meta.url, {
@@ -17,7 +18,7 @@ e2e(import.meta.url, {
 
     beforeAll(async () => {
       result = await runFixture({ filename: 'test.ts' });
-    });
+    }, TIMEOUTS.RUN_FIXTURE);
 
     describe('ESM compatibility (Deno)', () => {
       it('exits successfully', () => {

--- a/ts/e2e-tests/runtimes/node/cjs-basic/e2e.test.ts
+++ b/ts/e2e-tests/runtimes/node/cjs-basic/e2e.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { e2e, type E2ETestResult } from '@e2e-tests/utils';
+import { TIMEOUTS } from '@e2e-tests/utils/const';
 import { describe, it, expect, beforeAll } from 'bun:test';
 
 e2e(import.meta.url, {
@@ -23,7 +24,7 @@ e2e(import.meta.url, {
 
     beforeAll(async () => {
       result = await runFixture({ filename: 'test.cjs' });
-    });
+    }, TIMEOUTS.RUN_FIXTURE);
 
     describe('CommonJS compatibility', () => {
       it('exits successfully', () => {

--- a/ts/e2e-tests/runtimes/node/esm-basic/e2e.test.ts
+++ b/ts/e2e-tests/runtimes/node/esm-basic/e2e.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { e2e, type E2ETestResult } from '@e2e-tests/utils';
+import { TIMEOUTS } from '@e2e-tests/utils/const';
 import { describe, it, expect, beforeAll } from 'bun:test';
 
 e2e(import.meta.url, {
@@ -23,7 +24,7 @@ e2e(import.meta.url, {
 
     beforeAll(async () => {
       result = await runFixture({ filename: 'test.mjs' });
-    });
+    }, TIMEOUTS.RUN_FIXTURE);
 
     describe('ESM compatibility', () => {
       it('exits successfully', () => {

--- a/ts/e2e-tests/runtimes/node/file-roundtrip/e2e.test.ts
+++ b/ts/e2e-tests/runtimes/node/file-roundtrip/e2e.test.ts
@@ -1,4 +1,5 @@
 import { e2e, type E2ETestResult, type DefineTestsContext } from '@e2e-tests/utils';
+import { TIMEOUTS } from '@e2e-tests/utils/const';
 import { describe, it, expect, beforeAll } from 'bun:test';
 
 declare module 'bun' {
@@ -18,7 +19,7 @@ e2e(import.meta.url, {
 
     beforeAll(async () => {
       result = await runFixture({ filename: 'test.mjs' })
-    }, 300_000);
+    }, TIMEOUTS.RUN_FIXTURE);
 
     describe('file round-trip', () => {
       it('exits successfully', () => {

--- a/ts/e2e-tests/runtimes/node/openai-zod4-compat/e2e.test.ts
+++ b/ts/e2e-tests/runtimes/node/openai-zod4-compat/e2e.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { e2e, type E2ETestResultWithSetup } from '@e2e-tests/utils';
+import { TIMEOUTS } from '@e2e-tests/utils/const';
 import { describe, it, expect, beforeAll } from 'bun:test';
 
 declare module 'bun' {
@@ -28,7 +29,7 @@ e2e(import.meta.url, {
         filename: 'index.mjs',
         setup: 'npm install --legacy-peer-deps',
       });
-    });
+    }, TIMEOUTS.RUN_FIXTURE);
 
     describe('setup', () => {
       it('npm install completes successfully', () => {

--- a/ts/e2e-tests/runtimes/node/typescript-mjs-import-nodenext/e2e.test.ts
+++ b/ts/e2e-tests/runtimes/node/typescript-mjs-import-nodenext/e2e.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { e2e, type E2ETestResult } from '@e2e-tests/utils';
+import { TIMEOUTS } from '@e2e-tests/utils/const';
 import { describe, it, expect, beforeAll } from 'bun:test';
 
 declare module 'bun' {
@@ -26,7 +27,7 @@ e2e(import.meta.url, {
 
     beforeAll(async () => {
       result = await runFixture({ filename: 'fixtures/index.mjs' });
-    }, 300_000);
+    }, TIMEOUTS.RUN_FIXTURE);
 
     describe('TypeScript .mjs import resolution', () => {
       it('exits successfully', () => {

--- a/ts/packages/cli/README.md
+++ b/ts/packages/cli/README.md
@@ -63,7 +63,7 @@ Additionally, `composio upgrade` supports the following environment variables:
 | COMPOSIO_GITHUB_API_BASE_URL | The base URL for the GitHub API                                                                        | https://api.github.com |
 | COMPOSIO_GITHUB_OWNER        | The owner of the Composio repository on GitHub                                                         | ComposioHQ             |
 | COMPOSIO_GITHUB_REPO         | The repository name for the Composio CLI                                                               | composio               |
-| COMPOSIO_GITHUB_TAG          | The tag to use when fetching the Composio CLI binary from Github                                       | latest                 |
+| COMPOSIO_GITHUB_TAG          | The tag to use when fetching the Composio CLI binary from Github (e.g., `cli-v0.1.25` or `v0.11.1`)    | auto-detect            |
 | COMPOSIO_GITHUB_ACCESS_TOKEN | The access token for the GitHub API. Useful during development to avoid getting rate-limited by Github | None                   |
 
 ## Caching

--- a/ts/packages/cli/src/effects/compare-semver.ts
+++ b/ts/packages/cli/src/effects/compare-semver.ts
@@ -14,9 +14,9 @@ export const semverComparator = (
   version2: string
 ): Effect.Effect<number, CompareSemverError, never> =>
   Effect.gen(function* () {
-    // Remove 'v' or `cli@` prefix if present
-    const v1 = version1.replace(/^(v|cli@)/, '');
-    const v2 = version2.replace(/^(v|cli@)/, '');
+    // Remove version prefix (v, cli@, cli-v) if present
+    const v1 = version1.replace(/^(cli-v|cli@|v)/, '');
+    const v2 = version2.replace(/^(cli-v|cli@|v)/, '');
 
     /**
      * Comparison result of `semver.compare(clean1, clean2)`.

--- a/ts/packages/cli/src/services/upgrade-binary.ts
+++ b/ts/packages/cli/src/services/upgrade-binary.ts
@@ -40,24 +40,18 @@ export class UpgradeBinary extends Effect.Service<UpgradeBinary>()('services/Upg
     const githubConfig = yield* Config.all(GITHUB_CONFIG);
 
     /**
-     * Fetch latest release from GitHub
+     * Check if a tag matches the CLI release channel (cli-v* or v*)
      */
-    const fetchLatestRelease = (): Effect.Effect<GitHubRelease, UpgradeBinaryError, never> =>
-      Effect.gen(function* () {
-        const urlSuffix = yield* githubConfig.TAG.pipe(
-          Option.match({
-            onNone: Effect.fn(function* () {
-              yield* Effect.logDebug('No tag specified, using latest release');
-              return 'latest';
-            }),
-            onSome: Effect.fn(function* (tag) {
-              yield* Effect.logDebug(`Using tag: ${tag}`);
-              return `tags/${tag}`;
-            }),
-          })
-        );
+    const isCliReleaseTag = (tag: string): boolean => tag.startsWith('cli-v') || /^v\d+/.test(tag);
 
-        const url = `${githubConfig.API_BASE_URL}/repos/${githubConfig.OWNER}/${githubConfig.REPO}/releases/${urlSuffix}`;
+    /**
+     * Fetch a specific release by tag from GitHub
+     */
+    const fetchReleaseByTag = (
+      tag: string
+    ): Effect.Effect<GitHubRelease, UpgradeBinaryError, never> =>
+      Effect.gen(function* () {
+        const url = `${githubConfig.API_BASE_URL}/repos/${githubConfig.OWNER}/${githubConfig.REPO}/releases/tags/${tag}`;
         yield* Effect.logDebug(`GET ${url}`);
 
         const response = yield* Effect.gen(function* () {
@@ -66,7 +60,6 @@ export class UpgradeBinary extends Effect.Service<UpgradeBinary>()('services/Upg
             const json = yield* resp.json;
             const keyValues = Object.entries(json as object);
             const pretty = renderPrettyError(keyValues);
-
             return yield* Effect.fail(
               new UpgradeBinaryError({
                 cause: `HTTP ${resp.status}\n${pretty}`,
@@ -79,7 +72,7 @@ export class UpgradeBinary extends Effect.Service<UpgradeBinary>()('services/Upg
             Effect.fail(
               new UpgradeBinaryError({
                 cause: error,
-                message: `Failed to fetch ${urlSuffix} release from GitHub`,
+                message: `Failed to fetch release ${tag} from GitHub`,
               })
             )
           )
@@ -99,6 +92,84 @@ export class UpgradeBinary extends Effect.Service<UpgradeBinary>()('services/Upg
         );
 
         return release as GitHubRelease;
+      });
+
+    /**
+     * Fetch the latest CLI release from GitHub.
+     *
+     * When no explicit tag is set, queries recent releases and finds the first
+     * cli-v* or v* release that has binary assets for the current platform.
+     */
+    const fetchLatestRelease = (
+      platformArch: PlatformArch
+    ): Effect.Effect<GitHubRelease, UpgradeBinaryError, never> =>
+      Effect.gen(function* () {
+        // If an explicit tag is provided, use it directly
+        if (Option.isSome(githubConfig.TAG)) {
+          const tag = githubConfig.TAG.value;
+          yield* Effect.logDebug(`Using explicit tag: ${tag}`);
+          return yield* fetchReleaseByTag(tag);
+        }
+
+        yield* Effect.logDebug('Searching recent releases for CLI binaries...');
+        const url = `${githubConfig.API_BASE_URL}/repos/${githubConfig.OWNER}/${githubConfig.REPO}/releases?per_page=20`;
+        yield* Effect.logDebug(`GET ${url}`);
+
+        const response = yield* Effect.gen(function* () {
+          const resp = yield* httpClient.get(url);
+          if (resp.status < 200 || resp.status >= 300) {
+            return yield* Effect.fail(
+              new UpgradeBinaryError({
+                message: `Failed to fetch releases from GitHub (HTTP ${resp.status})`,
+              })
+            );
+          }
+          return resp;
+        }).pipe(
+          Effect.catchAll(error =>
+            Effect.fail(
+              new UpgradeBinaryError({
+                cause: error,
+                message: 'Failed to fetch releases from GitHub',
+              })
+            )
+          )
+        );
+
+        const releases = yield* Effect.gen(function* () {
+          return yield* response.json;
+        }).pipe(
+          Effect.catchAll(error =>
+            Effect.fail(
+              new UpgradeBinaryError({
+                cause: error,
+                message: 'Failed to parse GitHub releases JSON response',
+              })
+            )
+          )
+        );
+
+        const allReleases = releases as GitHubRelease[];
+        const binaryName = `${CLI_BINARY_NAME}-${platformArch.platform}-${platformArch.arch}.zip`;
+
+        // Find the first CLI release that has the matching platform asset
+        for (const release of allReleases) {
+          if (!isCliReleaseTag(release.tag_name)) continue;
+          const hasAsset = release.assets.some(asset => asset.name === binaryName);
+          if (hasAsset) {
+            yield* Effect.logDebug(`Found CLI release ${release.tag_name} with ${binaryName}`);
+            return release;
+          }
+          yield* Effect.logDebug(
+            `Release ${release.tag_name} missing ${binaryName}, trying previous...`
+          );
+        }
+
+        return yield* Effect.fail(
+          new UpgradeBinaryError({
+            message: `No CLI release found with ${binaryName} in the last 20 releases`,
+          })
+        );
       });
 
     /**
@@ -325,7 +396,8 @@ export class UpgradeBinary extends Effect.Service<UpgradeBinary>()('services/Upg
 
         yield* Console.log('Checking for updates...');
 
-        const release = yield* fetchLatestRelease();
+        const platformArch = yield* detectPlatform;
+        const release = yield* fetchLatestRelease(platformArch);
         const updateAvailable = yield* isUpdateAvailable(release);
         if (!updateAvailable) {
           yield* Console.log('✅ You are already running the latest version!');
@@ -336,7 +408,6 @@ export class UpgradeBinary extends Effect.Service<UpgradeBinary>()('services/Upg
           `📦 New version available: ${release.tag_name} (current: ${APP_VERSION})`
         );
 
-        const platformArch = yield* detectPlatform;
         const { name, data } = yield* downloadBinary(release, platformArch);
 
         // The temporary directory is automatically cleaned up


### PR DESCRIPTION
This PR:

- Closes [PLEN-1546](https://linear.app/composio/issue/PLEN-1546/cli-failed-to-download-composio-cli-from-url)
- Fixes stale reusable workflow reference in `build-cli-binaries.yml` that caused every `v*` tag push to fail, resulting in zero CLI binary assets on any GitHub Release
- Introduces a dedicated `cli-v*` tag channel to decouple CLI binary releases from SDK package releases (`v*` tags)
- Rewrites `install.sh` to query GitHub Releases API instead of `git ls-remote --tags`, with automatic fallback to previous releases when the latest is missing assets
- Updates `composio upgrade` to search recent releases for CLI binaries by tag pattern and asset availability, instead of blindly fetching `/releases/latest`
- Adds a `validate-and-publish` job that verifies all 4 platform assets are present before publishing a release (draft-then-validate-then-publish pattern)
- Adds `actionlint` CI workflow and extends `check-action-repos.sh` to validate reusable workflow references, preventing this class of bug from recurring
- Documents the CLI release policy and fixes `COMPOSIO_INSTALL` -> `COMPOSIO_INSTALL_DIR` inconsistency across `INSTALL.md` and troubleshooting docs

## Context

The `build-cli-binaries.yml` workflow referenced `./.github/workflows/test-installation.yml`, but that file was renamed to `cli.test-installation.yml`. Since GitHub Actions resolves local reusable workflow paths from the tag's commit, every `v*` tag push failed before uploading any binary assets. This broke both `curl -fsSL https://composio.dev/install | bash` and `composio upgrade`.

**Post-merge manual step:** Run `Build CLI Binaries` via `workflow_dispatch` with `version=v0.11.1` to backfill assets for the existing release.

```mermaid
graph TD
    A[cli-v* tag push] --> B[build-binaries matrix]
    B --> C[Upload to draft release]
    C --> D{validate-and-publish}
    D -->|All 4 assets present| E[Publish release]
    D -->|Missing assets| F[Fail - release stays draft]
    E --> G[test-installation]
    H[install.sh] --> I[Query /releases API]
    I --> J{Asset exists?}
    J -->|Yes| K[Download & install]
    J -->|No| L[Try previous release]