### PR TITLE
docs: add session recommendation banners to direct tool guides

### DIFF
--- a/docs/content/docs/auth-configuration/connected-accounts.mdx
+++ b/docs/content/docs/auth-configuration/connected-accounts.mdx
@@ -5,6 +5,10 @@ keywords: [list accounts, refresh token, disable, delete account]
 llmGuardrails: "direct-execution"
 ---
 
+<Callout type="info">
+If you're building an agent, we recommend using [sessions](/docs/configuring-sessions) instead. See [Managing multiple connected accounts](/docs/managing-multiple-connected-accounts) for how sessions handle account selection automatically.
+</Callout>
+
 Connected accounts are authenticated connections between your users and toolkits. After users authenticate (see [Authenticating tools](/docs/tools-direct/authenticating-tools)), you can manage these accounts throughout their lifecycle.
 
 Composio automatically handles token refresh and credential management. This guide covers manual operations: listing, retrieving, refreshing, enabling, disabling, and deleting accounts.

--- a/docs/content/docs/auth-configuration/custom-auth-configs.mdx
+++ b/docs/content/docs/auth-configuration/custom-auth-configs.mdx
@@ -5,6 +5,10 @@ keywords: [white label, custom oauth, own developer app]
 llmGuardrails: "direct-execution"
 ---
 
+<Callout type="info">
+If you're building an agent, we recommend using [sessions](/docs/configuring-sessions) instead. See [Using custom auth configs](/docs/using-custom-auth-configuration) for how to use custom credentials with sessions.
+</Callout>
+
 Many toolkits support a level of customization for the auth config, specifically OAuth applications.
 
 This guide will walk you through the process of customizing the auth config for toolkits where you can configure your own developer app.

--- a/docs/content/docs/auth-configuration/custom-auth-params.mdx
+++ b/docs/content/docs/auth-configuration/custom-auth-params.mdx
@@ -5,6 +5,10 @@ keywords: [inject headers, custom credentials]
 llmGuardrails: "direct-execution"
 ---
 
+<Callout type="info">
+If you're building an agent, we recommend using [sessions](/docs/configuring-sessions) instead. Sessions handle authentication automatically via [in-chat authentication](/docs/authenticating-users/in-chat-authentication) or [manual authentication](/docs/authenticating-users/manually-authenticating).
+</Callout>
+
 In cases where Composio is not being used for managing the auth but only for the tools, it is possible to use the `beforeExecute` hook to inject custom auth headers or parameters for a toolkit.
 
 ## Setup and Initialization

--- a/docs/content/docs/auth-configuration/programmatic-auth-configs.mdx
+++ b/docs/content/docs/auth-configuration/programmatic-auth-configs.mdx
@@ -5,6 +5,10 @@ keywords: [create auth config, sdk]
 llmGuardrails: "direct-execution"
 ---
 
+<Callout type="info">
+If you're building an agent, we recommend using [sessions](/docs/configuring-sessions#custom-auth-configs) instead. Sessions let you pass custom auth configs directly when creating a session.
+</Callout>
+
 Auth configs are created once and reused many times. However, when managing multiple toolkits, you may want to create auth configs programmatically.
 
 - When creating and destroying auth configs multiple times in your app's lifecycle.

--- a/docs/content/docs/tools-direct/authenticating-tools.mdx
+++ b/docs/content/docs/tools-direct/authenticating-tools.mdx
@@ -5,6 +5,10 @@ keywords: [oauth, api key, auth config, connect account, credentials]
 llmGuardrails: "direct-execution"
 ---
 
+<Callout type="info">
+If you're building an agent, we recommend using [sessions](/docs/configuring-sessions) instead. Sessions handle authentication automatically via [in-chat authentication](/docs/authenticating-users/in-chat-authentication) or [manual authentication](/docs/authenticating-users/manually-authenticating).
+</Callout>
+
 The first step in authenticating your users is to create an **Auth Config**. Every toolkit has its own authentication method such as `OAuth`, `API key`, `Basic Auth`, or custom schemes.
 
 An **Auth Config** is a blueprint that defines how authentication works for a toolkit across all your users. It defines:

--- a/docs/content/docs/tools-direct/custom-tools.mdx
+++ b/docs/content/docs/tools-direct/custom-tools.mdx
@@ -5,6 +5,10 @@ keywords: [create tool, custom action, extend, standalone tool]
 llmGuardrails: "direct-execution"
 ---
 
+<Callout type="info">
+If you're building an agent, we recommend using [sessions](/docs/configuring-sessions) instead. Sessions handle tool fetching, authentication, and execution automatically.
+</Callout>
+
 Custom tools allow you to create your own tools that can be used with Composio.
 
 1. **Standalone tools** - Simple tools that don't require any authentication

--- a/docs/content/docs/tools-direct/executing-tools.mdx
+++ b/docs/content/docs/tools-direct/executing-tools.mdx
@@ -5,6 +5,10 @@ keywords: [execute, run, tool calling, function calling, direct execution]
 llmGuardrails: "direct-execution"
 ---
 
