### PR TITLE
Release: custom tools alpha (0.7.0-alpha.0)

### DIFF
--- a/.changeset/custom-tools-alpha-release.md
+++ b/.changeset/custom-tools-alpha-release.md
@@ -1,0 +1,35 @@
+---
+"@composio/core": minor
+---
+
+feat(core): custom tools, custom toolkits, and proxy execute for tool router sessions (TypeScript only)
+
+### Custom Tools
+
+Define local tools that execute in-process alongside remote Composio tools:
+
+- **Standalone tools** — no auth, run entirely locally
+- **Extension tools** — inherit auth from a Composio toolkit (e.g. Gmail) via `extendsToolkit`
+- **Custom toolkits** — group related tools under a namespace
+
+### Proxy Execute
+
+`session.proxyExecute()` and `ctx.proxyExecute()` for raw HTTP API calls through Composio's auth layer. Returns `{ status, data, headers }`.
+
+### Session Creation
+
+```typescript
+const session = await composio.create("user_123", {
+  toolkits: ["gmail"],
+  experimental: {
+    customTools: [myTool, myExtensionTool],
+    customToolkits: [myToolkit],
+  },
+});
+```
+
+### Other Changes
+
+- Slug mapping uses backend response (`slug`/`original_slug`) instead of client-side prefix
+- Uses official `@composio/client@0.1.0-alpha.62` types
+- `proxyExecute` uses official client method

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,22 @@
+{
+  "mode": "pre",
+  "tag": "alpha",
+  "initialVersions": {
+    "@composio/cli": "0.2.4",
+    "@composio/core": "0.6.5",
+    "@composio/json-schema-to-zod": "0.1.20",
+    "@composio/anthropic": "0.6.5",
+    "@composio/claude-agent-sdk": "0.6.5",
+    "@composio/cloudflare": "0.6.5",
+    "@composio/google": "0.6.5",
+    "@composio/langchain": "0.6.5",
+    "@composio/llamaindex": "0.6.5",
+    "@composio/mastra": "0.6.5",
+    "@composio/openai": "0.6.5",
+    "@composio/openai-agents": "0.6.5",
+    "@composio/vercel": "0.6.5"
+  },
+  "changesets": [
+    "custom-tools-alpha-release"
+  ]
+}

--- a/ts/examples/tool-router/src/custom-tools.ts
+++ b/ts/examples/tool-router/src/custom-tools.ts
@@ -5,6 +5,11 @@
  * remote Composio tools. Includes a tool that calls the Gmail API
  * directly via ctx.proxyExecute().
  *
+ * Three tool types demonstrated:
+ *   1. Standalone — no auth, pure local logic
+ *   2. Extension — inherits auth from a Composio toolkit (Gmail)
+ *   3. Toolkit  — groups related tools under a namespace
+ *
  * Usage:
  *   COMPOSIO_API_KEY=... OPENAI_API_KEY=... bun src/custom-tools.ts
  */
@@ -14,16 +19,16 @@ import { OpenAIAgentsProvider } from "@composio/openai-agents";
 import { Agent, run } from "@openai/agents";
 import { z } from "zod/v3";
 
-// ── Custom tools ────────────────────────────────────────────────
+// ── 1. Standalone tool (no auth) ────────────────────────────────
 
