### PR TITLE
[codex] Deduplicate CLI skill release channel helpers

### DIFF
--- a/ts/packages/cli/skills-src/composio-cli/index.ts
+++ b/ts/packages/cli/skills-src/composio-cli/index.ts
@@ -5,6 +5,7 @@ import { composioDevReference } from './references/composio-dev';
 import { powerUserExamplesReference } from './references/power-user-examples';
 import { troubleshootingReference } from './references/troubleshooting';
 import {
+  isEnabledForBuild,
   renderReferenceDocument,
   resolveSkillBuildContext,
   validateReferenceDocument,
@@ -39,9 +40,6 @@ type SkillCommand = {
     markdown: string;
   }>;
 };
-
-const isEnabledForBuild = (build: SkillBuildContext, entry?: { features?: SkillFeatureFlag[] }) =>
-  !entry?.features || entry.features.every(feature => build.experimentalFeatures[feature]);
 
 const sourceAssetsDir = path.resolve(import.meta.dirname, './assets');
 

--- a/ts/packages/cli/skills-src/composio-cli/reference-schema.ts
+++ b/ts/packages/cli/skills-src/composio-cli/reference-schema.ts
@@ -1,6 +1,6 @@
-import { CLI_EXPERIMENTAL_FEATURES } from '../../src/constants';
+import { CLI_EXPERIMENTAL_FEATURES, type CliReleaseChannel } from '../../src/constants';
 
-export type SkillReleaseChannel = 'beta' | 'stable';
+export type SkillReleaseChannel = CliReleaseChannel;
 
 export type SkillFeatureFlag =
   (typeof CLI_EXPERIMENTAL_FEATURES)[keyof typeof CLI_EXPERIMENTAL_FEATURES];
@@ -54,7 +54,7 @@ export const resolveSkillBuildContext = (channel: SkillReleaseChannel): SkillBui
   },
 });
 
-const isEnabledForBuild = (build: SkillBuildContext, value?: FeatureScoped) =>
+export const isEnabledForBuild = (build: SkillBuildContext, value?: FeatureScoped) =>
   !value?.features || value.features.every(feature => build.experimentalFeatures[feature]);
 
 export const renderCommandSnippet = (snippet: CommandSnippet) => {

--- a/ts/packages/cli/src/constants.ts
+++ b/ts/packages/cli/src/constants.ts
@@ -89,3 +89,7 @@ export const GITHUB_REPO = {
 export const CLI_EXPERIMENTAL_FEATURES = {
   LISTEN: 'listen',
 } as const;
+
+export const CLI_RELEASE_CHANNELS = ['stable', 'beta'] as const;
+
+export type CliReleaseChannel = (typeof CLI_RELEASE_CHANNELS)[number];

--- a/ts/packages/cli/src/effects/install-skill.ts
+++ b/ts/packages/cli/src/effects/install-skill.ts
@@ -5,7 +5,7 @@ import { HttpClient } from '@effect/platform';
 import { NodeOs } from 'src/services/node-os';
 import { TerminalUI } from 'src/services/terminal-ui';
 import { GITHUB_CONFIG } from 'src/effects/github-config';
-import { APP_VERSION } from 'src/constants';
+import { APP_VERSION, type CliReleaseChannel } from 'src/constants';
 import {
   fetchLatestCliRelease,
   type GitHubRelease,
@@ -15,7 +15,7 @@ import decompress from 'decompress';
 
 const SKILL_NAME = 'composio-cli';
 const SKILL_ASSET_NAME = 'composio-skill.zip';
-export type SkillReleaseChannel = 'beta' | 'stable';
+export type SkillReleaseChannel = CliReleaseChannel;
 
 type GitHubConfig = GitHubRepoConfig & {
   TAG: Option.Option<string>;

--- a/ts/packages/cli/src/effects/resolve-cli-release.ts
+++ b/ts/packages/cli/src/effects/resolve-cli-release.ts
@@ -1,8 +1,7 @@
 import { Effect } from 'effect';
 import { HttpClient } from '@effect/platform';
 import { semverComparator } from 'src/effects/compare-semver';
-
-export type CliReleaseChannel = 'beta' | 'stable';
+import type { CliReleaseChannel } from 'src/constants';
 
 export type GitHubReleaseAsset = {
   name: string;

--- a/ts/packages/cli/src/services/cli-user-config.ts
+++ b/ts/packages/cli/src/services/cli-user-config.ts
@@ -12,8 +12,7 @@ import {
   cliUserConfigToJSON,
 } from 'src/models/cli-user-config';
 import * as constants from 'src/constants';
-
-export type CliReleaseChannel = 'stable' | 'beta';
+import type { CliReleaseChannel } from 'src/constants';
 
 export type CliUserConfigResolved = {
   readonly channel: CliReleaseChannel;


### PR DESCRIPTION
## Summary
- address the two unresolved bugbot cleanup comments from #3127
- centralize the CLI release channel type in one canonical definition
- reuse the existing feature-gating helper for composio-cli skill builds instead of duplicating it

## Why
The remaining bugbot comments on #3127 were both valid low-severity duplication issues. This follow-up keeps the release-channel and skill-build logic from drifting across files without changing behavior.

## Validation
- `pnpm --filter @composio/cli validate:skills`
- `pnpm --filter @composio/cli exec vitest run test/src/effects/install-skill.test.ts`
- `pnpm --filter @composio/cli typecheck`
