### PR TITLE
fix: prevent docs-update-data workflow failure on reviewer step

### DIFF
--- a/.github/workflows/docs-update-data.yml
+++ b/.github/workflows/docs-update-data.yml
@@ -96,8 +96,11 @@ jobs:
 
       - name: Request review from trigger actor
         if: steps.create-pr.outputs.pull-request-number
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
           AUTHOR: ${{ github.actor }}
-        run: gh pr edit "$PR_NUMBER" --add-reviewer "$AUTHOR"
+        run: |
+          gh pr edit "$PR_NUMBER" --add-reviewer "$AUTHOR" || \
+          gh pr edit "$PR_NUMBER" --add-reviewer "Sushmithamallesh"


### PR DESCRIPTION
## Summary
- Add `continue-on-error: true` to the reviewer request step
- Fall back to adding @Sushmithamallesh as reviewer when the trigger actor (e.g. bot) can't be added

Fixes: https://github.com/ComposioHQ/composio/actions/runs/24017959019

🤖 Generated with [Claude Code](https://claude.com/claude-code)