### PR TITLE
Cache no-auth toolkits as connected

### DIFF
--- a/ts/packages/cli/src/services/consumer-short-term-cache.ts
+++ b/ts/packages/cli/src/services/consumer-short-term-cache.ts
@@ -4,6 +4,7 @@ import { Effect, Option } from 'effect';
 import { setupCacheDir } from 'src/effects/setup-cache-dir';
 import { NodeProcess } from 'src/services/node-process';
 import {
+  ComposioToolkitsRepository,
   getConsumerConnectedToolkits,
   resolveConsumerProject,
 } from 'src/services/composio-clients';
@@ -193,6 +194,12 @@ export const refreshConsumerConnectedToolkitsCache = (params?: {
       orgId: scope.orgId,
       consumerUserId: scope.consumerUserId,
     });
+    const toolkitsRepository = yield* ComposioToolkitsRepository;
+    const noAuthToolkits = yield* toolkitsRepository.getToolkits().pipe(
+      Effect.map(toolkits =>
+        toolkits.filter(toolkit => toolkit.no_auth).map(toolkit => toolkit.slug.toLowerCase())
+      )
+    );
     const state = yield* readCache();
     const key = cacheKey(scope.orgId, scope.consumerUserId);
     const currentEntry = state[key];
@@ -204,7 +211,11 @@ export const refreshConsumerConnectedToolkitsCache = (params?: {
     yield* writeCache({
       ...state,
       [key]: {
-        toolkits: response.toolkits.map(toolkit => toolkit.toLowerCase()),
+        toolkits: [
+          ...new Set(
+            [...response.toolkits, ...noAuthToolkits].map(toolkit => toolkit.toLowerCase())
+          ),
+        ],
         expiresAt: new Date(Date.now() + CACHE_TTL_MS).toISOString(),
         ...searchSessionFields,
       },

--- a/ts/packages/cli/src/services/consumer-short-term-cache.ts
+++ b/ts/packages/cli/src/services/consumer-short-term-cache.ts
@@ -105,6 +105,21 @@ const writeCache = (state: CacheState) =>
     yield* fs.writeFileString(cachePath(cacheDir), JSON.stringify(state, null, 2));
   });
 
+const getAlwaysConnectedNoAuthToolkits = () =>
+  Effect.gen(function* () {
+    const toolkitsRepository = yield* ComposioToolkitsRepository;
+    const toolkits = yield* toolkitsRepository.getToolkits();
+
+    return toolkits
+      .filter(toolkit => toolkit.no_auth)
+      .map(toolkit => toolkit.slug.toLowerCase());
+  });
+
+const normalizeCachedToolkits = (
+  toolkits: ReadonlyArray<string>,
+  noAuthToolkits: ReadonlyArray<string>
+) => [...new Set([...toolkits, ...noAuthToolkits].map(toolkit => toolkit.toLowerCase()))];
+
 export const getFreshConsumerConnectedToolkitsFromCache = (params: {
   orgId: string;
   consumerUserId: string;
@@ -194,12 +209,7 @@ export const refreshConsumerConnectedToolkitsCache = (params?: {
       orgId: scope.orgId,
       consumerUserId: scope.consumerUserId,
     });
-    const toolkitsRepository = yield* ComposioToolkitsRepository;
-    const noAuthToolkits = yield* toolkitsRepository.getToolkits().pipe(
-      Effect.map(toolkits =>
-        toolkits.filter(toolkit => toolkit.no_auth).map(toolkit => toolkit.slug.toLowerCase())
-      )
-    );
+    const noAuthToolkits = yield* getAlwaysConnectedNoAuthToolkits();
     const state = yield* readCache();
     const key = cacheKey(scope.orgId, scope.consumerUserId);
     const currentEntry = state[key];
@@ -211,11 +221,7 @@ export const refreshConsumerConnectedToolkitsCache = (params?: {
     yield* writeCache({
       ...state,
       [key]: {
-        toolkits: [
-          ...new Set(
-            [...response.toolkits, ...noAuthToolkits].map(toolkit => toolkit.toLowerCase())
-          ),
-        ],
+        toolkits: normalizeCachedToolkits(response.toolkits, noAuthToolkits),
         expiresAt: new Date(Date.now() + CACHE_TTL_MS).toISOString(),
         ...searchSessionFields,
       },
@@ -228,6 +234,7 @@ export const writeConsumerConnectedToolkitsCache = (params: {
   readonly toolkits: ReadonlyArray<string>;
 }) =>
   Effect.gen(function* () {
+    const noAuthToolkits = yield* getAlwaysConnectedNoAuthToolkits();
     const state = yield* readCache();
     const key = cacheKey(params.orgId, params.consumerUserId);
     const currentEntry = state[key];
@@ -240,7 +247,7 @@ export const writeConsumerConnectedToolkitsCache = (params: {
     yield* writeCache({
       ...state,
       [key]: {
-        toolkits: [...new Set(params.toolkits.map(toolkit => toolkit.toLowerCase()))],
+        toolkits: normalizeCachedToolkits(params.toolkits, noAuthToolkits),
         expiresAt: new Date(Date.now() + CACHE_TTL_MS).toISOString(),
         ...searchSessionFields,
       },

--- a/ts/packages/cli/test/src/services/consumer-short-term-cache.test.ts
+++ b/ts/packages/cli/test/src/services/consumer-short-term-cache.test.ts
@@ -6,6 +6,7 @@ import * as composioClients from 'src/services/composio-clients';
 import {
   getFreshConsumerConnectedToolkitsFromCache,
   refreshConsumerConnectedToolkitsCache,
+  writeConsumerConnectedToolkitsCache,
 } from 'src/services/consumer-short-term-cache';
 import { TestLive } from 'test/__utils__';
 
@@ -73,6 +74,67 @@ describe('consumer short-term cache', () => {
         yield* refreshConsumerConnectedToolkitsCache({
           orgId: 'org_test',
           consumerUserId: 'consumer-user-test',
+        });
+
+        const cached = yield* getFreshConsumerConnectedToolkitsFromCache({
+          orgId: 'org_test',
+          consumerUserId: 'consumer-user-test',
+        });
+
+        expect(cached).toEqual(Option.some(['github', 'hackernews']));
+      })
+    );
+  });
+
+  layer(
+    TestLive({
+      baseConfigProvider: testConfigProvider,
+      toolkitsData: {
+        toolkits: [
+          {
+            name: 'GitHub',
+            slug: 'github',
+            auth_schemes: ['OAUTH2'],
+            composio_managed_auth_schemes: ['OAUTH2'],
+            is_local_toolkit: false,
+            no_auth: false,
+            meta: {
+              description: 'GitHub toolkit',
+              categories: [],
+              created_at: new Date('2024-05-03T11:44:32.061Z') as any,
+              updated_at: new Date('2024-05-03T11:44:32.061Z') as any,
+              available_versions: [],
+              tools_count: 0,
+              triggers_count: 0,
+            },
+          },
+          {
+            name: 'Hacker News',
+            slug: 'hackernews',
+            auth_schemes: [],
+            composio_managed_auth_schemes: [],
+            is_local_toolkit: false,
+            no_auth: true,
+            meta: {
+              description: 'No-auth toolkit',
+              categories: [],
+              created_at: new Date('2024-05-03T11:44:32.061Z') as any,
+              updated_at: new Date('2024-05-03T11:44:32.061Z') as any,
+              available_versions: [],
+              tools_count: 0,
+              triggers_count: 0,
+            },
+          },
+        ],
+      },
+    })
+  )('[Given] a search cache write [Then] no-auth toolkits are preserved', it => {
+    it.scoped('stores active and no-auth toolkit slugs together', () =>
+      Effect.gen(function* () {
+        yield* writeConsumerConnectedToolkitsCache({
+          orgId: 'org_test',
+          consumerUserId: 'consumer-user-test',
+          toolkits: ['github'],
         });
 
         const cached = yield* getFreshConsumerConnectedToolkitsFromCache({

--- a/ts/packages/cli/test/src/services/consumer-short-term-cache.test.ts
+++ b/ts/packages/cli/test/src/services/consumer-short-term-cache.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, layer } from '@effect/vitest';
+import { vi, afterEach } from 'vitest';
+import { ConfigProvider, Effect, Option } from 'effect';
+import { extendConfigProvider } from 'src/services/config';
+import * as composioClients from 'src/services/composio-clients';
+import {
+  getFreshConsumerConnectedToolkitsFromCache,
+  refreshConsumerConnectedToolkitsCache,
+} from 'src/services/consumer-short-term-cache';
+import { TestLive } from 'test/__utils__';
+
+const testConfigProvider = ConfigProvider.fromMap(
+  new Map([
+    ['COMPOSIO_USER_API_KEY', 'test_api_key'],
+    ['COMPOSIO_BASE_URL', 'https://backend.composio.dev'],
+  ])
+).pipe(extendConfigProvider);
+
+describe('consumer short-term cache', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  layer(
+    TestLive({
+      baseConfigProvider: testConfigProvider,
+      toolkitsData: {
+        toolkits: [
+          {
+            name: 'GitHub',
+            slug: 'github',
+            auth_schemes: ['OAUTH2'],
+            composio_managed_auth_schemes: ['OAUTH2'],
+            is_local_toolkit: false,
+            no_auth: false,
+            meta: {
+              description: 'GitHub toolkit',
+              categories: [],
+              created_at: new Date('2024-05-03T11:44:32.061Z') as any,
+              updated_at: new Date('2024-05-03T11:44:32.061Z') as any,
+              available_versions: [],
+              tools_count: 0,
+              triggers_count: 0,
+            },
+          },
+          {
+            name: 'Hacker News',
+            slug: 'hackernews',
+            auth_schemes: [],
+            composio_managed_auth_schemes: [],
+            is_local_toolkit: false,
+            no_auth: true,
+            meta: {
+              description: 'No-auth toolkit',
+              categories: [],
+              created_at: new Date('2024-05-03T11:44:32.061Z') as any,
+              updated_at: new Date('2024-05-03T11:44:32.061Z') as any,
+              available_versions: [],
+              tools_count: 0,
+              triggers_count: 0,
+            },
+          },
+        ],
+      },
+    })
+  )('[Given] no-auth toolkits [Then] refresh caches them as connected', it => {
+    it.scoped('stores connected and no-auth toolkit slugs together', () =>
+      Effect.gen(function* () {
+        vi.spyOn(composioClients, 'getConsumerConnectedToolkits').mockReturnValue(
+          Effect.succeed({ toolkits: ['github'] })
+        );
+
+        yield* refreshConsumerConnectedToolkitsCache({
+          orgId: 'org_test',
+          consumerUserId: 'consumer-user-test',
+        });
+
+        const cached = yield* getFreshConsumerConnectedToolkitsFromCache({
+          orgId: 'org_test',
+          consumerUserId: 'consumer-user-test',
+        });
+
+        expect(cached).toEqual(Option.some(['github', 'hackernews']));
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Cache no-auth toolkits alongside the consumer’s connected toolkits in the short-term cache.
- Normalize toolkit slugs to lowercase and deduplicate entries before persisting.
- Add a regression test covering the combined cached result for connected and no-auth toolkits.

## Testing
- `Not run` (not requested)
- Added unit coverage in `ts/packages/cli/test/src/services/consumer-short-term-cache.test.ts` for the merged cache behavior