### PR TITLE
docs: fix changelog .md endpoints missing content

### DIFF
--- a/docs/source.config.ts
+++ b/docs/source.config.ts
@@ -91,6 +91,9 @@ export const toolkits = defineDocs({
 export const changelog = defineCollections({
   type: 'doc',
   dir: 'content/changelog',
+  postprocess: {
+    includeProcessedMarkdown: true,
+  },
   schema: frontmatterSchema.extend({
     date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, {
       message: 'Date must be in YYYY-MM-DD format (e.g., "2025-12-29")',


### PR DESCRIPTION
## Summary

- Adds `postprocess: { includeProcessedMarkdown: true }` to the `changelog` collection in `source.config.ts`
- Every other collection (`docs`, `reference`, `cookbooks`, `toolkits`) already had this config — `changelog` was the only one missing it
- Without it, `getText()` was unavailable on changelog entries, so the `.md` endpoint only returned title and description

## Before

```
# Changelog - Feb 20, 2026

## Slackbot Toolkit: Bot-Compatible Actions Only

Slackbot toolkit now includes only actions that work with bot tokens

---
```

## After

Full changelog content is now included in the `.md` output.

## Test plan

- [x] Verified `.md` endpoint returns full content for multiple changelog dates
- [x] Dev server renders changelog pages without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)