### PR TITLE
Use supported macOS runner labels in release workflows

### DIFF
--- a/.github/workflows/build-cli-binaries.yml
+++ b/.github/workflows/build-cli-binaries.yml
@@ -28,10 +28,10 @@ jobs:
           - runner: depot-ubuntu-24.04-arm
             platform: linux-aarch64
             artifact: composio-linux-aarch64
-          - runner: macos-13 # Intel Mac
+          - runner: macos-15-intel # Intel Mac
             platform: darwin-x64
             artifact: composio-darwin-x64
-          - runner: macos-latest # Apple Silicon Mac
+          - runner: macos-15 # Apple Silicon Mac
             platform: darwin-aarch64
             artifact: composio-darwin-aarch64
 

--- a/.github/workflows/cli.test-installation.yml
+++ b/.github/workflows/cli.test-installation.yml
@@ -50,20 +50,20 @@ jobs:
             shell: zsh
 
           # macOS versions
-          - os: macos-13
-            name: 'macOS 13 (Ventura)'
+          - os: macos-15-intel
+            name: 'macOS 15 (Intel)'
             shell: bash
-          - os: macos-13
-            name: 'macOS 13 (zsh)'
+          - os: macos-15-intel
+            name: 'macOS 15 (Intel, zsh)'
             shell: zsh
           - os: macos-14
             name: 'macOS 14 (Sonoma)'
             shell: bash
-          - os: macos-latest
-            name: 'macOS Latest'
+          - os: macos-15
+            name: 'macOS 15 (Apple Silicon)'
             shell: bash
-          - os: macos-latest
-            name: 'macOS Latest (zsh)'
+          - os: macos-15
+            name: 'macOS 15 (Apple Silicon, zsh)'
             shell: zsh
 
     steps:
@@ -354,7 +354,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-15]
         node-version: [18, 20, 22]
 
     steps:
@@ -393,10 +393,10 @@ jobs:
           - os: depot-ubuntu-24.04-arm
             arch: arm64
             expected: 'Linux ARM64'
-          - os: macos-13
+          - os: macos-15-intel
             arch: x64
             expected: 'macOS x64'
-          - os: macos-latest
+          - os: macos-15
             arch: arm64
             expected: 'macOS ARM64'
 
@@ -443,7 +443,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-15]
 
     steps:
       - name: Checkout
@@ -527,8 +527,8 @@ jobs:
           echo "**Test Matrix Coverage:**" >> $GITHUB_STEP_SUMMARY
           echo "- **Linux x64**: Ubuntu 22.04, Latest" >> $GITHUB_STEP_SUMMARY
           echo "- **Linux ARM64**: Ubuntu 22.04, 24.04 (via Depot)" >> $GITHUB_STEP_SUMMARY
-          echo "- **macOS x64**: macOS 13, 14, Latest" >> $GITHUB_STEP_SUMMARY
-          echo "- **macOS ARM64**: macOS Latest" >> $GITHUB_STEP_SUMMARY
+          echo "- **macOS x64**: macOS 15 (Intel)" >> $GITHUB_STEP_SUMMARY
+          echo "- **macOS ARM64**: macOS 14, macOS 15 (Apple Silicon)" >> $GITHUB_STEP_SUMMARY
           echo "- **Shells**: Bash and Zsh" >> $GITHUB_STEP_SUMMARY
           echo "- **Node.js**: 18, 20, 22 (npm fallback)" >> $GITHUB_STEP_SUMMARY
           echo "- **Total platforms**: 4 architectures across 15+ environments" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- replace deprecated `macos-13` with `macos-15-intel` in CLI binary and install-test workflows
- replace `macos-latest` with explicit `macos-15` where ARM runners are expected
- update matrix labels and summary text to reflect explicit Intel/Apple Silicon coverage

## Test plan
- [ ] trigger `Build CLI Binaries` and confirm macOS jobs start on `macos-15-intel` and `macos-15`
- [ ] trigger `Test Installation` and confirm macOS matrix jobs execute successfully
- [ ] verify architecture detection job reports `macOS x64` on `macos-15-intel` and `macOS ARM64` on `macos-15`

Made with [Cursor](https://cursor.com)