### PR TITLE
docs: add providers index page and reorder sidebar

### DIFF
--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -51,15 +51,17 @@ npx skills add composiohq/skills
 Composio works with any AI framework. Pick your preferred SDK:
 
 <ProviderGrid>
-  <ProviderCard name="OpenAI Agents" href="/docs/providers/openai-agents" logo="/images/providers/openai-logo.svg" logoDark="/images/providers/openai-logo-dark.svg" languages={["Python"]} />
+  <ProviderCard name="Claude Agent SDK" href="/docs/providers/claude-agent-sdk" logo="/images/providers/anthropic-logo.svg" logoDark="/images/providers/anthropic-logo-dark.svg" languages={["Python", "TypeScript"]} />
   <ProviderCard name="Anthropic" href="/docs/providers/anthropic" logo="/images/providers/anthropic-logo.svg" logoDark="/images/providers/anthropic-logo-dark.svg" languages={["Python", "TypeScript"]} />
-  <ProviderCard name="Vercel AI SDK" href="/docs/providers/vercel" logo="/images/providers/vercel-logo.svg" logoDark="/images/providers/vercel-logo-dark.svg" languages={["TypeScript"]} />
-  <ProviderCard name="LangChain" href="/docs/providers/langchain" logo="/images/providers/langchain-logo.svg" logoDark="/images/providers/langchain-logo-dark.svg" languages={["Python", "TypeScript"]} />
-  <ProviderCard name="Mastra" href="/docs/providers/mastra" logo="/images/providers/mastra-logo.svg" logoDark="/images/providers/mastra-logo-dark.svg" languages={["TypeScript"]} />
+  <ProviderCard name="OpenAI Agents" href="/docs/providers/openai-agents" logo="/images/providers/openai-logo.svg" logoDark="/images/providers/openai-logo-dark.svg" languages={["Python", "TypeScript"]} />
   <ProviderCard name="OpenAI" href="/docs/providers/openai" logo="/images/providers/openai-logo.svg" logoDark="/images/providers/openai-logo-dark.svg" languages={["Python", "TypeScript"]} />
   <ProviderCard name="Google Gemini" href="/docs/providers/google" logo="/images/providers/google-logo.svg" languages={["Python", "TypeScript"]} />
-  <ProviderCard name="LlamaIndex" href="/docs/providers/llamaindex" logo="/images/providers/llamaIndex-logo.svg" languages={["Python", "TypeScript"]} />
+  <ProviderCard name="Vercel AI SDK" href="/docs/providers/vercel" logo="/images/providers/vercel-logo.svg" logoDark="/images/providers/vercel-logo-dark.svg" languages={["TypeScript"]} />
+  <ProviderCard name="LangChain" href="/docs/providers/langchain" logo="/images/providers/langchain-logo.svg" logoDark="/images/providers/langchain-logo-dark.svg" languages={["Python", "TypeScript"]} />
+  <ProviderCard name="LangGraph" href="/docs/providers/langgraph" logo="/images/providers/langgraph-logo.svg" languages={["Python"]} />
   <ProviderCard name="CrewAI" href="/docs/providers/crewai" logo="/images/providers/crewai-logo.svg" languages={["Python"]} />
+  <ProviderCard name="LlamaIndex" href="/docs/providers/llamaindex" logo="/images/providers/llamaIndex-logo.svg" languages={["Python", "TypeScript"]} />
+  <ProviderCard name="Mastra" href="/docs/providers/mastra" logo="/images/providers/mastra-logo.svg" logoDark="/images/providers/mastra-logo-dark.svg" languages={["TypeScript"]} />
   <ProviderCard name="Build your own" href="/docs/providers/custom-providers" icon={<Blocks size={32} />} languages={["Python", "TypeScript"]} />
 </ProviderGrid>
 

--- a/docs/content/docs/providers/index.mdx
+++ b/docs/content/docs/providers/index.mdx
@@ -5,17 +5,6 @@ description: Composio works with any AI framework. Pick your preferred SDK to ge
 
 Composio works with any AI framework. Each provider transforms Composio tools into the native format your framework expects — no glue code needed.
 
