### PR TITLE
bump cli version for support consumer experience

### DIFF
--- a/.changeset/vast-showers-lose.md
+++ b/.changeset/vast-showers-lose.md
@@ -1,6 +1,0 @@
----
-'@composio/cli': patch
----
-
-- Execute: Default to empty object `{}` when no -d/--data or piped stdin provided
-- Search CTA: Use `-d "{}"` for tools with no schema properties (shell-safe)

--- a/ts/packages/cli/CHANGELOG.md
+++ b/ts/packages/cli/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @composio/cli
 
+## 0.3.0
+
+### Minor Changes
+
+- move how the cli auth works for top level commands
+
+### Patch Changes
+
+- 68c6e50: - Execute: Default to empty object `{}` when no -d/--data or piped stdin provided
+  - Search CTA: Use `-d "{}"` for tools with no schema properties (shell-safe)
+
 ## 0.2.6
 
 ### Patch Changes

--- a/ts/packages/cli/package.json
+++ b/ts/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/cli",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "description": "Composio CLI",
   "main": "./dist/bin.mjs",
   "private": true,


### PR DESCRIPTION
this is breaking for users on `search`, `execute` and `link`