### PR TITLE
docs: add workbench.enable documentation

### DIFF
--- a/docs/content/docs/configuring-sessions.mdx
+++ b/docs/content/docs/configuring-sessions.mdx
@@ -165,6 +165,40 @@ When executing a tool, the connected account is selected in this order:
 
 If a user has multiple connected accounts for a toolkit, the most recently connected one is used.
 
+## Disabling workbench
+
+By default, sessions include the [workbench](/docs/workbench) — a persistent sandbox that provides `COMPOSIO_REMOTE_WORKBENCH` and `COMPOSIO_REMOTE_BASH_TOOL`. If your use case doesn't need code execution, you can disable it:
+
+<Tabs groupId="language" items={['Python', 'TypeScript']} persist>
+<Tab value="Python">
+```python
+session = composio.create(
+    user_id="user_123",
+    workbench={
+        "enable": False
+    }
+)
+```
+</Tab>
+<Tab value="TypeScript">
+```typescript
+import { Composio } from '@composio/core';
+const composio = new Composio({ apiKey: 'your_api_key' });
+// ---cut---
+const session = await composio.create("user_123", {
+  workbench: {
+    enable: false,
+  },
+});
+```
+</Tab>
+</Tabs>
+
+When disabled:
+- `COMPOSIO_REMOTE_WORKBENCH` and `COMPOSIO_REMOTE_BASH_TOOL` are excluded from the session
+- Workbench-related system prompt lines are stripped
+- Direct workbench calls are rejected with a 400 error
+
 ## Session methods
 
 ### mcp

--- a/python/docs/tool-router.md
+++ b/python/docs/tool-router.md
@@ -238,15 +238,32 @@ session = composio.tool_router.create(
 Configure workbench behavior:
 
 ```python
+# Disable workbench entirely — no code execution tools in the session
 session = composio.tool_router.create(
     user_id='user_123',
     toolkits=['gmail'],
     workbench={
+        'enable': False
+    }
+)
+
+# Fine-tune workbench settings
+session = composio.tool_router.create(
+    user_id='user_123',
+    toolkits=['gmail'],
+    workbench={
+        'enable': True,  # default
         'enable_proxy_execution': False,  # Whether to allow proxy execute calls in workbench
         'auto_offload_threshold': 300  # Maximum execution payload size to offload to workbench
     }
 )
 ```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enable` | `bool` | `True` | Enables/disables the workbench entirely. When `False`, `COMPOSIO_REMOTE_WORKBENCH` and `COMPOSIO_REMOTE_BASH_TOOL` are excluded from the session. |
+| `enable_proxy_execution` | `bool` | `True` | Controls proxy API execution in the workbench. |
+| `auto_offload_threshold` | `int` | auto | Character threshold for auto-offloading large responses to the workbench. |
 
 ## Session Properties and Methods
 
@@ -754,6 +771,7 @@ manage_connections: Union[
 
 # Workbench configuration
 ToolRouterWorkbenchConfig = TypedDict('ToolRouterWorkbenchConfig', {
+    'enable': bool,                      # Enable/disable workbench entirely (default: True)
     'enable_proxy_execution': bool,      # Whether to allow proxy execute calls
     'auto_offload_threshold': int        # Maximum execution payload size to offload to workbench
 })

--- a/python/docs/tool-router.md
+++ b/python/docs/tool-router.md
@@ -254,7 +254,7 @@ session = composio.tool_router.create(
     workbench={
         'enable': True,  # default
         'enable_proxy_execution': False,  # Whether to allow proxy execute calls in workbench
-        'auto_offload_threshold': 300  # Maximum execution payload size to offload to workbench
+        'auto_offload_threshold': 300  # Character threshold for auto-offloading large responses to the workbench
     }
 )
 ```
@@ -773,7 +773,7 @@ manage_connections: Union[
 ToolRouterWorkbenchConfig = TypedDict('ToolRouterWorkbenchConfig', {
     'enable': bool,                      # Enable/disable workbench entirely (default: True)
     'enable_proxy_execution': bool,      # Whether to allow proxy execute calls
-    'auto_offload_threshold': int        # Maximum execution payload size to offload to workbench
+    'auto_offload_threshold': int        # Character threshold for auto-offloading execution to workbench
 })
 
 workbench: ToolRouterWorkbenchConfig

--- a/ts/docs/api/tool-router.md
+++ b/ts/docs/api/tool-router.md
@@ -233,14 +233,30 @@ const session = await composio.create('user_123', {
 Configure workbench behavior for tool execution:
 
 ```typescript
+// Disable workbench entirely — no code execution tools in the session
 const session = await composio.create('user_123', {
   toolkits: ['gmail'],
   workbench: {
+    enable: false
+  }
+});
+
+// Fine-tune workbench settings
+const session2 = await composio.create('user_123', {
+  toolkits: ['gmail'],
+  workbench: {
+    enable: true, // default
     enableProxyExecution: true,
     autoOffloadThreshold: 400000, // Automatically offload to workbench if response > 400k characters
   },
 });
 ```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enable` | `boolean` | `true` | Enables/disables the workbench entirely. When `false`, `COMPOSIO_REMOTE_WORKBENCH` and `COMPOSIO_REMOTE_BASH_TOOL` are excluded from the session. |
+| `enableProxyExecution` | `boolean` | `true` | Controls proxy API execution in the workbench. |
+| `autoOffloadThreshold` | `number` | auto | Character threshold for auto-offloading large responses to the workbench. |
 
 ### `experimental`
 
@@ -929,6 +945,7 @@ interface ToolRouterCreateSessionConfig {
         waitForConnections?: boolean; // NEW in v0.4.0: Wait for connections to complete
       };
   workbench?: {
+    enable?: boolean; // Enable/disable workbench entirely (default: true)
     enableProxyExecution?: boolean;
     autoOffloadThreshold?: number;
   };


### PR DESCRIPTION
## Summary
Adds documentation for the `workbench.enable` session config option introduced in #3002.

## Changes
- `docs/content/docs/configuring-sessions.mdx` — Added "Disabling workbench" section with Python/TS examples
- `ts/docs/api/tool-router.md` — Updated workbench section with `enable` field and reference table
- `python/docs/tool-router.md` — Updated workbench section with `enable` field and reference table

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [x] Documentation
- [ ] Breaking change

## How Has This Been Tested?
- `@composio/core@0.6.7` is published on npm with the `enable` field in the types, so the twoslash type-checker in the docs build should pass without `// @noErrors`

## Checklist
- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed
- [x] I updated documentation as needed
- [ ] I added tests or explain why not applicable
- [ ] I added a changeset if this change affects published packages