### PR TITLE
docs(outlook): clarify primary vs secondary calendar event creation

### DIFF
--- a/docs/content/toolkits/faq/outlook.md
+++ b/docs/content/toolkits/faq/outlook.md
@@ -10,6 +10,29 @@ Outlook's webhooks send only the message ID on trigger events. To get the full m
 
 Microsoft Graph's send endpoint returns an HTTP 202 with no message details. To get the message ID and conversation ID, create a draft first with `OUTLOOK_CREATE_DRAFT`, then send it with `OUTLOOK_SEND_DRAFT`. See [Microsoft Graph docs](https://learn.microsoft.com/en-us/graph/api/user-sendmail?view=graph-rest-1.0&tabs=http).
 
+## How do I create a calendar event in a non-primary (secondary) Outlook calendar?
+
+`OUTLOOK_CALENDAR_CREATE_EVENT` always creates events in the **default (primary) calendar** (`POST /me/events`). Even if you pass a `calendar_id` argument, the backend ignores it and the event lands in the primary calendar.
+
+To create an event in a non-primary or secondary calendar, use **`OUTLOOK_CREATE_CALENDAR_EVENT`** instead, and provide the `calendar_id`:
+
+```python
+result = composio_client.tools.execute(
+    slug="OUTLOOK_CREATE_CALENDAR_EVENT",
+    arguments={
+        "calendar_id": "<your-non-primary-calendar-id>",  # Required
+        "subject": "Team sync",
+        "start": {"dateTime": "2026-03-10T10:00:00", "timeZone": "UTC"},
+        "end": {"dateTime": "2026-03-10T11:00:00", "timeZone": "UTC"},
+    },
+    user_id="me",
+)
+```
+
+This routes to `POST /me/calendars/{calendarId}/events` on Microsoft Graph, which correctly targets the specified calendar. See the [Microsoft Graph Calendar API docs](https://learn.microsoft.com/en-us/graph/api/calendar-post-events?view=graph-rest-1.0) for full parameter reference.
+
+To find the `calendar_id` for your calendars, call `OUTLOOK_LIST_CALENDARS`.
+
 ## What's the @odata.context / @odata URL?
 
 The `@odata.context` URL provides metadata about the response (entity set, service version, and schema info) to help clients interpret the payload structure. It's primarily used for pagination and data parsing — not as a direct URL to the resource itself.

--- a/docs/public/data/toolkits.json
+++ b/docs/public/data/toolkits.json
@@ -7613,7 +7613,7 @@
       {
         "slug": "OUTLOOK_CALENDAR_CREATE_EVENT",
         "name": "Create Calendar Event",
-        "description": "Creates a new Outlook calendar event, ensuring `start_datetime` is chronologically before `end_datetime`."
+        "description": "Creates a new Outlook calendar event in the default (primary) calendar, ensuring `start_datetime` is chronologically before `end_datetime`. To create an event in a non-primary or secondary calendar, use `OUTLOOK_CREATE_CALENDAR_EVENT` with a `calendar_id` instead."
       },
       {
         "slug": "OUTLOOK_CANCEL_CALENDAR_EVENT",
@@ -7698,7 +7698,7 @@
       {
         "slug": "OUTLOOK_CREATE_CALENDAR_EVENT",
         "name": "Create Event in Calendar",
-        "description": "Tool to create a new event in a specific Outlook calendar. Use when you need to add an event to a particular calendar by its ID."
+        "description": "Tool to create a new event in a specific Outlook calendar by `calendar_id`, routing to `/me/calendars/{calendarId}/events` on Microsoft Graph. Use when you need to add an event to a non-primary or secondary calendar. For the default (primary) calendar with start/end validation, use `OUTLOOK_CALENDAR_CREATE_EVENT` instead."
       },
       {
         "slug": "OUTLOOK_CREATE_CALENDAR_EVENT_ATTACHMENT",


### PR DESCRIPTION
## Summary

Clarifies the difference between `OUTLOOK_CALENDAR_CREATE_EVENT` and `OUTLOOK_CREATE_CALENDAR_EVENT` to reduce confusion when creating events in non-primary Outlook calendars.

While investigating issue #2674, it became clear that the documentation did not explain that `OUTLOOK_CALENDAR_CREATE_EVENT` creates events only in the default (primary) calendar. Developers attempting to create events in secondary calendars would naturally try this tool and pass `calendar_id`, which led to confusion.

This PR improves the documentation by:

* Explicitly stating that `OUTLOOK_CALENDAR_CREATE_EVENT` targets the primary calendar
* Directing users to `OUTLOOK_CREATE_CALENDAR_EVENT` when creating events in non-primary calendars
* Adding a FAQ entry with a working example and references to Microsoft Graph endpoints

Fixes #2674

## Changes

* Updated tool descriptions in `docs/public/data/toolkits.json` to clarify primary vs secondary calendar behavior
* Added a new FAQ entry in `docs/content/toolkits/faq/outlook.md` explaining how to create events in non-primary calendars
* Added example usage of `OUTLOOK_CREATE_CALENDAR_EVENT` with `calendar_id`

## Type of change

* [ ] Bug fix
* [ ] New feature
* [ ] Refactor/Chore
* [x] Documentation
* [ ] Breaking change

## How Has This Been Tested?

* Verified that `toolkits.json` remains valid JSON after modifications
* Confirmed that updated tool descriptions render correctly and reference the appropriate tools
* Reviewed the FAQ page locally to ensure formatting and code examples are correct
* No runtime behavior was modified (documentation-only change)

## Screenshots (if applicable)

N/A

## Checklist

* [x] I have read the Code of Conduct and this PR adheres to it
* [x] I ran linters/tests locally and they passed
* [x] I updated documentation as needed
* [ ] I added tests or explain why not applicable
* [ ] I added a changeset if this change affects published packages

## Additional context

During investigation it was also observed that multiple Outlook event creation tools have similar names (`OUTLOOK_CALENDAR_CREATE_EVENT`, `OUTLOOK_CREATE_CALENDAR_EVENT`, `OUTLOOK_CREATE_ME_EVENT`). This PR does not modify behavior but clarifies their intended usage to reduce developer confusion.
