### PR TITLE
docs: add chat app tutorial and revamp welcome page

### DIFF
--- a/docs/.claude/plan.md
+++ b/docs/.claude/plan.md
@@ -1,0 +1,190 @@
+# Cookbooks Complete Revamp — Task Tracker
+
+**Goal:** Transform cookbooks into a use-case-driven section with scannable card overview, concise dual-language examples, problem-first framing, and a Modal-inspired index page. All code uses the `session.create` paradigm exclusively.
+
+---
+
+## Phase 1: Foundation & Structure
+
+### 1.0 Rename Examples → Cookbooks ✅
+
+- [x] Renamed `content/examples/` → `content/cookbooks/`
+- [x] Updated all source configs, routes, nav, search, LLM endpoints, sitemap
+- [x] Added `/examples/` → `/cookbooks/` permanent redirects
+- PR #2638 (merged)
+
+### 1.1 Review & Update Provider Pages
+
+**LLM Guardrails** ✅
+
+- [x] Session guardrails (default, ~1100+ pages)
+- [x] Direct execution guardrails (12 tagged pages)
+- [x] Pipeline injection via `getLLMText()`
+- [x] `llms-full.txt` and `llms.txt` updated
+
+**Existing Providers (review & update)** ✅
+
+- [x] `openai.mdx` — Responses API + Chat Completions
+- [x] `anthropic.mdx` — Messages API, Steps pattern
+- [x] `google.mdx` — Chat API, Steps pattern
+- [x] `vercel.mdx` — Native tools only, Steps pattern
+- [x] `langchain.mdx` — PR #2651
+- [x] `llamaindex.mdx` — PR #2651
+- [x] `mastra.mdx` — PR #2651
+- [x] `crewai.mdx` — PR #2651 + PR #2650 (strict mode fix)
+- [x] `openai-agents.mdx` — PR #2651
+
+**New Providers (write from scratch)**
+
+- [x] `claude-agent-sdk.mdx` — Python + TS (PR #2651)
+- [x] `autogen.mdx` — Python only (PR #2651, SDK has broken imports — PLEN-1603)
+- [x] `google-adk.mdx` — Python only (PR #2651)
+- [ ] `langgraph.mdx` — Python only (not started)
+- [x] Providers index page with card grid (PR #2655)
+- Cloudflare removed (PLEN-1602 for e2e testing)
+
+**PRs:**
+- #2651 — Providers revamp (merged into next)
+- #2655 — Providers index page + reorder
+- #2650 — CrewAI strict mode fix
+- #2647 — LangChain serialization fix
+
+**Linear Tickets:**
+- PLEN-1602 — Cloudflare e2e testing
+- PLEN-1603 — AutoGen broken imports
+
+### 1.2 Move existing cookbooks to guides/ subfolder — DEFERRED
+
+- [ ] Move `fast-api`, `hono`, `slack-summariser`, `vercel-chat`, `tool-generator` to `content/cookbooks/guides/`
+- [ ] Delete `gmail-labeler.mdx` and `supabase-sql-agent.mdx`
+- [ ] Add redirects
+- Deferred until after Phase 2
+
+### 1.3 Rewrite cookbooks meta.json — DEFERRED
+
+- [ ] New category structure (Code & DevOps, Communication, Sales, Research, etc.)
+- Deferred until after Phase 2
+
+### 1.4 Create "Use Composio With" section — DEFERRED
+
+- [ ] chatgpt, agent-builder, claude-desktop, claude-code, cursor, vscode, mcp-url, n8n
+- Deferred until after Phase 2
+
+### 1.5 Rewrite cookbooks index page — DEFERRED
+
+- [ ] Card-grid overview inspired by Modal
+- Deferred until after Phase 2
+
+---
+
+## Phase 2: Write New Use-Case Cookbooks
+
+**Template for each cookbook:**
+- Title + 1-paragraph description
+- What You'll Build (2-3 bullets)
+- Prerequisites (API keys, connected accounts)
+- Implementation (code in files, imported via include)
+- How It Works
+- Next Steps
+
+**Key rules:**
+- All code uses `session.create` paradigm exclusively
+- No auth boilerplate — link to `/docs/authentication`
+- Code lives in `docs/cookbooks/{name}/` directory, imported into MDX via include
+- Action-oriented titles
+
+### Priority 1 (highest impact)
+
+- [x] `chat-app` — Build a Chat App (PR #2728, branch: `docs/chat-app-1`)
+- [ ] `slack-bot` — Build a Slack Bot (Vercel AI SDK + Composio)
+- [ ] `pr-review-agent` — Build a PR Review Agent (GitHub)
+- [ ] `gmail-auto-labeler` — Build a Gmail Auto-Labeler (Gmail)
+- [ ] `slack-summarizer` — Build a Slack Channel Summarizer (Slack)
+- [ ] `mcp-setup` — Connect Composio Tools via MCP
+- [ ] `research-agent` — Build a Research Agent (Web Search, Scraping)
+
+### Priority 2
+
+- [ ] `lead-enrichment` — Build a Lead Enrichment Agent (HubSpot, Web)
+- [ ] `email-at-scale` — Send Personalized Emails at Scale (Gmail)
+- [ ] `issue-triage` — Auto-Triage GitHub Issues (GitHub)
+- [ ] `meeting-notes-to-notion` — Sync Meeting Notes to Notion (Notion)
+- [ ] `sheets-sync` — Sync Data to Google Sheets (Google Sheets)
+
+### Priority 3
+
+- [ ] `email-trigger-agent` — Run an Agent on New Emails (Gmail, Triggers)
+- [ ] `daily-digest` — Daily GitHub Digest to Slack (GitHub, Slack)
+- [ ] `calendar-agent` — Create Calendar Events from Natural Language (Google Calendar)
+- [ ] `ci-failure-notifier` — Post CI Failures to Discord (GitHub, Discord)
+- [ ] `social-posting` — Social Media Content Agent (LinkedIn, Twitter)
+- [ ] `voice-agent` — Build a Voice Agent with Tool Calling (Voice, TBD)
+
+---
+
+## Phase 3: Write Framework Cookbooks
+
+Full-stack templates live as cloneable repos on GitHub. Docs pages describe what the template does, show key snippets, and link to the repo.
+
+### TypeScript Frameworks
+
+- [ ] `express.mdx`
+- [ ] `fastify.mdx`
+- [ ] `hono.mdx`
+- [ ] `nextjs.mdx`
+- [ ] `nestjs.mdx`
+- [ ] `nuxt.mdx`
+- [ ] `sveltekit.mdx`
+- [ ] `node-http.mdx`
+
+### Python Frameworks
+
+- [ ] `fastapi.mdx`
+- [ ] `flask.mdx`
+- [ ] `django.mdx`
+
+---
+
+## Phase 4: Polish
+
+- [ ] Run `bun run build` to validate all TypeScript code blocks
+- [ ] Test mobile layout
+- [ ] Verify all cross-links work
+- [ ] Update `.claude/decisions/examples.md` with status
+
+---
+
+## Phase 5: Revamp Cookbooks Index Page
+
+- [ ] Visual card grid with categories (Modal-inspired)
+- [ ] Each card: title, short description, toolkit tags
+- [ ] Featured/popular section at top
+- [ ] Update incrementally as cookbooks are added
+
+---
+
+## Decisions & Notes
+
+- Code files live at `docs/examples/{cookbook-name}/` (excluded from tsconfig, type-checked by twoslash via `<include>`)
+- MDX pages use fumadocs `<include>` component to import code from files
+- Cookbooks link to GitHub source: `github.com/ComposioHQ/composio/tree/master/docs/examples/{name}`
+- Tools count is now 1000+ (not 250+)
+- Phase 1.2–1.5 deferred until after Phase 2 for continuous shipping
+- Twoslash JSX fix: added `jsx: ReactJSX` + `jsxImportSource: react` to twoslash compilerOptions in source.config.ts (global fix for all TSX code blocks)
+- `examples/` excluded from tsconfig.json (twoslash handles type-checking via `<include>`, Next.js `tsc` can't resolve local relative imports)
+- Welcome page revamped: hero cards (Tutorial + How it works), full-width Quickstart, AIToolsBanner component, Explore section
+- AIToolsBanner component has markdown fallback in `lib/source.ts` for LLM crawlers
+
+---
+
+## Summary
+
+| Phase | Status |
+|-------|--------|
+| 1.0 Rename Examples → Cookbooks | ✅ Done |
+| 1.1 Provider Pages | ✅ Done (except `langgraph.mdx`) |
+| 1.2–1.5 Structure & Index | Deferred |
+| 2 Use-Case Cookbooks | In progress (1 done, 17 remaining) |
+| 3 Framework Cookbooks | Not started (11 cookbooks) |
+| 4 Polish | Not started |
+| 5 Index Page Revamp | Not started |

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -70,6 +70,10 @@ Detailed documentation for Claude is organized in `.claude/`:
    - Dynamic toolkit pages are validated against slugs from `public/data/toolkits.json`
    - Non-Fumadocs `.md` files (like FAQ snippets) are picked up via `content/**/*.md` glob
 
+## Code Review Guidelines
+
+**`docs/examples/` is tutorial code.** Review for correctness and clarity, not production-readiness. Skip accessibility (aria attributes, focus management), error boundaries, i18n, comprehensive error handling, and similar concerns that add noise to a teaching example. The goal is to teach Composio integration with minimal code.
+
 ## AI-Native Documentation
 
 **Prefer cURL over "click"** - Most docs traffic comes from AI crawlers. When documenting API interactions, prefer showing cURL commands over UI instructions like "click this button" or "navigate to settings". cURL is machine-readable and can be directly executed by AI agents.

--- a/docs/bun.lock
+++ b/docs/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "fumadocs",
@@ -26,6 +27,7 @@
         "@ai-sdk/anthropic": "^3.0.11",
         "@ai-sdk/mcp": "^1.0.6",
         "@ai-sdk/openai": "^3.0.9",
+        "@ai-sdk/react": "^3.0.99",
         "@anthropic-ai/claude-agent-sdk": "^0.2.5",
         "@anthropic-ai/sdk": "^0.71.2",
         "@composio/anthropic": "^0.5.5",
@@ -89,6 +91,8 @@
     "@ai-sdk/provider-v5": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
 
     "@ai-sdk/provider-v6": ["@ai-sdk/provider@3.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-m9ka3ptkPQbaHHZHqDXDF9C9B5/Mav0KTdky1k2HZ3/nrW2t1AgObxIVPyGDWQNS9FXT/FS6PIoSjpcP/No8rQ=="],
+
+    "@ai-sdk/react": ["@ai-sdk/react@3.0.99", "", { "dependencies": { "@ai-sdk/provider-utils": "4.0.15", "ai": "6.0.97", "swr": "^2.2.5", "throttleit": "2.1.0" }, "peerDependencies": { "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1" } }, "sha512-xMsp5br4Dpr/3BYq/jrE8q4YLgViU1KHVq8VB0+dzdLJFU3jKA83uoxpbWqzV/edQOBPgGBSb2CgmV5v77rvzA=="],
 
     "@ai-sdk/ui-utils-v5": ["@ai-sdk/ui-utils@1.2.11", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8", "zod-to-json-schema": "^3.24.1" }, "peerDependencies": { "zod": "^3.23.8" } }, "sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w=="],
 
@@ -2092,11 +2096,15 @@
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
+    "swr": ["swr@2.4.0", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-sUlC20T8EOt1pHmDiqueUWMmRRX03W7w5YxovWX7VR2KHEPCTMly85x05vpkP5i6Bu4h44ePSMD9Tc+G2MItFw=="],
+
     "tailwind-merge": ["tailwind-merge@3.4.0", "", {}, "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g=="],
 
     "tailwindcss": ["tailwindcss@4.1.18", "", {}, "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw=="],
 
     "tapable": ["tapable@2.3.0", "", {}, "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="],
+
+    "throttleit": ["throttleit@2.1.0", "", {}, "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw=="],
 
     "tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
 
@@ -2183,6 +2191,8 @@
     "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
 
     "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
+
+    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
@@ -2271,6 +2281,8 @@
     "@ai-sdk/provider-utils-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
 
     "@ai-sdk/provider-utils-v6/@ai-sdk/provider": ["@ai-sdk/provider@3.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-m9ka3ptkPQbaHHZHqDXDF9C9B5/Mav0KTdky1k2HZ3/nrW2t1AgObxIVPyGDWQNS9FXT/FS6PIoSjpcP/No8rQ=="],
+
+    "@ai-sdk/react/ai": ["ai@6.0.97", "", { "dependencies": { "@ai-sdk/gateway": "3.0.53", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.15", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-eZIAcBymwGhBwncRH/v9pillZNMeRCDkc4BwcvwXerXd7sxjVxRis3ZNCNCpP02pVH4NLs81ljm4cElC4vbNcQ=="],
 
     "@ai-sdk/ui-utils-v5/@ai-sdk/provider": ["@ai-sdk/provider@1.1.3", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg=="],
 
@@ -2495,6 +2507,8 @@
     "@a2a-js/sdk/express/serve-static": ["serve-static@1.16.3", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "~0.19.1" } }, "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA=="],
 
     "@a2a-js/sdk/express/type-is": ["type-is@1.6.18", "", { "dependencies": { "media-typer": "0.3.0", "mime-types": "~2.1.24" } }, "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g=="],
+
+    "@ai-sdk/react/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.53", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.15", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-QT3FEoNARMRlk8JJVR7L98exiK9C8AGfrEJVbRxBT1yIXKs/N19o/+PsjTRVsARgDJNcy9JbJp1FspKucEat0Q=="],
 
     "@eslint/eslintrc/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 

--- a/docs/components/ai-tools-banner.tsx
+++ b/docs/components/ai-tools-banner.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { Bot, FileText, Copy, Check, ExternalLink } from 'lucide-react';
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  return (
+    <button
+      onClick={() => {
+        navigator.clipboard.writeText(text);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      }}
+      className="shrink-0 rounded-md p-1 text-fd-muted-foreground/60 hover:text-fd-foreground transition-colors"
+      aria-label="Copy to clipboard"
+    >
+      {copied ? (
+        <Check className="h-3.5 w-3.5 text-green-500" />
+      ) : (
+        <Copy className="h-3.5 w-3.5" />
+      )}
+    </button>
+  );
+}
+
+export function AIToolsBanner() {
+  const skillsCommand = 'npx skills add composiohq/skills';
+
+  return (
+    <div className="not-prose relative mt-6 overflow-hidden rounded-xl border border-fd-border bg-gradient-to-br from-fd-card via-fd-card to-fd-muted/50 dark:from-fd-muted/20 dark:via-fd-card dark:to-fd-muted/40">
+      {/* Subtle grid pattern */}
+      <div
+        className="pointer-events-none absolute inset-0 opacity-[0.03] dark:opacity-[0.04]"
+        style={{
+          backgroundImage:
+            'linear-gradient(var(--color-fd-foreground) 1px, transparent 1px), linear-gradient(90deg, var(--color-fd-foreground) 1px, transparent 1px)',
+          backgroundSize: '24px 24px',
+        }}
+      />
+      <div className="relative p-5">
+        {/* Header */}
+        <div className="mb-4 flex items-center gap-2.5">
+          <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-fd-muted dark:bg-fd-muted/60">
+            <Bot className="h-4 w-4 text-fd-muted-foreground" />
+          </div>
+          <span className="text-sm font-semibold text-fd-foreground tracking-tight">
+            For AI tools
+          </span>
+        </div>
+
+        {/* Skills command */}
+        <div className="mb-3 flex items-center gap-2 rounded-lg border border-fd-border bg-fd-background dark:bg-fd-background/50 px-3.5 py-2.5 font-mono text-[13px] text-fd-foreground">
+          <span className="select-none text-fd-muted-foreground">$</span>
+          <span className="flex-1 select-all">{skillsCommand}</span>
+          <CopyButton text={skillsCommand} />
+        </div>
+
+        {/* Skills links */}
+        <div className="mb-4 flex items-center gap-3 text-xs">
+          <Link
+            href="https://skills.sh/composiohq/skills/composio"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 text-fd-muted-foreground hover:text-[var(--composio-orange)] transition-colors"
+          >
+            Skills.sh
+            <ExternalLink className="h-3 w-3" />
+          </Link>
+          <Link
+            href="https://github.com/composiohq/skills"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 text-fd-muted-foreground hover:text-[var(--composio-orange)] transition-colors"
+          >
+            GitHub
+            <ExternalLink className="h-3 w-3" />
+          </Link>
+        </div>
+
+        {/* Context files */}
+        <div className="flex gap-2">
+          <Link
+            href="/llms.txt"
+            className="group flex flex-1 items-center gap-2.5 rounded-lg border border-fd-border/80 bg-fd-card dark:bg-fd-background/30 px-3 py-2 transition-all hover:border-[var(--composio-orange)]/40"
+          >
+            <FileText className="h-3.5 w-3.5 shrink-0 text-fd-muted-foreground group-hover:text-[var(--composio-orange)] transition-colors" />
+            <span className="text-sm font-medium text-fd-foreground">llms.txt</span>
+            <span className="text-[11px] text-fd-muted-foreground">Index</span>
+          </Link>
+          <Link
+            href="/llms-full.txt"
+            className="group flex flex-1 items-center gap-2.5 rounded-lg border border-fd-border/80 bg-fd-card dark:bg-fd-background/30 px-3 py-2 transition-all hover:border-[var(--composio-orange)]/40"
+          >
+            <FileText className="h-3.5 w-3.5 shrink-0 text-fd-muted-foreground group-hover:text-[var(--composio-orange)] transition-colors" />
+            <span className="text-sm font-medium text-fd-foreground">llms-full.txt</span>
+            <span className="text-[11px] text-fd-muted-foreground">Complete</span>
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/docs/content/cookbooks/chat-app.mdx
+++ b/docs/content/cookbooks/chat-app.mdx
@@ -5,6 +5,8 @@ description: Build an AI chat app with tool access to 1000+ apps in about 30 lin
 
 Give your AI agent access to Gmail, GitHub, Slack, Notion, and 1000+ other apps. This tutorial builds a Next.js chat app that handles tool discovery, user authentication, and action execution in about **30 lines of code**.
 
+[View source on GitHub](https://github.com/ComposioHQ/composio/tree/next/docs/examples/chat-app)
+
 ## What you'll build
 
 - A chat app where your agent can find and use tools across 1000+ apps

--- a/docs/content/cookbooks/chat-app.mdx
+++ b/docs/content/cookbooks/chat-app.mdx
@@ -1,0 +1,125 @@
+---
+title: Build a Chat App
+description: Build an AI chat app with tool access to 1000+ apps in about 30 lines of code
+---
+
+Give your AI agent access to Gmail, GitHub, Slack, Notion, and 1000+ other apps. This tutorial builds a Next.js chat app that handles tool discovery, user authentication, and action execution in about **30 lines of code**.
+
+## What you'll build
+
+- A chat app where your agent can find and use tools across 1000+ apps
+- In-chat OAuth authentication so users can connect apps directly in the conversation
+- A tool call display that shows what the agent is doing in real time
+
+## Prerequisites
+
+- Node.js 18+
+- [Composio API key](https://platform.composio.dev/settings)
+- [OpenAI API key](https://platform.openai.com/api-keys)
+
+**Stack:** Next.js, Vercel AI SDK, OpenAI, Composio
+
+## Create the project
+
+Create a new Next.js app and install the dependencies:
+
+```bash
+pnpm create next-app composio-chat --yes
+cd composio-chat
+pnpm install @composio/core @composio/vercel @ai-sdk/openai ai @ai-sdk/react
+```
+
+<Callout type="info">
+Get your `COMPOSIO_API_KEY` from [Settings](https://platform.composio.dev/settings) and `OPENAI_API_KEY` from [OpenAI](https://platform.openai.com/api-keys).
+</Callout>
+
+Add your API keys to a `.env.local` file in the project root:
+
+```bash title=".env.local"
+COMPOSIO_API_KEY=your_composio_api_key
+OPENAI_API_KEY=your_openai_api_key
+```
+
+Start the dev server:
+
+```bash
+pnpm dev
+```
+
+## Build the backend
+
+A **session** scopes tools and credentials to a specific user. Create `app/api/chat/route.ts`:
+
+<include meta='title="app/api/chat/route.ts"'>../../examples/chat-app/route.ts</include>
+
+That's the entire backend. `composio.create("user_123")` creates a session that lets the agent search for tools, authenticate users, and execute actions. This ID scopes all connections and credentials to this user. In production, use the user ID from your auth system.
+
+## Build the chat UI
+
+Replace `app/page.tsx`:
+
+<include meta='title="app/page.tsx"'>../../examples/chat-app/page.tsx</include>
+
+Go to [localhost:3000](http://localhost:3000). You should see the chat interface.
+
+## Try a tool call
+
+Send this message:
+
+```
+Star the composio repo on GitHub
+```
+
+Here's what happens:
+
+1. The agent searches for relevant tools, finds `GITHUB_STAR_REPO`, and checks your connection status.
+2. You haven't connected GitHub yet, so the agent generates an auth link and shows it to you.
+3. Click the link, authorize with GitHub, and tell the agent you're done.
+4. The agent executes `GITHUB_STAR_REPO` with your credentials.
+
+Discovery, authentication, and execution all happened automatically. You didn't write any tool-specific code.
+
+<Callout>
+This in-chat authentication flow works out of the box. For production apps, you can [authenticate users ahead of time](/docs/authenticating-users/manually-authenticating) during onboarding.
+</Callout>
+
+## Show tool calls in the UI
+
+Tool calls happen invisibly by default. Add a component that shows the tool name and status so you can see what the agent is doing.
+
+Create `components/ToolCallDisplay.tsx`:
+
+<include meta='title="components/ToolCallDisplay.tsx"'>../../examples/chat-app/ToolCallDisplay.tsx</include>
+
+Update `app/page.tsx` to render tool calls:
+
+<include meta='title="app/page.tsx"'>../../examples/chat-app/page-with-tools.tsx</include>
+
+Tool calls now show inline with a spinner while running and a checkmark when complete. Click to expand and see the raw output.
+
+## How it works
+
+The session handles tool discovery and execution at runtime. Instead of loading thousands of tool definitions into your agent's context, the agent searches for what it needs, authenticates the user if necessary, and executes the action. Token refresh and credential management are handled automatically.
+
+Try a few more requests:
+
+- "Summarize my emails from today"
+- "What's on my calendar this week?"
+- "Create a GitHub issue in my repo"
+
+## Take it further
+
+<Cards>
+  <Card title="Configuring sessions" href="/docs/configuring-sessions">
+    Lock down which toolkits your agent can access
+  </Card>
+  <Card title="Manual authentication" href="/docs/authenticating-users/manually-authenticating">
+    Move authentication to your onboarding flow instead of in-chat
+  </Card>
+  <Card title="Users and sessions" href="/docs/users-and-sessions">
+    Scope sessions to real users for multi-tenant apps
+  </Card>
+  <Card title="How Composio works" href="/docs/how-composio-works">
+    Understand sessions, tool discovery, and execution under the hood
+  </Card>
+</Cards>

--- a/docs/content/cookbooks/chat-app.mdx
+++ b/docs/content/cookbooks/chat-app.mdx
@@ -15,7 +15,7 @@ Give your AI agent access to Gmail, GitHub, Slack, Notion, and 1000+ other apps.
 
 ## Prerequisites
 
-- Node.js 18+
+- [Bun](https://bun.sh) (or Node.js 18+)
 - [Composio API key](https://platform.composio.dev/settings)
 - [OpenAI API key](https://platform.openai.com/api-keys)
 
@@ -26,9 +26,9 @@ Give your AI agent access to Gmail, GitHub, Slack, Notion, and 1000+ other apps.
 Create a new Next.js app and install the dependencies:
 
 ```bash
-pnpm create next-app composio-chat --yes
+bunx create-next-app composio-chat --yes
 cd composio-chat
-pnpm install @composio/core @composio/vercel @ai-sdk/openai ai @ai-sdk/react
+bun add @composio/core @composio/vercel @ai-sdk/openai ai @ai-sdk/react
 ```
 
 <Callout type="info">
@@ -45,7 +45,7 @@ OPENAI_API_KEY=your_openai_api_key
 Start the dev server:
 
 ```bash
-pnpm dev
+bun dev
 ```
 
 ## Build the backend

--- a/docs/content/cookbooks/index.mdx
+++ b/docs/content/cookbooks/index.mdx
@@ -12,6 +12,7 @@ Browse open-source templates or follow step-by-step guides below.
 ## Getting Started
 
 <Cards>
+  <Card title="Build a Chat App" href="/cookbooks/chat-app" description="Next.js chat app with tool discovery across 1000+ apps" />
   <Card title="Basic FastAPI Server" href="/cookbooks/fast-api" description="Build a Gmail agent with FastAPI" />
   <Card title="Basic Hono Server" href="/cookbooks/hono" description="Build a Gmail agent with Hono.js" />
 </Cards>

--- a/docs/content/cookbooks/meta.json
+++ b/docs/content/cookbooks/meta.json
@@ -4,6 +4,7 @@
   "pages": [
     "---Getting Started---",
     "templates",
+    "chat-app",
     "fast-api",
     "hono",
     "---Productivity & Automation---",

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -8,43 +8,46 @@ Composio powers 1000+ toolkits, tool search, context management, authentication,
 
 <Cards>
   <Card
+    title="Tutorial: Build a chat app"
+    href="/cookbooks/chat-app"
+    description="Build a Next.js chat app where your agent can discover and use tools across 1000+ apps."
+  />
+  <Card
+    title="How Composio works"
+    href="/docs/how-composio-works"
+    description="Learn about sessions, meta tools, authentication, and the architecture behind Composio."
+  />
+</Cards>
+
+## Get Started
+
+<Cards className="grid-cols-1">
+  <Card
     icon={<Rocket />}
     title="Quickstart"
     href="/docs/quickstart"
-    description="Build your first agent in 5 minutes"
+    description="Install the SDK, connect an app, and run your first tool call in 5 minutes."
+  />
+</Cards>
+
+<AIToolsBanner />
+
+## Explore
+
+<Cards>
+  <Card
+    icon={<Wrench />}
+    title="Toolkits"
+    href="/toolkits"
+    description="Browse 1000+ toolkits across GitHub, Gmail, Slack, Notion, and more."
   />
   <Card
     icon={<Play />}
     title="Playground"
     href="https://platform.composio.dev/auth?next_page=%2Ftool-router"
-    description="Try Composio in your browser"
-  />
-  <Card
-    icon={<Rocket />}
-    title="How it works"
-    href="/docs/how-composio-works"
-    description="Sessions, meta tools, authentication, and execution"
-  />
-  <Card
-    icon={<Wrench />}
-    title="Toolkits"
-    href="/toolkits"
-    description="Browse 1000+ toolkits"
+    description="Try Composio in your browser without writing any code."
   />
 </Cards>
-
-## For AI tools
-
-- [composio.dev/llms.txt](/llms.txt) - Documentation index with links
-- [composio.dev/llms-full.txt](/llms-full.txt) - Complete documentation in one file
-
-### Skills
-
-```bash
-npx skills add composiohq/skills
-```
-
-[View on Skills.sh](https://skills.sh/composiohq/skills/composio) · [GitHub](https://github.com/composiohq/skills)
 
 ## Providers
 

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -15,7 +15,7 @@ Composio powers 1000+ toolkits, tool search, context management, authentication,
   <Card
     title="How Composio works"
     href="/docs/how-composio-works"
-    description="Learn about sessions, meta tools, authentication, and the architecture behind Composio."
+    description="See what happens under the hood when your agent searches, authenticates, and executes a tool."
   />
 </Cards>
 

--- a/docs/examples/chat-app/ToolCallDisplay.tsx
+++ b/docs/examples/chat-app/ToolCallDisplay.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useState } from "react";
+
+export function ToolCallDisplay({
+  toolName,
+  input,
+  output,
+  isLoading,
+}: {
+  toolName: string;
+  input: unknown;
+  output?: unknown;
+  isLoading: boolean;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="my-1">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className={`inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-xs transition-colors ${
+          isLoading
+            ? "border-gray-200 bg-gray-50 text-gray-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-400"
+            : "border-gray-200 bg-gray-50 text-gray-700 hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:hover:bg-gray-800"
+        }`}
+      >
+        {isLoading ? (
+          <span className="inline-block h-3 w-3 animate-spin rounded-full border border-gray-300 border-t-gray-600 dark:border-gray-600 dark:border-t-gray-300" />
+        ) : (
+          <span className="text-green-600 dark:text-green-400">✓</span>
+        )}
+        <code className="font-mono">{toolName}</code>
+        {!isLoading && <span className="text-gray-400">{expanded ? "▴" : "▾"}</span>}
+      </button>
+
+      {expanded && !isLoading && (
+        <pre className="mt-1 ml-1 max-h-40 max-w-full overflow-auto whitespace-pre-wrap break-words rounded-md border border-gray-200 bg-gray-50 p-2 text-xs text-gray-600 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-400">
+          {output != null
+            ? String(JSON.stringify(output, null, 2))
+            : String(JSON.stringify(input, null, 2))}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/docs/examples/chat-app/page-with-tools.tsx
+++ b/docs/examples/chat-app/page-with-tools.tsx
@@ -90,7 +90,7 @@ export default function Chat() {
         <button
           type="submit"
           disabled={isLoading}
-          className="px-4 py-3 bg-black text-white rounded-lg disabled:opacity-50"
+          className="px-6 py-3 bg-white text-black font-medium rounded-lg hover:bg-gray-200 transition-colors disabled:opacity-50"
         >
           Send
         </button>

--- a/docs/examples/chat-app/page-with-tools.tsx
+++ b/docs/examples/chat-app/page-with-tools.tsx
@@ -1,3 +1,4 @@
+// @errors: 2307
 "use client";
 
 import { useState } from "react";

--- a/docs/examples/chat-app/page-with-tools.tsx
+++ b/docs/examples/chat-app/page-with-tools.tsx
@@ -78,14 +78,22 @@ export default function Chat() {
           sendMessage({ text: input });
           setInput("");
         }}
+        className="flex gap-2"
       >
         <input
           value={input}
           onChange={(e) => setInput(e.target.value)}
           placeholder="Ask me anything..."
           disabled={isLoading}
-          className="w-full p-3 border border-gray-300 rounded-lg"
+          className="flex-1 p-3 border border-gray-300 rounded-lg"
         />
+        <button
+          type="submit"
+          disabled={isLoading}
+          className="px-4 py-3 bg-black text-white rounded-lg disabled:opacity-50"
+        >
+          Send
+        </button>
       </form>
     </main>
   );

--- a/docs/examples/chat-app/page-with-tools.tsx
+++ b/docs/examples/chat-app/page-with-tools.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useState } from "react";
+import { useChat } from "@ai-sdk/react";
+import { DefaultChatTransport, getToolName, isToolUIPart } from "ai";
+import { ToolCallDisplay } from "../components/ToolCallDisplay";
+
+export default function Chat() {
+  const [input, setInput] = useState("");
+  const { messages, sendMessage, status } = useChat({
+    transport: new DefaultChatTransport({ api: "/api/chat" }),
+  });
+
+  const isLoading = status === "streaming" || status === "submitted";
+
+  return (
+    <main className="max-w-2xl mx-auto p-6">
+      <h1 className="text-2xl font-bold mb-6">Composio Chat</h1>
+
+      <div className="space-y-4 mb-6 min-h-[200px]">
+        {messages.length === 0 && (
+          <p className="text-gray-400 text-center py-12">
+            Try: &quot;Star the composio repo on GitHub&quot;
+          </p>
+        )}
+        {messages.map((m) => (
+          <div key={m.id} className="flex gap-2">
+            <span className="font-semibold shrink-0">
+              {m.role === "user" ? "You:" : "Agent:"}
+            </span>
+            <div className="flex-1 whitespace-pre-wrap">
+              {m.parts.map((part, i) => {
+                if (part.type === "text") {
+                  return (
+                    <span key={i}>
+                      {String(part.text)
+                        .split(/(https?:\/\/[^\s)]+)/g)
+                        .map((segment, j) =>
+                          segment.match(/^https?:\/\//) ? (
+                            <a key={j} href={segment} target="_blank" rel="noopener noreferrer" className="text-blue-600 underline">{segment}</a>
+                          ) : (
+                            segment
+                          )
+                        )}
+                    </span>
+                  );
+                }
+                if (isToolUIPart(part)) {
+                  return (
+                    <ToolCallDisplay
+                      key={part.toolCallId}
+                      toolName={getToolName(part)}
+                      input={part.input}
+                      output={
+                        part.state === "output-available"
+                          ? part.output
+                          : undefined
+                      }
+                      isLoading={part.state !== "output-available"}
+                    />
+                  );
+                }
+                return null;
+              })}
+            </div>
+          </div>
+        ))}
+        {isLoading && (
+          <p className="text-gray-400 text-sm">Thinking...</p>
+        )}
+      </div>
+
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          if (!input.trim()) return;
+          sendMessage({ text: input });
+          setInput("");
+        }}
+      >
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Ask me anything..."
+          disabled={isLoading}
+          className="w-full p-3 border border-gray-300 rounded-lg"
+        />
+      </form>
+    </main>
+  );
+}

--- a/docs/examples/chat-app/page.tsx
+++ b/docs/examples/chat-app/page.tsx
@@ -70,7 +70,7 @@ export default function Chat() {
         <button
           type="submit"
           disabled={isLoading}
-          className="px-4 py-3 bg-black text-white rounded-lg disabled:opacity-50"
+          className="px-6 py-3 bg-white text-black font-medium rounded-lg hover:bg-gray-200 transition-colors disabled:opacity-50"
         >
           Send
         </button>

--- a/docs/examples/chat-app/page.tsx
+++ b/docs/examples/chat-app/page.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useState } from "react";
+import { useChat } from "@ai-sdk/react";
+import { DefaultChatTransport } from "ai";
+
+export default function Chat() {
+  const [input, setInput] = useState("");
+  const { messages, sendMessage, status } = useChat({
+    transport: new DefaultChatTransport({ api: "/api/chat" }),
+  });
+
+  const isLoading = status === "streaming" || status === "submitted";
+
+  return (
+    <main className="max-w-2xl mx-auto p-6">
+      <h1 className="text-2xl font-bold mb-6">Composio Chat</h1>
+
+      <div className="space-y-4 mb-6 min-h-[200px]">
+        {messages.length === 0 && (
+          <p className="text-gray-400 text-center py-12">
+            Try: &quot;Star the composio repo on GitHub&quot;
+          </p>
+        )}
+        {messages.map((m) => (
+          <div key={m.id} className="flex gap-2">
+            <span className="font-semibold shrink-0">
+              {m.role === "user" ? "You:" : "Agent:"}
+            </span>
+            <div className="whitespace-pre-wrap">
+              {m.parts.map((part, i) =>
+                part.type === "text" ? (
+                  <span key={i}>
+                    {String(part.text)
+                      .split(/(https?:\/\/[^\s)]+)/g)
+                      .map((segment, j) =>
+                        segment.match(/^https?:\/\//) ? (
+                          <a key={j} href={segment} target="_blank" rel="noopener noreferrer" className="text-blue-600 underline">{segment}</a>
+                        ) : (
+                          segment
+                        )
+                      )}
+                  </span>
+                ) : null
+              )}
+            </div>
+          </div>
+        ))}
+        {isLoading && (
+          <p className="text-gray-400 text-sm">Thinking...</p>
+        )}
+      </div>
+
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          if (!input.trim()) return;
+          sendMessage({ text: input });
+          setInput("");
+        }}
+      >
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Ask me anything..."
+          disabled={isLoading}
+          className="w-full p-3 border border-gray-300 rounded-lg"
+        />
+      </form>
+    </main>
+  );
+}

--- a/docs/examples/chat-app/page.tsx
+++ b/docs/examples/chat-app/page.tsx
@@ -58,14 +58,22 @@ export default function Chat() {
           sendMessage({ text: input });
           setInput("");
         }}
+        className="flex gap-2"
       >
         <input
           value={input}
           onChange={(e) => setInput(e.target.value)}
           placeholder="Ask me anything..."
           disabled={isLoading}
-          className="w-full p-3 border border-gray-300 rounded-lg"
+          className="flex-1 p-3 border border-gray-300 rounded-lg"
         />
+        <button
+          type="submit"
+          disabled={isLoading}
+          className="px-4 py-3 bg-black text-white rounded-lg disabled:opacity-50"
+        >
+          Send
+        </button>
       </form>
     </main>
   );

--- a/docs/examples/chat-app/route.ts
+++ b/docs/examples/chat-app/route.ts
@@ -1,0 +1,32 @@
+import { openai } from "@ai-sdk/openai";
+import { Composio } from "@composio/core";
+import { VercelProvider } from "@composio/vercel";
+import {
+  streamText,
+  convertToModelMessages,
+  generateId,
+  stepCountIs,
+  type UIMessage,
+} from "ai";
+
+const composio = new Composio({ provider: new VercelProvider() });
+
+export async function POST(req: Request) {
+  const { messages }: { messages: UIMessage[] } = await req.json();
+
+  const session = await composio.create("user_123");
+  const tools = await session.tools();
+
+  const result = streamText({
+    model: openai("gpt-5"),
+    system: "You are a helpful assistant. Use Composio tools to help the user.",
+    messages: await convertToModelMessages(messages),
+    tools,
+    stopWhen: stepCountIs(10),
+  });
+
+  return result.toUIMessageStreamResponse({
+    originalMessages: messages,
+    generateMessageId: () => generateId(),
+  });
+}

--- a/docs/lib/source.ts
+++ b/docs/lib/source.ts
@@ -227,6 +227,18 @@ export function mdxToCleanMarkdown(content: string): string {
     '- [$2]($1): $3'
   );
 
+  // Convert AIToolsBanner to plain text
+  result = result.replace(
+    /<AIToolsBanner\s*\/>/g,
+    '### For AI tools\n\n' +
+    '**Skills:**\n' +
+    '```bash\nnpx skills add composiohq/skills\n```\n' +
+    '[Skills.sh](https://skills.sh/composiohq/skills/composio) · [GitHub](https://github.com/composiohq/skills)\n\n' +
+    '**Context files:**\n' +
+    '- [llms.txt](/llms.txt) — Documentation index with links\n' +
+    '- [llms-full.txt](/llms-full.txt) — Complete documentation in one file'
+  );
+
   // Remove wrapper components (Cards, ProviderGrid, Tabs, Frame, div, QuickstartFlow, IntegrationTabs, Accordions, ToolTypeFlow, ToolkitsLanding, TemplateGrid, etc.)
   result = result.replace(/<\/?(Cards|ProviderGrid|Tabs|Frame|div|QuickstartFlow|IntegrationTabs|Accordions|ToolTypeFlow|ToolkitsLanding|TemplateGrid)[^>]*>/g, '');
 

--- a/docs/mdx-components.tsx
+++ b/docs/mdx-components.tsx
@@ -20,6 +20,7 @@ import { CapabilityCard, CapabilityList } from '@/components/capability-card';
 import { TemplateCard, TemplateGrid } from '@/components/template-card';
 import { ToolkitsLanding } from '@/components/toolkits/toolkits-landing';
 import { Mermaid } from '@/components/mermaid';
+import { AIToolsBanner } from '@/components/ai-tools-banner';
 import {
   ShieldCheck,
   Route as RouteIcon,
@@ -86,6 +87,7 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     TemplateGrid,
     ToolkitsLanding,
     Mermaid,
+    AIToolsBanner,
     StepTitle,
     // Lucide icons
     ShieldCheck,

--- a/docs/package.json
+++ b/docs/package.json
@@ -38,6 +38,7 @@
     "@ai-sdk/anthropic": "^3.0.11",
     "@ai-sdk/mcp": "^1.0.6",
     "@ai-sdk/openai": "^3.0.9",
+    "@ai-sdk/react": "^3.0.99",
     "@anthropic-ai/claude-agent-sdk": "^0.2.5",
     "@anthropic-ai/sdk": "^0.71.2",
     "@composio/anthropic": "^0.5.5",

--- a/docs/source.config.ts
+++ b/docs/source.config.ts
@@ -112,6 +112,12 @@ export default defineConfig({
           ? [
               transformerTwoslash({
                 explicitTrigger: false,
+                twoslashOptions: {
+                  compilerOptions: {
+                    jsx: 4, // JsxEmit.ReactJSX
+                    jsxImportSource: 'react',
+                  },
+                },
                 typesCache: createFileSystemTypesCache({
                   dir: '.next/cache/twoslash',
                 }),

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -34,5 +34,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules", "scripts/preload.ts", "tests"]
+  "exclude": ["node_modules", "scripts/preload.ts", "tests", "examples"]
 }


### PR DESCRIPTION
## Summary

- **Chat App Tutorial**: New "Build a Chat App" cookbook at `/cookbooks/chat-app` — walks through building a Next.js chat app with Composio tool access using Vercel AI SDK. Code files extracted to `docs/examples/chat-app/` using fumadocs `<include>` tags.
- **Welcome page revamp**: Restructured `/docs` landing with hero cards (Tutorial + How it works), full-width Quickstart, AI tools banner, and Explore section.
- **AI Tools Banner**: New `<AIToolsBanner />` component with grid pattern background, copy-able skills command, and llms.txt context file links. Includes markdown conversion in `lib/source.ts` for LLM crawlers.

## Test plan

- [ ] Verify chat-app cookbook renders at `/cookbooks/chat-app`
- [ ] Verify welcome page layout at `/docs` (light + dark mode)
- [ ] Verify AI tools banner dark mode styling
- [ ] Verify `/docs.md` endpoint includes AI tools section as plain markdown
- [ ] Verify `bun run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)