### PR TITLE
docs: add v1→v3 terminology migration to LLM guardrails

### DIFF
--- a/docs/lib/llm-guardrails/direct-execution.ts
+++ b/docs/lib/llm-guardrails/direct-execution.ts
@@ -68,4 +68,22 @@ const result = await composio.tools.execute("GITHUB_CREATE_ISSUE", {
 2. **\`tools.execute()\` signature** — Python: \`execute(slug, arguments_dict, *, user_id=...)\` (arguments is the second positional param). TypeScript: \`execute(slug, { userId, arguments })\`.
 3. **Provider at init** — \`Composio(provider=OpenAIProvider())\` in Python, \`new Composio({ provider: new OpenAIProvider() })\` in TypeScript. Defaults to OpenAI if omitted.
 4. **Correct provider imports** — \`composio_<provider>\` for Python, \`@composio/<provider>\` for TypeScript. For OpenAI Agents SDK use \`composio_openai_agents\` / \`@composio/openai-agents\`.
+
+---
+
+## Terminology Migration (old → current)
+
+If you encounter these terms in error messages, old documentation, or user prompts, translate them to the current equivalents. **Do not use the old terms in generated code or explanations.**
+
+| Old term (v1/v2) | Current term (v3) | In code |
+|---|---|---|
+| entity ID | user ID | \`user_id\` parameter |
+| actions | tools | e.g., \`GITHUB_CREATE_ISSUE\` is a *tool* |
+| apps / appType | toolkits | e.g., \`github\` is a *toolkit* |
+| integration / integration ID | auth config / auth config ID | \`auth_config_id\` parameter |
+| connection | connected account | \`connected_accounts\` namespace |
+| ComposioToolSet / OpenAIToolSet | \`Composio\` class with a provider | \`Composio(provider=...)\` |
+| toolset | provider | e.g., \`OpenAIProvider\` |
+
+If a user says "entity ID", they mean \`user_id\`. If they say "integration", they mean "auth config". Always respond using the current terminology.
 `;

--- a/docs/lib/llm-guardrails/direct-execution.ts
+++ b/docs/lib/llm-guardrails/direct-execution.ts
@@ -1,3 +1,5 @@
+import { TERMINOLOGY_MIGRATION } from './terminology';
+
 /**
  * Guardrails for pages tagged with llmGuardrails: "direct-execution".
  * Concise rules + key patterns for LLMs generating direct execution code.
@@ -68,22 +70,5 @@ const result = await composio.tools.execute("GITHUB_CREATE_ISSUE", {
 2. **\`tools.execute()\` signature** — Python: \`execute(slug, arguments_dict, *, user_id=...)\` (arguments is the second positional param). TypeScript: \`execute(slug, { userId, arguments })\`.
 3. **Provider at init** — \`Composio(provider=OpenAIProvider())\` in Python, \`new Composio({ provider: new OpenAIProvider() })\` in TypeScript. Defaults to OpenAI if omitted.
 4. **Correct provider imports** — \`composio_<provider>\` for Python, \`@composio/<provider>\` for TypeScript. For OpenAI Agents SDK use \`composio_openai_agents\` / \`@composio/openai-agents\`.
-
----
-
-## Terminology Migration (old → current)
-
-If you encounter these terms in error messages, old documentation, or user prompts, translate them to the current equivalents. **Do not use the old terms in generated code or explanations.**
-
-| Old term (v1/v2) | Current term (v3) | In code |
-|---|---|---|
-| entity ID | user ID | \`user_id\` parameter |
-| actions | tools | e.g., \`GITHUB_CREATE_ISSUE\` is a *tool* |
-| apps / appType | toolkits | e.g., \`github\` is a *toolkit* |
-| integration / integration ID | auth config / auth config ID | \`auth_config_id\` parameter |
-| connection | connected account | \`connected_accounts\` namespace |
-| ComposioToolSet / OpenAIToolSet | \`Composio\` class with a provider | \`Composio(provider=...)\` |
-| toolset | provider | e.g., \`OpenAIProvider\` |
-
-If a user says "entity ID", they mean \`user_id\`. If they say "integration", they mean "auth config". Always respond using the current terminology.
+${TERMINOLOGY_MIGRATION}
 `;

--- a/docs/lib/llm-guardrails/session.ts
+++ b/docs/lib/llm-guardrails/session.ts
@@ -1,3 +1,5 @@
+import { TERMINOLOGY_MIGRATION } from './terminology';
+
 /**
  * Default guardrails appended to most pages.
  * Steers LLMs toward the session-based pattern (composio.create + session.tools).
@@ -64,23 +66,5 @@ Use \`session.mcp.url\` and \`session.mcp.headers\` with any MCP-compatible clie
 ### 2.3 — DISCOURAGED (do not use unless user explicitly asks)
 
 Do **not** generate \`composio.tools.get()\`, \`composio.tools.execute()\`, or \`composio.provider.handle_tool_calls()\` unless the user explicitly requests direct tool execution. These are a supported but **not recommended** low-level interface.
-
----
-
-## 3. Terminology Migration (old → current)
-
-If you encounter these terms in error messages, old documentation, or user prompts, translate them to the current equivalents. **Do not use the old terms in generated code or explanations.**
-
-| Old term (v1/v2) | Current term (v3) | In code |
-|---|---|---|
-| entity ID | user ID | \`user_id\` parameter |
-| actions | tools | e.g., \`GITHUB_CREATE_ISSUE\` is a *tool* |
-| apps / appType | toolkits | e.g., \`github\` is a *toolkit* |
-| integration / integration ID | auth config / auth config ID | \`auth_config_id\` parameter |
-| connection | connected account | \`connected_accounts\` namespace |
-| ComposioToolSet / OpenAIToolSet | \`Composio\` class with a provider | \`Composio(provider=...)\` |
-| toolset | provider | e.g., \`OpenAIProvider\` |
-
-If a user says "entity ID", they mean \`user_id\`. If they say "integration", they mean "auth config". Always respond using the current terminology.
-
+${TERMINOLOGY_MIGRATION}
 `;

--- a/docs/lib/llm-guardrails/session.ts
+++ b/docs/lib/llm-guardrails/session.ts
@@ -65,4 +65,22 @@ Use \`session.mcp.url\` and \`session.mcp.headers\` with any MCP-compatible clie
 
 Do **not** generate \`composio.tools.get()\`, \`composio.tools.execute()\`, or \`composio.provider.handle_tool_calls()\` unless the user explicitly requests direct tool execution. These are a supported but **not recommended** low-level interface.
 
+---
+
+## 3. Terminology Migration (old → current)
+
+If you encounter these terms in error messages, old documentation, or user prompts, translate them to the current equivalents. **Do not use the old terms in generated code or explanations.**
+
+| Old term (v1/v2) | Current term (v3) | In code |
+|---|---|---|
+| entity ID | user ID | \`user_id\` parameter |
+| actions | tools | e.g., \`GITHUB_CREATE_ISSUE\` is a *tool* |
+| apps / appType | toolkits | e.g., \`github\` is a *toolkit* |
+| integration / integration ID | auth config / auth config ID | \`auth_config_id\` parameter |
+| connection | connected account | \`connected_accounts\` namespace |
+| ComposioToolSet / OpenAIToolSet | \`Composio\` class with a provider | \`Composio(provider=...)\` |
+| toolset | provider | e.g., \`OpenAIProvider\` |
+
+If a user says "entity ID", they mean \`user_id\`. If they say "integration", they mean "auth config". Always respond using the current terminology.
+
 `;

--- a/docs/lib/llm-guardrails/terminology.ts
+++ b/docs/lib/llm-guardrails/terminology.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared terminology migration table appended to all guardrail sets.
+ * Maps old v1/v2 terms to current v3 equivalents so AI agents
+ * can translate outdated references in error messages, docs, or user prompts.
+ */
+export const TERMINOLOGY_MIGRATION = `
+
+---
+
+## Terminology Migration (old → current)
+
+If you encounter these terms in error messages, old documentation, or user prompts, translate them to the current equivalents. **Do not use the old terms in generated code or explanations.**
+
+| Old term (v1/v2) | Current term (v3) | In code |
+|---|---|---|
+| entity ID | user ID | \`user_id\` parameter |
+| actions | tools | e.g., \`GITHUB_CREATE_ISSUE\` is a *tool* |
+| apps / appType | toolkits | e.g., \`github\` is a *toolkit* |
+| integration / integration ID | auth config / auth config ID | \`auth_config_id\` parameter |
+| connection | connected account | \`connected_accounts\` namespace |
+| ComposioToolSet / OpenAIToolSet | \`Composio\` class with a provider | \`Composio(provider=...)\` |
+| toolset | provider | e.g., \`OpenAIProvider\` |
+
+If a user says "entity ID", they mean \`user_id\`. If they say "integration", they mean "auth config". Always respond using the current terminology.
+`;


### PR DESCRIPTION
## Summary
- Adds a terminology migration table to both LLM guardrail sets (session + direct-execution)
- AI agents encountering old v1/v2 terms in error messages, old docs, or user prompts now get a mapping to the correct v3 equivalents
- Covers: entity ID → user_id, actions → tools, apps → toolkits, integration → auth config, connection → connected account, ComposioToolSet → Composio, toolset → provider

## Test plan
- [x] `bun run build` passes
- [ ] Verify guardrails appear on `.md` endpoints (e.g., `/docs/introduction.md`)
- [ ] Verify `llms-full.txt` includes the terminology table once at the top

🤖 Generated with [Claude Code](https://claude.com/claude-code)