### PR TITLE
ci: add changelog date validation check

### DIFF
--- a/.github/workflows/docs.changelog-date-check.yml
+++ b/.github/workflows/docs.changelog-date-check.yml
@@ -30,6 +30,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Validate changelog dates
+        id: validate
         if: steps.changed.outputs.found == 'true'
         run: |
           TODAY_UTC=$(date -u +%Y-%m-%d)
@@ -49,7 +50,7 @@ jobs:
             # Extract MM-DD-YY from filename (first 8 chars, e.g. 03-28-26)
             FILENAME_DATE_RAW=$(echo "$BASENAME" | grep -oP '^\d{2}-\d{2}-\d{2}')
             if [ -z "$FILENAME_DATE_RAW" ]; then
-              ERRORS="${ERRORS}\n❌ $FILE — filename does not start with a MM-DD-YY date"
+              ERRORS="${ERRORS}\n- $FILE — filename does not start with a MM-DD-YY date"
               continue
             fi
 
@@ -64,12 +65,12 @@ jobs:
 
             # Check filename date matches frontmatter date
             if [ -n "$FRONTMATTER_DATE" ] && [ "$FILENAME_DATE" != "$FRONTMATTER_DATE" ]; then
-              ERRORS="${ERRORS}\n❌ $FILE — filename date ($FILENAME_DATE) does not match frontmatter date ($FRONTMATTER_DATE)"
+              ERRORS="${ERRORS}\n- $FILE — filename date ($FILENAME_DATE) does not match frontmatter date ($FRONTMATTER_DATE)"
             fi
 
             # Check date is not stale (must be today or yesterday UTC)
             if [ "$FILENAME_DATE" != "$TODAY_UTC" ] && [ "$FILENAME_DATE" != "$YESTERDAY_UTC" ]; then
-              ERRORS="${ERRORS}\n❌ $FILE — date $FILENAME_DATE is stale. Changelog dates must be today ($TODAY_UTC) or yesterday ($YESTERDAY_UTC). Please rename the file and update the frontmatter date."
+              ERRORS="${ERRORS}\n- $FILE — date $FILENAME_DATE is stale (expected $TODAY_UTC or $YESTERDAY_UTC)"
             fi
 
             echo "   filename date:     $FILENAME_DATE"
@@ -87,7 +88,24 @@ jobs:
             echo "Changelog filenames must use today's date."
             echo "Format: MM-DD-YY-optional-slug.mdx"
             echo "========================================="
+
+            # Save errors for Slack notification
+            echo "errors<<EOF" >> $GITHUB_OUTPUT
+            echo -e "$ERRORS" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+
             exit 1
           fi
 
           echo "✅ All changelog dates are valid"
+
+      - name: Alert pod-dx on Slack
+        if: failure() && steps.validate.outcome == 'failure'
+        uses: slackapi/slack-github-action@fcfb566f8b0aab22203f066d80ca1d7e4b5d05b3 # v1.27.1
+        with:
+          payload: |
+            {
+              "text": "*Stale Changelog Date Detected*\n\nPR: <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} — ${{ github.event.pull_request.title }}>\nAuthor: ${{ github.event.pull_request.user.login }}\n\nErrors:\n${{ steps.validate.outputs.errors }}\n\nPlease update the changelog filename and frontmatter date before merging."
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_POD_DX_WEBHOOK_URL }}

