### PR TITLE
[codex] Repair missing run companion modules

### DIFF
--- a/.changeset/cli-patch.md
+++ b/.changeset/cli-patch.md
@@ -1,0 +1,5 @@
+---
+"@composio/cli": patch
+---
+
+patch

--- a/install.sh
+++ b/install.sh
@@ -169,6 +169,7 @@ companion_modules=(
     "run-subagent-acp.mjs"
     "run-subagent-legacy.mjs"
 )
+release_tag_file="$COMPOSIO_INSTALL_DIR/release-tag.txt"
 
 install_companion_modules() {
     local source_dir="$1"
@@ -206,6 +207,9 @@ fi
 
 chmod +x "$exe" ||
     error 'Failed to set permissions on executable'
+
+printf '%s\n' "$version" > "$release_tag_file" ||
+    error "Failed to write install metadata to \"$release_tag_file\""
 
 success "Composio CLI was installed successfully to $Bold_Green$(tildify "$exe")"
 

--- a/ts/packages/cli/src/commands/run.cmd.ts
+++ b/ts/packages/cli/src/commands/run.cmd.ts
@@ -6,12 +6,16 @@ import { pathToFileURL } from 'node:url';
 import { Args, Command, Options } from '@effect/cli';
 import { Effect, Option } from 'effect';
 import { ts } from 'ts-morph';
+import { APP_VERSION } from 'src/constants';
 import { resolveCommandProject } from 'src/services/command-project';
 import { warmToolInputDefinitions } from 'src/services/tool-input-validation';
 import { ComposioUserContext } from 'src/services/user-context';
 import { isPerfDebugEnabled, isToolDebugEnabled } from 'src/services/runtime-debug-flags';
 import { detectMaster, type MasterKind } from 'src/services/master-detector';
-import { resolveRunCompanionModulePath } from 'src/services/run-companion-modules';
+import {
+  repairMissingInstalledRunCompanionModules,
+  resolveRunCompanionModulePath,
+} from 'src/services/run-companion-modules';
 import {
   appendCliSessionHistory,
   resolveCliSessionArtifacts,
@@ -161,27 +165,35 @@ export const inferCliInvocationPrefix = (
     : [process.execPath];
 };
 
-const subAgentSharedModuleUrl = pathToFileURL(
-  resolveRunCompanionModulePath({
-    callerImportMetaUrl: import.meta.url,
-    execPath: process.execPath,
-    relativeNoExtensionFromCaller: '../services/run-subagent-shared',
-  })
-).href;
-const subAgentAcpModuleUrl = pathToFileURL(
-  resolveRunCompanionModulePath({
-    callerImportMetaUrl: import.meta.url,
-    execPath: process.execPath,
-    relativeNoExtensionFromCaller: '../services/run-subagent-acp',
-  })
-).href;
-const subAgentLegacyModuleUrl = pathToFileURL(
-  resolveRunCompanionModulePath({
-    callerImportMetaUrl: import.meta.url,
-    execPath: process.execPath,
-    relativeNoExtensionFromCaller: '../services/run-subagent-legacy',
-  })
-).href;
+type RunHelperModuleUrls = {
+  readonly subAgentSharedModuleUrl: string;
+  readonly subAgentAcpModuleUrl: string;
+  readonly subAgentLegacyModuleUrl: string;
+};
+
+const resolveRunHelperModuleUrls = (): RunHelperModuleUrls => ({
+  subAgentSharedModuleUrl: pathToFileURL(
+    resolveRunCompanionModulePath({
+      callerImportMetaUrl: import.meta.url,
+      execPath: process.execPath,
+      relativeNoExtensionFromCaller: '../services/run-subagent-shared',
+    })
+  ).href,
+  subAgentAcpModuleUrl: pathToFileURL(
+    resolveRunCompanionModulePath({
+      callerImportMetaUrl: import.meta.url,
+      execPath: process.execPath,
+      relativeNoExtensionFromCaller: '../services/run-subagent-acp',
+    })
+  ).href,
+  subAgentLegacyModuleUrl: pathToFileURL(
+    resolveRunCompanionModulePath({
+      callerImportMetaUrl: import.meta.url,
+      execPath: process.execPath,
+      relativeNoExtensionFromCaller: '../services/run-subagent-legacy',
+    })
+  ).href,
+});
 
 type RunHelperContext = {
   readonly apiKey?: string;
@@ -791,13 +803,14 @@ const buildRunProxyHelpersSource = (): ReadonlyArray<string> => [
 
 export const buildRunHelpersSource = (
   cliPrefix: ReadonlyArray<string>,
-  context: RunHelperContext = {}
+  context: RunHelperContext = {},
+  moduleUrls: RunHelperModuleUrls = resolveRunHelperModuleUrls()
 ): string =>
   [
     'import { z } from "zod";',
-    `import { isAcpInvokeError } from ${JSON.stringify(subAgentSharedModuleUrl)};`,
-    `import { invokeAcpSubAgent } from ${JSON.stringify(subAgentAcpModuleUrl)};`,
-    `import { invokeLegacySubAgent } from ${JSON.stringify(subAgentLegacyModuleUrl)};`,
+    `import { isAcpInvokeError } from ${JSON.stringify(moduleUrls.subAgentSharedModuleUrl)};`,
+    `import { invokeAcpSubAgent } from ${JSON.stringify(moduleUrls.subAgentAcpModuleUrl)};`,
+    `import { invokeLegacySubAgent } from ${JSON.stringify(moduleUrls.subAgentLegacyModuleUrl)};`,
     '',
     `const cliPrefix = ${JSON.stringify(cliPrefix)};`,
     `const helperContext = ${JSON.stringify(context)};`,
@@ -809,7 +822,8 @@ export const buildRunHelpersSource = (
 
 const createRunHelpersPreloadFile = (
   cliPrefix: ReadonlyArray<string>,
-  context: RunHelperContext
+  context: RunHelperContext,
+  moduleUrls: RunHelperModuleUrls
 ) => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'composio-run-'));
   const preloadPath = path.join(directory, 'globals.mjs');
@@ -820,7 +834,7 @@ const createRunHelpersPreloadFile = (
   fs.mkdirSync(runOutputDir, { recursive: true });
   fs.writeFileSync(
     preloadPath,
-    buildRunHelpersSource(cliPrefix, { ...context, runOutputDir }),
+    buildRunHelpersSource(cliPrefix, { ...context, runOutputDir }, moduleUrls),
     'utf8'
   );
   return { directory, preloadPath, runOutputDir };
@@ -1019,7 +1033,28 @@ export const runCmd = Command.make('run', {
           skipToolParamsCheck,
           skipChecks,
         };
-        const preload = createRunHelpersPreloadFile(inferCliInvocationPrefix(), helperContext);
+        const runHelperModuleUrls = yield* Effect.tryPromise({
+          try: async () => {
+            await repairMissingInstalledRunCompanionModules({
+              callerImportMetaUrl: import.meta.url,
+              execPath: process.execPath,
+              appVersion: APP_VERSION,
+            });
+
+            return resolveRunHelperModuleUrls();
+          },
+          catch: error =>
+            new Error(
+              error instanceof Error
+                ? error.message
+                : `Failed to prepare the modules required by 'composio run': ${String(error)}`
+            ),
+        });
+        const preload = createRunHelpersPreloadFile(
+          inferCliInvocationPrefix(),
+          helperContext,
+          runHelperModuleUrls
+        );
         let cleanupPaths: ReadonlyArray<string> = [];
         try {
           yield* appendCliSessionHistory({

--- a/ts/packages/cli/src/services/run-companion-modules.ts
+++ b/ts/packages/cli/src/services/run-companion-modules.ts
@@ -1,6 +1,8 @@
 import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import decompress from 'decompress';
 
 export const RUN_COMPANION_MODULE_BASENAMES = [
   'run-subagent-shared',
@@ -11,6 +13,276 @@ export const RUN_COMPANION_MODULE_BASENAMES = [
 export const RUN_COMPANION_MODULE_FILENAMES = RUN_COMPANION_MODULE_BASENAMES.map(
   name => `${name}.mjs`
 );
+
+export const RUN_COMPANION_RELEASE_TAG_FILENAME = 'release-tag.txt';
+
+type GitHubReleaseAsset = {
+  name: string;
+  browser_download_url: string;
+};
+
+type GitHubRelease = {
+  tag_name: string;
+  assets: GitHubReleaseAsset[];
+};
+
+const DEFAULT_GITHUB_CONFIG = {
+  apiBaseUrl: 'https://api.github.com',
+  owner: 'ComposioHQ',
+  repo: 'composio',
+} as const;
+
+const resolveCompanionInstallDirectory = (execPath: string) => path.dirname(execPath);
+
+const resolveBinaryAssetName = ({
+  platform = process.platform,
+  arch = process.arch,
+}: {
+  platform?: NodeJS.Platform;
+  arch?: string;
+}) => {
+  switch (`${platform}-${arch}`) {
+    case 'darwin-arm64':
+      return 'composio-darwin-aarch64.zip';
+    case 'darwin-x64':
+      return 'composio-darwin-x64.zip';
+    case 'linux-x64':
+      return 'composio-linux-x64.zip';
+    case 'linux-arm64':
+      return 'composio-linux-aarch64.zip';
+    default:
+      throw new Error(`Unsupported platform for run companion repair: ${platform}-${arch}`);
+  }
+};
+
+const readTextFileIfPresent = (filePath: string) => {
+  if (!fs.existsSync(filePath)) {
+    return undefined;
+  }
+
+  const value = fs.readFileSync(filePath, 'utf8').trim();
+  return value.length > 0 ? value : undefined;
+};
+
+export const readInstalledReleaseTag = (execPath: string) =>
+  readTextFileIfPresent(
+    path.join(resolveCompanionInstallDirectory(execPath), RUN_COMPANION_RELEASE_TAG_FILENAME)
+  );
+
+export const writeInstalledReleaseTag = (installDir: string, releaseTag: string) => {
+  fs.writeFileSync(
+    path.join(installDir, RUN_COMPANION_RELEASE_TAG_FILENAME),
+    `${releaseTag}\n`,
+    'utf8'
+  );
+};
+
+export const listMissingInstalledRunCompanionModules = (execPath: string) => {
+  const installDirectory = resolveCompanionInstallDirectory(execPath);
+  return RUN_COMPANION_MODULE_FILENAMES.filter(
+    fileName => !fs.existsSync(path.join(installDirectory, fileName))
+  );
+};
+
+const fetchGitHubJson = async <T>({
+  url,
+  accessToken,
+  fetchErrorMessage,
+}: {
+  url: string;
+  accessToken?: string;
+  fetchErrorMessage: string;
+}): Promise<T> => {
+  const response = await fetch(url, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'composio-cli-run-repair',
+      ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new Error(`${fetchErrorMessage} (HTTP ${response.status}${body ? `: ${body}` : ''})`);
+  }
+
+  return (await response.json()) as T;
+};
+
+const fetchChecksums = async ({
+  release,
+  accessToken,
+}: {
+  release: GitHubRelease;
+  accessToken?: string;
+}) => {
+  const checksumsAsset = release.assets.find(asset => asset.name === 'checksums.txt');
+  if (!checksumsAsset) {
+    return undefined;
+  }
+
+  const response = await fetch(checksumsAsset.browser_download_url, {
+    headers: accessToken ? { Authorization: `Bearer ${accessToken}` } : undefined,
+  });
+
+  if (!response.ok) {
+    return undefined;
+  }
+
+  const text = await response.text();
+  const checksums = new Map<string, string>();
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+
+    const parts = trimmed.split(/\s+/);
+    if (parts.length >= 2) {
+      checksums.set(parts[1]!, parts[0]!);
+    }
+  }
+
+  return checksums;
+};
+
+const verifyChecksum = async ({
+  data,
+  expectedHash,
+  fileName,
+}: {
+  data: Uint8Array;
+  expectedHash: string;
+  fileName: string;
+}) => {
+  const digest = await crypto.subtle.digest('SHA-256', data.slice().buffer);
+  const actualHash = Array.from(new Uint8Array(digest))
+    .map(byte => byte.toString(16).padStart(2, '0'))
+    .join('');
+
+  if (actualHash !== expectedHash) {
+    throw new Error(
+      `Checksum mismatch while repairing ${fileName}\n  Expected: ${expectedHash}\n  Actual:   ${actualHash}`
+    );
+  }
+};
+
+const resolveRepairReleaseTag = ({
+  execPath,
+  appVersion,
+}: {
+  execPath: string;
+  appVersion: string;
+}) =>
+  process.env.GITHUB_TAG?.trim() ||
+  readInstalledReleaseTag(execPath) ||
+  `@composio/cli@${appVersion}`;
+
+export const repairMissingInstalledRunCompanionModules = async ({
+  callerImportMetaUrl,
+  execPath,
+  appVersion,
+}: {
+  callerImportMetaUrl: string;
+  execPath: string;
+  appVersion: string;
+}) => {
+  const currentFilePath = fileURLToPath(callerImportMetaUrl);
+  if (!currentFilePath.startsWith('/$bunfs/')) {
+    return { repaired: false as const };
+  }
+
+  const missingModules = listMissingInstalledRunCompanionModules(execPath);
+  if (missingModules.length === 0) {
+    return { repaired: false as const };
+  }
+
+  const releaseTag = resolveRepairReleaseTag({ execPath, appVersion });
+  const githubConfig = {
+    apiBaseUrl: process.env.GITHUB_API_BASE_URL || DEFAULT_GITHUB_CONFIG.apiBaseUrl,
+    owner: process.env.GITHUB_OWNER || DEFAULT_GITHUB_CONFIG.owner,
+    repo: process.env.GITHUB_REPO || DEFAULT_GITHUB_CONFIG.repo,
+    accessToken: process.env.GITHUB_ACCESS_TOKEN,
+  };
+
+  const encodedTag = encodeURIComponent(releaseTag);
+  const release = await fetchGitHubJson<GitHubRelease>({
+    url: `${githubConfig.apiBaseUrl}/repos/${githubConfig.owner}/${githubConfig.repo}/releases/tags/${encodedTag}`,
+    accessToken: githubConfig.accessToken,
+    fetchErrorMessage: `Failed to fetch release metadata for ${releaseTag} while repairing run companion modules`,
+  }).catch(error => {
+    throw new Error(
+      [
+        `Unable to restore the files required by 'composio run' for ${releaseTag}.`,
+        error instanceof Error ? error.message : String(error),
+        `Reinstall the CLI, or set GITHUB_TAG to the exact release tag for this build and try again.`,
+      ].join('\n')
+    );
+  });
+
+  const assetName = resolveBinaryAssetName({});
+  const asset = release.assets.find(candidate => candidate.name === assetName);
+  if (!asset) {
+    throw new Error(
+      `Release ${release.tag_name} does not contain ${assetName}; cannot restore run companion modules.`
+    );
+  }
+
+  const archiveResponse = await fetch(asset.browser_download_url, {
+    headers: githubConfig.accessToken
+      ? { Authorization: `Bearer ${githubConfig.accessToken}` }
+      : undefined,
+  });
+  if (!archiveResponse.ok) {
+    throw new Error(
+      `Failed to download ${asset.name} from ${release.tag_name} while repairing run companion modules (HTTP ${archiveResponse.status}).`
+    );
+  }
+
+  const archiveData = new Uint8Array(await archiveResponse.arrayBuffer());
+  const checksums = await fetchChecksums({
+    release,
+    accessToken: githubConfig.accessToken,
+  });
+  const expectedChecksum = checksums?.get(asset.name);
+  if (expectedChecksum) {
+    await verifyChecksum({
+      data: archiveData,
+      expectedHash: expectedChecksum,
+      fileName: asset.name,
+    });
+  }
+
+  const tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'composio-run-repair-'));
+  try {
+    const archivePath = path.join(tempDirectory, asset.name);
+    const extractDirectory = path.join(tempDirectory, 'extract');
+    const packageDirectory = path.join(extractDirectory, path.parse(asset.name).name);
+    fs.writeFileSync(archivePath, archiveData);
+    fs.mkdirSync(extractDirectory, { recursive: true });
+    await decompress(archivePath, extractDirectory);
+
+    const installDirectory = resolveCompanionInstallDirectory(execPath);
+    for (const fileName of RUN_COMPANION_MODULE_FILENAMES) {
+      const sourcePath = path.join(packageDirectory, fileName);
+      if (!fs.existsSync(sourcePath)) {
+        throw new Error(
+          `Release ${release.tag_name} is missing ${fileName}; cannot restore the files required by 'composio run'.`
+        );
+      }
+
+      fs.copyFileSync(sourcePath, path.join(installDirectory, fileName));
+    }
+
+    writeInstalledReleaseTag(installDirectory, release.tag_name);
+    return {
+      repaired: true as const,
+      releaseTag: release.tag_name,
+    };
+  } finally {
+    fs.rmSync(tempDirectory, { recursive: true, force: true });
+  }
+};
 
 export const resolveRunCompanionModulePath = ({
   callerImportMetaUrl,

--- a/ts/packages/cli/src/services/upgrade-binary.ts
+++ b/ts/packages/cli/src/services/upgrade-binary.ts
@@ -12,7 +12,7 @@ import decompress from 'decompress';
 import type { Predicate } from 'effect/Predicate';
 import { renderPrettyError } from './utils/pretty-error';
 import { TerminalUI } from './terminal-ui';
-import { RUN_COMPANION_MODULE_FILENAMES } from './run-companion-modules';
+import { RUN_COMPANION_MODULE_FILENAMES, writeInstalledReleaseTag } from './run-companion-modules';
 
 export class UpgradeBinaryError extends Data.TaggedError('services/UpgradeBinaryError')<{
   readonly cause?: unknown;
@@ -449,7 +449,10 @@ export class UpgradeBinary extends Effect.Service<UpgradeBinary>()('services/Upg
      */
     const replaceBinary = (
       sourcePath: string,
-      targetPath: string
+      targetPath: string,
+      options: {
+        releaseTag?: string;
+      } = {}
     ): Effect.Effect<void, UpgradeBinaryError> =>
       Effect.gen(function* () {
         yield* Effect.logDebug(`Replacing binary: ${sourcePath} -> ${targetPath}`);
@@ -501,6 +504,17 @@ export class UpgradeBinary extends Effect.Service<UpgradeBinary>()('services/Upg
                 )
               )
             );
+        }
+
+        if (options.releaseTag) {
+          yield* Effect.try({
+            try: () => writeInstalledReleaseTag(targetDirectory, options.releaseTag!),
+            catch: error =>
+              new UpgradeBinaryError({
+                cause: error as Error,
+                message: 'Failed to update installed release metadata',
+              }),
+          });
         }
       });
 
@@ -571,7 +585,9 @@ export class UpgradeBinary extends Effect.Service<UpgradeBinary>()('services/Upg
               );
 
             const extractedBinary = yield* extractBinary({ name, data }, tmpDir);
-            yield* replaceBinary(extractedBinary.binaryPath, currentPath);
+            yield* replaceBinary(extractedBinary.binaryPath, currentPath, {
+              releaseTag: release.tag_name,
+            });
 
             yield* spinner.stop('Upgrade completed!');
             return release.tag_name;

--- a/ts/packages/cli/test/src/commands/run.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/run.cmd.test.ts
@@ -11,7 +11,13 @@ import {
   inferCliInvocationPrefix,
   wrapInlineCodeForRun,
 } from 'src/commands/run.cmd';
-import { resolveRunCompanionModulePath } from 'src/services/run-companion-modules';
+import {
+  RUN_COMPANION_MODULE_FILENAMES,
+  listMissingInstalledRunCompanionModules,
+  readInstalledReleaseTag,
+  resolveRunCompanionModulePath,
+  writeInstalledReleaseTag,
+} from 'src/services/run-companion-modules';
 import { buildStructuredPrompt, finalizeInvokeAgentText } from 'src/services/run-subagent-shared';
 import { cli, MockConsole, TestLive } from 'test/__utils__';
 
@@ -345,6 +351,27 @@ describe('resolveRunCompanionModulePath', () => {
         relativeNoExtensionFromCaller: '../services/run-subagent-shared',
       })
     ).toBe(companionPath);
+  });
+});
+
+describe('run companion install metadata', () => {
+  it('[Given] an installed release tag file [Then] run helpers can read it back from the install dir', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'composio-run-release-tag-'));
+    const execPath = path.join(tempDir, 'composio');
+
+    writeInstalledReleaseTag(tempDir, '@composio/cli@0.2.12');
+
+    expect(readInstalledReleaseTag(execPath)).toBe('@composio/cli@0.2.12');
+  });
+
+  it('[Given] a partial companion install [Then] it reports only the missing companion files', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'composio-run-missing-'));
+    const execPath = path.join(tempDir, 'composio');
+    fs.writeFileSync(path.join(tempDir, RUN_COMPANION_MODULE_FILENAMES[0]!), '', 'utf8');
+
+    expect(listMissingInstalledRunCompanionModules(execPath)).toEqual(
+      RUN_COMPANION_MODULE_FILENAMES.slice(1)
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

This changes `composio run` so an installed binary can recover missing `run-subagent-*.mjs` companion modules at runtime instead of failing immediately.

## What changed

- add run-time companion repair in `composio run`
- persist the installed release tag so `run` can fetch the matching release asset when repair is needed
- update binary upgrade flow to keep that release metadata current
- add CLI coverage for companion install metadata and missing companion detection
- include a patch changeset for `@composio/cli`

## Root cause

`composio run` launches a child Bun process that imports helper modules from disk. If the installed binary was missing the companion `.mjs` files, the command failed with `Cannot find module ... run-subagent-shared.mjs` before any user code ran.

## Impact

- future CLI binaries with this change can self-heal missing companion modules during `composio run`
- install and upgrade flows now record the release tag needed for deterministic repair
- already-shipped older binaries still need one reinstall to get this repair logic

## Validation

- `pnpm --filter @composio/cli test -- run.cmd.test.ts`
- `pnpm --filter @composio/cli run build:binary`
- verified a binary-only temp install containing just `composio` plus `release-tag.txt`; `composio run 'console.log("healed")'` restored the three companion modules and executed successfully
