### PR TITLE
docs: add next steps links to quickstart page

### DIFF
--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -826,3 +826,10 @@ readline.close();
 
 </QuickstartFlow>
 
+## Next steps
+
+<Cards>
+  <Card icon={<Wrench />} title="Configuring Sessions" href="/docs/configuring-sessions" description="Restrict toolkits, set custom auth configs, and select connected accounts" />
+  <Card icon={<Key />} title="Authenticating Users" href="/docs/authentication" description="Learn how users connect their accounts via Connect Links, OAuth, and API keys" />
+</Cards>
+


### PR DESCRIPTION
## Summary
- Adds a "Next steps" section at the bottom of the quickstart page
- Two cards guiding users through the happy path after their first agent:
  - **Configuring Sessions** — restrict toolkits, set custom auth configs, select connected accounts
  - **Authenticating Users** — Connect Links, OAuth, API keys

## Test plan
- [ ] Verify cards render correctly on the quickstart page
- [ ] Verify both links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)