### PR TITLE
docs: custom tools meta tools integration, verification, and programmatic execution

### DIFF
--- a/docs/content/docs/toolkits/custom-tools-and-toolkits.mdx
+++ b/docs/content/docs/toolkits/custom-tools-and-toolkits.mdx
@@ -114,11 +114,14 @@ Custom tools integrate seamlessly with Composio's meta tools:
 - **`COMPOSIO_MANAGE_CONNECTIONS`** handles auth for extension tools — if a tool extends `gmail`, the agent can prompt the user to connect Gmail just like any other toolkit
 - Custom tools are **not supported in Workbench** — the LLM is made aware of this and will not attempt to use them there
 
-## Tool naming
+## Best practices
 
-Tool names exposed to the agent are automatically prefixed with `LOCAL_` and the toolkit name (if any). For example, `GET_USER_PROFILE` becomes `LOCAL_GET_USER_PROFILE`, and `ASSIGN_ROLE` inside `USER_MANAGEMENT` becomes `LOCAL_USER_MANAGEMENT_ASSIGN_ROLE`.
+- **Descriptive names and slugs** — The agent sees your tool's name and description to decide when to use it. Be specific: "Send weekly promo email" is better than "Send email". Slugs should be uppercase with underscores: `SEND_PROMO_EMAIL`.
+- **Detailed descriptions** — Include what the tool does, when to use it, and what it returns. The agent relies on this to pick the right tool.
+- **Use `extendsToolkit` for auth** — If your tool needs Gmail/GitHub/etc. auth for `ctx.proxyExecute()` or `ctx.execute()`, set `extendsToolkit` so connection management is handled seamlessly via `COMPOSIO_MANAGE_CONNECTIONS`.
+- **Tool names get prefixed** — Slugs exposed to the agent are automatically prefixed with `LOCAL_` and the toolkit name (if any). `GET_USER_PROFILE` becomes `LOCAL_GET_USER_PROFILE`, `ASSIGN_ROLE` in `USER_MANAGEMENT` becomes `LOCAL_USER_MANAGEMENT_ASSIGN_ROLE`. Your slugs cannot start with `LOCAL_` — this prefix is reserved.
 
