### PR TITLE
Add composio listen and top-level trigger commands

### DIFF
--- a/ts/packages/cli/skills/composio-cli/SKILL.md
+++ b/ts/packages/cli/skills/composio-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: composio-cli
-description: Help users operate the published Composio CLI to find the right tool, connect accounts, inspect schemas, execute tools, script workflows with `composio run`, and call authenticated app APIs with `composio proxy`. Use when the user asks how to do something with `composio`, wants to run a known tool slug, needs to discover a slug with `composio search`, fix a missing connection with `composio link`, inspect tool inputs with `--get-schema` or `--dry-run`, troubleshoot top-level CLI flows, or explicitly needs `composio dev` guidance.
+description: Help users operate the published Composio CLI to find the right tool, connect accounts, inspect schemas, execute tools, subscribe to trigger events with `composio listen`, script workflows with `composio run`, and call authenticated app APIs with `composio proxy`. Use when the user asks how to do something with `composio`, wants to run a known tool slug, needs to discover a slug with `composio search`, fix a missing connection with `composio link`, inspect tool inputs with `--get-schema` or `--dry-run`, troubleshoot top-level CLI flows, or explicitly needs `composio dev` guidance.
 ---
 
 # Composio CLI
@@ -67,6 +67,28 @@ composio link googlecalendar --no-browser
 ```
 
 After linking, retry the original `execute` command.
+
+## `listen` — Subscribe To Trigger Events
+
+Use `composio listen` when the user wants a temporary subscription for consumer-project events, especially for background agents that should consume new emails, Slack messages, or similar trigger payloads from artifact files.
+
+The command creates a temporary trigger, subscribes to it, writes each event to the artifact folder, and disables the trigger on cleanup.
+
+```bash
+composio listen GMAIL_NEW_GMAIL_MESSAGE
+composio listen SLACK_RECEIVE_MESSAGE -p '{ trigger_config: { channel: "C123" } }'
+composio listen GMAIL_NEW_GMAIL_MESSAGE --stream
+composio listen GMAIL_NEW_GMAIL_MESSAGE --stream '.data.threadId'
+composio listen GMAIL_NEW_GMAIL_MESSAGE --timeout 5m
+composio listen GMAIL_NEW_GMAIL_MESSAGE -p @trigger.json --max-events 5
+```
+
+Key points:
+
+- `-p/--params` is only for trigger config fields; the connected account is resolved automatically.
+- `--stream` prints each event inline, and `--stream '.path.here'` prints only the selected field.
+- `--timeout` and `--max-events` are the normal ways to stop long-running listeners cleanly.
+- `composio artifacts cwd` shows the current artifact root when the user needs to inspect saved event payloads.
 
 ## `proxy` — Raw API Access
 

--- a/ts/packages/cli/src/commands/artifacts.cmd.ts
+++ b/ts/packages/cli/src/commands/artifacts.cmd.ts
@@ -1,7 +1,10 @@
 import process from 'node:process';
 import { Command } from '@effect/cli';
 import { Effect, Option } from 'effect';
-import { resolveCliSessionArtifacts } from 'src/services/cli-session-artifacts';
+import {
+  resolveArtifactsRoot,
+  resolveCliSessionArtifacts,
+} from 'src/services/cli-session-artifacts';
 
 const cwdCmd = Command.make('cwd').pipe(
   Command.withDescription('Print the cwd-scoped session artifact directory.'),
@@ -9,7 +12,7 @@ const cwdCmd = Command.make('cwd').pipe(
     Effect.gen(function* () {
       const artifacts = yield* resolveCliSessionArtifacts();
       const directoryPath = Option.match(artifacts, {
-        onNone: () => '/tmp/composio',
+        onNone: () => resolveArtifactsRoot(),
         onSome: value => value.directoryPath,
       });
       process.stdout.write(`${directoryPath}\n`);

--- a/ts/packages/cli/src/commands/index.ts
+++ b/ts/packages/cli/src/commands/index.ts
@@ -8,6 +8,7 @@ import { versionCmd } from './version.cmd';
 import { upgradeCmd } from './upgrade.cmd';
 import { whoamiCmd } from './whoami.cmd';
 import { loginCmd } from './login.cmd';
+import { listenCmd } from './listen.cmd';
 import { logoutCmd } from './logout.cmd';
 import { runCmd } from './run.cmd';
 import { proxyCmd } from './proxy.cmd';
@@ -42,6 +43,7 @@ const $cmd = $defaultCmd.pipe(
     upgradeCmd,
     whoamiCmd,
     loginCmd,
+    listenCmd,
     logoutCmd,
     runCmd,
     proxyCmd,
@@ -125,6 +127,34 @@ const normalizeVersionShortFlag = (argv: ReadonlyArray<string>): ReadonlyArray<s
     return [...argv.slice(0, 2), '--version'];
   }
   return argv;
+};
+
+const normalizeListenStreamFlag = (argv: ReadonlyArray<string>): ReadonlyArray<string> => {
+  const head = argv.slice(0, 2);
+  const args = argv.slice(2);
+  const isListen = args[0] === 'listen';
+  if (!isListen) {
+    return argv;
+  }
+
+  const normalized: string[] = [...head];
+  for (let i = 0; i < args.length; i += 1) {
+    const token = args[i];
+    if (token !== '--stream') {
+      normalized.push(token ?? '');
+      continue;
+    }
+
+    const next = args[i + 1];
+    if (next === undefined || next.startsWith('-')) {
+      normalized.push('--stream=');
+      continue;
+    }
+
+    normalized.push(token);
+  }
+
+  return normalized;
 };
 
 const normalizeHiddenDebugFlags = (argv: ReadonlyArray<string>): ReadonlyArray<string> => {
@@ -217,7 +247,9 @@ export const runWithConfig = Effect.gen(function* () {
   });
 
   return (argv: ReadonlyArray<string>) => {
-    const normalizedArgv = normalizeHiddenDebugFlags(normalizeVersionShortFlag(argv));
+    const normalizedArgv = normalizeHiddenDebugFlags(
+      normalizeListenStreamFlag(normalizeVersionShortFlag(argv))
+    );
     if (isRootHelp(normalizedArgv)) {
       return printRootHelp();
     }

--- a/ts/packages/cli/src/commands/listen.cmd.ts
+++ b/ts/packages/cli/src/commands/listen.cmd.ts
@@ -1,0 +1,473 @@
+import { Args, Command, Options } from '@effect/cli';
+import { FileSystem } from '@effect/platform';
+import { Deferred, Effect, Option, Runtime } from 'effect';
+import path from 'node:path';
+import { requireAuth } from 'src/effects/require-auth';
+import { resolveOptionalTextInput } from 'src/effects/resolve-optional-text-input';
+import { ComposioClientSingleton } from 'src/services/composio-clients';
+import {
+  formatResolveCommandProjectError,
+  resolveCommandProject,
+} from 'src/services/command-project';
+import {
+  resolveArtifactsRoot,
+  resolveCliSessionArtifacts,
+} from 'src/services/cli-session-artifacts';
+import { TerminalUI } from 'src/services/terminal-ui';
+import { TriggersRealtime } from 'src/services/triggers-realtime';
+import { parseJsonIsh } from 'src/utils/parse-json-ish';
+import { toolkitFromToolSlug } from 'src/utils/toolkit-from-tool-slug';
+import { matchesTriggerListenFilters } from './triggers/filter';
+import { parseTriggerListenEvent } from './triggers/parse';
+
+const slug = Args.text({ name: 'slug' }).pipe(
+  Args.withDescription('Trigger slug (e.g. "GMAIL_NEW_GMAIL_MESSAGE")')
+);
+
+const params = Options.text('params').pipe(
+  Options.withAlias('p'),
+  Options.withDescription('Trigger create params as JSON/JS object, @file, or - for stdin'),
+  Options.optional
+);
+
+const maxEvents = Options.integer('max-events').pipe(
+  Options.withDescription('Stop after receiving N events for this temporary trigger'),
+  Options.optional
+);
+
+const timeout = Options.text('timeout').pipe(
+  Options.withDescription('Stop after a duration such as "5m", "1hr", or "30s"'),
+  Options.optional
+);
+
+const stream = Options.text('stream').pipe(
+  Options.withDescription(
+    'Also stream each event payload inline. Pass an optional jq-like path such as ".thread.id" or ".data[0].id".'
+  ),
+  Options.optional
+);
+
+const debug = Options.boolean('debug').pipe(
+  Options.withDescription(
+    'Print verbose debug information (raw events, filter results, Pusher state)'
+  ),
+  Options.withDefault(false)
+);
+
+const sanitizePathPart = (value: string): string =>
+  value.replace(/[^A-Z0-9._-]+/gi, '-').replace(/^-+|-+$/g, '') || 'unknown';
+
+const resolveParamsInput = (input: Option.Option<string>) =>
+  resolveOptionalTextInput(input, { missingValue: '{}' });
+
+const parseCreateParams = (raw: string) =>
+  Effect.gen(function* () {
+    const parsed = yield* Effect.try({
+      try: () => parseJsonIsh(raw),
+      catch: () =>
+        new Error(
+          "Invalid --params input. Provide JSON or a JS-style object literal, e.g. -p '{ trigger_config: { ... } }'."
+        ),
+    });
+
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return yield* Effect.fail(
+        new Error("Expected --params to be an object, e.g. -p '{ trigger_config: { ... } }'.")
+      );
+    }
+
+    return parsed as Record<string, unknown>;
+  });
+
+const selectConnectedAccountId = (
+  items: ReadonlyArray<{
+    id: string;
+    updated_at: string;
+    is_disabled: boolean;
+  }>
+): string | undefined => {
+  const active = items.filter(item => !item.is_disabled);
+  if (active.length === 0) {
+    return undefined;
+  }
+
+  return [...active]
+    .sort((left, right) => Date.parse(right.updated_at) - Date.parse(left.updated_at))
+    .at(0)?.id;
+};
+
+const emitStreamLine = (line: string, ui: TerminalUI) =>
+  Effect.gen(function* () {
+    yield* ui.log.message(line);
+    yield* ui.output(line, { force: true });
+  });
+
+const extractEventFileId = (eventData: Record<string, unknown>): string => {
+  const candidates = [
+    eventData.id,
+    eventData.log_id,
+    typeof eventData.metadata === 'object' && eventData.metadata !== null
+      ? (eventData.metadata as Record<string, unknown>).id
+      : undefined,
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.length > 0) {
+      return sanitizePathPart(candidate);
+    }
+  }
+
+  return `${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
+};
+
+const resolveFallbackArtifactsDir = () => resolveArtifactsRoot();
+
+const parseStreamPath = (expression: string): ReadonlyArray<string | number> => {
+  const trimmed = expression.trim();
+  if (!trimmed.startsWith('.')) {
+    throw new Error('Expected --stream to contain a jq-like path starting with "."');
+  }
+
+  const pathTokens: Array<string | number> = [];
+  const tokenPattern = /(?:\.([A-Za-z0-9_-]+))|(?:\[(\d+)\])/g;
+  let lastIndex = 0;
+
+  for (const match of trimmed.matchAll(tokenPattern)) {
+    if ((match.index ?? -1) !== lastIndex) {
+      throw new Error(
+        'Unsupported --stream expression. Use a jq-like path such as ".foo.bar" or ".items[0].id".'
+      );
+    }
+
+    if (match[1]) pathTokens.push(match[1]);
+    if (match[2]) pathTokens.push(Number(match[2]));
+    lastIndex += match[0].length;
+  }
+
+  if (lastIndex !== trimmed.length) {
+    throw new Error(
+      'Unsupported --stream expression. Use a jq-like path such as ".foo.bar" or ".items[0].id".'
+    );
+  }
+
+  return pathTokens;
+};
+
+const applyStreamPath = (value: unknown, pathTokens: ReadonlyArray<string | number>): unknown => {
+  let current = value;
+  for (const token of pathTokens) {
+    if (typeof token === 'number') {
+      if (!Array.isArray(current) || token < 0 || token >= current.length) {
+        return undefined;
+      }
+      current = current[token];
+      continue;
+    }
+
+    if (typeof current !== 'object' || current === null || Array.isArray(current)) {
+      return undefined;
+    }
+
+    current = (current as Record<string, unknown>)[token];
+  }
+
+  return current;
+};
+
+const formatStreamValue = (value: unknown): string => {
+  if (value === undefined) return 'null';
+  if (typeof value === 'string') return value;
+  return JSON.stringify(value);
+};
+
+const TIMEOUT_UNITS_MS: Record<string, number> = {
+  ms: 1,
+  millisecond: 1,
+  milliseconds: 1,
+  s: 1_000,
+  sec: 1_000,
+  secs: 1_000,
+  second: 1_000,
+  seconds: 1_000,
+  m: 60_000,
+  min: 60_000,
+  mins: 60_000,
+  minute: 60_000,
+  minutes: 60_000,
+  h: 3_600_000,
+  hr: 3_600_000,
+  hrs: 3_600_000,
+  hour: 3_600_000,
+  hours: 3_600_000,
+  d: 86_400_000,
+  day: 86_400_000,
+  days: 86_400_000,
+};
+
+const parseTimeoutMs = (value: string): number => {
+  const trimmed = value.trim().toLowerCase();
+  const match = /^(\d+(?:\.\d+)?)\s*([a-z]+)$/.exec(trimmed);
+  if (!match) {
+    throw new Error(
+      'Invalid --timeout value. Use a duration such as "30s", "5m", "1hr", or "1day".'
+    );
+  }
+
+  const amount = Number(match[1]);
+  const unitMs = TIMEOUT_UNITS_MS[match[2]];
+  if (!Number.isFinite(amount) || amount <= 0 || unitMs === undefined) {
+    throw new Error(
+      'Invalid --timeout value. Use a duration such as "30s", "5m", "1hr", or "1day".'
+    );
+  }
+
+  return Math.round(amount * unitMs);
+};
+
+export const listenCmd = Command.make(
+  'listen',
+  { slug, params, maxEvents, timeout, stream, debug },
+  ({ slug, params, maxEvents, timeout, stream, debug }) =>
+    Effect.gen(function* () {
+      if (!(yield* requireAuth)) return;
+
+      const ui = yield* TerminalUI;
+      const fs = yield* FileSystem.FileSystem;
+      const runtime = yield* Effect.runtime<never>();
+      const clientSingleton = yield* ComposioClientSingleton;
+      const realtime = yield* TriggersRealtime;
+
+      const resolvedProject = yield* resolveCommandProject({ mode: 'consumer' }).pipe(
+        Effect.mapError(formatResolveCommandProjectError)
+      );
+
+      const client = yield* clientSingleton.getFor({
+        orgId: resolvedProject.orgId,
+        projectId: resolvedProject.projectId,
+      });
+
+      if (!resolvedProject.consumerUserId) {
+        return yield* Effect.fail(
+          new Error('No consumer user is available in the current project context.')
+        );
+      }
+
+      const rawParams = Option.isSome(params)
+        ? (yield* resolveParamsInput(params))?.trim() || '{}'
+        : '{}';
+      const createParamsInput = yield* parseCreateParams(rawParams);
+      const toolkitSlug = toolkitFromToolSlug(slug);
+      if (!toolkitSlug) {
+        return yield* Effect.fail(
+          new Error(
+            `Could not infer a toolkit from trigger slug "${slug}". Use a standard trigger slug such as "GMAIL_NEW_GMAIL_MESSAGE".`
+          )
+        );
+      }
+
+      const connectedAccounts = yield* Effect.tryPromise({
+        try: () =>
+          client.connectedAccounts.list({
+            toolkit_slugs: [toolkitSlug],
+            user_ids: resolvedProject.consumerUserId ? [resolvedProject.consumerUserId] : undefined,
+            statuses: ['ACTIVE'],
+            limit: 100,
+          }),
+        catch: error =>
+          new Error(`Failed to list connected accounts for "${toolkitSlug}": ${String(error)}`),
+      });
+      const resolvedConnectedAccountId = selectConnectedAccountId(connectedAccounts.items);
+
+      if (!resolvedConnectedAccountId) {
+        return yield* Effect.fail(
+          new Error(
+            `No active connected account found for toolkit "${toolkitSlug}" and consumer user "${resolvedProject.consumerUserId}". Run \`composio link ${toolkitSlug}\` first.`
+          )
+        );
+      }
+
+      const createParams = {
+        ...createParamsInput,
+        connected_account_id: resolvedConnectedAccountId,
+      } as Parameters<typeof client.triggerInstances.upsert>[1];
+      const timeoutMs = Option.match(timeout, {
+        onNone: () => undefined,
+        onSome: value => parseTimeoutMs(value),
+      });
+      const streamPath = Option.match(stream, {
+        onNone: () => undefined,
+        onSome: value => {
+          const trimmed = value.trim();
+          return trimmed.length === 0 ? [] : parseStreamPath(trimmed);
+        },
+      });
+      const shouldStream = Option.isSome(stream);
+
+      const artifactsOption = yield* resolveCliSessionArtifacts({
+        orgId: resolvedProject.orgId,
+        consumerUserId: resolvedProject.consumerUserId,
+      });
+      const artifactsRoot = Option.match(artifactsOption, {
+        onNone: () => resolveFallbackArtifactsDir(),
+        onSome: value => value.directoryPath,
+      });
+      const triggerDir = path.join(artifactsRoot, 'triggers', sanitizePathPart(slug));
+      const streamFilePath = path.join(triggerDir, 'events.jsonl');
+
+      yield* fs.makeDirectory(triggerDir, { recursive: true });
+      yield* fs.writeFileString(streamFilePath, '', { flag: 'a' });
+
+      const maxEventsLimit = Option.getOrUndefined(maxEvents);
+      const stopWhenDone = yield* Deferred.make<'max-events' | 'timeout'>();
+      let matchingEvents = 0;
+      const seenEventIds = new Set<string>();
+
+      yield* Effect.acquireUseRelease(
+        Effect.tryPromise({
+          try: () => client.triggerInstances.upsert(slug, createParams),
+          catch: error =>
+            new Error(`Failed to create temporary trigger "${slug}": ${String(error)}`),
+        }),
+        createdTrigger =>
+          Effect.gen(function* () {
+            yield* emitStreamLine(`listening for events ${slug} (tail at ${streamFilePath})`, ui);
+            if (debug) {
+              const debugMsg = `[debug] trigger_id=${createdTrigger.trigger_id} project=${resolvedProject.projectId} org=${resolvedProject.orgId} createParams=${JSON.stringify(createParams)}`;
+              yield* emitStreamLine(debugMsg, ui);
+              yield* emitStreamLine(
+                `[debug] upsert response: ${JSON.stringify(createdTrigger)}`,
+                ui
+              );
+            }
+
+            const onEvent = (eventData: Record<string, unknown>) => {
+              Runtime.runFork(runtime)(
+                Effect.gen(function* () {
+                  if (debug) {
+                    yield* emitStreamLine(
+                      `[debug] raw event keys: ${Object.keys(eventData).join(', ')}`,
+                      ui
+                    );
+                    yield* emitStreamLine(
+                      `[debug] raw event (truncated): ${JSON.stringify(eventData).slice(0, 500)}`,
+                      ui
+                    );
+                  }
+                  const parsed = parseTriggerListenEvent(eventData);
+                  const filterResult = matchesTriggerListenFilters(
+                    { triggerId: createdTrigger.trigger_id },
+                    parsed
+                  );
+                  if (debug) {
+                    yield* emitStreamLine(
+                      `[debug] parsed.id=${parsed.id} triggerSlug=${parsed.triggerSlug} trigger_id=${createdTrigger.trigger_id} match=${filterResult}`,
+                      ui
+                    );
+                  }
+                  if (!filterResult) {
+                    return;
+                  }
+
+                  const eventFileId = extractEventFileId(eventData);
+                  if (seenEventIds.has(eventFileId)) {
+                    if (debug) {
+                      yield* emitStreamLine(`[debug] skipping duplicate event ${eventFileId}`, ui);
+                    }
+                    return;
+                  }
+                  seenEventIds.add(eventFileId);
+
+                  matchingEvents += 1;
+                  const eventFilePath = path.join(triggerDir, `${eventFileId}-payload.json`);
+                  const eventJson = JSON.stringify(eventData, null, 2);
+                  const streamEntry = JSON.stringify({
+                    event_id: eventFileId,
+                    trigger_id: createdTrigger.trigger_id,
+                    trigger_slug: slug,
+                    file_path: eventFilePath,
+                    received_at: new Date().toISOString(),
+                  });
+
+                  yield* fs.writeFileString(eventFilePath, `${eventJson}\n`);
+                  yield* fs.writeFileString(streamFilePath, `${streamEntry}\n`, { flag: 'a' });
+                  yield* emitStreamLine(`event: ${eventFilePath}`, ui);
+
+                  if (shouldStream) {
+                    const streamValue =
+                      streamPath === undefined
+                        ? eventData
+                        : streamPath.length === 0
+                          ? eventData
+                          : applyStreamPath(eventData, streamPath);
+                    yield* emitStreamLine(`stream: ${formatStreamValue(streamValue)}`, ui);
+                  }
+
+                  if (maxEventsLimit !== undefined && matchingEvents >= maxEventsLimit) {
+                    yield* Deferred.succeed(stopWhenDone, 'max-events').pipe(Effect.ignore);
+                  }
+                }).pipe(
+                  Effect.catchAll(error =>
+                    ui.log.warn(error instanceof Error ? error.message : String(error))
+                  )
+                )
+              );
+            };
+
+            const listenEffect = realtime
+              .listenInProject(
+                {
+                  orgId: resolvedProject.orgId,
+                  projectId: resolvedProject.projectId,
+                },
+                onEvent
+              )
+              .pipe(Effect.onInterrupt(() => ui.log.info(`Stopped listening for events ${slug}.`)));
+
+            if (timeoutMs !== undefined) {
+              yield* Effect.forkScoped(
+                Effect.sleep(timeoutMs).pipe(
+                  Effect.andThen(Deferred.succeed(stopWhenDone, 'timeout')),
+                  Effect.ignore
+                )
+              );
+            }
+
+            if (maxEventsLimit === undefined && timeoutMs === undefined) {
+              yield* listenEffect;
+              return;
+            }
+
+            const stopReason = yield* Effect.raceFirst(listenEffect, Deferred.await(stopWhenDone));
+            if (stopReason === 'max-events') {
+              yield* ui.outro(
+                `Stopped after receiving ${matchingEvents} events. Temporary trigger disabled.`
+              );
+              return;
+            }
+
+            if (stopReason === 'timeout') {
+              yield* ui.outro(
+                `Stopped after timeout with ${matchingEvents} matching event${matchingEvents === 1 ? '' : 's'}. Temporary trigger disabled.`
+              );
+            }
+          }),
+        created =>
+          Effect.tryPromise({
+            try: () =>
+              client.triggerInstances.manage.update(created.trigger_id, { status: 'disable' }),
+            catch: error =>
+              new Error(
+                `Failed to disable temporary trigger "${created.trigger_id}": ${String(error)}`
+              ),
+          }).pipe(
+            Effect.catchAll(error =>
+              ui.log.warn(error instanceof Error ? error.message : String(error))
+            )
+          )
+      );
+    })
+).pipe(
+  Command.withDescription(
+    'Create a temporary subscription for consumer-project events and write each event to artifacts for easy background-agent consumption.'
+  )
+);

