### PR TITLE
docs: add click-to-expand zoom to Mermaid diagrams

### DIFF
--- a/docs/components/mermaid.tsx
+++ b/docs/components/mermaid.tsx
@@ -2,15 +2,20 @@
 
 import { useEffect, useRef, useState } from 'react';
 import mermaid from 'mermaid';
+import Zoom from 'react-medium-image-zoom';
+import 'react-medium-image-zoom/dist/styles.css';
 
 function getCssVar(name: string): string {
   return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
 }
 
+function svgToDataUrl(svg: string): string {
+  return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+}
+
 export function Mermaid({ chart }: { chart: string }) {
   const renderCount = useRef(0);
   const baseId = useRef(`mermaid-${Math.random().toString(36).slice(2, 9)}`);
-  const containerRef = useRef<HTMLDivElement>(null);
   const [svg, setSvg] = useState('');
 
   useEffect(() => {
@@ -60,11 +65,17 @@ export function Mermaid({ chart }: { chart: string }) {
     return () => observer.disconnect();
   }, [chart]);
 
+  if (!svg) return null;
+
   return (
-    <div
-      ref={containerRef}
-      className="my-4 overflow-x-auto max-w-full mx-auto [&>svg]:mx-auto"
-      dangerouslySetInnerHTML={{ __html: svg }}
-    />
+    <div className="my-4 max-w-full mx-auto">
+      <Zoom>
+        <img
+          src={svgToDataUrl(svg)}
+          alt="Mermaid diagram"
+          className="mx-auto"
+        />
+      </Zoom>
+    </div>
   );
 }

--- a/docs/components/mermaid.tsx
+++ b/docs/components/mermaid.tsx
@@ -1,21 +1,32 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react';
 import mermaid from 'mermaid';
 import Zoom from 'react-medium-image-zoom';
 import 'react-medium-image-zoom/dist/styles.css';
+
+const MOBILE_BREAKPOINT = 768;
+
+function useIsMobile() {
+  return useSyncExternalStore(
+    (cb) => {
+      const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+      mql.addEventListener('change', cb);
+      return () => mql.removeEventListener('change', cb);
+    },
+    () => window.innerWidth < MOBILE_BREAKPOINT,
+    () => false,
+  );
+}
 
 function getCssVar(name: string): string {
   return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
 }
 
-function svgToDataUrl(svg: string): string {
-  return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
-}
-
 export function Mermaid({ chart }: { chart: string }) {
   const renderCount = useRef(0);
   const baseId = useRef(`mermaid-${Math.random().toString(36).slice(2, 9)}`);
+  const containerRef = useRef<HTMLDivElement>(null);
   const [svg, setSvg] = useState('');
 
   useEffect(() => {
@@ -65,17 +76,19 @@ export function Mermaid({ chart }: { chart: string }) {
     return () => observer.disconnect();
   }, [chart]);
 
+  const isMobile = useIsMobile();
+
   if (!svg) return null;
 
-  return (
-    <div className="my-4 max-w-full mx-auto">
-      <Zoom>
-        <img
-          src={svgToDataUrl(svg)}
-          alt="Mermaid diagram"
-          className="mx-auto"
-        />
-      </Zoom>
-    </div>
+  const diagram = (
+    <div
+      ref={containerRef}
+      className="my-4 overflow-x-auto max-w-full mx-auto [&>svg]:mx-auto"
+      dangerouslySetInnerHTML={{ __html: svg }}
+    />
   );
+
+  if (isMobile) return diagram;
+
+  return <Zoom wrapElement="div">{diagram}</Zoom>;
 }

--- a/docs/lib/source.ts
+++ b/docs/lib/source.ts
@@ -397,7 +397,27 @@ ${page.data.description || ''}`;
 ${page.data.description || ''}`;
   }
 
-  const cleanContent = mdxToCleanMarkdown(content);
+  // Split content at Mermaid tags, process each segment separately, then rejoin
+  // with mermaid code blocks. This prevents JSX regexes with [\s\S]*? from
+  // matching across mermaid boundaries and consuming diagram content.
+  const mermaidRegex = /<Mermaid\s+chart="([\s\S]*?)"\s*\/>/g;
+  const segments: string[] = [];
+  const mermaidCharts: string[] = [];
+  let lastIndex = 0;
+  let match;
+
+  while ((match = mermaidRegex.exec(content)) !== null) {
+    segments.push(content.slice(lastIndex, match.index));
+    mermaidCharts.push(match[1]);
+    lastIndex = match.index + match[0].length;
+  }
+  segments.push(content.slice(lastIndex));
+
+  const cleanSegments = segments.map(s => mdxToCleanMarkdown(s));
+  let cleanContent = cleanSegments[0];
+  for (let i = 0; i < mermaidCharts.length; i++) {
+    cleanContent += `\n\n\`\`\`mermaid\n${mermaidCharts[i]}\n\`\`\`\n\n${cleanSegments[i + 1]}`;
+  }
 
   const footer = includeFooter
     ? `\n\n---\n\n📚 **More documentation:** [View all docs](https://docs.composio.dev/llms.txt) | [Glossary](https://docs.composio.dev/llms.mdx/docs/glossary) | [Cookbooks](https://docs.composio.dev/llms.mdx/cookbooks) | [API Reference](https://docs.composio.dev/llms.mdx/reference)`

--- a/docs/lib/source.ts
+++ b/docs/lib/source.ts
@@ -416,7 +416,9 @@ ${page.data.description || ''}`;
   const cleanSegments = segments.map(s => mdxToCleanMarkdown(s));
   let cleanContent = cleanSegments[0];
   for (let i = 0; i < mermaidCharts.length; i++) {
-    cleanContent += `\n\n\`\`\`mermaid\n${mermaidCharts[i]}\n\`\`\`\n\n${cleanSegments[i + 1]}`;
+    // Decode HTML entities that fumadocs encodes in JSX attributes
+    const chart = mermaidCharts[i].replace(/&#x22;/g, '"').replace(/&#x27;/g, "'").replace(/&amp;/g, '&');
+    cleanContent += `\n\n\`\`\`mermaid\n${chart}\n\`\`\`\n\n${cleanSegments[i + 1]}`;
   }
 
   const footer = includeFooter


### PR DESCRIPTION
## Summary
- Wraps Mermaid diagram output with `react-medium-image-zoom` (`<Zoom wrapElement="div">`) so users can click any diagram to expand it full-screen
- Disables zoom on mobile (below 768px) where pinch-to-zoom works natively
- Defers Zoom mount until SVG is rendered to fix first-load dimension detection
- Preserves mermaid diagrams as fenced code blocks in the LLM markdown output (`/llms.mdx/`, `/llms-full.txt`)
- Decodes HTML entities (`&#x22;` -> `"`) in mermaid chart output for clean LLM consumption

## Implementation notes
- Uses inline SVG (not data URL `<img>`) to preserve text selection, font inheritance, and CSS variable theming
- Splits content at `<Mermaid>` tag boundaries before running `mdxToCleanMarkdown` to prevent greedy `[\s\S]*?` Card regexes from consuming diagram content

## Test plan
- [ ] Visit pages with Mermaid diagrams (`/docs/how-composio-works`, `/docs/authentication`, `/docs/projects`, `/docs/workbench`)
- [ ] Click a diagram on desktop — should expand with smooth zoom animation
- [ ] Click outside or press Escape to close
- [ ] Test in both light and dark mode
- [ ] Test on mobile — zoom should be disabled, diagrams scroll normally
- [ ] Check `/llms.mdx/docs/authentication` — mermaid code block should be present with clean labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)