### PR TITLE
docs: rename Vercel AI to Vercel AI SDK

### DIFF
--- a/docs/components/quickstart/framework-selector.tsx
+++ b/docs/components/quickstart/framework-selector.tsx
@@ -37,7 +37,7 @@ const frameworks: FrameworkOption[] = [
   },
   {
     id: 'vercel-ai',
-    name: 'Vercel AI',
+    name: 'Vercel AI SDK',
     logo: '/images/providers/vercel-logo.svg',
     logoDark: '/images/providers/vercel-logo-dark.svg',
   },

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -627,7 +627,7 @@ readline.close();
 
 </FrameworkOption>
 
-<FrameworkOption id="vercel-ai" name="Vercel AI" logo="/images/providers/vercel-logo.svg" logoDark="/images/providers/vercel-logo-dark.svg">
+<FrameworkOption id="vercel-ai" name="Vercel AI SDK" logo="/images/providers/vercel-logo.svg" logoDark="/images/providers/vercel-logo-dark.svg">
 
 <IntegrationTabs>
 <IntegrationContent value="native">


### PR DESCRIPTION
## Summary
- Renames "Vercel AI" to "Vercel AI SDK" in the quickstart framework selector and MDX

## Test plan
- [ ] Quickstart page loads and Vercel AI SDK tab works

🤖 Generated with [Claude Code](https://claude.com/claude-code)