-## AI SDKs
-
-<ProviderGrid>
-  <ProviderCard name="Claude Agent SDK" href="/docs/providers/claude-agent-sdk" logo="/images/providers/anthropic-logo.svg" logoDark="/images/providers/anthropic-logo-dark.svg" languages={["Python", "TypeScript"]} />
-  <ProviderCard name="Anthropic" href="/docs/providers/anthropic" logo="/images/providers/anthropic-logo.svg" logoDark="/images/providers/anthropic-logo-dark.svg" languages={["Python", "TypeScript"]} />
-  <ProviderCard name="OpenAI Agents" href="/docs/providers/openai-agents" logo="/images/providers/openai-logo.svg" logoDark="/images/providers/openai-logo-dark.svg" languages={["Python", "TypeScript"]} />
-  <ProviderCard name="OpenAI" href="/docs/providers/openai" logo="/images/providers/openai-logo.svg" logoDark="/images/providers/openai-logo-dark.svg" languages={["Python", "TypeScript"]} />
-  <ProviderCard name="Google Gemini" href="/docs/providers/google" logo="/images/providers/google-logo.svg" languages={["Python", "TypeScript"]} />
-  <ProviderCard name="Vercel AI SDK" href="/docs/providers/vercel" logo="/images/providers/vercel-logo.svg" logoDark="/images/providers/vercel-logo-dark.svg" languages={["TypeScript"]} />
-</ProviderGrid>
-
 ## Agent Frameworks
 
 <ProviderGrid>
@@ -26,6 +15,17 @@ Composio works with any AI framework. Each provider transforms Composio tools in
   <ProviderCard name="Mastra" href="/docs/providers/mastra" logo="/images/providers/mastra-logo.svg" logoDark="/images/providers/mastra-logo-dark.svg" languages={["TypeScript"]} />
   <ProviderCard name="AutoGen" href="/docs/providers/autogen" languages={["Python"]} />
   <ProviderCard name="Google ADK" href="/docs/providers/google-adk" logo="/images/providers/google-logo.svg" languages={["Python"]} />
+</ProviderGrid>
+
+## AI SDKs
+
+<ProviderGrid>
+  <ProviderCard name="Claude Agent SDK" href="/docs/providers/claude-agent-sdk" logo="/images/providers/anthropic-logo.svg" logoDark="/images/providers/anthropic-logo-dark.svg" languages={["Python", "TypeScript"]} />
+  <ProviderCard name="Anthropic" href="/docs/providers/anthropic" logo="/images/providers/anthropic-logo.svg" logoDark="/images/providers/anthropic-logo-dark.svg" languages={["Python", "TypeScript"]} />
+  <ProviderCard name="OpenAI Agents" href="/docs/providers/openai-agents" logo="/images/providers/openai-logo.svg" logoDark="/images/providers/openai-logo-dark.svg" languages={["Python", "TypeScript"]} />
+  <ProviderCard name="OpenAI" href="/docs/providers/openai" logo="/images/providers/openai-logo.svg" logoDark="/images/providers/openai-logo-dark.svg" languages={["Python", "TypeScript"]} />
+  <ProviderCard name="Google Gemini" href="/docs/providers/google" logo="/images/providers/google-logo.svg" languages={["Python", "TypeScript"]} />
+  <ProviderCard name="Vercel AI SDK" href="/docs/providers/vercel" logo="/images/providers/vercel-logo.svg" logoDark="/images/providers/vercel-logo-dark.svg" languages={["TypeScript"]} />
 </ProviderGrid>
 
 ## Custom

