### PR TITLE
feat(cli): add composio init --install-skills for skill installation

### DIFF
--- a/.claude/skills/create-cli-e2e/SKILL.md
+++ b/.claude/skills/create-cli-e2e/SKILL.md
@@ -225,7 +225,6 @@ e2e(import.meta.url, {
       it('exits with non-zero code', () => {
         expect(missingArgResult.exitCode).not.toBe(0);
       });
-
       it('stderr contains an error message', () => {
         expect(missingArgResult.stderr).not.toBe('');
       });

--- a/.claude/skills/create-cli/SKILL.md
+++ b/.claude/skills/create-cli/SKILL.md
@@ -176,8 +176,8 @@ EXAMPLES
   $ composio generate --toolkits github,slack --type-tools
 
 COMMANDS
-  composio ts generate   Generate TypeScript stubs
-  composio py generate   Generate Python stubs
+  composio generate ts   Generate TypeScript stubs
+  composio generate py   Generate Python stubs
 ```
 
 **Suggest next commands** when it helps the user's flow:

--- a/.claude/skills/implement-cli-command/SKILL.md
+++ b/.claude/skills/implement-cli-command/SKILL.md
@@ -33,13 +33,18 @@ src/
 │   ├── login.cmd.ts          # Complex command (options, spinner, polling)
 │   ├── logout.cmd.ts         # Action command (no stdout data)
 │   ├── upgrade.cmd.ts        # Action command (delegates to service)
-│   ├── generate.cmd.ts       # Command that auto-delegates to subcommands
+│   ├── generate/
+│   │   ├── generate.cmd.ts   # Parent command group for `composio generate`
+│   │   ├── generate-py.cmd.ts # `composio generate py`
+│   │   └── generate-ts.cmd.ts # `composio generate ts`
+│   ├── manage/
+│   │   └── manage.cmd.ts     # Parent command group for `composio manage`
 │   ├── ts/
-│   │   ├── ts.cmd.ts         # Parent command group
+│   │   ├── ts.cmd.ts         # Existing TS generation internals, referenced from generate/
 │   │   └── commands/
-│   │       └── ts.generate.cmd.ts  # Subcommand with complex logic
+│   │       └── ts.generate.cmd.ts  # Reusable TS generation logic
 │   └── py/
-│       ├── py.cmd.ts
+│       ├── py.cmd.ts         # Existing Python generation internals, referenced from generate/
 │       └── commands/
 │           └── py.generate.cmd.ts
 ├── services/                 # Effect services (dependency injection)
@@ -53,11 +58,11 @@ src/
 ### File Naming Convention
 
 - Command files: `<name>.cmd.ts` (e.g., `version.cmd.ts`, `login.cmd.ts`)
-- Subcommand files: `<parent>.<name>.cmd.ts` inside `commands/` (e.g., `ts.generate.cmd.ts`)
-- Parent command groups: `<name>.cmd.ts` at the group level (e.g., `ts/ts.cmd.ts`)
+- Subcommand implementation files: `<parent>.<name>.cmd.ts` inside `commands/` (e.g., `ts.generate.cmd.ts`)
+- Parent command groups: `<name>.cmd.ts` at the group level (e.g., `generate/generate.cmd.ts`, `manage/manage.cmd.ts`)
+- Wrapper subcommand entrypoints can also live beside their parent group (e.g., `generate/generate-py.cmd.ts`, `generate/generate-ts.cmd.ts`)
 
 ## Creating a New Command
-
 ### Step 1: Create the Command File
 
 Create `src/commands/<name>.cmd.ts`.
@@ -147,8 +152,7 @@ const $cmd = $defaultCmd.pipe(
     loginCmd,
     logoutCmd,
     generateCmd,
-    pyCmd,
-    tsCmd,
+    manageCmd,
     myCmd,  // Add here
   ])
 );
@@ -175,8 +179,8 @@ For commands like `composio manage toolkits list`, `composio manage toolkits inf
 ### Step 1: Create the Directory Structure
 
 ```
-src/commands/toolkits/
-├── toolkits.cmd.ts              # Parent command group
+src/commands/manage/toolkits/
+├── toolkits.cmd.ts              # Parent command group under `manage`
 └── commands/
     ├── toolkits.list.cmd.ts     # composio manage toolkits list
     └── toolkits.info.cmd.ts     # composio manage toolkits info
@@ -184,8 +188,7 @@ src/commands/toolkits/
 
 ### Step 2: Create the Parent Command
 
-`src/commands/toolkits/toolkits.cmd.ts`:
-
+`src/commands/manage/toolkits/toolkits.cmd.ts`:
 ```typescript
 import { Command } from '@effect/cli';
 import { toolkitsCmd$List } from './commands/toolkits.list.cmd';
@@ -199,8 +202,7 @@ export const toolkitsCmd = Command.make('toolkits').pipe(
 
 ### Step 3: Create Each Subcommand
 
-`src/commands/toolkits/commands/toolkits.list.cmd.ts`:
-
+`src/commands/manage/toolkits/commands/toolkits.list.cmd.ts`:
 ```typescript
 import { Command, Options } from '@effect/cli';
 import { Effect, Option } from 'effect';
@@ -238,21 +240,22 @@ export const toolkitsCmd$List = Command.make('list', { searchOpt }).pipe(
 );
 ```
 
-### Step 4: Register the Parent in index.ts
+### Step 4: Register the Parent in `manage/manage.cmd.ts`
 
 ```typescript
+import { Command } from '@effect/cli';
 import { toolkitsCmd } from './toolkits/toolkits.cmd';
 
-const $cmd = $defaultCmd.pipe(
+export const manageCmd = Command.make('manage').pipe(
+  Command.withDescription('Manage existing Composio resources.'),
   Command.withSubcommands([
-    // ... existing commands
+    // ... existing manage subcommands
     toolkitsCmd,
   ])
 );
 ```
 
 ## Option Declaration Patterns
-
 Options are declared at module level using `@effect/cli`'s `Options` API. The template above demonstrates the most common types (required text, optional text). For other option types, see `ts/vendor/effect/packages/cli/src/Options.ts`.
 
 Both `Options.optional(Options.text(...))` (wrapping) and `Options.text(...).pipe(Options.optional)` (piped) are valid. Use whichever reads better.
@@ -408,8 +411,7 @@ const [toolkits, tools, triggerTypes] = yield* Effect.all(
 
 ## Extracting Reusable Logic
 
-For commands that share logic (e.g., `composio generate` delegates to `composio ts generate`):
-
+For commands that share logic (e.g., `composio generate` delegates to `composio generate ts`):
 ```typescript
 // In ts.generate.cmd.ts — export the logic separately
 export function generateTypescriptTypeStubs(params: { ... }) {
@@ -425,9 +427,8 @@ export const tsCmd$Generate = Command.make('generate', { ... }).pipe(
 );
 
 // Other commands can reuse it
-// In generate.cmd.ts
-import { generateTypescriptTypeStubs } from './ts/commands/ts.generate.cmd';
-
+// In generate/generate-ts.cmd.ts
+import { generateTypescriptTypeStubs } from '../ts/commands/ts.generate.cmd';
 yield* Match.value(envLang).pipe(
   Match.when('TypeScript', () => generateTypescriptTypeStubs({ ... })),
   Match.when('Python', () => generatePythonTypeStubs({ ... })),
@@ -534,8 +535,9 @@ recordings/
 | `src/commands/login.cmd.ts` | Complex command (options, spinner, polling, retry) |
 | `src/commands/logout.cmd.ts` | Action command (no stdout data) |
 | `src/commands/upgrade.cmd.ts` | Action command delegating to service |
-| `src/commands/generate.cmd.ts` | Auto-detection and delegation to subcommands |
-| `src/commands/ts/commands/ts.generate.cmd.ts` | Full subcommand with parallel fetching, spinner, file I/O |
+| `src/commands/generate/generate.cmd.ts` | Parent `generate` command and delegation entrypoint |
+| `src/commands/manage/manage.cmd.ts` | Parent `manage` command and subcommand registration |
+| `src/commands/ts/commands/ts.generate.cmd.ts` | Reusable TS generation logic used by `generate ts` |
 | `src/commands/index.ts` | Command tree registration |
 | `src/bin.ts` | Entry point, layer composition, error handling |
 | `src/services/terminal-ui.ts` | TerminalUI service interface |

--- a/docs/content/changelog/03-13-26-cli-improvements.mdx
+++ b/docs/content/changelog/03-13-26-cli-improvements.mdx
@@ -46,7 +46,7 @@ composio link github --no-wait    # Prints redirect URL and JSON, exits
 The `composio whoami` command no longer displays API keys in the output. This improves security and reduces the risk of accidental exposure in logs or screenshots.
 
 - API key is removed from both display and JSON output.
-- Hints for `composio orgs switch` and `composio init` are shown instead.
+- Hints for `composio manage orgs switch` and `composio init` are shown instead.
 
 ---
 
@@ -86,4 +86,4 @@ composio init            # Interactive project selection
 
 - **Login JSON output**: When using the org/project picker, the JSON output now reflects the final selection (not the initial session state).
 - **Picker error handling**: If the org/project picker fails (e.g. API error), the CLI shows a warning, emits JSON with session data, and displays hints so you are not left without guidance.
-- **Modularized org/project selection**: The selection logic is shared between `composio login` and `composio orgs switch`.
+- **Modularized org/project selection**: The selection logic is shared between `composio login` and `composio manage orgs switch`.

--- a/docs/content/docs/cli.mdx
+++ b/docs/content/docs/cli.mdx
@@ -33,32 +33,32 @@ composio whoami
 
 ```bash
 # Connect your GitHub account
-composio connected-accounts link github
+composio manage connected-accounts link github
 
 # Print connect URL + JSON and exit immediately (no wait)
-composio connected-accounts link github --no-wait
+composio manage connected-accounts link github --no-wait
 
 # Search for tools
-composio tools search "star a github repo"
+composio manage tools search "star a github repo"
 
 # Look up a tool's input schema
-composio tools info GITHUB_STAR_A_REPOSITORY_FOR_THE_AUTHENTICATED_USER
+composio manage tools info GITHUB_STAR_A_REPOSITORY_FOR_THE_AUTHENTICATED_USER
 
 # Execute a tool (star the Composio repo!)
-composio tools execute GITHUB_STAR_A_REPOSITORY_FOR_THE_AUTHENTICATED_USER -d '{"owner":"composiohq","repo":"composio"}'
+composio manage tools execute GITHUB_STAR_A_REPOSITORY_FOR_THE_AUTHENTICATED_USER -d '{"owner":"composiohq","repo":"composio"}'
 ```
 
 ## Set up and listen to triggers
 
 ```bash
 # Find your connected account ID
-composio connected-accounts list --toolkits github
+composio manage connected-accounts list --toolkits github
 
 # Create a trigger for star events on your repo
-composio triggers create GITHUB_STAR_ADDED_EVENT --connected-account-id your-connected-account-id --trigger-config '{"owner":"your-username","repo":"your-repo"}'
+composio manage triggers create GITHUB_STAR_ADDED_EVENT --connected-account-id your-connected-account-id --trigger-config '{"owner":"your-username","repo":"your-repo"}'
 
 # Listen to all GitHub trigger events on your account in real time
-composio triggers listen --toolkits github --table
+composio manage triggers listen --toolkits github --table
 ```
 
 ## Available commands
@@ -73,15 +73,14 @@ Run `composio <command> --help` for detailed usage and flags.
 | `composio logout` | | Remove stored authentication |
 | `composio whoami` | | Display your account and workspace information (without API keys) |
 | `composio init` | | Initialize a Composio project in the current directory |
-| `composio toolkits` | `list`, `search`, `info`, `version` | Discover and inspect toolkits |
-| `composio tools` | `list`, `search`, `info`, `execute` | Discover, inspect, and execute tools |
-| `composio connected-accounts` | `list`, `info`, `whoami`, `link`, `delete` | Manage connected accounts |
-| `composio auth-configs` | `list`, `info`, `create`, `delete` | Manage auth configurations |
-| `composio triggers` | `list`, `info`, `create`, `status`, `listen`, `enable`, `disable`, `delete` | Subscribe to events and manage trigger instances |
-| `composio logs` | `tools`, `triggers` | Inspect tool and trigger execution logs |
-| `composio generate` | | Generate type stubs (auto-detects language) |
-| `composio ts` | `generate` | Generate TypeScript type stubs |
-| `composio py` | `generate` | Generate Python type stubs |
+| `composio manage toolkits` | `list`, `search`, `info`, `version` | Discover and inspect toolkits |
+| `composio manage tools` | `list`, `search`, `info`, `execute` | Discover, inspect, and execute tools |
+| `composio manage connected-accounts` | `list`, `info`, `whoami`, `link`, `delete` | Manage connected accounts |
+| `composio manage auth-configs` | `list`, `info`, `create`, `delete` | Manage auth configurations |
+| `composio manage triggers` | `list`, `info`, `create`, `status`, `listen`, `enable`, `disable`, `delete` | Subscribe to events and manage trigger instances |
+| `composio manage logs` | `tools`, `triggers` | Inspect tool and trigger execution logs |
+| `composio generate ts` | `(options)` | Generate TypeScript type stubs |
+| `composio generate py` | `(options)` | Generate Python type stubs |
 | `composio upgrade` | | Upgrade CLI to the latest version |
 | `composio version` | | Display the current CLI version |
 

--- a/ts/packages/cli/AGENTS.md
+++ b/ts/packages/cli/AGENTS.md
@@ -27,17 +27,17 @@ Errors are captured via the custom `effect-errors/` module, which provides sourc
 
 Each command is declared with `@effect/cli`'s `Command.make()` pattern:
 
-| Command                                                  | Description                                                 |
-| -------------------------------------------------------- | ----------------------------------------------------------- |
-| `composio version`                                       | Display CLI version                                         |
-| `composio whoami`                                        | Show logged-in user's API key                               |
-| `composio login [--no-browser] [--no-wait] [--key text]` | Login with browser redirect                                 |
-| `composio logout`                                        | Clear stored API key                                        |
-| `composio upgrade`                                       | Self-update binary from GitHub releases                     |
-| `composio generate`                                      | Auto-detect project language, delegate to `ts` or `py`      |
-| `composio ts generate`                                   | Generate TypeScript type stubs for toolkits/tools/triggers  |
-| `composio py generate`                                   | Generate Python type stubs                                  |
-| `composio manage <subcommand>`                           | Manage Composio resources (toolkits, tools, accounts, etc.) |
+| Command                                                  | Description                                                |
+| -------------------------------------------------------- | ---------------------------------------------------------- |
+| `composio version`                                       | Display CLI version                                        |
+| `composio whoami`                                        | Show logged-in user's API key                              |
+| `composio login [--no-browser] [--no-wait] [--key text]` | Login with browser redirect                                |
+| `composio logout`                                        | Clear stored API key                                       |
+| `composio upgrade`                                       | Self-update binary from GitHub releases                    |
+| `composio generate`                                      | Auto-detect project language, delegate to `ts` or `py`     |
+| `composio generate ts`                                   | Generate TypeScript type stubs for toolkits/tools/triggers |
+| `composio generate py`                                   | Generate Python type stubs                                 |
+| `composio manage <command>`                              | Manage Composio resources (toolkits, tools, accounts, triggers, logs, orgs, projects) |
 
 Options use `Options.text()`, `Options.boolean()`, `Options.choice()`, `Options.directory()` with Effect Schema validation.
 
@@ -86,7 +86,7 @@ Each model has `fromJSON`/`toJSON` helpers using `JSONTransformSchema()`.
 
 ### Code Generation (`src/generation/`)
 
-Multi-stage pipeline for `composio ts generate` and `composio py generate`:
+Multi-stage pipeline for `composio generate ts` and `composio generate py`:
 
 1. **Fetch** — Toolkits, tools, trigger types from API (optionally filtered by `--toolkits`)
 2. **Index** — Groups tools/triggers by toolkit prefix into a `ToolkitIndex` map

--- a/ts/packages/cli/src/commands/init.cmd.ts
+++ b/ts/packages/cli/src/commands/init.cmd.ts
@@ -1,9 +1,11 @@
 import path from 'node:path';
 import { Command as CliCommand, Options } from '@effect/cli';
 import { Effect, Option } from 'effect';
-import { FileSystem } from '@effect/platform';
+import { Command, FileSystem } from '@effect/platform';
 import { ComposioUserContext } from 'src/services/user-context';
+import { NodeOs } from 'src/services/node-os';
 import { NodeProcess } from 'src/services/node-process';
+import { CommandRunner } from 'src/services/command-runner';
 import { projectKeysToJSON, type ProjectKeys } from 'src/models/project-keys';
 import { userDataFromJSON } from 'src/models/user-data';
 import {
@@ -28,12 +30,18 @@ import { setupCacheDir } from 'src/effects/setup-cache-dir';
  * ## Flags
  *
  * - `--yes` / `-y` — auto-select the first project from the list
+ * - `--install-skills` — install Composio agent skills after initialization
  */
 
 const yesOpt = Options.boolean('yes').pipe(
   Options.withAlias('y'),
   Options.withDefault(false),
   Options.withDescription('Auto-select default org/project, else first project')
+);
+
+const installSkillsOpt = Options.boolean('install-skills').pipe(
+  Options.withDefault(false),
+  Options.withDescription('Install Composio agent skills after initialization')
 );
 
 // ---------------------------------------------------------------------------
@@ -203,6 +211,48 @@ const selectDefaultProject = (params: {
   return projects[0];
 };
 
+const installSkillsFlow = () =>
+  Effect.gen(function* () {
+    const ui = yield* TerminalUI;
+    const proc = yield* NodeProcess;
+    const os = yield* NodeOs;
+    const runner = yield* CommandRunner;
+
+    const installLocation = yield* ui.select<'local' | 'global'>(
+      'Where would you like to install Composio skills?',
+      [
+        {
+          value: 'local' as const,
+          label: 'In this repository',
+          hint: `${proc.cwd}/.claude/skills/`,
+        },
+        {
+          value: 'global' as const,
+          label: 'Globally',
+          hint: '~/.claude/skills/',
+        },
+      ]
+    );
+
+    const targetDir =
+      installLocation === 'local'
+        ? path.join(proc.cwd, '.claude', 'skills')
+        : path.join(os.homedir, '.claude', 'skills');
+
+    yield* ui.log.step(`Installing Composio skills to ${targetDir}...`);
+
+    const exitCode = yield* runner.run(
+      Command.make('npx', 'skills', 'add', 'composiohq/skills', '--path', targetDir)
+    );
+
+    if (exitCode !== 0) {
+      yield* ui.log.error('Failed to install Composio skills.');
+      return;
+    }
+
+    yield* ui.log.success('Composio skills installed successfully!');
+  });
+
 // ---------------------------------------------------------------------------
 // Command
 // ---------------------------------------------------------------------------
@@ -224,8 +274,9 @@ export const initCmd = CliCommand.make(
   {
     noBrowser: noBrowserOpt,
     yes: yesOpt,
+    installSkills: installSkillsOpt,
   },
-  ({ noBrowser, yes }) =>
+  ({ noBrowser, yes, installSkills }) =>
     Effect.gen(function* () {
       const ui = yield* TerminalUI;
       const proc = yield* NodeProcess;
@@ -235,6 +286,10 @@ export const initCmd = CliCommand.make(
       const composioDir = path.join(proc.cwd, constants.PROJECT_COMPOSIO_DIR);
 
       yield* initInteractiveFlow({ composioDir, noBrowser, yes });
+
+      if (installSkills) {
+        yield* installSkillsFlow();
+      }
     })
 ).pipe(CliCommand.withDescription('Initialize a Composio project in the current directory.'));
 


### PR DESCRIPTION
## Summary

Adds a `--install-skills` flag to `composio init` that installs Composio agent skills (for Claude Code, etc.) as part of project initialization. Users can choose to install skills locally (in the repo's `.claude/skills/`) or globally (`~/.claude/skills/`).

## Changes
- Added `--install-skills` boolean flag to `init.cmd.ts`
- Implemented `installSkillsFlow()` that:
  - Prompts the user to choose between local (repo) and global installation
  - Runs `npx skills add composiohq/skills --path <target>` via the `CommandRunner` service
  - Reports success/failure via `TerminalUI`
- The flow only runs when `--install-skills` is explicitly passed; default `composio init` behavior is unchanged

## Type of change
- [x] New feature

## How Has This Been Tested?
- Tested `composio init --install-skills` with both local and global installation targets
- Verified `composio init` without the flag behaves identically to before

## Checklist
- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed
- [x] I updated documentation as needed
- [x] I added tests or explain why not applicable
- [x] I added a changeset if this change affects published packages