### PR TITLE
fix(cli): preserve test user id fallback on login

### DIFF
--- a/.changeset/salty-olives-guess.md
+++ b/.changeset/salty-olives-guess.md
@@ -1,0 +1,5 @@
+---
+'@composio/cli': patch
+---
+
+Fallback to global context if project apikeys not found

--- a/ts/packages/cli/src/commands/login.cmd.ts
+++ b/ts/packages/cli/src/commands/login.cmd.ts
@@ -96,7 +96,9 @@ const storeCredentials = (params: {
     const orgId = sessionInfo?.project.org.id ?? initialOrgId;
     const projectId = sessionInfo?.project.nano_id ?? initialProjectId;
     const sessionUserId = sessionInfo?.org_member.user_id ?? sessionInfo?.org_member.id;
-    const testUserId = sessionUserId ? `pg-test-${sessionUserId}` : undefined;
+    const testUserId = sessionUserId
+      ? `pg-test-${sessionUserId}`
+      : Option.getOrUndefined(ctx.data.testUserId);
 
     if (sessionInfo) {
       if (initialOrgId !== orgId) {

--- a/ts/packages/cli/src/commands/login.cmd.ts
+++ b/ts/packages/cli/src/commands/login.cmd.ts
@@ -93,8 +93,10 @@ const storeCredentials = (params: {
     // Use session/info as the canonical source of org/project IDs when available.
     // The initial IDs come from the linked session response (which may use session-level
     // identifiers rather than the actual org/project IDs).
-    const orgId = sessionInfo?.org_member.id ?? initialOrgId;
-    const projectId = sessionInfo?.project.id ?? initialProjectId;
+    const orgId = sessionInfo?.project.org.id ?? initialOrgId;
+    const projectId = sessionInfo?.project.nano_id ?? initialProjectId;
+    const sessionUserId = sessionInfo?.org_member.user_id ?? sessionInfo?.org_member.id;
+    const testUserId = sessionUserId ? `pg-test-${sessionUserId}` : undefined;
 
     if (sessionInfo) {
       if (initialOrgId !== orgId) {
@@ -108,7 +110,7 @@ const storeCredentials = (params: {
     }
 
     // Store UAK + org/project IDs in user_data.json
-    yield* ctx.login(uakApiKey, orgId, projectId);
+    yield* ctx.login(uakApiKey, orgId, projectId, testUserId);
 
     const email = sessionInfo?.org_member.email || fallbackEmail || undefined;
     yield* ui.log.success(email ? `Logged in as ${email}` : 'Logged in successfully');

--- a/ts/packages/cli/src/models/user-data.ts
+++ b/ts/packages/cli/src/models/user-data.ts
@@ -37,6 +37,13 @@ export const UserData = Schema.Struct({
   projectId: Schema.propertySignature(OptionFromNullishOr(Schema.String, null)).pipe(
     Schema.fromKey('project_id')
   ),
+
+  /**
+   * Optional global test user identifier used by CLI/e2e flows.
+   */
+  testUserId: Schema.propertySignature(OptionFromNullishOr(Schema.String, null)).pipe(
+    Schema.fromKey('test_user_id')
+  ),
 }).annotations({
   identifier: 'UserData',
   description: 'User data storage for the Composio CLI',

--- a/ts/packages/cli/src/services/composio-clients.ts
+++ b/ts/packages/cli/src/services/composio-clients.ts
@@ -1104,13 +1104,21 @@ export class ComposioClientSingleton extends Effect.Service<ComposioClientSingle
           // Note: `api_key` is not required in every API request.
           const apiKey = ctx.data.apiKey.pipe(Option.getOrUndefined);
           const baseURL = ctx.data.baseURL;
+          const globalOrgId = Option.getOrUndefined(ctx.data.orgId);
+          const globalProjectId = Option.getOrUndefined(ctx.data.projectId);
           const resolvedProjectContext = yield* Option.match(projectContextOpt, {
             onNone: () => Effect.succeed(Option.none()),
             onSome: projectContext =>
               projectContext.resolve.pipe(Effect.catchAll(() => Effect.succeed(Option.none()))),
           });
           const defaultHeaders = Option.match(resolvedProjectContext, {
-            onNone: () => undefined,
+            onNone: () =>
+              globalOrgId && globalProjectId
+                ? ({
+                    'x-org-id': globalOrgId,
+                    'x-project-id': globalProjectId,
+                  } satisfies Record<string, string>)
+                : undefined,
             onSome: keys =>
               ({
                 'x-org-id': keys.orgId,

--- a/ts/packages/cli/src/services/user-context.ts
+++ b/ts/packages/cli/src/services/user-context.ts
@@ -34,7 +34,8 @@ export class ComposioUserContext extends Context.Tag('ComposioUserData')<
     login: (
       apiKey: string,
       orgId?: string,
-      projectId?: string
+      projectId?: string,
+      testUserId?: string
     ) => Effect.Effect<void, ParseError | PlatformError, never>;
 
     /**
@@ -64,6 +65,7 @@ export const ComposioUserContextLive = Layer.effect(
       webURL: Option.some(webURL),
       orgId: Option.none(),
       projectId: Option.none(),
+      testUserId: Option.none(),
     });
 
     const logout = Effect.gen(function* () {
@@ -73,10 +75,11 @@ export const ComposioUserContextLive = Layer.effect(
         webURL: Option.some(webURL),
         orgId: Option.none(),
         projectId: Option.none(),
+        testUserId: Option.none(),
       });
     });
 
-    const login = (apiKey: string, orgId?: string, projectId?: string) =>
+    const login = (apiKey: string, orgId?: string, projectId?: string, testUserId?: string) =>
       Effect.gen(function* () {
         yield* update({
           apiKey: Option.some(apiKey),
@@ -84,6 +87,7 @@ export const ComposioUserContextLive = Layer.effect(
           webURL: Option.some(webURL),
           orgId: Option.fromNullable(orgId),
           projectId: Option.fromNullable(projectId),
+          testUserId: Option.fromNullable(testUserId),
         });
       });
 
@@ -117,6 +121,7 @@ export const ComposioUserContextLive = Layer.effect(
         webURL: Option.some(webURL),
         orgId: parsedUserData.orgId,
         projectId: parsedUserData.projectId,
+        testUserId: parsedUserData.testUserId,
       } satisfies UserData;
 
       yield* Effect.logDebug('User data (overridden from env vars):', overriddenUserData);
@@ -151,6 +156,7 @@ export const ComposioUserContextLive = Layer.effect(
       webURL: Option.getOrElse(userData.webURL, () => webURL),
       orgId: userData.orgId,
       projectId: userData.projectId,
+      testUserId: userData.testUserId,
     };
 
     return ComposioUserContext.of({

--- a/ts/packages/cli/test/src/commands/logout.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/logout.cmd.test.ts
@@ -19,6 +19,7 @@ describe('CLI: composio logout', () => {
             webURL: 'https://platform.composio.dev',
             orgId: Option.none(),
             projectId: Option.none(),
+            testUserId: Option.none(),
           });
 
           expect(ctx.data).toMatchObject(expectedUserData);
@@ -55,6 +56,7 @@ describe('CLI: composio logout', () => {
               webURL: 'https://platform.composio.dev',
               orgId: Option.none(),
               projectId: Option.none(),
+              testUserId: Option.none(),
             })
           );
 

--- a/ts/packages/cli/test/src/services/user-context.test.ts
+++ b/ts/packages/cli/test/src/services/user-context.test.ts
@@ -35,6 +35,7 @@ describe('ComposioUserContext', () => {
             webURL: 'https://platform.composio.dev',
             orgId: Option.none(),
             projectId: Option.none(),
+            testUserId: Option.none(),
           });
           assertEquals(Data.struct(ctx.data), Data.struct(expectedUserData));
           assertEquals(ctx.isLoggedIn(), false);
@@ -65,6 +66,7 @@ describe('ComposioUserContext', () => {
             webURL: 'https://platform.composio.dev',
             orgId: Option.none(),
             projectId: Option.none(),
+            testUserId: Option.none(),
           });
           assertEquals(Data.struct(ctx.data), Data.struct(expectedUserData));
           assertEquals(ctx.isLoggedIn(), true);
@@ -93,6 +95,7 @@ describe('ComposioUserContext', () => {
             webURL: Option.some('https://platform.composio.dev'),
             orgId: Option.none(),
             projectId: Option.none(),
+            testUserId: Option.none(),
           });
           const userDataAsJson = yield* userDataToJSON(expectedUserData);
 
@@ -132,6 +135,7 @@ describe('ComposioUserContext', () => {
             webURL: Option.some('https://platform.composio.dev'),
             orgId: Option.none(),
             projectId: Option.none(),
+            testUserId: Option.none(),
           });
           const userDataAsJson = yield* userDataToJSON(expectedUserData);
 
@@ -180,6 +184,7 @@ describe('ComposioUserContext', () => {
             webURL: 'https://platform.composio.dev',
             orgId: Option.none(),
             projectId: Option.none(),
+            testUserId: Option.none(),
           });
           assertEquals(Data.struct(ctx.data), Data.struct(expectedUserData));
           assertEquals(ctx.isLoggedIn(), false);
@@ -224,6 +229,7 @@ describe('ComposioUserContext', () => {
             webURL: 'https://platform.composio.dev',
             orgId: Option.none(),
             projectId: Option.none(),
+            testUserId: Option.none(),
           });
           assertEquals(Data.struct(ctx.data), Data.struct(expectedUserData));
           assertEquals(ctx.isLoggedIn(), false);
@@ -260,6 +266,7 @@ describe('ComposioUserContext', () => {
             webURL: 'https://platform.composio.dev',
             orgId: Option.none(),
             projectId: Option.none(),
+            testUserId: Option.none(),
           });
           assertEquals(Data.struct(ctx.data), Data.struct(expectedUserData));
           assertEquals(ctx.isLoggedIn(), false);


### PR DESCRIPTION
## Summary
- persist global `test_user_id` fallback during `composio login` when `session/info` omits member user id
- keep login metadata behavior aligned with nano-id/session-info based persistence updates
- include related CLI context/header fallback fixes from prior commits on this branch

## Test plan
- [x] `pnpm --filter @composio/cli typecheck`
- [x] `pnpm exec vitest run test/src/commands/login.cmd.test.ts test/src/services/user-context.test.ts test/src/commands/logout.cmd.test.ts test/src/commands/init.cmd.test.ts`
- [x] `pnpm exec vitest run test/src/commands/login.cmd.test.ts test/src/services/user-context.test.ts`

Made with [Cursor](https://cursor.com)