### PR TITLE
feat(cli): refine init wizard — 4-phase workflow, skills installation, `-y` non-interactive mode

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -680,16 +680,16 @@ importers:
         version: link:../../packages/providers/llamaindex
       '@llamaindex/openai':
         specifier: ^0.4.20
-        version: 0.4.22(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(ws@8.19.0)(zod@4.3.6)
+        version: 0.4.22(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(ws@8.19.0)(zod@3.25.76)
       '@llamaindex/workflow':
         specifier: ^1.1.24
-        version: 1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono@4.11.9)(zod@4.3.6)
+        version: 1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(hono@4.11.9)(zod@3.25.76)
       dotenv:
         specifier: ^16.4.1
         version: 16.6.1
       llamaindex:
         specifier: ^0.12.0
-        version: 0.12.1(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono@4.11.9)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@4.3.6)
+        version: 0.12.1(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(hono@4.11.9)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@3.25.76)
     devDependencies:
       '@types/bun':
         specifier: ^1.2.9
@@ -1047,6 +1047,9 @@ importers:
       effect:
         specifier: 'catalog:'
         version: 3.19.18
+      gray-matter:
+        specifier: ^4.0.3
+        version: 4.0.3
       indent-string:
         specifier: ^5.0.0
         version: 5.0.0
@@ -1289,7 +1292,7 @@ importers:
     dependencies:
       llamaindex:
         specifier: ^0.12.0
-        version: 0.12.1(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono@4.11.9)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@4.3.6)
+        version: 0.12.1(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@4.3.6)
     devDependencies:
       '@composio/core':
         specifier: workspace:*
@@ -7551,26 +7554,43 @@ snapshots:
       tree-sitter: 0.22.4
       web-tree-sitter: 0.24.7
 
-  '@llamaindex/openai@0.4.22(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(ws@8.19.0)(zod@4.3.6)':
+  '@llamaindex/openai@0.4.22(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(ws@8.19.0)(zod@3.25.76)':
     dependencies:
       '@llamaindex/core': 0.6.22
       '@llamaindex/env': 0.1.30
-      openai: 5.23.2(ws@8.19.0)(zod@4.3.6)
+      openai: 5.23.2(ws@8.19.0)(zod@3.25.76)
     transitivePeerDependencies:
       - ws
       - zod
 
-  '@llamaindex/workflow-core@1.3.3(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono@4.11.9)(zod@4.3.6)':
+  '@llamaindex/workflow-core@1.3.3(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(hono@4.11.9)(zod@3.25.76)':
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      '@modelcontextprotocol/sdk': 1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       hono: 4.11.9
+      zod: 3.25.76
+
+  '@llamaindex/workflow-core@1.3.3(zod@4.3.6)':
+    optionalDependencies:
       zod: 4.3.6
 
-  '@llamaindex/workflow@1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono@4.11.9)(zod@4.3.6)':
+  '@llamaindex/workflow@1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(hono@4.11.9)(zod@3.25.76)':
     dependencies:
       '@llamaindex/core': 0.6.22
       '@llamaindex/env': 0.1.30
-      '@llamaindex/workflow-core': 1.3.3(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono@4.11.9)(zod@4.3.6)
+      '@llamaindex/workflow-core': 1.3.3(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(hono@4.11.9)(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - hono
+      - next
+      - p-retry
+      - rxjs
+      - zod
+
+  '@llamaindex/workflow@1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(zod@4.3.6)':
+    dependencies:
+      '@llamaindex/core': 0.6.22
+      '@llamaindex/env': 0.1.30
+      '@llamaindex/workflow-core': 1.3.3(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - hono
@@ -8555,6 +8575,14 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@22.19.11)(tsx@4.21.0)(yaml@2.8.2)
 
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.10.13)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@24.10.13)(tsx@4.21.0)(yaml@2.8.2)
+
   '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
@@ -8584,7 +8612,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@22.19.11)(@vitest/ui@3.2.4)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 3.2.4(@types/node@24.10.13)(@vitest/ui@3.2.4)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -9951,12 +9979,34 @@ snapshots:
       rfdc: 1.4.1
       wrap-ansi: 9.0.2
 
-  llamaindex@0.12.1(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono@4.11.9)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@4.3.6):
+  llamaindex@0.12.1(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(hono@4.11.9)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@3.25.76):
     dependencies:
       '@llamaindex/core': 0.6.22
       '@llamaindex/env': 0.1.30
       '@llamaindex/node-parser': 2.0.22(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)
-      '@llamaindex/workflow': 1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono@4.11.9)(zod@4.3.6)
+      '@llamaindex/workflow': 1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(hono@4.11.9)(zod@3.25.76)
+      '@types/lodash': 4.17.23
+      '@types/node': 24.10.13
+      lodash: 4.17.23
+      magic-bytes.js: 1.13.0
+    transitivePeerDependencies:
+      - '@huggingface/transformers'
+      - '@modelcontextprotocol/sdk'
+      - gpt-tokenizer
+      - hono
+      - next
+      - p-retry
+      - rxjs
+      - tree-sitter
+      - web-tree-sitter
+      - zod
+
+  llamaindex@0.12.1(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@4.3.6):
+    dependencies:
+      '@llamaindex/core': 0.6.22
+      '@llamaindex/env': 0.1.30
+      '@llamaindex/node-parser': 2.0.22(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)
+      '@llamaindex/workflow': 1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(zod@4.3.6)
       '@types/lodash': 4.17.23
       '@types/node': 24.10.13
       lodash: 4.17.23
@@ -10235,6 +10285,11 @@ snapshots:
       define-lazy-prop: 3.0.0
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
+
+  openai@5.23.2(ws@8.19.0)(zod@3.25.76):
+    optionalDependencies:
+      ws: 8.19.0
+      zod: 3.25.76
 
   openai@5.23.2(ws@8.19.0)(zod@4.3.6):
     optionalDependencies:
@@ -11333,7 +11388,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@22.19.11)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.10.13)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4

--- a/ts/packages/cli/package.json
+++ b/ts/packages/cli/package.json
@@ -75,6 +75,7 @@
     "comment-json": "^4.2.5",
     "decompress": "^4.2.1",
     "effect": "catalog:",
+    "gray-matter": "^4.0.3",
     "indent-string": "^5.0.0",
     "open": "^10.2.0",
     "openapi-typescript": "^7.8.0",

