### PR TITLE
docs: add cross-linking to practical guides

### DIFF
--- a/docs/content/docs/authenticating-users/in-chat-authentication.mdx
+++ b/docs/content/docs/authenticating-users/in-chat-authentication.mdx
@@ -184,3 +184,12 @@ Assistant: I need you to connect your GitHub account first.
 Please click here to authorize: https://connect.composio.dev/link/ln_abc123
 
 > Done
+```
+
+## What to read next
+
+<Cards>
+  <Card icon={<ShieldCheck />} title="Manual authentication" href="/docs/authenticating-users/manually-authenticating" description="Pre-authenticate users before chat using Connect Links and session.authorize()" />
+  <Card icon={<Palette />} title="White-labeling authentication" href="/docs/white-labeling-authentication" description="Use your own OAuth apps so users see your branding on consent screens" />
+  <Card icon={<Wrench />} title="Configuring Sessions" href="/docs/configuring-sessions" description="Restrict toolkits, set custom auth configs, and select connected accounts" />
+</Cards>

--- a/docs/content/docs/authenticating-users/manually-authenticating.mdx
+++ b/docs/content/docs/authenticating-users/manually-authenticating.mdx
@@ -147,6 +147,7 @@ const session = await composio.create("user_123", {
 
 ## Putting it together
 
+
 A common pattern is to verify all required connections before starting the agent:
 
 <Tabs groupId="language" items={['Python', 'TypeScript']} persist>
@@ -212,3 +213,11 @@ console.log(`All toolkits connected! MCP URL: ${session.mcp.url}`);
 ```
 </Tab>
 </Tabs>
+
+## What to read next
+
+<Cards>
+  <Card icon={<MessageCircle />} title="In-chat authentication" href="/docs/authenticating-users/in-chat-authentication" description="Let the agent prompt users to connect accounts during conversation instead" />
+  <Card icon={<Palette />} title="White-labeling authentication" href="/docs/white-labeling-authentication" description="Use your own OAuth apps so users see your branding on consent screens" />
+  <Card icon={<Database />} title="Managing multiple accounts" href="/docs/managing-multiple-connected-accounts" description="Handle users with multiple accounts for the same toolkit (e.g., work and personal Gmail)" />
+</Cards>

