### PR TITLE
fix: normalize toolkit logo URLs to use CDN

### DIFF
--- a/docs/public/data/toolkits-list.json
+++ b/docs/public/data/toolkits-list.json
@@ -1234,7 +1234,7 @@
   {
     "slug": "flutterwave",
     "name": "Flutterwave",
-    "logo": "https://flutterwave.com/favicon.ico",
+    "logo": "https://logos.composio.dev/api/flutterwave",
     "category": "payment processing",
     "toolCount": 53,
     "triggerCount": 0
@@ -1266,7 +1266,7 @@
   {
     "slug": "screenshotone",
     "name": "ScreenshotOne",
-    "logo": "https://screenshotone.com/logo.png",
+    "logo": "https://logos.composio.dev/api/screenshotone",
     "category": "developer tools",
     "toolCount": 5,
     "triggerCount": 0
@@ -2346,7 +2346,7 @@
   {
     "slug": "bestbuy",
     "name": "Bestbuy",
-    "logo": "https://developer.bestbuy.com/images/bestbuy-logo.png",
+    "logo": "https://logos.composio.dev/api/bestbuy",
     "category": "ecommerce",
     "toolCount": 8,
     "triggerCount": 0
@@ -2866,7 +2866,7 @@
   {
     "slug": "clockify",
     "name": "Clockify",
-    "logo": "https://clockify.me/assets/images/clockify-logo.svg",
+    "logo": "https://logos.composio.dev/api/clockify",
     "category": "time tracking software",
     "toolCount": 75,
     "triggerCount": 0
@@ -2890,7 +2890,7 @@
   {
     "slug": "cloudflare_api_key",
     "name": "Cloudflare Api Key",
-    "logo": "https://www.cloudflare.com/img/logo-cloudflare.svg",
+    "logo": "https://logos.composio.dev/api/cloudflare_api_key",
     "category": "security & identity tools",
     "toolCount": 25,
     "triggerCount": 0
@@ -2914,7 +2914,7 @@
   {
     "slug": "cloudlayer",
     "name": "Cloudlayer",
-    "logo": "https://cloudlayer.io/logo.png",
+    "logo": "https://logos.composio.dev/api/cloudlayer",
     "category": "documents",
     "toolCount": 16,
     "triggerCount": 0
@@ -2970,7 +2970,7 @@
   {
     "slug": "coinmarketcap",
     "name": "CoinMarketCap",
-    "logo": "https://s2.coinmarketcap.com/static/cloud/img/coinmarketcap_1.svg",
+    "logo": "https://logos.composio.dev/api/coinmarketcap",
     "category": "analytics",
     "toolCount": 9,
     "triggerCount": 0
@@ -2978,7 +2978,7 @@
   {
     "slug": "coinranking",
     "name": "Coinranking",
-    "logo": "https://coinranking.com/favicon.ico",
+    "logo": "https://logos.composio.dev/api/coinranking",
     "category": "analytics",
     "toolCount": 14,
     "triggerCount": 0
@@ -4074,7 +4074,7 @@
   {
     "slug": "fraudlabs_pro",
     "name": "FraudLabs Pro",
-    "logo": "https://www.fraudlabspro.com/images/logo.png",
+    "logo": "https://logos.composio.dev/api/fraudlabs_pro",
     "category": "payment processing",
     "toolCount": 8,
     "triggerCount": 0
@@ -4098,7 +4098,7 @@
   {
     "slug": "fullenrich",
     "name": "Fullenrich",
-    "logo": "https://gravatar.com/avatar/0d4b0c4b0c4b0c4b0c4b0c4b0c4b0c4b0",
+    "logo": "https://logos.composio.dev/api/fullenrich",
     "category": "contact management",
     "toolCount": 9,
     "triggerCount": 0
@@ -4154,7 +4154,7 @@
   {
     "slug": "genderapi_io",
     "name": "GenderAPI.io",
-    "logo": "https://genderapi.io/logo.png",
+    "logo": "https://logos.composio.dev/api/genderapi_io",
     "category": "developer tools",
     "toolCount": 5,
     "triggerCount": 0
@@ -4170,7 +4170,7 @@
   {
     "slug": "geoapify",
     "name": "Geoapify",
-    "logo": "https://www.geoapify.com/wp-content/uploads/2020/06/geoapify_logo.svg",
+    "logo": "https://logos.composio.dev/api/geoapify",
     "category": "developer tools",
     "toolCount": 25,
     "triggerCount": 0
@@ -4194,7 +4194,7 @@
   {
     "slug": "getform",
     "name": "Getform",
-    "logo": "https://getform.io/favicon.ico",
+    "logo": "https://logos.composio.dev/api/getform",
     "category": "forms & surveys",
     "toolCount": 2,
     "triggerCount": 0
@@ -4210,7 +4210,7 @@
   {
     "slug": "gift_up",
     "name": "Gift Up!",
-    "logo": "https://giftup.app/favicon.ico",
+    "logo": "https://logos.composio.dev/api/gift_up",
     "category": "ecommerce",
     "toolCount": 44,
     "triggerCount": 0
@@ -4226,7 +4226,7 @@
   {
     "slug": "giphy",
     "name": "Giphy",
-    "logo": "https://giphy.com/static/img/giphy_logo_square_social.png",
+    "logo": "https://logos.composio.dev/api/giphy",
     "category": "images & design",
     "toolCount": 23,
     "triggerCount": 0
@@ -4234,7 +4234,7 @@
   {
     "slug": "gist",
     "name": "Gist",
-    "logo": "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png",
+    "logo": "https://logos.composio.dev/api/gist",
     "category": "developer tools",
     "toolCount": 20,
     "triggerCount": 0
@@ -4258,7 +4258,7 @@
   {
     "slug": "givebutter",
     "name": "Givebutter",
-    "logo": "https://givebutter.com/favicon.ico",
+    "logo": "https://logos.composio.dev/api/givebutter",
     "category": "fundraising",
     "toolCount": 58,
     "triggerCount": 0
@@ -4266,7 +4266,7 @@
   {
     "slug": "gladia",
     "name": "Gladia",
-    "logo": "https://www.gladia.io/favicon.ico",
+    "logo": "https://logos.composio.dev/api/gladia",
     "category": "transcription",
     "toolCount": 10,
     "triggerCount": 0
@@ -4282,7 +4282,7 @@
   {
     "slug": "globalping",
     "name": "Globalping",
-    "logo": "https://globalping.io/logo.png",
+    "logo": "https://logos.composio.dev/api/globalping",
     "category": "server monitoring",
     "toolCount": 5,
     "triggerCount": 0
@@ -4290,7 +4290,7 @@
   {
     "slug": "godial",
     "name": "Godial",
-    "logo": "https://godial.cc/wp-content/uploads/2020/06/GoDial-Logo-1.png",
+    "logo": "https://logos.composio.dev/api/godial",
     "category": "crm",
     "toolCount": 24,
     "triggerCount": 0
@@ -4298,7 +4298,7 @@
   {
     "slug": "goodbits",
     "name": "Goodbits",
-    "logo": "https://goodbits.io/logo.png",
+    "logo": "https://logos.composio.dev/api/goodbits",
     "category": "email newsletters",
     "toolCount": 5,
     "triggerCount": 0
@@ -4306,7 +4306,7 @@
   {
     "slug": "goody",
     "name": "Goody",
-    "logo": "https://www.ongoody.com/favicon.ico",
+    "logo": "https://logos.composio.dev/api/goody",
     "category": "ecommerce",
     "toolCount": 13,
     "triggerCount": 0
@@ -4378,7 +4378,7 @@
   {
     "slug": "gosquared",
     "name": "Gosquared",
-    "logo": "https://www.gosquared.com/images/logo.png",
+    "logo": "https://logos.composio.dev/api/gosquared",
     "category": "analytics",
     "toolCount": 90,
     "triggerCount": 0
@@ -4394,7 +4394,7 @@
   {
     "slug": "grafbase",
     "name": "Grafbase",
-    "logo": "https://grafbase.com/favicon.ico",
+    "logo": "https://logos.composio.dev/api/grafbase",
     "category": "developer tools",
     "toolCount": 28,
     "triggerCount": 0
@@ -4410,7 +4410,7 @@
   {
     "slug": "graphhopper",
     "name": "Graphhopper",
-    "logo": "https://www.graphhopper.com/images/graphhopper_logo.svg",
+    "logo": "https://logos.composio.dev/api/graphhopper",
     "category": "developer tools",
     "toolCount": 13,
     "triggerCount": 0
@@ -4418,7 +4418,7 @@
   {
     "slug": "griptape",
     "name": "Griptape",
-    "logo": "https://www.griptape.ai/logo.png",
+    "logo": "https://logos.composio.dev/api/griptape",
     "category": "artificial intelligence",
     "toolCount": 143,
     "triggerCount": 0
@@ -4426,7 +4426,7 @@
   {
     "slug": "grist",
     "name": "Grist",
-    "logo": "https://www.getgrist.com/static/images/logo.svg",
+    "logo": "https://logos.composio.dev/api/grist",
     "category": "productivity",
     "toolCount": 30,
     "triggerCount": 0
@@ -4474,7 +4474,7 @@
   {
     "slug": "happy_scribe",
     "name": "Happy Scribe",
-    "logo": "https://www.happyscribe.com/favicon.ico",
+    "logo": "https://logos.composio.dev/api/happy_scribe",
     "category": "transcription",
     "toolCount": 20,
     "triggerCount": 0
@@ -4538,7 +4538,7 @@
   {
     "slug": "here",
     "name": "Here",
-    "logo": "https://www.here.com/etc.clientlibs/here/clientlibs/website/clientlib-site/resources/images/here-logo.svg",
+    "logo": "https://logos.composio.dev/api/here",
     "category": "developer tools",
     "toolCount": 99,
     "triggerCount": 0
@@ -4570,7 +4570,7 @@
   {
     "slug": "heyzine",
     "name": "Heyzine",
-    "logo": "https://heyzine.com/favicon.ico",
+    "logo": "https://logos.composio.dev/api/heyzine",
     "category": "documents",
     "toolCount": 14,
     "triggerCount": 0
@@ -4578,7 +4578,7 @@
   {
     "slug": "highergov",
     "name": "Highergov",
-    "logo": "https://www.highergov.com/favicon.ico",
+    "logo": "https://logos.composio.dev/api/highergov",
     "category": "business intelligence",
     "toolCount": 16,
     "triggerCount": 0
@@ -4594,7 +4594,7 @@
   {
     "slug": "honeyhive",
     "name": "Honeyhive",
-    "logo": "https://www.honeyhive.ai/logo.png",
+    "logo": "https://logos.composio.dev/api/honeyhive",
     "category": "artificial intelligence",
     "toolCount": 42,
     "triggerCount": 0
@@ -4618,7 +4618,7 @@
   {
     "slug": "html_to_image",
     "name": "HTML to Image",
-    "logo": "https://html2img.com/logo.png",
+    "logo": "https://logos.composio.dev/api/html_to_image",
     "category": "images & design",
     "toolCount": 3,
     "triggerCount": 0
@@ -4642,7 +4642,7 @@
   {
     "slug": "humanitix",
     "name": "Humanitix",
-    "logo": "https://humanitix.com/favicon.ico",
+    "logo": "https://logos.composio.dev/api/humanitix",
     "category": "event management",
     "toolCount": 3,
     "triggerCount": 0
@@ -4650,7 +4650,7 @@
   {
     "slug": "hunter",
     "name": "Hunter",
-    "logo": "https://logo.clearbit.com/hunter.io",
+    "logo": "https://logos.composio.dev/api/hunter",
     "category": "email",
     "toolCount": 26,
     "triggerCount": 0
@@ -4658,7 +4658,7 @@
   {
     "slug": "hypeauditor",
     "name": "Hypeauditor",
-    "logo": "https://hypeauditor.com/favicon.ico",
+    "logo": "https://logos.composio.dev/api/hypeauditor",
     "category": "social media marketing",
     "toolCount": 4,
     "triggerCount": 0
@@ -4674,7 +4674,7 @@
   {
     "slug": "hyperise",
     "name": "Hyperise",
-    "logo": "https://hyperise.com/images/logo.png",
+    "logo": "https://logos.composio.dev/api/hyperise",
     "category": "marketing automation",
     "toolCount": 5,
     "triggerCount": 0
@@ -4698,7 +4698,7 @@
   {
     "slug": "icypeas",
     "name": "Icypeas",
-    "logo": "https://www.icypeas.com/logo.png",
+    "logo": "https://logos.composio.dev/api/icypeas",
     "category": "email",
     "toolCount": 22,
     "triggerCount": 0
@@ -4714,7 +4714,7 @@
   {
     "slug": "ignisign",
     "name": "Ignisign",
-    "logo": "https://ignisign.io/logo.png",
+    "logo": "https://logos.composio.dev/api/ignisign",
     "category": "signatures",
     "toolCount": 32,
     "triggerCount": 0
@@ -4722,7 +4722,7 @@
   {
     "slug": "imagekit_io",
     "name": "ImageKit",
-    "logo": "https://imagekit.io/static/imagekit-logo.svg",
+    "logo": "https://logos.composio.dev/api/imagekit_io",
     "category": "images & design",
     "toolCount": 26,
     "triggerCount": 0
@@ -4746,7 +4746,7 @@
   {
     "slug": "imgbb",
     "name": "ImgBB",
-    "logo": "https://imgbb.com/favicon.ico",
+    "logo": "https://logos.composio.dev/api/imgbb",
     "category": "images & design",
     "toolCount": 2,
     "triggerCount": 0
@@ -4754,7 +4754,7 @@
   {
     "slug": "imgix",
     "name": "Imgix",
-    "logo": "https://assets.imgix.net/press/imgix-logo.png",
+    "logo": "https://logos.composio.dev/api/imgix",
     "category": "images & design",
     "toolCount": 53,
     "triggerCount": 0
@@ -4770,7 +4770,7 @@
   {
     "slug": "influxdb_cloud",
     "name": "InfluxDB Cloud",
-    "logo": "https://www.influxdata.com/wp-content/uploads/influxdata-logo.png",
+    "logo": "https://logos.composio.dev/api/influxdb_cloud",
     "category": "databases",
     "toolCount": 9,
     "triggerCount": 0
@@ -4802,7 +4802,7 @@
   {
     "slug": "instantly",
     "name": "Instantly",
-    "logo": "https://app.instantly.ai/favicon.ico",
+    "logo": "https://logos.composio.dev/api/instantly",
     "category": "drip emails",
     "toolCount": 117,
     "triggerCount": 0
@@ -4818,7 +4818,7 @@
   {
     "slug": "ip2location",
     "name": "Ip2Location",
-    "logo": "https://www.ip2location.io/images/logo.png",
+    "logo": "https://logos.composio.dev/api/ip2location",
     "category": "developer tools",
     "toolCount": 8,
     "triggerCount": 0
@@ -4842,7 +4842,7 @@
   {
     "slug": "ip2whois",
     "name": "Ip2Whois",
-    "logo": "https://www.ip2whois.com/images/logo.png",
+    "logo": "https://logos.composio.dev/api/ip2whois",
     "category": "security & identity tools",
     "toolCount": 2,
     "triggerCount": 0
@@ -4850,7 +4850,7 @@
   {
     "slug": "ipdata_co",
     "name": "Ipdata.co",
-    "logo": "https://ipdata.co/static/images/ipdata-logo.png",
+    "logo": "https://logos.composio.dev/api/ipdata_co",
     "category": "developer tools",
     "toolCount": 28,
     "triggerCount": 0
@@ -4858,7 +4858,7 @@
   {
     "slug": "ipinfo_io",
     "name": "Ipinfo.io",
-    "logo": "https://ipinfo.io/static/images/ipinfo-logo.png",
+    "logo": "https://logos.composio.dev/api/ipinfo_io",
     "category": "developer tools",
     "toolCount": 27,
     "triggerCount": 0
@@ -6866,7 +6866,7 @@
   {
     "slug": "seat_geek",
     "name": "Seat Geek",
-    "logo": "https://seatgeek.com/favicon.ico",
+    "logo": "https://logos.composio.dev/api/seat_geek",
     "category": "event management",
     "toolCount": 10,
     "triggerCount": 0
@@ -7490,7 +7490,7 @@
   {
     "slug": "tapfiliate",
     "name": "Tapfiliate",
-    "logo": "https://logo.clearbit.com/tapfiliate.com",
+    "logo": "https://logos.composio.dev/api/tapfiliate",
     "category": "marketing automation",
     "toolCount": 40,
     "triggerCount": 0
@@ -7562,7 +7562,7 @@
   {
     "slug": "test_app",
     "name": "Test app",
-    "logo": "https://cdn.jsdelivr.net/gh/ComposioHQ/open-logos@master/icons/testapp.png",
+    "logo": "https://logos.composio.dev/api/test_app",
     "category": "tag1",
     "toolCount": 2,
     "triggerCount": 0
@@ -7610,7 +7610,7 @@
   {
     "slug": "ticktick",
     "name": "Ticktick",
-    "logo": "https://ticktick.com/favicon.ico",
+    "logo": "https://logos.composio.dev/api/ticktick",
     "category": "productivity",
     "toolCount": 14,
     "triggerCount": 0
@@ -7882,7 +7882,7 @@
   {
     "slug": "veo",
     "name": "Veo",
-    "logo": "https://cdn.jsdelivr.net/gh/ComposioHQ/open-logos@master/gemini.svg",
+    "logo": "https://logos.composio.dev/api/veo",
     "category": "artificial intelligence",
     "toolCount": 5,
     "triggerCount": 0

--- a/docs/public/data/toolkits.json
+++ b/docs/public/data/toolkits.json
@@ -3,7 +3,7 @@
     "slug": "gmail",
     "name": "Gmail",
     "logo": "https://logos.composio.dev/api/gmail",
-    "description": "Gmail is Google’s email service, featuring spam protection, search functions, and seamless integration with other G Suite apps for productivity",
+    "description": "Gmail is Google\u2019s email service, featuring spam protection, search functions, and seamless integration with other G Suite apps for productivity",
     "category": "email",
     "authSchemes": [
       "OAUTH2"
@@ -33,7 +33,7 @@
       {
         "slug": "GMAIL_CREATE_EMAIL_DRAFT",
         "name": "Create email draft",
-        "description": "Creates a Gmail email draft. While all fields are optional per the Gmail API, practical validation requires at least one of recipient_email, cc, or bcc and at least one of subject or body. Supports To/Cc/Bcc recipients, subject, plain/HTML body (ensure `is_html=True` for HTML), attachments, and threading. Returns a draft_id that must be used as-is with GMAIL_SEND_DRAFT — synthetic or stale IDs will fail. When creating a draft reply to an existing thread (thread_id provided), leave subject empty to stay in the same thread; setting a subject will create a NEW thread instead. HTTP 429 may occur on rapid creation/send sequences; apply exponential backoff."
+        "description": "Creates a Gmail email draft. While all fields are optional per the Gmail API, practical validation requires at least one of recipient_email, cc, or bcc and at least one of subject or body. Supports To/Cc/Bcc recipients, subject, plain/HTML body (ensure `is_html=True` for HTML), attachments, and threading. Returns a draft_id that must be used as-is with GMAIL_SEND_DRAFT \u2014 synthetic or stale IDs will fail. When creating a draft reply to an existing thread (thread_id provided), leave subject empty to stay in the same thread; setting a subject will create a NEW thread instead. HTTP 429 may occur on rapid creation/send sequences; apply exponential backoff."
       },
       {
         "slug": "GMAIL_CREATE_FILTER",
@@ -43,7 +43,7 @@
       {
         "slug": "GMAIL_CREATE_LABEL",
         "name": "Create label",
-        "description": "Creates a new label with a unique name in the specified user's Gmail account. Returns a labelId (e.g., 'Label_123') required for downstream tools like GMAIL_ADD_LABEL_TO_EMAIL, GMAIL_BATCH_MODIFY_MESSAGES, and GMAIL_MODIFY_THREAD_LABELS — those tools do not accept display names."
+        "description": "Creates a new label with a unique name in the specified user's Gmail account. Returns a labelId (e.g., 'Label_123') required for downstream tools like GMAIL_ADD_LABEL_TO_EMAIL, GMAIL_BATCH_MODIFY_MESSAGES, and GMAIL_MODIFY_THREAD_LABELS \u2014 those tools do not accept display names."
       },
       {
         "slug": "GMAIL_DELETE_DRAFT",
@@ -83,17 +83,17 @@
       {
         "slug": "GMAIL_FETCH_MESSAGE_BY_THREAD_ID",
         "name": "Fetch Message by Thread ID",
-        "description": "Retrieves messages from a Gmail thread using its `thread_id`, where the thread must be accessible by the specified `user_id`. Returns a `messages` array; `thread_id` is not echoed in the response. Message order is not guaranteed — sort by `internalDate` to find oldest/newest. Check `labelIds` per message to filter drafts. Concurrent bulk calls may trigger 403 `userRateLimitExceeded` or 429; cap concurrency ~10 and use exponential backoff."
+        "description": "Retrieves messages from a Gmail thread using its `thread_id`, where the thread must be accessible by the specified `user_id`. Returns a `messages` array; `thread_id` is not echoed in the response. Message order is not guaranteed \u2014 sort by `internalDate` to find oldest/newest. Check `labelIds` per message to filter drafts. Concurrent bulk calls may trigger 403 `userRateLimitExceeded` or 429; cap concurrency ~10 and use exponential backoff."
       },
       {
         "slug": "GMAIL_FORWARD_MESSAGE",
         "name": "Forward email message",
-        "description": "Forward an existing Gmail message to specified recipients, preserving original body and attachments. Verify recipients and content before forwarding to avoid unintended exposure. Bulk forwarding may trigger 429/5xx rate limits; keep concurrency to 5–10 and apply backoff. Messages near Gmail's size limits may fail; reconstruct a smaller draft if needed."
+        "description": "Forward an existing Gmail message to specified recipients, preserving original body and attachments. Verify recipients and content before forwarding to avoid unintended exposure. Bulk forwarding may trigger 429/5xx rate limits; keep concurrency to 5\u201310 and apply backoff. Messages near Gmail's size limits may fail; reconstruct a smaller draft if needed."
       },
       {
         "slug": "GMAIL_GET_ATTACHMENT",
         "name": "Get Gmail attachment",
-        "description": "Retrieves a specific attachment by ID from a message in a user's Gmail mailbox, requiring valid message and attachment IDs. Returns base64url-encoded binary data (up to ~25 MB); the downloaded file location is at data.file.s3url (also exposes mimetype and name; no s3key). Attachments exceeding ~25 MB may be exposed as Google Drive links — use GOOGLEDRIVE_DOWNLOAD_FILE when a Drive file_id is present instead."
+        "description": "Retrieves a specific attachment by ID from a message in a user's Gmail mailbox, requiring valid message and attachment IDs. Returns base64url-encoded binary data (up to ~25 MB); the downloaded file location is at data.file.s3url (also exposes mimetype and name; no s3key). Attachments exceeding ~25 MB may be exposed as Google Drive links \u2014 use GOOGLEDRIVE_DOWNLOAD_FILE when a Drive file_id is present instead."
       },
       {
         "slug": "GMAIL_GET_AUTO_FORWARDING",
@@ -103,7 +103,7 @@
       {
         "slug": "GMAIL_GET_CONTACTS",
         "name": "Get contacts",
-        "description": "Fetches contacts (connections) for the authenticated Google account, allowing selection of specific data fields and pagination. Only covers saved contacts and 'Other Contacts'; email-header-only senders are out of scope. Contact records may have sparse data — handle missing fields gracefully. People API shares a per-user QPS quota; HTTP 429 requires exponential backoff (1s, 2s, 4s)."
+        "description": "Fetches contacts (connections) for the authenticated Google account, allowing selection of specific data fields and pagination. Only covers saved contacts and 'Other Contacts'; email-header-only senders are out of scope. Contact records may have sparse data \u2014 handle missing fields gracefully. People API shares a per-user QPS quota; HTTP 429 requires exponential backoff (1s, 2s, 4s)."
       },
       {
         "slug": "GMAIL_GET_DRAFT",
@@ -133,7 +133,7 @@
       {
         "slug": "GMAIL_GET_PROFILE",
         "name": "Get Profile",
-        "description": "Retrieves Gmail profile information (email address, aggregate messagesTotal/threadsTotal, historyId) for a user. messagesTotal counts individual emails; threadsTotal counts conversations; neither is per-label — use GMAIL_FETCH_EMAILS with label filters for label-specific counts. The returned historyId seeds incremental sync via GMAIL_LIST_HISTORY; if historyIdTooOld is returned, rescan with GMAIL_FETCH_EMAILS before resuming. Response may be wrapped under a top-level data field; unwrap before reading fields. A successful call confirms mailbox connectivity but not full mailbox access if granted scopes are narrow. Use the returned email address to dynamically identify the authenticated account rather than hard-coding it."
+        "description": "Retrieves Gmail profile information (email address, aggregate messagesTotal/threadsTotal, historyId) for a user. messagesTotal counts individual emails; threadsTotal counts conversations; neither is per-label \u2014 use GMAIL_FETCH_EMAILS with label filters for label-specific counts. The returned historyId seeds incremental sync via GMAIL_LIST_HISTORY; if historyIdTooOld is returned, rescan with GMAIL_FETCH_EMAILS before resuming. Response may be wrapped under a top-level data field; unwrap before reading fields. A successful call confirms mailbox connectivity but not full mailbox access if granted scopes are narrow. Use the returned email address to dynamically identify the authenticated account rather than hard-coding it."
       },
       {
         "slug": "GMAIL_GET_VACATION_SETTINGS",
@@ -183,7 +183,7 @@
       {
         "slug": "GMAIL_LIST_LABELS",
         "name": "List Gmail labels",
-        "description": "Retrieves all system and user-created labels for a Gmail account in a single unpaginated response. Primary use: obtain internal label IDs (e.g., 'Label_123') required by other Gmail tools — display names cannot be used as label identifiers and cause silent failures or errors. System labels (INBOX, UNREAD, SPAM, TRASH, etc.) are case-sensitive and must be used exactly as returned; INBOX, SPAM, and TRASH are read-only and cannot be added/removed via label modification tools. The Gmail search 'label:' operator accepts display names, but label_ids parameters in tools like GMAIL_FETCH_EMAILS require internal IDs from this tool — mixing conventions yields zero results silently. Do not hardcode label IDs across sessions; refresh via this tool on conflict errors."
+        "description": "Retrieves all system and user-created labels for a Gmail account in a single unpaginated response. Primary use: obtain internal label IDs (e.g., 'Label_123') required by other Gmail tools \u2014 display names cannot be used as label identifiers and cause silent failures or errors. System labels (INBOX, UNREAD, SPAM, TRASH, etc.) are case-sensitive and must be used exactly as returned; INBOX, SPAM, and TRASH are read-only and cannot be added/removed via label modification tools. The Gmail search 'label:' operator accepts display names, but label_ids parameters in tools like GMAIL_FETCH_EMAILS require internal IDs from this tool \u2014 mixing conventions yields zero results silently. Do not hardcode label IDs across sessions; refresh via this tool on conflict errors."
       },
       {
         "slug": "GMAIL_LIST_MESSAGES",
@@ -238,17 +238,17 @@
       {
         "slug": "GMAIL_SEARCH_PEOPLE",
         "name": "Search People",
-        "description": "Searches contacts by matching the query against names, nicknames, emails, phone numbers, and organizations, optionally including 'Other Contacts'. Only searches the authenticated user's contact directory — people existing solely in message headers won't appear; use GMAIL_FETCH_EMAILS for those. Results may be zero or multiple; never auto-select from ambiguous results. Results paginate via next_page_token; follow until empty and deduplicate by email. Many records lack emailAddresses or names even when requested — handle missing keys. Directory/organization policies may suppress entries."
+        "description": "Searches contacts by matching the query against names, nicknames, emails, phone numbers, and organizations, optionally including 'Other Contacts'. Only searches the authenticated user's contact directory \u2014 people existing solely in message headers won't appear; use GMAIL_FETCH_EMAILS for those. Results may be zero or multiple; never auto-select from ambiguous results. Results paginate via next_page_token; follow until empty and deduplicate by email. Many records lack emailAddresses or names even when requested \u2014 handle missing keys. Directory/organization policies may suppress entries."
       },
       {
         "slug": "GMAIL_SEND_DRAFT",
         "name": "Send Draft",
-        "description": "Sends an existing draft email AS-IS to recipients already defined within the draft. IMPORTANT: This action does NOT accept recipient parameters (to, cc, bcc). The Gmail API's drafts/send endpoint sends drafts to whatever recipients are already set in the draft's To, Cc, and Bcc headers - it cannot add or override recipients. If the draft has no recipients, you must either: 1. Create a new draft with recipients using GMAIL_CREATE_EMAIL_DRAFT, then send it 2. Use GMAIL_SEND_EMAIL to send a new email directly with recipients. Send is immediate and irreversible — confirm recipients and content before calling. No scheduling support; trigger at the desired UTC time externally. Gmail enforces ~25 MB message size limit and daily send caps (~500 recipients/day personal, ~2,000/day Workspace)."
+        "description": "Sends an existing draft email AS-IS to recipients already defined within the draft. IMPORTANT: This action does NOT accept recipient parameters (to, cc, bcc). The Gmail API's drafts/send endpoint sends drafts to whatever recipients are already set in the draft's To, Cc, and Bcc headers - it cannot add or override recipients. If the draft has no recipients, you must either: 1. Create a new draft with recipients using GMAIL_CREATE_EMAIL_DRAFT, then send it 2. Use GMAIL_SEND_EMAIL to send a new email directly with recipients. Send is immediate and irreversible \u2014 confirm recipients and content before calling. No scheduling support; trigger at the desired UTC time externally. Gmail enforces ~25 MB message size limit and daily send caps (~500 recipients/day personal, ~2,000/day Workspace)."
       },
       {
         "slug": "GMAIL_SEND_EMAIL",
         "name": "Send Email",
-        "description": "Sends an email via Gmail API using the authenticated user's Google profile display name. Sends immediately and is irreversible — confirm recipients, subject, body, and attachments before calling. At least one of 'to' (or 'recipient_email'), 'cc', or 'bcc' must be provided. At least one of subject or body must be provided. Requires `is_html=True` if the body contains HTML. All common file types including PNG, JPG, PDF, MP4, etc. are supported as attachments. Gmail API limits total message size to ~25 MB after base64 encoding. To reply in an existing thread, use GMAIL_REPLY_TO_THREAD instead. No scheduled send support; enforce timing externally."
+        "description": "Sends an email via Gmail API using the authenticated user's Google profile display name. Sends immediately and is irreversible \u2014 confirm recipients, subject, body, and attachments before calling. At least one of 'to' (or 'recipient_email'), 'cc', or 'bcc' must be provided. At least one of subject or body must be provided. Requires `is_html=True` if the body contains HTML. All common file types including PNG, JPG, PDF, MP4, etc. are supported as attachments. Gmail API limits total message size to ~25 MB after base64 encoding. To reply in an existing thread, use GMAIL_REPLY_TO_THREAD instead. No scheduled send support; enforce timing externally."
       },
       {
         "slug": "GMAIL_SETTINGS_GET_IMAP",
@@ -405,7 +405,7 @@
       {
         "slug": "COMPOSIO_CREATE_PLAN",
         "name": "Create Plan",
-        "description": "\nThis is a workflow builder that ensures the LLM produces a complete, step-by-step plan for any use case.\nWHEN TO CALL:\n- Call this tool based on COMPOSIO_SEARCH_TOOLS output. If search tools response indicates create_plan should be called and the usecase is not easy, call it.\n- Use this tool after COMPOSIO_SEARCH_TOOLS or COMPOSIO_MANAGE_CONNECTIONS to generate an execution plan for the user's use case.\n- USE for medium or hard tasks — skip it for easy ones.\n- If the user switches to a new use case in the same chat and COMPOSIO_SEARCH_TOOLS again instructs you to call the planner, you MUST call this tool again for that new use case.\n\nMemory Integration:\n- You can choose to add the memory received from the search tool into the known_fields parameter of the plan function to enhance planning with discovered relationships and information.\n\nOutputs a complete plan with sections such as \"workflow_steps\", \"complexity_assessment\", \"decision_matrix\", \"failure_handling\" \"output_format\", and more as needed.\n\nIf you skip this step for non-easy tasks, workflows will likely be incomplete, or fail during execution for complex tasks.\nCalling it guarantees reliable, accurate, and end-to-end workflows aligned with the available tools and connections.\n    "
+        "description": "\nThis is a workflow builder that ensures the LLM produces a complete, step-by-step plan for any use case.\nWHEN TO CALL:\n- Call this tool based on COMPOSIO_SEARCH_TOOLS output. If search tools response indicates create_plan should be called and the usecase is not easy, call it.\n- Use this tool after COMPOSIO_SEARCH_TOOLS or COMPOSIO_MANAGE_CONNECTIONS to generate an execution plan for the user's use case.\n- USE for medium or hard tasks \u2014 skip it for easy ones.\n- If the user switches to a new use case in the same chat and COMPOSIO_SEARCH_TOOLS again instructs you to call the planner, you MUST call this tool again for that new use case.\n\nMemory Integration:\n- You can choose to add the memory received from the search tool into the known_fields parameter of the plan function to enhance planning with discovered relationships and information.\n\nOutputs a complete plan with sections such as \"workflow_steps\", \"complexity_assessment\", \"decision_matrix\", \"failure_handling\" \"output_format\", and more as needed.\n\nIf you skip this step for non-easy tasks, workflows will likely be incomplete, or fail during execution for complex tasks.\nCalling it guarantees reliable, accurate, and end-to-end workflows aligned with the available tools and connections.\n    "
       },
       {
         "slug": "COMPOSIO_DOWNLOAD_S3_FILE",
@@ -470,12 +470,12 @@
       {
         "slug": "COMPOSIO_REMOTE_WORKBENCH",
         "name": "Execute Code remotely in work bench",
-        "description": "\n  Process **REMOTE FILES** or script BULK TOOL EXECUTIONS using Python code IN A REMOTE SANDBOX. If you can see the data in chat, DON'T USE THIS TOOL.\n**ONLY** use this when processing **data stored in a remote file** or when scripting bulk tool executions.\n\nDO NOT USE\n- When the complete response is already inline/in-memory, or you only need quick parsing, summarization, or basic math.\n\nUSE IF\n- To parse/analyze tool outputs saved to a remote file in the sandbox or to script multi-tool chains there.\n- For bulk or repeated executions of known Composio tools (e.g., add a label to 100 emails).\n- To call APIs via proxy_execute when no Composio tool exists for that API.\n\n\nOUTPUTS\n- Returns a compact result or, if too long, artifacts under `/home/user/.code_out`.\n\nIMPORTANT CODING RULES:\n  1. Stepwise Execution: Split work into small steps. Save intermediate outputs in variables or temporary file in `/tmp/`. Call COMPOSIO_REMOTE_WORKBENCH again for the next step. This improves composability and avoids timeouts.\n  2. Notebook Persistence: This is a persistent Jupyter notebook cell: variables, functions, imports, and in-memory state from previous and future code executions are preserved in the notebook's history and available for reuse. You also have a few helper functions available.\n  3. Parallelism & Timeout (CRITICAL): There is a hard timeout of 4 minutes so complete the code within that. Prioritize PARALLEL execution using ThreadPoolExecutor with suitable concurrency for bulk operations - e.g., call run_composio_tool or invoke_llm parallelly across rows to maximize efficiency.\n    3.1 If the data is large, split into smaller batches and call the workbench multiple times to avoid timeouts.\n  4. Checkpoints: Implement checkpoints (in memory or files) so that long runs can be resumed from the last completed step.\n  5. Schema Safety: Never assume the response schema for run_composio_tool if not known already from previous tools. To inspect schema, either run a simple request **outside** the workbench via COMPOSIO_MULTI_EXECUTE_TOOL or use invoke_llm helper.\n  6. LLM Helpers: Always use invoke_llm helper for summary, analysis, or field extraction on results. This is a smart LLM that will give much better results than any adhoc filtering.\n  7. Avoid Meta Loops: Do not use run_composio_tool to call COMPOSIO_MULTI_EXECUTE_TOOL or other COMPOSIO_* meta tools to avoid cycles. Only use it for app tools.\n  8. Pagination: Use when data spans multiple pages. Continue fetching pages with the returned next_page_token or cursor until none remains. Parallelize fetching pages if tool supports page_number.\n  9. No Hardcoding: Never hardcode data in code. Always load it from files or tool responses, iterating to construct intermediate or final inputs/outputs.\n  10. If the final output is in a workbench file, use upload_local_file to download it - never expose the raw workbench file path to the user. Prefer to download useful artifacts after task is complete.\n\n\nENV & HELPERS:\n- Home directory: `/home/user`.\n- NOTE: Helper functions already initialized in the workbench - DO NOT import or redeclare them:\n    - \n`run_composio_tool(tool_slug: str, arguments: dict) -> tuple[Dict[str, Any], str]`: Execute a known Composio **app** tool (from COMPOSIO_SEARCH_TOOLS). Do not invent names; match the tool's input schema. Suited for loops/parallel/bulk over datasets.\n      i) run_composio_tool returns JSON with top-level \"data\". Parse carefully—structure may be nested.\n    \n    - \n`invoke_llm(query: str) -> tuple[str, str]`: Invoke an LLM for semantic tasks. Pass MAX 200k characters in input.\n      i) NOTE Prompting guidance: When building prompts for invoke_llm, prefer f-strings (or concatenation) so literal braces stay intact. If using str.format, escape braces by doubling them ({{ }}).\n      ii) Define the exact JSON schema you want and batch items into smaller groups to stay within token limit.\n\n    - `upload_local_file(*file_paths) -> tuple[Dict[str, Any], str]`: Upload files in workbench to Composio S3/R2 storage. Use this to download any generated files/artifacts from the workbench.\n    - `proxy_execute(method, endpoint, toolkit, query_params=None, body=None, headers=None) -> tuple[Any, str]`: Call a toolkit API directly when no Composio tool exists. Only one toolkit can be invoked with proxy_execute per workbench call\n    - `web_search(query: str) -> tuple[str, str]`: Search the web for information.\n    - `smart_file_extract(sandbox_file_path: str, show_preview: bool = True) -> tuple[str, str]`: Extracts text from files in the sandbox (e.g., PDF, image).\n    - Workbench comes with comprehensive Image Processing (PIL/Pillow, OpenCV, scikit-image), PyTorch ML libraries, Document and Report handling tools (pandoc, python-docx, pdfplumber, reportlab), and standard Data Analysis tools (pandas, numpy, matplotlib) for advanced visual, analytical, and AI tasks.\n  All helper functions return a tuple (result, error). Always check error before using result.\n\n## Python Helper Functions for LLM Scripting\n\n\n### run_composio_tool(tool_slug, arguments)\nExecutes a known Composio tool via backend API. Do NOT call COMPOSIO_* meta tools to avoid cyclic calls.\n\n    def run_composio_tool(tool_slug: str, arguments: Dict[str, Any]) -> tuple[Dict[str, Any], str]\n    # Returns: (tool_response_dict, error_message)\n    #   Success: ({\"data\": {actual_data}}, \"\") - Note the top-level data\n    #   Error:   ({}, \"error_message\") or (response_data, \"error_message\")\n\n    result, error = run_composio_tool(\"GMAIL_FETCH_EMAILS\", {\"max_results\": 1, \"user_id\": \"me\"})\n    if error:\n        print(\"GMAIL_FETCH_EMAILS error:\", error); return\n    email_data = result.get(\"data\", {})\n    print(\"Fetched:\", email_data)\n    \n\n\n### invoke_llm(query)\nCalls LLM for reasoning, analysis, and semantic tasks. Pass MAX 200k characters input.\n\n    def invoke_llm(query: str) -> tuple[str, str]\n    # Returns: (llm_response, error_message)\n\n    resp, error = invoke_llm(\"Summarize the key points from this data\")\n    if not error:\n      print(\"LLM:\", resp)\n\n    # Example: analyze tool response with LLM\n    tool_resp, err = run_composio_tool(\"GMAIL_FETCH_EMAILS\", {\"max_results\": 5, \"user_id\": \"me\"})\n    if not err:\n      parsed = tool_resp.get(\"data\", {})\n      resp, err2 = invoke_llm(f\"Analyze these emails and summarize: {parsed}\")\n      if not err2:\n        print(\"LLM Gmail Summary:\", resp)\n    # TIP: batch prompts to reduce LLM calls.\n    \n\n\n### upload_local_file(*file_paths)\nUploads sandbox files to Composio S3/R2 storage. Single files upload directly, multiple files are auto-zipped.\nUse this when you need to upload/download any generated artifacts from the sandbox.\n\n    def upload_local_file(*file_paths) -> tuple[Dict[str, Any], str]\n    # Returns: (result_dict, error_string)\n    # Success: ({\"s3_url\": str, \"uploaded_file\": str, \"type\": str, \"id\": str, \"s3key\": str, \"message\": str}, \"\")\n    # Error: ({}, \"error_message\")\n\n    # Single file\n    result, error = upload_local_file(\"/path/to/report.pdf\")\n\n    # Multiple files (auto-zipped)\n    result, error = upload_local_file(\"/home/user/doc1.txt\", \"/home/user/doc2.txt\")\n\n    if not error:\n      print(\"Uploaded:\", result[\"s3_url\"])\n\n\n### proxy_execute(method, endpoint, toolkit, query_params=None, body=None, headers=None)\nDirect API call to a connected toolkit service.\n\n    def proxy_execute(\n        method: Literal[\"GET\",\"POST\",\"PUT\",\"DELETE\",\"PATCH\"],\n        endpoint: str,\n        toolkit: str,\n        query_params: Optional[Dict[str, str]] = None,\n        body: Optional[object] = None,\n        headers: Optional[Dict[str, str]] = None,\n    ) -> tuple[Any, str]\n    # Returns: (response_data, error_message)\n\n    # Example: GET request with query parameters\n    query_params = {\"q\": \"is:unread\", \"maxResults\": \"10\"}\n    data, error = proxy_execute(\"GET\", \"/gmail/v1/users/me/messages\", \"gmail\", query_params=query_params)\n    if not error:\n      print(\"Success:\", data)\n\n\n### web_search(query)\nSearches the web via Exa AI.\n\n    def web_search(query: str) -> tuple[str, str]\n    # Returns: (search_results_text, error_message)\n\n    results, error = web_search(\"latest developments in AI\")\n    if not error:\n        print(\"Results:\", results)\n\n## Best Practices\n\n\n### Error-first pattern and Defensive parsing (print keys while narrowing)\n    res, err = run_composio_tool(\"GMAIL_FETCH_EMAILS\", {\"max_results\": 5})\n    if err:\n        print(\"error:\", err); return\n    if isinstance(res, dict):\n        print(\"res keys:\", list(res.keys()))\n        data = res.get(\"data\") or {}\n        print(\"data keys:\", list(data.keys()))\n        msgs = data.get(\"messages\") or []\n        print(\"messages count:\", len(msgs))\n        for m in msgs:\n            print(\"subject:\", m.get(\"subject\", \"<missing>\"))\n\n### Parallelize (4-min sandbox timeout)\nAdjust concurrency so all tasks finish within 4 minutes.\n\n    import concurrent.futures\n\n    MAX_CONCURRENCY = 10 # Adjust as needed\n\n    def send_bulk_emails(email_list):\n        def send_single(email):\n            result, error = run_composio_tool(\"GMAIL_SEND_EMAIL\", {\n                \"to\": email[\"recipient\"], \"subject\": email[\"subject\"], \"body\": email[\"body\"]\n            })\n            if error:\n                print(f\"Failed {email['recipient']}: {error}\")\n                return {\"status\": \"failed\", \"error\": error}\n            return {\"status\": \"sent\", \"data\": result}\n\n        results = []\n        with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_CONCURRENCY) as ex:\n            futures = [ex.submit(send_single, e) for e in email_list]\n            for f in concurrent.futures.as_completed(futures):\n                results.append(f.result())\n        return results\n\n    email_list = [{\"recipient\": f\"user{i}@example.com\", \"subject\": \"Test\", \"body\": \"Hello\"} for i in range(1000)]\n    results = send_bulk_emails(email_list)\n    \n\n    "
+        "description": "\n  Process **REMOTE FILES** or script BULK TOOL EXECUTIONS using Python code IN A REMOTE SANDBOX. If you can see the data in chat, DON'T USE THIS TOOL.\n**ONLY** use this when processing **data stored in a remote file** or when scripting bulk tool executions.\n\nDO NOT USE\n- When the complete response is already inline/in-memory, or you only need quick parsing, summarization, or basic math.\n\nUSE IF\n- To parse/analyze tool outputs saved to a remote file in the sandbox or to script multi-tool chains there.\n- For bulk or repeated executions of known Composio tools (e.g., add a label to 100 emails).\n- To call APIs via proxy_execute when no Composio tool exists for that API.\n\n\nOUTPUTS\n- Returns a compact result or, if too long, artifacts under `/home/user/.code_out`.\n\nIMPORTANT CODING RULES:\n  1. Stepwise Execution: Split work into small steps. Save intermediate outputs in variables or temporary file in `/tmp/`. Call COMPOSIO_REMOTE_WORKBENCH again for the next step. This improves composability and avoids timeouts.\n  2. Notebook Persistence: This is a persistent Jupyter notebook cell: variables, functions, imports, and in-memory state from previous and future code executions are preserved in the notebook's history and available for reuse. You also have a few helper functions available.\n  3. Parallelism & Timeout (CRITICAL): There is a hard timeout of 4 minutes so complete the code within that. Prioritize PARALLEL execution using ThreadPoolExecutor with suitable concurrency for bulk operations - e.g., call run_composio_tool or invoke_llm parallelly across rows to maximize efficiency.\n    3.1 If the data is large, split into smaller batches and call the workbench multiple times to avoid timeouts.\n  4. Checkpoints: Implement checkpoints (in memory or files) so that long runs can be resumed from the last completed step.\n  5. Schema Safety: Never assume the response schema for run_composio_tool if not known already from previous tools. To inspect schema, either run a simple request **outside** the workbench via COMPOSIO_MULTI_EXECUTE_TOOL or use invoke_llm helper.\n  6. LLM Helpers: Always use invoke_llm helper for summary, analysis, or field extraction on results. This is a smart LLM that will give much better results than any adhoc filtering.\n  7. Avoid Meta Loops: Do not use run_composio_tool to call COMPOSIO_MULTI_EXECUTE_TOOL or other COMPOSIO_* meta tools to avoid cycles. Only use it for app tools.\n  8. Pagination: Use when data spans multiple pages. Continue fetching pages with the returned next_page_token or cursor until none remains. Parallelize fetching pages if tool supports page_number.\n  9. No Hardcoding: Never hardcode data in code. Always load it from files or tool responses, iterating to construct intermediate or final inputs/outputs.\n  10. If the final output is in a workbench file, use upload_local_file to download it - never expose the raw workbench file path to the user. Prefer to download useful artifacts after task is complete.\n\n\nENV & HELPERS:\n- Home directory: `/home/user`.\n- NOTE: Helper functions already initialized in the workbench - DO NOT import or redeclare them:\n    - \n`run_composio_tool(tool_slug: str, arguments: dict) -> tuple[Dict[str, Any], str]`: Execute a known Composio **app** tool (from COMPOSIO_SEARCH_TOOLS). Do not invent names; match the tool's input schema. Suited for loops/parallel/bulk over datasets.\n      i) run_composio_tool returns JSON with top-level \"data\". Parse carefully\u2014structure may be nested.\n    \n    - \n`invoke_llm(query: str) -> tuple[str, str]`: Invoke an LLM for semantic tasks. Pass MAX 200k characters in input.\n      i) NOTE Prompting guidance: When building prompts for invoke_llm, prefer f-strings (or concatenation) so literal braces stay intact. If using str.format, escape braces by doubling them ({{ }}).\n      ii) Define the exact JSON schema you want and batch items into smaller groups to stay within token limit.\n\n    - `upload_local_file(*file_paths) -> tuple[Dict[str, Any], str]`: Upload files in workbench to Composio S3/R2 storage. Use this to download any generated files/artifacts from the workbench.\n    - `proxy_execute(method, endpoint, toolkit, query_params=None, body=None, headers=None) -> tuple[Any, str]`: Call a toolkit API directly when no Composio tool exists. Only one toolkit can be invoked with proxy_execute per workbench call\n    - `web_search(query: str) -> tuple[str, str]`: Search the web for information.\n    - `smart_file_extract(sandbox_file_path: str, show_preview: bool = True) -> tuple[str, str]`: Extracts text from files in the sandbox (e.g., PDF, image).\n    - Workbench comes with comprehensive Image Processing (PIL/Pillow, OpenCV, scikit-image), PyTorch ML libraries, Document and Report handling tools (pandoc, python-docx, pdfplumber, reportlab), and standard Data Analysis tools (pandas, numpy, matplotlib) for advanced visual, analytical, and AI tasks.\n  All helper functions return a tuple (result, error). Always check error before using result.\n\n## Python Helper Functions for LLM Scripting\n\n\n### run_composio_tool(tool_slug, arguments)\nExecutes a known Composio tool via backend API. Do NOT call COMPOSIO_* meta tools to avoid cyclic calls.\n\n    def run_composio_tool(tool_slug: str, arguments: Dict[str, Any]) -> tuple[Dict[str, Any], str]\n    # Returns: (tool_response_dict, error_message)\n    #   Success: ({\"data\": {actual_data}}, \"\") - Note the top-level data\n    #   Error:   ({}, \"error_message\") or (response_data, \"error_message\")\n\n    result, error = run_composio_tool(\"GMAIL_FETCH_EMAILS\", {\"max_results\": 1, \"user_id\": \"me\"})\n    if error:\n        print(\"GMAIL_FETCH_EMAILS error:\", error); return\n    email_data = result.get(\"data\", {})\n    print(\"Fetched:\", email_data)\n    \n\n\n### invoke_llm(query)\nCalls LLM for reasoning, analysis, and semantic tasks. Pass MAX 200k characters input.\n\n    def invoke_llm(query: str) -> tuple[str, str]\n    # Returns: (llm_response, error_message)\n\n    resp, error = invoke_llm(\"Summarize the key points from this data\")\n    if not error:\n      print(\"LLM:\", resp)\n\n    # Example: analyze tool response with LLM\n    tool_resp, err = run_composio_tool(\"GMAIL_FETCH_EMAILS\", {\"max_results\": 5, \"user_id\": \"me\"})\n    if not err:\n      parsed = tool_resp.get(\"data\", {})\n      resp, err2 = invoke_llm(f\"Analyze these emails and summarize: {parsed}\")\n      if not err2:\n        print(\"LLM Gmail Summary:\", resp)\n    # TIP: batch prompts to reduce LLM calls.\n    \n\n\n### upload_local_file(*file_paths)\nUploads sandbox files to Composio S3/R2 storage. Single files upload directly, multiple files are auto-zipped.\nUse this when you need to upload/download any generated artifacts from the sandbox.\n\n    def upload_local_file(*file_paths) -> tuple[Dict[str, Any], str]\n    # Returns: (result_dict, error_string)\n    # Success: ({\"s3_url\": str, \"uploaded_file\": str, \"type\": str, \"id\": str, \"s3key\": str, \"message\": str}, \"\")\n    # Error: ({}, \"error_message\")\n\n    # Single file\n    result, error = upload_local_file(\"/path/to/report.pdf\")\n\n    # Multiple files (auto-zipped)\n    result, error = upload_local_file(\"/home/user/doc1.txt\", \"/home/user/doc2.txt\")\n\n    if not error:\n      print(\"Uploaded:\", result[\"s3_url\"])\n\n\n### proxy_execute(method, endpoint, toolkit, query_params=None, body=None, headers=None)\nDirect API call to a connected toolkit service.\n\n    def proxy_execute(\n        method: Literal[\"GET\",\"POST\",\"PUT\",\"DELETE\",\"PATCH\"],\n        endpoint: str,\n        toolkit: str,\n        query_params: Optional[Dict[str, str]] = None,\n        body: Optional[object] = None,\n        headers: Optional[Dict[str, str]] = None,\n    ) -> tuple[Any, str]\n    # Returns: (response_data, error_message)\n\n    # Example: GET request with query parameters\n    query_params = {\"q\": \"is:unread\", \"maxResults\": \"10\"}\n    data, error = proxy_execute(\"GET\", \"/gmail/v1/users/me/messages\", \"gmail\", query_params=query_params)\n    if not error:\n      print(\"Success:\", data)\n\n\n### web_search(query)\nSearches the web via Exa AI.\n\n    def web_search(query: str) -> tuple[str, str]\n    # Returns: (search_results_text, error_message)\n\n    results, error = web_search(\"latest developments in AI\")\n    if not error:\n        print(\"Results:\", results)\n\n## Best Practices\n\n\n### Error-first pattern and Defensive parsing (print keys while narrowing)\n    res, err = run_composio_tool(\"GMAIL_FETCH_EMAILS\", {\"max_results\": 5})\n    if err:\n        print(\"error:\", err); return\n    if isinstance(res, dict):\n        print(\"res keys:\", list(res.keys()))\n        data = res.get(\"data\") or {}\n        print(\"data keys:\", list(data.keys()))\n        msgs = data.get(\"messages\") or []\n        print(\"messages count:\", len(msgs))\n        for m in msgs:\n            print(\"subject:\", m.get(\"subject\", \"<missing>\"))\n\n### Parallelize (4-min sandbox timeout)\nAdjust concurrency so all tasks finish within 4 minutes.\n\n    import concurrent.futures\n\n    MAX_CONCURRENCY = 10 # Adjust as needed\n\n    def send_bulk_emails(email_list):\n        def send_single(email):\n            result, error = run_composio_tool(\"GMAIL_SEND_EMAIL\", {\n                \"to\": email[\"recipient\"], \"subject\": email[\"subject\"], \"body\": email[\"body\"]\n            })\n            if error:\n                print(f\"Failed {email['recipient']}: {error}\")\n                return {\"status\": \"failed\", \"error\": error}\n            return {\"status\": \"sent\", \"data\": result}\n\n        results = []\n        with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_CONCURRENCY) as ex:\n            futures = [ex.submit(send_single, e) for e in email_list]\n            for f in concurrent.futures.as_completed(futures):\n                results.append(f.result())\n        return results\n\n    email_list = [{\"recipient\": f\"user{i}@example.com\", \"subject\": \"Test\", \"body\": \"Hello\"} for i in range(1000)]\n    results = send_bulk_emails(email_list)\n    \n\n    "
       },
       {
         "slug": "COMPOSIO_SEARCH_TOOLS",
         "name": "Search Composio Tools",
-        "description": "\n  MCP Server Info: COMPOSIO MCP connects 500+ apps—Slack, GitHub, Notion, Google Workspace (Gmail, Sheets, Drive, Calendar), Microsoft (Outlook, Teams), X/Twitter, Figma, Web Search / Deep research, Browser tool (scrape URLs, browser automation), Meta apps (Instagram, Meta Ads), TikTok, AI tools like Nano Banana & Veo3, and more—for seamless cross-app automation.\n  Use this MCP server to discover the right tools and the recommended step-by-step plan to execute reliably.\n  ALWAYS call this tool first whenever a user mentions or implies an external app, service, or workflow—never say \"I don't have access to X/Y app\" before calling it.\n\n  Tool Info: Extremely fast discovery tool that returns relevant MCP-callable tools along with a recommended execution plan and common pitfalls for reliable execution.\n\nUsage guidelines:\n  - Use this tool whenever kicking off a task. Re-run it when you need additional tools/plans due to missing details, errors, or a changed use case.\n  - If the user pivots to a different use case in same chat, you MUST call this tool again with the new use case and generate a new session_id.\n  - Specify the use_case with a normalized description of the problem, query, or task. Be clear and precise. Queries can be simple single-app actions or multiple linked queries for complex cross-app workflows.\n  - Pass known_fields along with use_case as a string of key–value hints (for example, \"channel_name: general\") to help the search resolve missing details such as IDs.\n  \n\nSplitting guidelines (Important):\n  1. Atomic queries: 1 query = 1 tool call. Include hidden prerequisites (e.g., add \"get Linear issue\" before \"update Linear issue\").\n  2. Include app names: If user names a toolkit, include it in every sub query so intent stays scoped (e.g., \"fetch Gmail emails\", \"reply to Gmail email\").\n  3. English input: Translate non-English prompts while preserving intent and identifiers.\n\n  Example:\n  User query: \"send an email to John welcoming him and create a meeting invite for tomorrow\"\n  Search call: queries: [\n    {use_case: \"send an email to someone\", known_fields: \"recipient_name: John\"},\n    {use_case: \"create a meeting invite\", known_fields: \"meeting_date: tomorrow\"}\n  ]\n\nPlan review checklist (Important):\n  - The response includes a detailed execution plan and common pitfalls. You MUST review this plan carefully, adapt it to your current context, and generate your own final step-by-step plan before execution. Execute the steps in order to ensure reliable and accurate execution. Skipping or ignoring required steps can lead to unexpected failures.\n  - Check the plan and pitfalls for input parameter nuances (required fields, IDs, formats, limits). Before executing any tool, you MUST review its COMPLETE input schema and provide STRICTLY schema-compliant arguments to avoid invalid-input errors.\n  - Determine whether pagination is needed; if a response returns a pagination token and completeness is implied, paginate until exhaustion and do not return partial results.\n\nResponse:\n  - Tools & Input Schemas: The response lists toolkits (apps) and tools suitable for the task, along with their tool_slug, description, input schema / schemaRef, and related tools for prerequisites, alternatives, or next steps.\n    - NOTE: Tools with schemaRef instead of input_schema require you to call COMPOSIO_GET_TOOL_SCHEMAS first to load their full input_schema before use.\n  - Connection Info: If a toolkit has an active connection, the response includes it along with any available current user information. If no active connection exists, you MUST initiate a new connection via COMPOSIO_MANAGE_CONNECTIONS with the correct toolkit name. DO NOT execute any toolkit tool without an ACTIVE connection.\n  - Time Info: The response includes the current UTC time for reference. You can reference UTC time from the response if needed.\n  - The tools returned to you through this are to be called via COMPOSIO_MULTI_EXECUTE_TOOL. Ensure each tool execution specifies the correct tool_slug and arguments exactly as defined by the tool's input schema.\n    - The response includes a memory parameter containing relevant information about the use case and the known fields that can be used to determine the flow of execution. Any user preferences in memory must be adhered to.\n\nSESSION: ALWAYS set this parameter, first for any workflow. Pass session: {generate_id: true} for new workflows OR session: {id: \"EXISTING_ID\"} to continue. ALWAYS use the returned session_id in ALL subsequent meta tool calls.\n    "
+        "description": "\n  MCP Server Info: COMPOSIO MCP connects 500+ apps\u2014Slack, GitHub, Notion, Google Workspace (Gmail, Sheets, Drive, Calendar), Microsoft (Outlook, Teams), X/Twitter, Figma, Web Search / Deep research, Browser tool (scrape URLs, browser automation), Meta apps (Instagram, Meta Ads), TikTok, AI tools like Nano Banana & Veo3, and more\u2014for seamless cross-app automation.\n  Use this MCP server to discover the right tools and the recommended step-by-step plan to execute reliably.\n  ALWAYS call this tool first whenever a user mentions or implies an external app, service, or workflow\u2014never say \"I don't have access to X/Y app\" before calling it.\n\n  Tool Info: Extremely fast discovery tool that returns relevant MCP-callable tools along with a recommended execution plan and common pitfalls for reliable execution.\n\nUsage guidelines:\n  - Use this tool whenever kicking off a task. Re-run it when you need additional tools/plans due to missing details, errors, or a changed use case.\n  - If the user pivots to a different use case in same chat, you MUST call this tool again with the new use case and generate a new session_id.\n  - Specify the use_case with a normalized description of the problem, query, or task. Be clear and precise. Queries can be simple single-app actions or multiple linked queries for complex cross-app workflows.\n  - Pass known_fields along with use_case as a string of key\u2013value hints (for example, \"channel_name: general\") to help the search resolve missing details such as IDs.\n  \n\nSplitting guidelines (Important):\n  1. Atomic queries: 1 query = 1 tool call. Include hidden prerequisites (e.g., add \"get Linear issue\" before \"update Linear issue\").\n  2. Include app names: If user names a toolkit, include it in every sub query so intent stays scoped (e.g., \"fetch Gmail emails\", \"reply to Gmail email\").\n  3. English input: Translate non-English prompts while preserving intent and identifiers.\n\n  Example:\n  User query: \"send an email to John welcoming him and create a meeting invite for tomorrow\"\n  Search call: queries: [\n    {use_case: \"send an email to someone\", known_fields: \"recipient_name: John\"},\n    {use_case: \"create a meeting invite\", known_fields: \"meeting_date: tomorrow\"}\n  ]\n\nPlan review checklist (Important):\n  - The response includes a detailed execution plan and common pitfalls. You MUST review this plan carefully, adapt it to your current context, and generate your own final step-by-step plan before execution. Execute the steps in order to ensure reliable and accurate execution. Skipping or ignoring required steps can lead to unexpected failures.\n  - Check the plan and pitfalls for input parameter nuances (required fields, IDs, formats, limits). Before executing any tool, you MUST review its COMPLETE input schema and provide STRICTLY schema-compliant arguments to avoid invalid-input errors.\n  - Determine whether pagination is needed; if a response returns a pagination token and completeness is implied, paginate until exhaustion and do not return partial results.\n\nResponse:\n  - Tools & Input Schemas: The response lists toolkits (apps) and tools suitable for the task, along with their tool_slug, description, input schema / schemaRef, and related tools for prerequisites, alternatives, or next steps.\n    - NOTE: Tools with schemaRef instead of input_schema require you to call COMPOSIO_GET_TOOL_SCHEMAS first to load their full input_schema before use.\n  - Connection Info: If a toolkit has an active connection, the response includes it along with any available current user information. If no active connection exists, you MUST initiate a new connection via COMPOSIO_MANAGE_CONNECTIONS with the correct toolkit name. DO NOT execute any toolkit tool without an ACTIVE connection.\n  - Time Info: The response includes the current UTC time for reference. You can reference UTC time from the response if needed.\n  - The tools returned to you through this are to be called via COMPOSIO_MULTI_EXECUTE_TOOL. Ensure each tool execution specifies the correct tool_slug and arguments exactly as defined by the tool's input schema.\n    - The response includes a memory parameter containing relevant information about the use case and the known fields that can be used to determine the flow of execution. Any user preferences in memory must be adhered to.\n\nSESSION: ALWAYS set this parameter, first for any workflow. Pass session: {generate_id: true} for new workflows OR session: {id: \"EXISTING_ID\"} to continue. ALWAYS use the returned session_id in ALL subsequent meta tool calls.\n    "
       },
       {
         "slug": "COMPOSIO_WAIT_FOR_CONNECTION",
@@ -485,7 +485,7 @@
       {
         "slug": "COMPOSIO_CREATE_UPDATE_RECIPE",
         "name": "Create / Update Recipe from Workflow",
-        "description": "Convert executed workflow into a reusable notebook. Only use when workflow is complete or user explicitly requests.\r\n\r\n--- DESCRIPTION FORMAT (MARKDOWN) - MUST BE NEUTRAL ---\r\n\r\nDescription is for ANY user of this recipe, not just the creator. Keep it generic.\r\n- NO PII (no real emails, names, channel names, repo names)\r\n- NO user-specific defaults (defaults go in defaults_for_required_parameters only)\r\n- Use placeholder examples only\r\n\r\nGenerate rich markdown with these sections:\r\n\r\n## Overview\r\n[2-3 sentences: what it does, what problem it solves]\r\n\r\n## How It Works\r\n[End-to-end flow in plain language]\r\n\r\n## Key Features\r\n- [Feature 1]\r\n- [Feature 2]\r\n\r\n## Step-by-Step Flow\r\n1. **[Step]**: [What happens]\r\n2. **[Step]**: [What happens]\r\n\r\n## Apps & Integrations\r\n| App | Purpose |\r\n|-----|---------|\r\n| [App] | [Usage] |\r\n\r\n## Inputs Required\r\n| Input | Description | Format |\r\n|-------|-------------|--------|\r\n| channel_name | Slack channel to post to | WITHOUT # prefix |\r\n\r\n(No default values here - just format guidance)\r\n\r\n## Output\r\n[What the recipe produces]\r\n\r\n## Notes & Limitations\r\n- [Edge cases, rate limits, caveats]\r\n\r\n--- CODE STRUCTURE ---\r\n\r\nCode has 2 parts:\r\n1. DOCSTRING HEADER (comments) - context, learnings, version history\r\n2. EXECUTABLE CODE - clean Python that runs\r\n\r\nDOCSTRING HEADER (preserve all history when updating):\r\n\r\n\"\"\"\r\nRECIPE: [Name]\r\nFLOW: [App1] → [App2] → [Output]\r\n\r\nVERSION HISTORY:\r\nv2 (current): [What changed] - [Why]\r\nv1: Initial version\r\n\r\nAPI LEARNINGS:\r\n- [API_NAME]: [Quirk, e.g., Response nested at data.data]\r\n\r\nKNOWN ISSUES:\r\n- [Issue and fix]\r\n\"\"\"\r\n\r\nThen EXECUTABLE CODE follows (keep code clean, learnings stay in docstring).\r\n\r\n--- INPUT SCHEMA (USER-FRIENDLY) ---\r\n\r\nAsk for: channel_name, repo_name, sheet_url, email_address\r\nNever ask for: channel_id, spreadsheet_id, user_id (resolve in code)\r\nNever ask for large inputs: use invoke_llm to generate content in code\r\n\r\nGOOD DESCRIPTIONS (explicit format, generic examples - no PII):\r\n  channel_name: Slack channel WITHOUT # prefix\r\n  repo_name: Repository name only, NOT owner/repo\r\n  google_sheet_url: Full URL from browser\r\n  gmail_label: Label as shown in Gmail sidebar\r\n\r\nREQUIRED vs OPTIONAL:\r\n- Required: things that change every run (channel name, date range, search terms)\r\n- Optional: generic settings with sensible defaults (sheet tab, row limits)\r\n\r\n--- DEFAULTS FOR REQUIRED PARAMETERS ---\r\n\r\n- Provide in defaults_for_required_parameters for all required inputs\r\n- Use values from workflow context\r\n- Use empty string if no value available - never hallucinate\r\n- Match types: string param needs string default, number needs number\r\n- Defaults are private to creator, not shared when recipe is published\r\n- SCHEDULE-FRIENDLY DEFAULTS:\r\n- Use RELATIVE time references unless user asks otherwise, not absolute dates\r\n✓ \"last_24_hours\", \"past_week\", \"7\" (days back)\r\n✗ \"2025-01-15\", \"December 18, 2025\"\r\n- - Never include timezone as an input parameter unless specifically asked\r\n- - Test: \"Will this default work if recipe runs tomorrow?\"\r\n\r\n--- CODING RULES ---\r\n\r\nSINGLE EXECUTION: Generate complete notebook that runs in one invocation.\r\nCODE CORRECTNESS: Must be syntactically and semantically correct and executable.\r\nENVIRONMENT VARIABLES: All inputs via os.environ.get(). Code is shared - no PII.\r\nTIMEOUT: 4 min hard limit. Use ThreadPoolExecutor for bulk operations.\r\nSCHEMA SAFETY: Never assume API response schema. Use invoke_llm to parse unknown responses.\r\nNESTED DATA: APIs often double-nest. Always extract properly before using.\r\nID RESOLUTION: Convert names to IDs in code using FIND/SEARCH tools.\r\nFAIL LOUDLY: Raise Exception if expected data is empty. Never silently continue.\r\nCONTENT GENERATION: Never hardcode text. Use invoke_llm() for generated content.\r\nDEBUGGING: Timestamp all print statements.\r\nNO META LOOPS: Never call RUBE_* or COMPOSIO_* meta tools via run_composio_tool.\r\nOUTPUT: End with just output variable (no print).\r\n\r\n--- HELPERS ---\r\n\r\nAvailable in notebook (dont import). See RUBE_REMOTE_WORKBENCH for details:\r\nrun_composio_tool(slug, args) returns (result, error)\r\ninvoke_llm(prompt, reasoning_effort=\"low\") returns (response, error)\r\n  # reasoning_effort: \"low\" (bulk classification), \"medium\" (summarization), \"high\" (creative/complex content)\r\n  # Always specify based on task - use low by default, medium for analysis, high for creative generation\r\nproxy_execute(method, endpoint, toolkit, ...) returns (result, error)\r\nupload_local_file(*paths) returns (result, error)\r\n\r\n--- CHECKLIST ---\r\n\r\n- Description: Neutral, no PII, no defaults - for any user\r\n- Docstring header: Version history, API learnings (preserve on update)\r\n- Input schema: Human-friendly names, format guidance, no large inputs\r\n- Defaults: In defaults_for_required_parameters, type-matched, from context\r\n- Code: Single execution, os.environ.get(), no PII, fail loudly\r\n- Output: Ends with just output"
+        "description": "Convert executed workflow into a reusable notebook. Only use when workflow is complete or user explicitly requests.\r\n\r\n--- DESCRIPTION FORMAT (MARKDOWN) - MUST BE NEUTRAL ---\r\n\r\nDescription is for ANY user of this recipe, not just the creator. Keep it generic.\r\n- NO PII (no real emails, names, channel names, repo names)\r\n- NO user-specific defaults (defaults go in defaults_for_required_parameters only)\r\n- Use placeholder examples only\r\n\r\nGenerate rich markdown with these sections:\r\n\r\n## Overview\r\n[2-3 sentences: what it does, what problem it solves]\r\n\r\n## How It Works\r\n[End-to-end flow in plain language]\r\n\r\n## Key Features\r\n- [Feature 1]\r\n- [Feature 2]\r\n\r\n## Step-by-Step Flow\r\n1. **[Step]**: [What happens]\r\n2. **[Step]**: [What happens]\r\n\r\n## Apps & Integrations\r\n| App | Purpose |\r\n|-----|---------|\r\n| [App] | [Usage] |\r\n\r\n## Inputs Required\r\n| Input | Description | Format |\r\n|-------|-------------|--------|\r\n| channel_name | Slack channel to post to | WITHOUT # prefix |\r\n\r\n(No default values here - just format guidance)\r\n\r\n## Output\r\n[What the recipe produces]\r\n\r\n## Notes & Limitations\r\n- [Edge cases, rate limits, caveats]\r\n\r\n--- CODE STRUCTURE ---\r\n\r\nCode has 2 parts:\r\n1. DOCSTRING HEADER (comments) - context, learnings, version history\r\n2. EXECUTABLE CODE - clean Python that runs\r\n\r\nDOCSTRING HEADER (preserve all history when updating):\r\n\r\n\"\"\"\r\nRECIPE: [Name]\r\nFLOW: [App1] \u2192 [App2] \u2192 [Output]\r\n\r\nVERSION HISTORY:\r\nv2 (current): [What changed] - [Why]\r\nv1: Initial version\r\n\r\nAPI LEARNINGS:\r\n- [API_NAME]: [Quirk, e.g., Response nested at data.data]\r\n\r\nKNOWN ISSUES:\r\n- [Issue and fix]\r\n\"\"\"\r\n\r\nThen EXECUTABLE CODE follows (keep code clean, learnings stay in docstring).\r\n\r\n--- INPUT SCHEMA (USER-FRIENDLY) ---\r\n\r\nAsk for: channel_name, repo_name, sheet_url, email_address\r\nNever ask for: channel_id, spreadsheet_id, user_id (resolve in code)\r\nNever ask for large inputs: use invoke_llm to generate content in code\r\n\r\nGOOD DESCRIPTIONS (explicit format, generic examples - no PII):\r\n  channel_name: Slack channel WITHOUT # prefix\r\n  repo_name: Repository name only, NOT owner/repo\r\n  google_sheet_url: Full URL from browser\r\n  gmail_label: Label as shown in Gmail sidebar\r\n\r\nREQUIRED vs OPTIONAL:\r\n- Required: things that change every run (channel name, date range, search terms)\r\n- Optional: generic settings with sensible defaults (sheet tab, row limits)\r\n\r\n--- DEFAULTS FOR REQUIRED PARAMETERS ---\r\n\r\n- Provide in defaults_for_required_parameters for all required inputs\r\n- Use values from workflow context\r\n- Use empty string if no value available - never hallucinate\r\n- Match types: string param needs string default, number needs number\r\n- Defaults are private to creator, not shared when recipe is published\r\n- SCHEDULE-FRIENDLY DEFAULTS:\r\n- Use RELATIVE time references unless user asks otherwise, not absolute dates\r\n\u2713 \"last_24_hours\", \"past_week\", \"7\" (days back)\r\n\u2717 \"2025-01-15\", \"December 18, 2025\"\r\n- - Never include timezone as an input parameter unless specifically asked\r\n- - Test: \"Will this default work if recipe runs tomorrow?\"\r\n\r\n--- CODING RULES ---\r\n\r\nSINGLE EXECUTION: Generate complete notebook that runs in one invocation.\r\nCODE CORRECTNESS: Must be syntactically and semantically correct and executable.\r\nENVIRONMENT VARIABLES: All inputs via os.environ.get(). Code is shared - no PII.\r\nTIMEOUT: 4 min hard limit. Use ThreadPoolExecutor for bulk operations.\r\nSCHEMA SAFETY: Never assume API response schema. Use invoke_llm to parse unknown responses.\r\nNESTED DATA: APIs often double-nest. Always extract properly before using.\r\nID RESOLUTION: Convert names to IDs in code using FIND/SEARCH tools.\r\nFAIL LOUDLY: Raise Exception if expected data is empty. Never silently continue.\r\nCONTENT GENERATION: Never hardcode text. Use invoke_llm() for generated content.\r\nDEBUGGING: Timestamp all print statements.\r\nNO META LOOPS: Never call RUBE_* or COMPOSIO_* meta tools via run_composio_tool.\r\nOUTPUT: End with just output variable (no print).\r\n\r\n--- HELPERS ---\r\n\r\nAvailable in notebook (dont import). See RUBE_REMOTE_WORKBENCH for details:\r\nrun_composio_tool(slug, args) returns (result, error)\r\ninvoke_llm(prompt, reasoning_effort=\"low\") returns (response, error)\r\n  # reasoning_effort: \"low\" (bulk classification), \"medium\" (summarization), \"high\" (creative/complex content)\r\n  # Always specify based on task - use low by default, medium for analysis, high for creative generation\r\nproxy_execute(method, endpoint, toolkit, ...) returns (result, error)\r\nupload_local_file(*paths) returns (result, error)\r\n\r\n--- CHECKLIST ---\r\n\r\n- Description: Neutral, no PII, no defaults - for any user\r\n- Docstring header: Version history, API learnings (preserve on update)\r\n- Input schema: Human-friendly names, format guidance, no large inputs\r\n- Defaults: In defaults_for_required_parameters, type-matched, from context\r\n- Code: Single execution, os.environ.get(), no PII, fail loudly\r\n- Output: Ends with just output"
       },
       {
         "slug": "COMPOSIO_EXECUTE_RECIPE",
@@ -495,7 +495,7 @@
       {
         "slug": "COMPOSIO_UPSERT_RECIPE",
         "name": "Create / Update Recipe from Workflow",
-        "description": "\n    Convert the executed workflow into a recipe using Python Pydantic code.\n    The recipe_slug parameter is required. If a recipe with the provided slug already exists, a new version will be created.\n    If the slug does not exist, a new recipe will be created.\n\n    \n    This tool allows you to:\n\n    1. Save the executed workflow as a reusable recipe using Python Pydantic code\n    2. The recipe_slug parameter is required. If a recipe with the provided slug already exists, a new version will be created. If the slug does not exist, a new recipe will be created.\n    3. Recipes are defined using Python Pydantic models that extend ComposioRecipe base class\n    4. You should generate the Python Pydantic code for the recipe based on the executed workflow, please see below for more instructions on how to generate the code for the recipe\n    5. The recipe code must define request and response Pydantic models and implement the execute method\n\n    WHEN TO USE\n    - Only run this tool when the workflow is completed and successful or if the user explicitly asked to run this tool\n\n    DO NOT USE\n    - When the workflow is still being processed, or not yet completed and the user explicitly didn't ask to run this tool\n\n    IMPORTANT CODING RULES:\n    1. Single Execution: Please generate the code for the full recipe that can be executed in a single invocation\n    2. Schema Safety: Never assume the response schema for run_composio_tool if not known already from previous tools. To inspect schema, either run a simple request **outside** the workbench via COMPOSIO_MULTI_EXECUTE_TOOL or use invoke_llm helper.\n    3. Parallelism & Timeout (CRITICAL): There is a hard timeout of 4 minutes so complete the code within that. Prioritize PARALLEL execution using ThreadPoolExecutor with suitable concurrency for bulk operations - e.g., call run_composio_tool or invoke_llm parallelly across rows to maximize efficiency.\n    4. LLM Helpers: You should always use invoke_llm helper for summary, analysis, or field extraction on results. This is a smart LLM that will give much better results than any adhoc filtering.\n    5. Avoid Meta Loops: Do not use run_composio_tool to call COMPOSIO_MULTI_EXECUTE_TOOL or other COMPOSIO_* meta tools to avoid cycles. Only use it for app tools.\n    6. Pagination: Use when data spans multiple pages. Continue fetching pages with the returned next_page_token or cursor until none remains. Parallelize fetching pages if tool supports page_number.\n    7. No Hardcoding: Never hardcode data in code. Always load it from files or tool responses, iterating to construct intermediate or final inputs/outputs.\n    8. No Hardcoding: Please do NOT hardcode any PII related information like email / name / home address / social security id or anything like that. This is very risky\n    9. NEVER HARDCODE CONTENT (CRITICAL): For ANY content generation use case, you MUST use invoke_llm helper instead of hardcoding. This includes but is not limited to: social media posts (Twitter, LinkedIn, Instagram, Facebook, Reddit, etc.), blog posts, articles, email content, SEO reports, market research, jokes, stories, creative writing, product descriptions, news summaries, documentation, or ANY text content that should be unique, personalized, or contextual. Always use invoke_llm with a specific prompt to generate fresh content every time.\n    10. Dynamic Content Generation: Structure your code like this for content generation: content_prompt = f\"Generate a [specific type] about [topic] that [requirements]\" then generated_content, error = invoke_llm(content_prompt). Every execution should produce different, contextually appropriate content.\n    11. Code Correctness (CRITICAL): Code must be syntactically and semantically correct and executable.\n    12. Recipe Structure: The recipe code must follow this structure:\n        - Import required modules: from pydantic import BaseModel, Field; from recipes.base import ComposioRecipe\n        - Define Request model: class RecipeRequest(BaseModel) with Field descriptions\n        - Define Response model: class RecipeResponse(BaseModel) with Field descriptions\n        - Define Recipe class: class RecipeName(ComposioRecipe[RecipeRequest, RecipeResponse]) with name attribute and execute method\n        - The execute method should use self.run_composio_tool() to call tools and return RecipeResponse instance\n        - IMPORTANT: The recipe class must have a name attribute that is a slug-type identifier (lowercase, underscores, no spaces). Example: name = \"weather_lookup\" or name = \"github_repo_analyzer\". This name will be used as the recipe slug identifier.\n    13. Pydantic Models: Use proper Field descriptions and types. Request model should have all input parameters with Field(..., description=\"...\")\n    14. Response Model: Should match the expected output structure with proper Field descriptions\n    15. Tool Execution: Use self.run_composio_tool(tool_slug, arguments) to execute tools within the recipe\n    16. Error Handling: Handle errors appropriately and return meaningful error messages\n    17. Debugging (CRITICAL): For every print statement in your code, please prefix it with the time at which it is being executed. This will help me investigate latency related stuff\n    18. If there are any errors while running, please throw the error so that the person running the recipe can see and fix it\n    19. FAIL LOUDLY (CRITICAL): If you expect data but get 0 results, raise Exception immediately. NEVER silently continue or create empty outputs. Recovery loop will fix the code - don't hide issues. Example: if len(items) == 0: raise Exception(\"Expected data but got none\")\n    20. NESTED DATA (CRITICAL): APIs often double-nest data. Always extract: data = result.get(\"data\", {}); if \"data\" in data: data = data[\"data\"]. Try flexible field names: item.get(\"id\") or item.get(\"channel_id\")\n\n    IMPORTANT SCHEMA RULES:\n    1. Keep request model simple - include only parameters users would want to vary between runs\n    2. Do not ask for large inputs. Use invoke_llm helper to generate large content in the code\n    3. HUMAN-FRIENDLY INPUTS (CRITICAL):\n       - ✓ Ask for: channel_name, google_sheet_url, repo_name, email_address\n       - ✗ Never ask for: channel_id, spreadsheet_id, document_id, user_id\n       - Extract IDs in code: use FIND/SEARCH tools to convert names/URLs to IDs\n       - For URLs: extract IDs in code with regex (e.g., spreadsheet_id from google_sheet_url)\n    4. REQUIRED vs OPTIONAL: Mark as required only if it's specific to the user's workflow and would change every run. Generic settings should be optional with sensible defaults\n    5. Identify what varies between runs: channel name, date range, search terms = required. Sheet tab name, row limits, formatting = optional\n    6. [CRITICAL]: Use search/find tools in code to convert human inputs (names/URLs) to IDs before calling other tools\n\n    ENV & HELPERS:\n    Recipes inherit from ComposioRecipe and have access to these helper methods:\n\n    1. self.run_composio_tool(tool_slug: str, params: Dict) -> Tuple[Dict, Optional[str]]\n       - Execute a Composio tool\n       - Returns: (result dict, error string or None)\n\n    2. self.invoke_llm(prompt: str) -> Tuple[str, Optional[str]]\n       - Invoke an LLM for semantic analysis, reasoning, summarization, and other generic tasks\n       - Returns: (completion text, error string or None)\n\n    3. self.web_search(query: str) -> Tuple[str, Optional[str]]\n       - Perform web search\n       - Returns: (answer text, error string or None)\n\n    NOTE: The recipe code must be valid Python Pydantic code that extends ComposioRecipe base class.\n  \n\n    "
+        "description": "\n    Convert the executed workflow into a recipe using Python Pydantic code.\n    The recipe_slug parameter is required. If a recipe with the provided slug already exists, a new version will be created.\n    If the slug does not exist, a new recipe will be created.\n\n    \n    This tool allows you to:\n\n    1. Save the executed workflow as a reusable recipe using Python Pydantic code\n    2. The recipe_slug parameter is required. If a recipe with the provided slug already exists, a new version will be created. If the slug does not exist, a new recipe will be created.\n    3. Recipes are defined using Python Pydantic models that extend ComposioRecipe base class\n    4. You should generate the Python Pydantic code for the recipe based on the executed workflow, please see below for more instructions on how to generate the code for the recipe\n    5. The recipe code must define request and response Pydantic models and implement the execute method\n\n    WHEN TO USE\n    - Only run this tool when the workflow is completed and successful or if the user explicitly asked to run this tool\n\n    DO NOT USE\n    - When the workflow is still being processed, or not yet completed and the user explicitly didn't ask to run this tool\n\n    IMPORTANT CODING RULES:\n    1. Single Execution: Please generate the code for the full recipe that can be executed in a single invocation\n    2. Schema Safety: Never assume the response schema for run_composio_tool if not known already from previous tools. To inspect schema, either run a simple request **outside** the workbench via COMPOSIO_MULTI_EXECUTE_TOOL or use invoke_llm helper.\n    3. Parallelism & Timeout (CRITICAL): There is a hard timeout of 4 minutes so complete the code within that. Prioritize PARALLEL execution using ThreadPoolExecutor with suitable concurrency for bulk operations - e.g., call run_composio_tool or invoke_llm parallelly across rows to maximize efficiency.\n    4. LLM Helpers: You should always use invoke_llm helper for summary, analysis, or field extraction on results. This is a smart LLM that will give much better results than any adhoc filtering.\n    5. Avoid Meta Loops: Do not use run_composio_tool to call COMPOSIO_MULTI_EXECUTE_TOOL or other COMPOSIO_* meta tools to avoid cycles. Only use it for app tools.\n    6. Pagination: Use when data spans multiple pages. Continue fetching pages with the returned next_page_token or cursor until none remains. Parallelize fetching pages if tool supports page_number.\n    7. No Hardcoding: Never hardcode data in code. Always load it from files or tool responses, iterating to construct intermediate or final inputs/outputs.\n    8. No Hardcoding: Please do NOT hardcode any PII related information like email / name / home address / social security id or anything like that. This is very risky\n    9. NEVER HARDCODE CONTENT (CRITICAL): For ANY content generation use case, you MUST use invoke_llm helper instead of hardcoding. This includes but is not limited to: social media posts (Twitter, LinkedIn, Instagram, Facebook, Reddit, etc.), blog posts, articles, email content, SEO reports, market research, jokes, stories, creative writing, product descriptions, news summaries, documentation, or ANY text content that should be unique, personalized, or contextual. Always use invoke_llm with a specific prompt to generate fresh content every time.\n    10. Dynamic Content Generation: Structure your code like this for content generation: content_prompt = f\"Generate a [specific type] about [topic] that [requirements]\" then generated_content, error = invoke_llm(content_prompt). Every execution should produce different, contextually appropriate content.\n    11. Code Correctness (CRITICAL): Code must be syntactically and semantically correct and executable.\n    12. Recipe Structure: The recipe code must follow this structure:\n        - Import required modules: from pydantic import BaseModel, Field; from recipes.base import ComposioRecipe\n        - Define Request model: class RecipeRequest(BaseModel) with Field descriptions\n        - Define Response model: class RecipeResponse(BaseModel) with Field descriptions\n        - Define Recipe class: class RecipeName(ComposioRecipe[RecipeRequest, RecipeResponse]) with name attribute and execute method\n        - The execute method should use self.run_composio_tool() to call tools and return RecipeResponse instance\n        - IMPORTANT: The recipe class must have a name attribute that is a slug-type identifier (lowercase, underscores, no spaces). Example: name = \"weather_lookup\" or name = \"github_repo_analyzer\". This name will be used as the recipe slug identifier.\n    13. Pydantic Models: Use proper Field descriptions and types. Request model should have all input parameters with Field(..., description=\"...\")\n    14. Response Model: Should match the expected output structure with proper Field descriptions\n    15. Tool Execution: Use self.run_composio_tool(tool_slug, arguments) to execute tools within the recipe\n    16. Error Handling: Handle errors appropriately and return meaningful error messages\n    17. Debugging (CRITICAL): For every print statement in your code, please prefix it with the time at which it is being executed. This will help me investigate latency related stuff\n    18. If there are any errors while running, please throw the error so that the person running the recipe can see and fix it\n    19. FAIL LOUDLY (CRITICAL): If you expect data but get 0 results, raise Exception immediately. NEVER silently continue or create empty outputs. Recovery loop will fix the code - don't hide issues. Example: if len(items) == 0: raise Exception(\"Expected data but got none\")\n    20. NESTED DATA (CRITICAL): APIs often double-nest data. Always extract: data = result.get(\"data\", {}); if \"data\" in data: data = data[\"data\"]. Try flexible field names: item.get(\"id\") or item.get(\"channel_id\")\n\n    IMPORTANT SCHEMA RULES:\n    1. Keep request model simple - include only parameters users would want to vary between runs\n    2. Do not ask for large inputs. Use invoke_llm helper to generate large content in the code\n    3. HUMAN-FRIENDLY INPUTS (CRITICAL):\n       - \u2713 Ask for: channel_name, google_sheet_url, repo_name, email_address\n       - \u2717 Never ask for: channel_id, spreadsheet_id, document_id, user_id\n       - Extract IDs in code: use FIND/SEARCH tools to convert names/URLs to IDs\n       - For URLs: extract IDs in code with regex (e.g., spreadsheet_id from google_sheet_url)\n    4. REQUIRED vs OPTIONAL: Mark as required only if it's specific to the user's workflow and would change every run. Generic settings should be optional with sensible defaults\n    5. Identify what varies between runs: channel name, date range, search terms = required. Sheet tab name, row limits, formatting = optional\n    6. [CRITICAL]: Use search/find tools in code to convert human inputs (names/URLs) to IDs before calling other tools\n\n    ENV & HELPERS:\n    Recipes inherit from ComposioRecipe and have access to these helper methods:\n\n    1. self.run_composio_tool(tool_slug: str, params: Dict) -> Tuple[Dict, Optional[str]]\n       - Execute a Composio tool\n       - Returns: (result dict, error string or None)\n\n    2. self.invoke_llm(prompt: str) -> Tuple[str, Optional[str]]\n       - Invoke an LLM for semantic analysis, reasoning, summarization, and other generic tasks\n       - Returns: (completion text, error string or None)\n\n    3. self.web_search(query: str) -> Tuple[str, Optional[str]]\n       - Perform web search\n       - Returns: (answer text, error string or None)\n\n    NOTE: The recipe code must be valid Python Pydantic code that extends ComposioRecipe base class.\n  \n\n    "
       },
       {
         "slug": "COMPOSIO_GET_RECIPE",
@@ -1790,7 +1790,7 @@
       {
         "slug": "GITHUB_FIND_REPOSITORIES",
         "name": "Find Repositories",
-        "description": "AI-optimized repository search with smart filtering by language, stars, topics, and ownership. Builds intelligent search queries and returns clean, actionable repository data. Check `incomplete_results` in the response — when true, results are non-exhaustive. Search endpoints are rate-limited to ~30 requests/minute (vs. 5000/hour for general REST); apply backoff on 403/429. Total results are capped at ~1000 per query regardless of pagination."
+        "description": "AI-optimized repository search with smart filtering by language, stars, topics, and ownership. Builds intelligent search queries and returns clean, actionable repository data. Check `incomplete_results` in the response \u2014 when true, results are non-exhaustive. Search endpoints are rate-limited to ~30 requests/minute (vs. 5000/hour for general REST); apply backoff on 403/429. Total results are capped at ~1000 per query regardless of pagination."
       },
       {
         "slug": "GITHUB_FOLLOW_ORGANIZATION_GRAPHQL",
@@ -2555,7 +2555,7 @@
       {
         "slug": "GITHUB_GET_RAW_REPOSITORY_CONTENT",
         "name": "Get Raw Repository Content",
-        "description": "Tool to fetch raw file content from a GitHub repository. Returns raw bytes in whatever format the file uses (JSON, CSV, binary, etc.) — parsing and validation are the caller's responsibility. Ensure owner, repo, ref, and path are consistent when combining with other GitHub tools to avoid mismatched-ref errors."
+        "description": "Tool to fetch raw file content from a GitHub repository. Returns raw bytes in whatever format the file uses (JSON, CSV, binary, etc.) \u2014 parsing and validation are the caller's responsibility. Ensure owner, repo, ref, and path are consistent when combining with other GitHub tools to avoid mismatched-ref errors."
       },
       {
         "slug": "GITHUB_GET_REPO_ALLOWED_ACTIONS",
@@ -4345,7 +4345,7 @@
       {
         "slug": "GITHUB_SEARCH_CODE_ALL_PAGES",
         "name": "Search code (all pages)",
-        "description": "Tool to search code across multiple pages using GitHub's code search API. Use when single-page searches may miss matches and you need a full or capped result set. GitHub caps results at ~1,000 total items regardless of pagination; results for broad queries may be silently truncated. Only the default branch is indexed, and very large files may be excluded — treat results as potentially partial. Rate limit: ~30 requests/minute; honor `Retry-After` on 403/429 responses."
+        "description": "Tool to search code across multiple pages using GitHub's code search API. Use when single-page searches may miss matches and you need a full or capped result set. GitHub caps results at ~1,000 total items regardless of pagination; results for broad queries may be silently truncated. Only the default branch is indexed, and very large files may be excluded \u2014 treat results as potentially partial. Rate limit: ~30 requests/minute; honor `Retry-After` on 403/429 responses."
       },
       {
         "slug": "GITHUB_SEARCH_COMMITS",
@@ -5120,7 +5120,7 @@
       {
         "slug": "GOOGLECALENDAR_CALENDAR_LIST_UPDATE",
         "name": "Update Calendar List Entry",
-        "description": "Updates a calendar list entry's display/subscription settings (color, visibility, reminders, selection) for the authenticated user — does not modify the underlying calendar resource (title, timezone, etc.). To modify the calendar itself, use GOOGLECALENDAR_CALENDARS_UPDATE."
+        "description": "Updates a calendar list entry's display/subscription settings (color, visibility, reminders, selection) for the authenticated user \u2014 does not modify the underlying calendar resource (title, timezone, etc.). To modify the calendar itself, use GOOGLECALENDAR_CALENDARS_UPDATE."
       },
       {
         "slug": "GOOGLECALENDAR_CALENDAR_LIST_WATCH",
@@ -5130,7 +5130,7 @@
       {
         "slug": "GOOGLECALENDAR_CALENDARS_DELETE",
         "name": "Delete Calendar",
-        "description": "Deletes a secondary calendar that you own or have delete permissions on. Deletion is permanent and irreversible — verify the correct calendar_id before calling. You cannot delete your primary calendar or calendars you only have read/write access to. Use calendarList.list to find calendars with owner accessRole. For primary calendars, use calendars.clear instead. Parallel calls may trigger userRateLimitExceeded; sequence bulk deletions."
+        "description": "Deletes a secondary calendar that you own or have delete permissions on. Deletion is permanent and irreversible \u2014 verify the correct calendar_id before calling. You cannot delete your primary calendar or calendars you only have read/write access to. Use calendarList.list to find calendars with owner accessRole. For primary calendars, use calendars.clear instead. Parallel calls may trigger userRateLimitExceeded; sequence bulk deletions."
       },
       {
         "slug": "GOOGLECALENDAR_CALENDARS_UPDATE",
@@ -5160,7 +5160,7 @@
       {
         "slug": "GOOGLECALENDAR_DELETE_EVENT",
         "name": "Delete event",
-        "description": "Deletes a specified event by `event_id` from a Google Calendar (`calendar_id`); idempotent — a 404 for an already-deleted event is a no-op. Bulk deletions may trigger `rateLimitExceeded` or `userRateLimitExceeded`; cap concurrency to 5–10 requests and apply exponential backoff."
+        "description": "Deletes a specified event by `event_id` from a Google Calendar (`calendar_id`); idempotent \u2014 a 404 for an already-deleted event is a no-op. Bulk deletions may trigger `rateLimitExceeded` or `userRateLimitExceeded`; cap concurrency to 5\u201310 requests and apply exponential backoff."
       },
       {
         "slug": "GOOGLECALENDAR_DUPLICATE_CALENDAR",
@@ -5190,7 +5190,7 @@
       {
         "slug": "GOOGLECALENDAR_EVENTS_LIST_ALL_CALENDARS",
         "name": "List Events from All Calendars",
-        "description": "Return a unified event list across all calendars in the user's calendar list for a given time range. Use when you need a single view of all events across multiple calendars. An inverted or incorrect time range silently returns empty results rather than an error. An empty `items` list means no events matched the filters—adjust `time_min`, `time_max`, or `q` before concluding no events exist."
+        "description": "Return a unified event list across all calendars in the user's calendar list for a given time range. Use when you need a single view of all events across multiple calendars. An inverted or incorrect time range silently returns empty results rather than an error. An empty `items` list means no events matched the filters\u2014adjust `time_min`, `time_max`, or `q` before concluding no events exist."
       },
       {
         "slug": "GOOGLECALENDAR_EVENTS_MOVE",
@@ -5205,7 +5205,7 @@
       {
         "slug": "GOOGLECALENDAR_FIND_EVENT",
         "name": "Find event",
-        "description": "Finds events in a specified Google Calendar using text query, time ranges (event start/end, last modification), and event types. Ensure `timeMin` is not chronologically after `timeMax` if both are provided. Results may span multiple pages; always follow `nextPageToken` until absent to avoid silently missing events. Validate the correct match from results by checking summary, start.dateTime, and organizer.email before using event_id for mutations. An empty `items` array means no events matched — widen filters rather than treating it as an error."
+        "description": "Finds events in a specified Google Calendar using text query, time ranges (event start/end, last modification), and event types. Ensure `timeMin` is not chronologically after `timeMax` if both are provided. Results may span multiple pages; always follow `nextPageToken` until absent to avoid silently missing events. Validate the correct match from results by checking summary, start.dateTime, and organizer.email before using event_id for mutations. An empty `items` array means no events matched \u2014 widen filters rather than treating it as an error."
       },
       {
         "slug": "GOOGLECALENDAR_FIND_FREE_SLOTS",
@@ -5215,12 +5215,12 @@
       {
         "slug": "GOOGLECALENDAR_FREE_BUSY_QUERY",
         "name": "Query Free/Busy Information (Deprecated)",
-        "description": "DEPRECATED: Use GOOGLECALENDAR_FIND_FREE_SLOTS instead (though this tool provides wider secondary/shared calendar coverage). Returns opaque busy intervals only—no event titles or details; use GOOGLECALENDAR_EVENTS_LIST when event details are needed."
+        "description": "DEPRECATED: Use GOOGLECALENDAR_FIND_FREE_SLOTS instead (though this tool provides wider secondary/shared calendar coverage). Returns opaque busy intervals only\u2014no event titles or details; use GOOGLECALENDAR_EVENTS_LIST when event details are needed."
       },
       {
         "slug": "GOOGLECALENDAR_GET_CALENDAR",
         "name": "Get Google Calendar",
-        "description": "Retrieves a specific Google Calendar, identified by `calendar_id`, to which the authenticated user has access. Response includes `timeZone` (IANA format, e.g., 'America/Los_Angeles') — use it directly when constructing `timeMin`/`timeMax` in other tools to avoid DST errors. An empty `defaultReminders` list is valid (no defaults configured). Insufficient `accessRole` may omit fields like `defaultReminders` and `colorId`."
+        "description": "Retrieves a specific Google Calendar, identified by `calendar_id`, to which the authenticated user has access. Response includes `timeZone` (IANA format, e.g., 'America/Los_Angeles') \u2014 use it directly when constructing `timeMin`/`timeMax` in other tools to avoid DST errors. An empty `defaultReminders` list is valid (no defaults configured). Insufficient `accessRole` may omit fields like `defaultReminders` and `colorId`."
       },
       {
         "slug": "GOOGLECALENDAR_GET_CALENDAR_PROFILE",
@@ -5235,7 +5235,7 @@
       {
         "slug": "GOOGLECALENDAR_LIST_CALENDARS",
         "name": "List Google Calendars",
-        "description": "Retrieves calendars from the user's Google Calendar list, with options for pagination and filtering. Loop through all pages using nextPageToken until absent to avoid missing calendars. Use the primary flag and accessRole field from the response to identify calendars — display names are not valid calendar_id values. Read access (listing) does not imply write OAuth scopes."
+        "description": "Retrieves calendars from the user's Google Calendar list, with options for pagination and filtering. Loop through all pages using nextPageToken until absent to avoid missing calendars. Use the primary flag and accessRole field from the response to identify calendars \u2014 display names are not valid calendar_id values. Read access (listing) does not imply write OAuth scopes."
       },
       {
         "slug": "GOOGLECALENDAR_LIST_SETTINGS",
@@ -5260,7 +5260,7 @@
       {
         "slug": "GOOGLECALENDAR_REMOVE_ATTENDEE",
         "name": "Remove attendee from event",
-        "description": "Removes an attendee from a specified event in a Google Calendar; the calendar and event must exist. Concurrent calls on the same event can overwrite attendee lists — apply changes sequentially per event."
+        "description": "Removes an attendee from a specified event in a Google Calendar; the calendar and event must exist. Concurrent calls on the same event can overwrite attendee lists \u2014 apply changes sequentially per event."
       },
       {
         "slug": "GOOGLECALENDAR_SETTINGS_GET",
@@ -5270,7 +5270,7 @@
       {
         "slug": "GOOGLECALENDAR_SETTINGS_LIST",
         "name": "List Settings",
-        "description": "Returns all user settings for the authenticated user. Results include multiple settings keyed by id (e.g., `timeZone`); locate a specific setting by its `id` field. `timeZone` values are IANA identifiers (e.g., `America/New_York`) — use directly in datetime and event logic; align with `timeZone` from GOOGLECALENDAR_GET_CALENDAR for consistent notification times."
+        "description": "Returns all user settings for the authenticated user. Results include multiple settings keyed by id (e.g., `timeZone`); locate a specific setting by its `id` field. `timeZone` values are IANA identifiers (e.g., `America/New_York`) \u2014 use directly in datetime and event logic; align with `timeZone` from GOOGLECALENDAR_GET_CALENDAR for consistent notification times."
       },
       {
         "slug": "GOOGLECALENDAR_SETTINGS_WATCH",
@@ -5396,12 +5396,12 @@
       {
         "slug": "NOTION_ADD_MULTIPLE_PAGE_CONTENT",
         "name": "Add multiple content blocks (bulk, user-friendly)",
-        "description": "Bulk-add content blocks to Notion. Text >2000 chars auto-splits. Parses markdown formatting. ⚠️ PARENT BLOCK TYPES: Content is added AS CHILDREN of parent_block_id. - To add content AFTER a heading, use PAGE ID as parent + heading ID in 'after' param. - Headings CANNOT have children unless is_toggleable=True. Simplified format: {'content': 'text', 'block_property': 'paragraph'} Full format for code: {'type': 'code', 'code': {'rich_text': [...], 'language': 'python'}} Array format also supported (auto-normalized): [{\"parent_block_id\": \"...\"}, {block1}, {block2}] => proper request structure"
+        "description": "Bulk-add content blocks to Notion. Text >2000 chars auto-splits. Parses markdown formatting. \u26a0\ufe0f PARENT BLOCK TYPES: Content is added AS CHILDREN of parent_block_id. - To add content AFTER a heading, use PAGE ID as parent + heading ID in 'after' param. - Headings CANNOT have children unless is_toggleable=True. Simplified format: {'content': 'text', 'block_property': 'paragraph'} Full format for code: {'type': 'code', 'code': {'rich_text': [...], 'language': 'python'}} Array format also supported (auto-normalized): [{\"parent_block_id\": \"...\"}, {block1}, {block2}] => proper request structure"
       },
       {
         "slug": "NOTION_ADD_PAGE_CONTENT",
         "name": "Add single content block to Notion page (Deprecated)",
-        "description": "DEPRECATED: Use 'add_multiple_page_content' for better performance. Adds a single content block to a Notion page/block. CRITICAL: Notion API enforces a HARD LIMIT of 2000 characters per text.content field. Content exceeding 2000 chars is AUTOMATICALLY SPLIT into multiple sequential blocks. REQUIRED 'content' field for text blocks: paragraph, heading_1-3, callout, to_do, toggle, quote, list items. Parent blocks MUST be: Page, Toggle, To-do, Bulleted/Numbered List Item, Callout, or Quote. Common errors: - \"content.length should be ≤ 2000\": Text exceeds API limit (should be auto-handled) - \"Content is required for paragraph blocks\": Missing 'content' field for text blocks - \"object_not_found\": Invalid parent_block_id or no integration access For bulk operations, use 'add_multiple_page_content' instead."
+        "description": "DEPRECATED: Use 'add_multiple_page_content' for better performance. Adds a single content block to a Notion page/block. CRITICAL: Notion API enforces a HARD LIMIT of 2000 characters per text.content field. Content exceeding 2000 chars is AUTOMATICALLY SPLIT into multiple sequential blocks. REQUIRED 'content' field for text blocks: paragraph, heading_1-3, callout, to_do, toggle, quote, list items. Parent blocks MUST be: Page, Toggle, To-do, Bulleted/Numbered List Item, Callout, or Quote. Common errors: - \"content.length should be \u2264 2000\": Text exceeds API limit (should be auto-handled) - \"Content is required for paragraph blocks\": Missing 'content' field for text blocks - \"object_not_found\": Invalid parent_block_id or no integration access For bulk operations, use 'add_multiple_page_content' instead."
       },
       {
         "slug": "NOTION_APPEND_BLOCK_CHILDREN",
@@ -5411,7 +5411,7 @@
       {
         "slug": "NOTION_APPEND_CODE_BLOCKS",
         "name": "Append code blocks (code, quote, equation)",
-        "description": "Append code and technical blocks (code, quote, equation) to a Notion page. Use for: - Code snippets and programming examples (code) - Citations and highlighted quotes (quote) - Mathematical formulas and equations (equation) Supported block types: - code: Code with syntax highlighting (70+ languages including Python, JavaScript, Go, Rust, etc.) - quote: Block quotes for citations - equation: LaTeX/KaTeX mathematical expressions ⚠️ Code content is limited to 2000 characters per text.content field. For longer code, split into multiple code blocks. For other block types, use specialized actions: - append_text_blocks: paragraphs, headings, lists - append_task_blocks: to-do, toggle, callout - append_media_blocks: image, video, audio, files - append_layout_blocks: divider, columns, TOC - append_table_blocks: tables"
+        "description": "Append code and technical blocks (code, quote, equation) to a Notion page. Use for: - Code snippets and programming examples (code) - Citations and highlighted quotes (quote) - Mathematical formulas and equations (equation) Supported block types: - code: Code with syntax highlighting (70+ languages including Python, JavaScript, Go, Rust, etc.) - quote: Block quotes for citations - equation: LaTeX/KaTeX mathematical expressions \u26a0\ufe0f Code content is limited to 2000 characters per text.content field. For longer code, split into multiple code blocks. For other block types, use specialized actions: - append_text_blocks: paragraphs, headings, lists - append_task_blocks: to-do, toggle, callout - append_media_blocks: image, video, audio, files - append_layout_blocks: divider, columns, TOC - append_table_blocks: tables"
       },
       {
         "slug": "NOTION_APPEND_LAYOUT_BLOCKS",
@@ -5426,7 +5426,7 @@
       {
         "slug": "NOTION_APPEND_TABLE_BLOCKS",
         "name": "Append table blocks",
-        "description": "Append table blocks to a Notion page. Use for structured tabular data like spreadsheets, comparison charts, and status trackers. Example: { \"table_width\": 3, \"has_column_header\": true, \"rows\": [ {\"cells\": [[{\"type\": \"text\", \"text\": {\"content\": \"Col1\"}}], [...], [...]]} ] } ⚠️ Cell content limited to 2000 chars per text.content field."
+        "description": "Append table blocks to a Notion page. Use for structured tabular data like spreadsheets, comparison charts, and status trackers. Example: { \"table_width\": 3, \"has_column_header\": true, \"rows\": [ {\"cells\": [[{\"type\": \"text\", \"text\": {\"content\": \"Col1\"}}], [...], [...]]} ] } \u26a0\ufe0f Cell content limited to 2000 chars per text.content field."
       },
       {
         "slug": "NOTION_APPEND_TASK_BLOCKS",
@@ -5436,7 +5436,7 @@
       {
         "slug": "NOTION_APPEND_TEXT_BLOCKS",
         "name": "Append text blocks (paragraphs, headings, lists)",
-        "description": "Append text blocks (paragraphs, headings, lists) to a Notion page. This is the most commonly used action for adding content to Notion. Use for: documentation, notes, articles, outlines, lists. Supported block types: - paragraph: Regular text - heading_1, heading_2, heading_3: Section headers - bulleted_list_item: Bullet points - numbered_list_item: Numbered lists ⚠️ Text content is limited to 2000 characters per text.content field. For other block types, use specialized actions: - append_task_blocks: to-do, toggle, callout - append_code_blocks: code, quote, equation - append_media_blocks: image, video, audio, files - append_layout_blocks: divider, columns, TOC - append_table_blocks: tables"
+        "description": "Append text blocks (paragraphs, headings, lists) to a Notion page. This is the most commonly used action for adding content to Notion. Use for: documentation, notes, articles, outlines, lists. Supported block types: - paragraph: Regular text - heading_1, heading_2, heading_3: Section headers - bulleted_list_item: Bullet points - numbered_list_item: Numbered lists \u26a0\ufe0f Text content is limited to 2000 characters per text.content field. For other block types, use specialized actions: - append_task_blocks: to-do, toggle, callout - append_code_blocks: code, quote, equation - append_media_blocks: image, video, audio, files - append_layout_blocks: divider, columns, TOC - append_table_blocks: tables"
       },
       {
         "slug": "NOTION_ARCHIVE_NOTION_PAGE",
@@ -5611,7 +5611,7 @@
       {
         "slug": "NOTION_UPDATE_BLOCK",
         "name": "Update block",
-        "description": "Updates existing Notion block's text content. ⚠️ CRITICAL: Content limited to 2000 chars. Cannot change block type or archive blocks. Content exceeding 2000 chars will fail with validation error. For longer content, split across multiple blocks using add_multiple_page_content."
+        "description": "Updates existing Notion block's text content. \u26a0\ufe0f CRITICAL: Content limited to 2000 chars. Cannot change block type or archive blocks. Content exceeding 2000 chars will fail with validation error. For longer content, split across multiple blocks using add_multiple_page_content."
       },
       {
         "slug": "NOTION_UPDATE_PAGE",
@@ -6129,7 +6129,7 @@
     "slug": "slack",
     "name": "Slack",
     "logo": "https://logos.composio.dev/api/slack",
-    "description": "Slack is a channel-based messaging platform. With Slack, people can work together more effectively, connect all their software tools and services, and find the information they need to do their best work — all within a secure, enterprise-grade environment.",
+    "description": "Slack is a channel-based messaging platform. With Slack, people can work together more effectively, connect all their software tools and services, and find the information they need to do their best work \u2014 all within a secure, enterprise-grade environment.",
     "category": "team chat",
     "authSchemes": [
       "OAUTH2"
@@ -6304,7 +6304,7 @@
       {
         "slug": "SLACK_ENABLE_PUBLIC_SHARING_OF_A_FILE",
         "name": "Share file public url",
-        "description": "Enables public sharing for an existing Slack file by generating a publicly accessible URL; this action does not create new files. Once enabled, the file is accessible to anyone with the URL — verify intent before sharing sensitive or confidential files."
+        "description": "Enables public sharing for an existing Slack file by generating a publicly accessible URL; this action does not create new files. Once enabled, the file is accessible to anyone with the URL \u2014 verify intent before sharing sensitive or confidential files."
       },
       {
         "slug": "SLACK_ENABLE_USER_GROUP",
@@ -6349,7 +6349,7 @@
       {
         "slug": "SLACK_FIND_CHANNELS",
         "name": "Find channels",
-        "description": "Find channels in a Slack workspace by any criteria - name, topic, purpose, or description. Returns channel IDs (C*/G* prefixed) required by most Slack tools — always resolve names to IDs here before passing to other tools. NOTE: This action can only search channels visible to the bot. Empty results may indicate: - No channels match the search query in name, topic, or purpose - The target channel is private and the bot hasn't been invited - The bot lacks required scopes (channels:read, groups:read). If empty, retry with exact_match=false or exclude_archived=false to avoid false negatives. In large workspaces, paginate using next_cursor to avoid missing matches. Check 'composio_execution_message' and 'total_channels_searched' in the response for details."
+        "description": "Find channels in a Slack workspace by any criteria - name, topic, purpose, or description. Returns channel IDs (C*/G* prefixed) required by most Slack tools \u2014 always resolve names to IDs here before passing to other tools. NOTE: This action can only search channels visible to the bot. Empty results may indicate: - No channels match the search query in name, topic, or purpose - The target channel is private and the bot hasn't been invited - The bot lacks required scopes (channels:read, groups:read). If empty, retry with exact_match=false or exclude_archived=false to avoid false negatives. In large workspaces, paginate using next_cursor to avoid missing matches. Check 'composio_execution_message' and 'total_channels_searched' in the response for details."
       },
       {
         "slug": "SLACK_FIND_USER_BY_EMAIL_ADDRESS",
@@ -6479,7 +6479,7 @@
       {
         "slug": "SLACK_LIST_ALL_USERS",
         "name": "List all users",
-        "description": "Retrieves a paginated list of all users with profile details, status, and team memberships in a Slack workspace; data may not be real-time. Filter response fields `is_bot`, `is_app_user`, and `deleted` to build human-only rosters. Profile fields like `email` and `phone` may be absent depending on OAuth scopes and workspace privacy settings. Guest/restricted accounts may be omitted based on scopes—do not treat results as a complete directory. High-frequency calls risk HTTP 429; honor the `Retry-After` header and throttle to ~1–2 requests/second. Use stable user IDs rather than display names for mapping. Prefer SLACK_FIND_USERS for targeted lookups; cache results to avoid full-workspace fetches."
+        "description": "Retrieves a paginated list of all users with profile details, status, and team memberships in a Slack workspace; data may not be real-time. Filter response fields `is_bot`, `is_app_user`, and `deleted` to build human-only rosters. Profile fields like `email` and `phone` may be absent depending on OAuth scopes and workspace privacy settings. Guest/restricted accounts may be omitted based on scopes\u2014do not treat results as a complete directory. High-frequency calls risk HTTP 429; honor the `Retry-After` header and throttle to ~1\u20132 requests/second. Use stable user IDs rather than display names for mapping. Prefer SLACK_FIND_USERS for targeted lookups; cache results to avoid full-workspace fetches."
       },
       {
         "slug": "SLACK_LIST_APPROVED_WORKSPACE_INVITE_REQUESTS",
@@ -6519,7 +6519,7 @@
       {
         "slug": "SLACK_LIST_FILES_WITH_FILTERS_IN_SLACK",
         "name": "List Slack files",
-        "description": "Lists files and their metadata within a Slack workspace, filterable by user, channel, timestamp, or type; returns metadata only, not file content. Results are limited to files visible to the authenticated user — files in private channels or restricted to certain members require appropriate membership and permissions. For large workspaces, check `paging.pages` in the response to determine total pages when paginating."
+        "description": "Lists files and their metadata within a Slack workspace, filterable by user, channel, timestamp, or type; returns metadata only, not file content. Results are limited to files visible to the authenticated user \u2014 files in private channels or restricted to certain members require appropriate membership and permissions. For large workspaces, check `paging.pages` in the response to determine total pages when paginating."
       },
       {
         "slug": "SLACK_LIST_IDP_GROUPS_LINKED_TO_CHANNEL",
@@ -6539,7 +6539,7 @@
       {
         "slug": "SLACK_LIST_REMINDERS",
         "name": "List reminders",
-        "description": "Lists all reminders with their details for the authenticated Slack user; returns an empty array if no reminders exist (valid state, not an error). Reminder text is not unique—perform client-side matching on returned objects before extracting a reminder ID for use with SLACK_MARK_REMINDER_AS_COMPLETE or SLACK_DELETE_A_SLACK_REMINDER."
+        "description": "Lists all reminders with their details for the authenticated Slack user; returns an empty array if no reminders exist (valid state, not an error). Reminder text is not unique\u2014perform client-side matching on returned objects before extracting a reminder ID for use with SLACK_MARK_REMINDER_AS_COMPLETE or SLACK_DELETE_A_SLACK_REMINDER."
       },
       {
         "slug": "SLACK_LIST_REMOTE_FILES",
@@ -6559,7 +6559,7 @@
       {
         "slug": "SLACK_LIST_STARRED_ITEMS",
         "name": "List starred items",
-        "description": "Lists items starred by a user. Returns classic starred items only — does not reflect Slack's 'saved for later' feature. Use SLACK_SEARCH_MESSAGES or SLACK_SEARCH_ALL for broader saved-content queries."
+        "description": "Lists items starred by a user. Returns classic starred items only \u2014 does not reflect Slack's 'saved for later' feature. Use SLACK_SEARCH_MESSAGES or SLACK_SEARCH_ALL for broader saved-content queries."
       },
       {
         "slug": "SLACK_LIST_USER_GROUP_MEMBERS",
@@ -6604,7 +6604,7 @@
       {
         "slug": "SLACK_OPEN_DM",
         "name": "Open DM",
-        "description": "Opens or resumes a Slack direct message (DM) or multi-person direct message (MPIM) by providing either user IDs or an existing channel ID. Returns `already_open=true` when the DM exists — treat as success and reuse the returned `channel.id` (starts with 'D') for subsequent SLACK_SEND_MESSAGE calls; passing a username, email, or user ID directly to SLACK_SEND_MESSAGE causes `channel_not_found`. Avoid redundant calls when an existing DM channel ID is available."
+        "description": "Opens or resumes a Slack direct message (DM) or multi-person direct message (MPIM) by providing either user IDs or an existing channel ID. Returns `already_open=true` when the DM exists \u2014 treat as success and reuse the returned `channel.id` (starts with 'D') for subsequent SLACK_SEND_MESSAGE calls; passing a username, email, or user ID directly to SLACK_SEND_MESSAGE causes `channel_not_found`. Avoid redundant calls when an existing DM channel ID is available."
       },
       {
         "slug": "SLACK_PIN_ITEM",
@@ -6739,12 +6739,12 @@
       {
         "slug": "SLACK_SEARCH_ALL",
         "name": "Search all content",
-        "description": "Tool to search all messages and files. Use when you need unified content search across channels and files in one call. Results are scoped to content visible to the authenticated token; missing hits in private or restricted channels reflect permission/membership gaps. Response separates messages and files into distinct sections — explicitly read the files section for document results. Results are index-based and may lag several minutes behind real-time; use SLACK_FETCH_CONVERSATION_HISTORY for near-real-time per-channel coverage. Paginated searches exceeding ~1 req/sec may return HTTP 429 too_many_requests; honor the Retry-After header and resume from the last page."
+        "description": "Tool to search all messages and files. Use when you need unified content search across channels and files in one call. Results are scoped to content visible to the authenticated token; missing hits in private or restricted channels reflect permission/membership gaps. Response separates messages and files into distinct sections \u2014 explicitly read the files section for document results. Results are index-based and may lag several minutes behind real-time; use SLACK_FETCH_CONVERSATION_HISTORY for near-real-time per-channel coverage. Paginated searches exceeding ~1 req/sec may return HTTP 429 too_many_requests; honor the Retry-After header and resume from the last page."
       },
       {
         "slug": "SLACK_SEARCH_MESSAGES",
         "name": "Search messages",
-        "description": "Workspace‑wide Slack message search with date ranges and filters. Use `query` modifiers (e.g., in:#channel, from:@user, before/after:YYYY-MM-DD), sorting (score/timestamp), and pagination."
+        "description": "Workspace\u2011wide Slack message search with date ranges and filters. Use `query` modifiers (e.g., in:#channel, from:@user, before/after:YYYY-MM-DD), sorting (score/timestamp), and pagination."
       },
       {
         "slug": "SLACK_SEND_EPHEMERAL_MESSAGE",
@@ -6759,7 +6759,7 @@
       {
         "slug": "SLACK_SEND_MESSAGE",
         "name": "Send message",
-        "description": "Posts a message to a Slack channel, DM, or private group; requires at least one content field (`markdown_text`, `text`, `blocks`, or `attachments`) — omitting all causes a `no_text` error. Fails with `not_in_channel`, `channel_not_found`, or `channel_is_archived` if the bot lacks access. Body limit ~4000 characters. Rate-limited at ~1 req/sec (HTTP 429, honor `Retry-After`). Not idempotent — duplicate calls post duplicate messages."
+        "description": "Posts a message to a Slack channel, DM, or private group; requires at least one content field (`markdown_text`, `text`, `blocks`, or `attachments`) \u2014 omitting all causes a `no_text` error. Fails with `not_in_channel`, `channel_not_found`, or `channel_is_archived` if the bot lacks access. Body limit ~4000 characters. Rate-limited at ~1 req/sec (HTTP 429, honor `Retry-After`). Not idempotent \u2014 duplicate calls post duplicate messages."
       },
       {
         "slug": "SLACK_SET_ADMIN_USER",
@@ -8373,7 +8373,7 @@
       {
         "slug": "OUTLOOK_DOWNLOAD_OUTLOOK_ATTACHMENT",
         "name": "Download Outlook attachment",
-        "description": "Downloads a specific file attachment from an email message in a Microsoft Outlook mailbox; the attachment must contain 'contentBytes' (binary data) and not be a link or embedded item. The returned data.file.s3url is temporary — download the file immediately after calling this tool; call again to get a fresh URL if needed. High-volume parallel calls may trigger HTTP 429 responses; honor the Retry-After header and use exponential backoff."
+        "description": "Downloads a specific file attachment from an email message in a Microsoft Outlook mailbox; the attachment must contain 'contentBytes' (binary data) and not be a link or embedded item. The returned data.file.s3url is temporary \u2014 download the file immediately after calling this tool; call again to get a fresh URL if needed. High-volume parallel calls may trigger HTTP 429 responses; honor the Retry-After header and use exponential backoff."
       },
       {
         "slug": "OUTLOOK_FIND_MEETING_TIMES",
@@ -8638,7 +8638,7 @@
       {
         "slug": "OUTLOOK_GET_SCHEDULE",
         "name": "Get schedule",
-        "description": "Retrieves free/busy schedule information for specified email addresses within a defined time window. Read-only; does not reserve time or prevent conflicts — verify availability before creating events."
+        "description": "Retrieves free/busy schedule information for specified email addresses within a defined time window. Read-only; does not reserve time or prevent conflicts \u2014 verify availability before creating events."
       },
       {
         "slug": "OUTLOOK_GET_SUPPORTED_LANGUAGES",
@@ -8868,7 +8868,7 @@
       {
         "slug": "OUTLOOK_LIST_OUTLOOK_ATTACHMENTS",
         "name": "List Outlook attachments",
-        "description": "Lists metadata (name, size, contentType, isInline — but not `contentBytes`) for all attachments of a specified Outlook email message. Returns fileAttachment, itemAttachment, and referenceAttachment types; only fileAttachment entries support download via OUTLOOK_DOWNLOAD_OUTLOOK_ATTACHMENT. Results include inline images and signatures — filter by `isInline == false` and check `contentType` to identify real document attachments. Results are nested under `data.response_data.value`."
+        "description": "Lists metadata (name, size, contentType, isInline \u2014 but not `contentBytes`) for all attachments of a specified Outlook email message. Returns fileAttachment, itemAttachment, and referenceAttachment types; only fileAttachment entries support download via OUTLOOK_DOWNLOAD_OUTLOOK_ATTACHMENT. Results include inline images and signatures \u2014 filter by `isInline == false` and check `contentType` to identify real document attachments. Results are nested under `data.response_data.value`."
       },
       {
         "slug": "OUTLOOK_LIST_PRIMARY_CALENDAR_PERMISSIONS",
@@ -8938,7 +8938,7 @@
       {
         "slug": "OUTLOOK_LIST_USERS",
         "name": "List users",
-        "description": "Tool to list users in Microsoft Entra ID. Use when you need to retrieve a paginated list of users, optionally filtering or selecting specific properties. For single-user lookups, prefer a dedicated get-user tool — listing all users is significantly heavier and slower."
+        "description": "Tool to list users in Microsoft Entra ID. Use when you need to retrieve a paginated list of users, optionally filtering or selecting specific properties. For single-user lookups, prefer a dedicated get-user tool \u2014 listing all users is significantly heavier and slower."
       },
       {
         "slug": "OUTLOOK_MOVE_MAIL_FOLDER",
@@ -8958,7 +8958,7 @@
       {
         "slug": "OUTLOOK_MOVE_MESSAGE_FROM_CHILD_FOLDER",
         "name": "Move message from child folder",
-        "description": "Tool to move a message from a child folder to another destination folder. Use when you need to move a message that exists within a specific folder hierarchy (parent folder → child folder → message)."
+        "description": "Tool to move a message from a child folder to another destination folder. Use when you need to move a message that exists within a specific folder hierarchy (parent folder \u2192 child folder \u2192 message)."
       },
       {
         "slug": "OUTLOOK_MOVE_MESSAGE_FROM_FOLDER",
@@ -8978,7 +8978,7 @@
       {
         "slug": "OUTLOOK_QUERY_EMAILS",
         "name": "Query Emails",
-        "description": "Query Outlook emails within a SINGLE folder using OData filters. Build precise server-side filters for dates, read status, importance, subjects, attachments, and conversations. Best for structured queries on message metadata within a specific folder. Returns up to 100 messages per request with pagination support. • Searches SINGLE folder only (inbox, sentitems, etc.) - NOT across all folders • For cross-folder/mailbox-wide search: Use OUTLOOK_SEARCH_MESSAGES • Server-side filters: dates, importance, isRead, hasAttachments, subjects, conversationId • CRITICAL: Always check response['@odata.nextLink'] for pagination • Limitations: Recipient/body filtering requires OUTLOOK_SEARCH_MESSAGES"
+        "description": "Query Outlook emails within a SINGLE folder using OData filters. Build precise server-side filters for dates, read status, importance, subjects, attachments, and conversations. Best for structured queries on message metadata within a specific folder. Returns up to 100 messages per request with pagination support. \u2022 Searches SINGLE folder only (inbox, sentitems, etc.) - NOT across all folders \u2022 For cross-folder/mailbox-wide search: Use OUTLOOK_SEARCH_MESSAGES \u2022 Server-side filters: dates, importance, isRead, hasAttachments, subjects, conversationId \u2022 CRITICAL: Always check response['@odata.nextLink'] for pagination \u2022 Limitations: Recipient/body filtering requires OUTLOOK_SEARCH_MESSAGES"
       },
       {
         "slug": "OUTLOOK_REPLY_EMAIL",
@@ -8993,7 +8993,7 @@
       {
         "slug": "OUTLOOK_SEND_DRAFT",
         "name": "Send draft",
-        "description": "Tool to send an existing draft message. Use after creating a draft when you want to deliver it to recipients immediately. Example: Send a draft message with ID 'AAMkAG…'."
+        "description": "Tool to send an existing draft message. Use after creating a draft when you want to deliver it to recipients immediately. Example: Send a draft message with ID 'AAMkAG\u2026'."
       },
       {
         "slug": "OUTLOOK_SEND_EMAIL",
@@ -9439,7 +9439,7 @@
       {
         "slug": "TWITTER_CREATION_OF_A_POST",
         "name": "Create a post",
-        "description": "Creates a Tweet on Twitter; `text` is required unless `card_uri`, `media_media_ids`, `poll_options`, or `quote_tweet_id` is provided. Example - Creating a tweet with media and location: { \"text\": \"Check out our latest product update! 🚀\", \"media_media_ids\": [\"1455952740635586573\"], \"geo_place_id\": \"df51dec6f4ee2b2c\" } Example - Quote tweet with commentary: { \"text\": \"This is a game-changer for the industry! Here's why... 🧵\", \"quote_tweet_id\": \"1453828617121234945\" } Example - Reply to a tweet: { \"text\": \"Great point! Here's my take on this...\", \"reply_in_reply_to_tweet_id\": \"1453828617121234945\" }"
+        "description": "Creates a Tweet on Twitter; `text` is required unless `card_uri`, `media_media_ids`, `poll_options`, or `quote_tweet_id` is provided. Example - Creating a tweet with media and location: { \"text\": \"Check out our latest product update! \ud83d\ude80\", \"media_media_ids\": [\"1455952740635586573\"], \"geo_place_id\": \"df51dec6f4ee2b2c\" } Example - Quote tweet with commentary: { \"text\": \"This is a game-changer for the industry! Here's why... \ud83e\uddf5\", \"quote_tweet_id\": \"1453828617121234945\" } Example - Reply to a tweet: { \"text\": \"Great point! Here's my take on this...\", \"reply_in_reply_to_tweet_id\": \"1453828617121234945\" }"
       },
       {
         "slug": "TWITTER_DELETE_DM",
@@ -9519,7 +9519,7 @@
       {
         "slug": "TWITTER_GET_MEDIA_UPLOAD_STATUS",
         "name": "Get Media Upload Status",
-        "description": "Get the processing status of uploaded media (videos/GIFs) on X/Twitter. Only call this when the FINALIZE command returned a processing_info field. Poll every 3–5 seconds with a 60–120 second maximum timeout to avoid HTTP 429 errors. Response state cycles through 'pending', 'in_progress', 'succeeded', and 'failed'. Only attach media_id to a tweet when state is 'succeeded'. State 'failed' is terminal — requires a completely new upload via TWITTER_UPLOAD_MEDIA or TWITTER_UPLOAD_LARGE_MEDIA. Video/GIF processing takes 30–120 seconds; posting before 'succeeded' results in non-playable media."
+        "description": "Get the processing status of uploaded media (videos/GIFs) on X/Twitter. Only call this when the FINALIZE command returned a processing_info field. Poll every 3\u20135 seconds with a 60\u2013120 second maximum timeout to avoid HTTP 429 errors. Response state cycles through 'pending', 'in_progress', 'succeeded', and 'failed'. Only attach media_id to a tweet when state is 'succeeded'. State 'failed' is terminal \u2014 requires a completely new upload via TWITTER_UPLOAD_MEDIA or TWITTER_UPLOAD_LARGE_MEDIA. Video/GIF processing takes 30\u2013120 seconds; posting before 'succeeded' results in non-playable media."
       },
       {
         "slug": "TWITTER_GET_MUTED_USERS",
@@ -9759,7 +9759,7 @@
       {
         "slug": "TWITTER_UPLOAD_LARGE_MEDIA",
         "name": "Upload Large Media",
-        "description": "DEPRECATED: Use TWITTER_UPLOAD_MEDIA instead. Use this to upload a single media file to X/Twitter. Automatically uses chunked upload for GIFs, videos, and images larger than 5 MB. Max file size: 512 MB; max video duration: 140 seconds. After upload, poll TWITTER_GET_MEDIA_UPLOAD_STATUS until processing_info.state=='succeeded' before attaching the media_id to a tweet — GIFs and videos take 30–120 seconds to process. A terminal 'failed' state means the media_id is unusable and the file must be re-uploaded."
+        "description": "DEPRECATED: Use TWITTER_UPLOAD_MEDIA instead. Use this to upload a single media file to X/Twitter. Automatically uses chunked upload for GIFs, videos, and images larger than 5 MB. Max file size: 512 MB; max video duration: 140 seconds. After upload, poll TWITTER_GET_MEDIA_UPLOAD_STATUS until processing_info.state=='succeeded' before attaching the media_id to a tweet \u2014 GIFs and videos take 30\u2013120 seconds to process. A terminal 'failed' state means the media_id is unusable and the file must be re-uploaded."
       },
       {
         "slug": "TWITTER_UPLOAD_MEDIA",
@@ -9886,7 +9886,7 @@
       {
         "slug": "GOOGLEDRIVE_COPY_FILE",
         "name": "Copy file (Deprecated)",
-        "description": "DEPRECATED: Use GOOGLEDRIVE_COPY_FILE_ADVANCED instead. Duplicates an existing file (not folders) in Google Drive by `file_id`; copy lands in same folder as original — use GOOGLEDRIVE_MOVE_FILE afterward for precise placement. Copy receives a new `file_id`; update stored references accordingly. For shared drives, requires organizer/manager rights."
+        "description": "DEPRECATED: Use GOOGLEDRIVE_COPY_FILE_ADVANCED instead. Duplicates an existing file (not folders) in Google Drive by `file_id`; copy lands in same folder as original \u2014 use GOOGLEDRIVE_MOVE_FILE afterward for precise placement. Copy receives a new `file_id`; update stored references accordingly. For shared drives, requires organizer/manager rights."
       },
       {
         "slug": "GOOGLEDRIVE_COPY_FILE_ADVANCED",
@@ -9906,12 +9906,12 @@
       {
         "slug": "GOOGLEDRIVE_CREATE_FILE",
         "name": "Create File or Folder",
-        "description": "Creates a new file or folder with metadata. Native Google file types (Docs, Sheets, Forms, etc.) and folders are created as empty shells; content must be added manually in the Google UI afterward. Newly created files are private by default — set sharing permissions afterward for collaboration. For shared-drive folders, use this tool with the target folder ID in `parents` rather than GOOGLEDRIVE_CREATE_FOLDER."
+        "description": "Creates a new file or folder with metadata. Native Google file types (Docs, Sheets, Forms, etc.) and folders are created as empty shells; content must be added manually in the Google UI afterward. Newly created files are private by default \u2014 set sharing permissions afterward for collaboration. For shared-drive folders, use this tool with the target folder ID in `parents` rather than GOOGLEDRIVE_CREATE_FOLDER."
       },
       {
         "slug": "GOOGLEDRIVE_CREATE_FILE_FROM_TEXT",
         "name": "Create a File from Text",
-        "description": "Creates a new file in Google Drive from provided text content (up to 10MB), supporting various formats including automatic conversion to Google Workspace types. Returns flat metadata fields (`id`, `mimeType`, `name`) at the top level — not nested under a `file` object. Created files are private by default; use a sharing tool afterward for collaborative access. Rapid successive calls may trigger `403 rateLimitExceeded` or `429 userRateLimitExceeded`; apply exponential backoff between retries. Does not support shared-drive targets in all cases."
+        "description": "Creates a new file in Google Drive from provided text content (up to 10MB), supporting various formats including automatic conversion to Google Workspace types. Returns flat metadata fields (`id`, `mimeType`, `name`) at the top level \u2014 not nested under a `file` object. Created files are private by default; use a sharing tool afterward for collaborative access. Rapid successive calls may trigger `403 rateLimitExceeded` or `429 userRateLimitExceeded`; apply exponential backoff between retries. Does not support shared-drive targets in all cases."
       },
       {
         "slug": "GOOGLEDRIVE_CREATE_FOLDER",
@@ -9946,7 +9946,7 @@
       {
         "slug": "GOOGLEDRIVE_DELETE_COMMENT",
         "name": "Delete Comment",
-        "description": "Permanently deletes a comment thread (and all its replies) from a Google Drive file — this action is irreversible. To remove only a single reply within a thread, use GOOGLEDRIVE_DELETE_REPLY instead. Verify the exact comment content and comment_id before calling."
+        "description": "Permanently deletes a comment thread (and all its replies) from a Google Drive file \u2014 this action is irreversible. To remove only a single reply within a thread, use GOOGLEDRIVE_DELETE_REPLY instead. Verify the exact comment content and comment_id before calling."
       },
       {
         "slug": "GOOGLEDRIVE_DELETE_DRIVE",
@@ -9966,7 +9966,7 @@
       {
         "slug": "GOOGLEDRIVE_DELETE_PERMISSION",
         "name": "Delete Permission",
-        "description": "Deletes a permission from a file by permission ID. Deletion is irreversible — confirm the target user, group, or permission type before executing. IMPORTANT: You must first call GOOGLEDRIVE_LIST_PERMISSIONS to get valid permission IDs. To fully revoke public access, the type='anyone' (link-sharing) permission must be explicitly deleted; revoking other permissions leaves the file publicly accessible via link. Use when you need to revoke access for a specific user or group from a file."
+        "description": "Deletes a permission from a file by permission ID. Deletion is irreversible \u2014 confirm the target user, group, or permission type before executing. IMPORTANT: You must first call GOOGLEDRIVE_LIST_PERMISSIONS to get valid permission IDs. To fully revoke public access, the type='anyone' (link-sharing) permission must be explicitly deleted; revoking other permissions leaves the file publicly accessible via link. Use when you need to revoke access for a specific user or group from a file."
       },
       {
         "slug": "GOOGLEDRIVE_DELETE_PROPERTY",
@@ -9976,7 +9976,7 @@
       {
         "slug": "GOOGLEDRIVE_DELETE_REPLY",
         "name": "Delete Reply",
-        "description": "Tool to delete a specific reply by reply ID. Deletion is irreversible; obtain explicit user confirmation before calling. Removes only the targeted reply, not the full comment thread — use GOOGLEDRIVE_DELETE_COMMENT to remove the entire thread."
+        "description": "Tool to delete a specific reply by reply ID. Deletion is irreversible; obtain explicit user confirmation before calling. Removes only the targeted reply, not the full comment thread \u2014 use GOOGLEDRIVE_DELETE_COMMENT to remove the entire thread."
       },
       {
         "slug": "GOOGLEDRIVE_DELETE_REVISION",
@@ -10001,7 +10001,7 @@
       {
         "slug": "GOOGLEDRIVE_DOWNLOAD_FILE_OPERATION",
         "name": "Download file via operation",
-        "description": "Tool to download file content using long-running operations. Use when you need to download Google Vids files or export Google Workspace documents as part of a long-running operation. Operations are valid for 24 hours from creation. Returns a response containing `downloaded_file_content.s3url` — a short-lived S3 URL; fetch the actual file bytes from that URL promptly after the call."
+        "description": "Tool to download file content using long-running operations. Use when you need to download Google Vids files or export Google Workspace documents as part of a long-running operation. Operations are valid for 24 hours from creation. Returns a response containing `downloaded_file_content.s3url` \u2014 a short-lived S3 URL; fetch the actual file bytes from that URL promptly after the call."
       },
       {
         "slug": "GOOGLEDRIVE_EDIT_FILE",
@@ -10011,7 +10011,7 @@
       {
         "slug": "GOOGLEDRIVE_EMPTY_TRASH",
         "name": "Empty Trash",
-        "description": "Tool to permanently and irreversibly delete ALL trashed files in the user's Google Drive or a specified shared drive. Recovery is impossible after execution — no Drive tool can restore items once trash is emptied. Affects every item in trash across the entire account or shared drive, not just files from the current workflow. Always obtain explicit user confirmation and clarify that recovery is impossible before executing. Provide driveId to target a specific shared drive's trash; omit to empty the user's root trash."
+        "description": "Tool to permanently and irreversibly delete ALL trashed files in the user's Google Drive or a specified shared drive. Recovery is impossible after execution \u2014 no Drive tool can restore items once trash is emptied. Affects every item in trash across the entire account or shared drive, not just files from the current workflow. Always obtain explicit user confirmation and clarify that recovery is impossible before executing. Provide driveId to target a specific shared drive's trash; omit to empty the user's root trash."
       },
       {
         "slug": "GOOGLEDRIVE_EXPORT_GOOGLE_WORKSPACE_FILE",
@@ -10036,7 +10036,7 @@
       {
         "slug": "GOOGLEDRIVE_GET_ABOUT",
         "name": "Get about",
-        "description": "Tool to retrieve information about the user, the user's Drive, and system capabilities. Use when you need to check storage quotas, user details, or supported import/export formats. Note: storageQuota reflects My Drive (personal) storage only — it does not cover shared drives; use GOOGLEDRIVE_LIST_SHARED_DRIVES and GOOGLEDRIVE_GET_DRIVE for shared drive quotas. A successful response confirms base Drive read access only; write access and shared drive access must be verified separately."
+        "description": "Tool to retrieve information about the user, the user's Drive, and system capabilities. Use when you need to check storage quotas, user details, or supported import/export formats. Note: storageQuota reflects My Drive (personal) storage only \u2014 it does not cover shared drives; use GOOGLEDRIVE_LIST_SHARED_DRIVES and GOOGLEDRIVE_GET_DRIVE for shared drive quotas. A successful response confirms base Drive read access only; write access and shared drive access must be verified separately."
       },
       {
         "slug": "GOOGLEDRIVE_GET_APP",
@@ -10051,7 +10051,7 @@
       {
         "slug": "GOOGLEDRIVE_GET_CHANGES_START_PAGE_TOKEN",
         "name": "Get Changes Start Page Token",
-        "description": "Tool to get the starting pageToken for listing future changes in Google Drive. Returns only a token — pass it to GOOGLEDRIVE_LIST_CHANGES to retrieve actual changes. Persist this token; losing it requires a full rescan. The token is forward-looking: GOOGLEDRIVE_LIST_CHANGES may return no results if no changes have occurred since issuance. For simple recent-file lookups, prefer GOOGLEDRIVE_FIND_FILE; use this tool only for incremental change-feed workflows."
+        "description": "Tool to get the starting pageToken for listing future changes in Google Drive. Returns only a token \u2014 pass it to GOOGLEDRIVE_LIST_CHANGES to retrieve actual changes. Persist this token; losing it requires a full rescan. The token is forward-looking: GOOGLEDRIVE_LIST_CHANGES may return no results if no changes have occurred since issuance. For simple recent-file lookups, prefer GOOGLEDRIVE_FIND_FILE; use this tool only for incremental change-feed workflows."
       },
       {
         "slug": "GOOGLEDRIVE_GET_CHILD",
@@ -10106,7 +10106,7 @@
       {
         "slug": "GOOGLEDRIVE_GET_REVISION",
         "name": "Get Revision",
-        "description": "Tool to get a specific revision's metadata (name, modifiedTime, keepForever, etc.) by revision ID. Returns metadata only — not file content. Use a separate download tool to retrieve file content or restore a revision."
+        "description": "Tool to get a specific revision's metadata (name, modifiedTime, keepForever, etc.) by revision ID. Returns metadata only \u2014 not file content. Use a separate download tool to retrieve file content or restore a revision."
       },
       {
         "slug": "GOOGLEDRIVE_GET_TEAM_DRIVE",
@@ -10141,7 +10141,7 @@
       {
         "slug": "GOOGLEDRIVE_LIST_CHANGES",
         "name": "List Changes",
-        "description": "Tool to list the changes for a user or shared drive. Use when a full incremental change feed is needed (for simple recent-file lookups, prefer GOOGLEDRIVE_FIND_FILE instead). Tracks modifications such as creations, deletions, or permission changes. The pageToken is optional - if not provided, the current start page token will be automatically fetched; an empty result is valid if no recent activity has occurred. Example usage: ```json { \"pageToken\": \"22633\", \"pageSize\": 100, \"includeRemoved\": true } ``` Returns changes with timestamps, file IDs, and modification details. Paginate by following `nextPageToken` until it is absent — stopping early will silently omit changes. Save `newStartPageToken` to monitor future changes efficiently."
+        "description": "Tool to list the changes for a user or shared drive. Use when a full incremental change feed is needed (for simple recent-file lookups, prefer GOOGLEDRIVE_FIND_FILE instead). Tracks modifications such as creations, deletions, or permission changes. The pageToken is optional - if not provided, the current start page token will be automatically fetched; an empty result is valid if no recent activity has occurred. Example usage: ```json { \"pageToken\": \"22633\", \"pageSize\": 100, \"includeRemoved\": true } ``` Returns changes with timestamps, file IDs, and modification details. Paginate by following `nextPageToken` until it is absent \u2014 stopping early will silently omit changes. Save `newStartPageToken` to monitor future changes efficiently."
       },
       {
         "slug": "GOOGLEDRIVE_LIST_CHILDREN_V2",
@@ -10226,7 +10226,7 @@
       {
         "slug": "GOOGLEDRIVE_STOP_WATCH_CHANNEL",
         "name": "Stop Watch Channel",
-        "description": "Tool to stop watching resources through a specified channel. Use this when you want to stop receiving notifications for a previously established watch. Both `id` and `resourceId` must be saved from the original watch response — they cannot be retrieved after the fact."
+        "description": "Tool to stop watching resources through a specified channel. Use this when you want to stop receiving notifications for a previously established watch. Both `id` and `resourceId` must be saved from the original watch response \u2014 they cannot be retrieved after the fact."
       },
       {
         "slug": "GOOGLEDRIVE_TRASH_FILE",
@@ -10241,7 +10241,7 @@
       {
         "slug": "GOOGLEDRIVE_UNTRASH_FILE",
         "name": "Untrash File",
-        "description": "Tool to restore a file from the trash. Use when you need to recover a deleted file. This action updates the file's metadata to set the 'trashed' property to false. Only works while the file remains in trash — recovery is impossible after trash is emptied via GOOGLEDRIVE_EMPTY_TRASH or auto-purged by policy."
+        "description": "Tool to restore a file from the trash. Use when you need to recover a deleted file. This action updates the file's metadata to set the 'trashed' property to false. Only works while the file remains in trash \u2014 recovery is impossible after trash is emptied via GOOGLEDRIVE_EMPTY_TRASH or auto-purged by policy."
       },
       {
         "slug": "GOOGLEDRIVE_UPDATE_COMMENT",
@@ -10266,7 +10266,7 @@
       {
         "slug": "GOOGLEDRIVE_UPDATE_FILE_PUT",
         "name": "Update File (Metadata)",
-        "description": "Updates file metadata. Uses PATCH semantics (partial update) as per Google Drive API v3 — only explicitly provided fields are updated, so omit fields you do not intend to overwrite. Use this tool to modify attributes of an existing file like its name, description, or parent folders. To move a file, supply add_parents and remove_parents together; omitting remove_parents creates multiple parents, omitting add_parents can orphan the file. Bulk updates may trigger 429 Too Many Requests; apply exponential backoff. Note: supports metadata updates only; file content updates are not yet implemented."
+        "description": "Updates file metadata. Uses PATCH semantics (partial update) as per Google Drive API v3 \u2014 only explicitly provided fields are updated, so omit fields you do not intend to overwrite. Use this tool to modify attributes of an existing file like its name, description, or parent folders. To move a file, supply add_parents and remove_parents together; omitting remove_parents creates multiple parents, omitting add_parents can orphan the file. Bulk updates may trigger 429 Too Many Requests; apply exponential backoff. Note: supports metadata updates only; file content updates are not yet implemented."
       },
       {
         "slug": "GOOGLEDRIVE_UPDATE_FILE_REVISION_METADATA",
@@ -10867,7 +10867,7 @@
       {
         "slug": "HUBSPOT_CREATE_AB_TEST_VARIATION",
         "name": "Create A/B test variation",
-        "description": "Creates a new A/B test variation for an existing HubSpot marketing email, using its `contentId`; the new variation is created as a draft that can be edited before publishing. This action only creates the variation—it does not start the A/B test or send emails. Note: If an active variation already exists for the email, a new one will not be created. Requires Marketing Hub Professional or Enterprise subscription."
+        "description": "Creates a new A/B test variation for an existing HubSpot marketing email, using its `contentId`; the new variation is created as a draft that can be edited before publishing. This action only creates the variation\u2014it does not start the A/B test or send emails. Note: If an active variation already exists for the email, a new one will not be created. Requires Marketing Hub Professional or Enterprise subscription."
       },
       {
         "slug": "HUBSPOT_CREATE_AND_RETURN_A_NEW_PROPERTY_GROUP",
@@ -11467,12 +11467,12 @@
       {
         "slug": "HUBSPOT_READ_ASSOCIATIONS_BATCH",
         "name": "Batch read associations",
-        "description": "Tool to batch-read CRM associations (e.g., deals→contacts, deals→companies) for up to 1,000 source record IDs in one request. Use when you need to retrieve associated target IDs and association type metadata for multiple records efficiently, avoiding rate-limit issues from per-record GET calls."
+        "description": "Tool to batch-read CRM associations (e.g., deals\u2192contacts, deals\u2192companies) for up to 1,000 source record IDs in one request. Use when you need to retrieve associated target IDs and association type metadata for multiple records efficiently, avoiding rate-limit issues from per-record GET calls."
       },
       {
         "slug": "HUBSPOT_READ_BATCH_CRM_OBJECT_PROPERTIES",
         "name": "Read a batch of CRM object properties",
-        "description": "Retrieves property definitions (metadata) for a batch of CRM object properties for a specified object type. Returns detailed information about property structure, data types, options, and configuration—not the actual property values of CRM records."
+        "description": "Retrieves property definitions (metadata) for a batch of CRM object properties for a specified object type. Returns detailed information about property structure, data types, options, and configuration\u2014not the actual property values of CRM records."
       },
       {
         "slug": "HUBSPOT_READ_BATCH_FEEDBACK_SUBMISSIONS_BY_ID_OR_PROPERTY",
@@ -12004,12 +12004,12 @@
       {
         "slug": "LINEAR_CREATE_LINEAR_COMMENT",
         "name": "Create a comment",
-        "description": "Creates a new comment on a specified Linear issue. This action modifies shared workspace data and is not reversible — confirm the target issue and comment content before executing."
+        "description": "Creates a new comment on a specified Linear issue. This action modifies shared workspace data and is not reversible \u2014 confirm the target issue and comment content before executing."
       },
       {
         "slug": "LINEAR_CREATE_LINEAR_ISSUE",
         "name": "Create linear issue",
-        "description": "Creates a new issue in a specified Linear project and team, requiring team_id and title, and allowing optional properties like description, assignee, state, priority, cycle, and due date. All UUID parameters (state_id, assignee_id, cycle_id, label_ids, project_id) must belong to the same team as team_id. The created issue's id is returned in data.id — capture it for use as parent_id in sub-issues or follow-up operations. No template_id field exists; expand templates manually into title and description before calling."
+        "description": "Creates a new issue in a specified Linear project and team, requiring team_id and title, and allowing optional properties like description, assignee, state, priority, cycle, and due date. All UUID parameters (state_id, assignee_id, cycle_id, label_ids, project_id) must belong to the same team as team_id. The created issue's id is returned in data.id \u2014 capture it for use as parent_id in sub-issues or follow-up operations. No template_id field exists; expand templates manually into title and description before calling."
       },
       {
         "slug": "LINEAR_CREATE_LINEAR_ISSUE_RELATION",
@@ -12039,7 +12039,7 @@
       {
         "slug": "LINEAR_DELETE_LINEAR_ISSUE",
         "name": "Delete issue",
-        "description": "Archives an existing Linear issue by its ID, which is Linear's standard way of deleting issues; the operation is idempotent. Archiving is permanent with no built-in undo — confirm the issue identifier and title with the user before executing, especially in bulk operations."
+        "description": "Archives an existing Linear issue by its ID, which is Linear's standard way of deleting issues; the operation is idempotent. Archiving is permanent with no built-in undo \u2014 confirm the issue identifier and title with the user before executing, especially in bulk operations."
       },
       {
         "slug": "LINEAR_GET_ALL_LINEAR_TEAMS",
@@ -12054,12 +12054,12 @@
       {
         "slug": "LINEAR_GET_CURRENT_USER",
         "name": "Get current user",
-        "description": "Gets the currently authenticated user's ID, name, email, and other profile information — this is the account behind the API token, which may be a bot or service account rather than a human user. Use the returned `id` field (nested under `data.viewer`) for downstream Linear operations requiring user ID filtering. To search or compare other workspace members, use LINEAR_LIST_LINEAR_USERS instead."
+        "description": "Gets the currently authenticated user's ID, name, email, and other profile information \u2014 this is the account behind the API token, which may be a bot or service account rather than a human user. Use the returned `id` field (nested under `data.viewer`) for downstream Linear operations requiring user ID filtering. To search or compare other workspace members, use LINEAR_LIST_LINEAR_USERS instead."
       },
       {
         "slug": "LINEAR_GET_CYCLES_BY_TEAM_ID",
         "name": "Get cycles by team ID",
-        "description": "Retrieves all cycles for a specified Linear team ID; cycles are time-boxed work periods (like sprints). Results are team-scoped to the given team_id. To identify the active cycle, check that the current date (in UTC) falls between a cycle's startAt and endAt fields; either field may be null. Results may be paginated — follow page_info cursors to retrieve all cycles."
+        "description": "Retrieves all cycles for a specified Linear team ID; cycles are time-boxed work periods (like sprints). Results are team-scoped to the given team_id. To identify the active cycle, check that the current date (in UTC) falls between a cycle's startAt and endAt fields; either field may be null. Results may be paginated \u2014 follow page_info cursors to retrieve all cycles."
       },
       {
         "slug": "LINEAR_GET_ISSUE_DEFAULTS",
@@ -12069,7 +12069,7 @@
       {
         "slug": "LINEAR_GET_LINEAR_ISSUE",
         "name": "Get Linear issue",
-        "description": "Retrieves an existing Linear issue's comprehensive details, including id, identifier, title, description, timestamps, state, team, creator, attachments, comments (with user info and timestamps, use issue.comments.nodes for comment IDs), subscribers, and due date. Does not include parent, milestone, cycle, or relation graphs—use LINEAR_RUN_QUERY_OR_MUTATION for those. Optional fields (labels, project, state, assignee, cycle) may be null; guard against null when accessing nested properties. Returns null or 'Entity not found' for invalid IDs, cross-workspace IDs, or restricted teams. Rate limit: ~60 req/min; HTTP 429 on excess—apply exponential backoff and respect Retry-After headers."
+        "description": "Retrieves an existing Linear issue's comprehensive details, including id, identifier, title, description, timestamps, state, team, creator, attachments, comments (with user info and timestamps, use issue.comments.nodes for comment IDs), subscribers, and due date. Does not include parent, milestone, cycle, or relation graphs\u2014use LINEAR_RUN_QUERY_OR_MUTATION for those. Optional fields (labels, project, state, assignee, cycle) may be null; guard against null when accessing nested properties. Returns null or 'Entity not found' for invalid IDs, cross-workspace IDs, or restricted teams. Rate limit: ~60 req/min; HTTP 429 on excess\u2014apply exponential backoff and respect Retry-After headers."
       },
       {
         "slug": "LINEAR_GET_LINEAR_PROJECT",
@@ -12089,7 +12089,7 @@
       {
         "slug": "LINEAR_LIST_LINEAR_CYCLES",
         "name": "Get all cycles",
-        "description": "Retrieves all cycles (time-boxed sprint iterations) org-wide from the Linear account; no filters applied. In large multi-team workspaces this produces heavy responses — filter client-side by team ID and date range using each cycle's startsAt/endsAt fields. Cycles are team-scoped; always group by team ID to avoid mixing sprints across teams. To identify the active sprint, verify the current UTC timestamp falls between startsAt and endsAt, and handle null startsAt/endsAt defensively. Timestamps are UTC. Results may be paginated; follow pageInfo.endCursor and hasNextPage until hasNextPage is false to avoid truncated lists."
+        "description": "Retrieves all cycles (time-boxed sprint iterations) org-wide from the Linear account; no filters applied. In large multi-team workspaces this produces heavy responses \u2014 filter client-side by team ID and date range using each cycle's startsAt/endsAt fields. Cycles are team-scoped; always group by team ID to avoid mixing sprints across teams. To identify the active sprint, verify the current UTC timestamp falls between startsAt and endsAt, and handle null startsAt/endsAt defensively. Timestamps are UTC. Results may be paginated; follow pageInfo.endCursor and hasNextPage until hasNextPage is false to avoid truncated lists."
       },
       {
         "slug": "LINEAR_LIST_LINEAR_ISSUES",
@@ -12099,32 +12099,32 @@
       {
         "slug": "LINEAR_LIST_LINEAR_LABELS",
         "name": "Get labels",
-        "description": "Retrieves labels from Linear. If team_id is provided, returns labels for that specific team; if omitted, returns all labels across the workspace. Label names are not unique across teams — always use returned IDs, not names, and track each label ID with its team ID. In large workspaces, results may paginate; follow pageInfo.hasNextPage and pageInfo.endCursor to retrieve all labels."
+        "description": "Retrieves labels from Linear. If team_id is provided, returns labels for that specific team; if omitted, returns all labels across the workspace. Label names are not unique across teams \u2014 always use returned IDs, not names, and track each label ID with its team ID. In large workspaces, results may paginate; follow pageInfo.hasNextPage and pageInfo.endCursor to retrieve all labels."
       },
       {
         "slug": "LINEAR_LIST_LINEAR_PROJECTS",
         "name": "List linear projects",
-        "description": "Retrieves all projects from the Linear account. Returns a flat array (not a GraphQL connection) with fields id and name; use LINEAR_RUN_QUERY_OR_MUTATION for progress, state, issues, or team linkage. No server-side filtering: all workspace projects are returned regardless of team or name — filter client-side. Multiple projects can share identical names; always confirm project_id before downstream use. Results are permission-scoped to the connected user. Pagination: loop while page_info.hasNextPage is true, passing page_info.endCursor as after, or results will be silently truncated. HTTP 429 may occur in large workspaces; apply exponential backoff between calls."
+        "description": "Retrieves all projects from the Linear account. Returns a flat array (not a GraphQL connection) with fields id and name; use LINEAR_RUN_QUERY_OR_MUTATION for progress, state, issues, or team linkage. No server-side filtering: all workspace projects are returned regardless of team or name \u2014 filter client-side. Multiple projects can share identical names; always confirm project_id before downstream use. Results are permission-scoped to the connected user. Pagination: loop while page_info.hasNextPage is true, passing page_info.endCursor as after, or results will be silently truncated. HTTP 429 may occur in large workspaces; apply exponential backoff between calls."
       },
       {
         "slug": "LINEAR_LIST_LINEAR_STATES",
         "name": "List Linear states",
-        "description": "Retrieves all workflow states for a specified team in Linear, representing the stages an issue progresses through in that team's workflow. Returned state IDs are team-scoped — never reuse a stateId across different teams, as this causes validation errors or 'Entity not found' failures in tools like LINEAR_UPDATE_ISSUE. State names (e.g., 'Done', 'In Progress') are non-unique across teams; always resolve names to IDs via this tool for the specific team_id before using them in filters or mutations. Uses cursor-based pagination via pageInfo.hasNextPage and endCursor; iterate until hasNextPage is false to avoid missing states in large workspaces. Always fetch fresh state IDs rather than hardcoding or reusing stale values."
+        "description": "Retrieves all workflow states for a specified team in Linear, representing the stages an issue progresses through in that team's workflow. Returned state IDs are team-scoped \u2014 never reuse a stateId across different teams, as this causes validation errors or 'Entity not found' failures in tools like LINEAR_UPDATE_ISSUE. State names (e.g., 'Done', 'In Progress') are non-unique across teams; always resolve names to IDs via this tool for the specific team_id before using them in filters or mutations. Uses cursor-based pagination via pageInfo.hasNextPage and endCursor; iterate until hasNextPage is false to avoid missing states in large workspaces. Always fetch fresh state IDs rather than hardcoding or reusing stale values."
       },
       {
         "slug": "LINEAR_LIST_LINEAR_TEAMS",
         "name": "Get teams",
-        "description": "Retrieves all teams with their members and projects. Use stable team IDs or keys (not display names) for subsequent operations — names are non-unique. Results reflect only teams visible to the authenticated token scope; missing teams or members indicate permission limits. Large workspaces paginate via pageInfo.hasNextPage/endCursor — incomplete pagination silently drops teams or members. Members may belong to multiple teams; deduplicate user IDs when aggregating. Use LINEAR_GET_ALL_LINEAR_TEAMS instead when only identifiers are needed."
+        "description": "Retrieves all teams with their members and projects. Use stable team IDs or keys (not display names) for subsequent operations \u2014 names are non-unique. Results reflect only teams visible to the authenticated token scope; missing teams or members indicate permission limits. Large workspaces paginate via pageInfo.hasNextPage/endCursor \u2014 incomplete pagination silently drops teams or members. Members may belong to multiple teams; deduplicate user IDs when aggregating. Use LINEAR_GET_ALL_LINEAR_TEAMS instead when only identifiers are needed."
       },
       {
         "slug": "LINEAR_LIST_LINEAR_USERS",
         "name": "List Linear users",
-        "description": "Lists all workspace users (not team-scoped) with their IDs, names, emails, and active status. Display names are non-unique — use email to disambiguate before extracting an ID. Only assign users with `active: true`. Returned IDs are UUID strings; pass them as-is to fields like `assignee_id` — never substitute names, emails, or tokens. When joining with other tools, always join on IDs."
+        "description": "Lists all workspace users (not team-scoped) with their IDs, names, emails, and active status. Display names are non-unique \u2014 use email to disambiguate before extracting an ID. Only assign users with `active: true`. Returned IDs are UUID strings; pass them as-is to fields like `assignee_id` \u2014 never substitute names, emails, or tokens. When joining with other tools, always join on IDs."
       },
       {
         "slug": "LINEAR_REMOVE_ISSUE_LABEL",
         "name": "Remove label from Linear issue",
-        "description": "Removes a specified label from an existing Linear issue using their IDs; successful even if the label isn't on the issue. Operation is irreversible — obtain explicit user approval before executing. Use this tool instead of LINEAR_UPDATE_ISSUE to avoid replacing the entire label set."
+        "description": "Removes a specified label from an existing Linear issue using their IDs; successful even if the label isn't on the issue. Operation is irreversible \u2014 obtain explicit user approval before executing. Use this tool instead of LINEAR_UPDATE_ISSUE to avoid replacing the entire label set."
       },
       {
         "slug": "LINEAR_REMOVE_REACTION",
@@ -12144,7 +12144,7 @@
       {
         "slug": "LINEAR_UPDATE_ISSUE",
         "name": "Update issue",
-        "description": "Updates an existing Linear issue using its `issue_id`; requires at least one other attribute for modification, and all provided entity IDs (for state, assignee, labels, etc.) must be valid UUIDs — only `issueId` accepts key format (e.g., 'ENG-123'). All updated fields are fully overwritten, not merged; omit any field you do not intend to change."
+        "description": "Updates an existing Linear issue using its `issue_id`; requires at least one other attribute for modification, and all provided entity IDs (for state, assignee, labels, etc.) must be valid UUIDs \u2014 only `issueId` accepts key format (e.g., 'ENG-123'). All updated fields are fully overwritten, not merged; omit any field you do not intend to change."
       },
       {
         "slug": "LINEAR_UPDATE_LINEAR_COMMENT",
@@ -12580,7 +12580,7 @@
       {
         "slug": "SERPAPI_BING_SEARCH",
         "name": "Bing Search",
-        "description": "Retrieve Bing Search Engine Results via SerpAPI (requires active SerpAPI connection; if unavailable, use COMPOSIO_SEARCH_WEB or COMPOSIO_SEARCH_NEWS). Consumes SerpAPI credits per call; throttle to ~1–2 calls/second and apply exponential backoff on HTTP 429. Supports query, location, language, and device parameters. Set `location`, `mkt`, or `cc` explicitly when local relevance matters — result ranking is highly sensitive to localization."
+        "description": "Retrieve Bing Search Engine Results via SerpAPI (requires active SerpAPI connection; if unavailable, use COMPOSIO_SEARCH_WEB or COMPOSIO_SEARCH_NEWS). Consumes SerpAPI credits per call; throttle to ~1\u20132 calls/second and apply exponential backoff on HTTP 429. Supports query, location, language, and device parameters. Set `location`, `mkt`, or `cc` explicitly when local relevance matters \u2014 result ranking is highly sensitive to localization."
       },
       {
         "slug": "SERPAPI_DUCK_DUCK_GO_LIGHT_SEARCH",
@@ -12660,7 +12660,7 @@
       {
         "slug": "SERPAPI_GOOGLE_JOBS_SEARCH",
         "name": "Google Jobs Search",
-        "description": "Retrieve Google Jobs Search Results via SerpApi. Returns job SERP data in JSON; key attributes like `work_from_home`, `posted_at`, `salary`, and `schedule_type` are nested under `detected_extensions` per job object and are often absent — treat as optional. Results may include stale postings; verify recency via `detected_extensions.posted_at`. Supports pagination, location filtering, and remote-job filtering."
+        "description": "Retrieve Google Jobs Search Results via SerpApi. Returns job SERP data in JSON; key attributes like `work_from_home`, `posted_at`, `salary`, and `schedule_type` are nested under `detected_extensions` per job object and are often absent \u2014 treat as optional. Results may include stale postings; verify recency via `detected_extensions.posted_at`. Supports pagination, location filtering, and remote-job filtering."
       },
       {
         "slug": "SERPAPI_GOOGLE_LENS_SEARCH",
@@ -12670,7 +12670,7 @@
       {
         "slug": "SERPAPI_GOOGLE_LIGHT_SEARCH",
         "name": "Google Light Search",
-        "description": "Retrieve Google Light Search Results via SerpApi. Requires an active SerpApi connection. Supports q, location, gl, hl, and other SERP parameters. Returns lightweight JSON SERP data; results are in organic_results (handle missing/empty gracefully). Snippets are shallow — follow citation URLs with BROWSER_TOOL_FETCH_WEBPAGE for full content. Rate limit: HTTP 429 under heavy use; keep to ~1–2 requests/sec with exponential backoff on retry."
+        "description": "Retrieve Google Light Search Results via SerpApi. Requires an active SerpApi connection. Supports q, location, gl, hl, and other SERP parameters. Returns lightweight JSON SERP data; results are in organic_results (handle missing/empty gracefully). Snippets are shallow \u2014 follow citation URLs with BROWSER_TOOL_FETCH_WEBPAGE for full content. Rate limit: HTTP 429 under heavy use; keep to ~1\u20132 requests/sec with exponential backoff on retry."
       },
       {
         "slug": "SERPAPI_GOOGLE_MAPS_POSTS",
@@ -12720,7 +12720,7 @@
       {
         "slug": "SERPAPI_NEWS_SEARCH",
         "name": "Search for news articles",
-        "description": "Searches Google News (via SerpApi, `tbm=nws`) for articles matching a query; precise key-phrase queries yield best results. Auth is handled via SerpApi connection — do not pass api_key as a parameter. Results returned under `news_results` field (~10 items/page). Rate-limited: throttle to ~1 req/s; HTTP 429 on bursts — apply exponential backoff (1s, 2s, 4s). Covers news content only; pair with SERPAPI_SEARCH for broader web sources. Headlines/snippets only — use EXA_GET_CONTENTS_ACTION for full article text."
+        "description": "Searches Google News (via SerpApi, `tbm=nws`) for articles matching a query; precise key-phrase queries yield best results. Auth is handled via SerpApi connection \u2014 do not pass api_key as a parameter. Results returned under `news_results` field (~10 items/page). Rate-limited: throttle to ~1 req/s; HTTP 429 on bursts \u2014 apply exponential backoff (1s, 2s, 4s). Covers news content only; pair with SERPAPI_SEARCH for broader web sources. Headlines/snippets only \u2014 use EXA_GET_CONTENTS_ACTION for full article text."
       },
       {
         "slug": "SERPAPI_OPEN_TABLE_REVIEWS",
@@ -12740,7 +12740,7 @@
       {
         "slug": "SERPAPI_SEARCH",
         "name": "Serp API search",
-        "description": "Performs a real-time Google search via the SerpAPI connection (must be active; if unavailable, use COMPOSIO_SEARCH_WEB or other COMPOSIO_SEARCH_* tools). Returns ~10 organic results per page nested under results.organic_results — not a flat list; handle missing/empty arrays. Paginate via start offset or serpapi_pagination.next; max num=100; stop when domains plateau to avoid quota exhaustion. Rate-limited: throttle to 1–2 req/s; HTTP 429 on bursts — apply exponential backoff (1s, 2s, 4s). Derive result rank from array index (absolute rank = start + index; no explicit rank field). Lacks date-bound controls — embed recency terms in query or use SERPAPI_NEWS_SEARCH for time-sensitive queries. Results may include ads and sponsored content; prefer authoritative domains. Use vertical tools (SERPAPI_IMAGE_SEARCH, SERPAPI_NEWS_SEARCH, SERPAPI_YOU_TUBE_SEARCH, SERPAPI_GOOGLE_JOBS_SEARCH) for specialized query types."
+        "description": "Performs a real-time Google search via the SerpAPI connection (must be active; if unavailable, use COMPOSIO_SEARCH_WEB or other COMPOSIO_SEARCH_* tools). Returns ~10 organic results per page nested under results.organic_results \u2014 not a flat list; handle missing/empty arrays. Paginate via start offset or serpapi_pagination.next; max num=100; stop when domains plateau to avoid quota exhaustion. Rate-limited: throttle to 1\u20132 req/s; HTTP 429 on bursts \u2014 apply exponential backoff (1s, 2s, 4s). Derive result rank from array index (absolute rank = start + index; no explicit rank field). Lacks date-bound controls \u2014 embed recency terms in query or use SERPAPI_NEWS_SEARCH for time-sensitive queries. Results may include ads and sponsored content; prefer authoritative domains. Use vertical tools (SERPAPI_IMAGE_SEARCH, SERPAPI_NEWS_SEARCH, SERPAPI_YOU_TUBE_SEARCH, SERPAPI_GOOGLE_JOBS_SEARCH) for specialized query types."
       },
       {
         "slug": "SERPAPI_SEARCH_APPLE_APP_STORE",
@@ -12770,7 +12770,7 @@
       {
         "slug": "SERPAPI_TRENDS_SEARCH",
         "name": "Google Trends search",
-        "description": "Fetches Google Trends data; returns relative 0–100 interest indices (not absolute volumes) meaningful only when comparing queries within the same request. The `query`'s format (single/multiple terms) must comply with the selected `data_type`."
+        "description": "Fetches Google Trends data; returns relative 0\u2013100 interest indices (not absolute volumes) meaningful only when comparing queries within the same request. The `query`'s format (single/multiple terms) must comply with the selected `data_type`."
       },
       {
         "slug": "SERPAPI_WALMART_PRODUCT_REVIEWS",
@@ -12976,7 +12976,7 @@
       {
         "slug": "JIRA_FIND_USERS",
         "name": "Find Users (Deprecated)",
-        "description": "DEPRECATED: Use JIRA_FIND_USERS2 instead. Searches for Jira users by email or display name to find account IDs; essential for assigning issues, adding watchers, and other user-related operations. Broad queries may return multiple matches — always disambiguate using full email before selecting an account_id. Results may include app/bot accounts; verify account_type is a human user before use in downstream operations."
+        "description": "DEPRECATED: Use JIRA_FIND_USERS2 instead. Searches for Jira users by email or display name to find account IDs; essential for assigning issues, adding watchers, and other user-related operations. Broad queries may return multiple matches \u2014 always disambiguate using full email before selecting an account_id. Results may include app/bot accounts; verify account_type is a human user before use in downstream operations."
       },
       {
         "slug": "JIRA_FIND_USERS2",
@@ -13001,7 +13001,7 @@
       {
         "slug": "JIRA_GET_ALL_PROJECTS",
         "name": "Get all projects",
-        "description": "Retrieves all visible projects using the modern paginated Jira API with server-side filtering and pagination support. Results reflect only projects the authenticated user can access — small or empty result sets may indicate permission restrictions, not absence of projects. An empty `values` array means no projects matched the filters; relax `query`, `status`, or `categoryId` if unexpected. Project keys are mutable; prefer the stable numeric project ID for durable references in follow-up calls."
+        "description": "Retrieves all visible projects using the modern paginated Jira API with server-side filtering and pagination support. Results reflect only projects the authenticated user can access \u2014 small or empty result sets may indicate permission restrictions, not absence of projects. An empty `values` array means no projects matched the filters; relax `query`, `status`, or `categoryId` if unexpected. Project keys are mutable; prefer the stable numeric project ID for durable references in follow-up calls."
       },
       {
         "slug": "JIRA_GET_ALL_STATUSES",
@@ -13011,7 +13011,7 @@
       {
         "slug": "JIRA_GET_ALL_USERS",
         "name": "Get All Users",
-        "description": "Retrieves all users from the Jira instance including active, inactive, app accounts, and system accounts, with pagination support. On Jira Cloud, fields like `email_address` may be redacted due to privacy settings — never treat them as guaranteed present. Successful responses may silently omit users due to permission restrictions; a smaller-than-expected result set may reflect access limits, not absence of users."
+        "description": "Retrieves all users from the Jira instance including active, inactive, app accounts, and system accounts, with pagination support. On Jira Cloud, fields like `email_address` may be redacted due to privacy settings \u2014 never treat them as guaranteed present. Successful responses may silently omit users due to permission restrictions; a smaller-than-expected result set may reflect access limits, not absence of users."
       },
       {
         "slug": "JIRA_GET_ATTACHMENT",
@@ -13041,7 +13041,7 @@
       {
         "slug": "JIRA_GET_CURRENT_USER",
         "name": "Get Current User",
-        "description": "Retrieves detailed information about the currently authenticated Jira user. The returned `accountId` is the correct identifier for fields like `lead_account_id` in JIRA_CREATE_PROJECT, JIRA_ADD_WATCHER_TO_ISSUE, and JIRA_REMOVE_WATCHER_FROM_ISSUE — never use email or username in those fields."
+        "description": "Retrieves detailed information about the currently authenticated Jira user. The returned `accountId` is the correct identifier for fields like `lead_account_id` in JIRA_CREATE_PROJECT, JIRA_ADD_WATCHER_TO_ISSUE, and JIRA_REMOVE_WATCHER_FROM_ISSUE \u2014 never use email or username in those fields."
       },
       {
         "slug": "JIRA_GET_DASHBOARDS",
@@ -13056,7 +13056,7 @@
       {
         "slug": "JIRA_GET_FIELDS",
         "name": "Get fields",
-        "description": "Tool to retrieve Jira issue fields metadata. Use before editing an issue to discover custom field IDs and names. Custom fields are addressed as customfield_XXXXX in API calls and cf[XXXXX] in JQL; using display names instead causes 400 Unknown field errors. Returns global metadata — cross-reference with JIRA_GET_ISSUE_EDIT_META before editing, as globally visible fields not listed there will also cause 400 errors when sent to JIRA_EDIT_ISSUE. Results are scoped to the authenticated user's permissions, so field sets may differ between users."
+        "description": "Tool to retrieve Jira issue fields metadata. Use before editing an issue to discover custom field IDs and names. Custom fields are addressed as customfield_XXXXX in API calls and cf[XXXXX] in JQL; using display names instead causes 400 Unknown field errors. Returns global metadata \u2014 cross-reference with JIRA_GET_ISSUE_EDIT_META before editing, as globally visible fields not listed there will also cause 400 errors when sent to JIRA_EDIT_ISSUE. Results are scoped to the authenticated user's permissions, so field sets may differ between users."
       },
       {
         "slug": "JIRA_GET_FIELDS_PAGINATED",
@@ -13176,7 +13176,7 @@
       {
         "slug": "JIRA_GET_PROJECT_VERSIONS",
         "name": "Get Project Versions",
-        "description": "Retrieves all versions for a Jira project with optional expansion. Use version IDs from the response (not names) when setting fixVersions or affectedVersions on issues — submitting names alone causes 400 validation errors."
+        "description": "Retrieves all versions for a Jira project with optional expansion. Use version IDs from the response (not names) when setting fixVersions or affectedVersions on issues \u2014 submitting names alone causes 400 validation errors."
       },
       {
         "slug": "JIRA_GET_RECENT_PROJECTS",
@@ -13206,7 +13206,7 @@
       {
         "slug": "JIRA_GET_TRANSITIONS",
         "name": "Get Transitions",
-        "description": "Retrieves available workflow transitions for a Jira issue. Always use the numeric `id` from the response when calling JIRA_TRANSITION_ISSUE — transition IDs are project/workflow-specific and must not be hardcoded or reused across different issues or projects. When multiple transitions share similar names, use `id` to disambiguate."
+        "description": "Retrieves available workflow transitions for a Jira issue. Always use the numeric `id` from the response when calling JIRA_TRANSITION_ISSUE \u2014 transition IDs are project/workflow-specific and must not be hardcoded or reused across different issues or projects. When multiple transitions share similar names, use `id` to disambiguate."
       },
       {
         "slug": "JIRA_GET_UNIVERSAL_AVATAR_TYPE_OWNER",
@@ -13595,7 +13595,7 @@
       {
         "slug": "FIRECRAWL_DEEP_RESEARCH",
         "name": "Perform deep research",
-        "description": "Initiates an AI-powered deep research operation that autonomously explores the web to investigate any topic and synthesizes findings from multiple sources. Requires an active Firecrawl connection. The research process iteratively searches, analyzes, and synthesizes information across multiple web sources, providing comprehensive insights with source citations. Results include a final analysis, detailed activity timeline, and curated source list. Billing: 1 credit per URL analyzed. Control costs with the maxUrls parameter. Note: This API is in Alpha and being deprecated after June 30, 2025; prefer FIRECRAWL_SEARCH + FIRECRAWL_EXTRACT or COMPOSIO_SEARCH_WEB for durable workflows. Reserve this tool for cases requiring synthesized multi-source analysis — it is slower and more resource-intensive than FIRECRAWL_SEARCH."
+        "description": "Initiates an AI-powered deep research operation that autonomously explores the web to investigate any topic and synthesizes findings from multiple sources. Requires an active Firecrawl connection. The research process iteratively searches, analyzes, and synthesizes information across multiple web sources, providing comprehensive insights with source citations. Results include a final analysis, detailed activity timeline, and curated source list. Billing: 1 credit per URL analyzed. Control costs with the maxUrls parameter. Note: This API is in Alpha and being deprecated after June 30, 2025; prefer FIRECRAWL_SEARCH + FIRECRAWL_EXTRACT or COMPOSIO_SEARCH_WEB for durable workflows. Reserve this tool for cases requiring synthesized multi-source analysis \u2014 it is slower and more resource-intensive than FIRECRAWL_SEARCH."
       },
       {
         "slug": "FIRECRAWL_EXTRACT",
@@ -14223,7 +14223,7 @@
       {
         "slug": "SLACKBOT_ENABLE_PUBLIC_SHARING_OF_A_FILE",
         "name": "Share file public url",
-        "description": "Enables public sharing for an existing Slack file by generating a publicly accessible URL; this action does not create new files. Once enabled, the file is accessible to anyone with the URL — verify intent before sharing sensitive or confidential files."
+        "description": "Enables public sharing for an existing Slack file by generating a publicly accessible URL; this action does not create new files. Once enabled, the file is accessible to anyone with the URL \u2014 verify intent before sharing sensitive or confidential files."
       },
       {
         "slug": "SLACKBOT_ENABLE_USER_GROUP",
@@ -14258,7 +14258,7 @@
       {
         "slug": "SLACKBOT_FIND_CHANNELS",
         "name": "Find channels",
-        "description": "Find channels in a Slack workspace by any criteria - name, topic, purpose, or description. Returns channel IDs (C*/G* prefixed) required by most Slack tools — always resolve names to IDs here before passing to other tools. NOTE: This action can only search channels visible to the bot. Empty results may indicate: - No channels match the search query in name, topic, or purpose - The target channel is private and the bot hasn't been invited - The bot lacks required scopes (channels:read, groups:read). If empty, retry with exact_match=false or exclude_archived=false to avoid false negatives. In large workspaces, paginate using next_cursor to avoid missing matches. Check 'composio_execution_message' and 'total_channels_searched' in the response for details."
+        "description": "Find channels in a Slack workspace by any criteria - name, topic, purpose, or description. Returns channel IDs (C*/G* prefixed) required by most Slack tools \u2014 always resolve names to IDs here before passing to other tools. NOTE: This action can only search channels visible to the bot. Empty results may indicate: - No channels match the search query in name, topic, or purpose - The target channel is private and the bot hasn't been invited - The bot lacks required scopes (channels:read, groups:read). If empty, retry with exact_match=false or exclude_archived=false to avoid false negatives. In large workspaces, paginate using next_cursor to avoid missing matches. Check 'composio_execution_message' and 'total_channels_searched' in the response for details."
       },
       {
         "slug": "SLACKBOT_FIND_USER_BY_EMAIL_ADDRESS",
@@ -14333,7 +14333,7 @@
       {
         "slug": "SLACKBOT_LIST_ALL_USERS",
         "name": "List all users",
-        "description": "Retrieves a paginated list of all users with profile details, status, and team memberships in a Slack workspace; data may not be real-time. Filter response fields `is_bot`, `is_app_user`, and `deleted` to build human-only rosters. Profile fields like `email` and `phone` may be absent depending on OAuth scopes and workspace privacy settings. Guest/restricted accounts may be omitted based on scopes—do not treat results as a complete directory. High-frequency calls risk HTTP 429; honor the `Retry-After` header and throttle to ~1–2 requests/second. Use stable user IDs rather than display names for mapping. Prefer SLACK_FIND_USERS for targeted lookups; cache results to avoid full-workspace fetches."
+        "description": "Retrieves a paginated list of all users with profile details, status, and team memberships in a Slack workspace; data may not be real-time. Filter response fields `is_bot`, `is_app_user`, and `deleted` to build human-only rosters. Profile fields like `email` and `phone` may be absent depending on OAuth scopes and workspace privacy settings. Guest/restricted accounts may be omitted based on scopes\u2014do not treat results as a complete directory. High-frequency calls risk HTTP 429; honor the `Retry-After` header and throttle to ~1\u20132 requests/second. Use stable user IDs rather than display names for mapping. Prefer SLACK_FIND_USERS for targeted lookups; cache results to avoid full-workspace fetches."
       },
       {
         "slug": "SLACKBOT_LIST_CANVASES",
@@ -14353,7 +14353,7 @@
       {
         "slug": "SLACKBOT_LIST_FILES_WITH_FILTERS_IN_SLACK",
         "name": "List Slack files",
-        "description": "Lists files and their metadata within a Slack workspace, filterable by user, channel, timestamp, or type; returns metadata only, not file content. Results are limited to files visible to the authenticated user — files in private channels or restricted to certain members require appropriate membership and permissions. For large workspaces, check `paging.pages` in the response to determine total pages when paginating."
+        "description": "Lists files and their metadata within a Slack workspace, filterable by user, channel, timestamp, or type; returns metadata only, not file content. Results are limited to files visible to the authenticated user \u2014 files in private channels or restricted to certain members require appropriate membership and permissions. For large workspaces, check `paging.pages` in the response to determine total pages when paginating."
       },
       {
         "slug": "SLACKBOT_LIST_PINNED_ITEMS",
@@ -14363,7 +14363,7 @@
       {
         "slug": "SLACKBOT_LIST_REMINDERS",
         "name": "List reminders",
-        "description": "Lists all reminders with their details for the authenticated Slack user; returns an empty array if no reminders exist (valid state, not an error). Reminder text is not unique—perform client-side matching on returned objects before extracting a reminder ID for use with SLACK_MARK_REMINDER_AS_COMPLETE or SLACK_DELETE_A_SLACK_REMINDER."
+        "description": "Lists all reminders with their details for the authenticated Slack user; returns an empty array if no reminders exist (valid state, not an error). Reminder text is not unique\u2014perform client-side matching on returned objects before extracting a reminder ID for use with SLACK_MARK_REMINDER_AS_COMPLETE or SLACK_DELETE_A_SLACK_REMINDER."
       },
       {
         "slug": "SLACKBOT_LIST_REMOTE_FILES",
@@ -14398,7 +14398,7 @@
       {
         "slug": "SLACKBOT_OPEN_DM",
         "name": "Open DM",
-        "description": "Opens or resumes a Slack direct message (DM) or multi-person direct message (MPIM) by providing either user IDs or an existing channel ID. Returns `already_open=true` when the DM exists — treat as success and reuse the returned `channel.id` (starts with 'D') for subsequent SLACK_SEND_MESSAGE calls; passing a username, email, or user ID directly to SLACK_SEND_MESSAGE causes `channel_not_found`. Avoid redundant calls when an existing DM channel ID is available."
+        "description": "Opens or resumes a Slack direct message (DM) or multi-person direct message (MPIM) by providing either user IDs or an existing channel ID. Returns `already_open=true` when the DM exists \u2014 treat as success and reuse the returned `channel.id` (starts with 'D') for subsequent SLACK_SEND_MESSAGE calls; passing a username, email, or user ID directly to SLACK_SEND_MESSAGE causes `channel_not_found`. Avoid redundant calls when an existing DM channel ID is available."
       },
       {
         "slug": "SLACKBOT_PIN_ITEM",
@@ -14473,7 +14473,7 @@
       {
         "slug": "SLACKBOT_SEARCH_MESSAGES",
         "name": "Search messages",
-        "description": "Workspace‑wide Slack message search with date ranges and filters. Use `query` modifiers (e.g., in:#channel, from:@user, before/after:YYYY-MM-DD), sorting (score/timestamp), and pagination."
+        "description": "Workspace\u2011wide Slack message search with date ranges and filters. Use `query` modifiers (e.g., in:#channel, from:@user, before/after:YYYY-MM-DD), sorting (score/timestamp), and pagination."
       },
       {
         "slug": "SLACKBOT_SEND_EPHEMERAL_MESSAGE",
@@ -14488,7 +14488,7 @@
       {
         "slug": "SLACKBOT_SEND_MESSAGE",
         "name": "Send message",
-        "description": "Posts a message to a Slack channel, DM, or private group; requires at least one content field (`markdown_text`, `text`, `blocks`, or `attachments`) — omitting all causes a `no_text` error. Fails with `not_in_channel`, `channel_not_found`, or `channel_is_archived` if the bot lacks access. Body limit ~4000 characters. Rate-limited at ~1 req/sec (HTTP 429, honor `Retry-After`). Not idempotent — duplicate calls post duplicate messages."
+        "description": "Posts a message to a Slack channel, DM, or private group; requires at least one content field (`markdown_text`, `text`, `blocks`, or `attachments`) \u2014 omitting all causes a `no_text` error. Fails with `not_in_channel`, `channel_not_found`, or `channel_is_archived` if the bot lacks access. Body limit ~4000 characters. Rate-limited at ~1 req/sec (HTTP 429, honor `Retry-After`). Not idempotent \u2014 duplicate calls post duplicate messages."
       },
       {
         "slug": "SLACKBOT_SET_CONVERSATION_PURPOSE",
@@ -18232,7 +18232,7 @@
       {
         "slug": "GOOGLETASKS_DELETE_TASK",
         "name": "Delete task",
-        "description": "Deletes a specified task from a Google Tasks list. Deletion is permanent and irreversible — confirm with the user before executing, and consider GOOGLETASKS_UPDATE_TASK or GOOGLETASKS_MOVE_TASK as non-destructive alternatives. Both tasklist_id and task_id are required parameters. The Google Tasks API does not support deleting tasks by task_id alone — you must specify which task list contains the task. Use 'List Task Lists' to get available list IDs, then 'List Tasks' to find the task_id within that list."
+        "description": "Deletes a specified task from a Google Tasks list. Deletion is permanent and irreversible \u2014 confirm with the user before executing, and consider GOOGLETASKS_UPDATE_TASK or GOOGLETASKS_MOVE_TASK as non-destructive alternatives. Both tasklist_id and task_id are required parameters. The Google Tasks API does not support deleting tasks by task_id alone \u2014 you must specify which task list contains the task. Use 'List Task Lists' to get available list IDs, then 'List Tasks' to find the task_id within that list."
       },
       {
         "slug": "GOOGLETASKS_DELETE_TASK_LIST",
@@ -18252,7 +18252,7 @@
       {
         "slug": "GOOGLETASKS_INSERT_TASK",
         "name": "Insert Task",
-        "description": "Creates a new task in a given `tasklist_id`, optionally as a subtask of an existing `task_parent` or positioned after an existing `task_previous` sibling, where both `task_parent` and `task_previous` must belong to the same `tasklist_id` if specified. IMPORTANT: Date fields (due, completed) accept various formats like '28 Sep 2025', '11:59 PM, 22 Sep 2025', or ISO format '2025-09-21T15:30:00Z' and will automatically convert them to RFC3339 format required by the API. Not idempotent — repeated calls with identical parameters create duplicate tasks; track returned task IDs to avoid duplication. High-volume inserts may trigger 403 rateLimitExceeded or 429; apply exponential backoff."
+        "description": "Creates a new task in a given `tasklist_id`, optionally as a subtask of an existing `task_parent` or positioned after an existing `task_previous` sibling, where both `task_parent` and `task_previous` must belong to the same `tasklist_id` if specified. IMPORTANT: Date fields (due, completed) accept various formats like '28 Sep 2025', '11:59 PM, 22 Sep 2025', or ISO format '2025-09-21T15:30:00Z' and will automatically convert them to RFC3339 format required by the API. Not idempotent \u2014 repeated calls with identical parameters create duplicate tasks; track returned task IDs to avoid duplication. High-volume inserts may trigger 403 rateLimitExceeded or 429; apply exponential backoff."
       },
       {
         "slug": "GOOGLETASKS_LIST_ALL_TASKS",
@@ -18262,7 +18262,7 @@
       {
         "slug": "GOOGLETASKS_LIST_TASK_LISTS",
         "name": "List task lists",
-        "description": "Fetches the authenticated user's task lists from Google Tasks; results may be paginated. Response contains task lists under the `items` key. Multiple lists may share similar names — confirm the correct list by ID before passing to other tools."
+        "description": "Fetches the authenticated user's task lists from Google Tasks; results may be paginated. Response contains task lists under the `items` key. Multiple lists may share similar names \u2014 confirm the correct list by ID before passing to other tools."
       },
       {
         "slug": "GOOGLETASKS_LIST_TASKS",
@@ -18608,17 +18608,17 @@
       {
         "slug": "FIGMA_DISCOVER_FIGMA_RESOURCES",
         "name": "Discover Figma Resources",
-        "description": "Smart Figma resource discovery - extract IDs from any Figma URL. Supports all URL formats: /file/, /design/, /board/, /proto/, /slides/ Example: figma.com/board/ABC123/Name → file_key=ABC123 Discovery workflow: team_id → projects → files → nodes Use extracted IDs with GetFileJson, DetectBackground, etc."
+        "description": "Smart Figma resource discovery - extract IDs from any Figma URL. Supports all URL formats: /file/, /design/, /board/, /proto/, /slides/ Example: figma.com/board/ABC123/Name \u2192 file_key=ABC123 Discovery workflow: team_id \u2192 projects \u2192 files \u2192 nodes Use extracted IDs with GetFileJson, DetectBackground, etc."
       },
       {
         "slug": "FIGMA_DOWNLOAD_FIGMA_IMAGES",
         "name": "Download Figma Images",
-        "description": "Download images from Figma file nodes. Renders specified nodes as images and downloads them. Supports PNG, SVG, JPG, and PDF formats. REQUIRED PARAMETERS: - file_key (string): The Figma file key from the URL - images (array): List of objects, each containing: - node_id (string, required): The node ID to export (e.g., \"1:2\") - file_name (string, required): Output filename with extension (e.g., \"logo.png\") - format (string, optional): One of 'png', 'svg', 'jpg', 'pdf'. Defaults to 'png' Example usage: { \"file_key\": \"abc123XYZ\", \"images\": [ {\"node_id\": \"1:2\", \"file_name\": \"logo.png\", \"format\": \"png\"} ] } To find node IDs, use FIGMA_GET_FILE_JSON or look in Figma URLs after 'node-id='. NOTE: Returned image URLs expire shortly after generation — download them immediately."
+        "description": "Download images from Figma file nodes. Renders specified nodes as images and downloads them. Supports PNG, SVG, JPG, and PDF formats. REQUIRED PARAMETERS: - file_key (string): The Figma file key from the URL - images (array): List of objects, each containing: - node_id (string, required): The node ID to export (e.g., \"1:2\") - file_name (string, required): Output filename with extension (e.g., \"logo.png\") - format (string, optional): One of 'png', 'svg', 'jpg', 'pdf'. Defaults to 'png' Example usage: { \"file_key\": \"abc123XYZ\", \"images\": [ {\"node_id\": \"1:2\", \"file_name\": \"logo.png\", \"format\": \"png\"} ] } To find node IDs, use FIGMA_GET_FILE_JSON or look in Figma URLs after 'node-id='. NOTE: Returned image URLs expire shortly after generation \u2014 download them immediately."
       },
       {
         "slug": "FIGMA_EXTRACT_DESIGN_TOKENS",
         "name": "Extract design tokens",
-        "description": "Extract design tokens from Figma files by combining styles, variables, and node-extracted values. Only values defined as Figma styles or variables are captured — any design values not encoded as styles/variables are silently omitted. Requires `file_variables:read` scope and a Figma plan that supports variables for full output; if variables return empty, supplement with FIGMA_GET_LOCAL_VARIABLES."
+        "description": "Extract design tokens from Figma files by combining styles, variables, and node-extracted values. Only values defined as Figma styles or variables are captured \u2014 any design values not encoded as styles/variables are silently omitted. Requires `file_variables:read` scope and a Figma plan that supports variables for full output; if variables return empty, supplement with FIGMA_GET_LOCAL_VARIABLES."
       },
       {
         "slug": "FIGMA_EXTRACT_PROTOTYPE_INTERACTIONS",
@@ -18953,7 +18953,7 @@
       {
         "slug": "COMPOSIO_SEARCH_FINANCE",
         "name": "Composio Finance Search",
-        "description": "Get real-time stock prices, market data, financial news, and company information with historical analysis. Retrieves stock quotes, market indices, cryptocurrency prices, exchange rates, and financial news. Supports discrete time windows (1D, 5D, 1M, 6M, YTD, 1Y, 5Y, MAX) for historical analysis. Returns numeric time-series graph data, summary information, and key events (6M+ windows only). Always verify finance_results_state in the response — HTTP 200 with status='Success' can still return empty data. Derived indicators (MACD, moving averages) are not included and must be computed from returned price series. Examples: query=\"AAPL:NASDAQ\" + window=\"1Y\" for Apple's 1-year chart query=\"GOOGL:NASDAQ\" + window=\"6M\" + hl=\"en\" for Alphabet with news events query=\"WMT:NYSE\" + window=\"MAX\" for Walmart's full history query=\"BTC-USD\" for Bitcoin query=\"EUR-USD\" for Euro/USD rate"
+        "description": "Get real-time stock prices, market data, financial news, and company information with historical analysis. Retrieves stock quotes, market indices, cryptocurrency prices, exchange rates, and financial news. Supports discrete time windows (1D, 5D, 1M, 6M, YTD, 1Y, 5Y, MAX) for historical analysis. Returns numeric time-series graph data, summary information, and key events (6M+ windows only). Always verify finance_results_state in the response \u2014 HTTP 200 with status='Success' can still return empty data. Derived indicators (MACD, moving averages) are not included and must be computed from returned price series. Examples: query=\"AAPL:NASDAQ\" + window=\"1Y\" for Apple's 1-year chart query=\"GOOGL:NASDAQ\" + window=\"6M\" + hl=\"en\" for Alphabet with news events query=\"WMT:NYSE\" + window=\"MAX\" for Walmart's full history query=\"BTC-USD\" for Bitcoin query=\"EUR-USD\" for Euro/USD rate"
       },
       {
         "slug": "COMPOSIO_SEARCH_FLIGHTS",
@@ -18963,27 +18963,27 @@
       {
         "slug": "COMPOSIO_SEARCH_GOOGLE_MAPS",
         "name": "Composio Google Maps Search",
-        "description": "Performs a location-specific search via the Composio Google Maps Search API, returning results under `results.local_results` (multi-place queries) or `results.place_results` (single place); always handle both branches. Fields like `opening_hours`, `phone`, `rating`, and `user_reviews` may be absent — treat missing values as unknown. Check `business_status`: closed businesses (`CLOSED_PERMANENTLY`, `TEMPORARILY_CLOSED`) can appear in results; filter for `OPERATIONAL` entries. Rate-limit calls to ~1 req/sec; HTTP 429 / `OVER_QUERY_LIMIT` indicates quota exhaustion. `gps_coordinates` may appear under `place_results` or inside individual `local_results` items."
+        "description": "Performs a location-specific search via the Composio Google Maps Search API, returning results under `results.local_results` (multi-place queries) or `results.place_results` (single place); always handle both branches. Fields like `opening_hours`, `phone`, `rating`, and `user_reviews` may be absent \u2014 treat missing values as unknown. Check `business_status`: closed businesses (`CLOSED_PERMANENTLY`, `TEMPORARILY_CLOSED`) can appear in results; filter for `OPERATIONAL` entries. Rate-limit calls to ~1 req/sec; HTTP 429 / `OVER_QUERY_LIMIT` indicates quota exhaustion. `gps_coordinates` may appear under `place_results` or inside individual `local_results` items."
       },
       {
         "slug": "COMPOSIO_SEARCH_GROQ_CHAT",
         "name": "Groq Chat Completion",
-        "description": "Execute fast LLM inference using Groq's optimized hardware and API. Groq provides ultra-fast inference for open-source models including LLaMA 3, Mixtral, and Gemma via OpenAI-compatible chat completions API. Use cases: real-time chat, content generation, Q&A, code generation, summarization, translation. For structured JSON output, instruct the model explicitly to return valid JSON with no markdown code fences or prose; validate with json.loads — batches of 150+ items are prone to malformed JSON. Strip triple-backtick wrappers from code/JSON outputs before parsing. Always validate that the response contains at least one choice with non-empty message.content before downstream use. On HTTP 429 or 5xx errors, use exponential backoff with a small retry cap; limit concurrency to ~3 concurrent calls. Model-reported character/word counts are approximate — verify independently when strict limits matter."
+        "description": "Execute fast LLM inference using Groq's optimized hardware and API. Groq provides ultra-fast inference for open-source models including LLaMA 3, Mixtral, and Gemma via OpenAI-compatible chat completions API. Use cases: real-time chat, content generation, Q&A, code generation, summarization, translation. For structured JSON output, instruct the model explicitly to return valid JSON with no markdown code fences or prose; validate with json.loads \u2014 batches of 150+ items are prone to malformed JSON. Strip triple-backtick wrappers from code/JSON outputs before parsing. Always validate that the response contains at least one choice with non-empty message.content before downstream use. On HTTP 429 or 5xx errors, use exponential backoff with a small retry cap; limit concurrency to ~3 concurrent calls. Model-reported character/word counts are approximate \u2014 verify independently when strict limits matter."
       },
       {
         "slug": "COMPOSIO_SEARCH_HOTELS",
         "name": "Hotel Search",
-        "description": "Search for hotels and vacation rentals with comprehensive filtering and pricing. Returns results under results.properties and results.ads; extract numeric pricing from rate_per_night.extracted_lowest, total_rate.extracted_lowest, or extracted_price (fields vary by property). Deduplicate across sections using property_token. Additional pages available via serpapi_pagination.next_page_token. Start with minimal filters — combining max_price, min_price, hotel_class, free_cancellation, gl, or hl too strictly can return empty results. Examples: q=\"New York\" + check_in_date=\"2025-06-01\" + check_out_date=\"2025-06-05\" + adults=2 q=\"Paris\" + check_in_date=\"2025-03-15\" + check_out_date=\"2025-03-18\" + min_price=100 + max_price=300 q=\"Tokyo\" + check_in_date=\"2025-12-20\" + check_out_date=\"2025-12-25\" + hotel_class=\"4,5\" + sort_by=3"
+        "description": "Search for hotels and vacation rentals with comprehensive filtering and pricing. Returns results under results.properties and results.ads; extract numeric pricing from rate_per_night.extracted_lowest, total_rate.extracted_lowest, or extracted_price (fields vary by property). Deduplicate across sections using property_token. Additional pages available via serpapi_pagination.next_page_token. Start with minimal filters \u2014 combining max_price, min_price, hotel_class, free_cancellation, gl, or hl too strictly can return empty results. Examples: q=\"New York\" + check_in_date=\"2025-06-01\" + check_out_date=\"2025-06-05\" + adults=2 q=\"Paris\" + check_in_date=\"2025-03-15\" + check_out_date=\"2025-03-18\" + min_price=100 + max_price=300 q=\"Tokyo\" + check_in_date=\"2025-12-20\" + check_out_date=\"2025-12-25\" + hotel_class=\"4,5\" + sort_by=3"
       },
       {
         "slug": "COMPOSIO_SEARCH_IMAGE",
         "name": "Composio Image Search",
-        "description": "The ImageSearch class performs an image search using the Composio Image Search API, targeting image metadata and URLs (not binary data) via Google Images. Returns results under `results.images_results`; each entry exposes `original` (full resolution) and `thumbnail` (low resolution) URLs — verify URLs are publicly accessible before passing downstream. Check `license_details_url` per result before commercial reuse. The number of results is controlled by `num` (1–100, default 20). For >100 images, paginate using `serpapi_pagination.next`. Rate limit: throttle to ~1–2 calls/second; apply exponential backoff on HTTP 429."
+        "description": "The ImageSearch class performs an image search using the Composio Image Search API, targeting image metadata and URLs (not binary data) via Google Images. Returns results under `results.images_results`; each entry exposes `original` (full resolution) and `thumbnail` (low resolution) URLs \u2014 verify URLs are publicly accessible before passing downstream. Check `license_details_url` per result before commercial reuse. The number of results is controlled by `num` (1\u2013100, default 20). For >100 images, paginate using `serpapi_pagination.next`. Rate limit: throttle to ~1\u20132 calls/second; apply exponential backoff on HTTP 429."
       },
       {
         "slug": "COMPOSIO_SEARCH_NEWS",
         "name": "Composio News Search",
-        "description": "Search for the latest news articles and current events with smart filtering. Searches news-oriented sources only (not blogs, docs, or company pages). Results nest under `data.results.news_results`; a 200 response with empty `news_results` or `news_results_state: 'Fully empty'` means no results — broaden query or `when` window. Auto-correction (`showing_results_for`) can silently redirect queries; verify returned articles match intended topic. Only first page returned by default; follow `pagination.next` for more pages. Supports 100+ languages and countries. Use advanced operators like 'site:' for publisher filtering directly in your query. Examples: query=\"artificial intelligence\" + when=\"w\" for past week's AI news query=\"climate change\" + gl=\"us\" + hl=\"en\" for US climate news query=\"business news\" + when=\"d\" for today's business news query=\"site:bbc.com tesla\" + when=\"d\" for today's BBC Tesla news"
+        "description": "Search for the latest news articles and current events with smart filtering. Searches news-oriented sources only (not blogs, docs, or company pages). Results nest under `data.results.news_results`; a 200 response with empty `news_results` or `news_results_state: 'Fully empty'` means no results \u2014 broaden query or `when` window. Auto-correction (`showing_results_for`) can silently redirect queries; verify returned articles match intended topic. Only first page returned by default; follow `pagination.next` for more pages. Supports 100+ languages and countries. Use advanced operators like 'site:' for publisher filtering directly in your query. Examples: query=\"artificial intelligence\" + when=\"w\" for past week's AI news query=\"climate change\" + gl=\"us\" + hl=\"en\" for US climate news query=\"business news\" + when=\"d\" for today's business news query=\"site:bbc.com tesla\" + when=\"d\" for today's BBC Tesla news"
       },
       {
         "slug": "COMPOSIO_SEARCH_NPPESNPI_LOOKUP",
@@ -18993,7 +18993,7 @@
       {
         "slug": "COMPOSIO_SEARCH_SCHOLAR",
         "name": "Composio Scholar Search",
-        "description": "Scholar API scrapes Google Scholar search results via SERP API, returning academic papers and scholarly articles. Results are nested under results.organic_results; access this key explicitly and use defensive .get() patterns as fields like DOI, citation_count, and author may be absent. Many results are paywalled — rely on titles, abstracts, and snippets when full text is unavailable. Results may include duplicate preprint and journal versions of the same work — deduplicate by DOI or normalized title. Only the first page is returned by default; follow pagination.next for additional pages. PDF links appear only under organic_results[n].resources where file_format is 'PDF'. Results may lag on recent work."
+        "description": "Scholar API scrapes Google Scholar search results via SERP API, returning academic papers and scholarly articles. Results are nested under results.organic_results; access this key explicitly and use defensive .get() patterns as fields like DOI, citation_count, and author may be absent. Many results are paywalled \u2014 rely on titles, abstracts, and snippets when full text is unavailable. Results may include duplicate preprint and journal versions of the same work \u2014 deduplicate by DOI or normalized title. Only the first page is returned by default; follow pagination.next for additional pages. PDF links appear only under organic_results[n].resources where file_format is 'PDF'. Results may lag on recent work."
       },
       {
         "slug": "COMPOSIO_SEARCH_SEC_FILINGS",
@@ -19013,12 +19013,12 @@
       {
         "slug": "COMPOSIO_SEARCH_TRENDS",
         "name": "Composio Trends Search",
-        "description": "Discover trending topics, search patterns, and popularity data. Analyzes search interest over time, compares multiple topics, and identifies rising trends. Returns normalized 0–100 relative interest indices (not absolute search volumes) via interest_over_time.timeline_data; values are objects with 'extracted_value' (may be string '<1'). The final timeline entry may have partial_data=true for incomplete periods. Data typically lags ~24–48 hours. Response schema varies by data_type: TIMESERIES returns timeline_data, GEO_MAP returns regional breakdowns, RELATED_TOPICS/RELATED_QUERIES return topic/query lists — parse accordingly. Ideal for market research, content planning, and SEO analysis."
+        "description": "Discover trending topics, search patterns, and popularity data. Analyzes search interest over time, compares multiple topics, and identifies rising trends. Returns normalized 0\u2013100 relative interest indices (not absolute search volumes) via interest_over_time.timeline_data; values are objects with 'extracted_value' (may be string '<1'). The final timeline entry may have partial_data=true for incomplete periods. Data typically lags ~24\u201348 hours. Response schema varies by data_type: TIMESERIES returns timeline_data, GEO_MAP returns regional breakdowns, RELATED_TOPICS/RELATED_QUERIES return topic/query lists \u2014 parse accordingly. Ideal for market research, content planning, and SEO analysis."
       },
       {
         "slug": "COMPOSIO_SEARCH_TRIP_ADVISOR",
         "name": "TripAdvisor Travel Search",
-        "description": "Search TripAdvisor for travel recommendations and itinerary planning without authentication (unlike TRIPADVISOR_CONTENT_API_SEARCH_LOCATIONS and other TripAdvisor tools requiring an active connection). Searches attractions, restaurants, hotels, tours, and activities. Returns detailed ratings, reviews, photos, and traveler recommendations. Response data is nested under results → locations. Results may include evergreen articles alongside specific venues; verify result type before use in itineraries. Examples: query=\"things to do in Paris\" + ssrc=\"A\" for attractions only | query=\"best restaurants in Tokyo\" + ssrc=\"r\" | query=\"hotels in Bali\" + ssrc=\"h\" + tripadvisor_domain=\"tripadvisor.com\""
+        "description": "Search TripAdvisor for travel recommendations and itinerary planning without authentication (unlike TRIPADVISOR_CONTENT_API_SEARCH_LOCATIONS and other TripAdvisor tools requiring an active connection). Searches attractions, restaurants, hotels, tours, and activities. Returns detailed ratings, reviews, photos, and traveler recommendations. Response data is nested under results \u2192 locations. Results may include evergreen articles alongside specific venues; verify result type before use in itineraries. Examples: query=\"things to do in Paris\" + ssrc=\"A\" for attractions only | query=\"best restaurants in Tokyo\" + ssrc=\"r\" | query=\"hotels in Bali\" + ssrc=\"h\" + tripadvisor_domain=\"tripadvisor.com\""
       },
       {
         "slug": "COMPOSIO_SEARCH_VERCEL_AI_CHAT",
@@ -19028,12 +19028,12 @@
       {
         "slug": "COMPOSIO_SEARCH_WALMART",
         "name": "Walmart Product Search",
-        "description": "Search Walmart for products with price filtering. This tool searches Walmart's product catalog including groceries, electronics, clothing, home goods, pharmacy, and auto services. Supports basic price range filtering for finding products within budget. Results may appear under response.data.results.shopping_results or data.products — do not hardcode a single response shape. Results mix sponsored and organic listings; check ad/sponsorship flags when ranking. Some products omit fields like bought_last_month; handle nulls in sorting logic. Examples: query=\"wireless headphones\" + min_price=50 + max_price=200 query=\"gaming laptop\" + max_price=800 query=\"organic coffee\" + min_price=10"
+        "description": "Search Walmart for products with price filtering. This tool searches Walmart's product catalog including groceries, electronics, clothing, home goods, pharmacy, and auto services. Supports basic price range filtering for finding products within budget. Results may appear under response.data.results.shopping_results or data.products \u2014 do not hardcode a single response shape. Results mix sponsored and organic listings; check ad/sponsorship flags when ranking. Some products omit fields like bought_last_month; handle nulls in sorting logic. Examples: query=\"wireless headphones\" + min_price=50 + max_price=200 query=\"gaming laptop\" + max_price=800 query=\"organic coffee\" + min_price=10"
       },
       {
         "slug": "COMPOSIO_SEARCH_WEB",
         "name": "Composio Web Search",
-        "description": "Perform a web search using the Exa API. Returns a nested structure: narrative summary under results.answer, sources under results.citations (and optionally results.organic_results). Prioritize results.citations as primary evidence over results.answer, which can be vague. Only indexes publicly available content — no paywalled, login-gated, or private content. No date filters enforced; include recency terms in query and verify dates in snippets manually. Throttle to ~1–2 requests/second; bursty queries trigger HTTP 429. Large responses may be stored remotely — use structure_info to locate results.answer and results.citations."
+        "description": "Perform a web search using the Exa API. Returns a nested structure: narrative summary under results.answer, sources under results.citations (and optionally results.organic_results). Prioritize results.citations as primary evidence over results.answer, which can be vague. Only indexes publicly available content \u2014 no paywalled, login-gated, or private content. No date filters enforced; include recency terms in query and verify dates in snippets manually. Throttle to ~1\u20132 requests/second; bursty queries trigger HTTP 429. Large responses may be stored remotely \u2014 use structure_info to locate results.answer and results.citations."
       }
     ],
     "triggers": [],
@@ -19073,7 +19073,7 @@
       {
         "slug": "REDDIT_CREATE_REDDIT_POST",
         "name": "Create a Reddit post",
-        "description": "Creates a new text or link post on a specified, existing Reddit subreddit, optionally applying a flair. Immediately publishes publicly visible content — confirm subreddit, title, and body with the user before executing. Posts may be silently removed post-submission by automoderator or subreddit rules (errors: SUBMIT_VALIDATION_BODY_BLACKLISTED_STRING, POST_GUIDANCE_VALIDATION_FAILED); verify visibility via the returned permalink. Rapid consecutive calls trigger RATELIMIT errors with cooldown hints."
+        "description": "Creates a new text or link post on a specified, existing Reddit subreddit, optionally applying a flair. Immediately publishes publicly visible content \u2014 confirm subreddit, title, and body with the user before executing. Posts may be silently removed post-submission by automoderator or subreddit rules (errors: SUBMIT_VALIDATION_BODY_BLACKLISTED_STRING, POST_GUIDANCE_VALIDATION_FAILED); verify visibility via the returned permalink. Rapid consecutive calls trigger RATELIMIT errors with cooldown hints."
       },
       {
         "slug": "REDDIT_DELETE_REDDIT_COMMENT",
@@ -19158,17 +19158,17 @@
       {
         "slug": "REDDIT_POST_REDDIT_COMMENT",
         "name": "Post a comment",
-        "description": "Posts a comment on Reddit, replying to an existing submission (post) or another comment. Fails if the target thread is locked, archived, or restricted — verify thread state beforehand. Rapid successive calls trigger Reddit RATELIMIT errors with explicit cooldown hints (e.g., 'take a break for 9 minutes'); honor the specified wait before retrying. A successful API response does not guarantee public visibility — automod or spam filters may silently remove the comment. Publishes immediately and publicly; confirm target and text before executing."
+        "description": "Posts a comment on Reddit, replying to an existing submission (post) or another comment. Fails if the target thread is locked, archived, or restricted \u2014 verify thread state beforehand. Rapid successive calls trigger Reddit RATELIMIT errors with explicit cooldown hints (e.g., 'take a break for 9 minutes'); honor the specified wait before retrying. A successful API response does not guarantee public visibility \u2014 automod or spam filters may silently remove the comment. Publishes immediately and publicly; confirm target and text before executing."
       },
       {
         "slug": "REDDIT_RETRIEVE_POST_COMMENTS",
         "name": "Retrieve Comments for a Post",
-        "description": "Retrieves all comments for a Reddit post given its base-36 article ID. Response is a two-element listings array: post metadata in `listings[0]`; comments in `listings[1].data.children` with text at each `[].data.body` and nested replies under each comment's `replies` field. Replies require recursive traversal to capture full discussion. Large, locked, or archived threads may return truncated trees or `more` placeholders rather than full results. Filter out comments where `body` is `[deleted]` or `[removed]`; use `parent_id` to reconstruct conversation flow. No time-filter parameter — compare `created_utc` against a UTC cutoff to filter by date."
+        "description": "Retrieves all comments for a Reddit post given its base-36 article ID. Response is a two-element listings array: post metadata in `listings[0]`; comments in `listings[1].data.children` with text at each `[].data.body` and nested replies under each comment's `replies` field. Replies require recursive traversal to capture full discussion. Large, locked, or archived threads may return truncated trees or `more` placeholders rather than full results. Filter out comments where `body` is `[deleted]` or `[removed]`; use `parent_id` to reconstruct conversation flow. No time-filter parameter \u2014 compare `created_utc` against a UTC cutoff to filter by date."
       },
       {
         "slug": "REDDIT_RETRIEVE_REDDIT_POST",
         "name": "Retrieve posts from subreddit",
-        "description": "Retrieves posts from a specified, publicly accessible subreddit. Responses nest post data under `data.children[].data`; inspect the structure before parsing. Pagination uses a `data.after` cursor; deduplicate across pages by post `id`. No built-in date filtering; compare `created_utc` (Unix seconds, UTC) client-side. Rate limit: ~1–2 requests/second; back off on HTTP 429."
+        "description": "Retrieves posts from a specified, publicly accessible subreddit. Responses nest post data under `data.children[].data`; inspect the structure before parsing. Pagination uses a `data.after` cursor; deduplicate across pages by post `id`. No built-in date filtering; compare `created_utc` (Unix seconds, UTC) client-side. Rate limit: ~1\u20132 requests/second; back off on HTTP 429."
       },
       {
         "slug": "REDDIT_RETRIEVE_SPECIFIC_COMMENT",
@@ -19178,7 +19178,7 @@
       {
         "slug": "REDDIT_SEARCH_ACROSS_SUBREDDITS",
         "name": "Search across subreddits",
-        "description": "Searches Reddit for posts/comments using a query. Results nested under `data.children[i].data` (kind `t3` for posts); a `posts` array may also appear — inspect actual response path. No native time-range filter; compare `created_utc` (Unix epoch, UTC) client-side for recency filtering. Empty `children` is a valid no-results outcome. Key post fields: `score`, `num_comments`, `created_utc`, `permalink`. Rate limit: ~1–2 requests/sec; HTTP 429 indicates throttling."
+        "description": "Searches Reddit for posts/comments using a query. Results nested under `data.children[i].data` (kind `t3` for posts); a `posts` array may also appear \u2014 inspect actual response path. No native time-range filter; compare `created_utc` (Unix epoch, UTC) client-side for recency filtering. Empty `children` is a valid no-results outcome. Key post fields: `score`, `num_comments`, `created_utc`, `permalink`. Rate limit: ~1\u20132 requests/sec; HTTP 429 indicates throttling."
       },
       {
         "slug": "REDDIT_TOGGLE_INBOX_REPLIES",
@@ -21081,7 +21081,7 @@
       {
         "slug": "EXA_GET_CONTENTS_ACTION",
         "name": "Get contents from URLs or document IDs",
-        "description": "Retrieves configurable text and highlights from a list of Exa document IDs or publicly accessible URLs. Calls may partially succeed — always inspect the per-item `statuses` array for errors like CRAWL_NOT_FOUND, CRAWL_LIVECRAWL_TIMEOUT, CRAWL_UNKNOWN_ERROR, or SOURCE_NOT_AVAILABLE. Retrieved text is nested under `results[i].text`, not a top-level field."
+        "description": "Retrieves configurable text and highlights from a list of Exa document IDs or publicly accessible URLs. Calls may partially succeed \u2014 always inspect the per-item `statuses` array for errors like CRAWL_NOT_FOUND, CRAWL_LIVECRAWL_TIMEOUT, CRAWL_UNKNOWN_ERROR, or SOURCE_NOT_AVAILABLE. Retrieved text is nested under `results[i].text`, not a top-level field."
       },
       {
         "slug": "EXA_GET_EVENT",
@@ -21116,7 +21116,7 @@
       {
         "slug": "EXA_SEARCH",
         "name": "Search",
-        "description": "Performs a web search using the Exa engine, useful for queries requiring advanced filtering, specific content categories, or AI-optimized prompting. Returns snippets and metadata only — use EXA_GET_CONTENTS_ACTION on returned URLs to retrieve full page content. No pagination; issue multiple calls with varied queries or date windows for broader coverage. IMPORTANT CONSTRAINTS: - includeDomains and excludeDomains are MUTUALLY EXCLUSIVE: You can use ONE or the OTHER, but NEVER both in the same request. Providing both will cause a validation error. TYPE-SPECIFIC PARAMETER COMPATIBILITY: - type='keyword': Fast exact matching. Does NOT support useAutoprompt, includeDomains, or excludeDomains. - type='neural': AI semantic search. Supports all parameters including useAutoprompt and domain filters. - type='auto': Smart routing. Supports all parameters."
+        "description": "Performs a web search using the Exa engine, useful for queries requiring advanced filtering, specific content categories, or AI-optimized prompting. Returns snippets and metadata only \u2014 use EXA_GET_CONTENTS_ACTION on returned URLs to retrieve full page content. No pagination; issue multiple calls with varied queries or date windows for broader coverage. IMPORTANT CONSTRAINTS: - includeDomains and excludeDomains are MUTUALLY EXCLUSIVE: You can use ONE or the OTHER, but NEVER both in the same request. Providing both will cause a validation error. TYPE-SPECIFIC PARAMETER COMPATIBILITY: - type='keyword': Fast exact matching. Does NOT support useAutoprompt, includeDomains, or excludeDomains. - type='neural': AI semantic search. Supports all parameters including useAutoprompt and domain filters. - type='auto': Smart routing. Supports all parameters."
       },
       {
         "slug": "EXA_UPDATE_IMPORT",
@@ -21265,7 +21265,7 @@
       {
         "slug": "SENTRY_CREATE_SCIM_GROUP_FOR_ORGANIZATION",
         "name": "Create scim group for organization",
-        "description": "Creates a new Sentry team (SCIM group) within an organization via the SCIM API. Requirements: - Organization must have SCIM enabled (requires Business Plan with SAML2) - Must use a SCIM bearer token (generated when SCIM is enabled) - Token must have 'team:admin' or 'team:write' scope Behavior: - A URL-friendly slug is auto-generated from displayName (e.g., 'My Team' → 'my-team') - Team is created with an empty member set - Members must be added separately through SCIM member operations - Returns SCIM 2.0 Group resource with unique ID Use this for SCIM provisioning workflows with identity providers like Okta or Azure AD."
+        "description": "Creates a new Sentry team (SCIM group) within an organization via the SCIM API. Requirements: - Organization must have SCIM enabled (requires Business Plan with SAML2) - Must use a SCIM bearer token (generated when SCIM is enabled) - Token must have 'team:admin' or 'team:write' scope Behavior: - A URL-friendly slug is auto-generated from displayName (e.g., 'My Team' \u2192 'my-team') - Team is created with an empty member set - Members must be added separately through SCIM member operations - Returns SCIM 2.0 Group resource with unique ID Use this for SCIM provisioning workflows with identity providers like Okta or Azure AD."
       },
       {
         "slug": "SENTRY_CREATE_SENTRY_EXTERNAL_ISSUE_LINK",
@@ -21290,12 +21290,12 @@
       {
         "slug": "SENTRY_DELETE_AN_ALERT",
         "name": "Delete an alert",
-        "description": "⚠️ This endpoint is currently in beta and may be subject to change. Deletes an alert. Use when you need to permanently remove an alert from an organization."
+        "description": "\u26a0\ufe0f This endpoint is currently in beta and may be subject to change. Deletes an alert. Use when you need to permanently remove an alert from an organization."
       },
       {
         "slug": "SENTRY_DELETE_BULK_ALERTS",
         "name": "Delete bulk alerts",
-        "description": "Bulk delete alerts for a given organization. Use when you need to delete multiple alerts at once. ⚠️ This endpoint is currently in beta and may be subject to change."
+        "description": "Bulk delete alerts for a given organization. Use when you need to delete multiple alerts at once. \u26a0\ufe0f This endpoint is currently in beta and may be subject to change."
       },
       {
         "slug": "SENTRY_DELETE_DSYMS_FOR_PROJECT",
@@ -21450,7 +21450,7 @@
       {
         "slug": "SENTRY_FETCH_ALERTS",
         "name": "Fetch alerts",
-        "description": "Retrieves a list of alerts (workflows) for a Sentry organization. Use to get alert configurations, statuses, and trigger details. ⚠️ Note: This endpoint is currently in beta and may be subject to change. It is supported by New Monitors and Alerts and may not be viewable in the UI today."
+        "description": "Retrieves a list of alerts (workflows) for a Sentry organization. Use to get alert configurations, statuses, and trigger details. \u26a0\ufe0f Note: This endpoint is currently in beta and may be subject to change. It is supported by New Monitors and Alerts and may not be viewable in the UI today."
       },
       {
         "slug": "SENTRY_FETCH_A_MONITOR",
@@ -21530,7 +21530,7 @@
       {
         "slug": "SENTRY_GET_ACTIVATION_OF_ALERT_RULE_FOR_ORGANIZATION",
         "name": "Get activation of alert rule for organization",
-        "description": "DEPRECATED: Retrieves all activations for a specific metric alert rule. ⚠️ WARNING: This endpoint has been removed from Sentry as of January 2025. The AlertRuleActivations feature was never fully released and has been completely removed from the Sentry codebase (database tables dropped in migration 0814). This action is retained for backwards compatibility but will fail with 404 errors. Sources: - https://github.com/getsentry/sentry/issues/81970 - https://github.com/getsentry/sentry/pull/83280 - https://github.com/getsentry/sentry/pull/83255"
+        "description": "DEPRECATED: Retrieves all activations for a specific metric alert rule. \u26a0\ufe0f WARNING: This endpoint has been removed from Sentry as of January 2025. The AlertRuleActivations feature was never fully released and has been completely removed from the Sentry codebase (database tables dropped in migration 0814). This action is retained for backwards compatibility but will fail with 404 errors. Sources: - https://github.com/getsentry/sentry/issues/81970 - https://github.com/getsentry/sentry/pull/83280 - https://github.com/getsentry/sentry/pull/83255"
       },
       {
         "slug": "SENTRY_GET_ALERTS",
@@ -22281,7 +22281,7 @@
       {
         "slug": "SNOWFLAKE_EXECUTE_SQL",
         "name": "Execute SQL",
-        "description": "Execute SQL statements in Snowflake and retrieve results. Supports SELECT queries for data retrieval, DDL statements (CREATE, ALTER, DROP) for schema management, and DML statements (INSERT, UPDATE, DELETE) for data modification. Returns comprehensive result metadata including column types, row counts, and execution status. Unquoted SQL identifiers are auto-uppercased by Snowflake — use matching case in `database`, `schema_name`, `warehouse`, and `role` parameters to avoid 'object not found' errors. Always apply explicit time-range filters and a LIMIT clause to unbounded SELECT queries to prevent large, slow result sets."
+        "description": "Execute SQL statements in Snowflake and retrieve results. Supports SELECT queries for data retrieval, DDL statements (CREATE, ALTER, DROP) for schema management, and DML statements (INSERT, UPDATE, DELETE) for data modification. Returns comprehensive result metadata including column types, row counts, and execution status. Unquoted SQL identifiers are auto-uppercased by Snowflake \u2014 use matching case in `database`, `schema_name`, `warehouse`, and `role` parameters to avoid 'object not found' errors. Always apply explicit time-range filters and a LIMIT clause to unbounded SELECT queries to prevent large, slow result sets."
       },
       {
         "slug": "SNOWFLAKE_FETCH_CATALOG_INTEGRATION",
@@ -22783,7 +22783,7 @@
       {
         "slug": "ELEVENLABS_GET_AGENT_DETAILS",
         "name": "Get agent details",
-        "description": "Tool to retrieve available Conversational AI agents and outbound-capable Twilio phone numbers. Use when selecting an agent and phone number for outbound calls. Always reference agents by agent_id (stable identifier), not agent_name (mutable). Returns basic metadata only — conversation_config and webhook settings require a separate ConvAI agent API call. Pass agent_id and agent_phone_number_id directly to ELEVENLABS_OUTBOUND_CALL; IDs must be current and owned by the authenticated account."
+        "description": "Tool to retrieve available Conversational AI agents and outbound-capable Twilio phone numbers. Use when selecting an agent and phone number for outbound calls. Always reference agents by agent_id (stable identifier), not agent_name (mutable). Returns basic metadata only \u2014 conversation_config and webhook settings require a separate ConvAI agent API call. Pass agent_id and agent_phone_number_id directly to ELEVENLABS_OUTBOUND_CALL; IDs must be current and owned by the authenticated account."
       },
       {
         "slug": "ELEVENLABS_GET_AGENT_LINK",
@@ -23223,7 +23223,7 @@
       {
         "slug": "ELEVENLABS_SUBMIT_BATCH_CALL",
         "name": "Submit Batch Call",
-        "description": "Tool to submit a batch call. Use when you need to initiate multiple calls (voice or WhatsApp) at once. Triggers real outbound calls immediately (if no scheduled_time_unix is set) or at the scheduled time — always confirm recipient list and call count with the user before executing."
+        "description": "Tool to submit a batch call. Use when you need to initiate multiple calls (voice or WhatsApp) at once. Triggers real outbound calls immediately (if no scheduled_time_unix is set) or at the scheduled time \u2014 always confirm recipient list and call count with the user before executing."
       },
       {
         "slug": "ELEVENLABS_TEXT_TO_SPEECH",
@@ -25187,7 +25187,7 @@
       {
         "slug": "PEOPLEDATALABS_IDENTIFY_PERSON_DATA",
         "name": "Identify person data",
-        "description": "Retrieves detailed profile information for an individual from People Data Labs (PDL), requiring at least one identifier such as email, phone, or profile URL. If using name alone, it must be paired with at least one additional attribute (company, location, school, etc.) — name-only queries return no match."
+        "description": "Retrieves detailed profile information for an individual from People Data Labs (PDL), requiring at least one identifier such as email, phone, or profile URL. If using name alone, it must be paired with at least one additional attribute (company, location, school, etc.) \u2014 name-only queries return no match."
       },
       {
         "slug": "PEOPLEDATALABS_PEOPLE_SEARCH_ELASTIC",
@@ -25474,7 +25474,7 @@
       {
         "slug": "SHOPIFY_CREATE_CUSTOMER",
         "name": "Create Customer",
-        "description": "Create a new customer in Shopify. Use to add a customer record to the store with contact details, addresses, and marketing preferences. Requires at least one of: email, phone, or both first_name and last_name. Errors (e.g., duplicate email, invalid fields) are returned in the response body's userErrors array, not as HTTP error codes — always inspect userErrors to detect failures."
+        "description": "Create a new customer in Shopify. Use to add a customer record to the store with contact details, addresses, and marketing preferences. Requires at least one of: email, phone, or both first_name and last_name. Errors (e.g., duplicate email, invalid fields) are returned in the response body's userErrors array, not as HTTP error codes \u2014 always inspect userErrors to detect failures."
       },
       {
         "slug": "SHOPIFY_CREATE_CUSTOMER_ACCOUNT_ACTIVATION_URL",
@@ -25549,7 +25549,7 @@
       {
         "slug": "SHOPIFY_CREATE_ORDER",
         "name": "Create an order",
-        "description": "Create a fully committed (real) order in Shopify without payment processing. Use when programmatically generating orders with line items, customer information, and addresses. Creates a live order immediately — not a draft; use draftOrderCreate for draft workflows."
+        "description": "Create a fully committed (real) order in Shopify without payment processing. Use when programmatically generating orders with line items, customer information, and addresses. Creates a live order immediately \u2014 not a draft; use draftOrderCreate for draft workflows."
       },
       {
         "slug": "SHOPIFY_CREATE_ORDER_RISK",
@@ -25949,7 +25949,7 @@
       {
         "slug": "SHOPIFY_GET_COLLECTS",
         "name": "Get collects",
-        "description": "Retrieves a list of collects from a Shopify store, where a collect links a product to a custom collection. Returns only collect mapping records (collect_id, collection_id, product_id, position, etc.), not full product details — use SHOPIFY_GET_PRODUCTS_IN_COLLECTION if product details are needed."
+        "description": "Retrieves a list of collects from a Shopify store, where a collect links a product to a custom collection. Returns only collect mapping records (collect_id, collection_id, product_id, position, etc.), not full product details \u2014 use SHOPIFY_GET_PRODUCTS_IN_COLLECTION if product details are needed."
       },
       {
         "slug": "SHOPIFY_GET_COLLECTS_COUNT",
@@ -26244,7 +26244,7 @@
       {
         "slug": "SHOPIFY_GET_ORDERS_WITH_FILTERS",
         "name": "Get orders with filters",
-        "description": "Retrieves Shopify orders filtered by dates and other filters. Uses server-side filtering. Results are paginated; follow `page_info` cursors until exhausted to retrieve all matching orders — a single request returns at most `limit` orders (max 250) and omits the rest."
+        "description": "Retrieves Shopify orders filtered by dates and other filters. Uses server-side filtering. Results are paginated; follow `page_info` cursors until exhausted to retrieve all matching orders \u2014 a single request returns at most `limit` orders (max 250) and omits the rest."
       },
       {
         "slug": "SHOPIFY_GET_ORDER_TRANSACTIONS_COUNT",
@@ -26304,7 +26304,7 @@
       {
         "slug": "SHOPIFY_GET_PRODUCTS",
         "name": "Get products",
-        "description": "Retrieves a list of products from a Shopify store. Results are paginated; for large catalogs, use SHOPIFY_GET_PRODUCTS_PAGINATED to iterate all pages, as this tool may return only a partial set. Product handles and SKUs must be unique — use this tool to check for existing products before creating new ones."
+        "description": "Retrieves a list of products from a Shopify store. Results are paginated; for large catalogs, use SHOPIFY_GET_PRODUCTS_PAGINATED to iterate all pages, as this tool may return only a partial set. Product handles and SKUs must be unique \u2014 use this tool to check for existing products before creating new ones."
       },
       {
         "slug": "SHOPIFY_GET_PRODUCTS_IN_COLLECTION",
@@ -26454,7 +26454,7 @@
       {
         "slug": "SHOPIFY_GRAPH_QL_QUERY",
         "name": "Execute Shopify GraphQL query",
-        "description": "Executes a GraphQL query against the Shopify Admin API for flexible data retrieval and mutations including metafields. Response data is nested under result['data']['data'], not result['data']. Always inspect both response_data.errors (top-level) and mutation-level userErrors—HTTP 200 can accompany GraphQL validation failures. Query costs draw from a ~1000-point bucket (~50 points/second refill); monitor extensions.cost.throttleStatus to avoid THROTTLED errors. Paginate list queries using pageInfo.hasNextPage and endCursor to avoid silently missing records. productUpdate replaces the entire tags array—send the complete final tag list. refundCreate requires orderId at both the top level and inside each transactions element. transaction parentId must reference a CAPTURE-kind transaction. Numeric fields like numberOfOrders may be returned as strings—cast before aggregating."
+        "description": "Executes a GraphQL query against the Shopify Admin API for flexible data retrieval and mutations including metafields. Response data is nested under result['data']['data'], not result['data']. Always inspect both response_data.errors (top-level) and mutation-level userErrors\u2014HTTP 200 can accompany GraphQL validation failures. Query costs draw from a ~1000-point bucket (~50 points/second refill); monitor extensions.cost.throttleStatus to avoid THROTTLED errors. Paginate list queries using pageInfo.hasNextPage and endCursor to avoid silently missing records. productUpdate replaces the entire tags array\u2014send the complete final tag list. refundCreate requires orderId at both the top level and inside each transactions element. transaction parentId must reference a CAPTURE-kind transaction. Numeric fields like numberOfOrders may be returned as strings\u2014cast before aggregating."
       },
       {
         "slug": "SHOPIFY_LIST_ABANDONED_CHECKOUTS",
@@ -26614,7 +26614,7 @@
       {
         "slug": "SHOPIFY_LIST_THEME_ASSETS",
         "name": "List Theme Assets",
-        "description": "Retrieves metadata for theme assets (files that make up a theme: templates, images, stylesheets, snippets). Returns metadata only—not file content. To get actual file content, you must retrieve assets individually using a separate action. Use the asset_key parameter to retrieve a single asset, or omit it to list all assets in the theme."
+        "description": "Retrieves metadata for theme assets (files that make up a theme: templates, images, stylesheets, snippets). Returns metadata only\u2014not file content. To get actual file content, you must retrieve assets individually using a separate action. Use the asset_key parameter to retrieve a single asset, or omit it to list all assets in the theme."
       },
       {
         "slug": "SHOPIFY_LIST_TRANSACTIONS",
@@ -27518,12 +27518,12 @@
       {
         "slug": "GOOGLE_MAPS_COMPUTE_ROUTE_MATRIX",
         "name": "Compute Route Matrix",
-        "description": "Calculates travel distance and duration matrix between multiple origins and destinations using the modern Routes API; supports OAuth2 authentication and various travel modes. Matrix is capped at 625 elements (e.g., 25×25); chunk larger sets to avoid RESOURCE_EXHAUSTED errors. Response elements may be returned out of input order — always use originIndex and destinationIndex to map results. Only use elements where condition='ROUTE_EXISTS'; the matrix may be incomplete."
+        "description": "Calculates travel distance and duration matrix between multiple origins and destinations using the modern Routes API; supports OAuth2 authentication and various travel modes. Matrix is capped at 625 elements (e.g., 25\u00d725); chunk larger sets to avoid RESOURCE_EXHAUSTED errors. Response elements may be returned out of input order \u2014 always use originIndex and destinationIndex to map results. Only use elements where condition='ROUTE_EXISTS'; the matrix may be incomplete."
       },
       {
         "slug": "GOOGLE_MAPS_DISTANCE_MATRIX_API",
         "name": "Distance Matrix (Legacy)",
-        "description": "DEPRECATED: Legacy API that calculates travel distance and time for a matrix of origins and destinations. This API only works with API keys (no OAuth2 support). Use the modern 'Compute Route Matrix' action instead, which supports OAuth2 authentication. Supports different modes of transportation and options like departure/arrival times. Capped at 100 elements per request (elements = origins × destinations count); split large sets into batches."
+        "description": "DEPRECATED: Legacy API that calculates travel distance and time for a matrix of origins and destinations. This API only works with API keys (no OAuth2 support). Use the modern 'Compute Route Matrix' action instead, which supports OAuth2 authentication. Supports different modes of transportation and options like departure/arrival times. Capped at 100 elements per request (elements = origins \u00d7 destinations count); split large sets into batches."
       },
       {
         "slug": "GOOGLE_MAPS_GEOCODE_ADDRESS",
@@ -27533,7 +27533,7 @@
       {
         "slug": "GOOGLE_MAPS_GEOCODE_ADDRESS_WITH_QUERY",
         "name": "Geocode Address With Query",
-        "description": "Tool to map addresses to geographic coordinates with query parameter. Use when you need to convert a textual address into latitude/longitude coordinates using the modern v4beta API. Results may match multiple places — always verify `formattedAddress`, `region`, and `addressComponents` in the response before using returned coordinates."
+        "description": "Tool to map addresses to geographic coordinates with query parameter. Use when you need to convert a textual address into latitude/longitude coordinates using the modern v4beta API. Results may match multiple places \u2014 always verify `formattedAddress`, `region`, and `addressComponents` in the response before using returned coordinates."
       },
       {
         "slug": "GOOGLE_MAPS_GEOCODE_DESTINATIONS",
@@ -27613,12 +27613,12 @@
       {
         "slug": "GOOGLE_MAPS_TEXT_SEARCH",
         "name": "Text Search",
-        "description": "Searches for places on Google Maps using a textual query (e.g., \"restaurants in London\", \"Eiffel Tower\"). Results may include CLOSED_PERMANENTLY or TEMPORARILY_CLOSED places — filter by businessStatus=OPERATIONAL. Include city/region and business type in textQuery to avoid empty or irrelevant results. Deduplicate using id or formattedAddress, not name alone. Throttle to ~1 req/s; OVER_QUERY_LIMIT (HTTP 429) requires exponential backoff."
+        "description": "Searches for places on Google Maps using a textual query (e.g., \"restaurants in London\", \"Eiffel Tower\"). Results may include CLOSED_PERMANENTLY or TEMPORARILY_CLOSED places \u2014 filter by businessStatus=OPERATIONAL. Include city/region and business type in textQuery to avoid empty or irrelevant results. Deduplicate using id or formattedAddress, not name alone. Throttle to ~1 req/s; OVER_QUERY_LIMIT (HTTP 429) requires exponential backoff."
       },
       {
         "slug": "GOOGLE_MAPS_TILES_CREATE_SESSION",
         "name": "Create Tiles Session",
-        "description": "Tool to create a session token required for accessing 2D Tiles and Street View imagery. Use when you need to initialize tile-based map rendering or street view display. The session token is valid for approximately two weeks and must be included in all subsequent tile requests. Each call consumes quota — cache and reuse the returned token across all tile requests within its validity window rather than creating a new session per request."
+        "description": "Tool to create a session token required for accessing 2D Tiles and Street View imagery. Use when you need to initialize tile-based map rendering or street view display. The session token is valid for approximately two weeks and must be included in all subsequent tile requests. Each call consumes quota \u2014 cache and reuse the returned token across all tile requests within its validity window rather than creating a new session per request."
       }
     ],
     "triggers": [],
@@ -27700,7 +27700,7 @@
     "slug": "one_drive",
     "name": "OneDrive",
     "logo": "https://logos.composio.dev/api/one_drive",
-    "description": "OneDrive is Microsoft’s cloud storage solution enabling users to store, sync, and share files across devices, offering offline access, real-time collaboration, and enterprise-grade security",
+    "description": "OneDrive is Microsoft\u2019s cloud storage solution enabling users to store, sync, and share files across devices, offering offline access, real-time collaboration, and enterprise-grade security",
     "category": "file management & storage",
     "authSchemes": [
       "OAUTH2",
@@ -27741,7 +27741,7 @@
       {
         "slug": "ONE_DRIVE_DELETE_ITEM",
         "name": "Delete Item",
-        "description": "Tool to delete a DriveItem (file or folder) by its unique ID from the authenticated user's OneDrive. Use when you need to remove an item from OneDrive. This action moves the item to the recycle bin, not permanently deleting it; storage quota is not freed until the recycle bin is emptied. Bulk deletions can trigger 429 (rate limit) or 5xx responses — limit concurrency and use exponential backoff."
+        "description": "Tool to delete a DriveItem (file or folder) by its unique ID from the authenticated user's OneDrive. Use when you need to remove an item from OneDrive. This action moves the item to the recycle bin, not permanently deleting it; storage quota is not freed until the recycle bin is emptied. Bulk deletions can trigger 429 (rate limit) or 5xx responses \u2014 limit concurrency and use exponential backoff."
       },
       {
         "slug": "ONE_DRIVE_DELETE_ITEM_PERMANENTLY",
@@ -27816,7 +27816,7 @@
       {
         "slug": "ONE_DRIVE_GET_ITEM_PERMISSIONS",
         "name": "Get Item Permissions",
-        "description": "Retrieves the permissions of a DriveItem by its unique ID within a specific Drive. Use when you need to check who has access to a file or folder and what level of access they have. Response nests permission entries under `data.value`; check top-level `success`/`error` flags before processing results. Results include inherited permissions, owner entries, and anonymous link entries — not just explicitly granted permissions. Sharing links may have differing scopes (org-only vs. anonymous); verify `link.scope` before treating a permission as externally accessible."
+        "description": "Retrieves the permissions of a DriveItem by its unique ID within a specific Drive. Use when you need to check who has access to a file or folder and what level of access they have. Response nests permission entries under `data.value`; check top-level `success`/`error` flags before processing results. Results include inherited permissions, owner entries, and anonymous link entries \u2014 not just explicitly granted permissions. Sharing links may have differing scopes (org-only vs. anonymous); verify `link.scope` before treating a permission as externally accessible."
       },
       {
         "slug": "ONE_DRIVE_GET_ITEM_THUMBNAILS",
@@ -27831,7 +27831,7 @@
       {
         "slug": "ONE_DRIVE_GET_RECENT_ITEMS",
         "name": "Get Recent Items",
-        "description": "Get files and folders recently accessed by the user. Returns items based on activity history (opened, edited, viewed), sorted by most recent first — NOT by modification time; use ONE_DRIVE_ONEDRIVE_LIST_ITEMS or ONE_DRIVE_LIST_ROOT_DRIVE_CHANGES for strictly modification-based queries. Use when you need to see what the user worked on recently (e.g., 'Show me files I worked on today'). Different from search - this tracks activity, not content. Results may contain duplicate names; disambiguate using lastModifiedDateTime, parentReference.path, and the file/folder property before acting on a specific item."
+        "description": "Get files and folders recently accessed by the user. Returns items based on activity history (opened, edited, viewed), sorted by most recent first \u2014 NOT by modification time; use ONE_DRIVE_ONEDRIVE_LIST_ITEMS or ONE_DRIVE_LIST_ROOT_DRIVE_CHANGES for strictly modification-based queries. Use when you need to see what the user worked on recently (e.g., 'Show me files I worked on today'). Different from search - this tracks activity, not content. Results may contain duplicate names; disambiguate using lastModifiedDateTime, parentReference.path, and the file/folder property before acting on a specific item."
       },
       {
         "slug": "ONE_DRIVE_GET_ROOT",
@@ -27891,7 +27891,7 @@
       {
         "slug": "ONE_DRIVE_LIST_DRIVES",
         "name": "List Drives",
-        "description": "Tool to retrieve a list of Drive resources available to the authenticated user, or for a specific user, group, or site. Use when you need to find out what drives are accessible. Returns only drives within the signed-in account's permission scope; missing drives indicate insufficient permissions or different tenant scope. Results are paginated — follow skip_token across all pages to avoid missing drives. Returned drives represent document libraries and may not reflect full SharePoint site structure; use SHARE_POINT_GET_SITE_COLLECTION_INFO or SHARE_POINT_SEARCH_QUERY for broader coverage. Use driveType and webUrl to distinguish personal, system, and SharePoint-backed drives."
+        "description": "Tool to retrieve a list of Drive resources available to the authenticated user, or for a specific user, group, or site. Use when you need to find out what drives are accessible. Returns only drives within the signed-in account's permission scope; missing drives indicate insufficient permissions or different tenant scope. Results are paginated \u2014 follow skip_token across all pages to avoid missing drives. Returned drives represent document libraries and may not reflect full SharePoint site structure; use SHARE_POINT_GET_SITE_COLLECTION_INFO or SHARE_POINT_SEARCH_QUERY for broader coverage. Use driveType and webUrl to distinguish personal, system, and SharePoint-backed drives."
       },
       {
         "slug": "ONE_DRIVE_LIST_FOLDER_CHILDREN",
@@ -27931,7 +27931,7 @@
       {
         "slug": "ONE_DRIVE_LIST_SITE_LISTS",
         "name": "List Site Lists",
-        "description": "Tool to list all lists under a specific SharePoint site. Use when you need to enumerate lists within a known site. Returns only Microsoft Graph-supported lists — internal/system lists are excluded, so results may be a strict subset of all site lists (e.g., 13 returned where 108 exist). Results are in the `data.value` array. IMPORTANT: Only works with organizational Microsoft 365 accounts (Azure AD/Entra ID). NOT supported for personal Microsoft accounts (MSA/Outlook.com/Hotmail). Personal OneDrive users cannot access SharePoint sites through this endpoint."
+        "description": "Tool to list all lists under a specific SharePoint site. Use when you need to enumerate lists within a known site. Returns only Microsoft Graph-supported lists \u2014 internal/system lists are excluded, so results may be a strict subset of all site lists (e.g., 13 returned where 108 exist). Results are in the `data.value` array. IMPORTANT: Only works with organizational Microsoft 365 accounts (Azure AD/Entra ID). NOT supported for personal Microsoft accounts (MSA/Outlook.com/Hotmail). Personal OneDrive users cannot access SharePoint sites through this endpoint."
       },
       {
         "slug": "ONE_DRIVE_LIST_SITE_SUBSITES",
@@ -27956,7 +27956,7 @@
       {
         "slug": "ONE_DRIVE_ONEDRIVE_CREATE_TEXT_FILE",
         "name": "Create a new text file",
-        "description": "Creates a new plain-text file with specified content in the authenticated user's personal OneDrive, using either the folder's unique ID or its absolute path relative to the user's OneDrive root (paths are automatically resolved to IDs); note that OneDrive may rename or create a new version if the filename already exists. All files are written as plain text regardless of extension — specifying .docx or .xlsx does not produce a true Office document. This action only works with the user's personal OneDrive (/me/drive) and does not support SharePoint document libraries or shared drives."
+        "description": "Creates a new plain-text file with specified content in the authenticated user's personal OneDrive, using either the folder's unique ID or its absolute path relative to the user's OneDrive root (paths are automatically resolved to IDs); note that OneDrive may rename or create a new version if the filename already exists. All files are written as plain text regardless of extension \u2014 specifying .docx or .xlsx does not produce a true Office document. This action only works with the user's personal OneDrive (/me/drive) and does not support SharePoint document libraries or shared drives."
       },
       {
         "slug": "ONE_DRIVE_ONEDRIVE_FIND_FILE",
@@ -27971,7 +27971,7 @@
       {
         "slug": "ONE_DRIVE_ONEDRIVE_LIST_ITEMS",
         "name": "List OneDrive items",
-        "description": "Retrieves all files and folders as `driveItem` resources from the root of a specified user's OneDrive, automatically handling pagination. Non-recursive: returns only root-level items; subfolder contents require separate calls. Results may include `remoteItem` pointers (shared items from other drives) — use `remoteItem.driveId` and `remoteItem.id` for those in downstream calls. Distinguish files from folders by presence of `file` or `folder` property. Always use `id` values returned by this tool directly; never construct item IDs manually. Items may be absent from results due to permission restrictions, not drive absence."
+        "description": "Retrieves all files and folders as `driveItem` resources from the root of a specified user's OneDrive, automatically handling pagination. Non-recursive: returns only root-level items; subfolder contents require separate calls. Results may include `remoteItem` pointers (shared items from other drives) \u2014 use `remoteItem.driveId` and `remoteItem.id` for those in downstream calls. Distinguish files from folders by presence of `file` or `folder` property. Always use `id` values returned by this tool directly; never construct item IDs manually. Items may be absent from results due to permission restrictions, not drive absence."
       },
       {
         "slug": "ONE_DRIVE_ONEDRIVE_UPLOAD_FILE",
@@ -27981,7 +27981,7 @@
       {
         "slug": "ONE_DRIVE_PREVIEW_DRIVE_ITEM",
         "name": "Preview Drive Item",
-        "description": "Generates or retrieves a short-lived, permission-bound embeddable URL for a preview of a specific item. URLs expire and must be regenerated per session — do not cache. Use when you need to display a temporary preview of a file."
+        "description": "Generates or retrieves a short-lived, permission-bound embeddable URL for a preview of a specific item. URLs expire and must be regenerated per session \u2014 do not cache. Use when you need to display a temporary preview of a file."
       },
       {
         "slug": "ONE_DRIVE_RESTORE_DRIVE_ITEM",
@@ -27991,7 +27991,7 @@
       {
         "slug": "ONE_DRIVE_SEARCH_ITEMS",
         "name": "Search Items",
-        "description": "Search OneDrive for files and folders by keyword. Searches filenames, metadata, and file content to find matching items. Use when you need to find specific files based on keywords, file types, or content. Supports filtering, sorting, and pagination. Results are mixed files and folders — filter client-side using file vs folder properties. Disambiguate similarly named items using parentReference.path, lastModifiedDateTime, and size before passing item IDs downstream. Newly created or recently moved files may not appear due to indexing delays; fall back to ONE_DRIVE_LIST_FOLDER_CHILDREN if expected items are missing. No server-side date filtering — apply lastModifiedDateTime/createdDateTime filtering in your own logic. HTTP 429 responses include a Retry-After header; use exponential backoff."
+        "description": "Search OneDrive for files and folders by keyword. Searches filenames, metadata, and file content to find matching items. Use when you need to find specific files based on keywords, file types, or content. Supports filtering, sorting, and pagination. Results are mixed files and folders \u2014 filter client-side using file vs folder properties. Disambiguate similarly named items using parentReference.path, lastModifiedDateTime, and size before passing item IDs downstream. Newly created or recently moved files may not appear due to indexing delays; fall back to ONE_DRIVE_LIST_FOLDER_CHILDREN if expected items are missing. No server-side date filtering \u2014 apply lastModifiedDateTime/createdDateTime filtering in your own logic. HTTP 429 responses include a Retry-After header; use exponential backoff."
       },
       {
         "slug": "ONE_DRIVE_UNFOLLOW_ITEM",
@@ -28431,7 +28431,7 @@
       {
         "slug": "DOCUSIGN_DELETE_BCC_EMAIL_ARCHIVE_CONFIGURATION",
         "name": "Delete bcc email archive configuration",
-        "description": "This endpoint deletes a BCC (Blind Carbon Copy) email archive configuration from a specified DocuSign account. When invoked, it changes the status of the targeted configuration to 'closed' and immediately stops the archiving of DocuSign-generated email messages to the associated BCC email address. This operation is useful for managing email archiving settings, particularly when an archiving configuration is no longer needed or needs to be replaced. It's important to note that this action is irreversible, and once deleted, the specific configuration cannot be reactivated – a new one would need to be created if archiving is required again in the future. This endpoint should be used cautiously, as it will impact the email archiving process for the account."
+        "description": "This endpoint deletes a BCC (Blind Carbon Copy) email archive configuration from a specified DocuSign account. When invoked, it changes the status of the targeted configuration to 'closed' and immediately stops the archiving of DocuSign-generated email messages to the associated BCC email address. This operation is useful for managing email archiving settings, particularly when an archiving configuration is no longer needed or needs to be replaced. It's important to note that this action is irreversible, and once deleted, the specific configuration cannot be reactivated \u2013 a new one would need to be created if archiving is required again in the future. This endpoint should be used cautiously, as it will impact the email archiving process for the account."
       },
       {
         "slug": "DOCUSIGN_DELETE_BRAND_FROM_GROUP",
@@ -28631,7 +28631,7 @@
       {
         "slug": "DOCUSIGN_DELETE_TEMPLATE_FROM_ENVELOPE_DOCUMENT",
         "name": "Deletetemplatefromenvelopedocument",
-        "description": "Deletes a template from a document within an envelope. Removes a previously applied template from a specific document. This is useful when: - Replacing one template with another - Reverting a document to its original state - Correcting template application errors ⚠️ This operation is permanent and cannot be undone. Requirements: - The envelope must be in a modifiable state (draft, created, or sent) - The template must have been previously applied to the document - You need the envelope ID, document ID, and template ID"
+        "description": "Deletes a template from a document within an envelope. Removes a previously applied template from a specific document. This is useful when: - Replacing one template with another - Reverting a document to its original state - Correcting template application errors \u26a0\ufe0f This operation is permanent and cannot be undone. Requirements: - The envelope must be in a modifiable state (draft, created, or sent) - The template must have been previously applied to the document - You need the envelope ID, document ID, and template ID"
       },
       {
         "slug": "DOCUSIGN_DELETE_TEMPLATE_LOCK",
@@ -29933,7 +29933,7 @@
       {
         "slug": "DISCORDBOT_ADD_MY_MESSAGE_REACTION",
         "name": "Add reaction to message",
-        "description": "Adds an emoji reaction (Unicode or custom) from the authenticated bot to a specific message in a Discord channel. Returns 204 No Content on success. Requires READ_MESSAGE_HISTORY permission, and ADD_REACTIONS permission if no one else has reacted with this emoji yet. Supports both Unicode emojis (e.g., 👍) and custom server emojis using 'name:id' format."
+        "description": "Adds an emoji reaction (Unicode or custom) from the authenticated bot to a specific message in a Discord channel. Returns 204 No Content on success. Requires READ_MESSAGE_HISTORY permission, and ADD_REACTIONS permission if no one else has reacted with this emoji yet. Supports both Unicode emojis (e.g., \ud83d\udc4d) and custom server emojis using 'name:id' format."
       },
       {
         "slug": "DISCORDBOT_ADD_THREAD_MEMBER",
@@ -30683,7 +30683,7 @@
       {
         "slug": "DISCORDBOT_UPDATE_GUILD_WELCOME_SCREEN",
         "name": "Update guild welcome screen",
-        "description": "Updates a guild's welcome screen configuration, including description, enabled status, and up to 5 welcome channels. Requires MANAGE_GUILD permission and the guild must have the COMMUNITY feature enabled. All parameters are optional - you can update individual fields without providing all values. When specifying channel emojis, use `emoji_name` (unicode emoji like '👋' or custom emoji name) while `emoji_id` must be `null` if sent."
+        "description": "Updates a guild's welcome screen configuration, including description, enabled status, and up to 5 welcome channels. Requires MANAGE_GUILD permission and the guild must have the COMMUNITY feature enabled. All parameters are optional - you can update individual fields without providing all values. When specifying channel emojis, use `emoji_name` (unicode emoji like '\ud83d\udc4b' or custom emoji name) while `emoji_id` must be `null` if sent."
       },
       {
         "slug": "DISCORDBOT_UPDATE_GUILD_WIDGET_SETTINGS",
@@ -30839,7 +30839,7 @@
       {
         "slug": "SALESFORCE_ADD_LEAD_TO_CAMPAIGN",
         "name": "Add lead to campaign",
-        "description": "Adds a lead to a campaign by creating a CampaignMember record, allowing you to track campaign engagement. Both `campaign_id` and `lead_id` must be valid Salesforce IDs of active, existing records — names or emails cannot be substituted, and deleted or inactive records will cause the call to fail. This is a persistent CRM write; confirm the correct lead and campaign before calling."
+        "description": "Adds a lead to a campaign by creating a CampaignMember record, allowing you to track campaign engagement. Both `campaign_id` and `lead_id` must be valid Salesforce IDs of active, existing records \u2014 names or emails cannot be substituted, and deleted or inactive records will cause the call to fail. This is a persistent CRM write; confirm the correct lead and campaign before calling."
       },
       {
         "slug": "SALESFORCE_ADD_OPPORTUNITY_LINE_ITEM",
@@ -30894,7 +30894,7 @@
       {
         "slug": "SALESFORCE_CREATE_CAMPAIGN",
         "name": "Create campaign",
-        "description": "Creates a new campaign in Salesforce. Only `name` is universally required, but org-level validation rules commonly enforce `type`, `status`, `start_date`, and `end_date` as well — omitting them may cause creation to fail."
+        "description": "Creates a new campaign in Salesforce. Only `name` is universally required, but org-level validation rules commonly enforce `type`, `status`, `start_date`, and `end_date` as well \u2014 omitting them may cause creation to fail."
       },
       {
         "slug": "SALESFORCE_CREATE_CAMPAIGN_RECORD_VIA_POST",
@@ -30904,7 +30904,7 @@
       {
         "slug": "SALESFORCE_CREATE_CONTACT",
         "name": "Create contact",
-        "description": "Creates a new contact in Salesforce with the specified information. Writes to live CRM data — obtain explicit user confirmation before executing. Failures may reflect org-specific validation rules, permission restrictions, or duplicate rules rather than invalid inputs."
+        "description": "Creates a new contact in Salesforce with the specified information. Writes to live CRM data \u2014 obtain explicit user confirmation before executing. Failures may reflect org-specific validation rules, permission restrictions, or duplicate rules rather than invalid inputs."
       },
       {
         "slug": "SALESFORCE_CREATE_CUSTOM_FIELD",
@@ -30934,7 +30934,7 @@
       {
         "slug": "SALESFORCE_CREATE_NOTE",
         "name": "Create note",
-        "description": "Creates a new note attached to a Salesforce record with the specified title and content. Does not deduplicate — identical calls create duplicate notes. High-volume creation can trigger REQUEST_LIMIT_EXCEEDED; apply exponential backoff on retries."
+        "description": "Creates a new note attached to a Salesforce record with the specified title and content. Does not deduplicate \u2014 identical calls create duplicate notes. High-volume creation can trigger REQUEST_LIMIT_EXCEEDED; apply exponential backoff on retries."
       },
       {
         "slug": "SALESFORCE_CREATE_NOTE_RECORD_WITH_CONTENT_TYPE_HEADER",
@@ -30984,7 +30984,7 @@
       {
         "slug": "SALESFORCE_DELETE_CONTACT",
         "name": "Delete contact",
-        "description": "Permanently deletes a contact from Salesforce. This action cannot be undone. Associated records (activities, opportunities) lose the contact reference upon deletion — ensure related data is migrated or acceptable to lose before proceeding. Returns HTTP 204 with empty body on success."
+        "description": "Permanently deletes a contact from Salesforce. This action cannot be undone. Associated records (activities, opportunities) lose the contact reference upon deletion \u2014 ensure related data is migrated or acceptable to lose before proceeding. Returns HTTP 204 with empty body on success."
       },
       {
         "slug": "SALESFORCE_DELETE_FILE",
@@ -31514,7 +31514,7 @@
       {
         "slug": "SALESFORCE_LIST_ACCOUNTS",
         "name": "List accounts",
-        "description": "Lists accounts from Salesforce using SOQL query, allowing flexible filtering, sorting, and field selection. Results paginate via nextRecordsUrl with up to ~2000 rows per page. REQUEST_LIMIT_EXCEEDED requires exponential backoff; INVALID_FIELD or INSUFFICIENT_ACCESS_OR_READONLY errors indicate profile or field-level restrictions — simplify SELECT/WHERE clauses."
+        "description": "Lists accounts from Salesforce using SOQL query, allowing flexible filtering, sorting, and field selection. Results paginate via nextRecordsUrl with up to ~2000 rows per page. REQUEST_LIMIT_EXCEEDED requires exponential backoff; INVALID_FIELD or INSUFFICIENT_ACCESS_OR_READONLY errors indicate profile or field-level restrictions \u2014 simplify SELECT/WHERE clauses."
       },
       {
         "slug": "SALESFORCE_LIST_ANALYTICS_TEMPLATES",
@@ -31529,7 +31529,7 @@
       {
         "slug": "SALESFORCE_LIST_CONTACTS",
         "name": "List contacts",
-        "description": "Lists contacts from Salesforce using SOQL query, allowing flexible filtering, sorting, and field selection. Results are returned under `response_data.records`; check `response_data.done` and `response_data.totalSize` for pagination — use OFFSET or `nextRecordsUrl` until `done=true` to retrieve all records."
+        "description": "Lists contacts from Salesforce using SOQL query, allowing flexible filtering, sorting, and field selection. Results are returned under `response_data.records`; check `response_data.done` and `response_data.totalSize` for pagination \u2014 use OFFSET or `nextRecordsUrl` until `done=true` to retrieve all records."
       },
       {
         "slug": "SALESFORCE_LIST_CUSTOM_INVOCABLE_ACTIONS",
@@ -31549,7 +31549,7 @@
       {
         "slug": "SALESFORCE_LIST_LEADS",
         "name": "List leads",
-        "description": "Lists leads from Salesforce using SOQL query, allowing flexible filtering, sorting, and field selection. Results are paginated; follow nextRecordsUrl in the response to retrieve subsequent pages — the first page may silently omit matching records beyond the page limit."
+        "description": "Lists leads from Salesforce using SOQL query, allowing flexible filtering, sorting, and field selection. Results are paginated; follow nextRecordsUrl in the response to retrieve subsequent pages \u2014 the first page may silently omit matching records beyond the page limit."
       },
       {
         "slug": "SALESFORCE_LIST_NOTES",
@@ -31564,7 +31564,7 @@
       {
         "slug": "SALESFORCE_LIST_PRICEBOOK_ENTRIES",
         "name": "List pricebook entries",
-        "description": "Lists pricebook entries from Salesforce using SOQL query, allowing flexible filtering, sorting, and field selection. Use this to map product names to pricebook entry IDs needed for opportunity line items. When using returned IDs with SALESFORCE_ADD_OPPORTUNITY_LINE_ITEM, always filter with WHERE IsActive = true — inactive entries cause REQUIRED_FIELD_MISSING or INVALID_CROSS_REFERENCE_KEY errors."
+        "description": "Lists pricebook entries from Salesforce using SOQL query, allowing flexible filtering, sorting, and field selection. Use this to map product names to pricebook entry IDs needed for opportunity line items. When using returned IDs with SALESFORCE_ADD_OPPORTUNITY_LINE_ITEM, always filter with WHERE IsActive = true \u2014 inactive entries cause REQUIRED_FIELD_MISSING or INVALID_CROSS_REFERENCE_KEY errors."
       },
       {
         "slug": "SALESFORCE_LIST_PRICEBOOKS",
@@ -31719,7 +31719,7 @@
       {
         "slug": "SALESFORCE_RUN_REPORT",
         "name": "Run report",
-        "description": "Runs a report and returns the results. Creates a report instance that can be checked for completion. Results are returned in a nested structure (factMap, reportExtendedMetadata), not a flat record list; an empty factMap/rows is a valid result. Avoid repeated calls when freshness allows — reuse an existing instance_id instead."
+        "description": "Runs a report and returns the results. Creates a report instance that can be checked for completion. Results are returned in a nested structure (factMap, reportExtendedMetadata), not a flat record list; an empty factMap/rows is a valid result. Avoid repeated calls when freshness allows \u2014 reuse an existing instance_id instead."
       },
       {
         "slug": "SALESFORCE_RUN_SOQL_QUERY",
@@ -31734,7 +31734,7 @@
       {
         "slug": "SALESFORCE_SEARCH_ACCOUNTS",
         "name": "Search accounts",
-        "description": "Search for Salesforce accounts using criteria like name, industry, type, location, or contact information. Always provide at least one filter parameter; omitting all filters returns a broad, slow listing. Owner/territory filtering is unsupported — use SALESFORCE_RUN_SOQL_QUERY for ownership-based filters. Use SALESFORCE_GET_ACCOUNT to fetch complete field data for a specific record. Unsupported filter fields may be silently ignored — verify results reflect intended criteria."
+        "description": "Search for Salesforce accounts using criteria like name, industry, type, location, or contact information. Always provide at least one filter parameter; omitting all filters returns a broad, slow listing. Owner/territory filtering is unsupported \u2014 use SALESFORCE_RUN_SOQL_QUERY for ownership-based filters. Use SALESFORCE_GET_ACCOUNT to fetch complete field data for a specific record. Unsupported filter fields may be silently ignored \u2014 verify results reflect intended criteria."
       },
       {
         "slug": "SALESFORCE_SEARCH_CAMPAIGNS",
@@ -31744,7 +31744,7 @@
       {
         "slug": "SALESFORCE_SEARCH_CONTACTS",
         "name": "Search contacts",
-        "description": "Search Salesforce Contact records (not Leads — use SALESFORCE_SEARCH_LEADS for those) using name, email, phone, account, or title. All parameters support partial/fuzzy matching, so results may include unrelated records; post-filter client-side for exact matches. Partial matches and common names can return multiple contacts — always confirm the correct contact by its 18-character Id before passing to write operations like SALESFORCE_LOG_CALL or SALESFORCE_CREATE_TASK. A response with totalSize=0 is a valid 'not found' outcome. Provide at least one search criterion; omitting all returns a broad, slow result set. Returned Ids are 18-character strings and must be used as-is in downstream tools."
+        "description": "Search Salesforce Contact records (not Leads \u2014 use SALESFORCE_SEARCH_LEADS for those) using name, email, phone, account, or title. All parameters support partial/fuzzy matching, so results may include unrelated records; post-filter client-side for exact matches. Partial matches and common names can return multiple contacts \u2014 always confirm the correct contact by its 18-character Id before passing to write operations like SALESFORCE_LOG_CALL or SALESFORCE_CREATE_TASK. A response with totalSize=0 is a valid 'not found' outcome. Provide at least one search criterion; omitting all returns a broad, slow result set. Returned Ids are 18-character strings and must be used as-is in downstream tools."
       },
       {
         "slug": "SALESFORCE_SEARCH_KNOWLEDGE_ARTICLES",
@@ -31754,12 +31754,12 @@
       {
         "slug": "SALESFORCE_SEARCH_LEADS",
         "name": "Search leads",
-        "description": "Search for Salesforce leads using criteria like name, email, phone, company, title, status, or lead source. At least one search criterion should be provided — omitting all parameters results in a broad, slow listing of arbitrary records. Partial matches on name, email, and company may return multiple candidates; confirm Email or Company field values before using a lead ID in downstream operations."
+        "description": "Search for Salesforce leads using criteria like name, email, phone, company, title, status, or lead source. At least one search criterion should be provided \u2014 omitting all parameters results in a broad, slow listing of arbitrary records. Partial matches on name, email, and company may return multiple candidates; confirm Email or Company field values before using a lead ID in downstream operations."
       },
       {
         "slug": "SALESFORCE_SEARCH_NOTES",
         "name": "Search notes",
-        "description": "Search for Salesforce notes using multiple criteria like title, body content, parent record, owner, or creation date. Provide at least one filter criterion — omitting all filters returns a broad, slow, noisy listing."
+        "description": "Search for Salesforce notes using multiple criteria like title, body content, parent record, owner, or creation date. Provide at least one filter criterion \u2014 omitting all filters returns a broad, slow, noisy listing."
       },
       {
         "slug": "SALESFORCE_SEARCH_OPPORTUNITIES",
@@ -31769,12 +31769,12 @@
       {
         "slug": "SALESFORCE_SEARCH_TASKS",
         "name": "Search tasks",
-        "description": "Search for Salesforce tasks using multiple criteria like subject, status, priority, assigned user, related records, or dates. Always provide at least one filter criterion — no filters produces broad, slow results. For complex filtering not supported here, use SALESFORCE_RUN_SOQL_QUERY."
+        "description": "Search for Salesforce tasks using multiple criteria like subject, status, priority, assigned user, related records, or dates. Always provide at least one filter criterion \u2014 no filters produces broad, slow results. For complex filtering not supported here, use SALESFORCE_RUN_SOQL_QUERY."
       },
       {
         "slug": "SALESFORCE_SEND_EMAIL",
         "name": "Send email",
-        "description": "Sends an email through Salesforce with options for recipients, attachments, and activity logging. Can partially succeed — check per-recipient success/failure status rather than treating the call as all-or-nothing. For large recipient lists, use SALESFORCE_SEND_MASS_EMAIL instead."
+        "description": "Sends an email through Salesforce with options for recipients, attachments, and activity logging. Can partially succeed \u2014 check per-recipient success/failure status rather than treating the call as all-or-nothing. For large recipient lists, use SALESFORCE_SEND_MASS_EMAIL instead."
       },
       {
         "slug": "SALESFORCE_SEND_EMAIL_FROM_TEMPLATE",
@@ -31864,7 +31864,7 @@
       {
         "slug": "SALESFORCE_UPDATE_OPPORTUNITY",
         "name": "Update opportunity",
-        "description": "Updates an existing opportunity in Salesforce with the specified changes. Only provided fields will be updated. Returns HTTP 204 with empty body on success; call SALESFORCE_GET_OPPORTUNITY afterward to read updated values. Updates may fail with FIELD_CUSTOM_VALIDATION_EXCEPTION or REQUIRED_FIELD_MISSING — inspect the error message to identify the offending field."
+        "description": "Updates an existing opportunity in Salesforce with the specified changes. Only provided fields will be updated. Returns HTTP 204 with empty body on success; call SALESFORCE_GET_OPPORTUNITY afterward to read updated values. Updates may fail with FIELD_CUSTOM_VALIDATION_EXCEPTION or REQUIRED_FIELD_MISSING \u2014 inspect the error message to identify the offending field."
       },
       {
         "slug": "SALESFORCE_UPDATE_OPPORTUNITY_BY_ID",
@@ -32983,7 +32983,7 @@
       {
         "slug": "TRELLO_GET_CARDS_CUSTOM_FIELD_ITEMS_BY_ID_CARD",
         "name": "Get card custom field items",
-        "description": "Tool to retrieve a card's customFieldItems array. Use when you need structured metadata from custom fields for automation. Must be called per card — no bulk endpoint exists. Returns an empty array if no custom fields are populated on the card. Power-Up data (e.g., time tracking) is not included in customFieldItems."
+        "description": "Tool to retrieve a card's customFieldItems array. Use when you need structured metadata from custom fields for automation. Must be called per card \u2014 no bulk endpoint exists. Returns an empty array if no custom fields are populated on the card. Power-Up data (e.g., time tracking) is not included in customFieldItems."
       },
       {
         "slug": "TRELLO_GET_CARDS_LIST_BY_ID_CARD",
@@ -34160,7 +34160,7 @@
       {
         "slug": "APOLLO_ADD_CONTACTS_TO_SEQUENCE",
         "name": "Add Contacts to Sequence",
-        "description": "Adds contacts to a specified Apollo email sequence and returns the contact details. `sequence_id`, `emailer_campaign_id`, and `send_email_from_email_account_id` must be retrieved from Apollo listing/search endpoints before calling this tool — these IDs cannot be inferred from names."
+        "description": "Adds contacts to a specified Apollo email sequence and returns the contact details. `sequence_id`, `emailer_campaign_id`, and `send_email_from_email_account_id` must be retrieved from Apollo listing/search endpoints before calling this tool \u2014 these IDs cannot be inferred from names."
       },
       {
         "slug": "APOLLO_BULK_ORGANIZATION_ENRICHMENT",
@@ -34200,7 +34200,7 @@
       {
         "slug": "APOLLO_CREATE_CONTACT",
         "name": "Create Apollo contact",
-        "description": "Creates a new contact in Apollo.io; use `account_id` to link to an organization and `contact_stage_id` for sales stage. Apollo does not auto-deduplicate — duplicate records sharing the same email are silently created; always search via APOLLO_SEARCH_CONTACTS before calling this tool. Requires explicit user confirmation before execution."
+        "description": "Creates a new contact in Apollo.io; use `account_id` to link to an organization and `contact_stage_id` for sales stage. Apollo does not auto-deduplicate \u2014 duplicate records sharing the same email are silently created; always search via APOLLO_SEARCH_CONTACTS before calling this tool. Requires explicit user confirmation before execution."
       },
       {
         "slug": "APOLLO_CREATE_CUSTOM_FIELD",
@@ -34210,7 +34210,7 @@
       {
         "slug": "APOLLO_CREATE_DEAL",
         "name": "Create Apollo deal",
-        "description": "Creates a new sales opportunity (deal) in Apollo.io; all provided IDs (`owner_id`, `account_id`, `opportunity_stage_id`) must be valid existing Apollo identifiers. This action has persistent side effects — obtain explicit user confirmation before invoking."
+        "description": "Creates a new sales opportunity (deal) in Apollo.io; all provided IDs (`owner_id`, `account_id`, `opportunity_stage_id`) must be valid existing Apollo identifiers. This action has persistent side effects \u2014 obtain explicit user confirmation before invoking."
       },
       {
         "slug": "APOLLO_CREATE_TASK",
@@ -34260,7 +34260,7 @@
       {
         "slug": "APOLLO_GET_TYPED_CUSTOM_FIELDS",
         "name": "Get typed custom fields",
-        "description": "Retrieves all typed custom field definitions available in the Apollo.io instance, detailing their types and configurations. Call before constructing payloads for APOLLO_UPDATE_CONTACT or APOLLO_UPDATE_ACCOUNT — mismatched types or invalid enum options cause 400 errors."
+        "description": "Retrieves all typed custom field definitions available in the Apollo.io instance, detailing their types and configurations. Call before constructing payloads for APOLLO_UPDATE_CONTACT or APOLLO_UPDATE_ACCOUNT \u2014 mismatched types or invalid enum options cause 400 errors."
       },
       {
         "slug": "APOLLO_LIST_ACCOUNT_STAGES",
@@ -34290,7 +34290,7 @@
       {
         "slug": "APOLLO_LIST_USERS",
         "name": "List Apollo Users",
-        "description": "Retrieves a list of all users (teammates) associated with the Apollo account, supporting pagination via `page` and `per_page` parameters. Use this to obtain numeric user IDs required by operations like APOLLO_UPDATE_CONTACT_OWNERSHIP — names or email addresses are not accepted in place of these IDs."
+        "description": "Retrieves a list of all users (teammates) associated with the Apollo account, supporting pagination via `page` and `per_page` parameters. Use this to obtain numeric user IDs required by operations like APOLLO_UPDATE_CONTACT_OWNERSHIP \u2014 names or email addresses are not accepted in place of these IDs."
       },
       {
         "slug": "APOLLO_ORGANIZATION_ENRICHMENT",
@@ -34300,7 +34300,7 @@
       {
         "slug": "APOLLO_ORGANIZATION_SEARCH",
         "name": "Search organizations in Apollo",
-        "description": "Searches Apollo's database for organizations using various filters; consumes credits on every call (unavailable on free plans) — avoid re-running identical queries and surface quota errors rather than retrying. Retrieves a maximum of 50,000 records; uses `page` (1-500) and `per_page` (1-100) for pagination — check `total_pages` in the response to iterate. Overly strict filter combinations can return zero results; start broad and narrow iteratively. Empty results and `org_not_found` are valid outcomes, not errors."
+        "description": "Searches Apollo's database for organizations using various filters; consumes credits on every call (unavailable on free plans) \u2014 avoid re-running identical queries and surface quota errors rather than retrying. Retrieves a maximum of 50,000 records; uses `page` (1-500) and `per_page` (1-100) for pagination \u2014 check `total_pages` in the response to iterate. Overly strict filter combinations can return zero results; start broad and narrow iteratively. Empty results and `org_not_found` are valid outcomes, not errors."
       },
       {
         "slug": "APOLLO_PEOPLE_ENRICHMENT",
@@ -34310,7 +34310,7 @@
       {
         "slug": "APOLLO_PEOPLE_SEARCH",
         "name": "Apollo people search",
-        "description": "Searches Apollo's contact database for people using various filters; results capped at 50,000 records and does not enrich contact data. Combining multiple strict filters (organization_ids, person_titles, person_seniorities) can return zero results — start broad and narrow iteratively. Result records may have null email, phone, or organization fields."
+        "description": "Searches Apollo's contact database for people using various filters; results capped at 50,000 records and does not enrich contact data. Combining multiple strict filters (organization_ids, person_titles, person_seniorities) can return zero results \u2014 start broad and narrow iteratively. Result records may have null email, phone, or organization fields."
       },
       {
         "slug": "APOLLO_SEARCH_ACCOUNTS",
@@ -34476,7 +34476,7 @@
       {
         "slug": "SEMRUSH_BATCH_KEYWORD_OVERVIEW",
         "name": "Batch keyword overview",
-        "description": "Fetches a keyword overview report from a Semrush regional database for up to 100 keywords, providing metrics like search volume, CPC, and keyword difficulty. Response is CSV-like text (not JSON); parse accordingly. Returns literal string 'ERROR 50 :: NOTHING FOUND' for keywords with no data in the selected database — treat as zero results and fall back to SEMRUSH_KEYWORD_OVERVIEW_ONE_DATABASE or SEMRUSH_KEYWORD_OVERVIEW_ALL_DATABASES for those terms."
+        "description": "Fetches a keyword overview report from a Semrush regional database for up to 100 keywords, providing metrics like search volume, CPC, and keyword difficulty. Response is CSV-like text (not JSON); parse accordingly. Returns literal string 'ERROR 50 :: NOTHING FOUND' for keywords with no data in the selected database \u2014 treat as zero results and fall back to SEMRUSH_KEYWORD_OVERVIEW_ONE_DATABASE or SEMRUSH_KEYWORD_OVERVIEW_ALL_DATABASES for those terms."
       },
       {
         "slug": "SEMRUSH_BROAD_MATCH_KEYWORD",
@@ -34521,7 +34521,7 @@
       {
         "slug": "SEMRUSH_DOMAIN_ORGANIC_SEARCH_KEYWORDS",
         "name": "Get domain organic search keywords",
-        "description": "Retrieves organic search keywords for a domain from a specified Semrush regional database; `display_positions` must be set if `display_daily=1` for daily updates. Response is semicolon-delimited CSV text (parse with sep=';', cast numeric columns before aggregations). A response of 'ERROR 50 :: NOTHING FOUND' indicates no data for the domain in the selected database — treat as a valid zero-result."
+        "description": "Retrieves organic search keywords for a domain from a specified Semrush regional database; `display_positions` must be set if `display_daily=1` for daily updates. Response is semicolon-delimited CSV text (parse with sep=';', cast numeric columns before aggregations). A response of 'ERROR 50 :: NOTHING FOUND' indicates no data for the domain in the selected database \u2014 treat as a valid zero-result."
       },
       {
         "slug": "SEMRUSH_DOMAIN_ORGANIC_SUBDOMAINS",
@@ -35539,7 +35539,7 @@
       {
         "slug": "WEATHERMAP_WEATHER",
         "name": "Weather Info",
-        "description": "Tool for querying the OpenWeatherMap API. Returns current weather conditions only — no UV index, AQI, or official alerts. Timestamps are in UTC; apply the timezone offset field before grouping by local day."
+        "description": "Tool for querying the OpenWeatherMap API. Returns current weather conditions only \u2014 no UV index, AQI, or official alerts. Timestamps are in UTC; apply the timezone offset field before grouping by local day."
       }
     ],
     "triggers": [],
@@ -35846,7 +35846,7 @@
       {
         "slug": "POSTHOG_CREATE_ORGANIZATION_PROXY_RECORD",
         "name": "Create organization proxy record for custom domain",
-        "description": "Create a managed reverse proxy record for an organization to enable custom domain routing for PostHog analytics events. This bypasses ad blockers by routing analytics through your own domain. After creating the record, you must: 1. Create a CNAME DNS record pointing your domain to the returned target_cname 2. Wait 2-30 minutes for DNS propagation and SSL certificate provisioning 3. The status will progress from 'waiting' → 'issuing' → 'live' IMPORTANT: If using Cloudflare, set the CNAME to \"DNS only\" (disable proxy) to avoid SSL certificate provisioning issues. Requires organization write access (organization:write permission)."
+        "description": "Create a managed reverse proxy record for an organization to enable custom domain routing for PostHog analytics events. This bypasses ad blockers by routing analytics through your own domain. After creating the record, you must: 1. Create a CNAME DNS record pointing your domain to the returned target_cname 2. Wait 2-30 minutes for DNS propagation and SSL certificate provisioning 3. The status will progress from 'waiting' \u2192 'issuing' \u2192 'live' IMPORTANT: If using Cloudflare, set the CNAME to \"DNS only\" (disable proxy) to avoid SSL certificate provisioning issues. Requires organization write access (organization:write permission)."
       },
       {
         "slug": "POSTHOG_CREATE_ORGANIZATION_ROLE",
@@ -36491,7 +36491,7 @@
       {
         "slug": "POSTHOG_GET_FEATURE_FLAGS_EVALUATION_REASONS",
         "name": "Retrieve feature flags evaluation reasons",
-        "description": "Manage feature flags—create, read, update, delete—using the PostHog JavaScript Library or endpoint for user-specific flag status. (More in docs)."
+        "description": "Manage feature flags\u2014create, read, update, delete\u2014using the PostHog JavaScript Library or endpoint for user-specific flag status. (More in docs)."
       },
       {
         "slug": "POSTHOG_GET_FEATURE_FLAGS_MATCHING_IDS",
@@ -39105,7 +39105,7 @@
       {
         "slug": "BREVO_GET_ACCOUNT_INFO",
         "name": "Get Account Information",
-        "description": "Retrieves comprehensive information about the authenticated Brevo account. Returns account details including: - Account holder information (email, first name, last name, company name) - Complete address (street, city, zip code, country) - Plan details with credit information (type, credits remaining, start/end dates) - Relay configuration for transactional emails (enabled status and data) - Marketing Automation status and tracker key (if enabled) No input parameters are required - the action uses the authenticated account's credentials. Use this action to: - Verify account configuration and settings - Check available credits and plan type - Monitor transactional email relay status - Retrieve Marketing Automation tracker information. If credentials are missing or invalid, verify the Brevo connection is active before calling — retries will not resolve credential issues. If blocked by an 'unrecognised IP address' error, add the integration host's IP to the Brevo account allowlist."
+        "description": "Retrieves comprehensive information about the authenticated Brevo account. Returns account details including: - Account holder information (email, first name, last name, company name) - Complete address (street, city, zip code, country) - Plan details with credit information (type, credits remaining, start/end dates) - Relay configuration for transactional emails (enabled status and data) - Marketing Automation status and tracker key (if enabled) No input parameters are required - the action uses the authenticated account's credentials. Use this action to: - Verify account configuration and settings - Check available credits and plan type - Monitor transactional email relay status - Retrieve Marketing Automation tracker information. If credentials are missing or invalid, verify the Brevo connection is active before calling \u2014 retries will not resolve credential issues. If blocked by an 'unrecognised IP address' error, add the integration host's IP to the Brevo account allowlist."
       },
       {
         "slug": "BREVO_GET_ALL_CONTACTS",
@@ -44521,7 +44521,7 @@
       {
         "slug": "ATTIO_GET_OBJECT",
         "name": "Get Object",
-        "description": "Tool to get a single object by its object_id or slug. Use to retrieve detailed schema information about a specific object type in the Attio workspace. Also use as a prerequisite validation step before calling ATTIO_FIND_RECORD, ATTIO_LIST_RECORDS, or ATTIO_CREATE_RECORD — attribute slugs must exactly match what this tool returns. The returned schema defines required attributes for record creation; omitting them causes invalid_request_error with code missing_value (HTTP 400). Custom attributes (e.g., industry, category) vary by object type — verify their presence and data type here before building filters or record values."
+        "description": "Tool to get a single object by its object_id or slug. Use to retrieve detailed schema information about a specific object type in the Attio workspace. Also use as a prerequisite validation step before calling ATTIO_FIND_RECORD, ATTIO_LIST_RECORDS, or ATTIO_CREATE_RECORD \u2014 attribute slugs must exactly match what this tool returns. The returned schema defines required attributes for record creation; omitting them causes invalid_request_error with code missing_value (HTTP 400). Custom attributes (e.g., industry, category) vary by object type \u2014 verify their presence and data type here before building filters or record values."
       },
       {
         "slug": "ATTIO_GET_RECORD",
@@ -44641,7 +44641,7 @@
       {
         "slug": "ATTIO_LIST_LISTS",
         "name": "List Lists",
-        "description": "This tool retrieves all lists available in the Attio workspace, sorted as they appear in the sidebar. Returns list metadata only (names, IDs, configuration) — not the records/entries within those lists. To fetch actual list entries, use ATTIO_FIND_RECORD with appropriate filters. This tool is a prerequisite for many list-related operations. Requires the list_configuration:read permission scope."
+        "description": "This tool retrieves all lists available in the Attio workspace, sorted as they appear in the sidebar. Returns list metadata only (names, IDs, configuration) \u2014 not the records/entries within those lists. To fetch actual list entries, use ATTIO_FIND_RECORD with appropriate filters. This tool is a prerequisite for many list-related operations. Requires the list_configuration:read permission scope."
       },
       {
         "slug": "ATTIO_LIST_MEETINGS",
@@ -44656,7 +44656,7 @@
       {
         "slug": "ATTIO_LIST_OBJECTS",
         "name": "List Objects",
-        "description": "This tool retrieves a list of all available objects (both system-defined and user-defined) in the Attio workspace via GET /v2/objects, returning key metadata including slugs and IDs for each object. Call this tool first before ATTIO_LIST_RECORDS, ATTIO_FIND_RECORD, or ATTIO_CREATE_RECORD to discover valid object slugs — hardcoded slugs may not exist across workspaces. Concepts like tasks may be modeled as deals or custom objects rather than dedicated types, so confirm the correct object type before proceeding. Attribute values in responses can be arrays of time-bounded entries rather than simple scalars; downstream code must handle nested structures."
+        "description": "This tool retrieves a list of all available objects (both system-defined and user-defined) in the Attio workspace via GET /v2/objects, returning key metadata including slugs and IDs for each object. Call this tool first before ATTIO_LIST_RECORDS, ATTIO_FIND_RECORD, or ATTIO_CREATE_RECORD to discover valid object slugs \u2014 hardcoded slugs may not exist across workspaces. Concepts like tasks may be modeled as deals or custom objects rather than dedicated types, so confirm the correct object type before proceeding. Attribute values in responses can be arrays of time-bounded entries rather than simple scalars; downstream code must handle nested structures."
       },
       {
         "slug": "ATTIO_LIST_PEOPLE_ATTRIBUTE_VALUES",
@@ -44676,7 +44676,7 @@
       {
         "slug": "ATTIO_LIST_RECORDS",
         "name": "List Records",
-        "description": "This tool lists records from a specific object type in Attio. It provides simple pagination support and returns records in creation order (oldest first). For complex filtering, use the FindRecord action instead. Standard object types include: people, companies, deals, users, workspaces. If you get a 404 error, verify the object type exists using the List Objects action first. Response attribute values are returned as arrays of time-bounded objects under a `values` map (e.g., `values['name']`), not simple scalars — handle arrays, nested objects, and empty arrays accordingly. Select attributes are accessed via `option.title`; currency, stage, and select fields may be null or empty arrays. Access records via `data.data` in the response."
+        "description": "This tool lists records from a specific object type in Attio. It provides simple pagination support and returns records in creation order (oldest first). For complex filtering, use the FindRecord action instead. Standard object types include: people, companies, deals, users, workspaces. If you get a 404 error, verify the object type exists using the List Objects action first. Response attribute values are returned as arrays of time-bounded objects under a `values` map (e.g., `values['name']`), not simple scalars \u2014 handle arrays, nested objects, and empty arrays accordingly. Select attributes are accessed via `option.title`; currency, stage, and select fields may be null or empty arrays. Access records via `data.data` in the response."
       },
       {
         "slug": "ATTIO_LIST_THREADS",
@@ -44935,12 +44935,12 @@
       {
         "slug": "GOOGLEMEET_CREATE_MEET",
         "name": "Create Google Meet Space",
-        "description": "Creates a new Google Meet space with optional configuration. Does not attach to any calendar event — calendar linking requires a separate Calendar tool call. Capture `meetingUri`, `meetingCode`, and `space.name` from the response immediately for downstream lookups. Requires `meetings.space.created` OAuth scope. Returns HTTP 429 under rapid calls; apply exponential backoff. Use when you need a meeting space with specific access controls, moderation, recording, or transcription settings."
+        "description": "Creates a new Google Meet space with optional configuration. Does not attach to any calendar event \u2014 calendar linking requires a separate Calendar tool call. Capture `meetingUri`, `meetingCode`, and `space.name` from the response immediately for downstream lookups. Requires `meetings.space.created` OAuth scope. Returns HTTP 429 under rapid calls; apply exponential backoff. Use when you need a meeting space with specific access controls, moderation, recording, or transcription settings."
       },
       {
         "slug": "GOOGLEMEET_END_ACTIVE_CONFERENCE",
         "name": "End active conference",
-        "description": "Ends an active conference in a Google Meet space. REQUIRES 'space_name' parameter (e.g., 'spaces/jQCFfuBOdN5z' or just 'jQCFfuBOdN5z'). Use when you need to terminate an ongoing conference in a specified space. This operation only succeeds if a conference is actively running in the space. You must always provide the space_name to identify which space's conference to end. Immediately drops all active participants — obtain explicit user confirmation before calling."
+        "description": "Ends an active conference in a Google Meet space. REQUIRES 'space_name' parameter (e.g., 'spaces/jQCFfuBOdN5z' or just 'jQCFfuBOdN5z'). Use when you need to terminate an ongoing conference in a specified space. This operation only succeeds if a conference is actively running in the space. You must always provide the space_name to identify which space's conference to end. Immediately drops all active participants \u2014 obtain explicit user confirmation before calling."
       },
       {
         "slug": "GOOGLEMEET_GET_CONFERENCE_RECORD_BY_NAME",
@@ -44950,7 +44950,7 @@
       {
         "slug": "GOOGLEMEET_GET_MEET",
         "name": "Get Meet details",
-        "description": "Retrieve details of a Google Meet space using its unique identifier. Newly created spaces may return incomplete data; retry after 1–3 seconds if needed."
+        "description": "Retrieve details of a Google Meet space using its unique identifier. Newly created spaces may return incomplete data; retry after 1\u20133 seconds if needed."
       },
       {
         "slug": "GOOGLEMEET_GET_PARTICIPANT_SESSION",
@@ -44960,7 +44960,7 @@
       {
         "slug": "GOOGLEMEET_GET_RECORDINGS_BY_CONFERENCE_RECORD_ID",
         "name": "Get recordings by conference record ID",
-        "description": "Retrieves recordings from Google Meet for a given conference record ID. Only returns recordings if recording was enabled and permitted by the organizer's domain policies; a valid conferenceRecord_id does not guarantee recordings exist. After a meeting ends, recordings may take several minutes to process — an empty result may be temporary, not permanent."
+        "description": "Retrieves recordings from Google Meet for a given conference record ID. Only returns recordings if recording was enabled and permitted by the organizer's domain policies; a valid conferenceRecord_id does not guarantee recordings exist. After a meeting ends, recordings may take several minutes to process \u2014 an empty result may be temporary, not permanent."
       },
       {
         "slug": "GOOGLEMEET_GET_TRANSCRIPT",
@@ -44975,7 +44975,7 @@
       {
         "slug": "GOOGLEMEET_GET_TRANSCRIPTS_BY_CONFERENCE_RECORD_ID",
         "name": "Get transcripts by conference record ID",
-        "description": "Retrieves all transcripts for a specific Google Meet conference using its conferenceRecord_id. Transcripts require processing time after a meeting ends — empty results may be transient; retry after a delay before concluding no transcripts exist. Returns results only if transcription was enabled during the meeting and permitted by the organizer's domain policies; an empty list may also indicate transcription was never generated."
+        "description": "Retrieves all transcripts for a specific Google Meet conference using its conferenceRecord_id. Transcripts require processing time after a meeting ends \u2014 empty results may be transient; retry after a delay before concluding no transcripts exist. Returns results only if transcription was enabled during the meeting and permitted by the organizer's domain policies; an empty list may also indicate transcription was never generated."
       },
       {
         "slug": "GOOGLEMEET_LIST_CONFERENCE_RECORDS",
@@ -45146,7 +45146,7 @@
       {
         "slug": "ZOHO_CREATE_ZOHO_RECORD",
         "name": "Create Zoho CRM Record",
-        "description": "Creates new records in a specified module in Zoho CRM. Bulk operations may partially succeed — inspect each item's status field in the response, as some records may be created while others fail."
+        "description": "Creates new records in a specified module in Zoho CRM. Bulk operations may partially succeed \u2014 inspect each item's status field in the response, as some records may be created while others fail."
       },
       {
         "slug": "ZOHO_CREATE_ZOHO_TAG",
@@ -45331,12 +45331,12 @@
       {
         "slug": "FIREFLIES_GET_BITES",
         "name": "Get Transcripts",
-        "description": "Fetches a list of bites (highlights) against input arguments. Bites are generated asynchronously after transcript completion — only call this after FIREFLIES_GET_TRANSCRIPT_BY_ID reports `status=completed`. Empty results are possible for valid meetings; use FIREFLIES_GET_TRANSCRIPT_BY_ID for full transcript context when bites are unavailable."
+        "description": "Fetches a list of bites (highlights) against input arguments. Bites are generated asynchronously after transcript completion \u2014 only call this after FIREFLIES_GET_TRANSCRIPT_BY_ID reports `status=completed`. Empty results are possible for valid meetings; use FIREFLIES_GET_TRANSCRIPT_BY_ID for full transcript context when bites are unavailable."
       },
       {
         "slug": "FIREFLIES_GET_TRANSCRIPT_BY_ID",
         "name": "Get Transcript by ID",
-        "description": "Fetches details for a specific Fireflies transcript ID. Requires a paid Fireflies plan. Response is nested at data.outputs.data.transcript; fields like sentences and attendees can be null — handle gracefully. transcript.summary.action_items may be a single newline-delimited string rather than an array — split by line breaks instead of iterating as an array. Limit concurrent calls to ~3 and apply exponential backoff on 429 responses, respecting Retry-After headers."
+        "description": "Fetches details for a specific Fireflies transcript ID. Requires a paid Fireflies plan. Response is nested at data.outputs.data.transcript; fields like sentences and attendees can be null \u2014 handle gracefully. transcript.summary.action_items may be a single newline-delimited string rather than an array \u2014 split by line breaks instead of iterating as an array. Limit concurrent calls to ~3 and apply exponential backoff on 429 responses, respecting Retry-After headers."
       },
       {
         "slug": "FIREFLIES_GET_TRANSCRIPTS",
@@ -45386,7 +45386,7 @@
       {
         "slug": "FIREFLIES_UPLOAD_AUDIO",
         "name": "Upload Audio",
-        "description": "The UploadAudio Action allows you to upload audio files to Fireflies.ai for transcription. Transcription is asynchronous — after submission, results may take several minutes to become available; use transcript retrieval tools to poll for completion. Note: This action requires a paid Fireflies plan to upload and transcribe audio files."
+        "description": "The UploadAudio Action allows you to upload audio files to Fireflies.ai for transcription. Transcription is asynchronous \u2014 after submission, results may take several minutes to become available; use transcript retrieval tools to poll for completion. Note: This action requires a paid Fireflies plan to upload and transcribe audio files."
       }
     ],
     "triggers": [
@@ -45651,7 +45651,7 @@
       {
         "slug": "DROPBOX_DELETE_FILE_OR_FOLDER",
         "name": "Delete file or folder (Deprecated)",
-        "description": "DEPRECATED: Use DeleteFile instead. Permanently and irreversibly deletes the file or folder at the specified path in Dropbox. Folder deletion is recursive — all nested contents are removed. Always obtain explicit user confirmation before calling, especially for folders. Requires the `files.content.write` scope."
+        "description": "DEPRECATED: Use DeleteFile instead. Permanently and irreversibly deletes the file or folder at the specified path in Dropbox. Folder deletion is recursive \u2014 all nested contents are removed. Always obtain explicit user confirmation before calling, especially for folders. Requires the `files.content.write` scope."
       },
       {
         "slug": "DROPBOX_DELETE_FILE_REQUESTS",
@@ -45926,7 +45926,7 @@
       {
         "slug": "DROPBOX_LIST_FILES_IN_FOLDER",
         "name": "List files in folder",
-        "description": "Tool to list files and folders in a specified Dropbox directory. Use when you need to see the contents of a folder, including subfolders if recursive is true. When the response contains `has_more=true`, continue fetching with the returned cursor until `has_more=false` — stopping early misses entries in large folders. Response entries include both files and folders; use the `.tag` field on each entry to distinguish item types."
+        "description": "Tool to list files and folders in a specified Dropbox directory. Use when you need to see the contents of a folder, including subfolders if recursive is true. When the response contains `has_more=true`, continue fetching with the returned cursor until `has_more=false` \u2014 stopping early misses entries in large folders. Response entries include both files and folders; use the `.tag` field on each entry to distinguish item types."
       },
       {
         "slug": "DROPBOX_LIST_FOLDER_CONTINUE",
@@ -46487,7 +46487,7 @@
       {
         "slug": "SHORTCUT_CREATE_STORY_LINK",
         "name": "Create story link",
-        "description": "Story Links (called Story Relationships in the UI) allow you create semantic relationships between two stories. The parameters read like an active voice grammatical sentence: subject -> verb -> object. The subject story acts on the object Story; the object story is the direct object of the sentence. The subject story \"blocks\", \"duplicates\", or \"relates to\" the object story. Examples: - \"story 5 blocks story 6” -- story 6 is now \"blocked\" until story 5 is moved to a Done workflow state. - \"story 2 duplicates story 1” -- Story 2 represents the same body of work as Story 1 (and should probably be archived). - \"story 7 relates to story 3”"
+        "description": "Story Links (called Story Relationships in the UI) allow you create semantic relationships between two stories. The parameters read like an active voice grammatical sentence: subject -> verb -> object. The subject story acts on the object Story; the object story is the direct object of the sentence. The subject story \"blocks\", \"duplicates\", or \"relates to\" the object story. Examples: - \"story 5 blocks story 6\u201d -- story 6 is now \"blocked\" until story 5 is moved to a Done workflow state. - \"story 2 duplicates story 1\u201d -- Story 2 represents the same body of work as Story 1 (and should probably be archived). - \"story 7 relates to story 3\u201d"
       },
       {
         "slug": "SHORTCUT_CREATE_STORY_REACTION",
@@ -47223,7 +47223,7 @@
       {
         "slug": "CONFLUENCE_DELETE_PAGE",
         "name": "Delete Page",
-        "description": "Tool to delete a Confluence page. Use with caution as this permanently removes the page and its content with no recovery option. In move or migration workflows, confirm all target pages were successfully created before deleting source pages — partial creation failures combined with deletion result in unrecoverable data loss."
+        "description": "Tool to delete a Confluence page. Use with caution as this permanently removes the page and its content with no recovery option. In move or migration workflows, confirm all target pages were successfully created before deleting source pages \u2014 partial creation failures combined with deletion result in unrecoverable data loss."
       },
       {
         "slug": "CONFLUENCE_DELETE_SPACE",
@@ -47318,7 +47318,7 @@
       {
         "slug": "CONFLUENCE_GET_CURRENT_USER",
         "name": "Get Current User",
-        "description": "Tool to get information about the currently authenticated user — always scoped to the account tied to the configured connection, not arbitrary users. Use CONFLUENCE_SEARCH_USERS to look up other users. Response contains nested metadata; key fields include accountId, displayName, and email for use in downstream logic."
+        "description": "Tool to get information about the currently authenticated user \u2014 always scoped to the account tied to the configured connection, not arbitrary users. Use CONFLUENCE_SEARCH_USERS to look up other users. Response contains nested metadata; key fields include accountId, displayName, and email for use in downstream logic."
       },
       {
         "slug": "CONFLUENCE_GET_INLINE_COMMENTS_FOR_BLOG_POST",
@@ -47353,7 +47353,7 @@
       {
         "slug": "CONFLUENCE_GET_PAGE_BY_ID",
         "name": "Get Page by ID",
-        "description": "Tool to retrieve a Confluence page by its ID. Use when you have a page ID and need its detailed metadata and content. Response body is in `body.storage.value` as Confluence storage format (HTML); strip tags before plain-text use. Before calling CONFLUENCE_UPDATE_PAGE, fetch the latest version here — that tool requires `version.number` = current + 1, else a 409 conflict occurs."
+        "description": "Tool to retrieve a Confluence page by its ID. Use when you have a page ID and need its detailed metadata and content. Response body is in `body.storage.value` as Confluence storage format (HTML); strip tags before plain-text use. Before calling CONFLUENCE_UPDATE_PAGE, fetch the latest version here \u2014 that tool requires `version.number` = current + 1, else a 409 conflict occurs."
       },
       {
         "slug": "CONFLUENCE_GET_PAGE_FOOTER_COMMENTS",
@@ -47378,7 +47378,7 @@
       {
         "slug": "CONFLUENCE_GET_PAGE_VERSIONS",
         "name": "Get Page Versions",
-        "description": "Tool to retrieve all versions of a specific Confluence page. Use to audit edit history or to get the latest version.number before calling CONFLUENCE_UPDATE_PAGE — using a stale version.number causes a 409 Conflict error."
+        "description": "Tool to retrieve all versions of a specific Confluence page. Use to audit edit history or to get the latest version.number before calling CONFLUENCE_UPDATE_PAGE \u2014 using a stale version.number causes a 409 Conflict error."
       },
       {
         "slug": "CONFLUENCE_GET_SPACE_BY_ID",
@@ -47388,7 +47388,7 @@
       {
         "slug": "CONFLUENCE_GET_SPACE_CONTENTS",
         "name": "Get Space Contents",
-        "description": "Tool to retrieve content in a Confluence space. Use when you need to list pages, blogposts, or attachments of a specific space key. Results are in data.results (not data.page.results). Paginate via start/limit (max 200/request); follow response._links.next until absent to avoid missing content. Only returns content accessible to the authenticated user — missing items may indicate permission restrictions. Atlassian Cloud enforces HTTP 429 rate limits; throttle to ~1–2 requests/second, honor Retry-After headers, and cap start ≤ 1000 for large spaces. Construct item URLs by combining data._links.base with each item's _links.webui."
+        "description": "Tool to retrieve content in a Confluence space. Use when you need to list pages, blogposts, or attachments of a specific space key. Results are in data.results (not data.page.results). Paginate via start/limit (max 200/request); follow response._links.next until absent to avoid missing content. Only returns content accessible to the authenticated user \u2014 missing items may indicate permission restrictions. Atlassian Cloud enforces HTTP 429 rate limits; throttle to ~1\u20132 requests/second, honor Retry-After headers, and cap start \u2264 1000 for large spaces. Construct item URLs by combining data._links.base with each item's _links.webui."
       },
       {
         "slug": "CONFLUENCE_GET_SPACE_PROPERTIES",
@@ -47398,7 +47398,7 @@
       {
         "slug": "CONFLUENCE_GET_SPACES",
         "name": "Get Spaces",
-        "description": "Tool to retrieve a paginated list of Confluence spaces with optional filtering. Paginate by incrementing `start` in steps of `limit` until fewer results than `limit` are returned. Results are scoped to spaces visible to the authenticated user; absent spaces may be restricted rather than nonexistent. Use `spaceKey` or numeric space ID (not display name) for stable identification in downstream calls. Combined filters apply as AND logic — relax filters before concluding a space is missing."
+        "description": "Tool to retrieve a paginated list of Confluence spaces with optional filtering. Paginate by incrementing `start` in steps of `limit` until fewer results than `limit` are returned. Results are scoped to spaces visible to the authenticated user; absent spaces may be restricted rather than nonexistent. Use `spaceKey` or numeric space ID (not display name) for stable identification in downstream calls. Combined filters apply as AND logic \u2014 relax filters before concluding a space is missing."
       },
       {
         "slug": "CONFLUENCE_GET_TASKS",
@@ -47413,7 +47413,7 @@
       {
         "slug": "CONFLUENCE_SEARCH_CONTENT",
         "name": "Search Content",
-        "description": "Searches for content by filtering pages from the Confluence v2 API with intelligent ranking. Since the native search endpoint is deprecated, this action: 1. Fetches pages from the v2 pages endpoint with pagination (up to 300 pages) 2. Applies intelligent client-side filtering with relevance scoring 3. Returns results ranked by match quality (exact phrase > all words > partial matches). NOTE: Only page titles are searched — queries matching only body content return no results. Results omit full body content and canonical URLs; use CONFLUENCE_GET_PAGE_BY_ID for complete page data. Cannot filter by author, date, or labels. Results reflect only pages accessible to the authenticated user. When multiple pages share similar titles, verify the correct page via spaceId or pageId before performing writes."
+        "description": "Searches for content by filtering pages from the Confluence v2 API with intelligent ranking. Since the native search endpoint is deprecated, this action: 1. Fetches pages from the v2 pages endpoint with pagination (up to 300 pages) 2. Applies intelligent client-side filtering with relevance scoring 3. Returns results ranked by match quality (exact phrase > all words > partial matches). NOTE: Only page titles are searched \u2014 queries matching only body content return no results. Results omit full body content and canonical URLs; use CONFLUENCE_GET_PAGE_BY_ID for complete page data. Cannot filter by author, date, or labels. Results reflect only pages accessible to the authenticated user. When multiple pages share similar titles, verify the correct page via spaceId or pageId before performing writes."
       },
       {
         "slug": "CONFLUENCE_SEARCH_USERS",
@@ -51433,7 +51433,7 @@
       {
         "slug": "HEYGEN_RETRIEVE_VIDEO_STATUS_DETAILS",
         "name": "Retrieve video status details",
-        "description": "Tool to retrieve the current processing status and metadata for a specific video by ID. Use when you need to check video processing progress, get time-limited URLs for video downloads, or monitor video generation completion. Video rendering is asynchronous and typically takes 30–180+ seconds; poll at moderate intervals rather than tight loops. Verify returned URLs are accessible before surfacing to users. Note that returned URLs expire after 7 days but can be regenerated by calling this endpoint again."
+        "description": "Tool to retrieve the current processing status and metadata for a specific video by ID. Use when you need to check video processing progress, get time-limited URLs for video downloads, or monitor video generation completion. Video rendering is asynchronous and typically takes 30\u2013180+ seconds; poll at moderate intervals rather than tight loops. Verify returned URLs are accessible before surfacing to users. Note that returned URLs expire after 7 days but can be regenerated by calling this endpoint again."
       },
       {
         "slug": "HEYGEN_SEARCH_PUBLIC_AVATAR_GROUPS",
@@ -53113,7 +53113,7 @@
       {
         "slug": "MONDAY_DELETE_TEAM",
         "name": "Delete team",
-        "description": "Tool to delete an existing team; use when you need to permanently remove a team by its ID after confirming it’s no longer needed."
+        "description": "Tool to delete an existing team; use when you need to permanently remove a team by its ID after confirming it\u2019s no longer needed."
       },
       {
         "slug": "MONDAY_DELETE_TEAMS_FROM_BOARD",
@@ -53278,7 +53278,7 @@
       {
         "slug": "MONDAY_LIST_BOARD_ITEMS",
         "name": "List board items",
-        "description": "DEPRECATED: Use MONDAY_ITEMS_PAGE instead, which supports cursor-based pagination. This tool may silently omit items on larger boards. Results include archived and deleted items by default — filter by state to retrieve only active items."
+        "description": "DEPRECATED: Use MONDAY_ITEMS_PAGE instead, which supports cursor-based pagination. This tool may silently omit items on larger boards. Results include archived and deleted items by default \u2014 filter by state to retrieve only active items."
       },
       {
         "slug": "MONDAY_LIST_BOARDS",
@@ -53293,7 +53293,7 @@
       {
         "slug": "MONDAY_LIST_GROUPS",
         "name": "List groups",
-        "description": "Tool to retrieve all groups of a specified board. Use when you need to list groups on a board after confirming its board ID. Response is nested under data → boards[0] → groups; confirm boards[0] exists before accessing groups."
+        "description": "Tool to retrieve all groups of a specified board. Use when you need to list groups on a board after confirming its board ID. Response is nested under data \u2192 boards[0] \u2192 groups; confirm boards[0] exists before accessing groups."
       },
       {
         "slug": "MONDAY_LIST_ITEMS",
@@ -53408,7 +53408,7 @@
       {
         "slug": "MONDAY_UPDATE_COLUMN",
         "name": "Update column",
-        "description": "Tool to update column title or description. Use when modifying a column’s metadata after creation."
+        "description": "Tool to update column title or description. Use when modifying a column\u2019s metadata after creation."
       },
       {
         "slug": "MONDAY_UPDATE_DOC",
@@ -53710,7 +53710,7 @@
       {
         "slug": "SENDGRID_ADD_A_SINGLE_RECIPIENT_TO_A_LIST",
         "name": "Add a single recipient to a list",
-        "description": "Adds a single recipient to a contact list in SendGrid's Legacy Contact Database. IMPORTANT: This uses the deprecated Legacy API (/v3/contactdb/). Many accounts no longer have access and will receive 403 errors. Use PUT /v3/marketing/contacts instead. Prerequisites: The recipient and list must already exist in your database. Parameters: - list_id: Numeric list ID from 'create_a_list' or 'retrieve_all_lists' - recipient_id: Base64-encoded lowercase email (e.g., 'test@example.com' → 'dGVzdEBleGFtcGxlLmNvbQ==') Returns: Empty dict {} on success (HTTP 201), or error details with status_code, message, and hint for troubleshooting."
+        "description": "Adds a single recipient to a contact list in SendGrid's Legacy Contact Database. IMPORTANT: This uses the deprecated Legacy API (/v3/contactdb/). Many accounts no longer have access and will receive 403 errors. Use PUT /v3/marketing/contacts instead. Prerequisites: The recipient and list must already exist in your database. Parameters: - list_id: Numeric list ID from 'create_a_list' or 'retrieve_all_lists' - recipient_id: Base64-encoded lowercase email (e.g., 'test@example.com' \u2192 'dGVzdEBleGFtcGxlLmNvbQ==') Returns: Empty dict {} on success (HTTP 201), or error details with status_code, message, and hint for troubleshooting."
       },
       {
         "slug": "SENDGRID_ADD_A_TWILIO_SEND_GRID_IP_ADDRESS",
@@ -53745,7 +53745,7 @@
       {
         "slug": "SENDGRID_APPROVE_ACCESS_REQUEST",
         "name": "Approve access request",
-        "description": "**This endpoint allows you to approve an access attempt.** **Note:** Only teammate admins may approve another teammate’s access request."
+        "description": "**This endpoint allows you to approve an access attempt.** **Note:** Only teammate admins may approve another teammate\u2019s access request."
       },
       {
         "slug": "SENDGRID_ASSIGN_A_BATCH_OF_SUBUSERS_TO_AN_IP",
@@ -53765,7 +53765,7 @@
       {
         "slug": "SENDGRID_AUTHENTICATE_A_DOMAIN",
         "name": "Authenticate a domain",
-        "description": "The endpoint enables domain authentication for users or subusers, offering two methods—'username' parameter for visibility and modification, or the Association workflow for a fixed, non-editable domain assignment."
+        "description": "The endpoint enables domain authentication for users or subusers, offering two methods\u2014'username' parameter for visibility and modification, or the Association workflow for a fixed, non-editable domain assignment."
       },
       {
         "slug": "SENDGRID_AUTHENTICATE_AN_ACCOUNT_WITH_SINGLE_SIGN_ON",
@@ -53870,7 +53870,7 @@
       {
         "slug": "SENDGRID_CREATE_A_PARSE_SETTING",
         "name": "Create a parse setting",
-        "description": "Creates a new Inbound Parse Webhook setting to receive and parse incoming emails. **Prerequisites:** 1. The hostname must be part of a domain that is authenticated via SendGrid Domain Authentication. 2. Your domain's MX records must point to `mx.sendgrid.net` (priority 10). 3. The receiving URL must be publicly accessible and return HTTP 200 on success. **Parameters:** - `hostname`: Required. A subdomain of your authenticated domain (e.g., `parse.yourdomain.com`). - `url`: Required. Public webhook URL to receive parsed emails via HTTP POST. - `send_raw`: Optional. Set to `true` to receive raw MIME content. - `spam_check`: Optional. Set to `true` to enable spam filtering (emails ≤2.5MB). **Returns:** The created parse setting with hostname, url, send_raw, and spam_check values."
+        "description": "Creates a new Inbound Parse Webhook setting to receive and parse incoming emails. **Prerequisites:** 1. The hostname must be part of a domain that is authenticated via SendGrid Domain Authentication. 2. Your domain's MX records must point to `mx.sendgrid.net` (priority 10). 3. The receiving URL must be publicly accessible and return HTTP 200 on success. **Parameters:** - `hostname`: Required. A subdomain of your authenticated domain (e.g., `parse.yourdomain.com`). - `url`: Required. Public webhook URL to receive parsed emails via HTTP POST. - `send_raw`: Optional. Set to `true` to receive raw MIME content. - `spam_check`: Optional. Set to `true` to enable spam filtering (emails \u22642.5MB). **Returns:** The created parse setting with hostname, url, send_raw, and spam_check values."
       },
       {
         "slug": "SENDGRID_CREATE_API_KEYS",
@@ -55300,7 +55300,7 @@
       {
         "slug": "SENDGRID_UPDATE_A_PARSE_SETTING",
         "name": "Update a parse setting",
-        "description": "Updates an existing Inbound Parse Webhook setting by hostname. **Prerequisites:** 1. The hostname must already exist as a configured parse setting. 2. Use 'Retrieve all parse settings' to list available hostnames. **Parameters:** - `hostname`: Required. The hostname of the parse setting to update. - `url`: Optional. New webhook URL to receive parsed emails via HTTP POST. - `send_raw`: Optional. Set to `true` to receive raw MIME content instead of parsed fields. - `spam_check`: Optional. Set to `true` to enable spam filtering (emails ≤2.5MB). - `on_behalf_of`: Optional. Subuser username to make the call on their behalf. **Returns:** The updated parse setting with hostname, url, send_raw, and spam_check values. **Note:** Only include the fields you want to update. Omitted fields remain unchanged."
+        "description": "Updates an existing Inbound Parse Webhook setting by hostname. **Prerequisites:** 1. The hostname must already exist as a configured parse setting. 2. Use 'Retrieve all parse settings' to list available hostnames. **Parameters:** - `hostname`: Required. The hostname of the parse setting to update. - `url`: Optional. New webhook URL to receive parsed emails via HTTP POST. - `send_raw`: Optional. Set to `true` to receive raw MIME content instead of parsed fields. - `spam_check`: Optional. Set to `true` to enable spam filtering (emails \u22642.5MB). - `on_behalf_of`: Optional. Subuser username to make the call on their behalf. **Returns:** The updated parse setting with hostname, url, send_raw, and spam_check values. **Note:** Only include the fields you want to update. Omitted fields remain unchanged."
       },
       {
         "slug": "SENDGRID_UPDATE_API_KEY_NAME",
@@ -56141,7 +56141,7 @@
       {
         "slug": "PIPEDRIVE_DELETE_PERSON_PICTURE",
         "name": "Delete person picture",
-        "description": "Deletes a person’s picture. Note: Pipedrive may return a 400 with error \"Item not found\" when the person has no picture set. Since delete is idempotent, we treat this specific case as a successful no-op and return a normalized response rather than raising."
+        "description": "Deletes a person\u2019s picture. Note: Pipedrive may return a 400 with error \"Item not found\" when the person has no picture set. Since delete is idempotent, we treat this specific case as a successful no-op and return a normalized response rather than raising."
       },
       {
         "slug": "PIPEDRIVE_DELETE_PERSONS_BULK",
@@ -57396,7 +57396,7 @@
       {
         "slug": "PIPEDRIVE_UPDATE_A_PERSON",
         "name": "Update a person",
-        "description": "Modifies a person’s details in Pipedrive. See the linked tutorial for guidance. If utilizing Campaigns, the endpoint also handles `data.marketing_status`."
+        "description": "Modifies a person\u2019s details in Pipedrive. See the linked tutorial for guidance. If utilizing Campaigns, the endpoint also handles `data.marketing_status`."
       },
       {
         "slug": "PIPEDRIVE_UPDATE_A_PERSON_FIELD",
@@ -58432,12 +58432,12 @@
       {
         "slug": "ZENDESK_COUNT_ZENDESK_ORGANIZATIONS",
         "name": "Count Zendesk Organizations",
-        "description": "Count the number of organizations in Zendesk. Returns a single numeric total only — no names, IDs, or custom fields. Use ZENDESK_GET_ALL_ZENDESK_ORGANIZATIONS for per-organization detail."
+        "description": "Count the number of organizations in Zendesk. Returns a single numeric total only \u2014 no names, IDs, or custom fields. Use ZENDESK_GET_ALL_ZENDESK_ORGANIZATIONS for per-organization detail."
       },
       {
         "slug": "ZENDESK_CREATE_ZENDESK_ORGANIZATION",
         "name": "Create Zendesk Organization",
-        "description": "Create an organization in Zendesk. Both `name` and `external_id` must be unique across the account; verify no duplicates exist before calling. Returns `data.id` — persist it for subsequent update or delete operations."
+        "description": "Create an organization in Zendesk. Both `name` and `external_id` must be unique across the account; verify no duplicates exist before calling. Returns `data.id` \u2014 persist it for subsequent update or delete operations."
       },
       {
         "slug": "ZENDESK_CREATE_ZENDESK_TICKET",
@@ -58467,7 +58467,7 @@
       {
         "slug": "ZENDESK_DESTROY_MANY_ORGANIZATIONS",
         "name": "Bulk Delete Zendesk Organizations",
-        "description": "Tool to bulk delete Zendesk organizations. Irreversible — confirm ids/external_ids before calling. Use when cleaning up test data or removing obsolete organizations in one call. Returns a job_status payload (initial status typically 'queued'); deletions complete asynchronously and may require follow-up polling to confirm completion."
+        "description": "Tool to bulk delete Zendesk organizations. Irreversible \u2014 confirm ids/external_ids before calling. Use when cleaning up test data or removing obsolete organizations in one call. Returns a job_status payload (initial status typically 'queued'); deletions complete asynchronously and may require follow-up polling to confirm completion."
       },
       {
         "slug": "ZENDESK_GET_ABOUT_ME",
@@ -58477,7 +58477,7 @@
       {
         "slug": "ZENDESK_GET_ALL_ZENDESK_ORGANIZATIONS",
         "name": "Get Zendesk Organizations",
-        "description": "Get all organizations in Zendesk. Returns results nested under an 'organizations' array; an empty list is valid. Accepts no server-side filters — all filtering by name, domain_names (an array field), or organization_fields must be done client-side. Large accounts require pagination; missing pages will undercount results. Multiple organizations may share similar names or domains — always disambiguate using external_id or domain_names and confirm organization_id before acting. Avoid repeated full-list fetches on large accounts; cache or batch client-side instead."
+        "description": "Get all organizations in Zendesk. Returns results nested under an 'organizations' array; an empty list is valid. Accepts no server-side filters \u2014 all filtering by name, domain_names (an array field), or organization_fields must be done client-side. Large accounts require pagination; missing pages will undercount results. Multiple organizations may share similar names or domains \u2014 always disambiguate using external_id or domain_names and confirm organization_id before acting. Avoid repeated full-list fetches on large accounts; cache or batch client-side instead."
       },
       {
         "slug": "ZENDESK_GET_USER",
@@ -58492,12 +58492,12 @@
       {
         "slug": "ZENDESK_GET_ZENDESK_TICKET_BY_ID",
         "name": "Get Zendesk Ticket",
-        "description": "Get ticket details from Zendesk. Response wraps all data under a top-level `data` key; access `data['comments']` for comments and `data['comments'][i]['attachments']` for attachments (attachments unavailable from list endpoints). Each comment has both `html_body` and plain `body` fields — choose appropriately. Fields like `subject`, `organization_id`, `author_id`, and `body` may be null; handle defensively. First comment in `data.comments` is not necessarily from the requester — compare `author_id` against ticket `requester_id` to identify requester messages. For bulk calls, honor `Retry-After` headers on HTTP 429."
+        "description": "Get ticket details from Zendesk. Response wraps all data under a top-level `data` key; access `data['comments']` for comments and `data['comments'][i]['attachments']` for attachments (attachments unavailable from list endpoints). Each comment has both `html_body` and plain `body` fields \u2014 choose appropriately. Fields like `subject`, `organization_id`, `author_id`, and `body` may be null; handle defensively. First comment in `data.comments` is not necessarily from the requester \u2014 compare `author_id` against ticket `requester_id` to identify requester messages. For bulk calls, honor `Retry-After` headers on HTTP 429."
       },
       {
         "slug": "ZENDESK_LIST_ZENDESK_TICKETS",
         "name": "List Tickets",
-        "description": "List Zendesk tickets with pagination and filtering. Only server-side filter available is external_id; status, priority, tags, assignee_id, and date-range filters must be applied client-side. Timestamps (created_at, updated_at) are ISO 8601 UTC. ticket.subject may be null — coerce to string before filtering. Attachments are not included; retrieve via ZENDESK_GET_ZENDESK_TICKET_BY_ID. HTTP 429 rate limit responses include Retry-After header; apply exponential backoff. Paginate by following next_page until null to avoid missing tickets."
+        "description": "List Zendesk tickets with pagination and filtering. Only server-side filter available is external_id; status, priority, tags, assignee_id, and date-range filters must be applied client-side. Timestamps (created_at, updated_at) are ISO 8601 UTC. ticket.subject may be null \u2014 coerce to string before filtering. Attachments are not included; retrieve via ZENDESK_GET_ZENDESK_TICKET_BY_ID. HTTP 429 rate limit responses include Retry-After header; apply exponential backoff. Paginate by following next_page until null to avoid missing tickets."
       },
       {
         "slug": "ZENDESK_LIST_ZENDESK_USERS",
@@ -58517,7 +58517,7 @@
       {
         "slug": "ZENDESK_SEARCH_ZENDESK_USERS",
         "name": "Search Users",
-        "description": "Tool to search Zendesk users by email or name. At least one of 'email' or 'name' must be provided; pagination-only calls fail. Results span all roles (end-users, agents, admins); filter by 'role' client-side if needed. No org-scoped filtering — filter by 'organization_id' client-side. A response with count=0 and empty users array means no match, not an error. Use before ticket creation to confirm user identity."
+        "description": "Tool to search Zendesk users by email or name. At least one of 'email' or 'name' must be provided; pagination-only calls fail. Results span all roles (end-users, agents, admins); filter by 'role' client-side if needed. No org-scoped filtering \u2014 filter by 'organization_id' client-side. A response with count=0 and empty users array means no match, not an error. Use before ticket creation to confirm user identity."
       },
       {
         "slug": "ZENDESK_UPDATE_ZENDESK_ORGANIZATION",
@@ -58787,7 +58787,7 @@
       {
         "slug": "LMNT_SYNTHESIZE_SPEECH",
         "name": "Synthesize Speech",
-        "description": "Synthesizes speech from text using LMNT's AI voices. Converts text (up to 5000 characters) into natural-sounding speech audio using a specified voice. Returns base64-encoded audio at `data.response_data.audio` — decode before saving or passing to other tools. Supports multiple audio formats and quality settings for different use cases."
+        "description": "Synthesizes speech from text using LMNT's AI voices. Converts text (up to 5000 characters) into natural-sounding speech audio using a specified voice. Returns base64-encoded audio at `data.response_data.audio` \u2014 decode before saving or passing to other tools. Supports multiple audio formats and quality settings for different use cases."
       },
       {
         "slug": "LMNT_UPDATE_VOICE",
@@ -59488,7 +59488,7 @@
       {
         "slug": "GOOGLESUPER_CALENDAR_LIST_UPDATE",
         "name": "Update Calendar List Entry",
-        "description": "Updates a calendar list entry's display/subscription settings (color, visibility, reminders, selection) for the authenticated user — does not modify the underlying calendar resource (title, timezone, etc.). To modify the calendar itself, use GOOGLECALENDAR_CALENDARS_UPDATE."
+        "description": "Updates a calendar list entry's display/subscription settings (color, visibility, reminders, selection) for the authenticated user \u2014 does not modify the underlying calendar resource (title, timezone, etc.). To modify the calendar itself, use GOOGLECALENDAR_CALENDARS_UPDATE."
       },
       {
         "slug": "GOOGLESUPER_CALENDAR_LIST_WATCH",
@@ -59498,7 +59498,7 @@
       {
         "slug": "GOOGLESUPER_CALENDARS_DELETE",
         "name": "Delete Calendar",
-        "description": "Deletes a secondary calendar that you own or have delete permissions on. Deletion is permanent and irreversible — verify the correct calendar_id before calling. You cannot delete your primary calendar or calendars you only have read/write access to. Use calendarList.list to find calendars with owner accessRole. For primary calendars, use calendars.clear instead. Parallel calls may trigger userRateLimitExceeded; sequence bulk deletions."
+        "description": "Deletes a secondary calendar that you own or have delete permissions on. Deletion is permanent and irreversible \u2014 verify the correct calendar_id before calling. You cannot delete your primary calendar or calendars you only have read/write access to. Use calendarList.list to find calendars with owner accessRole. For primary calendars, use calendars.clear instead. Parallel calls may trigger userRateLimitExceeded; sequence bulk deletions."
       },
       {
         "slug": "GOOGLESUPER_CALENDARS_UPDATE",
@@ -59543,7 +59543,7 @@
       {
         "slug": "GOOGLESUPER_COMPUTE_ROUTE_MATRIX",
         "name": "Compute Route Matrix",
-        "description": "Calculates travel distance and duration matrix between multiple origins and destinations using the modern Routes API; supports OAuth2 authentication and various travel modes. Matrix is capped at 625 elements (e.g., 25×25); chunk larger sets to avoid RESOURCE_EXHAUSTED errors. Response elements may be returned out of input order — always use originIndex and destinationIndex to map results. Only use elements where condition='ROUTE_EXISTS'; the matrix may be incomplete."
+        "description": "Calculates travel distance and duration matrix between multiple origins and destinations using the modern Routes API; supports OAuth2 authentication and various travel modes. Matrix is capped at 625 elements (e.g., 25\u00d725); chunk larger sets to avoid RESOURCE_EXHAUSTED errors. Response elements may be returned out of input order \u2014 always use originIndex and destinationIndex to map results. Only use elements where condition='ROUTE_EXISTS'; the matrix may be incomplete."
       },
       {
         "slug": "GOOGLESUPER_COPY_DOCUMENT",
@@ -59553,7 +59553,7 @@
       {
         "slug": "GOOGLESUPER_COPY_FILE",
         "name": "Copy file (Deprecated)",
-        "description": "DEPRECATED: Use GOOGLEDRIVE_COPY_FILE_ADVANCED instead. Duplicates an existing file (not folders) in Google Drive by `file_id`; copy lands in same folder as original — use GOOGLEDRIVE_MOVE_FILE afterward for precise placement. Copy receives a new `file_id`; update stored references accordingly. For shared drives, requires organizer/manager rights."
+        "description": "DEPRECATED: Use GOOGLEDRIVE_COPY_FILE_ADVANCED instead. Duplicates an existing file (not folders) in Google Drive by `file_id`; copy lands in same folder as original \u2014 use GOOGLEDRIVE_MOVE_FILE afterward for precise placement. Copy receives a new `file_id`; update stored references accordingly. For shared drives, requires organizer/manager rights."
       },
       {
         "slug": "GOOGLESUPER_COPY_FILE_ADVANCED",
@@ -59623,7 +59623,7 @@
       {
         "slug": "GOOGLESUPER_CREATE_EMAIL_DRAFT",
         "name": "Create email draft",
-        "description": "Creates a Gmail email draft. While all fields are optional per the Gmail API, practical validation requires at least one of recipient_email, cc, or bcc and at least one of subject or body. Supports To/Cc/Bcc recipients, subject, plain/HTML body (ensure `is_html=True` for HTML), attachments, and threading. Returns a draft_id that must be used as-is with GMAIL_SEND_DRAFT — synthetic or stale IDs will fail. When creating a draft reply to an existing thread (thread_id provided), leave subject empty to stay in the same thread; setting a subject will create a NEW thread instead. HTTP 429 may occur on rapid creation/send sequences; apply exponential backoff."
+        "description": "Creates a Gmail email draft. While all fields are optional per the Gmail API, practical validation requires at least one of recipient_email, cc, or bcc and at least one of subject or body. Supports To/Cc/Bcc recipients, subject, plain/HTML body (ensure `is_html=True` for HTML), attachments, and threading. Returns a draft_id that must be used as-is with GMAIL_SEND_DRAFT \u2014 synthetic or stale IDs will fail. When creating a draft reply to an existing thread (thread_id provided), leave subject empty to stay in the same thread; setting a subject will create a NEW thread instead. HTTP 429 may occur on rapid creation/send sequences; apply exponential backoff."
       },
       {
         "slug": "GOOGLESUPER_CREATE_EVENT",
@@ -59638,12 +59638,12 @@
       {
         "slug": "GOOGLESUPER_CREATE_FILE",
         "name": "Create File or Folder",
-        "description": "Creates a new file or folder with metadata. Native Google file types (Docs, Sheets, Forms, etc.) and folders are created as empty shells; content must be added manually in the Google UI afterward. Newly created files are private by default — set sharing permissions afterward for collaboration. For shared-drive folders, use this tool with the target folder ID in `parents` rather than GOOGLEDRIVE_CREATE_FOLDER."
+        "description": "Creates a new file or folder with metadata. Native Google file types (Docs, Sheets, Forms, etc.) and folders are created as empty shells; content must be added manually in the Google UI afterward. Newly created files are private by default \u2014 set sharing permissions afterward for collaboration. For shared-drive folders, use this tool with the target folder ID in `parents` rather than GOOGLEDRIVE_CREATE_FOLDER."
       },
       {
         "slug": "GOOGLESUPER_CREATE_FILE_FROM_TEXT",
         "name": "Create a File from Text",
-        "description": "Creates a new file in Google Drive from provided text content (up to 10MB), supporting various formats including automatic conversion to Google Workspace types. Returns flat metadata fields (`id`, `mimeType`, `name`) at the top level — not nested under a `file` object. Created files are private by default; use a sharing tool afterward for collaborative access. Rapid successive calls may trigger `403 rateLimitExceeded` or `429 userRateLimitExceeded`; apply exponential backoff between retries. Does not support shared-drive targets in all cases."
+        "description": "Creates a new file in Google Drive from provided text content (up to 10MB), supporting various formats including automatic conversion to Google Workspace types. Returns flat metadata fields (`id`, `mimeType`, `name`) at the top level \u2014 not nested under a `file` object. Created files are private by default; use a sharing tool afterward for collaborative access. Rapid successive calls may trigger `403 rateLimitExceeded` or `429 userRateLimitExceeded`; apply exponential backoff between retries. Does not support shared-drive targets in all cases."
       },
       {
         "slug": "GOOGLESUPER_CREATE_FILTER",
@@ -59678,12 +59678,12 @@
       {
         "slug": "GOOGLESUPER_CREATE_LABEL",
         "name": "Create label",
-        "description": "Creates a new label with a unique name in the specified user's Gmail account. Returns a labelId (e.g., 'Label_123') required for downstream tools like GMAIL_ADD_LABEL_TO_EMAIL, GMAIL_BATCH_MODIFY_MESSAGES, and GMAIL_MODIFY_THREAD_LABELS — those tools do not accept display names."
+        "description": "Creates a new label with a unique name in the specified user's Gmail account. Returns a labelId (e.g., 'Label_123') required for downstream tools like GMAIL_ADD_LABEL_TO_EMAIL, GMAIL_BATCH_MODIFY_MESSAGES, and GMAIL_MODIFY_THREAD_LABELS \u2014 those tools do not accept display names."
       },
       {
         "slug": "GOOGLESUPER_CREATE_MEET",
         "name": "Create Google Meet Space",
-        "description": "Creates a new Google Meet space with optional configuration. Does not attach to any calendar event — calendar linking requires a separate Calendar tool call. Capture `meetingUri`, `meetingCode`, and `space.name` from the response immediately for downstream lookups. Requires `meetings.space.created` OAuth scope. Returns HTTP 429 under rapid calls; apply exponential backoff. Use when you need a meeting space with specific access controls, moderation, recording, or transcription settings."
+        "description": "Creates a new Google Meet space with optional configuration. Does not attach to any calendar event \u2014 calendar linking requires a separate Calendar tool call. Capture `meetingUri`, `meetingCode`, and `space.name` from the response immediately for downstream lookups. Requires `meetings.space.created` OAuth scope. Returns HTTP 429 under rapid calls; apply exponential backoff. Use when you need a meeting space with specific access controls, moderation, recording, or transcription settings."
       },
       {
         "slug": "GOOGLESUPER_CREATE_NAMED_RANGE",
@@ -59763,7 +59763,7 @@
       {
         "slug": "GOOGLESUPER_DELETE_COMMENT",
         "name": "Delete Comment",
-        "description": "Permanently deletes a comment thread (and all its replies) from a Google Drive file — this action is irreversible. To remove only a single reply within a thread, use GOOGLEDRIVE_DELETE_REPLY instead. Verify the exact comment content and comment_id before calling."
+        "description": "Permanently deletes a comment thread (and all its replies) from a Google Drive file \u2014 this action is irreversible. To remove only a single reply within a thread, use GOOGLEDRIVE_DELETE_REPLY instead. Verify the exact comment content and comment_id before calling."
       },
       {
         "slug": "GOOGLESUPER_DELETE_CONTENT_RANGE",
@@ -59788,7 +59788,7 @@
       {
         "slug": "GOOGLESUPER_DELETE_EVENT",
         "name": "Delete event",
-        "description": "Deletes a specified event by `event_id` from a Google Calendar (`calendar_id`); idempotent — a 404 for an already-deleted event is a no-op. Bulk deletions may trigger `rateLimitExceeded` or `userRateLimitExceeded`; cap concurrency to 5–10 requests and apply exponential backoff."
+        "description": "Deletes a specified event by `event_id` from a Google Calendar (`calendar_id`); idempotent \u2014 a 404 for an already-deleted event is a no-op. Bulk deletions may trigger `rateLimitExceeded` or `userRateLimitExceeded`; cap concurrency to 5\u201310 requests and apply exponential backoff."
       },
       {
         "slug": "GOOGLESUPER_DELETE_FILE",
@@ -59838,7 +59838,7 @@
       {
         "slug": "GOOGLESUPER_DELETE_PERMISSION",
         "name": "Delete Permission",
-        "description": "Deletes a permission from a file by permission ID. Deletion is irreversible — confirm the target user, group, or permission type before executing. IMPORTANT: You must first call GOOGLEDRIVE_LIST_PERMISSIONS to get valid permission IDs. To fully revoke public access, the type='anyone' (link-sharing) permission must be explicitly deleted; revoking other permissions leaves the file publicly accessible via link. Use when you need to revoke access for a specific user or group from a file."
+        "description": "Deletes a permission from a file by permission ID. Deletion is irreversible \u2014 confirm the target user, group, or permission type before executing. IMPORTANT: You must first call GOOGLEDRIVE_LIST_PERMISSIONS to get valid permission IDs. To fully revoke public access, the type='anyone' (link-sharing) permission must be explicitly deleted; revoking other permissions leaves the file publicly accessible via link. Use when you need to revoke access for a specific user or group from a file."
       },
       {
         "slug": "GOOGLESUPER_DELETE_PROPERTY",
@@ -59848,7 +59848,7 @@
       {
         "slug": "GOOGLESUPER_DELETE_REPLY",
         "name": "Delete Reply",
-        "description": "Tool to delete a specific reply by reply ID. Deletion is irreversible; obtain explicit user confirmation before calling. Removes only the targeted reply, not the full comment thread — use GOOGLEDRIVE_DELETE_COMMENT to remove the entire thread."
+        "description": "Tool to delete a specific reply by reply ID. Deletion is irreversible; obtain explicit user confirmation before calling. Removes only the targeted reply, not the full comment thread \u2014 use GOOGLEDRIVE_DELETE_COMMENT to remove the entire thread."
       },
       {
         "slug": "GOOGLESUPER_DELETE_REVISION",
@@ -59873,7 +59873,7 @@
       {
         "slug": "GOOGLESUPER_DELETE_TASK",
         "name": "Delete task",
-        "description": "Deletes a specified task from a Google Tasks list. Deletion is permanent and irreversible — confirm with the user before executing, and consider GOOGLETASKS_UPDATE_TASK or GOOGLETASKS_MOVE_TASK as non-destructive alternatives. Both tasklist_id and task_id are required parameters. The Google Tasks API does not support deleting tasks by task_id alone — you must specify which task list contains the task. Use 'List Task Lists' to get available list IDs, then 'List Tasks' to find the task_id within that list."
+        "description": "Deletes a specified task from a Google Tasks list. Deletion is permanent and irreversible \u2014 confirm with the user before executing, and consider GOOGLETASKS_UPDATE_TASK or GOOGLETASKS_MOVE_TASK as non-destructive alternatives. Both tasklist_id and task_id are required parameters. The Google Tasks API does not support deleting tasks by task_id alone \u2014 you must specify which task list contains the task. Use 'List Task Lists' to get available list IDs, then 'List Tasks' to find the task_id within that list."
       },
       {
         "slug": "GOOGLESUPER_DELETE_TASK_LIST",
@@ -59893,7 +59893,7 @@
       {
         "slug": "GOOGLESUPER_DISTANCE_MATRIX_API",
         "name": "Distance Matrix (Legacy)",
-        "description": "DEPRECATED: Legacy API that calculates travel distance and time for a matrix of origins and destinations. This API only works with API keys (no OAuth2 support). Use the modern 'Compute Route Matrix' action instead, which supports OAuth2 authentication. Supports different modes of transportation and options like departure/arrival times. Capped at 100 elements per request (elements = origins × destinations count); split large sets into batches."
+        "description": "DEPRECATED: Legacy API that calculates travel distance and time for a matrix of origins and destinations. This API only works with API keys (no OAuth2 support). Use the modern 'Compute Route Matrix' action instead, which supports OAuth2 authentication. Supports different modes of transportation and options like departure/arrival times. Capped at 100 elements per request (elements = origins \u00d7 destinations count); split large sets into batches."
       },
       {
         "slug": "GOOGLESUPER_DOWNLOAD_FILE",
@@ -59908,7 +59908,7 @@
       {
         "slug": "GOOGLESUPER_DOWNLOAD_FILE_OPERATION",
         "name": "Download file via operation",
-        "description": "Tool to download file content using long-running operations. Use when you need to download Google Vids files or export Google Workspace documents as part of a long-running operation. Operations are valid for 24 hours from creation. Returns a response containing `downloaded_file_content.s3url` — a short-lived S3 URL; fetch the actual file bytes from that URL promptly after the call."
+        "description": "Tool to download file content using long-running operations. Use when you need to download Google Vids files or export Google Workspace documents as part of a long-running operation. Operations are valid for 24 hours from creation. Returns a response containing `downloaded_file_content.s3url` \u2014 a short-lived S3 URL; fetch the actual file bytes from that URL promptly after the call."
       },
       {
         "slug": "GOOGLESUPER_DUPLICATE_CALENDAR",
@@ -59923,12 +59923,12 @@
       {
         "slug": "GOOGLESUPER_EMPTY_TRASH",
         "name": "Empty Trash",
-        "description": "Tool to permanently and irreversibly delete ALL trashed files in the user's Google Drive or a specified shared drive. Recovery is impossible after execution — no Drive tool can restore items once trash is emptied. Affects every item in trash across the entire account or shared drive, not just files from the current workflow. Always obtain explicit user confirmation and clarify that recovery is impossible before executing. Provide driveId to target a specific shared drive's trash; omit to empty the user's root trash."
+        "description": "Tool to permanently and irreversibly delete ALL trashed files in the user's Google Drive or a specified shared drive. Recovery is impossible after execution \u2014 no Drive tool can restore items once trash is emptied. Affects every item in trash across the entire account or shared drive, not just files from the current workflow. Always obtain explicit user confirmation and clarify that recovery is impossible before executing. Provide driveId to target a specific shared drive's trash; omit to empty the user's root trash."
       },
       {
         "slug": "GOOGLESUPER_END_ACTIVE_CONFERENCE",
         "name": "End active conference",
-        "description": "Ends an active conference in a Google Meet space. REQUIRES 'space_name' parameter (e.g., 'spaces/jQCFfuBOdN5z' or just 'jQCFfuBOdN5z'). Use when you need to terminate an ongoing conference in a specified space. This operation only succeeds if a conference is actively running in the space. You must always provide the space_name to identify which space's conference to end. Immediately drops all active participants — obtain explicit user confirmation before calling."
+        "description": "Ends an active conference in a Google Meet space. REQUIRES 'space_name' parameter (e.g., 'spaces/jQCFfuBOdN5z' or just 'jQCFfuBOdN5z'). Use when you need to terminate an ongoing conference in a specified space. This operation only succeeds if a conference is actively running in the space. You must always provide the space_name to identify which space's conference to end. Immediately drops all active participants \u2014 obtain explicit user confirmation before calling."
       },
       {
         "slug": "GOOGLESUPER_EVENTS_GET",
@@ -59953,7 +59953,7 @@
       {
         "slug": "GOOGLESUPER_EVENTS_LIST_ALL_CALENDARS",
         "name": "List Events from All Calendars",
-        "description": "Return a unified event list across all calendars in the user's calendar list for a given time range. Use when you need a single view of all events across multiple calendars. An inverted or incorrect time range silently returns empty results rather than an error. An empty `items` list means no events matched the filters—adjust `time_min`, `time_max`, or `q` before concluding no events exist."
+        "description": "Return a unified event list across all calendars in the user's calendar list for a given time range. Use when you need a single view of all events across multiple calendars. An inverted or incorrect time range silently returns empty results rather than an error. An empty `items` list means no events matched the filters\u2014adjust `time_min`, `time_max`, or `q` before concluding no events exist."
       },
       {
         "slug": "GOOGLESUPER_EVENTS_MOVE",
@@ -59993,12 +59993,12 @@
       {
         "slug": "GOOGLESUPER_FETCH_MESSAGE_BY_THREAD_ID",
         "name": "Fetch Message by Thread ID",
-        "description": "Retrieves messages from a Gmail thread using its `thread_id`, where the thread must be accessible by the specified `user_id`. Returns a `messages` array; `thread_id` is not echoed in the response. Message order is not guaranteed — sort by `internalDate` to find oldest/newest. Check `labelIds` per message to filter drafts. Concurrent bulk calls may trigger 403 `userRateLimitExceeded` or 429; cap concurrency ~10 and use exponential backoff."
+        "description": "Retrieves messages from a Gmail thread using its `thread_id`, where the thread must be accessible by the specified `user_id`. Returns a `messages` array; `thread_id` is not echoed in the response. Message order is not guaranteed \u2014 sort by `internalDate` to find oldest/newest. Check `labelIds` per message to filter drafts. Concurrent bulk calls may trigger 403 `userRateLimitExceeded` or 429; cap concurrency ~10 and use exponential backoff."
       },
       {
         "slug": "GOOGLESUPER_FIND_EVENT",
         "name": "Find event",
-        "description": "Finds events in a specified Google Calendar using text query, time ranges (event start/end, last modification), and event types. Ensure `timeMin` is not chronologically after `timeMax` if both are provided. Results may span multiple pages; always follow `nextPageToken` until absent to avoid silently missing events. Validate the correct match from results by checking summary, start.dateTime, and organizer.email before using event_id for mutations. An empty `items` array means no events matched — widen filters rather than treating it as an error."
+        "description": "Finds events in a specified Google Calendar using text query, time ranges (event start/end, last modification), and event types. Ensure `timeMin` is not chronologically after `timeMax` if both are provided. Results may span multiple pages; always follow `nextPageToken` until absent to avoid silently missing events. Validate the correct match from results by checking summary, start.dateTime, and organizer.email before using event_id for mutations. An empty `items` array means no events matched \u2014 widen filters rather than treating it as an error."
       },
       {
         "slug": "GOOGLESUPER_FIND_FILE",
@@ -60033,12 +60033,12 @@
       {
         "slug": "GOOGLESUPER_FORWARD_MESSAGE",
         "name": "Forward email message",
-        "description": "Forward an existing Gmail message to specified recipients, preserving original body and attachments. Verify recipients and content before forwarding to avoid unintended exposure. Bulk forwarding may trigger 429/5xx rate limits; keep concurrency to 5–10 and apply backoff. Messages near Gmail's size limits may fail; reconstruct a smaller draft if needed."
+        "description": "Forward an existing Gmail message to specified recipients, preserving original body and attachments. Verify recipients and content before forwarding to avoid unintended exposure. Bulk forwarding may trigger 429/5xx rate limits; keep concurrency to 5\u201310 and apply backoff. Messages near Gmail's size limits may fail; reconstruct a smaller draft if needed."
       },
       {
         "slug": "GOOGLESUPER_FREE_BUSY_QUERY",
         "name": "Query Free/Busy Information (Deprecated)",
-        "description": "DEPRECATED: Use GOOGLECALENDAR_FIND_FREE_SLOTS instead (though this tool provides wider secondary/shared calendar coverage). Returns opaque busy intervals only—no event titles or details; use GOOGLECALENDAR_EVENTS_LIST when event details are needed."
+        "description": "DEPRECATED: Use GOOGLECALENDAR_FIND_FREE_SLOTS instead (though this tool provides wider secondary/shared calendar coverage). Returns opaque busy intervals only\u2014no event titles or details; use GOOGLECALENDAR_EVENTS_LIST when event details are needed."
       },
       {
         "slug": "GOOGLESUPER_GENERATE_IDS",
@@ -60053,7 +60053,7 @@
       {
         "slug": "GOOGLESUPER_GEOCODE_ADDRESS_WITH_QUERY",
         "name": "Geocode Address With Query",
-        "description": "Tool to map addresses to geographic coordinates with query parameter. Use when you need to convert a textual address into latitude/longitude coordinates using the modern v4beta API. Results may match multiple places — always verify `formattedAddress`, `region`, and `addressComponents` in the response before using returned coordinates."
+        "description": "Tool to map addresses to geographic coordinates with query parameter. Use when you need to convert a textual address into latitude/longitude coordinates using the modern v4beta API. Results may match multiple places \u2014 always verify `formattedAddress`, `region`, and `addressComponents` in the response before using returned coordinates."
       },
       {
         "slug": "GOOGLESUPER_GEOCODE_DESTINATIONS",
@@ -60093,7 +60093,7 @@
       {
         "slug": "GOOGLESUPER_GET_ABOUT",
         "name": "Get about",
-        "description": "Tool to retrieve information about the user, the user's Drive, and system capabilities. Use when you need to check storage quotas, user details, or supported import/export formats. Note: storageQuota reflects My Drive (personal) storage only — it does not cover shared drives; use GOOGLEDRIVE_LIST_SHARED_DRIVES and GOOGLEDRIVE_GET_DRIVE for shared drive quotas. A successful response confirms base Drive read access only; write access and shared drive access must be verified separately."
+        "description": "Tool to retrieve information about the user, the user's Drive, and system capabilities. Use when you need to check storage quotas, user details, or supported import/export formats. Note: storageQuota reflects My Drive (personal) storage only \u2014 it does not cover shared drives; use GOOGLEDRIVE_LIST_SHARED_DRIVES and GOOGLEDRIVE_GET_DRIVE for shared drive quotas. A successful response confirms base Drive read access only; write access and shared drive access must be verified separately."
       },
       {
         "slug": "GOOGLESUPER_GET_ACCOUNT",
@@ -60113,7 +60113,7 @@
       {
         "slug": "GOOGLESUPER_GET_ATTACHMENT",
         "name": "Get Gmail attachment",
-        "description": "Retrieves a specific attachment by ID from a message in a user's Gmail mailbox, requiring valid message and attachment IDs. Returns base64url-encoded binary data (up to ~25 MB); the downloaded file location is at data.file.s3url (also exposes mimetype and name; no s3key). Attachments exceeding ~25 MB may be exposed as Google Drive links — use GOOGLEDRIVE_DOWNLOAD_FILE when a Drive file_id is present instead."
+        "description": "Retrieves a specific attachment by ID from a message in a user's Gmail mailbox, requiring valid message and attachment IDs. Returns base64url-encoded binary data (up to ~25 MB); the downloaded file location is at data.file.s3url (also exposes mimetype and name; no s3key). Attachments exceeding ~25 MB may be exposed as Google Drive links \u2014 use GOOGLEDRIVE_DOWNLOAD_FILE when a Drive file_id is present instead."
       },
       {
         "slug": "GOOGLESUPER_GET_ATTRIBUTION_SETTINGS",
@@ -60148,7 +60148,7 @@
       {
         "slug": "GOOGLESUPER_GET_CALENDAR",
         "name": "Get Google Calendar",
-        "description": "Retrieves a specific Google Calendar, identified by `calendar_id`, to which the authenticated user has access. Response includes `timeZone` (IANA format, e.g., 'America/Los_Angeles') — use it directly when constructing `timeMin`/`timeMax` in other tools to avoid DST errors. An empty `defaultReminders` list is valid (no defaults configured). Insufficient `accessRole` may omit fields like `defaultReminders` and `colorId`."
+        "description": "Retrieves a specific Google Calendar, identified by `calendar_id`, to which the authenticated user has access. Response includes `timeZone` (IANA format, e.g., 'America/Los_Angeles') \u2014 use it directly when constructing `timeMin`/`timeMax` in other tools to avoid DST errors. An empty `defaultReminders` list is valid (no defaults configured). Insufficient `accessRole` may omit fields like `defaultReminders` and `colorId`."
       },
       {
         "slug": "GOOGLESUPER_GET_CALENDAR_PROFILE",
@@ -60173,7 +60173,7 @@
       {
         "slug": "GOOGLESUPER_GET_CHANGES_START_PAGE_TOKEN",
         "name": "Get Changes Start Page Token",
-        "description": "Tool to get the starting pageToken for listing future changes in Google Drive. Returns only a token — pass it to GOOGLEDRIVE_LIST_CHANGES to retrieve actual changes. Persist this token; losing it requires a full rescan. The token is forward-looking: GOOGLEDRIVE_LIST_CHANGES may return no results if no changes have occurred since issuance. For simple recent-file lookups, prefer GOOGLEDRIVE_FIND_FILE; use this tool only for incremental change-feed workflows."
+        "description": "Tool to get the starting pageToken for listing future changes in Google Drive. Returns only a token \u2014 pass it to GOOGLEDRIVE_LIST_CHANGES to retrieve actual changes. Persist this token; losing it requires a full rescan. The token is forward-looking: GOOGLEDRIVE_LIST_CHANGES may return no results if no changes have occurred since issuance. For simple recent-file lookups, prefer GOOGLEDRIVE_FIND_FILE; use this tool only for incremental change-feed workflows."
       },
       {
         "slug": "GOOGLESUPER_GET_CHILD",
@@ -60198,7 +60198,7 @@
       {
         "slug": "GOOGLESUPER_GET_CONTACTS",
         "name": "Get contacts",
-        "description": "Fetches contacts (connections) for the authenticated Google account, allowing selection of specific data fields and pagination. Only covers saved contacts and 'Other Contacts'; email-header-only senders are out of scope. Contact records may have sparse data — handle missing fields gracefully. People API shares a per-user QPS quota; HTTP 429 requires exponential backoff (1s, 2s, 4s)."
+        "description": "Fetches contacts (connections) for the authenticated Google account, allowing selection of specific data fields and pagination. Only covers saved contacts and 'Other Contacts'; email-header-only senders are out of scope. Contact records may have sparse data \u2014 handle missing fields gracefully. People API shares a per-user QPS quota; HTTP 429 requires exponential backoff (1s, 2s, 4s)."
       },
       {
         "slug": "GOOGLESUPER_GET_CURRENT_DATE_TIME",
@@ -60213,7 +60213,7 @@
       {
         "slug": "GOOGLESUPER_GET_CUSTOMER_LISTS",
         "name": "Get customer lists",
-        "description": "GetCustomerLists Tool lists all customer lists (audience/remarketing lists) in Google Ads. These are user segments for targeting, not Google Ads accounts — list IDs are distinct from account IDs. When multiple lists share similar names, review all returned results before selecting one for downstream operations."
+        "description": "GetCustomerLists Tool lists all customer lists (audience/remarketing lists) in Google Ads. These are user segments for targeting, not Google Ads accounts \u2014 list IDs are distinct from account IDs. When multiple lists share similar names, review all returned results before selecting one for downstream operations."
       },
       {
         "slug": "GOOGLESUPER_GET_DATA_RETENTION_SETTINGS",
@@ -60303,12 +60303,12 @@
       {
         "slug": "GOOGLESUPER_GET_MEET",
         "name": "Get Meet details",
-        "description": "Retrieve details of a Google Meet space using its unique identifier. Newly created spaces may return incomplete data; retry after 1–3 seconds if needed."
+        "description": "Retrieve details of a Google Meet space using its unique identifier. Newly created spaces may return incomplete data; retry after 1\u20133 seconds if needed."
       },
       {
         "slug": "GOOGLESUPER_GET_METADATA",
         "name": "Get Metadata",
-        "description": "Tool to get metadata for dimensions, metrics, and comparisons for a GA4 property. Use to discover available fields before building a report — always derive dimension/metric apiNames from this output rather than hardcoding from GA4 UI labels, which differ. Available fields vary per property; skip validation and downstream report tools like GOOGLE_ANALYTICS_RUN_REPORT return 400 INVALID_ARGUMENT on incompatible or invalid field combinations. Response can contain hundreds of fields; filter to relevant subset before passing to downstream logic."
+        "description": "Tool to get metadata for dimensions, metrics, and comparisons for a GA4 property. Use to discover available fields before building a report \u2014 always derive dimension/metric apiNames from this output rather than hardcoding from GA4 UI labels, which differ. Available fields vary per property; skip validation and downstream report tools like GOOGLE_ANALYTICS_RUN_REPORT return 400 INVALID_ARGUMENT on incompatible or invalid field combinations. Response can contain hundreds of fields; filter to relevant subset before passing to downstream logic."
       },
       {
         "slug": "GOOGLESUPER_GET_PAGE_THUMBNAIL2",
@@ -60348,7 +60348,7 @@
       {
         "slug": "GOOGLESUPER_GET_PROFILE",
         "name": "Get Profile",
-        "description": "Retrieves Gmail profile information (email address, aggregate messagesTotal/threadsTotal, historyId) for a user. messagesTotal counts individual emails; threadsTotal counts conversations; neither is per-label — use GMAIL_FETCH_EMAILS with label filters for label-specific counts. The returned historyId seeds incremental sync via GMAIL_LIST_HISTORY; if historyIdTooOld is returned, rescan with GMAIL_FETCH_EMAILS before resuming. Response may be wrapped under a top-level data field; unwrap before reading fields. A successful call confirms mailbox connectivity but not full mailbox access if granted scopes are narrow. Use the returned email address to dynamically identify the authenticated account rather than hard-coding it."
+        "description": "Retrieves Gmail profile information (email address, aggregate messagesTotal/threadsTotal, historyId) for a user. messagesTotal counts individual emails; threadsTotal counts conversations; neither is per-label \u2014 use GMAIL_FETCH_EMAILS with label filters for label-specific counts. The returned historyId seeds incremental sync via GMAIL_LIST_HISTORY; if historyIdTooOld is returned, rescan with GMAIL_FETCH_EMAILS before resuming. Response may be wrapped under a top-level data field; unwrap before reading fields. A successful call confirms mailbox connectivity but not full mailbox access if granted scopes are narrow. Use the returned email address to dynamically identify the authenticated account rather than hard-coding it."
       },
       {
         "slug": "GOOGLESUPER_GET_PROPERTY",
@@ -60363,7 +60363,7 @@
       {
         "slug": "GOOGLESUPER_GET_RECORDINGS_BY_CONFERENCE_RECORD_ID",
         "name": "Get recordings by conference record ID",
-        "description": "Retrieves recordings from Google Meet for a given conference record ID. Only returns recordings if recording was enabled and permitted by the organizer's domain policies; a valid conferenceRecord_id does not guarantee recordings exist. After a meeting ends, recordings may take several minutes to process — an empty result may be temporary, not permanent."
+        "description": "Retrieves recordings from Google Meet for a given conference record ID. Only returns recordings if recording was enabled and permitted by the organizer's domain policies; a valid conferenceRecord_id does not guarantee recordings exist. After a meeting ends, recordings may take several minutes to process \u2014 an empty result may be temporary, not permanent."
       },
       {
         "slug": "GOOGLESUPER_GET_RECURRING_AUDIENCE_LIST",
@@ -60383,7 +60383,7 @@
       {
         "slug": "GOOGLESUPER_GET_REVISION",
         "name": "Get Revision",
-        "description": "Tool to get a specific revision's metadata (name, modifiedTime, keepForever, etc.) by revision ID. Returns metadata only — not file content. Use a separate download tool to retrieve file content or restore a revision."
+        "description": "Tool to get a specific revision's metadata (name, modifiedTime, keepForever, etc.) by revision ID. Returns metadata only \u2014 not file content. Use a separate download tool to retrieve file content or restore a revision."
       },
       {
         "slug": "GOOGLESUPER_GET_ROUTE",
@@ -60438,7 +60438,7 @@
       {
         "slug": "GOOGLESUPER_GET_TRANSCRIPTS_BY_CONFERENCE_RECORD_ID",
         "name": "Get transcripts by conference record ID",
-        "description": "Retrieves all transcripts for a specific Google Meet conference using its conferenceRecord_id. Transcripts require processing time after a meeting ends — empty results may be transient; retry after a delay before concluding no transcripts exist. Returns results only if transcription was enabled during the meeting and permitted by the organizer's domain policies; an empty list may also indicate transcription was never generated."
+        "description": "Retrieves all transcripts for a specific Google Meet conference using its conferenceRecord_id. Transcripts require processing time after a meeting ends \u2014 empty results may be transient; retry after a delay before concluding no transcripts exist. Returns results only if transcription was enabled during the meeting and permitted by the organizer's domain policies; an empty list may also indicate transcription was never generated."
       },
       {
         "slug": "GOOGLESUPER_GET_VACATION_SETTINGS",
@@ -60498,7 +60498,7 @@
       {
         "slug": "GOOGLESUPER_INSERT_TASK",
         "name": "Insert Task",
-        "description": "Creates a new task in a given `tasklist_id`, optionally as a subtask of an existing `task_parent` or positioned after an existing `task_previous` sibling, where both `task_parent` and `task_previous` must belong to the same `tasklist_id` if specified. IMPORTANT: Date fields (due, completed) accept various formats like '28 Sep 2025', '11:59 PM, 22 Sep 2025', or ISO format '2025-09-21T15:30:00Z' and will automatically convert them to RFC3339 format required by the API. Not idempotent — repeated calls with identical parameters create duplicate tasks; track returned task IDs to avoid duplication. High-volume inserts may trigger 403 rateLimitExceeded or 429; apply exponential backoff."
+        "description": "Creates a new task in a given `tasklist_id`, optionally as a subtask of an existing `task_parent` or positioned after an existing `task_previous` sibling, where both `task_parent` and `task_previous` must belong to the same `tasklist_id` if specified. IMPORTANT: Date fields (due, completed) accept various formats like '28 Sep 2025', '11:59 PM, 22 Sep 2025', or ISO format '2025-09-21T15:30:00Z' and will automatically convert them to RFC3339 format required by the API. Not idempotent \u2014 repeated calls with identical parameters create duplicate tasks; track returned task IDs to avoid duplication. High-volume inserts may trigger 403 rateLimitExceeded or 429; apply exponential backoff."
       },
       {
         "slug": "GOOGLESUPER_INSERT_TEXT_ACTION",
@@ -60573,12 +60573,12 @@
       {
         "slug": "GOOGLESUPER_LIST_CALENDARS",
         "name": "List Google Calendars",
-        "description": "Retrieves calendars from the user's Google Calendar list, with options for pagination and filtering. Loop through all pages using nextPageToken until absent to avoid missing calendars. Use the primary flag and accessRole field from the response to identify calendars — display names are not valid calendar_id values. Read access (listing) does not imply write OAuth scopes."
+        "description": "Retrieves calendars from the user's Google Calendar list, with options for pagination and filtering. Loop through all pages using nextPageToken until absent to avoid missing calendars. Use the primary flag and accessRole field from the response to identify calendars \u2014 display names are not valid calendar_id values. Read access (listing) does not imply write OAuth scopes."
       },
       {
         "slug": "GOOGLESUPER_LIST_CHANGES",
         "name": "List Changes",
-        "description": "Tool to list the changes for a user or shared drive. Use when a full incremental change feed is needed (for simple recent-file lookups, prefer GOOGLEDRIVE_FIND_FILE instead). Tracks modifications such as creations, deletions, or permission changes. The pageToken is optional - if not provided, the current start page token will be automatically fetched; an empty result is valid if no recent activity has occurred. Example usage: ```json { \"pageToken\": \"22633\", \"pageSize\": 100, \"includeRemoved\": true } ``` Returns changes with timestamps, file IDs, and modification details. Paginate by following `nextPageToken` until it is absent — stopping early will silently omit changes. Save `newStartPageToken` to monitor future changes efficiently."
+        "description": "Tool to list the changes for a user or shared drive. Use when a full incremental change feed is needed (for simple recent-file lookups, prefer GOOGLEDRIVE_FIND_FILE instead). Tracks modifications such as creations, deletions, or permission changes. The pageToken is optional - if not provided, the current start page token will be automatically fetched; an empty result is valid if no recent activity has occurred. Example usage: ```json { \"pageToken\": \"22633\", \"pageSize\": 100, \"includeRemoved\": true } ``` Returns changes with timestamps, file IDs, and modification details. Paginate by following `nextPageToken` until it is absent \u2014 stopping early will silently omit changes. Save `newStartPageToken` to monitor future changes efficiently."
       },
       {
         "slug": "GOOGLESUPER_LIST_CHANNEL_GROUPS",
@@ -60703,7 +60703,7 @@
       {
         "slug": "GOOGLESUPER_LIST_LABELS",
         "name": "List Gmail labels",
-        "description": "Retrieves all system and user-created labels for a Gmail account in a single unpaginated response. Primary use: obtain internal label IDs (e.g., 'Label_123') required by other Gmail tools — display names cannot be used as label identifiers and cause silent failures or errors. System labels (INBOX, UNREAD, SPAM, TRASH, etc.) are case-sensitive and must be used exactly as returned; INBOX, SPAM, and TRASH are read-only and cannot be added/removed via label modification tools. The Gmail search 'label:' operator accepts display names, but label_ids parameters in tools like GMAIL_FETCH_EMAILS require internal IDs from this tool — mixing conventions yields zero results silently. Do not hardcode label IDs across sessions; refresh via this tool on conflict errors."
+        "description": "Retrieves all system and user-created labels for a Gmail account in a single unpaginated response. Primary use: obtain internal label IDs (e.g., 'Label_123') required by other Gmail tools \u2014 display names cannot be used as label identifiers and cause silent failures or errors. System labels (INBOX, UNREAD, SPAM, TRASH, etc.) are case-sensitive and must be used exactly as returned; INBOX, SPAM, and TRASH are read-only and cannot be added/removed via label modification tools. The Gmail search 'label:' operator accepts display names, but label_ids parameters in tools like GMAIL_FETCH_EMAILS require internal IDs from this tool \u2014 mixing conventions yields zero results silently. Do not hardcode label IDs across sessions; refresh via this tool on conflict errors."
       },
       {
         "slug": "GOOGLESUPER_LIST_MEASUREMENT_PROTOCOL_SECRETS",
@@ -60833,7 +60833,7 @@
       {
         "slug": "GOOGLESUPER_LIST_TASK_LISTS",
         "name": "List task lists",
-        "description": "Fetches the authenticated user's task lists from Google Tasks; results may be paginated. Response contains task lists under the `items` key. Multiple lists may share similar names — confirm the correct list by ID before passing to other tools."
+        "description": "Fetches the authenticated user's task lists from Google Tasks; results may be paginated. Response contains task lists under the `items` key. Multiple lists may share similar names \u2014 confirm the correct list by ID before passing to other tools."
       },
       {
         "slug": "GOOGLESUPER_LIST_TASKS",
@@ -61018,7 +61018,7 @@
       {
         "slug": "GOOGLESUPER_REMOVE_ATTENDEE",
         "name": "Remove attendee from event",
-        "description": "Removes an attendee from a specified event in a Google Calendar; the calendar and event must exist. Concurrent calls on the same event can overwrite attendee lists — apply changes sequentially per event."
+        "description": "Removes an attendee from a specified event in a Google Calendar; the calendar and event must exist. Concurrent calls on the same event can overwrite attendee lists \u2014 apply changes sequentially per event."
       },
       {
         "slug": "GOOGLESUPER_RENDER_AERIAL_VIDEO",
@@ -61083,7 +61083,7 @@
       {
         "slug": "GOOGLESUPER_SEARCH_PEOPLE",
         "name": "Search People",
-        "description": "Searches contacts by matching the query against names, nicknames, emails, phone numbers, and organizations, optionally including 'Other Contacts'. Only searches the authenticated user's contact directory — people existing solely in message headers won't appear; use GMAIL_FETCH_EMAILS for those. Results may be zero or multiple; never auto-select from ambiguous results. Results paginate via next_page_token; follow until empty and deduplicate by email. Many records lack emailAddresses or names even when requested — handle missing keys. Directory/organization policies may suppress entries."
+        "description": "Searches contacts by matching the query against names, nicknames, emails, phone numbers, and organizations, optionally including 'Other Contacts'. Only searches the authenticated user's contact directory \u2014 people existing solely in message headers won't appear; use GMAIL_FETCH_EMAILS for those. Results may be zero or multiple; never auto-select from ambiguous results. Results paginate via next_page_token; follow until empty and deduplicate by email. Many records lack emailAddresses or names even when requested \u2014 handle missing keys. Directory/organization policies may suppress entries."
       },
       {
         "slug": "GOOGLESUPER_SEARCH_SPREADSHEETS",
@@ -61093,12 +61093,12 @@
       {
         "slug": "GOOGLESUPER_SEND_DRAFT",
         "name": "Send Draft",
-        "description": "Sends an existing draft email AS-IS to recipients already defined within the draft. IMPORTANT: This action does NOT accept recipient parameters (to, cc, bcc). The Gmail API's drafts/send endpoint sends drafts to whatever recipients are already set in the draft's To, Cc, and Bcc headers - it cannot add or override recipients. If the draft has no recipients, you must either: 1. Create a new draft with recipients using GMAIL_CREATE_EMAIL_DRAFT, then send it 2. Use GMAIL_SEND_EMAIL to send a new email directly with recipients. Send is immediate and irreversible — confirm recipients and content before calling. No scheduling support; trigger at the desired UTC time externally. Gmail enforces ~25 MB message size limit and daily send caps (~500 recipients/day personal, ~2,000/day Workspace)."
+        "description": "Sends an existing draft email AS-IS to recipients already defined within the draft. IMPORTANT: This action does NOT accept recipient parameters (to, cc, bcc). The Gmail API's drafts/send endpoint sends drafts to whatever recipients are already set in the draft's To, Cc, and Bcc headers - it cannot add or override recipients. If the draft has no recipients, you must either: 1. Create a new draft with recipients using GMAIL_CREATE_EMAIL_DRAFT, then send it 2. Use GMAIL_SEND_EMAIL to send a new email directly with recipients. Send is immediate and irreversible \u2014 confirm recipients and content before calling. No scheduling support; trigger at the desired UTC time externally. Gmail enforces ~25 MB message size limit and daily send caps (~500 recipients/day personal, ~2,000/day Workspace)."
       },
       {
         "slug": "GOOGLESUPER_SEND_EMAIL",
         "name": "Send Email",
-        "description": "Sends an email via Gmail API using the authenticated user's Google profile display name. Sends immediately and is irreversible — confirm recipients, subject, body, and attachments before calling. At least one of 'to' (or 'recipient_email'), 'cc', or 'bcc' must be provided. At least one of subject or body must be provided. Requires `is_html=True` if the body contains HTML. All common file types including PNG, JPG, PDF, MP4, etc. are supported as attachments. Gmail API limits total message size to ~25 MB after base64 encoding. To reply in an existing thread, use GMAIL_REPLY_TO_THREAD instead. No scheduled send support; enforce timing externally."
+        "description": "Sends an email via Gmail API using the authenticated user's Google profile display name. Sends immediately and is irreversible \u2014 confirm recipients, subject, body, and attachments before calling. At least one of 'to' (or 'recipient_email'), 'cc', or 'bcc' must be provided. At least one of subject or body must be provided. Requires `is_html=True` if the body contains HTML. All common file types including PNG, JPG, PDF, MP4, etc. are supported as attachments. Gmail API limits total message size to ~25 MB after base64 encoding. To reply in an existing thread, use GMAIL_REPLY_TO_THREAD instead. No scheduled send support; enforce timing externally."
       },
       {
         "slug": "GOOGLESUPER_SEND_EVENTS",
@@ -61133,7 +61133,7 @@
       {
         "slug": "GOOGLESUPER_SETTINGS_LIST",
         "name": "List Settings",
-        "description": "Returns all user settings for the authenticated user. Results include multiple settings keyed by id (e.g., `timeZone`); locate a specific setting by its `id` field. `timeZone` values are IANA identifiers (e.g., `America/New_York`) — use directly in datetime and event logic; align with `timeZone` from GOOGLECALENDAR_GET_CALENDAR for consistent notification times."
+        "description": "Returns all user settings for the authenticated user. Results include multiple settings keyed by id (e.g., `timeZone`); locate a specific setting by its `id` field. `timeZone` values are IANA identifiers (e.g., `America/New_York`) \u2014 use directly in datetime and event logic; align with `timeZone` from GOOGLECALENDAR_GET_CALENDAR for consistent notification times."
       },
       {
         "slug": "GOOGLESUPER_SETTINGS_SEND_AS_GET",
@@ -61178,7 +61178,7 @@
       {
         "slug": "GOOGLESUPER_STOP_WATCH_CHANNEL",
         "name": "Stop Watch Channel",
-        "description": "Tool to stop watching resources through a specified channel. Use this when you want to stop receiving notifications for a previously established watch. Both `id` and `resourceId` must be saved from the original watch response — they cannot be retrieved after the fact."
+        "description": "Tool to stop watching resources through a specified channel. Use this when you want to stop receiving notifications for a previously established watch. Both `id` and `resourceId` must be saved from the original watch response \u2014 they cannot be retrieved after the fact."
       },
       {
         "slug": "GOOGLESUPER_SYNC_EVENTS",
@@ -61188,12 +61188,12 @@
       {
         "slug": "GOOGLESUPER_TEXT_SEARCH",
         "name": "Text Search",
-        "description": "Searches for places on Google Maps using a textual query (e.g., \"restaurants in London\", \"Eiffel Tower\"). Results may include CLOSED_PERMANENTLY or TEMPORARILY_CLOSED places — filter by businessStatus=OPERATIONAL. Include city/region and business type in textQuery to avoid empty or irrelevant results. Deduplicate using id or formattedAddress, not name alone. Throttle to ~1 req/s; OVER_QUERY_LIMIT (HTTP 429) requires exponential backoff."
+        "description": "Searches for places on Google Maps using a textual query (e.g., \"restaurants in London\", \"Eiffel Tower\"). Results may include CLOSED_PERMANENTLY or TEMPORARILY_CLOSED places \u2014 filter by businessStatus=OPERATIONAL. Include city/region and business type in textQuery to avoid empty or irrelevant results. Deduplicate using id or formattedAddress, not name alone. Throttle to ~1 req/s; OVER_QUERY_LIMIT (HTTP 429) requires exponential backoff."
       },
       {
         "slug": "GOOGLESUPER_TILES_CREATE_SESSION",
         "name": "Create Tiles Session",
-        "description": "Tool to create a session token required for accessing 2D Tiles and Street View imagery. Use when you need to initialize tile-based map rendering or street view display. The session token is valid for approximately two weeks and must be included in all subsequent tile requests. Each call consumes quota — cache and reuse the returned token across all tile requests within its validity window rather than creating a new session per request."
+        "description": "Tool to create a session token required for accessing 2D Tiles and Street View imagery. Use when you need to initialize tile-based map rendering or street view display. The session token is valid for approximately two weeks and must be included in all subsequent tile requests. Each call consumes quota \u2014 cache and reuse the returned token across all tile requests within its validity window rather than creating a new session per request."
       },
       {
         "slug": "GOOGLESUPER_TRASH_FILE",
@@ -61213,7 +61213,7 @@
       {
         "slug": "GOOGLESUPER_UNTRASH_FILE",
         "name": "Untrash File",
-        "description": "Tool to restore a file from the trash. Use when you need to recover a deleted file. This action updates the file's metadata to set the 'trashed' property to false. Only works while the file remains in trash — recovery is impossible after trash is emptied via GOOGLEDRIVE_EMPTY_TRASH or auto-purged by policy."
+        "description": "Tool to restore a file from the trash. Use when you need to recover a deleted file. This action updates the file's metadata to set the 'trashed' property to false. Only works while the file remains in trash \u2014 recovery is impossible after trash is emptied via GOOGLEDRIVE_EMPTY_TRASH or auto-purged by policy."
       },
       {
         "slug": "GOOGLESUPER_UNTRASH_MESSAGE",
@@ -61293,7 +61293,7 @@
       {
         "slug": "GOOGLESUPER_UPDATE_FILE_PUT",
         "name": "Update File (Metadata)",
-        "description": "Updates file metadata. Uses PATCH semantics (partial update) as per Google Drive API v3 — only explicitly provided fields are updated, so omit fields you do not intend to overwrite. Use this tool to modify attributes of an existing file like its name, description, or parent folders. To move a file, supply add_parents and remove_parents together; omitting remove_parents creates multiple parents, omitting add_parents can orphan the file. Bulk updates may trigger 429 Too Many Requests; apply exponential backoff. Note: supports metadata updates only; file content updates are not yet implemented."
+        "description": "Updates file metadata. Uses PATCH semantics (partial update) as per Google Drive API v3 \u2014 only explicitly provided fields are updated, so omit fields you do not intend to overwrite. Use this tool to modify attributes of an existing file like its name, description, or parent folders. To move a file, supply add_parents and remove_parents together; omitting remove_parents creates multiple parents, omitting add_parents can orphan the file. Bulk updates may trigger 429 Too Many Requests; apply exponential backoff. Note: supports metadata updates only; file content updates are not yet implemented."
       },
       {
         "slug": "GOOGLESUPER_UPDATE_FILE_REVISION_METADATA",
@@ -62819,7 +62819,7 @@
       {
         "slug": "ZOOM_GET_MEETING_RECORDINGS",
         "name": "Get meeting recordings",
-        "description": "To download meeting recordings, use `download_url`. Include OAuth token in the header for passcode-protected ones. Supports `recording:read` and `phone_recording:read:admin` scopes, with a `LIGHT` rate limit. Requires a paid Zoom plan with cloud recording enabled; missing entitlements return empty results or entitlement errors, not system failures. Error code 3301 means no cloud recording exists for the meeting — an expected empty-result case."
+        "description": "To download meeting recordings, use `download_url`. Include OAuth token in the header for passcode-protected ones. Supports `recording:read` and `phone_recording:read:admin` scopes, with a `LIGHT` rate limit. Requires a paid Zoom plan with cloud recording enabled; missing entitlements return empty results or entitlement errors, not system failures. Error code 3301 means no cloud recording exists for the meeting \u2014 an expected empty-result case."
       },
       {
         "slug": "ZOOM_GET_PAST_MEETING_PARTICIPANTS",
@@ -63601,12 +63601,12 @@
       {
         "slug": "SERVICENOW_ATTACH_FILE_TO_RECORD",
         "name": "Attach file to record",
-        "description": "Attaches a file to a specified record in a ServiceNow table. This action uploads a file and associates it with a specific record (e.g., incident, problem, change request). The file will be visible in the ServiceNow UI under the record's attachments section. Common use cases: - Attach screenshots to incident reports - Upload documents to change requests - Add log files to problem records - Store evidence files for security incidents The action returns complete attachment metadata including download link, file size, and creation details. Note: This action permanently modifies a live ServiceNow instance — attachments cannot be bulk-removed once added."
+        "description": "Attaches a file to a specified record in a ServiceNow table. This action uploads a file and associates it with a specific record (e.g., incident, problem, change request). The file will be visible in the ServiceNow UI under the record's attachments section. Common use cases: - Attach screenshots to incident reports - Upload documents to change requests - Add log files to problem records - Store evidence files for security incidents The action returns complete attachment metadata including download link, file size, and creation details. Note: This action permanently modifies a live ServiceNow instance \u2014 attachments cannot be bulk-removed once added."
       },
       {
         "slug": "SERVICENOW_CANCEL_CHANGE_CONFLICT_CHECK",
         "name": "Cancel change conflict check",
-        "description": "Cancels the running conflict checking process for a specified ServiceNow change request. Use this action when a conflict check is taking too long or needs to be aborted, and you want to stop the process without waiting for it to complete naturally. This is commonly used when automated change management workflows need to be expedited or when conflict checks are blocking other operations. This action is idempotent — calling it on a change request that has no active conflict check running will still return a success response. However, if the change request doesn't exist, a 404 error will be returned."
+        "description": "Cancels the running conflict checking process for a specified ServiceNow change request. Use this action when a conflict check is taking too long or needs to be aborted, and you want to stop the process without waiting for it to complete naturally. This is commonly used when automated change management workflows need to be expedited or when conflict checks are blocking other operations. This action is idempotent \u2014 calling it on a change request that has no active conflict check running will still return a success response. However, if the change request doesn't exist, a 404 error will be returned."
       },
       {
         "slug": "SERVICENOW_CREATE_A_RECORD",
@@ -63616,7 +63616,7 @@
       {
         "slug": "SERVICENOW_CREATE_ATTACHMENT_UPLOAD",
         "name": "Create attachment upload",
-        "description": "Uploads a file as a multipart form-data attachment to a specified record in ServiceNow. Use this action when you need to attach files to ServiceNow records (e.g., incidents, problems, change requests) using the multipart form-data upload endpoint. This action sends the file as a multipart/form-data request with the table name, table sys_id, and file content. Common use cases: - Attach documents or screenshots to incident reports - Upload evidence files to problem records - Add files to change requests for documentation The action returns complete attachment metadata including the sys_id, download link, file size, and creation details. This action permanently modifies a live ServiceNow instance — the attachment cannot be recovered once deleted."
+        "description": "Uploads a file as a multipart form-data attachment to a specified record in ServiceNow. Use this action when you need to attach files to ServiceNow records (e.g., incidents, problems, change requests) using the multipart form-data upload endpoint. This action sends the file as a multipart/form-data request with the table name, table sys_id, and file content. Common use cases: - Attach documents or screenshots to incident reports - Upload evidence files to problem records - Add files to change requests for documentation The action returns complete attachment metadata including the sys_id, download link, file size, and creation details. This action permanently modifies a live ServiceNow instance \u2014 the attachment cannot be recovered once deleted."
       },
       {
         "slug": "SERVICENOW_CREATE_CILIFECYCLEMGMT_ACTION",
@@ -63676,7 +63676,7 @@
       {
         "slug": "SERVICENOW_CREATE_IDENTIFYRECONCILE_QUERY",
         "name": "Query CMDB Identify Reconcile",
-        "description": "Queries the ServiceNow Identify and Reconcile API to determine whether a Configuration Item (CI) should be inserted (created) or updated in the CMDB based on identity matching rules. Use this action when you need to check whether a CI already exists in the CMDB before creating or updating it, or when you want ServiceNow to automatically determine the correct operation (INSERT vs UPDATE) based on configured identity matching rules and the provided attributes. This is commonly used during data migration, discovery integration, or bulk CI reconciliation workflows where the operation (create vs update) needs to be determined programmatically. Note: This action performs a query/reconciliation check only — it does not execute the actual INSERT or UPDATE operation. It returns the recommended operation and the matched CI details."
+        "description": "Queries the ServiceNow Identify and Reconcile API to determine whether a Configuration Item (CI) should be inserted (created) or updated in the CMDB based on identity matching rules. Use this action when you need to check whether a CI already exists in the CMDB before creating or updating it, or when you want ServiceNow to automatically determine the correct operation (INSERT vs UPDATE) based on configured identity matching rules and the provided attributes. This is commonly used during data migration, discovery integration, or bulk CI reconciliation workflows where the operation (create vs update) needs to be determined programmatically. Note: This action performs a query/reconciliation check only \u2014 it does not execute the actual INSERT or UPDATE operation. It returns the recommended operation and the matched CI details."
       },
       {
         "slug": "SERVICENOW_CREATE_IDENTIFYRECONCILE_QUERYENHANCED",
@@ -63711,7 +63711,7 @@
       {
         "slug": "SERVICENOW_CREATE_PUSH_INSTALLATION",
         "name": "Create push installation",
-        "description": "Registers or updates a device token for receiving push notifications through ServiceNow. Use this action when you need to register a mobile device token with ServiceNow's push notification system, enabling the device to receive push notifications from ServiceNow mobile apps. The action creates a new push installation or updates an existing one if the same token already exists for the specified push application. Common use cases: - Registering iOS devices for APNS push notifications - Registering Android devices for FCM push notifications - Updating existing device tokens when they change (token refresh) - Linking devices to specific ServiceNow users This action modifies the ServiceNow push notification registry — registered devices will be eligible to receive push notifications from ServiceNow."
+        "description": "Registers or updates a device token for receiving push notifications through ServiceNow. Use this action when you need to register a mobile device token with ServiceNow's push notification system, enabling the device to receive push notifications from ServiceNow mobile apps. The action creates a new push installation or updates an existing one if the same token already exists for the specified push application. Common use cases: - Registering iOS devices for APNS push notifications - Registering Android devices for FCM push notifications - Updating existing device tokens when they change (token refresh) - Linking devices to specific ServiceNow users This action modifies the ServiceNow push notification registry \u2014 registered devices will be eligible to receive push notifications from ServiceNow."
       },
       {
         "slug": "SERVICENOW_CREATE_PUSH_REMOVE_INSTALLATION",
@@ -63731,12 +63731,12 @@
       {
         "slug": "SERVICENOW_CREATE_SERVICE_CATALOG_CART_CHECKOUT",
         "name": "Checkout Service Catalog Cart",
-        "description": "Checks out the Service Catalog shopping cart and submits the order as a request. This action retrieves the items in the cart, creates a service catalog request, deletes the cart contents, and returns the request ID and number for tracking. The cart is emptied after successful checkout. This action is irreversible once the checkout is completed — the order has been submitted and cannot be cancelled through this action. Use this action when you need to finalize a Service Catalog order by submitting all items in the shopping cart for processing and approval."
+        "description": "Checks out the Service Catalog shopping cart and submits the order as a request. This action retrieves the items in the cart, creates a service catalog request, deletes the cart contents, and returns the request ID and number for tracking. The cart is emptied after successful checkout. This action is irreversible once the checkout is completed \u2014 the order has been submitted and cannot be cancelled through this action. Use this action when you need to finalize a Service Catalog order by submitting all items in the shopping cart for processing and approval."
       },
       {
         "slug": "SERVICENOW_CREATE_SERVICE_CATALOG_CART_SUBMIT_ORDER",
         "name": "Submit Service Catalog Cart Order",
-        "description": "Submits the Service Catalog shopping cart and creates a service catalog request. This action checks out the user cart, creates a service catalog request with all items in the cart, and returns the request ID and number for tracking. The cart contents are converted into a submitted order. This action is irreversible once submitted — the order has been created and cannot be cancelled through this action. Use this action when you need to finalize a Service Catalog order by submitting all items in the shopping cart for processing and approval. This is typically called after items have been added to the cart using other cart operations."
+        "description": "Submits the Service Catalog shopping cart and creates a service catalog request. This action checks out the user cart, creates a service catalog request with all items in the cart, and returns the request ID and number for tracking. The cart contents are converted into a submitted order. This action is irreversible once submitted \u2014 the order has been created and cannot be cancelled through this action. Use this action when you need to finalize a Service Catalog order by submitting all items in the shopping cart for processing and approval. This is typically called after items have been added to the cart using other cart operations."
       },
       {
         "slug": "SERVICENOW_CREATE_SERVICECATALOG_ITEMS_CHECKOUT_GUIDE",
@@ -63791,7 +63791,7 @@
       {
         "slug": "SERVICENOW_CREATE_SN_CICD_APP_BATCH_INSTALL",
         "name": "Create sn cicd app batch install",
-        "description": "Installs two or more ServiceNow application packages in a single batch operation via the CICD API. Use this action when you need to deploy multiple applications at once as part of a CI/CD pipeline or automated deployment process. The batch install allows for efficient bulk installation of related applications rather than installing them one at a time. This action is idempotent — running it multiple times with the same packages will produce the same result. Note: At least two packages must be specified for a batch install operation."
+        "description": "Installs two or more ServiceNow application packages in a single batch operation via the CICD API. Use this action when you need to deploy multiple applications at once as part of a CI/CD pipeline or automated deployment process. The batch install allows for efficient bulk installation of related applications rather than installing them one at a time. This action is idempotent \u2014 running it multiple times with the same packages will produce the same result. Note: At least two packages must be specified for a batch install operation."
       },
       {
         "slug": "SERVICENOW_CREATE_SN_CICD_APP_REPO_INSTALL",
@@ -63851,17 +63851,17 @@
       {
         "slug": "SERVICENOW_DELETE_ATTACHMENT_BY_ID",
         "name": "Delete attachment by",
-        "description": "Permanently deletes a specific attachment from ServiceNow using its sys_id. This is a destructive, irreversible operation — the attachment cannot be recovered once deleted. Requires the user to have delete permissions on the attachment. If the attachment doesn't exist or the user lacks permissions, an error will be returned. This action should be used when you have the specific sys_id of an attachment to remove (obtained from FindFile action). Use when you need to remove a specific file attachment from a record and know its sys_id."
+        "description": "Permanently deletes a specific attachment from ServiceNow using its sys_id. This is a destructive, irreversible operation \u2014 the attachment cannot be recovered once deleted. Requires the user to have delete permissions on the attachment. If the attachment doesn't exist or the user lacks permissions, an error will be returned. This action should be used when you have the specific sys_id of an attachment to remove (obtained from FindFile action). Use when you need to remove a specific file attachment from a record and know its sys_id."
       },
       {
         "slug": "SERVICENOW_DELETE_ATTACHMENT_BY_ID_V1",
         "name": "Delete attachment by id v1",
-        "description": "Permanently deletes a specific attachment from ServiceNow using its sys_id via the v1 API endpoint. This is a destructive, irreversible operation — the attachment cannot be recovered once deleted. Requires the user to have delete permissions on the attachment record. If the attachment does not exist or the user lacks permissions, an error will be returned. This action uses the /api/now/v1/attachment/{sys_id} endpoint specifically. Use when you need to remove a specific file attachment from a record and already know its sys_id."
+        "description": "Permanently deletes a specific attachment from ServiceNow using its sys_id via the v1 API endpoint. This is a destructive, irreversible operation \u2014 the attachment cannot be recovered once deleted. Requires the user to have delete permissions on the attachment record. If the attachment does not exist or the user lacks permissions, an error will be returned. This action uses the /api/now/v1/attachment/{sys_id} endpoint specifically. Use when you need to remove a specific file attachment from a record and already know its sys_id."
       },
       {
         "slug": "SERVICENOW_DELETE_ATTACHMENT_CSM",
         "name": "Delete attachment csm",
-        "description": "Permanently deletes a specific CSM (Customer Service Management) attachment from ServiceNow using its sys_id. This is a destructive, irreversible operation — the CSM attachment cannot be recovered once deleted. Requires the user to have delete permissions on the attachment. If the attachment doesn't exist or the user lacks permissions, an error will be returned. This action specifically targets attachments associated with CSM records (cases, etc.). Use when you need to remove a specific file attachment from a CSM record and know its sys_id."
+        "description": "Permanently deletes a specific CSM (Customer Service Management) attachment from ServiceNow using its sys_id. This is a destructive, irreversible operation \u2014 the CSM attachment cannot be recovered once deleted. Requires the user to have delete permissions on the attachment. If the attachment doesn't exist or the user lacks permissions, an error will be returned. This action specifically targets attachments associated with CSM records (cases, etc.). Use when you need to remove a specific file attachment from a CSM record and know its sys_id."
       },
       {
         "slug": "SERVICENOW_DELETE_CHANGE_TASK",
@@ -63871,57 +63871,57 @@
       {
         "slug": "SERVICENOW_DELETE_CI_LIFECYCLE_MGMT_ACTION",
         "name": "Delete ci lifecycle mgmt action",
-        "description": "Permanently deletes a specific CI Lifecycle Management action from ServiceNow using its sys_id. Use this action when you need to remove a CI Lifecycle Management action record that is no longer needed. This action is irreversible — the CI action cannot be recovered once deleted. Requires the user to have appropriate permissions for the CI Lifecycle Management module. Use when you need to clean up obsolete, incorrect, or duplicate CI lifecycle action records."
+        "description": "Permanently deletes a specific CI Lifecycle Management action from ServiceNow using its sys_id. Use this action when you need to remove a CI Lifecycle Management action record that is no longer needed. This action is irreversible \u2014 the CI action cannot be recovered once deleted. Requires the user to have appropriate permissions for the CI Lifecycle Management module. Use when you need to clean up obsolete, incorrect, or duplicate CI lifecycle action records."
       },
       {
         "slug": "SERVICENOW_DELETE_CI_LIFECYCLE_MGMT_OPERATORS",
         "name": "Delete ci lifecycle mgmt operators",
-        "description": "Permanently unregisters an operator from the ServiceNow CI Lifecycle Management system. This action removes an operator registration for non-workflow users. This is a destructive, irreversible operation — once the operator is unregistered, it cannot be recovered and will need to be re-registered if needed again. Use this action with caution. Use when you need to clean up obsolete operator registrations for non-workflow users in the CI Lifecycle Management system. The user must have appropriate permissions to unregister operators. If the operator doesn't exist or the user lacks permissions, an error will be returned."
+        "description": "Permanently unregisters an operator from the ServiceNow CI Lifecycle Management system. This action removes an operator registration for non-workflow users. This is a destructive, irreversible operation \u2014 once the operator is unregistered, it cannot be recovered and will need to be re-registered if needed again. Use this action with caution. Use when you need to clean up obsolete operator registrations for non-workflow users in the CI Lifecycle Management system. The user must have appropriate permissions to unregister operators. If the operator doesn't exist or the user lacks permissions, an error will be returned."
       },
       {
         "slug": "SERVICENOW_DELETE_CMDB_INSTANCE_RELATION",
         "name": "Delete cmdb instance relation",
-        "description": "Permanently deletes a specific CMDB CI (Configuration Item) relation using its sys_id. This is a destructive, irreversible operation — the relation between two CIs cannot be recovered once deleted. The relation represents a connection between a parent and child CI (e.g., a server running an application). Requires the user to have the ITIL role and appropriate CMDB permissions. If the relation, CI, or class doesn't exist, or the user lacks permissions, an error will be returned. Use when you need to remove a specific relationship between two configuration items in the CMDB."
+        "description": "Permanently deletes a specific CMDB CI (Configuration Item) relation using its sys_id. This is a destructive, irreversible operation \u2014 the relation between two CIs cannot be recovered once deleted. The relation represents a connection between a parent and child CI (e.g., a server running an application). Requires the user to have the ITIL role and appropriate CMDB permissions. If the relation, CI, or class doesn't exist, or the user lacks permissions, an error will be returned. Use when you need to remove a specific relationship between two configuration items in the CMDB."
       },
       {
         "slug": "SERVICENOW_DELETE_EMERGENCY_CHANGE_REQUEST",
         "name": "Delete emergency change request",
-        "description": "Permanently deletes a specific emergency change request from ServiceNow using its sys_id. This is a destructive operation that cannot be undone. The emergency change request will be permanently removed from the system. Use this action when an emergency change request is no longer needed or was created in error. Use this action when you need to remove an emergency change request from ServiceNow. This action is irreversible — the emergency change request cannot be recovered once deleted. Requires the user to have delete permissions for change requests. If the record doesn't exist, is not an emergency change request, or the user lacks permissions, an error will be returned."
+        "description": "Permanently deletes a specific emergency change request from ServiceNow using its sys_id. This is a destructive operation that cannot be undone. The emergency change request will be permanently removed from the system. Use this action when an emergency change request is no longer needed or was created in error. Use this action when you need to remove an emergency change request from ServiceNow. This action is irreversible \u2014 the emergency change request cannot be recovered once deleted. Requires the user to have delete permissions for change requests. If the record doesn't exist, is not an emergency change request, or the user lacks permissions, an error will be returned."
       },
       {
         "slug": "SERVICENOW_DELETE_INCIDENT_BY_ID",
         "name": "Delete incident by",
-        "description": "Permanently deletes a specific incident from ServiceNow using its sys_id. This is a destructive, irreversible operation — the incident cannot be recovered once deleted. Requires the user to have delete permissions for the incident table. If the incident doesn't exist or the user lacks permissions, an error will be returned. Use this action when you need to remove a specific incident record and know its sys_id."
+        "description": "Permanently deletes a specific incident from ServiceNow using its sys_id. This is a destructive, irreversible operation \u2014 the incident cannot be recovered once deleted. Requires the user to have delete permissions for the incident table. If the incident doesn't exist or the user lacks permissions, an error will be returned. Use this action when you need to remove a specific incident record and know its sys_id."
       },
       {
         "slug": "SERVICENOW_DELETE_INCIDENT_BY_ID2",
         "name": "Delete incident by id2",
-        "description": "Permanently deletes a specific incident from ServiceNow using its sys_id via the Table API. This is a destructive, irreversible operation — the incident cannot be recovered once deleted. Requires the user to have delete permissions for the incident table. If the incident doesn't exist or the user lacks permissions, an error will be returned. Use when you need to remove a specific incident record and know its sys_id."
+        "description": "Permanently deletes a specific incident from ServiceNow using its sys_id via the Table API. This is a destructive, irreversible operation \u2014 the incident cannot be recovered once deleted. Requires the user to have delete permissions for the incident table. If the incident doesn't exist or the user lacks permissions, an error will be returned. Use when you need to remove a specific incident record and know its sys_id."
       },
       {
         "slug": "SERVICENOW_DELETE_SERVICECATALOG_CART",
         "name": "Delete servicecatalog cart",
-        "description": "Removes a specific item from the current ServiceNow Service Portal shopping cart. This action permanently removes a cart item from the active shopping cart session. Use this action when a user wants to remove an unwanted item from their Service Catalog cart before submitting the order. This action is irreversible — once the item is removed, it must be added again if still needed. Use when you need to remove an item from a user's Service Portal shopping cart and have the cart item's sys_id."
+        "description": "Removes a specific item from the current ServiceNow Service Portal shopping cart. This action permanently removes a cart item from the active shopping cart session. Use this action when a user wants to remove an unwanted item from their Service Catalog cart before submitting the order. This action is irreversible \u2014 once the item is removed, it must be added again if still needed. Use when you need to remove an item from a user's Service Portal shopping cart and have the cart item's sys_id."
       },
       {
         "slug": "SERVICENOW_DELETE_SERVICE_CATALOG_CART_EMPTY",
         "name": "Delete service catalog cart empty",
-        "description": "Empties all items from a specified Service Catalog shopping cart using its sys_id. This action removes all items from the cart but does not delete the cart itself. This is a destructive, irreversible operation — all cart items will be permanently removed and cannot be recovered once emptied. Use this action with caution. Use when you need to clear all items from a user's Service Catalog shopping cart before adding new items or before discarding an unwanted order."
+        "description": "Empties all items from a specified Service Catalog shopping cart using its sys_id. This action removes all items from the cart but does not delete the cart itself. This is a destructive, irreversible operation \u2014 all cart items will be permanently removed and cannot be recovered once emptied. Use this action with caution. Use when you need to clear all items from a user's Service Catalog shopping cart before adding new items or before discarding an unwanted order."
       },
       {
         "slug": "SERVICENOW_DELETE_SN_CHG_REST_CHANGE",
         "name": "Delete sn chg rest change",
-        "description": "Permanently deletes a specific change request using its sys_id via the Change Management REST API. Use this action when you need to remove a change request from ServiceNow that is no longer needed. This action is irreversible — the change request cannot be recovered once deleted. Requires the user to have appropriate permissions for the change management module."
+        "description": "Permanently deletes a specific change request using its sys_id via the Change Management REST API. Use this action when you need to remove a change request from ServiceNow that is no longer needed. This action is irreversible \u2014 the change request cannot be recovered once deleted. Requires the user to have appropriate permissions for the change management module."
       },
       {
         "slug": "SERVICENOW_DELETE_SN_CHG_REST_CHANGE_NORMAL",
         "name": "Delete Normal Change Request",
-        "description": "Permanently deletes a normal change request identified by its sys_id using the ServiceNow Change Management REST API. This is a destructive operation that cannot be undone. The normal change request will be permanently removed from the system. Use when you need to remove an unwanted or obsolete normal change request from ServiceNow. This action is irreversible — the change request cannot be recovered once deleted."
+        "description": "Permanently deletes a normal change request identified by its sys_id using the ServiceNow Change Management REST API. This is a destructive operation that cannot be undone. The normal change request will be permanently removed from the system. Use when you need to remove an unwanted or obsolete normal change request from ServiceNow. This action is irreversible \u2014 the change request cannot be recovered once deleted."
       },
       {
         "slug": "SERVICENOW_DELETE_SN_CHG_REST_CHANGE_STANDARD",
         "name": "Delete sn chg rest change standard",
-        "description": "Permanently deletes a standard change request from ServiceNow using its sys_id. Use this action when you need to remove a specific standard change request that is no longer needed. This is a destructive operation that cannot be undone — the standard change request cannot be recovered once deleted. Requires appropriate permissions to delete change requests in ServiceNow."
+        "description": "Permanently deletes a standard change request from ServiceNow using its sys_id. Use this action when you need to remove a specific standard change request that is no longer needed. This is a destructive operation that cannot be undone \u2014 the standard change request cannot be recovered once deleted. Requires appropriate permissions to delete change requests in ServiceNow."
       },
       {
         "slug": "SERVICENOW_DELETE_TABLE",
@@ -63931,7 +63931,7 @@
       {
         "slug": "SERVICENOW_DELETE_TABLE_INCIDENT",
         "name": "Delete table incident",
-        "description": "Permanently deletes a specific incident record from ServiceNow using its sys_id. This is a destructive, irreversible operation — the incident cannot be recovered once deleted. Requires the user to have delete permissions on the incident table. If the incident doesn't exist or the user lacks permissions, an error will be returned. Use when you need to remove a specific incident record from ServiceNow and know its sys_id."
+        "description": "Permanently deletes a specific incident record from ServiceNow using its sys_id. This is a destructive, irreversible operation \u2014 the incident cannot be recovered once deleted. Requires the user to have delete permissions on the incident table. If the incident doesn't exist or the user lacks permissions, an error will be returned. Use when you need to remove a specific incident record from ServiceNow and know its sys_id."
       },
       {
         "slug": "SERVICENOW_FIND_FILE",
@@ -63951,7 +63951,7 @@
       {
         "slug": "SERVICENOW_GET_AGENT_INTELLIGENCE_SOLUTION_PREDICTION",
         "name": "Get Agent Intelligence Solution Prediction",
-        "description": "Predicts an output field value using a trained Agent Intelligence solution model. Use this action when you need to invoke a deployed Predictive Intelligence solution to predict an output field value based on input field data. This is typically used after the Predictive Intelligence plugin is activated and solutions have been trained and deployed — for example, to predict incident assignment, priority, urgency, category, or any other custom trained output field. The action requires the name of an existing, deployed solution and optionally accepts input field values that the model uses to generate the prediction. The response includes the predicted value along with a confidence score indicating the model's certainty."
+        "description": "Predicts an output field value using a trained Agent Intelligence solution model. Use this action when you need to invoke a deployed Predictive Intelligence solution to predict an output field value based on input field data. This is typically used after the Predictive Intelligence plugin is activated and solutions have been trained and deployed \u2014 for example, to predict incident assignment, priority, urgency, category, or any other custom trained output field. The action requires the name of an existing, deployed solution and optionally accepts input field values that the model uses to generate the prediction. The response includes the predicted value along with a confidence score indicating the model's certainty."
       },
       {
         "slug": "SERVICENOW_GET_AGENT_INTELLIGENCE_SOLUTION_PREDICTION_LIST",
@@ -64216,7 +64216,7 @@
       {
         "slug": "SERVICENOW_GET_SN_CHG_REST_CHANGE_NORMAL_BY_ID",
         "name": "Get Normal Change Request by ID",
-        "description": "Retrieves a specific normal change request from ServiceNow using its sys_id via the Change Management REST API. Use when you need to fetch detailed information about a particular normal change request, including its state, type, priority, dates, assignments, and approvals. This is a read-only operation that does not modify any data in ServiceNow. The action specifically targets change requests of type 'normal' — if the provided sys_id does not correspond to a normal change request, a 404 error will be returned."
+        "description": "Retrieves a specific normal change request from ServiceNow using its sys_id via the Change Management REST API. Use when you need to fetch detailed information about a particular normal change request, including its state, type, priority, dates, assignments, and approvals. This is a read-only operation that does not modify any data in ServiceNow. The action specifically targets change requests of type 'normal' \u2014 if the provided sys_id does not correspond to a normal change request, a 404 error will be returned."
       },
       {
         "slug": "SERVICENOW_GET_SN_CHG_REST_CHANGE_NORMAL_LIST",
@@ -64236,7 +64236,7 @@
       {
         "slug": "SERVICENOW_GET_SN_CHG_REST_CHANGE_STANDARD_TEMPLATE_BY_ID",
         "name": "Get ServiceNow Standard Change Template by ID",
-        "description": "Retrieves a specific standard change template from ServiceNow using its sys_id. Use this action when you need to fetch detailed information about a particular standard change template, including its name, description, category, implementation plan, test plan, risk assessment, and other predefined fields. This is a read-only operation that does not modify any data in ServiceNow. This action complements the list action — use the list action to discover template sys_ids, then use this action to retrieve full details of a specific template by its sys_id."
+        "description": "Retrieves a specific standard change template from ServiceNow using its sys_id. Use this action when you need to fetch detailed information about a particular standard change template, including its name, description, category, implementation plan, test plan, risk assessment, and other predefined fields. This is a read-only operation that does not modify any data in ServiceNow. This action complements the list action \u2014 use the list action to discover template sys_ids, then use this action to retrieve full details of a specific template by its sys_id."
       },
       {
         "slug": "SERVICENOW_GET_SN_CHG_REST_CHANGE_STANDARD_TEMPLATE_LIST",
@@ -64366,12 +64366,12 @@
       {
         "slug": "SERVICENOW_UPDATE_CMDB_INSTANCE_BY_ID2",
         "name": "Update CMDB Instance by ID",
-        "description": "Updates an existing Configuration Item (CI) instance in the ServiceNow CMDB. Use this action when you need to modify the attributes of a specific CMDB record, such as updating its description, operational status, assignment group, IP address, or any other supported field. This action sends a PATCH request to the CMDB Instance API, replacing only the specified attributes on the target record. This is an update operation — changes made by this action can be reverted by calling this action again with corrected values."
+        "description": "Updates an existing Configuration Item (CI) instance in the ServiceNow CMDB. Use this action when you need to modify the attributes of a specific CMDB record, such as updating its description, operational status, assignment group, IP address, or any other supported field. This action sends a PATCH request to the CMDB Instance API, replacing only the specified attributes on the target record. This is an update operation \u2014 changes made by this action can be reverted by calling this action again with corrected values."
       },
       {
         "slug": "SERVICENOW_UPDATE_CONVERSATION_MEMBER_DROP",
         "name": "Update conversation member drop",
-        "description": "Drops an agent from a conversation in ServiceNow using the Conversation Member API. Use this action when you need to remove an agent or user from an active conversation. This operation requires the wa_integration_user role. The member will be immediately removed from the conversation and will no longer receive messages or events for it. This action is irreversible — once a member is dropped from a conversation, they cannot be automatically restored through this API and would need to be re-added manually."
+        "description": "Drops an agent from a conversation in ServiceNow using the Conversation Member API. Use this action when you need to remove an agent or user from an active conversation. This operation requires the wa_integration_user role. The member will be immediately removed from the conversation and will no longer receive messages or events for it. This action is irreversible \u2014 once a member is dropped from a conversation, they cannot be automatically restored through this API and would need to be re-added manually."
       },
       {
         "slug": "SERVICENOW_UPDATE_INCIDENT_BY_ID",
@@ -64411,7 +64411,7 @@
       {
         "slug": "SERVICENOW_UPDATE_SN_CHG_REST_CHANGE_NORMAL",
         "name": "Update Normal Change Request",
-        "description": "Updates a normal change request identified by its sys_id using the ServiceNow Change Management REST API. Use this action when you need to modify the details of an existing normal change request, such as updating its description, changing its state or priority, reassigning it to a different user or group, or updating schedule dates. Only the fields provided in the request will be updated; all other fields retain their current values. This is a PATCH operation — it performs a partial update. Only include the fields you want to change."
+        "description": "Updates a normal change request identified by its sys_id using the ServiceNow Change Management REST API. Use this action when you need to modify the details of an existing normal change request, such as updating its description, changing its state or priority, reassigning it to a different user or group, or updating schedule dates. Only the fields provided in the request will be updated; all other fields retain their current values. This is a PATCH operation \u2014 it performs a partial update. Only include the fields you want to change."
       },
       {
         "slug": "SERVICENOW_UPDATE_SN_CHG_REST_CHANGE_STANDARD",
@@ -64436,7 +64436,7 @@
       {
         "slug": "SERVICENOW_UPDATE_TABLE_BY_ID",
         "name": "Update table by",
-        "description": "Updates an existing record in a specified ServiceNow table by its sys_id using the Table API. Use this action when you need to modify specific fields of an existing record, such as updating the short_description, changing the state, reassigning the record, adding close_notes, or modifying any other table field. Only the fields specified in record_data are updated — all other fields retain their current values. This action sends a PATCH request to the ServiceNow Table API. This action modifies data but the changes can be reverted by calling this action again with the corrected values. This is an idempotent operation — calling it multiple times with the same parameters produces the same result."
+        "description": "Updates an existing record in a specified ServiceNow table by its sys_id using the Table API. Use this action when you need to modify specific fields of an existing record, such as updating the short_description, changing the state, reassigning the record, adding close_notes, or modifying any other table field. Only the fields specified in record_data are updated \u2014 all other fields retain their current values. This action sends a PATCH request to the ServiceNow Table API. This action modifies data but the changes can be reverted by calling this action again with the corrected values. This is an idempotent operation \u2014 calling it multiple times with the same parameters produces the same result."
       },
       {
         "slug": "SERVICENOW_UPDATE_TABLE_BY_ID2",
@@ -64456,7 +64456,7 @@
       {
         "slug": "SERVICENOW_UPLOAD_ATTACHMENT",
         "name": "Upload Attachment to ServiceNow Record",
-        "description": "Uploads a file as an attachment to a specified record in ServiceNow. Use this action when you need to attach files to ServiceNow records (e.g., incidents, problems, change requests) using the raw binary upload endpoint (/api/now/v1/attachment/file). The file content is sent as raw binary data with the Content-Type header reflecting the file type. Common use cases: - Attach documents or screenshots to incident reports - Upload evidence files to problem records - Add files to change requests for documentation This action permanently modifies a live ServiceNow instance — the attachment cannot be recovered once deleted."
+        "description": "Uploads a file as an attachment to a specified record in ServiceNow. Use this action when you need to attach files to ServiceNow records (e.g., incidents, problems, change requests) using the raw binary upload endpoint (/api/now/v1/attachment/file). The file content is sent as raw binary data with the Content-Type header reflecting the file type. Common use cases: - Attach documents or screenshots to incident reports - Upload evidence files to problem records - Add files to change requests for documentation This action permanently modifies a live ServiceNow instance \u2014 the attachment cannot be recovered once deleted."
       }
     ],
     "triggers": [],
@@ -64581,7 +64581,7 @@
       {
         "slug": "GOOGLEADS_GET_CUSTOMER_LISTS",
         "name": "Get customer lists",
-        "description": "GetCustomerLists Tool lists all customer lists (audience/remarketing lists) in Google Ads. These are user segments for targeting, not Google Ads accounts — list IDs are distinct from account IDs. When multiple lists share similar names, review all returned results before selecting one for downstream operations."
+        "description": "GetCustomerLists Tool lists all customer lists (audience/remarketing lists) in Google Ads. These are user segments for targeting, not Google Ads accounts \u2014 list IDs are distinct from account IDs. When multiple lists share similar names, review all returned results before selecting one for downstream operations."
       }
     ],
     "triggers": [],
@@ -66320,7 +66320,7 @@
       {
         "slug": "PAGERDUTY_UPDATE_CUSTOM_FIELD_OPTION",
         "name": "Update custom field option",
-        "description": "Updates a field option for a custom field on an incident type in PagerDuty. Field options represent the selectable values for multi-value or dropdown custom fields. Use this action to modify the display value or data type of an existing option. **Prerequisites:** 1. A valid incident type ID or name (use PAGERDUTY_LIST_INCIDENT_TYPES) 2. A valid custom field ID for that incident type (use PAGERDUTY_LIST_INCIDENT_TYPE_CUSTOM_FIELDS) 3. An existing field option ID to update (use PAGERDUTY_LIST_FIELD_OPTIONS_ON_A_CUSTOM_FIELD) 4. The custom field should be of type 'multi_value' or 'multi_value_fixed' to support options **Common use cases:** - Renaming field options to match updated terminology (e.g., \"Critical\" → \"Urgent\") - Correcting typos in existing field option values - Adjusting options to better reflect current operational needs **Note:** This is an Early Access endpoint requiring the `custom_fields.write` OAuth scope. The X-EARLY-ACCESS header with value 'analytics-v2' is automatically included."
+        "description": "Updates a field option for a custom field on an incident type in PagerDuty. Field options represent the selectable values for multi-value or dropdown custom fields. Use this action to modify the display value or data type of an existing option. **Prerequisites:** 1. A valid incident type ID or name (use PAGERDUTY_LIST_INCIDENT_TYPES) 2. A valid custom field ID for that incident type (use PAGERDUTY_LIST_INCIDENT_TYPE_CUSTOM_FIELDS) 3. An existing field option ID to update (use PAGERDUTY_LIST_FIELD_OPTIONS_ON_A_CUSTOM_FIELD) 4. The custom field should be of type 'multi_value' or 'multi_value_fixed' to support options **Common use cases:** - Renaming field options to match updated terminology (e.g., \"Critical\" \u2192 \"Urgent\") - Correcting typos in existing field option values - Adjusting options to better reflect current operational needs **Note:** This is an Early Access endpoint requiring the `custom_fields.write` OAuth scope. The X-EARLY-ACCESS header with value 'analytics-v2' is automatically included."
       },
       {
         "slug": "PAGERDUTY_UPDATE_ESCALATION_POLICY_BY_ID",
@@ -66988,12 +66988,12 @@
       {
         "slug": "FINAGE_GET_STOCK_HISTORICAL_DATA",
         "name": "Get Stock Historical Data (Deprecated)",
-        "description": "DEPRECATED: Use FINAGE_GET_STOCK_MARKET_AGGREGATES instead. Fetches historical OHLCV (open, high, low, close, volume) data for US stocks from Finage API. Returned timestamps are UTC-aligned; non-trading days are omitted entirely — do not treat date gaps as zero values. Ensure from_date/to_date are past UTC dates to avoid partial or future bars. Requirements: - Symbols must be alphabetic US ticker symbols in English - No numeric-only symbols - No exchange prefixes or suffixes - Standard ticker format only (typically 1-5 characters) For supported symbols and complete documentation, visit: https://finage.co.uk/docs"
+        "description": "DEPRECATED: Use FINAGE_GET_STOCK_MARKET_AGGREGATES instead. Fetches historical OHLCV (open, high, low, close, volume) data for US stocks from Finage API. Returned timestamps are UTC-aligned; non-trading days are omitted entirely \u2014 do not treat date gaps as zero values. Ensure from_date/to_date are past UTC dates to avoid partial or future bars. Requirements: - Symbols must be alphabetic US ticker symbols in English - No numeric-only symbols - No exchange prefixes or suffixes - Standard ticker format only (typically 1-5 characters) For supported symbols and complete documentation, visit: https://finage.co.uk/docs"
       },
       {
         "slug": "FINAGE_GET_STOCK_LAST_QUOTE",
         "name": "Get Stock Last Quote",
-        "description": "Fetches the latest single-tick quote for a stock symbol, returning a JSON object with fields: symbol, ask, bid, asize, bsize, and timestamp. Suitable for real-time trading and market analysis. During pre/post-market or closed sessions, the returned quote may be stale — always compare the timestamp field against current UTC before treating data as live. Returns only the latest tick; not a substitute for historical or charted series data. Rate-limited: throttle to 2–5 requests/second and honor Retry-After headers on HTTP 429."
+        "description": "Fetches the latest single-tick quote for a stock symbol, returning a JSON object with fields: symbol, ask, bid, asize, bsize, and timestamp. Suitable for real-time trading and market analysis. During pre/post-market or closed sessions, the returned quote may be stale \u2014 always compare the timestamp field against current UTC before treating data as live. Returns only the latest tick; not a substitute for historical or charted series data. Rate-limited: throttle to 2\u20135 requests/second and honor Retry-After headers on HTTP 429."
       },
       {
         "slug": "FINAGE_GET_STOCK_LAST_TRADE",
@@ -67963,7 +67963,7 @@
       {
         "slug": "SHARE_POINT_ENSURE_USER",
         "name": "Ensure SharePoint User",
-        "description": "Ensures a user exists in a SharePoint site by their login name. If the user already exists, returns their info; if not, adds them to the site — this is a write operation with a provisioning side effect, not a read-only presence check. Use when you need to add a user or get their user ID for permissions. The login name must be in SharePoint claims format (e.g., 'i:0#.f|membership|user@domain.com'). This action only registers the user in the site collection and does not grant any permissions. To assign list-level access, pass the returned Id field as principal_id to SHARE_POINT_ADD_ROLE_ASSIGNMENT_TO_LIST."
+        "description": "Ensures a user exists in a SharePoint site by their login name. If the user already exists, returns their info; if not, adds them to the site \u2014 this is a write operation with a provisioning side effect, not a read-only presence check. Use when you need to add a user or get their user ID for permissions. The login name must be in SharePoint claims format (e.g., 'i:0#.f|membership|user@domain.com'). This action only registers the user in the site collection and does not grant any permissions. To assign list-level access, pass the returned Id field as principal_id to SHARE_POINT_ADD_ROLE_ASSIGNMENT_TO_LIST."
       },
       {
         "slug": "SHARE_POINT_FOLLOW",
@@ -68083,12 +68083,12 @@
       {
         "slug": "SHARE_POINT_GET_ROLE_DEFINITIONS",
         "name": "Get Role Definitions",
-        "description": "Tool to list role definitions at the web level. Role definition IDs and names are scoped per web/site collection — never hard-code them, as admins can modify role sets and IDs differ across site collections. Always resolve current values dynamically via this tool."
+        "description": "Tool to list role definitions at the web level. Role definition IDs and names are scoped per web/site collection \u2014 never hard-code them, as admins can modify role sets and IDs differ across site collections. Always resolve current values dynamically via this tool."
       },
       {
         "slug": "SHARE_POINT_GET_SITE_COLLECTION_INFO",
         "name": "Get SharePoint Site Collection Info",
-        "description": "Tool to fetch site collection metadata (URL, ID, root web URI) only—not list item or document-level details. Use before subsequent calls to resolve correct API names. Requires SharePoint connection with site-collection-level scopes; may fail even when user-level tools succeed. Verify site_id before use—an incorrect site_id can silently return data for an unrelated site."
+        "description": "Tool to fetch site collection metadata (URL, ID, root web URI) only\u2014not list item or document-level details. Use before subsequent calls to resolve correct API names. Requires SharePoint connection with site-collection-level scopes; may fail even when user-level tools succeed. Verify site_id before use\u2014an incorrect site_id can silently return data for an unrelated site."
       },
       {
         "slug": "SHARE_POINT_GET_SITE_DRIVE_ITEM_BY_PATH",
@@ -68223,7 +68223,7 @@
       {
         "slug": "SHARE_POINT_SEARCH_QUERY",
         "name": "Search SharePoint Site",
-        "description": "Search SharePoint content using Keyword Query Language (KQL). Returns documents, list items, folders, and other content matching your query. Supports filtering by properties (file type, author, date), pagination, and custom property selection. Results are nested under PrimaryQueryResult→RelevantResults→Table→Rows→Cells as Key/Value pairs requiring explicit extraction. Results are security-trimmed: inaccessible content never appears even if it exists. Use contentclass (e.g., STS_Site, STS_Web, STS_ListItem_DocumentLibrary) in querytext to isolate specific item types."
+        "description": "Search SharePoint content using Keyword Query Language (KQL). Returns documents, list items, folders, and other content matching your query. Supports filtering by properties (file type, author, date), pagination, and custom property selection. Results are nested under PrimaryQueryResult\u2192RelevantResults\u2192Table\u2192Rows\u2192Cells as Key/Value pairs requiring explicit extraction. Results are security-trimmed: inaccessible content never appears even if it exists. Use contentclass (e.g., STS_Site, STS_Web, STS_ListItem_DocumentLibrary) in querytext to isolate specific item types."
       },
       {
         "slug": "SHARE_POINT_SEARCH_SUGGEST",
@@ -68258,7 +68258,7 @@
       {
         "slug": "SHARE_POINT_SHAREPOINT_FIND_USER",
         "name": "Find SharePoint User",
-        "description": "Searches for a user in the SharePoint site by email address and returns their profile information if found. Response includes `exists_in_graph`, `exists_in_sharepoint`, and `error_details` fields; inspect all three together — `successful=true` can coexist with Graph errors in `error_details`. When the two backends diverge, treat `exists_in_sharepoint` as authoritative for access decisions."
+        "description": "Searches for a user in the SharePoint site by email address and returns their profile information if found. Response includes `exists_in_graph`, `exists_in_sharepoint`, and `error_details` fields; inspect all three together \u2014 `successful=true` can coexist with Graph errors in `error_details`. When the two backends diverge, treat `exists_in_sharepoint` as authoritative for access decisions."
       },
       {
         "slug": "SHARE_POINT_SHAREPOINT_REMOVE_USER",
@@ -70062,7 +70062,7 @@
       {
         "slug": "MAILERLITE_CREATE_GROUP",
         "name": "Create Group",
-        "description": "Tool to create a new subscriber group. Use after deciding the group name for categorization. Store `group_id` from the response — required by MAILERLITE_UPDATE_GROUP, MAILERLITE_DELETE_GROUP, and MAILERLITE_GET_GROUP_SUBSCRIBERS."
+        "description": "Tool to create a new subscriber group. Use after deciding the group name for categorization. Store `group_id` from the response \u2014 required by MAILERLITE_UPDATE_GROUP, MAILERLITE_DELETE_GROUP, and MAILERLITE_GET_GROUP_SUBSCRIBERS."
       },
       {
         "slug": "MAILERLITE_CREATE_SEGMENT",
@@ -70082,7 +70082,7 @@
       {
         "slug": "MAILERLITE_DELETE_AUTOMATION",
         "name": "Delete Automation",
-        "description": "Tool to delete an automation workflow by ID. Deletion is permanent and irreversible — always require explicit user confirmation before calling. Use when you need to remove an automation after confirming it's no longer needed. Returns success=True on 204 No Content."
+        "description": "Tool to delete an automation workflow by ID. Deletion is permanent and irreversible \u2014 always require explicit user confirmation before calling. Use when you need to remove an automation after confirming it's no longer needed. Returns success=True on 204 No Content."
       },
       {
         "slug": "MAILERLITE_DELETE_ECOMMERCE_CART_ITEM",
@@ -70122,7 +70122,7 @@
       {
         "slug": "MAILERLITE_DELETE_GROUP",
         "name": "Delete Group",
-        "description": "Tool to delete a subscriber group by ID. Permanently removes the group and all its subscriber associations — irreversible with no undo. Use when you need to remove an existing subscriber group from your MailerLite account. Require explicit user confirmation before invoking. Returns success=True on 204 No Content."
+        "description": "Tool to delete a subscriber group by ID. Permanently removes the group and all its subscriber associations \u2014 irreversible with no undo. Use when you need to remove an existing subscriber group from your MailerLite account. Require explicit user confirmation before invoking. Returns success=True on 204 No Content."
       },
       {
         "slug": "MAILERLITE_DELETE_SEGMENT",
@@ -70152,7 +70152,7 @@
       {
         "slug": "MAILERLITE_GET_ACCOUNT_INFO",
         "name": "Get Account Info",
-        "description": "Tool to retrieve basic MailerLite account details. Use when you need to verify authentication and review account metadata. Response payload is nested under results[i].response.data with data and meta subkeys — not a flat data key. Does not return a dedicated sender-domain list; absent domain fields indicate unknown status, not verified or unverified."
+        "description": "Tool to retrieve basic MailerLite account details. Use when you need to verify authentication and review account metadata. Response payload is nested under results[i].response.data with data and meta subkeys \u2014 not a flat data key. Does not return a dedicated sender-domain list; absent domain fields indicate unknown status, not verified or unverified."
       },
       {
         "slug": "MAILERLITE_GET_ACCOUNT_STATS",
@@ -70867,7 +70867,7 @@
       {
         "slug": "CONTENTFUL_GET_SPACE",
         "name": "Get space",
-        "description": "Retrieves metadata of a specific space by its ID. Returns space-level details only (name, locales, sys fields) — not entries, content types, or assets. The returned sys.version is required for subsequent CONTENTFUL_UPDATE_SPACE calls to avoid version conflict errors."
+        "description": "Retrieves metadata of a specific space by its ID. Returns space-level details only (name, locales, sys fields) \u2014 not entries, content types, or assets. The returned sys.version is required for subsequent CONTENTFUL_UPDATE_SPACE calls to avoid version conflict errors."
       },
       {
         "slug": "CONTENTFUL_GET_SPACE_MEMBERSHIPS",
@@ -71517,7 +71517,7 @@
                 "name": "generic_api_key",
                 "displayName": "API Key",
                 "type": "string",
-                "description": "Your More Trees API key. Find it under Settings → Account Settings on the platform.",
+                "description": "Your More Trees API key. Find it under Settings \u2192 Account Settings on the platform.",
                 "required": true,
                 "default": null
               },
@@ -71525,7 +71525,7 @@
                 "name": "generic_id",
                 "displayName": "Account Code",
                 "type": "string",
-                "description": "Your More Trees account code. Find it under Settings → Account Settings on the platform.",
+                "description": "Your More Trees account code. Find it under Settings \u2192 Account Settings on the platform.",
                 "required": true,
                 "default": null
               }
@@ -71557,7 +71557,7 @@
       {
         "slug": "NETSUITE_ASYNC_GET_JOB_TASK",
         "name": "Get Async Job Task",
-        "description": "Retrieves the task reference (task ID and URL) for an asynchronous job in NetSuite. Use this action after submitting an async request with 'Prefer: respond-async' header and receiving a job_id in the Location header. The task ID is required to retrieve the job's result using the async get job task result action. Typical workflow: 1) Submit async request → 2) Get job_id → 3) Use this action to get task_id → 4) Poll job status → 5) Retrieve results with task_id."
+        "description": "Retrieves the task reference (task ID and URL) for an asynchronous job in NetSuite. Use this action after submitting an async request with 'Prefer: respond-async' header and receiving a job_id in the Location header. The task ID is required to retrieve the job's result using the async get job task result action. Typical workflow: 1) Submit async request \u2192 2) Get job_id \u2192 3) Use this action to get task_id \u2192 4) Poll job status \u2192 5) Retrieve results with task_id."
       },
       {
         "slug": "NETSUITE_ASYNC_GET_JOB_TASK_RESULT",
@@ -72752,7 +72752,7 @@
       {
         "slug": "SURVEY_MONKEY_CREATE_SURVEY",
         "name": "Create Survey",
-        "description": "Creates a new empty survey in SurveyMonkey with one empty page and no questions. Returns the survey ID and internal URLs for editing, previewing, and analyzing results — shareable collector URLs are not returned; use SURVEY_MONKEY_GET_COLLECTORS after creation to retrieve or manage those. The survey_id can be used with other actions to add questions, pages, or collectors. Finalize survey design before broad distribution, as modifying questions after distributing live links can invalidate prior responses. Example: \"Create a survey titled 'Customer Satisfaction Survey'\""
+        "description": "Creates a new empty survey in SurveyMonkey with one empty page and no questions. Returns the survey ID and internal URLs for editing, previewing, and analyzing results \u2014 shareable collector URLs are not returned; use SURVEY_MONKEY_GET_COLLECTORS after creation to retrieve or manage those. The survey_id can be used with other actions to add questions, pages, or collectors. Finalize survey design before broad distribution, as modifying questions after distributing live links can invalidate prior responses. Example: \"Create a survey titled 'Customer Satisfaction Survey'\""
       },
       {
         "slug": "SURVEY_MONKEY_CREATE_SURVEY_FOLDER",
@@ -74116,7 +74116,7 @@
       {
         "slug": "ZOHO_BOOKS_UPDATE_CREDIT_NOTE_REFUND",
         "name": "Update Credit Note Refund",
-        "description": "Tool to update details of a specific credit note refund. Use when you need to modify an existing refund associated with a credit note—change the description, reference number, or other refund fields."
+        "description": "Tool to update details of a specific credit note refund. Use when you need to modify an existing refund associated with a credit note\u2014change the description, reference number, or other refund fields."
       },
       {
         "slug": "ZOHO_BOOKS_UPDATE_CURRENCY",
@@ -74151,7 +74151,7 @@
       {
         "slug": "ZOHO_BOOKS_UPDATE_INVOICE",
         "name": "Update Invoice",
-        "description": "Tool to update details of a specific invoice. Use when you need to modify an existing invoice in Zoho Books—change line items, dates, or other invoice fields. Requires invoice ID and organization ID before calling."
+        "description": "Tool to update details of a specific invoice. Use when you need to modify an existing invoice in Zoho Books\u2014change line items, dates, or other invoice fields. Requires invoice ID and organization ID before calling."
       },
       {
         "slug": "ZOHO_BOOKS_UPDATE_INVOICE_ATTACHMENT_PREFERENCE",
@@ -74181,7 +74181,7 @@
       {
         "slug": "ZOHO_BOOKS_UPDATE_JOURNAL",
         "name": "Update Journal",
-        "description": "Tool to update a journal entry in Zoho Books. Use when modifying existing journal entries—changing line items, dates, amounts, or other journal fields."
+        "description": "Tool to update a journal entry in Zoho Books. Use when modifying existing journal entries\u2014changing line items, dates, amounts, or other journal fields."
       },
       {
         "slug": "ZOHO_BOOKS_UPDATE_LOCATION",
@@ -74707,7 +74707,7 @@
                 "name": "generic_key",
                 "displayName": "Organization ID",
                 "type": "string",
-                "description": "Your Zoho Inventory organization ID. Find it in Settings → Organization Profile. If not provided, we'll use the first available organization for your account.",
+                "description": "Your Zoho Inventory organization ID. Find it in Settings \u2192 Organization Profile. If not provided, we'll use the first available organization for your account.",
                 "required": false,
                 "default": null
               }
@@ -74756,7 +74756,7 @@
       {
         "slug": "FACEBOOK_CREATE_POST",
         "name": "Create Post",
-        "description": "Creates a new text or link post on a Facebook Page. Requires `pages_manage_posts` permission and manage-level Page role on the target Page. For image posts use FACEBOOK_CREATE_PHOTO_POST; for video posts use FACEBOOK_CREATE_VIDEO_POST — media fields are not supported here. Returns a composite post ID in `PageID_PostID` format, required for FACEBOOK_GET_POST retrieval."
+        "description": "Creates a new text or link post on a Facebook Page. Requires `pages_manage_posts` permission and manage-level Page role on the target Page. For image posts use FACEBOOK_CREATE_PHOTO_POST; for video posts use FACEBOOK_CREATE_VIDEO_POST \u2014 media fields are not supported here. Returns a composite post ID in `PageID_PostID` format, required for FACEBOOK_GET_POST retrieval."
       },
       {
         "slug": "FACEBOOK_CREATE_VIDEO_POST",
@@ -74771,7 +74771,7 @@
       {
         "slug": "FACEBOOK_DELETE_POST",
         "name": "Delete Post",
-        "description": "Permanently deletes a Facebook Page post. Deletion is irreversible — deleted posts cannot be recovered. For bulk deletions, keep throughput to ~1 delete/second to avoid Graph API rate limits."
+        "description": "Permanently deletes a Facebook Page post. Deletion is irreversible \u2014 deleted posts cannot be recovered. For bulk deletions, keep throughput to ~1 delete/second to avoid Graph API rate limits."
       },
       {
         "slug": "FACEBOOK_GET_COMMENT",
@@ -74826,7 +74826,7 @@
       {
         "slug": "FACEBOOK_GET_PAGE_ROLES",
         "name": "Get Page Roles",
-        "description": "Retrieves a list of people and their tasks/roles on a Facebook Page. The connected account must have management access to the target Page; otherwise the response may be empty or incomplete. Returned role types include MANAGE and CREATE_CONTENT — verify these before calling tools like FACEBOOK_UPDATE_PAGE_SETTINGS. Recently changed roles may take time to propagate; retry if role data appears stale after an update."
+        "description": "Retrieves a list of people and their tasks/roles on a Facebook Page. The connected account must have management access to the target Page; otherwise the response may be empty or incomplete. Returned role types include MANAGE and CREATE_CONTENT \u2014 verify these before calling tools like FACEBOOK_UPDATE_PAGE_SETTINGS. Recently changed roles may take time to propagate; retry if role data appears stale after an update."
       },
       {
         "slug": "FACEBOOK_GET_PAGE_TAGGED_POSTS",
@@ -74856,22 +74856,22 @@
       {
         "slug": "FACEBOOK_GET_SCHEDULED_POSTS",
         "name": "Get Scheduled Posts",
-        "description": "Retrieves scheduled and unpublished posts for a Facebook Page. Results are cursor-paginated; follow pagination cursors to retrieve all results beyond the limit. When searching for posts near a specific time, filter to a narrow (~±5 minutes) window. Use this tool to check for existing entries before scheduling new posts to avoid duplicates."
+        "description": "Retrieves scheduled and unpublished posts for a Facebook Page. Results are cursor-paginated; follow pagination cursors to retrieve all results beyond the limit. When searching for posts near a specific time, filter to a narrow (~\u00b15 minutes) window. Use this tool to check for existing entries before scheduling new posts to avoid duplicates."
       },
       {
         "slug": "FACEBOOK_GET_USER_PAGES",
         "name": "Get User Pages (Deprecated)",
-        "description": "DEPRECATED: Use FACEBOOK_LIST_MANAGED_PAGES instead. Retrieves Facebook Pages the user manages (excludes personal profiles, groups, and non-Page entities); an empty `data` array means no manageable Pages exist. Requires `pages_show_list` scope; missing scopes yield empty `data` or OAuthException code 200. Results paginate ~100 items per page — follow `paging.cursors.after` or `next` until exhausted."
+        "description": "DEPRECATED: Use FACEBOOK_LIST_MANAGED_PAGES instead. Retrieves Facebook Pages the user manages (excludes personal profiles, groups, and non-Page entities); an empty `data` array means no manageable Pages exist. Requires `pages_show_list` scope; missing scopes yield empty `data` or OAuthException code 200. Results paginate ~100 items per page \u2014 follow `paging.cursors.after` or `next` until exhausted."
       },
       {
         "slug": "FACEBOOK_LIKE_POST_OR_COMMENT",
         "name": "Add Reaction",
-        "description": "Adds a LIKE reaction to a Facebook post or comment. Note: Due to API limitations, only LIKE reactions can be added programmatically. This action is user-visible and irreversible — confirm with the user before calling."
+        "description": "Adds a LIKE reaction to a Facebook post or comment. Note: Due to API limitations, only LIKE reactions can be added programmatically. This action is user-visible and irreversible \u2014 confirm with the user before calling."
       },
       {
         "slug": "FACEBOOK_LIST_MANAGED_PAGES",
         "name": "List Managed Pages",
-        "description": "Retrieves a list of Facebook Pages that the user manages (not personal profiles), including page details, access tokens, and tasks. Requires `pages_show_list` or `pages_read_engagement` OAuth scopes; missing scopes silently return empty results rather than an error. An empty `data` array means the user manages no Pages. Results are paginated via `paging.cursors`; follow `paging.next` until absent to retrieve all Pages when count exceeds `limit`. Graph API throttling (error codes 4, 17, 613) can occur during pagination — use exponential backoff."
+        "description": "Retrieves a list of Facebook Pages that the user manages (not personal profiles), including page details, access tokens, and tasks. Requires `pages_show_list` or `pages_read_engagement` OAuth scopes; missing scopes silently return empty results rather than an error. An empty `data` array means the user manages no Pages. Results are paginated via `paging.cursors`; follow `paging.next` until absent to retrieve all Pages when count exceeds `limit`. Graph API throttling (error codes 4, 17, 613) can occur during pagination \u2014 use exponential backoff."
       },
       {
         "slug": "FACEBOOK_MARK_MESSAGE_SEEN",
@@ -75152,7 +75152,7 @@
                 "name": "generic_api_key",
                 "displayName": "Public Key",
                 "type": "string",
-                "description": "The public key (ID) for the application communicating with the API. Obtained from Mopinion Suite at Settings » Feedback Api (classic) or Integrations » Feedback API (Raspberry)",
+                "description": "The public key (ID) for the application communicating with the API. Obtained from Mopinion Suite at Settings \u00bb Feedback Api (classic) or Integrations \u00bb Feedback API (Raspberry)",
                 "required": true,
                 "default": null
               },
@@ -75506,7 +75506,7 @@
       {
         "slug": "BRANDFETCH_GET_BRAND_INFO",
         "name": "Get Brand Information",
-        "description": "Retrieves brand information including logos, colors, fonts, and company details using a domain, Brand ID, ISIN, or stock ticker. Logo data may be absent for some domains — do not assume logos are always returned. The response includes multiple logo types (e.g., icon, logo) and themes; explicitly select the desired type and size rather than defaulting to the first URL."
+        "description": "Retrieves brand information including logos, colors, fonts, and company details using a domain, Brand ID, ISIN, or stock ticker. Logo data may be absent for some domains \u2014 do not assume logos are always returned. The response includes multiple logo types (e.g., icon, logo) and themes; explicitly select the desired type and size rather than defaulting to the first URL."
       },
       {
         "slug": "BRANDFETCH_GET_GRAPHQL_VERSION",
@@ -76361,7 +76361,7 @@
       {
         "slug": "DIGICERT_UPDATE_REPORT",
         "name": "Update Report",
-        "description": "Tool to update an existing report’s configuration. Use when you need to modify the schedule, recipients, or format of a scheduled report."
+        "description": "Tool to update an existing report\u2019s configuration. Use when you need to modify the schedule, recipients, or format of a scheduled report."
       },
       {
         "slug": "DIGICERT_UPDATE_USER",
@@ -77371,7 +77371,7 @@
       {
         "slug": "BOX_COPY_FILE_REQUEST",
         "name": "Copy file request",
-        "description": "Copies an existing file request to a new folder. File requests allow external users to upload files to a specific folder without needing a Box account. This action creates a copy of an existing file request and associates it with a different destination folder. IMPORTANT LIMITATION: File request IDs cannot be discovered via API - they can only be obtained from the Box web application. To find a file_request_id: 1. Navigate to Box web UI (https://app.box.com) 2. Go to the folder containing the file request 3. Open the file request settings 4. Copy the ID from the URL (e.g., https://*.app.box.com/filerequest/123 → ID is \"123\") Common use cases: - Creating file request templates that can be copied to multiple project folders - Automating file request creation for new cases/customers/projects - Duplicating file requests with different settings (title, description, etc.) When copying, you can optionally override settings from the source file request including title, description, status, and form requirements."
+        "description": "Copies an existing file request to a new folder. File requests allow external users to upload files to a specific folder without needing a Box account. This action creates a copy of an existing file request and associates it with a different destination folder. IMPORTANT LIMITATION: File request IDs cannot be discovered via API - they can only be obtained from the Box web application. To find a file_request_id: 1. Navigate to Box web UI (https://app.box.com) 2. Go to the folder containing the file request 3. Open the file request settings 4. Copy the ID from the URL (e.g., https://*.app.box.com/filerequest/123 \u2192 ID is \"123\") Common use cases: - Creating file request templates that can be copied to multiple project folders - Automating file request creation for new cases/customers/projects - Duplicating file requests with different settings (title, description, etc.) When copying, you can optionally override settings from the source file request including title, description, status, and form requirements."
       },
       {
         "slug": "BOX_COPY_FOLDER",
@@ -77611,7 +77611,7 @@
       {
         "slug": "BOX_DELETE_FILE_REQUEST",
         "name": "Delete file request",
-        "description": "Deletes a file request permanently. File requests allow external users to upload files to a specific folder without needing a Box account. This action permanently deletes a file request. IMPORTANT LIMITATION: File request IDs cannot be discovered via API - they can only be obtained from the Box web application. To find a file_request_id: 1. Navigate to Box web UI (https://app.box.com) 2. Go to the folder containing the file request 3. Open the file request settings 4. Copy the ID from the URL (e.g., https://*.app.box.com/filerequest/123 → ID is \"123\") **Response:** Returns HTTP 204 No Content on success (empty response body). **Common Use Cases:** - Removing file requests that are no longer needed - Cleaning up expired or inactive file requests - Managing file request lifecycle programmatically **Note:** This operation is permanent and cannot be undone. The file request will be deleted immediately, but any files that were already uploaded through the file request will remain in the destination folder."
+        "description": "Deletes a file request permanently. File requests allow external users to upload files to a specific folder without needing a Box account. This action permanently deletes a file request. IMPORTANT LIMITATION: File request IDs cannot be discovered via API - they can only be obtained from the Box web application. To find a file_request_id: 1. Navigate to Box web UI (https://app.box.com) 2. Go to the folder containing the file request 3. Open the file request settings 4. Copy the ID from the URL (e.g., https://*.app.box.com/filerequest/123 \u2192 ID is \"123\") **Response:** Returns HTTP 204 No Content on success (empty response body). **Common Use Cases:** - Removing file requests that are no longer needed - Cleaning up expired or inactive file requests - Managing file request lifecycle programmatically **Note:** This operation is permanent and cannot be undone. The file request will be deleted immediately, but any files that were already uploaded through the file request will remain in the destination folder."
       },
       {
         "slug": "BOX_DELETE_FILE_VERSION",
@@ -79308,7 +79308,7 @@
       {
         "slug": "PRODUCTBOARD_LIST_FEATURE_RELEASE_ASSIGNMENTS",
         "name": "List Feature Release Assignments",
-        "description": "Tool to list feature–release assignments. Use when you need to retrieve assignments for a specific feature or release with optional state or date filters; paginate using links.next."
+        "description": "Tool to list feature\u2013release assignments. Use when you need to retrieve assignments for a specific feature or release with optional state or date filters; paginate using links.next."
       },
       {
         "slug": "PRODUCTBOARD_LIST_FEATURE_STATUSES",
@@ -80225,7 +80225,7 @@
   {
     "slug": "flutterwave",
     "name": "Flutterwave",
-    "logo": "https://flutterwave.com/favicon.ico",
+    "logo": "https://logos.composio.dev/api/flutterwave",
     "description": "Flutterwave is a payments technology company that provides payment infrastructure and APIs enabling businesses to accept and send payments in Africa and globally.",
     "category": "payment processing",
     "authSchemes": [
@@ -80368,7 +80368,7 @@
       {
         "slug": "FLUTTERWAVE_GET_PAYMENT_PLANS",
         "name": "Get Payment Plans",
-        "description": "Tool to retrieve a list of all payment plans. Use when you need to fetch and present your account’s configured billing plans."
+        "description": "Tool to retrieve a list of all payment plans. Use when you need to fetch and present your account\u2019s configured billing plans."
       },
       {
         "slug": "FLUTTERWAVE_GET_REFUND",
@@ -80772,7 +80772,7 @@
   {
     "slug": "screenshotone",
     "name": "ScreenshotOne",
-    "logo": "https://screenshotone.com/logo.png",
+    "logo": "https://logos.composio.dev/api/screenshotone",
     "description": "ScreenshotOne is a screenshot API for developers, enabling the rendering of website screenshots through simple API calls without managing browser clusters.",
     "category": "developer tools",
     "authSchemes": [
@@ -85344,7 +85344,7 @@
       {
         "slug": "GOOGLE_ANALYTICS_GET_METADATA",
         "name": "Get Metadata",
-        "description": "Tool to get metadata for dimensions, metrics, and comparisons for a GA4 property. Use to discover available fields before building a report — always derive dimension/metric apiNames from this output rather than hardcoding from GA4 UI labels, which differ. Available fields vary per property; skip validation and downstream report tools like GOOGLE_ANALYTICS_RUN_REPORT return 400 INVALID_ARGUMENT on incompatible or invalid field combinations. Response can contain hundreds of fields; filter to relevant subset before passing to downstream logic."
+        "description": "Tool to get metadata for dimensions, metrics, and comparisons for a GA4 property. Use to discover available fields before building a report \u2014 always derive dimension/metric apiNames from this output rather than hardcoding from GA4 UI labels, which differ. Available fields vary per property; skip validation and downstream report tools like GOOGLE_ANALYTICS_RUN_REPORT return 400 INVALID_ARGUMENT on incompatible or invalid field combinations. Response can contain hundreds of fields; filter to relevant subset before passing to downstream logic."
       },
       {
         "slug": "GOOGLE_ANALYTICS_GET_PROPERTY",
@@ -85768,7 +85768,7 @@
       {
         "slug": "TODOIST_GET_ALL_PROJECTS",
         "name": "Get all projects",
-        "description": "Get all projects from a user's Todoist account. Retrieves all active (non-archived) projects; use TODOIST_LIST_ARCHIVED_WORKSPACE_PROJECTS for archived ones. Response nests the list under data.projects, with fields including project_id, name, color, parent project, sharing status, and is_inbox_project flag. Always reference projects by project_id — names are non-unique and may be localized. Detect the Inbox via is_inbox_project, not by name. Results are a point-in-time snapshot; re-call after structural changes before relying on cached project_ids. In large accounts, paginate until no next-page token remains to avoid missing projects. Check existing projects before creating new ones to prevent duplicates."
+        "description": "Get all projects from a user's Todoist account. Retrieves all active (non-archived) projects; use TODOIST_LIST_ARCHIVED_WORKSPACE_PROJECTS for archived ones. Response nests the list under data.projects, with fields including project_id, name, color, parent project, sharing status, and is_inbox_project flag. Always reference projects by project_id \u2014 names are non-unique and may be localized. Detect the Inbox via is_inbox_project, not by name. Results are a point-in-time snapshot; re-call after structural changes before relying on cached project_ids. In large accounts, paginate until no next-page token remains to avoid missing projects. Check existing projects before creating new ones to prevent duplicates."
       },
       {
         "slug": "TODOIST_GET_ALL_TASKS",
@@ -85778,7 +85778,7 @@
       {
         "slug": "TODOIST_GET_BACKUPS",
         "name": "Get Backups",
-        "description": "Tool to list all available backup archives for the user. Returns archive metadata only — not live task or project data; do not use as a proxy for active data availability. May return an empty list if no backups exist or backups are not enabled. For completed task history, use /sync/v9/completed/get_all instead."
+        "description": "Tool to list all available backup archives for the user. Returns archive metadata only \u2014 not live task or project data; do not use as a proxy for active data availability. May return an empty list if no backups exist or backups are not enabled. For completed task history, use /sync/v9/completed/get_all instead."
       },
       {
         "slug": "TODOIST_GET_COMMENT_V1",
@@ -85808,7 +85808,7 @@
       {
         "slug": "TODOIST_GET_PROJECT",
         "name": "Get Project (API v1)",
-        "description": "Tool to retrieve a specific project by its ID using Todoist API v1. Use when you have a project ID and need its metadata before display or update. Verify project_id matches the intended project before destructive operations — similar project names can cause mistakes; use TODOIST_GET_ALL_PROJECTS to resolve ambiguous names to IDs first."
+        "description": "Tool to retrieve a specific project by its ID using Todoist API v1. Use when you have a project ID and need its metadata before display or update. Verify project_id matches the intended project before destructive operations \u2014 similar project names can cause mistakes; use TODOIST_GET_ALL_PROJECTS to resolve ambiguous names to IDs first."
       },
       {
         "slug": "TODOIST_GET_PROJECT_FULL",
@@ -85828,7 +85828,7 @@
       {
         "slug": "TODOIST_GET_SPECIAL_BACKUPS",
         "name": "Get Special Backups",
-        "description": "Tool to list special backup archives for the authenticated user's projects. Returns an empty list if no backups exist — callers must not assume archives are present. Read-only: confirms archive visibility only, not live task or project data access."
+        "description": "Tool to list special backup archives for the authenticated user's projects. Returns an empty list if no backups exist \u2014 callers must not assume archives are present. Read-only: confirms archive visibility only, not live task or project data access."
       },
       {
         "slug": "TODOIST_GET_TASK",
@@ -86853,7 +86853,7 @@
       {
         "slug": "ASHBY_SET_OPENING_OPENING_STATE",
         "name": "Set Opening State",
-        "description": "Set the workflow state of an opening (job requisition). Use this to transition an opening between states: Draft, Approved, Open, or Closed. Important notes: - When setting state to 'Closed', you must provide a closeReasonId (use LIST_CLOSE_REASONS to get valid IDs) - Not all state transitions are allowed by Ashby's workflow rules; the API will return an error for invalid transitions - Common valid transitions: Open ↔ Closed, Approved → Open - Returns the updated opening details including the new state, timestamps, and close reason if applicable"
+        "description": "Set the workflow state of an opening (job requisition). Use this to transition an opening between states: Draft, Approved, Open, or Closed. Important notes: - When setting state to 'Closed', you must provide a closeReasonId (use LIST_CLOSE_REASONS to get valid IDs) - Not all state transitions are allowed by Ashby's workflow rules; the API will return an error for invalid transitions - Common valid transitions: Open \u2194 Closed, Approved \u2192 Open - Returns the updated opening details including the new state, timestamps, and close reason if applicable"
       },
       {
         "slug": "ASHBY_START_OFFER",
@@ -92328,7 +92328,7 @@
     "slug": "yandex",
     "name": "Yandex",
     "logo": "https://logos.composio.dev/api/yandex",
-    "description": "Yandex is a Russian internet services provider offering search, email, navigation, and other web-based solutions, often referred to as “Russia’s Google”",
+    "description": "Yandex is a Russian internet services provider offering search, email, navigation, and other web-based solutions, often referred to as \u201cRussia\u2019s Google\u201d",
     "category": "email",
     "authSchemes": [
       "OAUTH2"
@@ -94836,7 +94836,7 @@
       {
         "slug": "BITWARDEN_UPDATE_MEMBER",
         "name": "Update Member",
-        "description": "Tool to update an organization member’s admin status. Use when toggling admin privileges for an existing member."
+        "description": "Tool to update an organization member\u2019s admin status. Use when toggling admin privileges for an existing member."
       }
     ],
     "triggers": [],
@@ -94872,7 +94872,7 @@
                 "name": "client_id",
                 "displayName": "Client ID",
                 "type": "string",
-                "description": "The organization API key client ID from Bitwarden Admin Console → Settings → Organization info (format: organization.{UUID}).",
+                "description": "The organization API key client ID from Bitwarden Admin Console \u2192 Settings \u2192 Organization info (format: organization.{UUID}).",
                 "required": true,
                 "default": null
               },
@@ -95032,7 +95032,7 @@
       {
         "slug": "EPIC_GAMES_PUT_PRESET_PROPERTY",
         "name": "Update Preset Property",
-        "description": "Tool to update a property exposed through a Remote Control Preset. Use when you need to change the value of a preset’s property after inspecting its metadata."
+        "description": "Tool to update a property exposed through a Remote Control Preset. Use when you need to change the value of a preset\u2019s property after inspecting its metadata."
       },
       {
         "slug": "EPIC_GAMES_PUT_REMOTE_BATCH",
@@ -95499,7 +95499,7 @@
       {
         "slug": "GUMROAD_GET_SALES",
         "name": "Get Sales",
-        "description": "Tool to retrieve all successful sales by the authenticated user; excludes failed charges, abandoned carts, and page views — conversion rates cannot be derived from this data. Use when you need to list your Gumroad sales, optionally filtering by email, date range, product, or pagination. For high sales volumes, combine product_id and/or after/before filters with page to avoid large unfiltered result sets."
+        "description": "Tool to retrieve all successful sales by the authenticated user; excludes failed charges, abandoned carts, and page views \u2014 conversion rates cannot be derived from this data. Use when you need to list your Gumroad sales, optionally filtering by email, date range, product, or pagination. For high sales volumes, combine product_id and/or after/before filters with page to avoid large unfiltered result sets."
       },
       {
         "slug": "GUMROAD_GET_USER",
@@ -96495,7 +96495,7 @@
       {
         "slug": "DATAGMA_DETECT_JOB_CHANGE",
         "name": "Detect Job Change",
-        "description": "Tool to detect if a contact changed jobs. Use when verifying a contact’s current employment details by email."
+        "description": "Tool to detect if a contact changed jobs. Use when verifying a contact\u2019s current employment details by email."
       },
       {
         "slug": "DATAGMA_ENRICH_PERSON_OR_COMPANY",
@@ -97236,7 +97236,7 @@
       {
         "slug": "CLOUDFLARE_LIST_ZONES",
         "name": "List Zones",
-        "description": "Lists, searches, sorts, and filters zones in the authenticated account. Use `page`/`per_page` to paginate; check `result_info.total_pages` in the response to iterate all pages. Does not return DNS records — extract `zone_id` from results before passing to zone-scoped tools (DNS, firewall, etc.). Only zones delegated to Cloudflare nameservers appear; empty results indicate scope or delegation constraints, not errors."
+        "description": "Lists, searches, sorts, and filters zones in the authenticated account. Use `page`/`per_page` to paginate; check `result_info.total_pages` in the response to iterate all pages. Does not return DNS records \u2014 extract `zone_id` from results before passing to zone-scoped tools (DNS, firewall, etc.). Only zones delegated to Cloudflare nameservers appear; empty results indicate scope or delegation constraints, not errors."
       },
       {
         "slug": "CLOUDFLARE_UPDATE_DNS_RECORD",
@@ -97863,7 +97863,7 @@
       {
         "slug": "XERO_GET_BALANCE_SHEET_REPORT",
         "name": "Get Balance Sheet Report",
-        "description": "Retrieve Balance Sheet report from Xero. Shows assets, liabilities, and equity at a specific date. Liability and credit balances appear as negative numbers in the response. Response structure is Reports → Rows → Sections; account lines are nested inside group sections and summary totals (e.g., 'Total Current Assets') appear in SummaryRows."
+        "description": "Retrieve Balance Sheet report from Xero. Shows assets, liabilities, and equity at a specific date. Liability and credit balances appear as negative numbers in the response. Response structure is Reports \u2192 Rows \u2192 Sections; account lines are nested inside group sections and summary totals (e.g., 'Total Current Assets') appear in SummaryRows."
       },
       {
         "slug": "XERO_GET_BUDGET",
@@ -97873,7 +97873,7 @@
       {
         "slug": "XERO_GET_CONNECTIONS",
         "name": "Get Connections",
-        "description": "Tool to list active Xero connections. Use to retrieve all current tenant connections for the authenticated user and resolve the correct tenant_id before making data requests. When multiple tenants are returned, never assume the first connection is correct — always explicitly pass the intended tenant_id to every subsequent call. Using a wrong or stale tenant_id can silently return or modify data for a different organisation."
+        "description": "Tool to list active Xero connections. Use to retrieve all current tenant connections for the authenticated user and resolve the correct tenant_id before making data requests. When multiple tenants are returned, never assume the first connection is correct \u2014 always explicitly pass the intended tenant_id to every subsequent call. Using a wrong or stale tenant_id can silently return or modify data for a different organisation."
       },
       {
         "slug": "XERO_GET_CONTACTS",
@@ -97903,7 +97903,7 @@
       {
         "slug": "XERO_GET_PROFIT_LOSS_REPORT",
         "name": "Get Profit & Loss Report",
-        "description": "Retrieve Profit & Loss report from Xero. Shows income, expenses, and net profit for a specified period. Response rows are labeled (e.g., 'Net Profit', SummaryRow); parse by row label, not array index. Aggregates multiple tax codes — not suitable for tax compliance reporting."
+        "description": "Retrieve Profit & Loss report from Xero. Shows income, expenses, and net profit for a specified period. Response rows are labeled (e.g., 'Net Profit', SummaryRow); parse by row label, not array index. Aggregates multiple tax codes \u2014 not suitable for tax compliance reporting."
       },
       {
         "slug": "XERO_GET_PROJECT",
@@ -97973,7 +97973,7 @@
       {
         "slug": "XERO_LIST_JOURNALS",
         "name": "List Journals",
-        "description": "Retrieve journals from Xero. Journals show the accounting entries for all transactions. Omitting filters returns the full historical journal ledger and can produce very large responses — use If-Modified-Since and/or paymentsOnly to narrow scope. No date range filter parameter exists. Results are returned inside a Journals array field."
+        "description": "Retrieve journals from Xero. Journals show the accounting entries for all transactions. Omitting filters returns the full historical journal ledger and can produce very large responses \u2014 use If-Modified-Since and/or paymentsOnly to narrow scope. No date range filter parameter exists. Results are returned inside a Journals array field."
       },
       {
         "slug": "XERO_LIST_MANUAL_JOURNALS",
@@ -97998,7 +97998,7 @@
       {
         "slug": "XERO_LIST_TAX_RATES",
         "name": "List Tax Rates",
-        "description": "Retrieve tax rates from Xero. Shows available tax codes and rates for the organization. Use returned tax codes as valid `TaxType` values in other tools — invalid values cause ValidationException errors."
+        "description": "Retrieve tax rates from Xero. Shows available tax codes and rates for the organization. Use returned tax codes as valid `TaxType` values in other tools \u2014 invalid values cause ValidationException errors."
       },
       {
         "slug": "XERO_LIST_TRACKING_CATEGORIES",
@@ -99770,7 +99770,7 @@
       {
         "slug": "ZOHO_MAIL_ACCOUNTS_LIST_ACCOUNTS",
         "name": "List Zoho Mail Accounts",
-        "description": "Retrieves all Zoho Mail accounts associated with the authenticated user. Returns account details including accountId (required for other mail operations), email addresses, storage information, account status, user preferences, and security settings. Use this action first to get the accountId needed for subsequent mailbox, message, folder, and email operations. The accountId is a unique identifier for each mail account. Typical workflow: List accounts → Get accountId → Use accountId in other mail operations."
+        "description": "Retrieves all Zoho Mail accounts associated with the authenticated user. Returns account details including accountId (required for other mail operations), email addresses, storage information, account status, user preferences, and security settings. Use this action first to get the accountId needed for subsequent mailbox, message, folder, and email operations. The accountId is a unique identifier for each mail account. Typical workflow: List accounts \u2192 Get accountId \u2192 Use accountId in other mail operations."
       },
       {
         "slug": "ZOHO_MAIL_DOMAIN_OPERATIONS",
@@ -99820,7 +99820,7 @@
       {
         "slug": "ZOHO_MAIL_ORGANIZATION_GET_USER_STORAGE_DETAILS",
         "name": "Get Organization User Storage Details",
-        "description": "Tool to retrieve storage details for a specific user in the organization. Use when you need to know a user’s total and used storage quotas."
+        "description": "Tool to retrieve storage details for a specific user in the organization. Use when you need to know a user\u2019s total and used storage quotas."
       },
       {
         "slug": "ZOHO_MAIL_ORGANIZATION_UPDATE_SPAM_PROCESS_TYPE",
@@ -100305,7 +100305,7 @@
       {
         "slug": "BREX_GET_TRANSACTIONS",
         "name": "Get Card Transactions",
-        "description": "Get card transactions from the primary Brex account. Retrieves settled card transactions including purchases, refunds, chargebacks, and collections. Returns transaction details with merchant information, amounts, dates, and associated metadata. Supports pagination for handling large result sets. Note: The Brex API does not support server-side date filtering. Date filtering (posted_at_start/posted_at_end) is performed client-side by filtering the posted_at_date field in the response. When using date filters, paginate through all pages by following next_cursor until exhausted before applying date range filtering locally — stopping early will cause in-range transactions to be missed."
+        "description": "Get card transactions from the primary Brex account. Retrieves settled card transactions including purchases, refunds, chargebacks, and collections. Returns transaction details with merchant information, amounts, dates, and associated metadata. Supports pagination for handling large result sets. Note: The Brex API does not support server-side date filtering. Date filtering (posted_at_start/posted_at_end) is performed client-side by filtering the posted_at_date field in the response. When using date filters, paginate through all pages by following next_cursor until exhausted before applying date range filtering locally \u2014 stopping early will cause in-range transactions to be missed."
       },
       {
         "slug": "BREX_GET_TRANSACTIONS_BY_AMOUNT_RANGE",
@@ -100687,7 +100687,7 @@
       {
         "slug": "INTERCOM_CLOSE_CONVERSATION",
         "name": "Close conversation",
-        "description": "Closes a conversation in Intercom, marking it as resolved. Requires explicit user confirmation before calling; closing is irreversible without a separate reopen action. Send any reply via INTERCOM_REPLY_TO_CONVERSATION before calling this tool — parallel execution on the same conversation causes conflicts."
+        "description": "Closes a conversation in Intercom, marking it as resolved. Requires explicit user confirmation before calling; closing is irreversible without a separate reopen action. Send any reply via INTERCOM_REPLY_TO_CONVERSATION before calling this tool \u2014 parallel execution on the same conversation causes conflicts."
       },
       {
         "slug": "INTERCOM_CREATE_A_COLLECTION",
@@ -100717,7 +100717,7 @@
       {
         "slug": "INTERCOM_CREATE_CONVERSATION",
         "name": "Create conversation",
-        "description": "Creates a new conversation in Intercom. Requires exactly one of from_user_id or from_contact_id — both are schema-optional but at least one must be provided."
+        "description": "Creates a new conversation in Intercom. Requires exactly one of from_user_id or from_contact_id \u2014 both are schema-optional but at least one must be provided."
       },
       {
         "slug": "INTERCOM_CREATE_DATA_ATTRIBUTE",
@@ -100742,7 +100742,7 @@
       {
         "slug": "INTERCOM_CREATE_HELP_CENTER_SECTION",
         "name": "Create help center section",
-        "description": "Tool to create a new help center section within a collection. Use when you need to add a new section to organize articles in the help center hierarchy (Help Center → Collections → Sections → Articles). Supports multilingual content via translated_content parameter."
+        "description": "Tool to create a new help center section within a collection. Use when you need to add a new section to organize articles in the help center hierarchy (Help Center \u2192 Collections \u2192 Sections \u2192 Articles). Supports multilingual content via translated_content parameter."
       },
       {
         "slug": "INTERCOM_CREATE_INTERNAL_ARTICLE",
@@ -100877,7 +100877,7 @@
       {
         "slug": "INTERCOM_GET_CONVERSATION",
         "name": "Get conversation",
-        "description": "Retrieves a specific conversation by ID with all messages and details. Key response caveats: `conversation_parts` are paginated — walk all cursors for complete transcripts. Fields `title`, `subject`, `source.body`, `conversation_parts.body`, `statistics`, and some contact properties can be null. System/workflow events appear in `conversation_parts` with null `body` or `author`; `first_admin_reply_at` may be null despite actual replies — use `last_admin_reply_at` for SLA calculations. Attachment URLs in `conversation_parts` are short-lived — download promptly. The `state` field and `open` boolean can diverge — re-fetch to verify state before assign/reply/close actions. Timestamps are Unix epoch seconds UTC. Use this tool (not INTERCOM_SEARCH_CONVERSATIONS) when full message context is required."
+        "description": "Retrieves a specific conversation by ID with all messages and details. Key response caveats: `conversation_parts` are paginated \u2014 walk all cursors for complete transcripts. Fields `title`, `subject`, `source.body`, `conversation_parts.body`, `statistics`, and some contact properties can be null. System/workflow events appear in `conversation_parts` with null `body` or `author`; `first_admin_reply_at` may be null despite actual replies \u2014 use `last_admin_reply_at` for SLA calculations. Attachment URLs in `conversation_parts` are short-lived \u2014 download promptly. The `state` field and `open` boolean can diverge \u2014 re-fetch to verify state before assign/reply/close actions. Timestamps are Unix epoch seconds UTC. Use this tool (not INTERCOM_SEARCH_CONVERSATIONS) when full message context is required."
       },
       {
         "slug": "INTERCOM_GET_COUNTS",
@@ -100907,7 +100907,7 @@
       {
         "slug": "INTERCOM_IDENTIFY_AN_ADMIN",
         "name": "Identify an admin",
-        "description": "You can view the currently authorised admin along with the embedded app object (a \"workspace\" in legacy terminology). > 🚧 Single Sign On > > If you are building a custom \"Log in with Intercom\" flow for your site, and you call the `/me` endpoint to identify the logged-in user, you should not accept any sign-ins from users with unverified email addresses as it poses a potential impersonation security risk."
+        "description": "You can view the currently authorised admin along with the embedded app object (a \"workspace\" in legacy terminology). > \ud83d\udea7 Single Sign On > > If you are building a custom \"Log in with Intercom\" flow for your site, and you call the `/me` endpoint to identify the logged-in user, you should not accept any sign-ins from users with unverified email addresses as it poses a potential impersonation security risk."
       },
       {
         "slug": "INTERCOM_JOBS_STATUS",
@@ -100927,7 +100927,7 @@
       {
         "slug": "INTERCOM_LIST_ALL_ARTICLES",
         "name": "List all articles",
-        "description": "You can fetch a list of all articles by making a GET request to `https://api.intercom.io/articles`. > 📘 How are the articles sorted and ordered? > > Articles will be returned in descending order on the `updated_at` attribute. This means if you need to iterate through results then we'll show the most recently updated articles first."
+        "description": "You can fetch a list of all articles by making a GET request to `https://api.intercom.io/articles`. > \ud83d\udcd8 How are the articles sorted and ordered? > > Articles will be returned in descending order on the `updated_at` attribute. This means if you need to iterate through results then we'll show the most recently updated articles first."
       },
       {
         "slug": "INTERCOM_LIST_ALL_COLLECTIONS",
@@ -101027,7 +101027,7 @@
       {
         "slug": "INTERCOM_LIST_HELP_CENTER_SECTIONS",
         "name": "List help center sections",
-        "description": "Tool to fetch a list of all help center sections in descending order by updated_at. Use when you need to retrieve sections from the help center hierarchy (Help Center → Collections → Sections → Articles)."
+        "description": "Tool to fetch a list of all help center sections in descending order by updated_at. Use when you need to retrieve sections from the help center hierarchy (Help Center \u2192 Collections \u2192 Sections \u2192 Articles)."
       },
       {
         "slug": "INTERCOM_LIST_INTERNAL_ARTICLES",
@@ -101112,7 +101112,7 @@
       {
         "slug": "INTERCOM_REPLY_TO_CONVERSATION",
         "name": "Reply to conversation",
-        "description": "Sends a reply to an existing conversation in Intercom. Always send reply before closing a conversation — never parallelize with INTERCOM_CLOSE_CONVERSATION on the same conversation. Verify conversation state via INTERCOM_GET_CONVERSATION before replying, as open/snoozed/closed states may diverge from cached values."
+        "description": "Sends a reply to an existing conversation in Intercom. Always send reply before closing a conversation \u2014 never parallelize with INTERCOM_CLOSE_CONVERSATION on the same conversation. Verify conversation state via INTERCOM_GET_CONVERSATION before replying, as open/snoozed/closed states may diverge from cached values."
       },
       {
         "slug": "INTERCOM_RETRIEVE_A_COLLECTION",
@@ -101908,7 +101908,7 @@
     "slug": "beeminder",
     "name": "Beeminder",
     "logo": "https://logos.composio.dev/api/beeminder",
-    "description": "Beeminder is an online goal-tracking service that uses financial incentives—pledge money on your objectives and forfeit it if you don’t keep up—to help you achieve your goals.",
+    "description": "Beeminder is an online goal-tracking service that uses financial incentives\u2014pledge money on your objectives and forfeit it if you don\u2019t keep up\u2014to help you achieve your goals.",
     "category": "task management",
     "authSchemes": [
       "API_KEY",
@@ -102008,7 +102008,7 @@
                 "name": "bearer_token",
                 "displayName": "Beeminder Personal Auth Token",
                 "type": "string",
-                "description": "Your personal Beeminder API auth token, obtainable from Account Settings → Apps & API in your Beeminder account.",
+                "description": "Your personal Beeminder API auth token, obtainable from Account Settings \u2192 Apps & API in your Beeminder account.",
                 "required": true,
                 "default": null
               }
@@ -102241,7 +102241,7 @@
       {
         "slug": "INTERZOID_GET_ORG_MATCH_SCORE",
         "name": "Get Org Match Score",
-        "description": "Tool to return a 1–99 match score between two organization names. Use after gathering both names to evaluate organization similarity."
+        "description": "Tool to return a 1\u201399 match score between two organization names. Use after gathering both names to evaluate organization similarity."
       },
       {
         "slug": "INTERZOID_GET_ORG_STANDARD",
@@ -104351,7 +104351,7 @@
       {
         "slug": "DATADOG_LIST_EVENTS",
         "name": "List events",
-        "description": "Lists events from Datadog within a specified time range. Events track important occurrences like deployments, outages, and configuration changes. Combining multiple filters (tags, sources, priority) with narrow time ranges may return empty results even when events exist — start with broad filters and narrow incrementally. Large time ranges with minimal filtering can return very high event volumes; tune tags, sources, and start/end before processing results."
+        "description": "Lists events from Datadog within a specified time range. Events track important occurrences like deployments, outages, and configuration changes. Combining multiple filters (tags, sources, priority) with narrow time ranges may return empty results even when events exist \u2014 start with broad filters and narrow incrementally. Large time ranges with minimal filtering can return very high event volumes; tune tags, sources, and start/end before processing results."
       },
       {
         "slug": "DATADOG_LIST_HOSTS",
@@ -106392,7 +106392,7 @@
       {
         "slug": "ADYNTEL_GET_GOOGLE_ADS_BY_COMPANY",
         "name": "Get Google Ads By Company",
-        "description": "Retrieve Google ads for a company domain. Returns ad creatives including text, image, and video ads with advertiser information. Response includes a `total_ad_count` field that typically exceeds the count of ads in the returned `ads` array — a single call returns only a partial slice of all available ads."
+        "description": "Retrieve Google ads for a company domain. Returns ad creatives including text, image, and video ads with advertiser information. Response includes a `total_ad_count` field that typically exceeds the count of ads in the returned `ads` array \u2014 a single call returns only a partial slice of all available ads."
       },
       {
         "slug": "ADYNTEL_GET_GOOGLE_SHOPPING_SEARCH_STATUS",
@@ -108560,7 +108560,7 @@
       {
         "slug": "ALGOLIA_GET_OBJECT_POSITION",
         "name": "Get Object Position",
-        "description": "Tool to retrieve an object’s position in a result set. Use when debugging relevance after performing a search query."
+        "description": "Tool to retrieve an object\u2019s position in a result set. Use when debugging relevance after performing a search query."
       },
       {
         "slug": "ALGOLIA_GET_OBJECTS",
@@ -109090,7 +109090,7 @@
       {
         "slug": "ALPHA_VANTAGE_COMPANY_OVERVIEW",
         "name": "Company Overview (Stocks Only)",
-        "description": "Tool to retrieve company overview and fundamental data for individual company stocks. Note: This endpoint only works for stocks, not ETFs, mutual funds, or indices. Use after specifying a valid stock ticker symbol. Numeric fields (e.g., MarketCapitalization, SharesOutstanding, Beta, DividendYield, PERatio) are returned as strings and may be empty — treat empty/missing values as null, not zero. Fundamentals such as Beta, PERatio, and PayoutRatio may reflect different reporting periods across symbols; avoid naive cross-symbol aggregation without aligning periods. Check the as-of date in the response; SharesOutstanding and similar fields can lag corporate actions. Alpha Vantage enforces per-minute and per-day rate caps; throttle requests when processing bulk symbol lists."
+        "description": "Tool to retrieve company overview and fundamental data for individual company stocks. Note: This endpoint only works for stocks, not ETFs, mutual funds, or indices. Use after specifying a valid stock ticker symbol. Numeric fields (e.g., MarketCapitalization, SharesOutstanding, Beta, DividendYield, PERatio) are returned as strings and may be empty \u2014 treat empty/missing values as null, not zero. Fundamentals such as Beta, PERatio, and PayoutRatio may reflect different reporting periods across symbols; avoid naive cross-symbol aggregation without aligning periods. Check the as-of date in the response; SharesOutstanding and similar fields can lag corporate actions. Alpha Vantage enforces per-minute and per-day rate caps; throttle requests when processing bulk symbol lists."
       },
       {
         "slug": "ALPHA_VANTAGE_COPPER",
@@ -109120,7 +109120,7 @@
       {
         "slug": "ALPHA_VANTAGE_CURRENCY_EXCHANGE_RATE",
         "name": "Currency Exchange Rate",
-        "description": "Tool to retrieve real-time exchange rate for a currency pair. Use after confirming base and quote currency codes to get current rates. Rate is nested at response['Realtime Currency Exchange Rate']['5. Exchange Rate'] as a string; cast to float before calculations. Treat missing key or '0.00000000' as unavailable. On free-tier keys, throttling returns HTTP 200 with 'Information' or 'Note' field instead of data — inspect response body before parsing. Free-tier limits: ~5 requests/minute, ~25 requests/day. For historical or intraday data use ALPHA_VANTAGE_FX_DAILY or TWELVE_DATA_TIME_SERIES."
+        "description": "Tool to retrieve real-time exchange rate for a currency pair. Use after confirming base and quote currency codes to get current rates. Rate is nested at response['Realtime Currency Exchange Rate']['5. Exchange Rate'] as a string; cast to float before calculations. Treat missing key or '0.00000000' as unavailable. On free-tier keys, throttling returns HTTP 200 with 'Information' or 'Note' field instead of data \u2014 inspect response body before parsing. Free-tier limits: ~5 requests/minute, ~25 requests/day. For historical or intraday data use ALPHA_VANTAGE_FX_DAILY or TWELVE_DATA_TIME_SERIES."
       },
       {
         "slug": "ALPHA_VANTAGE_DIGITAL_CURRENCY_DAILY",
@@ -109130,7 +109130,7 @@
       {
         "slug": "ALPHA_VANTAGE_DIGITAL_CURRENCY_MONTHLY",
         "name": "Digital Currency Monthly Time Series",
-        "description": "Tool to retrieve monthly digital currency prices in a fiat currency. Use when needing long-term monthly OHLC and volume data for a given crypto/fiat pair. Always returns full history; no date range filtering — filter client-side. OHLCV response values are strings; convert to numeric types before calculations."
+        "description": "Tool to retrieve monthly digital currency prices in a fiat currency. Use when needing long-term monthly OHLC and volume data for a given crypto/fiat pair. Always returns full history; no date range filtering \u2014 filter client-side. OHLCV response values are strings; convert to numeric types before calculations."
       },
       {
         "slug": "ALPHA_VANTAGE_DIGITAL_CURRENCY_WEEKLY",
@@ -109145,7 +109145,7 @@
       {
         "slug": "ALPHA_VANTAGE_EARNINGS",
         "name": "Earnings",
-        "description": "Tool to retrieve annual and quarterly earnings (EPS history) for a specific company symbol. Free tier limit: ~25 requests/day, 1 request/second; an 'Information' key or empty array in the response indicates rate limit exhaustion or missing data — avoid parallel calls."
+        "description": "Tool to retrieve annual and quarterly earnings (EPS history) for a specific company symbol. Free tier limit: ~25 requests/day, 1 request/second; an 'Information' key or empty array in the response indicates rate limit exhaustion or missing data \u2014 avoid parallel calls."
       },
       {
         "slug": "ALPHA_VANTAGE_EARNINGS_CALENDAR",
@@ -109155,7 +109155,7 @@
       {
         "slug": "ALPHA_VANTAGE_EARNINGS_CALL_TRANSCRIPT",
         "name": "Earnings Call Transcript",
-        "description": "Tool to retrieve the earnings call transcript for a given company and quarter. Use after confirming symbol and quarter. Returns full transcript text and associated LLM-based sentiment signals. Transcripts may be unavailable for some quarters; verify available periods via ALPHA_VANTAGE_EARNINGS if response is empty. Free tier: ~25 requests/day, ~1 request/second — empty arrays or 'Information' messages may indicate rate limits rather than missing data; space out requests and avoid parallel calls. Transcripts can be very long; chunk or extract key sections before passing to an LLM."
+        "description": "Tool to retrieve the earnings call transcript for a given company and quarter. Use after confirming symbol and quarter. Returns full transcript text and associated LLM-based sentiment signals. Transcripts may be unavailable for some quarters; verify available periods via ALPHA_VANTAGE_EARNINGS if response is empty. Free tier: ~25 requests/day, ~1 request/second \u2014 empty arrays or 'Information' messages may indicate rate limits rather than missing data; space out requests and avoid parallel calls. Transcripts can be very long; chunk or extract key sections before passing to an LLM."
       },
       {
         "slug": "ALPHA_VANTAGE_FEDERAL_FUNDS_RATE",
@@ -109175,12 +109175,12 @@
       {
         "slug": "ALPHA_VANTAGE_FX_MONTHLY",
         "name": "FX Monthly Time Series",
-        "description": "Tool to get monthly time series (open, high, low, close) for a currency pair. Use when you need historical monthly forex data for a given currency pair. Data is returned in reverse-chronological order; OHLC values are strings and must be cast to numeric types before computations. The most recent entry may represent an incomplete period — treat its OHLC values as preliminary until the month closes."
+        "description": "Tool to get monthly time series (open, high, low, close) for a currency pair. Use when you need historical monthly forex data for a given currency pair. Data is returned in reverse-chronological order; OHLC values are strings and must be cast to numeric types before computations. The most recent entry may represent an incomplete period \u2014 treat its OHLC values as preliminary until the month closes."
       },
       {
         "slug": "ALPHA_VANTAGE_FX_WEEKLY",
         "name": "FX Weekly Time Series",
-        "description": "Tool to get weekly time series (open, high, low, close) for a currency pair. Use when you need weekly FX rates. Results are reverse-chronological; sort ascending and cast OHLC string values to numeric before computing indicators. The most recent entry may represent an incomplete week — treat its high, low, and close as provisional until the week closes."
+        "description": "Tool to get weekly time series (open, high, low, close) for a currency pair. Use when you need weekly FX rates. Results are reverse-chronological; sort ascending and cast OHLC string values to numeric before computing indicators. The most recent entry may represent an incomplete week \u2014 treat its high, low, and close as provisional until the week closes."
       },
       {
         "slug": "ALPHA_VANTAGE_GET_DIVIDENDS",
@@ -109205,7 +109205,7 @@
       {
         "slug": "ALPHA_VANTAGE_INCOME_STATEMENT",
         "name": "Income Statement",
-        "description": "Tool to fetch annual and quarterly income statements. Use after confirming the company symbol. Numeric fields may be returned as strings or empty values — convert safely and treat empty/missing as null, not zero, before computing derived metrics. Some symbols may be missing fields entirely; treat absent fields as missing data rather than defaults. One API call per symbol; when processing multiple symbols, retain only key derived fields rather than full raw responses."
+        "description": "Tool to fetch annual and quarterly income statements. Use after confirming the company symbol. Numeric fields may be returned as strings or empty values \u2014 convert safely and treat empty/missing as null, not zero, before computing derived metrics. Some symbols may be missing fields entirely; treat absent fields as missing data rather than defaults. One API call per symbol; when processing multiple symbols, retain only key derived fields rather than full raw responses."
       },
       {
         "slug": "ALPHA_VANTAGE_INFLATION",
@@ -109275,12 +109275,12 @@
       {
         "slug": "ALPHA_VANTAGE_SYMBOL_SEARCH",
         "name": "Symbol Search",
-        "description": "Tool to search for best-matching symbols based on keywords. Use when you need to find ticker symbols by a name or keyword. Returns multiple close matches — inspect the exchange, region, and currency fields in each result to select the correct symbol before passing it to downstream calls. Coverage excludes some exotic instruments and non-US assets; handle empty results explicitly."
+        "description": "Tool to search for best-matching symbols based on keywords. Use when you need to find ticker symbols by a name or keyword. Returns multiple close matches \u2014 inspect the exchange, region, and currency fields in each result to select the correct symbol before passing it to downstream calls. Coverage excludes some exotic instruments and non-US assets; handle empty results explicitly."
       },
       {
         "slug": "ALPHA_VANTAGE_TECHNICAL_INDICATOR",
         "name": "Technical Indicator",
-        "description": "Tool to fetch technical indicators for the specified equity or currency pair. Use after obtaining time series to compute moving averages or oscillators. Response body may contain 'Information' or 'Note' keys indicating errors or rate-limit signals — inspect payload before treating data as valid. Results are nested under a function-specific key (e.g., 'Technical Analysis: RSI') with values as strings; convert to numeric before calculations. No date range filtering supported; returns all available data points — filter client-side to the required window."
+        "description": "Tool to fetch technical indicators for the specified equity or currency pair. Use after obtaining time series to compute moving averages or oscillators. Response body may contain 'Information' or 'Note' keys indicating errors or rate-limit signals \u2014 inspect payload before treating data as valid. Results are nested under a function-specific key (e.g., 'Technical Analysis: RSI') with values as strings; convert to numeric before calculations. No date range filtering supported; returns all available data points \u2014 filter client-side to the required window."
       },
       {
         "slug": "ALPHA_VANTAGE_TIME_SERIES_DAILY",
@@ -109290,7 +109290,7 @@
       {
         "slug": "ALPHA_VANTAGE_TIME_SERIES_INTRADAY",
         "name": "Time Series Intraday",
-        "description": "Tool to retrieve intraday OHLCV for a given equity. Use when you need high-frequency pricing data within the trading day. Always inspect the JSON response body for 'Information' or 'Error Message' fields — the API may return these instead of data even on HTTP 200."
+        "description": "Tool to retrieve intraday OHLCV for a given equity. Use when you need high-frequency pricing data within the trading day. Always inspect the JSON response body for 'Information' or 'Error Message' fields \u2014 the API may return these instead of data even on HTTP 200."
       },
       {
         "slug": "ALPHA_VANTAGE_TIME_SERIES_INTRADAY_EXTENDED",
@@ -110023,7 +110023,7 @@
       {
         "slug": "ANCHOR_BROWSER_GET_WEBPAGE_CONTENT",
         "name": "Get Webpage Content",
-        "description": "Tool to retrieve rendered content of a webpage in HTML or Markdown format. Use when you need to fetch a page’s full content, optionally within an existing browser session."
+        "description": "Tool to retrieve rendered content of a webpage in HTML or Markdown format. Use when you need to fetch a page\u2019s full content, optionally within an existing browser session."
       },
       {
         "slug": "ANCHOR_BROWSER_LIST_AGENT_RESOURCES",
@@ -110148,7 +110148,7 @@
       {
         "slug": "ANCHOR_BROWSER_SCREENSHOT_WEBPAGE",
         "name": "Screenshot Webpage",
-        "description": "Tool to take a screenshot of a specified webpage within a session. Use when you need a visual PNG snapshot of a live page. Example: \"Capture a 1280×720 screenshot of https://example.com\"."
+        "description": "Tool to take a screenshot of a specified webpage within a session. Use when you need a visual PNG snapshot of a live page. Example: \"Capture a 1280\u00d7720 screenshot of https://example.com\"."
       },
       {
         "slug": "ANCHOR_BROWSER_SCROLL_SESSION",
@@ -111183,7 +111183,7 @@
       {
         "slug": "API_SPORTS_GET_FIXTURES",
         "name": "Get Fixtures",
-        "description": "Tool to retrieve football fixtures/matches. Use when filtering fixtures by id, date, league, season, team, or date ranges to get upcoming or past matches. Always provide at least one of season, date, team, or league to avoid oversized payloads. Never guess IDs — obtain valid league, season, team, or fixture IDs before calling this tool."
+        "description": "Tool to retrieve football fixtures/matches. Use when filtering fixtures by id, date, league, season, team, or date ranges to get upcoming or past matches. Always provide at least one of season, date, team, or league to avoid oversized payloads. Never guess IDs \u2014 obtain valid league, season, team, or fixture IDs before calling this tool."
       },
       {
         "slug": "API_SPORTS_GET_FIXTURES_EVENTS",
@@ -112017,7 +112017,7 @@
       {
         "slug": "APIFY_GET_ACTOR",
         "name": "Get Actor Details",
-        "description": "Tool to get details of a specific Actor. Use when you need actor metadata by ID or username/actorName. Response includes `isDeprecated` and `notice` fields indicating deprecation status, and `pricingInfos` for per-unit cost details — review both before scheduling runs."
+        "description": "Tool to get details of a specific Actor. Use when you need actor metadata by ID or username/actorName. Response includes `isDeprecated` and `notice` fields indicating deprecation status, and `pricingInfos` for per-unit cost details \u2014 review both before scheduling runs."
       },
       {
         "slug": "APIFY_GET_ACTOR_LAST_RUN_DATASET_ITEMS",
@@ -112047,7 +112047,7 @@
       {
         "slug": "APIFY_GET_LIST_OF_BUILDS",
         "name": "Get list of builds",
-        "description": "Tool to get a list of builds for a specific Actor. Use when you need paginated access to an Actor’s build (version) history."
+        "description": "Tool to get a list of builds for a specific Actor. Use when you need paginated access to an Actor\u2019s build (version) history."
       },
       {
         "slug": "APIFY_GET_LIST_OF_RUNS",
@@ -112072,7 +112072,7 @@
       {
         "slug": "APIFY_GET_LOG",
         "name": "Get log",
-        "description": "Tool to retrieve logs for a specific Actor run or build. Use after a run completes or fails — a run may report success status yet contain only informational messages, making log inspection the only way to confirm actual outcomes. For long runs, log responses can be very large; prioritize error-level entries and recent timestamps to diagnose issues efficiently."
+        "description": "Tool to retrieve logs for a specific Actor run or build. Use after a run completes or fails \u2014 a run may report success status yet contain only informational messages, making log inspection the only way to confirm actual outcomes. For long runs, log responses can be very large; prioritize error-level entries and recent timestamps to diagnose issues efficiently."
       },
       {
         "slug": "APIFY_GET_OPEN_API_DEFINITION",
@@ -112418,7 +112418,7 @@
       {
         "slug": "APIFY_MCP_GET_ACTOR_OUTPUT",
         "name": "Get-actor-output",
-        "description": "Retrieve the output dataset items of a specific Actor run using its datasetId.\nYou can select specific fields to return (supports dot notation like \"crawl.statusCode\") and paginate results with offset and limit.\nThis tool is a simplified version of the get-dataset-items tool, focused on Actor run outputs.\n\nThe results will include the dataset items from the specified dataset. If you provide fields, only those fields will be included (nested fields supported via dot notation).\n\nYou can obtain the datasetId from an Actor run (e.g., after calling an Actor with the call-actor tool) or from the Apify Console (Runs → Run details → Dataset ID).\n\nUSAGE:\n- Use when you need to read Actor output data (full items or selected fields), especially when preview does not include all fields.\n\nUSAGE EXAMPLES:\n- user_input: Get data of my last Actor run\n- user_input: Get number_of_likes from my dataset\n- user_input: Return only crawl.statusCode and url from dataset aab123\n\nNote: This tool is automatically included if the Apify MCP Server is configured with any Actor tools (e.g., \"apify-slash-rag-web-browser\") or tools that can interact with Actors (e.g., \"call-actor\", \"add-actor\")."
+        "description": "Retrieve the output dataset items of a specific Actor run using its datasetId.\nYou can select specific fields to return (supports dot notation like \"crawl.statusCode\") and paginate results with offset and limit.\nThis tool is a simplified version of the get-dataset-items tool, focused on Actor run outputs.\n\nThe results will include the dataset items from the specified dataset. If you provide fields, only those fields will be included (nested fields supported via dot notation).\n\nYou can obtain the datasetId from an Actor run (e.g., after calling an Actor with the call-actor tool) or from the Apify Console (Runs \u2192 Run details \u2192 Dataset ID).\n\nUSAGE:\n- Use when you need to read Actor output data (full items or selected fields), especially when preview does not include all fields.\n\nUSAGE EXAMPLES:\n- user_input: Get data of my last Actor run\n- user_input: Get number_of_likes from my dataset\n- user_input: Return only crawl.statusCode and url from dataset aab123\n\nNote: This tool is automatically included if the Apify MCP Server is configured with any Actor tools (e.g., \"apify-slash-rag-web-browser\") or tools that can interact with Actors (e.g., \"call-actor\", \"add-actor\")."
       },
       {
         "slug": "APIFY_MCP_GET_ACTOR_RUN",
@@ -112433,7 +112433,7 @@
       {
         "slug": "APIFY_MCP_SEARCH_APIFY_DOCS",
         "name": "Search-apify-docs",
-        "description": "Search Apify and Crawlee documentation using full-text search.\n\nYou must explicitly select which documentation source to search using the docSource parameter:\n\n• docSource=\"apify\" - Apify:\n  Apify Platform documentation including: Platform features, SDKs (JS, Python), CLI, REST API, Academy (web scraping fundamentals), Actor development and deployment\n\n• docSource=\"crawlee-js\" - Crawlee (JavaScript):\n  Crawlee is a web scraping library for JavaScript. It handles blocking, crawling, proxies, and browsers for you.\n\n• docSource=\"crawlee-py\" - Crawlee (Python):\n  Crawlee is a web scraping library for Python. It handles blocking, crawling, proxies, and browsers for you.\n\nThe results will include the URL of the documentation page (which may include an anchor),\nand a limited piece of content that matches the search query.\n\nFetch the full content of the document using the fetch-apify-docs tool by providing the URL."
+        "description": "Search Apify and Crawlee documentation using full-text search.\n\nYou must explicitly select which documentation source to search using the docSource parameter:\n\n\u2022 docSource=\"apify\" - Apify:\n  Apify Platform documentation including: Platform features, SDKs (JS, Python), CLI, REST API, Academy (web scraping fundamentals), Actor development and deployment\n\n\u2022 docSource=\"crawlee-js\" - Crawlee (JavaScript):\n  Crawlee is a web scraping library for JavaScript. It handles blocking, crawling, proxies, and browsers for you.\n\n\u2022 docSource=\"crawlee-py\" - Crawlee (Python):\n  Crawlee is a web scraping library for Python. It handles blocking, crawling, proxies, and browsers for you.\n\nThe results will include the URL of the documentation page (which may include an anchor),\nand a limited piece of content that matches the search query.\n\nFetch the full content of the document using the fetch-apify-docs tool by providing the URL."
       }
     ],
     "triggers": [],
@@ -113977,7 +113977,7 @@
       {
         "slug": "BART_GET_ROUTE_INFO",
         "name": "Get Route Info",
-        "description": "Tool to fetch detailed information about a specific BART route. Use when you know the route number (1–12) or need all routes configuration. Call after confirming the route ID."
+        "description": "Tool to fetch detailed information about a specific BART route. Use when you know the route number (1\u201312) or need all routes configuration. Call after confirming the route ID."
       },
       {
         "slug": "BART_GET_ROUTE_SCHEDULE",
@@ -117288,7 +117288,7 @@
       {
         "slug": "BENCHMARK_EMAIL_PATCH_SEND_RESET_EMAIL",
         "name": "Send Reset Email",
-        "description": "Tool to send a reset email link to change the primary email address. Use when initiating an email-based reset of the account’s primary email after user request."
+        "description": "Tool to send a reset email link to change the primary email address. Use when initiating an email-based reset of the account\u2019s primary email after user request."
       },
       {
         "slug": "BENCHMARK_EMAIL_PATCH_UPDATE_CLIENT_SETTINGS",
@@ -117682,7 +117682,7 @@
   {
     "slug": "bestbuy",
     "name": "Bestbuy",
-    "logo": "https://developer.bestbuy.com/images/bestbuy-logo.png",
+    "logo": "https://logos.composio.dev/api/bestbuy",
     "description": "Best Buy offers a suite of APIs providing access to product, store, category, and recommendation data.",
     "category": "ecommerce",
     "authSchemes": [
@@ -118914,7 +118914,7 @@
       {
         "slug": "BIG_DATA_CLOUD_NETWORK_BY_IP_ADDRESS_API",
         "name": "Network by IP Address API",
-        "description": "Tool to retrieve registry, ASN, and BGP details for a given IP address’s network. Use when you need detailed network information (e.g., ASNs, prefixes) after confirming the target IP."
+        "description": "Tool to retrieve registry, ASN, and BGP details for a given IP address\u2019s network. Use when you need detailed network information (e.g., ASNs, prefixes) after confirming the target IP."
       },
       {
         "slug": "BIG_DATA_CLOUD_PHONE_NUMBER_VALIDATION_BY_IP",
@@ -120405,7 +120405,7 @@
       {
         "slug": "BOLT_IOT_ANALOG_READ",
         "name": "Analog Read",
-        "description": "Tool to read the analog value from a specified pin on a Bolt device. Use when you need sensor readings (0–1023) after confirming the device is online."
+        "description": "Tool to read the analog value from a specified pin on a Bolt device. Use when you need sensor readings (0\u20131023) after confirming the device is online."
       },
       {
         "slug": "BOLT_IOT_CHECK_DEVICE_STATUS",
@@ -121949,7 +121949,7 @@
       {
         "slug": "BOTSONIC_GET_ALL_STARTER_QUESTIONS",
         "name": "Get All Starter Questions",
-        "description": "Tool to retrieve all starter questions. Use after authenticating when you need to list the bot’s opening prompts."
+        "description": "Tool to retrieve all starter questions. Use after authenticating when you need to list the bot\u2019s opening prompts."
       },
       {
         "slug": "BOTSONIC_UPDATE_STARTER_QUESTION",
@@ -122828,7 +122828,7 @@
       {
         "slug": "BRIGHTDATA_CRAWL_API",
         "name": "Trigger Site Crawl",
-        "description": "Tool to trigger an asynchronous site crawl job to extract content across multiple pages or entire domains. Returns a snapshot_id required by BRIGHTDATA_GET_SNAPSHOT_STATUS (poll until complete) and BRIGHTDATA_GET_SNAPSHOT_RESULTS (call only after completion; querying early yields empty or partial data). Use when you need to start a crawl for a given dataset and list of URLs. Large crawls can produce very large payloads — fetch results incrementally."
+        "description": "Tool to trigger an asynchronous site crawl job to extract content across multiple pages or entire domains. Returns a snapshot_id required by BRIGHTDATA_GET_SNAPSHOT_STATUS (poll until complete) and BRIGHTDATA_GET_SNAPSHOT_RESULTS (call only after completion; querying early yields empty or partial data). Use when you need to start a crawl for a given dataset and list of URLs. Large crawls can produce very large payloads \u2014 fetch results incrementally."
       },
       {
         "slug": "BRIGHTDATA_DATASET_LIST",
@@ -122853,7 +122853,7 @@
       {
         "slug": "BRIGHTDATA_GET_SNAPSHOT_RESULTS",
         "name": "Download Scraped Data",
-        "description": "Tool to retrieve the scraped data from a completed crawl job by snapshot ID. Only call after confirming the job is complete via BRIGHTDATA_GET_SNAPSHOT_STATUS — querying before completion yields empty or partial data. Use after triggering a crawl or filtering a dataset to download the collected data."
+        "description": "Tool to retrieve the scraped data from a completed crawl job by snapshot ID. Only call after confirming the job is complete via BRIGHTDATA_GET_SNAPSHOT_STATUS \u2014 querying before completion yields empty or partial data. Use after triggering a crawl or filtering a dataset to download the collected data."
       },
       {
         "slug": "BRIGHTDATA_GET_SNAPSHOT_STATUS",
@@ -123821,7 +123821,7 @@
       {
         "slug": "BUGSNAG_LIST_ERRORS_ON_PROJECT",
         "name": "List Errors on Project",
-        "description": "List all errors in a Bugsnag project with optional filtering and sorting. Use this to retrieve error summaries including error class, message, severity, status, occurrence counts, and affected users. Results are paginated; follow pagination indicators to retrieve all pages. No status filter parameter exists — filter by open/fixed/ignored status client-side using the status field in responses. Requires a valid project_id which can be obtained from the List Projects action."
+        "description": "List all errors in a Bugsnag project with optional filtering and sorting. Use this to retrieve error summaries including error class, message, severity, status, occurrence counts, and affected users. Results are paginated; follow pagination indicators to retrieve all pages. No status filter parameter exists \u2014 filter by open/fixed/ignored status client-side using the status field in responses. Requires a valid project_id which can be obtained from the List Projects action."
       },
       {
         "slug": "BUGSNAG_LIST_EVENT_FIELDS_FOR_PROJECT",
@@ -124153,7 +124153,7 @@
       {
         "slug": "BUNNYCDN_ADD_STORAGE_ZONE",
         "name": "Add Storage Zone",
-        "description": "Tool to add a new storage zone. Use when you need dedicated file storage in a specific region. Zone creation is irreversible — confirm Name, Region, and ZoneTier before executing."
+        "description": "Tool to add a new storage zone. Use when you need dedicated file storage in a specific region. Zone creation is irreversible \u2014 confirm Name, Region, and ZoneTier before executing."
       },
       {
         "slug": "BUNNYCDN_ADD_UPDATE_EDGE_RULE",
@@ -124253,7 +124253,7 @@
       {
         "slug": "BUNNYCDN_DELETE_STORAGE_ZONE",
         "name": "Delete Storage Zone",
-        "description": "Tool to delete a storage zone. Deletion is irreversible — permanently removes the zone and all associated data. Use only after confirming the correct zone ID with the user."
+        "description": "Tool to delete a storage zone. Deletion is irreversible \u2014 permanently removes the zone and all associated data. Use only after confirming the correct zone ID with the user."
       },
       {
         "slug": "BUNNYCDN_GENERATE2FA_VERIFICATION",
@@ -124513,7 +124513,7 @@
       {
         "slug": "BUNNYCDN_GET_STORAGE_ZONE_DETAILS",
         "name": "Get Storage Zone Details",
-        "description": "Tool to retrieve the full details of a storage zone, including configuration, usage metrics, and credentials. The response includes sensitive fields Password and ReadOnlyPassword — mask or omit these from logs and user-facing output."
+        "description": "Tool to retrieve the full details of a storage zone, including configuration, usage metrics, and credentials. The response includes sensitive fields Password and ReadOnlyPassword \u2014 mask or omit these from logs and user-facing output."
       },
       {
         "slug": "BUNNYCDN_GET_STORAGE_ZONE_LIST",
@@ -125303,7 +125303,7 @@
       {
         "slug": "CALLINGLY_CREATE_CALL",
         "name": "Create Outbound Call",
-        "description": "Creates a new outbound call record and initiates a real outbound call, which incurs cost — ensure explicit user authorization and compliance with applicable consent and telemarketing regulations before use. The call will be routed to available agents on the specified team based on account-level routing configuration. Use List Teams first to get valid account_id and team_id values. Returns a call_id that can be used with Get Call to retrieve call status, recordings, and other details."
+        "description": "Creates a new outbound call record and initiates a real outbound call, which incurs cost \u2014 ensure explicit user authorization and compliance with applicable consent and telemarketing regulations before use. The call will be routed to available agents on the specified team based on account-level routing configuration. Use List Teams first to get valid account_id and team_id values. Returns a call_id that can be used with Get Call to retrieve call status, recordings, and other details."
       },
       {
         "slug": "CALLINGLY_CREATE_CLIENT",
@@ -125877,7 +125877,7 @@
       {
         "slug": "CANNY_DELETE_USER",
         "name": "Delete User",
-        "description": "Tool to delete a user and their comments and votes. Use when you need to fully remove a user’s account and all associated data (e.g., GDPR compliance)."
+        "description": "Tool to delete a user and their comments and votes. Use when you need to fully remove a user\u2019s account and all associated data (e.g., GDPR compliance)."
       },
       {
         "slug": "CANNY_DELETE_VOTE",
@@ -126867,7 +126867,7 @@
       {
         "slug": "CARDLY_UPDATE_WEBHOOK",
         "name": "Update Webhook",
-        "description": "Tool to update a webhook’s settings, including target URL and events. Use after retrieving existing webhook to apply configuration changes."
+        "description": "Tool to update a webhook\u2019s settings, including target URL and events. Use after retrieving existing webhook to apply configuration changes."
       }
     ],
     "triggers": [],
@@ -127785,7 +127785,7 @@
                 "name": "generic_api_key",
                 "displayName": "API Token",
                 "type": "string",
-                "description": "Your Celigo API token. Create one in integrator.io under Resources → API tokens (requires account owner or administrator role)",
+                "description": "Your Celigo API token. Create one in integrator.io under Resources \u2192 API tokens (requires account owner or administrator role)",
                 "required": true,
                 "default": null
               }
@@ -128737,7 +128737,7 @@
       {
         "slug": "CENTRALSTATIONCRM_GET_PERSON_ADDRESSES",
         "name": "Get Person Addresses",
-        "description": "Tool to retrieve all addresses for a specific person. Use when you need to list a person’s addresses after confirming their ID. Example: \"Get addresses for person with ID 42.\""
+        "description": "Tool to retrieve all addresses for a specific person. Use when you need to list a person\u2019s addresses after confirming their ID. Example: \"Get addresses for person with ID 42.\""
       },
       {
         "slug": "CENTRALSTATIONCRM_GET_PERSON_ASSI",
@@ -129162,7 +129162,7 @@
       {
         "slug": "CENTRALSTATIONCRM_UPDATE_PERSON_ASSI",
         "name": "Update Person Assi",
-        "description": "Tool to update an assi entry of a person. Use when you need to modify a specific assistant record after retrieving the person’s assis list. Example: \"Update assi 101 for person 42 changing email to foo@example.com\"."
+        "description": "Tool to update an assi entry of a person. Use when you need to modify a specific assistant record after retrieving the person\u2019s assis list. Example: \"Update assi 101 for person 42 changing email to foo@example.com\"."
       },
       {
         "slug": "CENTRALSTATIONCRM_UPDATE_PERSON_CONTACT_DETAIL",
@@ -131870,12 +131870,12 @@
       {
         "slug": "CLEAROUT_REVERSE_LOOKUP_FIND_PERSON_VIA_EMAIL",
         "name": "Reverse Lookup Person by Email",
-        "description": "Tool to retrieve a person’s profile from an email address. Use when you want to enrich a valid email with associated person details."
+        "description": "Tool to retrieve a person\u2019s profile from an email address. Use when you want to enrich a valid email with associated person details."
       },
       {
         "slug": "CLEAROUT_REVERSE_LOOKUP_FIND_PERSON_VIA_LINKED_IN",
         "name": "Find Person via LinkedIn URL",
-        "description": "Tool to discover person information via a LinkedIn profile URL. Use when you need to retrieve person’s profile details from a LinkedIn URL."
+        "description": "Tool to discover person information via a LinkedIn profile URL. Use when you need to retrieve person\u2019s profile details from a LinkedIn URL."
       },
       {
         "slug": "CLEAROUT_ROLE_ACCOUNT_VERIFY",
@@ -133033,7 +133033,7 @@
       {
         "slug": "CLICKSEND_USER_COUNTRIES_AGREE_POST",
         "name": "Agree to User Countries Rules",
-        "description": "Agrees to the rules and regulations for all previously selected countries in Global Sending. This action confirms acceptance of the regulatory requirements and content restrictions for countries that have been selected via POST /user-countries. After agreeing, the action returns a detailed list of all selected countries including their specific regulatory requirements, registration status, and any additional compliance information needed for sending SMS/MMS to those regions. Use this after selecting countries for international messaging to formally acknowledge compliance with their sending rules. The response includes critical information such as content restrictions (e.g., no gambling, adult content), registration requirements, and links to detailed country-specific guidelines. This is typically part of a workflow: 1) Get available countries (GET /country-list) → 2) Select countries (POST /user-countries) → 3) Agree to rules (this action) → 4) Begin sending messages."
+        "description": "Agrees to the rules and regulations for all previously selected countries in Global Sending. This action confirms acceptance of the regulatory requirements and content restrictions for countries that have been selected via POST /user-countries. After agreeing, the action returns a detailed list of all selected countries including their specific regulatory requirements, registration status, and any additional compliance information needed for sending SMS/MMS to those regions. Use this after selecting countries for international messaging to formally acknowledge compliance with their sending rules. The response includes critical information such as content restrictions (e.g., no gambling, adult content), registration requirements, and links to detailed country-specific guidelines. This is typically part of a workflow: 1) Get available countries (GET /country-list) \u2192 2) Select countries (POST /user-countries) \u2192 3) Agree to rules (this action) \u2192 4) Begin sending messages."
       },
       {
         "slug": "CLICKSEND_USER_COUNTRIES_GET",
@@ -133458,7 +133458,7 @@
   {
     "slug": "clockify",
     "name": "Clockify",
-    "logo": "https://clockify.me/assets/images/clockify-logo.svg",
+    "logo": "https://logos.composio.dev/api/clockify",
     "description": "Clockify is a free time tracking software that allows individuals and teams to track work hours across projects.",
     "category": "time tracking software",
     "authSchemes": [
@@ -133622,7 +133622,7 @@
       {
         "slug": "CLOCKIFY_GET_ALL_MY_WORKSPACES",
         "name": "Get All My Workspaces",
-        "description": "Tool to list all workspaces the user belongs to. Use when you need an overview of accessible workspaces after authentication. Verify the correct workspace ID from the returned list before using it in subsequent operations — wrong workspace IDs misroute all entries. Each workspace object may include settings such as forceTasks; when enabled, time entry creation requires a valid taskId or returns HTTP 400 (code 501)."
+        "description": "Tool to list all workspaces the user belongs to. Use when you need an overview of accessible workspaces after authentication. Verify the correct workspace ID from the returned list before using it in subsequent operations \u2014 wrong workspace IDs misroute all entries. Each workspace object may include settings such as forceTasks; when enabled, time entry creation requires a valid taskId or returns HTTP 400 (code 501)."
       },
       {
         "slug": "CLOCKIFY_GET_ALL_WEBHOOKS",
@@ -134817,7 +134817,7 @@
   {
     "slug": "cloudflare_api_key",
     "name": "Cloudflare Api Key",
-    "logo": "https://www.cloudflare.com/img/logo-cloudflare.svg",
+    "logo": "https://logos.composio.dev/api/cloudflare_api_key",
     "description": "Cloudflare provides a suite of services to enhance the security, performance, and reliability of websites and applications.",
     "category": "security & identity tools",
     "authSchemes": [
@@ -134984,7 +134984,7 @@
     "slug": "cloudflare_browser_rendering",
     "name": "Cloudflare Browser Rendering",
     "logo": "https://logos.composio.dev/api/cloudflare_browser_rendering",
-    "description": "Cloudflare Browser Rendering enables developers to programmatically control and interact with headless browser instances running on Cloudflare’s global network, facilitating tasks such as automating browser interactions, capturing screenshots, generating PDFs, and extracting data from web pages.",
+    "description": "Cloudflare Browser Rendering enables developers to programmatically control and interact with headless browser instances running on Cloudflare\u2019s global network, facilitating tasks such as automating browser interactions, capturing screenshots, generating PDFs, and extracting data from web pages.",
     "category": "ai web scraping",
     "authSchemes": [
       "API_KEY"
@@ -134996,7 +134996,7 @@
       {
         "slug": "CLOUDFLARE_BROWSER_RENDERING_CAPTURE_SCREENSHOT",
         "name": "Capture Screenshot",
-        "description": "Tool to capture a webpage screenshot. Use when you need a visual snapshot of a URL or HTML with optional viewport and clipping. Always validate screenshot content — the tool returns a successful result even when the captured page is a 404 or error page, with no error signal raised."
+        "description": "Tool to capture a webpage screenshot. Use when you need a visual snapshot of a URL or HTML with optional viewport and clipping. Always validate screenshot content \u2014 the tool returns a successful result even when the captured page is a 404 or error page, with no error signal raised."
       },
       {
         "slug": "CLOUDFLARE_BROWSER_RENDERING_LIST_ACCOUNTS",
@@ -135270,7 +135270,7 @@
       {
         "slug": "CLOUDINARY_GET_CONFIG",
         "name": "Get product environment config details",
-        "description": "Tool to get product environment config details. Use when you need to fetch or verify environment configuration such as folder_mode. Config values like folder_mode constrain uploads, folder creation, and preset creation — check this config before those operations to avoid mode conflicts."
+        "description": "Tool to get product environment config details. Use when you need to fetch or verify environment configuration such as folder_mode. Config values like folder_mode constrain uploads, folder creation, and preset creation \u2014 check this config before those operations to avoid mode conflicts."
       },
       {
         "slug": "CLOUDINARY_GET_LIVE_STREAM",
@@ -135654,7 +135654,7 @@
   {
     "slug": "cloudlayer",
     "name": "Cloudlayer",
-    "logo": "https://cloudlayer.io/logo.png",
+    "logo": "https://logos.composio.dev/api/cloudlayer",
     "description": "cloudlayer.io is a document and asset generation service that enables users to dynamically create PDFs and images through a REST-based API, SDKs, or no-code integrations.",
     "category": "documents",
     "authSchemes": [
@@ -136459,7 +136459,7 @@
   {
     "slug": "coinmarketcap",
     "name": "CoinMarketCap",
-    "logo": "https://s2.coinmarketcap.com/static/cloud/img/coinmarketcap_1.svg",
+    "logo": "https://logos.composio.dev/api/coinmarketcap",
     "description": "CoinMarketCap provides a comprehensive cryptocurrency market data API, offering real-time and historical data on cryptocurrencies and exchanges.",
     "category": "analytics",
     "authSchemes": [
@@ -136482,7 +136482,7 @@
       {
         "slug": "COINMARKETCAP_CRYPTOCURRENCY_QUOTES_LATEST",
         "name": "Get Latest Cryptocurrency Quotes",
-        "description": "Tool to get the latest aggregated global market quotes for one or more cryptocurrencies. Exactly one of id, symbol, or slug must be provided; combining multiple identifier types or omitting all causes an error. Response is nested under data → SYMBOL (or ID) → quote → TARGET_CURRENCY for fields like price and last_updated."
+        "description": "Tool to get the latest aggregated global market quotes for one or more cryptocurrencies. Exactly one of id, symbol, or slug must be provided; combining multiple identifier types or omitting all causes an error. Response is nested under data \u2192 SYMBOL (or ID) \u2192 quote \u2192 TARGET_CURRENCY for fields like price and last_updated."
       },
       {
         "slug": "COINMARKETCAP_GET_CRYPTOCURRENCY_INFO",
@@ -136545,7 +136545,7 @@
   {
     "slug": "coinranking",
     "name": "Coinranking",
-    "logo": "https://coinranking.com/favicon.ico",
+    "logo": "https://logos.composio.dev/api/coinranking",
     "description": "Coinranking provides a comprehensive API for accessing cryptocurrency market data, including coin prices, market caps, and historical data.",
     "category": "analytics",
     "authSchemes": [
@@ -136583,7 +136583,7 @@
       {
         "slug": "COINRANKING_GET_COINS",
         "name": "Get Coins",
-        "description": "Retrieve a comprehensive list of cryptocurrency coins with detailed market data including prices, market caps, rankings, and price history. Supports filtering by search terms, quality tiers, and sorting by various metrics like market cap, price, or volume. Ideal for: - Getting top cryptocurrencies by market cap - Searching for specific coins by name or symbol - Filtering high-quality coins (tier 1) - Analyzing price changes over different time periods - Paginating through large result sets Returns detailed coin information including current price, market cap, 24h volume, price change percentages, sparkline data, and all-time high values. Note: numeric fields in responses (price, marketCap, 24hVolume) are returned as strings — cast to numeric types before arithmetic or comparisons."
+        "description": "Retrieve a comprehensive list of cryptocurrency coins with detailed market data including prices, market caps, rankings, and price history. Supports filtering by search terms, quality tiers, and sorting by various metrics like market cap, price, or volume. Ideal for: - Getting top cryptocurrencies by market cap - Searching for specific coins by name or symbol - Filtering high-quality coins (tier 1) - Analyzing price changes over different time periods - Paginating through large result sets Returns detailed coin information including current price, market cap, 24h volume, price change percentages, sparkline data, and all-time high values. Note: numeric fields in responses (price, marketCap, 24hVolume) are returned as strings \u2014 cast to numeric types before arithmetic or comparisons."
       },
       {
         "slug": "COINRANKING_GET_COIN_TRADING_VOLUME_HISTORY",
@@ -136734,7 +136734,7 @@
       {
         "slug": "COLLEGE_FOOTBALL_DATA_GET_GAMES_AND_RESULTS",
         "name": "Get Games and Results",
-        "description": "Tool to retrieve college American football games and results for a given season/week/team. Use when you need game schedules or outcomes filtered by specific criteria. Covers NCAA only; NFL and other sports return no data. Overly narrow filter combinations (e.g., mismatched `team` and `conference`) may yield zero results — relax filters if the response is empty."
+        "description": "Tool to retrieve college American football games and results for a given season/week/team. Use when you need game schedules or outcomes filtered by specific criteria. Covers NCAA only; NFL and other sports return no data. Overly narrow filter combinations (e.g., mismatched `team` and `conference`) may yield zero results \u2014 relax filters if the response is empty."
       },
       {
         "slug": "COLLEGE_FOOTBALL_DATA_GET_PLAYER_GAME_STATS",
@@ -136799,7 +136799,7 @@
       {
         "slug": "COLLEGE_FOOTBALL_DATA_LIST_COACHES_AND_HISTORY",
         "name": "List Coaches and History",
-        "description": "Tool to get coaching records and history. Use when you need coaches’ season-by-season data with optional filters."
+        "description": "Tool to get coaching records and history. Use when you need coaches\u2019 season-by-season data with optional filters."
       },
       {
         "slug": "COLLEGE_FOOTBALL_DATA_LIST_CONFERENCES",
@@ -136909,7 +136909,7 @@
       {
         "slug": "COLLEGE_FOOTBALL_DATA_RETURNING_PRODUCTION_TEAM",
         "name": "Returning Production by Team",
-        "description": "Tool to fetch Bill Connelly–style returning production splits by team and season. Use when evaluating returning offense, defense, and overall production for teams in a given season."
+        "description": "Tool to fetch Bill Connelly\u2013style returning production splits by team and season. Use when evaluating returning offense, defense, and overall production for teams in a given season."
       },
       {
         "slug": "COLLEGE_FOOTBALL_DATA_SEARCH_PLAYERS",
@@ -137455,7 +137455,7 @@
     "slug": "context7_mcp",
     "name": "Context7 MCP",
     "logo": "https://logos.composio.dev/api/context7_mcp",
-    "description": "Context7 MCP pulls up-to-date, version-specific documentation and code examples straight from the source — and places them directly into your prompt",
+    "description": "Context7 MCP pulls up-to-date, version-specific documentation and code examples straight from the source \u2014 and places them directly into your prompt",
     "category": "developer tools & devops",
     "authSchemes": [
       "API_KEY"
@@ -138487,7 +138487,7 @@
     "slug": "corrently",
     "name": "Corrently",
     "logo": "https://logos.composio.dev/api/corrently",
-    "description": "Corrently provides a suite of APIs offering real-time and forecasted data on renewable energy availability, CO₂ emissions, and electricity pricing, enabling users to optimize energy consumption and reduce carbon footprints.",
+    "description": "Corrently provides a suite of APIs offering real-time and forecasted data on renewable energy availability, CO\u2082 emissions, and electricity pricing, enabling users to optimize energy consumption and reduce carbon footprints.",
     "category": "analytics",
     "authSchemes": [
       "API_KEY"
@@ -138498,8 +138498,8 @@
     "tools": [
       {
         "slug": "CORRENTLY_CO2_METER_UPDATE_READING",
-        "name": "CO₂ Meter Update",
-        "description": "Tool to create or update a CO₂ meter reading for emissions tracking. Use when sending new or updated electricity consumption readings to Corrently."
+        "name": "CO\u2082 Meter Update",
+        "description": "Tool to create or update a CO\u2082 meter reading for emissions tracking. Use when sending new or updated electricity consumption readings to Corrently."
       },
       {
         "slug": "CORRENTLY_COMMIT_QUITTUNG",
@@ -138514,7 +138514,7 @@
       {
         "slug": "CORRENTLY_GET_ENERGY_SCHEDULE",
         "name": "Energy Schedule Computation",
-        "description": "Create an optimized operation schedule for energy-consuming devices based on the GrünstromIndex (Green Power Index). This tool determines the best time slots to run energy-intensive devices (heat pumps, EV chargers, etc.) by analyzing regional renewable energy availability, electricity prices, and CO2 emissions forecasts. Use this after collecting: - German postal code (required for regional data) - Desired optimization goal (price, co2, or comfort) - Number of hours the device needs to run"
+        "description": "Create an optimized operation schedule for energy-consuming devices based on the Gr\u00fcnstromIndex (Green Power Index). This tool determines the best time slots to run energy-intensive devices (heat pumps, EV chargers, etc.) by analyzing regional renewable energy availability, electricity prices, and CO2 emissions forecasts. Use this after collecting: - German postal code (required for regional data) - Desired optimization goal (price, co2, or comfort) - Number of hours the device needs to run"
       },
       {
         "slug": "CORRENTLY_GET_METERING_READING",
@@ -138538,13 +138538,13 @@
       },
       {
         "slug": "CORRENTLY_GRUNSTROM_INDEX_FORECAST",
-        "name": "GrünstromIndex Forecast",
+        "name": "Gr\u00fcnstromIndex Forecast",
         "description": "Tool to retrieve hourly green power forecast and CO2 data. Use after obtaining the user API key."
       },
       {
         "slug": "CORRENTLY_GSI_BEST_HOUR",
         "name": "GSI Best Hour",
-        "description": "Determines if now is the best time to turn on a device based on regional green energy (GrünstromIndex) forecasts in Germany. Returns true if the current hour has high renewable energy availability within the specified timeframe, false if waiting would be more sustainable."
+        "description": "Determines if now is the best time to turn on a device based on regional green energy (Gr\u00fcnstromIndex) forecasts in Germany. Returns true if the current hour has high renewable energy availability within the specified timeframe, false if waiting would be more sustainable."
       },
       {
         "slug": "CORRENTLY_LOGIN_STROMKONTO",
@@ -138594,7 +138594,7 @@
       {
         "slug": "CORRENTLY_TARIFF_COMPONENTS",
         "name": "Tariff Components",
-        "description": "Retrieve detailed German electricity tariff cost breakdown by postal code. Returns comprehensive cost components including: - Grundgebühr (base monthly fee) - Arbeitspreis (energy price per kWh) - Network fees (Netznutzungsentgelt) - Taxes (Stromsteuer, Mehrwertsteuer) - Levies (EEG, KWKG, Offshore-Netzumlage) - Renewable energy credits Use this tool to understand electricity pricing transparency in Germany."
+        "description": "Retrieve detailed German electricity tariff cost breakdown by postal code. Returns comprehensive cost components including: - Grundgeb\u00fchr (base monthly fee) - Arbeitspreis (energy price per kWh) - Network fees (Netznutzungsentgelt) - Taxes (Stromsteuer, Mehrwertsteuer) - Levies (EEG, KWKG, Offshore-Netzumlage) - Renewable energy credits Use this tool to understand electricity pricing transparency in Germany."
       },
       {
         "slug": "CORRENTLY_TARIFF_SLPH0",
@@ -138770,7 +138770,7 @@
       {
         "slug": "COUNTDOWN_API_STOP_COLLECTION",
         "name": "Stop Collection",
-        "description": "Tool to stop (pause) a single collection’s processing by ID. Use when you need to halt a running or queued collection after confirming the target collection ID."
+        "description": "Tool to stop (pause) a single collection\u2019s processing by ID. Use when you need to halt a running or queued collection after confirming the target collection ID."
       },
       {
         "slug": "COUNTDOWN_API_UPDATE_DESTINATION",
@@ -140561,7 +140561,7 @@
       {
         "slug": "COUPA_UPDATE_EXCHANGE_RATE",
         "name": "Update Exchange Rate",
-        "description": "Tool to update an exchange rate between two currencies in Coupa. Use when you need to modify exchange rate values or effective dates. Exchange rates are one-way only (e.g., USD→EUR and EUR→USD require separate records). The currencies must already exist in the system before updating the exchange rate."
+        "description": "Tool to update an exchange rate between two currencies in Coupa. Use when you need to modify exchange rate values or effective dates. Exchange rates are one-way only (e.g., USD\u2192EUR and EUR\u2192USD require separate records). The currencies must already exist in the system before updating the exchange rate."
       },
       {
         "slug": "COUPA_UPDATE_EXISTING_ADDRESS",
@@ -142679,7 +142679,7 @@
                 "name": "generic_api_key",
                 "displayName": "API Key",
                 "type": "string",
-                "description": "Your Cursor API key. Generate from Dashboard → Integrations (Cloud Agents), Settings → Advanced (Admin API), or Team settings (Analytics API).",
+                "description": "Your Cursor API key. Generate from Dashboard \u2192 Integrations (Cloud Agents), Settings \u2192 Advanced (Admin API), or Team settings (Analytics API).",
                 "required": true,
                 "default": null
               }
@@ -143244,7 +143244,7 @@
       {
         "slug": "DADATA_RU_CLEAN_EMAIL",
         "name": "Clean Email",
-        "description": "Standardize and validate an email address. Fixes typos in domains (e.g., 'gnail.con' → 'gmail.com'), validates format, and classifies as PERSONAL, CORPORATE, ROLE, or DISPOSABLE. Use to clean user-provided emails before storing or sending mail."
+        "description": "Standardize and validate an email address. Fixes typos in domains (e.g., 'gnail.con' \u2192 'gmail.com'), validates format, and classifies as PERSONAL, CORPORATE, ROLE, or DISPOSABLE. Use to clean user-provided emails before storing or sending mail."
       },
       {
         "slug": "DADATA_RU_CLEAN_NAME",
@@ -143514,7 +143514,7 @@
       {
         "slug": "DADATA_RU_SUGGEST_OKTMO",
         "name": "Suggest OKTMO",
-        "description": "Suggest Russian municipal territory codes (OKTMO) by code prefix or partial name. OKTMO (Общероссийский классификатор территорий муниципальных образований) is a classifier for Russian municipal territories. Use this tool to: - Autocomplete OKTMO codes when user starts typing a code prefix (e.g., '45' for Moscow) - Look up a specific OKTMO code to get territory details - Search for municipalities by partial code match Returns district (area) and settlement (subarea) information for each match."
+        "description": "Suggest Russian municipal territory codes (OKTMO) by code prefix or partial name. OKTMO (\u041e\u0431\u0449\u0435\u0440\u043e\u0441\u0441\u0438\u0439\u0441\u043a\u0438\u0439 \u043a\u043b\u0430\u0441\u0441\u0438\u0444\u0438\u043a\u0430\u0442\u043e\u0440 \u0442\u0435\u0440\u0440\u0438\u0442\u043e\u0440\u0438\u0439 \u043c\u0443\u043d\u0438\u0446\u0438\u043f\u0430\u043b\u044c\u043d\u044b\u0445 \u043e\u0431\u0440\u0430\u0437\u043e\u0432\u0430\u043d\u0438\u0439) is a classifier for Russian municipal territories. Use this tool to: - Autocomplete OKTMO codes when user starts typing a code prefix (e.g., '45' for Moscow) - Look up a specific OKTMO code to get territory details - Search for municipalities by partial code match Returns district (area) and settlement (subarea) information for each match."
       },
       {
         "slug": "DADATA_RU_SUGGEST_OKVED2",
@@ -143544,7 +143544,7 @@
       {
         "slug": "DADATA_RU_SUGGEST_POSTAL_UNIT",
         "name": "Suggest Postal Unit",
-        "description": "Suggests Russian Post offices (Почта России) by postal code or address. Use for autocompleting postal codes, finding post offices by address fragments, or getting details like working hours and location coordinates."
+        "description": "Suggests Russian Post offices (\u041f\u043e\u0447\u0442\u0430 \u0420\u043e\u0441\u0441\u0438\u0438) by postal code or address. Use for autocompleting postal codes, finding post offices by address fragments, or getting details like working hours and location coordinates."
       }
     ],
     "triggers": [],
@@ -144295,7 +144295,7 @@
       {
         "slug": "DATABRICKS_CATALOG_GRANTS_GET_EFFECTIVE",
         "name": "Get Effective Catalog Permissions",
-        "description": "Tool to get effective permissions for a securable in Unity Catalog, including inherited permissions from parent securables. Use when you need to understand what privileges are granted to principals through direct assignments or inheritance. Returns privileges conveyed to each principal through the Unity Catalog hierarchy (metastore → catalog → schema → table/view/volume)."
+        "description": "Tool to get effective permissions for a securable in Unity Catalog, including inherited permissions from parent securables. Use when you need to understand what privileges are granted to principals through direct assignments or inheritance. Returns privileges conveyed to each principal through the Unity Catalog hierarchy (metastore \u2192 catalog \u2192 schema \u2192 table/view/volume)."
       },
       {
         "slug": "DATABRICKS_CATALOG_GRANTS_UPDATE",
@@ -148121,7 +148121,7 @@
       {
         "slug": "DEADLINE_FUNNEL_START_DEADLINE_CUSTOM_WEBHOOK",
         "name": "Start Deadline via Custom Webhook",
-        "description": "Tool to start an individual subscriber’s deadline tracking via a custom webhook URL. Use after generating a campaign-specific webhook token. Example: StartDeadlineCustomWebhook(account_id='123456', token='abcdef', email='joe@example.com')"
+        "description": "Tool to start an individual subscriber\u2019s deadline tracking via a custom webhook URL. Use after generating a campaign-specific webhook token. Example: StartDeadlineCustomWebhook(account_id='123456', token='abcdef', email='joe@example.com')"
       },
       {
         "slug": "DEADLINE_FUNNEL_TRACK_SALE_WEBHOOK",
@@ -148415,7 +148415,7 @@
     "slug": "delighted",
     "name": "Delighted",
     "logo": "https://logos.composio.dev/api/delighted",
-    "description": "Delighted uses the Net Promoter System® to gather real feedback from your customers – in minutes, not weeks. No technical knowledge required.",
+    "description": "Delighted uses the Net Promoter System\u00ae to gather real feedback from your customers \u2013 in minutes, not weeks. No technical knowledge required.",
     "category": "forms & surveys",
     "authSchemes": [
       "API_KEY"
@@ -148900,7 +148900,7 @@
       {
         "slug": "DESKTIME_GET_ALL_COMPANY_EMPLOYEES",
         "name": "Get All Company Employees",
-        "description": "Tool to list all employees in the company, including their roles and statuses. Use after confirming valid credentials to fetch the organization’s roster."
+        "description": "Tool to list all employees in the company, including their roles and statuses. Use after confirming valid credentials to fetch the organization\u2019s roster."
       },
       {
         "slug": "DESKTIME_GET_EMPLOYEE",
@@ -149821,7 +149821,7 @@
       {
         "slug": "DIGITAL_OCEAN_CREATE_NEW_DROPLET",
         "name": "Create New Droplet",
-        "description": "Tool to create a new Droplet. Use when you need to provision a VM with name, region, size, and image. The `image`, `region`, and `size` must be mutually compatible — the chosen `region` must be listed in the image's available regions."
+        "description": "Tool to create a new Droplet. Use when you need to provision a VM with name, region, size, and image. The `image`, `region`, and `size` must be mutually compatible \u2014 the chosen `region` must be listed in the image's available regions."
       },
       {
         "slug": "DIGITAL_OCEAN_CREATE_NEW_FIREWALL",
@@ -149876,7 +149876,7 @@
       {
         "slug": "DIGITAL_OCEAN_DELETE_EXISTING_DROPLET",
         "name": "Delete Existing Droplet",
-        "description": "Tool to delete a Droplet by ID. Deletion is irreversible — all data is permanently lost. Confirm droplet_id with the user and verify a backup or snapshot exists before proceeding."
+        "description": "Tool to delete a Droplet by ID. Deletion is irreversible \u2014 all data is permanently lost. Confirm droplet_id with the user and verify a backup or snapshot exists before proceeding."
       },
       {
         "slug": "DIGITAL_OCEAN_DELETE_FIREWALL",
@@ -149906,7 +149906,7 @@
       {
         "slug": "DIGITAL_OCEAN_DELETE_VPC",
         "name": "Delete VPC",
-        "description": "Delete a VPC (Virtual Private Cloud) by its unique identifier. Use this tool when you need to permanently remove a VPC from your DigitalOcean account. Deletion is irreversible — always confirm the vpc_id with the user before proceeding. **Important Restrictions:** - Cannot delete a VPC that is the default VPC for its region - Cannot delete a VPC that has member resources (droplets, databases, load balancers, etc.) — all resources must be detached or migrated first - VPC must be empty before deletion Returns an empty response (HTTP 204) on successful deletion."
+        "description": "Delete a VPC (Virtual Private Cloud) by its unique identifier. Use this tool when you need to permanently remove a VPC from your DigitalOcean account. Deletion is irreversible \u2014 always confirm the vpc_id with the user before proceeding. **Important Restrictions:** - Cannot delete a VPC that is the default VPC for its region - Cannot delete a VPC that has member resources (droplets, databases, load balancers, etc.) \u2014 all resources must be detached or migrated first - VPC must be empty before deletion Returns an empty response (HTTP 204) on successful deletion."
       },
       {
         "slug": "DIGITAL_OCEAN_LIST_ALL_DATABASES",
@@ -151152,7 +151152,7 @@
       {
         "slug": "DOCKER_HUB_DELETE_IMAGE",
         "name": "Delete Repository Images",
-        "description": "Delete one or more images from your Docker Hub namespace using the bulk delete API. IMPORTANT REQUIREMENTS: - You must own the namespace (your username or an organization you admin) - You cannot delete images from 'library' (official Docker images) - Images are identified by SHA256 digest (get from LIST_IMAGES action) USAGE: 1. First use LIST_IMAGES to get image digests for your repository 2. Then call this action with the namespace, repository, and digest(s) Example: DELETE_IMAGE( namespace=\"myusername\", manifests=[{\"repository\": \"myapp\", \"digest\": \"sha256:abc123...\"}] ). WARNING: Deletion is permanent and irreversible — obtain explicit user confirmation before calling this action."
+        "description": "Delete one or more images from your Docker Hub namespace using the bulk delete API. IMPORTANT REQUIREMENTS: - You must own the namespace (your username or an organization you admin) - You cannot delete images from 'library' (official Docker images) - Images are identified by SHA256 digest (get from LIST_IMAGES action) USAGE: 1. First use LIST_IMAGES to get image digests for your repository 2. Then call this action with the namespace, repository, and digest(s) Example: DELETE_IMAGE( namespace=\"myusername\", manifests=[{\"repository\": \"myapp\", \"digest\": \"sha256:abc123...\"}] ). WARNING: Deletion is permanent and irreversible \u2014 obtain explicit user confirmation before calling this action."
       },
       {
         "slug": "DOCKER_HUB_DELETE_ORGANIZATION",
@@ -151212,7 +151212,7 @@
       {
         "slug": "DOCKER_HUB_LIST_ORGANIZATIONS",
         "name": "List Docker Hub Organizations",
-        "description": "List Docker Hub organizations that the authenticated user belongs to. Returns a paginated list of organizations with details like name, company, and badge status; some metadata fields may be absent — use org name for follow-up detail calls when complete metadata is required. An empty result is valid and indicates the user belongs to no organizations. Use this to discover which organizations a user has access to before performing org-specific operations."
+        "description": "List Docker Hub organizations that the authenticated user belongs to. Returns a paginated list of organizations with details like name, company, and badge status; some metadata fields may be absent \u2014 use org name for follow-up detail calls when complete metadata is required. An empty result is valid and indicates the user belongs to no organizations. Use this to discover which organizations a user has access to before performing org-specific operations."
       },
       {
         "slug": "DOCKER_HUB_LIST_ORG_MEMBERS",
@@ -151460,7 +151460,7 @@
       {
         "slug": "DOCRAPTOR_CREATE_ASYNC_DOC",
         "name": "Create Async Document",
-        "description": "Tool to create documents asynchronously from HTML content. Use when generating PDF, XLS, or XLSX documents and you need to poll for completion status or use a callback URL for notification. Returns a response containing an `id` field — store this value and pass it to DOCRAPTOR_GET_ASYNC_DOC_STATUS to poll for completion, then to DOCRAPTOR_GET_ASYNC_DOC to download the finished document."
+        "description": "Tool to create documents asynchronously from HTML content. Use when generating PDF, XLS, or XLSX documents and you need to poll for completion status or use a callback URL for notification. Returns a response containing an `id` field \u2014 store this value and pass it to DOCRAPTOR_GET_ASYNC_DOC_STATUS to poll for completion, then to DOCRAPTOR_GET_ASYNC_DOC to download the finished document."
       },
       {
         "slug": "DOCRAPTOR_CREATE_DOC",
@@ -152004,7 +152004,7 @@
       {
         "slug": "DOCUGENERATE_TEMPLATE_UPDATE",
         "name": "Update Template",
-        "description": "Tool to update a template’s file and settings. Use after confirming the template ID and desired inputs."
+        "description": "Tool to update a template\u2019s file and settings. Use after confirming the template ID and desired inputs."
       }
     ],
     "triggers": [],
@@ -154170,7 +154170,7 @@
       {
         "slug": "DREAMSTUDIO_USER_BALANCE",
         "name": "DreamStudio User Balance",
-        "description": "Retrieves the user's current credit balance from their DreamStudio account. Use this tool to check how many credits are available before generating images or to monitor remaining credits after API operations. Credits are consumed when generating images through the Stability AI API. For large or high-resolution batch generation, verify sufficient balance first — insufficient credits will cause failures mid-run."
+        "description": "Retrieves the user's current credit balance from their DreamStudio account. Use this tool to check how many credits are available before generating images or to monitor remaining credits after API operations. Credits are consumed when generating images through the Stability AI API. For large or high-resolution batch generation, verify sufficient balance first \u2014 insufficient credits will cause failures mid-run."
       }
     ],
     "triggers": [],
@@ -155204,7 +155204,7 @@
       {
         "slug": "ECOLOGI_GET_USER_CARBON_REMOVAL",
         "name": "Get User Carbon Removal",
-        "description": "Tool to retrieve the total tonnes of CO₂e a user has permanently removed from the atmosphere. Data refreshes every 10 minutes. Use when checking carbon offset impact for a specific Ecologi user or business."
+        "description": "Tool to retrieve the total tonnes of CO\u2082e a user has permanently removed from the atmosphere. Data refreshes every 10 minutes. Use when checking carbon offset impact for a specific Ecologi user or business."
       },
       {
         "slug": "ECOLOGI_GET_USER_HABITAT_RESTORATION",
@@ -155238,7 +155238,7 @@
                 "name": "generic_api_key",
                 "displayName": "API Key",
                 "type": "string",
-                "description": "Navigate to your Ecologi account → \"Account\" → \"Impact API\" to generate an API key",
+                "description": "Navigate to your Ecologi account \u2192 \"Account\" \u2192 \"Impact API\" to generate an API key",
                 "required": true,
                 "default": null
               }
@@ -158434,7 +158434,7 @@
                 "name": "generic_api_key",
                 "displayName": "API Key",
                 "type": "string",
-                "description": "Navigate to User list → Select user → Settings tab → API Access section → Click \"Generate Keys\" to get your API Key",
+                "description": "Navigate to User list \u2192 Select user \u2192 Settings tab \u2192 API Access section \u2192 Click \"Generate Keys\" to get your API Key",
                 "required": true,
                 "default": null
               },
@@ -158514,7 +158514,7 @@
       {
         "slug": "ESIGNATURES_IO_GET_TEMPLATE",
         "name": "Get Template",
-        "description": "Tool to retrieve details of a specific template by its ID. Use when you need to fetch a template’s metadata after selecting its ID."
+        "description": "Tool to retrieve details of a specific template by its ID. Use when you need to fetch a template\u2019s metadata after selecting its ID."
       },
       {
         "slug": "ESIGNATURES_IO_LIST_TEMPLATE_COLLABORATORS",
@@ -160987,7 +160987,7 @@
     "slug": "faraday",
     "name": "Faraday",
     "logo": "https://logos.composio.dev/api/faraday",
-    "description": "Faraday lets you embed AI in workflows throughout your stack—to make your favorite tools perform even better",
+    "description": "Faraday lets you embed AI in workflows throughout your stack\u2014to make your favorite tools perform even better",
     "category": "artificial intelligence",
     "authSchemes": [
       "API_KEY"
@@ -161644,7 +161644,7 @@
       {
         "slug": "FATHOM_GET_RECORDING_TRANSCRIPT",
         "name": "Get Recording Transcript",
-        "description": "Tool to retrieve the full transcript for a specific recording. Use when you need to access the complete meeting transcript with speaker information and timestamps. Can operate synchronously (returns transcript directly) or asynchronously (posts transcript to a destination URL). In the response, speaker is an object — access speaker.display_name rather than treating speaker as a string. Prefer this tool over fetching transcripts via list-meetings calls with include_transcript=true, which produces extremely large responses when many meetings are returned."
+        "description": "Tool to retrieve the full transcript for a specific recording. Use when you need to access the complete meeting transcript with speaker information and timestamps. Can operate synchronously (returns transcript directly) or asynchronously (posts transcript to a destination URL). In the response, speaker is an object \u2014 access speaker.display_name rather than treating speaker as a string. Prefer this tool over fetching transcripts via list-meetings calls with include_transcript=true, which produces extremely large responses when many meetings are returned."
       },
       {
         "slug": "FATHOM_LIST_MEETINGS",
@@ -161753,7 +161753,7 @@
       {
         "slug": "FEATHERY_ACCOUNT_EDIT",
         "name": "Edit Feathery Account",
-        "description": "Tool to edit an existing account’s role and permissions. Use when modifying account settings after confirming identity."
+        "description": "Tool to edit an existing account\u2019s role and permissions. Use when modifying account settings after confirming identity."
       },
       {
         "slug": "FEATHERY_ACCOUNT_GET_INFO",
@@ -166418,7 +166418,7 @@
   {
     "slug": "fraudlabs_pro",
     "name": "FraudLabs Pro",
-    "logo": "https://www.fraudlabspro.com/images/logo.png",
+    "logo": "https://logos.composio.dev/api/fraudlabs_pro",
     "description": "FraudLabs Pro is an online payment fraud detection service that helps merchants minimize chargebacks and maximize revenue by detecting fraud across various payment methods.",
     "category": "payment processing",
     "authSchemes": [
@@ -167051,7 +167051,7 @@
   {
     "slug": "fullenrich",
     "name": "Fullenrich",
-    "logo": "https://gravatar.com/avatar/0d4b0c4b0c4b0c4b0c4b0c4b0c4b0c4b0",
+    "logo": "https://logos.composio.dev/api/fullenrich",
     "description": "FullEnrich is a B2B email and phone waterfall enrichment platform that aggregates contact information from over 15 premium vendors to find the emails and phone numbers of leads.",
     "category": "contact management",
     "authSchemes": [
@@ -167257,7 +167257,7 @@
     "slug": "gamma",
     "name": "Gamma",
     "logo": "https://logos.composio.dev/api/gamma",
-    "description": "Gamma helps create beautiful, interactive content and presentations using AI. This integration enables programmatic generation via Gamma’s API.",
+    "description": "Gamma helps create beautiful, interactive content and presentations using AI. This integration enables programmatic generation via Gamma\u2019s API.",
     "category": "ai content generation",
     "authSchemes": [
       "API_KEY"
@@ -167525,27 +167525,27 @@
       {
         "slug": "GEMINI_GENERATE_IMAGE",
         "name": "Generate Image (Nano Banana)",
-        "description": "Generates images from text prompts using Gemini models (Nano Banana). Supports models: 'gemini-2.5-flash-image' (GA stable, fast), 'gemini-3-pro-image-preview' (Nano Banana Pro - advanced with 4K resolution, thinking mode, up to 14 reference images), and 'gemini-2.0-flash-exp-image-generation' (2.0 Flash experimental). Returns one image per call; images are uploaded to S3. Parse response at data.image.s3url or the text-type entry in data.content — prefer the URL to avoid base64 blobs. Always validate s3url before treating call as successful; a 200 response may contain only text with no image. Store s3url immediately as URLs can expire. Output formats are raster only (JPG/PNG/WebP); request PNG for transparency. Concurrent usage may trigger HTTP 429/RESOURCE_EXHAUSTED — keep concurrency ≤3 and use exponential backoff (1s→2s→4s, ~5 retries). NOTE NEVER EVER TRUE SYNC_TO_WORKBENCH IN RUBE_MULTI_EXECUTE_TOOL"
+        "description": "Generates images from text prompts using Gemini models (Nano Banana). Supports models: 'gemini-2.5-flash-image' (GA stable, fast), 'gemini-3-pro-image-preview' (Nano Banana Pro - advanced with 4K resolution, thinking mode, up to 14 reference images), and 'gemini-2.0-flash-exp-image-generation' (2.0 Flash experimental). Returns one image per call; images are uploaded to S3. Parse response at data.image.s3url or the text-type entry in data.content \u2014 prefer the URL to avoid base64 blobs. Always validate s3url before treating call as successful; a 200 response may contain only text with no image. Store s3url immediately as URLs can expire. Output formats are raster only (JPG/PNG/WebP); request PNG for transparency. Concurrent usage may trigger HTTP 429/RESOURCE_EXHAUSTED \u2014 keep concurrency \u22643 and use exponential backoff (1s\u21922s\u21924s, ~5 retries). NOTE NEVER EVER TRUE SYNC_TO_WORKBENCH IN RUBE_MULTI_EXECUTE_TOOL"
       },
       {
         "slug": "GEMINI_GENERATE_VIDEOS",
         "name": "Generate Videos (Veo)",
-        "description": "Generates videos from text prompts using Google's Veo models. Returns an operation_name for tracking; pass it verbatim (no edits) to GEMINI_WAIT_FOR_VIDEO or GEMINI_GET_VIDEOS_OPERATION. Jobs take 30–180+ seconds; wait 10s before first poll, then poll every 10–30s (allow up to 12 min). Successful results include data.video_file.s3url — missing s3url means failure. If done=true but no video_file, check raiMediaFilteredReasons (safety block); revise prompt and regenerate. Text-only; cannot accept image inputs. Max ~3–5 concurrent jobs; 429 RESOURCE_EXHAUSTED requires exponential backoff. For retries, always start a fresh call — never reuse a failed operation_name."
+        "description": "Generates videos from text prompts using Google's Veo models. Returns an operation_name for tracking; pass it verbatim (no edits) to GEMINI_WAIT_FOR_VIDEO or GEMINI_GET_VIDEOS_OPERATION. Jobs take 30\u2013180+ seconds; wait 10s before first poll, then poll every 10\u201330s (allow up to 12 min). Successful results include data.video_file.s3url \u2014 missing s3url means failure. If done=true but no video_file, check raiMediaFilteredReasons (safety block); revise prompt and regenerate. Text-only; cannot accept image inputs. Max ~3\u20135 concurrent jobs; 429 RESOURCE_EXHAUSTED requires exponential backoff. For retries, always start a fresh call \u2014 never reuse a failed operation_name."
       },
       {
         "slug": "GEMINI_GET_VIDEOS_OPERATION",
         "name": "Get Videos Operation (Veo) (Deprecated)",
-        "description": "DEPRECATED: Use WaitForVideo instead. Checks status of a Veo video generation operation. Use operation_name from GenerateVideos to track progress. Wait several seconds after starting GenerateVideos before first call to avoid OPERATION_NOT_FOUND. Poll at 10–30s intervals; use exponential backoff on HTTP 429 RESOURCE_EXHAUSTED; cap total polling at ~15 minutes. Complete when done=true AND a valid video URI is present; done=true without video_file indicates safety filtering blocked output — inspect raiMediaFilteredReasons and rephrase prompt. Video URL is at generatedSamples[].video.uri — persist promptly as URLs are time-limited. Keep concurrent polling to 3–5 parallel calls to avoid rate limits. If WaitForVideo times out, continue polling here using the same operation_name rather than starting a new GenerateVideos job."
+        "description": "DEPRECATED: Use WaitForVideo instead. Checks status of a Veo video generation operation. Use operation_name from GenerateVideos to track progress. Wait several seconds after starting GenerateVideos before first call to avoid OPERATION_NOT_FOUND. Poll at 10\u201330s intervals; use exponential backoff on HTTP 429 RESOURCE_EXHAUSTED; cap total polling at ~15 minutes. Complete when done=true AND a valid video URI is present; done=true without video_file indicates safety filtering blocked output \u2014 inspect raiMediaFilteredReasons and rephrase prompt. Video URL is at generatedSamples[].video.uri \u2014 persist promptly as URLs are time-limited. Keep concurrent polling to 3\u20135 parallel calls to avoid rate limits. If WaitForVideo times out, continue polling here using the same operation_name rather than starting a new GenerateVideos job."
       },
       {
         "slug": "GEMINI_LIST_MODELS",
         "name": "List Models (Gemini API)",
-        "description": "Lists available Gemini and Veo models with their capabilities and limits. Useful for discovering supported models and their features before making generation requests. Before calling video generation tools, verify model availability here — preview Veo models (e.g., veo-3.0-generate-preview) may be unavailable or return missing video URIs; prefer stable models like veo-2.0-generate-001."
+        "description": "Lists available Gemini and Veo models with their capabilities and limits. Useful for discovering supported models and their features before making generation requests. Before calling video generation tools, verify model availability here \u2014 preview Veo models (e.g., veo-3.0-generate-preview) may be unavailable or return missing video URIs; prefer stable models like veo-2.0-generate-001."
       },
       {
         "slug": "GEMINI_WAIT_FOR_VIDEO",
         "name": "Wait and Download Video (Veo)",
-        "description": "Polls a Veo video generation operation until completion, then downloads and returns the video as a FileDownloadable. Generation takes 30–120+ seconds (up to ~10–12 min); long waits are normal, not failures. On completion, the URL is nested at data.video_file.s3url — validate it is non-empty before downstream use. A done=true response without a valid s3url indicates safety filter rejection (check raiMediaFilteredReasons) or quota exhaustion — adjust the prompt and regenerate. On timeout, use GEMINI_GET_VIDEOS_OPERATION with incremental backoff before starting a new job. Keep parallel jobs to 3–5 to avoid 429 RESOURCE_EXHAUSTED errors."
+        "description": "Polls a Veo video generation operation until completion, then downloads and returns the video as a FileDownloadable. Generation takes 30\u2013120+ seconds (up to ~10\u201312 min); long waits are normal, not failures. On completion, the URL is nested at data.video_file.s3url \u2014 validate it is non-empty before downstream use. A done=true response without a valid s3url indicates safety filter rejection (check raiMediaFilteredReasons) or quota exhaustion \u2014 adjust the prompt and regenerate. On timeout, use GEMINI_GET_VIDEOS_OPERATION with incremental backoff before starting a new job. Keep parallel jobs to 3\u20135 to avoid 429 RESOURCE_EXHAUSTED errors."
       }
     ],
     "triggers": [],
@@ -167655,7 +167655,7 @@
   {
     "slug": "genderapi_io",
     "name": "GenderAPI.io",
-    "logo": "https://genderapi.io/logo.png",
+    "logo": "https://logos.composio.dev/api/genderapi_io",
     "description": "GenderAPI.io provides an API to determine the gender associated with a given name, email address, or username.",
     "category": "developer tools",
     "authSchemes": [
@@ -167767,7 +167767,7 @@
   {
     "slug": "geoapify",
     "name": "Geoapify",
-    "logo": "https://www.geoapify.com/wp-content/uploads/2020/06/geoapify_logo.svg",
+    "logo": "https://logos.composio.dev/api/geoapify",
     "description": "Geoapify offers a suite of APIs for integrating maps, geocoding, routing, and other location-based services into applications.",
     "category": "developer tools",
     "authSchemes": [
@@ -168060,7 +168060,7 @@
   {
     "slug": "getform",
     "name": "Getform",
-    "logo": "https://getform.io/favicon.ico",
+    "logo": "https://logos.composio.dev/api/getform",
     "description": "Getform is a modern form backend platform that enables developers to handle web forms and submissions without setting up a server or writing backend code.",
     "category": "forms & surveys",
     "authSchemes": [
@@ -168262,7 +168262,7 @@
   {
     "slug": "gift_up",
     "name": "Gift Up!",
-    "logo": "https://giftup.app/favicon.ico",
+    "logo": "https://logos.composio.dev/api/gift_up",
     "description": "Gift Up! is a digital platform that allows businesses to sell, manage, and redeem gift cards online, integrating seamlessly with websites and apps to streamline gift card transactions and promotions.",
     "category": "ecommerce",
     "authSchemes": [
@@ -169314,7 +169314,7 @@
   {
     "slug": "giphy",
     "name": "Giphy",
-    "logo": "https://giphy.com/static/img/giphy_logo_square_social.png",
+    "logo": "https://logos.composio.dev/api/giphy",
     "description": "GIPHY is the first and largest GIF search engine, offering an extensive library of GIFs and Stickers for integration into applications.",
     "category": "images & design",
     "authSchemes": [
@@ -169422,7 +169422,7 @@
       {
         "slug": "GIPHY_TRANSLATE_STICKER",
         "name": "GIPHY Translate Sticker",
-        "description": "Tool to translate a term or phrase into a single sticker using GIPHY’s translation algorithm. Use after confirming the exact phrase to visualize as a sticker."
+        "description": "Tool to translate a term or phrase into a single sticker using GIPHY\u2019s translation algorithm. Use after confirming the exact phrase to visualize as a sticker."
       },
       {
         "slug": "GIPHY_TRENDING_GIFS",
@@ -169470,7 +169470,7 @@
   {
     "slug": "gist",
     "name": "Gist",
-    "logo": "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png",
+    "logo": "https://logos.composio.dev/api/gist",
     "description": "GitHub Gist is a service provided by GitHub that allows users to share code snippets, notes, and other text-based content. It supports both public and private gists, enabling easy sharing and collaboration.",
     "category": "developer tools",
     "authSchemes": [
@@ -170130,7 +170130,7 @@
   {
     "slug": "givebutter",
     "name": "Givebutter",
-    "logo": "https://givebutter.com/favicon.ico",
+    "logo": "https://logos.composio.dev/api/givebutter",
     "description": "Givebutter is a fundraising platform that offers a free, open, and public API for developers to manage campaigns, track donations, and engage with supporters.",
     "category": "fundraising",
     "authSchemes": [
@@ -170461,7 +170461,7 @@
   {
     "slug": "gladia",
     "name": "Gladia",
-    "logo": "https://www.gladia.io/favicon.ico",
+    "logo": "https://logos.composio.dev/api/gladia",
     "description": "Gladia provides state-of-the-art audio transcription and intelligence services through a simple API, enabling real-time and asynchronous transcription, translation, and audio analysis.",
     "category": "transcription",
     "authSchemes": [
@@ -171355,12 +171355,12 @@
       {
         "slug": "GLEAP_UPDATE_A_USER_FOR_A_PROJECT",
         "name": "Update a User for a Project",
-        "description": "Tool to update a user’s role in a project. Use when you need to change a user's permissions."
+        "description": "Tool to update a user\u2019s role in a project. Use when you need to change a user's permissions."
       },
       {
         "slug": "GLEAP_UPDATE_CHAT_MESSAGE",
         "name": "Update Chat Message",
-        "description": "Updates an existing chat message in Gleap by its ID. This action modifies one or more fields of a chat message such as content, status, visibility, and other properties. Use this after creating a chat message to edit its text, change its status from draft to active, or update other metadata. The message ID must be obtained from a prior create or list operation. Common use cases: - Edit message content after sending - Change message status (draft → active) - Toggle message visibility (hidden/shown) - Update message metadata (name, sound settings)"
+        "description": "Updates an existing chat message in Gleap by its ID. This action modifies one or more fields of a chat message such as content, status, visibility, and other properties. Use this after creating a chat message to edit its text, change its status from draft to active, or update other metadata. The message ID must be obtained from a prior create or list operation. Common use cases: - Edit message content after sending - Change message status (draft \u2192 active) - Toggle message visibility (hidden/shown) - Update message metadata (name, sound settings)"
       },
       {
         "slug": "GLEAP_UPDATE_CHECKLIST",
@@ -171496,7 +171496,7 @@
   {
     "slug": "globalping",
     "name": "Globalping",
-    "logo": "https://globalping.io/logo.png",
+    "logo": "https://logos.composio.dev/api/globalping",
     "description": "Globalping is a global network of probes that allows users to run network tests like ping, traceroute, and DNS resolve from various locations worldwide.",
     "category": "server monitoring",
     "authSchemes": [
@@ -171562,7 +171562,7 @@
   {
     "slug": "godial",
     "name": "Godial",
-    "logo": "https://godial.cc/wp-content/uploads/2020/06/GoDial-Logo-1.png",
+    "logo": "https://logos.composio.dev/api/godial",
     "description": "GoDial is an automatic call app, mobile CRM, and outbound dialer software that transforms your phone into a call center, enabling efficient management of calls and contacts.",
     "category": "crm",
     "authSchemes": [
@@ -171723,7 +171723,7 @@
   {
     "slug": "goodbits",
     "name": "Goodbits",
-    "logo": "https://goodbits.io/logo.png",
+    "logo": "https://logos.composio.dev/api/goodbits",
     "description": "Goodbits is a service that helps you and your business create stellar newsletters from the best links your team and customers are reading.",
     "category": "email newsletters",
     "authSchemes": [
@@ -171756,7 +171756,7 @@
       {
         "slug": "GOODBITS_UPDATE_SUBSCRIBER_STATUS",
         "name": "Update Subscriber Status",
-        "description": "Tool to update subscriber status. Use when you need to change an existing subscriber’s subscription status by email. Example: \"Update the status of john@example.com to unsubscribed\""
+        "description": "Tool to update subscriber status. Use when you need to change an existing subscriber\u2019s subscription status by email. Example: \"Update the status of john@example.com to unsubscribed\""
       }
     ],
     "triggers": [],
@@ -171789,7 +171789,7 @@
   {
     "slug": "goody",
     "name": "Goody",
-    "logo": "https://www.ongoody.com/favicon.ico",
+    "logo": "https://logos.composio.dev/api/goody",
     "description": "Goody is a platform that enables users to send gifts and physical products without handling logistics, offering APIs for commerce and automation.",
     "category": "ecommerce",
     "authSchemes": [
@@ -172693,7 +172693,7 @@
       {
         "slug": "GOOGLE_SEARCH_CONSOLE_LIST_SITES",
         "name": "List Sites",
-        "description": "Lists all verified sites (properties) owned by the authenticated user in Google Search Console. Response contains a siteEntry array — always iterate it, never assume a single object. Each entry includes permissionLevel, which varies per site; do not assume owner-level access for all returned properties. When calling downstream tools, use the site_url value exactly as returned, including protocol, subdomain, sc-domain: prefix, and trailing slash — any deviation causes empty results or permission errors. Empty siteEntry may indicate missing OAuth scopes or no verified properties. Newly added properties may not appear immediately due to propagation delay."
+        "description": "Lists all verified sites (properties) owned by the authenticated user in Google Search Console. Response contains a siteEntry array \u2014 always iterate it, never assume a single object. Each entry includes permissionLevel, which varies per site; do not assume owner-level access for all returned properties. When calling downstream tools, use the site_url value exactly as returned, including protocol, subdomain, sc-domain: prefix, and trailing slash \u2014 any deviation causes empty results or permission errors. Empty siteEntry may indicate missing OAuth scopes or no verified properties. Newly added properties may not appear immediately due to propagation delay."
       },
       {
         "slug": "GOOGLE_SEARCH_CONSOLE_SEARCH_ANALYTICS_QUERY",
@@ -172919,22 +172919,22 @@
       {
         "slug": "GOOGLECONTACTS_DELETE_CONTACT",
         "name": "Delete Google Contact",
-        "description": "Delete a contact person from Google Contacts. Any non-contact data will not be deleted. Use this action when you need to permanently remove a contact from the user's Google Contacts list. This action is irreversible — the contact cannot be recovered once deleted. Mutate requests for the same user should be sent sequentially to avoid increased latency and failures."
+        "description": "Delete a contact person from Google Contacts. Any non-contact data will not be deleted. Use this action when you need to permanently remove a contact from the user's Google Contacts list. This action is irreversible \u2014 the contact cannot be recovered once deleted. Mutate requests for the same user should be sent sequentially to avoid increased latency and failures."
       },
       {
         "slug": "GOOGLECONTACTS_DELETE_CONTACT_GROUP",
         "name": "Delete contact group",
-        "description": "Deletes an existing contact group owned by the authenticated user by specifying the contact group resource name. This action is irreversible — once deleted, the contact group cannot be recovered. Use this action when you need to remove a contact group that is no longer needed. Mutate requests for the same user should be sent sequentially to avoid increased latency and failures."
+        "description": "Deletes an existing contact group owned by the authenticated user by specifying the contact group resource name. This action is irreversible \u2014 once deleted, the contact group cannot be recovered. Use this action when you need to remove a contact group that is no longer needed. Mutate requests for the same user should be sent sequentially to avoid increased latency and failures."
       },
       {
         "slug": "GOOGLECONTACTS_DELETE_CONTACT_PHOTO",
         "name": "Delete Contact Photo",
-        "description": "Delete a contact's photo from Google Contacts. Use when you need to remove a profile picture from a specific contact. This action is irreversible — once the photo is deleted, it cannot be recovered. Mutate requests for the same user should be sent sequentially to avoid lock contention and failures."
+        "description": "Delete a contact's photo from Google Contacts. Use when you need to remove a profile picture from a specific contact. This action is irreversible \u2014 once the photo is deleted, it cannot be recovered. Mutate requests for the same user should be sent sequentially to avoid lock contention and failures."
       },
       {
         "slug": "GOOGLECONTACTS_DELETE_CONTACTS_BATCH",
         "name": "Batch Delete Google Contacts",
-        "description": "Delete a batch of contacts from Google Contacts. Any non-contact data will not be deleted. Use this action when you need to permanently remove multiple contacts from the user's Google Contacts list at once. This action is irreversible — the contacts cannot be recovered once deleted. Mutate requests for the same user should be sent sequentially to avoid increased latency and failures."
+        "description": "Delete a batch of contacts from Google Contacts. Any non-contact data will not be deleted. Use this action when you need to permanently remove multiple contacts from the user's Google Contacts list at once. This action is irreversible \u2014 the contacts cannot be recovered once deleted. Mutate requests for the same user should be sent sequentially to avoid increased latency and failures."
       },
       {
         "slug": "GOOGLECONTACTS_GET_BATCH_PEOPLE",
@@ -172954,7 +172954,7 @@
       {
         "slug": "GOOGLECONTACTS_LIST_CONNECTIONS",
         "name": "List Connections",
-        "description": "Lists the connections (contacts) for the authenticated user. Use when you need to retrieve a paginated list of all contacts with optional sorting, filtering, and incremental sync support. Sync tokens expire 7 days after a full sync — requests with expired tokens return a 410 error. When using page_token or sync_token, all other parameters must match the original request. Deleted contacts appear as Person objects with PersonMetadata.deleted set to true. Incremental syncs are not intended for read-after-write use cases."
+        "description": "Lists the connections (contacts) for the authenticated user. Use when you need to retrieve a paginated list of all contacts with optional sorting, filtering, and incremental sync support. Sync tokens expire 7 days after a full sync \u2014 requests with expired tokens return a 410 error. When using page_token or sync_token, all other parameters must match the original request. Deleted contacts appear as Person objects with PersonMetadata.deleted set to true. Incremental syncs are not intended for read-after-write use cases."
       },
       {
         "slug": "GOOGLECONTACTS_LIST_CONTACT_GROUPS",
@@ -172964,7 +172964,7 @@
       {
         "slug": "GOOGLECONTACTS_LIST_DIRECTORY_PEOPLE",
         "name": "List Directory People",
-        "description": "Lists domain profiles and domain contacts in the authenticated user's domain directory. Use when you need to retrieve directory information for all users in a Google Workspace domain, including their contact details like names, emails, and phone numbers. Supports pagination via pageToken and incremental sync via syncToken. When syncToken is used, deleted resources are returned with PersonMetadata.deleted set to true. Note: Write propagation delays of several minutes may apply for sync requests — this is not suitable for read-after-write use cases. All request parameters must remain consistent when using pagination or sync tokens."
+        "description": "Lists domain profiles and domain contacts in the authenticated user's domain directory. Use when you need to retrieve directory information for all users in a Google Workspace domain, including their contact details like names, emails, and phone numbers. Supports pagination via pageToken and incremental sync via syncToken. When syncToken is used, deleted resources are returned with PersonMetadata.deleted set to true. Note: Write propagation delays of several minutes may apply for sync requests \u2014 this is not suitable for read-after-write use cases. All request parameters must remain consistent when using pagination or sync tokens."
       },
       {
         "slug": "GOOGLECONTACTS_LIST_OTHER_CONTACTS",
@@ -173090,7 +173090,7 @@
       {
         "slug": "GOOGLEFORMS_DELETE_WATCH",
         "name": "Delete Form Watch",
-        "description": "Deletes a watch from a Google Form, stopping push notifications for that watch. Use when you no longer want to receive notifications for a specific watch on a form. This action is irreversible — once deleted, the watch cannot be recovered and notifications will stop immediately. If you need to resume notifications, you must create a new watch using the CreateWatch action."
+        "description": "Deletes a watch from a Google Form, stopping push notifications for that watch. Use when you no longer want to receive notifications for a specific watch on a form. This action is irreversible \u2014 once deleted, the watch cannot be recovered and notifications will stop immediately. If you need to resume notifications, you must create a new watch using the CreateWatch action."
       },
       {
         "slug": "GOOGLEFORMS_GET_FORM",
@@ -173178,7 +173178,7 @@
   {
     "slug": "gosquared",
     "name": "Gosquared",
-    "logo": "https://www.gosquared.com/images/logo.png",
+    "logo": "https://logos.composio.dev/api/gosquared",
     "description": "GoSquared provides real-time web analytics and customer engagement tools to help businesses understand and interact with their website visitors.",
     "category": "analytics",
     "authSchemes": [
@@ -173789,7 +173789,7 @@
   {
     "slug": "grafbase",
     "name": "Grafbase",
-    "logo": "https://grafbase.com/favicon.ico",
+    "logo": "https://logos.composio.dev/api/grafbase",
     "description": "Grafbase is a platform that accelerates the development of GraphQL APIs, offering features like edge caching, unified data access, and seamless integration with popular authentication strategies.",
     "category": "developer tools",
     "authSchemes": [
@@ -174006,7 +174006,7 @@
       {
         "slug": "GRANOLA_MCP_QUERY_GRANOLA_MEETINGS",
         "name": "Query granola meetings",
-        "description": "Query Granola about the user's meetings using natural language. Returns a tailored response with inline citation links in mark  (e.g. [[0]](url)) that reference source meeting notes.\n\nIMPORTANT: The response includes numbered citation links to specific Granola meeting notes. These citations MUST be preserved in your response to the user — they provide transparency and allow the user to verify information by clicking through to the original notes.\n\nWhen to use:\n- User asks about what was discussed, decided, or action-items from meetings\n- User asks about follow-ups, todos, or commitments from recent meetings\n- User references 'Granola notes' or 'meeting notes'\n\nWhen NOT to use:\n- User is asking about calendar scheduling or upcoming events\n- User explicitly asks for a specific meeting by ID (use get_meetings instead)\n\nPrioritize using query_granola_meetings over list_meetings/get_meetings for open-ended or natural language queries about meeting content."
+        "description": "Query Granola about the user's meetings using natural language. Returns a tailored response with inline citation links in mark  (e.g. [[0]](url)) that reference source meeting notes.\n\nIMPORTANT: The response includes numbered citation links to specific Granola meeting notes. These citations MUST be preserved in your response to the user \u2014 they provide transparency and allow the user to verify information by clicking through to the original notes.\n\nWhen to use:\n- User asks about what was discussed, decided, or action-items from meetings\n- User asks about follow-ups, todos, or commitments from recent meetings\n- User references 'Granola notes' or 'meeting notes'\n\nWhen NOT to use:\n- User is asking about calendar scheduling or upcoming events\n- User explicitly asks for a specific meeting by ID (use get_meetings instead)\n\nPrioritize using query_granola_meetings over list_meetings/get_meetings for open-ended or natural language queries about meeting content."
       }
     ],
     "triggers": [],
@@ -174063,7 +174063,7 @@
   {
     "slug": "graphhopper",
     "name": "Graphhopper",
-    "logo": "https://www.graphhopper.com/images/graphhopper_logo.svg",
+    "logo": "https://logos.composio.dev/api/graphhopper",
     "description": "GraphHopper Directions API provides enterprise-grade routing services, including route planning, optimization, geocoding, and more, for various vehicle types.",
     "category": "developer tools",
     "authSchemes": [
@@ -174169,7 +174169,7 @@
   {
     "slug": "griptape",
     "name": "Griptape",
-    "logo": "https://www.griptape.ai/logo.png",
+    "logo": "https://logos.composio.dev/api/griptape",
     "description": "Griptape is a comprehensive platform offering tools and frameworks for building, deploying, and scaling generative AI applications.",
     "category": "artificial intelligence",
     "authSchemes": [
@@ -174925,7 +174925,7 @@
   {
     "slug": "grist",
     "name": "Grist",
-    "logo": "https://www.getgrist.com/static/images/logo.svg",
+    "logo": "https://logos.composio.dev/api/grist",
     "description": "Grist is a relational spreadsheet platform that combines the flexibility of a spreadsheet with the robustness of a database, allowing users to create custom applications tailored to their data needs.",
     "category": "productivity",
     "authSchemes": [
@@ -175162,7 +175162,7 @@
       {
         "slug": "GROQCLOUD_LIST_MODELS",
         "name": "List Models",
-        "description": "Tool to list all available models and their metadata. Always call this to retrieve current model IDs rather than using hard-coded or cached identifiers, as deprecated names cause failures in GROQCLOUD_GROQ_RETRIEVE_MODEL and GROQCLOUD_GROQ_CREATE_CHAT_COMPLETION. Returns availability and metadata only — excludes usage stats, latency metrics, and pricing. Response may include many models; filter client-side by provider, family, modality, or context length. Frequent polling combined with high-volume requests risks HTTP 429 rate_limit_exceeded; use backoff and minimize call frequency."
+        "description": "Tool to list all available models and their metadata. Always call this to retrieve current model IDs rather than using hard-coded or cached identifiers, as deprecated names cause failures in GROQCLOUD_GROQ_RETRIEVE_MODEL and GROQCLOUD_GROQ_CREATE_CHAT_COMPLETION. Returns availability and metadata only \u2014 excludes usage stats, latency metrics, and pricing. Response may include many models; filter client-side by provider, family, modality, or context length. Frequent polling combined with high-volume requests risks HTTP 429 rate_limit_exceeded; use backoff and minimize call frequency."
       },
       {
         "slug": "GROQCLOUD_LIST_VOICES",
@@ -176456,7 +176456,7 @@
       {
         "slug": "HABITICA_DELETE_TAG",
         "name": "Delete Habitica Tag",
-        "description": "Tool to delete a tag for the authenticated user. Use when you need to remove an obsolete tag after confirming it’s no longer applied to any tasks."
+        "description": "Tool to delete a tag for the authenticated user. Use when you need to remove an obsolete tag after confirming it\u2019s no longer applied to any tasks."
       },
       {
         "slug": "HABITICA_DELETE_TASK",
@@ -177049,7 +177049,7 @@
                 "name": "generic_api_key",
                 "displayName": "API Key",
                 "type": "string",
-                "description": "Navigate to your Handwrytten account → Account Settings → Integrations → API Keys",
+                "description": "Navigate to your Handwrytten account \u2192 Account Settings \u2192 Integrations \u2192 API Keys",
                 "required": true,
                 "default": null
               }
@@ -177063,7 +177063,7 @@
   {
     "slug": "happy_scribe",
     "name": "Happy Scribe",
-    "logo": "https://www.happyscribe.com/favicon.ico",
+    "logo": "https://logos.composio.dev/api/happy_scribe",
     "description": "Happy Scribe offers automatic and professional transcription services, converting audio and video files into text with high accuracy.",
     "category": "transcription",
     "authSchemes": [
@@ -178409,7 +178409,7 @@
       {
         "slug": "HELP_SCOUT_UPDATE_CUSTOM_FIELDS",
         "name": "Update Custom Fields",
-        "description": "Tool to update custom fields on a Help Scout conversation. The complete fields list replaces existing data—omitted fields are removed. Use when you need to set or clear custom field values on a conversation."
+        "description": "Tool to update custom fields on a Help Scout conversation. The complete fields list replaces existing data\u2014omitted fields are removed. Use when you need to set or clear custom field values on a conversation."
       },
       {
         "slug": "HELP_SCOUT_UPDATE_MAILBOXES_ROUTING",
@@ -178857,7 +178857,7 @@
   {
     "slug": "here",
     "name": "Here",
-    "logo": "https://www.here.com/etc.clientlibs/here/clientlibs/website/clientlib-site/resources/images/here-logo.svg",
+    "logo": "https://logos.composio.dev/api/here",
     "description": "HERE Technologies provides comprehensive location data and mapping services, offering APIs and SDKs for developers to integrate maps, geocoding, routing, and other location-based features into their applications.",
     "category": "developer tools",
     "authSchemes": [
@@ -179075,7 +179075,7 @@
       {
         "slug": "HERE_GET_MATRIX",
         "name": "Compute Routing Matrix",
-        "description": "Computes routing matrices for batch distance and travel time calculations between multiple origins and destinations. Use this tool when you need to: - Calculate distances/times for all combinations of multiple starting points and destinations - Perform batch routing calculations efficiently (up to 10,000 origins × 10,000 destinations) - Get travel times with traffic considerations (when departureTime is provided) - Optimize delivery routes, logistics planning, or proximity analysis The response returns flat arrays in row-major order where element k represents the route from origin i to destination j, calculated as: k = numDestinations * i + j"
+        "description": "Computes routing matrices for batch distance and travel time calculations between multiple origins and destinations. Use this tool when you need to: - Calculate distances/times for all combinations of multiple starting points and destinations - Perform batch routing calculations efficiently (up to 10,000 origins \u00d7 10,000 destinations) - Get travel times with traffic considerations (when departureTime is provided) - Optimize delivery routes, logistics planning, or proximity analysis The response returns flat arrays in row-major order where element k represents the route from origin i to destination j, calculated as: k = numDestinations * i + j"
       },
       {
         "slug": "HERE_GET_MATRIX_MATRIX_ID",
@@ -179700,7 +179700,7 @@
       {
         "slug": "HEYREACH_UPDATE_WEBHOOK",
         "name": "Update Webhook",
-        "description": "Tool to update an existing webhook’s configuration. Use when you need to modify a webhook's name, URL, event type, campaigns, or activation status after confirming the webhookId."
+        "description": "Tool to update an existing webhook\u2019s configuration. Use when you need to modify a webhook's name, URL, event type, campaigns, or activation status after confirming the webhookId."
       }
     ],
     "triggers": [],
@@ -179839,7 +179839,7 @@
   {
     "slug": "heyzine",
     "name": "Heyzine",
-    "logo": "https://heyzine.com/favicon.ico",
+    "logo": "https://logos.composio.dev/api/heyzine",
     "description": "Heyzine is a flipbook maker that converts PDFs into interactive, customizable digital publications with various page flip effects.",
     "category": "documents",
     "authSchemes": [
@@ -179950,7 +179950,7 @@
   {
     "slug": "highergov",
     "name": "Highergov",
-    "logo": "https://www.highergov.com/favicon.ico",
+    "logo": "https://logos.composio.dev/api/highergov",
     "description": "HigherGov is a market intelligence platform providing comprehensive data on U.S. federal, state, and local government contracts and grants.",
     "category": "business intelligence",
     "authSchemes": [
@@ -180147,7 +180147,7 @@
   {
     "slug": "honeyhive",
     "name": "Honeyhive",
-    "logo": "https://www.honeyhive.ai/logo.png",
+    "logo": "https://logos.composio.dev/api/honeyhive",
     "description": "HoneyHive is a modern AI observability and evaluation platform that enables developers and domain experts to collaboratively build reliable AI applications faster.",
     "category": "artificial intelligence",
     "authSchemes": [
@@ -180185,7 +180185,7 @@
       {
         "slug": "HONEYHIVE_CREATE_BATCH_TOOL_EVENTS",
         "name": "Create Batch Tool Events",
-        "description": "Tool to log a batch of external API calls as tool events. Use when you need to record multiple tool events in one request—use after gathering all event data."
+        "description": "Tool to log a batch of external API calls as tool events. Use when you need to record multiple tool events in one request\u2014use after gathering all event data."
       },
       {
         "slug": "HONEYHIVE_CREATE_CONFIGURATION",
@@ -180355,7 +180355,7 @@
       {
         "slug": "HONEYHIVE_UPDATE_METRIC",
         "name": "Update Metric",
-        "description": "Tool to update an existing metric. Use when you need to modify a metric’s properties after creation. Ensure you retrieve the metric first to verify its current state."
+        "description": "Tool to update an existing metric. Use when you need to modify a metric\u2019s properties after creation. Ensure you retrieve the metric first to verify its current state."
       },
       {
         "slug": "HONEYHIVE_UPDATE_PROJECT",
@@ -181100,7 +181100,7 @@
   {
     "slug": "html_to_image",
     "name": "HTML to Image",
-    "logo": "https://html2img.com/logo.png",
+    "logo": "https://logos.composio.dev/api/html_to_image",
     "description": "HTML to Image is a service that converts HTML and CSS into images or captures screenshots of web pages.",
     "category": "images & design",
     "authSchemes": [
@@ -182575,7 +182575,7 @@
   {
     "slug": "humanitix",
     "name": "Humanitix",
-    "logo": "https://humanitix.com/favicon.ico",
+    "logo": "https://logos.composio.dev/api/humanitix",
     "description": "Humanitix is a not-for-profit ticketing platform that donates 100% of its profits to charity.",
     "category": "event management",
     "authSchemes": [
@@ -182631,7 +182631,7 @@
   {
     "slug": "hunter",
     "name": "Hunter",
-    "logo": "https://logo.clearbit.com/hunter.io",
+    "logo": "https://logos.composio.dev/api/hunter",
     "description": "Hunter is an email marketing company specializing in lead generation and data enrichment.",
     "category": "email",
     "authSchemes": [
@@ -182694,7 +182694,7 @@
       {
         "slug": "HUNTER_DOMAIN_SEARCH",
         "name": "Domain Search",
-        "description": "Tool to search all email addresses for a given domain or company. Use when you need public emails and metadata for outreach or enrichment. Rate-limited; HTTP 429 returned on excess requests — honor the Retry-After header."
+        "description": "Tool to search all email addresses for a given domain or company. Use when you need public emails and metadata for outreach or enrichment. Rate-limited; HTTP 429 returned on excess requests \u2014 honor the Retry-After header."
       },
       {
         "slug": "HUNTER_EMAIL_COUNT",
@@ -182704,7 +182704,7 @@
       {
         "slug": "HUNTER_EMAIL_FINDER",
         "name": "Email Finder",
-        "description": "Tool to find the most likely email address for a person at a domain or company. Use when you have a person's name and a domain or company and need to infer their email. Results include a confidence score and status; treat emails with status 'accept_all' or 'risky' as lower reliability. Each call consumes API credits — avoid re-enriching the same contact."
+        "description": "Tool to find the most likely email address for a person at a domain or company. Use when you have a person's name and a domain or company and need to infer their email. Results include a confidence score and status; treat emails with status 'accept_all' or 'risky' as lower reliability. Each call consumes API credits \u2014 avoid re-enriching the same contact."
       },
       {
         "slug": "HUNTER_EMAIL_VERIFIER",
@@ -182802,7 +182802,7 @@
   {
     "slug": "hypeauditor",
     "name": "Hypeauditor",
-    "logo": "https://hypeauditor.com/favicon.ico",
+    "logo": "https://logos.composio.dev/api/hypeauditor",
     "description": "HypeAuditor provides comprehensive influencer marketing solutions, offering tools for influencer discovery, analytics, and campaign management across multiple social media platforms.",
     "category": "social media marketing",
     "authSchemes": [
@@ -182984,7 +182984,7 @@
       {
         "slug": "HYPERBROWSER_GET_SCRAPE_JOB_STATUS",
         "name": "Get Scrape Job Status",
-        "description": "Tool to retrieve the current status of a specific scrape job. Use after initiating a scrape job to poll its status; poll at moderate intervals (e.g., every 2–5 seconds) rather than tight loops to avoid exhausting quota. Responses may be large when the job includes screenshots or full HTML."
+        "description": "Tool to retrieve the current status of a specific scrape job. Use after initiating a scrape job to poll its status; poll at moderate intervals (e.g., every 2\u20135 seconds) rather than tight loops to avoid exhausting quota. Responses may be large when the job includes screenshots or full HTML."
       },
       {
         "slug": "HYPERBROWSER_GET_SESSION_DETAILS",
@@ -183127,7 +183127,7 @@
   {
     "slug": "hyperise",
     "name": "Hyperise",
-    "logo": "https://hyperise.com/images/logo.png",
+    "logo": "https://logos.composio.dev/api/hyperise",
     "description": "Hyperise is a personalization toolkit that enables sales and marketing teams to add dynamic, personalized elements to images, videos, and websites, enhancing engagement across various channels.",
     "category": "marketing automation",
     "authSchemes": [
@@ -183323,7 +183323,7 @@
   {
     "slug": "icypeas",
     "name": "Icypeas",
-    "logo": "https://www.icypeas.com/logo.png",
+    "logo": "https://logos.composio.dev/api/icypeas",
     "description": "Icypeas is an email discovery and verification tool that allows users to find and verify professional email addresses using first name, last name, and company domain.",
     "category": "email",
     "authSchemes": [
@@ -183522,7 +183522,7 @@
       {
         "slug": "IDENTITYCHECK_FETCH_ONBOARDINGS",
         "name": "Fetch Onboardings",
-        "description": "Retrieves identity verification onboarding sessions with comprehensive filtering and pagination. An onboarding represents a customer's identity verification journey, tracking their progress from link creation through document capture and verification completion. Each onboarding has a unique link sent via email/phone/none, and transitions through states: CREATED → CLICKED → CAPTURE_ONGOING → SUCCESS/ERROR/EXPIRED. Use this to: - Monitor verification sessions by status, date range, or customer identifiers - Track onboarding completion rates and error patterns - Retrieve specific onboardings by UID or business-specific identifiers - Analyze notification delivery methods and their effectiveness Returns paginated results with statistics (total results, distinct users, captures per document). All filter parameters are optional; omit them to retrieve all onboardings. Example: Find all failed verifications due to network errors in January 2024"
+        "description": "Retrieves identity verification onboarding sessions with comprehensive filtering and pagination. An onboarding represents a customer's identity verification journey, tracking their progress from link creation through document capture and verification completion. Each onboarding has a unique link sent via email/phone/none, and transitions through states: CREATED \u2192 CLICKED \u2192 CAPTURE_ONGOING \u2192 SUCCESS/ERROR/EXPIRED. Use this to: - Monitor verification sessions by status, date range, or customer identifiers - Track onboarding completion rates and error patterns - Retrieve specific onboardings by UID or business-specific identifiers - Analyze notification delivery methods and their effectiveness Returns paginated results with statistics (total results, distinct users, captures per document). All filter parameters are optional; omit them to retrieve all onboardings. Example: Find all failed verifications due to network errors in January 2024"
       },
       {
         "slug": "IDENTITYCHECK_GET_DOCUMENT_CONTENT",
@@ -183570,7 +183570,7 @@
   {
     "slug": "ignisign",
     "name": "Ignisign",
-    "logo": "https://ignisign.io/logo.png",
+    "logo": "https://logos.composio.dev/api/ignisign",
     "description": "IgniSign is a comprehensive electronic signature platform that enables users to sign, send, and manage documents securely online.",
     "category": "signatures",
     "authSchemes": [
@@ -183771,7 +183771,7 @@
   {
     "slug": "imagekit_io",
     "name": "ImageKit",
-    "logo": "https://imagekit.io/static/imagekit-logo.svg",
+    "logo": "https://logos.composio.dev/api/imagekit_io",
     "description": "ImageKit.io is a comprehensive media management solution offering real-time image and video optimization, transformation, and delivery through a global content delivery network (CDN).",
     "category": "images & design",
     "authSchemes": [
@@ -184039,7 +184039,7 @@
   {
     "slug": "imgbb",
     "name": "ImgBB",
-    "logo": "https://imgbb.com/favicon.ico",
+    "logo": "https://logos.composio.dev/api/imgbb",
     "description": "ImgBB is a free image hosting and sharing service that allows users to upload and share images easily.",
     "category": "images & design",
     "authSchemes": [
@@ -184090,7 +184090,7 @@
   {
     "slug": "imgix",
     "name": "Imgix",
-    "logo": "https://assets.imgix.net/press/imgix-logo.png",
+    "logo": "https://logos.composio.dev/api/imgix",
     "description": "imgix is a real-time image processing and delivery service that enables developers to optimize, transform, and deliver images efficiently.",
     "category": "images & design",
     "authSchemes": [
@@ -184138,7 +184138,7 @@
       {
         "slug": "IMGIX_BRI",
         "name": "Adjust Image Brightness",
-        "description": "Tool to adjust image brightness. Use when you need to modify an image's brightness level (−100 to 100) by supplying your source domain and asset path."
+        "description": "Tool to adjust image brightness. Use when you need to modify an image's brightness level (\u2212100 to 100) by supplying your source domain and asset path."
       },
       {
         "slug": "IMGIX_CANCEL_UPLOAD_SESSION",
@@ -184158,7 +184158,7 @@
       {
         "slug": "IMGIX_CON",
         "name": "Adjust Image Contrast",
-        "description": "Tool to adjust image contrast. Use when you need to modify an image's contrast level (−100 to 100)."
+        "description": "Tool to adjust image contrast. Use when you need to modify an image's contrast level (\u2212100 to 100)."
       },
       {
         "slug": "IMGIX_CREATE_IMGIX_SOURCE",
@@ -184228,7 +184228,7 @@
       {
         "slug": "IMGIX_HIGH",
         "name": "Adjust Image Highlights",
-        "description": "Tool to adjust highlight tonal mapping (−100 to 0). Use when preserving detail in bright areas of an image."
+        "description": "Tool to adjust highlight tonal mapping (\u2212100 to 0). Use when preserving detail in bright areas of an image."
       },
       {
         "slug": "IMGIX_LIST_ASSETS",
@@ -184313,7 +184313,7 @@
       {
         "slug": "IMGIX_ROT",
         "name": "Imgix Rotate",
-        "description": "Tool to rotate an image on Imgix. Use when you need to apply a counter-clockwise rotation (0–359°) with optional mode control."
+        "description": "Tool to rotate an image on Imgix. Use when you need to apply a counter-clockwise rotation (0\u2013359\u00b0) with optional mode control."
       },
       {
         "slug": "IMGIX_ROT_TYPE",
@@ -184867,7 +184867,7 @@
   {
     "slug": "influxdb_cloud",
     "name": "InfluxDB Cloud",
-    "logo": "https://www.influxdata.com/wp-content/uploads/influxdata-logo.png",
+    "logo": "https://logos.composio.dev/api/influxdb_cloud",
     "description": "InfluxDB Cloud is a fully managed, scalable, and secure time series database service designed for real-time analytics and monitoring.",
     "category": "databases",
     "authSchemes": [
@@ -185449,12 +185449,12 @@
       {
         "slug": "INSTAGRAM_CREATE_MEDIA_CONTAINER",
         "name": "Create Media Container (Deprecated)",
-        "description": "DEPRECATED: Use INSTAGRAM_POST_IG_USER_MEDIA instead. Creates a draft media container for photos/videos/reels before publishing. Business/Creator accounts only — personal accounts unsupported. Returns a container ID (data.id or data.creation_id) used as creation_id for publishing. Containers expire in ~24 hours — recreate stale containers rather than reusing old IDs. Before publishing via INSTAGRAM_CREATE_POST, call INSTAGRAM_GET_POST_STATUS and wait for FINISHED status — publishing before FINISHED triggers error 9007. Each creation_id is one-time-use; if container creation fails (status_code='ERROR'), fix media params and recreate via this tool rather than retrying publish with the failed ID."
+        "description": "DEPRECATED: Use INSTAGRAM_POST_IG_USER_MEDIA instead. Creates a draft media container for photos/videos/reels before publishing. Business/Creator accounts only \u2014 personal accounts unsupported. Returns a container ID (data.id or data.creation_id) used as creation_id for publishing. Containers expire in ~24 hours \u2014 recreate stale containers rather than reusing old IDs. Before publishing via INSTAGRAM_CREATE_POST, call INSTAGRAM_GET_POST_STATUS and wait for FINISHED status \u2014 publishing before FINISHED triggers error 9007. Each creation_id is one-time-use; if container creation fails (status_code='ERROR'), fix media params and recreate via this tool rather than retrying publish with the failed ID."
       },
       {
         "slug": "INSTAGRAM_CREATE_POST",
         "name": "Create Post (Deprecated)",
-        "description": "DEPRECATED: Use INSTAGRAM_POST_IG_USER_MEDIA_PUBLISH instead. Publish a draft media container to Instagram (final publishing step). Posts become immediately and publicly visible upon success — confirm intent before calling. Requires Business or Creator account with publish scopes; missing scopes return Graph error code 10. After creating a media container, Instagram may need time to process media before publishing. If called too early, error code 9007 is returned. This action automatically retries with exponential backoff (up to ~44 seconds total). For large videos, use INSTAGRAM_GET_POST_STATUS to poll until status_code='FINISHED' before calling; for carousels, all child containers must individually reach FINISHED status first. No native scheduling support — use an external scheduler to trigger this call at the desired time."
+        "description": "DEPRECATED: Use INSTAGRAM_POST_IG_USER_MEDIA_PUBLISH instead. Publish a draft media container to Instagram (final publishing step). Posts become immediately and publicly visible upon success \u2014 confirm intent before calling. Requires Business or Creator account with publish scopes; missing scopes return Graph error code 10. After creating a media container, Instagram may need time to process media before publishing. If called too early, error code 9007 is returned. This action automatically retries with exponential backoff (up to ~44 seconds total). For large videos, use INSTAGRAM_GET_POST_STATUS to poll until status_code='FINISHED' before calling; for carousels, all child containers must individually reach FINISHED status first. No native scheduling support \u2014 use an external scheduler to trigger this call at the desired time."
       },
       {
         "slug": "INSTAGRAM_DELETE_COMMENT",
@@ -185499,7 +185499,7 @@
       {
         "slug": "INSTAGRAM_GET_IG_USER_CONTENT_PUBLISHING_LIMIT",
         "name": "Get IG User Content Publishing Limit",
-        "description": "Get an Instagram Business Account's current content publishing usage. Use this to monitor quota usage before publishing; exceeding the daily cap blocks new posts until the quota resets (no partial failure — new publish calls are rejected until reset). IMPORTANT: This endpoint requires an IG User ID (Instagram Business Account ID), NOT an IGSID (Instagram Scoped ID). IGSID is only used for messaging-related endpoints. Content publishing endpoints require a proper IG User ID. Excessive polling of this endpoint may trigger Graph error 613 (rate limit); space calls several seconds apart."
+        "description": "Get an Instagram Business Account's current content publishing usage. Use this to monitor quota usage before publishing; exceeding the daily cap blocks new posts until the quota resets (no partial failure \u2014 new publish calls are rejected until reset). IMPORTANT: This endpoint requires an IG User ID (Instagram Business Account ID), NOT an IGSID (Instagram Scoped ID). IGSID is only used for messaging-related endpoints. Content publishing endpoints require a proper IG User ID. Excessive polling of this endpoint may trigger Graph error 613 (rate limit); space calls several seconds apart."
       },
       {
         "slug": "INSTAGRAM_GET_IG_USER_LIVE_MEDIA",
@@ -185544,7 +185544,7 @@
       {
         "slug": "INSTAGRAM_GET_POST_STATUS",
         "name": "Get Post Status (Deprecated)",
-        "description": "DEPRECATED: Use GetIgMedia instead. Check the processing status of a draft post container. Poll until status_code='FINISHED' before calling INSTAGRAM_CREATE_POST; publishing early triggers OAuthException 9007 (HTTP 400). If status_code='ERROR' or remains non-terminal after ~30 attempts, the container is permanently failed — recreate a new container. Poll every 3–5s with exponential backoff to avoid error 613/code 4/HTTP 429. For carousels, all child containers must reach FINISHED before publishing the parent."
+        "description": "DEPRECATED: Use GetIgMedia instead. Check the processing status of a draft post container. Poll until status_code='FINISHED' before calling INSTAGRAM_CREATE_POST; publishing early triggers OAuthException 9007 (HTTP 400). If status_code='ERROR' or remains non-terminal after ~30 attempts, the container is permanently failed \u2014 recreate a new container. Poll every 3\u20135s with exponential backoff to avoid error 613/code 4/HTTP 429. For carousels, all child containers must reach FINISHED before publishing the parent."
       },
       {
         "slug": "INSTAGRAM_GET_USER_INFO",
@@ -185559,12 +185559,12 @@
       {
         "slug": "INSTAGRAM_GET_USER_MEDIA",
         "name": "Get User Media (Deprecated)",
-        "description": "DEPRECATED: Use INSTAGRAM_GET_IG_USER_MEDIA instead. Get Instagram user's media (posts, photos, videos). Only works for connected Business or Creator accounts; personal accounts return no data. Response data is nested under `data.data`; unwrap before processing. Items mix images, videos, carousels, and reels — filter by `media_type` and `media_product_type`. Use `media_url` for file download, `permalink` for share links. Fields like `caption`, `like_count` may be null. Timestamps are UTC ISO 8601. HTTP 429 with `Retry-After` header indicates rate limiting."
+        "description": "DEPRECATED: Use INSTAGRAM_GET_IG_USER_MEDIA instead. Get Instagram user's media (posts, photos, videos). Only works for connected Business or Creator accounts; personal accounts return no data. Response data is nested under `data.data`; unwrap before processing. Items mix images, videos, carousels, and reels \u2014 filter by `media_type` and `media_product_type`. Use `media_url` for file download, `permalink` for share links. Fields like `caption`, `like_count` may be null. Timestamps are UTC ISO 8601. HTTP 429 with `Retry-After` header indicates rate limiting."
       },
       {
         "slug": "INSTAGRAM_LIST_ALL_CONVERSATIONS",
         "name": "List All Conversations",
-        "description": "List all Instagram DM conversations for the authenticated user. Requires a Business/Creator account with messaging permissions; personal accounts return empty results. Response conversations are nested under `data.data` — accessing top-level `data` as the final list returns zero items. An empty `data` list is a valid non-error outcome meaning no conversations exist in scope."
+        "description": "List all Instagram DM conversations for the authenticated user. Requires a Business/Creator account with messaging permissions; personal accounts return empty results. Response conversations are nested under `data.data` \u2014 accessing top-level `data` as the final list returns zero items. An empty `data` list is a valid non-error outcome meaning no conversations exist in scope."
       },
       {
         "slug": "INSTAGRAM_LIST_ALL_MESSAGES",
@@ -185574,7 +185574,7 @@
       {
         "slug": "INSTAGRAM_MARK_SEEN",
         "name": "Mark Seen",
-        "description": "Mark Instagram DM messages as read/seen for a specific user. Sends a 'mark_seen' sender action to indicate messages from the specified recipient have been read. Marking as seen is visible to the other party and changes inbox read state — use with explicit user approval in automated or bulk flows. IMPORTANT LIMITATIONS: - The sender_action API feature may have limited support on Instagram - The recipient must have an active 24-hour messaging window open - Requires instagram_manage_messages permission - Only works with Instagram Business or Creator accounts If this action fails with a 500 error, it may indicate that the sender_action feature is not supported for your Instagram account or the specific recipient."
+        "description": "Mark Instagram DM messages as read/seen for a specific user. Sends a 'mark_seen' sender action to indicate messages from the specified recipient have been read. Marking as seen is visible to the other party and changes inbox read state \u2014 use with explicit user approval in automated or bulk flows. IMPORTANT LIMITATIONS: - The sender_action API feature may have limited support on Instagram - The recipient must have an active 24-hour messaging window open - Requires instagram_manage_messages permission - Only works with Instagram Business or Creator accounts If this action fails with a 500 error, it may indicate that the sender_action feature is not supported for your Instagram account or the specific recipient."
       },
       {
         "slug": "INSTAGRAM_POST_IG_COMMENT_REPLIES",
@@ -185614,7 +185614,7 @@
       {
         "slug": "INSTAGRAM_SEND_TEXT_MESSAGE",
         "name": "Send Text Message",
-        "description": "Send a text message to an Instagram user via DM in an existing conversation. Cannot initiate new DM threads — a prior conversation must exist. Requires an Instagram Business or Creator account with messaging permissions. Fails with error_subcode 2534022 if outside the messaging window; do not retry these failures."
+        "description": "Send a text message to an Instagram user via DM in an existing conversation. Cannot initiate new DM threads \u2014 a prior conversation must exist. Requires an Instagram Business or Creator account with messaging permissions. Fails with error_subcode 2534022 if outside the messaging window; do not retry these failures."
       },
       {
         "slug": "INSTAGRAM_UPDATE_MESSENGER_PROFILE",
@@ -185677,7 +185677,7 @@
   {
     "slug": "instantly",
     "name": "Instantly",
-    "logo": "https://app.instantly.ai/favicon.ico",
+    "logo": "https://logos.composio.dev/api/instantly",
     "description": "Instantly is a platform designed to streamline cold email outreach by automating campaigns, managing leads, and enhancing email deliverability.",
     "category": "drip emails",
     "authSchemes": [
@@ -186235,7 +186235,7 @@
       {
         "slug": "INSTANTLY_UPDATE_LEAD_INTEREST_STATUS",
         "name": "Update Lead Interest Status",
-        "description": "Tool to update a lead's interest status. Use when you need to set or reset a lead’s interest status for follow-up actions."
+        "description": "Tool to update a lead's interest status. Use when you need to set or reset a lead\u2019s interest status for follow-up actions."
       },
       {
         "slug": "INSTANTLY_UPDATE_LEAD_LIST",
@@ -186449,7 +186449,7 @@
   {
     "slug": "ip2location",
     "name": "Ip2Location",
-    "logo": "https://www.ip2location.io/images/logo.png",
+    "logo": "https://logos.composio.dev/api/ip2location",
     "description": "IP2Location.io provides fast and accurate IP geolocation data, including country, city, ISP, latitude, longitude, and more, supporting both IPv4 and IPv6 lookups.",
     "category": "developer tools",
     "authSchemes": [
@@ -186642,7 +186642,7 @@
   {
     "slug": "ip2whois",
     "name": "Ip2Whois",
-    "logo": "https://www.ip2whois.com/images/logo.png",
+    "logo": "https://logos.composio.dev/api/ip2whois",
     "description": "IP2WHOIS provides a WHOIS lookup API that returns comprehensive domain information, including creation date, updated date, expiration date, domain age, registrant contact information, and nameservers.",
     "category": "security & identity tools",
     "authSchemes": [
@@ -186693,7 +186693,7 @@
   {
     "slug": "ipdata_co",
     "name": "Ipdata.co",
-    "logo": "https://ipdata.co/static/images/ipdata-logo.png",
+    "logo": "https://logos.composio.dev/api/ipdata_co",
     "description": "ipdata provides a simple HTTP-based API that allows you to look up the location, ownership, and threat profile of any IP address.",
     "category": "developer tools",
     "authSchemes": [
@@ -186874,7 +186874,7 @@
   {
     "slug": "ipinfo_io",
     "name": "Ipinfo.io",
-    "logo": "https://ipinfo.io/static/images/ipinfo-logo.png",
+    "logo": "https://logos.composio.dev/api/ipinfo_io",
     "description": "IPinfo.io provides a comprehensive API for IP address geolocation and related data.",
     "category": "developer tools",
     "authSchemes": [
@@ -187093,7 +187093,7 @@
       {
         "slug": "IQAIR_AIRVISUAL_GET_NEAREST_STATION_AIR_QUALITY",
         "name": "Get Nearest Station Air Quality",
-        "description": "Tool to get nearest station air quality. Use when you have GPS coordinates and need closest station’s AQI."
+        "description": "Tool to get nearest station air quality. Use when you have GPS coordinates and need closest station\u2019s AQI."
       },
       {
         "slug": "IQAIR_AIRVISUAL_GET_STATES",
@@ -187325,7 +187325,7 @@
       {
         "slug": "JOBNIMBUS_CONTACT_GET",
         "name": "Get Contact by ID",
-        "description": "Tool to retrieve a contact by ID. Use after obtaining the contact’s jnid to fetch full details."
+        "description": "Tool to retrieve a contact by ID. Use after obtaining the contact\u2019s jnid to fetch full details."
       },
       {
         "slug": "JOBNIMBUS_CONTACT_LIST",
@@ -188117,7 +188117,7 @@
       {
         "slug": "KAGGLE_CONFIG_VIEW",
         "name": "View Kaggle Configuration",
-        "description": "View local Kaggle API credentials and configuration settings. This action reads Kaggle configuration from local sources (does NOT make API calls to Kaggle). Configuration is retrieved in the following precedence order: 1. kaggle.json file (from KAGGLE_CONFIG_DIR env var, ~/.config/kaggle/, or ~/.kaggle/) 2. 'kaggle config view' CLI output (for proxy/path settings) 3. Environment variables (KAGGLE_USERNAME, KAGGLE_KEY) 4. Authorization header from metadata Use this action to: - Verify Kaggle credentials are configured before making API calls - Check current proxy settings - Debug authentication issues Returns empty strings for username/key if no credentials are found; use KAGGLE_CONFIG_INIT to set up credentials first. Note: username and key are independent — an empty username field does not indicate missing or invalid credentials. WARNING: This action returns sensitive API key data in plain text."
+        "description": "View local Kaggle API credentials and configuration settings. This action reads Kaggle configuration from local sources (does NOT make API calls to Kaggle). Configuration is retrieved in the following precedence order: 1. kaggle.json file (from KAGGLE_CONFIG_DIR env var, ~/.config/kaggle/, or ~/.kaggle/) 2. 'kaggle config view' CLI output (for proxy/path settings) 3. Environment variables (KAGGLE_USERNAME, KAGGLE_KEY) 4. Authorization header from metadata Use this action to: - Verify Kaggle credentials are configured before making API calls - Check current proxy settings - Debug authentication issues Returns empty strings for username/key if no credentials are found; use KAGGLE_CONFIG_INIT to set up credentials first. Note: username and key are independent \u2014 an empty username field does not indicate missing or invalid credentials. WARNING: This action returns sensitive API key data in plain text."
       },
       {
         "slug": "KAGGLE_DATASET_CREATE",
@@ -189344,7 +189344,7 @@
       {
         "slug": "KIEAI_GET_ALEPH_VIDEO_DETAILS",
         "name": "Get Aleph Video Details",
-        "description": "Retrieves details and status of an Aleph video generation task. Returns task information including current status (generating, success, or failed) and video URLs when complete. Use this action when checking the progress of a video generation task or retrieving the final video output after completion. This is a polling endpoint—call periodically until task completion. Note: Generated videos are only available for 14 days. The resultVideoUrl and resultImageUrl are only present when successFlag is 1 (success)."
+        "description": "Retrieves details and status of an Aleph video generation task. Returns task information including current status (generating, success, or failed) and video URLs when complete. Use this action when checking the progress of a video generation task or retrieving the final video output after completion. This is a polling endpoint\u2014call periodically until task completion. Note: Generated videos are only available for 14 days. The resultVideoUrl and resultImageUrl are only present when successFlag is 1 (success)."
       },
       {
         "slug": "KIEAI_GET_COVER_DETAILS",
@@ -189359,7 +189359,7 @@
       {
         "slug": "KIEAI_GET_GPT4O_IMAGE_DETAILS",
         "name": "Get GPT-4o Image Details",
-        "description": "Retrieves details and status of a GPT-4o image generation task. Returns task information including current status (generating, success, or failed) and image URLs when complete. Use when checking the progress of an image generation task or retrieving the final image output after completion. This is a polling endpoint—call periodically until task completion. Note: Image generation tasks return URLs that are available only for a limited time. Download images promptly after task completion."
+        "description": "Retrieves details and status of a GPT-4o image generation task. Returns task information including current status (generating, success, or failed) and image URLs when complete. Use when checking the progress of an image generation task or retrieving the final image output after completion. This is a polling endpoint\u2014call periodically until task completion. Note: Image generation tasks return URLs that are available only for a limited time. Download images promptly after task completion."
       },
       {
         "slug": "KIEAI_GET_LYRICS_DETAILS",
@@ -189374,7 +189374,7 @@
       {
         "slug": "KIEAI_GET_MIDI_DETAILS",
         "name": "Get MIDI Details",
-        "description": "Retrieves details and status of a MIDI generation task. Returns MIDI data including detected instruments, notes, timing, and velocity when the task is complete. Use when checking the progress of a MIDI generation task or retrieving the final MIDI output after completion. This is a polling endpoint—call periodically until task completion. Note: MIDI records are retained for 14 days. When using vocal separation with type 'split_stem', the midiData field may be empty. Check errorCode and errorMessage fields when successFlag indicates failure."
+        "description": "Retrieves details and status of a MIDI generation task. Returns MIDI data including detected instruments, notes, timing, and velocity when the task is complete. Use when checking the progress of a MIDI generation task or retrieving the final MIDI output after completion. This is a polling endpoint\u2014call periodically until task completion. Note: MIDI records are retained for 14 days. When using vocal separation with type 'split_stem', the midiData field may be empty. Check errorCode and errorMessage fields when successFlag indicates failure."
       },
       {
         "slug": "KIEAI_GET_MUSIC_DETAILS",
@@ -189384,12 +189384,12 @@
       {
         "slug": "KIEAI_GET_MUSIC_VIDEO_DETAILS",
         "name": "Get Music Video Details",
-        "description": "Retrieves details and status of a music video generation task. Returns task information including current status (PENDING, SUCCESS, or failed) and video URL when complete. Use when checking the progress of a music video generation task or retrieving the final video output after completion. This is a polling endpoint—call periodically until task completion. Note: Video records are only available within 14 days after generation."
+        "description": "Retrieves details and status of a music video generation task. Returns task information including current status (PENDING, SUCCESS, or failed) and video URL when complete. Use when checking the progress of a music video generation task or retrieving the final video output after completion. This is a polling endpoint\u2014call periodically until task completion. Note: Video records are only available within 14 days after generation."
       },
       {
         "slug": "KIEAI_GET_RUNWAY_VIDEO_DETAILS",
         "name": "Get Runway Video Details",
-        "description": "Retrieves details and status of a Runway video generation task. Returns comprehensive task information including the current state (wait, queueing, generating, success, or fail) and video URLs when the task is complete. Use this action when checking the progress of a Runway video generation task or retrieving the final video output after completion. This is a polling endpoint—call periodically until the task reaches a terminal state. Note: Video URLs returned in the response are valid for 14 days. For extension tasks, the parentTaskId field indicates the original generation task."
+        "description": "Retrieves details and status of a Runway video generation task. Returns comprehensive task information including the current state (wait, queueing, generating, success, or fail) and video URLs when the task is complete. Use this action when checking the progress of a Runway video generation task or retrieving the final video output after completion. This is a polling endpoint\u2014call periodically until the task reaches a terminal state. Note: Video URLs returned in the response are valid for 14 days. For extension tasks, the parentTaskId field indicates the original generation task."
       },
       {
         "slug": "KIEAI_GET_TIMESTAMPED_LYRICS_STATUS",
@@ -189409,12 +189409,12 @@
       {
         "slug": "KIEAI_GET_VEO_VIDEO_DETAILS",
         "name": "Get Veo Video Details",
-        "description": "Retrieves details and status of a Veo3.1 video generation task. Returns task information including current status (generating, success, or failed) and video URLs when complete. Use when checking the progress of a video generation task or retrieving the final video output after completion. This is a polling endpoint—call periodically until task completion. Note: Videos generated with fallback model cannot be upgraded to 1080P. Records are only available within 14 days."
+        "description": "Retrieves details and status of a Veo3.1 video generation task. Returns task information including current status (generating, success, or failed) and video URLs when complete. Use when checking the progress of a video generation task or retrieving the final video output after completion. This is a polling endpoint\u2014call periodically until task completion. Note: Videos generated with fallback model cannot be upgraded to 1080P. Records are only available within 14 days."
       },
       {
         "slug": "KIEAI_GET_WAV_DETAILS",
         "name": "Get WAV Details",
-        "description": "Retrieves the status and download URL for a WAV conversion task. Returns task information including current status (PENDING, SUCCESS, or failed) and the WAV audio URL when complete. Use when checking the progress of a WAV conversion task or retrieving the final audio output after completion. This is a polling endpoint—call periodically until task completion. Note: WAV files are retained for 14 days. The audioWavUrl is only available when successFlag is SUCCESS."
+        "description": "Retrieves the status and download URL for a WAV conversion task. Returns task information including current status (PENDING, SUCCESS, or failed) and the WAV audio URL when complete. Use when checking the progress of a WAV conversion task or retrieving the final audio output after completion. This is a polling endpoint\u2014call periodically until task completion. Note: WAV files are retained for 14 days. The audioWavUrl is only available when successFlag is SUCCESS."
       },
       {
         "slug": "KIEAI_REPLACE_MUSIC_SECTION",
@@ -190846,7 +190846,7 @@
                 "name": "generic_api_key",
                 "displayName": "API Key",
                 "type": "string",
-                "description": "Navigate to Integrations → data → API Key in your LeadBoxer dashboard",
+                "description": "Navigate to Integrations \u2192 data \u2192 API Key in your LeadBoxer dashboard",
                 "required": true,
                 "default": null
               },
@@ -191151,7 +191151,7 @@
                 "name": "username",
                 "displayName": "API Key ID",
                 "type": "string",
-                "description": "Navigate to Leexi → Settings → Company Settings → API Keys to generate your API Key ID",
+                "description": "Navigate to Leexi \u2192 Settings \u2192 Company Settings \u2192 API Keys to generate your API Key ID",
                 "required": true,
                 "default": null
               },
@@ -191159,7 +191159,7 @@
                 "name": "password",
                 "displayName": "API Key Secret",
                 "type": "string",
-                "description": "Navigate to Leexi → Settings → Company Settings → API Keys to generate your API Key Secret",
+                "description": "Navigate to Leexi \u2192 Settings \u2192 Company Settings \u2192 API Keys to generate your API Key Secret",
                 "required": true,
                 "default": null
               }
@@ -192770,7 +192770,7 @@
       {
         "slug": "LODGIFY_LIST_PROPERTIES",
         "name": "List Properties",
-        "description": "Retrieves all properties from the Lodgify account with optional pagination. Use this action to: - Get a list of all properties in the account - Iterate through properties using pagination - Check which properties exist before performing operations on specific properties Returns property IDs, names, and address details including coordinates. Paginate through all pages until results are exhausted — stopping early silently omits remaining properties. No server-side filtering by region or location; filter client-side using returned name or address fields."
+        "description": "Retrieves all properties from the Lodgify account with optional pagination. Use this action to: - Get a list of all properties in the account - Iterate through properties using pagination - Check which properties exist before performing operations on specific properties Returns property IDs, names, and address details including coordinates. Paginate through all pages until results are exhausted \u2014 stopping early silently omits remaining properties. No server-side filtering by region or location; filter client-side using returned name or address fields."
       },
       {
         "slug": "LODGIFY_LIST_RESERVATIONS",
@@ -192914,7 +192914,7 @@
       {
         "slug": "LOGO_DEV_SEARCH_BRAND",
         "name": "Search Brand",
-        "description": "Tool to search for brands based on a query string. Returns existing brand metadata only — no logo creation or editing. Use when you need to retrieve a list of matching brands with optional pagination and filters by country or industry. Results may include similar or ambiguous brand matches; verify the returned domain matches the intended brand before using brand IDs or domains in downstream calls."
+        "description": "Tool to search for brands based on a query string. Returns existing brand metadata only \u2014 no logo creation or editing. Use when you need to retrieve a list of matching brands with optional pagination and filters by country or industry. Results may include similar or ambiguous brand matches; verify the returned domain matches the intended brand before using brand IDs or domains in downstream calls."
       }
     ],
     "triggers": [],
@@ -195664,22 +195664,22 @@
       {
         "slug": "MAXIO_ARCHIVE_COMPONENT",
         "name": "Archive Component",
-        "description": "Archives a component to prevent new allocations. Use this action when you need to stop allowing new component allocations while keeping existing allocations active. This action is irreversible — once archived, the component cannot be used for new subscriptions, but existing subscriptions with the component will continue to work."
+        "description": "Archives a component to prevent new allocations. Use this action when you need to stop allowing new component allocations while keeping existing allocations active. This action is irreversible \u2014 once archived, the component cannot be used for new subscriptions, but existing subscriptions with the component will continue to work."
       },
       {
         "slug": "MAXIO_ARCHIVE_COMPONENT_PRICE_POINT",
         "name": "Archive Component Price Point",
-        "description": "Archives a component price point, making it inactive. Use when you need to deactivate a price point that is no longer needed but should not be permanently deleted. Archived price points are no longer available for new subscriptions but remain accessible for historical reference. This action is irreversible — once archived, a price point cannot be directly unarchived to its original state (use the unarchive action instead)."
+        "description": "Archives a component price point, making it inactive. Use when you need to deactivate a price point that is no longer needed but should not be permanently deleted. Archived price points are no longer available for new subscriptions but remain accessible for historical reference. This action is irreversible \u2014 once archived, a price point cannot be directly unarchived to its original state (use the unarchive action instead)."
       },
       {
         "slug": "MAXIO_ARCHIVE_COUPON",
         "name": "Archive Coupon",
-        "description": "Archives a coupon to prevent new uses. Use this action when you need to deactivate a coupon while preserving its redemption history. This action is irreversible — once archived, the coupon cannot be used for new subscriptions, but existing redemptions remain valid."
+        "description": "Archives a coupon to prevent new uses. Use this action when you need to deactivate a coupon while preserving its redemption history. This action is irreversible \u2014 once archived, the coupon cannot be used for new subscriptions, but existing redemptions remain valid."
       },
       {
         "slug": "MAXIO_ARCHIVE_OFFER",
         "name": "Archive Offer",
-        "description": "Archives an offer to prevent new subscriptions from using it. Use this action when you need to deactivate an offer while preserving existing subscriptions. This action is irreversible — once archived, the offer cannot be used for new subscriptions, but existing subscriptions using this offer will continue to function normally."
+        "description": "Archives an offer to prevent new subscriptions from using it. Use this action when you need to deactivate an offer while preserving existing subscriptions. This action is irreversible \u2014 once archived, the offer cannot be used for new subscriptions, but existing subscriptions using this offer will continue to function normally."
       },
       {
         "slug": "MAXIO_ARCHIVE_PRODUCT",
@@ -195714,7 +195714,7 @@
       {
         "slug": "MAXIO_CREATE_COMPONENT_PRICE_POINT",
         "name": "Create Component Price Point",
-        "description": "Creates a price point for a component in Maxio Advanced Billing. Use this action when you need to define a new pricing configuration (such as per-unit, tiered, volume, or stair-step pricing) for a component. This action is irreversible — once created, a price point cannot be deleted via API; it can only be archived."
+        "description": "Creates a price point for a component in Maxio Advanced Billing. Use this action when you need to define a new pricing configuration (such as per-unit, tiered, volume, or stair-step pricing) for a component. This action is irreversible \u2014 once created, a price point cannot be deleted via API; it can only be archived."
       },
       {
         "slug": "MAXIO_CREATE_COUPON_SUBCODES",
@@ -195824,7 +195824,7 @@
       {
         "slug": "MAXIO_DEACTIVATE_EVENT_BASED_COMPONENT",
         "name": "Deactivate Event Based Component",
-        "description": "Deactivates an event-based component on a subscription. Use when you need to disable event-based billing on a subscription, such as pausing usage tracking or stopping billing for a specific component. This action is commonly used to: - Pause event-based billing temporarily - Stop collecting events for a specific component - Deactivate a component before removing it from a subscription The endpoint requires both the subscription ID and component ID as path parameters. This action is reversible — the component can be reactivated using the corresponding activate action."
+        "description": "Deactivates an event-based component on a subscription. Use when you need to disable event-based billing on a subscription, such as pausing usage tracking or stopping billing for a specific component. This action is commonly used to: - Pause event-based billing temporarily - Stop collecting events for a specific component - Deactivate a component before removing it from a subscription The endpoint requires both the subscription ID and component ID as path parameters. This action is reversible \u2014 the component can be reactivated using the corresponding activate action."
       },
       {
         "slug": "MAXIO_DEDUCT_SERVICE_CREDIT",
@@ -195834,42 +195834,42 @@
       {
         "slug": "MAXIO_DELETE_COUPON_SUBCODE",
         "name": "Delete Coupon Subcode",
-        "description": "Deletes a specific subcode from an existing coupon in Maxio Advanced Billing. Use this action when you need to remove a single subcode from a coupon. This action is irreversible — the subcode will be permanently deleted and cannot be recovered once removed."
+        "description": "Deletes a specific subcode from an existing coupon in Maxio Advanced Billing. Use this action when you need to remove a single subcode from a coupon. This action is irreversible \u2014 the subcode will be permanently deleted and cannot be recovered once removed."
       },
       {
         "slug": "MAXIO_DELETE_CUSTOMER",
         "name": "Delete Customer",
-        "description": "Deletes a customer from Maxio/Chargify. Use this action when you need to permanently remove a customer record. This action is irreversible — once deleted, the customer cannot be recovered. Note: A customer can only be deleted if they have no associated subscriptions. Attempting to delete a customer with active subscriptions will result in an error."
+        "description": "Deletes a customer from Maxio/Chargify. Use this action when you need to permanently remove a customer record. This action is irreversible \u2014 once deleted, the customer cannot be recovered. Note: A customer can only be deleted if they have no associated subscriptions. Attempting to delete a customer with active subscriptions will result in an error."
       },
       {
         "slug": "MAXIO_DELETE_PREPAID_USAGE_ALLOCATION",
         "name": "Delete Prepaid Usage Allocation",
-        "description": "Deletes a prepaid usage allocation from a subscription component. Use this action when you need to remove a specific prepaid allocation that was previously created. This action is irreversible — once deleted, the allocation cannot be recovered. This action is commonly used to: - Remove incorrect or duplicate allocations - Clean up allocations that are no longer needed - Adjust prepaid usage when customers request refunds Note: Deleting an allocation will not automatically adjust billing. You may need to issue a credit or adjust subsequent invoices separately."
+        "description": "Deletes a prepaid usage allocation from a subscription component. Use this action when you need to remove a specific prepaid allocation that was previously created. This action is irreversible \u2014 once deleted, the allocation cannot be recovered. This action is commonly used to: - Remove incorrect or duplicate allocations - Clean up allocations that are no longer needed - Adjust prepaid usage when customers request refunds Note: Deleting an allocation will not automatically adjust billing. You may need to issue a credit or adjust subsequent invoices separately."
       },
       {
         "slug": "MAXIO_DELETE_REASON_CODE",
         "name": "Delete Reason Code",
-        "description": "Deletes a churn reason code from Maxio/Chargify Advanced Billing. Use this action when you need to permanently remove a reason code from your account. This action is irreversible — once deleted, the reason code cannot be recovered, and any associated reporting data will be affected. Note: This endpoint returns a 404 error if the reason code does not exist."
+        "description": "Deletes a churn reason code from Maxio/Chargify Advanced Billing. Use this action when you need to permanently remove a reason code from your account. This action is irreversible \u2014 once deleted, the reason code cannot be recovered, and any associated reporting data will be affected. Note: This endpoint returns a 404 error if the reason code does not exist."
       },
       {
         "slug": "MAXIO_DELETE_SUBSCRIPTION_GROUP",
         "name": "Delete Subscription Group",
-        "description": "Deletes a subscription group and all its associated data. Use this action when you need to permanently remove a subscription group from the system. This action is irreversible — once deleted, the subscription group and all its subscriptions cannot be recovered."
+        "description": "Deletes a subscription group and all its associated data. Use this action when you need to permanently remove a subscription group from the system. This action is irreversible \u2014 once deleted, the subscription group and all its subscriptions cannot be recovered."
       },
       {
         "slug": "MAXIO_DELETE_SUBSCRIPTION_NOTE",
         "name": "Delete Subscription Note",
-        "description": "Deletes a specific note from a subscription in Maxio Advanced Billing. Use this action when you need to remove a single note from a subscription. This action is irreversible — the note will be permanently deleted and cannot be recovered once removed."
+        "description": "Deletes a specific note from a subscription in Maxio Advanced Billing. Use this action when you need to remove a single note from a subscription. This action is irreversible \u2014 the note will be permanently deleted and cannot be recovered once removed."
       },
       {
         "slug": "MAXIO_DELETE_SUBSCRIPTION_PAYMENT_PROFILE",
         "name": "Delete Subscription Payment Profile",
-        "description": "Removes a payment profile from a subscription in Maxio Advanced Billing. Use when you need to unlink a credit card or payment method from a subscription, for example, when cleaning up obsolete payment profiles or replacing them with new ones. This action is irreversible — once the payment profile is removed from the subscription, it cannot be recovered through this endpoint."
+        "description": "Removes a payment profile from a subscription in Maxio Advanced Billing. Use when you need to unlink a credit card or payment method from a subscription, for example, when cleaning up obsolete payment profiles or replacing them with new ones. This action is irreversible \u2014 once the payment profile is removed from the subscription, it cannot be recovered through this endpoint."
       },
       {
         "slug": "MAXIO_DELETE_UNUSED_PAYMENT_PROFILE",
         "name": "Delete Unused Payment Profile",
-        "description": "Permanently deletes an unused payment profile from Maxio/Chargify. Use when you need to remove a payment profile that is no longer associated with any active subscriptions or payment references. This action is irreversible — once deleted, the payment profile cannot be recovered. Note: Only unused payment profiles can be deleted. Attempting to delete a profile that is currently in use (e.g., associated with an active subscription) will result in an error (422 Unprocessable Entity)."
+        "description": "Permanently deletes an unused payment profile from Maxio/Chargify. Use when you need to remove a payment profile that is no longer associated with any active subscriptions or payment references. This action is irreversible \u2014 once deleted, the payment profile cannot be recovered. Note: Only unused payment profiles can be deleted. Attempting to delete a profile that is currently in use (e.g., associated with an active subscription) will result in an error (422 Unprocessable Entity)."
       },
       {
         "slug": "MAXIO_DELIVER_PROFORMA_INVOICE",
@@ -195879,7 +195879,7 @@
       {
         "slug": "MAXIO_ENABLE_WEBHOOKS",
         "name": "Enable Webhooks",
-        "description": "Enables or disables webhooks for the Maxio/Chargify site. Use this action when you need to turn webhook notifications on or off. This can be useful during maintenance windows, troubleshooting, or when temporarily pausing webhook deliveries. Note: This action is idempotent — calling it with the same enabled value will not produce any side effects beyond the initial state change."
+        "description": "Enables or disables webhooks for the Maxio/Chargify site. Use this action when you need to turn webhook notifications on or off. This can be useful during maintenance windows, troubleshooting, or when temporarily pausing webhook deliveries. Note: This action is idempotent \u2014 calling it with the same enabled value will not produce any side effects beyond the initial state change."
       },
       {
         "slug": "MAXIO_EXPORT_INVOICES",
@@ -195904,7 +195904,7 @@
       {
         "slug": "MAXIO_INITIATE_DELAYED_CANCELLATION",
         "name": "Initiate Delayed Cancellation",
-        "description": "Schedules a subscription for cancellation at the end of its current billing period. Use when a customer requests to cancel their subscription but you want to allow them to continue using the service until the end of the current billing period. This action is reversible — the scheduled cancellation can be cancelled before it takes effect using the Cancel Delayed Cancellation action. Once the scheduled cancellation time passes, the subscription will be cancelled and cannot be automatically reactivated."
+        "description": "Schedules a subscription for cancellation at the end of its current billing period. Use when a customer requests to cancel their subscription but you want to allow them to continue using the service until the end of the current billing period. This action is reversible \u2014 the scheduled cancellation can be cancelled before it takes effect using the Cancel Delayed Cancellation action. Once the scheduled cancellation time passes, the subscription will be cancelled and cannot be automatically reactivated."
       },
       {
         "slug": "MAXIO_ISSUE_ADVANCE_INVOICE",
@@ -196149,7 +196149,7 @@
       {
         "slug": "MAXIO_PAUSE_SUBSCRIPTION",
         "name": "Pause Subscription",
-        "description": "Pauses an active subscription in Maxio (Chargify) Advanced Billing. Use when you need to temporarily suspend a subscription without canceling it, such as when a customer requests a pause in service or when there are payment issues that need to be resolved before billing can continue. When paused, the subscription will not be billed and the customer will not have access to the service. The subscription can be resumed using the Resume Subscription action. This action is reversible — resuming the subscription will restore the subscription to its previous state (typically 'active')."
+        "description": "Pauses an active subscription in Maxio (Chargify) Advanced Billing. Use when you need to temporarily suspend a subscription without canceling it, such as when a customer requests a pause in service or when there are payment issues that need to be resolved before billing can continue. When paused, the subscription will not be billed and the customer will not have access to the service. The subscription can be resumed using the Resume Subscription action. This action is reversible \u2014 resuming the subscription will restore the subscription to its previous state (typically 'active')."
       },
       {
         "slug": "MAXIO_PREVIEW_ALLOCATIONS",
@@ -196194,12 +196194,12 @@
       {
         "slug": "MAXIO_REACTIVATE_SUBSCRIPTION",
         "name": "Reactivate Subscription",
-        "description": "Reactivates a canceled subscription in Maxio (Chargify) Advanced Billing. Use when you need to restore a previously canceled subscription and resume billing for the customer. This action is reversible — you can cancel the subscription again if needed. The subscription will transition from 'canceled' state back to 'active' state and billing will resume according to the subscription's billing cycle."
+        "description": "Reactivates a canceled subscription in Maxio (Chargify) Advanced Billing. Use when you need to restore a previously canceled subscription and resume billing for the customer. This action is reversible \u2014 you can cancel the subscription again if needed. The subscription will transition from 'canceled' state back to 'active' state and billing will resume according to the subscription's billing cycle."
       },
       {
         "slug": "MAXIO_REACTIVATE_SUBSCRIPTION_GROUP",
         "name": "Reactivate Subscription Group",
-        "description": "Reactivates a canceled subscription group in Maxio/Chargify. Use this action when you need to restore a previously canceled subscription group and resume billing for all its associated subscriptions. This action is reversible — you can cancel the group again if needed."
+        "description": "Reactivates a canceled subscription group in Maxio/Chargify. Use this action when you need to restore a previously canceled subscription group and resume billing for all its associated subscriptions. This action is reversible \u2014 you can cancel the group again if needed."
       },
       {
         "slug": "MAXIO_READ_ACCOUNT_BALANCES",
@@ -196364,22 +196364,22 @@
       {
         "slug": "MAXIO_REFUND_INVOICE",
         "name": "Refund Invoice",
-        "description": "Creates a refund for a paid invoice. Use this action when you need to process a refund for a customer whose invoice has already been paid. The refund will be recorded against the invoice and a credit note may be generated depending on your settings. This action is irreversible — once a refund is processed, it cannot be automatically reversed. Ensure you have verified the refund amount and reason before executing. Note: The invoice must be in a 'paid' state to process a refund."
+        "description": "Creates a refund for a paid invoice. Use this action when you need to process a refund for a customer whose invoice has already been paid. The refund will be recorded against the invoice and a credit note may be generated depending on your settings. This action is irreversible \u2014 once a refund is processed, it cannot be automatically reversed. Ensure you have verified the refund amount and reason before executing. Note: The invoice must be in a 'paid' state to process a refund."
       },
       {
         "slug": "MAXIO_REFUND_PREPAYMENT",
         "name": "Refund Prepayment",
-        "description": "Refunds a prepayment made on a subscription. This action is irreversible — once a prepayment is refunded, the refund cannot be undone. Use this action when a customer requests a refund for a prepayment, or when you need to reverse an incorrectly applied prepayment. The refund amount will be returned to the customer according to your refund policy. Note: You must provide either `amount` (decimal string) or `amount_in_cents` (integer), but not both. If the prepayment was made through a payment profile (non-external), the `external` flag should be set appropriately."
+        "description": "Refunds a prepayment made on a subscription. This action is irreversible \u2014 once a prepayment is refunded, the refund cannot be undone. Use this action when a customer requests a refund for a prepayment, or when you need to reverse an incorrectly applied prepayment. The refund amount will be returned to the customer according to your refund policy. Note: You must provide either `amount` (decimal string) or `amount_in_cents` (integer), but not both. If the prepayment was made through a payment profile (non-external), the `external` flag should be set appropriately."
       },
       {
         "slug": "MAXIO_REMOVE_COUPON_FROM_SUBSCRIPTION",
         "name": "Remove Coupon from Subscription",
-        "description": "Removes an applied coupon from a subscription in Maxio (Chargify) Advanced Billing. Use when you need to remove a promotional discount from an existing subscription and restore regular pricing. This action is irreversible — the coupon will be permanently removed from the subscription and cannot be recovered without reapplying it. Note: If multiple coupons are applied to the subscription, all coupons will be removed. The subscription will then be billed at its regular product price."
+        "description": "Removes an applied coupon from a subscription in Maxio (Chargify) Advanced Billing. Use when you need to remove a promotional discount from an existing subscription and restore regular pricing. This action is irreversible \u2014 the coupon will be permanently removed from the subscription and cannot be recovered without reapplying it. Note: If multiple coupons are applied to the subscription, all coupons will be removed. The subscription will then be billed at its regular product price."
       },
       {
         "slug": "MAXIO_REMOVE_SUBSCRIPTION_FROM_GROUP",
         "name": "Remove Subscription from Group",
-        "description": "Removes a subscription from its subscription group in Maxio Advanced Billing. Use this action when you need to unlink a subscription from its group, such as when migrating a subscription to operate independently or reorganizing group membership. This action is irreversible — once the subscription is removed from the group, it cannot be recovered through this endpoint."
+        "description": "Removes a subscription from its subscription group in Maxio Advanced Billing. Use this action when you need to unlink a subscription from its group, such as when migrating a subscription to operate independently or reorganizing group membership. This action is irreversible \u2014 once the subscription is removed from the group, it cannot be recovered through this endpoint."
       },
       {
         "slug": "MAXIO_REOPEN_INVOICE",
@@ -196389,7 +196389,7 @@
       {
         "slug": "MAXIO_REPLAY_WEBHOOKS",
         "name": "Replay Webhooks",
-        "description": "Replays specified webhook deliveries in Maxio Advanced Billing. Use this action when you need to resend webhooks that may have failed, were not delivered, or need to be resent for any reason. Provide a list of webhook IDs to replay their corresponding events. This action is idempotent — calling it with the same webhook IDs will resend the same webhooks again."
+        "description": "Replays specified webhook deliveries in Maxio Advanced Billing. Use this action when you need to resend webhooks that may have failed, were not delivered, or need to be resent for any reason. Provide a list of webhook IDs to replay their corresponding events. This action is idempotent \u2014 calling it with the same webhook IDs will resend the same webhooks again."
       },
       {
         "slug": "MAXIO_RESET_SUBSCRIPTION_COMPONENTS_PRICE_POINTS",
@@ -196399,7 +196399,7 @@
       {
         "slug": "MAXIO_RESUME_SUBSCRIPTION",
         "name": "Resume Subscription",
-        "description": "Resumes a paused subscription in Maxio (Chargify) Advanced Billing. Use when you need to restore a previously paused subscription and resume billing and service delivery. This action is reversible — you can pause the subscription again if needed. The subscription will transition from 'paused' state back to 'active' state and billing will resume according to the subscription's billing cycle."
+        "description": "Resumes a paused subscription in Maxio (Chargify) Advanced Billing. Use when you need to restore a previously paused subscription and resume billing and service delivery. This action is reversible \u2014 you can pause the subscription again if needed. The subscription will transition from 'paused' state back to 'active' state and billing will resume according to the subscription's billing cycle."
       },
       {
         "slug": "MAXIO_RETRY_SUBSCRIPTION",
@@ -196409,7 +196409,7 @@
       {
         "slug": "MAXIO_REVOKE_BILLING_PORTAL_ACCESS",
         "name": "Revoke Billing Portal Access",
-        "description": "Revokes billing portal access for a customer. This action invalidates the customer's current billing portal invitation, preventing them from accessing the self-service portal to view invoices, update payment methods, or manage their subscription. Use this action when a customer requests to have their billing portal access removed, or when access needs to be terminated for security or billing reasons. This action is irreversible — once revoked, the customer will need to be re-invited to regain portal access. Note: The customer must already have portal access enabled. If the customer does not have an active portal invitation, the API may return an appropriate error."
+        "description": "Revokes billing portal access for a customer. This action invalidates the customer's current billing portal invitation, preventing them from accessing the self-service portal to view invoices, update payment methods, or manage their subscription. Use this action when a customer requests to have their billing portal access removed, or when access needs to be terminated for security or billing reasons. This action is irreversible \u2014 once revoked, the customer will need to be re-invited to regain portal access. Note: The customer must already have portal access enabled. If the customer does not have an active portal invitation, the API may return an appropriate error."
       },
       {
         "slug": "MAXIO_SEND_INVOICE",
@@ -196419,22 +196419,22 @@
       {
         "slug": "MAXIO_SEND_REQUEST_UPDATE_PAYMENT_EMAIL",
         "name": "Send Request Update Payment Email",
-        "description": "Sends an email to the customer requesting they update their payment method. Use when you need to prompt a customer to update their credit card or payment method on file. This is typically used when their current payment method is expiring, has been declined, or needs to be refreshed for any reason. The email will be sent to the billing email address associated with the subscription's customer account. The customer will receive a link to securely update their payment information through the billing portal. This action does not modify any subscription or payment data directly — it only triggers an email notification to the customer."
+        "description": "Sends an email to the customer requesting they update their payment method. Use when you need to prompt a customer to update their credit card or payment method on file. This is typically used when their current payment method is expiring, has been declined, or needs to be refreshed for any reason. The email will be sent to the billing email address associated with the subscription's customer account. The customer will receive a link to securely update their payment information through the billing portal. This action does not modify any subscription or payment data directly \u2014 it only triggers an email notification to the customer."
       },
       {
         "slug": "MAXIO_UNARCHIVE_COMPONENT_PRICE_POINT",
         "name": "Unarchive Component Price Point",
-        "description": "Unarchives a component price point, restoring it to active status. Use this action when you need to reactivate an archived price point that was previously deactivated. Once unarchived, the price point becomes available for new subscriptions again. This action is idempotent — unarchiving an already active price point has no effect."
+        "description": "Unarchives a component price point, restoring it to active status. Use this action when you need to reactivate an archived price point that was previously deactivated. Once unarchived, the price point becomes available for new subscriptions again. This action is idempotent \u2014 unarchiving an already active price point has no effect."
       },
       {
         "slug": "MAXIO_UNARCHIVE_OFFER",
         "name": "Unarchive Offer",
-        "description": "Unarchives a previously archived offer, making it available for new subscriptions again. Use this action when you need to restore an archived offer that was previously deactivated. This action is idempotent — unarchiving an already active offer has no effect."
+        "description": "Unarchives a previously archived offer, making it available for new subscriptions again. Use this action when you need to restore an archived offer that was previously deactivated. This action is idempotent \u2014 unarchiving an already active offer has no effect."
       },
       {
         "slug": "MAXIO_UNARCHIVE_PRODUCT_PRICE_POINT",
         "name": "Unarchive product price point",
-        "description": "Unarchives a product price point by its ID. Use when you need to restore an archived price point that was previously deactivated. Once unarchived, the price point becomes available for new subscriptions again. This action is idempotent — unarchiving an already active price point has no effect."
+        "description": "Unarchives a product price point by its ID. Use when you need to restore an archived price point that was previously deactivated. Once unarchived, the price point becomes available for new subscriptions again. This action is idempotent \u2014 unarchiving an already active price point has no effect."
       },
       {
         "slug": "MAXIO_UPDATE_AUTOMATIC_SUBSCRIPTION_RESUMPTION",
@@ -196444,7 +196444,7 @@
       {
         "slug": "MAXIO_UPDATE_COMPONENT",
         "name": "Update Component",
-        "description": "Updates a component's details in Chargify. Use when you need to modify the name, description, pricing scheme, or other attributes of an existing billing component. Only the fields you provide in the request will be updated — fields not included retain their current values. The component_id is required to identify which component to update. This action is idempotent — calling it with the same parameters will produce the same result without side effects."
+        "description": "Updates a component's details in Chargify. Use when you need to modify the name, description, pricing scheme, or other attributes of an existing billing component. Only the fields you provide in the request will be updated \u2014 fields not included retain their current values. The component_id is required to identify which component to update. This action is idempotent \u2014 calling it with the same parameters will produce the same result without side effects."
       },
       {
         "slug": "MAXIO_UPDATE_COMPONENT_PRICE_POINT",
@@ -196494,7 +196494,7 @@
       {
         "slug": "MAXIO_UPDATE_PRODUCT_FAMILY_COMPONENT",
         "name": "Update Product Family Component",
-        "description": "Updates a component within its product family in Maxio/Chargify. Use this action when you need to modify the configuration of an existing billing component (metered, quantity-based, on/off, prepaid usage, or event-based) within a product family. Only the fields provided in the component object will be updated. Fields not included in the request will retain their current values. The response returns the full updated component object. This is an idempotent operation — calling it multiple times with the same parameters will produce the same result."
+        "description": "Updates a component within its product family in Maxio/Chargify. Use this action when you need to modify the configuration of an existing billing component (metered, quantity-based, on/off, prepaid usage, or event-based) within a product family. Only the fields provided in the component object will be updated. Fields not included in the request will retain their current values. The response returns the full updated component object. This is an idempotent operation \u2014 calling it multiple times with the same parameters will produce the same result."
       },
       {
         "slug": "MAXIO_UPDATE_PRODUCT_PRICE_POINT",
@@ -196529,12 +196529,12 @@
       {
         "slug": "MAXIO_VOID_ADVANCE_INVOICE",
         "name": "Void Advance Invoice",
-        "description": "Voids an advance invoice for a subscription. This cancels the advance billing charges and prevents them from being processed. Use this action when you need to cancel or reverse an advance invoice before it is paid. This action is irreversible once executed — the advance invoice will be marked as voided and cannot be reinstated. Use with caution and ensure you have verified the correct invoice_uid before proceeding. Note: The invoice_uid is required to specify which advance invoice to void. Only advance invoices in 'open' or 'pending' state can be voided."
+        "description": "Voids an advance invoice for a subscription. This cancels the advance billing charges and prevents them from being processed. Use this action when you need to cancel or reverse an advance invoice before it is paid. This action is irreversible once executed \u2014 the advance invoice will be marked as voided and cannot be reinstated. Use with caution and ensure you have verified the correct invoice_uid before proceeding. Note: The invoice_uid is required to specify which advance invoice to void. Only advance invoices in 'open' or 'pending' state can be voided."
       },
       {
         "slug": "MAXIO_VOID_INVOICE",
         "name": "Void Invoice",
-        "description": "Voids an open invoice to stop future collection. Once voided, the invoice transitions from 'open' (or 'draft') to 'voided' state and will not be collected. Use when you need to cancel an invoice before payment is processed, such as when a customer cancels before payment is due, there's a billing error, or the service was not provided. This action is irreversible — once voided, the invoice cannot be restored to its previous state. Note: Only invoices in 'draft' or 'open' state can be voided. Voiding stops all future collection attempts and marks the invoice as permanently canceled."
+        "description": "Voids an open invoice to stop future collection. Once voided, the invoice transitions from 'open' (or 'draft') to 'voided' state and will not be collected. Use when you need to cancel an invoice before payment is processed, such as when a customer cancels before payment is due, there's a billing error, or the service was not provided. This action is irreversible \u2014 once voided, the invoice cannot be restored to its previous state. Note: Only invoices in 'draft' or 'open' state can be voided. Voiding stops all future collection attempts and marks the invoice as permanently canceled."
       }
     ],
     "triggers": [],
@@ -196654,12 +196654,12 @@
       {
         "slug": "MEM_DELETE_COLLECTION",
         "name": "Delete Collection",
-        "description": "Tool to permanently delete a Mem collection. Deletion is irreversible — only invoke after explicit user confirmation and verification of the correct collection_id."
+        "description": "Tool to permanently delete a Mem collection. Deletion is irreversible \u2014 only invoke after explicit user confirmation and verification of the correct collection_id."
       },
       {
         "slug": "MEM_DELETE_NOTE",
         "name": "Delete Note",
-        "description": "Tool to permanently delete a specific note. Deletion is irreversible — obtain explicit user confirmation before calling. Use when you need to remove a note by its unique identifier after confirming the note_id."
+        "description": "Tool to permanently delete a specific note. Deletion is irreversible \u2014 obtain explicit user confirmation before calling. Use when you need to remove a note by its unique identifier after confirming the note_id."
       },
       {
         "slug": "MEM_GET_COLLECTION",
@@ -197616,12 +197616,12 @@
       {
         "slug": "METABASE_GET_TABLE_QUERY_METADATA",
         "name": "Get Table Query Metadata",
-        "description": "Tool to get metadata about a Table useful for running queries. Returns DB, fields, field FKs, and field values. Deprecated: Use METABASE_GET_TABLE_SCHEMA instead — it provides a more concise, LLM-friendly output with FK resolution and supports lookup by table name."
+        "description": "Tool to get metadata about a Table useful for running queries. Returns DB, fields, field FKs, and field values. Deprecated: Use METABASE_GET_TABLE_SCHEMA instead \u2014 it provides a more concise, LLM-friendly output with FK resolution and supports lookup by table name."
       },
       {
         "slug": "METABASE_GET_TABLE_SCHEMA",
         "name": "Get Table Schema",
-        "description": "Gets column names, types, and foreign key relationships for a Metabase table. Use this before writing queries to know exact column names and types. Accepts either a table_id directly, or database_id + table_name to look up the table. Discovery chain: METABASE_LIST_DATABASES → METABASE_LIST_TABLES → METABASE_GET_TABLE_SCHEMA → METABASE_POST_API_DATASET."
+        "description": "Gets column names, types, and foreign key relationships for a Metabase table. Use this before writing queries to know exact column names and types. Accepts either a table_id directly, or database_id + table_name to look up the table. Discovery chain: METABASE_LIST_DATABASES \u2192 METABASE_LIST_TABLES \u2192 METABASE_GET_TABLE_SCHEMA \u2192 METABASE_POST_API_DATASET."
       },
       {
         "slug": "METABASE_GET_USER_KEY_VALUE",
@@ -200206,7 +200206,7 @@
       {
         "slug": "MOCO_LIST_PURCHASE_DRAFTS",
         "name": "List Purchase Drafts",
-        "description": "Tool to retrieve all purchase drafts (German: Ausgaben – Entwürfe). Use when you need to view all draft purchases that have been created but not yet finalized."
+        "description": "Tool to retrieve all purchase drafts (German: Ausgaben \u2013 Entw\u00fcrfe). Use when you need to view all draft purchases that have been created but not yet finalized."
       },
       {
         "slug": "MOCO_LIST_PURCHASES",
@@ -200706,7 +200706,7 @@
       {
         "slug": "MONDAY_MCP_CREATE_FORM",
         "name": "Create form",
-        "description": "Create a monday.com form. This will create a new form as well as a new board for which the form’s responses will be stored. The returned board_id is the ID of the board that was created while the returned formToken can be used for all future queries and mutations to continue editing the form."
+        "description": "Create a monday.com form. This will create a new form as well as a new board for which the form\u2019s responses will be stored. The returned board_id is the ID of the board that was created while the returned formToken can be used for all future queries and mutations to continue editing the form."
       },
       {
         "slug": "MONDAY_MCP_CREATE_GROUP",
@@ -200761,7 +200761,7 @@
       {
         "slug": "MONDAY_MCP_GET_FORM",
         "name": "Get form",
-        "description": "Get a monday.com form by its form token. Form tokens can be extracted from the form’s url. Given a form url, such as https://forms.monday.com/forms/abc123def456ghi789?r=use1, the token is the alphanumeric string that appears right after /forms/ and before the ?. In the example, the token is abc123def456ghi789."
+        "description": "Get a monday.com form by its form token. Form tokens can be extracted from the form\u2019s url. Given a form url, such as https://forms.monday.com/forms/abc123def456ghi789?r=use1, the token is the alphanumeric string that appears right after /forms/ and before the ?. In the example, the token is abc123def456ghi789."
       },
       {
         "slug": "MONDAY_MCP_GET_GRAPHQL_SCHEMA",
@@ -200796,7 +200796,7 @@
       {
         "slug": "MONDAY_MCP_LIST_USERS_AND_TEAMS",
         "name": "List users and teams",
-        "description": "Tool to fetch users and/or teams data. \n\n      MANDATORY BEST PRACTICES:\n      1. ALWAYS use specific IDs or names when available\n      2. If no ids available, use name search if possible (USERS ONLY)\n      3. Use 'getMe: true' to get current user information\n      4. AVOID broad queries (no parameters) - use only as last resort\n\n      REQUIRED PARAMETER PRIORITY (use in this order):\n      1. getMe - STANDALONE\n      2. userIds\n      3. name - STANDALONE (USERS ONLY, NOT for teams)\n      4. teamIds + teamsOnly\n      5. No parameters - LAST RESORT\n\n      CRITICAL USAGE RULES:\n      • userIds + teamIds requires explicit includeTeams: true flag\n      • includeTeams: true fetches both users and teams, do not use this to fetch a specific user's teams rather fetch that user by id and you will get their team memberships.\n      • name parameter is for USER search ONLY - it cannot be used to search for teams. Use teamIds to fetch specific teams."
+        "description": "Tool to fetch users and/or teams data. \n\n      MANDATORY BEST PRACTICES:\n      1. ALWAYS use specific IDs or names when available\n      2. If no ids available, use name search if possible (USERS ONLY)\n      3. Use 'getMe: true' to get current user information\n      4. AVOID broad queries (no parameters) - use only as last resort\n\n      REQUIRED PARAMETER PRIORITY (use in this order):\n      1. getMe - STANDALONE\n      2. userIds\n      3. name - STANDALONE (USERS ONLY, NOT for teams)\n      4. teamIds + teamsOnly\n      5. No parameters - LAST RESORT\n\n      CRITICAL USAGE RULES:\n      \u2022 userIds + teamIds requires explicit includeTeams: true flag\n      \u2022 includeTeams: true fetches both users and teams, do not use this to fetch a specific user's teams rather fetch that user by id and you will get their team memberships.\n      \u2022 name parameter is for USER search ONLY - it cannot be used to search for teams. Use teamIds to fetch specific teams."
       },
       {
         "slug": "MONDAY_MCP_LIST_WORKSPACES",
@@ -201641,7 +201641,7 @@
       {
         "slug": "MX_TECHNOLOGIES_CREATE_AUDIENCE_API_CREDENTIALS",
         "name": "Retrieve Audience API Credentials",
-        "description": "Tool to retrieve Audience API credentials. Use when obtaining client_id and client_secret for Audience Service authentication before generating an access token. Credentials must be created in the Partner Dashboard (Partner Administrator → Authentication → Audience API Key). The tool prefers explicitly provided values, then falls back to environment variables."
+        "description": "Tool to retrieve Audience API credentials. Use when obtaining client_id and client_secret for Audience Service authentication before generating an access token. Credentials must be created in the Partner Dashboard (Partner Administrator \u2192 Authentication \u2192 Audience API Key). The tool prefers explicitly provided values, then falls back to environment variables."
       },
       {
         "slug": "MX_TECHNOLOGIES_CREATE_MEMBER",
@@ -201966,7 +201966,7 @@
       {
         "slug": "NANGO_ACTION_TRIGGER_POST",
         "name": "Trigger Nango Action",
-        "description": "Trigger a Nango action to execute a workflow or operation. Use this to run pre-defined actions in your Nango integrations, such as creating issues, sending messages, or fetching data from external APIs. All three of `connection_id`, `provider_config_key`, and `action_name` must simultaneously match a pre-configured integration and connection in Nango — a valid `connection_id` alone is insufficient if the other two don't correspond to an existing setup. Actions may have real upstream side effects (e.g., creating records, sending messages); confirm intent before triggering non-read-only operations."
+        "description": "Trigger a Nango action to execute a workflow or operation. Use this to run pre-defined actions in your Nango integrations, such as creating issues, sending messages, or fetching data from external APIs. All three of `connection_id`, `provider_config_key`, and `action_name` must simultaneously match a pre-configured integration and connection in Nango \u2014 a valid `connection_id` alone is insufficient if the other two don't correspond to an existing setup. Actions may have real upstream side effects (e.g., creating records, sending messages); confirm intent before triggering non-read-only operations."
       },
       {
         "slug": "NANGO_ADD_CONNECTION",
@@ -203075,7 +203075,7 @@
       {
         "slug": "NEEDLE_LIST_COLLECTION_FILES",
         "name": "List Collection Files",
-        "description": "Tool to list all files within a specific collection by its ID. Returns file metadata (including file URLs) only — not document text content; fetch file URLs separately to access content. Use when you have a collection ID and need to retrieve its files. Supports pagination."
+        "description": "Tool to list all files within a specific collection by its ID. Returns file metadata (including file URLs) only \u2014 not document text content; fetch file URLs separately to access content. Use when you have a collection ID and need to retrieve its files. Supports pagination."
       },
       {
         "slug": "NEEDLE_LIST_COLLECTIONS",
@@ -204415,7 +204415,7 @@
       {
         "slug": "NEWS_API_GET_SOURCES",
         "name": "Get Sources",
-        "description": "Tool to fetch available news sources. Use when you need to retrieve a list of publishers by optional filters like category, language, or country. Source IDs returned here are the only valid IDs for filtering in NEWS_API_GET_EVERYTHING or NEWS_API_GET_TOP_HEADLINES — unrecognized IDs cause silently empty results."
+        "description": "Tool to fetch available news sources. Use when you need to retrieve a list of publishers by optional filters like category, language, or country. Source IDs returned here are the only valid IDs for filtering in NEWS_API_GET_EVERYTHING or NEWS_API_GET_TOP_HEADLINES \u2014 unrecognized IDs cause silently empty results."
       },
       {
         "slug": "NEWS_API_GET_TOP_HEADLINES",
@@ -205678,7 +205678,7 @@
                 "name": "generic_api_key",
                 "displayName": "API Token",
                 "type": "string",
-                "description": "Navigate to Settings → Integrations → API tokens in your Nozbe Teams account and create a new token",
+                "description": "Navigate to Settings \u2192 Integrations \u2192 API tokens in your Nozbe Teams account and create a new token",
                 "required": true,
                 "default": null
               }
@@ -206577,7 +206577,7 @@
       {
         "slug": "OCR_WEB_SERVICE_GET_ACCOUNT_INFORMATION",
         "name": "Get Account Information",
-        "description": "Retrieve OCRWebService account information including remaining pages, subscription plan, and expiration date. Use this tool to check your account status before large OCR jobs — exhausted page quotas will cause OCR_WEB_SERVICE_RECOGNIZE to fail mid-run. Returns details about your subscription including pages remaining and plan expiration. If credentials are invalid or stale, retrieve fresh user_name and license_code via OCR_WEB_SERVICE_GET_ACCOUNT_CREDENTIALS before retrying. Requires valid OCRWebService credentials (username and license code)."
+        "description": "Retrieve OCRWebService account information including remaining pages, subscription plan, and expiration date. Use this tool to check your account status before large OCR jobs \u2014 exhausted page quotas will cause OCR_WEB_SERVICE_RECOGNIZE to fail mid-run. Returns details about your subscription including pages remaining and plan expiration. If credentials are invalid or stale, retrieve fresh user_name and license_code via OCR_WEB_SERVICE_GET_ACCOUNT_CREDENTIALS before retrying. Requires valid OCRWebService credentials (username and license code)."
       },
       {
         "slug": "OCR_WEB_SERVICE_LOG",
@@ -206587,7 +206587,7 @@
       {
         "slug": "OCR_WEB_SERVICE_RECOGNIZE",
         "name": "OCRWebService Recognize",
-        "description": "Tool to call SOAP Recognize operation. Use when performing OCR on an image to retrieve text, output document, word coordinates, and errors. Consumes page quota per call; returns HTTP 429 when limits exceeded. Check quota via OCR_WEB_SERVICE_GET_ACCOUNT_INFORMATION before large jobs; batch large PDFs in ~25–50 page chunks."
+        "description": "Tool to call SOAP Recognize operation. Use when performing OCR on an image to retrieve text, output document, word coordinates, and errors. Consumes page quota per call; returns HTTP 429 when limits exceeded. Check quota via OCR_WEB_SERVICE_GET_ACCOUNT_INFORMATION before large jobs; batch large PDFs in ~25\u201350 page chunks."
       }
     ],
     "triggers": [],
@@ -206769,7 +206769,7 @@
                 "name": "generic_api_key",
                 "displayName": "API Key",
                 "type": "string",
-                "description": "Generate from User Profile → Preferences → Account Security → New API Key",
+                "description": "Generate from User Profile \u2192 Preferences \u2192 Account Security \u2192 New API Key",
                 "required": true,
                 "default": null
               }
@@ -207822,7 +207822,7 @@
       {
         "slug": "OPENAI_CREATE_MESSAGE",
         "name": "Create Message",
-        "description": "Tool to create a new message in a specific thread. Appends the message only — does not trigger a model response; create a separate run to obtain assistant replies. Use when adding messages to an existing conversation after confirming the thread ID."
+        "description": "Tool to create a new message in a specific thread. Appends the message only \u2014 does not trigger a model response; create a separate run to obtain assistant replies. Use when adding messages to an existing conversation after confirming the thread ID."
       },
       {
         "slug": "OPENAI_CREATE_MODERATION",
@@ -208167,7 +208167,7 @@
       {
         "slug": "OPENAI_LIST_MODELS",
         "name": "List models",
-        "description": "Tool to list available models scoped to the current account/organization — some public models may be absent due to permissions. Use when you need to discover which models you can call. Results may include deprecated or assistant-incompatible models; confirm a specific model's status via OPENAI_RETRIEVE_MODEL before using it in OPENAI_CREATE_ASSISTANT or other calls. Use model IDs exactly as returned — misspelled or unsupported IDs cause validation errors. Models vary in capability (vision, file-based features, context size); inspect metadata before assuming support. Filter results by id, owned_by, or status to handle large result sets efficiently."
+        "description": "Tool to list available models scoped to the current account/organization \u2014 some public models may be absent due to permissions. Use when you need to discover which models you can call. Results may include deprecated or assistant-incompatible models; confirm a specific model's status via OPENAI_RETRIEVE_MODEL before using it in OPENAI_CREATE_ASSISTANT or other calls. Use model IDs exactly as returned \u2014 misspelled or unsupported IDs cause validation errors. Models vary in capability (vision, file-based features, context size); inspect metadata before assuming support. Filter results by id, owned_by, or status to handle large result sets efficiently."
       },
       {
         "slug": "OPENAI_LIST_RUNS",
@@ -208272,7 +208272,7 @@
       {
         "slug": "OPENAI_RETRIEVE_MODEL",
         "name": "Retrieve model",
-        "description": "Tool to retrieve details of a specific model, confirming its metadata (ownership, created date) and verifying access under your org — a model appearing in OPENAI_LIST_MODELS does not guarantee access. Use before depending on a model ID in downstream calls."
+        "description": "Tool to retrieve details of a specific model, confirming its metadata (ownership, created date) and verifying access under your org \u2014 a model appearing in OPENAI_LIST_MODELS does not guarantee access. Use before depending on a model ID in downstream calls."
       },
       {
         "slug": "OPENAI_RETRIEVE_RUN",
@@ -208282,7 +208282,7 @@
       {
         "slug": "OPENAI_RETRIEVE_THREAD",
         "name": "Retrieve thread",
-        "description": "Tool to retrieve metadata of a specific thread by its ID — does not include message bodies or assistant replies (those require a completed run and separate message listing). Use before listing messages. After thread creation or message appending, wait 2–3 seconds before polling; use exponential backoff (1s, 2s, 4s) for HTTP 429 responses. Avoid concurrent OPENAI_CREATE_MESSAGE writes during retrieval to prevent inconsistent message states."
+        "description": "Tool to retrieve metadata of a specific thread by its ID \u2014 does not include message bodies or assistant replies (those require a completed run and separate message listing). Use before listing messages. After thread creation or message appending, wait 2\u20133 seconds before polling; use exponential backoff (1s, 2s, 4s) for HTTP 429 responses. Avoid concurrent OPENAI_CREATE_MESSAGE writes during retrieval to prevent inconsistent message states."
       },
       {
         "slug": "OPENAI_RETRIEVE_VECTOR_STORE_FILE_CONTENT",
@@ -208327,7 +208327,7 @@
       {
         "slug": "OPENAI_UPLOAD_FILE",
         "name": "Upload file",
-        "description": "Tool to upload a file for use across OpenAI endpoints. Use before referencing the file in tasks like fine-tuning. Returns a `file_id` that must be explicitly passed to endpoints like OPENAI_CREATE_ASSISTANT or OPENAI_CREATE_MESSAGE — uploaded files are not auto-discovered. Files exceeding size limits return HTTP 413; split or compress oversized content before retrying. Verify uploads via OPENAI_LIST_FILES before referencing `file_id`, as unsupported formats may be silently rejected. Repeated uploads accumulate against storage quotas; delete unused files with OPENAI_DELETE_FILE."
+        "description": "Tool to upload a file for use across OpenAI endpoints. Use before referencing the file in tasks like fine-tuning. Returns a `file_id` that must be explicitly passed to endpoints like OPENAI_CREATE_ASSISTANT or OPENAI_CREATE_MESSAGE \u2014 uploaded files are not auto-discovered. Files exceeding size limits return HTTP 413; split or compress oversized content before retrying. Verify uploads via OPENAI_LIST_FILES before referencing `file_id`, as unsupported formats may be silently rejected. Repeated uploads accumulate against storage quotas; delete unused files with OPENAI_DELETE_FILE."
       },
       {
         "slug": "OPENAI_VALIDATE_GRADER",
@@ -208640,7 +208640,7 @@
       {
         "slug": "OPENROUTER_LIST_AVAILABLE_MODELS",
         "name": "List Available Models",
-        "description": "Tool to list available models via OpenRouter API. Use after confirming authentication to fetch the model catalog. Use exact model IDs returned here in OPENROUTER_CREATE_CHAT_COMPLETION or OPENROUTER_CREATE_COMPLETION calls — hard-coded IDs may break when the catalog changes. Use exact author and slug values from this response as inputs to OPENROUTER_LIST_MODEL_ENDPOINTS. Models have varying capabilities (e.g., tools, reasoning); verify individual model capabilities before downstream use. Pricing and latency metadata may be null or approximate — handle missing values in routing logic."
+        "description": "Tool to list available models via OpenRouter API. Use after confirming authentication to fetch the model catalog. Use exact model IDs returned here in OPENROUTER_CREATE_CHAT_COMPLETION or OPENROUTER_CREATE_COMPLETION calls \u2014 hard-coded IDs may break when the catalog changes. Use exact author and slug values from this response as inputs to OPENROUTER_LIST_MODEL_ENDPOINTS. Models have varying capabilities (e.g., tools, reasoning); verify individual model capabilities before downstream use. Pricing and latency metadata may be null or approximate \u2014 handle missing values in routing logic."
       },
       {
         "slug": "OPENROUTER_LIST_EMBEDDING_MODELS",
@@ -208655,7 +208655,7 @@
       {
         "slug": "OPENROUTER_LIST_PROVIDERS",
         "name": "OpenRouter List Providers",
-        "description": "Tool to list all AI model providers available through the OpenRouter API. Use after authentication to retrieve available provider options for routing configuration. Providers differ in latency, context window sizes, and rate limits — switching providers affects these constraints. Newly added providers may not appear immediately due to catalog propagation delays."
+        "description": "Tool to list all AI model providers available through the OpenRouter API. Use after authentication to retrieve available provider options for routing configuration. Providers differ in latency, context window sizes, and rate limits \u2014 switching providers affects these constraints. Newly added providers may not appear immediately due to catalog propagation delays."
       },
       {
         "slug": "OPENROUTER_LIST_USER_MODELS",
@@ -210308,7 +210308,7 @@
       {
         "slug": "PARMA_DATA_JSON",
         "name": "Get data.json metadata",
-        "description": "Tool to retrieve DCAT-US 1.1 compliant metadata of all datasets. Use when you need the complete catalog JSON (data.json) from Parma’s open data portal."
+        "description": "Tool to retrieve DCAT-US 1.1 compliant metadata of all datasets. Use when you need the complete catalog JSON (data.json) from Parma\u2019s open data portal."
       },
       {
         "slug": "PARMA_DELETE_RELATIONSHIP",
@@ -210769,7 +210769,7 @@
       {
         "slug": "PARSEUR_UPDATE_WEBHOOK",
         "name": "Update webhook",
-        "description": "Tool to update an existing webhook’s settings. Use when you need to change the webhook’s target URL, event type, headers, or name after creation."
+        "description": "Tool to update an existing webhook\u2019s settings. Use when you need to change the webhook\u2019s target URL, event type, headers, or name after creation."
       },
       {
         "slug": "PARSEUR_UPLOAD_EMAIL_DOCUMENT",
@@ -212221,7 +212221,7 @@
       {
         "slug": "PDF4ME_CONVERT_TO_PDF",
         "name": "Convert to PDF",
-        "description": "Tool to convert various document and image formats to PDF. Handles one file per call; multi-file PDFs require multiple calls followed by a separate merge step. Conversion permanently removes interactive form field editability — retain the original file as backup, and ensure all form fields are populated before converting. Use when you need to transform base64-encoded files into PDFs before further processing."
+        "description": "Tool to convert various document and image formats to PDF. Handles one file per call; multi-file PDFs require multiple calls followed by a separate merge step. Conversion permanently removes interactive form field editability \u2014 retain the original file as backup, and ensure all form fields are populated before converting. Use when you need to transform base64-encoded files into PDFs before further processing."
       },
       {
         "slug": "PDF4ME_EXTRACT_TEXT",
@@ -212343,7 +212343,7 @@
       {
         "slug": "PDFMONKEY_CREATE_TEMPLATE",
         "name": "Create Template",
-        "description": "Creates a new PDF document template in PDFMonkey. Use this to define reusable templates with HTML/Liquid content and CSS styles for generating PDF documents. Typical workflow: Create template → Preview with draft content → Publish → Generate documents. The template supports Liquid templating syntax (e.g., {{variable_name}}) for dynamic content injection. Only 'identifier' is required; all other fields have sensible defaults."
+        "description": "Creates a new PDF document template in PDFMonkey. Use this to define reusable templates with HTML/Liquid content and CSS styles for generating PDF documents. Typical workflow: Create template \u2192 Preview with draft content \u2192 Publish \u2192 Generate documents. The template supports Liquid templating syntax (e.g., {{variable_name}}) for dynamic content injection. Only 'identifier' is required; all other fields have sensible defaults."
       },
       {
         "slug": "PDFMONKEY_DELETE_DOCUMENT",
@@ -212413,7 +212413,7 @@
       {
         "slug": "PDFMONKEY_UPDATE_TEMPLATE",
         "name": "Update Document Template",
-        "description": "Tool to update a document template’s properties. Use when you need to modify an existing template’s content, styles, settings, engine, folder, or TTL."
+        "description": "Tool to update a document template\u2019s properties. Use when you need to modify an existing template\u2019s content, styles, settings, engine, folder, or TTL."
       },
       {
         "slug": "PDFMONKEY_VIEW_PUBLIC_SHARE_LINK",
@@ -212936,7 +212936,7 @@
                 "name": "generic_api_key",
                 "displayName": "Access Token",
                 "type": "string",
-                "description": "Access token from Your account → Access tokens in Penpot profile settings",
+                "description": "Access token from Your account \u2192 Access tokens in Penpot profile settings",
                 "required": true,
                 "default": null
               }
@@ -212968,7 +212968,7 @@
       {
         "slug": "PERIGON_GET_COMPANIES",
         "name": "Get Companies",
-        "description": "Tool to retrieve information on companies in Perigon’s entity database. Use when you need a full list of companies. Use after confirming a valid API key is present."
+        "description": "Tool to retrieve information on companies in Perigon\u2019s entity database. Use when you need a full list of companies. Use after confirming a valid API key is present."
       },
       {
         "slug": "PERIGON_GET_JOURNALISTS",
@@ -212998,7 +212998,7 @@
       {
         "slug": "PERIGON_VECTOR_SEARCH_ARTICLES",
         "name": "Vector Search Articles",
-        "description": "Tool to perform a vector search on Perigon’s real-time news database. Use when you need to retrieve semantically similar news articles given a natural language query."
+        "description": "Tool to perform a vector search on Perigon\u2019s real-time news database. Use when you need to retrieve semantically similar news articles given a natural language query."
       },
       {
         "slug": "PERIGON_VECTOR_SEARCH_WIKIPEDIA",
@@ -214816,7 +214816,7 @@
       {
         "slug": "PLAIN_FETCH_ISSUES",
         "name": "Fetch Issues",
-        "description": "Fetches external issue tracker links (Jira, Linear, GitHub, etc.) associated with a customer's threads. Returns a flattened list of all issue links across the customer's threads, including the thread context for each issue. Useful for getting a complete view of all external issues related to a customer. With defaults, returns up to threadFirst×linkFirst (2,500) total issue links; results are truncated if limits are exceeded, so reduce threadFirst or linkFirst for large datasets."
+        "description": "Fetches external issue tracker links (Jira, Linear, GitHub, etc.) associated with a customer's threads. Returns a flattened list of all issue links across the customer's threads, including the thread context for each issue. Useful for getting a complete view of all external issues related to a customer. With defaults, returns up to threadFirst\u00d7linkFirst (2,500) total issue links; results are truncated if limits are exceeded, so reduce threadFirst or linkFirst for large datasets."
       },
       {
         "slug": "PLAIN_FETCH_TIER",
@@ -215553,7 +215553,7 @@
       {
         "slug": "POLYGON_GET_ALL_TICKERS",
         "name": "Get All Tickers",
-        "description": "Tool to retrieve all ticker symbols across asset classes. Use when you need to filter by market or exchange and paginate through results. Without filters, result sets can be extremely large — always narrow queries using `market`, `search`, `ticker`, or `exchange`."
+        "description": "Tool to retrieve all ticker symbols across asset classes. Use when you need to filter by market or exchange and paginate through results. Without filters, result sets can be extremely large \u2014 always narrow queries using `market`, `search`, `ticker`, or `exchange`."
       },
       {
         "slug": "POLYGON_GET_CONDITION_CODES",
@@ -215598,7 +215598,7 @@
       {
         "slug": "POLYGON_GET_CRYPTO_PREV_CLOSE",
         "name": "Get Crypto Previous Close",
-        "description": "Tool to retrieve previous day’s close for a crypto ticker. Use when you need the last closing price of a cryptocurrency before analysis or trading."
+        "description": "Tool to retrieve previous day\u2019s close for a crypto ticker. Use when you need the last closing price of a cryptocurrency before analysis or trading."
       },
       {
         "slug": "POLYGON_GET_CRYPTO_RSI",
@@ -215818,7 +215818,7 @@
       {
         "slug": "POLYGON_GET_PREVIOUS_CLOSE",
         "name": "Get Previous Close",
-        "description": "Tool to get previous trading day’s OHLC and volume for a stock. Use when you need the last day’s open, high, low, close, and volume for a given ticker."
+        "description": "Tool to get previous trading day\u2019s OHLC and volume for a stock. Use when you need the last day\u2019s open, high, low, close, and volume for a given ticker."
       },
       {
         "slug": "POLYGON_GET_REFERENCE_EXCHANGES",
@@ -217941,7 +217941,7 @@
       {
         "slug": "POSTMARK_EDIT_WEBHOOK",
         "name": "Edit Webhook",
-        "description": "Tool to update an existing webhook’s URL or triggers. Use when you need to modify webhook settings after confirming the webhookID."
+        "description": "Tool to update an existing webhook\u2019s URL or triggers. Use when you need to modify webhook settings after confirming the webhookID."
       },
       {
         "slug": "POSTMARK_GET_BOUNCE_COUNTS",
@@ -221086,7 +221086,7 @@
       {
         "slug": "RADAR_DELETE_GEOFENCE",
         "name": "Delete Geofence",
-        "description": "Tool to delete a geofence by ID. Use when supplying a geofence’s unique identifier to remove it."
+        "description": "Tool to delete a geofence by ID. Use when supplying a geofence\u2019s unique identifier to remove it."
       },
       {
         "slug": "RADAR_DELETE_GEOFENCE_BY_TAG",
@@ -224898,7 +224898,7 @@
       {
         "slug": "RENDER_TRIGGER_DEPLOY",
         "name": "Trigger Deploy",
-        "description": "Tool to trigger a new deploy for a specified service. Requires the service to already exist on Render and be linked to a Git repo — initial setup and repo linking must be done in the Render UI. Use when you need to manually start a new build and deployment process, such as after updating service configuration or pushing code changes that Render does not auto-apply."
+        "description": "Tool to trigger a new deploy for a specified service. Requires the service to already exist on Render and be linked to a Git repo \u2014 initial setup and repo linking must be done in the Render UI. Use when you need to manually start a new build and deployment process, such as after updating service configuration or pushing code changes that Render does not auto-apply."
       },
       {
         "slug": "RENDER_UPDATE_ENV_GROUP",
@@ -226640,7 +226640,7 @@
       {
         "slug": "REPLICATE_FILES_LIST",
         "name": "List Files",
-        "description": "Tool to retrieve a paginated list of uploaded files. Use to view all files created by the authenticated user or organization. Files are sorted with most recent first. Pagination is cursor-based: follow the next cursor until empty to retrieve all files. Limit requests to 1–2/second to avoid 429 Too Many Requests errors. Use to validate current file_ids before passing to prediction tools, as stale file_ids cause runtime errors."
+        "description": "Tool to retrieve a paginated list of uploaded files. Use to view all files created by the authenticated user or organization. Files are sorted with most recent first. Pagination is cursor-based: follow the next cursor until empty to retrieve all files. Limit requests to 1\u20132/second to avoid 429 Too Many Requests errors. Use to validate current file_ids before passing to prediction tools, as stale file_ids cause runtime errors."
       },
       {
         "slug": "REPLICATE_GET_PREDICTION",
@@ -226660,7 +226660,7 @@
       {
         "slug": "REPLICATE_MODELS_GET",
         "name": "Get Model Details",
-        "description": "Tool to get details of a specific model by owner and name. Consult the returned input schema before constructing any prediction request — each model defines its own required/optional fields (e.g., `prompt`, `aspect_ratio`, `version`); missing or unknown keys cause validation errors. Model schemas and available versions may change over time; recheck before production use."
+        "description": "Tool to get details of a specific model by owner and name. Consult the returned input schema before constructing any prediction request \u2014 each model defines its own required/optional fields (e.g., `prompt`, `aspect_ratio`, `version`); missing or unknown keys cause validation errors. Model schemas and available versions may change over time; recheck before production use."
       },
       {
         "slug": "REPLICATE_MODELS_LIST",
@@ -226675,7 +226675,7 @@
       {
         "slug": "REPLICATE_MODELS_README_GET",
         "name": "Get Model README",
-        "description": "Tool to get the README content for a model in Markdown format. Consult alongside REPLICATE_MODELS_EXAMPLES_LIST before calling REPLICATE_CREATE_PREDICTION — Replicate enforces strict JSON schemas on model inputs and returns 422 errors for incorrect keys or types. Use after retrieving model details when you want to view its documentation."
+        "description": "Tool to get the README content for a model in Markdown format. Consult alongside REPLICATE_MODELS_EXAMPLES_LIST before calling REPLICATE_CREATE_PREDICTION \u2014 Replicate enforces strict JSON schemas on model inputs and returns 422 errors for incorrect keys or types. Use after retrieving model details when you want to view its documentation."
       },
       {
         "slug": "REPLICATE_MODELS_VERSIONS_GET",
@@ -227383,7 +227383,7 @@
       {
         "slug": "RESEND_SEND_EMAIL",
         "name": "Send Email",
-        "description": "Send an email using Resend. Confirm recipients and content with the user before invoking — sends are irreversible. All recipients must be listed explicitly via `to`, `cc`, or `bcc`; audience-based sending is unsupported. Render HTML or plain text externally before passing via `html` or `text`."
+        "description": "Send an email using Resend. Confirm recipients and content with the user before invoking \u2014 sends are irreversible. All recipients must be listed explicitly via `to`, `cc`, or `bcc`; audience-based sending is unsupported. Render HTML or plain text externally before passing via `html` or `text`."
       },
       {
         "slug": "RESEND_UPDATE_BROADCAST",
@@ -231719,7 +231719,7 @@
       {
         "slug": "SALESFORCE_SERVICE_CLOUD_GENERATE_SIGNED_JWT_ASSERTION",
         "name": "Generate Signed JWT Assertion",
-        "description": "Tool to generate a signed JWT assertion for Salesforce JWT bearer OAuth flow. Use when you need to perform server-to-server authentication using a connected app’s certificate. Use before exchanging the assertion for an access token."
+        "description": "Tool to generate a signed JWT assertion for Salesforce JWT bearer OAuth flow. Use when you need to perform server-to-server authentication using a connected app\u2019s certificate. Use before exchanging the assertion for an access token."
       },
       {
         "slug": "SALESFORCE_SERVICE_CLOUD_GET_CASE_RECORD",
@@ -233030,7 +233030,7 @@
       {
         "slug": "SCRAPE_DO_GET_PAGE",
         "name": "Scrape webpage using scrape.do",
-        "description": "A tool to scrape web pages using scrape.do's API service. Makes a basic GET request to fetch webpage content while handling anti-bot protections and proxy rotation automatically. Does not execute JavaScript by default — pages requiring client-side rendering (SPAs, dynamically loaded content) will return incomplete HTML; use SCRAPE_DO_GET_RENDER_PAGE or set render=true for those cases."
+        "description": "A tool to scrape web pages using scrape.do's API service. Makes a basic GET request to fetch webpage content while handling anti-bot protections and proxy rotation automatically. Does not execute JavaScript by default \u2014 pages requiring client-side rendering (SPAs, dynamically loaded content) will return incomplete HTML; use SCRAPE_DO_GET_RENDER_PAGE or set render=true for those cases."
       },
       {
         "slug": "SCRAPE_DO_LIST_ASYNC_JOBS",
@@ -233634,7 +233634,7 @@
   {
     "slug": "seat_geek",
     "name": "Seat Geek",
-    "logo": "https://seatgeek.com/favicon.ico",
+    "logo": "https://logos.composio.dev/api/seat_geek",
     "description": "SeatGeek Platform API provides access to events, venues, and performers data for concerts, sports, theater, and other live entertainment",
     "category": "event management",
     "authSchemes": [
@@ -233682,7 +233682,7 @@
       {
         "slug": "SEAT_GEEK_SEARCH_EVENTS",
         "name": "Search Events",
-        "description": "Search for ticketed events on SeatGeek by performers, venues, dates, or general queries. Covers concerts, sports games, theater shows, and other live entertainment. Only indexes ticketed events; empty results may indicate coverage gaps. Avoid over-filtering — start broad and progressively narrow. lat and lon parameters must be supplied together for location-based filtering."
+        "description": "Search for ticketed events on SeatGeek by performers, venues, dates, or general queries. Covers concerts, sports games, theater shows, and other live entertainment. Only indexes ticketed events; empty results may indicate coverage gaps. Avoid over-filtering \u2014 start broad and progressively narrow. lat and lon parameters must be supplied together for location-based filtering."
       },
       {
         "slug": "SEAT_GEEK_SEARCH_PERFORMERS",
@@ -233855,7 +233855,7 @@
       {
         "slug": "SEGMENT_GET_DESTINATION",
         "name": "Get Destination",
-        "description": "Tool to retrieve a Destination by ID. Use when you need to fetch the full configuration of a Segment Destination instance by its unique identifier. Falls back US→EU public API and legacy app endpoint; returns minimal envelope on legacy HTML or parse errors."
+        "description": "Tool to retrieve a Destination by ID. Use when you need to fetch the full configuration of a Segment Destination instance by its unique identifier. Falls back US\u2192EU public API and legacy app endpoint; returns minimal envelope on legacy HTML or parse errors."
       },
       {
         "slug": "SEGMENT_GROUP",
@@ -236307,7 +236307,7 @@
       {
         "slug": "SHIPENGINE_LIST_WEBHOOK_EVENTS",
         "name": "List Webhook Events",
-        "description": "Retrieve a list of available webhook event types supported by ShipEngine. Returns static documentation of all supported webhook events that can be used when creating webhooks. Always call this before SHIPENGINE_CREATE_WEBHOOK to obtain valid event type names — unsupported or mistyped event names result in no callbacks being received. Note: This is based on ShipEngine's documented event types as there is no API endpoint for listing events."
+        "description": "Retrieve a list of available webhook event types supported by ShipEngine. Returns static documentation of all supported webhook events that can be used when creating webhooks. Always call this before SHIPENGINE_CREATE_WEBHOOK to obtain valid event type names \u2014 unsupported or mistyped event names result in no callbacks being received. Note: This is based on ShipEngine's documented event types as there is no API endpoint for listing events."
       },
       {
         "slug": "SHIPENGINE_LIST_WEBHOOKS",
@@ -237500,7 +237500,7 @@
       {
         "slug": "SHOTSTACK_FETCH_SOURCE",
         "name": "Fetch Source",
-        "description": "Tool to fetch a remote media file and store it as a source asset. Operation is asynchronous — poll SHOTSTACK_GET_INGEST_STATUS or SHOTSTACK_INSPECT_MEDIA until the asset is ready before passing it to SHOTSTACK_RENDER_VIDEO or other downstream tools. Use when you need to ingest a file before rendering."
+        "description": "Tool to fetch a remote media file and store it as a source asset. Operation is asynchronous \u2014 poll SHOTSTACK_GET_INGEST_STATUS or SHOTSTACK_INSPECT_MEDIA until the asset is ready before passing it to SHOTSTACK_RENDER_VIDEO or other downstream tools. Use when you need to ingest a file before rendering."
       },
       {
         "slug": "SHOTSTACK_GET_ASSETS",
@@ -237520,7 +237520,7 @@
       {
         "slug": "SHOTSTACK_GET_RENDER_CALLBACK",
         "name": "Get Render Callback",
-        "description": "Tool to retrieve the webhook/callback URL configuration for a specific render job. Returns only callback settings (URL, method, headers), not render status or output URLs — use a separate render-status check to obtain final results."
+        "description": "Tool to retrieve the webhook/callback URL configuration for a specific render job. Returns only callback settings (URL, method, headers), not render status or output URLs \u2014 use a separate render-status check to obtain final results."
       },
       {
         "slug": "SHOTSTACK_GET_RENDER_STATUS",
@@ -237530,7 +237530,7 @@
       {
         "slug": "SHOTSTACK_GET_SOURCE",
         "name": "Get Source Details",
-        "description": "Tool to fetch the details of a specific source asset. Use when you need to inspect a source after uploading, check its status, or diagnose ingest/render failures—such as unsupported codecs, corrupt files, or bad URLs—before retrying."
+        "description": "Tool to fetch the details of a specific source asset. Use when you need to inspect a source after uploading, check its status, or diagnose ingest/render failures\u2014such as unsupported codecs, corrupt files, or bad URLs\u2014before retrying."
       },
       {
         "slug": "SHOTSTACK_GET_TEMPLATE",
@@ -237550,7 +237550,7 @@
       {
         "slug": "SHOTSTACK_INSPECT_MEDIA",
         "name": "Inspect Media",
-        "description": "Tool to inspect media metadata. Use before rendering to retrieve duration, resolution, frame rate, and format of an online media file — clip timecodes, trim points, and audio sync calculations depend on these values. Mixing assets without prior inspection can cause letterboxing, jitter, or audio sync issues in the final output."
+        "description": "Tool to inspect media metadata. Use before rendering to retrieve duration, resolution, frame rate, and format of an online media file \u2014 clip timecodes, trim points, and audio sync calculations depend on these values. Mixing assets without prior inspection can cause letterboxing, jitter, or audio sync issues in the final output."
       },
       {
         "slug": "SHOTSTACK_LIST_SOURCES",
@@ -239365,7 +239365,7 @@
       {
         "slug": "SKYFIRE_CHARGE_TOKEN",
         "name": "Charge Skyfire Token",
-        "description": "Charge a buyer's token (seller-side operation). REQUIRES SELLER API KEY: This action requires your seller agent API key, not the buyer's key. The buyer creates and sends you a pay/kya+pay token JWT, you provide the service, then call this endpoint to collect payment. Flow: Buyer creates token → Buyer calls your service with token → You validate token → You provide service → You call this to charge. Common errors: - 401: Invalid/expired token OR wrong API key (must use seller key) - 402: Charge amount exceeds token value"
+        "description": "Charge a buyer's token (seller-side operation). REQUIRES SELLER API KEY: This action requires your seller agent API key, not the buyer's key. The buyer creates and sends you a pay/kya+pay token JWT, you provide the service, then call this endpoint to collect payment. Flow: Buyer creates token \u2192 Buyer calls your service with token \u2192 You validate token \u2192 You provide service \u2192 You call this to charge. Common errors: - 401: Invalid/expired token OR wrong API key (must use seller key) - 402: Charge amount exceeds token value"
       },
       {
         "slug": "SKYFIRE_CREATE_KYA_PAY_TOKEN",
@@ -239410,7 +239410,7 @@
       {
         "slug": "SKYFIRE_GET_SERVICES_BY_TAGS",
         "name": "Get Services by Tags",
-        "description": "Filter services by tags to find exactly what you need. More efficient than browsing all services when you know the category. Chain: GetAllServiceTags → GetServicesByTags → CreatePayToken."
+        "description": "Filter services by tags to find exactly what you need. More efficient than browsing all services when you know the category. Chain: GetAllServiceTags \u2192 GetServicesByTags \u2192 CreatePayToken."
       },
       {
         "slug": "SKYFIRE_GET_TOKEN_CHARGES",
@@ -239683,7 +239683,7 @@
       {
         "slug": "SMS_ALERT_GET_BALANCE_CHECK",
         "name": "Get SMS Alert Balance",
-        "description": "Tool to retrieve the current SMS credit balance. Use when you need an up-to-date credit status before sending messages. If balance is low, gate high-volume sends before proceeding — insufficient credits cause messages to be silently dropped or rejected mid-campaign."
+        "description": "Tool to retrieve the current SMS credit balance. Use when you need an up-to-date credit status before sending messages. If balance is low, gate high-volume sends before proceeding \u2014 insufficient credits cause messages to be silently dropped or rejected mid-campaign."
       },
       {
         "slug": "SMS_ALERT_GET_DELIVERY_REPORT",
@@ -239758,7 +239758,7 @@
       {
         "slug": "SMS_ALERT_POST_EDIT_CONTACT",
         "name": "Edit Contact",
-        "description": "Tool to edit an existing contact’s details. Use when you need to update a contact’s information after confirming the contact_id."
+        "description": "Tool to edit an existing contact\u2019s details. Use when you need to update a contact\u2019s information after confirming the contact_id."
       },
       {
         "slug": "SMS_ALERT_POST_EDIT_GROUP",
@@ -239979,7 +239979,7 @@
       {
         "slug": "SMTP2GO_WEBHOOK_EDIT",
         "name": "Edit Webhook",
-        "description": "Tool to edit an existing webhook’s settings. Use when you need to update a webhook's configuration after creation."
+        "description": "Tool to edit an existing webhook\u2019s settings. Use when you need to update a webhook's configuration after creation."
       },
       {
         "slug": "SMTP2GO_WEBHOOK_REMOVE",
@@ -241002,7 +241002,7 @@
                 "name": "generic_api_key",
                 "displayName": "API Key",
                 "type": "string",
-                "description": "Navigate to Dashboard → Profile icon → My account → API Settings and click \"Generate API key\". You must be an application owner or workspace collaborator.",
+                "description": "Navigate to Dashboard \u2192 Profile icon \u2192 My account \u2192 API Settings and click \"Generate API key\". You must be an application owner or workspace collaborator.",
                 "required": true,
                 "default": null
               },
@@ -241010,7 +241010,7 @@
                 "name": "generic_id",
                 "displayName": "Domain",
                 "type": "string",
-                "description": "Your Softr app domain or subdomain (e.g., \"yourdomain.softr.app\" or \"yourdomain.com\"). Access your app on Softr → Publish to find your subdomain. Your app must be published before making API calls.",
+                "description": "Your Softr app domain or subdomain (e.g., \"yourdomain.softr.app\" or \"yourdomain.com\"). Access your app on Softr \u2192 Publish to find your subdomain. Your app must be published before making API calls.",
                 "required": true,
                 "default": null
               }
@@ -241301,7 +241301,7 @@
                 "name": "generic_api_key",
                 "displayName": "API Key",
                 "type": "string",
-                "description": "Generate your API Key from Preferences → Administration → API in your Specific workspace",
+                "description": "Generate your API Key from Preferences \u2192 Administration \u2192 API in your Specific workspace",
                 "required": true,
                 "default": null
               }
@@ -241347,7 +241347,7 @@
       {
         "slug": "SPLITWISE_CREATE_EXPENSE",
         "name": "Create Expense",
-        "description": "Tool to create a new Splitwise expense. Use when you need to record a payment or bill in a group or between users. Provide exactly one of split_equally or users for shares — supplying both or neither causes a validation error and no expense is created."
+        "description": "Tool to create a new Splitwise expense. Use when you need to record a payment or bill in a group or between users. Provide exactly one of split_equally or users for shares \u2014 supplying both or neither causes a validation error and no expense is created."
       },
       {
         "slug": "SPLITWISE_CREATE_FRIENDS",
@@ -241367,7 +241367,7 @@
       {
         "slug": "SPLITWISE_DELETE_EXPENSE",
         "name": "Delete Expense",
-        "description": "Tool to delete an existing expense by its ID. Deletion is irreversible — no undelete capability exists. Use after confirming you have the correct expense ID. Inspect the response's `success` and `error` fields to verify deletion succeeded; failures (e.g., user lacks owner/participant permissions) are surfaced there."
+        "description": "Tool to delete an existing expense by its ID. Deletion is irreversible \u2014 no undelete capability exists. Use after confirming you have the correct expense ID. Inspect the response's `success` and `error` fields to verify deletion succeeded; failures (e.g., user lacks owner/participant permissions) are surfaced there."
       },
       {
         "slug": "SPLITWISE_DELETE_FRIEND",
@@ -241427,7 +241427,7 @@
       {
         "slug": "SPLITWISE_GET_GROUPS",
         "name": "Get Groups",
-        "description": "Retrieves all groups the authenticated user belongs to, including group details, members, balances, and debt information. Returns a 'groups' array with no server-side filtering; all name- or ID-based filtering must be done client-side on the full response. Group names may share similar strings or differ in case/whitespace — normalize when matching and prefer group_id once identified. The groups array may be empty if the user belongs to no groups."
+        "description": "Retrieves all groups the authenticated user belongs to, including group details, members, balances, and debt information. Returns a 'groups' array with no server-side filtering; all name- or ID-based filtering must be done client-side on the full response. Group names may share similar strings or differ in case/whitespace \u2014 normalize when matching and prefer group_id once identified. The groups array may be empty if the user belongs to no groups."
       },
       {
         "slug": "SPLITWISE_GET_NOTIFICATIONS",
@@ -241447,7 +241447,7 @@
       {
         "slug": "SPLITWISE_UNDELETE_EXPENSE",
         "name": "Restore Deleted Expense",
-        "description": "Tool to restore a previously deleted expense and its associated records. Use when you need to recover an expense that was deleted. Call after confirming the correct expense ID. Not a guaranteed undo mechanism — treat deletion as high-impact and verify restoration completeness afterward."
+        "description": "Tool to restore a previously deleted expense and its associated records. Use when you need to recover an expense that was deleted. Call after confirming the correct expense ID. Not a guaranteed undo mechanism \u2014 treat deletion as high-impact and verify restoration completeness afterward."
       },
       {
         "slug": "SPLITWISE_UNDELETE_GROUP",
@@ -244196,7 +244196,7 @@
       {
         "slug": "STREAMTIME_ORGANISATION_GET_ORGANISATION",
         "name": "Get Organisation Details",
-        "description": "Tool to retrieve your organisation’s details. Use after confirming your authentication to ensure you are operating within the correct organisation context."
+        "description": "Tool to retrieve your organisation\u2019s details. Use after confirming your authentication to ensure you are operating within the correct organisation context."
       },
       {
         "slug": "STREAMTIME_ROLES_GET_ROLE",
@@ -245400,7 +245400,7 @@
       {
         "slug": "SVIX_ENDPOINT_PATCH",
         "name": "Patch Endpoint",
-        "description": "Tool to partially update an endpoint’s configuration. Use when you need to adjust endpoint settings without full replacement."
+        "description": "Tool to partially update an endpoint\u2019s configuration. Use when you need to adjust endpoint settings without full replacement."
       },
       {
         "slug": "SVIX_ENDPOINT_PATCH_HEADERS",
@@ -246233,7 +246233,7 @@
       {
         "slug": "SYNTHFLOW_AI_UPDATE_ASSISTANT",
         "name": "Update Assistant",
-        "description": "Tool to update an existing assistant’s settings. Use after confirming the assistant exists. Modify settings like name, phone, recording, webhook, or agent configuration."
+        "description": "Tool to update an existing assistant\u2019s settings. Use after confirming the assistant exists. Modify settings like name, phone, recording, webhook, or agent configuration."
       },
       {
         "slug": "SYNTHFLOW_AI_UPDATE_CONTACT",
@@ -246510,7 +246510,7 @@
       {
         "slug": "TALLY_GET_USER_INFO",
         "name": "Get User Info",
-        "description": "Tool to retrieve information about the authenticated user. Use when you need to confirm account-level details before proceeding. Returns account/workspace context only — not form-level access; follow up with TALLY_LIST_FORMS to verify form access. Confirm the returned workspace and user context match the intended account before creating or modifying resources, as acting on the wrong context places resources in an unintended account. Do not expose sensitive response fields (e.g., tokens) in user-visible output."
+        "description": "Tool to retrieve information about the authenticated user. Use when you need to confirm account-level details before proceeding. Returns account/workspace context only \u2014 not form-level access; follow up with TALLY_LIST_FORMS to verify form access. Confirm the returned workspace and user context match the intended account before creating or modifying resources, as acting on the wrong context places resources in an unintended account. Do not expose sensitive response fields (e.g., tokens) in user-visible output."
       },
       {
         "slug": "TALLY_GET_WEBHOOK_EVENTS",
@@ -246646,7 +246646,7 @@
   {
     "slug": "tapfiliate",
     "name": "Tapfiliate",
-    "logo": "https://logo.clearbit.com/tapfiliate.com",
+    "logo": "https://logos.composio.dev/api/tapfiliate",
     "description": "Tapfiliate is an affiliate and referral tracking platform that enables businesses to create, track, and scale their affiliate programs efficiently.",
     "category": "marketing automation",
     "authSchemes": [
@@ -247943,7 +247943,7 @@
       {
         "slug": "TELEGRAM_DELETE_MESSAGE",
         "name": "Delete Message",
-        "description": "Delete a message, including service messages. Limitations: cannot delete messages older than 48 hours in groups, forwarded messages, or content in protected chats (returns 400 'message can’t be deleted'). Bot must have delete/manage rights in the target chat; works reliably only on bot-authored messages in groups. Verify permissions via TELEGRAM_GET_CHAT or TELEGRAM_GET_CHAT_ADMINISTRATORS before calling. On flood control, Telegram returns HTTP 429 with a retry_after field; honor that backoff value."
+        "description": "Delete a message, including service messages. Limitations: cannot delete messages older than 48 hours in groups, forwarded messages, or content in protected chats (returns 400 'message can\u2019t be deleted'). Bot must have delete/manage rights in the target chat; works reliably only on bot-authored messages in groups. Verify permissions via TELEGRAM_GET_CHAT or TELEGRAM_GET_CHAT_ADMINISTRATORS before calling. On flood control, Telegram returns HTTP 429 with a retry_after field; honor that backoff value."
       },
       {
         "slug": "TELEGRAM_EDIT_MESSAGE",
@@ -247968,7 +247968,7 @@
       {
         "slug": "TELEGRAM_GET_CHAT_HISTORY",
         "name": "Get Chat History",
-        "description": "Get chat history messages via the getUpdates polling method. Bot can only retrieve messages sent after it joined the chat; missing older messages is expected. Requires no active webhook — a webhook causes HTTP 409 conflict; delete it before using this tool. Empty result arrays (ok=true) indicate no accessible messages, not a failure. Returned message dates are Unix timestamps in UTC seconds."
+        "description": "Get chat history messages via the getUpdates polling method. Bot can only retrieve messages sent after it joined the chat; missing older messages is expected. Requires no active webhook \u2014 a webhook causes HTTP 409 conflict; delete it before using this tool. Empty result arrays (ok=true) indicate no accessible messages, not a failure. Returned message dates are Unix timestamps in UTC seconds."
       },
       {
         "slug": "TELEGRAM_GET_CHAT_MEMBER",
@@ -247988,7 +247988,7 @@
       {
         "slug": "TELEGRAM_GET_UPDATES",
         "name": "Get Updates",
-        "description": "Use this method to receive incoming updates using long polling. An Array of Update objects is returned. IMPORTANT: This method will not work if an outgoing webhook is set up. Webhooks and getUpdates are mutually exclusive — call deleteWebhook first to switch modes (409 Conflict otherwise). Notes: - Only one method (webhook or polling) can be active at a time - Updates available for up to 24 hours if unclaimed - Recalculate offset after each response to avoid duplicates - Empty result array (ok=true) is valid, meaning no new updates - On HTTP 429, honor the retry_after value; keep polling to ~1 request/second - Only chats with updates since the bot joined or last offset appear in results - Update objects vary by type; always check update.message and update.message.text exist before accessing"
+        "description": "Use this method to receive incoming updates using long polling. An Array of Update objects is returned. IMPORTANT: This method will not work if an outgoing webhook is set up. Webhooks and getUpdates are mutually exclusive \u2014 call deleteWebhook first to switch modes (409 Conflict otherwise). Notes: - Only one method (webhook or polling) can be active at a time - Updates available for up to 24 hours if unclaimed - Recalculate offset after each response to avoid duplicates - Empty result array (ok=true) is valid, meaning no new updates - On HTTP 429, honor the retry_after value; keep polling to ~1 request/second - Only chats with updates since the bot joined or last offset appear in results - Update objects vary by type; always check update.message and update.message.text exist before accessing"
       },
       {
         "slug": "TELEGRAM_SEND_DOCUMENT",
@@ -248169,7 +248169,7 @@
       {
         "slug": "TELNYX_LIST_NOTIFICATION_EVENTS",
         "name": "List Notification Events",
-        "description": "Tool to list all notification events with their IDs. Use to dynamically retrieve notification_event_condition_id values before configuring webhook subscriptions — IDs are account-specific and must not be hardcoded, as stale IDs silently prevent events (e.g., call routing, recording) from reaching the webhook."
+        "description": "Tool to list all notification events with their IDs. Use to dynamically retrieve notification_event_condition_id values before configuring webhook subscriptions \u2014 IDs are account-specific and must not be hardcoded, as stale IDs silently prevent events (e.g., call routing, recording) from reaching the webhook."
       },
       {
         "slug": "TELNYX_LIST_NOTIFICATION_PROFILES",
@@ -248604,7 +248604,7 @@
   {
     "slug": "test_app",
     "name": "Test app",
-    "logo": "https://cdn.jsdelivr.net/gh/ComposioHQ/open-logos@master/icons/testapp.png",
+    "logo": "https://logos.composio.dev/api/test_app",
     "description": "...",
     "category": "tag1",
     "authSchemes": [
@@ -249021,7 +249021,7 @@
       {
         "slug": "THANKS_IO_RECIPIENTS_GET_DETAILS",
         "name": "Get Recipient Details",
-        "description": "Tool to get details for a specific recipient by ID. Use to verify a recipient’s full address and custom fields."
+        "description": "Tool to get details for a specific recipient by ID. Use to verify a recipient\u2019s full address and custom fields."
       },
       {
         "slug": "THANKS_IO_RECIPIENTS_SEARCH_BY_EMAIL",
@@ -249132,7 +249132,7 @@
       {
         "slug": "THE_ODDS_API_GET_ODDS",
         "name": "Get Odds",
-        "description": "Tool to fetch live and upcoming event odds for a specified sport, including bookmakers, regions, and markets. Use after retrieving sports via GET_SPORTS; filter by region, market, or event IDs. Response is nested bookmakers → markets → outcomes; not all bookmakers expose every market for every event, so handle missing keys and empty arrays defensively. Combining multiple regions, markets, and eventIds produces large payloads — narrow to one region or specific eventIds where possible."
+        "description": "Tool to fetch live and upcoming event odds for a specified sport, including bookmakers, regions, and markets. Use after retrieving sports via GET_SPORTS; filter by region, market, or event IDs. Response is nested bookmakers \u2192 markets \u2192 outcomes; not all bookmakers expose every market for every event, so handle missing keys and empty arrays defensively. Combining multiple regions, markets, and eventIds produces large payloads \u2014 narrow to one region or specific eventIds where possible."
       },
       {
         "slug": "THE_ODDS_API_GET_PARTICIPANTS",
@@ -249147,7 +249147,7 @@
       {
         "slug": "THE_ODDS_API_GET_SPORTS",
         "name": "Get Sports",
-        "description": "Tool to retrieve a list of in-season sports. Use when you need sports data; set 'all' to true to include out-of-season sports. Sport keys returned here must be passed to downstream tools like THE_ODDS_API_GET_EVENTS and THE_ODDS_API_GET_EVENT_ODDS — mismatched or guessed keys return empty payloads. Similarly named leagues and qualifier competitions appear as distinct entries with unique keys; verify the exact key before use."
+        "description": "Tool to retrieve a list of in-season sports. Use when you need sports data; set 'all' to true to include out-of-season sports. Sport keys returned here must be passed to downstream tools like THE_ODDS_API_GET_EVENTS and THE_ODDS_API_GET_EVENT_ODDS \u2014 mismatched or guessed keys return empty payloads. Similarly named leagues and qualifier competitions appear as distinct entries with unique keys; verify the exact key before use."
       },
       {
         "slug": "THE_ODDS_API_GET_V3_ODDS",
@@ -249353,7 +249353,7 @@
   {
     "slug": "ticktick",
     "name": "Ticktick",
-    "logo": "https://ticktick.com/favicon.ico",
+    "logo": "https://logos.composio.dev/api/ticktick",
     "description": "TickTick is a cross-platform task management and to-do list application designed to help users organize their tasks and schedules efficiently.",
     "category": "productivity",
     "authSchemes": [
@@ -249394,7 +249394,7 @@
       {
         "slug": "TICKTICK_DELETE_TASK",
         "name": "Delete Task",
-        "description": "Tool to permanently delete a specific task — irreversible, no recovery. Use when you need to remove a task from a project after confirming both project and task IDs. Returns an empty data object on success; check status/success flags rather than response payload. When moving tasks between projects via create+delete, comments and history are lost."
+        "description": "Tool to permanently delete a specific task \u2014 irreversible, no recovery. Use when you need to remove a task from a project after confirming both project and task IDs. Returns an empty data object on success; check status/success flags rather than response payload. When moving tasks between projects via create+delete, comments and history are lost."
       },
       {
         "slug": "TICKTICK_GET_PROJECT_BY_ID",
@@ -249404,7 +249404,7 @@
       {
         "slug": "TICKTICK_GET_PROJECT_WITH_DATA",
         "name": "Get project with data",
-        "description": "Retrieve a project's associated data (incomplete tasks, columns). IMPORTANT: This endpoint only returns INCOMPLETE tasks. Completed tasks are automatically filtered out by the TickTick API. An empty tasks list means either the project has no tasks at all, or all tasks have been completed. For completed tasks, check the TickTick app or web interface directly. Columns are only present for kanban-style projects; list-view projects return an empty columns array. Join tasks to columns via each task's columnId field. For large projects, results may paginate at ~100 items per page — iterate all pages and deduplicate by taskId. Multiple tasks can share the same title; always use taskId for follow-up create, update, or delete calls. All filtering by name, tag, or other fields must be done client-side. Scope is project-only — Inbox and other projects are excluded."
+        "description": "Retrieve a project's associated data (incomplete tasks, columns). IMPORTANT: This endpoint only returns INCOMPLETE tasks. Completed tasks are automatically filtered out by the TickTick API. An empty tasks list means either the project has no tasks at all, or all tasks have been completed. For completed tasks, check the TickTick app or web interface directly. Columns are only present for kanban-style projects; list-view projects return an empty columns array. Join tasks to columns via each task's columnId field. For large projects, results may paginate at ~100 items per page \u2014 iterate all pages and deduplicate by taskId. Multiple tasks can share the same title; always use taskId for follow-up create, update, or delete calls. All filtering by name, tag, or other fields must be done client-side. Scope is project-only \u2014 Inbox and other projects are excluded."
       },
       {
         "slug": "TICKTICK_GET_TASK_BY_PROJECT_AND_ID",
@@ -249414,7 +249414,7 @@
       {
         "slug": "TICKTICK_GET_USER_PROJECT",
         "name": "Get User Projects",
-        "description": "Retrieves all projects accessible to the authenticated user, including personal and shared projects. Use this tool to list available projects before creating tasks or to get project IDs for other operations. Returns project metadata including name, color, view mode, and organization details. Always use returned projectId values (not project names) when calling TICKTICK_CREATE_TASK, TICKTICK_UPDATE_TASK, or TICKTICK_GET_PROJECT_WITH_DATA. The inbox project may not appear in results — omit projectId in TICKTICK_CREATE_TASK to target the inbox. Non-kanban projects return an empty columns array; check viewMode before assuming columns exist."
+        "description": "Retrieves all projects accessible to the authenticated user, including personal and shared projects. Use this tool to list available projects before creating tasks or to get project IDs for other operations. Returns project metadata including name, color, view mode, and organization details. Always use returned projectId values (not project names) when calling TICKTICK_CREATE_TASK, TICKTICK_UPDATE_TASK, or TICKTICK_GET_PROJECT_WITH_DATA. The inbox project may not appear in results \u2014 omit projectId in TICKTICK_CREATE_TASK to target the inbox. Non-kanban projects return an empty columns array; check viewMode before assuming columns exist."
       },
       {
         "slug": "TICKTICK_LIST_ALL_TASKS",
@@ -249434,7 +249434,7 @@
       {
         "slug": "TICKTICK_UPDATE_TASK",
         "name": "Update Task",
-        "description": "Tool to update an existing task. Use after confirming the taskId and projectId. Omitting optional fields resets them to null — include all existing field values in every payload. Cannot move a task to a different project; use TICKTICK_CREATE_TASK + TICKTICK_DELETE_TASK instead. Fields outside the input schema (e.g., columnId, assignee) are silently ignored."
+        "description": "Tool to update an existing task. Use after confirming the taskId and projectId. Omitting optional fields resets them to null \u2014 include all existing field values in every payload. Cannot move a task to a different project; use TICKTICK_CREATE_TASK + TICKTICK_DELETE_TASK instead. Fields outside the input schema (e.g., columnId, assignee) are silently ignored."
       }
     ],
     "triggers": [],
@@ -249596,7 +249596,7 @@
       {
         "slug": "TIKTOK_FETCH_PUBLISH_STATUS",
         "name": "Fetch publish status",
-        "description": "Check the processing status of a TikTok video or photo post using its publish_id. Use this action to poll the status of content after initiating an upload or post. The API returns detailed information about processing stages (upload, download, moderation) and any errors that occurred. Non-terminal statuses mean processing is still pending — never re-initiate TIKTOK_PUBLISH_VIDEO for the same publish_id. Use exponential backoff when polling (e.g., 5s→10s→20s) to avoid the 30 requests/minute per access token rate limit."
+        "description": "Check the processing status of a TikTok video or photo post using its publish_id. Use this action to poll the status of content after initiating an upload or post. The API returns detailed information about processing stages (upload, download, moderation) and any errors that occurred. Non-terminal statuses mean processing is still pending \u2014 never re-initiate TIKTOK_PUBLISH_VIDEO for the same publish_id. Use exponential backoff when polling (e.g., 5s\u219210s\u219220s) to avoid the 30 requests/minute per access token rate limit."
       },
       {
         "slug": "TIKTOK_GET_ACTION_CATEGORIES",
@@ -249631,7 +249631,7 @@
       {
         "slug": "TIKTOK_PUBLISH_VIDEO",
         "name": "Publish video",
-        "description": "Publishes a video to TikTok by pulling it from a public URL. TikTok downloads the video from the provided URL and publishes it directly to the creator's profile. Publishing is asynchronous — after calling this action, poll TIKTOK_FETCH_PUBLISH_STATUS with the returned publish_id to check completion. For uploading video files instead of URLs, use TIKTOK_UPLOAD_VIDEO."
+        "description": "Publishes a video to TikTok by pulling it from a public URL. TikTok downloads the video from the provided URL and publishes it directly to the creator's profile. Publishing is asynchronous \u2014 after calling this action, poll TIKTOK_FETCH_PUBLISH_STATUS with the returned publish_id to check completion. For uploading video files instead of URLs, use TIKTOK_UPLOAD_VIDEO."
       },
       {
         "slug": "TIKTOK_UPLOAD_VIDEO",
@@ -249880,7 +249880,7 @@
       {
         "slug": "TINYFISH_MCP_GET_RUN",
         "name": "Get run",
-        "description": "Retrieves details of a specific automation run by its ID. Returns status, result, error, and other metadata. IMPORTANT: Call this after run_web_automation errors or times out — the run is likely still executing. If you do not have a run_id, use list_runs to find it. Also use this to poll for completion after run_web_automation_async. Runs typically take a few minutes. Wait 30-60 seconds between polls."
+        "description": "Retrieves details of a specific automation run by its ID. Returns status, result, error, and other metadata. IMPORTANT: Call this after run_web_automation errors or times out \u2014 the run is likely still executing. If you do not have a run_id, use list_runs to find it. Also use this to poll for completion after run_web_automation_async. Runs typically take a few minutes. Wait 30-60 seconds between polls."
       },
       {
         "slug": "TINYFISH_MCP_GET_STEPS",
@@ -249900,12 +249900,12 @@
       {
         "slug": "TINYFISH_MCP_RUN_WEB_AUTOMATION",
         "name": "Run web automation",
-        "description": "Executes web automation given a URL and a Natural Language description of the automation goal to be performed. Automation is mostly focused around navigating complex web pages and extracting data from web pages. Include _meta.progressToken in your request to receive progress notifications. WARNING: This tool may take several minutes. If it errors or times out, the run is STILL EXECUTING on the server. DO NOT call this tool again or call run_web_automation_async — both would create a duplicate run. Instead: if you have a run_id from progress notifications, call get_run. If you have no run_id, call list_runs to find it. Only create a new run after confirming the previous one finished."
+        "description": "Executes web automation given a URL and a Natural Language description of the automation goal to be performed. Automation is mostly focused around navigating complex web pages and extracting data from web pages. Include _meta.progressToken in your request to receive progress notifications. WARNING: This tool may take several minutes. If it errors or times out, the run is STILL EXECUTING on the server. DO NOT call this tool again or call run_web_automation_async \u2014 both would create a duplicate run. Instead: if you have a run_id from progress notifications, call get_run. If you have no run_id, call list_runs to find it. Only create a new run after confirming the previous one finished."
       },
       {
         "slug": "TINYFISH_MCP_RUN_WEB_AUTOMATION_ASYNC",
         "name": "Run web automation async",
-        "description": "Starts a NEW web automation run asynchronously and returns a run_id immediately without waiting for completion. WARNING: Do NOT use this to retry a failed run_web_automation call — that run is still executing. Use get_run or list_runs to check its status instead. Only use this tool for genuinely new tasks. Workflow: 1) Call this tool to get a run_id. 2) Wait 30-60 seconds. 3) Call get_run with the run_id to check status. 4) Repeat step 2-3 until status is COMPLETED, FAILED, or CANCELLED."
+        "description": "Starts a NEW web automation run asynchronously and returns a run_id immediately without waiting for completion. WARNING: Do NOT use this to retry a failed run_web_automation call \u2014 that run is still executing. Use get_run or list_runs to check its status instead. Only use this tool for genuinely new tasks. Workflow: 1) Call this tool to get a run_id. 2) Wait 30-60 seconds. 3) Call get_run with the run_id to check status. 4) Repeat step 2-3 until status is COMPLETED, FAILED, or CANCELLED."
       }
     ],
     "triggers": [],
@@ -250271,7 +250271,7 @@
       {
         "slug": "TOGGL_GET_USER_WORKSPACES",
         "name": "Get User Workspaces",
-        "description": "Tool to retrieve all workspaces the authenticated user belongs to. Use when you need to list accessible workspaces before performing workspace-specific operations. Verify the correct workspace ID from the returned list before use — an incorrect workspace ID will misroute entries and skew reports."
+        "description": "Tool to retrieve all workspaces the authenticated user belongs to. Use when you need to list accessible workspaces before performing workspace-specific operations. Verify the correct workspace ID from the returned list before use \u2014 an incorrect workspace ID will misroute entries and skew reports."
       },
       {
         "slug": "TOGGL_GET_WORKSPACE_DETAILS",
@@ -250382,7 +250382,7 @@
       {
         "slug": "TOKEN_METRICS_GET_TOKENS",
         "name": "Get Tokens",
-        "description": "Tool to retrieve a paginated list of supported tokens with metadata. Use when you need comprehensive token listings across price, market cap, supply, and contract details. Returns token_id values required by TOKEN_METRICS_GET_PRICE and other endpoints — build your token_id mapping here first. Response fields such as volume24h and numberOfHolders may be absent for some tokens; treat missing values as null/unknown, not zero. tokenCreationDate is ISO-8601; convert to UTC for accurate age comparisons."
+        "description": "Tool to retrieve a paginated list of supported tokens with metadata. Use when you need comprehensive token listings across price, market cap, supply, and contract details. Returns token_id values required by TOKEN_METRICS_GET_PRICE and other endpoints \u2014 build your token_id mapping here first. Response fields such as volume24h and numberOfHolders may be absent for some tokens; treat missing values as null/unknown, not zero. tokenCreationDate is ISO-8601; convert to UTC for accurate age comparisons."
       },
       {
         "slug": "TOKEN_METRICS_GET_TOP_MARKET_CAP_TOKENS",
@@ -252368,7 +252368,7 @@
       {
         "slug": "TWELVE_DATA_EPS_REVISIONS",
         "name": "EPS Revisions",
-        "description": "Tool to provide analysts’ revisions of a company’s future EPS over the last week and month. Use after confirming the stock symbol."
+        "description": "Tool to provide analysts\u2019 revisions of a company\u2019s future EPS over the last week and month. Use after confirming the stock symbol."
       },
       {
         "slug": "TWELVE_DATA_EPS_TREND_ACTION",
@@ -252633,7 +252633,7 @@
       {
         "slug": "TWELVE_DATA_GET_MUTUAL_FUNDS_WORLD_SUMMARY",
         "name": "Global Mutual Fund Summary",
-        "description": "Tool to retrieve a global mutual fund summary snapshot. Use when you need a high-level overview of a fund’s key identifiers and attributes."
+        "description": "Tool to retrieve a global mutual fund summary snapshot. Use when you need a high-level overview of a fund\u2019s key identifiers and attributes."
       },
       {
         "slug": "TWELVE_DATA_GET_MUTUAL_FUNDS_WORLD_SUSTAINABILITY",
@@ -254910,7 +254910,7 @@
   {
     "slug": "veo",
     "name": "Veo",
-    "logo": "https://cdn.jsdelivr.net/gh/ComposioHQ/open-logos@master/gemini.svg",
+    "logo": "https://logos.composio.dev/api/veo",
     "description": "Veo 3 is Google's state-of-the-art model for generating high-fidelity 8s 720p videos with natively generated audio via the Gemini API.",
     "category": "artificial intelligence",
     "authSchemes": [
@@ -254989,7 +254989,7 @@
       {
         "slug": "VERCEL_ADD_ENVIRONMENT_VARIABLE",
         "name": "Add Environment Variable",
-        "description": "Tool to add an environment variable to a Vercel project. Variables only take effect in subsequent deployments — already-running deployments are not updated. Use after confirming the project exists and you need to configure secrets or configuration values across environments before deployment. Example: \"Add API_KEY=secret to production\"."
+        "description": "Tool to add an environment variable to a Vercel project. Variables only take effect in subsequent deployments \u2014 already-running deployments are not updated. Use after confirming the project exists and you need to configure secrets or configuration values across environments before deployment. Example: \"Add API_KEY=secret to production\"."
       },
       {
         "slug": "VERCEL_ADD_PROJECT_DOMAIN",
@@ -255074,7 +255074,7 @@
       {
         "slug": "VERCEL_CREATE_PROJECT",
         "name": "Create Vercel Project (Deprecated)",
-        "description": "DEPRECATED: Use VERCEL_VERCEL_CREATE_PROJECT2 instead. Tool to create a new Vercel project. Use when automating project provisioning in CI/CD before deployment. Project names must be unique per team; duplicate names cause 409 conflicts — check for existing projects first."
+        "description": "DEPRECATED: Use VERCEL_VERCEL_CREATE_PROJECT2 instead. Tool to create a new Vercel project. Use when automating project provisioning in CI/CD before deployment. Project names must be unique per team; duplicate names cause 409 conflicts \u2014 check for existing projects first."
       },
       {
         "slug": "VERCEL_CREATE_PROJECT2",
@@ -255129,7 +255129,7 @@
       {
         "slug": "VERCEL_DELETE_DEPLOYMENT",
         "name": "Delete Deployment (V2)",
-        "description": "Permanently delete a Vercel deployment by its ID or URL. Use this action to remove a deployment from Vercel. The deployment can be identified either by its unique deployment ID (e.g., 'dpl_xxx') or by providing the deployment URL as a query parameter. Note: This action is destructive and cannot be undone. The deployment will be permanently removed. Do not target the latest production deployment. When filtering deployments by branch or status before deletion, use `meta.githubCommitRef` for branch and `readyState` for status — misreading these fields can cause unintended deletions."
+        "description": "Permanently delete a Vercel deployment by its ID or URL. Use this action to remove a deployment from Vercel. The deployment can be identified either by its unique deployment ID (e.g., 'dpl_xxx') or by providing the deployment URL as a query parameter. Note: This action is destructive and cannot be undone. The deployment will be permanently removed. Do not target the latest production deployment. When filtering deployments by branch or status before deletion, use `meta.githubCommitRef` for branch and `readyState` for status \u2014 misreading these fields can cause unintended deletions."
       },
       {
         "slug": "VERCEL_DELETE_DNS_RECORD",
@@ -255254,7 +255254,7 @@
       {
         "slug": "VERCEL_GET_DEPLOYMENT_DETAILS",
         "name": "Get deployment details",
-        "description": "DEPRECATED: Use VERCEL_VERCEL_GET_DEPLOYMENT instead. Retrieves detailed information about a specific deployment. Use after triggering a deployment to inspect status and configuration. Poll with exponential backoff (5–30s) since deployments may remain in QUEUED or BUILDING state for minutes; tight polling triggers HTTP 429. Deployment is live only when readyState=READY and errorCode is absent; other states (QUEUED, BUILDING, CANCELED, ERROR) mean no traffic is served. Build failures surface in readyState=ERROR with errorCode and errorMessage fields — successful creation does not guarantee a successful build. Example: { \"idOrUrl\": \"dpl_Br7FSrRXuUkSHj7t7GVVadyuGvFg\" }"
+        "description": "DEPRECATED: Use VERCEL_VERCEL_GET_DEPLOYMENT instead. Retrieves detailed information about a specific deployment. Use after triggering a deployment to inspect status and configuration. Poll with exponential backoff (5\u201330s) since deployments may remain in QUEUED or BUILDING state for minutes; tight polling triggers HTTP 429. Deployment is live only when readyState=READY and errorCode is absent; other states (QUEUED, BUILDING, CANCELED, ERROR) mean no traffic is served. Build failures surface in readyState=ERROR with errorCode and errorMessage fields \u2014 successful creation does not guarantee a successful build. Example: { \"idOrUrl\": \"dpl_Br7FSrRXuUkSHj7t7GVVadyuGvFg\" }"
       },
       {
         "slug": "VERCEL_GET_DEPLOYMENT_EVENTS",
@@ -255534,7 +255534,7 @@
       {
         "slug": "VERCEL_LIST_PROJECTS",
         "name": "List All Projects (Deprecated)",
-        "description": "DEPRECATED: Use GetProjects instead. Tool to list all projects accessible to the authenticated user or team. Use this to retrieve project IDs and metadata for further operations. Results are paginated (max 100 per page); iterate using the `pagination.next` cursor to retrieve all pages — `pagination.count` reflects only the current page, not the total."
+        "description": "DEPRECATED: Use GetProjects instead. Tool to list all projects accessible to the authenticated user or team. Use this to retrieve project IDs and metadata for further operations. Results are paginated (max 100 per page); iterate using the `pagination.next` cursor to retrieve all pages \u2014 `pagination.count` reflects only the current page, not the total."
       },
       {
         "slug": "VERCEL_LIST_SUPPORTED_TLDS",
@@ -255549,7 +255549,7 @@
       {
         "slug": "VERCEL_LIST_TEAMS",
         "name": "List All Teams (Deprecated)",
-        "description": "DEPRECATED: Use VERCEL_VERCEL_GET_TEAMS instead. Tool to list all teams accessible to the authenticated user. Use after authentication to retrieve team IDs and slugs; resolve the correct teamId or slug here before passing it to other Vercel tools (e.g., VERCEL_GET_PROJECT, deployment queries) — an incorrect or missing teamId causes 404 or scoping errors."
+        "description": "DEPRECATED: Use VERCEL_VERCEL_GET_TEAMS instead. Tool to list all teams accessible to the authenticated user. Use after authentication to retrieve team IDs and slugs; resolve the correct teamId or slug here before passing it to other Vercel tools (e.g., VERCEL_GET_PROJECT, deployment queries) \u2014 an incorrect or missing teamId causes 404 or scoping errors."
       },
       {
         "slug": "VERCEL_LIST_WEBHOOKS",
@@ -255659,7 +255659,7 @@
       {
         "slug": "VERCEL_UPDATE_PROJECT",
         "name": "Update Vercel Project (Deprecated)",
-        "description": "DEPRECATED: Use VERCEL_VERCEL_UPDATE_PROJECT2 instead. Tool to update an existing project. Partial-update: omitted fields are preserved, but nullable fields explicitly set to null will be cleared. Changes (including rootDirectory, buildCommand) only take effect on subsequent deployments — trigger a new deployment with VERCEL_CREATE_NEW_DEPLOYMENT after updating. Use after confirming the project ID or name."
+        "description": "DEPRECATED: Use VERCEL_VERCEL_UPDATE_PROJECT2 instead. Tool to update an existing project. Partial-update: omitted fields are preserved, but nullable fields explicitly set to null will be cleared. Changes (including rootDirectory, buildCommand) only take effect on subsequent deployments \u2014 trigger a new deployment with VERCEL_CREATE_NEW_DEPLOYMENT after updating. Use after confirming the project ID or name."
       },
       {
         "slug": "VERCEL_UPDATE_PROJECT2",
@@ -255769,7 +255769,7 @@
       {
         "slug": "VERIFIEDEMAIL_CHECK_CREDITS",
         "name": "Check Credits",
-        "description": "Tool to retrieve the remaining verification credits. Call before VERIFIEDEMAIL_VERIFY_EMAIL operations—especially in bulk or repeated workflows—as VERIFIEDEMAIL_VERIFY_EMAIL fails immediately when credits are exhausted. Use after confirming account authentication to ensure sufficient credits before proceeding."
+        "description": "Tool to retrieve the remaining verification credits. Call before VERIFIEDEMAIL_VERIFY_EMAIL operations\u2014especially in bulk or repeated workflows\u2014as VERIFIEDEMAIL_VERIFY_EMAIL fails immediately when credits are exhausted. Use after confirming account authentication to ensure sufficient credits before proceeding."
       },
       {
         "slug": "VERIFIEDEMAIL_CHECK_FILE_STATUS",
@@ -255809,7 +255809,7 @@
       {
         "slug": "VERIFIEDEMAIL_VERIFY_EMAIL",
         "name": "Verify Email",
-        "description": "Tool to verify the deliverability and validity of an email address. Use when you need to confirm if an email can receive mail by checking server existence, mailbox status, and more. For bulk use, call VERIFIEDEMAIL_CHECK_CREDITS first — this tool fails if verification credits are exhausted."
+        "description": "Tool to verify the deliverability and validity of an email address. Use when you need to confirm if an email can receive mail by checking server existence, mailbox status, and more. For bulk use, call VERIFIEDEMAIL_CHECK_CREDITS first \u2014 this tool fails if verification credits are exhausted."
       }
     ],
     "triggers": [],
@@ -255982,7 +255982,7 @@
       {
         "slug": "VIRUSTOTAL_GET_DOMAIN_REPORT",
         "name": "Get Domain Report",
-        "description": "Tool to retrieve the analysis report of a domain. Use when you need detailed insight on a domain's reputation and analysis stats. No malicious signals on obscure or low-traffic domains may indicate limited analysis history rather than safety — treat sparse results as 'unknown', not 'safe'. Covers external OSINT only (reputation, malware, SSL posture); cannot analyze internal/private assets."
+        "description": "Tool to retrieve the analysis report of a domain. Use when you need detailed insight on a domain's reputation and analysis stats. No malicious signals on obscure or low-traffic domains may indicate limited analysis history rather than safety \u2014 treat sparse results as 'unknown', not 'safe'. Covers external OSINT only (reputation, malware, SSL posture); cannot analyze internal/private assets."
       },
       {
         "slug": "VIRUSTOTAL_GET_FILE_REPORT",
@@ -255997,7 +255997,7 @@
       {
         "slug": "VIRUSTOTAL_GET_IP_ADDRESS_REPORT",
         "name": "Get IP Address Report",
-        "description": "Tool to retrieve the analysis report of an IP address. Use when you need detailed insight on an IP's reputation, ASN, country, and analysis stats. Low or zero detections indicate unknown risk, not safety — treat sparse data accordingly. Provides external OSINT only; insufficient as standalone compliance evidence."
+        "description": "Tool to retrieve the analysis report of an IP address. Use when you need detailed insight on an IP's reputation, ASN, country, and analysis stats. Low or zero detections indicate unknown risk, not safety \u2014 treat sparse data accordingly. Provides external OSINT only; insufficient as standalone compliance evidence."
       },
       {
         "slug": "VIRUSTOTAL_GET_METADATA",
@@ -256022,7 +256022,7 @@
       {
         "slug": "VIRUSTOTAL_SCAN_URL",
         "name": "Scan URL",
-        "description": "Tool to submit a URL for scanning. Use when you have a URL and need to submit it to VirusTotal to obtain an analysis ID for later retrieval. The returned analysis ID is preliminary — scanning engines may not have finished. Poll VIRUSTOTAL_GET_URL_REPORT with the ID using short delays to retrieve complete results."
+        "description": "Tool to submit a URL for scanning. Use when you have a URL and need to submit it to VirusTotal to obtain an analysis ID for later retrieval. The returned analysis ID is preliminary \u2014 scanning engines may not have finished. Poll VIRUSTOTAL_GET_URL_REPORT with the ID using short delays to retrieve complete results."
       },
       {
         "slug": "VIRUSTOTAL_SEARCH",
@@ -256437,7 +256437,7 @@
       {
         "slug": "WEBSCRAPING_AI_GET_TEXT",
         "name": "Get Text",
-        "description": "Tool to retrieve raw text content from a specified web page. Returns unstructured plain text — markdown formatting (code fences, lists, headings) is not preserved. Use when you need plain text extraction from a URL. Use FIRECRAWL_EXTRACT instead when formatted markdown output is required."
+        "description": "Tool to retrieve raw text content from a specified web page. Returns unstructured plain text \u2014 markdown formatting (code fences, lists, headings) is not preserved. Use when you need plain text extraction from a URL. Use FIRECRAWL_EXTRACT instead when formatted markdown output is required."
       }
     ],
     "triggers": [],

--- a/docs/scripts/generate-toolkits.ts
+++ b/docs/scripts/generate-toolkits.ts
@@ -222,14 +222,25 @@ async function fetchAuthConfigDetails(slug: string): Promise<AuthConfigDetail[]>
   }));
 }
 
+function normalizeLogoUrl(logo: string | null | undefined, slug: string): string {
+  const cdnBase = 'https://logos.composio.dev/api/';
+  // Always use the CDN URL — external logo URLs are unreliable (many return 404/500)
+  // See: https://github.com/ComposioHQ/composio/issues/3175
+  if (!logo || !logo.startsWith(cdnBase)) {
+    return `${cdnBase}${slug}`;
+  }
+  return logo;
+}
+
 function transformToolkit(raw: any): Toolkit {
   const authSchemes = raw.auth_schemes || raw.authSchemes || [];
   const composioManaged = raw.composio_managed_auth_schemes || raw.composioManagedAuthSchemes || [];
+  const slug = raw.slug?.toLowerCase() || '';
 
   return {
-    slug: raw.slug?.toLowerCase() || '',
+    slug,
     name: raw.name || raw.slug || '',
-    logo: raw.meta?.logo || raw.logo || null,
+    logo: normalizeLogoUrl(raw.meta?.logo || raw.logo || null, slug),
     description: raw.meta?.description || raw.description || '',
     category: raw.meta?.categories?.[0]?.name || raw.meta?.categories?.[0] || null,
     authSchemes,


### PR DESCRIPTION
## Summary
- Fixes 53 broken toolkit logo URLs that returned 404/500/DNS errors by normalizing them to the CDN format `https://logos.composio.dev/api/{slug}`
- Added `normalizeLogoUrl()` to the toolkit generation script so future regenerations are also protected
- Updated both `toolkits.json` and `toolkits-list.json` with corrected URLs

Closes #3175

## Test plan
- [ ] Verify a sample of previously broken logos now load (e.g. `https://logos.composio.dev/api/flutterwave`, `https://logos.composio.dev/api/hunter`, `https://logos.composio.dev/api/instantly`)
- [ ] Run `bun run generate:toolkits` and confirm all logos use the CDN pattern
- [ ] Check the docs toolkit listing page renders logos correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)