### PR TITLE
docs: update all tool/toolkit counts to 1000+

### DIFF
--- a/docs/.claude/decisions/examples.md
+++ b/docs/.claude/decisions/examples.md
@@ -29,7 +29,7 @@ Based on user interview analysis from #user-interviews Slack channel (50 use cas
 |---------|---------------------|
 | Build a PR review agent with GitHub and Claude | Multi-tool (GitHub + AI), code context |
 | Deploy an email assistant that drafts responses | Email integration, response generation |
-| Create a Slack bot with access to 250+ tools | Tool router, many toolkits |
+| Create a Slack bot with access to 1000+ tools | Tool router, many toolkits |
 | Run a research agent that searches, scrapes, and summarizes | Web tools, chaining outputs |
 | Build an AI SDR that enriches leads automatically | CRM + web research, data enrichment |
 | Build an agentic RAG agent over your docs | RAG + tool calling combined |

--- a/docs/app/(home)/page.tsx
+++ b/docs/app/(home)/page.tsx
@@ -7,7 +7,7 @@ export default function HomePage() {
         Composio Documentation
       </h1>
       <p className="text-lg text-[var(--color-fd-muted-foreground)] max-w-xl mx-auto mb-8">
-        Connect AI agents to 250+ tools with managed authentication.
+        Connect AI agents to 1000+ tools with managed authentication.
       </p>
       <div className="flex gap-4 justify-center">
         <Link 

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -11,11 +11,11 @@ export const metadata: Metadata = {
     default: 'Composio Docs',
     template: '%s | Composio',
   },
-  description: 'Build AI agents with 250+ tools. Connect LLMs to external services like GitHub, Slack, Gmail, and more.',
+  description: 'Build AI agents with 1000+ tools. Connect LLMs to external services like GitHub, Slack, Gmail, and more.',
   metadataBase: new URL('https://docs.composio.dev'),
   openGraph: {
     title: 'Composio Docs',
-    description: 'Build AI agents with 250+ tools. Connect LLMs to external services like GitHub, Slack, Gmail, and more.',
+    description: 'Build AI agents with 1000+ tools. Connect LLMs to external services like GitHub, Slack, Gmail, and more.',
     siteName: 'Composio Docs',
     type: 'website',
     images: ['https://og.composio.dev/api/og?title=Composio%20Docs'],
@@ -23,7 +23,7 @@ export const metadata: Metadata = {
   twitter: {
     card: 'summary_large_image',
     title: 'Composio Docs',
-    description: 'Build AI agents with 250+ tools. Connect LLMs to external services like GitHub, Slack, Gmail, and more.',
+    description: 'Build AI agents with 1000+ tools. Connect LLMs to external services like GitHub, Slack, Gmail, and more.',
     images: ['https://og.composio.dev/api/og?title=Composio%20Docs'],
   },
 };
@@ -63,7 +63,7 @@ export default function Layout({ children }: LayoutProps<'/'>) {
                   '@id': 'https://docs.composio.dev/#website',
                   url: 'https://docs.composio.dev',
                   name: 'Composio Docs',
-                  description: 'Build AI agents with 250+ tools. Connect LLMs to external services like GitHub, Slack, Gmail, and more.',
+                  description: 'Build AI agents with 1000+ tools. Connect LLMs to external services like GitHub, Slack, Gmail, and more.',
                   publisher: { '@id': 'https://composio.dev/#organization' },
                 },
                 {

--- a/docs/app/llms-full.txt/route.ts
+++ b/docs/app/llms-full.txt/route.ts
@@ -107,7 +107,7 @@ export async function GET() {
     ]);
 
     const results = [
-      `# Composio Documentation\n\n> Composio powers 800+ toolkits, tool search, context management, authentication, and a sandboxed workbench to help you build AI agents that turn intent into action.${SESSION_GUARDRAILS}\n# Documentation\n`,
+      `# Composio Documentation\n\n> Composio powers 1000+ toolkits, tool search, context management, authentication, and a sandboxed workbench to help you build AI agents that turn intent into action.${SESSION_GUARDRAILS}\n# Documentation\n`,
       ...docsResults,
       '\n# Cookbooks\n',
       ...cookbooksResults,

--- a/docs/app/llms.txt/route.ts
+++ b/docs/app/llms.txt/route.ts
@@ -89,7 +89,7 @@ export async function GET() {
 
     const index = `# Composio Documentation
 
-> Composio powers 800+ toolkits, tool search, context management, authentication, and a sandboxed workbench to help you build AI agents that turn intent into action.
+> Composio powers 1000+ toolkits, tool search, context management, authentication, and a sandboxed workbench to help you build AI agents that turn intent into action.
 
 > **For AI agents:** Composio supports two integration modes. **Native Tools:** use \`composio.create(user_id)\` + \`session.tools()\` with a provider package (e.g. \`composio_openai\`, \`@composio/openai\`). **MCP:** use \`composio.create(user_id)\` + \`session.mcp.url\` with any MCP-compatible client — no provider package needed. See any page's .md endpoint for full usage instructions.
 

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -1,10 +1,10 @@
 ---
 title: Welcome
-description: Composio powers 800+ toolkits, tool search, context management, authentication, and a sandboxed workbench to help you build AI agents that turn intent into action.
+description: Composio powers 1000+ toolkits, tool search, context management, authentication, and a sandboxed workbench to help you build AI agents that turn intent into action.
 keywords: [getting started, introduction]
 ---
 
-Composio powers 800+ toolkits, tool search, context management, authentication, and a sandboxed workbench to help you build AI agents that turn intent into action.
+Composio powers 1000+ toolkits, tool search, context management, authentication, and a sandboxed workbench to help you build AI agents that turn intent into action.
 
 <Cards>
   <Card
@@ -29,7 +29,7 @@ Composio powers 800+ toolkits, tool search, context management, authentication, 
     icon={<Wrench />}
     title="Toolkits"
     href="/toolkits"
-    description="Browse 800+ toolkits"
+    description="Browse 1000+ toolkits"
   />
 </Cards>
 

--- a/docs/content/docs/providers/anthropic.mdx
+++ b/docs/content/docs/providers/anthropic.mdx
@@ -1,6 +1,6 @@
 ---
 title: Anthropic
-description: Build an agent with Claude and enable it to use 800+ tools with Composio.
+description: Build an agent with Claude and enable it to use 1000+ tools with Composio.
 keywords: [claude, messages api]
 ---
 

--- a/docs/content/docs/providers/autogen.mdx
+++ b/docs/content/docs/providers/autogen.mdx
@@ -1,6 +1,6 @@
 ---
 title: AutoGen
-description: Build an agent with AutoGen and enable it to use 800+ tools with Composio.
+description: Build an agent with AutoGen and enable it to use 1000+ tools with Composio.
 keywords: [autogen, microsoft autogen]
 ---
 

--- a/docs/content/docs/providers/claude-agent-sdk.mdx
+++ b/docs/content/docs/providers/claude-agent-sdk.mdx
@@ -1,6 +1,6 @@
 ---
 title: Claude Agent SDK
-description: Build an agent with the Claude Agent SDK and enable it to use 800+ tools with Composio.
+description: Build an agent with the Claude Agent SDK and enable it to use 1000+ tools with Composio.
 keywords: [claude agent sdk, claude code]
 ---
 

--- a/docs/content/docs/providers/crewai.mdx
+++ b/docs/content/docs/providers/crewai.mdx
@@ -1,6 +1,6 @@
 ---
 title: CrewAI
-description: Build an agent with CrewAI and enable it to use 800+ tools with Composio.
+description: Build an agent with CrewAI and enable it to use 1000+ tools with Composio.
 keywords: [crewai]
 ---
 

--- a/docs/content/docs/providers/custom-providers/index.mdx
+++ b/docs/content/docs/providers/custom-providers/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Custom Providers
-description: Build an agent with any framework and enable it to use 800+ tools with Composio.
+description: Build an agent with any framework and enable it to use 1000+ tools with Composio.
 keywords: [custom provider]
 ---
 

--- a/docs/content/docs/providers/custom-providers/python.mdx
+++ b/docs/content/docs/providers/custom-providers/python.mdx
@@ -1,6 +1,6 @@
 ---
 title: Python Custom Provider
-description: Build an agent with any Python framework and enable it to use 800+ tools with Composio.
+description: Build an agent with any Python framework and enable it to use 1000+ tools with Composio.
 ---
 
 This guide shows how to create custom providers for the Composio Python SDK. Custom providers enable compatibility with different AI frameworks and platforms.

--- a/docs/content/docs/providers/custom-providers/typescript.mdx
+++ b/docs/content/docs/providers/custom-providers/typescript.mdx
@@ -1,6 +1,6 @@
 ---
 title: TypeScript Custom Provider
-description: Build an agent with any TypeScript framework and enable it to use 800+ tools with Composio.
+description: Build an agent with any TypeScript framework and enable it to use 1000+ tools with Composio.
 ---
 
 This guide provides a comprehensive walkthrough of creating custom providers for the Composio TypeScript SDK, enabling compatibility with different AI frameworks and platforms.

--- a/docs/content/docs/providers/google-adk.mdx
+++ b/docs/content/docs/providers/google-adk.mdx
@@ -1,6 +1,6 @@
 ---
 title: Google ADK
-description: Build an agent with Google ADK and enable it to use 800+ tools with Composio.
+description: Build an agent with Google ADK and enable it to use 1000+ tools with Composio.
 keywords: [google adk, agent development kit, gemini]
 ---
 

--- a/docs/content/docs/providers/google.mdx
+++ b/docs/content/docs/providers/google.mdx
@@ -1,6 +1,6 @@
 ---
 title: Google Generative AI
-description: Build an agent with Gemini and enable it to use 800+ tools with Composio.
+description: Build an agent with Gemini and enable it to use 1000+ tools with Composio.
 keywords: [gemini, google generative ai, google genai]
 ---
 

--- a/docs/content/docs/providers/langchain.mdx
+++ b/docs/content/docs/providers/langchain.mdx
@@ -1,6 +1,6 @@
 ---
 title: LangChain
-description: Build an agent with LangChain and enable it to use 800+ tools with Composio.
+description: Build an agent with LangChain and enable it to use 1000+ tools with Composio.
 keywords: [langchain]
 ---
 

--- a/docs/content/docs/providers/langgraph.mdx
+++ b/docs/content/docs/providers/langgraph.mdx
@@ -1,6 +1,6 @@
 ---
 title: LangGraph
-description: Build an agent with LangGraph and enable it to use 800+ tools with Composio.
+description: Build an agent with LangGraph and enable it to use 1000+ tools with Composio.
 keywords: [langgraph]
 ---
 

--- a/docs/content/docs/providers/llamaindex.mdx
+++ b/docs/content/docs/providers/llamaindex.mdx
@@ -1,6 +1,6 @@
 ---
 title: LlamaIndex
-description: Build an agent with LlamaIndex and enable it to use 800+ tools with Composio.
+description: Build an agent with LlamaIndex and enable it to use 1000+ tools with Composio.
 keywords: [llamaindex]
 ---
 

--- a/docs/content/docs/providers/mastra.mdx
+++ b/docs/content/docs/providers/mastra.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mastra
-description: Build an agent with Mastra and enable it to use 800+ tools with Composio.
+description: Build an agent with Mastra and enable it to use 1000+ tools with Composio.
 keywords: [mastra]
 ---
 

--- a/docs/content/docs/providers/openai-agents.mdx
+++ b/docs/content/docs/providers/openai-agents.mdx
@@ -1,6 +1,6 @@
 ---
 title: OpenAI Agents SDK
-description: Build an agent with OpenAI Agents SDK and enable it to use 800+ tools with Composio.
+description: Build an agent with OpenAI Agents SDK and enable it to use 1000+ tools with Composio.
 keywords: [openai agents sdk, agents sdk]
 ---
 

--- a/docs/content/docs/providers/openai.mdx
+++ b/docs/content/docs/providers/openai.mdx
@@ -1,6 +1,6 @@
 ---
 title: OpenAI
-description: Build an agent with OpenAI and enable it to use 800+ tools with Composio.
+description: Build an agent with OpenAI and enable it to use 1000+ tools with Composio.
 keywords: [gpt, responses api, chat completions]
 ---
 

--- a/docs/content/docs/providers/vercel.mdx
+++ b/docs/content/docs/providers/vercel.mdx
@@ -1,6 +1,6 @@
 ---
 title: Vercel AI SDK
-description: Build an agent with Vercel AI SDK and enable it to use 800+ tools with Composio.
+description: Build an agent with Vercel AI SDK and enable it to use 1000+ tools with Composio.
 keywords: [ai sdk, vercel]
 ---
 

--- a/docs/content/docs/toolkits/enable-and-disable-toolkits.mdx
+++ b/docs/content/docs/toolkits/enable-and-disable-toolkits.mdx
@@ -3,7 +3,7 @@ title: Enable and disable toolkits
 description: Control which toolkits and tools are available in your sessions
 ---
 
-When creating a session, you can control which toolkits are available to your agent. By default, all 800+ toolkits are discoverable, but you can restrict or exclude specific ones.
+When creating a session, you can control which toolkits are available to your agent. By default, all 1000+ toolkits are discoverable, but you can restrict or exclude specific ones.
 
 ## Enabling specific toolkits
 

--- a/docs/content/docs/tools-and-toolkits.mdx
+++ b/docs/content/docs/tools-and-toolkits.mdx
@@ -4,7 +4,7 @@ description: Understand how tools and toolkits work in Composio
 keywords: [tools, toolkits, meta tools, context management]
 ---
 
-Composio offers 800+ toolkits, but loading all the tools into context would overwhelm your agent. Instead, your agent has access to 5 meta tools that discover, authenticate, and execute the right tools at runtime.
+Composio offers 1000+ toolkits, but loading all the tools into context would overwhelm your agent. Instead, your agent has access to 5 meta tools that discover, authenticate, and execute the right tools at runtime.
 
 ## Meta tools
 
@@ -12,7 +12,7 @@ When you create a session, your agent gets these 5 meta tools:
 
 | Meta tool | What it does |
 |-----------|--------------|
-| `COMPOSIO_SEARCH_TOOLS` | Discover relevant tools across 800+ apps |
+| `COMPOSIO_SEARCH_TOOLS` | Discover relevant tools across 1000+ apps |
 | `COMPOSIO_MANAGE_CONNECTIONS` | Handle OAuth and API key authentication |
 | `COMPOSIO_MULTI_EXECUTE_TOOL` | Execute up to 20 tools in parallel |
 | `COMPOSIO_REMOTE_WORKBENCH` | Run Python code in a [persistent sandbox](/docs/workbench) |

--- a/docs/content/reference/index.mdx
+++ b/docs/content/reference/index.mdx
@@ -4,7 +4,7 @@ description: Composio REST API and SDK reference for AI agent tool execution, au
 keywords: [Composio API, REST API, SDK reference, AI agent tools, tool execution, API documentation]
 ---
 
-Composio powers tool discovery, execution, authentication, and context management for your AI agents with 800+ toolkits. This reference covers our REST APIs and SDKs.
+Composio powers tool discovery, execution, authentication, and context management for your AI agents with 1000+ toolkits. This reference covers our REST APIs and SDKs.
 
 ## Quick Reference
 


### PR DESCRIPTION
## Summary
- Updates all instances of "800+" and "250+" tool/toolkit counts to "1000+" across 25 files
- Covers: homepage, layout meta tags, LLM endpoints, provider pages, core docs, reference, internal decision docs

## Test plan
- [ ] Verify docs build passes
- [ ] Spot-check a few pages for correct count

🤖 Generated with [Claude Code](https://claude.com/claude-code)