### PR TITLE
feat(ci): add DevSecOps security scanning workflows

### DIFF
--- a/.github/secret_scanning.yml
+++ b/.github/secret_scanning.yml
@@ -1,0 +1,11 @@
+paths-ignore:
+  - "**/*.test.ts"
+  - "**/*.spec.ts"
+  - "**/test_*.py"
+  - "**/*_test.py"
+  - "**/testdata/**"
+  - "**/fixtures/**"
+  - "**/__mocks__/**"
+  - "**/*.md"
+  - "docs/**"
+  - "fern/**"

--- a/.github/semgrep-rules/composio-security.yaml
+++ b/.github/semgrep-rules/composio-security.yaml
@@ -1,0 +1,131 @@
+rules:
+  - id: composio-python-subprocess-shell
+    patterns:
+      - pattern: subprocess.$FUNC(..., shell=True, ...)
+    message: >
+      Subprocess call with shell=True is vulnerable to command injection.
+      Use shell=False and pass arguments as a list instead.
+    languages: [python]
+    severity: ERROR
+    metadata:
+      cwe:
+        - "CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"
+      category: security
+      technology:
+        - python
+
+  - id: composio-python-sql-fstring
+    patterns:
+      - pattern: $CURSOR.execute(f"...", ...)
+      - pattern: $CURSOR.execute("...".format(...), ...)
+    message: >
+      SQL query built with f-string or .format() is vulnerable to SQL injection.
+      Use parameterized queries instead.
+    languages: [python]
+    severity: ERROR
+    metadata:
+      cwe:
+        - "CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')"
+      category: security
+      technology:
+        - python
+
+  - id: composio-python-pickle-load
+    patterns:
+      - pattern: pickle.load(...)
+      - pattern: pickle.loads(...)
+    message: >
+      Deserializing untrusted data with pickle can lead to remote code execution.
+      Use safer alternatives like json for data serialization.
+    languages: [python]
+    severity: WARNING
+    metadata:
+      cwe:
+        - "CWE-502: Deserialization of Untrusted Data"
+      category: security
+      technology:
+        - python
+
+  - id: composio-python-eval
+    patterns:
+      - pattern: eval(...)
+      - pattern: exec(...)
+    message: >
+      Use of eval() or exec() can lead to code injection.
+      Avoid dynamic code execution with untrusted input.
+    languages: [python]
+    severity: ERROR
+    metadata:
+      cwe:
+        - "CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')"
+      category: security
+      technology:
+        - python
+
+  - id: composio-python-hardcoded-password
+    patterns:
+      - pattern: password = "..."
+      - pattern: secret = "..."
+    message: >
+      Hardcoded password or secret detected. Use environment variables
+      or a secrets manager instead.
+    languages: [python]
+    severity: WARNING
+    metadata:
+      cwe:
+        - "CWE-798: Use of Hard-coded Credentials"
+      category: security
+      technology:
+        - python
+
+  - id: composio-no-raw-fetch
+    patterns:
+      - pattern: fetch(...)
+    message: >
+      Direct use of fetch() detected. Use a safeFetch wrapper that includes
+      SSRF protections and consistent error handling.
+    languages: [typescript, javascript]
+    severity: ERROR
+    metadata:
+      cwe:
+        - "CWE-918: Server-Side Request Forgery (SSRF)"
+      category: security
+      technology:
+        - typescript
+        - javascript
+
+  - id: composio-weak-hash
+    patterns:
+      - pattern: crypto.createHash("md5")
+      - pattern: crypto.createHash("sha1")
+    message: >
+      Weak hash algorithm detected. MD5 and SHA-1 are cryptographically broken.
+      Use SHA-256 or stronger algorithms.
+    languages: [typescript, javascript]
+    severity: WARNING
+    metadata:
+      cwe:
+        - "CWE-328: Use of Weak Hash"
+      category: security
+      technology:
+        - typescript
+        - javascript
+
+  - id: composio-no-console-log-secrets
+    patterns:
+      - pattern: console.log(<... $SECRET ...>)
+    message: >
+      Potential secret logged to console. Ensure sensitive values
+      (passwords, tokens, API keys) are never logged.
+    languages: [typescript, javascript]
+    severity: WARNING
+    metadata:
+      cwe:
+        - "CWE-532: Insertion of Sensitive Information into Log File"
+      category: security
+      technology:
+        - typescript
+        - javascript
+      pattern-metavariable:
+        $SECRET:
+          regex: "(password|secret|token|apiKey|api_key|private_key|accessToken|auth)"

