### PR TITLE
fix: add workspace-write sandbox to Codex changelog workflow

### DIFF
--- a/.github/workflows/docs.changelog-to-docs.yml
+++ b/.github/workflows/docs.changelog-to-docs.yml
@@ -47,6 +47,7 @@ jobs:
         uses: openai/codex-action@v1
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          sandbox: workspace-write
           prompt: |
             New changelog entries were merged to next. Read the agent instructions and update documentation accordingly.
 


### PR DESCRIPTION
## Summary
- Adds `sandbox: workspace-write` to the `openai/codex-action` step in the changelog-to-docs workflow
- Without this, Codex runs in read-only mode and can never modify files, making the entire workflow non-functional (the PR creation step always exits with "No documentation changes needed")

## Test plan
- [ ] Push a changelog `.mdx` to `next` and verify Codex can write file changes
- [ ] Verify the PR creation step picks up the changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)