### PR TITLE
fix(anthropic): sanitize property keys exceeding 64-char API limit

### DIFF
--- a/ts/packages/providers/anthropic/src/index.ts
+++ b/ts/packages/providers/anthropic/src/index.ts
@@ -18,6 +18,7 @@ import {
 } from '@composio/core';
 import Anthropic from '@anthropic-ai/sdk';
 import { AnthropicTool, InputSchema } from './types';
+import { sanitizeSchemaPropertyKeys, restoreOriginalKeys } from './sanitize-keys';
 
 export type AnthropicMcpServerGetResponse = {
   type: 'url';
@@ -58,6 +59,7 @@ export class AnthropicProvider extends BaseNonAgenticProvider<
 > {
   readonly name = 'anthropic';
   private chacheTools: boolean = false;
+  private _toolKeyMaps: Map<string, Map<string, string>> = new Map();
 
   /**
    * Creates a new instance of the AnthropicProvider.
@@ -118,14 +120,30 @@ export class AnthropicProvider extends BaseNonAgenticProvider<
    * ```
    */
   override wrapTool(tool: ComposioTool): AnthropicTool {
+    // Clear any stale key mapping for this tool before recomputing.
+    // Without this, re-wrapping a tool whose schema changed from long to short keys
+    // would leave a stale mapping that corrupts executeToolCall arguments.
+    this._toolKeyMaps.delete(tool.slug);
+
+    const rawSchema = (tool.inputParameters || {
+      type: 'object',
+      properties: {},
+      required: [],
+    }) as InputSchema;
+
+    const { schema: sanitizedSchema, keyMap } = sanitizeSchemaPropertyKeys(rawSchema);
+
+    if (keyMap.size > 0) {
+      this._toolKeyMaps.set(tool.slug, keyMap);
+      logger.debug(
+        `Sanitized ${keyMap.size} property key(s) for tool "${tool.slug}" to comply with Anthropic's 64-char limit`
+      );
+    }
+
     return {
       name: tool.slug,
       description: tool.description || '',
-      input_schema: (tool.inputParameters || {
-        type: 'object',
-        properties: {},
-        required: [],
-      }) as InputSchema,
+      input_schema: sanitizedSchema as InputSchema,
       cache_control: this.chacheTools ? { type: 'ephemeral' } : undefined,
     };
   }
@@ -210,8 +228,11 @@ export class AnthropicProvider extends BaseNonAgenticProvider<
     options?: ExecuteToolFnOptions,
     modifiers?: ExecuteToolModifiers
   ): Promise<string> {
+    const keyMap = this._toolKeyMaps.get(toolUse.name);
+    const args = keyMap ? restoreOriginalKeys(toolUse.input, keyMap) : toolUse.input;
+
     const payload: ToolExecuteParams = {
-      arguments: toolUse.input,
+      arguments: args,
       connectedAccountId: options?.connectedAccountId,
       customAuthParams: options?.customAuthParams,
       customConnectionData: options?.customConnectionData,

--- a/ts/packages/providers/anthropic/src/sanitize-keys.ts
+++ b/ts/packages/providers/anthropic/src/sanitize-keys.ts
@@ -1,0 +1,102 @@
+/**
+ * @file Utilities for sanitizing JSON schema property keys to comply with
+ *       Anthropic's API constraint: property keys must match ^[a-zA-Z0-9_.-]{1,64}$
+ * @module providers/anthropic/sanitize-keys
+ */
+
+const MAX_KEY_LENGTH = 64;
+const HASH_SUFFIX_LENGTH = 7;
+const TRUNCATED_PREFIX_LENGTH = MAX_KEY_LENGTH - 1 - HASH_SUFFIX_LENGTH; // 56
+
+/**
+ * Deterministic short hash using djb2.
+ * Returns a 7-character lowercase hex string.
+ */
+function shortHash(str: string): string {
+  let hash = 5381;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) + hash + str.charCodeAt(i)) >>> 0;
+  }
+  return hash.toString(16).padStart(HASH_SUFFIX_LENGTH, '0').slice(-HASH_SUFFIX_LENGTH);
+}
+
+function truncateKey(key: string): string {
+  if (key.length <= MAX_KEY_LENGTH) {
+    return key;
+  }
+  return `${key.slice(0, TRUNCATED_PREFIX_LENGTH)}_${shortHash(key)}`;
+}
+
+interface InputSchemaLike {
+  type: 'object';
+  properties?: Record<string, unknown> | null;
+  required?: string[];
+  [k: string]: unknown;
+}
+
+export interface SanitizeResult {
+  schema: InputSchemaLike;
+  keyMap: Map<string, string>;
+}
+
+/**
+ * Sanitize property keys in an input schema to fit Anthropic's 64-char limit.
+ * Returns the (possibly unchanged) schema and a reverse mapping
+ * (sanitized key -> original key) for restoring keys during tool execution.
+ */
+export function sanitizeSchemaPropertyKeys(schema: InputSchemaLike): SanitizeResult {
+  const keyMap = new Map<string, string>();
+
+  if (!schema || !schema.properties) {
+    return { schema, keyMap };
+  }
+
+  const originalProperties = schema.properties;
+  const newProperties: Record<string, unknown> = {};
+  let hasChanges = false;
+
+  for (const [originalKey, value] of Object.entries(originalProperties)) {
+    const sanitizedKey = truncateKey(originalKey);
+    newProperties[sanitizedKey] = value;
+
+    if (sanitizedKey !== originalKey) {
+      keyMap.set(sanitizedKey, originalKey);
+      hasChanges = true;
+    }
+  }
+
+  if (!hasChanges) {
+    return { schema, keyMap };
+  }
+
+  const newRequired = schema.required?.map(key => truncateKey(key));
+
+  return {
+    schema: {
+      ...schema,
+      properties: newProperties,
+      required: newRequired,
+    },
+    keyMap,
+  };
+}
+
+/**
+ * Restore original property keys in tool call arguments.
+ * Keys not in the mapping pass through unchanged.
+ */
+export function restoreOriginalKeys(
+  input: Record<string, unknown>,
+  keyMap: Map<string, string>
+): Record<string, unknown> {
+  if (keyMap.size === 0) {
+    return input;
+  }
+
+  const restored: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(input)) {
+    const originalKey = keyMap.get(key) ?? key;
+    restored[originalKey] = value;
+  }
+  return restored;
+}

