### PR TITLE
feat(cli): add triggers list/info commands with richer trigger detail

### DIFF
--- a/ts/packages/cli/src/commands/tools/format.ts
+++ b/ts/packages/cli/src/commands/tools/format.ts
@@ -2,6 +2,7 @@ import type { Tool } from 'src/models/tools';
 import type { ToolDetailedResponse } from 'src/services/composio-clients';
 import { bold, gray } from 'src/ui/colors';
 import { truncate } from 'src/ui/truncate';
+import { extractSchemaProperties } from 'src/ui/extract-schema-properties';
 
 /**
  * Format a list of tools as a human-readable table.
@@ -40,20 +41,10 @@ export function formatToolsJson(tools: ReadonlyArray<Tool>): string {
  * Extracts `properties` entries, cross-references `required` array.
  */
 function formatSchemaProperties(schema: Record<string, unknown>): string {
-  const properties = schema['properties'] as Record<string, Record<string, unknown>> | undefined;
-  if (!properties || Object.keys(properties).length === 0) {
+  const entries = extractSchemaProperties(schema);
+  if (entries.length === 0) {
     return '  (none)';
   }
-
-  const requiredArr = (schema['required'] as string[] | undefined) ?? [];
-  const requiredSet = new Set(requiredArr);
-
-  const entries = Object.entries(properties).map(([name, prop]) => {
-    const type = (prop['type'] as string) ?? 'unknown';
-    const label = requiredSet.has(name) ? 'required' : 'optional';
-    const description = prop['description'] as string | undefined;
-    return { name, type, label, description };
-  });
 
   const nameWidth = Math.max(...entries.map(e => e.name.length));
   const typeWidth = Math.max(...entries.map(e => e.type.length));

--- a/ts/packages/cli/src/commands/triggers/commands/triggers.info.cmd.ts
+++ b/ts/packages/cli/src/commands/triggers/commands/triggers.info.cmd.ts
@@ -34,25 +34,26 @@ export const triggersCmd$Info = Command.make('info', { slug }, ({ slug }) =>
     }
 
     const slugValue = slug.value;
-    const triggerTypes = yield* ui.withSpinner('Fetching trigger types...', repo.getTriggerTypes());
-    const normalizedSlug = slugValue.toUpperCase();
-    const triggerType = triggerTypes.find(item => item.slug.toUpperCase() === normalizedSlug);
+    const triggerType = yield* ui
+      .withSpinner('Fetching trigger type details...', repo.getTriggerTypeDetailed(slugValue))
+      .pipe(
+        Effect.catchTag('services/HttpServerError', e =>
+          Effect.if(e.status === 404, {
+            onTrue: () =>
+              ui.log
+                .error(`Trigger "${slugValue}" not found.`)
+                .pipe(
+                  Effect.zipRight(
+                    ui.log.step('Browse available trigger types:\n> composio triggers list')
+                  ),
+                  Effect.as(undefined)
+                ),
+            onFalse: () => Effect.fail(e),
+          })
+        )
+      );
 
-    if (!triggerType) {
-      yield* ui.log.error(`Trigger "${slugValue}" not found.`);
-      const suggestions = triggerTypes
-        .filter(item => item.slug.toUpperCase().includes(normalizedSlug))
-        .slice(0, 3);
-      if (suggestions.length > 0) {
-        yield* ui.log.step('Did you mean:');
-        yield* Effect.forEach(suggestions, item =>
-          ui.log.step(`> composio triggers info "${item.slug}"`)
-        );
-      } else {
-        yield* ui.log.step('Browse available trigger types:\n> composio triggers list');
-      }
-      return;
-    }
+    if (!triggerType) return;
 
     yield* ui.log.info(formatTriggerTypeInfo(triggerType));
 

--- a/ts/packages/cli/src/commands/triggers/commands/triggers.info.cmd.ts
+++ b/ts/packages/cli/src/commands/triggers/commands/triggers.info.cmd.ts
@@ -54,7 +54,7 @@ export const triggersCmd$Info = Command.make('info', { slug }, ({ slug }) =>
       return;
     }
 
-    yield* ui.note(formatTriggerTypeInfo(triggerType), `Trigger: ${triggerType.name}`);
+    yield* ui.log.info(formatTriggerTypeInfo(triggerType));
 
     const toolkitSlug = triggerType.slug.split('_')[0]?.toLowerCase();
     if (toolkitSlug) {

--- a/ts/packages/cli/src/commands/triggers/commands/triggers.info.cmd.ts
+++ b/ts/packages/cli/src/commands/triggers/commands/triggers.info.cmd.ts
@@ -1,0 +1,68 @@
+import { Args, Command } from '@effect/cli';
+import { Effect, Option } from 'effect';
+import { requireAuth } from 'src/effects/require-auth';
+import { ComposioToolkitsRepository } from 'src/services/composio-clients';
+import { TerminalUI } from 'src/services/terminal-ui';
+import { formatTriggerTypeInfo } from '../format';
+
+const slug = Args.text({ name: 'slug' }).pipe(
+  Args.withDescription('Trigger slug (e.g. "GMAIL_NEW_GMAIL_MESSAGE")'),
+  Args.optional
+);
+
+/**
+ * View details of a specific trigger type including config and payload schemas.
+ *
+ * @example
+ * ```bash
+ * composio triggers info "GMAIL_NEW_GMAIL_MESSAGE"
+ * ```
+ */
+export const triggersCmd$Info = Command.make('info', { slug }, ({ slug }) =>
+  Effect.gen(function* () {
+    if (!(yield* requireAuth)) return;
+
+    const ui = yield* TerminalUI;
+    const repo = yield* ComposioToolkitsRepository;
+
+    if (Option.isNone(slug)) {
+      yield* ui.log.warn('Missing required argument: <slug>');
+      yield* ui.log.step(
+        'Try specifying a trigger slug, e.g.:\n> composio triggers info "GMAIL_NEW_GMAIL_MESSAGE"'
+      );
+      return;
+    }
+
+    const slugValue = slug.value;
+    const triggerTypes = yield* ui.withSpinner('Fetching trigger types...', repo.getTriggerTypes());
+    const normalizedSlug = slugValue.toUpperCase();
+    const triggerType = triggerTypes.find(item => item.slug.toUpperCase() === normalizedSlug);
+
+    if (!triggerType) {
+      yield* ui.log.error(`Trigger "${slugValue}" not found.`);
+      const suggestions = triggerTypes
+        .filter(item => item.slug.toUpperCase().includes(normalizedSlug))
+        .slice(0, 3);
+      if (suggestions.length > 0) {
+        yield* ui.log.step('Did you mean:');
+        yield* Effect.forEach(suggestions, item =>
+          ui.log.step(`> composio triggers info "${item.slug}"`)
+        );
+      } else {
+        yield* ui.log.step('Browse available trigger types:\n> composio triggers list');
+      }
+      return;
+    }
+
+    yield* ui.note(formatTriggerTypeInfo(triggerType), `Trigger: ${triggerType.name}`);
+
+    const toolkitSlug = triggerType.slug.split('_')[0]?.toLowerCase();
+    if (toolkitSlug) {
+      yield* ui.log.step(
+        `To list more trigger types in this toolkit:\n> composio triggers list --toolkits "${toolkitSlug}"`
+      );
+    }
+
+    yield* ui.output(JSON.stringify(triggerType, null, 2));
+  })
+).pipe(Command.withDescription('View details of a specific trigger type.'));

--- a/ts/packages/cli/src/commands/triggers/commands/triggers.info.cmd.ts
+++ b/ts/packages/cli/src/commands/triggers/commands/triggers.info.cmd.ts
@@ -57,7 +57,7 @@ export const triggersCmd$Info = Command.make('info', { slug }, ({ slug }) =>
 
     yield* ui.log.info(formatTriggerTypeInfo(triggerType));
 
-    const toolkitSlug = triggerType.slug.split('_')[0]?.toLowerCase();
+    const toolkitSlug = triggerType.toolkit?.slug?.toLowerCase();
     if (toolkitSlug) {
       yield* ui.log.step(
         `To list more trigger types in this toolkit:\n> composio triggers list --toolkits "${toolkitSlug}"`

--- a/ts/packages/cli/src/commands/triggers/commands/triggers.info.cmd.ts
+++ b/ts/packages/cli/src/commands/triggers/commands/triggers.info.cmd.ts
@@ -1,6 +1,7 @@
 import { Args, Command } from '@effect/cli';
 import { Effect, Option } from 'effect';
 import { requireAuth } from 'src/effects/require-auth';
+import { handleHttpServerError } from 'src/effects/handle-http-error';
 import { ComposioToolkitsRepository } from 'src/services/composio-clients';
 import { TerminalUI } from 'src/services/terminal-ui';
 import { formatTriggerTypeInfo } from '../format';
@@ -34,28 +35,26 @@ export const triggersCmd$Info = Command.make('info', { slug }, ({ slug }) =>
     }
 
     const slugValue = slug.value;
-    const triggerType = yield* ui
+
+    const triggerTypeOpt = yield* ui
       .withSpinner('Fetching trigger type details...', repo.getTriggerTypeDetailed(slugValue))
       .pipe(
-        Effect.catchTag('services/HttpServerError', e =>
-          Effect.if(e.status === 404, {
-            onTrue: () =>
-              ui.log
-                .error(`Trigger "${slugValue}" not found.`)
-                .pipe(
-                  Effect.zipRight(
-                    ui.log.step('Browse available trigger types:\n> composio triggers list')
-                  ),
-                  Effect.as(undefined)
-                ),
-            onFalse: () => Effect.fail(e),
+        Effect.asSome,
+        Effect.catchTag(
+          'services/HttpServerError',
+          handleHttpServerError(ui, {
+            fallbackMessage: `Trigger "${slugValue}" not found.`,
+            hint: 'Browse available trigger types:\n> composio triggers list',
+            fallbackValue: Option.none(),
           })
         )
       );
 
-    if (!triggerType) return;
+    if (Option.isNone(triggerTypeOpt)) return;
 
-    yield* ui.log.info(formatTriggerTypeInfo(triggerType));
+    const triggerType = triggerTypeOpt.value;
+
+    yield* ui.note(formatTriggerTypeInfo(triggerType), `Trigger: ${triggerType.name}`);
 
     const toolkitSlug = triggerType.toolkit?.slug?.toLowerCase();
     if (toolkitSlug) {

--- a/ts/packages/cli/src/commands/triggers/commands/triggers.list.cmd.ts
+++ b/ts/packages/cli/src/commands/triggers/commands/triggers.list.cmd.ts
@@ -5,6 +5,7 @@ import { ComposioToolkitsRepository } from 'src/services/composio-clients';
 import { TerminalUI } from 'src/services/terminal-ui';
 import { clampLimit } from 'src/ui/clamp-limit';
 import { formatTriggerTypesJson, formatTriggerTypesTable } from '../format';
+import { parseCsv } from '../parse-csv';
 
 const toolkits = Options.text('toolkits').pipe(
   Options.withDescription(
@@ -17,12 +18,6 @@ const limit = Options.integer('limit').pipe(
   Options.withDefault(30),
   Options.withDescription('Maximum number of trigger types to show (1-1000)')
 );
-
-const parseCsv = (value: string): ReadonlyArray<string> =>
-  value
-    .split(',')
-    .map(item => item.trim())
-    .filter(Boolean);
 
 /**
  * List available trigger types with optional toolkit filters.

--- a/ts/packages/cli/src/commands/triggers/commands/triggers.list.cmd.ts
+++ b/ts/packages/cli/src/commands/triggers/commands/triggers.list.cmd.ts
@@ -1,0 +1,65 @@
+import { Command, Options } from '@effect/cli';
+import { Effect, Option } from 'effect';
+import { requireAuth } from 'src/effects/require-auth';
+import { ComposioToolkitsRepository } from 'src/services/composio-clients';
+import { TerminalUI } from 'src/services/terminal-ui';
+import { clampLimit } from 'src/ui/clamp-limit';
+import { formatTriggerTypesJson, formatTriggerTypesTable } from '../format';
+
+const toolkits = Options.text('toolkits').pipe(
+  Options.withDescription(
+    'Filter by toolkit slugs, comma-separated (e.g. "gmail" or "gmail,slack")'
+  ),
+  Options.optional
+);
+
+const limit = Options.integer('limit').pipe(
+  Options.withDefault(30),
+  Options.withDescription('Maximum number of trigger types to show (1-1000)')
+);
+
+const parseCsv = (value: string): ReadonlyArray<string> =>
+  value
+    .split(',')
+    .map(item => item.trim())
+    .filter(Boolean);
+
+/**
+ * List available trigger types with optional toolkit filters.
+ *
+ * @example
+ * ```bash
+ * composio triggers list
+ * composio triggers list --toolkits "gmail"
+ * composio triggers list --toolkits "gmail,slack"
+ * ```
+ */
+export const triggersCmd$List = Command.make('list', { toolkits, limit }, ({ toolkits, limit }) =>
+  Effect.gen(function* () {
+    if (!(yield* requireAuth)) return;
+
+    const ui = yield* TerminalUI;
+    const repo = yield* ComposioToolkitsRepository;
+    const toolkitFilters = Option.isSome(toolkits) ? parseCsv(toolkits.value) : undefined;
+    const clampedLimit = clampLimit(limit);
+
+    const allTriggerTypes = yield* ui.withSpinner(
+      'Fetching trigger types...',
+      repo.getTriggerTypes(toolkitFilters)
+    );
+    const triggerTypes = allTriggerTypes.slice(0, clampedLimit);
+
+    if (triggerTypes.length === 0) {
+      const hint = Option.isSome(toolkits)
+        ? `No trigger types found in toolkit "${toolkits.value}". Verify the toolkit slug with:\n> composio toolkits list`
+        : 'No trigger types found.';
+      yield* ui.log.warn(hint);
+      return;
+    }
+
+    yield* ui.log.info(
+      `Listing ${triggerTypes.length} trigger types\n\n${formatTriggerTypesTable(triggerTypes)}`
+    );
+    yield* ui.output(formatTriggerTypesJson(triggerTypes));
+  })
+).pipe(Command.withDescription('List available trigger types.'));

--- a/ts/packages/cli/src/commands/triggers/commands/triggers.list.cmd.ts
+++ b/ts/packages/cli/src/commands/triggers/commands/triggers.list.cmd.ts
@@ -52,9 +52,18 @@ export const triggersCmd$List = Command.make('list', { toolkits, limit }, ({ too
       return;
     }
 
+    const count = triggerTypes.length;
     yield* ui.log.info(
-      `Listing ${triggerTypes.length} trigger types\n\n${formatTriggerTypesTable(triggerTypes)}`
+      `Listing ${count} trigger type${count === 1 ? '' : 's'}\n\n${formatTriggerTypesTable(triggerTypes)}`
     );
+
+    const firstSlug = triggerTypes[0]?.slug;
+    if (firstSlug) {
+      yield* ui.log.step(
+        `To view details of a trigger type:\n> composio triggers info "${firstSlug}"`
+      );
+    }
+
     yield* ui.output(formatTriggerTypesJson(triggerTypes));
   })
 ).pipe(Command.withDescription('List available trigger types.'));

--- a/ts/packages/cli/src/commands/triggers/commands/triggers.listen.cmd.ts
+++ b/ts/packages/cli/src/commands/triggers/commands/triggers.listen.cmd.ts
@@ -12,6 +12,7 @@ import {
   formatTriggerListenTableHeader,
   formatTriggerListenTableRow,
 } from '../format';
+import { parseCsv } from '../parse-csv';
 import { parseTriggerListenEvent } from '../parse';
 import type { TriggerListenFilters } from '../types';
 
@@ -72,12 +73,6 @@ const out = Options.text('out').pipe(
   Options.withDescription('Append each matching event to this file'),
   Options.optional
 );
-
-const parseCsv = (value: string): ReadonlyArray<string> =>
-  value
-    .split(',')
-    .map(item => item.trim())
-    .filter(Boolean);
 
 const randomUUID = () => crypto.randomUUID();
 

--- a/ts/packages/cli/src/commands/triggers/format.ts
+++ b/ts/packages/cli/src/commands/triggers/format.ts
@@ -1,3 +1,4 @@
+import type { TriggerType } from 'src/models/trigger-types';
 import type { TriggerListenEvent } from './types';
 import { bold, gray } from 'src/ui/colors';
 import { truncate } from 'src/ui/truncate';
@@ -55,4 +56,103 @@ export const formatTriggerListenTableRow = ({
     truncate(userId, TRIGGER_TABLE.userId).padEnd(TRIGGER_TABLE.userId),
     truncate(connectedAccountId, TRIGGER_TABLE.connectedAccountId),
   ].join(' ');
+};
+
+const TRIGGER_TYPES_TABLE = {
+  slug: 35,
+  name: 26,
+  type: 8,
+} as const;
+
+export const formatTriggerTypesTable = (triggerTypes: ReadonlyArray<TriggerType>): string => {
+  const header = [
+    bold('Slug'.padEnd(TRIGGER_TYPES_TABLE.slug)),
+    bold('Name'.padEnd(TRIGGER_TYPES_TABLE.name)),
+    bold('Type'.padEnd(TRIGGER_TYPES_TABLE.type)),
+    bold('Description'),
+  ].join(' ');
+
+  const rows = triggerTypes.map(triggerType => {
+    const slug = truncate(triggerType.slug, TRIGGER_TYPES_TABLE.slug).padEnd(
+      TRIGGER_TYPES_TABLE.slug
+    );
+    const name = truncate(triggerType.name, TRIGGER_TYPES_TABLE.name).padEnd(
+      TRIGGER_TYPES_TABLE.name
+    );
+    const type = triggerType.type.padEnd(TRIGGER_TYPES_TABLE.type);
+    const description = gray(truncate(triggerType.description, 50));
+    return `${slug} ${name} ${type} ${description}`;
+  });
+
+  return [header, ...rows].join('\n');
+};
+
+export const formatTriggerTypesJson = (triggerTypes: ReadonlyArray<TriggerType>): string =>
+  JSON.stringify(
+    triggerTypes.map(triggerType => ({
+      slug: triggerType.slug,
+      name: triggerType.name,
+      type: triggerType.type,
+      description: triggerType.description,
+    })),
+    null,
+    2
+  );
+
+function formatSchemaProperties(schema: Record<string, unknown>): string {
+  const properties = schema['properties'] as Record<string, Record<string, unknown>> | undefined;
+  if (!properties || Object.keys(properties).length === 0) {
+    return '  (none)';
+  }
+
+  const requiredArr = (schema['required'] as string[] | undefined) ?? [];
+  const requiredSet = new Set(requiredArr);
+
+  const entries = Object.entries(properties).map(([name, prop]) => {
+    const type = (prop['type'] as string) ?? 'unknown';
+    const label = requiredSet.has(name) ? 'required' : 'optional';
+    const description = prop['description'] as string | undefined;
+    const hasDefault = Object.prototype.hasOwnProperty.call(prop, 'default');
+    const defaultValue = hasDefault ? prop['default'] : undefined;
+    return { name, type, label, description, hasDefault, defaultValue };
+  });
+
+  const typeWidth = Math.max(...entries.map(e => e.type.length));
+  const labelWidth = Math.max(...entries.map(e => e.label.length));
+
+  return entries
+    .map(e => {
+      const lines: string[] = [];
+      lines.push(`  ${bold(e.name)}`);
+      lines.push(
+        `    ${bold('description:')} ${e.description ? gray(truncate(e.description, 70)) : '-'}`
+      );
+      lines.push(`    ${bold('type:')} ${e.type.padEnd(typeWidth)}`);
+      lines.push(`    ${bold('required:')} ${e.label.padEnd(labelWidth)}`);
+      if (e.hasDefault) {
+        lines.push(`    ${bold('default:')} ${gray(truncate(JSON.stringify(e.defaultValue), 40))}`);
+      }
+      return lines.join('\n');
+    })
+    .join('\n\n');
+}
+
+export const formatTriggerTypeInfo = (triggerType: TriggerType): string => {
+  const lines: string[] = [];
+
+  lines.push(`${bold('Name:')} ${triggerType.name}`);
+  lines.push(`${bold('Slug:')} ${triggerType.slug}`);
+  lines.push(`${bold('Type:')} ${triggerType.type}`);
+  lines.push(`${bold('Description:')} ${triggerType.description}`);
+  lines.push(`${bold('Instructions:')} ${triggerType.instructions}`);
+
+  lines.push('');
+  lines.push(bold('Config Fields:'));
+  lines.push(formatSchemaProperties(triggerType.config));
+
+  lines.push('');
+  lines.push(bold('Payload Fields:'));
+  lines.push(formatSchemaProperties(triggerType.payload));
+
+  return lines.join('\n');
 };

--- a/ts/packages/cli/src/commands/triggers/format.ts
+++ b/ts/packages/cli/src/commands/triggers/format.ts
@@ -2,6 +2,7 @@ import type { TriggerType } from 'src/models/trigger-types';
 import type { TriggerListenEvent } from './types';
 import { bold, gray } from 'src/ui/colors';
 import { truncate } from 'src/ui/truncate';
+import { extractSchemaProperties } from 'src/ui/extract-schema-properties';
 
 export const formatTriggerListenSummary = (event: TriggerListenEvent): string => {
   const userId = event.userId || '-';
@@ -79,7 +80,9 @@ export const formatTriggerTypesTable = (triggerTypes: ReadonlyArray<TriggerType>
     const name = truncate(triggerType.name, TRIGGER_TYPES_TABLE.name).padEnd(
       TRIGGER_TYPES_TABLE.name
     );
-    const type = triggerType.type.padEnd(TRIGGER_TYPES_TABLE.type);
+    const type = truncate(triggerType.type, TRIGGER_TYPES_TABLE.type).padEnd(
+      TRIGGER_TYPES_TABLE.type
+    );
     const description = gray(truncate(triggerType.description, 50));
     return `${slug} ${name} ${type} ${description}`;
   });
@@ -100,22 +103,10 @@ export const formatTriggerTypesJson = (triggerTypes: ReadonlyArray<TriggerType>)
   );
 
 function formatSchemaProperties(schema: Record<string, unknown>): string {
-  const properties = schema['properties'] as Record<string, Record<string, unknown>> | undefined;
-  if (!properties || Object.keys(properties).length === 0) {
+  const entries = extractSchemaProperties(schema);
+  if (entries.length === 0) {
     return '  (none)';
   }
-
-  const requiredArr = (schema['required'] as string[] | undefined) ?? [];
-  const requiredSet = new Set(requiredArr);
-
-  const entries = Object.entries(properties).map(([name, prop]) => {
-    const type = (prop['type'] as string) ?? 'unknown';
-    const label = requiredSet.has(name) ? 'required' : 'optional';
-    const description = prop['description'] as string | undefined;
-    const hasDefault = Object.prototype.hasOwnProperty.call(prop, 'default');
-    const defaultValue = hasDefault ? prop['default'] : undefined;
-    return { name, type, label, description, hasDefault, defaultValue };
-  });
 
   const typeWidth = Math.max(...entries.map(e => e.type.length));
   const labelWidth = Math.max(...entries.map(e => e.label.length));

--- a/ts/packages/cli/src/commands/triggers/format.ts
+++ b/ts/packages/cli/src/commands/triggers/format.ts
@@ -119,18 +119,22 @@ function formatSchemaProperties(schema: Record<string, unknown>): string {
 
   const typeWidth = Math.max(...entries.map(e => e.type.length));
   const labelWidth = Math.max(...entries.map(e => e.label.length));
+  const metadataLabels = ['description:', 'type:', 'required:', 'default:'] as const;
+  const metadataLabelWidth = Math.max(...metadataLabels.map(label => label.length));
 
   return entries
     .map(e => {
       const lines: string[] = [];
       lines.push(`  ${bold(e.name)}`);
       lines.push(
-        `    ${bold('description:')} ${e.description ? gray(truncate(e.description, 70)) : '-'}`
+        `    ${'description:'.padEnd(metadataLabelWidth)} ${e.description ? gray(truncate(e.description, 70)) : '-'}`
       );
-      lines.push(`    ${bold('type:')} ${e.type.padEnd(typeWidth)}`);
-      lines.push(`    ${bold('required:')} ${e.label.padEnd(labelWidth)}`);
+      lines.push(`    ${'type:'.padEnd(metadataLabelWidth)} ${e.type.padEnd(typeWidth)}`);
+      lines.push(`    ${'required:'.padEnd(metadataLabelWidth)} ${e.label.padEnd(labelWidth)}`);
       if (e.hasDefault) {
-        lines.push(`    ${bold('default:')} ${gray(truncate(JSON.stringify(e.defaultValue), 40))}`);
+        lines.push(
+          `    ${'default:'.padEnd(metadataLabelWidth)} ${gray(truncate(JSON.stringify(e.defaultValue), 40))}`
+        );
       }
       return lines.join('\n');
     })
@@ -147,10 +151,12 @@ export const formatTriggerTypeInfo = (triggerType: TriggerType): string => {
   lines.push(`${bold('Instructions:')} ${triggerType.instructions}`);
 
   lines.push('');
+  lines.push(gray('------------------------------'));
   lines.push(bold('Config Fields:'));
   lines.push(formatSchemaProperties(triggerType.config));
 
   lines.push('');
+  lines.push(gray('------------------------------'));
   lines.push(bold('Payload Fields:'));
   lines.push(formatSchemaProperties(triggerType.payload));
 

--- a/ts/packages/cli/src/commands/triggers/parse-csv.ts
+++ b/ts/packages/cli/src/commands/triggers/parse-csv.ts
@@ -1,0 +1,5 @@
+export const parseCsv = (value: string): ReadonlyArray<string> =>
+  value
+    .split(',')
+    .map(item => item.trim())
+    .filter(Boolean);

--- a/ts/packages/cli/src/commands/triggers/triggers.cmd.ts
+++ b/ts/packages/cli/src/commands/triggers/triggers.cmd.ts
@@ -1,4 +1,6 @@
 import { Command } from '@effect/cli';
+import { triggersCmd$Info } from './commands/triggers.info.cmd';
+import { triggersCmd$List } from './commands/triggers.list.cmd';
 import { triggersCmd$Listen } from './commands/triggers.listen.cmd';
 
 /**
@@ -10,6 +12,6 @@ import { triggersCmd$Listen } from './commands/triggers.listen.cmd';
  * ```
  */
 export const triggersCmd = Command.make('triggers').pipe(
-  Command.withDescription('Subscribe to realtime trigger events.'),
-  Command.withSubcommands([triggersCmd$Listen])
+  Command.withDescription('List trigger types and subscribe to realtime trigger events.'),
+  Command.withSubcommands([triggersCmd$List, triggersCmd$Info, triggersCmd$Listen])
 );

--- a/ts/packages/cli/src/models/trigger-types.ts
+++ b/ts/packages/cli/src/models/trigger-types.ts
@@ -61,7 +61,12 @@ export const TriggerType = Schema.Struct({
   /**
    * Information about the toolkit that provides this trigger
    */
-  // toolkit: Toolkit,
+  toolkit: Schema.optional(
+    Schema.Struct({
+      name: Schema.String,
+      slug: Schema.String,
+    })
+  ),
 
   /**
    * The trigger mechanism - either webhook (event-based) or poll (scheduled check)

--- a/ts/packages/cli/src/services/composio-clients-cached.ts
+++ b/ts/packages/cli/src/services/composio-clients-cached.ts
@@ -180,6 +180,9 @@ export const ComposioToolkitsRepositoryCached = Layer.effect(
         );
       },
 
+      // Trigger type detail should NOT be cached (single-item fetch, should be fresh)
+      getTriggerTypeDetailed: slug => underlyingRepository.getTriggerTypeDetailed(slug),
+
       getTriggerTypes: (toolkitSlugs?: ReadonlyArray<string>) => {
         const cacheFilter =
           toolkitSlugs && toolkitSlugs.length > 0

--- a/ts/packages/cli/src/services/composio-clients.ts
+++ b/ts/packages/cli/src/services/composio-clients.ts
@@ -1084,6 +1084,18 @@ export class ComposioClientLive extends Effect.Service<ComposioClientLive>()(
               )
             ),
           /**
+           * Retrieves detailed info about a single trigger type by slug.
+           * @param slug - Trigger type slug (e.g. "GMAIL_NEW_GMAIL_MESSAGE")
+           */
+          retrieve: (slug: string) =>
+            withMetrics(
+              callClient(
+                clientSingleton,
+                client => client.triggersTypes.retrieve(slug),
+                TriggerType
+              )
+            ),
+          /**
            * Retrieve a list of trigger types, automatically handling pagination.
            * @param toolkitSlugs - Optional array of toolkit slugs to filter by
            */
@@ -1246,6 +1258,11 @@ export class ComposioToolkitsRepository extends Effect.Service<ComposioToolkitsR
             )
           ),
         getTriggerTypesAsEnums: () => client.triggersTypes.retrieveEnum(),
+        /**
+         * Retrieves detailed info about a single trigger type by slug.
+         * @param slug - Trigger type slug (e.g. "GMAIL_NEW_GMAIL_MESSAGE")
+         */
+        getTriggerTypeDetailed: (slug: string) => client.triggersTypes.retrieve(slug),
         /**
          * Fetches trigger types with optional toolkit filtering.
          * When toolkitSlugs is provided, fetches all matching trigger types.

--- a/ts/packages/cli/src/ui/extract-schema-properties.ts
+++ b/ts/packages/cli/src/ui/extract-schema-properties.ts
@@ -1,0 +1,36 @@
+export interface SchemaPropertyEntry {
+  readonly name: string;
+  readonly type: string;
+  readonly label: 'required' | 'optional';
+  readonly description?: string;
+  readonly hasDefault: boolean;
+  readonly defaultValue: unknown;
+}
+
+export function extractSchemaProperties(
+  schema: Record<string, unknown>
+): ReadonlyArray<SchemaPropertyEntry> {
+  const properties = schema['properties'] as Record<string, Record<string, unknown>> | undefined;
+  if (!properties || Object.keys(properties).length === 0) {
+    return [];
+  }
+
+  const requiredArr = (schema['required'] as string[] | undefined) ?? [];
+  const requiredSet = new Set(requiredArr);
+
+  return Object.entries(properties).map(([name, prop]) => {
+    const type = (prop['type'] as string) ?? 'unknown';
+    const label = requiredSet.has(name) ? 'required' : 'optional';
+    const description = prop['description'] as string | undefined;
+    const hasDefault = Object.prototype.hasOwnProperty.call(prop, 'default');
+    const defaultValue = hasDefault ? prop['default'] : undefined;
+    return {
+      name,
+      type,
+      label,
+      description,
+      hasDefault,
+      defaultValue,
+    };
+  });
+}

--- a/ts/packages/cli/test/__utils__/services/test-layer.ts
+++ b/ts/packages/cli/test/__utils__/services/test-layer.ts
@@ -184,6 +184,17 @@ export const TestLayer = (input?: TestLiveInput) =>
           }
           return Effect.succeed(triggers);
         },
+        getTriggerTypeDetailed: (slug: string) => {
+          const found = toolkitsData.triggerTypes.find(
+            trigger => trigger.slug.toUpperCase() === slug.toUpperCase()
+          );
+          if (!found) {
+            return Effect.fail(
+              new HttpServerError({ cause: `Trigger type "${slug}" not found`, status: 404 })
+            );
+          }
+          return Effect.succeed(found);
+        },
         getTools: (toolkitSlugs?: ReadonlyArray<string>) => {
           let tools = toolkitsData.tools;
           if (toolkitSlugs && toolkitSlugs.length > 0) {

--- a/ts/packages/cli/test/src/commands/$default.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/$default.cmd.test.ts
@@ -122,7 +122,11 @@ describe('CLI: composio', () => {
 
             - connected-accounts link --auth-config text [--user-id text] [--no-browser]                                                                                                                          Link an external account via OAuth redirect.
 
-            - triggers                                                                                                                                                                                            Subscribe to realtime trigger events.
+            - triggers                                                                                                                                                                                            List trigger types and subscribe to realtime trigger events.
+
+            - triggers list [--toolkits text] [--limit integer]                                                                                                                                                   List available trigger types.
+
+            - triggers info [<slug>]                                                                                                                                                                              View details of a specific trigger type.
 
             - triggers listen [--toolkits text] [--trigger-id text] [--connected-account-id text] [--trigger-slug text] [--user-id text] [--json] [--table] [--max-events integer] [--forward text] [--out text]  Listen to realtime trigger events for your project.
           "

--- a/ts/packages/cli/test/src/commands/triggers/triggers.info.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/triggers/triggers.info.cmd.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, layer } from '@effect/vitest';
+import { ConfigProvider, Effect } from 'effect';
+import { extendConfigProvider } from 'src/services/config';
+import { cli, MockConsole, TestLive } from 'test/__utils__';
+import type { TriggerTypes } from 'src/models/trigger-types';
+import type { TestLiveInput } from 'test/__utils__/services/test-layer';
+
+const testTriggerTypes: TriggerTypes = [
+  {
+    slug: 'GMAIL_NEW_GMAIL_MESSAGE',
+    name: 'NEW_GMAIL_MESSAGE',
+    description: 'Fires when a new message arrives in Gmail',
+    instructions: 'Connect Gmail and subscribe to this trigger',
+    type: 'webhook',
+    config: {
+      type: 'object',
+      properties: {
+        label: { type: 'string', description: 'Label filter for inbox messages' },
+        include_spam: {
+          type: 'boolean',
+          description: 'Include spam messages',
+          default: false,
+        },
+      },
+      required: ['label'],
+    },
+    payload: {
+      type: 'object',
+      properties: {
+        subject: { type: 'string', description: 'Email subject line' },
+        from: { type: 'string', description: 'Sender email address' },
+      },
+      required: ['subject'],
+    },
+  },
+  {
+    slug: 'SLACK_NEW_MESSAGE',
+    name: 'NEW_MESSAGE',
+    description: 'Fires when a new message is posted in Slack',
+    instructions: 'Connect Slack and subscribe to this trigger',
+    type: 'webhook',
+    config: { type: 'object', properties: {} },
+    payload: { type: 'object', properties: {} },
+  },
+];
+
+const toolkitsData = {
+  triggerTypes: testTriggerTypes,
+} satisfies TestLiveInput['toolkitsData'];
+
+const testConfigProvider = ConfigProvider.fromMap(
+  new Map([['COMPOSIO_API_KEY', 'test_api_key']])
+).pipe(extendConfigProvider);
+
+describe('CLI: composio triggers info', () => {
+  layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
+    '[Given] valid slug [Then] displays trigger type info',
+    it => {
+      it.scoped('shows trigger details with config and payload fields', () =>
+        Effect.gen(function* () {
+          yield* cli(['triggers', 'info', 'GMAIL_NEW_GMAIL_MESSAGE']);
+          const lines = yield* MockConsole.getLines({ stripAnsi: true });
+          const output = lines.join('\n');
+
+          expect(output).toContain('NEW_GMAIL_MESSAGE');
+          expect(output).toContain('GMAIL_NEW_GMAIL_MESSAGE');
+          expect(output).toContain('Config Fields');
+          expect(output).toContain('label');
+          expect(output).toContain('required');
+          expect(output).toContain('Payload Fields');
+          expect(output).toContain('subject');
+          expect(output).toContain('default: false');
+          expect(output).toContain('composio triggers list --toolkits "gmail"');
+        })
+      );
+    }
+  );
+
+  layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
+    '[Given] no slug [Then] warns missing argument',
+    it => {
+      it.scoped('shows missing argument warning', () =>
+        Effect.gen(function* () {
+          yield* cli(['triggers', 'info']);
+          const lines = yield* MockConsole.getLines({ stripAnsi: true });
+          const output = lines.join('\n');
+
+          expect(output).toContain('Missing required argument');
+        })
+      );
+    }
+  );
+
+  layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
+    '[Given] invalid slug [Then] shows not found hint',
+    it => {
+      it.scoped('shows not found fallback hint', () =>
+        Effect.gen(function* () {
+          yield* cli(['triggers', 'info', 'NONEXISTENT_TRIGGER']);
+          const lines = yield* MockConsole.getLines({ stripAnsi: true });
+          const output = lines.join('\n');
+
+          expect(output).toContain('not found');
+          expect(output).toContain('composio triggers list');
+        })
+      );
+    }
+  );
+
+  layer(TestLive())('[Given] no API key [Then] warns user to login', it => {
+    it.scoped('warns user to login', () =>
+      Effect.gen(function* () {
+        yield* cli(['triggers', 'info', 'GMAIL_NEW_GMAIL_MESSAGE']);
+        const lines = yield* MockConsole.getLines({ stripAnsi: true });
+        const output = lines.join('\n');
+
+        expect(output).toContain('not logged in');
+      })
+    );
+  });
+});

--- a/ts/packages/cli/test/src/commands/triggers/triggers.info.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/triggers/triggers.info.cmd.test.ts
@@ -69,7 +69,8 @@ describe('CLI: composio triggers info', () => {
           expect(output).toContain('required');
           expect(output).toContain('Payload Fields');
           expect(output).toContain('subject');
-          expect(output).toContain('default: false');
+          expect(output).toContain('default:');
+          expect(output).toContain('false');
           expect(output).toContain('composio triggers list --toolkits "gmail"');
         })
       );

--- a/ts/packages/cli/test/src/commands/triggers/triggers.info.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/triggers/triggers.info.cmd.test.ts
@@ -11,6 +11,7 @@ const testTriggerTypes: TriggerTypes = [
     name: 'NEW_GMAIL_MESSAGE',
     description: 'Fires when a new message arrives in Gmail',
     instructions: 'Connect Gmail and subscribe to this trigger',
+    toolkit: { name: 'Gmail', slug: 'gmail' },
     type: 'webhook',
     config: {
       type: 'object',
@@ -38,6 +39,7 @@ const testTriggerTypes: TriggerTypes = [
     name: 'NEW_MESSAGE',
     description: 'Fires when a new message is posted in Slack',
     instructions: 'Connect Slack and subscribe to this trigger',
+    toolkit: { name: 'Slack', slug: 'slack' },
     type: 'webhook',
     config: { type: 'object', properties: {} },
     payload: { type: 'object', properties: {} },

--- a/ts/packages/cli/test/src/commands/triggers/triggers.list.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/triggers/triggers.list.cmd.test.ts
@@ -11,6 +11,7 @@ const testTriggerTypes: TriggerTypes = [
     name: 'NEW_GMAIL_MESSAGE',
     description: 'Fires when a new message arrives in Gmail',
     instructions: 'Connect Gmail and subscribe to this trigger',
+    toolkit: { name: 'Gmail', slug: 'gmail' },
     type: 'webhook',
     config: { type: 'object', properties: {} },
     payload: { type: 'object', properties: {} },
@@ -20,6 +21,7 @@ const testTriggerTypes: TriggerTypes = [
     name: 'NEW_LABEL',
     description: 'Fires when a new label is created in Gmail',
     instructions: 'Connect Gmail and subscribe to this trigger',
+    toolkit: { name: 'Gmail', slug: 'gmail' },
     type: 'poll',
     config: { type: 'object', properties: {} },
     payload: { type: 'object', properties: {} },
@@ -29,6 +31,7 @@ const testTriggerTypes: TriggerTypes = [
     name: 'NEW_MESSAGE',
     description: 'Fires when a new message is posted in Slack',
     instructions: 'Connect Slack and subscribe to this trigger',
+    toolkit: { name: 'Slack', slug: 'slack' },
     type: 'webhook',
     config: { type: 'object', properties: {} },
     payload: { type: 'object', properties: {} },
@@ -80,15 +83,31 @@ describe('CLI: composio triggers list', () => {
   );
 
   layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
-    '[Given] --limit 1 [Then] lists one trigger type',
+    '[Given] --limit 1 [Then] lists one trigger type with singular grammar',
     it => {
-      it.scoped('respects limit', () =>
+      it.scoped('uses singular form for one result', () =>
         Effect.gen(function* () {
           yield* cli(['triggers', 'list', '--limit', '1']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
-          expect(output).toContain('Listing 1 trigger types');
+          expect(output).toContain('Listing 1 trigger type');
+          expect(output).not.toContain('Listing 1 trigger types');
+        })
+      );
+    }
+  );
+
+  layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
+    '[Given] no flags [Then] shows next step hint',
+    it => {
+      it.scoped('shows hint to view trigger details', () =>
+        Effect.gen(function* () {
+          yield* cli(['triggers', 'list']);
+          const lines = yield* MockConsole.getLines({ stripAnsi: true });
+          const output = lines.join('\n');
+
+          expect(output).toContain('composio triggers info');
         })
       );
     }

--- a/ts/packages/cli/test/src/commands/triggers/triggers.list.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/triggers/triggers.list.cmd.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, layer } from '@effect/vitest';
+import { ConfigProvider, Effect } from 'effect';
+import { extendConfigProvider } from 'src/services/config';
+import { cli, MockConsole, TestLive } from 'test/__utils__';
+import type { TriggerTypes } from 'src/models/trigger-types';
+import type { TestLiveInput } from 'test/__utils__/services/test-layer';
+
+const testTriggerTypes: TriggerTypes = [
+  {
+    slug: 'GMAIL_NEW_GMAIL_MESSAGE',
+    name: 'NEW_GMAIL_MESSAGE',
+    description: 'Fires when a new message arrives in Gmail',
+    instructions: 'Connect Gmail and subscribe to this trigger',
+    type: 'webhook',
+    config: { type: 'object', properties: {} },
+    payload: { type: 'object', properties: {} },
+  },
+  {
+    slug: 'GMAIL_NEW_LABEL',
+    name: 'NEW_LABEL',
+    description: 'Fires when a new label is created in Gmail',
+    instructions: 'Connect Gmail and subscribe to this trigger',
+    type: 'poll',
+    config: { type: 'object', properties: {} },
+    payload: { type: 'object', properties: {} },
+  },
+  {
+    slug: 'SLACK_NEW_MESSAGE',
+    name: 'NEW_MESSAGE',
+    description: 'Fires when a new message is posted in Slack',
+    instructions: 'Connect Slack and subscribe to this trigger',
+    type: 'webhook',
+    config: { type: 'object', properties: {} },
+    payload: { type: 'object', properties: {} },
+  },
+];
+
+const toolkitsData = {
+  triggerTypes: testTriggerTypes,
+} satisfies TestLiveInput['toolkitsData'];
+
+const testConfigProvider = ConfigProvider.fromMap(
+  new Map([['COMPOSIO_API_KEY', 'test_api_key']])
+).pipe(extendConfigProvider);
+
+describe('CLI: composio triggers list', () => {
+  layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
+    '[Given] no flags [Then] lists all trigger types',
+    it => {
+      it.scoped('lists all trigger types', () =>
+        Effect.gen(function* () {
+          yield* cli(['triggers', 'list']);
+          const lines = yield* MockConsole.getLines({ stripAnsi: true });
+          const output = lines.join('\n');
+
+          expect(output).toContain('GMAIL_NEW_GMAIL_MESSAGE');
+          expect(output).toContain('SLACK_NEW_MESSAGE');
+          expect(output).toContain('Listing 3 trigger types');
+        })
+      );
+    }
+  );
+
+  layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
+    '[Given] --toolkits "gmail" [Then] lists only gmail trigger types',
+    it => {
+      it.scoped('filters by toolkit', () =>
+        Effect.gen(function* () {
+          yield* cli(['triggers', 'list', '--toolkits', 'gmail']);
+          const lines = yield* MockConsole.getLines({ stripAnsi: true });
+          const output = lines.join('\n');
+
+          expect(output).toContain('GMAIL_NEW_GMAIL_MESSAGE');
+          expect(output).toContain('GMAIL_NEW_LABEL');
+          expect(output).not.toContain('SLACK_NEW_MESSAGE');
+          expect(output).toContain('Listing 2 trigger types');
+        })
+      );
+    }
+  );
+
+  layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
+    '[Given] --limit 1 [Then] lists one trigger type',
+    it => {
+      it.scoped('respects limit', () =>
+        Effect.gen(function* () {
+          yield* cli(['triggers', 'list', '--limit', '1']);
+          const lines = yield* MockConsole.getLines({ stripAnsi: true });
+          const output = lines.join('\n');
+
+          expect(output).toContain('Listing 1 trigger types');
+        })
+      );
+    }
+  );
+
+  layer(TestLive())('[Given] no API key [Then] warns user to login', it => {
+    it.scoped('warns user to login', () =>
+      Effect.gen(function* () {
+        yield* cli(['triggers', 'list']);
+        const lines = yield* MockConsole.getLines({ stripAnsi: true });
+        const output = lines.join('\n');
+
+        expect(output).toContain('not logged in');
+      })
+    );
+  });
+
+  layer(TestLive({ baseConfigProvider: testConfigProvider }))(
+    '[Given] empty results [Then] shows no trigger types found',
+    it => {
+      it.scoped('shows no trigger types found', () =>
+        Effect.gen(function* () {
+          yield* cli(['triggers', 'list']);
+          const lines = yield* MockConsole.getLines({ stripAnsi: true });
+          const output = lines.join('\n');
+
+          expect(output).toContain('No trigger types found');
+        })
+      );
+    }
+  );
+
+  layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
+    '[Given] --toolkits "nonexistent" [Then] shows no trigger types found with hint',
+    it => {
+      it.scoped('shows hint about verifying toolkit slug', () =>
+        Effect.gen(function* () {
+          yield* cli(['triggers', 'list', '--toolkits', 'nonexistent']);
+          const lines = yield* MockConsole.getLines({ stripAnsi: true });
+          const output = lines.join('\n');
+
+          expect(output).toContain('No trigger types found');
+          expect(output).toContain('composio toolkits list');
+        })
+      );
+    }
+  );
+});


### PR DESCRIPTION
## Summary
- add `composio triggers list` with `--toolkits` filter and `--limit` support, reusing list-style table/json output conventions
- add `composio triggers info <slug>` to inspect trigger details including config/payload field metadata and default values
- expand trigger command formatting and add test coverage for list/info flows (auth, empty state, filtering, missing args, not-found)

## Dependency
- this PR depends on `plen-1580-cli-local-trigger-development-experience-listen`
- base branch is set to `plen-1580-cli-local-trigger-development-experience-listen`

## Test plan
- [x] `pnpm test test/src/commands/triggers/triggers.list.cmd.test.ts test/src/commands/triggers/triggers.info.cmd.test.ts`
- [x] `pnpm run typecheck`

Made with [Cursor](https://cursor.com)