### PR TITLE
wip: feat(sdk): add allow_shared_connected_accounts and top-level assistive_prompt_config

### DIFF
--- a/python/composio/core/models/tool_router.py
+++ b/python/composio/core/models/tool_router.py
@@ -202,7 +202,8 @@ class ToolRouterExperimentalConfig(te.TypedDict, total=False):
     Note: These features are experimental and may be modified or removed in future versions.
 
     Attributes:
-        assistive_prompt: Configuration for assistive prompt generation.
+        assistive_prompt: [Deprecated] Use top-level assistive_prompt parameter instead.
+                         Kept for backward compatibility.
     """
 
     assistive_prompt: ToolRouterAssistivePromptConfig
@@ -801,7 +802,9 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
         ] = None,
         auth_configs: t.Optional[t.Dict[str, str]] = None,
         connected_accounts: t.Optional[t.Dict[str, str]] = None,
+        allow_shared_connected_accounts: t.Optional[bool] = None,
         workbench: t.Optional[ToolRouterWorkbenchConfig] = None,
+        assistive_prompt: t.Optional[ToolRouterAssistivePromptConfig] = None,
         experimental: t.Optional[ToolRouterExperimentalConfig] = None,
     ) -> ToolRouterSession[TTool, TToolCollection]:
         """
@@ -857,7 +860,14 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
         :param auth_configs: Optional mapping of toolkit slug to auth config ID.
                            Example: {'github': 'ac_xxx', 'slack': 'ac_yyy'}
         :param connected_accounts: Optional mapping of toolkit slug to connected account ID.
+                                  By default these must belong to the same user_id as the session
+                                  unless allow_shared_connected_accounts is True.
                                   Example: {'github': 'ca_xxx', 'slack': 'ca_yyy'}
+        :param allow_shared_connected_accounts: When True, explicit connected account overrides
+                                               may reference accounts belonging to a different user.
+                                               Use for intentionally shared, non-user-scoped services
+                                               (e.g., shared Firecrawl or Datadog accounts). Default False.
+                                               Example: True
         :param workbench: Optional workbench configuration (ToolRouterWorkbenchConfig).
                          Dict with:
                          - 'enable_proxy_execution' (bool): Whether to allow proxy execute
@@ -865,8 +875,14 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
                          - 'auto_offload_threshold' (int): Maximum execution payload size to
                            offload to workbench.
                          Example: {'enable_proxy_execution': False, 'auto_offload_threshold': 300}
-        :param experimental: Optional experimental configuration (ToolRouterExperimentalConfig).
-                            Note: These features are experimental and may change.
+        :param assistive_prompt: Optional assistive prompt configuration.
+                               Takes priority over experimental.assistive_prompt.
+                               Dict with:
+                               - 'user_timezone' (str): IANA timezone identifier
+                                 (e.g., "America/New_York", "Europe/London").
+                               Example: {'user_timezone': 'America/New_York'}
+        :param experimental: [Deprecated] Optional experimental configuration.
+                            Use top-level assistive_prompt instead.
                             Dict with:
                             - 'assistive_prompt' (dict): Configuration for assistive prompt generation.
                               - 'user_timezone' (str): IANA timezone identifier
@@ -1035,6 +1051,11 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
         if connected_accounts is not None:
             create_params["connected_accounts"] = connected_accounts
 
+        if allow_shared_connected_accounts is not None:
+            create_params["allow_shared_connected_accounts"] = (
+                allow_shared_connected_accounts
+            )
+
         if toolkits_payload is not None:
             create_params["toolkits"] = toolkits_payload
 
@@ -1060,20 +1081,27 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
             if execution_payload:
                 create_params["workbench"] = execution_payload
 
