### PR TITLE
fix: Ask AI shortcut not showing in embedded browsers

### DIFF
--- a/docs/components/ask-ai-button.tsx
+++ b/docs/components/ask-ai-button.tsx
@@ -95,7 +95,7 @@ export function SearchAndAskAI() {
         className="inline-flex items-center gap-2 rounded-lg border border-[var(--composio-orange)]/20 bg-[var(--composio-orange)]/5 p-1.5 ps-2.5 text-sm text-[var(--composio-orange)] transition-colors hover:bg-[var(--composio-orange)]/10 shrink-0"
       >
         Ask AI
-        <div className="hidden xl:inline-flex gap-0.5">
+        <div className="hidden lg:inline-flex gap-0.5">
           <kbd className="rounded-md border bg-fd-background px-1.5">{isMac ? '⌘' : 'Ctrl'}</kbd>
           <kbd className="rounded-md border bg-fd-background px-1.5">I</kbd>
         </div>

--- a/docs/components/ask-ai-button.tsx
+++ b/docs/components/ask-ai-button.tsx
@@ -26,10 +26,21 @@ export function toggleDecimalWidget() {
   widgetOpen = !widgetOpen;
 }
 
+function detectMac(): boolean {
+  try {
+    if ('userAgentData' in navigator) {
+      return (navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData?.platform === 'macOS';
+    }
+    return /mac/i.test(navigator.platform);
+  } catch {
+    return true; // default to Mac
+  }
+}
+
 function useIsMac() {
   const [isMac, setIsMac] = useState(true);
   useEffect(() => {
-    setIsMac(navigator.platform.toUpperCase().includes('MAC'));
+    setIsMac(detectMac());
   }, []);
   return isMac;
 }

--- a/docs/components/ask-ai-button.tsx
+++ b/docs/components/ask-ai-button.tsx
@@ -29,7 +29,10 @@ export function toggleDecimalWidget() {
 export function detectMac(): boolean {
   try {
     if ('userAgentData' in navigator) {
-      return (navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData?.platform === 'macOS';
+      const platform = (navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData?.platform;
+      if (platform) {
+        return platform === 'macOS';
+      }
     }
     return /mac/i.test(navigator.platform);
   } catch {

--- a/docs/components/ask-ai-button.tsx
+++ b/docs/components/ask-ai-button.tsx
@@ -26,7 +26,7 @@ export function toggleDecimalWidget() {
   widgetOpen = !widgetOpen;
 }
 
-function detectMac(): boolean {
+export function detectMac(): boolean {
   try {
     if ('userAgentData' in navigator) {
       return (navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData?.platform === 'macOS';

--- a/docs/components/custom-search-dialog.tsx
+++ b/docs/components/custom-search-dialog.tsx
@@ -18,10 +18,21 @@ import { useDocsSearch } from 'fumadocs-core/search/client';
 import { BotMessageSquare } from 'lucide-react';
 import { toggleDecimalWidget } from './ask-ai-button';
 
+function detectMac(): boolean {
+  try {
+    if ('userAgentData' in navigator) {
+      return (navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData?.platform === 'macOS';
+    }
+    return /mac/i.test(navigator.platform);
+  } catch {
+    return true; // default to Mac
+  }
+}
+
 function MetaKey() {
   const [key, setKey] = useState('⌘');
   useEffect(() => {
-    if (!navigator.platform.toUpperCase().includes('MAC')) setKey('Ctrl');
+    if (!detectMac()) setKey('Ctrl');
   }, []);
   return key;
 }

--- a/docs/components/custom-search-dialog.tsx
+++ b/docs/components/custom-search-dialog.tsx
@@ -16,18 +16,7 @@ import {
 import { useI18n } from 'fumadocs-ui/contexts/i18n';
 import { useDocsSearch } from 'fumadocs-core/search/client';
 import { BotMessageSquare } from 'lucide-react';
-import { toggleDecimalWidget } from './ask-ai-button';
-
-function detectMac(): boolean {
-  try {
-    if ('userAgentData' in navigator) {
-      return (navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData?.platform === 'macOS';
-    }
-    return /mac/i.test(navigator.platform);
-  } catch {
-    return true; // default to Mac
-  }
-}
+import { toggleDecimalWidget, detectMac } from './ask-ai-button';
 
 function MetaKey() {
   const [key, setKey] = useState('⌘');


### PR DESCRIPTION
## Summary
- Replace deprecated `navigator.platform` with `navigator.userAgentData.platform` (modern API), falling back to `navigator.platform` regex, defaulting to Mac on failure
- Fix early-return bug where `userAgentData` exists but `platform` is undefined (e.g. ChatGPT Atlas) — now falls through to the regex fallback
- Deduplicate `detectMac` into a single export from `ask-ai-button.tsx`
- Lower shortcut hint breakpoint from `xl` (1280px) to `lg` (1024px) so it shows in narrower desktop viewports

## Test plan
- [ ] Verify ⌘I hint shows on Mac in Chrome/Safari/Firefox
- [ ] Verify Ctrl+I shows on Windows/Linux
- [ ] Verify shortcut displays in ChatGPT Atlas on Mac
- [ ] Verify layout doesn't squeeze at ~1024px viewport width

🤖 Generated with [Claude Code](https://claude.com/claude-code)