### PR TITLE
Fix fish completion install paths

### DIFF
--- a/ts/packages/cli/src/commands/install.cmd.ts
+++ b/ts/packages/cli/src/commands/install.cmd.ts
@@ -31,7 +31,8 @@ type Shell = 'bash' | 'zsh' | 'fish';
 
 interface ShellConfig {
   readonly shell: Shell;
-  readonly rcFile: string;
+  readonly pathFile: string;
+  readonly completionFile: string;
   readonly pathBlock: string;
   readonly completionBlock: string | undefined;
 }
@@ -108,10 +109,15 @@ const buildShellConfig = (
   shell: Shell,
   rcFile: string,
   installDir: string,
-  completionScript: string | undefined
+  completionScript: string | undefined,
+  homedir: string
 ): ShellConfig => ({
   shell,
-  rcFile,
+  pathFile: rcFile,
+  completionFile:
+    shell === 'fish'
+      ? path.join(homedir, '.config', 'fish', 'completions', 'composio.fish')
+      : rcFile,
   pathBlock: pathBlockForShell(shell, installDir),
   completionBlock: completionScript ? `${COMPLETIONS_MARKER}\n${completionScript}` : undefined,
 });
@@ -122,6 +128,18 @@ const fileContains = (contents: string, marker: string): boolean =>
 
 const tildify = (p: string, homedir: string): string =>
   p.startsWith(homedir + '/') ? `~/${p.slice(homedir.length + 1)}` : p;
+
+const readMaybeMissingFile = (
+  filePath: string,
+  fs: FileSystem.FileSystem
+): Effect.Effect<string, PlatformError> =>
+  fs
+    .readFileString(filePath)
+    .pipe(
+      Effect.catchAll(e =>
+        Effect.logDebug('File does not exist yet, will create:', e).pipe(Effect.as(''))
+      )
+    );
 
 // ---------------------------------------------------------------------------
 // Exported logic (reusable from install.sh post-install delegation)