--- a/ts/packages/cli/src/commands/init.cmd.ts
+++ b/ts/packages/cli/src/commands/init.cmd.ts
@@ -42,7 +42,6 @@ import {
   selectAgentsInteractive,
   cancelSymbol,
   checkOverwrites,
-  buildInstallationSummary,
   installAllSkills,
   buildInstallationResultDisplay,
   formatList,
@@ -51,21 +50,34 @@ import {
 /**
  * `composio init` — Initialize a Composio project in the current directory.
  *
- * ## Behavior
+ * ## Workflow (4 phases)
  *
- * 1. **Project selection** — fetches projects from the API or accepts `--org-id`/`--project-id`.
- * 2. **Usage mode** — asks "Native tools" vs "Composio MCP".
- * 3. **Framework** — if native, asks which agent framework.
- * 4. **Coding-agent skills** — asks whether to install Composio skills.
- * 5. **Environment detection** — detects language (TS/Python) and package manager.
- * 6. **Dependency installation** — installs `@composio/core` or `composio` via detected PM.
- * 7. **Writes config** — saves `<cwd>/.composio/project.json` and `<cwd>/.composio/config.json`.
+ * ### Phase 1: COLLECT (interactive, no writes)
+ * 1. Login (if needed) + project selection
+ * 2. Usage mode — "Native tools" vs "Composio MCP"
+ * 3. Framework — which agent framework (if native)
+ * 4. Skills — whether to install, agent selection, scope, method
+ * 5. Environment detection + dependency plan (if native)
+ *
+ * ### Phase 2: CONFIRM
+ * 6. Unified summary of everything to install
+ * 7. Single confirmation prompt
+ *
+ * ### Phase 3: EXECUTE
+ * 8. Resolve API keys (lazy network call)
+ * 9. Write `.composio/project.json`, `config.json`, `.env.local`
+ * 10. Install dependencies + skills
+ *
+ * ### Phase 4: OUTRO (always runs, even on partial failure)
+ * 11. Show API keys
+ * 12. Show manual commands for any failed installs
+ * 13. Success message
  *
  * ## Flags
  *
- * - `--dry-run` — print install command without executing
+ * - `--dry-run` — show summary without executing
  * - `--force` — reinstall even if dependency is already present
- * - `--yes` / `-y` — auto-select the first project from the list
+ * - `--yes` / `-y` — auto-select defaults, skip confirmation
  * - `--no-skills` — skip Composio skills installation
  */
 
@@ -135,6 +147,19 @@ const NATIVE_FRAMEWORK_OPTIONS: ReadonlyArray<{
 ];
 
 // ---------------------------------------------------------------------------
+// SkillsConfig — collected during Phase 1, executed in Phase 3
+// ---------------------------------------------------------------------------
+
+interface SkillsConfig {
+  readonly tempDir: string;
+  readonly skills: Skill[];
+  readonly targetAgents: AgentType[];
+  readonly installGlobally: boolean;
+  readonly installMode: InstallMode;
+  readonly overwriteStatus: Map<string, Map<string, boolean>>;
+}
+
+// ---------------------------------------------------------------------------
 // InitConfig — type-safe builder for the init wizard answers
 // ---------------------------------------------------------------------------
 
@@ -153,8 +178,10 @@ class InitConfigBuilder<T extends Record<string, unknown> = Record<string, never
     return new InitConfigBuilder({ ...this.data, frameworks: fws });
   }
 
-  withInstallSkills(install: boolean): InitConfigBuilder<T & { installSkills: boolean }> {
-    return new InitConfigBuilder({ ...this.data, installSkills: install });
+  withSkillsConfig(
+    sc: SkillsConfig | undefined
+  ): InitConfigBuilder<T & { skillsConfig: SkillsConfig | undefined }> {
+    return new InitConfigBuilder({ ...this.data, skillsConfig: sc });
   }
 
   withDetectedEnv(
@@ -174,7 +201,7 @@ class InitConfigBuilder<T extends Record<string, unknown> = Record<string, never
     this: InitConfigBuilder<{
       usageMode: UsageMode;
       frameworks: NativeFramework[];
-      installSkills: boolean;
+      skillsConfig: SkillsConfig | undefined;
       detectedEnv: ProjectEnvironment | undefined;
       installPlan: CoreDependencyPlan | undefined;
     }>
@@ -182,7 +209,7 @@ class InitConfigBuilder<T extends Record<string, unknown> = Record<string, never
     return {
       usageMode: this.data.usageMode,
       frameworks: this.data.frameworks,
-      installSkills: this.data.installSkills,
+      skillsConfig: this.data.skillsConfig,
       detectedEnv: this.data.detectedEnv,
       installPlan: this.data.installPlan,
     };
@@ -197,13 +224,13 @@ class InitConfigBuilder<T extends Record<string, unknown> = Record<string, never
 interface InitConfig {
   readonly usageMode: UsageMode;
   readonly frameworks: NativeFramework[];
-  readonly installSkills: boolean;
+  readonly skillsConfig: SkillsConfig | undefined;
   readonly detectedEnv: ProjectEnvironment | undefined;
   readonly installPlan: CoreDependencyPlan | undefined;
 }
 
 // ---------------------------------------------------------------------------
-// Init wizard — collects all answers via the builder
+// Phase 1: COLLECT — all interactive, no writes
 // ---------------------------------------------------------------------------
 
 /**
@@ -237,20 +264,148 @@ const resolveInstallPlan = (cwd: string) =>
   detectCoreDependencyPlan(cwd).pipe(Effect.catchAll(() => Effect.succeed(null)));
 
 /**
- * Runs the interactive init wizard.
+ * Collects skills configuration interactively: clone repo, discover skills,
+ * prompt for agents, scope, and method. Returns `undefined` if the user cancels
+ * or if cloning/discovery fails.
+ */
+const collectSkillsConfig = (params: { yes: boolean }) =>
+  Effect.gen(function* () {
+    const ui = yield* TerminalUI;
+    const { yes } = params;
+
+    // 1. Clone composiohq/skills to temp dir
+    let tempDir: string;
+    try {
+      tempDir = yield* ui.withSpinner(
+        'Cloning Composio skills repository...',
+        Effect.tryPromise(() => cloneSkillsRepo()),
+        { successMessage: 'Skills repository cloned' }
+      );
+    } catch (e) {
+      yield* ui.log.error(
+        `Failed to clone skills repository: ${e instanceof Error ? e.message : String(e)}`
+      );
+      yield* ui.log.info(`You can install skills manually: ${SKILLS_MANUAL_COMMAND}`);
+      return undefined;
+    }
+
+    // 2. Discover skills
+    let skills: Skill[];
+    try {
+      skills = yield* ui.withSpinner(
+        'Discovering skills...',
+        Effect.tryPromise(() => discoverSkills(tempDir)),
+        { successMessage: (s: Skill[]) => `Found ${s.length} skill${s.length !== 1 ? 's' : ''}` }
+      );
+    } catch (e) {
+      yield* ui.log.error(
+        `Failed to discover skills: ${e instanceof Error ? e.message : String(e)}`
+      );
+      yield* Effect.tryPromise(() => cleanupTempDir(tempDir)).pipe(
+        Effect.catchAll(() => Effect.void)
+      );
+      return undefined;
+    }
+
+    if (skills.length === 0) {
+      yield* ui.log.warn('No skills found in composiohq/skills.');
+      yield* Effect.tryPromise(() => cleanupTempDir(tempDir)).pipe(
+        Effect.catchAll(() => Effect.void)
+      );
+      return undefined;
+    }
+
+    // 3. Detect installed agents
+    const installedAgents = yield* Effect.tryPromise(() => detectInstalledAgents());
+
+    // 4. Agent selection
+    let targetAgents: AgentType[];
+    if (yes) {
+      targetAgents = ensureUniversalAgents(
+        installedAgents.length > 0 ? installedAgents : (Object.keys(agents) as AgentType[])
+      );
+      yield* ui.log.info(
+        `Installing to: ${targetAgents.map(a => agents[a].displayName).join(', ')}`
+      );
+    } else {
+      const selected = yield* Effect.tryPromise(() => selectAgentsInteractive({ global: false }));
+      if (selected === cancelSymbol) {
+        yield* ui.log.warn('Skills installation cancelled.');
+        yield* Effect.tryPromise(() => cleanupTempDir(tempDir)).pipe(
+          Effect.catchAll(() => Effect.void)
+        );
+        return undefined;
+      }
+      targetAgents = selected as AgentType[];
+    }
+
+    // 5. Scope selection
+    let installGlobally: boolean;
+    if (yes) {
+      installGlobally = false;
+    } else {
+      installGlobally = yield* ui.select<boolean>('Installation scope', [
+        {
+          value: false,
+          label: 'Project',
+          hint: 'Install in current directory (committed with your project)',
+        },
+        {
+          value: true,
+          label: 'Global',
+          hint: 'Install in home directory (available across all projects)',
+        },
+      ]);
+    }
+
+    // 6. Method selection
+    let installMode: InstallMode;
+    if (yes) {
+      installMode = 'symlink';
+    } else {
+      installMode = yield* ui.select<InstallMode>('Installation method', [
+        {
+          value: 'symlink',
+          label: 'Symlink (Recommended)',
+          hint: 'Single source of truth, easy updates',
+        },
+        {
+          value: 'copy',
+          label: 'Copy to all agents',
+          hint: 'Independent copies for each agent',
+        },
+      ]);
+    }
+
+    // 7. Check for overwrites
+    const overwriteStatus = yield* Effect.tryPromise(() =>
+      checkOverwrites(skills, targetAgents, { global: installGlobally })
+    );
+
+    return {
+      tempDir,
+      skills,
+      targetAgents,
+      installGlobally,
+      installMode,
+      overwriteStatus,
+    } satisfies SkillsConfig;
+  });
+
+/**
+ * Runs the interactive init wizard (Phase 1).
  *
  * Steps:
  * 1. Usage mode — "Native tools" or "Composio MCP"
  * 2. Framework — which agent framework (only if native)
- * 3. Install skills — whether to install Composio coding-agent skills
+ * 3. Skills — yes/no, then agent selection, scope, method (if yes)
  * 4. Detect project environment (only if native)
  * 5. Resolve install plan (only if native and environment detected)
  *
- * All inputs are collected through the builder before any side effects run.
- * Confirmation of the install plan is deferred to a unified prompt later.
+ * All inputs are collected before any writes happen.
  * Returns a fully-built `InitConfig`.
  */
-const runInitWizard = (cwd: string, params: { noSkills: boolean }) =>
+const runInitWizard = (cwd: string, params: { noSkills: boolean; yes: boolean }) =>
   Effect.gen(function* () {
     const ui = yield* TerminalUI;
 
@@ -269,12 +424,16 @@ const runInitWizard = (cwd: string, params: { noSkills: boolean }) =>
           )
         : [];
 
-    // Step 3: Install Composio skills (skip prompt when --no-skills)
-    const installSkills = params.noSkills
-      ? false
-      : yield* ui.confirm('Install Composio skills for your Coding Agent?', {
-          defaultValue: true,
-        });
+    // Step 3: Skills sub-wizard (skip entirely when --no-skills)
+    let skillsConfig: SkillsConfig | undefined;
+    if (!params.noSkills) {
+      const wantSkills = yield* ui.confirm('Install Composio skills for your Coding Agent?', {
+        defaultValue: true,
+      });
+      if (wantSkills) {
+        skillsConfig = yield* collectSkillsConfig({ yes: params.yes });
+      }
+    }
 
     // Steps 4+5: Detect environment + resolve install plan (only for native tools)
     let detectedEnv: ProjectEnvironment | undefined;
@@ -284,7 +443,7 @@ const runInitWizard = (cwd: string, params: { noSkills: boolean }) =>
       // Step 4: Detect project environment
       detectedEnv = yield* detectEnvironment(cwd);
 
-      // Step 5: Resolve install plan (confirmation deferred to unified prompt)
+      // Step 5: Resolve install plan
       if (detectedEnv) {
         const plan = yield* resolveInstallPlan(cwd);
         if (plan) {
@@ -296,11 +455,62 @@ const runInitWizard = (cwd: string, params: { noSkills: boolean }) =>
     return InitConfigBuilder.create()
       .withUsageMode(usageMode)
       .withFrameworks(frameworks)
-      .withInstallSkills(installSkills)
+      .withSkillsConfig(skillsConfig)
       .withDetectedEnv(detectedEnv)
       .withInstallPlan(installPlan)
       .build();
   });
+
+// ---------------------------------------------------------------------------
+// Phase 2: CONFIRM — unified summary
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds a human-readable summary of everything that will be installed.
+ */
+const buildUnifiedSummary = (projectName: string, config: InitConfig): string => {
+  const lines: string[] = [];
+
+  lines.push(`Project: ${projectName}`);
+  lines.push(`Usage mode: ${config.usageMode === 'native' ? 'Native tools' : 'Composio MCP'}`);
+
+  if (config.frameworks.length > 0) {
+    const fwLabels = config.frameworks.map(
+      fw => NATIVE_FRAMEWORK_OPTIONS.find(o => o.value === fw)?.label ?? fw
+    );
+    lines.push(`Frameworks: ${fwLabels.join(', ')}`);
+  }
+
+  if (config.skillsConfig) {
+    const { skills, targetAgents, installGlobally, installMode, overwriteStatus } =
+      config.skillsConfig;
+    lines.push('');
+    lines.push(`Skills: ${skills.length} skill${skills.length !== 1 ? 's' : ''}`);
+    lines.push(`  Agents: ${formatList(targetAgents.map(a => agents[a].displayName))}`);
+    lines.push(`  Scope: ${installGlobally ? 'Global' : 'Project'}`);
+    lines.push(`  Method: ${installMode === 'symlink' ? 'Symlink' : 'Copy'}`);
+
+    // Count overwrites
+    let overwriteCount = 0;
+    for (const [, agentMap] of overwriteStatus) {
+      for (const [, willOverwrite] of agentMap) {
+        if (willOverwrite) overwriteCount++;
+      }
+    }
+    if (overwriteCount > 0) {
+      lines.push(
+        `  Overwrites: ${overwriteCount} existing skill${overwriteCount !== 1 ? 's' : ''}`
+      );
+    }
+  }
+
+  if (config.installPlan) {
+    lines.push('');
+    lines.push(`Dependencies: ${config.installPlan.installCommand}`);
+  }
+
+  return lines.join('\n');
+};
 
 // ---------------------------------------------------------------------------
 // File I/O helpers
@@ -316,7 +526,7 @@ const initConfigToJSON = (config: InitConfig): string => {
   if (config.frameworks.length > 0) {
     payload.frameworks = config.frameworks;
   }
-  payload.install_skills = config.installSkills;
+  payload.install_skills = !!config.skillsConfig;
   if (config.detectedEnv) {
     payload.detected_language = config.detectedEnv.language;
     payload.package_manager = config.detectedEnv.packageManager;
@@ -351,24 +561,39 @@ const writeProjectConfig = (composioDir: string, selected: ProjectKeys, config?:
     }
   });
 
+/** Writes environment variables to `.composio/.env.local`. */
+const writeEnvLocal = (composioDir: string, envVars: ResolvedEnvVars) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const lines: string[] = ['# Generated by `composio init` — do not commit'];
+    if (envVars.composioApiKey) {
+      lines.push(`COMPOSIO_API_KEY=${envVars.composioApiKey}`);
+    }
+    lines.push(`COMPOSIO_TEST_USER_ID=${envVars.composioTestUserId}`);
+    lines.push(''); // trailing newline
+    yield* fs.writeFileString(path.join(composioDir, '.env.local'), lines.join('\n'));
+  });
+
 // ---------------------------------------------------------------------------
-// Install step — runs after wizard, before outro
+// Phase 3: EXECUTE — install deps + skills, write config
 // ---------------------------------------------------------------------------
 
+/** Tracks what succeeded and failed during Phase 3. */
+interface ExecutionOutcome {
+  envVars: ResolvedEnvVars | null;
+  depInstallOk: boolean;
+  skillsInstallOk: boolean;
+}
+
 /**
- * Runs the dependency installation step based on the init config.
- * Handles --dry-run, --force flags and already-installed detection.
- * Confirmation is handled by the caller (`printEnvVarsAndInstall`).
+ * Runs the dependency installation step.
+ * Handles --force and already-installed detection.
+ * Returns `true` on success, `false` on failure.
  */
-const runInstallStep = (params: {
-  config: InitConfig;
-  cwd: string;
-  dryRun: boolean;
-  force: boolean;
-}) =>
+const runInstallStep = (params: { config: InitConfig; cwd: string; force: boolean }) =>
   Effect.gen(function* () {
-    const { config, cwd, dryRun, force } = params;
-    if (!config.installPlan) return;
+    const { config, cwd, force } = params;
+    if (!config.installPlan) return true;
 
     const ui = yield* TerminalUI;
     const runner = yield* CommandRunner;
@@ -387,18 +612,12 @@ const runInstallStep = (params: {
             : `${depState.installedVersion.version} (${depState.installedVersion.source})`;
         yield* ui.log.info(`Found ${plan.dependency}: ${detail}`);
         yield* ui.log.success('Dependency already installed.');
-        return;
+        return true;
       }
 
       if (depState.installedVersion && force) {
         yield* ui.log.warn('Reinstalling due to --force.');
       }
-    }
-
-    if (dryRun) {
-      yield* ui.note(plan.installCommand, 'Install Command');
-      yield* ui.log.info('Dry run complete.');
-      return;
     }
 
     const [cmd, ...args] = plan.installCommand.split(' ');
@@ -413,6 +632,7 @@ const runInstallStep = (params: {
       }
     });
 
+    let ok = true;
     yield* ui
       .withSpinner(`Installing ${plan.dependency}...`, install, {
         successMessage: `Installed ${plan.dependency}.`,
@@ -422,246 +642,55 @@ const runInstallStep = (params: {
         Effect.catchAll(e =>
           Effect.gen(function* () {
             yield* ui.log.error(`Install failed: ${e instanceof Error ? e.message : String(e)}`);
-            yield* ui.log.info(`You can install manually: ${plan.installCommand}`);
+            ok = false;
           })
         )
       );
+
+    return ok;
   });
 
-// ---------------------------------------------------------------------------
-// Skills install step — inline installation from composiohq/skills
-// ---------------------------------------------------------------------------
-
 /**
- * Runs the Composio skills installation step.
- * Clones composiohq/skills, discovers skills, prompts for agents/scope/method,
- * shows summary, confirms, and installs.
+ * Executes the skills installation (no interactive prompts — config is pre-collected).
+ * Returns `true` on success, `false` on failure.
  */
-const runSkillsInstallStep = (params: {
-  config: InitConfig;
-  cwd: string;
-  dryRun: boolean;
-  yes: boolean;
-}) =>
+const runSkillsExecuteStep = (params: { skillsConfig: SkillsConfig; cwd: string }) =>
   Effect.gen(function* () {
-    const { config, cwd, dryRun, yes } = params;
-    if (!config.installSkills) return;
-
+    const { skillsConfig, cwd } = params;
     const ui = yield* TerminalUI;
 
-    // 1. Clone composiohq/skills to temp dir
-    let tempDir: string;
-    try {
-      tempDir = yield* ui.withSpinner(
-        'Cloning Composio skills repository...',
-        Effect.tryPromise(() => cloneSkillsRepo()),
-        { successMessage: 'Skills repository cloned' }
-      );
-    } catch (e) {
-      yield* ui.log.error(
-        `Failed to clone skills repository: ${e instanceof Error ? e.message : String(e)}`
-      );
-      yield* ui.log.info(`You can install skills manually: ${SKILLS_MANUAL_COMMAND}`);
-      return;
-    }
-
-    const doInstall = Effect.gen(function* () {
-      // 2. Discover skills
-      const skills = yield* ui.withSpinner(
-        'Discovering skills...',
-        Effect.tryPromise(() => discoverSkills(tempDir)),
-        { successMessage: (s: Skill[]) => `Found ${s.length} skill${s.length !== 1 ? 's' : ''}` }
-      );
-
-      if (skills.length === 0) {
-        yield* ui.log.warn('No skills found in composiohq/skills.');
-        return;
-      }
-
-      // 3. Detect installed agents
-      const installedAgents = yield* Effect.tryPromise(() => detectInstalledAgents());
-
-      // 4. Agent selection
-      let targetAgents: AgentType[];
-      if (yes) {
-        targetAgents = ensureUniversalAgents(
-          installedAgents.length > 0 ? installedAgents : (Object.keys(agents) as AgentType[])
-        );
-        yield* ui.log.info(
-          `Installing to: ${targetAgents.map(a => agents[a].displayName).join(', ')}`
-        );
-      } else {
-        const selected = yield* Effect.tryPromise(() => selectAgentsInteractive({ global: false }));
-        if (selected === cancelSymbol) {
-          yield* ui.log.warn('Skills installation cancelled.');
-          return;
-        }
-        targetAgents = selected as AgentType[];
-      }
-
-      // 5. Scope selection
-      let installGlobally: boolean;
-      if (yes) {
-        installGlobally = false;
-      } else {
-        installGlobally = yield* ui.select<boolean>('Installation scope', [
-          {
-            value: false,
-            label: 'Project',
-            hint: 'Install in current directory (committed with your project)',
-          },
-          {
-            value: true,
-            label: 'Global',
-            hint: 'Install in home directory (available across all projects)',
-          },
-        ]);
-      }
-
-      // 6. Method selection
-      let installMode: InstallMode;
-      if (yes) {
-        installMode = 'symlink';
-      } else {
-        installMode = yield* ui.select<InstallMode>('Installation method', [
-          {
-            value: 'symlink',
-            label: 'Symlink (Recommended)',
-            hint: 'Single source of truth, easy updates',
-          },
-          {
-            value: 'copy',
-            label: 'Copy to all agents',
-            hint: 'Independent copies for each agent',
-          },
-        ]);
-      }
-
-      // 7. Check for overwrites + build summary
-      const overwriteStatus = yield* Effect.tryPromise(() =>
-        checkOverwrites(skills, targetAgents, { global: installGlobally })
-      );
-
-      const summaryLines = buildInstallationSummary(
-        skills,
-        targetAgents,
-        installMode,
-        installGlobally,
-        cwd,
-        overwriteStatus
-      );
-      yield* ui.note(summaryLines.join('\n'), 'Installation Summary');
-
-      // 8. Dry run — show summary and exit
-      if (dryRun) {
-        yield* ui.log.info('Dry run — no changes made.');
-        return;
-      }
-
-      // 9. Confirm
-      const confirmed =
-        yes || (yield* ui.confirm('Proceed with installation?', { defaultValue: true }));
-      if (!confirmed) {
-        yield* ui.log.warn('Skills installation cancelled.');
-        return;
-      }
-
-      // 10. Install skills
-      const results = yield* ui.withSpinner(
-        'Installing skills...',
-        Effect.tryPromise(() =>
-          installAllSkills(skills, targetAgents, {
-            global: installGlobally,
-            mode: installMode,
-            cwd,
-          })
-        ),
-        {
-          successMessage: 'Installation complete',
-          errorMessage: 'Failed to install skills',
-        }
-      );
-
-      // 11. Display results
-      const display = buildInstallationResultDisplay(results, targetAgents, cwd);
-
-      if (display.resultNoteLines.length > 0) {
-        yield* ui.note(display.resultNoteLines.join('\n'), display.resultNoteTitle);
-      }
-      if (display.symlinkWarning) {
-        yield* ui.log.warn(`Symlinks failed for: ${formatList(display.symlinkWarning.agents)}`);
-        yield* ui.log.message(
-          '  Files were copied instead. On Windows, enable Developer Mode for symlink support.'
-        );
-      }
-      for (const line of display.failedLines) {
-        yield* ui.log.error(line);
-      }
-    });
-
-    yield* Effect.ensuring(
-      doInstall.pipe(
-        Effect.catchAll(e =>
-          Effect.gen(function* () {
-            yield* ui.log.error(
-              `Skills install failed: ${e instanceof Error ? e.message : String(e)}`
-            );
-            yield* ui.log.info(`You can install manually: ${SKILLS_MANUAL_COMMAND}`);
-          })
-        )
+    const results = yield* ui.withSpinner(
+      'Installing skills...',
+      Effect.tryPromise(() =>
+        installAllSkills(skillsConfig.skills, skillsConfig.targetAgents, {
+          global: skillsConfig.installGlobally,
+          mode: skillsConfig.installMode,
+          cwd,
+        })
       ),
-      Effect.tryPromise(() => cleanupTempDir(tempDir)).pipe(Effect.catchAll(() => Effect.void))
-    );
-  });
-
-// ---------------------------------------------------------------------------
-// Unified install confirmation — shows env vars, summary, then installs
-// ---------------------------------------------------------------------------
-
-/**
- * Prints env vars (if available), shows an install summary, asks for a single
- * confirmation, and runs both install steps. Skips the prompt entirely when
- * there is nothing to install (no install plan AND no skills).
- */
-const printEnvVarsAndInstall = (params: {
-  config: InitConfig;
-  envVars: ResolvedEnvVars | null;
-  cwd: string;
-  dryRun: boolean;
-  force: boolean;
-  yes: boolean;
-}) =>
-  Effect.gen(function* () {
-    const { config, envVars, cwd, dryRun, force, yes } = params;
-    const ui = yield* TerminalUI;
-
-    const hasWork = !!config.installPlan || config.installSkills;
-
-    // Always print env vars if available
-    if (envVars) {
-      yield* printEnvVars(envVars);
-    }
-
-    // Nothing to install — skip the confirmation prompt entirely
-    if (!hasWork) return;
-
-    // For non-dry-run: show install summary and ask for confirmation (dep install only)
-    if (!dryRun && config.installPlan) {
-      yield* ui.note(config.installPlan.installCommand, 'Install commands');
-
-      if (!yes) {
-        const confirmed = yield* ui.confirm('Proceed with installation?', { defaultValue: true });
-        if (!confirmed) {
-          yield* ui.log.warn('Installation cancelled.');
-          return;
-        }
+      {
+        successMessage: 'Skills installation complete',
+        errorMessage: 'Failed to install skills',
       }
+    );
+
+    // Display results
+    const display = buildInstallationResultDisplay(results, skillsConfig.targetAgents, cwd);
+
+    if (display.resultNoteLines.length > 0) {
+      yield* ui.note(display.resultNoteLines.join('\n'), display.resultNoteTitle);
+    }
+    if (display.symlinkWarning) {
+      yield* ui.log.warn(`Symlinks failed for: ${formatList(display.symlinkWarning.agents)}`);
+      yield* ui.log.message(
+        '  Files were copied instead. On Windows, enable Developer Mode for symlink support.'
+      );
+    }
+    for (const line of display.failedLines) {
+      yield* ui.log.error(line);
     }
 
-    // Run install steps (dry-run is handled internally by each step)
-    yield* runInstallStep({ config, cwd, dryRun, force });
-    // Skills step has its own interactive prompts (agents, scope, method, confirm)
-    yield* runSkillsInstallStep({ config, cwd, dryRun, yes });
+    return display.failedLines.length === 0;
   });
 
 // ---------------------------------------------------------------------------
@@ -685,7 +714,7 @@ const makeOutputJson = (
     project_id: selected.projectId,
     usage_mode: config.usageMode,
     frameworks: config.frameworks,
-    install_skills: config.installSkills,
+    install_skills: !!config.skillsConfig,
     detected_language: config.detectedEnv?.language ?? null,
     package_manager: config.detectedEnv?.packageManager ?? null,
     install_command: config.installPlan?.installCommand ?? null,
@@ -695,7 +724,7 @@ const makeOutputJson = (
   });
 
 // ---------------------------------------------------------------------------
-// Global user API key + env var helpers (from recent improvements)
+// Global user API key + env var helpers
 // ---------------------------------------------------------------------------
 
 const getGlobalUserApiKey = () =>
@@ -748,23 +777,6 @@ const resolveProjectEnvVars = (params: { selected: ProjectKeys }) =>
     return { composioApiKey: projectApiKey, composioTestUserId };
   });
 
-const printEnvVars = (envVars: ResolvedEnvVars) =>
-  Effect.gen(function* () {
-    const ui = yield* TerminalUI;
-
-    const redactedLines: string[] = [];
-    if (envVars.composioApiKey) {
-      redactedLines.push(
-        `COMPOSIO_API_KEY=${redact({ value: envVars.composioApiKey, prefix: 'ak_' })}`
-      );
-    }
-    redactedLines.push(
-      `COMPOSIO_TEST_USER_ID=${redact({ value: envVars.composioTestUserId, prefix: 'pr_' })}`
-    );
-
-    yield* ui.note(redactedLines.join('\n'), 'Environment variables');
-  });
-
 const logEnvCreationHttpError =
   (ui: TerminalUI) =>
   (e: { status?: number; details?: { message: string; suggestedFix: string }; cause?: unknown }) =>
@@ -805,6 +817,181 @@ const selectDefaultProject = (params: {
 };
 
 // ---------------------------------------------------------------------------
+// Phases 2-4: Confirm → Execute → Outro
+// ---------------------------------------------------------------------------
+
+/**
+ * Runs Phases 2-4 of the init workflow:
+ * - Phase 2: Show unified summary + single confirmation
+ * - Phase 3: Resolve API keys, write config, install deps + skills
+ * - Phase 4: Always show API keys + manual commands for failed installs
+ *
+ * Cancel at confirmation = exit cleanly, nothing written.
+ */
+const runConfirmExecuteOutro = (params: {
+  selected: ProjectKeys;
+  projectDisplayName: string;
+  config: InitConfig;
+  composioDir: string;
+  cwd: string;
+  dryRun: boolean;
+  force: boolean;
+  yes: boolean;
+}) =>
+  Effect.gen(function* () {
+    const { selected, projectDisplayName, config, composioDir, cwd, dryRun, force, yes } = params;
+    const ui = yield* TerminalUI;
+
+    const hasWork = !!config.installPlan || !!config.skillsConfig;
+
+    // ── Phase 2: CONFIRM ──────────────────────────────────────────────
+
+    if (hasWork) {
+      const summary = buildUnifiedSummary(projectDisplayName, config);
+      yield* ui.note(summary, 'Installation Summary');
+
+      // Dry run: show summary and exit without writing anything
+      if (dryRun) {
+        yield* ui.log.info('Dry run complete — no changes made.');
+        if (config.skillsConfig) {
+          yield* Effect.tryPromise(() => cleanupTempDir(config.skillsConfig!.tempDir)).pipe(
+            Effect.catchAll(() => Effect.void)
+          );
+        }
+        yield* ui.outro('');
+        return;
+      }
+
+      // Confirm (skip when --yes)
+      if (!yes) {
+        const confirmed = yield* ui.confirm('Proceed with installation?', { defaultValue: true });
+        if (!confirmed) {
+          if (config.skillsConfig) {
+            yield* Effect.tryPromise(() => cleanupTempDir(config.skillsConfig!.tempDir)).pipe(
+              Effect.catchAll(() => Effect.void)
+            );
+          }
+          yield* ui.log.warn('Installation cancelled.');
+          yield* ui.outro('');
+          return;
+        }
+      }
+    }
+
+    // ── Phase 3: EXECUTE ──────────────────────────────────────────────
+
+    const outcome: ExecutionOutcome = {
+      envVars: null,
+      depInstallOk: true,
+      skillsInstallOk: true,
+    };
+
+    // Ensure skills tempDir is cleaned up regardless of success/failure
+    const skillsTempDir = config.skillsConfig?.tempDir;
+    const cleanupSkills = skillsTempDir
+      ? Effect.tryPromise(() => cleanupTempDir(skillsTempDir)).pipe(
+          Effect.catchAll(() => Effect.void)
+        )
+      : Effect.void;
+
+    yield* Effect.ensuring(
+      Effect.gen(function* () {
+        // Step 6: Resolve API keys (lazy — first network call after confirmation)
+        outcome.envVars = yield* resolveProjectEnvVars({ selected }).pipe(
+          Effect.catchTag('services/HttpServerError', e =>
+            Effect.gen(function* () {
+              yield* Effect.logDebug('Failed to resolve project API key:', e);
+              yield* logEnvCreationHttpError(ui)(e);
+              return null;
+            })
+          ),
+          Effect.catchTag('services/HttpDecodingError', e =>
+            Effect.gen(function* () {
+              yield* Effect.logDebug('Failed to decode API key response:', e);
+              yield* logEnvCreationDecodingError(ui)(e);
+              return null;
+            })
+          )
+        );
+
+        // Step 7: Write project config (once, with testUserId if available)
+        const projectKeys = outcome.envVars
+          ? { ...selected, testUserId: Option.some(outcome.envVars.composioTestUserId) }
+          : selected;
+        yield* writeProjectConfig(composioDir, projectKeys, config);
+
+        // Step 8: Write .composio/.env.local
+        if (outcome.envVars) {
+          yield* writeEnvLocal(composioDir, outcome.envVars);
+        }
+
+        // Step 9: Install dependencies
+        if (config.installPlan) {
+          outcome.depInstallOk = yield* runInstallStep({ config, cwd, force }).pipe(
+            Effect.catchAll(() => Effect.succeed(false))
+          );
+        }
+
+        // Step 10: Install skills
+        if (config.skillsConfig) {
+          outcome.skillsInstallOk = yield* runSkillsExecuteStep({
+            skillsConfig: config.skillsConfig,
+            cwd,
+          }).pipe(
+            Effect.catchAll(e =>
+              Effect.gen(function* () {
+                yield* ui.log.error(
+                  `Skills install failed: ${e instanceof Error ? e.message : String(e)}`
+                );
+                return false;
+              })
+            )
+          );
+        }
+      }).pipe(
+        // Safety net: if anything unexpected escapes individual error handling
+        Effect.catchAll(() => Effect.void)
+      ),
+      cleanupSkills
+    );
+
+    // ── Phase 4: OUTRO (always runs) ──────────────────────────────────
+
+    // Step 11: Show API keys
+    if (outcome.envVars) {
+      const envLines: string[] = [];
+      if (outcome.envVars.composioApiKey) {
+        envLines.push(
+          `COMPOSIO_API_KEY=${redact({ value: outcome.envVars.composioApiKey, prefix: 'ak_' })}`
+        );
+      }
+      envLines.push(
+        `COMPOSIO_TEST_USER_ID=${redact({ value: outcome.envVars.composioTestUserId, prefix: 'pr_' })}`
+      );
+      envLines.push('');
+      envLines.push(`Saved to ${composioDir}/.env.local`);
+      yield* ui.note(envLines.join('\n'), 'Environment variables');
+    }
+
+    // Step 12: If dep install failed → show manual command
+    if (!outcome.depInstallOk && config.installPlan) {
+      yield* ui.log.warn('Dependency installation failed. Install manually:');
+      yield* ui.log.message(`  ${config.installPlan.installCommand}`);
+    }
+
+    // Step 13: If skills install failed → show manual command
+    if (!outcome.skillsInstallOk) {
+      yield* ui.log.warn('Skills installation failed. Install manually:');
+      yield* ui.log.message(`  ${SKILLS_MANUAL_COMMAND}`);
+    }
+
+    // Step 14: Success
+    yield* ui.log.success(`Project initialized in ${composioDir}/`);
+    yield* ui.output(makeOutputJson(selected, config, composioDir, outcome.envVars));
+    yield* ui.outro('');
+  });
+
+// ---------------------------------------------------------------------------
 // Command
 // ---------------------------------------------------------------------------
 
@@ -812,7 +999,8 @@ const selectDefaultProject = (params: {
  * CLI command to initialize a Composio project in the current directory.
  *
  * Creates `<cwd>/.composio/project.json` with org_id and project_id,
- * plus `<cwd>/.composio/config.json` with usage mode, framework, and skill preferences.
+ * plus `<cwd>/.composio/config.json` with usage mode, framework, and skill preferences,
+ * and `<cwd>/.composio/.env.local` with API keys.
  *
  * Supports two modes:
  * 1. Interactive: Fetches projects from the API and prompts for selection
@@ -855,39 +1043,20 @@ export const initCmd = CliCommand.make(
           testUserId: Option.none(),
         };
 
-        const config = yield* runInitWizard(proc.cwd, { noSkills });
-        yield* writeProjectConfig(composioDir, selected, config);
+        // Phase 1: COLLECT
+        const config = yield* runInitWizard(proc.cwd, { noSkills, yes });
 
-        const envVars = yield* resolveProjectEnvVars({ selected }).pipe(
-          Effect.catchTag('services/HttpServerError', e =>
-            Effect.gen(function* () {
-              yield* Effect.logDebug('Failed to resolve project API key from session/info:', e);
-              yield* logEnvCreationHttpError(ui)(e);
-              return null;
-            })
-          ),
-          Effect.catchTag('services/HttpDecodingError', e =>
-            Effect.gen(function* () {
-              yield* Effect.logDebug('Failed to decode API key response:', e);
-              yield* logEnvCreationDecodingError(ui)(e);
-              return null;
-            })
-          )
-        );
-
-        if (envVars) {
-          yield* writeProjectConfig(
-            composioDir,
-            { ...selected, testUserId: Option.some(envVars.composioTestUserId) },
-            config
-          );
-        }
-
-        yield* printEnvVarsAndInstall({ config, envVars, cwd: proc.cwd, dryRun, force, yes });
-
-        yield* ui.log.success(`Project initialized in ${composioDir}/`);
-        yield* ui.output(makeOutputJson(selected, config, composioDir, envVars));
-        yield* ui.outro('');
+        // Phases 2-4: CONFIRM → EXECUTE → OUTRO
+        yield* runConfirmExecuteOutro({
+          selected,
+          projectDisplayName: projectId.value,
+          config,
+          composioDir,
+          cwd: proc.cwd,
+          dryRun,
+          force,
+          yes,
+        });
         return;
       }
 
@@ -993,38 +1162,18 @@ const initInteractiveFlow = (params: {
     const selected = orgProjectToKeys(selectedProject);
     yield* ui.log.step(`Using project "${selectedProject.name}"`);
 
-    // 4. Run wizard + write config + install
-    const config = yield* runInitWizard(proc.cwd, { noSkills });
-    yield* writeProjectConfig(composioDir, selected, config);
+    // Phase 1: COLLECT (wizard)
+    const config = yield* runInitWizard(proc.cwd, { noSkills, yes });
 
-    const envVars = yield* resolveProjectEnvVars({ selected }).pipe(
-      Effect.catchTag('services/HttpServerError', e =>
-        Effect.gen(function* () {
-          yield* Effect.logDebug('Failed to resolve project API key from session/info:', e);
-          yield* logEnvCreationHttpError(ui)(e);
-          return null;
-        })
-      ),
-      Effect.catchTag('services/HttpDecodingError', e =>
-        Effect.gen(function* () {
-          yield* Effect.logDebug('Failed to decode API key response:', e);
-          yield* logEnvCreationDecodingError(ui)(e);
-          return null;
-        })
-      )
-    );
-
-    if (envVars) {
-      yield* writeProjectConfig(
-        composioDir,
-        { ...selected, testUserId: Option.some(envVars.composioTestUserId) },
-        config
-      );
-    }
-
-    yield* printEnvVarsAndInstall({ config, envVars, cwd: proc.cwd, dryRun, force, yes });
-
-    yield* ui.log.success(`Project initialized in ${composioDir}/`);
-    yield* ui.output(makeOutputJson(selected, config, composioDir, envVars));
-    yield* ui.outro('');
+    // Phases 2-4: CONFIRM → EXECUTE → OUTRO
+    yield* runConfirmExecuteOutro({
+      selected,
+      projectDisplayName: selectedProject.name,
+      config,
+      composioDir,
+      cwd: proc.cwd,
+      dryRun,
+      force,
+      yes,
+    });
   });

--- a/ts/packages/cli/src/commands/init.cmd.ts
+++ b/ts/packages/cli/src/commands/init.cmd.ts
@@ -218,27 +218,6 @@ const resolveInstallPlan = (cwd: string) =>
   detectCoreDependencyPlan(cwd).pipe(Effect.catchAll(() => Effect.succeed(null)));
 
 /**
- * After detecting the project environment and resolving an install plan,
- * ask the user to confirm the detected package manager or skip installation.
- * Returns the plan if confirmed, `undefined` if skipped.
- */
-const confirmInstallPlan = (plan: CoreDependencyPlan) =>
-  Effect.gen(function* () {
-    const ui = yield* TerminalUI;
-
-    type PmChoice = 'confirm' | 'skip';
-    const choice = yield* ui.select<PmChoice>(
-      `Install ${plan.dependency} using ${plan.packageManager}?`,
-      [
-        { value: 'confirm' as PmChoice, label: plan.packageManager, hint: plan.installCommand },
-        { value: 'skip' as PmChoice, label: 'Skip' },
-      ]
-    );
-
-    return choice === 'confirm' ? plan : undefined;
-  });
-
-/**
  * Runs the interactive init wizard.
  *
  * Steps:
@@ -246,9 +225,10 @@ const confirmInstallPlan = (plan: CoreDependencyPlan) =>
  * 2. Framework — which agent framework (only if native)
  * 3. Install skills — whether to install Composio coding-agent skills
  * 4. Detect project environment (only if native)
- * 5. Resolve + confirm install plan (only if native and environment detected)
+ * 5. Resolve install plan (only if native and environment detected)
  *
  * All inputs are collected through the builder before any side effects run.
+ * Confirmation of the install plan is deferred to a unified prompt later.
  * Returns a fully-built `InitConfig`.
  */
 const runInitWizard = (cwd: string, params: { noSkills: boolean }) =>
@@ -277,7 +257,7 @@ const runInitWizard = (cwd: string, params: { noSkills: boolean }) =>
           defaultValue: true,
         });
 
-    // Steps 4+5: Detect environment + confirm install plan (only for native tools)
+    // Steps 4+5: Detect environment + resolve install plan (only for native tools)
     let detectedEnv: ProjectEnvironment | undefined;
     let installPlan: CoreDependencyPlan | undefined;
 
@@ -285,11 +265,11 @@ const runInitWizard = (cwd: string, params: { noSkills: boolean }) =>
       // Step 4: Detect project environment
       detectedEnv = yield* detectEnvironment(cwd);
 
-      // Step 5: Resolve install plan and confirm package manager
+      // Step 5: Resolve install plan (confirmation deferred to unified prompt)
       if (detectedEnv) {
         const plan = yield* resolveInstallPlan(cwd);
         if (plan) {
-          installPlan = yield* confirmInstallPlan(plan);
+          installPlan = plan;
         }
       }
     }
@@ -358,17 +338,17 @@ const writeProjectConfig = (composioDir: string, selected: ProjectKeys, config?:
 
 /**
  * Runs the dependency installation step based on the init config.
- * Handles --dry-run, --force, --yes flags and already-installed detection.
+ * Handles --dry-run, --force flags and already-installed detection.
+ * Confirmation is handled by the caller (`printEnvVarsAndInstall`).
  */
 const runInstallStep = (params: {
   config: InitConfig;
   cwd: string;
   dryRun: boolean;
   force: boolean;
-  yes: boolean;
 }) =>
   Effect.gen(function* () {
-    const { config, cwd, dryRun, force, yes } = params;
+    const { config, cwd, dryRun, force } = params;
     if (!config.installPlan) return;
 
     const ui = yield* TerminalUI;
@@ -399,13 +379,6 @@ const runInstallStep = (params: {
     if (dryRun) {
       yield* ui.note(plan.installCommand, 'Install Command');
       yield* ui.log.info('Dry run complete.');
-      return;
-    }
-
-    const shouldInstall =
-      yes || (yield* ui.confirm(`Run: ${plan.installCommand}?`, { defaultValue: true }));
-    if (!shouldInstall) {
-      yield* ui.log.warn('Installation cancelled.');
       return;
     }
 
@@ -446,14 +419,9 @@ const SKILLS_INSTALL_COMMAND = 'npx skills add composiohq/skills';
  * Runs the Composio skills installation step.
  * Uses `npx skills add composiohq/skills` to install coding-agent skills.
  */
-const runSkillsInstallStep = (params: {
-  config: InitConfig;
-  cwd: string;
-  dryRun: boolean;
-  yes: boolean;
-}) =>
+const runSkillsInstallStep = (params: { config: InitConfig; cwd: string; dryRun: boolean }) =>
   Effect.gen(function* () {
-    const { config, cwd, dryRun, yes } = params;
+    const { config, cwd, dryRun } = params;
     if (!config.installSkills) return;
 
     const ui = yield* TerminalUI;
@@ -461,13 +429,6 @@ const runSkillsInstallStep = (params: {
 
     if (dryRun) {
       yield* ui.note(SKILLS_INSTALL_COMMAND, 'Skills Install Command');
-      return;
-    }
-
-    const shouldInstall =
-      yes || (yield* ui.confirm(`Run: ${SKILLS_INSTALL_COMMAND}?`, { defaultValue: true }));
-    if (!shouldInstall) {
-      yield* ui.log.warn('Skills installation cancelled.');
       return;
     }
 
@@ -496,6 +457,58 @@ const runSkillsInstallStep = (params: {
           })
         )
       );
+  });
+
+// ---------------------------------------------------------------------------
+// Unified install confirmation — shows env vars, summary, then installs
+// ---------------------------------------------------------------------------
+
+/**
+ * Prints env vars (if available), shows an install summary, asks for a single
+ * confirmation, and runs both install steps. Skips the prompt entirely when
+ * there is nothing to install (no install plan AND no skills).
+ */
+const printEnvVarsAndInstall = (params: {
+  config: InitConfig;
+  envVars: ResolvedEnvVars | null;
+  cwd: string;
+  dryRun: boolean;
+  force: boolean;
+  yes: boolean;
+}) =>
+  Effect.gen(function* () {
+    const { config, envVars, cwd, dryRun, force, yes } = params;
+    const ui = yield* TerminalUI;
+
+    const hasWork = !!config.installPlan || config.installSkills;
+
+    // Always print env vars if available
+    if (envVars) {
+      yield* printEnvVars(envVars);
+    }
+
+    // Nothing to install — skip the confirmation prompt entirely
+    if (!hasWork) return;
+
+    // For non-dry-run: show install summary and ask for confirmation
+    if (!dryRun) {
+      const lines: string[] = [];
+      if (config.installPlan) lines.push(config.installPlan.installCommand);
+      if (config.installSkills) lines.push(SKILLS_INSTALL_COMMAND);
+      yield* ui.note(lines.join('\n'), 'Install commands');
+
+      if (!yes) {
+        const confirmed = yield* ui.confirm('Proceed with installation?', { defaultValue: true });
+        if (!confirmed) {
+          yield* ui.log.warn('Installation cancelled.');
+          return;
+        }
+      }
+    }
+
+    // Run install steps (dry-run is handled internally by each step)
+    yield* runInstallStep({ config, cwd, dryRun, force });
+    yield* runSkillsInstallStep({ config, cwd, dryRun });
   });
 
 // ---------------------------------------------------------------------------
@@ -715,11 +728,9 @@ export const initCmd = CliCommand.make(
             { ...selected, testUserId: Option.some(envVars.composioTestUserId) },
             config
           );
-          yield* printEnvVars(envVars);
         }
 
-        yield* runInstallStep({ config, cwd: proc.cwd, dryRun, force, yes });
-        yield* runSkillsInstallStep({ config, cwd: proc.cwd, dryRun, yes });
+        yield* printEnvVarsAndInstall({ config, envVars, cwd: proc.cwd, dryRun, force, yes });
 
         yield* ui.log.success(`Project initialized in ${composioDir}/`);
         yield* ui.output(makeOutputJson(selected, config, composioDir, envVars));
@@ -856,11 +867,9 @@ const initInteractiveFlow = (params: {
         { ...selected, testUserId: Option.some(envVars.composioTestUserId) },
         config
       );
-      yield* printEnvVars(envVars);
     }
 
-    yield* runInstallStep({ config, cwd: proc.cwd, dryRun, force, yes });
-    yield* runSkillsInstallStep({ config, cwd: proc.cwd, dryRun, yes });
+    yield* printEnvVarsAndInstall({ config, envVars, cwd: proc.cwd, dryRun, force, yes });
 
     yield* ui.log.success(`Project initialized in ${composioDir}/`);
     yield* ui.output(makeOutputJson(selected, config, composioDir, envVars));

--- a/ts/packages/cli/src/commands/init.cmd.ts
+++ b/ts/packages/cli/src/commands/init.cmd.ts
@@ -774,6 +774,7 @@ const resolveProjectEnvVars = (params: { selected: ProjectKeys }) =>
 
     const uakApiKey = yield* getGlobalUserApiKey();
     if (!uakApiKey) {
+      yield* Effect.logDebug('No global API key found; skipping .env.local creation.');
       return null;
     }
 

--- a/ts/packages/cli/src/commands/init.cmd.ts
+++ b/ts/packages/cli/src/commands/init.cmd.ts
@@ -86,7 +86,7 @@ const noSkillsOpt = Options.boolean('no-skills').pipe(
 // ---------------------------------------------------------------------------
 
 type UsageMode = 'native' | 'mcp';
-type NativeFramework = 'skip' | 'ai-sdk' | 'mastra' | 'openai-agents' | 'claude-agent-sdk';
+type NativeFramework = 'ai-sdk' | 'mastra' | 'openai-agents' | 'claude-agent-sdk';
 
 const USAGE_MODE_OPTIONS: ReadonlyArray<{
   value: UsageMode;
@@ -109,7 +109,6 @@ const NATIVE_FRAMEWORK_OPTIONS: ReadonlyArray<{
   value: NativeFramework;
   label: string;
 }> = [
-  { value: 'skip', label: 'Skip' },
   { value: 'ai-sdk', label: 'AI SDK' },
   { value: 'mastra', label: 'Mastra' },
   { value: 'openai-agents', label: 'OpenAI Agents' },
@@ -131,10 +130,8 @@ class InitConfigBuilder<T extends Record<string, unknown> = Record<string, never
     return new InitConfigBuilder({ ...this.data, usageMode: mode });
   }
 
-  withFramework(
-    fw: NativeFramework | undefined
-  ): InitConfigBuilder<T & { framework: NativeFramework | undefined }> {
-    return new InitConfigBuilder({ ...this.data, framework: fw });
+  withFrameworks(fws: NativeFramework[]): InitConfigBuilder<T & { frameworks: NativeFramework[] }> {
+    return new InitConfigBuilder({ ...this.data, frameworks: fws });
   }
 
   withInstallSkills(install: boolean): InitConfigBuilder<T & { installSkills: boolean }> {
@@ -157,7 +154,7 @@ class InitConfigBuilder<T extends Record<string, unknown> = Record<string, never
   build(
     this: InitConfigBuilder<{
       usageMode: UsageMode;
-      framework: NativeFramework | undefined;
+      frameworks: NativeFramework[];
       installSkills: boolean;
       detectedEnv: ProjectEnvironment | undefined;
       installPlan: CoreDependencyPlan | undefined;
@@ -165,7 +162,7 @@ class InitConfigBuilder<T extends Record<string, unknown> = Record<string, never
   ): InitConfig {
     return {
       usageMode: this.data.usageMode,
-      framework: this.data.framework,
+      frameworks: this.data.frameworks,
       installSkills: this.data.installSkills,
       detectedEnv: this.data.detectedEnv,
       installPlan: this.data.installPlan,
@@ -180,7 +177,7 @@ class InitConfigBuilder<T extends Record<string, unknown> = Record<string, never
 
 interface InitConfig {
   readonly usageMode: UsageMode;
-  readonly framework: NativeFramework | undefined;
+  readonly frameworks: NativeFramework[];
   readonly installSkills: boolean;
   readonly detectedEnv: ProjectEnvironment | undefined;
   readonly installPlan: CoreDependencyPlan | undefined;
@@ -264,13 +261,14 @@ const runInitWizard = (cwd: string, params: { noSkills: boolean }) =>
       USAGE_MODE_OPTIONS
     );
 
-    // Step 2: Framework (only for native tools)
-    const framework: NativeFramework | undefined =
+    // Step 2: Frameworks (only for native tools, multi-select)
+    const frameworks: NativeFramework[] =
       usageMode === 'native'
-        ? yield* ui
-            .select<NativeFramework>('Which framework do you use?', NATIVE_FRAMEWORK_OPTIONS)
-            .pipe(Effect.map(fw => (fw === 'skip' ? undefined : fw)))
-        : undefined;
+        ? yield* ui.multiSelect<NativeFramework>(
+            'Which frameworks do you use? (Space to select, Enter to confirm)',
+            NATIVE_FRAMEWORK_OPTIONS
+          )
+        : [];
 
     // Step 3: Install Composio skills (skip prompt when --no-skills)
     const installSkills = params.noSkills
@@ -298,7 +296,7 @@ const runInitWizard = (cwd: string, params: { noSkills: boolean }) =>
 
     return InitConfigBuilder.create()
       .withUsageMode(usageMode)
-      .withFramework(framework)
+      .withFrameworks(frameworks)
       .withInstallSkills(installSkills)
       .withDetectedEnv(detectedEnv)
       .withInstallPlan(installPlan)
@@ -316,8 +314,8 @@ const initConfigToJSON = (config: InitConfig): string => {
   const payload: Record<string, unknown> = {
     usage_mode: config.usageMode,
   };
-  if (config.framework) {
-    payload.framework = config.framework;
+  if (config.frameworks.length > 0) {
+    payload.frameworks = config.frameworks;
   }
   payload.install_skills = config.installSkills;
   if (config.detectedEnv) {
@@ -520,7 +518,7 @@ const makeOutputJson = (
     org_id: selected.orgId,
     project_id: selected.projectId,
     usage_mode: config.usageMode,
-    framework: config.framework ?? null,
+    frameworks: config.frameworks,
     install_skills: config.installSkills,
     detected_language: config.detectedEnv?.language ?? null,
     package_manager: config.detectedEnv?.packageManager ?? null,

--- a/ts/packages/cli/src/commands/init.cmd.ts
+++ b/ts/packages/cli/src/commands/init.cmd.ts
@@ -990,16 +990,18 @@ const runConfirmExecuteOutro = (params: {
       yield* ui.note(envLines.join('\n'), 'Environment variables');
     }
 
-    // Step 12: If dep install failed → show manual command
-    if (!outcome.depInstallOk && config.installPlan) {
-      yield* ui.log.warn('Dependency installation failed. Install manually:');
-      yield* ui.log.message(`  ${config.installPlan.installCommand}`);
-    }
+    // Steps 12-13: Show manual commands only when Phase 3 actually reached the install steps
+    // (i.e. config writes succeeded). Otherwise these steps were never attempted.
+    if (outcome.configWriteOk) {
+      if (!outcome.depInstallOk && config.installPlan) {
+        yield* ui.log.warn('Dependency installation failed. Install manually:');
+        yield* ui.log.message(`  ${config.installPlan.installCommand}`);
+      }
 
-    // Step 13: If skills install failed → show manual command
-    if (!outcome.skillsInstallOk) {
-      yield* ui.log.warn('Skills installation failed. Install manually:');
-      yield* ui.log.message(`  ${SKILLS_MANUAL_COMMAND}`);
+      if (!outcome.skillsInstallOk) {
+        yield* ui.log.warn('Skills installation failed. Install manually:');
+        yield* ui.log.message(`  ${SKILLS_MANUAL_COMMAND}`);
+      }
     }
 
     // Step 14: Final status

--- a/ts/packages/cli/src/commands/init.cmd.ts
+++ b/ts/packages/cli/src/commands/init.cmd.ts
@@ -433,7 +433,8 @@ const runInitWizard = (cwd: string, params: { noSkills: boolean; yes: boolean })
           ? NATIVE_FRAMEWORK_OPTIONS.map(o => o.value)
           : yield* ui.multiSelect<NativeFramework>(
               'Which frameworks do you use?',
-              NATIVE_FRAMEWORK_OPTIONS
+              NATIVE_FRAMEWORK_OPTIONS,
+              { required: true }
             )
         : [];
 

--- a/ts/packages/cli/src/commands/init.cmd.ts
+++ b/ts/packages/cli/src/commands/init.cmd.ts
@@ -40,7 +40,6 @@ import {
   detectInstalledAgents,
   ensureUniversalAgents,
   selectAgentsInteractive,
-  cancelSymbol,
   checkOverwrites,
   installAllSkills,
   buildInstallationResultDisplay,
@@ -77,7 +76,7 @@ import {
  *
  * - `--dry-run` — show summary without executing
  * - `--force` — reinstall even if dependency is already present
- * - `--yes` / `-y` — auto-select defaults, skip confirmation
+ * - `--yes` / `-y` — bypass all prompts with sensible defaults
  * - `--no-skills` — skip Composio skills installation
  */
 
@@ -104,7 +103,9 @@ const forceOpt = Options.boolean('force').pipe(
 const yesOpt = Options.boolean('yes').pipe(
   Options.withAlias('y'),
   Options.withDefault(false),
-  Options.withDescription('Auto-select default org/project, else first project')
+  Options.withDescription(
+    'Skip all prompts, use defaults (native mode, all frameworks, install skills)'
+  )
 );
 
 const noSkillsOpt = Options.boolean('no-skills').pipe(
@@ -263,55 +264,67 @@ const detectEnvironment = (cwd: string) =>
 const resolveInstallPlan = (cwd: string) =>
   detectCoreDependencyPlan(cwd).pipe(Effect.catchAll(() => Effect.succeed(null)));
 
+/** Best-effort cleanup of a temp directory. */
+const safeCleanupTempDir = (dir: string) =>
+  Effect.tryPromise(() => cleanupTempDir(dir)).pipe(Effect.catchAll(() => Effect.void));
+
 /**
  * Collects skills configuration interactively: clone repo, discover skills,
  * prompt for agents, scope, and method. Returns `undefined` if the user cancels
  * or if cloning/discovery fails.
+ *
+ * The cloned temp directory is registered with the current Effect `Scope` via
+ * `acquireRelease` — it is automatically cleaned up when the scope closes
+ * (on success, failure, cancellation, or interruption). Callers must wrap
+ * this in `Effect.scoped` to provide the scope.
  */
 const collectSkillsConfig = (params: { yes: boolean }) =>
   Effect.gen(function* () {
     const ui = yield* TerminalUI;
     const { yes } = params;
 
-    // 1. Clone composiohq/skills to temp dir
-    let tempDir: string;
-    try {
-      tempDir = yield* ui.withSpinner(
+    // 1. Clone composiohq/skills to temp dir (scoped — auto-cleaned when scope closes)
+    const tempDir = yield* Effect.acquireRelease(
+      ui.withSpinner(
         'Cloning Composio skills repository...',
         Effect.tryPromise(() => cloneSkillsRepo()),
         { successMessage: 'Skills repository cloned' }
-      );
-    } catch (e) {
-      yield* ui.log.error(
-        `Failed to clone skills repository: ${e instanceof Error ? e.message : String(e)}`
-      );
-      yield* ui.log.info(`You can install skills manually: ${SKILLS_MANUAL_COMMAND}`);
-      return undefined;
-    }
+      ),
+      dir => safeCleanupTempDir(dir)
+    ).pipe(
+      Effect.catchAll(e =>
+        Effect.gen(function* () {
+          yield* ui.log.error(
+            `Failed to clone skills repository: ${e instanceof Error ? e.message : String(e)}`
+          );
+          yield* ui.log.info(`You can install skills manually: ${SKILLS_MANUAL_COMMAND}`);
+          return undefined as string | undefined;
+        })
+      )
+    );
+    if (!tempDir) return undefined;
 
     // 2. Discover skills
-    let skills: Skill[];
-    try {
-      skills = yield* ui.withSpinner(
+    const skills = yield* ui
+      .withSpinner(
         'Discovering skills...',
         Effect.tryPromise(() => discoverSkills(tempDir)),
         { successMessage: (s: Skill[]) => `Found ${s.length} skill${s.length !== 1 ? 's' : ''}` }
+      )
+      .pipe(
+        Effect.catchAll(e =>
+          Effect.gen(function* () {
+            yield* ui.log.error(
+              `Failed to discover skills: ${e instanceof Error ? e.message : String(e)}`
+            );
+            return undefined as Skill[] | undefined;
+          })
+        )
       );
-    } catch (e) {
-      yield* ui.log.error(
-        `Failed to discover skills: ${e instanceof Error ? e.message : String(e)}`
-      );
-      yield* Effect.tryPromise(() => cleanupTempDir(tempDir)).pipe(
-        Effect.catchAll(() => Effect.void)
-      );
-      return undefined;
-    }
+    if (!skills) return undefined;
 
     if (skills.length === 0) {
       yield* ui.log.warn('No skills found in composiohq/skills.');
-      yield* Effect.tryPromise(() => cleanupTempDir(tempDir)).pipe(
-        Effect.catchAll(() => Effect.void)
-      );
       return undefined;
     }
 
@@ -328,15 +341,14 @@ const collectSkillsConfig = (params: { yes: boolean }) =>
         `Installing to: ${targetAgents.map(a => agents[a].displayName).join(', ')}`
       );
     } else {
-      const selected = yield* Effect.tryPromise(() => selectAgentsInteractive({ global: false }));
-      if (selected === cancelSymbol) {
+      const agentResult = yield* Effect.tryPromise(() =>
+        selectAgentsInteractive({ global: false })
+      );
+      if (!Array.isArray(agentResult)) {
         yield* ui.log.warn('Skills installation cancelled.');
-        yield* Effect.tryPromise(() => cleanupTempDir(tempDir)).pipe(
-          Effect.catchAll(() => Effect.void)
-        );
         return undefined;
       }
-      targetAgents = selected as AgentType[];
+      targetAgents = agentResult;
     }
 
     // 5. Scope selection
@@ -410,26 +422,29 @@ const runInitWizard = (cwd: string, params: { noSkills: boolean; yes: boolean })
     const ui = yield* TerminalUI;
 
     // Step 1: Usage mode
-    const usageMode = yield* ui.select<UsageMode>(
-      'How would you like to use Composio?',
-      USAGE_MODE_OPTIONS
-    );
+    const usageMode: UsageMode = params.yes
+      ? 'native'
+      : yield* ui.select<UsageMode>('How would you like to use Composio?', USAGE_MODE_OPTIONS);
 
     // Step 2: Frameworks (only for native tools, multi-select)
     const frameworks: NativeFramework[] =
       usageMode === 'native'
-        ? yield* ui.multiSelect<NativeFramework>(
-            'Which frameworks do you use?',
-            NATIVE_FRAMEWORK_OPTIONS
-          )
+        ? params.yes
+          ? NATIVE_FRAMEWORK_OPTIONS.map(o => o.value)
+          : yield* ui.multiSelect<NativeFramework>(
+              'Which frameworks do you use?',
+              NATIVE_FRAMEWORK_OPTIONS
+            )
         : [];
 
     // Step 3: Skills sub-wizard (skip entirely when --no-skills)
     let skillsConfig: SkillsConfig | undefined;
     if (!params.noSkills) {
-      const wantSkills = yield* ui.confirm('Install Composio skills for your Coding Agent?', {
-        defaultValue: true,
-      });
+      const wantSkills = params.yes
+        ? true
+        : yield* ui.confirm('Install Composio skills for your Coding Agent?', {
+            defaultValue: true,
+          });
       if (wantSkills) {
         skillsConfig = yield* collectSkillsConfig({ yes: params.yes });
       }
@@ -516,17 +531,25 @@ const buildUnifiedSummary = (projectName: string, config: InitConfig): string =>
 // File I/O helpers
 // ---------------------------------------------------------------------------
 
+interface InitConfigPayload {
+  usage_mode: UsageMode;
+  frameworks?: NativeFramework[];
+  install_skills: boolean;
+  detected_language?: string;
+  package_manager?: string;
+}
+
 /**
  * Serializes an `InitConfig` to the JSON payload written to `.composio/config.json`.
  */
 const initConfigToJSON = (config: InitConfig): string => {
-  const payload: Record<string, unknown> = {
+  const payload: InitConfigPayload = {
     usage_mode: config.usageMode,
+    install_skills: !!config.skillsConfig,
   };
   if (config.frameworks.length > 0) {
     payload.frameworks = config.frameworks;
   }
-  payload.install_skills = !!config.skillsConfig;
   if (config.detectedEnv) {
     payload.detected_language = config.detectedEnv.language;
     payload.package_manager = config.detectedEnv.packageManager;
@@ -571,7 +594,9 @@ const writeEnvLocal = (composioDir: string, envVars: ResolvedEnvVars) =>
     }
     lines.push(`COMPOSIO_TEST_USER_ID=${envVars.composioTestUserId}`);
     lines.push(''); // trailing newline
-    yield* fs.writeFileString(path.join(composioDir, '.env.local'), lines.join('\n'));
+    const envLocalPath = path.join(composioDir, '.env.local');
+    yield* fs.writeFileString(envLocalPath, lines.join('\n'));
+    yield* fs.chmod(envLocalPath, 0o600);
   });
 
 // ---------------------------------------------------------------------------
@@ -632,22 +657,20 @@ const runInstallStep = (params: { config: InitConfig; cwd: string; force: boolea
       }
     });
 
-    let ok = true;
-    yield* ui
+    return yield* ui
       .withSpinner(`Installing ${plan.dependency}...`, install, {
         successMessage: `Installed ${plan.dependency}.`,
         errorMessage: `Failed to install ${plan.dependency}.`,
       })
       .pipe(
+        Effect.map(() => true),
         Effect.catchAll(e =>
           Effect.gen(function* () {
             yield* ui.log.error(`Install failed: ${e instanceof Error ? e.message : String(e)}`);
-            ok = false;
+            return false;
           })
         )
       );
-
-    return ok;
   });
 
 /**
@@ -853,11 +876,6 @@ const runConfirmExecuteOutro = (params: {
       // Dry run: show summary and exit without writing anything
       if (dryRun) {
         yield* ui.log.info('Dry run complete — no changes made.');
-        if (config.skillsConfig) {
-          yield* Effect.tryPromise(() => cleanupTempDir(config.skillsConfig!.tempDir)).pipe(
-            Effect.catchAll(() => Effect.void)
-          );
-        }
         yield* ui.outro('');
         return;
       }
@@ -866,11 +884,6 @@ const runConfirmExecuteOutro = (params: {
       if (!yes) {
         const confirmed = yield* ui.confirm('Proceed with installation?', { defaultValue: true });
         if (!confirmed) {
-          if (config.skillsConfig) {
-            yield* Effect.tryPromise(() => cleanupTempDir(config.skillsConfig!.tempDir)).pipe(
-              Effect.catchAll(() => Effect.void)
-            );
-          }
           yield* ui.log.warn('Installation cancelled.');
           yield* ui.outro('');
           return;
@@ -880,79 +893,77 @@ const runConfirmExecuteOutro = (params: {
 
     // ── Phase 3: EXECUTE ──────────────────────────────────────────────
 
+    // Pessimistic defaults — flipped to true only on success.
+    // This ensures the safety net catchAll never masks failures as successes.
     const outcome: ExecutionOutcome = {
       envVars: null,
-      depInstallOk: true,
-      skillsInstallOk: true,
+      depInstallOk: !config.installPlan,
+      skillsInstallOk: !config.skillsConfig,
     };
 
-    // Ensure skills tempDir is cleaned up regardless of success/failure
-    const skillsTempDir = config.skillsConfig?.tempDir;
-    const cleanupSkills = skillsTempDir
-      ? Effect.tryPromise(() => cleanupTempDir(skillsTempDir)).pipe(
-          Effect.catchAll(() => Effect.void)
-        )
-      : Effect.void;
+    // Skills tempDir cleanup is handled by Effect.acquireRelease in collectSkillsConfig —
+    // it runs automatically when the surrounding Effect.scoped closes.
 
-    yield* Effect.ensuring(
-      Effect.gen(function* () {
-        // Step 6: Resolve API keys (lazy — first network call after confirmation)
-        outcome.envVars = yield* resolveProjectEnvVars({ selected }).pipe(
-          Effect.catchTag('services/HttpServerError', e =>
+    yield* Effect.gen(function* () {
+      // Step 6: Resolve API keys (lazy — first network call after confirmation)
+      outcome.envVars = yield* resolveProjectEnvVars({ selected }).pipe(
+        Effect.catchTag('services/HttpServerError', e =>
+          Effect.gen(function* () {
+            yield* Effect.logDebug('Failed to resolve project API key:', e);
+            yield* logEnvCreationHttpError(ui)(e);
+            return null;
+          })
+        ),
+        Effect.catchTag('services/HttpDecodingError', e =>
+          Effect.gen(function* () {
+            yield* Effect.logDebug('Failed to decode API key response:', e);
+            yield* logEnvCreationDecodingError(ui)(e);
+            return null;
+          })
+        )
+      );
+
+      // Step 7: Write project config (once, with testUserId if available)
+      const projectKeys = outcome.envVars
+        ? { ...selected, testUserId: Option.some(outcome.envVars.composioTestUserId) }
+        : selected;
+      yield* writeProjectConfig(composioDir, projectKeys, config);
+
+      // Step 8: Write .composio/.env.local
+      if (outcome.envVars) {
+        yield* writeEnvLocal(composioDir, outcome.envVars);
+      }
+
+      // Step 9: Install dependencies
+      if (config.installPlan) {
+        outcome.depInstallOk = yield* runInstallStep({ config, cwd, force }).pipe(
+          Effect.catchAll(() => Effect.succeed(false))
+        );
+      }
+
+      // Step 10: Install skills
+      if (config.skillsConfig) {
+        outcome.skillsInstallOk = yield* runSkillsExecuteStep({
+          skillsConfig: config.skillsConfig,
+          cwd,
+        }).pipe(
+          Effect.catchAll(e =>
             Effect.gen(function* () {
-              yield* Effect.logDebug('Failed to resolve project API key:', e);
-              yield* logEnvCreationHttpError(ui)(e);
-              return null;
-            })
-          ),
-          Effect.catchTag('services/HttpDecodingError', e =>
-            Effect.gen(function* () {
-              yield* Effect.logDebug('Failed to decode API key response:', e);
-              yield* logEnvCreationDecodingError(ui)(e);
-              return null;
+              yield* ui.log.error(
+                `Skills install failed: ${e instanceof Error ? e.message : String(e)}`
+              );
+              return false;
             })
           )
         );
-
-        // Step 7: Write project config (once, with testUserId if available)
-        const projectKeys = outcome.envVars
-          ? { ...selected, testUserId: Option.some(outcome.envVars.composioTestUserId) }
-          : selected;
-        yield* writeProjectConfig(composioDir, projectKeys, config);
-
-        // Step 8: Write .composio/.env.local
-        if (outcome.envVars) {
-          yield* writeEnvLocal(composioDir, outcome.envVars);
-        }
-
-        // Step 9: Install dependencies
-        if (config.installPlan) {
-          outcome.depInstallOk = yield* runInstallStep({ config, cwd, force }).pipe(
-            Effect.catchAll(() => Effect.succeed(false))
-          );
-        }
-
-        // Step 10: Install skills
-        if (config.skillsConfig) {
-          outcome.skillsInstallOk = yield* runSkillsExecuteStep({
-            skillsConfig: config.skillsConfig,
-            cwd,
-          }).pipe(
-            Effect.catchAll(e =>
-              Effect.gen(function* () {
-                yield* ui.log.error(
-                  `Skills install failed: ${e instanceof Error ? e.message : String(e)}`
-                );
-                return false;
-              })
-            )
-          );
-        }
-      }).pipe(
-        // Safety net: if anything unexpected escapes individual error handling
-        Effect.catchAll(() => Effect.void)
-      ),
-      cleanupSkills
+      }
+    }).pipe(
+      // Safety net: log if anything unexpected escapes individual error handling
+      Effect.catchAll(e =>
+        Effect.logWarning(
+          `Unexpected error during init execution: ${e instanceof Error ? e.message : String(e)}`
+        )
+      )
     );
 
     // ── Phase 4: OUTRO (always runs) ──────────────────────────────────
@@ -1043,20 +1054,22 @@ export const initCmd = CliCommand.make(
           testUserId: Option.none(),
         };
 
-        // Phase 1: COLLECT
-        const config = yield* runInitWizard(proc.cwd, { noSkills, yes });
-
-        // Phases 2-4: CONFIRM → EXECUTE → OUTRO
-        yield* runConfirmExecuteOutro({
-          selected,
-          projectDisplayName: projectId.value,
-          config,
-          composioDir,
-          cwd: proc.cwd,
-          dryRun,
-          force,
-          yes,
-        });
+        // Scope manages the skills tempDir lifetime (acquireRelease in collectSkillsConfig)
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            const config = yield* runInitWizard(proc.cwd, { noSkills, yes });
+            yield* runConfirmExecuteOutro({
+              selected,
+              projectDisplayName: projectId.value,
+              config,
+              composioDir,
+              cwd: proc.cwd,
+              dryRun,
+              force,
+              yes,
+            });
+          })
+        );
         return;
       }
 
@@ -1162,18 +1175,20 @@ const initInteractiveFlow = (params: {
     const selected = orgProjectToKeys(selectedProject);
     yield* ui.log.step(`Using project "${selectedProject.name}"`);
 
-    // Phase 1: COLLECT (wizard)
-    const config = yield* runInitWizard(proc.cwd, { noSkills, yes });
-
-    // Phases 2-4: CONFIRM → EXECUTE → OUTRO
-    yield* runConfirmExecuteOutro({
-      selected,
-      projectDisplayName: selectedProject.name,
-      config,
-      composioDir,
-      cwd: proc.cwd,
-      dryRun,
-      force,
-      yes,
-    });
+    // Scope manages the skills tempDir lifetime (acquireRelease in collectSkillsConfig)
+    yield* Effect.scoped(
+      Effect.gen(function* () {
+        const config = yield* runInitWizard(proc.cwd, { noSkills, yes });
+        yield* runConfirmExecuteOutro({
+          selected,
+          projectDisplayName: selectedProject.name,
+          config,
+          composioDir,
+          cwd: proc.cwd,
+          dryRun,
+          force,
+          yes,
+        });
+      })
+    );
   });

--- a/ts/packages/cli/src/commands/init.cmd.ts
+++ b/ts/packages/cli/src/commands/init.cmd.ts
@@ -607,6 +607,7 @@ const writeEnvLocal = (composioDir: string, envVars: ResolvedEnvVars) =>
 /** Tracks what succeeded and failed during Phase 3. */
 interface ExecutionOutcome {
   envVars: ResolvedEnvVars | null;
+  configWriteOk: boolean;
   depInstallOk: boolean;
   skillsInstallOk: boolean;
 }
@@ -898,6 +899,7 @@ const runConfirmExecuteOutro = (params: {
     // This ensures the safety net catchAll never masks failures as successes.
     const outcome: ExecutionOutcome = {
       envVars: null,
+      configWriteOk: false,
       depInstallOk: !config.installPlan,
       skillsInstallOk: !config.skillsConfig,
     };
@@ -934,6 +936,8 @@ const runConfirmExecuteOutro = (params: {
       if (outcome.envVars) {
         yield* writeEnvLocal(composioDir, outcome.envVars);
       }
+
+      outcome.configWriteOk = true;
 
       // Step 9: Install dependencies
       if (config.installPlan) {
@@ -997,9 +1001,15 @@ const runConfirmExecuteOutro = (params: {
       yield* ui.log.message(`  ${SKILLS_MANUAL_COMMAND}`);
     }
 
-    // Step 14: Success
-    yield* ui.log.success(`Project initialized in ${composioDir}/`);
-    yield* ui.output(makeOutputJson(selected, config, composioDir, outcome.envVars));
+    // Step 14: Final status
+    if (outcome.configWriteOk) {
+      yield* ui.log.success(`Project initialized in ${composioDir}/`);
+      yield* ui.output(makeOutputJson(selected, config, composioDir, outcome.envVars));
+    } else {
+      yield* ui.log.error(
+        `Initialization failed — config files could not be written to ${composioDir}/`
+      );
+    }
     yield* ui.outro('');
   });
 

--- a/ts/packages/cli/src/commands/init.cmd.ts
+++ b/ts/packages/cli/src/commands/init.cmd.ts
@@ -28,6 +28,25 @@ import {
   resolveCoreDependencyState,
   type CoreDependencyPlan,
 } from 'src/effects/core-dependency';
+import {
+  type AgentType,
+  type InstallMode,
+  type Skill,
+  agents,
+  cloneSkillsRepo,
+  cleanupTempDir,
+  SKILLS_MANUAL_COMMAND,
+  discoverSkills,
+  detectInstalledAgents,
+  ensureUniversalAgents,
+  selectAgentsInteractive,
+  cancelSymbol,
+  checkOverwrites,
+  buildInstallationSummary,
+  installAllSkills,
+  buildInstallationResultDisplay,
+  formatList,
+} from 'src/skills';
 
 /**
  * `composio init` — Initialize a Composio project in the current directory.
@@ -245,7 +264,7 @@ const runInitWizard = (cwd: string, params: { noSkills: boolean }) =>
     const frameworks: NativeFramework[] =
       usageMode === 'native'
         ? yield* ui.multiSelect<NativeFramework>(
-            'Which frameworks do you use? (Space to select, Enter to confirm)',
+            'Which frameworks do you use?',
             NATIVE_FRAMEWORK_OPTIONS
           )
         : [];
@@ -410,53 +429,189 @@ const runInstallStep = (params: {
   });
 
 // ---------------------------------------------------------------------------
-// Skills install step — runs `npx skills add composiohq/skills`
+// Skills install step — inline installation from composiohq/skills
 // ---------------------------------------------------------------------------
-
-const SKILLS_INSTALL_COMMAND = 'npx skills add composiohq/skills';
 
 /**
  * Runs the Composio skills installation step.
- * Uses `npx skills add composiohq/skills` to install coding-agent skills.
+ * Clones composiohq/skills, discovers skills, prompts for agents/scope/method,
+ * shows summary, confirms, and installs.
  */
-const runSkillsInstallStep = (params: { config: InitConfig; cwd: string; dryRun: boolean }) =>
+const runSkillsInstallStep = (params: {
+  config: InitConfig;
+  cwd: string;
+  dryRun: boolean;
+  yes: boolean;
+}) =>
   Effect.gen(function* () {
-    const { config, cwd, dryRun } = params;
+    const { config, cwd, dryRun, yes } = params;
     if (!config.installSkills) return;
 
     const ui = yield* TerminalUI;
-    const runner = yield* CommandRunner;
 
-    if (dryRun) {
-      yield* ui.note(SKILLS_INSTALL_COMMAND, 'Skills Install Command');
+    // 1. Clone composiohq/skills to temp dir
+    let tempDir: string;
+    try {
+      tempDir = yield* ui.withSpinner(
+        'Cloning Composio skills repository...',
+        Effect.tryPromise(() => cloneSkillsRepo()),
+        { successMessage: 'Skills repository cloned' }
+      );
+    } catch (e) {
+      yield* ui.log.error(
+        `Failed to clone skills repository: ${e instanceof Error ? e.message : String(e)}`
+      );
+      yield* ui.log.info(`You can install skills manually: ${SKILLS_MANUAL_COMMAND}`);
       return;
     }
 
-    const [cmd, ...args] = SKILLS_INSTALL_COMMAND.split(' ');
-    const command = PlatformCommand.make(cmd!, ...args).pipe(PlatformCommand.workingDirectory(cwd));
+    const doInstall = Effect.gen(function* () {
+      // 2. Discover skills
+      const skills = yield* ui.withSpinner(
+        'Discovering skills...',
+        Effect.tryPromise(() => discoverSkills(tempDir)),
+        { successMessage: (s: Skill[]) => `Found ${s.length} skill${s.length !== 1 ? 's' : ''}` }
+      );
 
-    const install = Effect.gen(function* () {
-      const exitCode = yield* runner.run(command);
-      if (exitCode !== 0) {
-        yield* Effect.fail(new Error(`Skills install command failed with exit code ${exitCode}`));
+      if (skills.length === 0) {
+        yield* ui.log.warn('No skills found in composiohq/skills.');
+        return;
+      }
+
+      // 3. Detect installed agents
+      const installedAgents = yield* Effect.tryPromise(() => detectInstalledAgents());
+
+      // 4. Agent selection
+      let targetAgents: AgentType[];
+      if (yes) {
+        targetAgents = ensureUniversalAgents(
+          installedAgents.length > 0 ? installedAgents : (Object.keys(agents) as AgentType[])
+        );
+        yield* ui.log.info(
+          `Installing to: ${targetAgents.map(a => agents[a].displayName).join(', ')}`
+        );
+      } else {
+        const selected = yield* Effect.tryPromise(() => selectAgentsInteractive({ global: false }));
+        if (selected === cancelSymbol) {
+          yield* ui.log.warn('Skills installation cancelled.');
+          return;
+        }
+        targetAgents = selected as AgentType[];
+      }
+
+      // 5. Scope selection
+      let installGlobally: boolean;
+      if (yes) {
+        installGlobally = false;
+      } else {
+        installGlobally = yield* ui.select<boolean>('Installation scope', [
+          {
+            value: false,
+            label: 'Project',
+            hint: 'Install in current directory (committed with your project)',
+          },
+          {
+            value: true,
+            label: 'Global',
+            hint: 'Install in home directory (available across all projects)',
+          },
+        ]);
+      }
+
+      // 6. Method selection
+      let installMode: InstallMode;
+      if (yes) {
+        installMode = 'symlink';
+      } else {
+        installMode = yield* ui.select<InstallMode>('Installation method', [
+          {
+            value: 'symlink',
+            label: 'Symlink (Recommended)',
+            hint: 'Single source of truth, easy updates',
+          },
+          {
+            value: 'copy',
+            label: 'Copy to all agents',
+            hint: 'Independent copies for each agent',
+          },
+        ]);
+      }
+
+      // 7. Check for overwrites + build summary
+      const overwriteStatus = yield* Effect.tryPromise(() =>
+        checkOverwrites(skills, targetAgents, { global: installGlobally })
+      );
+
+      const summaryLines = buildInstallationSummary(
+        skills,
+        targetAgents,
+        installMode,
+        installGlobally,
+        cwd,
+        overwriteStatus
+      );
+      yield* ui.note(summaryLines.join('\n'), 'Installation Summary');
+
+      // 8. Dry run — show summary and exit
+      if (dryRun) {
+        yield* ui.log.info('Dry run — no changes made.');
+        return;
+      }
+
+      // 9. Confirm
+      const confirmed =
+        yes || (yield* ui.confirm('Proceed with installation?', { defaultValue: true }));
+      if (!confirmed) {
+        yield* ui.log.warn('Skills installation cancelled.');
+        return;
+      }
+
+      // 10. Install skills
+      const results = yield* ui.withSpinner(
+        'Installing skills...',
+        Effect.tryPromise(() =>
+          installAllSkills(skills, targetAgents, {
+            global: installGlobally,
+            mode: installMode,
+            cwd,
+          })
+        ),
+        {
+          successMessage: 'Installation complete',
+          errorMessage: 'Failed to install skills',
+        }
+      );
+
+      // 11. Display results
+      const display = buildInstallationResultDisplay(results, targetAgents, cwd);
+
+      if (display.resultNoteLines.length > 0) {
+        yield* ui.note(display.resultNoteLines.join('\n'), display.resultNoteTitle);
+      }
+      if (display.symlinkWarning) {
+        yield* ui.log.warn(`Symlinks failed for: ${formatList(display.symlinkWarning.agents)}`);
+        yield* ui.log.message(
+          '  Files were copied instead. On Windows, enable Developer Mode for symlink support.'
+        );
+      }
+      for (const line of display.failedLines) {
+        yield* ui.log.error(line);
       }
     });
 
-    yield* ui
-      .withSpinner('Installing Composio skills...', install, {
-        successMessage: 'Installed Composio skills.',
-        errorMessage: 'Failed to install Composio skills.',
-      })
-      .pipe(
+    yield* Effect.ensuring(
+      doInstall.pipe(
         Effect.catchAll(e =>
           Effect.gen(function* () {
             yield* ui.log.error(
               `Skills install failed: ${e instanceof Error ? e.message : String(e)}`
             );
-            yield* ui.log.info(`You can install manually: ${SKILLS_INSTALL_COMMAND}`);
+            yield* ui.log.info(`You can install manually: ${SKILLS_MANUAL_COMMAND}`);
           })
         )
-      );
+      ),
+      Effect.tryPromise(() => cleanupTempDir(tempDir)).pipe(Effect.catchAll(() => Effect.void))
+    );
   });
 
 // ---------------------------------------------------------------------------
@@ -490,12 +645,9 @@ const printEnvVarsAndInstall = (params: {
     // Nothing to install — skip the confirmation prompt entirely
     if (!hasWork) return;
 
-    // For non-dry-run: show install summary and ask for confirmation
-    if (!dryRun) {
-      const lines: string[] = [];
-      if (config.installPlan) lines.push(config.installPlan.installCommand);
-      if (config.installSkills) lines.push(SKILLS_INSTALL_COMMAND);
-      yield* ui.note(lines.join('\n'), 'Install commands');
+    // For non-dry-run: show install summary and ask for confirmation (dep install only)
+    if (!dryRun && config.installPlan) {
+      yield* ui.note(config.installPlan.installCommand, 'Install commands');
 
       if (!yes) {
         const confirmed = yield* ui.confirm('Proceed with installation?', { defaultValue: true });
@@ -508,7 +660,8 @@ const printEnvVarsAndInstall = (params: {
 
     // Run install steps (dry-run is handled internally by each step)
     yield* runInstallStep({ config, cwd, dryRun, force });
-    yield* runSkillsInstallStep({ config, cwd, dryRun });
+    // Skills step has its own interactive prompts (agents, scope, method, confirm)
+    yield* runSkillsInstallStep({ config, cwd, dryRun, yes });
   });
 
 // ---------------------------------------------------------------------------

--- a/ts/packages/cli/src/commands/init.cmd.ts
+++ b/ts/packages/cli/src/commands/init.cmd.ts
@@ -16,6 +16,7 @@ import * as constants from 'src/constants';
 import { TerminalUI } from 'src/services/terminal-ui';
 import { browserLogin, noBrowser as noBrowserOpt } from 'src/commands/login.cmd';
 import { setupCacheDir } from 'src/effects/setup-cache-dir';
+import { redact } from 'src/ui/redact';
 
 /**
  * `composio init` — Initialize a Composio project in the current directory.
@@ -76,11 +77,17 @@ const writeProjectConfig = (composioDir: string, selected: ProjectKeys) =>
 // Structured output helper
 // ---------------------------------------------------------------------------
 
-const makeOutputJson = (selected: ProjectKeys, composioDir: string) =>
+const makeOutputJson = (
+  selected: ProjectKeys,
+  composioDir: string,
+  envVars?: ResolvedEnvVars | null
+) =>
   JSON.stringify({
     org_id: selected.orgId,
     project_id: selected.projectId,
     path: composioDir,
+    ...(envVars?.composioApiKey ? { composio_api_key: envVars.composioApiKey } : {}),
+    ...(envVars ? { composio_test_user_id: envVars.composioTestUserId } : {}),
   });
 
 const getGlobalUserApiKey = () =>
@@ -98,33 +105,20 @@ const getGlobalUserApiKey = () =>
     return Option.getOrUndefined(parsed.value.apiKey);
   });
 
-const upsertEnvVar = (content: string, key: string, value: string): string => {
-  const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const line = `${key}=${value}`;
-  const pattern = new RegExp(`^${escapedKey}=.*$`, 'm');
-  if (pattern.test(content)) {
-    return content.replace(pattern, line);
-  }
-  return content.trim().length ? `${content.trimEnd()}\n${line}\n` : `${line}\n`;
-};
+/** Resolved credentials to be printed and included in structured output. */
+interface ResolvedEnvVars {
+  readonly composioApiKey: string | null;
+  readonly composioTestUserId: string;
+}
 
-const ensureProjectApiKeyInEnv = (params: { cwd: string; selected: ProjectKeys }) =>
+const resolveProjectEnvVars = (params: { selected: ProjectKeys }) =>
   Effect.gen(function* () {
-    const { cwd, selected } = params;
-    const ui = yield* TerminalUI;
-    const fs = yield* FileSystem.FileSystem;
+    const { selected } = params;
     const ctx = yield* ComposioUserContext;
-
-    const envPath = path.join(cwd, '.env.local');
-    const envExists = yield* fs.exists(envPath);
-    const existingEnvContent = envExists ? yield* fs.readFileString(envPath, 'utf8') : '';
-    const hasProjectApiKey = /^COMPOSIO_API_KEY=.*/m.test(existingEnvContent);
-    const hasTestUserId = /^COMPOSIO_TEST_USER_ID=.*/m.test(existingEnvContent);
 
     const uakApiKey = yield* getGlobalUserApiKey();
     if (!uakApiKey) {
-      yield* ui.log.warn('No global API key found; skipping .env.local creation.');
-      return;
+      return null;
     }
 
     const sessionInfo = yield* getSessionInfo({
@@ -135,7 +129,7 @@ const ensureProjectApiKeyInEnv = (params: { cwd: string; selected: ProjectKeys }
     });
 
     let projectApiKey = sessionInfo.api_key?.api_key ?? sessionInfo.api_key?.key ?? null;
-    if (!projectApiKey && !hasProjectApiKey) {
+    if (!projectApiKey) {
       const dateSuffix = new Date().toISOString().slice(0, 10);
       projectApiKey = yield* createProjectApiKey({
         baseURL: ctx.data.baseURL,
@@ -148,37 +142,32 @@ const ensureProjectApiKeyInEnv = (params: { cwd: string; selected: ProjectKeys }
 
     const sessionUserId = sessionInfo.org_member.user_id ?? sessionInfo.org_member.id;
     const composioTestUserId = `pg-test-${sessionUserId}`;
-    const composioDir = path.join(cwd, constants.PROJECT_COMPOSIO_DIR);
 
-    let nextEnvContent = existingEnvContent;
-    if (!hasProjectApiKey && projectApiKey) {
-      nextEnvContent = upsertEnvVar(nextEnvContent, 'COMPOSIO_API_KEY', projectApiKey);
-    }
-    if (!hasTestUserId) {
-      nextEnvContent = upsertEnvVar(nextEnvContent, 'COMPOSIO_TEST_USER_ID', composioTestUserId);
-    }
+    return { composioApiKey: projectApiKey, composioTestUserId };
+  });
 
-    if (nextEnvContent !== existingEnvContent) {
-      yield* fs.writeFileString(envPath, nextEnvContent);
-    }
-    yield* writeProjectConfig(composioDir, {
-      ...selected,
-      testUserId: Option.some(composioTestUserId),
-    });
-    if (nextEnvContent !== existingEnvContent) {
-      yield* ui.log.step(
-        envExists
-          ? 'Updated .env.local with Composio credentials'
-          : 'Created .env.local with Composio credentials'
+const printEnvVars = (envVars: ResolvedEnvVars) =>
+  Effect.gen(function* () {
+    const ui = yield* TerminalUI;
+
+    const redactedLines: string[] = [];
+    if (envVars.composioApiKey) {
+      redactedLines.push(
+        `COMPOSIO_API_KEY=${redact({ value: envVars.composioApiKey, prefix: 'ak_' })}`
       );
     }
+    redactedLines.push(
+      `COMPOSIO_TEST_USER_ID=${redact({ value: envVars.composioTestUserId, prefix: 'pr_' })}`
+    );
+
+    yield* ui.note(redactedLines.join('\n'), 'Environment variables');
   });
 
 const logEnvCreationHttpError =
   (ui: TerminalUI) =>
   (e: { status?: number; details?: { message: string; suggestedFix: string }; cause?: unknown }) =>
     Effect.gen(function* () {
-      yield* ui.log.warn('Could not create .env.local from session info.');
+      yield* ui.log.warn('Could not resolve environment variables from session info.');
       if (e.status) {
         yield* ui.log.error(`HTTP ${e.status}`);
       }
@@ -192,7 +181,7 @@ const logEnvCreationHttpError =
 
 const logEnvCreationDecodingError = (ui: TerminalUI) => (e: { cause?: unknown }) =>
   Effect.gen(function* () {
-    yield* ui.log.warn('Could not decode API key response; skipping .env.local creation.');
+    yield* ui.log.warn('Could not decode API key response; skipping environment variable display.');
     if (e.cause) {
       yield* ui.log.error(String(e.cause));
     }
@@ -261,23 +250,33 @@ export const initCmd = CliCommand.make(
         };
 
         yield* writeProjectConfig(composioDir, selected);
-        yield* ensureProjectApiKeyInEnv({ cwd: proc.cwd, selected }).pipe(
+        const envVars = yield* resolveProjectEnvVars({ selected }).pipe(
           Effect.catchTag('services/HttpServerError', e =>
             Effect.gen(function* () {
               yield* Effect.logDebug('Failed to resolve project API key from session/info:', e);
               yield* logEnvCreationHttpError(ui)(e);
+              return null;
             })
           ),
           Effect.catchTag('services/HttpDecodingError', e =>
             Effect.gen(function* () {
               yield* Effect.logDebug('Failed to decode API key response:', e);
               yield* logEnvCreationDecodingError(ui)(e);
+              return null;
             })
           )
         );
 
+        if (envVars) {
+          yield* writeProjectConfig(composioDir, {
+            ...selected,
+            testUserId: Option.some(envVars.composioTestUserId),
+          });
+          yield* printEnvVars(envVars);
+        }
+
         yield* ui.log.success(`Project initialized in ${composioDir}/`);
-        yield* ui.output(makeOutputJson(selected, composioDir));
+        yield* ui.output(makeOutputJson(selected, composioDir, envVars));
         yield* ui.outro('');
         return;
       }
@@ -295,7 +294,6 @@ const initInteractiveFlow = (params: { composioDir: string; noBrowser: boolean; 
     const { composioDir, noBrowser, yes } = params;
     const ui = yield* TerminalUI;
     const ctx = yield* ComposioUserContext;
-    const proc = yield* NodeProcess;
 
     // 1. Ensure global user API key exists (ignore local/project keys).
     let globalApiKey = yield* getGlobalUserApiKey();
@@ -379,22 +377,32 @@ const initInteractiveFlow = (params: { composioDir: string; noBrowser: boolean; 
 
     // 4. Write project config
     yield* writeProjectConfig(composioDir, selected);
-    yield* ensureProjectApiKeyInEnv({ cwd: proc.cwd, selected }).pipe(
+    const envVars = yield* resolveProjectEnvVars({ selected }).pipe(
       Effect.catchTag('services/HttpServerError', e =>
         Effect.gen(function* () {
           yield* Effect.logDebug('Failed to resolve project API key from session/info:', e);
           yield* logEnvCreationHttpError(ui)(e);
+          return null;
         })
       ),
       Effect.catchTag('services/HttpDecodingError', e =>
         Effect.gen(function* () {
           yield* Effect.logDebug('Failed to decode API key response:', e);
           yield* logEnvCreationDecodingError(ui)(e);
+          return null;
         })
       )
     );
 
+    if (envVars) {
+      yield* writeProjectConfig(composioDir, {
+        ...selected,
+        testUserId: Option.some(envVars.composioTestUserId),
+      });
+      yield* printEnvVars(envVars);
+    }
+
     yield* ui.log.success(`Project initialized in ${composioDir}/`);
-    yield* ui.output(makeOutputJson(selected, composioDir));
+    yield* ui.output(makeOutputJson(selected, composioDir, envVars));
     yield* ui.outro('');
   });

--- a/ts/packages/cli/src/commands/init.cmd.ts
+++ b/ts/packages/cli/src/commands/init.cmd.ts
@@ -872,22 +872,22 @@ const runConfirmExecuteOutro = (params: {
     if (hasWork) {
       const summary = buildUnifiedSummary(projectDisplayName, config);
       yield* ui.note(summary, 'Installation Summary');
+    }
 
-      // Dry run: show summary and exit without writing anything
-      if (dryRun) {
-        yield* ui.log.info('Dry run complete — no changes made.');
+    // Dry run: show summary (if any) and exit without writing anything
+    if (dryRun) {
+      yield* ui.log.info('Dry run complete — no changes made.');
+      yield* ui.outro('');
+      return;
+    }
+
+    if (hasWork && !yes) {
+      // Confirm (skip when --yes)
+      const confirmed = yield* ui.confirm('Proceed with installation?', { defaultValue: true });
+      if (!confirmed) {
+        yield* ui.log.warn('Installation cancelled.');
         yield* ui.outro('');
         return;
-      }
-
-      // Confirm (skip when --yes)
-      if (!yes) {
-        const confirmed = yield* ui.confirm('Proceed with installation?', { defaultValue: true });
-        if (!confirmed) {
-          yield* ui.log.warn('Installation cancelled.');
-          yield* ui.outro('');
-          return;
-        }
       }
     }
 

--- a/ts/packages/cli/src/commands/init.cmd.ts
+++ b/ts/packages/cli/src/commands/init.cmd.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { Command as CliCommand, Options } from '@effect/cli';
+import { Command as PlatformCommand } from '@effect/platform';
 import { Effect, Option } from 'effect';
 import { FileSystem } from '@effect/platform';
 import { ComposioUserContext } from 'src/services/user-context';
@@ -17,6 +18,16 @@ import { TerminalUI } from 'src/services/terminal-ui';
 import { browserLogin, noBrowser as noBrowserOpt } from 'src/commands/login.cmd';
 import { setupCacheDir } from 'src/effects/setup-cache-dir';
 import { redact } from 'src/ui/redact';
+import {
+  ProjectEnvironmentDetector,
+  type ProjectEnvironment,
+} from 'src/services/project-environment-detector';
+import { CommandRunner } from 'src/services/command-runner';
+import {
+  detectCoreDependencyPlan,
+  resolveCoreDependencyState,
+  type CoreDependencyPlan,
+} from 'src/effects/core-dependency';
 
 /**
  * `composio init` — Initialize a Composio project in the current directory.
@@ -24,11 +35,19 @@ import { redact } from 'src/ui/redact';
  * ## Behavior
  *
  * 1. **Project selection** — fetches projects from the API or accepts `--org-id`/`--project-id`.
- * 2. **Writes config** — saves `<cwd>/.composio/project.json`.
+ * 2. **Usage mode** — asks "Native tools" vs "Composio MCP".
+ * 3. **Framework** — if native, asks which agent framework.
+ * 4. **Coding-agent skills** — asks whether to install Composio skills.
+ * 5. **Environment detection** — detects language (TS/Python) and package manager.
+ * 6. **Dependency installation** — installs `@composio/core` or `composio` via detected PM.
+ * 7. **Writes config** — saves `<cwd>/.composio/project.json` and `<cwd>/.composio/config.json`.
  *
  * ## Flags
  *
+ * - `--dry-run` — print install command without executing
+ * - `--force` — reinstall even if dependency is already present
  * - `--yes` / `-y` — auto-select the first project from the list
+ * - `--no-skills` — skip Composio skills installation
  */
 
 const orgIdOpt = Options.text('org-id').pipe(
@@ -41,17 +60,275 @@ const projectIdOpt = Options.text('project-id').pipe(
   Options.withDescription('Project ID (skip interactive picker)')
 );
 
+const dryRunOpt = Options.boolean('dry-run').pipe(
+  Options.withDefault(false),
+  Options.withDescription('Print install command without executing it')
+);
+
+const forceOpt = Options.boolean('force').pipe(
+  Options.withDefault(false),
+  Options.withDescription('Reinstall even if dependency appears installed')
+);
+
 const yesOpt = Options.boolean('yes').pipe(
   Options.withAlias('y'),
   Options.withDefault(false),
   Options.withDescription('Auto-select default org/project, else first project')
 );
 
+const noSkillsOpt = Options.boolean('no-skills').pipe(
+  Options.withDefault(false),
+  Options.withDescription('Skip Composio skills installation')
+);
+
+// ---------------------------------------------------------------------------
+// Init config types and options
+// ---------------------------------------------------------------------------
+
+type UsageMode = 'native' | 'mcp';
+type NativeFramework = 'skip' | 'ai-sdk' | 'mastra' | 'openai-agents' | 'claude-agent-sdk';
+
+const USAGE_MODE_OPTIONS: ReadonlyArray<{
+  value: UsageMode;
+  label: string;
+  hint: string;
+}> = [
+  {
+    value: 'native',
+    label: 'Native tools',
+    hint: 'Use with Agent frameworks: AI SDK, Mastra, etc.',
+  },
+  {
+    value: 'mcp',
+    label: 'Composio MCP',
+    hint: 'Use Composio tools via MCP',
+  },
+];
+
+const NATIVE_FRAMEWORK_OPTIONS: ReadonlyArray<{
+  value: NativeFramework;
+  label: string;
+}> = [
+  { value: 'skip', label: 'Skip' },
+  { value: 'ai-sdk', label: 'AI SDK' },
+  { value: 'mastra', label: 'Mastra' },
+  { value: 'openai-agents', label: 'OpenAI Agents' },
+  { value: 'claude-agent-sdk', label: 'Claude Agent SDK' },
+];
+
+// ---------------------------------------------------------------------------
+// InitConfig — type-safe builder for the init wizard answers
+// ---------------------------------------------------------------------------
+
+class InitConfigBuilder<T extends Record<string, unknown> = Record<string, never>> {
+  private constructor(private readonly data: T) {}
+
+  static create(): InitConfigBuilder {
+    return new InitConfigBuilder({});
+  }
+
+  withUsageMode(mode: UsageMode): InitConfigBuilder<T & { usageMode: UsageMode }> {
+    return new InitConfigBuilder({ ...this.data, usageMode: mode });
+  }
+
+  withFramework(
+    fw: NativeFramework | undefined
+  ): InitConfigBuilder<T & { framework: NativeFramework | undefined }> {
+    return new InitConfigBuilder({ ...this.data, framework: fw });
+  }
+
+  withInstallSkills(install: boolean): InitConfigBuilder<T & { installSkills: boolean }> {
+    return new InitConfigBuilder({ ...this.data, installSkills: install });
+  }
+
+  withDetectedEnv(
+    env: ProjectEnvironment | undefined
+  ): InitConfigBuilder<T & { detectedEnv: ProjectEnvironment | undefined }> {
+    return new InitConfigBuilder({ ...this.data, detectedEnv: env });
+  }
+
+  withInstallPlan(
+    plan: CoreDependencyPlan | undefined
+  ): InitConfigBuilder<T & { installPlan: CoreDependencyPlan | undefined }> {
+    return new InitConfigBuilder({ ...this.data, installPlan: plan });
+  }
+
+  /** Extract the final config. Only callable when all required fields are present. */
+  build(
+    this: InitConfigBuilder<{
+      usageMode: UsageMode;
+      framework: NativeFramework | undefined;
+      installSkills: boolean;
+      detectedEnv: ProjectEnvironment | undefined;
+      installPlan: CoreDependencyPlan | undefined;
+    }>
+  ): InitConfig {
+    return {
+      usageMode: this.data.usageMode,
+      framework: this.data.framework,
+      installSkills: this.data.installSkills,
+      detectedEnv: this.data.detectedEnv,
+      installPlan: this.data.installPlan,
+    };
+  }
+
+  /** Read accumulated data (for intermediate access). */
+  get value(): T {
+    return this.data;
+  }
+}
+
+interface InitConfig {
+  readonly usageMode: UsageMode;
+  readonly framework: NativeFramework | undefined;
+  readonly installSkills: boolean;
+  readonly detectedEnv: ProjectEnvironment | undefined;
+  readonly installPlan: CoreDependencyPlan | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Init wizard — collects all answers via the builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect the project environment. Returns `undefined` if detection fails
+ * (logs a warning but does not abort the wizard).
+ */
+const detectEnvironment = (cwd: string) =>
+  Effect.gen(function* () {
+    const ui = yield* TerminalUI;
+    const envDetector = yield* ProjectEnvironmentDetector;
+
+    return yield* envDetector.detectProjectEnvironment(cwd).pipe(
+      Effect.tap(env => ui.log.step(`Detected: ${env.language} (${env.packageManager})`)),
+      Effect.catchTag('services/ProjectEnvironmentDetectorError', e =>
+        Effect.gen(function* () {
+          yield* ui.log.warn(e.message);
+          if (e.details) yield* ui.log.info(e.details);
+          yield* ui.log.info('Skipping dependency installation.');
+          return undefined;
+        })
+      )
+    );
+  });
+
+/**
+ * Resolve the install plan for the detected environment.
+ * Only determines WHAT to install (no version checking or shell commands).
+ * Version checking is deferred to `runInstallStep`.
+ */
+const resolveInstallPlan = (cwd: string) =>
+  detectCoreDependencyPlan(cwd).pipe(Effect.catchAll(() => Effect.succeed(null)));
+
+/**
+ * After detecting the project environment and resolving an install plan,
+ * ask the user to confirm the detected package manager or skip installation.
+ * Returns the plan if confirmed, `undefined` if skipped.
+ */
+const confirmInstallPlan = (plan: CoreDependencyPlan) =>
+  Effect.gen(function* () {
+    const ui = yield* TerminalUI;
+
+    type PmChoice = 'confirm' | 'skip';
+    const choice = yield* ui.select<PmChoice>(
+      `Install ${plan.dependency} using ${plan.packageManager}?`,
+      [
+        { value: 'confirm' as PmChoice, label: plan.packageManager, hint: plan.installCommand },
+        { value: 'skip' as PmChoice, label: 'Skip' },
+      ]
+    );
+
+    return choice === 'confirm' ? plan : undefined;
+  });
+
+/**
+ * Runs the interactive init wizard.
+ *
+ * Steps:
+ * 1. Usage mode — "Native tools" or "Composio MCP"
+ * 2. Framework — which agent framework (only if native)
+ * 3. Install skills — whether to install Composio coding-agent skills
+ * 4. Detect project environment (only if native)
+ * 5. Resolve + confirm install plan (only if native and environment detected)
+ *
+ * All inputs are collected through the builder before any side effects run.
+ * Returns a fully-built `InitConfig`.
+ */
+const runInitWizard = (cwd: string, params: { noSkills: boolean }) =>
+  Effect.gen(function* () {
+    const ui = yield* TerminalUI;
+
+    // Step 1: Usage mode
+    const usageMode = yield* ui.select<UsageMode>(
+      'How would you like to use Composio?',
+      USAGE_MODE_OPTIONS
+    );
+
+    // Step 2: Framework (only for native tools)
+    const framework: NativeFramework | undefined =
+      usageMode === 'native'
+        ? yield* ui
+            .select<NativeFramework>('Which framework do you use?', NATIVE_FRAMEWORK_OPTIONS)
+            .pipe(Effect.map(fw => (fw === 'skip' ? undefined : fw)))
+        : undefined;
+
+    // Step 3: Install Composio skills (skip prompt when --no-skills)
+    const installSkills = params.noSkills
+      ? false
+      : yield* ui.confirm('Install Composio skills for your Coding Agent?', {
+          defaultValue: true,
+        });
+
+    // Steps 4+5: Detect environment + confirm install plan (only for native tools)
+    let detectedEnv: ProjectEnvironment | undefined;
+    let installPlan: CoreDependencyPlan | undefined;
+
+    if (usageMode === 'native') {
+      // Step 4: Detect project environment
+      detectedEnv = yield* detectEnvironment(cwd);
+
+      // Step 5: Resolve install plan and confirm package manager
+      if (detectedEnv) {
+        const plan = yield* resolveInstallPlan(cwd);
+        if (plan) {
+          installPlan = yield* confirmInstallPlan(plan);
+        }
+      }
+    }
+
+    return InitConfigBuilder.create()
+      .withUsageMode(usageMode)
+      .withFramework(framework)
+      .withInstallSkills(installSkills)
+      .withDetectedEnv(detectedEnv)
+      .withInstallPlan(installPlan)
+      .build();
+  });
+
 // ---------------------------------------------------------------------------
 // File I/O helpers
 // ---------------------------------------------------------------------------
-/** Writes project keys to `<cwd>/.composio/` and creates a `.gitignore`. */
-const writeProjectConfig = (composioDir: string, selected: ProjectKeys) =>
+
+/**
+ * Serializes an `InitConfig` to the JSON payload written to `.composio/config.json`.
+ */
+const initConfigToJSON = (config: InitConfig): string => {
+  const payload: Record<string, unknown> = {
+    usage_mode: config.usageMode,
+  };
+  if (config.framework) {
+    payload.framework = config.framework;
+  }
+  payload.install_skills = config.installSkills;
+  if (config.detectedEnv) {
+    payload.detected_language = config.detectedEnv.language;
+    payload.package_manager = config.detectedEnv.packageManager;
+  }
+  return JSON.stringify(payload, null, 2);
+};
+
+/** Writes project keys + init config to `<cwd>/.composio/` and creates a `.gitignore`. */
+const writeProjectConfig = (composioDir: string, selected: ProjectKeys, config?: InitConfig) =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
 
@@ -65,6 +342,10 @@ const writeProjectConfig = (composioDir: string, selected: ProjectKeys) =>
       projectJson
     );
 
+    if (config) {
+      yield* fs.writeFileString(path.join(composioDir, 'config.json'), initConfigToJSON(config));
+    }
+
     // Create .composio/.gitignore to prevent accidental commits
     const gitignorePath = path.join(composioDir, '.gitignore');
     const gitignoreExists = yield* fs.exists(gitignorePath);
@@ -74,21 +355,184 @@ const writeProjectConfig = (composioDir: string, selected: ProjectKeys) =>
   });
 
 // ---------------------------------------------------------------------------
+// Install step — runs after wizard, before outro
+// ---------------------------------------------------------------------------
+
+/**
+ * Runs the dependency installation step based on the init config.
+ * Handles --dry-run, --force, --yes flags and already-installed detection.
+ */
+const runInstallStep = (params: {
+  config: InitConfig;
+  cwd: string;
+  dryRun: boolean;
+  force: boolean;
+  yes: boolean;
+}) =>
+  Effect.gen(function* () {
+    const { config, cwd, dryRun, force, yes } = params;
+    if (!config.installPlan) return;
+
+    const ui = yield* TerminalUI;
+    const runner = yield* CommandRunner;
+    const plan = config.installPlan;
+
+    // Check if already installed (only for JS — Python version check requires shell)
+    if (plan.kind === 'js') {
+      const depState = yield* resolveCoreDependencyState(cwd).pipe(
+        Effect.catchAll(() => Effect.succeed({ plan, installedVersion: null }))
+      );
+
+      if (depState.installedVersion && !force) {
+        const detail =
+          depState.installedVersion.source === 'package.json'
+            ? `declared in package.json (${depState.installedVersion.version})`
+            : `${depState.installedVersion.version} (${depState.installedVersion.source})`;
+        yield* ui.log.info(`Found ${plan.dependency}: ${detail}`);
+        yield* ui.log.success('Dependency already installed.');
+        return;
+      }
+
+      if (depState.installedVersion && force) {
+        yield* ui.log.warn('Reinstalling due to --force.');
+      }
+    }
+
+    if (dryRun) {
+      yield* ui.note(plan.installCommand, 'Install Command');
+      yield* ui.log.info('Dry run complete.');
+      return;
+    }
+
+    const shouldInstall =
+      yes || (yield* ui.confirm(`Run: ${plan.installCommand}?`, { defaultValue: true }));
+    if (!shouldInstall) {
+      yield* ui.log.warn('Installation cancelled.');
+      return;
+    }
+
+    const [cmd, ...args] = plan.installCommand.split(' ');
+    const command = PlatformCommand.make(cmd!, ...args).pipe(
+      PlatformCommand.workingDirectory(plan.rootDir)
+    );
+
+    const install = Effect.gen(function* () {
+      const exitCode = yield* runner.run(command);
+      if (exitCode !== 0) {
+        yield* Effect.fail(new Error(`Install command failed with exit code ${exitCode}`));
+      }
+    });
+
+    yield* ui
+      .withSpinner(`Installing ${plan.dependency}...`, install, {
+        successMessage: `Installed ${plan.dependency}.`,
+        errorMessage: `Failed to install ${plan.dependency}.`,
+      })
+      .pipe(
+        Effect.catchAll(e =>
+          Effect.gen(function* () {
+            yield* ui.log.error(`Install failed: ${e instanceof Error ? e.message : String(e)}`);
+            yield* ui.log.info(`You can install manually: ${plan.installCommand}`);
+          })
+        )
+      );
+  });
+
+// ---------------------------------------------------------------------------
+// Skills install step — runs `npx skills add composiohq/skills`
+// ---------------------------------------------------------------------------
+
+const SKILLS_INSTALL_COMMAND = 'npx skills add composiohq/skills';
+
+/**
+ * Runs the Composio skills installation step.
+ * Uses `npx skills add composiohq/skills` to install coding-agent skills.
+ */
+const runSkillsInstallStep = (params: {
+  config: InitConfig;
+  cwd: string;
+  dryRun: boolean;
+  yes: boolean;
+}) =>
+  Effect.gen(function* () {
+    const { config, cwd, dryRun, yes } = params;
+    if (!config.installSkills) return;
+
+    const ui = yield* TerminalUI;
+    const runner = yield* CommandRunner;
+
+    if (dryRun) {
+      yield* ui.note(SKILLS_INSTALL_COMMAND, 'Skills Install Command');
+      return;
+    }
+
+    const shouldInstall =
+      yes || (yield* ui.confirm(`Run: ${SKILLS_INSTALL_COMMAND}?`, { defaultValue: true }));
+    if (!shouldInstall) {
+      yield* ui.log.warn('Skills installation cancelled.');
+      return;
+    }
+
+    const [cmd, ...args] = SKILLS_INSTALL_COMMAND.split(' ');
+    const command = PlatformCommand.make(cmd!, ...args).pipe(PlatformCommand.workingDirectory(cwd));
+
+    const install = Effect.gen(function* () {
+      const exitCode = yield* runner.run(command);
+      if (exitCode !== 0) {
+        yield* Effect.fail(new Error(`Skills install command failed with exit code ${exitCode}`));
+      }
+    });
+
+    yield* ui
+      .withSpinner('Installing Composio skills...', install, {
+        successMessage: 'Installed Composio skills.',
+        errorMessage: 'Failed to install Composio skills.',
+      })
+      .pipe(
+        Effect.catchAll(e =>
+          Effect.gen(function* () {
+            yield* ui.log.error(
+              `Skills install failed: ${e instanceof Error ? e.message : String(e)}`
+            );
+            yield* ui.log.info(`You can install manually: ${SKILLS_INSTALL_COMMAND}`);
+          })
+        )
+      );
+  });
+
+// ---------------------------------------------------------------------------
 // Structured output helper
 // ---------------------------------------------------------------------------
 
+/** Resolved credentials to be printed and included in structured output. */
+interface ResolvedEnvVars {
+  readonly composioApiKey: string | null;
+  readonly composioTestUserId: string;
+}
+
 const makeOutputJson = (
   selected: ProjectKeys,
+  config: InitConfig,
   composioDir: string,
   envVars?: ResolvedEnvVars | null
 ) =>
   JSON.stringify({
     org_id: selected.orgId,
     project_id: selected.projectId,
+    usage_mode: config.usageMode,
+    framework: config.framework ?? null,
+    install_skills: config.installSkills,
+    detected_language: config.detectedEnv?.language ?? null,
+    package_manager: config.detectedEnv?.packageManager ?? null,
+    install_command: config.installPlan?.installCommand ?? null,
     path: composioDir,
     ...(envVars?.composioApiKey ? { composio_api_key: envVars.composioApiKey } : {}),
     ...(envVars ? { composio_test_user_id: envVars.composioTestUserId } : {}),
   });
+
+// ---------------------------------------------------------------------------
+// Global user API key + env var helpers (from recent improvements)
+// ---------------------------------------------------------------------------
 
 const getGlobalUserApiKey = () =>
   Effect.gen(function* () {
@@ -104,12 +548,6 @@ const getGlobalUserApiKey = () =>
 
     return Option.getOrUndefined(parsed.value.apiKey);
   });
-
-/** Resolved credentials to be printed and included in structured output. */
-interface ResolvedEnvVars {
-  readonly composioApiKey: string | null;
-  readonly composioTestUserId: string;
-}
 
 const resolveProjectEnvVars = (params: { selected: ProjectKeys }) =>
   Effect.gen(function* () {
@@ -209,7 +647,8 @@ const selectDefaultProject = (params: {
 /**
  * CLI command to initialize a Composio project in the current directory.
  *
- * Creates `<cwd>/.composio/project.json` with org_id and project_id.
+ * Creates `<cwd>/.composio/project.json` with org_id and project_id,
+ * plus `<cwd>/.composio/config.json` with usage mode, framework, and skill preferences.
  *
  * Supports two modes:
  * 1. Interactive: Fetches projects from the API and prompts for selection
@@ -227,9 +666,12 @@ export const initCmd = CliCommand.make(
     orgId: orgIdOpt,
     projectId: projectIdOpt,
     noBrowser: noBrowserOpt,
+    dryRun: dryRunOpt,
+    force: forceOpt,
     yes: yesOpt,
+    noSkills: noSkillsOpt,
   },
-  ({ orgId, projectId, noBrowser, yes }) =>
+  ({ orgId, projectId, noBrowser, dryRun, force, yes, noSkills }) =>
     Effect.gen(function* () {
       const ui = yield* TerminalUI;
       const proc = yield* NodeProcess;
@@ -249,7 +691,9 @@ export const initCmd = CliCommand.make(
           testUserId: Option.none(),
         };
 
-        yield* writeProjectConfig(composioDir, selected);
+        const config = yield* runInitWizard(proc.cwd, { noSkills });
+        yield* writeProjectConfig(composioDir, selected, config);
+
         const envVars = yield* resolveProjectEnvVars({ selected }).pipe(
           Effect.catchTag('services/HttpServerError', e =>
             Effect.gen(function* () {
@@ -268,20 +712,24 @@ export const initCmd = CliCommand.make(
         );
 
         if (envVars) {
-          yield* writeProjectConfig(composioDir, {
-            ...selected,
-            testUserId: Option.some(envVars.composioTestUserId),
-          });
+          yield* writeProjectConfig(
+            composioDir,
+            { ...selected, testUserId: Option.some(envVars.composioTestUserId) },
+            config
+          );
           yield* printEnvVars(envVars);
         }
 
+        yield* runInstallStep({ config, cwd: proc.cwd, dryRun, force, yes });
+        yield* runSkillsInstallStep({ config, cwd: proc.cwd, dryRun, yes });
+
         yield* ui.log.success(`Project initialized in ${composioDir}/`);
-        yield* ui.output(makeOutputJson(selected, composioDir, envVars));
+        yield* ui.output(makeOutputJson(selected, config, composioDir, envVars));
         yield* ui.outro('');
         return;
       }
 
-      yield* initInteractiveFlow({ composioDir, noBrowser, yes });
+      yield* initInteractiveFlow({ composioDir, noBrowser, dryRun, force, yes, noSkills });
     })
 ).pipe(CliCommand.withDescription('Initialize a Composio project in the current directory.'));
 
@@ -289,11 +737,19 @@ export const initCmd = CliCommand.make(
  * Interactive init flow — handles login, project selection, wizard, install.
  * Extracted to keep the main command handler under the line limit.
  */
-const initInteractiveFlow = (params: { composioDir: string; noBrowser: boolean; yes: boolean }) =>
+const initInteractiveFlow = (params: {
+  composioDir: string;
+  noBrowser: boolean;
+  dryRun: boolean;
+  force: boolean;
+  yes: boolean;
+  noSkills: boolean;
+}) =>
   Effect.gen(function* () {
-    const { composioDir, noBrowser, yes } = params;
+    const { composioDir, noBrowser, dryRun, force, yes, noSkills } = params;
     const ui = yield* TerminalUI;
     const ctx = yield* ComposioUserContext;
+    const proc = yield* NodeProcess;
 
     // 1. Ensure global user API key exists (ignore local/project keys).
     let globalApiKey = yield* getGlobalUserApiKey();
@@ -375,8 +831,10 @@ const initInteractiveFlow = (params: { composioDir: string; noBrowser: boolean; 
     const selected = orgProjectToKeys(selectedProject);
     yield* ui.log.step(`Using project "${selectedProject.name}"`);
 
-    // 4. Write project config
-    yield* writeProjectConfig(composioDir, selected);
+    // 4. Run wizard + write config + install
+    const config = yield* runInitWizard(proc.cwd, { noSkills });
+    yield* writeProjectConfig(composioDir, selected, config);
+
     const envVars = yield* resolveProjectEnvVars({ selected }).pipe(
       Effect.catchTag('services/HttpServerError', e =>
         Effect.gen(function* () {
@@ -395,14 +853,18 @@ const initInteractiveFlow = (params: { composioDir: string; noBrowser: boolean; 
     );
 
     if (envVars) {
-      yield* writeProjectConfig(composioDir, {
-        ...selected,
-        testUserId: Option.some(envVars.composioTestUserId),
-      });
+      yield* writeProjectConfig(
+        composioDir,
+        { ...selected, testUserId: Option.some(envVars.composioTestUserId) },
+        config
+      );
       yield* printEnvVars(envVars);
     }
 
+    yield* runInstallStep({ config, cwd: proc.cwd, dryRun, force, yes });
+    yield* runSkillsInstallStep({ config, cwd: proc.cwd, dryRun, yes });
+
     yield* ui.log.success(`Project initialized in ${composioDir}/`);
-    yield* ui.output(makeOutputJson(selected, composioDir, envVars));
+    yield* ui.output(makeOutputJson(selected, config, composioDir, envVars));
     yield* ui.outro('');
   });

--- a/ts/packages/cli/src/commands/init.cmd.ts
+++ b/ts/packages/cli/src/commands/init.cmd.ts
@@ -983,7 +983,7 @@ const runConfirmExecuteOutro = (params: {
         );
       }
       envLines.push(
-        `COMPOSIO_TEST_USER_ID=${redact({ value: outcome.envVars.composioTestUserId, prefix: 'pr_' })}`
+        `COMPOSIO_TEST_USER_ID=${redact({ value: outcome.envVars.composioTestUserId, prefix: 'pg-test-' })}`
       );
       envLines.push('');
       envLines.push(`Saved to ${composioDir}/.env.local`);

--- a/ts/packages/cli/src/services/terminal-ui.ts
+++ b/ts/packages/cli/src/services/terminal-ui.ts
@@ -92,6 +92,20 @@ export interface TerminalUI {
   ) => Effect.Effect<Value>;
 
   /**
+   * Present a multi-select list to the user.
+   * In non-interactive mode (piped), returns all option values.
+   */
+  readonly multiSelect: <Value>(
+    message: string,
+    options: ReadonlyArray<{
+      readonly value: Value;
+      readonly label: string;
+      readonly hint?: string;
+    }>,
+    selectOptions?: { readonly required?: boolean }
+  ) => Effect.Effect<Value[]>;
+
+  /**
    * Create a controllable spinner that is automatically stopped on error or interruption.
    * The `use` function receives a SpinnerHandle and must return an Effect.
    * On success: the caller should call `spinner.stop(...)` inside `use`.
@@ -200,6 +214,26 @@ const makeLive: TerminalUI = {
           return result;
         })
       : Effect.succeed(options[0].value)) as TerminalUI['select'],
+
+  multiSelect: ((
+    message: string,
+    options: ReadonlyArray<{ value: unknown; label: string; hint?: string }>,
+    selectOptions?: { readonly required?: boolean }
+  ) =>
+    isInteractive
+      ? Effect.promise(async () => {
+          const result = await p.multiselect({
+            message,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            options: [...options] as any,
+            required: selectOptions?.required ?? false,
+            output: process.stderr,
+          });
+          // p.multiselect returns Value[] | symbol (symbol on cancel)
+          if (typeof result === 'symbol') return options.map(o => o.value);
+          return result;
+        })
+      : Effect.succeed(options.map(o => o.value))) as TerminalUI['multiSelect'],
 
   confirm: (message, options) =>
     isInteractive

--- a/ts/packages/cli/src/services/terminal-ui.ts
+++ b/ts/packages/cli/src/services/terminal-ui.ts
@@ -350,7 +350,7 @@ const makeLive: TerminalUI = {
             output: process.stderr,
           });
           // multiselect returns Value[] | symbol (symbol on cancel)
-          if (typeof result === 'symbol') return options.map(o => o.value);
+          if (typeof result === 'symbol') return [];
           return result;
         })
       : Effect.succeed(options.map(o => o.value))) as TerminalUI['multiSelect'],

--- a/ts/packages/cli/src/services/terminal-ui.ts
+++ b/ts/packages/cli/src/services/terminal-ui.ts
@@ -1,5 +1,8 @@
 import process from 'node:process';
+import type { Writable } from 'node:stream';
 import * as p from '@clack/prompts';
+import { MultiSelectPrompt } from '@clack/core';
+import pc from 'picocolors';
 import { Context, Effect, Exit, Layer } from 'effect';
 
 // ---------------------------------------------------------------------------
@@ -166,6 +169,124 @@ const silentSpinnerHandle: SpinnerHandle = {
   error: () => Effect.void,
 };
 
+// ---------------------------------------------------------------------------
+// Custom multiselect — adds a dimmed instruction hint that disappears on submit
+// ---------------------------------------------------------------------------
+
+// Clack symbols (matching @clack/prompts internals)
+const S_BAR_MS = '│';
+const S_BAR_END_MS = '└';
+const S_CHECKBOX_ACTIVE_MS = '◻';
+const S_CHECKBOX_SELECTED_MS = '◼';
+const S_CHECKBOX_INACTIVE_MS = '◻';
+
+interface MSOption<V> {
+  value: V;
+  label: string;
+  hint?: string;
+  disabled?: boolean;
+}
+
+function clackMultiselect<V>(opts: {
+  message: string;
+  options: MSOption<V>[];
+  required?: boolean;
+  output?: Writable;
+}): Promise<V[] | symbol> {
+  const output = (opts.output ?? process.stdout) as Writable;
+  const required = opts.required ?? true;
+  const hint = pc.dim('space select, enter confirm');
+
+  const sym = (state: string) => {
+    if (state === 'cancel') return pc.red('■');
+    if (state === 'submit') return pc.green('◇');
+    if (state === 'error') return pc.yellow('▲');
+    return pc.cyan('◆');
+  };
+  const bar = (state: string) => {
+    if (state === 'cancel') return pc.red(S_BAR_MS);
+    if (state === 'error') return pc.yellow(S_BAR_MS);
+    if (state === 'submit') return pc.green(S_BAR_MS);
+    return pc.cyan(S_BAR_MS);
+  };
+
+  const renderOpt = (o: MSOption<V>, mode: string) => {
+    const label = o.label ?? String(o.value);
+    const h = o.hint ? ` ${pc.dim(`(${o.hint})`)}` : '';
+    if (mode === 'active') return `${pc.cyan(S_CHECKBOX_ACTIVE_MS)} ${label}${h}`;
+    if (mode === 'selected') return `${pc.green(S_CHECKBOX_SELECTED_MS)} ${pc.dim(label)}${h}`;
+    if (mode === 'active-selected') return `${pc.green(S_CHECKBOX_SELECTED_MS)} ${label}${h}`;
+    if (mode === 'submitted') return pc.dim(label);
+    if (mode === 'cancelled') return pc.strikethrough(pc.dim(label));
+    return `${pc.dim(S_CHECKBOX_INACTIVE_MS)} ${pc.dim(label)}`;
+  };
+
+  return new MultiSelectPrompt({
+    options: opts.options,
+    input: process.stdin,
+    output,
+    required,
+    validate(selected: V[] | undefined) {
+      if (required && (!selected || selected.length === 0)) {
+        return `Please select at least one option.\n${pc.reset(
+          pc.dim(
+            `Press ${pc.gray(pc.bgWhite(pc.inverse(' space ')))} to select, ` +
+              `${pc.gray(pc.bgWhite(pc.inverse(' enter ')))} to submit`
+          )
+        )}`;
+      }
+      return undefined;
+    },
+    render() {
+      const value = this.value ?? [];
+      const title = `${pc.gray(S_BAR_MS)}\n${sym(this.state)}  ${pc.bold(opts.message)}\n`;
+
+      const style = (o: MSOption<V>, active: boolean) => {
+        if (o.disabled) return renderOpt(o, 'inactive');
+        const sel = value.includes(o.value);
+        if (active && sel) return renderOpt(o, 'active-selected');
+        if (sel) return renderOpt(o, 'selected');
+        return renderOpt(o, active ? 'active' : 'inactive');
+      };
+
+      switch (this.state) {
+        case 'submit': {
+          const text =
+            this.options
+              .filter(o => value.includes(o.value))
+              .map(o => renderOpt(o, 'submitted'))
+              .join(pc.dim(', ')) || pc.dim('none');
+          return `${title}${pc.gray(S_BAR_MS)}  ${text}`;
+        }
+        case 'cancel': {
+          const text = this.options
+            .filter(o => value.includes(o.value))
+            .map(o => renderOpt(o, 'cancelled'))
+            .join(pc.dim(', '));
+          if (!text.trim()) return `${title}${pc.gray(S_BAR_MS)}`;
+          return `${title}${pc.gray(S_BAR_MS)}  ${text}\n${pc.gray(S_BAR_MS)}`;
+        }
+        case 'error': {
+          const pfx = `${pc.yellow(S_BAR_MS)}  `;
+          const lines = this.options.map((o, i) => style(o, i === this.cursor));
+          const footer = this.error
+            .split('\n')
+            .map((ln: string, i: number) =>
+              i === 0 ? `${pc.yellow(S_BAR_END_MS)}  ${pc.yellow(ln)}` : `   ${ln}`
+            )
+            .join('\n');
+          return `${title}${pfx}${lines.join(`\n${pfx}`)}\n${footer}\n`;
+        }
+        default: {
+          const pfx = `${pc.cyan(S_BAR_MS)}  `;
+          const lines = this.options.map((o, i) => style(o, i === this.cursor));
+          return `${title}${bar(this.state)}  ${hint}\n${pfx}${lines.join(`\n${pfx}`)}\n${pc.cyan(S_BAR_END_MS)}\n`;
+        }
+      }
+    },
+  }).prompt() as Promise<V[] | symbol>;
+}
+
 const makeLive: TerminalUI = {
   output: data =>
     Effect.sync(() => {
@@ -222,14 +343,13 @@ const makeLive: TerminalUI = {
   ) =>
     isInteractive
       ? Effect.promise(async () => {
-          const result = await p.multiselect({
+          const result = await clackMultiselect({
             message,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            options: [...options] as any,
+            options: [...options],
             required: selectOptions?.required ?? false,
             output: process.stderr,
           });
-          // p.multiselect returns Value[] | symbol (symbol on cancel)
+          // multiselect returns Value[] | symbol (symbol on cancel)
           if (typeof result === 'symbol') return options.map(o => o.value);
           return result;
         })

--- a/ts/packages/cli/src/services/terminal-ui.ts
+++ b/ts/packages/cli/src/services/terminal-ui.ts
@@ -350,7 +350,10 @@ const makeLive: TerminalUI = {
             output: process.stderr,
           });
           // multiselect returns Value[] | symbol (symbol on cancel)
-          if (typeof result === 'symbol') return [];
+          if (typeof result === 'symbol') {
+            p.cancel('Operation cancelled.');
+            process.exit(0);
+          }
           return result;
         })
       : Effect.succeed(options.map(o => o.value))) as TerminalUI['multiSelect'],

--- a/ts/packages/cli/src/skills/agents.ts
+++ b/ts/packages/cli/src/skills/agents.ts
@@ -1,0 +1,506 @@
+// Ported from ts/vendor/skills/src/agents.ts
+// Full agent registry with detection and helper functions.
+
+import { homedir } from 'os';
+import { join } from 'path';
+import { existsSync } from 'fs';
+import type { AgentConfig, AgentType } from './types';
+import { searchMultiselect, type LockedSection } from './prompts/search-multiselect';
+
+const home = homedir();
+// Use XDG_CONFIG_HOME or fallback to ~/.config
+const configHome = process.env.XDG_CONFIG_HOME?.trim() || join(home, '.config');
+const codexHome = process.env.CODEX_HOME?.trim() || join(home, '.codex');
+const claudeHome = process.env.CLAUDE_CONFIG_DIR?.trim() || join(home, '.claude');
+
+export function getOpenClawGlobalSkillsDir(
+  homeDir = home,
+  pathExists: (path: string) => boolean = existsSync
+) {
+  if (pathExists(join(homeDir, '.openclaw'))) {
+    return join(homeDir, '.openclaw/skills');
+  }
+  if (pathExists(join(homeDir, '.clawdbot'))) {
+    return join(homeDir, '.clawdbot/skills');
+  }
+  if (pathExists(join(homeDir, '.moltbot'))) {
+    return join(homeDir, '.moltbot/skills');
+  }
+  return join(homeDir, '.openclaw/skills');
+}
+
+export const agents: Record<AgentType, AgentConfig> = {
+  amp: {
+    name: 'amp',
+    displayName: 'Amp',
+    skillsDir: '.agents/skills',
+    globalSkillsDir: join(configHome, 'agents/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(configHome, 'amp'));
+    },
+  },
+  antigravity: {
+    name: 'antigravity',
+    displayName: 'Antigravity',
+    skillsDir: '.agent/skills',
+    globalSkillsDir: join(home, '.gemini/antigravity/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.gemini/antigravity'));
+    },
+  },
+  augment: {
+    name: 'augment',
+    displayName: 'Augment',
+    skillsDir: '.augment/skills',
+    globalSkillsDir: join(home, '.augment/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.augment'));
+    },
+  },
+  'claude-code': {
+    name: 'claude-code',
+    displayName: 'Claude Code',
+    skillsDir: '.claude/skills',
+    globalSkillsDir: join(claudeHome, 'skills'),
+    detectInstalled: async () => {
+      return existsSync(claudeHome);
+    },
+  },
+  openclaw: {
+    name: 'openclaw',
+    displayName: 'OpenClaw',
+    skillsDir: 'skills',
+    globalSkillsDir: getOpenClawGlobalSkillsDir(),
+    detectInstalled: async () => {
+      return (
+        existsSync(join(home, '.openclaw')) ||
+        existsSync(join(home, '.clawdbot')) ||
+        existsSync(join(home, '.moltbot'))
+      );
+    },
+  },
+  cline: {
+    name: 'cline',
+    displayName: 'Cline',
+    skillsDir: '.cline/skills',
+    globalSkillsDir: join(home, '.cline/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.cline'));
+    },
+  },
+  codebuddy: {
+    name: 'codebuddy',
+    displayName: 'CodeBuddy',
+    skillsDir: '.codebuddy/skills',
+    globalSkillsDir: join(home, '.codebuddy/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(process.cwd(), '.codebuddy')) || existsSync(join(home, '.codebuddy'));
+    },
+  },
+  codex: {
+    name: 'codex',
+    displayName: 'Codex',
+    skillsDir: '.agents/skills',
+    globalSkillsDir: join(codexHome, 'skills'),
+    detectInstalled: async () => {
+      return existsSync(codexHome) || existsSync('/etc/codex');
+    },
+  },
+  'command-code': {
+    name: 'command-code',
+    displayName: 'Command Code',
+    skillsDir: '.commandcode/skills',
+    globalSkillsDir: join(home, '.commandcode/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.commandcode'));
+    },
+  },
+  continue: {
+    name: 'continue',
+    displayName: 'Continue',
+    skillsDir: '.continue/skills',
+    globalSkillsDir: join(home, '.continue/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(process.cwd(), '.continue')) || existsSync(join(home, '.continue'));
+    },
+  },
+  cortex: {
+    name: 'cortex',
+    displayName: 'Cortex Code',
+    skillsDir: '.cortex/skills',
+    globalSkillsDir: join(home, '.snowflake/cortex/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.snowflake/cortex'));
+    },
+  },
+  crush: {
+    name: 'crush',
+    displayName: 'Crush',
+    skillsDir: '.crush/skills',
+    globalSkillsDir: join(home, '.config/crush/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.config/crush'));
+    },
+  },
+  cursor: {
+    name: 'cursor',
+    displayName: 'Cursor',
+    skillsDir: '.agents/skills',
+    globalSkillsDir: join(home, '.cursor/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.cursor'));
+    },
+  },
+  droid: {
+    name: 'droid',
+    displayName: 'Droid',
+    skillsDir: '.factory/skills',
+    globalSkillsDir: join(home, '.factory/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.factory'));
+    },
+  },
+  'gemini-cli': {
+    name: 'gemini-cli',
+    displayName: 'Gemini CLI',
+    skillsDir: '.agents/skills',
+    globalSkillsDir: join(home, '.gemini/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.gemini'));
+    },
+  },
+  'github-copilot': {
+    name: 'github-copilot',
+    displayName: 'GitHub Copilot',
+    skillsDir: '.agents/skills',
+    globalSkillsDir: join(home, '.copilot/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.copilot'));
+    },
+  },
+  goose: {
+    name: 'goose',
+    displayName: 'Goose',
+    skillsDir: '.goose/skills',
+    globalSkillsDir: join(configHome, 'goose/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(configHome, 'goose'));
+    },
+  },
+  junie: {
+    name: 'junie',
+    displayName: 'Junie',
+    skillsDir: '.junie/skills',
+    globalSkillsDir: join(home, '.junie/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.junie'));
+    },
+  },
+  'iflow-cli': {
+    name: 'iflow-cli',
+    displayName: 'iFlow CLI',
+    skillsDir: '.iflow/skills',
+    globalSkillsDir: join(home, '.iflow/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.iflow'));
+    },
+  },
+  kilo: {
+    name: 'kilo',
+    displayName: 'Kilo Code',
+    skillsDir: '.kilocode/skills',
+    globalSkillsDir: join(home, '.kilocode/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.kilocode'));
+    },
+  },
+  'kimi-cli': {
+    name: 'kimi-cli',
+    displayName: 'Kimi Code CLI',
+    skillsDir: '.agents/skills',
+    globalSkillsDir: join(home, '.config/agents/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.kimi'));
+    },
+  },
+  'kiro-cli': {
+    name: 'kiro-cli',
+    displayName: 'Kiro CLI',
+    skillsDir: '.kiro/skills',
+    globalSkillsDir: join(home, '.kiro/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.kiro'));
+    },
+  },
+  kode: {
+    name: 'kode',
+    displayName: 'Kode',
+    skillsDir: '.kode/skills',
+    globalSkillsDir: join(home, '.kode/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.kode'));
+    },
+  },
+  mcpjam: {
+    name: 'mcpjam',
+    displayName: 'MCPJam',
+    skillsDir: '.mcpjam/skills',
+    globalSkillsDir: join(home, '.mcpjam/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.mcpjam'));
+    },
+  },
+  'mistral-vibe': {
+    name: 'mistral-vibe',
+    displayName: 'Mistral Vibe',
+    skillsDir: '.vibe/skills',
+    globalSkillsDir: join(home, '.vibe/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.vibe'));
+    },
+  },
+  mux: {
+    name: 'mux',
+    displayName: 'Mux',
+    skillsDir: '.mux/skills',
+    globalSkillsDir: join(home, '.mux/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.mux'));
+    },
+  },
+  opencode: {
+    name: 'opencode',
+    displayName: 'OpenCode',
+    skillsDir: '.agents/skills',
+    globalSkillsDir: join(configHome, 'opencode/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(configHome, 'opencode'));
+    },
+  },
+  openhands: {
+    name: 'openhands',
+    displayName: 'OpenHands',
+    skillsDir: '.openhands/skills',
+    globalSkillsDir: join(home, '.openhands/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.openhands'));
+    },
+  },
+  pi: {
+    name: 'pi',
+    displayName: 'Pi',
+    skillsDir: '.pi/skills',
+    globalSkillsDir: join(home, '.pi/agent/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.pi/agent'));
+    },
+  },
+  qoder: {
+    name: 'qoder',
+    displayName: 'Qoder',
+    skillsDir: '.qoder/skills',
+    globalSkillsDir: join(home, '.qoder/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.qoder'));
+    },
+  },
+  'qwen-code': {
+    name: 'qwen-code',
+    displayName: 'Qwen Code',
+    skillsDir: '.qwen/skills',
+    globalSkillsDir: join(home, '.qwen/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.qwen'));
+    },
+  },
+  replit: {
+    name: 'replit',
+    displayName: 'Replit',
+    skillsDir: '.agents/skills',
+    globalSkillsDir: join(configHome, 'agents/skills'),
+    showInUniversalList: false,
+    detectInstalled: async () => {
+      return existsSync(join(process.cwd(), '.replit'));
+    },
+  },
+  roo: {
+    name: 'roo',
+    displayName: 'Roo Code',
+    skillsDir: '.roo/skills',
+    globalSkillsDir: join(home, '.roo/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.roo'));
+    },
+  },
+  trae: {
+    name: 'trae',
+    displayName: 'Trae',
+    skillsDir: '.trae/skills',
+    globalSkillsDir: join(home, '.trae/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.trae'));
+    },
+  },
+  'trae-cn': {
+    name: 'trae-cn',
+    displayName: 'Trae CN',
+    skillsDir: '.trae/skills',
+    globalSkillsDir: join(home, '.trae-cn/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.trae-cn'));
+    },
+  },
+  windsurf: {
+    name: 'windsurf',
+    displayName: 'Windsurf',
+    skillsDir: '.windsurf/skills',
+    globalSkillsDir: join(home, '.codeium/windsurf/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.codeium/windsurf'));
+    },
+  },
+  zencoder: {
+    name: 'zencoder',
+    displayName: 'Zencoder',
+    skillsDir: '.zencoder/skills',
+    globalSkillsDir: join(home, '.zencoder/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.zencoder'));
+    },
+  },
+  neovate: {
+    name: 'neovate',
+    displayName: 'Neovate',
+    skillsDir: '.neovate/skills',
+    globalSkillsDir: join(home, '.neovate/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.neovate'));
+    },
+  },
+  pochi: {
+    name: 'pochi',
+    displayName: 'Pochi',
+    skillsDir: '.pochi/skills',
+    globalSkillsDir: join(home, '.pochi/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.pochi'));
+    },
+  },
+  adal: {
+    name: 'adal',
+    displayName: 'AdaL',
+    skillsDir: '.adal/skills',
+    globalSkillsDir: join(home, '.adal/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.adal'));
+    },
+  },
+  universal: {
+    name: 'universal',
+    displayName: 'Universal',
+    skillsDir: '.agents/skills',
+    globalSkillsDir: join(configHome, 'agents/skills'),
+    showInUniversalList: false,
+    detectInstalled: async () => false,
+  },
+};
+
+export async function detectInstalledAgents(): Promise<AgentType[]> {
+  const results = await Promise.all(
+    Object.entries(agents).map(async ([type, config]) => ({
+      type: type as AgentType,
+      installed: await config.detectInstalled(),
+    }))
+  );
+  return results.filter(r => r.installed).map(r => r.type);
+}
+
+/**
+ * Returns agents that use the universal .agents/skills directory.
+ * These agents share a common skill location and don't need symlinks.
+ * Agents with showInUniversalList: false are excluded.
+ */
+export function getUniversalAgents(): AgentType[] {
+  return (Object.entries(agents) as [AgentType, AgentConfig][])
+    .filter(
+      ([_, config]) => config.skillsDir === '.agents/skills' && config.showInUniversalList !== false
+    )
+    .map(([type]) => type);
+}
+
+/**
+ * Returns agents that use agent-specific skill directories (not universal).
+ * These agents need symlinks from the canonical .agents/skills location.
+ */
+export function getNonUniversalAgents(): AgentType[] {
+  return (Object.entries(agents) as [AgentType, AgentConfig][])
+    .filter(([_, config]) => config.skillsDir !== '.agents/skills')
+    .map(([type]) => type);
+}
+
+/**
+ * Check if an agent uses the universal .agents/skills directory.
+ */
+export function isUniversalAgent(type: AgentType): boolean {
+  return agents[type].skillsDir === '.agents/skills';
+}
+
+/**
+ * Ensures universal agents are always included in the target agents list.
+ */
+export function ensureUniversalAgents(targetAgents: AgentType[]): AgentType[] {
+  const universalAgents = getUniversalAgents();
+  const result = [...targetAgents];
+
+  for (const ua of universalAgents) {
+    if (!result.includes(ua)) {
+      result.push(ua);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Interactive agent selection using fuzzy search.
+ * Shows universal agents as locked (always selected), and other agents as selectable.
+ */
+export async function selectAgentsInteractive(options: {
+  global?: boolean;
+}): Promise<AgentType[] | symbol> {
+  // Filter out agents that don't support global installation when --global is used
+  const supportsGlobalFilter = (a: AgentType) => !options.global || agents[a].globalSkillsDir;
+
+  const universalAgents = getUniversalAgents().filter(supportsGlobalFilter);
+  const otherAgents = getNonUniversalAgents().filter(supportsGlobalFilter);
+
+  // Universal agents shown as locked section
+  const universalSection: LockedSection<AgentType> = {
+    title: 'Universal (.agents/skills)',
+    items: universalAgents.map(a => ({
+      value: a,
+      label: agents[a].displayName,
+    })),
+  };
+
+  // Other agents are selectable with their skillsDir as hint
+  const otherChoices = otherAgents.map(a => ({
+    value: a,
+    label: agents[a].displayName,
+    hint: options.global ? agents[a].globalSkillsDir! : agents[a].skillsDir,
+  }));
+
+  // Default agents to pre-select when no valid history exists
+  const defaultAgents: AgentType[] = ['claude-code', 'opencode', 'codex'];
+  const validAgents = otherChoices.map(c => c.value);
+  const initialSelected = defaultAgents.filter(a => validAgents.includes(a));
+
+  const selected = await searchMultiselect({
+    message: 'Which agents do you want to install to?',
+    items: otherChoices,
+    initialSelected,
+    lockedSection: universalSection,
+  });
+
+  return selected as AgentType[] | symbol;
+}

--- a/ts/packages/cli/src/skills/clone.ts
+++ b/ts/packages/cli/src/skills/clone.ts
@@ -3,7 +3,7 @@
 import { mkdtemp, rm } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { execSync } from 'child_process';
+import { execFile } from 'child_process';
 
 export const SKILLS_REPO_URL = 'https://github.com/composiohq/skills.git';
 export const SKILLS_MANUAL_COMMAND = 'npx skills add composiohq/skills';
@@ -14,9 +14,13 @@ export const SKILLS_MANUAL_COMMAND = 'npx skills add composiohq/skills';
  */
 export async function cloneSkillsRepo(): Promise<string> {
   const tempDir = await mkdtemp(join(tmpdir(), 'composio-skills-'));
-  execSync(`git clone --depth 1 ${SKILLS_REPO_URL} "${tempDir}"`, {
-    stdio: 'pipe',
-    timeout: 60_000,
+  await new Promise<void>((resolve, reject) => {
+    execFile(
+      'git',
+      ['clone', '--depth', '1', SKILLS_REPO_URL, tempDir],
+      { timeout: 60_000 },
+      err => (err ? reject(err) : resolve())
+    );
   });
   return tempDir;
 }

--- a/ts/packages/cli/src/skills/clone.ts
+++ b/ts/packages/cli/src/skills/clone.ts
@@ -1,0 +1,30 @@
+// Git clone and temp directory management for skills installation.
+
+import { mkdtemp, rm } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { execSync } from 'child_process';
+
+export const SKILLS_REPO_URL = 'https://github.com/composiohq/skills.git';
+export const SKILLS_MANUAL_COMMAND = 'npx skills add composiohq/skills';
+
+/**
+ * Clones the composiohq/skills repo to a temp directory.
+ * Returns the path to the temp directory.
+ */
+export async function cloneSkillsRepo(): Promise<string> {
+  const tempDir = await mkdtemp(join(tmpdir(), 'composio-skills-'));
+  execSync(`git clone --depth 1 ${SKILLS_REPO_URL} "${tempDir}"`, {
+    stdio: 'pipe',
+    timeout: 60_000,
+  });
+  return tempDir;
+}
+
+export async function cleanupTempDir(dir: string): Promise<void> {
+  try {
+    await rm(dir, { recursive: true, force: true });
+  } catch {
+    // Best-effort cleanup
+  }
+}

--- a/ts/packages/cli/src/skills/clone.ts
+++ b/ts/packages/cli/src/skills/clone.ts
@@ -14,15 +14,20 @@ export const SKILLS_MANUAL_COMMAND = 'npx skills add composiohq/skills';
  */
 export async function cloneSkillsRepo(): Promise<string> {
   const tempDir = await mkdtemp(join(tmpdir(), 'composio-skills-'));
-  await new Promise<void>((resolve, reject) => {
-    execFile(
-      'git',
-      ['clone', '--depth', '1', SKILLS_REPO_URL, tempDir],
-      { timeout: 60_000 },
-      err => (err ? reject(err) : resolve())
-    );
-  });
-  return tempDir;
+  try {
+    await new Promise<void>((resolve, reject) => {
+      execFile(
+        'git',
+        ['clone', '--depth', '1', SKILLS_REPO_URL, tempDir],
+        { timeout: 60_000 },
+        err => (err ? reject(err) : resolve())
+      );
+    });
+    return tempDir;
+  } catch (err) {
+    await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    throw err;
+  }
 }
 
 export async function cleanupTempDir(dir: string): Promise<void> {

--- a/ts/packages/cli/src/skills/constants.ts
+++ b/ts/packages/cli/src/skills/constants.ts
@@ -1,0 +1,5 @@
+// Ported from ts/vendor/skills/src/constants.ts
+
+export const AGENTS_DIR = '.agents';
+export const SKILLS_SUBDIR = 'skills';
+export const UNIVERSAL_SKILLS_DIR = '.agents/skills';

--- a/ts/packages/cli/src/skills/discovery.ts
+++ b/ts/packages/cli/src/skills/discovery.ts
@@ -19,10 +19,7 @@ async function hasSkillMd(dir: string): Promise<boolean> {
   }
 }
 
-export async function parseSkillMd(
-  skillMdPath: string,
-  options?: { includeInternal?: boolean }
-): Promise<Skill | null> {
+export async function parseSkillMd(skillMdPath: string): Promise<Skill | null> {
   try {
     const content = await readFile(skillMdPath, 'utf-8');
     const { data } = matter(content);
@@ -36,9 +33,8 @@ export async function parseSkillMd(
       return null;
     }
 
-    // Skip internal skills unless includeInternal option is true
-    const isInternal = data.metadata?.internal === true;
-    if (isInternal && !options?.includeInternal) {
+    // Skip internal skills
+    if (data.metadata?.internal === true) {
       return null;
     }
 
@@ -78,32 +74,18 @@ async function findSkillDirs(dir: string, depth = 0, maxDepth = 5): Promise<stri
   }
 }
 
-export interface DiscoverSkillsOptions {
-  /** Include internal skills (e.g., when user explicitly requests a skill by name) */
-  includeInternal?: boolean;
-  /** Search all subdirectories even when a root SKILL.md exists */
-  fullDepth?: boolean;
-}
-
-export async function discoverSkills(
-  basePath: string,
-  subpath?: string,
-  options?: DiscoverSkillsOptions
-): Promise<Skill[]> {
+export async function discoverSkills(basePath: string): Promise<Skill[]> {
   const skills: Skill[] = [];
   const seenNames = new Set<string>();
-  const searchPath = subpath ? join(basePath, subpath) : basePath;
+  const searchPath = basePath;
 
-  // If pointing directly at a skill, add it (and return early unless fullDepth is set)
+  // If pointing directly at a skill, return it immediately
   if (await hasSkillMd(searchPath)) {
-    const skill = await parseSkillMd(join(searchPath, 'SKILL.md'), options);
+    const skill = await parseSkillMd(join(searchPath, 'SKILL.md'));
     if (skill) {
       skills.push(skill);
       seenNames.add(skill.name);
-      // Only return early if fullDepth is not set
-      if (!options?.fullDepth) {
-        return skills;
-      }
+      return skills;
     }
   }
 
@@ -148,7 +130,7 @@ export async function discoverSkills(
         if (entry.isDirectory()) {
           const skillDir = join(dir, entry.name);
           if (await hasSkillMd(skillDir)) {
-            const skill = await parseSkillMd(join(skillDir, 'SKILL.md'), options);
+            const skill = await parseSkillMd(join(skillDir, 'SKILL.md'));
             if (skill && !seenNames.has(skill.name)) {
               skills.push(skill);
               seenNames.add(skill.name);
@@ -161,12 +143,12 @@ export async function discoverSkills(
     }
   }
 
-  // Fall back to recursive search if nothing found, or if fullDepth is set
-  if (skills.length === 0 || options?.fullDepth) {
+  // Fall back to recursive search if nothing found in priority dirs
+  if (skills.length === 0) {
     const allSkillDirs = await findSkillDirs(searchPath);
 
     for (const skillDir of allSkillDirs) {
-      const skill = await parseSkillMd(join(skillDir, 'SKILL.md'), options);
+      const skill = await parseSkillMd(join(skillDir, 'SKILL.md'));
       if (skill && !seenNames.has(skill.name)) {
         skills.push(skill);
         seenNames.add(skill.name);

--- a/ts/packages/cli/src/skills/discovery.ts
+++ b/ts/packages/cli/src/skills/discovery.ts
@@ -1,0 +1,182 @@
+// Ported from ts/vendor/skills/src/skills.ts
+// Skill discovery: walks directories to find SKILL.md files and parses frontmatter.
+// Simplified: no plugin manifest handling.
+
+import { readdir, readFile, stat } from 'fs/promises';
+import { join, basename, dirname } from 'path';
+import matter from 'gray-matter';
+import type { Skill } from './types';
+
+const SKIP_DIRS = ['node_modules', '.git', 'dist', 'build', '__pycache__'];
+
+async function hasSkillMd(dir: string): Promise<boolean> {
+  try {
+    const skillPath = join(dir, 'SKILL.md');
+    const stats = await stat(skillPath);
+    return stats.isFile();
+  } catch {
+    return false;
+  }
+}
+
+export async function parseSkillMd(
+  skillMdPath: string,
+  options?: { includeInternal?: boolean }
+): Promise<Skill | null> {
+  try {
+    const content = await readFile(skillMdPath, 'utf-8');
+    const { data } = matter(content);
+
+    if (!data.name || !data.description) {
+      return null;
+    }
+
+    // Ensure name and description are strings (YAML can parse numbers, booleans, etc.)
+    if (typeof data.name !== 'string' || typeof data.description !== 'string') {
+      return null;
+    }
+
+    // Skip internal skills unless includeInternal option is true
+    const isInternal = data.metadata?.internal === true;
+    if (isInternal && !options?.includeInternal) {
+      return null;
+    }
+
+    return {
+      name: data.name,
+      description: data.description,
+      path: dirname(skillMdPath),
+      rawContent: content,
+      metadata: data.metadata,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function findSkillDirs(dir: string, depth = 0, maxDepth = 5): Promise<string[]> {
+  if (depth > maxDepth) return [];
+
+  try {
+    const [hasSkill, entries] = await Promise.all([
+      hasSkillMd(dir),
+      readdir(dir, { withFileTypes: true }).catch(() => []),
+    ]);
+
+    const currentDir = hasSkill ? [dir] : [];
+
+    // Search subdirectories in parallel
+    const subDirResults = await Promise.all(
+      entries
+        .filter(entry => entry.isDirectory() && !SKIP_DIRS.includes(entry.name))
+        .map(entry => findSkillDirs(join(dir, entry.name), depth + 1, maxDepth))
+    );
+
+    return [...currentDir, ...subDirResults.flat()];
+  } catch {
+    return [];
+  }
+}
+
+export interface DiscoverSkillsOptions {
+  /** Include internal skills (e.g., when user explicitly requests a skill by name) */
+  includeInternal?: boolean;
+  /** Search all subdirectories even when a root SKILL.md exists */
+  fullDepth?: boolean;
+}
+
+export async function discoverSkills(
+  basePath: string,
+  subpath?: string,
+  options?: DiscoverSkillsOptions
+): Promise<Skill[]> {
+  const skills: Skill[] = [];
+  const seenNames = new Set<string>();
+  const searchPath = subpath ? join(basePath, subpath) : basePath;
+
+  // If pointing directly at a skill, add it (and return early unless fullDepth is set)
+  if (await hasSkillMd(searchPath)) {
+    const skill = await parseSkillMd(join(searchPath, 'SKILL.md'), options);
+    if (skill) {
+      skills.push(skill);
+      seenNames.add(skill.name);
+      // Only return early if fullDepth is not set
+      if (!options?.fullDepth) {
+        return skills;
+      }
+    }
+  }
+
+  // Search common skill locations first
+  const prioritySearchDirs = [
+    searchPath,
+    join(searchPath, 'skills'),
+    join(searchPath, 'skills/.curated'),
+    join(searchPath, 'skills/.experimental'),
+    join(searchPath, 'skills/.system'),
+    join(searchPath, '.agent/skills'),
+    join(searchPath, '.agents/skills'),
+    join(searchPath, '.claude/skills'),
+    join(searchPath, '.cline/skills'),
+    join(searchPath, '.codebuddy/skills'),
+    join(searchPath, '.codex/skills'),
+    join(searchPath, '.commandcode/skills'),
+    join(searchPath, '.continue/skills'),
+    join(searchPath, '.github/skills'),
+    join(searchPath, '.goose/skills'),
+    join(searchPath, '.iflow/skills'),
+    join(searchPath, '.junie/skills'),
+    join(searchPath, '.kilocode/skills'),
+    join(searchPath, '.kiro/skills'),
+    join(searchPath, '.mux/skills'),
+    join(searchPath, '.neovate/skills'),
+    join(searchPath, '.opencode/skills'),
+    join(searchPath, '.openhands/skills'),
+    join(searchPath, '.pi/skills'),
+    join(searchPath, '.qoder/skills'),
+    join(searchPath, '.roo/skills'),
+    join(searchPath, '.trae/skills'),
+    join(searchPath, '.windsurf/skills'),
+    join(searchPath, '.zencoder/skills'),
+  ];
+
+  for (const dir of prioritySearchDirs) {
+    try {
+      const entries = await readdir(dir, { withFileTypes: true });
+
+      for (const entry of entries) {
+        if (entry.isDirectory()) {
+          const skillDir = join(dir, entry.name);
+          if (await hasSkillMd(skillDir)) {
+            const skill = await parseSkillMd(join(skillDir, 'SKILL.md'), options);
+            if (skill && !seenNames.has(skill.name)) {
+              skills.push(skill);
+              seenNames.add(skill.name);
+            }
+          }
+        }
+      }
+    } catch {
+      // Directory doesn't exist
+    }
+  }
+
+  // Fall back to recursive search if nothing found, or if fullDepth is set
+  if (skills.length === 0 || options?.fullDepth) {
+    const allSkillDirs = await findSkillDirs(searchPath);
+
+    for (const skillDir of allSkillDirs) {
+      const skill = await parseSkillMd(join(skillDir, 'SKILL.md'), options);
+      if (skill && !seenNames.has(skill.name)) {
+        skills.push(skill);
+        seenNames.add(skill.name);
+      }
+    }
+  }
+
+  return skills;
+}
+
+export function getSkillDisplayName(skill: Skill): string {
+  return skill.name || basename(skill.path);
+}

--- a/ts/packages/cli/src/skills/index.ts
+++ b/ts/packages/cli/src/skills/index.ts
@@ -1,0 +1,8 @@
+export * from './types';
+export * from './constants';
+export * from './agents';
+export * from './clone';
+export * from './discovery';
+export * from './installer';
+export * from './summary';
+export { searchMultiselect, cancelSymbol } from './prompts/search-multiselect';

--- a/ts/packages/cli/src/skills/installer.ts
+++ b/ts/packages/cli/src/skills/installer.ts
@@ -1,0 +1,338 @@
+// Ported from ts/vendor/skills/src/installer.ts
+// Core installation logic: copy/symlink skills to agent directories.
+// Simplified: only installSkillForAgent (no remote/well-known/mintlify variants).
+
+import {
+  mkdir,
+  cp,
+  access,
+  readdir,
+  symlink,
+  lstat,
+  rm,
+  readlink,
+  stat,
+  realpath,
+} from 'fs/promises';
+import { join, basename, normalize, resolve, sep, relative, dirname } from 'path';
+import { homedir, platform } from 'os';
+import type { Skill, AgentType, InstallMode, InstallResult } from './types';
+import { agents, isUniversalAgent } from './agents';
+import { AGENTS_DIR, SKILLS_SUBDIR } from './constants';
+
+/**
+ * Sanitizes a filename/directory name to prevent path traversal attacks
+ * and ensures it follows kebab-case convention
+ */
+export function sanitizeName(name: string): string {
+  const sanitized = name
+    .toLowerCase()
+    .replace(/[^a-z0-9._]+/g, '-')
+    .replace(/^[.\-]+|[.\-]+$/g, '');
+
+  return sanitized.substring(0, 255) || 'unnamed-skill';
+}
+
+/**
+ * Validates that a path is within an expected base directory
+ */
+function isPathSafe(basePath: string, targetPath: string): boolean {
+  const normalizedBase = normalize(resolve(basePath));
+  const normalizedTarget = normalize(resolve(targetPath));
+
+  return normalizedTarget.startsWith(normalizedBase + sep) || normalizedTarget === normalizedBase;
+}
+
+export function getCanonicalSkillsDir(global: boolean, cwd?: string): string {
+  const baseDir = global ? homedir() : cwd || process.cwd();
+  return join(baseDir, AGENTS_DIR, SKILLS_SUBDIR);
+}
+
+/**
+ * Gets the base directory for an agent's skills, respecting universal agents.
+ * Universal agents always use the canonical directory, which prevents
+ * redundant symlinks and double-listing of skills.
+ */
+export function getAgentBaseDir(agentType: AgentType, global: boolean, cwd?: string): string {
+  if (isUniversalAgent(agentType)) {
+    return getCanonicalSkillsDir(global, cwd);
+  }
+
+  const agent = agents[agentType];
+  const baseDir = global ? homedir() : cwd || process.cwd();
+
+  if (global) {
+    if (agent.globalSkillsDir === undefined) {
+      return join(baseDir, agent.skillsDir);
+    }
+    return agent.globalSkillsDir;
+  }
+
+  return join(baseDir, agent.skillsDir);
+}
+
+function resolveSymlinkTarget(linkPath: string, linkTarget: string): string {
+  return resolve(dirname(linkPath), linkTarget);
+}
+
+async function cleanAndCreateDirectory(path: string): Promise<void> {
+  try {
+    await rm(path, { recursive: true, force: true });
+  } catch {
+    // Ignore cleanup errors - mkdir will fail if there's a real problem
+  }
+  await mkdir(path, { recursive: true });
+}
+
+async function resolveParentSymlinks(path: string): Promise<string> {
+  const resolved = resolve(path);
+  const dir = dirname(resolved);
+  const base = basename(resolved);
+  try {
+    const realDir = await realpath(dir);
+    return join(realDir, base);
+  } catch {
+    return resolved;
+  }
+}
+
+async function createSymlink(target: string, linkPath: string): Promise<boolean> {
+  try {
+    const resolvedTarget = resolve(target);
+    const resolvedLinkPath = resolve(linkPath);
+
+    const [realTarget, realLinkPath] = await Promise.all([
+      realpath(resolvedTarget).catch(() => resolvedTarget),
+      realpath(resolvedLinkPath).catch(() => resolvedLinkPath),
+    ]);
+
+    if (realTarget === realLinkPath) {
+      return true;
+    }
+
+    const realTargetWithParents = await resolveParentSymlinks(target);
+    const realLinkPathWithParents = await resolveParentSymlinks(linkPath);
+
+    if (realTargetWithParents === realLinkPathWithParents) {
+      return true;
+    }
+
+    try {
+      const stats = await lstat(linkPath);
+      if (stats.isSymbolicLink()) {
+        const existingTarget = await readlink(linkPath);
+        if (resolveSymlinkTarget(linkPath, existingTarget) === resolvedTarget) {
+          return true;
+        }
+        await rm(linkPath);
+      } else {
+        await rm(linkPath, { recursive: true });
+      }
+    } catch (err: unknown) {
+      if (err && typeof err === 'object' && 'code' in err && err.code === 'ELOOP') {
+        try {
+          await rm(linkPath, { force: true });
+        } catch {
+          // If we can't remove it, symlink creation will fail and trigger copy fallback
+        }
+      }
+    }
+
+    const linkDir = dirname(linkPath);
+    await mkdir(linkDir, { recursive: true });
+
+    const realLinkDir = await resolveParentSymlinks(linkDir);
+    const relativePath = relative(realLinkDir, target);
+    const symlinkType = platform() === 'win32' ? 'junction' : undefined;
+
+    await symlink(relativePath, linkPath, symlinkType);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function installSkillForAgent(
+  skill: Skill,
+  agentType: AgentType,
+  options: { global?: boolean; cwd?: string; mode?: InstallMode } = {}
+): Promise<InstallResult> {
+  const agent = agents[agentType];
+  const isGlobal = options.global ?? false;
+  const cwd = options.cwd || process.cwd();
+
+  if (isGlobal && agent.globalSkillsDir === undefined) {
+    return {
+      success: false,
+      path: '',
+      mode: options.mode ?? 'symlink',
+      error: `${agent.displayName} does not support global skill installation`,
+    };
+  }
+
+  const rawSkillName = skill.name || basename(skill.path);
+  const skillName = sanitizeName(rawSkillName);
+
+  const canonicalBase = getCanonicalSkillsDir(isGlobal, cwd);
+  const canonicalDir = join(canonicalBase, skillName);
+
+  const agentBase = getAgentBaseDir(agentType, isGlobal, cwd);
+  const agentDir = join(agentBase, skillName);
+
+  const installMode = options.mode ?? 'symlink';
+
+  if (!isPathSafe(canonicalBase, canonicalDir)) {
+    return {
+      success: false,
+      path: agentDir,
+      mode: installMode,
+      error: 'Invalid skill name: potential path traversal detected',
+    };
+  }
+
+  if (!isPathSafe(agentBase, agentDir)) {
+    return {
+      success: false,
+      path: agentDir,
+      mode: installMode,
+      error: 'Invalid skill name: potential path traversal detected',
+    };
+  }
+
+  try {
+    if (installMode === 'copy') {
+      await cleanAndCreateDirectory(agentDir);
+      await copyDirectory(skill.path, agentDir);
+
+      return {
+        success: true,
+        path: agentDir,
+        mode: 'copy',
+      };
+    }
+
+    // Symlink mode: copy to canonical location and symlink to agent location
+    await cleanAndCreateDirectory(canonicalDir);
+    await copyDirectory(skill.path, canonicalDir);
+
+    if (isGlobal && isUniversalAgent(agentType)) {
+      return {
+        success: true,
+        path: canonicalDir,
+        canonicalPath: canonicalDir,
+        mode: 'symlink',
+      };
+    }
+
+    const symlinkCreated = await createSymlink(canonicalDir, agentDir);
+
+    if (!symlinkCreated) {
+      await cleanAndCreateDirectory(agentDir);
+      await copyDirectory(skill.path, agentDir);
+
+      return {
+        success: true,
+        path: agentDir,
+        canonicalPath: canonicalDir,
+        mode: 'symlink',
+        symlinkFailed: true,
+      };
+    }
+
+    return {
+      success: true,
+      path: agentDir,
+      canonicalPath: canonicalDir,
+      mode: 'symlink',
+    };
+  } catch (error) {
+    return {
+      success: false,
+      path: agentDir,
+      mode: installMode,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    };
+  }
+}
+
+const EXCLUDE_FILES = new Set(['metadata.json']);
+const EXCLUDE_DIRS = new Set(['.git']);
+
+const isExcluded = (name: string, isDirectory: boolean = false): boolean => {
+  if (EXCLUDE_FILES.has(name)) return true;
+  if (name.startsWith('_')) return true;
+  if (isDirectory && EXCLUDE_DIRS.has(name)) return true;
+  return false;
+};
+
+async function copyDirectory(src: string, dest: string): Promise<void> {
+  await mkdir(dest, { recursive: true });
+
+  const entries = await readdir(src, { withFileTypes: true });
+
+  await Promise.all(
+    entries
+      .filter(entry => !isExcluded(entry.name, entry.isDirectory()))
+      .map(async entry => {
+        const srcPath = join(src, entry.name);
+        const destPath = join(dest, entry.name);
+
+        if (entry.isDirectory()) {
+          await copyDirectory(srcPath, destPath);
+        } else {
+          await cp(srcPath, destPath, {
+            dereference: true,
+            recursive: true,
+          });
+        }
+      })
+  );
+}
+
+export async function isSkillInstalled(
+  skillName: string,
+  agentType: AgentType,
+  options: { global?: boolean; cwd?: string } = {}
+): Promise<boolean> {
+  const agent = agents[agentType];
+  const sanitized = sanitizeName(skillName);
+
+  if (options.global && agent.globalSkillsDir === undefined) {
+    return false;
+  }
+
+  const targetBase = options.global
+    ? agent.globalSkillsDir!
+    : join(options.cwd || process.cwd(), agent.skillsDir);
+
+  const skillDir = join(targetBase, sanitized);
+
+  if (!isPathSafe(targetBase, skillDir)) {
+    return false;
+  }
+
+  try {
+    await access(skillDir);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Gets the canonical .agents/skills/<skill> path
+ */
+export function getCanonicalPath(
+  skillName: string,
+  options: { global?: boolean; cwd?: string } = {}
+): string {
+  const sanitized = sanitizeName(skillName);
+  const canonicalBase = getCanonicalSkillsDir(options.global ?? false, options.cwd);
+  const canonicalPath = join(canonicalBase, sanitized);
+
+  if (!isPathSafe(canonicalBase, canonicalPath)) {
+    throw new Error('Invalid skill name: potential path traversal detected');
+  }
+
+  return canonicalPath;
+}

--- a/ts/packages/cli/src/skills/installer.ts
+++ b/ts/packages/cli/src/skills/installer.ts
@@ -141,11 +141,14 @@ async function createSymlink(target: string, linkPath: string): Promise<boolean>
     const linkDir = dirname(linkPath);
     await mkdir(linkDir, { recursive: true });
 
-    const realLinkDir = await resolveParentSymlinks(linkDir);
-    const relativePath = relative(realLinkDir, target);
-    const symlinkType = platform() === 'win32' ? 'junction' : undefined;
+    const isWindows = platform() === 'win32';
+    const symlinkType = isWindows ? 'junction' : undefined;
+    // Windows junctions require absolute target paths; other platforms use relative.
+    const symlinkTarget = isWindows
+      ? resolvedTarget
+      : relative(await resolveParentSymlinks(linkDir), target);
 
-    await symlink(relativePath, linkPath, symlinkType);
+    await symlink(symlinkTarget, linkPath, symlinkType);
     return true;
   } catch {
     return false;

--- a/ts/packages/cli/src/skills/installer.ts
+++ b/ts/packages/cli/src/skills/installer.ts
@@ -318,21 +318,3 @@ export async function isSkillInstalled(
     return false;
   }
 }
-
-/**
- * Gets the canonical .agents/skills/<skill> path
- */
-export function getCanonicalPath(
-  skillName: string,
-  options: { global?: boolean; cwd?: string } = {}
-): string {
-  const sanitized = sanitizeName(skillName);
-  const canonicalBase = getCanonicalSkillsDir(options.global ?? false, options.cwd);
-  const canonicalPath = join(canonicalBase, sanitized);
-
-  if (!isPathSafe(canonicalBase, canonicalPath)) {
-    throw new Error('Invalid skill name: potential path traversal detected');
-  }
-
-  return canonicalPath;
-}

--- a/ts/packages/cli/src/skills/prompts/search-multiselect.ts
+++ b/ts/packages/cli/src/skills/prompts/search-multiselect.ts
@@ -1,0 +1,300 @@
+// Ported from ts/vendor/skills/src/prompts/search-multiselect.ts
+// Custom Clack-style interactive search multiselect prompt.
+// Modified to write to process.stderr instead of process.stdout for CLI decoration convention.
+
+import * as readline from 'readline';
+import { Writable } from 'stream';
+import pc from 'picocolors';
+
+// Silent writable stream to prevent readline from echoing input
+const silentOutput = new Writable({
+  write(_chunk, _encoding, callback) {
+    callback();
+  },
+});
+
+export interface SearchItem<T> {
+  value: T;
+  label: string;
+  hint?: string;
+}
+
+export interface LockedSection<T> {
+  title: string;
+  items: SearchItem<T>[];
+}
+
+export interface SearchMultiselectOptions<T> {
+  message: string;
+  items: SearchItem<T>[];
+  maxVisible?: number;
+  initialSelected?: T[];
+  /** If true, require at least one item to be selected before submitting */
+  required?: boolean;
+  /** Locked section shown above the searchable list - items are always selected and can't be toggled */
+  lockedSection?: LockedSection<T>;
+}
+
+const S_STEP_ACTIVE = pc.green('◆');
+const S_STEP_CANCEL = pc.red('■');
+const S_STEP_SUBMIT = pc.green('◇');
+const S_RADIO_ACTIVE = pc.green('●');
+const S_RADIO_INACTIVE = pc.dim('○');
+const S_BULLET = pc.green('•');
+const S_BAR = pc.dim('│');
+const S_BAR_H = pc.dim('─');
+
+export const cancelSymbol = Symbol('cancel');
+
+/**
+ * Interactive search multiselect prompt.
+ * Allows users to filter a long list by typing and select multiple items.
+ * Optionally supports a "locked" section that displays always-selected items.
+ *
+ * Writes all decoration to process.stderr (Composio CLI convention).
+ */
+export async function searchMultiselect<T>(
+  options: SearchMultiselectOptions<T>
+): Promise<T[] | symbol> {
+  const {
+    message,
+    items,
+    maxVisible = 8,
+    initialSelected = [],
+    required = false,
+    lockedSection,
+  } = options;
+
+  // Use stderr for all output (CLI decoration convention)
+  const output = process.stderr;
+
+  return new Promise(resolve => {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: silentOutput,
+      terminal: false,
+    });
+
+    // Enable raw mode for keypress detection
+    if (process.stdin.isTTY) {
+      process.stdin.setRawMode(true);
+    }
+    readline.emitKeypressEvents(process.stdin, rl);
+
+    let query = '';
+    let cursor = 0;
+    const selected = new Set<T>(initialSelected);
+    let lastRenderHeight = 0;
+
+    // Locked items are always included in the result
+    const lockedValues = lockedSection ? lockedSection.items.map(i => i.value) : [];
+
+    const filter = (item: SearchItem<T>, q: string): boolean => {
+      if (!q) return true;
+      const lowerQ = q.toLowerCase();
+      return (
+        item.label.toLowerCase().includes(lowerQ) ||
+        String(item.value).toLowerCase().includes(lowerQ)
+      );
+    };
+
+    const getFiltered = (): SearchItem<T>[] => {
+      return items.filter(item => filter(item, query));
+    };
+
+    const clearRender = (): void => {
+      if (lastRenderHeight > 0) {
+        output.write(`\x1b[${lastRenderHeight}A`);
+        for (let i = 0; i < lastRenderHeight; i++) {
+          output.write('\x1b[2K\x1b[1B');
+        }
+        output.write(`\x1b[${lastRenderHeight}A`);
+      }
+    };
+
+    const render = (state: 'active' | 'submit' | 'cancel' = 'active'): void => {
+      clearRender();
+
+      const lines: string[] = [];
+      const filtered = getFiltered();
+
+      // Header
+      const icon =
+        state === 'active' ? S_STEP_ACTIVE : state === 'cancel' ? S_STEP_CANCEL : S_STEP_SUBMIT;
+      lines.push(`${icon}  ${pc.bold(message)}`);
+
+      if (state === 'active') {
+        // Locked section (universal agents)
+        if (lockedSection && lockedSection.items.length > 0) {
+          lines.push(`${S_BAR}`);
+          const lockedTitle = `${pc.bold(lockedSection.title)} ${pc.dim('── always included')}`;
+          lines.push(`${S_BAR}  ${S_BAR_H}${S_BAR_H} ${lockedTitle} ${S_BAR_H.repeat(12)}`);
+          for (const item of lockedSection.items) {
+            lines.push(`${S_BAR}    ${S_BULLET} ${pc.bold(item.label)}`);
+          }
+          lines.push(`${S_BAR}`);
+          lines.push(
+            `${S_BAR}  ${S_BAR_H}${S_BAR_H} ${pc.bold('Additional agents')} ${S_BAR_H.repeat(29)}`
+          );
+        }
+
+        // Search input
+        const searchLine = `${S_BAR}  ${pc.dim('Search:')} ${query}${pc.inverse(' ')}`;
+        lines.push(searchLine);
+
+        // Hint
+        lines.push(`${S_BAR}  ${pc.dim('↑↓ move, space select, enter confirm')}`);
+        lines.push(`${S_BAR}`);
+
+        // Items
+        const visibleStart = Math.max(
+          0,
+          Math.min(cursor - Math.floor(maxVisible / 2), filtered.length - maxVisible)
+        );
+        const visibleEnd = Math.min(filtered.length, visibleStart + maxVisible);
+        const visibleItems = filtered.slice(visibleStart, visibleEnd);
+
+        if (filtered.length === 0) {
+          lines.push(`${S_BAR}  ${pc.dim('No matches found')}`);
+        } else {
+          for (let i = 0; i < visibleItems.length; i++) {
+            const item = visibleItems[i]!;
+            const actualIndex = visibleStart + i;
+            const isSelected = selected.has(item.value);
+            const isCursor = actualIndex === cursor;
+
+            const radio = isSelected ? S_RADIO_ACTIVE : S_RADIO_INACTIVE;
+            const label = isCursor ? pc.underline(item.label) : item.label;
+            const hint = item.hint ? pc.dim(` (${item.hint})`) : '';
+
+            const prefix = isCursor ? pc.cyan('❯') : ' ';
+            lines.push(`${S_BAR} ${prefix} ${radio} ${label}${hint}`);
+          }
+
+          // Show count if more items
+          const hiddenBefore = visibleStart;
+          const hiddenAfter = filtered.length - visibleEnd;
+          if (hiddenBefore > 0 || hiddenAfter > 0) {
+            const parts: string[] = [];
+            if (hiddenBefore > 0) parts.push(`↑ ${hiddenBefore} more`);
+            if (hiddenAfter > 0) parts.push(`↓ ${hiddenAfter} more`);
+            lines.push(`${S_BAR}  ${pc.dim(parts.join('  '))}`);
+          }
+        }
+
+        // Selected summary (include locked items)
+        lines.push(`${S_BAR}`);
+        const allSelectedLabels = [
+          ...(lockedSection ? lockedSection.items.map(i => i.label) : []),
+          ...items.filter(item => selected.has(item.value)).map(item => item.label),
+        ];
+        if (allSelectedLabels.length === 0) {
+          lines.push(`${S_BAR}  ${pc.dim('Selected: (none)')}`);
+        } else {
+          const summary =
+            allSelectedLabels.length <= 3
+              ? allSelectedLabels.join(', ')
+              : `${allSelectedLabels.slice(0, 3).join(', ')} +${allSelectedLabels.length - 3} more`;
+          lines.push(`${S_BAR}  ${pc.green('Selected:')} ${summary}`);
+        }
+
+        lines.push(`${pc.dim('└')}`);
+      } else if (state === 'submit') {
+        const allSelectedLabels = [
+          ...(lockedSection ? lockedSection.items.map(i => i.label) : []),
+          ...items.filter(item => selected.has(item.value)).map(item => item.label),
+        ];
+        lines.push(`${S_BAR}  ${pc.dim(allSelectedLabels.join(', '))}`);
+      } else if (state === 'cancel') {
+        lines.push(`${S_BAR}  ${pc.strikethrough(pc.dim('Cancelled'))}`);
+      }
+
+      output.write(lines.join('\n') + '\n');
+      lastRenderHeight = lines.length;
+    };
+
+    const cleanup = (): void => {
+      process.stdin.removeListener('keypress', keypressHandler);
+      if (process.stdin.isTTY) {
+        process.stdin.setRawMode(false);
+      }
+      rl.close();
+    };
+
+    const submit = (): void => {
+      if (required && selected.size === 0 && lockedValues.length === 0) {
+        return;
+      }
+      render('submit');
+      cleanup();
+      resolve([...lockedValues, ...Array.from(selected)]);
+    };
+
+    const cancel = (): void => {
+      render('cancel');
+      cleanup();
+      resolve(cancelSymbol);
+    };
+
+    const keypressHandler = (_str: string, key: readline.Key): void => {
+      if (!key) return;
+
+      const filtered = getFiltered();
+
+      if (key.name === 'return') {
+        submit();
+        return;
+      }
+
+      if (key.name === 'escape' || (key.ctrl && key.name === 'c')) {
+        cancel();
+        return;
+      }
+
+      if (key.name === 'up') {
+        cursor = Math.max(0, cursor - 1);
+        render();
+        return;
+      }
+
+      if (key.name === 'down') {
+        cursor = Math.min(filtered.length - 1, cursor + 1);
+        render();
+        return;
+      }
+
+      if (key.name === 'space') {
+        const item = filtered[cursor];
+        if (item) {
+          if (selected.has(item.value)) {
+            selected.delete(item.value);
+          } else {
+            selected.add(item.value);
+          }
+        }
+        render();
+        return;
+      }
+
+      if (key.name === 'backspace') {
+        query = query.slice(0, -1);
+        cursor = 0;
+        render();
+        return;
+      }
+
+      // Regular character input
+      if (key.sequence && !key.ctrl && !key.meta && key.sequence.length === 1) {
+        query += key.sequence;
+        cursor = 0;
+        render();
+        return;
+      }
+    };
+
+    process.stdin.on('keypress', keypressHandler);
+
+    // Initial render
+    render();
+  });
+}

--- a/ts/packages/cli/src/skills/prompts/search-multiselect.ts
+++ b/ts/packages/cli/src/skills/prompts/search-multiselect.ts
@@ -237,58 +237,63 @@ export async function searchMultiselect<T>(
     };
 
     const keypressHandler = (_str: string, key: readline.Key): void => {
-      if (!key) return;
+      try {
+        if (!key) return;
 
-      const filtered = getFiltered();
+        const filtered = getFiltered();
 
-      if (key.name === 'return') {
-        submit();
-        return;
-      }
-
-      if (key.name === 'escape' || (key.ctrl && key.name === 'c')) {
-        cancel();
-        return;
-      }
-
-      if (key.name === 'up') {
-        cursor = Math.max(0, cursor - 1);
-        render();
-        return;
-      }
-
-      if (key.name === 'down') {
-        cursor = Math.min(filtered.length - 1, cursor + 1);
-        render();
-        return;
-      }
-
-      if (key.name === 'space') {
-        const item = filtered[cursor];
-        if (item) {
-          if (selected.has(item.value)) {
-            selected.delete(item.value);
-          } else {
-            selected.add(item.value);
-          }
+        if (key.name === 'return') {
+          submit();
+          return;
         }
-        render();
-        return;
-      }
 
-      if (key.name === 'backspace') {
-        query = query.slice(0, -1);
-        cursor = 0;
-        render();
-        return;
-      }
+        if (key.name === 'escape' || (key.ctrl && key.name === 'c')) {
+          cancel();
+          return;
+        }
 
-      // Regular character input
-      if (key.sequence && !key.ctrl && !key.meta && key.sequence.length === 1) {
-        query += key.sequence;
-        cursor = 0;
-        render();
-        return;
+        if (key.name === 'up') {
+          cursor = Math.max(0, cursor - 1);
+          render();
+          return;
+        }
+
+        if (key.name === 'down') {
+          cursor = Math.min(filtered.length - 1, cursor + 1);
+          render();
+          return;
+        }
+
+        if (key.name === 'space') {
+          const item = filtered[cursor];
+          if (item) {
+            if (selected.has(item.value)) {
+              selected.delete(item.value);
+            } else {
+              selected.add(item.value);
+            }
+          }
+          render();
+          return;
+        }
+
+        if (key.name === 'backspace') {
+          query = query.slice(0, -1);
+          cursor = 0;
+          render();
+          return;
+        }
+
+        // Regular character input
+        if (key.sequence && !key.ctrl && !key.meta && key.sequence.length === 1) {
+          query += key.sequence;
+          cursor = 0;
+          render();
+          return;
+        }
+      } catch {
+        cleanup();
+        resolve(cancelSymbol);
       }
     };
 

--- a/ts/packages/cli/src/skills/summary.ts
+++ b/ts/packages/cli/src/skills/summary.ts
@@ -6,7 +6,7 @@ import { sep } from 'path';
 import pc from 'picocolors';
 import type { AgentType, InstallMode, InstallResult, Skill } from './types';
 import { agents, isUniversalAgent } from './agents';
-import { getCanonicalPath, isSkillInstalled } from './installer';
+import { isSkillInstalled } from './installer';
 import { getSkillDisplayName } from './discovery';
 
 /**
@@ -55,32 +55,6 @@ export function splitAgentsByType(agentTypes: AgentType[]): {
   }
 
   return { universal, symlinked };
-}
-
-/**
- * Builds summary lines showing universal vs symlinked agents
- */
-export function buildAgentSummaryLines(
-  targetAgents: AgentType[],
-  installMode: InstallMode
-): string[] {
-  const lines: string[] = [];
-  const { universal, symlinked } = splitAgentsByType(targetAgents);
-
-  if (installMode === 'symlink') {
-    if (universal.length > 0) {
-      lines.push(`  ${pc.green('universal:')} ${formatList(universal)}`);
-    }
-    if (symlinked.length > 0) {
-      lines.push(`  ${pc.dim('symlink →')} ${formatList(symlinked)}`);
-    }
-  } else {
-    // Copy mode - all agents get copies
-    const allNames = targetAgents.map(a => agents[a].displayName);
-    lines.push(`  ${pc.dim('copy →')} ${formatList(allNames)}`);
-  }
-
-  return lines;
 }
 
 /**
@@ -157,38 +131,6 @@ export async function checkOverwrites(
     status.get(skillName)!.set(agent, installed);
   }
   return status;
-}
-
-/**
- * Builds the pre-installation summary lines (skills, agents, overwrites).
- */
-export function buildInstallationSummary(
-  skills: Skill[],
-  targetAgents: AgentType[],
-  installMode: InstallMode,
-  installGlobally: boolean,
-  cwd: string,
-  overwriteStatus: Map<string, Map<string, boolean>>
-): string[] {
-  const summaryLines: string[] = [];
-  for (const skill of skills) {
-    if (summaryLines.length > 0) summaryLines.push('');
-
-    const canonicalPath = getCanonicalPath(skill.name, { global: installGlobally, cwd });
-    const shortCanonical = shortenPath(canonicalPath, cwd);
-    summaryLines.push(shortCanonical);
-    summaryLines.push(...buildAgentSummaryLines(targetAgents, installMode));
-
-    const skillOverwrites = overwriteStatus.get(skill.name);
-    const overwriteAgents = targetAgents
-      .filter(a => skillOverwrites?.get(a))
-      .map(a => agents[a].displayName);
-
-    if (overwriteAgents.length > 0) {
-      summaryLines.push(`  ${pc.yellow('overwrites:')} ${formatList(overwriteAgents)}`);
-    }
-  }
-  return summaryLines;
 }
 
 /**

--- a/ts/packages/cli/src/skills/summary.ts
+++ b/ts/packages/cli/src/skills/summary.ts
@@ -1,0 +1,293 @@
+// Ported from ts/vendor/skills/src/add.ts (display helper functions only)
+// Builds installation summary and result lines for display.
+
+import { homedir } from 'os';
+import { sep } from 'path';
+import pc from 'picocolors';
+import type { AgentType, InstallMode, InstallResult, Skill } from './types';
+import { agents, isUniversalAgent } from './agents';
+import { getCanonicalPath, isSkillInstalled } from './installer';
+import { getSkillDisplayName } from './discovery';
+
+/**
+ * Shortens a path for display: replaces homedir with ~ and cwd with .
+ */
+export function shortenPath(fullPath: string, cwd: string): string {
+  const home = homedir();
+  if (fullPath === home || fullPath.startsWith(home + sep)) {
+    return '~' + fullPath.slice(home.length);
+  }
+  if (fullPath === cwd || fullPath.startsWith(cwd + sep)) {
+    return '.' + fullPath.slice(cwd.length);
+  }
+  return fullPath;
+}
+
+/**
+ * Formats a list of items, truncating if too many
+ */
+export function formatList(items: string[], maxShow: number = 5): string {
+  if (items.length <= maxShow) {
+    return items.join(', ');
+  }
+  const shown = items.slice(0, maxShow);
+  const remaining = items.length - maxShow;
+  return `${shown.join(', ')} +${remaining} more`;
+}
+
+/**
+ * Splits agents into universal and non-universal (symlinked) groups.
+ * Returns display names for each group.
+ */
+export function splitAgentsByType(agentTypes: AgentType[]): {
+  universal: string[];
+  symlinked: string[];
+} {
+  const universal: string[] = [];
+  const symlinked: string[] = [];
+
+  for (const a of agentTypes) {
+    if (isUniversalAgent(a)) {
+      universal.push(agents[a].displayName);
+    } else {
+      symlinked.push(agents[a].displayName);
+    }
+  }
+
+  return { universal, symlinked };
+}
+
+/**
+ * Builds summary lines showing universal vs symlinked agents
+ */
+export function buildAgentSummaryLines(
+  targetAgents: AgentType[],
+  installMode: InstallMode
+): string[] {
+  const lines: string[] = [];
+  const { universal, symlinked } = splitAgentsByType(targetAgents);
+
+  if (installMode === 'symlink') {
+    if (universal.length > 0) {
+      lines.push(`  ${pc.green('universal:')} ${formatList(universal)}`);
+    }
+    if (symlinked.length > 0) {
+      lines.push(`  ${pc.dim('symlink →')} ${formatList(symlinked)}`);
+    }
+  } else {
+    // Copy mode - all agents get copies
+    const allNames = targetAgents.map(a => agents[a].displayName);
+    lines.push(`  ${pc.dim('copy →')} ${formatList(allNames)}`);
+  }
+
+  return lines;
+}
+
+/**
+ * Builds result lines from installation results, splitting by universal vs symlinked
+ */
+export function buildResultLines(
+  results: Array<{
+    agent: string;
+    symlinkFailed?: boolean;
+  }>,
+  targetAgents: AgentType[]
+): string[] {
+  const lines: string[] = [];
+
+  const { universal, symlinked: symlinkAgents } = splitAgentsByType(targetAgents);
+
+  const successfulSymlinks = results
+    .filter(r => !r.symlinkFailed && !universal.includes(r.agent))
+    .map(r => r.agent);
+  const failedSymlinks = results.filter(r => r.symlinkFailed).map(r => r.agent);
+
+  if (universal.length > 0) {
+    lines.push(`  ${pc.green('universal:')} ${formatList(universal)}`);
+  }
+  if (successfulSymlinks.length > 0) {
+    lines.push(`  ${pc.dim('symlinked:')} ${formatList(successfulSymlinks)}`);
+  }
+  if (failedSymlinks.length > 0) {
+    lines.push(`  ${pc.yellow('copied:')} ${formatList(failedSymlinks)}`);
+  }
+
+  return lines;
+}
+
+// ---------------------------------------------------------------------------
+// Installation summary (pre-install) and result display (post-install)
+// ---------------------------------------------------------------------------
+
+export interface SkillInstallEntry {
+  skill: string;
+  agent: string;
+  success: boolean;
+  path: string;
+  canonicalPath?: string;
+  mode: InstallMode;
+  symlinkFailed?: boolean;
+  error?: string;
+  pluginName?: string;
+}
+
+/**
+ * Checks which skills would overwrite existing installations.
+ * Returns a map of skillName -> agentType -> isInstalled.
+ */
+export async function checkOverwrites(
+  skills: Skill[],
+  targetAgents: AgentType[],
+  options: { global: boolean }
+): Promise<Map<string, Map<string, boolean>>> {
+  const checks = await Promise.all(
+    skills.flatMap(skill =>
+      targetAgents.map(async agent => ({
+        skillName: skill.name,
+        agent,
+        installed: await isSkillInstalled(skill.name, agent, { global: options.global }),
+      }))
+    )
+  );
+  const status = new Map<string, Map<string, boolean>>();
+  for (const { skillName, agent, installed } of checks) {
+    if (!status.has(skillName)) {
+      status.set(skillName, new Map());
+    }
+    status.get(skillName)!.set(agent, installed);
+  }
+  return status;
+}
+
+/**
+ * Builds the pre-installation summary lines (skills, agents, overwrites).
+ */
+export function buildInstallationSummary(
+  skills: Skill[],
+  targetAgents: AgentType[],
+  installMode: InstallMode,
+  installGlobally: boolean,
+  cwd: string,
+  overwriteStatus: Map<string, Map<string, boolean>>
+): string[] {
+  const summaryLines: string[] = [];
+  for (const skill of skills) {
+    if (summaryLines.length > 0) summaryLines.push('');
+
+    const canonicalPath = getCanonicalPath(skill.name, { global: installGlobally, cwd });
+    const shortCanonical = shortenPath(canonicalPath, cwd);
+    summaryLines.push(shortCanonical);
+    summaryLines.push(...buildAgentSummaryLines(targetAgents, installMode));
+
+    const skillOverwrites = overwriteStatus.get(skill.name);
+    const overwriteAgents = targetAgents
+      .filter(a => skillOverwrites?.get(a))
+      .map(a => agents[a].displayName);
+
+    if (overwriteAgents.length > 0) {
+      summaryLines.push(`  ${pc.yellow('overwrites:')} ${formatList(overwriteAgents)}`);
+    }
+  }
+  return summaryLines;
+}
+
+/**
+ * Installs all skills to all target agents.
+ * Returns an array of per-skill-per-agent results.
+ */
+export async function installAllSkills(
+  skills: Skill[],
+  targetAgents: AgentType[],
+  options: { global: boolean; mode: InstallMode; cwd: string }
+): Promise<SkillInstallEntry[]> {
+  const { installSkillForAgent } = await import('./installer');
+
+  const allResults: SkillInstallEntry[] = [];
+  for (const skill of skills) {
+    for (const agent of targetAgents) {
+      const result = await installSkillForAgent(skill, agent, {
+        global: options.global,
+        mode: options.mode,
+        cwd: options.cwd,
+      });
+      allResults.push({
+        skill: getSkillDisplayName(skill),
+        agent: agents[agent].displayName,
+        pluginName: skill.pluginName,
+        ...result,
+      });
+    }
+  }
+  return allResults;
+}
+
+/**
+ * Builds the post-installation result display lines.
+ */
+export function buildInstallationResultDisplay(
+  results: SkillInstallEntry[],
+  targetAgents: AgentType[],
+  cwd: string
+): {
+  resultNoteLines: string[];
+  resultNoteTitle: string;
+  symlinkWarning: { agents: string[] } | null;
+  failedLines: string[];
+} {
+  const successful = results.filter(r => r.success);
+  const failed = results.filter(r => !r.success);
+
+  const resultNoteLines: string[] = [];
+  let resultNoteTitle = '';
+  let symlinkWarning: { agents: string[] } | null = null;
+
+  if (successful.length > 0) {
+    const bySkill = new Map<string, SkillInstallEntry[]>();
+    for (const r of successful) {
+      const skillResults = bySkill.get(r.skill) || [];
+      skillResults.push(r);
+      bySkill.set(r.skill, skillResults);
+    }
+
+    const skillCount = bySkill.size;
+
+    for (const [skillName, skillResults] of bySkill) {
+      const firstResult = skillResults[0]!;
+
+      if (firstResult.mode === 'copy') {
+        resultNoteLines.push(`${pc.green('✓')} ${skillName} ${pc.dim('(copied)')}`);
+        for (const r of skillResults) {
+          const shortPath = shortenPath(r.path, cwd);
+          resultNoteLines.push(`  ${pc.dim('→')} ${shortPath}`);
+        }
+      } else {
+        if (firstResult.canonicalPath) {
+          const shortPath = shortenPath(firstResult.canonicalPath, cwd);
+          resultNoteLines.push(`${pc.green('✓')} ${shortPath}`);
+        } else {
+          resultNoteLines.push(`${pc.green('✓')} ${skillName}`);
+        }
+        resultNoteLines.push(...buildResultLines(skillResults, targetAgents));
+      }
+    }
+
+    resultNoteTitle = pc.green(`Installed ${skillCount} skill${skillCount !== 1 ? 's' : ''}`);
+
+    const symlinkFailures = successful.filter(r => r.mode === 'symlink' && r.symlinkFailed);
+    if (symlinkFailures.length > 0) {
+      symlinkWarning = { agents: symlinkFailures.map(r => r.agent) };
+    }
+  }
+
+  const failedLines: string[] = [];
+  if (failed.length > 0) {
+    failedLines.push(`Failed to install ${failed.length}`);
+    for (const r of failed) {
+      failedLines.push(
+        `  ${pc.red('✗')} ${r.skill} → ${r.agent}: ${pc.dim(r.error ?? 'Unknown error')}`
+      );
+    }
+  }
+
+  return { resultNoteLines, resultNoteTitle, symlinkWarning, failedLines };
+}

--- a/ts/packages/cli/src/skills/types.ts
+++ b/ts/packages/cli/src/skills/types.ts
@@ -1,0 +1,78 @@
+// Ported from ts/vendor/skills/src/types.ts
+// Only types needed for the init flow skills installation.
+
+export type AgentType =
+  | 'amp'
+  | 'antigravity'
+  | 'augment'
+  | 'claude-code'
+  | 'openclaw'
+  | 'cline'
+  | 'codebuddy'
+  | 'codex'
+  | 'command-code'
+  | 'continue'
+  | 'cortex'
+  | 'crush'
+  | 'cursor'
+  | 'droid'
+  | 'gemini-cli'
+  | 'github-copilot'
+  | 'goose'
+  | 'iflow-cli'
+  | 'junie'
+  | 'kilo'
+  | 'kimi-cli'
+  | 'kiro-cli'
+  | 'kode'
+  | 'mcpjam'
+  | 'mistral-vibe'
+  | 'mux'
+  | 'neovate'
+  | 'opencode'
+  | 'openhands'
+  | 'pi'
+  | 'qoder'
+  | 'qwen-code'
+  | 'replit'
+  | 'roo'
+  | 'trae'
+  | 'trae-cn'
+  | 'windsurf'
+  | 'zencoder'
+  | 'pochi'
+  | 'adal'
+  | 'universal';
+
+export interface Skill {
+  name: string;
+  description: string;
+  path: string;
+  /** Raw SKILL.md content for hashing */
+  rawContent?: string;
+  /** Name of the plugin this skill belongs to (if any) */
+  pluginName?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface AgentConfig {
+  name: string;
+  displayName: string;
+  skillsDir: string;
+  /** Global skills directory. Set to undefined if the agent doesn't support global installation. */
+  globalSkillsDir: string | undefined;
+  detectInstalled: () => Promise<boolean>;
+  /** Whether to show this agent in the universal agents list. Defaults to true. */
+  showInUniversalList?: boolean;
+}
+
+export type InstallMode = 'symlink' | 'copy';
+
+export interface InstallResult {
+  success: boolean;
+  path: string;
+  canonicalPath?: string;
+  mode: InstallMode;
+  symlinkFailed?: boolean;
+  error?: string;
+}

--- a/ts/packages/cli/test/__utils__/services/terminal-ui-test.ts
+++ b/ts/packages/cli/test/__utils__/services/terminal-ui-test.ts
@@ -28,6 +28,8 @@ export const TerminalUITest = Layer.succeed(
 
     select: (_message, options) => Effect.succeed(options[0].value),
 
+    multiSelect: (_message, options) => Effect.succeed(options.map(o => o.value)),
+
     confirm: (_message, options) => Effect.succeed(options?.defaultValue ?? true),
 
     withSpinner: (message, effect, options) =>

--- a/ts/packages/cli/test/src/commands/__snapshots__/$default.cmd.test.ts.snap
+++ b/ts/packages/cli/test/src/commands/__snapshots__/$default.cmd.test.ts.snap
@@ -35,7 +35,7 @@ Composio CLI - A tool for managing Python and TypeScript composio.dev projects.
 
   - logout                                                                                                                                                                                                                                                                                                   Log out from the Composio SDK.
 
-  - init [--org-id text] [--project-id text] [--no-browser] [(-y, --yes)]                                                                                                                                                                                                                                    Initialize a Composio project in the current directory.
+  - init [--org-id text] [--project-id text] [--no-browser] [--dry-run] [--force] [(-y, --yes)] [--no-skills]                                                                                                                                                                                                Initialize a Composio project in the current directory.
 
   - generate [(-o, --output-dir directory)] [--type-tools] --toolkits text...                                                                                                                                                                                                                                Generate type stubs for toolkits, tools, and triggers, auto-detecting project language (TypeScript | Python)
 

--- a/ts/packages/cli/test/src/commands/init.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/init.cmd.test.ts
@@ -8,7 +8,7 @@ import { cli, TestLive, MockConsole } from 'test/__utils__';
 describe('CLI: composio init', () => {
   describe('[Given] --org-id + --project-id flags', () => {
     layer(TestLive({ fixture: 'typescript-project' }))(it => {
-      it.scoped('[Then] it initializes project config and prints machine output', () =>
+      it.scoped('[Then] it runs wizard, writes config, and prints machine output', () =>
         Effect.gen(function* () {
           const fs = yield* FileSystem.FileSystem;
           const proc = yield* NodeProcess;
@@ -23,6 +23,11 @@ describe('CLI: composio init', () => {
           expect(output).toContain('"org_id":"org1"');
           expect(output).toContain('"project_id":"proj1"');
 
+          // Wizard fields are present in structured output
+          expect(output).toContain('"usage_mode"');
+          expect(output).toContain('"install_skills"');
+
+          // project.json was created
           const projectConfigPath = path.join(proc.cwd, '.composio', 'project.json');
           const exists = yield* fs.exists(projectConfigPath);
           expect(exists).toBe(true);
@@ -32,7 +37,17 @@ describe('CLI: composio init', () => {
           expect(projectConfig.org_id).toBe('org1');
           expect(projectConfig.project_id).toBe('proj1');
 
-          // Verify no .env.local was created (env vars are printed, not written)
+          // config.json was created alongside project.json
+          const configJsonPath = path.join(proc.cwd, '.composio', 'config.json');
+          const configExists = yield* fs.exists(configJsonPath);
+          expect(configExists).toBe(true);
+
+          const configRaw = yield* fs.readFileString(configJsonPath, 'utf8');
+          const config = JSON.parse(configRaw) as Record<string, unknown>;
+          expect(config.usage_mode).toBe('native'); // first option selected by test TerminalUI
+          expect(config.install_skills).toBe(true); // confirm defaults to true
+
+          // No .env.local was created (env vars are printed, not written)
           const envLocalPath = path.join(proc.cwd, '.env.local');
           const envLocalExists = yield* fs.exists(envLocalPath);
           expect(envLocalExists).toBe(false);
@@ -43,7 +58,7 @@ describe('CLI: composio init', () => {
 
   describe('[Given] explicit project ids but no global credentials', () => {
     layer(TestLive({ fixture: 'typescript-project' }))(it => {
-      it.scoped('[Then] it warns and skips env var display', () =>
+      it.scoped('[Then] it runs wizard, writes config, and skips env var display', () =>
         Effect.gen(function* () {
           const fs = yield* FileSystem.FileSystem;
           const proc = yield* NodeProcess;
@@ -53,11 +68,15 @@ describe('CLI: composio init', () => {
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
+          // Wizard still ran (config.json should exist)
+          const configJsonPath = path.join(proc.cwd, '.composio', 'config.json');
+          const configExists = yield* fs.exists(configJsonPath);
+          expect(configExists).toBe(true);
+
           // Environment variables are not printed when there is no global API key
-          expect(output).not.toContain('Environment variables');
           expect(output).not.toContain('COMPOSIO_API_KEY');
 
-          // Verify no .env.local was created
+          // No .env.local was created
           const envLocalPath = path.join(proc.cwd, '.env.local');
           const envLocalExists = yield* fs.exists(envLocalPath);
           expect(envLocalExists).toBe(false);

--- a/ts/packages/cli/test/src/commands/init.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/init.cmd.test.ts
@@ -31,6 +31,11 @@ describe('CLI: composio init', () => {
           const projectConfig = JSON.parse(projectConfigRaw) as Record<string, unknown>;
           expect(projectConfig.org_id).toBe('org1');
           expect(projectConfig.project_id).toBe('proj1');
+
+          // Verify no .env.local was created (env vars are printed, not written)
+          const envLocalPath = path.join(proc.cwd, '.env.local');
+          const envLocalExists = yield* fs.exists(envLocalPath);
+          expect(envLocalExists).toBe(false);
         })
       );
     });
@@ -38,13 +43,24 @@ describe('CLI: composio init', () => {
 
   describe('[Given] explicit project ids but no global credentials', () => {
     layer(TestLive({ fixture: 'typescript-project' }))(it => {
-      it.scoped('[Then] it warns and skips .env.local creation', () =>
+      it.scoped('[Then] it warns and skips env var display', () =>
         Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const proc = yield* NodeProcess;
+
           yield* cli(['init', '--org-id', 'org1', '--project-id', 'proj1']);
 
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
-          expect(output).toContain('No global API key found; skipping .env.local creation.');
+
+          // Environment variables are not printed when there is no global API key
+          expect(output).not.toContain('Environment variables');
+          expect(output).not.toContain('COMPOSIO_API_KEY');
+
+          // Verify no .env.local was created
+          const envLocalPath = path.join(proc.cwd, '.env.local');
+          const envLocalExists = yield* fs.exists(envLocalPath);
+          expect(envLocalExists).toBe(false);
         })
       );
     });

--- a/ts/packages/cli/test/src/commands/init.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/init.cmd.test.ts
@@ -45,6 +45,12 @@ describe('CLI: composio init', () => {
           const configRaw = yield* fs.readFileString(configJsonPath, 'utf8');
           const config = JSON.parse(configRaw) as Record<string, unknown>;
           expect(config.usage_mode).toBe('native'); // first option selected by test TerminalUI
+          expect(config.frameworks).toEqual([
+            'ai-sdk',
+            'mastra',
+            'openai-agents',
+            'claude-agent-sdk',
+          ]); // multiSelect returns all options in test
           expect(config.install_skills).toBe(true); // confirm defaults to true
 
           // No .env.local was created (env vars are printed, not written)

--- a/ts/packages/cli/test/src/commands/init.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/init.cmd.test.ts
@@ -1,11 +1,80 @@
 import path from 'node:path';
 import { describe, expect, layer } from '@effect/vitest';
-import { Effect } from 'effect';
+import { Console, Effect, Exit } from 'effect';
 import { FileSystem } from '@effect/platform';
 import { NodeProcess } from 'src/services/node-process';
+import { TerminalUI } from 'src/services/terminal-ui';
+import { CommandRunner } from 'src/services/command-runner';
+import { CommandExecutor } from '@effect/platform';
 import { cli, TestLive, MockConsole } from 'test/__utils__';
 
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Read all captured output lines as a single string. */
+const getOutput = () =>
+  MockConsole.getLines({ stripAnsi: true }).pipe(Effect.map(lines => lines.join('\n')));
+
+/** Build a TerminalUI override that rejects at the confirmation prompt. */
+const terminalUIThatCancelsConfirm = TerminalUI.of({
+  output: data => Console.log(data),
+  intro: title => Console.log(`-- ${title} --`),
+  outro: message => Console.log(`-- ${message} --`),
+  log: {
+    info: message => Console.log(message),
+    success: message => Console.log(message),
+    warn: message => Console.warn(message),
+    error: message => Console.error(message),
+    step: message => Console.log(message),
+    message: message => Console.log(message),
+  },
+  note: (message, title) => Console.log(title ? `[${title}] ${message}` : message),
+  // confirm returns false → user cancelled
+  confirm: () => Effect.succeed(false),
+  select: (_message, options) => Effect.succeed(options[0].value),
+  multiSelect: (_message, options) => Effect.succeed(options.map(o => o.value)),
+  withSpinner: (_message, effect, options) =>
+    Effect.gen(function* () {
+      const result = yield* effect;
+      const successMsg =
+        typeof options?.successMessage === 'function'
+          ? options.successMessage(result)
+          : (options?.successMessage ?? _message);
+      yield* Console.log(successMsg);
+      return result;
+    }),
+  useMakeSpinner: (_message, use) =>
+    Effect.gen(function* () {
+      let stopped = false;
+      const handle = {
+        message: (_msg: string) => Effect.void,
+        stop: (msg?: string) =>
+          Effect.gen(function* () {
+            stopped = true;
+            if (msg) yield* Console.log(msg);
+          }),
+        error: (msg?: string) =>
+          Effect.gen(function* () {
+            stopped = true;
+            if (msg) yield* Console.error(msg);
+          }),
+      };
+      const exit = yield* Effect.exit(use(handle));
+      if (Exit.isFailure(exit) && !stopped) {
+        yield* Console.error(_message);
+      }
+      return yield* exit;
+    }),
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
 describe('CLI: composio init', () => {
+  // ── Agent-native path (--org-id + --project-id) ───────────────────
+
   describe('[Given] --org-id + --project-id flags', () => {
     layer(TestLive({ fixture: 'typescript-project' }))(it => {
       it.scoped('[Then] it runs wizard, writes config, and prints machine output', () =>
@@ -15,8 +84,7 @@ describe('CLI: composio init', () => {
 
           yield* cli(['init', '--org-id', 'org1', '--project-id', 'proj1', '--yes']);
 
-          const lines = yield* MockConsole.getLines({ stripAnsi: true });
-          const output = lines.join('\n');
+          const output = yield* getOutput();
 
           expect(output).toContain('-- composio init --');
           expect(output).toContain('Project initialized in');
@@ -52,11 +120,6 @@ describe('CLI: composio init', () => {
             'claude-agent-sdk',
           ]); // multiSelect returns all options in test
           expect(config.install_skills).toBe(true); // confirm defaults to true
-
-          // No .env.local was created (env vars are printed, not written)
-          const envLocalPath = path.join(proc.cwd, '.env.local');
-          const envLocalExists = yield* fs.exists(envLocalPath);
-          expect(envLocalExists).toBe(false);
         })
       );
     });
@@ -64,15 +127,14 @@ describe('CLI: composio init', () => {
 
   describe('[Given] explicit project ids but no global credentials', () => {
     layer(TestLive({ fixture: 'typescript-project' }))(it => {
-      it.scoped('[Then] it runs wizard, writes config, and skips env var display', () =>
+      it.scoped('[Then] it writes config but skips .env.local (no API key)', () =>
         Effect.gen(function* () {
           const fs = yield* FileSystem.FileSystem;
           const proc = yield* NodeProcess;
 
-          yield* cli(['init', '--org-id', 'org1', '--project-id', 'proj1']);
+          yield* cli(['init', '--org-id', 'org1', '--project-id', 'proj1', '--no-skills']);
 
-          const lines = yield* MockConsole.getLines({ stripAnsi: true });
-          const output = lines.join('\n');
+          const output = yield* getOutput();
 
           // Wizard still ran (config.json should exist)
           const configJsonPath = path.join(proc.cwd, '.composio', 'config.json');
@@ -82,10 +144,209 @@ describe('CLI: composio init', () => {
           // Environment variables are not printed when there is no global API key
           expect(output).not.toContain('COMPOSIO_API_KEY');
 
-          // No .env.local was created
-          const envLocalPath = path.join(proc.cwd, '.env.local');
+          // .env.local was NOT created inside .composio/ (no credentials to write)
+          const envLocalPath = path.join(proc.cwd, '.composio', '.env.local');
           const envLocalExists = yield* fs.exists(envLocalPath);
           expect(envLocalExists).toBe(false);
+        })
+      );
+    });
+  });
+
+  // ── --no-skills flag ──────────────────────────────────────────────
+
+  describe('[Given] --no-skills flag', () => {
+    layer(TestLive({ fixture: 'typescript-project' }))(it => {
+      it.scoped('[Then] it skips skills prompts and sets install_skills to false', () =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const proc = yield* NodeProcess;
+
+          yield* cli(['init', '--org-id', 'org1', '--project-id', 'proj1', '--yes', '--no-skills']);
+
+          const output = yield* getOutput();
+
+          // Skills-related prompts did not appear
+          expect(output).not.toContain('Cloning Composio skills');
+          expect(output).not.toContain('Installation scope');
+          expect(output).not.toContain('Installation method');
+
+          // config.json has install_skills: false
+          const configJsonPath = path.join(proc.cwd, '.composio', 'config.json');
+          const configRaw = yield* fs.readFileString(configJsonPath, 'utf8');
+          const config = JSON.parse(configRaw) as Record<string, unknown>;
+          expect(config.install_skills).toBe(false);
+
+          // Structured output also reflects no skills
+          expect(output).toContain('"install_skills":false');
+        })
+      );
+    });
+  });
+
+  // ── --yes flag (fully non-interactive) ─────────────────────────────
+
+  describe('[Given] --yes flag', () => {
+    layer(TestLive({ fixture: 'typescript-project' }))(it => {
+      it.scoped('[Then] it uses defaults for all prompts (native, all frameworks, skills)', () =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const proc = yield* NodeProcess;
+
+          yield* cli([
+            'init',
+            '--org-id',
+            'org1',
+            '--project-id',
+            'proj1',
+            '--yes',
+            '--no-skills', // skip skills to avoid interactive selectAgentsInteractive in test
+          ]);
+
+          const output = yield* getOutput();
+
+          // Config was written with defaults
+          const configJsonPath = path.join(proc.cwd, '.composio', 'config.json');
+          const configRaw = yield* fs.readFileString(configJsonPath, 'utf8');
+          const config = JSON.parse(configRaw) as Record<string, unknown>;
+          expect(config.usage_mode).toBe('native');
+          expect(config.frameworks).toEqual([
+            'ai-sdk',
+            'mastra',
+            'openai-agents',
+            'claude-agent-sdk',
+          ]);
+
+          // No interactive prompts were shown (usage mode, frameworks)
+          expect(output).not.toContain('How would you like to use Composio?');
+          expect(output).not.toContain('Which frameworks do you use?');
+
+          // Init completed
+          expect(output).toContain('Project initialized in');
+        })
+      );
+    });
+  });
+
+  // ── --dry-run flag ────────────────────────────────────────────────
+
+  describe('[Given] --dry-run flag', () => {
+    layer(TestLive({ fixture: 'typescript-project' }))(it => {
+      it.scoped('[Then] it shows summary but writes no files', () =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const proc = yield* NodeProcess;
+
+          yield* cli([
+            'init',
+            '--org-id',
+            'org1',
+            '--project-id',
+            'proj1',
+            '--yes',
+            '--dry-run',
+            '--no-skills',
+          ]);
+
+          const output = yield* getOutput();
+
+          expect(output).toContain('Dry run complete');
+
+          // No config files were written
+          const composioDir = path.join(proc.cwd, '.composio');
+          const projectJsonExists = yield* fs.exists(path.join(composioDir, 'project.json'));
+          const configJsonExists = yield* fs.exists(path.join(composioDir, 'config.json'));
+          const envLocalExists = yield* fs.exists(path.join(composioDir, '.env.local'));
+          expect(projectJsonExists).toBe(false);
+          expect(configJsonExists).toBe(false);
+          expect(envLocalExists).toBe(false);
+        })
+      );
+    });
+  });
+
+  // ── Cancellation at confirmation ──────────────────────────────────
+
+  describe('[Given] user cancels at confirmation prompt', () => {
+    layer(
+      TestLive({
+        fixture: 'typescript-project',
+        terminalUI: terminalUIThatCancelsConfirm,
+      })
+    )(it => {
+      it.scoped('[Then] it writes nothing and exits cleanly', () =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const proc = yield* NodeProcess;
+
+          yield* cli(['init', '--org-id', 'org1', '--project-id', 'proj1']);
+
+          const output = yield* getOutput();
+
+          expect(output).toContain('Installation cancelled');
+
+          // Nothing was written
+          const composioDir = path.join(proc.cwd, '.composio');
+          const projectJsonExists = yield* fs.exists(path.join(composioDir, 'project.json'));
+          const configJsonExists = yield* fs.exists(path.join(composioDir, 'config.json'));
+          expect(projectJsonExists).toBe(false);
+          expect(configJsonExists).toBe(false);
+        })
+      );
+    });
+  });
+
+  // ── Dep install failure ───────────────────────────────────────────
+
+  describe('[Given] dependency installation fails', () => {
+    layer(
+      TestLive({
+        fixture: 'typescript-project',
+        commandRunner: new CommandRunner({
+          run: () => Effect.succeed(CommandExecutor.ExitCode(1)),
+        }),
+      })
+    )(it => {
+      it.scoped('[Then] it shows fallback install command and still reports success', () =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const proc = yield* NodeProcess;
+
+          yield* cli(['init', '--org-id', 'org1', '--project-id', 'proj1', '--yes', '--no-skills']);
+
+          const output = yield* getOutput();
+
+          // Install failed but init still completed
+          expect(output).toContain('Install failed');
+          expect(output).toContain('Dependency installation failed. Install manually:');
+          expect(output).toContain('Project initialized in');
+
+          // Config was still written (Phase 3 writes config before install step)
+          const configJsonPath = path.join(proc.cwd, '.composio', 'config.json');
+          const configExists = yield* fs.exists(configJsonPath);
+          expect(configExists).toBe(true);
+        })
+      );
+    });
+  });
+
+  // ── .gitignore creation ───────────────────────────────────────────
+
+  describe('[Given] .composio directory does not exist', () => {
+    layer(TestLive({ fixture: 'typescript-project' }))(it => {
+      it.scoped('[Then] it creates .composio/.gitignore with wildcard', () =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const proc = yield* NodeProcess;
+
+          yield* cli(['init', '--org-id', 'org1', '--project-id', 'proj1', '--yes', '--no-skills']);
+
+          const gitignorePath = path.join(proc.cwd, '.composio', '.gitignore');
+          const gitignoreExists = yield* fs.exists(gitignorePath);
+          expect(gitignoreExists).toBe(true);
+
+          const content = yield* fs.readFileString(gitignorePath, 'utf8');
+          expect(content).toBe('*\n');
         })
       );
     });

--- a/ts/packages/cli/test/src/services/upgrade-binary.test.ts
+++ b/ts/packages/cli/test/src/services/upgrade-binary.test.ts
@@ -23,6 +23,7 @@ const TerminalUINoop = Layer.succeed(
     },
     note: () => Effect.void,
     select: (_message, options) => Effect.succeed(options[0].value),
+    multiSelect: (_message, options) => Effect.succeed(options.map(o => o.value)),
     confirm: () => Effect.succeed(true),
     withSpinner: (_message, effect) => effect,
     useMakeSpinner: (_message, use) =>


### PR DESCRIPTION
This PR:

- Restructures `composio init` into a 4-phase workflow: **COLLECT** (all prompts upfront) → **CONFIRM** (unified summary + single confirmation) → **EXECUTE** (write config, install deps + skills) → **OUTRO** (always shows API keys and manual fallback commands on failure)
- Adds inline skills installation: clones `composiohq/skills`, discovers SKILL.md files, prompts for agent targets / scope / method, then installs via symlink or copy
- Makes `--yes` / `-y` fully non-interactive — defaults to native mode, all frameworks, install skills, project scope, symlink method; zero TTY prompts required
- Writes API keys to `.composio/.env.local` (with `0o600` permissions) instead of only printing them
- Uses `Effect.acquireRelease` + `Effect.scoped` for temp directory lifecycle — cleanup is guaranteed on any exit path (success, failure, cancel, interrupt) with zero manual cleanup sites
- Adds `TerminalUI.multiSelect` backed by a custom `@clack/prompts`-style search-multiselect prompt
- Adds 8 test cases covering `--yes`, `--no-skills`, `--dry-run`, cancellation at confirm, partial dep failure, `.gitignore` creation, and no-credentials path

## How `composio init` works now

- **Phase 1 — COLLECT**: login (if needed) → select project → usage mode (native/MCP) → frameworks (multi-select) → skills (clone repo, discover, choose agents/scope/method) → detect environment + dependency plan. No files written.
- **Phase 2 — CONFIRM**: displays a unified summary of everything to install. `--dry-run` exits here. User gets a single confirmation prompt. Cancel = nothing written.
- **Phase 3 — EXECUTE**: resolves API keys (lazy), writes `.composio/project.json` + `config.json` + `.env.local`, installs SDK dependency, installs skills. Each step tracks success/failure independently.
- **Phase 4 — OUTRO** (always runs): shows API keys, prints manual install commands for any failed steps, prints success message.
- **`-y` mode**: bypasses every prompt with sensible defaults — native mode, all frameworks, detect installed agents + universals, project-scoped symlinks, auto-confirm.