+<Callout type="info">
+If you're building an agent, we recommend using [sessions](/docs/configuring-sessions) instead. Sessions handle tool fetching, authentication, and execution automatically.
+</Callout>
+
 LLMs on their own can only do generation. Tool calling changes that by letting them interact with external services. Instead of just drafting an email, the model can call `GMAIL_SEND_EMAIL` to actually send it. The tool's results feed back to the LLM, closing the loop so it can decide, act, observe, and adapt.
 
 In Composio, every **tool** is a single API action—fully described with schema, parameters, and return type. Tools live inside **toolkits** like Gmail, Slack, or GitHub, and Composio handles authentication and user scoping.

--- a/docs/content/docs/tools-direct/fetching-tools.mdx
+++ b/docs/content/docs/tools-direct/fetching-tools.mdx
@@ -5,6 +5,10 @@ keywords: [get tools, list tools, filter, schema]
 llmGuardrails: "direct-execution"
 ---
 
+<Callout type="info">
+If you're building an agent, we recommend using [sessions](/docs/configuring-sessions) instead. See [Tools and toolkits](/docs/tools-and-toolkits) for how sessions discover and fetch tools automatically.
+</Callout>
+
 Fetch specific tools, filter by permissions or search, and inspect schemas for type information. Tools are automatically formatted for your provider.
 
 ## Basic usage

--- a/docs/content/docs/tools-direct/modify-tool-behavior/after-execution-modifiers.mdx
+++ b/docs/content/docs/tools-direct/modify-tool-behavior/after-execution-modifiers.mdx
@@ -4,6 +4,10 @@ description: Transform tool results after execution
 llmGuardrails: "direct-execution"
 ---
 
+<Callout type="info">
+If you're building an agent, we recommend using [sessions](/docs/configuring-sessions) instead. Sessions handle tool fetching, authentication, and execution automatically.
+</Callout>
+
 After execution modifiers are part of Composio SDK's powerful middleware capabilities that allow you to customize and extend the behavior of tools.
 
 These modifiers are called after the tool is executed. This allows you to modify the result of the tool before it is returned to the agent.

--- a/docs/content/docs/tools-direct/modify-tool-behavior/before-execution-modifiers.mdx
+++ b/docs/content/docs/tools-direct/modify-tool-behavior/before-execution-modifiers.mdx
@@ -4,6 +4,10 @@ description: Modify tool arguments before execution
 llmGuardrails: "direct-execution"
 ---
 
+<Callout type="info">
+If you're building an agent, we recommend using [sessions](/docs/configuring-sessions) instead. Sessions handle tool fetching, authentication, and execution automatically.
+</Callout>
+
 Before execution modifiers are part of Composio SDK's powerful middleware capabilities that allow you to customize and extend the behavior of tools.
 
 These modifiers are called before the tool is executed by the LLM. This allows you to modify the arguments called by the LLM before they are executed by Composio.

--- a/docs/content/docs/tools-direct/modify-tool-behavior/schema-modifiers.mdx
+++ b/docs/content/docs/tools-direct/modify-tool-behavior/schema-modifiers.mdx
@@ -4,6 +4,10 @@ description: Customize how tools appear to agents
 llmGuardrails: "direct-execution"
 ---
 
+<Callout type="info">
+If you're building an agent, we recommend using [sessions](/docs/configuring-sessions) instead. Sessions handle tool fetching, authentication, and execution automatically.
+</Callout>
+
 Schema modifiers are part of Composio SDK's powerful middleware capabilities that allow you to customize and extend the behavior of tools.
 
 Schema modifiers transform a tool's schema before the tool is seen by an agent.

--- a/docs/content/docs/tools-direct/toolkit-versioning.mdx
+++ b/docs/content/docs/tools-direct/toolkit-versioning.mdx
@@ -5,6 +5,10 @@ keywords: [version, pin version, tool versioning]
 llmGuardrails: "direct-execution"
 ---
 
+<Callout type="info">
+If you're building an agent, we recommend using [sessions](/docs/configuring-sessions) instead. Sessions handle toolkit versions automatically so you don't have to manage them yourself.
+</Callout>
+
 Toolkit versioning ensures your tools behave consistently across deployments. You can pin specific versions in production, test new releases in development, and roll back when needed.
 
 To view available versions, go to [Dashboard](https://platform.composio.dev) > **All Toolkits** > select a toolkit. The version dropdown shows the latest and all available versions:


### PR DESCRIPTION
## Summary
- Adds info callout banners to all 12 direct tool execution and auth configuration pages
- Each banner recommends using sessions when building agents, with links to the relevant session-based equivalent page
- Tailored links per page (e.g., fetching tools → Tools and toolkits, auth configs → Using custom auth configs, connected accounts → Managing multiple connected accounts)

## Pages updated
**tools-direct/** (8 files)
- `executing-tools`, `fetching-tools`, `authenticating-tools`, `custom-tools`, `toolkit-versioning`
- `modify-tool-behavior/` — before, after, and schema modifiers

**auth-configuration/** (4 files)
- `connected-accounts`, `custom-auth-configs`, `custom-auth-params`, `programmatic-auth-configs`

## Test plan
- [ ] Verify banners render correctly on each page
- [ ] Verify all internal links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)