### PR TITLE
ci: add cron schedule to docs data update workflow

### DIFF
--- a/.github/workflows/docs-update-data.yml
+++ b/.github/workflows/docs-update-data.yml
@@ -1,6 +1,8 @@
 name: Docs - Update Data
 
 on:
+  schedule:
+    - cron: '0 */5 * * *'
   repository_dispatch:
     types: [apollo-production-deploy]
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- Adds a 5-hour cron schedule (`0 */5 * * *`) to the "Docs - Update Data" workflow so toolkit and API data stay fresh even between Hermes production deploys.

## Test plan
- [ ] Verify the workflow runs on schedule (check Actions tab after next cron window)
- [ ] Confirm existing `repository_dispatch` and `workflow_dispatch` triggers still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)