### PR TITLE
fix(cli): valid CTA payload, lowercase link, and JSON output for link command

### DIFF
--- a/.changeset/forty-aliens-listen.md
+++ b/.changeset/forty-aliens-listen.md
@@ -1,0 +1,5 @@
+---
+'@composio/cli': patch
+---
+
+Fix CTAs and Link commands

--- a/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
+++ b/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
@@ -32,6 +32,7 @@ const noBrowser = Options.boolean('no-browser').pipe(
 
 /**
  * Open the browser and poll until the connected account becomes ACTIVE.
+ * On success, outputs valid JSON to stdout for piping (e.g. to jq).
  */
 const waitForActiveConnection = (
   ui: TerminalUI,
@@ -41,9 +42,8 @@ const waitForActiveConnection = (
   noBrowser: boolean
 ) =>
   Effect.gen(function* () {
-    // Display the redirect URL
+    // Display the redirect URL (interactive only)
     yield* ui.note(redirectUrl, 'Redirect URL');
-    yield* ui.output(redirectUrl);
 
     if (!noBrowser) {
       // Validate URL scheme before opening — prevent non-HTTPS redirects
@@ -92,10 +92,22 @@ const waitForActiveConnection = (
         )
       ).pipe(
         Effect.tap(account => {
+          const message = `Connected account "${account.id}" is now ACTIVE (toolkit: ${account.toolkit.slug}).`;
           return Effect.all([
             spinner.stop('Connection successful'),
-            ui.log.success(
-              `Connected account "${account.id}" is now ACTIVE (toolkit: ${account.toolkit.slug}).`
+            ui.log.success(message),
+            ui.output(
+              JSON.stringify(
+                {
+                  status: 'success',
+                  message,
+                  connected_account_id: account.id,
+                  toolkit: account.toolkit.slug,
+                  redirect_url: redirectUrl,
+                },
+                null,
+                2
+              )
             ),
           ]);
         }),

--- a/ts/packages/cli/src/commands/root-help.ts
+++ b/ts/packages/cli/src/commands/root-help.ts
@@ -54,10 +54,11 @@ const BASIC_COMMANDS: ReadonlyArray<BasicCommand> = [
   {
     name: 'search',
     description: 'Search tools by use case across toolkits/apps.',
-    usage: 'search <query> [--toolkits text] [--limit integer]',
+    usage: 'search <query> [--toolkits text] [--user-id text] [--limit integer]',
     options: [
       { name: '<query>', description: 'Semantic use-case query (e.g. "send emails")' },
       { name: '--toolkits', description: 'Filter by toolkit slugs, comma-separated' },
+      { name: '--user-id', description: 'User ID (falls back to project/global test_user_id)' },
       { name: '--limit', description: 'Number of results per page (1-1000)' },
     ],
   },

--- a/ts/packages/cli/src/commands/tools/commands/tools.search.cmd.ts
+++ b/ts/packages/cli/src/commands/tools/commands/tools.search.cmd.ts
@@ -7,6 +7,8 @@ import { resolveToolRouterSession } from 'src/effects/create-tool-router-session
 import { buildMinimalPayloadFromSchema } from 'src/ui/build-minimal-payload';
 import { formatToolsTable } from '../format';
 import type { Tool } from 'src/models/tools';
+import { ProjectContext } from 'src/services/project-context';
+import { ComposioUserContext } from 'src/services/user-context';
 
 const query = Args.text({ name: 'query' }).pipe(
   Args.withDescription(
@@ -17,6 +19,11 @@ const query = Args.text({ name: 'query' }).pipe(
 const toolkits = Options.text('toolkits').pipe(
   Options.withDescription('Filter by toolkit slugs, comma-separated (e.g. "gmail,outlook")'),
   Options.optional
+);
+
+const userId = Options.text('user-id').pipe(
+  Options.optional,
+  Options.withDescription('User ID for the session (falls back to project/global test_user_id)')
 );
 
 const limit = Options.integer('limit').pipe(
@@ -40,12 +47,38 @@ const limit = Options.integer('limit').pipe(
  */
 export const toolsCmd$Search = Command.make(
   'search',
-  { query, toolkits, limit },
-  ({ query, toolkits, limit }) =>
+  { query, toolkits, userId, limit },
+  ({ query, toolkits, userId, limit }) =>
     Effect.gen(function* () {
       if (!(yield* requireAuth)) return;
 
       const ui = yield* TerminalUI;
+      const projectContext = yield* ProjectContext;
+      const userContext = yield* ComposioUserContext;
+      const resolvedProjectContext = yield* projectContext.resolve.pipe(
+        Effect.catchAll(() => Effect.succeed(Option.none()))
+      );
+      const testUserId = Option.flatMap(resolvedProjectContext, keys => keys.testUserId);
+      const globalTestUserId = userContext.data.testUserId;
+      const resolvedUserId = Option.match(userId, {
+        onSome: value => Option.some(value),
+        onNone: () => Option.orElse(testUserId, () => globalTestUserId),
+      });
+
+      if (Option.isNone(resolvedUserId)) {
+        return yield* Effect.fail(
+          new Error(
+            'Missing user id. Provide --user-id or run composio init to set test_user_id, or composio login to set global test_user_id.'
+          )
+        );
+      }
+
+      if (Option.isNone(userId) && Option.isSome(testUserId)) {
+        yield* ui.log.warn(`Using test user id "${testUserId.value}"`);
+      } else if (Option.isNone(userId) && Option.isSome(globalTestUserId)) {
+        yield* ui.log.warn(`Using global test user id "${globalTestUserId.value}"`);
+      }
+
       const clampedLimit = clampLimit(limit);
       const toolkitFilter = Option.getOrUndefined(toolkits);
       const toolkitList =
@@ -59,7 +92,7 @@ export const toolsCmd$Search = Command.make(
       const searchResponse = yield* ui.withSpinner(
         `Searching tools for "${query}"...`,
         Effect.gen(function* () {
-          const { client, sessionId } = yield* resolveToolRouterSession('default-cli', {
+          const { client, sessionId } = yield* resolveToolRouterSession(resolvedUserId.value, {
             toolkits: toolkitList,
           });
           return yield* Effect.tryPromise(() =>

--- a/ts/packages/cli/src/commands/tools/commands/tools.search.cmd.ts
+++ b/ts/packages/cli/src/commands/tools/commands/tools.search.cmd.ts
@@ -140,22 +140,21 @@ export const toolsCmd$Search = Command.make(
       }
 
       // For machine-readable output (e.g. piping to jq), expose the full API payload with CTA.
-      const firstSlugForOutput = toolsList[0]?.slug;
       const firstSchema =
-        firstSlugForOutput && searchResponse.tool_schemas[firstSlugForOutput]
-          ? searchResponse.tool_schemas[firstSlugForOutput]
+        firstSlug && searchResponse.tool_schemas[firstSlug]
+          ? searchResponse.tool_schemas[firstSlug]
           : undefined;
       const firstToolkit = firstSchema?.toolkit;
 
       const cta: Array<{ action: string; command: string }> = [];
-      if (firstSlugForOutput) {
+      if (firstSlug) {
         const payload = buildMinimalPayloadFromSchema(
           firstSchema?.input_schema as Record<string, unknown>
         );
         const payloadJson = JSON.stringify(payload);
         cta.push({
           action: 'Execute a tool',
-          command: `composio execute "${firstSlugForOutput}" -d '${payloadJson}'`,
+          command: `composio execute "${firstSlug}" -d '${payloadJson}'`,
         });
       }
       if (firstToolkit) {

--- a/ts/packages/cli/src/commands/tools/commands/tools.search.cmd.ts
+++ b/ts/packages/cli/src/commands/tools/commands/tools.search.cmd.ts
@@ -4,6 +4,7 @@ import { TerminalUI } from 'src/services/terminal-ui';
 import { requireAuth } from 'src/effects/require-auth';
 import { clampLimit } from 'src/ui/clamp-limit';
 import { resolveToolRouterSession } from 'src/effects/create-tool-router-session';
+import { buildMinimalPayloadFromSchema } from 'src/ui/build-minimal-payload';
 import { formatToolsTable } from '../format';
 import type { Tool } from 'src/models/tools';
 
@@ -138,8 +139,37 @@ export const toolsCmd$Search = Command.make(
         yield* ui.log.warn(searchResponse.error);
       }
 
-      // For machine-readable output (e.g. piping to jq), expose the full API payload.
-      yield* ui.output(JSON.stringify(searchResponse, null, 2));
+      // For machine-readable output (e.g. piping to jq), expose the full API payload with CTA.
+      const firstSlugForOutput = toolsList[0]?.slug;
+      const firstSchema =
+        firstSlugForOutput && searchResponse.tool_schemas[firstSlugForOutput]
+          ? searchResponse.tool_schemas[firstSlugForOutput]
+          : undefined;
+      const firstToolkit = firstSchema?.toolkit;
+
+      const cta: Array<{ action: string; command: string }> = [];
+      if (firstSlugForOutput) {
+        const payload = buildMinimalPayloadFromSchema(
+          firstSchema?.input_schema as Record<string, unknown>
+        );
+        const payloadJson = JSON.stringify(payload);
+        cta.push({
+          action: 'Execute a tool',
+          command: `composio execute "${firstSlugForOutput}" -d '${payloadJson}'`,
+        });
+      }
+      if (firstToolkit) {
+        cta.push({
+          action: 'Connect a user account',
+          command: `composio link ${String(firstToolkit).toLowerCase()}`,
+        });
+      }
+
+      const outputForJq = {
+        ...searchResponse,
+        CTA: cta,
+      };
+      yield* ui.output(JSON.stringify(outputForJq, null, 2));
     })
 ).pipe(
   Command.withDescription(

--- a/ts/packages/cli/src/ui/build-minimal-payload.ts
+++ b/ts/packages/cli/src/ui/build-minimal-payload.ts
@@ -1,0 +1,45 @@
+import { extractSchemaProperties } from './extract-schema-properties';
+
+/**
+ * Builds a minimal valid JSON payload from a JSON Schema input_schema.
+ * Used for CTA examples (e.g. composio execute "TOOL" -d '...').
+ */
+export function buildMinimalPayloadFromSchema(
+  schema: Record<string, unknown> | null | undefined
+): Record<string, unknown> {
+  if (!schema || typeof schema !== 'object') {
+    return {};
+  }
+
+  const entries = extractSchemaProperties(schema);
+  if (entries.length === 0) {
+    return {};
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const entry of entries) {
+    result[entry.name] = defaultForType(entry.type, entry.defaultValue);
+  }
+  return result;
+}
+
+function defaultForType(type: string, schemaDefault: unknown): unknown {
+  if (schemaDefault !== undefined) {
+    return schemaDefault;
+  }
+  switch (type) {
+    case 'string':
+      return '';
+    case 'number':
+    case 'integer':
+      return 0;
+    case 'boolean':
+      return false;
+    case 'array':
+      return [];
+    case 'object':
+      return {};
+    default:
+      return '';
+  }
+}

--- a/ts/packages/cli/test/src/commands/__snapshots__/$default.cmd.test.ts.snap
+++ b/ts/packages/cli/test/src/commands/__snapshots__/$default.cmd.test.ts.snap
@@ -44,10 +44,11 @@ BASIC COMMANDS
 
   search
     Search tools by use case across toolkits/apps.
-    Usage: composio search <query> [--toolkits text] [--limit integer]
+    Usage: composio search <query> [--toolkits text] [--user-id text] [--limit integer]
     Options:
       <query>               Semantic use-case query (e.g. "send emails")
       --toolkits            Filter by toolkit slugs, comma-separated
+      --user-id             User ID (falls back to project/global test_user_id)
       --limit               Number of results per page (1-1000)
 
   execute

--- a/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.link.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.link.cmd.test.ts
@@ -143,4 +143,38 @@ describe('CLI: composio connected-accounts link', () => {
       );
     }
   );
+
+  layer(TestLive({ baseConfigProvider: testConfigProvider, connectedAccountsData }))(
+    '[Given] successful link [Then] outputs valid JSON with success message for jq',
+    it => {
+      it.scoped(
+        'prints JSON with status, message, connected_account_id, toolkit, redirect_url',
+        () =>
+          Effect.gen(function* () {
+            yield* cli([
+              'connected-accounts',
+              'link',
+              '--auth-config',
+              'ac_gmail_oauth',
+              '--user-id',
+              'default',
+              '--no-browser',
+            ]);
+            const lines = yield* MockConsole.getLines({ stripAnsi: true });
+            const output = lines.join('\n');
+
+            expect(output).toContain('"status"');
+            expect(output).toContain('"success"');
+            expect(output).toContain('"message"');
+            expect(output).toContain('ACTIVE');
+            expect(output).toContain('"connected_account_id"');
+            expect(output).toContain('con_test_link');
+            expect(output).toContain('"toolkit"');
+            expect(output).toContain('"gmail"');
+            expect(output).toContain('"redirect_url"');
+            expect(output).toContain('https://app.composio.dev/link');
+          })
+      );
+    }
+  );
 });

--- a/ts/packages/cli/test/src/commands/tools/tools.search.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/tools/tools.search.cmd.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, layer } from '@effect/vitest';
-import { Cause, ConfigProvider, Effect, Exit } from 'effect';
+import { ConfigProvider, Effect } from 'effect';
 import type {
   SessionCreateParams,
   SessionSearchParams,
@@ -378,14 +378,9 @@ describe('CLI: composio tools search', () => {
     it => {
       it.scoped('fails when user id cannot be resolved', () =>
         Effect.gen(function* () {
-          const exit = yield* cli(['tools', 'search', 'send']).pipe(Effect.exit);
+          const err = yield* cli(['tools', 'search', 'send']).pipe(Effect.flip);
+          const message = err instanceof Error ? err.message : String(err);
 
-          expect(Exit.isFailure(exit)).toBe(true);
-          const failures = Cause.failures(exit.cause);
-          const defects = Cause.defects(exit.cause);
-          const err = failures[0] ?? defects[0];
-          const message =
-            err instanceof Error ? err.message : String(err ?? Cause.pretty(exit.cause));
           expect(message).toContain('Missing user id');
           expect(message).toContain('--user-id');
           expect(message).toContain('composio init');

--- a/ts/packages/cli/test/src/commands/tools/tools.search.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/tools/tools.search.cmd.test.ts
@@ -100,9 +100,9 @@ describe('CLI: composio tools search', () => {
   );
 
   layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
-    '[Given] tools search [Then] JSON output includes full tool-router payload',
+    '[Given] tools search [Then] JSON output includes full tool-router payload and CTA',
     it => {
-      it.scoped('prints full search response for jq', () =>
+      it.scoped('prints full search response with CTA for jq', () =>
         Effect.gen(function* () {
           yield* cli(['tools', 'search', 'send']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
@@ -113,6 +113,63 @@ describe('CLI: composio tools search', () => {
           expect(output).toContain('"toolkit_connection_statuses"');
           expect(output).toContain('"session"');
           expect(output).toContain('"time_info"');
+          expect(output).toContain('"CTA"');
+          expect(output).toContain('"Execute a tool"');
+          expect(output).toContain('"Connect a user account"');
+          expect(output).toContain('composio execute');
+          expect(output).toContain('composio link gmail');
+        })
+      );
+    }
+  );
+
+  layer(TestLive({ baseConfigProvider: testConfigProvider }))(
+    '[Given] search with schema properties [Then] CTA has valid payload and lowercase link',
+    it => {
+      it.scoped('CTA uses valid payload from input_schema and lowercase toolkit', () =>
+        Effect.gen(function* () {
+          const live = TestLive({
+            baseConfigProvider: testConfigProvider,
+            toolkitsData: {
+              tools: [
+                {
+                  name: 'Send Email',
+                  slug: 'GMAIL_SEND_EMAIL',
+                  description: 'Sends an email',
+                  tags: [],
+                  available_versions: [],
+                  input_parameters: {
+                    type: 'object',
+                    properties: {
+                      to: { type: 'string' },
+                      subject: { type: 'string' },
+                      body: { type: 'string' },
+                    },
+                    required: ['to'],
+                  },
+                  output_parameters: { type: 'object', properties: {} },
+                },
+              ],
+            },
+          });
+
+          yield* cli(['tools', 'search', 'send']).pipe(Effect.provide(live));
+          const lines = yield* MockConsole.getLines({ stripAnsi: true });
+          const output = lines.join('\n');
+
+          const ctaMatch = output.match(/"CTA":\s*\[([\s\S]*?)\]/);
+          expect(ctaMatch).toBeTruthy();
+          const ctaJson = `[${ctaMatch![1]}]`;
+          const cta = JSON.parse(ctaJson) as Array<{ action: string; command: string }>;
+
+          const executeCta = cta.find(c => c.action === 'Execute a tool');
+          expect(executeCta).toBeTruthy();
+          expect(executeCta!.command).toContain('composio execute "GMAIL_SEND_EMAIL"');
+          expect(executeCta!.command).toMatch(/-d '\{"to":"","subject":"","body":""\}'/);
+
+          const linkCta = cta.find(c => c.action === 'Connect a user account');
+          expect(linkCta).toBeTruthy();
+          expect(linkCta!.command).toBe('composio link gmail');
         })
       );
     }

--- a/ts/packages/cli/test/src/commands/tools/tools.search.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/tools/tools.search.cmd.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, layer } from '@effect/vitest';
-import { ConfigProvider, Effect } from 'effect';
+import { Cause, ConfigProvider, Effect, Exit } from 'effect';
 import type {
   SessionCreateParams,
   SessionSearchParams,
@@ -47,26 +47,29 @@ const testConfigProvider = ConfigProvider.fromMap(
   new Map([['COMPOSIO_USER_API_KEY', 'test_api_key']])
 ).pipe(extendConfigProvider);
 
+const testLiveOptions = {
+  baseConfigProvider: testConfigProvider,
+  toolkitsData,
+  fixture: 'global-test-user-id' as const,
+};
+
 describe('CLI: composio tools search', () => {
-  layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
-    '[Given] query "send" [Then] returns matching tools',
-    it => {
-      it.scoped('returns matching tools', () =>
-        Effect.gen(function* () {
-          yield* cli(['tools', 'search', 'send']);
-          const lines = yield* MockConsole.getLines({ stripAnsi: true });
-          const output = lines.join('\n');
+  layer(TestLive(testLiveOptions))('[Given] query "send" [Then] returns matching tools', it => {
+    it.scoped('returns matching tools', () =>
+      Effect.gen(function* () {
+        yield* cli(['tools', 'search', 'send']);
+        const lines = yield* MockConsole.getLines({ stripAnsi: true });
+        const output = lines.join('\n');
 
-          expect(output).toContain('GMAIL_SEND_EMAIL');
-          expect(output).toContain('SLACK_SEND_MESSAGE');
-          expect(output).not.toContain('GITHUB_CREATE_ISSUE');
-          expect(output).toContain('Found 2 tools');
-        })
-      );
-    }
-  );
+        expect(output).toContain('GMAIL_SEND_EMAIL');
+        expect(output).toContain('SLACK_SEND_MESSAGE');
+        expect(output).not.toContain('GITHUB_CREATE_ISSUE');
+        expect(output).toContain('Found 2 tools');
+      })
+    );
+  });
 
-  layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
+  layer(TestLive(testLiveOptions))(
     '[Given] query with no results [Then] shows not found message',
     it => {
       it.scoped('shows not found message', () =>
@@ -81,7 +84,7 @@ describe('CLI: composio tools search', () => {
     }
   );
 
-  layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
+  layer(TestLive(testLiveOptions))(
     '[Given] query "send" --toolkits "gmail" [Then] scopes to toolkit',
     it => {
       it.scoped('scopes search to toolkit', () =>
@@ -99,7 +102,7 @@ describe('CLI: composio tools search', () => {
     }
   );
 
-  layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
+  layer(TestLive(testLiveOptions))(
     '[Given] tools search [Then] JSON output includes full tool-router payload and CTA',
     it => {
       it.scoped('prints full search response with CTA for jq', () =>
@@ -123,13 +126,14 @@ describe('CLI: composio tools search', () => {
     }
   );
 
-  layer(TestLive({ baseConfigProvider: testConfigProvider }))(
+  layer(TestLive({ baseConfigProvider: testConfigProvider, fixture: 'global-test-user-id' }))(
     '[Given] search with schema properties [Then] CTA has valid payload and lowercase link',
     it => {
       it.scoped('CTA uses valid payload from input_schema and lowercase toolkit', () =>
         Effect.gen(function* () {
           const live = TestLive({
             baseConfigProvider: testConfigProvider,
+            fixture: 'global-test-user-id',
             toolkitsData: {
               tools: [
                 {
@@ -175,7 +179,7 @@ describe('CLI: composio tools search', () => {
     }
   );
 
-  layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
+  layer(TestLive(testLiveOptions))(
     '[Given] --toolkits filter [Then] it is passed to session create as enabled toolkits',
     it => {
       it.scoped('passes toolkit filter into tool router session', () =>
@@ -186,6 +190,7 @@ describe('CLI: composio tools search', () => {
           const live = TestLive({
             baseConfigProvider: testConfigProvider,
             toolkitsData,
+            fixture: 'global-test-user-id',
             toolRouter: {
               create: async params => {
                 createParams = params;
@@ -255,7 +260,7 @@ describe('CLI: composio tools search', () => {
     }
   );
 
-  layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
+  layer(TestLive(testLiveOptions))(
     '[Given] search response with recommended plan [Then] it prints plan and execute hint',
     it => {
       it.scoped('prints plan and command hints', () =>
@@ -263,6 +268,7 @@ describe('CLI: composio tools search', () => {
           const live = TestLive({
             baseConfigProvider: testConfigProvider,
             toolkitsData,
+            fixture: 'global-test-user-id',
             toolRouter: {
               search: async (_sessionId, params) => ({
                 success: true,
@@ -338,7 +344,57 @@ describe('CLI: composio tools search', () => {
     );
   });
 
-  layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
+  layer(TestLive(testLiveOptions))(
+    '[Given] explicit --user-id [Then] uses that user id for session',
+    it => {
+      it.scoped('passes user-id to session create', () =>
+        Effect.gen(function* () {
+          let createParams: SessionCreateParams | undefined;
+          const live = TestLive({
+            ...testLiveOptions,
+            toolRouter: {
+              create: async params => {
+                createParams = params;
+                return {
+                  session_id: 'trs_test_session',
+                  config: { user_id: params.user_id },
+                  mcp: { type: 'http', url: 'https://mcp.test.composio.dev' },
+                  tool_router_tools: ['COMPOSIO_SEARCH_TOOLS'],
+                };
+              },
+            },
+          });
+
+          yield* cli(['tools', 'search', 'send', '--user-id', 'alice']).pipe(Effect.provide(live));
+
+          expect(createParams?.user_id).toBe('alice');
+        })
+      );
+    }
+  );
+
+  layer(TestLive({ baseConfigProvider: testConfigProvider }))(
+    '[Given] no test_user_id and no --user-id [Then] fails with missing user id message',
+    it => {
+      it.scoped('fails when user id cannot be resolved', () =>
+        Effect.gen(function* () {
+          const exit = yield* cli(['tools', 'search', 'send']).pipe(Effect.exit);
+
+          expect(Exit.isFailure(exit)).toBe(true);
+          const failures = Cause.failures(exit.cause);
+          const defects = Cause.defects(exit.cause);
+          const err = failures[0] ?? defects[0];
+          const message =
+            err instanceof Error ? err.message : String(err ?? Cause.pretty(exit.cause));
+          expect(message).toContain('Missing user id');
+          expect(message).toContain('--user-id');
+          expect(message).toContain('composio init');
+        })
+      );
+    }
+  );
+
+  layer(TestLive(testLiveOptions))(
     '[Given] composio search alias [Then] works like composio tools search',
     it => {
       it.scoped('alias expands to tools search', () =>


### PR DESCRIPTION
## Summary

- **Search CTA**: Use valid payload derived from `input_schema` for the execute command (instead of empty `{}`)
- **Search CTA**: Use lowercase toolkit for link command (e.g. `composio link gmail`)
- **Link command**: Output valid JSON with success message when piping to jq (fixes broken jq output)

## Changes

- Add `buildMinimalPayloadFromSchema` helper to derive minimal valid JSON from tool input schema
- Update search CTA execute command to use schema-derived payload
- Update search CTA link command to use lowercase toolkit
- Link command: remove raw URL stdout output, output single JSON object on success with `status`, `message`, `connected_account_id`, `toolkit`, `redirect_url`
- Add tests for CTA payload and link JSON output

Made with [Cursor](https://cursor.com)