### PR TITLE
fix: handle additionalProperties in json_schema_to_pydantic_type

### DIFF
--- a/python/composio/utils/schema_converter.py
+++ b/python/composio/utils/schema_converter.py
@@ -190,6 +190,16 @@ def _convert_with_library(
 
         # For object schemas, create model directly
         if schema.get("type") == "object":
+            # Handle objects with additionalProperties but no explicit properties
+            # e.g. {"type": "object", "additionalProperties": {"type": "string"}}
+            # should map to Dict[str, str], not an empty Pydantic model.
+            if "additionalProperties" in schema and "properties" not in schema:
+                additional = schema["additionalProperties"]
+                if isinstance(additional, bool):
+                    return t.Dict[str, t.Any] if additional else t.Dict
+                value_type = json_schema_to_pydantic_type(additional)
+                return t.Dict[str, t.cast(t.Type, value_type)]  # type: ignore
+
             if "title" not in schema:
                 schema = {**schema, "title": "GeneratedModel"}
             return create_model_from_schema(

--- a/python/composio/utils/schema_converter.py
+++ b/python/composio/utils/schema_converter.py
@@ -196,9 +196,14 @@ def _convert_with_library(
             if "additionalProperties" in schema and "properties" not in schema:
                 additional = schema["additionalProperties"]
                 if isinstance(additional, bool):
-                    return t.Dict[str, t.Any] if additional else t.Dict
-                value_type = json_schema_to_pydantic_type(additional)
-                return t.Dict[str, t.cast(t.Type, value_type)]  # type: ignore
+                    if additional:
+                        return t.Dict[str, t.Any]
+                    # additionalProperties: false with no properties means
+                    # only empty objects are valid — fall through to
+                    # create_model_from_schema which produces a strict model.
+                else:
+                    value_type = json_schema_to_pydantic_type(additional)
+                    return t.Dict[str, t.cast(t.Type, value_type)]  # type: ignore
 
             if "title" not in schema:
                 schema = {**schema, "title": "GeneratedModel"}


### PR DESCRIPTION
## Summary

Fixes #3087

When a JSON schema defines an object with `additionalProperties` but no explicit `properties` (e.g. `{"type": "object", "additionalProperties": {"type": "string"}}`), `json_schema_to_pydantic_type()` delegates to `create_model_from_schema()` which generates an empty Pydantic model. This causes Pydantic to silently strip all fields during validation, resulting in empty objects like `[{}]` instead of the expected data.

This affects any tool in the catalog whose schema uses `additionalProperties` without explicit `properties` — including `OUTLOOK_CALENDAR_CREATE_EVENT`'s `attendees_info` field.

## Fix

Before delegating to `create_model_from_schema()`, check if the object schema has `additionalProperties` but no `properties`. In that case, map directly to `Dict[str, value_type]`:

| Schema | Before | After |
|---|---|---|
| `{"type": "object", "additionalProperties": {"type": "string"}}` | Empty model `→ {}` | `Dict[str, str]` |
| `{"type": "object", "additionalProperties": {"type": "integer"}}` | Empty model `→ {}` | `Dict[str, int]` |
| `{"type": "object", "additionalProperties": true}` | Empty model `→ {}` | `Dict[str, Any]` |
| `{"type": "object", "properties": {...}}` | Unchanged | Unchanged |

## Verification

Using the MRE from the issue:
```python
from composio.utils.shared import json_schema_to_model

schema = {
    "type": "object",
    "title": "CreateEventRequest",
    "properties": {
        "attendees_info": {
            "type": "array",
            "items": {
                "type": "object",
                "additionalProperties": {"type": "string"}
            },
            "default": []
        }
    }
}

Model = json_schema_to_model(schema)
result = Model.model_validate({
    "attendees_info": [
        {"name": "John Doe", "type": "required", "email": "john@example.com"}
    ]
})
print(result.model_dump())
# Before: {'attendees_info': [{}]}
# After:  {'attendees_info': [{'name': 'John Doe', 'type': 'required', 'email': 'john@example.com'}]}
```