### PR TITLE
Fix release-triggered CLI/Python workflow flow

### DIFF
--- a/.changeset/slick-wolves-heal.md
+++ b/.changeset/slick-wolves-heal.md
@@ -1,0 +1,5 @@
+---
+'@composio/cli': patch
+---
+
+Fix test installation

--- a/.github/workflows/build-cli-binaries.yml
+++ b/.github/workflows/build-cli-binaries.yml
@@ -1,11 +1,8 @@
 name: Build CLI Binaries
 
 on:
-  push:
-    tags:
-      # Temporary compatibility window: support both legacy v* and package-scoped CLI tags.
-      - 'v*'
-      - '@composio/cli@*'
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       version:
@@ -18,6 +15,7 @@ permissions:
 jobs:
   build-binaries:
     name: Build CLI Binaries
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, '@composio/cli@') || startsWith(github.event.release.tag_name, 'v')
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
@@ -105,15 +103,15 @@ jobs:
           retention-days: 7
 
       - name: Create Release
-        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.event_name == 'workflow_dispatch' && format('@composio/cli@{0}', inputs.version) || github.ref_name }}
-          name: ${{ github.event_name == 'workflow_dispatch' && format('CLI @composio/cli@{0} (Manual Build)', inputs.version) || github.ref_name }}
+          tag_name: ${{ github.event_name == 'workflow_dispatch' && format('@composio/cli@{0}', inputs.version) || github.event.release.tag_name }}
+          name: ${{ github.event_name == 'workflow_dispatch' && format('CLI @composio/cli@{0} (Manual Build)', inputs.version) || github.event.release.tag_name }}
           files: |
             ts/packages/cli/dist/binaries/${{ matrix.artifact }}.zip
           draft: false
-          prerelease: ${{ github.event_name == 'workflow_dispatch' || contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
+          prerelease: ${{ github.event_name == 'workflow_dispatch' || github.event.release.prerelease || contains(github.event.release.tag_name, 'alpha') || contains(github.event.release.tag_name, 'beta') || contains(github.event.release.tag_name, 'rc') }}
           generate_release_notes: true
           make_latest: ${{ github.event_name != 'workflow_dispatch' }}
         env:
@@ -122,16 +120,16 @@ jobs:
   test-installation:
     name: Test Installation
     needs: build-binaries
-    if: always() && !cancelled() && (startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch')
+    if: always() && !cancelled() && (github.event_name == 'release' || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/cli.test-installation.yml
     with:
-      version: ${{ github.event_name == 'workflow_dispatch' && format('@composio/cli@{0}', inputs.version) || github.ref_name }}
+      version: ${{ github.event_name == 'workflow_dispatch' && format('@composio/cli@{0}', inputs.version) || github.event.release.tag_name }}
 
   create-install-instructions:
     name: Create Install Instructions
     needs: build-binaries
     runs-on: ubuntu-latest
-    if: always() && !cancelled() && (startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch')
+    if: always() && !cancelled() && (github.event_name == 'release' || github.event_name == 'workflow_dispatch')
 
     steps:
       - name: Checkout
@@ -139,7 +137,7 @@ jobs:
 
       - name: Create installation README
         run: |
-          RELEASE_TAG="${{ github.event_name == 'workflow_dispatch' && format('@composio/cli@{0}', inputs.version) || github.ref_name }}"
+          RELEASE_TAG="${{ github.event_name == 'workflow_dispatch' && format('@composio/cli@{0}', inputs.version) || github.event.release.tag_name }}"
           cat > INSTALL.md << 'EOF'
           # Composio CLI Installation
 

--- a/.github/workflows/cli.test-installation.yml
+++ b/.github/workflows/cli.test-installation.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Semver version to test (e.g., 1.0.0)'
+        description: 'Version to test (e.g., 1.0.0 or @composio/cli@1.0.0)'
         required: true
   workflow_call:
     inputs:
@@ -81,16 +81,20 @@ jobs:
             exit 0
           fi
 
-          # For manual runs, require semver input and build the release tag.
+          # For manual runs, accept a full package tag or semver and normalize to a package tag.
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            if [[ ! "$raw_input" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
-              echo "Invalid semver version: '$raw_input'"
-              echo "Expected format like: 1.2.3, 1.2.3-beta.1, 1.2.3+build.7"
-              exit 1
+            if [[ "$raw_input" =~ ^@composio/cli@ ]]; then
+              echo "use_latest=false" >> "$GITHUB_OUTPUT"
+              echo "release_tag=$raw_input" >> "$GITHUB_OUTPUT"
+              exit 0
+            elif [[ "$raw_input" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+              echo "use_latest=false" >> "$GITHUB_OUTPUT"
+              echo "release_tag=@composio/cli@$raw_input" >> "$GITHUB_OUTPUT"
+              exit 0
             fi
-            echo "use_latest=false" >> "$GITHUB_OUTPUT"
-            echo "release_tag=@composio/cli@$raw_input" >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "Invalid version: '$raw_input'"
+            echo "Expected format like: 1.2.3, 1.2.3-beta.1, 1.2.3+build.7, or @composio/cli@1.2.3"
+            exit 1
           fi
 
           # For workflow_call / push, accept a full package tag, semver, or legacy v* tag.
@@ -103,6 +107,7 @@ jobs:
           else
             echo "use_latest=false" >> "$GITHUB_OUTPUT"
             echo "release_tag=$raw_input" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
       - name: Setup shell environment

--- a/.github/workflows/py.release.yml
+++ b/.github/workflows/py.release.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   publish-core:
     name: Build and release SDK
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'py-v')
     defaults:
       run:
         working-directory: ./python


### PR DESCRIPTION
## Summary
- switch CLI binary workflow trigger from tag push to `release.published`, while keeping `workflow_dispatch`
- gate CLI binary workflow execution to CLI/legacy release tags and update release context usage to `github.event.release.tag_name`
- allow manual CLI installation test runs to accept either semver (`1.2.3`) or full package tag (`@composio/cli@1.2.3`), and gate Python release publishing to `py-v*` tags only

## Test plan
- [ ] publish a CLI release with tag `@composio/cli@x.y.z` and verify `Build CLI Binaries` runs
- [ ] run `Build CLI Binaries` via `workflow_dispatch` with semver input and verify release artifacts are generated
- [ ] run `cli.test-installation` via `workflow_dispatch` with `@composio/cli@x.y.z` and verify version normalization passes
- [ ] publish a non-Python release tag and verify `Release Python Packages` is skipped
- [ ] publish a `py-v*` release tag and verify Python publish job runs

Made with [Cursor](https://cursor.com)