### PR TITLE
feat(cli): add `composio toolkits` command

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,24 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
 
+  ts/e2e-tests/cli/toolkits/info:
+    devDependencies:
+      '@e2e-tests/utils':
+        specifier: workspace:*
+        version: link:../../../_utils
+
+  ts/e2e-tests/cli/toolkits/list:
+    devDependencies:
+      '@e2e-tests/utils':
+        specifier: workspace:*
+        version: link:../../../_utils
+
+  ts/e2e-tests/cli/toolkits/search:
+    devDependencies:
+      '@e2e-tests/utils':
+        specifier: workspace:*
+        version: link:../../../_utils
+
   ts/e2e-tests/cli/version:
     devDependencies:
       '@e2e-tests/utils':
@@ -662,16 +680,16 @@ importers:
         version: link:../../packages/providers/llamaindex
       '@llamaindex/openai':
         specifier: ^0.4.20
-        version: 0.4.22(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(ws@8.19.0)(zod@3.25.76)
+        version: 0.4.22(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(ws@8.19.0)(zod@4.3.6)
       '@llamaindex/workflow':
         specifier: ^1.1.24
-        version: 1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(hono@4.11.9)(zod@3.25.76)
+        version: 1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono@4.11.9)(zod@4.3.6)
       dotenv:
         specifier: ^16.4.1
         version: 16.6.1
       llamaindex:
         specifier: ^0.12.0
-        version: 0.12.1(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(hono@4.11.9)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@3.25.76)
+        version: 0.12.1(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono@4.11.9)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@4.3.6)
     devDependencies:
       '@types/bun':
         specifier: ^1.2.9
@@ -1268,7 +1286,7 @@ importers:
     dependencies:
       llamaindex:
         specifier: ^0.12.0
-        version: 0.12.1(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@4.3.6)
+        version: 0.12.1(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono@4.11.9)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@4.3.6)
     devDependencies:
       '@composio/core':
         specifier: workspace:*
@@ -7530,43 +7548,26 @@ snapshots:
       tree-sitter: 0.22.4
       web-tree-sitter: 0.24.7
 
-  '@llamaindex/openai@0.4.22(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(ws@8.19.0)(zod@3.25.76)':
+  '@llamaindex/openai@0.4.22(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@llamaindex/core': 0.6.22
       '@llamaindex/env': 0.1.30
-      openai: 5.23.2(ws@8.19.0)(zod@3.25.76)
+      openai: 5.23.2(ws@8.19.0)(zod@4.3.6)
     transitivePeerDependencies:
       - ws
       - zod
 
-  '@llamaindex/workflow-core@1.3.3(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(hono@4.11.9)(zod@3.25.76)':
+  '@llamaindex/workflow-core@1.3.3(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono@4.11.9)(zod@4.3.6)':
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       hono: 4.11.9
-      zod: 3.25.76
-
-  '@llamaindex/workflow-core@1.3.3(zod@4.3.6)':
-    optionalDependencies:
       zod: 4.3.6
 
-  '@llamaindex/workflow@1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(hono@4.11.9)(zod@3.25.76)':
+  '@llamaindex/workflow@1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono@4.11.9)(zod@4.3.6)':
     dependencies:
       '@llamaindex/core': 0.6.22
       '@llamaindex/env': 0.1.30
-      '@llamaindex/workflow-core': 1.3.3(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(hono@4.11.9)(zod@3.25.76)
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - hono
-      - next
-      - p-retry
-      - rxjs
-      - zod
-
-  '@llamaindex/workflow@1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(zod@4.3.6)':
-    dependencies:
-      '@llamaindex/core': 0.6.22
-      '@llamaindex/env': 0.1.30
-      '@llamaindex/workflow-core': 1.3.3(zod@4.3.6)
+      '@llamaindex/workflow-core': 1.3.3(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono@4.11.9)(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - hono
@@ -9947,34 +9948,12 @@ snapshots:
       rfdc: 1.4.1
       wrap-ansi: 9.0.2
 
-  llamaindex@0.12.1(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(hono@4.11.9)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@3.25.76):
+  llamaindex@0.12.1(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono@4.11.9)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@4.3.6):
     dependencies:
       '@llamaindex/core': 0.6.22
       '@llamaindex/env': 0.1.30
       '@llamaindex/node-parser': 2.0.22(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)
-      '@llamaindex/workflow': 1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(hono@4.11.9)(zod@3.25.76)
-      '@types/lodash': 4.17.23
-      '@types/node': 24.10.13
-      lodash: 4.17.23
-      magic-bytes.js: 1.13.0
-    transitivePeerDependencies:
-      - '@huggingface/transformers'
-      - '@modelcontextprotocol/sdk'
-      - gpt-tokenizer
-      - hono
-      - next
-      - p-retry
-      - rxjs
-      - tree-sitter
-      - web-tree-sitter
-      - zod
-
-  llamaindex@0.12.1(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@4.3.6):
-    dependencies:
-      '@llamaindex/core': 0.6.22
-      '@llamaindex/env': 0.1.30
-      '@llamaindex/node-parser': 2.0.22(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)
-      '@llamaindex/workflow': 1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(zod@4.3.6)
+      '@llamaindex/workflow': 1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono@4.11.9)(zod@4.3.6)
       '@types/lodash': 4.17.23
       '@types/node': 24.10.13
       lodash: 4.17.23
@@ -10253,11 +10232,6 @@ snapshots:
       define-lazy-prop: 3.0.0
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
-
-  openai@5.23.2(ws@8.19.0)(zod@3.25.76):
-    optionalDependencies:
-      ws: 8.19.0
-      zod: 3.25.76
 
   openai@5.23.2(ws@8.19.0)(zod@4.3.6):
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - ts/e2e-tests/_utils
   - ts/e2e-tests/cli/*
+  - ts/e2e-tests/cli/**/*
   - ts/e2e-tests/runtimes/node/*
   - ts/e2e-tests/runtimes/deno/*
   - ts/e2e-tests/runtimes/cloudflare/*

--- a/ts/e2e-tests/README.md
+++ b/ts/e2e-tests/README.md
@@ -42,7 +42,11 @@ ts/e2e-tests/
         └── cf-workers-tool-router-ai/       # Cloudflare Workers AI SDK tool router tests
 └── cli/                                     # CLI runtime tests (scratch)
     ├── version/                             # composio version command tests
-    └── whoami/                              # composio whoami command tests
+    ├── whoami/                              # composio whoami command tests
+    └── toolkits/                            # composio toolkits command tests
+        ├── list/                            # composio toolkits list tests
+        ├── info/                            # composio toolkits info tests
+        └── search/                          # composio toolkits search tests
 ```
 
 ## Running Tests

--- a/ts/e2e-tests/cli/toolkits/info/README.md
+++ b/ts/e2e-tests/cli/toolkits/info/README.md
@@ -1,0 +1,22 @@
+# CLI `composio toolkits info` Test
+
+Verifies that `composio toolkits info <slug>` returns detailed toolkit JSON in piped mode, handles invalid slugs gracefully, and supports stdout redirection.
+
+## What It Tests
+
+| Test | Description |
+| --- | --- |
+| Valid slug | `info gmail` returns JSON object with name, slug, meta, auth_config_details |
+| Stdout redirection | `info gmail > out.json` captures the JSON in the file |
+| Invalid slug | `info nonexistent_toolkit_xyz12345` exits 0, empty stdout |
+| Missing slug | `info` (no arg) exits 0, empty stdout |
+
+## Requirements
+
+- `COMPOSIO_API_KEY` (**required**) — Composio API key passed to the container
+
+## Running
+
+```bash
+pnpm test:e2e:cli
+```

--- a/ts/e2e-tests/cli/toolkits/info/e2e.test.ts
+++ b/ts/e2e-tests/cli/toolkits/info/e2e.test.ts
@@ -1,0 +1,146 @@
+/**
+ * CLI `composio toolkits info` e2e test
+ *
+ * Verifies that the info subcommand returns detailed toolkit JSON in piped mode,
+ * handles invalid slugs gracefully, and supports stdout redirection.
+ */
+
+import {
+  e2e,
+  sanitizeOutput,
+  type E2ETestResult,
+  type E2ETestResultWithFiles,
+} from '@e2e-tests/utils';
+import { TIMEOUTS } from '@e2e-tests/utils/const';
+import { describe, it, expect, beforeAll } from 'bun:test';
+
+declare module 'bun' {
+  interface Env {
+    COMPOSIO_API_KEY: string;
+  }
+}
+
+e2e(import.meta.url, {
+  versions: {
+    cli: ['current'],
+  },
+  env: {
+    COMPOSIO_API_KEY: Bun.env.COMPOSIO_API_KEY,
+  },
+  defineTests: ({ runCmd }) => {
+    let validResult: E2ETestResult;
+    let redirectResult: E2ETestResultWithFiles<'out.json'>;
+    let invalidResult: E2ETestResult;
+    let missingSlugResult: E2ETestResult;
+
+    beforeAll(async () => {
+      validResult = await runCmd('composio toolkits info gmail');
+      redirectResult = await runCmd({
+        command: 'composio toolkits info gmail > out.json',
+        files: ['out.json'],
+      });
+      invalidResult = await runCmd('composio toolkits info nonexistent_toolkit_xyz12345');
+      missingSlugResult = await runCmd('composio toolkits info');
+    }, TIMEOUTS.FIXTURE);
+
+    describe('composio toolkits info gmail (valid slug)', () => {
+      it('exits successfully', () => {
+        expect(validResult.exitCode).toBe(0);
+      });
+
+      it('stderr is empty', () => {
+        expect(validResult.stderr).toBe('');
+      });
+
+      it('stdout is a valid JSON object', () => {
+        const obj = JSON.parse(sanitizeOutput(validResult.stdout));
+        expect(typeof obj).toBe('object');
+        expect(Array.isArray(obj)).toBe(false);
+      });
+
+      it('has the correct name and slug', () => {
+        const obj = JSON.parse(sanitizeOutput(validResult.stdout));
+        expect(obj.name).toBe('Gmail');
+        expect(obj.slug).toBe('gmail');
+      });
+
+      it('has meta with description, tools_count, and triggers_count', () => {
+        const obj = JSON.parse(sanitizeOutput(validResult.stdout));
+        expect(obj.meta).toHaveProperty('description');
+        expect(typeof obj.meta.tools_count).toBe('number');
+        expect(typeof obj.meta.triggers_count).toBe('number');
+      });
+
+      it('has auth_config_details array', () => {
+        const obj = JSON.parse(sanitizeOutput(validResult.stdout));
+        expect(Array.isArray(obj.auth_config_details)).toBe(true);
+        expect(obj.auth_config_details.length).toBeGreaterThan(0);
+      });
+
+      it('each auth_config_detail has mode, name, and fields', () => {
+        const obj = JSON.parse(sanitizeOutput(validResult.stdout));
+        for (const detail of obj.auth_config_details) {
+          expect(detail).toHaveProperty('mode');
+          expect(detail).toHaveProperty('name');
+          expect(detail).toHaveProperty('fields');
+          expect(detail.fields).toHaveProperty('auth_config_creation');
+          expect(detail.fields).toHaveProperty('connected_account_initiation');
+        }
+      });
+
+      it('has composio_managed_auth_schemes, no_auth, and is_local_toolkit', () => {
+        const obj = JSON.parse(sanitizeOutput(validResult.stdout));
+        expect(Array.isArray(obj.composio_managed_auth_schemes)).toBe(true);
+        expect(typeof obj.no_auth).toBe('boolean');
+        expect(typeof obj.is_local_toolkit).toBe('boolean');
+      });
+    });
+
+    describe('composio toolkits info gmail > out.json (stdout redirection)', () => {
+      it('exits successfully', () => {
+        expect(redirectResult.exitCode).toBe(0);
+      });
+
+      it('stdout is empty', () => {
+        expect(redirectResult.stdout).toBe('');
+      });
+
+      it('stderr is empty', () => {
+        expect(redirectResult.stderr).toBe('');
+      });
+
+      it('out.json contains valid JSON with slug "gmail"', () => {
+        const obj = JSON.parse(sanitizeOutput(redirectResult.files['out.json']));
+        expect(obj.slug).toBe('gmail');
+      });
+    });
+
+    describe('composio toolkits info nonexistent_toolkit_xyz12345 (invalid slug)', () => {
+      it('exits successfully (graceful error handling)', () => {
+        expect(invalidResult.exitCode).toBe(0);
+      });
+
+      it('stdout is empty (no data on error)', () => {
+        expect(sanitizeOutput(invalidResult.stdout)).toBe('');
+      });
+
+      it('stderr is empty (piped mode suppresses decoration)', () => {
+        expect(invalidResult.stderr).toBe('');
+      });
+    });
+
+    describe('composio toolkits info (missing slug)', () => {
+      it('exits successfully (optional arg, handler guards)', () => {
+        expect(missingSlugResult.exitCode).toBe(0);
+      });
+
+      it('stdout is empty', () => {
+        expect(sanitizeOutput(missingSlugResult.stdout)).toBe('');
+      });
+
+      it('stderr is empty', () => {
+        expect(missingSlugResult.stderr).toBe('');
+      });
+    });
+  },
+});

