### PR TITLE
feat(cli): add background upgrade-available hint

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -6,3 +6,6 @@ cadbd463fddb5b31c901d2c222b73354b6d87327:docs/content/docs/common-faq.mdx:curl-a
 cadbd463fddb5b31c901d2c222b73354b6d87327:docs/content/docs/troubleshooting/tools.mdx:curl-auth-header:43
 cadbd463fddb5b31c901d2c222b73354b6d87327:docs/content/docs/tools-direct/toolkit-versioning.mdx:curl-auth-header:34
 cadbd463fddb5b31c901d2c222b73354b6d87327:docs/content/docs/tools-direct/toolkit-versioning.mdx:curl-auth-header:38
+
+# Test fixture dummy token for verifying Authorization header forwarding (not a real secret)
+694231f9ffcdb23ca5baf67509101355764d81dc:ts/packages/cli/test/src/services/update-check.test.ts:generic-api-key:296

--- a/ts/packages/cli/src/bin.ts
+++ b/ts/packages/cli/src/bin.ts
@@ -27,6 +27,7 @@ import { ProjectContext } from 'src/services/project-context';
 import { ProjectEnvironmentDetector } from 'src/services/project-environment-detector';
 import { CommandRunner } from 'src/services/command-runner';
 import { StdinLive } from 'src/services/stdin';