--- a/ts/packages/providers/anthropic/test/anthropic.test.ts
+++ b/ts/packages/providers/anthropic/test/anthropic.test.ts
@@ -3,6 +3,7 @@ import { AnthropicProvider, AnthropicToolUseBlock } from '../src';
 import type { AnthropicTool } from '../src/types';
 import type { Tool } from '@composio/core';
 import Anthropic from '@anthropic-ai/sdk';
+import { sanitizeSchemaPropertyKeys, restoreOriginalKeys } from '../src/sanitize-keys';
 
 vi.mock('@anthropic-ai/sdk', () => {
   return {
@@ -486,6 +487,203 @@ describe('AnthropicProvider', () => {
         expect(result[0].url).toBe('https://test.com');
         expect(result[0].type).toBe('url');
       });
+    });
+  });
+
+  describe('property key sanitization (issue #2330)', () => {
+    const LONG_KEY_1 = 'settings__approved__or__denied__countries__or__regions__approved__list'; // 70 chars
+    const LONG_KEY_2 = 'settings__approved__or__denied__countries__or__regions__denied__list'; // 68 chars
+    const LONG_KEY_3 = 'settings__continuous__meeting__chat__auto__add__invited__external__users'; // 72 chars
+
+    function makeLongKeyTool(slug: string, keys: string[]): Tool {
+      const properties: Record<string, unknown> = {};
+      for (const k of keys) {
+        properties[k] = { type: 'string' };
+      }
+      return {
+        slug,
+        name: slug,
+        description: 'Test tool',
+        inputParameters: {
+          type: 'object',
+          properties,
+          required: keys.length > 0 ? [keys[0]] : [],
+        },
+        tags: [],
+      };
+    }
+
+    it('should truncate property keys exceeding 64 characters', () => {
+      const tool = makeLongKeyTool('ZOOM_CREATE_A_MEETING', [
+        'short_key',
+        LONG_KEY_1,
+        LONG_KEY_2,
+        LONG_KEY_3,
+      ]);
+
+      const wrapped = provider.wrapTool(tool) as AnthropicTool;
+      const propertyKeys = Object.keys(wrapped.input_schema.properties as Record<string, unknown>);
+
+      for (const key of propertyKeys) {
+        expect(key.length).toBeLessThanOrEqual(64);
+      }
+      expect(propertyKeys).toContain('short_key');
+      expect(propertyKeys).toHaveLength(4);
+      expect(new Set(propertyKeys).size).toBe(4);
+    });
+
+    it('should update the required array with sanitized keys', () => {
+      const tool = makeLongKeyTool('ZOOM_TOOL', [LONG_KEY_1]);
+
+      const wrapped = provider.wrapTool(tool) as AnthropicTool;
+      const required = (wrapped.input_schema as any).required as string[];
+
+      expect(required).toHaveLength(1);
+      expect(required[0].length).toBeLessThanOrEqual(64);
+      expect(required[0]).not.toBe(LONG_KEY_1);
+    });
+
+    it('should not modify schemas with keys under 64 characters', () => {
+      const wrapped = provider.wrapTool(mockTool) as AnthropicTool;
+
+      expect(wrapped.input_schema).toEqual({
+        type: 'object',
+        properties: mockTool.inputParameters?.properties,
+        required: mockTool.inputParameters?.required,
+      });
+    });
+
+    it('should restore original keys when executing tool calls', async () => {
+      const tool = makeLongKeyTool('ZOOM_TOOL', [LONG_KEY_1]);
+
+      const wrapped = provider.wrapTool(tool) as AnthropicTool;
+      const truncatedKey = Object.keys(
+        wrapped.input_schema.properties as Record<string, unknown>
+      )[0];
+
+      const toolUse: AnthropicToolUseBlock = {
+        type: 'tool_use',
+        id: 'tu_zoom',
+        name: 'ZOOM_TOOL',
+        input: { [truncatedKey]: 'US,CA' },
+      };
+
+      await provider.executeToolCall('user-1', toolUse);
+
+      expect(mockExecuteToolFn).toHaveBeenCalledWith(
+        'ZOOM_TOOL',
+        expect.objectContaining({
+          arguments: { [LONG_KEY_1]: 'US,CA' },
+        }),
+        undefined
+      );
+    });
+
+    it('should clear stale key mappings when tool is re-wrapped with short keys', () => {
+      // First wrap: tool has long keys -> mapping stored
+      const longKeyTool = makeLongKeyTool('STALE_TOOL', [LONG_KEY_1]);
+      provider.wrapTool(longKeyTool);
+
+      // Second wrap: same slug, but now all keys are short -> mapping must be cleared
+      const shortKeyTool: Tool = {
+        slug: 'STALE_TOOL',
+        name: 'Stale Tool',
+        description: 'Updated tool',
+        inputParameters: {
+          type: 'object',
+          properties: { short_key: { type: 'string' } },
+          required: [],
+        },
+        tags: [],
+      };
+      provider.wrapTool(shortKeyTool);
+
+      // Internal map should NOT have a mapping for this slug
+      // Verify by executing: args should pass through unchanged
+      const toolUse: AnthropicToolUseBlock = {
+        type: 'tool_use',
+        id: 'tu_stale',
+        name: 'STALE_TOOL',
+        input: { short_key: 'value' },
+      };
+
+      provider.executeToolCall('user-1', toolUse);
+
+      expect(mockExecuteToolFn).toHaveBeenCalledWith(
+        'STALE_TOOL',
+        expect.objectContaining({
+          arguments: { short_key: 'value' },
+        }),
+        undefined
+      );
+    });
+  });
+
+  describe('sanitizeSchemaPropertyKeys', () => {
+    it('should return schema unchanged when all keys fit', () => {
+      const schema = {
+        type: 'object' as const,
+        properties: { name: { type: 'string' }, age: { type: 'number' } },
+        required: ['name'],
+      };
+      const { schema: result, keyMap } = sanitizeSchemaPropertyKeys(schema);
+      expect(result).toBe(schema);
+      expect(keyMap.size).toBe(0);
+    });
+
+    it('should handle schema without properties', () => {
+      const schema = { type: 'object' as const };
+      const { schema: result, keyMap } = sanitizeSchemaPropertyKeys(schema);
+      expect(result).toBe(schema);
+      expect(keyMap.size).toBe(0);
+    });
+
+    it('should truncate keys deterministically', () => {
+      const longKey = 'a'.repeat(70);
+      const schema = {
+        type: 'object' as const,
+        properties: { [longKey]: { type: 'string' } },
+      };
+      const { schema: result, keyMap } = sanitizeSchemaPropertyKeys(schema);
+      const newKey = Object.keys(result.properties!)[0];
+
+      expect(newKey.length).toBe(64);
+      expect(keyMap.size).toBe(1);
+      expect(keyMap.get(newKey)).toBe(longKey);
+
+      // Same input produces same output
+      const { schema: result2 } = sanitizeSchemaPropertyKeys(schema);
+      expect(Object.keys(result2.properties!)[0]).toBe(newKey);
+    });
+
+    it('should produce unique truncated keys for different long keys', () => {
+      const key1 = 'settings__approved__or__denied__countries__or__regions__approved__list';
+      const key2 = 'settings__approved__or__denied__countries__or__regions__denied__list';
+      const schema = {
+        type: 'object' as const,
+        properties: { [key1]: { type: 'string' }, [key2]: { type: 'string' } },
+      };
+      const { schema: result } = sanitizeSchemaPropertyKeys(schema);
+      const keys = Object.keys(result.properties!);
+
+      expect(keys[0]).not.toBe(keys[1]);
+      expect(keys[0].length).toBeLessThanOrEqual(64);
+      expect(keys[1].length).toBeLessThanOrEqual(64);
+    });
+  });
+
+  describe('restoreOriginalKeys', () => {
+    it('should restore mapped keys and pass through unmapped ones', () => {
+      const keyMap = new Map([['short_abc1234', 'very_long_original_key']]);
+      const input = { short_abc1234: 'value', other: 'val2' };
+      const result = restoreOriginalKeys(input, keyMap);
+      expect(result).toEqual({ very_long_original_key: 'value', other: 'val2' });
+    });
+
+    it('should return input unchanged with empty map', () => {
+      const input = { key: 'value' };
+      const result = restoreOriginalKeys(input, new Map());
+      expect(result).toBe(input);
     });
   });
 });


