### PR TITLE
docs: improve quickstart selector discoverability

### DIFF
--- a/docs/components/quickstart/integration-tabs.tsx
+++ b/docs/components/quickstart/integration-tabs.tsx
@@ -24,7 +24,39 @@ interface IntegrationTabsProps {
   tabs?: TabConfig[];
 }
 
-function IntegrationTabsHeader({ tabs }: { tabs: TabConfig[] }) {
+function TabsHeader({ tabs }: { tabs: TabConfig[] }) {
+  return (
+    <div className="flex items-center gap-3">
+      <TabsList>
+        {tabs.map((tab) => (
+          <TabsTrigger key={tab.value} value={tab.value} className="gap-2">
+            {tab.icon && tab.iconDark && (
+              <div className="flex h-4 w-4 shrink-0 items-center justify-center">
+                <Image
+                  src={tab.icon}
+                  alt={tab.label}
+                  width={16}
+                  height={16}
+                  className="h-4 w-4 dark:hidden"
+                />
+                <Image
+                  src={tab.iconDark}
+                  alt={tab.label}
+                  width={16}
+                  height={16}
+                  className="hidden h-4 w-4 dark:block"
+                />
+              </div>
+            )}
+            {tab.label}
+          </TabsTrigger>
+        ))}
+      </TabsList>
+    </div>
+  );
+}
+
+function PortaledTabsHeader({ tabs }: { tabs: TabConfig[] }) {
   const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
 
   useEffect(() => {
@@ -48,33 +80,7 @@ function IntegrationTabsHeader({ tabs }: { tabs: TabConfig[] }) {
   const header = (
     <div className="mt-4 border-t border-fd-border pt-4">
       <p className="mb-3 text-sm font-medium text-fd-muted-foreground">Choose your integration type · <Link href="/docs/native-tools-vs-mcp" className="text-fd-muted-foreground hover:text-fd-foreground transition-colors underline underline-offset-2">Use this guide to decide</Link></p>
-      <div className="flex items-center gap-3">
-        <TabsList>
-          {tabs.map((tab) => (
-            <TabsTrigger key={tab.value} value={tab.value} className="gap-2">
-              {tab.icon && tab.iconDark && (
-                <div className="flex h-4 w-4 shrink-0 items-center justify-center">
-                  <Image
-                    src={tab.icon}
-                    alt={tab.label}
-                    width={16}
-                    height={16}
-                    className="h-4 w-4 dark:hidden"
-                  />
-                  <Image
-                    src={tab.iconDark}
-                    alt={tab.label}
-                    width={16}
-                    height={16}
-                    className="hidden h-4 w-4 dark:block"
-                  />
-                </div>
-              )}
-              {tab.label}
-            </TabsTrigger>
-          ))}
-        </TabsList>
-      </div>
+      <TabsHeader tabs={tabs} />
     </div>
   );
 
@@ -87,9 +93,17 @@ function IntegrationTabsHeader({ tabs }: { tabs: TabConfig[] }) {
 }
 
 export function IntegrationTabs({ children, defaultValue, tabs = defaultTabs }: IntegrationTabsProps) {
+  const isQuickstart = tabs === defaultTabs;
+
   return (
     <Tabs defaultValue={defaultValue ?? tabs[0]?.value ?? 'native'} className="not-prose">
-      <IntegrationTabsHeader tabs={tabs} />
+      {isQuickstart ? (
+        <PortaledTabsHeader tabs={tabs} />
+      ) : (
+        <div className="mb-5">
+          <TabsHeader tabs={tabs} />
+        </div>
+      )}
       {children}
     </Tabs>
   );

--- a/docs/components/quickstart/integration-tabs.tsx
+++ b/docs/components/quickstart/integration-tabs.tsx
@@ -28,7 +28,21 @@ function IntegrationTabsHeader({ tabs }: { tabs: TabConfig[] }) {
   const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
 
   useEffect(() => {
-    setPortalTarget(document.getElementById('integration-tabs-portal'));
+    const target = document.getElementById('integration-tabs-portal');
+    if (target) {
+      setPortalTarget(target);
+      return;
+    }
+    // Portal target may not exist yet (frameworks register asynchronously via useEffect)
+    const observer = new MutationObserver(() => {
+      const el = document.getElementById('integration-tabs-portal');
+      if (el) {
+        setPortalTarget(el);
+        observer.disconnect();
+      }
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+    return () => observer.disconnect();
   }, []);
 
   const header = (

--- a/docs/components/quickstart/integration-tabs.tsx
+++ b/docs/components/quickstart/integration-tabs.tsx
@@ -3,7 +3,8 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
-import { ReactNode } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 interface TabConfig {
   value: string;
@@ -23,10 +24,17 @@ interface IntegrationTabsProps {
   tabs?: TabConfig[];
 }
 
-export function IntegrationTabs({ children, defaultValue, tabs = defaultTabs }: IntegrationTabsProps) {
-  return (
-    <Tabs defaultValue={defaultValue ?? tabs[0]?.value ?? 'native'} className="not-prose -mt-2">
-      <div className="mb-5 flex items-center gap-3">
+function IntegrationTabsHeader({ tabs }: { tabs: TabConfig[] }) {
+  const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    setPortalTarget(document.getElementById('integration-tabs-portal'));
+  }, []);
+
+  const header = (
+    <div className="mt-4 border-t border-fd-border pt-4">
+      <p className="mb-3 text-sm font-medium text-fd-muted-foreground">Choose your integration type · <Link href="/docs/native-tools-vs-mcp" className="text-fd-muted-foreground hover:text-fd-foreground transition-colors underline underline-offset-2">Use this guide to decide</Link></p>
+      <div className="flex items-center gap-3">
         <TabsList>
           {tabs.map((tab) => (
             <TabsTrigger key={tab.value} value={tab.value} className="gap-2">
@@ -52,10 +60,22 @@ export function IntegrationTabs({ children, defaultValue, tabs = defaultTabs }: 
             </TabsTrigger>
           ))}
         </TabsList>
-        <Link href="/docs/native-tools-vs-mcp" className="text-xs text-fd-muted-foreground hover:text-fd-foreground transition-colors">
-          Which should I use?
-        </Link>
       </div>
+    </div>
+  );
+
+  if (portalTarget) {
+    return createPortal(header, portalTarget);
+  }
+
+  // Fallback: render inline if portal target not found
+  return <div className="mb-5">{header}</div>;
+}
+
+export function IntegrationTabs({ children, defaultValue, tabs = defaultTabs }: IntegrationTabsProps) {
+  return (
+    <Tabs defaultValue={defaultValue ?? tabs[0]?.value ?? 'native'} className="not-prose">
+      <IntegrationTabsHeader tabs={tabs} />
       {children}
     </Tabs>
   );

--- a/docs/components/quickstart/quickstart-flow.tsx
+++ b/docs/components/quickstart/quickstart-flow.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Image from 'next/image';
+import Link from 'next/link';
 import {
   createContext,
   useContext,
@@ -157,9 +158,10 @@ export function QuickstartFlow({ children }: QuickstartFlowProps) {
 
   return (
     <QuickstartContext.Provider value={contextValue}>
-      {/* Framework selector */}
+      {/* Framework + integration type selector */}
       {frameworks.length > 0 && (
-        <div className="not-prose mb-6">
+        <div className="not-prose mb-6 rounded-lg border border-fd-border bg-fd-card/50 p-4">
+          <p className="mb-3 text-sm font-medium text-fd-muted-foreground">Choose your framework</p>
           <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
             {frameworks.map((framework) => (
               <FrameworkCard
@@ -172,7 +174,16 @@ export function QuickstartFlow({ children }: QuickstartFlowProps) {
                 onSelect={() => setSelectedId(framework.id)}
               />
             ))}
+            <Link
+              href="/docs/providers"
+              className="flex items-center gap-3 rounded-lg border border-dashed border-fd-border px-3 py-2.5 text-left transition-all hover:bg-fd-accent/50 hover:border-fd-muted-foreground"
+            >
+              <span className="flex h-6 w-6 shrink-0 items-center justify-center text-fd-muted-foreground">→</span>
+              <span className="text-sm font-medium text-fd-muted-foreground">Other providers</span>
+            </Link>
           </div>
+          {/* Portal target for integration tabs header */}
+          <div id="integration-tabs-portal" />
         </div>
       )}
 

--- a/docs/components/quickstart/quickstart-flow.tsx
+++ b/docs/components/quickstart/quickstart-flow.tsx
@@ -176,7 +176,7 @@ export function QuickstartFlow({ children }: QuickstartFlowProps) {
             ))}
             <Link
               href="/docs/providers"
-              className="flex items-center gap-3 rounded-lg border border-dashed border-fd-border px-3 py-2.5 text-left transition-all hover:bg-fd-accent/50 hover:border-fd-muted-foreground"
+              className="flex items-center gap-3 rounded-lg border border-dashed border-fd-border px-3 py-2.5 transition-all hover:bg-fd-accent/50 hover:border-fd-muted-foreground"
             >
               <span className="flex h-6 w-6 shrink-0 items-center justify-center text-fd-muted-foreground">→</span>
               <span className="text-sm font-medium text-fd-muted-foreground">Other providers</span>

--- a/docs/lib/source.ts
+++ b/docs/lib/source.ts
@@ -188,13 +188,13 @@ export function mdxToCleanMarkdown(content: string): string {
       while ((match = labelRegex.exec(tabsContent)) !== null) {
         tabLabelMap[match[1]] = match[2];
       }
-      return '\n> Which should I use? See [Native Tools vs MCP](/docs/native-tools-vs-mcp)\n';
+      return '\n> Choose your integration type · [Use this guide to decide](/docs/native-tools-vs-mcp)\n';
     }
   );
   // Also handle IntegrationTabs without explicit tabs prop
   result = result.replace(
     /<IntegrationTabs(?![^>]*tabs=)[\s\S]*?>/g,
-    '\n> Which should I use? See [Native Tools vs MCP](/docs/native-tools-vs-mcp)\n'
+    '\n> Choose your integration type · [Use this guide to decide](/docs/native-tools-vs-mcp)\n'
   );
 
   // Convert IntegrationContent to labeled section


### PR DESCRIPTION
## Summary
- Wrapped the framework selector and integration type tabs in a single bordered card with clear labels ("Choose your framework", "Choose your integration type") so users notice they're interactive
- Added an "Other providers →" link card in the framework grid pointing to `/docs/providers`
- Portaled the integration tabs header into the framework card so both selectors live in one box with a divider
- Added "Use this guide to decide" link next to integration type label

## Test plan
- [ ] Visit `/docs/quickstart` and verify both selectors appear in a single card
- [ ] Confirm clicking framework cards and integration type tabs still switches content correctly
- [ ] Verify "Other providers" card links to `/docs/providers`
- [ ] Verify "Use this guide to decide" links to `/docs/native-tools-vs-mcp`
- [ ] Check dark mode renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)