### PR TITLE
docs: fix broken internal links in Google toolkit FAQs

### DIFF
--- a/docs/content/toolkit-faq/gmail.md
+++ b/docs/content/toolkit-faq/gmail.md
@@ -14,11 +14,11 @@ When using custom OAuth credentials, the Gmail API must be enabled in the Google
 
 ## Why am I getting "Error 400: invalid_scope"?
 
-The requested scopes are invalid or incorrectly formatted in the authorization URL. Verify your scope values against the [Google OAuth scopes docs](https://developers.google.com/identity/protocols/oauth2). If you're creating auth configs programmatically, see the [programmatic auth config guide](/docs/programmatic-auth-configs).
+The requested scopes are invalid or incorrectly formatted in the authorization URL. Verify your scope values against the [Google OAuth scopes docs](https://developers.google.com/identity/protocols/oauth2). If you're creating auth configs programmatically, see the [programmatic auth config guide](/docs/auth-configuration/programmatic-auth-configs).
 
 ## Why does the OAuth consent screen show "Composio" instead of my app?
 
-By default, the consent screen uses Composio's OAuth app. To show your own app name and logo, create your own OAuth app and set a custom redirect URL. See [White-labeling the OAuth consent screen](/docs/custom-auth-configs#white-labeling-the-oauth-consent-screen).
+By default, the consent screen uses Composio's OAuth app. To show your own app name and logo, create your own OAuth app and set a custom redirect URL. See [White-labeling the OAuth consent screen](/docs/auth-configuration/custom-auth-configs#white-labeling-the-oauth-consent-screen).
 
 ## Why am I getting 401 errors on tool calls?
 

--- a/docs/content/toolkit-faq/google_classroom.md
+++ b/docs/content/toolkit-faq/google_classroom.md
@@ -14,11 +14,11 @@ When using custom OAuth credentials, the Google Classroom API must be enabled in
 
 ## Why am I getting "Error 400: invalid_scope"?
 
-The requested scopes are invalid or incorrectly formatted in the authorization URL. Verify your scope values against the [Google OAuth scopes docs](https://developers.google.com/identity/protocols/oauth2). If you're creating auth configs programmatically, see the [programmatic auth config guide](/docs/programmatic-auth-configs).
+The requested scopes are invalid or incorrectly formatted in the authorization URL. Verify your scope values against the [Google OAuth scopes docs](https://developers.google.com/identity/protocols/oauth2). If you're creating auth configs programmatically, see the [programmatic auth config guide](/docs/auth-configuration/programmatic-auth-configs).
 
 ## Why does the OAuth consent screen show "Composio" instead of my app?
 
-By default, the consent screen uses Composio's OAuth app. To show your own app name and logo, create your own OAuth app and set a custom redirect URL. See [White-labeling the OAuth consent screen](/docs/custom-auth-configs#white-labeling-the-oauth-consent-screen).
+By default, the consent screen uses Composio's OAuth app. To show your own app name and logo, create your own OAuth app and set a custom redirect URL. See [White-labeling the OAuth consent screen](/docs/auth-configuration/custom-auth-configs#white-labeling-the-oauth-consent-screen).
 
 ## Why am I getting 401 errors on tool calls?
 

--- a/docs/content/toolkit-faq/google_maps.md
+++ b/docs/content/toolkit-faq/google_maps.md
@@ -14,11 +14,11 @@ When using custom OAuth credentials, the Google Maps API must be enabled in the 
 
 ## Why am I getting "Error 400: invalid_scope"?
 
-The requested scopes are invalid or incorrectly formatted in the authorization URL. Verify your scope values against the [Google OAuth scopes docs](https://developers.google.com/identity/protocols/oauth2). If you're creating auth configs programmatically, see the [programmatic auth config guide](/docs/programmatic-auth-configs).
+The requested scopes are invalid or incorrectly formatted in the authorization URL. Verify your scope values against the [Google OAuth scopes docs](https://developers.google.com/identity/protocols/oauth2). If you're creating auth configs programmatically, see the [programmatic auth config guide](/docs/auth-configuration/programmatic-auth-configs).
 
 ## Why does the OAuth consent screen show "Composio" instead of my app?
 
-By default, the consent screen uses Composio's OAuth app. To show your own app name and logo, create your own OAuth app and set a custom redirect URL. See [White-labeling the OAuth consent screen](/docs/custom-auth-configs#white-labeling-the-oauth-consent-screen).
+By default, the consent screen uses Composio's OAuth app. To show your own app name and logo, create your own OAuth app and set a custom redirect URL. See [White-labeling the OAuth consent screen](/docs/auth-configuration/custom-auth-configs#white-labeling-the-oauth-consent-screen).
 
 ## Why am I getting 401 errors on tool calls?
 

--- a/docs/content/toolkit-faq/googlecalendar.md
+++ b/docs/content/toolkit-faq/googlecalendar.md
@@ -14,11 +14,11 @@ When using custom OAuth credentials, the Google Calendar API must be enabled in 
 
 ## Why am I getting "Error 400: invalid_scope"?
 
-The requested scopes are invalid or incorrectly formatted in the authorization URL. Verify your scope values against the [Google OAuth scopes docs](https://developers.google.com/identity/protocols/oauth2). If you're creating auth configs programmatically, see the [programmatic auth config guide](/docs/programmatic-auth-configs).
+The requested scopes are invalid or incorrectly formatted in the authorization URL. Verify your scope values against the [Google OAuth scopes docs](https://developers.google.com/identity/protocols/oauth2). If you're creating auth configs programmatically, see the [programmatic auth config guide](/docs/auth-configuration/programmatic-auth-configs).
 
 ## Why does the OAuth consent screen show "Composio" instead of my app?
 
-By default, the consent screen uses Composio's OAuth app. To show your own app name and logo, create your own OAuth app and set a custom redirect URL. See [White-labeling the OAuth consent screen](/docs/custom-auth-configs#white-labeling-the-oauth-consent-screen).
+By default, the consent screen uses Composio's OAuth app. To show your own app name and logo, create your own OAuth app and set a custom redirect URL. See [White-labeling the OAuth consent screen](/docs/auth-configuration/custom-auth-configs#white-labeling-the-oauth-consent-screen).
 
 ## Why am I getting 401 errors on tool calls?
 

--- a/docs/content/toolkit-faq/googledocs.md
+++ b/docs/content/toolkit-faq/googledocs.md
@@ -14,11 +14,11 @@ When using custom OAuth credentials, the Google Docs API must be enabled in the 
 
 ## Why am I getting "Error 400: invalid_scope"?
 
-The requested scopes are invalid or incorrectly formatted in the authorization URL. Verify your scope values against the [Google OAuth scopes docs](https://developers.google.com/identity/protocols/oauth2). If you're creating auth configs programmatically, see the [programmatic auth config guide](/docs/programmatic-auth-configs).
+The requested scopes are invalid or incorrectly formatted in the authorization URL. Verify your scope values against the [Google OAuth scopes docs](https://developers.google.com/identity/protocols/oauth2). If you're creating auth configs programmatically, see the [programmatic auth config guide](/docs/auth-configuration/programmatic-auth-configs).
 
 ## Why does the OAuth consent screen show "Composio" instead of my app?
 
-By default, the consent screen uses Composio's OAuth app. To show your own app name and logo, create your own OAuth app and set a custom redirect URL. See [White-labeling the OAuth consent screen](/docs/custom-auth-configs#white-labeling-the-oauth-consent-screen).
+By default, the consent screen uses Composio's OAuth app. To show your own app name and logo, create your own OAuth app and set a custom redirect URL. See [White-labeling the OAuth consent screen](/docs/auth-configuration/custom-auth-configs#white-labeling-the-oauth-consent-screen).
 
 ## Why am I getting 401 errors on tool calls?
 

--- a/docs/content/toolkit-faq/googledrive.md
+++ b/docs/content/toolkit-faq/googledrive.md
@@ -14,11 +14,11 @@ When using custom OAuth credentials, the Google Drive API must be enabled in the
 
 ## Why am I getting "Error 400: invalid_scope"?
 
-The requested scopes are invalid or incorrectly formatted in the authorization URL. Verify your scope values against the [Google OAuth scopes docs](https://developers.google.com/identity/protocols/oauth2). If you're creating auth configs programmatically, see the [programmatic auth config guide](/docs/programmatic-auth-configs).
+The requested scopes are invalid or incorrectly formatted in the authorization URL. Verify your scope values against the [Google OAuth scopes docs](https://developers.google.com/identity/protocols/oauth2). If you're creating auth configs programmatically, see the [programmatic auth config guide](/docs/auth-configuration/programmatic-auth-configs).
 
 ## Why does the OAuth consent screen show "Composio" instead of my app?
 
-By default, the consent screen uses Composio's OAuth app. To show your own app name and logo, create your own OAuth app and set a custom redirect URL. See [White-labeling the OAuth consent screen](/docs/custom-auth-configs#white-labeling-the-oauth-consent-screen).
+By default, the consent screen uses Composio's OAuth app. To show your own app name and logo, create your own OAuth app and set a custom redirect URL. See [White-labeling the OAuth consent screen](/docs/auth-configuration/custom-auth-configs#white-labeling-the-oauth-consent-screen).
 
 ## Why am I getting 401 errors on tool calls?
 

--- a/docs/content/toolkit-faq/googlemeet.md
+++ b/docs/content/toolkit-faq/googlemeet.md
@@ -14,11 +14,11 @@ When using custom OAuth credentials, the Google Meet API must be enabled in the 
 
 ## Why am I getting "Error 400: invalid_scope"?
 
-The requested scopes are invalid or incorrectly formatted in the authorization URL. Verify your scope values against the [Google OAuth scopes docs](https://developers.google.com/identity/protocols/oauth2). If you're creating auth configs programmatically, see the [programmatic auth config guide](/docs/programmatic-auth-configs).
+The requested scopes are invalid or incorrectly formatted in the authorization URL. Verify your scope values against the [Google OAuth scopes docs](https://developers.google.com/identity/protocols/oauth2). If you're creating auth configs programmatically, see the [programmatic auth config guide](/docs/auth-configuration/programmatic-auth-configs).
 
 ## Why does the OAuth consent screen show "Composio" instead of my app?
 
-By default, the consent screen uses Composio's OAuth app. To show your own app name and logo, create your own OAuth app and set a custom redirect URL. See [White-labeling the OAuth consent screen](/docs/custom-auth-configs#white-labeling-the-oauth-consent-screen).
+By default, the consent screen uses Composio's OAuth app. To show your own app name and logo, create your own OAuth app and set a custom redirect URL. See [White-labeling the OAuth consent screen](/docs/auth-configuration/custom-auth-configs#white-labeling-the-oauth-consent-screen).
 
 ## Why am I getting 401 errors on tool calls?
 

--- a/docs/content/toolkit-faq/googlesheets.md
+++ b/docs/content/toolkit-faq/googlesheets.md
@@ -14,11 +14,11 @@ When using custom OAuth credentials, the Google Sheets API must be enabled in th
 
 ## Why am I getting "Error 400: invalid_scope"?
 
-The requested scopes are invalid or incorrectly formatted in the authorization URL. Verify your scope values against the [Google OAuth scopes docs](https://developers.google.com/identity/protocols/oauth2). If you're creating auth configs programmatically, see the [programmatic auth config guide](/docs/programmatic-auth-configs).
+The requested scopes are invalid or incorrectly formatted in the authorization URL. Verify your scope values against the [Google OAuth scopes docs](https://developers.google.com/identity/protocols/oauth2). If you're creating auth configs programmatically, see the [programmatic auth config guide](/docs/auth-configuration/programmatic-auth-configs).
 
 ## Why does the OAuth consent screen show "Composio" instead of my app?
 
-By default, the consent screen uses Composio's OAuth app. To show your own app name and logo, create your own OAuth app and set a custom redirect URL. See [White-labeling the OAuth consent screen](/docs/custom-auth-configs#white-labeling-the-oauth-consent-screen).
+By default, the consent screen uses Composio's OAuth app. To show your own app name and logo, create your own OAuth app and set a custom redirect URL. See [White-labeling the OAuth consent screen](/docs/auth-configuration/custom-auth-configs#white-labeling-the-oauth-consent-screen).
 
 ## Why am I getting 401 errors on tool calls?
 

--- a/docs/content/toolkit-faq/googleslides.md
+++ b/docs/content/toolkit-faq/googleslides.md
@@ -14,11 +14,11 @@ When using custom OAuth credentials, the Google Slides API must be enabled in th
 
 ## Why am I getting "Error 400: invalid_scope"?
 
-The requested scopes are invalid or incorrectly formatted in the authorization URL. Verify your scope values against the [Google OAuth scopes docs](https://developers.google.com/identity/protocols/oauth2). If you're creating auth configs programmatically, see the [programmatic auth config guide](/docs/programmatic-auth-configs).
+The requested scopes are invalid or incorrectly formatted in the authorization URL. Verify your scope values against the [Google OAuth scopes docs](https://developers.google.com/identity/protocols/oauth2). If you're creating auth configs programmatically, see the [programmatic auth config guide](/docs/auth-configuration/programmatic-auth-configs).
 
 ## Why does the OAuth consent screen show "Composio" instead of my app?
 
-By default, the consent screen uses Composio's OAuth app. To show your own app name and logo, create your own OAuth app and set a custom redirect URL. See [White-labeling the OAuth consent screen](/docs/custom-auth-configs#white-labeling-the-oauth-consent-screen).
+By default, the consent screen uses Composio's OAuth app. To show your own app name and logo, create your own OAuth app and set a custom redirect URL. See [White-labeling the OAuth consent screen](/docs/auth-configuration/custom-auth-configs#white-labeling-the-oauth-consent-screen).
 
 ## Why am I getting 401 errors on tool calls?
 

--- a/docs/content/toolkit-faq/googlesuper.md
+++ b/docs/content/toolkit-faq/googlesuper.md
@@ -14,10 +14,10 @@ When using custom OAuth credentials, the required Google API must be enabled in 
 
 ## Why am I getting "Error 400: invalid_scope"?
 
-The requested scopes are invalid or incorrectly formatted in the authorization URL. Verify your scope values against the [Google OAuth scopes docs](https://developers.google.com/identity/protocols/oauth2). If you're creating auth configs programmatically, see the [programmatic auth config guide](/docs/programmatic-auth-configs).
+The requested scopes are invalid or incorrectly formatted in the authorization URL. Verify your scope values against the [Google OAuth scopes docs](https://developers.google.com/identity/protocols/oauth2). If you're creating auth configs programmatically, see the [programmatic auth config guide](/docs/auth-configuration/programmatic-auth-configs).
 
 ## Why does the OAuth consent screen show "Composio" instead of my app?
 
-By default, the consent screen uses Composio's OAuth app. To show your own app name and logo, create your own OAuth app and set a custom redirect URL. See [White-labeling the OAuth consent screen](/docs/custom-auth-configs#white-labeling-the-oauth-consent-screen).
+By default, the consent screen uses Composio's OAuth app. To show your own app name and logo, create your own OAuth app and set a custom redirect URL. See [White-labeling the OAuth consent screen](/docs/auth-configuration/custom-auth-configs#white-labeling-the-oauth-consent-screen).
 
 ---

--- a/docs/content/toolkit-faq/googletasks.md
+++ b/docs/content/toolkit-faq/googletasks.md
@@ -14,11 +14,11 @@ When using custom OAuth credentials, the Google Tasks API must be enabled in the
 
 ## Why am I getting "Error 400: invalid_scope"?
 
-The requested scopes are invalid or incorrectly formatted in the authorization URL. Verify your scope values against the [Google OAuth scopes docs](https://developers.google.com/identity/protocols/oauth2). If you're creating auth configs programmatically, see the [programmatic auth config guide](/docs/programmatic-auth-configs).
+The requested scopes are invalid or incorrectly formatted in the authorization URL. Verify your scope values against the [Google OAuth scopes docs](https://developers.google.com/identity/protocols/oauth2). If you're creating auth configs programmatically, see the [programmatic auth config guide](/docs/auth-configuration/programmatic-auth-configs).
 
 ## Why does the OAuth consent screen show "Composio" instead of my app?
 
-By default, the consent screen uses Composio's OAuth app. To show your own app name and logo, create your own OAuth app and set a custom redirect URL. See [White-labeling the OAuth consent screen](/docs/custom-auth-configs#white-labeling-the-oauth-consent-screen).
+By default, the consent screen uses Composio's OAuth app. To show your own app name and logo, create your own OAuth app and set a custom redirect URL. See [White-labeling the OAuth consent screen](/docs/auth-configuration/custom-auth-configs#white-labeling-the-oauth-consent-screen).
 
 ## Why am I getting 401 errors on tool calls?
 


### PR DESCRIPTION
## Summary
- Fixed 22 broken internal links across 11 Google toolkit FAQ files
- `/docs/programmatic-auth-configs` → `/docs/auth-configuration/programmatic-auth-configs`
- `/docs/custom-auth-configs#...` → `/docs/auth-configuration/custom-auth-configs#...`

## Test plan
- [ ] Verify links resolve correctly on the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)