### PR TITLE
docs: show Composio Managed App availability on toolkit pages

### DIFF
--- a/docs/app/llms.mdx/[[...slug]]/route.ts
+++ b/docs/app/llms.mdx/[[...slug]]/route.ts
@@ -627,6 +627,13 @@ function toolkitToMarkdown(toolkit: Toolkit, detailedTools?: Tool[], detailedTri
     '',
     `- **Category:** ${toolkit.category || 'Uncategorized'}`,
     `- **Auth:** ${toolkit.authSchemes.join(', ') || 'None'}`,
+    `- **Composio Managed App Available?** ${
+      toolkit.authSchemes?.some((s) => s.toUpperCase().includes('OAUTH'))
+        ? (toolkit.composioManagedAuthSchemes && toolkit.composioManagedAuthSchemes.length > 0
+            ? 'Yes'
+            : 'No')
+        : 'N/A'
+    }`,
     `- **Tools:** ${toolkit.toolCount}`,
     `- **Triggers:** ${toolkit.triggerCount}`,
     `- **Slug:** \`${toolkit.slug.toUpperCase()}\``,
@@ -713,15 +720,19 @@ async function generateToolkitsIndex(): Promise<string> {
     '',
     '## All Toolkits',
     '',
-    '| Toolkit | Slug | Tools | Triggers | Auth |',
-    '|---------|------|-------|----------|------|',
+    '| Toolkit | Slug | Tools | Triggers | Auth | Managed App |',
+    '|---------|------|-------|----------|------|-------------|',
   ];
 
   for (const toolkit of sorted) {
     const name = toolkit.name?.trim() || toolkit.slug;
     const auth = toolkit.authSchemes?.join(', ') || 'None';
+    const hasOAuth = toolkit.authSchemes?.some((s) => s.toUpperCase().includes('OAUTH'));
+    const managedApp = hasOAuth
+      ? (toolkit.composioManagedAuthSchemes && toolkit.composioManagedAuthSchemes.length > 0 ? 'Yes' : 'No')
+      : '—';
     lines.push(
-      `| [${name}](/toolkits/${toolkit.slug}.md) | \`${toolkit.slug.toUpperCase()}\` | ${toolkit.toolCount} | ${toolkit.triggerCount} | ${auth} |`
+      `| [${name}](/toolkits/${toolkit.slug}.md) | \`${toolkit.slug.toUpperCase()}\` | ${toolkit.toolCount} | ${toolkit.triggerCount} | ${auth} | ${managedApp} |`
     );
   }
 

--- a/docs/components/toolkits/auth-details-section.tsx
+++ b/docs/components/toolkits/auth-details-section.tsx
@@ -7,6 +7,7 @@ import type { AuthConfigDetail, AuthConfigField } from '@/types/toolkit';
 
 interface AuthDetailsSectionProps {
   authConfigDetails: AuthConfigDetail[];
+  authSchemes?: string[];
   composioManagedAuthSchemes?: string[];
 }
 
@@ -57,7 +58,7 @@ function getAllFields(detail: AuthConfigDetail): AuthConfigField[] {
   ];
 }
 
