### PR TITLE
[codex] bundle bun support files for standalone binaries

### DIFF
--- a/.changeset/bundle-bun-support.md
+++ b/.changeset/bundle-bun-support.md
@@ -1,0 +1,5 @@
+---
+"@composio/cli": patch
+---
+
+fix: bundle bun support files into CLI binary so standalone builds work without external bun dependencies

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -703,16 +703,16 @@ importers:
         version: link:../../packages/providers/llamaindex
       '@llamaindex/openai':
         specifier: ^0.4.20
-        version: 0.4.22(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(ws@8.19.0)(zod@4.3.6)
+        version: 0.4.22(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(ws@8.19.0)(zod@3.25.76)
       '@llamaindex/workflow':
         specifier: ^1.1.24
-        version: 1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono@4.11.9)(zod@4.3.6)
+        version: 1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(hono@4.11.9)(zod@3.25.76)
       dotenv:
         specifier: ^16.4.1
         version: 16.6.1
       llamaindex:
         specifier: ^0.12.0
-        version: 0.12.1(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono@4.11.9)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@4.3.6)
+        version: 0.12.1(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(hono@4.11.9)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@3.25.76)
     devDependencies:
       '@types/bun':
         specifier: ^1.2.9
@@ -1058,6 +1058,9 @@ importers:
       '@composio/core':
         specifier: workspace:*
         version: link:../core
+      '@composio/json-schema-to-zod':
+        specifier: workspace:*
+        version: link:../json-schema-to-zod
       '@composio/ts-builders':
         specifier: workspace:*
         version: link:../ts-builders
@@ -1339,7 +1342,7 @@ importers:
     dependencies:
       llamaindex:
         specifier: ^0.12.0
-        version: 0.12.1(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono@4.11.9)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@4.3.6)
+        version: 0.12.1(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@4.3.6)
     devDependencies:
       '@composio/core':
         specifier: workspace:*
@@ -7664,26 +7667,43 @@ snapshots:
       tree-sitter: 0.22.4
       web-tree-sitter: 0.24.7
 
-  '@llamaindex/openai@0.4.22(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(ws@8.19.0)(zod@4.3.6)':
+  '@llamaindex/openai@0.4.22(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(ws@8.19.0)(zod@3.25.76)':
     dependencies:
       '@llamaindex/core': 0.6.22
       '@llamaindex/env': 0.1.30
-      openai: 5.23.2(ws@8.19.0)(zod@4.3.6)
+      openai: 5.23.2(ws@8.19.0)(zod@3.25.76)
     transitivePeerDependencies:
       - ws
       - zod
 
-  '@llamaindex/workflow-core@1.3.3(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono@4.11.9)(zod@4.3.6)':
+  '@llamaindex/workflow-core@1.3.3(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(hono@4.11.9)(zod@3.25.76)':
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      '@modelcontextprotocol/sdk': 1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       hono: 4.11.9
+      zod: 3.25.76
+
+  '@llamaindex/workflow-core@1.3.3(zod@4.3.6)':
+    optionalDependencies:
       zod: 4.3.6
 
-  '@llamaindex/workflow@1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono@4.11.9)(zod@4.3.6)':
+  '@llamaindex/workflow@1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(hono@4.11.9)(zod@3.25.76)':
     dependencies:
       '@llamaindex/core': 0.6.22
       '@llamaindex/env': 0.1.30
-      '@llamaindex/workflow-core': 1.3.3(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono@4.11.9)(zod@4.3.6)
+      '@llamaindex/workflow-core': 1.3.3(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(hono@4.11.9)(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - hono
+      - next
+      - p-retry
+      - rxjs
+      - zod
+
+  '@llamaindex/workflow@1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(zod@4.3.6)':
+    dependencies:
+      '@llamaindex/core': 0.6.22
+      '@llamaindex/env': 0.1.30
+      '@llamaindex/workflow-core': 1.3.3(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - hono
@@ -8617,6 +8637,14 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@22.19.11)(tsx@4.21.0)(yaml@2.8.2)
 
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.10.13)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@24.10.13)(tsx@4.21.0)(yaml@2.8.2)
+
   '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
