### PR TITLE
fix: log transform validation failures as warnings with field details

### DIFF
--- a/ts/packages/core/src/utils/transform.ts
+++ b/ts/packages/core/src/utils/transform.ts
@@ -26,9 +26,9 @@ export function transform<RawInput>(raw: RawInput) {
           const result = schema.safeParse(transformed);
 
           if (!result.success) {
-            const label = options?.label ? ` ${options.label}` : '';
+            const label = options?.label ? ` for ${options.label}` : '';
             const issues = result.error.issues
-              .map(issue => `  - ${issue.path.join('.')}: ${issue.message}`)
+              .map(issue => `  - ${issue.path.join('.') || 'parameter'}: ${issue.message}`)
               .join('\n');
             logger.warn(`Transform validation failed${label}:\n${issues}`);
             return transformed;

--- a/ts/packages/core/src/utils/transform.ts
+++ b/ts/packages/core/src/utils/transform.ts
@@ -12,7 +12,6 @@
  * ```
  */
 import { ZodTypeAny, z } from 'zod/v3';
-import { ValidationError } from '../errors';
 import { logger } from '..';
 
 export function transform<RawInput>(raw: RawInput) {
@@ -27,14 +26,11 @@ export function transform<RawInput>(raw: RawInput) {
           const result = schema.safeParse(transformed);
 
           if (!result.success) {
-            // @TODO:send telemetry here
-            // throw new ValidationError(
-            //   `Failed to transform${options?.label ? ` ${options.label}` : ''}`,
-            //   {
-            //     cause: result.error,
-            //   }
-            // );
-            logger.error(result.error);
+            const label = options?.label ? ` ${options.label}` : '';
+            const issues = result.error.issues
+              .map(issue => `  - ${issue.path.join('.')}: ${issue.message}`)
+              .join('\n');
+            logger.warn(`Transform validation failed${label}:\n${issues}`);
             return transformed;
           }
 

--- a/ts/packages/core/test/utils/transform.test.ts
+++ b/ts/packages/core/test/utils/transform.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { z } from 'zod/v3';
+
+const mockLogger = vi.hoisted(() => ({
+  warn: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+}));
+
+vi.mock('../../src/utils/logger', () => ({
+  default: mockLogger,
+}));
+
+vi.mock('../../src/index', () => ({
+  logger: mockLogger,
+}));
+
+import { transform } from '../../src/utils/transform';
+
+describe('transform', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return validated data when schema matches', () => {
+    const schema = z.object({
+      name: z.string(),
+      age: z.number(),
+    });
+
+    const result = transform({ raw_name: 'Alice', raw_age: 30 })
+      .with(schema)
+      .using(raw => ({ name: raw.raw_name, age: raw.raw_age }));
+
+    expect(result).toEqual({ name: 'Alice', age: 30 });
+  });
+
+  it('should strip extra fields via Zod parsing on valid data', () => {
+    const schema = z.object({
+      name: z.string(),
+    });
+
+    const result = transform({ name: 'Alice', extra: 'field' })
+      .with(schema)
+      .using(raw => raw as any);
+
+    expect(result).toEqual({ name: 'Alice' });
+    expect(result).not.toHaveProperty('extra');
+  });
+
+  it('should return untransformed data and log a warning on validation failure', () => {
+    const schema = z.object({
+      name: z.string(),
+      age: z.number(),
+    });
+
+    const result = transform({ name: 123, age: 'not a number' })
+      .with(schema)
+      .using(raw => raw as any);
+
+    expect(result).toEqual({ name: 123, age: 'not a number' });
+
+    expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+    expect(mockLogger.error).not.toHaveBeenCalled();
+
+    const warnMessage = mockLogger.warn.mock.calls[0][0] as string;
+    expect(warnMessage).toContain('Transform validation failed');
+    expect(warnMessage).toContain('name');
+    expect(warnMessage).toContain('age');
+  });
+
+  it('should include label in the warning message when provided', () => {
+    const schema = z.object({ id: z.string() });
+
+    transform({ id: 42 })
+      .with(schema)
+      .using(raw => raw as any, { label: 'ConnectedAccount' });
+
+    expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+    const warnMessage = mockLogger.warn.mock.calls[0][0] as string;
+    expect(warnMessage).toContain('ConnectedAccount');
+  });
+
+  it('should not log anything when validation succeeds', () => {
+    const schema = z.object({ id: z.string() });
+
+    const result = transform({ id: 'abc' })
+      .with(schema)
+      .using(raw => raw as any);
+
+    expect(result).toEqual({ id: 'abc' });
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+    expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+
+  it('should handle nested schema validation failures', () => {
+    const schema = z.object({
+      user: z.object({
+        email: z.string().email(),
+      }),
+    });
+
+    const result = transform({ user: { email: 'not-an-email' } })
+      .with(schema)
+      .using(raw => raw as any);
+
+    expect(result).toEqual({ user: { email: 'not-an-email' } });
+    expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+
+    const warnMessage = mockLogger.warn.mock.calls[0][0] as string;
+    expect(warnMessage).toContain('user.email');
+  });
+});


### PR DESCRIPTION
Fixes #2716

The transform utility in ts/packages/core/src/utils/transform.ts was calling logger.error() with the raw ZodError object when schema validation failed. This made validation failures hard to debug because the error was logged as a serialized object blob with no context about which transform or which fields failed.

Changes:
- Replace logger.error(result.error) with logger.warn() that formats a human-readable message listing each failing field path and its validation message
- Remove the unused ValidationError import and the stale commented-out throw block
- Add test coverage for the transform utility (6 tests covering success, failure, labels, nested schemas)

This is a non-breaking change. The transform still returns the untransformed data on validation failure (same behavior as before), but now the warning output actually tells you what went wrong and where. For example instead of a raw ZodError dump, you get:

  Transform validation failed for ConnectedAccount:
    - user.email: Invalid email

The warn level was chosen over error because the current contract is soft-fail (return untransformed data). error level implies something is broken, warn level correctly signals "this data didn't validate but we're proceeding."