### PR TITLE
Fix typo in Toolkits class docstring

### DIFF
--- a/python/composio/core/models/toolkits.py
+++ b/python/composio/core/models/toolkits.py
@@ -25,7 +25,7 @@ AuthFieldsT: t.TypeAlias = t.List[
 
 class Toolkits(Resource):
     """
-    Toolkits are a collectiono of tools that can be used to perform various tasks.
+    Toolkits are a collection of tools that can be used to perform various tasks.
     They're conceptualized as a set of tools. Ex: Github toolkit can perform
     Github actions via its collection of tools. This is a replacement of the
     `apps` concept in the earlier versions of the SDK.


### PR DESCRIPTION
## Summary
Explain the motivation and context for this change. Link to any related issues.



Just a simple typo i found out while going through the code
