### PR TITLE
fix: add allowed_tools to claude-code-action workflows

### DIFF
--- a/.github/workflows/docs.sdk-change-sync.yml
+++ b/.github/workflows/docs.sdk-change-sync.yml
@@ -58,6 +58,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_tools: "Read,Write,Edit,Glob,Grep"
           prompt: |
             SDK source code was just updated. Check if any documentation needs to change.
 

--- a/.github/workflows/docs.sync-connect-clients.yml
+++ b/.github/workflows/docs.sync-connect-clients.yml
@@ -53,6 +53,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_tools: "Read,Write,Edit,Glob,Grep,Bash(curl *)"
           prompt: |
             Sync the Composio Connect clients page from the dashboard repo.
 


### PR DESCRIPTION
## Summary
Claude was getting **15 permission denials** when trying to edit docs files because `claude-code-action`'s default sandbox blocks file writes.

Adds `allowed_tools` to both workflows that use `claude-code-action` for file editing:
- `docs.sync-connect-clients.yml` — `Read,Write,Edit,Glob,Grep,Bash(curl *)`
- `docs.sdk-change-sync.yml` — `Read,Write,Edit,Glob,Grep`

The connect clients workflow also needs `Bash(curl *)` for downloading new client logos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)