@@ -8646,7 +8674,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@22.19.11)(@vitest/ui@3.2.4)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 3.2.4(@types/node@24.10.13)(@vitest/ui@3.2.4)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -10054,12 +10082,34 @@ snapshots:
       rfdc: 1.4.1
       wrap-ansi: 9.0.2
 
-  llamaindex@0.12.1(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono@4.11.9)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@4.3.6):
+  llamaindex@0.12.1(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(hono@4.11.9)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@3.25.76):
     dependencies:
       '@llamaindex/core': 0.6.22
       '@llamaindex/env': 0.1.30
       '@llamaindex/node-parser': 2.0.22(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)
-      '@llamaindex/workflow': 1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono@4.11.9)(zod@4.3.6)
+      '@llamaindex/workflow': 1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(hono@4.11.9)(zod@3.25.76)
+      '@types/lodash': 4.17.23
+      '@types/node': 24.10.13
+      lodash: 4.17.23
+      magic-bytes.js: 1.13.0
+    transitivePeerDependencies:
+      - '@huggingface/transformers'
+      - '@modelcontextprotocol/sdk'
+      - gpt-tokenizer
+      - hono
+      - next
+      - p-retry
+      - rxjs
+      - tree-sitter
+      - web-tree-sitter
+      - zod
+
+  llamaindex@0.12.1(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@4.3.6):
+    dependencies:
+      '@llamaindex/core': 0.6.22
+      '@llamaindex/env': 0.1.30
+      '@llamaindex/node-parser': 2.0.22(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)
+      '@llamaindex/workflow': 1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(zod@4.3.6)
       '@types/lodash': 4.17.23
       '@types/node': 24.10.13
       lodash: 4.17.23
@@ -10338,6 +10388,11 @@ snapshots:
       define-lazy-prop: 3.0.0
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
+
+  openai@5.23.2(ws@8.19.0)(zod@3.25.76):
+    optionalDependencies:
+      ws: 8.19.0
+      zod: 3.25.76
 
   openai@5.23.2(ws@8.19.0)(zod@4.3.6):
     optionalDependencies:
@@ -11436,7 +11491,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@22.19.11)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.10.13)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4

--- a/ts/packages/cli/package.json
+++ b/ts/packages/cli/package.json
@@ -74,6 +74,7 @@
     "@clack/prompts": "catalog:",
     "@composio/client": "catalog:",
     "@composio/core": "workspace:*",
+    "@composio/json-schema-to-zod": "workspace:*",
     "@composio/ts-builders": "workspace:*",
     "@effect/cli": "catalog:",
     "@effect/platform-bun": "catalog:",

