### PR TITLE
docs: add Twitter managed credentials removal FAQ

### DIFF
--- a/docs/content/toolkits/faq/twitter.md
+++ b/docs/content/toolkits/faq/twitter.md
@@ -1,6 +1,15 @@
+## Why are Composio managed credentials no longer available for Twitter?
+
+As of February 2026, Composio managed credentials for the Twitter toolkit have been removed. You must now bring your own Twitter API credentials. To migrate:
+
+1. Create a Twitter Developer account and obtain API credentials from the [Twitter Developer Portal](https://developer.x.com/en/portal/dashboard).
+2. Set up a custom auth configuration with your credentials in Composio.
+
+If you were relying on managed credentials, your Twitter integrations will stop working until you configure your own. See the [changelog entry](/docs/changelog/2026/02/12) for full details.
+
 ## Why am I getting rate limit or "UsageCapExceeded" errors on Twitter?
 
-The default OAuth app is shared across users and has strict rate limits. It works for testing, but for production use your own OAuth app.
+Twitter enforces strict rate limits per app. Use your own OAuth app with appropriate rate limit allocations for production workloads.
 
 ## Why can't I access certain Twitter API endpoints?
 


### PR DESCRIPTION
## Summary
- Adds a new FAQ entry to the Twitter toolkit page about the removal of Composio managed credentials, with migration steps and a link to the [changelog](/docs/changelog/2026/02/12)
- Updates the existing rate limit FAQ to reflect that managed credentials are no longer available

## Test plan
- [ ] Verify the FAQ renders correctly on the Twitter toolkit page
- [ ] Verify the changelog link resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)