-        # Build experimental config
-        # Map SDK's experimental.assistive_prompt.user_timezone to API's
-        # experimental.assistive_prompt_config.user_timezone
-        if experimental is not None:
-            assistive_prompt_config = experimental.get("assistive_prompt")
-            if assistive_prompt_config is not None:
-                user_timezone = assistive_prompt_config.get("user_timezone")
-                # Only include if user_timezone is a non-empty string
-                if user_timezone:
-                    create_params["experimental"] = {
-                        "assistive_prompt_config": {
-                            "user_timezone": user_timezone,
-                        }
-                    }
+        # Resolve assistive prompt config: top-level takes priority over deprecated
+        # experimental path. Maps to API's assistive_prompt_config.user_timezone
+        resolved_timezone: t.Optional[str] = None
+        if assistive_prompt is not None:
+            resolved_timezone = assistive_prompt.get("user_timezone") or None
+        if not resolved_timezone and experimental is not None:
+            exp_prompt = experimental.get("assistive_prompt")
+            if exp_prompt is not None:
+                resolved_timezone = exp_prompt.get("user_timezone") or None
+
+        if resolved_timezone:
+            # Send as top-level assistive_prompt_config
+            create_params["assistive_prompt_config"] = {
+                "user_timezone": resolved_timezone,
+            }
+            # Also send via experimental for backward compat with older API versions
+            create_params["experimental"] = {
+                "assistive_prompt_config": {
+                    "user_timezone": resolved_timezone,
+                }
+            }
 
         # Make API call to create session
         session = self._client.tool_router.session.create(**create_params)

--- a/python/tests/test_tool_router.py
+++ b/python/tests/test_tool_router.py
@@ -585,7 +585,10 @@ class TestToolRouter:
         assert kwargs["assistive_prompt_config"] == {
             "user_timezone": "Asia/Tokyo",
         }
-        assert kwargs["experimental"]["assistive_prompt_config"]["user_timezone"] == "Asia/Tokyo"
+        assert (
+            kwargs["experimental"]["assistive_prompt_config"]["user_timezone"]
+            == "Asia/Tokyo"
+        )
 
     def test_create_session_with_workbench_config(self, tool_router, mock_client):
         """Test creating a session with workbench configuration."""

--- a/python/tests/test_tool_router.py
+++ b/python/tests/test_tool_router.py
@@ -496,6 +496,97 @@ class TestToolRouter:
         kwargs = call_args.kwargs
         assert kwargs["connected_accounts"] == {"github": "ca_xxx", "slack": "ca_yyy"}
 
