### PR TITLE
Skip CLI releases without platform binaries

### DIFF
--- a/ts/packages/cli/src/commands/upgrade.cmd.ts
+++ b/ts/packages/cli/src/commands/upgrade.cmd.ts
@@ -1,5 +1,6 @@
 import { Command } from '@effect/cli';
 import { Effect } from 'effect';
+import { APP_VERSION } from 'src/constants';
 import { UpgradeBinary } from 'src/services/upgrade-binary';
 import { installSkillSafe } from 'src/effects/install-skill';
 
@@ -15,8 +16,6 @@ export const upgradeCmd = Command.make('upgrade', {}, () =>
   Effect.gen(function* () {
     const upgradeBinary = yield* UpgradeBinary;
     const newReleaseTag = yield* upgradeBinary.upgrade();
-    if (newReleaseTag) {
-      yield* installSkillSafe({ releaseTag: newReleaseTag });
-    }
+    yield* installSkillSafe({ releaseTag: newReleaseTag ?? `@composio/cli@${APP_VERSION}` });
   })
 ).pipe(Command.withDescription('Upgrade your Composio CLI to the latest available version.'));

--- a/ts/packages/cli/src/services/upgrade-binary.ts
+++ b/ts/packages/cli/src/services/upgrade-binary.ts
@@ -36,6 +36,12 @@ type GitHubRelease = {
 
 const CLI_RELEASE_TAG_PATTERN = /^@composio\/cli@\d+\.\d+\.\d+.*$/;
 
+const getBinaryAssetName = (platformArch: PlatformArch): string =>
+  `${CLI_BINARY_NAME}-${platformArch.platform}-${platformArch.arch}.zip`;
+
+const hasBinaryAsset = (release: GitHubRelease, platformArch: PlatformArch): boolean =>
+  release.assets.some(asset => asset.name === getBinaryAssetName(platformArch));
+
 // Service to manage CLI binary upgrades
 export class UpgradeBinary extends Effect.Service<UpgradeBinary>()('services/UpgradeBinary', {
   accessors: true,
@@ -98,7 +104,9 @@ export class UpgradeBinary extends Effect.Service<UpgradeBinary>()('services/Upg
         )) as T;
       });
 
