### PR TITLE
Add beta-channel CLI release promotion flow

### DIFF
--- a/.agents/skills/cli-release-promotion/SKILL.md
+++ b/.agents/skills/cli-release-promotion/SKILL.md
@@ -1,0 +1,67 @@
+---
+description: Validate a Composio CLI beta release and promote it to a stable release by dispatching the CLI binary workflow with an existing beta tag.
+---
+
+# CLI Release Promotion
+
+Use this skill when working on the Composio CLI release pipeline or when an agent needs to test a beta CLI binary and trigger the final stable promotion.
+
+## What This Covers
+
+- Finding the beta release tag produced from the Changesets release PR
+- Smoke-testing that beta release through the existing installation path
+- Promoting only an existing beta release to a stable CLI release
+
+## Beta Release Model
+
+- Beta releases are created by `.github/workflows/build-cli-binaries.yml`
+- They are triggered from the Changesets release PR titled `Release: update version`
+- Beta tags use the form `@composio/cli@<version>-beta.<pr-number>`
+- Stable releases are promoted manually from an existing beta tag through the same workflow
+
+## Validate The Beta
+
+Pick the beta tag you intend to promote, then test it before promotion.
+
+Use the existing installation health check workflow if you only need repo-side validation:
+
+```bash
+gh workflow run cli.test-installation.yml -f version='@composio/cli@0.2.18-beta.123'
+```
+
+For a local smoke test, install that exact beta binary and verify the upgrade path:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/ComposioHQ/composio/main/install.sh | bash -s -- '@composio/cli@0.2.18-beta.123'
+composio --version
+composio upgrade --beta
+```
+
+`composio upgrade --beta` should stay on the beta channel and resolve the newest prerelease, not the latest stable release.
+
+## Promote To Stable
+
+Only promote by referencing an existing beta tag.
+
+Run the CLI binary workflow manually with that beta tag:
+
+```bash
+gh workflow run build-cli-binaries.yml -f beta_tag='@composio/cli@0.2.18-beta.123'
+```
+
+The workflow will:
+
+- verify the beta release exists
+- reject non-prerelease tags
+- derive the stable tag `@composio/cli@0.2.18`
+- rebuild from the beta release's recorded commit
+- publish the stable GitHub release
+
+## Reference Files
+
+Read these when you need implementation details:
+
+- `.github/workflows/build-cli-binaries.yml`
+- `ts/packages/cli/src/commands/upgrade.cmd.ts`
+- `ts/packages/cli/src/services/upgrade-binary.ts`
+- `ts/docs/internal/release.md`

--- a/.claude/skills/cli-release/SKILL.md
+++ b/.claude/skills/cli-release/SKILL.md
@@ -1,0 +1,194 @@
+---
+description: Release the CLI — diff features since last release, run /full-cli-test on them, and create a changeset PR with patch bump and test results.
+---
+
+# CLI Release
+
+Orchestrates a CLI release by identifying what changed since the last release, testing those changes via `/full-cli-test`, and creating a changeset PR with a patch version bump.
+
+## Overview
+
+Two workstreams run **in parallel**:
+
+1. **Testing** — Run `/full-cli-test` to validate the CLI binary (types/lint CI, local build, bundled build).
+2. **Changeset PR** — Identify changes since the last release, create a changeset file, open a PR.
+
+Once testing completes, update the PR description with test results.
+
+## Step 1: Identify Changes Since Last Release
+
+Find the last release tag or version bump commit for `@composio/cli`:
+
+```bash
+# Find the last release commit (look for "Release: update version" commits that touched the CLI)
+git log --oneline --all -- ts/packages/cli/package.json | head -20
+```
+
+Look for the most recent commit where the CLI version was bumped (typically a "Release: update version" commit). Use that as the base.
+
+Then collect all commits between that base and HEAD that touch the CLI:
+
+```bash
+git log <base_commit>..HEAD --oneline -- ts/packages/cli/
+```
+
+For each commit, read the commit message and understand what it does. Categorize changes as:
+- **Features** — new commands, new flags, new capabilities
+- **Fixes** — bug fixes, error handling improvements
+- **Improvements** — refactors, performance, DX improvements
+
+Also run a full diff to understand the scope:
+
+```bash
+git diff <base_commit>..HEAD -- ts/packages/cli/src/
+```
+
+## Step 2: Run /full-cli-test (Parallel Track 1)
+
+Run the `/full-cli-test` skill. This executes:
+
+1. **Phase 1:** Monitor CI for types/lint passing
+2. **Phase 2:** Local binary build and test (including Slack integration test)
+3. **Phase 3:** Bundled binary build and test via CI (including Slack integration test)
+
+Track the results of each phase — you'll need them for the PR description.
+
+## Step 3: Create Changeset PR (Parallel Track 2)
+
+While testing runs, create the changeset and PR. Do this **in parallel** with Step 2.
+
+### 3a. Create a new branch
+
+```bash
+git checkout -b cli-release/patch-<short-description>
+```
+
+### 3b. Write the changeset file
+
+Create a changeset file at `.changeset/<descriptive-name>.md`. The format is:
+
+```markdown
+---
+"@composio/cli": patch
+---
+
+<summary of all changes since last release>
+```
+
+The summary should be a concise but complete description of all changes. Use the categorized changes from Step 1. Example:
+
+```markdown
+---
+"@composio/cli": patch
+---
+
+feat: add `composio manage triggers` command for listing and inspecting trigger types
+fix: bundle MCP server into subagent helper for standalone binaries
+fix: harden run subAgent structured output and logfile path propagation
+improve: better error messages for missing auth configs
+```
+
+Use `patch` by default. Only use `minor` if explicitly requested by the user.
+
+### 3c. Commit and push
+
+```bash
+git add .changeset/<name>.md
+git commit -m "chore: add changeset for CLI patch release"
+git push -u origin cli-release/patch-<short-description>
+```
+
+### 3d. Open the PR
+
+Create a PR against `next` with a clear description. Use a placeholder for test results that will be filled in once testing completes:
+
+```bash
+gh pr create --base next --title "chore: CLI patch release" --body "$(cat <<'EOF'
+## Changes
+
+<list of changes from Step 1, categorized>
+
+## Changeset
+
+- Bump: `@composio/cli` patch
+- File: `.changeset/<name>.md`
+
+## Testing
+
+⏳ Full CLI test pipeline in progress...
+
+_Test results will be updated once `/full-cli-test` completes._
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+## Step 4: Update PR with Test Results
+
+Once `/full-cli-test` completes (all 3 phases), update the PR description with the actual test results:
+
+```bash
+gh pr edit <PR_NUMBER> --body "$(cat <<'EOF'
+## Changes
+
+<same list of changes>
+
+## Changeset
+
+- Bump: `@composio/cli` patch
+- File: `.changeset/<name>.md`
+
+## Testing
+
+✅ Full CLI test pipeline passed
+
+### Phase 1: CI Types/Lint
+- Status: ✅ Passed
+- <link to CI run if available>
+
+### Phase 2: Local Binary Test
+- `composio version`: ✅
+- `composio whoami`: ✅
+- `composio --help`: ✅
+- Slack integration test: ✅
+
+### Phase 3: Bundled Binary Test
+- Binary version: <version>
+- `composio version`: ✅
+- `composio whoami`: ✅
+- `composio --help`: ✅
+- `composio run`: ✅
+- `experimental_subAgent()`: ✅
+- Slack integration test: ✅
+
+### Features Tested
+<for each new feature/fix identified in Step 1, describe how it was tested>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+If any phase fails, update the PR description with the failure details and mark the PR as draft:
+
+```bash
+gh pr ready <PR_NUMBER> --undo  # Convert to draft
+```
+
+## Important Notes
+
+- **Default to patch.** Only use `minor` or `major` if the user explicitly requests it.
+- **Don't use `pnpm changeset` CLI** — create the `.changeset/*.md` file manually.
+- **The changeset file format is strict:** YAML frontmatter with package name in quotes and bump type, then a blank line, then the description.
+- **Feature-specific testing:** When identifying changes in Step 1, note any new commands or flags. During testing (Step 2), explicitly test those new features with the built binary beyond the standard test suite.
+- **The PR targets `next`** — this is the main development branch.
+
+## Reference Files
+
+| File | Purpose |
+|---|---|
+| `ts/packages/cli/package.json` | Current CLI version |
+| `.changeset/config.json` | Changeset configuration |
+| `.github/workflows/build-cli-binaries.yml` | CI binary build workflow |
+| `ts/packages/cli/src/commands/` | CLI command implementations |

--- a/.github/workflows/build-cli-binaries.yml
+++ b/.github/workflows/build-cli-binaries.yml
@@ -1,21 +1,133 @@
 name: Build CLI Binaries
 
 on:
-  release:
-    types: [published]
+  pull_request:
+    branches: [next]
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Semver version to release (e.g., 1.0.0)'
+      beta_tag:
+        description: 'Existing beta release tag to promote (e.g., @composio/cli@1.0.0-beta.123)'
         required: true
 
 permissions:
   contents: write
 
 jobs:
+  prepare:
+    name: Resolve Release Metadata
+    if: "${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.title == 'Release: update version' }}"
+    runs-on: ubuntu-latest
+    outputs:
+      checkout_ref: ${{ steps.resolve.outputs.checkout_ref }}
+      release_name: ${{ steps.resolve.outputs.release_name }}
+      release_tag: ${{ steps.resolve.outputs.release_tag }}
+      release_version: ${{ steps.resolve.outputs.release_version }}
+      prerelease: ${{ steps.resolve.outputs.prerelease }}
+      make_latest: ${{ steps.resolve.outputs.make_latest }}
+
+    steps:
+      - name: Checkout release PR head
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Resolve beta or stable release target
+        id: resolve
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BETA_TAG_INPUT: ${{ inputs.beta_tag }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            version=$(node -p "require('./ts/packages/cli/package.json').version")
+            if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "Expected ts/packages/cli/package.json version to be a stable semver on the release PR, got: $version"
+              exit 1
+            fi
+
+            release_tag="@composio/cli@${version}-beta.${PR_NUMBER}"
+            release_name="CLI Beta ${release_tag}"
+            {
+              echo "checkout_ref=${PR_HEAD_SHA}"
+              echo "release_name=${release_name}"
+              echo "release_tag=${release_tag}"
+              echo "release_version=${version}"
+              echo "prerelease=true"
+              echo "make_latest=false"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          encoded_beta_tag=$(python3 - <<'PY'
+          import os, urllib.parse
+          print(urllib.parse.quote(os.environ["BETA_TAG_INPUT"], safe=""))
+          PY
+          )
+
+          release_json=$(curl -fsSL \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${REPOSITORY}/releases/tags/${encoded_beta_tag}")
+
+          is_prerelease=$(jq -r '.prerelease' <<<"$release_json")
+          if [[ "$is_prerelease" != "true" ]]; then
+            echo "Release ${BETA_TAG_INPUT} is not a beta prerelease"
+            exit 1
+          fi
+
+          if [[ ! "$BETA_TAG_INPUT" =~ ^@composio/cli@([0-9]+\.[0-9]+\.[0-9]+)-beta\.[0-9]+$ ]]; then
+            echo "Beta tag must match @composio/cli@<version>-beta.<pr-number>"
+            exit 1
+          fi
+
+          stable_version="${BASH_REMATCH[1]}"
+          stable_tag="@composio/cli@${stable_version}"
+          export stable_tag
+
+          stable_status=$(curl -sS -o /tmp/stable-release.json -w "%{http_code}" \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${REPOSITORY}/releases/tags/$(python3 - <<'PY'
+            import os, urllib.parse
+            print(urllib.parse.quote(os.environ["stable_tag"], safe=""))
+            PY
+            )")
+          if [[ "$stable_status" == "200" ]]; then
+            echo "Stable release ${stable_tag} already exists"
+            exit 1
+          fi
+          if [[ "$stable_status" != "404" ]]; then
+            echo "Unexpected response while checking stable release ${stable_tag}: HTTP ${stable_status}"
+            cat /tmp/stable-release.json
+            exit 1
+          fi
+
+          target_commitish=$(jq -r '.target_commitish' <<<"$release_json")
+          if [[ -z "$target_commitish" || "$target_commitish" == "null" ]]; then
+            echo "Beta release ${BETA_TAG_INPUT} does not expose target_commitish"
+            exit 1
+          fi
+
+          {
+            echo "checkout_ref=${target_commitish}"
+            echo "release_name=CLI ${stable_tag}"
+            echo "release_tag=${stable_tag}"
+            echo "release_version=${stable_version}"
+            echo "prerelease=false"
+            echo "make_latest=true"
+          } >> "$GITHUB_OUTPUT"
+
   build:
     name: Build ${{ matrix.artifact }}
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, '@composio/cli@') || startsWith(github.event.release.tag_name, 'v')
+    needs: prepare
+    if: needs.prepare.result == 'success'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -32,16 +144,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-
-      - name: Validate manual version input
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          version="${{ inputs.version }}"
-          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
-            echo "Invalid semver version: '$version'"
-            echo "Expected format like: 1.2.3, 1.2.3-beta.1, 1.2.3+build.7"
-            exit 1
-          fi
+        with:
+          ref: ${{ needs.prepare.outputs.checkout_ref }}
 
       - name: Setup Node.js, pnpm, Bun
         uses: ./.github/actions/setup-node-pnpm-bun
@@ -84,13 +188,15 @@ jobs:
 
   release:
     name: Create Release
-    needs: build
+    needs: [prepare, build]
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    if: needs.build.result == 'success'
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.checkout_ref }}
 
       - name: Setup Node.js, pnpm, Bun
         uses: ./.github/actions/setup-node-pnpm-bun
@@ -119,29 +225,31 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.event_name == 'workflow_dispatch' && format('@composio/cli@{0}', inputs.version) || github.event.release.tag_name }}
-          name: ${{ github.event_name == 'workflow_dispatch' && format('CLI @composio/cli@{0} (Manual Build)', inputs.version) || github.event.release.tag_name }}
+          tag_name: ${{ needs.prepare.outputs.release_tag }}
+          name: ${{ needs.prepare.outputs.release_name }}
           files: |
             ts/packages/cli/dist/binaries/*.zip
             ts/packages/cli/dist/binaries/checksums.txt
           draft: false
-          prerelease: ${{ github.event_name == 'workflow_dispatch' || github.event.release.prerelease || contains(github.event.release.tag_name, 'alpha') || contains(github.event.release.tag_name, 'beta') || contains(github.event.release.tag_name, 'rc') }}
+          prerelease: ${{ needs.prepare.outputs.prerelease == 'true' }}
           generate_release_notes: true
-          make_latest: ${{ github.event_name != 'workflow_dispatch' }}
+          make_latest: ${{ needs.prepare.outputs.make_latest }}
+          target_commitish: ${{ needs.prepare.outputs.checkout_ref }}
+          overwrite_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   test-installation:
     name: Test Installation
-    needs: release
+    needs: [prepare, release]
     if: always() && !cancelled() && needs.release.result == 'success'
     uses: ./.github/workflows/cli.test-installation.yml
     with:
-      version: ${{ github.event_name == 'workflow_dispatch' && format('@composio/cli@{0}', inputs.version) || github.event.release.tag_name }}
+      version: ${{ needs.prepare.outputs.release_tag }}
 
   create-install-instructions:
     name: Create Install Instructions
-    needs: release
+    needs: [prepare, release]
     runs-on: ubuntu-latest
     if: always() && !cancelled() && needs.release.result == 'success'
 
@@ -151,7 +259,7 @@ jobs:
 
       - name: Create installation README
         run: |
-          RELEASE_TAG="${{ github.event_name == 'workflow_dispatch' && format('@composio/cli@{0}', inputs.version) || github.event.release.tag_name }}"
+          RELEASE_TAG="${{ needs.prepare.outputs.release_tag }}"
           cat > INSTALL.md << 'EOF'
           # Composio CLI Installation
 

--- a/ts/docs/internal/release.md
+++ b/ts/docs/internal/release.md
@@ -9,35 +9,42 @@ The CLI binary release process is separate from npm publishing.
 - `@composio/cli` is marked private and is not published to npm via Changesets.
 - CLI binaries are built and published as GitHub Release assets by `.github/workflows/build-cli-binaries.yml`.
 - Install and upgrade flows (`install.sh` and `composio upgrade`) download binaries from GitHub Releases.
+- `composio upgrade --beta` resolves the newest CLI prerelease from GitHub Releases.
 
 ### Triggers
 
-The CLI binary workflow supports two tag formats during the migration window:
+The CLI binary workflow supports two entry points:
 
-- Legacy: `v*`
-- New package-scoped tags: `@composio/cli@*`
+- Beta release: the auto-generated Changesets release PR titled `Release: update version`
+- Stable release: manual `workflow_dispatch`, but only from an existing beta release tag
 
-It also supports manual runs (`workflow_dispatch`).
+### Beta CLI Release
 
-### Manual CLI Binary Release
+When the Changesets release PR is opened or updated, the workflow:
+
+1. Reads the bumped CLI version from `ts/packages/cli/package.json`
+2. Publishes a prerelease tag in the form `@composio/cli@<version>-beta.<pr-number>`
+3. Attaches the built binaries to that prerelease
+
+### Stable CLI Release
 
 When running **Build CLI Binaries** manually:
 
-1. Enter a plain semver version (for example `1.2.3`).
-2. The workflow validates semver format.
-3. The workflow creates/publishes the release under tag `@composio/cli@<version>`.
+1. Enter an existing beta tag (for example `@composio/cli@1.2.3-beta.456`)
+2. The workflow verifies that the beta release already exists and is marked as a prerelease
+3. The workflow checks out the exact commit associated with that beta release
+4. The workflow rebuilds the binaries and publishes the stable release under `@composio/cli@<version>`
 
 ### What the workflow does
 
 1. Builds CLI binaries for Linux/macOS (x64 + arm64)
 2. Creates platform zip archives (`composio-<platform>.zip`)
-3. Publishes assets to the GitHub Release
+3. Publishes assets to the beta or stable GitHub Release
 4. Runs `.github/workflows/cli.test-installation.yml` to validate installation paths and shell integration
 
 ### Notes
 
-- The temporary dual-tag support (`v*` + `@composio/cli@*`) is intended to keep older installed CLIs upgradeable during migration.
-- After migration, legacy `v*` support can be removed.
+- Stable promotion is intentionally gated on an existing beta release so the shipped stable binaries always correspond to a tested beta artifact.
 
 ## Automated Release Process
 

--- a/ts/packages/cli/README.md
+++ b/ts/packages/cli/README.md
@@ -41,7 +41,7 @@ composio [--log-level all|trace|debug|info|warning|error|fatal|none]
 - `composio generate [-o, --output-dir <directory>] [--toolkits <toolkit>] [--type-tools]`: Auto-detect the project language (Python or TypeScript) and generate type stubs for toolkits, tools, and triggers.
 - `composio generate py [-o, --output-dir <directory>] [--toolkits <toolkit>]`: Generate Python type stubs for toolkits, tools, and triggers from the Composio API.
 - `composio generate ts [-o, --output-dir <directory>] [--compact] [--transpiled] [--type-tools] [--toolkits <toolkit>]`: Generate TypeScript types for toolkits, tools, and triggers from the Composio API.
-- `composio upgrade`: Self-update the Composio CLI if a new release is out.
+- `composio upgrade [--beta]`: Self-update the Composio CLI from the stable channel, or from the beta channel with `--beta`.
 
 ## Configuration
 
@@ -83,6 +83,12 @@ If you pin upgrades with `COMPOSIO_GITHUB_TAG`, prefer the package-scoped tag fo
 
 ```bash
 COMPOSIO_GITHUB_TAG='@composio/cli@0.1.24' composio upgrade
+```
+
+To pull from the beta channel instead of the stable channel:
+
+```bash
+composio upgrade --beta
 ```
 
 ## Caching

--- a/ts/packages/cli/src/commands/upgrade.cmd.ts
+++ b/ts/packages/cli/src/commands/upgrade.cmd.ts
@@ -1,8 +1,14 @@
-import { Command } from '@effect/cli';
+import { Command, Options } from '@effect/cli';
 import { Effect } from 'effect';
 import { APP_VERSION } from 'src/constants';
 import { UpgradeBinary } from 'src/services/upgrade-binary';
 import { installSkillSafe } from 'src/effects/install-skill';
+
+const betaOpt = Options.boolean('beta').pipe(
+  Options.withAlias('b'),
+  Options.withDefault(false),
+  Options.withDescription('Upgrade to the latest beta CLI release instead of the stable channel')
+);
 
 /**
  * CLI command to upgrade the CLI to the latest available version.
@@ -12,10 +18,10 @@ import { installSkillSafe } from 'src/effects/install-skill';
  * composio upgrade
  * ```
  */
