### PR TITLE
fix: source shell config before verifying CLI installation

### DIFF
--- a/.github/workflows/cli.install-health-check.yml
+++ b/.github/workflows/cli.install-health-check.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Verify installation
         if: steps.install.outcome == 'success'
         run: |
+          source ~/.bashrc 2>/dev/null || source ~/.zshrc 2>/dev/null || true
           export PATH="$HOME/.composio/bin:$PATH"
           if composio --version; then
             echo "✅ CLI installation verified"

--- a/.github/workflows/cli.install-health-check.yml
+++ b/.github/workflows/cli.install-health-check.yml
@@ -1,0 +1,44 @@
+name: CLI Install Health Check
+
+on:
+  schedule:
+    # Run every hour at minute 0
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+jobs:
+  health-check:
+    name: Test CLI Installation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test install script from composio.dev
+        id: install
+        run: |
+          if curl -fsSL https://composio.dev/install | bash; then
+            echo "success=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "success=false" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+      - name: Verify installation
+        if: steps.install.outcome == 'success'
+        run: |
+          export PATH="$HOME/.composio/bin:$PATH"
+          if composio --version; then
+            echo "✅ CLI installation verified"
+          else
+            echo "❌ CLI binary failed to execute"
+            exit 1
+          fi
+
+      - name: Send Slack Notification (Failure)
+        if: failure()
+        uses: slackapi/slack-github-action@fcfb566f8b0aab22203f066d80ca1d7e4b5d05b3 # v1.27.1
+        with:
+          payload: |
+            {
+              "text": "⚠️ CLI Install Health Check Failed!\n*Repository:* ${{ github.repository }}\n*Workflow:* ${{ github.workflow }}\n*Run:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Commit:* ${{ github.sha }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary
Follow-up to #2884. Sources `~/.bashrc` or `~/.zshrc` before running `composio --version` so the install script's PATH changes are applied in the current shell.

Made with [Cursor](https://cursor.com)