### PR TITLE
fix: decouple skill build scripts from @composio/core

### DIFF
--- a/ts/packages/cli/skills-src/composio-cli/index.ts
+++ b/ts/packages/cli/skills-src/composio-cli/index.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { CLI_EXPERIMENTAL_FEATURES } from '../../src/constants';
+import { CLI_EXPERIMENTAL_FEATURES } from '../../src/experimental-features';
 import { composioDevReference } from './references/composio-dev';
 import { powerUserExamplesReference } from './references/power-user-examples';
 import { troubleshootingReference } from './references/troubleshooting';

--- a/ts/packages/cli/skills-src/composio-cli/index.ts
+++ b/ts/packages/cli/skills-src/composio-cli/index.ts
@@ -72,6 +72,12 @@ const commands: SkillCommand[] = [
         name: '`--parallel`',
         description: 'Execute multiple independent tool calls in the same invocation.',
       },
+      {
+        name: '`--account`',
+        description:
+          'Select which connected account to use by alias, word_id, or account id when multiple accounts exist for the same toolkit.',
+        features: [CLI_EXPERIMENTAL_FEATURES.MULTI_ACCOUNT],
+      },
     ],
     examples: [
       {
@@ -125,6 +131,14 @@ const commands: SkillCommand[] = [
         code: 'composio link gmail\ncomposio link googlecalendar --no-browser',
       },
     ],
+    flags: [
+      {
+        name: '`--alias`',
+        description:
+          'Assign an alias to the connected account. Required when creating an additional account for the same toolkit.',
+        features: [CLI_EXPERIMENTAL_FEATURES.MULTI_ACCOUNT],
+      },
+    ],
     notes: ['Retry the original `execute` command after linking succeeds.'],
   },
   {
@@ -151,6 +165,11 @@ const commands: SkillCommand[] = [
       {
         name: '`--timeout` and `--max-events`',
         description: 'Stop long-running listeners cleanly.',
+      },
+      {
+        name: '`--account`',
+        description: 'Select which connected account to use by alias, word_id, or account id.',
+        features: [CLI_EXPERIMENTAL_FEATURES.MULTI_ACCOUNT],
       },
     ],
     notes: [

--- a/ts/packages/cli/skills-src/composio-cli/reference-schema.ts
+++ b/ts/packages/cli/skills-src/composio-cli/reference-schema.ts
@@ -51,6 +51,7 @@ export const resolveSkillBuildContext = (channel: SkillReleaseChannel): SkillBui
   channel,
   experimentalFeatures: {
     [CLI_EXPERIMENTAL_FEATURES.LISTEN]: channel === 'beta',
+    [CLI_EXPERIMENTAL_FEATURES.MULTI_ACCOUNT]: channel === 'beta',
   },
 });
 

--- a/ts/packages/cli/skills-src/composio-cli/reference-schema.ts
+++ b/ts/packages/cli/skills-src/composio-cli/reference-schema.ts
@@ -1,4 +1,4 @@
-import { CLI_EXPERIMENTAL_FEATURES, type CliReleaseChannel } from '../../src/constants';
+import { CLI_EXPERIMENTAL_FEATURES, type CliReleaseChannel } from '../../src/experimental-features';
 
 export type SkillReleaseChannel = CliReleaseChannel;
 

--- a/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
+++ b/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
@@ -23,6 +23,8 @@ import {
   groupCachedConnectedAccountsByToolkit,
   resolveDefaultConnectedAccountsByToolkit,
 } from 'src/services/connected-account-selection';