+    def test_create_session_with_allow_shared_connected_accounts_true(
+        self, tool_router, mock_client
+    ):
+        """Test creating a session with allow_shared_connected_accounts=True."""
+        session = tool_router.create(
+            user_id="user_123",
+            connected_accounts={"datadog": "ca_shared123"},
+            allow_shared_connected_accounts=True,
+        )
+
+        assert session.session_id == "session_123"
+
+        call_args = mock_client.tool_router.session.create.call_args
+        kwargs = call_args.kwargs
+        assert kwargs["connected_accounts"] == {"datadog": "ca_shared123"}
+        assert kwargs["allow_shared_connected_accounts"] is True
+
+    def test_create_session_with_allow_shared_connected_accounts_false(
+        self, tool_router, mock_client
+    ):
+        """Test creating a session with allow_shared_connected_accounts=False."""
+        session = tool_router.create(
+            user_id="user_123",
+            allow_shared_connected_accounts=False,
+        )
+
+        assert session.session_id == "session_123"
+
+        call_args = mock_client.tool_router.session.create.call_args
+        kwargs = call_args.kwargs
+        assert kwargs["allow_shared_connected_accounts"] is False
+
+    def test_create_session_without_allow_shared_connected_accounts(
+        self, tool_router, mock_client
+    ):
+        """Test that allow_shared_connected_accounts is not sent when not provided."""
+        session = tool_router.create(user_id="user_123")
+
+        assert session.session_id == "session_123"
+
+        call_args = mock_client.tool_router.session.create.call_args
+        kwargs = call_args.kwargs
+        assert "allow_shared_connected_accounts" not in kwargs
+
+    def test_create_session_with_top_level_assistive_prompt(
+        self, tool_router, mock_client
+    ):
+        """Test creating a session with top-level assistive_prompt config."""
+        session = tool_router.create(
+            user_id="user_123",
+            assistive_prompt={"user_timezone": "Asia/Tokyo"},
+        )
+
+        assert session.session_id == "session_123"
+
+        call_args = mock_client.tool_router.session.create.call_args
+        kwargs = call_args.kwargs
+        assert kwargs["assistive_prompt_config"] == {
+            "user_timezone": "Asia/Tokyo",
+        }
+        # Should also be sent via experimental for backward compat
+        assert kwargs["experimental"] == {
+            "assistive_prompt_config": {
+                "user_timezone": "Asia/Tokyo",
+            }
+        }
+
+    def test_create_session_assistive_prompt_priority_over_experimental(
+        self, tool_router, mock_client
+    ):
+        """Test that top-level assistive_prompt takes priority over experimental."""
+        session = tool_router.create(
+            user_id="user_123",
+            assistive_prompt={"user_timezone": "Asia/Tokyo"},
+            experimental={
+                "assistive_prompt": {
+                    "user_timezone": "Europe/London",
+                }
+            },
+        )
+
+        assert session.session_id == "session_123"
+
+        call_args = mock_client.tool_router.session.create.call_args
+        kwargs = call_args.kwargs
+        # Top-level should win
+        assert kwargs["assistive_prompt_config"] == {
+            "user_timezone": "Asia/Tokyo",
+        }
+        assert kwargs["experimental"]["assistive_prompt_config"]["user_timezone"] == "Asia/Tokyo"
+
     def test_create_session_with_workbench_config(self, tool_router, mock_client):
         """Test creating a session with workbench configuration."""
         session = tool_router.create(
@@ -545,7 +636,7 @@ class TestToolRouter:
         assert "workbench" in kwargs
 
     def test_create_session_with_experimental_config(self, tool_router, mock_client):
-        """Test creating a session with experimental configuration."""
+        """Test creating a session with experimental configuration (backward compat)."""
         session = tool_router.create(
             user_id="user_123",
             experimental={
@@ -557,7 +648,7 @@ class TestToolRouter:
 
         assert session.session_id == "session_123"
 
-        # Verify the API was called with experimental config transformed correctly
+        # Verify the API was called with both top-level and experimental config
         call_args = mock_client.tool_router.session.create.call_args
         kwargs = call_args.kwargs
         assert "experimental" in kwargs
@@ -565,6 +656,10 @@ class TestToolRouter:
             "assistive_prompt_config": {
                 "user_timezone": "America/New_York",
             }
+        }
+        # Should also send top-level assistive_prompt_config
+        assert kwargs["assistive_prompt_config"] == {
+            "user_timezone": "America/New_York",
         }
 
     def test_create_session_with_experimental_empty_config(

--- a/ts/packages/core/src/models/ToolRouter.ts
+++ b/ts/packages/core/src/models/ToolRouter.ts
@@ -254,10 +254,18 @@ export class ToolRouter<
   ): Promise<ToolRouterSession<TToolCollection, TTool, TProvider>> {
     const routerConfig = ToolRouterCreateSessionConfigSchema.parse(config ?? {});
 
+    // Resolve assistive prompt config: top-level takes priority over deprecated experimental path
+    const resolvedTimezone =
+      routerConfig.assistivePrompt?.userTimezone ||
+      routerConfig.experimental?.assistivePrompt?.userTimezone;
+
     const payload: SessionCreateParams = {
       user_id: userId,
       auth_configs: routerConfig.authConfigs,
       connected_accounts: routerConfig.connectedAccounts,
+      ...(routerConfig.allowSharedConnectedAccounts !== undefined && {
+        allow_shared_connected_accounts: routerConfig.allowSharedConnectedAccounts,
+      }),
       toolkits: transformToolRouterToolkitsParams(routerConfig.toolkits),
       tools: transformToolRouterToolsParams(routerConfig.tools),
       tags: transformToolRouterTagsParams(routerConfig.tags),
@@ -265,11 +273,19 @@ export class ToolRouter<
         routerConfig.manageConnections
       ),
       workbench: transformToolRouterWorkbenchParams(routerConfig.workbench),
-      // Map SDK's experimental.assistivePrompt.userTimezone to API's experimental.assistive_prompt_config.user_timezone
-      experimental: routerConfig.experimental?.assistivePrompt?.userTimezone
+      // Map resolved assistive prompt config to top-level API field
+      ...(resolvedTimezone
         ? {
             assistive_prompt_config: {
-              user_timezone: routerConfig.experimental.assistivePrompt.userTimezone,
+              user_timezone: resolvedTimezone,
+            },
+          }
+        : {}),
+      // Also send via experimental for backward compatibility with older API versions
+      experimental: resolvedTimezone
+        ? {
+            assistive_prompt_config: {
+              user_timezone: resolvedTimezone,
             },
           }
         : undefined,

--- a/ts/packages/core/src/types/toolRouter.types.ts
+++ b/ts/packages/core/src/types/toolRouter.types.ts
@@ -173,9 +173,15 @@ export const ToolRouterCreateSessionConfigSchema = z
     connectedAccounts: z
       .record(z.string(), z.string())
       .describe(
-        'The connected accounts to use in the tool router session. The key is the toolkit slug, the value is the connected account id.'
+        'The connected accounts to use in the tool router session. The key is the toolkit slug, the value is the connected account id. By default these must belong to the same user_id as the session unless allowSharedConnectedAccounts is true.'
       )
       .default({}),
+    allowSharedConnectedAccounts: z
+      .boolean()
+      .optional()
+      .describe(
+        'When true, explicit connected account overrides may reference accounts belonging to a different user. Use this for intentionally shared, non-user-scoped services (e.g., shared Firecrawl or Datadog accounts). Default false.'
+      ),
     manageConnections: z
       .union([z.boolean(), ToolRouterConfigManageConnectionsSchema])
       .optional()
@@ -183,12 +189,27 @@ export const ToolRouterCreateSessionConfigSchema = z
       .describe(
         'The config for the manage connections in the tool router session. Defaults to true, if set to false, you need to manage connections manually. If set to an object, you can configure the manage connections settings.'
       ),
+    assistivePrompt: z
+      .object({
+        userTimezone: z
+          .string()
+          .optional()
+          .describe(
+            'IANA timezone identifier (e.g., "America/New_York", "Europe/London") for timezone-aware assistive prompts'
+          ),
+      })
+      .optional()
+      .describe(
+        'Configuration for assistive prompt generation. Takes priority over experimental.assistivePrompt.'
+      ),
     workbench: z
       .object({
         enableProxyExecution: z
           .boolean()
           .optional()
-          .describe('Whether to enable proxy execution in the tool router session'),
+          .describe(
+            'When true, enables direct API execution from workbench when relevant toolkit tools are not available.'
+          ),
         autoOffloadThreshold: z
           .number()
           .optional()
@@ -210,7 +231,9 @@ export const ToolRouterCreateSessionConfigSchema = z
               ),
           })
           .optional()
-          .describe('Configuration for assistive prompt generation'),
+          .describe(
+            '[Deprecated] Use top-level assistivePrompt instead. Kept for backward compatibility.'
+          ),
       })
       .optional()
       .describe('Experimental features configuration - not stable, may be modified or removed'),
