### PR TITLE
fix: coerce MCP tool-call input to object, preventing string-type validation errors

### DIFF
--- a/ts/packages/core/src/models/Tools.ts
+++ b/ts/packages/core/src/models/Tools.ts
@@ -57,6 +57,31 @@ import { ToolExecuteMetaParams } from '../types/tool.types';
 import { SessionExecuteMetaParams } from '@composio/client/resources/tool-router.mjs';
 import { CONFIG_DEFAULTS } from '../utils/config-defaults';
 /**
+ * Coerce a value to a plain object. Some LLM providers and the MCP protocol
+ * occasionally emit tool-call arguments as a JSON string instead of an object.
+ * This utility normalises the input so downstream code always receives a
+ * `Record<string, unknown>`.
+ */
+function coerceToObject(value: unknown): Record<string, unknown> {
+  if (value === null || value === undefined) return {};
+  if (typeof value === 'object' && !Array.isArray(value)) return value as Record<string, unknown>;
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed.startsWith('{')) {
+      try {
+        const parsed = JSON.parse(trimmed);
+        if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+          return parsed as Record<string, unknown>;
+        }
+      } catch {
+        // Not valid JSON — fall through to empty object
+      }
+    }
+  }
+  return {};
+}
+
+/**
  * This class is used to manage tools in the Composio SDK.
  * It provides methods to list, get, and execute tools.
  */
@@ -725,7 +750,7 @@ export class Tools<
         toolSlug,
         {
           userId,
-          arguments: input,
+          arguments: coerceToObject(input),
           // dangerously skip version check for agentic tool execution via providers
           // this can be safe because most agentic flows users fetch latest version and then execute the tool
           dangerouslySkipVersionCheck: true,
@@ -756,7 +781,7 @@ export class Tools<
         toolSlug,
         {
           sessionId,
-          arguments: input,
+          arguments: coerceToObject(input),
         },
         modifiers
       );
@@ -957,8 +982,8 @@ export class Tools<
       });
     }
 
-    // Apply beforeExecute modifier if provided
-    let modifiedParams = body.arguments ?? {};
+    // Coerce arguments to object (LLMs/MCP may emit as string)
+    let modifiedParams = coerceToObject(body.arguments ?? {});
     if (modifiers?.beforeExecute) {
       modifiedParams = await modifiers.beforeExecute({
         toolSlug,

--- a/ts/packages/providers/anthropic/src/index.ts
+++ b/ts/packages/providers/anthropic/src/index.ts
@@ -210,8 +210,19 @@ export class AnthropicProvider extends BaseNonAgenticProvider<
     options?: ExecuteToolFnOptions,
     modifiers?: ExecuteToolModifiers
   ): Promise<string> {
+    let toolInput = toolUse.input;
+    if (typeof toolInput === 'string') {
+      try {
+        toolInput = JSON.parse(toolInput);
+      } catch {
+        toolInput = {};
+      }
+    }
+    if (typeof toolInput !== 'object' || toolInput === null || Array.isArray(toolInput)) {
+      toolInput = {};
+    }
     const payload: ToolExecuteParams = {
-      arguments: toolUse.input,
+      arguments: toolInput as Record<string, unknown>,
       connectedAccountId: options?.connectedAccountId,
       customAuthParams: options?.customAuthParams,
       customConnectionData: options?.customConnectionData,

--- a/ts/packages/providers/claude-agent-sdk/src/index.ts
+++ b/ts/packages/providers/claude-agent-sdk/src/index.ts
@@ -114,7 +114,18 @@ export class ClaudeAgentSDKProvider extends BaseAgenticProvider<
       inputZodShape,
       async args => {
         try {
-          const result = await executeTool(composioTool.slug, args);
+          let input = args;
+          if (typeof input === 'string') {
+            try {
+              input = JSON.parse(input);
+            } catch {
+              input = {};
+            }
+          }
+          if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+            input = {};
+          }
+          const result = await executeTool(composioTool.slug, input as Record<string, unknown>);
           return {
             content: [
               {

--- a/ts/packages/providers/google/src/index.ts
+++ b/ts/packages/providers/google/src/index.ts
@@ -241,8 +241,19 @@ export class GoogleProvider extends BaseNonAgenticProvider<
     options?: ExecuteToolFnOptions,
     modifiers?: ExecuteToolModifiers
   ): Promise<string> {
+    let toolArgs = tool.args;
+    if (typeof toolArgs === 'string') {
+      try {
+        toolArgs = JSON.parse(toolArgs);
+      } catch {
+        toolArgs = {};
+      }
+    }
+    if (typeof toolArgs !== 'object' || toolArgs === null || Array.isArray(toolArgs)) {
+      toolArgs = {};
+    }
     const payload: ToolExecuteParams = {
-      arguments: tool.args,
+      arguments: toolArgs as Record<string, unknown>,
       connectedAccountId: options?.connectedAccountId,
       customAuthParams: options?.customAuthParams,
       customConnectionData: options?.customConnectionData,

--- a/ts/packages/providers/langchain/src/index.ts
+++ b/ts/packages/providers/langchain/src/index.ts
@@ -128,7 +128,18 @@ export class LangchainProvider extends BaseAgenticProvider<
       throw new Error('App name is not defined');
     }
     const func = async (...args: unknown[]): Promise<unknown> => {
-      const result = await executeTool(toolName, args[0] as Record<string, unknown>);
+      let input = args[0];
+      if (typeof input === 'string') {
+        try {
+          input = JSON.parse(input);
+        } catch {
+          input = {};
+        }
+      }
+      if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+        input = {};
+      }
+      const result = await executeTool(toolName, input as Record<string, unknown>);
       return JSON.stringify(result);
     };
     if (!tool.inputParameters) {

--- a/ts/packages/providers/llamaindex/src/index.ts
+++ b/ts/packages/providers/llamaindex/src/index.ts
@@ -38,7 +38,18 @@ export class LlamaindexProvider extends BaseAgenticProvider<
       name: tool.slug,
       description: tool.description ?? tool.name ?? '',
       parameters: inputParametersSchema,
-      execute: async input => {
+      execute: async rawInput => {
+        let input = rawInput;
+        if (typeof input === 'string') {
+          try {
+            input = JSON.parse(input);
+          } catch {
+            input = {};
+          }
+        }
+        if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+          input = {};
+        }
         const result = await executeTool(tool.slug, input as Record<string, unknown>);
         return JSON.stringify(result);
       },

--- a/ts/packages/providers/mastra/src/index.ts
+++ b/ts/packages/providers/mastra/src/index.ts
@@ -110,7 +110,18 @@ export class MastraProvider extends BaseAgenticProvider<
       // @ts-ignore
       outputSchema,
       execute: async (inputData, _context) => {
-        const result = await executeTool(tool.slug, inputData as Record<string, unknown>);
+        let input = inputData;
+        if (typeof input === 'string') {
+          try {
+            input = JSON.parse(input);
+          } catch {
+            input = {};
+          }
+        }
+        if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+          input = {};
+        }
+        const result = await executeTool(tool.slug, input as Record<string, unknown>);
         return result;
       },
     });

--- a/ts/packages/providers/openai-agents/src/index.ts
+++ b/ts/packages/providers/openai-agents/src/index.ts
@@ -132,8 +132,18 @@ export class OpenAIAgentsProvider extends BaseAgenticProvider<
       },
       strict: false,
       execute: async params => {
-        const input = typeof params === 'string' ? JSON.parse(params) : params;
-        return await executeTool(composioTool.slug, input);
+        let input = params;
+        if (typeof params === 'string') {
+          try {
+            input = JSON.parse(params);
+          } catch {
+            input = {};
+          }
+        }
+        if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+          input = {};
+        }
+        return await executeTool(composioTool.slug, input as Record<string, unknown>);
       },
     });
   }

