### PR TITLE
fix(python): handle missing JSON schema titles in json_schema_to_model

### DIFF
--- a/python/composio/utils/shared.py
+++ b/python/composio/utils/shared.py
@@ -194,8 +194,16 @@ def json_schema_to_model(
     :param skip_default: Skip the default values when building field object
     :return: Pydantic `BaseModel` type
     """
-    model_name = json_schema.get("title")
-    field_definitions = {}
+    model_name = json_schema.get("title") or json_schema.get("name")
+    # Pydantic requires a string model name. Some tool schemas contain anonymous
+    # nested objects (e.g., array items) and/or omit a title entirely.
+    if not model_name or model_name == "null":
+        model_name = f"GeneratedModel_{uuid.uuid4().hex}"
+    model_name = str(model_name).replace(" ", "")
+    if not model_name:
+        model_name = f"GeneratedModel_{uuid.uuid4().hex}"
+
+    field_definitions: t.Dict[str, t.Any] = {}
     for name, prop in json_schema.get("properties", {}).items():
         updated_name, pydantic_type, pydantic_field = json_schema_to_pydantic_field(
             name,

--- a/python/tests/test_json_schema_to_model_missing_title.py
+++ b/python/tests/test_json_schema_to_model_missing_title.py
@@ -1,0 +1,30 @@
+"""Tests for json_schema_to_model robustness."""
+
+from composio.utils.shared import json_schema_to_model
+
+
+def test_json_schema_to_model_generates_name_when_title_missing() -> None:
+    """Anonymous/untitled schemas should not crash create_model."""
+    schema = {
+        "type": "object",
+        # Intentionally omit "title" to match real-world tool schemas.
+        "properties": {
+            "items": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    # Intentionally omit nested object title.
+                    "properties": {"a": {"type": "string"}},
+                    "required": ["a"],
+                },
+            }
+        },
+        "required": ["items"],
+    }
+
+    Model = json_schema_to_model(schema)
+    assert isinstance(Model.__name__, str)
+    assert Model.__name__
+
+    instance = Model(items=[{"a": "x"}])
+    assert instance.items[0].a == "x"


### PR DESCRIPTION
Fixes #2435

### Problem
The Python helper `json_schema_to_model` could pass a null/None model name into `pydantic.create_model` when the JSON schema omitted `title` (common for anonymous nested object schemas, e.g. array items). This raises:

```
TypeError: type.__new__() argument 1 must be str, not None
```

### Fix
- Fall back to `name` and finally a generated model name when `title` is missing
- Add a regression test for an object schema containing an array of anonymous objects

### Validation
- `pytest -q python/tests/test_json_schema_to_model_missing_title.py`
- `ruff check python/composio/utils/shared.py python/tests/test_json_schema_to_model_missing_title.py`