### PR TITLE
fix: robust platform detection for Ask AI shortcut

### DIFF
--- a/docs/components/ask-ai-button.tsx
+++ b/docs/components/ask-ai-button.tsx
@@ -26,10 +26,21 @@ export function toggleDecimalWidget() {
   widgetOpen = !widgetOpen;
 }
 
+function detectMac(): boolean {
+  try {
+    if ('userAgentData' in navigator) {
+      return (navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData?.platform === 'macOS';
+    }
+    return /mac/i.test(navigator.platform);
+  } catch {
+    return true; // default to Mac
+  }
+}
+
 function useIsMac() {
   const [isMac, setIsMac] = useState(true);
   useEffect(() => {
-    setIsMac(navigator.platform.toUpperCase().includes('MAC'));
+    setIsMac(detectMac());
   }, []);
   return isMac;
 }

--- a/docs/components/ask-ai-button.tsx
+++ b/docs/components/ask-ai-button.tsx
@@ -29,7 +29,10 @@ export function toggleDecimalWidget() {
 export function detectMac(): boolean {
   try {
     if ('userAgentData' in navigator) {
-      return (navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData?.platform === 'macOS';
+      const platform = (navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData?.platform;
+      if (platform) {
+        return platform === 'macOS';
+      }
     }
     return /mac/i.test(navigator.platform);
   } catch {

--- a/docs/components/ask-ai-button.tsx
+++ b/docs/components/ask-ai-button.tsx
@@ -26,7 +26,7 @@ export function toggleDecimalWidget() {
   widgetOpen = !widgetOpen;
 }
 
-function detectMac(): boolean {
+export function detectMac(): boolean {
   try {
     if ('userAgentData' in navigator) {
       return (navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData?.platform === 'macOS';

--- a/docs/components/custom-search-dialog.tsx
+++ b/docs/components/custom-search-dialog.tsx
@@ -18,10 +18,21 @@ import { useDocsSearch } from 'fumadocs-core/search/client';
 import { BotMessageSquare } from 'lucide-react';
 import { toggleDecimalWidget } from './ask-ai-button';
 
+function detectMac(): boolean {
+  try {
+    if ('userAgentData' in navigator) {
+      return (navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData?.platform === 'macOS';
+    }
+    return /mac/i.test(navigator.platform);
+  } catch {
+    return true; // default to Mac
+  }
+}
+
 function MetaKey() {
   const [key, setKey] = useState('⌘');
   useEffect(() => {
-    if (!navigator.platform.toUpperCase().includes('MAC')) setKey('Ctrl');
+    if (!detectMac()) setKey('Ctrl');
   }, []);
   return key;
 }

--- a/docs/components/custom-search-dialog.tsx
+++ b/docs/components/custom-search-dialog.tsx
@@ -16,18 +16,7 @@ import {
 import { useI18n } from 'fumadocs-ui/contexts/i18n';
 import { useDocsSearch } from 'fumadocs-core/search/client';
 import { BotMessageSquare } from 'lucide-react';
-import { toggleDecimalWidget } from './ask-ai-button';
-
-function detectMac(): boolean {
-  try {
-    if ('userAgentData' in navigator) {
-      return (navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData?.platform === 'macOS';
-    }
-    return /mac/i.test(navigator.platform);
-  } catch {
-    return true; // default to Mac
-  }
-}
+import { toggleDecimalWidget, detectMac } from './ask-ai-button';
 
 function MetaKey() {
   const [key, setKey] = useState('⌘');


### PR DESCRIPTION
## Summary
- `navigator.platform` is deprecated and returns unexpected values in embedded browsers (e.g. ChatGPT Atlas), causing the ⌘I shortcut hint to not display on Mac
- Use `navigator.userAgentData.platform` (modern API) with `navigator.platform` fallback, defaulting to Mac if detection fails

## Test plan
- [ ] Verify ⌘I shortcut hint shows on Mac in Chrome/Safari/Firefox
- [ ] Verify Ctrl+I shows on Windows/Linux
- [ ] Verify shortcut displays correctly in ChatGPT Atlas on Mac

🤖 Generated with [Claude Code](https://claude.com/claude-code)