-Registered slugs cannot start with `LOCAL_` — this prefix is reserved.
+For more best practices, see [How to Build Tools for AI Agents: A Field Guide](https://composio.dev/blog/how-to-build-tools-for-ai-agents-a-field-guide).
 
 ## Verifying registration
 

--- a/docs/content/docs/toolkits/custom-tools-and-toolkits.mdx
+++ b/docs/content/docs/toolkits/custom-tools-and-toolkits.mdx
@@ -118,7 +118,7 @@ Custom tools integrate seamlessly with Composio's meta tools:
 
 Tool names exposed to the agent are automatically prefixed with `LOCAL_` and the toolkit name (if any). For example, `GET_USER_PROFILE` becomes `LOCAL_GET_USER_PROFILE`, and `ASSIGN_ROLE` inside `USER_MANAGEMENT` becomes `LOCAL_USER_MANAGEMENT_ASSIGN_ROLE`.
 
-Registered slugs cannot start with `LOCAL_` or `COMPOSIO_` — these prefixes are reserved.
+Registered slugs cannot start with `LOCAL_` — this prefix is reserved.
 
 ## Verifying registration
 

--- a/docs/content/docs/toolkits/custom-tools-and-toolkits.mdx
+++ b/docs/content/docs/toolkits/custom-tools-and-toolkits.mdx
@@ -9,7 +9,7 @@ Custom tools are experimental. The `experimental_` prefix and `experimental` ses
 </Callout>
 
 <Callout type="info">
-Custom tools work with **native tools** (`session.tools()`). MCP support is coming soon.
+Custom tools work with **native tools** (`session.tools()`). MCP support is coming soon — custom tools are not available via the MCP server URL yet.
 </Callout>
 
 Custom tools let you define tools that run in-process alongside remote Composio tools within a session. There are three patterns:
@@ -103,6 +103,74 @@ const session = await composio.create("user_1", {
 
 const tools = await session.tools();
 ```
+
+## How custom tools work with meta tools
+
+Custom tools integrate seamlessly with Composio's meta tools:
+
+- **`COMPOSIO_SEARCH_TOOLS`** automatically includes your custom tools and toolkits in search results, giving slight priority to tools that don't require auth or are already connected
+- **`COMPOSIO_GET_TOOL_SCHEMAS`** returns schemas for custom tools alongside remote tools — the agent sees them as first-class tools
+- **`COMPOSIO_MULTI_EXECUTE_TOOL`** intelligently splits execution — custom tools run in-process while remote tools go to the backend, results are merged transparently
+- **`COMPOSIO_MANAGE_CONNECTIONS`** handles auth for extension tools — if a tool extends `gmail`, the agent can prompt the user to connect Gmail just like any other toolkit
+- Custom tools are **not supported in Workbench** — the LLM is made aware of this and will not attempt to use them there
+
+## Tool naming
+
+Tool names exposed to the agent are automatically prefixed with `LOCAL_` and the toolkit name (if any):
+
+- `GET_USER_PROFILE` → `LOCAL_GET_USER_PROFILE`
+- `SEND_PROMO_EMAIL` → `LOCAL_SEND_PROMO_EMAIL`
+- `ASSIGN_ROLE` in `USER_MANAGEMENT` toolkit → `LOCAL_USER_MANAGEMENT_ASSIGN_ROLE`
+
+Slugs cannot start with `LOCAL_` or `COMPOSIO_` — these prefixes are reserved.
+
+## Verifying registration
+
+After creating a session, use `session.customTools()` and `session.customToolkits()` to verify your tools were registered correctly:
+
+```typescript
+import { Composio, experimental_createTool, experimental_createToolkit } from "@composio/core";
+import { z } from "zod/v3";
+
+const getUserProfile = experimental_createTool("GET_USER_PROFILE", { name: "Get user profile", description: "Retrieve profile", inputParams: z.object({}), execute: async (_input, ctx) => ({}) });
+const userManagement = experimental_createToolkit("USER_MANAGEMENT", { name: "User management", description: "Manage roles", tools: [experimental_createTool("ASSIGN_ROLE", { name: "Assign role", description: "Assign role", inputParams: z.object({ user_id: z.string() }), execute: async () => ({}) })] });
+const composio = new Composio({ apiKey: "your_api_key" });
+const session = await composio.create("user_1", { experimental: { customTools: [getUserProfile], customToolkits: [userManagement] } });
+// ---cut---
+// List all registered custom tools (with their final LOCAL_ prefixed slugs)
+const registeredTools = session.customTools();
+console.log(registeredTools);
+// [{ slug: "LOCAL_GET_USER_PROFILE", name: "Get user profile", ... }]
+
+// Filter by toolkit
+const managementTools = session.customTools({ toolkit: "USER_MANAGEMENT" });
+
+// List registered custom toolkits
+const registeredToolkits = session.customToolkits();
+console.log(registeredToolkits);
+// [{ slug: "USER_MANAGEMENT", name: "User management", tools: [...] }]
+```
+
+## Programmatic execution
+
+Use `session.execute()` to run custom tools directly — outside of an agent loop. You can use the original slug without the `LOCAL_` prefix:
+
+```typescript
+import { Composio, experimental_createTool } from "@composio/core";
+import { z } from "zod/v3";
+
+const getUserProfile = experimental_createTool("GET_USER_PROFILE", { name: "Get user profile", description: "Retrieve profile", inputParams: z.object({}), execute: async (_input, ctx) => ({ name: "Alice", tier: "enterprise" }) });
+const composio = new Composio({ apiKey: "your_api_key" });
+const session = await composio.create("user_1", { experimental: { customTools: [getUserProfile] } });
+// ---cut---
+// Both work — original slug or full LOCAL_ prefixed slug
+const result = await session.execute("GET_USER_PROFILE");
+const same = await session.execute("LOCAL_GET_USER_PROFILE");
+
+console.log(result.data); // { name: "Alice", tier: "enterprise" }
+```
+
+Custom tools execute in-process. Remote Composio tools are sent to the backend automatically.
 
 ## SessionContext
 

--- a/docs/content/docs/toolkits/custom-tools-and-toolkits.mdx
+++ b/docs/content/docs/toolkits/custom-tools-and-toolkits.mdx
@@ -116,61 +116,17 @@ Custom tools integrate seamlessly with Composio's meta tools:
 
 ## Tool naming
 
-Tool names exposed to the agent are automatically prefixed with `LOCAL_` and the toolkit name (if any):
+Tool names exposed to the agent are automatically prefixed with `LOCAL_` and the toolkit name (if any). For example, `GET_USER_PROFILE` becomes `LOCAL_GET_USER_PROFILE`, and `ASSIGN_ROLE` inside `USER_MANAGEMENT` becomes `LOCAL_USER_MANAGEMENT_ASSIGN_ROLE`.
 
-- `GET_USER_PROFILE` → `LOCAL_GET_USER_PROFILE`
-- `SEND_PROMO_EMAIL` → `LOCAL_SEND_PROMO_EMAIL`
-- `ASSIGN_ROLE` in `USER_MANAGEMENT` toolkit → `LOCAL_USER_MANAGEMENT_ASSIGN_ROLE`
-
-Slugs cannot start with `LOCAL_` or `COMPOSIO_` — these prefixes are reserved.
+Registered slugs cannot start with `LOCAL_` or `COMPOSIO_` — these prefixes are reserved.
 
 ## Verifying registration
 
-After creating a session, use `session.customTools()` and `session.customToolkits()` to verify your tools were registered correctly:
-
-```typescript
-import { Composio, experimental_createTool, experimental_createToolkit } from "@composio/core";
-import { z } from "zod/v3";
-
-const getUserProfile = experimental_createTool("GET_USER_PROFILE", { name: "Get user profile", description: "Retrieve profile", inputParams: z.object({}), execute: async (_input, ctx) => ({}) });
-const userManagement = experimental_createToolkit("USER_MANAGEMENT", { name: "User management", description: "Manage roles", tools: [experimental_createTool("ASSIGN_ROLE", { name: "Assign role", description: "Assign role", inputParams: z.object({ user_id: z.string() }), execute: async () => ({}) })] });
-const composio = new Composio({ apiKey: "your_api_key" });
-const session = await composio.create("user_1", { experimental: { customTools: [getUserProfile], customToolkits: [userManagement] } });
-// ---cut---
-// List all registered custom tools (with their final LOCAL_ prefixed slugs)
-const registeredTools = session.customTools();
-console.log(registeredTools);
-// [{ slug: "LOCAL_GET_USER_PROFILE", name: "Get user profile", ... }]
-
-// Filter by toolkit
-const managementTools = session.customTools({ toolkit: "USER_MANAGEMENT" });
-
-// List registered custom toolkits
-const registeredToolkits = session.customToolkits();
-console.log(registeredToolkits);
-// [{ slug: "USER_MANAGEMENT", name: "User management", tools: [...] }]
-```
+Use `session.customTools()` to list registered tools (with their final `LOCAL_` prefixed slugs), or filter by toolkit with `session.customTools({ toolkit: "USER_MANAGEMENT" })`. Use `session.customToolkits()` to list registered toolkits.
 
 ## Programmatic execution
 
-Use `session.execute()` to run custom tools directly — outside of an agent loop. You can use the original slug without the `LOCAL_` prefix:
-
-```typescript
-import { Composio, experimental_createTool } from "@composio/core";
-import { z } from "zod/v3";
-
-const getUserProfile = experimental_createTool("GET_USER_PROFILE", { name: "Get user profile", description: "Retrieve profile", inputParams: z.object({}), execute: async (_input, ctx) => ({ name: "Alice", tier: "enterprise" }) });
-const composio = new Composio({ apiKey: "your_api_key" });
-const session = await composio.create("user_1", { experimental: { customTools: [getUserProfile] } });
-// ---cut---
-// Both work — original slug or full LOCAL_ prefixed slug
-const result = await session.execute("GET_USER_PROFILE");
-const same = await session.execute("LOCAL_GET_USER_PROFILE");
-
-console.log(result.data); // { name: "Alice", tier: "enterprise" }
-```
-
-Custom tools execute in-process. Remote Composio tools are sent to the backend automatically.
+Use `session.execute()` to run custom tools directly, outside of an agent loop. Accepts the original slug — no `LOCAL_` prefix needed (e.g. `session.execute("GET_USER_PROFILE")`). Custom tools execute in-process; remote tools are sent to the backend automatically.
 
 ## SessionContext
 

--- a/docs/content/docs/toolkits/custom-tools-and-toolkits.mdx
+++ b/docs/content/docs/toolkits/custom-tools-and-toolkits.mdx
@@ -126,7 +126,7 @@ Use `session.customTools()` to list registered tools (with their final `LOCAL_` 
 
 ## Programmatic execution
 
-Use `session.execute()` to run custom tools directly, outside of an agent loop. Accepts the original slug — no `LOCAL_` prefix needed (e.g. `session.execute("GET_USER_PROFILE")`). Custom tools execute in-process; remote tools are sent to the backend automatically.
+Use `session.execute()` to run custom tools directly, outside of an agent loop (e.g. `session.execute("GET_USER_PROFILE")`). Custom tools execute in-process; remote tools are sent to the backend automatically.
 
 ## SessionContext
 

--- a/docs/content/docs/tools-direct/custom-tools.mdx
+++ b/docs/content/docs/tools-direct/custom-tools.mdx
@@ -6,7 +6,7 @@ llmGuardrails: "direct-execution"
 ---
 
 <Callout type="info">
-If you're building an agent, we recommend using [sessions](/docs/configuring-sessions) instead. See [Tools and toolkits](/docs/tools-and-toolkits) for how sessions discover and execute tools automatically.
+If you're building an agent, we recommend using [sessions](/docs/configuring-sessions) instead. See [Custom Tools and Toolkits (Experimental)](/docs/toolkits/custom-tools-and-toolkits) for defining local tools that run in-process alongside remote Composio tools within a session.
 </Callout>
 
 Custom tools allow you to create your own tools that can be used with Composio.

--- a/ts/packages/core/src/models/CustomTool.ts
+++ b/ts/packages/core/src/models/CustomTool.ts
@@ -83,6 +83,11 @@ function validateSlugLength(toolSlug: string, toolkitSlug: string | undefined, c
  * Just return the result data from `execute`, or throw an error.
  * The SDK wraps it into the standard response format internally.
  *
+ * **Slug naming:** The slug you provide is automatically prefixed with `LOCAL_` when
+ * exposed to the agent (e.g. `'GREP'` becomes `LOCAL_GREP`). If the tool is inside a
+ * custom toolkit, the toolkit slug is also included (e.g. `LOCAL_DEV_TOOLS_GREP`).
+ * The `LOCAL_` and `COMPOSIO_` prefixes are reserved and cannot be used in your slug.
+ *
  * @param slug - Unique tool identifier (alphanumeric, underscores, hyphens; no LOCAL_ or COMPOSIO_ prefix)
  * @param options - Tool definition including name, schema, and execute function
  * @returns A CustomTool to pass to session creation
@@ -181,6 +186,10 @@ export function createCustomTool<T extends z.ZodType>(
  * Create a custom toolkit that groups related tools.
  *
  * Tools passed here must NOT have `extendsToolkit` set — they inherit the toolkit identity instead.
+ *
+ * **Slug naming:** The toolkit slug becomes part of the final tool slug exposed to the agent.
+ * For example, a toolkit `'DEV_TOOLS'` with a tool `'GREP'` produces `LOCAL_DEV_TOOLS_GREP`.
+ * The `LOCAL_` and `COMPOSIO_` prefixes are reserved and cannot be used in your slug.
  *
  * @param slug - Unique toolkit identifier (alphanumeric, underscores, hyphens; no LOCAL_ or COMPOSIO_ prefix)
  * @param options - Toolkit definition including name, description, and tools

--- a/ts/packages/core/src/models/CustomTool.ts
+++ b/ts/packages/core/src/models/CustomTool.ts
@@ -86,7 +86,7 @@ function validateSlugLength(toolSlug: string, toolkitSlug: string | undefined, c
  * **Slug naming:** The slug you provide is automatically prefixed with `LOCAL_` when
  * exposed to the agent (e.g. `'GREP'` becomes `LOCAL_GREP`). If the tool is inside a
  * custom toolkit, the toolkit slug is also included (e.g. `LOCAL_DEV_TOOLS_GREP`).
- * The `LOCAL_` and `COMPOSIO_` prefixes are reserved and cannot be used in your slug.
+ * The `LOCAL_` prefix is reserved and cannot be used in your slug.
  *
  * @param slug - Unique tool identifier (alphanumeric, underscores, hyphens; no LOCAL_ or COMPOSIO_ prefix)
  * @param options - Tool definition including name, schema, and execute function
@@ -189,7 +189,7 @@ export function createCustomTool<T extends z.ZodType>(
  *
  * **Slug naming:** The toolkit slug becomes part of the final tool slug exposed to the agent.
  * For example, a toolkit `'DEV_TOOLS'` with a tool `'GREP'` produces `LOCAL_DEV_TOOLS_GREP`.
- * The `LOCAL_` and `COMPOSIO_` prefixes are reserved and cannot be used in your slug.
+ * The `LOCAL_` prefix is reserved and cannot be used in your slug.
  *
  * @param slug - Unique toolkit identifier (alphanumeric, underscores, hyphens; no LOCAL_ or COMPOSIO_ prefix)
  * @param options - Toolkit definition including name, description, and tools


### PR DESCRIPTION
## Summary
Follow-up to #2966 based on dogfooding feedback. Adds:

- **Meta tools integration** — how custom tools work with `COMPOSIO_SEARCH_TOOLS`, `COMPOSIO_GET_TOOL_SCHEMAS`, `COMPOSIO_MULTI_EXECUTE_TOOL`, and `COMPOSIO_MANAGE_CONNECTIONS`
- **Workbench caveat** — custom tools not supported in Workbench, LLM is made aware
- **Tool naming** — documents `LOCAL_` prefix + toolkit name auto-prefixing with examples
- **Verification** — `session.customTools()` and `session.customToolkits()` to verify registration
- **Programmatic execution** — `session.execute()` with original slug (no `LOCAL_` prefix needed)
- **Old custom tools callout** — updated `tools-direct/custom-tools.mdx` to point to new experimental API

## Test plan
- [ ] Verify `bun run build` passes (Twoslash type-checking)
- [ ] Check page renders at `/docs/toolkits/custom-tools-and-toolkits`

🤖 Generated with [Claude Code](https://claude.com/claude-code)