### PR TITLE
Harden `run subAgent` output handling and skip zsh completions on install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -239,7 +239,7 @@ else
             else
                 info "PATH already configured in \"$(tildify "$zsh_config")\""
             fi
-            refresh_command="exec $SHELL"
+            refresh_command="source $(tildify "$zsh_config")"
         else
             echo "Manually add the directory to $(tildify "$zsh_config") (or similar):"
             for cmd in "${commands[@]}"; do info_bold "  $cmd"; done

--- a/ts/packages/cli/src/commands/install.cmd.ts
+++ b/ts/packages/cli/src/commands/install.cmd.ts
@@ -162,7 +162,7 @@ export const installShellIntegration = (params: {
     // Lazy-import the root command to avoid a circular dependency
     // (index.ts → install.cmd.ts → index.ts).
     let completionScript: string | undefined;
-    if (!params.noCompletions) {
+    if (!params.noCompletions && shell !== 'zsh') {
       const mod = yield* Effect.promise(() => import('src/commands'));
       const lines = yield* getCompletionScript(mod.rootCommand, shell);
       completionScript = lines.length > 0 ? Arr.join(lines, '\n') : undefined;
@@ -191,7 +191,9 @@ export const installShellIntegration = (params: {
       yield* ui.log.step('PATH: already configured');
     }
 
-    if (config.completionBlock && !fileContains(existing, COMPLETIONS_MARKER)) {
+    if (shell === 'zsh') {
+      yield* ui.log.step('Completions: skipped for zsh');
+    } else if (config.completionBlock && !fileContains(existing, COMPLETIONS_MARKER)) {
       blocks.push(config.completionBlock);
       yield* ui.log.step('Completions: will install shell completions');
     } else if (params.noCompletions) {
@@ -222,7 +224,7 @@ export const installShellIntegration = (params: {
 
       yield* ui.log.success(`Updated ${tildify(rcPath, os.homedir)}`);
       yield* ui.note(
-        shell === 'fish' ? `source ${tildify(rcPath, os.homedir)}` : 'exec $SHELL',
+        shell === 'fish' || shell === 'zsh' ? `source ${tildify(rcPath, os.homedir)}` : 'exec $SHELL',
         'Restart your shell to apply changes'
       );
     } else {

--- a/ts/packages/cli/test/src/commands/install.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/install.cmd.test.ts
@@ -31,7 +31,7 @@ describe('CLI: composio install', () => {
 
   describe('[When] shell is zsh', () => {
     layer(TestLive())(it => {
-      it.scoped('[Then] creates .zshrc with PATH and completions', () =>
+      it.scoped('[Then] creates .zshrc with PATH only', () =>
         Effect.gen(function* () {
           const os = yield* NodeOs;
           process.env.SHELL = '/bin/zsh';
@@ -46,14 +46,15 @@ describe('CLI: composio install', () => {
           expect(contents).toContain('# Composio CLI');
           expect(contents).toContain('export COMPOSIO_INSTALL_DIR=');
           expect(contents).toContain('export PATH="$COMPOSIO_INSTALL_DIR:$PATH"');
-          expect(contents).toContain('# Composio CLI completions');
+          expect(contents).not.toContain('# Composio CLI completions');
 
           const lines = yield* MockConsole.getLines();
           const output = lines.join('\n');
           expect(output).toContain('Detected shell: zsh');
           expect(output).toContain('PATH: will add');
-          expect(output).toContain('Completions: will install shell completions');
+          expect(output).toContain('Completions: skipped for zsh');
           expect(output).toContain('Updated');
+          expect(output).toContain('source ~/.zshrc');
         })
       );
     });
@@ -153,7 +154,7 @@ describe('CLI: composio install', () => {
           expect(pathMarkerCount).toBe(1);
 
           const completionsCount = contents.match(/^# Composio CLI completions$/gm)?.length ?? 0;
-          expect(completionsCount).toBe(1);
+          expect(completionsCount).toBe(0);
         })
       );
     });
@@ -180,13 +181,12 @@ describe('CLI: composio install', () => {
           const lines = yield* MockConsole.getLines();
           const output = lines.join('\n');
           expect(output).toContain('PATH: already configured');
-          expect(output).toContain('Completions: already configured');
+          expect(output).toContain('Completions: skipped for zsh');
           expect(output).toContain('Shell integration already configured');
 
           // File should not have grown
           const contents = yield* fs.readFileString(rcPath);
           const markerCount = contents.split('# Composio CLI').length - 1;
-          // "# Composio CLI" appears in both the PATH block marker and the completions marker
           expect(markerCount).toBe(2);
         })
       );


### PR DESCRIPTION
## Summary
- Hardened `composio run` subagent execution to preserve structured output and recover more reliably when the primary prompt result is malformed.
- Added a dedicated MCP helper for structured output so helper runs can write results through a file-backed path instead of relying only on stderr/stdout parsing.
- Propagated run log and artifact paths through helper context so subagent logs land in the run log file consistently.
- Skipped zsh completion installation in `install.sh` and the CLI installer to avoid broken completion wiring for zsh users.
- Refreshed the CLI lockfile and bundled the new MCP runtime dependency into the CLI package.

## Testing
- `Not run`