--- a/docs/content/docs/configuring-sessions.mdx
+++ b/docs/content/docs/configuring-sessions.mdx
@@ -271,3 +271,12 @@ toolkits.items.forEach((toolkit) => {
 </Tabs>
 
 Returns the first 20 toolkits by default.
+
+## What to read next
+
+<Cards>
+  <Card icon={<MessageCircle />} title="In-chat authentication" href="/docs/authenticating-users/in-chat-authentication" description="Let the agent prompt users to connect accounts during conversation" />
+  <Card icon={<ShieldCheck />} title="Manual authentication" href="/docs/authenticating-users/manually-authenticating" description="Pre-authenticate users before chat using Connect Links and session.authorize()" />
+  <Card icon={<Wrench />} title="Enable & disable toolkits" href="/docs/toolkits/enable-and-disable-toolkits" description="Control which toolkits and individual tools are available in sessions" />
+  <Card icon={<Palette />} title="White-labeling authentication" href="/docs/white-labeling-authentication" description="Use your own OAuth apps so users see your branding on consent screens" />
+</Cards>

--- a/docs/content/docs/projects.mdx
+++ b/docs/content/docs/projects.mdx
@@ -1,10 +1,10 @@
 ---
 title: Projects
-description: Organize your Composio resources with projects and manage team access
-keywords: [projects, organizations, teams, api keys, environments]
+description: Isolate resources across environments or clients using projects for multi-tenancy
+keywords: [projects, organizations, teams, api keys, environments, multi-tenancy, multitenancy, tenant isolation]
 ---
 
-Every Composio account belongs to an **organization**. Inside an organization, **projects** are isolated environments that scope your API keys, connected accounts, auth configs, and webhook configurations. Resources in one project are not accessible from another.
+Projects are Composio's multi-tenancy primitive. Every Composio account belongs to an **organization**. Inside an organization, **projects** are isolated environments that scope your API keys, connected accounts, auth configs, and webhook configurations. Resources in one project are not accessible from another.
 
 ```mermaid
 graph LR
@@ -19,9 +19,9 @@ graph LR
 ```
 
 Common reasons to use multiple projects:
-- **Separate environments** — keep production and staging isolated
-- **Separate products** — keep resources for different apps independent
-- **Client isolation** — give each client their own project with separate credentials and data
+- **Separate environments**: keep production and staging isolated
+- **Separate products**: keep resources for different apps independent
+- **Client isolation**: give each client their own project with separate credentials and data
 
 ## Managing projects
 

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -831,5 +831,6 @@ readline.close();
 <Cards>
   <Card icon={<Wrench />} title="Configuring Sessions" href="/docs/configuring-sessions" description="Restrict toolkits, set custom auth configs, and select connected accounts" />
   <Card icon={<Key />} title="Authenticating Users" href="/docs/authentication" description="Learn how users connect their accounts via Connect Links, OAuth, and API keys" />
+  <Card icon={<BookOpen />} title="How Composio works" href="/docs/how-composio-works" description="Understand what happens under the hood: sessions, meta tools, and the tool execution lifecycle" />
 </Cards>
 

--- a/docs/content/docs/setting-up-triggers/creating-triggers.mdx
+++ b/docs/content/docs/setting-up-triggers/creating-triggers.mdx
@@ -85,3 +85,10 @@ The trigger instance uses the toolkit version configured during Composio initial
 5. Click **Create Trigger**
 
 <Video src="/videos/triggers-creation.mp4" caption="Creating a GitHub Star Added trigger from the dashboard" />
+
+## What to read next
+
+<Cards>
+  <Card icon={<Zap />} title="Subscribing to events" href="/docs/setting-up-triggers/subscribing-to-events" description="Receive trigger events via webhooks or SDK subscriptions" />
+  <Card icon={<Zap />} title="Managing triggers" href="/docs/setting-up-triggers/managing-triggers" description="List, enable, disable, and delete trigger instances" />
+</Cards>

--- a/docs/content/docs/setting-up-triggers/managing-triggers.mdx
+++ b/docs/content/docs/setting-up-triggers/managing-triggers.mdx
@@ -121,3 +121,11 @@ await composio.triggers.delete('ti_abcd123');
 <Callout type="warn">
 Deleting a trigger is permanent. Use `disable()` instead to temporarily stop receiving events.
 </Callout>
+
+## What to read next
+
+<Cards>
+  <Card icon={<Zap />} title="Creating triggers" href="/docs/setting-up-triggers/creating-triggers" description="Create trigger instances to start receiving events from connected apps" />
+  <Card icon={<Zap />} title="Subscribing to events" href="/docs/setting-up-triggers/subscribing-to-events" description="Set up webhooks or SDK subscriptions to handle trigger events" />
+  <Card icon={<ShieldCheck />} title="Verifying webhooks" href="/docs/webhook-verification" description="Validate webhook signatures to ensure payloads are authentic" />
+</Cards>

--- a/docs/content/docs/setting-up-triggers/subscribing-to-events.mdx
+++ b/docs/content/docs/setting-up-triggers/subscribing-to-events.mdx
@@ -222,6 +222,10 @@ Every webhook event includes a `metadata` object that tells you exactly where it
 
 Use `trigger_id` to match events to a specific trigger instance, or `trigger_slug` to handle all events of a certain type. These fields can also be passed as filters when using [SDK subscriptions](#sdk-subscriptions).
 
+## What to read next
+
 <Cards>
-  <Card title="Troubleshooting triggers" href="/docs/troubleshooting/triggers" description="Not receiving events? Check common trigger issues and how to fix them" />
+  <Card icon={<ShieldCheck />} title="Verifying webhooks" href="/docs/webhook-verification" description="Validate webhook signatures to ensure payloads are authentic" />
+  <Card icon={<Zap />} title="Managing triggers" href="/docs/setting-up-triggers/managing-triggers" description="List, enable, disable, and delete trigger instances" />
+  <Card icon={<Zap />} title="Troubleshooting triggers" href="/docs/troubleshooting/triggers" description="Not receiving events? Check common trigger issues and how to fix them" />
 </Cards>

--- a/docs/content/docs/toolkits/enable-and-disable-toolkits.mdx
+++ b/docs/content/docs/toolkits/enable-and-disable-toolkits.mdx
@@ -267,3 +267,9 @@ const session = await composio.create("user_123", {
 </Tab>
 </Tabs>
 
+## What to read next
+
+<Cards>
+  <Card icon={<Wrench />} title="Fetching tools and toolkits" href="/docs/toolkits/fetching-tools-and-toolkits" description="List enabled toolkits, get meta tools, and browse the catalog" />
+</Cards>
+

--- a/docs/content/docs/toolkits/fetching-tools-and-toolkits.mdx
+++ b/docs/content/docs/toolkits/fetching-tools-and-toolkits.mdx
@@ -172,3 +172,9 @@ console.log(tool.outputParameters);
 ```
 </Tab>
 </Tabs>
+
+## What to read next
+
+<Cards>
+  <Card icon={<Wrench />} title="Enable & disable toolkits" href="/docs/toolkits/enable-and-disable-toolkits" description="Control which toolkits and individual tools are available in sessions" />
+</Cards>

--- a/docs/content/docs/white-labeling-authentication.mdx
+++ b/docs/content/docs/white-labeling-authentication.mdx
@@ -155,3 +155,9 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
 3. Update your auth config in the Composio dashboard to use your custom redirect URI.
 
 This makes the OAuth flow go through your domain first, then to Composio for token storage.
+
+## What to read next
+
+<Cards>
+  <Card icon={<Key />} title="Using custom auth configuration" href="/docs/using-custom-auth-configuration" description="Set up auth configs for toolkits that don't have Composio managed authentication" />
+</Cards>


### PR DESCRIPTION
## Summary
- Adds "What to read next" sections to 9 practical guide pages (configuring-sessions, in-chat auth, manual auth, fetching toolkits, enable/disable toolkits, creating triggers, subscribing to events, managing triggers, white-labeling)
- Links point forward to sibling practical guides, not back to concept pages
- Adds "How Composio works" card to quickstart next steps
- Fixes unclosed code block in in-chat-authentication that was swallowing the page footer
- Adds multi-tenancy keywords to projects page for LLM/search discoverability
- Replaces em dashes with colons in projects page

## Test plan
- [x] `bun run scripts/validate-links.ts` passes with 0 errors
- [ ] Visual check on dev server that cards render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)