### PR TITLE
Document `--file` support for CLI skill uploads

### DIFF
--- a/ts/packages/cli/skills/composio-cli/SKILL.md
+++ b/ts/packages/cli/skills/composio-cli/SKILL.md
@@ -38,6 +38,16 @@ composio execute GITHUB_CREATE_AN_ISSUE -d @issue.json
 cat issue.json | composio execute GITHUB_CREATE_AN_ISSUE -d -
 ```
 
+Upload a local file when the tool has a single `file_uploadable` input:
+
+```bash
+composio execute SLACK_UPLOAD_OR_CREATE_A_FILE_IN_SLACK \
+  --file ./image.png \
+  -d '{ channels: "C123" }'
+```
+
+`--file` injects the local path into the tool's single uploadable file field. If a tool has no uploadable file input, or has more than one, use explicit `-d` JSON instead.
+
 Run independent tool calls in parallel:
 
 ```bash
@@ -80,7 +90,7 @@ composio proxy https://api.github.com/user --toolkit github --method GET </dev/n
 
 > **For programmatic calls, LLM workflows, or anything beyond a single tool call — use `composio run`.**
 
-`composio run` executes an inline JavaScript snippet with authenticated `execute()`, `search()`, `proxy()`, and the experimental `experimental_subAgent()` helper pre-injected. No SDK setup required.
+`composio run` executes an inline ESM JavaScript/Typescript (bun compatible) snippet with authenticated `execute()`, `search()`, `proxy()`, and the experimental `experimental_subAgent()` helper pre-injected. No SDK setup required.
 
 Chain multiple tools:
 


### PR DESCRIPTION
## Summary
- Documented how to upload a local file with `composio execute` when a tool exposes a single `file_uploadable` input.
- Added an example for `SLACK_UPLOAD_OR_CREATE_A_FILE_IN_SLACK` using `--file` alongside `-d` JSON arguments.
- Clarified that `--file` only applies when there is exactly one uploadable file field; otherwise `-d` JSON should be used.

## Testing
- Not run (documentation-only change).
- Verified the updated CLI skill guidance in `ts/packages/cli/skills/composio-cli/SKILL.md`.