### PR TITLE
feat(ai): add CLI development skills trilogy

### DIFF
--- a/.claude/skills/create-cli-e2e/SKILL.md
+++ b/.claude/skills/create-cli-e2e/SKILL.md
@@ -1,0 +1,616 @@
+# CLI E2E Test Development
+
+Write, expand, and maintain end-to-end tests for CLI commands in `ts/e2e-tests/cli/`.
+
+## When to Use
+
+- Adding a new e2e test suite for a CLI command
+- Modifying or extending an existing CLI e2e test
+- Debugging a failing CLI e2e test
+- Reviewing whether a CLI command's output contract is properly tested
+
+## Architecture
+
+Each CLI e2e test runs the compiled `composio` binary inside a **scratch Debian Docker container**. The binary is self-contained (built via `bun build --compile`) — no Node, Bun, or pnpm exists in the runtime image.
+
+Key properties:
+
+- Each test suite = a directory under `ts/e2e-tests/cli/<suite-name>/`
+- Use `runCmd` only. Never use `runFixture` (throws an error for CLI tests). Never set `usesFixtures`.
+- **Each `runCmd` call creates a fresh container.** No state persists between calls.
+- Commands run inside `sh -c '...'` — POSIX shell only, no bash-isms.
+- Containers have network access — API-calling commands work.
+- `HOME=/tmp`, cache dir is `/tmp/.composio/` — auth passes via env vars only.
+- `process.stdout.isTTY` is always `false` inside Docker — the CLI always runs in piped mode.
+
+### What "piped mode" means for tests
+
+Inside Docker `sh -c`, the composio binary's stdout is never a TTY. This means `ui.output()` writes to stdout and all Clack decoration is suppressed. Both test groups verify piped-mode behavior:
+
+| Test Group | What It Verifies |
+|---|---|
+| **Command execution** (`composio version`) | stdout contains the data, stderr is empty |
+| **Stdout redirection** (`composio version > out.txt`) | Shell-level redirect captures data into a file; Docker stdout and stderr are both empty |
+
+## File Structure
+
+For a new test suite `<suite-name>`, create 2 files:
+
+```
+ts/e2e-tests/cli/<suite-name>/
+├── e2e.test.ts     # Test file
+└── package.json    # Package manifest
+```
+
+### Naming Conventions
+
+- **Directory**: hyphen-separated lowercase matching the command structure
+  - `version`, `whoami`, `toolkits-list`, `tools-info`, `auth-configs-list`, `connected-accounts-link`
+- **Package name**: `@e2e-tests/cli-<suite-name>`
+  - `@e2e-tests/cli-version`, `@e2e-tests/cli-toolkits-list`
+
+### package.json Template
+
+```json
+{
+  "name": "@e2e-tests/cli-<suite-name>",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test:e2e": "bun test e2e.test.ts",
+    "test:e2e:cli": "bun test e2e.test.ts"
+  },
+  "devDependencies": {
+    "@e2e-tests/utils": "workspace:*"
+  }
+}
+```
+
+## Test Patterns
+
+Every test file starts with the same structure:
+
+```typescript
+import { e2e, sanitizeOutput, type E2ETestResult, type E2ETestResultWithFiles } from '@e2e-tests/utils';
+import { TIMEOUTS } from '@e2e-tests/utils/const';
+import { describe, it, expect, beforeAll } from 'bun:test';
+
+e2e(import.meta.url, {
+  versions: { cli: ['current'] },
+  // env: { ... },  // Only if needed
+  defineTests: ({ runCmd }) => {
+    // Tests here
+  },
+});
+```
+
+### Pattern A: Simple Command, No Env Vars
+
+For commands that produce deterministic output without needing authentication.
+
+**Reference**: `ts/e2e-tests/cli/version/e2e.test.ts`
+
+```typescript
+/**
+ * CLI version command e2e test
+ *
+ * Verifies that the compiled composio CLI behaves correctly in a scratch container.
+ */
+
+import { e2e, sanitizeOutput, type E2ETestResult, type E2ETestResultWithFiles } from '@e2e-tests/utils';
+import { TIMEOUTS } from '@e2e-tests/utils/const';
+import { describe, it, expect, beforeAll } from 'bun:test';
+import cliPkg from '../../../packages/cli/package.json' with { type: 'json' };
+
+e2e(import.meta.url, {
+  versions: {
+    cli: ['current'],
+  },
+  defineTests: ({ runCmd }) => {
+    const expectedVersion = String(cliPkg.version ?? '').trim();
+    let versionResult: E2ETestResult;
+    let redirectedResult: E2ETestResultWithFiles<'out.txt'>;
+
+    beforeAll(async () => {
+      versionResult = await runCmd('composio version');
+      redirectedResult = await runCmd({
+        command: 'composio version > out.txt',
+        files: ['out.txt'],
+      });
+    }, TIMEOUTS.FIXTURE);
+
+    describe('composio version', () => {
+      it('exits successfully', () => {
+        expect(versionResult.exitCode).toBe(0);
+      });
+
+      it('stdout matches snapshot', () => {
+        expect(sanitizeOutput(versionResult.stdout)).toBe(expectedVersion);
+      });
+
+      it('stderr matches snapshot', () => {
+        expect(versionResult.stderr).toBe('');
+      });
+    });
+
+    describe('stdout redirection to out.txt', () => {
+      it('exits successfully', () => {
+        expect(redirectedResult.exitCode).toBe(0);
+      });
+
+      it('stdout is empty', () => {
+        expect(redirectedResult.stdout).toBe('');
+      });
+
+      it('stderr is empty', () => {
+        expect(redirectedResult.stderr).toBe('');
+      });
+
+      it('out.txt matches snapshot', () => {
+        expect(sanitizeOutput(redirectedResult.files['out.txt'])).toBe(expectedVersion);
+      });
+    });
+  },
+});
+```
+
+### Pattern B: Command Requiring Env Vars
+
+For commands that need authentication or configuration from the host environment.
+
+**Reference**: `ts/e2e-tests/cli/whoami/e2e.test.ts`
+
+Three additions compared to Pattern A:
+
+1. **Type augmentation** for compile-time safety on `Bun.env`:
+   ```typescript
+   declare module 'bun' {
+     interface Env {
+       COMPOSIO_API_KEY: string;
+     }
+   }
+   ```
+
+2. **Pass env vars** in the config:
+   ```typescript
+   env: {
+     COMPOSIO_API_KEY: Bun.env.COMPOSIO_API_KEY,
+   },
+   ```
+
+3. **Derive expected values** from the env:
+   ```typescript
+   const expectedApiKey = Bun.env.COMPOSIO_API_KEY.trim();
+   ```
+
+The rest follows the same two-group structure (command execution + stdout redirection).
+
+**Full example:**
+
+```typescript
+/**
+ * CLI whoami command e2e test
+ *
+ * Verifies that the compiled composio CLI prints the API key in a scratch container.
+ */
+
+import { e2e, sanitizeOutput, type E2ETestResult, type E2ETestResultWithFiles } from '@e2e-tests/utils';
+import { TIMEOUTS } from '@e2e-tests/utils/const';
+import { describe, it, expect, beforeAll } from 'bun:test';
+
+declare module 'bun' {
+  interface Env {
+    COMPOSIO_API_KEY: string;
+  }
+}
+
+e2e(import.meta.url, {
+  versions: {
+    cli: ['current'],
+  },
+  env: {
+    COMPOSIO_API_KEY: Bun.env.COMPOSIO_API_KEY,
+  },
+  defineTests: ({ runCmd }) => {
+    const expectedApiKey = Bun.env.COMPOSIO_API_KEY.trim();
+    let whoamiResult: E2ETestResult;
+    let redirectedResult: E2ETestResultWithFiles<'out.txt'>;
+
+    beforeAll(async () => {
+      whoamiResult = await runCmd('composio whoami');
+      redirectedResult = await runCmd({
+        command: 'composio whoami > out.txt',
+        files: ['out.txt'],
+      });
+    }, TIMEOUTS.FIXTURE);
+
+    describe('composio whoami', () => {
+      it('exits successfully', () => {
+        expect(whoamiResult.exitCode).toBe(0);
+      });
+
+      it('stdout contains the API key', () => {
+        expect(sanitizeOutput(whoamiResult.stdout)).toBe(expectedApiKey);
+      });
+
+      it('stderr is empty', () => {
+        expect(whoamiResult.stderr).toBe('');
+      });
+    });
+
+    describe('stdout redirection to out.txt', () => {
+      it('exits successfully', () => {
+        expect(redirectedResult.exitCode).toBe(0);
+      });
+
+      it('stdout is empty', () => {
+        expect(redirectedResult.stdout).toBe('');
+      });
+
+      it('stderr is empty', () => {
+        expect(redirectedResult.stderr).toBe('');
+      });
+
+      it('out.txt contains the API key', () => {
+        expect(sanitizeOutput(redirectedResult.files['out.txt'])).toBe(expectedApiKey);
+      });
+    });
+  },
+});
+```
+
+### Pattern C: Error Case Testing
+
+For verifying that the CLI fails gracefully with correct exit codes and error messages.
+
+```typescript
+/**
+ * CLI tools-info error case e2e test
+ *
+ * Verifies that the CLI fails gracefully when required arguments are missing.
+ */
+
+import { e2e, sanitizeOutput, type E2ETestResult } from '@e2e-tests/utils';
+import { TIMEOUTS } from '@e2e-tests/utils/const';
+import { describe, it, expect, beforeAll } from 'bun:test';
+
+e2e(import.meta.url, {
+  versions: {
+    cli: ['current'],
+  },
+  defineTests: ({ runCmd }) => {
+    let missingArgResult: E2ETestResult;
+
+    beforeAll(async () => {
+      missingArgResult = await runCmd('composio tools info');
+    }, TIMEOUTS.FIXTURE);
+
+    describe('composio tools info (missing argument)', () => {
+      it('exits with non-zero code', () => {
+        expect(missingArgResult.exitCode).not.toBe(0);
+      });
+
+      it('stderr contains an error message', () => {
+        expect(missingArgResult.stderr).not.toBe('');
+      });
+    });
+  },
+});
+```
+
+Notes:
+- No stdout redirection test needed — error cases don't produce data output.
+- Use `not.toBe(0)` for exit code rather than a specific number (the CLI may change error codes).
+- Assert stderr is non-empty; optionally use `toContain()` for specific error message fragments.
+
+### Pattern D: Multi-line / API-dependent Output
+
+For commands that call the Composio API and return dynamic, multi-line data.
+
+```typescript
+/**
+ * CLI toolkits-list command e2e test
+ *
+ * Verifies that the CLI lists available toolkits from the API.
+ */
+
+import { e2e, sanitizeOutput, type E2ETestResult, type E2ETestResultWithFiles } from '@e2e-tests/utils';
+import { TIMEOUTS } from '@e2e-tests/utils/const';
+import { describe, it, expect, beforeAll } from 'bun:test';
+
+declare module 'bun' {
+  interface Env {
+    COMPOSIO_API_KEY: string;
+  }
+}
+
+e2e(import.meta.url, {
+  versions: {
+    cli: ['current'],
+  },
+  env: {
+    COMPOSIO_API_KEY: Bun.env.COMPOSIO_API_KEY,
+  },
+  defineTests: ({ runCmd }) => {
+    let listResult: E2ETestResult;
+    let redirectedResult: E2ETestResultWithFiles<'out.txt'>;
+
+    beforeAll(async () => {
+      listResult = await runCmd('composio toolkits list');
+      redirectedResult = await runCmd({
+        command: 'composio toolkits list > out.txt',
+        files: ['out.txt'],
+      });
+    }, TIMEOUTS.FIXTURE);
+
+    describe('composio toolkits list', () => {
+      it('exits successfully', () => {
+        expect(listResult.exitCode).toBe(0);
+      });
+
+      it('stdout is non-empty', () => {
+        expect(sanitizeOutput(listResult.stdout).length).toBeGreaterThan(0);
+      });
+
+      it('stdout contains known toolkits', () => {
+        const output = sanitizeOutput(listResult.stdout);
+        // Use well-known toolkits that are always present
+        expect(output).toContain('github');
+      });
+
+      it('stdout has multiple lines', () => {
+        const lines = sanitizeOutput(listResult.stdout).split('\n').filter(Boolean);
+        expect(lines.length).toBeGreaterThan(1);
+      });
+
+      it('stderr is empty', () => {
+        expect(listResult.stderr).toBe('');
+      });
+    });
+
+    describe('stdout redirection to out.txt', () => {
+      it('exits successfully', () => {
+        expect(redirectedResult.exitCode).toBe(0);
+      });
+
+      it('stdout is empty', () => {
+        expect(redirectedResult.stdout).toBe('');
+      });
+
+      it('stderr is empty', () => {
+        expect(redirectedResult.stderr).toBe('');
+      });
+
+      it('out.txt contains data', () => {
+        expect(sanitizeOutput(redirectedResult.files['out.txt']).length).toBeGreaterThan(0);
+      });
+    });
+  },
+});
+```
+
+Key rules for API-dependent output:
+- **Never use exact-match assertions** (`toBe`) on API data — the data changes over time.
+- Use `toContain()` for known, stable items (e.g., `github`, `gmail` are always present).
+- Use `toBeGreaterThan()` for structural checks (line count, length).
+- Use `toMatch()` with regex for format validation.
+
+### Pattern E: Action Command, No Stdout Data
+
+For commands that perform an action but produce no machine-readable output (e.g., `logout`, `upgrade`).
+
+```typescript
+/**
+ * CLI logout command e2e test
+ *
+ * Verifies that the CLI logout command completes without error.
+ */
+
+import { e2e, type E2ETestResult } from '@e2e-tests/utils';
+import { TIMEOUTS } from '@e2e-tests/utils/const';
+import { describe, it, expect, beforeAll } from 'bun:test';
+
+e2e(import.meta.url, {
+  versions: {
+    cli: ['current'],
+  },
+  defineTests: ({ runCmd }) => {
+    let logoutResult: E2ETestResult;
+
+    beforeAll(async () => {
+      logoutResult = await runCmd('composio logout');
+    }, TIMEOUTS.FIXTURE);
+
+    describe('composio logout', () => {
+      it('exits successfully', () => {
+        expect(logoutResult.exitCode).toBe(0);
+      });
+
+      it('stdout is empty', () => {
+        expect(logoutResult.stdout).toBe('');
+      });
+
+      it('stderr is empty', () => {
+        expect(logoutResult.stderr).toBe('');
+      });
+    });
+  },
+});
+```
+
+Notes:
+- No redirection test needed — there's no data to redirect.
+- No `sanitizeOutput()` needed — stdout should be literally empty.
+- Import only `E2ETestResult`, not `E2ETestResultWithFiles`.
+
+## Output Contract Rules
+
+Enforce these in every CLI e2e test:
+
+1. **Data commands** produce machine-readable output on stdout (via `ui.output()`).
+2. **Action commands** produce no stdout data — stdout is always empty.
+3. **stderr is always empty** for successful commands (non-TTY suppresses all Clack decoration).
+4. **Redirected output** (`> out.txt`) captures the same data that direct stdout contains; Docker stdout and stderr both become empty.
+
+## Commands NOT Testable with This Framework
+
+Do not attempt to write e2e tests for:
+
+| Category | Examples | Why |
+|---|---|---|
+| **Interactive commands** | `login`, `init` (with prompts) | No TTY in Docker — Clack prompts hang |
+| **Long-running commands** | `triggers listen` | No mechanism to stop the process |
+| **Browser-dependent commands** | `login` (without `--no-browser`) | No browser in Docker |
+| **Host filesystem writers** | `generate` (writes to project dir) | Docker container is isolated |
+
+## Environment Variables
+
+### Auto-passed vars
+
+`COMPOSIO_API_KEY` and `OPENAI_API_KEY` are automatically forwarded to Docker containers if present on the host (defined in `WELL_KNOWN_ENV_VARS`).
+
+### Declaring required vars
+
+For tests that need env vars:
+
+1. Add the `declare module 'bun'` augmentation (compile-time safety).
+2. Pass via `E2EConfig.env` (runtime delivery to Docker).
+3. If any `E2EConfig.env` value is `undefined`, the test fails fast at startup — before any Docker container runs.
+
+### Multiple env vars
+
+```typescript
+declare module 'bun' {
+  interface Env {
+    COMPOSIO_API_KEY: string;
+    COMPOSIO_BASE_URL: string;
+  }
+}
+
+e2e(import.meta.url, {
+  env: {
+    COMPOSIO_API_KEY: Bun.env.COMPOSIO_API_KEY,
+    COMPOSIO_BASE_URL: Bun.env.COMPOSIO_BASE_URL,
+  },
+  // ...
+});
+```
+
+## Shell Quoting
+
+Commands run inside `sh -c '...'` in a POSIX shell. Rules:
+
+- Use double quotes for flag values with spaces or special chars:
+  ```typescript
+  runCmd('composio tools info "GMAIL_SEND_EMAIL"')
+  ```
+- Use single quotes inside double-quoted contexts for literal strings.
+- **No bash-isms**: no `[[`, no `$()`, no arrays.
+- `PATH` is `/usr/local/bin:/bin` — set in the Dockerfile.
+
+## Checklist for Adding a New Test Suite
+
+1. **Create directory**: `ts/e2e-tests/cli/<suite-name>/`
+2. **Create `package.json`**: Use the template above with name `@e2e-tests/cli-<suite-name>`
+3. **Create `e2e.test.ts`**: Follow the appropriate pattern (A through E)
+4. **Run `pnpm install`** from the monorepo root to resolve the workspace link
+5. **Run `pnpm test:e2e:cli`** to verify the test passes
+6. **Update `ts/e2e-tests/cli/README.md`**: Add a new row to the test suites table
+
+### README table format
+
+```markdown
+| [suite-name](./suite-name/) | `composio <command>` description | `ENV_VAR_1`, `ENV_VAR_2` (or None) |
+```
+
+## Troubleshooting
+
+### Reading DEBUG.log
+
+Each test suite generates a `DEBUG.log` in its directory with Docker execution details: container name, command, duration, exit code, stdout, stderr. Read this first when a test fails.
+
+### Stale Docker image
+
+If CLI code changed but tests show old behavior, the Docker image is cached. Rebuild:
+
+```bash
+docker rmi composio-e2e-cli:$(jq -r .version ts/packages/cli/package.json)
+```
+
+### Shell quoting issues
+
+Check the command string in `DEBUG.log`. Look for unescaped special characters that break `sh -c` parsing.
+
+### Missing env vars
+
+The error appears at test startup (before any Docker container runs), not during execution. Verify `Bun.env.*` values are set in your shell.
+
+### Container statelessness
+
+Each `runCmd` call runs in a fresh container. If you need to test a multi-step workflow (e.g., "set config then run command"), you must chain commands in a single `runCmd` call:
+
+```typescript
+runCmd('composio logout && composio whoami')
+```
+
+## API Reference
+
+### `e2e(importMetaUrl, config)`
+
+Entry point. Pass `import.meta.url` as the first argument — the framework infers `cwd` and `suiteName` from the file path.
+
+### `E2EConfig`
+
+```typescript
+{
+  versions: { cli: ['current'] },  // Always use ['current'] for CLI tests
+  env?: Record<string, string | undefined>,  // Env vars to pass to Docker
+  defineTests: (ctx: DefineTestsContext) => void,
+}
+```
+
+### `runCmd` (two overloads)
+
+```typescript
+// Simple: returns { exitCode, stdout, stderr }
+const result: E2ETestResult = await runCmd('composio version');
+
+// With file capture: returns { exitCode, stdout, stderr, files }
+const result: E2ETestResultWithFiles<'out.txt'> = await runCmd({
+  command: 'composio version > out.txt',
+  files: ['out.txt'],
+});
+// Access: result.files['out.txt']
+```
+
+### `sanitizeOutput(output)`
+
+Strips ANSI escape codes, normalizes `\r\n` to `\n`, trims whitespace. Use on stdout and file contents before assertions.
+
+### `TIMEOUTS`
+
+```typescript
+TIMEOUTS.DEFAULT   // 5_000ms   — individual test timeout
+TIMEOUTS.FIXTURE   // 120_000ms — beforeAll timeout (Docker startup + command execution)
+TIMEOUTS.LLM_SHORT // 30_000ms  — commands involving LLM calls
+TIMEOUTS.LLM_LONG  // 60_000ms  — commands involving longer LLM calls
+```
+
+Use `TIMEOUTS.FIXTURE` for the `beforeAll` that runs Docker commands. Use `TIMEOUTS.DEFAULT` for individual `it()` blocks (the default).
+
+## Reference Files
+
+| File | Purpose |
+|---|---|
+| `ts/e2e-tests/cli/version/e2e.test.ts` | Pattern A reference |
+| `ts/e2e-tests/cli/whoami/e2e.test.ts` | Pattern B reference |
+| `ts/e2e-tests/_utils/src/types.ts` | `E2EConfig`, `E2ETestResult`, `DefineTestsContext` types |
+| `ts/e2e-tests/_utils/src/e2e.ts` | `e2e()` entry point |
+| `ts/e2e-tests/_utils/src/const.ts` | `TIMEOUTS`, `WELL_KNOWN_ENV_VARS` |
+| `ts/e2e-tests/_utils/src/sanitize.ts` | `sanitizeOutput()` |
+| `ts/e2e-tests/_utils/Dockerfile.cli` | Docker image definition |
+| `ts/e2e-tests/cli/README.md` | Test suites table |
+| `CLI.md` | Planned CLI commands |
+| `ts/packages/cli/CLAUDE.md` | CLI architecture and output conventions |

