### PR TITLE
fix: add workflow_dispatch to SDK change sync workflow

### DIFF
--- a/.github/workflows/docs.sdk-change-sync.yml
+++ b/.github/workflows/docs.sdk-change-sync.yml
@@ -31,7 +31,11 @@ jobs:
           BEFORE: ${{ github.event.before }}
           AFTER: ${{ github.event.after }}
         run: |
-          if [[ "$BEFORE" =~ ^0+$ ]] || ! git cat-file -e "$BEFORE" 2>/dev/null; then
+          if [ -z "$AFTER" ] || ! git cat-file -e "$AFTER" 2>/dev/null; then
+            AFTER=$(git rev-parse HEAD)
+          fi
+
+          if [ -z "$BEFORE" ] || [[ "$BEFORE" =~ ^0+$ ]] || ! git cat-file -e "$BEFORE" 2>/dev/null; then
             echo "BEFORE ref unavailable — falling back to HEAD~1"
             BEFORE=$(git rev-parse HEAD~1)
           fi

--- a/.github/workflows/docs.sdk-change-sync.yml
+++ b/.github/workflows/docs.sdk-change-sync.yml
@@ -8,6 +8,7 @@ on:
       - 'ts/packages/cli/src/**'
       - 'ts/packages/providers/*/src/**'
       - 'python/composio/**'
+  workflow_dispatch:
 
 jobs:
   sync-docs:


### PR DESCRIPTION
## Summary
Adds `workflow_dispatch` trigger to `docs.sdk-change-sync.yml` so it can be manually triggered from the Actions UI.

Previously it could only run on push to `next` with SDK path changes.

## Test plan
- [ ] Merge and trigger manually from Actions UI
- [ ] Verify it picks up the latest SDK diff and runs Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>