### PR TITLE
chore: CLI release changeset

### DIFF
--- a/.changeset/vast-showers-lose.md
+++ b/.changeset/vast-showers-lose.md
@@ -1,0 +1,6 @@
+---
+'@composio/cli': patch
+---
+
+- Execute: Default to empty object `{}` when no -d/--data or piped stdin provided
+- Search CTA: Use `-d "{}"` for tools with no schema properties (shell-safe)

--- a/.changeset/vast-showers-lose.md
+++ b/.changeset/vast-showers-lose.md
@@ -2,5 +2,9 @@
 '@composio/cli': patch
 ---
 
+- Make top-level `composio search`, `composio link`, and `composio execute` consumer-only
+- Keep developer-scoped usage under `composio manage ...`
+- Remove developer-only flags from root help and add short related-command hints
+- Use `consumer_user_id` from consumer project resolve for consumer flows
 - Execute: Default to empty object `{}` when no -d/--data or piped stdin provided
 - Search CTA: Use `-d "{}"` for tools with no schema properties (shell-safe)

--- a/ts/packages/cli/CHANGELOG.md
+++ b/ts/packages/cli/CHANGELOG.md
@@ -1,16 +1,5 @@
 # @composio/cli
 
-## 0.3.0
-
-### Minor Changes
-
-- move how the cli auth works for top level commands
-
-### Patch Changes
-
-- 68c6e50: - Execute: Default to empty object `{}` when no -d/--data or piped stdin provided
-  - Search CTA: Use `-d "{}"` for tools with no schema properties (shell-safe)
-
 ## 0.2.6
 
 ### Patch Changes

--- a/ts/packages/cli/package.json
+++ b/ts/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/cli",
-  "version": "0.3.0",
+  "version": "0.2.6",
   "description": "Composio CLI",
   "main": "./dist/bin.mjs",
   "private": true,


### PR DESCRIPTION
## Summary
- Reverts accidental local changeset consumption
- Updates changeset description to include consumer-only CLI changes

## Test plan
- CI will pick up the changeset and auto-release CLI patch version

🤖 Generated with [Claude Code](https://claude.com/claude-code)