--- a/.github/workflows/docs.changelog-date-check.yml
+++ b/.github/workflows/docs.changelog-date-check.yml
@@ -1,0 +1,93 @@
+name: Changelog Date Check
+
+on:
+  pull_request:
+    branches: [next]
+    paths:
+      - 'docs/content/changelog/**.mdx'
+
+jobs:
+  validate-changelog-date:
+    name: Validate Changelog Date
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Get changed changelog files
+        id: changed
+        run: |
+          FILES=$(gh pr diff "${{ github.event.pull_request.number }}" --name-only | grep '^docs/content/changelog/.*\.mdx$' || echo "")
+          if [ -z "$FILES" ]; then
+            echo "found=false" >> $GITHUB_OUTPUT
+          else
+            echo "found=true" >> $GITHUB_OUTPUT
+            echo "files<<EOF" >> $GITHUB_OUTPUT
+            echo "$FILES" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate changelog dates
+        if: steps.changed.outputs.found == 'true'
+        run: |
+          TODAY_UTC=$(date -u +%Y-%m-%d)
+          YESTERDAY_UTC=$(date -u -d "yesterday" +%Y-%m-%d)
+          ERRORS=""
+
+          echo "UTC today:     $TODAY_UTC"
+          echo "UTC yesterday: $YESTERDAY_UTC"
+          echo ""
+
+          while IFS= read -r FILE; do
+            [ -z "$FILE" ] && continue
+            BASENAME=$(basename "$FILE" .mdx)
+
+            echo "Checking: $FILE"
+
+            # Extract MM-DD-YY from filename (first 8 chars, e.g. 03-28-26)
+            FILENAME_DATE_RAW=$(echo "$BASENAME" | grep -oP '^\d{2}-\d{2}-\d{2}')
+            if [ -z "$FILENAME_DATE_RAW" ]; then
+              ERRORS="${ERRORS}\n❌ $FILE — filename does not start with a MM-DD-YY date"
+              continue
+            fi
+
+            # Convert MM-DD-YY to YYYY-MM-DD
+            MM=$(echo "$FILENAME_DATE_RAW" | cut -d'-' -f1)
+            DD=$(echo "$FILENAME_DATE_RAW" | cut -d'-' -f2)
+            YY=$(echo "$FILENAME_DATE_RAW" | cut -d'-' -f3)
+            FILENAME_DATE="20${YY}-${MM}-${DD}"
+
+            # Extract date from frontmatter
+            FRONTMATTER_DATE=$(grep '^date:' "$FILE" | head -1 | sed 's/^date: *["\x27]*//' | sed 's/["\x27]*$//')
+
+            # Check filename date matches frontmatter date
+            if [ -n "$FRONTMATTER_DATE" ] && [ "$FILENAME_DATE" != "$FRONTMATTER_DATE" ]; then
+              ERRORS="${ERRORS}\n❌ $FILE — filename date ($FILENAME_DATE) does not match frontmatter date ($FRONTMATTER_DATE)"
+            fi
+
+            # Check date is not stale (must be today or yesterday UTC)
+            if [ "$FILENAME_DATE" != "$TODAY_UTC" ] && [ "$FILENAME_DATE" != "$YESTERDAY_UTC" ]; then
+              ERRORS="${ERRORS}\n❌ $FILE — date $FILENAME_DATE is stale. Changelog dates must be today ($TODAY_UTC) or yesterday ($YESTERDAY_UTC). Please rename the file and update the frontmatter date."
+            fi
+
+            echo "   filename date:     $FILENAME_DATE"
+            echo "   frontmatter date:  $FRONTMATTER_DATE"
+            echo ""
+          done <<< "${{ steps.changed.outputs.files }}"
+
+          if [ -n "$ERRORS" ]; then
+            echo ""
+            echo "========================================="
+            echo "CHANGELOG DATE VALIDATION FAILED"
+            echo "========================================="
+            echo -e "$ERRORS"
+            echo ""
+            echo "Changelog filenames must use today's date."
+            echo "Format: MM-DD-YY-optional-slug.mdx"
+            echo "========================================="
+            exit 1
+          fi
+
+          echo "✅ All changelog dates are valid"

--- a/.github/workflows/docs.changelog-date-check.yml
+++ b/.github/workflows/docs.changelog-date-check.yml
@@ -14,24 +14,66 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
-      - name: Get changed changelog files
+      - name: Classify changed changelog files
         id: changed
         run: |
