### PR TITLE
fix(cli): change default web redirect URL to dashboard

### DIFF
--- a/ts/packages/cli/README.md
+++ b/ts/packages/cli/README.md
@@ -49,7 +49,7 @@ By default, this file is stored in `~/.composio`, but you can specify a custom l
 | ---------------------- | ---------------- | ------------------------------------------------------------------ | ----------------------------- |
 | COMPOSIO_API_KEY       | `api_key`        | Composio backend API key                                           | None                          |
 | COMPOSIO_BASE_URL      | `base_url`       | The base URL of the Composio backend API                           | https://backend.composio.dev  |
-| COMPOSIO_WEB_URL       | `web_url`        | The base URL of the Composio web app                               | https://platform.composio.dev |
+| COMPOSIO_WEB_URL       | `web_url`        | The base URL of the Composio web app                               | https://dashboard.composio.dev/ |
 | COMPOSIO_CACHE_DIR     | -                | The directory where the Composio CLI stores cache files            | ~/.composio                   |
 | COMPOSIO_LOG_LEVEL     | -                | The log level for the Composio CLI                                 | None                          |
 | DEBUG_OVERRIDE_VERSION | -                | The version to use when upgrading the Composio CLI (for debugging) | None                          |

--- a/ts/packages/cli/test/src/commands/logout.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/logout.cmd.test.ts
@@ -16,7 +16,7 @@ describe('CLI: composio logout', () => {
           const expectedUserData = UserDataWithDefaults.make({
             apiKey: Option.none(),
             baseURL: 'https://backend.composio.dev',
-            webURL: 'https://platform.composio.dev',
+            webURL: 'https://dashboard.composio.dev/',
             orgId: Option.none(),
             projectId: Option.none(),
             testUserId: Option.none(),
@@ -53,7 +53,7 @@ describe('CLI: composio logout', () => {
             UserDataWithDefaults.make({
               apiKey: Option.some('api_key_already_logged_in'),
               baseURL: 'https://backend.composio.dev',
-              webURL: 'https://platform.composio.dev',
+              webURL: 'https://dashboard.composio.dev/',
               orgId: Option.none(),
               projectId: Option.none(),
               testUserId: Option.none(),

--- a/ts/packages/cli/test/src/services/config.test.ts
+++ b/ts/packages/cli/test/src/services/config.test.ts
@@ -30,7 +30,7 @@ describe('Config', () => {
             LOG_LEVEL: Option.none(),
             ORG_ID: Option.none(),
             PROJECT_ID: Option.none(),
-            WEB_URL: 'https://platform.composio.dev',
+            WEB_URL: 'https://dashboard.composio.dev/',
           })
         );
       });
@@ -57,7 +57,7 @@ describe('Config', () => {
             LOG_LEVEL: Option.none(),
             ORG_ID: Option.none(),
             PROJECT_ID: Option.none(),
-            WEB_URL: 'https://platform.composio.dev',
+            WEB_URL: 'https://dashboard.composio.dev/',
           })
         );
       });
@@ -307,7 +307,7 @@ describe('Config', () => {
             USER_API_KEY: Option.none(),
             ENVIRONMENT: Option.none(),
             BASE_URL: 'https://backend.composio.dev',
-            WEB_URL: 'https://platform.composio.dev',
+            WEB_URL: 'https://dashboard.composio.dev/',
             CACHE_DIR: Option.none(),
             LOG_LEVEL: Option.none(),
             ORG_ID: Option.none(),
@@ -332,7 +332,7 @@ describe('Config', () => {
             USER_API_KEY: Option.none(),
             ENVIRONMENT: Option.none(),
             BASE_URL: 'https://backend.composio.dev',
-            WEB_URL: 'https://platform.composio.dev',
+            WEB_URL: 'https://dashboard.composio.dev/',
             CACHE_DIR: Option.none(),
             LOG_LEVEL: Option.none(),
             ORG_ID: Option.none(),

--- a/ts/packages/cli/test/src/services/user-context.test.ts
+++ b/ts/packages/cli/test/src/services/user-context.test.ts
@@ -32,7 +32,7 @@ describe('ComposioUserContext', () => {
           const expectedUserData = UserDataWithDefaults.make({
             apiKey: Option.none(),
             baseURL: 'https://backend.composio.dev',
-            webURL: 'https://platform.composio.dev',
+            webURL: 'https://dashboard.composio.dev/',
             orgId: Option.none(),
             projectId: Option.none(),
             testUserId: Option.none(),
@@ -63,7 +63,7 @@ describe('ComposioUserContext', () => {
           const expectedUserData = UserDataWithDefaults.make({
             apiKey: Option.some('api_key'),
             baseURL: 'https://test.composio.localhost',
-            webURL: 'https://platform.composio.dev',
+            webURL: 'https://dashboard.composio.dev/',
             orgId: Option.none(),
             projectId: Option.none(),
             testUserId: Option.none(),
@@ -109,7 +109,7 @@ describe('ComposioUserContext', () => {
           const expectedUserData = UserData.make({
             apiKey: Option.some('api_key'),
             baseURL: Option.some('https://test.composio.localhost'),
-            webURL: Option.some('https://platform.composio.dev'),
+            webURL: Option.some('https://dashboard.composio.dev/'),
             orgId: Option.none(),
             projectId: Option.none(),
             testUserId: Option.none(),
@@ -149,7 +149,7 @@ describe('ComposioUserContext', () => {
           const expectedUserData = UserData.make({
             apiKey: Option.some('api_key'),
             baseURL: Option.none(),
-            webURL: Option.some('https://platform.composio.dev'),
+            webURL: Option.some('https://dashboard.composio.dev/'),
             orgId: Option.none(),
             projectId: Option.none(),
             testUserId: Option.none(),
@@ -198,7 +198,7 @@ describe('ComposioUserContext', () => {
           const expectedUserData = UserDataWithDefaults.make({
             apiKey: Option.none(),
             baseURL: 'https://backend.composio.dev',
-            webURL: 'https://platform.composio.dev',
+            webURL: 'https://dashboard.composio.dev/',
             orgId: Option.none(),
             projectId: Option.none(),
             testUserId: Option.none(),
@@ -243,7 +243,7 @@ describe('ComposioUserContext', () => {
           const expectedUserData = UserDataWithDefaults.make({
             apiKey: Option.none(),
             baseURL: 'https://backend.composio.dev',
-            webURL: 'https://platform.composio.dev',
+            webURL: 'https://dashboard.composio.dev/',
             orgId: Option.none(),
             projectId: Option.none(),
             testUserId: Option.none(),
@@ -280,7 +280,7 @@ describe('ComposioUserContext', () => {
           const expectedUserData = UserDataWithDefaults.make({
             apiKey: Option.none(),
             baseURL: 'https://backend.composio.dev',
-            webURL: 'https://platform.composio.dev',
+            webURL: 'https://dashboard.composio.dev/',
             orgId: Option.none(),
             projectId: Option.none(),
             testUserId: Option.none(),

--- a/ts/packages/core/src/utils/constants.ts
+++ b/ts/packages/core/src/utils/constants.ts
@@ -5,7 +5,7 @@ export const COMPOSIO_DIR = '.composio';
 export const USER_DATA_FILE_NAME = 'user_data.json';
 export const TEMP_FILES_DIRECTORY_NAME = 'files';
 export const DEFAULT_BASE_URL = 'https://backend.composio.dev';
-export const DEFAULT_WEB_URL = 'https://platform.composio.dev';
+export const DEFAULT_WEB_URL = 'https://dashboard.composio.dev/';
 
 export const TELEMETRY_URL = 'https://app.composio.dev';
 export const CLIENT_PUSHER_KEY = getEnvVariable('CLIENT_PUSHER_KEY') || 'ff9f18c208855d77a152';


### PR DESCRIPTION
## Summary
- change the default web URL used by the CLI from `https://platform.composio.dev` to `https://dashboard.composio.dev/`
- update CLI tests and README expectations to match the new default

## Testing
- Could not run `@composio/cli` Vitest tests in this worktree because `node_modules` is not installed (`vitest: command not found`).