@@ -224,7 +247,10 @@ export const ToolRouterCreateSessionConfigSchema = z
  * @param {Record<string, ToolRouterToolsParam | ToolRouterConfigTools>} tools - The tools to configure per toolkit (key is toolkit slug)
  * @param {Array<'readOnlyHint' | 'destructiveHint' | 'idempotentHint' | 'openWorldHint'>} tags - Global tags to filter tools by behavior
  * @param {Record<string, string>} authConfigs - The auth configs to use in the tool router session
- * @param {Record<string, string>} connectedAccounts - The connected accounts to use in the tool router session
+ * @param {Record<string, string>} connectedAccounts - The connected accounts to use in the tool router session. By default must belong to the same user_id unless allowSharedConnectedAccounts is true.
+ * @param {boolean} [allowSharedConnectedAccounts] - When true, connected account overrides may reference accounts from a different user. Default false.
+ * @param {object} [assistivePrompt] - Configuration for assistive prompt generation. Takes priority over experimental.assistivePrompt.
+ * @param {string} [assistivePrompt.userTimezone] - IANA timezone identifier for timezone-aware assistive prompts
  * @param {ToolRouterConfigManageConnectionsSchema | boolean} manageConnections - The config for the manage connections in the tool router session. Defaults to true, if set to false, you need to manage connections manually. If set to an object, you can configure the manage connections settings.
  * @param {boolean} [manageConnections.enable] - Whether to use tools to manage connections in the tool router session @default true
  * @param {string} [manageConnections.callbackUrl] - The callback url to use in the tool router session

