### PR TITLE
docs: rewrite tool type generator cookbook

### DIFF
--- a/docs/content/cookbooks/tool-generator.mdx
+++ b/docs/content/cookbooks/tool-generator.mdx
@@ -1,273 +1,81 @@
 ---
 title: Tool Type Generator
-description: Build your own platform using raw tool definitions
+description: Build a platform on top of Composio using raw tool definitions and toolkit metadata
 ---
 
-This is a bit of a checky tutorial as it is dogfooding the `docs` tool generation process.
+[View source on GitHub](https://github.com/ComposioHQ/composio/tree/next/docs/examples/tool-generator)
 
-To motivate this example clearly, in our tools section — we have details about let's say [`Github`](/toolkits/github) tool, that shows its auth scheme, actions and their params.
+This cookbook shows how to access the raw tool definitions and toolkit metadata that Composio exposes. If you are building a platform on top of Composio, say a workflow builder or an IDE plugin, you will need to display tool schemas, auth requirements, and input/output parameters to your users. This is how you get that data.
 
-Now why would anyone outside of Composio want to do this? Well if you are building a platform on top of Composio, perchance a Workflow builder like langflow. You would want to show some or all of this information to your users.
+## Prerequisites
 
-This is a non standard use case, that we support and love users building on top of us but if this is uninteresting to you, you can skip this tutorial.
+* Python 3.10+
+* [UV](https://docs.astral.sh/uv/getting-started/installation/)
+* [Composio API key](https://platform.composio.dev/settings)
 
-## How does one build a tool type generator?
+## Project setup
 
-In composio, we have two internal states for tools
+Create a new project and install dependencies:
 
-1. Raw tool definition
-2. Provider tool definition
-
-The raw tool definition is an generic input output schema definition that we internally for tools, we expose it for customers if they want to build on top of it but it is not the primary way tools are normally used.
-
-The provider tool definition, translates this raw tool definition to the specific schema of a provider (by default `openai`). 
-
-For building something like this, we need to use the raw tool definition.
-
-
-## Getting the raw tool definition
-
-Of course, you need to initiate the `Composio` sdk first and use a `COMPOSIO_API_KEY` environment variable.
-
-
-```python Python {2} title="tool_doc_generator/main.py" maxLines=40 wordWrap
-
-    def __init__(self, include_local: bool = False):
-        """
+```bash
+mkdir composio-tool-generator && cd composio-tool-generator
+uv init && uv add composio
 ```
 
+Add your API key to a `.env` file:
 
-Let us see an example output for a raw `GMAIL` toolkit, with all of its tools.
-
-this is just a taste but you can see the full output [here](https://github.com/composio-dev/composio/blob/next/fern/pages/src/examples/tool-generator/output.json).
-
-```json JSON title="output.json" maxLines=40 
-[
-    {
-        "deprecated": {
-            "available_versions": [
-                "0_1",
-                "latest",
-                "latest:base"
-            ],
-            "display_name": "Modify email labels",
-            "is_deprecated": false,
-            "toolkit": {
-                "logo": "https://cdn.jsdelivr.net/gh/ComposioHQ/open-logos@master/gmail.svg"
-            },
-            "version": "0_1",
-            "displayName": "Modify email labels"
-        },
-        "description": "Adds and/or removes specified gmail labels for a message; ensure `message id` and all `label ids` are valid (use 'listlabels' for custom label ids).",
-        "input_parameters": {
-            "properties": {
-                "add_label_ids": {
-                    "default": [],
-                    "description": "Label IDs to add. For custom labels, obtain IDs via 'listLabels'. System labels (e.g., 'INBOX', 'SPAM') can also be used.",
-                    "examples": [
-                        "STARRED",
-                        "IMPORTANT",
-                        "Label_123"
-                    ],
-                    "items": {
-                        "type": "string"
-                    },
-                    "title": "Add Label Ids",
-                    "type": "array"
-                },
-                "message_id": {
-                    "description": "Immutable ID of the message to modify (e.g., from 'fetchEmails' or 'fetchMessagesByThreadId').",
-                    "examples": [
-                        "17f1b2b9c1b2a3d4"
-                    ],
-                    "title": "Message Id",
-                    "type": "string"
-                },
-                "remove_label_ids": {
-                    "default": [],
-                    "description": "Label IDs to remove. For custom labels, obtain IDs via 'listLabels'. System labels can also be used.",
-                    "examples": [
-                        "UNREAD",
-                        "Label_456"
-                    ],
-                    "items": {
-                        "type": "string"
-                    },
-                    "title": "Remove Label Ids",
-                    "type": "array"
-                },
-                "user_id": {
-                    "default": "me",
-                    "description": "User's email address or 'me' for the authenticated user.",
-                    "examples": [
-                        "me",
-                        "user@example.com"
-                    ],
-                    "title": "User Id",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "message_id"
-            ],
-            "title": "AddLabelToEmailRequest",
-            "type": "object"
-        },
-        "name": "Modify email labels",
-        "no_auth": false,
-        "output_parameters": {
-            "properties": {
-                "data": {
-                    "description": "Data from the action execution",
-                    "properties": {
-                        "response_data": {
-                            "description": "Full `Message` resource with updated labels.",
-                            "title": "Response Data",
-                            "type": "object"
-                        }
-                    },
-                    "required": [
-                        "response_data"
-                    ],
-                    "title": "Data",
-                    "type": "object"
-                },
-                "error": {
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "default": null,
+```bash title=".env"
+COMPOSIO_API_KEY=your_composio_api_key
 ```
 
-```sh
-jq '.[0] | keys' pages/src/examples/tool-generator/output.json
-[
-  "available_versions",
-  "deprecated",
-  "description",
-  "input_parameters",
-  "name",
-  "no_auth",
-  "output_parameters",
-  "scopes",
-  "slug",
-  "tags",
-  "toolkit",
-  "version"
-]
+## Setting up the client
+
+No provider is needed here. We are reading tool metadata directly from the Composio API, not passing tools to an AI framework.
+
+<include>../../examples/tool-generator/main.py#setup</include>
+
+## Raw tool definitions
+
+Composio has two internal representations for tools: **raw definitions** and **provider definitions**. Raw definitions are framework-agnostic JSON schemas with `input_parameters`, `output_parameters`, scopes, and tags. Provider definitions translate these into the format a specific framework expects (OpenAI, Anthropic, etc.).
+
+For building platform UIs, the raw definitions are what you want. `composio.tools.get_raw_composio_tools()` returns them for an entire toolkit. Each tool has a standard JSON Schema for its inputs and outputs, so you can render forms, validate user input, or generate types from it.
+
+<include>../../examples/tool-generator/main.py#list-tools</include>
+
+## Toolkit metadata
+
+A toolkit groups related tools under one integration. `composio.toolkits.get()` returns metadata about the toolkit itself, including its supported auth schemes. Each auth scheme lists the fields required for two stages: creating an auth config (platform setup) and initiating a connected account (end-user connection). This is useful if you need to build your own auth configuration UI.
+
+<include>../../examples/tool-generator/main.py#toolkit-info</include>
+
+## Exporting to JSON
+
+For code generation or static analysis, you can export the full raw schemas to a JSON file. Each entry includes the `input_parameters` and `output_parameters` as standard JSON Schema objects, which you can feed into tools like `json-schema-to-typescript` or `datamodel-code-generator` to produce typed interfaces.
+
+<include>../../examples/tool-generator/main.py#export</include>
+
+## Complete script
+
+Here is everything together:
+
+<include>../../examples/tool-generator/main.py</include>
+
+## Running the script
+
+List all tools in a toolkit:
+
+```bash
+uv run --env-file .env python main.py list-tools gmail
 ```
 
-There is a bunch of useful information here, around the `input_parameters` and `output_parameters` for this example but `scopes` is very valuable to know what permissions are required for this tool.
+Inspect a toolkit's auth schemes:
 
-Now from these `input_parameters` and `output_parameters` you can showcase the tool definitions.
-
-
-```python Python title="tool_doc_generator/main.py" maxLines=40 
-        fields = []
-        _, field_config = field
-
-        for field_list, required in [
-            (getattr(field_config, "required", []), True),
-            (getattr(field_config, "optional", []), False),
-        ]:
-            for f in field_list:
-                if hasattr(f, "name"):
-                    fields.append(self._create_param_from_field(f, required))
+```bash
+uv run --env-file .env python main.py toolkit-info gmail
 ```
 
-There is a bunch of other processing things happening here that are super generally relevant, so not going to call them out here that said there is another thing i want to showcase
+Export raw tool schemas to a JSON file:
 
-## Toolkit Information
-
-Toolkis are what we call apps or integrations, for us they are a collection of tools. `GMAIL` has `GMAIL_SEND_EMAIL` as a tool.
-
-Now for building something out like this, you might also want information about the toolkit itself.
-
-A toolkit has information like `categories` or `auth_schemes`
-
-```python Python title="tool_doc_generator/main.py" maxLines=40 
-        """
-        Initialize the tool documentation generator.
-
-        Args:
+```bash
+uv run --env-file .env python main.py export gmail tools.json
 ```
-
-`auth_schemes` here are `OAUTH2`, `API_KEY` or `BASIC_AUTH`, etc — essentially the types of how one could authenticate with the toolkit.
-
-```python Python title="tool_doc_generator/main.py" maxLines=40 
-        # Initialize composio client
-        self.composio = Composio()
-        self.include_local = include_local
-
-        # For tracking generated tools
-        self.generated_tools = []
-        self.problematic_actions = []
-
-    def generate_docs(
-        self, output_path: Path, max_workers: int | None = None, limit: int | None = None
-```
-
-Here is a way to parse the `auth_scheme` data
-
-
-these are `tuple` objects as they have different schema for specific conditions like `auth_config_creation` or `connected_account_initiation`
-
-they also have `required` and `optional` fields.
-
-the context here is there are some fields you need while creating an auth config and some you need while connecting an account. this separation is done by the `tuple` here
-
-```python Python title="tool_doc_generator/main.py" maxLines=40 
-        auth_schemes: t.Optional[t.List[toolkit_retrieve_response.AuthConfigDetail]] = None,
-    ) -> None:
-        schemes = ", ".join(
-            self._get_auth_type(s) for s in (auth_schemes or []) if self._extract_auth_fields(s)
-        )
-        self._blocks.extend(
-            [
-                f"""## Connecting to {app_name}
-### Create an auth config
-Use the dashboard to create an auth config for the {app_name} toolkit. This allows you to connect multiple {app_name} accounts to Composio for agents to use.
-
-<Steps>
-  <Step title="Select App">
-    Navigate to **[{app_name}](https://platform.composio.dev?next_page=/marketplace/{app_name})**.
-  </Step>
-  <Step title="Configure Auth Config Settings">
-    Select among the supported auth schemes of and configure them here.
-  </Step>
-  <Step title="Create and Get auth config ID">
-    Click **"Create {app_name} Auth Config"**. After creation, **copy the displayed ID starting with `ac_`**. This is your auth config ID. This is _not_ a sensitive ID -- you can save it in environment variables or a database.
-    **This ID will be used to create connections to the toolkit for a given user.**
-  </Step>
-</Steps>
-"""
-            ],
-        )
-
-        # Add auth code snippets
-        self._add_auth_section(app_name, app_slug, auth_schemes)
-
-    def _add_auth_section(
-        self,
-        app_name: str,
-        app_slug: str,
-        auth_schemes: t.List[toolkit_retrieve_response.AuthConfigDetail] = None,
-    ) -> None:
-        """Add code snippets for each auth scheme using direct template processing"""
-        if not auth_schemes:
-            return
-        
-        self._blocks.append("### Connect Your Account")
-        
-        # Group auth schemes by type to avoid duplicates
-        seen_auth_types = set()
-        
-```
-
-
-This is a fairly minimal explanation for the amount of code, as most of it is not super related to composio but it will be a good example on seeing behind the scenes of how composio is working and how to leverage the platform further.

--- a/docs/examples/tool-generator/main.py
+++ b/docs/examples/tool-generator/main.py
@@ -18,8 +18,9 @@ def list_tools(toolkit_slug: str):
         print(f"Name: {tool.name}")
         print(f"Description: {tool.description}")
 
-        required = tool.input_parameters.get("required", [])
-        for name, schema in tool.input_parameters.get("properties", {}).items():
+        params = tool.input_parameters or {}
+        required = params.get("required", [])
+        for name, schema in params.get("properties", {}).items():
             tag = "required" if name in required else "optional"
             print(f"  [{tag}] {name}: {schema.get('type', 'any')} - {schema.get('description', '')}")
 # endregion list-tools
@@ -40,19 +41,24 @@ def toolkit_info(toolkit_slug: str):
     for scheme in toolkit.auth_config_details:
         print(f"\nAuth scheme: {scheme.mode}")
 
-        creation_fields = scheme.fields.auth_config_creation
-        print("  Auth config creation:")
-        for field in creation_fields.required:
-            print(f"    [required] {field.name}: {field.description}")
-        for field in creation_fields.optional:
-            print(f"    [optional] {field.name}: {field.description}")
+        if not scheme.fields:
+            continue
 
-        connection_fields = scheme.fields.connected_account_initiation
-        print("  Account connection:")
-        for field in connection_fields.required:
-            print(f"    [required] {field.name}: {field.description}")
-        for field in connection_fields.optional:
-            print(f"    [optional] {field.name}: {field.description}")
+        creation = scheme.fields.auth_config_creation
+        if creation:
+            print("  Auth config creation:")
+            for field in creation.required or []:
+                print(f"    [required] {field.name}: {field.description}")
+            for field in creation.optional or []:
+                print(f"    [optional] {field.name}: {field.description}")
+
+        connection = scheme.fields.connected_account_initiation
+        if connection:
+            print("  Account connection:")
+            for field in connection.required or []:
+                print(f"    [required] {field.name}: {field.description}")
+            for field in connection.optional or []:
+                print(f"    [optional] {field.name}: {field.description}")
 # endregion toolkit-info
 
 
@@ -67,8 +73,8 @@ def export(toolkit_slug: str, output_file: str):
             "slug": tool.slug,
             "name": tool.name,
             "description": tool.description,
-            "input_parameters": tool.input_parameters,
-            "output_parameters": tool.output_parameters,
+            "input_parameters": tool.input_parameters or {},
+            "output_parameters": tool.output_parameters or {},
             "scopes": getattr(tool, "scopes", []),
             "tags": getattr(tool, "tags", []),
             "no_auth": getattr(tool, "no_auth", False),

--- a/docs/examples/tool-generator/main.py
+++ b/docs/examples/tool-generator/main.py
@@ -74,7 +74,7 @@ def export(toolkit_slug: str, output_file: str):
             "no_auth": getattr(tool, "no_auth", False),
         })
 
-    with open(output_file, "w") as f:
+    with open(output_file, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2, default=str)
 
     print(f"Exported {len(data)} tools to {output_file}")

--- a/docs/examples/tool-generator/main.py
+++ b/docs/examples/tool-generator/main.py
@@ -1,0 +1,107 @@
+import json
+import sys
+
+# region setup
+from composio import Composio
+
+composio = Composio()
+# endregion setup
+
+
+# region list-tools
+def list_tools(toolkit_slug: str):
+    """Fetch raw tool definitions for a toolkit and print them."""
+    tools = composio.tools.get_raw_composio_tools(toolkits=[toolkit_slug])
+
+    for tool in tools:
+        print(f"\n--- {tool.slug} ---")
+        print(f"Name: {tool.name}")
+        print(f"Description: {tool.description}")
+
+        required = tool.input_parameters.get("required", [])
+        for name, schema in tool.input_parameters.get("properties", {}).items():
+            tag = "required" if name in required else "optional"
+            print(f"  [{tag}] {name}: {schema.get('type', 'any')} - {schema.get('description', '')}")
+# endregion list-tools
+
+
+# region toolkit-info
+def toolkit_info(toolkit_slug: str):
+    """Fetch toolkit metadata including auth schemes."""
+    toolkit = composio.toolkits.get(toolkit_slug)
+
+    print(f"Name: {toolkit.name}")
+    print(f"Slug: {toolkit.slug}")
+
+    if not toolkit.auth_config_details:
+        print("Auth: none (no auth required)")
+        return
+
+    for scheme in toolkit.auth_config_details:
+        print(f"\nAuth scheme: {scheme.mode}")
+
+        creation_fields = scheme.fields.auth_config_creation
+        print("  Auth config creation:")
+        for field in creation_fields.required:
+            print(f"    [required] {field.name}: {field.description}")
+        for field in creation_fields.optional:
+            print(f"    [optional] {field.name}: {field.description}")
+
+        connection_fields = scheme.fields.connected_account_initiation
+        print("  Account connection:")
+        for field in connection_fields.required:
+            print(f"    [required] {field.name}: {field.description}")
+        for field in connection_fields.optional:
+            print(f"    [optional] {field.name}: {field.description}")
+# endregion toolkit-info
+
+
+# region export
+def export(toolkit_slug: str, output_file: str):
+    """Export raw tool definitions to a JSON file."""
+    tools = composio.tools.get_raw_composio_tools(toolkits=[toolkit_slug])
+
+    data = []
+    for tool in tools:
+        data.append({
+            "slug": tool.slug,
+            "name": tool.name,
+            "description": tool.description,
+            "input_parameters": tool.input_parameters,
+            "output_parameters": tool.output_parameters,
+            "scopes": getattr(tool, "scopes", []),
+            "tags": getattr(tool, "tags", []),
+            "no_auth": getattr(tool, "no_auth", False),
+        })
+
+    with open(output_file, "w") as f:
+        json.dump(data, f, indent=2, default=str)
+
+    print(f"Exported {len(data)} tools to {output_file}")
+# endregion export
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage:")
+        print("  python main.py list-tools <toolkit>")
+        print("  python main.py toolkit-info <toolkit>")
+        print("  python main.py export <toolkit> <output.json>")
+        sys.exit(1)
+
+    command = sys.argv[1]
+
+    if command == "list-tools":
+        slug = sys.argv[2] if len(sys.argv) > 2 else "gmail"
+        list_tools(slug)
+    elif command == "toolkit-info":
+        slug = sys.argv[2] if len(sys.argv) > 2 else "gmail"
+        toolkit_info(slug)
+    elif command == "export":
+        slug = sys.argv[2] if len(sys.argv) > 2 else "gmail"
+        out = sys.argv[3] if len(sys.argv) > 3 else "output.json"
+        export(slug, out)
+    else:
+        print(f"Unknown command: {command}")
+        print("Use 'list-tools', 'toolkit-info', or 'export'.")
+        sys.exit(1)


### PR DESCRIPTION
## Summary
- Rewrites the tool type generator cookbook from fragmented inline snippets to the `<include>` pattern with region markers
- Creates `docs/examples/tool-generator/main.py` with three CLI subcommands: `list-tools`, `toolkit-info`, `export`
- Uses the v3 SDK APIs: `composio.tools.get_raw_composio_tools()` and `composio.toolkits.get()`

## Test plan
- [x] `bun run build` passes
- [x] `bun run scripts/validate-links.ts` passes (0 errors)
- [x] `list-tools gmail` prints 20 tool schemas with required/optional params
- [x] `toolkit-info gmail` prints OAUTH2 auth scheme with creation/connection fields
- [x] `export gmail tools.json` writes full JSON schemas

🤖 Generated with [Claude Code](https://claude.com/claude-code)