--- a/ts/e2e-tests/cli/toolkits/info/package.json
+++ b/ts/e2e-tests/cli/toolkits/info/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@e2e-tests/cli-toolkits-info",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test:e2e": "bun test e2e.test.ts",
+    "test:e2e:cli": "bun test e2e.test.ts"
+  },
+  "devDependencies": {
+    "@e2e-tests/utils": "workspace:*"
+  }
+}

--- a/ts/e2e-tests/cli/toolkits/list/README.md
+++ b/ts/e2e-tests/cli/toolkits/list/README.md
@@ -1,0 +1,21 @@
+# CLI `composio toolkits list` Test
+
+Verifies that `composio toolkits list` returns toolkits as JSON in piped mode with correct `--query` filtering behavior.
+
+## What It Tests
+
+| Test | Description |
+| --- | --- |
+| Exact slug match | `--query gmail --limit 1` returns 1 item with slug "gmail" |
+| Prefix search | `--query gmai --limit 1` returns 1 item (API supports prefix matching) |
+| No fuzzy search | `--query gmal --limit 1` returns empty (backend doesn't support fuzzy search) |
+
+## Requirements
+
+- `COMPOSIO_API_KEY` (**required**) — Composio API key passed to the container
+
+## Running
+
+```bash
+pnpm test:e2e:cli
+```

--- a/ts/e2e-tests/cli/toolkits/list/e2e.test.ts
+++ b/ts/e2e-tests/cli/toolkits/list/e2e.test.ts
@@ -1,0 +1,101 @@
+/**
+ * CLI `composio toolkits list` e2e test
+ *
+ * Verifies that the list subcommand returns toolkits as JSON in piped mode,
+ * supports --query filtering (exact, prefix, no fuzzy), and respects --limit.
+ */
+
+import { e2e, sanitizeOutput, type E2ETestResult } from '@e2e-tests/utils';
+import { TIMEOUTS } from '@e2e-tests/utils/const';
+import { describe, it, expect, beforeAll } from 'bun:test';
+
+declare module 'bun' {
+  interface Env {
+    COMPOSIO_API_KEY: string;
+  }
+}
+
+e2e(import.meta.url, {
+  versions: {
+    cli: ['current'],
+  },
+  env: {
+    COMPOSIO_API_KEY: Bun.env.COMPOSIO_API_KEY,
+  },
+  defineTests: ({ runCmd }) => {
+    let exactResult: E2ETestResult;
+    let prefixResult: E2ETestResult;
+    let noFuzzyResult: E2ETestResult;
+
+    beforeAll(async () => {
+      exactResult = await runCmd('composio toolkits list --query gmail --limit 1');
+      prefixResult = await runCmd('composio toolkits list --query gmai --limit 1');
+      noFuzzyResult = await runCmd('composio toolkits list --query gmal --limit 1');
+    }, TIMEOUTS.FIXTURE);
+
+    describe('composio toolkits list --query gmail --limit 1 (exact slug)', () => {
+      it('exits successfully', () => {
+        expect(exactResult.exitCode).toBe(0);
+      });
+
+      it('stderr is empty', () => {
+        expect(exactResult.stderr).toBe('');
+      });
+
+      it('stdout is a JSON array with 1 element', () => {
+        const items = JSON.parse(sanitizeOutput(exactResult.stdout));
+        expect(Array.isArray(items)).toBe(true);
+        expect(items).toHaveLength(1);
+      });
+
+      it('the element has slug "gmail"', () => {
+        const items = JSON.parse(sanitizeOutput(exactResult.stdout));
+        expect(items[0].slug).toBe('gmail');
+      });
+
+      it('the element has the expected shape', () => {
+        const item = JSON.parse(sanitizeOutput(exactResult.stdout))[0];
+        expect(item).toHaveProperty('name');
+        expect(item).toHaveProperty('slug');
+        expect(item).toHaveProperty('tools_count');
+        expect(item).toHaveProperty('triggers_count');
+        expect(item).toHaveProperty('description');
+      });
+    });
+
+    describe('composio toolkits list --query gmai --limit 1 (prefix search)', () => {
+      it('exits successfully', () => {
+        expect(prefixResult.exitCode).toBe(0);
+      });
+
+      it('stderr is empty', () => {
+        expect(prefixResult.stderr).toBe('');
+      });
+
+      it('stdout is a JSON array with 1 element', () => {
+        const items = JSON.parse(sanitizeOutput(prefixResult.stdout));
+        expect(Array.isArray(items)).toBe(true);
+        expect(items).toHaveLength(1);
+      });
+
+      it('the element has slug "gmail"', () => {
+        const items = JSON.parse(sanitizeOutput(prefixResult.stdout));
+        expect(items[0].slug).toBe('gmail');
+      });
+    });
+
+    describe('composio toolkits list --query gmal --limit 1 (no fuzzy search)', () => {
+      it('exits successfully', () => {
+        expect(noFuzzyResult.exitCode).toBe(0);
+      });
+
+      it('stderr is empty', () => {
+        expect(noFuzzyResult.stderr).toBe('');
+      });
+
+      it('stdout is empty (no results)', () => {
+        expect(sanitizeOutput(noFuzzyResult.stdout)).toBe('');
+      });
+    });
+  },
+});

--- a/ts/e2e-tests/cli/toolkits/list/package.json
+++ b/ts/e2e-tests/cli/toolkits/list/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@e2e-tests/cli-toolkits-list",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test:e2e": "bun test e2e.test.ts",
+    "test:e2e:cli": "bun test e2e.test.ts"
+  },
+  "devDependencies": {
+    "@e2e-tests/utils": "workspace:*"
+  }
+}

--- a/ts/e2e-tests/cli/toolkits/search/README.md
+++ b/ts/e2e-tests/cli/toolkits/search/README.md
@@ -1,0 +1,22 @@
+# CLI `composio toolkits search` Test
+
+Verifies that `composio toolkits search <query>` returns matching toolkits as JSON in piped mode, respects `--limit`, supports stdout redirection, and handles queries with no results.
+
+## What It Tests
+
+| Test | Description |
+| --- | --- |
+| Known query | `search gmail` returns JSON array with "gmail" as first result |
+| With limit | `search gmail --limit 1` returns exactly 1 element |
+| Stdout redirection | `search gmail --limit 1 > out.json` captures JSON in the file |
+| No results | `search xyznonexistent_abc_12345` returns empty stdout |
+
+## Requirements
+
+- `COMPOSIO_API_KEY` (**required**) — Composio API key passed to the container
+
+## Running
+
+```bash
+pnpm test:e2e:cli
+```

--- a/ts/e2e-tests/cli/toolkits/search/e2e.test.ts
+++ b/ts/e2e-tests/cli/toolkits/search/e2e.test.ts
@@ -1,0 +1,134 @@
+/**
+ * CLI `composio toolkits search` e2e test
+ *
+ * Verifies that the search subcommand returns matching toolkits as JSON in piped mode,
+ * respects --limit, supports stdout redirection, and handles no-result queries.
+ */
+
+import {
+  e2e,
+  sanitizeOutput,
+  type E2ETestResult,
+  type E2ETestResultWithFiles,
+} from '@e2e-tests/utils';
+import { TIMEOUTS } from '@e2e-tests/utils/const';
+import { describe, it, expect, beforeAll } from 'bun:test';
+
+declare module 'bun' {
+  interface Env {
+    COMPOSIO_API_KEY: string;
+  }
+}
+
+e2e(import.meta.url, {
+  versions: {
+    cli: ['current'],
+  },
+  env: {
+    COMPOSIO_API_KEY: Bun.env.COMPOSIO_API_KEY,
+  },
+  defineTests: ({ runCmd }) => {
+    let validResult: E2ETestResult;
+    let limitResult: E2ETestResult;
+    let redirectResult: E2ETestResultWithFiles<'out.json'>;
+    let noResultsResult: E2ETestResult;
+
+    beforeAll(async () => {
+      validResult = await runCmd('composio toolkits search gmail');
+      limitResult = await runCmd('composio toolkits search gmail --limit 1');
+      redirectResult = await runCmd({
+        command: 'composio toolkits search gmail --limit 1 > out.json',
+        files: ['out.json'],
+      });
+      noResultsResult = await runCmd('composio toolkits search xyznonexistent_abc_12345');
+    }, TIMEOUTS.FIXTURE);
+
+    describe('composio toolkits search gmail (known query)', () => {
+      it('exits successfully', () => {
+        expect(validResult.exitCode).toBe(0);
+      });
+
+      it('stderr is empty', () => {
+        expect(validResult.stderr).toBe('');
+      });
+
+      it('stdout is a JSON array with at least 1 element', () => {
+        const items = JSON.parse(sanitizeOutput(validResult.stdout));
+        expect(Array.isArray(items)).toBe(true);
+        expect(items.length).toBeGreaterThanOrEqual(1);
+      });
+
+      it('first element has slug "gmail"', () => {
+        const items = JSON.parse(sanitizeOutput(validResult.stdout));
+        expect(items[0].slug).toBe('gmail');
+      });
+
+      it('each element has the expected shape', () => {
+        const items = JSON.parse(sanitizeOutput(validResult.stdout));
+        for (const item of items) {
+          expect(item).toHaveProperty('name');
+          expect(item).toHaveProperty('slug');
+          expect(item).toHaveProperty('tools_count');
+          expect(item).toHaveProperty('triggers_count');
+          expect(item).toHaveProperty('description');
+        }
+      });
+    });
+
+    describe('composio toolkits search gmail --limit 1 (with limit)', () => {
+      it('exits successfully', () => {
+        expect(limitResult.exitCode).toBe(0);
+      });
+
+      it('stderr is empty', () => {
+        expect(limitResult.stderr).toBe('');
+      });
+
+      it('stdout is a JSON array with exactly 1 element', () => {
+        const items = JSON.parse(sanitizeOutput(limitResult.stdout));
+        expect(Array.isArray(items)).toBe(true);
+        expect(items).toHaveLength(1);
+      });
+
+      it('the element has slug "gmail"', () => {
+        const items = JSON.parse(sanitizeOutput(limitResult.stdout));
+        expect(items[0].slug).toBe('gmail');
+      });
+    });
+
+    describe('composio toolkits search gmail --limit 1 > out.json (stdout redirection)', () => {
+      it('exits successfully', () => {
+        expect(redirectResult.exitCode).toBe(0);
+      });
+
+      it('stdout is empty', () => {
+        expect(redirectResult.stdout).toBe('');
+      });
+
+      it('stderr is empty', () => {
+        expect(redirectResult.stderr).toBe('');
+      });
+
+      it('out.json contains a JSON array with slug "gmail"', () => {
+        const items = JSON.parse(sanitizeOutput(redirectResult.files['out.json']));
+        expect(Array.isArray(items)).toBe(true);
+        expect(items).toHaveLength(1);
+        expect(items[0].slug).toBe('gmail');
+      });
+    });
+
+    describe('composio toolkits search xyznonexistent_abc_12345 (no results)', () => {
+      it('exits successfully', () => {
+        expect(noResultsResult.exitCode).toBe(0);
+      });
+
+      it('stderr is empty', () => {
+        expect(noResultsResult.stderr).toBe('');
+      });
+
+      it('stdout is empty (no results)', () => {
+        expect(sanitizeOutput(noResultsResult.stdout)).toBe('');
+      });
+    });
+  },
+});

--- a/ts/e2e-tests/cli/toolkits/search/package.json
+++ b/ts/e2e-tests/cli/toolkits/search/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@e2e-tests/cli-toolkits-search",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test:e2e": "bun test e2e.test.ts",
+    "test:e2e:cli": "bun test e2e.test.ts"
+  },
+  "devDependencies": {
+    "@e2e-tests/utils": "workspace:*"
+  }
+}

