### PR TITLE
chore: CLI patch release

### DIFF
--- a/.changeset/cli-beta-flow-and-custom-auth.md
+++ b/.changeset/cli-beta-flow-and-custom-auth.md
@@ -1,0 +1,8 @@
+---
+"@composio/cli": patch
+---
+
+feat: add `--beta` flag to `composio upgrade` for prerelease channel support
+feat: preload custom auth connections into tool router sessions for seamless custom-auth toolkit execution
+improve: beta-channel CLI release promotion flow in CI workflow
+improve: expanded test coverage for upgrade binary and custom auth session creation


### PR DESCRIPTION
## Changes

### Features
- Add `--beta` flag to `composio upgrade` for prerelease channel support
- Preload custom auth connections into CLI tool router sessions for seamless custom-auth toolkit execution

### Improvements
- Beta-channel CLI release promotion flow in CI workflow (beta tag validation, promotion to stable)
- Expanded test coverage for upgrade binary and custom auth session creation
- Updated release documentation and CLI README for new beta/stable release model

## Changeset

- Bump: `@composio/cli` patch
- File: `.changeset/cli-beta-flow-and-custom-auth.md`

## Testing

### Phase 1: CI Types/Lint
- Status: ✅ Passed (verified on merged PRs #3077 and #3089)

### Phase 2: Local Binary Test
- `composio version`: ✅ `0.2.17`
- `composio whoami`: ✅ `rahul@composio.dev`
- `composio --help`: ✅ Full output rendered
- Slack integration test: ✅ Passed (`execute()` + `experimental_subAgent()` with structured output)

### Phase 3: Bundled Binary Test
- Status: ⏳ Deferred — will run automatically when the "Release: update version" PR is opened
- The new beta release flow (shipped in #3089) triggers binary builds on the release PR, not the changeset PR

### Slack Integration Test Details
- `SLACK_FIND_CHANNELS`: ✅ Found `#buzz-skill-based-cli-testing`
- `SLACK_SEND_MESSAGE`: ✅ Posted test start message
- `SLACK_FETCH_CONVERSATION_HISTORY`: ✅ Retrieved 20 messages
- `experimental_subAgent()` with `z.object` schema: ✅ Returned structured summary
- `SLACK_SEND_MESSAGE`: ✅ Posted summary back to channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)