### PR TITLE
fix: capture bumped package versions in Slack release notification

### DIFF
--- a/.github/workflows/ts.release.yml
+++ b/.github/workflows/ts.release.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # Required for git show HEAD^ when comparing published package versions
 
       - name: Setup Node.js, pnpm, Bun
         uses: ./.github/actions/setup-node-pnpm-bun

--- a/.github/workflows/ts.release.yml
+++ b/.github/workflows/ts.release.yml
@@ -43,9 +43,27 @@ jobs:
 
       - name: Set Version Info
         if: steps.changesets.outputs.published == 'true'
+        env:
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
         run: |
-          VERSIONS=$(pnpm changeset status --json | jq -r '.releases[] | "⚡️ \(.name) -> \(.version)"' || echo "No version info available")
-          echo "SLACK_VERSIONS=$VERSIONS" >> $GITHUB_ENV
+          echo "SLACK_VERSIONS<<EOF" >> $GITHUB_ENV
+          echo "$PUBLISHED_PACKAGES" | jq -c '.[]' | while read -r pkg; do
+            NAME=$(echo "$pkg" | jq -r '.name')
+            NEW_VERSION=$(echo "$pkg" | jq -r '.version')
+            PKG_PATH=$(pnpm list --filter "$NAME" --json | jq -r '.[0].path')
+            if [ "$PKG_PATH" != "null" ] && [ -n "$PKG_PATH" ]; then
+              REL_PKG_JSON_PATH="${PKG_PATH#$GITHUB_WORKSPACE/}/package.json"
+              OLD_VERSION=$(git show "HEAD^:$REL_PKG_JSON_PATH" | jq -r .version 2>/dev/null || echo "")
+              if [ -n "$OLD_VERSION" ] && [ "$OLD_VERSION" != "$NEW_VERSION" ]; then
+                echo "⚡️ $NAME: \`$OLD_VERSION\` -> \`$NEW_VERSION\`" >> $GITHUB_ENV
+              else
+                echo "⚡️ $NAME: \`$NEW_VERSION\`" >> $GITHUB_ENV
+              fi
+            else
+              echo "⚡️ $NAME: \`$NEW_VERSION\`" >> $GITHUB_ENV
+            fi
+          done
+          echo "EOF" >> $GITHUB_ENV
 
       - name: Send Slack Notification
         if: steps.changesets.outputs.published == 'true'

--- a/.github/workflows/ts.release.yml
+++ b/.github/workflows/ts.release.yml
@@ -48,8 +48,8 @@ jobs:
         env:
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
         run: |
-          echo "SLACK_VERSIONS<<EOF" >> $GITHUB_ENV
-          echo "$PUBLISHED_PACKAGES" | jq -c '.[]' | while read -r pkg; do
+          SLACK_VERSIONS=""
+          while read -r pkg; do
             NAME=$(echo "$pkg" | jq -r '.name')
             NEW_VERSION=$(echo "$pkg" | jq -r '.version')
             PKG_PATH=$(pnpm list --filter "$NAME" --json | jq -r '.[0].path')
@@ -57,23 +57,32 @@ jobs:
               REL_PKG_JSON_PATH="${PKG_PATH#$GITHUB_WORKSPACE/}/package.json"
               OLD_VERSION=$(git show "HEAD^:$REL_PKG_JSON_PATH" | jq -r .version 2>/dev/null || echo "")
               if [ -n "$OLD_VERSION" ] && [ "$OLD_VERSION" != "$NEW_VERSION" ]; then
-                echo "⚡️ $NAME: \`$OLD_VERSION\` -> \`$NEW_VERSION\`" >> $GITHUB_ENV
+                VERSION_LINE="⚡️ $NAME: \`$OLD_VERSION\` -> \`$NEW_VERSION\`"
               else
-                echo "⚡️ $NAME: \`$NEW_VERSION\`" >> $GITHUB_ENV
+                VERSION_LINE="⚡️ $NAME: \`$NEW_VERSION\`"
               fi
             else
-              echo "⚡️ $NAME: \`$NEW_VERSION\`" >> $GITHUB_ENV
+              VERSION_LINE="⚡️ $NAME: \`$NEW_VERSION\`"
             fi