-          FILES=$(gh pr diff "${{ github.event.pull_request.number }}" --name-only | grep '^docs/content/changelog/.*\.mdx$' || echo "")
-          if [ -z "$FILES" ]; then
+          # Get all changelog files in the PR diff
+          ALL_FILES=$(gh pr diff "${{ github.event.pull_request.number }}" --name-only | grep '^docs/content/changelog/.*\.mdx$' || echo "")
+
+          if [ -z "$ALL_FILES" ]; then
             echo "found=false" >> $GITHUB_OUTPUT
-          else
-            echo "found=true" >> $GITHUB_OUTPUT
-            echo "files<<EOF" >> $GITHUB_OUTPUT
-            echo "$FILES" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "found=true" >> $GITHUB_OUTPUT
+
+          # Separate into new vs modified files using the merge base
+          BASE_SHA=$(gh pr view "${{ github.event.pull_request.number }}" --json baseRefOid -q .baseRefOid)
+          NEW_FILES=""
+          MODIFIED_FILES=""
+
+          while IFS= read -r FILE; do
+            [ -z "$FILE" ] && continue
+            if git cat-file -e "${BASE_SHA}:${FILE}" 2>/dev/null; then
+              MODIFIED_FILES="${MODIFIED_FILES}${FILE}\n"
+            else
+              NEW_FILES="${NEW_FILES}${FILE}\n"
+            fi
+          done <<< "$ALL_FILES"
+
+          # Trim trailing newlines
+          NEW_FILES=$(echo -e "$NEW_FILES" | sed '/^$/d')
+          MODIFIED_FILES=$(echo -e "$MODIFIED_FILES" | sed '/^$/d')
+
+          echo "New files:"
+          echo "$NEW_FILES"
+          echo ""
+          echo "Modified files:"
+          echo "$MODIFIED_FILES"
+
+          if [ -n "$NEW_FILES" ]; then
+            echo "has_new=true" >> $GITHUB_OUTPUT
+            echo "new_files<<EOF" >> $GITHUB_OUTPUT
+            echo "$NEW_FILES" >> $GITHUB_OUTPUT
             echo "EOF" >> $GITHUB_OUTPUT
+          else
+            echo "has_new=false" >> $GITHUB_OUTPUT
+          fi
+
+          if [ -n "$MODIFIED_FILES" ]; then
+            echo "has_modified=true" >> $GITHUB_OUTPUT
+            echo "modified_files<<EOF" >> $GITHUB_OUTPUT
+            echo "$MODIFIED_FILES" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          else
+            echo "has_modified=false" >> $GITHUB_OUTPUT
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Validate changelog dates
+      - name: Validate new changelog dates
         id: validate
-        if: steps.changed.outputs.found == 'true'
+        if: steps.changed.outputs.has_new == 'true'
         run: |
           TODAY_UTC=$(date -u +%Y-%m-%d)
           YESTERDAY_UTC=$(date -u -d "yesterday" +%Y-%m-%d)
@@ -76,7 +118,7 @@ jobs:
             echo "   filename date:     $FILENAME_DATE"
             echo "   frontmatter date:  $FRONTMATTER_DATE"
             echo ""
-          done <<< "${{ steps.changed.outputs.files }}"
+          done <<< "${{ steps.changed.outputs.new_files }}"
 
           if [ -n "$ERRORS" ]; then
             echo ""
@@ -97,15 +139,26 @@ jobs:
             exit 1
           fi
 
-          echo "✅ All changelog dates are valid"
+          echo "✅ All new changelog dates are valid"
 
