### PR TITLE
fix(cli): fallback to global test user id for action commands

### DIFF
--- a/.changeset/short-singers-fix.md
+++ b/.changeset/short-singers-fix.md
@@ -1,0 +1,5 @@
+---
+'@composio/cli': patch
+---
+
+Fallback to gloabl user_id if project user_id is not present

--- a/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
+++ b/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
@@ -2,6 +2,7 @@ import { Args, Command, Options } from '@effect/cli';
 import { Effect, Option, Schedule } from 'effect';
 import open from 'open';
 import { ComposioToolkitsRepository } from 'src/services/composio-clients';
+import { ComposioUserContext } from 'src/services/user-context';
 import { TerminalUI } from 'src/services/terminal-ui';
 import { requireAuth } from 'src/effects/require-auth';
 import { handleHttpServerError } from 'src/effects/handle-http-error';
@@ -127,11 +128,13 @@ export const connectedAccountsCmd$Link = Command.make(
       const ui = yield* TerminalUI;
       const repo = yield* ComposioToolkitsRepository;
       const projectContext = yield* ProjectContext;
+      const userContext = yield* ComposioUserContext;
       const resolvedProjectContext = yield* projectContext.resolve;
       const testUserId = Option.flatMap(resolvedProjectContext, keys => keys.testUserId);
+      const globalTestUserId = userContext.data.testUserId;
       const resolvedUserId = Option.match(userId, {
         onSome: value => Option.some(value),
-        onNone: () => testUserId,
+        onNone: () => Option.orElse(testUserId, () => globalTestUserId),
       });
       if (Option.isNone(resolvedUserId)) {
         return yield* Effect.fail(
@@ -140,6 +143,8 @@ export const connectedAccountsCmd$Link = Command.make(
       }
       if (Option.isNone(userId) && Option.isSome(testUserId)) {
         yield* ui.log.warn(`Using test user id "${testUserId.value}"`);
+      } else if (Option.isNone(userId) && Option.isSome(globalTestUserId)) {
+        yield* ui.log.warn(`Using global test user id "${globalTestUserId.value}"`);
       }
 
       // Validate: exactly one of <toolkit> or --auth-config must be provided

--- a/ts/packages/cli/src/commands/tools/commands/tools.execute.cmd.ts
+++ b/ts/packages/cli/src/commands/tools/commands/tools.execute.cmd.ts
@@ -14,6 +14,7 @@ import {
 import type { ToolExecuteParams } from 'src/services/tools-executor';
 import { ProjectContext } from 'src/services/project-context';
 import { ComposioToolkitsRepository } from 'src/services/composio-clients';
+import { ComposioUserContext } from 'src/services/user-context';
 import {
   extractApiErrorDetails,
   extractMessage,
@@ -294,11 +295,13 @@ export const toolsCmd$Execute = Command.make(
       const ui = yield* TerminalUI;
       const executor = yield* ToolsExecutor;
       const projectContext = yield* ProjectContext;
+      const userContext = yield* ComposioUserContext;
       const resolvedProjectContext = yield* projectContext.resolve;
       const testUserId = Option.flatMap(resolvedProjectContext, keys => keys.testUserId);
+      const globalTestUserId = userContext.data.testUserId;
       const resolvedUserId = Option.match(userId, {
         onSome: value => Option.some(value),
-        onNone: () => testUserId,
+        onNone: () => Option.orElse(testUserId, () => globalTestUserId),
       });
       if (Option.isNone(resolvedUserId)) {
         return yield* Effect.fail(
@@ -307,6 +310,8 @@ export const toolsCmd$Execute = Command.make(
       }
       if (Option.isNone(userId) && Option.isSome(testUserId)) {
         yield* ui.log.warn(`Using test user id "${testUserId.value}"`);
+      } else if (Option.isNone(userId) && Option.isSome(globalTestUserId)) {
+        yield* ui.log.warn(`Using global test user id "${globalTestUserId.value}"`);
       }
 
       const input = yield* resolveInput(data);

--- a/ts/packages/cli/test/__fixtures__/global-test-user-id/.composio/user_data.json
+++ b/ts/packages/cli/test/__fixtures__/global-test-user-id/.composio/user_data.json
@@ -1,0 +1,8 @@
+{
+  "api_key": "test_api_key",
+  "base_url": "https://backend.composio.dev",
+  "web_url": "https://platform.composio.dev",
+  "org_id": null,
+  "project_id": null,
+  "test_user_id": "global-default"
+}

--- a/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.link.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.link.cmd.test.ts
@@ -81,6 +81,34 @@ describe('CLI: composio connected-accounts link', () => {
     }
   );
 
+  layer(
+    TestLive({
+      baseConfigProvider: testConfigProvider,
+      connectedAccountsData,
+      fixture: 'global-test-user-id',
+    })
+  )(
+    '[Given] no --user-id and no project test_user_id [Then] falls back to global test_user_id',
+    it => {
+      it.scoped('uses global test user id from user_data.json', () =>
+        Effect.gen(function* () {
+          yield* cli([
+            'connected-accounts',
+            'link',
+            '--auth-config',
+            'ac_gmail_oauth',
+            '--no-browser',
+          ]);
+          const lines = yield* MockConsole.getLines({ stripAnsi: true });
+          const output = lines.join('\n');
+
+          expect(output).toContain('Using global test user id "global-default"');
+          expect(output).toContain('https://app.composio.dev/link?token=lt_test_token');
+        })
+      );
+    }
+  );
+
   layer(TestLive())('[Given] no API key [Then] warns user to login', it => {
     it.scoped('warns user to login', () =>
       Effect.gen(function* () {

--- a/ts/packages/cli/test/src/commands/tools/tools.execute.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/tools/tools.execute.cmd.test.ts
@@ -74,6 +74,30 @@ describe('CLI: composio tools execute', () => {
   layer(
     TestLive({
       baseConfigProvider: testConfigProvider,
+      fixture: 'global-test-user-id',
+      stdin: { isTTY: true, data: '' },
+    })
+  )(
+    '[Given] no --user-id and no project test_user_id [Then] falls back to global test_user_id',
+    it => {
+      it.scoped('uses global test user id from user_data.json', () =>
+        Effect.gen(function* () {
+          yield* cli(['tools', 'execute', 'GMAIL_SEND_EMAIL', '-d', '{"recipient":"a"}']);
+          const lines = yield* MockConsole.getLines({ stripAnsi: true });
+          const output = parseLastJson(lines);
+          const text = lines.join('\n');
+
+          expect(output.successful).toBe(true);
+          expect(output.data.tool_slug).toBe('GMAIL_SEND_EMAIL');
+          expect(text).toContain('Using global test user id "global-default"');
+        })
+      );
+    }
+  );
+
+  layer(
+    TestLive({
+      baseConfigProvider: testConfigProvider,
       toolkitsData: {
         tools: [
           {


### PR DESCRIPTION
## Summary
- add fallback precedence for action commands: `--user-id` -> project `test_user_id` -> global `~/.composio/user_data.json` `test_user_id`
- apply fallback in `composio tools execute` and `composio connected-accounts link`
- add regression tests and fixture coverage for global fallback behavior

## Test plan
- [x] `pnpm test test/src/commands/tools/tools.execute.cmd.test.ts test/src/commands/connected-accounts/connected-accounts.link.cmd.test.ts`
- [ ] Wait for GitHub CI checks to pass

Made with [Cursor](https://cursor.com)