### PR TITLE
docs: add API reference pages to search index

### DIFF
--- a/.github/workflows/docs-update-data.yml
+++ b/.github/workflows/docs-update-data.yml
@@ -51,6 +51,7 @@ jobs:
         id: changes
         run: |
           cd ..
+          git add -N docs/public/data/ docs/public/openapi.json docs/content/reference/api-reference/ 2>/dev/null || true
           if git diff --quiet docs/public/data/ docs/public/openapi.json docs/content/reference/api-reference/ 2>/dev/null; then
             echo "has_changes=false" >> $GITHUB_OUTPUT
             echo "No changes detected"

--- a/.github/workflows/docs.health-check.yml
+++ b/.github/workflows/docs.health-check.yml
@@ -21,9 +21,9 @@ jobs:
           check_url() {
             local label="$1"
             local url="$2"
-            local extra_args="${3:-}"
+            shift 2
             CHECKED=$((CHECKED + 1))
-            if STATUS=$(curl -sL -o /dev/null -w "%{http_code}" --max-time 15 $extra_args "$url" 2>/dev/null); then
+            if STATUS=$(curl -sL -o /dev/null -w "%{http_code}" --max-time 15 "$@" "$url" 2>/dev/null); then
               :
             else
               STATUS="000"
@@ -66,11 +66,11 @@ jobs:
           check_url "/docs/common-faq" "${BASE_URL}/docs/common-faq"
 
           # Markdown content negotiation
-          check_url "/docs/quickstart (markdown)" "${BASE_URL}/docs/quickstart" '-H "Accept: text/markdown"'
-          check_url "/docs/tools-and-toolkits (markdown)" "${BASE_URL}/docs/tools-and-toolkits" '-H "Accept: text/markdown"'
-          check_url "/docs/authentication (markdown)" "${BASE_URL}/docs/authentication" '-H "Accept: text/markdown"'
-          check_url "/docs/providers/openai (markdown)" "${BASE_URL}/docs/providers/openai" '-H "Accept: text/markdown"'
-          check_url "/cookbooks (markdown)" "${BASE_URL}/cookbooks" '-H "Accept: text/markdown"'
+          check_url "/docs/quickstart (markdown)" "${BASE_URL}/docs/quickstart" -H "Accept: text/markdown"
+          check_url "/docs/tools-and-toolkits (markdown)" "${BASE_URL}/docs/tools-and-toolkits" -H "Accept: text/markdown"
+          check_url "/docs/authentication (markdown)" "${BASE_URL}/docs/authentication" -H "Accept: text/markdown"
+          check_url "/docs/providers/openai (markdown)" "${BASE_URL}/docs/providers/openai" -H "Accept: text/markdown"
+          check_url "/cookbooks (markdown)" "${BASE_URL}/cookbooks" -H "Accept: text/markdown"
 
           if [ "$FAIL_COUNT" -gt 0 ]; then
             echo "has_failures=true" >> $GITHUB_OUTPUT

--- a/docs/app/api/search/route.ts
+++ b/docs/app/api/search/route.ts
@@ -1,8 +1,10 @@
 // Use direct imports from collections to avoid top-level await in lib/source.ts
 import { docs, reference, cookbooks, toolkits, changelog } from 'fumadocs-mdx:collections/server';
 import { createSearchAPI } from 'fumadocs-core/search/server';
-import { loader } from 'fumadocs-core/source';
+import { loader, multiple } from 'fumadocs-core/source';
 import { lucideIconsPlugin } from 'fumadocs-core/source/lucide-icons';
+import { openapiSource, openapiPlugin } from 'fumadocs-openapi/server';
+import { openapi } from '@/lib/openapi';
 import { getAllToolkitsSync } from '@/lib/toolkit-data';
 
 // Create loaders directly here to avoid the problematic lib/source.ts import
@@ -24,30 +26,7 @@ const toolkitsSource = loader({
   plugins: [lucideIconsPlugin()],
 });
 
-// Sync reference source (MDX pages only — SDK reference, errors, rate-limits, etc.)
-// OpenAPI-generated API reference pages require async loading and can't be indexed here
-const referenceSource = loader({
-  baseUrl: '/reference',
-  source: reference.toFumadocsSource(),
-  plugins: [lucideIconsPlugin()],
-});
-
-// MDX pages from Fumadocs sources
-const mdxIndexes = [
-  ...docsSource.getPages(),
-  ...cookbooksSource.getPages(),
-  ...toolkitsSource.getPages(),
-  ...referenceSource.getPages(),
-].map((page) => ({
-  id: page.url,
-  title: page.data.title ?? 'Untitled',
-  description: page.data.description,
-  url: page.url,
-  structuredData: page.data.structuredData,
-  keywords: 'keywords' in page.data ? page.data.keywords : undefined,
-}));
-
-// Dynamic toolkit pages from toolkits.json
+// Dynamic toolkit entries from toolkits.json
 const mdxToolkitSlugs = new Set(
   toolkitsSource.getPages().map((page) => page.slugs.join('/')),
 );
@@ -59,7 +38,7 @@ const dynamicToolkitIndexes = getAllToolkitsSync()
     title: toolkit.name,
     description: toolkit.description,
     url: `/toolkits/${toolkit.slug}`,
-    structuredData: { headings: [], contents: [] },
+    structuredData: { headings: [] as never[], contents: [] as never[] },
     keywords: [toolkit.slug, toolkit.category].filter(Boolean) as string[],
   }));
 
