### PR TITLE
fix(docs): update Vercel AI SDK quickstart snippets

### DIFF
--- a/docs/bun.lock
+++ b/docs/bun.lock
@@ -37,7 +37,7 @@
         "@composio/mastra": "^0.5.5",
         "@composio/openai": "^0.5.5",
         "@composio/openai-agents": "^0.5.5",
-        "@composio/vercel": "^0.5.5",
+        "@composio/vercel": "^0.6.3",
         "@google/genai": "^1.35.0",
         "@langchain/core": "^1.1.12",
         "@langchain/langgraph": "^1.0.15",
@@ -70,17 +70,17 @@
   "packages": {
     "@a2a-js/sdk": ["@a2a-js/sdk@0.2.5", "", { "dependencies": { "@types/cors": "^2.8.17", "@types/express": "^4.17.23", "body-parser": "^2.2.0", "cors": "^2.8.5", "express": "^4.21.2", "uuid": "^11.1.0" } }, "sha512-VTDuRS5V0ATbJ/LkaQlisMnTAeYKXAK6scMguVBstf+KIBQ7HIuKhiXLv+G/hvejkV+THoXzoNifInAkU81P1g=="],
 
-    "@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.12", "", { "dependencies": { "@ai-sdk/provider": "3.0.2", "@ai-sdk/provider-utils": "4.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-1ygMQ2acJ9k+CPRuDiywtkuQwSdsZwAISgbRIayE3PF/Ct2b80c4iGS1CbycYMx+yswPyBMOuPTqebh9vvwMMg=="],
+    "@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.45", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.15" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-bpIS3RakSsaUhCRTIvL9bcVNeeUMDXWbndpYdXNeMJIIPcElTcvwktvla+JxIfbeK1AdQjB8ggYVChepeXPGwQ=="],
 
-    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.22", "", { "dependencies": { "@ai-sdk/provider": "3.0.5", "@ai-sdk/provider-utils": "4.0.9", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-NgnlY73JNuooACHqUIz5uMOEWvqR1MMVbb2soGLMozLY1fgwEIF5iJFDAGa5/YArlzw2ATVU7zQu7HkR/FUjgA=="],
+    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.50", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.15", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Jdd1a8VgbD7l7r+COj0h5SuaYRfPvOJ/AO6l0OrmTPEcI2MUQPr3C4JttfpNkcheEN+gOdy0CtZWuG17bW2fjw=="],
 
