### PR TITLE
docs: hide Composio Connect page from navigation

### DIFF
--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -47,12 +47,6 @@ Composio powers 1000+ toolkits, tool search, context management, authentication,
     href="https://platform.composio.dev/auth?next_page=%2Ftool-router"
     description="Try Composio in your browser without writing any code."
   />
-  <Card
-    icon={<Plug />}
-    title="Composio Connect"
-    href="/docs/composio-connect"
-    description="Add Composio tools to Claude Code, Codex, OpenClaw, Claude Desktop, and other AI clients via MCP."
-  />
 </Cards>
 
 ## Providers

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -3,7 +3,6 @@
     "---Get Started---",
     "index",
     "quickstart",
-    "composio-connect",
     "providers",
     "cli",
     "---Core Concepts---",


### PR DESCRIPTION
## Summary
- Remove Composio Connect from the sidebar navigation (`meta.json`)
- Remove the Composio Connect card from the welcome/index page
- The page itself (`/docs/composio-connect`) remains accessible via direct URL

## Test plan
- [ ] Verify Composio Connect no longer appears in the sidebar nav
- [ ] Verify the welcome page no longer shows the Composio Connect card
- [ ] Verify `/docs/composio-connect` still loads correctly via direct URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)