-      - name: Alert pod-dx on Slack
+      - name: Alert pod-dx — stale date
         if: failure() && steps.validate.outcome == 'failure'
         uses: slackapi/slack-github-action@fcfb566f8b0aab22203f066d80ca1d7e4b5d05b3 # v1.27.1
         with:
           payload: |
             {
               "text": "*Stale Changelog Date Detected*\n\nPR: <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} — ${{ github.event.pull_request.title }}>\nAuthor: ${{ github.event.pull_request.user.login }}\n\nErrors:\n${{ steps.validate.outputs.errors }}\n\nPlease update the changelog filename and frontmatter date before merging."
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_POD_DX_WEBHOOK_URL }}
+
+      - name: Alert pod-dx — old changelog edited
+        if: always() && steps.changed.outputs.has_modified == 'true'
+        uses: slackapi/slack-github-action@fcfb566f8b0aab22203f066d80ca1d7e4b5d05b3 # v1.27.1
+        with:
+          payload: |
+            {
+              "text": "*Old Changelog Edited*\n\nPR: <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} — ${{ github.event.pull_request.title }}>\nAuthor: ${{ github.event.pull_request.user.login }}\n\nModified files:\n${{ steps.changed.outputs.modified_files }}\n\nPlease review — edits to published changelogs may need extra attention."
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_POD_DX_WEBHOOK_URL }}

--- a/.github/workflows/docs.changelog-date-check.yml
+++ b/.github/workflows/docs.changelog-date-check.yml
@@ -18,7 +18,7 @@ jobs:
         id: changed
         run: |
           # Get all changelog files in the PR diff
-          ALL_FILES=$(gh pr diff "${{ github.event.pull_request.number }}" --name-only | grep '^docs/content/changelog/.*\.mdx$' || echo "")
+          ALL_FILES=$(gh pr diff "$PR_NUMBER" --name-only | grep '^docs/content/changelog/.*\.mdx$' || echo "")
 
           if [ -z "$ALL_FILES" ]; then
             echo "found=false" >> $GITHUB_OUTPUT
@@ -28,7 +28,7 @@ jobs:
           echo "found=true" >> $GITHUB_OUTPUT
 
           # Separate into new vs modified files using the merge base
-          BASE_SHA=$(gh pr view "${{ github.event.pull_request.number }}" --json baseRefOid -q .baseRefOid)
+          BASE_SHA=$(gh pr view "$PR_NUMBER" --json baseRefOid -q .baseRefOid)
           NEW_FILES=""
           MODIFIED_FILES=""
 
@@ -70,6 +70,7 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
 
       - name: Validate new changelog dates
         id: validate
@@ -90,7 +91,7 @@ jobs:
             echo "Checking: $FILE"
 
             # Extract MM-DD-YY from filename (first 8 chars, e.g. 03-28-26)
-            FILENAME_DATE_RAW=$(echo "$BASENAME" | grep -oP '^\d{2}-\d{2}-\d{2}')
+            FILENAME_DATE_RAW=$(echo "$BASENAME" | grep -oP '^\d{2}-\d{2}-\d{2}' || true)
             if [ -z "$FILENAME_DATE_RAW" ]; then
               ERRORS="${ERRORS}\n- $FILE — filename does not start with a MM-DD-YY date"
               continue
@@ -103,7 +104,7 @@ jobs:
             FILENAME_DATE="20${YY}-${MM}-${DD}"
 
             # Extract date from frontmatter
-            FRONTMATTER_DATE=$(grep '^date:' "$FILE" | head -1 | sed 's/^date: *["\x27]*//' | sed 's/["\x27]*$//')
+            FRONTMATTER_DATE=$(grep '^date:' "$FILE" | head -1 | sed 's/^date: *["\x27]*//' | sed 's/["\x27]*$//' || true)
 
             # Check filename date matches frontmatter date
             if [ -n "$FRONTMATTER_DATE" ] && [ "$FILENAME_DATE" != "$FRONTMATTER_DATE" ]; then
@@ -118,7 +119,7 @@ jobs:
             echo "   filename date:     $FILENAME_DATE"
             echo "   frontmatter date:  $FRONTMATTER_DATE"
             echo ""
-          done <<< "${{ steps.changed.outputs.new_files }}"
+          done <<< "$NEW_FILES"
 
           if [ -n "$ERRORS" ]; then
             echo ""
@@ -131,34 +132,51 @@ jobs:
             echo "Format: MM-DD-YY-optional-slug.mdx"
             echo "========================================="
 
