### PR TITLE
fix: enable mobile scrolling in docs search dialog

### DIFF
--- a/docs/app/global.css
+++ b/docs/app/global.css
@@ -556,6 +556,25 @@ p.text-fd-muted-foreground.not-prose:has(> code.text-xs) {
   color: var(--color-green-500);
 }
 
+/* ==========================================================================
+   Search Dialog – Mobile Scroll Fix
+   On mobile, when the keyboard opens the viewport shrinks. Constrain the
+   search result list to the remaining space so it stays scrollable.
+   ========================================================================== */
+
+@media (max-width: 767px) {
+  /* Let the list wrapper (SearchDialogList outer div) shrink within the flex column */
+  [role="dialog"].fixed > div[data-empty] {
+    min-height: 0;
+    flex: 1 1 0%;
+  }
+
+  /* Override the fixed max-h-[460px] on the inner scrollable div */
+  [role="dialog"].fixed > div[data-empty] > div {
+    max-height: 100%;
+  }
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/docs/app/global.css
+++ b/docs/app/global.css
@@ -563,14 +563,8 @@ p.text-fd-muted-foreground.not-prose:has(> code.text-xs) {
    ========================================================================== */
 
 @media (max-width: 767px) {
-  /* Let the list wrapper (SearchDialogList outer div) shrink within the flex column */
-  [role="dialog"].fixed > div[data-empty] {
-    min-height: 0;
-    flex: 1 1 0%;
-  }
-
-  /* Override the fixed max-h-[460px] on the inner scrollable div */
-  [role="dialog"].fixed > div[data-empty] > div {
+  /* Override the fixed max-h-[460px] on the inner scrollable div inside SearchDialogList */
+  .search-scroll-container > div > div {
     max-height: 100%;
   }
 }

--- a/docs/components/custom-search-dialog.tsx
+++ b/docs/components/custom-search-dialog.tsx
@@ -63,25 +63,27 @@ export default function CustomSearchDialog({
           <SearchDialogInput />
           <SearchDialogClose />
         </SearchDialogHeader>
-        {query.data === 'empty' && defaultLinks.length > 0 ? (
-          <div className="flex flex-col p-2">
-            {defaultLinks.map((link) => (
-              <Link
-                key={link.href}
-                href={link.href}
-                onClick={() => props.onOpenChange(false)}
-                className="rounded-lg px-2.5 py-2 text-start text-sm transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground"
-              >
-                <p className="font-medium">{link.title}</p>
-                <p className="text-xs text-fd-muted-foreground">
-                  {link.description}
-                </p>
-              </Link>
-            ))}
-          </div>
-        ) : (
-          <SearchDialogList items={query.data === 'empty' ? null : query.data} />
-        )}
+        <div className="search-scroll-container max-md:min-h-0 max-md:flex-1 max-md:overflow-hidden">
+          {query.data === 'empty' && defaultLinks.length > 0 ? (
+            <div className="flex flex-col p-2">
+              {defaultLinks.map((link) => (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  onClick={() => props.onOpenChange(false)}
+                  className="rounded-lg px-2.5 py-2 text-start text-sm transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground"
+                >
+                  <p className="font-medium">{link.title}</p>
+                  <p className="text-xs text-fd-muted-foreground">
+                    {link.description}
+                  </p>
+                </Link>
+              ))}
+            </div>
+          ) : (
+            <SearchDialogList items={query.data === 'empty' ? null : query.data} />
+          )}
+        </div>
         <div className="flex items-center justify-between border-t px-3 py-2">
           <button
             type="button"

--- a/docs/components/custom-search-dialog.tsx
+++ b/docs/components/custom-search-dialog.tsx
@@ -63,7 +63,7 @@ export default function CustomSearchDialog({
           <SearchDialogInput />
           <SearchDialogClose />
         </SearchDialogHeader>
-        <div className="search-scroll-container max-md:min-h-0 max-md:flex-1 max-md:overflow-hidden">
+        <div className="search-scroll-container max-md:min-h-0 max-md:flex-1 max-md:overflow-y-auto">
           {query.data === 'empty' && defaultLinks.length > 0 ? (
             <div className="flex flex-col p-2">
               {defaultLinks.map((link) => (

--- a/docs/components/custom-search-dialog.tsx
+++ b/docs/components/custom-search-dialog.tsx
@@ -57,7 +57,7 @@ export default function CustomSearchDialog({
       {...props}
     >
       <SearchDialogOverlay />
-      <SearchDialogContent>
+      <SearchDialogContent className="max-md:max-h-[calc(100dvh-2rem)] max-md:flex max-md:flex-col">
         <SearchDialogHeader>
           <SearchDialogIcon />
           <SearchDialogInput />


### PR DESCRIPTION
## Summary
- Search results were unscrollable on mobile (especially with keyboard open) because the dialog had no viewport-height constraint and the inner list used a fixed `max-h-[460px]` that overflowed
- Constrain `SearchDialogContent` to `100dvh` on mobile with flex layout so the results list shrinks to available space
- Override the inner list's fixed max-height via CSS media query so it fills remaining room instead of overflowing

## Test plan
- [ ] Open docs.composio.dev on a mobile device (or Chrome DevTools mobile emulation)
- [ ] Open the search dialog and type a query
- [ ] Verify the results list is scrollable, including when the soft keyboard is open
- [ ] Verify desktop search dialog is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)