--- a/.claude/skills/create-cli-e2e/SKILL.md
+++ b/.claude/skills/create-cli-e2e/SKILL.md
@@ -1,3 +1,7 @@
+---
+description: Write end-to-end tests for CLI commands using the Docker-based test framework in ts/e2e-tests/cli/.
+---
+
 # CLI E2E Test Development
 
 Write, expand, and maintain end-to-end tests for CLI commands in `ts/e2e-tests/cli/`.
@@ -8,6 +12,9 @@ Write, expand, and maintain end-to-end tests for CLI commands in `ts/e2e-tests/c
 - Modifying or extending an existing CLI e2e test
 - Debugging a failing CLI e2e test
 - Reviewing whether a CLI command's output contract is properly tested
+
+For CLI **design** (arguments, flags, help text, UX), see the `create-cli` skill.
+For CLI **implementation** (Effect patterns, services, command registration), see the `implement-cli-command` skill.
 
 ## Architecture
 
@@ -25,12 +32,10 @@ Key properties:
 
 ### What "piped mode" means for tests
 
-Inside Docker `sh -c`, the composio binary's stdout is never a TTY. This means `ui.output()` writes to stdout and all Clack decoration is suppressed. Both test groups verify piped-mode behavior:
-
-| Test Group | What It Verifies |
-|---|---|
-| **Command execution** (`composio version`) | stdout contains the data, stderr is empty |
-| **Stdout redirection** (`composio version > out.txt`) | Shell-level redirect captures data into a file; Docker stdout and stderr are both empty |
+Inside Docker, the composio binary's stdout is never a TTY. This triggers the CLI's piped-mode behavior (see `ts/packages/cli/AGENTS.md` § "Output Conventions"):
+- `ui.output()` writes to stdout
+- All Clack decoration is suppressed
+- stderr is empty for successful commands
 
 ## File Structure
 
@@ -68,27 +73,31 @@ ts/e2e-tests/cli/<suite-name>/
 }
 ```
 
