### PR TITLE
fix(anthropic): truncate schema property keys exceeding 64-char limit

### DIFF
--- a/ts/packages/providers/anthropic/src/index.ts
+++ b/ts/packages/providers/anthropic/src/index.ts
@@ -18,6 +18,7 @@ import {
 } from '@composio/core';
 import Anthropic from '@anthropic-ai/sdk';
 import { AnthropicTool, InputSchema } from './types';
+import { sanitizeSchemaPropertyKeys, restoreOriginalKeys } from './sanitize-keys';
 
 export type AnthropicMcpServerGetResponse = {
   type: 'url';
@@ -58,6 +59,13 @@ export class AnthropicProvider extends BaseNonAgenticProvider<
 > {
   readonly name = 'anthropic';
   private chacheTools: boolean = false;
+  /**
+   * @internal
+   * Stores reverse key mappings per tool slug.
+   * When property keys are truncated to comply with Anthropic's 64-char limit,
+   * this map allows restoring original keys during tool execution.
+   */
+  private _toolKeyMaps: Map<string, Map<string, string>> = new Map();
 
   /**
    * Creates a new instance of the AnthropicProvider.
@@ -118,14 +126,28 @@ export class AnthropicProvider extends BaseNonAgenticProvider<
    * ```
    */
   override wrapTool(tool: ComposioTool): AnthropicTool {
+    const rawSchema = (tool.inputParameters || {
+      type: 'object',
+      properties: {},
+      required: [],
+    }) as InputSchema;
+
+    // Sanitize property keys to comply with Anthropic's 64-character limit.
+    // See: https://github.com/ComposioHQ/composio/issues/2330
+    const { schema: sanitizedSchema, keyMap } = sanitizeSchemaPropertyKeys(rawSchema);
+
+    // Store the reverse key mapping so executeToolCall can restore original keys.
+    if (keyMap.size > 0) {
+      this._toolKeyMaps.set(tool.slug, keyMap);
+      logger.debug(
+        `Sanitized ${keyMap.size} property key(s) for tool "${tool.slug}" to comply with Anthropic's 64-char limit`
+      );
+    }
+
     return {
       name: tool.slug,
       description: tool.description || '',
-      input_schema: (tool.inputParameters || {
-        type: 'object',
-        properties: {},
-        required: [],
-      }) as InputSchema,
+      input_schema: sanitizedSchema as InputSchema,
       cache_control: this.chacheTools ? { type: 'ephemeral' } : undefined,
     };
   }
@@ -210,8 +232,12 @@ export class AnthropicProvider extends BaseNonAgenticProvider<
     options?: ExecuteToolFnOptions,
     modifiers?: ExecuteToolModifiers
   ): Promise<string> {
+    // Restore original property keys if they were sanitized during wrapTool.
+    const keyMap = this._toolKeyMaps.get(toolUse.name);
+    const args = keyMap ? restoreOriginalKeys(toolUse.input, keyMap) : toolUse.input;
+
     const payload: ToolExecuteParams = {
-      arguments: toolUse.input,
+      arguments: args,
       connectedAccountId: options?.connectedAccountId,
       customAuthParams: options?.customAuthParams,
       customConnectionData: options?.customConnectionData,

--- a/ts/packages/providers/anthropic/src/sanitize-keys.ts
+++ b/ts/packages/providers/anthropic/src/sanitize-keys.ts
@@ -1,0 +1,163 @@
+/**
+ * @file Utilities for sanitizing JSON schema property keys to comply with
+ *       Anthropic's API constraint: property keys must match ^[a-zA-Z0-9_.-]{1,64}$
+ * @module providers/anthropic/sanitize-keys
+ */
+
+/**
+ * Maximum allowed length for Anthropic tool input schema property keys.
+ * @see https://docs.anthropic.com/en/docs/build-with-claude/tool-use
+ */
+const MAX_KEY_LENGTH = 64;
+
+/**
+ * Length of the hash suffix used when truncating keys.
+ * Format: `_` + 7 hex chars = 8 chars total overhead.
+ */
+const HASH_SUFFIX_LENGTH = 7;
+
+/**
+ * Truncation prefix length: MAX_KEY_LENGTH - 1 (underscore) - HASH_SUFFIX_LENGTH
+ */
+const TRUNCATED_PREFIX_LENGTH = MAX_KEY_LENGTH - 1 - HASH_SUFFIX_LENGTH;
+
+/**
+ * Simple string hash that produces a short, deterministic hex string.
+ * Uses djb2 algorithm for speed and reasonable distribution.
+ *
+ * @param str - The string to hash
+ * @returns A 7-character lowercase hex string
+ */
+function shortHash(str: string): string {
+  let hash = 5381;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) + hash + str.charCodeAt(i)) >>> 0;
+  }
+  return hash.toString(16).padStart(HASH_SUFFIX_LENGTH, '0').slice(-HASH_SUFFIX_LENGTH);
+}
+
+/**
+ * Truncate a property key to fit within the 64-character limit.
+ * Keys within the limit are returned unchanged.
+ * Keys exceeding the limit are truncated to 56 chars + '_' + 7-char hash.
+ *
+ * @param key - The original property key
+ * @returns The sanitized key (at most 64 characters)
+ */
+function truncateKey(key: string): string {
+  if (key.length <= MAX_KEY_LENGTH) {
+    return key;
+  }
+  return `${key.slice(0, TRUNCATED_PREFIX_LENGTH)}_${shortHash(key)}`;
+}
+
+/**
+ * Result of sanitizing an input schema's property keys.
+ */
+export interface SanitizedSchema {
+  /** The schema with all property keys truncated to <= 64 chars */
+  schema: InputSchemaLike;
+  /** Map from sanitized key -> original key (only contains entries for keys that were changed) */
+  keyMap: Map<string, string>;
+}
+
+/**
+ * Minimal interface for an input schema object.
+ */
+interface InputSchemaLike {
+  type: 'object';
+  properties?: Record<string, unknown> | null;
+  required?: string[];
+  [k: string]: unknown;
+}
+
+/**
+ * Sanitize all property keys in an input schema to comply with Anthropic's
+ * 64-character limit. Returns the sanitized schema and a reverse mapping
+ * so that tool call arguments can be mapped back to their original keys.
+ *
+ * @param schema - The original input schema
+ * @returns The sanitized schema and a key mapping for reverse lookup
+ *
+ * @example
+ * ```ts
+ * const { schema, keyMap } = sanitizeSchemaPropertyKeys({
+ *   type: 'object',
+ *   properties: {
+ *     'settings__approved__or__denied__countries__or__regions__approved__list': { type: 'string' },
+ *     'short_key': { type: 'string' },
+ *   },
+ *   required: ['settings__approved__or__denied__countries__or__regions__approved__list'],
+ * });
+ *
+ * // schema.properties will have the truncated key
+ * // keyMap will map truncated -> original
+ * ```
+ */
+export function sanitizeSchemaPropertyKeys(schema: InputSchemaLike): SanitizedSchema {
+  const keyMap = new Map<string, string>();
+
+  if (!schema || !schema.properties) {
+    return { schema, keyMap };
+  }
+
+  const originalProperties = schema.properties;
+  const newProperties: Record<string, unknown> = {};
+  let hasChanges = false;
+
+  for (const [originalKey, value] of Object.entries(originalProperties)) {
+    const sanitizedKey = truncateKey(originalKey);
+    newProperties[sanitizedKey] = value;
+
+    if (sanitizedKey !== originalKey) {
+      keyMap.set(sanitizedKey, originalKey);
+      hasChanges = true;
+    }
+  }
+
+  if (!hasChanges) {
+    return { schema, keyMap };
+  }
+
+  // Update the required array to use sanitized keys
+  let newRequired = schema.required;
+  if (schema.required && schema.required.length > 0) {
+    newRequired = schema.required.map(key => {
+      const sanitized = truncateKey(key);
+      return sanitized;
+    });
+  }
+
+  return {
+    schema: {
+      ...schema,
+      properties: newProperties,
+      required: newRequired,
+    },
+    keyMap,
+  };
+}
+
+/**
+ * Restore original property keys in a tool call's input arguments.
+ * Keys not found in the mapping are passed through unchanged.
+ *
+ * @param input - The tool call input with potentially sanitized keys
+ * @param keyMap - The reverse mapping from sanitized key -> original key
+ * @returns The input with original keys restored
+ */
+export function restoreOriginalKeys(
+  input: Record<string, unknown>,
+  keyMap: Map<string, string>
+): Record<string, unknown> {
+  if (keyMap.size === 0) {
+    return input;
+  }
+
+  const restored: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(input)) {
+    const originalKey = keyMap.get(key) ?? key;
+    restored[originalKey] = value;
+  }
+  return restored;
+}

