### PR TITLE
docs: add changelog for 26 deprecated toolkits

### DIFF
--- a/docs/content/changelog/02-23-26-deprecated-toolkits.mdx
+++ b/docs/content/changelog/02-23-26-deprecated-toolkits.mdx
@@ -1,5 +1,5 @@
 ---
-title: "26 Deprecated Toolkits Removed"
+title: "26 Toolkits Deprecated"
 description: "Dead services and duplicate toolkit variants have been deprecated"
 date: "2026-02-23"
 ---

--- a/docs/content/changelog/02-23-26-deprecated-toolkits.mdx
+++ b/docs/content/changelog/02-23-26-deprecated-toolkits.mdx
@@ -1,0 +1,44 @@
+---
+title: "26 Deprecated Toolkits Removed"
+description: "Dead services and duplicate toolkit variants have been deprecated"
+date: "2026-02-23"
+---
+
+26 toolkits have been deprecated — 7 for dead/defunct services and 19 that were duplicates, rebrands, or naming variants of existing toolkits.
+
+### Dead Services (7)
+
+These services are no longer operational:
+
+`cloudpress`, `bench`, `leadoku`, `induced_ai`, `docnify`, `logoraisr`, `ncscale`
+
+### Duplicates, Rebrands, and Naming Variants (19)
+
+These toolkits were redundant with existing ones and have been deprecated in favor of the canonical version:
+
+| Deprecated Toolkit | Use Instead | Reason |
+|-------------------|-------------|--------|
+| `doppler_secretops` | `doppler` | Duplicate |
+| `rev_ai` | `rev` | Duplicate |
+| `metaphor` | `exa` | Rebranded |
+| `reply` | `reply_io` | Duplicate |
+| `foursquare_v1` | `foursquare` | Legacy version |
+| `foursquare_v2` | `foursquare` | Legacy version |
+| `polygon_io` | `polygon` | Subset |
+| `customer_io` | `customerio` | Naming variant |
+| `parsio_io` | `parsio` | Naming variant |
+| `onbee_app` | `onbee` | Naming variant |
+| `fixer_io` | `fixer` | Naming variant |
+| `ip2location_io` | `ip2location` | Naming variant |
+| `cloudflare_api_key` | `cloudflare` | Different auth only |
+| `onesignal_user_auth` | `onesignal_rest_api` | Identical functionality |
+| `firecrawl2` | `firecrawl` | Version variant |
+| `openweather_api` | `weathermap` | Same API |
+| `scheduleonce` | `oncehub` | Rebranded |
+| `elevenreader` | `elevenlabs` | Duplicate |
+| `sendbird_ai_chabot` | `sendbird` | Subset |
+
+### Why This Matters
+
+- **Less confusion**: Developers won't accidentally pick a deprecated variant when a canonical toolkit exists
+- **Cleaner discovery**: Toolkit listings now surface only the actively maintained version of each service


### PR DESCRIPTION
## Summary

- Adds changelog entry for 26 toolkits deprecated — 7 dead services, 19 duplicates/rebrands/naming variants
- Includes migration table showing which toolkit to use instead

Related: https://github.com/ComposioHQ/hermes/pull/8169


Made with [Cursor](https://cursor.com)