### PR TITLE
feat(cli): add global org/project switch and list commands

### DIFF
--- a/.changeset/spotty-bats-shine.md
+++ b/.changeset/spotty-bats-shine.md
@@ -1,0 +1,5 @@
+---
+'@composio/cli': patch
+---
+
+Add a new commands for CLI org switching and project switching

--- a/ts/e2e-tests/cli/whoami/e2e.test.ts
+++ b/ts/e2e-tests/cli/whoami/e2e.test.ts
@@ -23,6 +23,12 @@ e2e(import.meta.url, {
   },
   defineTests: ({ runCmd }) => {
     const expectedApiKey = Bun.env.COMPOSIO_USER_API_KEY.trim();
+    const expectedWhoamiJson = JSON.stringify({
+      global_user_api_key: expectedApiKey,
+      default_org_id: null,
+      default_project_id: null,
+      test_user_id: null,
+    });
     let whoamiResult: E2ETestResult;
     let redirectedResult: E2ETestResultWithFiles<'out.txt'>;
 
@@ -39,8 +45,8 @@ e2e(import.meta.url, {
         expect(whoamiResult.exitCode).toBe(0);
       });
 
-      it('stdout contains the API key', () => {
-        expect(sanitizeOutput(whoamiResult.stdout)).toBe(expectedApiKey);
+      it('stdout contains global user context JSON', () => {
+        expect(sanitizeOutput(whoamiResult.stdout)).toBe(expectedWhoamiJson);
       });
 
       it('stderr is empty', () => {
@@ -61,8 +67,8 @@ e2e(import.meta.url, {
         expect(redirectedResult.stderr).toBe('');
       });
 
-      it('out.txt contains the API key', () => {
-        expect(sanitizeOutput(redirectedResult.files['out.txt'])).toBe(expectedApiKey);
+      it('out.txt contains global user context JSON', () => {
+        expect(sanitizeOutput(redirectedResult.files['out.txt'])).toBe(expectedWhoamiJson);
       });
     });
   },

--- a/ts/packages/cli/src/commands/index.ts
+++ b/ts/packages/cli/src/commands/index.ts
@@ -18,6 +18,8 @@ import { authConfigsCmd } from './auth-configs/auth-configs.cmd';
 import { connectedAccountsCmd } from './connected-accounts/connected-accounts.cmd';
 import { triggersCmd } from './triggers/triggers.cmd';
 import { logsCmd } from './logs-cmd/logs.cmd';
+import { orgsCmd } from './orgs/orgs.cmd';
+import { projectsCmd } from './projects/projects.cmd';
 import { showToolsExecuteInputHelp } from './tools/commands/tools.execute.cmd';
 
 const $cmd = $defaultCmd.pipe(
@@ -37,6 +39,8 @@ const $cmd = $defaultCmd.pipe(
     connectedAccountsCmd,
     triggersCmd,
     logsCmd,
+    orgsCmd,
+    projectsCmd,
   ])
 );
 

--- a/ts/packages/cli/src/commands/init.cmd.ts
+++ b/ts/packages/cli/src/commands/init.cmd.ts
@@ -277,6 +277,9 @@ export const initCmd = CliCommand.make(
         );
 
         yield* ui.log.success(`Project initialized in ${composioDir}/`);
+        yield* ui.log.info(
+          'To switch your default global org/project later, run `composio orgs switch`.'
+        );
         yield* ui.output(makeOutputJson(selected, composioDir));
         yield* ui.outro('');
         return;
@@ -395,6 +398,9 @@ const initInteractiveFlow = (params: { composioDir: string; noBrowser: boolean; 
     );
 
     yield* ui.log.success(`Project initialized in ${composioDir}/`);
+    yield* ui.log.info(
+      'To switch your default global org/project later, run `composio orgs switch`.'
+    );
     yield* ui.output(makeOutputJson(selected, composioDir));
     yield* ui.outro('');
   });

--- a/ts/packages/cli/src/commands/login.cmd.ts
+++ b/ts/packages/cli/src/commands/login.cmd.ts
@@ -117,6 +117,9 @@ const storeCredentials = (params: {
     const email = sessionInfo?.org_member.email || fallbackEmail || undefined;
     yield* ui.log.success(email ? `Logged in as ${email}` : 'Logged in successfully');
     yield* ui.log.info('Run `composio init` in your project directory to set up project context.');
+    yield* ui.log.info(
+      'To switch your default global org/project later, run `composio orgs switch`.'
+    );
 
     // Emit structured JSON for piped/scripted consumption (agent-native)
     yield* ui.output(

--- a/ts/packages/cli/src/commands/orgs/commands/orgs.list.cmd.ts
+++ b/ts/packages/cli/src/commands/orgs/commands/orgs.list.cmd.ts
@@ -1,0 +1,66 @@
+import { Command, Options } from '@effect/cli';
+import { Effect, Option } from 'effect';
+import { requireAuth } from 'src/effects/require-auth';
+import { TerminalUI } from 'src/services/terminal-ui';
+import { listOrganizations } from 'src/services/composio-clients';
+import { ComposioUserContext } from 'src/services/user-context';
+import { clampLimit } from 'src/ui/clamp-limit';
+
+const limit = Options.integer('limit').pipe(
+  Options.withDefault(50),
+  Options.withDescription('Max organizations to fetch from API (default: 50)')
+);
+
+export const orgsCmd$List = Command.make('list', { limit }, ({ limit }) =>
+  Effect.gen(function* () {
+    if (!(yield* requireAuth)) return;
+
+    const ui = yield* TerminalUI;
+    const ctx = yield* ComposioUserContext;
+    const apiKey = Option.getOrUndefined(ctx.data.apiKey);
+    if (!apiKey) {
+      yield* ui.log.warn('No user API key found. Run `composio login` first.');
+      return;
+    }
+
+    const clampedLimit = clampLimit(limit);
+    const defaultOrgId = Option.getOrUndefined(ctx.data.orgId);
+
+    yield* ui.intro(`composio orgs list`);
+
+    const organizations = yield* ui.withSpinner(
+      'Loading organizations...',
+      listOrganizations({
+        baseURL: ctx.data.baseURL,
+        apiKey,
+        limit: clampedLimit,
+      }),
+      {
+        successMessage: result => `Loaded ${result.data.length} orgs`,
+        errorMessage: 'Failed to fetch organizations',
+      }
+    );
+
+    if (organizations.data.length === 0) {
+      yield* ui.log.warn('No organizations found.');
+      return;
+    }
+
+    const lines = organizations.data.map(org => {
+      const isSelected = defaultOrgId === org.id;
+      return `${isSelected ? '✓' : ' '} ${org.name} (${org.id})`;
+    });
+    yield* ui.log.info(lines.join('\n'));
+    yield* ui.outro('Hint: run `composio orgs switch` to switch the default global org/project.');
+
+    yield* ui.output(
+      JSON.stringify(
+        organizations.data.map(org => ({
+          id: org.id,
+          name: org.name,
+          is_selected_global_org: defaultOrgId === org.id,
+        }))
+      )
+    );
+  })
+).pipe(Command.withDescription('List organizations and show current global selection.'));

--- a/ts/packages/cli/src/commands/orgs/commands/orgs.switch.cmd.ts
+++ b/ts/packages/cli/src/commands/orgs/commands/orgs.switch.cmd.ts
@@ -1,0 +1,185 @@
+import { Command, Options } from '@effect/cli';
+import { Effect, Option } from 'effect';
+import { requireAuth } from 'src/effects/require-auth';
+import { TerminalUI } from 'src/services/terminal-ui';
+import {
+  listOrganizationProjects,
+  listOrganizations,
+  type OrganizationSummary,
+  type OrganizationProjectSummary,
+} from 'src/services/composio-clients';
+import { ComposioUserContext } from 'src/services/user-context';
+import { clampLimit } from 'src/ui/clamp-limit';
+
+const orgId = Options.text('org-id').pipe(
+  Options.optional,
+  Options.withDescription('Organization ID to use as global default')
+);
+
+const projectId = Options.text('project-id').pipe(
+  Options.optional,
+  Options.withDescription('Project ID to use as global default')
+);
+
+const limit = Options.integer('limit').pipe(
+  Options.withDefault(50),
+  Options.withDescription('Max org/projects to fetch from API (default: 50)')
+);
+
+const selectOrganization = (params: {
+  organizations: ReadonlyArray<OrganizationSummary>;
+  selectedOrgId?: string;
+}) =>
+  Effect.gen(function* () {
+    const { organizations, selectedOrgId } = params;
+    const ui = yield* TerminalUI;
+    if (organizations.length === 0) return undefined;
+
+    if (selectedOrgId) {
+      const explicitMatch = organizations.find(org => org.id === selectedOrgId);
+      if (explicitMatch) return explicitMatch;
+    }
+
+    if (organizations.length === 1) return organizations[0];
+
+    return yield* ui.select('Select a default organization (global scope):', [
+      ...organizations.map(org => ({
+        value: org,
+        label: org.name,
+        hint: org.id,
+      })),
+    ]);
+  });
+
+const selectProject = (params: {
+  projects: ReadonlyArray<OrganizationProjectSummary>;
+  selectedProjectId?: string;
+}) =>
+  Effect.gen(function* () {
+    const { projects, selectedProjectId } = params;
+    const ui = yield* TerminalUI;
+    if (projects.length === 0) return undefined;
+
+    if (selectedProjectId) {
+      const explicitMatch = projects.find(project => project.id === selectedProjectId);
+      if (explicitMatch) return explicitMatch;
+    }
+
+    if (projects.length === 1) return projects[0];
+
+    return yield* ui.select('Select a default project (global scope):', [
+      ...projects.map(project => ({
+        value: project,
+        label: project.name,
+        hint: project.id,
+      })),
+    ]);
+  });
+
+export const orgsCmd$Switch = Command.make(
+  'switch',
+  { orgId, projectId, limit },
+  ({ orgId, projectId, limit }) =>
+    Effect.gen(function* () {
+      if (!(yield* requireAuth)) return;
+
+      const ui = yield* TerminalUI;
+      const ctx = yield* ComposioUserContext;
+      yield* ui.intro('composio orgs switch');
+
+      const apiKey = Option.getOrUndefined(ctx.data.apiKey);
+      if (!apiKey) {
+        yield* ui.log.warn('No user API key found. Run `composio login` first.');
+        yield* ui.outro('');
+        return;
+      }
+
+      const clampedLimit = clampLimit(limit);
+      const explicitOrgId = Option.getOrUndefined(orgId);
+      const explicitProjectId = Option.getOrUndefined(projectId);
+
+      yield* ui.note(
+        'This updates your default global org/project context for CLI commands. Use `composio init` for per-project local overrides.',
+        'Global defaults'
+      );
+
+      const selectedOrganization =
+        explicitOrgId !== undefined
+          ? ({ id: explicitOrgId, name: explicitOrgId } satisfies OrganizationSummary)
+          : yield* Effect.gen(function* () {
+              const organizations = yield* listOrganizations({
+                baseURL: ctx.data.baseURL,
+                apiKey,
+                limit: clampedLimit,
+              });
+              yield* ui.log.info(`Loaded ${organizations.data.length} orgs`);
+              return organizations;
+            }).pipe(
+              Effect.flatMap(organizations =>
+                Effect.gen(function* () {
+                  if (organizations.data.length === 0) {
+                    return undefined;
+                  }
+                  return yield* selectOrganization({
+                    organizations: organizations.data,
+                    selectedOrgId: explicitOrgId,
+                  });
+                })
+              )
+            );
+
+      if (!selectedOrganization) {
+        yield* ui.log.warn('No organizations found for this API key.');
+        yield* ui.outro('No org selected.');
+        return;
+      }
+      yield* ui.log.info(
+        `Selected organization: "${selectedOrganization.name}" (${selectedOrganization.id})`
+      );
+
+      const projects = yield* listOrganizationProjects({
+        baseURL: ctx.data.baseURL,
+        apiKey,
+        orgId: selectedOrganization.id,
+        limit: clampedLimit,
+      });
+      yield* ui.log.info(`Loaded ${projects.data.length} projects`);
+
+      if (projects.data.length === 0) {
+        yield* ui.log.warn(`No projects found for org "${selectedOrganization.name}".`);
+        yield* ui.outro('No projects available.');
+        return;
+      }
+
+      const selectedProject = yield* selectProject({
+        projects: projects.data,
+        selectedProjectId: explicitProjectId,
+      });
+
+      if (!selectedProject) {
+        yield* ui.log.warn('No project selected.');
+        yield* ui.outro('No project selected.');
+        return;
+      }
+      yield* ui.log.info(`Selected project: "${selectedProject.name}" (${selectedProject.id})`);
+
+      yield* ctx.login(
+        apiKey,
+        selectedOrganization.id,
+        selectedProject.id,
+        Option.getOrUndefined(ctx.data.testUserId)
+      );
+
+      yield* ui.log.success(
+        `Updated global defaults to "${selectedOrganization.name}" / "${selectedProject.name}".`
+      );
+      yield* ui.output(
+        JSON.stringify({
+          scope: 'global',
+          org_id: selectedOrganization.id,
+          project_id: selectedProject.id,
+        })
+      );
+      yield* ui.outro('Global org/project defaults updated.');
+    })
+).pipe(Command.withDescription('Switch default global organization/project context.'));

--- a/ts/packages/cli/src/commands/orgs/orgs.cmd.ts
+++ b/ts/packages/cli/src/commands/orgs/orgs.cmd.ts
@@ -1,0 +1,11 @@
+import { Command } from '@effect/cli';
+import { orgsCmd$List } from './commands/orgs.list.cmd';
+import { orgsCmd$Switch } from './commands/orgs.switch.cmd';
+
+/**
+ * CLI entry point for organization context commands.
+ */
+export const orgsCmd = Command.make('orgs').pipe(
+  Command.withDescription('Manage default global organization/project context.'),
+  Command.withSubcommands([orgsCmd$List, orgsCmd$Switch])
+);

--- a/ts/packages/cli/src/commands/projects/commands/projects.list.cmd.ts
+++ b/ts/packages/cli/src/commands/projects/commands/projects.list.cmd.ts
@@ -1,0 +1,86 @@
+import { Command, Options } from '@effect/cli';
+import { Effect, Option } from 'effect';
+import { requireAuth } from 'src/effects/require-auth';
+import { TerminalUI } from 'src/services/terminal-ui';
+import { listOrganizationProjects } from 'src/services/composio-clients';
+import { ComposioUserContext } from 'src/services/user-context';
+import { clampLimit } from 'src/ui/clamp-limit';
+
+const orgId = Options.text('org-id').pipe(
+  Options.optional,
+  Options.withDescription('Organization ID to list projects for (defaults to current global org)')
+);
+
+const limit = Options.integer('limit').pipe(
+  Options.withDefault(50),
+  Options.withDescription('Max projects to fetch from API (default: 50)')
+);
+
+export const projectsCmd$List = Command.make('list', { orgId, limit }, ({ orgId, limit }) =>
+  Effect.gen(function* () {
+    if (!(yield* requireAuth)) return;
+
+    const ui = yield* TerminalUI;
+    const ctx = yield* ComposioUserContext;
+    yield* ui.intro('composio projects list');
+    const apiKey = Option.getOrUndefined(ctx.data.apiKey);
+    if (!apiKey) {
+      yield* ui.log.warn('No user API key found. Run `composio login` first.');
+      return;
+    }
+
+    const resolvedOrgId = Option.getOrUndefined(orgId) ?? Option.getOrUndefined(ctx.data.orgId);
+    if (!resolvedOrgId) {
+      yield* ui.log.warn('No default org is configured.');
+      yield* ui.outro('Hint: run `composio orgs switch` first, or pass `--org-id`.');
+      return;
+    }
+
+    const clampedLimit = clampLimit(limit);
+    const defaultOrgId = Option.getOrUndefined(ctx.data.orgId);
+    const defaultProjectId = Option.getOrUndefined(ctx.data.projectId);
+
+    const projects = yield* ui.withSpinner(
+      'Loading projects...',
+      listOrganizationProjects({
+        baseURL: ctx.data.baseURL,
+        apiKey,
+        orgId: resolvedOrgId,
+        limit: clampedLimit,
+      }),
+      {
+        successMessage: result => `Loaded ${result.data.length} projects`,
+        errorMessage: 'Failed to fetch projects',
+      }
+    );
+
+    if (projects.data.length === 0) {
+      yield* ui.log.warn('No projects found.');
+      yield* ui.outro('Hint: run `composio orgs switch` to switch org/project defaults.');
+      return;
+    }
+
+    const lines = projects.data.map(project => {
+      const isSelected = defaultOrgId === resolvedOrgId && defaultProjectId === project.id;
+      return `${isSelected ? '✓' : ' '} ${project.name} (${project.id})`;
+    });
+    yield* ui.log.step(lines.join('\n'));
+    yield* ui.outro(
+      [
+        'Hint: run `composio projects switch` to switch the default global project.',
+        'Run `composio orgs switch` to switch org and project together.',
+      ].join('\n')
+    );
+
+    yield* ui.output(
+      JSON.stringify(
+        projects.data.map(project => ({
+          id: project.id,
+          name: project.name,
+          is_selected_global_project:
+            defaultOrgId === resolvedOrgId && defaultProjectId === project.id,
+        }))
+      )
+    );
+  })
+).pipe(Command.withDescription('List projects and show current global selection.'));

--- a/ts/packages/cli/src/commands/projects/commands/projects.switch.cmd.ts
+++ b/ts/packages/cli/src/commands/projects/commands/projects.switch.cmd.ts
@@ -1,0 +1,132 @@
+import { Command, Options } from '@effect/cli';
+import { Effect, Option } from 'effect';
+import { requireAuth } from 'src/effects/require-auth';
+import { TerminalUI } from 'src/services/terminal-ui';
+import {
+  listOrganizationProjects,
+  type OrganizationProjectSummary,
+} from 'src/services/composio-clients';
+import { ComposioUserContext } from 'src/services/user-context';
+import { clampLimit } from 'src/ui/clamp-limit';
+
+const orgId = Options.text('org-id').pipe(
+  Options.optional,
+  Options.withDescription('Organization ID to use while switching project')
+);
+
+const projectId = Options.text('project-id').pipe(
+  Options.optional,
+  Options.withDescription('Project ID to use as global default')
+);
+
+const limit = Options.integer('limit').pipe(
+  Options.withDefault(50),
+  Options.withDescription('Max projects to fetch from API (default: 50)')
+);
+
+const selectProject = (params: {
+  projects: ReadonlyArray<OrganizationProjectSummary>;
+  selectedProjectId?: string;
+}) =>
+  Effect.gen(function* () {
+    const { projects, selectedProjectId } = params;
+    const ui = yield* TerminalUI;
+    if (projects.length === 0) return undefined;
+
+    if (selectedProjectId) {
+      const explicitMatch = projects.find(project => project.id === selectedProjectId);
+      if (explicitMatch) return explicitMatch;
+    }
+
+    if (projects.length === 1) return projects[0];
+
+    return yield* ui.select('Select a default project (global scope):', [
+      ...projects.map(project => ({
+        value: project,
+        label: project.name,
+        hint: project.id,
+      })),
+    ]);
+  });
+
+export const projectsCmd$Switch = Command.make(
+  'switch',
+  { orgId, projectId, limit },
+  ({ orgId, projectId, limit }) =>
+    Effect.gen(function* () {
+      if (!(yield* requireAuth)) return;
+
+      const ui = yield* TerminalUI;
+      const ctx = yield* ComposioUserContext;
+      yield* ui.intro('composio projects switch');
+
+      const apiKey = Option.getOrUndefined(ctx.data.apiKey);
+      if (!apiKey) {
+        yield* ui.log.warn('No user API key found. Run `composio login` first.');
+        yield* ui.outro('');
+        return;
+      }
+
+      const resolvedOrgId = Option.getOrUndefined(orgId) ?? Option.getOrUndefined(ctx.data.orgId);
+      if (!resolvedOrgId) {
+        yield* ui.log.warn('No default org is configured.');
+        yield* ui.log.info('Run `composio orgs switch` to select org and project globally.');
+        yield* ui.outro('');
+        return;
+      }
+
+      const clampedLimit = clampLimit(limit);
+      const explicitProjectId = Option.getOrUndefined(projectId);
+
+      yield* ui.note(
+        'This updates your default global project context. To switch organization, use `composio orgs switch`.',
+        'Global defaults'
+      );
+      yield* ui.log.info(`Using organization: ${resolvedOrgId}`);
+
+      const projects = yield* listOrganizationProjects({
+        baseURL: ctx.data.baseURL,
+        apiKey,
+        orgId: resolvedOrgId,
+        limit: clampedLimit,
+      });
+      yield* ui.log.info(`Loaded ${projects.data.length} projects`);
+
+      if (projects.data.length === 0) {
+        yield* ui.log.warn('No projects found for the selected org.');
+        yield* ui.log.info('Use `composio orgs switch` to switch to another organization.');
+        yield* ui.outro('No projects available.');
+        return;
+      }
+
+      const selectedProject = yield* selectProject({
+        projects: projects.data,
+        selectedProjectId: explicitProjectId,
+      });
+
+      if (!selectedProject) {
+        yield* ui.log.warn('No project selected.');
+        yield* ui.outro('No project selected.');
+        return;
+      }
+      yield* ui.log.info(`Selected project: "${selectedProject.name}" (${selectedProject.id})`);
+
+      yield* ctx.login(
+        apiKey,
+        resolvedOrgId,
+        selectedProject.id,
+        Option.getOrUndefined(ctx.data.testUserId)
+      );
+
+      yield* ui.log.success(`Updated global default project to "${selectedProject.name}".`);
+      yield* ui.log.info('To switch organization as well, run `composio orgs switch`.');
+      yield* ui.output(
+        JSON.stringify({
+          scope: 'global',
+          org_id: resolvedOrgId,
+          project_id: selectedProject.id,
+        })
+      );
+      yield* ui.outro('Global project default updated.');
+    })
+).pipe(Command.withDescription('Switch default global project context.'));

--- a/ts/packages/cli/src/commands/projects/projects.cmd.ts
+++ b/ts/packages/cli/src/commands/projects/projects.cmd.ts
@@ -1,0 +1,11 @@
+import { Command } from '@effect/cli';
+import { projectsCmd$List } from './commands/projects.list.cmd';
+import { projectsCmd$Switch } from './commands/projects.switch.cmd';
+
+/**
+ * CLI entry point for project context commands.
+ */
+export const projectsCmd = Command.make('projects').pipe(
+  Command.withDescription('Manage default global project context.'),
+  Command.withSubcommands([projectsCmd$List, projectsCmd$Switch])
+);

--- a/ts/packages/cli/src/commands/whoami.cmd.ts
+++ b/ts/packages/cli/src/commands/whoami.cmd.ts
@@ -25,9 +25,27 @@ export const whoamiCmd = Command.make('whoami', {}).pipe(
           onSome: apiKey =>
             Effect.gen(function* () {
               const redactedApiKey = redact({ value: apiKey, prefix: 'ak_' });
+              const defaultOrgId = Option.getOrUndefined(ctx.data.orgId);
+              const defaultProjectId = Option.getOrUndefined(ctx.data.projectId);
+              const testUserId = Option.getOrUndefined(ctx.data.testUserId);
 
-              yield* ui.note(redactedApiKey, 'API Key');
-              yield* ui.output(apiKey);
+              yield* ui.note(
+                [
+                  `Global User API Key: ${redactedApiKey}`,
+                  `Default Org ID: ${defaultOrgId ?? 'not set'}`,
+                  `Default Project ID: ${defaultProjectId ?? 'not set'}`,
+                  `Test User ID: ${testUserId ?? 'not set'}`,
+                ].join('\n'),
+                'Global User Context'
+              );
+              yield* ui.output(
+                JSON.stringify({
+                  global_user_api_key: apiKey,
+                  default_org_id: defaultOrgId ?? null,
+                  default_project_id: defaultProjectId ?? null,
+                  test_user_id: testUserId ?? null,
+                })
+              );
             }),
         })
       );

--- a/ts/packages/cli/src/services/composio-clients.ts
+++ b/ts/packages/cli/src/services/composio-clients.ts
@@ -712,6 +712,159 @@ export const OrgProjectListResponse = Schema.Struct({
 }).annotations({ identifier: 'OrgProjectListResponse' });
 export type OrgProjectListResponse = Schema.Schema.Type<typeof OrgProjectListResponse>;
 
+export interface OrganizationSummary {
+  readonly id: string;
+  readonly name: string;
+}
+
+export interface OrganizationListResponse {
+  readonly data: ReadonlyArray<OrganizationSummary>;
+  readonly total_items: number;
+}
+
+export interface OrganizationProjectSummary {
+  readonly id: string;
+  readonly name: string;
+}
+
+export interface OrganizationProjectListResponse {
+  readonly data: ReadonlyArray<OrganizationProjectSummary>;
+  readonly total_items: number;
+}
+
+const extractArrayPayload = (json: unknown): ReadonlyArray<unknown> => {
+  if (Array.isArray(json)) return json;
+  if (json && typeof json === 'object') {
+    const record = json as Record<string, unknown>;
+    if (Array.isArray(record.organizations)) return record.organizations;
+    if (Array.isArray(record.projects)) return record.projects;
+    if (Array.isArray(record.data)) return record.data;
+    if (Array.isArray(record.items)) return record.items;
+    if (record.data && typeof record.data === 'object') {
+      const nested = record.data as Record<string, unknown>;
+      if (Array.isArray(nested.organizations)) return nested.organizations;
+      if (Array.isArray(nested.projects)) return nested.projects;
+      if (Array.isArray(nested.items)) return nested.items;
+      if (Array.isArray(nested.data)) return nested.data;
+    }
+  }
+  return [];
+};
+
+const readIdFromItem = (item: unknown): string | undefined => {
+  if (!item || typeof item !== 'object') return undefined;
+  const record = item as Record<string, unknown>;
+  if (typeof record.id === 'string') return record.id;
+  if (typeof record.nano_id === 'string') return record.nano_id;
+  if (typeof record.org_id === 'string') return record.org_id;
+  if (typeof record.project_id === 'string') return record.project_id;
+  return undefined;
+};
+
+const readNameFromItem = (item: unknown): string | undefined => {
+  if (!item || typeof item !== 'object') return undefined;
+  const record = item as Record<string, unknown>;
+  if (typeof record.name === 'string' && record.name.trim().length > 0) return record.name;
+  if (typeof record.slug === 'string' && record.slug.trim().length > 0) return record.slug;
+  return undefined;
+};
+
+/**
+ * Lists organizations available to the current user API key.
+ * Uses plain fetch since this endpoint is not available in @composio/client.
+ */
+export const listOrganizations = (params: {
+  baseURL: string;
+  apiKey: string;
+  limit?: number;
+}): Effect.Effect<OrganizationListResponse, HttpServerError | HttpDecodingError> =>
+  Effect.gen(function* () {
+    const limit = params.limit ?? 50;
+    const response = yield* Effect.tryPromise({
+      try: () =>
+        fetch(`${params.baseURL}/api/v3/org/list?limit=${limit}`, {
+          method: 'GET',
+          redirect: 'error',
+          headers: {
+            'x-user-api-key': params.apiKey,
+            'User-Agent': '@composio/cli',
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+          },
+        }),
+      catch: error => new HttpServerError({ cause: error }),
+    });
+
+    if (!response.ok) {
+      return yield* handleHttpErrorResponse(response);
+    }
+
+    const { json } = yield* streamResponseWithByteCount(response);
+    const items = extractArrayPayload(json);
+    const organizations = items
+      .map(item => {
+        const id = readIdFromItem(item);
+        const name = readNameFromItem(item);
+        if (!id || !name) return undefined;
+        return { id, name } satisfies OrganizationSummary;
+      })
+      .filter((value): value is OrganizationSummary => value !== undefined);
+
+    return {
+      data: organizations,
+      total_items: organizations.length,
+    };
+  });
+
+/**
+ * Lists projects for a specific organization.
+ * Uses plain fetch since this endpoint is not available in @composio/client.
+ */
+export const listOrganizationProjects = (params: {
+  baseURL: string;
+  apiKey: string;
+  orgId: string;
+  limit?: number;
+}): Effect.Effect<OrganizationProjectListResponse, HttpServerError | HttpDecodingError> =>
+  Effect.gen(function* () {
+    const limit = params.limit ?? 50;
+    const response = yield* Effect.tryPromise({
+      try: () =>
+        fetch(`${params.baseURL}/api/v3/org/project/list?limit=${limit}`, {
+          method: 'GET',
+          redirect: 'error',
+          headers: {
+            'x-user-api-key': params.apiKey,
+            'x-org-id': params.orgId,
+            'User-Agent': '@composio/cli',
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+          },
+        }),
+      catch: error => new HttpServerError({ cause: error }),
+    });
+
+    if (!response.ok) {
+      return yield* handleHttpErrorResponse(response);
+    }
+
+    const { json } = yield* streamResponseWithByteCount(response);
+    const items = extractArrayPayload(json);
+    const projects = items
+      .map(item => {
+        const id = readIdFromItem(item);
+        const name = readNameFromItem(item);
+        if (!id || !name) return undefined;
+        return { id, name } satisfies OrganizationProjectSummary;
+      })
+      .filter((value): value is OrganizationProjectSummary => value !== undefined);
+
+    return {
+      data: projects,
+      total_items: projects.length,
+    };
+  });
+
 /**
  * Lists all projects for the logged-in user's organization.
  * Uses plain fetch since this endpoint is not available in @composio/client.
@@ -719,7 +872,7 @@ export type OrgProjectListResponse = Schema.Schema.Type<typeof OrgProjectListRes
  * @param params.baseURL    - API base URL
  * @param params.apiKey     - UAK (sent as `x-user-api-key`)
  * @param params.orgId      - Organization ID (sent as `x-org-id`)
- * @param params.limit      - Max projects to return (default 100)
+ * @param params.limit      - Max projects to return (default 50)
  */
 export const listOrgProjects = (params: {
   baseURL: string;
@@ -728,7 +881,7 @@ export const listOrgProjects = (params: {
   limit?: number;
 }): Effect.Effect<OrgProjectListResponse, HttpServerError | HttpDecodingError> =>
   Effect.gen(function* () {
-    const limit = params.limit ?? 100;
+    const limit = params.limit ?? 50;
     const response = yield* Effect.tryPromise({
       try: () =>
         fetch(

--- a/ts/packages/cli/test/__fixtures__/user-config-with-global-context/.composio/user_data.json
+++ b/ts/packages/cli/test/__fixtures__/user-config-with-global-context/.composio/user_data.json
@@ -1,0 +1,5 @@
+{
+  "api_key": "uak_test_key",
+  "org_id": "org_1",
+  "project_id": "project_1"
+}

--- a/ts/packages/cli/test/src/commands/$default.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/$default.cmd.test.ts
@@ -15,7 +15,7 @@ describe('CLI: composio', () => {
         expect(result).toEqual(
           ValidationError.commandMismatch(
             HelpDoc.p(
-              "Invalid subcommand for composio - use one of 'version', 'upgrade', 'whoami', 'login', 'logout', 'init', 'generate', 'py', 'ts', 'toolkits', 'tools', 'auth-configs', 'connected-accounts', 'triggers', 'logs'"
+              "Invalid subcommand for composio - use one of 'version', 'upgrade', 'whoami', 'login', 'logout', 'init', 'generate', 'py', 'ts', 'toolkits', 'tools', 'auth-configs', 'connected-accounts', 'triggers', 'logs', 'orgs', 'projects'"
             )
           )
         );

--- a/ts/packages/cli/test/src/commands/__snapshots__/$default.cmd.test.ts.snap
+++ b/ts/packages/cli/test/src/commands/__snapshots__/$default.cmd.test.ts.snap
@@ -63,6 +63,8 @@ Environment Variables:
 
   - toolkits search [--limit integer] <query>                                                                                                                                                                                                                                                                Search toolkits by use case.
 
+  - toolkits version <slug>                                                                                                                                                                                                                                                                                  Show latest and recent versions for a toolkit.
+
   - tools                                                                                                                                                                                                                                                                                                    Discover and inspect Composio tools.
 
   - tools list [--query text] [--toolkits text] [--tags text] [--limit integer]                                                                                                                                                                                                                              List available tools.
@@ -118,5 +120,17 @@ Environment Variables:
   - logs triggers [--cursor text] [--user-id text] [--connected-account-id text] [--trigger text] [--trigger-id text] [--log-id text] [--from integer] [--to integer] [--limit integer] [--time 5m | 30m | 6h | 1d | 1w | 1month | 1y] [--search text] [--include-payload] [<log_id>]                        List trigger logs.
 
   - logs tools [--cursor integer] [--from integer] [--to integer] [--limit integer] [--case-sensitive] [--toolkit text] [--tool text] [--connected-account-id text] [--auth-config-id text] [--status text] [--user-id text] [--log-id text] [--tool-router-session-id text] [--session-id text] [<log_id>]  List tool execution logs, or pass a log_id to fetch a specific log.
+
+  - orgs                                                                                                                                                                                                                                                                                                     Manage default global organization/project context.
+
+  - orgs list [--limit integer]                                                                                                                                                                                                                                                                              List organizations and show current global selection.
+
+  - orgs switch [--org-id text] [--project-id text] [--limit integer]                                                                                                                                                                                                                                        Switch default global organization/project context.
+
+  - projects                                                                                                                                                                                                                                                                                                 Manage default global project context.
+
+  - projects list [--org-id text] [--limit integer]                                                                                                                                                                                                                                                          List projects and show current global selection.
+
+  - projects switch [--org-id text] [--project-id text] [--limit integer]                                                                                                                                                                                                                                    Switch default global project context.
 "
 `;

--- a/ts/packages/cli/test/src/commands/orgs/orgs.list.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/orgs/orgs.list.cmd.test.ts
@@ -1,0 +1,48 @@
+import { Effect } from 'effect';
+import { describe, expect, layer } from '@effect/vitest';
+import { afterEach, vi } from 'vitest';
+import { cli, MockConsole, TestLive } from 'test/__utils__';
+
+const mockFetchResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+describe('CLI: composio orgs list', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  layer(TestLive({ fixture: 'user-config-with-global-context' }))(it => {
+    it.scoped('[Then] lists orgs, marks selected global org, and shows switch hint', () =>
+      Effect.gen(function* () {
+        const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+          mockFetchResponse({
+            organizations: [
+              { id: 'org_1', name: 'Org One' },
+              { id: 'org_2', name: 'Org Two' },
+            ],
+          })
+        );
+
+        yield* cli(['orgs', 'list']);
+
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        const [orgUrl, orgRequest] = fetchSpy.mock.calls[0]!;
+        expect(orgUrl).toContain('/api/v3/org/list?limit=50');
+        expect((orgRequest as RequestInit).headers).toMatchObject({
+          'x-user-api-key': 'uak_test_key',
+        });
+
+        const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
+        expect(output).toContain('Loaded 2 orgs');
+        expect(output).toContain('✓ Org One (org_1)');
+        expect(output).toContain('  Org Two (org_2)');
+        expect(output).toContain(
+          'Hint: run `composio orgs switch` to switch the default global org/project.'
+        );
+      })
+    );
+  });
+});

--- a/ts/packages/cli/test/src/commands/orgs/orgs.switch.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/orgs/orgs.switch.cmd.test.ts
@@ -1,0 +1,106 @@
+import path from 'node:path';
+import { ConfigProvider, Effect } from 'effect';
+import { describe, expect, layer } from '@effect/vitest';
+import { afterEach, vi } from 'vitest';
+import { FileSystem } from '@effect/platform';
+import { cli, MockConsole, TestLive } from 'test/__utils__';
+import * as constants from 'src/constants';
+import { setupCacheDir } from 'src/effects/setup-cache-dir';
+
+const testConfigProvider = ConfigProvider.fromMap(
+  new Map([
+    ['COMPOSIO_USER_API_KEY', 'uak_test_key'],
+    ['USER_API_KEY', 'uak_test_key'],
+  ])
+);
+
+const mockFetchResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+describe('CLI: composio orgs switch', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  layer(TestLive({ baseConfigProvider: testConfigProvider }))(it => {
+    it.scoped('[When] no --org-id is provided [Then] lists orgs and projects with limit=50', () =>
+      Effect.gen(function* () {
+        const fetchSpy = vi
+          .spyOn(globalThis, 'fetch')
+          .mockResolvedValueOnce(
+            mockFetchResponse({
+              organizations: [{ id: 'org_1', name: 'Org One' }],
+            })
+          )
+          .mockResolvedValueOnce(
+            mockFetchResponse({
+              data: [{ id: 'project_1', name: 'Project One' }],
+            })
+          );
+
+        yield* cli(['orgs', 'switch']);
+
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+        const [orgUrl, orgRequest] = fetchSpy.mock.calls[0]!;
+        expect(orgUrl).toContain('/api/v3/org/list?limit=50');
+        expect((orgRequest as RequestInit).headers).toMatchObject({
+          'x-user-api-key': 'uak_test_key',
+        });
+
+        const [projectUrl, projectRequest] = fetchSpy.mock.calls[1]!;
+        expect(projectUrl).toContain('/api/v3/org/project/list?limit=50');
+        expect((projectRequest as RequestInit).headers).toMatchObject({
+          'x-user-api-key': 'uak_test_key',
+          'x-org-id': 'org_1',
+        });
+
+        const fs = yield* FileSystem.FileSystem;
+        const cacheDir = yield* setupCacheDir;
+        const userConfigPath = path.join(cacheDir, constants.USER_CONFIG_FILE_NAME);
+        const rawUserConfig = yield* fs.readFileString(userConfigPath, 'utf8');
+        const userConfig = JSON.parse(rawUserConfig) as Record<string, unknown>;
+        expect(userConfig.org_id).toBe('org_1');
+        expect(userConfig.project_id).toBe('project_1');
+
+        const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
+        expect(output).toContain('Updated global defaults');
+      })
+    );
+  });
+
+  layer(TestLive({ baseConfigProvider: testConfigProvider }))(it => {
+    it.scoped('[When] --org-id is provided [Then] skips org list and selects project', () =>
+      Effect.gen(function* () {
+        const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+          mockFetchResponse({
+            data: [
+              { id: 'project_1', name: 'Project One' },
+              { id: 'project_2', name: 'Project Two' },
+            ],
+          })
+        );
+
+        yield* cli(['orgs', 'switch', '--org-id', 'org_manual']);
+
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        const [projectUrl, projectRequest] = fetchSpy.mock.calls[0]!;
+        expect(projectUrl).toContain('/api/v3/org/project/list?limit=50');
+        expect((projectRequest as RequestInit).headers).toMatchObject({
+          'x-user-api-key': 'uak_test_key',
+          'x-org-id': 'org_manual',
+        });
+
+        const fs = yield* FileSystem.FileSystem;
+        const cacheDir = yield* setupCacheDir;
+        const userConfigPath = path.join(cacheDir, constants.USER_CONFIG_FILE_NAME);
+        const rawUserConfig = yield* fs.readFileString(userConfigPath, 'utf8');
+        const userConfig = JSON.parse(rawUserConfig) as Record<string, unknown>;
+        expect(userConfig.org_id).toBe('org_manual');
+        expect(userConfig.project_id).toBe('project_1');
+      })
+    );
+  });
+});

--- a/ts/packages/cli/test/src/commands/projects/projects.list.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/projects/projects.list.cmd.test.ts
@@ -1,0 +1,50 @@
+import { Effect } from 'effect';
+import { describe, expect, layer } from '@effect/vitest';
+import { afterEach, vi } from 'vitest';
+import { cli, MockConsole, TestLive } from 'test/__utils__';
+
+const mockFetchResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+describe('CLI: composio projects list', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  layer(TestLive({ fixture: 'user-config-with-global-context' }))(it => {
+    it.scoped('[Then] lists projects, marks selected global project, and shows switch hints', () =>
+      Effect.gen(function* () {
+        const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+          mockFetchResponse({
+            data: [
+              { id: 'project_1', name: 'Project One' },
+              { id: 'project_2', name: 'Project Two' },
+            ],
+          })
+        );
+
+        yield* cli(['projects', 'list', '--org-id', 'org_1']);
+
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        const [projectUrl, projectRequest] = fetchSpy.mock.calls[0]!;
+        expect(projectUrl).toContain('/api/v3/org/project/list?limit=50');
+        expect((projectRequest as RequestInit).headers).toMatchObject({
+          'x-user-api-key': 'uak_test_key',
+          'x-org-id': 'org_1',
+        });
+
+        const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
+        expect(output).toContain('Loaded 2 projects');
+        expect(output).toContain('✓ Project One (project_1)');
+        expect(output).toContain('  Project Two (project_2)');
+        expect(output).toContain(
+          'Hint: run `composio projects switch` to switch the default global project.'
+        );
+        expect(output).toContain('Run `composio orgs switch` to switch org and project together.');
+      })
+    );
+  });
+});

--- a/ts/packages/cli/test/src/commands/projects/projects.switch.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/projects/projects.switch.cmd.test.ts
@@ -1,0 +1,65 @@
+import path from 'node:path';
+import { ConfigProvider, Effect } from 'effect';
+import { describe, expect, layer } from '@effect/vitest';
+import { afterEach, vi } from 'vitest';
+import { FileSystem } from '@effect/platform';
+import { cli, MockConsole, TestLive } from 'test/__utils__';
+import * as constants from 'src/constants';
+import { setupCacheDir } from 'src/effects/setup-cache-dir';
+
+const testConfigProvider = ConfigProvider.fromMap(
+  new Map([
+    ['COMPOSIO_USER_API_KEY', 'uak_test_key'],
+    ['USER_API_KEY', 'uak_test_key'],
+  ])
+);
+
+const mockFetchResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+describe('CLI: composio projects switch', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  layer(TestLive({ baseConfigProvider: testConfigProvider }))(it => {
+    it.scoped(
+      '[When] --org-id is provided [Then] it switches global project and shows org hint',
+      () =>
+        Effect.gen(function* () {
+          const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+            mockFetchResponse({
+              data: [
+                { id: 'project_1', name: 'Project One' },
+                { id: 'project_2', name: 'Project Two' },
+              ],
+            })
+          );
+
+          yield* cli(['projects', 'switch', '--org-id', 'org_manual']);
+
+          expect(fetchSpy).toHaveBeenCalledTimes(1);
+          const [projectUrl, projectRequest] = fetchSpy.mock.calls[0]!;
+          expect(projectUrl).toContain('/api/v3/org/project/list?limit=50');
+          expect((projectRequest as RequestInit).headers).toMatchObject({
+            'x-user-api-key': 'uak_test_key',
+            'x-org-id': 'org_manual',
+          });
+
+          const fs = yield* FileSystem.FileSystem;
+          const cacheDir = yield* setupCacheDir;
+          const userConfigPath = path.join(cacheDir, constants.USER_CONFIG_FILE_NAME);
+          const rawUserConfig = yield* fs.readFileString(userConfigPath, 'utf8');
+          const userConfig = JSON.parse(rawUserConfig) as Record<string, unknown>;
+          expect(userConfig.org_id).toBe('org_manual');
+          expect(userConfig.project_id).toBe('project_1');
+
+          const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
+          expect(output).toContain('To switch organization as well, run `composio orgs switch`.');
+        })
+    );
+  });
+});

--- a/ts/packages/cli/test/src/commands/whoami.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/whoami.cmd.test.ts
@@ -9,7 +9,7 @@ describe('CLI: composio whoami', () => {
   ).pipe(extendConfigProvider);
 
   layer(TestLive({ baseConfigProvider: testConfigProvider }))('with config override', it => {
-    it.scoped('[Given] `COMPOSIO_USER_API_KEY` [Then] prints it to stdout', () =>
+    it.scoped('[Given] `COMPOSIO_USER_API_KEY` [Then] prints global user context JSON', () =>
       Effect.gen(function* () {
         const args = ['whoami'];
         yield* cli(args);
@@ -17,12 +17,16 @@ describe('CLI: composio whoami', () => {
         const lines = yield* MockConsole.getLines();
         const output = lines.join('\n');
         expect(output).toContain(`api_key_from_test_config_provider`);
+        expect(output).toContain(`"global_user_api_key":"api_key_from_test_config_provider"`);
+        expect(output).toContain(`"default_org_id":null`);
+        expect(output).toContain(`"default_project_id":null`);
+        expect(output).toContain(`"test_user_id":null`);
       })
     );
   });
 
   layer(TestLive({ fixture: 'user-config-example' }))('with fixture', it => {
-    it.scoped('[Given] user_data.json in fixture [Then] prints its `api_key` to stdout', () =>
+    it.scoped('[Given] user_data.json in fixture [Then] prints global user context JSON', () =>
       Effect.gen(function* () {
         const args = ['whoami'];
         yield* cli(args);
@@ -30,6 +34,10 @@ describe('CLI: composio whoami', () => {
         const lines = yield* MockConsole.getLines();
         const output = lines.join('\n');
         expect(output).toContain(`api_key_from_test_fixture`);
+        expect(output).toContain(`"global_user_api_key":"api_key_from_test_fixture"`);
+        expect(output).toContain(`"default_org_id":null`);
+        expect(output).toContain(`"default_project_id":null`);
+        expect(output).toContain(`"test_user_id":null`);
       })
     );
   });


### PR DESCRIPTION
## Summary
- add `composio orgs switch` with interactive org/project selection, global-scope messaging, direct org/project list API calls, and persisted global defaults
- add `composio projects switch`, `composio orgs list`, and `composio projects list` with selected-item indicators and switch hints
- update `login`, `init`, and `whoami` outputs to better communicate global context and switching; add/refresh CLI tests and fixtures

## Test plan
- [x] Run `pnpm test` from repository root
- [x] Verify CLI tests for org/project switch and list commands pass
- [x] Verify help snapshots include new `orgs`/`projects` command groups

Made with [Cursor](https://cursor.com)