### PR TITLE
docs: update Skills.sh link

### DIFF
--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -44,7 +44,7 @@ Composio powers 1000+ toolkits, tool search, context management, authentication,
 npx skills add composiohq/skills
 ```
 
-[View on Skills.sh](https://skills.sh/composiohq/skills/composio-tool-router) · [GitHub](https://github.com/composiohq/skills)
+[View on Skills.sh](https://skills.sh/composiohq/skills/composio) · [GitHub](https://github.com/composiohq/skills)
 
 ## Providers
 


### PR DESCRIPTION
## Summary
- Update Skills.sh link from `composio-tool-router` to `composio`

## Test plan
- [ ] Verify link works on the docs index page

🤖 Generated with [Claude Code](https://claude.com/claude-code)