### PR TITLE
docs: fix Python custom tools references

### DIFF
--- a/docs/content/docs/toolkits/custom-tools-and-toolkits.mdx
+++ b/docs/content/docs/toolkits/custom-tools-and-toolkits.mdx
@@ -227,13 +227,13 @@ For more best practices, see [How to Build Tools for AI Agents: A Field Guide](h
 
 Use `session.customTools()` / `session.customToolkits()` in TypeScript or `session.custom_tools()` / `session.custom_toolkits()` in Python to list registered tools and toolkits. Registered tool slugs include their final `LOCAL_` prefix, and toolkit-scoped tools also include the toolkit slug.
 
-Reference: [TypeScript ToolRouterSession](/reference/sdk-reference/typescript/tool-router-session) · [Python SDK Reference](/reference/sdk-reference/python)
+Reference: [TypeScript ToolRouterSession](/reference/sdk-reference/typescript/tool-router-session) · [Python ToolRouterSession](/reference/sdk-reference/python/tool-router-session)
 
 ## Programmatic execution
 
 Use `session.execute()` to run custom tools directly, outside of an agent loop (e.g. `session.execute("GET_USER_PROFILE")`). Custom tools execute in-process; remote tools are sent to the backend automatically.
 
-Reference: [Tool Router API Reference](/reference/api-reference/tool-router) · [TypeScript ToolRouterSession](/reference/sdk-reference/typescript/tool-router-session) · [Python SDK Reference](/reference/sdk-reference/python)
+Reference: [TypeScript ToolRouterSession](/reference/sdk-reference/typescript/tool-router-session) · [Python ToolRouterSession](/reference/sdk-reference/python/tool-router-session)
 
 ## SessionContext
 
@@ -262,4 +262,4 @@ Every custom tool's `execute` function receives `(input, ctx)`. The `ctx` object
 
 In Python, `parameters` dictionaries accept both `in` and `type`; this guide uses `in` to match the TypeScript examples.
 
-Reference: [TypeScript SessionContextImpl](/reference/sdk-reference/typescript/session-context-impl) · [Python SDK Reference](/reference/sdk-reference/python)
+Reference: [TypeScript SessionContextImpl](/reference/sdk-reference/typescript/session-context-impl) · [Python SessionContextImpl](/reference/sdk-reference/python/session-context-impl)

--- a/docs/content/reference/sdk-reference/python/index.mdx
+++ b/docs/content/reference/sdk-reference/python/index.mdx
@@ -30,6 +30,8 @@ uv add composio
 | [`ConnectedAccounts`](/reference/sdk-reference/python/connected-accounts) | Manage connected accounts.  This class is used to manage connected accounts in t... |
 | [`AuthConfigs`](/reference/sdk-reference/python/auth-configs) | Manage authentication configurations. |
 | [`MCP`](/reference/sdk-reference/python/mcp) | MCP (Model Control Protocol) class. Provides enhanced MCP server operations  Thi... |
+| [`ToolRouterSession`](/reference/sdk-reference/python/tool-router-session) | Tool router session containing session information and methods.  Generic Paramet... |
+| [`SessionContextImpl`](/reference/sdk-reference/python/session-context-impl) | Concrete implementation of SessionContext.  One instance is created per session ... |
 
 ## Quick Start
 

--- a/docs/content/reference/sdk-reference/python/meta.json
+++ b/docs/content/reference/sdk-reference/python/meta.json
@@ -7,6 +7,8 @@
     "triggers",
     "connected-accounts",
     "auth-configs",
-    "mcp"
+    "mcp",
+    "tool-router-session",
+    "session-context-impl"
   ]
 }

--- a/docs/content/reference/sdk-reference/python/session-context-impl.mdx
+++ b/docs/content/reference/sdk-reference/python/session-context-impl.mdx
@@ -3,6 +3,12 @@ title: SessionContextImpl
 description: Concrete implementation of SessionContext.  One instance is created per session (singleton) and shared across all custom tool invocations. When ``c...
 ---
 
+## Properties
+
+| Name | Type | Description |
+|------|------|-------------|
+| `user_id` | `str` | The user ID for the current session. |
+
 ## Methods
 
 ### execute()

