### PR TITLE
fix(core): transform `customAuthParams.baseURL` to `base_url` in tool execution

### DIFF
--- a/.changeset/fix-baseurl-custom-auth-params.md
+++ b/.changeset/fix-baseurl-custom-auth-params.md
@@ -1,0 +1,5 @@
+---
+"@composio/core": patch
+---
+
+Fix `customAuthParams.baseURL` not being sent to the API during tool execution. The SDK property `baseURL` is now correctly mapped to the API's expected `base_url` field.

--- a/ts/packages/core/src/models/Tools.ts
+++ b/ts/packages/core/src/models/Tools.ts
@@ -786,7 +786,13 @@ export class Tools<
       const result = await this.client.tools.execute(tool.slug, {
         allow_tracing: body.allowTracing,
         connected_account_id: body.connectedAccountId,
-        custom_auth_params: body.customAuthParams,
+        custom_auth_params: body.customAuthParams
+          ? {
+              base_url: body.customAuthParams.baseURL,
+              body: body.customAuthParams.body,
+              parameters: body.customAuthParams.parameters,
+            }
+          : undefined,
         /**
          * @deprecated: customConnectionData
          * @description

--- a/ts/packages/core/test/tools/tools.test.ts
+++ b/ts/packages/core/test/tools/tools.test.ts
@@ -650,6 +650,41 @@ describe('Tools', () => {
       expect(result).toEqual(toolMocks.toolExecuteResponse);
     });
 
+    it('should transform customAuthParams.baseURL to base_url when executing a tool', async () => {
+      const slug = 'COMPOSIO_TOOL';
+      const body = {
+        userId: 'test-user',
+        connectedAccountId: 'test-connected-account-id',
+        arguments: { query: 'test' },
+        dangerouslySkipVersionCheck: true,
+        customAuthParams: {
+          baseURL: 'https://custom-api.example.com',
+          parameters: [{ name: 'x-api-key', value: 'test-key', in: 'header' as const }],
+          body: { extra: 'data' },
+        },
+      };
+
+      await mockToolExecution(context.tools);
+
+      const result = await context.tools.execute(slug, body);
+
+      expect(mockClient.tools.execute).toHaveBeenCalledWith(slug, {
+        allow_tracing: undefined,
+        connected_account_id: 'test-connected-account-id',
+        custom_auth_params: {
+          base_url: 'https://custom-api.example.com',
+          parameters: [{ name: 'x-api-key', value: 'test-key', in: 'header' }],
+          body: { extra: 'data' },
+        },
+        custom_connection_data: undefined,
+        arguments: body.arguments,
+        user_id: body.userId,
+        version: 'latest',
+        text: undefined,
+      });
+      expect(result).toEqual(toolMocks.toolExecuteResponse);
+    });
+
     it('should pass version parameter from execute() to getRawComposioToolBySlug()', async () => {
       const slug = 'COMPOSIO_TOOL';
       const explicitVersion = '20250909_00';


### PR DESCRIPTION
This PR:

- closes [PLEN-1942](https://linear.app/composio/issue/PLEN-1942/baseurl-not-passed-with-custom-auth-params-in-ts)
- Fixes `customAuthParams.baseURL` being silently dropped during tool execution because the SDK passed the camelCase property directly to the API, which expects snake_case `base_url`
- Explicitly maps `baseURL` → `base_url`, `body`, and `parameters` when constructing the `custom_auth_params` payload sent to `@composio/client`
- Adds a regression test verifying the property name transformation