### PR TITLE
feat(cli): add --no-wait flag to composio link command

### DIFF
--- a/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
+++ b/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
@@ -30,6 +30,11 @@ const noBrowser = Options.boolean('no-browser').pipe(
   Options.withDescription('Skip auto-opening the browser')
 );
 
+const noWait = Options.boolean('no-wait').pipe(
+  Options.withDefault(false),
+  Options.withDescription('Do not wait for authorization; only print link info')
+);
+
 /**
  * Open the browser and poll until the connected account becomes ACTIVE.
  * On success, outputs valid JSON to stdout for piping (e.g. to jq).
@@ -132,8 +137,8 @@ const waitForActiveConnection = (
  */
 export const connectedAccountsCmd$Link = Command.make(
   'link',
-  { toolkit, authConfig, userId, noBrowser },
-  ({ toolkit, authConfig, userId, noBrowser }) =>
+  { toolkit, authConfig, userId, noBrowser, noWait },
+  ({ toolkit, authConfig, userId, noBrowser, noWait }) =>
     Effect.gen(function* () {
       if (!(yield* requireAuth)) return;
 
@@ -204,13 +209,25 @@ export const connectedAccountsCmd$Link = Command.make(
           return;
         }
 
-        yield* waitForActiveConnection(
-          ui,
-          repo,
-          linkOpt.value.connected_account_id,
-          linkOpt.value.redirect_url,
-          noBrowser
-        );
+        const { connected_account_id: connId, redirect_url: redirectUrl } = linkOpt.value;
+
+        if (noWait) {
+          yield* ui.note(redirectUrl, 'Redirect URL');
+          yield* ui.output(
+            JSON.stringify(
+              {
+                status: 'pending',
+                message: 'Complete authorization by opening the URL',
+                connected_account_id: connId,
+                redirect_url: redirectUrl,
+              },
+              null,
+              2
+            )
+          );
+        } else {
+          yield* waitForActiveConnection(ui, repo, connId, redirectUrl, noBrowser);
+        }
       } else {
         // Path B: Tool Router flow — toolkit is guaranteed Some (validated above)
         const toolkitSlug = Option.getOrThrow(toolkit);
@@ -254,7 +271,24 @@ export const connectedAccountsCmd$Link = Command.make(
           return;
         }
 
-        yield* waitForActiveConnection(ui, repo, connAccountId, redirectUrl, noBrowser);
+        if (noWait) {
+          yield* ui.note(redirectUrl, 'Redirect URL');
+          yield* ui.output(
+            JSON.stringify(
+              {
+                status: 'pending',
+                message: 'Complete authorization by opening the URL',
+                connected_account_id: connAccountId,
+                redirect_url: redirectUrl,
+                toolkit: toolkitSlug,
+              },
+              null,
+              2
+            )
+          );
+        } else {
+          yield* waitForActiveConnection(ui, repo, connAccountId, redirectUrl, noBrowser);
+        }
       }
     })
 ).pipe(Command.withDescription('Link an external account via OAuth redirect.'));

--- a/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.link.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.link.cmd.test.ts
@@ -35,9 +35,9 @@ const testConfigProvider = ConfigProvider.fromMap(
 
 describe('CLI: composio connected-accounts link', () => {
   layer(TestLive({ baseConfigProvider: testConfigProvider, connectedAccountsData }))(
-    '[Given] valid --auth-config and --user-id [Then] creates link and shows URL',
+    '[Given] valid --auth-config and --user-id [Then] creates link and waits (default)',
     it => {
-      it.scoped('creates link and shows redirect URL', () =>
+      it.scoped('creates link and waits for ACTIVE', () =>
         Effect.gen(function* () {
           yield* cli([
             'connected-accounts',
@@ -145,10 +145,48 @@ describe('CLI: composio connected-accounts link', () => {
   );
 
   layer(TestLive({ baseConfigProvider: testConfigProvider, connectedAccountsData }))(
-    '[Given] successful link [Then] outputs valid JSON with success message for jq',
+    '[Given] --no-wait [Then] outputs valid JSON parseable by jq',
+    it => {
+      it.scoped('prints JSON with status pending, connected_account_id, redirect_url', () =>
+        Effect.gen(function* () {
+          yield* cli([
+            'connected-accounts',
+            'link',
+            '--auth-config',
+            'ac_gmail_oauth',
+            '--user-id',
+            'default',
+            '--no-browser',
+            '--no-wait',
+          ]);
+          const lines = yield* MockConsole.getLines({ stripAnsi: true });
+          const output = lines.join('\n');
+
+          expect(output).toContain('"status"');
+          expect(output).toContain('"pending"');
+          expect(output).toContain('"message"');
+          expect(output).toContain('"connected_account_id"');
+          expect(output).toContain('con_test_link');
+          expect(output).toContain('"redirect_url"');
+          expect(output).toContain('https://app.composio.dev/link');
+          // JSON is parseable
+          const jsonMatch = output.match(/\{[\s\S]*"status"[\s\S]*\}/);
+          expect(jsonMatch).toBeTruthy();
+          if (jsonMatch) {
+            const parsed = JSON.parse(jsonMatch[0]);
+            expect(parsed.status).toBe('pending');
+            expect(parsed.connected_account_id).toBe('con_test_link');
+          }
+        })
+      );
+    }
+  );
+
+  layer(TestLive({ baseConfigProvider: testConfigProvider, connectedAccountsData }))(
+    '[Given] default (wait) [Then] waits for ACTIVE and outputs success JSON for jq',
     it => {
       it.scoped(
-        'prints JSON with status, message, connected_account_id, toolkit, redirect_url',
+        'prints JSON with status success, message, connected_account_id, toolkit, redirect_url',
         () =>
           Effect.gen(function* () {
             yield* cli([


### PR DESCRIPTION
## Summary
Adds `--no-wait` flag to `composio link` / `composio connected-accounts link` command.

## Behavior
- **Default (no flag)**: Waits until authorization is completed (opens browser, polls until ACTIVE)
- **`--no-wait`**: Only prints link info and JSON to stdout (JQ-parseable), no waiting

## Output (JQ-parseable)
- **With `--no-wait`**: `status: "pending"`, `connected_account_id`, `redirect_url`, `toolkit` (Tool Router flow)
- **Default (wait)**: `status: "success"` when ACTIVE

## Usage
```bash
# Default: wait for authorization
composio link gmail

# Print info only, no waiting
composio link gmail --no-wait
composio link gmail --no-wait | jq -r '.redirect_url'
```

Made with [Cursor](https://cursor.com)