+import { ComposioCliUserConfig } from 'src/services/cli-user-config';
+import { CLI_EXPERIMENTAL_FEATURES } from 'src/constants';
 
 const toolkit = Args.text({ name: 'toolkit' }).pipe(
   Args.withDescription('Toolkit slug to link (e.g. "github", "gmail")'),
@@ -619,6 +621,13 @@ const runConnectedAccountsLink = (params: {
   Effect.gen(function* () {
     if (!(yield* requireAuth)) return;
 
+    const cliConfig = yield* ComposioCliUserConfig;
+    const aliasOption = cliConfig.isExperimentalFeatureEnabled(
+      CLI_EXPERIMENTAL_FEATURES.MULTI_ACCOUNT
+    )
+      ? params.alias
+      : Option.none<string>();
+
     const ui = yield* TerminalUI;
     const clientSingleton = yield* ComposioClientSingleton;
     const projectContext = yield* ProjectContext;
@@ -675,7 +684,7 @@ const runConnectedAccountsLink = (params: {
         requestedUserId: params.userId,
         projectName: params.projectName,
         noWait: params.noWait,
-        alias: params.alias,
+        alias: aliasOption,
         ui,
         clientSingleton,
         projectContext,
@@ -758,7 +767,7 @@ const runConnectedAccountsLink = (params: {
     const { connectedAccountId: connAccountId, redirectUrl } = validatedLink.value;
     const canContinue = yield* ensureAliasForAdditionalAccount({
       ui,
-      alias: params.alias,
+      alias: aliasOption,
       connectedAccountId: connAccountId,
       existingAccounts,
       scopeDescription: `user "${resolvedUserId.value}" in toolkit "${toolkitSlug}"`,
@@ -769,7 +778,7 @@ const runConnectedAccountsLink = (params: {
       ui,
       client,
       connectedAccountId: connAccountId,
-      alias: params.alias,
+      alias: aliasOption,
     });
 
     if (params.noWait) {

--- a/ts/packages/cli/src/commands/listen.cmd.ts
+++ b/ts/packages/cli/src/commands/listen.cmd.ts
@@ -22,6 +22,8 @@ import {
 } from 'src/services/connected-account-selection';
 import { parseJsonIsh } from 'src/utils/parse-json-ish';
 import { toolkitFromToolSlug } from 'src/utils/toolkit-from-tool-slug';
+import { ComposioCliUserConfig } from 'src/services/cli-user-config';
+import { CLI_EXPERIMENTAL_FEATURES } from 'src/constants';
 import { matchesTriggerListenFilters } from './triggers/filter';
 import { parseTriggerListenEvent } from './triggers/parse';
 
@@ -396,6 +398,12 @@ export const listenCmd = Command.make(
         orgId: resolvedProject.orgId,
         projectId: resolvedProject.projectId,
       });
+      const cliConfig = yield* ComposioCliUserConfig;
+      const accountSelector = cliConfig.isExperimentalFeatureEnabled(
+        CLI_EXPERIMENTAL_FEATURES.MULTI_ACCOUNT
+      )
+        ? account
+        : Option.none<string>();
       const {
         listeningToProjectEvent,
         createParams,
@@ -410,7 +418,7 @@ export const listenCmd = Command.make(
         timeout,
         stream,
         maxEvents,
-        account,
+        account: accountSelector,
         client,
         resolvedProject,
       });

--- a/ts/packages/cli/src/commands/tools/commands/tools.execute.cmd.ts
+++ b/ts/packages/cli/src/commands/tools/commands/tools.execute.cmd.ts
@@ -60,6 +60,8 @@ import {
   normalizeCliError,
 } from 'src/services/composio-error-overrides';
 import * as constants from 'src/constants';
+import { ComposioCliUserConfig } from 'src/services/cli-user-config';
+import { CLI_EXPERIMENTAL_FEATURES } from 'src/constants';
 
 const slug = Args.text({ name: 'slug' }).pipe(
   Args.withDescription('Tool slug (e.g. "GITHUB_CREATE_ISSUE")')
@@ -1009,12 +1011,18 @@ const resolveExecuteContext = (params: RunToolsExecuteParams) =>
       orgId: resolvedProject.orgId,
       projectId: resolvedProject.projectId,
     });
+    const cliConfig = yield* ComposioCliUserConfig;
+    const accountSelector = cliConfig.isExperimentalFeatureEnabled(
+      CLI_EXPERIMENTAL_FEATURES.MULTI_ACCOUNT
+    )
+      ? params.account
+      : Option.none<string>();
     const toolkitSlug = toolkitFromToolSlug(params.slug);
     const selectedConnectedAccountId = yield* resolveExplicitConnectedAccount({
       client,
       toolkitSlug,
       userId: resolvedUserId.value,
-      selector: params.account,
+      selector: accountSelector,
     });
     const args = Option.isSome(params.file)
       ? yield* getOrFetchToolInputDefinition(params.slug, {

--- a/ts/packages/cli/src/constants.ts
+++ b/ts/packages/cli/src/constants.ts
@@ -86,10 +86,8 @@ export const GITHUB_REPO = {
   API_BASE_URL: 'https://api.github.com',
 } as const;
 
-export const CLI_EXPERIMENTAL_FEATURES = {
-  LISTEN: 'listen',
-} as const;
-
-export const CLI_RELEASE_CHANNELS = ['stable', 'beta'] as const;
-
-export type CliReleaseChannel = (typeof CLI_RELEASE_CHANNELS)[number];
+export {
+  CLI_EXPERIMENTAL_FEATURES,
+  CLI_RELEASE_CHANNELS,
+  type CliReleaseChannel,
+} from './experimental-features';

--- a/ts/packages/cli/src/experimental-features.ts
+++ b/ts/packages/cli/src/experimental-features.ts
@@ -1,0 +1,14 @@
+/**
+ * Map of experimental feature flags used to gate CLI commands and skill output.
+ *
+ * Extracted into its own module so that the skill build/validate scripts
+ * (`skills-src/`) can import it without pulling in `@composio/core` (which
+ * requires a prior build step).
+ */
+export const CLI_EXPERIMENTAL_FEATURES = {
+  LISTEN: 'listen',
+} as const;
+
+export const CLI_RELEASE_CHANNELS = ['stable', 'beta'] as const;
+
+export type CliReleaseChannel = (typeof CLI_RELEASE_CHANNELS)[number];

--- a/ts/packages/cli/src/experimental-features.ts
+++ b/ts/packages/cli/src/experimental-features.ts
@@ -7,6 +7,7 @@
  */
 export const CLI_EXPERIMENTAL_FEATURES = {
   LISTEN: 'listen',
+  MULTI_ACCOUNT: 'multi_account',
 } as const;
 
 export const CLI_RELEASE_CHANNELS = ['stable', 'beta'] as const;

--- a/ts/packages/cli/test/__utils__/services/test-layer.ts
+++ b/ts/packages/cli/test/__utils__/services/test-layer.ts
@@ -11,6 +11,7 @@ import {
   Layer,
   Logger,
   LogLevel,
+  Option,
   Schedule,
   String,
 } from 'effect';
@@ -39,7 +40,8 @@ import type { TriggerInstanceItem } from 'src/models/triggers';
 import type { AuthConfigCreateResponse, LinkCreateResponse } from 'src/services/composio-clients';
 import type { ToolkitVersionSpec } from 'src/effects/toolkit-version-overrides';
 import { ComposioUserContextLive } from 'src/services/user-context';
-import { ComposioCliUserConfigLive } from 'src/services/cli-user-config';
+import { ComposioCliUserConfig } from 'src/services/cli-user-config';
+import { CliUserConfig } from 'src/models/cli-user-config';
 import { UpgradeBinary } from 'src/services/upgrade-binary';
 import { NodeOs } from 'src/services/node-os';
 import { TriggersRealtime } from 'src/services/triggers-realtime';
@@ -800,9 +802,24 @@ export const TestLayer = (input?: TestLiveInput) =>
       Layer.merge(BunFileSystem.layer, NodeOsTest)
     );
 
-    const ComposioCliUserConfigTest = Layer.provideMerge(
-      ComposioCliUserConfigLive,
-      Layer.mergeAll(BunFileSystem.layer, NodeOsTest)
+    const ComposioCliUserConfigTest = Layer.succeed(
+      ComposioCliUserConfig,
+      ComposioCliUserConfig.of({
+        data: {
+          channel: 'beta',
+          experimentalFeatures: {},
+          artifactDirectory: undefined,
+          experimentalSubagentTarget: 'auto',
+        },
+        raw: CliUserConfig.make({
+          experimentalFeatures: {},
+          artifactDirectory: Option.none(),
+          experimentalSubagent: Option.none(),
+        }),
+        channel: 'beta',
+        isExperimentalFeatureEnabled: () => true,
+        update: () => Effect.void,
+      })
     );
 
     const UpgradeBinaryTest = Layer.provide(


### PR DESCRIPTION
## Summary
- Skill build/validate scripts were failing in CI because they transitively imported `@composio/core` via `src/constants.ts`, which isn't built when the binary release workflow runs.
- Extracts `CLI_EXPERIMENTAL_FEATURES` (and `CLI_RELEASE_CHANNELS`/`CliReleaseChannel`) into a standalone `src/experimental-features.ts` with zero external dependencies.
- Adds `MULTI_ACCOUNT` experimental feature flag that gates `--account` on execute/listen and `--alias` on link. When disabled (default on stable), these flags are silently ignored and hidden from help. Beta builds enable them by default.
- Skill builder now includes `--account`/`--alias` documentation only in beta channel builds.

## Test plan
- [x] `pnpm run validate:skills` passes
- [x] `pnpm turbo typecheck --filter=@composio/cli` passes
- [x] Binary build and runtime verified
- [x] Stable help hides `--account`/`--alias` flags
- [x] Beta skill output includes multi-account flags, stable does not
- [ ] CI `Build CLI Binaries` workflow should now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)