### PR TITLE
docs[draft]: document GET_TOOL_SCHEMAS and WAIT_FOR_CONNECTIONS meta tools

### DIFF
--- a/docs/content/docs/authenticating-users/in-chat-authentication.mdx
+++ b/docs/content/docs/authenticating-users/in-chat-authentication.mdx
@@ -32,6 +32,39 @@ const session = await composio.create("user_123");
 </Tab>
 </Tabs>
 
+### Automatic connection polling
+
+By default, after the agent shows an auth link, it waits for the user to say something like "Done" before continuing. If you'd rather the agent detect the connection automatically, enable `enable_wait_for_connections`. This gives the agent a `COMPOSIO_WAIT_FOR_CONNECTIONS` tool that polls every 5 seconds (up to 3 minutes) until the user finishes authenticating:
+
+<Tabs groupId="language" items={['Python', 'TypeScript']} persist>
+<Tab value="Python">
+```python
+session = composio.create(
+    user_id="user_123",
+    manage_connections={
+        "enable_wait_for_connections": True
+    },
+)
+```
+</Tab>
+<Tab value="TypeScript">
+```typescript
+import { Composio } from '@composio/core';
+const composio = new Composio({ apiKey: 'your_api_key' });
+// ---cut---
+const session = await composio.create("user_123", {
+  manageConnections: {
+    enableWaitForConnections: true,
+  },
+});
+```
+</Tab>
+</Tabs>
+
+<Callout type="warn">
+This may not work reliably with GPT models since the tool call blocks while polling.
+</Callout>
+
 ### Custom callback URL
 
 Redirect users back to your chat page after they complete authentication:

--- a/docs/content/docs/configuring-sessions.mdx
+++ b/docs/content/docs/configuring-sessions.mdx
@@ -161,6 +161,39 @@ When executing a tool, the connected account is selected in this order:
 
 If a user has multiple connected accounts for a toolkit, the most recently connected one is used.
 
+## Connection polling
+
+By default, during [in-chat authentication](/docs/authenticating-users/in-chat-authentication), the agent waits for the user to confirm they've connected. You can enable automatic polling instead — the agent gets a `COMPOSIO_WAIT_FOR_CONNECTIONS` tool that checks the connection status every 5 seconds for up to 3 minutes:
+
+<Tabs groupId="language" items={['Python', 'TypeScript']} persist>
+<Tab value="Python">
+```python
+session = composio.create(
+    user_id="user_123",
+    manage_connections={
+        "enable_wait_for_connections": True
+    }
+)
+```
+</Tab>
+<Tab value="TypeScript">
+```typescript
+import { Composio } from '@composio/core';
+const composio = new Composio({ apiKey: 'your_api_key' });
+// ---cut---
+const session = await composio.create("user_123", {
+  manageConnections: {
+    enableWaitForConnections: true,
+  },
+});
+```
+</Tab>
+</Tabs>
+
+<Callout type="warn">
+This may not work reliably with GPT models since the tool call blocks while polling.
+</Callout>
+
 ## Session methods
 
 ### mcp

--- a/docs/content/docs/tools-and-toolkits.mdx
+++ b/docs/content/docs/tools-and-toolkits.mdx
@@ -4,19 +4,22 @@ description: Understand how tools and toolkits work in Composio
 keywords: [tools, toolkits, meta tools, context management]
 ---
 
-Composio offers 800+ toolkits, but loading all the tools into context would overwhelm your agent. Instead, your agent has access to 5 meta tools that discover, authenticate, and execute the right tools at runtime.
+Composio offers 800+ toolkits, but loading all the tools into context would overwhelm your agent. Instead, your agent has access to meta tools that discover, authenticate, and execute the right tools at runtime.
 
 ## Meta tools
 
-When you create a session, your agent gets these 5 meta tools:
+When you create a session, your agent gets these meta tools:
 
 | Meta tool | What it does |
 |-----------|--------------|
 | `COMPOSIO_SEARCH_TOOLS` | Discover relevant tools across 800+ apps |
+| `COMPOSIO_GET_TOOL_SCHEMAS` | Fetch full input schemas for specific tools |
 | `COMPOSIO_MANAGE_CONNECTIONS` | Handle OAuth and API key authentication |
 | `COMPOSIO_MULTI_EXECUTE_TOOL` | Execute up to 20 tools in parallel |
 | `COMPOSIO_REMOTE_WORKBENCH` | Run Python code in a [persistent sandbox](/docs/workbench) |
 | `COMPOSIO_REMOTE_BASH_TOOL` | Execute bash commands for file and data processing |
+
+You can also enable `COMPOSIO_WAIT_FOR_CONNECTIONS` per session — it lets the agent poll until the user finishes authenticating instead of waiting for them to say "I've connected." See [configuring sessions](/docs/configuring-sessions) for details.
 
 Meta tool calls in a session are correlated using a `session_id`, allowing them to share context. The tools can also store useful information (like IDs and relationships discovered during execution) in memory for subsequent calls.
 
@@ -49,6 +52,8 @@ Done. (For large results, agent can use REMOTE_WORKBENCH to process)
 - **Connection status** - Whether the user has already authenticated with each toolkit
 - **Execution plan** - Recommended steps and common pitfalls for the task
 - **Related tools** - Prerequisites, alternatives, and follow-up tools
+
+Sometimes `SEARCH_TOOLS` returns a `schemaRef` instead of the full input schema for a tool — this keeps the response compact when many tools match. When the agent needs the complete parameter definitions, it calls `COMPOSIO_GET_TOOL_SCHEMAS` with the tool slugs to get the full schemas before executing.
 
 ### Processing large results
 


### PR DESCRIPTION
## Summary
- Add `COMPOSIO_GET_TOOL_SCHEMAS` to the meta tools table in tools-and-toolkits, with explanation of when agents use it (when SEARCH_TOOLS returns `schemaRef` instead of full schema)
- Document `COMPOSIO_WAIT_FOR_CONNECTIONS` as an opt-in meta tool for automatic connection polling during in-chat auth
- Add `enable_wait_for_connections` config option to configuring-sessions and in-chat-authentication pages

## Test plan
- [ ] `bun run build` passes
- [ ] Review tools-and-toolkits page renders correctly with new meta tool in table
- [ ] Review in-chat-authentication page shows new "Automatic connection polling" section
- [ ] Review configuring-sessions page shows new "Connection polling" section
- [ ] Code snippets render correctly in both Python and TypeScript tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)