### PR TITLE
docs: style Ask AI buttons with composio orange

### DIFF
--- a/docs/components/ask-ai-button.tsx
+++ b/docs/components/ask-ai-button.tsx
@@ -78,7 +78,7 @@ export function SearchAndAskAI() {
       <button
         type="button"
         onClick={toggleDecimalWidget}
-        className="inline-flex items-center gap-2 rounded-lg border bg-fd-secondary/50 p-1.5 ps-2.5 text-sm text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground shrink-0"
+        className="inline-flex items-center gap-2 rounded-lg border border-[var(--composio-orange)]/20 bg-[var(--composio-orange)]/5 p-1.5 ps-2.5 text-sm text-[var(--composio-orange)] transition-colors hover:bg-[var(--composio-orange)]/10 shrink-0"
       >
         Ask AI
         <div className="hidden xl:inline-flex gap-0.5">

--- a/docs/components/custom-search-dialog.tsx
+++ b/docs/components/custom-search-dialog.tsx
@@ -85,7 +85,7 @@ export default function CustomSearchDialog({
         <div className="flex items-center justify-between border-t px-3 py-2">
           <button
             type="button"
-            className="inline-flex items-center gap-1.5 text-xs text-fd-muted-foreground hover:text-fd-foreground transition-colors"
+            className="inline-flex items-center gap-1.5 text-xs text-[var(--composio-orange)] hover:text-[var(--composio-orange)]/80 transition-colors"
             onClick={() => {
               props.onOpenChange(false);
               toggleDecimalWidget();


### PR DESCRIPTION
## Summary
- Navbar "Ask AI" button: orange text, subtle orange background (5%), soft orange border (20%), darker hover (10%)
- Search dialog "Ask AI" footer: orange text to match

## Test plan
- [ ] Check navbar "Ask AI" button stands out in both light and dark mode
- [ ] Open search dialog (Cmd+K) — verify "You can also Ask AI" text is orange
- [ ] Both buttons remain readable and not too loud

🤖 Generated with [Claude Code](https://claude.com/claude-code)