### PR TITLE
feat(cli): compact root help, fix project-environment-detector empty dir test

### DIFF
--- a/ts/packages/cli/src/bin.ts
+++ b/ts/packages/cli/src/bin.ts
@@ -224,7 +224,6 @@ runWithArgs.pipe(
   ),
   Effect.provide(layers),
   Effect.withConfigProvider(extendConfigProvider(BaseConfigProviderLive)),
-  BunRuntime.runMain({
-    teardown,
-  })
+  effect =>
+    (BunRuntime.runMain({ teardown }) as (e: Effect.Effect<void, unknown, unknown>) => void)(effect)
 );

--- a/ts/packages/cli/src/commands/index.ts
+++ b/ts/packages/cli/src/commands/index.ts
@@ -21,6 +21,7 @@ import { logsCmd } from './logs-cmd/logs.cmd';
 import { orgsCmd } from './orgs/orgs.cmd';
 import { projectsCmd } from './projects/projects.cmd';
 import { showToolsExecuteInputHelp } from './tools/commands/tools.execute.cmd';
+import { printRootHelp } from './root-help';
 
 const $cmd = $defaultCmd.pipe(
   Command.withSubcommands([
@@ -99,6 +100,11 @@ const normalizeVersionShortFlag = (argv: ReadonlyArray<string>): ReadonlyArray<s
   return argv;
 };
 
+const isRootHelp = (argv: ReadonlyArray<string>): boolean => {
+  const args = argv.slice(2);
+  return args.length === 1 && (args[0] === '--help' || args[0] === '-h');
+};
+
 export const runWithConfig = Effect.gen(function* () {
   const version = yield* getVersion;
   const run = Command.run($cmd, {
@@ -109,6 +115,9 @@ export const runWithConfig = Effect.gen(function* () {
 
   return (argv: ReadonlyArray<string>) => {
     const normalizedArgv = normalizeVersionShortFlag(argv);
+    if (isRootHelp(normalizedArgv)) {
+      return printRootHelp();
+    }
     const executeHelpSlug = parseExecuteInputHelpSlug(normalizedArgv);
     if (executeHelpSlug) {
       return showToolsExecuteInputHelp(executeHelpSlug);

--- a/ts/packages/cli/src/commands/index.ts
+++ b/ts/packages/cli/src/commands/index.ts
@@ -23,26 +23,29 @@ import { projectsCmd } from './projects/projects.cmd';
 import { showToolsExecuteInputHelp } from './tools/commands/tools.execute.cmd';
 import { printRootHelp } from './root-help';
 
+/** Subcommands in display order. Single source of truth for root help. */
+const subcommands = [
+  versionCmd,
+  upgradeCmd,
+  whoamiCmd,
+  loginCmd,
+  logoutCmd,
+  initCmd,
+  generateCmd,
+  pyCmd,
+  tsCmd,
+  toolkitsCmd,
+  toolsCmd,
+  authConfigsCmd,
+  connectedAccountsCmd,
+  triggersCmd,
+  logsCmd,
+  orgsCmd,
+  projectsCmd,
+];
+
 const $cmd = $defaultCmd.pipe(
-  Command.withSubcommands([
-    versionCmd,
-    upgradeCmd,
-    whoamiCmd,
-    loginCmd,
-    logoutCmd,
-    initCmd,
-    generateCmd,
-    pyCmd,
-    tsCmd,
-    toolkitsCmd,
-    toolsCmd,
-    authConfigsCmd,
-    connectedAccountsCmd,
-    triggersCmd,
-    logsCmd,
-    orgsCmd,
-    projectsCmd,
-  ])
+  Command.withSubcommands(subcommands as unknown as Parameters<typeof Command.withSubcommands>[1])
 );
 
 export const rootCommand = $cmd;
@@ -116,7 +119,7 @@ export const runWithConfig = Effect.gen(function* () {
   return (argv: ReadonlyArray<string>) => {
     const normalizedArgv = normalizeVersionShortFlag(argv);
     if (isRootHelp(normalizedArgv)) {
-      return printRootHelp();
+      return printRootHelp(subcommands as Parameters<typeof printRootHelp>[0]);
     }
     const executeHelpSlug = parseExecuteInputHelpSlug(normalizedArgv);
     if (executeHelpSlug) {

--- a/ts/packages/cli/src/commands/index.ts
+++ b/ts/packages/cli/src/commands/index.ts
@@ -23,29 +23,26 @@ import { projectsCmd } from './projects/projects.cmd';
 import { showToolsExecuteInputHelp } from './tools/commands/tools.execute.cmd';
 import { printRootHelp } from './root-help';
 
-/** Subcommands in display order. Single source of truth for root help. */
-const subcommands = [
-  versionCmd,
-  upgradeCmd,
-  whoamiCmd,
-  loginCmd,
-  logoutCmd,
-  initCmd,
-  generateCmd,
-  pyCmd,
-  tsCmd,
-  toolkitsCmd,
-  toolsCmd,
-  authConfigsCmd,
-  connectedAccountsCmd,
-  triggersCmd,
-  logsCmd,
-  orgsCmd,
-  projectsCmd,
-];
-
 const $cmd = $defaultCmd.pipe(
-  Command.withSubcommands(subcommands as unknown as Parameters<typeof Command.withSubcommands>[1])
+  Command.withSubcommands([
+    versionCmd,
+    upgradeCmd,
+    whoamiCmd,
+    loginCmd,
+    logoutCmd,
+    initCmd,
+    generateCmd,
+    pyCmd,
+    tsCmd,
+    toolkitsCmd,
+    toolsCmd,
+    authConfigsCmd,
+    connectedAccountsCmd,
+    triggersCmd,
+    logsCmd,
+    orgsCmd,
+    projectsCmd,
+  ])
 );
 
 export const rootCommand = $cmd;
@@ -119,7 +116,7 @@ export const runWithConfig = Effect.gen(function* () {
   return (argv: ReadonlyArray<string>) => {
     const normalizedArgv = normalizeVersionShortFlag(argv);
     if (isRootHelp(normalizedArgv)) {
-      return printRootHelp(subcommands as Parameters<typeof printRootHelp>[0]);
+      return printRootHelp();
     }
     const executeHelpSlug = parseExecuteInputHelpSlug(normalizedArgv);
     if (executeHelpSlug) {

--- a/ts/packages/cli/src/commands/root-help.ts
+++ b/ts/packages/cli/src/commands/root-help.ts
@@ -1,0 +1,57 @@
+import { Console, Effect } from 'effect';
+import { bold } from 'src/ui/colors';
+
+/**
+ * Top-level commands for the root help output.
+ * Order and descriptions must match the commands in index.ts.
+ */
+const ROOT_COMMANDS: ReadonlyArray<{ name: string; description: string }> = [
+  { name: 'version', description: 'Display the current Composio CLI version.' },
+  { name: 'upgrade', description: 'Upgrade your Composio CLI to the latest available version.' },
+  { name: 'whoami', description: 'Display your account information.' },
+  { name: 'login', description: 'Log in to the Composio SDK.' },
+  { name: 'logout', description: 'Log out from the Composio SDK.' },
+  { name: 'init', description: 'Initialize a Composio project in the current directory.' },
+  { name: 'generate', description: 'Generate type stubs for toolkits, tools, and triggers.' },
+  { name: 'py', description: 'Handle Python projects.' },
+  { name: 'ts', description: 'Handle TypeScript projects.' },
+  { name: 'toolkits', description: 'Discover and inspect Composio toolkits.' },
+  { name: 'tools', description: 'Discover and inspect Composio tools.' },
+  { name: 'auth-configs', description: 'View and manage Composio auth configs.' },
+  { name: 'connected-accounts', description: 'View and manage Composio connected accounts.' },
+  { name: 'triggers', description: 'Inspect and subscribe to trigger events.' },
+  { name: 'logs', description: 'Inspect trigger and tool execution logs.' },
+  { name: 'orgs', description: 'Manage default global organization/project context.' },
+  { name: 'projects', description: 'Manage default global project context.' },
+];
+
+/**
+ * Prints the root-level help output in gh-style format.
+ * Shows only top-level commands, not nested subcommands.
+ */
+export function printRootHelp(): Effect.Effect<void> {
+  const name = 'composio';
+  const maxNameLen = Math.max(...ROOT_COMMANDS.map(c => c.name.length), 10);
+
+  const lines: string[] = [
+    '',
+    'A tool for managing Python and TypeScript composio.dev projects.',
+    '',
+    bold('USAGE'),
+    `  ${name} <command> [options]`,
+    '',
+    bold('COMMANDS'),
+    ...ROOT_COMMANDS.map(cmd => `  ${cmd.name.padEnd(maxNameLen)}  ${cmd.description}`),
+    '',
+    bold('FLAGS'),
+    `  -h, --help     Show help for command`,
+    `  --version      Show ${name} version`,
+    '',
+    bold('LEARN MORE'),
+    `  Use \`${name} <command> --help\` for more information about a command.`,
+    `  Documentation: https://docs.composio.dev`,
+    '',
+  ];
+
+  return Console.log(lines.join('\n'));
+}

--- a/ts/packages/cli/src/commands/root-help.ts
+++ b/ts/packages/cli/src/commands/root-help.ts
@@ -1,37 +1,58 @@
 import { Console, Effect } from 'effect';
+import { Command, HelpDoc } from '@effect/cli';
+import * as HashSet from 'effect/HashSet';
 import { bold } from 'src/ui/colors';
 
-/**
- * Top-level commands for the root help output.
- * Order and descriptions must match the commands in index.ts.
- */
-const ROOT_COMMANDS: ReadonlyArray<{ name: string; description: string }> = [
-  { name: 'version', description: 'Display the current Composio CLI version.' },
-  { name: 'upgrade', description: 'Upgrade your Composio CLI to the latest available version.' },
-  { name: 'whoami', description: 'Display your account information.' },
-  { name: 'login', description: 'Log in to the Composio SDK.' },
-  { name: 'logout', description: 'Log out from the Composio SDK.' },
-  { name: 'init', description: 'Initialize a Composio project in the current directory.' },
-  { name: 'generate', description: 'Generate type stubs for toolkits, tools, and triggers.' },
-  { name: 'py', description: 'Handle Python projects.' },
-  { name: 'ts', description: 'Handle TypeScript projects.' },
-  { name: 'toolkits', description: 'Discover and inspect Composio toolkits.' },
-  { name: 'tools', description: 'Discover and inspect Composio tools.' },
-  { name: 'auth-configs', description: 'View and manage Composio auth configs.' },
-  { name: 'connected-accounts', description: 'View and manage Composio connected accounts.' },
-  { name: 'triggers', description: 'Inspect and subscribe to trigger events.' },
-  { name: 'logs', description: 'Inspect trigger and tool execution logs.' },
-  { name: 'orgs', description: 'Manage default global organization/project context.' },
-  { name: 'projects', description: 'Manage default global project context.' },
-];
+/** Strip ANSI escape codes from a string. */
+const stripAnsi = (str: string) =>
+  str.replace(
+    /[\u001B\u009B][[\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\d/#&.:=?%@~_]+)*|[a-zA-Z\d]+(?:;[-a-zA-Z\d/#&.:=?%@~_]*)*)?\u0007)|(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PRZcf-ntqry=><~]))/g,
+    ''
+  );
+
+/** Recursively get the description HelpDoc from a command descriptor. */
+function getDescriptionFromDescriptor(descriptor: {
+  _tag?: string;
+  description?: HelpDoc.HelpDoc;
+  command?: unknown;
+  parent?: unknown;
+}): HelpDoc.HelpDoc {
+  if (descriptor._tag === 'Map' && descriptor.command) {
+    return getDescriptionFromDescriptor(descriptor.command as typeof descriptor);
+  }
+  if (descriptor._tag === 'Subcommands' && descriptor.parent) {
+    return getDescriptionFromDescriptor(descriptor.parent as typeof descriptor);
+  }
+  return descriptor.description ?? HelpDoc.empty;
+}
+
+/** CLI command type accepted by Command.getNames. */
+type CliCommand = Parameters<typeof Command.getNames>[0];
+
+/** Derive root help entries from subcommands in display order. */
+function getRootHelpEntries(
+  subcommands: ReadonlyArray<CliCommand>
+): ReadonlyArray<{ name: string; description: string }> {
+  return subcommands.map(cmd => {
+    const names = HashSet.toValues(Command.getNames(cmd));
+    const name = names[0] ?? '';
+    const helpDoc = getDescriptionFromDescriptor(
+      cmd.descriptor as Parameters<typeof getDescriptionFromDescriptor>[0]
+    );
+    const raw = HelpDoc.toAnsiText(helpDoc);
+    const description = stripAnsi(raw).trim() || '';
+    return { name, description };
+  });
+}
 
 /**
  * Prints the root-level help output in gh-style format.
- * Shows only top-level commands, not nested subcommands.
+ * Derives command list from the actual subcommand definitions (single source of truth).
  */
-export function printRootHelp(): Effect.Effect<void> {
+export function printRootHelp(subcommands: ReadonlyArray<CliCommand>): Effect.Effect<void> {
   const name = 'composio';
-  const maxNameLen = Math.max(...ROOT_COMMANDS.map(c => c.name.length), 10);
+  const entries = getRootHelpEntries(subcommands);
+  const maxNameLen = Math.max(...entries.map(c => c.name.length), 10);
 
   const lines: string[] = [
     '',
@@ -41,7 +62,7 @@ export function printRootHelp(): Effect.Effect<void> {
     `  ${name} <command> [options]`,
     '',
     bold('COMMANDS'),
-    ...ROOT_COMMANDS.map(cmd => `  ${cmd.name.padEnd(maxNameLen)}  ${cmd.description}`),
+    ...entries.map(cmd => `  ${cmd.name.padEnd(maxNameLen)}  ${cmd.description}`),
     '',
     bold('FLAGS'),
     `  -h, --help     Show help for command`,

--- a/ts/packages/cli/src/commands/root-help.ts
+++ b/ts/packages/cli/src/commands/root-help.ts
@@ -9,10 +9,14 @@ const ROOT_COMMANDS: ReadonlyArray<{ name: string; description: string }> = [
   { name: 'version', description: 'Display the current Composio CLI version.' },
   { name: 'upgrade', description: 'Upgrade your Composio CLI to the latest available version.' },
   { name: 'whoami', description: 'Display your account information.' },
-  { name: 'login', description: 'Log in to the Composio SDK.' },
-  { name: 'logout', description: 'Log out from the Composio SDK.' },
+  { name: 'login', description: 'Log in to the Composio CLI session.' },
+  { name: 'logout', description: 'Log out from the Composio CLI session.' },
   { name: 'init', description: 'Initialize a Composio project in the current directory.' },
-  { name: 'generate', description: 'Generate type stubs for toolkits, tools, and triggers.' },
+  {
+    name: 'generate',
+    description:
+      'Generate type stubs for toolkits, tools, and triggers, auto-detecting project language (TypeScript | Python)',
+  },
   { name: 'py', description: 'Handle Python projects.' },
   { name: 'ts', description: 'Handle TypeScript projects.' },
   { name: 'toolkits', description: 'Discover and inspect Composio toolkits.' },
@@ -35,7 +39,7 @@ export function printRootHelp(): Effect.Effect<void> {
 
   const lines: string[] = [
     '',
-    'A tool for managing Python and TypeScript composio.dev projects.',
+    'Connect AI agents to external tools. Link accounts, discover tools, and execute them.',
     '',
     bold('USAGE'),
     `  ${name} <command> [options]`,

--- a/ts/packages/cli/src/commands/root-help.ts
+++ b/ts/packages/cli/src/commands/root-help.ts
@@ -1,68 +1,47 @@
 import { Console, Effect } from 'effect';
-import { Command, HelpDoc } from '@effect/cli';
-import * as HashSet from 'effect/HashSet';
 import { bold } from 'src/ui/colors';
 
-/** Strip ANSI escape codes from a string. */
-const stripAnsi = (str: string) =>
-  str.replace(
-    /[\u001B\u009B][[\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\d/#&.:=?%@~_]+)*|[a-zA-Z\d]+(?:;[-a-zA-Z\d/#&.:=?%@~_]*)*)?\u0007)|(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PRZcf-ntqry=><~]))/g,
-    ''
-  );
-
-/** Recursively get the description HelpDoc from a command descriptor. */
-function getDescriptionFromDescriptor(descriptor: {
-  _tag?: string;
-  description?: HelpDoc.HelpDoc;
-  command?: unknown;
-  parent?: unknown;
-}): HelpDoc.HelpDoc {
-  if (descriptor._tag === 'Map' && descriptor.command) {
-    return getDescriptionFromDescriptor(descriptor.command as typeof descriptor);
-  }
-  if (descriptor._tag === 'Subcommands' && descriptor.parent) {
-    return getDescriptionFromDescriptor(descriptor.parent as typeof descriptor);
-  }
-  return descriptor.description ?? HelpDoc.empty;
-}
-
-/** CLI command type accepted by Command.getNames. */
-type CliCommand = Parameters<typeof Command.getNames>[0];
-
-/** Derive root help entries from subcommands in display order. */
-function getRootHelpEntries(
-  subcommands: ReadonlyArray<CliCommand>
-): ReadonlyArray<{ name: string; description: string }> {
-  return subcommands.map(cmd => {
-    const names = HashSet.toValues(Command.getNames(cmd));
-    const name = names[0] ?? '';
-    const helpDoc = getDescriptionFromDescriptor(
-      cmd.descriptor as Parameters<typeof getDescriptionFromDescriptor>[0]
-    );
-    const raw = HelpDoc.toAnsiText(helpDoc);
-    const description = stripAnsi(raw).trim() || '';
-    return { name, description };
-  });
-}
+/**
+ * Top-level commands for the root help output.
+ * Order and descriptions must match the commands in index.ts.
+ */
+const ROOT_COMMANDS: ReadonlyArray<{ name: string; description: string }> = [
+  { name: 'version', description: 'Display the current Composio CLI version.' },
+  { name: 'upgrade', description: 'Upgrade your Composio CLI to the latest available version.' },
+  { name: 'whoami', description: 'Display your account information.' },
+  { name: 'login', description: 'Log in to the Composio SDK.' },
+  { name: 'logout', description: 'Log out from the Composio SDK.' },
+  { name: 'init', description: 'Initialize a Composio project in the current directory.' },
+  { name: 'generate', description: 'Generate type stubs for toolkits, tools, and triggers.' },
+  { name: 'py', description: 'Handle Python projects.' },
+  { name: 'ts', description: 'Handle TypeScript projects.' },
+  { name: 'toolkits', description: 'Discover and inspect Composio toolkits.' },
+  { name: 'tools', description: 'Discover and inspect Composio tools.' },
+  { name: 'auth-configs', description: 'View and manage Composio auth configs.' },
+  { name: 'connected-accounts', description: 'View and manage Composio connected accounts.' },
+  { name: 'triggers', description: 'Inspect and subscribe to trigger events.' },
+  { name: 'logs', description: 'Inspect trigger and tool execution logs.' },
+  { name: 'orgs', description: 'Manage default global organization/project context.' },
+  { name: 'projects', description: 'Manage default global project context.' },
+];
 
 /**
  * Prints the root-level help output in gh-style format.
- * Derives command list from the actual subcommand definitions (single source of truth).
+ * Shows only top-level commands, not nested subcommands.
  */
-export function printRootHelp(subcommands: ReadonlyArray<CliCommand>): Effect.Effect<void> {
+export function printRootHelp(): Effect.Effect<void> {
   const name = 'composio';
-  const entries = getRootHelpEntries(subcommands);
-  const maxNameLen = Math.max(...entries.map(c => c.name.length), 10);
+  const maxNameLen = Math.max(...ROOT_COMMANDS.map(c => c.name.length), 10);
 
   const lines: string[] = [
     '',
-    'Connect AI agents to external tools. Link accounts, discover tools, and execute them.',
+    'A tool for managing Python and TypeScript composio.dev projects.',
     '',
     bold('USAGE'),
     `  ${name} <command> [options]`,
     '',
     bold('COMMANDS'),
-    ...entries.map(cmd => `  ${cmd.name.padEnd(maxNameLen)}  ${cmd.description}`),
+    ...ROOT_COMMANDS.map(cmd => `  ${cmd.name.padEnd(maxNameLen)}  ${cmd.description}`),
     '',
     bold('FLAGS'),
     `  -h, --help     Show help for command`,

--- a/ts/packages/cli/src/commands/root-help.ts
+++ b/ts/packages/cli/src/commands/root-help.ts
@@ -56,7 +56,7 @@ export function printRootHelp(subcommands: ReadonlyArray<CliCommand>): Effect.Ef
 
   const lines: string[] = [
     '',
-    'A tool for managing Python and TypeScript composio.dev projects.',
+    'Connect AI agents to external tools. Link accounts, discover tools, and execute them.',
     '',
     bold('USAGE'),
     `  ${name} <command> [options]`,

--- a/ts/packages/cli/src/services/project-environment-detector.ts
+++ b/ts/packages/cli/src/services/project-environment-detector.ts
@@ -144,6 +144,26 @@ const pickBestWeak = (candidate: DirEvidence, depth: number) => {
   } as const;
 };
 
+/** Known system paths that must not be treated as project roots for weak detection. */
+const SYSTEM_ROOTS = new Set([
+  '/',
+  '/tmp',
+  '/var',
+  '/usr',
+  '/private',
+  '/private/tmp',
+  '/private/var',
+]);
+
+/** Reject system roots (/, /tmp, /var, /private/tmp, etc.) as project roots for weak detection. */
+const isSystemRoot = (dir: string): boolean => {
+  const resolved = path.resolve(dir);
+  if (SYSTEM_ROOTS.has(resolved)) return true;
+  const parent = path.dirname(resolved);
+  if (parent === resolved) return true; // root
+  return parent === path.resolve('/'); // direct child of root, e.g. /tmp, /var, /usr
+};
+
 const parsePackageManagerField = (pm: string) =>
   Match.value(pm).pipe(
     Match.when(
@@ -416,7 +436,7 @@ const detectLanguage = (fs: FileSystem.FileSystem, cwd: string) =>
         bestWeak = weakCandidate;
     }
 
-    if (bestWeak)
+    if (bestWeak && !isSystemRoot(bestWeak.dir))
       return {
         language: bestWeak.language,
         rootDir: bestWeak.dir,

--- a/ts/packages/cli/test/src/commands/$default.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/$default.cmd.test.ts
@@ -28,7 +28,7 @@ describe('CLI: composio', () => {
       Effect.gen(function* () {
         const args = ['--help'];
         yield* cli(args);
-        const lines = yield* MockConsole.getLines();
+        const lines = yield* MockConsole.getLines({ stripAnsi: true });
         const output = lines.join('\n');
         expect(yield* sanitize(output)).toMatchSnapshot();
       })

--- a/ts/packages/cli/test/src/commands/__snapshots__/$default.cmd.test.ts.snap
+++ b/ts/packages/cli/test/src/commands/__snapshots__/$default.cmd.test.ts.snap
@@ -11,8 +11,8 @@ COMMANDS
   version             Display the current Composio CLI version.
   upgrade             Upgrade your Composio CLI to the latest available version.
   whoami              Display your account information.
-  login               Log in to the Composio SDK.
-  logout              Log out from the Composio SDK.
+  login               Log in to the Composio CLI session.
+  logout              Log out from the Composio CLI session.
   init                Initialize a Composio project in the current directory.
   generate            Generate type stubs for toolkits, tools, and triggers, auto-detecting project language (TypeScript | Python)
   py                  Handle Python projects.

--- a/ts/packages/cli/test/src/commands/__snapshots__/$default.cmd.test.ts.snap
+++ b/ts/packages/cli/test/src/commands/__snapshots__/$default.cmd.test.ts.snap
@@ -1,136 +1,37 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`CLI: composio > [Given] --help flag [Then] prints help message 1`] = `
-"[0;1m[0;37;1mcomposio[0;1m[0m
+"
+A tool for managing Python and TypeScript composio.dev projects.
 
-composio <VERSION>
+USAGE
+  composio <command> [options]
 
-[0;1mUSAGE[0m
+COMMANDS
+  version             Display the current Composio CLI version.
+  upgrade             Upgrade your Composio CLI to the latest available version.
+  whoami              Display your account information.
+  login               Log in to the Composio SDK.
+  logout              Log out from the Composio SDK.
+  init                Initialize a Composio project in the current directory.
+  generate            Generate type stubs for toolkits, tools, and triggers.
+  py                  Handle Python projects.
+  ts                  Handle TypeScript projects.
+  toolkits            Discover and inspect Composio toolkits.
+  tools               Discover and inspect Composio tools.
+  auth-configs        View and manage Composio auth configs.
+  connected-accounts  View and manage Composio connected accounts.
+  triggers            Inspect and subscribe to trigger events.
+  logs                Inspect trigger and tool execution logs.
+  orgs                Manage default global organization/project context.
+  projects            Manage default global project context.
 
-$ composio [--log-level all | trace | debug | info | warning | error | fatal | none]
+FLAGS
+  -h, --help     Show help for command
+  --version      Show composio version
 
-[0;1mDESCRIPTION[0m
-
-Composio CLI - A tool for managing Python and TypeScript composio.dev projects.
-
-[0;1mOPTIONS[0m
-
-[0;1m--log-level all | trace | debug | info | warning | error | fatal | none[0m
-
-  One of the following: all, trace, debug, info, warning, error, fatal, none
-
-  Define log level
-
-  This setting is optional.
-
-[0;1mCOMMANDS[0m
-
-  - version                                                                                                                                                                                                                                                                                                  Display the current Composio CLI version.
-
-  - upgrade                                                                                                                                                                                                                                                                                                  Upgrade your Composio CLI to the latest available version.
-
-  - whoami                                                                                                                                                                                                                                                                                                   Display your account information.
-
-  - login [--no-browser] [--api-key text] [--org-id text] [--project-id text]                                                                                                                                                                                                                                Log in to the Composio SDK.
-
-  - logout                                                                                                                                                                                                                                                                                                   Log out from the Composio SDK.
-
-  - init [--org-id text] [--project-id text] [--no-browser] [(-y, --yes)]                                                                                                                                                                                                                                    Initialize a Composio project in the current directory.
-
-  - generate [(-o, --output-dir directory)] [--type-tools] --toolkits text...                                                                                                                                                                                                                                Generate type stubs for toolkits, tools, and triggers, auto-detecting project language (TypeScript | Python)
-
-  - py                                                                                                                                                                                                                                                                                                       Handle Python projects.
-
-  - py generate [(-o, --output-dir directory)] --toolkits text...                                                                                                                                                                                                                                            Generate Python type stubs for toolkits, tools, and triggers from the Composio API.
-
-Environment Variables:
-  COMPOSIO_TOOLKIT_VERSION_<TOOLKIT>  Override toolkit version (e.g., COMPOSIO_TOOLKIT_VERSION_GMAIL=20250901_00)
-                                      Use "latest" or unset to use the latest version.
-
-  - ts                                                                                                                                                                                                                                                                                                       Handle TypeScript projects.
-
-  - ts generate [(-o, --output-dir directory)] [--compact] [--transpiled] [--type-tools] --toolkits text...                                                                                                                                                                                                  Generate TypeScript types for toolkits, tools, and triggers from the Composio API.
-
-Environment Variables:
-  COMPOSIO_TOOLKIT_VERSION_<TOOLKIT>  Override toolkit version (e.g., COMPOSIO_TOOLKIT_VERSION_GMAIL=20250901_00)
-                                      Use "latest" or unset to use the latest version.
-
-  - toolkits                                                                                                                                                                                                                                                                                                 Discover and inspect Composio toolkits.
-
-  - toolkits list [--query text] [--limit integer] [--connected] [--user-id text]                                                                                                                                                                                                                            List available toolkits with connection status.
-
-  - toolkits info [--user-id text] [(-a, --all)] [<slug>]                                                                                                                                                                                                                                                    View details of a specific toolkit.
-
-  - toolkits search [--limit integer] <query>                                                                                                                                                                                                                                                                Search toolkits by use case.
-
-  - toolkits version <slug>                                                                                                                                                                                                                                                                                  Show latest and recent versions for a toolkit.
-
-  - tools                                                                                                                                                                                                                                                                                                    Discover and inspect Composio tools.
-
-  - tools list [--query text] [--toolkits text] [--tags text] [--limit integer]                                                                                                                                                                                                                              List available tools.
-
-  - tools info [<slug>]                                                                                                                                                                                                                                                                                      View details of a specific tool.
-
-  - tools search [--toolkits text] [--limit integer] <query>                                                                                                                                                                                                                                                 Semantically search tools by use case; returns best-fit tools plus recommended usage guidance.
-
-  - tools execute [(-d, --data text)] [--user-id text] <slug>                                                                                                                                                                                                                                                Execute a tool by slug with JSON arguments.
-
-  - auth-configs                                                                                                                                                                                                                                                                                             View and manage Composio auth configs.
-
-  - auth-configs list [--toolkits text] [--query text] [--limit integer]                                                                                                                                                                                                                                     List auth configs.
-
-  - auth-configs info [<id>]                                                                                                                                                                                                                                                                                 View details of a specific auth config.
-
-  - auth-configs create --toolkit text [--auth-scheme text] [--scopes text] [--custom-credentials text] [<name>]                                                                                                                                                                                             Create a new auth config.
-
-  - auth-configs delete [(-y, --yes)] [<id>]                                                                                                                                                                                                                                                                 Delete an auth config.
-
-  - connected-accounts                                                                                                                                                                                                                                                                                       View and manage Composio connected accounts.
-
-  - connected-accounts list [--toolkits text] [--user-id text] [--status INITIALIZING | INITIATED | ACTIVE | FAILED | EXPIRED | INACTIVE] [--limit integer]                                                                                                                                                  List connected accounts.
-
-  - connected-accounts info [<id>]                                                                                                                                                                                                                                                                           View details of a specific connected account.
-
-  - connected-accounts whoami [<id>]                                                                                                                                                                                                                                                                         Show the external account profile for a connected account.
-
-  - connected-accounts delete [(-y, --yes)] [<id>]                                                                                                                                                                                                                                                           Delete a connected account.
-
-  - connected-accounts link [--auth-config text] [--user-id text] [--no-browser] [<toolkit>]                                                                                                                                                                                                                 Link an external account via OAuth redirect.
-
-  - triggers                                                                                                                                                                                                                                                                                                 Inspect and subscribe to trigger events.
-
-  - triggers list [--toolkits text] [--limit integer]                                                                                                                                                                                                                                                        List available trigger types.
-
-  - triggers info [<slug>]                                                                                                                                                                                                                                                                                   View details of a specific trigger type.
-
-  - triggers listen [--toolkits text] [--trigger-id text] [--connected-account-id text] [--trigger-slug text] [--user-id text] [--json] [--table] [--max-events integer] [--forward text] [--out text]                                                                                                       Listen to realtime trigger events for your project.
-
-  - triggers status [--user-ids text] [--connected-account-ids text] [--toolkits text] [--trigger-ids text] [--trigger-names text] [--show-disabled] [--limit integer]                                                                                                                                       Show active triggers with optional filters.
-
-  - triggers create [--connected-account-id text] [--trigger-config text] [<trigger-name>]                                                                                                                                                                                                                   Create a new trigger instance.
-
-  - triggers enable [<id>]                                                                                                                                                                                                                                                                                   Enable a trigger instance.
-
-  - triggers disable [<id>]                                                                                                                                                                                                                                                                                  Disable a trigger instance.
-
-  - triggers delete [(-y, --yes)] [<id>]                                                                                                                                                                                                                                                                     Delete a trigger instance.
-
-  - logs                                                                                                                                                                                                                                                                                                     Inspect trigger and tool execution logs.
-
-  - logs triggers [--cursor text] [--user-id text] [--connected-account-id text] [--trigger text] [--trigger-id text] [--log-id text] [--from integer] [--to integer] [--limit integer] [--time 5m | 30m | 6h | 1d | 1w | 1month | 1y] [--search text] [--include-payload] [<log_id>]                        List trigger logs.
-
-  - logs tools [--cursor integer] [--from integer] [--to integer] [--limit integer] [--case-sensitive] [--toolkit text] [--tool text] [--connected-account-id text] [--auth-config-id text] [--status text] [--user-id text] [--log-id text] [--tool-router-session-id text] [--session-id text] [<log_id>]  List tool execution logs, or pass a log_id to fetch a specific log.
-
-  - orgs                                                                                                                                                                                                                                                                                                     Manage default global organization/project context.
-
-  - orgs list [--limit integer]                                                                                                                                                                                                                                                                              List organizations and show current global selection.
-
-  - orgs switch [--org-id text] [--project-id text] [--limit integer]                                                                                                                                                                                                                                        Switch default global organization/project context.
-
-  - projects                                                                                                                                                                                                                                                                                                 Manage default global project context.
-
-  - projects list [--org-id text] [--limit integer]                                                                                                                                                                                                                                                          List projects and show current global selection.
-
-  - projects switch [--org-id text] [--project-id text] [--limit integer]                                                                                                                                                                                                                                    Switch default global project context.
+LEARN MORE
+  Use \`composio <command> --help\` for more information about a command.
+  Documentation: https://docs.composio.dev
 "
 `;

--- a/ts/packages/cli/test/src/commands/__snapshots__/$default.cmd.test.ts.snap
+++ b/ts/packages/cli/test/src/commands/__snapshots__/$default.cmd.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`CLI: composio > [Given] --help flag [Then] prints help message 1`] = `
 "
-A tool for managing Python and TypeScript composio.dev projects.
+Connect AI agents to external tools. Link accounts, discover tools, and execute them.
 
 USAGE
   composio <command> [options]

--- a/ts/packages/cli/test/src/commands/__snapshots__/$default.cmd.test.ts.snap
+++ b/ts/packages/cli/test/src/commands/__snapshots__/$default.cmd.test.ts.snap
@@ -14,7 +14,7 @@ COMMANDS
   login               Log in to the Composio SDK.
   logout              Log out from the Composio SDK.
   init                Initialize a Composio project in the current directory.
-  generate            Generate type stubs for toolkits, tools, and triggers.
+  generate            Generate type stubs for toolkits, tools, and triggers, auto-detecting project language (TypeScript | Python)
   py                  Handle Python projects.
   ts                  Handle TypeScript projects.
   toolkits            Discover and inspect Composio toolkits.

--- a/ts/packages/cli/test/src/services/project-environment-detector.test.ts
+++ b/ts/packages/cli/test/src/services/project-environment-detector.test.ts
@@ -251,10 +251,13 @@ describe('ProjectEnvironmentDetector', () => {
     layer(testLayer)('Edge cases', it => {
       it.scoped('[Given] empty directory [Then] fails with no-detection error', () =>
         Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
           const detector = yield* ProjectEnvironmentDetector;
-          const cwd = tempy.temporaryDirectory();
+          const tempRoot = tempy.temporaryDirectory();
+          const emptyDir = path.join(tempRoot, 'a', 'b', 'c');
+          yield* fs.makeDirectory(emptyDir, { recursive: true });
 
-          const result = yield* detector.detectProjectEnvironment(cwd).pipe(Effect.either);
+          const result = yield* detector.detectProjectEnvironment(emptyDir).pipe(Effect.either);
 
           assert(Either.isLeft(result));
           expect(result.left.message).toContain('No recognizable');


### PR DESCRIPTION
## Summary

- **Compact root help**: Add `root-help.ts` for gh-style top-level command list when running `composio --help`
- **Project environment detector fix**: Add `isSystemRoot` to reject `/tmp`, `/private/tmp` (macOS temp symlink) as project roots for weak detection — fixes flaky empty dir test when run via turbo from repo root
- **Empty dir test**: Use tempy with nested a/b/c subdirs; test now passes in all environments (CI, local, turbo)
- **Snapshot**: Update `$default.cmd` snapshot for new help format

Made with [Cursor](https://cursor.com)