### PR DESCRIPTION
## Summary

Anthropic's API rejects tool input schemas with property keys longer than 64 characters (`^[a-zA-Z0-9_.-]{1,64}$`). Composio's schema flattening produces keys that exceed this limit for tools like Zoom, GitHub, and DocuSign, blocking all Composio+Claude users on those toolkits.

This PR sanitizes long property keys in the Anthropic provider (truncate to 56-char prefix + `_` + 7-char djb2 hash = 64 chars max) and restores original keys before sending arguments to the backend.

Fixes #2330

## Changes

- New `sanitize-keys.ts`: deterministic key truncation (`shortHash` via djb2) and reverse mapping (`restoreOriginalKeys`)
- `wrapTool()`: sanitize keys on wrap, store reverse mapping per tool slug
- `executeToolCall()`: restore original keys from the mapping before dispatching
- **Stale mapping fix**: `wrapTool()` deletes existing mapping for a slug before recomputing. This prevents the bug from PR #3067 where re-wrapping a tool whose schema changed from long to short keys would leave a stale mapping that corrupts `executeToolCall` arguments.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [ ] Documentation
- [ ] Breaking change

## How Has This Been Tested?

Unit tests added covering:
1. Long keys (70+ chars) truncated to exactly 64 chars
2. Short keys pass through unchanged
3. `required` array updated with sanitized keys
4. Different long keys produce unique truncated keys (hash-based uniqueness)
5. Deterministic output (same input = same truncated key)
6. Round-trip: `wrapTool` -> `executeToolCall` restores original keys
7. **Stale mapping regression**: re-wrapping a tool with short keys clears the old mapping (the bug that closed PR #3067)
8. Edge cases: null properties, empty map

## Checklist
- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed
- [x] I updated documentation as needed
- [x] I added tests or explain why not applicable
- [ ] I added a changeset if this change affects published packages

## Additional context

This approach was proven in PR #3067 but that PR was closed due to a stale key mapping bug flagged in review. The specific bug: `_toolKeyMaps` was populated when long keys existed but never cleared when a tool was re-wrapped with all-short keys. This PR fixes that by deleting the mapping at the start of `wrapTool` before recomputing.

Scope is limited to property key length (#2330). Tool name length (#2788) and duplicate required entries (#2933) are separate issues.