### PR TITLE
[codex] fix CLI binary release workflow

### DIFF
--- a/.github/workflows/build-cli-binaries.yml
+++ b/.github/workflows/build-cli-binaries.yml
@@ -80,6 +80,7 @@ jobs:
           rm -rf "$temp_dir"
           mkdir -p "$temp_dir/${{ matrix.artifact }}"
           cp "${{ matrix.artifact }}" "$temp_dir/${{ matrix.artifact }}/composio"
+          cp companions/run-subagent-*.mjs "$temp_dir/${{ matrix.artifact }}/"
           cd "$temp_dir" && zip -r "../${{ matrix.artifact }}.zip" "${{ matrix.artifact }}"
           cd .. && rm -r "$temp_dir"
 

--- a/.github/workflows/cli.test-installation.yml
+++ b/.github/workflows/cli.test-installation.yml
@@ -148,19 +148,19 @@ jobs:
 
           # Verify installation
           source ~/.bashrc 2>/dev/null || source ~/.zshrc 2>/dev/null || true
-          export PATH="$HOME/.composio/bin:$PATH"
+          export PATH="$HOME/.composio:$PATH"
 
           # Check if binary exists
-          if [[ -f "$HOME/.composio/bin/composio" ]]; then
+          if [[ -f "$HOME/.composio/composio" ]]; then
             echo "✅ Binary installed successfully"
-            ls -la "$HOME/.composio/bin/composio"
+            ls -la "$HOME/.composio/composio"
           else
             echo "❌ Binary not found"
             exit 1
           fi
 
           # Test binary execution
-          if "$HOME/.composio/bin/composio" --version; then
+          if "$HOME/.composio/composio" --version; then
             echo "✅ Binary executes successfully"
           else
             echo "❌ Binary execution failed"
@@ -179,19 +179,19 @@ jobs:
 
           # Verify installation
           source ~/.bashrc 2>/dev/null || source ~/.zshrc 2>/dev/null || true
-          export PATH="$HOME/.composio/bin:$PATH"
+          export PATH="$HOME/.composio:$PATH"
 
           # Check if binary exists
-          if [[ -f "$HOME/.composio/bin/composio" ]]; then
+          if [[ -f "$HOME/.composio/composio" ]]; then
             echo "✅ Binary installed successfully"
-            ls -la "$HOME/.composio/bin/composio"
+            ls -la "$HOME/.composio/composio"
           else
             echo "❌ Binary not found"
             exit 1
           fi
 
           # Test binary execution
-          if "$HOME/.composio/bin/composio" --version; then
+          if "$HOME/.composio/composio" --version; then
             echo "✅ Binary executes successfully"
           else
             echo "❌ Binary execution failed"
@@ -219,7 +219,7 @@ jobs:
           fi
 
           echo "=== Installation directory ==="
-          ls -la ~/.composio/bin/ || echo "~/.composio/bin/ not found"
+          ls -la ~/.composio/ || echo "~/.composio/ not found"
 
           echo "=== Current PATH before sourcing ==="
           echo "$PATH"
@@ -262,28 +262,28 @@ jobs:
           echo "Checking shell configuration updates..."
 
           if [[ "${{ matrix.shell }}" == "zsh" ]]; then
-            if grep -q "COMPOSIO_INSTALL" ~/.zshrc; then
+            if grep -q "COMPOSIO_INSTALL_DIR" ~/.zshrc; then
               echo "✅ .zshrc updated with COMPOSIO_INSTALL"
             else
               echo "❌ .zshrc not updated"
               exit 1
             fi
             
-            if grep -q "COMPOSIO_INSTALL/bin" ~/.zshrc; then
+            if grep -q 'PATH="\\$COMPOSIO_INSTALL_DIR:\\$PATH"' ~/.zshrc; then
               echo "✅ .zshrc updated with PATH"
             else
               echo "❌ .zshrc PATH not updated"
               exit 1
             fi
           else
