### PR TITLE
docs: bearer token connections & credential patching

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -9,4 +9,6 @@ cadbd463fddb5b31c901d2c222b73354b6d87327:docs/content/docs/tools-direct/toolkit-
 
 # Test fixture dummy token for verifying Authorization header forwarding (not a real secret)
 694231f9ffcdb23ca5baf67509101355764d81dc:ts/packages/cli/test/src/services/update-check.test.ts:generic-api-key:296
-e875c451f76d6a36d76448e9c608868a8bdbf56a:docs/content/docs/importing-existing-connections.mdx:curl-auth-header:277
+e921d2d767a779fcaf40fb4f1fde789424d4b7c9:docs/content/docs/importing-existing-connections.mdx:curl-auth-header:207
+786f40ade6a3a7287c4c79694830edf3c02001d5:docs/content/docs/importing-existing-connections.mdx:curl-auth-header:247
+786f40ade6a3a7287c4c79694830edf3c02001d5:docs/content/docs/importing-existing-connections.mdx:curl-auth-header:287

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -9,3 +9,4 @@ cadbd463fddb5b31c901d2c222b73354b6d87327:docs/content/docs/tools-direct/toolkit-
 
 # Test fixture dummy token for verifying Authorization header forwarding (not a real secret)
 694231f9ffcdb23ca5baf67509101355764d81dc:ts/packages/cli/test/src/services/update-check.test.ts:generic-api-key:296
+e875c451f76d6a36d76448e9c608868a8bdbf56a:docs/content/docs/importing-existing-connections.mdx:curl-auth-header:277

--- a/docs/bun.lock
+++ b/docs/bun.lock
@@ -31,7 +31,7 @@
         "@anthropic-ai/sdk": "^0.71.2",
         "@composio/anthropic": "^0.5.5",
         "@composio/claude-agent-sdk": "^0.6.3",
-        "@composio/core": "0.6.9",
+        "@composio/core": "^0.6.9",
         "@composio/google": "^0.5.5",
         "@composio/langchain": "^0.5.5",
         "@composio/llamaindex": "^0.5.5",

--- a/docs/bun.lock
+++ b/docs/bun.lock
@@ -31,7 +31,7 @@
         "@anthropic-ai/sdk": "^0.71.2",
         "@composio/anthropic": "^0.5.5",
         "@composio/claude-agent-sdk": "^0.6.3",
-        "@composio/core": "^0.6.6",
+        "@composio/core": "0.6.9",
         "@composio/google": "^0.5.5",
         "@composio/langchain": "^0.5.5",
         "@composio/llamaindex": "^0.5.5",
@@ -163,9 +163,9 @@
 
     "@composio/claude-agent-sdk": ["@composio/claude-agent-sdk@0.6.3", "", { "dependencies": { "zod": "^3.25.76" }, "peerDependencies": { "@anthropic-ai/claude-agent-sdk": ">=0.1.0", "@composio/core": "0.6.3" } }, "sha512-724KwTShuore9zQrxRvbOzVrqZ8w9Z5ZkzElKYJX6mbUq33GaVs5bFbgSomNDaRe9kkLAI7fPP8WteZJB32akA=="],
 
-    "@composio/client": ["@composio/client@0.1.0-alpha.62", "", {}, "sha512-MUBawDp6Uw85m3T0ZtPUSTe9v4SPa0K/Ey3ADZQ/k1NkWsin0oGWhrB/i9hMzndRobijHmBw6xgnFCwjU1B9MQ=="],
+    "@composio/client": ["@composio/client@0.1.0-alpha.66", "", {}, "sha512-SDHcTWzz2dgdYAew/gQsRpjHpEzHKm6sW7KM4wCoJWNJuuMuey9Ahje91ZucNjfaqpI8CFW+pXY4nWkZf5LD7Q=="],
 