+import { showUpdateNotice, checkForUpdateInBackground } from 'src/services/update-check';
 
 /**
  * Concrete Effect layer compositions for the Composio CLI runtime.
@@ -171,6 +172,14 @@ const valueOptionNames = (() => {
   visit(rootCommand.descriptor);
   return names;
 })();
+
+/**
+ * Upgrade hint — runs outside the Effect runtime, never blocks or throws.
+ * showUpdateNotice() reads a cached file (~1 ms) and prints to stderr.
+ * checkForUpdateInBackground() fires a non-blocking fetch to GitHub.
+ */
+showUpdateNotice();
+checkForUpdateInBackground();
 
 /**
  * CLI entrypoint, which:

--- a/ts/packages/cli/src/services/update-check.ts
+++ b/ts/packages/cli/src/services/update-check.ts
@@ -137,8 +137,13 @@ export function createUpdateChecker(config: UpdateCheckConfig) {
       // Always persist lastChecked to prevent retry loops when the fetch
       // fails or returns no matching tags.
       const writeState = (latestVersion?: string): Promise<void> => {
-        const stateDir = dirname(config.stateFile);
-        mkdirSync(stateDir, { recursive: true });
+        try {
+          const stateDir = dirname(config.stateFile);
+          mkdirSync(stateDir, { recursive: true });
+        } catch {
+          // If we can't create the directory, bail out silently.
+          return Promise.resolve();
+        }
 
         const state: UpdateCheckState = {
           lastChecked: new Date().toISOString(),

--- a/ts/packages/cli/src/services/update-check.ts
+++ b/ts/packages/cli/src/services/update-check.ts
@@ -114,11 +114,13 @@ export function createUpdateChecker(config: UpdateCheckConfig) {
   function checkForUpdate(): Promise<void> | undefined {
     try {
       // Throttle: skip if checked recently.
+      let previousLatestVersion: string | undefined;
       try {
         const state: UpdateCheckState = JSON.parse(readFileSync(config.stateFile, 'utf-8'));
         if (Date.now() - new Date(state.lastChecked).getTime() < config.checkIntervalMs) {
           return undefined;
         }
+        previousLatestVersion = state.latestVersion;
       } catch {
         // ENOENT or corrupt file — re-check.
       }
@@ -132,33 +134,35 @@ export function createUpdateChecker(config: UpdateCheckConfig) {
         headers.Authorization = `Bearer ${config.accessToken}`;
       }
 
-      return (
-        config
-          .fetchFn(config.refsUrl, { headers, signal: AbortSignal.timeout(10_000) })
-          .then(res => {
-            if (!res.ok) throw new Error(`HTTP ${res.status}`);
-            return res.json();
-          })
-          .then((refs: unknown) => {
-            const latestVersion = parseLatestVersionFromRefs(refs);
-            if (!latestVersion) return;
+      // Always persist lastChecked to prevent retry loops when the fetch
+      // fails or returns no matching tags.
+      const writeState = (latestVersion?: string): Promise<void> => {
+        const stateDir = dirname(config.stateFile);
+        mkdirSync(stateDir, { recursive: true });
 
-            const stateDir = dirname(config.stateFile);
-            mkdirSync(stateDir, { recursive: true });
+        const state: UpdateCheckState = {
+          lastChecked: new Date().toISOString(),
+          latestVersion: latestVersion ?? previousLatestVersion ?? config.currentVersion,
+        };
 
-            const state: UpdateCheckState = {
-              lastChecked: new Date().toISOString(),
-              latestVersion,
-            };
+        return writeFile(config.stateFile, JSON.stringify(state, null, 2)).then(() => {});
+      };
 
-            return writeFile(config.stateFile, JSON.stringify(state, null, 2));
-          })
-          // Normalize return type to Promise<void> (writeFile returns void, early-return yields undefined).
-          .then(() => {})
-          .catch(() => {
-            // Silently ignore — never block the CLI.
-          })
-      );
+      return config
+        .fetchFn(config.refsUrl, { headers, signal: AbortSignal.timeout(10_000) })
+        .then(res => {
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          return res.json();
+        })
+        .then((refs: unknown) => {
+          const latestVersion = parseLatestVersionFromRefs(refs);
+          return writeState(latestVersion);
+        })
+        .catch(() => {
+          // Silently ignore fetch/parse errors — never block the CLI.
+          // Still update the timestamp to prevent unbounded retry loops.
+          return writeState().catch(() => {});
+        });
     } catch {
       // Silently ignore.
       return undefined;

--- a/ts/packages/cli/src/services/update-check.ts
+++ b/ts/packages/cli/src/services/update-check.ts
@@ -1,0 +1,183 @@
+import { readFileSync, mkdirSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import semver from 'semver';
+import { bold, cyanBright, dim } from 'src/ui/colors';
+import { APP_VERSION, GITHUB_REPO } from '../constants';
+
+/**
+ * Background update check for @composio/cli.
+ *
+ * Two entry points, both called synchronously from bin.ts BEFORE the Effect
+ * runtime boots — they must never block or throw:
+ *
+ *   showUpdateNotice()              — sync file read (~1 ms)
+ *   checkForUpdateInBackground()    — fire-and-forget fetch, no await
+ *
+ * Strategy:
+ *   Uses GitHub's `git/matching-refs` API with the prefix
+ *   `tags/@composio/cli@` so only CLI tags are returned (tiny payload,
+ *   no monorepo noise). The result is cached to ~/.composio/update-check.json
+ *   and refreshed at most once every 24 hours.
+ */
+
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+/** Matches `refs/tags/@composio/cli@<semver>` — excludes prereleases. */
+const CLI_REF_RE = /^refs\/tags\/@composio\/cli@(\d+\.\d+\.\d+)$/;
+
+export interface UpdateCheckState {
+  lastChecked: string; // ISO-8601
+  latestVersion: string; // e.g. "0.3.0"
+}
+
+// ── Injectable configuration ────────────────────────────────────────────
+
+/** Dependencies injected into the update checker — mirrors the Effect service pattern. */
+export interface UpdateCheckConfig {
+  readonly stateFile: string;
+  readonly currentVersion: string;
+  readonly checkIntervalMs: number;
+  readonly refsUrl: string;
+  readonly accessToken: string | undefined;
+  readonly fetchFn: (url: string, init?: RequestInit) => Promise<Response>;
+}
+
+const _home = join(homedir(), '.composio');
+
+const defaultConfig: UpdateCheckConfig = {
+  stateFile: join(_home, 'update-check.json'),
+  currentVersion: APP_VERSION,
+  checkIntervalMs: CHECK_INTERVAL_MS,
+  refsUrl: `${GITHUB_REPO.API_BASE_URL}/repos/${GITHUB_REPO.OWNER}/${GITHUB_REPO.REPO}/git/matching-refs/tags/@composio/cli@`,
+  accessToken: process.env.COMPOSIO_GITHUB_ACCESS_TOKEN,
+  fetchFn: fetch,
+};
+
+// ── Pure helpers ────────────────────────────────────────────────────────
+
+/** Extract the highest stable semver from a GitHub matching-refs response. */
+export function parseLatestVersionFromRefs(refs: unknown): string | undefined {
+  if (!Array.isArray(refs)) return undefined;
+
+  let latest: string | undefined;
+  for (const ref of refs) {
+    if (typeof ref !== 'object' || ref === null || !('ref' in ref) || typeof ref.ref !== 'string')
+      continue;
+
+    const match = CLI_REF_RE.exec(ref.ref);
+    if (!match) continue;
+
+    const version = match[1];
+    if (!latest || semver.gt(version, latest)) {
+      latest = version;
+    }
+  }
+
+  return latest;
+}
+
+// ── Factory ─────────────────────────────────────────────────────────────
+
+export function createUpdateChecker(config: UpdateCheckConfig) {
+  /**
+   * If a cached newer version is known, print a one-line hint to stderr.
+   * Purely synchronous — reads a tiny JSON file and does a semver compare.
+   */
+  function showUpdateNotice(): void {
+    try {
+      const state: UpdateCheckState = JSON.parse(readFileSync(config.stateFile, 'utf-8'));
+      if (!state.latestVersion || !semver.valid(state.latestVersion)) return;
+      if (state.latestVersion === config.currentVersion) return;
+
+      // Only show when the cached version is strictly newer.
+      if (!semver.gt(state.latestVersion, config.currentVersion)) return;
+
+      const msg =
+        `  ${dim('Update available:')} ${dim(config.currentVersion)} ${dim('→')} ${bold(cyanBright(state.latestVersion))}\n` +
+        `  ${dim('Run')} ${cyanBright('composio upgrade')} ${dim('to update')}\n`;
+
+      process.stderr.write(`\n${msg}\n`);
+    } catch {
+      // Silently ignore — ENOENT, corrupt JSON, etc. Never block the CLI.
+    }
+  }
+
+  /**
+   * Fetch the latest @composio/cli tag from GitHub via the lightweight
+   * `git/matching-refs` endpoint, then write the result to the state file.
+   *
+   * Returns the internal promise so tests can await completion.
+   * The public wrapper discards it (fire-and-forget).
+   */
+  function checkForUpdate(): Promise<void> | undefined {
+    try {
+      // Throttle: skip if checked recently.
+      try {
+        const state: UpdateCheckState = JSON.parse(readFileSync(config.stateFile, 'utf-8'));
+        if (Date.now() - new Date(state.lastChecked).getTime() < config.checkIntervalMs) {
+          return undefined;
+        }
+      } catch {
+        // ENOENT or corrupt file — re-check.
+      }
+
+      const headers: Record<string, string> = {
+        Accept: 'application/vnd.github.v3+json',
+        'User-Agent': `composio-cli/${config.currentVersion}`,
+      };
+
+      if (config.accessToken) {
+        headers.Authorization = `Bearer ${config.accessToken}`;
+      }
+
+      return (
+        config
+          .fetchFn(config.refsUrl, { headers, signal: AbortSignal.timeout(10_000) })
+          .then(res => {
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            return res.json();
+          })
+          .then((refs: unknown) => {
+            const latestVersion = parseLatestVersionFromRefs(refs);
+            if (!latestVersion) return;
+
+            const stateDir = dirname(config.stateFile);
+            mkdirSync(stateDir, { recursive: true });
+
+            const state: UpdateCheckState = {
+              lastChecked: new Date().toISOString(),
+              latestVersion,
+            };
+
+            return writeFile(config.stateFile, JSON.stringify(state, null, 2));
+          })
+          // Normalize return type to Promise<void> (writeFile returns void, early-return yields undefined).
+          .then(() => {})
+          .catch(() => {
+            // Silently ignore — never block the CLI.
+          })
+      );
+    } catch {
+      // Silently ignore.
+      return undefined;
+    }
+  }
+
+  return { showUpdateNotice, checkForUpdate };
+}
+
+// ── Public API (production defaults, fire-and-forget) ───────────────────
+
+const _checker = createUpdateChecker(defaultConfig);
+
+/** Print upgrade hint to stderr if a newer version is cached. */
+export function showUpdateNotice(): void {
+  _checker.showUpdateNotice();
+}
+
+/** Fire-and-forget background fetch to GitHub. */
+export function checkForUpdateInBackground(): void {
+  _checker.checkForUpdate();
+}

