### PR TITLE
fix(cli): support Brave and other non-standard browsers in login

### DIFF
--- a/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
+++ b/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
@@ -1,6 +1,6 @@
 import { Args, Command, Options } from '@effect/cli';
 import { Effect, Option, Schedule } from 'effect';
-import open from 'open';
+import { openUrl } from 'src/utils/open-url';
 import { ComposioToolkitsRepository } from 'src/services/composio-clients';
 import { ComposioUserContext } from 'src/services/user-context';
 import { TerminalUI } from 'src/services/terminal-ui';
@@ -59,7 +59,7 @@ const waitForActiveConnection = (
         yield* ui.log.warn(`Redirect URL has an unexpected scheme: ${redirectUrl}`);
         yield* ui.log.info('Open the URL manually if you trust the source.');
       } else {
-        yield* Effect.tryPromise(() => open(redirectUrl, { wait: false })).pipe(
+        yield* openUrl(redirectUrl).pipe(
           Effect.catchAll(error =>
             Effect.gen(function* () {
               yield* Effect.logDebug('Failed to open browser:', error);

--- a/ts/packages/cli/src/commands/login.cmd.ts
+++ b/ts/packages/cli/src/commands/login.cmd.ts
@@ -1,6 +1,6 @@
 import { Command, Options } from '@effect/cli';
 import { Effect, Option, Schedule } from 'effect';
-import open from 'open';
+import { openUrl } from 'src/utils/open-url';
 import {
   ComposioSessionRepository,
   getSessionInfo,
@@ -173,7 +173,7 @@ export const browserLogin = (params: {
     yield* ui.output(url);
 
     if (!params.noBrowser) {
-      yield* Effect.tryPromise(() => open(url, { wait: false })).pipe(
+      yield* openUrl(url).pipe(
         Effect.catchAll(error =>
           Effect.gen(function* () {
             yield* Effect.logDebug('Failed to open browser:', error);

--- a/ts/packages/cli/src/utils/open-url.ts
+++ b/ts/packages/cli/src/utils/open-url.ts
@@ -1,0 +1,59 @@
+import { Effect } from 'effect';
+import process from 'node:process';
+import childProcess from 'node:child_process';
+
+/**
+ * Open a URL in the user's default browser.
+ *
+ * Uses the platform-native command (`open` on macOS, `xdg-open` on Linux,
+ * `start` on Windows) via `child_process.spawn` instead of the `open` npm
+ * package. The npm package's `apps.browser` / `apps.browserPrivate` code
+ * path maintains an allow-list of recognized browser bundle IDs and throws
+ * "Error: <name> is not supported as a default browser" for any browser
+ * not in that list (e.g. Brave in versions before `open@10.2.0`).
+ *
+ * By calling the OS command directly we avoid browser detection entirely —
+ * the OS routes the URL to whatever the user has configured as default,
+ * regardless of browser vendor.
+ *
+ * @see https://github.com/ComposioHQ/composio/issues/2542
+ */
+export const openUrl = (url: string): Effect.Effect<void, Error> =>
+  Effect.tryPromise({
+    try: () =>
+      new Promise<void>((resolve, reject) => {
+        const { platform } = process;
+        let command: string;
+        let args: string[];
+
+        if (platform === 'darwin') {
+          command = 'open';
+          args = [url];
+        } else if (platform === 'win32') {
+          command = 'cmd';
+          args = ['/c', 'start', '', url];
+        } else {
+          // Linux and other Unix-like systems
+          command = 'xdg-open';
+          args = [url];
+        }
+
+        const child = childProcess.spawn(command, args, {
+          stdio: 'ignore',
+          detached: true,
+        });
+
+        child.on('error', reject);
+
+        // For fire-and-forget, resolve once spawned successfully.
+        // The 'spawn' event fires when the child process has been created.
+        child.on('spawn', () => {
+          child.unref();
+          resolve();
+        });
+      }),
+    catch: error =>
+      new Error(
+        `Failed to open URL in browser: ${error instanceof Error ? error.message : String(error)}`
+      ),
+  });


### PR DESCRIPTION
## Summary

Fixes #2542

The `composio login` command fails with `"Error: Brave is not supported as a default browser"` on macOS when Brave is the default browser. This happens because the `open` npm package maintains an allow-list of recognized browser bundle IDs and rejects any browser not in that list.

This PR replaces the `open` npm package with a direct `child_process.spawn` call to the platform-native command:
- **macOS**: `open <url>`
- **Linux**: `xdg-open <url>`
- **Windows**: `cmd /c start "" <url>`

By calling the OS command directly, we bypass browser detection entirely. The OS routes the URL to whatever the user has configured as their default browser, regardless of vendor (Brave, Arc, Vivaldi, etc.).

## Changes

- **New**: `ts/packages/cli/src/utils/open-url.ts` -- shared utility that opens a URL using the platform-native command
- **Modified**: `ts/packages/cli/src/commands/login.cmd.ts` -- use `openUrl()` instead of `open` npm package
- **Modified**: `ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts` -- same change

## Test plan

- [x] `pnpm typecheck` passes (all 14 packages)
- [x] `pnpm --filter @composio/cli test` passes (493 tests, 0 failures)
- [ ] Manual: `composio login` with Brave as default browser on macOS
- [ ] Manual: `composio login` with Chrome/Firefox/Safari as default browser
- [ ] Manual: `composio connected-accounts link <toolkit>` with non-standard browser