### PR TITLE
docs: add missing icon to dashboard card

### DIFF
--- a/docs/content/docs/authenticating-users/manually-authenticating.mdx
+++ b/docs/content/docs/authenticating-users/manually-authenticating.mdx
@@ -217,7 +217,7 @@ console.log(`All toolkits connected! MCP URL: ${session.mcp.url}`);
 ## What to read next
 
 <Cards>
-  <Card title="Build an App Connections Dashboard" href="/cookbooks/app-connections-dashboard" description="Full working example of a connections page with OAuth and disconnect" />
+  <Card icon={<LayoutDashboard />} title="Build an App Connections Dashboard" href="/cookbooks/app-connections-dashboard" description="Full working example of a connections page with OAuth and disconnect" />
   <Card icon={<MessageCircle />} title="In-chat authentication" href="/docs/authenticating-users/in-chat-authentication" description="Let the agent prompt users to connect accounts during conversation instead" />
   <Card icon={<Palette />} title="White-labeling authentication" href="/docs/white-labeling-authentication" description="Use your own OAuth apps so users see your branding on consent screens" />
   <Card icon={<Database />} title="Managing multiple accounts" href="/docs/managing-multiple-connected-accounts" description="Handle users with multiple accounts for the same toolkit (e.g., work and personal Gmail)" />

--- a/docs/mdx-components.tsx
+++ b/docs/mdx-components.tsx
@@ -40,6 +40,7 @@ import {
   BookOpen,
   Monitor,
   MessageCircle,
+  LayoutDashboard,
 } from 'lucide-react';
 
 function slugify(text: string): string {
@@ -112,6 +113,7 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     BookOpen,
     Monitor,
     MessageCircle,
+    LayoutDashboard,
     ...components,
   };
 }


### PR DESCRIPTION
## Summary

- Adds `LayoutDashboard` icon to the "Build an App Connections Dashboard" card on the manually-authenticating page
- The other 3 cards in that group all had icons, making this one look visually inconsistent

## Test plan

- [ ] Verify the card renders with the icon on `/docs/authenticating-users/manually-authenticating`

🤖 Generated with [Claude Code](https://claude.com/claude-code)