--- a/ts/packages/cli/test/__utils__/http-server.ts
+++ b/ts/packages/cli/test/__utils__/http-server.ts
@@ -1,0 +1,41 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+
+/**
+ * Spin up a local HTTP server on an ephemeral port, run the callback,
+ * then tear down. Useful for integration-testing code that uses `fetch`.
+ */
+export async function withHttpServer(
+  handler: (req: IncomingMessage, res: ServerResponse) => void,
+  run: (baseUrl: string) => Promise<void>
+): Promise<void> {
+  const server = createServer(handler);
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen({ port: 0, host: '127.0.0.1' }, () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+  if (address === null || typeof address === 'string') {
+    throw new Error('Failed to bind test server to an ephemeral port');
+  }
+
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+
+  try {
+    await run(baseUrl);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close(error => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+}

--- a/ts/packages/cli/test/__utils__/index.ts
+++ b/ts/packages/cli/test/__utils__/index.ts
@@ -5,3 +5,4 @@ export * as MockTerminal from './services/mock-terminal';
 export { TestLayer as TestLive } from './services/test-layer';
 export { cli } from './cli';
 export { pkg };
+export { withHttpServer } from './http-server';

--- a/ts/packages/cli/test/src/services/update-check.test.ts
+++ b/ts/packages/cli/test/src/services/update-check.test.ts
@@ -1,0 +1,370 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { withHttpServer } from 'test/__utils__/http-server';
+import {
+  createUpdateChecker,
+  parseLatestVersionFromRefs,
+  type UpdateCheckConfig,
+  type UpdateCheckState,
+} from 'src/services/update-check';
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+/** Create a temp directory that is cleaned up after each test. */
+let tempDir: string;
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'update-check-test-'));
+});
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+/** Build a test config pointing at a temp directory with optional overrides. */
+function makeConfig(overrides?: Partial<UpdateCheckConfig>): UpdateCheckConfig {
+  return {
+    stateFile: join(tempDir, '.composio', 'update-check.json'),
+    currentVersion: '0.2.0',
+    checkIntervalMs: 24 * 60 * 60 * 1000,
+    refsUrl: 'http://unused.test',
+    accessToken: undefined,
+    fetchFn: () => Promise.reject(new Error('fetch not configured')),
+    ...overrides,
+  };
+}
+
+/** Write a state file to the test config's stateFile path. */
+function writeState(config: UpdateCheckConfig, state: UpdateCheckState): void {
+  mkdirSync(dirname(config.stateFile), { recursive: true });
+  writeFileSync(config.stateFile, JSON.stringify(state));
+}
+
+/** Create a GitHub matching-refs response body. */
+function makeRefsPayload(versions: string[]) {
+  return versions.map(v => ({
+    ref: `refs/tags/@composio/cli@${v}`,
+    node_id: 'unused',
+    url: 'unused',
+    object: { sha: 'abc', type: 'tag', url: 'unused' },
+  }));
+}
+
+// ── parseLatestVersionFromRefs (pure) ───────────────────────────────────
+
+describe('parseLatestVersionFromRefs', () => {
+  it('returns undefined for non-array input', () => {
+    expect(parseLatestVersionFromRefs(null)).toBeUndefined();
+    expect(parseLatestVersionFromRefs('string')).toBeUndefined();
+    expect(parseLatestVersionFromRefs(42)).toBeUndefined();
+  });
+
+  it('returns undefined when no refs match the CLI pattern', () => {
+    const refs = [
+      { ref: 'refs/tags/@composio/core@1.0.0' },
+      { ref: 'refs/tags/v1.0.0' },
+      { ref: 'refs/heads/main' },
+    ];
+    expect(parseLatestVersionFromRefs(refs)).toBeUndefined();
+  });
+
+  it('returns the single matching version', () => {
+    const refs = makeRefsPayload(['0.2.1']);
+    expect(parseLatestVersionFromRefs(refs)).toBe('0.2.1');
+  });
+
+  it('returns the highest semver, not the last element', () => {
+    // GitHub returns refs sorted lexicographically — 0.10.0 < 0.9.0 lexically
+    // but 0.10.0 > 0.9.0 in semver.
+    const refs = makeRefsPayload(['0.1.0', '0.10.0', '0.9.0', '0.2.0']);
+    expect(parseLatestVersionFromRefs(refs)).toBe('0.10.0');
+  });
+
+  it('excludes prerelease tags', () => {
+    const refs = [
+      { ref: 'refs/tags/@composio/cli@0.2.0' },
+      { ref: 'refs/tags/@composio/cli@0.3.0-beta.1' },
+    ];
+    expect(parseLatestVersionFromRefs(refs)).toBe('0.2.0');
+  });
+
+  it('skips malformed ref objects', () => {
+    const refs = [
+      null,
+      42,
+      { noRef: true },
+      { ref: 123 },
+      { ref: 'refs/tags/@composio/cli@0.5.0' },
+    ];
+    expect(parseLatestVersionFromRefs(refs)).toBe('0.5.0');
+  });
+});
+
+// ── showUpdateNotice ────────────────────────────────────────────────────
+
+describe('showUpdateNotice', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let stderrSpy: any;
+
+  beforeEach(() => {
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stderrSpy.mockRestore();
+  });
+
+  it('does nothing when no state file exists', () => {
+    const { showUpdateNotice } = createUpdateChecker(makeConfig());
+
+    showUpdateNotice();
+
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when cached version equals current version', () => {
+    const config = makeConfig({ currentVersion: '0.2.0' });
+    writeState(config, { lastChecked: new Date().toISOString(), latestVersion: '0.2.0' });
+    const { showUpdateNotice } = createUpdateChecker(config);
+
+    showUpdateNotice();
+
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when cached version is older than current', () => {
+    const config = makeConfig({ currentVersion: '0.3.0' });
+    writeState(config, { lastChecked: new Date().toISOString(), latestVersion: '0.2.0' });
+    const { showUpdateNotice } = createUpdateChecker(config);
+
+    showUpdateNotice();
+
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  it('prints upgrade hint when cached version is newer', () => {
+    const config = makeConfig({ currentVersion: '0.2.0' });
+    writeState(config, { lastChecked: new Date().toISOString(), latestVersion: '0.3.0' });
+    const { showUpdateNotice } = createUpdateChecker(config);
+
+    showUpdateNotice();
+
+    expect(stderrSpy).toHaveBeenCalledOnce();
+    const output = stderrSpy.mock.calls[0][0] as string;
+    expect(output).toContain('Update available');
+    expect(output).toContain('0.3.0');
+    expect(output).toContain('composio upgrade');
+  });
+
+  it('silently ignores corrupt state file', () => {
+    const config = makeConfig();
+    mkdirSync(dirname(config.stateFile), { recursive: true });
+    writeFileSync(config.stateFile, 'not-json!!!');
+    const { showUpdateNotice } = createUpdateChecker(config);
+
+    showUpdateNotice();
+
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when cached version is not valid semver', () => {
+    const config = makeConfig({ currentVersion: '0.2.0' });
+    writeState(config, { lastChecked: new Date().toISOString(), latestVersion: 'not-semver' });
+    const { showUpdateNotice } = createUpdateChecker(config);
+
+    showUpdateNotice();
+
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ── checkForUpdate ──────────────────────────────────────────────────────
+
+describe('checkForUpdate', () => {
+  it('skips fetch when cache is fresh', () => {
+    const fetchFn = vi.fn();
+    const config = makeConfig({ fetchFn: fetchFn as unknown as typeof fetch });
+    writeState(config, {
+      lastChecked: new Date().toISOString(),
+      latestVersion: '0.2.0',
+    });
+    const { checkForUpdate } = createUpdateChecker(config);
+
+    const result = checkForUpdate();
+
+    expect(result).toBeUndefined(); // returned early, no promise
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('fetches when cache is stale', async () => {
+    const stale = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString(); // 25 hours ago
+    const config = makeConfig({
+      fetchFn: vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(makeRefsPayload(['0.3.0'])),
+      }) as unknown as typeof fetch,
+    });
+    writeState(config, { lastChecked: stale, latestVersion: '0.2.0' });
+    const { checkForUpdate } = createUpdateChecker(config);
+
+    await checkForUpdate();
+
+    expect(config.fetchFn).toHaveBeenCalledOnce();
+    const state: UpdateCheckState = JSON.parse(readFileSync(config.stateFile, 'utf-8'));
+    expect(state.latestVersion).toBe('0.3.0');
+  });
+
+  it('fetches when no cache exists', async () => {
+    const config = makeConfig({
+      fetchFn: vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(makeRefsPayload(['0.4.0', '0.3.0'])),
+      }) as unknown as typeof fetch,
+    });
+    const { checkForUpdate } = createUpdateChecker(config);
+
+    await checkForUpdate();
+
+    expect(existsSync(config.stateFile)).toBe(true);
+    const state: UpdateCheckState = JSON.parse(readFileSync(config.stateFile, 'utf-8'));
+    expect(state.latestVersion).toBe('0.4.0');
+  });
+
+  it('fetches when cache file is corrupt', async () => {
+    const config = makeConfig({
+      fetchFn: vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(makeRefsPayload(['0.5.0'])),
+      }) as unknown as typeof fetch,
+    });
+    mkdirSync(dirname(config.stateFile), { recursive: true });
+    writeFileSync(config.stateFile, 'garbage');
+    const { checkForUpdate } = createUpdateChecker(config);
+
+    await checkForUpdate();
+
+    const state: UpdateCheckState = JSON.parse(readFileSync(config.stateFile, 'utf-8'));
+    expect(state.latestVersion).toBe('0.5.0');
+  });
+
+  it('does not write state when no CLI tags are found', async () => {
+    const config = makeConfig({
+      fetchFn: vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([{ ref: 'refs/tags/@composio/core@1.0.0' }]),
+      }) as unknown as typeof fetch,
+    });
+    const { checkForUpdate } = createUpdateChecker(config);
+
+    await checkForUpdate();
+
+    expect(existsSync(config.stateFile)).toBe(false);
+  });
+
+  it('silently ignores HTTP errors', async () => {
+    const config = makeConfig({
+      fetchFn: vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+      }) as unknown as typeof fetch,
+    });
+    const { checkForUpdate } = createUpdateChecker(config);
+
+    // Should not throw
+    await checkForUpdate();
+
+    expect(existsSync(config.stateFile)).toBe(false);
+  });
+
+  it('silently ignores network errors', async () => {
+    const config = makeConfig({
+      fetchFn: vi.fn().mockRejectedValue(new Error('DNS failed')) as unknown as typeof fetch,
+    });
+    const { checkForUpdate } = createUpdateChecker(config);
+
+    await checkForUpdate();
+
+    expect(existsSync(config.stateFile)).toBe(false);
+  });
+
+  it('sends Authorization header when accessToken is set', async () => {
+    const fetchFn = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(makeRefsPayload(['0.2.1'])),
+    });
+    const config = makeConfig({
+      accessToken: 'ghp_secret123',
+      fetchFn: fetchFn as unknown as typeof fetch,
+    });
+    const { checkForUpdate } = createUpdateChecker(config);
+
+    await checkForUpdate();
+
+    expect(fetchFn).toHaveBeenCalledOnce();
+    const [, init] = fetchFn.mock.calls[0];
+    expect(init.headers.Authorization).toBe('Bearer ghp_secret123');
+  });
+
+  it('does not send Authorization header when accessToken is undefined', async () => {
+    const fetchFn = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(makeRefsPayload(['0.2.1'])),
+    });
+    const config = makeConfig({
+      accessToken: undefined,
+      fetchFn: fetchFn as unknown as typeof fetch,
+    });
+    const { checkForUpdate } = createUpdateChecker(config);
+
+    await checkForUpdate();
+
+    const [, init] = fetchFn.mock.calls[0];
+    expect(init.headers.Authorization).toBeUndefined();
+  });
+});
+
+// ── Integration: real HTTP server ───────────────────────────────────────
+
+describe('checkForUpdate with real HTTP', () => {
+  it('fetches from a real server and writes state', async () => {
+    await withHttpServer(
+      (_req, res) => {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(makeRefsPayload(['0.1.26', '0.2.0', '0.2.1'])));
+      },
+      async baseUrl => {
+        const config = makeConfig({ refsUrl: baseUrl, fetchFn: fetch });
+        const { checkForUpdate } = createUpdateChecker(config);
+
+        await checkForUpdate();
+
+        const state: UpdateCheckState = JSON.parse(readFileSync(config.stateFile, 'utf-8'));
+        expect(state.latestVersion).toBe('0.2.1');
+      }
+    );
+  });
+
+  it('passes Authorization header to the server', async () => {
+    let receivedAuth: string | undefined;
+
+    await withHttpServer(
+      (req, res) => {
+        receivedAuth = req.headers.authorization;
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(makeRefsPayload(['0.2.1'])));
+      },
+      async baseUrl => {
+        const config = makeConfig({
+          refsUrl: baseUrl,
+          accessToken: 'ghp_test_token',
+          fetchFn: fetch,
+        });
+        const { checkForUpdate } = createUpdateChecker(config);
+
+        await checkForUpdate();
+
+        expect(receivedAuth).toBe('Bearer ghp_test_token');
+      }
+    );
+  });
+});

