### PR TITLE
docs[draft]: document how to fetch all tools and toolkits

### DIFF
--- a/docs/content/docs/toolkits/fetching-tools-and-toolkits.mdx
+++ b/docs/content/docs/toolkits/fetching-tools-and-toolkits.mdx
@@ -145,6 +145,74 @@ const tools = await composio.tools.get(userId, { toolkits: ["GITHUB"] });
 </Tab>
 </Tabs>
 
+### Fetching all toolkits
+
+`composio.toolkits.get()` returns the first page of results. To paginate through all toolkits, use cursor-based pagination:
+
+<Tabs groupId="language" items={['Python', 'TypeScript']} persist>
+<Tab value="Python">
+```python
+all_toolkits = []
+cursor = None
+
+while True:
+    result = composio.toolkits.list(limit=20, cursor=cursor)
+    all_toolkits.extend(result.items)
+    cursor = result.next_cursor
+    if not cursor:
+        break
+```
+</Tab>
+<Tab value="TypeScript">
+```typescript
+import { Composio } from '@composio/core';
+const composio = new Composio({ apiKey: 'your_api_key' });
+// ---cut---
+const allToolkits: Awaited<ReturnType<typeof composio.toolkits.get>>["items"] = [];
+let cursor: string | undefined;
+
+do {
+  const result = await composio.toolkits.get({ limit: 20, cursor });
+  allToolkits.push(...result.items);
+  cursor = result.nextCursor ?? undefined;
+} while (cursor);
+```
+</Tab>
+</Tabs>
+
+### Fetching all tools in a toolkit
+
+By default, `composio.tools.get()` returns a curated subset of popular tools per toolkit. To fetch **all** tools, pass a `limit`:
+
+<Tabs groupId="language" items={['Python', 'TypeScript']} persist>
+<Tab value="Python">
+```python
+# Default — returns popular tools only
+tools = composio.tools.get("user_123", toolkits=["github"])
+
+# All tools in the toolkit
+all_tools = composio.tools.get("user_123", toolkits=["github"], limit=500)
+```
+</Tab>
+<Tab value="TypeScript">
+```typescript
+import { Composio } from '@composio/core';
+const composio = new Composio({ apiKey: 'your_api_key' });
+const userId = 'user_123';
+// ---cut---
+// Default — returns popular tools only
+const tools = await composio.tools.get(userId, { toolkits: ['github'] });
+
+// All tools in the toolkit
+const allTools = await composio.tools.get(userId, { toolkits: ['github'], limit: 500 });
+```
+</Tab>
+</Tabs>
+
+<Callout type="info">
+Most toolkits have fewer than 200 tools, so a `limit` of 500 is usually sufficient to fetch everything.
+</Callout>
+
 ### Get a tool's schema
 
 To inspect a tool's input parameters and types without needing a user context, use `getRawComposioToolBySlug`:

--- a/docs/content/docs/tools-direct/fetching-tools.mdx
+++ b/docs/content/docs/tools-direct/fetching-tools.mdx
@@ -30,7 +30,7 @@ const tools = await composio.tools.get(userId, {
   </Tab>
 </Tabs>
 
-Returns top 20 tools by default. Tools require a `user_id` because they're scoped to authenticated accounts. See [User management](/docs/users-and-sessions) and [Authentication](/docs/tools-direct/authenticating-tools).
+Returns a curated subset of popular tools by default. Pass a `limit` to [fetch all tools](#fetching-all-tools). Tools require a `user_id` because they're scoped to authenticated accounts. See [User management](/docs/users-and-sessions) and [Authentication](/docs/tools-direct/authenticating-tools).
 
 ## Tool schemas
 
@@ -232,6 +232,39 @@ const toolkitSearchRaw = await composio.tools.getRawComposioTools({
 ```
   </Tab>
 </Tabs>
+
+## Fetching all tools
+
+By default, `composio.tools.get()` returns a curated subset of popular tools per toolkit. To fetch **every** tool in a toolkit, pass a `limit`:
+
+<Tabs groupId="language" items={['Python', 'TypeScript']} persist>
+  <Tab value="Python">
+```python
+# Default — popular tools only
+tools = composio.tools.get(user_id, toolkits=["GITHUB"])
+
+# All tools in the toolkit
+all_tools = composio.tools.get(user_id, toolkits=["GITHUB"], limit=500)
+```
+  </Tab>
+  <Tab value="TypeScript">
+```typescript
+import { Composio } from '@composio/core';
+const composio = new Composio({ apiKey: 'your_api_key' });
+const userId = 'user-123';
+// ---cut---
+// Default — popular tools only
+const tools = await composio.tools.get(userId, { toolkits: ["GITHUB"] });
+
+// All tools in the toolkit
+const allTools = await composio.tools.get(userId, { toolkits: ["GITHUB"], limit: 500 });
+```
+  </Tab>
+</Tabs>
+
+<Callout type="info">
+Most toolkits have fewer than 200 tools, so a `limit` of 500 is usually sufficient to fetch everything.
+</Callout>
 
 <Callout type="info">
 Use specific toolkit versions in production to prevent breaking changes. See [toolkit versioning](/docs/tools-direct/toolkit-versioning).


### PR DESCRIPTION
## Summary
- Addresses hackathon feedback ([PLEN-1565](https://linear.app/composio/issue/PLEN-1565)) where users were confused about how to fetch beyond the default curated tool subset
- Adds "Fetching all toolkits" section with cursor-based pagination examples (Python + TypeScript) to `fetching-tools-and-toolkits.mdx`
- Adds "Fetching all tools in a toolkit" section showing the `limit` parameter to both `fetching-tools-and-toolkits.mdx` and `fetching-tools.mdx`
- Updates intro text on the direct tools page to mention `limit` upfront

## Context
By default, `composio.tools.get()` returns a curated subset of popular tools (via an internal `important: true` filter). Users at the hackathon didn't know they needed to pass a `limit` to get all tools. This was undocumented in both paradigms (session-based and direct).

## Test plan
- [ ] Verify `bun run build` passes (TypeScript code blocks are type-checked)
- [ ] Check both pages render correctly on dev server
- [ ] Confirm anchor link `#fetching-all-tools` works on the direct tools page

🤖 Generated with [Claude Code](https://claude.com/claude-code)