-## Test Patterns
+## Choosing a Test Pattern
 
-Every test file starts with the same structure:
+Use this decision tree to select the right pattern:
 
-```typescript
-import { e2e, sanitizeOutput, type E2ETestResult, type E2ETestResultWithFiles } from '@e2e-tests/utils';
-import { TIMEOUTS } from '@e2e-tests/utils/const';
-import { describe, it, expect, beforeAll } from 'bun:test';
+```
+Does the command need env vars (e.g., COMPOSIO_API_KEY)?
+├─ No → Is the output deterministic (exact value known at test time)?
+│       ├─ Yes → Pattern A (simple command, exact assertions)
+│       └─ No  → Pattern D (fuzzy assertions: toContain, toBeGreaterThan)
+└─ Yes → Is the output deterministic given the env?
+         ├─ Yes → Pattern B (env vars + exact assertions)
+         └─ No  → Pattern D (env vars + fuzzy assertions)
 
-e2e(import.meta.url, {
-  versions: { cli: ['current'] },
-  // env: { ... },  // Only if needed
-  defineTests: ({ runCmd }) => {
-    // Tests here
-  },
-});
+Are you testing an error case (missing args, invalid input)?
+└─ Yes → Pattern C (non-zero exit code, stderr non-empty)
+
+Does the command perform an action with no machine-readable output?
+└─ Yes → Pattern E (exitCode=0, stdout empty, no redirect test)
 ```
 
-### Pattern A: Simple Command, No Env Vars
+## Test Patterns
 
-For commands that produce deterministic output without needing authentication.
+### Pattern A: Simple Command, No Env Vars (Canonical)
+
+For commands that produce deterministic output without needing authentication. This is the base pattern — all other patterns are variations of this.
 
 **Reference**: `ts/e2e-tests/cli/version/e2e.test.ts`
 
@@ -156,13 +165,16 @@ e2e(import.meta.url, {
 });
 ```
 
+**Structure summary:**
+- Two test groups: **command execution** (stdout has data, stderr empty) + **stdout redirection** (file has data, Docker stdout/stderr both empty)
+- Use `sanitizeOutput()` on stdout and file contents before assertions
+- Use `TIMEOUTS.FIXTURE` for the `beforeAll` that runs Docker commands
+
 ### Pattern B: Command Requiring Env Vars
 
-For commands that need authentication or configuration from the host environment.
+**Same as Pattern A**, with three additions:
 
 **Reference**: `ts/e2e-tests/cli/whoami/e2e.test.ts`
-
-Three additions compared to Pattern A:
 
 1. **Type augmentation** for compile-time safety on `Bun.env`:
    ```typescript
@@ -187,99 +199,21 @@ Three additions compared to Pattern A:
 
 The rest follows the same two-group structure (command execution + stdout redirection).
 
-**Full example:**
-
-```typescript
-/**
- * CLI whoami command e2e test
- *
- * Verifies that the compiled composio CLI prints the API key in a scratch container.
- */
-
-import { e2e, sanitizeOutput, type E2ETestResult, type E2ETestResultWithFiles } from '@e2e-tests/utils';
-import { TIMEOUTS } from '@e2e-tests/utils/const';
-import { describe, it, expect, beforeAll } from 'bun:test';
-
-declare module 'bun' {
-  interface Env {
-    COMPOSIO_API_KEY: string;
-  }
-}
-
-e2e(import.meta.url, {
-  versions: {
-    cli: ['current'],
-  },
-  env: {
-    COMPOSIO_API_KEY: Bun.env.COMPOSIO_API_KEY,
-  },
-  defineTests: ({ runCmd }) => {
-    const expectedApiKey = Bun.env.COMPOSIO_API_KEY.trim();
-    let whoamiResult: E2ETestResult;
-    let redirectedResult: E2ETestResultWithFiles<'out.txt'>;
-
-    beforeAll(async () => {
-      whoamiResult = await runCmd('composio whoami');
-      redirectedResult = await runCmd({
-        command: 'composio whoami > out.txt',
-        files: ['out.txt'],
-      });
-    }, TIMEOUTS.FIXTURE);
-
-    describe('composio whoami', () => {
-      it('exits successfully', () => {
-        expect(whoamiResult.exitCode).toBe(0);
-      });
-
-      it('stdout contains the API key', () => {
-        expect(sanitizeOutput(whoamiResult.stdout)).toBe(expectedApiKey);
-      });
-
-      it('stderr is empty', () => {
-        expect(whoamiResult.stderr).toBe('');
-      });
-    });
-
-    describe('stdout redirection to out.txt', () => {
-      it('exits successfully', () => {
-        expect(redirectedResult.exitCode).toBe(0);
-      });
-
-      it('stdout is empty', () => {
-        expect(redirectedResult.stdout).toBe('');
-      });
-
-      it('stderr is empty', () => {
-        expect(redirectedResult.stderr).toBe('');
-      });
-
-      it('out.txt contains the API key', () => {
-        expect(sanitizeOutput(redirectedResult.files['out.txt'])).toBe(expectedApiKey);
-      });
-    });
-  },
-});
-```
-
 ### Pattern C: Error Case Testing
 
-For verifying that the CLI fails gracefully with correct exit codes and error messages.
+**Differences from Pattern A:**
+- No stdout redirection test needed — error cases don't produce data output
+- Assert non-zero exit code with `not.toBe(0)` (don't hardcode a specific error code)
+- Assert stderr is non-empty; optionally use `toContain()` for specific error message fragments
+- Import only `E2ETestResult`, not `E2ETestResultWithFiles`
 
 ```typescript