--- a/.github/workflows/sast-codeql.yml
+++ b/.github/workflows/sast-codeql.yml
@@ -1,0 +1,77 @@
+name: "SAST - CodeQL"
+
+on:
+  push:
+    branches: [master, next]
+  pull_request:
+    branches: [master, next]
+  schedule:
+    - cron: "0 6 * * 1"
+
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  codeql-javascript:
+    name: CodeQL - JavaScript/TypeScript
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          queries: security-extended
+          paths: ts/
+          paths-ignore: |
+            ts/**/*.test.ts
+            ts/**/*.spec.ts
+            ts/**/test/
+            ts/**/tests/
+            ts/**/__tests__/
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:javascript-typescript"
+
+  codeql-python:
+    name: CodeQL - Python
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: python
+          queries: security-extended
+          paths: python/
+          paths-ignore: |
+            python/**/test_*.py
+            python/**/*_test.py
+            python/**/tests/
+            python/**/test/
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:python"

--- a/.github/workflows/sast-semgrep.yml
+++ b/.github/workflows/sast-semgrep.yml
@@ -1,0 +1,59 @@
+name: "SAST - Semgrep"
+
+on:
+  push:
+    branches: [master, next]
+  pull_request:
+    branches: [master, next]
+
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  semgrep:
+    name: Semgrep SAST Scan
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run Semgrep scan
+        run: |
+          semgrep scan \
+            --config "p/owasp-top-ten" \
+            --config "p/python" \
+            --config "p/typescript" \
+            --config "p/nodejs" \
+            --config "p/sql-injection" \
+            --config "p/xss" \
+            --config "p/command-injection" \
+            --config "p/supply-chain" \
+            --config ".github/semgrep-rules" \
+            --error \
+            --severity ERROR \
+            --sarif \
+            --output semgrep-results.sarif \
+            --exclude "node_modules" \
+            --exclude "dist" \
+            --exclude "__pycache__" \
+            --exclude ".venv" \
+            --exclude "*.test.ts" \
+            --exclude "*.spec.ts" \
+            --exclude "*_test.py" \
+            --exclude "docs/" \
+            --exclude "fern/"
+
+      - name: Upload SARIF to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: semgrep-results.sarif

--- a/.github/workflows/security-dependency-audit.yml
+++ b/.github/workflows/security-dependency-audit.yml
@@ -1,0 +1,121 @@
+name: "Security - Dependency Audit"
+
+on:
+  push:
+    branches: [master, next]
+    paths:
+      - "package.json"
+      - "ts/**/package.json"
+      - "pnpm-lock.yaml"
+      - "yarn.lock"
+      - "**/package-lock.json"
+  pull_request:
+    branches: [master, next]
+    paths:
+      - "package.json"
+      - "ts/**/package.json"
+      - "pnpm-lock.yaml"
+      - "yarn.lock"
+      - "**/package-lock.json"
+  schedule:
+    - cron: "0 7 * * *"
+
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write
+  pull-requests: write
+
+jobs:
+  npm-audit:
+    name: npm/pnpm Audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: ts/
+        continue-on-error: true
+
+      - name: Run pnpm audit
+        id: pnpm_audit
+        run: pnpm audit --severity high 2>&1 | tee audit-results.txt
+        working-directory: ts/
+        continue-on-error: true
+
+      - name: Post results to PR on failure
+        if: steps.pnpm_audit.outcome == 'failure' && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const results = fs.readFileSync('ts/audit-results.txt', 'utf8');
+            const body = `## pnpm audit: Vulnerabilities Found (high/critical)
+
+            \`\`\`
+            ${results.substring(0, 60000)}
+            \`\`\`
+
+            Please review and update the affected dependencies.`;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: body
+            });
+
+      - name: Fail on high/critical vulnerabilities
+        if: steps.pnpm_audit.outcome == 'failure'
+        run: exit 1
+
+  license-check:
+    name: License Compliance Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: ts/
+        continue-on-error: true
+
+      - name: Install license-checker
+        run: npm install -g license-checker
+
+      - name: Check for copyleft licenses
+        run: |
+          license-checker \
+            --failOn "GPL-2.0-only;GPL-2.0-or-later;GPL-3.0-only;GPL-3.0-or-later;AGPL-1.0-only;AGPL-3.0-only;AGPL-3.0-or-later;SSPL-1.0;EUPL-1.1;EUPL-1.2;CPAL-1.0;OSL-3.0;RPL-1.1;RPL-1.5;Sleepycat;Watcom-1.0" \
+            --summary
+        working-directory: ts/

