### PR TITLE
fix(core): add connection param to connectedAccounts.update()

### DIFF
--- a/ts/packages/core/src/models/ConnectedAccounts.ts
+++ b/ts/packages/core/src/models/ConnectedAccounts.ts
@@ -28,6 +28,7 @@ import {
   ConnectedAccountRefreshOptions,
   ConnectedAccountRefreshOptionsSchema,
   UpdateConnectedAccountParams,
+  UpdateConnectedAccountParamsSchema,
 } from '../types/connectedAccounts.types';
 import { ConnectionRequest } from '../types/connectionRequest.types';
 import { createConnectionRequest } from './ConnectionRequest';
@@ -492,6 +493,13 @@ export class ConnectedAccounts {
     nanoid: string,
     params: UpdateConnectedAccountParams,
   ): Promise<ConnectedAccountPatchResponse> {
-    return this.client.connectedAccounts.patch(nanoid, params);
+    const parsedParams = UpdateConnectedAccountParamsSchema.safeParse(params);
+    if (!parsedParams.success) {
+      throw new ValidationError('Failed to parse connected account update params', {
+        cause: parsedParams.error,
+      });
+    }
+
+    return this.client.connectedAccounts.patch(nanoid, parsedParams.data);
   }
 }

--- a/ts/packages/core/src/models/ConnectedAccounts.ts
+++ b/ts/packages/core/src/models/ConnectedAccounts.ts
@@ -28,7 +28,6 @@ import {
   ConnectedAccountRefreshOptions,
   ConnectedAccountRefreshOptionsSchema,
   UpdateConnectedAccountParams,
-  UpdateConnectedAccountParamsSchema,
 } from '../types/connectedAccounts.types';
 import { ConnectionRequest } from '../types/connectionRequest.types';
 import { createConnectionRequest } from './ConnectionRequest';
@@ -491,18 +490,8 @@ export class ConnectedAccounts {
    */
   async update(
     nanoid: string,
-    params: UpdateConnectedAccountParams
+    params: UpdateConnectedAccountParams,
   ): Promise<ConnectedAccountPatchResponse> {
-    const parsedParams = UpdateConnectedAccountParamsSchema.safeParse(params);
-    if (!parsedParams.success) {
-      throw new ValidationError('Failed to parse connected account update params', {
-        cause: parsedParams.error,
-      });
-    }
-
-    return this.client.connectedAccounts.patch(nanoid, {
-      alias: parsedParams.data.alias,
-      connection: parsedParams.data.connection,
-    });
+    return this.client.connectedAccounts.patch(nanoid, params);
   }
 }

--- a/ts/packages/core/src/models/ConnectedAccounts.ts
+++ b/ts/packages/core/src/models/ConnectedAccounts.ts
@@ -467,20 +467,26 @@ export class ConnectedAccounts {
   }
 
   /**
-   * Update a connected account's alias.
+   * Update a connected account's alias and/or credentials.
    *
    * @param {string} nanoid - The unique identifier of the connected account
    * @param {UpdateConnectedAccountParams} params - The update parameters
-   * @param {string} params.alias - Human-readable alias for the account. Must be unique per userId and toolkit within the project. Pass an empty string to clear.
    * @returns {Promise<ConnectedAccountPatchResponse>} The update response
    *
    * @example
    * ```typescript
    * // Set an alias
-   * await composio.connectedAccounts.update('conn_abc123', { alias: 'work-gmail' });
+   * await composio.connectedAccounts.update('ca_abc123', { alias: 'work-gmail' });
    *
-   * // Clear an alias
-   * await composio.connectedAccounts.update('conn_abc123', { alias: '' });
+   * // Update credentials
+   * await composio.connectedAccounts.update('ca_abc123', {
+   *   connection: {
+   *     state: {
+   *       authScheme: 'BEARER_TOKEN',
+   *       val: { token: 'new-access-token' },
+   *     },
+   *   },
+   * });
    * ```
    */
   async update(
@@ -496,6 +502,7 @@ export class ConnectedAccounts {
 
     return this.client.connectedAccounts.patch(nanoid, {
       alias: parsedParams.data.alias,
+      connection: parsedParams.data.connection,
     });
   }
 }

