### PR TITLE
feat: add Soulink agent identity custom tools example

### DIFF
--- a/ts/examples/soulink-identity/README.md
+++ b/ts/examples/soulink-identity/README.md
@@ -1,0 +1,27 @@
+# Soulink Agent Identity Tools
+
+This example registers [Soulink](https://soulink.dev) agent identity verification as custom Composio tools.
+
+## What it adds
+
+Three tools any Composio-connected agent can use:
+
+| Tool | Description |
+|------|-------------|
+| `SOULINK_RESOLVE_AGENT` | Look up agent's verified on-chain identity (.agent name → wallet address) |
+| `SOULINK_CHECK_CREDIT` | Check agent's credit score (0-100, based on peer behavior reports) |
+| `SOULINK_VERIFY_IDENTITY` | Verify agent owns their wallet via EIP-191 signed message |
+
+## Why
+
+Composio connects agents to 250+ tools. Soulink adds the missing identity layer — agents can verify who they're interacting with and check trust scores before calling tools or sharing data.
+
+## Setup
+
+1. Set `COMPOSIO_API_KEY` in `.env`
+2. Run: `pnpm start`
+
+## Links
+
+- [Soulink](https://soulink.dev) — On-chain identity for AI agents
+- [Soulink API](https://soulink.dev/skill.md) — Agent-readable API guide

--- a/ts/examples/soulink-identity/package.json
+++ b/ts/examples/soulink-identity/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "soulink-identity-example",
+  "private": true,
+  "version": "0.1.0",
+  "description": "Example: Soulink agent identity verification as Composio custom tools",
+  "main": "src/index.ts",
+  "scripts": {
+    "clean": "git clean -xdf node_modules",
+    "start": "bun src/index.ts",
+    "dev": "bun --watch src/index.ts",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "composio",
+    "example",
+    "soulink",
+    "agent-identity"
+  ],
+  "author": "",
+  "license": "ISC",
+  "packageManager": "pnpm@10.17.0",
+  "dependencies": {
+    "@composio/core": "workspace:*",
+    "dotenv": "^16.4.1",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.2.9",
+    "typescript": "catalog:"
+  }
+}

--- a/ts/examples/soulink-identity/src/index.ts
+++ b/ts/examples/soulink-identity/src/index.ts
@@ -24,7 +24,7 @@ const SOULINK_API = 'https://soulink.dev/api/v1';
 await composio.tools.createCustomTool({
   slug: 'SOULINK_RESOLVE_AGENT',
   name: 'Resolve agent identity on Soulink',
-  toolkitSlug: 'soulink',
+  toolkitSlug: 'custom',
   description:
     'Look up an agent\'s verified on-chain identity by their .agent name. Returns wallet address, expiration, and registration status.',
   inputParams: z.object({
@@ -33,9 +33,9 @@ await composio.tools.createCustomTool({
   execute: async (input) => {
     const res = await fetch(`${SOULINK_API}/resolve/${encodeURIComponent(input.name)}`);
     if (!res.ok) {
-      return { success: false, error: `Agent ${input.name} not found` };
+      return { successful: false, data: null, error: `Agent ${input.name} not found` };
     }
-    return res.json();
+    return { successful: true, data: await res.json(), error: null };
   },
 });
 
@@ -45,7 +45,7 @@ await composio.tools.createCustomTool({
 await composio.tools.createCustomTool({
   slug: 'SOULINK_CHECK_CREDIT',
   name: 'Check agent credit score on Soulink',
-  toolkitSlug: 'soulink',
+  toolkitSlug: 'custom',
   description:
     'Check an agent\'s on-chain credit score (0-100) based on peer behavior reports. Use this before interacting with unknown agents.',
   inputParams: z.object({
@@ -54,9 +54,9 @@ await composio.tools.createCustomTool({
   execute: async (input) => {
     const res = await fetch(`${SOULINK_API}/credit/${encodeURIComponent(input.name)}`);
     if (!res.ok) {
-      return { success: false, error: `No credit data for ${input.name}` };
+      return { successful: false, data: null, error: `No credit data for ${input.name}` };
     }
-    return res.json();
+    return { successful: true, data: await res.json(), error: null };
   },
 });
 
@@ -66,7 +66,7 @@ await composio.tools.createCustomTool({
 await composio.tools.createCustomTool({
   slug: 'SOULINK_VERIFY_IDENTITY',
   name: 'Verify agent identity on Soulink',
-  toolkitSlug: 'soulink',
+  toolkitSlug: 'custom',
   description:
     'Verify that an agent owns the wallet associated with their .agent name by checking an EIP-191 signed message.',
   inputParams: z.object({
@@ -81,9 +81,9 @@ await composio.tools.createCustomTool({
       body: JSON.stringify(input),
     });
     if (!res.ok) {
-      return { success: false, error: `Verification failed for ${input.name}` };
+      return { successful: false, data: null, error: `Verification failed for ${input.name}` };
     }
-    return res.json();
+    return { successful: true, data: await res.json(), error: null };
   },
 });
 

--- a/ts/examples/soulink-identity/src/index.ts
+++ b/ts/examples/soulink-identity/src/index.ts
@@ -1,0 +1,108 @@
+/**
+ * Soulink Identity Tool Example
+ *
+ * Registers Soulink agent identity verification, credit checking, and
+ * agent resolution as custom Composio tools. Any Composio-connected
+ * agent can then verify identities and check trust scores.
+ *
+ * Soulink: https://soulink.dev
+ */
+
+import { Composio } from '@composio/core';
+import 'dotenv/config';
+import { z } from 'zod';
+
+const composio = new Composio({
+  apiKey: process.env.COMPOSIO_API_KEY,
+});
+
+const SOULINK_API = 'https://soulink.dev/api/v1';
+
+/**
+ * Tool 1: Resolve an agent's on-chain identity
+ */
+await composio.tools.createCustomTool({
+  slug: 'SOULINK_RESOLVE_AGENT',
+  name: 'Resolve agent identity on Soulink',
+  toolkitSlug: 'soulink',
+  description:
+    'Look up an agent\'s verified on-chain identity by their .agent name. Returns wallet address, expiration, and registration status.',
+  inputParams: z.object({
+    name: z.string().describe('Agent name without .agent suffix (e.g., "helper-bot")'),
+  }),
+  execute: async (input) => {
+    const res = await fetch(`${SOULINK_API}/resolve/${encodeURIComponent(input.name)}`);
+    if (!res.ok) {
+      return { success: false, error: `Agent ${input.name} not found` };
+    }
+    return res.json();
+  },
+});
+
+/**
+ * Tool 2: Check an agent's credit score
+ */
+await composio.tools.createCustomTool({
+  slug: 'SOULINK_CHECK_CREDIT',
+  name: 'Check agent credit score on Soulink',
+  toolkitSlug: 'soulink',
+  description:
+    'Check an agent\'s on-chain credit score (0-100) based on peer behavior reports. Use this before interacting with unknown agents.',
+  inputParams: z.object({
+    name: z.string().describe('Agent name without .agent suffix'),
+  }),
+  execute: async (input) => {
+    const res = await fetch(`${SOULINK_API}/credit/${encodeURIComponent(input.name)}`);
+    if (!res.ok) {
+      return { success: false, error: `No credit data for ${input.name}` };
+    }
+    return res.json();
+  },
+});
+
+/**
+ * Tool 3: Verify an agent's identity via signed message
+ */
+await composio.tools.createCustomTool({
+  slug: 'SOULINK_VERIFY_IDENTITY',
+  name: 'Verify agent identity on Soulink',
+  toolkitSlug: 'soulink',
+  description:
+    'Verify that an agent owns the wallet associated with their .agent name by checking an EIP-191 signed message.',
+  inputParams: z.object({
+    name: z.string().describe('Agent name without .agent suffix'),
+    signature: z.string().describe('EIP-191 signature hex string'),
+    message: z.string().describe('Signed message in format: soulink:{name}:{unix_timestamp}'),
+  }),
+  execute: async (input) => {
+    const res = await fetch(`${SOULINK_API}/verify`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    });
+    return res.json();
+  },
+});
+
+console.log('Soulink tools registered successfully');
+
+/**
+ * Demo: use the registered tools
+ */
+async function main() {
+  console.log('Resolving agent identity...');
+  const resolveResult = await composio.tools.execute('SOULINK_RESOLVE_AGENT', {
+    arguments: { name: 'helper-bot' },
+    userId: 'default',
+  });
+  console.log('Resolve result:', resolveResult);
+
+  console.log('\nChecking credit score...');
+  const creditResult = await composio.tools.execute('SOULINK_CHECK_CREDIT', {
+    arguments: { name: 'helper-bot' },
+    userId: 'default',
+  });
+  console.log('Credit result:', creditResult);
+}
+
+main().catch(console.error);

--- a/ts/examples/soulink-identity/src/index.ts
+++ b/ts/examples/soulink-identity/src/index.ts
@@ -80,6 +80,9 @@ await composio.tools.createCustomTool({
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(input),
     });
+    if (!res.ok) {
+      return { success: false, error: `Verification failed for ${input.name}` };
+    }
     return res.json();
   },
 });

--- a/ts/examples/soulink-identity/tsconfig.json
+++ b/ts/examples/soulink-identity/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "esnext",
+    "declaration": true,
+    "declarationDir": "./dist",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

Adds an example showing how to register [Soulink](https://soulink.dev) agent identity verification as custom Composio tools.

## What this adds

- `ts/examples/soulink-identity/` — new example following the `custom-tools` pattern
- Three custom tools any Composio-connected agent can use:

| Tool | Description |
|------|-------------|
| `SOULINK_RESOLVE_AGENT` | Look up agent's verified on-chain identity (.agent name → wallet) |
| `SOULINK_CHECK_CREDIT` | Check agent's credit score (0-100, peer-reported) |
| `SOULINK_VERIFY_IDENTITY` | Verify agent owns their wallet via EIP-191 signature |

## Why this pairing

Composio connects agents to 250+ tools. Soulink adds the missing identity layer — agents can verify who they're interacting with and check trust scores before calling tools or sharing data. No API key needed for read operations.

## Links

- [Soulink](https://soulink.dev) — On-chain identity for AI agents
- [API Guide](https://soulink.dev/skill.md)