### PR TITLE
feat: add CLI install health check workflow

### DIFF
--- a/.github/workflows/cli.install-health-check.yml
+++ b/.github/workflows/cli.install-health-check.yml
@@ -1,0 +1,44 @@
+name: CLI Install Health Check
+
+on:
+  schedule:
+    # Run every hour at minute 0
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+jobs:
+  health-check:
+    name: Test CLI Installation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test install script from composio.dev
+        id: install
+        run: |
+          if curl -fsSL https://composio.dev/install | bash; then
+            echo "success=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "success=false" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+      - name: Verify installation
+        if: steps.install.outcome == 'success'
+        run: |
+          export PATH="$HOME/.composio/bin:$PATH"
+          if composio --version; then
+            echo "✅ CLI installation verified"
+          else
+            echo "❌ CLI binary failed to execute"
+            exit 1
+          fi
+
+      - name: Send Slack Notification (Failure)
+        if: failure()
+        uses: slackapi/slack-github-action@fcfb566f8b0aab22203f066d80ca1d7e4b5d05b3 # v1.27.1
+        with:
+          payload: |
+            {
+              "text": "⚠️ CLI Install Health Check Failed!\n*Repository:* ${{ github.repository }}\n*Workflow:* ${{ github.workflow }}\n*Run:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Commit:* ${{ github.sha }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary
Adds a new workflow that runs every hour to verify the CLI installation from `curl -fsSL https://composio.dev/install | bash` succeeds.

## Changes
- **Schedule**: Runs every hour via cron (`0 * * * *`)
- **Install test**: Executes the install script from composio.dev
- **Verification**: Confirms `composio --version` works after install
- **Slack alert**: On failure, sends notification to the release Slack channel (same as ts.release.yml)
- **Manual trigger**: Supports `workflow_dispatch` for on-demand testing

## Notes
- Uses `SLACK_RELEASE_WEBHOOK_URL` secret (same as release workflow)
- Scheduled runs only execute from the default branch

Made with [Cursor](https://cursor.com)