### PR TITLE
fix: resolve mobile scrolling issues across docs site

### DIFF
--- a/docs/app/(home)/toolkits/layout.tsx
+++ b/docs/app/(home)/toolkits/layout.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 
 export default function ToolkitsLayout({ children }: { children: ReactNode }) {
   return (
-    <main className="min-h-screen">
+    <main className="min-h-dvh">
       <div className="mx-auto max-w-6xl px-4 py-12 sm:px-6 lg:px-8">
         {children}
       </div>

--- a/docs/app/global.css
+++ b/docs/app/global.css
@@ -248,7 +248,7 @@ a:focus-visible {
 #nd-sidebar {
   position: sticky;
   top: 3.5rem;
-  height: calc(100vh - 3.5rem);
+  height: calc(100dvh - 3.5rem);
   background-color: var(--composio-sidebar);
 }
 
@@ -561,7 +561,7 @@ p.text-fd-muted-foreground.not-prose:has(> code.text-xs) {
    ========================================================================== */
 
 body {
-  overflow-x: hidden;
+  overflow-x: clip;
   transition: max-width 0.3s ease;
 }
 

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -104,7 +104,7 @@ export default function Layout({ children }: LayoutProps<'/'>) {
           }}
         />
       </head>
-      <body className="flex flex-col min-h-screen font-sans">
+      <body className="flex flex-col min-h-dvh font-sans">
         <Analytics />
         <PostHogProvider>
           <RootProvider

--- a/docs/components/feedback.tsx
+++ b/docs/components/feedback.tsx
@@ -115,7 +115,7 @@ export function Feedback({ page }: FeedbackProps) {
               animate-in slide-in-from-bottom duration-200 sm:zoom-in-95
               motion-reduce:animate-none
               overscroll-contain
-              max-h-[90vh] overflow-y-auto"
+              max-h-[90dvh] overflow-y-auto"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="flex items-center justify-between mb-4">


### PR DESCRIPTION
## Summary
- Replace `overflow-x: hidden` with `overflow-x: clip` on `<body>` to fix iOS Safari scroll blocking
- Replace all `100vh` / `min-h-screen` with `100dvh` / `min-h-dvh` for proper mobile viewport handling (sidebar, body, toolkits layout, feedback modal)

## Test plan
- [ ] Test scrolling on iOS Safari (index page, docs pages, toolkits page)
- [ ] Test scrolling on Android Chrome
- [ ] Verify feedback modal scrolls correctly with keyboard open
- [ ] Verify sidebar height adjusts when mobile address bar collapses

🤖 Generated with [Claude Code](https://claude.com/claude-code)