### PR TITLE
chore: add minimumReleaseAge for supply chain security

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -46,7 +46,7 @@ catalog:
   zod: ^4.1.0
   zod-to-json-schema: ^3.25.1
 
-minimumReleaseAge: 300
+minimumReleaseAge: 4320
 
 minimumReleaseAgeExclude:
   - '@composio/client'


### PR DESCRIPTION
# Description
Add `minimumReleaseAge: 4320` (3 days) to `pnpm-workspace.yaml` to protect against supply chain attacks by ensuring newly published package versions have a cooling-off period before they can be installed.

This is a pnpm 10.16+ feature that delays installation of packages published less than 3 days ago. The 3-day window is the community-recommended best practice (used as default by Renovate's best-practices config) and would have blocked most known supply chain attacks.

# How did I test this PR
- Verified pnpm version is 10.28.0 (>= 10.16.0 required)
- Setting is declarative — no runtime test needed
- Confirmed syntax matches pnpm documentation

Triggered by: srujan@composio.dev | Source: slack
Session: https://zen-api-production-4c98.up.railway.app/dashboard/#/chat/zen-5c25c1f7023d