@@ -69,10 +48,42 @@ const changelogIndexes = changelog.map((entry) => ({
   title: entry.title,
   description: entry.description ?? '',
   url: `/docs/changelog/${entry.date.replace(/-/g, '/')}`,
-  structuredData: { headings: [], contents: [] },
+  structuredData: { headings: [] as never[], contents: [] as never[] },
   keywords: ['changelog'],
 }));
 
+// Use dynamic indexes to support async OpenAPI page loading
 export const { GET } = createSearchAPI('advanced', {
-  indexes: [...mdxIndexes, ...dynamicToolkitIndexes, ...changelogIndexes],
+  indexes: async () => {
+    // Load OpenAPI pages and build full reference source
+    const openapiPages = await openapiSource(openapi, {
+      groupBy: 'tag',
+      baseDir: 'api-reference',
+    });
+
+    const fullReferenceSource = loader({
+      baseUrl: '/reference',
+      source: multiple({
+        mdx: reference.toFumadocsSource(),
+        openapi: openapiPages,
+      }),
+      plugins: [lucideIconsPlugin(), openapiPlugin()],
+    });
+
+    const mdxIndexes = [
+      ...docsSource.getPages(),
+      ...cookbooksSource.getPages(),
+      ...toolkitsSource.getPages(),
+      ...fullReferenceSource.getPages(),
+    ].map((page) => ({
+      id: page.url,
+      title: page.data.title ?? 'Untitled',
+      description: page.data.description,
+      url: page.url,
+      structuredData: page.data.structuredData,
+      keywords: 'keywords' in page.data ? (page.data.keywords as string[]) : undefined,
+    }));
+
+    return [...mdxIndexes, ...dynamicToolkitIndexes, ...changelogIndexes];
+  },
 });


### PR DESCRIPTION
## Summary
- Switches search `indexes` from a sync array to an async function so OpenAPI-generated API reference pages can be loaded at request time
- All API reference endpoints (connected accounts, tools, triggers, MCP, etc.) are now searchable
- SDK reference pages were already indexed via MDX — no change needed there
- Fixes a `readonly` type error from `as const` on empty `structuredData` arrays

## Test plan
- [x] `bun run build` passes
- [x] Search for "connected accounts" returns API reference endpoints like `/reference/api-reference/connected-accounts/getConnectedAccounts`
- [x] Search for "execute tool" returns `/reference/api-reference/tools/postToolsExecuteByToolSlug`
- [x] Existing search results (figma, changelog, triggers, quickstart) still work
- [x] SDK reference pages still appear in results

🤖 Generated with [Claude Code](https://claude.com/claude-code)