--- a/ts/packages/cli/test/src/services/update-check.test.ts
+++ b/ts/packages/cli/test/src/services/update-check.test.ts
@@ -247,7 +247,7 @@ describe('checkForUpdate', () => {
     expect(state.latestVersion).toBe('0.5.0');
   });
 
-  it('does not write state when no CLI tags are found', async () => {
+  it('still writes lastChecked when no CLI tags are found', async () => {
     const config = makeConfig({
       fetchFn: vi.fn().mockResolvedValue({
         ok: true,
@@ -258,10 +258,32 @@ describe('checkForUpdate', () => {
 
     await checkForUpdate();
 
-    expect(existsSync(config.stateFile)).toBe(false);
+    expect(existsSync(config.stateFile)).toBe(true);
+    const state: UpdateCheckState = JSON.parse(readFileSync(config.stateFile, 'utf-8'));
+    expect(state.lastChecked).toBeDefined();
+    // Falls back to currentVersion since no previous state and no tags found
+    expect(state.latestVersion).toBe(config.currentVersion);
   });
 
-  it('silently ignores HTTP errors', async () => {
+  it('preserves previous latestVersion when no CLI tags are found', async () => {
+    const config = makeConfig({
+      fetchFn: vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([{ ref: 'refs/tags/@composio/core@1.0.0' }]),
+      }) as unknown as typeof fetch,
+    });
+    const stale = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
+    writeState(config, { lastChecked: stale, latestVersion: '0.3.0' });
+    const { checkForUpdate } = createUpdateChecker(config);
+
+    await checkForUpdate();
+
+    const state: UpdateCheckState = JSON.parse(readFileSync(config.stateFile, 'utf-8'));
+    expect(state.latestVersion).toBe('0.3.0');
+    expect(new Date(state.lastChecked).getTime()).toBeGreaterThan(new Date(stale).getTime());
+  });
+
+  it('writes lastChecked on HTTP errors to prevent retry loops', async () => {
     const config = makeConfig({
       fetchFn: vi.fn().mockResolvedValue({
         ok: false,
@@ -273,10 +295,13 @@ describe('checkForUpdate', () => {
     // Should not throw
     await checkForUpdate();
 
-    expect(existsSync(config.stateFile)).toBe(false);
+    expect(existsSync(config.stateFile)).toBe(true);
+    const state: UpdateCheckState = JSON.parse(readFileSync(config.stateFile, 'utf-8'));
+    expect(state.lastChecked).toBeDefined();
+    expect(state.latestVersion).toBe(config.currentVersion);
   });
 
-  it('silently ignores network errors', async () => {
+  it('writes lastChecked on network errors to prevent retry loops', async () => {
     const config = makeConfig({
       fetchFn: vi.fn().mockRejectedValue(new Error('DNS failed')) as unknown as typeof fetch,
     });
@@ -284,7 +309,10 @@ describe('checkForUpdate', () => {
 
     await checkForUpdate();
 
-    expect(existsSync(config.stateFile)).toBe(false);
+    expect(existsSync(config.stateFile)).toBe(true);
+    const state: UpdateCheckState = JSON.parse(readFileSync(config.stateFile, 'utf-8'));
+    expect(state.lastChecked).toBeDefined();
+    expect(state.latestVersion).toBe(config.currentVersion);
   });
 
   it('sends Authorization header when accessToken is set', async () => {

--- a/ts/packages/cli/test/src/services/upgrade-binary.test.ts
+++ b/ts/packages/cli/test/src/services/upgrade-binary.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from '@effect/vitest';
 import { ConfigProvider, Effect, Layer } from 'effect';
 import { FetchHttpClient } from '@effect/platform';
 import { BunFileSystem } from '@effect/platform-bun';
-import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { withHttpServer } from 'test/__utils__/http-server';
 import { TerminalUI } from 'src/services/terminal-ui';
 import { UpgradeBinary, UpgradeBinaryError } from 'src/services/upgrade-binary';
 import { NodeOs } from 'src/services/node-os';
@@ -57,42 +57,6 @@ const runUpgrade = (configEntries: ReadonlyArray<[string, string]>) =>
     Effect.scoped,
     Effect.runPromise
   );
-
-const withHttpServer = async (
-  handler: (req: IncomingMessage, res: ServerResponse) => void,
-  run: (apiBaseUrl: string) => Promise<void>
-) => {
-  const server = createServer(handler);
-
-  await new Promise<void>((resolve, reject) => {
-    server.once('error', reject);
-    server.listen({ port: 0, host: '127.0.0.1' }, () => {
-      server.off('error', reject);
-      resolve();
-    });
-  });
-
-  const address = server.address();
-  if (address === null || typeof address === 'string') {
-    throw new Error('Failed to bind test server to an ephemeral port');
-  }
-
-  const apiBaseUrl = `http://127.0.0.1:${address.port}`;
-
-  try {
-    await run(apiBaseUrl);
-  } finally {
-    await new Promise<void>((resolve, reject) => {
-      server.close(error => {
-        if (error) {
-          reject(error);
-          return;
-        }
-        resolve();
-      });
-    });
-  }
-};
 
 describe('UpgradeBinary', () => {
   it('wraps non-2xx releases fetch failures with fetch context (no tag branch)', async () => {


### PR DESCRIPTION
## Summary

- This PR builds on top of https://github.com/ComposioHQ/composio/pull/2839
- Closes [PLEN-1741](https://linear.app/composio/issue/PLEN-1741/cli-add-a-upgrade-hint-to-detect-new-version)
- Adds a non-blocking "Update available" notice to stderr on every CLI invocation when a newer `@composio/cli` version exists on GitHub
- Uses GitHub's lightweight `git/matching-refs` API (prefix-filtered to `@composio/cli@` tags — ~12 tiny ref objects vs 100 full release objects)
- Caches result to `~/.composio/update-check.json` with a 24h TTL; respects `COMPOSIO_GITHUB_ACCESS_TOKEN` to avoid rate limits
- Runs entirely outside the Effect runtime: sync file read for the notice (~1ms), fire-and-forget fetch for the background check

## Design

The module deliberately lives outside the Effect service graph because:
1. The notice must print **before** `BunRuntime.runMain()` boots
2. It must never block, fail, or interfere with the CLI's error pipeline
3. Fire-and-forget semantics don't fit Effect's structured concurrency model

Testability is achieved via a `createUpdateChecker(config)` factory with injectable deps (paths, version, fetch function) — the same DI principle as Effect services, without the runtime.

## Files

| File | Purpose |
|---|---|
| `src/services/update-check.ts` | New service: factory + pure `parseLatestVersionFromRefs` helper |
| `src/bin.ts` | Wire in `showUpdateNotice()` + `checkForUpdateInBackground()` before `runMain` |
| `test/src/services/update-check.test.ts` | 23 tests: pure logic, notice display, background fetch (mock + real HTTP) |
| `test/__utils__/http-server.ts` | Shared `withHttpServer` helper (extracted from `upgrade-binary.test.ts`) |

## Test plan

- [x] `pnpm typecheck` passes (all 7 tasks)
- [x] `pnpm vitest run test/src/services/update-check.test.ts` — 23 tests pass
- [x] `pnpm vitest run test/src/services/upgrade-binary.test.ts` — 3 tests pass (refactored to shared helper)
- [ ] Manual: delete `~/.composio/update-check.json`, run any `composio` command, verify no notice appears on first run, then after 24h (or by editing the file's `lastChecked`) verify the notice appears