### PR TITLE
fix(py): handle all Python reserved keywords in provider parameter names

### DIFF
--- a/.github/workflows/py.test.yml
+++ b/.github/workflows/py.test.yml
@@ -50,6 +50,7 @@ jobs:
           uv venv --python ${{ matrix.python-version }}
           source .venv/bin/activate
           uv pip install -e .
+          uv pip install -e providers/langchain
           uv pip install pytest pytest-mock
 
       - name: Run Import Tests

--- a/python/composio/utils/shared.py
+++ b/python/composio/utils/shared.py
@@ -2,6 +2,8 @@
 Shared utils.
 """
 
+import copy
+import keyword
 import typing as t
 import uuid
 from inspect import Parameter
@@ -32,9 +34,85 @@ __all__ = [
     "get_signature_format_from_schema_params",
     "get_pydantic_signature_format_from_schema_params",
     "generate_request_id",
+    "substitute_reserved_python_keywords",
+    "reinstate_reserved_python_keywords",
 ]
 
 reserved_names = ["validate"]
+
+_OBJ_MARKER = "-_object_-"
+
+
+def _make_safe_name(name: str) -> str:
+    """Append ``_rs`` to a Python keyword so it can be used as a parameter name."""
+    return f"{name}_rs"
+
+
+def substitute_reserved_python_keywords(
+    schema: t.Dict,
+) -> t.Tuple[dict, dict]:
+    """Replace Python reserved keywords in a JSON schema's property names.
+
+    Returns a ``(schema, keywords)`` tuple where *schema* has safe property
+    names and *keywords* maps each safe name back to the original.  Nested
+    object schemas are processed recursively.
+
+    The schema is deep-copied before any mutation so the caller's original
+    is never modified.
+    """
+    if "properties" not in schema:
+        return schema, {}
+
+    schema = copy.deepcopy(schema)
+
+    keywords: t.Dict[str, t.Any] = {}
+    for p_name in list(schema["properties"]):
+        if not keyword.iskeyword(p_name):
+            continue
+
+        _nested_kw: t.Dict[str, t.Any] = {}
+        p_val = schema["properties"].pop(p_name)
+        if p_val.get("type") == "object":
+            p_val, _nested_kw = substitute_reserved_python_keywords(schema=p_val)
+
+        safe = _make_safe_name(p_name)
+        schema["properties"][safe] = p_val
+        keywords[safe] = p_name
+        keywords[f"{safe}{_OBJ_MARKER}"] = _nested_kw
+
+    # Also rename entries in the ``required`` list.
+    if keywords and "required" in schema:
+        reverse = {v: k for k, v in keywords.items() if not k.endswith(_OBJ_MARKER)}
+        schema["required"] = [reverse.get(r, r) for r in schema["required"]]
+
+    return schema, keywords
+
+
+def reinstate_reserved_python_keywords(
+    request: dict,
+    keywords: dict,
+) -> dict:
+    """Reverse the substitution performed by :func:`substitute_reserved_python_keywords`.
+
+    Modifies *request* **in-place** and returns it.
+    """
+    for clean_key in sorted(list(keywords), reverse=True):
+        subkeys = None
+        if clean_key.endswith(_OBJ_MARKER):
+            subkeys = keywords[clean_key]
+            clean_key, _ = clean_key.split(_OBJ_MARKER, maxsplit=1)
+
+        if clean_key not in request:
+            continue
+
+        original_value = request.pop(clean_key)
+        if subkeys:
+            original_value = reinstate_reserved_python_keywords(
+                request=original_value,
+                keywords=subkeys,
+            )
+        request[keywords[clean_key]] = original_value
+    return request
 
 
 def _coerce_default_value(

--- a/python/providers/autogen/composio_autogen/provider.py
+++ b/python/providers/autogen/composio_autogen/provider.py
@@ -10,7 +10,11 @@ from autogen_core.tools import FunctionTool
 from composio.client.types import Tool
 from composio.core.provider import AgenticProvider
 from composio.core.provider.agentic import AgenticProviderExecuteFn
-from composio.utils.shared import get_signature_format_from_schema_params
+from composio.utils.shared import (
+    get_signature_format_from_schema_params,
+    reinstate_reserved_python_keywords,
+    substitute_reserved_python_keywords,
+)
 
 
 class AutogenProvider(
@@ -65,9 +69,15 @@ class AutogenProvider(
         execute_tool: AgenticProviderExecuteFn,
     ) -> FunctionTool:
         """Wraps a composio tool as an Autogen FunctionTool."""
+        schema_params, keywords = substitute_reserved_python_keywords(
+            schema=tool.input_parameters
+        )
 
         def execute_action(**kwargs: t.Any) -> t.Dict:
             """Placeholder function for executing action."""
+            kwargs = reinstate_reserved_python_keywords(
+                request=kwargs, keywords=keywords
+            )
             return execute_tool(slug=tool.slug, arguments=kwargs)
 
         # Create function with proper signature
@@ -80,7 +90,7 @@ class AutogenProvider(
 
         # Set signature and annotations
         params = get_signature_format_from_schema_params(
-            schema_params=tool.input_parameters,
+            schema_params=schema_params,
         )
         function.__doc__ = tool.description
         setattr(function, "__signature__", Signature(parameters=params))

--- a/python/providers/gemini/composio_gemini/provider.py
+++ b/python/providers/gemini/composio_gemini/provider.py
@@ -5,7 +5,6 @@ Calling (AFC). The SDK can introspect the callable's signature to derive
 FunctionDeclaration schemas and auto-execute tool calls in the chat loop.
 """
 