-export const upgradeCmd = Command.make('upgrade', {}, () =>
+export const upgradeCmd = Command.make('upgrade', { beta: betaOpt }, ({ beta }) =>
   Effect.gen(function* () {
     const upgradeBinary = yield* UpgradeBinary;
-    const newReleaseTag = yield* upgradeBinary.upgrade();
+    const newReleaseTag = yield* upgradeBinary.upgrade({ prerelease: beta });
     yield* installSkillSafe({ releaseTag: newReleaseTag ?? `@composio/cli@${APP_VERSION}` });
   })
 ).pipe(Command.withDescription('Upgrade your Composio CLI to the latest available version.'));

--- a/ts/packages/cli/src/services/upgrade-binary.ts
+++ b/ts/packages/cli/src/services/upgrade-binary.ts
@@ -14,6 +14,7 @@ import { renderPrettyError } from './utils/pretty-error';
 import { TerminalUI } from './terminal-ui';
 import {
   collectExpectedRunCompanionAssetRelativePaths,
+  readInstalledReleaseTag,
   writeInstalledReleaseTag,
 } from './run-companion-modules';
 
@@ -216,13 +217,17 @@ export class UpgradeBinary extends Effect.Service<UpgradeBinary>()('services/Upg
     /**
      * Check if update is available
      */
+    const resolveCurrentReleaseIdentifier = (currentPath: string) =>
+      readInstalledReleaseTag(currentPath) || `@composio/cli@${APP_VERSION}`;
+
     const isUpdateAvailable = (
-      release: GitHubRelease
+      release: GitHubRelease,
+      currentReleaseIdentifier: string
     ): Effect.Effect<boolean, CompareSemverError | UpgradeBinaryError, never> =>
       Effect.gen(function* () {
         // Current version is older than latest
         const isVersionOutdated: Predicate<number> = comparison => comparison < 0;
-        const comparison = yield* semverComparator(APP_VERSION, release.tag_name);
+        const comparison = yield* semverComparator(currentReleaseIdentifier, release.tag_name);
         return isVersionOutdated(comparison);
       });
 
@@ -577,13 +582,15 @@ export class UpgradeBinary extends Effect.Service<UpgradeBinary>()('services/Upg
         const upgradeTargetOpt = yield* DEBUG_OVERRIDE_CONFIG['UPGRADE_TARGET'];
         const currentPath = yield* getCurrentExecutablePath();
         const prerelease = options.prerelease ?? false;
+        const currentReleaseIdentifier = resolveCurrentReleaseIdentifier(currentPath);
         yield* Effect.logDebug(`Current executable path: ${currentPath}`);
+        yield* Effect.logDebug(`Current release identifier: ${currentReleaseIdentifier}`);
 
         yield* ui.intro('composio upgrade');
 
         // If local binary path is provided (for testing), use it directly
         if (Option.isSome(upgradeTargetOpt)) {
-          yield* ui.log.info(`New local version available (current: ${APP_VERSION})`);
+          yield* ui.log.info(`New local version available (current: ${currentReleaseIdentifier})`);
           yield* replaceBinary(upgradeTargetOpt.value, currentPath);
           yield* ui.outro('Upgrade completed');
           return undefined;
@@ -593,14 +600,14 @@ export class UpgradeBinary extends Effect.Service<UpgradeBinary>()('services/Upg
           Effect.gen(function* () {
             const platformArch = yield* detectPlatform;
             const release = yield* fetchLatestRelease(platformArch, { prerelease });
-            const updateAvailable = yield* isUpdateAvailable(release);
+            const updateAvailable = yield* isUpdateAvailable(release, currentReleaseIdentifier);
             if (!updateAvailable) {
               yield* spinner.stop('You are already running the latest version!');
               return false;
             }
 
             yield* spinner.message(
-              `New version available: ${release.tag_name} (current: ${APP_VERSION}). Downloading...`
+              `New version available: ${release.tag_name} (current: ${currentReleaseIdentifier}). Downloading...`
             );
 
             const { name, data } = yield* downloadBinary(release, platformArch);

--- a/ts/packages/cli/src/services/upgrade-binary.ts
+++ b/ts/packages/cli/src/services/upgrade-binary.ts
@@ -108,14 +108,18 @@ export class UpgradeBinary extends Effect.Service<UpgradeBinary>()('services/Upg
       });
 
     const fetchLatestRelease = (
-      platformArch: PlatformArch
+      platformArch: PlatformArch,
+      options: {
+        prerelease?: boolean;
+      } = {}
     ): Effect.Effect<GitHubRelease, UpgradeBinaryError, never> =>
       Effect.gen(function* () {
+        const prerelease = options.prerelease ?? false;
         const release = yield* githubConfig.TAG.pipe(
           Option.match({
             onNone: Effect.fn(function* () {
               yield* Effect.logDebug(
-                'No tag specified, resolving latest package-scoped CLI release'
+                `No tag specified, resolving latest package-scoped CLI ${prerelease ? 'beta' : 'stable'} release`
               );
               const url = `${githubConfig.API_BASE_URL}/repos/${githubConfig.OWNER}/${githubConfig.REPO}/releases?per_page=100`;
               const releases = yield* fetchGitHubJson<unknown>({
@@ -139,7 +143,9 @@ export class UpgradeBinary extends Effect.Service<UpgradeBinary>()('services/Upg
                   release !== null &&
                   'tag_name' in release &&
                   typeof release.tag_name === 'string' &&
-                  ('prerelease' in release ? release.prerelease === false : true) &&
+                  ('prerelease' in release
+                    ? release.prerelease === prerelease
+                    : prerelease === false) &&
                   ('draft' in release ? release.draft === false : true) &&
                   CLI_RELEASE_TAG_PATTERN.test(release.tag_name)
               );
@@ -147,9 +153,10 @@ export class UpgradeBinary extends Effect.Service<UpgradeBinary>()('services/Upg
               if (cliReleases.length === 0) {
                 return yield* Effect.fail(
                   new UpgradeBinaryError({
-                    cause: new Error('No package-scoped CLI releases found'),
-                    message:
-                      'Failed to determine latest CLI release from @composio/cli tags on GitHub',
+                    cause: new Error(
+                      `No package-scoped CLI ${prerelease ? 'beta' : 'stable'} releases found`
+                    ),
+                    message: `Failed to determine latest CLI ${prerelease ? 'beta' : 'stable'} release from @composio/cli tags on GitHub`,
                   })
                 );
               }
@@ -162,10 +169,9 @@ export class UpgradeBinary extends Effect.Service<UpgradeBinary>()('services/Upg
                 return yield* Effect.fail(
                   new UpgradeBinaryError({
                     cause: new Error(
-                      `No package-scoped CLI releases found with ${getBinaryAssetName(platformArch)}`
+                      `No package-scoped CLI ${prerelease ? 'beta' : 'stable'} releases found with ${getBinaryAssetName(platformArch)}`
                     ),
-                    message:
-                      'Failed to determine latest CLI release from @composio/cli tags on GitHub',
+                    message: `Failed to determine latest CLI ${prerelease ? 'beta' : 'stable'} release from @composio/cli tags on GitHub`,
                   })
                 );
               }
@@ -561,11 +567,16 @@ export class UpgradeBinary extends Effect.Service<UpgradeBinary>()('services/Upg
     /**
      * Main upgrade function
      */
-    const upgrade = () =>
+    const upgrade = (
+      options: {
+        prerelease?: boolean;
+      } = {}
+    ) =>
       Effect.gen(function* () {
         const ui = yield* TerminalUI;
         const upgradeTargetOpt = yield* DEBUG_OVERRIDE_CONFIG['UPGRADE_TARGET'];
         const currentPath = yield* getCurrentExecutablePath();
+        const prerelease = options.prerelease ?? false;
         yield* Effect.logDebug(`Current executable path: ${currentPath}`);
 
         yield* ui.intro('composio upgrade');
@@ -581,7 +592,7 @@ export class UpgradeBinary extends Effect.Service<UpgradeBinary>()('services/Upg
         const didUpgrade = yield* ui.useMakeSpinner('Checking for updates...', spinner =>
           Effect.gen(function* () {
             const platformArch = yield* detectPlatform;
-            const release = yield* fetchLatestRelease(platformArch);
+            const release = yield* fetchLatestRelease(platformArch, { prerelease });
             const updateAvailable = yield* isUpdateAvailable(release);
             if (!updateAvailable) {
               yield* spinner.stop('You are already running the latest version!');

--- a/ts/packages/cli/test/src/services/upgrade-binary.test.ts
+++ b/ts/packages/cli/test/src/services/upgrade-binary.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it, vi } from '@effect/vitest';
 import { ConfigProvider, Effect, Layer } from 'effect';
 import { FetchHttpClient } from '@effect/platform';
 import { BunFileSystem } from '@effect/platform-bun';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import { withHttpServer } from 'test/__utils__/http-server';
 import { TerminalUI } from 'src/services/terminal-ui';
 import { UpgradeBinary, UpgradeBinaryError } from 'src/services/upgrade-binary';
@@ -336,6 +339,58 @@ describe('UpgradeBinary', () => {
         }
       );
     } finally {
+      vi.unstubAllGlobals();
+      vi.restoreAllMocks();
+    }
+  });
+
+  it('uses the installed beta release tag when comparing beta updates', async () => {
+    const installDir = mkdtempSync(path.join(tmpdir(), 'composio-beta-upgrade-'));
+    const fakeExecPath = path.join(installDir, 'composio');
+    writeFileSync(path.join(installDir, 'release-tag.txt'), '@composio/cli@0.2.17-beta.1\n');
+    vi.stubGlobal('Bun', { which: vi.fn(() => null) });
+    const execPathSpy = vi.spyOn(process, 'execPath', 'get').mockReturnValue(fakeExecPath);
+
+    try {
+      await withHttpServer(
+        (_req, res) => {
+          res.writeHead(200, { 'content-type': 'application/json' });
+          res.end(
+            JSON.stringify([
+              {
+                tag_name: '@composio/cli@0.2.17-beta.3',
+                draft: false,
+                prerelease: true,
+                assets: [
+                  {
+                    name: 'composio-darwin-aarch64.zip',
+                    browser_download_url: 'http://127.0.0.1/beta-3.zip',
+                  },
+                ],
+              },
+            ])
+          );
+        },
+        async apiBaseUrl => {
+          const error = await runUpgrade(
+            [
+              ['GITHUB_API_BASE_URL', apiBaseUrl],
+              ['GITHUB_OWNER', 'test-owner'],
+              ['GITHUB_REPO', 'test-repo'],
+            ],
+            { prerelease: true }
+          );
+
+          expect(error).toBeInstanceOf(UpgradeBinaryError);
+          if (!(error instanceof UpgradeBinaryError)) {
+            throw error;
+          }
+          expect(error.message).toBe('Failed to download binary: composio-darwin-aarch64.zip');
+          expect(String(error.cause)).toContain('beta-3.zip');
+        }
+      );
+    } finally {
+      execPathSpy.mockRestore();
       vi.unstubAllGlobals();
       vi.restoreAllMocks();
     }

--- a/ts/packages/cli/test/src/services/upgrade-binary.test.ts
+++ b/ts/packages/cli/test/src/services/upgrade-binary.test.ts
@@ -43,10 +43,15 @@ const NodeOsTest = Layer.succeed(
   })
 );
 
-const makeUpgradeEffect = (configEntries: ReadonlyArray<[string, string]>) =>
+const makeUpgradeEffect = (
+  configEntries: ReadonlyArray<[string, string]>,
+  options?: {
+    prerelease?: boolean;
+  }
+) =>
   Effect.gen(function* () {
     const service = yield* UpgradeBinary;
-    return yield* service.upgrade();
+    return yield* service.upgrade(options);
   }).pipe(
     Effect.provide(UpgradeBinary.Default),
     Effect.provide(FetchHttpClient.layer),
@@ -57,11 +62,19 @@ const makeUpgradeEffect = (configEntries: ReadonlyArray<[string, string]>) =>
     Effect.scoped
   );
 
-const runUpgrade = (configEntries: ReadonlyArray<[string, string]>) =>
-  makeUpgradeEffect(configEntries).pipe(Effect.flip, Effect.runPromise);
+const runUpgrade = (
+  configEntries: ReadonlyArray<[string, string]>,
+  options?: {
+    prerelease?: boolean;
+  }
+) => makeUpgradeEffect(configEntries, options).pipe(Effect.flip, Effect.runPromise);
 
-const runUpgradeSuccess = (configEntries: ReadonlyArray<[string, string]>) =>
-  makeUpgradeEffect(configEntries).pipe(Effect.runPromise);
+const runUpgradeSuccess = (
+  configEntries: ReadonlyArray<[string, string]>,
+  options?: {
+    prerelease?: boolean;
+  }
+) => makeUpgradeEffect(configEntries, options).pipe(Effect.runPromise);
 
 describe('UpgradeBinary', () => {
   it('wraps non-2xx releases fetch failures with fetch context (no tag branch)', async () => {
@@ -201,6 +214,125 @@ describe('UpgradeBinary', () => {
           ]);
 
           expect(result).toBeUndefined();
+        }
+      );
+    } finally {
+      vi.unstubAllGlobals();
+      vi.restoreAllMocks();
+    }
+  });
+
+  it('ignores prereleases when checking the stable channel', async () => {
+    vi.stubGlobal('Bun', { which: vi.fn(() => null) });
+
+    try {
+      await withHttpServer(
+        (_req, res) => {
+          res.writeHead(200, { 'content-type': 'application/json' });
+          res.end(
+            JSON.stringify([
+              {
+                tag_name: '@composio/cli@0.2.18-beta.9',
+                draft: false,
+                prerelease: true,
+                assets: [
+                  {
+                    name: 'composio-darwin-aarch64.zip',
+                    browser_download_url: 'http://127.0.0.1/beta.zip',
+                  },
+                ],
+              },
+              {
+                tag_name: '@composio/cli@0.2.17',
+                draft: false,
+                prerelease: false,
+                assets: [
+                  {
+                    name: 'composio-darwin-aarch64.zip',
+                    browser_download_url: 'http://127.0.0.1/stable.zip',
+                  },
+                ],
+              },
+            ])
+          );
+        },
+        async apiBaseUrl => {
+          const result = await runUpgradeSuccess([
+            ['GITHUB_API_BASE_URL', apiBaseUrl],
+            ['GITHUB_OWNER', 'test-owner'],
+            ['GITHUB_REPO', 'test-repo'],
+          ]);
+
+          expect(result).toBeUndefined();
+        }
+      );
+    } finally {
+      vi.unstubAllGlobals();
+      vi.restoreAllMocks();
+    }
+  });
+
+  it('selects the latest prerelease when beta upgrades are requested', async () => {
+    vi.stubGlobal('Bun', { which: vi.fn(() => null) });
+
+    try {
+      await withHttpServer(
+        (_req, res) => {
+          res.writeHead(200, { 'content-type': 'application/json' });
+          res.end(
+            JSON.stringify([
+              {
+                tag_name: '@composio/cli@0.2.18-beta.1',
+                draft: false,
+                prerelease: true,
+                assets: [
+                  {
+                    name: 'composio-darwin-aarch64.zip',
+                    browser_download_url: 'http://127.0.0.1/beta-1.zip',
+                  },
+                ],
+              },
+              {
+                tag_name: '@composio/cli@0.2.18-beta.3',
+                draft: false,
+                prerelease: true,
+                assets: [
+                  {
+                    name: 'composio-darwin-aarch64.zip',
+                    browser_download_url: 'http://127.0.0.1/beta-3.zip',
+                  },
+                ],
+              },
+              {
+                tag_name: '@composio/cli@0.2.17',
+                draft: false,
+                prerelease: false,
+                assets: [
+                  {
+                    name: 'composio-darwin-aarch64.zip',
+                    browser_download_url: 'http://127.0.0.1/stable.zip',
+                  },
+                ],
+              },
+            ])
+          );
+        },
+        async apiBaseUrl => {
+          const error = await runUpgrade(
+            [
+              ['GITHUB_API_BASE_URL', apiBaseUrl],
+              ['GITHUB_OWNER', 'test-owner'],
+              ['GITHUB_REPO', 'test-repo'],
+            ],
+            { prerelease: true }
+          );
+
+          expect(error).toBeInstanceOf(UpgradeBinaryError);
+          if (!(error instanceof UpgradeBinaryError)) {
+            throw error;
+          }
+          expect(error.message).toBe('Failed to download binary: composio-darwin-aarch64.zip');
+          expect(String(error.cause)).toContain('beta-3.zip');
         }
       );
     } finally {


### PR DESCRIPTION
## Summary
- Add support for beta CLI releases in the binary publish workflow, including beta tag validation and promotion to stable from an existing prerelease tag.
- Update `composio upgrade` to support a `--beta` flag that stays on the prerelease channel.
- Refresh release documentation and CLI README to describe the new beta/stable release model.
- Expand upgrade binary tests to cover prerelease resolution and channel-specific behavior.

## Testing
- Not run (PR content generation only).
- Checked the workflow and CLI changes for beta/stable tag handling paths.
- Reviewed updated release documentation for the new promotion flow.