### PR TITLE
Make root search/link/execute consumer-only

### DIFF
--- a/ts/packages/cli/package.json
+++ b/ts/packages/cli/package.json
@@ -35,7 +35,7 @@
     "table:metrics": "bun run ./scripts/optimize-metrics-table.ts",
     "mock": "bun run ./scripts/copy-mocks-from-cache.ts",
     "prebuild": "pnpm run typecheck",
-    "build": "bun run --bun tsdown",
+    "build": "pnpm exec tsdown",
     "bin": "./dist/composio",
     "test": "vitest run",
     "prepublishOnly": "pnpm run build && pnpm run build:binary",

--- a/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
+++ b/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
@@ -25,9 +25,7 @@ const authConfig = Options.text('auth-config').pipe(
 );
 
 const userId = Options.text('user-id').pipe(
-  Options.withDescription(
-    'User ID for the connection (falls back to local developer or global test_user_id)'
-  ),
+  Options.withDescription('Developer-project user ID override'),
   Options.optional
 );
 
@@ -46,10 +44,6 @@ const noWait = Options.boolean('no-wait').pipe(
   Options.withDescription('Do not wait for authorization; only print link info')
 );
 
-/**
- * Open the browser and poll until the connected account becomes ACTIVE.
- * On success, outputs valid JSON to stdout for piping (e.g. to jq).
- */
 const waitForActiveConnection = (
   ui: TerminalUI,
   repo: ComposioToolkitsRepository,
@@ -58,17 +52,15 @@ const waitForActiveConnection = (
   noBrowser: boolean
 ) =>
   Effect.gen(function* () {
-    // Display the redirect URL (interactive only)
     yield* ui.note(redirectUrl, 'Redirect URL');
 
     if (!noBrowser) {
-      // Validate URL scheme before opening — prevent non-HTTPS redirects
       let urlSchemeValid = false;
       try {
         const parsed = new URL(redirectUrl);
         urlSchemeValid = parsed.protocol === 'https:' || parsed.protocol === 'http:';
       } catch {
-        // Malformed URL — fall through to the warning below
+        // ignore
       }
 
       if (!urlSchemeValid) {
@@ -87,21 +79,17 @@ const waitForActiveConnection = (
       }
     }
 
-    // Poll until the connected account becomes ACTIVE
     yield* ui.useMakeSpinner('Waiting for authentication...', spinner =>
       Effect.retry(
         Effect.gen(function* () {
           const account = yield* repo.getConnectedAccount(connectedAccountId);
-
           if (account.status === 'ACTIVE') {
             return account;
           }
-
           return yield* Effect.fail(
             new Error(`Connection status is still '${account.status}', waiting for 'ACTIVE'`)
           );
         }),
-        // Exponential backoff: start with 0.3s, max 5s, up to 15 retries
         Schedule.exponential('0.3 seconds').pipe(
           Schedule.intersect(Schedule.recurs(15)),
           Schedule.intersect(Schedule.spaced('5 seconds'))
@@ -132,224 +120,266 @@ const waitForActiveConnection = (
     );
   });
 
-/**
- * Link an external account via OAuth redirect.
- *
- * Two modes:
- * - **Tool Router** (default): `composio manage connected-accounts link <toolkit>`
- * - **Legacy**: `composio manage connected-accounts link --auth-config <id>`
- *
- * @example
- * ```bash
- * composio manage connected-accounts link github
- * composio manage connected-accounts link gmail --user-id "alice"
- * composio manage connected-accounts link --auth-config "ac_..." --user-id "default"
- * ```
- */
+const runConnectedAccountsLink = (params: {
+  toolkit: Option.Option<string>;
+  authConfig: Option.Option<string>;
+  userId: Option.Option<string>;
+  projectName: Option.Option<string>;
+  noBrowser: boolean;
+  noWait: boolean;
+  rootOnly: boolean;
+}) =>
+  Effect.gen(function* () {
+    if (!(yield* requireAuth)) return;
+
+    const ui = yield* TerminalUI;
+    const repo = yield* ComposioToolkitsRepository;
+    const clientSingleton = yield* ComposioClientSingleton;
+    const projectContext = yield* ProjectContext;
+    const userContext = yield* ComposioUserContext;
+
+    if (params.rootOnly) {
+      if (Option.isSome(params.authConfig)) {
+        return yield* Effect.fail(
+          new Error(
+            'Top-level `composio link` is consumer-only and does not accept `--auth-config`. Use `composio manage connected-accounts link --auth-config ...` for developer-scoped usage.'
+          )
+        );
+      }
+    }
+
+    if (Option.isSome(params.toolkit) && Option.isSome(params.authConfig)) {
+      yield* ui.log.error(
+        'Cannot use both <toolkit> and --auth-config. Choose one:\n' +
+          '  Tool Router: composio manage connected-accounts link <toolkit>\n' +
+          '  Legacy:      composio manage connected-accounts link --auth-config <id>'
+      );
+      return;
+    }
+
+    if (Option.isNone(params.toolkit) && Option.isNone(params.authConfig)) {
+      yield* ui.log.error(
+        params.rootOnly
+          ? 'Missing argument. Provide a toolkit slug:\n  composio link github'
+          : 'Missing argument. Provide a toolkit slug or --auth-config:\n' +
+              '  composio manage connected-accounts link github\n' +
+              '  composio manage connected-accounts link --auth-config "ac_..."'
+      );
+      return;
+    }
+
+    if (Option.isSome(params.authConfig)) {
+      const authConfigId = params.authConfig.value;
+      const resolvedProjectContext = yield* projectContext.resolve.pipe(
+        Effect.catchAll(() => Effect.succeed(Option.none()))
+      );
+      const localTestUserId = Option.flatMap(resolvedProjectContext, keys => keys.testUserId);
+      const globalTestUserId = userContext.data.testUserId;
+      const resolvedUserId = Option.match(params.userId, {
+        onSome: value => Option.some(value),
+        onNone: () => Option.orElse(localTestUserId, () => globalTestUserId),
+      });
+      if (Option.isNone(resolvedUserId)) {
+        return yield* Effect.fail(
+          new Error('Missing user id. Provide --user-id or run composio init to set test_user_id.')
+        );
+      }
+      if (Option.isNone(params.projectName) && Option.isNone(resolvedProjectContext)) {
+        yield* ui.log.error(
+          '`--auth-config` is developer-project scoped. Pass `--project-name <name>` or run from a directory initialized with `composio init`.'
+        );
+        return;
+      }
+      if (Option.isNone(params.userId) && Option.isSome(localTestUserId)) {
+        yield* ui.log.warn(`Using test user id "${localTestUserId.value}"`);
+      } else if (Option.isNone(params.userId) && Option.isSome(globalTestUserId)) {
+        yield* ui.log.warn(`Using global test user id "${globalTestUserId.value}"`);
+      }
+      const resolvedProject = yield* resolveCommandProject({
+        mode: 'developer',
+        projectName: Option.getOrUndefined(params.projectName),
+      }).pipe(Effect.mapError(formatResolveCommandProjectError));
+      const client = yield* clientSingleton.getFor({
+        orgId: resolvedProject.orgId,
+        projectId: resolvedProject.projectId,
+      });
+      const linkOpt = yield* ui
+        .withSpinner(
+          'Creating link session...',
+          Effect.tryPromise(() =>
+            client.link.create({
+              auth_config_id: authConfigId,
+              user_id: resolvedUserId.value,
+            })
+          )
+        )
+        .pipe(
+          Effect.asSome,
+          Effect.catchAll(error =>
+            Effect.gen(function* () {
+              const message =
+                extractMessage(error) ?? `Failed to create link for auth config "${authConfigId}".`;
+              yield* ui.log.error(message);
+              yield* ui.log.step(
+                'Browse available auth configs:\n> composio manage auth-configs list'
+              );
+              return Option.none();
+            })
+          )
+        );
+
+      if (Option.isNone(linkOpt)) return;
+
+      const { connected_account_id: connId, redirect_url: redirectUrl } = linkOpt.value;
+      if (params.noWait) {
+        yield* ui.note(redirectUrl, 'Redirect URL');
+        yield* ui.output(
+          JSON.stringify(
+            {
+              status: 'pending',
+              message: 'Complete authorization by opening the URL',
+              connected_account_id: connId,
+              redirect_url: redirectUrl,
+              project_type: resolvedProject.projectType,
+            },
+            null,
+            2
+          )
+        );
+      } else {
+        yield* waitForActiveConnection(ui, repo, connId, redirectUrl, params.noBrowser);
+      }
+      return;
+    }
+
+    const toolkitSlug = Option.getOrThrow(params.toolkit);
+    const resolvedProject = yield* resolveCommandProject({
+      mode: 'consumer',
+      projectName: params.rootOnly ? undefined : Option.getOrUndefined(params.projectName),
+    }).pipe(Effect.mapError(formatResolveCommandProjectError));
+    const resolvedUserId =
+      resolvedProject.projectType === 'CONSUMER'
+        ? Option.fromNullable(resolvedProject.consumerUserId)
+        : Option.match(params.userId, {
+            onSome: value => Option.some(value),
+            onNone: () => userContext.data.testUserId,
+          });
+    if (Option.isNone(resolvedUserId)) {
+      return yield* Effect.fail(
+        new Error(
+          'Missing user id. Provide --user-id or run composio login to set global test_user_id.'
+        )
+      );
+    }
+    const client = yield* clientSingleton.getFor({
+      orgId: resolvedProject.orgId,
+      projectId: resolvedProject.projectId,
+    });
+
+    const linkOpt = yield* ui
+      .withSpinner(
+        `Linking ${toolkitSlug}...`,
+        Effect.gen(function* () {
+          const { sessionId } = yield* resolveToolRouterSession(client, resolvedUserId.value, {
+            manageConnections: true,
+          });
+          return yield* Effect.tryPromise(() =>
+            client.toolRouter.session.link(sessionId, { toolkit: toolkitSlug })
+          );
+        })
+      )
+      .pipe(
+        Effect.asSome,
+        Effect.catchAll(error =>
+          Effect.gen(function* () {
+            const message =
+              extractMessage(error) ?? `Failed to create link for toolkit "${toolkitSlug}".`;
+            yield* ui.log.error(message);
+            yield* Effect.logDebug('Link error:', error);
+            yield* ui.log.step('Browse available toolkits:\n> composio manage toolkits list');
+            return Option.none();
+          })
+        )
+      );
+
+    if (Option.isNone(linkOpt)) return;
+
+    const { connected_account_id: connAccountId, redirect_url: redirectUrl } = linkOpt.value;
+    if (!connAccountId || !redirectUrl) {
+      yield* ui.log.error(
+        'The API returned an incomplete link response (missing connected_account_id or redirect_url).'
+      );
+      yield* Effect.logDebug('Link response:', linkOpt.value);
+      return;
+    }
+
+    if (params.noWait) {
+      yield* ui.note(redirectUrl, 'Redirect URL');
+      yield* ui.output(
+        JSON.stringify(
+          {
+            status: 'pending',
+            message: 'Complete authorization by opening the URL',
+            connected_account_id: connAccountId,
+            redirect_url: redirectUrl,
+            toolkit: toolkitSlug,
+            project_type: resolvedProject.projectType,
+          },
+          null,
+          2
+        )
+      );
+    } else {
+      yield* waitForActiveConnection(ui, repo, connAccountId, redirectUrl, params.noBrowser);
+    }
+  });
+
 export const connectedAccountsCmd$Link = Command.make(
   'link',
   { toolkit, authConfig, userId, projectName, noBrowser, noWait },
   ({ toolkit, authConfig, userId, projectName, noBrowser, noWait }) =>
-    Effect.gen(function* () {
-      if (!(yield* requireAuth)) return;
-
-      const ui = yield* TerminalUI;
-      const repo = yield* ComposioToolkitsRepository;
-      const clientSingleton = yield* ComposioClientSingleton;
-      const projectContext = yield* ProjectContext;
-      const userContext = yield* ComposioUserContext;
-
-      // Validate: exactly one of <toolkit> or --auth-config must be provided
-      if (Option.isSome(toolkit) && Option.isSome(authConfig)) {
-        yield* ui.log.error(
-          'Cannot use both <toolkit> and --auth-config. Choose one:\n' +
-            '  Tool Router: composio manage connected-accounts link <toolkit>\n' +
-            '  Legacy:      composio manage connected-accounts link --auth-config <id>'
-        );
-        return;
-      }
-
-      if (Option.isNone(toolkit) && Option.isNone(authConfig)) {
-        yield* ui.log.error(
-          'Missing argument. Provide a toolkit slug or --auth-config:\n' +
-            '  composio manage connected-accounts link github\n' +
-            '  composio manage connected-accounts link --auth-config "ac_..."'
-        );
-        return;
-      }
-
-      if (Option.isSome(authConfig)) {
-        const resolvedProjectContext = yield* projectContext.resolve.pipe(
-          Effect.catchAll(() => Effect.succeed(Option.none()))
-        );
-        const localTestUserId = Option.flatMap(resolvedProjectContext, keys => keys.testUserId);
-        const globalTestUserId = userContext.data.testUserId;
-        const resolvedUserId = Option.match(userId, {
-          onSome: value => Option.some(value),
-          onNone: () => Option.orElse(localTestUserId, () => globalTestUserId),
-        });
-        if (Option.isNone(resolvedUserId)) {
-          return yield* Effect.fail(
-            new Error(
-              'Missing user id. Provide --user-id or run composio init to set test_user_id.'
-            )
-          );
-        }
-        if (Option.isNone(projectName) && Option.isNone(resolvedProjectContext)) {
-          yield* ui.log.error(
-            '`--auth-config` is developer-project scoped. Pass `--project-name <name>` or run from a directory initialized with `composio init`.'
-          );
-          return;
-        }
-        if (Option.isNone(userId) && Option.isSome(localTestUserId)) {
-          yield* ui.log.warn(`Using test user id "${localTestUserId.value}"`);
-        } else if (Option.isNone(userId) && Option.isSome(globalTestUserId)) {
-          yield* ui.log.warn(`Using global test user id "${globalTestUserId.value}"`);
-        }
-        const resolvedProject = yield* resolveCommandProject({
-          mode: 'developer',
-          projectName: Option.getOrUndefined(projectName),
-        }).pipe(Effect.mapError(formatResolveCommandProjectError));
-        const client = yield* clientSingleton.getFor({
-          orgId: resolvedProject.orgId,
-          projectId: resolvedProject.projectId,
-        });
-        // Path A: Legacy flow — use existing client.link.create()
-        const linkOpt = yield* ui
-          .withSpinner(
-            'Creating link session...',
-            Effect.tryPromise(() =>
-              client.link.create({
-                auth_config_id: authConfig.value,
-                user_id: resolvedUserId.value,
-              })
-            )
-          )
-          .pipe(
-            Effect.asSome,
-            Effect.catchAll(error =>
-              Effect.gen(function* () {
-                const message =
-                  extractMessage(error) ??
-                  `Failed to create link for auth config "${authConfig.value}".`;
-                yield* ui.log.error(message);
-                yield* ui.log.step(
-                  'Browse available auth configs:\n> composio manage auth-configs list'
-                );
-                return Option.none();
-              })
-            )
-          );
-
-        if (Option.isNone(linkOpt)) {
-          return;
-        }
-
-        const { connected_account_id: connId, redirect_url: redirectUrl } = linkOpt.value;
-
-        if (noWait) {
-          yield* ui.note(redirectUrl, 'Redirect URL');
-          yield* ui.output(
-            JSON.stringify(
-              {
-                status: 'pending',
-                message: 'Complete authorization by opening the URL',
-                connected_account_id: connId,
-                redirect_url: redirectUrl,
-                project_type: resolvedProject.projectType,
-              },
-              null,
-              2
-            )
-          );
-        } else {
-          yield* waitForActiveConnection(ui, repo, connId, redirectUrl, noBrowser);
-        }
-      } else {
-        // Path B: Tool Router flow — toolkit is guaranteed Some (validated above)
-        const toolkitSlug = Option.getOrThrow(toolkit);
-        const globalTestUserId = userContext.data.testUserId;
-        const resolvedUserId = Option.match(userId, {
-          onSome: value => Option.some(value),
-          onNone: () => globalTestUserId,
-        });
-        if (Option.isNone(resolvedUserId)) {
-          return yield* Effect.fail(
-            new Error(
-              'Missing user id. Provide --user-id or run composio login to set global test_user_id.'
-            )
-          );
-        }
-        if (Option.isNone(userId) && Option.isSome(globalTestUserId)) {
-          yield* ui.log.warn(`Using global test user id "${globalTestUserId.value}"`);
-        }
-        const resolvedProject = yield* resolveCommandProject({
-          mode: 'consumer',
-          projectName: Option.getOrUndefined(projectName),
-        }).pipe(Effect.mapError(formatResolveCommandProjectError));
-        const client = yield* clientSingleton.getFor({
-          orgId: resolvedProject.orgId,
-          projectId: resolvedProject.projectId,
-        });
-
-        const linkOpt = yield* ui
-          .withSpinner(
-            `Linking ${toolkitSlug}...`,
-            Effect.gen(function* () {
-              const { sessionId } = yield* resolveToolRouterSession(client, resolvedUserId.value, {
-                manageConnections: true,
-              });
-              return yield* Effect.tryPromise(() =>
-                client.toolRouter.session.link(sessionId, { toolkit: toolkitSlug })
-              );
-            })
-          )
-          .pipe(
-            Effect.asSome,
-            Effect.catchAll(error =>
-              Effect.gen(function* () {
-                const message =
-                  extractMessage(error) ?? `Failed to create link for toolkit "${toolkitSlug}".`;
-                yield* ui.log.error(message);
-                yield* Effect.logDebug('Link error:', error);
-                yield* ui.log.step('Browse available toolkits:\n> composio manage toolkits list');
-                return Option.none();
-              })
-            )
-          );
-
-        if (Option.isNone(linkOpt)) {
-          return;
-        }
-
-        const { connected_account_id: connAccountId, redirect_url: redirectUrl } = linkOpt.value;
-        if (!connAccountId || !redirectUrl) {
-          yield* ui.log.error(
-            'The API returned an incomplete link response (missing connected_account_id or redirect_url).'
-          );
-          yield* Effect.logDebug('Link response:', linkOpt.value);
-          return;
-        }
-
-        if (noWait) {
-          yield* ui.note(redirectUrl, 'Redirect URL');
-          yield* ui.output(
-            JSON.stringify(
-              {
-                status: 'pending',
-                message: 'Complete authorization by opening the URL',
-                connected_account_id: connAccountId,
-                redirect_url: redirectUrl,
-                toolkit: toolkitSlug,
-                project_type: resolvedProject.projectType,
-              },
-              null,
-              2
-            )
-          );
-        } else {
-          yield* waitForActiveConnection(ui, repo, connAccountId, redirectUrl, noBrowser);
-        }
-      }
+    runConnectedAccountsLink({
+      toolkit,
+      authConfig,
+      userId,
+      projectName,
+      noBrowser,
+      noWait,
+      rootOnly: false,
     })
-).pipe(Command.withDescription('Link an external account via OAuth redirect.'));
+).pipe(
+  Command.withDescription(
+    [
+      'Link an external account via OAuth redirect.',
+      '',
+      'Related:',
+      '  composio search "<query>"',
+      "  composio execute <slug> -d '{}'",
+    ].join('\n')
+  )
+);
+
+export const rootConnectedAccountsCmd$Link = Command.make(
+  'link',
+  { toolkit, noBrowser, noWait },
+  ({ toolkit, noBrowser, noWait }) =>
+    runConnectedAccountsLink({
+      toolkit,
+      authConfig: Option.none(),
+      userId: Option.none(),
+      projectName: Option.none(),
+      noBrowser,
+      noWait,
+      rootOnly: true,
+    })
+).pipe(
+  Command.withDescription(
+    [
+      'Link an external account via OAuth redirect.',
+      '',
+      'Related:',
+      '  composio search "<query>"',
+      "  composio execute <slug> -d '{}'",
+    ].join('\n')
+  )
+);

--- a/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
+++ b/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
@@ -120,6 +120,31 @@ const waitForActiveConnection = (
     );
   });
 
+const validateLinkResponse = (
+  ui: TerminalUI,
+  linkResponse: {
+    connected_account_id?: string | null;
+    redirect_url?: string | null;
+  }
+) =>
+  Effect.gen(function* () {
+    const connectedAccountId = linkResponse.connected_account_id;
+    const redirectUrl = linkResponse.redirect_url;
+
+    if (!connectedAccountId || !redirectUrl) {
+      yield* ui.log.error(
+        'The API returned an incomplete link response (missing connected_account_id or redirect_url).'
+      );
+      yield* Effect.logDebug('Link response:', linkResponse);
+      return Option.none();
+    }
+
+    return Option.some({
+      connectedAccountId,
+      redirectUrl,
+    });
+  });
+
 const runConnectedAccountsLink = (params: {
   toolkit: Option.Option<string>;
   authConfig: Option.Option<string>;
@@ -230,7 +255,10 @@ const runConnectedAccountsLink = (params: {
 
       if (Option.isNone(linkOpt)) return;
 
-      const { connected_account_id: connId, redirect_url: redirectUrl } = linkOpt.value;
+      const validatedLink = yield* validateLinkResponse(ui, linkOpt.value);
+      if (Option.isNone(validatedLink)) return;
+
+      const { connectedAccountId: connId, redirectUrl } = validatedLink.value;
       if (params.noWait) {
         yield* ui.note(redirectUrl, 'Redirect URL');
         yield* ui.output(
@@ -304,14 +332,10 @@ const runConnectedAccountsLink = (params: {
 
     if (Option.isNone(linkOpt)) return;
 
-    const { connected_account_id: connAccountId, redirect_url: redirectUrl } = linkOpt.value;
-    if (!connAccountId || !redirectUrl) {
-      yield* ui.log.error(
-        'The API returned an incomplete link response (missing connected_account_id or redirect_url).'
-      );
-      yield* Effect.logDebug('Link response:', linkOpt.value);
-      return;
-    }
+    const validatedLink = yield* validateLinkResponse(ui, linkOpt.value);
+    if (Option.isNone(validatedLink)) return;
+
+    const { connectedAccountId: connAccountId, redirectUrl } = validatedLink.value;
 
     if (params.noWait) {
       yield* ui.note(redirectUrl, 'Redirect URL');

--- a/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
+++ b/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
@@ -5,10 +5,14 @@ import { ComposioToolkitsRepository } from 'src/services/composio-clients';
 import { ComposioUserContext } from 'src/services/user-context';
 import { TerminalUI } from 'src/services/terminal-ui';
 import { requireAuth } from 'src/effects/require-auth';
-import { handleHttpServerError } from 'src/effects/handle-http-error';
 import { resolveToolRouterSession } from 'src/effects/create-tool-router-session';
 import { extractMessage } from 'src/utils/api-error-extraction';
 import { ProjectContext } from 'src/services/project-context';
+import { ComposioClientSingleton } from 'src/services/composio-clients';
+import {
+  resolveCommandProject,
+  formatResolveCommandProjectError,
+} from 'src/services/command-project';
 
 const toolkit = Args.text({ name: 'toolkit' }).pipe(
   Args.withDescription('Toolkit slug to link (e.g. "github", "gmail")'),
@@ -21,8 +25,15 @@ const authConfig = Options.text('auth-config').pipe(
 );
 
 const userId = Options.text('user-id').pipe(
-  Options.withDescription('User ID for the connection (falls back to project test_user_id)'),
+  Options.withDescription(
+    'User ID for the connection (falls back to local developer or global test_user_id)'
+  ),
   Options.optional
+);
+
+const projectName = Options.text('project-name').pipe(
+  Options.optional,
+  Options.withDescription('Developer project name override for this command')
 );
 
 const noBrowser = Options.boolean('no-browser').pipe(
@@ -137,32 +148,16 @@ const waitForActiveConnection = (
  */
 export const connectedAccountsCmd$Link = Command.make(
   'link',
-  { toolkit, authConfig, userId, noBrowser, noWait },
-  ({ toolkit, authConfig, userId, noBrowser, noWait }) =>
+  { toolkit, authConfig, userId, projectName, noBrowser, noWait },
+  ({ toolkit, authConfig, userId, projectName, noBrowser, noWait }) =>
     Effect.gen(function* () {
       if (!(yield* requireAuth)) return;
 
       const ui = yield* TerminalUI;
       const repo = yield* ComposioToolkitsRepository;
+      const clientSingleton = yield* ComposioClientSingleton;
       const projectContext = yield* ProjectContext;
       const userContext = yield* ComposioUserContext;
-      const resolvedProjectContext = yield* projectContext.resolve;
-      const testUserId = Option.flatMap(resolvedProjectContext, keys => keys.testUserId);
-      const globalTestUserId = userContext.data.testUserId;
-      const resolvedUserId = Option.match(userId, {
-        onSome: value => Option.some(value),
-        onNone: () => Option.orElse(testUserId, () => globalTestUserId),
-      });
-      if (Option.isNone(resolvedUserId)) {
-        return yield* Effect.fail(
-          new Error('Missing user id. Provide --user-id or run composio init to set test_user_id.')
-        );
-      }
-      if (Option.isNone(userId) && Option.isSome(testUserId)) {
-        yield* ui.log.warn(`Using test user id "${testUserId.value}"`);
-      } else if (Option.isNone(userId) && Option.isSome(globalTestUserId)) {
-        yield* ui.log.warn(`Using global test user id "${globalTestUserId.value}"`);
-      }
 
       // Validate: exactly one of <toolkit> or --auth-config must be provided
       if (Option.isSome(toolkit) && Option.isSome(authConfig)) {
@@ -184,23 +179,64 @@ export const connectedAccountsCmd$Link = Command.make(
       }
 
       if (Option.isSome(authConfig)) {
+        const resolvedProjectContext = yield* projectContext.resolve.pipe(
+          Effect.catchAll(() => Effect.succeed(Option.none()))
+        );
+        const localTestUserId = Option.flatMap(resolvedProjectContext, keys => keys.testUserId);
+        const globalTestUserId = userContext.data.testUserId;
+        const resolvedUserId = Option.match(userId, {
+          onSome: value => Option.some(value),
+          onNone: () => Option.orElse(localTestUserId, () => globalTestUserId),
+        });
+        if (Option.isNone(resolvedUserId)) {
+          return yield* Effect.fail(
+            new Error(
+              'Missing user id. Provide --user-id or run composio init to set test_user_id.'
+            )
+          );
+        }
+        if (Option.isNone(projectName) && Option.isNone(resolvedProjectContext)) {
+          yield* ui.log.error(
+            '`--auth-config` is developer-project scoped. Pass `--project-name <name>` or run from a directory initialized with `composio init`.'
+          );
+          return;
+        }
+        if (Option.isNone(userId) && Option.isSome(localTestUserId)) {
+          yield* ui.log.warn(`Using test user id "${localTestUserId.value}"`);
+        } else if (Option.isNone(userId) && Option.isSome(globalTestUserId)) {
+          yield* ui.log.warn(`Using global test user id "${globalTestUserId.value}"`);
+        }
+        const resolvedProject = yield* resolveCommandProject({
+          mode: 'developer',
+          projectName: Option.getOrUndefined(projectName),
+        }).pipe(Effect.mapError(formatResolveCommandProjectError));
+        const client = yield* clientSingleton.getFor({
+          orgId: resolvedProject.orgId,
+          projectId: resolvedProject.projectId,
+        });
         // Path A: Legacy flow — use existing client.link.create()
         const linkOpt = yield* ui
           .withSpinner(
             'Creating link session...',
-            repo.createConnectedAccountLink({
-              auth_config_id: authConfig.value,
-              user_id: resolvedUserId.value,
-            })
+            Effect.tryPromise(() =>
+              client.link.create({
+                auth_config_id: authConfig.value,
+                user_id: resolvedUserId.value,
+              })
+            )
           )
           .pipe(
             Effect.asSome,
-            Effect.catchTag(
-              'services/HttpServerError',
-              handleHttpServerError(ui, {
-                fallbackMessage: `Failed to create link for auth config "${authConfig.value}".`,
-                hint: 'Browse available auth configs:\n> composio manage auth-configs list',
-                fallbackValue: Option.none(),
+            Effect.catchAll(error =>
+              Effect.gen(function* () {
+                const message =
+                  extractMessage(error) ??
+                  `Failed to create link for auth config "${authConfig.value}".`;
+                yield* ui.log.error(message);
+                yield* ui.log.step(
+                  'Browse available auth configs:\n> composio manage auth-configs list'
+                );
+                return Option.none();
               })
             )
           );
@@ -220,6 +256,7 @@ export const connectedAccountsCmd$Link = Command.make(
                 message: 'Complete authorization by opening the URL',
                 connected_account_id: connId,
                 redirect_url: redirectUrl,
+                project_type: resolvedProject.projectType,
               },
               null,
               2
@@ -231,12 +268,35 @@ export const connectedAccountsCmd$Link = Command.make(
       } else {
         // Path B: Tool Router flow — toolkit is guaranteed Some (validated above)
         const toolkitSlug = Option.getOrThrow(toolkit);
+        const globalTestUserId = userContext.data.testUserId;
+        const resolvedUserId = Option.match(userId, {
+          onSome: value => Option.some(value),
+          onNone: () => globalTestUserId,
+        });
+        if (Option.isNone(resolvedUserId)) {
+          return yield* Effect.fail(
+            new Error(
+              'Missing user id. Provide --user-id or run composio login to set global test_user_id.'
+            )
+          );
+        }
+        if (Option.isNone(userId) && Option.isSome(globalTestUserId)) {
+          yield* ui.log.warn(`Using global test user id "${globalTestUserId.value}"`);
+        }
+        const resolvedProject = yield* resolveCommandProject({
+          mode: 'consumer',
+          projectName: Option.getOrUndefined(projectName),
+        }).pipe(Effect.mapError(formatResolveCommandProjectError));
+        const client = yield* clientSingleton.getFor({
+          orgId: resolvedProject.orgId,
+          projectId: resolvedProject.projectId,
+        });
 
         const linkOpt = yield* ui
           .withSpinner(
             `Linking ${toolkitSlug}...`,
             Effect.gen(function* () {
-              const { client, sessionId } = yield* resolveToolRouterSession(resolvedUserId.value, {
+              const { sessionId } = yield* resolveToolRouterSession(client, resolvedUserId.value, {
                 manageConnections: true,
               });
               return yield* Effect.tryPromise(() =>
@@ -281,6 +341,7 @@ export const connectedAccountsCmd$Link = Command.make(
                 connected_account_id: connAccountId,
                 redirect_url: redirectUrl,
                 toolkit: toolkitSlug,
+                project_type: resolvedProject.projectType,
               },
               null,
               2

--- a/ts/packages/cli/src/commands/index.ts
+++ b/ts/packages/cli/src/commands/index.ts
@@ -14,9 +14,9 @@ import { generateCmd } from './generate/generate.cmd';
 import { manageCmd } from './manage/manage.cmd';
 import { showToolsExecuteInputHelp } from './tools/commands/tools.execute.cmd';
 import { printRootHelp } from './root-help';
-import { toolsCmd$Search } from './tools/commands/tools.search.cmd';
-import { toolsCmd$Execute } from './tools/commands/tools.execute.cmd';
-import { connectedAccountsCmd$Link } from './connected-accounts/commands/connected-accounts.link.cmd';
+import { rootToolsCmd$Search } from './tools/commands/tools.search.cmd';
+import { rootToolsCmd$Execute } from './tools/commands/tools.execute.cmd';
+import { rootConnectedAccountsCmd$Link } from './connected-accounts/commands/connected-accounts.link.cmd';
 import { triggersCmd$Listen } from './triggers/commands/triggers.listen.cmd';
 
 const $cmd = $defaultCmd.pipe(
@@ -28,9 +28,9 @@ const $cmd = $defaultCmd.pipe(
     logoutCmd,
     installCmd,
     initCmd,
-    toolsCmd$Search,
-    connectedAccountsCmd$Link,
-    toolsCmd$Execute,
+    rootToolsCmd$Search,
+    rootConnectedAccountsCmd$Link,
+    rootToolsCmd$Execute,
     triggersCmd$Listen,
     generateCmd,
     manageCmd,

--- a/ts/packages/cli/src/commands/index.ts
+++ b/ts/packages/cli/src/commands/index.ts
@@ -14,6 +14,10 @@ import { generateCmd } from './generate/generate.cmd';
 import { manageCmd } from './manage/manage.cmd';
 import { showToolsExecuteInputHelp } from './tools/commands/tools.execute.cmd';
 import { printRootHelp } from './root-help';
+import { toolsCmd$Search } from './tools/commands/tools.search.cmd';
+import { toolsCmd$Execute } from './tools/commands/tools.execute.cmd';
+import { connectedAccountsCmd$Link } from './connected-accounts/commands/connected-accounts.link.cmd';
+import { triggersCmd$Listen } from './triggers/commands/triggers.listen.cmd';
 
 const $cmd = $defaultCmd.pipe(
   Command.withSubcommands([
@@ -24,6 +28,10 @@ const $cmd = $defaultCmd.pipe(
     logoutCmd,
     installCmd,
     initCmd,
+    toolsCmd$Search,
+    connectedAccountsCmd$Link,
+    toolsCmd$Execute,
+    triggersCmd$Listen,
     generateCmd,
     manageCmd,
   ])
@@ -32,13 +40,14 @@ export const rootCommand = $cmd;
 
 const parseExecuteInputHelpSlug = (argv: ReadonlyArray<string>): string | undefined => {
   const args = argv.slice(2);
-  if (args.length < 4) return undefined;
-  if (args[0] !== 'manage' || args[1] !== 'tools' || args[2] !== 'execute') return undefined;
+  const isRootExecute = args[0] === 'execute';
+  const isManageExecute = args[0] === 'manage' && args[1] === 'tools' && args[2] === 'execute';
+  if (!isRootExecute && !isManageExecute) return undefined;
 
   const hasHelp = args.includes('--help') || args.includes('-h');
   if (!hasHelp) return undefined;
 
-  const tail = args.slice(3);
+  const tail = isRootExecute ? args.slice(1) : args.slice(3);
   for (let i = 0; i < tail.length; i += 1) {
     const token = tail[i];
     if (!token) continue;
@@ -55,11 +64,21 @@ const parseExecuteInputHelpSlug = (argv: ReadonlyArray<string>): string | undefi
     }
 
     // Skip known execute option values.
-    if (token === '--data' || token === '-d' || token === '--user-id') {
+    if (
+      token === '--data' ||
+      token === '-d' ||
+      token === '--user-id' ||
+      token === '--project-name'
+    ) {
       i += 1;
       continue;
     }
-    if (token.startsWith('--data=') || token.startsWith('-d=') || token.startsWith('--user-id=')) {
+    if (
+      token.startsWith('--data=') ||
+      token.startsWith('-d=') ||
+      token.startsWith('--user-id=') ||
+      token.startsWith('--project-name=')
+    ) {
       continue;
     }
 
@@ -83,22 +102,6 @@ const normalizeVersionShortFlag = (argv: ReadonlyArray<string>): ReadonlyArray<s
   return argv;
 };
 
-const ALIAS_TO_PARENT: Record<string, ReadonlyArray<string>> = {
-  search: ['manage', 'tools'],
-  execute: ['manage', 'tools'],
-  link: ['manage', 'connected-accounts'],
-  listen: ['manage', 'triggers'],
-};
-
-const normalizeAliases = (argv: ReadonlyArray<string>): ReadonlyArray<string> => {
-  const args = argv.slice(2);
-  if (args.length === 0) return argv;
-  const first = args[0];
-  const parents = first && ALIAS_TO_PARENT[first];
-  if (!parents) return argv;
-  return [...argv.slice(0, 2), ...parents, ...args];
-};
-
 const isRootHelp = (argv: ReadonlyArray<string>): boolean => {
   const args = argv.slice(2);
   return args.length === 1 && (args[0] === '--help' || args[0] === '-h');
@@ -113,7 +116,7 @@ export const runWithConfig = Effect.gen(function* () {
   });
 
   return (argv: ReadonlyArray<string>) => {
-    const normalizedArgv = normalizeAliases(normalizeVersionShortFlag(argv));
+    const normalizedArgv = normalizeVersionShortFlag(argv);
     if (isRootHelp(normalizedArgv)) {
       return printRootHelp();
     }

--- a/ts/packages/cli/src/commands/init.cmd.ts
+++ b/ts/packages/cli/src/commands/init.cmd.ts
@@ -18,7 +18,7 @@ import { browserLogin, noBrowser as noBrowserOpt } from 'src/commands/login.cmd'
 import { setupCacheDir } from 'src/effects/setup-cache-dir';
 
 /**
- * `composio init` — Initialize a Composio project in the current directory.
+ * `composio init` — Initialize a developer project in the current directory.
  *
  * ## Behavior
  *
@@ -33,7 +33,7 @@ import { setupCacheDir } from 'src/effects/setup-cache-dir';
 const yesOpt = Options.boolean('yes').pipe(
   Options.withAlias('y'),
   Options.withDefault(false),
-  Options.withDescription('Auto-select default org/project, else first project')
+  Options.withDescription('Auto-select the default org project, else first developer project')
 );
 
 // ---------------------------------------------------------------------------
@@ -236,7 +236,7 @@ export const initCmd = CliCommand.make(
 
       yield* initInteractiveFlow({ composioDir, noBrowser, yes });
     })
-).pipe(CliCommand.withDescription('Initialize a Composio project in the current directory.'));
+).pipe(CliCommand.withDescription('Initialize this directory with a developer project.'));
 
 /**
  * Interactive init flow — handles login, project selection, wizard, install.
@@ -304,7 +304,7 @@ const initInteractiveFlow = (params: { composioDir: string; noBrowser: boolean; 
       return;
     }
 
-    // 3. Select a project
+    // 3. Select a developer project
     const orgProjectToKeys = (p: OrgProject): ProjectKeys => ({
       orgId: p.org_id,
       projectId: p.id,
@@ -322,12 +322,12 @@ const initInteractiveFlow = (params: { composioDir: string; noBrowser: boolean; 
             defaultProjectId: projectIdValue,
           }) ?? orgProjects.data[0])
         : yield* ui.select<OrgProject>(
-            'Select a project:',
+            'Select a developer project:',
             orgProjects.data.map(p => ({ value: p, label: p.name, hint: p.id }))
           );
 
     const selected = orgProjectToKeys(selectedProject);
-    yield* ui.log.step(`Using project "${selectedProject.name}"`);
+    yield* ui.log.step(`Using developer project "${selectedProject.name}"`);
 
     // 4. Write project config
     yield* writeProjectConfig(composioDir, selected);
@@ -348,7 +348,7 @@ const initInteractiveFlow = (params: { composioDir: string; noBrowser: boolean; 
 
     yield* ui.log.success(`Project initialized in ${composioDir}/`);
     yield* ui.log.info(
-      'To switch your default global org/project later, run `composio manage orgs switch`.'
+      'This directory will use the selected developer project for manage/listen flows.'
     );
     yield* ui.output(makeOutputJson(selected, composioDir));
     yield* ui.outro('');

--- a/ts/packages/cli/src/commands/login.cmd.ts
+++ b/ts/packages/cli/src/commands/login.cmd.ts
@@ -9,7 +9,7 @@ import {
 } from 'src/services/composio-clients';
 import { ComposioUserContext } from 'src/services/user-context';
 import { TerminalUI } from 'src/services/terminal-ui';
-import { runOrgProjectSelection } from 'src/effects/select-org-project';
+import { runOrgSelection } from 'src/effects/select-org-project';
 
 export const noBrowser = Options.boolean('no-browser').pipe(
   Options.withDefault(false),
@@ -31,7 +31,7 @@ const keyOpt = Options.text('key').pipe(
 const yesOpt = Options.boolean('yes').pipe(
   Options.withAlias('y'),
   Options.withDefault(false),
-  Options.withDescription('Skip org/project picker; use session defaults')
+  Options.withDescription('Skip org picker; use session default org')
 );
 
 /**
@@ -47,9 +47,9 @@ const storeCredentials = (params: {
   initialOrgId: string;
   initialProjectId: string;
   fallbackEmail: string;
-  /** When true, skip the init/switch hints and outro (shown later after org/project picker). */
+  /** When true, skip the init/switch hints and outro (shown later after org picker). */
   skipHints?: boolean;
-  /** When true, skip JSON output (emitted later after org/project picker with final selection). */
+  /** When true, skip JSON output (emitted later after org picker with final selection). */
   skipOutput?: boolean;
 }) =>
   Effect.gen(function* () {
@@ -92,7 +92,6 @@ const storeCredentials = (params: {
     // The initial IDs come from the linked session response (which may use session-level
     // identifiers rather than the actual org/project IDs).
     const orgId = sessionInfo?.project.org.id ?? initialOrgId;
-    const projectId = sessionInfo?.project.nano_id ?? initialProjectId;
     const sessionUserId = sessionInfo?.org_member.user_id ?? sessionInfo?.org_member.id;
     const testUserId = sessionUserId
       ? `pg-test-${sessionUserId}`
@@ -102,15 +101,9 @@ const storeCredentials = (params: {
       if (initialOrgId !== orgId) {
         yield* Effect.logDebug(`orgId corrected: ${initialOrgId} -> ${orgId} (from session/info)`);
       }
-      if (initialProjectId !== projectId) {
-        yield* Effect.logDebug(
-          `projectId corrected: ${initialProjectId} -> ${projectId} (from session/info)`
-        );
-      }
     }
 
-    // Store UAK + org/project IDs in user_data.json
-    yield* ctx.login(uakApiKey, orgId, projectId, testUserId);
+    yield* ctx.login(uakApiKey, orgId, testUserId);
 
     const email = sessionInfo?.org_member.email || fallbackEmail || undefined;
     yield* ui.log.success(email ? `Logged in as ${email}` : 'Logged in successfully');
@@ -118,9 +111,7 @@ const storeCredentials = (params: {
       yield* ui.log.info(
         'Run `composio init` in your project directory to set up project context.'
       );
-      yield* ui.log.info(
-        'To switch your default global org/project later, run `composio manage orgs switch`.'
-      );
+      yield* ui.log.info('To switch your default org later, run `composio manage orgs switch`.');
     }
 
     // Emit structured JSON for piped/scripted consumption (agent-native)
@@ -129,9 +120,7 @@ const storeCredentials = (params: {
         JSON.stringify({
           email,
           org_id: orgId,
-          project_id: projectId,
           org_name: sessionInfo?.project.org.name ?? '',
-          project_name: sessionInfo?.project.name ?? '',
         })
       );
     }
@@ -219,14 +208,14 @@ const loginWithKey = (params: { key: string; noWait: boolean; skipOrgProjectPick
     });
 
     if (willRunPicker) {
-      const result = yield* runOrgProjectSelection({
+      const result = yield* runOrgSelection({
         apiKey: uakApiKey,
         baseURL: ctx.data.baseURL,
       }).pipe(
         Effect.catchAll(error =>
           Effect.gen(function* () {
-            yield* Effect.logDebug('Org/project picker failed:', error);
-            yield* ui.log.warn('Could not load org/project list. Using session defaults.');
+            yield* Effect.logDebug('Org picker failed:', error);
+            yield* ui.log.warn('Could not load org list. Using session default org.');
             return undefined;
           })
         )
@@ -236,33 +225,24 @@ const loginWithKey = (params: { key: string; noWait: boolean; skipOrgProjectPick
         const testUserId = sessionUserId ? `pg-test-${sessionUserId}` : undefined;
         yield* ctx.login(
           uakApiKey,
-          result.org.id,
-          result.project.id,
+          result.id,
           testUserId ?? Option.getOrUndefined(ctx.data.testUserId)
         );
-        yield* ui.log.success(
-          `Default org/project set to "${result.org.name}" / "${result.project.name}".`
-        );
+        yield* ui.log.success(`Default org set to "${result.name}".`);
       }
-      const finalOrgId = result?.org.id ?? xOrgId;
-      const finalProjectId = result?.project.id ?? xProjectId;
-      const finalOrgName = result?.org.name ?? uakSessionInfo.project.org.name ?? '';
-      const finalProjectName = result?.project.name ?? uakSessionInfo.project.name ?? '';
+      const finalOrgId = result?.id ?? xOrgId;
+      const finalOrgName = result?.name ?? uakSessionInfo.project.org.name ?? '';
       yield* ui.output(
         JSON.stringify({
           email: linkedSession.account.email ?? undefined,
           org_id: finalOrgId,
-          project_id: finalProjectId,
           org_name: finalOrgName,
-          project_name: finalProjectName,
         })
       );
       yield* ui.log.info(
         'Run `composio init` in your project directory to set up project context.'
       );
-      yield* ui.log.info(
-        'To switch your default global org/project later, run `composio manage orgs switch`.'
-      );
+      yield* ui.log.info('To switch your default org later, run `composio manage orgs switch`.');
       yield* ui.outro("You're all set!");
     }
   });
@@ -387,14 +367,14 @@ export const browserLogin = (params: {
     });
 
     if (willRunPicker) {
-      const result = yield* runOrgProjectSelection({
+      const result = yield* runOrgSelection({
         apiKey: uakApiKey,
         baseURL: ctx.data.baseURL,
       }).pipe(
         Effect.catchAll(error =>
           Effect.gen(function* () {
-            yield* Effect.logDebug('Org/project picker failed:', error);
-            yield* ui.log.warn('Could not load org/project list. Using session defaults.');
+            yield* Effect.logDebug('Org picker failed:', error);
+            yield* ui.log.warn('Could not load org list. Using session default org.');
             return undefined;
           })
         )
@@ -404,34 +384,24 @@ export const browserLogin = (params: {
         const testUserId = sessionUserId ? `pg-test-${sessionUserId}` : undefined;
         yield* ctx.login(
           uakApiKey,
-          result.org.id,
-          result.project.id,
+          result.id,
           testUserId ?? Option.getOrUndefined(ctx.data.testUserId)
         );
-        yield* ui.log.success(
-          `Default org/project set to "${result.org.name}" / "${result.project.name}".`
-        );
+        yield* ui.log.success(`Default org set to "${result.name}".`);
       }
-      // Emit JSON with final org/project (from picker or session) for piped/scripted consumption
-      const finalOrgId = result?.org.id ?? xOrgId;
-      const finalProjectId = result?.project.id ?? xProjectId;
-      const finalOrgName = result?.org.name ?? uakSessionInfo.project.org.name ?? '';
-      const finalProjectName = result?.project.name ?? uakSessionInfo.project.name ?? '';
+      const finalOrgId = result?.id ?? xOrgId;
+      const finalOrgName = result?.name ?? uakSessionInfo.project.org.name ?? '';
       yield* ui.output(
         JSON.stringify({
           email: linkedSession.account.email ?? undefined,
           org_id: finalOrgId,
-          project_id: finalProjectId,
           org_name: finalOrgName,
-          project_name: finalProjectName,
         })
       );
       yield* ui.log.info(
         'Run `composio init` in your project directory to set up project context.'
       );
-      yield* ui.log.info(
-        'To switch your default global org/project later, run `composio manage orgs switch`.'
-      );
+      yield* ui.log.info('To switch your default org later, run `composio manage orgs switch`.');
       yield* ui.outro("You're all set!");
     }
   });
@@ -444,7 +414,7 @@ export const browserLogin = (params: {
  * Use --no-wait to print login URL and session info (JSON) then exit without opening browser or waiting.
  * Use --key to complete login with a session key from --no-wait. Without --no-wait, polls until linked;
  * with --no-wait, checks once and fails if not linked.
- * Use -y to skip org/project picker and use session defaults.
+ * Use -y to skip org picker and use session default org.
  *
  * @example
  * ```bash
@@ -476,8 +446,7 @@ export const loginCmd = Command.make(
       }
 
       if (ctx.isLoggedIn()) {
-        // Allow re-login when orgId/projectId are not yet set (old CLI login without multi-project support)
-        if (Option.isSome(ctx.data.orgId) && Option.isSome(ctx.data.projectId)) {
+        if (Option.isSome(ctx.data.orgId)) {
           yield* ui.log.warn(`You're already logged in!`);
           yield* ui.outro(
             'If you want to log in with a different account, please run `composio logout` first.'

--- a/ts/packages/cli/src/commands/manage/manage.cmd.ts
+++ b/ts/packages/cli/src/commands/manage/manage.cmd.ts
@@ -22,7 +22,9 @@ import { projectsCmd } from '../projects/projects.cmd';
  * ```
  */
 export const manageCmd = Command.make('manage').pipe(
-  Command.withDescription('Manage Composio resources — toolkits, tools, accounts, triggers, logs, orgs, and projects.'),
+  Command.withDescription(
+    'Developer/admin workflows: orgs, toolkits, tools, accounts, triggers, logs, auth configs, and deprecated project commands.'
+  ),
   Command.withSubcommands([
     toolkitsCmd,
     toolsCmd,

--- a/ts/packages/cli/src/commands/orgs/commands/orgs.switch.cmd.ts
+++ b/ts/packages/cli/src/commands/orgs/commands/orgs.switch.cmd.ts
@@ -1,7 +1,7 @@
 import { Command, Options } from '@effect/cli';
 import { Effect, Option } from 'effect';
 import { requireAuth } from 'src/effects/require-auth';
-import { runOrgProjectSelection } from 'src/effects/select-org-project';
+import { runOrgSelection } from 'src/effects/select-org-project';
 import { TerminalUI } from 'src/services/terminal-ui';
 import { ComposioUserContext } from 'src/services/user-context';
 
@@ -10,71 +10,52 @@ const orgId = Options.text('org-id').pipe(
   Options.withDescription('Organization ID to use as global default')
 );
 
-const projectId = Options.text('project-id').pipe(
-  Options.optional,
-  Options.withDescription('Project ID to use as global default')
-);
-
 const limit = Options.integer('limit').pipe(
   Options.withDefault(50),
-  Options.withDescription('Max org/projects to fetch from API (default: 50)')
+  Options.withDescription('Max orgs to fetch from API (default: 50)')
 );
 
-export const orgsCmd$Switch = Command.make(
-  'switch',
-  { orgId, projectId, limit },
-  ({ orgId, projectId, limit }) =>
-    Effect.gen(function* () {
-      if (!(yield* requireAuth)) return;
+export const orgsCmd$Switch = Command.make('switch', { orgId, limit }, ({ orgId, limit }) =>
+  Effect.gen(function* () {
+    if (!(yield* requireAuth)) return;
 
-      const ui = yield* TerminalUI;
-      const ctx = yield* ComposioUserContext;
-      yield* ui.intro('composio manage orgs switch');
+    const ui = yield* TerminalUI;
+    const ctx = yield* ComposioUserContext;
+    yield* ui.intro('composio manage orgs switch');
 
-      const apiKey = Option.getOrUndefined(ctx.data.apiKey);
-      if (!apiKey) {
-        yield* ui.log.warn('No user API key found. Run `composio login` first.');
-        yield* ui.outro('');
-        return;
-      }
+    const apiKey = Option.getOrUndefined(ctx.data.apiKey);
+    if (!apiKey) {
+      yield* ui.log.warn('No user API key found. Run `composio login` first.');
+      yield* ui.outro('');
+      return;
+    }
 
-      yield* ui.note(
-        'This updates your default global org/project context for CLI commands. Use `composio init` for per-project local overrides.',
-        'Global defaults'
-      );
+    yield* ui.note(
+      'This updates your default org for CLI commands. Use `composio init` for local developer project setup.',
+      'Global defaults'
+    );
 
-      const result = yield* runOrgProjectSelection({
-        apiKey,
-        baseURL: ctx.data.baseURL,
-        explicitOrgId: Option.getOrUndefined(orgId),
-        explicitProjectId: Option.getOrUndefined(projectId),
-        limit,
-      });
+    const result = yield* runOrgSelection({
+      apiKey,
+      baseURL: ctx.data.baseURL,
+      explicitOrgId: Option.getOrUndefined(orgId),
+      limit,
+    });
 
-      if (!result) {
-        yield* ui.outro('No org selected.');
-        return;
-      }
+    if (!result) {
+      yield* ui.outro('No org selected.');
+      return;
+    }
 
-      const { org: selectedOrganization, project: selectedProject } = result;
+    yield* ctx.login(apiKey, result.id, Option.getOrUndefined(ctx.data.testUserId));
 
-      yield* ctx.login(
-        apiKey,
-        selectedOrganization.id,
-        selectedProject.id,
-        Option.getOrUndefined(ctx.data.testUserId)
-      );
-
-      yield* ui.log.success(
-        `Updated global defaults to "${selectedOrganization.name}" / "${selectedProject.name}".`
-      );
-      yield* ui.output(
-        JSON.stringify({
-          scope: 'global',
-          org_id: selectedOrganization.id,
-          project_id: selectedProject.id,
-        })
-      );
-      yield* ui.outro('Global org/project defaults updated.');
-    })
-).pipe(Command.withDescription('Switch default global organization/project context.'));
+    yield* ui.log.success(`Updated default org to "${result.name}".`);
+    yield* ui.output(
+      JSON.stringify({
+        scope: 'global',
+        org_id: result.id,
+      })
+    );
+    yield* ui.outro('Default org updated.');
+  })
+).pipe(Command.withDescription('Switch default organization context.'));

--- a/ts/packages/cli/src/commands/projects/commands/projects.list.cmd.ts
+++ b/ts/packages/cli/src/commands/projects/commands/projects.list.cmd.ts
@@ -37,9 +37,6 @@ export const projectsCmd$List = Command.make('list', { orgId, limit }, ({ orgId,
     }
 
     const clampedLimit = clampLimit(limit);
-    const defaultOrgId = Option.getOrUndefined(ctx.data.orgId);
-    const defaultProjectId = Option.getOrUndefined(ctx.data.projectId);
-
     const projects = yield* ui.withSpinner(
       'Loading projects...',
       listOrganizationProjects({
@@ -56,19 +53,20 @@ export const projectsCmd$List = Command.make('list', { orgId, limit }, ({ orgId,
 
     if (projects.data.length === 0) {
       yield* ui.log.warn('No projects found.');
-      yield* ui.outro('Hint: run `composio manage orgs switch` to switch org/project defaults.');
+      yield* ui.outro(
+        'Hint: run `composio init` in a directory to bind it to a developer project.'
+      );
       return;
     }
 
     const lines = projects.data.map(project => {
-      const isSelected = defaultOrgId === resolvedOrgId && defaultProjectId === project.id;
-      return `${isSelected ? '✓' : ' '} ${project.name} (${project.id})`;
+      return `  ${project.name} (${project.id})`;
     });
     yield* ui.log.step(lines.join('\n'));
     yield* ui.outro(
       [
-        'Hint: run `composio manage projects switch` to switch the default global project.',
-        'Run `composio manage orgs switch` to switch org and project together.',
+        'Hint: run `composio init` in a directory to bind it to a developer project.',
+        'Run `composio manage orgs switch` to change your default org.',
       ].join('\n')
     );
 
@@ -77,10 +75,9 @@ export const projectsCmd$List = Command.make('list', { orgId, limit }, ({ orgId,
         projects.data.map(project => ({
           id: project.id,
           name: project.name,
-          is_selected_global_project:
-            defaultOrgId === resolvedOrgId && defaultProjectId === project.id,
+          is_selected_global_project: false,
         }))
       )
     );
   })
-).pipe(Command.withDescription('List projects and show current global selection.'));
+).pipe(Command.withDescription('List developer projects for the current organization.'));

--- a/ts/packages/cli/src/commands/projects/commands/projects.switch.cmd.ts
+++ b/ts/packages/cli/src/commands/projects/commands/projects.switch.cmd.ts
@@ -1,132 +1,15 @@
-import { Command, Options } from '@effect/cli';
-import { Effect, Option } from 'effect';
-import { requireAuth } from 'src/effects/require-auth';
+import { Command } from '@effect/cli';
+import { Effect } from 'effect';
 import { TerminalUI } from 'src/services/terminal-ui';
-import {
-  listOrganizationProjects,
-  type OrganizationProjectSummary,
-} from 'src/services/composio-clients';
-import { ComposioUserContext } from 'src/services/user-context';
-import { clampLimit } from 'src/ui/clamp-limit';
 
-const orgId = Options.text('org-id').pipe(
-  Options.optional,
-  Options.withDescription('Organization ID to use while switching project')
-);
-
-const projectId = Options.text('project-id').pipe(
-  Options.optional,
-  Options.withDescription('Project ID to use as global default')
-);
-
-const limit = Options.integer('limit').pipe(
-  Options.withDefault(50),
-  Options.withDescription('Max projects to fetch from API (default: 50)')
-);
-
-const selectProject = (params: {
-  projects: ReadonlyArray<OrganizationProjectSummary>;
-  selectedProjectId?: string;
-}) =>
-  Effect.gen(function* () {
-    const { projects, selectedProjectId } = params;
-    const ui = yield* TerminalUI;
-    if (projects.length === 0) return undefined;
-
-    if (selectedProjectId) {
-      const explicitMatch = projects.find(project => project.id === selectedProjectId);
-      if (explicitMatch) return explicitMatch;
-    }
-
-    if (projects.length === 1) return projects[0];
-
-    return yield* ui.select('Select a default project (global scope):', [
-      ...projects.map(project => ({
-        value: project,
-        label: project.name,
-        hint: project.id,
-      })),
-    ]);
-  });
-
-export const projectsCmd$Switch = Command.make(
-  'switch',
-  { orgId, projectId, limit },
-  ({ orgId, projectId, limit }) =>
+export const projectsCmd$Switch = Command.make('switch', {}).pipe(
+  Command.withDescription('Deprecated. Global developer project switching is no longer supported.'),
+  Command.withHandler(() =>
     Effect.gen(function* () {
-      if (!(yield* requireAuth)) return;
-
       const ui = yield* TerminalUI;
-      const ctx = yield* ComposioUserContext;
-      yield* ui.intro('composio manage projects switch');
-
-      const apiKey = Option.getOrUndefined(ctx.data.apiKey);
-      if (!apiKey) {
-        yield* ui.log.warn('No user API key found. Run `composio login` first.');
-        yield* ui.outro('');
-        return;
-      }
-
-      const resolvedOrgId = Option.getOrUndefined(orgId) ?? Option.getOrUndefined(ctx.data.orgId);
-      if (!resolvedOrgId) {
-        yield* ui.log.warn('No default org is configured.');
-        yield* ui.log.info('Run `composio manage orgs switch` to select org and project globally.');
-        yield* ui.outro('');
-        return;
-      }
-
-      const clampedLimit = clampLimit(limit);
-      const explicitProjectId = Option.getOrUndefined(projectId);
-
-      yield* ui.note(
-        'This updates your default global project context. To switch organization, use `composio manage orgs switch`.',
-        'Global defaults'
+      yield* ui.log.error(
+        'Global developer project switching is no longer supported. Run `composio init` in a directory to bind it to a developer project.'
       );
-      yield* ui.log.info(`Using organization: ${resolvedOrgId}`);
-
-      const projects = yield* listOrganizationProjects({
-        baseURL: ctx.data.baseURL,
-        apiKey,
-        orgId: resolvedOrgId,
-        limit: clampedLimit,
-      });
-      yield* ui.log.info(`Loaded ${projects.data.length} projects`);
-
-      if (projects.data.length === 0) {
-        yield* ui.log.warn('No projects found for the selected org.');
-        yield* ui.log.info('Use `composio manage orgs switch` to switch to another organization.');
-        yield* ui.outro('No projects available.');
-        return;
-      }
-
-      const selectedProject = yield* selectProject({
-        projects: projects.data,
-        selectedProjectId: explicitProjectId,
-      });
-
-      if (!selectedProject) {
-        yield* ui.log.warn('No project selected.');
-        yield* ui.outro('No project selected.');
-        return;
-      }
-      yield* ui.log.info(`Selected project: "${selectedProject.name}" (${selectedProject.id})`);
-
-      yield* ctx.login(
-        apiKey,
-        resolvedOrgId,
-        selectedProject.id,
-        Option.getOrUndefined(ctx.data.testUserId)
-      );
-
-      yield* ui.log.success(`Updated global default project to "${selectedProject.name}".`);
-      yield* ui.log.info('To switch organization as well, run `composio manage orgs switch`.');
-      yield* ui.output(
-        JSON.stringify({
-          scope: 'global',
-          org_id: resolvedOrgId,
-          project_id: selectedProject.id,
-        })
-      );
-      yield* ui.outro('Global project default updated.');
     })
-).pipe(Command.withDescription('Switch default global project context.'));
+  )
+);

--- a/ts/packages/cli/src/commands/root-help.ts
+++ b/ts/packages/cli/src/commands/root-help.ts
@@ -38,7 +38,7 @@ const BASIC_COMMANDS: ReadonlyArray<BasicCommand> = [
         name: '--key',
         description: 'Complete login using session key from --no-wait',
       },
-      { name: '-y, --yes', description: 'Skip org/project picker; use session defaults' },
+      { name: '-y, --yes', description: 'Skip org picker; use session default org' },
     ],
   },
   {
@@ -48,42 +48,56 @@ const BASIC_COMMANDS: ReadonlyArray<BasicCommand> = [
   },
   {
     name: 'init',
-    description: 'Initialize a Composio project in the current directory.',
+    description: 'Initialize this directory with a developer project.',
     usage: 'init [--no-browser] [-y, --yes]',
     options: [
       { name: '--no-browser', description: 'Skip opening browser for auth' },
-      { name: '-y, --yes', description: 'Auto-select default org/project' },
+      { name: '-y, --yes', description: 'Auto-select the default developer project' },
     ],
   },
   {
     name: 'search',
     description: 'Search tools by use case across toolkits/apps.',
-    usage: 'search <query> [--toolkits text] [--user-id text] [--limit integer]',
+    usage:
+      'search <query> [--toolkits text] [--user-id text] [--project-name text] [--limit integer]',
     options: [
       { name: '<query>', description: 'Semantic use-case query (e.g. "send emails")' },
       { name: '--toolkits', description: 'Filter by toolkit slugs, comma-separated' },
-      { name: '--user-id', description: 'User ID (falls back to project/global test_user_id)' },
+      { name: '--user-id', description: 'User ID (falls back to global test_user_id)' },
+      {
+        name: '--project-name',
+        description: 'Use a developer project instead of the org consumer project',
+      },
       { name: '--limit', description: 'Number of results per page (1-1000)' },
     ],
   },
   {
     name: 'execute',
     description: 'Execute a tool.',
-    usage: 'execute <slug> [-d, --data text] [--user-id text]',
+    usage: 'execute <slug> [-d, --data text] [--user-id text] [--project-name text]',
     options: [
       { name: '<slug>', description: 'Tool slug (e.g. "GITHUB_CREATE_ISSUE")' },
       { name: '-d, --data', description: 'JSON arguments, @file, or - for stdin' },
-      { name: '--user-id', description: 'User ID (falls back to project test_user_id)' },
+      { name: '--user-id', description: 'User ID (falls back to global test_user_id)' },
+      {
+        name: '--project-name',
+        description: 'Use a developer project instead of the org consumer project',
+      },
     ],
   },
   {
     name: 'link',
     description: 'Connect a user account for a toolkit/app.',
-    usage: 'link [<toolkit>] [--auth-config text] [--user-id text] [--no-browser]',
+    usage:
+      'link [<toolkit>] [--auth-config text] [--user-id text] [--project-name text] [--no-browser]',
     options: [
       { name: '<toolkit>', description: 'Toolkit slug to link (e.g. "github", "gmail")' },
       { name: '--auth-config', description: 'Auth config ID (legacy flow)' },
       { name: '--user-id', description: 'User ID for the connection' },
+      {
+        name: '--project-name',
+        description: 'Use a developer project instead of the org consumer project',
+      },
       { name: '--no-browser', description: 'Skip auto-opening the browser' },
     ],
   },
@@ -117,7 +131,7 @@ const ADVANCED_COMMANDS: ReadonlyArray<{ name: string; description: string }> = 
   {
     name: 'manage',
     description:
-      'Manage Composio resources — toolkits, tools, accounts, triggers, logs, orgs, and projects.',
+      'Developer/admin workflows: orgs, toolkits, triggers, auth configs, logs, and deprecated project commands.',
   },
 ];
 
@@ -150,7 +164,7 @@ export function printRootHelp(): Effect.Effect<void> {
 
   const lines: string[] = [
     '',
-    'Connect AI agents to external tools. Link accounts, discover tools, and execute them.',
+    'Connect AI agents to external tools. `search`, `link`, and `execute` use your org consumer project by default. `init`, `listen`, and `manage` use developer project context.',
     '',
     bold('USAGE'),
     `  ${name} <command> [options]`,

--- a/ts/packages/cli/src/commands/root-help.ts
+++ b/ts/packages/cli/src/commands/root-help.ts
@@ -58,46 +58,28 @@ const BASIC_COMMANDS: ReadonlyArray<BasicCommand> = [
   {
     name: 'search',
     description: 'Search tools by use case across toolkits/apps.',
-    usage:
-      'search <query> [--toolkits text] [--user-id text] [--project-name text] [--limit integer]',
+    usage: 'search <query> [--toolkits text] [--limit integer]',
     options: [
       { name: '<query>', description: 'Semantic use-case query (e.g. "send emails")' },
       { name: '--toolkits', description: 'Filter by toolkit slugs, comma-separated' },
-      { name: '--user-id', description: 'User ID (falls back to global test_user_id)' },
-      {
-        name: '--project-name',
-        description: 'Use a developer project instead of the org consumer project',
-      },
       { name: '--limit', description: 'Number of results per page (1-1000)' },
     ],
   },
   {
     name: 'execute',
     description: 'Execute a tool.',
-    usage: 'execute <slug> [-d, --data text] [--user-id text] [--project-name text]',
+    usage: 'execute <slug> [-d, --data text]',
     options: [
       { name: '<slug>', description: 'Tool slug (e.g. "GITHUB_CREATE_ISSUE")' },
       { name: '-d, --data', description: 'JSON arguments, @file, or - for stdin' },
-      { name: '--user-id', description: 'User ID (falls back to global test_user_id)' },
-      {
-        name: '--project-name',
-        description: 'Use a developer project instead of the org consumer project',
-      },
     ],
   },
   {
     name: 'link',
     description: 'Connect a user account for a toolkit/app.',
-    usage:
-      'link [<toolkit>] [--auth-config text] [--user-id text] [--project-name text] [--no-browser]',
+    usage: 'link [<toolkit>] [--no-browser]',
     options: [
       { name: '<toolkit>', description: 'Toolkit slug to link (e.g. "github", "gmail")' },
-      { name: '--auth-config', description: 'Auth config ID (legacy flow)' },
-      { name: '--user-id', description: 'User ID for the connection' },
-      {
-        name: '--project-name',
-        description: 'Use a developer project instead of the org consumer project',
-      },
       { name: '--no-browser', description: 'Skip auto-opening the browser' },
     ],
   },

--- a/ts/packages/cli/src/commands/toolkits/commands/toolkits.info.cmd.ts
+++ b/ts/packages/cli/src/commands/toolkits/commands/toolkits.info.cmd.ts
@@ -1,6 +1,6 @@
 import { Args, Command, Options } from '@effect/cli';
 import { Effect, Option } from 'effect';
-import { ComposioToolkitsRepository } from 'src/services/composio-clients';
+import { ComposioClientSingleton, ComposioToolkitsRepository } from 'src/services/composio-clients';
 import { TerminalUI } from 'src/services/terminal-ui';
 import { requireAuth } from 'src/effects/require-auth';
 import { resolveToolRouterSession } from 'src/effects/create-tool-router-session';
@@ -46,6 +46,7 @@ export const toolkitsCmd$Info = Command.make(
       const ui = yield* TerminalUI;
       const projectContext = yield* ProjectContext;
       const userContext = yield* ComposioUserContext;
+      const clientSingleton = yield* ComposioClientSingleton;
 
       // Missing slug guard
       if (Option.isNone(slug)) {
@@ -85,7 +86,8 @@ export const toolkitsCmd$Info = Command.make(
               .pipe(Effect.option);
 
             if (Option.isSome(resolvedUserId)) {
-              const { client, sessionId } = yield* resolveToolRouterSession(resolvedUserId.value);
+              const client = yield* clientSingleton.get();
+              const { sessionId } = yield* resolveToolRouterSession(client, resolvedUserId.value);
               const sessionToolkits = yield* Effect.tryPromise(() =>
                 client.toolRouter.session.toolkits(sessionId, { toolkits: [slugValue] })
               );

--- a/ts/packages/cli/src/commands/toolkits/commands/toolkits.list.cmd.ts
+++ b/ts/packages/cli/src/commands/toolkits/commands/toolkits.list.cmd.ts
@@ -4,7 +4,7 @@ import { Effect, Option } from 'effect';
 import { TerminalUI } from 'src/services/terminal-ui';
 import { requireAuth } from 'src/effects/require-auth';
 import { resolveToolRouterSession } from 'src/effects/create-tool-router-session';
-import { ComposioToolkitsRepository } from 'src/services/composio-clients';
+import { ComposioClientSingleton, ComposioToolkitsRepository } from 'src/services/composio-clients';
 import { ProjectContext } from 'src/services/project-context';
 import { ComposioUserContext } from 'src/services/user-context';
 import { clampLimit } from 'src/ui/clamp-limit';
@@ -57,6 +57,7 @@ export const toolkitsCmd$List = Command.make(
 
       const ui = yield* TerminalUI;
       const repo = yield* ComposioToolkitsRepository;
+      const clientSingleton = yield* ComposioClientSingleton;
       const projectContext = yield* ProjectContext;
       const userContext = yield* ComposioUserContext;
 
@@ -95,7 +96,10 @@ export const toolkitsCmd$List = Command.make(
 
       // Resolve session context in parallel with catalog fetch (saves one round trip).
       const sessionContextEffect = Option.isSome(resolvedUserId)
-        ? resolveToolRouterSession(resolvedUserId.value).pipe(
+        ? Effect.gen(function* () {
+            const client = yield* clientSingleton.get();
+            return yield* resolveToolRouterSession(client, resolvedUserId.value);
+          }).pipe(
             Effect.catchAll(error =>
               Effect.logDebug('Failed to create session:', error).pipe(Effect.as(undefined))
             )

--- a/ts/packages/cli/src/commands/tools/commands/tools.execute.cmd.ts
+++ b/ts/packages/cli/src/commands/tools/commands/tools.execute.cmd.ts
@@ -12,7 +12,6 @@ import {
   ToolsExecutor,
 } from 'src/services/tools-executor';
 import type { ToolExecuteParams } from 'src/services/tools-executor';
-import { ProjectContext } from 'src/services/project-context';
 import { ComposioToolkitsRepository } from 'src/services/composio-clients';
 import { ComposioUserContext } from 'src/services/user-context';
 import {
@@ -23,6 +22,11 @@ import {
 import { bold } from 'src/ui/colors';
 import { handleHttpServerError } from 'src/effects/handle-http-error';
 import { formatToolInputParameters } from '../format';
+import { ComposioClientSingleton } from 'src/services/composio-clients';
+import {
+  resolveCommandProject,
+  formatResolveCommandProjectError,
+} from 'src/services/command-project';
 
 const slug = Args.text({ name: 'slug' }).pipe(
   Args.withDescription('Tool slug (e.g. "GITHUB_CREATE_ISSUE")')
@@ -36,7 +40,12 @@ const data = Options.text('data').pipe(
 
 const userId = Options.text('user-id').pipe(
   Options.optional,
-  Options.withDescription('User ID to execute the tool for (falls back to project test_user_id)')
+  Options.withDescription('User ID to execute the tool for (falls back to global test_user_id)')
+);
+
+const projectName = Options.text('project-name').pipe(
+  Options.optional,
+  Options.withDescription('Developer project name override for this command')
 );
 
 const resolveInput = (input: Option.Option<string>) =>
@@ -102,11 +111,11 @@ const toolkitFromToolSlug = (toolSlug: string): string | undefined => {
 const connectionTips = (toolSlug: string, userId: string) => {
   const toolkit = toolkitFromToolSlug(toolSlug);
   if (!toolkit) {
-    return `Retry: ${bold(`composio manage tools execute ${toolSlug} ...`)}`;
+    return `Retry: ${bold(`composio execute ${toolSlug} ...`)}`;
   }
   return [
-    `Link the toolkit first: ${bold(`composio manage connected-accounts link ${toolkit} --user-id ${userId}`)}`,
-    `Then retry:             ${bold(`composio manage tools execute ${toolSlug} ...`)}`,
+    `Link the toolkit first: ${bold(`composio link ${toolkit} --user-id ${userId}`)}`,
+    `Then retry:             ${bold(`composio execute ${toolSlug} ...`)}`,
   ].join('\n');
 };
 
@@ -198,7 +207,7 @@ export const showToolsExecuteInputHelp = (toolSlug: string) =>
                 Effect.map(r =>
                   r.items.map(s => ({
                     label: `${s.slug} — ${s.description}`,
-                    command: `> composio manage tools execute "${s.slug}" --help`,
+                    command: `> composio execute "${s.slug}" --help`,
                   }))
                 )
               ),
@@ -211,7 +220,7 @@ export const showToolsExecuteInputHelp = (toolSlug: string) =>
 
     yield* ui.note(formatToolInputParameters(tool), `Execute Help: ${tool.slug}`);
     yield* ui.log.step(
-      `Run:\n> composio manage tools execute "${tool.slug}" --user-id "<user-id>" -d '{"key":"value"}'`
+      `Run:\n> composio execute "${tool.slug}" --user-id "<user-id>" -d '{"key":"value"}'`
     );
     yield* ui.output(
       JSON.stringify({ slug: tool.slug, input_parameters: tool.input_parameters }, null, 2)
@@ -286,39 +295,46 @@ class ToolExecutionError {
  */
 export const toolsCmd$Execute = Command.make(
   'execute',
-  { slug, data, userId },
-  ({ slug, data, userId }) =>
+  { slug, data, userId, projectName },
+  ({ slug, data, userId, projectName }) =>
     Effect.gen(function* () {
       if (!(yield* requireAuth)) return;
 
       const ui = yield* TerminalUI;
       const executor = yield* ToolsExecutor;
-      const projectContext = yield* ProjectContext;
+      const clientSingleton = yield* ComposioClientSingleton;
       const userContext = yield* ComposioUserContext;
-      const resolvedProjectContext = yield* projectContext.resolve;
-      const testUserId = Option.flatMap(resolvedProjectContext, keys => keys.testUserId);
       const globalTestUserId = userContext.data.testUserId;
       const resolvedUserId = Option.match(userId, {
         onSome: value => Option.some(value),
-        onNone: () => Option.orElse(testUserId, () => globalTestUserId),
+        onNone: () => globalTestUserId,
       });
       if (Option.isNone(resolvedUserId)) {
         return yield* Effect.fail(
-          new Error('Missing user id. Provide --user-id or run composio init to set test_user_id.')
+          new Error(
+            'Missing user id. Provide --user-id or run composio login to set global test_user_id.'
+          )
         );
       }
-      if (Option.isNone(userId) && Option.isSome(testUserId)) {
-        yield* ui.log.warn(`Using test user id "${testUserId.value}"`);
-      } else if (Option.isNone(userId) && Option.isSome(globalTestUserId)) {
+      if (Option.isNone(userId) && Option.isSome(globalTestUserId)) {
         yield* ui.log.warn(`Using global test user id "${globalTestUserId.value}"`);
       }
 
       const input = yield* resolveInput(data);
       const args = yield* parseArguments(input);
+      const resolvedProject = yield* resolveCommandProject({
+        mode: 'consumer',
+        projectName: Option.getOrUndefined(projectName),
+      }).pipe(Effect.mapError(formatResolveCommandProjectError));
+      const client = yield* clientSingleton.getFor({
+        orgId: resolvedProject.orgId,
+        projectId: resolvedProject.projectId,
+      });
 
       const params: ToolExecuteParams = {
         userId: resolvedUserId.value,
         arguments: args,
+        client,
       };
 
       yield* ui.useMakeSpinner(`Executing tool "${slug}"...`, spinner =>

--- a/ts/packages/cli/src/commands/tools/commands/tools.execute.cmd.ts
+++ b/ts/packages/cli/src/commands/tools/commands/tools.execute.cmd.ts
@@ -40,7 +40,7 @@ const data = Options.text('data').pipe(
 
 const userId = Options.text('user-id').pipe(
   Options.optional,
-  Options.withDescription('User ID to execute the tool for (falls back to global test_user_id)')
+  Options.withDescription('Developer-project user ID override')
 );
 
 const projectName = Options.text('project-name').pipe(
@@ -92,38 +92,33 @@ const parseArguments = (raw: string) =>
     return parsed as Record<string, unknown>;
   });
 
-/**
- * Derive the toolkit slug from a tool slug.
- * e.g. "GMAIL_CREATE_EMAIL_DRAFT" → "gmail", "GITHUB_GET_REPOS" → "github"
- *
- * Returns `undefined` for meta tool slugs (COMPOSIO_*) since they don't map
- * to a real toolkit and would produce misleading connection tips.
- */
 const toolkitFromToolSlug = (toolSlug: string): string | undefined => {
   const idx = toolSlug.indexOf('_');
   if (idx <= 0) return toolSlug.toLowerCase();
   const prefix = toolSlug.slice(0, idx).toLowerCase();
-  // Meta tools (COMPOSIO_*) are internal and don't correspond to a real toolkit.
   if (prefix === 'composio') return undefined;
   return prefix;
 };
 
-const connectionTips = (toolSlug: string, userId: string) => {
+const connectionTips = (toolSlug: string, surface: 'root' | 'manage') => {
   const toolkit = toolkitFromToolSlug(toolSlug);
   if (!toolkit) {
     return `Retry: ${bold(`composio execute ${toolSlug} ...`)}`;
   }
   return [
-    `Link the toolkit first: ${bold(`composio link ${toolkit} --user-id ${userId}`)}`,
-    `Then retry:             ${bold(`composio execute ${toolSlug} ...`)}`,
+    `Link the toolkit first: ${bold(
+      surface === 'root'
+        ? `composio link ${toolkit}`
+        : `composio manage connected-accounts link ${toolkit} --user-id "<user-id>"`
+    )}`,
+    `Then retry:             ${bold(
+      surface === 'root'
+        ? `composio execute ${toolSlug} ...`
+        : `composio manage tools execute ${toolSlug} ...`
+    )}`,
   ].join('\n');
 };
 
-/**
- * JSON.stringify replacer that redacts ID-like string values in CI.
- * Fields named "id", ending with "Id", or ending with "_id" are redacted.
- * The "logId" field preserves its "log_" prefix.
- */
 const ciRedactReplacer = (_key: string, value: unknown): unknown => {
   if (typeof value !== 'string') return value;
   if (_key === 'logId') return redact({ value, prefix: 'log_' });
@@ -181,10 +176,6 @@ const normalizeError = (error: unknown): unknown => {
   return current;
 };
 
-/**
- * Show execute-focused help for a specific tool slug.
- * This prints only input parameters (data payload schema).
- */
 export const showToolsExecuteInputHelp = (toolSlug: string) =>
   Effect.gen(function* () {
     if (!(yield* requireAuth)) return;
@@ -219,28 +210,19 @@ export const showToolsExecuteInputHelp = (toolSlug: string) =>
     const tool = toolOpt.value;
 
     yield* ui.note(formatToolInputParameters(tool), `Execute Help: ${tool.slug}`);
-    yield* ui.log.step(
-      `Run:\n> composio execute "${tool.slug}" --user-id "<user-id>" -d '{"key":"value"}'`
-    );
+    yield* ui.log.step(`Run:\n> composio execute "${tool.slug}" -d '{"key":"value"}'`);
     yield* ui.output(
       JSON.stringify({ slug: tool.slug, input_parameters: tool.input_parameters }, null, 2)
     );
   });
 
-/**
- * Display a user-friendly error message for tool execution failures.
- *
- * Returns a structured error summary suitable for `ui.output()` in piped mode.
- */
 const handleExecutionError = (
   ui: TerminalUI,
   error: unknown,
-  context: { toolSlug: string; userId: string }
+  context: { toolSlug: string; surface: 'root' | 'manage' }
 ) =>
   Effect.gen(function* () {
     const normalized = normalizeError(error);
-
-    // ActionExecuteConnectedAccountNotFoundError stores the API payload in `.details`
     const connAccountDetails =
       normalized instanceof ActionExecuteConnectedAccountNotFoundError
         ? normalized.details
@@ -253,10 +235,8 @@ const handleExecutionError = (
     const slugValue = apiDetails?.slug ?? extractSlug(error) ?? extractSlug(connAccountDetails);
     const message = extractMessage(apiDetails) ?? extractMessage(normalized) ?? 'Unknown error';
 
-    // Display the primary error message
     yield* ui.log.error(message);
 
-    // Show API error details when available
     const detailsObject =
       apiDetails ??
       (normalized instanceof ActionExecuteConnectedAccountNotFoundError &&
@@ -268,14 +248,10 @@ const handleExecutionError = (
       yield* ui.note(formatUnknownObject(redactRequestId(detailsObject)), 'Error details');
     }
 
-    // No-connection tips — the executor already classifies these into
-    // ActionExecuteConnectedAccountNotFoundError, so check the typed error
-    // instead of re-inspecting the slug.
     if (normalized instanceof ActionExecuteConnectedAccountNotFoundError) {
-      yield* ui.note(connectionTips(context.toolSlug, context.userId), 'Tips');
+      yield* ui.note(connectionTips(context.toolSlug, context.surface), 'Tips');
     }
 
-    // Return structured summary for piped output
     return { error: message, slug: slugValue };
   });
 
@@ -284,101 +260,127 @@ class ToolExecutionError {
   constructor(readonly message: string) {}
 }
 
-/**
- * Execute a tool with JSON arguments.
- *
- * @example
- * ```bash
- * composio manage tools execute GITHUB_GET_REPOS -d '{"owner":"composio"}'
- * echo '{"owner":"composio"}' | composio manage tools execute GITHUB_GET_REPOS
- * ```
- */
+const runToolsExecute = (params: {
+  slug: string;
+  data: Option.Option<string>;
+  userId: Option.Option<string>;
+  projectName: Option.Option<string>;
+  rootOnly: boolean;
+}) =>
+  Effect.gen(function* () {
+    if (!(yield* requireAuth)) return;
+
+    const ui = yield* TerminalUI;
+    const executor = yield* ToolsExecutor;
+    const clientSingleton = yield* ComposioClientSingleton;
+    const userContext = yield* ComposioUserContext;
+
+    const input = yield* resolveInput(params.data);
+    const args = yield* parseArguments(input);
+    const resolvedProject = yield* resolveCommandProject({
+      mode: 'consumer',
+      projectName: params.rootOnly ? undefined : Option.getOrUndefined(params.projectName),
+    }).pipe(Effect.mapError(formatResolveCommandProjectError));
+    const resolvedUserId =
+      resolvedProject.projectType === 'CONSUMER'
+        ? Option.fromNullable(resolvedProject.consumerUserId)
+        : Option.match(params.userId, {
+            onSome: value => Option.some(value),
+            onNone: () => userContext.data.testUserId,
+          });
+    if (Option.isNone(resolvedUserId)) {
+      return yield* Effect.fail(
+        new Error(
+          'Missing user id. Provide --user-id or run composio login to set global test_user_id.'
+        )
+      );
+    }
+    const client = yield* clientSingleton.getFor({
+      orgId: resolvedProject.orgId,
+      projectId: resolvedProject.projectId,
+    });
+
+    const executeParams: ToolExecuteParams = {
+      userId: resolvedUserId.value,
+      arguments: args,
+      client,
+    };
+
+    yield* ui.useMakeSpinner(`Executing tool "${params.slug}"...`, spinner =>
+      Effect.gen(function* () {
+        const resultEither = yield* executor
+          .execute(params.slug, executeParams)
+          .pipe(Effect.either);
+
+        if (Either.isLeft(resultEither)) {
+          yield* spinner.error();
+          const summary = yield* handleExecutionError(ui, resultEither.left, {
+            toolSlug: params.slug,
+            surface: params.rootOnly ? 'root' : 'manage',
+          });
+          yield* ui.output(JSON.stringify({ successful: false, ...summary }, ciRedactReplacer, 2));
+          return yield* Effect.fail(new ToolExecutionError(summary.error));
+        }
+
+        const result = resultEither.right;
+
+        if (!result.successful) {
+          const logId = result.logId
+            ? ` (logId: ${redact({ value: result.logId, prefix: 'log_' })})`
+            : '';
+          yield* spinner.error(`Execution failed${logId}`);
+
+          const summary = yield* handleExecutionError(ui, result.error ?? result, {
+            toolSlug: params.slug,
+            surface: params.rootOnly ? 'root' : 'manage',
+          });
+          yield* ui.output(JSON.stringify(result, ciRedactReplacer, 2));
+          return yield* Effect.fail(new ToolExecutionError(summary.error));
+        }
+
+        const logId = result.logId
+          ? ` (logId: ${redact({ value: result.logId, prefix: 'log_' })})`
+          : '';
+        yield* spinner.stop(`Execution successful${logId}`);
+        yield* ui.log.message(`Response\n${JSON.stringify(result, ciRedactReplacer, 2)}`);
+        yield* ui.output(JSON.stringify(result, ciRedactReplacer, 2));
+      })
+    );
+  });
+
 export const toolsCmd$Execute = Command.make(
   'execute',
   { slug, data, userId, projectName },
   ({ slug, data, userId, projectName }) =>
-    Effect.gen(function* () {
-      if (!(yield* requireAuth)) return;
+    runToolsExecute({ slug, data, userId, projectName, rootOnly: false })
+).pipe(
+  Command.withDescription(
+    [
+      'Execute a tool by slug with JSON arguments.',
+      '',
+      'Related:',
+      '  composio search "<query>"',
+      '  composio link <toolkit>',
+    ].join('\n')
+  )
+);
 
-      const ui = yield* TerminalUI;
-      const executor = yield* ToolsExecutor;
-      const clientSingleton = yield* ComposioClientSingleton;
-      const userContext = yield* ComposioUserContext;
-      const globalTestUserId = userContext.data.testUserId;
-      const resolvedUserId = Option.match(userId, {
-        onSome: value => Option.some(value),
-        onNone: () => globalTestUserId,
-      });
-      if (Option.isNone(resolvedUserId)) {
-        return yield* Effect.fail(
-          new Error(
-            'Missing user id. Provide --user-id or run composio login to set global test_user_id.'
-          )
-        );
-      }
-      if (Option.isNone(userId) && Option.isSome(globalTestUserId)) {
-        yield* ui.log.warn(`Using global test user id "${globalTestUserId.value}"`);
-      }
-
-      const input = yield* resolveInput(data);
-      const args = yield* parseArguments(input);
-      const resolvedProject = yield* resolveCommandProject({
-        mode: 'consumer',
-        projectName: Option.getOrUndefined(projectName),
-      }).pipe(Effect.mapError(formatResolveCommandProjectError));
-      const client = yield* clientSingleton.getFor({
-        orgId: resolvedProject.orgId,
-        projectId: resolvedProject.projectId,
-      });
-
-      const params: ToolExecuteParams = {
-        userId: resolvedUserId.value,
-        arguments: args,
-        client,
-      };
-
-      yield* ui.useMakeSpinner(`Executing tool "${slug}"...`, spinner =>
-        Effect.gen(function* () {
-          const resultEither = yield* executor.execute(slug, params).pipe(Effect.either);
-
-          // Hard failure: API threw an exception
-          if (Either.isLeft(resultEither)) {
-            yield* spinner.error();
-            const summary = yield* handleExecutionError(ui, resultEither.left, {
-              toolSlug: slug,
-              userId: resolvedUserId.value,
-            });
-            yield* ui.output(
-              JSON.stringify({ successful: false, ...summary }, ciRedactReplacer, 2)
-            );
-            return yield* Effect.fail(new ToolExecutionError(summary.error));
-          }
-
-          const result = resultEither.right;
-
-          // Soft failure: execution returned an error
-          if (!result.successful) {
-            const logId = result.logId
-              ? ` (logId: ${redact({ value: result.logId, prefix: 'log_' })})`
-              : '';
-            yield* spinner.error(`Execution failed${logId}`);
-
-            const summary = yield* handleExecutionError(ui, result.error ?? result, {
-              toolSlug: slug,
-              userId: resolvedUserId.value,
-            });
-            yield* ui.output(JSON.stringify(result, ciRedactReplacer, 2));
-            return yield* Effect.fail(new ToolExecutionError(summary.error));
-          }
-
-          // Success
-          const logId = result.logId
-            ? ` (logId: ${redact({ value: result.logId, prefix: 'log_' })})`
-            : '';
-          yield* spinner.stop(`Execution successful${logId}`);
-          yield* ui.log.message(`Response\n${JSON.stringify(result, ciRedactReplacer, 2)}`);
-          yield* ui.output(JSON.stringify(result, ciRedactReplacer, 2));
-        })
-      );
-    })
-).pipe(Command.withDescription('Execute a tool by slug with JSON arguments.'));
+export const rootToolsCmd$Execute = Command.make('execute', { slug, data }, ({ slug, data }) =>
+  runToolsExecute({
+    slug,
+    data,
+    userId: Option.none(),
+    projectName: Option.none(),
+    rootOnly: true,
+  })
+).pipe(
+  Command.withDescription(
+    [
+      'Execute a tool by slug with JSON arguments.',
+      '',
+      'Related:',
+      '  composio search "<query>"',
+      '  composio link <toolkit>',
+    ].join('\n')
+  )
+);

--- a/ts/packages/cli/src/commands/tools/commands/tools.search.cmd.ts
+++ b/ts/packages/cli/src/commands/tools/commands/tools.search.cmd.ts
@@ -7,8 +7,12 @@ import { resolveToolRouterSession } from 'src/effects/create-tool-router-session
 import { buildMinimalPayloadFromSchema } from 'src/ui/build-minimal-payload';
 import { formatToolsTable } from '../format';
 import type { Tool } from 'src/models/tools';
-import { ProjectContext } from 'src/services/project-context';
 import { ComposioUserContext } from 'src/services/user-context';
+import { ComposioClientSingleton } from 'src/services/composio-clients';
+import {
+  resolveCommandProject,
+  formatResolveCommandProjectError,
+} from 'src/services/command-project';
 
 const query = Args.text({ name: 'query' }).pipe(
   Args.withDescription(
@@ -23,7 +27,12 @@ const toolkits = Options.text('toolkits').pipe(
 
 const userId = Options.text('user-id').pipe(
   Options.optional,
-  Options.withDescription('User ID for the session (falls back to project/global test_user_id)')
+  Options.withDescription('User ID for the session (falls back to global test_user_id)')
+);
+
+const projectName = Options.text('project-name').pipe(
+  Options.optional,
+  Options.withDescription('Developer project name override for this command')
 );
 
 const limit = Options.integer('limit').pipe(
@@ -47,35 +56,28 @@ const limit = Options.integer('limit').pipe(
  */
 export const toolsCmd$Search = Command.make(
   'search',
-  { query, toolkits, userId, limit },
-  ({ query, toolkits, userId, limit }) =>
+  { query, toolkits, userId, projectName, limit },
+  ({ query, toolkits, userId, projectName, limit }) =>
     Effect.gen(function* () {
       if (!(yield* requireAuth)) return;
 
       const ui = yield* TerminalUI;
-      const projectContext = yield* ProjectContext;
       const userContext = yield* ComposioUserContext;
-      const resolvedProjectContext = yield* projectContext.resolve.pipe(
-        Effect.catchAll(() => Effect.succeed(Option.none()))
-      );
-      const testUserId = Option.flatMap(resolvedProjectContext, keys => keys.testUserId);
       const globalTestUserId = userContext.data.testUserId;
       const resolvedUserId = Option.match(userId, {
         onSome: value => Option.some(value),
-        onNone: () => Option.orElse(testUserId, () => globalTestUserId),
+        onNone: () => globalTestUserId,
       });
 
       if (Option.isNone(resolvedUserId)) {
         return yield* Effect.fail(
           new Error(
-            'Missing user id. Provide --user-id or run composio init to set test_user_id, or composio login to set global test_user_id.'
+            'Missing user id. Provide --user-id or run composio login to set global test_user_id.'
           )
         );
       }
 
-      if (Option.isNone(userId) && Option.isSome(testUserId)) {
-        yield* ui.log.warn(`Using test user id "${testUserId.value}"`);
-      } else if (Option.isNone(userId) && Option.isSome(globalTestUserId)) {
+      if (Option.isNone(userId) && Option.isSome(globalTestUserId)) {
         yield* ui.log.warn(`Using global test user id "${globalTestUserId.value}"`);
       }
 
@@ -92,9 +94,21 @@ export const toolsCmd$Search = Command.make(
       const searchResponse = yield* ui.withSpinner(
         `Searching tools for "${query}"...`,
         Effect.gen(function* () {
-          const { client, sessionId } = yield* resolveToolRouterSession(resolvedUserId.value, {
+          const resolvedProject = yield* resolveCommandProject({
+            mode: 'consumer',
+            projectName: Option.getOrUndefined(projectName),
+          }).pipe(Effect.mapError(formatResolveCommandProjectError));
+          const clientSingleton = yield* ComposioClientSingleton;
+          const client = yield* clientSingleton.getFor({
+            orgId: resolvedProject.orgId,
+            projectId: resolvedProject.projectId,
+          });
+          const { sessionId } = yield* resolveToolRouterSession(client, resolvedUserId.value, {
             toolkits: toolkitList,
           });
+          yield* ui.log.info(
+            `Using ${resolvedProject.projectType.toLowerCase()} project "${resolvedProject.projectName ?? resolvedProject.projectId}".`
+          );
           return yield* Effect.tryPromise(() =>
             client.toolRouter.session.search(sessionId, {
               queries: [{ use_case: query }],
@@ -162,8 +176,8 @@ export const toolsCmd$Search = Command.make(
         yield* ui.log.step(
           [
             'Hints:',
-            `> composio manage tools info "${firstSlug}"`,
-            `> composio manage tools execute "${firstSlug}" --user-id "<user-id>" --arguments '{}'`,
+            `> composio execute "${firstSlug}" --user-id "<user-id>" -d '{}'`,
+            `> composio link <toolkit> --user-id "<user-id>"`,
           ].join('\n')
         );
       }

--- a/ts/packages/cli/src/commands/tools/commands/tools.search.cmd.ts
+++ b/ts/packages/cli/src/commands/tools/commands/tools.search.cmd.ts
@@ -27,7 +27,7 @@ const toolkits = Options.text('toolkits').pipe(
 
 const userId = Options.text('user-id').pipe(
   Options.optional,
-  Options.withDescription('User ID for the session (falls back to global test_user_id)')
+  Options.withDescription('Developer-project user ID override')
 );
 
 const projectName = Options.text('project-name').pipe(
@@ -40,186 +40,208 @@ const limit = Options.integer('limit').pipe(
   Options.withDescription('Number of results per page (1-1000)')
 );
 
-/**
- * Search tools semantically by use case.
- *
- * The query is interpreted semantically (not exact keyword matching), so you can
- * describe an outcome or workflow. The command returns the most relevant tools
- * for that use case and includes recommended guidance/plan steps to help execute it.
- *
- * @example
- * ```bash
- * composio manage tools search "send emails"
- * composio manage tools search "send emails" --toolkits "gmail,outlook"
- * composio manage tools search "messaging" --limit 5
- * ```
- */
+const runToolsSearch = (params: {
+  query: string;
+  toolkits: Option.Option<string>;
+  userId: Option.Option<string>;
+  projectName: Option.Option<string>;
+  limit: number;
+  rootOnly: boolean;
+}) =>
+  Effect.gen(function* () {
+    if (!(yield* requireAuth)) return;
+
+    const ui = yield* TerminalUI;
+    const userContext = yield* ComposioUserContext;
+
+    const clampedLimit = clampLimit(params.limit);
+    const toolkitFilter = Option.getOrUndefined(params.toolkits);
+    const toolkitList =
+      toolkitFilter && toolkitFilter.trim().length > 0
+        ? toolkitFilter
+            .split(',')
+            .map(s => s.trim().toLowerCase())
+            .filter(Boolean)
+        : undefined;
+
+    const searchResponse = yield* ui.withSpinner(
+      `Searching tools for "${params.query}"...`,
+      Effect.gen(function* () {
+        const resolvedProject = yield* resolveCommandProject({
+          mode: 'consumer',
+          projectName: params.rootOnly ? undefined : Option.getOrUndefined(params.projectName),
+        }).pipe(Effect.mapError(formatResolveCommandProjectError));
+        const resolvedUserId =
+          resolvedProject.projectType === 'CONSUMER'
+            ? Option.fromNullable(resolvedProject.consumerUserId)
+            : Option.match(params.userId, {
+                onSome: value => Option.some(value),
+                onNone: () => userContext.data.testUserId,
+              });
+        if (Option.isNone(resolvedUserId)) {
+          return yield* Effect.fail(
+            new Error(
+              'Missing user id. Provide --user-id or run composio login to set global test_user_id.'
+            )
+          );
+        }
+        const clientSingleton = yield* ComposioClientSingleton;
+        const client = yield* clientSingleton.getFor({
+          orgId: resolvedProject.orgId,
+          projectId: resolvedProject.projectId,
+        });
+        const { sessionId } = yield* resolveToolRouterSession(client, resolvedUserId.value, {
+          toolkits: toolkitList,
+        });
+        return yield* Effect.tryPromise(() =>
+          client.toolRouter.session.search(sessionId, {
+            queries: [{ use_case: params.query }],
+          })
+        );
+      })
+    );
+
+    const toolkitSet = toolkitList && toolkitList.length > 0 ? new Set(toolkitList) : undefined;
+
+    const mergedSlugs: string[] = [];
+    const seen = new Set<string>();
+    for (const item of searchResponse.results) {
+      for (const slug of [...item.primary_tool_slugs, ...item.related_tool_slugs]) {
+        if (!seen.has(slug)) {
+          seen.add(slug);
+          mergedSlugs.push(slug);
+        }
+      }
+    }
+
+    const toolsList: Tool[] = [];
+    for (const slug of mergedSlugs) {
+      const schema = searchResponse.tool_schemas[slug];
+      if (!schema) continue;
+      if (toolkitSet && !toolkitSet.has(schema.toolkit.toLowerCase())) continue;
+
+      toolsList.push({
+        slug: schema.tool_slug,
+        name: schema.tool_slug,
+        description: schema.description ?? '',
+        tags: [],
+        available_versions: [],
+        input_parameters: (schema.input_schema ?? {}) as Record<string, unknown>,
+        output_parameters: (schema.output_schema ?? {}) as Record<string, unknown>,
+      } as Tool);
+
+      if (toolsList.length >= clampedLimit) break;
+    }
+
+    if (toolsList.length === 0) {
+      yield* ui.log.warn(`No tools found matching "${params.query}". Try broadening your search.`);
+      return;
+    }
+
+    const showing = toolsList.length;
+    yield* ui.log.info(`Found ${showing} tools\n\n${formatToolsTable(toolsList)}`);
+
+    const planSteps = Array.from(
+      new Set(searchResponse.results.flatMap(result => result.recommended_plan_steps ?? []))
+    );
+    if (planSteps.length > 0) {
+      yield* ui.log.info(`Plan:\n${planSteps.map((step, i) => `${i + 1}. ${step}`).join('\n')}`);
+    } else if (searchResponse.next_steps_guidance.length > 0) {
+      yield* ui.log.info(
+        `Plan:\n${searchResponse.next_steps_guidance
+          .map((step, i) => `${i + 1}. ${step}`)
+          .join('\n')}`
+      );
+    }
+
+    const firstSlug = toolsList[0]?.slug;
+    if (firstSlug) {
+      const executeHint = params.rootOnly
+        ? `> composio execute "${firstSlug}" -d '{}'`
+        : `> composio manage tools execute "${firstSlug}" --user-id "<user-id>" -d '{}'`;
+      const linkHint = params.rootOnly
+        ? `> composio link <toolkit>`
+        : `> composio manage connected-accounts link <toolkit> --user-id "<user-id>"`;
+      yield* ui.log.step(['Hints:', executeHint, linkHint].join('\n'));
+    }
+
+    if (searchResponse.error) {
+      yield* ui.log.warn(searchResponse.error);
+    }
+
+    const firstSchema =
+      firstSlug && searchResponse.tool_schemas[firstSlug]
+        ? searchResponse.tool_schemas[firstSlug]
+        : undefined;
+    const firstToolkit = firstSchema?.toolkit;
+
+    const cta: Array<{ action: string; command: string }> = [];
+    if (firstSlug) {
+      const payload = buildMinimalPayloadFromSchema(
+        firstSchema?.input_schema as Record<string, unknown>
+      );
+      const payloadJson = JSON.stringify(payload);
+      const dataArg = Object.keys(payload).length === 0 ? '-d "{}"' : `-d '${payloadJson}'`;
+      cta.push({
+        action: 'Execute a tool',
+        command: params.rootOnly
+          ? `composio execute "${firstSlug}" ${dataArg}`
+          : `composio manage tools execute "${firstSlug}" --user-id "<user-id>" -d '${payloadJson}'`,
+      });
+    }
+    if (firstToolkit) {
+      cta.push({
+        action: 'Connect a user account',
+        command: params.rootOnly
+          ? `composio link ${String(firstToolkit).toLowerCase()}`
+          : `composio manage connected-accounts link ${String(firstToolkit).toLowerCase()} --user-id "<user-id>"`,
+      });
+    }
+
+    const outputForJq = {
+      ...searchResponse,
+      CTA: cta,
+    };
+    yield* ui.output(JSON.stringify(outputForJq, null, 2));
+  });
+
 export const toolsCmd$Search = Command.make(
   'search',
   { query, toolkits, userId, projectName, limit },
   ({ query, toolkits, userId, projectName, limit }) =>
-    Effect.gen(function* () {
-      if (!(yield* requireAuth)) return;
+    runToolsSearch({ query, toolkits, userId, projectName, limit, rootOnly: false })
+).pipe(
+  Command.withDescription(
+    [
+      'Semantically search tools by use case; returns best-fit tools plus recommended usage guidance.',
+      '',
+      'Related:',
+      '  composio link <toolkit>',
+      "  composio execute <slug> -d '{}'",
+    ].join('\n')
+  )
+);
 
-      const ui = yield* TerminalUI;
-      const userContext = yield* ComposioUserContext;
-      const globalTestUserId = userContext.data.testUserId;
-      const resolvedUserId = Option.match(userId, {
-        onSome: value => Option.some(value),
-        onNone: () => globalTestUserId,
-      });
-
-      if (Option.isNone(resolvedUserId)) {
-        return yield* Effect.fail(
-          new Error(
-            'Missing user id. Provide --user-id or run composio login to set global test_user_id.'
-          )
-        );
-      }
-
-      if (Option.isNone(userId) && Option.isSome(globalTestUserId)) {
-        yield* ui.log.warn(`Using global test user id "${globalTestUserId.value}"`);
-      }
-
-      const clampedLimit = clampLimit(limit);
-      const toolkitFilter = Option.getOrUndefined(toolkits);
-      const toolkitList =
-        toolkitFilter && toolkitFilter.trim().length > 0
-          ? toolkitFilter
-              .split(',')
-              .map(s => s.trim().toLowerCase())
-              .filter(Boolean)
-          : undefined;
-
-      const searchResponse = yield* ui.withSpinner(
-        `Searching tools for "${query}"...`,
-        Effect.gen(function* () {
-          const resolvedProject = yield* resolveCommandProject({
-            mode: 'consumer',
-            projectName: Option.getOrUndefined(projectName),
-          }).pipe(Effect.mapError(formatResolveCommandProjectError));
-          const clientSingleton = yield* ComposioClientSingleton;
-          const client = yield* clientSingleton.getFor({
-            orgId: resolvedProject.orgId,
-            projectId: resolvedProject.projectId,
-          });
-          const { sessionId } = yield* resolveToolRouterSession(client, resolvedUserId.value, {
-            toolkits: toolkitList,
-          });
-          yield* ui.log.info(
-            `Using ${resolvedProject.projectType.toLowerCase()} project "${resolvedProject.projectName ?? resolvedProject.projectId}".`
-          );
-          return yield* Effect.tryPromise(() =>
-            client.toolRouter.session.search(sessionId, {
-              queries: [{ use_case: query }],
-            })
-          );
-        })
-      );
-
-      const toolkitSet = toolkitList && toolkitList.length > 0 ? new Set(toolkitList) : undefined;
-
-      const mergedSlugs: string[] = [];
-      const seen = new Set<string>();
-      for (const item of searchResponse.results) {
-        for (const slug of [...item.primary_tool_slugs, ...item.related_tool_slugs]) {
-          if (!seen.has(slug)) {
-            seen.add(slug);
-            mergedSlugs.push(slug);
-          }
-        }
-      }
-
-      const toolsList: Tool[] = [];
-      for (const slug of mergedSlugs) {
-        const schema = searchResponse.tool_schemas[slug];
-        if (!schema) continue;
-        if (toolkitSet && !toolkitSet.has(schema.toolkit.toLowerCase())) continue;
-
-        toolsList.push({
-          slug: schema.tool_slug,
-          name: schema.tool_slug,
-          description: schema.description ?? '',
-          tags: [],
-          available_versions: [],
-          input_parameters: (schema.input_schema ?? {}) as Record<string, unknown>,
-          output_parameters: (schema.output_schema ?? {}) as Record<string, unknown>,
-        } as Tool);
-
-        if (toolsList.length >= clampedLimit) break;
-      }
-
-      if (toolsList.length === 0) {
-        yield* ui.log.warn(`No tools found matching "${query}". Try broadening your search.`);
-        return;
-      }
-
-      const showing = toolsList.length;
-      yield* ui.log.info(`Found ${showing} tools\n\n${formatToolsTable(toolsList)}`);
-
-      const planSteps = Array.from(
-        new Set(searchResponse.results.flatMap(result => result.recommended_plan_steps ?? []))
-      );
-      if (planSteps.length > 0) {
-        yield* ui.log.info(`Plan:\n${planSteps.map((step, i) => `${i + 1}. ${step}`).join('\n')}`);
-      } else if (searchResponse.next_steps_guidance.length > 0) {
-        yield* ui.log.info(
-          `Plan:\n${searchResponse.next_steps_guidance
-            .map((step, i) => `${i + 1}. ${step}`)
-            .join('\n')}`
-        );
-      }
-
-      // Next step hint
-      const firstSlug = toolsList[0]?.slug;
-      if (firstSlug) {
-        yield* ui.log.step(
-          [
-            'Hints:',
-            `> composio execute "${firstSlug}" --user-id "<user-id>" -d '{}'`,
-            `> composio link <toolkit> --user-id "<user-id>"`,
-          ].join('\n')
-        );
-      }
-
-      if (searchResponse.error) {
-        yield* ui.log.warn(searchResponse.error);
-      }
-
-      // For machine-readable output (e.g. piping to jq), expose the full API payload with CTA.
-      const firstSchema =
-        firstSlug && searchResponse.tool_schemas[firstSlug]
-          ? searchResponse.tool_schemas[firstSlug]
-          : undefined;
-      const firstToolkit = firstSchema?.toolkit;
-
-      const cta: Array<{ action: string; command: string }> = [];
-      if (firstSlug) {
-        const payload = buildMinimalPayloadFromSchema(
-          firstSchema?.input_schema as Record<string, unknown>
-        );
-        const payloadJson = JSON.stringify(payload);
-        const dataArg = Object.keys(payload).length === 0 ? '-d "{}"' : `-d '${payloadJson}'`;
-        cta.push({
-          action: 'Execute a tool',
-          command: `composio execute "${firstSlug}" ${dataArg}`,
-        });
-      }
-      if (firstToolkit) {
-        cta.push({
-          action: 'Connect a user account',
-          command: `composio link ${String(firstToolkit).toLowerCase()}`,
-        });
-      }
-
-      const outputForJq = {
-        ...searchResponse,
-        CTA: cta,
-      };
-      yield* ui.output(JSON.stringify(outputForJq, null, 2));
+export const rootToolsCmd$Search = Command.make(
+  'search',
+  { query, toolkits, limit },
+  ({ query, toolkits, limit }) =>
+    runToolsSearch({
+      query,
+      toolkits,
+      userId: Option.none(),
+      projectName: Option.none(),
+      limit,
+      rootOnly: true,
     })
 ).pipe(
   Command.withDescription(
-    'Semantically search tools by use case; returns best-fit tools plus recommended usage guidance.'
+    [
+      'Semantically search tools by use case; returns best-fit tools plus recommended usage guidance.',
+      '',
+      'Related:',
+      '  composio link <toolkit>',
+      "  composio execute <slug> -d '{}'",
+    ].join('\n')
   )
 );

--- a/ts/packages/cli/src/commands/tools/commands/tools.search.cmd.ts
+++ b/ts/packages/cli/src/commands/tools/commands/tools.search.cmd.ts
@@ -155,10 +155,22 @@ const runToolsSearch = (params: {
     }
 
     const firstSlug = toolsList[0]?.slug;
+    const firstSchema =
+      firstSlug && searchResponse.tool_schemas[firstSlug]
+        ? searchResponse.tool_schemas[firstSlug]
+        : undefined;
+    const firstToolkit = firstSchema?.toolkit;
+    const firstPayload = buildMinimalPayloadFromSchema(
+      (firstSchema?.input_schema ?? {}) as Record<string, unknown>
+    );
+    const firstPayloadJson = JSON.stringify(firstPayload);
+    const firstDataArg =
+      Object.keys(firstPayload).length === 0 ? '-d "{}"' : `-d '${firstPayloadJson}'`;
+
     if (firstSlug) {
       const executeHint = params.rootOnly
-        ? `> composio execute "${firstSlug}" -d '{}'`
-        : `> composio manage tools execute "${firstSlug}" --user-id "<user-id>" -d '{}'`;
+        ? `> composio execute "${firstSlug}" ${firstDataArg}`
+        : `> composio manage tools execute "${firstSlug}" --user-id "<user-id>" ${firstDataArg}`;
       const linkHint = params.rootOnly
         ? `> composio link <toolkit>`
         : `> composio manage connected-accounts link <toolkit> --user-id "<user-id>"`;
@@ -169,24 +181,13 @@ const runToolsSearch = (params: {
       yield* ui.log.warn(searchResponse.error);
     }
 
-    const firstSchema =
-      firstSlug && searchResponse.tool_schemas[firstSlug]
-        ? searchResponse.tool_schemas[firstSlug]
-        : undefined;
-    const firstToolkit = firstSchema?.toolkit;
-
     const cta: Array<{ action: string; command: string }> = [];
     if (firstSlug) {
-      const payload = buildMinimalPayloadFromSchema(
-        firstSchema?.input_schema as Record<string, unknown>
-      );
-      const payloadJson = JSON.stringify(payload);
-      const dataArg = Object.keys(payload).length === 0 ? '-d "{}"' : `-d '${payloadJson}'`;
       cta.push({
         action: 'Execute a tool',
         command: params.rootOnly
-          ? `composio execute "${firstSlug}" ${dataArg}`
-          : `composio manage tools execute "${firstSlug}" --user-id "<user-id>" -d '${payloadJson}'`,
+          ? `composio execute "${firstSlug}" ${firstDataArg}`
+          : `composio manage tools execute "${firstSlug}" --user-id "<user-id>" ${firstDataArg}`,
       });
     }
     if (firstToolkit) {

--- a/ts/packages/cli/src/commands/triggers/commands/triggers.listen.cmd.ts
+++ b/ts/packages/cli/src/commands/triggers/commands/triggers.listen.cmd.ts
@@ -14,6 +14,10 @@ import {
 import { parseCsv } from '../parse-csv';
 import { parseTriggerListenEvent } from '../parse';
 import type { TriggerListenFilters } from '../types';
+import {
+  resolveCommandProject,
+  formatResolveCommandProjectError,
+} from 'src/services/command-project';
 
 const toolkits = Options.text('toolkits').pipe(
   Options.withDescription(
@@ -172,6 +176,9 @@ export const triggersCmd$Listen = Command.make(
       if (!(yield* requireAuth)) return;
 
       const ui = yield* TerminalUI;
+      yield* resolveCommandProject({ mode: 'developer' }).pipe(
+        Effect.mapError(formatResolveCommandProjectError)
+      );
       const fs = yield* FileSystem.FileSystem;
       const realtime = yield* TriggersRealtime;
       const runtime = yield* Effect.runtime<never>();

--- a/ts/packages/cli/src/commands/whoami.cmd.ts
+++ b/ts/packages/cli/src/commands/whoami.cmd.ts
@@ -25,13 +25,11 @@ export const whoamiCmd = Command.make('whoami', {}).pipe(
           onSome: () =>
             Effect.gen(function* () {
               const defaultOrgId = Option.getOrUndefined(ctx.data.orgId);
-              const defaultProjectId = Option.getOrUndefined(ctx.data.projectId);
               const testUserId = Option.getOrUndefined(ctx.data.testUserId);
 
               yield* ui.note(
                 [
                   `Default Org ID: ${defaultOrgId ?? 'not set'}`,
-                  `Default Project ID: ${defaultProjectId ?? 'not set'}`,
                   `Test User ID: ${testUserId ?? 'not set'}`,
                 ].join('\n'),
                 'Global User Context'
@@ -45,7 +43,6 @@ export const whoamiCmd = Command.make('whoami', {}).pipe(
               yield* ui.output(
                 JSON.stringify({
                   default_org_id: defaultOrgId ?? null,
-                  default_project_id: defaultProjectId ?? null,
                   test_user_id: testUserId ?? null,
                 })
               );

--- a/ts/packages/cli/src/effects/create-tool-router-session.ts
+++ b/ts/packages/cli/src/effects/create-tool-router-session.ts
@@ -1,6 +1,5 @@
 import { Effect } from 'effect';
 import type { Composio } from '@composio/client';
-import { ComposioClientSingleton } from 'src/services/composio-clients';
 
 export interface CreateToolRouterSessionOptions {
   /** Enable auto connection management. Default: false. */
@@ -39,12 +38,10 @@ export const createToolRouterSession = (
  * (resolve singleton, get client, create session) repeated across commands.
  */
 export const resolveToolRouterSession = (
+  client: Composio,
   userId: string,
   options?: CreateToolRouterSessionOptions
 ) =>
-  Effect.gen(function* () {
-    const clientSingleton = yield* ComposioClientSingleton;
-    const client = yield* clientSingleton.get();
-    const sessionId = yield* createToolRouterSession(client, userId, options);
-    return { client, sessionId };
-  });
+  createToolRouterSession(client, userId, options).pipe(
+    Effect.map(sessionId => ({ client, sessionId }))
+  );

--- a/ts/packages/cli/src/effects/select-org-project.ts
+++ b/ts/packages/cli/src/effects/select-org-project.ts
@@ -1,11 +1,6 @@
 import { Effect } from 'effect';
 import { TerminalUI } from 'src/services/terminal-ui';
-import {
-  listOrganizationProjects,
-  listOrganizations,
-  type OrganizationProjectSummary,
-  type OrganizationSummary,
-} from 'src/services/composio-clients';
+import { listOrganizations, type OrganizationSummary } from 'src/services/composio-clients';
 import { clampLimit } from 'src/ui/clamp-limit';
 
 const DEFAULT_LIMIT = 50;
@@ -56,104 +51,4 @@ export const runOrgSelection = (params: {
     );
 
     return selectedOrganization;
-  });
-
-export const runDeveloperProjectSelection = (params: {
-  apiKey: string;
-  baseURL: string;
-  orgId: string;
-  explicitProjectId?: string;
-  limit?: number;
-}) =>
-  Effect.gen(function* () {
-    const ui = yield* TerminalUI;
-    const { apiKey, baseURL, orgId, explicitProjectId, limit = DEFAULT_LIMIT } = params;
-    const clampedLimit = clampLimit(limit);
-
-    const projects = yield* listOrganizationProjects({
-      baseURL,
-      apiKey,
-      orgId,
-      limit: clampedLimit,
-    });
-    yield* ui.log.info(`Loaded ${projects.data.length} projects`);
-
-    if (projects.data.length === 0) {
-      yield* ui.log.warn(`No projects found for org "${orgId}".`);
-      return undefined;
-    }
-
-    const selectedProject = yield* selectProject(projects.data, explicitProjectId);
-    if (!selectedProject) {
-      yield* ui.log.warn('No project selected.');
-      return undefined;
-    }
-
-    yield* ui.log.info(`Selected project: "${selectedProject.name}" (${selectedProject.id})`);
-    return selectedProject;
-  });
-
-/**
- * Prompts user to select a project, or auto-selects if only one.
- * When explicitProjectId is provided (e.g. from `orgs switch --project-id`), finds and returns it without prompting.
- */
-const selectProject = (
-  projects: ReadonlyArray<OrganizationProjectSummary>,
-  explicitProjectId?: string
-) =>
-  Effect.gen(function* () {
-    const ui = yield* TerminalUI;
-    if (projects.length === 0) return undefined;
-    if (explicitProjectId) {
-      const match = projects.find(p => p.id === explicitProjectId);
-      if (match) return match;
-    }
-    if (projects.length === 1) return projects[0];
-    return yield* ui.select('Select a default project (global scope):', [
-      ...projects.map(project => ({ value: project, label: project.name, hint: project.id })),
-    ]);
-  });
-
-/**
- * Runs the org/project selection flow: lists orgs, prompts for org (or auto-selects if 1),
- * lists projects, prompts for project (or auto-selects if 1).
- *
- * Reused by `composio manage orgs switch` and `composio login -y`.
- *
- * @param params.apiKey - User API key for API calls
- * @param params.baseURL - API base URL
- * @param params.explicitOrgId - If provided, skip org picker and use this org
- * @param params.explicitProjectId - If provided (and org selected), skip project picker
- * @param params.limit - Max orgs/projects to fetch (default 50)
- */
-export const runOrgProjectSelection = (params: {
-  apiKey: string;
-  baseURL: string;
-  explicitOrgId?: string;
-  explicitProjectId?: string;
-  limit?: number;
-}) =>
-  Effect.gen(function* () {
-    const { apiKey, baseURL, explicitOrgId, explicitProjectId, limit = DEFAULT_LIMIT } = params;
-    const selectedOrganization = yield* runOrgSelection({
-      apiKey,
-      baseURL,
-      explicitOrgId,
-      limit,
-    });
-    if (!selectedOrganization) {
-      return undefined;
-    }
-    const selectedProject = yield* runDeveloperProjectSelection({
-      apiKey,
-      baseURL,
-      orgId: selectedOrganization.id,
-      explicitProjectId,
-      limit,
-    });
-    if (!selectedProject) {
-      return undefined;
-    }
-
-    return { org: selectedOrganization, project: selectedProject } as const;
   });

--- a/ts/packages/cli/src/effects/select-org-project.ts
+++ b/ts/packages/cli/src/effects/select-org-project.ts
@@ -21,6 +21,78 @@ const selectOrganization = (organizations: ReadonlyArray<OrganizationSummary>) =
     ]);
   });
 
+export const runOrgSelection = (params: {
+  apiKey: string;
+  baseURL: string;
+  explicitOrgId?: string;
+  limit?: number;
+}) =>
+  Effect.gen(function* () {
+    const ui = yield* TerminalUI;
+    const { apiKey, baseURL, explicitOrgId, limit = DEFAULT_LIMIT } = params;
+    const clampedLimit = clampLimit(limit);
+
+    const selectedOrganization =
+      explicitOrgId !== undefined
+        ? ({ id: explicitOrgId, name: explicitOrgId } satisfies OrganizationSummary)
+        : yield* Effect.gen(function* () {
+            const organizations = yield* listOrganizations({
+              baseURL,
+              apiKey,
+              limit: clampedLimit,
+            });
+            yield* ui.log.info(`Loaded ${organizations.data.length} orgs`);
+            if (organizations.data.length === 0) return undefined;
+            return yield* selectOrganization(organizations.data);
+          });
+
+    if (!selectedOrganization) {
+      yield* ui.log.warn('No organizations found for this API key.');
+      return undefined;
+    }
+
+    yield* ui.log.info(
+      `Selected organization: "${selectedOrganization.name}" (${selectedOrganization.id})`
+    );
+
+    return selectedOrganization;
+  });
+
+export const runDeveloperProjectSelection = (params: {
+  apiKey: string;
+  baseURL: string;
+  orgId: string;
+  explicitProjectId?: string;
+  limit?: number;
+}) =>
+  Effect.gen(function* () {
+    const ui = yield* TerminalUI;
+    const { apiKey, baseURL, orgId, explicitProjectId, limit = DEFAULT_LIMIT } = params;
+    const clampedLimit = clampLimit(limit);
+
+    const projects = yield* listOrganizationProjects({
+      baseURL,
+      apiKey,
+      orgId,
+      limit: clampedLimit,
+    });
+    yield* ui.log.info(`Loaded ${projects.data.length} projects`);
+
+    if (projects.data.length === 0) {
+      yield* ui.log.warn(`No projects found for org "${orgId}".`);
+      return undefined;
+    }
+
+    const selectedProject = yield* selectProject(projects.data, explicitProjectId);
+    if (!selectedProject) {
+      yield* ui.log.warn('No project selected.');
+      return undefined;
+    }
+
+    yield* ui.log.info(`Selected project: "${selectedProject.name}" (${selectedProject.id})`);
+    return selectedProject;
+  });
+
 /**
  * Prompts user to select a project, or auto-selects if only one.
  * When explicitProjectId is provided (e.g. from `orgs switch --project-id`), finds and returns it without prompting.
@@ -62,52 +134,26 @@ export const runOrgProjectSelection = (params: {
   limit?: number;
 }) =>
   Effect.gen(function* () {
-    const ui = yield* TerminalUI;
     const { apiKey, baseURL, explicitOrgId, explicitProjectId, limit = DEFAULT_LIMIT } = params;
-    const clampedLimit = clampLimit(limit);
-
-    const selectedOrganization =
-      explicitOrgId !== undefined
-        ? ({ id: explicitOrgId, name: explicitOrgId } satisfies OrganizationSummary)
-        : yield* Effect.gen(function* () {
-            const organizations = yield* listOrganizations({
-              baseURL,
-              apiKey,
-              limit: clampedLimit,
-            });
-            yield* ui.log.info(`Loaded ${organizations.data.length} orgs`);
-            if (organizations.data.length === 0) return undefined;
-            return yield* selectOrganization(organizations.data);
-          });
-
-    if (!selectedOrganization) {
-      yield* ui.log.warn('No organizations found for this API key.');
-      return undefined;
-    }
-    yield* ui.log.info(
-      `Selected organization: "${selectedOrganization.name}" (${selectedOrganization.id})`
-    );
-
-    const projects = yield* listOrganizationProjects({
-      baseURL,
+    const selectedOrganization = yield* runOrgSelection({
       apiKey,
-      orgId: selectedOrganization.id,
-      limit: clampedLimit,
+      baseURL,
+      explicitOrgId,
+      limit,
     });
-    yield* ui.log.info(`Loaded ${projects.data.length} projects`);
-
-    if (projects.data.length === 0) {
-      yield* ui.log.warn(`No projects found for org "${selectedOrganization.name}".`);
+    if (!selectedOrganization) {
       return undefined;
     }
-
-    const selectedProject = yield* selectProject(projects.data, explicitProjectId);
-
+    const selectedProject = yield* runDeveloperProjectSelection({
+      apiKey,
+      baseURL,
+      orgId: selectedOrganization.id,
+      explicitProjectId,
+      limit,
+    });
     if (!selectedProject) {
-      yield* ui.log.warn('No project selected.');
       return undefined;
     }
-    yield* ui.log.info(`Selected project: "${selectedProject.name}" (${selectedProject.id})`);
 
     return { org: selectedOrganization, project: selectedProject } as const;
   });

--- a/ts/packages/cli/src/models/project-keys.ts
+++ b/ts/packages/cli/src/models/project-keys.ts
@@ -3,9 +3,9 @@ import { OptionFromNullishOr } from 'effect/Schema';
 import { JSONTransformSchema } from './utils/json-transform-schema';
 
 /**
- * Organization and project identifiers for a CLI project profile.
+ * Organization and developer-project identifiers for a CLI project profile.
  * Stored in `~/.composio/_keys/<projectId>.json` (global registry)
- * and `<cwd>/.composio/project.json` (per-directory config).
+ * and `<cwd>/.composio/project.json` (per-directory developer config).
  */
 export const ProjectKeys = Schema.Struct({
   /**

--- a/ts/packages/cli/src/models/user-data.ts
+++ b/ts/packages/cli/src/models/user-data.ts
@@ -32,7 +32,8 @@ export const UserData = Schema.Struct({
   ),
 
   /**
-   * Project ID for the current user.
+   * Legacy global project ID retained for backward-compatible reads.
+   * New CLI versions no longer persist this field.
    */
   projectId: Schema.propertySignature(OptionFromNullishOr(Schema.String, null)).pipe(
     Schema.fromKey('project_id')
@@ -57,7 +58,7 @@ export const UserDataWithDefaults = Schema.Struct({
   baseURL: Schema.propertySignature(Schema.String).pipe(Schema.fromKey('base_url')),
   webURL: Schema.propertySignature(Schema.String).pipe(Schema.fromKey('web_url')),
 
-  // orgId and projectId remain as Option<string> — they may not be set.
+  // orgId and legacy projectId remain as Option<string> — they may not be set.
 }).annotations({
   identifier: 'UserDataWithDefaults',
   description: 'User data storage for the Composio CLI with defaults',

--- a/ts/packages/cli/src/services/command-project.ts
+++ b/ts/packages/cli/src/services/command-project.ts
@@ -25,6 +25,7 @@ export interface ResolvedCommandProject {
   readonly projectId: string;
   readonly projectName?: string;
   readonly projectType: CliProjectType;
+  readonly consumerUserId?: string;
   readonly source: CliProjectResolutionSource;
 }
 
@@ -82,6 +83,7 @@ export const resolveCommandProject = (params: { mode: ProjectMode; projectName?:
         projectId: consumerProject.project_nano_id,
         projectName: consumerProject.project_name,
         projectType: 'CONSUMER',
+        consumerUserId: consumerProject.consumer_user_id,
         source: 'consumer-default',
       } satisfies ResolvedCommandProject;
     }

--- a/ts/packages/cli/src/services/command-project.ts
+++ b/ts/packages/cli/src/services/command-project.ts
@@ -117,14 +117,7 @@ export const resolveCommandProject = (params: { mode: ProjectMode; projectName?:
       projectType: 'DEVELOPER',
       source: 'developer-local-config',
     } satisfies ResolvedCommandProject;
-  }).pipe(
-    Effect.catchTags({
-      'services/DeveloperProjectNotFoundError': error => Effect.fail(error),
-      'services/AmbiguousDeveloperProjectNameError': error => Effect.fail(error),
-      'services/HttpServerError': error => Effect.fail(error),
-      'services/HttpDecodingError': error => Effect.fail(error),
-    })
-  ) as Effect.Effect<
+  }) as Effect.Effect<
     ResolvedCommandProject,
     | MissingDefaultOrgError
     | MissingDeveloperProjectError

--- a/ts/packages/cli/src/services/command-project.ts
+++ b/ts/packages/cli/src/services/command-project.ts
@@ -1,0 +1,164 @@
+import { Data, Effect, Option } from 'effect';
+import { ProjectContext } from './project-context';
+import { ComposioUserContext } from './user-context';
+import {
+  resolveConsumerProject,
+  findDeveloperProjectByName,
+  DeveloperProjectNotFoundError,
+  AmbiguousDeveloperProjectNameError,
+  type HttpDecodingError,
+  type HttpServerError,
+} from './composio-clients';
+
+export type ProjectMode = 'consumer' | 'developer';
+
+export type CliProjectType = 'CONSUMER' | 'DEVELOPER';
+
+export type CliProjectResolutionSource =
+  | 'consumer-default'
+  | 'developer-project-name'
+  | 'developer-local-config'
+  | 'developer-explicit';
+
+export interface ResolvedCommandProject {
+  readonly orgId: string;
+  readonly projectId: string;
+  readonly projectName?: string;
+  readonly projectType: CliProjectType;
+  readonly source: CliProjectResolutionSource;
+}
+
+export class MissingDefaultOrgError extends Data.TaggedError(
+  'services/MissingDefaultOrgError'
+)<{}> {}
+
+export class MissingDeveloperProjectError extends Data.TaggedError(
+  'services/MissingDeveloperProjectError'
+)<{}> {}
+
+const requireDefaultOrg = (orgId: Option.Option<string>) =>
+  Option.match(orgId, {
+    onNone: () => Effect.fail(new MissingDefaultOrgError()),
+    onSome: value => Effect.succeed(value),
+  });
+
+export const resolveCommandProject = (params: { mode: ProjectMode; projectName?: string }) =>
+  Effect.gen(function* () {
+    const ctx = yield* ComposioUserContext;
+    const projectContext = yield* ProjectContext;
+    const apiKey = Option.getOrUndefined(ctx.data.apiKey);
+    const currentOrgId = yield* requireDefaultOrg(ctx.data.orgId);
+
+    if (!apiKey) {
+      return yield* Effect.fail(new MissingDefaultOrgError());
+    }
+
+    if (params.mode === 'consumer') {
+      if (params.projectName) {
+        const developerProject = yield* findDeveloperProjectByName({
+          baseURL: ctx.data.baseURL,
+          apiKey,
+          orgId: currentOrgId,
+          name: params.projectName,
+        });
+
+        return {
+          orgId: currentOrgId,
+          projectId: developerProject.id,
+          projectName: developerProject.name,
+          projectType: 'DEVELOPER',
+          source: 'developer-project-name',
+        } satisfies ResolvedCommandProject;
+      }
+
+      const consumerProject = yield* resolveConsumerProject({
+        baseURL: ctx.data.baseURL,
+        apiKey,
+        orgId: currentOrgId,
+      });
+
+      return {
+        orgId: consumerProject.org_id,
+        projectId: consumerProject.project_nano_id,
+        projectName: consumerProject.project_name,
+        projectType: 'CONSUMER',
+        source: 'consumer-default',
+      } satisfies ResolvedCommandProject;
+    }
+
+    if (params.projectName) {
+      const developerProject = yield* findDeveloperProjectByName({
+        baseURL: ctx.data.baseURL,
+        apiKey,
+        orgId: currentOrgId,
+        name: params.projectName,
+      });
+
+      return {
+        orgId: currentOrgId,
+        projectId: developerProject.id,
+        projectName: developerProject.name,
+        projectType: 'DEVELOPER',
+        source: 'developer-explicit',
+      } satisfies ResolvedCommandProject;
+    }
+
+    const localProject = yield* projectContext.resolve;
+    if (Option.isNone(localProject)) {
+      return yield* Effect.fail(new MissingDeveloperProjectError());
+    }
+
+    return {
+      orgId: localProject.value.orgId,
+      projectId: localProject.value.projectId,
+      projectName: Option.getOrUndefined(localProject.value.projectName),
+      projectType: 'DEVELOPER',
+      source: 'developer-local-config',
+    } satisfies ResolvedCommandProject;
+  }).pipe(
+    Effect.catchTags({
+      'services/DeveloperProjectNotFoundError': error => Effect.fail(error),
+      'services/AmbiguousDeveloperProjectNameError': error => Effect.fail(error),
+      'services/HttpServerError': error => Effect.fail(error),
+      'services/HttpDecodingError': error => Effect.fail(error),
+    })
+  ) as Effect.Effect<
+    ResolvedCommandProject,
+    | MissingDefaultOrgError
+    | MissingDeveloperProjectError
+    | DeveloperProjectNotFoundError
+    | AmbiguousDeveloperProjectNameError
+    | HttpServerError
+    | HttpDecodingError
+  >;
+
+export const formatResolveCommandProjectError = (error: unknown): Error => {
+  if (error instanceof MissingDefaultOrgError) {
+    return new Error(
+      'No default org configured. Run `composio login` or `composio manage orgs switch`.'
+    );
+  }
+  if (error instanceof MissingDeveloperProjectError) {
+    return new Error('No developer project configured for this directory. Run `composio init`.');
+  }
+  if (error instanceof DeveloperProjectNotFoundError) {
+    return new Error(
+      `Developer project "${error.projectName}" was not found in org "${error.orgId}". Run \`composio init\` or \`composio manage projects list\`.`
+    );
+  }
+  if (error instanceof AmbiguousDeveloperProjectNameError) {
+    return new Error(
+      `Developer project name "${error.projectName}" is ambiguous in org "${error.orgId}". Use an exact unique project name.`
+    );
+  }
+  if (typeof error === 'object' && error && 'details' in error) {
+    const details = (error as { details?: { message?: string } }).details;
+    if (details?.message) {
+      return new Error(details.message);
+    }
+  }
+  if (error instanceof Error) {
+    return error;
+  }
+  return new Error(String(error));
+};

--- a/ts/packages/cli/src/services/composio-clients.ts
+++ b/ts/packages/cli/src/services/composio-clients.ts
@@ -738,6 +738,7 @@ export const ConsumerProjectResolveResponse = Schema.Struct({
   project_name: Schema.String,
   org_id: Schema.String,
   project_type: Schema.Literal('CONSUMER'),
+  consumer_user_id: Schema.String,
 }).annotations({ identifier: 'ConsumerProjectResolveResponse' });
 export type ConsumerProjectResolveResponse = Schema.Schema.Type<
   typeof ConsumerProjectResolveResponse

--- a/ts/packages/cli/src/services/composio-clients.ts
+++ b/ts/packages/cli/src/services/composio-clients.ts
@@ -732,6 +732,17 @@ export interface OrganizationProjectListResponse {
   readonly total_items: number;
 }
 
+export const ConsumerProjectResolveResponse = Schema.Struct({
+  project_id: Schema.String,
+  project_nano_id: Schema.String,
+  project_name: Schema.String,
+  org_id: Schema.String,
+  project_type: Schema.Literal('CONSUMER'),
+}).annotations({ identifier: 'ConsumerProjectResolveResponse' });
+export type ConsumerProjectResolveResponse = Schema.Schema.Type<
+  typeof ConsumerProjectResolveResponse
+>;
+
 const extractArrayPayload = (json: unknown): ReadonlyArray<unknown> => {
   if (Array.isArray(json)) return json;
   if (json && typeof json === 'object') {
@@ -1085,6 +1096,131 @@ export const createProjectApiKey = (params: {
     return createdApiKey;
   });
 
+export const resolveConsumerProject = (params: {
+  baseURL: string;
+  apiKey: string;
+  orgId: string;
+}): Effect.Effect<ConsumerProjectResolveResponse, HttpServerError | HttpDecodingError> =>
+  Effect.gen(function* () {
+    const response = yield* Effect.tryPromise({
+      try: () =>
+        fetch(`${params.baseURL}/api/v3/org/consumer/project/resolve`, {
+          method: 'POST',
+          redirect: 'error',
+          headers: {
+            'x-user-api-key': params.apiKey,
+            'x-org-id': params.orgId,
+            'User-Agent': '@composio/cli',
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+          },
+        }),
+      catch: error => new HttpServerError({ cause: error }),
+    });
+
+    if (!response.ok) {
+      return yield* handleHttpErrorResponse(response);
+    }
+
+    const { json } = yield* streamResponseWithByteCount(response);
+
+    return yield* pipe(
+      Schema.decodeUnknown(ConsumerProjectResolveResponse)(json),
+      Effect.catchTag('ParseError', e => {
+        const message = ParseResult.TreeFormatter.formatErrorSync(e);
+        return new HttpDecodingError({
+          cause: `ParseError\n   ${message}`,
+        });
+      })
+    );
+  });
+
+export class DeveloperProjectNotFoundError extends Data.TaggedError(
+  'services/DeveloperProjectNotFoundError'
+)<{
+  readonly orgId: string;
+  readonly projectName: string;
+}> {}
+
+export class AmbiguousDeveloperProjectNameError extends Data.TaggedError(
+  'services/AmbiguousDeveloperProjectNameError'
+)<{
+  readonly orgId: string;
+  readonly projectName: string;
+  readonly matches: ReadonlyArray<OrganizationProjectSummary>;
+}> {}
+
+export const findDeveloperProjectByName = (params: {
+  baseURL: string;
+  apiKey: string;
+  orgId: string;
+  name: string;
+  limit?: number;
+}): Effect.Effect<
+  OrganizationProjectSummary,
+  | DeveloperProjectNotFoundError
+  | AmbiguousDeveloperProjectNameError
+  | HttpServerError
+  | HttpDecodingError
+> =>
+  Effect.gen(function* () {
+    const projects = yield* listOrgProjects({
+      baseURL: params.baseURL,
+      apiKey: params.apiKey,
+      orgId: params.orgId,
+      limit: params.limit,
+    });
+
+    const normalizedName = String.toLowerCase(params.name.trim());
+    const matches = projects.data.filter(
+      project => String.toLowerCase(project.name) === normalizedName
+    );
+
+    if (matches.length === 0) {
+      return yield* Effect.fail(
+        new DeveloperProjectNotFoundError({
+          orgId: params.orgId,
+          projectName: params.name,
+        })
+      );
+    }
+
+    if (matches.length > 1) {
+      return yield* Effect.fail(
+        new AmbiguousDeveloperProjectNameError({
+          orgId: params.orgId,
+          projectName: params.name,
+          matches,
+        })
+      );
+    }
+
+    return matches[0];
+  });
+
+const normalizeApiKey = (rawApiKey?: string): string | undefined =>
+  typeof rawApiKey === 'string' && rawApiKey.trim().length > 0 ? rawApiKey : undefined;
+
+const buildDefaultHeaders = (params: {
+  userApiKey?: string;
+  orgId?: string;
+  projectId?: string;
+}): Record<string, string> | undefined => {
+  const defaultHeaders = {
+    ...(params.userApiKey
+      ? ({ 'x-user-api-key': params.userApiKey } satisfies Record<string, string>)
+      : {}),
+    ...(params.orgId && params.projectId
+      ? ({
+          'x-org-id': params.orgId,
+          'x-project-id': params.projectId,
+        } satisfies Record<string, string>)
+      : {}),
+  };
+
+  return Object.keys(defaultHeaders).length > 0 ? defaultHeaders : undefined;
+};
+
 // Utility function for calling the Composio API and decoding its response.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const callClient = <T, S extends Schema.Schema<any, any>>(
@@ -1243,59 +1379,64 @@ export class ComposioClientSingleton extends Effect.Service<ComposioClientSingle
     effect: Effect.gen(function* () {
       const ctx = yield* ComposioUserContext;
       const projectContextOpt = yield* Effect.serviceOption(ProjectContext);
-      let ref = Option.none<_RawComposioClient>();
+      const cache = new Map<string, _RawComposioClient>();
+
+      const getFor = (params?: { userApiKey?: string; orgId?: string; projectId?: string }) =>
+        Effect.gen(function* () {
+          const apiKey = normalizeApiKey(
+            params?.userApiKey ?? Option.getOrUndefined(ctx.data.apiKey)
+          );
+          const cacheKey = JSON.stringify({
+            apiKey: apiKey ?? null,
+            orgId: params?.orgId ?? null,
+            projectId: params?.projectId ?? null,
+          });
+          const cached = cache.get(cacheKey);
+          if (cached) {
+            return cached;
+          }
+
+          const client = new _RawComposioClient({
+            apiKey: null,
+            baseURL: ctx.data.baseURL,
+            defaultHeaders: buildDefaultHeaders({
+              userApiKey: apiKey,
+              orgId: params?.orgId,
+              projectId: params?.projectId,
+            }),
+          });
+
+          cache.set(cacheKey, client);
+          return client;
+        });
 
       return {
         get: Effect.fn(function* () {
-          if (Option.isSome(ref)) {
-            return ref.value;
-          }
-
-          // Note: `api_key` is not required in every API request.
-          const rawApiKey = ctx.data.apiKey.pipe(Option.getOrUndefined);
-          const apiKey =
-            typeof rawApiKey === 'string' && rawApiKey.trim().length > 0 ? rawApiKey : undefined;
-          const baseURL = ctx.data.baseURL;
-          const globalOrgId = Option.getOrUndefined(ctx.data.orgId);
-          const globalProjectId = Option.getOrUndefined(ctx.data.projectId);
           const resolvedProjectContext = yield* Option.match(projectContextOpt, {
             onNone: () => Effect.succeed(Option.none()),
             onSome: projectContext =>
               projectContext.resolve.pipe(Effect.catchAll(() => Effect.succeed(Option.none()))),
           });
-          const projectContextHeaders = Option.match(resolvedProjectContext, {
-            onNone: () =>
-              globalOrgId && globalProjectId
-                ? ({
-                    'x-org-id': globalOrgId,
-                    'x-project-id': globalProjectId,
-                  } satisfies Record<string, string>)
-                : undefined,
+          return yield* Option.match(resolvedProjectContext, {
+            onNone: () => getFor(),
             onSome: keys =>
-              ({
-                'x-org-id': keys.orgId,
-                'x-project-id': keys.projectId,
-              }) satisfies Record<string, string>,
+              getFor({
+                orgId: keys.orgId,
+                projectId: keys.projectId,
+              }),
           });
-          const defaultHeaders = {
-            ...(apiKey ? ({ 'x-user-api-key': apiKey } satisfies Record<string, string>) : {}),
-            ...(projectContextHeaders ?? {}),
-          };
-          const normalizedDefaultHeaders =
-            Object.keys(defaultHeaders).length > 0 ? defaultHeaders : undefined;
-
-          yield* Effect.logDebug('Creating raw Composio client...');
-          const client = new _RawComposioClient({
-            // Disable @composio/client's built-in x-api-key auth header.
-            // CLI always authenticates with x-user-api-key instead.
-            apiKey: null,
-            baseURL,
-            defaultHeaders: normalizedDefaultHeaders,
-          });
-
-          ref = Option.some(client);
-          return client;
         }) satisfies () => Effect.Effect<_RawComposioClient, NoSuchElementException, never>,
+        getFor: Effect.fn(function* (params: {
+          userApiKey?: string;
+          orgId?: string;
+          projectId?: string;
+        }) {
+          return yield* getFor(params);
+        }) satisfies (params: {
+          userApiKey?: string;
+          orgId?: string;
+          projectId?: string;
+        }) => Effect.Effect<_RawComposioClient, NoSuchElementException, never>,
       };
     }),
     dependencies: [ComposioUserContextLive],

--- a/ts/packages/cli/src/services/project-context.ts
+++ b/ts/packages/cli/src/services/project-context.ts
@@ -44,8 +44,8 @@ const parseEnvFile = (content: string): Map<string, string> => {
 };
 
 /**
- * Service that resolves the current project context using a precedence chain.
- * Read-only -- it does NOT write files.
+ * Service that resolves the current developer project context using a precedence chain.
+ * Read-only -- it does NOT write files and is never used for consumer-project routing.
  *
  * Precedence (highest first):
  * 1. System env vars (COMPOSIO_ORG_ID, COMPOSIO_PROJECT_ID)

--- a/ts/packages/cli/src/services/tools-executor.ts
+++ b/ts/packages/cli/src/services/tools-executor.ts
@@ -1,4 +1,5 @@
 import { Context, Effect, Layer } from 'effect';
+import type { Composio } from '@composio/client';
 import type {
   SessionExecuteResponse,
   SessionExecuteMetaResponse,
@@ -38,6 +39,7 @@ export class ActionExecuteConnectedAccountNotFoundError extends Error {
 export interface ToolExecuteParams {
   readonly userId: string;
   readonly arguments: Record<string, unknown>;
+  readonly client?: Composio;
 }
 
 /**
@@ -107,20 +109,21 @@ export const ToolsExecutorLive = Layer.effect(
       execute: (slug, params) =>
         Effect.gen(function* () {
           const client = yield* clientSingleton.get();
+          const resolvedClient = params.client ?? client;
           // One session per invocation — CLI runs one tool per process.
-          const sessionId = yield* createToolRouterSession(client, params.userId, {
+          const sessionId = yield* createToolRouterSession(resolvedClient, params.userId, {
             manageConnections: true,
           });
 
           const raw: SessionExecuteResponse | SessionExecuteMetaResponse = yield* Effect.tryPromise(
             () => {
               if (isMetaToolSlug(slug)) {
-                return client.toolRouter.session.executeMeta(sessionId, {
+                return resolvedClient.toolRouter.session.executeMeta(sessionId, {
                   slug,
                   arguments: params.arguments,
                 });
               }
-              return client.toolRouter.session.execute(sessionId, {
+              return resolvedClient.toolRouter.session.execute(sessionId, {
                 tool_slug: slug,
                 arguments: params.arguments,
               });

--- a/ts/packages/cli/src/services/user-context.ts
+++ b/ts/packages/cli/src/services/user-context.ts
@@ -29,12 +29,11 @@ export class ComposioUserContext extends Context.Tag('ComposioUserData')<
     logout: Effect.Effect<void, ParseError | PlatformError, never>;
 
     /**
-     * Logs in the user by setting the API key, and optionally org/project IDs.
+     * Logs in the user by setting the API key, and optionally org ID.
      */
     login: (
       apiKey: string,
       orgId?: string,
-      projectId?: string,
       testUserId?: string
     ) => Effect.Effect<void, ParseError | PlatformError, never>;
 
@@ -79,14 +78,14 @@ export const ComposioUserContextLive = Layer.effect(
       });
     });
 
-    const login = (apiKey: string, orgId?: string, projectId?: string, testUserId?: string) =>
+    const login = (apiKey: string, orgId?: string, testUserId?: string) =>
       Effect.gen(function* () {
         yield* update({
           apiKey: Option.some(apiKey),
           baseURL: Option.some(baseURL),
           webURL: Option.some(webURL),
           orgId: Option.fromNullable(orgId),
-          projectId: Option.fromNullable(projectId),
+          projectId: Option.none(),
           testUserId: Option.fromNullable(testUserId),
         });
       });
@@ -96,10 +95,20 @@ export const ComposioUserContextLive = Layer.effect(
      */
     const update = (data: Partial<UserData>) =>
       Effect.gen(function* () {
-        const userDataAsJson = yield* userDataToJSON({ ...userData, ...data });
-        yield* Effect.logDebug('Saving user data:', userDataAsJson);
-        yield* fs.writeFileString(jsonUserConfigPath, userDataAsJson);
-        userData = { ...userData, ...data } satisfies UserData;
+        const nextUserData = { ...userData, ...data } satisfies UserData;
+        const encodedUserData = yield* userDataToJSON(nextUserData);
+        const normalizedUserDataJson = JSON.stringify(
+          (() => {
+            const parsed = JSON.parse(encodedUserData) as Record<string, unknown>;
+            if (parsed.project_id === null) {
+              delete parsed.project_id;
+            }
+            return parsed;
+          })()
+        );
+        yield* Effect.logDebug('Saving user data:', normalizedUserDataJson);
+        yield* fs.writeFileString(jsonUserConfigPath, normalizedUserDataJson);
+        userData = nextUserData;
         yield* Effect.logDebug('User data updated:', userData);
       });
 

--- a/ts/packages/cli/test/__fixtures__/global-test-user-id/.composio/project.json
+++ b/ts/packages/cli/test/__fixtures__/global-test-user-id/.composio/project.json
@@ -1,0 +1,5 @@
+{
+  "org_id": "org_test",
+  "project_id": "proj_test",
+  "project_name": "Developer Project"
+}

--- a/ts/packages/cli/test/__fixtures__/global-test-user-id/.composio/user_data.json
+++ b/ts/packages/cli/test/__fixtures__/global-test-user-id/.composio/user_data.json
@@ -2,7 +2,7 @@
   "api_key": "test_api_key",
   "base_url": "https://backend.composio.dev",
   "web_url": "https://platform.composio.dev",
-  "org_id": null,
+  "org_id": "org_test",
   "project_id": null,
   "test_user_id": "global-default"
 }

--- a/ts/packages/cli/test/__utils__/services/test-layer.ts
+++ b/ts/packages/cli/test/__utils__/services/test-layer.ts
@@ -270,6 +270,7 @@ export const TestLayer = (input?: TestLiveInput) =>
             project_name: 'Consumer Project',
             org_id: orgId,
             project_type: 'CONSUMER',
+            consumer_user_id: `consumer-user-${orgId}`,
           }),
           {
             status: 200,

--- a/ts/packages/cli/test/__utils__/services/test-layer.ts
+++ b/ts/packages/cli/test/__utils__/services/test-layer.ts
@@ -199,6 +199,54 @@ export interface TestLiveInput {
 
 type RequiredLayer = Layer.Layer<any, any, never>;
 
+const ConsumerProjectResolveFetchMock = Layer.scopedDiscard(
+  Effect.acquireRelease(
+    Effect.sync(() => {
+      const originalFetch = globalThis.fetch;
+
+      globalThis.fetch = (async (requestInput: RequestInfo | URL, init?: RequestInit) => {
+        const url =
+          typeof requestInput === 'string'
+            ? requestInput
+            : requestInput instanceof URL
+              ? requestInput.toString()
+              : requestInput.url;
+
+        if (url.includes('/api/v3/org/consumer/project/resolve')) {
+          const headers = new Headers(
+            requestInput instanceof Request ? requestInput.headers : undefined
+          );
+          new Headers(init?.headers).forEach((value, key) => headers.set(key, value));
+
+          const orgId = headers.get('x-org-id') ?? 'org_test';
+          return new Response(
+            JSON.stringify({
+              project_id: 'consumer_project_id_test',
+              project_nano_id: 'consumer_project_test',
+              project_name: 'Consumer Project',
+              org_id: orgId,
+              project_type: 'CONSUMER',
+              consumer_user_id: `consumer-user-${orgId}`,
+            }),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            }
+          );
+        }
+
+        return originalFetch(requestInput, init);
+      }) as typeof globalThis.fetch;
+
+      return originalFetch;
+    }),
+    originalFetch =>
+      Effect.sync(() => {
+        globalThis.fetch = originalFetch;
+      })
+  )
+);
+
 /**
  * Effect layer that injects all the services needed for tests, using mocks to avoid
  * side-effects like unwanted HTTP requests to remote services.
@@ -256,30 +304,6 @@ export const TestLayer = (input?: TestLiveInput) =>
 
     const tempDir = tempy.temporaryDirectory({ prefix: 'test' });
     const cwd = (yield* setupFixtureFolder({ fixture, tempDir })) ?? tempDir;
-    const originalFetch = globalThis.fetch.bind(globalThis);
-    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url =
-        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
-      if (url.includes('/api/v3/org/consumer/project/resolve')) {
-        const headers = new Headers(init?.headers);
-        const orgId = headers.get('x-org-id') ?? 'org_test';
-        return new Response(
-          JSON.stringify({
-            project_id: 'consumer_project_id_test',
-            project_nano_id: 'consumer_project_test',
-            project_name: 'Consumer Project',
-            org_id: orgId,
-            project_type: 'CONSUMER',
-            consumer_user_id: `consumer-user-${orgId}`,
-          }),
-          {
-            status: 200,
-            headers: { 'Content-Type': 'application/json' },
-          }
-        );
-      }
-      return originalFetch(input, init);
-    }) as typeof globalThis.fetch;
 
     const ComposioToolkitsRepositoryTest = Layer.succeed(
       ComposioToolkitsRepository,
@@ -1051,6 +1075,7 @@ export const TestLayer = (input?: TestLiveInput) =>
       BunContext.layer,
       MockTerminal.layer,
       BunPath.layer,
+      ConsumerProjectResolveFetchMock,
       StdinTest,
       TerminalUILayer,
       Layer.provide(

--- a/ts/packages/cli/test/__utils__/services/test-layer.ts
+++ b/ts/packages/cli/test/__utils__/services/test-layer.ts
@@ -948,6 +948,10 @@ export const TestLayer = (input?: TestLiveInput) =>
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           return mockComposioClient as any;
         }),
+        getFor: Effect.fn(function* () {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          return mockComposioClient as any;
+        }),
       })
     );
 

--- a/ts/packages/cli/test/__utils__/services/test-layer.ts
+++ b/ts/packages/cli/test/__utils__/services/test-layer.ts
@@ -64,7 +64,6 @@ import { ProjectEnvironmentDetector } from 'src/services/project-environment-det
 import { CommandRunner } from 'src/services/command-runner';
 import { TerminalUI } from 'src/services/terminal-ui';
 import { CommandExecutor } from '@effect/platform';
-import { Option } from 'effect';
 
 export interface TestLiveInput {
   /**
@@ -257,6 +256,29 @@ export const TestLayer = (input?: TestLiveInput) =>
 
     const tempDir = tempy.temporaryDirectory({ prefix: 'test' });
     const cwd = (yield* setupFixtureFolder({ fixture, tempDir })) ?? tempDir;
+    const originalFetch = globalThis.fetch.bind(globalThis);
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      if (url.includes('/api/v3/org/consumer/project/resolve')) {
+        const headers = new Headers(init?.headers);
+        const orgId = headers.get('x-org-id') ?? 'org_test';
+        return new Response(
+          JSON.stringify({
+            project_id: 'consumer_project_id_test',
+            project_nano_id: 'consumer_project_test',
+            project_name: 'Consumer Project',
+            org_id: orgId,
+            project_type: 'CONSUMER',
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        );
+      }
+      return originalFetch(input, init);
+    }) as typeof globalThis.fetch;
 
     const ComposioToolkitsRepositoryTest = Layer.succeed(
       ComposioToolkitsRepository,
@@ -866,6 +888,17 @@ export const TestLayer = (input?: TestLiveInput) =>
     };
 
     const mockComposioClient = {
+      link: {
+        create: async (params: { auth_config_id: string; user_id: string }) => {
+          const response = connectedAccountsData.linkResponse ?? {
+            connected_account_id: 'con_test_link',
+            expires_at: '2026-12-31T23:59:59Z',
+            link_token: 'lt_test_token',
+            redirect_url: `https://app.composio.dev/link?token=lt_test_token`,
+          };
+          return response;
+        },
+      },
       toolkits: {
         retrieve: async (slug: string) => {
           const detailed = toolkitsData.detailedToolkits.find(
@@ -1019,11 +1052,9 @@ export const TestLayer = (input?: TestLiveInput) =>
       BunPath.layer,
       StdinTest,
       TerminalUILayer,
-      Layer.succeed(
-        ProjectContext,
-        new ProjectContext({
-          resolve: Effect.succeed(Option.none()),
-        })
+      Layer.provide(
+        ProjectContext.Default,
+        Layer.mergeAll(BunFileSystem.layer, NodeOsTest, NodeProcessTest)
       )
     ) satisfies RequiredLayer;
 

--- a/ts/packages/cli/test/src/commands/$default.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/$default.cmd.test.ts
@@ -15,7 +15,7 @@ describe('CLI: composio', () => {
         expect(result).toEqual(
           ValidationError.commandMismatch(
             HelpDoc.p(
-              "Invalid subcommand for composio - use one of 'version', 'upgrade', 'whoami', 'login', 'logout', 'install', 'init', 'generate', 'manage'"
+              "Invalid subcommand for composio - use one of 'version', 'upgrade', 'whoami', 'login', 'logout', 'install', 'init', 'search', 'link', 'execute', 'listen', 'generate', 'manage'"
             )
           )
         );

--- a/ts/packages/cli/test/src/commands/__snapshots__/$default.cmd.test.ts.snap
+++ b/ts/packages/cli/test/src/commands/__snapshots__/$default.cmd.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`CLI: composio > [Given] --help flag [Then] prints help message 1`] = `
 "
-Connect AI agents to external tools. Link accounts, discover tools, and execute them.
+Connect AI agents to external tools. \`search\`, \`link\`, and \`execute\` use your org consumer project by default. \`init\`, \`listen\`, and \`manage\` use developer project context.
 
 USAGE
   composio <command> [options]
@@ -27,43 +27,46 @@ BASIC COMMANDS
       --no-browser          Login without browser interaction
       --no-wait             Print login URL and session info, then exit (no browser, no waiting)
       --key                 Complete login using session key from --no-wait
-      -y, --yes             Skip org/project picker; use session defaults
+      -y, --yes             Skip org picker; use session default org
 
   logout
     Log out from the Composio CLI session.
     Usage: composio logout
 
   init
-    Initialize a Composio project in the current directory.
+    Initialize this directory with a developer project.
     Usage: composio init [--no-browser] [-y, --yes]
     Options:
       --no-browser          Skip opening browser for auth
-      -y, --yes             Auto-select default org/project
+      -y, --yes             Auto-select the default developer project
 
   search
     Search tools by use case across toolkits/apps.
-    Usage: composio search <query> [--toolkits text] [--user-id text] [--limit integer]
+    Usage: composio search <query> [--toolkits text] [--user-id text] [--project-name text] [--limit integer]
     Options:
       <query>               Semantic use-case query (e.g. "send emails")
       --toolkits            Filter by toolkit slugs, comma-separated
-      --user-id             User ID (falls back to project/global test_user_id)
+      --user-id             User ID (falls back to global test_user_id)
+      --project-name        Use a developer project instead of the org consumer project
       --limit               Number of results per page (1-1000)
 
   execute
     Execute a tool.
-    Usage: composio execute <slug> [-d, --data text] [--user-id text]
+    Usage: composio execute <slug> [-d, --data text] [--user-id text] [--project-name text]
     Options:
       <slug>                Tool slug (e.g. "GITHUB_CREATE_ISSUE")
       -d, --data            JSON arguments, @file, or - for stdin
-      --user-id             User ID (falls back to project test_user_id)
+      --user-id             User ID (falls back to global test_user_id)
+      --project-name        Use a developer project instead of the org consumer project
 
   link
     Connect a user account for a toolkit/app.
-    Usage: composio link [<toolkit>] [--auth-config text] [--user-id text] [--no-browser]
+    Usage: composio link [<toolkit>] [--auth-config text] [--user-id text] [--project-name text] [--no-browser]
     Options:
       <toolkit>             Toolkit slug to link (e.g. "github", "gmail")
       --auth-config         Auth config ID (legacy flow)
       --user-id             User ID for the connection
+      --project-name        Use a developer project instead of the org consumer project
       --no-browser          Skip auto-opening the browser
 
   listen
@@ -81,7 +84,7 @@ BASIC COMMANDS
 
 ADVANCED COMMANDS
   generate    Generate type stubs for toolkits, tools, and triggers, auto-detecting project language (TypeScript | Python)
-  manage      Manage Composio resources — toolkits, tools, accounts, triggers, logs, orgs, and projects.
+  manage      Developer/admin workflows: orgs, toolkits, triggers, auth configs, logs, and deprecated project commands.
 
 FLAGS
   -h, --help     Show help for command

--- a/ts/packages/cli/test/src/commands/__snapshots__/$default.cmd.test.ts.snap
+++ b/ts/packages/cli/test/src/commands/__snapshots__/$default.cmd.test.ts.snap
@@ -42,31 +42,24 @@ BASIC COMMANDS
 
   search
     Search tools by use case across toolkits/apps.
-    Usage: composio search <query> [--toolkits text] [--user-id text] [--project-name text] [--limit integer]
+    Usage: composio search <query> [--toolkits text] [--limit integer]
     Options:
       <query>               Semantic use-case query (e.g. "send emails")
       --toolkits            Filter by toolkit slugs, comma-separated
-      --user-id             User ID (falls back to global test_user_id)
-      --project-name        Use a developer project instead of the org consumer project
       --limit               Number of results per page (1-1000)
 
   execute
     Execute a tool.
-    Usage: composio execute <slug> [-d, --data text] [--user-id text] [--project-name text]
+    Usage: composio execute <slug> [-d, --data text]
     Options:
       <slug>                Tool slug (e.g. "GITHUB_CREATE_ISSUE")
       -d, --data            JSON arguments, @file, or - for stdin
-      --user-id             User ID (falls back to global test_user_id)
-      --project-name        Use a developer project instead of the org consumer project
 
   link
     Connect a user account for a toolkit/app.
-    Usage: composio link [<toolkit>] [--auth-config text] [--user-id text] [--project-name text] [--no-browser]
+    Usage: composio link [<toolkit>] [--no-browser]
     Options:
       <toolkit>             Toolkit slug to link (e.g. "github", "gmail")
-      --auth-config         Auth config ID (legacy flow)
-      --user-id             User ID for the connection
-      --project-name        Use a developer project instead of the org consumer project
       --no-browser          Skip auto-opening the browser
 
   listen

--- a/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.link.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.link.cmd.test.ts
@@ -29,6 +29,16 @@ const connectedAccountsData = {
   items: testConnectedAccounts,
 } satisfies TestLiveInput['connectedAccountsData'];
 
+const incompleteConnectedAccountsData = {
+  items: testConnectedAccounts,
+  linkResponse: {
+    connected_account_id: '',
+    expires_at: '2026-12-31T23:59:59Z',
+    link_token: 'lt_test_token',
+    redirect_url: '',
+  },
+} satisfies TestLiveInput['connectedAccountsData'];
+
 const testConfigProvider = ConfigProvider.fromMap(
   new Map([['COMPOSIO_USER_API_KEY', 'test_api_key']])
 ).pipe(extendConfigProvider);
@@ -197,6 +207,38 @@ describe('CLI: composio manage connected-accounts link', () => {
       })
     );
   });
+
+  layer(
+    TestLive({
+      baseConfigProvider: testConfigProvider,
+      connectedAccountsData: incompleteConnectedAccountsData,
+      fixture: 'global-test-user-id',
+    })
+  )(
+    '[Given] auth-config link returns an incomplete response [Then] logs an error and exits early',
+    it => {
+      it.scoped('reports the incomplete response instead of waiting with empty values', () =>
+        Effect.gen(function* () {
+          yield* cli([
+            'manage',
+            'connected-accounts',
+            'link',
+            '--auth-config',
+            'ac_gmail_oauth',
+            '--user-id',
+            'default',
+            '--no-browser',
+          ]);
+          const lines = yield* MockConsole.getLines({ stripAnsi: true });
+          const output = lines.join('\n');
+
+          expect(output).toContain('The API returned an incomplete link response');
+          expect(output).not.toContain('"status"');
+          expect(output).not.toContain('Connection successful');
+        })
+      );
+    }
+  );
 
   layer(
     TestLive({

--- a/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.link.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.link.cmd.test.ts
@@ -144,16 +144,9 @@ describe('CLI: composio manage connected-accounts link', () => {
       fixture: 'global-test-user-id',
     })
   )('[Given] composio link alias [Then] works like composio manage connected-accounts link', it => {
-    it.scoped('alias expands to connected-accounts link', () =>
+    it.scoped('root link works for consumer toolkit linking only', () =>
       Effect.gen(function* () {
-        yield* cli([
-          'link',
-          '--auth-config',
-          'ac_gmail_oauth',
-          '--user-id',
-          'default',
-          '--no-browser',
-        ]);
+        yield* cli(['link', 'gmail', '--no-browser']);
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
         const output = lines.join('\n');
 

--- a/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.link.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.link.cmd.test.ts
@@ -34,54 +34,60 @@ const testConfigProvider = ConfigProvider.fromMap(
 ).pipe(extendConfigProvider);
 
 describe('CLI: composio manage connected-accounts link', () => {
-  layer(TestLive({ baseConfigProvider: testConfigProvider, connectedAccountsData }))(
-    '[Given] valid --auth-config and --user-id [Then] creates link and waits (default)',
-    it => {
-      it.scoped('creates link and waits for ACTIVE', () =>
-        Effect.gen(function* () {
-          yield* cli([
-            'manage',
-            'connected-accounts',
-            'link',
-            '--auth-config',
-            'ac_gmail_oauth',
-            '--user-id',
-            'default',
-            '--no-browser',
-          ]);
-          const lines = yield* MockConsole.getLines({ stripAnsi: true });
-          const output = lines.join('\n');
+  layer(
+    TestLive({
+      baseConfigProvider: testConfigProvider,
+      connectedAccountsData,
+      fixture: 'global-test-user-id',
+    })
+  )('[Given] valid --auth-config and --user-id [Then] creates link and waits (default)', it => {
+    it.scoped('creates link and waits for ACTIVE', () =>
+      Effect.gen(function* () {
+        yield* cli([
+          'manage',
+          'connected-accounts',
+          'link',
+          '--auth-config',
+          'ac_gmail_oauth',
+          '--user-id',
+          'default',
+          '--no-browser',
+        ]);
+        const lines = yield* MockConsole.getLines({ stripAnsi: true });
+        const output = lines.join('\n');
 
-          expect(output).toContain('https://app.composio.dev/link?token=lt_test_token');
-          expect(output).toContain('ACTIVE');
-        })
-      );
-    }
-  );
+        expect(output).toContain('https://app.composio.dev/link?token=lt_test_token');
+        expect(output).toContain('ACTIVE');
+      })
+    );
+  });
 
-  layer(TestLive({ baseConfigProvider: testConfigProvider, connectedAccountsData }))(
-    '[Given] valid --auth-config with explicit --user-id [Then] creates link',
-    it => {
-      it.scoped('uses explicit user-id', () =>
-        Effect.gen(function* () {
-          yield* cli([
-            'manage',
-            'connected-accounts',
-            'link',
-            '--auth-config',
-            'ac_gmail_oauth',
-            '--user-id',
-            'default',
-            '--no-browser',
-          ]);
-          const lines = yield* MockConsole.getLines({ stripAnsi: true });
-          const output = lines.join('\n');
+  layer(
+    TestLive({
+      baseConfigProvider: testConfigProvider,
+      connectedAccountsData,
+      fixture: 'global-test-user-id',
+    })
+  )('[Given] valid --auth-config with explicit --user-id [Then] creates link', it => {
+    it.scoped('uses explicit user-id', () =>
+      Effect.gen(function* () {
+        yield* cli([
+          'manage',
+          'connected-accounts',
+          'link',
+          '--auth-config',
+          'ac_gmail_oauth',
+          '--user-id',
+          'default',
+          '--no-browser',
+        ]);
+        const lines = yield* MockConsole.getLines({ stripAnsi: true });
+        const output = lines.join('\n');
 
-          expect(output).toContain('https://app.composio.dev/link');
-        })
-      );
-    }
-  );
+        expect(output).toContain('https://app.composio.dev/link');
+      })
+    );
+  });
 
   layer(
     TestLive({
@@ -131,33 +137,84 @@ describe('CLI: composio manage connected-accounts link', () => {
     );
   });
 
-  layer(TestLive({ baseConfigProvider: testConfigProvider, connectedAccountsData }))(
-    '[Given] composio link alias [Then] works like composio manage connected-accounts link',
-    it => {
-      it.scoped('alias expands to connected-accounts link', () =>
-        Effect.gen(function* () {
-          yield* cli([
-            'link',
-            '--auth-config',
-            'ac_gmail_oauth',
-            '--user-id',
-            'default',
-            '--no-browser',
-          ]);
-          const lines = yield* MockConsole.getLines({ stripAnsi: true });
-          const output = lines.join('\n');
+  layer(
+    TestLive({
+      baseConfigProvider: testConfigProvider,
+      connectedAccountsData,
+      fixture: 'global-test-user-id',
+    })
+  )('[Given] composio link alias [Then] works like composio manage connected-accounts link', it => {
+    it.scoped('alias expands to connected-accounts link', () =>
+      Effect.gen(function* () {
+        yield* cli([
+          'link',
+          '--auth-config',
+          'ac_gmail_oauth',
+          '--user-id',
+          'default',
+          '--no-browser',
+        ]);
+        const lines = yield* MockConsole.getLines({ stripAnsi: true });
+        const output = lines.join('\n');
 
-          expect(output).toContain('https://app.composio.dev/link?token=lt_test_token');
-          expect(output).toContain('ACTIVE');
-        })
-      );
-    }
-  );
+        expect(output).toContain('https://app.composio.dev/link?token=lt_test_token');
+        expect(output).toContain('ACTIVE');
+      })
+    );
+  });
 
-  layer(TestLive({ baseConfigProvider: testConfigProvider, connectedAccountsData }))(
-    '[Given] --no-wait [Then] outputs valid JSON parseable by jq',
-    it => {
-      it.scoped('prints JSON with status pending, connected_account_id, redirect_url', () =>
+  layer(
+    TestLive({
+      baseConfigProvider: testConfigProvider,
+      connectedAccountsData,
+      fixture: 'global-test-user-id',
+    })
+  )('[Given] --no-wait [Then] outputs valid JSON parseable by jq', it => {
+    it.scoped('prints JSON with status pending, connected_account_id, redirect_url', () =>
+      Effect.gen(function* () {
+        yield* cli([
+          'manage',
+          'connected-accounts',
+          'link',
+          '--auth-config',
+          'ac_gmail_oauth',
+          '--user-id',
+          'default',
+          '--no-browser',
+          '--no-wait',
+        ]);
+        const lines = yield* MockConsole.getLines({ stripAnsi: true });
+        const output = lines.join('\n');
+
+        expect(output).toContain('"status"');
+        expect(output).toContain('"pending"');
+        expect(output).toContain('"message"');
+        expect(output).toContain('"connected_account_id"');
+        expect(output).toContain('con_test_link');
+        expect(output).toContain('"redirect_url"');
+        expect(output).toContain('https://app.composio.dev/link');
+        // JSON is parseable
+        const jsonMatch = output.match(/\{[\s\S]*"status"[\s\S]*\}/);
+        expect(jsonMatch).toBeTruthy();
+        if (jsonMatch) {
+          const parsed = JSON.parse(jsonMatch[0]);
+          expect(parsed.status).toBe('pending');
+          expect(parsed.connected_account_id).toBe('con_test_link');
+        }
+      })
+    );
+  });
+
+  layer(
+    TestLive({
+      baseConfigProvider: testConfigProvider,
+      connectedAccountsData,
+      fixture: 'global-test-user-id',
+    })
+  )('[Given] default (wait) [Then] waits for ACTIVE and outputs success JSON for jq', it => {
+    it.scoped(
+      'prints JSON with status success, message, connected_account_id, toolkit, redirect_url',
+      () =>
         Effect.gen(function* () {
           yield* cli([
             'manage',
@@ -168,63 +225,21 @@ describe('CLI: composio manage connected-accounts link', () => {
             '--user-id',
             'default',
             '--no-browser',
-            '--no-wait',
           ]);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
 
           expect(output).toContain('"status"');
-          expect(output).toContain('"pending"');
+          expect(output).toContain('"success"');
           expect(output).toContain('"message"');
+          expect(output).toContain('ACTIVE');
           expect(output).toContain('"connected_account_id"');
           expect(output).toContain('con_test_link');
+          expect(output).toContain('"toolkit"');
+          expect(output).toContain('"gmail"');
           expect(output).toContain('"redirect_url"');
           expect(output).toContain('https://app.composio.dev/link');
-          // JSON is parseable
-          const jsonMatch = output.match(/\{[\s\S]*"status"[\s\S]*\}/);
-          expect(jsonMatch).toBeTruthy();
-          if (jsonMatch) {
-            const parsed = JSON.parse(jsonMatch[0]);
-            expect(parsed.status).toBe('pending');
-            expect(parsed.connected_account_id).toBe('con_test_link');
-          }
         })
-      );
-    }
-  );
-
-  layer(TestLive({ baseConfigProvider: testConfigProvider, connectedAccountsData }))(
-    '[Given] default (wait) [Then] waits for ACTIVE and outputs success JSON for jq',
-    it => {
-      it.scoped(
-        'prints JSON with status success, message, connected_account_id, toolkit, redirect_url',
-        () =>
-          Effect.gen(function* () {
-            yield* cli([
-              'manage',
-              'connected-accounts',
-              'link',
-              '--auth-config',
-              'ac_gmail_oauth',
-              '--user-id',
-              'default',
-              '--no-browser',
-            ]);
-            const lines = yield* MockConsole.getLines({ stripAnsi: true });
-            const output = lines.join('\n');
-
-            expect(output).toContain('"status"');
-            expect(output).toContain('"success"');
-            expect(output).toContain('"message"');
-            expect(output).toContain('ACTIVE');
-            expect(output).toContain('"connected_account_id"');
-            expect(output).toContain('con_test_link');
-            expect(output).toContain('"toolkit"');
-            expect(output).toContain('"gmail"');
-            expect(output).toContain('"redirect_url"');
-            expect(output).toContain('https://app.composio.dev/link');
-          })
-      );
-    }
-  );
+    );
+  });
 });

--- a/ts/packages/cli/test/src/commands/orgs/orgs.switch.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/orgs/orgs.switch.cmd.test.ts
@@ -26,72 +26,47 @@ describe('CLI: composio manage orgs switch', () => {
   });
 
   layer(TestLive({ baseConfigProvider: testConfigProvider }))(it => {
-    it.scoped('[When] no --org-id is provided [Then] lists orgs and projects with limit=50', () =>
-      Effect.gen(function* () {
-        const fetchSpy = vi
-          .spyOn(globalThis, 'fetch')
-          .mockResolvedValueOnce(
+    it.scoped(
+      '[When] no --org-id is provided [Then] lists orgs with limit=50 and stores org only',
+      () =>
+        Effect.gen(function* () {
+          const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
             mockFetchResponse({
               organizations: [{ id: 'org_1', name: 'Org One' }],
             })
-          )
-          .mockResolvedValueOnce(
-            mockFetchResponse({
-              data: [{ id: 'project_1', name: 'Project One' }],
-            })
           );
 
-        yield* cli(['manage', 'orgs', 'switch']);
+          yield* cli(['manage', 'orgs', 'switch']);
 
-        expect(fetchSpy).toHaveBeenCalledTimes(2);
-        const [orgUrl, orgRequest] = fetchSpy.mock.calls[0]!;
-        expect(orgUrl).toContain('/api/v3/org/list?limit=50');
-        expect((orgRequest as RequestInit).headers).toMatchObject({
-          'x-user-api-key': 'uak_test_key',
-        });
+          expect(fetchSpy).toHaveBeenCalledTimes(1);
+          const [orgUrl, orgRequest] = fetchSpy.mock.calls[0]!;
+          expect(orgUrl).toContain('/api/v3/org/list?limit=50');
+          expect((orgRequest as RequestInit).headers).toMatchObject({
+            'x-user-api-key': 'uak_test_key',
+          });
 
-        const [projectUrl, projectRequest] = fetchSpy.mock.calls[1]!;
-        expect(projectUrl).toContain('/api/v3/org/project/list?limit=50');
-        expect((projectRequest as RequestInit).headers).toMatchObject({
-          'x-user-api-key': 'uak_test_key',
-          'x-org-id': 'org_1',
-        });
+          const fs = yield* FileSystem.FileSystem;
+          const cacheDir = yield* setupCacheDir;
+          const userConfigPath = path.join(cacheDir, constants.USER_CONFIG_FILE_NAME);
+          const rawUserConfig = yield* fs.readFileString(userConfigPath, 'utf8');
+          const userConfig = JSON.parse(rawUserConfig) as Record<string, unknown>;
+          expect(userConfig.org_id).toBe('org_1');
+          expect(userConfig.project_id).toBeUndefined();
 
-        const fs = yield* FileSystem.FileSystem;
-        const cacheDir = yield* setupCacheDir;
-        const userConfigPath = path.join(cacheDir, constants.USER_CONFIG_FILE_NAME);
-        const rawUserConfig = yield* fs.readFileString(userConfigPath, 'utf8');
-        const userConfig = JSON.parse(rawUserConfig) as Record<string, unknown>;
-        expect(userConfig.org_id).toBe('org_1');
-        expect(userConfig.project_id).toBe('project_1');
-
-        const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
-        expect(output).toContain('Updated global defaults');
-      })
+          const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
+          expect(output).toContain('Updated default org');
+        })
     );
   });
 
   layer(TestLive({ baseConfigProvider: testConfigProvider }))(it => {
-    it.scoped('[When] --org-id is provided [Then] skips org list and selects project', () =>
+    it.scoped('[When] --org-id is provided [Then] skips org list and stores org only', () =>
       Effect.gen(function* () {
-        const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-          mockFetchResponse({
-            data: [
-              { id: 'project_1', name: 'Project One' },
-              { id: 'project_2', name: 'Project Two' },
-            ],
-          })
-        );
+        const fetchSpy = vi.spyOn(globalThis, 'fetch');
 
         yield* cli(['manage', 'orgs', 'switch', '--org-id', 'org_manual']);
 
-        expect(fetchSpy).toHaveBeenCalledTimes(1);
-        const [projectUrl, projectRequest] = fetchSpy.mock.calls[0]!;
-        expect(projectUrl).toContain('/api/v3/org/project/list?limit=50');
-        expect((projectRequest as RequestInit).headers).toMatchObject({
-          'x-user-api-key': 'uak_test_key',
-          'x-org-id': 'org_manual',
-        });
+        expect(fetchSpy).toHaveBeenCalledTimes(0);
 
         const fs = yield* FileSystem.FileSystem;
         const cacheDir = yield* setupCacheDir;
@@ -99,7 +74,7 @@ describe('CLI: composio manage orgs switch', () => {
         const rawUserConfig = yield* fs.readFileString(userConfigPath, 'utf8');
         const userConfig = JSON.parse(rawUserConfig) as Record<string, unknown>;
         expect(userConfig.org_id).toBe('org_manual');
-        expect(userConfig.project_id).toBe('project_1');
+        expect(userConfig.project_id).toBeUndefined();
       })
     );
   });

--- a/ts/packages/cli/test/src/commands/projects/projects.list.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/projects/projects.list.cmd.test.ts
@@ -15,7 +15,7 @@ describe('CLI: composio manage projects list', () => {
   });
 
   layer(TestLive({ fixture: 'user-config-with-global-context' }))(it => {
-    it.scoped('[Then] lists projects, marks selected global project, and shows switch hints', () =>
+    it.scoped('[Then] lists developer projects and shows init guidance', () =>
       Effect.gen(function* () {
         const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
           mockFetchResponse({
@@ -38,14 +38,12 @@ describe('CLI: composio manage projects list', () => {
 
         const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
         expect(output).toContain('Loaded 2 projects');
-        expect(output).toContain('✓ Project One (project_1)');
+        expect(output).toContain('  Project One (project_1)');
         expect(output).toContain('  Project Two (project_2)');
         expect(output).toContain(
-          'Hint: run `composio manage projects switch` to switch the default global project.'
+          'Hint: run `composio init` in a directory to bind it to a developer project.'
         );
-        expect(output).toContain(
-          'Run `composio manage orgs switch` to switch org and project together.'
-        );
+        expect(output).toContain('Run `composio manage orgs switch` to change your default org.');
       })
     );
   });

--- a/ts/packages/cli/test/src/commands/projects/projects.switch.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/projects/projects.switch.cmd.test.ts
@@ -1,67 +1,16 @@
-import path from 'node:path';
-import { ConfigProvider, Effect } from 'effect';
+import { Effect } from 'effect';
 import { describe, expect, layer } from '@effect/vitest';
-import { afterEach, vi } from 'vitest';
-import { FileSystem } from '@effect/platform';
 import { cli, MockConsole, TestLive } from 'test/__utils__';
-import * as constants from 'src/constants';
-import { setupCacheDir } from 'src/effects/setup-cache-dir';
-
-const testConfigProvider = ConfigProvider.fromMap(
-  new Map([
-    ['COMPOSIO_USER_API_KEY', 'uak_test_key'],
-    ['USER_API_KEY', 'uak_test_key'],
-  ])
-);
-
-const mockFetchResponse = (body: unknown, status = 200) =>
-  new Response(JSON.stringify(body), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  });
 
 describe('CLI: composio manage projects switch', () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  layer(TestLive({ baseConfigProvider: testConfigProvider }))(it => {
-    it.scoped(
-      '[When] --org-id is provided [Then] it switches global project and shows org hint',
-      () =>
-        Effect.gen(function* () {
-          const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-            mockFetchResponse({
-              data: [
-                { id: 'project_1', name: 'Project One' },
-                { id: 'project_2', name: 'Project Two' },
-              ],
-            })
-          );
-
-          yield* cli(['manage', 'projects', 'switch', '--org-id', 'org_manual']);
-
-          expect(fetchSpy).toHaveBeenCalledTimes(1);
-          const [projectUrl, projectRequest] = fetchSpy.mock.calls[0]!;
-          expect(projectUrl).toContain('/api/v3/org/project/list?limit=50');
-          expect((projectRequest as RequestInit).headers).toMatchObject({
-            'x-user-api-key': 'uak_test_key',
-            'x-org-id': 'org_manual',
-          });
-
-          const fs = yield* FileSystem.FileSystem;
-          const cacheDir = yield* setupCacheDir;
-          const userConfigPath = path.join(cacheDir, constants.USER_CONFIG_FILE_NAME);
-          const rawUserConfig = yield* fs.readFileString(userConfigPath, 'utf8');
-          const userConfig = JSON.parse(rawUserConfig) as Record<string, unknown>;
-          expect(userConfig.org_id).toBe('org_manual');
-          expect(userConfig.project_id).toBe('project_1');
-
-          const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
-          expect(output).toContain(
-            'To switch organization as well, run `composio manage orgs switch`.'
-          );
-        })
+  layer(TestLive())(it => {
+    it.scoped('[Then] it reports global developer project switching is deprecated', () =>
+      Effect.gen(function* () {
+        yield* cli(['manage', 'projects', 'switch']).pipe(Effect.catchAll(() => Effect.void));
+        const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
+        expect(output).toContain('Global developer project switching is no longer supported');
+        expect(output).toContain('composio init');
+      })
     );
   });
 });

--- a/ts/packages/cli/test/src/commands/tools/tools.execute.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/tools/tools.execute.cmd.test.ts
@@ -45,6 +45,7 @@ describe('CLI: composio manage tools execute', () => {
   layer(
     TestLive({
       baseConfigProvider: testConfigProvider,
+      fixture: 'global-test-user-id',
       stdin: { isTTY: true, data: '' },
     })
   )('[Given] -d inline JSON [Then] executes via Tool Router with defaults', it => {
@@ -75,6 +76,7 @@ describe('CLI: composio manage tools execute', () => {
   layer(
     TestLive({
       baseConfigProvider: testConfigProvider,
+      fixture: 'global-test-user-id',
       stdin: { isTTY: true, data: '' },
     })
   )('[Given] composio execute alias [Then] works like composio manage tools execute', it => {
@@ -223,6 +225,7 @@ describe('CLI: composio manage tools execute', () => {
   layer(
     TestLive({
       baseConfigProvider: testConfigProvider,
+      fixture: 'global-test-user-id',
       stdin: { isTTY: false, data: '{"owner":"composio"}' },
     })
   )('[Given] stdin is piped [Then] reads input from stdin', it => {
@@ -242,6 +245,7 @@ describe('CLI: composio manage tools execute', () => {
   layer(
     TestLive({
       baseConfigProvider: testConfigProvider,
+      fixture: 'global-test-user-id',
       stdin: { isTTY: true, data: '' },
       toolsExecutor: {
         failWith: new ActionExecuteConnectedAccountNotFoundError({
@@ -268,7 +272,7 @@ describe('CLI: composio manage tools execute', () => {
 
         expect(output).toContain('No connected account found');
         expect(output).toContain('Tips');
-        expect(output).toContain('composio manage connected-accounts link');
+        expect(output).toContain('composio link');
       })
     );
   });
@@ -278,6 +282,7 @@ describe('CLI: composio manage tools execute', () => {
   layer(
     TestLive({
       baseConfigProvider: testConfigProvider,
+      fixture: 'global-test-user-id',
       stdin: { isTTY: true, data: '' },
       toolRouter: {
         execute: async () => {
@@ -311,7 +316,7 @@ describe('CLI: composio manage tools execute', () => {
 
         expect(output).toContain('No active connection');
         expect(output).toContain('Tips');
-        expect(output).toContain('composio manage connected-accounts link gmail');
+        expect(output).toContain('composio link gmail');
       })
     );
   });
@@ -319,6 +324,7 @@ describe('CLI: composio manage tools execute', () => {
   layer(
     TestLive({
       baseConfigProvider: testConfigProvider,
+      fixture: 'global-test-user-id',
       stdin: { isTTY: true, data: '' },
       toolRouter: {
         execute: async (_sessionId, params) => ({
@@ -355,6 +361,7 @@ describe('CLI: composio manage tools execute', () => {
   layer(
     TestLive({
       baseConfigProvider: testConfigProvider,
+      fixture: 'global-test-user-id',
       stdin: { isTTY: true, data: '' },
       toolsExecutor: {
         failWith: {
@@ -388,6 +395,7 @@ describe('CLI: composio manage tools execute', () => {
   layer(
     TestLive({
       baseConfigProvider: testConfigProvider,
+      fixture: 'global-test-user-id',
       stdin: { isTTY: true, data: '' },
       toolsExecutor: {
         failWith: { error: { message: 'API error: invalid input' } },
@@ -420,6 +428,7 @@ describe('CLI: composio manage tools execute', () => {
   layer(
     TestLive({
       baseConfigProvider: testConfigProvider,
+      fixture: 'global-test-user-id',
       stdin: { isTTY: true, data: '' },
       toolsExecutor: {
         respondWith: {
@@ -460,6 +469,7 @@ describe('CLI: composio manage tools execute', () => {
   layer(
     TestLive({
       baseConfigProvider: testConfigProvider,
+      fixture: 'global-test-user-id',
       stdin: { isTTY: true, data: '' },
       toolsExecutor: {
         respondWith: {
@@ -501,6 +511,7 @@ describe('CLI: composio manage tools execute', () => {
   layer(
     TestLive({
       baseConfigProvider: testConfigProvider,
+      fixture: 'global-test-user-id',
       stdin: { isTTY: true, data: '' },
       toolsExecutor: {
         failWith: new ActionExecuteConnectedAccountNotFoundError({
@@ -671,6 +682,7 @@ describe('CLI: composio manage tools execute', () => {
   layer(
     TestLive({
       baseConfigProvider: testConfigProvider,
+      fixture: 'global-test-user-id',
       stdin: { isTTY: true, data: '' },
       toolsExecutor: {
         respondWith: {

--- a/ts/packages/cli/test/src/commands/tools/tools.execute.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/tools/tools.execute.cmd.test.ts
@@ -617,6 +617,7 @@ describe('CLI: composio manage tools execute', () => {
   layer(
     TestLive({
       baseConfigProvider: testConfigProvider,
+      fixture: 'global-test-user-id',
       stdin: { isTTY: true, data: '' },
       toolsExecutor: {
         respondWith: {

--- a/ts/packages/cli/test/src/commands/tools/tools.execute.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/tools/tools.execute.cmd.test.ts
@@ -80,16 +80,9 @@ describe('CLI: composio manage tools execute', () => {
       stdin: { isTTY: true, data: '' },
     })
   )('[Given] composio execute alias [Then] works like composio manage tools execute', it => {
-    it.scoped('alias expands to tools execute', () =>
+    it.scoped('root execute works for consumer flow without developer-only flags', () =>
       Effect.gen(function* () {
-        yield* cli([
-          'execute',
-          'GMAIL_SEND_EMAIL',
-          '--user-id',
-          'default',
-          '-d',
-          '{"recipient":"a"}',
-        ]);
+        yield* cli(['execute', 'GMAIL_SEND_EMAIL', '-d', '{"recipient":"a"}']);
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
         const output = parseLastJson(lines);
 
@@ -109,7 +102,7 @@ describe('CLI: composio manage tools execute', () => {
   )(
     '[Given] no --user-id and no project test_user_id [Then] falls back to global test_user_id',
     it => {
-      it.scoped('uses global test user id from user_data.json', () =>
+      it.scoped('executes without printing global test user diagnostics', () =>
         Effect.gen(function* () {
           yield* cli(['manage', 'tools', 'execute', 'GMAIL_SEND_EMAIL', '-d', '{"recipient":"a"}']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
@@ -118,7 +111,7 @@ describe('CLI: composio manage tools execute', () => {
 
           expect(output.successful).toBe(true);
           expect(output.data.tool_slug).toBe('GMAIL_SEND_EMAIL');
-          expect(text).toContain('Using global test user id "global-default"');
+          expect(text).not.toContain('Using global test user id');
         })
       );
     }
@@ -200,24 +193,15 @@ describe('CLI: composio manage tools execute', () => {
       stdin: { isTTY: true, data: '' },
     })
   )('[Given] execute-help with options before slug [Then] resolves correct slug', it => {
-    it.scoped('does not treat --user-id value as slug', () =>
+    it.scoped('resolves root execute help slug correctly', () =>
       Effect.gen(function* () {
-        yield* cli([
-          'manage',
-          'tools',
-          'execute',
-          '--user-id',
-          'default',
-          'GMAIL_SEND_EMAIL',
-          '--help',
-        ]);
+        yield* cli(['execute', 'GMAIL_SEND_EMAIL', '--help']);
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
         const output = lines.join('\n');
 
         expect(output).toContain('Slug: GMAIL_SEND_EMAIL');
         expect(output).toContain('Data Parameters:');
         expect(output).toContain('recipient');
-        expect(output).not.toContain('default');
       })
     );
   });
@@ -272,7 +256,9 @@ describe('CLI: composio manage tools execute', () => {
 
         expect(output).toContain('No connected account found');
         expect(output).toContain('Tips');
-        expect(output).toContain('composio link');
+        expect(output).toContain(
+          'composio manage connected-accounts link gmail --user-id "<user-id>"'
+        );
       })
     );
   });
@@ -316,7 +302,9 @@ describe('CLI: composio manage tools execute', () => {
 
         expect(output).toContain('No active connection');
         expect(output).toContain('Tips');
-        expect(output).toContain('composio link gmail');
+        expect(output).toContain(
+          'composio manage connected-accounts link gmail --user-id "<user-id>"'
+        );
       })
     );
   });

--- a/ts/packages/cli/test/src/commands/tools/tools.search.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/tools/tools.search.cmd.test.ts
@@ -119,8 +119,8 @@ describe('CLI: composio manage tools search', () => {
           expect(output).toContain('"CTA"');
           expect(output).toContain('"Execute a tool"');
           expect(output).toContain('"Connect a user account"');
-          expect(output).toContain('composio execute');
-          expect(output).toContain('composio link gmail');
+          expect(output).toContain('composio manage tools execute');
+          expect(output).toContain('composio manage connected-accounts link gmail');
         })
       );
     }
@@ -168,12 +168,16 @@ describe('CLI: composio manage tools search', () => {
 
           const executeCta = cta.find(c => c.action === 'Execute a tool');
           expect(executeCta).toBeTruthy();
-          expect(executeCta!.command).toContain('composio execute "GMAIL_SEND_EMAIL"');
+          expect(executeCta!.command).toContain(
+            'composio manage tools execute "GMAIL_SEND_EMAIL" --user-id "<user-id>"'
+          );
           expect(executeCta!.command).toMatch(/-d '\{"to":"","subject":"","body":""\}'/);
 
           const linkCta = cta.find(c => c.action === 'Connect a user account');
           expect(linkCta).toBeTruthy();
-          expect(linkCta!.command).toBe('composio link gmail');
+          expect(linkCta!.command).toBe(
+            'composio manage connected-accounts link gmail --user-id "<user-id>"'
+          );
         })
       );
     }
@@ -345,8 +349,12 @@ describe('CLI: composio manage tools search', () => {
           expect(output).toContain('Plan:');
           expect(output).toContain('1. Collect recipient details');
           expect(output).toContain('Hints:');
-          expect(output).toContain('composio execute "GMAIL_SEND_EMAIL" --user-id "<user-id>"');
-          expect(output).toContain(`composio link <toolkit> --user-id "<user-id>"`);
+          expect(output).toContain(
+            `composio manage tools execute "GMAIL_SEND_EMAIL" --user-id "<user-id>" -d '{}'`
+          );
+          expect(output).toContain(
+            `composio manage connected-accounts link <toolkit> --user-id "<user-id>"`
+          );
         })
       );
     }
@@ -365,9 +373,9 @@ describe('CLI: composio manage tools search', () => {
   });
 
   layer(TestLive(testLiveOptions))(
-    '[Given] explicit --user-id [Then] uses that user id for session',
+    '[Given] consumer search with explicit --user-id [Then] it still uses resolved consumer user id',
     it => {
-      it.scoped('passes user-id to session create', () =>
+      it.scoped('uses consumer user id from the resolved project context', () =>
         Effect.gen(function* () {
           let createParams: SessionCreateParams | undefined;
           const live = TestLive({
@@ -389,27 +397,30 @@ describe('CLI: composio manage tools search', () => {
             Effect.provide(live)
           );
 
-          expect(createParams?.user_id).toBe('alice');
+          expect(createParams?.user_id).toBe('consumer-user-org_test');
         })
       );
     }
   );
 
-  layer(TestLive({ baseConfigProvider: testConfigProvider }))(
-    '[Given] no test_user_id and no --user-id [Then] fails with missing user id message',
-    it => {
-      it.scoped('fails when user id cannot be resolved', () =>
-        Effect.gen(function* () {
-          const err = yield* cli(['manage', 'tools', 'search', 'send']).pipe(Effect.flip);
-          const message = err instanceof Error ? err.message : String(err);
+  layer(
+    TestLive({
+      baseConfigProvider: testConfigProvider,
+      fixture: 'user-config-with-global-context',
+      toolkitsData,
+    })
+  )('[Given] no explicit --user-id [Then] consumer search does not require one', it => {
+    it.scoped('runs without printing global test user diagnostics', () =>
+      Effect.gen(function* () {
+        yield* cli(['manage', 'tools', 'search', 'send']);
+        const lines = yield* MockConsole.getLines({ stripAnsi: true });
+        const output = lines.join('\n');
 
-          expect(message).toContain('Missing user id');
-          expect(message).toContain('--user-id');
-          expect(message).toContain('composio login');
-        })
-      );
-    }
-  );
+        expect(output).toContain('Found 2 tools');
+        expect(output).not.toContain('Using global test user id');
+      })
+    );
+  });
 
   layer(TestLive(testLiveOptions))(
     '[Given] composio search alias [Then] works like composio manage tools search',

--- a/ts/packages/cli/test/src/commands/tools/tools.search.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/tools/tools.search.cmd.test.ts
@@ -345,10 +345,8 @@ describe('CLI: composio manage tools search', () => {
           expect(output).toContain('Plan:');
           expect(output).toContain('1. Collect recipient details');
           expect(output).toContain('Hints:');
-          expect(output).toContain('composio manage tools info "GMAIL_SEND_EMAIL"');
-          expect(output).toContain(
-            `composio manage tools execute "GMAIL_SEND_EMAIL" --user-id "<user-id>" --arguments '{}'`
-          );
+          expect(output).toContain('composio execute "GMAIL_SEND_EMAIL" --user-id "<user-id>"');
+          expect(output).toContain(`composio link <toolkit> --user-id "<user-id>"`);
         })
       );
     }
@@ -407,7 +405,7 @@ describe('CLI: composio manage tools search', () => {
 
           expect(message).toContain('Missing user id');
           expect(message).toContain('--user-id');
-          expect(message).toContain('composio init');
+          expect(message).toContain('composio login');
         })
       );
     }

--- a/ts/packages/cli/test/src/commands/tools/tools.search.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/tools/tools.search.cmd.test.ts
@@ -350,7 +350,7 @@ describe('CLI: composio manage tools search', () => {
           expect(output).toContain('1. Collect recipient details');
           expect(output).toContain('Hints:');
           expect(output).toContain(
-            `composio manage tools execute "GMAIL_SEND_EMAIL" --user-id "<user-id>" -d '{}'`
+            `composio manage tools execute "GMAIL_SEND_EMAIL" --user-id "<user-id>" -d "{}"`
           );
           expect(output).toContain(
             `composio manage connected-accounts link <toolkit> --user-id "<user-id>"`

--- a/ts/packages/cli/test/src/commands/triggers/triggers.listen.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/triggers/triggers.listen.cmd.test.ts
@@ -110,6 +110,7 @@ describe('CLI: composio manage triggers listen', () => {
   layer(
     TestLive({
       baseConfigProvider: testConfigProvider,
+      fixture: 'global-test-user-id',
       realtimeData: {
         events: [mockV3TriggerEvent],
       },
@@ -133,6 +134,7 @@ describe('CLI: composio manage triggers listen', () => {
   layer(
     TestLive({
       baseConfigProvider: testConfigProvider,
+      fixture: 'global-test-user-id',
       realtimeData: {
         events: [mockV3TriggerEvent],
       },
@@ -154,6 +156,7 @@ describe('CLI: composio manage triggers listen', () => {
   layer(
     TestLive({
       baseConfigProvider: testConfigProvider,
+      fixture: 'global-test-user-id',
       realtimeData: {
         events: [mockV3TriggerEvent],
       },
@@ -196,6 +199,7 @@ describe('CLI: composio manage triggers listen', () => {
   layer(
     TestLive({
       baseConfigProvider: testConfigProvider,
+      fixture: 'global-test-user-id',
       realtimeData: { events: [mockV3TriggerEvent] },
     })
   )(
@@ -226,6 +230,7 @@ describe('CLI: composio manage triggers listen', () => {
   layer(
     TestLive({
       baseConfigProvider: testConfigProvider,
+      fixture: 'global-test-user-id',
       realtimeData: { events: [mockV3TriggerEvent] },
     })
   )('[Given] --forward [Then] sends signed webhook verifiable by composio/core', it => {

--- a/ts/packages/cli/test/src/commands/whoami.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/whoami.cmd.test.ts
@@ -19,7 +19,6 @@ describe('CLI: composio whoami', () => {
         expect(output).not.toContain(`api_key_from_test_config_provider`);
         expect(output).not.toContain(`global_user_api_key`);
         expect(output).toContain(`"default_org_id":null`);
-        expect(output).toContain(`"default_project_id":null`);
         expect(output).toContain(`"test_user_id":null`);
       })
     );
@@ -36,7 +35,6 @@ describe('CLI: composio whoami', () => {
         expect(output).not.toContain(`api_key_from_test_fixture`);
         expect(output).not.toContain(`global_user_api_key`);
         expect(output).toContain(`"default_org_id":null`);
-        expect(output).toContain(`"default_project_id":null`);
         expect(output).toContain(`"test_user_id":null`);
       })
     );

--- a/ts/packages/cli/test/src/services/test-layer.test.ts
+++ b/ts/packages/cli/test/src/services/test-layer.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Effect } from 'effect';
+import { TestLive } from 'test/__utils__';
+
+describe('TestLayer', () => {
+  it('restores globalThis.fetch after the layer scope closes', async () => {
+    const originalFetch = globalThis.fetch;
+
+    await Effect.provide(Effect.void, TestLive()).pipe(Effect.scoped, Effect.runPromise);
+
+    expect(globalThis.fetch).toBe(originalFetch);
+  });
+
+  it('does not leak the fetch mock into later spy restore cycles', async () => {
+    const originalFetch = globalThis.fetch;
+
+    await Effect.provide(Effect.void, TestLive()).pipe(Effect.scoped, Effect.runPromise);
+
+    vi.spyOn(globalThis, 'fetch');
+    vi.restoreAllMocks();
+
+    expect(globalThis.fetch).toBe(originalFetch);
+  });
+});

--- a/ts/packages/cli/vitest.config.ts
+++ b/ts/packages/cli/vitest.config.ts
@@ -3,6 +3,8 @@ import path from 'node:path';
 
 const __dirname = path.resolve(path.dirname(new URL(import.meta.url).pathname));
 const coreDir = path.resolve(__dirname, '../core');
+const tsBuildersDir = path.resolve(__dirname, '../ts-builders');
+const jsonSchemaToZodDir = path.resolve(__dirname, '../json-schema-to-zod');
 
 export default defineConfig({
   resolve: {
@@ -10,6 +12,9 @@ export default defineConfig({
       '~': path.resolve(__dirname, './'),
       src: path.resolve(__dirname, './src'),
       test: path.resolve(__dirname, './test'),
+      '@composio/core': path.join(coreDir, 'src/index.ts'),
+      '@composio/ts-builders': path.join(tsBuildersDir, 'src/index.ts'),
+      '@composio/json-schema-to-zod': path.join(jsonSchemaToZodDir, 'src/index.ts'),
       'effect-errors/*': path.resolve(__dirname, './src/effect-errors'),
       // @composio/core uses package.json "imports" (#config_defaults, #platform, etc.)
       // Vitest/Vite does not resolve these for workspace deps, so alias them explicitly

--- a/ts/packages/core/package.json
+++ b/ts/packages/core/package.json
@@ -131,7 +131,7 @@
   ],
   "scripts": {
     "clean": "git clean -xdf node_modules",
-    "build": "bun run --bun tsdown",
+    "build": "pnpm exec tsdown",
     "test": "vitest run",
     "typecheck": "tsc --noEmit --skipLibCheck && tsc --noEmit --skipLibCheck -p tsconfig.type-tests.json",
     "generate:docs": "tsx scripts/generate-docs.ts"

--- a/ts/packages/json-schema-to-zod/package.json
+++ b/ts/packages/json-schema-to-zod/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "clean": "git clean -xdf node_modules",
-    "build": "bun run --bun tsdown",
+    "build": "pnpm exec tsdown",
     "test": "vitest run",
     "typecheck:src": "tsc --noEmit -p ./tsconfig.src.json",
     "typecheck:test": "tsc --noEmit -p ./tsconfig.test.json",

--- a/ts/packages/providers/anthropic/package.json
+++ b/ts/packages/providers/anthropic/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "clean": "git clean -xdf node_modules",
-    "build": "bun run --bun tsdown",
+    "build": "pnpm exec tsdown",
     "test": "vitest run"
   },
   "keywords": [

--- a/ts/packages/providers/claude-agent-sdk/package.json
+++ b/ts/packages/providers/claude-agent-sdk/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "clean": "git clean -xdf node_modules",
-    "build": "bun run --bun tsdown",
+    "build": "pnpm exec tsdown",
     "test": "vitest run"
   },
   "keywords": [

--- a/ts/packages/providers/cloudflare/package.json
+++ b/ts/packages/providers/cloudflare/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "clean": "git clean -xdf node_modules",
-    "build": "bun run --bun tsdown",
+    "build": "pnpm exec tsdown",
     "test": "vitest run"
   },
   "keywords": [],

--- a/ts/packages/providers/google/package.json
+++ b/ts/packages/providers/google/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "clean": "git clean -xdf node_modules",
-    "build": "bun run --bun tsdown",
+    "build": "pnpm exec tsdown",
     "test": "vitest run"
   },
   "keywords": [

--- a/ts/packages/providers/langchain/package.json
+++ b/ts/packages/providers/langchain/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "clean": "git clean -xdf node_modules",
-    "build": "bun run --bun tsdown",
+    "build": "pnpm exec tsdown",
     "test": "vitest run"
   },
   "keywords": [],

--- a/ts/packages/providers/llamaindex/package.json
+++ b/ts/packages/providers/llamaindex/package.json
@@ -29,7 +29,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "bun run --bun tsdown",
+    "build": "pnpm exec tsdown",
     "test": "vitest run"
   },
   "keywords": [

--- a/ts/packages/providers/mastra/package.json
+++ b/ts/packages/providers/mastra/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "clean": "git clean -xdf node_modules",
-    "build": "bun run --bun tsdown",
+    "build": "pnpm exec tsdown",
     "test": "vitest run",
     "typecheck": "tsc --noEmit --skipLibCheck"
   },

--- a/ts/packages/providers/openai-agents/package.json
+++ b/ts/packages/providers/openai-agents/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "clean": "git clean -xdf node_modules",
-    "build": "bun run --bun tsdown",
+    "build": "pnpm exec tsdown",
     "test": "vitest run"
   },
   "keywords": [],

--- a/ts/packages/providers/openai/package.json
+++ b/ts/packages/providers/openai/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "clean": "git clean -xdf node_modules",
-    "build": "bun run --bun tsdown",
+    "build": "pnpm exec tsdown",
     "test": "vitest run"
   },
   "keywords": [],

--- a/ts/packages/providers/vercel/package.json
+++ b/ts/packages/providers/vercel/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "clean": "git clean -xdf node_modules",
-    "build": "bun run --bun tsdown",
+    "build": "pnpm exec tsdown",
     "test": "vitest run"
   },
   "keywords": [],

--- a/ts/packages/ts-builders/package.json
+++ b/ts/packages/ts-builders/package.json
@@ -35,7 +35,7 @@
   },
   "scripts": {
     "clean": "git clean -xdf node_modules",
-    "build": "bun run --bun tsdown",
+    "build": "pnpm exec tsdown",
     "test": "vitest run"
   },
   "files": [

--- a/tsdown.config.base.ts
+++ b/tsdown.config.base.ts
@@ -1,5 +1,9 @@
 import type { UserConfig, OutExtensionContext } from 'tsdown';
 
+// Turbo task execution triggers a tsdown ATTW tarball path bug for scoped packages.
+// Keep ATTW for direct package builds, but disable it for workspace builds.
+const isTurboTask = Boolean(process.env.TURBO_HASH);
+
 /**
  * tsdown config with shared defaults.
  * Package-specific options (e.g., entry, outDir, outExtensions) can be overridden by the caller.
@@ -77,7 +81,7 @@ export const baseConfig = {
    */
   attw: {
     entrypoints: ['.'],
-    enabled: true,
+    enabled: !isTurboTask,
     level: 'error',
     profile: 'node16',
     ignoreRules: [/* Node.js 10 only, attw doesn't automatically exclude it despite the selected profile */ 'internal-resolution-error'],


### PR DESCRIPTION
## Summary
- make top-level `composio search`, `composio link`, and `composio execute` consumer-only
- keep developer-scoped usage under `composio manage ...`
- remove developer-only flags from root help and add short related-command hints
- use `consumer_user_id` from consumer project resolve and stop showing internal test-user/project diagnostics on consumer flows

## Testing
- `pnpm -C ts/packages/cli exec tsc --noEmit -p ./tsconfig.src.json`
- `pnpm -C ts/packages/cli test -- --runInBand`

will show you the top level commands working

```
export COMPOSIO_BASE_URL="https://apollo-k05mgspn8-composio.vercel.app/"
export COMPOSIO_WEB_URL="https://dashboard-git-t3code-cli-landing-redesign-composio.vercel.app/"
pnpm -C ts/packages/cli run cli -- login
```