### PR TITLE
docs: remove internal API from troubleshooting

### DIFF
--- a/docs/content/docs/troubleshooting/tools.mdx
+++ b/docs/content/docs/troubleshooting/tools.mdx
@@ -9,19 +9,7 @@ Authentication and permission errors typically occur due to:
 
 ### Missing scopes
 
-Check if your connection has the required scopes using this API:
-
-```bash
-curl --location 'https://backend.composio.dev/api/v3/tools/get_scopes_required' \
---header 'x-api-key: YOUR_COMPOSIO_API_KEY' \
---header 'Content-Type: application/json' \
---data '{
-    "tools": [
-        "SLACK_SENDS_A_MESSAGE_TO_A_SLACK_CHANNEL",
-        "SLACK_CREATE_A_REMINDER"
-    ]
-}'
-```
+The tool you're calling may require OAuth scopes that weren't granted when the user authenticated. Re-authenticate the user with the required scopes, or check the toolkit's documentation for which scopes each tool needs.
 
 ### Insufficient permissions
 


### PR DESCRIPTION
## Summary
- Removes the `get_scopes_required` internal API endpoint from the public troubleshooting docs
- Replaces with general guidance about re-authenticating with required scopes

## Test plan
- [ ] Verify page renders at `/docs/troubleshooting/tools`
- [ ] Run `bun run scripts/validate-links.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)