### PR TITLE
fix(docs): Ask AI button improvements

### DIFF
--- a/docs/components/ask-ai-button.tsx
+++ b/docs/components/ask-ai-button.tsx
@@ -11,17 +11,8 @@ function getDecimal() {
   return (window as typeof window & { Decimal?: DecimalAPI }).Decimal;
 }
 
-let isDecimalOpen = false;
-
-function toggleDecimalWidget() {
-  const decimal = getDecimal();
-  if (!decimal) return;
-  if (isDecimalOpen) {
-    decimal.hide();
-  } else {
-    decimal.show();
-  }
-  isDecimalOpen = !isDecimalOpen;
+function showDecimalWidget() {
+  getDecimal()?.show();
 }
 
 function useIsMac() {
@@ -41,7 +32,7 @@ function useAskAIShortcut() {
     function handleKeyDown(e: KeyboardEvent) {
       if ((e.metaKey || e.ctrlKey) && e.key === 'i') {
         e.preventDefault();
-        toggleDecimalWidget();
+        showDecimalWidget();
       }
     }
     document.addEventListener('keydown', handleKeyDown);
@@ -81,7 +72,7 @@ export function SearchAndAskAI() {
       )}
       <button
         type="button"
-        onClick={toggleDecimalWidget}
+        onClick={showDecimalWidget}
         className="inline-flex items-center gap-2 rounded-lg border bg-fd-secondary/50 p-1.5 ps-2.5 text-sm text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground shrink-0"
       >
         Ask AI
@@ -114,7 +105,7 @@ export function SearchAndAskAIMobile() {
       <button
         type="button"
         aria-label="Ask AI"
-        onClick={toggleDecimalWidget}
+        onClick={showDecimalWidget}
         className="inline-flex items-center justify-center rounded-md p-2 text-sm font-medium transition-colors duration-100 hover:bg-fd-accent hover:text-fd-accent-foreground"
       >
         <MessageSquare className="size-4.5" />

--- a/docs/components/ask-ai-button.tsx
+++ b/docs/components/ask-ai-button.tsx
@@ -32,8 +32,12 @@ function useIsMac() {
   return isMac;
 }
 
+let shortcutRegistered = false;
+
 function useAskAIShortcut() {
   useEffect(() => {
+    if (shortcutRegistered) return;
+    shortcutRegistered = true;
     function handleKeyDown(e: KeyboardEvent) {
       if ((e.metaKey || e.ctrlKey) && e.key === 'i') {
         e.preventDefault();
@@ -41,7 +45,10 @@ function useAskAIShortcut() {
       }
     }
     document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      shortcutRegistered = false;
+    };
   }, []);
 }
 
@@ -90,7 +97,6 @@ export function SearchAndAskAI() {
 /** Mobile: search icon + Ask AI icon, shown below lg breakpoint */
 export function SearchAndAskAIMobile() {
   const { enabled, setOpenSearch } = useSearchContext();
-  useAskAIShortcut();
 
   return (
     <>

--- a/docs/components/ask-ai-button.tsx
+++ b/docs/components/ask-ai-button.tsx
@@ -12,11 +12,12 @@ function getDecimal() {
 }
 
 function isDecimalVisible() {
-  // Check if the push-sidebar panel is visible in the DOM
-  const panel = document.querySelector('iframe[src*="decimal"], [class*="decimal" i]');
+  // Look for the sidebar panel (iframe), not the small launcher button
+  const panel = document.querySelector('iframe[src*="decimal"]');
   if (!panel) return false;
   const rect = panel.getBoundingClientRect();
-  return rect.width > 0 && rect.height > 0;
+  // The push-sidebar panel is wide (300px+); the launcher is small
+  return rect.width > 200;
 }
 
 function toggleDecimalWidget() {

--- a/docs/components/ask-ai-button.tsx
+++ b/docs/components/ask-ai-button.tsx
@@ -11,8 +11,17 @@ function getDecimal() {
   return (window as typeof window & { Decimal?: DecimalAPI }).Decimal;
 }
 
-function showDecimalWidget() {
-  getDecimal()?.show();
+let isDecimalOpen = false;
+
+function toggleDecimalWidget() {
+  const decimal = getDecimal();
+  if (!decimal) return;
+  if (isDecimalOpen) {
+    decimal.hide();
+  } else {
+    decimal.show();
+  }
+  isDecimalOpen = !isDecimalOpen;
 }
 
 function useIsMac() {
@@ -32,7 +41,7 @@ function useAskAIShortcut() {
     function handleKeyDown(e: KeyboardEvent) {
       if ((e.metaKey || e.ctrlKey) && e.key === 'i') {
         e.preventDefault();
-        showDecimalWidget();
+        toggleDecimalWidget();
       }
     }
     document.addEventListener('keydown', handleKeyDown);
@@ -72,7 +81,7 @@ export function SearchAndAskAI() {
       )}
       <button
         type="button"
-        onClick={showDecimalWidget}
+        onClick={toggleDecimalWidget}
         className="inline-flex items-center gap-2 rounded-lg border bg-fd-secondary/50 p-1.5 ps-2.5 text-sm text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground shrink-0"
       >
         Ask AI
@@ -105,7 +114,7 @@ export function SearchAndAskAIMobile() {
       <button
         type="button"
         aria-label="Ask AI"
-        onClick={showDecimalWidget}
+        onClick={toggleDecimalWidget}
         className="inline-flex items-center justify-center rounded-md p-2 text-sm font-medium transition-colors duration-100 hover:bg-fd-accent hover:text-fd-accent-foreground"
       >
         <MessageSquare className="size-4.5" />

--- a/docs/components/ask-ai-button.tsx
+++ b/docs/components/ask-ai-button.tsx
@@ -11,26 +11,13 @@ function getDecimal() {
   return (window as typeof window & { Decimal?: DecimalAPI }).Decimal;
 }
 
-function isDecimalVisible() {
-  // Look for the sidebar panel (iframe), not the small launcher button
-  const panel = document.querySelector('iframe[src*="decimal"]');
-  if (!panel) return false;
-  const rect = panel.getBoundingClientRect();
-  // The push-sidebar panel is wide (300px+); the launcher is small
-  return rect.width > 200;
-}
-
-function toggleDecimalWidget() {
+function showDecimalWidget() {
   const decimal = getDecimal();
-  if (!decimal) {
-    setTimeout(() => getDecimal()?.show(), 500);
+  if (decimal) {
+    decimal.show();
     return;
   }
-  if (isDecimalVisible()) {
-    decimal.hide();
-  } else {
-    decimal.show();
-  }
+  setTimeout(() => getDecimal()?.show(), 500);
 }
 
 function useIsMac() {
@@ -44,7 +31,7 @@ function useIsMac() {
 const handleKeyDown = (e: KeyboardEvent) => {
   if ((e.metaKey || e.ctrlKey) && e.key === 'i') {
     e.preventDefault();
-    toggleDecimalWidget();
+    showDecimalWidget();
   }
 };
 
@@ -84,7 +71,7 @@ export function SearchAndAskAI() {
       )}
       <button
         type="button"
-        onClick={toggleDecimalWidget}
+        onClick={showDecimalWidget}
         className="inline-flex items-center gap-2 rounded-lg border bg-fd-secondary/50 p-1.5 ps-2.5 text-sm text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground shrink-0"
       >
         Ask AI
@@ -117,7 +104,7 @@ export function SearchAndAskAIMobile() {
       <button
         type="button"
         aria-label="Ask AI"
-        onClick={toggleDecimalWidget}
+        onClick={showDecimalWidget}
         className="inline-flex items-center justify-center rounded-md p-2 text-sm font-medium transition-colors duration-100 hover:bg-fd-accent hover:text-fd-accent-foreground"
       >
         <MessageSquare className="size-4.5" />

--- a/docs/components/ask-ai-button.tsx
+++ b/docs/components/ask-ai-button.tsx
@@ -5,23 +5,18 @@ import { Search, MessageSquare } from 'lucide-react';
 import { useSearchContext } from '@fumadocs/ui/contexts/search';
 import { useI18n } from '@fumadocs/ui/contexts/i18n';
 
-function openDecimalWidget() {
-  // Try the global API first
-  const win = window as typeof window & { Decimal?: Record<string, unknown> };
-  if (win.Decimal) {
-    for (const key of ['open', 'toggle', 'show'] as const) {
-      if (typeof win.Decimal[key] === 'function') {
-        (win.Decimal[key] as () => void)();
-        return;
-      }
-    }
-  }
-  // Fallback: find and click the widget's launcher button in the DOM
-  const launcher =
-    document.querySelector<HTMLElement>('[data-decimal-widget]') ??
-    document.querySelector<HTMLElement>('[class*="decimal" i]') ??
-    document.querySelector<HTMLElement>('#decimal-widget button');
-  launcher?.click();
+type DecimalAPI = {
+  show: () => void;
+  hide: () => void;
+  theme: (config: Record<string, string>) => void;
+};
+
+function getDecimal() {
+  return (window as typeof window & { Decimal?: DecimalAPI }).Decimal;
+}
+
+function showDecimalWidget() {
+  getDecimal()?.show();
 }
 
 function useIsMac() {
@@ -41,7 +36,7 @@ function useAskAIShortcut() {
     function handleKeyDown(e: KeyboardEvent) {
       if ((e.metaKey || e.ctrlKey) && e.key === 'i') {
         e.preventDefault();
-        openDecimalWidget();
+        showDecimalWidget();
       }
     }
     document.addEventListener('keydown', handleKeyDown);
@@ -81,7 +76,7 @@ export function SearchAndAskAI() {
       )}
       <button
         type="button"
-        onClick={openDecimalWidget}
+        onClick={showDecimalWidget}
         className="inline-flex items-center gap-2 rounded-lg border bg-fd-secondary/50 p-1.5 ps-2.5 text-sm text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground shrink-0"
       >
         Ask AI
@@ -114,7 +109,7 @@ export function SearchAndAskAIMobile() {
       <button
         type="button"
         aria-label="Ask AI"
-        onClick={openDecimalWidget}
+        onClick={showDecimalWidget}
         className="inline-flex items-center justify-center rounded-md p-2 text-sm font-medium transition-colors duration-100 hover:bg-fd-accent hover:text-fd-accent-foreground"
       >
         <MessageSquare className="size-4.5" />

--- a/docs/components/ask-ai-button.tsx
+++ b/docs/components/ask-ai-button.tsx
@@ -11,13 +11,19 @@ function getDecimal() {
   return (window as typeof window & { Decimal?: DecimalAPI }).Decimal;
 }
 
-function showDecimalWidget() {
+let widgetOpen = false;
+
+function toggleDecimalWidget() {
   const decimal = getDecimal();
-  if (decimal) {
-    decimal.show();
+  if (!decimal) {
+    setTimeout(() => {
+      getDecimal()?.show();
+      widgetOpen = true;
+    }, 500);
     return;
   }
-  setTimeout(() => getDecimal()?.show(), 500);
+  widgetOpen ? decimal.hide() : decimal.show();
+  widgetOpen = !widgetOpen;
 }
 
 function useIsMac() {
@@ -31,7 +37,7 @@ function useIsMac() {
 const handleKeyDown = (e: KeyboardEvent) => {
   if ((e.metaKey || e.ctrlKey) && e.key === 'i') {
     e.preventDefault();
-    showDecimalWidget();
+    toggleDecimalWidget();
   }
 };
 
@@ -71,7 +77,7 @@ export function SearchAndAskAI() {
       )}
       <button
         type="button"
-        onClick={showDecimalWidget}
+        onClick={toggleDecimalWidget}
         className="inline-flex items-center gap-2 rounded-lg border bg-fd-secondary/50 p-1.5 ps-2.5 text-sm text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground shrink-0"
       >
         Ask AI
@@ -104,7 +110,7 @@ export function SearchAndAskAIMobile() {
       <button
         type="button"
         aria-label="Ask AI"
-        onClick={showDecimalWidget}
+        onClick={toggleDecimalWidget}
         className="inline-flex items-center justify-center rounded-md p-2 text-sm font-medium transition-colors duration-100 hover:bg-fd-accent hover:text-fd-accent-foreground"
       >
         <MessageSquare className="size-4.5" />

--- a/docs/components/ask-ai-button.tsx
+++ b/docs/components/ask-ai-button.tsx
@@ -23,23 +23,17 @@ function useIsMac() {
   return isMac;
 }
 
-let shortcutRegistered = false;
+const handleKeyDown = (e: KeyboardEvent) => {
+  if ((e.metaKey || e.ctrlKey) && e.key === 'i') {
+    e.preventDefault();
+    showDecimalWidget();
+  }
+};
 
 function useAskAIShortcut() {
   useEffect(() => {
-    if (shortcutRegistered) return;
-    shortcutRegistered = true;
-    function handleKeyDown(e: KeyboardEvent) {
-      if ((e.metaKey || e.ctrlKey) && e.key === 'i') {
-        e.preventDefault();
-        showDecimalWidget();
-      }
-    }
     document.addEventListener('keydown', handleKeyDown);
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown);
-      shortcutRegistered = false;
-    };
+    return () => document.removeEventListener('keydown', handleKeyDown);
   }, []);
 }
 

--- a/docs/components/ask-ai-button.tsx
+++ b/docs/components/ask-ai-button.tsx
@@ -12,7 +12,13 @@ function getDecimal() {
 }
 
 function showDecimalWidget() {
-  getDecimal()?.show();
+  const decimal = getDecimal();
+  if (decimal) {
+    decimal.show();
+    return;
+  }
+  // Widget script may not have loaded yet — retry once after a short delay
+  setTimeout(() => getDecimal()?.show(), 500);
 }
 
 function useIsMac() {

--- a/docs/components/ask-ai-button.tsx
+++ b/docs/components/ask-ai-button.tsx
@@ -5,11 +5,7 @@ import { Search, MessageSquare } from 'lucide-react';
 import { useSearchContext } from '@fumadocs/ui/contexts/search';
 import { useI18n } from '@fumadocs/ui/contexts/i18n';
 
-type DecimalAPI = {
-  show: () => void;
-  hide: () => void;
-  theme: (config: Record<string, string>) => void;
-};
+import type { DecimalAPI } from './decimal-widget';
 
 function getDecimal() {
   return (window as typeof window & { Decimal?: DecimalAPI }).Decimal;

--- a/docs/components/ask-ai-button.tsx
+++ b/docs/components/ask-ai-button.tsx
@@ -11,14 +11,25 @@ function getDecimal() {
   return (window as typeof window & { Decimal?: DecimalAPI }).Decimal;
 }
 
-function showDecimalWidget() {
+function isDecimalVisible() {
+  // Check if the push-sidebar panel is visible in the DOM
+  const panel = document.querySelector('iframe[src*="decimal"], [class*="decimal" i]');
+  if (!panel) return false;
+  const rect = panel.getBoundingClientRect();
+  return rect.width > 0 && rect.height > 0;
+}
+
+function toggleDecimalWidget() {
   const decimal = getDecimal();
-  if (decimal) {
-    decimal.show();
+  if (!decimal) {
+    setTimeout(() => getDecimal()?.show(), 500);
     return;
   }
-  // Widget script may not have loaded yet — retry once after a short delay
-  setTimeout(() => getDecimal()?.show(), 500);
+  if (isDecimalVisible()) {
+    decimal.hide();
+  } else {
+    decimal.show();
+  }
 }
 
 function useIsMac() {
@@ -32,7 +43,7 @@ function useIsMac() {
 const handleKeyDown = (e: KeyboardEvent) => {
   if ((e.metaKey || e.ctrlKey) && e.key === 'i') {
     e.preventDefault();
-    showDecimalWidget();
+    toggleDecimalWidget();
   }
 };
 
@@ -72,7 +83,7 @@ export function SearchAndAskAI() {
       )}
       <button
         type="button"
-        onClick={showDecimalWidget}
+        onClick={toggleDecimalWidget}
         className="inline-flex items-center gap-2 rounded-lg border bg-fd-secondary/50 p-1.5 ps-2.5 text-sm text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground shrink-0"
       >
         Ask AI
@@ -105,7 +116,7 @@ export function SearchAndAskAIMobile() {
       <button
         type="button"
         aria-label="Ask AI"
-        onClick={showDecimalWidget}
+        onClick={toggleDecimalWidget}
         className="inline-flex items-center justify-center rounded-md p-2 text-sm font-medium transition-colors duration-100 hover:bg-fd-accent hover:text-fd-accent-foreground"
       >
         <MessageSquare className="size-4.5" />

--- a/docs/components/decimal-widget.tsx
+++ b/docs/components/decimal-widget.tsx
@@ -3,7 +3,11 @@
 import Script from 'next/script';
 import { useEffect, useState } from 'react';
 
-type DecimalAPI = { theme: (config: Record<string, string>) => void };
+type DecimalAPI = {
+  show: () => void;
+  hide: () => void;
+  theme: (config: Record<string, string>) => void;
+};
 
 const DARK_THEME = {
   colorScheme: 'dark',

--- a/docs/components/decimal-widget.tsx
+++ b/docs/components/decimal-widget.tsx
@@ -3,7 +3,7 @@
 import Script from 'next/script';
 import { useEffect, useState } from 'react';
 
-type DecimalAPI = {
+export type DecimalAPI = {
   show: () => void;
   hide: () => void;
   theme: (config: Record<string, string>) => void;


### PR DESCRIPTION
## Summary
- Show platform-aware keyboard shortcut hint (`⌘ I` on Mac, `Ctrl I` on Windows/Linux)
- Fix duplicate keyboard shortcut listeners — both desktop and mobile components were registering separate `keydown` handlers, causing `openDecimalWidget()` to fire twice per keystroke

## Test plan
- [ ] Desktop: verify kbd hint shows `⌘ I` on Mac, `Ctrl I` on other platforms
- [ ] Press `⌘I` / `Ctrl+I` — widget opens only once (no double-fire)
- [ ] Button click still works on both desktop and mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)