### PR TITLE
docs: replace hardcoded IGNORED_PATHS with x-internal tag filter

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -1335,10 +1335,10 @@
           {
             "schema": {
               "type": "string",
-              "description": "Search auth configs by name"
+              "description": "Search auth configs by name or id"
             },
             "required": false,
-            "description": "Search auth configs by name",
+            "description": "Search auth configs by name or id",
             "name": "search",
             "in": "query"
           },
@@ -2809,7 +2809,7 @@
                           "status_reason": {
                             "type": "string",
                             "nullable": true,
-                            "description": "The reason the connection is disabled"
+                            "description": "The reason the connection status changed. Possible reasons: Connection initiation did not complete within 10 minutes, Permanent auth error during token refresh, Max auth failures reached, OAuth callback failed during token exchange, Connection status updated by user, Auth config is disabled"
                           },
                           "is_disabled": {
                             "type": "boolean",
@@ -3731,7 +3731,7 @@
                     "status_reason": {
                       "type": "string",
                       "nullable": true,
-                      "description": "The reason the connection is disabled"
+                      "description": "The reason the connection status changed. Possible reasons: Connection initiation did not complete within 10 minutes, Permanent auth error during token refresh, Max auth failures reached, OAuth callback failed during token exchange, Connection status updated by user, Auth config is disabled"
                     },
                     "is_disabled": {
                       "type": "boolean",

--- a/docs/scripts/fetch-openapi.mjs
+++ b/docs/scripts/fetch-openapi.mjs
@@ -11,23 +11,13 @@ import { dirname, join } from 'node:path';
 
 const OPENAPI_URL = process.env.OPENAPI_SPEC_URL || 'https://backend.composio.dev/api/v3/openapi.json';
 
-// Endpoints to ignore (same as fern openapi-overrides.yml)
-const IGNORED_PATHS = [
-  '/api/v3/mcp/validate/{uuid}',
-  '/api/v3/labs/tool_router/session',
-  '/api/v3/cli/get-session',
-  '/api/v3/cli/create-session',
-  '/api/v3/auth/session/logout',
-  '/api/v3/cli/realtime/credentials',
-  '/api/v3/cli/realtime/auth',
-];
-
 // Tags to ignore (internal/admin)
 const IGNORED_TAGS = [
   'CLI',
   'Admin',
   'Profiling',
   'User',
+  'x-internal',
 ];
 
 async function fetchAndFilterSpec() {
@@ -45,12 +35,6 @@ async function fetchAndFilterSpec() {
   let removedCount = 0;
 
   for (const [path, methods] of Object.entries(spec.paths)) {
-    // Skip ignored paths
-    if (IGNORED_PATHS.includes(path)) {
-      removedCount++;
-      continue;
-    }
-
     const filteredMethods = {};
 
     for (const [method, operation] of Object.entries(methods)) {
@@ -63,8 +47,8 @@ async function fetchAndFilterSpec() {
         continue;
       }
 
-      // Skip if marked as internal
-      if (operation['x-internal'] === true) {
+      // Skip if marked as internal (property or tag)
+      if (operation['x-internal'] === true || tags.includes('x-internal')) {
         removedCount++;
         continue;
       }


### PR DESCRIPTION
## Summary
- Removed the hardcoded `IGNORED_PATHS` array (7 paths) from `fetch-openapi.mjs`
- Updated the internal endpoint filter to also check for the `x-internal` tag, not just the `x-internal: true` property
- New internal endpoints tagged with `x-internal` in the OpenAPI spec are now automatically filtered — no more manual maintenance

## Context
Resolves [PLEN-1655](https://linear.app/composio/issue/PLEN-1655/migrate-hardcoded-ignored-paths-to-x-internal-in-hermes-openapi-spec)

The OpenAPI spec now uses `x-internal` as a tag on internal endpoints. All 7 previously hardcoded paths already have this tag, so the hardcoded list is no longer needed.

## Test plan
- [x] Ran `bun run scripts/fetch-openapi.mjs` — all 7 previously hardcoded paths are filtered
- [x] Verified output `openapi.json` does not contain any internal endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)