-    "@ai-sdk/mcp": ["@ai-sdk/mcp@1.0.6", "", { "dependencies": { "@ai-sdk/provider": "3.0.2", "@ai-sdk/provider-utils": "4.0.5", "pkce-challenge": "^5.0.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ybDhfRArYXrA6Lg6JCPgr3FI3h2COPDRLN9DW6mSFITy4eFK3EccC7UyRTJBY+qp7u2qcqUChrOuYFua/HeFPQ=="],
+    "@ai-sdk/mcp": ["@ai-sdk/mcp@1.0.21", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.15", "pkce-challenge": "^5.0.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-dRX2X6GDadZNpiylNnw0HP7zJC8ggVOOJV/JtxuF6CgtP8CKnc7a/wEzpUw1m/4AGdD3mTDhKnKFwC4y10a8FQ=="],
 
     "@ai-sdk/openai": ["@ai-sdk/openai@3.0.9", "", { "dependencies": { "@ai-sdk/provider": "3.0.2", "@ai-sdk/provider-utils": "4.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-azgo1gmAFwkCDHKWlv9goKBe7SOG5c8zxIX94SEf8748t+ZL0sjPH2RNXk7G6POaZ4A6Os4zhkUnx9KwSk9Bjw=="],
 
-    "@ai-sdk/provider": ["@ai-sdk/provider@3.0.2", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-HrEmNt/BH/hkQ7zpi2o6N3k1ZR1QTb7z85WYhYygiTxOQuaml4CMtHCWRbric5WPU+RNsYI7r1EpyVQMKO1pYw=="],
+    "@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
 
-    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.5", "", { "dependencies": { "@ai-sdk/provider": "3.0.2", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Ow/X/SEkeExTTc1x+nYLB9ZHK2WUId8+9TlkamAx7Tl9vxU+cKzWx2dwjgMHeCN6twrgwkLrrtqckQeO4mxgVA=="],
+    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.15", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-8XiKWbemmCbvNN0CLR9u3PQiet4gtEVIrX4zzLxnCj06AwsEDJwJVBbKrEI4t6qE8XRSIvU2irka0dcpziKW6w=="],
 
     "@ai-sdk/provider-utils-v5": ["@ai-sdk/provider-utils@3.0.12", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ZtbdvYxdMoria+2SlNarEk6Hlgyf+zzcznlD55EAl+7VZvJaSg2sqPvwArY7L6TfDEDJsnCq0fdhBSkYo0Xqdg=="],
 
@@ -178,7 +178,7 @@
 
     "@composio/openai-agents": ["@composio/openai-agents@0.5.5", "", { "peerDependencies": { "@composio/core": "0.5.5", "@openai/agents": "^0.1.3", "zod": "^4.1.0" } }, "sha512-s8fXolOPf+rbya312QsgNU31ly9d/2xIbRn2Ig2AKkdsIZhB5/kXh710n+pGm7ssTXFOs/Jb9/fiXD+M9PL4Ug=="],
 
-    "@composio/vercel": ["@composio/vercel@0.5.5", "", { "peerDependencies": { "@composio/core": "0.5.5", "ai": "^5.0.0 || ^6.0.0" } }, "sha512-Z2nT3/5KLFmGQJVxpq5sXZNoa+PSNWEJnIvjB/9J31adR3K/rnanB+L943R1fQtCk93g+nnv3ggZZfaxMZqktw=="],
+    "@composio/vercel": ["@composio/vercel@0.6.3", "", { "peerDependencies": { "@composio/core": "0.6.3", "ai": "^5.0.0 || ^6.0.0" } }, "sha512-hwtqufR2mWNwdATsRfrAuWRjPVZG4maRcqWZB4jDLpuIZU1NEBMLmL2Ae7b/QFXvNYXibA4w0Ug8XavV4Zkxlg=="],
 
     "@emnapi/core": ["@emnapi/core@1.7.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg=="],
 
@@ -854,7 +854,7 @@
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
-    "ai": ["ai@6.0.49", "", { "dependencies": { "@ai-sdk/gateway": "3.0.22", "@ai-sdk/provider": "3.0.5", "@ai-sdk/provider-utils": "4.0.9", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-LABniBX/0R6Tv+iUK5keUZhZLaZUe4YjP5M2rZ4wAdZ8iKV3EfTAoJxuL1aaWTSJKIilKa9QUEkCgnp89/32bw=="],
+    "ai": ["ai@6.0.91", "", { "dependencies": { "@ai-sdk/gateway": "3.0.50", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.15", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-k1/8BusZMhYVxxLZt0BUZzm9HVDCCh117nyWfWUx5xjR2+tWisJbXgysL7EBMq2lgyHwgpA1jDR3tVjWSdWZXw=="],
 
     "ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
@@ -2262,9 +2262,9 @@
 
     "@a2a-js/sdk/uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
-    "@ai-sdk/gateway/@ai-sdk/provider": ["@ai-sdk/provider@3.0.5", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-2Xmoq6DBJqmSl80U6V9z5jJSJP7ehaJJQMy2iFUqTay06wdCqTnPVBBQbtEL8RCChenL+q5DC5H5WzU3vV3v8w=="],
+    "@ai-sdk/openai/@ai-sdk/provider": ["@ai-sdk/provider@3.0.2", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-HrEmNt/BH/hkQ7zpi2o6N3k1ZR1QTb7z85WYhYygiTxOQuaml4CMtHCWRbric5WPU+RNsYI7r1EpyVQMKO1pYw=="],
 
-    "@ai-sdk/gateway/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.9", "", { "dependencies": { "@ai-sdk/provider": "3.0.5", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-bB4r6nfhBOpmoS9mePxjRoCy+LnzP3AfhyMGCkGL4Mn9clVNlqEeKj26zEKEtB6yoSVcT1IQ0Zh9fytwMCDnow=="],
+    "@ai-sdk/openai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.5", "", { "dependencies": { "@ai-sdk/provider": "3.0.2", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Ow/X/SEkeExTTc1x+nYLB9ZHK2WUId8+9TlkamAx7Tl9vxU+cKzWx2dwjgMHeCN6twrgwkLrrtqckQeO4mxgVA=="],
 
     "@ai-sdk/provider-utils-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
 
@@ -2367,10 +2367,6 @@
     "@vue/compiler-core/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "@vue/compiler-sfc/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
-
-    "ai/@ai-sdk/provider": ["@ai-sdk/provider@3.0.5", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-2Xmoq6DBJqmSl80U6V9z5jJSJP7ehaJJQMy2iFUqTay06wdCqTnPVBBQbtEL8RCChenL+q5DC5H5WzU3vV3v8w=="],
-
-    "ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.9", "", { "dependencies": { "@ai-sdk/provider": "3.0.5", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-bB4r6nfhBOpmoS9mePxjRoCy+LnzP3AfhyMGCkGL4Mn9clVNlqEeKj26zEKEtB6yoSVcT1IQ0Zh9fytwMCDnow=="],
 
     "chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -697,7 +697,6 @@ ANTHROPIC_API_KEY=your_anthropic_api_key
 <StepTitle>Create session and run agent</StepTitle>
 
 ```typescript
-// @noErrors
 import "dotenv/config";
 import { anthropic } from "@ai-sdk/anthropic";
 import { Composio } from "@composio/core";
@@ -724,7 +723,6 @@ Example tasks:
   - 'List all open issues on the composio github repository'
 `);
 
-// Message history for multi-turn conversation
 const messages: ModelMessage[] = [];
 
 while (true) {
@@ -734,32 +732,25 @@ while (true) {
   messages.push({ role: "user", content: input });
   process.stdout.write("Assistant: ");
 
-  try {
-    const result = await streamText({
-      system: "You are a helpful personal assistant. Use Composio tools to take action.",
-      model: anthropic("claude-sonnet-4-5"),
-      messages,
-      stopWhen: stepCountIs(10),
-      onStepFinish: (step) => {
-        for (const toolCall of step.toolCalls) {
-          process.stdout.write(`\n[Using tool: ${toolCall.toolName}]`);
-        }
-      },
-      tools,
-    });
+  const result = await streamText({
+    system: "You are a helpful personal assistant. Use Composio tools to take action.",
+    model: anthropic("claude-sonnet-4-6"),
+    messages,
+    stopWhen: stepCountIs(10),
+    onStepFinish: (step) => {
+      for (const toolCall of step.toolCalls) {
+        process.stdout.write(`\n[Using tool: ${toolCall.toolName}]`);
+      }
+    },
+    tools,
+  });
 
-    let assistantResponse = "";
-    for await (const textPart of result.textStream) {
-      process.stdout.write(textPart);
-      assistantResponse += textPart;
-    }
-    console.log();
-
-    // Add assistant response to history for context
-    messages.push({ role: "assistant", content: assistantResponse });
-  } catch (error) {
-    console.error("\n[Error]:", error instanceof Error ? error.message : error);
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
   }
+  console.log();
+
+  messages.push(...(await result.response).messages);
 }
 
 readline.close();
@@ -796,10 +787,9 @@ ANTHROPIC_API_KEY=your_anthropic_api_key
 <StepTitle>Create session and run agent</StepTitle>
 
 ```typescript
-// @noErrors
 import "dotenv/config";
 import { anthropic } from "@ai-sdk/anthropic";
-import { experimental_createMCPClient as createMCPClient } from "@ai-sdk/mcp";
+import { createMCPClient } from "@ai-sdk/mcp";
 import { Composio } from "@composio/core";
 import { streamText, stepCountIs, type ModelMessage } from "ai";
 import { createInterface } from "readline/promises";
@@ -832,7 +822,6 @@ Example tasks:
   - 'List all open issues on the composio github repository'
 `);
 
-// Message history for multi-turn conversation
 const messages: ModelMessage[] = [];
 
 while (true) {
@@ -842,34 +831,28 @@ while (true) {
   messages.push({ role: "user", content: input });
   process.stdout.write("Assistant: ");
 
-  try {
-    const result = await streamText({
-      system: "You are a helpful personal assistant. Use Composio tools to take action.",
-      model: anthropic("claude-sonnet-4-5"),
-      messages,
-      stopWhen: stepCountIs(10),
-      onStepFinish: (step) => {
-        for (const toolCall of step.toolCalls) {
-          process.stdout.write(`\n[Using tool: ${toolCall.toolName}]`);
-        }
-      },
-      tools,
-    });
+  const result = await streamText({
+    system: "You are a helpful personal assistant. Use Composio tools to take action.",
+    model: anthropic("claude-sonnet-4-6"),
+    messages,
+    stopWhen: stepCountIs(10),
+    onStepFinish: (step) => {
+      for (const toolCall of step.toolCalls) {
+        process.stdout.write(`\n[Using tool: ${toolCall.toolName}]`);
+      }
+    },
+    tools,
+  });
 
-    let assistantResponse = "";
-    for await (const textPart of result.textStream) {
-      process.stdout.write(textPart);
-      assistantResponse += textPart;
-    }
-    console.log();
-
-    // Add assistant response to history for context
-    messages.push({ role: "assistant", content: assistantResponse });
-  } catch (error) {
-    console.error("\n[Error]:", error instanceof Error ? error.message : error);
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
   }
+  console.log();
+
+  messages.push(...(await result.response).messages);
 }
 
+await client.close();
 readline.close();
 ```
 </Step>

--- a/docs/package.json
+++ b/docs/package.json
@@ -47,7 +47,7 @@
     "@composio/mastra": "^0.5.5",
     "@composio/openai": "^0.5.5",
     "@composio/openai-agents": "^0.5.5",
-    "@composio/vercel": "^0.5.5",
+    "@composio/vercel": "^0.6.3",
     "@google/genai": "^1.35.0",
     "@langchain/core": "^1.1.12",
     "@langchain/langgraph": "^1.0.15",


### PR DESCRIPTION
## Summary
- Rename `experimental_createMCPClient` to `createMCPClient` (graduated in `@ai-sdk/mcp` v1.0)
- Fix multi-turn message history to preserve tool call context via `result.response.messages` instead of only storing the final text
- Add missing `await client.close()` cleanup in the MCP snippet

## Test plan
- [x] Ran the exact MCP snippet end-to-end with `bun` — connects to Composio MCP, lists tools, generates text successfully
- [ ] Verify `bun run build` passes (twoslash type-checking on TS code blocks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)