### PR TITLE
chore: change workbench.enable changeset from minor to patch

### DIFF
--- a/.changeset/workbench-enable-config.md
+++ b/.changeset/workbench-enable-config.md
@@ -1,5 +1,5 @@
 ---
-'@composio/core': minor
+'@composio/core': patch
 ---
 
 Add `workbench.enable` option to session config for disabling the workbench entirely. When set to `false`, code execution tools (COMPOSIO_REMOTE_WORKBENCH, COMPOSIO_REMOTE_BASH_TOOL) are excluded from the session. Defaults to `true`.


### PR DESCRIPTION
## Summary
Downgrades the changeset for the `workbench.enable` feature from `minor` to `patch`. The feature is additive and backwards compatible — a patch bump is sufficient.

## Changes
- `.changeset/workbench-enable-config.md`: `minor` → `patch`

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor/Chore
- [ ] Documentation
- [ ] Breaking change

## How Has This Been Tested?
N/A — changeset metadata only.

## Checklist
- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed
- [ ] I updated documentation as needed
- [ ] I added tests or explain why not applicable
- [ ] I added a changeset if this change affects published packages