-          done
-          echo "EOF" >> $GITHUB_ENV
+            if [ -n "$SLACK_VERSIONS" ]; then
+              SLACK_VERSIONS="$SLACK_VERSIONS
+$VERSION_LINE"
+            else
+              SLACK_VERSIONS="$VERSION_LINE"
+            fi
+          done < <(jq -c '.[]' <<<"$PUBLISHED_PACKAGES")
+          # Build a single-line JSON payload so multiline version info is safely escaped.
+          SLACK_PAYLOAD=$(jq -nc \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg versions "$SLACK_VERSIONS" \
+            --arg sha "$GITHUB_SHA" \
+            '{text: "🚀 New SDK version published!\n*Repository:* \($repository)\n*Versions:*\n\($versions)\n*Commit:* \($sha)"}')
+          echo "SLACK_PAYLOAD=$SLACK_PAYLOAD" >> "$GITHUB_ENV"
 
       - name: Send Slack Notification
         if: steps.changesets.outputs.published == 'true'
         uses: slackapi/slack-github-action@fcfb566f8b0aab22203f066d80ca1d7e4b5d05b3 # v1.27.1
         with:
-          payload: |
-            {
-              "text": "🚀 New SDK version published!\n*Repository:* ${{ github.repository }}\n*Versions:*\n${{ env.SLACK_VERSIONS }}\n*Commit:* ${{ github.sha }}"
-            }
+          payload: ${{ env.SLACK_PAYLOAD }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_WEBHOOK_URL }}

--- a/.github/workflows/ts.release.yml
+++ b/.github/workflows/ts.release.yml
@@ -50,19 +50,20 @@ jobs:
         run: |
           SLACK_VERSIONS=""
           while read -r pkg; do
-            NAME=$(echo "$pkg" | jq -r '.name')
-            NEW_VERSION=$(echo "$pkg" | jq -r '.version')
-            PKG_PATH=$(pnpm list --filter "$NAME" --json | jq -r '.[0].path')
-            if [ "$PKG_PATH" != "null" ] && [ -n "$PKG_PATH" ]; then
+            NAME=$(jq -r '.name // empty' <<<"$pkg" 2>/dev/null || echo "")
+            NEW_VERSION=$(jq -r '.version // empty' <<<"$pkg" 2>/dev/null || echo "")
+            if [ -z "$NAME" ] || [ -z "$NEW_VERSION" ]; then
+              continue
+            fi
+
+            VERSION_LINE="⚡️ $NAME: \`$NEW_VERSION\`"
+            PKG_PATH=$(pnpm list --filter "$NAME" --json 2>/dev/null | jq -r '.[0].path // empty' 2>/dev/null || echo "")
+            if [ -n "$PKG_PATH" ]; then
               REL_PKG_JSON_PATH="${PKG_PATH#$GITHUB_WORKSPACE/}/package.json"
-              OLD_VERSION=$(git show "HEAD^:$REL_PKG_JSON_PATH" | jq -r .version 2>/dev/null || echo "")
+              OLD_VERSION=$(git show "HEAD^:$REL_PKG_JSON_PATH" 2>/dev/null | jq -r '.version // empty' 2>/dev/null || echo "")
               if [ -n "$OLD_VERSION" ] && [ "$OLD_VERSION" != "$NEW_VERSION" ]; then
                 VERSION_LINE="⚡️ $NAME: \`$OLD_VERSION\` -> \`$NEW_VERSION\`"
-              else
-                VERSION_LINE="⚡️ $NAME: \`$NEW_VERSION\`"
               fi
-            else
-              VERSION_LINE="⚡️ $NAME: \`$NEW_VERSION\`"
             fi
             if [ -n "$SLACK_VERSIONS" ]; then
               SLACK_VERSIONS="$SLACK_VERSIONS
@@ -70,7 +71,10 @@ $VERSION_LINE"
             else
               SLACK_VERSIONS="$VERSION_LINE"
             fi
-          done < <(jq -c '.[]' <<<"$PUBLISHED_PACKAGES")
+          done < <(jq -c 'if type == "array" then .[] else empty end' <<<"$PUBLISHED_PACKAGES" 2>/dev/null || true)
+          if [ -z "$SLACK_VERSIONS" ]; then
+            SLACK_VERSIONS="No version info available"
+          fi
           # Build a single-line JSON payload so multiline version info is safely escaped.
           SLACK_PAYLOAD=$(jq -nc \
             --arg repository "$GITHUB_REPOSITORY" \


### PR DESCRIPTION
## Summary
- Updated `.github/workflows/ts.release.yml` to correctly identify and format published package versions.
- Uses `steps.changesets.outputs.publishedPackages` which is the reliable source of truth after publication.
- Enhances Slack notifications by showing the version bump (e.g., `0.6.3 -> 0.6.4`) by comparing against the previous commit.

## Test plan
- Manual review of the shell script logic.
- The `pnpm list` and `git show` commands have been verified to work as expected for locating package files and reading their historical versions.

Made with [Cursor](https://cursor.com)