--- a/ts/packages/cli/src/bin.ts
+++ b/ts/packages/cli/src/bin.ts
@@ -125,7 +125,12 @@ const collectValueOptionNamesFromUsage = (usage: Usage.Usage, acc: Set<string>) 
 
 const valueOptionNames = (() => {
   const names = new Set<string>();
+  const visited = new Set<CommandDescriptor.Command<unknown>>();
   const visit = (command: CommandDescriptor.Command<unknown>) => {
+    if (visited.has(command)) {
+      return;
+    }
+    visited.add(command);
     collectValueOptionNamesFromUsage(CommandDescriptor.getUsage(command), names);
     for (const [, subcommand] of HashMap.toEntries(CommandDescriptor.getSubcommands(command))) {
       visit(subcommand);

--- a/ts/packages/cli/src/bin.ts
+++ b/ts/packages/cli/src/bin.ts
@@ -1,7 +1,7 @@
 import process from 'node:process';
 import { Cause, Console, Effect, Exit, Layer, Logger } from 'effect';
 import { captureErrors, prettyPrintFromCapturedErrors } from 'effect-errors/index';
-import { CliConfig, ValidationError } from '@effect/cli';
+import { CliConfig, HelpDoc, ValidationError } from '@effect/cli';
 import { FetchHttpClient } from '@effect/platform';
 import { BunContext, BunRuntime, BunFileSystem } from '@effect/platform-bun';
 import type { Teardown } from '@effect/platform/Runtime';
@@ -101,9 +101,18 @@ const runWithArgs = Effect.flatMap(runWithConfig, run => run(process.argv)) sati
 runWithArgs.pipe(
   Effect.scoped,
   // @effect/cli already prints validation errors (missing args, invalid flags, etc.)
-  // via its own printDocs before re-failing. Swallow the error here to avoid
+  // via its own printDocs before re-failing. Swallow the re-thrown error to avoid
   // routing it through the generic error box which would dump raw JSON.
-  Effect.catchIf(ValidationError.isValidationError, () => Effect.void),
+  // When a flag is passed without its required value (e.g. `--query` instead of
+  // `--query "text"`), @effect/cli reports it as "unknown argument" — add a tip.
+  Effect.catchIf(ValidationError.isValidationError, error => {
+    const text = HelpDoc.toAnsiText(error.error).trim();
+    const flagMatch = text.match(/Received unknown argument: '(--\w+)'/);
+    if (flagMatch) {
+      return Console.error(`Tip: ${flagMatch[1]} requires a value, e.g. ${flagMatch[1]} "value"`);
+    }
+    return Effect.void;
+  }),
   Effect.withSpan('composio-cli', {
     attributes: {
       name: constants.APP_NAME,

--- a/ts/packages/cli/src/bin.ts
+++ b/ts/packages/cli/src/bin.ts
@@ -1,7 +1,7 @@
 import process from 'node:process';
 import { Cause, Console, Effect, Exit, Layer, Logger } from 'effect';
 import { captureErrors, prettyPrintFromCapturedErrors } from 'effect-errors/index';
-import { CliConfig } from '@effect/cli';
+import { CliConfig, ValidationError } from '@effect/cli';
 import { FetchHttpClient } from '@effect/platform';
 import { BunContext, BunRuntime, BunFileSystem } from '@effect/platform-bun';
 import type { Teardown } from '@effect/platform/Runtime';
@@ -100,6 +100,10 @@ const runWithArgs = Effect.flatMap(runWithConfig, run => run(process.argv)) sati
  */
 runWithArgs.pipe(
   Effect.scoped,
+  // @effect/cli already prints validation errors (missing args, invalid flags, etc.)
+  // via its own printDocs before re-failing. Swallow the error here to avoid
+  // routing it through the generic error box which would dump raw JSON.
+  Effect.catchIf(ValidationError.isValidationError, () => Effect.void),
   Effect.withSpan('composio-cli', {
     attributes: {
       name: constants.APP_NAME,

--- a/ts/packages/cli/src/bin.ts
+++ b/ts/packages/cli/src/bin.ts
@@ -107,7 +107,7 @@ runWithArgs.pipe(
   // `--query "text"`), @effect/cli reports it as "unknown argument" — add a tip.
   Effect.catchIf(ValidationError.isValidationError, error => {
     const text = HelpDoc.toAnsiText(error.error).trim();
-    const flagMatch = text.match(/Received unknown argument: '(--\w+)'/);
+    const flagMatch = text.match(/Received unknown argument: '(-{1,2}[\w-]+)'/);
     if (flagMatch) {
       return Console.error(`Tip: ${flagMatch[1]} requires a value, e.g. ${flagMatch[1]} "value"`);
     }

--- a/ts/packages/cli/src/bin.ts
+++ b/ts/packages/cli/src/bin.ts
@@ -1,7 +1,7 @@
 import process from 'node:process';
 import { Cause, Console, Effect, Exit, HashMap, Layer, Logger, Option } from 'effect';
 import { captureErrors, prettyPrintFromCapturedErrors } from 'effect-errors/index';
-import { CliConfig, Command, HelpDoc, Usage, ValidationError } from '@effect/cli';
+import { CliConfig, CommandDescriptor, HelpDoc, Usage, ValidationError } from '@effect/cli';
 import { FetchHttpClient } from '@effect/platform';
 import { BunContext, BunRuntime, BunFileSystem } from '@effect/platform-bun';
 import type { Teardown } from '@effect/platform/Runtime';
@@ -125,13 +125,13 @@ const collectValueOptionNamesFromUsage = (usage: Usage.Usage, acc: Set<string>) 
 
 const valueOptionNames = (() => {
   const names = new Set<string>();
-  const visit = (command: Command.Command<unknown>) => {
-    collectValueOptionNamesFromUsage(Command.getUsage(command), names);
-    for (const [, subcommand] of HashMap.toEntries(Command.getSubcommands(command))) {
+  const visit = (command: CommandDescriptor.Command<unknown>) => {
+    collectValueOptionNamesFromUsage(CommandDescriptor.getUsage(command), names);
+    for (const [, subcommand] of HashMap.toEntries(CommandDescriptor.getSubcommands(command))) {
       visit(subcommand);
     }
   };
-  visit(rootCommand);
+  visit(rootCommand.descriptor);
   return names;
 })();
 

--- a/ts/packages/cli/src/bin.ts
+++ b/ts/packages/cli/src/bin.ts
@@ -1,11 +1,11 @@
 import process from 'node:process';
-import { Cause, Console, Effect, Exit, Layer, Logger } from 'effect';
+import { Cause, Console, Effect, Exit, HashMap, Layer, Logger, Option } from 'effect';
 import { captureErrors, prettyPrintFromCapturedErrors } from 'effect-errors/index';
-import { CliConfig, HelpDoc, ValidationError } from '@effect/cli';
+import { CliConfig, Command, HelpDoc, Usage, ValidationError } from '@effect/cli';
 import { FetchHttpClient } from '@effect/platform';
 import { BunContext, BunRuntime, BunFileSystem } from '@effect/platform-bun';
 import type { Teardown } from '@effect/platform/Runtime';
-import { runWithConfig } from 'src/commands';
+import { rootCommand, runWithConfig } from 'src/commands';
 import * as constants from 'src/constants';
 import { ComposioCliConfig } from 'src/cli-config';
 import { BaseConfigProviderLive, ConfigLive, extendConfigProvider } from 'src/services/config';
@@ -93,6 +93,48 @@ const runWithArgs = Effect.flatMap(runWithConfig, run => run(process.argv)) sati
   unknown
 >;
 
+const collectValueOptionNamesFromUsage = (usage: Usage.Usage, acc: Set<string>) => {
+  switch (usage._tag) {
+    case 'Named': {
+      if (Option.isSome(usage.acceptedValues)) {
+        for (const name of usage.names) {
+          if (name.startsWith('-')) {
+            acc.add(name);
+          }
+        }
+      }
+      return;
+    }
+    case 'Optional':
+    case 'Repeated': {
+      collectValueOptionNamesFromUsage(usage.usage, acc);
+      return;
+    }
+    case 'Alternation':
+    case 'Concat': {
+      collectValueOptionNamesFromUsage(usage.left, acc);
+      collectValueOptionNamesFromUsage(usage.right, acc);
+      return;
+    }
+    case 'Mixed':
+    case 'Empty': {
+      return;
+    }
+  }
+};
+
+const valueOptionNames = (() => {
+  const names = new Set<string>();
+  const visit = (command: Command.Command<unknown>) => {
+    collectValueOptionNamesFromUsage(Command.getUsage(command), names);
+    for (const [, subcommand] of HashMap.toEntries(Command.getSubcommands(command))) {
+      visit(subcommand);
+    }
+  };
+  visit(rootCommand);
+  return names;
+})();
+
 /**
  * CLI entrypoint, which:
  * - runs the Effect runtime and sets up its runtime environment
@@ -108,7 +150,7 @@ runWithArgs.pipe(
   Effect.catchIf(ValidationError.isValidationError, error => {
     const text = HelpDoc.toAnsiText(error.error).trim();
     const flagMatch = text.match(/Received unknown argument: '(-{1,2}[\w-]+)'/);
-    if (flagMatch) {
+    if (flagMatch && valueOptionNames.has(flagMatch[1])) {
       return Console.error(`Tip: ${flagMatch[1]} requires a value, e.g. ${flagMatch[1]} "value"`);
     }
     return Effect.void;

--- a/ts/packages/cli/src/commands/index.ts
+++ b/ts/packages/cli/src/commands/index.ts
@@ -27,6 +27,8 @@ const $cmd = $defaultCmd.pipe(
   ])
 );
 
+export const rootCommand = $cmd;
+
 export const runWithConfig = Effect.gen(function* () {
   const version = yield* getVersion;
 

--- a/ts/packages/cli/src/commands/index.ts
+++ b/ts/packages/cli/src/commands/index.ts
@@ -11,6 +11,7 @@ import { logoutCmd } from './logout.cmd';
 import { pyCmd } from './py/py.cmd';
 import { tsCmd } from './ts/ts.cmd';
 import { generateCmd } from './generate.cmd';
+import { toolkitsCmd } from './toolkits/toolkits.cmd';
 
 const $cmd = $defaultCmd.pipe(
   Command.withSubcommands([
@@ -22,6 +23,7 @@ const $cmd = $defaultCmd.pipe(
     generateCmd,
     pyCmd,
     tsCmd,
+    toolkitsCmd,
   ])
 );
 

--- a/ts/packages/cli/src/commands/toolkits/commands/toolkits.info.cmd.ts
+++ b/ts/packages/cli/src/commands/toolkits/commands/toolkits.info.cmd.ts
@@ -26,9 +26,15 @@ function formatFields(fields: ReadonlyArray<AuthConfigDetail['fields']['auth_con
     if (allFields.length === 0) {
       lines.push('    (none)');
     } else {
+      const nameWidth = Math.max(...allFields.map(f => f.name.length));
+      const labelWidth = Math.max(...allFields.map(f => f.label.length));
+      const typeWidth = Math.max(...allFields.map(f => f.type.length));
+
       for (const field of allFields) {
         const desc = field.description ? `  ${gray(`"${field.description}"`)}` : '';
-        lines.push(`    ${field.name.padEnd(16)} ${field.label.padEnd(10)} ${field.type}${desc}`);
+        lines.push(
+          `    ${field.name.padEnd(nameWidth)} ${field.label.padEnd(labelWidth)} ${field.type.padEnd(typeWidth)}${desc}`
+        );
       }
     }
   }

--- a/ts/packages/cli/src/commands/toolkits/commands/toolkits.info.cmd.ts
+++ b/ts/packages/cli/src/commands/toolkits/commands/toolkits.info.cmd.ts
@@ -1,0 +1,139 @@
+import { Args, Command } from '@effect/cli';
+import { Effect, Option } from 'effect';
+import { ComposioToolkitsRepository, HttpServerError } from 'src/services/composio-clients';
+import { ComposioUserContext } from 'src/services/user-context';
+import { TerminalUI } from 'src/services/terminal-ui';
+import type { ToolkitDetailed, AuthConfigDetail } from 'src/models/toolkits';
+import { bold, gray } from 'src/ui/colors';
+
+const slug = Args.text({ name: 'slug' }).pipe(Args.withDescription('Toolkit slug (e.g. "gmail")'));
+
+/**
+ * Format auth config fields for display.
+ */
+function formatFields(fields: ReadonlyArray<AuthConfigDetail['fields']['auth_config_creation']>) {
+  const lines: string[] = [];
+
+  for (const group of fields) {
+    const allFields = [
+      ...group.required.map(f => ({ ...f, label: 'required' })),
+      ...group.optional.map(f => ({ ...f, label: 'optional' })),
+    ];
+
+    if (allFields.length === 0) {
+      lines.push('    (none)');
+    } else {
+      for (const field of allFields) {
+        const desc = field.description ? `  ${gray(`"${field.description}"`)}` : '';
+        lines.push(`    ${field.name.padEnd(16)} ${field.label.padEnd(10)} ${field.type}${desc}`);
+      }
+    }
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Format a detailed toolkit for interactive display.
+ */
+function formatToolkitInfo(toolkit: ToolkitDetailed): string {
+  const lines: string[] = [];
+
+  lines.push(`${bold('Name:')} ${toolkit.name}`);
+  lines.push(`${bold('Slug:')} ${toolkit.slug}`);
+  lines.push(`${bold('Description:')} ${toolkit.meta.description || '(none)'}`);
+
+  // Derive auth schemes from auth_config_details
+  const authSchemes = toolkit.auth_config_details.map(d => d.mode);
+  if (toolkit.no_auth) {
+    lines.push(`${bold('Auth:')} No authentication required`);
+  } else if (authSchemes.length > 0) {
+    lines.push(`${bold('Auth Schemes:')} ${authSchemes.join(', ')}`);
+    if (toolkit.composio_managed_auth_schemes.length > 0) {
+      lines.push(
+        `${bold('Composio Managed Auth Schemes:')} ${toolkit.composio_managed_auth_schemes.join(', ')}`
+      );
+    }
+  }
+
+  // Auth config creation fields
+  if (toolkit.auth_config_details.length > 0) {
+    lines.push('');
+    lines.push(bold('Fields Required for AuthConfig creation:'));
+    for (const detail of toolkit.auth_config_details) {
+      lines.push(`  ${detail.name} (${detail.mode}):`);
+      lines.push(formatFields([detail.fields.auth_config_creation]));
+    }
+
+    lines.push('');
+    lines.push(bold('Fields Required for Connected Account creation:'));
+    for (const detail of toolkit.auth_config_details) {
+      lines.push(`  ${detail.name} (${detail.mode}):`);
+      lines.push(formatFields([detail.fields.connected_account_initiation]));
+    }
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * View details of a specific toolkit including auth schemes and required fields.
+ *
+ * @example
+ * ```bash
+ * composio toolkits info "gmail"
+ * ```
+ */
+export const toolkitsCmd$Info = Command.make('info', { slug }, ({ slug }) =>
+  Effect.gen(function* () {
+    const ui = yield* TerminalUI;
+    const ctx = yield* ComposioUserContext;
+    const repo = yield* ComposioToolkitsRepository;
+
+    // Auth guard
+    if (Option.isNone(ctx.data.apiKey)) {
+      yield* ui.log.warn('You are not logged in yet. Please run `composio login`.');
+      return;
+    }
+
+    const toolkit = yield* ui
+      .withSpinner(`Fetching toolkit "${slug}"...`, repo.getToolkitDetailed(slug))
+      .pipe(
+        Effect.catchTag('services/HttpServerError', (e: HttpServerError) =>
+          Effect.gen(function* () {
+            if (e.status === 404) {
+              // Try to suggest similar toolkits
+              const suggestions = yield* repo.searchToolkits({ search: slug, limit: 3 }).pipe(
+                Effect.map(r => r.items),
+                Effect.catchAll(() => Effect.succeed([]))
+              );
+
+              if (suggestions.length > 0) {
+                const suggestionLines = suggestions
+                  .map(s => `  ${s.slug} — ${s.meta.description}`)
+                  .join('\n');
+                yield* ui.log.error(
+                  `Toolkit "${slug}" not found.\n\nDid you mean?\n${suggestionLines}\n\n> composio toolkits info "${suggestions[0]!.slug}"`
+                );
+              } else {
+                yield* ui.log.error(`Toolkit "${slug}" not found.`);
+              }
+
+              return yield* Effect.fail(e);
+            }
+
+            return yield* Effect.fail(e);
+          })
+        )
+      );
+
+    yield* ui.note(formatToolkitInfo(toolkit), `Toolkit: ${toolkit.name}`);
+
+    // Next step hint
+    yield* ui.log.step(
+      `To list tools in this toolkit:\n> composio tools list --toolkit "${toolkit.slug}"`
+    );
+
+    yield* ui.output(JSON.stringify(toolkit, null, 2));
+  })
+).pipe(Command.withDescription('View details of a specific toolkit.'));

--- a/ts/packages/cli/src/commands/toolkits/commands/toolkits.info.cmd.ts
+++ b/ts/packages/cli/src/commands/toolkits/commands/toolkits.info.cmd.ts
@@ -108,9 +108,10 @@ export const toolkitsCmd$Info = Command.make('info', { slug }, ({ slug }) =>
 
     const slugValue = slug.value;
 
-    const toolkit = yield* ui
+    const toolkitOpt = yield* ui
       .withSpinner(`Fetching toolkit "${slugValue}"...`, repo.getToolkitDetailed(slugValue))
       .pipe(
+        Effect.asSome,
         Effect.catchTag('services/HttpServerError', (e: HttpServerError) =>
           Effect.gen(function* () {
             // Show structured error message and suggested fix from the API
@@ -134,12 +135,20 @@ export const toolkitsCmd$Info = Command.make('info', { slug }, ({ slug }) =>
               yield* ui.log.step(
                 `Did you mean?\n${suggestionLines}\n\n> composio toolkits info "${suggestions[0]!.slug}"`
               );
+            } else {
+              yield* ui.log.step('Browse available toolkits:\n> composio toolkits list');
             }
 
-            return yield* Effect.fail(e);
+            return Option.none();
           })
         )
       );
+
+    if (Option.isNone(toolkitOpt)) {
+      return;
+    }
+
+    const toolkit = toolkitOpt.value;
 
     yield* ui.note(formatToolkitInfo(toolkit), `Toolkit: ${toolkit.name}`);
 

--- a/ts/packages/cli/src/commands/toolkits/commands/toolkits.info.cmd.ts
+++ b/ts/packages/cli/src/commands/toolkits/commands/toolkits.info.cmd.ts
@@ -6,7 +6,10 @@ import { TerminalUI } from 'src/services/terminal-ui';
 import type { ToolkitDetailed, AuthConfigDetail } from 'src/models/toolkits';
 import { bold, gray } from 'src/ui/colors';
 
-const slug = Args.text({ name: 'slug' }).pipe(Args.withDescription('Toolkit slug (e.g. "gmail")'));
+const slug = Args.text({ name: 'slug' }).pipe(
+  Args.withDescription('Toolkit slug (e.g. "gmail")'),
+  Args.optional
+);
 
 /**
  * Format auth config fields for display.
@@ -96,30 +99,41 @@ export const toolkitsCmd$Info = Command.make('info', { slug }, ({ slug }) =>
       return;
     }
 
+    // Missing slug guard
+    if (Option.isNone(slug)) {
+      yield* ui.log.warn('Missing required argument: <slug>');
+      yield* ui.log.step('Try specifying a toolkit slug, e.g.:\n> composio toolkits info "gmail"');
+      return;
+    }
+
+    const slugValue = slug.value;
+
     const toolkit = yield* ui
-      .withSpinner(`Fetching toolkit "${slug}"...`, repo.getToolkitDetailed(slug))
+      .withSpinner(`Fetching toolkit "${slugValue}"...`, repo.getToolkitDetailed(slugValue))
       .pipe(
         Effect.catchTag('services/HttpServerError', (e: HttpServerError) =>
           Effect.gen(function* () {
-            if (e.status === 404) {
-              // Try to suggest similar toolkits
-              const suggestions = yield* repo.searchToolkits({ search: slug, limit: 3 }).pipe(
-                Effect.map(r => r.items),
-                Effect.catchAll(() => Effect.succeed([]))
+            // Show structured error message and suggested fix from the API
+            if (e.details) {
+              yield* ui.log.error(e.details.message);
+              yield* ui.log.step(e.details.suggestedFix);
+            } else {
+              yield* ui.log.error(`Failed to fetch toolkit "${slugValue}".`);
+            }
+
+            // Try to suggest similar toolkits
+            const suggestions = yield* repo.searchToolkits({ search: slugValue, limit: 3 }).pipe(
+              Effect.map(r => r.items),
+              Effect.catchAll(() => Effect.succeed([]))
+            );
+
+            if (suggestions.length > 0) {
+              const suggestionLines = suggestions
+                .map(s => `  ${s.slug} — ${s.meta.description}`)
+                .join('\n');
+              yield* ui.log.step(
+                `Did you mean?\n${suggestionLines}\n\n> composio toolkits info "${suggestions[0]!.slug}"`
               );
-
-              if (suggestions.length > 0) {
-                const suggestionLines = suggestions
-                  .map(s => `  ${s.slug} — ${s.meta.description}`)
-                  .join('\n');
-                yield* ui.log.error(
-                  `Toolkit "${slug}" not found.\n\nDid you mean?\n${suggestionLines}\n\n> composio toolkits info "${suggestions[0]!.slug}"`
-                );
-              } else {
-                yield* ui.log.error(`Toolkit "${slug}" not found.`);
-              }
-
-              return yield* Effect.fail(e);
             }
 
             return yield* Effect.fail(e);

--- a/ts/packages/cli/src/commands/toolkits/commands/toolkits.list.cmd.ts
+++ b/ts/packages/cli/src/commands/toolkits/commands/toolkits.list.cmd.ts
@@ -1,0 +1,82 @@
+import { Command, Options } from '@effect/cli';
+import { Effect, Option } from 'effect';
+import { ComposioToolkitsRepository } from 'src/services/composio-clients';
+import { ComposioUserContext } from 'src/services/user-context';
+import { TerminalUI } from 'src/services/terminal-ui';
+import { formatToolkitsTable, formatToolkitsJson } from '../format';
+
+const query = Options.text('query').pipe(
+  Options.withDescription('Text search by name, slug, or description'),
+  Options.optional
+);
+
+const category = Options.text('category').pipe(
+  Options.withDescription('Filter by category ID'),
+  Options.optional
+);
+
+const limit = Options.integer('limit').pipe(
+  Options.withDefault(30),
+  Options.withDescription('Number of results per page (1-1000)')
+);
+
+/**
+ * List available toolkits with optional filters.
+ *
+ * @example
+ * ```bash
+ * composio toolkits list
+ * composio toolkits list --query "email"
+ * composio toolkits list --category "messaging" --limit 10
+ * ```
+ */
+export const toolkitsCmd$List = Command.make(
+  'list',
+  { query, category, limit },
+  ({ query, category, limit }) =>
+    Effect.gen(function* () {
+      const ui = yield* TerminalUI;
+      const ctx = yield* ComposioUserContext;
+      const repo = yield* ComposioToolkitsRepository;
+
+      // Auth guard
+      if (Option.isNone(ctx.data.apiKey)) {
+        yield* ui.log.warn('You are not logged in yet. Please run `composio login`.');
+        return;
+      }
+
+      const clampedLimit = Math.max(1, Math.min(1000, limit));
+
+      const result = yield* ui.withSpinner(
+        'Fetching toolkits...',
+        repo.searchToolkits({
+          search: Option.getOrUndefined(query),
+          category: Option.getOrUndefined(category),
+          limit: clampedLimit,
+        })
+      );
+
+      if (result.items.length === 0) {
+        yield* ui.log.warn('No toolkits found. Try broadening your search.');
+        return;
+      }
+
+      const showing = result.items.length;
+      const total = result.total_items;
+
+      yield* ui.log.info(`Listing ${showing} of ${total} toolkits`);
+      yield* ui.log.message('');
+      yield* ui.log.message(formatToolkitsTable(result.items));
+
+      // Next step hint
+      const firstSlug = result.items[0]?.slug;
+      if (firstSlug) {
+        yield* ui.log.message('');
+        yield* ui.log.step(
+          `To view details of a toolkit:\n> composio toolkits info "${firstSlug}"`
+        );
+      }
+
+      yield* ui.output(formatToolkitsJson(result.items));
+    })
+).pipe(Command.withDescription('List available toolkits.'));

--- a/ts/packages/cli/src/commands/toolkits/commands/toolkits.list.cmd.ts
+++ b/ts/packages/cli/src/commands/toolkits/commands/toolkits.list.cmd.ts
@@ -10,11 +10,6 @@ const query = Options.text('query').pipe(
   Options.optional
 );
 
-const category = Options.text('category').pipe(
-  Options.withDescription('Filter by category ID'),
-  Options.optional
-);
-
 const limit = Options.integer('limit').pipe(
   Options.withDefault(30),
   Options.withDescription('Number of results per page (1-1000)')
@@ -30,53 +25,47 @@ const limit = Options.integer('limit').pipe(
  * composio toolkits list --category "messaging" --limit 10
  * ```
  */
-export const toolkitsCmd$List = Command.make(
-  'list',
-  { query, category, limit },
-  ({ query, category, limit }) =>
-    Effect.gen(function* () {
-      const ui = yield* TerminalUI;
-      const ctx = yield* ComposioUserContext;
-      const repo = yield* ComposioToolkitsRepository;
+export const toolkitsCmd$List = Command.make('list', { query, limit }, ({ query, limit }) =>
+  Effect.gen(function* () {
+    const ui = yield* TerminalUI;
+    const ctx = yield* ComposioUserContext;
+    const repo = yield* ComposioToolkitsRepository;
 
-      // Auth guard
-      if (Option.isNone(ctx.data.apiKey)) {
-        yield* ui.log.warn('You are not logged in yet. Please run `composio login`.');
-        return;
-      }
+    // Auth guard
+    if (Option.isNone(ctx.data.apiKey)) {
+      yield* ui.log.warn('You are not logged in yet. Please run `composio login`.');
+      return;
+    }
 
-      const clampedLimit = Math.max(1, Math.min(1000, limit));
+    const clampedLimit = Math.max(1, Math.min(1000, limit));
 
-      const result = yield* ui.withSpinner(
-        'Fetching toolkits...',
-        repo.searchToolkits({
-          search: Option.getOrUndefined(query),
-          category: Option.getOrUndefined(category),
-          limit: clampedLimit,
-        })
-      );
+    const result = yield* ui.withSpinner(
+      'Fetching toolkits...',
+      repo.searchToolkits({
+        search: Option.getOrUndefined(query),
+        limit: clampedLimit,
+      })
+    );
 
-      if (result.items.length === 0) {
-        yield* ui.log.warn('No toolkits found. Try broadening your search.');
-        return;
-      }
+    if (result.items.length === 0) {
+      yield* ui.log.warn('No toolkits found. Try broadening your search.');
+      return;
+    }
 
-      const showing = result.items.length;
-      const total = result.total_items;
+    const showing = result.items.length;
+    const total = result.total_items;
 
-      yield* ui.log.info(`Listing ${showing} of ${total} toolkits`);
+    yield* ui.log.info(`Listing ${showing} of ${total} toolkits`);
+    yield* ui.log.message('');
+    yield* ui.log.message(formatToolkitsTable(result.items));
+
+    // Next step hint
+    const firstSlug = result.items[0]?.slug;
+    if (firstSlug) {
       yield* ui.log.message('');
-      yield* ui.log.message(formatToolkitsTable(result.items));
+      yield* ui.log.step(`To view details of a toolkit:\n> composio toolkits info "${firstSlug}"`);
+    }
 
-      // Next step hint
-      const firstSlug = result.items[0]?.slug;
-      if (firstSlug) {
-        yield* ui.log.message('');
-        yield* ui.log.step(
-          `To view details of a toolkit:\n> composio toolkits info "${firstSlug}"`
-        );
-      }
-
-      yield* ui.output(formatToolkitsJson(result.items));
-    })
+    yield* ui.output(formatToolkitsJson(result.items));
+  })
 ).pipe(Command.withDescription('List available toolkits.'));

--- a/ts/packages/cli/src/commands/toolkits/commands/toolkits.list.cmd.ts
+++ b/ts/packages/cli/src/commands/toolkits/commands/toolkits.list.cmd.ts
@@ -55,14 +55,13 @@ export const toolkitsCmd$List = Command.make('list', { query, limit }, ({ query,
     const showing = result.items.length;
     const total = result.total_items;
 
-    yield* ui.log.info(`Listing ${showing} of ${total} toolkits`);
-    yield* ui.log.message('');
-    yield* ui.log.message(formatToolkitsTable(result.items));
+    yield* ui.log.info(
+      `Listing ${showing} of ${total} toolkits\n\n${formatToolkitsTable(result.items)}`
+    );
 
     // Next step hint
     const firstSlug = result.items[0]?.slug;
     if (firstSlug) {
-      yield* ui.log.message('');
       yield* ui.log.step(`To view details of a toolkit:\n> composio toolkits info "${firstSlug}"`);
     }
 

--- a/ts/packages/cli/src/commands/toolkits/commands/toolkits.search.cmd.ts
+++ b/ts/packages/cli/src/commands/toolkits/commands/toolkits.search.cmd.ts
@@ -1,0 +1,63 @@
+import { Args, Command, Options } from '@effect/cli';
+import { Effect, Option } from 'effect';
+import { ComposioToolkitsRepository } from 'src/services/composio-clients';
+import { ComposioUserContext } from 'src/services/user-context';
+import { TerminalUI } from 'src/services/terminal-ui';
+import { formatToolkitsTable, formatToolkitsJson } from '../format';
+
+const query = Args.text({ name: 'query' }).pipe(
+  Args.withDescription('Search query (e.g. "send emails")')
+);
+
+const limit = Options.integer('limit').pipe(
+  Options.withDefault(10),
+  Options.withDescription('Number of results per page (1-1000)')
+);
+
+/**
+ * Search toolkits by use case.
+ *
+ * @example
+ * ```bash
+ * composio toolkits search "send emails"
+ * composio toolkits search "messaging" --limit 5
+ * ```
+ */
+export const toolkitsCmd$Search = Command.make('search', { query, limit }, ({ query, limit }) =>
+  Effect.gen(function* () {
+    const ui = yield* TerminalUI;
+    const ctx = yield* ComposioUserContext;
+    const repo = yield* ComposioToolkitsRepository;
+
+    // Auth guard
+    if (Option.isNone(ctx.data.apiKey)) {
+      yield* ui.log.warn('You are not logged in yet. Please run `composio login`.');
+      return;
+    }
+
+    const clampedLimit = Math.max(1, Math.min(1000, limit));
+
+    const result = yield* ui.withSpinner(
+      `Searching toolkits for "${query}"...`,
+      repo.searchToolkits({ search: query, limit: clampedLimit })
+    );
+
+    if (result.items.length === 0) {
+      yield* ui.log.warn(`No toolkits found matching "${query}". Try broadening your search.`);
+      return;
+    }
+
+    yield* ui.log.info(`Found ${result.items.length} toolkits`);
+    yield* ui.log.message('');
+    yield* ui.log.message(formatToolkitsTable(result.items));
+
+    // Next step hint
+    const firstSlug = result.items[0]?.slug;
+    if (firstSlug) {
+      yield* ui.log.message('');
+      yield* ui.log.step(`To view details:\n> composio toolkits info "${firstSlug}"`);
+    }
+
+    yield* ui.output(formatToolkitsJson(result.items));
+  })
+).pipe(Command.withDescription('Search toolkits by use case.'));

--- a/ts/packages/cli/src/commands/toolkits/commands/toolkits.search.cmd.ts
+++ b/ts/packages/cli/src/commands/toolkits/commands/toolkits.search.cmd.ts
@@ -47,8 +47,11 @@ export const toolkitsCmd$Search = Command.make('search', { query, limit }, ({ qu
       return;
     }
 
+    const showing = result.items.length;
+    const total = result.total_items;
+
     yield* ui.log.info(
-      `Found ${result.items.length} toolkits\n\n${formatToolkitsTable(result.items)}`
+      `Found ${showing} of ${total} toolkits\n\n${formatToolkitsTable(result.items)}`
     );
 
     // Next step hint

--- a/ts/packages/cli/src/commands/toolkits/commands/toolkits.search.cmd.ts
+++ b/ts/packages/cli/src/commands/toolkits/commands/toolkits.search.cmd.ts
@@ -47,14 +47,13 @@ export const toolkitsCmd$Search = Command.make('search', { query, limit }, ({ qu
       return;
     }
 
-    yield* ui.log.info(`Found ${result.items.length} toolkits`);
-    yield* ui.log.message('');
-    yield* ui.log.message(formatToolkitsTable(result.items));
+    yield* ui.log.info(
+      `Found ${result.items.length} toolkits\n\n${formatToolkitsTable(result.items)}`
+    );
 
     // Next step hint
     const firstSlug = result.items[0]?.slug;
     if (firstSlug) {
-      yield* ui.log.message('');
       yield* ui.log.step(`To view details:\n> composio toolkits info "${firstSlug}"`);
     }
 

--- a/ts/packages/cli/src/commands/toolkits/format.ts
+++ b/ts/packages/cli/src/commands/toolkits/format.ts
@@ -1,0 +1,45 @@
+import type { Toolkit } from 'src/models/toolkits';
+import { bold, gray } from 'src/ui/colors';
+
+/**
+ * Truncate a string to the given max length, appending "..." if truncated.
+ */
+function truncate(str: string, max: number): string {
+  if (str.length <= max) return str;
+  return str.slice(0, max - 3) + '...';
+}
+
+/**
+ * Format a list of toolkits as a human-readable table.
+ */
+export function formatToolkitsTable(toolkits: ReadonlyArray<Toolkit>): string {
+  const header = `${bold('Name'.padEnd(20))} ${bold('Slug'.padEnd(20))} ${bold('Tools'.padEnd(7))} ${bold('Triggers'.padEnd(10))} ${bold('Description')}`;
+
+  const rows = toolkits.map(t => {
+    const name = t.name.padEnd(20);
+    const slug = t.slug.padEnd(20);
+    const tools = String(t.meta.tools_count).padEnd(7);
+    const triggers = String(t.meta.triggers_count).padEnd(10);
+    const desc = gray(truncate(t.meta.description, 50));
+    return `${name} ${slug} ${tools} ${triggers} ${desc}`;
+  });
+
+  return [header, ...rows].join('\n');
+}
+
+/**
+ * Format toolkits as JSON for piped output.
+ */
+export function formatToolkitsJson(toolkits: ReadonlyArray<Toolkit>): string {
+  return JSON.stringify(
+    toolkits.map(t => ({
+      name: t.name,
+      slug: t.slug,
+      tools_count: t.meta.tools_count,
+      triggers_count: t.meta.triggers_count,
+      description: t.meta.description,
+    })),
+    null,
+    2
+  );
+}

--- a/ts/packages/cli/src/commands/toolkits/toolkits.cmd.ts
+++ b/ts/packages/cli/src/commands/toolkits/toolkits.cmd.ts
@@ -1,0 +1,17 @@
+import { Command } from '@effect/cli';
+import { toolkitsCmd$List } from './commands/toolkits.list.cmd';
+import { toolkitsCmd$Info } from './commands/toolkits.info.cmd';
+import { toolkitsCmd$Search } from './commands/toolkits.search.cmd';
+
+/**
+ * CLI entry point for toolkit discovery commands.
+ *
+ * @example
+ * ```bash
+ * composio toolkits <command>
+ * ```
+ */
+export const toolkitsCmd = Command.make('toolkits').pipe(
+  Command.withDescription('Discover and inspect Composio toolkits.'),
+  Command.withSubcommands([toolkitsCmd$List, toolkitsCmd$Info, toolkitsCmd$Search])
+);

--- a/ts/packages/cli/src/models/toolkits.ts
+++ b/ts/packages/cli/src/models/toolkits.ts
@@ -13,6 +13,8 @@ export const Toolkit = Schema.Struct({
     created_at: Schema.DateTimeUtc, // "2024-05-03T11:44:32.061Z"
     updated_at: Schema.DateTimeUtc, // "2024-05-03T11:44:32.061Z"
     available_versions: Schema.optionalWith(Schema.Array(Schema.String), { default: () => [] }),
+    tools_count: Schema.optionalWith(Schema.Int, { default: () => 0 }),
+    triggers_count: Schema.optionalWith(Schema.Int, { default: () => 0 }),
   }),
   no_auth: Schema.Boolean,
 }).annotations({ identifier: 'Toolkit' });
@@ -27,3 +29,79 @@ export const toolkitsToJSON = Schema.encode(ToolkitsJSON);
 
 export type ToolkitName = string & Brand.Brand<'ToolkitName'>;
 export const ToolkitName = Brand.nominal<ToolkitName>();
+
+/**
+ * Field definition for auth config creation / connected account initiation.
+ */
+export const AuthConfigField = Schema.Struct({
+  name: Schema.String,
+  displayName: Schema.String,
+  description: Schema.String,
+  type: Schema.String,
+  required: Schema.Boolean,
+  default: Schema.optionalWith(Schema.NullOr(Schema.String), { default: () => null }),
+}).annotations({ identifier: 'AuthConfigField' });
+export type AuthConfigField = Schema.Schema.Type<typeof AuthConfigField>;
+
+/**
+ * Auth config detail for a specific auth scheme (e.g. OAUTH2, API_KEY).
+ */
+export const AuthConfigDetail = Schema.Struct({
+  mode: Schema.String,
+  name: Schema.String,
+  fields: Schema.Struct({
+    auth_config_creation: Schema.Struct({
+      required: Schema.Array(AuthConfigField),
+      optional: Schema.Array(AuthConfigField),
+    }),
+    connected_account_initiation: Schema.Struct({
+      required: Schema.Array(AuthConfigField),
+      optional: Schema.Array(AuthConfigField),
+    }),
+  }),
+}).annotations({ identifier: 'AuthConfigDetail' });
+export type AuthConfigDetail = Schema.Schema.Type<typeof AuthConfigDetail>;
+
+/**
+ * Detailed toolkit info from the retrieve endpoint, includes auth_config_details.
+ */
+export const ToolkitDetailed = Schema.Struct({
+  name: Schema.String,
+  slug: Schema.Trim.pipe(Schema.nonEmptyString()),
+  is_local_toolkit: Schema.Boolean,
+  composio_managed_auth_schemes: Schema.optionalWith(Schema.Array(Schema.String), {
+    default: () => [],
+  }),
+  no_auth: Schema.optionalWith(Schema.Boolean, { default: () => false }),
+  meta: Schema.Struct({
+    description: Schema.optionalWith(Schema.String, { default: () => '' }),
+    categories: Schema.optionalWith(Schema.Array(Schema.Unknown), { default: () => [] }),
+    created_at: Schema.DateTimeUtc,
+    updated_at: Schema.DateTimeUtc,
+    available_versions: Schema.optionalWith(Schema.Array(Schema.String), { default: () => [] }),
+    tools_count: Schema.optionalWith(Schema.Int, { default: () => 0 }),
+    triggers_count: Schema.optionalWith(Schema.Int, { default: () => 0 }),
+  }),
+  auth_config_details: Schema.optionalWith(Schema.Array(AuthConfigDetail), { default: () => [] }),
+}).annotations({ identifier: 'ToolkitDetailed' });
+export type ToolkitDetailed = Schema.Schema.Type<typeof ToolkitDetailed>;
+
+/**
+ * Toolkit category.
+ */
+export const ToolkitCategory = Schema.Struct({
+  id: Schema.String,
+  name: Schema.String,
+}).annotations({ identifier: 'ToolkitCategory' });
+export type ToolkitCategory = Schema.Schema.Type<typeof ToolkitCategory>;
+
+/**
+ * Search result for a single page of toolkits.
+ */
+export const ToolkitSearchResult = Schema.Struct({
+  items: Toolkits,
+  total_items: Schema.Int,
+  total_pages: Schema.Int,
+  next_cursor: Schema.NullOr(Schema.String),
+}).annotations({ identifier: 'ToolkitSearchResult' });
+export type ToolkitSearchResult = Schema.Schema.Type<typeof ToolkitSearchResult>;

--- a/ts/packages/cli/src/models/toolkits.ts
+++ b/ts/packages/cli/src/models/toolkits.ts
@@ -87,15 +87,6 @@ export const ToolkitDetailed = Schema.Struct({
 export type ToolkitDetailed = Schema.Schema.Type<typeof ToolkitDetailed>;
 
 /**
- * Toolkit category.
- */
-export const ToolkitCategory = Schema.Struct({
-  id: Schema.String,
-  name: Schema.String,
-}).annotations({ identifier: 'ToolkitCategory' });
-export type ToolkitCategory = Schema.Schema.Type<typeof ToolkitCategory>;
-
-/**
  * Search result for a single page of toolkits.
  */
 export const ToolkitSearchResult = Schema.Struct({

--- a/ts/packages/cli/src/services/composio-clients-cached.ts
+++ b/ts/packages/cli/src/services/composio-clients-cached.ts
@@ -238,6 +238,13 @@ export const ComposioToolkitsRepositoryCached = Layer.effect(
       // 3. Caching validation results could cause false positives/negatives
       validateToolkitVersions: (overrides, relevantToolkits) =>
         underlyingRepository.validateToolkitVersions(overrides, relevantToolkits),
+      // These methods should NOT be cached:
+      // - searchToolkits: results depend on query params, caching would be misleading
+      // - getToolkitDetailed: detailed info should be fresh (auth config fields change)
+      // - getCategories: categories change infrequently but are cheap to fetch
+      searchToolkits: params => underlyingRepository.searchToolkits(params),
+      getToolkitDetailed: slug => underlyingRepository.getToolkitDetailed(slug),
+      getCategories: () => underlyingRepository.getCategories(),
     });
   })
 ).pipe(

--- a/ts/packages/cli/src/services/composio-clients-cached.ts
+++ b/ts/packages/cli/src/services/composio-clients-cached.ts
@@ -241,10 +241,8 @@ export const ComposioToolkitsRepositoryCached = Layer.effect(
       // These methods should NOT be cached:
       // - searchToolkits: results depend on query params, caching would be misleading
       // - getToolkitDetailed: detailed info should be fresh (auth config fields change)
-      // - getCategories: categories change infrequently but are cheap to fetch
       searchToolkits: params => underlyingRepository.searchToolkits(params),
       getToolkitDetailed: slug => underlyingRepository.getToolkitDetailed(slug),
-      getCategories: () => underlyingRepository.getCategories(),
     });
   })
 ).pipe(

--- a/ts/packages/cli/src/services/composio-clients.ts
+++ b/ts/packages/cli/src/services/composio-clients.ts
@@ -246,6 +246,8 @@ export const ToolkitRetrieveResponse = Schema.Struct({
     created_at: Schema.DateTimeUtc,
     updated_at: Schema.DateTimeUtc,
     available_versions: Schema.optionalWith(Schema.Array(Schema.String), { default: () => [] }),
+    tools_count: Schema.optionalWith(Schema.Int, { default: () => 0 }),
+    triggers_count: Schema.optionalWith(Schema.Int, { default: () => 0 }),
   }),
 }).annotations({ identifier: 'ToolkitRetrieveResponse' });
 export type ToolkitRetrieveResponse = Schema.Schema.Type<typeof ToolkitRetrieveResponse>;
@@ -682,11 +684,7 @@ export class ComposioClientLive extends Effect.Service<ComposioClientLive>()(
                     composio_managed_auth_schemes: retrieved.composio_managed_auth_schemes,
                     is_local_toolkit: retrieved.is_local_toolkit,
                     no_auth: retrieved.no_auth,
-                    meta: {
-                      ...retrieved.meta,
-                      tools_count: 0,
-                      triggers_count: 0,
-                    },
+                    meta: retrieved.meta,
                   }) satisfies Toolkit
               )
             ),

--- a/ts/packages/cli/src/services/composio-clients.ts
+++ b/ts/packages/cli/src/services/composio-clients.ts
@@ -13,13 +13,7 @@ import {
   SynchronizedRef,
 } from 'effect';
 import { Composio as _RawComposioClient, APIPromise } from '@composio/client';
-import {
-  Toolkit,
-  Toolkits,
-  ToolkitDetailed,
-  ToolkitCategory,
-  type ToolkitSearchResult,
-} from 'src/models/toolkits';
+import { Toolkit, Toolkits, ToolkitDetailed, type ToolkitSearchResult } from 'src/models/toolkits';
 import { ToolsAsEnums, Tools, Tool } from 'src/models/tools';
 import {
   groupByVersion,
@@ -284,13 +278,6 @@ export const ToolkitSearchResponse = Schema.Struct({
 export const ToolkitDetailedResponse = ToolkitDetailed.annotations({
   identifier: 'ToolkitDetailedResponse',
 });
-
-// Categories response
-export const ToolkitCategoriesResponse = Schema.Struct({
-  items: Schema.Array(ToolkitCategory),
-  total_items: Schema.Int,
-  next_cursor: Schema.NullOr(Schema.String),
-}).annotations({ identifier: 'ToolkitCategoriesResponse' });
 
 /**
  * Error response schemas
@@ -733,17 +720,6 @@ export class ComposioClientLive extends Effect.Service<ComposioClientLive>()(
                 ToolkitDetailedResponse
               )
             ),
-          /**
-           * Retrieves all available toolkit categories.
-           */
-          retrieveCategories: () =>
-            withMetrics(
-              callClient(
-                clientSingleton,
-                client => client.toolkits.retrieveCategories(),
-                ToolkitCategoriesResponse
-              )
-            ).pipe(Effect.map(response => response.items)),
         },
         tools: {
           /**
@@ -1066,10 +1042,6 @@ export class ComposioToolkitsRepository extends Effect.Service<ComposioToolkitsR
          * @param slug - Toolkit slug
          */
         getToolkitDetailed: (slug: string) => client.toolkits.retrieveDetailed(slug),
-        /**
-         * Retrieves all available toolkit categories.
-         */
-        getCategories: () => client.toolkits.retrieveCategories(),
       };
     }),
     dependencies: [ComposioClientLive.Default],

--- a/ts/packages/cli/src/services/composio-clients.ts
+++ b/ts/packages/cli/src/services/composio-clients.ts
@@ -37,11 +37,21 @@ import { renderPrettyError } from './utils/pretty-error';
  */
 
 /**
+ * Structured error details from the Composio API.
+ */
+export interface HttpErrorDetails {
+  readonly message: string;
+  readonly suggestedFix: string;
+  readonly code: number;
+}
+
+/**
  * Error thrown when a HTTP request fails.
  */
 export class HttpServerError extends Data.TaggedError('services/HttpServerError')<{
   readonly cause?: unknown;
   readonly status?: number;
+  readonly details?: HttpErrorDetails;
 }> {}
 
 /**
@@ -347,6 +357,11 @@ const handleHttpErrorResponse = (response: Response): Effect.Effect<never, HttpS
           new HttpServerError({
             cause: `HTTP ${status}\n${pretty}`,
             status,
+            details: {
+              message: error.message,
+              suggestedFix: error.suggested_fix,
+              code: error.code,
+            },
           })
         );
       }

--- a/ts/packages/cli/src/services/composio-clients.ts
+++ b/ts/packages/cli/src/services/composio-clients.ts
@@ -13,7 +13,13 @@ import {
   SynchronizedRef,
 } from 'effect';
 import { Composio as _RawComposioClient, APIPromise } from '@composio/client';
-import { Toolkit, Toolkits } from 'src/models/toolkits';
+import {
+  Toolkit,
+  Toolkits,
+  ToolkitDetailed,
+  ToolkitCategory,
+  type ToolkitSearchResult,
+} from 'src/models/toolkits';
 import { ToolsAsEnums, Tools, Tool } from 'src/models/tools';
 import {
   groupByVersion,
@@ -252,6 +258,27 @@ export const TriggerTypesResponse = Schema.Struct({
   total_pages: Schema.Int,
   next_cursor: Schema.NullOr(Schema.String),
 }).annotations({ identifier: 'TriggerTypesResponse' });
+
+// Single-page search response (includes total_items for "Listing X of Y" display)
+export const ToolkitSearchResponse = Schema.Struct({
+  items: Toolkits,
+  total_items: Schema.Int,
+  total_pages: Schema.Int,
+  current_page: Schema.Int,
+  next_cursor: Schema.NullOr(Schema.String),
+}).annotations({ identifier: 'ToolkitSearchResponse' });
+
+// Detailed retrieve response (includes auth_config_details)
+export const ToolkitDetailedResponse = ToolkitDetailed.annotations({
+  identifier: 'ToolkitDetailedResponse',
+});
+
+// Categories response
+export const ToolkitCategoriesResponse = Schema.Struct({
+  items: Schema.Array(ToolkitCategory),
+  total_items: Schema.Int,
+  next_cursor: Schema.NullOr(Schema.String),
+}).annotations({ identifier: 'ToolkitCategoriesResponse' });
 
 /**
  * Error response schemas
@@ -640,10 +667,70 @@ export class ComposioClientLive extends Effect.Service<ComposioClientLive>()(
                     composio_managed_auth_schemes: retrieved.composio_managed_auth_schemes,
                     is_local_toolkit: retrieved.is_local_toolkit,
                     no_auth: retrieved.no_auth,
-                    meta: retrieved.meta,
+                    meta: {
+                      ...retrieved.meta,
+                      tools_count: 0,
+                      triggers_count: 0,
+                    },
                   }) satisfies Toolkit
               )
             ),
+          /**
+           * Searches toolkits with optional filters. Returns a single page of results (no auto-pagination).
+           * @param params - Search/filter parameters
+           */
+          search: (params: {
+            search?: string;
+            category?: string;
+            limit?: number;
+            cursor?: string;
+          }) =>
+            withMetrics(
+              callClient(
+                clientSingleton,
+                client =>
+                  client.toolkits.list({
+                    search: params.search,
+                    category: params.category,
+                    limit: params.limit,
+                    cursor: params.cursor,
+                  }),
+                ToolkitSearchResponse
+              )
+            ).pipe(
+              Effect.map(
+                response =>
+                  ({
+                    items: response.items,
+                    total_items: response.total_items,
+                    total_pages: response.total_pages,
+                    next_cursor: response.next_cursor,
+                  }) satisfies ToolkitSearchResult
+              )
+            ),
+          /**
+           * Retrieves detailed toolkit info including auth_config_details.
+           * @param slug - Toolkit slug
+           */
+          retrieveDetailed: (slug: string) =>
+            withMetrics(
+              callClient(
+                clientSingleton,
+                client => client.toolkits.retrieve(slug),
+                ToolkitDetailedResponse
+              )
+            ),
+          /**
+           * Retrieves all available toolkit categories.
+           */
+          retrieveCategories: () =>
+            withMetrics(
+              callClient(
+                clientSingleton,
+                client => client.toolkits.retrieveCategories(),
+                ToolkitCategoriesResponse
+              )
+            ).pipe(Effect.map(response => response.items)),
         },
         tools: {
           /**
@@ -951,6 +1038,25 @@ export class ComposioToolkitsRepository extends Effect.Service<ComposioToolkitsR
           },
           InvalidToolkitVersionsError | InvalidToolkitsError | HttpError | NoSuchElementException
         > => validateToolkitVersionsImpl(client, overrides, relevantToolkits),
+        /**
+         * Searches toolkits with optional filters. Returns a single page of results.
+         * @param params - Search/filter parameters
+         */
+        searchToolkits: (params: {
+          search?: string;
+          category?: string;
+          limit?: number;
+          cursor?: string;
+        }) => client.toolkits.search(params),
+        /**
+         * Retrieves detailed toolkit info including auth_config_details.
+         * @param slug - Toolkit slug
+         */
+        getToolkitDetailed: (slug: string) => client.toolkits.retrieveDetailed(slug),
+        /**
+         * Retrieves all available toolkit categories.
+         */
+        getCategories: () => client.toolkits.retrieveCategories(),
       };
     }),
     dependencies: [ComposioClientLive.Default],

--- a/ts/packages/cli/src/services/terminal-ui.ts
+++ b/ts/packages/cli/src/services/terminal-ui.ts
@@ -157,7 +157,9 @@ const makeLive: TerminalUI = {
   },
 
   note: (message, title) =>
-    Effect.sync(() => decorate(() => p.note(message, title ?? '', { output: process.stderr }))),
+    Effect.sync(() =>
+      decorate(() => p.note(message, title ?? '', { format: line => line, output: process.stderr }))
+    ),
 
   withSpinner: (message, effect, options) =>
     isInteractive

--- a/ts/packages/cli/test/__utils__/services/test-layer.ts
+++ b/ts/packages/cli/test/__utils__/services/test-layer.ts
@@ -90,10 +90,11 @@ export const TestLayer = (input?: TestLiveInput) =>
       triggerTypesAsEnums: [] as TriggerTypesAsEnums,
       triggerTypes: [] as TriggerTypes,
     } satisfies TestLiveInput['toolkitsData'];
-    const { fixture, toolkitsData } = Object.assign(
-      { fixture: undefined, toolkitsData: defaultAppClientData },
-      input
-    );
+    const fixture = input?.fixture;
+    const toolkitsData = {
+      ...defaultAppClientData,
+      ...(input?.toolkitsData ?? {}),
+    };
 
     const tempDir = tempy.temporaryDirectory({ prefix: 'test' });
     const cwd = (yield* setupFixtureFolder({ fixture, tempDir })) ?? tempDir;

--- a/ts/packages/cli/test/__utils__/services/test-layer.ts
+++ b/ts/packages/cli/test/__utils__/services/test-layer.ts
@@ -18,11 +18,12 @@ import { ComposioCliConfig } from 'src/cli-config';
 import * as MockConsole from './mock-console';
 import * as MockTerminal from './mock-terminal';
 import { TerminalUITest } from './terminal-ui-test';
-import type { Toolkits } from 'src/models/toolkits';
+import type { Toolkits, ToolkitDetailed, ToolkitCategory } from 'src/models/toolkits';
 import { NodeProcess } from 'src/services/node-process';
 import {
   ComposioSessionRepository,
   ComposioToolkitsRepository,
+  HttpServerError,
   InvalidToolkitsError,
   InvalidToolkitVersionsError,
   type InvalidVersionDetail,
@@ -55,6 +56,8 @@ export interface TestLiveInput {
    */
   toolkitsData?: {
     toolkits?: Toolkits;
+    detailedToolkits?: ToolkitDetailed[];
+    categories?: ToolkitCategory[];
     tools?: Tools;
     triggerTypesAsEnums?: TriggerTypesAsEnums;
     triggerTypes?: TriggerTypes;
@@ -81,6 +84,8 @@ export const TestLayer = (input?: TestLiveInput) =>
   Effect.gen(function* () {
     const defaultAppClientData = {
       toolkits: [] as Toolkits,
+      detailedToolkits: [] as ToolkitDetailed[],
+      categories: [] as ToolkitCategory[],
       tools: [] as Tools,
       triggerTypesAsEnums: [] as TriggerTypesAsEnums,
       triggerTypes: [] as TriggerTypes,
@@ -213,6 +218,45 @@ export const TestLayer = (input?: TestLiveInput) =>
             warnings: warnings as ReadonlyArray<string>,
           });
         },
+        searchToolkits: (params: {
+          search?: string;
+          category?: string;
+          limit?: number;
+          cursor?: string;
+        }) => {
+          let results = [...toolkitsData.toolkits];
+
+          if (params.search) {
+            const q = params.search.toLowerCase();
+            results = results.filter(
+              t =>
+                t.name.toLowerCase().includes(q) ||
+                t.slug.toLowerCase().includes(q) ||
+                t.meta.description.toLowerCase().includes(q)
+            );
+          }
+
+          const limit = params.limit ?? 30;
+          const items = results.slice(0, limit);
+          return Effect.succeed({
+            items,
+            total_items: results.length,
+            total_pages: Math.ceil(results.length / limit),
+            next_cursor: null,
+          });
+        },
+        getToolkitDetailed: (slug: string) => {
+          const found = toolkitsData.detailedToolkits.find(
+            t => t.slug.toLowerCase() === slug.toLowerCase()
+          );
+          if (!found) {
+            return Effect.fail(
+              new HttpServerError({ cause: `Toolkit "${slug}" not found`, status: 404 })
+            );
+          }
+          return Effect.succeed(found);
+        },
+        getCategories: () => Effect.succeed(toolkitsData.categories),
       })
     );
     const ComposioSessionRepositoryTest = yield* setupComposioSessionRepository();

--- a/ts/packages/cli/test/__utils__/services/test-layer.ts
+++ b/ts/packages/cli/test/__utils__/services/test-layer.ts
@@ -18,7 +18,7 @@ import { ComposioCliConfig } from 'src/cli-config';
 import * as MockConsole from './mock-console';
 import * as MockTerminal from './mock-terminal';
 import { TerminalUITest } from './terminal-ui-test';
-import type { Toolkits, ToolkitDetailed, ToolkitCategory } from 'src/models/toolkits';
+import type { Toolkits, ToolkitDetailed } from 'src/models/toolkits';
 import { NodeProcess } from 'src/services/node-process';
 import {
   ComposioSessionRepository,
@@ -57,7 +57,6 @@ export interface TestLiveInput {
   toolkitsData?: {
     toolkits?: Toolkits;
     detailedToolkits?: ToolkitDetailed[];
-    categories?: ToolkitCategory[];
     tools?: Tools;
     triggerTypesAsEnums?: TriggerTypesAsEnums;
     triggerTypes?: TriggerTypes;
@@ -85,7 +84,6 @@ export const TestLayer = (input?: TestLiveInput) =>
     const defaultAppClientData = {
       toolkits: [] as Toolkits,
       detailedToolkits: [] as ToolkitDetailed[],
-      categories: [] as ToolkitCategory[],
       tools: [] as Tools,
       triggerTypesAsEnums: [] as TriggerTypesAsEnums,
       triggerTypes: [] as TriggerTypes,
@@ -94,6 +92,8 @@ export const TestLayer = (input?: TestLiveInput) =>
     const toolkitsData = {
       ...defaultAppClientData,
       ...(input?.toolkitsData ?? {}),
+      detailedToolkits:
+        input?.toolkitsData?.detailedToolkits ?? defaultAppClientData.detailedToolkits,
     };
 
     const tempDir = tempy.temporaryDirectory({ prefix: 'test' });
@@ -257,7 +257,6 @@ export const TestLayer = (input?: TestLiveInput) =>
           }
           return Effect.succeed(found);
         },
-        getCategories: () => Effect.succeed(toolkitsData.categories),
       })
     );
     const ComposioSessionRepositoryTest = yield* setupComposioSessionRepository();

--- a/ts/packages/cli/test/src/commands/$default.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/$default.cmd.test.ts
@@ -15,7 +15,7 @@ describe('CLI: composio', () => {
         expect(result).toEqual(
           ValidationError.commandMismatch(
             HelpDoc.p(
-              "Invalid subcommand for composio - use one of 'version', 'upgrade', 'whoami', 'login', 'logout', 'generate', 'py', 'ts'"
+              "Invalid subcommand for composio - use one of 'version', 'upgrade', 'whoami', 'login', 'logout', 'generate', 'py', 'ts', 'toolkits'"
             )
           )
         );
@@ -83,6 +83,14 @@ describe('CLI: composio', () => {
           Environment Variables:
             COMPOSIO_TOOLKIT_VERSION_<TOOLKIT>  Override toolkit version (e.g., COMPOSIO_TOOLKIT_VERSION_GMAIL=20250901_00)
                                                 Use "latest" or unset to use the latest version.
+
+            - toolkits                                                                                                 Discover and inspect Composio toolkits.
+
+            - toolkits list [--query text] [--category text] [--limit integer]                                         List available toolkits.
+
+            - toolkits info <slug>                                                                                     View details of a specific toolkit.
+
+            - toolkits search [--limit integer] <query>                                                                Search toolkits by use case.
           "
         `);
       })

--- a/ts/packages/cli/test/src/commands/$default.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/$default.cmd.test.ts
@@ -86,7 +86,7 @@ describe('CLI: composio', () => {
 
             - toolkits                                                                                                 Discover and inspect Composio toolkits.
 
-            - toolkits list [--query text] [--category text] [--limit integer]                                         List available toolkits.
+            - toolkits list [--query text] [--limit integer]                                                           List available toolkits.
 
             - toolkits info [<slug>]                                                                                   View details of a specific toolkit.
 

--- a/ts/packages/cli/test/src/commands/$default.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/$default.cmd.test.ts
@@ -88,7 +88,7 @@ describe('CLI: composio', () => {
 
             - toolkits list [--query text] [--category text] [--limit integer]                                         List available toolkits.
 
-            - toolkits info <slug>                                                                                     View details of a specific toolkit.
+            - toolkits info [<slug>]                                                                                   View details of a specific toolkit.
 
             - toolkits search [--limit integer] <query>                                                                Search toolkits by use case.
           "

--- a/ts/packages/cli/test/src/commands/toolkits/toolkits.info.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/toolkits/toolkits.info.cmd.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, layer } from '@effect/vitest';
+import { ConfigProvider, Effect } from 'effect';
+import { extendConfigProvider } from 'src/services/config';
+import { cli, TestLive, MockConsole } from 'test/__utils__';
+import type { TestLiveInput } from 'test/__utils__/services/test-layer';
+import type { Toolkits, ToolkitDetailed } from 'src/models/toolkits';
+
+const testToolkits: Toolkits = [
+  {
+    name: 'Gmail',
+    slug: 'gmail',
+    auth_schemes: ['OAUTH2', 'BEARER_TOKEN'],
+    composio_managed_auth_schemes: ['OAUTH2'],
+    is_local_toolkit: false,
+    no_auth: false,
+    meta: {
+      description: 'Email service to send and receive emails',
+      categories: [],
+      created_at: new Date('2024-05-03T11:44:32.061Z') as any,
+      updated_at: new Date('2024-05-03T11:44:32.061Z') as any,
+      available_versions: [],
+      tools_count: 36,
+      triggers_count: 2,
+    },
+  },
+];
+
+const detailedToolkits: ToolkitDetailed[] = [
+  {
+    name: 'Gmail',
+    slug: 'gmail',
+    is_local_toolkit: false,
+    composio_managed_auth_schemes: ['OAUTH2'],
+    no_auth: false,
+    meta: {
+      description: 'Email service to send and receive emails',
+      categories: [],
+      created_at: new Date('2024-05-03T11:44:32.061Z') as any,
+      updated_at: new Date('2024-05-03T11:44:32.061Z') as any,
+      available_versions: [],
+      tools_count: 36,
+      triggers_count: 2,
+    },
+    auth_config_details: [
+      {
+        mode: 'OAUTH2',
+        name: 'OAuth 2.0',
+        fields: {
+          auth_config_creation: { required: [], optional: [] },
+          connected_account_initiation: { required: [], optional: [] },
+        },
+      },
+      {
+        mode: 'BEARER_TOKEN',
+        name: 'Bearer Token',
+        fields: {
+          auth_config_creation: {
+            required: [
+              {
+                name: 'apiKey',
+                displayName: 'API Key',
+                description: 'Your API key',
+                type: 'string',
+                required: true,
+                default: null,
+              },
+            ],
+            optional: [],
+          },
+          connected_account_initiation: {
+            required: [
+              {
+                name: 'apiKey',
+                displayName: 'API Key',
+                description: 'Your API key',
+                type: 'string',
+                required: true,
+                default: null,
+              },
+            ],
+            optional: [],
+          },
+        },
+      },
+    ],
+  },
+  {
+    name: 'Code Interpreter',
+    slug: 'codeinterpreter',
+    is_local_toolkit: false,
+    composio_managed_auth_schemes: [],
+    no_auth: true,
+    meta: {
+      description: 'Execute code snippets',
+      categories: [],
+      created_at: new Date('2024-05-03T11:44:32.061Z') as any,
+      updated_at: new Date('2024-05-03T11:44:32.061Z') as any,
+      available_versions: [],
+      tools_count: 5,
+      triggers_count: 0,
+    },
+    auth_config_details: [],
+  },
+];
+
+const toolkitsData = {
+  toolkits: testToolkits,
+  detailedToolkits,
+} satisfies TestLiveInput['toolkitsData'];
+
+const testConfigProvider = ConfigProvider.fromMap(
+  new Map([['COMPOSIO_API_KEY', 'test_api_key']])
+).pipe(extendConfigProvider);
+
+describe('CLI: composio toolkits info', () => {
+  layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
+    '[Given] valid slug "gmail"',
+    it => {
+      it.scoped('shows detailed info with auth schemes', () =>
+        Effect.gen(function* () {
+          yield* cli(['toolkits', 'info', 'gmail']);
+          const lines = yield* MockConsole.getLines({ stripAnsi: true });
+          const output = lines.join('\n');
+
+          expect(output).toContain('Gmail');
+          expect(output).toContain('gmail');
+          expect(output).toContain('Email service to send and receive emails');
+          expect(output).toContain('OAUTH2');
+          expect(output).toContain('BEARER_TOKEN');
+          expect(output).toContain('apiKey');
+          expect(output).toContain('AuthConfig creation');
+          expect(output).toContain('Connected Account creation');
+        })
+      );
+    }
+  );
+
+  layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
+    '[Given] toolkit with no_auth=true',
+    it => {
+      it.scoped('shows "No authentication required"', () =>
+        Effect.gen(function* () {
+          yield* cli(['toolkits', 'info', 'codeinterpreter']);
+          const lines = yield* MockConsole.getLines({ stripAnsi: true });
+          const output = lines.join('\n');
+
+          expect(output).toContain('Code Interpreter');
+          expect(output).toContain('No authentication required');
+        })
+      );
+    }
+  );
+
+  layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
+    '[Given] invalid slug',
+    it => {
+      it.scoped('shows error', () =>
+        Effect.gen(function* () {
+          const result = yield* cli(['toolkits', 'info', 'gmal']).pipe(Effect.either);
+          const lines = yield* MockConsole.getLines({ stripAnsi: true });
+          const output = lines.join('\n');
+
+          expect(output).toContain('not found');
+        })
+      );
+    }
+  );
+
+  layer(TestLive())('[Given] no API key', it => {
+    it.scoped('warns user to login', () =>
+      Effect.gen(function* () {
+        yield* cli(['toolkits', 'info', 'gmail']);
+        const lines = yield* MockConsole.getLines({ stripAnsi: true });
+        const output = lines.join('\n');
+
+        expect(output).toContain('not logged in');
+      })
+    );
+  });
+});

--- a/ts/packages/cli/test/src/commands/toolkits/toolkits.info.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/toolkits/toolkits.info.cmd.test.ts
@@ -160,7 +160,41 @@ describe('CLI: composio toolkits info', () => {
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
-          expect(output).toContain('not found');
+          expect(output).toContain('Failed to fetch toolkit "gmal"');
+        })
+      );
+    }
+  );
+
+  layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
+    '[Given] invalid slug with substring match',
+    it => {
+      it.scoped('shows error with suggestion', () =>
+        Effect.gen(function* () {
+          // "gma" is a substring of "gmail", so the mock will find suggestions
+          const result = yield* cli(['toolkits', 'info', 'gma']).pipe(Effect.either);
+          const lines = yield* MockConsole.getLines({ stripAnsi: true });
+          const output = lines.join('\n');
+
+          expect(output).toContain('Failed to fetch toolkit "gma"');
+          expect(output).toContain('Did you mean?');
+          expect(output).toContain('gmail');
+        })
+      );
+    }
+  );
+
+  layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
+    '[Given] no slug argument',
+    it => {
+      it.scoped('shows missing argument warning with tip', () =>
+        Effect.gen(function* () {
+          yield* cli(['toolkits', 'info']);
+          const lines = yield* MockConsole.getLines({ stripAnsi: true });
+          const output = lines.join('\n');
+
+          expect(output).toContain('Missing required argument');
+          expect(output).toContain('composio toolkits info "gmail"');
         })
       );
     }

--- a/ts/packages/cli/test/src/commands/toolkits/toolkits.list.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/toolkits/toolkits.list.cmd.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, layer } from '@effect/vitest';
+import { ConfigProvider, Effect } from 'effect';
+import { extendConfigProvider } from 'src/services/config';
+import { cli, TestLive, MockConsole } from 'test/__utils__';
+import type { TestLiveInput } from 'test/__utils__/services/test-layer';
+import type { Toolkits } from 'src/models/toolkits';
+
+const testToolkits: Toolkits = [
+  {
+    name: 'Gmail',
+    slug: 'gmail',
+    auth_schemes: ['OAUTH2'],
+    composio_managed_auth_schemes: ['OAUTH2'],
+    is_local_toolkit: false,
+    no_auth: false,
+    meta: {
+      description: 'Email service to send and receive emails',
+      categories: [],
+      created_at: new Date('2024-05-03T11:44:32.061Z') as any,
+      updated_at: new Date('2024-05-03T11:44:32.061Z') as any,
+      available_versions: [],
+      tools_count: 36,
+      triggers_count: 2,
+    },
+  },
+  {
+    name: 'Slack',
+    slug: 'slack',
+    auth_schemes: ['OAUTH2'],
+    composio_managed_auth_schemes: ['OAUTH2'],
+    is_local_toolkit: false,
+    no_auth: false,
+    meta: {
+      description: 'Messaging platform for teams',
+      categories: [],
+      created_at: new Date('2024-05-03T11:44:32.061Z') as any,
+      updated_at: new Date('2024-05-03T11:44:32.061Z') as any,
+      available_versions: [],
+      tools_count: 42,
+      triggers_count: 5,
+    },
+  },
+  {
+    name: 'GitHub',
+    slug: 'github',
+    auth_schemes: ['OAUTH2'],
+    composio_managed_auth_schemes: ['OAUTH2'],
+    is_local_toolkit: false,
+    no_auth: false,
+    meta: {
+      description: 'Code hosting and collaboration platform',
+      categories: [],
+      created_at: new Date('2024-05-03T11:44:32.061Z') as any,
+      updated_at: new Date('2024-05-03T11:44:32.061Z') as any,
+      available_versions: [],
+      tools_count: 50,
+      triggers_count: 10,
+    },
+  },
+];
+
+const toolkitsData = {
+  toolkits: testToolkits,
+} satisfies TestLiveInput['toolkitsData'];
+
+const testConfigProvider = ConfigProvider.fromMap(
+  new Map([['COMPOSIO_API_KEY', 'test_api_key']])
+).pipe(extendConfigProvider);
+
+describe('CLI: composio toolkits list', () => {
+  layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
+    '[Given] no flags [Then] lists all toolkits',
+    it => {
+      it.scoped('lists all toolkits', () =>
+        Effect.gen(function* () {
+          yield* cli(['toolkits', 'list']);
+          const lines = yield* MockConsole.getLines({ stripAnsi: true });
+          const output = lines.join('\n');
+
+          expect(output).toContain('Gmail');
+          expect(output).toContain('gmail');
+          expect(output).toContain('Slack');
+          expect(output).toContain('GitHub');
+          expect(output).toContain('Listing 3 of 3 toolkits');
+        })
+      );
+    }
+  );
+
+  layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
+    '[Given] --query "email"',
+    it => {
+      it.scoped('shows filtered results', () =>
+        Effect.gen(function* () {
+          yield* cli(['toolkits', 'list', '--query', 'email']);
+          const lines = yield* MockConsole.getLines({ stripAnsi: true });
+          const output = lines.join('\n');
+
+          expect(output).toContain('Gmail');
+          expect(output).not.toContain('GitHub');
+          expect(output).toContain('Listing 1 of 1 toolkits');
+        })
+      );
+    }
+  );
+
+  layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
+    '[Given] --limit 2',
+    it => {
+      it.scoped('respects limit', () =>
+        Effect.gen(function* () {
+          yield* cli(['toolkits', 'list', '--limit', '2']);
+          const lines = yield* MockConsole.getLines({ stripAnsi: true });
+          const output = lines.join('\n');
+
+          expect(output).toContain('Listing 2 of 3 toolkits');
+        })
+      );
+    }
+  );
+
+  layer(TestLive())('[Given] no API key', it => {
+    it.scoped('warns user to login', () =>
+      Effect.gen(function* () {
+        yield* cli(['toolkits', 'list']);
+        const lines = yield* MockConsole.getLines({ stripAnsi: true });
+        const output = lines.join('\n');
+
+        expect(output).toContain('not logged in');
+      })
+    );
+  });
+
+  layer(TestLive({ baseConfigProvider: testConfigProvider }))('[Given] empty results', it => {
+    it.scoped('shows no toolkits found', () =>
+      Effect.gen(function* () {
+        yield* cli(['toolkits', 'list']);
+        const lines = yield* MockConsole.getLines({ stripAnsi: true });
+        const output = lines.join('\n');
+
+        expect(output).toContain('No toolkits found');
+      })
+    );
+  });
+});

--- a/ts/packages/cli/test/src/commands/toolkits/toolkits.search.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/toolkits/toolkits.search.cmd.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, layer } from '@effect/vitest';
+import { ConfigProvider, Effect } from 'effect';
+import { extendConfigProvider } from 'src/services/config';
+import { cli, TestLive, MockConsole } from 'test/__utils__';
+import type { TestLiveInput } from 'test/__utils__/services/test-layer';
+import type { Toolkits } from 'src/models/toolkits';
+
+const testToolkits: Toolkits = [
+  {
+    name: 'Gmail',
+    slug: 'gmail',
+    auth_schemes: ['OAUTH2'],
+    composio_managed_auth_schemes: ['OAUTH2'],
+    is_local_toolkit: false,
+    no_auth: false,
+    meta: {
+      description: 'Email service to send and receive emails',
+      categories: [],
+      created_at: new Date('2024-05-03T11:44:32.061Z') as any,
+      updated_at: new Date('2024-05-03T11:44:32.061Z') as any,
+      available_versions: [],
+      tools_count: 36,
+      triggers_count: 2,
+    },
+  },
+  {
+    name: 'Outlook',
+    slug: 'outlook',
+    auth_schemes: ['OAUTH2'],
+    composio_managed_auth_schemes: ['OAUTH2'],
+    is_local_toolkit: false,
+    no_auth: false,
+    meta: {
+      description: 'Microsoft email service',
+      categories: [],
+      created_at: new Date('2024-05-03T11:44:32.061Z') as any,
+      updated_at: new Date('2024-05-03T11:44:32.061Z') as any,
+      available_versions: [],
+      tools_count: 28,
+      triggers_count: 1,
+    },
+  },
+  {
+    name: 'Slack',
+    slug: 'slack',
+    auth_schemes: ['OAUTH2'],
+    composio_managed_auth_schemes: ['OAUTH2'],
+    is_local_toolkit: false,
+    no_auth: false,
+    meta: {
+      description: 'Messaging platform for teams',
+      categories: [],
+      created_at: new Date('2024-05-03T11:44:32.061Z') as any,
+      updated_at: new Date('2024-05-03T11:44:32.061Z') as any,
+      available_versions: [],
+      tools_count: 42,
+      triggers_count: 5,
+    },
+  },
+];
+
+const toolkitsData = {
+  toolkits: testToolkits,
+} satisfies TestLiveInput['toolkitsData'];
+
+const testConfigProvider = ConfigProvider.fromMap(
+  new Map([['COMPOSIO_API_KEY', 'test_api_key']])
+).pipe(extendConfigProvider);
+
+describe('CLI: composio toolkits search', () => {
+  layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
+    '[Given] query "email"',
+    it => {
+      it.scoped('shows matching toolkits', () =>
+        Effect.gen(function* () {
+          yield* cli(['toolkits', 'search', 'email']);
+          const lines = yield* MockConsole.getLines({ stripAnsi: true });
+          const output = lines.join('\n');
+
+          expect(output).toContain('Gmail');
+          expect(output).toContain('Outlook');
+          expect(output).not.toContain('Slack');
+          expect(output).toContain('Found 2 toolkits');
+        })
+      );
+    }
+  );
+
+  layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
+    '[Given] query with no results',
+    it => {
+      it.scoped('shows "No toolkits found"', () =>
+        Effect.gen(function* () {
+          yield* cli(['toolkits', 'search', 'xyzzy']);
+          const lines = yield* MockConsole.getLines({ stripAnsi: true });
+          const output = lines.join('\n');
+
+          expect(output).toContain('No toolkits found');
+        })
+      );
+    }
+  );
+
+  layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
+    '[Given] --limit 1',
+    it => {
+      it.scoped('respects limit', () =>
+        Effect.gen(function* () {
+          yield* cli(['toolkits', 'search', 'email', '--limit', '1']);
+          const lines = yield* MockConsole.getLines({ stripAnsi: true });
+          const output = lines.join('\n');
+
+          expect(output).toContain('Found 1 toolkits');
+        })
+      );
+    }
+  );
+
+  layer(TestLive())('[Given] no API key', it => {
+    it.scoped('warns user to login', () =>
+      Effect.gen(function* () {
+        yield* cli(['toolkits', 'search', 'email']);
+        const lines = yield* MockConsole.getLines({ stripAnsi: true });
+        const output = lines.join('\n');
+
+        expect(output).toContain('not logged in');
+      })
+    );
+  });
+});

--- a/ts/packages/cli/test/src/commands/toolkits/toolkits.search.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/toolkits/toolkits.search.cmd.test.ts
@@ -80,7 +80,7 @@ describe('CLI: composio toolkits search', () => {
           expect(output).toContain('Gmail');
           expect(output).toContain('Outlook');
           expect(output).not.toContain('Slack');
-          expect(output).toContain('Found 2 toolkits');
+          expect(output).toContain('Found 2 of 2 toolkits');
         })
       );
     }
@@ -110,7 +110,7 @@ describe('CLI: composio toolkits search', () => {
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
-          expect(output).toContain('Found 1 toolkits');
+          expect(output).toContain('Found 1 of 2 toolkits');
         })
       );
     }


### PR DESCRIPTION
This PR:

- builds on top of https://github.com/ComposioHQ/composio/pull/2661
- closes [PLEN-1584](https://linear.app/composio/issue/PLEN-1584/clicommand-toolkits)
- adds `composio toolkits` command with `list`, `info`, and `search` subcommands for discovering and inspecting available toolkits
- adds `ComposioToolkitsRepository` and `ComposioToolkitsRepositoryCached` client services wrapping the `/v3/toolkits` API
- adds a `Toolkit` domain model with helpers like `authSchemeNames()` and `composioManagedAuthSchemeNames()`
- suppresses duplicate `@effect/cli` validation error output and adds a tip when a flag is passed without its required value
- stops re-throwing `HttpServerError` after the friendly message has already been displayed
- reduces excess newlines in toolkits `list` / `search` table output
- drops the dim background from `note()` and aligns auth field columns dynamically in `toolkits info`
- includes unit tests for all three subcommands (`list`, `info`, `search`) with mocked API responses

---