### PR TITLE
fix: send empty object for params in telemetry instead of full function call

### DIFF
--- a/.changeset/slow-bars-lose.md
+++ b/.changeset/slow-bars-lose.md
@@ -1,0 +1,5 @@
+---
+'@composio/core': patch
+---
+
+Remove telemetry payload

--- a/python/composio/core/models/base.py
+++ b/python/composio/core/models/base.py
@@ -21,7 +21,7 @@ allow_tracking = contextvars.ContextVar[bool]("allow_tracking", default=True)
 _environment = os.getenv("ENVIRONMENT", "development")
 
 
-def trace_method(method: t.Callable, name: str, **attributes: t.Any) -> t.Callable:
+def trace_method(method: t.Callable, name: str) -> t.Callable:
     """Wrap a method to log the call."""
 
     # Check if the method is a class method
@@ -39,7 +39,7 @@ def trace_method(method: t.Callable, name: str, **attributes: t.Any) -> t.Callab
             type="metric",
             functionName=name,
             timestamp=time.time(),
-            props=attributes,
+            props={},
             source={
                 "environment": _environment,  # type: ignore
                 "language": "python",

--- a/python/providers/anthropic/pyproject.toml
+++ b/python/providers/anthropic/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio-anthropic"
-version = "0.11.1"
+version = "0.11.2"
 description = "Use Composio to get an array of tools with your Anthropic LLMs."
 readme = "README.md"
 requires-python = ">=3.10,<4"

--- a/python/providers/anthropic/setup.py
+++ b/python/providers/anthropic/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 
 setup(
     name="composio_anthropic",
-    version="0.11.1",
+    version="0.11.2",
     author="Composio",
     author_email="tech@composio.dev",
     description="Use Composio to get an array of tools with your Anthropic LLMs.",

--- a/python/providers/autogen/pyproject.toml
+++ b/python/providers/autogen/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio-autogen"
-version = "0.11.1"
+version = "0.11.2"
 description = "Use Composio to get an array of tools with your autogen agent."
 readme = "README.md"
 requires-python = ">=3.9,<4"

--- a/python/providers/autogen/setup.py
+++ b/python/providers/autogen/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 
 setup(
     name="composio_autogen",
-    version="0.11.1",
+    version="0.11.2",
     author="Composio",
     author_email="tech@composio.dev",
     description="Use Composio to get an array of tools with your Autogen agent.",

--- a/python/providers/claude_agent_sdk/pyproject.toml
+++ b/python/providers/claude_agent_sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio-claude-agent-sdk"
-version = "0.11.1"
+version = "0.11.2"
 description = "Use Composio to get an array of tools with Claude Code Agents SDK."
 readme = "README.md"
 requires-python = ">=3.10,<4"

--- a/python/providers/claude_agent_sdk/setup.py
+++ b/python/providers/claude_agent_sdk/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="composio_claude_agent_sdk",
-    version="0.11.1",
+    version="0.11.2",
     author="Composio",
     author_email="tech@composio.dev",
     description="Use Composio to get array of tools for Claude Agent SDK",

--- a/python/providers/crewai/pyproject.toml
+++ b/python/providers/crewai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio-crewai"
-version = "0.11.1"
+version = "0.11.2"
 description = "Use Composio to get an array of tools with your CrewAI agent."
 readme = "README.md"
 requires-python = ">=3.9,<4"

--- a/python/providers/crewai/setup.py
+++ b/python/providers/crewai/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 setup(
     name="composio_crewai",
-    version="0.11.1",
+    version="0.11.2",
     author="Composio",
     author_email="tech@composio.dev",
     description="Use Composio to get an array of tools with your CrewAI agent.",

--- a/python/providers/gemini/pyproject.toml
+++ b/python/providers/gemini/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio-gemini"
-version = "0.11.1"
+version = "0.11.2"
 description = "Use Composio to get an array of tools with your Gemini agent."
 readme = "README.md"
 requires-python = ">=3.9,<4"

--- a/python/providers/gemini/setup.py
+++ b/python/providers/gemini/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 
 setup(
     name="composio_gemini",
-    version="0.11.1",
+    version="0.11.2",
     author="Composio",
     author_email="tech@composio.dev",
     description="Use Composio to get an array of tools with your Gemini agent.",

--- a/python/providers/google/pyproject.toml
+++ b/python/providers/google/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio-google"
-version = "0.11.1"
+version = "0.11.2"
 description = "Use Composio to get an array of tools with your Google AI Python Gemini model."
 readme = "README.md"
 requires-python = ">=3.9,<4"

--- a/python/providers/google/setup.py
+++ b/python/providers/google/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 
 setup(
     name="composio_google",
-    version="0.11.1",
+    version="0.11.2",
     author="Composio",
     author_email="tech@composio.dev",
     description="Use Composio to get an array of tools with your Google AI Python Gemini model.",

--- a/python/providers/google_adk/pyproject.toml
+++ b/python/providers/google_adk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio-google-adk"
-version = "0.11.1"
+version = "0.11.2"
 description = "Use Composio to get an array of tools with your Google AI Python Gemini model."
 readme = "README.md"
 requires-python = ">=3.9,<4"

--- a/python/providers/google_adk/setup.py
+++ b/python/providers/google_adk/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 
 setup(
     name="composio_google_adk",
-    version="0.11.1",
+    version="0.11.2",
     author="Composio",
     author_email="tech@composio.dev",
     description="Use Composio to get an array of tools with your Google AI Python Gemini model.",

--- a/python/providers/langchain/pyproject.toml
+++ b/python/providers/langchain/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio-langchain"
-version = "0.11.1"
+version = "0.11.2"
 description = "Use Composio to get an array of tools with your Langchain agent."
 readme = "README.md"
 requires-python = ">=3.9,<4"

--- a/python/providers/langchain/setup.py
+++ b/python/providers/langchain/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 
 setup(
     name="composio_langchain",
-    version="0.11.1",
+    version="0.11.2",
     author="composio",
     author_email="tech@composio.dev",
     description="Use Composio to get an array of tools with your Langchain agent.",

--- a/python/providers/langgraph/pyproject.toml
+++ b/python/providers/langgraph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio-langgraph"
-version = "0.11.1"
+version = "0.11.2"
 description = "Use Composio to get array of tools with LangGraph Agent Workflows."
 readme = "README.md"
 requires-python = ">=3.9,<4"

--- a/python/providers/langgraph/setup.py
+++ b/python/providers/langgraph/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 
 setup(
     name="composio_langgraph",
-    version="0.11.1",
+    version="0.11.2",
     author="composio",
     author_email="tech@composio.dev",
     description="Use Composio to get array of tools with LangGraph Agent Workflows",

--- a/python/providers/llamaindex/pyproject.toml
+++ b/python/providers/llamaindex/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio-llamaindex"
-version = "0.11.1"
+version = "0.11.2"
 description = "Use Composio to get array of tools with LlamaIndex Agent Workflows."
 readme = "README.md"
 requires-python = ">=3.9,<4"

--- a/python/providers/llamaindex/setup.py
+++ b/python/providers/llamaindex/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 
 setup(
     name="composio_llamaindex",
-    version="0.11.1",
+    version="0.11.2",
     author="composio",
     author_email="tech@composio.dev",
     description="Use Composio to get array of tools with LlamaIndex Agent Workflows",

--- a/python/providers/openai/pyproject.toml
+++ b/python/providers/openai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio-openai"
-version = "0.11.1"
+version = "0.11.2"
 description = "Use Composio to get an array of tools with your OpenAI Function Call."
 readme = "README.md"
 requires-python = ">=3.9,<4"

--- a/python/providers/openai/setup.py
+++ b/python/providers/openai/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 
 setup(
     name="composio_openai",
-    version="0.11.1",
+    version="0.11.2",
     author="Composio",
     author_email="tech@composio.dev",
     description="Use Composio to get an array of tools with your OpenAI Function Call.",

--- a/python/providers/openai_agents/pyproject.toml
+++ b/python/providers/openai_agents/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio-openai-agents"
-version = "0.11.1"
+version = "0.11.2"
 description = "Use Composio to get array of strongly typed tools for OpenAI Agents"
 readme = "README.md"
 requires-python = ">=3.9,<4"

--- a/python/providers/openai_agents/setup.py
+++ b/python/providers/openai_agents/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="composio_openai_agents",
-    version="0.11.1",
+    version="0.11.2",
     author="Composio",
     author_email="tech@composio.dev",
     description="Use Composio to get array of strongly typed tools for OpenAI Agents",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio"
-version = "0.11.1"
+version = "0.11.2"
 description = "SDK for integrating Composio with your applications."
 readme = "README.md"
 requires-python = ">=3.10,<4"

--- a/ts/packages/core/src/telemetry/Telemetry.ts
+++ b/ts/packages/core/src/telemetry/Telemetry.ts
@@ -125,7 +125,7 @@ export class TelemetryTransport {
               props: {
                 fileName: instrumentedClassName,
                 method: name,
-                params: args,
+                params: {},
               },
               metadata: {
                 provider: this.telemetryMetadata?.provider ?? 'openai',
@@ -204,7 +204,7 @@ export class TelemetryTransport {
       props: {
         fileName: instrumentedClassName,
         method: name,
-        params: args,
+        params: {},
       },
       metadata: {
         provider: this.telemetryMetadata?.provider ?? 'openai',

--- a/ts/packages/core/src/telemetry/Telemetry.ts
+++ b/ts/packages/core/src/telemetry/Telemetry.ts
@@ -149,7 +149,6 @@ export class TelemetryTransport {
                   error,
                   instrumentedClassName,
                   name,
-                  args,
                   startTime,
                   durationMs
                 );
@@ -185,7 +184,6 @@ export class TelemetryTransport {
    * @param {unknown} error - The error to send.
    * @param {string} instrumentedClassName - The class name of the instrumented class.
    * @param {string} name - The name of the method that threw the error.
-   * @param {unknown[]} args - The arguments passed to the method.
    * @param {number} startTime - The start time of the method invocation in milliseconds.
    * @param {number} durationMs - The duration of the method invocation in milliseconds.
    */
@@ -193,7 +191,6 @@ export class TelemetryTransport {
     error: unknown,
     instrumentedClassName: string,
     name: string,
-    args: unknown[],
     startTime: number,
     durationMs: number
   ) {


### PR DESCRIPTION
## Summary

Stop sending method arguments in telemetry payloads. Both success and error telemetry now send `params: {}` instead of the full argument list.

## Changes

- **TypeScript**: Replace `params: args` with `params: {}` in success and error telemetry
- **Python**: Send `props: {}` explicitly, remove unused `**attributes` parameter from `trace_method`

## Rationale

Telemetry should only collect metadata needed for usage analytics (function name, duration, errors). Method arguments are not required and should not be transmitted.

Made with [Cursor](https://cursor.com)