### PR TITLE
fix(cli): use nano IDs in login and simplify org project list headers

### DIFF
--- a/.changeset/flat-islands-cry.md
+++ b/.changeset/flat-islands-cry.md
@@ -1,0 +1,5 @@
+---
+'@composio/cli': patch
+---
+
+Fix cli login command

--- a/ts/packages/cli/src/commands/init.cmd.ts
+++ b/ts/packages/cli/src/commands/init.cmd.ts
@@ -201,7 +201,7 @@ const logEnvCreationDecodingError = (ui: TerminalUI) => (e: { cause?: unknown })
 const selectDefaultProject = (params: {
   projects: ReadonlyArray<OrgProject>;
   defaultOrgId: string;
-  defaultProjectId: string;
+  defaultProjectId?: string;
 }): OrgProject | undefined => {
   const { projects, defaultOrgId, defaultProjectId } = params;
   const exactMatch = projects.find(p => p.org_id === defaultOrgId && p.id === defaultProjectId);
@@ -308,10 +308,8 @@ const initInteractiveFlow = (params: { composioDir: string; noBrowser: boolean; 
     // 2. Fetch projects
     const orgIdValue = Option.getOrUndefined(ctx.data.orgId);
     const projectIdValue = Option.getOrUndefined(ctx.data.projectId);
-    if (!globalApiKey || !orgIdValue || !projectIdValue) {
-      yield* ui.log.warn(
-        'No global API key, org ID, or project ID found. Please try `composio login` first.'
-      );
+    if (!globalApiKey || !orgIdValue) {
+      yield* ui.log.warn('No global API key or org ID found. Please try `composio login` first.');
       yield* ui.outro('');
       return;
     }
@@ -320,7 +318,6 @@ const initInteractiveFlow = (params: { composioDir: string; noBrowser: boolean; 
       baseURL: ctx.data.baseURL,
       apiKey: globalApiKey,
       orgId: orgIdValue,
-      projectId: projectIdValue,
     }).pipe(
       Effect.catchTag('services/HttpServerError', e =>
         Effect.gen(function* () {

--- a/ts/packages/cli/src/commands/login.cmd.ts
+++ b/ts/packages/cli/src/commands/login.cmd.ts
@@ -93,8 +93,8 @@ const storeCredentials = (params: {
     // Use session/info as the canonical source of org/project IDs when available.
     // The initial IDs come from the linked session response (which may use session-level
     // identifiers rather than the actual org/project IDs).
-    const orgId = sessionInfo?.org_member.id ?? initialOrgId;
-    const projectId = sessionInfo?.project.id ?? initialProjectId;
+    const orgId = sessionInfo?.project.org.id ?? initialOrgId;
+    const projectId = sessionInfo?.project.nano_id ?? initialProjectId;
 
     if (sessionInfo) {
       if (initialOrgId !== orgId) {

--- a/ts/packages/cli/src/services/composio-clients.ts
+++ b/ts/packages/cli/src/services/composio-clients.ts
@@ -719,14 +719,12 @@ export type OrgProjectListResponse = Schema.Schema.Type<typeof OrgProjectListRes
  * @param params.baseURL    - API base URL
  * @param params.apiKey     - UAK (sent as `x-user-api-key`)
  * @param params.orgId      - Organization ID (sent as `x-org-id`)
- * @param params.projectId  - Project ID (sent as `x-project-id`)
  * @param params.limit      - Max projects to return (default 100)
  */
 export const listOrgProjects = (params: {
   baseURL: string;
   apiKey: string;
   orgId: string;
-  projectId: string;
   limit?: number;
 }): Effect.Effect<OrgProjectListResponse, HttpServerError | HttpDecodingError> =>
   Effect.gen(function* () {
@@ -741,7 +739,6 @@ export const listOrgProjects = (params: {
             headers: {
               'x-user-api-key': params.apiKey,
               'x-org-id': params.orgId,
-              'x-project-id': params.projectId,
               'User-Agent': '@composio/cli',
               Accept: 'application/json',
               'Content-Type': 'application/json',
@@ -1102,7 +1099,9 @@ export class ComposioClientSingleton extends Effect.Service<ComposioClientSingle
           }
 
           // Note: `api_key` is not required in every API request.
-          const apiKey = ctx.data.apiKey.pipe(Option.getOrUndefined);
+          const rawApiKey = ctx.data.apiKey.pipe(Option.getOrUndefined);
+          const apiKey =
+            typeof rawApiKey === 'string' && rawApiKey.trim().length > 0 ? rawApiKey : undefined;
           const baseURL = ctx.data.baseURL;
           const resolvedProjectContext = yield* Option.match(projectContextOpt, {
             onNone: () => Effect.succeed(Option.none()),

--- a/ts/packages/cli/test/src/commands/login.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/login.cmd.test.ts
@@ -12,6 +12,8 @@ import { cli, TestLive, MockConsole } from 'test/__utils__';
  */
 const makeSessionInfoBody = (overrides?: {
   orgId?: string;
+  orgNanoId?: string;
+  orgMemberId?: string;
   orgName?: string;
   projectId?: string;
   projectNanoId?: string;
@@ -29,12 +31,12 @@ const makeSessionInfoBody = (overrides?: {
     updated_at: '2026-01-01T00:00:00.000Z',
     org: {
       name: overrides?.orgName ?? 'Test Org',
-      id: overrides?.orgId ?? 'org_test_456',
+      id: overrides?.orgNanoId ?? 'org_nano_456',
       plan: 'free',
     },
   },
   org_member: {
-    id: overrides?.orgId ?? 'org_test_456',
+    id: overrides?.orgMemberId ?? 'org_member_uuid_456',
     email: overrides?.email ?? 'test@composio.dev',
     name: overrides?.memberName ?? 'Test User',
     role: 'admin',
@@ -77,8 +79,11 @@ describe('CLI: composio login', () => {
             const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
               mockFetchResponse(
                 makeSessionInfoBody({
-                  orgId: 'org_verified',
-                  projectId: 'proj_verified',
+                  orgId: 'org_verified_uuid',
+                  orgNanoId: 'org_verified_nano',
+                  orgMemberId: 'org_member_verified_uuid',
+                  projectId: 'proj_verified_uuid',
+                  projectNanoId: 'proj_verified_nano',
                   email: 'verified@composio.dev',
                   projectName: 'Verified Project',
                   orgName: 'Verified Org',
@@ -113,6 +118,8 @@ describe('CLI: composio login', () => {
             const lines = yield* MockConsole.getLines();
             const output = lines.join('\n');
             expect(output).toContain('verified@composio.dev');
+            expect(output).toContain('"org_id":"org_verified_nano"');
+            expect(output).toContain('"project_id":"proj_verified_nano"');
             expect(output).toContain("You're all set!");
           })
         );


### PR DESCRIPTION
## Summary
- store nano identifiers from `session/info` during login (`org_id` from `project.org.id`, `project_id` from `project.nano_id`) instead of UUID fields
- update org project listing to send only global org context (`x-org-id`) with `x-user-api-key`, removing `x-project-id` from that request path
- keep login/init coverage aligned by updating login tests and adding a changeset for the CLI package

## Test plan
- [x] `pnpm --filter @composio/cli typecheck`
- [x] `pnpm exec vitest run test/src/commands/login.cmd.test.ts`
- [x] `pnpm exec vitest run test/src/commands/init.cmd.test.ts`

Made with [Cursor](https://cursor.com)