-import copy
 import types as pytypes
 import typing as t
 from inspect import Parameter, Signature
@@ -13,7 +12,11 @@ from inspect import Parameter, Signature
 from composio.client.types import Tool
 from composio.core.provider import AgenticProvider
 from composio.core.provider.agentic import AgenticProviderExecuteFn
-from composio.utils.shared import get_pydantic_signature_format_from_schema_params
+from composio.utils.shared import (
+    get_pydantic_signature_format_from_schema_params,
+    reinstate_reserved_python_keywords,
+    substitute_reserved_python_keywords,
+)
 
 # google-genai is only needed for handle_response (backward compat)
 try:
@@ -23,45 +26,6 @@ try:
 except ImportError:
     genai_types = None  # type: ignore
     HAS_GENAI = False
-
-_python_reserved = {"for", "async"}
-
-
-def _clean_reserved_keyword(keyword: str) -> str:
-    return f"{keyword}_rs"
-
-
-def _substitute_reserved_python_keywords(schema: t.Dict) -> t.Tuple[dict, dict]:
-    if "properties" not in schema:
-        return schema, {}
-
-    schema = copy.deepcopy(schema)
-
-    keywords: t.Dict[str, str] = {}
-    for p_name in list(schema["properties"]):
-        if p_name not in _python_reserved:
-            continue
-
-        p_val = schema["properties"].pop(p_name)
-        p_name_clean = _clean_reserved_keyword(keyword=p_name)
-        schema["properties"][p_name_clean] = p_val
-        keywords[p_name_clean] = p_name
-
-    if keywords and "required" in schema:
-        reverse_map = {v: k for k, v in keywords.items()}
-        schema["required"] = [
-            reverse_map.get(name, name) for name in schema["required"]
-        ]
-
-    return schema, keywords
-
-
-def _reinstate_reserved_python_keywords(request: dict, keywords: dict) -> dict:
-    for clean_key, original_key in keywords.items():
-        if clean_key not in request:
-            continue
-        request[original_key] = request.pop(clean_key)
-    return request
 
 
 def _to_serializable(value: t.Any) -> t.Any:
