### PR TITLE
fix: Ask AI widget toggle and layout stability

### DIFF
--- a/docs/app/global.css
+++ b/docs/app/global.css
@@ -554,6 +554,17 @@ p.text-fd-muted-foreground.not-prose:has(> code.text-xs) {
   }
 }
 
+/* ==========================================================================
+   Decimal AI Widget – Push-Sidebar Transition
+   The widget sets body.style.maxWidth inline when opening. Smooth it out
+   and prevent horizontal overflow while the sidebar animates.
+   ========================================================================== */
+
+body {
+  overflow-x: hidden;
+  transition: max-width 0.3s ease;
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/docs/components/ai-tools-banner.tsx
+++ b/docs/components/ai-tools-banner.tsx
@@ -38,7 +38,7 @@ function CopyableCommand({ text }: { text: string }) {
 
 export function AIToolsBanner() {
   return (
-    <div className="not-prose relative mt-4 mb-4 sm:mt-6 sm:mb-6 overflow-hidden rounded-xl border border-fd-border bg-fd-card">
+    <div className="not-prose relative mt-4 mb-4 sm:mt-6 sm:mb-6 overflow-hidden rounded-xl border border-fd-border bg-fd-card @container">
       {/* Shader gradient blobs — same as PromptBanner */}
       <div
         className="pointer-events-none absolute -left-16 -top-24 h-64 w-64 rounded-full"
@@ -64,7 +64,7 @@ export function AIToolsBanner() {
         </div>
 
         {/* Two-column: Skills + CLI */}
-        <div className="flex flex-col gap-3 md:flex-row md:gap-4">
+        <div className="flex flex-col gap-3 @md:flex-row @md:gap-4">
           {/* Skills */}
           <div className="flex flex-1 flex-col gap-1">
             <span className="text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--composio-orange)]">Skills</span>

--- a/docs/components/ai-tools-banner.tsx
+++ b/docs/components/ai-tools-banner.tsx
@@ -64,7 +64,7 @@ export function AIToolsBanner() {
         </div>
 
         {/* Two-column: Skills + CLI */}
-        <div className="flex flex-col gap-3 @md:flex-row @md:gap-4">
+        <div className="flex flex-col gap-3 @2xl:flex-row @2xl:gap-4">
           {/* Skills */}
           <div className="flex flex-1 flex-col gap-1">
             <span className="text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--composio-orange)]">Skills</span>

--- a/docs/components/ai-tools-banner.tsx
+++ b/docs/components/ai-tools-banner.tsx
@@ -64,7 +64,7 @@ export function AIToolsBanner() {
         </div>
 
         {/* Two-column: Skills + CLI */}
-        <div className="flex flex-col gap-3 sm:flex-row sm:gap-4">
+        <div className="flex flex-col gap-3 md:flex-row md:gap-4">
           {/* Skills */}
           <div className="flex flex-1 flex-col gap-1">
             <span className="text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--composio-orange)]">Skills</span>

--- a/docs/components/ask-ai-button.tsx
+++ b/docs/components/ask-ai-button.tsx
@@ -11,19 +11,20 @@ function getDecimal() {
   return (window as typeof window & { Decimal?: DecimalAPI }).Decimal;
 }
 
-let widgetOpen = false;
+function isWidgetVisible(): boolean {
+  const sidebar = document.querySelector('.decimal-widget-sidebar');
+  return sidebar?.classList.contains('open') ?? false;
+}
 
 export function toggleDecimalWidget() {
   const decimal = getDecimal();
   if (!decimal) {
     setTimeout(() => {
       getDecimal()?.show();
-      widgetOpen = true;
     }, 500);
     return;
   }
-  widgetOpen ? decimal.hide() : decimal.show();
-  widgetOpen = !widgetOpen;
+  isWidgetVisible() ? decimal.hide() : decimal.show();
 }
 
 export function detectMac(): boolean {


### PR DESCRIPTION
## Summary
- Adds `overflow-x: hidden` and `transition: max-width 0.3s ease` to body so the Decimal push-sidebar animates smoothly without causing horizontal scroll
- Replaces stale module-level `widgetOpen` boolean with a DOM query (`.decimal-widget-sidebar.open`) so the toggle stays in sync when the widget is closed by the user directly
- Bumps the AI tools banner two-column breakpoint from `sm` to `md` so it stacks gracefully when the sidebar squeezes the content area on narrower viewports

## Test plan
- [ ] Open docs landing page, click "Ask AI" — sidebar should push content smoothly without horizontal scroll
- [ ] Close the widget via its own close button, then click "Ask AI" again — should re-open (not silently hide)
- [ ] Verify the "For AI tools" banner stacks to single column when sidebar is open on ~1024px screens
- [ ] Test on mobile (375px viewport) — sidebar overlay should not break layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)