-export function AuthDetailsSection({ authConfigDetails, composioManagedAuthSchemes }: AuthDetailsSectionProps) {
+export function AuthDetailsSection({ authConfigDetails, authSchemes, composioManagedAuthSchemes }: AuthDetailsSectionProps) {
   if (!authConfigDetails || authConfigDetails.length === 0) {
     return null;
   }
@@ -71,7 +72,7 @@ export function AuthDetailsSection({ authConfigDetails, composioManagedAuthSchem
     return null;
   }
 
-  const hasOAuth = validDetails.some((d) => d.mode.toLowerCase().includes('oauth'));
+  const hasOAuth = authSchemes?.some((s) => s.toUpperCase().includes('OAUTH')) ?? false;
 
   return (
     <div className="space-y-3">

--- a/docs/components/toolkits/auth-details-section.tsx
+++ b/docs/components/toolkits/auth-details-section.tsx
@@ -7,6 +7,7 @@ import type { AuthConfigDetail, AuthConfigField } from '@/types/toolkit';
 
 interface AuthDetailsSectionProps {
   authConfigDetails: AuthConfigDetail[];
+  composioManagedAuthSchemes?: string[];
 }
 
 function formatTypeName(mode: string): string {
@@ -56,7 +57,7 @@ function getAllFields(detail: AuthConfigDetail): AuthConfigField[] {
   ];
 }
 
-export function AuthDetailsSection({ authConfigDetails }: AuthDetailsSectionProps) {
+export function AuthDetailsSection({ authConfigDetails, composioManagedAuthSchemes }: AuthDetailsSectionProps) {
   if (!authConfigDetails || authConfigDetails.length === 0) {
     return null;
   }
@@ -70,11 +71,24 @@ export function AuthDetailsSection({ authConfigDetails }: AuthDetailsSectionProp
     return null;
   }
 
+  const hasOAuth = validDetails.some((d) => d.mode.toLowerCase().includes('oauth'));
+
   return (
     <div className="space-y-3">
       <h2 className="flex items-center gap-2 text-base font-semibold text-fd-foreground">
         <Key className="h-4 w-4" />
         Authentication Details
+        {hasOAuth && (
+          composioManagedAuthSchemes && composioManagedAuthSchemes.length > 0 ? (
+            <span className="rounded bg-green-500/10 px-2 py-0.5 text-xs font-medium text-green-600 dark:text-green-400">
+              Composio Managed App available
+            </span>
+          ) : (
+            <span className="rounded bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-600 dark:text-amber-400">
+              Composio Managed App not available
+            </span>
+          )
+        )}
       </h2>
       <Accordions type="single">
         {validDetails.map((detail) => {

--- a/docs/components/toolkits/toolkit-detail.tsx
+++ b/docs/components/toolkits/toolkit-detail.tsx
@@ -355,7 +355,7 @@ export function ToolkitDetail({ toolkit, tools, triggers, path, faq }: ToolkitDe
 
       {/* Authentication Details */}
       {toolkit.authConfigDetails && toolkit.authConfigDetails.length > 0 && (
-        <AuthDetailsSection authConfigDetails={toolkit.authConfigDetails} composioManagedAuthSchemes={toolkit.composioManagedAuthSchemes} />
+        <AuthDetailsSection authConfigDetails={toolkit.authConfigDetails} authSchemes={toolkit.authSchemes} composioManagedAuthSchemes={toolkit.composioManagedAuthSchemes} />
       )}
 
       {/* FAQ */}

--- a/docs/components/toolkits/toolkit-detail.tsx
+++ b/docs/components/toolkits/toolkit-detail.tsx
@@ -353,13 +353,13 @@ export function ToolkitDetail({ toolkit, tools, triggers, path, faq }: ToolkitDe
           </div>
       </div>
 
-      {/* FAQ */}
-      {faq && faq.length > 0 && <FaqSection faq={faq} />}
-
       {/* Authentication Details */}
       {toolkit.authConfigDetails && toolkit.authConfigDetails.length > 0 && (
-        <AuthDetailsSection authConfigDetails={toolkit.authConfigDetails} />
+        <AuthDetailsSection authConfigDetails={toolkit.authConfigDetails} composioManagedAuthSchemes={toolkit.composioManagedAuthSchemes} />
       )}
+
+      {/* FAQ */}
+      {faq && faq.length > 0 && <FaqSection faq={faq} />}
 
       {/* Tools & Triggers */}
       {(tools.length > 0 || triggers.length > 0) && (

--- a/docs/scripts/generate-toolkits.ts
+++ b/docs/scripts/generate-toolkits.ts
@@ -64,6 +64,7 @@ interface Toolkit {
   description: string;
   category: string | null;
   authSchemes: string[];
+  composioManagedAuthSchemes?: string[];
   toolCount: number;
   triggerCount: number;
   version: string | null;
@@ -222,13 +223,17 @@ async function fetchAuthConfigDetails(slug: string): Promise<AuthConfigDetail[]>
 }
 
 function transformToolkit(raw: any): Toolkit {
+  const authSchemes = raw.auth_schemes || raw.authSchemes || [];
+  const composioManaged = raw.composio_managed_auth_schemes || raw.composioManagedAuthSchemes || [];
+
   return {
     slug: raw.slug?.toLowerCase() || '',
     name: raw.name || raw.slug || '',
     logo: raw.meta?.logo || raw.logo || null,
     description: raw.meta?.description || raw.description || '',
     category: raw.meta?.categories?.[0]?.name || raw.meta?.categories?.[0] || null,
-    authSchemes: raw.auth_schemes || raw.authSchemes || [],
+    authSchemes,
+    ...(composioManaged.length > 0 ? { composioManagedAuthSchemes: composioManaged } : {}),
     toolCount: raw.tool_count || raw.toolCount || 0,
     triggerCount: raw.trigger_count || raw.triggerCount || 0,
     version: null,

--- a/docs/types/toolkit.ts
+++ b/docs/types/toolkit.ts
@@ -77,6 +77,7 @@ export interface ToolkitSummary {
 export interface Toolkit extends ToolkitSummary {
   description: string;
   authSchemes: string[];
+  composioManagedAuthSchemes?: string[];
   version: string | null;
   tools: Tool[];
   triggers: Trigger[];


### PR DESCRIPTION
## Summary

- Surfaces the `composioManagedAuthSchemes` API field on toolkit detail pages so users know upfront whether Composio managed OAuth is available or they need their own credentials
- Adds a badge next to the "Authentication Details" heading — green for "Composio Managed App available", amber for "Composio Managed App not available" (only shown for OAuth toolkits)
- Includes managed app status in the markdown/LLM export (`/toolkits/{slug}.md`) and the toolkits index table (`/toolkits.md`)
- Regenerates `toolkits.json` with the new field — 114 out of 980 toolkits have Composio managed auth

## Motivation

Users (like us!) hit confusing errors when trying to use Composio managed auth on toolkits that don't support it (e.g. Google Ads). There was no way to know upfront from the docs whether managed auth was available. This makes it visible at a glance.

## Files changed

| File | What |
|------|------|
| `docs/types/toolkit.ts` | Added `composioManagedAuthSchemes` to `Toolkit` interface |
| `docs/scripts/generate-toolkits.ts` | Extract field from API response into generated JSON |
| `docs/components/toolkits/auth-details-section.tsx` | Badge next to Authentication Details heading |
| `docs/components/toolkits/toolkit-detail.tsx` | Pass managed auth data to auth section |
| `docs/app/llms.mdx/[[...slug]]/route.ts` | Managed app status in markdown export |
| `docs/public/data/toolkits.json` | Regenerated with `composioManagedAuthSchemes` data |

## Test plan

- [ ] Visit `/toolkits/gmail` — should show green "Composio Managed App available" badge
- [ ] Visit `/toolkits/twitter` — should show amber "Composio Managed App not available" badge  
- [ ] Visit `/toolkits/sendinblue` (API_KEY only) — should show no badge
- [ ] Check `/toolkits/gmail.md` — should include `**Composio Managed App Available?** Yes`
- [ ] Check `/toolkits.md` — index table should have "Managed App" column

🤖 Generated with [Claude Code](https://claude.com/claude-code)