### PR TITLE
fix: handle missing 'type' key in nested object schemas

### DIFF
--- a/python/composio/utils/shared.py
+++ b/python/composio/utils/shared.py
@@ -292,7 +292,6 @@ def pydantic_model_from_param_schema(param_schema: t.Dict) -> t.Type:
     :param param_schema: Schema with 'title', 'properties', and optionally 'required' keys.
     :return: A Pydantic model class for the defined schema.
 
-    :raises KeyError: Missing 'type' in property definitions.
     :raised ValueError: Invalid 'type' for property or recursive model creation.
 
     Note: Requires global `schema_type_python_type_dict` for type mapping and
@@ -320,14 +319,22 @@ def pydantic_model_from_param_schema(param_schema: t.Dict) -> t.Type:
         return t.List
 
     for prop_name, prop_info in param_schema.get("properties", {}).items():
-        prop_type = prop_info["type"]
-        prop_title = prop_info["title"].replace(" ", "")
-        prop_default = prop_info.get("default", FALLBACK_VALUES[prop_type])
+        prop_type = prop_info.get("type")
+        prop_title = prop_info.get("title", prop_name).replace(" ", "")
+        prop_default = prop_info.get("default", FALLBACK_VALUES.get(prop_type))
         if (
-            prop_type in PYDANTIC_TYPE_TO_PYTHON_TYPE
+            prop_type is not None
+            and prop_type in PYDANTIC_TYPE_TO_PYTHON_TYPE
             and prop_type not in CONTAINER_TYPE
         ):
             signature_prop_type = PYDANTIC_TYPE_TO_PYTHON_TYPE[prop_type]
+        elif prop_type is None:
+            # Schema uses anyOf/allOf/oneOf/$ref instead of a top-level "type" key.
+            # Delegate to json_schema_to_pydantic_type which handles all combiners.
+            signature_prop_type = t.cast(
+                t.Type,
+                json_schema_to_pydantic_type(json_schema=prop_info),
+            )
         else:
             signature_prop_type = pydantic_model_from_param_schema(prop_info)
 


### PR DESCRIPTION
## Summary

Fixes #2459

When executing `DROPBOX_SEARCH_FILE_OR_FOLDER` with the optional `options` parameter, the SDK crashes with `KeyError: 'type'` before the API request is even sent. This happens because `pydantic_model_from_param_schema()` uses direct dictionary access (`prop_info["type"]`, `prop_info["title"]`) on schema entries that may not have a top-level `type` key — nested object schemas can use `anyOf`, `allOf`, `oneOf`, or `$ref` instead.

### Changes in `python/composio/utils/shared.py`

- `prop_info["type"]` → `prop_info.get("type")` — prevents `KeyError` on schemas without `type`
- `prop_info["title"]` → `prop_info.get("title", prop_name)` — falls back to property name when `title` is absent
- `FALLBACK_VALUES[prop_type]` → `FALLBACK_VALUES.get(prop_type)` — handles `None` prop_type gracefully
- When `prop_type is None` (schema uses combiners instead of `type`), delegates to `json_schema_to_pydantic_type()` which already handles `anyOf`/`allOf`/`oneOf` correctly
- Removed stale `:raises KeyError` from docstring since the function no longer raises it

### Before

```python
prop_type = prop_info["type"]           # KeyError if schema uses anyOf/allOf/$ref
prop_title = prop_info["title"]         # KeyError if title is absent
prop_default = prop_info.get("default", FALLBACK_VALUES[prop_type])  # KeyError if prop_type not in FALLBACK_VALUES
```

### After

```python
prop_type = prop_info.get("type")
prop_title = prop_info.get("title", prop_name).replace(" ", "")
prop_default = prop_info.get("default", FALLBACK_VALUES.get(prop_type))
if prop_type is not None and prop_type in PYDANTIC_TYPE_TO_PYTHON_TYPE and prop_type not in CONTAINER_TYPE:
    signature_prop_type = PYDANTIC_TYPE_TO_PYTHON_TYPE[prop_type]
elif prop_type is None:
    # Delegate to json_schema_to_pydantic_type which handles all combiners
    signature_prop_type = t.cast(t.Type, json_schema_to_pydantic_type(json_schema=prop_info))
else:
    signature_prop_type = pydantic_model_from_param_schema(prop_info)
```

This fix is generic — it handles all cases where a schema property lacks a `type` key, not just the Dropbox case.

**Note: This PR was authored by Claude (AI), operated by @maxwellcalkin.**