### PR TITLE
docs: remove OAuth2 token import, add auth scheme reference

### DIFF
--- a/docs/content/docs/importing-existing-connections.mdx
+++ b/docs/content/docs/importing-existing-connections.mdx
@@ -1,91 +1,35 @@
 ---
 title: Importing existing connections
-description: Pass existing OAuth tokens, API keys, or other credentials into Composio so your users don't need to re-authenticate
+description: Pass existing API keys, bearer tokens, or other non-OAuth credentials into Composio so your users don't need to re-authenticate
 keywords: [import connections, existing tokens, pass through credentials, bring your own tokens, no re-auth, pre-authenticated]
 ---
 
-If your users have already authenticated with a service, say they connected their Google Drive through your app, or you already store their Slack OAuth tokens, you can pass those credentials directly into Composio. No re-authentication required.
+If your users have already authenticated with a service and you have their credentials (API keys, bearer tokens, etc.), you can pass those directly into Composio. No re-authentication required.
 
 This is useful when:
-- Your app already has OAuth tokens for users (e.g., from a Slack or GitHub integration you built)
+- Your app already stores API keys or tokens for users
 - You're adopting Composio and want to onboard existing users without disrupting them
-- Another platform (like Airtable or Retool) already holds credentials for your users' accounts
+- Another platform already holds credentials for your users' accounts
 
 ## How it works
 
-Instead of redirecting users through an OAuth flow, you pass their existing tokens to `connectedAccounts.initiate()` using the `AuthScheme` helpers. Composio creates a connected account directly from those credentials.
+Instead of asking users to authenticate again, you pass their existing credentials to `connectedAccounts.initiate()` using the `AuthScheme` helpers. Composio creates a connected account directly from those credentials.
 
 ```mermaid
 graph LR
-    A[Your existing tokens] --> B[connectedAccounts.initiate]
+    A[Your existing credentials] --> B[connectedAccounts.initiate]
     B --> C[Connected account in Composio]
     C --> D[Execute tools immediately]
 ```
 
 ## Prerequisites
 
-1. **An auth config** for the toolkit you're importing into. See the note below on which type to use.
-2. **The existing credentials** for each user (access tokens, refresh tokens, API keys, etc.)
+1. **An auth config** for the toolkit you're importing into
+2. **The existing credentials** for each user (API keys, bearer tokens, username/password, etc.)
 3. **A user ID** for each user, any string that uniquely identifies them in your system
 
 <Callout type="warn">
-To import OAuth tokens, you must create a [custom auth config](/docs/using-custom-auth-configuration) using the same client ID and secret that originally issued them. You cannot import OAuth tokens into Composio's managed auth config. If you use managed auth, your users will need to re-authenticate through the standard OAuth flow. This does not apply to API keys, bearer tokens, or basic auth, which work with any auth config.
-</Callout>
-
-## OAuth2 tokens
-
-The most common case. You have access tokens (and ideally refresh tokens) from your existing OAuth integration.
-
-<Tabs groupId="language" items={['Python', 'TypeScript']} persist>
-<Tab value="Python">
-```python
-from composio import Composio
-from composio.types import auth_scheme
-
-composio = Composio(api_key="your-api-key")
-
-connection = composio.connected_accounts.initiate(
-    user_id="user_123",
-    auth_config_id="ac_your_auth_config",
-    config=auth_scheme.oauth2({
-        "access_token": "xoxb-existing-slack-token",
-        "refresh_token": "xoxr-existing-refresh-token",  # recommended
-        "expires_in": 3600,  # optional, seconds until expiry
-        "scope": "chat:write,channels:read",  # optional
-    }),
-)
-
-connected_account = connection.wait_for_connection()
-print(f"Connected: {connected_account.id}")
-```
-</Tab>
-<Tab value="TypeScript">
-```typescript
-import { Composio, AuthScheme } from '@composio/core';
-
-const composio = new Composio({ apiKey: 'your-api-key' });
-
-const connection = await composio.connectedAccounts.initiate(
-  'user_123',
-  'ac_your_auth_config',
-  {
-    config: AuthScheme.OAuth2({
-      access_token: 'xoxb-existing-slack-token',
-      refresh_token: 'xoxr-existing-refresh-token',  // recommended
-      expires_in: 3600,  // optional, seconds until expiry
-      scope: 'chat:write,channels:read',  // optional
-    }),
-  }
-);
-
-const connectedAccount = await connection.waitForConnection();
-console.log('Connected:', connectedAccount.id);
-```
-</Tab>
-</Tabs>
-
-<Callout type="info">
-Always include a `refresh_token` when possible. Combined with your auth config's client ID and secret, Composio will automatically refresh tokens when they expire, so the imported connection stays alive long-term.
+Importing existing OAuth tokens (access tokens, refresh tokens) is **not currently supported**. For OAuth-based services (Google, GitHub, Slack, etc.), users must authenticate through the standard [OAuth flow](/docs/tools-direct/authenticating-tools). This page covers importing non-OAuth credentials like API keys, bearer tokens, and basic auth.
 </Callout>
 
 ## API keys


### PR DESCRIPTION
## Summary
- Removed the OAuth2 token import section from the "Importing existing connections" page — the backend doesn't support this flow (connections get stuck in INITIATED state)
- Added a callout warning that OAuth token import is not currently supported
- Added new Auth Scheme Reference page documenting all `AuthScheme` helpers with parameters and code examples
- Cross-linked the new reference page from authenticating-tools, common FAQ, and SDK reference docs

## Test plan
- [ ] Verify `bun run build` passes in `docs/`
- [ ] Check the importing-existing-connections page no longer shows OAuth2 section
- [ ] Check the new auth-scheme-reference page renders correctly
- [ ] Verify cross-links from other pages work

🤖 Generated with [Claude Code](https://claude.com/claude-code)