-/**
- * CLI tools-info error case e2e test
- *
- * Verifies that the CLI fails gracefully when required arguments are missing.
- */
-
 import { e2e, sanitizeOutput, type E2ETestResult } from '@e2e-tests/utils';
 import { TIMEOUTS } from '@e2e-tests/utils/const';
 import { describe, it, expect, beforeAll } from 'bun:test';
 
 e2e(import.meta.url, {
-  versions: {
-    cli: ['current'],
-  },
+  versions: { cli: ['current'] },
   defineTests: ({ runCmd }) => {
     let missingArgResult: E2ETestResult;
 
@@ -300,122 +234,42 @@ e2e(import.meta.url, {
 });
 ```
 
-Notes:
-- No stdout redirection test needed — error cases don't produce data output.
-- Use `not.toBe(0)` for exit code rather than a specific number (the CLI may change error codes).
-- Assert stderr is non-empty; optionally use `toContain()` for specific error message fragments.
+Pattern C can be combined with A or B in the same test file to test both success and error paths.
 
 ### Pattern D: Multi-line / API-dependent Output
 
-For commands that call the Composio API and return dynamic, multi-line data.
+**Same structure as Pattern A or B** (depending on whether env vars are needed), with different assertion strategies:
 
-```typescript
-/**
- * CLI toolkits-list command e2e test
- *
- * Verifies that the CLI lists available toolkits from the API.
- */
-
-import { e2e, sanitizeOutput, type E2ETestResult, type E2ETestResultWithFiles } from '@e2e-tests/utils';
-import { TIMEOUTS } from '@e2e-tests/utils/const';
-import { describe, it, expect, beforeAll } from 'bun:test';
-
-declare module 'bun' {
-  interface Env {
-    COMPOSIO_API_KEY: string;
-  }
-}
-
-e2e(import.meta.url, {
-  versions: {
-    cli: ['current'],
-  },
-  env: {
-    COMPOSIO_API_KEY: Bun.env.COMPOSIO_API_KEY,
-  },
-  defineTests: ({ runCmd }) => {
-    let listResult: E2ETestResult;
-    let redirectedResult: E2ETestResultWithFiles<'out.txt'>;
-
-    beforeAll(async () => {
-      listResult = await runCmd('composio toolkits list');
-      redirectedResult = await runCmd({
-        command: 'composio toolkits list > out.txt',
-        files: ['out.txt'],
-      });
-    }, TIMEOUTS.FIXTURE);
-
-    describe('composio toolkits list', () => {
-      it('exits successfully', () => {
-        expect(listResult.exitCode).toBe(0);
-      });
-
-      it('stdout is non-empty', () => {
-        expect(sanitizeOutput(listResult.stdout).length).toBeGreaterThan(0);
-      });
-
-      it('stdout contains known toolkits', () => {
-        const output = sanitizeOutput(listResult.stdout);
-        // Use well-known toolkits that are always present
-        expect(output).toContain('github');
-      });
-
-      it('stdout has multiple lines', () => {
-        const lines = sanitizeOutput(listResult.stdout).split('\n').filter(Boolean);
-        expect(lines.length).toBeGreaterThan(1);
-      });
-
-      it('stderr is empty', () => {
-        expect(listResult.stderr).toBe('');
-      });
-    });
-
-    describe('stdout redirection to out.txt', () => {
-      it('exits successfully', () => {
-        expect(redirectedResult.exitCode).toBe(0);
-      });
-
-      it('stdout is empty', () => {
-        expect(redirectedResult.stdout).toBe('');
-      });
-
-      it('stderr is empty', () => {
-        expect(redirectedResult.stderr).toBe('');
-      });
-
-      it('out.txt contains data', () => {
-        expect(sanitizeOutput(redirectedResult.files['out.txt']).length).toBeGreaterThan(0);
-      });
-    });
-  },
-});
-```
-
-Key rules for API-dependent output:
 - **Never use exact-match assertions** (`toBe`) on API data — the data changes over time.
 - Use `toContain()` for known, stable items (e.g., `github`, `gmail` are always present).
 - Use `toBeGreaterThan()` for structural checks (line count, length).
 - Use `toMatch()` with regex for format validation.
 
+```typescript
+// Instead of:
+expect(sanitizeOutput(listResult.stdout)).toBe(exactValue);
+
+// Use fuzzy assertions:
+expect(sanitizeOutput(listResult.stdout).length).toBeGreaterThan(0);
+expect(sanitizeOutput(listResult.stdout)).toContain('github');
+const lines = sanitizeOutput(listResult.stdout).split('\n').filter(Boolean);
+expect(lines.length).toBeGreaterThan(1);
+```
+
+The redirect test group is identical to Pattern A — assert the file contains data, Docker stdout/stderr are empty.
+
 ### Pattern E: Action Command, No Stdout Data
 
 For commands that perform an action but produce no machine-readable output (e.g., `logout`, `upgrade`).
 
+**Differences from Pattern A:**
+- No redirection test — there's no data to redirect
+- stdout should be literally empty (no `sanitizeOutput()` needed)
+- Import only `E2ETestResult`, not `E2ETestResultWithFiles`
+
 ```typescript
-/**
- * CLI logout command e2e test
- *
- * Verifies that the CLI logout command completes without error.
- */
-
-import { e2e, type E2ETestResult } from '@e2e-tests/utils';
-import { TIMEOUTS } from '@e2e-tests/utils/const';
-import { describe, it, expect, beforeAll } from 'bun:test';
-
 e2e(import.meta.url, {
-  versions: {
-    cli: ['current'],
-  },
+  versions: { cli: ['current'] },
   defineTests: ({ runCmd }) => {
     let logoutResult: E2ETestResult;
 
@@ -439,20 +293,6 @@ e2e(import.meta.url, {
   },
 });
 ```
-
-Notes:
-- No redirection test needed — there's no data to redirect.
-- No `sanitizeOutput()` needed — stdout should be literally empty.
-- Import only `E2ETestResult`, not `E2ETestResultWithFiles`.
-
-## Output Contract Rules
-
-Enforce these in every CLI e2e test:
-
-1. **Data commands** produce machine-readable output on stdout (via `ui.output()`).
-2. **Action commands** produce no stdout data — stdout is always empty.
-3. **stderr is always empty** for successful commands (non-TTY suppresses all Clack decoration).
-4. **Redirected output** (`> out.txt`) captures the same data that direct stdout contains; Docker stdout and stderr both become empty.
 
 ## Commands NOT Testable with This Framework
 
@@ -557,20 +397,6 @@ runCmd('composio logout && composio whoami')
 
 ## API Reference
 
-### `e2e(importMetaUrl, config)`
-
-Entry point. Pass `import.meta.url` as the first argument — the framework infers `cwd` and `suiteName` from the file path.
-
-### `E2EConfig`
-
-```typescript
-{
-  versions: { cli: ['current'] },  // Always use ['current'] for CLI tests
-  env?: Record<string, string | undefined>,  // Env vars to pass to Docker
-  defineTests: (ctx: DefineTestsContext) => void,
-}
-```
-
 ### `runCmd` (two overloads)
 
 ```typescript
@@ -585,11 +411,9 @@ const result: E2ETestResultWithFiles<'out.txt'> = await runCmd({
 // Access: result.files['out.txt']
 ```
 
-### `sanitizeOutput(output)`
-
-Strips ANSI escape codes, normalizes `\r\n` to `\n`, trims whitespace. Use on stdout and file contents before assertions.
-
 ### `TIMEOUTS`
+
+Defined in `ts/e2e-tests/_utils/src/const.ts`:
 
 ```typescript
 TIMEOUTS.DEFAULT   // 5_000ms   — individual test timeout
@@ -607,10 +431,9 @@ Use `TIMEOUTS.FIXTURE` for the `beforeAll` that runs Docker commands. Use `TIMEO
 | `ts/e2e-tests/cli/version/e2e.test.ts` | Pattern A reference |
 | `ts/e2e-tests/cli/whoami/e2e.test.ts` | Pattern B reference |
 | `ts/e2e-tests/_utils/src/types.ts` | `E2EConfig`, `E2ETestResult`, `DefineTestsContext` types |
-| `ts/e2e-tests/_utils/src/e2e.ts` | `e2e()` entry point |
 | `ts/e2e-tests/_utils/src/const.ts` | `TIMEOUTS`, `WELL_KNOWN_ENV_VARS` |
 | `ts/e2e-tests/_utils/src/sanitize.ts` | `sanitizeOutput()` |
 | `ts/e2e-tests/_utils/Dockerfile.cli` | Docker image definition |
 | `ts/e2e-tests/cli/README.md` | Test suites table |
 | `CLI.md` | Planned CLI commands |
-| `ts/packages/cli/CLAUDE.md` | CLI architecture and output conventions |
+| `ts/packages/cli/AGENTS.md` | CLI architecture and output conventions |

--- a/.claude/skills/create-cli/SKILL.md
+++ b/.claude/skills/create-cli/SKILL.md
@@ -1,1 +1,240 @@
-../../../ts/packages/cli/.cursor/rules/cli-design-guidelines.mdc
+---
+description: CLI design guidelines — arguments, flags, subcommands, help, output, errors, interactivity, config precedence. Apply when designing new commands or reviewing CLI UX.
+globs:
+  - "ts/packages/cli/src/**/*.ts"
+alwaysApply: false
+---
+
+# CLI Design Guidelines
+
+Design CLI surface area (syntax + behavior), human-first, script-friendly.
+Adapted from [clig.dev](https://clig.dev/) for our TypeScript + Effect.ts + Clack stack.
+
+## When to Use
+
+- Designing a CLI spec (before implementation) or refactoring CLI surface area.
+- Adding new commands, flags, or interactive prompts.
+- Reviewing CLI UX decisions.
+
+After designing a command, use the `implement-cli-command` skill to build it.
+After implementation, use the `create-cli-e2e` skill to write end-to-end tests.
+
+## Stack & Architecture
+
+See `ts/packages/cli/AGENTS.md` for the full architecture reference, including dependencies, services, effects, and vendor submodule locations.
+
+## Output Conventions
+
+The CLI separates human-readable decoration from machine-readable data. See `ts/packages/cli/AGENTS.md` § "Output Conventions" for the full specification.
+
+Key rule: when adding a command, ask "Does this produce a value scripts should capture?"
+- **Yes** → `ui.output(value)` for data, `ui.log.*` / `ui.note()` for context.
+- **No** → Only `ui.log.*` / `ui.note()` / `ui.intro()` / `ui.outro()`.
+
+**Show state changes.** When a command modifies state, say what changed and the new state:
+
+```typescript
+// After logout:
+yield* ui.log.info('Removed API key from ~/.composio/user-config.json');
+
+// After generate:
+yield* ui.log.success('Generated 42 tools across 5 toolkits → src/generated/');
+```
+
+## Arguments & Flags
+
+Define options via `@effect/cli`:
+
+```typescript
+const toolkits = Options.text('toolkits').pipe(
+  Options.optional,
+  Options.withDescription('Comma-separated toolkit slugs'),
+);
+const force = Options.boolean('force').pipe(
+  Options.withAlias('f'),
+  Options.withDefault(false),
+);
+```
+
+Principles:
+- Prefer flags over positional args for clarity and extensibility.
+- Provide long versions of all flags; one-letter aliases only for the most common.
+- Default values should be right for most users.
+- Never accept secrets via flags — they leak to `ps` output and shell history. Use `--password-file`, stdin, or a secret manager instead.
+- Support `-` for stdin/stdout when input/output is a file path.
+
+Standard flag names:
+
+| Flag | Short | Purpose |
+| ---- | ----- | ------- |
+| `--help` | `-h` | Show help (built-in via @effect/cli) |
+| `--version` | | Print version to stdout |
+| `--quiet` | `-q` | Less output |
+| `--verbose` | `-v` | More output (never use `-v` for version) |
+| `--debug` | `-d` | Debug output |
+| `--force` | `-f` | Skip confirmations |
+| `--dry-run` | `-n` | Preview only |
+| `--json` | | Structured output |
+| `--output` | `-o` | Output file path |
+| `--no-input` | | Disable prompts; fail if required input missing |
+| `--no-browser` | | Skip browser-open steps |
+| `--no-color` | | Disable color output |
+
+## Subcommands
+
+```typescript
+const login = Command.make('login', { noBrowser }, handler);
+const generate = Command.make('generate', { toolkits, typeTools }, handler);
+const root = Command.make('composio').pipe(
+  Command.withSubcommands([login, generate, /* ... */]),
+);
+```
+
+- Follow verb-noun pattern consistently: `composio login`, `composio generate`.
+- Share global flags via parent command composition.
+- Support `composio help <subcmd>` and `composio <subcmd> --help`.
+- Avoid ambiguous pairs (`update` vs `upgrade`) unless sharply differentiated.
+
+## Interactivity
+
+Use `@clack/prompts` for all interactive UI. All Clack output goes to stderr via `{ output: process.stderr }`.
+
+| Prompt | When to use |
+| ------ | ----------- |
+| `text()` | Free-form text input |
+| `password()` | Secret input (echo disabled) |
+| `confirm()` | Yes/no decisions |
+| `select()` | Choose one from a list |
+| `multiselect()` | Choose multiple from a list |
+| `spinner()` | Long-running operations |
+| `log.info/warn/error/step()` | Styled status messages |
+| `note()` | Boxed contextual info |
+| `intro()` / `outro()` | Session start/end markers |
+
+Rules:
+- Prompt only if stdin is a TTY.
+- `--no-input`: never prompt; fail with actionable message if required input missing.
+- Make escape hatches obvious (Ctrl-C).
+- Destructive operations: interactive confirmation + non-interactive requires `--force`.
+
+## Error Handling
+
+- Use the `effect-errors/` module for capture and formatting.
+- Catch and rewrite expected errors for humans; no stack traces by default.
+- Put the most important info last; use red intentionally.
+- For unexpected crashes: provide debug info path + bug report instructions.
+
+**Write actionable error messages.** Tell the user *what went wrong* and *how to fix it*:
+
+```
+// Bad:
+Error: EACCES
+
+// Good:
+Can't write to ~/.composio/user-config.json.
+You might need to fix permissions: chmod +w ~/.composio/user-config.json
+
+// Bad:
+Error: 401
+
+// Good:
+API key is invalid or expired.
+Run `composio login` to authenticate again.
+```
+
+**Suggest corrections** when the user mistypes a subcommand or flag. If they ran `composio genrate`, suggest `composio generate`.
+
+Exit codes:
+
+| Code | Meaning |
+| ---- | ------- |
+| `0` | Success |
+| `1` | Generic failure |
+| `2` | Invalid usage (parse/validation error) |
+
+## Help & Documentation
+
+- `@effect/cli` generates help text from Command/Options declarations.
+- If run with missing required args, show concise help + 1–2 examples + "use --help for more".
+- Lead with examples; show common flags first.
+- Link to docs URL per subcommand when applicable.
+- Provide both terminal help (offline, version-synced) and web docs (searchable, linkable).
+
+Good help text structure:
+
+```
+USAGE
+  $ composio generate [--toolkits <slugs>] [--type-tools]
+
+OPTIONS
+  --toolkits <slugs>   Comma-separated toolkit slugs (default: all)
+  --type-tools         Generate full type definitions
+  -o, --output <dir>   Output directory (default: @composio/core/generated)
+
+EXAMPLES
+  $ composio generate
+  $ composio generate --toolkits github,slack --type-tools
+
+COMMANDS
+  composio ts generate   Generate TypeScript stubs
+  composio py generate   Generate Python stubs
+```
+
+**Suggest next commands** when it helps the user's flow:
+
+```
+✔ Logged in as user@example.com
+  Next: run `composio generate` to generate type stubs for your toolkits.
+```
+
+## Configuration Precedence
+
+High to low: **flags > process env > project config > user config > system config**.
+
+- Composio prefixes: `COMPOSIO_*` for app config, `DEBUG_OVERRIDE_*` for debug.
+- User config stored in `~/.composio/`.
+- Respect common env vars: `NO_COLOR`, `DEBUG`, `EDITOR`, `PAGER`, `TERM`, `TMPDIR`, `HOME`.
+
+## Naming
+
+- Subcommand names: simple, lowercase, single word when possible.
+- Avoid too-generic names that collide with system tools.
+- Keep names short but not cryptic — easy to type matters.
+- Never create implicit catch-all subcommands that prevent future expansion.
+- Don't allow arbitrary abbreviations (reserving `g` for `generate` blocks future `g`-commands).
+- Use explicit aliases only when there's a clear, stable mapping.
+
+## Robustness & Performance
+
+- Validate early; fail fast with good error messages.
+- Print something within ~100ms (especially before network I/O). Start a Clack spinner immediately before any network call.
+- Show progress for long tasks (interactive only) via Clack spinners.
+- Use timeouts for network calls; allow configuration.
+- Make reruns safe: idempotent where possible; recoverable on failure.
+- **Crash-only design**: assume cleanup might not run. Defer cleanup to the next invocation rather than relying on shutdown hooks. If a cache file is half-written, the next run should detect and rebuild it.
+
+## Example Invocations
+
+```bash
+# Interactive — user sees Clack decoration on stderr
+composio login
+composio generate --toolkits github,slack
+
+# Piped — only data on stdout, no decoration
+composio whoami | pbcopy
+API_KEY=$(composio whoami)
+composio version | cat
+
+# Non-interactive with force
+composio logout --force --no-input
+
+# Debug mode
+composio generate --debug --verbose
+```
+
+## References
+
+- Community CLI Guidelines: https://clig.dev/
+- CLI architecture: `ts/packages/cli/AGENTS.md`
+- @effect/cli source: `ts/vendor/effect/packages/cli/src/`
+- @clack/prompts source: `ts/vendor/clack/packages/prompts/src/`

--- a/.claude/skills/create-cli/SKILL.md
+++ b/.claude/skills/create-cli/SKILL.md
@@ -1,0 +1,1 @@
+../../../ts/packages/cli/.cursor/rules/cli-design-guidelines.mdc

--- a/.claude/skills/implement-cli-command/SKILL.md
+++ b/.claude/skills/implement-cli-command/SKILL.md
@@ -1,0 +1,576 @@
+# Implement CLI Command
+
+Implement new commands and subcommands in `ts/packages/cli/`. Covers file creation, Effect patterns, service wiring, option declaration, output conventions, and registration.
+
+## When to Use
+
+- Implementing a new CLI command from a spec or design
+- Adding a subcommand to an existing command group
+- Wiring a new command into the command tree
+- Understanding how existing commands work to extend them
+
+For CLI **design** (arguments, flags, help text, UX), see the `create-cli` skill instead.
+For CLI **e2e tests**, see the `create-cli-e2e` skill instead.
+
+## Architecture
+
+The CLI uses `@effect/cli` for command declaration, `effect` for the runtime, and a service-oriented architecture with dependency injection via Effect layers.
+
+```
+src/
+├── bin.ts                    # Entry point — layer composition, error handling, runtime
+├── commands/
+│   ├── index.ts              # Command tree — registers all commands
+│   ├── $default.cmd.ts       # Root command with global options (--log-level)
+│   ├── version.cmd.ts        # Simple data command
+│   ├── whoami.cmd.ts         # Data command with service dependency
+│   ├── login.cmd.ts          # Complex command (options, spinner, polling)
+│   ├── logout.cmd.ts         # Action command (no stdout data)
+│   ├── upgrade.cmd.ts        # Action command (delegates to service)
+│   ├── generate.cmd.ts       # Command that auto-delegates to subcommands
+│   ├── ts/
+│   │   ├── ts.cmd.ts         # Parent command group
+│   │   └── commands/
+│   │       └── ts.generate.cmd.ts  # Subcommand with complex logic
+│   └── py/
+│       ├── py.cmd.ts
+│       └── commands/
+│           └── py.generate.cmd.ts
+├── services/                 # Effect services (dependency injection)
+├── effects/                  # Reusable Effect computations
+├── models/                   # Effect Schema definitions
+├── generation/               # Code generation pipeline
+├── effect-errors/            # Error capture and formatting
+└── ui/                       # Terminal output helpers
+```
+
+### File Naming Convention
+
+- Command files: `<name>.cmd.ts` (e.g., `version.cmd.ts`, `login.cmd.ts`)
+- Subcommand files: `<parent>.<name>.cmd.ts` inside `commands/` (e.g., `ts.generate.cmd.ts`)
+- Parent command groups: `<name>.cmd.ts` at the group level (e.g., `ts/ts.cmd.ts`)
+
+## Creating a New Command
+
+### Step 1: Create the Command File
+
+Create `src/commands/<name>.cmd.ts`.
+
+**Minimal template** (data command, no options):
+
+```typescript
+import { Command } from '@effect/cli';
+import { Effect } from 'effect';
+import { TerminalUI } from 'src/services/terminal-ui';
+
+export const myCmd = Command.make('my-command', {}).pipe(
+  Command.withDescription('Brief description of what the command does.'),
+  Command.withHandler(() =>
+    Effect.gen(function* () {
+      const ui = yield* TerminalUI;
+
+      // Compute result...
+      const result = 'some-value';
+
+      yield* ui.log.info(result);   // Decoration → stderr
+      yield* ui.output(result);     // Data → stdout (for scripts)
+    })
+  )
+);
+```
+
+**Template with options:**
+
+```typescript
+import { Command, Options } from '@effect/cli';
+import { Effect, Option } from 'effect';
+import { TerminalUI } from 'src/services/terminal-ui';
+import { ComposioToolkitsRepository } from 'src/services/composio-clients';
+
+// Define options at module level
+const toolkitSlug = Options.text('toolkit').pipe(
+  Options.withDescription('Toolkit slug to look up.')
+);
+
+const searchOpt = Options.optional(
+  Options.text('search')
+).pipe(
+  Options.withDescription('Search query to filter results.')
+);
+
+export const myCmd = Command.make('my-command', { toolkitSlug, searchOpt }).pipe(
+  Command.withDescription('Brief description.'),
+  Command.withHandler(({ toolkitSlug, searchOpt }) =>
+    Effect.gen(function* () {
+      const ui = yield* TerminalUI;
+      const client = yield* ComposioToolkitsRepository;
+
+      yield* ui.intro('composio my-command');
+
+      // Use options — searchOpt is Option<string>
+      const search = Option.getOrUndefined(searchOpt);
+
+      // Fetch data with spinner
+      const result = yield* ui.withSpinner(
+        'Fetching data...',
+        client.getToolkits(),
+        { successMessage: 'Done', errorMessage: 'Failed to fetch' }
+      );
+
+      // Output
+      yield* ui.note(formatResult(result), 'Result');
+      yield* ui.output(formatResult(result));
+      yield* ui.outro('Done');
+    })
+  )
+);
+```
+
+### Step 2: Register the Command
+
+Add the command to `src/commands/index.ts`:
+
+```typescript
+import { myCmd } from './my-command.cmd';
+
+const $cmd = $defaultCmd.pipe(
+  Command.withSubcommands([
+    versionCmd,
+    upgradeCmd,
+    whoamiCmd,
+    loginCmd,
+    logoutCmd,
+    generateCmd,
+    pyCmd,
+    tsCmd,
+    myCmd,  // Add here
+  ])
+);
+```
+
+### Step 3: Add Required Service Layers (if any)
+
+If your command uses a new service not already in `bin.ts`, add its layer:
+
+```typescript
+// In src/bin.ts
+const layers = Layer.mergeAll(
+  // ... existing layers
+  MyNewServiceLive,  // Add if needed
+);
+```
+
+Most commands only use services already provided: `TerminalUI`, `ComposioUserContext`, `ComposioToolkitsRepository`, `ComposioSessionRepository`, `UpgradeBinary`, `FileSystem`, `NodeProcess`, `NodeOs`.
+
+## Creating a Subcommand Group
+
+For commands like `composio toolkits list`, `composio toolkits info`:
+
+### Step 1: Create the Directory Structure
+
+```
+src/commands/toolkits/
+├── toolkits.cmd.ts              # Parent command group
+└── commands/
+    ├── toolkits.list.cmd.ts     # composio toolkits list
+    └── toolkits.info.cmd.ts     # composio toolkits info
+```
+
+### Step 2: Create the Parent Command
+
+`src/commands/toolkits/toolkits.cmd.ts`:
+
+```typescript
+import { Command } from '@effect/cli';
+import { toolkitsCmd$List } from './commands/toolkits.list.cmd';
+import { toolkitsCmd$Info } from './commands/toolkits.info.cmd';
+
+export const toolkitsCmd = Command.make('toolkits').pipe(
+  Command.withDescription('Discover and inspect available toolkits.'),
+  Command.withSubcommands([toolkitsCmd$List, toolkitsCmd$Info])
+);
+```
+
+### Step 3: Create Each Subcommand
+
+`src/commands/toolkits/commands/toolkits.list.cmd.ts`:
+
+```typescript
+import { Command, Options } from '@effect/cli';
+import { Effect, Option } from 'effect';
+import { TerminalUI } from 'src/services/terminal-ui';
+import { ComposioToolkitsRepository } from 'src/services/composio-clients';
+
+const searchOpt = Options.optional(
+  Options.text('search')
+).pipe(
+  Options.withDescription('Search toolkits by name or description.')
+);
+
+export const toolkitsCmd$List = Command.make('list', { searchOpt }).pipe(
+  Command.withDescription('List available toolkits.'),
+  Command.withHandler(({ searchOpt }) =>
+    Effect.gen(function* () {
+      const ui = yield* TerminalUI;
+      const client = yield* ComposioToolkitsRepository;
+
+      const toolkits = yield* ui.withSpinner(
+        'Fetching toolkits...',
+        client.getToolkits(),
+        { successMessage: 'Toolkits loaded' }
+      );
+
+      // Format and output
+      const output = toolkits
+        .map(t => `${t.slug} - ${t.meta.description}`)
+        .join('\n');
+
+      yield* ui.log.info(output);
+      yield* ui.output(output);
+    })
+  )
+);
+```
+
+### Step 4: Register the Parent in index.ts
+
+```typescript
+import { toolkitsCmd } from './toolkits/toolkits.cmd';
+
+const $cmd = $defaultCmd.pipe(
+  Command.withSubcommands([
+    // ... existing commands
+    toolkitsCmd,
+  ])
+);
+```
+
+## Option Declaration Patterns
+
+Options are declared at module level using `@effect/cli`'s `Options` API.
+
+### Common Option Types
+
+```typescript
+import { Options } from '@effect/cli';
+
+// Boolean flag (with default)
+const verbose = Options.boolean('verbose').pipe(
+  Options.withDefault(false),
+  Options.withDescription('Enable verbose output.')
+);
+
+// Required text
+const name = Options.text('name').pipe(
+  Options.withDescription('Name of the resource.')
+);
+
+// Optional text — yields Option<string> in handler
+const search = Options.optional(
+  Options.text('search')
+).pipe(
+  Options.withDescription('Search query.')
+);
+
+// Text with alias
+const output = Options.optional(
+  Options.text('output')
+).pipe(
+  Options.withAlias('o'),
+  Options.withDescription('Output path.')
+);
+
+// Repeated text — yields Array<string>
+const toolkits = Options.text('toolkits').pipe(
+  Options.repeated,
+  Options.withDescription('One or more toolkit slugs.')
+);
+
+// Choice from fixed set
+const format = Options.choice('format', ['json', 'table', 'plain']).pipe(
+  Options.withDefault('table'),
+  Options.withDescription('Output format.')
+);
+
+// Directory path (with existence check)
+const dir = Options.optional(
+  Options.directory('output-dir', { exists: 'either' })
+).pipe(
+  Options.withAlias('o'),
+  Options.withDescription('Output directory.')
+);
+
+// Schema-validated option
+import { Schema } from 'effect';
+
+const limit = Options.integer('limit').pipe(
+  Options.withSchema(Schema.Int.pipe(Schema.positive())),
+  Options.withDefault(10),
+  Options.withDescription('Max results.')
+);
+```
+
+### Using Options in Handler
+
+```typescript
+Command.make('my-cmd', { search, verbose, toolkits }, ({ search, verbose, toolkits }) =>
+  Effect.gen(function* () {
+    // search: Option<string> — use Option.getOrUndefined, Option.match, Option.isSome
+    const searchValue = Option.getOrUndefined(search);
+
+    // verbose: boolean — direct use
+    if (verbose) { yield* Effect.logDebug('Verbose mode'); }
+
+    // toolkits: Array<string> — may be empty
+    if (Array.isNonEmptyArray(toolkits)) {
+      // filter by toolkits
+    }
+  })
+)
+```
+
+## Output Conventions
+
+Every command must follow the composable CLI output contract:
+
+### Data Commands
+
+Commands that produce a value scripts should capture:
+
+```typescript
+yield* ui.note(apiKey, 'API Key');   // Decoration → stderr (pretty box)
+yield* ui.output(apiKey);            // Data → stdout (scripts capture)
+```
+
+### Action Commands
+
+Commands that perform a side effect but produce no data:
+
+```typescript
+yield* ui.log.success('Logged out successfully.');
+// NO ui.output() call — nothing for scripts to capture
+```
+
+### Rule: Never Mix
+
+- Never write data to stderr (decoration methods only)
+- Never write decoration to stdout (ui.output only)
+- `ui.output()` is a no-op in interactive mode (TTY) and writes to stdout when piped
+
+## Available Services
+
+Resolve services in handlers with `yield* ServiceName`.
+
+| Service | Import | Purpose |
+|---|---|---|
+| `TerminalUI` | `src/services/terminal-ui` | Output: `output()`, `log.*`, `note()`, `intro()`, `outro()`, spinners |
+| `ComposioUserContext` | `src/services/user-context` | Auth state: `data.apiKey`, `isLoggedIn()`, `logout` |
+| `ComposioToolkitsRepository` | `src/services/composio-clients` | API: `getToolkits()`, `getTools()`, `getTriggerTypes()`, `validateToolkits()` |
+| `ComposioSessionRepository` | `src/services/composio-clients` | OAuth: `createSession()`, `getSession()` |
+| `UpgradeBinary` | `src/services/upgrade-binary` | Self-update: `upgrade()` |
+| `FileSystem.FileSystem` | `@effect/platform` | File I/O: `readFileString()`, `writeFileString()`, `exists()` |
+| `NodeProcess` | `src/services/node-process` | Process info: `cwd`, `env` |
+| `NodeOs` | `src/services/node-os` | OS info: `homedir()`, `platform()`, `arch()` |
+| `EnvLangDetector` | `src/services/env-lang-detector` | Detect project language (TS/Python) |
+| `JsPackageManagerDetector` | `src/services/js-package-manager-detector` | Detect npm/pnpm/yarn/bun |
+
+## Available Effects
+
+Reusable computations from `src/effects/`:
+
+| Effect | Import | Purpose |
+|---|---|---|
+| `getVersion` | `src/effects/version` | CLI version from package.json |
+| `logMetrics` | `src/effects/log-metrics` | Log API request count and bytes |
+| `setupCacheDir` | `src/effects/setup-cache-dir` | Ensure `~/.composio/` exists |
+| `getToolkitVersionOverrides` | `src/effects/toolkit-version-overrides` | Parse `COMPOSIO_TOOLKIT_VERSION_*` env vars |
+| `jsFindComposioCoreGenerated` | `src/effects/find-composio-core-generated` | Locate `@composio/core` in node_modules |
+| `compareSemver` | `src/effects/compare-semver` | Semantic version comparison |
+
+## TerminalUI API
+
+### Output
+
+```typescript
+yield* ui.output(data);  // Machine-readable data → stdout when piped, no-op when interactive
+```
+
+### Decoration (all → stderr when interactive, suppressed when piped)
+
+```typescript
+yield* ui.intro('composio my-command');          // Opening banner
+yield* ui.outro('Done');                          // Closing banner
+yield* ui.note(content, 'Title');                 // Boxed note
+yield* ui.log.info('message');                    // Blue info
+yield* ui.log.success('message');                 // Green success
+yield* ui.log.warn('message');                    // Yellow warning
+yield* ui.log.error('message');                   // Red error
+yield* ui.log.step('message');                    // Green checkmark step
+yield* ui.log.message('message');                 // With vertical bar
+```
+
+### Spinners
+
+```typescript
+// Automatic: wraps an Effect, auto-stops on success/error
+const result = yield* ui.withSpinner(
+  'Loading...',
+  someEffect,
+  { successMessage: 'Done!', errorMessage: 'Failed!' }
+);
+
+// Manual: full control over message updates
+const result = yield* ui.useMakeSpinner('Loading...', spinner =>
+  Effect.gen(function* () {
+    yield* spinner.message('Step 1...');
+    const data = yield* fetchStep1;
+    yield* spinner.message('Step 2...');
+    const result = yield* fetchStep2(data);
+    yield* spinner.stop('All done!');
+    return result;
+  })
+);
+```
+
+## Error Handling Patterns
+
+### Optional Values
+
+```typescript
+yield* ctx.data.apiKey.pipe(
+  Option.match({
+    onNone: () => ui.log.warn('Not logged in. Run `composio login`.'),
+    onSome: apiKey => ui.output(apiKey),
+  })
+);
+```
+
+### Typed Errors with catchTag
+
+```typescript
+yield* client.getToolkitsBySlugs(slugs).pipe(
+  Effect.catchTag('services/InvalidToolkitsError', error =>
+    Effect.gen(function* () {
+      yield* ui.log.error(`Invalid toolkits: ${error.invalidToolkits.join(', ')}`);
+      return yield* Effect.fail(error);
+    })
+  )
+);
+```
+
+### Error Transformation
+
+```typescript
+yield* fs.writeFileString(path, content).pipe(
+  Effect.mapError(err => new Error(`Failed to write ${path}: ${err}`))
+);
+```
+
+### Logging Non-Fatal Errors
+
+```typescript
+yield* riskyOperation.pipe(
+  Effect.catchAll(error =>
+    Effect.logWarning(`Non-critical failure: ${error.message}`)
+  )
+);
+```
+
+## Parallel Data Fetching
+
+Use `Effect.all` with `concurrency` for parallel API calls:
+
+```typescript
+const [toolkits, tools, triggerTypes] = yield* Effect.all(
+  [
+    client.getToolkits(),
+    client.getTools(slugs),
+    client.getTriggerTypes(slugs),
+  ],
+  { concurrency: 'unbounded' }
+);
+```
+
+## Extracting Reusable Logic
+
+For commands that share logic (e.g., `composio generate` delegates to `composio ts generate`):
+
+```typescript
+// In ts.generate.cmd.ts — export the logic separately
+export function generateTypescriptTypeStubs(params: { ... }) {
+  return Effect.gen(function* () {
+    const ui = yield* TerminalUI;
+    // ... implementation
+  });
+}
+
+// The command uses it
+export const tsCmd$Generate = Command.make('generate', { ... }).pipe(
+  Command.withHandler(params => generateTypescriptTypeStubs(params))
+);
+
+// Other commands can reuse it
+// In generate.cmd.ts
+import { generateTypescriptTypeStubs } from './ts/commands/ts.generate.cmd';
+
+yield* Match.value(envLang).pipe(
+  Match.when('TypeScript', () => generateTypescriptTypeStubs({ ... })),
+  Match.when('Python', () => generatePythonTypeStubs({ ... })),
+  Match.exhaustive
+);
+```
+
+## Retry with Exponential Backoff
+
+For polling operations (e.g., waiting for OAuth):
+
+```typescript
+import { Schedule } from 'effect';
+
+const result = yield* ui.useMakeSpinner('Waiting...', spinner =>
+  Effect.retry(
+    Effect.gen(function* () {
+      const status = yield* client.getSession(session);
+      if (status.status === 'linked') return status;
+      return yield* Effect.fail(new Error('Still pending'));
+    }),
+    Schedule.exponential('0.3 seconds').pipe(
+      Schedule.intersect(Schedule.recurs(15)),
+      Schedule.intersect(Schedule.spaced('5 seconds'))
+    )
+  ).pipe(
+    Effect.tap(() => spinner.stop('Success!')),
+    Effect.tapError(() => spinner.error('Timed out'))
+  )
+);
+```
+
+## Checklist
+
+When implementing a new command:
+
+1. Create `src/commands/<name>.cmd.ts` (or `src/commands/<group>/commands/<group>.<name>.cmd.ts` for subcommands)
+2. Define options at module level using `Options.*`
+3. Create the command with `Command.make(name, options).pipe(Command.withDescription(...), Command.withHandler(...))`
+4. In the handler, resolve services with `yield* ServiceName`
+5. Follow the output convention: `ui.output()` for data, `ui.log.*` for decoration
+6. Register in `src/commands/index.ts` (or in the parent group's command file)
+7. If using a new service, add its layer to `src/bin.ts`
+8. Build to verify: `cd ts/packages/cli && pnpm build`
+
+## Reference Files
+
+| File | Purpose |
+|---|---|
+| `src/commands/version.cmd.ts` | Simplest command (no options, no services beyond TerminalUI) |
+| `src/commands/whoami.cmd.ts` | Data command with service dependency |
+| `src/commands/login.cmd.ts` | Complex command (options, spinner, polling, retry) |
+| `src/commands/logout.cmd.ts` | Action command (no stdout data) |
+| `src/commands/upgrade.cmd.ts` | Action command delegating to service |
+| `src/commands/generate.cmd.ts` | Auto-detection and delegation to subcommands |
+| `src/commands/ts/commands/ts.generate.cmd.ts` | Full subcommand with parallel fetching, spinner, file I/O |
+| `src/commands/index.ts` | Command tree registration |
+| `src/bin.ts` | Entry point, layer composition, error handling |
+| `src/services/terminal-ui.ts` | TerminalUI service interface |
+| `src/services/composio-clients.ts` | API client service (HTTP, pagination, metrics) |
+| `ts/packages/cli/CLAUDE.md` | CLI architecture and output conventions |

--- a/.claude/skills/implement-cli-command/SKILL.md
+++ b/.claude/skills/implement-cli-command/SKILL.md
@@ -1,3 +1,7 @@
+---
+description: Implement new CLI commands in ts/packages/cli/ using Effect.ts patterns, service wiring, and @effect/cli declarations.
+---
+
 # Implement CLI Command
 
 Implement new commands and subcommands in `ts/packages/cli/`. Covers file creation, Effect patterns, service wiring, option declaration, output conventions, and registration.
@@ -15,6 +19,8 @@ For CLI **e2e tests**, see the `create-cli-e2e` skill instead.
 ## Architecture
 
 The CLI uses `@effect/cli` for command declaration, `effect` for the runtime, and a service-oriented architecture with dependency injection via Effect layers.
+
+See `ts/packages/cli/AGENTS.md` for the full architecture reference (services, effects, models, dependencies, vendor submodule locations).
 
 ```
 src/
@@ -160,7 +166,7 @@ const layers = Layer.mergeAll(
 );
 ```
 
-Most commands only use services already provided: `TerminalUI`, `ComposioUserContext`, `ComposioToolkitsRepository`, `ComposioSessionRepository`, `UpgradeBinary`, `FileSystem`, `NodeProcess`, `NodeOs`.
+Most commands only use services already provided. The `ComposioToolkitsRepository` service is provided by `ComposioToolkitsRepositoryCachedLive` in `bin.ts` — you do not need to add a separate layer for the base repository.
 
 ## Creating a Subcommand Group
 
@@ -247,9 +253,11 @@ const $cmd = $defaultCmd.pipe(
 
 ## Option Declaration Patterns
 
-Options are declared at module level using `@effect/cli`'s `Options` API.
+Options are declared at module level using `@effect/cli`'s `Options` API. The template above demonstrates the most common types (required text, optional text). For other option types, see `ts/vendor/effect/packages/cli/src/Options.ts`.
 
-### Common Option Types
+Both `Options.optional(Options.text(...))` (wrapping) and `Options.text(...).pipe(Options.optional)` (piped) are valid. Use whichever reads better.
+
+### Common patterns:
 
 ```typescript
 import { Options } from '@effect/cli';
@@ -260,18 +268,6 @@ const verbose = Options.boolean('verbose').pipe(
   Options.withDescription('Enable verbose output.')
 );
 
-// Required text
-const name = Options.text('name').pipe(
-  Options.withDescription('Name of the resource.')
-);
-
-// Optional text — yields Option<string> in handler
-const search = Options.optional(
-  Options.text('search')
-).pipe(
-  Options.withDescription('Search query.')
-);
-
 // Text with alias
 const output = Options.optional(
   Options.text('output')
@@ -280,136 +276,50 @@ const output = Options.optional(
   Options.withDescription('Output path.')
 );
 
-// Repeated text — yields Array<string>
-const toolkits = Options.text('toolkits').pipe(
-  Options.repeated,
-  Options.withDescription('One or more toolkit slugs.')
-);
-
 // Choice from fixed set
 const format = Options.choice('format', ['json', 'table', 'plain']).pipe(
   Options.withDefault('table'),
   Options.withDescription('Output format.')
-);
-
-// Directory path (with existence check)
-const dir = Options.optional(
-  Options.directory('output-dir', { exists: 'either' })
-).pipe(
-  Options.withAlias('o'),
-  Options.withDescription('Output directory.')
-);
-
-// Schema-validated option
-import { Schema } from 'effect';
-
-const limit = Options.integer('limit').pipe(
-  Options.withSchema(Schema.Int.pipe(Schema.positive())),
-  Options.withDefault(10),
-  Options.withDescription('Max results.')
 );
 ```
 
 ### Using Options in Handler
 
 ```typescript
-Command.make('my-cmd', { search, verbose, toolkits }, ({ search, verbose, toolkits }) =>
-  Effect.gen(function* () {
-    // search: Option<string> — use Option.getOrUndefined, Option.match, Option.isSome
-    const searchValue = Option.getOrUndefined(search);
+Command.make('my-cmd', { search, verbose }).pipe(
+  Command.withHandler(({ search, verbose }) =>
+    Effect.gen(function* () {
+      // search: Option<string> — use Option.getOrUndefined, Option.match, Option.isSome
+      const searchValue = Option.getOrUndefined(search);
 
-    // verbose: boolean — direct use
-    if (verbose) { yield* Effect.logDebug('Verbose mode'); }
-
-    // toolkits: Array<string> — may be empty
-    if (Array.isNonEmptyArray(toolkits)) {
-      // filter by toolkits
-    }
-  })
-)
+      // verbose: boolean — direct use
+      if (verbose) { yield* Effect.logDebug('Verbose mode'); }
+    })
+  )
+);
 ```
 
 ## Output Conventions
 
-Every command must follow the composable CLI output contract:
+Follow the output conventions in `ts/packages/cli/AGENTS.md` § "Output Conventions" (stdout for data via `ui.output()`, stderr for decoration).
 
-### Data Commands
-
-Commands that produce a value scripts should capture:
+**Data commands** — produce a value scripts should capture:
 
 ```typescript
 yield* ui.note(apiKey, 'API Key');   // Decoration → stderr (pretty box)
 yield* ui.output(apiKey);            // Data → stdout (scripts capture)
 ```
 
-### Action Commands
-
-Commands that perform a side effect but produce no data:
+**Action commands** — perform a side effect, no data:
 
 ```typescript
 yield* ui.log.success('Logged out successfully.');
 // NO ui.output() call — nothing for scripts to capture
 ```
 
-### Rule: Never Mix
+## TerminalUI Spinners
 
-- Never write data to stderr (decoration methods only)
-- Never write decoration to stdout (ui.output only)
-- `ui.output()` is a no-op in interactive mode (TTY) and writes to stdout when piped
-
-## Available Services
-
-Resolve services in handlers with `yield* ServiceName`.
-
-| Service | Import | Purpose |
-|---|---|---|
-| `TerminalUI` | `src/services/terminal-ui` | Output: `output()`, `log.*`, `note()`, `intro()`, `outro()`, spinners |
-| `ComposioUserContext` | `src/services/user-context` | Auth state: `data.apiKey`, `isLoggedIn()`, `logout` |
-| `ComposioToolkitsRepository` | `src/services/composio-clients` | API: `getToolkits()`, `getTools()`, `getTriggerTypes()`, `validateToolkits()` |
-| `ComposioSessionRepository` | `src/services/composio-clients` | OAuth: `createSession()`, `getSession()` |
-| `UpgradeBinary` | `src/services/upgrade-binary` | Self-update: `upgrade()` |
-| `FileSystem.FileSystem` | `@effect/platform` | File I/O: `readFileString()`, `writeFileString()`, `exists()` |
-| `NodeProcess` | `src/services/node-process` | Process info: `cwd`, `env` |
-| `NodeOs` | `src/services/node-os` | OS info: `homedir()`, `platform()`, `arch()` |
-| `EnvLangDetector` | `src/services/env-lang-detector` | Detect project language (TS/Python) |
-| `JsPackageManagerDetector` | `src/services/js-package-manager-detector` | Detect npm/pnpm/yarn/bun |
-
-## Available Effects
-
-Reusable computations from `src/effects/`:
-
-| Effect | Import | Purpose |
-|---|---|---|
-| `getVersion` | `src/effects/version` | CLI version from package.json |
-| `logMetrics` | `src/effects/log-metrics` | Log API request count and bytes |
-| `setupCacheDir` | `src/effects/setup-cache-dir` | Ensure `~/.composio/` exists |
-| `getToolkitVersionOverrides` | `src/effects/toolkit-version-overrides` | Parse `COMPOSIO_TOOLKIT_VERSION_*` env vars |
-| `jsFindComposioCoreGenerated` | `src/effects/find-composio-core-generated` | Locate `@composio/core` in node_modules |
-| `compareSemver` | `src/effects/compare-semver` | Semantic version comparison |
-
-## TerminalUI API
-
-### Output
-
-```typescript
-yield* ui.output(data);  // Machine-readable data → stdout when piped, no-op when interactive
-```
-
-### Decoration (all → stderr when interactive, suppressed when piped)
-
-```typescript
-yield* ui.intro('composio my-command');          // Opening banner
-yield* ui.outro('Done');                          // Closing banner
-yield* ui.note(content, 'Title');                 // Boxed note
-yield* ui.log.info('message');                    // Blue info
-yield* ui.log.success('message');                 // Green success
-yield* ui.log.warn('message');                    // Yellow warning
-yield* ui.log.error('message');                   // Red error
-yield* ui.log.step('message');                    // Green checkmark step
-yield* ui.log.message('message');                 // With vertical bar
-```
-
-### Spinners
+The `TerminalUI` service provides two spinner APIs. For output/decoration methods (`output`, `log.*`, `note`, `intro`, `outro`), see `ts/packages/cli/src/services/terminal-ui.ts`.
 
 ```typescript
 // Automatic: wraps an Effect, auto-stops on success/error
@@ -432,6 +342,16 @@ const result = yield* ui.useMakeSpinner('Loading...', spinner =>
 );
 ```
 
+## Creating a New Service
+
+If your command requires functionality not covered by existing services (see `ts/packages/cli/AGENTS.md` for the full list):
+
+1. Define the service interface and tag in `src/services/<name>.ts`
+2. Create a `Live` layer implementation
+3. Register the layer in `src/bin.ts`
+
+Reference `src/services/upgrade-binary.ts` for a simple service pattern, or `src/services/composio-clients.ts` for a complex one with caching.
+
 ## Error Handling Patterns
 
 ### Optional Values
@@ -440,7 +360,10 @@ const result = yield* ui.useMakeSpinner('Loading...', spinner =>
 yield* ctx.data.apiKey.pipe(
   Option.match({
     onNone: () => ui.log.warn('Not logged in. Run `composio login`.'),
-    onSome: apiKey => ui.output(apiKey),
+    onSome: apiKey =>
+      Effect.gen(function* () {
+        yield* ui.output(apiKey);
+      }),
   })
 );
 ```
@@ -455,14 +378,6 @@ yield* client.getToolkitsBySlugs(slugs).pipe(
       return yield* Effect.fail(error);
     })
   )
-);
-```
-
-### Error Transformation
-
-```typescript
-yield* fs.writeFileString(path, content).pipe(
-  Effect.mapError(err => new Error(`Failed to write ${path}: ${err}`))
 );
 ```
 
@@ -558,6 +473,8 @@ When implementing a new command:
 7. If using a new service, add its layer to `src/bin.ts`
 8. Build to verify: `cd ts/packages/cli && pnpm build`
 
+If the build fails, check for: (1) missing service imports, (2) `Option<string>` being used where `string` is expected (use `Option.getOrUndefined` or `Option.match`), (3) the command not being exported from its file.
+
 ## Reference Files
 
 | File | Purpose |
@@ -573,4 +490,4 @@ When implementing a new command:
 | `src/bin.ts` | Entry point, layer composition, error handling |
 | `src/services/terminal-ui.ts` | TerminalUI service interface |
 | `src/services/composio-clients.ts` | API client service (HTTP, pagination, metrics) |
-| `ts/packages/cli/CLAUDE.md` | CLI architecture and output conventions |
+| `ts/packages/cli/AGENTS.md` | CLI architecture, services, effects, output conventions |

--- a/ts/packages/cli/.cursor/rules/cli-design-guidelines.mdc
+++ b/ts/packages/cli/.cursor/rules/cli-design-guidelines.mdc
@@ -1,0 +1,321 @@
+---
+description: CLI design guidelines — arguments, flags, subcommands, help, output, errors, interactivity, config precedence. Apply when designing new commands or reviewing CLI UX.
+globs:
+  - "src/**/*.ts"
+alwaysApply: true
+---
+
+# CLI Design Guidelines
+
+Design CLI surface area (syntax + behavior), human-first, script-friendly.
+Adapted from [clig.dev](https://clig.dev/) for our TypeScript + Effect.ts + Clack stack.
+
+## When to Use
+
+- Designing a CLI spec (before implementation) or refactoring CLI surface area.
+- Adding new commands, flags, or interactive prompts.
+- Reviewing CLI UX decisions.
+
+## Our Stack
+
+| Library | Role | Source reference |
+| ------- | ---- | --------------- |
+| `@effect/cli` | Command, Options, Args declaration and parsing | `ts/vendor/effect/packages/cli/src/` |
+| `@clack/prompts` | Interactive terminal UI (prompts, spinners, logs, notes) | `ts/vendor/clack/packages/prompts/src/` |
+| `effect` | Core runtime, services, layers, error handling | `ts/vendor/effect/packages/effect/src/` |
+| `@effect/platform` | FileSystem, Terminal abstraction | `ts/vendor/effect/packages/platform/src/` |
+
+Existing architecture is documented in `ts/packages/cli/AGENTS.md`.
+
+## Philosophy
+
+1. **Human-first design** — Optimize for humans; scripts work via `--json`, `--plain`, exit codes.
+2. **Simple parts that work together** — stdout for data, stderr for decoration, respect exit codes and signals.
+3. **Consistency** — Reuse standard flag names (`--help`, `--version`, `--json`, `--dry-run`).
+4. **Say just enough** — Brief success output, visible progress, no noise.
+5. **Ease of discovery** — Help text is UX. Lead with examples; suggest next commands on error.
+6. **Conversation as the norm** — Expect trial-and-error. Provide `--dry-run` and confirmations for scary actions.
+7. **Robustness** — Validate early, fail fast, no stack traces by default.
+8. **Empathy** — Make success likely; make failure informative. Character is fine; clutter is not.
+
+## Output Conventions
+
+The CLI separates human-readable decoration from machine-readable data:
+
+- **stdout** — data only (`ui.output()`). Captured by pipes and scripts.
+- **stderr** — all decoration (Clack spinners, logs, notes, intro/outro). Visible in terminal, invisible in pipes.
+
+Rules:
+
+1. All `TerminalUI` methods except `output()` write to stderr via `{ output: process.stderr }`.
+2. `ui.output(data)` writes to stdout only when piped — no-op in interactive mode.
+3. When stdout is piped, ALL decoration is suppressed. Only `ui.output()` writes.
+4. Never write data to stderr. Never write decoration to stdout.
+
+```typescript
+// Data command (e.g., whoami):
+yield* ui.note(apiKey, 'API Key');   // Decoration → stderr
+yield* ui.output(apiKey);            // Data → stdout
+
+// Action command (e.g., login):
+yield* ui.intro('composio login');   // Decoration → stderr
+yield* ui.log.step('Redirecting');   // Decoration → stderr
+// No ui.output() — nothing for scripts to capture
+```
+
+When adding a command, ask: "Does this produce a value scripts should capture?"
+- **Yes** → `ui.output(value)` for data, `ui.log.*` / `ui.note()` for context.
+- **No** → Only `ui.log.*` / `ui.note()` / `ui.intro()` / `ui.outro()`.
+
+**Show state changes.** When a command modifies state, say what changed and the new state:
+
+```typescript
+// After logout:
+yield* ui.log.info('Removed API key from ~/.composio/user-config.json');
+
+// After generate:
+yield* ui.log.success('Generated 42 tools across 5 toolkits → src/generated/');
+```
+
+## Arguments & Flags
+
+Define options via `@effect/cli`:
+
+```typescript
+const toolkits = Options.text('toolkits').pipe(
+  Options.optional,
+  Options.withDescription('Comma-separated toolkit slugs'),
+);
+const force = Options.boolean('force').pipe(
+  Options.withAlias('f'),
+  Options.withDefault(false),
+);
+```
+
+Principles:
+- Prefer flags over positional args for clarity and extensibility.
+- Provide long versions of all flags; one-letter aliases only for the most common.
+- Default values should be right for most users.
+- Never accept secrets via flags — they leak to `ps` output and shell history. Use `--password-file`, stdin, or a secret manager instead.
+- Support `-` for stdin/stdout when input/output is a file path.
+
+Standard flag names:
+
+| Flag | Short | Purpose |
+| ---- | ----- | ------- |
+| `--help` | `-h` | Show help (built-in via @effect/cli) |
+| `--version` | | Print version to stdout |
+| `--quiet` | `-q` | Less output |
+| `--verbose` | `-v` | More output (never use `-v` for version) |
+| `--debug` | `-d` | Debug output |
+| `--force` | `-f` | Skip confirmations |
+| `--dry-run` | `-n` | Preview only |
+| `--json` | | Structured output |
+| `--output` | `-o` | Output file path |
+| `--no-input` | | Disable prompts; fail if required input missing |
+| `--no-browser` | | Skip browser-open steps |
+| `--no-color` | | Disable color output |
+
+## Subcommands
+
+```typescript
+const login = Command.make('login', { noBrowser }, handler);
+const generate = Command.make('generate', { toolkits, typeTools }, handler);
+const root = Command.make('composio').pipe(
+  Command.withSubcommands([login, generate, /* ... */]),
+);
+```
+
+- Follow verb-noun pattern consistently: `composio login`, `composio generate`.
+- Share global flags via parent command composition.
+- Support `composio help <subcmd>` and `composio <subcmd> --help`.
+- Avoid ambiguous pairs (`update` vs `upgrade`) unless sharply differentiated.
+
+## Interactivity
+
+Use `@clack/prompts` for all interactive UI. All Clack output goes to stderr via `{ output: process.stderr }`.
+
+| Prompt | When to use |
+| ------ | ----------- |
+| `text()` | Free-form text input |
+| `password()` | Secret input (echo disabled) |
+| `confirm()` | Yes/no decisions |
+| `select()` | Choose one from a list |
+| `multiselect()` | Choose multiple from a list |
+| `spinner()` | Long-running operations |
+| `log.info/warn/error/step()` | Styled status messages |
+| `note()` | Boxed contextual info |
+| `intro()` / `outro()` | Session start/end markers |
+
+Rules:
+- Prompt only if stdin is a TTY.
+- `--no-input`: never prompt; fail with actionable message if required input missing.
+- Make escape hatches obvious (Ctrl-C).
+- Destructive operations: interactive confirmation + non-interactive requires `--force`.
+
+## Error Handling
+
+- Use the `effect-errors/` module for capture and formatting.
+- Catch and rewrite expected errors for humans; no stack traces by default.
+- Put the most important info last; use red intentionally.
+- For unexpected crashes: provide debug info path + bug report instructions.
+
+**Write actionable error messages.** Tell the user *what went wrong* and *how to fix it*:
+
+```
+// Bad:
+Error: EACCES
+
+// Good:
+Can't write to ~/.composio/user-config.json.
+You might need to fix permissions: chmod +w ~/.composio/user-config.json
+
+// Bad:
+Error: 401
+
+// Good:
+API key is invalid or expired.
+Run `composio login` to authenticate again.
+```
+
+**Suggest corrections** when the user mistypes a subcommand or flag. If they ran `composio genrate`, suggest `composio generate`.
+
+Exit codes:
+
+| Code | Meaning |
+| ---- | ------- |
+| `0` | Success |
+| `1` | Generic failure |
+| `2` | Invalid usage (parse/validation error) |
+
+## Help & Documentation
+
+- `@effect/cli` generates help text from Command/Options declarations.
+- If run with missing required args, show concise help + 1–2 examples + "use --help for more".
+- Lead with examples; show common flags first.
+- Link to docs URL per subcommand when applicable.
+- Provide both terminal help (offline, version-synced) and web docs (searchable, linkable).
+
+Good help text structure:
+
+```
+USAGE
+  $ composio generate [--toolkits <slugs>] [--type-tools]
+
+OPTIONS
+  --toolkits <slugs>   Comma-separated toolkit slugs (default: all)
+  --type-tools         Generate full type definitions
+  -o, --output <dir>   Output directory (default: @composio/core/generated)
+
+EXAMPLES
+  $ composio generate
+  $ composio generate --toolkits github,slack --type-tools
+
+COMMANDS
+  composio ts generate   Generate TypeScript stubs
+  composio py generate   Generate Python stubs
+```
+
+**Suggest next commands** when it helps the user's flow:
+
+```
+✔ Logged in as user@example.com
+  Next: run `composio generate` to generate type stubs for your toolkits.
+```
+
+## Color & Formatting
+
+- Use `ansis` or `picocolors` for colored output.
+- Respect `NO_COLOR` env var and `TERM=dumb`.
+- Provide `--no-color` flag.
+- No animations or progress bars when stdout isn't a TTY.
+- Spinners only in interactive mode, always on stderr.
+
+## Configuration Precedence
+
+High to low: **flags > process env > project config > user config > system config**.
+
+- Composio prefixes: `COMPOSIO_*` for app config, `DEBUG_OVERRIDE_*` for debug.
+- User config stored in `~/.composio/`.
+- Respect common env vars: `NO_COLOR`, `DEBUG`, `EDITOR`, `PAGER`, `TERM`, `TMPDIR`, `HOME`.
+
+## Naming
+
+- Subcommand names: simple, lowercase, single word when possible.
+- Avoid too-generic names that collide with system tools.
+- Keep names short but not cryptic — easy to type matters.
+- Never create implicit catch-all subcommands that prevent future expansion.
+- Don't allow arbitrary abbreviations (reserving `g` for `generate` blocks future `g`-commands).
+- Use explicit aliases only when there's a clear, stable mapping.
+
+## Robustness & Performance
+
+- Validate early; fail fast with good error messages.
+- Print something within ~100ms (especially before network I/O). Start a Clack spinner immediately before any network call.
+- Show progress for long tasks (interactive only) via Clack spinners.
+- Use timeouts for network calls; allow configuration.
+- Make reruns safe: idempotent where possible; recoverable on failure.
+- **Crash-only design**: assume cleanup might not run. Defer cleanup to the next invocation rather than relying on shutdown hooks. If a cache file is half-written, the next run should detect and rebuild it.
+
+## Future-Proofing
+
+- Interfaces are contracts: args, flags, subcommands, env vars, output modes.
+- Keep changes additive; deprecate loudly + early; provide migration paths.
+- Human output can evolve; keep scripts stable via `--json`/`--plain`.
+
+## Signals
+
+- Ctrl-C: exit quickly; say something immediately; bounded cleanup.
+- Use Effect's interrupt handling (`Effect.scoped`, fiber interruption).
+- Design for crash-only recovery; assume cleanup might not run.
+
+## CLI Spec Template
+
+When designing a new command, produce this spec:
+
+```
+1. Name: `composio <subcommand>`
+2. One-liner: Brief description
+3. USAGE: `composio [global flags] <subcommand> [args]`
+4. Options (via @effect/cli Options.*):
+   - Flag table (name, type, default, required, description)
+5. I/O contract:
+   - stdout: what data is emitted
+   - stderr: what decoration is shown
+6. Exit codes: 0/1/2 + command-specific
+7. Env/config: COMPOSIO_* vars, ~/.composio/ files
+8. Examples: 5–10 invocations (interactive + piped)
+```
+
+## Example Invocations
+
+```bash
+# Interactive — user sees Clack decoration on stderr
+composio login
+composio generate --toolkits github,slack
+
+# Piped — only data on stdout, no decoration
+composio whoami | pbcopy
+API_KEY=$(composio whoami)
+composio version | cat
+
+# Non-interactive with force
+composio logout --force --no-input
+
+# Debug mode
+composio generate --debug --verbose
+```
+
+## Telemetry
+
+- Never phone home without explicit user consent.
+- Prefer opt-in. If opt-out, make it obvious and easy to disable (`COMPOSIO_DISABLE_TELEMETRY=true`).
+- Clearly explain what is collected, why, how, and retention period.
+- Consider alternatives: docs site analytics, download metrics, direct user feedback.
+
+## References
+
+- Community CLI Guidelines: https://clig.dev/
+- @effect/cli source: `ts/vendor/effect/packages/cli/src/`
+- @clack/prompts source: `ts/vendor/clack/packages/prompts/src/`
+- CLI architecture: `ts/packages/cli/AGENTS.md`

--- a/ts/packages/cli/AGENTS.md
+++ b/ts/packages/cli/AGENTS.md
@@ -285,7 +285,7 @@ When working on CLI code, reference the Effect source for accurate patterns:
 
 For principles on how to design CLI interactions (arguments, flags, help text, output, errors, interactivity, config precedence), see:
 
-- **Full guidelines**: `ts/packages/cli/.cursor/rules/cli-design-guidelines.mdc`
-- **Also available as**: `.claude/skills/create-cli/SKILL.md` (symlink)
+- **Cursor rules**: `ts/packages/cli/.cursor/rules/cli-design-guidelines.mdc`
+- **Claude skill**: `.claude/skills/create-cli/SKILL.md` (standalone, trimmed for Claude Code context)
 
 Use these guidelines when adding new commands, designing flag interfaces, or making UX decisions for the CLI.

--- a/ts/packages/cli/AGENTS.md
+++ b/ts/packages/cli/AGENTS.md
@@ -278,3 +278,14 @@ When working on CLI code, reference the Effect source for accurate patterns:
 
 - The submodule is for **read-only reference only**. Do not modify files in `ts/vendor/effect/`.
 - The CLI's actual dependencies come from npm via `pnpm install`.
+
+---
+
+## CLI Design Guidelines
+
+For principles on how to design CLI interactions (arguments, flags, help text, output, errors, interactivity, config precedence), see:
+
+- **Full guidelines**: `ts/packages/cli/.cursor/rules/cli-design-guidelines.mdc`
+- **Also available as**: `.claude/skills/create-cli/SKILL.md` (symlink)
+
+Use these guidelines when adding new commands, designing flag interfaces, or making UX decisions for the CLI.


### PR DESCRIPTION
This PR:

- builds on top of https://github.com/ComposioHQ/composio/pull/2660
- adds three Claude Code skills for CLI development: `create-cli` (design guidelines), `implement-cli-command` (Effect.ts patterns, service wiring), `create-cli-e2e` (Docker-based e2e test patterns)
- adds `TerminalUI` Effect service with Clack-backed spinners, logs, notes, and composable stdout/stderr output
- adds CLI runtime support to the e2e test framework with `Dockerfile.cli` and `runCmd` API
- adds `composio version` and `composio whoami` e2e test suites
- adds `@clack/prompts` vendor submodule for read-only API reference
- deduplicates skill content against `AGENTS.md`, reducing total skill LOC by 23% (1516 → 1172 lines)
- adds decision flowchart, cross-references, and build troubleshooting to skills

## Context

The CLI skills form a lifecycle-oriented trilogy: **design** (`create-cli`) → **implementation** (`implement-cli-command`) → **testing** (`create-cli-e2e`). Each skill references `ts/packages/cli/AGENTS.md` as the single source of truth for architecture details, avoiding content duplication.

The `TerminalUI` service enforces composable output: all Clack decoration routes to stderr, `ui.output()` writes data to stdout only when piped, and all decoration is suppressed in non-TTY mode. This enables `composio whoami | pbcopy` and `API_KEY=$(composio whoami)` to work silently.