--- a/ts/packages/providers/anthropic/test/anthropic.test.ts
+++ b/ts/packages/providers/anthropic/test/anthropic.test.ts
@@ -3,6 +3,7 @@ import { AnthropicProvider, AnthropicToolUseBlock } from '../src';
 import type { AnthropicTool } from '../src/types';
 import type { Tool } from '@composio/core';
 import Anthropic from '@anthropic-ai/sdk';
+import { sanitizeSchemaPropertyKeys, restoreOriginalKeys } from '../src/sanitize-keys';
 
 vi.mock('@anthropic-ai/sdk', () => {
   return {
@@ -486,6 +487,183 @@ describe('AnthropicProvider', () => {
         expect(result[0].url).toBe('https://test.com');
         expect(result[0].type).toBe('url');
       });
+    });
+  });
+
+  describe('property key sanitization (issue #2330)', () => {
+    it('should truncate property keys exceeding 64 characters', () => {
+      const longKeyTool: Tool = {
+        slug: 'ZOOM_CREATE_A_MEETING',
+        name: 'Create a Meeting',
+        description: 'Create a Zoom meeting',
+        inputParameters: {
+          type: 'object',
+          properties: {
+            short_key: { type: 'string' },
+            settings__approved__or__denied__countries__or__regions__approved__list: {
+              type: 'array',
+              description: 'Approved countries list',
+            },
+            settings__approved__or__denied__countries__or__regions__denied__list: {
+              type: 'array',
+              description: 'Denied countries list',
+            },
+            settings__continuous__meeting__chat__auto__add__invited__external__users: {
+              type: 'boolean',
+              description: 'Auto add external users',
+            },
+          },
+          required: ['settings__approved__or__denied__countries__or__regions__approved__list'],
+        },
+        tags: [],
+      };
+
+      const wrapped = provider.wrapTool(longKeyTool) as AnthropicTool;
+      const properties = wrapped.input_schema.properties as Record<string, unknown>;
+      const propertyKeys = Object.keys(properties);
+
+      // All keys should be <= 64 characters
+      for (const key of propertyKeys) {
+        expect(key.length).toBeLessThanOrEqual(64);
+      }
+
+      // Short key should be unchanged
+      expect(propertyKeys).toContain('short_key');
+
+      // Should still have 4 properties
+      expect(propertyKeys).toHaveLength(4);
+
+      // All truncated keys should be unique
+      const uniqueKeys = new Set(propertyKeys);
+      expect(uniqueKeys.size).toBe(4);
+
+      // Required array should also be updated
+      const required = (wrapped.input_schema as any).required as string[];
+      expect(required).toHaveLength(1);
+      expect(required[0].length).toBeLessThanOrEqual(64);
+    });
+
+    it('should not modify schemas with keys under 64 characters', () => {
+      const wrapped = provider.wrapTool(mockTool) as AnthropicTool;
+
+      expect(wrapped.input_schema).toEqual({
+        type: 'object',
+        properties: mockTool.inputParameters?.properties,
+        required: mockTool.inputParameters?.required,
+      });
+    });
+
+    it('should restore original keys when executing tool calls', async () => {
+      const longKey = 'settings__approved__or__denied__countries__or__regions__approved__list';
+      const longKeyTool: Tool = {
+        slug: 'ZOOM_TOOL',
+        name: 'Zoom Tool',
+        description: 'A zoom tool',
+        inputParameters: {
+          type: 'object',
+          properties: {
+            [longKey]: { type: 'string' },
+          },
+          required: [],
+        },
+        tags: [],
+      };
+
+      // Wrap the tool (stores key mapping)
+      const wrapped = provider.wrapTool(longKeyTool) as AnthropicTool;
+      const truncatedKey = Object.keys(
+        wrapped.input_schema.properties as Record<string, unknown>
+      )[0];
+
+      // Execute with the truncated key
+      const toolUse: AnthropicToolUseBlock = {
+        type: 'tool_use',
+        id: 'tu_zoom',
+        name: 'ZOOM_TOOL',
+        input: { [truncatedKey]: 'US,CA' },
+      };
+
+      await provider.executeToolCall('user-1', toolUse);
+
+      // The execute function should receive the ORIGINAL key
+      expect(mockExecuteToolFn).toHaveBeenCalledWith(
+        'ZOOM_TOOL',
+        expect.objectContaining({
+          arguments: { [longKey]: 'US,CA' },
+        }),
+        undefined
+      );
+    });
+  });
+
+  describe('sanitizeSchemaPropertyKeys', () => {
+    it('should return schema unchanged when all keys are within limit', () => {
+      const schema = {
+        type: 'object' as const,
+        properties: { name: { type: 'string' }, age: { type: 'number' } },
+        required: ['name'],
+      };
+      const { schema: result, keyMap } = sanitizeSchemaPropertyKeys(schema);
+      expect(result).toBe(schema); // same reference, no changes
+      expect(keyMap.size).toBe(0);
+    });
+
+    it('should handle schema without properties', () => {
+      const schema = { type: 'object' as const };
+      const { schema: result, keyMap } = sanitizeSchemaPropertyKeys(schema);
+      expect(result).toBe(schema);
+      expect(keyMap.size).toBe(0);
+    });
+
+    it('should truncate keys and produce deterministic results', () => {
+      const longKey = 'a'.repeat(70);
+      const schema = {
+        type: 'object' as const,
+        properties: { [longKey]: { type: 'string' } },
+      };
+      const { schema: result, keyMap } = sanitizeSchemaPropertyKeys(schema);
+      const newKey = Object.keys(result.properties!)[0];
+
+      expect(newKey.length).toBe(64);
+      expect(keyMap.size).toBe(1);
+      expect(keyMap.get(newKey)).toBe(longKey);
+
+      // Deterministic: same input produces same output
+      const { schema: result2 } = sanitizeSchemaPropertyKeys(schema);
+      expect(Object.keys(result2.properties!)[0]).toBe(newKey);
+    });
+
+    it('should produce unique truncated keys for different long keys', () => {
+      const key1 = 'settings__approved__or__denied__countries__or__regions__approved__list';
+      const key2 = 'settings__approved__or__denied__countries__or__regions__denied__list';
+      const schema = {
+        type: 'object' as const,
+        properties: {
+          [key1]: { type: 'string' },
+          [key2]: { type: 'string' },
+        },
+      };
+      const { schema: result } = sanitizeSchemaPropertyKeys(schema);
+      const keys = Object.keys(result.properties!);
+
+      expect(keys[0]).not.toBe(keys[1]);
+      expect(keys[0].length).toBeLessThanOrEqual(64);
+      expect(keys[1].length).toBeLessThanOrEqual(64);
+    });
+  });
+
+  describe('restoreOriginalKeys', () => {
+    it('should restore mapped keys', () => {
+      const keyMap = new Map([['short_abc1234', 'very_long_original_key']]);
+      const input = { short_abc1234: 'value', other: 'val2' };
+      const result = restoreOriginalKeys(input, keyMap);
+      expect(result).toEqual({ very_long_original_key: 'value', other: 'val2' });
+    });
+
+    it('should pass through with empty map', () => {
+      const input = { key: 'value' };
+      const result = restoreOriginalKeys(input, new Map());
+      expect(result).toBe(input);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Fixes Anthropic API compatibility when tool input schemas have property keys exceeding 64 characters
- Adds `sanitizeSchemaPropertyKeys()` utility that truncates long keys (56 chars + `_` + 7-char deterministic hash = 64 max) while preserving uniqueness
- Integrates sanitization into `AnthropicProvider.wrapTool()` and restores original keys in `executeToolCall()` so the backend receives correct property names

## Problem

When Composio flattens nested JSON schema properties using `__` separators, it generates property names like:

| Property Name | Length |
|---|---|
| `settings__approved__or__denied__countries__or__regions__approved__list` | 70 |
| `settings__approved__or__denied__countries__or__regions__denied__list` | 68 |
| `settings__continuous__meeting__chat__auto__add__invited__external__users` | 72 |

Anthropic's API requires property keys to match `^[a-zA-Z0-9_.-]{1,64}$`, so all Zoom (and potentially other) tools fail with:

```
tools.0.custom.input_schema.properties: Property keys should match pattern '^[a-zA-Z0-9_.-]{1,64}$'
```

## Solution

Added a provider-level sanitization layer in `@composio/anthropic` that:

1. **On `wrapTool()`**: Scans property keys and truncates any exceeding 64 chars using a deterministic hash suffix (djb2). Stores a reverse key mapping per tool.
2. **On `executeToolCall()`**: Restores original property keys before sending arguments to the Composio backend.

This approach is scoped to the Anthropic provider since the 64-char limit is Anthropic-specific.

## Files Changed

- `ts/packages/providers/anthropic/src/sanitize-keys.ts` -- New utility: `sanitizeSchemaPropertyKeys()`, `restoreOriginalKeys()`
- `ts/packages/providers/anthropic/src/index.ts` -- Integrated sanitization into `wrapTool()` and key restoration into `executeToolCall()`
- `ts/packages/providers/anthropic/test/anthropic.test.ts` -- Added tests for key truncation, uniqueness, determinism, round-trip restoration

## Test Plan

- [x] Unit tests for `sanitizeSchemaPropertyKeys()` -- short keys pass through, long keys truncated to 64, unique hashes for different inputs, deterministic
- [x] Unit tests for `restoreOriginalKeys()` -- mapped keys restored, unmapped keys pass through
- [x] Integration test -- `wrapTool()` with Zoom-style long keys produces valid schema, `executeToolCall()` sends original keys to backend
- [x] Verified with exact property names from the issue (70, 68, 72 chars)

Closes #2330

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>