### PR TITLE
docs: fix mobile responsiveness and markdown Card conversion

### DIFF
--- a/docs/components/ai-tools-banner.tsx
+++ b/docs/components/ai-tools-banner.tsx
@@ -15,10 +15,10 @@ function CopyableCommand({ text }: { text: string }) {
         setTimeout(() => setCopied(false), 2000);
       }}
       aria-label={`Copy command: ${text}`}
-      className="mb-3 flex w-full cursor-pointer items-center gap-2 rounded-lg border border-fd-border bg-fd-background dark:bg-fd-background/50 px-3.5 py-2.5 font-mono text-[13px] text-fd-foreground transition-colors hover:border-[var(--composio-orange)]/40"
+      className="mb-3 flex w-full cursor-pointer items-center gap-2 rounded-lg border border-fd-border bg-fd-background dark:bg-fd-background/50 px-2.5 py-2 sm:px-3.5 sm:py-2.5 font-mono text-[13px] text-fd-foreground transition-colors hover:border-[var(--composio-orange)]/40"
     >
       <span className="select-none text-fd-muted-foreground">$</span>
-      <span className="flex-1 text-left">{text}</span>
+      <span className="min-w-0 flex-1 overflow-x-auto text-left whitespace-nowrap">{text}</span>
       {copied ? (
         <Check className="h-3.5 w-3.5 shrink-0 text-green-500" />
       ) : (
@@ -32,7 +32,7 @@ export function AIToolsBanner() {
   const skillsCommand = 'npx skills add composiohq/skills';
 
   return (
-    <div className="not-prose relative mt-6 mb-6 overflow-hidden rounded-xl border border-fd-border bg-gradient-to-br from-fd-card via-fd-card to-fd-muted/50 dark:from-fd-muted/20 dark:via-fd-card dark:to-fd-muted/40">
+    <div className="not-prose relative mt-4 mb-4 sm:mt-6 sm:mb-6 overflow-hidden rounded-xl border border-fd-border bg-gradient-to-br from-fd-card via-fd-card to-fd-muted/50 dark:from-fd-muted/20 dark:via-fd-card dark:to-fd-muted/40">
       {/* Subtle grid pattern */}
       <div
         className="pointer-events-none absolute inset-0 opacity-[0.03] dark:opacity-[0.02]"
@@ -42,9 +42,9 @@ export function AIToolsBanner() {
           backgroundSize: '24px 24px',
         }}
       />
-      <div className="relative p-5">
+      <div className="relative p-4 sm:p-5">
         {/* Header */}
-        <div className="mb-4 flex items-center gap-2.5">
+        <div className="mb-3 sm:mb-4 flex items-center gap-2.5">
           <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-fd-muted dark:bg-fd-muted/60">
             <Bot className="h-4 w-4 text-fd-muted-foreground" />
           </div>
@@ -57,7 +57,7 @@ export function AIToolsBanner() {
         <CopyableCommand text={skillsCommand} />
 
         {/* Skills links */}
-        <div className="mb-4 flex items-center gap-3 text-xs">
+        <div className="mb-3 sm:mb-4 flex items-center gap-3 text-xs">
           <Link
             href="https://skills.sh/composiohq/skills/composio"
             target="_blank"
@@ -79,7 +79,7 @@ export function AIToolsBanner() {
         </div>
 
         {/* Context files */}
-        <div className="flex gap-2">
+        <div className="flex flex-col gap-2 sm:flex-row">
           <Link
             href="/llms.txt"
             className="group flex flex-1 items-center gap-2.5 rounded-lg border border-fd-border/80 bg-fd-card dark:bg-fd-background/30 px-3 py-2 transition-all hover:border-[var(--composio-orange)]/40"

--- a/docs/components/custom-search-dialog.tsx
+++ b/docs/components/custom-search-dialog.tsx
@@ -94,7 +94,7 @@ export default function CustomSearchDialog({
             <BotMessageSquare className="size-3.5" />
             You can also Ask AI
           </button>
-          <div className="inline-flex gap-0.5">
+          <div className="hidden sm:inline-flex gap-0.5">
             <kbd className="rounded-md border bg-fd-background px-1.5 text-xs text-fd-muted-foreground">
               <MetaKey />
             </kbd>

--- a/docs/components/mermaid.tsx
+++ b/docs/components/mermaid.tsx
@@ -63,7 +63,7 @@ export function Mermaid({ chart }: { chart: string }) {
   return (
     <div
       ref={containerRef}
-      className="my-4 flex justify-center max-w-lg mx-auto"
+      className="my-4 overflow-x-auto max-w-full mx-auto [&>svg]:mx-auto"
       dangerouslySetInnerHTML={{ __html: svg }}
     />
   );

--- a/docs/components/page-actions.tsx
+++ b/docs/components/page-actions.tsx
@@ -123,7 +123,7 @@ export function PageActions({ path }: PageActionsProps) {
         aria-label="View page as markdown (opens in new tab)"
       >
         <ExternalLink className="size-3.5" aria-hidden="true" />
-        <span className="hidden xs:inline">View </span>
+        <span className="hidden sm:inline">View </span>
         <span>Markdown</span>
       </a>
 

--- a/docs/components/toolkits/toolkit-detail.tsx
+++ b/docs/components/toolkits/toolkit-detail.tsx
@@ -203,25 +203,25 @@ function ToolItem({ item, toolkitVersion }: { item: Tool | Trigger; toolkitVersi
             onClick={copySlug}
             className="inline-flex w-fit shrink-0 items-center gap-1 rounded bg-fd-muted px-1.5 py-0.5 font-mono text-xs text-fd-muted-foreground transition-colors hover:text-fd-foreground"
           >
-            <span className="max-w-[200px] truncate sm:max-w-[300px]">{item.slug}</span>
+            <span className="max-w-[140px] truncate sm:max-w-[300px]">{item.slug}</span>
             {copied ? <Check className="h-3 w-3 shrink-0 text-green-500" /> : <Copy className="h-3 w-3 shrink-0" />}
           </span>
         </span>
       </button>
       {expanded && (
-        <div className="space-y-4 bg-fd-muted/20 px-4 py-3 pl-10">
+        <div className="space-y-4 bg-fd-muted/20 px-3 py-3 sm:px-4 sm:pl-10">
           <p className="text-sm text-fd-muted-foreground">{item.description}</p>
 
           {/* Tool parameters */}
           {hasInputParams && (
-            <div className="space-y-2">
+            <div className="space-y-2 overflow-x-auto">
               <h4 className="text-xs font-semibold uppercase tracking-wide text-fd-muted-foreground">Input Parameters</h4>
               <TypeTable type={paramsToTypeTable(inputParams!)} />
             </div>
           )}
 
           {hasOutputParams && (
-            <div className="space-y-2">
+            <div className="space-y-2 overflow-x-auto">
               <h4 className="text-xs font-semibold uppercase tracking-wide text-fd-muted-foreground">Output</h4>
               <TypeTable type={paramsToTypeTable(outputParams!)} />
             </div>
@@ -229,14 +229,14 @@ function ToolItem({ item, toolkitVersion }: { item: Tool | Trigger; toolkitVersi
 
           {/* Trigger config/payload */}
           {hasConfig && (
-            <div className="space-y-2">
+            <div className="space-y-2 overflow-x-auto">
               <h4 className="text-xs font-semibold uppercase tracking-wide text-fd-muted-foreground">Configuration</h4>
               <TypeTable type={paramsToTypeTable(trigger.config!)} />
             </div>
           )}
 
           {hasPayload && (
-            <div className="space-y-2">
+            <div className="space-y-2 overflow-x-auto">
               <h4 className="text-xs font-semibold uppercase tracking-wide text-fd-muted-foreground">Payload</h4>
               <TypeTable type={paramsToTypeTable(trigger.payload!)} />
             </div>

--- a/docs/components/toolkits/toolkits-landing.tsx
+++ b/docs/components/toolkits/toolkits-landing.tsx
@@ -155,7 +155,7 @@ export function ToolkitsLanding() {
           </p>
           <PageActions path="/toolkits" />
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           <a
             href="https://platform.composio.dev/auth?next_page=%2Ftool-router"
             target="_blank"

--- a/docs/lib/source.ts
+++ b/docs/lib/source.ts
@@ -117,28 +117,35 @@ export function mdxToCleanMarkdown(content: string): string {
     (_, content) => `> ${content.trim()}`
   );
 
+  // Remove Cards wrapper before processing individual Card tags
+  // (prevents <Cards> from being matched by <Card regex since <Cards starts with <Card)
+  result = result.replace(/<\/?Cards[^>]*>/g, '');
+
   // Convert Card - handle multiline and various attribute orders
   // Self-closing Cards with description attribute
   result = result.replace(
-    /<Card[\s\S]*?title="([^"]*)"[\s\S]*?href="([^"]*)"[\s\S]*?description="([^"]*)"[\s\S]*?\/>/g,
+    /<Card\b[\s\S]*?title="([^"]*)"[\s\S]*?href="([^"]*)"[\s\S]*?description="([^"]*)"[\s\S]*?\/>/g,
     '- [$1]($2): $3'
   );
   // Cards with children content (non-self-closing)
   result = result.replace(
-    /<Card[\s\S]*?title="([^"]*)"[\s\S]*?href="([^"]*)"[\s\S]*?>([\s\S]*?)<\/Card>/g,
+    /<Card\b[\s\S]*?title="([^"]*)"[\s\S]*?href="([^"]*)"[\s\S]*?>([\s\S]*?)<\/Card>/g,
     '- [$1]($2): $3'
   );
   // Cards with href before title
   result = result.replace(
-    /<Card[\s\S]*?href="([^"]*)"[\s\S]*?title="([^"]*)"[\s\S]*?>([\s\S]*?)<\/Card>/g,
+    /<Card\b[\s\S]*?href="([^"]*)"[\s\S]*?title="([^"]*)"[\s\S]*?>([\s\S]*?)<\/Card>/g,
     '- [$2]($1): $3'
   );
-
   // Convert ProviderCard to markdown link
   result = result.replace(
     /<ProviderCard[\s\S]*?name="([^"]*)"[\s\S]*?href="([^"]*)"[\s\S]*?languages=\{\[([^\]]*)\]\}[\s\S]*?\/>/g,
     (_, name, href, langs) => `- [${name}](${href}) (${langs.replace(/"/g, '')})`
   );
+
+  // Strip orphaned indentation from converted list items
+  // (Cards/ProviderCards nested inside wrapper components had JSX indentation that persists after wrapper removal)
+  result = result.replace(/^[ \t]+(- \[)/gm, '$1');
 
   // Convert Tabs/Tab content - keep inner content
   result = result.replace(/<TabsList>[\s\S]*?<\/TabsList>/g, '');
@@ -239,8 +246,9 @@ export function mdxToCleanMarkdown(content: string): string {
     '- [llms-full.txt](/llms-full.txt) — Complete documentation in one file'
   );
 
-  // Remove wrapper components (Cards, ProviderGrid, Tabs, Frame, div, QuickstartFlow, IntegrationTabs, Accordions, ToolTypeFlow, ToolkitsLanding, TemplateGrid, etc.)
-  result = result.replace(/<\/?(Cards|ProviderGrid|Tabs|Frame|div|QuickstartFlow|IntegrationTabs|Accordions|ToolTypeFlow|ToolkitsLanding|TemplateGrid)[^>]*>/g, '');
+  // Remove wrapper components (ProviderGrid, Tabs, Frame, div, QuickstartFlow, IntegrationTabs, Accordions, ToolTypeFlow, ToolkitsLanding, TemplateGrid, etc.)
+  // Note: Cards wrapper is removed earlier (before Card conversion) to prevent regex conflicts
+  result = result.replace(/<\/?(ProviderGrid|Tabs|Frame|div|QuickstartFlow|IntegrationTabs|Accordions|ToolTypeFlow|ToolkitsLanding|TemplateGrid)[^>]*>/g, '');
 
   // Remove remaining self-closing JSX tags (including those with JSX expressions)
   result = result.replace(/<[A-Z][a-zA-Z]*[\s\S]*?\/>/g, '');

--- a/docs/lib/source.ts
+++ b/docs/lib/source.ts
@@ -119,7 +119,7 @@ export function mdxToCleanMarkdown(content: string): string {
 
   // Remove Cards wrapper before processing individual Card tags
   // (prevents <Cards> from being matched by <Card regex since <Cards starts with <Card)
-  result = result.replace(/<\/?Cards[^>]*>/g, '');
+  result = result.replace(/<\/?Cards\b[^>]*>/g, '');
 
   // Convert Card - handle multiline and various attribute orders
   // Self-closing Cards with description attribute


### PR DESCRIPTION
## Summary
- Fix 7 mobile UI issues across docs components (AI tools banner, mermaid diagrams, page actions, toolkits landing, toolkit detail, search dialog)
- Fix a bug where `<Card>` items inside `<Cards>` wrappers rendered as nested list items in `.md` endpoints because the `<Cards>` tag was matching the `<Card` regex

## Changes

### Mobile fixes
- **ai-tools-banner**: Reduce padding/margins on mobile, stack context file links vertically, prevent command text word-wrapping
- **mermaid**: Replace fixed `max-w-lg` with scrollable `overflow-x-auto` so diagrams don't overflow
- **page-actions**: Fix `xs:inline` → `sm:inline` (`xs:` breakpoint doesn't exist in Tailwind v4)
- **toolkits-landing**: Add `flex-wrap` to header buttons to prevent overflow on narrow screens
- **toolkit-detail**: Add `overflow-x-auto` to TypeTable wrappers, reduce expanded section padding on mobile
- **custom-search-dialog**: Hide keyboard shortcut hint on mobile

### Markdown `.md` endpoint fix
- Remove `<Cards>` wrapper tags **before** processing `<Card>` regex (previously `<Cards>` matched the `<Card` pattern)
- Add `\b` word boundary to all Card regexes for safety
- Strip orphaned JSX indentation from converted list items

**Before:** Second card rendered as nested list item
```
- [Tutorial: Build a chat app](/cookbooks/chat-app): ...
  - [How Composio works](/docs/how-composio-works): ...
```

**After:** Both cards render as top-level items
```
- [Tutorial: Build a chat app](/cookbooks/chat-app): ...
- [How Composio works](/docs/how-composio-works): ...
```

## Test plan
- [x] `bun run types:check` passes
- [x] `bun run scripts/validate-links.ts` passes
- [ ] Verify mobile rendering on key pages (homepage, toolkits landing, toolkit detail, search dialog)
- [ ] Verify `/docs.md` endpoint shows all Cards as top-level list items

🤖 Generated with [Claude Code](https://claude.com/claude-code)