### PR TITLE
docs: rewrite toolkit FAQs as questions, add session FAQ

### DIFF
--- a/docs/content/docs/common-faq.mdx
+++ b/docs/content/docs/common-faq.mdx
@@ -142,6 +142,10 @@ Composio does not have fixed IP ranges. Traffic is routed through Cloudflare and
 <Accordion title="How do I increase my quota?">
 Upgrade your plan. See [pricing](https://composio.dev/pricing) for available plans and limits.
 </Accordion>
+<Accordion title="When should I create a new session?">
+Create a new session when the config changes: different toolkits, different auth config, or a different connected account. You don't need to store or manage session IDs. Just call `create()` each time. See [Users and sessions](/docs/users-and-sessions).
+</Accordion>
+
 <Accordion title="How do I configure sessions with custom auth configs?">
 Some toolkits require your own OAuth credentials or API keys. Create an auth config in the dashboard by selecting the toolkit, choosing the auth scheme, and entering your credentials. Then pass the auth config ID when creating a session using the `auth_configs` (or `auth_config_id`) parameter so the session uses your developer credentials instead of Composio-managed auth. See [Using custom auth configuration](/docs/using-custom-auth-configuration).
 </Accordion>

--- a/docs/content/docs/users-and-sessions.mdx
+++ b/docs/content/docs/users-and-sessions.mdx
@@ -113,6 +113,12 @@ This means the boundary for a new session isn't a new chat or a new request. It'
 
 Connections are tied to the user ID, not the session. A user who connected Gmail in one session can access it in every future session without re-authenticating.
 
+<Accordions>
+<Accordion title="When should I create a new session?">
+Create a new session when the config changes: different toolkits, different auth config, or a different connected account. You don't need to store or manage session IDs. Just call `create()` each time.
+</Accordion>
+</Accordions>
+
 <Cards>
   <Card icon={<BookOpen />} title="Configuring Sessions" href="/docs/configuring-sessions" description="Enable toolkits, set auth configs, and select connected accounts" />
   <Card icon={<BookOpen />} title="Workbench" href="/docs/workbench" description="Write and run code in a persistent sandbox" />


### PR DESCRIPTION
Toolkit FAQ headings were statements, not questions. Rewrote all of them. Cleaned up answers, removed broken title headings, fixed copy-paste errors, removed duplicates.

Added "When should I create a new session?" to `users-and-sessions.mdx` and `common-faq.mdx`.

Removed unused `invalid_scope-error.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)