### PR TITLE
docs: add changelog for mcp.composio.dev endpoint removal

### DIFF
--- a/docs/content/changelog/03-25-26-mcp-endpoint-removed.mdx
+++ b/docs/content/changelog/03-25-26-mcp-endpoint-removed.mdx
@@ -1,0 +1,20 @@
+---
+title: "mcp.composio.dev Deprecated Endpoint Removed"
+date: "2026-03-25"
+---
+
+We've permanently removed the deprecated `mcp.composio.dev` endpoint that was deprecated in November 2025.
+
+This endpoint was part of our early MCP integration experiments and the latest MCP offering from Composio is [Composio For You](https://dashboard.composio.dev/~/org/connect) (access 1000+ apps through one MCP).
+
+### What Changed
+
+- All traffic to `mcp.composio.dev` web page now redirects to [composio.dev/toolkits](https://composio.dev/toolkits)
+- The underlying service has been fully decommissioned
+- No action needed if you're using our current MCP
+
+### Migrating?
+
+If you were still using the old endpoint, head to [https://dashboard.composio.dev/~/org/connect](https://dashboard.composio.dev/~/org/connect) to get started with the new MCP.
+
+Questions? Reach out to support@composio.dev

--- a/docs/content/changelog/03-25-26-mcp-endpoint-removed.mdx
+++ b/docs/content/changelog/03-25-26-mcp-endpoint-removed.mdx
@@ -1,5 +1,6 @@
 ---
 title: "mcp.composio.dev Deprecated Endpoint Removed"
+description: "Deprecated mcp.composio.dev endpoint permanently removed; traffic redirects to composio.dev/toolkits"
 date: "2026-03-25"
 ---
 


### PR DESCRIPTION
# Description
Add changelog entry dated March 25, 2026 documenting the permanent removal of the deprecated `mcp.composio.dev` endpoint. The entry explains the redirect to composio.dev/toolkits and points users to the new Composio For You MCP offering.

# How did I test this PR
- Verified file follows changelog format conventions from `docs/.claude/guides/changelog.md`
- Frontmatter has required `title` and `date` (YYYY-MM-DD) fields
- Uses `###` headings (not `#` or `##` for content sections)
- No emojis used
- File naming follows `MM-DD-YY-suffix.mdx` convention

Triggered by: Palash Kala palash@composio.dev | Source: slack
Session: https://zen-api-production-4c98.up.railway.app/dashboard/#/chat/zen-c463c1ca2f89