@@ -135,14 +99,14 @@ class GeminiProvider(AgenticProvider[t.Callable, list[t.Callable]], name="gemini
         self._executors[tool.slug] = execute_tool
 
         # Handle reserved Python keywords in parameter names
-        schema_params, keywords = _substitute_reserved_python_keywords(
+        schema_params, keywords = substitute_reserved_python_keywords(
             schema=tool.input_parameters
         )
 
         def function(**kwargs: t.Any) -> t.Dict:
             """Composio tool execution wrapper."""
             kwargs = _to_serializable(kwargs)
-            kwargs = _reinstate_reserved_python_keywords(
+            kwargs = reinstate_reserved_python_keywords(
                 request=kwargs, keywords=keywords
             )
             result = execute_tool(tool.slug, kwargs)

--- a/python/providers/langchain/composio_langchain/provider.py
+++ b/python/providers/langchain/composio_langchain/provider.py
@@ -13,56 +13,9 @@ from composio.utils.pydantic import parse_pydantic_error
 from composio.utils.shared import (
     get_signature_format_from_schema_params,
     json_schema_to_model,
+    reinstate_reserved_python_keywords,
+    substitute_reserved_python_keywords,
 )
-
-_python_reserved = {"for", "async"}
-_obj_marker = "-_object_-"
-
-
-def _clean_reserved_keyword(keyword: str):
-    return f"{keyword}_rs"
-
-
-def _substitute_reserved_python_keywords(schema: t.Dict) -> t.Tuple[dict, dict]:
-    if "properties" not in schema:
-        return schema, {}
-
-    keywords = {}
-    for p_name in list(schema["properties"]):
-        if p_name not in _python_reserved:
-            continue
-
-        _keywords = {}
-        p_val = schema["properties"].pop(p_name)
-        if p_val.get("type") == "object":
-            p_val, _keywords = _substitute_reserved_python_keywords(schema=p_val)
-
-        p_name_clean = _clean_reserved_keyword(keyword=p_name)
-        schema["properties"][p_name_clean] = p_val
-        keywords[p_name_clean] = p_name
-        keywords[f"{p_name_clean}{_obj_marker}"] = _keywords
-
-    return schema, keywords
-
-
-def _reinstate_reserved_python_keywords(request: dict, keywords: dict) -> dict:
-    for clean_key in sorted(list(keywords), reverse=True):
-        subkeys = None
-        if clean_key.endswith(_obj_marker):
-            subkeys = keywords[clean_key]
-            clean_key, _ = clean_key.split(_obj_marker, maxsplit=1)
-
-        if clean_key not in request:
-            continue
-
-        orginal_value = request.pop(clean_key)
-        if subkeys is not None:
-            orginal_value = _reinstate_reserved_python_keywords(
-                request=orginal_value,
-                keywords=subkeys,
-            )
-        request[keywords[clean_key]] = orginal_value
-    return request
 
 
 class StructuredTool(BaseStructuredTool):  # type: ignore[misc]
@@ -88,13 +41,13 @@ class LangchainProvider(
     ) -> StructuredTool:
         """Wraps composio tool as Langchain StructuredTool object."""
         # Replace reserved python keywords
-        schema_params, keywords = _substitute_reserved_python_keywords(
+        schema_params, keywords = substitute_reserved_python_keywords(
             schema=tool.input_parameters
         )
 
         def function(**kwargs: t.Any) -> t.Dict:
             """Wrapper function for composio action."""
-            kwargs = _reinstate_reserved_python_keywords(
+            kwargs = reinstate_reserved_python_keywords(
                 request=kwargs,
                 keywords=keywords,
             )

--- a/python/providers/langgraph/composio_langgraph/provider.py
+++ b/python/providers/langgraph/composio_langgraph/provider.py
@@ -13,6 +13,8 @@ from composio.utils.pydantic import parse_pydantic_error
 from composio.utils.shared import (
     get_signature_format_from_schema_params,
     json_schema_to_model,
+    reinstate_reserved_python_keywords,
+    substitute_reserved_python_keywords,
 )
 
 
@@ -37,10 +39,14 @@ class LanggraphProvider(
         tool: str,
         description: str,
         schema_params: t.Dict,
+        keywords: t.Dict,
         execute_tool: AgenticProviderExecuteFn,
     ):
         def function(**kwargs: t.Any) -> t.Dict:
             """Wrapper function for composio action."""
+            kwargs = reinstate_reserved_python_keywords(
+                request=kwargs, keywords=keywords
+            )
             return execute_tool(tool, kwargs)
 
         action_func = types.FunctionType(
@@ -61,20 +67,24 @@ class LanggraphProvider(
         self, tool: Tool, execute_tool: AgenticProviderExecuteFn
     ) -> StructuredTool:
         """Wraps composio tool as Langchain StructuredTool object."""
+        schema_params, keywords = substitute_reserved_python_keywords(
+            schema=tool.input_parameters
+        )
         return t.cast(
             StructuredTool,
             StructuredTool.from_function(
                 name=tool.slug,
                 description=tool.description,
                 args_schema=json_schema_to_model(
-                    json_schema=tool.input_parameters,
+                    json_schema=schema_params,
                     skip_default=self.skip_default,
                 ),
                 return_schema=True,
                 func=self._wrap_action(
                     tool=tool.slug,
                     description=tool.description,
-                    schema_params=tool.input_parameters,
+                    schema_params=schema_params,
+                    keywords=keywords,
                     execute_tool=execute_tool,
                 ),
                 handle_tool_error=True,

--- a/python/providers/llamaindex/composio_llamaindex/provider.py
+++ b/python/providers/llamaindex/composio_llamaindex/provider.py
@@ -8,7 +8,11 @@ from llama_index.core.tools import FunctionTool
 
 from composio.core.provider import AgenticProvider, AgenticProviderExecuteFn
 from composio.types import Tool
-from composio.utils.shared import get_signature_format_from_schema_params
+from composio.utils.shared import (
+    get_signature_format_from_schema_params,
+    reinstate_reserved_python_keywords,
+    substitute_reserved_python_keywords,
+)
 
 
 class LlamaIndexProvider(
@@ -27,9 +31,15 @@ class LlamaIndexProvider(
         """
         Wrap a tool into a LlamaIndex FunctionTool object.
         """
+        schema_params, keywords = substitute_reserved_python_keywords(
+            schema=tool.input_parameters
+        )
 
         def function(**kwargs: t.Any) -> t.Dict:
             """Wrapper function for composio action."""
+            kwargs = reinstate_reserved_python_keywords(
+                request=kwargs, keywords=keywords
+            )
             return execute_tool(slug=tool.slug, arguments=kwargs)
 
         action_func = types.FunctionType(
@@ -40,7 +50,7 @@ class LlamaIndexProvider(
         )
         action_func.__signature__ = Signature(  # type: ignore
             parameters=get_signature_format_from_schema_params(
-                schema_params=tool.input_parameters,
+                schema_params=schema_params,
                 skip_default=self.skip_default,
             )
         )

--- a/python/tests/test_provider.py
+++ b/python/tests/test_provider.py
@@ -672,6 +672,169 @@ class TestAgenticProviderFunctionality:
         assert wrapped[0]["has_executor"] is True
 
 
+class TestLangchainReservedKeywords:
+    """Regression tests for PLEN-1671: ValueError when tool schema has Python reserved keywords as parameter names.
+
+    Tools from some toolkits (e.g. Intercom) have parameters named 'from',
+    which is a Python reserved keyword. The LangchainProvider must substitute
+    these names before building function signatures and reinstate them when
+    executing the tool.
+    """
+
+    def _make_tool_with_params(self, properties: dict, required: list | None = None):
+        """Helper: create a mock Tool whose input_parameters use the given properties."""
+        return Tool(
+            name="Test Tool",
+            slug="TEST_TOOL",
+            description="A tool for testing reserved keyword handling",
+            input_parameters={
+                "type": "object",
+                "title": "TestToolRequest",
+                "properties": properties,
+                "required": required or [],
+            },
+            output_parameters={},
+            available_versions=["12012025_00"],
+            version="12012025_00",
+            scopes=[],
+            status="active",
+            toolkit=tool_list_response.ItemToolkit(name="Test", slug="test", logo=""),
+            deprecated=tool_list_response.ItemDeprecated(
+                available_versions=["12012025_00"],
+                displayName="Test Tool",
+                version="12012025_00",
+                toolkit=tool_list_response.ItemDeprecatedToolkit(logo=""),
+                is_deprecated=False,
+            ),
+            is_deprecated=False,
+            no_auth=False,
+            tags=[],
+        )
+
+    def test_wrap_tool_with_from_parameter(self):
+        """PLEN-1671: 'from' parameter must not raise ValueError."""
+        from composio_langchain import LangchainProvider
+
+        provider = LangchainProvider()
+        tool = self._make_tool_with_params(
+            properties={
+                "from": {
+                    "type": "string",
+                    "description": "Starting point for listing",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max results",
+                    "default": 20,
+                },
+            },
+        )
+
+        captured = {}
+
+        def mock_execute(slug, arguments):
+            captured.update(arguments)
+            return {"data": {}, "error": None, "successful": True}
+
+        # Must not raise ValueError: 'from' is not a valid parameter name
+        wrapped = provider.wrap_tool(tool, mock_execute)
+
+        assert wrapped.name == "TEST_TOOL"
+
+        # Invoke the tool and verify 'from' is reinstated in the arguments
+        wrapped.run({"from_rs": "2024-01-01", "limit": 10})
+        assert captured == {"from": "2024-01-01", "limit": 10}
+
+    def test_wrap_tool_with_multiple_reserved_keywords(self):
+        """All Python reserved keywords used as parameter names must be handled."""
+        from composio_langchain import LangchainProvider
+
+        provider = LangchainProvider()
+        tool = self._make_tool_with_params(
+            properties={
+                "from": {
+                    "type": "string",
+                    "description": "Start date",
+                },
+                "for": {
+                    "type": "string",
+                    "description": "Recipient",
+                },
+                "import": {
+                    "type": "string",
+                    "description": "Import source",
+                },
+                "class": {
+                    "type": "string",
+                    "description": "CSS class",
+                },
+                "async": {
+                    "type": "boolean",
+                    "description": "Async flag",
+                    "default": False,
+                },
+                "normal_param": {
+                    "type": "string",
+                    "description": "A normal parameter",
+                },
+            },
+        )
+
+        captured = {}
+
+        def mock_execute(slug, arguments):
+            captured.update(arguments)
+            return {"data": {}, "error": None, "successful": True}
+
+        wrapped = provider.wrap_tool(tool, mock_execute)
+        assert wrapped.name == "TEST_TOOL"
+
+        # Invoke with renamed parameters and verify originals are reinstated
+        wrapped.run(
+            {
+                "from_rs": "2024-01-01",
+                "for_rs": "user@example.com",
+                "import_rs": "csv",
+                "class_rs": "primary",
+                "async_rs": True,
+                "normal_param": "hello",
+            }
+        )
+        assert captured == {
+            "from": "2024-01-01",
+            "for": "user@example.com",
+            "import": "csv",
+            "class": "primary",
+            "async": True,
+            "normal_param": "hello",
+        }
+
+    def test_wrap_tool_with_required_reserved_keyword_param(self):
+        """Reserved keywords that are also required params must work."""
+        from composio_langchain import LangchainProvider
+
+        provider = LangchainProvider()
+        tool = self._make_tool_with_params(
+            properties={
+                "from": {
+                    "type": "string",
+                    "description": "Required start date",
+                },
+            },
+            required=["from"],
+        )
+
+        captured = {}
+
+        def mock_execute(slug, arguments):
+            captured.update(arguments)
+            return {"data": {}, "error": None, "successful": True}
+
+        wrapped = provider.wrap_tool(tool, mock_execute)
+        wrapped.run({"from_rs": "2024-01-01"})
+        assert captured == {"from": "2024-01-01"}
+
+
 class TestProviderEdgeCases:
     """Test edge cases and error handling for providers."""
 


### PR DESCRIPTION
This PR:

- closes [PLEN-1671](https://linear.app/composio/issue/PLEN-1671/valueerror-when-working-with-langchain-provider-from-not-a-valid)
- extracts `substitute_reserved_python_keywords()` and `reinstate_reserved_python_keywords()` into `composio/utils/shared.py`, using `keyword.iskeyword()` from stdlib for complete coverage of all Python keywords
- fixes the langchain and gemini providers, which had a hardcoded `_python_reserved = {"for", "async"}` set that was missing `"from"` and ~30 other Python keywords
- adds keyword substitution to the langgraph, autogen, and llamaindex providers, which previously had no reserved-keyword handling at all and would crash on the same inputs
- adds 3 regression tests covering: single `from` parameter, multiple reserved keywords together (`from`, `for`, `import`, `class`, `async`), and required reserved keyword parameters