### PR TITLE
docs: improve how-composio-works page

### DIFF
--- a/docs/content/docs/authentication.mdx
+++ b/docs/content/docs/authentication.mdx
@@ -24,7 +24,7 @@ Here's what this looks like in a conversation:
 
 This flow works well for chat applications where users interact directly with the agent.
 
-<Card icon={<BookOpen />} title="In-chat authentication" href="/docs/authenticating-users/in-chat-authentication">
+<Card icon={<MessageCircle />} title="In-chat authentication" href="/docs/authenticating-users/in-chat-authentication">
   Let the agent handle authentication prompts automatically during conversation
 </Card>
 
@@ -32,7 +32,7 @@ This flow works well for chat applications where users interact directly with th
 
 For apps that manage auth outside of chat, use `session.authorize()` to generate Connect Links programmatically. This is useful when you want users to connect accounts during onboarding, or when building a custom connections page.
 
-<Card icon={<BookOpen />} title="Manual authentication" href="/docs/authenticating-users/manually-authenticating">
+<Card icon={<ShieldCheck />} title="Manual authentication" href="/docs/authenticating-users/manually-authenticating">
   Control when and how users connect their accounts
 </Card>
 
@@ -94,10 +94,10 @@ To bring your own OAuth apps or customize scopes, see [custom auth configs](/doc
 ## Useful links
 
 <Cards>
-  <Card icon={<BookOpen />} title="In-chat authentication" href="/docs/authenticating-users/in-chat-authentication">
+  <Card icon={<MessageCircle />} title="In-chat authentication" href="/docs/authenticating-users/in-chat-authentication">
     Let the agent prompt users to authenticate during conversation
   </Card>
-  <Card icon={<BookOpen />} title="Manual authentication" href="/docs/authenticating-users/manually-authenticating">
+  <Card icon={<ShieldCheck />} title="Manual authentication" href="/docs/authenticating-users/manually-authenticating">
     Generate Connect Links programmatically in your app
   </Card>
   <Card icon={<Palette />} title="White-labeling" href="/docs/white-labeling-authentication">

--- a/docs/content/docs/how-composio-works.mdx
+++ b/docs/content/docs/how-composio-works.mdx
@@ -85,11 +85,17 @@ graph TD
     classDef annotation stroke-dasharray: 5 5
 ```
 
-`SEARCH_TOOLS` discovers the right toolkit tools for the task. `MULTI_EXECUTE_TOOL` runs them against the external API with the user's credentials. If the user isn't authenticated yet, `MANAGE_CONNECTIONS` handles that in between.
+`COMPOSIO_SEARCH_TOOLS` discovers the right toolkit tools for the task. `COMPOSIO_MULTI_EXECUTE_TOOL` runs them against the external API with the user's credentials. If the user isn't authenticated yet, `COMPOSIO_MANAGE_CONNECTIONS` handles that in between.
 
 For large responses or bulk operations (labeling hundreds of emails, processing CSVs), the agent uses `COMPOSIO_REMOTE_WORKBENCH` to run Python with helper functions like `invoke_llm` and `run_composio_tool`.
 
 <Card icon={<BookOpen />} title="Tools and toolkits" href="/docs/tools-and-toolkits" description="Meta tools, context management, and execution" />
+
+## Tool discovery
+
+When the agent calls `COMPOSIO_SEARCH_TOOLS`, Composio runs a Vector + BM25 hybrid search across all available toolkits to find the right tools for a given use-case query. The search returns matching tool schemas, connection statuses, and related tools in a single call.
+
+Composio also surfaces **learned plans** from past executions. These are step-by-step workflows that have worked before for similar tasks, guiding the LLM to better perform an operation without starting from scratch.
 
 ## Authentication
 
@@ -121,6 +127,19 @@ For apps that manage auth outside of chat, like during onboarding or on a settin
 When the agent calls `COMPOSIO_MULTI_EXECUTE_TOOL`, Composio resolves the session to look up the user and their connections, validates the input against the tool's schema, injects the user's OAuth token or API key, calls the external API, and returns a structured result.
 
 Your agent doesn't touch API credentials or handle token refresh. Composio resolves credentials from the session and connected account, makes the authenticated call, and returns the result.
+
+## Remote workbench
+
+Large responses from `COMPOSIO_MULTI_EXECUTE_TOOL` are automatically synced to a secure remote workbench. Instead of stuffing thousands of lines into the context window, the agent can work with the data inside the workbench:
+
+- **Reading** files and tool responses
+- **Searching** across large outputs
+- **Writing and executing** Python code to transform, filter, or aggregate data
+- **Calling Composio tools** via the `run_composio_tool` helper for bulk orchestration
+
+This keeps the agent's context window lean while still letting it handle operations like labeling hundreds of emails, processing CSV exports, or summarizing long API responses.
+
+<Card icon={<BookOpen />} title="Workbench" href="/docs/workbench" description="Persistent Python sandbox for large-context operations" />
 
 ## Direct tool execution
 

--- a/docs/content/docs/how-composio-works.mdx
+++ b/docs/content/docs/how-composio-works.mdx
@@ -32,7 +32,7 @@ A session ties together:
 
 Sessions are immutable. Their configuration is fixed at creation. If the context changes (different toolkits, different connected account), create a new session. You don't need to cache or manage session IDs.
 
-<Card icon={<BookOpen />} title="Users & Sessions" href="/docs/users-and-sessions" description="How users and sessions scope tools and connections" />
+<Card icon={<Database />} title="Users & Sessions" href="/docs/users-and-sessions" description="How users and sessions scope tools and connections" />
 
 ## Meta tools
 
@@ -89,7 +89,7 @@ graph TD
 
 For large responses or bulk operations (labeling hundreds of emails, processing CSVs), the agent uses `COMPOSIO_REMOTE_WORKBENCH` to run Python with helper functions like `invoke_llm` and `run_composio_tool`.
 
-<Card icon={<BookOpen />} title="Tools and toolkits" href="/docs/tools-and-toolkits" description="Meta tools, context management, and execution" />
+<Card icon={<Wrench />} title="Tools and toolkits" href="/docs/tools-and-toolkits" description="Meta tools, context management, and execution" />
 
 ## Tool discovery
 
@@ -119,7 +119,7 @@ For apps that manage auth outside of chat, like during onboarding or on a settin
 
 <Cards>
   <Card icon={<Key />} title="Authentication" href="/docs/authentication" description="Connect Links, OAuth, API keys, and custom auth configs" />
-  <Card icon={<BookOpen />} title="Manual authentication" href="/docs/authenticating-users/manually-authenticating" description="Authenticate users outside of chat with session.authorize()" />
+  <Card icon={<ShieldCheck />} title="Manual authentication" href="/docs/authenticating-users/manually-authenticating" description="Authenticate users outside of chat with session.authorize()" />
 </Cards>
 
 ## Tool execution
@@ -139,7 +139,7 @@ Large responses from `COMPOSIO_MULTI_EXECUTE_TOOL` are automatically synced to a
 
 This keeps the agent's context window lean while still letting it handle operations like labeling hundreds of emails, processing CSV exports, or summarizing long API responses.
 
-<Card icon={<BookOpen />} title="Workbench" href="/docs/workbench" description="Persistent Python sandbox for large-context operations" />
+<Card icon={<Monitor />} title="Workbench" href="/docs/workbench" description="Persistent Python sandbox for large-context operations" />
 
 ## Direct tool execution
 
@@ -162,4 +162,4 @@ result = composio.tools.execute(
 
 This is useful for deterministic workflows where the agent doesn't need to discover tools at runtime.
 
-<Card icon={<BookOpen />} title="Direct tool execution" href="/docs/tools-direct/executing-tools" description="Fetch, authenticate, and execute tools without meta tools" />
+<Card icon={<Zap />} title="Direct tool execution" href="/docs/tools-direct/executing-tools" description="Fetch, authenticate, and execute tools without meta tools" />

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -20,7 +20,7 @@ Composio powers 1000+ toolkits, tool search, context management, authentication,
     description="Try Composio in your browser"
   />
   <Card
-    icon={<BookOpen />}
+    icon={<Rocket />}
     title="How it works"
     href="/docs/how-composio-works"
     description="Sessions, meta tools, authentication, and execution"

--- a/docs/content/docs/tools-and-toolkits.mdx
+++ b/docs/content/docs/tools-and-toolkits.mdx
@@ -84,7 +84,7 @@ If a tool requires authentication and the user hasn't connected yet, the agent c
   <Card icon={<Blocks />} title="Browse toolkits" href="/toolkits">
     Explore all available toolkits
   </Card>
-  <Card icon={<BookOpen />} title="Fetching tools" href="/docs/toolkits/fetching-tools-and-toolkits">
+  <Card icon={<Wrench />} title="Fetching tools" href="/docs/toolkits/fetching-tools-and-toolkits">
     Browse the catalog and fetch tools for sessions
   </Card>
 </Cards>

--- a/docs/content/docs/troubleshooting/index.mdx
+++ b/docs/content/docs/troubleshooting/index.mdx
@@ -73,7 +73,7 @@ See [Troubleshooting triggers](/docs/troubleshooting/triggers#reporting-issues) 
   <Card title="Contact Support" href="mailto:support@composio.dev" icon={<Mail />}>
     Reach out to support for account, billing, or escalations
   </Card>
-  <Card title="Migration guides" href="/docs/migration-guide" icon={<BookOpen />}>
+  <Card title="Migration guides" href="/docs/migration-guide" icon={<RouteIcon />}>
     Check out our migration guides to help you upgrade to the latest version.
   </Card>
 </Cards>

--- a/docs/content/docs/users-and-sessions.mdx
+++ b/docs/content/docs/users-and-sessions.mdx
@@ -24,7 +24,7 @@ Let's say you want to allow users to connect both their work and personal email.
 account ID.
 
 Here is a detailed guide on how to manage such connections:
-<Card icon={<BookOpen />} title="Managing Multiple Connections" href="/docs/managing-multiple-connected-accounts" description="Handle multiple accounts per toolkit for a single user" />
+<Card icon={<Plug />} title="Managing Multiple Connections" href="/docs/managing-multiple-connected-accounts" description="Handle multiple accounts per toolkit for a single user" />
 
 Triggers are scoped to a connected account. When you create a trigger, it's tied to a specific user's connection:
 <Card icon={<Zap />} title="Triggers" href="/docs/triggers" description="Event-driven payloads from connected apps" />
@@ -120,6 +120,6 @@ Create a new session when the config changes: different toolkits, different auth
 </Accordions>
 
 <Cards>
-  <Card icon={<BookOpen />} title="Configuring Sessions" href="/docs/configuring-sessions" description="Enable toolkits, set auth configs, and select connected accounts" />
-  <Card icon={<BookOpen />} title="Workbench" href="/docs/workbench" description="Write and run code in a persistent sandbox" />
+  <Card icon={<Wrench />} title="Configuring Sessions" href="/docs/configuring-sessions" description="Enable toolkits, set auth configs, and select connected accounts" />
+  <Card icon={<Monitor />} title="Workbench" href="/docs/workbench" description="Write and run code in a persistent sandbox" />
 </Cards>

--- a/docs/content/docs/workbench.mdx
+++ b/docs/content/docs/workbench.mdx
@@ -75,7 +75,7 @@ The sandbox preserves variables and files across calls. The agent can paginate t
   <Card icon={<Blocks />} title="Tools and toolkits" href="/docs/tools-and-toolkits">
     How meta tools discover, authenticate, and execute tools at runtime
   </Card>
-  <Card icon={<BookOpen />} title="Browse toolkits" href="/toolkits">
+  <Card icon={<Blocks />} title="Browse toolkits" href="/toolkits">
     Explore all available toolkits
   </Card>
 </Cards>

--- a/docs/mdx-components.tsx
+++ b/docs/mdx-components.tsx
@@ -35,6 +35,8 @@ import {
   Terminal,
   Palette,
   BookOpen,
+  Monitor,
+  MessageCircle,
 } from 'lucide-react';
 
 function slugify(text: string): string {
@@ -100,6 +102,8 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     Terminal,
     Palette,
     BookOpen,
+    Monitor,
+    MessageCircle,
     ...components,
   };
 }


### PR DESCRIPTION
## Summary
- Fix inconsistent meta tool naming (use `COMPOSIO_` prefix everywhere)
- Add "Tool discovery" section covering Vector+BM25 search and learned plans
- Add "Remote workbench" section explaining automatic large response handling

## Test plan
- [ ] Verify Vercel preview renders the page correctly
- [ ] Check that internal links are valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)