### PR TITLE
docs: add default links and Ask AI to search dialog

### DIFF
--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -114,6 +114,7 @@ export default function Layout({ children }: LayoutProps<'/'>) {
             search={{
               SearchDialog: CustomSearchDialog,
               options: {
+                api: '/api/search',
                 defaultLinks,
               } as Record<string, unknown>,
             }}

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -5,6 +5,22 @@ import './global.css';
 import { Inter, IBM_Plex_Mono } from 'next/font/google';
 import { PostHogProvider } from '@/components/posthog-provider';
 import { DecimalWidget } from '@/components/decimal-widget';
+import CustomSearchDialog from '@/components/custom-search-dialog';
+import { source } from '@/lib/source';
+
+const defaultLinkSlugs = [
+  ['quickstart'],
+  ['authentication'],
+  ['configuring-sessions'],
+  ['common-faq'],
+  ['troubleshooting'],
+];
+
+const defaultLinks = defaultLinkSlugs.flatMap((slug) => {
+  const page = source.getPage(slug);
+  if (!page) return [];
+  return [{ title: page.data.title, description: page.data.description ?? '', href: page.url }];
+});
 
 export const metadata: Metadata = {
   title: {
@@ -96,9 +112,10 @@ export default function Layout({ children }: LayoutProps<'/'>) {
               enableSystem: true,
             }}
             search={{
+              SearchDialog: CustomSearchDialog,
               options: {
-                api: '/api/search',
-              },
+                defaultLinks,
+              } as Record<string, unknown>,
             }}
           >
             {children}

--- a/docs/components/ask-ai-button.tsx
+++ b/docs/components/ask-ai-button.tsx
@@ -13,7 +13,7 @@ function getDecimal() {
 
 let widgetOpen = false;
 
-function toggleDecimalWidget() {
+export function toggleDecimalWidget() {
   const decimal = getDecimal();
   if (!decimal) {
     setTimeout(() => {

--- a/docs/components/custom-search-dialog.tsx
+++ b/docs/components/custom-search-dialog.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import {
   SearchDialog,
@@ -16,6 +17,14 @@ import { useI18n } from 'fumadocs-ui/contexts/i18n';
 import { useDocsSearch } from 'fumadocs-core/search/client';
 import { BotMessageSquare } from 'lucide-react';
 import { toggleDecimalWidget } from './ask-ai-button';
+
+function MetaKey() {
+  const [key, setKey] = useState('⌘');
+  useEffect(() => {
+    if (!navigator.platform.toUpperCase().includes('MAC')) setKey('Ctrl');
+  }, []);
+  return key;
+}
 
 export interface DefaultLink {
   title: string;
@@ -73,7 +82,7 @@ export default function CustomSearchDialog({
         ) : (
           <SearchDialogList items={query.data === 'empty' ? null : query.data} />
         )}
-        <div className="border-t px-3 py-2">
+        <div className="flex items-center justify-between border-t px-3 py-2">
           <button
             type="button"
             className="inline-flex items-center gap-1.5 text-xs text-fd-muted-foreground hover:text-fd-foreground transition-colors"
@@ -85,6 +94,14 @@ export default function CustomSearchDialog({
             <BotMessageSquare className="size-3.5" />
             You can also Ask AI
           </button>
+          <div className="inline-flex gap-0.5">
+            <kbd className="rounded-md border bg-fd-background px-1.5 text-xs text-fd-muted-foreground">
+              <MetaKey />
+            </kbd>
+            <kbd className="rounded-md border bg-fd-background px-1.5 text-xs text-fd-muted-foreground">
+              I
+            </kbd>
+          </div>
         </div>
       </SearchDialogContent>
     </SearchDialog>

--- a/docs/components/custom-search-dialog.tsx
+++ b/docs/components/custom-search-dialog.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import Link from 'next/link';
+import {
+  SearchDialog,
+  SearchDialogClose,
+  SearchDialogContent,
+  SearchDialogHeader,
+  SearchDialogIcon,
+  SearchDialogInput,
+  SearchDialogList,
+  SearchDialogOverlay,
+  type SharedProps,
+} from 'fumadocs-ui/components/dialog/search';
+import { useI18n } from 'fumadocs-ui/contexts/i18n';
+import { useDocsSearch } from 'fumadocs-core/search/client';
+import { BotMessageSquare } from 'lucide-react';
+import { toggleDecimalWidget } from './ask-ai-button';
+
+export interface DefaultLink {
+  title: string;
+  description: string;
+  href: string;
+}
+
+interface CustomSearchDialogProps extends SharedProps {
+  defaultLinks?: DefaultLink[];
+}
+
+export default function CustomSearchDialog({
+  defaultLinks = [],
+  ...props
+}: CustomSearchDialogProps) {
+  const { locale } = useI18n();
+  const { search, setSearch, query } = useDocsSearch({
+    type: 'fetch',
+    locale,
+    api: '/api/search',
+  });
+
+  const isEmpty = query.data === 'empty';
+
+  return (
+    <SearchDialog
+      search={search}
+      onSearchChange={setSearch}
+      isLoading={query.isLoading}
+      {...props}
+    >
+      <SearchDialogOverlay />
+      <SearchDialogContent>
+        <SearchDialogHeader>
+          <SearchDialogIcon />
+          <SearchDialogInput />
+          <SearchDialogClose />
+        </SearchDialogHeader>
+        {isEmpty && defaultLinks.length > 0 ? (
+          <div className="flex flex-col p-2">
+            {defaultLinks.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                onClick={() => props.onOpenChange(false)}
+                className="rounded-lg px-2.5 py-2 text-start text-sm transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground"
+              >
+                <p className="font-medium">{link.title}</p>
+                <p className="text-xs text-fd-muted-foreground">
+                  {link.description}
+                </p>
+              </Link>
+            ))}
+          </div>
+        ) : (
+          <SearchDialogList items={query.data === 'empty' ? null : query.data} />
+        )}
+        <div className="border-t px-3 py-2">
+          <button
+            type="button"
+            className="inline-flex items-center gap-1.5 text-xs text-fd-muted-foreground hover:text-fd-foreground transition-colors"
+            onClick={() => {
+              props.onOpenChange(false);
+              toggleDecimalWidget();
+            }}
+          >
+            <BotMessageSquare className="size-3.5" />
+            You can also Ask AI
+          </button>
+        </div>
+      </SearchDialogContent>
+    </SearchDialog>
+  );
+}

--- a/docs/components/custom-search-dialog.tsx
+++ b/docs/components/custom-search-dialog.tsx
@@ -25,20 +25,20 @@ export interface DefaultLink {
 
 interface CustomSearchDialogProps extends SharedProps {
   defaultLinks?: DefaultLink[];
+  api?: string;
 }
 
 export default function CustomSearchDialog({
   defaultLinks = [],
+  api = '/api/search',
   ...props
 }: CustomSearchDialogProps) {
   const { locale } = useI18n();
   const { search, setSearch, query } = useDocsSearch({
     type: 'fetch',
     locale,
-    api: '/api/search',
+    api,
   });
-
-  const isEmpty = query.data === 'empty';
 
   return (
     <SearchDialog
@@ -54,7 +54,7 @@ export default function CustomSearchDialog({
           <SearchDialogInput />
           <SearchDialogClose />
         </SearchDialogHeader>
-        {isEmpty && defaultLinks.length > 0 ? (
+        {query.data === 'empty' && defaultLinks.length > 0 ? (
           <div className="flex flex-col p-2">
             {defaultLinks.map((link) => (
               <Link


### PR DESCRIPTION
## Summary
- Custom search dialog replaces the default Fumadocs dialog
- Shows quick-access links with subtitles (title + description from MDX frontmatter) when search query is empty: Quickstart, Authentication, Configuring Sessions, General FAQs, Troubleshooting
- Adds "You can also Ask AI" button inside the dialog content that opens the Decimal widget
- Titles and descriptions are derived from page frontmatter at build time via `source.getPage()`, so they stay in sync automatically

## Test plan
- [ ] Open search dialog (Cmd+K) — verify 5 default links with subtitles appear
- [ ] Type a query — verify links disappear and search results show
- [ ] Click a default link — verify navigation works and dialog closes
- [ ] Click "Ask AI" — verify dialog closes and Decimal widget opens
- [ ] `bun run build` passes with no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)