--- a/docs/content/docs/providers/index.mdx
+++ b/docs/content/docs/providers/index.mdx
@@ -1,0 +1,35 @@
+---
+title: Providers
+description: Composio works with any AI framework. Pick your preferred SDK to get started.
+---
+
+Composio works with any AI framework. Each provider transforms Composio tools into the native format your framework expects — no glue code needed.
+
+## AI SDKs
+
+<ProviderGrid>
+  <ProviderCard name="Claude Agent SDK" href="/docs/providers/claude-agent-sdk" logo="/images/providers/anthropic-logo.svg" logoDark="/images/providers/anthropic-logo-dark.svg" languages={["Python", "TypeScript"]} />
+  <ProviderCard name="Anthropic" href="/docs/providers/anthropic" logo="/images/providers/anthropic-logo.svg" logoDark="/images/providers/anthropic-logo-dark.svg" languages={["Python", "TypeScript"]} />
+  <ProviderCard name="OpenAI Agents" href="/docs/providers/openai-agents" logo="/images/providers/openai-logo.svg" logoDark="/images/providers/openai-logo-dark.svg" languages={["Python", "TypeScript"]} />
+  <ProviderCard name="OpenAI" href="/docs/providers/openai" logo="/images/providers/openai-logo.svg" logoDark="/images/providers/openai-logo-dark.svg" languages={["Python", "TypeScript"]} />
+  <ProviderCard name="Google Gemini" href="/docs/providers/google" logo="/images/providers/google-logo.svg" languages={["Python", "TypeScript"]} />
+  <ProviderCard name="Vercel AI SDK" href="/docs/providers/vercel" logo="/images/providers/vercel-logo.svg" logoDark="/images/providers/vercel-logo-dark.svg" languages={["TypeScript"]} />
+</ProviderGrid>
+
+## Agent Frameworks
+
+<ProviderGrid>
+  <ProviderCard name="LangChain" href="/docs/providers/langchain" logo="/images/providers/langchain-logo.svg" logoDark="/images/providers/langchain-logo-dark.svg" languages={["Python", "TypeScript"]} />
+  <ProviderCard name="LangGraph" href="/docs/providers/langgraph" logo="/images/providers/langgraph-logo.svg" languages={["Python"]} />
+  <ProviderCard name="CrewAI" href="/docs/providers/crewai" logo="/images/providers/crewai-logo.svg" languages={["Python"]} />
+  <ProviderCard name="LlamaIndex" href="/docs/providers/llamaindex" logo="/images/providers/llamaIndex-logo.svg" languages={["Python", "TypeScript"]} />
+  <ProviderCard name="Mastra" href="/docs/providers/mastra" logo="/images/providers/mastra-logo.svg" logoDark="/images/providers/mastra-logo-dark.svg" languages={["TypeScript"]} />
+  <ProviderCard name="AutoGen" href="/docs/providers/autogen" languages={["Python"]} />
+  <ProviderCard name="Google ADK" href="/docs/providers/google-adk" logo="/images/providers/google-logo.svg" languages={["Python"]} />
+</ProviderGrid>
+
+## Custom
+
+<ProviderGrid>
+  <ProviderCard name="Build your own" href="/docs/providers/custom-providers" icon={<Blocks size={32} />} languages={["Python", "TypeScript"]} />
+</ProviderGrid>

--- a/docs/content/docs/providers/meta.json
+++ b/docs/content/docs/providers/meta.json
@@ -1,19 +1,20 @@
 {
   "title": "Providers",
   "pages": [
-    "openai-agents",
-    "anthropic",
+    "...",
     "claude-agent-sdk",
-    "vercel",
-    "langchain",
-    "langgraph",
-    "mastra",
+    "anthropic",
+    "openai-agents",
     "openai",
+    "autogen",
+    "crewai",
     "google",
     "google-adk",
+    "langchain",
+    "langgraph",
     "llamaindex",
-    "crewai",
-    "autogen",
+    "mastra",
+    "vercel",
     "custom-providers"
   ]
 }

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -522,11 +522,7 @@ const config = {
         destination: '/docs/quickstart',
         permanent: true,
       },
-      {
-        source: '/docs/providers',
-        destination: '/docs/tools-and-toolkits',
-        permanent: true,
-      },
+      // Removed: /docs/providers now has its own index page
       {
         source: '/docs/providers/custom-providers/my-ai-provider',
         destination: '/docs/providers/custom-providers/typescript',


### PR DESCRIPTION
## Summary
- Add a new providers index page (`/docs/providers`) with card grid layout grouped by category (AI SDKs, Agent Frameworks, Custom)
- Reorder provider sidebar: Claude Agent SDK and Anthropic first, then OpenAI Agents and OpenAI, then rest alphabetical
- Update the docs homepage provider grid to match the new order and include all new providers (Claude Agent SDK, LangGraph)

## Test plan
- [ ] Verify providers index page renders correctly at `/docs/providers`
- [ ] Check card grid layout on mobile
- [ ] Verify all provider links work
- [ ] Check sidebar order matches the new grouping

🤖 Generated with [Claude Code](https://claude.com/claude-code)