### PR TITLE
docs: polling interval changes lookahead changelog

### DIFF
--- a/docs/content/changelog/03-03-26-polling-interval-changes.mdx
+++ b/docs/content/changelog/03-03-26-polling-interval-changes.mdx
@@ -38,12 +38,12 @@ composio.triggers.enable(
 
 During the transition period, intervals below the minimum are **silently clamped** — your triggers will continue to work without errors, but they will run at the minimum interval instead of your requested interval.
 
-### Enforcement (April 1, 2026)
+### Enforcement (April 15, 2026)
 
-Starting **April 1, 2026**, requesting an interval below the minimum will return an **API error** instead of silently clamping. Update your trigger configurations to use an interval of 15 minutes or higher before this date.
+Starting **April 15, 2026**, requesting an interval below the minimum will return an **API error** instead of silently clamping. Update your trigger configurations to use an interval of 15 minutes or higher before this date.
 
 ```python
-# This will return an error after April 1, 2026
+# This will return an error after April 15, 2026
 composio.triggers.enable(
     trigger_name="GMAIL_NEW_GMAIL_MESSAGE",
     connected_account_id="ca_xxx",
@@ -51,22 +51,22 @@ composio.triggers.enable(
 )
 ```
 
-### Using Custom Auth?
+### Need Intervals Below 15 Minutes?
 
-If you're using **custom auth** (your own OAuth apps), the 15-minute minimum does not apply. You can set polling intervals as low as **1 minute**.
+If you require polling intervals shorter than 15 minutes, you should **use your own OAuth app** (custom auth). With custom auth, the 15-minute minimum does not apply — you can set polling intervals as low as **1 minute**.
 
 ## What You Need to Do
 
 1. **Review your trigger configurations** — check if any triggers use intervals shorter than 15 minutes
-2. **Update intervals** to 15 minutes or higher before **April 1, 2026**
+2. **Update intervals** to 15 minutes or higher before **April 15, 2026**
 3. **If you need near-real-time events**, consider using **webhook triggers** instead of polling triggers, or use **custom auth** for intervals as low as 1 minute
 
 ## Rollout Timeline
 
 - **March 3, 2026**: Silent clamping enabled — intervals below 15 minutes are automatically raised to 15 minutes
-- **April 1, 2026**: API enforcement — intervals below 15 minutes will return an error
-- **April 1, 2026**: Dashboard enforcement — the UI will prevent setting intervals below 15 minutes
+- **April 15, 2026**: API enforcement — intervals below 15 minutes will return an error
+- **April 15, 2026**: Dashboard enforcement — the UI will prevent setting intervals below 15 minutes
 
 <Callout type="info">
-Existing triggers with intervals below 15 minutes will continue to function during the transition period, but at the clamped 15-minute interval. Update your configurations before April 1 to avoid errors.
+Existing triggers with intervals below 15 minutes will continue to function during the transition period, but at the clamped 15-minute interval. Update your configurations before April 15 to avoid errors.
 </Callout>

--- a/docs/content/changelog/03-03-26-polling-interval-changes.mdx
+++ b/docs/content/changelog/03-03-26-polling-interval-changes.mdx
@@ -51,6 +51,10 @@ composio.triggers.enable(
 )
 ```
 
+### App-Level Interval Overrides
+
+We will also be introducing **app-specific default polling intervals**. Each app will have its own default interval based on the rate limits that app allows and whether the rate limit is per-user or per-app. These app-level defaults may be lower or higher than 15 minutes depending on the app. When you don't specify an `interval`, the app-level default will be used instead of the global 15-minute default.
+
 ### Need Intervals Below 15 Minutes?
 
 If you require polling intervals shorter than 15 minutes, you should **use your own OAuth app** (custom auth). With custom auth, the 15-minute minimum does not apply — you can set polling intervals as low as **1 minute**.

--- a/docs/content/changelog/03-03-26-polling-interval-changes.mdx
+++ b/docs/content/changelog/03-03-26-polling-interval-changes.mdx
@@ -53,7 +53,7 @@ composio.triggers.enable(
 
 ### Using Custom Auth?
 
-If you're using **custom auth** (your own API keys), the 15-minute minimum does not apply. You can set polling intervals as low as **1 minute**.
+If you're using **custom auth** (your own OAuth apps), the 15-minute minimum does not apply. You can set polling intervals as low as **1 minute**.
 
 ## What You Need to Do
 

--- a/docs/content/changelog/03-03-26-polling-interval-changes.mdx
+++ b/docs/content/changelog/03-03-26-polling-interval-changes.mdx
@@ -1,10 +1,10 @@
 ---
-title: "Polling Trigger Interval Changes - Lookahead Announcement"
+title: "Polling Trigger Interval Changes"
 description: "Default polling interval increasing from 1 minute to 15 minutes, with silent clamping during transition"
 date: "2026-03-03"
 ---
 
-We're updating **polling trigger intervals** to improve platform reliability and reduce unnecessary API load. This change affects how frequently polling triggers execute.
+We're updating **polling trigger intervals** to improve platform reliability and avoid rate limiting. This change affects how frequently polling triggers execute.
 
 ## What's Changing?
 
@@ -18,8 +18,6 @@ If you don't specify an `interval` in your trigger configuration, your triggers 
 
 A new **minimum polling interval of 15 minutes** is being introduced. Triggers configured with intervals shorter than 15 minutes will be automatically clamped to 15 minutes.
 
-**Example:**
-
 ```python
 # Before: this would poll every 5 minutes
 composio.triggers.enable(
@@ -28,7 +26,7 @@ composio.triggers.enable(
     config={"interval": 5}
 )
 
-# After: interval is silently clamped to 15 minutes
+# Now: interval is silently clamped to 15 minutes
 composio.triggers.enable(
     trigger_name="GMAIL_NEW_GMAIL_MESSAGE",
     connected_account_id="ca_xxx",
@@ -38,14 +36,14 @@ composio.triggers.enable(
 
 ### Current Behavior (Transition Period)
 
-During the transition period, intervals below the minimum are **silently clamped** — your triggers will continue to work without errors, but they will run at the minimum interval instead of your requested interval. A warning is logged when clamping occurs.
+During the transition period, intervals below the minimum are **silently clamped** — your triggers will continue to work without errors, but they will run at the minimum interval instead of your requested interval.
 
-### Upcoming Enforcement (~2 Weeks)
+### Enforcement (April 1, 2026)
 
-After the transition period, requesting an interval below the minimum will return an **API error** instead of silently clamping. You will need to update your trigger configurations to use an interval of 15 minutes or higher.
+Starting **April 1, 2026**, requesting an interval below the minimum will return an **API error** instead of silently clamping. Update your trigger configurations to use an interval of 15 minutes or higher before this date.
 
 ```python
-# This will return an error after enforcement begins
+# This will return an error after April 1, 2026
 composio.triggers.enable(
     trigger_name="GMAIL_NEW_GMAIL_MESSAGE",
     connected_account_id="ca_xxx",
@@ -53,31 +51,18 @@ composio.triggers.enable(
 )
 ```
 
-## Why This Change?
-
-1. **Platform Reliability**: Reducing polling frequency decreases load on both Composio infrastructure and third-party APIs
-2. **Rate Limit Protection**: Many third-party APIs have rate limits that are easily hit with 1-minute polling across many triggers
-3. **Cost Efficiency**: Less frequent polling reduces infrastructure costs, keeping the platform sustainable
-
 ## What You Need to Do
 
 1. **Review your trigger configurations** — check if any triggers use intervals shorter than 15 minutes
-2. **Update intervals** to 15 minutes or higher before enforcement begins
+2. **Update intervals** to 15 minutes or higher before **April 1, 2026**
 3. **If you need near-real-time events**, consider using **webhook triggers** instead of polling triggers where available
 
 ## Rollout Timeline
 
-- **March 2026**: Silent clamping enabled — intervals below 15 minutes are automatically raised to 15 minutes
-- **Mid-March 2026**: API enforcement — intervals below 15 minutes will return an error
-- **Frontend enforcement**: The dashboard will prevent setting intervals below 15 minutes
+- **March 3, 2026**: Silent clamping enabled — intervals below 15 minutes are automatically raised to 15 minutes
+- **April 1, 2026**: API enforcement — intervals below 15 minutes will return an error
+- **April 1, 2026**: Dashboard enforcement — the UI will prevent setting intervals below 15 minutes
 
 <Callout type="info">
-Existing triggers with intervals below 15 minutes will continue to function during the transition period, but at the clamped 15-minute interval. We recommend updating your configurations proactively.
+Existing triggers with intervals below 15 minutes will continue to function during the transition period, but at the clamped 15-minute interval. Update your configurations before April 1 to avoid errors.
 </Callout>
-
-## Need Help?
-
-If you have questions about this change or need assistance:
-- Join our [Discord community](https://discord.gg/composio)
-- Check our [documentation](https://docs.composio.dev)
-- Contact support at support@composio.dev

--- a/docs/content/changelog/03-03-26-polling-interval-changes.mdx
+++ b/docs/content/changelog/03-03-26-polling-interval-changes.mdx
@@ -51,11 +51,15 @@ composio.triggers.enable(
 )
 ```
 
+### Using Custom Auth?
+
+If you're using **custom auth** (your own API keys), the 15-minute minimum does not apply. You can set polling intervals as low as **1 minute**.
+
 ## What You Need to Do
 
 1. **Review your trigger configurations** — check if any triggers use intervals shorter than 15 minutes
 2. **Update intervals** to 15 minutes or higher before **April 1, 2026**
-3. **If you need near-real-time events**, consider using **webhook triggers** instead of polling triggers where available
+3. **If you need near-real-time events**, consider using **webhook triggers** instead of polling triggers, or use **custom auth** for intervals as low as 1 minute
 
 ## Rollout Timeline
 

--- a/docs/content/changelog/03-03-26-polling-interval-changes.mdx
+++ b/docs/content/changelog/03-03-26-polling-interval-changes.mdx
@@ -1,0 +1,83 @@
+---
+title: "Polling Trigger Interval Changes - Lookahead Announcement"
+description: "Default polling interval increasing from 1 minute to 15 minutes, with silent clamping during transition"
+date: "2026-03-03"
+---
+
+We're updating **polling trigger intervals** to improve platform reliability and reduce unnecessary API load. This change affects how frequently polling triggers execute.
+
+## What's Changing?
+
+### Default Polling Interval
+
+The default polling interval for triggers is increasing from **1 minute** to **15 minutes**.
+
+If you don't specify an `interval` in your trigger configuration, your triggers will now poll every 15 minutes instead of every 1 minute.
+
+### Minimum Polling Interval
+
+A new **minimum polling interval of 15 minutes** is being introduced. Triggers configured with intervals shorter than 15 minutes will be automatically clamped to 15 minutes.
+
+**Example:**
+
+```python
+# Before: this would poll every 5 minutes
+composio.triggers.enable(
+    trigger_name="GMAIL_NEW_GMAIL_MESSAGE",
+    connected_account_id="ca_xxx",
+    config={"interval": 5}
+)
+
+# After: interval is silently clamped to 15 minutes
+composio.triggers.enable(
+    trigger_name="GMAIL_NEW_GMAIL_MESSAGE",
+    connected_account_id="ca_xxx",
+    config={"interval": 5}  # Effective interval: 15 minutes
+)
+```
+
+### Current Behavior (Transition Period)
+
+During the transition period, intervals below the minimum are **silently clamped** — your triggers will continue to work without errors, but they will run at the minimum interval instead of your requested interval. A warning is logged when clamping occurs.
+
+### Upcoming Enforcement (~2 Weeks)
+
+After the transition period, requesting an interval below the minimum will return an **API error** instead of silently clamping. You will need to update your trigger configurations to use an interval of 15 minutes or higher.
+
+```python
+# This will return an error after enforcement begins
+composio.triggers.enable(
+    trigger_name="GMAIL_NEW_GMAIL_MESSAGE",
+    connected_account_id="ca_xxx",
+    config={"interval": 5}  # Error: interval must be >= 15 minutes
+)
+```
+
+## Why This Change?
+
+1. **Platform Reliability**: Reducing polling frequency decreases load on both Composio infrastructure and third-party APIs
+2. **Rate Limit Protection**: Many third-party APIs have rate limits that are easily hit with 1-minute polling across many triggers
+3. **Cost Efficiency**: Less frequent polling reduces infrastructure costs, keeping the platform sustainable
+
+## What You Need to Do
+
+1. **Review your trigger configurations** — check if any triggers use intervals shorter than 15 minutes
+2. **Update intervals** to 15 minutes or higher before enforcement begins
+3. **If you need near-real-time events**, consider using **webhook triggers** instead of polling triggers where available
+
+## Rollout Timeline
+
+- **March 2026**: Silent clamping enabled — intervals below 15 minutes are automatically raised to 15 minutes
+- **Mid-March 2026**: API enforcement — intervals below 15 minutes will return an error
+- **Frontend enforcement**: The dashboard will prevent setting intervals below 15 minutes
+
+<Callout type="info">
+Existing triggers with intervals below 15 minutes will continue to function during the transition period, but at the clamped 15-minute interval. We recommend updating your configurations proactively.
+</Callout>
+
+## Need Help?
+
+If you have questions about this change or need assistance:
+- Join our [Discord community](https://discord.gg/composio)
+- Check our [documentation](https://docs.composio.dev)
+- Contact support at support@composio.dev


### PR DESCRIPTION
## Summary
- Add lookahead changelog announcing transition from 1-minute to 15-minute default polling intervals
- During transition period, sub-minimum intervals are silently clamped
- Hard enforcement via API errors will follow in ~2 weeks

## Test plan
- [ ] Verify MDX renders correctly on the docs site
- [ ] Confirm changelog date ordering is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)