### PR TITLE
docs: add Ask AI button to page actions

### DIFF
--- a/docs/components/ask-ai-button.tsx
+++ b/docs/components/ask-ai-button.tsx
@@ -13,7 +13,7 @@ function getDecimal() {
 
 let widgetOpen = false;
 
-function toggleDecimalWidget() {
+export function toggleDecimalWidget() {
   const decimal = getDecimal();
   if (!decimal) {
     setTimeout(() => {

--- a/docs/components/feedback.tsx
+++ b/docs/components/feedback.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useRef, useEffect } from 'react';
-import { MessageSquare, X, Loader2 } from 'lucide-react';
+import { PenLine, X, Loader2 } from 'lucide-react';
 
 type Sentiment = 'positive' | 'neutral' | 'negative' | null;
 
@@ -91,7 +91,7 @@ export function Feedback({ page }: FeedbackProps) {
           motion-reduce:transition-none motion-reduce:active:scale-100"
         aria-label="Share feedback about this page"
       >
-        <MessageSquare className="size-3.5" aria-hidden="true" />
+        <PenLine className="size-3.5" aria-hidden="true" />
         <span>Feedback</span>
       </button>
 

--- a/docs/components/page-actions.tsx
+++ b/docs/components/page-actions.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { useState, useCallback } from 'react';
-import { Copy, Check, Loader2, ExternalLink } from 'lucide-react';
+import { Copy, Check, Loader2, ExternalLink, BotMessageSquare } from 'lucide-react';
 import { Feedback } from './feedback';
+import { toggleDecimalWidget } from './ask-ai-button';
 
 interface PageActionsProps {
   path: string;
@@ -132,6 +133,25 @@ export function PageActions({ path }: PageActionsProps) {
         role="separator"
         aria-orientation="vertical"
       />
+
+      {/* Ask AI */}
+      <button
+        type="button"
+        onClick={toggleDecimalWidget}
+        className="inline-flex items-center gap-1.5 px-3 py-2 sm:px-2.5 sm:py-1.5 text-xs font-medium
+          text-fd-muted-foreground hover:text-fd-foreground
+          bg-fd-secondary/50 hover:bg-fd-secondary
+          rounded-md
+          transition-all duration-150 ease-out
+          focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fd-ring focus-visible:ring-offset-2 focus-visible:ring-offset-fd-background
+          active:scale-[0.98]
+          touch-manipulation
+          motion-reduce:transition-none motion-reduce:active:scale-100"
+        aria-label="Ask AI"
+      >
+        <BotMessageSquare className="size-3.5" aria-hidden="true" />
+        <span>Ask AI</span>
+      </button>
 
       {/* Feedback */}
       <Feedback page={path} />


### PR DESCRIPTION
## Summary
- Add "Ask AI" button to page actions bar (opens Decimal AI widget) next to Copy page, Markdown, and Feedback
- Export `toggleDecimalWidget` from `ask-ai-button.tsx` for reuse across components
- Update Feedback icon from `MessageSquare` to `PenLine` for visual distinction

## Test plan
- [ ] Open any docs page and verify "Ask AI" button appears in page actions
- [ ] Click "Ask AI" — verify Decimal widget opens
- [ ] Click "Feedback" — verify feedback dialog still works
- [ ] Verify icons are visually distinct (BotMessageSquare for AI, PenLine for Feedback)
- [ ] `bun run build` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)