### PR TITLE
fix: add dynamic toolkit pages to docs search

### DIFF
--- a/docs/app/api/search/route.ts
+++ b/docs/app/api/search/route.ts
@@ -1,5 +1,5 @@
 // Use direct imports from collections to avoid top-level await in lib/source.ts
-import { docs, cookbooks, toolkits } from 'fumadocs-mdx:collections/server';
+import { docs, reference, cookbooks, toolkits, changelog } from 'fumadocs-mdx:collections/server';
 import { createSearchAPI } from 'fumadocs-core/search/server';
 import { loader } from 'fumadocs-core/source';
 import { lucideIconsPlugin } from 'fumadocs-core/source/lucide-icons';
@@ -24,11 +24,20 @@ const toolkitsSource = loader({
   plugins: [lucideIconsPlugin()],
 });
 
+// Sync reference source (MDX pages only — SDK reference, errors, rate-limits, etc.)
+// OpenAPI-generated API reference pages require async loading and can't be indexed here
+const referenceSource = loader({
+  baseUrl: '/reference',
+  source: reference.toFumadocsSource(),
+  plugins: [lucideIconsPlugin()],
+});
+
 // MDX pages from Fumadocs sources
 const mdxIndexes = [
   ...docsSource.getPages(),
   ...cookbooksSource.getPages(),
   ...toolkitsSource.getPages(),
+  ...referenceSource.getPages(),
 ].map((page) => ({
   id: page.url,
   title: page.data.title ?? 'Untitled',
@@ -54,6 +63,16 @@ const dynamicToolkitIndexes = getAllToolkitsSync()
     keywords: [toolkit.slug, toolkit.category].filter(Boolean) as string[],
   }));
 
+// Changelog entries
+const changelogIndexes = changelog.map((entry) => ({
+  id: `/docs/changelog/${entry.date.replace(/-/g, '/')}`,
+  title: entry.title,
+  description: entry.description ?? '',
+  url: `/docs/changelog/${entry.date.replace(/-/g, '/')}`,
+  structuredData: { headings: [], contents: [] },
+  keywords: ['changelog'],
+}));
+
 export const { GET } = createSearchAPI('advanced', {
-  indexes: [...mdxIndexes, ...dynamicToolkitIndexes],
+  indexes: [...mdxIndexes, ...dynamicToolkitIndexes, ...changelogIndexes],
 });

--- a/docs/app/api/search/route.ts
+++ b/docs/app/api/search/route.ts
@@ -65,7 +65,7 @@ const dynamicToolkitIndexes = getAllToolkitsSync()
 
 // Changelog entries
 const changelogIndexes = changelog.map((entry) => ({
-  id: `/docs/changelog/${entry.date.replace(/-/g, '/')}`,
+  id: `/docs/changelog/${entry.date.replace(/-/g, '/')}#${entry.title}`,
   title: entry.title,
   description: entry.description ?? '',
   url: `/docs/changelog/${entry.date.replace(/-/g, '/')}`,

--- a/docs/app/api/search/route.ts
+++ b/docs/app/api/search/route.ts
@@ -3,6 +3,7 @@ import { docs, cookbooks, toolkits } from 'fumadocs-mdx:collections/server';
 import { createSearchAPI } from 'fumadocs-core/search/server';
 import { loader } from 'fumadocs-core/source';
 import { lucideIconsPlugin } from 'fumadocs-core/source/lucide-icons';
+import { getAllToolkitsSync } from '@/lib/toolkit-data';
 
 // Create loaders directly here to avoid the problematic lib/source.ts import
 const docsSource = loader({
@@ -23,19 +24,36 @@ const toolkitsSource = loader({
   plugins: [lucideIconsPlugin()],
 });
 
-const allPages = [
+// MDX pages from Fumadocs sources
+const mdxIndexes = [
   ...docsSource.getPages(),
   ...cookbooksSource.getPages(),
   ...toolkitsSource.getPages(),
-];
+].map((page) => ({
+  id: page.url,
+  title: page.data.title ?? 'Untitled',
+  description: page.data.description,
+  url: page.url,
+  structuredData: page.data.structuredData,
+  keywords: 'keywords' in page.data ? page.data.keywords : undefined,
+}));
+
+// Dynamic toolkit pages from toolkits.json
+const mdxToolkitSlugs = new Set(
+  toolkitsSource.getPages().map((page) => page.slugs.join('/')),
+);
+
+const dynamicToolkitIndexes = getAllToolkitsSync()
+  .filter((toolkit) => !mdxToolkitSlugs.has(toolkit.slug))
+  .map((toolkit) => ({
+    id: `/toolkits/${toolkit.slug}`,
+    title: toolkit.name,
+    description: toolkit.description,
+    url: `/toolkits/${toolkit.slug}`,
+    structuredData: { headings: [], contents: [] },
+    keywords: [toolkit.slug, toolkit.category].filter(Boolean) as string[],
+  }));
 
 export const { GET } = createSearchAPI('advanced', {
-  indexes: allPages.map((page) => ({
-    id: page.url,
-    title: page.data.title ?? 'Untitled',
-    description: page.data.description,
-    url: page.url,
-    structuredData: page.data.structuredData,
-    keywords: 'keywords' in page.data ? page.data.keywords : undefined,
-  })),
+  indexes: [...mdxIndexes, ...dynamicToolkitIndexes],
 });


### PR DESCRIPTION
## Summary
- Dynamic toolkit pages (e.g. `/toolkits/figma`, `/toolkits/github`) were not appearing in search results
- The search API only indexed Fumadocs MDX pages, but toolkit pages are generated from `toolkits.json` at runtime
- Added toolkit entries from `getAllToolkitsSync()` to the search index, deduplicating against existing MDX pages

## Test plan
- [x] `bun run build` passes
- [ ] Search for "figma" returns the figma toolkit page
- [ ] Search for "github" returns the github toolkit page
- [ ] Existing MDX page search still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)