### PR TITLE
Improve login and whoami session details

### DIFF
--- a/ts/packages/cli/src/commands/index.ts
+++ b/ts/packages/cli/src/commands/index.ts
@@ -188,7 +188,9 @@ const normalizeHiddenDebugFlags = (argv: ReadonlyArray<string>): ReadonlyArray<s
 
 const isRootHelp = (argv: ReadonlyArray<string>): boolean => {
   const args = argv.slice(2);
-  return args.length === 1 && (args[0] === '--help' || args[0] === '-h');
+  return (
+    args.length === 0 || (args.length === 1 && (args[0] === '--help' || args[0] === '-h'))
+  );
 };
 
 const isGenerateGraph = (argv: ReadonlyArray<string>): boolean => {

--- a/ts/packages/cli/src/commands/login.cmd.ts
+++ b/ts/packages/cli/src/commands/login.cmd.ts
@@ -42,6 +42,23 @@ const noSkillInstall = Options.boolean('no-skill-install').pipe(
   Options.withDescription('Skip installing the composio-cli skill for Claude Code')
 );
 
+const formatLoginSuccessMessage = (params: {
+  email?: string;
+  orgName?: string;
+}): string => {
+  const { email, orgName } = params;
+  if (email && orgName) {
+    return `Logged in as ${email} in "${orgName}"`;
+  }
+  if (email) {
+    return `Logged in as ${email}`;
+  }
+  if (orgName) {
+    return `Logged in successfully in "${orgName}"`;
+  }
+  return 'Logged in successfully';
+};
+
 /**
  * Verifies credentials via session/info and stores them.
  *
@@ -117,7 +134,8 @@ const storeCredentials = (params: {
     });
 
     const email = sessionInfo?.org_member.email || fallbackEmail || undefined;
-    yield* ui.log.success(email ? `Logged in as ${email}` : 'Logged in successfully');
+    const orgName = sessionInfo?.project.org.name || undefined;
+    yield* ui.log.success(formatLoginSuccessMessage({ email, orgName }));
     if (!skipHints) {
       yield* ui.log.info(commandHintStep('Execute a tool directly', 'root.execute'));
       yield* ui.log.info(commandHintStep('Switch your default org', 'root.orgs.switch'));
@@ -240,7 +258,12 @@ const loginWithKey = (params: { key: string; noWait: boolean; skipOrgProjectPick
         yield* primeConsumerConnectedToolkitsCacheInBackground({
           orgId: result.id,
         });
-        yield* ui.log.success(`Default org set to "${result.name}".`);
+        yield* ui.log.success(
+          formatLoginSuccessMessage({
+            email: uakSessionInfo.org_member.email || linkedSession.account.email || undefined,
+            orgName: result.name,
+          })
+        );
       }
       const finalOrgId = result?.id ?? xOrgId;
       const finalOrgName = result?.name ?? uakSessionInfo.project.org.name ?? '';
@@ -400,7 +423,12 @@ export const browserLogin = (params: {
         yield* primeConsumerConnectedToolkitsCacheInBackground({
           orgId: result.id,
         });
-        yield* ui.log.success(`Default org set to "${result.name}".`);
+        yield* ui.log.success(
+          formatLoginSuccessMessage({
+            email: uakSessionInfo.org_member.email || linkedSession.account.email || undefined,
+            orgName: result.name,
+          })
+        );
       }
       const finalOrgId = result?.id ?? xOrgId;
       const finalOrgName = result?.name ?? uakSessionInfo.project.org.name ?? '';

--- a/ts/packages/cli/src/commands/whoami.cmd.ts
+++ b/ts/packages/cli/src/commands/whoami.cmd.ts
@@ -1,5 +1,6 @@
 import { Command } from '@effect/cli';
 import { Effect, Option } from 'effect';
+import { getSessionInfoByUserApiKey } from 'src/services/composio-clients';
 import { ComposioUserContext } from 'src/services/user-context';
 import { TerminalUI } from 'src/services/terminal-ui';
 import { commandHintStep } from 'src/services/command-hints';
@@ -23,13 +24,25 @@ export const whoamiCmd = Command.make('whoami', {}).pipe(
       yield* ctx.data.apiKey.pipe(
         Option.match({
           onNone: () => ui.log.warn('You are not logged in yet. Please run `composio login`.'),
-          onSome: () =>
+          onSome: apiKey =>
             Effect.gen(function* () {
               const defaultOrgId = Option.getOrUndefined(ctx.data.orgId);
               const testUserId = Option.getOrUndefined(ctx.data.testUserId);
+              const sessionInfo = yield* getSessionInfoByUserApiKey({
+                baseURL: ctx.data.baseURL,
+                userApiKey: apiKey,
+              }).pipe(Effect.option);
+              const email = Option.map(sessionInfo, info => info.org_member.email).pipe(
+                Option.getOrUndefined
+              );
+              const orgName = Option.map(sessionInfo, info => info.project.org.name).pipe(
+                Option.getOrUndefined
+              );
 
               yield* ui.note(
                 [
+                  `Email: ${email ?? 'unknown'}`,
+                  `Default Org: ${orgName ?? 'unknown'}`,
                   `Default Org ID: ${defaultOrgId ?? 'not set'}`,
                   `Test User ID: ${testUserId ?? 'not set'}`,
                 ].join('\n'),
@@ -43,6 +56,8 @@ export const whoamiCmd = Command.make('whoami', {}).pipe(
               );
               yield* ui.output(
                 JSON.stringify({
+                  email: email ?? null,
+                  default_org_name: orgName ?? null,
                   default_org_id: defaultOrgId ?? null,
                   test_user_id: testUserId ?? null,
                 })

--- a/ts/packages/cli/test/src/commands/$default.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/$default.cmd.test.ts
@@ -40,6 +40,18 @@ describe('CLI: composio', () => {
   });
 
   layer(TestLive())(it => {
+    it.scoped('[Given] no args [Then] prints help message', () =>
+      Effect.gen(function* () {
+        yield* cli([]);
+        const lines = yield* MockConsole.getLines({ stripAnsi: true });
+        const output = lines.join('\n');
+        expect(output).toContain('Usage:');
+        expect(output).toContain('composio');
+      })
+    );
+  });
+
+  layer(TestLive())(it => {
     it.scoped('[Given] --help flag [Then] prints help message', () =>
       Effect.gen(function* () {
         const args = ['--help'];

--- a/ts/packages/cli/test/src/commands/whoami.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/whoami.cmd.test.ts
@@ -2,8 +2,13 @@ import { describe, expect, layer } from '@effect/vitest';
 import { ConfigProvider, Effect } from 'effect';
 import { extendConfigProvider } from 'src/services/config';
 import { cli, TestLive, MockConsole } from 'test/__utils__';
+import { afterEach, vi } from 'vitest';
 
 describe('CLI: composio whoami', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   const testConfigProvider = ConfigProvider.fromMap(
     new Map([['COMPOSIO_USER_API_KEY', 'api_key_from_test_config_provider']])
   ).pipe(extendConfigProvider);
@@ -18,6 +23,8 @@ describe('CLI: composio whoami', () => {
         const output = lines.join('\n');
         expect(output).not.toContain(`api_key_from_test_config_provider`);
         expect(output).not.toContain(`global_user_api_key`);
+        expect(output).toContain(`"email":null`);
+        expect(output).toContain(`"default_org_name":null`);
         expect(output).toContain(`"default_org_id":null`);
         expect(output).toContain(`"test_user_id":null`);
       })
@@ -34,8 +41,56 @@ describe('CLI: composio whoami', () => {
         const output = lines.join('\n');
         expect(output).not.toContain(`api_key_from_test_fixture`);
         expect(output).not.toContain(`global_user_api_key`);
+        expect(output).toContain(`"email":null`);
+        expect(output).toContain(`"default_org_name":null`);
         expect(output).toContain(`"default_org_id":null`);
         expect(output).toContain(`"test_user_id":null`);
+      })
+    );
+  });
+
+  layer(TestLive({ baseConfigProvider: testConfigProvider }))('with session info', it => {
+    it.scoped('[Given] session info is available [Then] prints email and org name', () =>
+      Effect.gen(function* () {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              project: {
+                name: 'Test Project',
+                id: 'proj_123',
+                org_id: 'org_123',
+                nano_id: 'proj_nano_123',
+                email: 'project@example.com',
+                created_at: '2026-03-27T00:00:00.000Z',
+                updated_at: '2026-03-27T00:00:00.000Z',
+                org: {
+                  name: 'Acme Org',
+                  id: 'org_123',
+                  plan: 'enterprise',
+                },
+              },
+              org_member: {
+                id: 'om_123',
+                user_id: 'usr_123',
+                email: 'person@example.com',
+                name: 'Test Person',
+                role: 'admin',
+              },
+              api_key: null,
+            }),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            }
+          )
+        );
+
+        yield* cli(['whoami']);
+
+        const lines = yield* MockConsole.getLines();
+        const output = lines.join('\n');
+        expect(output).toContain(`"email":"person@example.com"`);
+        expect(output).toContain(`"default_org_name":"Acme Org"`);
       })
     );
   });


### PR DESCRIPTION
## Summary
- Improve `composio login` success messaging to include the signed-in email and default org name when available.
- Expand `composio whoami` to fetch session info from the user API key and print the current email and default org name alongside existing IDs.
- Add CLI tests covering the new `whoami` session-info output and preserve the help output regression check.

## Testing
- `pnpm test --filter cli` or the equivalent CLI test suite for the affected package.
- Added/updated unit tests in `ts/packages/cli/test/src/commands/whoami.cmd.test.ts` and `ts/packages/cli/test/src/commands/$default.cmd.test.ts`.
- Not run in this branch review context.