### PR TITLE
feat: add connected account update() for credential patching

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ catalogs:
       specifier: ^4.20250917.0
       version: 4.20260218.0
     '@composio/client':
-      specifier: 0.1.0-alpha.62
-      version: 0.1.0-alpha.62
+      specifier: 0.1.0-alpha.63
+      version: 0.1.0-alpha.63
     '@effect/cli':
       specifier: ^0.73.2
       version: 0.73.2
@@ -1060,7 +1060,7 @@ importers:
         version: 1.0.1
       '@composio/client':
         specifier: 'catalog:'
-        version: 0.1.0-alpha.62
+        version: 0.1.0-alpha.63
       '@composio/core':
         specifier: workspace:*
         version: link:../core
@@ -1175,7 +1175,7 @@ importers:
     dependencies:
       '@composio/client':
         specifier: 'catalog:'
-        version: 0.1.0-alpha.62
+        version: 0.1.0-alpha.63
       '@composio/json-schema-to-zod':
         specifier: workspace:*
         version: link:../json-schema-to-zod
@@ -1838,8 +1838,8 @@ packages:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
 
-  '@composio/client@0.1.0-alpha.62':
-    resolution: {integrity: sha512-MUBawDp6Uw85m3T0ZtPUSTe9v4SPa0K/Ey3ADZQ/k1NkWsin0oGWhrB/i9hMzndRobijHmBw6xgnFCwjU1B9MQ==}
+  '@composio/client@0.1.0-alpha.63':
+    resolution: {integrity: sha512-4bN3s/y7ZTaRlAVz+kEfJNcrTMIc55mzu1fbYSgItioIZwrxaPm/3WW8uIgTdO9RUIKp0QCwo4Qio8+omI2s1Q==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -7198,7 +7198,7 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@composio/client@0.1.0-alpha.62': {}
+  '@composio/client@0.1.0-alpha.63': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,7 +20,7 @@ catalog:
   '@clack/prompts': '^1.0.1'
   '@cloudflare/vitest-pool-workers': ^0.9.2
   '@cloudflare/workers-types': ^4.20250917.0
-  '@composio/client': 0.1.0-alpha.62
+  '@composio/client': 0.1.0-alpha.63
   '@effect/cli': ^0.73.2
   '@effect/eslint-plugin': ^0.3.2
   '@effect/language-service': ^0.74.0

--- a/python/composio/core/models/connected_accounts.py
+++ b/python/composio/core/models/connected_accounts.py
@@ -11,6 +11,8 @@ from composio import exceptions
 from composio.client import HttpClient
 from composio.client.types import (
     connected_account_create_params,
+    connected_account_patch_params,
+    connected_account_patch_response,
     connected_account_retrieve_response,
     connected_account_update_status_response,
 )
@@ -485,6 +487,27 @@ class ConnectedAccounts:
             client=self._client,
         ).wait_for_connection(
             timeout=timeout,
+        )
+
+    def update(
+        self,
+        nano_id: str,
+        *,
+        alias: t.Optional[str] = None,
+        connection: t.Optional[connected_account_patch_params.Connection] = None,
+    ) -> connected_account_patch_response.ConnectedAccountPatchResponse:
+        """
+        Update credentials and/or alias on a connected account.
+
+        Args:
+            nano_id: The connected account ID (ca_xxx)
+            alias: Human-readable alias. Empty string clears alias.
+            connection: Credential update with authScheme and val fields.
+        """
+        return self._client.connected_accounts.patch(
+            nano_id,
+            alias=alias,
+            connection=connection,
         )
 
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.10,<4"
 dependencies = [
     "pysher>=1.0.8",
     "pydantic>=2.6.4",
-    "composio-client==1.29.0",
+    "composio-client==1.30.0",
     "typing-extensions>=4.0.0",
     "openai",
     "json-schema-to-pydantic>=0.4.8",

--- a/ts/packages/core/src/models/ConnectedAccounts.ts
+++ b/ts/packages/core/src/models/ConnectedAccounts.ts
@@ -8,6 +8,8 @@
 import ComposioClient from '@composio/client';
 import {
   ConnectedAccountDeleteResponse,
+  ConnectedAccountPatchParams,
+  ConnectedAccountPatchResponse,
   ConnectedAccountRefreshParams,
   ConnectedAccountRefreshResponse,
   ConnectedAccountUpdateStatusParams,
@@ -460,5 +462,36 @@ export class ConnectedAccounts {
    */
   async disable(nanoid: string): Promise<ConnectedAccountUpdateStatusResponse> {
     return this.client.connectedAccounts.updateStatus(nanoid, { enabled: false });
+  }
+
+  /**
+   * Update credentials and/or alias on a connected account
+   * @param {string} nanoid - Unique identifier of the connected account
+   * @param {ConnectedAccountPatchParams} params - Fields to update
+   * @returns {Promise<ConnectedAccountPatchResponse>} Updated connected account
+   *
+   * @example
+   * ```typescript
+   * // Update credentials
+   * await composio.connectedAccounts.update('ca_abc123', {
+   *   connection: {
+   *     state: {
+   *       authScheme: 'BEARER_TOKEN',
+   *       val: { token: 'new-access-token' },
+   *     },
+   *   },
+   * });
+   *
+   * // Update alias
+   * await composio.connectedAccounts.update('ca_abc123', {
+   *   alias: 'work-gmail',
+   * });
+   * ```
+   */
+  async update(
+    nanoid: string,
+    params: ConnectedAccountPatchParams,
+  ): Promise<ConnectedAccountPatchResponse> {
+    return this.client.connectedAccounts.patch(nanoid, params);
   }
 }


### PR DESCRIPTION
## Summary
- Bump `@composio/client` to `0.1.0-alpha.63` — adds `connectedAccounts.patch()` method
- Bump `composio-client` to `1.30.0` — adds `connected_accounts.patch()` method
- Add `update()` wrapper in TypeScript SDK (`ConnectedAccounts.ts`)
- Add `update()` wrapper in Python SDK (`connected_accounts.py`)

## Usage

### TypeScript
```typescript
await composio.connectedAccounts.update('ca_abc123', {
  connection: {
    state: {
      authScheme: 'BEARER_TOKEN',
      val: { token: 'new-access-token' },
    },
  },
});

// Update alias
await composio.connectedAccounts.update('ca_abc123', {
  alias: 'work-gmail',
});
```

### Python
```python
composio.connected_accounts.update(
    "ca_abc123",
    connection={
        "state": {
            "authScheme": "BEARER_TOKEN",
            "val": {"token": "new-access-token"},
        },
    },
)
```

## Test plan
- [ ] TS: verify `connectedAccounts.update()` calls through to `client.connectedAccounts.patch()`
- [ ] Python: verify `connected_accounts.update()` calls through to `client.connected_accounts.patch()`
- [ ] E2E: test against production with existing BEARER_TOKEN connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)