### PR TITLE
refactor(cli): migrate commands to Tool Router session API

### DIFF
--- a/ts/e2e-tests/_utils/src/const.ts
+++ b/ts/e2e-tests/_utils/src/const.ts
@@ -1,7 +1,7 @@
 /**
  * Environment variables to automatically pass through to Docker containers.
  */
-export const WELL_KNOWN_ENV_VARS = ['COMPOSIO_API_KEY', 'OPENAI_API_KEY'] as const;
+export const WELL_KNOWN_ENV_VARS = ['COMPOSIO_API_KEY', 'COMPOSIO_BASE_URL', 'OPENAI_API_KEY'] as const;
 
 /**
  * Node.js versions that are well-known to the CI matrix strategy.

--- a/ts/e2e-tests/cli/toolkits/info/e2e.test.ts
+++ b/ts/e2e-tests/cli/toolkits/info/e2e.test.ts
@@ -64,35 +64,27 @@ e2e(import.meta.url, {
         expect(obj.slug).toBe('gmail');
       });
 
-      it('has meta with description, tools_count, and triggers_count', () => {
+      it('has meta with description and logo', () => {
         const obj = JSON.parse(sanitizeOutput(validResult.stdout));
         expect(obj.meta).toHaveProperty('description');
-        expect(typeof obj.meta.tools_count).toBe('number');
-        expect(typeof obj.meta.triggers_count).toBe('number');
+        expect(typeof obj.meta.description).toBe('string');
+        expect(obj.meta).toHaveProperty('logo');
       });
 
-      it('has auth_config_details array', () => {
+      it('has is_no_auth and enabled', () => {
         const obj = JSON.parse(sanitizeOutput(validResult.stdout));
-        expect(Array.isArray(obj.auth_config_details)).toBe(true);
-        expect(obj.auth_config_details.length).toBeGreaterThan(0);
+        expect(typeof obj.is_no_auth).toBe('boolean');
+        expect(typeof obj.enabled).toBe('boolean');
       });
 
-      it('each auth_config_detail has mode, name, and fields', () => {
-        const obj = JSON.parse(sanitizeOutput(validResult.stdout));
-        for (const detail of obj.auth_config_details) {
-          expect(detail).toHaveProperty('mode');
-          expect(detail).toHaveProperty('name');
-          expect(detail).toHaveProperty('fields');
-          expect(detail.fields).toHaveProperty('auth_config_creation');
-          expect(detail.fields).toHaveProperty('connected_account_initiation');
-        }
-      });
-
-      it('has composio_managed_auth_schemes, no_auth, and is_local_toolkit', () => {
+      it('has composio_managed_auth_schemes array', () => {
         const obj = JSON.parse(sanitizeOutput(validResult.stdout));
         expect(Array.isArray(obj.composio_managed_auth_schemes)).toBe(true);
-        expect(typeof obj.no_auth).toBe('boolean');
-        expect(typeof obj.is_local_toolkit).toBe('boolean');
+      });
+
+      it('has connected_account (object or null)', () => {
+        const obj = JSON.parse(sanitizeOutput(validResult.stdout));
+        expect(obj).toHaveProperty('connected_account');
       });
     });
 
@@ -110,7 +102,8 @@ e2e(import.meta.url, {
       });
 
       it('out.json contains valid JSON with slug "gmail"', () => {
-        const obj = JSON.parse(sanitizeOutput(redirectResult.files['out.json']));
+        const content = redirectResult.files['out.json'];
+        const obj = JSON.parse(sanitizeOutput(content));
         expect(obj.slug).toBe('gmail');
       });
     });

--- a/ts/e2e-tests/cli/toolkits/list/e2e.test.ts
+++ b/ts/e2e-tests/cli/toolkits/list/e2e.test.ts
@@ -57,9 +57,10 @@ e2e(import.meta.url, {
         const item = JSON.parse(sanitizeOutput(exactResult.stdout))[0];
         expect(item).toHaveProperty('name');
         expect(item).toHaveProperty('slug');
-        expect(item).toHaveProperty('tools_count');
-        expect(item).toHaveProperty('triggers_count');
         expect(item).toHaveProperty('description');
+        expect(item).toHaveProperty('is_no_auth');
+        expect(item).toHaveProperty('enabled');
+        expect(item).toHaveProperty('composio_managed_auth_schemes');
       });
     });
 
@@ -93,8 +94,8 @@ e2e(import.meta.url, {
         expect(noFuzzyResult.stderr).toBe('');
       });
 
-      it('stdout is empty (no results)', () => {
-        expect(sanitizeOutput(noFuzzyResult.stdout)).toBe('');
+      it('stdout is an empty JSON array (no results)', () => {
+        expect(sanitizeOutput(noFuzzyResult.stdout)).toBe('[]');
       });
     });
   },

--- a/ts/packages/cli/src/bin.ts
+++ b/ts/packages/cli/src/bin.ts
@@ -10,6 +10,7 @@ import * as constants from 'src/constants';
 import { ComposioCliConfig } from 'src/cli-config';
 import { BaseConfigProviderLive, ConfigLive, extendConfigProvider } from 'src/services/config';
 import {
+  ComposioClientSingleton,
   ComposioSessionRepository,
   ComposioToolkitsRepository,
 } from 'src/services/composio-clients';
@@ -73,9 +74,14 @@ export const TriggersRealtimeLive = Layer.provide(
   Layer.mergeAll(BunFileSystem.layer, NodeOs.Default)
 ) satisfies RequiredLayer;
 
+export const ComposioClientSingletonLive = Layer.provide(
+  ComposioClientSingleton.Default,
+  Layer.mergeAll(BunFileSystem.layer, NodeOs.Default, ConfigLive)
+) satisfies RequiredLayer;
+
 export const ToolsExecutorLive = Layer.provide(
   _ToolsExecutorLive,
-  ComposioUserContextLive
+  ComposioClientSingletonLive
 ) satisfies RequiredLayer;
 
 const layers = Layer.mergeAll(
@@ -85,6 +91,7 @@ const layers = Layer.mergeAll(
   UpgradeBinaryLive,
   ComposioUserContextLive,
   ComposioSessionRepositoryLive,
+  ComposioClientSingletonLive, // Expose ComposioClientSingleton for commands that use Tool Router directly
   ComposioToolkitsRepositoryCachedLive, // Use the cached layer instead of the regular one
   ToolsExecutorLive,
   EnvLangDetector.Default,

--- a/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
+++ b/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
@@ -205,13 +205,16 @@ export const connectedAccountsCmd$Link = Command.make(
           return;
         }
 
-        yield* waitForActiveConnection(
-          ui,
-          repo,
-          linkOpt.value.connected_account_id,
-          linkOpt.value.redirect_url,
-          noBrowser
-        );
+        const { connected_account_id: connAccountId, redirect_url: redirectUrl } = linkOpt.value;
+        if (!connAccountId || !redirectUrl) {
+          yield* ui.log.error(
+            'The API returned an incomplete link response (missing connected_account_id or redirect_url).'
+          );
+          yield* Effect.logDebug('Link response:', linkOpt.value);
+          return;
+        }
+
+        yield* waitForActiveConnection(ui, repo, connAccountId, redirectUrl, noBrowser);
       }
     })
 ).pipe(Command.withDescription('Link an external account via OAuth redirect.'));

--- a/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
+++ b/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
@@ -43,15 +43,29 @@ const waitForActiveConnection = (
     yield* ui.output(redirectUrl);
 
     if (!noBrowser) {
-      yield* Effect.tryPromise(() => open(redirectUrl, { wait: false })).pipe(
-        Effect.catchAll(error =>
-          Effect.gen(function* () {
-            yield* Effect.logDebug('Failed to open browser:', error);
-            yield* ui.log.warn('Could not open the browser automatically.');
-            yield* ui.log.info('Tip: try using `--no-browser` and open the URL manually.');
-          })
-        )
-      );
+      // Validate URL scheme before opening — prevent non-HTTPS redirects
+      let urlSchemeValid = false;
+      try {
+        const parsed = new URL(redirectUrl);
+        urlSchemeValid = parsed.protocol === 'https:' || parsed.protocol === 'http:';
+      } catch {
+        // Malformed URL — fall through to the warning below
+      }
+
+      if (!urlSchemeValid) {
+        yield* ui.log.warn(`Redirect URL has an unexpected scheme: ${redirectUrl}`);
+        yield* ui.log.info('Open the URL manually if you trust the source.');
+      } else {
+        yield* Effect.tryPromise(() => open(redirectUrl, { wait: false })).pipe(
+          Effect.catchAll(error =>
+            Effect.gen(function* () {
+              yield* Effect.logDebug('Failed to open browser:', error);
+              yield* ui.log.warn('Could not open the browser automatically.');
+              yield* ui.log.info('Tip: try using `--no-browser` and open the URL manually.');
+            })
+          )
+        );
+      }
     }
 
     // Poll until the connected account becomes ACTIVE

--- a/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
+++ b/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
@@ -1,11 +1,12 @@
 import { Args, Command, Options } from '@effect/cli';
 import { Effect, Option, Schedule } from 'effect';
 import open from 'open';
-import { ComposioClientSingleton, ComposioToolkitsRepository } from 'src/services/composio-clients';
+import { ComposioToolkitsRepository } from 'src/services/composio-clients';
 import { TerminalUI } from 'src/services/terminal-ui';
 import { requireAuth } from 'src/effects/require-auth';
 import { handleHttpServerError } from 'src/effects/handle-http-error';
-import { createToolRouterSession } from 'src/effects/create-tool-router-session';
+import { resolveToolRouterSession } from 'src/effects/create-tool-router-session';
+import { extractMessage } from 'src/utils/api-error-extraction';
 
 const toolkit = Args.text({ name: 'toolkit' }).pipe(
   Args.withDescription('Toolkit slug to link (e.g. "github", "gmail")'),
@@ -180,14 +181,12 @@ export const connectedAccountsCmd$Link = Command.make(
       } else {
         // Path B: Tool Router flow — toolkit is guaranteed Some (validated above)
         const toolkitSlug = Option.getOrThrow(toolkit);
-        const clientSingleton = yield* ComposioClientSingleton;
-        const client = yield* clientSingleton.get();
 
         const linkOpt = yield* ui
           .withSpinner(
             `Linking ${toolkitSlug}...`,
             Effect.gen(function* () {
-              const sessionId = yield* createToolRouterSession(client, userId, {
+              const { client, sessionId } = yield* resolveToolRouterSession(userId, {
                 manageConnections: true,
               });
               return yield* Effect.tryPromise(() =>
@@ -199,14 +198,8 @@ export const connectedAccountsCmd$Link = Command.make(
             Effect.asSome,
             Effect.catchAll(error =>
               Effect.gen(function* () {
-                // Surface the API error message when available
                 const message =
-                  error instanceof Error
-                    ? error.message
-                    : typeof error === 'object' && error !== null && 'message' in error
-                      ? String((error as { message: unknown }).message)
-                      : `Failed to create link for toolkit "${toolkitSlug}".`;
-
+                  extractMessage(error) ?? `Failed to create link for toolkit "${toolkitSlug}".`;
                 yield* ui.log.error(message);
                 yield* Effect.logDebug('Link error:', error);
                 yield* ui.log.step('Browse available toolkits:\n> composio toolkits list');

--- a/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
+++ b/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
@@ -1,13 +1,20 @@
-import { Command, Options } from '@effect/cli';
+import { Args, Command, Options } from '@effect/cli';
 import { Effect, Option, Schedule } from 'effect';
 import open from 'open';
-import { ComposioToolkitsRepository } from 'src/services/composio-clients';
+import { ComposioClientSingleton, ComposioToolkitsRepository } from 'src/services/composio-clients';
 import { TerminalUI } from 'src/services/terminal-ui';
 import { requireAuth } from 'src/effects/require-auth';
 import { handleHttpServerError } from 'src/effects/handle-http-error';
+import { createToolRouterSession } from 'src/effects/create-tool-router-session';
+
+const toolkit = Args.text({ name: 'toolkit' }).pipe(
+  Args.withDescription('Toolkit slug to link (e.g. "github", "gmail")'),
+  Args.optional
+);
 
 const authConfig = Options.text('auth-config').pipe(
-  Options.withDescription('Auth config ID (e.g. "ac_...")')
+  Options.withDescription('Auth config ID (e.g. "ac_..."). Uses legacy flow (no Tool Router).'),
+  Options.optional
 );
 
 const userId = Options.text('user-id').pipe(
@@ -21,100 +28,190 @@ const noBrowser = Options.boolean('no-browser').pipe(
 );
 
 /**
- * Link an external account by creating an OAuth redirect session.
+ * Open the browser and poll until the connected account becomes ACTIVE.
+ */
+const waitForActiveConnection = (
+  ui: TerminalUI,
+  repo: ComposioToolkitsRepository,
+  connectedAccountId: string,
+  redirectUrl: string,
+  noBrowser: boolean
+) =>
+  Effect.gen(function* () {
+    // Display the redirect URL
+    yield* ui.note(redirectUrl, 'Redirect URL');
+    yield* ui.output(redirectUrl);
+
+    if (!noBrowser) {
+      yield* Effect.tryPromise(() => open(redirectUrl, { wait: false })).pipe(
+        Effect.catchAll(error =>
+          Effect.gen(function* () {
+            yield* Effect.logDebug('Failed to open browser:', error);
+            yield* ui.log.warn('Could not open the browser automatically.');
+            yield* ui.log.info('Tip: try using `--no-browser` and open the URL manually.');
+          })
+        )
+      );
+    }
+
+    // Poll until the connected account becomes ACTIVE
+    yield* ui.useMakeSpinner('Waiting for authentication...', spinner =>
+      Effect.retry(
+        Effect.gen(function* () {
+          const account = yield* repo.getConnectedAccount(connectedAccountId);
+
+          if (account.status === 'ACTIVE') {
+            return account;
+          }
+
+          return yield* Effect.fail(
+            new Error(`Connection status is still '${account.status}', waiting for 'ACTIVE'`)
+          );
+        }),
+        // Exponential backoff: start with 0.3s, max 5s, up to 15 retries
+        Schedule.exponential('0.3 seconds').pipe(
+          Schedule.intersect(Schedule.recurs(15)),
+          Schedule.intersect(Schedule.spaced('5 seconds'))
+        )
+      ).pipe(
+        Effect.tap(account => {
+          return Effect.all([
+            spinner.stop('Connection successful'),
+            ui.log.success(
+              `Connected account "${account.id}" is now ACTIVE (toolkit: ${account.toolkit.slug}).`
+            ),
+          ]);
+        }),
+        Effect.tapError(() => spinner.error('Connection timed out. Please try again.'))
+      )
+    );
+  });
+
+/**
+ * Link an external account via OAuth redirect.
  *
- * Opens the browser to the redirect URL and polls until the connection
- * becomes ACTIVE.
+ * Two modes:
+ * - **Tool Router** (default): `composio connected-accounts link <toolkit>`
+ * - **Legacy**: `composio connected-accounts link --auth-config <id>`
  *
  * @example
  * ```bash
+ * composio connected-accounts link github
+ * composio connected-accounts link gmail --user-id "alice"
  * composio connected-accounts link --auth-config "ac_..." --user-id "default"
- * composio connected-accounts link --auth-config "ac_..." --no-browser
  * ```
  */
 export const connectedAccountsCmd$Link = Command.make(
   'link',
-  { authConfig, userId, noBrowser },
-  ({ authConfig, userId, noBrowser }) =>
+  { toolkit, authConfig, userId, noBrowser },
+  ({ toolkit, authConfig, userId, noBrowser }) =>
     Effect.gen(function* () {
       if (!(yield* requireAuth)) return;
 
       const ui = yield* TerminalUI;
       const repo = yield* ComposioToolkitsRepository;
 
-      // Create the link session
-      const linkOpt = yield* ui
-        .withSpinner(
-          'Creating link session...',
-          repo.createConnectedAccountLink({
-            auth_config_id: authConfig,
-            user_id: userId,
-          })
-        )
-        .pipe(
-          Effect.asSome,
-          Effect.catchTag(
-            'services/HttpServerError',
-            handleHttpServerError(ui, {
-              fallbackMessage: `Failed to create link for auth config "${authConfig}".`,
-              hint: 'Browse available auth configs:\n> composio auth-configs list',
-              fallbackValue: Option.none(),
-            })
-          )
+      // Validate: exactly one of <toolkit> or --auth-config must be provided
+      if (Option.isSome(toolkit) && Option.isSome(authConfig)) {
+        yield* ui.log.error(
+          'Cannot use both <toolkit> and --auth-config. Choose one:\n' +
+            '  Tool Router: composio connected-accounts link <toolkit>\n' +
+            '  Legacy:      composio connected-accounts link --auth-config <id>'
         );
-
-      if (Option.isNone(linkOpt)) {
         return;
       }
 
-      const { connected_account_id, redirect_url } = linkOpt.value;
-
-      // Display the redirect URL
-      yield* ui.note(redirect_url, 'Redirect URL');
-      yield* ui.output(redirect_url);
-
-      if (!noBrowser) {
-        yield* Effect.tryPromise(() => open(redirect_url, { wait: false })).pipe(
-          Effect.catchAll(error =>
-            Effect.gen(function* () {
-              yield* Effect.logDebug('Failed to open browser:', error);
-              yield* ui.log.warn('Could not open the browser automatically.');
-              yield* ui.log.info('Tip: try using `--no-browser` and open the URL manually.');
-            })
-          )
+      if (Option.isNone(toolkit) && Option.isNone(authConfig)) {
+        yield* ui.log.error(
+          'Missing argument. Provide a toolkit slug or --auth-config:\n' +
+            '  composio connected-accounts link github\n' +
+            '  composio connected-accounts link --auth-config "ac_..."'
         );
+        return;
       }
 
-      // Poll until the connected account becomes ACTIVE
-      yield* ui.useMakeSpinner('Waiting for authentication...', spinner =>
-        Effect.retry(
-          Effect.gen(function* () {
-            const account = yield* repo.getConnectedAccount(connected_account_id);
-
-            if (account.status === 'ACTIVE') {
-              return account;
-            }
-
-            return yield* Effect.fail(
-              new Error(`Connection status is still '${account.status}', waiting for 'ACTIVE'`)
-            );
-          }),
-          // Exponential backoff: start with 0.3s, max 5s, up to 15 retries
-          Schedule.exponential('0.3 seconds').pipe(
-            Schedule.intersect(Schedule.recurs(15)),
-            Schedule.intersect(Schedule.spaced('5 seconds'))
+      if (Option.isSome(authConfig)) {
+        // Path A: Legacy flow — use existing client.link.create()
+        const linkOpt = yield* ui
+          .withSpinner(
+            'Creating link session...',
+            repo.createConnectedAccountLink({
+              auth_config_id: authConfig.value,
+              user_id: userId,
+            })
           )
-        ).pipe(
-          Effect.tap(account => {
-            return Effect.all([
-              spinner.stop('Connection successful'),
-              ui.log.success(
-                `Connected account "${account.id}" is now ACTIVE (toolkit: ${account.toolkit.slug}).`
-              ),
-            ]);
-          }),
-          Effect.tapError(() => spinner.error('Connection timed out. Please try again.'))
-        )
-      );
+          .pipe(
+            Effect.asSome,
+            Effect.catchTag(
+              'services/HttpServerError',
+              handleHttpServerError(ui, {
+                fallbackMessage: `Failed to create link for auth config "${authConfig.value}".`,
+                hint: 'Browse available auth configs:\n> composio auth-configs list',
+                fallbackValue: Option.none(),
+              })
+            )
+          );
+
+        if (Option.isNone(linkOpt)) {
+          return;
+        }
+
+        yield* waitForActiveConnection(
+          ui,
+          repo,
+          linkOpt.value.connected_account_id,
+          linkOpt.value.redirect_url,
+          noBrowser
+        );
+      } else {
+        // Path B: Tool Router flow — toolkit is guaranteed Some (validated above)
+        const toolkitSlug = Option.getOrThrow(toolkit);
+        const clientSingleton = yield* ComposioClientSingleton;
+        const client = yield* clientSingleton.get();
+
+        const linkOpt = yield* ui
+          .withSpinner(
+            `Linking ${toolkitSlug}...`,
+            Effect.gen(function* () {
+              const sessionId = yield* createToolRouterSession(client, userId, {
+                manageConnections: true,
+              });
+              return yield* Effect.tryPromise(() =>
+                client.toolRouter.session.link(sessionId, { toolkit: toolkitSlug })
+              );
+            })
+          )
+          .pipe(
+            Effect.asSome,
+            Effect.catchAll(error =>
+              Effect.gen(function* () {
+                // Surface the API error message when available
+                const message =
+                  error instanceof Error
+                    ? error.message
+                    : typeof error === 'object' && error !== null && 'message' in error
+                      ? String((error as { message: unknown }).message)
+                      : `Failed to create link for toolkit "${toolkitSlug}".`;
+
+                yield* ui.log.error(message);
+                yield* Effect.logDebug('Link error:', error);
+                yield* ui.log.step('Browse available toolkits:\n> composio toolkits list');
+                return Option.none();
+              })
+            )
+          );
+
+        if (Option.isNone(linkOpt)) {
+          return;
+        }
+
+        yield* waitForActiveConnection(
+          ui,
+          repo,
+          linkOpt.value.connected_account_id,
+          linkOpt.value.redirect_url,
+          noBrowser
+        );
+      }
     })
 ).pipe(Command.withDescription('Link an external account via OAuth redirect.'));

--- a/ts/packages/cli/src/commands/toolkits/commands/toolkits.info.cmd.ts
+++ b/ts/packages/cli/src/commands/toolkits/commands/toolkits.info.cmd.ts
@@ -1,9 +1,10 @@
 import { Args, Command, Options } from '@effect/cli';
 import { Effect, Option } from 'effect';
-import { ComposioClientSingleton, ComposioToolkitsRepository } from 'src/services/composio-clients';
+import { ComposioToolkitsRepository } from 'src/services/composio-clients';
 import { TerminalUI } from 'src/services/terminal-ui';
 import { requireAuth } from 'src/effects/require-auth';
-import { createToolRouterSession } from 'src/effects/create-tool-router-session';
+import { resolveToolRouterSession } from 'src/effects/create-tool-router-session';
+import { extractMessage } from 'src/utils/api-error-extraction';
 import { formatToolkitInfo, formatToolkitInfoJson } from '../format';
 
 const slug = Args.text({ name: 'slug' }).pipe(
@@ -40,14 +41,11 @@ export const toolkitsCmd$Info = Command.make('info', { slug, userId }, ({ slug, 
 
     const slugValue = slug.value;
 
-    const clientSingleton = yield* ComposioClientSingleton;
-    const client = yield* clientSingleton.get();
-
     const resultOpt = yield* ui
       .withSpinner(
         `Fetching toolkit "${slugValue}"...`,
         Effect.gen(function* () {
-          const sessionId = yield* createToolRouterSession(client, userId);
+          const { client, sessionId } = yield* resolveToolRouterSession(userId);
           return yield* Effect.tryPromise(() =>
             client.toolRouter.session.toolkits(sessionId, {
               toolkits: [slugValue],
@@ -59,9 +57,9 @@ export const toolkitsCmd$Info = Command.make('info', { slug, userId }, ({ slug, 
         Effect.asSome,
         Effect.catchAll(error =>
           Effect.gen(function* () {
-            const message =
-              error instanceof Error ? error.message : `Failed to fetch toolkit "${slugValue}".`;
+            const message = extractMessage(error) ?? `Failed to fetch toolkit "${slugValue}".`;
             yield* ui.log.error(message);
+            yield* Effect.logDebug('Toolkit info error:', error);
             yield* ui.log.step('Browse available toolkits:\n> composio toolkits list');
             return Option.none();
           })
@@ -73,8 +71,7 @@ export const toolkitsCmd$Info = Command.make('info', { slug, userId }, ({ slug, 
     }
 
     const result = resultOpt.value;
-    const items = Array.isArray(result.items) ? result.items : [];
-    const toolkit = items[0];
+    const toolkit = result.items[0];
 
     if (!toolkit) {
       yield* ui.log.warn(`Toolkit "${slugValue}" not found.`);

--- a/ts/packages/cli/src/commands/toolkits/commands/toolkits.info.cmd.ts
+++ b/ts/packages/cli/src/commands/toolkits/commands/toolkits.info.cmd.ts
@@ -43,41 +43,24 @@ export const toolkitsCmd$Info = Command.make('info', { slug, userId }, ({ slug, 
     const clientSingleton = yield* ComposioClientSingleton;
     const client = yield* clientSingleton.get();
 
-    const toolkitOpt = yield* ui
-      .withSpinner(
-        `Fetching toolkit "${slugValue}"...`,
-        Effect.gen(function* () {
-          const sessionId = yield* createToolRouterSession(client, userId);
-          const result = yield* Effect.tryPromise(() =>
-            client.toolRouter.session.toolkits(sessionId, {
-              toolkits: [slugValue],
-            })
-          );
-          const item = result.items[0];
-          if (!item) {
-            return yield* Effect.fail(new Error(`Toolkit "${slugValue}" not found.`));
-          }
-          return item;
-        })
-      )
-      .pipe(
-        Effect.asSome,
-        Effect.catchAll(error =>
-          Effect.gen(function* () {
-            const message =
-              error instanceof Error ? error.message : `Failed to fetch toolkit "${slugValue}".`;
-            yield* ui.log.error(message);
-            yield* ui.log.step('Browse available toolkits:\n> composio toolkits list');
-            return Option.none();
+    const result = yield* ui.withSpinner(
+      `Fetching toolkit "${slugValue}"...`,
+      Effect.gen(function* () {
+        const sessionId = yield* createToolRouterSession(client, userId);
+        return yield* Effect.tryPromise(() =>
+          client.toolRouter.session.toolkits(sessionId, {
+            toolkits: [slugValue],
           })
-        )
-      );
+        );
+      })
+    );
 
-    if (Option.isNone(toolkitOpt)) {
+    const toolkit = result.items[0];
+    if (!toolkit) {
+      yield* ui.log.warn(`Toolkit "${slugValue}" not found.`);
+      yield* ui.log.step('Browse available toolkits:\n> composio toolkits list');
       return;
     }
-
-    const toolkit = toolkitOpt.value;
 
     yield* ui.note(formatToolkitInfo(toolkit), `Toolkit: ${toolkit.name}`);
 

--- a/ts/packages/cli/src/commands/toolkits/commands/toolkits.info.cmd.ts
+++ b/ts/packages/cli/src/commands/toolkits/commands/toolkits.info.cmd.ts
@@ -1,6 +1,6 @@
 import { Args, Command, Options } from '@effect/cli';
 import { Effect, Option } from 'effect';
-import { ComposioClientSingleton } from 'src/services/composio-clients';
+import { ComposioClientSingleton, ComposioToolkitsRepository } from 'src/services/composio-clients';
 import { TerminalUI } from 'src/services/terminal-ui';
 import { requireAuth } from 'src/effects/require-auth';
 import { createToolRouterSession } from 'src/effects/create-tool-router-session';
@@ -43,22 +43,61 @@ export const toolkitsCmd$Info = Command.make('info', { slug, userId }, ({ slug, 
     const clientSingleton = yield* ComposioClientSingleton;
     const client = yield* clientSingleton.get();
 
-    const result = yield* ui.withSpinner(
-      `Fetching toolkit "${slugValue}"...`,
-      Effect.gen(function* () {
-        const sessionId = yield* createToolRouterSession(client, userId);
-        return yield* Effect.tryPromise(() =>
-          client.toolRouter.session.toolkits(sessionId, {
-            toolkits: [slugValue],
+    const resultOpt = yield* ui
+      .withSpinner(
+        `Fetching toolkit "${slugValue}"...`,
+        Effect.gen(function* () {
+          const sessionId = yield* createToolRouterSession(client, userId);
+          return yield* Effect.tryPromise(() =>
+            client.toolRouter.session.toolkits(sessionId, {
+              toolkits: [slugValue],
+            })
+          );
+        })
+      )
+      .pipe(
+        Effect.asSome,
+        Effect.catchAll(error =>
+          Effect.gen(function* () {
+            const message =
+              error instanceof Error ? error.message : `Failed to fetch toolkit "${slugValue}".`;
+            yield* ui.log.error(message);
+            yield* ui.log.step('Browse available toolkits:\n> composio toolkits list');
+            return Option.none();
           })
-        );
-      })
-    );
+        )
+      );
 
-    const toolkit = result.items[0];
+    if (Option.isNone(resultOpt)) {
+      return;
+    }
+
+    const result = resultOpt.value;
+    const items = Array.isArray(result.items) ? result.items : [];
+    const toolkit = items[0];
+
     if (!toolkit) {
       yield* ui.log.warn(`Toolkit "${slugValue}" not found.`);
-      yield* ui.log.step('Browse available toolkits:\n> composio toolkits list');
+
+      // "Did you mean?" suggestions via legacy search
+      const repo = yield* ComposioToolkitsRepository;
+      const suggestions = yield* repo.searchToolkits({ search: slugValue, limit: 3 }).pipe(
+        Effect.map(r =>
+          r.items.map(s => ({
+            label: `${s.slug} — ${s.meta.description}`,
+            command: `> composio toolkits info "${s.slug}"`,
+          }))
+        ),
+        Effect.catchAll(() => Effect.succeed([] as { label: string; command: string }[]))
+      );
+
+      const [first] = suggestions;
+      if (first) {
+        const lines = suggestions.map(s => `  ${s.label}`).join('\n');
+        yield* ui.log.step(`Did you mean?\n${lines}\n\n${first.command}`);
+      } else {
+        yield* ui.log.step('Browse available toolkits:\n> composio toolkits list');
+      }
       return;
     }
 

--- a/ts/packages/cli/src/commands/toolkits/commands/toolkits.info.cmd.ts
+++ b/ts/packages/cli/src/commands/toolkits/commands/toolkits.info.cmd.ts
@@ -4,7 +4,7 @@ import { ComposioClientSingleton, ComposioToolkitsRepository } from 'src/service
 import { TerminalUI } from 'src/services/terminal-ui';
 import { requireAuth } from 'src/effects/require-auth';
 import { createToolRouterSession } from 'src/effects/create-tool-router-session';
-import { formatToolkitInfo } from '../format';
+import { formatToolkitInfo, formatToolkitInfoJson } from '../format';
 
 const slug = Args.text({ name: 'slug' }).pipe(
   Args.withDescription('Toolkit slug (e.g. "gmail")'),
@@ -108,6 +108,6 @@ export const toolkitsCmd$Info = Command.make('info', { slug, userId }, ({ slug, 
       `To list tools in this toolkit:\n> composio tools list --toolkits "${toolkit.slug}"`
     );
 
-    yield* ui.output(JSON.stringify(toolkit, null, 2));
+    yield* ui.output(formatToolkitInfoJson(toolkit));
   })
 ).pipe(Command.withDescription('View details of a specific toolkit.'));

--- a/ts/packages/cli/src/commands/toolkits/commands/toolkits.info.cmd.ts
+++ b/ts/packages/cli/src/commands/toolkits/commands/toolkits.info.cmd.ts
@@ -1,9 +1,9 @@
-import { Args, Command } from '@effect/cli';
+import { Args, Command, Options } from '@effect/cli';
 import { Effect, Option } from 'effect';
-import { ComposioToolkitsRepository } from 'src/services/composio-clients';
+import { ComposioClientSingleton } from 'src/services/composio-clients';
 import { TerminalUI } from 'src/services/terminal-ui';
 import { requireAuth } from 'src/effects/require-auth';
-import { handleHttpServerError } from 'src/effects/handle-http-error';
+import { createToolRouterSession } from 'src/effects/create-tool-router-session';
 import { formatToolkitInfo } from '../format';
 
 const slug = Args.text({ name: 'slug' }).pipe(
@@ -11,20 +11,25 @@ const slug = Args.text({ name: 'slug' }).pipe(
   Args.optional
 );
 
+const userId = Options.text('user-id').pipe(
+  Options.withDefault('default'),
+  Options.withDescription('User ID for connection status (default: "default")')
+);
+
 /**
- * View details of a specific toolkit including auth schemes and required fields.
+ * View details of a specific toolkit including connection status.
  *
  * @example
  * ```bash
  * composio toolkits info "gmail"
+ * composio toolkits info "github" --user-id "alice"
  * ```
  */
-export const toolkitsCmd$Info = Command.make('info', { slug }, ({ slug }) =>
+export const toolkitsCmd$Info = Command.make('info', { slug, userId }, ({ slug, userId }) =>
   Effect.gen(function* () {
     if (!(yield* requireAuth)) return;
 
     const ui = yield* TerminalUI;
-    const repo = yield* ComposioToolkitsRepository;
 
     // Missing slug guard
     if (Option.isNone(slug)) {
@@ -35,25 +40,35 @@ export const toolkitsCmd$Info = Command.make('info', { slug }, ({ slug }) =>
 
     const slugValue = slug.value;
 
+    const clientSingleton = yield* ComposioClientSingleton;
+    const client = yield* clientSingleton.get();
+
     const toolkitOpt = yield* ui
-      .withSpinner(`Fetching toolkit "${slugValue}"...`, repo.getToolkitDetailed(slugValue))
+      .withSpinner(
+        `Fetching toolkit "${slugValue}"...`,
+        Effect.gen(function* () {
+          const sessionId = yield* createToolRouterSession(client, userId);
+          const result = yield* Effect.tryPromise(() =>
+            client.toolRouter.session.toolkits(sessionId, {
+              toolkits: [slugValue],
+            })
+          );
+          const item = result.items[0];
+          if (!item) {
+            return yield* Effect.fail(new Error(`Toolkit "${slugValue}" not found.`));
+          }
+          return item;
+        })
+      )
       .pipe(
         Effect.asSome,
-        Effect.catchTag(
-          'services/HttpServerError',
-          handleHttpServerError(ui, {
-            fallbackMessage: `Failed to fetch toolkit "${slugValue}".`,
-            hint: 'Browse available toolkits:\n> composio toolkits list',
-            fallbackValue: Option.none(),
-            searchForSuggestions: () =>
-              repo.searchToolkits({ search: slugValue, limit: 3 }).pipe(
-                Effect.map(r =>
-                  r.items.map(s => ({
-                    label: `${s.slug} — ${s.meta.description}`,
-                    command: `> composio toolkits info "${s.slug}"`,
-                  }))
-                )
-              ),
+        Effect.catchAll(error =>
+          Effect.gen(function* () {
+            const message =
+              error instanceof Error ? error.message : `Failed to fetch toolkit "${slugValue}".`;
+            yield* ui.log.error(message);
+            yield* ui.log.step('Browse available toolkits:\n> composio toolkits list');
+            return Option.none();
           })
         )
       );

--- a/ts/packages/cli/src/commands/toolkits/commands/toolkits.list.cmd.ts
+++ b/ts/packages/cli/src/commands/toolkits/commands/toolkits.list.cmd.ts
@@ -1,8 +1,9 @@
 import { Command, Options } from '@effect/cli';
 import { Effect, Option } from 'effect';
-import { ComposioToolkitsRepository } from 'src/services/composio-clients';
+import { ComposioClientSingleton } from 'src/services/composio-clients';
 import { TerminalUI } from 'src/services/terminal-ui';
 import { requireAuth } from 'src/effects/require-auth';
+import { createToolRouterSession } from 'src/effects/create-tool-router-session';
 import { clampLimit } from 'src/ui/clamp-limit';
 import { formatToolkitsTable, formatToolkitsJson } from '../format';
 
@@ -16,51 +17,75 @@ const limit = Options.integer('limit').pipe(
   Options.withDescription('Number of results per page (1-1000)')
 );
 
+const connected = Options.boolean('connected').pipe(
+  Options.withDescription('Filter to connected toolkits only'),
+  Options.optional
+);
+
+const userId = Options.text('user-id').pipe(
+  Options.withDefault('default'),
+  Options.withDescription('User ID for connection status (default: "default")')
+);
+
 /**
- * List available toolkits with optional filters.
+ * List available toolkits with connection status.
  *
  * @example
  * ```bash
  * composio toolkits list
  * composio toolkits list --query "email"
- * composio toolkits list --category "messaging" --limit 10
+ * composio toolkits list --connected
+ * composio toolkits list --user-id "alice"
  * ```
  */
-export const toolkitsCmd$List = Command.make('list', { query, limit }, ({ query, limit }) =>
-  Effect.gen(function* () {
-    if (!(yield* requireAuth)) return;
+export const toolkitsCmd$List = Command.make(
+  'list',
+  { query, limit, connected, userId },
+  ({ query, limit, connected, userId }) =>
+    Effect.gen(function* () {
+      if (!(yield* requireAuth)) return;
 
-    const ui = yield* TerminalUI;
-    const repo = yield* ComposioToolkitsRepository;
+      const ui = yield* TerminalUI;
+      const clientSingleton = yield* ComposioClientSingleton;
+      const client = yield* clientSingleton.get();
 
-    const clampedLimit = clampLimit(limit);
+      const clampedLimit = clampLimit(limit);
 
-    const result = yield* ui.withSpinner(
-      'Fetching toolkits...',
-      repo.searchToolkits({
-        search: Option.getOrUndefined(query),
-        limit: clampedLimit,
-      })
-    );
+      const result = yield* ui.withSpinner(
+        'Fetching toolkits...',
+        Effect.gen(function* () {
+          const sessionId = yield* createToolRouterSession(client, userId);
+          return yield* Effect.tryPromise(() =>
+            client.toolRouter.session.toolkits(sessionId, {
+              search: Option.getOrUndefined(query),
+              limit: clampedLimit,
+              is_connected: Option.getOrUndefined(connected),
+            })
+          );
+        })
+      );
 
-    if (result.items.length === 0) {
-      yield* ui.log.warn('No toolkits found. Try broadening your search.');
-      return;
-    }
+      if (result.items.length === 0) {
+        yield* ui.log.warn('No toolkits found. Try broadening your search.');
+        yield* ui.output('[]');
+        return;
+      }
 
-    const showing = result.items.length;
-    const total = result.total_items;
+      const showing = result.items.length;
+      const total = result.total_items;
 
-    yield* ui.log.info(
-      `Listing ${showing} of ${total} toolkits\n\n${formatToolkitsTable(result.items)}`
-    );
+      yield* ui.log.info(
+        `Listing ${showing} of ${total} toolkits\n\n${formatToolkitsTable(result.items)}`
+      );
 
-    // Next step hint
-    const firstSlug = result.items[0]?.slug;
-    if (firstSlug) {
-      yield* ui.log.step(`To view details of a toolkit:\n> composio toolkits info "${firstSlug}"`);
-    }
+      // Next step hint
+      const firstSlug = result.items[0]?.slug;
+      if (firstSlug) {
+        yield* ui.log.step(
+          `To view details of a toolkit:\n> composio toolkits info "${firstSlug}"`
+        );
+      }
 
-    yield* ui.output(formatToolkitsJson(result.items));
-  })
-).pipe(Command.withDescription('List available toolkits.'));
+      yield* ui.output(formatToolkitsJson(result.items));
+    })
+).pipe(Command.withDescription('List available toolkits with connection status.'));

--- a/ts/packages/cli/src/commands/toolkits/commands/toolkits.list.cmd.ts
+++ b/ts/packages/cli/src/commands/toolkits/commands/toolkits.list.cmd.ts
@@ -1,9 +1,8 @@
 import { Command, Options } from '@effect/cli';
 import { Effect, Option } from 'effect';
-import { ComposioClientSingleton } from 'src/services/composio-clients';
 import { TerminalUI } from 'src/services/terminal-ui';
 import { requireAuth } from 'src/effects/require-auth';
-import { createToolRouterSession } from 'src/effects/create-tool-router-session';
+import { resolveToolRouterSession } from 'src/effects/create-tool-router-session';
 import { clampLimit } from 'src/ui/clamp-limit';
 import { formatToolkitsTable, formatToolkitsJson } from '../format';
 
@@ -46,15 +45,13 @@ export const toolkitsCmd$List = Command.make(
       if (!(yield* requireAuth)) return;
 
       const ui = yield* TerminalUI;
-      const clientSingleton = yield* ComposioClientSingleton;
-      const client = yield* clientSingleton.get();
 
       const clampedLimit = clampLimit(limit);
 
       const result = yield* ui.withSpinner(
         'Fetching toolkits...',
         Effect.gen(function* () {
-          const sessionId = yield* createToolRouterSession(client, userId);
+          const { client, sessionId } = yield* resolveToolRouterSession(userId);
           return yield* Effect.tryPromise(() =>
             client.toolRouter.session.toolkits(sessionId, {
               search: Option.getOrUndefined(query),
@@ -65,7 +62,7 @@ export const toolkitsCmd$List = Command.make(
         })
       );
 
-      const items = Array.isArray(result.items) ? result.items : [];
+      const { items } = result;
 
       if (items.length === 0) {
         yield* ui.log.warn('No toolkits found. Try broadening your search.');

--- a/ts/packages/cli/src/commands/toolkits/commands/toolkits.list.cmd.ts
+++ b/ts/packages/cli/src/commands/toolkits/commands/toolkits.list.cmd.ts
@@ -65,27 +65,29 @@ export const toolkitsCmd$List = Command.make(
         })
       );
 
-      if (result.items.length === 0) {
+      const items = Array.isArray(result.items) ? result.items : [];
+
+      if (items.length === 0) {
         yield* ui.log.warn('No toolkits found. Try broadening your search.');
         yield* ui.output('[]');
         return;
       }
 
-      const showing = result.items.length;
+      const showing = items.length;
       const total = result.total_items;
 
       yield* ui.log.info(
-        `Listing ${showing} of ${total} toolkits\n\n${formatToolkitsTable(result.items)}`
+        `Listing ${showing} of ${total} toolkits\n\n${formatToolkitsTable(items)}`
       );
 
       // Next step hint
-      const firstSlug = result.items[0]?.slug;
+      const firstSlug = items[0]?.slug;
       if (firstSlug) {
         yield* ui.log.step(
           `To view details of a toolkit:\n> composio toolkits info "${firstSlug}"`
         );
       }
 
-      yield* ui.output(formatToolkitsJson(result.items));
+      yield* ui.output(formatToolkitsJson(items));
     })
 ).pipe(Command.withDescription('List available toolkits with connection status.'));

--- a/ts/packages/cli/src/commands/toolkits/commands/toolkits.search.cmd.ts
+++ b/ts/packages/cli/src/commands/toolkits/commands/toolkits.search.cmd.ts
@@ -4,7 +4,7 @@ import { ComposioToolkitsRepository } from 'src/services/composio-clients';
 import { TerminalUI } from 'src/services/terminal-ui';
 import { requireAuth } from 'src/effects/require-auth';
 import { clampLimit } from 'src/ui/clamp-limit';
-import { formatToolkitsTable, formatToolkitsJson } from '../format';
+import { formatLegacyToolkitsTable, formatLegacyToolkitsJson } from '../format';
 
 const query = Args.text({ name: 'query' }).pipe(
   Args.withDescription('Search query (e.g. "send emails")')
@@ -14,6 +14,9 @@ const limit = Options.integer('limit').pipe(
   Options.withDefault(10),
   Options.withDescription('Number of results per page (1-1000)')
 );
+
+// TODO(tool-router-migration): migrate to Tool Router when the session toolkits endpoint
+// supports text search. Currently SessionToolsParams has no search capability.
 
 /**
  * Search toolkits by use case.
@@ -47,7 +50,7 @@ export const toolkitsCmd$Search = Command.make('search', { query, limit }, ({ qu
     const total = result.total_items;
 
     yield* ui.log.info(
-      `Found ${showing} of ${total} toolkits\n\n${formatToolkitsTable(result.items)}`
+      `Found ${showing} of ${total} toolkits\n\n${formatLegacyToolkitsTable(result.items)}`
     );
 
     // Next step hint
@@ -56,6 +59,6 @@ export const toolkitsCmd$Search = Command.make('search', { query, limit }, ({ qu
       yield* ui.log.step(`To view details:\n> composio toolkits info "${firstSlug}"`);
     }
 
-    yield* ui.output(formatToolkitsJson(result.items));
+    yield* ui.output(formatLegacyToolkitsJson(result.items));
   })
 ).pipe(Command.withDescription('Search toolkits by use case.'));

--- a/ts/packages/cli/src/commands/toolkits/format.ts
+++ b/ts/packages/cli/src/commands/toolkits/format.ts
@@ -55,8 +55,8 @@ export function formatToolkitsJson(toolkits: ReadonlyArray<SessionToolkitItem>):
         ? {
             status: t.connected_account.status,
             id: t.connected_account.id,
-            auth_scheme: t.connected_account.auth_config.auth_scheme,
-            is_composio_managed: t.connected_account.auth_config.is_composio_managed,
+            auth_scheme: t.connected_account.auth_config?.auth_scheme ?? null,
+            is_composio_managed: t.connected_account.auth_config?.is_composio_managed ?? null,
           }
         : null,
       composio_managed_auth_schemes: t.composio_managed_auth_schemes,
@@ -91,8 +91,10 @@ export function formatToolkitInfo(toolkit: SessionToolkitItem): string {
     const statusDisplay = ca.status === 'ACTIVE' ? green(ca.status) : dim(ca.status);
     lines.push(`${bold('Connection Status:')} ${statusDisplay}`);
     lines.push(`${bold('Connected Account ID:')} ${ca.id}`);
-    lines.push(`${bold('Auth Scheme:')} ${ca.auth_config.auth_scheme}`);
-    lines.push(`${bold('Composio Managed:')} ${ca.auth_config.is_composio_managed ? 'Yes' : 'No'}`);
+    lines.push(`${bold('Auth Scheme:')} ${ca.auth_config?.auth_scheme ?? '-'}`);
+    lines.push(
+      `${bold('Composio Managed:')} ${ca.auth_config?.is_composio_managed ? 'Yes' : 'No'}`
+    );
   } else if (!toolkit.is_no_auth) {
     lines.push(`${bold('Connection Status:')} ${dim('Not connected')}`);
     lines.push(

--- a/ts/packages/cli/src/commands/toolkits/format.ts
+++ b/ts/packages/cli/src/commands/toolkits/format.ts
@@ -114,10 +114,13 @@ export function formatToolkitInfoJson(toolkit: SessionToolkitItem): string {
     {
       name: toolkit.name,
       slug: toolkit.slug,
-      description: toolkit.meta.description,
+      meta: {
+        description: toolkit.meta.description,
+        logo: toolkit.meta.logo,
+      },
       is_no_auth: toolkit.is_no_auth,
       enabled: toolkit.enabled,
-      connected: toolkit.connected_account
+      connected_account: toolkit.connected_account
         ? {
             status: toolkit.connected_account.status,
             id: toolkit.connected_account.id,

--- a/ts/packages/cli/src/commands/toolkits/format.ts
+++ b/ts/packages/cli/src/commands/toolkits/format.ts
@@ -1,11 +1,114 @@
-import type { Toolkit, ToolkitDetailed, AuthConfigDetail } from 'src/models/toolkits';
-import { bold, gray } from 'src/ui/colors';
+import type { Toolkit } from 'src/models/toolkits';
+import type { SessionToolkitsResponse } from '@composio/client/resources/tool-router';
+import { bold, gray, green, dim } from 'src/ui/colors';
 import { truncate } from 'src/ui/truncate';
 
+type SessionToolkitItem = SessionToolkitsResponse.Item;
+
+// ---------- Tool Router format functions ----------
+
 /**
- * Format a list of toolkits as a human-readable table.
+ * Derive connection status text and color from a session toolkit item.
+ * Returns plain text + color function so callers can pad before coloring.
  */
-export function formatToolkitsTable(toolkits: ReadonlyArray<Toolkit>): string {
+function connectionStatusParts(item: SessionToolkitItem): {
+  text: string;
+  color: (s: string) => string;
+} {
+  if (item.is_no_auth) return { text: 'no auth', color: dim };
+  if (item.connected_account?.status === 'ACTIVE') return { text: 'active', color: green };
+  return { text: 'not connected', color: dim };
+}
+
+/**
+ * Format a list of session toolkits as a human-readable table.
+ */
+export function formatToolkitsTable(toolkits: ReadonlyArray<SessionToolkitItem>): string {
+  const header = `${bold('Name'.padEnd(20))} ${bold('Slug'.padEnd(20))} ${bold('Connected'.padEnd(16))} ${bold('Auth Scheme'.padEnd(14))} ${bold('Description')}`;
+
+  const rows = toolkits.map(t => {
+    const name = t.name.padEnd(20);
+    const slug = t.slug.padEnd(20);
+    // Pad plain text first, then apply color — ANSI escapes break padEnd.
+    const { text: statusText, color: statusColor } = connectionStatusParts(t);
+    const status = statusColor(statusText.padEnd(16));
+    const authScheme = (t.connected_account?.auth_config?.auth_scheme ?? '-').padEnd(14);
+    const desc = gray(truncate(t.meta.description, 50));
+    return `${name} ${slug} ${status} ${authScheme} ${desc}`;
+  });
+
+  return [header, ...rows].join('\n');
+}
+
+/**
+ * Format session toolkits as JSON for piped output.
+ */
+export function formatToolkitsJson(toolkits: ReadonlyArray<SessionToolkitItem>): string {
+  return JSON.stringify(
+    toolkits.map(t => ({
+      name: t.name,
+      slug: t.slug,
+      description: t.meta.description,
+      is_no_auth: t.is_no_auth,
+      enabled: t.enabled,
+      connected: t.connected_account
+        ? {
+            status: t.connected_account.status,
+            id: t.connected_account.id,
+            auth_scheme: t.connected_account.auth_config.auth_scheme,
+            is_composio_managed: t.connected_account.auth_config.is_composio_managed,
+          }
+        : null,
+      composio_managed_auth_schemes: t.composio_managed_auth_schemes,
+    })),
+    null,
+    2
+  );
+}
+
+/**
+ * Format a single session toolkit for detailed interactive display.
+ */
+export function formatToolkitInfo(toolkit: SessionToolkitItem): string {
+  const lines: string[] = [];
+
+  lines.push(`${bold('Name:')} ${toolkit.name}`);
+  lines.push(`${bold('Slug:')} ${toolkit.slug}`);
+  lines.push(`${bold('Description:')} ${toolkit.meta.description || '(none)'}`);
+
+  if (toolkit.is_no_auth) {
+    lines.push(`${bold('Auth:')} No authentication required`);
+  } else if (toolkit.composio_managed_auth_schemes.length > 0) {
+    lines.push(
+      `${bold('Composio Managed Auth Schemes:')} ${toolkit.composio_managed_auth_schemes.join(', ')}`
+    );
+  }
+
+  // Connection status — render the actual status, not a hardcoded label
+  lines.push('');
+  if (toolkit.connected_account) {
+    const ca = toolkit.connected_account;
+    const statusDisplay = ca.status === 'ACTIVE' ? green(ca.status) : dim(ca.status);
+    lines.push(`${bold('Connection Status:')} ${statusDisplay}`);
+    lines.push(`${bold('Connected Account ID:')} ${ca.id}`);
+    lines.push(`${bold('Auth Scheme:')} ${ca.auth_config.auth_scheme}`);
+    lines.push(`${bold('Composio Managed:')} ${ca.auth_config.is_composio_managed ? 'Yes' : 'No'}`);
+  } else if (!toolkit.is_no_auth) {
+    lines.push(`${bold('Connection Status:')} ${dim('Not connected')}`);
+    lines.push(
+      `${bold('Tip:')} Link this toolkit:\n> composio connected-accounts link "${toolkit.slug}"`
+    );
+  }
+
+  return lines.join('\n');
+}
+
+// ---------- Legacy format functions (used by non-migrated commands) ----------
+
+/**
+ * Format a list of toolkits as a human-readable table (legacy format).
+ */
+export function formatLegacyToolkitsTable(toolkits: ReadonlyArray<Toolkit>): string {
   const header = `${bold('Name'.padEnd(20))} ${bold('Slug'.padEnd(20))} ${bold('Version'.padEnd(12))} ${bold('Tools'.padEnd(7))} ${bold('Triggers'.padEnd(10))} ${bold('Description')}`;
 
   const rows = toolkits.map(t => {
@@ -22,9 +125,9 @@ export function formatToolkitsTable(toolkits: ReadonlyArray<Toolkit>): string {
 }
 
 /**
- * Format toolkits as JSON for piped output.
+ * Format toolkits as JSON for piped output (legacy format).
  */
-export function formatToolkitsJson(toolkits: ReadonlyArray<Toolkit>): string {
+export function formatLegacyToolkitsJson(toolkits: ReadonlyArray<Toolkit>): string {
   return JSON.stringify(
     toolkits.map(t => ({
       name: t.name,
@@ -37,81 +140,4 @@ export function formatToolkitsJson(toolkits: ReadonlyArray<Toolkit>): string {
     null,
     2
   );
-}
-
-/**
- * Format auth config fields for display.
- */
-function formatFields(group: AuthConfigDetail['fields']['auth_config_creation']) {
-  const allFields = [
-    ...group.required.map(f => ({ ...f, label: 'required' })),
-    ...group.optional.map(f => ({ ...f, label: 'optional' })),
-  ];
-
-  if (allFields.length === 0) {
-    return '    (none)';
-  }
-
-  const nameWidth = Math.max(...allFields.map(f => f.name.length));
-  const labelWidth = Math.max(...allFields.map(f => f.label.length));
-  const typeWidth = Math.max(...allFields.map(f => f.type.length));
-
-  return allFields
-    .map(field => {
-      const desc = field.description ? `  ${gray(`"${field.description}"`)}` : '';
-      return `    ${field.name.padEnd(nameWidth)} ${field.label.padEnd(labelWidth)} ${field.type.padEnd(typeWidth)}${desc}`;
-    })
-    .join('\n');
-}
-
-/**
- * Format a detailed toolkit for interactive display.
- */
-export function formatToolkitInfo(toolkit: ToolkitDetailed): string {
-  const lines: string[] = [];
-
-  lines.push(`${bold('Name:')} ${toolkit.name}`);
-  lines.push(`${bold('Slug:')} ${toolkit.slug}`);
-
-  const versions = toolkit.meta.available_versions;
-  const latest = versions.at(-1);
-  if (latest) {
-    lines.push(`${bold('Latest Version:')} ${latest} (${versions.length} available)`);
-  } else {
-    lines.push(`${bold('Latest Version:')} -`);
-  }
-
-  lines.push(`${bold('Description:')} ${toolkit.meta.description || '(none)'}`);
-
-  // Derive auth schemes from auth_config_details
-  const authSchemes = toolkit.auth_config_details.map(d => d.mode);
-  if (toolkit.no_auth) {
-    lines.push(`${bold('Auth:')} No authentication required`);
-  } else if (authSchemes.length > 0) {
-    lines.push(`${bold('Auth Schemes:')} ${authSchemes.join(', ')}`);
-    if (toolkit.composio_managed_auth_schemes.length > 0) {
-      lines.push(
-        `${bold('Composio Managed Auth Schemes:')} ${toolkit.composio_managed_auth_schemes.join(', ')}`
-      );
-    }
-  }
-
-  // Auth config creation fields
-  if (toolkit.auth_config_details.length > 0) {
-    lines.push('');
-    lines.push(bold('Fields Required for AuthConfig creation:'));
-    for (const detail of toolkit.auth_config_details) {
-      lines.push(`  ${detail.name} (${detail.mode}):`);
-      lines.push(formatFields(detail.fields.auth_config_creation));
-    }
-
-    lines.push('');
-    lines.push(bold('Fields Required for Connected Account creation:'));
-    for (const detail of toolkit.auth_config_details) {
-      lines.push(`  ${detail.name} (${detail.mode}):`);
-      lines.push(formatFields(detail.fields.connected_account_initiation));
-    }
-  }
-
-  return lines.join('\n');
 }

--- a/ts/packages/cli/src/commands/toolkits/format.ts
+++ b/ts/packages/cli/src/commands/toolkits/format.ts
@@ -105,6 +105,33 @@ export function formatToolkitInfo(toolkit: SessionToolkitItem): string {
   return lines.join('\n');
 }
 
+/**
+ * Format a single session toolkit as JSON for piped output.
+ * Produces a stable, curated schema — does not leak the raw API response.
+ */
+export function formatToolkitInfoJson(toolkit: SessionToolkitItem): string {
+  return JSON.stringify(
+    {
+      name: toolkit.name,
+      slug: toolkit.slug,
+      description: toolkit.meta.description,
+      is_no_auth: toolkit.is_no_auth,
+      enabled: toolkit.enabled,
+      connected: toolkit.connected_account
+        ? {
+            status: toolkit.connected_account.status,
+            id: toolkit.connected_account.id,
+            auth_scheme: toolkit.connected_account.auth_config?.auth_scheme ?? null,
+            is_composio_managed: toolkit.connected_account.auth_config?.is_composio_managed ?? null,
+          }
+        : null,
+      composio_managed_auth_schemes: toolkit.composio_managed_auth_schemes,
+    },
+    null,
+    2
+  );
+}
+
 // ---------- Legacy format functions (used by non-migrated commands) ----------
 
 /**

--- a/ts/packages/cli/src/commands/tools/commands/tools.execute.cmd.ts
+++ b/ts/packages/cli/src/commands/tools/commands/tools.execute.cmd.ts
@@ -2,8 +2,6 @@ import { Args, Command, Options } from '@effect/cli';
 import util from 'node:util';
 import { Effect, Option, Either } from 'effect';
 import { FileSystem } from '@effect/platform';
-import { ComposioError } from '@composio/core';
-import type { ToolExecuteParams } from '@composio/core';
 import { JSONParse } from 'src/effects/json';
 import { redact } from 'src/ui/redact';
 import { readStdin, readStdinIfPiped } from 'src/effects/read-stdin';
@@ -11,8 +9,10 @@ import { requireAuth } from 'src/effects/require-auth';
 import { TerminalUI } from 'src/services/terminal-ui';
 import {
   ActionExecuteConnectedAccountNotFoundError,
+  isNoConnectionSlug,
   ToolsExecutor,
 } from 'src/services/tools-executor';
+import type { ToolExecuteParams } from 'src/services/tools-executor';
 import {
   extractApiErrorDetails,
   extractMessage,
@@ -33,16 +33,6 @@ const data = Options.text('data').pipe(
 const userId = Options.text('user-id').pipe(
   Options.withDefault('default'),
   Options.withDescription('User ID to execute the tool for (default: "default")')
-);
-
-const connectedAccountId = Options.text('connected-account-id').pipe(
-  Options.withDescription('Connected account ID to use for authenticated tools'),
-  Options.optional
-);
-
-const toolkitVersion = Options.text('toolkit-version').pipe(
-  Options.withDescription('Toolkit version to execute (e.g. "20250909_00")'),
-  Options.optional
 );
 
 const resolveInput = (input: Option.Option<string>) =>
@@ -90,15 +80,22 @@ const parseArguments = (raw: string) =>
     return parsed as Record<string, unknown>;
   });
 
-const formatPossibleFixes = (fixes: ReadonlyArray<string>) =>
-  fixes.map(fix => `- ${fix}`).join('\n');
+/**
+ * Derive the toolkit slug from a tool slug.
+ * e.g. "GMAIL_CREATE_EMAIL_DRAFT" → "gmail", "GITHUB_GET_REPOS" → "github"
+ */
+const toolkitFromToolSlug = (toolSlug: string): string => {
+  const idx = toolSlug.indexOf('_');
+  return idx > 0 ? toolSlug.slice(0, idx).toLowerCase() : toolSlug.toLowerCase();
+};
 
-const connectedAccountTips = [
-  `Create or find an auth config: ${bold('composio auth-configs list --toolkits <toolkit>')}`,
-  `Link the account: ${bold('composio connected-accounts link --auth-config <AUTH_CONFIG_ID> --user-id <USER_ID>')}`,
-  `Verify the link: ${bold('composio connected-accounts list --toolkits <toolkit> --user-id <USER_ID>')}`,
-  `Retry the tool or pass ${bold('--connected-account-id <ID>')}`,
-].join('\n');
+const connectionTips = (toolSlug: string, userId: string) => {
+  const toolkit = toolkitFromToolSlug(toolSlug);
+  return [
+    `Link the toolkit first: ${bold(`composio connected-accounts link ${toolkit} --user-id ${userId}`)}`,
+    `Then retry:             ${bold(`composio tools execute ${toolSlug} ...`)}`,
+  ].join('\n');
+};
 
 /**
  * JSON.stringify replacer that redacts ID-like string values in CI.
@@ -144,7 +141,7 @@ const normalizeError = (error: unknown): unknown => {
   while (current && typeof current === 'object' && !seen.has(current)) {
     seen.add(current);
 
-    if (current instanceof ComposioError || current instanceof Error) {
+    if (current instanceof Error) {
       return current;
     }
 
@@ -167,7 +164,11 @@ const normalizeError = (error: unknown): unknown => {
  *
  * Returns a structured error summary suitable for `ui.output()` in piped mode.
  */
-const handleExecutionError = (ui: TerminalUI, error: unknown) =>
+const handleExecutionError = (
+  ui: TerminalUI,
+  error: unknown,
+  context: { toolSlug: string; userId: string }
+) =>
   Effect.gen(function* () {
     const normalized = normalizeError(error);
 
@@ -187,25 +188,6 @@ const handleExecutionError = (ui: TerminalUI, error: unknown) =>
     // Display the primary error message
     yield* ui.log.error(message);
 
-    // ComposioError-specific: show code, status, cause, possible fixes
-    if (normalized instanceof ComposioError) {
-      if (normalized.code) {
-        yield* ui.log.message(`Code: ${normalized.code}`);
-      }
-      const statusCode = (normalized as { statusCode?: number }).statusCode;
-      if (statusCode) {
-        yield* ui.log.message(`Status: ${statusCode}`);
-      }
-      const cause = (normalized as { cause?: unknown }).cause;
-      if (cause) {
-        const causeMessage = cause instanceof Error ? cause.message : String(cause);
-        yield* ui.log.message(`Cause: ${causeMessage}`);
-      }
-      if (normalized.possibleFixes && normalized.possibleFixes.length > 0) {
-        yield* ui.note(formatPossibleFixes(normalized.possibleFixes), 'Possible fixes');
-      }
-    }
-
     // Show API error details when available
     const detailsObject =
       apiDetails ??
@@ -218,9 +200,9 @@ const handleExecutionError = (ui: TerminalUI, error: unknown) =>
       yield* ui.note(formatUnknownObject(redactRequestId(detailsObject)), 'Error details');
     }
 
-    // Connected-account tips
-    if (slugValue === 'ActionExecute_ConnectedAccountNotFound') {
-      yield* ui.note(connectedAccountTips, 'Tips');
+    // No-connection tips — show for both legacy and Tool Router error slugs
+    if (isNoConnectionSlug(slugValue)) {
+      yield* ui.note(connectionTips(context.toolSlug, context.userId), 'Tips');
     }
 
     // Return structured summary for piped output
@@ -243,8 +225,8 @@ class ToolExecutionError {
  */
 export const toolsCmd$Execute = Command.make(
   'execute',
-  { slug, data, userId, connectedAccountId, toolkitVersion },
-  ({ slug, data, userId, connectedAccountId, toolkitVersion }) =>
+  { slug, data, userId },
+  ({ slug, data, userId }) =>
     Effect.gen(function* () {
       if (!(yield* requireAuth)) return;
 
@@ -254,15 +236,9 @@ export const toolsCmd$Execute = Command.make(
       const input = yield* resolveInput(data);
       const args = yield* parseArguments(input);
 
-      const versionValue = Option.getOrUndefined(toolkitVersion);
-      const shouldSkipVersionCheck = !versionValue || versionValue === 'latest';
-
       const params: ToolExecuteParams = {
         userId,
         arguments: args,
-        connectedAccountId: Option.getOrUndefined(connectedAccountId),
-        version: versionValue,
-        dangerouslySkipVersionCheck: shouldSkipVersionCheck ? true : undefined,
       };
 
       yield* ui.useMakeSpinner(`Executing tool "${slug}"...`, spinner =>
@@ -272,7 +248,10 @@ export const toolsCmd$Execute = Command.make(
           // Hard failure: API threw an exception
           if (Either.isLeft(resultEither)) {
             yield* spinner.error();
-            const summary = yield* handleExecutionError(ui, resultEither.left);
+            const summary = yield* handleExecutionError(ui, resultEither.left, {
+              toolSlug: slug,
+              userId,
+            });
             yield* ui.output(
               JSON.stringify({ successful: false, ...summary }, ciRedactReplacer, 2)
             );
@@ -281,14 +260,17 @@ export const toolsCmd$Execute = Command.make(
 
           const result = resultEither.right;
 
-          // Soft failure: API returned { successful: false }
+          // Soft failure: execution returned an error
           if (!result.successful) {
             const logId = result.logId
               ? ` (logId: ${redact({ value: result.logId, prefix: 'log_' })})`
               : '';
             yield* spinner.error(`Execution failed${logId}`);
 
-            const summary = yield* handleExecutionError(ui, result.error ?? result);
+            const summary = yield* handleExecutionError(ui, result.error ?? result, {
+              toolSlug: slug,
+              userId,
+            });
             yield* ui.output(JSON.stringify(result, ciRedactReplacer, 2));
             return yield* Effect.fail(new ToolExecutionError(summary.error));
           }

--- a/ts/packages/cli/src/commands/tools/commands/tools.execute.cmd.ts
+++ b/ts/packages/cli/src/commands/tools/commands/tools.execute.cmd.ts
@@ -83,14 +83,24 @@ const parseArguments = (raw: string) =>
 /**
  * Derive the toolkit slug from a tool slug.
  * e.g. "GMAIL_CREATE_EMAIL_DRAFT" → "gmail", "GITHUB_GET_REPOS" → "github"
+ *
+ * Returns `undefined` for meta tool slugs (COMPOSIO_*) since they don't map
+ * to a real toolkit and would produce misleading connection tips.
  */
-const toolkitFromToolSlug = (toolSlug: string): string => {
+const toolkitFromToolSlug = (toolSlug: string): string | undefined => {
   const idx = toolSlug.indexOf('_');
-  return idx > 0 ? toolSlug.slice(0, idx).toLowerCase() : toolSlug.toLowerCase();
+  if (idx <= 0) return toolSlug.toLowerCase();
+  const prefix = toolSlug.slice(0, idx).toLowerCase();
+  // Meta tools (COMPOSIO_*) are internal and don't correspond to a real toolkit.
+  if (prefix === 'composio') return undefined;
+  return prefix;
 };
 
 const connectionTips = (toolSlug: string, userId: string) => {
   const toolkit = toolkitFromToolSlug(toolSlug);
+  if (!toolkit) {
+    return `Retry: ${bold(`composio tools execute ${toolSlug} ...`)}`;
+  }
   return [
     `Link the toolkit first: ${bold(`composio connected-accounts link ${toolkit} --user-id ${userId}`)}`,
     `Then retry:             ${bold(`composio tools execute ${toolSlug} ...`)}`,

--- a/ts/packages/cli/src/commands/tools/commands/tools.execute.cmd.ts
+++ b/ts/packages/cli/src/commands/tools/commands/tools.execute.cmd.ts
@@ -9,7 +9,6 @@ import { requireAuth } from 'src/effects/require-auth';
 import { TerminalUI } from 'src/services/terminal-ui';
 import {
   ActionExecuteConnectedAccountNotFoundError,
-  isNoConnectionSlug,
   ToolsExecutor,
 } from 'src/services/tools-executor';
 import type { ToolExecuteParams } from 'src/services/tools-executor';
@@ -210,8 +209,10 @@ const handleExecutionError = (
       yield* ui.note(formatUnknownObject(redactRequestId(detailsObject)), 'Error details');
     }
 
-    // No-connection tips — show for both legacy and Tool Router error slugs
-    if (isNoConnectionSlug(slugValue)) {
+    // No-connection tips — the executor already classifies these into
+    // ActionExecuteConnectedAccountNotFoundError, so check the typed error
+    // instead of re-inspecting the slug.
+    if (normalized instanceof ActionExecuteConnectedAccountNotFoundError) {
       yield* ui.note(connectionTips(context.toolSlug, context.userId), 'Tips');
     }
 

--- a/ts/packages/cli/src/effects/create-tool-router-session.ts
+++ b/ts/packages/cli/src/effects/create-tool-router-session.ts
@@ -1,0 +1,26 @@
+import { Effect } from 'effect';
+import type { Composio } from '@composio/client';
+
+export interface CreateToolRouterSessionOptions {
+  /** Enable auto connection management. Default: false. */
+  readonly manageConnections?: boolean;
+}
+
+/**
+ * Create an ephemeral Tool Router session for the given user ID.
+ * Returns the session ID string.
+ *
+ * Accepts a pre-resolved client instance (from ComposioClientSingleton)
+ * so callers can resolve the dependency at layer construction time.
+ */
+export const createToolRouterSession = (
+  client: Composio,
+  userId: string,
+  options?: CreateToolRouterSessionOptions
+) =>
+  Effect.tryPromise(() =>
+    client.toolRouter.session.create({
+      user_id: userId,
+      manage_connections: { enable: options?.manageConnections ?? false },
+    })
+  ).pipe(Effect.map(session => session.session_id));

--- a/ts/packages/cli/src/effects/create-tool-router-session.ts
+++ b/ts/packages/cli/src/effects/create-tool-router-session.ts
@@ -1,5 +1,6 @@
 import { Effect } from 'effect';
 import type { Composio } from '@composio/client';
+import { ComposioClientSingleton } from 'src/services/composio-clients';
 
 export interface CreateToolRouterSessionOptions {
   /** Enable auto connection management. Default: false. */
@@ -12,6 +13,7 @@ export interface CreateToolRouterSessionOptions {
  *
  * Accepts a pre-resolved client instance (from ComposioClientSingleton)
  * so callers can resolve the dependency at layer construction time.
+ * Used by `ToolsExecutorLive` which already holds the client reference.
  */
 export const createToolRouterSession = (
   client: Composio,
@@ -24,3 +26,19 @@ export const createToolRouterSession = (
       manage_connections: { enable: options?.manageConnections ?? false },
     })
   ).pipe(Effect.map(session => session.session_id));
+
+/**
+ * Resolve the Composio client and create a Tool Router session in one step.
+ * Returns `{ client, sessionId }` — eliminates the 3-step boilerplate
+ * (resolve singleton, get client, create session) repeated across commands.
+ */
+export const resolveToolRouterSession = (
+  userId: string,
+  options?: CreateToolRouterSessionOptions
+) =>
+  Effect.gen(function* () {
+    const clientSingleton = yield* ComposioClientSingleton;
+    const client = yield* clientSingleton.get();
+    const sessionId = yield* createToolRouterSession(client, userId, options);
+    return { client, sessionId };
+  });

--- a/ts/packages/cli/src/services/composio-clients.ts
+++ b/ts/packages/cli/src/services/composio-clients.ts
@@ -792,7 +792,7 @@ const callClientWithPagination = <T, S extends PaginatedSchema>(
  * Singleton service that lazily accesses `Config` only when needed, which is used to build and provide
  * a raw (uneffectful, Promise-based) Composio client instance.
  */
-class ComposioClientSingleton extends Effect.Service<ComposioClientSingleton>()(
+export class ComposioClientSingleton extends Effect.Service<ComposioClientSingleton>()(
   'services/ComposioClientSingleton',
   {
     accessors: true,

--- a/ts/packages/cli/src/services/tools-executor.ts
+++ b/ts/packages/cli/src/services/tools-executor.ts
@@ -1,12 +1,25 @@
-import { Composio, ComposioToolExecutionError } from '@composio/core';
-import { Context, Effect, Layer, Option } from 'effect';
-import type { ToolExecuteParams, ToolExecuteResponse } from '@composio/core';
-import { ComposioUserContext } from 'src/services/user-context';
+import { Context, Effect, Layer } from 'effect';
+import type {
+  SessionExecuteResponse,
+  SessionExecuteMetaResponse,
+  SessionExecuteMetaParams,
+} from '@composio/client/resources/tool-router';
+import { ComposioClientSingleton } from 'src/services/composio-clients';
+import { createToolRouterSession } from 'src/effects/create-tool-router-session';
 import {
   extractMessage,
   extractSlug,
   extractApiErrorDetails,
 } from 'src/utils/api-error-extraction';
+
+/** Error slugs that indicate a missing connected account / no active connection. */
+const NO_CONNECTION_SLUGS: ReadonlySet<string> = new Set([
+  'ActionExecute_ConnectedAccountNotFound',
+  'ToolRouterV2_NoActiveConnection',
+]);
+
+export const isNoConnectionSlug = (slug: string | undefined | null): boolean =>
+  slug != null && NO_CONNECTION_SLUGS.has(slug);
 
 export class ActionExecuteConnectedAccountNotFoundError extends Error {
   readonly details: unknown;
@@ -19,28 +32,23 @@ export class ActionExecuteConnectedAccountNotFoundError extends Error {
   }
 }
 
-const hasComposioToolExecutionError = (value: unknown): boolean => {
-  let current: unknown = value;
-  const seen = new Set<unknown>();
+/**
+ * Parameters accepted by the Tool Router-based executor.
+ */
+export interface ToolExecuteParams {
+  readonly userId: string;
+  readonly arguments: Record<string, unknown>;
+}
 
-  while (current && typeof current === 'object' && !seen.has(current)) {
-    seen.add(current);
-    if (current instanceof ComposioToolExecutionError) {
-      return true;
-    }
-    if ('error' in current) {
-      current = (current as { error?: unknown }).error;
-      continue;
-    }
-    if ('cause' in current) {
-      current = (current as { cause?: unknown }).cause;
-      continue;
-    }
-    break;
-  }
-
-  return false;
-};
+/**
+ * Normalized response that matches the shape consumers expect.
+ */
+export interface ToolExecuteResponse {
+  readonly successful: boolean;
+  readonly data: Record<string, unknown>;
+  readonly error: string | null;
+  readonly logId: string;
+}
 
 export interface ToolsExecutor {
   readonly execute: (
@@ -51,29 +59,74 @@ export interface ToolsExecutor {
 
 export const ToolsExecutor = Context.GenericTag<ToolsExecutor>('services/ToolsExecutor');
 
+/**
+ * Meta tool slugs handled by `session.executeMeta` instead of `session.execute`.
+ */
+const META_TOOL_SLUGS: ReadonlySet<string> = new Set([
+  'COMPOSIO_SEARCH_TOOLS',
+  'COMPOSIO_MULTI_EXECUTE_TOOL',
+  'COMPOSIO_MANAGE_CONNECTIONS',
+  'COMPOSIO_WAIT_FOR_CONNECTIONS',
+  'COMPOSIO_REMOTE_WORKBENCH',
+  'COMPOSIO_REMOTE_BASH_TOOL',
+  'COMPOSIO_GET_TOOL_SCHEMAS',
+  'COMPOSIO_UPSERT_RECIPE',
+  'COMPOSIO_GET_RECIPE',
+] as const);
+
+const isMetaToolSlug = (slug: string): slug is SessionExecuteMetaParams['slug'] =>
+  META_TOOL_SLUGS.has(slug);
+
+/**
+ * Normalize the raw Tool Router response into the shape the CLI commands expect.
+ */
+const normalizeResponse = (
+  raw: SessionExecuteResponse | SessionExecuteMetaResponse
+): ToolExecuteResponse => ({
+  successful: raw.error === null,
+  data: raw.data,
+  error: raw.error,
+  logId: raw.log_id,
+});
+
 export const ToolsExecutorLive = Layer.effect(
   ToolsExecutor,
   Effect.gen(function* () {
-    const ctx = yield* ComposioUserContext;
-    const apiKey = ctx.data.apiKey.pipe(Option.getOrUndefined);
-    const baseURL = ctx.data.baseURL;
-
-    // Lazy: defer Composio SDK initialization until first execute call.
-    // The CLI has its own `composio upgrade` command, so skip the npm version check.
-    let composio: Composio | undefined;
-    const getComposio = () =>
-      (composio ??= new Composio({ apiKey, baseURL, disableVersionCheck: true }));
+    // Resolve the client singleton at layer construction time.
+    // The `get` instance method is an Effect.fn that lazily initializes
+    // the raw Composio client on first call — no environment requirements.
+    const clientSingleton = yield* ComposioClientSingleton;
 
     return ToolsExecutor.of({
       execute: (slug, params) =>
-        Effect.tryPromise(() => getComposio().tools.execute(slug, params)).pipe(
+        Effect.gen(function* () {
+          const client = yield* clientSingleton.get();
+          // One session per invocation — CLI runs one tool per process.
+          const sessionId = yield* createToolRouterSession(client, params.userId, {
+            manageConnections: true,
+          });
+
+          const raw: SessionExecuteResponse | SessionExecuteMetaResponse = yield* Effect.tryPromise(
+            () => {
+              if (isMetaToolSlug(slug)) {
+                return client.toolRouter.session.executeMeta(sessionId, {
+                  slug,
+                  arguments: params.arguments,
+                });
+              }
+              return client.toolRouter.session.execute(sessionId, {
+                tool_slug: slug,
+                arguments: params.arguments,
+              });
+            }
+          );
+
+          return normalizeResponse(raw);
+        }).pipe(
           Effect.catchAll((error): Effect.Effect<never, unknown> => {
             const apiDetails = extractApiErrorDetails(error);
             const slugValue = apiDetails?.slug ?? extractSlug(error);
-            const shouldWrap =
-              slugValue === 'ActionExecute_ConnectedAccountNotFound' &&
-              hasComposioToolExecutionError(error);
-            if (shouldWrap) {
+            if (isNoConnectionSlug(slugValue)) {
               return Effect.fail(
                 new ActionExecuteConnectedAccountNotFoundError(apiDetails ?? error)
               );

--- a/ts/packages/cli/src/services/tools-executor.ts
+++ b/ts/packages/cli/src/services/tools-executor.ts
@@ -61,8 +61,12 @@ export const ToolsExecutor = Context.GenericTag<ToolsExecutor>('services/ToolsEx
 
 /**
  * Meta tool slugs handled by `session.executeMeta` instead of `session.execute`.
+ *
+ * The `satisfies` constraint ensures this list stays in sync with the API's
+ * `SessionExecuteMetaParams['slug']` union — a compile error will surface if
+ * a slug is misspelled or if the API adds/removes a meta tool.
  */
-const META_TOOL_SLUGS: ReadonlySet<string> = new Set([
+const META_TOOL_SLUG_LIST = [
   'COMPOSIO_SEARCH_TOOLS',
   'COMPOSIO_MULTI_EXECUTE_TOOL',
   'COMPOSIO_MANAGE_CONNECTIONS',
@@ -72,7 +76,9 @@ const META_TOOL_SLUGS: ReadonlySet<string> = new Set([
   'COMPOSIO_GET_TOOL_SCHEMAS',
   'COMPOSIO_UPSERT_RECIPE',
   'COMPOSIO_GET_RECIPE',
-] as const);
+] as const satisfies ReadonlyArray<SessionExecuteMetaParams['slug']>;
+
+const META_TOOL_SLUGS: ReadonlySet<string> = new Set(META_TOOL_SLUG_LIST);
 
 const isMetaToolSlug = (slug: string): slug is SessionExecuteMetaParams['slug'] =>
   META_TOOL_SLUGS.has(slug);

--- a/ts/packages/cli/src/ui/colors.ts
+++ b/ts/packages/cli/src/ui/colors.ts
@@ -7,6 +7,8 @@ export const {
   bgBlack,
   bgRed,
   gray,
+  dim,
+  green,
   red,
   redBright,
   white,

--- a/ts/packages/cli/test/__utils__/services/test-layer.ts
+++ b/ts/packages/cli/test/__utils__/services/test-layer.ts
@@ -21,6 +21,7 @@ import { TerminalUITest } from './terminal-ui-test';
 import type { Toolkits, ToolkitDetailed } from 'src/models/toolkits';
 import { NodeProcess } from 'src/services/node-process';
 import {
+  ComposioClientSingleton,
   ComposioSessionRepository,
   ComposioToolkitsRepository,
   HttpServerError,
@@ -42,8 +43,20 @@ import { ComposioUserContextLive } from 'src/services/user-context';
 import { UpgradeBinary } from 'src/services/upgrade-binary';
 import { NodeOs } from 'src/services/node-os';
 import { TriggersRealtime } from 'src/services/triggers-realtime';
-import type { ToolExecuteResponse } from '@composio/core';
-import { ToolsExecutor } from 'src/services/tools-executor';
+import { ToolsExecutor, ToolsExecutorLive } from 'src/services/tools-executor';
+import type { ToolExecuteResponse } from 'src/services/tools-executor';
+import type {
+  SessionCreateResponse,
+  SessionExecuteResponse,
+  SessionExecuteMetaResponse,
+  SessionLinkResponse,
+  SessionToolkitsResponse,
+  SessionCreateParams,
+  SessionExecuteParams,
+  SessionExecuteMetaParams,
+  SessionLinkParams,
+  SessionToolkitsParams,
+} from '@composio/client/resources/tool-router';
 import { Stdin } from 'src/services/stdin';
 
 export interface TestLiveInput {
@@ -111,12 +124,45 @@ export interface TestLiveInput {
   /**
    * Override tools executor behavior for tests.
    *
-   * - `failWith`: The executor rejects with this value (hard failure, e.g. API throw).
-   * - `respondWith`: The executor resolves with this response (for soft failures like `{ successful: false }`).
+   * When set, the `ToolsExecutor` service is replaced with a canned mock
+   * that bypasses the real `ToolsExecutorLive` and the Tool Router entirely.
+   * Use this only for tests that need to control the executor response directly
+   * (e.g. soft failure tests).
+   *
+   * When NOT set, the real `ToolsExecutorLive` is used, which flows through
+   * the mock `ComposioClientSingleton` → Tool Router session mocks.
    */
   toolsExecutor?: {
     failWith?: unknown;
     respondWith?: ToolExecuteResponse;
+  };
+
+  /**
+   * Override Tool Router session behavior for tests.
+   *
+   * Controls the mock `ComposioClientSingleton`'s `toolRouter.session.*` methods.
+   * Each method can be overridden individually; defaults are provided for all.
+   *
+   * When `toolsExecutor` is also set, its mock takes precedence for `tools execute`
+   * (the Tool Router mock is still used by `toolkits list`, `toolkits info`, etc.).
+   */
+  toolRouter?: {
+    /** Override `session.create`. Receives the create params. */
+    create?: (params: SessionCreateParams) => Promise<SessionCreateResponse>;
+    /** Override `session.execute`. Receives sessionId and params. */
+    execute?: (sessionId: string, params: SessionExecuteParams) => Promise<SessionExecuteResponse>;
+    /** Override `session.executeMeta`. Receives sessionId and params. */
+    executeMeta?: (
+      sessionId: string,
+      params: SessionExecuteMetaParams
+    ) => Promise<SessionExecuteMetaResponse>;
+    /** Override `session.link`. Receives sessionId and params. */
+    link?: (sessionId: string, params: SessionLinkParams) => Promise<SessionLinkResponse>;
+    /** Override `session.toolkits`. Receives sessionId and optional params. */
+    toolkits?: (
+      sessionId: string,
+      params?: SessionToolkitsParams | null
+    ) => Promise<SessionToolkitsResponse>;
   };
 }
 
@@ -676,25 +722,6 @@ export const TestLayer = (input?: TestLiveInput) =>
       Layer.mergeAll(BunFileSystem.layer, FetchHttpClient.layer)
     );
 
-    const ToolsExecutorTest = Layer.succeed(
-      ToolsExecutor,
-      ToolsExecutor.of({
-        execute: (slug, params) => {
-          if (input?.toolsExecutor?.failWith) {
-            return Effect.fail(input.toolsExecutor.failWith);
-          }
-          if (input?.toolsExecutor?.respondWith) {
-            return Effect.succeed(input.toolsExecutor.respondWith);
-          }
-          return Effect.succeed({
-            data: { slug, params },
-            error: null,
-            successful: true,
-          });
-        },
-      })
-    );
-
     const StdinTest = Layer.succeed(
       Stdin,
       Stdin.of({
@@ -702,6 +729,127 @@ export const TestLayer = (input?: TestLiveInput) =>
         readAll: () => Effect.succeed(input?.stdin?.data ?? ''),
       })
     );
+
+    // --- Tool Router mock (ComposioClientSingleton) ---
+    // Provides a fake `@composio/client` Composio instance with configurable
+    // `toolRouter.session.*` methods. Each method has a sensible default that
+    // can be overridden per-test via `input.toolRouter.<method>`.
+
+    const toolRouterOverrides = input?.toolRouter;
+
+    const defaultToolkitsHandler = async (
+      _sessionId: string,
+      params?: SessionToolkitsParams | null
+    ): Promise<SessionToolkitsResponse> => {
+      let results: SessionToolkitsResponse['items'] = toolkitsData.toolkits.map(t => ({
+        slug: t.slug,
+        name: t.name,
+        meta: { description: t.meta.description, logo: '' },
+        is_no_auth: t.no_auth ?? false,
+        enabled: true,
+        connected_account: null,
+        composio_managed_auth_schemes: [...(t.composio_managed_auth_schemes ?? [])],
+      }));
+
+      if (params?.search) {
+        const q = params.search.toLowerCase();
+        results = results.filter(
+          t =>
+            t.name.toLowerCase().includes(q) ||
+            t.slug.toLowerCase().includes(q) ||
+            t.meta.description.toLowerCase().includes(q)
+        );
+      }
+
+      if (params?.toolkits) {
+        const slugSet = new Set(params.toolkits.map(s => s.toLowerCase()));
+        results = results.filter(t => slugSet.has(t.slug.toLowerCase()));
+      }
+
+      const limit = params?.limit ?? 1000;
+      const items = results.slice(0, limit);
+      return {
+        items,
+        current_page: 1,
+        total_items: results.length,
+        total_pages: Math.ceil(results.length / limit),
+        next_cursor: null,
+      };
+    };
+
+    const mockComposioClient = {
+      toolRouter: {
+        session: {
+          create:
+            toolRouterOverrides?.create ??
+            (async (params: SessionCreateParams) => ({
+              session_id: 'trs_test_session',
+              config: { user_id: params.user_id },
+              mcp: { type: 'http' as const, url: 'https://mcp.test.composio.dev' },
+              tool_router_tools: ['COMPOSIO_SEARCH_TOOLS', 'COMPOSIO_MANAGE_CONNECTIONS'],
+            })),
+          execute:
+            toolRouterOverrides?.execute ??
+            (async (_sessionId: string, params: SessionExecuteParams) => ({
+              data: { tool_slug: params.tool_slug, arguments: params.arguments },
+              error: null,
+              log_id: 'log_test',
+            })),
+          executeMeta:
+            toolRouterOverrides?.executeMeta ??
+            (async (_sessionId: string, params: SessionExecuteMetaParams) => ({
+              data: { slug: params.slug, arguments: params.arguments },
+              error: null,
+              log_id: 'log_test',
+            })),
+          link:
+            toolRouterOverrides?.link ??
+            (async () => ({
+              connected_account_id: 'con_test_link',
+              link_token: 'lt_test_token',
+              redirect_url: 'https://app.composio.dev/link?token=lt_test_token',
+            })),
+          toolkits: toolRouterOverrides?.toolkits ?? defaultToolkitsHandler,
+          tools: async () => ({
+            items: [],
+          }),
+        },
+      },
+    };
+
+    const ComposioClientSingletonTest = Layer.succeed(
+      ComposioClientSingleton,
+      new ComposioClientSingleton({
+        get: Effect.fn(function* () {
+          return mockComposioClient as any;
+        }),
+      })
+    );
+
+    // --- ToolsExecutor ---
+    // When `input.toolsExecutor` is set, use a canned mock (bypasses Tool Router).
+    // Otherwise, use the real ToolsExecutorLive which flows through the mock ComposioClientSingleton.
+    const ToolsExecutorTest = input?.toolsExecutor
+      ? Layer.succeed(
+          ToolsExecutor,
+          ToolsExecutor.of({
+            execute: (slug, params) => {
+              if (input.toolsExecutor!.failWith) {
+                return Effect.fail(input.toolsExecutor!.failWith);
+              }
+              if (input.toolsExecutor!.respondWith) {
+                return Effect.succeed(input.toolsExecutor!.respondWith);
+              }
+              return Effect.succeed({
+                data: { slug, params },
+                error: null,
+                successful: true,
+                logId: 'log_test',
+              });
+            },
+          })
+        )
+      : Layer.provide(ToolsExecutorLive, ComposioClientSingletonTest);
 
     const CliConfigLive = CliConfig.layer(ComposioCliConfig);
 
@@ -715,6 +863,7 @@ export const TestLayer = (input?: TestLiveInput) =>
       ComposioUserContextTest,
       ComposioSessionRepositoryTest,
       TriggersRealtimeTest,
+      ComposioClientSingletonTest,
       ComposioToolkitsRepositoryTest,
       EnvLangDetector.Default,
       JsPackageManagerDetector.Default,

--- a/ts/packages/cli/test/__utils__/services/test-layer.ts
+++ b/ts/packages/cli/test/__utils__/services/test-layer.ts
@@ -821,6 +821,10 @@ export const TestLayer = (input?: TestLiveInput) =>
       ComposioClientSingleton,
       new ComposioClientSingleton({
         get: Effect.fn(function* () {
+          // Partial mock: only implements `toolRouter.session.*` methods used by
+          // CLI commands under test. The full Composio client interface is too
+          // large to mock completely for unit tests.
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           return mockComposioClient as any;
         }),
       })

--- a/ts/packages/cli/test/src/commands/$default.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/$default.cmd.test.ts
@@ -86,9 +86,9 @@ describe('CLI: composio', () => {
 
             - toolkits                                                                                                                                                                                            Discover and inspect Composio toolkits.
 
-            - toolkits list [--query text] [--limit integer]                                                                                                                                                      List available toolkits.
+            - toolkits list [--query text] [--limit integer] [--connected] [--user-id text]                                                                                                                       List available toolkits with connection status.
 
-            - toolkits info [<slug>]                                                                                                                                                                              View details of a specific toolkit.
+            - toolkits info [--user-id text] [<slug>]                                                                                                                                                             View details of a specific toolkit.
 
             - toolkits search [--limit integer] <query>                                                                                                                                                           Search toolkits by use case.
 
@@ -100,7 +100,7 @@ describe('CLI: composio', () => {
 
             - tools search [--toolkits text] [--limit integer] <query>                                                                                                                                            Search tools by use case.
 
-            - tools execute [(-d, --data text)] [--user-id text] [--connected-account-id text] [--toolkit-version text] <slug>                                                                                    Execute a tool by slug with JSON arguments.
+            - tools execute [(-d, --data text)] [--user-id text] <slug>                                                                                                                                           Execute a tool by slug with JSON arguments.
 
             - auth-configs                                                                                                                                                                                        View and manage Composio auth configs.
 
@@ -122,7 +122,7 @@ describe('CLI: composio', () => {
 
             - connected-accounts delete [(-y, --yes)] [<id>]                                                                                                                                                      Delete a connected account.
 
-            - connected-accounts link --auth-config text [--user-id text] [--no-browser]                                                                                                                          Link an external account via OAuth redirect.
+            - connected-accounts link [--auth-config text] [--user-id text] [--no-browser] [<toolkit>]                                                                                                            Link an external account via OAuth redirect.
 
             - triggers                                                                                                                                                                                            Inspect and subscribe to trigger events.
 

--- a/ts/packages/cli/test/src/commands/toolkits/toolkits.info.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/toolkits/toolkits.info.cmd.test.ts
@@ -23,6 +23,23 @@ const testToolkits: Toolkits = [
       triggers_count: 2,
     },
   },
+  {
+    name: 'Code Interpreter',
+    slug: 'codeinterpreter',
+    auth_schemes: [],
+    composio_managed_auth_schemes: [],
+    is_local_toolkit: false,
+    no_auth: true,
+    meta: {
+      description: 'Execute code in a sandboxed environment',
+      categories: [],
+      created_at: new Date('2024-05-03T11:44:32.061Z') as any,
+      updated_at: new Date('2024-05-03T11:44:32.061Z') as any,
+      available_versions: [],
+      tools_count: 1,
+      triggers_count: 0,
+    },
+  },
 ];
 
 const detailedToolkits: ToolkitDetailed[] = [
@@ -116,7 +133,7 @@ describe('CLI: composio toolkits info', () => {
   layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
     '[Given] valid slug "gmail"',
     it => {
-      it.scoped('shows detailed info with auth schemes', () =>
+      it.scoped('shows detailed info with connection status', () =>
         Effect.gen(function* () {
           yield* cli(['toolkits', 'info', 'gmail']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
@@ -125,13 +142,8 @@ describe('CLI: composio toolkits info', () => {
           expect(output).toContain('Gmail');
           expect(output).toContain('gmail');
           expect(output).toContain('Email service to send and receive emails');
-          expect(output).toContain('20250909');
-          expect(output).toContain('3 available');
-          expect(output).toContain('OAUTH2');
-          expect(output).toContain('BEARER_TOKEN');
-          expect(output).toContain('apiKey');
-          expect(output).toContain('AuthConfig creation');
-          expect(output).toContain('Connected Account creation');
+          // Connection status
+          expect(output).toContain('Not connected');
         })
       );
     }
@@ -140,15 +152,13 @@ describe('CLI: composio toolkits info', () => {
   layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
     '[Given] toolkit with no_auth=true',
     it => {
-      it.scoped('shows "No authentication required"', () =>
+      it.scoped('shows "no auth"', () =>
         Effect.gen(function* () {
           yield* cli(['toolkits', 'info', 'codeinterpreter']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
           expect(output).toContain('Code Interpreter');
-          expect(output).toContain('Latest Version:');
-          expect(output).toContain('-');
           expect(output).toContain('No authentication required');
         })
       );
@@ -160,11 +170,11 @@ describe('CLI: composio toolkits info', () => {
     it => {
       it.scoped('shows error', () =>
         Effect.gen(function* () {
-          const result = yield* cli(['toolkits', 'info', 'gmal']).pipe(Effect.either);
+          yield* cli(['toolkits', 'info', 'gmal']).pipe(Effect.either);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
-          expect(output).toContain('Failed to fetch toolkit "gmal"');
+          expect(output).toContain('Toolkit "gmal" not found');
         })
       );
     }
@@ -173,16 +183,14 @@ describe('CLI: composio toolkits info', () => {
   layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
     '[Given] invalid slug with substring match',
     it => {
-      it.scoped('shows error with suggestion', () =>
+      it.scoped('shows error with hint', () =>
         Effect.gen(function* () {
-          // "gma" is a substring of "gmail", so the mock will find suggestions
-          const result = yield* cli(['toolkits', 'info', 'gma']).pipe(Effect.either);
+          yield* cli(['toolkits', 'info', 'gma']).pipe(Effect.either);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
-          expect(output).toContain('Failed to fetch toolkit "gma"');
-          expect(output).toContain('Did you mean?');
-          expect(output).toContain('gmail');
+          expect(output).toContain('Toolkit "gma" not found');
+          expect(output).toContain('composio toolkits list');
         })
       );
     }

--- a/ts/packages/cli/test/src/commands/toolkits/toolkits.info.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/toolkits/toolkits.info.cmd.test.ts
@@ -190,7 +190,7 @@ describe('CLI: composio toolkits info', () => {
           const output = lines.join('\n');
 
           expect(output).toContain('Toolkit "gma" not found');
-          expect(output).toContain('composio toolkits list');
+          expect(output).toContain('composio toolkits info "gmail"');
         })
       );
     }

--- a/ts/packages/cli/test/src/commands/toolkits/toolkits.list.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/toolkits/toolkits.list.cmd.test.ts
@@ -81,10 +81,8 @@ describe('CLI: composio toolkits list', () => {
           expect(output).toContain('gmail');
           expect(output).toContain('Slack');
           expect(output).toContain('GitHub');
-          // Version column
-          expect(output).toContain('Version');
-          expect(output).toContain('20250909');
-          expect(output).toContain('20260101');
+          // Connection status column
+          expect(output).toContain('Connected');
           expect(output).toContain('Listing 3 of 3 toolkits');
         })
       );

--- a/ts/packages/cli/test/src/commands/tools/tools.execute.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/tools/tools.execute.cmd.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, layer } from '@effect/vitest';
 import { vi, beforeEach, afterEach } from 'vitest';
 import { ConfigProvider, Effect } from 'effect';
 import { extendConfigProvider } from 'src/services/config';
-import { ComposioToolExecutionError } from '@composio/core';
 import { ActionExecuteConnectedAccountNotFoundError } from 'src/services/tools-executor';
 import * as redactModule from 'src/ui/redact';
 import { cli, TestLive, MockConsole } from 'test/__utils__';
@@ -17,7 +16,10 @@ const parseLastJson = (lines: ReadonlyArray<string>) => {
     if (!line) continue;
     try {
       return JSON.parse(line) as {
-        data: { slug: string; params: Record<string, unknown> };
+        successful: boolean;
+        data: Record<string, unknown>;
+        error: string | null;
+        logId: string;
       };
     } catch {
       // keep searching for the last JSON line
@@ -43,18 +45,18 @@ describe('CLI: composio tools execute', () => {
       baseConfigProvider: testConfigProvider,
       stdin: { isTTY: true, data: '' },
     })
-  )('[Given] -d inline JSON [Then] executes with defaults', it => {
-    it.scoped('executes with defaults', () =>
+  )('[Given] -d inline JSON [Then] executes via Tool Router with defaults', it => {
+    it.scoped('executes via Tool Router with defaults', () =>
       Effect.gen(function* () {
         yield* cli(['tools', 'execute', 'GMAIL_SEND_EMAIL', '-d', '{"recipient":"a"}']);
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
         const output = parseLastJson(lines);
-        const params = output.data.params as Record<string, unknown>;
 
-        expect(output.data.slug).toBe('GMAIL_SEND_EMAIL');
-        expect(params.userId).toBe('default');
-        expect(params.arguments).toEqual({ recipient: 'a' });
-        expect(params.dangerouslySkipVersionCheck).toBe(true);
+        // Response flows through real ToolsExecutorLive → mock session.execute
+        expect(output.successful).toBe(true);
+        expect(output.data.tool_slug).toBe('GMAIL_SEND_EMAIL');
+        expect(output.data.arguments).toEqual({ recipient: 'a' });
+        expect(output.logId).toBe('log_test');
       })
     );
   });
@@ -70,9 +72,10 @@ describe('CLI: composio tools execute', () => {
         yield* cli(['tools', 'execute', 'GITHUB_GET_REPOS']);
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
         const output = parseLastJson(lines);
-        const params = output.data.params as Record<string, unknown>;
 
-        expect(params.arguments).toEqual({ owner: 'composio' });
+        expect(output.successful).toBe(true);
+        expect(output.data.tool_slug).toBe('GITHUB_GET_REPOS');
+        expect(output.data.arguments).toEqual({ owner: 'composio' });
       })
     );
   });
@@ -88,8 +91,8 @@ describe('CLI: composio tools execute', () => {
         }),
       },
     })
-  )('[Given] connected account not found slug [Then] prints tips', it => {
-    it.scoped('prints connected account tips', () =>
+  )('[Given] connected account not found slug (legacy) [Then] prints tips', it => {
+    it.scoped('prints connected account tips for legacy slug', () =>
       Effect.gen(function* () {
         yield* cli([
           'tools',
@@ -108,32 +111,75 @@ describe('CLI: composio tools execute', () => {
     );
   });
 
+  // --- Tool Router error path (flows through real ToolsExecutorLive) ---
+
   layer(
     TestLive({
       baseConfigProvider: testConfigProvider,
       stdin: { isTTY: true, data: '' },
+      toolRouter: {
+        execute: async () => {
+          throw Object.assign(new Error("No active connection found for toolkit(s) 'gmail'"), {
+            error: {
+              message: "No active connection found for toolkit(s) 'gmail' in this session",
+              code: 4302,
+              slug: 'ToolRouterV2_NoActiveConnection',
+              status: 400,
+              request_id: 'test-request-id',
+            },
+          });
+        },
+      },
     })
-  )('[Given] --version override [Then] passes version and no auto-skip', it => {
-    it.scoped('passes version and no auto-skip', () =>
+  )('[Given] Tool Router NoActiveConnection error [Then] prints connection tips', it => {
+    it.scoped('prints connection tips with toolkit name derived from tool slug', () =>
       Effect.gen(function* () {
         yield* cli([
           'tools',
           'execute',
-          'GITHUB_GET_REPOS',
+          'GMAIL_CREATE_EMAIL_DRAFT',
           '-d',
-          '{"owner":"composio"}',
-          '--user-id',
-          'user_123',
-          '--toolkit-version',
-          '20250909_00',
+          '{"recipient":"to@example.com"}',
+        ]).pipe(Effect.catchAll(() => Effect.void));
+        const lines = yield* MockConsole.getLines({ stripAnsi: true });
+        const output = lines.join('\n');
+
+        expect(output).toContain('No active connection');
+        expect(output).toContain('Tips');
+        expect(output).toContain('composio connected-accounts link gmail');
+      })
+    );
+  });
+
+  layer(
+    TestLive({
+      baseConfigProvider: testConfigProvider,
+      stdin: { isTTY: true, data: '' },
+      toolRouter: {
+        execute: async (_sessionId, params) => ({
+          data: { tool_slug: params.tool_slug, custom: 'response' },
+          error: null,
+          log_id: 'log_custom',
+        }),
+      },
+    })
+  )('[Given] custom Tool Router execute mock [Then] returns custom response', it => {
+    it.scoped('flows through real ToolsExecutorLive with custom mock', () =>
+      Effect.gen(function* () {
+        yield* cli([
+          'tools',
+          'execute',
+          'GITHUB_STAR_REPO',
+          '-d',
+          '{"owner":"composio","repo":"composio"}',
         ]);
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
         const output = parseLastJson(lines);
-        const params = output.data.params as Record<string, unknown>;
 
-        expect(params.userId).toBe('user_123');
-        expect(params.version).toBe('20250909_00');
-        expect('dangerouslySkipVersionCheck' in params).toBe(false);
+        expect(output.successful).toBe(true);
+        expect(output.data.tool_slug).toBe('GITHUB_STAR_REPO');
+        expect(output.data.custom).toBe('response');
+        expect(output.logId).toBe('log_custom');
       })
     );
   });
@@ -144,12 +190,9 @@ describe('CLI: composio tools execute', () => {
       stdin: { isTTY: true, data: '' },
       toolsExecutor: {
         failWith: {
-          error: new ComposioToolExecutionError(
-            'Error executing the tool GMAIL_CREATE_EMAIL_DRAFT',
-            {
-              possibleFixes: ['Ensure the tool slug is correct'],
-            }
-          ),
+          error: {
+            message: 'Error executing the tool GMAIL_CREATE_EMAIL_DRAFT',
+          },
         },
       },
     })
@@ -167,8 +210,6 @@ describe('CLI: composio tools execute', () => {
         const output = lines.join('\n');
 
         expect(output).toContain('Error executing the tool GMAIL_CREATE_EMAIL_DRAFT');
-        expect(output).toContain('Possible fixes');
-        expect(output).toContain('Ensure the tool slug is correct');
       })
     );
   });
@@ -248,6 +289,7 @@ describe('CLI: composio tools execute', () => {
           data: {},
           error: 'Tool execution failed',
           successful: false,
+          logId: '',
         },
       },
     })
@@ -268,7 +310,8 @@ describe('CLI: composio tools execute', () => {
         expect(output).not.toContain('Executing tool');
         expect(output).toContain('Execution failed');
         expect(output).toContain('Tool execution failed');
-        expect(output).not.toContain('logId');
+        // logId is empty, so the spinner line should not show "(logId: ...)"
+        expect(output).not.toContain('(logId:');
       })
     );
   });
@@ -379,59 +422,6 @@ describe('CLI: composio tools execute', () => {
         expect(result instanceof Error ? result.message : String(result)).toContain(
           'Invalid JSON input'
         );
-      })
-    );
-  });
-
-  layer(
-    TestLive({
-      baseConfigProvider: testConfigProvider,
-      stdin: { isTTY: true, data: '' },
-    })
-  )('[Given] --toolkit-version latest [Then] sets dangerouslySkipVersionCheck', it => {
-    it.scoped('skips version check for "latest"', () =>
-      Effect.gen(function* () {
-        yield* cli([
-          'tools',
-          'execute',
-          'GITHUB_GET_REPOS',
-          '-d',
-          '{"owner":"composio"}',
-          '--toolkit-version',
-          'latest',
-        ]);
-        const lines = yield* MockConsole.getLines({ stripAnsi: true });
-        const output = parseLastJson(lines);
-        const params = output.data.params as Record<string, unknown>;
-
-        expect(params.version).toBe('latest');
-        expect(params.dangerouslySkipVersionCheck).toBe(true);
-      })
-    );
-  });
-
-  layer(
-    TestLive({
-      baseConfigProvider: testConfigProvider,
-      stdin: { isTTY: true, data: '' },
-    })
-  )('[Given] --connected-account-id [Then] passes it through', it => {
-    it.scoped('forwards connected account id', () =>
-      Effect.gen(function* () {
-        yield* cli([
-          'tools',
-          'execute',
-          'GMAIL_SEND_EMAIL',
-          '-d',
-          '{"recipient":"a"}',
-          '--connected-account-id',
-          'con_abc123',
-        ]);
-        const lines = yield* MockConsole.getLines({ stripAnsi: true });
-        const output = parseLastJson(lines);
-        const params = output.data.params as Record<string, unknown>;
-
-        expect(params.connectedAccountId).toBe('con_abc123');
       })
     );
   });

--- a/ts/packages/cli/test/src/commands/tools/tools.execute.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/tools/tools.execute.cmd.test.ts
@@ -316,6 +316,35 @@ describe('CLI: composio tools execute', () => {
     );
   });
 
+  // --- Meta tool error tests ---
+
+  layer(
+    TestLive({
+      baseConfigProvider: testConfigProvider,
+      stdin: { isTTY: true, data: '' },
+      toolsExecutor: {
+        failWith: new ActionExecuteConnectedAccountNotFoundError({
+          slug: 'ToolRouterV2_NoActiveConnection',
+          message: 'No active connection found for toolkit(s) in this session',
+        }),
+      },
+    })
+  )('[Given] meta tool NoActiveConnection error [Then] does not suggest "link composio"', it => {
+    it.scoped('omits connection tips for meta tool slugs', () =>
+      Effect.gen(function* () {
+        yield* cli(['tools', 'execute', 'COMPOSIO_SEARCH_TOOLS', '-d', '{"query":"email"}']).pipe(
+          Effect.catchAll(() => Effect.void)
+        );
+        const lines = yield* MockConsole.getLines({ stripAnsi: true });
+        const output = lines.join('\n');
+
+        expect(output).toContain('No active connection');
+        // Should NOT produce a misleading tip like "link composio"
+        expect(output).not.toContain('link composio');
+      })
+    );
+  });
+
   // --- Edge case tests ---
 
   layer(


### PR DESCRIPTION
This PR:

- Closes [PLEN-1656](https://linear.app/composio/issue/PLEN-1656/cli-use-tool-router-in-composio-tools-execute)
- Replaces standard Composio API endpoints with Tool Router session-based execution for `tools execute`, `toolkits list`, `toolkits info`, and `connected-accounts link`
- Adds `createToolRouterSession` helper in `src/effects/` for ephemeral session creation with configurable `manageConnections` (read-only commands default to `false`)
- Rewrites `ToolsExecutor` to use `@composio/client` Tool Router `session.execute`/`session.executeMeta` directly, removing the `@composio/core` dependency
- Adds dual code path in `connected-accounts link`: `<toolkit>` positional arg uses Tool Router, `--auth-config` flag preserves the legacy flow unchanged
- Migrates `toolkits list` and `toolkits info` to `session.toolkits()` with connection status columns (`Connected`, `Auth Scheme`)
- Handles `ToolRouterV2_NoActiveConnection` errors with actionable tips (`composio connected-accounts link <toolkit>`)
- Makes test Tool Router mocks configurable via `TestLiveInput.toolRouter` — `tools execute` tests now flow through real `ToolsExecutorLive`