--- a/.github/workflows/security-python.yml
+++ b/.github/workflows/security-python.yml
@@ -1,0 +1,99 @@
+name: "Security - Python"
+
+on:
+  push:
+    branches: [master, next]
+    paths:
+      - "python/**"
+  pull_request:
+    branches: [master, next]
+    paths:
+      - "python/**"
+
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write
+  pull-requests: write
+
+jobs:
+  bandit:
+    name: Bandit Static Analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Bandit
+        run: pip install bandit[sarif]
+
+      - name: Run Bandit scan
+        run: bandit -r python/ -f sarif -o bandit-results.sarif -ll
+        continue-on-error: true
+
+      - name: Upload SARIF to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: bandit-results.sarif
+
+  pip-audit:
+    name: pip-audit Dependency Scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Python package
+        run: pip install ./python/
+
+      - name: Install pip-audit
+        run: pip install pip-audit
+
+      - name: Run pip-audit
+        id: pip_audit
+        run: pip-audit --severity high 2>&1 | tee pip-audit-results.txt
+        continue-on-error: true
+
+      - name: Post results to PR on failure
+        if: steps.pip_audit.outcome == 'failure' && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const results = fs.readFileSync('pip-audit-results.txt', 'utf8');
+            const body = `## pip-audit: Vulnerable Dependencies Found
+
+            \`\`\`
+            ${results.substring(0, 60000)}
+            \`\`\`
+
+            Please review and update the affected dependencies.`;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: body
+            });
+
+      - name: Fail on vulnerabilities
+        if: steps.pip_audit.outcome == 'failure'
+        run: exit 1


### PR DESCRIPTION
## Summary
- Add **Semgrep SAST** with OWASP Top 10, Python, TypeScript, SQLi, XSS, command injection rulesets + 8 custom Composio rules (subprocess shell=True, SQL f-string injection, pickle deserialization, eval/exec, hardcoded passwords, raw fetch SSRF, weak hashes, secret logging)
- Add **CodeQL** for Python and TypeScript with security-extended queries (PR + weekly schedule)
- Add **Bandit** for Python-specific static analysis + **pip-audit** for Python dependency CVEs
- Add **npm audit** (high/critical) + **license compliance** checks on dependency changes
- Enable **GitHub native secret scanning push protection**, validity checks, and non-provider patterns
- Remove gitleaks workflow (superseded by GitHub secret scanning push protection)
- Add `secret_scanning.yml` to exclude test fixtures and docs from false positives

## Test plan
- [ ] Verify Semgrep workflow runs on a test PR and uploads SARIF to Security tab
- [ ] Verify CodeQL initializes and analyzes both Python and JS/TS
- [ ] Verify Bandit and pip-audit jobs complete without false blocking
- [ ] Verify npm audit posts PR comment when vulnerabilities are found
- [ ] Verify secret scanning push protection blocks a test secret push

🤖 Generated with [Claude Code](https://claude.com/claude-code)