### PR TITLE
docs(slack): add integration overview and privacy FAQ

### DIFF
--- a/docs/content/toolkits/faq/slack.md
+++ b/docs/content/toolkits/faq/slack.md
@@ -1,3 +1,11 @@
+## What does the Composio + Slack integration do?
+
+Composio turns Slack's API into ready-to-use tools that AI agents and automations can call. With the integration you can send and read messages, manage channels, upload files, react to events, search conversations, and more — all through a unified platform. Composio supports two toolkits: **Slack** (authenticate as a user for workspace-level actions) and **Slackbot** (authenticate as a bot for in-channel messaging, app mentions, and slash commands). Developers connect their Slack workspace once and then orchestrate any combination of these actions from their agents or workflows.
+
+## How does Composio handle my Slack data?
+
+Composio executes API calls on behalf of your connected account. All data is encrypted and subject to a 30-day retention policy. Authentication tokens are encrypted at rest and scoped to the permissions you grant during the OAuth flow. For full details on data handling, retention, and third-party data practices, see our [Privacy Policy](https://composio.dev/privacy).
+
 ## How do I set up custom OAuth credentials for Slack?
 
 For a step-by-step guide on creating and configuring your own Slack OAuth credentials with Composio, see [How to create OAuth credentials for Slack](https://composio.dev/auth/slack).


### PR DESCRIPTION
## Summary
- Adds two new FAQ entries at the top of the Slack toolkit docs page to address Slack marketplace review requirements:
  - **What does the Composio + Slack integration do?** — Describes capabilities and the two toolkits (Slack user + Slackbot)
  - **How does Composio handle my Slack data?** — Covers encryption, 30-day retention policy, and links to [privacy policy](https://composio.dev/privacy)

## Context
Slack marketplace reviewer flagged that our landing page (`docs.composio.dev/toolkits/slack`) needs:
1. A clear description of what the integration does
2. An accessible privacy policy link

🤖 Generated with [Claude Code](https://claude.com/claude-code)