--- a/docs/content/reference/sdk-reference/python/session-context-impl.mdx
+++ b/docs/content/reference/sdk-reference/python/session-context-impl.mdx
@@ -1,0 +1,53 @@
+---
+title: SessionContextImpl
+description: Concrete implementation of SessionContext.  One instance is created per session (singleton) and shared across all custom tool invocations. When ``c...
+---
+
+## Methods
+
+### execute()
+
+Execute any tool from within a custom tool.  Routes to sibling local tools in-process when available, otherwise delegates to the backend API.  Returns the same response model as ``session.execute()``.
+
+```python
+def execute(tool_slug: str, arguments: Dict[str, Any]) -> SessionExecuteResponse
+```
+
+**Parameters**
+
+| Name | Type |
+|------|------|
+| `tool_slug` | `str` |
+| `arguments` | `Dict[str, Any]` |
+
+**Returns**
+
+`SessionExecuteResponse`
+
+---
+
+### proxy_execute()
+
+Proxy API calls through Composio's auth layer.  Returns the same response model as ``session.proxy_execute()``.
+
+```python
+def proxy_execute(toolkit: str, endpoint: str, method: Literal['GET', 'POST', 'PUT', 'DELETE', 'PATCH'], body: Any = ..., parameters: List[Dict[str, Any | None]] = ...) -> SessionProxyExecuteResponse
+```
+
+**Parameters**
+
+| Name | Type |
+|------|------|
+| `toolkit` | `str` |
+| `endpoint` | `str` |
+| `method` | `Literal['GET', 'POST', 'PUT', 'DELETE', 'PATCH']` |
+| `body?` | `Any` |
+| `parameters?` | `List[Dict[str, Any \| None]]` |
+
+**Returns**
+
+`SessionProxyExecuteResponse`
+
+---
+
+[View source](https://github.com/composiohq/composio/blob/next/python/composio/core/models/session_context.py#L87)

--- a/docs/content/reference/sdk-reference/python/tool-router-session.mdx
+++ b/docs/content/reference/sdk-reference/python/tool-router-session.mdx
@@ -3,6 +3,14 @@ title: ToolRouterSession
 description: "Tool router session containing session information and methods.  Generic Parameters: TTool: The individual tool type returned by the provider. TToo..."
 ---
 
+## Properties
+
+| Name | Type |
+|------|------|
+| `session_id` | `str` |
+| `mcp` | `Any` |
+| `experimental` | `'ToolRouterSessionExperimental'` |
+
 ## Methods
 
 ### tools()
@@ -51,7 +59,7 @@ def authorize(toolkit: str, callback_url: str | None = ...) -> ConnectionRequest
 Get toolkit connection states for the session.
 
 ```python
-def toolkits(toolkits: List[str | None] = ..., next_cursor: str | None = ..., limit: int | None = ..., is_connected: bool | None = ..., search: str | None = ...)
+def toolkits(toolkits: List[str | None] = ..., next_cursor: str | None = ..., limit: int | None = ..., is_connected: bool | None = ..., search: str | None = ...) -> ToolkitConnectionsDetails
 ```
 
 **Parameters**
@@ -64,6 +72,10 @@ def toolkits(toolkits: List[str | None] = ..., next_cursor: str | None = ..., li
 | `is_connected?` | `bool \| None` |
 | `search?` | `str \| None` |
 
+**Returns**
+
+`ToolkitConnectionsDetails`
+
 ---
 
 ### search()
@@ -71,7 +83,7 @@ def toolkits(toolkits: List[str | None] = ..., next_cursor: str | None = ..., li
 Search for tools by semantic use case.  Returns relevant tools for the given query with schemas and guidance.
 
 ```python
-def search(query: str, model: str | None = ...)
+def search(query: str, model: str | None = ...) -> SessionSearchResponse
 ```
 
 **Parameters**
@@ -80,6 +92,10 @@ def search(query: str, model: str | None = ...)
 |------|------|
 | `query` | `str` |
 | `model?` | `str \| None` |
+
+**Returns**
+
+`SessionSearchResponse`
 
 ---
 
@@ -162,4 +178,4 @@ def proxy_execute(toolkit: str, endpoint: str, method: Literal['GET', 'POST', 'P
 
 ---
 
-[View source](https://github.com/composiohq/composio/blob/next/python/composio/core/models/tool_router_session.py#L47)
+[View source](https://github.com/composiohq/composio/blob/next/python/composio/core/models/tool_router_session.py#L53)

--- a/docs/content/reference/sdk-reference/python/tool-router-session.mdx
+++ b/docs/content/reference/sdk-reference/python/tool-router-session.mdx
@@ -1,0 +1,165 @@
+---
+title: ToolRouterSession
+description: "Tool router session containing session information and methods.  Generic Parameters: TTool: The individual tool type returned by the provider. TToo..."
+---
+
+## Methods
+
+### tools()
+
+Get provider-wrapped tools for execution with your AI framework.  Returns tools configured for this session, wrapped in the format expected by your AI provider (OpenAI, Anthropic, LangChain, etc.).  When custom tools are bound to the session, execution of COMPOSIO_MULTI_EXECUTE_TOOL is intercepted: local tools are executed in-process, remote tools are sent to the backend.
+
+```python
+def tools(modifiers: 'Modifiers' | None = ...) -> TToolCollection
+```
+
+**Parameters**
+
+| Name | Type |
+|------|------|
+| `modifiers?` | `'Modifiers' \| None` |
+
+**Returns**
+
+`TToolCollection`
+
+---
+
+### authorize()
+
+Authorize a toolkit for the user and get a connection request.  Initiates the OAuth flow and returns a ConnectionRequest with redirect URL.
+
+```python
+def authorize(toolkit: str, callback_url: str | None = ...) -> ConnectionRequest
+```
+
+**Parameters**
+
+| Name | Type |
+|------|------|
+| `toolkit` | `str` |
+| `callback_url?` | `str \| None` |
+
+**Returns**
+
+`ConnectionRequest`
+
+---
+
+### toolkits()
+
+Get toolkit connection states for the session.
+
+```python
+def toolkits(toolkits: List[str | None] = ..., next_cursor: str | None = ..., limit: int | None = ..., is_connected: bool | None = ..., search: str | None = ...)
+```
+
+**Parameters**
+
+| Name | Type |
+|------|------|
+| `toolkits?` | `List[str \| None]` |
+| `next_cursor?` | `str \| None` |
+| `limit?` | `int \| None` |
+| `is_connected?` | `bool \| None` |
+| `search?` | `str \| None` |
+
+---
+
+### search()
+
+Search for tools by semantic use case.  Returns relevant tools for the given query with schemas and guidance.
+
+```python
+def search(query: str, model: str | None = ...)
+```
+
+**Parameters**
+
+| Name | Type |
+|------|------|
+| `query` | `str` |
+| `model?` | `str \| None` |
+
+---
+
+### execute()
+
+Execute a tool within the session.  For custom tools, accepts the original slug (e.g. "GREP") or the full slug (e.g. "LOCAL_GREP"). Custom tools are executed in-process; remote tools are sent to the Composio backend.  Both paths return a ``SessionExecuteResponse`` with ``data``, ``error``, and ``log_id`` attributes.
+
+```python
+def execute(tool_slug: str, arguments: Dict[str, Any | None] = ...) -> SessionExecuteResponse
+```
+
+**Parameters**
+
+| Name | Type |
+|------|------|
+| `tool_slug` | `str` |
+| `arguments?` | `Dict[str, Any \| None]` |
+
+**Returns**
+
+`SessionExecuteResponse`
+
+---
+
+### custom_tools()
+
+List all custom tools registered in this session.  Returns tools with their final slugs, schemas, and resolved toolkit.
+
+```python
+def custom_tools(toolkit: str | None = ...) -> List[RegisteredCustomTool]
+```
+
+**Parameters**
+
+| Name | Type |
+|------|------|
+| `toolkit?` | `str \| None` |
+
+**Returns**
+
+`List[RegisteredCustomTool]` — Array of registered custom tools
+
+---
+
+### custom_toolkits()
+
+List all custom toolkits registered in this session.  Returns toolkits with their tools showing final slugs.
+
+```python
+def custom_toolkits() -> List[RegisteredCustomToolkit]
+```
+
+**Returns**
+
+`List[RegisteredCustomToolkit]`
+
+---
+
+### proxy_execute()
+
+Proxy an API call through Composio's auth layer.
+
+```python
+def proxy_execute(toolkit: str, endpoint: str, method: Literal['GET', 'POST', 'PUT', 'DELETE', 'PATCH'], body: Any = ..., parameters: List[Dict[str, Any | None]] = ...) -> SessionProxyExecuteResponse
+```
+
+**Parameters**
+
+| Name | Type |
+|------|------|
+| `toolkit` | `str` |
+| `endpoint` | `str` |
+| `method` | `Literal['GET', 'POST', 'PUT', 'DELETE', 'PATCH']` |
+| `body?` | `Any` |
+| `parameters?` | `List[Dict[str, Any \| None]]` |
+
+**Returns**
+
+`SessionProxyExecuteResponse` — Proxied API response
+
+---
+
+[View source](https://github.com/composiohq/composio/blob/next/python/composio/core/models/tool_router_session.py#L47)

--- a/python/composio/core/models/session_context.py
+++ b/python/composio/core/models/session_context.py
@@ -107,6 +107,7 @@ class SessionContextImpl:
 
     @property
     def user_id(self) -> str:
+        """The user ID for the current session."""
         return self._user_id
 
     def execute(

--- a/python/composio/core/models/tool_router_session.py
+++ b/python/composio/core/models/tool_router_session.py
@@ -18,6 +18,9 @@ from composio_client.types.tool_router.session_execute_response import (
 from composio_client.types.tool_router.session_proxy_execute_response import (
     SessionProxyExecuteResponse,
 )
+from composio_client.types.tool_router.session_search_response import (
+    SessionSearchResponse,
+)
 
 from composio.client import HttpClient
 from composio.core.models.connected_accounts import ConnectionRequest
@@ -38,7 +41,10 @@ from composio.core.provider import TTool, TToolCollection
 from composio.core.provider.base import BaseProvider
 
 if t.TYPE_CHECKING:
-    from composio.core.models.tool_router import ToolRouterSessionExperimental
+    from composio.core.models.tool_router import (
+        ToolRouterSessionExperimental,
+        ToolkitConnectionsDetails,
+    )
 
 COMPOSIO_MULTI_EXECUTE_TOOL = "COMPOSIO_MULTI_EXECUTE_TOOL"
 MAX_PARALLEL_WORKERS = 5
@@ -57,6 +63,13 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
         mcp: MCP server configuration
         experimental: Experimental features (files, assistive prompt, etc.)
     """
+
+    #: Unique session identifier.
+    session_id: str
+    #: MCP server configuration for this session.
+    mcp: t.Any
+    #: Experimental capabilities available on this session.
+    experimental: "ToolRouterSessionExperimental"
 
     def __init__(
         self,
@@ -399,7 +412,7 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
         limit: t.Optional[int] = None,
         is_connected: t.Optional[bool] = None,
         search: t.Optional[str] = None,
-    ) -> t.Any:
+    ) -> ToolkitConnectionsDetails:
         """
         Get toolkit connection states for the session.
         """
@@ -480,7 +493,7 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
         *,
         query: str,
         model: t.Optional[str] = None,
-    ) -> t.Any:
+    ) -> SessionSearchResponse:
         """
         Search for tools by semantic use case.
 

--- a/python/scripts/generate-docs.py
+++ b/python/scripts/generate-docs.py
@@ -272,23 +272,51 @@ def generate_class_mdx(
 
     source_link = info.get("source_link", "")
 
-    # Properties - as table for Composio class
-    if prop_to_class:
-        prop_rows = []
-        for prop in info["properties"]:
-            prop_name = prop["name"]
-            if prop_name in prop_to_class:
-                class_name = prop_to_class[prop_name]
-                link = f"/reference/sdk-reference/python/{to_kebab_case(class_name)}"
-                prop_rows.append(f"| [`{prop_name}`]({link}) | `{class_name}` |")
+    # Properties
+    property_rows = []
+    if info["properties"]:
+        if prop_to_class:
+            for prop in info["properties"]:
+                prop_name = prop["name"]
+                if prop_name in prop_to_class:
+                    class_name = prop_to_class[prop_name]
+                    link = (
+                        f"/reference/sdk-reference/python/{to_kebab_case(class_name)}"
+                    )
+                    property_rows.append(
+                        {
+                            "name": f"[`{prop_name}`]({link})",
+                            "type": f"`{class_name}`",
+                            "description": prop["description"],
+                        }
+                    )
+        elif info["name"] in ADDITIONAL_CLASSES:
+            for prop in info["properties"]:
+                property_rows.append(
+                    {
+                        "name": f"`{prop['name']}`",
+                        "type": f"`{prop['type']}`",
+                        "description": prop["description"],
+                    }
+                )
 
-        if prop_rows:
-            lines.append("## Properties")
-            lines.append("")
+    if property_rows:
+        include_descriptions = any(row["description"] for row in property_rows)
+        lines.append("## Properties")
+        lines.append("")
+        if include_descriptions:
+            lines.append("| Name | Type | Description |")
+            lines.append("|------|------|-------------|")
+            for row in property_rows:
+                lines.append(
+                    f"| {row['name']} | {row['type']} | {row['description']} |"
+                )
+        else:
             lines.append("| Name | Type |")
             lines.append("|------|------|")
-            lines.extend(prop_rows)
-            lines.append("")
+            for row in property_rows:
+                lines.append(f"| {row['name']} | {row['type']} |")
+        lines.append("")
 
     # Methods
     if info["methods"]:

--- a/python/scripts/generate-docs.py
+++ b/python/scripts/generate-docs.py
@@ -52,6 +52,13 @@ EXPECTED_CLASSES = {
     "MCP": "mcp",
 }
 
+# Additional public-facing classes worth documenting even though they are not
+# exposed as direct properties on ``Composio``.
+ADDITIONAL_CLASSES = {
+    "ToolRouterSession": "core.models.tool_router_session",
+    "SessionContextImpl": "core.models.session_context",
+}
+
 # Modules to search for classes
 CLASS_MODULES = [
     "core.models.tools",
@@ -488,6 +495,27 @@ def main():
                         }
                         prop_to_class[prop_name] = class_name
                         print(f"  Found {class_name} (via composio.{prop_name})")
+        except (KeyError, AttributeError):
+            continue
+
+    # Add standalone public-facing classes that are not surfaced via a direct
+    # ``composio.<property>`` access pattern.
+    for class_name, module_name in ADDITIONAL_CLASSES.items():
+        try:
+            parts = module_name.split(".")
+            current = package
+            for part in parts:
+                current = current.members[part]
+
+            if class_name in current.members:
+                cls = current.members[class_name]
+                if isinstance(cls, griffe.Class):
+                    classes_to_doc[class_name] = {
+                        "cls": cls,
+                        "access": None,
+                        "prop": None,
+                    }
+                    print(f"  Found {class_name}")
         except (KeyError, AttributeError):
             continue
 


### PR DESCRIPTION
## Summary
- add generated Python SDK reference pages for `ToolRouterSession` and `SessionContextImpl`, and wire them into the Python SDK reference index/meta
- update the custom tools docs page to link to those real Python pages instead of the generic Python SDK index or Tool Router API reference
- keep the Python/TypeScript `parameters` examples aligned on `in`
- align the generated Python session/session-context pages more closely with the TypeScript counterparts by including the relevant properties and complete return-type sections

## Generator Changes
- add `ToolRouterSession` and `SessionContextImpl` to `ADDITIONAL_CLASSES` in `python/scripts/generate-docs.py` so they are emitted as public Python SDK reference pages
- extend the Python docs generator so those additional public classes can render `## Properties` tables, instead of only rendering properties for the root `Composio` page
- regenerate:
  - `docs/content/reference/sdk-reference/python/tool-router-session.mdx`
  - `docs/content/reference/sdk-reference/python/session-context-impl.mdx`

## Source Metadata Cleanup For Generation
- tighten `ToolRouterSession.toolkits()` from `Any` to `ToolkitConnectionsDetails` so the generated Python page includes the correct `Returns` section
- tighten `ToolRouterSession.search()` from `Any` to `SessionSearchResponse` for the same reason
- add doc metadata for the public `ToolRouterSession` properties used in the generated page: `session_id`, `mcp`, and `experimental`
- add a docstring to `SessionContextImpl.user_id` so the generated property table has a real description

These source changes are intended to improve generated documentation and static typing only; they do not change runtime behavior.

## Why
The previous docs pass added section-level references, but the Python side still did not expose equivalent generated reference pages for the session and session-context APIs. This PR makes those Python references real, points the guide at the correct targets, and keeps the generated Python pages consistent with the TypeScript reference surface for the custom-tools flow.

## Verification
- regenerated Python SDK docs with `uv run --with griffe python scripts/generate-docs.py`
- verified `session.custom_tools()` / `session.custom_toolkits()` coverage with:
  `uv run --with pytest pytest tests/test_custom_tools.py -q -k 'custom_tools_list or custom_tools_filter or custom_toolkits_list'`
