### PR TITLE
docs: auto-open Ask AI widget on desktop screens

### DIFF
--- a/docs/components/ask-ai-button.tsx
+++ b/docs/components/ask-ai-button.tsx
@@ -13,6 +13,10 @@ function getDecimal() {
 
 let widgetOpen = false;
 
+export function markWidgetOpen() {
+  widgetOpen = true;
+}
+
 export function toggleDecimalWidget() {
   const decimal = getDecimal();
   if (!decimal) {

--- a/docs/components/decimal-widget.tsx
+++ b/docs/components/decimal-widget.tsx
@@ -2,6 +2,7 @@
 
 import Script from 'next/script';
 import { useEffect, useState } from 'react';
+import { markWidgetOpen } from './ask-ai-button';
 
 export type DecimalAPI = {
   show: () => void;
@@ -44,6 +45,12 @@ export function DecimalWidget() {
     };
 
     applyTheme();
+
+    // Auto-open the widget on large screens
+    if (window.matchMedia('(min-width: 1024px)').matches) {
+      Decimal.show();
+      markWidgetOpen();
+    }
 
     const observer = new MutationObserver((mutations) => {
       for (const mutation of mutations) {


### PR DESCRIPTION
## Summary
- Auto-opens the Decimal Ask AI chat widget on screens >= 1024px (Tailwind `lg` breakpoint)
- On smaller screens where Ask AI shows as just an icon, the widget stays closed as before
- Syncs the toggle state so the Ask AI button correctly hides/shows after auto-open

## Test plan
- [ ] Open docs on a desktop browser (>= 1024px wide) — widget should open automatically on page load
- [ ] Open docs on a narrow window or mobile — widget should stay closed
- [ ] After auto-open on desktop, clicking "Ask AI" should close the widget
- [ ] Keyboard shortcut (⌘I / Ctrl+I) should still toggle correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)