-    "@composio/core": ["@composio/core@0.6.7", "", { "dependencies": { "@composio/client": "0.1.0-alpha.62", "@composio/json-schema-to-zod": "0.1.20", "@types/json-schema": "^7.0.15", "chalk": "^4.1.2", "openai": "^6.16.0", "pusher-js": "^8.4.0", "semver": "^7.7.2", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-nWveoUAoCSVTVwOEBaBiRAHu2fVy1nMH7kTICgSaFTaYJYYvpiD8tjCClYRBnp1W4QN3HoRDH4dBWCBdCe9D6A=="],
+    "@composio/core": ["@composio/core@0.6.9", "", { "dependencies": { "@composio/client": "0.1.0-alpha.66", "@composio/json-schema-to-zod": "0.1.20", "@types/json-schema": "^7.0.15", "chalk": "^4.1.2", "openai": "^6.16.0", "pusher-js": "^8.4.0", "semver": "^7.7.2", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-DEhRiSKvlLsse2YZKlTYD9I8rLrGeVB90mr8ORafVyptQ1HJ6MUMCM9HzImUfxic/zFkvsT1rMH6nze2bSza4Q=="],
 
     "@composio/google": ["@composio/google@0.5.5", "", { "peerDependencies": { "@composio/core": "0.5.5", "@google/genai": "^1.1.0" } }, "sha512-0W+WZANsVSVAkhaRxbUUpuHJ52O3BbknAEV/C38/1yZq3mmvzx/DlRjGf/tiDRaS7Pxr8WhYwGUKgeyzYR4qAw=="],
 

--- a/docs/content/changelog/04-07-26-bearer-token-patch.mdx
+++ b/docs/content/changelog/04-07-26-bearer-token-patch.mdx
@@ -10,7 +10,7 @@ Two features for teams managing their own authentication credentials.
 
 All OAuth2 toolkits (Gmail, GitHub, Slack, Google Docs, and more) now support `BEARER_TOKEN` as an auth scheme. Import your own access tokens directly without setting up an OAuth app.
 
-This restores and improves the BEARER_TOKEN support that was [deprecated in December 2025](/changelog/12-31-25). The new implementation injects BEARER_TOKEN as an alternative scheme alongside OAuth2, so existing OAuth connections are unaffected.
+BEARER_TOKEN is injected as an alternative scheme alongside OAuth2, so existing OAuth connections are unaffected.
 
 ### How to use
 

--- a/docs/content/changelog/04-07-26-bearer-token-patch.mdx
+++ b/docs/content/changelog/04-07-26-bearer-token-patch.mdx
@@ -29,6 +29,9 @@ See the [importing connections guide](/docs/importing-existing-connections) for 
 New `PATCH /api/v3/connected_accounts/{nanoid}` endpoint and SDK method — update credentials and alias on existing connections without recreating them.
 
 ```typescript
+import { Composio } from '@composio/core';
+const composio = new Composio({ apiKey: 'your-api-key' });
+// ---cut---
 await composio.connectedAccounts.update('ca_abc123', {
   connection: {
     state: {

--- a/docs/content/changelog/04-07-26-bearer-token-patch.mdx
+++ b/docs/content/changelog/04-07-26-bearer-token-patch.mdx
@@ -1,0 +1,41 @@
+---
+title: "Bearer Token Connections & Credential Patching"
+description: "Import bearer tokens for any OAuth toolkit and update credentials in place"
+date: "2026-04-07"
+---
+
+Two features for teams managing their own authentication credentials.
+
+## Bearer Token for OAuth Toolkits
+
+All OAuth2 toolkits (Gmail, GitHub, Slack, Google Docs, and more) now support `BEARER_TOKEN` as an auth scheme. Import your own access tokens directly without setting up an OAuth app.
+
+This restores and improves the BEARER_TOKEN support that was [deprecated in December 2025](/changelog/12-31-25). The new implementation injects BEARER_TOKEN as an alternative scheme alongside OAuth2, so existing OAuth connections are unaffected.
+
+### How to use
+
+1. Create a custom auth config with `authScheme: "BEARER_TOKEN"` for the toolkit
+2. Create a connected account with your access token
+3. Pass the auth config or connection ID to `composio.create()` for use with Tool Router
+
+See the [importing connections guide](/docs/importing-existing-connections) for full examples.
+
+## Credential Patching
+
+New `PATCH /api/v3/connected_accounts/{nanoid}` endpoint and SDK method — update credentials and alias on existing connections without recreating them.
+
+```typescript
+await composio.connectedAccounts.update('ca_abc123', {
+  connection: {
+    state: {
+      authScheme: 'BEARER_TOKEN',
+      val: { token: 'rotated-access-token' },
+    },
+  },
+});
+```
+
+- **Credential rotation** — update expired tokens in place
+- **Alias management** — name connections for multi-account scenarios
+- **Partial updates** — omitted fields are preserved, fields set to `null` are removed
+- **Supported schemes** — BEARER_TOKEN, API_KEY, BASIC, BASIC_WITH_JWT, GOOGLE_SERVICE_ACCOUNT, SERVICE_ACCOUNT

--- a/docs/content/changelog/04-07-26-bearer-token-patch.mdx
+++ b/docs/content/changelog/04-07-26-bearer-token-patch.mdx
@@ -35,7 +35,6 @@ await composio.connectedAccounts.update('ca_abc123', {
 });
 ```
 
-- **Credential rotation** — update expired tokens in place
-- **Alias management** — name connections for multi-account scenarios
+- **Keep access tokens updated** — call PATCH whenever you refresh the token on your end (e.g., after an OAuth refresh flow)
 - **Partial updates** — omitted fields are preserved, fields set to `null` are removed
 - **Supported schemes** — BEARER_TOKEN, API_KEY, BASIC, BASIC_WITH_JWT, GOOGLE_SERVICE_ACCOUNT, SERVICE_ACCOUNT

--- a/docs/content/changelog/04-07-26-bearer-token-patch.mdx
+++ b/docs/content/changelog/04-07-26-bearer-token-patch.mdx
@@ -18,6 +18,10 @@ This restores and improves the BEARER_TOKEN support that was [deprecated in Dece
 2. Create a connected account with your access token
 3. Pass the auth config or connection ID to `composio.create()` for use with Tool Router
 
+<Callout type="info">
+Creating bearer token auth configs is currently available only via API and SDK — not yet supported in the dashboard UI.
+</Callout>
+
 See the [importing connections guide](/docs/importing-existing-connections) for full examples.
 
 ## Credential Patching

--- a/docs/content/docs/importing-existing-connections.mdx
+++ b/docs/content/docs/importing-existing-connections.mdx
@@ -74,7 +74,7 @@ console.log('Connected:', connection.id);
 
 ## Bearer tokens
 
-For services where you already have an access token. Bearer token is supported for **all toolkits that have OAuth2 or S2S auth** — including Gmail, GitHub, Slack, Google Docs, and more. This lets you use existing access tokens without setting up an OAuth app. It also supports the same additional parameters as the original auth scheme (e.g., `subdomain`, `base_url`).
+If you already have an access token for a service, you can import it directly as a bearer token. This works with **all toolkits that support OAuth2 or S2S auth** — Gmail, GitHub, Slack, Google Docs, and more — so you can skip OAuth app setup entirely. Any additional parameters the toolkit supports (e.g., `subdomain`, `base_url`) work the same way.
 
 <Tabs groupId="language" items={['Python', 'TypeScript']} persist>
 <Tab value="Python">

--- a/docs/content/docs/importing-existing-connections.mdx
+++ b/docs/content/docs/importing-existing-connections.mdx
@@ -28,11 +28,7 @@ graph LR
 
 ## Creating an auth config
 
-Before importing credentials, you need an auth config for the toolkit. This is a one-time setup.
-
-<Callout type="info">
-Bearer token auth configs work with **any toolkit that supports OAuth2 or S2S auth** — including Gmail, GitHub, Slack, Google Docs, and more. This lets you import your own access tokens without setting up an OAuth app.
-</Callout>
+Before importing credentials, you need an auth config for the toolkit. This tells Composio which auth scheme to use. This is a one-time setup per toolkit.
 
 <Tabs groupId="language" items={['Python', 'TypeScript', 'curl']} persist>
 <Tab value="Python">
@@ -41,6 +37,14 @@ from composio import Composio
 
 composio = Composio(api_key="your-api-key")
 
+# For API key toolkits (e.g., SendGrid, Tavily)
+auth_config = composio.auth_configs.create("sendgrid", {
+    "type": "use_custom_auth",
+    "authScheme": "API_KEY",
+    "credentials": {},
+})
+
+# For bearer token — works with any OAuth toolkit (Gmail, GitHub, Slack, etc.)
 auth_config = composio.auth_configs.create("gmail", {
     "type": "use_custom_auth",
     "authScheme": "BEARER_TOKEN",
@@ -56,6 +60,14 @@ import { Composio } from '@composio/core';
 
 const composio = new Composio({ apiKey: 'your-api-key' });
 
+// For API key toolkits (e.g., SendGrid, Tavily)
+const authConfig = await composio.authConfigs.create('sendgrid', {
+  type: 'use_custom_auth',
+  authScheme: 'API_KEY',
+  credentials: {},
+});
+
+// For bearer token — works with any OAuth toolkit (Gmail, GitHub, Slack, etc.)
 const authConfig = await composio.authConfigs.create('gmail', {
   type: 'use_custom_auth',
   authScheme: 'BEARER_TOKEN',
@@ -81,6 +93,10 @@ curl -X POST https://backend.composio.dev/api/v3/auth_configs \
 ```
 </Tab>
 </Tabs>
+
+<Callout type="info">
+Bearer token auth configs work with **any toolkit that supports OAuth2 or S2S auth** — including Gmail, GitHub, Slack, Google Docs, and more. This lets you import your own access tokens without setting up an OAuth app.
+</Callout>
 
 ## API keys
 
@@ -266,18 +282,6 @@ curl -X PATCH https://backend.composio.dev/api/v3/connected_accounts/ca_xxx \
 ```
 </Tab>
 </Tabs>
-
-You can also update the alias or both at once:
-
-```bash
-# Update alias
-curl -X PATCH .../api/v3/connected_accounts/ca_xxx \
-  -d '{"alias": "work-gmail"}'
-
-# Remove a field (set to null)
-curl -X PATCH .../api/v3/connected_accounts/ca_xxx \
-  -d '{"connection":{"state":{"authScheme":"API_KEY","val":{"subdomain":null}}}}'
-```
 
 Fields you omit are preserved. Fields set to `null` are removed.
 

--- a/docs/content/docs/importing-existing-connections.mdx
+++ b/docs/content/docs/importing-existing-connections.mdx
@@ -188,6 +188,9 @@ composio.connected_accounts.update(
 </Tab>
 <Tab value="TypeScript">
 ```typescript
+import { Composio } from '@composio/core';
+const composio = new Composio({ apiKey: 'your-api-key' });
+// ---cut---
 await composio.connectedAccounts.update('ca_your_connection_id', {
   connection: {
     state: {
@@ -225,6 +228,9 @@ composio.connected_accounts.update(
 </Tab>
 <Tab value="TypeScript">
 ```typescript
+import { Composio } from '@composio/core';
+const composio = new Composio({ apiKey: 'your-api-key' });
+// ---cut---
 await composio.connectedAccounts.update('ca_your_connection_id', {
   connection: {
     state: {
@@ -262,6 +268,9 @@ composio.connected_accounts.update(
 </Tab>
 <Tab value="TypeScript">
 ```typescript
+import { Composio } from '@composio/core';
+const composio = new Composio({ apiKey: 'your-api-key' });
+// ---cut---
 await composio.connectedAccounts.update('ca_your_connection_id', {
   connection: {
     state: {
@@ -300,6 +309,9 @@ session = composio.create(
 </Tab>
 <Tab value="TypeScript">
 ```typescript
+import { Composio } from '@composio/core';
+const composio = new Composio({ apiKey: 'your-api-key' });
+// ---cut---
 const session = await composio.create('user_123', {
   authConfigs: { gmail: 'ac_your_auth_config' },
   toolkits: ['gmail'],

--- a/docs/content/docs/importing-existing-connections.mdx
+++ b/docs/content/docs/importing-existing-connections.mdx
@@ -78,7 +78,7 @@ console.log('Connected:', connection.id);
 
 ## Bearer tokens
 
-For services where you already have an access token — including OAuth toolkits like Gmail, GitHub, Slack, and more:
+For services where you already have an access token. Bearer token is supported for **all toolkits that have OAuth2 or S2S auth** — including Gmail, GitHub, Slack, Google Docs, and more. It also supports the same additional parameters as the original auth scheme (e.g., `subdomain`, `base_url`).
 
 <Tabs groupId="language" items={['Python', 'TypeScript']} persist>
 <Tab value="Python">

--- a/docs/content/docs/importing-existing-connections.mdx
+++ b/docs/content/docs/importing-existing-connections.mdx
@@ -170,8 +170,10 @@ console.log('Connected:', connection.id);
 
 ## Updating credentials
 
-When credentials expire or rotate, update them in place without recreating the connection:
+When credentials expire or rotate, update them in place without recreating the connection. Fields you omit are preserved. Fields set to `null` are removed.
 
+<Tabs groupId="auth-scheme" items={['Bearer token', 'API key', 'Basic auth']} persist>
+<Tab value="Bearer token">
 <Tabs groupId="language" items={['Python', 'TypeScript', 'curl']} persist>
 <Tab value="Python">
 ```python
@@ -203,19 +205,86 @@ await composio.connectedAccounts.update('ca_your_connection_id', {
 curl -X PATCH https://backend.composio.dev/api/v3/connected_accounts/ca_xxx \
   -H 'x-api-key: YOUR_API_KEY' \
   -H 'Content-Type: application/json' \
-  -d '{
-    "connection": {
-      "state": {
-        "authScheme": "BEARER_TOKEN",
-        "val": {"token": "new-access-token"}
-      }
-    }
-  }'
+  -d '{"connection":{"state":{"authScheme":"BEARER_TOKEN","val":{"token":"new-access-token"}}}}'
 ```
 </Tab>
 </Tabs>
-
-Fields you omit are preserved. Fields set to `null` are removed.
+</Tab>
+<Tab value="API key">
+<Tabs groupId="language" items={['Python', 'TypeScript', 'curl']} persist>
+<Tab value="Python">
+```python
+composio.connected_accounts.update(
+    "ca_your_connection_id",
+    connection={
+        "state": {
+            "authScheme": "API_KEY",
+            "val": {"generic_api_key": "new-api-key"},
+        },
+    },
+)
+```
+</Tab>
+<Tab value="TypeScript">
+```typescript
+await composio.connectedAccounts.update('ca_your_connection_id', {
+  connection: {
+    state: {
+      authScheme: 'API_KEY',
+      val: { generic_api_key: 'new-api-key' },
+    },
+  },
+});
+```
+</Tab>
+<Tab value="curl">
+```bash
+curl -X PATCH https://backend.composio.dev/api/v3/connected_accounts/ca_xxx \
+  -H 'x-api-key: YOUR_API_KEY' \
+  -H 'Content-Type: application/json' \
+  -d '{"connection":{"state":{"authScheme":"API_KEY","val":{"generic_api_key":"new-api-key"}}}}'
+```
+</Tab>
+</Tabs>
+</Tab>
+<Tab value="Basic auth">
+<Tabs groupId="language" items={['Python', 'TypeScript', 'curl']} persist>
+<Tab value="Python">
+```python
+composio.connected_accounts.update(
+    "ca_your_connection_id",
+    connection={
+        "state": {
+            "authScheme": "BASIC",
+            "val": {"username": "user@example.com", "password": "new-password"},
+        },
+    },
+)
+```
+</Tab>
+<Tab value="TypeScript">
+```typescript
+await composio.connectedAccounts.update('ca_your_connection_id', {
+  connection: {
+    state: {
+      authScheme: 'BASIC',
+      val: { username: 'user@example.com', password: 'new-password' },
+    },
+  },
+});
+```
+</Tab>
+<Tab value="curl">
+```bash
+curl -X PATCH https://backend.composio.dev/api/v3/connected_accounts/ca_xxx \
+  -H 'x-api-key: YOUR_API_KEY' \
+  -H 'Content-Type: application/json' \
+  -d '{"connection":{"state":{"authScheme":"BASIC","val":{"username":"user@example.com","password":"new-password"}}}}'
+```
+</Tab>
+</Tabs>
+</Tab>
+</Tabs>
 
 ## Using with Tool Router
 

--- a/docs/content/docs/importing-existing-connections.mdx
+++ b/docs/content/docs/importing-existing-connections.mdx
@@ -74,11 +74,7 @@ console.log('Connected:', connection.id);
 
 ## Bearer tokens
 
-For services where you already have an access token.
-
-<Callout type="info">
-Bearer token is supported for **all toolkits that have OAuth2 or S2S auth** — including Gmail, GitHub, Slack, Google Docs, and more. This lets you use existing access tokens without setting up an OAuth app. It also supports the same additional parameters as the original auth scheme (e.g., `subdomain`, `base_url`).
-</Callout>
+For services where you already have an access token. Bearer token is supported for **all toolkits that have OAuth2 or S2S auth** — including Gmail, GitHub, Slack, Google Docs, and more. This lets you use existing access tokens without setting up an OAuth app. It also supports the same additional parameters as the original auth scheme (e.g., `subdomain`, `base_url`).
 
 <Tabs groupId="language" items={['Python', 'TypeScript']} persist>
 <Tab value="Python">

--- a/docs/content/docs/importing-existing-connections.mdx
+++ b/docs/content/docs/importing-existing-connections.mdx
@@ -1,7 +1,7 @@
 ---
 title: Importing existing connections
-description: Pass existing API keys, bearer tokens, or other non-OAuth credentials into Composio so your users don't need to re-authenticate
-keywords: [import connections, existing tokens, pass through credentials, bring your own tokens, no re-auth, pre-authenticated]
+description: Pass existing API keys, bearer tokens, or other credentials into Composio so your users don't need to re-authenticate
+keywords: [import connections, existing tokens, pass through credentials, bring your own tokens, no re-auth, pre-authenticated, patch credentials, update token, rotate credentials, oauth bearer token]
 ---
 
 If your users have already authenticated with a service and you have their credentials (API keys, bearer tokens, etc.), you can pass those directly into Composio. No re-authentication required.
@@ -9,28 +9,78 @@ If your users have already authenticated with a service and you have their crede
 This is useful when:
 - Your app already stores API keys or tokens for users
 - You're adopting Composio and want to onboard existing users without disrupting them
-- Another platform already holds credentials for your users' accounts
+- You want to use bearer tokens with OAuth toolkits (Gmail, GitHub, Slack, etc.) without setting up an OAuth app
 
 ## How it works
 
-Instead of asking users to authenticate again, you pass their existing credentials to `connectedAccounts.initiate()` using the `AuthScheme` helpers. Composio creates a connected account directly from those credentials.
-
 ```mermaid
 graph LR
-    A[Your existing credentials] --> B[connectedAccounts.initiate]
-    B --> C[Connected account in Composio]
-    C --> D[Execute tools immediately]
+    A[Create auth config] --> B[Create connection with credentials]
+    B --> C[Use in Tool Router / Execute tools]
+    C --> D[Update credentials when needed]
 ```
 
 ## Prerequisites
 
-1. **An auth config** for the toolkit you're importing into
+1. **A Composio API key** — from your project settings
 2. **The existing credentials** for each user (API keys, bearer tokens, username/password, etc.)
-3. **A user ID** for each user, any string that uniquely identifies them in your system
+3. **A user ID** for each user — any string that uniquely identifies them in your system
 
-<Callout type="warn">
-Importing existing OAuth tokens (access tokens, refresh tokens) is **not currently supported**. For OAuth-based services (Google, GitHub, Slack, etc.), users must authenticate through the standard [OAuth flow](/docs/tools-direct/authenticating-tools). This page covers importing non-OAuth credentials like API keys, bearer tokens, and basic auth.
+## Creating an auth config
+
+Before importing credentials, you need an auth config for the toolkit. This is a one-time setup.
+
+<Callout type="info">
+Bearer token auth configs work with **any toolkit that supports OAuth2 or S2S auth** — including Gmail, GitHub, Slack, Google Docs, and more. This lets you import your own access tokens without setting up an OAuth app.
 </Callout>
+
+<Tabs groupId="language" items={['Python', 'TypeScript', 'curl']} persist>
+<Tab value="Python">
+```python
+from composio import Composio
+
+composio = Composio(api_key="your-api-key")
+
+auth_config = composio.auth_configs.create("gmail", {
+    "type": "use_custom_auth",
+    "authScheme": "BEARER_TOKEN",
+    "credentials": {},
+})
+
+print(f"Auth config ID: {auth_config.id}")
+```
+</Tab>
+<Tab value="TypeScript">
+```typescript
+import { Composio } from '@composio/core';
+
+const composio = new Composio({ apiKey: 'your-api-key' });
+
+const authConfig = await composio.authConfigs.create('gmail', {
+  type: 'use_custom_auth',
+  authScheme: 'BEARER_TOKEN',
+  credentials: {},
+});
+
+console.log('Auth config ID:', authConfig.id);
+```
+</Tab>
+<Tab value="curl">
+```bash
+curl -X POST https://backend.composio.dev/api/v3/auth_configs \
+  -H 'x-api-key: YOUR_API_KEY' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "toolkit": {"slug": "gmail"},
+    "auth_config": {
+      "type": "use_custom_auth",
+      "authScheme": "BEARER_TOKEN",
+      "credentials": {}
+    }
+  }'
+```
+</Tab>
+</Tabs>
 
 ## API keys
 
@@ -79,6 +129,8 @@ console.log('Connected:', connection.id);
 </Tabs>
 
 ## Bearer tokens
+
+For services where you already have an access token — including OAuth toolkits like Gmail, GitHub, Slack, and more:
 
 <Tabs groupId="language" items={['Python', 'TypeScript']} persist>
 <Tab value="Python">
@@ -164,6 +216,91 @@ const connection = await composio.connectedAccounts.initiate(
 
 // Basic auth connections are immediately active
 console.log('Connected:', connection.id);
+```
+</Tab>
+</Tabs>
+
+## Updating credentials
+
+When credentials expire or rotate, update them in place without recreating the connection:
+
+<Tabs groupId="language" items={['Python', 'TypeScript', 'curl']} persist>
+<Tab value="Python">
+```python
+composio.connected_accounts.update(
+    "ca_your_connection_id",
+    connection={
+        "state": {
+            "authScheme": "BEARER_TOKEN",
+            "val": {"token": "new-access-token"},
+        },
+    },
+)
+```
+</Tab>
+<Tab value="TypeScript">
+```typescript
+await composio.connectedAccounts.update('ca_your_connection_id', {
+  connection: {
+    state: {
+      authScheme: 'BEARER_TOKEN',
+      val: { token: 'new-access-token' },
+    },
+  },
+});
+```
+</Tab>
+<Tab value="curl">
+```bash
+curl -X PATCH https://backend.composio.dev/api/v3/connected_accounts/ca_xxx \
+  -H 'x-api-key: YOUR_API_KEY' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "connection": {
+      "state": {
+        "authScheme": "BEARER_TOKEN",
+        "val": {"token": "new-access-token"}
+      }
+    }
+  }'
+```
+</Tab>
+</Tabs>
+
+You can also update the alias or both at once:
+
+```bash
+# Update alias
+curl -X PATCH .../api/v3/connected_accounts/ca_xxx \
+  -d '{"alias": "work-gmail"}'
+
+# Remove a field (set to null)
+curl -X PATCH .../api/v3/connected_accounts/ca_xxx \
+  -d '{"connection":{"state":{"authScheme":"API_KEY","val":{"subdomain":null}}}}'
+```
+
+Fields you omit are preserved. Fields set to `null` are removed.
+
+## Using with Tool Router
+
+Pass the auth config or connection ID when creating a session:
+
+<Tabs groupId="language" items={['Python', 'TypeScript']} persist>
+<Tab value="Python">
+```python
+session = composio.create(
+    "user_123",
+    auth_configs={"gmail": "ac_your_auth_config"},
+    toolkits=["gmail"],
+)
+```
+</Tab>
+<Tab value="TypeScript">
+```typescript
+const session = await composio.create('user_123', {
+  authConfigs: { gmail: 'ac_your_auth_config' },
+  toolkits: ['gmail'],
+});
 ```
 </Tab>
 </Tabs>

--- a/docs/content/docs/importing-existing-connections.mdx
+++ b/docs/content/docs/importing-existing-connections.mdx
@@ -74,9 +74,9 @@ console.log('Connected:', connection.id);
 
 ## Bearer tokens
 
-If you already have an access token for a service, you can import it directly as a bearer token. This works with **all toolkits that support OAuth2 or S2S auth** — Gmail, GitHub, Slack, Google Docs, and more — so you can skip OAuth app setup entirely. Any additional parameters the toolkit supports (e.g., `subdomain`, `base_url`) work the same way.
+If you already have an access token for a service (e.g., from an OAuth flow you manage), you can pass it directly to Composio as a bearer token. This works with **all toolkits that support OAuth2 or S2S auth** — Gmail, GitHub, Slack, Google Docs, and more. Any additional parameters the toolkit supports (e.g., `subdomain`, `base_url`) work the same way.
 
-Since access tokens typically expire, you'll need to keep them updated. Use the [PATCH endpoint](#updating-credentials) to push a refreshed token whenever it changes on your end (e.g., after an OAuth refresh flow).
+After [creating an auth config](/docs/auth-configuration/programmatic-auth-configs) with `authScheme: "BEARER_TOKEN"`, use the snippet below to create a connected account. Since access tokens typically expire, use the [PATCH endpoint](#updating-credentials) to push a refreshed token whenever it changes on your end.
 
 <Tabs groupId="language" items={['Python', 'TypeScript']} persist>
 <Tab value="Python">

--- a/docs/content/docs/importing-existing-connections.mdx
+++ b/docs/content/docs/importing-existing-connections.mdx
@@ -284,7 +284,7 @@ curl -X PATCH https://backend.composio.dev/api/v3/connected_accounts/ca_xxx \
 </Tab>
 </Tabs>
 
-## Using with Tool Router
+## Using in your session
 
 Pass the auth config or connection ID when creating a session:
 

--- a/docs/content/docs/importing-existing-connections.mdx
+++ b/docs/content/docs/importing-existing-connections.mdx
@@ -76,7 +76,7 @@ console.log('Connected:', connection.id);
 
 If you already have an access token for a service, you can import it directly as a bearer token. This works with **all toolkits that support OAuth2 or S2S auth** — Gmail, GitHub, Slack, Google Docs, and more — so you can skip OAuth app setup entirely. Any additional parameters the toolkit supports (e.g., `subdomain`, `base_url`) work the same way.
 
-Since bearer tokens typically expire, you'll need to keep them updated. Use the [PATCH endpoint](#updating-credentials) to push a refreshed token whenever it changes on your end (e.g., after an OAuth refresh flow).
+Since access tokens typically expire, you'll need to keep them updated. Use the [PATCH endpoint](#updating-credentials) to push a refreshed token whenever it changes on your end (e.g., after an OAuth refresh flow).
 
 <Tabs groupId="language" items={['Python', 'TypeScript']} persist>
 <Tab value="Python">

--- a/docs/content/docs/importing-existing-connections.mdx
+++ b/docs/content/docs/importing-existing-connections.mdx
@@ -76,6 +76,8 @@ console.log('Connected:', connection.id);
 
 If you already have an access token for a service, you can import it directly as a bearer token. This works with **all toolkits that support OAuth2 or S2S auth** — Gmail, GitHub, Slack, Google Docs, and more — so you can skip OAuth app setup entirely. Any additional parameters the toolkit supports (e.g., `subdomain`, `base_url`) work the same way.
 
+Since bearer tokens typically expire, you'll need to keep them updated. Use the [PATCH endpoint](#updating-credentials) to push a refreshed token whenever it changes on your end (e.g., after an OAuth refresh flow).
+
 <Tabs groupId="language" items={['Python', 'TypeScript']} persist>
 <Tab value="Python">
 ```python

--- a/docs/content/docs/importing-existing-connections.mdx
+++ b/docs/content/docs/importing-existing-connections.mdx
@@ -22,80 +22,12 @@ graph LR
 
 ## Prerequisites
 
-1. **A Composio API key** — from your project settings
+1. **An [auth config](/docs/auth-configuration/programmatic-auth-configs)** for the toolkit you're importing into
 2. **The existing credentials** for each user (API keys, bearer tokens, username/password, etc.)
 3. **A user ID** for each user — any string that uniquely identifies them in your system
 
-## Creating an auth config
-
-Before importing credentials, you need an auth config for the toolkit. This tells Composio which auth scheme to use. This is a one-time setup per toolkit.
-
-<Tabs groupId="language" items={['Python', 'TypeScript', 'curl']} persist>
-<Tab value="Python">
-```python
-from composio import Composio
-
-composio = Composio(api_key="your-api-key")
-
-# For API key toolkits (e.g., SendGrid, Tavily)
-auth_config = composio.auth_configs.create("sendgrid", {
-    "type": "use_custom_auth",
-    "authScheme": "API_KEY",
-    "credentials": {},
-})
-
-# For bearer token — works with any OAuth toolkit (Gmail, GitHub, Slack, etc.)
-auth_config = composio.auth_configs.create("gmail", {
-    "type": "use_custom_auth",
-    "authScheme": "BEARER_TOKEN",
-    "credentials": {},
-})
-
-print(f"Auth config ID: {auth_config.id}")
-```
-</Tab>
-<Tab value="TypeScript">
-```typescript
-import { Composio } from '@composio/core';
-
-const composio = new Composio({ apiKey: 'your-api-key' });
-
-// For API key toolkits (e.g., SendGrid, Tavily)
-const authConfig = await composio.authConfigs.create('sendgrid', {
-  type: 'use_custom_auth',
-  authScheme: 'API_KEY',
-  credentials: {},
-});
-
-// For bearer token — works with any OAuth toolkit (Gmail, GitHub, Slack, etc.)
-const authConfig = await composio.authConfigs.create('gmail', {
-  type: 'use_custom_auth',
-  authScheme: 'BEARER_TOKEN',
-  credentials: {},
-});
-
-console.log('Auth config ID:', authConfig.id);
-```
-</Tab>
-<Tab value="curl">
-```bash
-curl -X POST https://backend.composio.dev/api/v3/auth_configs \
-  -H 'x-api-key: YOUR_API_KEY' \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "toolkit": {"slug": "gmail"},
-    "auth_config": {
-      "type": "use_custom_auth",
-      "authScheme": "BEARER_TOKEN",
-      "credentials": {}
-    }
-  }'
-```
-</Tab>
-</Tabs>
-
 <Callout type="info">
-Bearer token auth configs work with **any toolkit that supports OAuth2 or S2S auth** — including Gmail, GitHub, Slack, Google Docs, and more. This lets you import your own access tokens without setting up an OAuth app.
+Bearer token auth configs work with **any toolkit that supports OAuth2 or S2S auth** — including Gmail, GitHub, Slack, Google Docs, and more. This lets you use existing access tokens without setting up an OAuth app.
 </Callout>
 
 ## API keys

--- a/docs/content/docs/importing-existing-connections.mdx
+++ b/docs/content/docs/importing-existing-connections.mdx
@@ -26,10 +26,6 @@ graph LR
 2. **The existing credentials** for each user (API keys, bearer tokens, username/password, etc.)
 3. **A user ID** for each user — any string that uniquely identifies them in your system
 
-<Callout type="info">
-Bearer token auth configs work with **any toolkit that supports OAuth2 or S2S auth** — including Gmail, GitHub, Slack, Google Docs, and more. This lets you use existing access tokens without setting up an OAuth app.
-</Callout>
-
 ## API keys
 
 For services that use API key authentication (e.g., SendGrid, Tavily, PostHog):
@@ -78,7 +74,11 @@ console.log('Connected:', connection.id);
 
 ## Bearer tokens
 
-For services where you already have an access token. Bearer token is supported for **all toolkits that have OAuth2 or S2S auth** — including Gmail, GitHub, Slack, Google Docs, and more. It also supports the same additional parameters as the original auth scheme (e.g., `subdomain`, `base_url`).
+For services where you already have an access token.
+
+<Callout type="info">
+Bearer token is supported for **all toolkits that have OAuth2 or S2S auth** — including Gmail, GitHub, Slack, Google Docs, and more. This lets you use existing access tokens without setting up an OAuth app. It also supports the same additional parameters as the original auth scheme (e.g., `subdomain`, `base_url`).
+</Callout>
 
 <Tabs groupId="language" items={['Python', 'TypeScript']} persist>
 <Tab value="Python">

--- a/docs/package.json
+++ b/docs/package.json
@@ -44,7 +44,7 @@
     "@anthropic-ai/sdk": "^0.71.2",
     "@composio/anthropic": "^0.5.5",
     "@composio/claude-agent-sdk": "^0.6.3",
-    "@composio/core": "^0.6.6",
+    "@composio/core": "^0.6.9",
     "@composio/google": "^0.5.5",
     "@composio/langchain": "^0.5.5",
     "@composio/llamaindex": "^0.5.5",


### PR DESCRIPTION
## Summary
Updates the "Importing existing connections" docs page and adds a changelog entry for BEARER_TOKEN injection + PATCH endpoint.

## Docs changes
- **Removed** outdated callout saying "OAuth token import is not currently supported" — BEARER_TOKEN now works for all OAuth toolkits
- **Added** "Creating an auth config" section — was missing, page assumed auth config already exists
- **Added** "Updating credentials" section — PATCH endpoint with Python/TS/curl examples
- **Added** "Using with Tool Router" section — session creation with auth config/connection overrides
- **Updated** keywords for search discoverability

## Changelog
New entry for April 7, 2026: Bearer Token Connections & Credential Patching
- References the December 2025 deprecation that this restores
- Documents the PATCH endpoint and SDK method

## Test plan
- [ ] `cd docs && bun dev` — verify page renders
- [ ] Check changelog appears in feed

🤖 Generated with [Claude Code](https://claude.com/claude-code)