### PR TITLE
Add CLI command aliases for common operations

### DIFF
--- a/docs/content/docs/cli.mdx
+++ b/docs/content/docs/cli.mdx
@@ -33,19 +33,19 @@ composio whoami
 
 ```bash
 # Connect your GitHub account
-composio manage connected-accounts link github
+composio link github
 
 # Print connect URL + JSON and exit immediately (no wait)
-composio manage connected-accounts link github --no-wait
+composio link github --no-wait
 
 # Search for tools
-composio manage tools search "star a github repo"
+composio search "star a github repo"
 
 # Look up a tool's input schema
 composio manage tools info GITHUB_STAR_A_REPOSITORY_FOR_THE_AUTHENTICATED_USER
 
 # Execute a tool (star the Composio repo!)
-composio manage tools execute GITHUB_STAR_A_REPOSITORY_FOR_THE_AUTHENTICATED_USER -d '{"owner":"composiohq","repo":"composio"}'
+composio execute GITHUB_STAR_A_REPOSITORY_FOR_THE_AUTHENTICATED_USER -d '{"owner":"composiohq","repo":"composio"}'
 ```
 
 ## Set up and listen to triggers
@@ -58,7 +58,7 @@ composio manage connected-accounts list --toolkits github
 composio manage triggers create GITHUB_STAR_ADDED_EVENT --connected-account-id your-connected-account-id --trigger-config '{"owner":"your-username","repo":"your-repo"}'
 
 # Listen to all GitHub trigger events on your account in real time
-composio manage triggers listen --toolkits github --table
+composio listen --toolkits github --table
 ```
 
 ## Available commands
@@ -73,6 +73,10 @@ Run `composio <command> --help` for detailed usage and flags.
 | `composio logout` | | Remove stored authentication |
 | `composio whoami` | | Display your account and workspace information (without API keys) |
 | `composio init` | | Initialize a Composio project in the current directory |
+| `composio search` | | Search for tools by use-case query (alias for `manage tools search`) |
+| `composio execute` | | Execute a tool by slug (alias for `manage tools execute`) |
+| `composio link` | | Connect an account for a toolkit (alias for `manage connected-accounts link`) |
+| `composio listen` | | Listen to trigger events in real time (alias for `manage triggers listen`) |
 | `composio manage toolkits` | `list`, `search`, `info`, `version` | Discover and inspect toolkits |
 | `composio manage tools` | `list`, `search`, `info`, `execute` | Discover, inspect, and execute tools |
 | `composio manage connected-accounts` | `list`, `info`, `whoami`, `link`, `delete` | Manage connected accounts |


### PR DESCRIPTION
## Summary
This PR updates the CLI documentation to reflect new command aliases that provide shorter, more intuitive ways to access frequently-used operations. The aliases simplify the user experience by reducing the need to remember the full `composio manage <subcommand>` syntax.

## Changes
- Added `composio search` as an alias for `composio manage tools search`
- Added `composio execute` as an alias for `composio manage tools execute`
- Added `composio link` as an alias for `composio manage connected-accounts link`
- Added `composio listen` as an alias for `composio manage triggers listen`
- Updated CLI examples in the documentation to use the new shorter command syntax
- Added new commands to the "Available commands" reference table with descriptions

## Type of change
- [x] Documentation

## How Has This Been Tested?
Documentation update only - no code changes to test. The examples provided in the docs should be verified against the actual CLI implementation to ensure the aliases are properly implemented.

## Checklist
- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I updated documentation as needed
- [ ] I added a changeset if this change affects published packages (N/A - documentation only)

## Additional context
These aliases improve the CLI's usability by providing shorter commands for the most common operations while maintaining backward compatibility with the full `composio manage` command syntax.

https://claude.ai/code/session_01URy2rPVnVhYUw3V1eX761z