### PR TITLE
fix(crewai): make tool schemas compatible with OpenAI strict mode

### DIFF
--- a/python/providers/crewai/composio_crewai/providers.py
+++ b/python/providers/crewai/composio_crewai/providers.py
@@ -1,3 +1,4 @@
+import json
 import typing as t
 
 import pydantic
@@ -9,9 +10,80 @@ from composio.utils.pydantic import parse_pydantic_error
 from composio.utils.shared import json_schema_to_model
 
 
+def _make_strict_compatible(schema: t.Dict[str, t.Any]) -> t.Dict[str, t.Any]:
+    """Make a JSON schema compatible with OpenAI's strict mode.
+
+    CrewAI uses OpenAI strict mode for function calling, which requires
+    ``additionalProperties: false`` on every nested object. Freeform dicts
+    (``additionalProperties: true`` with no defined properties) are converted
+    to ``type: string`` so the model outputs a JSON string instead.
+
+    Returns a new schema dict (does not mutate the original).
+    """
+    schema = dict(schema)
+
+    # Process $defs first so $ref targets are also strict-compatible
+    if "$defs" in schema:
+        schema["$defs"] = {
+            k: _make_strict_compatible(v) for k, v in schema["$defs"].items()
+        }
+
+    # Recurse into properties
+    if "properties" in schema:
+        schema["properties"] = {
+            k: _make_strict_compatible(v) for k, v in schema["properties"].items()
+        }
+
+    # Recurse into array items
+    if "items" in schema and isinstance(schema["items"], dict):
+        schema["items"] = _make_strict_compatible(schema["items"])
+
+    if schema.get("type") == "object":
+        has_properties = bool(schema.get("properties"))
+        if schema.get("additionalProperties") is True or (
+            not has_properties and "additionalProperties" not in schema
+        ):
+            if not has_properties:
+                # Freeform dict with no defined keys — strict mode cannot
+                # represent this as an object, so convert to a JSON string.
+                desc = schema.get("description", "")
+                schema = {
+                    "type": "string",
+                    "description": f"{desc} (as a JSON string)",
+                }
+                return schema
+        # Object with defined properties — just lock it down.
+        schema["additionalProperties"] = False
+
+    return schema
+
+
+def _parse_json_strings(value: t.Any) -> t.Any:
+    """Recursively parse string values that look like JSON objects back into
+    dicts/lists.
+
+    When freeform dict fields are converted to string type for strict-mode
+    compatibility, the model outputs JSON strings. This function converts
+    them back so downstream ``execute_tool`` receives the expected types.
+    """
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+            if isinstance(parsed, (dict, list)):
+                return _parse_json_strings(parsed)
+        except (json.JSONDecodeError, TypeError):
+            pass
+        return value
+    if isinstance(value, dict):
+        return {k: _parse_json_strings(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_parse_json_strings(item) for item in value]
+    return value
+
+
 class CrewAIProvider(AgenticProvider[BaseTool, list[BaseTool]], name="crewai"):
     """
-    Composio toolset for CrewiAI framework.
+    Composio toolset for CrewAI framework.
     """
 
     def wrap_tool(
@@ -24,7 +96,10 @@ class CrewAIProvider(AgenticProvider[BaseTool, list[BaseTool]], name="crewai"):
         class Wrapper(BaseTool):
             def _run(self, **kwargs):
                 try:
-                    return execute_tool(slug=tool.slug, arguments=kwargs)
+                    return execute_tool(
+                        slug=tool.slug,
+                        arguments=_parse_json_strings(kwargs),
+                    )
                 except pydantic.ValidationError as e:
                     return {
                         "successful": False,
@@ -32,11 +107,12 @@ class CrewAIProvider(AgenticProvider[BaseTool, list[BaseTool]], name="crewai"):
                         "data": None,
                     }
 
+        strict_schema = _make_strict_compatible(tool.input_parameters)
         return Wrapper(
             name=tool.slug,
             description=tool.description,
             args_schema=json_schema_to_model(
-                json_schema=tool.input_parameters,
+                json_schema=strict_schema,
                 skip_default=self.skip_default,
             ),
         )


### PR DESCRIPTION
## Problem

CrewAI uses OpenAI's **strict mode** for function calling, which enforces that every nested object in a tool's JSON schema must have `additionalProperties: false`. Several Composio tools — notably `COMPOSIO_MULTI_EXECUTE_TOOL` — include freeform dict fields defined as `{"type": "object", "additionalProperties": true}`, which strict mode rejects:

```
Error code: 400 - Invalid schema for function 'composio_multi_execute_tool':
In context=('properties', 'tools', 'items', 'properties', 'arguments'),
'additionalProperties' is required to be supplied and to be false.
```

This makes the CrewAI provider completely non-functional — every agent call fails before even reaching the LLM.

## Root Cause

OpenAI's strict function calling mode (which CrewAI enables by default) requires:
1. `additionalProperties: false` on **all** object-type properties in the schema
2. No freeform dict fields (`additionalProperties: true` is not allowed)

The Composio tool schemas use freeform dicts in several places (e.g., the `arguments` field in `COMPOSIO_MULTI_EXECUTE_TOOL` which accepts arbitrary tool arguments). These are valid JSON Schema but incompatible with OpenAI's strict mode.

## Fix

Two helpers added to the CrewAI provider (`composio_crewai/providers.py`):

### 1. `_make_strict_compatible(schema)`
Recursively preprocesses JSON schemas **before** Pydantic model creation:
- **Objects with defined properties** → adds `additionalProperties: false` (safe, the model will only output defined keys)
- **Freeform dicts** (no properties, `additionalProperties: true`) → converted to `type: string` with description noting it should be a JSON string. This is the only way to represent arbitrary key-value data under strict mode.

### 2. `_parse_json_strings(value)`
Recursively walks the model's output kwargs **after** generation, parsing any JSON strings back into dicts/lists so the downstream `execute_tool` receives the expected Python types.

## Testing

Tested end-to-end with CrewAI agent sending an email via Gmail:

```python
from crewai import Agent, Crew, Task
from composio import Composio
from composio_crewai import CrewAIProvider

composio = Composio(provider=CrewAIProvider())
session = composio.create(user_id="user_123")
tools = session.tools()

agent = Agent(
    role="Email Agent",
    goal="Send emails on behalf of the user",
    backstory="You are an AI agent that sends emails using Gmail.",
    tools=tools,
    llm="gpt-4o",
)

task = Task(
    description="Send an email to sushdec6@gmail.com with subject 'Hello from CrewAI'",
    agent=agent,
    expected_output="Confirmation that the email was sent",
)

crew = Crew(agents=[agent], tasks=[task])
result = crew.kickoff()
# ✅ Email sent successfully
```

**Before fix:** `openai.BadRequestError: Invalid schema for function 'composio_multi_execute_tool'`
**After fix:** Email sent successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)