### PR TITLE
test(cli): fix stale beta upgrade version expectation

### DIFF
--- a/ts/packages/cli/test/src/services/upgrade-binary.test.ts
+++ b/ts/packages/cli/test/src/services/upgrade-binary.test.ts
@@ -285,7 +285,7 @@ describe('UpgradeBinary', () => {
           res.end(
             JSON.stringify([
               {
-                tag_name: '@composio/cli@0.2.18-beta.1',
+                tag_name: '@composio/cli@0.2.19-beta.1',
                 draft: false,
                 prerelease: true,
                 assets: [
@@ -296,7 +296,7 @@ describe('UpgradeBinary', () => {
                 ],
               },
               {
-                tag_name: '@composio/cli@0.2.18-beta.3',
+                tag_name: '@composio/cli@0.2.19-beta.3',
                 draft: false,
                 prerelease: true,
                 assets: [


### PR DESCRIPTION
This PR:

- builds on top of https://github.com/ComposioHQ/composio/pull/3099
- bumps beta version tags from `0.2.18` to `0.2.19` in `upgrade-binary.test.ts` to match the current test data (the test expects `beta-3.zip` to be selected as the latest prerelease, but the version needs to be higher than the stable `0.2.17` fixture)

## Testing

```bash
pnpm --dir ts/packages/cli exec vitest run test/src/services/upgrade-binary.test.ts
```

> **Stack:** 2/3 — between #3099 (feature) and #mock-migration