--- a/ts/packages/core/test/models/toolRouter.test.ts
+++ b/ts/packages/core/test/models/toolRouter.test.ts
@@ -1149,8 +1149,109 @@ describe('ToolRouter', () => {
     //   });
     // });
 
-    describe('experimental configuration', () => {
-      it('should create a session with experimental assistivePrompt userTimezone', async () => {
+    describe('allowSharedConnectedAccounts', () => {
+      it('should include allow_shared_connected_accounts when set to true', async () => {
+        mockClient.toolRouter.session.create.mockResolvedValueOnce(mockSessionCreateResponse);
+
+        const config: ToolRouterCreateSessionConfig = {
+          connectedAccounts: { datadog: 'ca_shared123' },
+          allowSharedConnectedAccounts: true,
+        };
+
+        await toolRouter.create(userId, config);
+
+        expect(mockClient.toolRouter.session.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            user_id: userId,
+            connected_accounts: { datadog: 'ca_shared123' },
+            allow_shared_connected_accounts: true,
+          })
+        );
+      });
+
+      it('should include allow_shared_connected_accounts when set to false', async () => {
+        mockClient.toolRouter.session.create.mockResolvedValueOnce(mockSessionCreateResponse);
+
+        const config: ToolRouterCreateSessionConfig = {
+          allowSharedConnectedAccounts: false,
+        };
+
+        await toolRouter.create(userId, config);
+
+        expect(mockClient.toolRouter.session.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            allow_shared_connected_accounts: false,
+          })
+        );
+      });
+
+      it('should not include allow_shared_connected_accounts when not provided', async () => {
+        mockClient.toolRouter.session.create.mockResolvedValueOnce(mockSessionCreateResponse);
+
+        await toolRouter.create(userId);
+
+        const callArg = mockClient.toolRouter.session.create.mock.calls[0][0];
+        expect(callArg).not.toHaveProperty('allow_shared_connected_accounts');
+      });
+    });
+
+    describe('assistive prompt configuration', () => {
+      it('should send top-level assistive_prompt_config when assistivePrompt is provided', async () => {
+        mockClient.toolRouter.session.create.mockResolvedValueOnce(mockSessionCreateResponse);
+
+        const config: ToolRouterCreateSessionConfig = {
+          assistivePrompt: {
+            userTimezone: 'Asia/Tokyo',
+          },
+        };
+
+        await toolRouter.create(userId, config);
+
+        expect(mockClient.toolRouter.session.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            assistive_prompt_config: {
+              user_timezone: 'Asia/Tokyo',
+            },
+            experimental: {
+              assistive_prompt_config: {
+                user_timezone: 'Asia/Tokyo',
+              },
+            },
+          })
+        );
+      });
+
+      it('should prioritize top-level assistivePrompt over experimental.assistivePrompt', async () => {
+        mockClient.toolRouter.session.create.mockResolvedValueOnce(mockSessionCreateResponse);
+
+        const config: ToolRouterCreateSessionConfig = {
+          assistivePrompt: {
+            userTimezone: 'Asia/Tokyo',
+          },
+          experimental: {
+            assistivePrompt: {
+              userTimezone: 'Europe/London',
+            },
+          },
+        };
+
+        await toolRouter.create(userId, config);
+
+        expect(mockClient.toolRouter.session.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            assistive_prompt_config: {
+              user_timezone: 'Asia/Tokyo',
+            },
+            experimental: {
+              assistive_prompt_config: {
+                user_timezone: 'Asia/Tokyo',
+              },
+            },
+          })
+        );
+      });
+
+      it('should fall back to experimental.assistivePrompt when top-level is not provided', async () => {
         mockClient.toolRouter.session.create.mockResolvedValueOnce(mockSessionCreateResponse);
 
         const config: ToolRouterCreateSessionConfig = {
@@ -1163,24 +1264,31 @@ describe('ToolRouter', () => {
 
         await toolRouter.create(userId, config);
 
-        expect(mockClient.toolRouter.session.create).toHaveBeenCalledWith({
-          user_id: userId,
-          toolkits: undefined,
-          auth_configs: undefined,
-          connected_accounts: undefined,
-          tools: undefined,
-          tags: undefined,
-          manage_connections: createExpectedManageConnections(),
-          workbench: undefined,
-          experimental: {
+        expect(mockClient.toolRouter.session.create).toHaveBeenCalledWith(
+          expect.objectContaining({
             assistive_prompt_config: {
               user_timezone: 'America/New_York',
             },
-          },
-        });
+            experimental: {
+              assistive_prompt_config: {
+                user_timezone: 'America/New_York',
+              },
+            },
+          })
+        );
       });
 
-      it('should not include experimental in payload when assistivePrompt is not provided', async () => {
+      it('should not include assistive_prompt_config when no timezone is provided', async () => {
+        mockClient.toolRouter.session.create.mockResolvedValueOnce(mockSessionCreateResponse);
+
+        await toolRouter.create(userId);
+
+        const callArg = mockClient.toolRouter.session.create.mock.calls[0][0];
+        expect(callArg).not.toHaveProperty('assistive_prompt_config');
+        expect(callArg.experimental).toBeUndefined();
+      });
+
+      it('should not include assistive_prompt_config when experimental is empty', async () => {
         mockClient.toolRouter.session.create.mockResolvedValueOnce(mockSessionCreateResponse);
 
         const config: ToolRouterCreateSessionConfig = {
@@ -1189,74 +1297,9 @@ describe('ToolRouter', () => {
 
         await toolRouter.create(userId, config);
 
-        expect(mockClient.toolRouter.session.create).toHaveBeenCalledWith({
-          user_id: userId,
-          toolkits: undefined,
-          auth_configs: undefined,
-          connected_accounts: undefined,
-          tools: undefined,
-          tags: undefined,
-          manage_connections: createExpectedManageConnections(),
-          workbench: undefined,
-          experimental: undefined,
-        });
-      });
-
-      it('should not include experimental in payload when userTimezone is not provided', async () => {
-        mockClient.toolRouter.session.create.mockResolvedValueOnce(mockSessionCreateResponse);
-
-        const config: ToolRouterCreateSessionConfig = {
-          experimental: {
-            assistivePrompt: {},
-          },
-        };
-
-        await toolRouter.create(userId, config);
-
-        expect(mockClient.toolRouter.session.create).toHaveBeenCalledWith({
-          user_id: userId,
-          toolkits: undefined,
-          auth_configs: undefined,
-          connected_accounts: undefined,
-          tools: undefined,
-          tags: undefined,
-          manage_connections: createExpectedManageConnections(),
-          workbench: undefined,
-          experimental: undefined,
-        });
-      });
-
-      it('should create a session with experimental config combined with other options', async () => {
-        mockClient.toolRouter.session.create.mockResolvedValueOnce(mockSessionCreateResponse);
-
-        const config: ToolRouterCreateSessionConfig = {
-          toolkits: ['gmail', 'slack'],
-          experimental: {
-            assistivePrompt: {
-              userTimezone: 'Europe/London',
-            },
-          },
-        };
-
-        await toolRouter.create(userId, config);
-
-        expect(mockClient.toolRouter.session.create).toHaveBeenCalledWith({
-          user_id: userId,
-          toolkits: {
-            enable: ['gmail', 'slack'],
-          },
-          auth_configs: undefined,
-          connected_accounts: undefined,
-          tools: undefined,
-          tags: undefined,
-          manage_connections: createExpectedManageConnections(),
-          workbench: undefined,
-          experimental: {
-            assistive_prompt_config: {
-              user_timezone: 'Europe/London',
-            },
-          },
-        });
+        const callArg = mockClient.toolRouter.session.create.mock.calls[0][0];
+        expect(callArg).not.toHaveProperty('assistive_prompt_config');
+        expect(callArg.experimental).toBeUndefined();
       });
 
       it('should transform experimental assistive_prompt from API response to SDK format', async () => {
@@ -1271,10 +1314,8 @@ describe('ToolRouter', () => {
         mockClient.toolRouter.session.create.mockResolvedValueOnce(responseWithExperimental);
 
         const session = await toolRouter.create(userId, {
-          experimental: {
-            assistivePrompt: {
-              userTimezone: 'America/New_York',
-            },
+          assistivePrompt: {
+            userTimezone: 'America/New_York',
           },
         });
 


### PR DESCRIPTION
# Description
Mirrors [hermes PR #8164](https://github.com/ComposioHQ/hermes/pull/8164) changes in both TypeScript and Python SDKs:

### New parameters for tool router session creation:

1. **`allowSharedConnectedAccounts` (TS) / `allow_shared_connected_accounts` (Python)**
   - Optional boolean (default: not sent / false on API)
   - When `true`, explicit `connectedAccounts` overrides may reference accounts belonging to a different user
   - Use case: shared non-user-scoped services like Firecrawl, Datadog
   - Only included in API payload when explicitly set

2. **Top-level `assistivePrompt` (TS) / `assistive_prompt` (Python)**
   - Moves assistive prompt config out of the deprecated `experimental` block
   - Top-level config takes priority over `experimental.assistivePrompt`
   - Both `assistive_prompt_config` (top-level) and `experimental.assistive_prompt_config` are sent for backward compat
   - `experimental.assistivePrompt` path still works but is marked as deprecated

### Files changed:
- **TypeScript**: `toolRouter.types.ts` (schema), `ToolRouter.ts` (model), `toolRouter.test.ts` (tests)
- **Python**: `tool_router.py` (types + model), `test_tool_router.py` (tests)

### Backward compatibility:
- Both new fields are omitted from the API payload when not provided
- Existing `experimental.assistivePrompt` path continues to work
- No breaking changes for existing SDK consumers

Triggered by: dhawal dhawal@composio.dev | Source: slack

# How did I test this PR

### TypeScript SDK:
```
cd ts/packages/core && npx vitest run test/models/toolRouter.test.ts
# 84 passed (84)

npx vitest run test/lib/toolRouterParams.test.ts
# 11 passed (11)
```

### Python SDK:
```
python -m pytest python/tests/test_tool_router.py -v
# 72 passed in 0.67s
```

### New test coverage includes:
- `allow_shared_connected_accounts=true` is included in payload
- `allow_shared_connected_accounts=false` is included in payload
- `allow_shared_connected_accounts` is omitted when not provided
- Top-level `assistivePrompt` sends both `assistive_prompt_config` and `experimental`
- Top-level takes priority over `experimental.assistivePrompt`
- Fallback to `experimental.assistivePrompt` when top-level is not provided
- No assistive prompt config when neither is provided