### PR TITLE
docs: add session lifecycle and immutability info

### DIFF
--- a/docs/content/docs/users-and-sessions.mdx
+++ b/docs/content/docs/users-and-sessions.mdx
@@ -97,6 +97,22 @@ const toolkits = await session.toolkits();
 </Tab>
 </Tabs>
 
+## How sessions behave
+
+A session ties together a user, a set of available toolkits, auth configuration for those toolkits, and connected accounts. Call `create()` whenever you want to do a task. Each session is designed for a particular agentic task, and if you want to change the context of the task, create a new session.
+
+You don't need to cache session IDs, manage session lifetimes, or worry about expiration. Sessions persist on the server and don't expire. Just call `create()` with what you need.
+
+### Sessions are immutable
+
+A session's configuration is fixed at creation. You cannot change the toolkits, auth configs, or connected accounts on an existing session.
+
+This means the boundary for a new session isn't a new chat or a new request. It's when the contract changes. If a user starts with "search my personal Gmail" and then says "actually use my work email," that's a different session because the auth changed.
+
+### Connected accounts persist across sessions
+
+Connections are tied to the user ID, not the session. A user who connected Gmail in one session can access it in every future session without re-authenticating.
+
 <Cards>
   <Card icon={<BookOpen />} title="Configuring Sessions" href="/docs/configuring-sessions" description="Enable toolkits, set auth configs, and select connected accounts" />
   <Card icon={<BookOpen />} title="Workbench" href="/docs/workbench" description="Write and run code in a persistent sandbox" />


### PR DESCRIPTION
## Summary
- Adds a "How sessions behave" section to the users-and-sessions page
- Explains that sessions are immutable (config fixed at creation), persist indefinitely, and connected accounts follow the user ID across sessions
- Includes a concrete example (personal vs work Gmail) to illustrate when to create a new session

## Test plan
- [x] `bun run build` passes
- [ ] Visual check on `/docs/users-and-sessions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)