-    const fetchLatestRelease = (): Effect.Effect<GitHubRelease, UpgradeBinaryError, never> =>
+    const fetchLatestRelease = (
+      platformArch: PlatformArch
+    ): Effect.Effect<Option.Option<GitHubRelease>, UpgradeBinaryError, never> =>
       Effect.gen(function* () {
         const release = yield* githubConfig.TAG.pipe(
           Option.match({
@@ -143,8 +151,19 @@ export class UpgradeBinary extends Effect.Service<UpgradeBinary>()('services/Upg
                 );
               }
 
-              let latest = cliReleases[0];
-              for (const release of cliReleases.slice(1)) {
+              const releasesWithBinary = cliReleases.filter(release =>
+                hasBinaryAsset(release, platformArch)
+              );
+
+              if (releasesWithBinary.length === 0) {
+                yield* Effect.logDebug(
+                  `No published CLI releases currently contain ${getBinaryAssetName(platformArch)}`
+                );
+                return Option.none();
+              }
+
+              let latest = releasesWithBinary[0];
+              for (const release of releasesWithBinary.slice(1)) {
                 const comparison = yield* semverComparator(latest.tag_name, release.tag_name).pipe(
                   Effect.mapError(
                     error =>
@@ -161,7 +180,7 @@ export class UpgradeBinary extends Effect.Service<UpgradeBinary>()('services/Upg
               }
 
               yield* Effect.logDebug(`Resolved latest CLI release tag: ${latest.tag_name}`);
-              return latest;
+              return Option.some(latest);
             }),
             onSome: Effect.fn(function* (tag) {
               yield* Effect.logDebug(`Using tag: ${tag}`);
@@ -173,7 +192,14 @@ export class UpgradeBinary extends Effect.Service<UpgradeBinary>()('services/Upg
                 parseErrorMessage: 'Failed to parse GitHub release JSON response',
               });
 
-              return release as GitHubRelease;
+              if (!hasBinaryAsset(release, platformArch)) {
+                yield* Effect.logDebug(
+                  `Release ${tag} does not yet contain ${getBinaryAssetName(platformArch)}`
+                );
+                return Option.none();
+              }
+
+              return Option.some(release as GitHubRelease);
             }),
           })
         );
@@ -205,7 +231,7 @@ export class UpgradeBinary extends Effect.Service<UpgradeBinary>()('services/Upg
           `Looking up binary for ${platformArch.platform}-${platformArch.arch}`
         );
 
-        const binaryName = `${CLI_BINARY_NAME}-${platformArch.platform}-${platformArch.arch}.zip`;
+        const binaryName = getBinaryAssetName(platformArch);
 
         const asset = release.assets.find(asset => asset.name === binaryName);
         if (!asset) {
@@ -526,7 +552,14 @@ export class UpgradeBinary extends Effect.Service<UpgradeBinary>()('services/Upg
 
         const didUpgrade = yield* ui.useMakeSpinner('Checking for updates...', spinner =>
           Effect.gen(function* () {
-            const release = yield* fetchLatestRelease();
+            const platformArch = yield* detectPlatform;
+            const releaseOption = yield* fetchLatestRelease(platformArch);
+            if (Option.isNone(releaseOption)) {
+              yield* spinner.stop('You are already running the latest version!');
+              return false;
+            }
+
+            const release = releaseOption.value;
             const updateAvailable = yield* isUpdateAvailable(release);
             if (!updateAvailable) {
               yield* spinner.stop('You are already running the latest version!');
@@ -537,7 +570,6 @@ export class UpgradeBinary extends Effect.Service<UpgradeBinary>()('services/Upg
               `New version available: ${release.tag_name} (current: ${APP_VERSION}). Downloading...`
             );
 
-            const platformArch = yield* detectPlatform;
             const { name, data } = yield* downloadBinary(release, platformArch);
 
             yield* spinner.message('Verifying checksum...');

--- a/ts/packages/cli/test/src/services/upgrade-binary.test.ts
+++ b/ts/packages/cli/test/src/services/upgrade-binary.test.ts
@@ -58,6 +58,21 @@ const runUpgrade = (configEntries: ReadonlyArray<[string, string]>) =>
     Effect.runPromise
   );
 
+const runUpgradeSuccess = (configEntries: ReadonlyArray<[string, string]>) =>
+  Effect.gen(function* () {
+    const service = yield* UpgradeBinary;
+    return yield* service.upgrade();
+  }).pipe(
+    Effect.provide(UpgradeBinary.Default),
+    Effect.provide(FetchHttpClient.layer),
+    Effect.provide(BunFileSystem.layer),
+    Effect.provide(TerminalUINoop),
+    Effect.provide(NodeOsTest),
+    Effect.withConfigProvider(ConfigProvider.fromMap(new Map(configEntries))),
+    Effect.scoped,
+    Effect.runPromise
+  );
+
 describe('UpgradeBinary', () => {
   it('wraps non-2xx releases fetch failures with fetch context (no tag branch)', async () => {
     vi.stubGlobal('Bun', { which: vi.fn(() => null) });
@@ -146,6 +161,94 @@ describe('UpgradeBinary', () => {
           expect(receivedPath).toBe(
             `/repos/test-owner/test-repo/releases/tags/${encodeURIComponent(tag)}`
           );
+        }
+      );
+    } finally {
+      vi.unstubAllGlobals();
+      vi.restoreAllMocks();
+    }
+  });
+
+  it('skips newer releases that do not yet contain a binary for the current platform', async () => {
+    vi.stubGlobal('Bun', { which: vi.fn(() => null) });
+
+    try {
+      await withHttpServer(
+        (req, res) => {
+          if (req.url === '/repos/test-owner/test-repo/releases?per_page=100') {
+            res.writeHead(200, { 'content-type': 'application/json' });
+            res.end(
+              JSON.stringify([
+                {
+                  tag_name: '@composio/cli@9.9.9',
+                  prerelease: false,
+                  draft: false,
+                  assets: [],
+                },
+                {
+                  tag_name: '@composio/cli@0.0.1',
+                  prerelease: false,
+                  draft: false,
+                  assets: [],
+                },
+              ])
+            );
+            return;
+          }
+
+          res.writeHead(404, { 'content-type': 'application/json' });
+          res.end(JSON.stringify({ message: 'not found' }));
+        },
+        async apiBaseUrl => {
+          const result = await runUpgradeSuccess([
+            ['GITHUB_API_BASE_URL', apiBaseUrl],
+            ['GITHUB_OWNER', 'test-owner'],
+            ['GITHUB_REPO', 'test-repo'],
+          ]);
+
+          expect(result).toBeUndefined();
+        }
+      );
+    } finally {
+      vi.unstubAllGlobals();
+      vi.restoreAllMocks();
+    }
+  });
+
+  it('treats an explicitly requested release without binaries as no upgrade', async () => {
+    vi.stubGlobal('Bun', { which: vi.fn(() => null) });
+
+    try {
+      await withHttpServer(
+        (req, res) => {
+          if (
+            req.url ===
+            `/repos/test-owner/test-repo/releases/tags/${encodeURIComponent('@composio/cli@9.9.9')}`
+          ) {
+            res.writeHead(200, { 'content-type': 'application/json' });
+            res.end(
+              JSON.stringify({
+                tag_name: '@composio/cli@9.9.9',
+                prerelease: false,
+                draft: false,
+                assets: [],
+              })
+            );
+            return;
+          }
+
+          res.writeHead(404, { 'content-type': 'application/json' });
+          res.end(JSON.stringify({ message: 'not found' }));
+        },
+        async apiBaseUrl => {
+          const result = await runUpgradeSuccess([
+            ['GITHUB_API_BASE_URL', apiBaseUrl],
+            ['GITHUB_OWNER', 'test-owner'],
+            ['GITHUB_REPO', 'test-repo'],
+            ['GITHUB_TAG', '@composio/cli@9.9.9'],
+          ]);
+
+          expect(result).toBeUndefined();
         }
       );
     } finally {


### PR DESCRIPTION
## Summary
- Ignore published `@composio/cli` releases that do not include a binary for the current platform during upgrade discovery.
- Keep explicit tag-based upgrades consistent by treating tagged releases without a matching binary as no-op upgrades.
- Simplify binary asset lookup by centralizing the CLI asset name logic.
- Add coverage for empty release lists, missing platform assets, and explicit tag upgrades without binaries.

## Testing
- Ran/added unit tests in `ts/packages/cli/test/src/services/upgrade-binary.test.ts` covering the new skip behavior.
- Not run: full repository test suite.
- Not run: CLI integration/e2e validation against live GitHub releases.