### PR TITLE
ci: changelog-to-docs GitHub Action

### DIFF
--- a/.github/workflows/docs.changelog-to-docs.yml
+++ b/.github/workflows/docs.changelog-to-docs.yml
@@ -1,0 +1,59 @@
+name: Changelog → Docs PR
+
+on:
+  push:
+    branches: [next]
+    paths:
+      - 'docs/content/changelog/**.mdx'
+
+jobs:
+  suggest-docs-updates:
+    name: Suggest Documentation Updates
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect new changelog files
+        id: detect
+        run: |
+          BEFORE="${{ github.event.before }}"
+          AFTER="${{ github.event.after }}"
+
+          if [[ "$BEFORE" =~ ^0+$ ]]; then
+            FILES=$(git diff --name-only --diff-filter=AM HEAD^..HEAD | grep '^docs/content/changelog/.*\.mdx$' || echo "")
+          else
+            FILES=$(git diff --name-only --diff-filter=AM "$BEFORE".."$AFTER" | grep '^docs/content/changelog/.*\.mdx$' || echo "")
+          fi
+
+          if [ -z "$FILES" ]; then
+            echo "found=false" >> $GITHUB_OUTPUT
+          else
+            echo "found=true" >> $GITHUB_OUTPUT
+            echo "files<<EOF" >> $GITHUB_OUTPUT
+            echo "$FILES" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Claude suggests docs updates
+        if: steps.detect.outputs.found == 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          direct_prompt: |
+            New changelog entries were merged to next. Read the agent instructions and update documentation accordingly.
+
+            1. Read docs/.claude/agents/changelog-docs-updater.md for full instructions
+            2. Read each of these changelog files:
+            ${{ steps.detect.outputs.files }}
+            3. For each change, search docs/content/docs/ for pages that need updating
+            4. Make the documentation updates following the agent instructions
+            5. If no docs changes are needed, make no file changes and explain why

--- a/.github/workflows/docs.changelog-to-docs.yml
+++ b/.github/workflows/docs.changelog-to-docs.yml
@@ -10,6 +10,7 @@ jobs:
   suggest-docs-updates:
     name: Suggest Documentation Updates
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/docs.changelog-to-docs.yml
+++ b/.github/workflows/docs.changelog-to-docs.yml
@@ -48,7 +48,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          direct_prompt: |
+          prompt: |
             New changelog entries were merged to next. Read the agent instructions and update documentation accordingly.
 
             1. Read docs/.claude/agents/changelog-docs-updater.md for full instructions

--- a/docs/.claude/agents/changelog-docs-updater.md
+++ b/docs/.claude/agents/changelog-docs-updater.md
@@ -1,0 +1,53 @@
+# Changelog → Docs Updater
+
+Analyzes new changelog entries and updates documentation to reflect the changes.
+
+## When This Runs
+
+Triggered when a changelog file (`docs/content/changelog/*.mdx`) is pushed to `next`. Creates a PR with suggested documentation updates.
+
+## Process
+
+1. Read each new/modified changelog file
+2. Categorize the changes (breaking change, new feature, deprecation, bug fix, behavior change)
+3. For each change, search `docs/content/docs/` for pages that reference the affected feature
+4. Make targeted documentation updates
+
+## What to Update
+
+| Changelog Type | Docs Action |
+|---|---|
+| **Breaking change** (new API signature, removed parameter) | Update code examples in affected guides to use the new API |
+| **New feature** (new parameter, new method, new option) | Add to the relevant existing guide where it fits naturally |
+| **Deprecation** | Add a `<Callout type="warn">` note near the deprecated usage |
+| **Behavior change** (default changed, response format changed) | Update descriptions and examples that reference the old behavior |
+| **New toolkit support** | No docs changes needed (toolkits are auto-generated) |
+| **Bug fix** (no API change) | No docs changes needed |
+| **Performance improvement** | No docs changes needed |
+
+## Rules
+
+- Only modify files in `docs/content/docs/` and `docs/content/cookbooks/`
+- Do NOT create new pages — only update existing ones
+- Do NOT add changelog-style content ("as of v0.6.0...") to docs. Docs should describe current behavior.
+- Do NOT make cosmetic or stylistic changes unrelated to the changelog
+- Follow existing patterns in the docs (Tabs for Python/TypeScript, `<Callout>` for warnings)
+- TypeScript code blocks in MDX are type-checked at build time. Add proper imports above `// ---cut---` lines. See `docs/.claude/context/twoslash.md` for details.
+- If no documentation changes are needed, make no file changes
+
+## Key Docs Pages
+
+These are the most commonly affected pages. Search broadly, but start here:
+
+| Topic | Docs Page |
+|---|---|
+| Sessions API | `configuring-sessions.mdx` |
+| Authentication | `authentication.mdx`, `authenticating-users/` |
+| Tools & toolkits | `tools-and-toolkits.mdx`, `tools-direct/` |
+| Triggers & webhooks | `triggers.mdx`, `webhook-verification.mdx`, `setting-up-triggers/` |
+| Connected accounts | `managing-multiple-connected-accounts.mdx`, `auth-configuration/connected-accounts.mdx` |
+| Auth configs | `using-custom-auth-configuration.mdx`, `auth-configuration/` |
+| White labeling | `white-labeling-authentication.mdx` |
+| Migration | `migration-guide/` |
+| SDK quickstart | `quickstart.mdx` |
+| Providers | `providers/` |

--- a/docs/.claude/agents/changelog-docs-updater.md
+++ b/docs/.claude/agents/changelog-docs-updater.md
@@ -21,9 +21,10 @@ Triggered when a changelog file (`docs/content/changelog/*.mdx`) is pushed to `n
 | **New feature** (new parameter, new method, new option) | Add to the relevant existing guide where it fits naturally |
 | **Deprecation** | Add a `<Callout type="warn">` note near the deprecated usage |
 | **Behavior change** (default changed, response format changed) | Update descriptions and examples that reference the old behavior |
-| **New toolkit support** | No docs changes needed (toolkits are auto-generated) |
+| **Toolkit changes** (new toolkit, toolkit deprecation, credential removal, toolkit-level config) | No docs changes needed (toolkit pages are auto-generated) |
 | **Bug fix** (no API change) | No docs changes needed |
 | **Performance improvement** | No docs changes needed |
+| **Infrastructure / internal changes** | No docs changes needed |
 
 ## Rules
 


### PR DESCRIPTION
## Summary
- Adds a GitHub Action that triggers when changelog entries are pushed to `next`
- Claude Code Action reads the changelog, searches docs for affected pages, and creates a PR with suggested documentation updates
- Agent instructions in `docs/.claude/agents/changelog-docs-updater.md` define what to update per changelog type (breaking changes, new features, deprecations) and what to skip (bug fixes, perf improvements)

## Test plan
- [ ] Merge a changelog entry to `next` and verify the action triggers
- [ ] Confirm Claude creates a PR with relevant docs updates (or makes no changes if none are needed)
- [ ] Verify the action skips when no changelog files are in the push

🤖 Generated with [Claude Code](https://claude.com/claude-code)