### PR TITLE
feat(cli): add manage namespace for advanced commands

### DIFF
--- a/.claude/skills/create-cli-e2e/SKILL.md
+++ b/.claude/skills/create-cli-e2e/SKILL.md
@@ -218,10 +218,10 @@ e2e(import.meta.url, {
     let missingArgResult: E2ETestResult;
 
     beforeAll(async () => {
-      missingArgResult = await runCmd('composio tools info');
+      missingArgResult = await runCmd('composio manage tools info');
     }, TIMEOUTS.FIXTURE);
 
-    describe('composio tools info (missing argument)', () => {
+    describe('composio manage tools info (missing argument)', () => {
       it('exits with non-zero code', () => {
         expect(missingArgResult.exitCode).not.toBe(0);
       });
@@ -344,7 +344,7 @@ Commands run inside `sh -c '...'` in a POSIX shell. Rules:
 
 - Use double quotes for flag values with spaces or special chars:
   ```typescript
-  runCmd('composio tools info "GMAIL_SEND_EMAIL"')
+  runCmd('composio manage tools info "GMAIL_SEND_EMAIL"')
   ```
 - Use single quotes inside double-quoted contexts for literal strings.
 - **No bash-isms**: no `[[`, no `$()`, no arrays.

--- a/.claude/skills/implement-cli-command/SKILL.md
+++ b/.claude/skills/implement-cli-command/SKILL.md
@@ -170,7 +170,7 @@ Most commands only use services already provided. The `ComposioToolkitsRepositor
 
 ## Creating a Subcommand Group
 
-For commands like `composio toolkits list`, `composio toolkits info`:
+For commands like `composio manage toolkits list`, `composio manage toolkits info`:
 
 ### Step 1: Create the Directory Structure
 
@@ -178,8 +178,8 @@ For commands like `composio toolkits list`, `composio toolkits info`:
 src/commands/toolkits/
 ├── toolkits.cmd.ts              # Parent command group
 └── commands/
-    ├── toolkits.list.cmd.ts     # composio toolkits list
-    └── toolkits.info.cmd.ts     # composio toolkits info
+    ├── toolkits.list.cmd.ts     # composio manage toolkits list
+    └── toolkits.info.cmd.ts     # composio manage toolkits info
 ```
 
 ### Step 2: Create the Parent Command

--- a/ts/e2e-tests/cli/toolkits/info/README.md
+++ b/ts/e2e-tests/cli/toolkits/info/README.md
@@ -1,6 +1,6 @@
-# CLI `composio toolkits info` Test
+# CLI `composio manage toolkits info` Test
 
-Verifies that `composio toolkits info <slug>` returns detailed toolkit JSON in piped mode, handles invalid slugs gracefully, and supports stdout redirection.
+Verifies that `composio manage toolkits info <slug>` returns detailed toolkit JSON in piped mode, handles invalid slugs gracefully, and supports stdout redirection.
 
 ## What It Tests
 

--- a/ts/e2e-tests/cli/toolkits/info/e2e.test.ts
+++ b/ts/e2e-tests/cli/toolkits/info/e2e.test.ts
@@ -1,5 +1,5 @@
 /**
- * CLI `composio toolkits info` e2e test
+ * CLI `composio manage toolkits info` e2e test
  *
  * Verifies that the info subcommand returns detailed toolkit JSON in piped mode,
  * handles invalid slugs gracefully, and supports stdout redirection.
@@ -35,16 +35,16 @@ e2e(import.meta.url, {
     let missingSlugResult: E2ETestResult;
 
     beforeAll(async () => {
-      validResult = await runCmd('composio toolkits info gmail');
+      validResult = await runCmd('composio manage toolkits info gmail');
       redirectResult = await runCmd({
-        command: 'composio toolkits info gmail > out.json',
+        command: 'composio manage toolkits info gmail > out.json',
         files: ['out.json'],
       });
-      invalidResult = await runCmd('composio toolkits info nonexistent_toolkit_xyz12345');
-      missingSlugResult = await runCmd('composio toolkits info');
+      invalidResult = await runCmd('composio manage toolkits info nonexistent_toolkit_xyz12345');
+      missingSlugResult = await runCmd('composio manage toolkits info');
     }, TIMEOUTS.FIXTURE);
 
-    describe('composio toolkits info gmail (valid slug)', () => {
+    describe('composio manage toolkits info gmail (valid slug)', () => {
       it('exits successfully', () => {
         expect(validResult.exitCode).toBe(0);
       });
@@ -89,7 +89,7 @@ e2e(import.meta.url, {
       });
     });
 
-    describe('composio toolkits info gmail > out.json (stdout redirection)', () => {
+    describe('composio manage toolkits info gmail > out.json (stdout redirection)', () => {
       it('exits successfully', () => {
         expect(redirectResult.exitCode).toBe(0);
       });
@@ -109,7 +109,7 @@ e2e(import.meta.url, {
       });
     });
 
-    describe('composio toolkits info nonexistent_toolkit_xyz12345 (invalid slug)', () => {
+    describe('composio manage toolkits info nonexistent_toolkit_xyz12345 (invalid slug)', () => {
       it('exits successfully (graceful error handling)', () => {
         expect(invalidResult.exitCode).toBe(0);
       });
@@ -123,7 +123,7 @@ e2e(import.meta.url, {
       });
     });
 
-    describe('composio toolkits info (missing slug)', () => {
+    describe('composio manage toolkits info (missing slug)', () => {
       it('exits successfully (optional arg, handler guards)', () => {
         expect(missingSlugResult.exitCode).toBe(0);
       });

--- a/ts/e2e-tests/cli/toolkits/list/README.md
+++ b/ts/e2e-tests/cli/toolkits/list/README.md
@@ -1,6 +1,6 @@
-# CLI `composio toolkits list` Test
+# CLI `composio manage toolkits list` Test
 
-Verifies that `composio toolkits list` returns toolkits as JSON in piped mode with correct `--query` filtering behavior.
+Verifies that `composio manage toolkits list` returns toolkits as JSON in piped mode with correct `--query` filtering behavior.
 
 ## What It Tests
 

--- a/ts/e2e-tests/cli/toolkits/list/e2e.test.ts
+++ b/ts/e2e-tests/cli/toolkits/list/e2e.test.ts
@@ -1,5 +1,5 @@
 /**
- * CLI `composio toolkits list` e2e test
+ * CLI `composio manage toolkits list` e2e test
  *
  * Verifies that the list subcommand returns toolkits as JSON in piped mode,
  * supports --query filtering (exact, prefix, no fuzzy), and respects --limit.
@@ -28,12 +28,12 @@ e2e(import.meta.url, {
     let noFuzzyResult: E2ETestResult;
 
     beforeAll(async () => {
-      exactResult = await runCmd('composio toolkits list --query gmail --limit 1');
-      prefixResult = await runCmd('composio toolkits list --query gmai --limit 1');
-      noFuzzyResult = await runCmd('composio toolkits list --query gmal --limit 1');
+      exactResult = await runCmd('composio manage toolkits list --query gmail --limit 1');
+      prefixResult = await runCmd('composio manage toolkits list --query gmai --limit 1');
+      noFuzzyResult = await runCmd('composio manage toolkits list --query gmal --limit 1');
     }, TIMEOUTS.FIXTURE);
 
-    describe('composio toolkits list --query gmail --limit 1 (exact slug)', () => {
+    describe('composio manage toolkits list --query gmail --limit 1 (exact slug)', () => {
       it('exits successfully', () => {
         expect(exactResult.exitCode).toBe(0);
       });
@@ -67,7 +67,7 @@ e2e(import.meta.url, {
       });
     });
 
-    describe('composio toolkits list --query gmai --limit 1 (prefix search)', () => {
+    describe('composio manage toolkits list --query gmai --limit 1 (prefix search)', () => {
       it('exits successfully', () => {
         expect(prefixResult.exitCode).toBe(0);
       });
@@ -88,7 +88,7 @@ e2e(import.meta.url, {
       });
     });
 
-    describe('composio toolkits list --query gmal --limit 1 (no fuzzy search)', () => {
+    describe('composio manage toolkits list --query gmal --limit 1 (no fuzzy search)', () => {
       it('exits successfully', () => {
         expect(noFuzzyResult.exitCode).toBe(0);
       });

--- a/ts/e2e-tests/cli/toolkits/search/README.md
+++ b/ts/e2e-tests/cli/toolkits/search/README.md
@@ -1,6 +1,6 @@
-# CLI `composio toolkits search` Test
+# CLI `composio manage toolkits search` Test
 
-Verifies that `composio toolkits search <query>` returns matching toolkits as JSON in piped mode, respects `--limit`, supports stdout redirection, and handles queries with no results.
+Verifies that `composio manage toolkits search <query>` returns matching toolkits as JSON in piped mode, respects `--limit`, supports stdout redirection, and handles queries with no results.
 
 ## What It Tests
 

--- a/ts/e2e-tests/cli/toolkits/search/e2e.test.ts
+++ b/ts/e2e-tests/cli/toolkits/search/e2e.test.ts
@@ -1,5 +1,5 @@
 /**
- * CLI `composio toolkits search` e2e test
+ * CLI `composio manage toolkits search` e2e test
  *
  * Verifies that the search subcommand returns matching toolkits as JSON in piped mode,
  * respects --limit, supports stdout redirection, and handles no-result queries.
@@ -35,16 +35,16 @@ e2e(import.meta.url, {
     let noResultsResult: E2ETestResult;
 
     beforeAll(async () => {
-      validResult = await runCmd('composio toolkits search gmail');
-      limitResult = await runCmd('composio toolkits search gmail --limit 1');
+      validResult = await runCmd('composio manage toolkits search gmail');
+      limitResult = await runCmd('composio manage toolkits search gmail --limit 1');
       redirectResult = await runCmd({
-        command: 'composio toolkits search gmail --limit 1 > out.json',
+        command: 'composio manage toolkits search gmail --limit 1 > out.json',
         files: ['out.json'],
       });
-      noResultsResult = await runCmd('composio toolkits search xyznonexistent_abc_12345');
+      noResultsResult = await runCmd('composio manage toolkits search xyznonexistent_abc_12345');
     }, TIMEOUTS.FIXTURE);
 
-    describe('composio toolkits search gmail (known query)', () => {
+    describe('composio manage toolkits search gmail (known query)', () => {
       it('exits successfully', () => {
         expect(validResult.exitCode).toBe(0);
       });
@@ -76,7 +76,7 @@ e2e(import.meta.url, {
       });
     });
 
-    describe('composio toolkits search gmail --limit 1 (with limit)', () => {
+    describe('composio manage toolkits search gmail --limit 1 (with limit)', () => {
       it('exits successfully', () => {
         expect(limitResult.exitCode).toBe(0);
       });
@@ -97,7 +97,7 @@ e2e(import.meta.url, {
       });
     });
 
-    describe('composio toolkits search gmail --limit 1 > out.json (stdout redirection)', () => {
+    describe('composio manage toolkits search gmail --limit 1 > out.json (stdout redirection)', () => {
       it('exits successfully', () => {
         expect(redirectResult.exitCode).toBe(0);
       });
@@ -118,7 +118,7 @@ e2e(import.meta.url, {
       });
     });
 
-    describe('composio toolkits search xyznonexistent_abc_12345 (no results)', () => {
+    describe('composio manage toolkits search xyznonexistent_abc_12345 (no results)', () => {
       it('exits successfully', () => {
         expect(noResultsResult.exitCode).toBe(0);
       });

--- a/ts/packages/cli/AGENTS.md
+++ b/ts/packages/cli/AGENTS.md
@@ -27,16 +27,17 @@ Errors are captured via the custom `effect-errors/` module, which provides sourc
 
 Each command is declared with `@effect/cli`'s `Command.make()` pattern:
 
-| Command                                                  | Description                                                |
-| -------------------------------------------------------- | ---------------------------------------------------------- |
-| `composio version`                                       | Display CLI version                                        |
-| `composio whoami`                                        | Show logged-in user's API key                              |
-| `composio login [--no-browser] [--no-wait] [--key text]` | Login with browser redirect                                |
-| `composio logout`                                        | Clear stored API key                                       |
-| `composio upgrade`                                       | Self-update binary from GitHub releases                    |
-| `composio generate`                                      | Auto-detect project language, delegate to `ts` or `py`     |
-| `composio ts generate`                                   | Generate TypeScript type stubs for toolkits/tools/triggers |
-| `composio py generate`                                   | Generate Python type stubs                                 |
+| Command                                                  | Description                                                 |
+| -------------------------------------------------------- | ----------------------------------------------------------- |
+| `composio version`                                       | Display CLI version                                         |
+| `composio whoami`                                        | Show logged-in user's API key                               |
+| `composio login [--no-browser] [--no-wait] [--key text]` | Login with browser redirect                                 |
+| `composio logout`                                        | Clear stored API key                                        |
+| `composio upgrade`                                       | Self-update binary from GitHub releases                     |
+| `composio generate`                                      | Auto-detect project language, delegate to `ts` or `py`      |
+| `composio ts generate`                                   | Generate TypeScript type stubs for toolkits/tools/triggers  |
+| `composio py generate`                                   | Generate Python type stubs                                  |
+| `composio manage <subcommand>`                           | Manage Composio resources (toolkits, tools, accounts, etc.) |
 
 Options use `Options.text()`, `Options.boolean()`, `Options.choice()`, `Options.directory()` with Effect Schema validation.
 

--- a/ts/packages/cli/recordings/recordings.yaml
+++ b/ts/packages/cli/recordings/recordings.yaml
@@ -51,92 +51,92 @@ recordings:
   toolkits:
     - name: help
       description: Show toolkits subcommand help
-      command: "composio toolkits --help"
+      command: "composio manage toolkits --help"
       height: dynamic
 
     - name: search-google
       description: Search toolkits by name
-      command: "composio toolkits search google"
+      command: "composio manage toolkits search google"
       height: dynamic
 
     - name: search-google-limit-1
       description: Search with --limit flag
-      command: "composio toolkits search google --limit 1"
+      command: "composio manage toolkits search google --limit 1"
 
     - name: search-gmail
       description: Search for a specific toolkit
-      command: "composio toolkits search gmail"
+      command: "composio manage toolkits search gmail"
       height: dynamic
 
     - name: search-gma
       description: Search with partial match
-      command: "composio toolkits search gma"
+      command: "composio manage toolkits search gma"
       height: dynamic
 
     - name: search-gmax
       description: Search with no results
-      command: "composio toolkits search gmax"
+      command: "composio manage toolkits search gmax"
 
     - name: search-gmail-pipe
       description: Pipe output to JSON
-      command: "composio toolkits search gmail | jq 'first'"
+      command: "composio manage toolkits search gmail | jq 'first'"
       height: dynamic
 
     - name: info
       description: Show info without arguments
-      command: "composio toolkits info"
+      command: "composio manage toolkits info"
 
     - name: info-gmail
       description: Show toolkit details
-      command: "composio toolkits info gmail"
+      command: "composio manage toolkits info gmail"
       height: dynamic
 
     - name: info-gmai
       description: Info with partial match
-      command: "composio toolkits info gmai"
+      command: "composio manage toolkits info gmai"
       height: dynamic
 
     - name: info-gmax
       description: Info with no results
-      command: "composio toolkits info gmax"
+      command: "composio manage toolkits info gmax"
 
     - name: list
       description: List all toolkits
-      command: "composio toolkits list"
+      command: "composio manage toolkits list"
       height: dynamic
 
     - name: list-limit-1
       description: List with --limit flag
-      command: "composio toolkits list --limit 1"
+      command: "composio manage toolkits list --limit 1"
 
     - name: list-query-gmail
       description: List with --query filter
-      command: "composio toolkits list --query 'gmail'"
+      command: "composio manage toolkits list --query 'gmail'"
       height: dynamic
 
     - name: list-query-gmail-limit-1
       description: Combine --query and --limit
-      command: "composio toolkits list --query 'gmail' --limit 1"
+      command: "composio manage toolkits list --query 'gmail' --limit 1"
 
     - name: list-query-gmaxx
       description: List with no results
-      command: "composio toolkits list --query 'gmaxx'"
+      command: "composio manage toolkits list --query 'gmaxx'"
 
   tools:
     - name: help
       description: Show tools subcommand help
-      command: "composio tools --help"
+      command: "composio manage tools --help"
       height: dynamic
 
     - name: execute-help
       description: Show execute subcommand help
-      command: "composio tools execute --help"
+      command: "composio manage tools execute --help"
       height: dynamic
 
     - name: execute-explicit
       description: Execute a tool, with explicit user ID and toolkit version
       command: |-
-        composio tools execute GMAIL_CREATE_EMAIL_DRAFT \
+        composio manage tools execute GMAIL_CREATE_EMAIL_DRAFT \
           -d '{"recipient_email":"to@example.com","subject":"Draft","body":"Draft body"}' \
           --user-id jkomyno \
           --toolkit-version 20250909_00
@@ -144,7 +144,7 @@ recordings:
     - name: execute-failure-no-connected-account
       description: Execeute a tool, with no connected account associated
       command: |-
-        composio tools execute GMAIL_CREATE_EMAIL_DRAFT \
+        composio manage tools execute GMAIL_CREATE_EMAIL_DRAFT \
           -d '{"recipient":"to@example.com","subject":"Draft","body":"Draft body"}' \
           --user-id default
 
@@ -152,115 +152,115 @@ recordings:
       description: Execute a tool, with piped input
       command: |-
         echo '{"recipient_email":"to@example.com","subject":"Hello","body":"From stdin"}' \
-          | composio tools execute GMAIL_SEND_EMAIL \
+          | composio manage tools execute GMAIL_SEND_EMAIL \
             --user-id jkomyno \
           | jq
 
     - name: list-toolkit-gmail
       description: List tools in a toolkit
-      command: "composio tools list --toolkits gmail"
+      command: "composio manage tools list --toolkits gmail"
       height: dynamic
 
     - name: list-toolkit-gmail-limit-3
       description: List with --limit flag
-      command: "composio tools list --toolkits gmail --limit 3"
+      command: "composio manage tools list --toolkits gmail --limit 3"
 
     - name: list-query-send-email
       description: List with --query filter
-      command: "composio tools list --query 'send email'"
+      command: "composio manage tools list --query 'send email'"
       height: dynamic
 
     - name: list-search-no-results
       description: List with no results
-      command: "composio tools list --toolkits 'nonexistent'"
+      command: "composio manage tools list --toolkits 'nonexistent'"
 
     - name: search-send-email
       description: Search tools by use case
-      command: "composio tools search 'send email'"
+      command: "composio manage tools search 'send email'"
       height: dynamic
 
     - name: search-no-results
       description: Search with no results
-      command: "composio tools search 'xyznonexistent'"
+      command: "composio manage tools search 'xyznonexistent'"
 
     - name: info
       description: Show info without arguments
-      command: "composio tools info"
+      command: "composio manage tools info"
 
     - name: info-gmail-send-email
       description: Show tool details
-      command: "composio tools info GMAIL_SEND_EMAIL"
+      command: "composio manage tools info GMAIL_SEND_EMAIL"
       height: dynamic
 
     - name: info-nonexistent
       description: Info with nonexistent tool
-      command: "composio tools info NONEXISTENT_TOOL"
+      command: "composio manage tools info NONEXISTENT_TOOL"
       height: dynamic
 
   auth-configs:
     - name: help
       description: Show auth-configs subcommand help
-      command: "composio auth-configs --help"
+      command: "composio manage auth-configs --help"
       height: dynamic
 
     - name: list
       description: List all auth configs
-      command: "composio auth-configs list"
+      command: "composio manage auth-configs list"
       height: dynamic
 
     - name: list-toolkits-gmail
       description: List filtered by toolkit
-      command: "composio auth-configs list --toolkits gmail"
+      command: "composio manage auth-configs list --toolkits gmail"
       height: dynamic
 
     - name: list-limit-1
       description: List with --limit flag
-      command: "composio auth-configs list --limit 1"
+      command: "composio manage auth-configs list --limit 1"
 
     - name: info
       description: Show info without arguments
-      command: "composio auth-configs info"
+      command: "composio manage auth-configs info"
 
     - name: info-nonexistent
       description: Info with nonexistent ID
-      command: "composio auth-configs info nonexistent_id"
+      command: "composio manage auth-configs info nonexistent_id"
 
     - name: delete
       description: Delete without arguments
-      command: "composio auth-configs delete"
+      command: "composio manage auth-configs delete"
 
   connected-accounts:
     - name: help
       description: Show connected-accounts subcommand help
-      command: "composio connected-accounts --help"
+      command: "composio manage connected-accounts --help"
       height: dynamic
 
     - name: list
       description: List all connected accounts
-      command: "composio connected-accounts list"
+      command: "composio manage connected-accounts list"
       height: dynamic
 
     - name: list-toolkits-gmail
       description: List filtered by toolkit
-      command: "composio connected-accounts list --toolkits gmail"
+      command: "composio manage connected-accounts list --toolkits gmail"
       height: dynamic
 
     - name: list-limit-1
       description: List with --limit flag
-      command: "composio connected-accounts list --limit 1"
+      command: "composio manage connected-accounts list --limit 1"
 
     - name: info
       description: Show info without arguments
-      command: "composio connected-accounts info"
+      command: "composio manage connected-accounts info"
 
     - name: info-nonexistent
       description: Info with nonexistent ID
-      command: "composio connected-accounts info nonexistent_id"
+      command: "composio manage connected-accounts info nonexistent_id"
 
     - name: delete
       description: Delete without arguments
-      command: "composio connected-accounts delete"
+      command: "composio manage connected-accounts delete"
 
     - name: link-no-args
       description: Link without arguments
-      command: "composio connected-accounts link"
+      command: "composio manage connected-accounts link"

--- a/ts/packages/cli/src/commands/auth-configs/auth-configs.cmd.ts
+++ b/ts/packages/cli/src/commands/auth-configs/auth-configs.cmd.ts
@@ -9,7 +9,7 @@ import { authConfigsCmd$Delete } from './commands/auth-configs.delete.cmd';
  *
  * @example
  * ```bash
- * composio auth-configs <command>
+ * composio manage auth-configs <command>
  * ```
  */
 export const authConfigsCmd = Command.make('auth-configs').pipe(

--- a/ts/packages/cli/src/commands/auth-configs/commands/auth-configs.create.cmd.ts
+++ b/ts/packages/cli/src/commands/auth-configs/commands/auth-configs.create.cmd.ts
@@ -40,13 +40,13 @@ const customCredentials = Options.text('custom-credentials').pipe(
  * @example
  * ```bash
  * # Composio-managed defaults
- * composio auth-configs create "my-gmail-config" --toolkit "gmail"
+ * composio manage auth-configs create "my-gmail-config" --toolkit "gmail"
  *
  * # Custom auth with specific scheme
- * composio auth-configs create "custom-gmail" --toolkit "gmail" --auth-scheme "OAUTH2" --scopes "send_email"
+ * composio manage auth-configs create "custom-gmail" --toolkit "gmail" --auth-scheme "OAUTH2" --scopes "send_email"
  *
  * # White-labeling with custom credentials
- * composio auth-configs create "custom-gmail" --toolkit "gmail" --auth-scheme "OAUTH2" --custom-credentials '{"client_id":"...","client_secret":"..."}'
+ * composio manage auth-configs create "custom-gmail" --toolkit "gmail" --auth-scheme "OAUTH2" --custom-credentials '{"client_id":"...","client_secret":"..."}'
  * ```
  */
 export const authConfigsCmd$Create = Command.make(
@@ -67,7 +67,7 @@ export const authConfigsCmd$Create = Command.make(
         } catch {
           yield* ui.log.error('Invalid JSON in --custom-credentials. Please provide valid JSON.');
           yield* ui.log.step(
-            'Example:\n> composio auth-configs create "name" --toolkit "gmail" --custom-credentials \'{"client_id":"...","client_secret":"..."}\''
+            'Example:\n> composio manage auth-configs create "name" --toolkit "gmail" --custom-credentials \'{"client_id":"...","client_secret":"..."}\''
           );
           return;
         }
@@ -117,7 +117,7 @@ export const authConfigsCmd$Create = Command.make(
             'services/HttpServerError',
             handleHttpServerError(ui, {
               fallbackMessage: 'Failed to create auth config.',
-              hint: `Check available auth schemes for "${toolkit}":\n> composio toolkits info "${toolkit}"`,
+              hint: `Check available auth schemes for "${toolkit}":\n> composio manage toolkits info "${toolkit}"`,
               fallbackValue: Option.none(),
             })
           )
@@ -135,7 +135,7 @@ export const authConfigsCmd$Create = Command.make(
       const redactedId = redact({ value: result.auth_config.id, prefix: 'ac_' });
 
       // Next step hint
-      yield* ui.log.step(`To view details:\n> composio auth-configs info "${redactedId}"`);
+      yield* ui.log.step(`To view details:\n> composio manage auth-configs info "${redactedId}"`);
 
       yield* ui.output(JSON.stringify(result, null, 2));
     })

--- a/ts/packages/cli/src/commands/auth-configs/commands/auth-configs.delete.cmd.ts
+++ b/ts/packages/cli/src/commands/auth-configs/commands/auth-configs.delete.cmd.ts
@@ -24,8 +24,8 @@ const yes = Options.boolean('yes').pipe(
  *
  * @example
  * ```bash
- * composio auth-configs delete "ac_1232323"
- * composio auth-configs delete "ac_1232323" --yes
+ * composio manage auth-configs delete "ac_1232323"
+ * composio manage auth-configs delete "ac_1232323" --yes
  * ```
  */
 export const authConfigsCmd$Delete = Command.make('delete', { id, yes }, ({ id, yes }) =>
@@ -39,7 +39,7 @@ export const authConfigsCmd$Delete = Command.make('delete', { id, yes }, ({ id, 
     if (Option.isNone(id)) {
       yield* ui.log.warn('Missing required argument: <id>');
       yield* ui.log.step(
-        'Try specifying an auth config ID, e.g.:\n> composio auth-configs delete "ac_1232323"\n\nTo find auth config IDs:\n> composio auth-configs list'
+        'Try specifying an auth config ID, e.g.:\n> composio manage auth-configs delete "ac_1232323"\n\nTo find auth config IDs:\n> composio manage auth-configs list'
       );
       return;
     }
@@ -66,7 +66,7 @@ export const authConfigsCmd$Delete = Command.make('delete', { id, yes }, ({ id, 
           'services/HttpServerError',
           handleHttpServerError(ui, {
             fallbackMessage: `Failed to delete auth config "${idValue}".`,
-            hint: 'Browse available auth configs:\n> composio auth-configs list',
+            hint: 'Browse available auth configs:\n> composio manage auth-configs list',
             fallbackValue: false,
           })
         )

--- a/ts/packages/cli/src/commands/auth-configs/commands/auth-configs.info.cmd.ts
+++ b/ts/packages/cli/src/commands/auth-configs/commands/auth-configs.info.cmd.ts
@@ -17,7 +17,7 @@ const id = Args.text({ name: 'id' }).pipe(
  *
  * @example
  * ```bash
- * composio auth-configs info "ac_1232323"
+ * composio manage auth-configs info "ac_1232323"
  * ```
  */
 export const authConfigsCmd$Info = Command.make('info', { id }, ({ id }) =>
@@ -31,7 +31,7 @@ export const authConfigsCmd$Info = Command.make('info', { id }, ({ id }) =>
     if (Option.isNone(id)) {
       yield* ui.log.warn('Missing required argument: <id>');
       yield* ui.log.step(
-        'Try specifying an auth config ID, e.g.:\n> composio auth-configs info "ac_1232323"\n\nTo find auth config IDs:\n> composio auth-configs list'
+        'Try specifying an auth config ID, e.g.:\n> composio manage auth-configs info "ac_1232323"\n\nTo find auth config IDs:\n> composio manage auth-configs list'
       );
       return;
     }
@@ -47,7 +47,7 @@ export const authConfigsCmd$Info = Command.make('info', { id }, ({ id }) =>
           'services/HttpServerError',
           handleHttpServerError(ui, {
             fallbackMessage: `Failed to fetch auth config "${idValue}".`,
-            hint: 'Browse available auth configs:\n> composio auth-configs list',
+            hint: 'Browse available auth configs:\n> composio manage auth-configs list',
             fallbackValue: Option.none(),
           })
         )
@@ -65,7 +65,7 @@ export const authConfigsCmd$Info = Command.make('info', { id }, ({ id }) =>
 
     // Next step hint
     yield* ui.log.step(
-      `To delete this auth config:\n> composio auth-configs delete "${redactedId}"`
+      `To delete this auth config:\n> composio manage auth-configs delete "${redactedId}"`
     );
 
     yield* ui.output(JSON.stringify(item, null, 2));

--- a/ts/packages/cli/src/commands/auth-configs/commands/auth-configs.list.cmd.ts
+++ b/ts/packages/cli/src/commands/auth-configs/commands/auth-configs.list.cmd.ts
@@ -29,9 +29,9 @@ const limit = Options.integer('limit').pipe(
  *
  * @example
  * ```bash
- * composio auth-configs list
- * composio auth-configs list --toolkits "gmail"
- * composio auth-configs list --query "my config" --limit 10
+ * composio manage auth-configs list
+ * composio manage auth-configs list --toolkits "gmail"
+ * composio manage auth-configs list --query "my config" --limit 10
  * ```
  */
 export const authConfigsCmd$List = Command.make(
@@ -55,7 +55,7 @@ export const authConfigsCmd$List = Command.make(
 
       if (result.items.length === 0) {
         const hint = Option.isSome(toolkits)
-          ? `No auth configs found for toolkit "${toolkits.value}". Verify the toolkit slug with:\n> composio toolkits list`
+          ? `No auth configs found for toolkit "${toolkits.value}". Verify the toolkit slug with:\n> composio manage toolkits list`
           : 'No auth configs found. Try broadening your search.';
         yield* ui.log.warn(hint);
         return;
@@ -74,7 +74,7 @@ export const authConfigsCmd$List = Command.make(
 
       if (firstId) {
         yield* ui.log.step(
-          `To view details of an auth config:\n> composio auth-configs info "${redactedId}"`
+          `To view details of an auth config:\n> composio manage auth-configs info "${redactedId}"`
         );
       }
 

--- a/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.delete.cmd.ts
+++ b/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.delete.cmd.ts
@@ -24,8 +24,8 @@ const yes = Options.boolean('yes').pipe(
  *
  * @example
  * ```bash
- * composio connected-accounts delete "con_1a2b3c4d5e6f"
- * composio connected-accounts delete "con_1a2b3c4d5e6f" --yes
+ * composio manage connected-accounts delete "con_1a2b3c4d5e6f"
+ * composio manage connected-accounts delete "con_1a2b3c4d5e6f" --yes
  * ```
  */
 export const connectedAccountsCmd$Delete = Command.make('delete', { id, yes }, ({ id, yes }) =>
@@ -39,7 +39,7 @@ export const connectedAccountsCmd$Delete = Command.make('delete', { id, yes }, (
     if (Option.isNone(id)) {
       yield* ui.log.warn('Missing required argument: <id>');
       yield* ui.log.step(
-        'Try specifying a connected account ID, e.g.:\n> composio connected-accounts delete "con_1a2b3c4d5e6f"\n\nTo find connected account IDs:\n> composio connected-accounts list'
+        'Try specifying a connected account ID, e.g.:\n> composio manage connected-accounts delete "con_1a2b3c4d5e6f"\n\nTo find connected account IDs:\n> composio manage connected-accounts list'
       );
       return;
     }
@@ -69,7 +69,7 @@ export const connectedAccountsCmd$Delete = Command.make('delete', { id, yes }, (
           'services/HttpServerError',
           handleHttpServerError(ui, {
             fallbackMessage: `Failed to delete connected account "${idValue}".`,
-            hint: 'Browse available connected accounts:\n> composio connected-accounts list',
+            hint: 'Browse available connected accounts:\n> composio manage connected-accounts list',
             fallbackValue: false,
           })
         )

--- a/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.info.cmd.ts
+++ b/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.info.cmd.ts
@@ -17,7 +17,7 @@ const id = Args.text({ name: 'id' }).pipe(
  *
  * @example
  * ```bash
- * composio connected-accounts info "con_1a2b3c4d5e6f"
+ * composio manage connected-accounts info "con_1a2b3c4d5e6f"
  * ```
  */
 export const connectedAccountsCmd$Info = Command.make('info', { id }, ({ id }) =>
@@ -31,7 +31,7 @@ export const connectedAccountsCmd$Info = Command.make('info', { id }, ({ id }) =
     if (Option.isNone(id)) {
       yield* ui.log.warn('Missing required argument: <id>');
       yield* ui.log.step(
-        'Try specifying a connected account ID, e.g.:\n> composio connected-accounts info "con_1a2b3c4d5e6f"\n\nTo find connected account IDs:\n> composio connected-accounts list'
+        'Try specifying a connected account ID, e.g.:\n> composio manage connected-accounts info "con_1a2b3c4d5e6f"\n\nTo find connected account IDs:\n> composio manage connected-accounts list'
       );
       return;
     }
@@ -46,7 +46,7 @@ export const connectedAccountsCmd$Info = Command.make('info', { id }, ({ id }) =
           'services/HttpServerError',
           handleHttpServerError(ui, {
             fallbackMessage: `Failed to fetch connected account "${idValue}".`,
-            hint: 'Browse available connected accounts:\n> composio connected-accounts list',
+            hint: 'Browse available connected accounts:\n> composio manage connected-accounts list',
             fallbackValue: Option.none(),
           })
         )
@@ -64,7 +64,7 @@ export const connectedAccountsCmd$Info = Command.make('info', { id }, ({ id }) =
 
     // Next step hint
     yield* ui.log.step(
-      `To delete this connected account:\n> composio connected-accounts delete "${redactedId}"`
+      `To delete this connected account:\n> composio manage connected-accounts delete "${redactedId}"`
     );
 
     yield* ui.output(JSON.stringify(item, null, 2));

--- a/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
+++ b/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
@@ -125,14 +125,14 @@ const waitForActiveConnection = (
  * Link an external account via OAuth redirect.
  *
  * Two modes:
- * - **Tool Router** (default): `composio connected-accounts link <toolkit>`
- * - **Legacy**: `composio connected-accounts link --auth-config <id>`
+ * - **Tool Router** (default): `composio manage connected-accounts link <toolkit>`
+ * - **Legacy**: `composio manage connected-accounts link --auth-config <id>`
  *
  * @example
  * ```bash
- * composio connected-accounts link github
- * composio connected-accounts link gmail --user-id "alice"
- * composio connected-accounts link --auth-config "ac_..." --user-id "default"
+ * composio manage connected-accounts link github
+ * composio manage connected-accounts link gmail --user-id "alice"
+ * composio manage connected-accounts link --auth-config "ac_..." --user-id "default"
  * ```
  */
 export const connectedAccountsCmd$Link = Command.make(
@@ -168,8 +168,8 @@ export const connectedAccountsCmd$Link = Command.make(
       if (Option.isSome(toolkit) && Option.isSome(authConfig)) {
         yield* ui.log.error(
           'Cannot use both <toolkit> and --auth-config. Choose one:\n' +
-            '  Tool Router: composio connected-accounts link <toolkit>\n' +
-            '  Legacy:      composio connected-accounts link --auth-config <id>'
+            '  Tool Router: composio manage connected-accounts link <toolkit>\n' +
+            '  Legacy:      composio manage connected-accounts link --auth-config <id>'
         );
         return;
       }
@@ -177,8 +177,8 @@ export const connectedAccountsCmd$Link = Command.make(
       if (Option.isNone(toolkit) && Option.isNone(authConfig)) {
         yield* ui.log.error(
           'Missing argument. Provide a toolkit slug or --auth-config:\n' +
-            '  composio connected-accounts link github\n' +
-            '  composio connected-accounts link --auth-config "ac_..."'
+            '  composio manage connected-accounts link github\n' +
+            '  composio manage connected-accounts link --auth-config "ac_..."'
         );
         return;
       }
@@ -199,7 +199,7 @@ export const connectedAccountsCmd$Link = Command.make(
               'services/HttpServerError',
               handleHttpServerError(ui, {
                 fallbackMessage: `Failed to create link for auth config "${authConfig.value}".`,
-                hint: 'Browse available auth configs:\n> composio auth-configs list',
+                hint: 'Browse available auth configs:\n> composio manage auth-configs list',
                 fallbackValue: Option.none(),
               })
             )
@@ -252,7 +252,7 @@ export const connectedAccountsCmd$Link = Command.make(
                   extractMessage(error) ?? `Failed to create link for toolkit "${toolkitSlug}".`;
                 yield* ui.log.error(message);
                 yield* Effect.logDebug('Link error:', error);
-                yield* ui.log.step('Browse available toolkits:\n> composio toolkits list');
+                yield* ui.log.step('Browse available toolkits:\n> composio manage toolkits list');
                 return Option.none();
               })
             )

--- a/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.list.cmd.ts
+++ b/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.list.cmd.ts
@@ -38,9 +38,9 @@ const limit = Options.integer('limit').pipe(
  *
  * @example
  * ```bash
- * composio connected-accounts list
- * composio connected-accounts list --toolkits "gmail"
- * composio connected-accounts list --user-id "default" --status ACTIVE
+ * composio manage connected-accounts list
+ * composio manage connected-accounts list --toolkits "gmail"
+ * composio manage connected-accounts list --user-id "default" --status ACTIVE
  * ```
  */
 export const connectedAccountsCmd$List = Command.make(
@@ -70,7 +70,7 @@ export const connectedAccountsCmd$List = Command.make(
       if (result.items.length === 0) {
         let hint: string;
         if (Option.isSome(toolkits)) {
-          hint = `No connected accounts found for toolkit "${toolkits.value}". Verify the toolkit slug with:\n> composio toolkits list`;
+          hint = `No connected accounts found for toolkit "${toolkits.value}". Verify the toolkit slug with:\n> composio manage toolkits list`;
         } else if (Option.isSome(userId)) {
           hint = `No connected accounts found for user "${userId.value}".`;
         } else if (Option.isSome(status)) {
@@ -95,7 +95,7 @@ export const connectedAccountsCmd$List = Command.make(
 
       if (firstId) {
         yield* ui.log.step(
-          `To view details of a connected account:\n> composio connected-accounts info "${redactedId}"`
+          `To view details of a connected account:\n> composio manage connected-accounts info "${redactedId}"`
         );
       }
 

--- a/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.whoami.cmd.ts
+++ b/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.whoami.cmd.ts
@@ -20,7 +20,7 @@ const id = Args.text({ name: 'id' }).pipe(
  *
  * @example
  * ```bash
- * composio connected-accounts whoami "con_1a2b3c4d5e6f"
+ * composio manage connected-accounts whoami "con_1a2b3c4d5e6f"
  * ```
  */
 export const connectedAccountsCmd$Whoami = Command.make('whoami', { id }, ({ id }) =>
@@ -34,7 +34,7 @@ export const connectedAccountsCmd$Whoami = Command.make('whoami', { id }, ({ id 
     if (Option.isNone(id)) {
       yield* ui.log.warn('Missing required argument: <id>');
       yield* ui.log.step(
-        'Try specifying a connected account ID, e.g.:\n> composio connected-accounts whoami "con_1a2b3c4d5e6f"\n\nTo find connected account IDs:\n> composio connected-accounts list'
+        'Try specifying a connected account ID, e.g.:\n> composio manage connected-accounts whoami "con_1a2b3c4d5e6f"\n\nTo find connected account IDs:\n> composio manage connected-accounts list'
       );
       return;
     }
@@ -49,7 +49,7 @@ export const connectedAccountsCmd$Whoami = Command.make('whoami', { id }, ({ id 
           'services/HttpServerError',
           handleHttpServerError(ui, {
             fallbackMessage: `Failed to fetch connected account "${idValue}".`,
-            hint: 'Browse available connected accounts:\n> composio connected-accounts list',
+            hint: 'Browse available connected accounts:\n> composio manage connected-accounts list',
             fallbackValue: Option.none(),
           })
         )

--- a/ts/packages/cli/src/commands/connected-accounts/connected-accounts.cmd.ts
+++ b/ts/packages/cli/src/commands/connected-accounts/connected-accounts.cmd.ts
@@ -10,7 +10,7 @@ import { connectedAccountsCmd$Link } from './commands/connected-accounts.link.cm
  *
  * @example
  * ```bash
- * composio connected-accounts <command>
+ * composio manage connected-accounts <command>
  * ```
  */
 export const connectedAccountsCmd = Command.make('connected-accounts').pipe(

--- a/ts/packages/cli/src/commands/index.ts
+++ b/ts/packages/cli/src/commands/index.ts
@@ -13,14 +13,7 @@ import { initCmd } from './init.cmd';
 import { pyCmd } from './py/py.cmd';
 import { tsCmd } from './ts/ts.cmd';
 import { generateCmd } from './generate.cmd';
-import { toolkitsCmd } from './toolkits/toolkits.cmd';
-import { toolsCmd } from './tools/tools.cmd';
-import { authConfigsCmd } from './auth-configs/auth-configs.cmd';
-import { connectedAccountsCmd } from './connected-accounts/connected-accounts.cmd';
-import { triggersCmd } from './triggers/triggers.cmd';
-import { logsCmd } from './logs-cmd/logs.cmd';
-import { orgsCmd } from './orgs/orgs.cmd';
-import { projectsCmd } from './projects/projects.cmd';
+import { manageCmd } from './manage/manage.cmd';
 import { showToolsExecuteInputHelp } from './tools/commands/tools.execute.cmd';
 import { printRootHelp } from './root-help';
 
@@ -36,14 +29,7 @@ const $cmd = $defaultCmd.pipe(
     generateCmd,
     pyCmd,
     tsCmd,
-    toolkitsCmd,
-    toolsCmd,
-    authConfigsCmd,
-    connectedAccountsCmd,
-    triggersCmd,
-    logsCmd,
-    orgsCmd,
-    projectsCmd,
+    manageCmd,
   ])
 );
 
@@ -51,13 +37,13 @@ export const rootCommand = $cmd;
 
 const parseExecuteInputHelpSlug = (argv: ReadonlyArray<string>): string | undefined => {
   const args = argv.slice(2);
-  if (args.length < 3) return undefined;
-  if (args[0] !== 'tools' || args[1] !== 'execute') return undefined;
+  if (args.length < 4) return undefined;
+  if (args[0] !== 'manage' || args[1] !== 'tools' || args[2] !== 'execute') return undefined;
 
   const hasHelp = args.includes('--help') || args.includes('-h');
   if (!hasHelp) return undefined;
 
-  const tail = args.slice(2);
+  const tail = args.slice(3);
   for (let i = 0; i < tail.length; i += 1) {
     const token = tail[i];
     if (!token) continue;
@@ -102,20 +88,20 @@ const normalizeVersionShortFlag = (argv: ReadonlyArray<string>): ReadonlyArray<s
   return argv;
 };
 
-const ALIAS_TO_PARENT: Record<string, string> = {
-  search: 'tools',
-  execute: 'tools',
-  link: 'connected-accounts',
-  listen: 'triggers',
+const ALIAS_TO_PARENT: Record<string, ReadonlyArray<string>> = {
+  search: ['manage', 'tools'],
+  execute: ['manage', 'tools'],
+  link: ['manage', 'connected-accounts'],
+  listen: ['manage', 'triggers'],
 };
 
 const normalizeAliases = (argv: ReadonlyArray<string>): ReadonlyArray<string> => {
   const args = argv.slice(2);
   if (args.length === 0) return argv;
   const first = args[0];
-  const parent = first && ALIAS_TO_PARENT[first];
-  if (!parent) return argv;
-  return [...argv.slice(0, 2), parent, ...args];
+  const parents = first && ALIAS_TO_PARENT[first];
+  if (!parents) return argv;
+  return [...argv.slice(0, 2), ...parents, ...args];
 };
 
 const isRootHelp = (argv: ReadonlyArray<string>): boolean => {

--- a/ts/packages/cli/src/commands/init.cmd.ts
+++ b/ts/packages/cli/src/commands/init.cmd.ts
@@ -348,7 +348,7 @@ const initInteractiveFlow = (params: { composioDir: string; noBrowser: boolean; 
 
     yield* ui.log.success(`Project initialized in ${composioDir}/`);
     yield* ui.log.info(
-      'To switch your default global org/project later, run `composio orgs switch`.'
+      'To switch your default global org/project later, run `composio manage orgs switch`.'
     );
     yield* ui.output(makeOutputJson(selected, composioDir));
     yield* ui.outro('');

--- a/ts/packages/cli/src/commands/login.cmd.ts
+++ b/ts/packages/cli/src/commands/login.cmd.ts
@@ -119,7 +119,7 @@ const storeCredentials = (params: {
         'Run `composio init` in your project directory to set up project context.'
       );
       yield* ui.log.info(
-        'To switch your default global org/project later, run `composio orgs switch`.'
+        'To switch your default global org/project later, run `composio manage orgs switch`.'
       );
     }
 
@@ -261,7 +261,7 @@ const loginWithKey = (params: { key: string; noWait: boolean; skipOrgProjectPick
         'Run `composio init` in your project directory to set up project context.'
       );
       yield* ui.log.info(
-        'To switch your default global org/project later, run `composio orgs switch`.'
+        'To switch your default global org/project later, run `composio manage orgs switch`.'
       );
       yield* ui.outro("You're all set!");
     }
@@ -430,7 +430,7 @@ export const browserLogin = (params: {
         'Run `composio init` in your project directory to set up project context.'
       );
       yield* ui.log.info(
-        'To switch your default global org/project later, run `composio orgs switch`.'
+        'To switch your default global org/project later, run `composio manage orgs switch`.'
       );
       yield* ui.outro("You're all set!");
     }

--- a/ts/packages/cli/src/commands/logs-cmd/commands/logs.tools.cmd.ts
+++ b/ts/packages/cli/src/commands/logs-cmd/commands/logs.tools.cmd.ts
@@ -117,12 +117,12 @@ const logId = Args.text({ name: 'log_id' }).pipe(
  *
  * @example
  * ```bash
- * composio logs tools --limit 50
- * composio logs tools <log_id>
- * composio logs tools --toolkit gmail --tool GMAIL_SEND_EMAIL
- * composio logs tools --connected-account-id con_123 --user-id user_123
- * composio logs tools --status success --auth-config-id ac_123
- * composio logs tools --from 1735689600000 --to 1735776000000
+ * composio manage logs tools --limit 50
+ * composio manage logs tools <log_id>
+ * composio manage logs tools --toolkit gmail --tool GMAIL_SEND_EMAIL
+ * composio manage logs tools --connected-account-id con_123 --user-id user_123
+ * composio manage logs tools --status success --auth-config-id ac_123
+ * composio manage logs tools --from 1735689600000 --to 1735776000000
  * ```
  */
 export const logsCmd$Tools = Command.make(
@@ -223,7 +223,7 @@ export const logsCmd$Tools = Command.make(
       const firstLogId = logs[0]?.id;
       if (firstLogId) {
         yield* ui.log.step(
-          `To view full details for a log:\n> composio logs tools "${firstLogId}"`
+          `To view full details for a log:\n> composio manage logs tools "${firstLogId}"`
         );
       }
 

--- a/ts/packages/cli/src/commands/logs-cmd/commands/logs.triggers.cmd.ts
+++ b/ts/packages/cli/src/commands/logs-cmd/commands/logs.triggers.cmd.ts
@@ -78,11 +78,11 @@ const includePayload = Options.boolean('include-payload').pipe(
  *
  * @example
  * ```bash
- * composio logs triggers <log_id>
- * composio logs triggers --trigger GMAIL_NEW_GMAIL_MESSAGE
- * composio logs triggers --trigger-id 77ac1dbf-6db0-4039-8dbe-e903b3f2057e
- * composio logs triggers --connected-account-id ca_123 --user-id user_123
- * composio logs triggers --log-id log_123
+ * composio manage logs triggers <log_id>
+ * composio manage logs triggers --trigger GMAIL_NEW_GMAIL_MESSAGE
+ * composio manage logs triggers --trigger-id 77ac1dbf-6db0-4039-8dbe-e903b3f2057e
+ * composio manage logs triggers --connected-account-id ca_123 --user-id user_123
+ * composio manage logs triggers --log-id log_123
  * ```
  */
 export const logsCmd$Triggers = Command.make(
@@ -193,7 +193,7 @@ export const logsCmd$Triggers = Command.make(
       const firstLogId = logs[0]?.id;
       if (firstLogId) {
         yield* ui.log.step(
-          `To view full details for a log:\n> composio logs triggers "${firstLogId}"`
+          `To view full details for a log:\n> composio manage logs triggers "${firstLogId}"`
         );
       }
 

--- a/ts/packages/cli/src/commands/logs-cmd/logs.cmd.ts
+++ b/ts/packages/cli/src/commands/logs-cmd/logs.cmd.ts
@@ -7,7 +7,7 @@ import { logsCmd$Triggers } from './commands/logs.triggers.cmd';
  *
  * @example
  * ```bash
- * composio logs <command>
+ * composio manage logs <command>
  * ```
  */
 export const logsCmd = Command.make('logs').pipe(

--- a/ts/packages/cli/src/commands/manage/manage.cmd.ts
+++ b/ts/packages/cli/src/commands/manage/manage.cmd.ts
@@ -1,0 +1,36 @@
+import { Command } from '@effect/cli';
+import { toolkitsCmd } from '../toolkits/toolkits.cmd';
+import { toolsCmd } from '../tools/tools.cmd';
+import { authConfigsCmd } from '../auth-configs/auth-configs.cmd';
+import { connectedAccountsCmd } from '../connected-accounts/connected-accounts.cmd';
+import { triggersCmd } from '../triggers/triggers.cmd';
+import { logsCmd } from '../logs-cmd/logs.cmd';
+import { orgsCmd } from '../orgs/orgs.cmd';
+import { projectsCmd } from '../projects/projects.cmd';
+
+/**
+ * CLI entry point for management commands.
+ *
+ * Groups toolkits, tools, auth-configs, connected-accounts, triggers, logs, orgs, and projects
+ * under a single `composio manage` namespace.
+ *
+ * @example
+ * ```bash
+ * composio manage <command>
+ * composio manage toolkits list
+ * composio manage tools search "send email"
+ * ```
+ */
+export const manageCmd = Command.make('manage').pipe(
+  Command.withDescription('Manage Composio resources — toolkits, tools, accounts, triggers, logs, orgs, and projects.'),
+  Command.withSubcommands([
+    toolkitsCmd,
+    toolsCmd,
+    authConfigsCmd,
+    connectedAccountsCmd,
+    triggersCmd,
+    logsCmd,
+    orgsCmd,
+    projectsCmd,
+  ])
+);

--- a/ts/packages/cli/src/commands/orgs/commands/orgs.list.cmd.ts
+++ b/ts/packages/cli/src/commands/orgs/commands/orgs.list.cmd.ts
@@ -26,7 +26,7 @@ export const orgsCmd$List = Command.make('list', { limit }, ({ limit }) =>
     const clampedLimit = clampLimit(limit);
     const defaultOrgId = Option.getOrUndefined(ctx.data.orgId);
 
-    yield* ui.intro(`composio orgs list`);
+    yield* ui.intro(`composio manage orgs list`);
 
     const organizations = yield* ui.withSpinner(
       'Loading organizations...',
@@ -51,7 +51,9 @@ export const orgsCmd$List = Command.make('list', { limit }, ({ limit }) =>
       return `${isSelected ? '✓' : ' '} ${org.name} (${org.id})`;
     });
     yield* ui.log.info(lines.join('\n'));
-    yield* ui.outro('Hint: run `composio orgs switch` to switch the default global org/project.');
+    yield* ui.outro(
+      'Hint: run `composio manage orgs switch` to switch the default global org/project.'
+    );
 
     yield* ui.output(
       JSON.stringify(

--- a/ts/packages/cli/src/commands/orgs/commands/orgs.switch.cmd.ts
+++ b/ts/packages/cli/src/commands/orgs/commands/orgs.switch.cmd.ts
@@ -29,7 +29,7 @@ export const orgsCmd$Switch = Command.make(
 
       const ui = yield* TerminalUI;
       const ctx = yield* ComposioUserContext;
-      yield* ui.intro('composio orgs switch');
+      yield* ui.intro('composio manage orgs switch');
 
       const apiKey = Option.getOrUndefined(ctx.data.apiKey);
       if (!apiKey) {

--- a/ts/packages/cli/src/commands/projects/commands/projects.list.cmd.ts
+++ b/ts/packages/cli/src/commands/projects/commands/projects.list.cmd.ts
@@ -22,7 +22,7 @@ export const projectsCmd$List = Command.make('list', { orgId, limit }, ({ orgId,
 
     const ui = yield* TerminalUI;
     const ctx = yield* ComposioUserContext;
-    yield* ui.intro('composio projects list');
+    yield* ui.intro('composio manage projects list');
     const apiKey = Option.getOrUndefined(ctx.data.apiKey);
     if (!apiKey) {
       yield* ui.log.warn('No user API key found. Run `composio login` first.');
@@ -32,7 +32,7 @@ export const projectsCmd$List = Command.make('list', { orgId, limit }, ({ orgId,
     const resolvedOrgId = Option.getOrUndefined(orgId) ?? Option.getOrUndefined(ctx.data.orgId);
     if (!resolvedOrgId) {
       yield* ui.log.warn('No default org is configured.');
-      yield* ui.outro('Hint: run `composio orgs switch` first, or pass `--org-id`.');
+      yield* ui.outro('Hint: run `composio manage orgs switch` first, or pass `--org-id`.');
       return;
     }
 
@@ -56,7 +56,7 @@ export const projectsCmd$List = Command.make('list', { orgId, limit }, ({ orgId,
 
     if (projects.data.length === 0) {
       yield* ui.log.warn('No projects found.');
-      yield* ui.outro('Hint: run `composio orgs switch` to switch org/project defaults.');
+      yield* ui.outro('Hint: run `composio manage orgs switch` to switch org/project defaults.');
       return;
     }
 
@@ -67,8 +67,8 @@ export const projectsCmd$List = Command.make('list', { orgId, limit }, ({ orgId,
     yield* ui.log.step(lines.join('\n'));
     yield* ui.outro(
       [
-        'Hint: run `composio projects switch` to switch the default global project.',
-        'Run `composio orgs switch` to switch org and project together.',
+        'Hint: run `composio manage projects switch` to switch the default global project.',
+        'Run `composio manage orgs switch` to switch org and project together.',
       ].join('\n')
     );
 

--- a/ts/packages/cli/src/commands/projects/commands/projects.switch.cmd.ts
+++ b/ts/packages/cli/src/commands/projects/commands/projects.switch.cmd.ts
@@ -58,7 +58,7 @@ export const projectsCmd$Switch = Command.make(
 
       const ui = yield* TerminalUI;
       const ctx = yield* ComposioUserContext;
-      yield* ui.intro('composio projects switch');
+      yield* ui.intro('composio manage projects switch');
 
       const apiKey = Option.getOrUndefined(ctx.data.apiKey);
       if (!apiKey) {
@@ -70,7 +70,7 @@ export const projectsCmd$Switch = Command.make(
       const resolvedOrgId = Option.getOrUndefined(orgId) ?? Option.getOrUndefined(ctx.data.orgId);
       if (!resolvedOrgId) {
         yield* ui.log.warn('No default org is configured.');
-        yield* ui.log.info('Run `composio orgs switch` to select org and project globally.');
+        yield* ui.log.info('Run `composio manage orgs switch` to select org and project globally.');
         yield* ui.outro('');
         return;
       }
@@ -79,7 +79,7 @@ export const projectsCmd$Switch = Command.make(
       const explicitProjectId = Option.getOrUndefined(projectId);
 
       yield* ui.note(
-        'This updates your default global project context. To switch organization, use `composio orgs switch`.',
+        'This updates your default global project context. To switch organization, use `composio manage orgs switch`.',
         'Global defaults'
       );
       yield* ui.log.info(`Using organization: ${resolvedOrgId}`);
@@ -94,7 +94,7 @@ export const projectsCmd$Switch = Command.make(
 
       if (projects.data.length === 0) {
         yield* ui.log.warn('No projects found for the selected org.');
-        yield* ui.log.info('Use `composio orgs switch` to switch to another organization.');
+        yield* ui.log.info('Use `composio manage orgs switch` to switch to another organization.');
         yield* ui.outro('No projects available.');
         return;
       }
@@ -119,7 +119,7 @@ export const projectsCmd$Switch = Command.make(
       );
 
       yield* ui.log.success(`Updated global default project to "${selectedProject.name}".`);
-      yield* ui.log.info('To switch organization as well, run `composio orgs switch`.');
+      yield* ui.log.info('To switch organization as well, run `composio manage orgs switch`.');
       yield* ui.output(
         JSON.stringify({
           scope: 'global',

--- a/ts/packages/cli/src/commands/root-help.ts
+++ b/ts/packages/cli/src/commands/root-help.ts
@@ -114,16 +114,11 @@ const ADVANCED_COMMANDS: ReadonlyArray<{ name: string; description: string }> = 
     description:
       'Generate type stubs for toolkits, tools, and triggers, auto-detecting project language (TypeScript | Python)',
   },
-  { name: 'py', description: 'Handle Python projects.' },
-  { name: 'ts', description: 'Handle TypeScript projects.' },
-  { name: 'toolkits', description: 'Discover and inspect Composio toolkits.' },
-  { name: 'tools', description: 'Discover and inspect Composio tools.' },
-  { name: 'auth-configs', description: 'View and manage Composio auth configs.' },
-  { name: 'connected-accounts', description: 'View and manage Composio connected accounts.' },
-  { name: 'triggers', description: 'Inspect and subscribe to trigger events.' },
-  { name: 'logs', description: 'Inspect trigger and tool execution logs.' },
-  { name: 'orgs', description: 'Manage default global organization/project context.' },
-  { name: 'projects', description: 'Manage default global project context.' },
+  {
+    name: 'manage',
+    description:
+      'Manage Composio resources — toolkits, tools, accounts, triggers, logs, orgs, and projects.',
+  },
 ];
 
 /**

--- a/ts/packages/cli/src/commands/toolkits/commands/toolkits.info.cmd.ts
+++ b/ts/packages/cli/src/commands/toolkits/commands/toolkits.info.cmd.ts
@@ -32,8 +32,8 @@ const allDetails = Options.boolean('all').pipe(
  *
  * @example
  * ```bash
- * composio toolkits info "gmail"
- * composio toolkits info "github" --user-id "alice"
+ * composio manage toolkits info "gmail"
+ * composio manage toolkits info "github" --user-id "alice"
  * ```
  */
 export const toolkitsCmd$Info = Command.make(
@@ -51,7 +51,7 @@ export const toolkitsCmd$Info = Command.make(
       if (Option.isNone(slug)) {
         yield* ui.log.warn('Missing required argument: <slug>');
         yield* ui.log.step(
-          'Try specifying a toolkit slug, e.g.:\n> composio toolkits info "gmail"'
+          'Try specifying a toolkit slug, e.g.:\n> composio manage toolkits info "gmail"'
         );
         return;
       }
@@ -117,7 +117,7 @@ export const toolkitsCmd$Info = Command.make(
               const message = extractMessage(error) ?? `Failed to fetch toolkit "${slugValue}".`;
               yield* ui.log.error(message);
               yield* Effect.logDebug('Toolkit info error:', error);
-              yield* ui.log.step('Browse available toolkits:\n> composio toolkits list');
+              yield* ui.log.step('Browse available toolkits:\n> composio manage toolkits list');
               return Option.none();
             })
           )
@@ -139,7 +139,7 @@ export const toolkitsCmd$Info = Command.make(
           Effect.map(r =>
             r.items.map(s => ({
               label: `${s.slug} — ${s.meta.description}`,
-              command: `> composio toolkits info "${s.slug}"`,
+              command: `> composio manage toolkits info "${s.slug}"`,
             }))
           ),
           Effect.catchAll(() => Effect.succeed([] as { label: string; command: string }[]))
@@ -150,7 +150,7 @@ export const toolkitsCmd$Info = Command.make(
           const lines = suggestions.map(s => `  ${s.label}`).join('\n');
           yield* ui.log.step(`Did you mean?\n${lines}\n\n${first.command}`);
         } else {
-          yield* ui.log.step('Browse available toolkits:\n> composio toolkits list');
+          yield* ui.log.step('Browse available toolkits:\n> composio manage toolkits list');
         }
         return;
       }
@@ -161,7 +161,7 @@ export const toolkitsCmd$Info = Command.make(
 
       // Next step hint
       yield* ui.log.step(
-        `To list tools in this toolkit:\n> composio tools list --toolkits "${toolkit.slug}"`
+        `To list tools in this toolkit:\n> composio manage tools list --toolkits "${toolkit.slug}"`
       );
 
       yield* ui.output(formatToolkitInfoJson(toolkit, detailedToolkit, allDetails));

--- a/ts/packages/cli/src/commands/toolkits/commands/toolkits.list.cmd.ts
+++ b/ts/packages/cli/src/commands/toolkits/commands/toolkits.list.cmd.ts
@@ -42,10 +42,10 @@ const userId = Options.text('user-id').pipe(
  *
  * @example
  * ```bash
- * composio toolkits list
- * composio toolkits list --query "email"
- * composio toolkits list --connected
- * composio toolkits list --user-id "alice"
+ * composio manage toolkits list
+ * composio manage toolkits list --query "email"
+ * composio manage toolkits list --connected
+ * composio manage toolkits list --user-id "alice"
  * ```
  */
 export const toolkitsCmd$List = Command.make(
@@ -174,7 +174,7 @@ export const toolkitsCmd$List = Command.make(
       const firstSlug = unified[0]?.slug;
       if (firstSlug) {
         yield* ui.log.step(
-          `To view details of a toolkit:\n> composio toolkits info "${firstSlug}"`
+          `To view details of a toolkit:\n> composio manage toolkits info "${firstSlug}"`
         );
       }
       yield* ui.output(formatToolkitsJson(unified));

--- a/ts/packages/cli/src/commands/toolkits/commands/toolkits.search.cmd.ts
+++ b/ts/packages/cli/src/commands/toolkits/commands/toolkits.search.cmd.ts
@@ -25,8 +25,8 @@ const limit = Options.integer('limit').pipe(
  *
  * @example
  * ```bash
- * composio toolkits search "send emails"
- * composio toolkits search "messaging" --limit 5
+ * composio manage toolkits search "send emails"
+ * composio manage toolkits search "messaging" --limit 5
  * ```
  */
 export const toolkitsCmd$Search = Command.make('search', { query, limit }, ({ query, limit }) =>
@@ -59,7 +59,7 @@ export const toolkitsCmd$Search = Command.make('search', { query, limit }, ({ qu
     // Next step hint
     const firstSlug = unified[0]?.slug;
     if (firstSlug) {
-      yield* ui.log.step(`To view details:\n> composio toolkits info "${firstSlug}"`);
+      yield* ui.log.step(`To view details:\n> composio manage toolkits info "${firstSlug}"`);
     }
 
     yield* ui.output(formatToolkitsJson(unified));

--- a/ts/packages/cli/src/commands/toolkits/commands/toolkits.version.cmd.ts
+++ b/ts/packages/cli/src/commands/toolkits/commands/toolkits.version.cmd.ts
@@ -38,7 +38,7 @@ export const toolkitsCmd$Version = Command.make('version', { slug }, ({ slug }) 
               extractMessage(error) ?? `Failed to fetch version info for toolkit "${slug}".`;
             yield* ui.log.error(message);
             yield* Effect.logDebug('Toolkit version error:', error);
-            yield* ui.log.step('Browse available toolkits:\n> composio toolkits list');
+            yield* ui.log.step('Browse available toolkits:\n> composio manage toolkits list');
             return Option.none();
           })
         )

--- a/ts/packages/cli/src/commands/toolkits/format.ts
+++ b/ts/packages/cli/src/commands/toolkits/format.ts
@@ -234,7 +234,7 @@ export function formatToolkitInfo(
   } else if (!toolkit.is_no_auth) {
     lines.push(`${bold('Connection Status:')} ${dim('Not connected')}`);
     lines.push(
-      `${bold('Tip:')} Link this toolkit:\n> composio connected-accounts link "${toolkit.slug}"`
+      `${bold('Tip:')} Link this toolkit:\n> composio manage connected-accounts link "${toolkit.slug}"`
     );
   }
 

--- a/ts/packages/cli/src/commands/toolkits/toolkits.cmd.ts
+++ b/ts/packages/cli/src/commands/toolkits/toolkits.cmd.ts
@@ -9,7 +9,7 @@ import { toolkitsCmd$Version } from './commands/toolkits.version.cmd';
  *
  * @example
  * ```bash
- * composio toolkits <command>
+ * composio manage toolkits <command>
  * ```
  */
 export const toolkitsCmd = Command.make('toolkits').pipe(

--- a/ts/packages/cli/src/commands/tools/commands/tools.execute.cmd.ts
+++ b/ts/packages/cli/src/commands/tools/commands/tools.execute.cmd.ts
@@ -103,11 +103,11 @@ const toolkitFromToolSlug = (toolSlug: string): string | undefined => {
 const connectionTips = (toolSlug: string, userId: string) => {
   const toolkit = toolkitFromToolSlug(toolSlug);
   if (!toolkit) {
-    return `Retry: ${bold(`composio tools execute ${toolSlug} ...`)}`;
+    return `Retry: ${bold(`composio manage tools execute ${toolSlug} ...`)}`;
   }
   return [
-    `Link the toolkit first: ${bold(`composio connected-accounts link ${toolkit} --user-id ${userId}`)}`,
-    `Then retry:             ${bold(`composio tools execute ${toolSlug} ...`)}`,
+    `Link the toolkit first: ${bold(`composio manage connected-accounts link ${toolkit} --user-id ${userId}`)}`,
+    `Then retry:             ${bold(`composio manage tools execute ${toolSlug} ...`)}`,
   ].join('\n');
 };
 
@@ -192,14 +192,14 @@ export const showToolsExecuteInputHelp = (toolSlug: string) =>
           'services/HttpServerError',
           handleHttpServerError(ui, {
             fallbackMessage: `Tool "${toolSlug}" not found.`,
-            hint: 'Browse available tools:\n> composio tools list',
+            hint: 'Browse available tools:\n> composio manage tools list',
             fallbackValue: Option.none(),
             searchForSuggestions: () =>
               repo.searchTools({ search: toolSlug, limit: 3 }).pipe(
                 Effect.map(r =>
                   r.items.map(s => ({
                     label: `${s.slug} — ${s.description}`,
-                    command: `> composio tools execute "${s.slug}" --help`,
+                    command: `> composio manage tools execute "${s.slug}" --help`,
                   }))
                 )
               ),
@@ -212,7 +212,7 @@ export const showToolsExecuteInputHelp = (toolSlug: string) =>
 
     yield* ui.note(formatToolInputParameters(tool), `Execute Help: ${tool.slug}`);
     yield* ui.log.step(
-      `Run:\n> composio tools execute "${tool.slug}" --user-id "<user-id>" -d '{"key":"value"}'`
+      `Run:\n> composio manage tools execute "${tool.slug}" --user-id "<user-id>" -d '{"key":"value"}'`
     );
     yield* ui.output(
       JSON.stringify({ slug: tool.slug, input_parameters: tool.input_parameters }, null, 2)
@@ -281,8 +281,8 @@ class ToolExecutionError {
  *
  * @example
  * ```bash
- * composio tools execute GITHUB_GET_REPOS -d '{"owner":"composio"}'
- * echo '{"owner":"composio"}' | composio tools execute GITHUB_GET_REPOS
+ * composio manage tools execute GITHUB_GET_REPOS -d '{"owner":"composio"}'
+ * echo '{"owner":"composio"}' | composio manage tools execute GITHUB_GET_REPOS
  * ```
  */
 export const toolsCmd$Execute = Command.make(

--- a/ts/packages/cli/src/commands/tools/commands/tools.info.cmd.ts
+++ b/ts/packages/cli/src/commands/tools/commands/tools.info.cmd.ts
@@ -16,7 +16,7 @@ const slug = Args.text({ name: 'slug' }).pipe(
  *
  * @example
  * ```bash
- * composio tools info "GMAIL_SEND_EMAIL"
+ * composio manage tools info "GMAIL_SEND_EMAIL"
  * ```
  */
 export const toolsCmd$Info = Command.make('info', { slug }, ({ slug }) =>
@@ -30,7 +30,7 @@ export const toolsCmd$Info = Command.make('info', { slug }, ({ slug }) =>
     if (Option.isNone(slug)) {
       yield* ui.log.warn('Missing required argument: <slug>');
       yield* ui.log.step(
-        'Try specifying a tool slug, e.g.:\n> composio tools info "GMAIL_SEND_EMAIL"'
+        'Try specifying a tool slug, e.g.:\n> composio manage tools info "GMAIL_SEND_EMAIL"'
       );
       return;
     }
@@ -45,14 +45,14 @@ export const toolsCmd$Info = Command.make('info', { slug }, ({ slug }) =>
           'services/HttpServerError',
           handleHttpServerError(ui, {
             fallbackMessage: `Tool "${slugValue}" not found.`,
-            hint: 'Browse available tools:\n> composio tools list',
+            hint: 'Browse available tools:\n> composio manage tools list',
             fallbackValue: Option.none(),
             searchForSuggestions: () =>
               repo.searchTools({ search: slugValue, limit: 3 }).pipe(
                 Effect.map(r =>
                   r.items.map(s => ({
                     label: `${s.slug} — ${s.description}`,
-                    command: `> composio tools info "${s.slug}"`,
+                    command: `> composio manage tools info "${s.slug}"`,
                   }))
                 )
               ),
@@ -72,7 +72,7 @@ export const toolsCmd$Info = Command.make('info', { slug }, ({ slug }) =>
     const toolkitSlug = tool.toolkit.slug;
     if (toolkitSlug) {
       yield* ui.log.step(
-        `To list more tools in this toolkit:\n> composio tools list --toolkits "${toolkitSlug}"`
+        `To list more tools in this toolkit:\n> composio manage tools list --toolkits "${toolkitSlug}"`
       );
     }
 

--- a/ts/packages/cli/src/commands/tools/commands/tools.list.cmd.ts
+++ b/ts/packages/cli/src/commands/tools/commands/tools.list.cmd.ts
@@ -33,9 +33,9 @@ const limit = Options.integer('limit').pipe(
  *
  * @example
  * ```bash
- * composio tools list --toolkits "gmail"
- * composio tools list --query "send email" --toolkits "gmail"
- * composio tools list --tags "important" --limit 10
+ * composio manage tools list --toolkits "gmail"
+ * composio manage tools list --query "send email" --toolkits "gmail"
+ * composio manage tools list --tags "important" --limit 10
  * ```
  */
 export const toolsCmd$List = Command.make(
@@ -62,7 +62,7 @@ export const toolsCmd$List = Command.make(
 
       if (result.items.length === 0) {
         const hint = Option.isSome(toolkits)
-          ? `No tools found in toolkit "${toolkits.value}". Verify the toolkit slug with:\n> composio toolkits list`
+          ? `No tools found in toolkit "${toolkits.value}". Verify the toolkit slug with:\n> composio manage toolkits list`
           : 'No tools found. Try broadening your search.';
         yield* ui.log.warn(hint);
         return;
@@ -80,7 +80,9 @@ export const toolsCmd$List = Command.make(
       // Next step hint
       const firstSlug = result.items[0]?.slug;
       if (firstSlug) {
-        yield* ui.log.step(`To view details of a tool:\n> composio tools info "${firstSlug}"`);
+        yield* ui.log.step(
+          `To view details of a tool:\n> composio manage tools info "${firstSlug}"`
+        );
       }
 
       yield* ui.output(formatToolsJson(result.items));

--- a/ts/packages/cli/src/commands/tools/commands/tools.search.cmd.ts
+++ b/ts/packages/cli/src/commands/tools/commands/tools.search.cmd.ts
@@ -40,9 +40,9 @@ const limit = Options.integer('limit').pipe(
  *
  * @example
  * ```bash
- * composio tools search "send emails"
- * composio tools search "send emails" --toolkits "gmail,outlook"
- * composio tools search "messaging" --limit 5
+ * composio manage tools search "send emails"
+ * composio manage tools search "send emails" --toolkits "gmail,outlook"
+ * composio manage tools search "messaging" --limit 5
  * ```
  */
 export const toolsCmd$Search = Command.make(
@@ -162,8 +162,8 @@ export const toolsCmd$Search = Command.make(
         yield* ui.log.step(
           [
             'Hints:',
-            `> composio tools info "${firstSlug}"`,
-            `> composio tools execute "${firstSlug}" --user-id "<user-id>" --arguments '{}'`,
+            `> composio manage tools info "${firstSlug}"`,
+            `> composio manage tools execute "${firstSlug}" --user-id "<user-id>" --arguments '{}'`,
           ].join('\n')
         );
       }

--- a/ts/packages/cli/src/commands/tools/tools.cmd.ts
+++ b/ts/packages/cli/src/commands/tools/tools.cmd.ts
@@ -9,7 +9,7 @@ import { toolsCmd$Execute } from './commands/tools.execute.cmd';
  *
  * @example
  * ```bash
- * composio tools <command>
+ * composio manage tools <command>
  * ```
  */
 export const toolsCmd = Command.make('tools').pipe(

--- a/ts/packages/cli/src/commands/triggers/commands/triggers.create.cmd.ts
+++ b/ts/packages/cli/src/commands/triggers/commands/triggers.create.cmd.ts
@@ -36,7 +36,7 @@ export const triggersCmd$Create = Command.make(
       if (Option.isNone(triggerName)) {
         yield* ui.log.warn('Missing required argument: <trigger-name>');
         yield* ui.log.step(
-          'Try specifying a trigger slug, e.g.:\n> composio triggers create "GMAIL_NEW_GMAIL_MESSAGE" --connected-account-id "con_123"'
+          'Try specifying a trigger slug, e.g.:\n> composio manage triggers create "GMAIL_NEW_GMAIL_MESSAGE" --connected-account-id "con_123"'
         );
         return;
       }
@@ -55,7 +55,7 @@ export const triggersCmd$Create = Command.make(
         } catch {
           yield* ui.log.error('Invalid JSON in --trigger-config. Please provide valid JSON.');
           yield* ui.log.step(
-            'Example:\n> composio triggers create "GMAIL_NEW_GMAIL_MESSAGE" --trigger-config \'{"label":"inbox"}\''
+            'Example:\n> composio manage triggers create "GMAIL_NEW_GMAIL_MESSAGE" --trigger-config \'{"label":"inbox"}\''
           );
           return;
         }
@@ -75,7 +75,7 @@ export const triggersCmd$Create = Command.make(
             'services/HttpServerError',
             handleHttpServerError(ui, {
               fallbackMessage: `Failed to create trigger "${triggerName.value}".`,
-              hint: 'List available trigger types with:\n> composio triggers list',
+              hint: 'List available trigger types with:\n> composio manage triggers list',
               fallbackValue: Option.none(),
             })
           )
@@ -88,7 +88,7 @@ export const triggersCmd$Create = Command.make(
       const created = createdOpt.value;
       yield* ui.log.success(`Trigger created: ${created.trigger_id}`);
       yield* ui.log.step(
-        `To check status:\n> composio triggers status --trigger-ids "${created.trigger_id}"`
+        `To check status:\n> composio manage triggers status --trigger-ids "${created.trigger_id}"`
       );
       yield* ui.output(JSON.stringify(created, null, 2));
     })

--- a/ts/packages/cli/src/commands/triggers/commands/triggers.delete.cmd.ts
+++ b/ts/packages/cli/src/commands/triggers/commands/triggers.delete.cmd.ts
@@ -29,7 +29,7 @@ export const triggersCmd$Delete = Command.make('delete', { id, yes }, ({ id, yes
     if (Option.isNone(id)) {
       yield* ui.log.warn('Missing required argument: <id>');
       yield* ui.log.step(
-        'Try specifying a trigger ID, e.g.:\n> composio triggers delete "trg_123" --yes\n\nTo find trigger IDs:\n> composio triggers status --show-disabled'
+        'Try specifying a trigger ID, e.g.:\n> composio manage triggers delete "trg_123" --yes\n\nTo find trigger IDs:\n> composio manage triggers status --show-disabled'
       );
       return;
     }
@@ -54,7 +54,7 @@ export const triggersCmd$Delete = Command.make('delete', { id, yes }, ({ id, yes
           'services/HttpServerError',
           handleHttpServerError(ui, {
             fallbackMessage: `Failed to delete trigger "${idValue}".`,
-            hint: 'Browse available triggers:\n> composio triggers status --show-disabled',
+            hint: 'Browse available triggers:\n> composio manage triggers status --show-disabled',
             fallbackValue: false,
           })
         )

--- a/ts/packages/cli/src/commands/triggers/commands/triggers.disable.cmd.ts
+++ b/ts/packages/cli/src/commands/triggers/commands/triggers.disable.cmd.ts
@@ -23,7 +23,7 @@ export const triggersCmd$Disable = Command.make('disable', { id }, ({ id }) =>
     if (Option.isNone(id)) {
       yield* ui.log.warn('Missing required argument: <id>');
       yield* ui.log.step(
-        'Try specifying a trigger ID, e.g.:\n> composio triggers disable "trg_123"\n\nTo find trigger IDs:\n> composio triggers status'
+        'Try specifying a trigger ID, e.g.:\n> composio manage triggers disable "trg_123"\n\nTo find trigger IDs:\n> composio manage triggers status'
       );
       return;
     }
@@ -37,7 +37,7 @@ export const triggersCmd$Disable = Command.make('disable', { id }, ({ id }) =>
           'services/HttpServerError',
           handleHttpServerError(ui, {
             fallbackMessage: `Failed to disable trigger "${idValue}".`,
-            hint: 'Browse available triggers:\n> composio triggers status',
+            hint: 'Browse available triggers:\n> composio manage triggers status',
             fallbackValue: false,
           })
         )

--- a/ts/packages/cli/src/commands/triggers/commands/triggers.enable.cmd.ts
+++ b/ts/packages/cli/src/commands/triggers/commands/triggers.enable.cmd.ts
@@ -23,7 +23,7 @@ export const triggersCmd$Enable = Command.make('enable', { id }, ({ id }) =>
     if (Option.isNone(id)) {
       yield* ui.log.warn('Missing required argument: <id>');
       yield* ui.log.step(
-        'Try specifying a trigger ID, e.g.:\n> composio triggers enable "trg_123"\n\nTo find trigger IDs:\n> composio triggers status --show-disabled'
+        'Try specifying a trigger ID, e.g.:\n> composio manage triggers enable "trg_123"\n\nTo find trigger IDs:\n> composio manage triggers status --show-disabled'
       );
       return;
     }
@@ -37,7 +37,7 @@ export const triggersCmd$Enable = Command.make('enable', { id }, ({ id }) =>
           'services/HttpServerError',
           handleHttpServerError(ui, {
             fallbackMessage: `Failed to enable trigger "${idValue}".`,
-            hint: 'Browse available triggers:\n> composio triggers status --show-disabled',
+            hint: 'Browse available triggers:\n> composio manage triggers status --show-disabled',
             fallbackValue: false,
           })
         )

--- a/ts/packages/cli/src/commands/triggers/commands/triggers.info.cmd.ts
+++ b/ts/packages/cli/src/commands/triggers/commands/triggers.info.cmd.ts
@@ -16,7 +16,7 @@ const slug = Args.text({ name: 'slug' }).pipe(
  *
  * @example
  * ```bash
- * composio triggers info "GMAIL_NEW_GMAIL_MESSAGE"
+ * composio manage triggers info "GMAIL_NEW_GMAIL_MESSAGE"
  * ```
  */
 export const triggersCmd$Info = Command.make('info', { slug }, ({ slug }) =>
@@ -29,7 +29,7 @@ export const triggersCmd$Info = Command.make('info', { slug }, ({ slug }) =>
     if (Option.isNone(slug)) {
       yield* ui.log.warn('Missing required argument: <slug>');
       yield* ui.log.step(
-        'Try specifying a trigger slug, e.g.:\n> composio triggers info "GMAIL_NEW_GMAIL_MESSAGE"'
+        'Try specifying a trigger slug, e.g.:\n> composio manage triggers info "GMAIL_NEW_GMAIL_MESSAGE"'
       );
       return;
     }
@@ -44,7 +44,7 @@ export const triggersCmd$Info = Command.make('info', { slug }, ({ slug }) =>
           'services/HttpServerError',
           handleHttpServerError(ui, {
             fallbackMessage: `Trigger "${slugValue}" not found.`,
-            hint: 'Browse available trigger types:\n> composio triggers list',
+            hint: 'Browse available trigger types:\n> composio manage triggers list',
             fallbackValue: Option.none(),
           })
         )
@@ -59,7 +59,7 @@ export const triggersCmd$Info = Command.make('info', { slug }, ({ slug }) =>
     const toolkitSlug = triggerType.toolkit?.slug?.toLowerCase();
     if (toolkitSlug) {
       yield* ui.log.step(
-        `To list more trigger types in this toolkit:\n> composio triggers list --toolkits "${toolkitSlug}"`
+        `To list more trigger types in this toolkit:\n> composio manage triggers list --toolkits "${toolkitSlug}"`
       );
     }
 

--- a/ts/packages/cli/src/commands/triggers/commands/triggers.list.cmd.ts
+++ b/ts/packages/cli/src/commands/triggers/commands/triggers.list.cmd.ts
@@ -24,9 +24,9 @@ const limit = Options.integer('limit').pipe(
  *
  * @example
  * ```bash
- * composio triggers list
- * composio triggers list --toolkits "gmail"
- * composio triggers list --toolkits "gmail,slack"
+ * composio manage triggers list
+ * composio manage triggers list --toolkits "gmail"
+ * composio manage triggers list --toolkits "gmail,slack"
  * ```
  */
 export const triggersCmd$List = Command.make('list', { toolkits, limit }, ({ toolkits, limit }) =>
@@ -46,7 +46,7 @@ export const triggersCmd$List = Command.make('list', { toolkits, limit }, ({ too
 
     if (triggerTypes.length === 0) {
       const hint = Option.isSome(toolkits)
-        ? `No trigger types found in toolkit "${toolkits.value}". Verify the toolkit slug with:\n> composio toolkits list`
+        ? `No trigger types found in toolkit "${toolkits.value}". Verify the toolkit slug with:\n> composio manage toolkits list`
         : 'No trigger types found.';
       yield* ui.log.warn(hint);
       return;
@@ -60,7 +60,7 @@ export const triggersCmd$List = Command.make('list', { toolkits, limit }, ({ too
     const firstSlug = triggerTypes[0]?.slug;
     if (firstSlug) {
       yield* ui.log.step(
-        `To view details of a trigger type:\n> composio triggers info "${firstSlug}"`
+        `To view details of a trigger type:\n> composio manage triggers info "${firstSlug}"`
       );
     }
 

--- a/ts/packages/cli/src/commands/triggers/commands/triggers.listen.cmd.ts
+++ b/ts/packages/cli/src/commands/triggers/commands/triggers.listen.cmd.ts
@@ -137,9 +137,9 @@ const emitTableLine = (line: string, ui: TerminalUI): Effect.Effect<void> =>
  *
  * @example
  * ```bash
- * composio triggers listen --toolkits gmail --table
- * composio triggers listen --trigger-slug GMAIL_NEW_GMAIL_MESSAGE --json --max-events 5
- * composio triggers listen --forward "http://localhost:8080/webhook" --out events.jsonl
+ * composio manage triggers listen --toolkits gmail --table
+ * composio manage triggers listen --trigger-slug GMAIL_NEW_GMAIL_MESSAGE --json --max-events 5
+ * composio manage triggers listen --forward "http://localhost:8080/webhook" --out events.jsonl
  * ```
  */
 export const triggersCmd$Listen = Command.make(
@@ -201,7 +201,7 @@ export const triggersCmd$Listen = Command.make(
       let matchingEvents = 0;
       let tableHeaderPrinted = false;
 
-      yield* ui.intro('composio triggers listen');
+      yield* ui.intro('composio manage triggers listen');
       if (forwardUrl) {
         if (process.env.COMPOSIO_WEBHOOK_SECRET) {
           yield* ui.note(

--- a/ts/packages/cli/src/commands/triggers/commands/triggers.status.cmd.ts
+++ b/ts/packages/cli/src/commands/triggers/commands/triggers.status.cmd.ts
@@ -97,7 +97,7 @@ export const triggersCmd$Status = Command.make(
             'services/HttpServerError',
             handleHttpServerError(ui, {
               fallbackMessage: 'Failed to fetch trigger status.',
-              hint: 'Retry with:\n> composio triggers status --show-disabled',
+              hint: 'Retry with:\n> composio manage triggers status --show-disabled',
               fallbackValue: Option.none(),
             })
           )

--- a/ts/packages/cli/src/commands/triggers/triggers.cmd.ts
+++ b/ts/packages/cli/src/commands/triggers/triggers.cmd.ts
@@ -13,7 +13,7 @@ import { triggersCmd$Delete } from './commands/triggers.delete.cmd';
  *
  * @example
  * ```bash
- * composio triggers <command>
+ * composio manage triggers <command>
  * ```
  */
 export const triggersCmd = Command.make('triggers').pipe(

--- a/ts/packages/cli/src/commands/whoami.cmd.ts
+++ b/ts/packages/cli/src/commands/whoami.cmd.ts
@@ -38,7 +38,7 @@ export const whoamiCmd = Command.make('whoami', {}).pipe(
               );
               yield* ui.log.step(
                 [
-                  'To switch orgs:\n> composio orgs switch',
+                  'To switch orgs:\n> composio manage orgs switch',
                   'To get API keys:\n> composio init (in your project)',
                 ].join('\n\n')
               );

--- a/ts/packages/cli/src/effects/handle-http-error.ts
+++ b/ts/packages/cli/src/effects/handle-http-error.ts
@@ -25,7 +25,7 @@ const noSuggestions: ReadonlyArray<Suggestion> = [];
  *   Effect.catchTag('services/HttpServerError',
  *     handleHttpServerError(ui, {
  *       fallbackMessage: `Failed to fetch auth config "${id}".`,
- *       hint: 'Browse available auth configs:\n> composio auth-configs list',
+ *       hint: 'Browse available auth configs:\n> composio manage auth-configs list',
  *       fallbackValue: Option.none(),
  *     })
  *   )

--- a/ts/packages/cli/src/effects/select-org-project.ts
+++ b/ts/packages/cli/src/effects/select-org-project.ts
@@ -46,7 +46,7 @@ const selectProject = (
  * Runs the org/project selection flow: lists orgs, prompts for org (or auto-selects if 1),
  * lists projects, prompts for project (or auto-selects if 1).
  *
- * Reused by `composio orgs switch` and `composio login -y`.
+ * Reused by `composio manage orgs switch` and `composio login -y`.
  *
  * @param params.apiKey - User API key for API calls
  * @param params.baseURL - API base URL

--- a/ts/packages/cli/test/src/commands/$default.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/$default.cmd.test.ts
@@ -15,7 +15,7 @@ describe('CLI: composio', () => {
         expect(result).toEqual(
           ValidationError.commandMismatch(
             HelpDoc.p(
-              "Invalid subcommand for composio - use one of 'version', 'upgrade', 'whoami', 'login', 'logout', 'install', 'init', 'generate', 'py', 'ts', 'toolkits', 'tools', 'auth-configs', 'connected-accounts', 'triggers', 'logs', 'orgs', 'projects'"
+              "Invalid subcommand for composio - use one of 'version', 'upgrade', 'whoami', 'login', 'logout', 'install', 'init', 'generate', 'py', 'ts', 'manage'"
             )
           )
         );

--- a/ts/packages/cli/test/src/commands/__snapshots__/$default.cmd.test.ts.snap
+++ b/ts/packages/cli/test/src/commands/__snapshots__/$default.cmd.test.ts.snap
@@ -80,17 +80,8 @@ BASIC COMMANDS
       --table               Show compact table rows
 
 ADVANCED COMMANDS
-  generate            Generate type stubs for toolkits, tools, and triggers, auto-detecting project language (TypeScript | Python)
-  py                  Handle Python projects.
-  ts                  Handle TypeScript projects.
-  toolkits            Discover and inspect Composio toolkits.
-  tools               Discover and inspect Composio tools.
-  auth-configs        View and manage Composio auth configs.
-  connected-accounts  View and manage Composio connected accounts.
-  triggers            Inspect and subscribe to trigger events.
-  logs                Inspect trigger and tool execution logs.
-  orgs                Manage default global organization/project context.
-  projects            Manage default global project context.
+  generate    Generate type stubs for toolkits, tools, and triggers, auto-detecting project language (TypeScript | Python)
+  manage      Manage Composio resources — toolkits, tools, accounts, triggers, logs, orgs, and projects.
 
 FLAGS
   -h, --help     Show help for command

--- a/ts/packages/cli/test/src/commands/auth-configs/auth-configs.create.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/auth-configs/auth-configs.create.cmd.test.ts
@@ -8,13 +8,13 @@ const testConfigProvider = ConfigProvider.fromMap(
   new Map([['COMPOSIO_USER_API_KEY', 'test_api_key']])
 ).pipe(extendConfigProvider);
 
-describe('CLI: composio auth-configs create', () => {
+describe('CLI: composio manage auth-configs create', () => {
   layer(TestLive({ baseConfigProvider: testConfigProvider }))(
     '[Given] --toolkit "gmail" [Then] creates with Composio managed auth',
     it => {
       it.scoped('creates successfully', () =>
         Effect.gen(function* () {
-          yield* cli(['auth-configs', 'create', '--toolkit', 'gmail']);
+          yield* cli(['manage', 'auth-configs', 'create', '--toolkit', 'gmail']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -31,7 +31,7 @@ describe('CLI: composio auth-configs create', () => {
     it => {
       it.scoped('creates with name successfully', () =>
         Effect.gen(function* () {
-          yield* cli(['auth-configs', 'create', 'my-config', '--toolkit', 'gmail']);
+          yield* cli(['manage', 'auth-configs', 'create', 'my-config', '--toolkit', 'gmail']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -47,7 +47,15 @@ describe('CLI: composio auth-configs create', () => {
     it => {
       it.scoped('creates with custom auth scheme', () =>
         Effect.gen(function* () {
-          yield* cli(['auth-configs', 'create', '--toolkit', 'gmail', '--auth-scheme', 'OAUTH2']);
+          yield* cli([
+            'manage',
+            'auth-configs',
+            'create',
+            '--toolkit',
+            'gmail',
+            '--auth-scheme',
+            'OAUTH2',
+          ]);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -70,7 +78,7 @@ describe('CLI: composio auth-configs create', () => {
   )('[Given] custom create response [Then] shows correct details', it => {
     it.scoped('shows custom response data', () =>
       Effect.gen(function* () {
-        yield* cli(['auth-configs', 'create', '--toolkit', 'slack']);
+        yield* cli(['manage', 'auth-configs', 'create', '--toolkit', 'slack']);
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
         const output = lines.join('\n');
 
@@ -87,6 +95,7 @@ describe('CLI: composio auth-configs create', () => {
       it.scoped('shows JSON parse error', () =>
         Effect.gen(function* () {
           yield* cli([
+            'manage',
             'auth-configs',
             'create',
             '--toolkit',
@@ -108,7 +117,7 @@ describe('CLI: composio auth-configs create', () => {
   layer(TestLive())('[Given] no API key [Then] warns user to login', it => {
     it.scoped('warns user to login', () =>
       Effect.gen(function* () {
-        yield* cli(['auth-configs', 'create', '--toolkit', 'gmail']);
+        yield* cli(['manage', 'auth-configs', 'create', '--toolkit', 'gmail']);
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
         const output = lines.join('\n');
 
@@ -122,11 +131,11 @@ describe('CLI: composio auth-configs create', () => {
     it => {
       it.scoped('shows next step hint', () =>
         Effect.gen(function* () {
-          yield* cli(['auth-configs', 'create', '--toolkit', 'gmail']);
+          yield* cli(['manage', 'auth-configs', 'create', '--toolkit', 'gmail']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
-          expect(output).toContain('composio auth-configs info');
+          expect(output).toContain('composio manage auth-configs info');
         })
       );
     }

--- a/ts/packages/cli/test/src/commands/auth-configs/auth-configs.delete.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/auth-configs/auth-configs.delete.cmd.test.ts
@@ -29,13 +29,13 @@ const testConfigProvider = ConfigProvider.fromMap(
   new Map([['COMPOSIO_USER_API_KEY', 'test_api_key']])
 ).pipe(extendConfigProvider);
 
-describe('CLI: composio auth-configs delete', () => {
+describe('CLI: composio manage auth-configs delete', () => {
   layer(TestLive({ baseConfigProvider: testConfigProvider, authConfigsData }))(
     '[Given] valid ID with --yes [Then] deletes successfully',
     it => {
       it.scoped('shows success message', () =>
         Effect.gen(function* () {
-          yield* cli(['auth-configs', 'delete', 'ac_gmail_default', '--yes']);
+          yield* cli(['manage', 'auth-configs', 'delete', 'ac_gmail_default', '--yes']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -51,7 +51,7 @@ describe('CLI: composio auth-configs delete', () => {
     it => {
       it.scoped('shows missing argument warning', () =>
         Effect.gen(function* () {
-          yield* cli(['auth-configs', 'delete']);
+          yield* cli(['manage', 'auth-configs', 'delete']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -66,12 +66,12 @@ describe('CLI: composio auth-configs delete', () => {
     it => {
       it.scoped('shows not found error', () =>
         Effect.gen(function* () {
-          yield* cli(['auth-configs', 'delete', 'ac_nonexistent', '--yes']);
+          yield* cli(['manage', 'auth-configs', 'delete', 'ac_nonexistent', '--yes']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
           expect(output).toContain('not found');
-          expect(output).toContain('composio auth-configs list');
+          expect(output).toContain('composio manage auth-configs list');
         })
       );
     }
@@ -80,7 +80,7 @@ describe('CLI: composio auth-configs delete', () => {
   layer(TestLive())('[Given] no API key [Then] warns user to login', it => {
     it.scoped('warns user to login', () =>
       Effect.gen(function* () {
-        yield* cli(['auth-configs', 'delete', 'ac_gmail_default', '--yes']);
+        yield* cli(['manage', 'auth-configs', 'delete', 'ac_gmail_default', '--yes']);
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
         const output = lines.join('\n');
 

--- a/ts/packages/cli/test/src/commands/auth-configs/auth-configs.info.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/auth-configs/auth-configs.info.cmd.test.ts
@@ -29,13 +29,13 @@ const testConfigProvider = ConfigProvider.fromMap(
   new Map([['COMPOSIO_USER_API_KEY', 'test_api_key']])
 ).pipe(extendConfigProvider);
 
-describe('CLI: composio auth-configs info', () => {
+describe('CLI: composio manage auth-configs info', () => {
   layer(TestLive({ baseConfigProvider: testConfigProvider, authConfigsData }))(
     '[Given] valid ID [Then] displays auth config details',
     it => {
       it.scoped('shows auth config details', () =>
         Effect.gen(function* () {
-          yield* cli(['auth-configs', 'info', 'ac_gmail_default']);
+          yield* cli(['manage', 'auth-configs', 'info', 'ac_gmail_default']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -46,7 +46,7 @@ describe('CLI: composio auth-configs info', () => {
           expect(output).toContain('ENABLED');
           expect(output).toContain('Yes'); // is_composio_managed
           // Next step hint
-          expect(output).toContain('composio auth-configs delete');
+          expect(output).toContain('composio manage auth-configs delete');
         })
       );
     }
@@ -57,7 +57,7 @@ describe('CLI: composio auth-configs info', () => {
     it => {
       it.scoped('shows missing argument warning', () =>
         Effect.gen(function* () {
-          yield* cli(['auth-configs', 'info']);
+          yield* cli(['manage', 'auth-configs', 'info']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -72,12 +72,12 @@ describe('CLI: composio auth-configs info', () => {
     it => {
       it.scoped('shows not found error', () =>
         Effect.gen(function* () {
-          yield* cli(['auth-configs', 'info', 'ac_nonexistent']);
+          yield* cli(['manage', 'auth-configs', 'info', 'ac_nonexistent']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
           expect(output).toContain('not found');
-          expect(output).toContain('composio auth-configs list');
+          expect(output).toContain('composio manage auth-configs list');
         })
       );
     }
@@ -86,7 +86,7 @@ describe('CLI: composio auth-configs info', () => {
   layer(TestLive())('[Given] no API key [Then] warns user to login', it => {
     it.scoped('warns user to login', () =>
       Effect.gen(function* () {
-        yield* cli(['auth-configs', 'info', 'ac_gmail_default']);
+        yield* cli(['manage', 'auth-configs', 'info', 'ac_gmail_default']);
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
         const output = lines.join('\n');
 

--- a/ts/packages/cli/test/src/commands/auth-configs/auth-configs.list.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/auth-configs/auth-configs.list.cmd.test.ts
@@ -55,13 +55,13 @@ const testConfigProvider = ConfigProvider.fromMap(
   new Map([['COMPOSIO_USER_API_KEY', 'test_api_key']])
 ).pipe(extendConfigProvider);
 
-describe('CLI: composio auth-configs list', () => {
+describe('CLI: composio manage auth-configs list', () => {
   layer(TestLive({ baseConfigProvider: testConfigProvider, authConfigsData }))(
     '[Given] no flags [Then] lists all auth configs',
     it => {
       it.scoped('lists all auth configs with table', () =>
         Effect.gen(function* () {
-          yield* cli(['auth-configs', 'list']);
+          yield* cli(['manage', 'auth-configs', 'list']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -79,7 +79,7 @@ describe('CLI: composio auth-configs list', () => {
     it => {
       it.scoped('filters by toolkit', () =>
         Effect.gen(function* () {
-          yield* cli(['auth-configs', 'list', '--toolkits', 'gmail']);
+          yield* cli(['manage', 'auth-configs', 'list', '--toolkits', 'gmail']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -97,7 +97,7 @@ describe('CLI: composio auth-configs list', () => {
     it => {
       it.scoped('filters by name search', () =>
         Effect.gen(function* () {
-          yield* cli(['auth-configs', 'list', '--query', 'Custom']);
+          yield* cli(['manage', 'auth-configs', 'list', '--query', 'Custom']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -113,7 +113,7 @@ describe('CLI: composio auth-configs list', () => {
     it => {
       it.scoped('respects limit', () =>
         Effect.gen(function* () {
-          yield* cli(['auth-configs', 'list', '--limit', '1']);
+          yield* cli(['manage', 'auth-configs', 'list', '--limit', '1']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -126,7 +126,7 @@ describe('CLI: composio auth-configs list', () => {
   layer(TestLive())('[Given] no API key [Then] warns user to login', it => {
     it.scoped('warns user to login', () =>
       Effect.gen(function* () {
-        yield* cli(['auth-configs', 'list']);
+        yield* cli(['manage', 'auth-configs', 'list']);
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
         const output = lines.join('\n');
 
@@ -140,7 +140,7 @@ describe('CLI: composio auth-configs list', () => {
     it => {
       it.scoped('shows no auth configs found', () =>
         Effect.gen(function* () {
-          yield* cli(['auth-configs', 'list']);
+          yield* cli(['manage', 'auth-configs', 'list']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -155,12 +155,12 @@ describe('CLI: composio auth-configs list', () => {
     it => {
       it.scoped('shows toolkit hint', () =>
         Effect.gen(function* () {
-          yield* cli(['auth-configs', 'list', '--toolkits', 'nonexistent']);
+          yield* cli(['manage', 'auth-configs', 'list', '--toolkits', 'nonexistent']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
           expect(output).toContain('No auth configs found');
-          expect(output).toContain('composio toolkits list');
+          expect(output).toContain('composio manage toolkits list');
         })
       );
     }

--- a/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.delete.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.delete.cmd.test.ts
@@ -33,13 +33,13 @@ const testConfigProvider = ConfigProvider.fromMap(
   new Map([['COMPOSIO_USER_API_KEY', 'test_api_key']])
 ).pipe(extendConfigProvider);
 
-describe('CLI: composio connected-accounts delete', () => {
+describe('CLI: composio manage connected-accounts delete', () => {
   layer(TestLive({ baseConfigProvider: testConfigProvider, connectedAccountsData }))(
     '[Given] valid ID with --yes [Then] deletes successfully',
     it => {
       it.scoped('deletes the connected account', () =>
         Effect.gen(function* () {
-          yield* cli(['connected-accounts', 'delete', 'con_gmail_active', '--yes']);
+          yield* cli(['manage', 'connected-accounts', 'delete', 'con_gmail_active', '--yes']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -54,12 +54,12 @@ describe('CLI: composio connected-accounts delete', () => {
     it => {
       it.scoped('shows error for nonexistent account', () =>
         Effect.gen(function* () {
-          yield* cli(['connected-accounts', 'delete', 'con_nonexistent', '--yes']);
+          yield* cli(['manage', 'connected-accounts', 'delete', 'con_nonexistent', '--yes']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
           expect(output).toContain('not found');
-          expect(output).toContain('composio connected-accounts list');
+          expect(output).toContain('composio manage connected-accounts list');
         })
       );
     }
@@ -70,12 +70,12 @@ describe('CLI: composio connected-accounts delete', () => {
     it => {
       it.scoped('warns about missing argument', () =>
         Effect.gen(function* () {
-          yield* cli(['connected-accounts', 'delete']);
+          yield* cli(['manage', 'connected-accounts', 'delete']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
           expect(output).toContain('Missing required argument');
-          expect(output).toContain('composio connected-accounts delete');
+          expect(output).toContain('composio manage connected-accounts delete');
         })
       );
     }
@@ -84,7 +84,7 @@ describe('CLI: composio connected-accounts delete', () => {
   layer(TestLive())('[Given] no API key [Then] warns user to login', it => {
     it.scoped('warns user to login', () =>
       Effect.gen(function* () {
-        yield* cli(['connected-accounts', 'delete', 'con_gmail_active', '--yes']);
+        yield* cli(['manage', 'connected-accounts', 'delete', 'con_gmail_active', '--yes']);
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
         const output = lines.join('\n');
 

--- a/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.info.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.info.cmd.test.ts
@@ -33,13 +33,13 @@ const testConfigProvider = ConfigProvider.fromMap(
   new Map([['COMPOSIO_USER_API_KEY', 'test_api_key']])
 ).pipe(extendConfigProvider);
 
-describe('CLI: composio connected-accounts info', () => {
+describe('CLI: composio manage connected-accounts info', () => {
   layer(TestLive({ baseConfigProvider: testConfigProvider, connectedAccountsData }))(
     '[Given] valid ID [Then] shows connected account info',
     it => {
       it.scoped('displays info for existing account', () =>
         Effect.gen(function* () {
-          yield* cli(['connected-accounts', 'info', 'con_gmail_active']);
+          yield* cli(['manage', 'connected-accounts', 'info', 'con_gmail_active']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -57,12 +57,12 @@ describe('CLI: composio connected-accounts info', () => {
     it => {
       it.scoped('shows error for nonexistent account', () =>
         Effect.gen(function* () {
-          yield* cli(['connected-accounts', 'info', 'con_nonexistent']);
+          yield* cli(['manage', 'connected-accounts', 'info', 'con_nonexistent']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
           expect(output).toContain('not found');
-          expect(output).toContain('composio connected-accounts list');
+          expect(output).toContain('composio manage connected-accounts list');
         })
       );
     }
@@ -73,12 +73,12 @@ describe('CLI: composio connected-accounts info', () => {
     it => {
       it.scoped('warns about missing argument', () =>
         Effect.gen(function* () {
-          yield* cli(['connected-accounts', 'info']);
+          yield* cli(['manage', 'connected-accounts', 'info']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
           expect(output).toContain('Missing required argument');
-          expect(output).toContain('composio connected-accounts info');
+          expect(output).toContain('composio manage connected-accounts info');
         })
       );
     }
@@ -87,7 +87,7 @@ describe('CLI: composio connected-accounts info', () => {
   layer(TestLive())('[Given] no API key [Then] warns user to login', it => {
     it.scoped('warns user to login', () =>
       Effect.gen(function* () {
-        yield* cli(['connected-accounts', 'info', 'con_gmail_active']);
+        yield* cli(['manage', 'connected-accounts', 'info', 'con_gmail_active']);
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
         const output = lines.join('\n');
 

--- a/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.link.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.link.cmd.test.ts
@@ -33,13 +33,14 @@ const testConfigProvider = ConfigProvider.fromMap(
   new Map([['COMPOSIO_USER_API_KEY', 'test_api_key']])
 ).pipe(extendConfigProvider);
 
-describe('CLI: composio connected-accounts link', () => {
+describe('CLI: composio manage connected-accounts link', () => {
   layer(TestLive({ baseConfigProvider: testConfigProvider, connectedAccountsData }))(
     '[Given] valid --auth-config and --user-id [Then] creates link and waits (default)',
     it => {
       it.scoped('creates link and waits for ACTIVE', () =>
         Effect.gen(function* () {
           yield* cli([
+            'manage',
             'connected-accounts',
             'link',
             '--auth-config',
@@ -64,6 +65,7 @@ describe('CLI: composio connected-accounts link', () => {
       it.scoped('uses explicit user-id', () =>
         Effect.gen(function* () {
           yield* cli([
+            'manage',
             'connected-accounts',
             'link',
             '--auth-config',
@@ -93,6 +95,7 @@ describe('CLI: composio connected-accounts link', () => {
       it.scoped('uses global test user id from user_data.json', () =>
         Effect.gen(function* () {
           yield* cli([
+            'manage',
             'connected-accounts',
             'link',
             '--auth-config',
@@ -112,7 +115,14 @@ describe('CLI: composio connected-accounts link', () => {
   layer(TestLive())('[Given] no API key [Then] warns user to login', it => {
     it.scoped('warns user to login', () =>
       Effect.gen(function* () {
-        yield* cli(['connected-accounts', 'link', '--auth-config', 'ac_test', '--no-browser']);
+        yield* cli([
+          'manage',
+          'connected-accounts',
+          'link',
+          '--auth-config',
+          'ac_test',
+          '--no-browser',
+        ]);
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
         const output = lines.join('\n');
 
@@ -122,7 +132,7 @@ describe('CLI: composio connected-accounts link', () => {
   });
 
   layer(TestLive({ baseConfigProvider: testConfigProvider, connectedAccountsData }))(
-    '[Given] composio link alias [Then] works like composio connected-accounts link',
+    '[Given] composio link alias [Then] works like composio manage connected-accounts link',
     it => {
       it.scoped('alias expands to connected-accounts link', () =>
         Effect.gen(function* () {
@@ -150,6 +160,7 @@ describe('CLI: composio connected-accounts link', () => {
       it.scoped('prints JSON with status pending, connected_account_id, redirect_url', () =>
         Effect.gen(function* () {
           yield* cli([
+            'manage',
             'connected-accounts',
             'link',
             '--auth-config',
@@ -190,6 +201,7 @@ describe('CLI: composio connected-accounts link', () => {
         () =>
           Effect.gen(function* () {
             yield* cli([
+              'manage',
               'connected-accounts',
               'link',
               '--auth-config',

--- a/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.list.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.list.cmd.test.ts
@@ -67,13 +67,13 @@ const testConfigProvider = ConfigProvider.fromMap(
   new Map([['COMPOSIO_USER_API_KEY', 'test_api_key']])
 ).pipe(extendConfigProvider);
 
-describe('CLI: composio connected-accounts list', () => {
+describe('CLI: composio manage connected-accounts list', () => {
   layer(TestLive({ baseConfigProvider: testConfigProvider, connectedAccountsData }))(
     '[Given] no flags [Then] lists all connected accounts',
     it => {
       it.scoped('lists all connected accounts with table', () =>
         Effect.gen(function* () {
-          yield* cli(['connected-accounts', 'list']);
+          yield* cli(['manage', 'connected-accounts', 'list']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -91,7 +91,7 @@ describe('CLI: composio connected-accounts list', () => {
     it => {
       it.scoped('filters by toolkit', () =>
         Effect.gen(function* () {
-          yield* cli(['connected-accounts', 'list', '--toolkits', 'gmail']);
+          yield* cli(['manage', 'connected-accounts', 'list', '--toolkits', 'gmail']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -108,7 +108,7 @@ describe('CLI: composio connected-accounts list', () => {
     it => {
       it.scoped('filters by user ID', () =>
         Effect.gen(function* () {
-          yield* cli(['connected-accounts', 'list', '--user-id', 'default']);
+          yield* cli(['manage', 'connected-accounts', 'list', '--user-id', 'default']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -126,7 +126,7 @@ describe('CLI: composio connected-accounts list', () => {
     it => {
       it.scoped('filters by status', () =>
         Effect.gen(function* () {
-          yield* cli(['connected-accounts', 'list', '--status', 'ACTIVE']);
+          yield* cli(['manage', 'connected-accounts', 'list', '--status', 'ACTIVE']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -144,7 +144,7 @@ describe('CLI: composio connected-accounts list', () => {
     it => {
       it.scoped('respects limit', () =>
         Effect.gen(function* () {
-          yield* cli(['connected-accounts', 'list', '--limit', '1']);
+          yield* cli(['manage', 'connected-accounts', 'list', '--limit', '1']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -157,7 +157,7 @@ describe('CLI: composio connected-accounts list', () => {
   layer(TestLive())('[Given] no API key [Then] warns user to login', it => {
     it.scoped('warns user to login', () =>
       Effect.gen(function* () {
-        yield* cli(['connected-accounts', 'list']);
+        yield* cli(['manage', 'connected-accounts', 'list']);
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
         const output = lines.join('\n');
 
@@ -171,7 +171,7 @@ describe('CLI: composio connected-accounts list', () => {
     it => {
       it.scoped('shows no connected accounts found', () =>
         Effect.gen(function* () {
-          yield* cli(['connected-accounts', 'list']);
+          yield* cli(['manage', 'connected-accounts', 'list']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -186,12 +186,12 @@ describe('CLI: composio connected-accounts list', () => {
     it => {
       it.scoped('shows toolkit hint', () =>
         Effect.gen(function* () {
-          yield* cli(['connected-accounts', 'list', '--toolkits', 'nonexistent']);
+          yield* cli(['manage', 'connected-accounts', 'list', '--toolkits', 'nonexistent']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
           expect(output).toContain('No connected accounts found');
-          expect(output).toContain('composio toolkits list');
+          expect(output).toContain('composio manage toolkits list');
         })
       );
     }

--- a/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.whoami.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.whoami.cmd.test.ts
@@ -50,13 +50,13 @@ const testConfigProvider = ConfigProvider.fromMap(
   new Map([['COMPOSIO_USER_API_KEY', 'test_api_key']])
 ).pipe(extendConfigProvider);
 
-describe('CLI: composio connected-accounts whoami', () => {
+describe('CLI: composio manage connected-accounts whoami', () => {
   layer(TestLive({ baseConfigProvider: testConfigProvider, connectedAccountsData }))(
     '[Given] active connection [Then] shows account details',
     it => {
       it.scoped('displays whoami for active connection', () =>
         Effect.gen(function* () {
-          yield* cli(['connected-accounts', 'whoami', 'con_gmail_active']);
+          yield* cli(['manage', 'connected-accounts', 'whoami', 'con_gmail_active']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -74,7 +74,7 @@ describe('CLI: composio connected-accounts whoami', () => {
     it => {
       it.scoped('shows warning for non-ACTIVE connection', () =>
         Effect.gen(function* () {
-          yield* cli(['connected-accounts', 'whoami', 'con_github_expired']);
+          yield* cli(['manage', 'connected-accounts', 'whoami', 'con_github_expired']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -91,12 +91,12 @@ describe('CLI: composio connected-accounts whoami', () => {
     it => {
       it.scoped('shows error for nonexistent account', () =>
         Effect.gen(function* () {
-          yield* cli(['connected-accounts', 'whoami', 'con_nonexistent']);
+          yield* cli(['manage', 'connected-accounts', 'whoami', 'con_nonexistent']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
           expect(output).toContain('not found');
-          expect(output).toContain('composio connected-accounts list');
+          expect(output).toContain('composio manage connected-accounts list');
         })
       );
     }
@@ -107,12 +107,12 @@ describe('CLI: composio connected-accounts whoami', () => {
     it => {
       it.scoped('warns about missing argument', () =>
         Effect.gen(function* () {
-          yield* cli(['connected-accounts', 'whoami']);
+          yield* cli(['manage', 'connected-accounts', 'whoami']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
           expect(output).toContain('Missing required argument');
-          expect(output).toContain('composio connected-accounts whoami');
+          expect(output).toContain('composio manage connected-accounts whoami');
         })
       );
     }
@@ -121,7 +121,7 @@ describe('CLI: composio connected-accounts whoami', () => {
   layer(TestLive())('[Given] no API key [Then] warns user to login', it => {
     it.scoped('warns user to login', () =>
       Effect.gen(function* () {
-        yield* cli(['connected-accounts', 'whoami', 'con_gmail_active']);
+        yield* cli(['manage', 'connected-accounts', 'whoami', 'con_gmail_active']);
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
         const output = lines.join('\n');
 

--- a/ts/packages/cli/test/src/commands/orgs/orgs.list.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/orgs/orgs.list.cmd.test.ts
@@ -9,7 +9,7 @@ const mockFetchResponse = (body: unknown, status = 200) =>
     headers: { 'Content-Type': 'application/json' },
   });
 
-describe('CLI: composio orgs list', () => {
+describe('CLI: composio manage orgs list', () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -26,7 +26,7 @@ describe('CLI: composio orgs list', () => {
           })
         );
 
-        yield* cli(['orgs', 'list']);
+        yield* cli(['manage', 'orgs', 'list']);
 
         expect(fetchSpy).toHaveBeenCalledTimes(1);
         const [orgUrl, orgRequest] = fetchSpy.mock.calls[0]!;
@@ -40,7 +40,7 @@ describe('CLI: composio orgs list', () => {
         expect(output).toContain('✓ Org One (org_1)');
         expect(output).toContain('  Org Two (org_2)');
         expect(output).toContain(
-          'Hint: run `composio orgs switch` to switch the default global org/project.'
+          'Hint: run `composio manage orgs switch` to switch the default global org/project.'
         );
       })
     );

--- a/ts/packages/cli/test/src/commands/orgs/orgs.switch.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/orgs/orgs.switch.cmd.test.ts
@@ -20,7 +20,7 @@ const mockFetchResponse = (body: unknown, status = 200) =>
     headers: { 'Content-Type': 'application/json' },
   });
 
-describe('CLI: composio orgs switch', () => {
+describe('CLI: composio manage orgs switch', () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -41,7 +41,7 @@ describe('CLI: composio orgs switch', () => {
             })
           );
 
-        yield* cli(['orgs', 'switch']);
+        yield* cli(['manage', 'orgs', 'switch']);
 
         expect(fetchSpy).toHaveBeenCalledTimes(2);
         const [orgUrl, orgRequest] = fetchSpy.mock.calls[0]!;
@@ -83,7 +83,7 @@ describe('CLI: composio orgs switch', () => {
           })
         );
 
-        yield* cli(['orgs', 'switch', '--org-id', 'org_manual']);
+        yield* cli(['manage', 'orgs', 'switch', '--org-id', 'org_manual']);
 
         expect(fetchSpy).toHaveBeenCalledTimes(1);
         const [projectUrl, projectRequest] = fetchSpy.mock.calls[0]!;

--- a/ts/packages/cli/test/src/commands/projects/projects.list.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/projects/projects.list.cmd.test.ts
@@ -9,7 +9,7 @@ const mockFetchResponse = (body: unknown, status = 200) =>
     headers: { 'Content-Type': 'application/json' },
   });
 
-describe('CLI: composio projects list', () => {
+describe('CLI: composio manage projects list', () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -26,7 +26,7 @@ describe('CLI: composio projects list', () => {
           })
         );
 
-        yield* cli(['projects', 'list', '--org-id', 'org_1']);
+        yield* cli(['manage', 'projects', 'list', '--org-id', 'org_1']);
 
         expect(fetchSpy).toHaveBeenCalledTimes(1);
         const [projectUrl, projectRequest] = fetchSpy.mock.calls[0]!;
@@ -41,9 +41,11 @@ describe('CLI: composio projects list', () => {
         expect(output).toContain('✓ Project One (project_1)');
         expect(output).toContain('  Project Two (project_2)');
         expect(output).toContain(
-          'Hint: run `composio projects switch` to switch the default global project.'
+          'Hint: run `composio manage projects switch` to switch the default global project.'
         );
-        expect(output).toContain('Run `composio orgs switch` to switch org and project together.');
+        expect(output).toContain(
+          'Run `composio manage orgs switch` to switch org and project together.'
+        );
       })
     );
   });

--- a/ts/packages/cli/test/src/commands/projects/projects.switch.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/projects/projects.switch.cmd.test.ts
@@ -20,7 +20,7 @@ const mockFetchResponse = (body: unknown, status = 200) =>
     headers: { 'Content-Type': 'application/json' },
   });
 
-describe('CLI: composio projects switch', () => {
+describe('CLI: composio manage projects switch', () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -39,7 +39,7 @@ describe('CLI: composio projects switch', () => {
             })
           );
 
-          yield* cli(['projects', 'switch', '--org-id', 'org_manual']);
+          yield* cli(['manage', 'projects', 'switch', '--org-id', 'org_manual']);
 
           expect(fetchSpy).toHaveBeenCalledTimes(1);
           const [projectUrl, projectRequest] = fetchSpy.mock.calls[0]!;
@@ -58,7 +58,9 @@ describe('CLI: composio projects switch', () => {
           expect(userConfig.project_id).toBe('project_1');
 
           const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
-          expect(output).toContain('To switch organization as well, run `composio orgs switch`.');
+          expect(output).toContain(
+            'To switch organization as well, run `composio manage orgs switch`.'
+          );
         })
     );
   });

--- a/ts/packages/cli/test/src/commands/toolkits/toolkits.info.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/toolkits/toolkits.info.cmd.test.ts
@@ -129,13 +129,13 @@ const testConfigProvider = ConfigProvider.fromMap(
   new Map([['COMPOSIO_USER_API_KEY', 'test_api_key']])
 ).pipe(extendConfigProvider);
 
-describe('CLI: composio toolkits info', () => {
+describe('CLI: composio manage toolkits info', () => {
   layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
     '[Given] valid slug "gmail"',
     it => {
       it.scoped('shows detailed info with connection status', () =>
         Effect.gen(function* () {
-          yield* cli(['toolkits', 'info', 'gmail']);
+          yield* cli(['manage', 'toolkits', 'info', 'gmail']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -165,7 +165,7 @@ describe('CLI: composio toolkits info', () => {
     it => {
       it.scoped('uses global test user id for toolkit info', () =>
         Effect.gen(function* () {
-          yield* cli(['toolkits', 'info', 'gmail']);
+          yield* cli(['manage', 'toolkits', 'info', 'gmail']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -181,7 +181,7 @@ describe('CLI: composio toolkits info', () => {
     it => {
       it.scoped('shows "no auth"', () =>
         Effect.gen(function* () {
-          yield* cli(['toolkits', 'info', 'codeinterpreter']);
+          yield* cli(['manage', 'toolkits', 'info', 'codeinterpreter']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -199,7 +199,7 @@ describe('CLI: composio toolkits info', () => {
     it => {
       it.scoped('shows full auth config setup fields', () =>
         Effect.gen(function* () {
-          yield* cli(['toolkits', 'info', 'gmail', '--all']);
+          yield* cli(['manage', 'toolkits', 'info', 'gmail', '--all']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -218,7 +218,7 @@ describe('CLI: composio toolkits info', () => {
     it => {
       it.scoped('shows error', () =>
         Effect.gen(function* () {
-          yield* cli(['toolkits', 'info', 'gmal']).pipe(Effect.either);
+          yield* cli(['manage', 'toolkits', 'info', 'gmal']).pipe(Effect.either);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -233,12 +233,12 @@ describe('CLI: composio toolkits info', () => {
     it => {
       it.scoped('shows error with hint', () =>
         Effect.gen(function* () {
-          yield* cli(['toolkits', 'info', 'gma']).pipe(Effect.either);
+          yield* cli(['manage', 'toolkits', 'info', 'gma']).pipe(Effect.either);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
           expect(output).toContain('Toolkit "gma" not found');
-          expect(output).toContain('composio toolkits info "gmail"');
+          expect(output).toContain('composio manage toolkits info "gmail"');
         })
       );
     }
@@ -249,12 +249,12 @@ describe('CLI: composio toolkits info', () => {
     it => {
       it.scoped('shows missing argument warning with tip', () =>
         Effect.gen(function* () {
-          yield* cli(['toolkits', 'info']);
+          yield* cli(['manage', 'toolkits', 'info']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
           expect(output).toContain('Missing required argument');
-          expect(output).toContain('composio toolkits info "gmail"');
+          expect(output).toContain('composio manage toolkits info "gmail"');
         })
       );
     }
@@ -263,7 +263,7 @@ describe('CLI: composio toolkits info', () => {
   layer(TestLive())('[Given] no API key', it => {
     it.scoped('warns user to login', () =>
       Effect.gen(function* () {
-        yield* cli(['toolkits', 'info', 'gmail']);
+        yield* cli(['manage', 'toolkits', 'info', 'gmail']);
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
         const output = lines.join('\n');
 

--- a/ts/packages/cli/test/src/commands/toolkits/toolkits.list.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/toolkits/toolkits.list.cmd.test.ts
@@ -67,13 +67,13 @@ const testConfigProvider = ConfigProvider.fromMap(
   new Map([['COMPOSIO_USER_API_KEY', 'test_api_key']])
 ).pipe(extendConfigProvider);
 
-describe('CLI: composio toolkits list', () => {
+describe('CLI: composio manage toolkits list', () => {
   layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
     '[Given] no flags [Then] lists all toolkits with unified table',
     it => {
       it.scoped('lists all toolkits with catalog and connection columns', () =>
         Effect.gen(function* () {
-          yield* cli(['toolkits', 'list']);
+          yield* cli(['manage', 'toolkits', 'list']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -100,7 +100,7 @@ describe('CLI: composio toolkits list', () => {
     it => {
       it.scoped('shows connected column with global test user id', () =>
         Effect.gen(function* () {
-          yield* cli(['toolkits', 'list']);
+          yield* cli(['manage', 'toolkits', 'list']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -116,7 +116,7 @@ describe('CLI: composio toolkits list', () => {
     it => {
       it.scoped('shows connected column with explicit user id', () =>
         Effect.gen(function* () {
-          yield* cli(['toolkits', 'list', '--user-id', 'default']);
+          yield* cli(['manage', 'toolkits', 'list', '--user-id', 'default']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -132,7 +132,7 @@ describe('CLI: composio toolkits list', () => {
     it => {
       it.scoped('shows filtered results', () =>
         Effect.gen(function* () {
-          yield* cli(['toolkits', 'list', '--query', 'email']);
+          yield* cli(['manage', 'toolkits', 'list', '--query', 'email']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -149,7 +149,7 @@ describe('CLI: composio toolkits list', () => {
     it => {
       it.scoped('respects limit', () =>
         Effect.gen(function* () {
-          yield* cli(['toolkits', 'list', '--limit', '2']);
+          yield* cli(['manage', 'toolkits', 'list', '--limit', '2']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -162,7 +162,7 @@ describe('CLI: composio toolkits list', () => {
   layer(TestLive())('[Given] no API key', it => {
     it.scoped('warns user to login', () =>
       Effect.gen(function* () {
-        yield* cli(['toolkits', 'list']);
+        yield* cli(['manage', 'toolkits', 'list']);
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
         const output = lines.join('\n');
 
@@ -174,7 +174,7 @@ describe('CLI: composio toolkits list', () => {
   layer(TestLive({ baseConfigProvider: testConfigProvider }))('[Given] empty results', it => {
     it.scoped('shows no toolkits found', () =>
       Effect.gen(function* () {
-        yield* cli(['toolkits', 'list']);
+        yield* cli(['manage', 'toolkits', 'list']);
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
         const output = lines.join('\n');
 

--- a/ts/packages/cli/test/src/commands/toolkits/toolkits.search.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/toolkits/toolkits.search.cmd.test.ts
@@ -67,13 +67,13 @@ const testConfigProvider = ConfigProvider.fromMap(
   new Map([['COMPOSIO_USER_API_KEY', 'test_api_key']])
 ).pipe(extendConfigProvider);
 
-describe('CLI: composio toolkits search', () => {
+describe('CLI: composio manage toolkits search', () => {
   layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
     '[Given] query "email"',
     it => {
       it.scoped('shows matching toolkits', () =>
         Effect.gen(function* () {
-          yield* cli(['toolkits', 'search', 'email']);
+          yield* cli(['manage', 'toolkits', 'search', 'email']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -91,7 +91,7 @@ describe('CLI: composio toolkits search', () => {
     it => {
       it.scoped('shows "No toolkits found"', () =>
         Effect.gen(function* () {
-          yield* cli(['toolkits', 'search', 'xyzzy']);
+          yield* cli(['manage', 'toolkits', 'search', 'xyzzy']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -106,7 +106,7 @@ describe('CLI: composio toolkits search', () => {
     it => {
       it.scoped('respects limit', () =>
         Effect.gen(function* () {
-          yield* cli(['toolkits', 'search', 'email', '--limit', '1']);
+          yield* cli(['manage', 'toolkits', 'search', 'email', '--limit', '1']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -119,7 +119,7 @@ describe('CLI: composio toolkits search', () => {
   layer(TestLive())('[Given] no API key', it => {
     it.scoped('warns user to login', () =>
       Effect.gen(function* () {
-        yield* cli(['toolkits', 'search', 'email']);
+        yield* cli(['manage', 'toolkits', 'search', 'email']);
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
         const output = lines.join('\n');
 

--- a/ts/packages/cli/test/src/commands/toolkits/toolkits.version.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/toolkits/toolkits.version.cmd.test.ts
@@ -76,13 +76,13 @@ const parseLastJson = (lines: ReadonlyArray<string>) => {
   throw new Error('Expected JSON output but none found');
 };
 
-describe('CLI: composio toolkits version', () => {
+describe('CLI: composio manage toolkits version', () => {
   layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
     '[Given] valid slug [Then] shows latest and last 20 versions',
     it => {
       it.scoped('prints latest version and truncates to last 20', () =>
         Effect.gen(function* () {
-          yield* cli(['toolkits', 'version', 'gmail']);
+          yield* cli(['manage', 'toolkits', 'version', 'gmail']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
           const json = parseLastJson(lines);
@@ -105,12 +105,12 @@ describe('CLI: composio toolkits version', () => {
     it => {
       it.scoped('prints fetch failure and browse hint', () =>
         Effect.gen(function* () {
-          yield* cli(['toolkits', 'version', 'unknown']).pipe(Effect.either);
+          yield* cli(['manage', 'toolkits', 'version', 'unknown']).pipe(Effect.either);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
           expect(output).toContain('Toolkit "unknown" not found');
-          expect(output).toContain('composio toolkits list');
+          expect(output).toContain('composio manage toolkits list');
         })
       );
     }
@@ -119,7 +119,7 @@ describe('CLI: composio toolkits version', () => {
   layer(TestLive())('[Given] no API key [Then] warns user to login', it => {
     it.scoped('warns user to login', () =>
       Effect.gen(function* () {
-        yield* cli(['toolkits', 'version', 'gmail']);
+        yield* cli(['manage', 'toolkits', 'version', 'gmail']);
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
         const output = lines.join('\n');
 

--- a/ts/packages/cli/test/src/commands/tools/tools.execute.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/tools/tools.execute.cmd.test.ts
@@ -30,7 +30,7 @@ const parseLastJson = (lines: ReadonlyArray<string>) => {
   throw new Error('Expected JSON output but none found');
 };
 
-describe('CLI: composio tools execute', () => {
+describe('CLI: composio manage tools execute', () => {
   // Disable CI redaction so tests see raw values.
   // The explicit CI-redaction test overrides via vi.spyOn and is unaffected.
   let savedCI: string | undefined;
@@ -51,6 +51,7 @@ describe('CLI: composio tools execute', () => {
     it.scoped('executes via Tool Router with defaults', () =>
       Effect.gen(function* () {
         yield* cli([
+          'manage',
           'tools',
           'execute',
           'GMAIL_SEND_EMAIL',
@@ -76,7 +77,7 @@ describe('CLI: composio tools execute', () => {
       baseConfigProvider: testConfigProvider,
       stdin: { isTTY: true, data: '' },
     })
-  )('[Given] composio execute alias [Then] works like composio tools execute', it => {
+  )('[Given] composio execute alias [Then] works like composio manage tools execute', it => {
     it.scoped('alias expands to tools execute', () =>
       Effect.gen(function* () {
         yield* cli([
@@ -108,7 +109,7 @@ describe('CLI: composio tools execute', () => {
     it => {
       it.scoped('uses global test user id from user_data.json', () =>
         Effect.gen(function* () {
-          yield* cli(['tools', 'execute', 'GMAIL_SEND_EMAIL', '-d', '{"recipient":"a"}']);
+          yield* cli(['manage', 'tools', 'execute', 'GMAIL_SEND_EMAIL', '-d', '{"recipient":"a"}']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = parseLastJson(lines);
           const text = lines.join('\n');
@@ -199,7 +200,15 @@ describe('CLI: composio tools execute', () => {
   )('[Given] execute-help with options before slug [Then] resolves correct slug', it => {
     it.scoped('does not treat --user-id value as slug', () =>
       Effect.gen(function* () {
-        yield* cli(['tools', 'execute', '--user-id', 'default', 'GMAIL_SEND_EMAIL', '--help']);
+        yield* cli([
+          'manage',
+          'tools',
+          'execute',
+          '--user-id',
+          'default',
+          'GMAIL_SEND_EMAIL',
+          '--help',
+        ]);
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
         const output = lines.join('\n');
 
@@ -219,7 +228,7 @@ describe('CLI: composio tools execute', () => {
   )('[Given] stdin is piped [Then] reads input from stdin', it => {
     it.scoped('reads stdin input', () =>
       Effect.gen(function* () {
-        yield* cli(['tools', 'execute', 'GITHUB_GET_REPOS', '--user-id', 'default']);
+        yield* cli(['manage', 'tools', 'execute', 'GITHUB_GET_REPOS', '--user-id', 'default']);
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
         const output = parseLastJson(lines);
 
@@ -245,6 +254,7 @@ describe('CLI: composio tools execute', () => {
     it.scoped('prints connected account tips for legacy slug', () =>
       Effect.gen(function* () {
         yield* cli([
+          'manage',
           'tools',
           'execute',
           'GMAIL_CREATE_EMAIL_DRAFT',
@@ -258,7 +268,7 @@ describe('CLI: composio tools execute', () => {
 
         expect(output).toContain('No connected account found');
         expect(output).toContain('Tips');
-        expect(output).toContain('composio connected-accounts link');
+        expect(output).toContain('composio manage connected-accounts link');
       })
     );
   });
@@ -287,6 +297,7 @@ describe('CLI: composio tools execute', () => {
     it.scoped('prints connection tips with toolkit name derived from tool slug', () =>
       Effect.gen(function* () {
         yield* cli([
+          'manage',
           'tools',
           'execute',
           'GMAIL_CREATE_EMAIL_DRAFT',
@@ -300,7 +311,7 @@ describe('CLI: composio tools execute', () => {
 
         expect(output).toContain('No active connection');
         expect(output).toContain('Tips');
-        expect(output).toContain('composio connected-accounts link gmail');
+        expect(output).toContain('composio manage connected-accounts link gmail');
       })
     );
   });
@@ -321,6 +332,7 @@ describe('CLI: composio tools execute', () => {
     it.scoped('flows through real ToolsExecutorLive with custom mock', () =>
       Effect.gen(function* () {
         yield* cli([
+          'manage',
           'tools',
           'execute',
           'GITHUB_STAR_REPO',
@@ -356,6 +368,7 @@ describe('CLI: composio tools execute', () => {
     it.scoped('prints actionable error details', () =>
       Effect.gen(function* () {
         yield* cli([
+          'manage',
           'tools',
           'execute',
           'GMAIL_CREATE_EMAIL_DRAFT',
@@ -384,6 +397,7 @@ describe('CLI: composio tools execute', () => {
     it.scoped('prints object error message and details', () =>
       Effect.gen(function* () {
         yield* cli([
+          'manage',
           'tools',
           'execute',
           'GMAIL_CREATE_EMAIL_DRAFT',
@@ -421,6 +435,7 @@ describe('CLI: composio tools execute', () => {
     it.scoped('shows error and logId for soft failure', () =>
       Effect.gen(function* () {
         yield* cli([
+          'manage',
           'tools',
           'execute',
           'GMAIL_CREATE_EMAIL_DRAFT',
@@ -459,6 +474,7 @@ describe('CLI: composio tools execute', () => {
     it.scoped('shows error without logId for soft failure', () =>
       Effect.gen(function* () {
         yield* cli([
+          'manage',
           'tools',
           'execute',
           'GMAIL_CREATE_EMAIL_DRAFT',
@@ -497,6 +513,7 @@ describe('CLI: composio tools execute', () => {
     it.scoped('omits connection tips for meta tool slugs', () =>
       Effect.gen(function* () {
         yield* cli([
+          'manage',
           'tools',
           'execute',
           'COMPOSIO_SEARCH_TOOLS',
@@ -526,6 +543,7 @@ describe('CLI: composio tools execute', () => {
     it.scoped('fails with invalid JSON error', () =>
       Effect.gen(function* () {
         const result = yield* cli([
+          'manage',
           'tools',
           'execute',
           'GMAIL_SEND_EMAIL',
@@ -552,6 +570,7 @@ describe('CLI: composio tools execute', () => {
     it.scoped('fails with expected object error', () =>
       Effect.gen(function* () {
         const result = yield* cli([
+          'manage',
           'tools',
           'execute',
           'GMAIL_SEND_EMAIL',
@@ -578,6 +597,7 @@ describe('CLI: composio tools execute', () => {
     it.scoped('fails with expected object error for string', () =>
       Effect.gen(function* () {
         const result = yield* cli([
+          'manage',
           'tools',
           'execute',
           'GMAIL_SEND_EMAIL',
@@ -604,6 +624,7 @@ describe('CLI: composio tools execute', () => {
     it.scoped('fails with missing input error', () =>
       Effect.gen(function* () {
         const result = yield* cli([
+          'manage',
           'tools',
           'execute',
           'GMAIL_SEND_EMAIL',
@@ -628,6 +649,7 @@ describe('CLI: composio tools execute', () => {
     it.scoped('fails with error for empty stdin', () =>
       Effect.gen(function* () {
         const result = yield* cli([
+          'manage',
           'tools',
           'execute',
           'GMAIL_SEND_EMAIL',
@@ -674,6 +696,7 @@ describe('CLI: composio tools execute', () => {
 
         try {
           yield* cli([
+            'manage',
             'tools',
             'execute',
             'GMAIL_SEND_EMAIL',

--- a/ts/packages/cli/test/src/commands/tools/tools.info.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/tools/tools.info.cmd.test.ts
@@ -49,13 +49,13 @@ const testConfigProvider = ConfigProvider.fromMap(
   new Map([['COMPOSIO_USER_API_KEY', 'test_api_key']])
 ).pipe(extendConfigProvider);
 
-describe('CLI: composio tools info', () => {
+describe('CLI: composio manage tools info', () => {
   layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
     '[Given] valid slug [Then] displays tool info',
     it => {
       it.scoped('shows tool details with input/output schemas', () =>
         Effect.gen(function* () {
-          yield* cli(['tools', 'info', 'GMAIL_SEND_EMAIL']);
+          yield* cli(['manage', 'tools', 'info', 'GMAIL_SEND_EMAIL']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -67,7 +67,7 @@ describe('CLI: composio tools info', () => {
           expect(output).toContain('Output Parameters');
           expect(output).toContain('message_id');
           // Verify next-step hint includes derived toolkit slug
-          expect(output).toContain('composio tools list --toolkits "gmail"');
+          expect(output).toContain('composio manage tools list --toolkits "gmail"');
         })
       );
     }
@@ -78,7 +78,7 @@ describe('CLI: composio tools info', () => {
     it => {
       it.scoped('shows missing argument warning', () =>
         Effect.gen(function* () {
-          yield* cli(['tools', 'info']);
+          yield* cli(['manage', 'tools', 'info']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -93,7 +93,7 @@ describe('CLI: composio tools info', () => {
     it => {
       it.scoped('shows not found with suggestions', () =>
         Effect.gen(function* () {
-          yield* cli(['tools', 'info', 'NONEXISTENT_TOOL']);
+          yield* cli(['manage', 'tools', 'info', 'NONEXISTENT_TOOL']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -106,7 +106,7 @@ describe('CLI: composio tools info', () => {
   layer(TestLive())('[Given] no API key [Then] warns user to login', it => {
     it.scoped('warns user to login', () =>
       Effect.gen(function* () {
-        yield* cli(['tools', 'info', 'GMAIL_SEND_EMAIL']);
+        yield* cli(['manage', 'tools', 'info', 'GMAIL_SEND_EMAIL']);
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
         const output = lines.join('\n');
 

--- a/ts/packages/cli/test/src/commands/tools/tools.list.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/tools/tools.list.cmd.test.ts
@@ -55,13 +55,13 @@ const testConfigProvider = ConfigProvider.fromMap(
   new Map([['COMPOSIO_USER_API_KEY', 'test_api_key']])
 ).pipe(extendConfigProvider);
 
-describe('CLI: composio tools list', () => {
+describe('CLI: composio manage tools list', () => {
   layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
     '[Given] no flags [Then] lists all tools',
     it => {
       it.scoped('lists all tools', () =>
         Effect.gen(function* () {
-          yield* cli(['tools', 'list']);
+          yield* cli(['manage', 'tools', 'list']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -78,7 +78,7 @@ describe('CLI: composio tools list', () => {
     it => {
       it.scoped('filters by toolkit', () =>
         Effect.gen(function* () {
-          yield* cli(['tools', 'list', '--toolkits', 'gmail']);
+          yield* cli(['manage', 'tools', 'list', '--toolkits', 'gmail']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -96,7 +96,7 @@ describe('CLI: composio tools list', () => {
     it => {
       it.scoped('filters by search query', () =>
         Effect.gen(function* () {
-          yield* cli(['tools', 'list', '--query', 'send']);
+          yield* cli(['manage', 'tools', 'list', '--query', 'send']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -113,7 +113,7 @@ describe('CLI: composio tools list', () => {
     it => {
       it.scoped('respects limit', () =>
         Effect.gen(function* () {
-          yield* cli(['tools', 'list', '--limit', '2']);
+          yield* cli(['manage', 'tools', 'list', '--limit', '2']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -126,7 +126,7 @@ describe('CLI: composio tools list', () => {
   layer(TestLive())('[Given] no API key [Then] warns user to login', it => {
     it.scoped('warns user to login', () =>
       Effect.gen(function* () {
-        yield* cli(['tools', 'list']);
+        yield* cli(['manage', 'tools', 'list']);
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
         const output = lines.join('\n');
 
@@ -140,7 +140,7 @@ describe('CLI: composio tools list', () => {
     it => {
       it.scoped('shows no tools found', () =>
         Effect.gen(function* () {
-          yield* cli(['tools', 'list']);
+          yield* cli(['manage', 'tools', 'list']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -155,7 +155,7 @@ describe('CLI: composio tools list', () => {
     it => {
       it.scoped('filters by tag', () =>
         Effect.gen(function* () {
-          yield* cli(['tools', 'list', '--tags', 'email']);
+          yield* cli(['manage', 'tools', 'list', '--tags', 'email']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -172,12 +172,12 @@ describe('CLI: composio tools list', () => {
     it => {
       it.scoped('shows hint about verifying toolkit slug', () =>
         Effect.gen(function* () {
-          yield* cli(['tools', 'list', '--toolkits', 'nonexistent']);
+          yield* cli(['manage', 'tools', 'list', '--toolkits', 'nonexistent']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
           expect(output).toContain('No tools found');
-          expect(output).toContain('composio toolkits list');
+          expect(output).toContain('composio manage toolkits list');
         })
       );
     }

--- a/ts/packages/cli/test/src/commands/tools/tools.search.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/tools/tools.search.cmd.test.ts
@@ -53,11 +53,11 @@ const testLiveOptions = {
   fixture: 'global-test-user-id' as const,
 };
 
-describe('CLI: composio tools search', () => {
+describe('CLI: composio manage tools search', () => {
   layer(TestLive(testLiveOptions))('[Given] query "send" [Then] returns matching tools', it => {
     it.scoped('returns matching tools', () =>
       Effect.gen(function* () {
-        yield* cli(['tools', 'search', 'send']);
+        yield* cli(['manage', 'tools', 'search', 'send']);
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
         const output = lines.join('\n');
 
@@ -74,7 +74,7 @@ describe('CLI: composio tools search', () => {
     it => {
       it.scoped('shows not found message', () =>
         Effect.gen(function* () {
-          yield* cli(['tools', 'search', 'nonexistent_query']);
+          yield* cli(['manage', 'tools', 'search', 'nonexistent_query']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -89,7 +89,7 @@ describe('CLI: composio tools search', () => {
     it => {
       it.scoped('scopes search to toolkit', () =>
         Effect.gen(function* () {
-          yield* cli(['tools', 'search', 'send', '--toolkits', 'gmail']);
+          yield* cli(['manage', 'tools', 'search', 'send', '--toolkits', 'gmail']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
           const humanOutput = output.split('\n{')[0] ?? output;
@@ -107,7 +107,7 @@ describe('CLI: composio tools search', () => {
     it => {
       it.scoped('prints full search response with CTA for jq', () =>
         Effect.gen(function* () {
-          yield* cli(['tools', 'search', 'send']);
+          yield* cli(['manage', 'tools', 'search', 'send']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -157,7 +157,7 @@ describe('CLI: composio tools search', () => {
             },
           });
 
-          yield* cli(['tools', 'search', 'send']).pipe(Effect.provide(live));
+          yield* cli(['manage', 'tools', 'search', 'send']).pipe(Effect.provide(live));
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -249,7 +249,7 @@ describe('CLI: composio tools search', () => {
             },
           });
 
-          yield* cli(['tools', 'search', 'send', '--toolkits', 'gmail,outlook']).pipe(
+          yield* cli(['manage', 'tools', 'search', 'send', '--toolkits', 'gmail,outlook']).pipe(
             Effect.provide(live)
           );
 
@@ -316,16 +316,16 @@ describe('CLI: composio tools search', () => {
             },
           });
 
-          yield* cli(['tools', 'search', 'send email']).pipe(Effect.provide(live));
+          yield* cli(['manage', 'tools', 'search', 'send email']).pipe(Effect.provide(live));
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
           expect(output).toContain('Plan:');
           expect(output).toContain('1. Collect recipient details');
           expect(output).toContain('Hints:');
-          expect(output).toContain('composio tools info "GMAIL_SEND_EMAIL"');
+          expect(output).toContain('composio manage tools info "GMAIL_SEND_EMAIL"');
           expect(output).toContain(
-            `composio tools execute "GMAIL_SEND_EMAIL" --user-id "<user-id>" --arguments '{}'`
+            `composio manage tools execute "GMAIL_SEND_EMAIL" --user-id "<user-id>" --arguments '{}'`
           );
         })
       );
@@ -335,7 +335,7 @@ describe('CLI: composio tools search', () => {
   layer(TestLive())('[Given] no API key [Then] warns user to login', it => {
     it.scoped('warns user to login', () =>
       Effect.gen(function* () {
-        yield* cli(['tools', 'search', 'send']);
+        yield* cli(['manage', 'tools', 'search', 'send']);
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
         const output = lines.join('\n');
 
@@ -365,7 +365,9 @@ describe('CLI: composio tools search', () => {
             },
           });
 
-          yield* cli(['tools', 'search', 'send', '--user-id', 'alice']).pipe(Effect.provide(live));
+          yield* cli(['manage', 'tools', 'search', 'send', '--user-id', 'alice']).pipe(
+            Effect.provide(live)
+          );
 
           expect(createParams?.user_id).toBe('alice');
         })
@@ -378,7 +380,7 @@ describe('CLI: composio tools search', () => {
     it => {
       it.scoped('fails when user id cannot be resolved', () =>
         Effect.gen(function* () {
-          const err = yield* cli(['tools', 'search', 'send']).pipe(Effect.flip);
+          const err = yield* cli(['manage', 'tools', 'search', 'send']).pipe(Effect.flip);
           const message = err instanceof Error ? err.message : String(err);
 
           expect(message).toContain('Missing user id');
@@ -390,7 +392,7 @@ describe('CLI: composio tools search', () => {
   );
 
   layer(TestLive(testLiveOptions))(
-    '[Given] composio search alias [Then] works like composio tools search',
+    '[Given] composio search alias [Then] works like composio manage tools search',
     it => {
       it.scoped('alias expands to tools search', () =>
         Effect.gen(function* () {

--- a/ts/packages/cli/test/src/commands/triggers/triggers.info.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/triggers/triggers.info.cmd.test.ts
@@ -54,13 +54,13 @@ const testConfigProvider = ConfigProvider.fromMap(
   new Map([['COMPOSIO_USER_API_KEY', 'test_api_key']])
 ).pipe(extendConfigProvider);
 
-describe('CLI: composio triggers info', () => {
+describe('CLI: composio manage triggers info', () => {
   layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
     '[Given] valid slug [Then] displays trigger type info',
     it => {
       it.scoped('shows trigger details with config and payload fields', () =>
         Effect.gen(function* () {
-          yield* cli(['triggers', 'info', 'GMAIL_NEW_GMAIL_MESSAGE']);
+          yield* cli(['manage', 'triggers', 'info', 'GMAIL_NEW_GMAIL_MESSAGE']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -73,7 +73,7 @@ describe('CLI: composio triggers info', () => {
           expect(output).toContain('subject');
           expect(output).toContain('default:');
           expect(output).toContain('false');
-          expect(output).toContain('composio triggers list --toolkits "gmail"');
+          expect(output).toContain('composio manage triggers list --toolkits "gmail"');
         })
       );
     }
@@ -84,7 +84,7 @@ describe('CLI: composio triggers info', () => {
     it => {
       it.scoped('shows missing argument warning', () =>
         Effect.gen(function* () {
-          yield* cli(['triggers', 'info']);
+          yield* cli(['manage', 'triggers', 'info']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -99,12 +99,12 @@ describe('CLI: composio triggers info', () => {
     it => {
       it.scoped('shows not found fallback hint', () =>
         Effect.gen(function* () {
-          yield* cli(['triggers', 'info', 'NONEXISTENT_TRIGGER']);
+          yield* cli(['manage', 'triggers', 'info', 'NONEXISTENT_TRIGGER']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
           expect(output).toContain('not found');
-          expect(output).toContain('composio triggers list');
+          expect(output).toContain('composio manage triggers list');
         })
       );
     }
@@ -113,7 +113,7 @@ describe('CLI: composio triggers info', () => {
   layer(TestLive())('[Given] no API key [Then] warns user to login', it => {
     it.scoped('warns user to login', () =>
       Effect.gen(function* () {
-        yield* cli(['triggers', 'info', 'GMAIL_NEW_GMAIL_MESSAGE']);
+        yield* cli(['manage', 'triggers', 'info', 'GMAIL_NEW_GMAIL_MESSAGE']);
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
         const output = lines.join('\n');
 

--- a/ts/packages/cli/test/src/commands/triggers/triggers.list.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/triggers/triggers.list.cmd.test.ts
@@ -46,13 +46,13 @@ const testConfigProvider = ConfigProvider.fromMap(
   new Map([['COMPOSIO_USER_API_KEY', 'test_api_key']])
 ).pipe(extendConfigProvider);
 
-describe('CLI: composio triggers list', () => {
+describe('CLI: composio manage triggers list', () => {
   layer(TestLive({ baseConfigProvider: testConfigProvider, toolkitsData }))(
     '[Given] no flags [Then] lists all trigger types',
     it => {
       it.scoped('lists all trigger types', () =>
         Effect.gen(function* () {
-          yield* cli(['triggers', 'list']);
+          yield* cli(['manage', 'triggers', 'list']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -69,7 +69,7 @@ describe('CLI: composio triggers list', () => {
     it => {
       it.scoped('filters by toolkit', () =>
         Effect.gen(function* () {
-          yield* cli(['triggers', 'list', '--toolkits', 'gmail']);
+          yield* cli(['manage', 'triggers', 'list', '--toolkits', 'gmail']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -87,7 +87,7 @@ describe('CLI: composio triggers list', () => {
     it => {
       it.scoped('uses singular form for one result', () =>
         Effect.gen(function* () {
-          yield* cli(['triggers', 'list', '--limit', '1']);
+          yield* cli(['manage', 'triggers', 'list', '--limit', '1']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -103,11 +103,11 @@ describe('CLI: composio triggers list', () => {
     it => {
       it.scoped('shows hint to view trigger details', () =>
         Effect.gen(function* () {
-          yield* cli(['triggers', 'list']);
+          yield* cli(['manage', 'triggers', 'list']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
-          expect(output).toContain('composio triggers info');
+          expect(output).toContain('composio manage triggers info');
         })
       );
     }
@@ -116,7 +116,7 @@ describe('CLI: composio triggers list', () => {
   layer(TestLive())('[Given] no API key [Then] warns user to login', it => {
     it.scoped('warns user to login', () =>
       Effect.gen(function* () {
-        yield* cli(['triggers', 'list']);
+        yield* cli(['manage', 'triggers', 'list']);
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
         const output = lines.join('\n');
 
@@ -130,7 +130,7 @@ describe('CLI: composio triggers list', () => {
     it => {
       it.scoped('shows no trigger types found', () =>
         Effect.gen(function* () {
-          yield* cli(['triggers', 'list']);
+          yield* cli(['manage', 'triggers', 'list']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -145,12 +145,12 @@ describe('CLI: composio triggers list', () => {
     it => {
       it.scoped('shows hint about verifying toolkit slug', () =>
         Effect.gen(function* () {
-          yield* cli(['triggers', 'list', '--toolkits', 'nonexistent']);
+          yield* cli(['manage', 'triggers', 'list', '--toolkits', 'nonexistent']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
           expect(output).toContain('No trigger types found');
-          expect(output).toContain('composio toolkits list');
+          expect(output).toContain('composio manage toolkits list');
         })
       );
     }

--- a/ts/packages/cli/test/src/commands/triggers/triggers.listen.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/triggers/triggers.listen.cmd.test.ts
@@ -106,7 +106,7 @@ const startWebhookServer = async (): Promise<{
   };
 };
 
-describe('CLI: composio triggers listen', () => {
+describe('CLI: composio manage triggers listen', () => {
   layer(
     TestLive({
       baseConfigProvider: testConfigProvider,
@@ -117,7 +117,7 @@ describe('CLI: composio triggers listen', () => {
   )('[Given] one realtime event [Then] prints normalized event output', it => {
     it.scoped('prints event summary and payload', () =>
       Effect.gen(function* () {
-        yield* cli(['triggers', 'listen', '--max-events', '1']);
+        yield* cli(['manage', 'triggers', 'listen', '--max-events', '1']);
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
         const output = lines.join('\n');
 
@@ -137,7 +137,7 @@ describe('CLI: composio triggers listen', () => {
         events: [mockV3TriggerEvent],
       },
     })
-  )('[Given] composio listen alias [Then] works like composio triggers listen', it => {
+  )('[Given] composio listen alias [Then] works like composio manage triggers listen', it => {
     it.scoped('alias expands to triggers listen', () =>
       Effect.gen(function* () {
         yield* cli(['listen', '--max-events', '1']);
@@ -161,7 +161,7 @@ describe('CLI: composio triggers listen', () => {
   )('[Given] --table [Then] prints compact table rows', it => {
     it.scoped('prints table header and event row', () =>
       Effect.gen(function* () {
-        yield* cli(['triggers', 'listen', '--table', '--max-events', '1']);
+        yield* cli(['manage', 'triggers', 'listen', '--table', '--max-events', '1']);
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
         const output = lines.join('\n');
 
@@ -185,7 +185,7 @@ describe('CLI: composio triggers listen', () => {
   layer(TestLive())('[Given] no API key [Then] warns user to login', it => {
     it.scoped('warns user to login', () =>
       Effect.gen(function* () {
-        yield* cli(['triggers', 'listen']);
+        yield* cli(['manage', 'triggers', 'listen']);
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
         const output = lines.join('\n');
         expect(output).toContain('not logged in');
@@ -205,6 +205,7 @@ describe('CLI: composio triggers listen', () => {
         Effect.gen(function* () {
           delete process.env.COMPOSIO_WEBHOOK_SECRET;
           yield* cli([
+            'manage',
             'triggers',
             'listen',
             '--forward',
@@ -247,7 +248,7 @@ describe('CLI: composio triggers listen', () => {
             Effect.tryPromise(() => resource.close()).pipe(Effect.catchAll(() => Effect.void))
         );
 
-        yield* cli(['triggers', 'listen', '--forward', server.url, '--max-events', '1']);
+        yield* cli(['manage', 'triggers', 'listen', '--forward', server.url, '--max-events', '1']);
 
         const request = yield* Effect.tryPromise({
           try: () =>

--- a/ts/packages/cli/test/src/commands/triggers/triggers.mutations.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/triggers/triggers.mutations.cmd.test.ts
@@ -7,13 +7,14 @@ const testConfigProvider = ConfigProvider.fromMap(
   new Map([['COMPOSIO_USER_API_KEY', 'test_api_key']])
 ).pipe(extendConfigProvider);
 
-describe('CLI: composio triggers mutations', () => {
+describe('CLI: composio manage triggers mutations', () => {
   layer(TestLive({ baseConfigProvider: testConfigProvider }))(
     '[Given] create with valid args [Then] creates trigger',
     it => {
       it.scoped('creates trigger and prints id', () =>
         Effect.gen(function* () {
           yield* cli([
+            'manage',
             'triggers',
             'create',
             'GMAIL_NEW_GMAIL_MESSAGE',
@@ -35,7 +36,14 @@ describe('CLI: composio triggers mutations', () => {
     it => {
       it.scoped('rejects invalid trigger config JSON', () =>
         Effect.gen(function* () {
-          yield* cli(['triggers', 'create', 'GMAIL_NEW_GMAIL_MESSAGE', '--trigger-config', '{']);
+          yield* cli([
+            'manage',
+            'triggers',
+            'create',
+            'GMAIL_NEW_GMAIL_MESSAGE',
+            '--trigger-config',
+            '{',
+          ]);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -50,7 +58,7 @@ describe('CLI: composio triggers mutations', () => {
     it => {
       it.scoped('enables trigger successfully', () =>
         Effect.gen(function* () {
-          yield* cli(['triggers', 'enable', 'trg_123']);
+          yield* cli(['manage', 'triggers', 'enable', 'trg_123']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
           expect(output).toContain('enabled');
@@ -64,7 +72,7 @@ describe('CLI: composio triggers mutations', () => {
     it => {
       it.scoped('disables trigger successfully', () =>
         Effect.gen(function* () {
-          yield* cli(['triggers', 'disable', 'trg_123']);
+          yield* cli(['manage', 'triggers', 'disable', 'trg_123']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
           expect(output).toContain('disabled');
@@ -78,7 +86,7 @@ describe('CLI: composio triggers mutations', () => {
     it => {
       it.scoped('deletes trigger successfully', () =>
         Effect.gen(function* () {
-          yield* cli(['triggers', 'delete', 'trg_123', '--yes']);
+          yield* cli(['manage', 'triggers', 'delete', 'trg_123', '--yes']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
           expect(output).toContain('deleted');
@@ -93,6 +101,7 @@ describe('CLI: composio triggers mutations', () => {
       it.scoped('rejects array JSON in --trigger-config', () =>
         Effect.gen(function* () {
           yield* cli([
+            'manage',
             'triggers',
             'create',
             'GMAIL_NEW_GMAIL_MESSAGE',
@@ -108,7 +117,14 @@ describe('CLI: composio triggers mutations', () => {
 
       it.scoped('rejects number JSON in --trigger-config', () =>
         Effect.gen(function* () {
-          yield* cli(['triggers', 'create', 'GMAIL_NEW_GMAIL_MESSAGE', '--trigger-config', '42']);
+          yield* cli([
+            'manage',
+            'triggers',
+            'create',
+            'GMAIL_NEW_GMAIL_MESSAGE',
+            '--trigger-config',
+            '42',
+          ]);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -123,7 +139,7 @@ describe('CLI: composio triggers mutations', () => {
     it => {
       it.scoped('shows missing id warning', () =>
         Effect.gen(function* () {
-          yield* cli(['triggers', 'enable']);
+          yield* cli(['manage', 'triggers', 'enable']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
           expect(output).toContain('Missing required argument');
@@ -137,7 +153,7 @@ describe('CLI: composio triggers mutations', () => {
     it => {
       it.scoped('shows missing id warning', () =>
         Effect.gen(function* () {
-          yield* cli(['triggers', 'disable']);
+          yield* cli(['manage', 'triggers', 'disable']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
           expect(output).toContain('Missing required argument');
@@ -151,7 +167,7 @@ describe('CLI: composio triggers mutations', () => {
     it => {
       it.scoped('shows missing id warning', () =>
         Effect.gen(function* () {
-          yield* cli(['triggers', 'delete']);
+          yield* cli(['manage', 'triggers', 'delete']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
           expect(output).toContain('Missing required argument');

--- a/ts/packages/cli/test/src/commands/triggers/triggers.status.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/triggers/triggers.status.cmd.test.ts
@@ -55,13 +55,13 @@ const testConfigProvider = ConfigProvider.fromMap(
   new Map([['COMPOSIO_USER_API_KEY', 'test_api_key']])
 ).pipe(extendConfigProvider);
 
-describe('CLI: composio triggers status', () => {
+describe('CLI: composio manage triggers status', () => {
   layer(TestLive({ baseConfigProvider: testConfigProvider, triggersData }))(
     '[Given] no flags [Then] lists active triggers only',
     it => {
       it.scoped('lists active trigger instances', () =>
         Effect.gen(function* () {
-          yield* cli(['triggers', 'status']);
+          yield* cli(['manage', 'triggers', 'status']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -79,7 +79,7 @@ describe('CLI: composio triggers status', () => {
     it => {
       it.scoped('includes disabled trigger instances', () =>
         Effect.gen(function* () {
-          yield* cli(['triggers', 'status', '--show-disabled']);
+          yield* cli(['manage', 'triggers', 'status', '--show-disabled']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -96,7 +96,7 @@ describe('CLI: composio triggers status', () => {
     it => {
       it.scoped('filters by user_ids', () =>
         Effect.gen(function* () {
-          yield* cli(['triggers', 'status', '--user-ids', 'user_123']);
+          yield* cli(['manage', 'triggers', 'status', '--user-ids', 'user_123']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -113,7 +113,13 @@ describe('CLI: composio triggers status', () => {
     it => {
       it.scoped('normalizes trigger names to uppercase', () =>
         Effect.gen(function* () {
-          yield* cli(['triggers', 'status', '--trigger-names', 'gmail_new_gmail_message']);
+          yield* cli([
+            'manage',
+            'triggers',
+            'status',
+            '--trigger-names',
+            'gmail_new_gmail_message',
+          ]);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -130,7 +136,7 @@ describe('CLI: composio triggers status', () => {
     it => {
       it.scoped('filters by toolkit prefix in trigger name', () =>
         Effect.gen(function* () {
-          yield* cli(['triggers', 'status', '--toolkits', 'slack']);
+          yield* cli(['manage', 'triggers', 'status', '--toolkits', 'slack']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
@@ -145,7 +151,7 @@ describe('CLI: composio triggers status', () => {
   layer(TestLive())('[Given] no API key [Then] warns user to login', it => {
     it.scoped('warns user to login', () =>
       Effect.gen(function* () {
-        yield* cli(['triggers', 'status']);
+        yield* cli(['manage', 'triggers', 'status']);
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
         const output = lines.join('\n');
 


### PR DESCRIPTION
## Summary

Introduces a `composio manage` namespace that groups resource management commands (toolkits, tools, auth-configs, connected-accounts, triggers, logs, orgs, projects) under a single parent command. This declutters the top-level CLI help and creates a clearer separation between everyday commands (`init`, `login`, `generate`) and advanced resource management.

## Changes
- Created `manage/manage.cmd.ts` with all resource subcommands registered under `composio manage`
- Removed individual top-level imports (toolkits, tools, auth-configs, etc.) from `index.ts` and replaced with single `manageCmd` import
- Updated alias mapping (`ALIAS_TO_PARENT`) to route through `manage` (e.g., `search` → `manage tools`, `link` → `manage connected-accounts`)
- Updated `parseExecuteInputHelpSlug` to account for the new `manage` prefix in argv parsing
- Consolidated the root help advanced commands section to show a single `manage` entry

## Type of change
- [x] Refactor/Chore

## How Has This Been Tested?
- Verified CLI help output displays correctly with the new `manage` namespace
- Tested that aliases (`composio search`, `composio execute`, `composio link`, `composio listen`) still resolve correctly through the `manage` prefix

## Checklist
- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed
- [x] I updated documentation as needed
- [x] I added tests or explain why not applicable
- [x] I added a changeset if this change affects published packages