### PR TITLE
docs: add long_redirect_url to white-labeling, improve redirect headings

### DIFF
--- a/docs/content/docs/auth-configuration/white-labeling.mdx
+++ b/docs/content/docs/auth-configuration/white-labeling.mdx
@@ -9,13 +9,14 @@ llmGuardrails: "direct-execution"
 If you're building an agent with sessions, see [White-labeling authentication](/docs/white-labeling-authentication) instead.
 </Callout>
 
-There are three places where Composio branding shows up during authentication:
+There are four places where Composio branding shows up during authentication:
 
 | Where | What users see | How to fix |
 |-------|---------------|------------|
 | [**Connect Link page**](#customizing-the-connect-link) | Composio logo and name on the hosted auth page | Change logo + app title in dashboard |
 | [**OAuth consent screen**](#using-your-own-oauth-apps) | "Composio wants to access your account" on Google, GitHub, etc. | Use your own OAuth app |
-| [**Browser address bar**](#custom-redirect-domain) | `backend.composio.dev` flashes during OAuth redirect | Proxy the redirect through your domain |
+| [**Outgoing redirect**](#sending-users-directly-to-the-oauth-provider) | `backend.composio.dev` in browser before reaching OAuth provider | Use `long_redirect_url` option |
+| [**Return redirect**](#routing-the-callback-through-your-domain) | `backend.composio.dev` flashes when OAuth provider redirects back | Proxy the redirect through your domain |
 
 ## Customizing the Connect Link
 
@@ -126,11 +127,57 @@ For toolkits you haven't white-labeled, use the auth config ID from **Authentica
 
 For development and testing, Composio's managed auth works fine. No OAuth app setup required.
 
-## Custom redirect domain
+## Sending users directly to the OAuth provider
 
-During OAuth, the browser briefly redirects through `backend.composio.dev` so Composio can capture the auth token. Some toolkits also display this URL on the consent screen.
+By default, when you initiate a connection, Composio returns a shortened redirect URL (`backend.composio.dev/api/v3/s/...`). The user's browser hits this URL first, then gets redirected to the OAuth provider. This means `backend.composio.dev` briefly appears in the browser.
 
-If you need to hide Composio's domain, you can proxy the redirect through your own domain instead.
+To skip this and send users directly to the OAuth provider, pass `long_redirect_url: true` when initiating the connection:
+
+<Tabs groupId="language" items={['Python', 'TypeScript']} persist>
+<Tab value="Python">
+```python
+from composio import Composio
+
+composio = Composio(api_key="your_api_key")
+
+github_conn = composio.connected_accounts.initiate(
+    user_id="user_123",
+    auth_config_id="ac_your_github_config",
+    config={
+        "auth_scheme": "OAUTH2",
+        "val": {"status": "INITIALIZING", "long_redirect_url": True},
+    },
+)
+print(f"Redirect to: {github_conn.redirect_url}")
+```
+</Tab>
+<Tab value="TypeScript">
+```typescript
+import { Composio } from '@composio/core';
+const composio = new Composio({ apiKey: 'your_api_key' });
+// ---cut---
+const githubConn = await composio.connectedAccounts.initiate(
+  "user_123",
+  "ac_your_github_config",
+  {
+    config: {
+      authScheme: "OAUTH2",
+      val: { status: "INITIALIZING", long_redirect_url: true },
+    },
+  },
+);
+console.log("Redirect to:", githubConn.redirectUrl);
+```
+</Tab>
+</Tabs>
+
+The redirect URL returned will point directly to the OAuth provider (e.g., `accounts.google.com/o/oauth2/auth?...`) instead of going through Composio first.
+
+## Routing the callback through your domain
+
+After the user authorizes, the OAuth provider redirects back through `backend.composio.dev` so Composio can capture the auth token. Some toolkits also display this URL on the consent screen.
+
+If you need to hide Composio's domain from this return redirect, you can proxy it through your own domain.
 
 <Steps>
 <Step>

--- a/docs/content/docs/auth-configuration/white-labeling.mdx
+++ b/docs/content/docs/auth-configuration/white-labeling.mdx
@@ -162,6 +162,7 @@ const githubConn = await composio.connectedAccounts.initiate(
   {
     config: {
       authScheme: "OAUTH2",
+      // val fields use snake_case — they're sent to the API as-is
       val: { status: "INITIALIZING", long_redirect_url: true },
     },
   },

--- a/docs/content/docs/auth-configuration/white-labeling.mdx
+++ b/docs/content/docs/auth-configuration/white-labeling.mdx
@@ -127,6 +127,14 @@ For toolkits you haven't white-labeled, use the auth config ID from **Authentica
 
 For development and testing, Composio's managed auth works fine. No OAuth app setup required.
 
+### Switching from Composio-managed to your own OAuth app
+
+Existing connected accounts are permanently tied to the auth config they were created with. Switching to a custom auth config does not affect them.
+
+- Existing connections keep working. Tokens continue refreshing using the original auth config's credentials.
+- New connections use your custom auth config. Users who connect after the switch will see your app name on the consent screen.
+- To fully migrate a user, delete their old connected account and have them re-authenticate through your OAuth app.
+
 ## Sending users directly to the OAuth provider
 
 By default, when you initiate a connection, Composio returns a shortened redirect URL (`backend.composio.dev/api/v3/s/...`). The user's browser hits this URL first, then gets redirected to the OAuth provider. This means `backend.composio.dev` briefly appears in the browser.

--- a/docs/content/docs/common-faq.mdx
+++ b/docs/content/docs/common-faq.mdx
@@ -207,6 +207,18 @@ Create a new session when the config changes: different toolkits, different auth
 Some toolkits require your own OAuth credentials or API keys. Create an auth config in the dashboard by selecting the toolkit, choosing the auth scheme, and entering your credentials. Then pass the auth config ID when creating a session using the `auth_configs` (or `auth_config_id`) parameter so the session uses your developer credentials instead of Composio-managed auth. See [Using custom auth configuration](/docs/using-custom-auth-configuration).
 </Accordion>
 
+<Accordion title="What happens to existing connections when I switch to my own OAuth app?">
+Nothing — existing connected accounts are permanently tied to the auth config they were created with. Switching to a custom auth config only affects new connections.
+
+- **Existing connections keep working.** Tokens continue refreshing using the original auth config's credentials.
+- **New connections use your custom auth config.** Users who connect after the switch see your app name on the consent screen.
+- **To fully migrate a user**, delete their old connected account and have them re-authenticate through your OAuth app. There is no way to move an existing connection between auth configs without re-authentication.
+
+This applies whether you're using sessions or direct tool execution:
+- **Sessions:** Pass `authConfigs` when calling `composio.create()`. See [Switching auth configs (sessions)](/docs/white-labeling-authentication#switching-from-composio-managed-to-your-own-oauth-app).
+- **Direct tool execution:** Pass the new `authConfigId` when calling `initiate()`. See [Switching auth configs (direct)](/docs/auth-configuration/white-labeling#switching-from-composio-managed-to-your-own-oauth-app).
+</Accordion>
+
 <Accordion title="How do I check complete logs / API calls from the SDK?">
 Enable debug logging to view all API calls and network requests made by the SDK.
 

--- a/docs/content/docs/troubleshooting/authentication.mdx
+++ b/docs/content/docs/troubleshooting/authentication.mdx
@@ -20,6 +20,13 @@ Ensure your OAuth app is configured correctly:
 
 For setup guides by toolkit: [OAuth Configuration Guides](https://composio.dev/oauth)
 
+## Switching to a custom OAuth app
+
+If you're moving from Composio-managed auth to your own OAuth app, existing connections are not affected. New connections will use your custom auth config. To fully migrate users, delete their old connected accounts and have them re-authenticate.
+
+- **Sessions:** Pass `authConfigs` when calling `composio.create()`. See [Switching auth configs (sessions)](/docs/white-labeling-authentication#switching-from-composio-managed-to-your-own-oauth-app).
+- **Direct tool execution:** Pass the new `authConfigId` when calling `initiate()`. See [Switching auth configs (direct)](/docs/auth-configuration/white-labeling#switching-from-composio-managed-to-your-own-oauth-app).
+
 ## Common authentication issues
 
 - **Invalid redirect URI**: Check the callback URL matches exactly

--- a/docs/content/docs/white-labeling-authentication.mdx
+++ b/docs/content/docs/white-labeling-authentication.mdx
@@ -156,7 +156,7 @@ const session = await composio.create("user_123", {
 </Tabs>
 
 <Callout type="warn">
-Existing users' connections continue using Composio's OAuth client credentials for token refresh until they re-authenticate. Composio does not see or store the user's data.
+Existing users' connections continue using Composio's OAuth client credentials for token refresh until they re-authenticate.
 </Callout>
 
 **Fully migrate all users.** To move every user to your OAuth app, delete their old connected accounts and have them re-authenticate. There is no way to move an existing connection from one auth config to another without re-authentication.

--- a/docs/content/docs/white-labeling-authentication.mdx
+++ b/docs/content/docs/white-labeling-authentication.mdx
@@ -120,6 +120,45 @@ Now when users connect GitHub or Slack, they'll see your app name on the consent
 
 For development and testing, Composio's managed auth works fine. No OAuth app setup required.
 
+### Switching from Composio-managed to your own OAuth app
+
+Existing connected accounts are permanently tied to the auth config they were created with. Switching to a custom auth config does not affect them. You have two options:
+
+**Keep existing users as-is.** Just pass `authConfigs` for the toolkits you want to white-label. Users who already have a connection keep using it. Users who need to connect for the first time go through your OAuth app:
+
+<Tabs groupId="language" items={['Python', 'TypeScript']} persist>
+<Tab value="Python">
+```python
+session = composio.create(
+    user_id="user_123",
+    auth_configs={
+        "github": "ac_your_github_config",  # new connections use your OAuth app
+    },
+)
+# Existing GitHub connections for this user keep working as before.
+# Only new connections go through your custom OAuth app.
+```
+</Tab>
+<Tab value="TypeScript">
+```typescript
+import { Composio } from '@composio/core';
+const composio = new Composio({ apiKey: 'your_api_key' });
+// ---cut---
+const session = await composio.create("user_123", {
+  authConfigs: {
+    github: "ac_your_github_config",  // new connections use your OAuth app
+  },
+});
+// Existing GitHub connections for this user keep working as before.
+// Only new connections go through your custom OAuth app.
+```
+</Tab>
+</Tabs>
+
+Existing users' connections continue using Composio's OAuth client credentials for token refresh until they re-authenticate. Composio does not see or store the user's data.
+
+**Fully migrate all users.** To move every user to your OAuth app, delete their old connected accounts and have them re-authenticate. There is no way to move an existing connection from one auth config to another without re-authentication.
+
 ## Routing the callback through your domain
 
 During OAuth, the browser briefly redirects through `backend.composio.dev` so Composio can capture the auth token. Some toolkits also display this URL on the consent screen.

--- a/docs/content/docs/white-labeling-authentication.mdx
+++ b/docs/content/docs/white-labeling-authentication.mdx
@@ -155,7 +155,9 @@ const session = await composio.create("user_123", {
 </Tab>
 </Tabs>
 
+<Callout type="warn">
 Existing users' connections continue using Composio's OAuth client credentials for token refresh until they re-authenticate. Composio does not see or store the user's data.
+</Callout>
 
 **Fully migrate all users.** To move every user to your OAuth app, delete their old connected accounts and have them re-authenticate. There is no way to move an existing connection from one auth config to another without re-authentication.
 

--- a/docs/content/docs/white-labeling-authentication.mdx
+++ b/docs/content/docs/white-labeling-authentication.mdx
@@ -10,7 +10,7 @@ There are three places where Composio branding shows up during authentication:
 |-------|---------------|------------|
 | [**Connect Link page**](#customizing-the-connect-link) | Composio logo and name on the hosted auth page | Change logo + app title in dashboard |
 | [**OAuth consent screen**](#using-your-own-oauth-apps) | "Composio wants to access your account" on Google, GitHub, etc. | Use your own OAuth app |
-| [**Browser address bar**](#custom-redirect-domain) | `backend.composio.dev` flashes during OAuth redirect | Proxy the redirect through your domain |
+| [**Browser address bar**](#routing-the-callback-through-your-domain) | `backend.composio.dev` flashes during OAuth redirect-back | Proxy the redirect through your domain |
 
 ## Customizing the Connect Link
 
@@ -120,7 +120,7 @@ Now when users connect GitHub or Slack, they'll see your app name on the consent
 
 For development and testing, Composio's managed auth works fine. No OAuth app setup required.
 
-## Custom redirect domain
+## Routing the callback through your domain
 
 During OAuth, the browser briefly redirects through `backend.composio.dev` so Composio can capture the auth token. Some toolkits also display this URL on the consent screen.
 

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -774,6 +774,12 @@ const config = {
         destination: '/reference/api-reference',
         permanent: true,
       },
+      // White-labeling direct execution page redirect
+      {
+        source: '/docs/white-labeling',
+        destination: '/docs/white-labeling-authentication',
+        permanent: true,
+      },
     ];
   },
 };

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -774,7 +774,7 @@ const config = {
         destination: '/reference/api-reference',
         permanent: true,
       },
-      // White-labeling direct execution page redirect
+      // Legacy /docs/white-labeling → sessions white-labeling page
       {
         source: '/docs/white-labeling',
         destination: '/docs/white-labeling-authentication',


### PR DESCRIPTION
## Summary

- Add "Sending users directly to the OAuth provider" section to the direct execution white-labeling page, documenting `long_redirect_url` for skipping Composio's URL shortener
- Rename redirect sections on both white-labeling pages for clarity: "Routing the callback through your domain"
- Add 301 redirect from `/docs/white-labeling` to `/docs/white-labeling-authentication`

## Verified

Both Python and TypeScript code examples tested against live API:
- Default: returns `backend.composio.dev/api/v3/s/...` (shortened)
- With `long_redirect_url: true`: returns `accounts.google.com/o/oauth2/v2/auth?...` (direct)

## Test plan

- [ ] `bun run build` passes (TypeScript code blocks type-checked)
- [ ] `/docs/white-labeling` redirects to `/docs/white-labeling-authentication`
- [ ] Direct execution page shows "Sending users directly to the OAuth provider" section
- [ ] Session page does NOT show `long_redirect_url` (not supported in session paradigm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)