-/** Standalone tool (no auth needed) */
 const getUser = experimental_createTool("GET_USER", {
   name: "Get user",
-  description: "Look up an internal user by ID",
+  description: "Look up an internal user by ID. Returns name, email, and role.",
   inputParams: z.object({
-    user_id: z.string().describe("User ID (e.g. user-1)"),
+    user_id: z.string().describe("User ID (e.g. user-1, user-2)"),
   }),
   execute: async ({ user_id }) => {
+    // In a real app, this would query your database
     const users: Record<string, Record<string, string>> = {
       "user-1": { name: "Alice Johnson", email: "alice@acme.com", role: "admin" },
       "user-2": { name: "Bob Smith", email: "bob@acme.com", role: "developer" },
@@ -34,46 +39,61 @@ const getUser = experimental_createTool("GET_USER", {
   },
 });
 
-/** Extension tool — inherits Gmail auth, calls the real API via proxy */
-const createDraft = experimental_createTool("CREATE_DRAFT", {
-  name: "Create Gmail draft",
-  description: "Create a real Gmail draft via the Gmail API. Appears in the user's drafts folder.",
+// ── 2. Extension tool (inherits Gmail auth via proxy execute) ───
+
+const sendCompanyEmail = experimental_createTool("SEND_COMPANY_EMAIL", {
+  name: "Send company formatted email",
+  description:
+    "Draft a company-branded email via Gmail. Adds a standard signature " +
+    "and formats the body with the company template. The draft appears " +
+    "in the authenticated user's Gmail drafts folder.",
   extendsToolkit: "gmail",
   inputParams: z.object({
     to: z.string().describe("Recipient email address"),
     subject: z.string().describe("Email subject"),
-    body: z.string().describe("Email body (plain text)"),
+    body: z.string().describe("Email body content (plain text)"),
   }),
   execute: async (input, ctx) => {
-    const raw = Buffer.from(
-      `To: ${input.to}\r\nSubject: ${input.subject}\r\nContent-Type: text/plain; charset=UTF-8\r\n\r\n${input.body}`
-    )
+    // Add company branding to the email
+    const branded = [
+      input.body,
+      "",
+      "---",
+      "Sent via Acme Corp Internal Tools",
+      `Drafted by: ${ctx.userId}`,
+    ].join("\r\n");
+
+    // Build RFC 2822 email and base64url encode
+    const rawEmail = `To: ${input.to}\r\nSubject: ${input.subject}\r\nContent-Type: text/plain; charset=UTF-8\r\n\r\n${branded}`;
+    const encoded = Buffer.from(rawEmail)
       .toString("base64")
       .replace(/\+/g, "-")
       .replace(/\//g, "_")
       .replace(/=+$/, "");
 
+    // Create draft via Gmail API using session's auth
     const res = await ctx.proxyExecute({
       toolkit: "gmail",
       endpoint: "https://gmail.googleapis.com/gmail/v1/users/me/drafts",
       method: "POST",
-      body: { message: { raw } },
+      body: { message: { raw: encoded } },
     });
 
     if (res.status !== 200) throw new Error(`Gmail API error ${res.status}`);
     const data = res.data as { id: string; message: { id: string } };
-    return { draft_id: data.id, message_id: data.message.id, to: input.to, subject: input.subject };
+    return { draft_id: data.id, to: input.to, subject: input.subject };
   },
 });
 
-/** Custom toolkit — groups related tools under one namespace */
+// ── 3. Custom toolkit (groups tools under a namespace) ──────────
+
 const roleManager = experimental_createToolkit("ROLE_MANAGER", {
   name: "Role Manager",
-  description: "Manage user roles",
+  description: "Manage internal user roles and permissions",
   tools: [
     experimental_createTool("SET_ROLE", {
       name: "Set role",
-      description: "Set a user's role",
+      description: "Assign a new role to a user",
       inputParams: z.object({
         user_id: z.string().describe("User ID"),
         role: z.enum(["admin", "developer", "viewer"]).describe("New role"),
@@ -83,19 +103,23 @@ const roleManager = experimental_createToolkit("ROLE_MANAGER", {
   ],
 });
 
-// ── Agent ────────────────────────────────────────────────────────
+// ── Agent setup ─────────────────────────────────────────────────
 
 const composio = new Composio({
   provider: new OpenAIAgentsProvider(),
 });
 
-const session = await composio.create("default", {
-  toolkits: ["gmail"],
+const session = await composio.create(process.env.COMPOSIO_USER_ID ?? "default", {
+  toolkits: ["gmail", "weathermap"],
   experimental: {
-    customTools: [getUser, createDraft],
+    customTools: [getUser, sendCompanyEmail],
     customToolkits: [roleManager],
   },
 });
+
+console.log(`Session: ${session.sessionId}`);
+console.log("Custom tools:", session.customTools().map(t => t.slug).join(", "));
+console.log();
 
 const tools = await session.tools();
 
@@ -108,8 +132,32 @@ const agent = new Agent({
   tools,
 });
 
-const prompt = process.argv[2] ?? "Get user-1's info and draft an email to them saying hello";
+// Tool call logging
+agent.on("agent_tool_start", (_ctx, tool, details: Record<string, unknown>) => {
+  const input = (details as { toolCall?: { arguments?: unknown } }).toolCall?.arguments ?? {};
+  const json = JSON.stringify(typeof input === "string" ? JSON.parse(input) : input, null, 2);
+  console.log(`\n  ┌─ ${tool.name}`);
+  console.log(`  │ INPUT: ${json.length > 500 ? json.slice(0, 500) + "..." : json}`);
+});
+agent.on("agent_tool_end", (_ctx, tool, result: unknown) => {
+  let output: unknown;
+  try { output = typeof result === "string" ? JSON.parse(result as string) : result; } catch { output = result; }
+  const json = JSON.stringify(output, null, 2);
+  console.log(`  │ OUTPUT: ${json.length > 500 ? json.slice(0, 500) + "..." : json}`);
+  console.log(`  └─ ${tool.name} done`);
+});
+
+// Multi-task prompt that exercises all tool types:
+//   - Standalone local tool (get user)
+//   - Toolkit local tool (set role)
+//   - Remote Composio tool (weather)
+//   - Extension local tool with proxy execute (company email)
+const prompt = process.argv[2] ?? `Do all of these:
+1. Look up user-1's profile
+2. Promote user-2 to admin
+3. What's the weather in Tokyo right now?
+4. Send a company formatted email to myself summarizing the above results`;
 
 console.log(`> ${prompt}\n`);
 const result = await run(agent, prompt);
-console.log(result.finalOutput);
+console.log(`\n${result.finalOutput}`);

--- a/ts/packages/cli/CHANGELOG.md
+++ b/ts/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @composio/cli
 
+## 0.2.5-alpha.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @composio/core@0.7.0-alpha.0
+
 ## 0.2.4
 
 ### Patch Changes

--- a/ts/packages/cli/CHANGELOG.md
+++ b/ts/packages/cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @composio/cli
 
-## 0.2.5-alpha.0
+## 0.7.0-alpha.0
 
 ### Patch Changes
 

--- a/ts/packages/cli/package.json
+++ b/ts/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/cli",
-  "version": "0.2.5-alpha.0",
+  "version": "0.7.0-alpha.0",
   "description": "Composio CLI",
   "main": "./dist/bin.mjs",
   "private": true,

--- a/ts/packages/cli/package.json
+++ b/ts/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/cli",
-  "version": "0.2.4",
+  "version": "0.2.5-alpha.0",
   "description": "Composio CLI",
   "main": "./dist/bin.mjs",
   "private": true,

--- a/ts/packages/core/CHANGELOG.md
+++ b/ts/packages/core/CHANGELOG.md
@@ -4,71 +4,11 @@
 
 ### Minor Changes
 
-- feat(core): custom tools, custom toolkits, and proxy execute for tool router sessions (TypeScript only)
-
-  #### Standalone tool (no auth)
-
-  ```typescript
-  import { experimental_createTool } from "@composio/core";
-
-  const getUser = experimental_createTool("GET_USER", {
-    name: "Get user",
-    description: "Look up user by ID",
-    inputParams: z.object({ user_id: z.string() }),
-    execute: async ({ user_id }) => {
-      return { name: "Alice", email: "alice@acme.com" };
-    },
-  });
-  ```
-
-  #### Extension tool (inherits auth from a Composio toolkit)
-
-  ```typescript
-  const createDraft = experimental_createTool("CREATE_DRAFT", {
-    extendsToolkit: "gmail",
-    name: "Create Gmail draft",
-    description: "Create a draft via Gmail API",
-    inputParams: z.object({ to: z.string(), subject: z.string(), body: z.string() }),
-    execute: async (input, ctx) => {
-      const res = await ctx.proxyExecute({
-        toolkit: "gmail",
-        endpoint: "https://gmail.googleapis.com/gmail/v1/users/me/drafts",
-        method: "POST",
-        body: { message: { raw: buildRawEmail(input) } },
-      });
-      return { draft_id: res.data.id, status: res.status };
-    },
-  });
-  ```
-
-  #### Custom toolkit (groups tools under a namespace)
-
-  ```typescript
-  import { experimental_createToolkit } from "@composio/core";
-
-  const userMgmt = experimental_createToolkit("USER_MANAGEMENT", {
-    name: "User Management",
-    description: "Manage user roles and status",
-    tools: [setRoleTool, updateStatusTool],
-  });
-  ```
-
-  #### Session creation
-
-  ```typescript
-  const session = await composio.create("user_123", {
-    toolkits: ["gmail"],
-    experimental: {
-      customTools: [getUser, createDraft],
-      customToolkits: [userMgmt],
-    },
-  });
-  ```
-
-  #### Other changes
-  - `session.proxyExecute()` / `ctx.proxyExecute()` for raw HTTP calls through Composio auth — returns `{ status, data, headers }`
-  - Slug mapping uses backend response instead of client-side `LOCAL_` prefix
-  - Uses official `@composio/client@0.1.0-alpha.62` types
+- Custom tools, custom toolkits, and proxy execute for tool router sessions (TypeScript only)
+  - `experimental_createTool()` — standalone (no auth), extension (inherits toolkit auth via `extendsToolkit`), or grouped in toolkits
+  - `experimental_createToolkit()` — group related tools under a namespace
+  - `session.proxyExecute()` / `ctx.proxyExecute()` — raw HTTP calls through Composio auth, returns `{ status, data, headers }`
+  - Bump `@composio/client` to `0.1.0-alpha.62`
 
 ## 0.6.5
 

--- a/ts/packages/core/CHANGELOG.md
+++ b/ts/packages/core/CHANGELOG.md
@@ -1,5 +1,39 @@
 # @composio/core
 
+## 0.7.0-alpha.0
+
+### Minor Changes
+
+- feat(core): custom tools, custom toolkits, and proxy execute for tool router sessions (TypeScript only)
+
+  ### Custom Tools
+
+  Define local tools that execute in-process alongside remote Composio tools:
+  - **Standalone tools** — no auth, run entirely locally
+  - **Extension tools** — inherit auth from a Composio toolkit (e.g. Gmail) via `extendsToolkit`
+  - **Custom toolkits** — group related tools under a namespace
+
+  ### Proxy Execute
+
+  `session.proxyExecute()` and `ctx.proxyExecute()` for raw HTTP API calls through Composio's auth layer. Returns `{ status, data, headers }`.
+
+  ### Session Creation
+
+  ```typescript
+  const session = await composio.create('user_123', {
+    toolkits: ['gmail'],
+    experimental: {
+      customTools: [myTool, myExtensionTool],
+      customToolkits: [myToolkit],
+    },
+  });
+  ```
+
+  ### Other Changes
+  - Slug mapping uses backend response (`slug`/`original_slug`) instead of client-side prefix
+  - Uses official `@composio/client@0.1.0-alpha.62` types
+  - `proxyExecute` uses official client method
+
 ## 0.6.5
 
 ### Patch Changes

--- a/ts/packages/core/CHANGELOG.md
+++ b/ts/packages/core/CHANGELOG.md
@@ -6,33 +6,69 @@
 
 - feat(core): custom tools, custom toolkits, and proxy execute for tool router sessions (TypeScript only)
 
-  ### Custom Tools
-
-  Define local tools that execute in-process alongside remote Composio tools:
-  - **Standalone tools** — no auth, run entirely locally
-  - **Extension tools** — inherit auth from a Composio toolkit (e.g. Gmail) via `extendsToolkit`
-  - **Custom toolkits** — group related tools under a namespace
-
-  ### Proxy Execute
-
-  `session.proxyExecute()` and `ctx.proxyExecute()` for raw HTTP API calls through Composio's auth layer. Returns `{ status, data, headers }`.
-
-  ### Session Creation
+  #### Standalone tool (no auth)
 
   ```typescript
-  const session = await composio.create('user_123', {
-    toolkits: ['gmail'],
-    experimental: {
-      customTools: [myTool, myExtensionTool],
-      customToolkits: [myToolkit],
+  import { experimental_createTool } from "@composio/core";
+
+  const getUser = experimental_createTool("GET_USER", {
+    name: "Get user",
+    description: "Look up user by ID",
+    inputParams: z.object({ user_id: z.string() }),
+    execute: async ({ user_id }) => {
+      return { name: "Alice", email: "alice@acme.com" };
     },
   });
   ```
 
-  ### Other Changes
-  - Slug mapping uses backend response (`slug`/`original_slug`) instead of client-side prefix
+  #### Extension tool (inherits auth from a Composio toolkit)
+
+  ```typescript
+  const createDraft = experimental_createTool("CREATE_DRAFT", {
+    extendsToolkit: "gmail",
+    name: "Create Gmail draft",
+    description: "Create a draft via Gmail API",
+    inputParams: z.object({ to: z.string(), subject: z.string(), body: z.string() }),
+    execute: async (input, ctx) => {
+      const res = await ctx.proxyExecute({
+        toolkit: "gmail",
+        endpoint: "https://gmail.googleapis.com/gmail/v1/users/me/drafts",
+        method: "POST",
+        body: { message: { raw: buildRawEmail(input) } },
+      });
+      return { draft_id: res.data.id, status: res.status };
+    },
+  });
+  ```
+
+  #### Custom toolkit (groups tools under a namespace)
+
+  ```typescript
+  import { experimental_createToolkit } from "@composio/core";
+
+  const userMgmt = experimental_createToolkit("USER_MANAGEMENT", {
+    name: "User Management",
+    description: "Manage user roles and status",
+    tools: [setRoleTool, updateStatusTool],
+  });
+  ```
+
+  #### Session creation
+
+  ```typescript
+  const session = await composio.create("user_123", {
+    toolkits: ["gmail"],
+    experimental: {
+      customTools: [getUser, createDraft],
+      customToolkits: [userMgmt],
+    },
+  });
+  ```
+
+  #### Other changes
+  - `session.proxyExecute()` / `ctx.proxyExecute()` for raw HTTP calls through Composio auth — returns `{ status, data, headers }`
+  - Slug mapping uses backend response instead of client-side `LOCAL_` prefix
   - Uses official `@composio/client@0.1.0-alpha.62` types
-  - `proxyExecute` uses official client method
 
 ## 0.6.5
 

--- a/ts/packages/core/package.json
+++ b/ts/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@composio/core",
   "type": "module",
-  "version": "0.6.5",
+  "version": "0.7.0-alpha.0",
   "description": "",
   "main": "src/index.ts",
   "publishConfig": {

--- a/ts/packages/providers/anthropic/CHANGELOG.md
+++ b/ts/packages/providers/anthropic/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @composio/anthropic
 
-## 0.6.6-alpha.0
+## 0.7.0-alpha.0
 
 ### Patch Changes
 

--- a/ts/packages/providers/anthropic/CHANGELOG.md
+++ b/ts/packages/providers/anthropic/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @composio/anthropic
 
+## 1.0.0-alpha.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @composio/core@0.7.0-alpha.0
+
 ## 0.6.5
 
 ### Patch Changes

--- a/ts/packages/providers/anthropic/CHANGELOG.md
+++ b/ts/packages/providers/anthropic/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @composio/anthropic
 
-## 1.0.0-alpha.0
+## 0.6.6-alpha.0
 
 ### Patch Changes
 

--- a/ts/packages/providers/anthropic/package.json
+++ b/ts/packages/providers/anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/anthropic",
-  "version": "0.6.6-alpha.0",
+  "version": "0.7.0-alpha.0",
   "description": "Non-Agentic Provider for Anthropic in Composio SDK",
   "main": "src/index.ts",
   "publishConfig": {

--- a/ts/packages/providers/anthropic/package.json
+++ b/ts/packages/providers/anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/anthropic",
-  "version": "1.0.0-alpha.0",
+  "version": "0.6.6-alpha.0",
   "description": "Non-Agentic Provider for Anthropic in Composio SDK",
   "main": "src/index.ts",
   "publishConfig": {

--- a/ts/packages/providers/anthropic/package.json
+++ b/ts/packages/providers/anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/anthropic",
-  "version": "0.6.5",
+  "version": "1.0.0-alpha.0",
   "description": "Non-Agentic Provider for Anthropic in Composio SDK",
   "main": "src/index.ts",
   "publishConfig": {
@@ -43,7 +43,7 @@
   "packageManager": "pnpm@10.28.0",
   "peerDependencies": {
     "@anthropic-ai/sdk": "^0.52.0",
-    "@composio/core": "0.6.5",
+    "@composio/core": "0.7.0-alpha.0",
     "@mastra/mcp": "^0.12.0"
   },
   "devDependencies": {

--- a/ts/packages/providers/claude-agent-sdk/CHANGELOG.md
+++ b/ts/packages/providers/claude-agent-sdk/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @composio/claude-code-agents
 
-## 0.6.6-alpha.0
+## 0.7.0-alpha.0
 
 ### Patch Changes
 

--- a/ts/packages/providers/claude-agent-sdk/CHANGELOG.md
+++ b/ts/packages/providers/claude-agent-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @composio/claude-code-agents
 
+## 1.0.0-alpha.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @composio/core@0.7.0-alpha.0
+
 ## 0.6.5
 
 ### Patch Changes

--- a/ts/packages/providers/claude-agent-sdk/CHANGELOG.md
+++ b/ts/packages/providers/claude-agent-sdk/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @composio/claude-code-agents
 
-## 1.0.0-alpha.0
+## 0.6.6-alpha.0
 
 ### Patch Changes
 

--- a/ts/packages/providers/claude-agent-sdk/package.json
+++ b/ts/packages/providers/claude-agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/claude-agent-sdk",
-  "version": "1.0.0-alpha.0",
+  "version": "0.6.6-alpha.0",
   "description": "Composio provider for Claude Agent SDK",
   "main": "src/index.ts",
   "publishConfig": {

--- a/ts/packages/providers/claude-agent-sdk/package.json
+++ b/ts/packages/providers/claude-agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/claude-agent-sdk",
-  "version": "0.6.6-alpha.0",
+  "version": "0.7.0-alpha.0",
   "description": "Composio provider for Claude Agent SDK",
   "main": "src/index.ts",
   "publishConfig": {

--- a/ts/packages/providers/claude-agent-sdk/package.json
+++ b/ts/packages/providers/claude-agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/claude-agent-sdk",
-  "version": "0.6.5",
+  "version": "1.0.0-alpha.0",
   "description": "Composio provider for Claude Agent SDK",
   "main": "src/index.ts",
   "publishConfig": {
@@ -48,7 +48,7 @@
     "zod": "^3.25.76"
   },
   "peerDependencies": {
-    "@composio/core": "0.6.5",
+    "@composio/core": "0.7.0-alpha.0",
     "@anthropic-ai/claude-agent-sdk": ">=0.1.0"
   },
   "devDependencies": {

--- a/ts/packages/providers/cloudflare/CHANGELOG.md
+++ b/ts/packages/providers/cloudflare/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @composio/cloudflare
 
-## 1.0.0-alpha.0
+## 0.6.6-alpha.0
 
 ### Patch Changes
 

--- a/ts/packages/providers/cloudflare/CHANGELOG.md
+++ b/ts/packages/providers/cloudflare/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @composio/cloudflare
 
+## 1.0.0-alpha.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @composio/core@0.7.0-alpha.0
+
 ## 0.6.5
 
 ### Patch Changes

--- a/ts/packages/providers/cloudflare/CHANGELOG.md
+++ b/ts/packages/providers/cloudflare/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @composio/cloudflare
 
-## 0.6.6-alpha.0
+## 0.7.0-alpha.0
 
 ### Patch Changes
 

--- a/ts/packages/providers/cloudflare/package.json
+++ b/ts/packages/providers/cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/cloudflare",
-  "version": "1.0.0-alpha.0",
+  "version": "0.6.6-alpha.0",
   "description": "",
   "main": "src/index.ts",
   "publishConfig": {

--- a/ts/packages/providers/cloudflare/package.json
+++ b/ts/packages/providers/cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/cloudflare",
-  "version": "0.6.5",
+  "version": "1.0.0-alpha.0",
   "description": "",
   "main": "src/index.ts",
   "publishConfig": {
@@ -39,7 +39,7 @@
   "packageManager": "pnpm@10.28.0",
   "peerDependencies": {
     "@cloudflare/workers-types": "catalog:",
-    "@composio/core": "0.6.5"
+    "@composio/core": "0.7.0-alpha.0"
   },
   "devDependencies": {
     "@composio/core": "workspace:*",

--- a/ts/packages/providers/cloudflare/package.json
+++ b/ts/packages/providers/cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/cloudflare",
-  "version": "0.6.6-alpha.0",
+  "version": "0.7.0-alpha.0",
   "description": "",
   "main": "src/index.ts",
   "publishConfig": {

--- a/ts/packages/providers/google/CHANGELOG.md
+++ b/ts/packages/providers/google/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @composio/google
 
+## 1.0.0-alpha.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @composio/core@0.7.0-alpha.0
+
 ## 0.6.5
 
 ### Patch Changes

--- a/ts/packages/providers/google/CHANGELOG.md
+++ b/ts/packages/providers/google/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @composio/google
 
-## 0.6.6-alpha.0
+## 0.7.0-alpha.0
 
 ### Patch Changes
 

--- a/ts/packages/providers/google/CHANGELOG.md
+++ b/ts/packages/providers/google/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @composio/google
 
-## 1.0.0-alpha.0
+## 0.6.6-alpha.0
 
 ### Patch Changes
 

--- a/ts/packages/providers/google/package.json
+++ b/ts/packages/providers/google/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/google",
-  "version": "0.6.6-alpha.0",
+  "version": "0.7.0-alpha.0",
   "description": "Google GenAI Provider for Composio SDK",
   "main": "src/index.ts",
   "publishConfig": {

--- a/ts/packages/providers/google/package.json
+++ b/ts/packages/providers/google/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/google",
-  "version": "1.0.0-alpha.0",
+  "version": "0.6.6-alpha.0",
   "description": "Google GenAI Provider for Composio SDK",
   "main": "src/index.ts",
   "publishConfig": {

--- a/ts/packages/providers/google/package.json
+++ b/ts/packages/providers/google/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/google",
-  "version": "0.6.5",
+  "version": "1.0.0-alpha.0",
   "description": "Google GenAI Provider for Composio SDK",
   "main": "src/index.ts",
   "publishConfig": {
@@ -44,7 +44,7 @@
   "license": "ISC",
   "packageManager": "pnpm@10.28.0",
   "peerDependencies": {
-    "@composio/core": "0.6.5",
+    "@composio/core": "0.7.0-alpha.0",
     "@google/genai": "^1.1.0"
   },
   "devDependencies": {

--- a/ts/packages/providers/langchain/CHANGELOG.md
+++ b/ts/packages/providers/langchain/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @composio/langchain
 
+## 1.0.0-alpha.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @composio/core@0.7.0-alpha.0
+
 ## 0.6.5
 
 ### Patch Changes

--- a/ts/packages/providers/langchain/CHANGELOG.md
+++ b/ts/packages/providers/langchain/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @composio/langchain
 
-## 0.6.6-alpha.0
+## 0.7.0-alpha.0
 
 ### Patch Changes
 

--- a/ts/packages/providers/langchain/CHANGELOG.md
+++ b/ts/packages/providers/langchain/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @composio/langchain
 
-## 1.0.0-alpha.0
+## 0.6.6-alpha.0
 
 ### Patch Changes
 

--- a/ts/packages/providers/langchain/package.json
+++ b/ts/packages/providers/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/langchain",
-  "version": "0.6.5",
+  "version": "1.0.0-alpha.0",
   "description": "",
   "main": "dist/index.js",
   "publishConfig": {
@@ -38,7 +38,7 @@
   "license": "ISC",
   "packageManager": "pnpm@10.28.0",
   "peerDependencies": {
-    "@composio/core": "0.6.5",
+    "@composio/core": "0.7.0-alpha.0",
     "@langchain/core": "^1.1.4"
   },
   "devDependencies": {

--- a/ts/packages/providers/langchain/package.json
+++ b/ts/packages/providers/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/langchain",
-  "version": "0.6.6-alpha.0",
+  "version": "0.7.0-alpha.0",
   "description": "",
   "main": "dist/index.js",
   "publishConfig": {

--- a/ts/packages/providers/langchain/package.json
+++ b/ts/packages/providers/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/langchain",
-  "version": "1.0.0-alpha.0",
+  "version": "0.6.6-alpha.0",
   "description": "",
   "main": "dist/index.js",
   "publishConfig": {

--- a/ts/packages/providers/llamaindex/CHANGELOG.md
+++ b/ts/packages/providers/llamaindex/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @composio/llamaindex
 
-## 0.6.6-alpha.0
+## 0.7.0-alpha.0
 
 ### Patch Changes
 

--- a/ts/packages/providers/llamaindex/CHANGELOG.md
+++ b/ts/packages/providers/llamaindex/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @composio/llamaindex
 
+## 1.0.0-alpha.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @composio/core@0.7.0-alpha.0
+
 ## 0.6.5
 
 ### Patch Changes

--- a/ts/packages/providers/llamaindex/CHANGELOG.md
+++ b/ts/packages/providers/llamaindex/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @composio/llamaindex
 
-## 1.0.0-alpha.0
+## 0.6.6-alpha.0
 
 ### Patch Changes
 

--- a/ts/packages/providers/llamaindex/package.json
+++ b/ts/packages/providers/llamaindex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/llamaindex",
-  "version": "1.0.0-alpha.0",
+  "version": "0.6.6-alpha.0",
   "description": "Agentic Provider for llamaindex in Composio SDK",
   "main": "src/index.ts",
   "publishConfig": {

--- a/ts/packages/providers/llamaindex/package.json
+++ b/ts/packages/providers/llamaindex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/llamaindex",
-  "version": "0.6.6-alpha.0",
+  "version": "0.7.0-alpha.0",
   "description": "Agentic Provider for llamaindex in Composio SDK",
   "main": "src/index.ts",
   "publishConfig": {

--- a/ts/packages/providers/llamaindex/package.json
+++ b/ts/packages/providers/llamaindex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/llamaindex",
-  "version": "0.6.5",
+  "version": "1.0.0-alpha.0",
   "description": "Agentic Provider for llamaindex in Composio SDK",
   "main": "src/index.ts",
   "publishConfig": {
@@ -41,7 +41,7 @@
   "license": "ISC",
   "packageManager": "pnpm@10.28.0",
   "peerDependencies": {
-    "@composio/core": "0.6.5",
+    "@composio/core": "0.7.0-alpha.0",
     "llamaindex": "^0.12.0"
   },
   "devDependencies": {

--- a/ts/packages/providers/mastra/CHANGELOG.md
+++ b/ts/packages/providers/mastra/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @composio/mastra
 
-## 0.6.6-alpha.0
+## 0.7.0-alpha.0
 
 ### Patch Changes
 

--- a/ts/packages/providers/mastra/CHANGELOG.md
+++ b/ts/packages/providers/mastra/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @composio/mastra
 
+## 1.0.0-alpha.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @composio/core@0.7.0-alpha.0
+
 ## 0.6.5
 
 ### Patch Changes

--- a/ts/packages/providers/mastra/CHANGELOG.md
+++ b/ts/packages/providers/mastra/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @composio/mastra
 
-## 1.0.0-alpha.0
+## 0.6.6-alpha.0
 
 ### Patch Changes
 

--- a/ts/packages/providers/mastra/package.json
+++ b/ts/packages/providers/mastra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/mastra",
-  "version": "0.6.6-alpha.0",
+  "version": "0.7.0-alpha.0",
   "description": "Agentic Provider for mastra in Composio SDK",
   "main": "src/index.ts",
   "publishConfig": {

--- a/ts/packages/providers/mastra/package.json
+++ b/ts/packages/providers/mastra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/mastra",
-  "version": "0.6.5",
+  "version": "1.0.0-alpha.0",
   "description": "Agentic Provider for mastra in Composio SDK",
   "main": "src/index.ts",
   "publishConfig": {
@@ -43,7 +43,7 @@
   "license": "ISC",
   "packageManager": "pnpm@10.28.0",
   "peerDependencies": {
-    "@composio/core": "0.6.5",
+    "@composio/core": "0.7.0-alpha.0",
     "@mastra/core": "^1.0.4",
     "zod": "^3.25 || ^4"
   },

--- a/ts/packages/providers/mastra/package.json
+++ b/ts/packages/providers/mastra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/mastra",
-  "version": "1.0.0-alpha.0",
+  "version": "0.6.6-alpha.0",
   "description": "Agentic Provider for mastra in Composio SDK",
   "main": "src/index.ts",
   "publishConfig": {

--- a/ts/packages/providers/openai-agents/CHANGELOG.md
+++ b/ts/packages/providers/openai-agents/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @composio/openai-agents
 
-## 1.0.0-alpha.0
+## 0.6.6-alpha.0
 
 ### Patch Changes
 

--- a/ts/packages/providers/openai-agents/CHANGELOG.md
+++ b/ts/packages/providers/openai-agents/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @composio/openai-agents
 
+## 1.0.0-alpha.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @composio/core@0.7.0-alpha.0
+
 ## 0.6.5
 
 ### Patch Changes

--- a/ts/packages/providers/openai-agents/CHANGELOG.md
+++ b/ts/packages/providers/openai-agents/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @composio/openai-agents
 
-## 0.6.6-alpha.0
+## 0.7.0-alpha.0
 
 ### Patch Changes
 

--- a/ts/packages/providers/openai-agents/package.json
+++ b/ts/packages/providers/openai-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/openai-agents",
-  "version": "1.0.0-alpha.0",
+  "version": "0.6.6-alpha.0",
   "description": "",
   "main": "src/index.ts",
   "publishConfig": {

--- a/ts/packages/providers/openai-agents/package.json
+++ b/ts/packages/providers/openai-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/openai-agents",
-  "version": "0.6.6-alpha.0",
+  "version": "0.7.0-alpha.0",
   "description": "",
   "main": "src/index.ts",
   "publishConfig": {

--- a/ts/packages/providers/openai-agents/package.json
+++ b/ts/packages/providers/openai-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/openai-agents",
-  "version": "0.6.5",
+  "version": "1.0.0-alpha.0",
   "description": "",
   "main": "src/index.ts",
   "publishConfig": {
@@ -38,7 +38,7 @@
   "license": "ISC",
   "packageManager": "pnpm@10.28.0",
   "peerDependencies": {
-    "@composio/core": "0.6.5",
+    "@composio/core": "0.7.0-alpha.0",
     "@openai/agents": "^0.1.3",
     "zod": "catalog:"
   },

--- a/ts/packages/providers/openai/CHANGELOG.md
+++ b/ts/packages/providers/openai/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @composio/openai
 
-## 1.0.0-alpha.0
+## 0.6.6-alpha.0
 
 ### Patch Changes
 

--- a/ts/packages/providers/openai/CHANGELOG.md
+++ b/ts/packages/providers/openai/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @composio/openai
 
+## 1.0.0-alpha.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @composio/core@0.7.0-alpha.0
+
 ## 0.6.5
 
 ### Patch Changes

--- a/ts/packages/providers/openai/CHANGELOG.md
+++ b/ts/packages/providers/openai/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @composio/openai
 
-## 0.6.6-alpha.0
+## 0.7.0-alpha.0
 
 ### Patch Changes
 

--- a/ts/packages/providers/openai/package.json
+++ b/ts/packages/providers/openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/openai",
-  "version": "0.6.5",
+  "version": "1.0.0-alpha.0",
   "description": "",
   "main": "src/index.ts",
   "publishConfig": {
@@ -38,7 +38,7 @@
   "license": "ISC",
   "packageManager": "pnpm@10.28.0",
   "peerDependencies": {
-    "@composio/core": "0.6.5",
+    "@composio/core": "0.7.0-alpha.0",
     "openai": "catalog:"
   },
   "devDependencies": {

--- a/ts/packages/providers/openai/package.json
+++ b/ts/packages/providers/openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/openai",
-  "version": "1.0.0-alpha.0",
+  "version": "0.6.6-alpha.0",
   "description": "",
   "main": "src/index.ts",
   "publishConfig": {

--- a/ts/packages/providers/openai/package.json
+++ b/ts/packages/providers/openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/openai",
-  "version": "0.6.6-alpha.0",
+  "version": "0.7.0-alpha.0",
   "description": "",
   "main": "src/index.ts",
   "publishConfig": {

--- a/ts/packages/providers/vercel/CHANGELOG.md
+++ b/ts/packages/providers/vercel/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @composio/vercel
 
-## 0.6.6-alpha.0
+## 0.7.0-alpha.0
 
 ### Patch Changes
 

--- a/ts/packages/providers/vercel/CHANGELOG.md
+++ b/ts/packages/providers/vercel/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @composio/vercel
 
+## 1.0.0-alpha.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @composio/core@0.7.0-alpha.0
+
 ## 0.6.5
 
 ### Patch Changes

--- a/ts/packages/providers/vercel/CHANGELOG.md
+++ b/ts/packages/providers/vercel/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @composio/vercel
 
-## 1.0.0-alpha.0
+## 0.6.6-alpha.0
 
 ### Patch Changes
 

--- a/ts/packages/providers/vercel/package.json
+++ b/ts/packages/providers/vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/vercel",
-  "version": "0.6.6-alpha.0",
+  "version": "0.7.0-alpha.0",
   "description": "",
   "main": "src/index.ts",
   "publishConfig": {

--- a/ts/packages/providers/vercel/package.json
+++ b/ts/packages/providers/vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/vercel",
-  "version": "1.0.0-alpha.0",
+  "version": "0.6.6-alpha.0",
   "description": "",
   "main": "src/index.ts",
   "publishConfig": {

--- a/ts/packages/providers/vercel/package.json
+++ b/ts/packages/providers/vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/vercel",
-  "version": "0.6.5",
+  "version": "1.0.0-alpha.0",
   "description": "",
   "main": "src/index.ts",
   "publishConfig": {
@@ -38,7 +38,7 @@
   "license": "ISC",
   "packageManager": "pnpm@10.28.0",
   "peerDependencies": {
-    "@composio/core": "0.6.5",
+    "@composio/core": "0.7.0-alpha.0",
     "ai": "^5.0.0 || ^6.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Alpha release for custom tools, custom toolkits, and proxy execute.

- `@composio/core` → `0.7.0-alpha.0`
- All provider packages bumped with alpha tags

### What's included
- `experimental_createTool()` — standalone, extension (inherits toolkit auth), and toolkit-grouped tools
- `session.proxyExecute()` / `ctx.proxyExecute()` — raw HTTP API calls through Composio's auth layer
- Slug mapping from backend response instead of client-side `LOCAL_` prefix
- Official `@composio/client@0.1.0-alpha.62` types

### To publish
Merge this PR → CI runs `pnpm changeset:release` → publishes to npm with alpha tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)