### PR TITLE
docs: changelog for MCP API key default on new orgs

### DIFF
--- a/docs/content/changelog/03-04-26-mcp-api-key-default-new-orgs.mdx
+++ b/docs/content/changelog/03-04-26-mcp-api-key-default-new-orgs.mdx
@@ -4,11 +4,11 @@ description: "Organizations created on or after March 5, 2026 will have require_
 date: "2026-03-04"
 ---
 
-As announced in our [Optional API Key Enforcement for MCP Servers](/docs/changelog/2026/01/08) changelog, **MCP API key enforcement is now enabled by default for all newly created organizations**.
+As announced in our [Optional API Key Enforcement for MCP Servers](/docs/changelog/2026/01/08) entry, **MCP API key enforcement is now enabled by default for all newly created organizations**.
 
 ### What's Changed
 
-Starting **March 5, 2026**, every new organization created on Composio will automatically have `require_mcp_api_key` set to `true` for all new projects. This means MCP server requests must include a valid API key in the `x-api-key` header.
+From **March 5, 2026**, all projects in newly created organizations will have `require_mcp_api_key` set to `true` by default. Any MCP server request without a valid `x-api-key` header will be rejected with `401 Unauthorized`.
 
 | Setting | Previous Default | New Default (orgs created March 5+) |
 |---------|-----------------|--------------------------------------|
@@ -16,9 +16,7 @@ Starting **March 5, 2026**, every new organization created on Composio will auto
 
 ### For New Organizations
 
-- All new projects require API key authentication for MCP server requests out of the box
-- Requests without a valid `x-api-key` header receive `401 Unauthorized`
-- You can opt out by explicitly setting `require_mcp_api_key: false` in your project configuration
+- You can opt out by setting `require_mcp_api_key: false` in your project configuration
 
 ### For Existing Organizations
 
@@ -29,7 +27,7 @@ Nothing changes for existing organizations. If your organization was created bef
 
 ### Opting Out (New Organizations)
 
-If you need to disable API key enforcement for a new project, you can set it explicitly during project creation or update the setting afterward:
+If you need to disable API key enforcement, set `require_mcp_api_key: false` during project creation or update it afterward:
 
 ```bash
 curl -X PATCH https://backend.composio.dev/api/v3/org/project/config \

--- a/docs/content/changelog/03-04-26-mcp-api-key-default-new-orgs.mdx
+++ b/docs/content/changelog/03-04-26-mcp-api-key-default-new-orgs.mdx
@@ -1,5 +1,5 @@
 ---
-title: "MCP API Key Enforcement Now Default for New Organizations"
+title: "MCP API Key Authentication Enabled by Default for New Orgs"
 description: "Organizations created on or after March 5, 2026 will have require_mcp_api_key enabled by default"
 date: "2026-03-04"
 ---
@@ -31,11 +31,11 @@ Nothing changes for existing organizations. If your organization was created bef
 
 If you need to disable API key enforcement for a new project, you can set it explicitly during project creation or update the setting afterward:
 
-```http
-PATCH /api/v3/org/project/config
-Content-Type: application/json
-
-{"require_mcp_api_key": false}
+```bash
+curl -X PATCH https://backend.composio.dev/api/v3/org/project/config \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: YOUR_API_KEY" \
+  -d '{"require_mcp_api_key": false}'
 ```
 
 <Callout type="info">

--- a/docs/content/changelog/03-04-26-mcp-api-key-default-new-orgs.mdx
+++ b/docs/content/changelog/03-04-26-mcp-api-key-default-new-orgs.mdx
@@ -1,0 +1,43 @@
+---
+title: "MCP API Key Enforcement Now Default for New Organizations"
+description: "Organizations created on or after March 5, 2026 will have require_mcp_api_key enabled by default"
+date: "2026-03-04"
+---
+
+As announced in our [Optional API Key Enforcement for MCP Servers](/docs/changelog/2026/01/08) changelog, **MCP API key enforcement is now enabled by default for all newly created organizations**.
+
+### What's Changed
+
+Starting **March 5, 2026**, every new organization created on Composio will automatically have `require_mcp_api_key` set to `true` for all new projects. This means MCP server requests must include a valid API key in the `x-api-key` header.
+
+| Setting | Previous Default | New Default (orgs created March 5+) |
+|---------|-----------------|--------------------------------------|
+| `require_mcp_api_key` | `false` | `true` |
+
+### For New Organizations
+
+- All new projects require API key authentication for MCP server requests out of the box
+- Requests without a valid `x-api-key` header receive `401 Unauthorized`
+- You can opt out by explicitly setting `require_mcp_api_key: false` in your project configuration
+
+### For Existing Organizations
+
+Nothing changes for existing organizations. If your organization was created before March 5, 2026:
+
+- Your current `require_mcp_api_key` setting remains unchanged
+- You can opt in at any time through your [project settings](https://platform.composio.dev) or via the API
+
+### Opting Out (New Organizations)
+
+If you need to disable API key enforcement for a new project, you can set it explicitly during project creation or update the setting afterward:
+
+```bash
+curl -X PATCH "https://backend.composio.dev/api/v3/org/project/config" \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: ak_your_api_key" \
+  -d '{"require_mcp_api_key": false}'
+```
+
+<Callout type="info">
+We strongly recommend keeping MCP API key enforcement enabled to prevent unauthorized access to your MCP servers. See the [original announcement](/docs/changelog/2026/01/08) for setup details and usage examples.
+</Callout>

--- a/docs/content/changelog/03-04-26-mcp-api-key-default-new-orgs.mdx
+++ b/docs/content/changelog/03-04-26-mcp-api-key-default-new-orgs.mdx
@@ -31,11 +31,11 @@ Nothing changes for existing organizations. If your organization was created bef
 
 If you need to disable API key enforcement for a new project, you can set it explicitly during project creation or update the setting afterward:
 
-```bash
-curl -X PATCH "https://backend.composio.dev/api/v3/org/project/config" \
-  -H "Content-Type: application/json" \
-  -H "x-api-key: ak_your_api_key" \
-  -d '{"require_mcp_api_key": false}'
+```http
+PATCH /api/v3/org/project/config
+Content-Type: application/json
+
+{"require_mcp_api_key": false}
 ```
 
 <Callout type="info">


### PR DESCRIPTION
# Description

Adds a changelog entry announcing that `require_mcp_api_key` is now enabled by default for organizations created on or after March 5, 2026.

Links back to the [Jan 8 opt-in announcement](https://docs.composio.dev/docs/changelog/2026/01/08) as referenced context.

Related backend PR: https://github.com/ComposioHQ/hermes/pull/8294

# How did I test this PR

- Verified MDX frontmatter follows changelog conventions (title, date in YYYY-MM-DD format)
- No `#` heading in body, sections use `###`
- No emojis

🤖 Generated with [Claude Code](https://claude.com/claude-code)