### PR TITLE
fix(ci): build binaries on release

### DIFF
--- a/.github/workflows/build-cli-binaries.yml
+++ b/.github/workflows/build-cli-binaries.yml
@@ -112,7 +112,7 @@ jobs:
     name: Test Installation
     needs: build-binaries
     if: always() && !cancelled() && (startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch')
-    uses: ./.github/workflows/test-installation.yml
+    uses: ./.github/workflows/cli.test-installation.yml
     with:
       version: ${{ inputs.version || github.ref_name }}
 


### PR DESCRIPTION
This PR:
- closes [PLEN-1546](https://linear.app/composio/issue/PLEN-1546/cli-failed-to-download-composio-cli-from-url)
- fixes integration between Github Releases and CLI build + release.

I've manually fixed the lack of `@composio/cli` binary assets in the [v0.11.1](https://github.com/ComposioHQ/composio/releases/tag/v0.11.1) release via a local run of:

```
gh release upload v0.11.1 \
    ts/packages/cli/dist/binaries/composio-linux-x64.zip \
    ts/packages/cli/dist/binaries/composio-linux-aarch64.zip \
    ts/packages/cli/dist/binaries/composio-darwin-x64.zip \
    ts/packages/cli/dist/binaries/composio-darwin-aarch64.zip \
    --clobber
```