### PR TITLE
fix: use allowed_tools instead of custom_tools in MCP.update()

### DIFF
--- a/python/composio/core/models/mcp.py
+++ b/python/composio/core/models/mcp.py
@@ -370,7 +370,7 @@ class MCP(Resource):
                 update_params["auth_config_ids"] = auth_config_ids
 
             if allowed_tools is not None:
-                update_params["custom_tools"] = allowed_tools
+                update_params["allowed_tools"] = allowed_tools
 
             if manually_manage_connections is not None:
                 update_params[

--- a/python/composio/integration_test/test_mcp.py
+++ b/python/composio/integration_test/test_mcp.py
@@ -520,9 +520,6 @@ class TestMCPRealWorldScenarios:
 
         print("✅ API compatibility verified with TypeScript patterns")
 
-    @pytest.mark.skip(
-        reason="MCP update bug with 'custom_tools' argument - TypeError in McpResource.update()"
-    )
     def test_full_crud_cycle(self, composio_client):
         """Test complete CRUD cycle: create -> get -> update -> get with assertions at each step."""
         test_name = generate_unique_name("pytest-crud")


### PR DESCRIPTION
## Summary

Fixes #2161

The `MCP.update()` method in the Python SDK incorrectly maps the `allowed_tools` parameter to `custom_tools` when building the update payload (line 373 of `mcp.py`):

```python
# Before (broken)
update_params["custom_tools"] = allowed_tools

# After (fixed)
update_params["allowed_tools"] = allowed_tools
```

The `create()` method correctly uses `custom_tools` because it calls `self._client.mcp.custom.create()`, but the `update()` method calls `self._client.mcp.update()` which expects `allowed_tools`. This causes:

```
TypeError: McpResource.update() got an unexpected keyword argument 'custom_tools'
```

## Changes

- **`python/composio/core/models/mcp.py`**: Change `update_params["custom_tools"]` to `update_params["allowed_tools"]` in the `update()` method
- **`python/composio/integration_test/test_mcp.py`**: Remove the `@pytest.mark.skip` decorator from `test_full_crud_cycle` that was added to document this bug

## Test plan

- The previously-skipped `test_full_crud_cycle` integration test now exercises the full create -> get -> update -> get flow, including updating `allowed_tools`
- Existing tests for `create()`, `list()`, `get()`, `delete()`, and `generate()` are unaffected

*This PR was authored by Claude, an AI assistant by Anthropic, as part of an open-source contribution effort. See https://github.com/maxwellcalkin/career for context.*