-            # Save errors for Slack notification
-            echo "errors<<EOF" >> $GITHUB_OUTPUT
-            echo -e "$ERRORS" >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
+            # Save errors for Slack notification (single line for JSON safety)
+            ERRORS_ONELINE=$(echo -e "$ERRORS" | tr '\n' ' ')
+            echo "errors=$ERRORS_ONELINE" >> $GITHUB_OUTPUT
 
             exit 1
           fi
 
-          echo "✅ All new changelog dates are valid"
+          echo "All new changelog dates are valid"
+        env:
+          NEW_FILES: ${{ steps.changed.outputs.new_files }}
 
       - name: Alert pod-dx — stale date
         if: failure() && steps.validate.outcome == 'failure'
-        uses: slackapi/slack-github-action@fcfb566f8b0aab22203f066d80ca1d7e4b5d05b3 # v1.27.1
-        with:
-          payload: |
-            {
-              "text": "*Stale Changelog Date Detected*\n\nPR: <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} — ${{ github.event.pull_request.title }}>\nAuthor: ${{ github.event.pull_request.user.login }}\n\nErrors:\n${{ steps.validate.outputs.errors }}\n\nPlease update the changelog filename and frontmatter date before merging."
-            }
+        run: |
+          PAYLOAD=$(jq -n \
+            --arg pr_url "$PR_URL" \
+            --arg pr_num "$PR_NUM" \
+            --arg pr_title "$PR_TITLE" \
+            --arg author "$PR_AUTHOR" \
+            --arg errors "$ERRORS" \
+            '{text: "*Stale Changelog Date Detected*\n\nPR: <\($pr_url)|#\($pr_num) — \($pr_title)>\nAuthor: \($author)\n\nErrors: \($errors)\n\nPlease update the changelog filename and frontmatter date before merging."}')
+          curl -X POST -H 'Content-type: application/json' --data "$PAYLOAD" "$SLACK_WEBHOOK_URL"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_POD_DX_WEBHOOK_URL }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          ERRORS: ${{ steps.validate.outputs.errors }}
 
       - name: Alert pod-dx — old changelog edited
         if: always() && steps.changed.outputs.has_modified == 'true'
-        uses: slackapi/slack-github-action@fcfb566f8b0aab22203f066d80ca1d7e4b5d05b3 # v1.27.1
-        with:
-          payload: |
-            {
-              "text": "*Old Changelog Edited*\n\nPR: <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} — ${{ github.event.pull_request.title }}>\nAuthor: ${{ github.event.pull_request.user.login }}\n\nModified files:\n${{ steps.changed.outputs.modified_files }}\n\nPlease review — edits to published changelogs may need extra attention."
-            }
+        run: |
+          PAYLOAD=$(jq -n \
+            --arg pr_url "$PR_URL" \
+            --arg pr_num "$PR_NUM" \
+            --arg pr_title "$PR_TITLE" \
+            --arg author "$PR_AUTHOR" \
+            --arg files "$MODIFIED_FILES" \
+            '{text: "*Old Changelog Edited*\n\nPR: <\($pr_url)|#\($pr_num) — \($pr_title)>\nAuthor: \($author)\n\nModified files: \($files)\n\nPlease review — edits to published changelogs may need extra attention."}')
+          curl -X POST -H 'Content-type: application/json' --data "$PAYLOAD" "$SLACK_WEBHOOK_URL"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_POD_DX_WEBHOOK_URL }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          MODIFIED_FILES: ${{ steps.changed.outputs.modified_files }}


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that validates changelog file dates on PRs to `next`
- Fails if the filename date is more than 1 day old (UTC), catching stale-dated changelogs
- Also validates that filename date matches the frontmatter `date:` field

## Setup required after merge
Add **"Validate Changelog Date"** as a required status check in branch protection rules for `next` (Settings → Branches → `next` → Require status checks).

## Test plan
- [ ] Open a PR with a changelog dated today — check passes
- [ ] Open a PR with a changelog dated >1 day ago — check fails with clear error message
- [ ] Verify filename/frontmatter date mismatch is caught

🤖 Generated with [Claude Code](https://claude.com/claude-code)