--- a/ts/packages/cli/scripts/_acp-adapters.ts
+++ b/ts/packages/cli/scripts/_acp-adapters.ts
@@ -1,9 +1,7 @@
 import { chmod, copyFile, mkdir, mkdtemp, readFile, rename, rm, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import * as path from 'node:path';
-import process from 'node:process';
 import decompress from 'decompress';
-import { $ } from 'bun';
 import { RUN_CODEX_ACP_BINARY_TARGETS } from '../src/services/run-companion-modules';
 
 const GENERATED_ROOT_DIR = path.resolve('./.generated');
@@ -12,6 +10,7 @@ const ACP_ADAPTERS_MANIFEST_PATH = path.join(GENERATED_ROOT_DIR, 'acp-adapters.m
 const REGISTRY_BASE_URL = 'https://registry.npmjs.org';
 const USER_AGENT = 'composio-cli-acp-vendor/1';
 const ACP_ADAPTERS_PREFIX = 'acp-adapters/';
+const ACP_ADAPTERS_CACHE_FORMAT_VERSION = 2;
 
 type PackageJson = {
   readonly bin?: Readonly<Record<string, string>>;
@@ -26,6 +25,7 @@ type RegistryVersionManifest = {
 };
 
 type AcpAdaptersManifest = {
+  readonly cacheFormatVersion: number;
   readonly claude: {
     readonly packageName: '@zed-industries/claude-code-acp';
     readonly version: string;
@@ -107,6 +107,7 @@ const buildCacheManifest = async (): Promise<AcpAdaptersManifest> => {
   }
 
   return {
+    cacheFormatVersion: ACP_ADAPTERS_CACHE_FORMAT_VERSION,
     claude: {
       packageName: '@zed-industries/claude-code-acp',
       version: claudePackage.version,
@@ -177,20 +178,51 @@ const downloadTarball = async (url: string, targetPath: string): Promise<void> =
   await writeFile(targetPath, new Uint8Array(await response.arrayBuffer()));
 };
 
-const buildClaudeAdapterBundle = async (cacheDir: string): Promise<void> => {
-  const outputPath = path.join(cacheDir, 'claude-code-acp.mjs');
-  const entryPath = await resolveClaudeAdapterEntryPath();
-  const result =
-    await $`${process.execPath} build ${entryPath} --target node --outfile ${outputPath}`.quiet();
-  if (result.exitCode !== 0) {
-    throw new Error('Failed to bundle claude-code-acp.mjs.');
+const bundleBunRuntimeFile = async ({
+  entryPath,
+  outputPath,
+}: {
+  readonly entryPath: string;
+  readonly outputPath: string;
+}): Promise<void> => {
+  const result = await Bun.build({
+    entrypoints: [entryPath],
+    outdir: path.dirname(outputPath),
+    naming: path.basename(outputPath),
+    target: 'bun',
+    format: 'esm',
+    packages: 'bundle',
+    sourcemap: 'none',
+  });
+
+  if (!result.success) {
+    const details = result.logs
+      .map(log => log.message)
+      .filter(message => message.length > 0)
+      .join('\n');
+    throw new Error(
+      details.length > 0
+        ? `Failed to bundle ${path.basename(outputPath)}:\n${details}`
+        : `Failed to bundle ${path.basename(outputPath)}.`
+    );
   }
 
   await chmod(outputPath, 0o755);
+};
+
+const buildClaudeAdapterBundle = async (cacheDir: string): Promise<void> => {
+  const outputPath = path.join(cacheDir, 'claude-code-acp.mjs');
+  const entryPath = await resolveClaudeAdapterEntryPath();
+  await bundleBunRuntimeFile({
+    entryPath,
+    outputPath,
+  });
 
   const cliOutputPath = path.join(cacheDir, 'cli.js');
-  await copyFile(resolveClaudeAgentSdkCliPath(), cliOutputPath);
-  await chmod(cliOutputPath, 0o755);
+  await bundleBunRuntimeFile({
+    entryPath: resolveClaudeAgentSdkCliPath(),
+    outputPath: cliOutputPath,
+  });
 };
 
 const extractCodexBinaryFromTarball = async ({

--- a/ts/packages/cli/scripts/_shared.ts
+++ b/ts/packages/cli/scripts/_shared.ts
@@ -1,13 +1,28 @@
-import { chmod, copyFile, mkdir, readdir, stat, writeFile } from 'node:fs/promises';
+import { builtinModules } from 'node:module';
+import { chmod, copyFile, mkdir, readdir, rm, stat, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
 import process from 'node:process';
 import { Cause, Effect, Exit } from 'effect';
 import type { Teardown } from '@effect/platform/Runtime';
-import {
-  collectRunCompanionAssetRelativePaths,
-  RUN_COMPANION_MODULE_BASENAMES,
-} from '../src/services/run-companion-modules';
+import { RUN_COMPANION_MODULE_BASENAMES } from '../src/services/run-companion-modules';
 import { materializeAcpAdaptersCache } from './_acp-adapters';
+
+const RUN_COMPANION_SERVICE_ENTRY_MAP = Object.fromEntries(
+  RUN_COMPANION_MODULE_BASENAMES.map(name => [`services/${name}`, `src/services/${name}.ts`])
+) satisfies Record<string, string>;
+
+const allowedRuntimeSpecifiers = new Set(
+  builtinModules.flatMap(specifier =>
+    specifier.startsWith('node:')
+      ? [specifier, specifier.slice('node:'.length)]
+      : [specifier, `node:${specifier}`]
+  )
+);
+
+const importStatementPattern = /(?:^|[;\n])\s*import\s+(?:[^'"`\n]+?\s+from\s+)?["']([^"']+)["']/gm;
+const exportStatementPattern =
+  /(?:^|[;\n])\s*export\s+(?:\*\s+from\s+|\{[^}\n]+\}\s+from\s+)["']([^"']+)["']/gm;
+const runtimeImportCallPattern = /(?:^|[^\w$.])(?:__require|require|import)\(\s*["']([^"']+)["']/g;
 
 const copyDirectoryRecursive = async (sourceDir: string, targetDir: string): Promise<void> => {
   await mkdir(targetDir, { recursive: true });
@@ -30,7 +45,226 @@ const copyDirectoryRecursive = async (sourceDir: string, targetDir: string): Pro
 const copyBundledAcpAdapters = async (outputDir: string): Promise<void> => {
   const acpAdaptersCacheDir = await materializeAcpAdaptersCache();
   const acpOutputDir = path.join(outputDir, 'acp-adapters');
+  await rm(acpOutputDir, { force: true, recursive: true });
   await copyDirectoryRecursive(acpAdaptersCacheDir, acpOutputDir);
+};
+
+const isAllowedRuntimeSpecifier = (specifier: string): boolean =>
+  specifier.startsWith('.') ||
+  specifier.startsWith('/') ||
+  specifier.startsWith('data:') ||
+  specifier === 'bun' ||
+  specifier.startsWith('bun:') ||
+  allowedRuntimeSpecifiers.has(specifier);
+
+const stripStringsAndComments = (source: string): string => {
+  let result = '';
+  let index = 0;
+
+  const appendSpace = (char: string) => {
+    result += char === '\n' ? '\n' : ' ';
+  };
+
+  while (index < source.length) {
+    const char = source[index];
+    const next = source[index + 1];
+
+    if (char === "'" || char === '"' || char === '`') {
+      const quote = char;
+      appendSpace(char);
+      index += 1;
+
+      while (index < source.length) {
+        const current = source[index];
+        appendSpace(current);
+        index += 1;
+
+        if (current === '\\') {
+          if (index < source.length) {
+            appendSpace(source[index]!);
+            index += 1;
+          }
+          continue;
+        }
+
+        if (current === quote) {
+          break;
+        }
+      }
+
+      continue;
+    }
+
+    if (char === '/' && next === '/') {
+      appendSpace(char);
+      appendSpace(next);
+      index += 2;
+
+      while (index < source.length) {
+        const current = source[index];
+        appendSpace(current);
+        index += 1;
+        if (current === '\n') {
+          break;
+        }
+      }
+
+      continue;
+    }
+
+    if (char === '/' && next === '*') {
+      appendSpace(char);
+      appendSpace(next);
+      index += 2;
+
+      while (index < source.length) {
+        const current = source[index];
+        const following = source[index + 1];
+        appendSpace(current);
+        index += 1;
+        if (current === '*' && following === '/') {
+          appendSpace(following);
+          index += 1;
+          break;
+        }
+      }
+
+      continue;
+    }
+
+    result += char;
+    index += 1;
+  }
+
+  return result;
+};
+
+const collectBundledSpecifiers = (source: string): ReadonlyArray<string> => {
+  const sanitizedSource = stripStringsAndComments(source);
+  const specifiers = new Set<string>();
+
+  for (const pattern of [
+    importStatementPattern,
+    exportStatementPattern,
+    runtimeImportCallPattern,
+  ]) {
+    for (const match of sanitizedSource.matchAll(pattern)) {
+      const specifier = match[1];
+      if (specifier) {
+        specifiers.add(specifier);
+      }
+    }
+  }
+
+  return [...specifiers];
+};
+
+const collectJavaScriptFiles = async (directory: string): Promise<ReadonlyArray<string>> => {
+  const collected: string[] = [];
+
+  const walk = async (directory: string): Promise<void> => {
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      const entryPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        await walk(entryPath);
+        continue;
+      }
+
+      if (/\.(?:m?js|cjs)$/.test(entry.name)) {
+        collected.push(entryPath);
+      }
+    }
+  };
+
+  await walk(directory);
+  return collected.sort();
+};
+
+const collectRuntimeFiles = async (rootDir: string): Promise<ReadonlyArray<string>> => {
+  const collected = new Set<string>();
+
+  for (const baseName of RUN_COMPANION_MODULE_BASENAMES) {
+    const wrapperPath = path.join(rootDir, `${baseName}.mjs`);
+    if (await Bun.file(wrapperPath).exists()) {
+      collected.add(wrapperPath);
+    }
+  }
+
+  for (const relativeDir of ['services', 'acp-adapters']) {
+    const absoluteDir = path.join(rootDir, relativeDir);
+    const exists = await stat(absoluteDir)
+      .then(stats => stats.isDirectory())
+      .catch(() => false);
+    if (!exists) {
+      continue;
+    }
+
+    for (const filePath of await collectJavaScriptFiles(absoluteDir)) {
+      collected.add(filePath);
+    }
+  }
+
+  return [...collected].sort();
+};
+
+const assertBundledRuntimeFiles = async (rootDir: string): Promise<void> => {
+  const files = await collectRuntimeFiles(rootDir);
+  const violations: string[] = [];
+
+  for (const filePath of files) {
+    const source = await Bun.file(filePath).text();
+    for (const specifier of collectBundledSpecifiers(source)) {
+      if (!specifier || isAllowedRuntimeSpecifier(specifier)) {
+        continue;
+      }
+
+      violations.push(`${path.relative(rootDir, filePath)} -> ${specifier}`);
+    }
+  }
+
+  if (violations.length > 0) {
+    throw new Error(
+      [
+        'Generated runtime support files still reference external packages:',
+        ...violations.map(violation => `  - ${violation}`),
+      ].join('\n')
+    );
+  }
+};
+
+const buildCompanionServiceBundles = async (outputDir: string): Promise<void> => {
+  const servicesOutputDir = path.join(outputDir, 'services');
+  await rm(servicesOutputDir, { force: true, recursive: true });
+  await mkdir(servicesOutputDir, { recursive: true });
+
+  for (const [entryName, entryPath] of Object.entries(RUN_COMPANION_SERVICE_ENTRY_MAP)) {
+    const relativeOutputPath = `${entryName}.mjs`;
+    const outputDirectory = path.join(outputDir, path.dirname(relativeOutputPath));
+    const outputFileName = path.basename(relativeOutputPath);
+    await mkdir(outputDirectory, { recursive: true });
+
+    const result = await Bun.build({
+      entrypoints: [path.resolve(entryPath)],
+      outdir: outputDirectory,
+      naming: outputFileName,
+      target: 'bun',
+      format: 'esm',
+      packages: 'bundle',
+      sourcemap: 'none',
+    });
+
+    if (!result.success) {
+      const details = result.logs
+        .map(log => log.message)
+        .filter(message => message.length > 0)
+        .join('\n');
+      throw new Error(
+        details.length > 0
+          ? `Failed to bundle ${entryName}:\n${details}`
+          : `Failed to bundle ${entryName}.`
+      );
+    }
+  }
 };
 
 /**
@@ -49,30 +283,7 @@ export const buildCompanionModules = (outputDir: string) =>
   Effect.gen(function* () {
     yield* Effect.tryPromise(() => mkdir(outputDir, { recursive: true }));
 
-    const compiledRootDir = path.resolve('./dist');
-    const companionRelativePaths = collectRunCompanionAssetRelativePaths(compiledRootDir);
-    if (companionRelativePaths.length === 0) {
-      return yield* Effect.fail(
-        new Error('Missing compiled run companion modules. Run `pnpm build:packages` first.')
-      );
-    }
-
-    for (const relativePath of companionRelativePaths) {
-      const sourcePath = path.join(compiledRootDir, relativePath);
-      const targetPath = path.join(outputDir, relativePath);
-
-      yield* Effect.tryPromise(async () => {
-        if (!(await Bun.file(sourcePath).exists())) {
-          throw new Error(`Missing companion module: ${sourcePath}`);
-        }
-        if (path.resolve(sourcePath) === path.resolve(targetPath)) {
-          return;
-        }
-
-        await mkdir(path.dirname(targetPath), { recursive: true });
-        await copyFile(sourcePath, targetPath);
-      });
-    }
+    yield* Effect.tryPromise(() => buildCompanionServiceBundles(outputDir));
 
     for (const name of RUN_COMPANION_MODULE_BASENAMES) {
       const wrapperPath = path.join(outputDir, `${name}.mjs`);
@@ -81,4 +292,5 @@ export const buildCompanionModules = (outputDir: string) =>
     }
 
     yield* Effect.tryPromise(() => copyBundledAcpAdapters(outputDir));
+    yield* Effect.tryPromise(() => assertBundledRuntimeFiles(outputDir));
   });

--- a/ts/packages/cli/src/services/run-subagent-output-mcp.ts
+++ b/ts/packages/cli/src/services/run-subagent-output-mcp.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs';
 import process from 'node:process';
-import { jsonSchemaToZodSchema } from '@composio/core';
+import { jsonSchemaToZod } from '@composio/json-schema-to-zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import {
@@ -22,7 +22,7 @@ const main = async (): Promise<void> => {
   const resultFilePath = readFlag('--result-file');
   const schemaText = fs.readFileSync(schemaFilePath, 'utf8');
   const structuredSchema = JSON.parse(schemaText) as Record<string, unknown>;
-  const toolInputSchema = jsonSchemaToZodSchema(buildStructuredOutputToolSchema(structuredSchema));
+  const toolInputSchema = jsonSchemaToZod(buildStructuredOutputToolSchema(structuredSchema));
 
   const server = new McpServer({
     name: 'composio-subagent-output',

--- a/ts/packages/cli/test/src/services/run-subagent-output-mcp.test.ts
+++ b/ts/packages/cli/test/src/services/run-subagent-output-mcp.test.ts
@@ -11,6 +11,8 @@ describe('run-subagent-output-mcp source', () => {
 
     expect(source).toContain("from '@modelcontextprotocol/sdk/server/mcp.js'");
     expect(source).toContain("from '@modelcontextprotocol/sdk/server/stdio.js'");
+    expect(source).toContain("from '@composio/json-schema-to-zod'");
+    expect(source).not.toContain("from '@composio/core'");
     expect(source).not.toContain('@modelcontextprotocol/sdk/package.json');
     expect(source).not.toContain('createRequire(import.meta.url)');
   });


### PR DESCRIPTION
## Summary
- bundle the shipped `composio run` companion services with direct `Bun.build(..., target: "bun")` output instead of reusing the shared `dist` graph
- rebuild the Claude ACP support files as Bun-bundled runtime assets and invalidate the cached adapter layout so stale raw files are not reused
- add runtime validation for shipped support files, wire the MCP helper through the workspace `@composio/json-schema-to-zod` package, and cover the static-import expectation in tests

## Why
Standalone binaries were still relying on external runtime dependencies from companion support files. On a clean machine this surfaced as failures like `Cannot find package 'decompress'` from the generated companion modules. The fix is to make every shipped support file self-contained for Bun and package exactly that tree into the binary archives.

## Validation
- `pnpm run typecheck`
- `pnpm exec vitest run test/src/services/run-subagent-output-mcp.test.ts test/src/services/run-subagent-acp.test.ts`
- `pnpm run build:binary:all`
- `pnpm run build:binary:package`
- unpacked `dist/binaries/composio-darwin-aarch64.zip` and verified `experimental_subAgent(..., { target: "codex", schema: ... })`
- unpacked `dist/binaries/composio-darwin-aarch64.zip` and verified `experimental_subAgent(..., { target: "claude", schema: ... })`
