### PR TITLE
fix: deduplicate required arrays in tool schemas to comply with JSON Schema 2020-12

### DIFF
--- a/python/composio/core/models/tools.py
+++ b/python/composio/core/models/tools.py
@@ -25,6 +25,7 @@ from composio.core.provider.none_agentic import NonAgenticProvider
 from composio.core.types import ToolkitVersionParam
 from composio.exceptions import InvalidParams, NotFoundError, ToolVersionRequiredError
 from composio.utils.pydantic import none_to_omit
+from composio.utils.shared import deduplicate_required_fields
 from composio.utils.toolkit_version import get_toolkit_version
 
 from ._modifiers import (
@@ -152,13 +153,17 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
         try:
             return t.cast(Tool, self._custom_tools[slug])
         except KeyError:
-            return t.cast(
+            tool = t.cast(
                 Tool,
                 self._client.tools.retrieve(
                     tool_slug=slug,
                     toolkit_versions=none_to_omit(self._toolkit_versions),
                 ),
             )
+            tool.input_parameters = deduplicate_required_fields(
+                tool.input_parameters,
+            )
+            return tool
 
     def get_raw_composio_tools(
         self,
@@ -199,6 +204,13 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
                     toolkit_versions=none_to_omit(self._toolkit_versions),
                 ).items
             )
+
+        # Deduplicate `required` arrays to comply with JSON Schema 2020-12 §6.5.3
+        for tool in tools_list:
+            tool.input_parameters = deduplicate_required_fields(
+                tool.input_parameters,
+            )
+
         return tools_list
 
     def get_raw_tool_router_meta_tools(

--- a/python/composio/utils/shared.py
+++ b/python/composio/utils/shared.py
@@ -36,6 +36,7 @@ __all__ = [
     "generate_request_id",
     "substitute_reserved_python_keywords",
     "reinstate_reserved_python_keywords",
+    "deduplicate_required_fields",
 ]
 
 reserved_names = ["validate"]
@@ -497,6 +498,46 @@ def get_pydantic_signature_format_from_schema_params(
         all_parameters.append(param)
 
     return all_parameters
+
+
+def deduplicate_required_fields(schema: t.Dict) -> t.Dict:
+    """Recursively deduplicate entries in ``required`` arrays throughout a JSON schema.
+
+    JSON Schema 2020-12 §6.5.3 mandates that elements of ``required`` must be
+    unique.  Some upstream schemas violate this, which causes strict validators
+    (e.g. the Anthropic Claude API) to reject the entire tool batch.
+
+    The schema is shallow-copied at each level so the caller's original dict is
+    not mutated.
+    """
+    if not isinstance(schema, dict):
+        return schema
+
+    result = dict(schema)
+
+    # Deduplicate top-level ``required`` array (preserving order)
+    if isinstance(result.get("required"), list):
+        result["required"] = list(dict.fromkeys(result["required"]))
+
+    # Recurse into ``properties``
+    if isinstance(result.get("properties"), dict):
+        result["properties"] = {
+            k: deduplicate_required_fields(v)
+            for k, v in result["properties"].items()
+        }
+
+    # Recurse into ``items`` (array schemas)
+    if isinstance(result.get("items"), dict):
+        result["items"] = deduplicate_required_fields(result["items"])
+
+    # Recurse into combiners: allOf, anyOf, oneOf
+    for combiner in ("allOf", "anyOf", "oneOf"):
+        if isinstance(result.get(combiner), list):
+            result[combiner] = [
+                deduplicate_required_fields(sub) for sub in result[combiner]
+            ]
+
+    return result
 
 
 def generate_request_id() -> str:

--- a/python/tests/test_deduplicate_required.py
+++ b/python/tests/test_deduplicate_required.py
@@ -1,0 +1,117 @@
+"""Tests for deduplicate_required_fields utility."""
+
+import copy
+
+import pytest
+
+from composio.utils.shared import deduplicate_required_fields
+
+
+class TestDeduplicateRequiredFields:
+    def test_removes_duplicates_from_top_level_required(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "owner": {"type": "string"},
+                "repo": {"type": "string"},
+            },
+            "required": ["owner", "repo", "owner"],
+        }
+        result = deduplicate_required_fields(schema)
+        assert result["required"] == ["owner", "repo"]
+
+    def test_leaves_unique_required_unchanged(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "age": {"type": "number"},
+            },
+            "required": ["name", "age"],
+        }
+        result = deduplicate_required_fields(schema)
+        assert result["required"] == ["name", "age"]
+
+    def test_handles_schema_without_required(self):
+        schema = {
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+        }
+        result = deduplicate_required_fields(schema)
+        assert "required" not in result
+
+    def test_deduplicates_nested_properties(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "object",
+                    "properties": {
+                        "street": {"type": "string"},
+                        "city": {"type": "string"},
+                    },
+                    "required": ["street", "city", "street"],
+                },
+            },
+            "required": ["address"],
+        }
+        result = deduplicate_required_fields(schema)
+        assert result["required"] == ["address"]
+        assert result["properties"]["address"]["required"] == ["street", "city"]
+
+    def test_deduplicates_inside_combiners(self):
+        schema = {
+            "type": "object",
+            "allOf": [
+                {
+                    "type": "object",
+                    "required": ["foo", "bar", "foo"],
+                }
+            ],
+            "anyOf": [
+                {
+                    "type": "object",
+                    "required": ["x", "y", "x"],
+                }
+            ],
+        }
+        result = deduplicate_required_fields(schema)
+        assert result["allOf"][0]["required"] == ["foo", "bar"]
+        assert result["anyOf"][0]["required"] == ["x", "y"]
+
+    def test_handles_array_items(self):
+        schema = {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "name": {"type": "string"},
+                },
+                "required": ["id", "name", "id"],
+            },
+        }
+        result = deduplicate_required_fields(schema)
+        assert result["items"]["required"] == ["id", "name"]
+
+    def test_does_not_mutate_original(self):
+        original = {
+            "type": "object",
+            "required": ["a", "b", "a"],
+        }
+        original_copy = copy.deepcopy(original)
+        deduplicate_required_fields(original)
+        assert original == original_copy
+
+    def test_handles_non_dict_input(self):
+        assert deduplicate_required_fields("not a dict") == "not a dict"
+        assert deduplicate_required_fields(42) == 42
+        assert deduplicate_required_fields(None) is None
+
+    def test_preserves_order(self):
+        schema = {
+            "type": "object",
+            "required": ["c", "a", "b", "a", "c"],
+        }
+        result = deduplicate_required_fields(schema)
+        assert result["required"] == ["c", "a", "b"]