@@ -186,23 +204,27 @@ export const installShellIntegration = (params: {
     }
 
     const rcFile = yield* resolveRcFile(rcFileCandidates(shell, os.homedir), fs);
-    const config = buildShellConfig(shell, rcFile, installDir, completionScript);
+    const config = buildShellConfig(shell, rcFile, installDir, completionScript, os.homedir);
 
-    // Read existing rc file (or empty if it doesn't exist yet)
-    const rcPath = config.rcFile;
-    const existing = yield* fs
-      .readFileString(rcPath)
-      .pipe(
-        Effect.catchAll(e =>
-          Effect.logDebug('RC file does not exist yet, will create:', e).pipe(Effect.as(''))
-        )
-      );
+    const uniqueTargetFiles = [...new Set([config.pathFile, config.completionFile])];
+    const existingByFile = new Map<string, string>();
+    for (const filePath of uniqueTargetFiles) {
+      existingByFile.set(filePath, yield* readMaybeMissingFile(filePath, fs));
+    }
 
-    // Build blocks to append (idempotently)
-    const blocks: string[] = [];
+    const blocksByFile = new Map<string, Array<string>>();
+    const pushBlock = (filePath: string, block: string) => {
+      const blocks = blocksByFile.get(filePath);
+      if (blocks) {
+        blocks.push(block);
+      } else {
+        blocksByFile.set(filePath, [block]);
+      }
+    };
 
-    if (!fileContains(existing, MARKER)) {
-      blocks.push(config.pathBlock);
+    const existingPathFile = existingByFile.get(config.pathFile) ?? '';
+    if (!fileContains(existingPathFile, MARKER)) {
+      pushBlock(config.pathFile, config.pathBlock);
       yield* ui.log.step(`PATH: will add ${tildify(installDir, os.homedir)} to $PATH`);
     } else {
       yield* ui.log.step('PATH: already configured');
@@ -212,42 +234,55 @@ export const installShellIntegration = (params: {
       yield* ui.log.step('Completions: skipped for zsh');
     } else if (!params.completions) {
       yield* ui.log.step('Completions: skipped by default (pass --completions to enable)');
-    } else if (config.completionBlock && !fileContains(existing, COMPLETIONS_MARKER)) {
-      blocks.push(config.completionBlock);
-      yield* ui.log.step('Completions: will install shell completions');
     } else if (!config.completionBlock) {
       yield* ui.log.step('Completions: not available for this shell');
     } else {
-      yield* ui.log.step('Completions: already configured');
+      const existingCompletionFile = existingByFile.get(config.completionFile) ?? '';
+      if (!fileContains(existingCompletionFile, COMPLETIONS_MARKER)) {
+        pushBlock(config.completionFile, config.completionBlock);
+        yield* ui.log.step(
+          config.shell === 'fish'
+            ? `Completions: will install fish completions to ${tildify(config.completionFile, os.homedir)}`
+            : 'Completions: will install shell completions'
+        );
+      } else {
+        yield* ui.log.step('Completions: already configured');
+      }
     }
 
-    if (blocks.length > 0) {
-      // Ensure parent directory exists (for fish config)
-      yield* fs
-        .makeDirectory(path.dirname(rcPath), { recursive: true })
-        .pipe(
-          Effect.catchAll(e =>
-            Effect.logDebug('Could not create parent directory (may already exist):', e)
-          )
-        );
+    if (blocksByFile.size > 0) {
+      for (const [filePath, blocks] of blocksByFile.entries()) {
+        const existingContents = existingByFile.get(filePath) ?? '';
 
-      const appendContent = '\n' + blocks.join('\n\n') + '\n';
+        yield* fs
+          .makeDirectory(path.dirname(filePath), { recursive: true })
+          .pipe(
+            Effect.catchAll(e =>
+              Effect.logDebug('Could not create parent directory (may already exist):', e)
+            )
+          );
 
-      // Atomic write: write to a temp file then rename, so a crash mid-write
-      // cannot leave the user's rc file truncated/corrupted.
-      const tmpPath = `${rcPath}.composio-tmp`;
-      yield* fs.writeFileString(tmpPath, existing + appendContent);
-      yield* fs.rename(tmpPath, rcPath);
+        const appendContent = '\n' + blocks.join('\n\n') + '\n';
+        const tmpPath = `${filePath}.composio-tmp`;
 
-      yield* ui.log.success(`Updated ${tildify(rcPath, os.homedir)}`);
-      yield* ui.note(
-        shell === 'fish' || shell === 'zsh'
-          ? `source ${tildify(rcPath, os.homedir)}`
-          : 'exec $SHELL',
-        'Restart your shell to apply changes'
-      );
+        yield* fs.writeFileString(tmpPath, existingContents + appendContent);
+        yield* fs.rename(tmpPath, filePath);
+
+        yield* ui.log.success(`Updated ${tildify(filePath, os.homedir)}`);
+      }
     } else {
       yield* ui.log.success('Shell integration already configured — nothing to do.');
+    }
+
+    if (blocksByFile.size > 0) {
+      yield* ui.note(
+        shell === 'fish'
+          ? 'exec fish'
+          : shell === 'zsh'
+            ? `source ${tildify(rcFile, os.homedir)}`
+            : 'exec $SHELL',
+        'Restart your shell to apply changes'
+      );
     }
 
     yield* ui.outro('Done');

--- a/ts/packages/cli/src/effects/shell-completions.ts
+++ b/ts/packages/cli/src/effects/shell-completions.ts
@@ -3,6 +3,24 @@ import { Effect } from 'effect';
 
 type Shell = 'bash' | 'zsh' | 'fish';
 
+const sanitizeFishCompletionLine = (line: string): string => {
+  if (!line.startsWith('complete ')) {
+    return line;
+  }
+
+  const descriptionIndex = line.indexOf(' -d ');
+  if (descriptionIndex === -1) {
+    return line;
+  }
+
+  // Fish descriptions are optional. Dropping them avoids parse errors from
+  // multiline or quote-heavy command descriptions emitted by the upstream generator.
+  return line.slice(0, descriptionIndex).trimEnd();
+};
+
+const sanitizeFishCompletionLines = (lines: Array<string>): Array<string> =>
+  lines.map(sanitizeFishCompletionLine);
+
 /**
  * Generate a shell completion script for the given command tree and shell type.
  * Uses @effect/cli's built-in completion generators.
@@ -17,6 +35,12 @@ export const getCompletionScript = <Name extends string, R, E, A>(
     case 'zsh':
       return Command.getZshCompletions(command, 'composio');
     case 'fish':
-      return Command.getFishCompletions(command, 'composio');
+      return Command.getFishCompletions(command, 'composio').pipe(
+        Effect.map(sanitizeFishCompletionLines)
+      );
   }
+};
+
+export const _test = {
+  sanitizeFishCompletionLine,
 };

--- a/ts/packages/cli/test/src/commands/install.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/install.cmd.test.ts
@@ -132,6 +132,47 @@ describe('CLI: composio install', () => {
     });
   });
 
+  describe('[When] fish shell installs completions', () => {
+    layer(TestLive())(it => {
+      it.scoped(
+        '[Then] keeps PATH setup in config.fish and writes completions to composio.fish',
+        () =>
+          Effect.gen(function* () {
+            const os = yield* NodeOs;
+            process.env.SHELL = '/usr/bin/fish';
+            process.env.COMPOSIO_INSTALL_DIR = path.join(os.homedir, '.composio');
+
+            yield* cli(['install', '--completions']);
+
+            const fs = yield* FileSystem.FileSystem;
+            const configPath = path.join(os.homedir, '.config', 'fish', 'config.fish');
+            const completionPath = path.join(
+              os.homedir,
+              '.config',
+              'fish',
+              'completions',
+              'composio.fish'
+            );
+            const configContents = yield* fs.readFileString(configPath);
+            const completionContents = yield* fs.readFileString(completionPath);
+
+            expect(configContents).toContain('# Composio CLI');
+            expect(configContents).toContain('set --export COMPOSIO_INSTALL_DIR');
+            expect(configContents).not.toContain('# Composio CLI completions');
+
+            expect(completionContents).toContain('# Composio CLI completions');
+
+            const lines = yield* MockConsole.getLines();
+            const output = lines.join('\n');
+            expect(output).toContain('Completions: will install fish completions to');
+            expect(output).toContain('Updated ~/.config/fish/config.fish');
+            expect(output).toContain('Updated ~/.config/fish/completions/composio.fish');
+            expect(output).toContain('exec fish');
+          })
+      );
+    });
+  });
+
   describe('[When] --no-completions is passed', () => {
     layer(TestLive())(it => {
       it.scoped('[Then] writes PATH block but skips completions', () =>

--- a/ts/packages/cli/test/src/effects/shell-completions.test.ts
+++ b/ts/packages/cli/test/src/effects/shell-completions.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { _test } from 'src/effects/shell-completions';
+
+describe('shell-completions', () => {
+  it('removes fish descriptions from completion commands', () => {
+    const line =
+      'complete -c composio -n "__fish_seen_subcommand_from orgs; and __fish_seen_subcommand_from switch" -l limit -r -f -d \'Max orgs to fetch from API (default: 50)\'';
+
+    expect(_test.sanitizeFishCompletionLine(line)).toBe(
+      'complete -c composio -n "__fish_seen_subcommand_from orgs; and __fish_seen_subcommand_from switch" -l limit -r -f'
+    );
+  });
+
+  it('preserves non-complete fish lines unchanged', () => {
+    const line = 'function __fish_composio_no_subcommand';
+
+    expect(_test.sanitizeFishCompletionLine(line)).toBe(line);
+  });
+
+  it('drops multiline descriptions before they can break fish parsing', () => {
+    const line = `complete -c composio -n "__fish_seen_subcommand_from dev" -l alias -r -f -d 'Line one
+line two with "quotes" and apostrophe'"'"'s'`;
+
+    expect(_test.sanitizeFishCompletionLine(line)).toBe(
+      'complete -c composio -n "__fish_seen_subcommand_from dev" -l alias -r -f'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Route fish shell completions to `~/.config/fish/completions/composio.fish` instead of writing them into the rc file.
- Keep fish PATH setup in `~/.config/fish/config.fish` while writing completion blocks to the dedicated completions file.
- Sanitize fish completion lines to strip description text that can break parsing, including multiline descriptions.
- Add tests covering fish install behavior and fish completion sanitization.

Closes #3147 

## Testing
- `pnpm test --filter ts/packages/cli/test/src/commands/install.cmd.test.ts`
- `pnpm test --filter ts/packages/cli/test/src/effects/shell-completions.test.ts`
- Not run: full repository test suite