--- a/ts/packages/cli/src/commands/root-help.ts
+++ b/ts/packages/cli/src/commands/root-help.ts
@@ -73,6 +73,35 @@ const CORE_COMMANDS: ReadonlyArray<DetailedCommand> = [
     ],
   },
   {
+    name: 'listen',
+    description:
+      'Create a temporary subscription for consumer-project events and persist each payload into the session artifact folder.',
+    usage:
+      'listen <slug> [-p, --params text] [--max-events integer] [--timeout text] [--stream [text]]',
+    options: [
+      { name: '<slug>', description: 'Trigger slug (e.g. "GMAIL_NEW_GMAIL_MESSAGE")' },
+      {
+        name: '-p, --params',
+        description:
+          "Trigger create params as JSON or JS-style object, e.g. -p '{ trigger_config: { ... } }'.",
+      },
+      {
+        name: '--max-events',
+        description: 'Stop after receiving N events, then disable the temporary trigger',
+      },
+      {
+        name: '--timeout',
+        description:
+          'Stop after a duration such as 30s, 5m, or 1hr, then disable the temporary trigger',
+      },
+      {
+        name: '--stream',
+        description:
+          'Also print each payload inline as a single-line stream value. Optionally pass a jq-like path such as ".thread.id".',
+      },
+    ],
+  },
+  {
     name: 'proxy',
     description:
       'curl-like access to any toolkit API through Composio using your connected account.',
@@ -270,6 +299,47 @@ const SUBCOMMAND_HELP: Record<string, SubcommandHelp> = {
       'composio tools info <slug>              Schema summary with jq hints',
       'composio link <toolkit>                 Connect an account for a toolkit',
       'composio artifacts cwd                  Print the current session artifact directory',
+    ],
+  },
+  listen: {
+    usage:
+      'composio listen <slug> [-p, --params text] [--max-events integer] [--timeout text] [--stream [text]]',
+    description:
+      'Create a temporary subscription for consumer-project events so background agents can easily consume new emails, Slack messages, and other trigger payloads from artifacts.',
+    args: [{ name: '<slug>', description: 'Trigger slug to create and listen to' }],
+    options: [
+      {
+        name: '-p, --params <text>',
+        description:
+          'Trigger create params as JSON/JS object, @file, or - for stdin. Pass optional trigger config fields only.',
+      },
+      {
+        name: '--max-events <integer>',
+        description: 'Stop after N events for this temporary trigger and disable it',
+      },
+      {
+        name: '--timeout <text>',
+        description: 'Stop after a duration such as "30s", "5m", or "1hr" and disable the trigger',
+      },
+      {
+        name: '--stream [text]',
+        description:
+          'Also print each event payload inline. Optionally pass a jq-like path such as ".thread.id" or ".data[0].id".',
+      },
+    ],
+    examples: [
+      'composio listen GMAIL_NEW_GMAIL_MESSAGE',
+      'composio listen GMAIL_NEW_GMAIL_MESSAGE -p @trigger.json --max-events 5',
+      'composio listen GMAIL_NEW_GMAIL_MESSAGE --timeout 5m',
+      "composio listen GMAIL_NEW_GMAIL_MESSAGE --timeout 1hr --stream '.data.threadId'",
+      'composio listen SLACK_RECEIVE_MESSAGE -p \'{ trigger_config: { channel: "C123" } }\'',
+      'composio listen GMAIL_NEW_GMAIL_MESSAGE -p @trigger.json --stream',
+      "composio listen GMAIL_NEW_GMAIL_MESSAGE -p @trigger.json --stream '.data.threadId'",
+    ],
+    seeAlso: [
+      'composio artifacts cwd                   Print the current session artifact directory',
+      'composio triggers info <slug>            Inspect trigger type details before listening',
+      'composio link <toolkit>                  Connect the required account before creating the trigger',
     ],
   },
   link: {

--- a/ts/packages/cli/src/commands/triggers/commands/triggers.list.cmd.ts
+++ b/ts/packages/cli/src/commands/triggers/commands/triggers.list.cmd.ts
@@ -1,7 +1,7 @@
 import { Args, Command, Options } from '@effect/cli';
 import { Effect } from 'effect';
 import { requireAuth } from 'src/effects/require-auth';
-import { ComposioToolkitsRepository } from 'src/services/composio-clients';
+import { ComposioToolkitsRepository, InvalidToolkitsError } from 'src/services/composio-clients';
 import { TerminalUI } from 'src/services/terminal-ui';
 import { clampLimit } from 'src/ui/clamp-limit';
 import { formatTriggerTypesJson, formatTriggerTypesTable } from '../format';
@@ -38,6 +38,21 @@ const makeTriggersListCommand = ({ noResultsCommand, infoCommand }: TriggersList
       const repo = yield* ComposioToolkitsRepository;
       const clampedLimit = clampLimit(limit);
 
+      yield* repo.validateToolkits([toolkit]).pipe(
+        Effect.catchTag('services/InvalidToolkitsError', (error: InvalidToolkitsError) =>
+          Effect.gen(function* () {
+            const availableExample = error.availableToolkits.slice(0, 8).join(', ');
+            yield* ui.log.error(
+              `Toolkit "${toolkit}" is not available. ${availableExample ? `Examples: ${availableExample}` : ''}`
+            );
+            yield* ui.log.step(`List valid toolkits with:\n> ${noResultsCommand}`);
+            return yield* Effect.fail(
+              new Error(`Invalid toolkit slug "${toolkit}" for trigger listing.`)
+            );
+          })
+        )
+      );
+
       const allTriggerTypes = yield* ui.withSpinner(
         'Fetching trigger types...',
         repo.getTriggerTypes([toolkit])
@@ -52,8 +67,9 @@ const makeTriggersListCommand = ({ noResultsCommand, infoCommand }: TriggersList
       }
 
       const count = triggerTypes.length;
-      yield* ui.log.info(
-        `Listing ${count} trigger type${count === 1 ? '' : 's'}\n\n${formatTriggerTypesTable(triggerTypes)}`
+      yield* ui.note(
+        formatTriggerTypesTable(triggerTypes),
+        `Listing ${count} trigger type${count === 1 ? '' : 's'}`
       );
 
       const firstSlug = triggerTypes[0]?.slug;

--- a/ts/packages/cli/src/services/cli-session-artifacts.ts
+++ b/ts/packages/cli/src/services/cli-session-artifacts.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { Effect, Option } from 'effect';
 import { getOrCreateProbablyMyCliSessionIdForCurrentCwd } from 'src/services/consumer-short-term-cache';
 
-const resolveArtifactsRoot = (): string =>
+export const resolveArtifactsRoot = (): string =>
   process.env.COMPOSIO_SESSION_DIR?.trim() ||
   process.env.COMPOSIO_CACHE_DIR?.trim() ||
   path.join(os.tmpdir(), 'composio');

--- a/ts/packages/cli/src/services/run-subagent-acp.ts
+++ b/ts/packages/cli/src/services/run-subagent-acp.ts
@@ -422,6 +422,9 @@ export const createStructuredOutputMcpContext = ({
 
   let tempDirectory: string | null = null;
   try {
+    // Keep this on an OS temp dir for now. Repointing MCP schema/result files into
+    // session artifacts needs a broader bundling + run-companion test pass so we
+    // don't break structured sub-agent output in packaged CLI builds.
     tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'composio-subagent-output-mcp-'));
     const schemaFilePath = path.join(tempDirectory, 'schema.json');
     const resultFilePath = path.join(tempDirectory, 'result.json');

--- a/ts/packages/cli/src/services/triggers-realtime.ts
+++ b/ts/packages/cli/src/services/triggers-realtime.ts
@@ -1,5 +1,10 @@
 import { Data, Effect, Runtime } from 'effect';
-import { ComposioSessionRepository } from 'src/services/composio-clients';
+import {
+  ComposioClientSingleton,
+  ComposioSessionRepository,
+  type CliRealtimeAuthResponse,
+  type CliRealtimeCredentialsResponse,
+} from 'src/services/composio-clients';
 
 type RawRealtimeEvent = Record<string, unknown>;
 
@@ -71,12 +76,20 @@ export class TriggersRealtime extends Effect.Service<TriggersRealtime>()(
   {
     effect: Effect.gen(function* () {
       const sessionRepo = yield* ComposioSessionRepository;
+      const clientSingleton = yield* ComposioClientSingleton;
       const runtime = yield* Effect.runtime<never>();
 
-      const listen = (onEvent: (data: RawRealtimeEvent) => void) =>
+      const listenWith = (params: {
+        getRealtimeCredentials: () => Effect.Effect<CliRealtimeCredentialsResponse>;
+        authRealtimeChannel: (params: {
+          channel_name: string;
+          socket_id: string;
+        }) => Effect.Effect<CliRealtimeAuthResponse>;
+        onEvent: (data: RawRealtimeEvent) => void;
+      }) =>
         Effect.acquireUseRelease(
           Effect.gen(function* () {
-            const creds = yield* sessionRepo.getRealtimeCredentials();
+            const creds = yield* params.getRealtimeCredentials();
             const channelName = `private-cli-${creds.project_id}`;
 
             const pusherModule = yield* Effect.tryPromise({
@@ -90,9 +103,9 @@ export class TriggersRealtime extends Effect.Service<TriggersRealtime>()(
               cluster: creds.pusher_cluster,
               channelAuthorization: {
                 customHandler: (authOptions: PusherAuthOptions, callback?: PusherAuthCallback) => {
-                  const params = authOptions.params ?? authOptions;
-                  const channel_name = params.channel_name ?? params.channelName;
-                  const socket_id = params.socket_id ?? params.socketId;
+                  const authParams = authOptions.params ?? authOptions;
+                  const channel_name = authParams.channel_name ?? authParams.channelName;
+                  const socket_id = authParams.socket_id ?? authParams.socketId;
 
                   const doAuth = async () => {
                     if (!channel_name || !socket_id) {
@@ -100,7 +113,7 @@ export class TriggersRealtime extends Effect.Service<TriggersRealtime>()(
                     }
 
                     const response = await Runtime.runPromise(runtime)(
-                      sessionRepo.authRealtimeChannel({
+                      params.authRealtimeChannel({
                         channel_name,
                         socket_id,
                       })
@@ -167,7 +180,7 @@ export class TriggersRealtime extends Effect.Service<TriggersRealtime>()(
             }, CHUNK_TTL_MS);
 
             channel.bind('trigger_to_client', eventData => {
-              onEvent((eventData ?? {}) as RawRealtimeEvent);
+              params.onEvent((eventData ?? {}) as RawRealtimeEvent);
             });
 
             channel.bind('chunked-trigger_to_client', data => {
@@ -217,7 +230,7 @@ export class TriggersRealtime extends Effect.Service<TriggersRealtime>()(
               ) {
                 try {
                   const parsed = JSON.parse(current.chunks.join('')) as RawRealtimeEvent;
-                  onEvent(parsed);
+                  params.onEvent(parsed);
                 } catch {
                   // Silently discard events that fail to parse after chunk reassembly
                 } finally {
@@ -243,8 +256,40 @@ export class TriggersRealtime extends Effect.Service<TriggersRealtime>()(
             }).pipe(Effect.catchAll(() => Effect.void))
         );
 
-      return { listen };
+      const listen = (onEvent: (data: RawRealtimeEvent) => void) =>
+        listenWith({
+          getRealtimeCredentials: () => sessionRepo.getRealtimeCredentials().pipe(Effect.orDie),
+          authRealtimeChannel: params => sessionRepo.authRealtimeChannel(params).pipe(Effect.orDie),
+          onEvent,
+        });
+
+      const listenInProject = (
+        scope: { orgId: string; projectId: string },
+        onEvent: (data: RawRealtimeEvent) => void
+      ) =>
+        Effect.gen(function* () {
+          const client = yield* clientSingleton.getFor({
+            orgId: scope.orgId,
+            projectId: scope.projectId,
+          });
+
+          return yield* listenWith({
+            getRealtimeCredentials: () =>
+              Effect.tryPromise({
+                try: () => client.cli.realtime.credentials(),
+                catch: cause => new TriggerRealtimeSubscriptionError({ cause }),
+              }).pipe(Effect.orDie),
+            authRealtimeChannel: params =>
+              Effect.tryPromise({
+                try: () => client.cli.realtime.auth(params),
+                catch: cause => new TriggerRealtimeSubscriptionError({ cause }),
+              }).pipe(Effect.orDie),
+            onEvent,
+          });
+        });
+
+      return { listen, listenInProject };
     }),
-    dependencies: [ComposioSessionRepository.Default],
+    dependencies: [ComposioSessionRepository.Default, ComposioClientSingleton.Default],
   }
 ) {}

--- a/ts/packages/cli/test/__utils__/services/test-layer.ts
+++ b/ts/packages/cli/test/__utils__/services/test-layer.ts
@@ -765,6 +765,11 @@ export const TestLayer = (input?: TestLiveInput) =>
             yield* Effect.forEach(realtimeData.events, event => Effect.sync(() => onEvent(event)));
             return yield* Effect.never;
           }),
+        listenInProject: (_scope, onEvent) =>
+          Effect.gen(function* () {
+            yield* Effect.forEach(realtimeData.events, event => Effect.sync(() => onEvent(event)));
+            return yield* Effect.never;
+          }),
       })
     );
 


### PR DESCRIPTION
## Summary
- Add a new `composio listen` command for listening to trigger artifacts in real time.
- Introduce top-level trigger commands and update CLI help, hints, and session artifact handling to surface them.
- Refresh generated docs and toolkit metadata to reflect current tool and trigger counts.
- Update CLI tests around trigger listing/info and command hint behavior.

## Testing
- Not run locally.
- Updated and added CLI tests for `triggers list`, `triggers info`, and command hints.
- Docs/data generation artifacts were refreshed as part of the change set.