--- a/ts/packages/core/src/types/connectedAccounts.types.ts
+++ b/ts/packages/core/src/types/connectedAccounts.types.ts
@@ -213,8 +213,20 @@ export const ConnectedAccountRefreshOptionsSchema = z.object({
 });
 export type ConnectedAccountRefreshOptions = z.infer<typeof ConnectedAccountRefreshOptionsSchema>;
 
-// Re-export the Stainless-generated type directly so it stays in sync
-// with the API contract without hardcoding auth scheme strings.
+// Use the Stainless-generated type as the source of truth for update params.
+// The Zod schema mirrors it for runtime validation (consistent with other methods in this file).
 export type { ConnectedAccountPatchParams as UpdateConnectedAccountParams } from '@composio/client/resources/connected-accounts';
+
+export const UpdateConnectedAccountParamsSchema = z.object({
+  alias: z.string().optional(),
+  connection: z
+    .object({
+      state: z.object({
+        authScheme: AuthSchemeEnum,
+        val: z.record(z.unknown()),
+      }),
+    })
+    .optional(),
+});
 
 // UpdateConnectedAccountResponse is now ConnectedAccountPatchResponse from @composio/client

--- a/ts/packages/core/src/types/connectedAccounts.types.ts
+++ b/ts/packages/core/src/types/connectedAccounts.types.ts
@@ -216,9 +216,26 @@ export type ConnectedAccountRefreshOptions = z.infer<typeof ConnectedAccountRefr
 export const UpdateConnectedAccountParamsSchema = z.object({
   alias: z
     .string()
+    .optional()
     .describe(
       'Human-readable alias for the account. Must be unique per userId and toolkit within the project. Pass an empty string to clear the alias.'
     ),
+  connection: z
+    .object({
+      state: z.object({
+        authScheme: z.enum([
+          'BEARER_TOKEN',
+          'API_KEY',
+          'BASIC',
+          'BASIC_WITH_JWT',
+          'GOOGLE_SERVICE_ACCOUNT',
+          'SERVICE_ACCOUNT',
+        ]),
+        val: z.record(z.unknown()),
+      }),
+    })
+    .optional()
+    .describe('Credential fields to update. Only provided fields are changed — omitted fields are preserved. Set a field to null to remove it.'),
 });
 export type UpdateConnectedAccountParams = z.infer<typeof UpdateConnectedAccountParamsSchema>;
 

--- a/ts/packages/core/src/types/connectedAccounts.types.ts
+++ b/ts/packages/core/src/types/connectedAccounts.types.ts
@@ -213,30 +213,8 @@ export const ConnectedAccountRefreshOptionsSchema = z.object({
 });
 export type ConnectedAccountRefreshOptions = z.infer<typeof ConnectedAccountRefreshOptionsSchema>;
 
-export const UpdateConnectedAccountParamsSchema = z.object({
-  alias: z
-    .string()
-    .optional()
-    .describe(
-      'Human-readable alias for the account. Must be unique per userId and toolkit within the project. Pass an empty string to clear the alias.'
-    ),
-  connection: z
-    .object({
-      state: z.object({
-        authScheme: z.enum([
-          'BEARER_TOKEN',
-          'API_KEY',
-          'BASIC',
-          'BASIC_WITH_JWT',
-          'GOOGLE_SERVICE_ACCOUNT',
-          'SERVICE_ACCOUNT',
-        ]),
-        val: z.record(z.unknown()),
-      }),
-    })
-    .optional()
-    .describe('Credential fields to update. Only provided fields are changed — omitted fields are preserved. Set a field to null to remove it.'),
-});
-export type UpdateConnectedAccountParams = z.infer<typeof UpdateConnectedAccountParamsSchema>;
+// Re-export the Stainless-generated type directly so it stays in sync
+// with the API contract without hardcoding auth scheme strings.
+export type { ConnectedAccountPatchParams as UpdateConnectedAccountParams } from '@composio/client/resources/connected-accounts';
 
 // UpdateConnectedAccountResponse is now ConnectedAccountPatchResponse from @composio/client

