### PR TITLE
docs: support additionalProperties in tool schema rendering

### DIFF
--- a/docs/app/llms.mdx/[[...slug]]/route.ts
+++ b/docs/app/llms.mdx/[[...slug]]/route.ts
@@ -137,6 +137,7 @@ interface OpenAPISchema {
   maximum?: number;
   minLength?: number;
   maxLength?: number;
+  additionalProperties?: OpenAPISchema | boolean;
 }
 
 interface OpenAPIParameter {
@@ -221,7 +222,13 @@ function generateSampleValue(schema: OpenAPISchema, depth = 0): unknown {
         for (const [key, prop] of Object.entries(schema.properties)) {
           obj[key] = generateSampleValue(prop, depth + 1);
         }
+        if (schema.additionalProperties && typeof schema.additionalProperties === 'object') {
+          obj['key'] = generateSampleValue(schema.additionalProperties, depth + 1);
+        }
         return obj;
+      }
+      if (schema.additionalProperties && typeof schema.additionalProperties === 'object') {
+        return { key: generateSampleValue(schema.additionalProperties, depth + 1) };
       }
       return {};
     default:
@@ -237,21 +244,37 @@ function renderSchema(schema: OpenAPISchema, indent = 0, maxDepth = 4): string[]
   const prefix = '  '.repeat(indent);
   const required = schema.required || [];
 
-  if (schema.type === 'object' && schema.properties) {
-    for (const [name, prop] of Object.entries(schema.properties)) {
-      const isRequired = required.includes(name);
-      const reqMark = isRequired ? ' *(required)*' : '';
-      const typeStr = getTypeString(prop);
-      const desc = prop.description ? `: ${prop.description}` : '';
+  if (schema.type === 'object' && (schema.properties || (schema.additionalProperties && typeof schema.additionalProperties === 'object'))) {
+    if (schema.properties) {
+      for (const [name, prop] of Object.entries(schema.properties)) {
+        const isRequired = required.includes(name);
+        const reqMark = isRequired ? ' *(required)*' : '';
+        const typeStr = getTypeString(prop);
+        const desc = prop.description ? `: ${prop.description}` : '';
 
-      lines.push(`${prefix}- \`${name}\` (${typeStr})${reqMark}${desc}`);
+        lines.push(`${prefix}- \`${name}\` (${typeStr})${reqMark}${desc}`);
 
-      // Recurse for nested objects/arrays
-      if (prop.type === 'object' && prop.properties) {
-        lines.push(...renderSchema(prop, indent + 1, maxDepth));
-      } else if (prop.type === 'array' && prop.items?.type === 'object' && prop.items.properties) {
+        // Recurse for nested objects/arrays
+        if (prop.type === 'object' && (prop.properties || (prop.additionalProperties && typeof prop.additionalProperties === 'object'))) {
+          lines.push(...renderSchema(prop, indent + 1, maxDepth));
+        } else if (prop.type === 'array' && prop.items?.type === 'object' && (prop.items.properties || (prop.items.additionalProperties && typeof prop.items.additionalProperties === 'object'))) {
+          lines.push(`${prefix}  - Array items:`);
+          lines.push(...renderSchema(prop.items, indent + 2, maxDepth));
+        }
+      }
+    }
+
+    // Render additionalProperties as [key: string]
+    if (schema.additionalProperties && typeof schema.additionalProperties === 'object') {
+      const ap = schema.additionalProperties;
+      const typeStr = getTypeString(ap);
+      const desc = ap.description ? `: ${ap.description}` : '';
+      lines.push(`${prefix}- \`[key: string]\` (${typeStr})${desc}`);
+      if (ap.type === 'object' && (ap.properties || (ap.additionalProperties && typeof ap.additionalProperties === 'object'))) {
+        lines.push(...renderSchema(ap, indent + 1, maxDepth));
+      } else if (ap.type === 'array' && ap.items?.type === 'object' && ap.items.properties) {
         lines.push(`${prefix}  - Array items:`);
-        lines.push(...renderSchema(prop.items, indent + 2, maxDepth));
+        lines.push(...renderSchema(ap.items, indent + 2, maxDepth));
       }
     }
   } else if (schema.oneOf || schema.anyOf) {

--- a/docs/app/llms.mdx/[[...slug]]/route.ts
+++ b/docs/app/llms.mdx/[[...slug]]/route.ts
@@ -272,7 +272,7 @@ function renderSchema(schema: OpenAPISchema, indent = 0, maxDepth = 4): string[]
       lines.push(`${prefix}- \`[key: string]\` (${typeStr})${desc}`);
       if (ap.type === 'object' && (ap.properties || (ap.additionalProperties && typeof ap.additionalProperties === 'object'))) {
         lines.push(...renderSchema(ap, indent + 1, maxDepth));
-      } else if (ap.type === 'array' && ap.items?.type === 'object' && ap.items.properties) {
+      } else if (ap.type === 'array' && ap.items?.type === 'object' && (ap.items.properties || (ap.items.additionalProperties && typeof ap.items.additionalProperties === 'object'))) {
         lines.push(`${prefix}  - Array items:`);
         lines.push(...renderSchema(ap.items, indent + 2, maxDepth));
       }

--- a/docs/components/schema-generator.tsx
+++ b/docs/components/schema-generator.tsx
@@ -175,16 +175,30 @@ export function generateSchemaData(
       }
     }
 
-    // Handle object
-    if ((schema.type === 'object' || schema.properties) && schema.properties) {
+    // Handle object (with properties and/or additionalProperties)
+    if ((schema.type === 'object' || schema.properties) && (schema.properties || (schema.additionalProperties && typeof schema.additionalProperties === 'object'))) {
       const required = schema.required || [];
-      const props = Object.entries(schema.properties)
-        .filter(([_, propSchema]) => isVisible(propSchema))
-        .map(([name, propSchema]) => ({
-          name,
-          $type: processSchema(propSchema as SimpleSchema),
-          required: required.includes(name),
-        }));
+      const props: { name: string; $type: string; required: boolean }[] = [];
+
+      if (schema.properties) {
+        for (const [name, propSchema] of Object.entries(schema.properties)) {
+          if (!isVisible(propSchema)) continue;
+          props.push({
+            name,
+            $type: processSchema(propSchema as SimpleSchema),
+            required: required.includes(name),
+          });
+        }
+      }
+
+      // Include additionalProperties as a synthetic [key: string] entry
+      if (schema.additionalProperties && typeof schema.additionalProperties === 'object') {
+        props.push({
+          name: '[key: string]',
+          $type: processSchema(schema.additionalProperties),
+          required: false,
+        });
+      }
 
       refs[id] = {
         ...base,

--- a/docs/components/toolkits/toolkit-detail.tsx
+++ b/docs/components/toolkits/toolkit-detail.tsx
@@ -64,25 +64,41 @@ function formatType(param: ParameterSchema): string {
   return typeStr;
 }
 
-// Get children from a param (object properties or array item properties)
+// Get children from a param (object properties, array item properties, or additionalProperties)
 function getChildren(param: ParameterSchema): Record<string, ParameterSchema> | null {
   const props = param.properties || param.items?.properties;
-  if (!props || typeof props !== 'object') return null;
+  const additionalProps = param.additionalProperties || param.items?.additionalProperties;
+
+  if ((!props || typeof props !== 'object') && (!additionalProps || typeof additionalProps !== 'object')) return null;
 
   const requiredList: string[] = param.requiredFields || param.items?.requiredFields || [];
   const result: Record<string, ParameterSchema> = {};
-  for (const [key, value] of Object.entries(props)) {
-    if (typeof value === 'object' && value !== null) {
-      const raw = value as ParameterSchema & { required?: string[] | boolean };
-      result[key] = {
-        ...raw,
-        required: Array.isArray(requiredList) ? requiredList.includes(key) : false,
-        // Map the child's own JSON Schema required array to requiredFields
-        // so that deeper nesting levels preserve required info
-        ...(Array.isArray(raw.required) ? { requiredFields: raw.required } : {}),
-      };
+
+  if (props && typeof props === 'object') {
+    for (const [key, value] of Object.entries(props)) {
+      if (typeof value === 'object' && value !== null) {
+        const raw = value as ParameterSchema & { required?: string[] | boolean };
+        result[key] = {
+          ...raw,
+          required: Array.isArray(requiredList) ? requiredList.includes(key) : false,
+          // Map the child's own JSON Schema required array to requiredFields
+          // so that deeper nesting levels preserve required info
+          ...(Array.isArray(raw.required) ? { requiredFields: raw.required } : {}),
+        };
+      }
     }
   }
+
+  // Include additionalProperties as a synthetic [key: string] entry
+  if (additionalProps && typeof additionalProps === 'object') {
+    const raw = additionalProps as ParameterSchema & { required?: string[] | boolean };
+    result['[key: string]'] = {
+      ...raw,
+      required: false,
+      ...(Array.isArray(raw.required) ? { requiredFields: raw.required } : {}),
+    };
+  }
+
   return Object.keys(result).length > 0 ? result : null;
 }
 

--- a/docs/lib/toolkit-schema.ts
+++ b/docs/lib/toolkit-schema.ts
@@ -21,6 +21,9 @@ function processParams(props: any, requiredList: string[]): Record<string, Param
           ...param.items,
           ...(Array.isArray(param.items.required) ? { requiredFields: param.items.required } : {}),
         } } : {}),
+        ...(param.additionalProperties && typeof param.additionalProperties === 'object'
+          ? { additionalProperties: param.additionalProperties }
+          : {}),
       };
     }
   }

--- a/docs/types/toolkit.ts
+++ b/docs/types/toolkit.ts
@@ -12,6 +12,8 @@ export interface ParameterSchema {
   requiredFields?: string[];
   // Array item schema
   items?: ParameterSchema;
+  // Additional properties schema (for map/dictionary types)
+  additionalProperties?: ParameterSchema | boolean;
 }
 
 export interface Tool {


### PR DESCRIPTION
## Summary
- Tool schemas using `additionalProperties` (like JIRA's `FieldMetadata` maps) were silently dropped, rendering as empty "object" types with no expandable children
- Now renders `additionalProperties` as `[key: string]` entries with full nested structure, matching the fumadocs-openapi convention
- Fixed across all three rendering paths: toolkit pages (`TypeTable`), API reference pages (`CustomSchemaUI`), and LLM markdown endpoint

## Test plan
- [ ] Visit `/toolkits/jira`, expand `JIRA_GET_ISSUE_CREATE_METADATA`, drill into Output → data → projects → issuetypes → **fields** — should show `[key: string]` with FieldMetadata properties (key, name, schema, required, etc.)
- [ ] Verify regular tools (e.g. `JIRA_CREATE_ISSUE`) still render input/output parameters correctly
- [ ] Run `bun run types:check` — passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)