### PR TITLE
fix: add alias to ToolRouterAuthorizeFn type

### DIFF
--- a/.changeset/fix-authorize-alias-type.md
+++ b/.changeset/fix-authorize-alias-type.md
@@ -1,0 +1,5 @@
+---
+"@composio/core": patch
+---
+
+Add missing `alias` option to `ToolRouterAuthorizeFn` type. The `ToolRouterSession.authorize()` implementation already accepted `alias`, but the exported type didn't include it, causing type errors when passing `{ alias: 'work-gmail' }` to `session.authorize()`.

--- a/ts/packages/core/src/types/toolRouter.types.ts
+++ b/ts/packages/core/src/types/toolRouter.types.ts
@@ -342,7 +342,7 @@ export type ToolRouterToolsFn<
 
 export type ToolRouterAuthorizeFn = (
   toolkit: string,
-  options?: { callbackUrl?: string }
+  options?: { callbackUrl?: string; alias?: string }
 ) => Promise<ConnectionRequest>;
 
 export const ToolRouterToolkitsOptionsSchema = z.object({


### PR DESCRIPTION
# Description
`ToolRouterAuthorizeFn` was missing the `alias` option that `Session.authorize` already supports. This caused type errors in docs code blocks that use `session.authorize('gmail', { alias: 'work-gmail' })`.

One-line fix: add `alias?: string` to the options type.

# How did I test this PR
- Verified `Session.authorize` already accepts `alias` in its type definition
- Confirmed `ToolRouterAuthorizeFn` is the type used by `ToolRouterSession.authorize` (returned by `composio.create()`)
- This fix aligns the two type definitions

Needed for docs PR #3160 to pass type checking.