--- a/ts/packages/core/src/models/Tools.ts
+++ b/ts/packages/core/src/models/Tools.ts
@@ -1,5 +1,6 @@
 import ComposioClient from '@composio/client';
 import { FileToolModifier } from '#file_tool_modifier';
+import { deduplicateRequiredFields } from '../utils/jsonSchema';
 import {
   Tool,
   ToolExecuteParams,
@@ -113,7 +114,9 @@ export class Tools<
   ): Tool {
     return ToolSchema.parse({
       ...tool,
-      inputParameters: tool.input_parameters,
+      inputParameters: deduplicateRequiredFields(
+        tool.input_parameters as Record<string, unknown>
+      ),
       outputParameters: tool.output_parameters,
       availableVersions: tool.available_versions,
       isDeprecated: tool.deprecated?.is_deprecated ?? false,

--- a/ts/packages/core/src/utils/jsonSchema.ts
+++ b/ts/packages/core/src/utils/jsonSchema.ts
@@ -3,6 +3,53 @@ import { JsonSchemaToZodError } from '../errors';
 import { jsonSchemaToZod } from '@composio/json-schema-to-zod';
 
 /**
+ * Recursively deduplicates entries in `required` arrays throughout a JSON schema.
+ *
+ * JSON Schema 2020-12 §6.5.3 mandates that elements of `required` must be unique.
+ * Some upstream schemas violate this, which causes strict validators (e.g. the
+ * Anthropic Claude API) to reject the entire tool batch.
+ *
+ * @param schema - A JSON schema (or sub-schema) to sanitize
+ * @returns The same schema structure with all `required` arrays deduplicated
+ */
+export const deduplicateRequiredFields = <T extends Record<string, unknown>>(schema: T): T => {
+  if (!schema || typeof schema !== 'object') {
+    return schema;
+  }
+
+  const result = { ...schema };
+
+  // Deduplicate top-level `required` array
+  if (Array.isArray(result.required)) {
+    result.required = [...new Set(result.required as string[])];
+  }
+
+  // Recurse into `properties`
+  if (result.properties && typeof result.properties === 'object') {
+    const props = result.properties as Record<string, Record<string, unknown>>;
+    result.properties = Object.fromEntries(
+      Object.entries(props).map(([key, prop]) => [key, deduplicateRequiredFields(prop)])
+    );
+  }
+
+  // Recurse into `items` (for array schemas)
+  if (result.items && typeof result.items === 'object' && !Array.isArray(result.items)) {
+    result.items = deduplicateRequiredFields(result.items as Record<string, unknown>);
+  }
+
+  // Recurse into combiners: allOf, anyOf, oneOf
+  for (const combiner of ['allOf', 'anyOf', 'oneOf'] as const) {
+    if (Array.isArray(result[combiner])) {
+      result[combiner] = (result[combiner] as Record<string, unknown>[]).map(sub =>
+        deduplicateRequiredFields(sub)
+      );
+    }
+  }
+
+  return result;
+};
+
+/**
  * Removes all non-required properties from the schema
  *
  * if no items are required, the schema is returned as is

--- a/ts/packages/core/test/utils/jsonSchema.test.ts
+++ b/ts/packages/core/test/utils/jsonSchema.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import { deduplicateRequiredFields } from '../../src/utils/jsonSchema';
+
+describe('deduplicateRequiredFields', () => {
+  it('should remove duplicate entries from a top-level required array', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        owner: { type: 'string' },
+        repo: { type: 'string' },
+      },
+      required: ['owner', 'repo', 'owner'],
+    };
+
+    const result = deduplicateRequiredFields(schema);
+    expect(result.required).toEqual(['owner', 'repo']);
+  });
+
+  it('should leave schemas without duplicates unchanged', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        age: { type: 'number' },
+      },
+      required: ['name', 'age'],
+    };
+
+    const result = deduplicateRequiredFields(schema);
+    expect(result.required).toEqual(['name', 'age']);
+  });
+
+  it('should handle schemas without a required array', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+      },
+    };
+
+    const result = deduplicateRequiredFields(schema);
+    expect(result.required).toBeUndefined();
+  });
+
+  it('should deduplicate required arrays in nested properties', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        address: {
+          type: 'object',
+          properties: {
+            street: { type: 'string' },
+            city: { type: 'string' },
+          },
+          required: ['street', 'city', 'street'],
+        },
+      },
+      required: ['address'],
+    };
+
+    const result = deduplicateRequiredFields(schema);
+    expect(result.required).toEqual(['address']);
+    expect((result.properties as Record<string, any>).address.required).toEqual([
+      'street',
+      'city',
+    ]);
+  });
+
+  it('should deduplicate required arrays inside allOf/anyOf/oneOf', () => {
+    const schema = {
+      type: 'object',
+      allOf: [
+        {
+          type: 'object',
+          properties: {
+            foo: { type: 'string' },
+            bar: { type: 'string' },
+          },
+          required: ['foo', 'bar', 'foo'],
+        },
+      ],
+      anyOf: [
+        {
+          type: 'object',
+          required: ['x', 'y', 'x'],
+        },
+      ],
+    };
+
+    const result = deduplicateRequiredFields(schema);
+    expect((result.allOf as any[])[0].required).toEqual(['foo', 'bar']);
+    expect((result.anyOf as any[])[0].required).toEqual(['x', 'y']);
+  });
+
+  it('should handle array items schemas', () => {
+    const schema = {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          name: { type: 'string' },
+        },
+        required: ['id', 'name', 'id'],
+      },
+    };
+
+    const result = deduplicateRequiredFields(schema);
+    expect((result.items as Record<string, any>).required).toEqual(['id', 'name']);
+  });
+
+  it('should not mutate the original schema', () => {
+    const original = {
+      type: 'object',
+      required: ['a', 'b', 'a'],
+    };
+
+    deduplicateRequiredFields(original);
+    expect(original.required).toEqual(['a', 'b', 'a']);
+  });
+
+  it('should handle null/undefined input gracefully', () => {
+    expect(deduplicateRequiredFields(null as any)).toBeNull();
+    expect(deduplicateRequiredFields(undefined as any)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
Some tool schemas returned by the Composio API contain duplicate entries in their `required` arrays, which violates [JSON Schema 2020-12 §6.5.3](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.5.3). When these schemas are sent to strict JSON Schema validators — most notably the Anthropic Claude API — the entire tool batch is rejected with:

```
tools.N.custom.input_schema: JSON schema is invalid. It must match JSON Schema draft 2020-12
```

This breaks inference for **all** users who have affected toolkits connected, not just calls to the specific offending tools. Known affected tools include `GITHUB_UPDATE_A_REPOSITORY_VARIABLE` and `INTERCOM_ATTACH_A_CONTACT_TO_A_COMPANY`, though any tool with merged schema variants (via `allOf`, `anyOf`, `oneOf`) could be affected.

This PR adds recursive deduplication of `required` arrays in both the TypeScript and Python SDKs at the central schema processing layer, ensuring all downstream providers (OpenAI, Anthropic, Vercel, LangChain, etc.) automatically receive compliant schemas without any per-provider changes.

Fixes #2933

## Changes
- **TypeScript SDK**: Added `deduplicateRequiredFields()` utility in `ts/packages/core/src/utils/jsonSchema.ts` that recursively traverses schemas (including nested `properties`, `items`, `allOf`, `anyOf`, `oneOf`) and deduplicates any `required` arrays using `[...new Set()]`
- **TypeScript SDK**: Integrated deduplication into `transformToolCases()` in `ts/packages/core/src/models/Tools.ts` so schemas are sanitized immediately when received from the API, before any provider processes them
- **Python SDK**: Added equivalent `deduplicate_required_fields()` utility in `python/composio/utils/shared.py` using `list(dict.fromkeys())` to preserve insertion order while removing duplicates
- **Python SDK**: Applied deduplication in both `get_raw_composio_tools()` and `get_raw_composio_tool_by_slug()` in `python/composio/core/models/tools.py` to cover all tool retrieval paths
- **Tests**: Added comprehensive test suites for both SDKs covering: basic deduplication, nested schemas, combiners (`allOf`/`anyOf`/`oneOf`), array `items`, immutability of original input, edge cases (null/undefined), and order preservation

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [ ] Documentation
- [ ] Breaking change

## How Has This Been Tested?

**TypeScript SDK:**
```bash
cd ts/packages/core
npx vitest run test/utils/jsonSchema.test.ts
# 8 tests passed covering all deduplication scenarios
```

**Python SDK:**
```bash
cd python
python -m pytest tests/test_deduplicate_required.py -v
# 9 tests passed covering all deduplication scenarios
```

Test scenarios include:
1. Removing duplicates from top-level `required` arrays
2. Passing through schemas with no duplicates unchanged
3. Handling schemas without a `required` field
4. Recursive deduplication in nested `properties`
5. Deduplication inside `allOf`, `anyOf`, and `oneOf` combiners
6. Array `items` schema deduplication
7. Verifying original schema immutability (no mutation)
8. Graceful handling of null/undefined/non-dict inputs
9. Preservation of insertion order when deduplicating

## Checklist
- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed
- [x] I updated documentation as needed
- [x] I added tests or explain why not applicable
- [x] I added a changeset if this change affects published packages

## Additional context

**Root cause:** The duplicate `required` entries likely originate from the backend API's schema generation pipeline, possibly when merging schema variants. This SDK-side fix acts as a defensive layer, ensuring compliance regardless of what the API returns.

**Performance impact:** Negligible — the deduplication is a lightweight `O(n)` operation using `Set` (TS) / `dict.fromkeys` (Python), applied once per tool schema during retrieval.

**Backward compatibility:** Fully backward compatible. Schemas without duplicates pass through unchanged. The fix only removes redundant entries that violate the spec.