-            if grep -q "COMPOSIO_INSTALL" ~/.bashrc; then
+            if grep -q "COMPOSIO_INSTALL_DIR" ~/.bashrc; then
               echo "✅ .bashrc updated with COMPOSIO_INSTALL"
             else
               echo "❌ .bashrc not updated"
               exit 1
             fi
             
-            if grep -q "COMPOSIO_INSTALL/bin" ~/.bashrc; then
+            if grep -q 'PATH="\\$COMPOSIO_INSTALL_DIR:\\$PATH"' ~/.bashrc; then
               echo "✅ .bashrc updated with PATH"
             else
               echo "❌ .bashrc PATH not updated"
@@ -300,7 +300,7 @@ jobs:
           rm -rf ~/.composio
 
           # Test with custom directory using the same version as the workflow
-          export COMPOSIO_INSTALL="/tmp/custom-composio"
+          export COMPOSIO_INSTALL_DIR="/tmp/custom-composio"
           if [[ "${{ steps.release_target.outputs.use_latest }}" == "true" ]]; then
             bash install.sh
           else
@@ -309,16 +309,16 @@ jobs:
           fi
 
           # Verify custom installation
-          if [[ -f "/tmp/custom-composio/bin/composio" ]]; then
+          if [[ -f "/tmp/custom-composio/composio" ]]; then
             echo "✅ Custom directory installation successful"
-            ls -la "/tmp/custom-composio/bin/composio"
+            ls -la "/tmp/custom-composio/composio"
           else
             echo "❌ Custom directory installation failed"
             exit 1
           fi
 
           # Test execution
-          if "/tmp/custom-composio/bin/composio" --version; then
+          if "/tmp/custom-composio/composio" --version; then
             echo "✅ Custom installation executes successfully"
           else
             echo "❌ Custom installation execution failed"
@@ -333,7 +333,7 @@ jobs:
           rm -rf ~/.composio /tmp/custom-composio
 
           # Check if binary is gone
-          if [[ ! -f "$HOME/.composio/bin/composio" ]]; then
+          if [[ ! -f "$HOME/.composio/composio" ]]; then
             echo "✅ Binary removed successfully"
           else
             echo "❌ Binary removal failed"

--- a/install.sh
+++ b/install.sh
@@ -164,12 +164,27 @@ mkdir -p "$COMPOSIO_INSTALL_DIR" ||
     error "Failed to create install directory \"$COMPOSIO_INSTALL_DIR\""
 
 exe="$COMPOSIO_INSTALL_DIR/composio"
+companion_modules=(
+    "run-subagent-shared.mjs"
+    "run-subagent-acp.mjs"
+    "run-subagent-legacy.mjs"
+)
 
 # Handle nested directory structure (composio-<target>/composio)
 if [[ -f "$tmpdir/composio-$target/composio" ]]; then
     mv "$tmpdir/composio-$target/composio" "$exe"
+    for module in "${companion_modules[@]}"; do
+        if [[ -f "$tmpdir/composio-$target/$module" ]]; then
+            mv "$tmpdir/composio-$target/$module" "$COMPOSIO_INSTALL_DIR/$module"
+        fi
+    done
 elif [[ -f "$tmpdir/composio" ]]; then
     mv "$tmpdir/composio" "$exe"
+    for module in "${companion_modules[@]}"; do
+        if [[ -f "$tmpdir/$module" ]]; then
+            mv "$tmpdir/$module" "$COMPOSIO_INSTALL_DIR/$module"
+        fi
+    done
 else
     error 'Binary not found in extracted archive'
 fi

--- a/ts/packages/cli/scripts/build-binary-cross.ts
+++ b/ts/packages/cli/scripts/build-binary-cross.ts
@@ -14,6 +14,7 @@
  * Output: `dist/binaries/<artifact-name>`
  */
 
+import { mkdir } from 'node:fs/promises';
 import process from 'node:process';
 import { Config, ConfigProvider, Console, Effect, Stream, Logger, Layer, LogLevel } from 'effect';
 import { Command } from '@effect/platform';