--- a/ts/packages/core/src/types/connectedAccounts.types.ts
+++ b/ts/packages/core/src/types/connectedAccounts.types.ts
@@ -214,7 +214,6 @@ export const ConnectedAccountRefreshOptionsSchema = z.object({
 export type ConnectedAccountRefreshOptions = z.infer<typeof ConnectedAccountRefreshOptionsSchema>;
 
 // Use the Stainless-generated type as the source of truth for update params.
-// The Zod schema mirrors it for runtime validation (consistent with other methods in this file).
 export type { ConnectedAccountPatchParams as UpdateConnectedAccountParams } from '@composio/client/resources/connected-accounts';
 
 export const UpdateConnectedAccountParamsSchema = z.object({

--- a/ts/packages/core/src/types/connectedAccounts.types.ts
+++ b/ts/packages/core/src/types/connectedAccounts.types.ts
@@ -221,7 +221,14 @@ export const UpdateConnectedAccountParamsSchema = z.object({
   connection: z
     .object({
       state: z.object({
-        authScheme: AuthSchemeEnum,
+        authScheme: z.enum([
+          'BEARER_TOKEN',
+          'API_KEY',
+          'BASIC',
+          'BASIC_WITH_JWT',
+          'GOOGLE_SERVICE_ACCOUNT',
+          'SERVICE_ACCOUNT',
+        ]),
         val: z.record(z.unknown()),
       }),
     })

--- a/ts/packages/core/test/connectedAccounts/connectedAccounts.test.ts
+++ b/ts/packages/core/test/connectedAccounts/connectedAccounts.test.ts
@@ -984,6 +984,12 @@ describe('ConnectedAccounts', () => {
       expect(extendedMockClient.connectedAccounts.patch).toHaveBeenCalledWith(nanoid, params);
       expect(result).toEqual({ success: true, id: nanoid, status: 'ACTIVE' });
     });
+
+    it('should throw ValidationError for invalid params', async () => {
+      await expect(connectedAccounts.update('conn_abc123', { alias: 123 } as any)).rejects.toThrow(
+        'Failed to parse connected account update params'
+      );
+    });
   });
 
   describe('link', () => {

--- a/ts/packages/core/test/connectedAccounts/connectedAccounts.test.ts
+++ b/ts/packages/core/test/connectedAccounts/connectedAccounts.test.ts
@@ -965,10 +965,24 @@ describe('ConnectedAccounts', () => {
       expect(result).toEqual({ success: true });
     });
 
-    it('should throw ValidationError for invalid params', async () => {
-      await expect(connectedAccounts.update('conn_abc123', { alias: 123 } as any)).rejects.toThrow(
-        'Failed to parse connected account update params'
-      );
+    it('should update credentials via connection param', async () => {
+      const nanoid = 'conn_abc123';
+      const mockResponse = { success: true, id: nanoid, status: 'ACTIVE' };
+      const params = {
+        connection: {
+          state: {
+            authScheme: 'BEARER_TOKEN' as const,
+            val: { token: 'new-access-token' },
+          },
+        },
+      };
+
+      extendedMockClient.connectedAccounts.patch.mockResolvedValueOnce(mockResponse);
+
+      const result = await connectedAccounts.update(nanoid, params);
+
+      expect(extendedMockClient.connectedAccounts.patch).toHaveBeenCalledWith(nanoid, params);
+      expect(result).toEqual({ success: true, id: nanoid, status: 'ACTIVE' });
     });
   });
 


### PR DESCRIPTION
## Summary
The TS SDK `connectedAccounts.update()` only passes `alias` to the PATCH endpoint. The `connection` param for credential updates is missing — unlike the Python SDK which already supports both.

## Changes
- Add `connection` (optional) to `UpdateConnectedAccountParamsSchema` with `state.authScheme` and `state.val`
- Make `alias` optional (was required — can't update credentials without also passing alias)
- Pass `connection` through to `client.connectedAccounts.patch()`
- Update JSDoc with credential update example

## Usage
```typescript
// Update credentials
await composio.connectedAccounts.update('ca_abc123', {
  connection: {
    state: {
      authScheme: 'BEARER_TOKEN',
      val: { token: 'new-access-token' },
    },
  },
});

// Update alias (unchanged)
await composio.connectedAccounts.update('ca_abc123', { alias: 'work-gmail' });

// Both at once
await composio.connectedAccounts.update('ca_abc123', {
  alias: 'work-gmail',
  connection: {
    state: {
      authScheme: 'BEARER_TOKEN',
      val: { token: 'new-access-token' },
    },
  },
});
```