### PR TITLE
test(e2e): replace live API dependencies with mock servers

### DIFF
--- a/ts/e2e-tests/cli/toolkits/info/e2e.test.ts
+++ b/ts/e2e-tests/cli/toolkits/info/e2e.test.ts
@@ -13,36 +13,46 @@ import {
   type E2ETestResultWithFiles,
 } from '@e2e-tests/utils';
 import { TIMEOUTS } from '@e2e-tests/utils/const';
-import { describe, it, expect, beforeAll } from 'bun:test';
-
-declare module 'bun' {
-  interface Env {
-    COMPOSIO_USER_API_KEY: string;
-  }
-}
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import {
+  startMockToolkitsListServer,
+  type MockToolkitsServer,
+} from '../../../../packages/cli/scripts/mock-toolkits-server';
 
 e2e(import.meta.url, {
   versions: {
     cli: ['current'],
   },
-  env: {
-    COMPOSIO_USER_API_KEY: Bun.env.COMPOSIO_USER_API_KEY,
-  },
   defineTests: ({ runCmd }) => {
+    let server: MockToolkitsServer;
     let validResult: E2ETestResult;
     let redirectResult: E2ETestResultWithFiles<'out.json'>;
     let invalidResult: E2ETestResult;
     let missingSlugResult: E2ETestResult;
 
     beforeAll(async () => {
-      validResult = await runCmd('composio dev toolkits info gmail');
+      server = await startMockToolkitsListServer();
+
+      const envPrefix = [
+        `COMPOSIO_BASE_URL=${server.dockerBaseUrl}`,
+        'COMPOSIO_CACHE_DIR=/tmp/composio-toolkits-info',
+        'COMPOSIO_USER_API_KEY=uak_mock_toolkits_info',
+      ].join(' ');
+
+      validResult = await runCmd(`${envPrefix} composio dev toolkits info gmail`);
       redirectResult = await runCmd({
-        command: 'composio dev toolkits info gmail > out.json',
+        command: `${envPrefix} composio dev toolkits info gmail > out.json`,
         files: ['out.json'],
       });
-      invalidResult = await runCmd('composio dev toolkits info nonexistent_toolkit_xyz12345');
-      missingSlugResult = await runCmd('composio dev toolkits info');
+      invalidResult = await runCmd(
+        `${envPrefix} composio dev toolkits info nonexistent_toolkit_xyz12345`
+      );
+      missingSlugResult = await runCmd(`${envPrefix} composio dev toolkits info`);
     }, TIMEOUTS.FIXTURE);
+
+    afterAll(async () => {
+      await server.close();
+    });
 
     describe('composio dev toolkits info gmail (valid slug)', () => {
       it('exits successfully', () => {
@@ -134,6 +144,15 @@ e2e(import.meta.url, {
 
       it('stderr is empty', () => {
         expect(missingSlugResult.stderr).toBe('');
+      });
+    });
+
+    describe('mock API usage', () => {
+      it('requests the detailed toolkit route for known and unknown slugs', () => {
+        expect(server.requests).toContain('GET /api/v3/toolkits/gmail');
+        expect(server.requests).toContain(
+          'GET /api/v3/toolkits/nonexistent_toolkit_xyz12345'
+        );
       });
     });
   },

--- a/ts/e2e-tests/cli/toolkits/list/e2e.test.ts
+++ b/ts/e2e-tests/cli/toolkits/list/e2e.test.ts
@@ -2,36 +2,49 @@
  * CLI `composio dev toolkits list` e2e test
  *
  * Verifies that the list subcommand returns toolkits as JSON in piped mode,
- * supports --query filtering (exact, prefix, no fuzzy), and respects --limit.
+ * supports deterministic `--query` filtering, and respects `--limit`.
  */
 
-import { e2e, sanitizeOutput, parseJsonStdout, type E2ETestResult } from '@e2e-tests/utils';
+import {
+  e2e,
+  sanitizeOutput,
+  parseJsonStdout,
+  type E2ETestResult,
+} from '@e2e-tests/utils';
 import { TIMEOUTS } from '@e2e-tests/utils/const';
-import { describe, it, expect, beforeAll } from 'bun:test';
-
-declare module 'bun' {
-  interface Env {
-    COMPOSIO_USER_API_KEY: string;
-  }
-}
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import {
+  startMockToolkitsListServer,
+  type MockToolkitsListServer,
+} from '../../../../packages/cli/scripts/mock-toolkits-list-server';
 
 e2e(import.meta.url, {
   versions: {
     cli: ['current'],
   },
-  env: {
-    COMPOSIO_USER_API_KEY: Bun.env.COMPOSIO_USER_API_KEY,
-  },
   defineTests: ({ runCmd }) => {
+    let server: MockToolkitsListServer;
     let exactResult: E2ETestResult;
     let prefixResult: E2ETestResult;
     let noFuzzyResult: E2ETestResult;
 
     beforeAll(async () => {
-      exactResult = await runCmd('composio dev toolkits list --query gmail --limit 1');
-      prefixResult = await runCmd('composio dev toolkits list --query gmai --limit 1');
-      noFuzzyResult = await runCmd('composio dev toolkits list --query gmal --limit 1');
+      server = await startMockToolkitsListServer();
+
+      const envPrefix = [
+        `COMPOSIO_BASE_URL=${server.dockerBaseUrl}`,
+        'COMPOSIO_CACHE_DIR=/tmp/composio-toolkits-list',
+        'COMPOSIO_USER_API_KEY=uak_mock_toolkits_list',
+      ].join(' ');
+
+      exactResult = await runCmd(`${envPrefix} composio dev toolkits list --query gmail --limit 1`);
+      prefixResult = await runCmd(`${envPrefix} composio dev toolkits list --query gmai --limit 1`);
+      noFuzzyResult = await runCmd(`${envPrefix} composio dev toolkits list --query gmal --limit 1`);
     }, TIMEOUTS.FIXTURE);
+
+    afterAll(async () => {
+      await server.close();
+    });
 
     describe('composio dev toolkits list --query gmail --limit 1 (exact slug)', () => {
       it('exits successfully', () => {
@@ -99,6 +112,14 @@ e2e(import.meta.url, {
 
       it('stdout is an empty JSON array (no results)', () => {
         expect(sanitizeOutput(noFuzzyResult.stdout)).toBe('[]');
+      });
+    });
+
+    describe('mock API usage', () => {
+      it('requests the toolkit catalog for each search term', () => {
+        expect(server.requests).toContain('GET /api/v3/toolkits?search=gmail&limit=1');
+        expect(server.requests).toContain('GET /api/v3/toolkits?search=gmai&limit=1');
+        expect(server.requests).toContain('GET /api/v3/toolkits?search=gmal&limit=1');
       });
     });
   },

--- a/ts/e2e-tests/cli/toolkits/list/e2e.test.ts
+++ b/ts/e2e-tests/cli/toolkits/list/e2e.test.ts
@@ -15,15 +15,15 @@ import { TIMEOUTS } from '@e2e-tests/utils/const';
 import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
 import {
   startMockToolkitsListServer,
-  type MockToolkitsListServer,
-} from '../../../../packages/cli/scripts/mock-toolkits-list-server';
+  type MockToolkitsServer,
+} from '../../../../packages/cli/scripts/mock-toolkits-server';
 
 e2e(import.meta.url, {
   versions: {
     cli: ['current'],
   },
   defineTests: ({ runCmd }) => {
-    let server: MockToolkitsListServer;
+    let server: MockToolkitsServer;
     let exactResult: E2ETestResult;
     let prefixResult: E2ETestResult;
     let noFuzzyResult: E2ETestResult;

--- a/ts/e2e-tests/cli/toolkits/search/e2e.test.ts
+++ b/ts/e2e-tests/cli/toolkits/search/e2e.test.ts
@@ -13,36 +13,46 @@ import {
   type E2ETestResultWithFiles,
 } from '@e2e-tests/utils';
 import { TIMEOUTS } from '@e2e-tests/utils/const';
-import { describe, it, expect, beforeAll } from 'bun:test';
-
-declare module 'bun' {
-  interface Env {
-    COMPOSIO_USER_API_KEY: string;
-  }
-}
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import {
+  startMockToolkitsListServer,
+  type MockToolkitsServer,
+} from '../../../../packages/cli/scripts/mock-toolkits-server';
 
 e2e(import.meta.url, {
   versions: {
     cli: ['current'],
   },
-  env: {
-    COMPOSIO_USER_API_KEY: Bun.env.COMPOSIO_USER_API_KEY,
-  },
   defineTests: ({ runCmd }) => {
+    let server: MockToolkitsServer;
     let validResult: E2ETestResult;
     let limitResult: E2ETestResult;
     let redirectResult: E2ETestResultWithFiles<'out.json'>;
     let noResultsResult: E2ETestResult;
 
     beforeAll(async () => {
-      validResult = await runCmd('composio dev toolkits search gmail');
-      limitResult = await runCmd('composio dev toolkits search gmail --limit 1');
+      server = await startMockToolkitsListServer();
+
+      const envPrefix = [
+        `COMPOSIO_BASE_URL=${server.dockerBaseUrl}`,
+        'COMPOSIO_CACHE_DIR=/tmp/composio-toolkits-search',
+        'COMPOSIO_USER_API_KEY=uak_mock_toolkits_search',
+      ].join(' ');
+
+      validResult = await runCmd(`${envPrefix} composio dev toolkits search gmail`);
+      limitResult = await runCmd(`${envPrefix} composio dev toolkits search gmail --limit 1`);
       redirectResult = await runCmd({
-        command: 'composio dev toolkits search gmail --limit 1 > out.json',
+        command: `${envPrefix} composio dev toolkits search gmail --limit 1 > out.json`,
         files: ['out.json'],
       });
-      noResultsResult = await runCmd('composio dev toolkits search xyznonexistent_abc_12345');
+      noResultsResult = await runCmd(
+        `${envPrefix} composio dev toolkits search xyznonexistent_abc_12345`
+      );
     }, TIMEOUTS.FIXTURE);
+
+    afterAll(async () => {
+      await server.close();
+    });
 
     describe('composio dev toolkits search gmail (known query)', () => {
       it('exits successfully', () => {
@@ -129,6 +139,16 @@ e2e(import.meta.url, {
 
       it('stdout is an empty JSON array (no results)', () => {
         expect(sanitizeOutput(noResultsResult.stdout)).toBe('[]');
+      });
+    });
+
+    describe('mock API usage', () => {
+      it('requests the toolkit catalog for each search scenario', () => {
+        expect(server.requests).toContain('GET /api/v3/toolkits?search=gmail&limit=10');
+        expect(server.requests).toContain('GET /api/v3/toolkits?search=gmail&limit=1');
+        expect(server.requests).toContain(
+          'GET /api/v3/toolkits?search=xyznonexistent_abc_12345&limit=10'
+        );
       });
     });
   },

--- a/ts/e2e-tests/runtimes/node/typescript-mjs-import-nodenext/.gitignore
+++ b/ts/e2e-tests/runtimes/node/typescript-mjs-import-nodenext/.gitignore
@@ -1,3 +1,5 @@
 generated/
+!fixtures/generated/
+!fixtures/generated/*.ts
 dist/
 node_modules/

--- a/ts/e2e-tests/runtimes/node/typescript-mjs-import-nodenext/e2e.test.ts
+++ b/ts/e2e-tests/runtimes/node/typescript-mjs-import-nodenext/e2e.test.ts
@@ -1,28 +1,15 @@
 /**
  * TypeScript .mjs import resolution e2e test
  *
- * Verifies that generated TypeScript files with .mjs imports
- * can be compiled successfully with moduleResolution: "nodenext".
- *
- * Requires COMPOSIO_API_KEY environment variable to be set.
+ * Verifies that representative generated TypeScript files using `.js` imports
+ * compile successfully with moduleResolution: "nodenext".
  */
 
 import { e2e, type E2ETestResult } from '@e2e-tests/utils';
 import { describe, it, expect, beforeAll } from 'bun:test';
 
-declare module 'bun' {
-  interface Env {
-    COMPOSIO_API_KEY: string;
-    COMPOSIO_USER_API_KEY: string;
-  }
-}
-
 e2e(import.meta.url, {
   versions: { node: ['current'] },
-  env: {
-    COMPOSIO_API_KEY: Bun.env.COMPOSIO_API_KEY,
-    COMPOSIO_USER_API_KEY: Bun.env.COMPOSIO_USER_API_KEY,
-  },
   defineTests: ({ runFixture }) => {
     let result: E2ETestResult;
 
@@ -35,16 +22,12 @@ e2e(import.meta.url, {
         expect(result.exitCode).toBe(0);
       });
 
-      it('composio generate ts succeeds', () => {
-        expect(result.stdout).toContain('Test 1 passed: composio generate ts succeeded');
-      });
-
-      it('generated files exist', () => {
-        expect(result.stdout).toContain('Test 2 passed: Generated files exist');
+      it('fixture generated files exist', () => {
+        expect(result.stdout).toContain('Test 1 passed: Fixture generated files exist');
       });
 
       it('TypeScript compilation succeeds', () => {
-        expect(result.stdout).toContain('Test 3 passed: TypeScript compilation succeeded');
+        expect(result.stdout).toContain('Test 2 passed: TypeScript compilation succeeded');
       });
 
       it('completes all tests', () => {

--- a/ts/e2e-tests/runtimes/node/typescript-mjs-import-nodenext/fixtures/generated/codeinterpreter.ts
+++ b/ts/e2e-tests/runtimes/node/typescript-mjs-import-nodenext/fixtures/generated/codeinterpreter.ts
@@ -1,0 +1,1 @@
+export const compileWithNodeNext = (): string => 'ok';

--- a/ts/e2e-tests/runtimes/node/typescript-mjs-import-nodenext/fixtures/generated/index.ts
+++ b/ts/e2e-tests/runtimes/node/typescript-mjs-import-nodenext/fixtures/generated/index.ts
@@ -1,0 +1,1 @@
+export { compileWithNodeNext } from './codeinterpreter.js';

--- a/ts/e2e-tests/runtimes/node/typescript-mjs-import-nodenext/fixtures/index.mjs
+++ b/ts/e2e-tests/runtimes/node/typescript-mjs-import-nodenext/fixtures/index.mjs
@@ -1,20 +1,13 @@
 /**
  * E2E test: TypeScript .mjs import resolution with moduleResolution: "nodenext"
  *
- * This test verifies that generated TypeScript files with .mjs imports
- * can be compiled successfully with moduleResolution: "nodenext".
- *
- * The issue: When `composio generate ts` uses importExtension: 'mjs',
- * the generated .ts files contain `import ... from "./foo.mjs"` statements.
- * With moduleResolution: "node16" or "nodenext", TypeScript expects .mjs
- * imports to resolve to .mts files, NOT .ts files.
- *
- * This causes TS2307: Cannot find module './foo.mjs' errors.
+ * This test verifies that representative generated TypeScript files using
+ * `.js` import specifiers compile successfully with moduleResolution: "nodenext".
  */
 
 import assert from 'node:assert';
 import { execSync } from 'node:child_process';
-import { existsSync, rmSync, readdirSync } from 'node:fs';
+import { existsSync, readdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -25,31 +18,8 @@ console.log('🧪 Testing TypeScript .mjs import resolution with moduleResolutio
 console.log(`Node.js version: ${process.version}`);
 console.log(`Working directory: ${__dirname}\n`);
 
-// Cleanup generated directory if it exists
-if (existsSync(GENERATED_DIR)) {
-  console.log('Cleaning up previous generated files...');
-  rmSync(GENERATED_DIR, { recursive: true });
-}
-
-// Test 1: Run composio generate ts --toolkits hackernews --output-dir ./generated
-console.log('Test 1: Running composio generate ts --toolkits hackernews --output-dir ./generated...');
-try {
-  // Use the composio CLI binary built and installed to /usr/local/bin in the Dockerfile
-  execSync(`composio generate ts --toolkits hackernews --output-dir ${GENERATED_DIR}`, {
-    cwd: __dirname,
-    stdio: 'inherit',
-    env: { ...process.env, FORCE_COLOR: '0' },
-  });
-
-  console.log('✅ Test 1 passed: composio generate ts succeeded\n');
-} catch (error) {
-  console.error('❌ Test 1 failed: composio generate ts threw an error');
-  console.error(error.message);
-  process.exit(1);
-}
-
-// Test 2: Verify generated files exist
-console.log('Test 2: Verifying generated files exist...');
+// Test 1: Verify representative generated files exist
+console.log('Test 1: Verifying fixture generated files exist...');
 try {
   assert.ok(existsSync(GENERATED_DIR), 'Generated directory should exist');
 
@@ -57,19 +27,22 @@ try {
   console.log('Generated files:', files);
 
   assert.ok(files.length > 0, 'Generated directory should not be empty');
-  assert.ok(files.some((f) => f.endsWith('.ts')), 'Should have .ts files');
+  assert.ok(files.includes('index.ts'), 'Generated directory should include index.ts');
+  assert.ok(
+    files.includes('codeinterpreter.ts'),
+    'Generated directory should include codeinterpreter.ts'
+  );
 
-  console.log('✅ Test 2 passed: Generated files exist\n');
+  console.log('✅ Test 1 passed: Fixture generated files exist\n');
 } catch (error) {
-  console.error('❌ Test 2 failed: Generated files verification failed');
+  console.error('❌ Test 1 failed: Fixture generated files verification failed');
   console.error(error.message);
   process.exit(1);
 }
 
-// Test 3: Run tsc --noEmit to check TypeScript compilation
-console.log('Test 3: Running tsc --noEmit to verify TypeScript compilation...');
-console.log('Expected: FAILURE with TS2307 if importExtension is "mjs"');
-console.log('Expected: SUCCESS if importExtension is "js"\n');
+// Test 2: Run tsc --noEmit to check TypeScript compilation
+console.log('Test 2: Running tsc --noEmit to verify TypeScript compilation...');
+console.log('Expected: SUCCESS when generated source uses ".js" specifiers under nodenext\n');
 
 try {
   execSync('npx tsc --noEmit', {
@@ -78,24 +51,15 @@ try {
     encoding: 'utf-8',
   });
 
-  console.log('✅ Test 3 passed: TypeScript compilation succeeded');
-  console.log('   (importExtension is correctly set to "js")\n');
+  console.log('✅ Test 2 passed: TypeScript compilation succeeded');
+  console.log('   (fixture imports correctly use ".js" specifiers)\n');
 } catch (error) {
-  // execSync error object has stdout/stderr as Buffer or string
   const stdout = error.stdout?.toString?.() || error.stdout || '';
   const stderr = error.stderr?.toString?.() || error.stderr || '';
   const output = stdout + stderr + error.message;
 
-  if (output.includes('TS2307') && output.includes('.mjs')) {
-    console.log('❌ Test 3 failed: TypeScript compilation failed with TS2307');
-    console.log('   This confirms the bug: .mjs imports do not resolve to .ts files');
-    console.log('   with moduleResolution: "nodenext"\n');
-    console.log('Error output:');
-    console.log(stdout || stderr);
-    process.exit(1);
-  }
-
-  console.error('❌ Test 3 failed: Unexpected TypeScript error');
+  console.error('❌ Test 2 failed: TypeScript compilation failed');
+  console.error('output:', output);
   console.error('stdout:', stdout);
   console.error('stderr:', stderr);
   console.error('message:', error.message);

--- a/ts/packages/cli/scripts/mock-toolkits-list-server.ts
+++ b/ts/packages/cli/scripts/mock-toolkits-list-server.ts
@@ -1,0 +1,144 @@
+#!/usr/bin/env bun
+
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+
+const GMAIL_TOOLKIT = {
+  name: 'Gmail',
+  slug: 'gmail',
+  auth_schemes: ['OAUTH2'],
+  composio_managed_auth_schemes: ['OAUTH2'],
+  is_local_toolkit: false,
+  meta: {
+    description: 'Gmail toolkit for deterministic CLI e2e tests.',
+    categories: [],
+    created_at: '2024-01-01T00:00:00.000Z',
+    updated_at: '2024-01-01T00:00:00.000Z',
+    available_versions: ['2024.01.01'],
+    tools_count: 40,
+    triggers_count: 2,
+  },
+  no_auth: false,
+} as const;
+
+export interface MockToolkitsListServer {
+  readonly hostBaseUrl: string;
+  readonly dockerBaseUrl: string;
+  readonly requests: string[];
+  readonly close: () => Promise<void>;
+}
+
+const sendJson = (res: ServerResponse, statusCode: number, body: unknown): void => {
+  res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+};
+
+const matchingToolkits = (search: string | null): ReadonlyArray<typeof GMAIL_TOOLKIT> => {
+  if (search === null || search.length === 0) {
+    return [GMAIL_TOOLKIT];
+  }
+
+  const normalized = search.toLowerCase();
+  if (normalized === 'gmail' || normalized === 'gmai') {
+    return [GMAIL_TOOLKIT];
+  }
+
+  return [];
+};
+
+const parseLimit = (req: IncomingMessage): number => {
+  const url = new URL(req.url ?? '/', `http://${req.headers.host ?? '127.0.0.1'}`);
+  const parsed = Number.parseInt(url.searchParams.get('limit') ?? '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 30;
+};
+
+export async function startMockToolkitsListServer(options?: {
+  host?: string;
+  port?: number;
+}): Promise<MockToolkitsListServer> {
+  const host = options?.host ?? '0.0.0.0';
+  const port = options?.port ?? 0;
+  const requests: string[] = [];
+
+  const server = createServer((req, res) => {
+    const url = new URL(req.url ?? '/', `http://${req.headers.host ?? '127.0.0.1'}`);
+    requests.push(`${req.method ?? 'GET'} ${url.pathname}${url.search}`);
+
+    if ((req.method ?? 'GET') === 'GET' && url.pathname === '/api/v3/toolkits') {
+      const items = matchingToolkits(url.searchParams.get('search')).slice(0, parseLimit(req));
+      sendJson(res, 200, {
+        items,
+        total_items: items.length,
+        total_pages: 1,
+        current_page: 1,
+        next_cursor: null,
+      });
+      return;
+    }
+
+    if ((req.method ?? 'GET') === 'POST' && url.pathname === '/api/v3/cli/analytics') {
+      sendJson(res, 204, {});
+      return;
+    }
+
+    sendJson(res, 404, {
+      error: `Unhandled mock route: ${req.method ?? 'GET'} ${url.pathname}`,
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen({ host, port }, () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+  if (address === null || typeof address === 'string') {
+    throw new Error('Failed to bind mock toolkits list server to a TCP port');
+  }
+
+  const close = () =>
+    new Promise<void>((resolve, reject) => {
+      server.close(error => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+
+  return {
+    hostBaseUrl: `http://127.0.0.1:${address.port}`,
+    dockerBaseUrl: `http://host.docker.internal:${address.port}`,
+    requests,
+    close,
+  };
+}
+
+const parsePortArg = (): number | undefined => {
+  const index = process.argv.indexOf('--port');
+  if (index === -1) return undefined;
+
+  const value = Number.parseInt(process.argv[index + 1] ?? '', 10);
+  return Number.isFinite(value) ? value : undefined;
+};
+
+if (import.meta.main) {
+  const server = await startMockToolkitsListServer({ port: parsePortArg() });
+
+  const shutdown = async () => {
+    await server.close();
+    process.exit(0);
+  };
+
+  process.on('SIGINT', () => {
+    void shutdown();
+  });
+  process.on('SIGTERM', () => {
+    void shutdown();
+  });
+
+  await new Promise(() => {});
+}

--- a/ts/packages/cli/scripts/mock-toolkits-server.ts
+++ b/ts/packages/cli/scripts/mock-toolkits-server.ts
@@ -20,7 +20,40 @@ const GMAIL_TOOLKIT = {
   no_auth: false,
 } as const;
 
-export interface MockToolkitsListServer {
+const GMAIL_TOOLKIT_DETAILED = {
+  name: 'Gmail',
+  slug: 'gmail',
+  is_local_toolkit: false,
+  composio_managed_auth_schemes: ['OAUTH2'],
+  no_auth: false,
+  meta: {
+    description: 'Gmail toolkit for deterministic CLI e2e tests.',
+    categories: [],
+    created_at: '2024-01-01T00:00:00.000Z',
+    updated_at: '2024-01-01T00:00:00.000Z',
+    available_versions: ['2024.01.01'],
+    tools_count: 40,
+    triggers_count: 2,
+  },
+  auth_config_details: [
+    {
+      mode: 'OAUTH2',
+      name: 'OAuth 2.0',
+      fields: {
+        auth_config_creation: {
+          required: [],
+          optional: [],
+        },
+        connected_account_initiation: {
+          required: [],
+          optional: [],
+        },
+      },
+    },
+  ],
+} as const;
+
+export interface MockToolkitsServer {
   readonly hostBaseUrl: string;
   readonly dockerBaseUrl: string;
   readonly requests: string[];
@@ -54,7 +87,7 @@ const parseLimit = (req: IncomingMessage): number => {
 export async function startMockToolkitsListServer(options?: {
   host?: string;
   port?: number;
-}): Promise<MockToolkitsListServer> {
+}): Promise<MockToolkitsServer> {
   const host = options?.host ?? '0.0.0.0';
   const port = options?.port ?? 0;
   const requests: string[] = [];
@@ -71,6 +104,18 @@ export async function startMockToolkitsListServer(options?: {
         total_pages: 1,
         current_page: 1,
         next_cursor: null,
+      });
+      return;
+    }
+
+    if ((req.method ?? 'GET') === 'GET' && url.pathname === '/api/v3/toolkits/gmail') {
+      sendJson(res, 200, GMAIL_TOOLKIT_DETAILED);
+      return;
+    }
+
+    if ((req.method ?? 'GET') === 'GET' && url.pathname.startsWith('/api/v3/toolkits/')) {
+      sendJson(res, 404, {
+        error: `Toolkit not found: ${url.pathname.split('/').at(-1) ?? 'unknown'}`,
       });
       return;
     }


### PR DESCRIPTION
This PR:

- builds on top of https://github.com/ComposioHQ/composio/pull/3100
- adds `mock-toolkits-server.ts` — a deterministic mock HTTP server for the `/api/v3/toolkits` and `/api/v3/toolkits/:slug` endpoints
- migrates `toolkits/list`, `toolkits/info`, and `toolkits/search` e2e suites from live API calls to the mock server, removing the `COMPOSIO_USER_API_KEY` env var requirement
- replaces the live `composio generate ts` call in the `typescript-mjs-import-nodenext` e2e suite with checked-in fixture files (`generated/index.ts`, `generated/codeinterpreter.ts`), removing the `COMPOSIO_API_KEY` dependency
- adds `afterAll` cleanup and `mock API usage` assertion blocks to each migrated suite for request verification

## Testing

```bash
pnpm --dir ts/e2e-tests/_utils typecheck
pnpm --filter @e2e-tests/cli-toolkits-info typecheck
pnpm --filter @e2e-tests/cli-toolkits-list typecheck
pnpm --filter @e2e-tests/cli-toolkits-search typecheck
```

> **Stack:** 3/3 — final PR after #3099 (feature) and #3100 (beta fix)