@@ -31,6 +32,12 @@ const TARGET_MAP: Record<string, string> = {
 };
 
 const VALID_TARGETS = Object.keys(TARGET_MAP);
+
+const RUN_COMPANION_MODULE_BASENAMES = [
+  'run-subagent-shared',
+  'run-subagent-acp',
+  'run-subagent-legacy',
+] as const;
 
 function parseTarget(): { target: string; artifact: string } {
   const targetIdx = process.argv.indexOf('--target');
@@ -104,6 +111,50 @@ export function buildBinaryCross() {
 
     if (exitCode !== 0) {
       return yield* Effect.fail(new Error(`Failed to cross-compile binary for ${target}`));
+    }
+
+    const companionOutputDir = './dist/binaries/companions';
+    yield* Effect.tryPromise(() => mkdir(companionOutputDir, { recursive: true }));
+
+    for (const name of RUN_COMPANION_MODULE_BASENAMES) {
+      const companionArgs = [
+        'bun',
+        'build',
+        `./src/services/${name}.ts`,
+        '--outfile',
+        `${companionOutputDir}/${name}.mjs`,
+        '--format',
+        'esm',
+        '--target',
+        'bun',
+      ] as const satisfies ReadonlyArray<string>;
+
+      const companionCmd = Command.make(...companionArgs);
+      const { exitCode: companionExitCode } = yield* companionCmd.pipe(
+        Command.start,
+        Effect.flatMap(process =>
+          Effect.all(
+            {
+              exitCode: process.exitCode,
+              output: Stream.merge(
+                Stream.decodeText(process.stdout, 'utf-8'),
+                Stream.decodeText(process.stderr, 'utf-8'),
+                { haltStrategy: 'left' }
+              ).pipe(
+                Stream.tap(chunk => Console.log(chunk)),
+                Stream.runDrain
+              ),
+            },
+            {
+              concurrency: 'unbounded',
+            }
+          )
+        )
+      );
+
+      if (companionExitCode !== 0) {
+        return yield* Effect.fail(new Error(`Failed to build companion module: ${name}`));
+      }
     }
 
     yield* Console.log(`Binary cross-compiled: ${outfile}`);


### PR DESCRIPTION
## What changed

- make `build:binary:cross` emit the `run-subagent-*.mjs` companion modules alongside the compiled CLI binary
- update the `Build CLI Binaries` workflow to include those companion modules in the published release archives
- make `install.sh` copy companion modules when they are present, while remaining backward compatible with older archives that only contain `composio`
- fix the CLI installation workflow assertions to match the actual installer behavior and paths

## Why

`composio run` launches a separate Bun runtime that imports the `run-subagent-*` helpers from disk. The main binary alone is not sufficient. The previous release workflow zipped only the `composio` binary, so prerelease assets installed successfully but failed at runtime with missing-module errors.

The installation test workflow also had stale expectations for `~/.composio/bin/composio` and `COMPOSIO_INSTALL`, which caused false negatives even when installation itself succeeded.

## Impact

- newly built CLI release assets will contain the files required for `composio run`
- `install.sh` will install sidecars for new releases and ignore them for older releases
- the installation workflow will validate the real install layout instead of the stale `bin/` path

## Validation

- `pnpm --filter @composio/cli run build:binary:cross --target bun-darwin-arm64` from the existing checkout emitted:
  - `dist/binaries/composio-darwin-aarch64`
  - `dist/binaries/companions/run-subagent-shared.mjs`
  - `dist/binaries/companions/run-subagent-acp.mjs`
  - `dist/binaries/companions/run-subagent-legacy.mjs`
- simulated the GitHub Actions archive step and verified the zip contains `composio` plus all three companion modules
- earlier local binary/package validation on the main fix branch confirmed the extracted binary runs `composio run 'console.log("hello")'` successfully once those files are packaged
