### PR TITLE
docs: rewrite FastAPI cookbook to use session-based API

### DIFF
--- a/docs/bun.lock
+++ b/docs/bun.lock
@@ -27,7 +27,7 @@
         "@ai-sdk/anthropic": "^3.0.11",
         "@ai-sdk/mcp": "^1.0.6",
         "@ai-sdk/openai": "^3.0.9",
-        "@ai-sdk/react": "^3.0.99",
+        "@ai-sdk/react": "^3.0.102",
         "@anthropic-ai/claude-agent-sdk": "^0.2.5",
         "@anthropic-ai/sdk": "^0.71.2",
         "@composio/anthropic": "^0.5.5",
@@ -92,7 +92,7 @@
 
     "@ai-sdk/provider-v6": ["@ai-sdk/provider@3.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-m9ka3ptkPQbaHHZHqDXDF9C9B5/Mav0KTdky1k2HZ3/nrW2t1AgObxIVPyGDWQNS9FXT/FS6PIoSjpcP/No8rQ=="],
 
-    "@ai-sdk/react": ["@ai-sdk/react@3.0.99", "", { "dependencies": { "@ai-sdk/provider-utils": "4.0.15", "ai": "6.0.97", "swr": "^2.2.5", "throttleit": "2.1.0" }, "peerDependencies": { "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1" } }, "sha512-xMsp5br4Dpr/3BYq/jrE8q4YLgViU1KHVq8VB0+dzdLJFU3jKA83uoxpbWqzV/edQOBPgGBSb2CgmV5v77rvzA=="],
+    "@ai-sdk/react": ["@ai-sdk/react@3.0.102", "", { "dependencies": { "@ai-sdk/provider-utils": "4.0.15", "ai": "6.0.100", "swr": "^2.2.5", "throttleit": "2.1.0" }, "peerDependencies": { "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1" } }, "sha512-WPSYJxk/HM3SWhhxE+WrLhIMbaRLpDHWWYzUlrptXowwEoyliYBYZAkzip/gV8hybT2NyrWnsUh5KRO5iBdsQA=="],
 
     "@ai-sdk/ui-utils-v5": ["@ai-sdk/ui-utils@1.2.11", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8", "zod-to-json-schema": "^3.24.1" }, "peerDependencies": { "zod": "^3.23.8" } }, "sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w=="],
 
@@ -2282,7 +2282,7 @@
 
     "@ai-sdk/provider-utils-v6/@ai-sdk/provider": ["@ai-sdk/provider@3.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-m9ka3ptkPQbaHHZHqDXDF9C9B5/Mav0KTdky1k2HZ3/nrW2t1AgObxIVPyGDWQNS9FXT/FS6PIoSjpcP/No8rQ=="],
 
-    "@ai-sdk/react/ai": ["ai@6.0.97", "", { "dependencies": { "@ai-sdk/gateway": "3.0.53", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.15", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-eZIAcBymwGhBwncRH/v9pillZNMeRCDkc4BwcvwXerXd7sxjVxRis3ZNCNCpP02pVH4NLs81ljm4cElC4vbNcQ=="],
+    "@ai-sdk/react/ai": ["ai@6.0.100", "", { "dependencies": { "@ai-sdk/gateway": "3.0.55", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.15", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-BIxhG7M7wvcWCF+IEnZi7WpkRLOM3jR2vJ0mMuohl2UB2i1R/ZUa1cHFel1xI8nWvyUpOoQXKqsM0BAH50EYSQ=="],
 
     "@ai-sdk/ui-utils-v5/@ai-sdk/provider": ["@ai-sdk/provider@1.1.3", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg=="],
 
@@ -2508,7 +2508,7 @@
 
     "@a2a-js/sdk/express/type-is": ["type-is@1.6.18", "", { "dependencies": { "media-typer": "0.3.0", "mime-types": "~2.1.24" } }, "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g=="],
 
-    "@ai-sdk/react/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.53", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.15", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-QT3FEoNARMRlk8JJVR7L98exiK9C8AGfrEJVbRxBT1yIXKs/N19o/+PsjTRVsARgDJNcy9JbJp1FspKucEat0Q=="],
+    "@ai-sdk/react/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.55", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.15", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-7xMeTJnCjwRwXKVCiv4Ly4qzWvDuW3+W1WIV0X1EFu6W83d4mEhV9bFArto10MeTw40ewuDjrbrZd21mXKohkw=="],
 
     "@eslint/eslintrc/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 

--- a/docs/content/cookbooks/fast-api.mdx
+++ b/docs/content/cookbooks/fast-api.mdx
@@ -133,7 +133,7 @@ Here's everything together:
 ## Running the server
 
 ```bash
-uv run uvicorn main:app --reload
+uv run --env-file .env uvicorn main:app --reload
 ```
 
 The server runs at `http://localhost:8000`. Visit `/docs` for the interactive Swagger UI.

--- a/docs/content/cookbooks/fast-api.mdx
+++ b/docs/content/cookbooks/fast-api.mdx
@@ -1,388 +1,171 @@
 ---
 title: Basic FastAPI Server
-description: Build a simple Gmail agent with Composio and FastAPI
+description: Build an AI agent with access to 1000+ tools using Composio and FastAPI
 ---
 
-This cookbook will guide you through building agents equipped with tools using `Composio`, `OpenAI`, and `FastAPI`.
+[View source on GitHub](https://github.com/ComposioHQ/composio/tree/next/docs/example/fast-api)
+
+This cookbook builds a FastAPI server where users can chat with an AI agent that has access to over 1000 tools like Gmail, GitHub, Slack, Notion, and more. Along the way we'll add endpoints to manage which apps a user has connected.
 
 ## Prerequisites
 
 * Python 3.10+
 * [UV](https://docs.astral.sh/uv/getting-started/installation/)
-* Composio API key
-* OpenAI API key
+* [Composio API key](https://platform.composio.dev/settings)
+* [OpenAI API key](https://platform.openai.com/api-keys)
 
-## Building an AI agent that can interact with `gmail` service
+## Project setup
 
-First, let's start with building a simple AI agent with Composio tools that lets the agent interact with `gmail`.
+Create a new project and install dependencies:
+
+```bash
+mkdir composio-fastapi && cd composio-fastapi
+uv init && uv add composio composio-openai-agents openai-agents fastapi uvicorn pydantic
+```
+
+Add your API keys to a `.env` file:
+
+```bash title=".env"
+COMPOSIO_API_KEY=your_composio_api_key
+OPENAI_API_KEY=your_openai_api_key
+```
+
+## Initializing the clients
+
+`Composio` takes an `OpenAIAgentsProvider` so that when we ask for tools later, they come back in the format the OpenAI Agents SDK expects.
 
 ```python
-from openai import OpenAI
+from agents import Agent, Runner
 from composio import Composio
-from composio_openai import OpenAIProvider
-import os
-
-def run_gmail_agent(
-    composio_client: Composio[OpenAIProvider],
-    openai_client: OpenAI,
-    user_id: str,  # Composio uses the User ID to store and access user-level authentication tokens.
-    prompt: str,
-):
-    """
-    Run the Gmail agent using composio and openai clients.
-    """
-    # Step 1: Fetch the necessary Gmail tools list with Composio
-    tools = composio_client.tools.get(
-        user_id=user_id,
-        tools=[
-            "GMAIL_FETCH_EMAILS",
-            "GMAIL_SEND_EMAIL",
-            "GMAIL_CREATE_EMAIL_DRAFT"
-        ]
-    )
-
-    # Step 2: Use OpenAI to generate a response based on the prompt and available tools
-    response = openai_client.chat.completions.create(
-        model="gpt-4.1",
-        tools=tools,
-        messages=[{"role": "user", "content": prompt}],
-    )
-
-    # Step 3: Handle tool calls with Composio and return the result
-    result = composio_client.provider.handle_tool_calls(response=response, user_id=user_id)
-    return result
-```
-
-<Callout>
-This example demonstrates a basic agent without state management or agentic loops,
-suitable for simple one-step tasks. For complex multi-step workflows requiring
-memory and iterative reasoning, see our cookbooks with frameworks like LangChain,
-CrewAI, or AutoGen.
-</Callout>
-
-To invoke this agent, authenticate your users with Composio's managed authentication service.
-
-## Authenticating users
-
-
-To authenticate your users with Composio you need an authentication config for the given app. In this case you need one for gmail. 
-
-To create an authentication config for `gmail` you need `client_id` and `client_secret` from your [Google OAuth Console](https://developers.google.com/identity/protocols/oauth2). Once you have the credentials, use the following piece of code to set up authentication for `gmail`.
-
-```python
-from composio import Composio
-from composio_openai import OpenAIProvider
-
-def create_auth_config(composio_client: Composio[OpenAIProvider]):
-    """
-    Create a auth config for the gmail toolkit.
-    """
-    client_id = os.getenv("GMAIL_CLIENT_ID")
-    client_secret = os.getenv("GMAIL_CLIENT_SECRET")
-    if not client_id or not client_secret:
-        raise ValueError("GMAIL_CLIENT_ID and GMAIL_CLIENT_SECRET must be set")
-
-    return composio_client.auth_configs.create(
-        toolkit="GMAIL",
-        options={
-            "name": "default_gmail_auth_config",
-            "type": "use_custom_auth",
-            "auth_scheme": "OAUTH2",
-            "credentials": {
-                "client_id": client_id,
-                "client_secret": client_secret,
-            },
-        },
-    )
-```
-
-This will create a Gmail authentication config to authenticate your app’s users. Ideally, create one authentication object per project, so check for an existing auth config before creating a new one.
-
-```python
-def fetch_auth_config(composio_client: Composio[OpenAIProvider]):
-    """
-    Fetch the auth config for a given user id.
-    """
-    auth_configs = composio_client.auth_configs.list()
-    for auth_config in auth_configs.items:
-        if auth_config.toolkit == "GMAIL":
-            return auth_config
-
-    return None
-```
-
-<Callout>
-Composio platform provides composio managed authentication for some apps to
-fast-track your development, `gmail` being one of them. You can use these
-default auth configs for development, but for production, always use your
-own oauth app configuration.
-</Callout>
-
-Once you have authentication management in place, we can start with connecting your users to your `gmail` app. Let's implement a function to connect users to your `gmail` app via composio.
-
-```python
+from composio_openai_agents import OpenAIAgentsProvider
 from fastapi import FastAPI
+from pydantic import BaseModel
 
-# Function to initiate a connected account
-def create_connection(composio_client: Composio[OpenAIProvider], user_id: str):
-    """
-    Create a connection for a given user id and auth config id.
-    """
-    # Fetch or create the auth config for the gmail toolkit
-    auth_config = fetch_auth_config(composio_client=composio_client)
-    if not auth_config:
-        auth_config = create_auth_config(composio_client=composio_client)
+composio = Composio(provider=OpenAIAgentsProvider())
 
-    # Create a connection for the user
-    return composio_client.connected_accounts.initiate(
-        user_id=user_id,
-        auth_config_id=auth_config.id,
-    )
-
-# Setup FastAPI
 app = FastAPI()
-
-# Connection initiation endpoint
-@app.post("/connection/create")
-def _create_connection(
-    request: CreateConnectionRequest,
-    composio_client: ComposioClient,
-) -> dict:
-    """
-    Create a connection for a given user id.
-    """
-    # For demonstration, using a default user_id. Replace with real user logic in production.
-    user_id = "default"
-
-    # Create a new connection for the user
-    connection_request = create_connection(composio_client=composio_client, user_id=user_id)
-    return {
-        "connection_id": connection_request.id,
-        "redirect_url": connection_request.redirect_url,
-    }
 ```
 
-Now, you can make a request to this endpoint on your client app, and your user will get a URL which they can use to authenticate.
+## Chat endpoint
 
-## Set Up FastAPI service
+The core of the server is a `/chat` endpoint. A user sends a message, and the agent responds, using whatever tools it needs.
 
-We will use [`FastApi`](https://fastapi.tiangolo.com/) to build an HTTP service that authenticates your users and lets them interact with your agent. This guide will provide best practices for using composio client in production environments.
-
-### Setup dependencies
-
-FastAPI allows [dependency injection](https://fastapi.tiangolo.com/reference/dependencies/) to simplify the usage of SDK clients that must be singletons. We recommend using composio SDK client as singleton.
+`composio.create()` creates a **session** scoped to a user. Calling `session.tools()` returns a set of meta tools that let the agent discover tools across all apps, handle OAuth when needed, and execute actions. We pass these to an `Agent` and let `Runner.run_sync` handle the agentic loop.
 
 ```python
-import os
-import typing_extensions as te
-
-from composio import Composio
-from composio_openai import OpenAIProvider
-
-from fastapi import Depends
-
-_composio_client: Composio[OpenAIProvider] | None = None
-
-def provide_composio_client():
-    """
-    Provide a Composio client.
-    """
-    global _composio_client
-    if _composio_client is None:
-        _composio_client = Composio(provider=OpenAIProvider())
-    return _composio_client
+class ChatRequest(BaseModel):
+    user_id: str
+    message: str
 
 
-ComposioClient = te.Annotated[Composio, Depends(provide_composio_client)]
-"""
-A Composio client dependency.
-"""
+@app.post("/chat")
+def chat(request: ChatRequest):
+    session = composio.create(user_id=request.user_id)
+    tools = session.tools()
+
+    agent = Agent(
+        name="Assistant",
+        instructions="You are a helpful assistant. Use tools to help the user.",
+        tools=tools,
+    )
+
+    result = Runner.run_sync(starting_agent=agent, input=request.message)
+    return {"response": result.final_output}
 ```
 
-### Invoke agent via FastAPI
+<Callout>
+If the user hasn't connected the app they're trying to use, the agent will automatically
+return an authentication link in its response. The user can complete OAuth and then retry.
+</Callout>
 
-When invoking an agent, make sure you validate the `user_id`.
+That's a working agent. But in most apps you'll also want to manage connections outside of chat, for example to show users what's connected or let them connect new apps from a settings page.
+
+## Checking connections
+
+`session.toolkits()` returns every toolkit in the session along with its connection status. We can expose this as a simple GET endpoint so your frontend can render a connections UI.
 
 ```python
-def check_connected_account_exists(
-    composio_client: Composio[OpenAIProvider],
-    user_id: str,
-):
-    """
-    Check if a connected account exists for a given user id.
-    """
-    # Fetch all connected accounts for the user
-    connected_accounts = composio_client.connected_accounts.list(
-        user_ids=[user_id],
-        toolkit_slugs=["GMAIL"],
-    )
-
-    # Check if there's an active connected account
-    for account in connected_accounts.items:
-        if account.status == "ACTIVE":
-            return True
-
-        # Ideally you should not have inactive accounts, but if you do, delete them.
-        print(f"[warning] inactive account {account.id} found for user id: {user_id}")
-    return False
-
-def validate_user_id(user_id: str, composio_client: ComposioClient):
-    """
-    Validate the user id, if no connected account is found, create a new connection.
-    """
-    if check_connected_account_exists(composio_client=composio_client, user_id=user_id):
-        return user_id
-
-    raise HTTPException(
-        status_code=404, detail={"error": "No connected account found for the user id"}
-    )
-
-# Endpoint: Run the Gmail agent for a given user id and prompt
-@app.post("/agent")
-def _run_gmail_agent(
-    request: RunGmailAgentRequest,
-    composio_client: ComposioClient,
-    openai_client: OpenAIClient,  # OpenAI client will be injected as dependency
-) -> List[ToolExecutionResponse]:
-    """
-    Run the Gmail agent for a given user id and prompt.
-    """
-    # For demonstration, using a default user_id. Replace with real user logic in production.
-    user_id = "default"
-
-    # Validate the user id before proceeding
-    user_id = validate_user_id(user_id=user_id, composio_client=composio_client)
-
-    # Run the Gmail agent using Composio and OpenAI
-    result = run_gmail_agent(
-        composio_client=composio_client,
-        openai_client=openai_client,
-        user_id=user_id,
-        prompt=request.prompt,
-    )
-    return result
+@app.get("/connections/{user_id}")
+def list_connections(user_id: str):
+    session = composio.create(user_id=user_id)
+    toolkits = session.toolkits()
+    return [
+        {"toolkit": t.slug, "connected": t.connection.is_active if t.connection else False}
+        for t in toolkits.items
+    ]
 ```
 
-## Putting everything together
+If you just need to check a single toolkit, say before kicking off a workflow that requires Gmail, you can scope the session to that toolkit:
 
-So far, we have created an agent with ability to interact with `gmail` using the `composio` SDK, functions to manage connected accounts for users and a FastAPI service. Now let's run the service.
-
-
-1. Clone the repository
-   ```bash
-   git clone git@github.com:composiohq/composio-fastapi
-   cd composio-fastapi/
-   ```
-2. Setup environment
-   ```bash
-   cp .env.example .env
-   ```
-
-   Fill the api keys
-   ```dotenv
-   COMPOSIO_API_KEY=
-   OPENAI_API_KEY=
-   ```
-
-   Create the virtual env
-   ```bash
-   make env
-   source .venv/bin/activate
-   ```
-3. Run the HTTP server
-   ```bash
-   uvicorn simple_gmail_agent.server.api:create_app --factory
-   ```
-## Testing the API with curl
-
-Assuming the server is running locally on `http://localhost:8000`.
-
-### Check if a connection exists
-```bash
-curl -X POST http://localhost:8000/connection/exists
+```python
+@app.get("/connections/{user_id}/{toolkit}")
+def check_connection(user_id: str, toolkit: str):
+    session = composio.create(user_id=user_id, toolkits=[toolkit])
+    toolkits = session.toolkits()
+    for t in toolkits.items:
+        if t.slug == toolkit:
+            return {"toolkit": toolkit, "connected": t.connection.is_active if t.connection else False}
+    return {"toolkit": toolkit, "connected": False}
 ```
 
-### Create a connection
-Note: The body fields are required by the API schema, but are ignored internally in this example service.
+## Connecting an app
+
+When a user wants to connect a new app, `session.authorize()` starts the OAuth flow and returns a redirect URL. Your frontend sends the user there, and once they complete auth, they're connected.
+
+```python
+class ConnectRequest(BaseModel):
+    user_id: str
+
+
+@app.post("/connect/{toolkit}")
+def connect_toolkit(toolkit: str, request: ConnectRequest):
+    session = composio.create(user_id=request.user_id, toolkits=[toolkit])
+    connection_request = session.authorize(toolkit)
+    return {"redirect_url": connection_request.redirect_url}
+```
+
+## Complete app
+
+Here's everything together:
+
+<include>../../example/fast-api/main.py</include>
+
+## Running the server
+
 ```bash
-curl -X POST http://localhost:8000/connection/create \
+uv run uvicorn main:app --reload
+```
+
+The server runs at `http://localhost:8000`. Visit `/docs` for the interactive Swagger UI.
+
+## Testing with cURL
+
+### Chat with the agent
+
+```bash
+curl -X POST http://localhost:8000/chat \
   -H "Content-Type: application/json" \
-  -d '{
-    "user_id": "default",
-    "auth_config_id": "AUTH_CONFIG_ID_FOR_GMAIL_FROM_THE_COMPOSIO_DASHBOARD"
-  }'
+  -d '{"user_id": "user_123", "message": "Star the composiohq/composio repo on GitHub"}'
 ```
-Response includes `connection_id` and `redirect_url`. Complete the OAuth flow at the `redirect_url`.
 
-### Check connection status
-Use the `connection_id` returned from the create step.
+### List all connections
+
 ```bash
-curl -X POST http://localhost:8000/connection/status \
-  -H "Content-Type: application/json" \
-  -d '{
-    "user_id": "default",
-    "connection_id": "CONNECTION_ID_FROM_CREATE_RESPONSE"
-  }'
+curl http://localhost:8000/connections/user_123
 ```
 
-### Run the Gmail agent
-Requires an active connected account for the `default` user.
+### Check a specific connection
+
 ```bash
-curl -X POST http://localhost:8000/agent \
-  -H "Content-Type: application/json" \
-  -d '{
-    "user_id": "default",
-    "prompt": "Summarize my latest unread emails from the last 24 hours."
-  }'
+curl http://localhost:8000/connections/user_123/gmail
 ```
 
-### Fetch emails (direct action)
+### Connect an app
+
 ```bash
-curl -X POST http://localhost:8000/actions/fetch_emails \
+curl -X POST http://localhost:8000/connect/gmail \
   -H "Content-Type: application/json" \
-  -d '{
-    "user_id": "default",
-    "limit": 5
-  }'
+  -d '{"user_id": "user_123"}'
 ```
 
-These examples are intended solely for testing purposes.
-
-## Using Composio for managed auth and tools
-
-Composio reduces boilerplate for building AI agents that access and use various apps. In this cookbook, to build Gmail integration without Composio, you would have to write code to
-
-- manage Gmail OAuth app
-- manage user connections
-- tools for your agents to interact with Gmail
-
-Using Composio simplifies all of the above to a few lines of code as shown in the cookbook.
-
-## Best practices
-
-**🎯 Effective Prompts**:
-- Be specific: "Send email to john@company.com about tomorrow's 2pm meeting" works better than "send email"
-- Include context: "Reply to Sarah's email about the budget with our approval"
-- Use natural language: The agent understands conversational requests
-
-**🔒 User Management**:
-- Use unique, consistent `user_id` values for each person
-- Each user maintains their own Gmail connection
-- User IDs can be email addresses, usernames, or any unique identifier
-
-
-## Troubleshooting
-
-**Connection Issues**:
-- Ensure your `.env` file has valid `COMPOSIO_API_KEY` and `OPENAI_API_KEY`
-- Check if the user has completed Gmail authorization.
-- Verify the user_id matches exactly between requests
-
-**API Errors**:
-- Check the server logs for detailed error messages
-- Ensure request payloads match the expected format
-- Visit `/docs` endpoint for API schema validation
-
-**Gmail API Limits**:
-- Gmail has rate limits; the agent will handle these gracefully
-- For high-volume usage, consider implementing request queuing
+Open the `redirect_url` from the response in your browser to complete OAuth.

--- a/docs/content/cookbooks/meta.json
+++ b/docs/content/cookbooks/meta.json
@@ -2,6 +2,8 @@
   "title": "Cookbooks",
   "root": true,
   "pages": [
+    "---Tutorials---",
+    "tutorial-chat-app",
     "---Getting Started---",
     "templates",
     "chat-app",

--- a/docs/content/cookbooks/tutorial-chat-app.mdx
+++ b/docs/content/cookbooks/tutorial-chat-app.mdx
@@ -288,6 +288,7 @@ export function ToolCallDisplay({
 Now update `app/page.tsx` to render tool calls:
 
 ```tsx title="app/page.tsx"
+// @errors: 2307
 import React from "react";
 declare function ToolCallDisplay(props: { toolName: string; input: unknown; output?: unknown; isLoading: boolean }): React.ReactElement;
 // ---cut---
@@ -296,7 +297,6 @@ declare function ToolCallDisplay(props: { toolName: string; input: unknown; outp
 import { useState } from "react";
 import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport, getToolName, isToolUIPart } from "ai";
-// @ts-ignore
 import { ToolCallDisplay } from "../components/ToolCallDisplay";
 
 export default function Chat() {

--- a/docs/content/cookbooks/tutorial-chat-app.mdx
+++ b/docs/content/cookbooks/tutorial-chat-app.mdx
@@ -409,7 +409,7 @@ We just touched on the basics. Here are some good next steps:
   <Card title="Users & Sessions" href="/docs/users-and-sessions">
     Understand the user model for multi-user production apps
   </Card>
-  <Card title="Full Stack Chat App" href="/examples/vercel-chat">
+  <Card title="Full Stack Chat App" href="/cookbooks/vercel-chat">
     A production chat app with connection management UI
   </Card>
 </Cards>

--- a/docs/content/cookbooks/tutorial-chat-app.mdx
+++ b/docs/content/cookbooks/tutorial-chat-app.mdx
@@ -1,0 +1,415 @@
+---
+title: Build a Chat App
+description: Build an AI chat app with access to 800+ tools in about 30 lines of backend code
+---
+
+Composio gives your AI agent access to 800+ app integrations — Gmail, GitHub, Slack, Notion, and more. Today, in about **30 lines of backend code**, we'll build a chat app where your agent can discover tools, authenticate users, and take actions across any app.
+
+After that we'll see how authentication works and how to show tool calls in the UI.
+
+## Create the project
+
+<Callout>
+Before you begin: you'll need Node.js 18+ and API keys for [Composio](https://platform.composio.dev/settings) and [OpenAI](https://platform.openai.com/api-keys).
+</Callout>
+
+Create a new Next.js app and install the dependencies:
+
+```bash
+pnpm create next-app composio-chat --yes
+cd composio-chat
+pnpm install @composio/core @composio/vercel @ai-sdk/openai ai @ai-sdk/react
+```
+
+Add your API keys to a `.env.local` file in the project root:
+
+```bash title=".env.local"
+COMPOSIO_API_KEY=your_composio_api_key
+OPENAI_API_KEY=your_openai_api_key
+```
+
+Start the dev server and keep it running throughout this tutorial:
+
+```bash
+pnpm dev
+```
+
+Open [localhost:3000](http://localhost:3000) — you'll see the default Next.js page. We'll replace it with a chat interface shortly.
+
+## How Composio works
+
+Instead of loading 1000+ tools into your agent's context (which would overwhelm any LLM), Composio gives your agent **5 meta tools** that handle everything at runtime:
+
+| Meta tool | What it does |
+|-----------|-------------|
+| `COMPOSIO_SEARCH_TOOLS` | Discover relevant tools across 800+ apps |
+| `COMPOSIO_MANAGE_CONNECTIONS` | Handle OAuth and API key authentication |
+| `COMPOSIO_MULTI_EXECUTE_TOOL` | Execute up to 20 tools in parallel |
+| `COMPOSIO_REMOTE_WORKBENCH` | Run Python code in a persistent sandbox |
+| `COMPOSIO_REMOTE_BASH_TOOL` | Execute bash commands for data processing |
+
+Here's the flow:
+
+```
+User: "Star the composio repo on GitHub"
+    ↓
+1. Agent calls COMPOSIO_SEARCH_TOOLS
+   → Returns GITHUB_STAR_REPO with input schema
+   → Returns connection status (not connected)
+    ↓
+2. Agent calls COMPOSIO_MANAGE_CONNECTIONS
+   → Returns an auth link for GitHub
+   → User clicks link and authorizes
+    ↓
+3. Agent calls COMPOSIO_MULTI_EXECUTE_TOOL
+   → Executes GITHUB_STAR_REPO
+   → Returns success
+    ↓
+Done. The repo is starred. ⭐
+```
+
+When you create a **session**, your agent gets these 5 tools. From there, the agent handles discovery, authentication, and execution on its own.
+
+Now let's write the code.
+
+## Your first session
+
+A **session** is the core Composio primitive. It scopes tools and connections to a specific user. One line of code gives your agent access to everything.
+
+Create a new file at `app/api/chat/route.ts`:
+
+```typescript title="app/api/chat/route.ts"
+import { openai } from "@ai-sdk/openai";
+import { Composio } from "@composio/core";
+import { VercelProvider } from "@composio/vercel";
+import {
+  streamText,
+  convertToModelMessages,
+  generateId,
+  stepCountIs,
+  type UIMessage,
+} from "ai";
+
+const composio = new Composio({ provider: new VercelProvider() });
+
+export async function POST(req: Request) {
+  const { messages }: { messages: UIMessage[] } = await req.json();
+
+  // Create a session for the user
+  const session = await composio.create("user_123");
+  const tools = await session.tools();
+
+  // Stream the AI response with tool access
+  const result = streamText({
+    model: openai("gpt-4o"),
+    system: "You are a helpful assistant. Use Composio tools to help the user.",
+    messages: await convertToModelMessages(messages),
+    tools,
+    stopWhen: stepCountIs(10),
+  });
+
+  return result.toUIMessageStreamResponse({
+    originalMessages: messages,
+    generateMessageId: () => generateId(),
+  });
+}
+```
+
+Let's break this down:
+
+1. **`new Composio({ provider: new VercelProvider() })`** initializes Composio with the Vercel AI SDK provider, so tools are returned in the right format.
+2. **`composio.create("user_123")`** creates a session for this user. All tool connections and data are scoped to this ID. In production, you'd use a real user ID from your auth system.
+3. **`session.tools()`** returns the 5 meta tools, formatted for the Vercel AI SDK.
+4. **`streamText`** sends the conversation to GPT-4o along with the tools. The model can now search for tools, authenticate users, and execute actions — all through those meta tools.
+5. **`stopWhen: stepCountIs(10)`** limits the agent to 10 steps per request. Each tool call counts as a step.
+
+That's the entire backend. Now let's build the chat UI.
+
+## The chat UI
+
+Replace your `app/page.tsx` with a simple chat interface:
+
+```tsx title="app/page.tsx"
+import React from "react";
+// ---cut---
+"use client";
+
+import { useState } from "react";
+import { useChat } from "@ai-sdk/react";
+import { DefaultChatTransport } from "ai";
+
+export default function Chat() {
+  const [input, setInput] = useState("");
+  const { messages, sendMessage, status } = useChat({
+    transport: new DefaultChatTransport({ api: "/api/chat" }),
+  });
+
+  const isLoading = status === "streaming" || status === "submitted";
+
+  return (
+    <main className="max-w-2xl mx-auto p-6">
+      <h1 className="text-2xl font-bold mb-6">Composio Chat</h1>
+
+      <div className="space-y-4 mb-6 min-h-[200px]">
+        {messages.length === 0 && (
+          <p className="text-gray-400 text-center py-12">
+            Try: &quot;Star the composio repo on GitHub&quot;
+          </p>
+        )}
+        {messages.map((m) => (
+          <div key={m.id} className="flex gap-2">
+            <span className="font-semibold shrink-0">
+              {m.role === "user" ? "You:" : "Agent:"}
+            </span>
+            <div>
+              {m.parts.map((part, i) =>
+                part.type === "text" ? <span key={i}>{String(part.text)}</span> : null
+              )}
+            </div>
+          </div>
+        ))}
+        {isLoading && (
+          <p className="text-gray-400 text-sm">Thinking...</p>
+        )}
+      </div>
+
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          if (!input.trim()) return;
+          sendMessage({ text: input });
+          setInput("");
+        }}
+      >
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Ask me anything..."
+          disabled={isLoading}
+          className="w-full p-3 border border-gray-300 rounded-lg"
+        />
+      </form>
+    </main>
+  );
+}
+```
+
+The `useChat` hook manages everything: message history, streaming, and state. It sends messages to your `/api/chat` route and streams the response back automatically.
+
+Go to [localhost:3000](http://localhost:3000). You should see the chat interface. Try sending a message like "Hello" — the agent will respond.
+
+## Your first tool call
+
+Now try asking the agent to do something real:
+
+```
+Star the composio repo on GitHub
+```
+
+Here's what happens behind the scenes:
+
+1. The agent calls **`COMPOSIO_SEARCH_TOOLS`** with your request. Composio returns the `GITHUB_STAR_REPO` tool along with its input schema and the user's connection status.
+
+2. Since you haven't connected GitHub yet, the agent calls **`COMPOSIO_MANAGE_CONNECTIONS`**. Composio returns an authentication link.
+
+3. The agent shows you the link in the chat. **Click it**, authorize with GitHub, and come back to the chat.
+
+4. Tell the agent you're done (e.g., "Done" or "I've connected"). It retries — this time calling **`COMPOSIO_MULTI_EXECUTE_TOOL`** to run `GITHUB_STAR_REPO`.
+
+5. The repo is starred.
+
+The agent handled **discovery**, **authentication**, and **execution** — all through the meta tools you gave it with `composio.create()`. You didn't write a single line of tool-specific code.
+
+<Callout>
+This in-chat authentication flow works out of the box. For production apps, you can also [authenticate users ahead of time](/docs/authenticating-users/manually-authenticating) during onboarding.
+</Callout>
+
+## Showing tool calls
+
+Right now tool calls happen invisibly. Let's add a component that shows them — the tool name, input, and output — so you can see what your agent is doing in real time.
+
+Create `components/ToolCallDisplay.tsx`:
+
+```tsx title="components/ToolCallDisplay.tsx"
+import React from "react";
+// ---cut---
+"use client";
+
+import { useState } from "react";
+
+export function ToolCallDisplay({
+  toolName,
+  input,
+  output,
+  isLoading,
+}: {
+  toolName: string;
+  input: unknown;
+  output?: unknown;
+  isLoading: boolean;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div
+      className={`my-2 rounded-lg border p-2 text-sm ${
+        isLoading
+          ? "border-blue-200 bg-blue-50"
+          : "border-green-200 bg-green-50"
+      }`}
+    >
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="flex items-center gap-2 w-full text-left"
+      >
+        <span>{isLoading ? "⏳" : "✅"}</span>
+        <code className="font-mono text-xs">{toolName}</code>
+        {isLoading && <span className="text-xs text-gray-500">Running...</span>}
+        <span className="ml-auto text-xs">{expanded ? "▲" : "▼"}</span>
+      </button>
+
+      {expanded && (
+        <div className="mt-2 space-y-2">
+          <pre className="text-xs bg-white/50 p-2 rounded overflow-auto max-h-32">
+            {String(JSON.stringify(input, null, 2))}
+          </pre>
+          {output != null && (
+            <pre className="text-xs bg-white/50 p-2 rounded overflow-auto max-h-32">
+              {String(JSON.stringify(output, null, 2))}
+            </pre>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+Now update `app/page.tsx` to render tool calls:
+
+```tsx title="app/page.tsx"
+import React from "react";
+declare function ToolCallDisplay(props: { toolName: string; input: unknown; output?: unknown; isLoading: boolean }): React.ReactElement;
+// ---cut---
+"use client";
+
+import { useState } from "react";
+import { useChat } from "@ai-sdk/react";
+import { DefaultChatTransport, getToolName, isToolUIPart } from "ai";
+// @ts-ignore
+import { ToolCallDisplay } from "../components/ToolCallDisplay";
+
+export default function Chat() {
+  const [input, setInput] = useState("");
+  const { messages, sendMessage, status } = useChat({
+    transport: new DefaultChatTransport({ api: "/api/chat" }),
+  });
+
+  const isLoading = status === "streaming" || status === "submitted";
+
+  return (
+    <main className="max-w-2xl mx-auto p-6">
+      <h1 className="text-2xl font-bold mb-6">Composio Chat</h1>
+
+      <div className="space-y-4 mb-6 min-h-[200px]">
+        {messages.length === 0 && (
+          <p className="text-gray-400 text-center py-12">
+            Try: &quot;Star the composio repo on GitHub&quot;
+          </p>
+        )}
+        {messages.map((m) => (
+          <div key={m.id} className="flex gap-2">
+            <span className="font-semibold shrink-0">
+              {m.role === "user" ? "You:" : "Agent:"}
+            </span>
+            <div className="flex-1">
+              {m.parts.map((part, i) => {
+                if (part.type === "text") {
+                  return <span key={i}>{String(part.text)}</span>;
+                }
+                if (isToolUIPart(part)) {
+                  return (
+                    <ToolCallDisplay
+                      key={part.toolCallId}
+                      toolName={getToolName(part)}
+                      input={part.input}
+                      output={
+                        part.state === "output-available"
+                          ? part.output
+                          : undefined
+                      }
+                      isLoading={part.state !== "output-available"}
+                    />
+                  );
+                }
+                return null;
+              })}
+            </div>
+          </div>
+        ))}
+        {isLoading && (
+          <p className="text-gray-400 text-sm">Thinking...</p>
+        )}
+      </div>
+
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          if (!input.trim()) return;
+          sendMessage({ text: input });
+          setInput("");
+        }}
+      >
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Ask me anything..."
+          disabled={isLoading}
+          className="w-full p-3 border border-gray-300 rounded-lg"
+        />
+      </form>
+    </main>
+  );
+}
+```
+
+Now when the agent uses tools, you'll see expandable cards showing what's happening — the tool name while it's running, and the full input/output when you click to expand.
+
+Try sending a few more requests:
+
+- "Summarize my emails from today"
+- "What's on my calendar this week?"
+- "Create a GitHub issue in my repo"
+
+Each one will trigger a different set of tools, and you'll see the full flow: search → authenticate → execute.
+
+## What you built
+
+With about 30 lines of backend code and a simple React frontend, you've built a chat app that:
+
+1. Creates a **session** that gives the agent 5 meta tools
+2. Uses **`COMPOSIO_SEARCH_TOOLS`** to discover the right tools across 800+ apps
+3. Uses **`COMPOSIO_MANAGE_CONNECTIONS`** to handle OAuth inline
+4. Uses **`COMPOSIO_MULTI_EXECUTE_TOOL`** to take actions on the user's behalf
+5. Streams responses and shows tool calls in real time
+
+The key concept is the **session** — one line (`composio.create("user_123")`) gives your agent access to every integration Composio supports.
+
+## Next up
+
+We just touched on the basics. Here are some good next steps:
+
+<Cards>
+  <Card title="Configuring sessions" href="/docs/configuring-sessions">
+    Restrict toolkits, set auth configs, and customize session behavior
+  </Card>
+  <Card title="Manual authentication" href="/docs/authenticating-users/manually-authenticating">
+    Authenticate users during onboarding instead of in-chat
+  </Card>
+  <Card title="Users & Sessions" href="/docs/users-and-sessions">
+    Understand the user model for multi-user production apps
+  </Card>
+  <Card title="Full Stack Chat App" href="/examples/vercel-chat">
+    A production chat app with connection management UI
+  </Card>
+</Cards>

--- a/docs/example/fast-api/main.py
+++ b/docs/example/fast-api/main.py
@@ -1,0 +1,64 @@
+from agents import Agent, Runner
+from composio import Composio
+from composio_openai_agents import OpenAIAgentsProvider
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+composio = Composio(provider=OpenAIAgentsProvider())
+
+app = FastAPI()
+
+
+class ChatRequest(BaseModel):
+    user_id: str
+    message: str
+
+
+class ConnectRequest(BaseModel):
+    user_id: str
+
+
+@app.post("/chat")
+def chat(request: ChatRequest):
+    """Send a message to an AI agent with access to all tools."""
+    session = composio.create(user_id=request.user_id)
+    tools = session.tools()
+
+    agent = Agent(
+        name="Assistant",
+        instructions="You are a helpful assistant. Use tools to help the user.",
+        tools=tools,
+    )
+
+    result = Runner.run_sync(starting_agent=agent, input=request.message)
+    return {"response": result.final_output}
+
+
+@app.get("/connections/{user_id}")
+def list_connections(user_id: str):
+    """List all toolkits and their connection status for a user."""
+    session = composio.create(user_id=user_id)
+    toolkits = session.toolkits()
+    return [
+        {"toolkit": t.slug, "connected": t.connection.is_active if t.connection else False}
+        for t in toolkits.items
+    ]
+
+
+@app.get("/connections/{user_id}/{toolkit}")
+def check_connection(user_id: str, toolkit: str):
+    """Check if a specific toolkit is connected for a user."""
+    session = composio.create(user_id=user_id, toolkits=[toolkit])
+    toolkits = session.toolkits()
+    for t in toolkits.items:
+        if t.slug == toolkit:
+            return {"toolkit": toolkit, "connected": t.connection.is_active if t.connection else False}
+    return {"toolkit": toolkit, "connected": False}
+
+
+@app.post("/connect/{toolkit}")
+def connect_toolkit(toolkit: str, request: ConnectRequest):
+    """Start OAuth for a toolkit. Returns a URL to redirect the user to."""
+    session = composio.create(user_id=request.user_id, toolkits=[toolkit])
+    connection_request = session.authorize(toolkit)
+    return {"redirect_url": connection_request.redirect_url}

--- a/docs/package.json
+++ b/docs/package.json
@@ -38,7 +38,7 @@
     "@ai-sdk/anthropic": "^3.0.11",
     "@ai-sdk/mcp": "^1.0.6",
     "@ai-sdk/openai": "^3.0.9",
-    "@ai-sdk/react": "^3.0.99",
+    "@ai-sdk/react": "^3.0.102",
     "@anthropic-ai/claude-agent-sdk": "^0.2.5",
     "@anthropic-ai/sdk": "^0.71.2",
     "@composio/anthropic": "^0.5.5",


### PR DESCRIPTION
## Summary

- Rewrites the FastAPI cookbook (`docs/content/cookbooks/fast-api.mdx`) from the old verbose auth config / connected accounts pattern to the modern session API (`composio.create`, `session.tools`, `session.authorize`, `session.toolkits`)
- Uses OpenAI Agents SDK (`Agent` + `Runner.run_sync`) for the agentic loop instead of raw OpenAI completions
- Adds a standalone `docs/example/fast-api/main.py` included via Fumadocs `<include>` tag
- Installs `@ai-sdk/react` to fix a pre-existing twoslash build error in the chat app tutorial

### Endpoints

| Endpoint | Description |
|----------|-------------|
| `POST /chat` | Send a message to an AI agent with access to all tools |
| `GET /connections/{user_id}` | List all toolkits and their connection status |
| `GET /connections/{user_id}/{toolkit}` | Check if a specific toolkit is connected |
| `POST /connect/{toolkit}` | Start OAuth for a toolkit, returns redirect URL |

## Test plan

- [x] All 4 endpoints tested live with real Composio + OpenAI API keys
- [x] `bun run build` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)