--- a/ts/packages/providers/vercel/src/index.ts
+++ b/ts/packages/providers/vercel/src/index.ts
@@ -126,8 +126,18 @@ export class VercelProvider extends BaseAgenticProvider<
       inputSchema: inputParametersSchema,
 
       execute: async params => {
-        const input = typeof params === 'string' ? JSON.parse(params) : params;
-        return await executeTool(composioTool.slug, input);
+        let input = params;
+        if (typeof params === 'string') {
+          try {
+            input = JSON.parse(params);
+          } catch {
+            input = {};
+          }
+        }
+        if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+          input = {};
+        }
+        return await executeTool(composioTool.slug, input as Record<string, unknown>);
       },
     });
   }

--- a/ts/packages/providers/vercel/test/vercel.test.ts
+++ b/ts/packages/providers/vercel/test/vercel.test.ts
@@ -129,6 +129,22 @@ describe('VercelProvider', () => {
 
       expect(mockExecuteToolFn).toHaveBeenCalledWith(mockTool.slug, params);
     });
+
+    it('should gracefully handle malformed string input by falling back to empty object', async () => {
+      provider.wrapTool(mockTool, mockExecuteToolFn) as unknown as MockedVercelTool;
+      const executeFunction = (tool as any).mock.calls[0][0].execute;
+
+      await executeFunction('not-valid-json');
+      expect(mockExecuteToolFn).toHaveBeenCalledWith(mockTool.slug, {});
+    });
+
+    it('should handle null/undefined input by falling back to empty object', async () => {
+      provider.wrapTool(mockTool, mockExecuteToolFn) as unknown as MockedVercelTool;
+      const executeFunction = (tool as any).mock.calls[0][0].execute;
+
+      await executeFunction(null);
+      expect(mockExecuteToolFn).toHaveBeenCalledWith(mockTool.slug, {});
+    });
   });
 
   describe('wrapTools', () => {


### PR DESCRIPTION
## Summary

Fixes #2406

Some LLM providers and the MCP protocol occasionally emit tool-call `input` as a **JSON string** instead of a plain object. When this happens, downstream schema validation fails:

- AI SDK's Zod validation rejects the non-object input before `execute()` is called
- Anthropic's API returns `tool_use.input: Input should be a valid dictionary`
- Streaming breaks with no recovery

This PR adds defensive input coercion at two levels to ensure tool-call arguments are always a valid object.

### Changes

**Core (`@composio/core` — `Tools.ts`)**
- Added `coerceToObject()` utility that safely converts string, null, undefined, or array inputs into a plain `Record<string, unknown>`
- Applied at the three central execution choke points: `createExecuteToolFn`, `createExecuteToolFnForToolRouter`, and `executeMetaTool`
- All providers benefit from this core fix automatically

**Providers (defense-in-depth)**
- **Vercel, OpenAI Agents**: Hardened existing `JSON.parse` guards with try-catch for malformed strings
- **Anthropic, Google, LangChain, LlamaIndex, Mastra, Claude Agent SDK**: Added missing string-to-object guards in `execute` callbacks and `executeToolCall` methods

**Tests**
- Added test cases for malformed string and null input handling in the Vercel provider

### Backward Compatibility

The fix is fully backward-compatible: valid object inputs pass through unchanged. Only string/null/undefined inputs are coerced to `{}`.

## Test plan

- [x] Existing Vercel provider tests pass with string JSON input
- [x] New tests for malformed string input → falls back to `{}`
- [x] New tests for null input → falls back to `{}`
- [ ] Manual test with `COMPOSIO_MULTI_EXECUTE_TOOL` + AI SDK `streamText()`