### PR TITLE
fix(py): handle anyOf/oneOf schemas in FileHelper recursive file processing

### DIFF
--- a/python/composio/core/models/_files.py
+++ b/python/composio/core/models/_files.py
@@ -686,6 +686,30 @@ class FileHelper(WithLogger):
 
         return None
 
+    def _resolve_object_schema(self, schema: t.Dict) -> t.Optional[t.Dict]:
+        """Resolve a schema (or variant) that is an object."""
+        if schema.get("type") == "object":
+            return schema
+
+        for key in ("anyOf", "oneOf", "allOf"):
+            for variant in schema.get(key, []):
+                if isinstance(variant, dict) and variant.get("type") == "object":
+                    return variant
+
+        return None
+
+    def _resolve_array_schema(self, schema: t.Dict) -> t.Optional[t.Dict]:
+        """Resolve a schema (or variant) that is an array."""
+        if schema.get("type") == "array":
+            return schema
+
+        for key in ("anyOf", "oneOf", "allOf"):
+            for variant in schema.get(key, []):
+                if isinstance(variant, dict) and variant.get("type") == "array":
+                    return variant
+
+        return None
+
     def _substitute_file_uploads_recursively(
         self,
         tool: Tool,
@@ -746,25 +770,24 @@ class FileHelper(WithLogger):
                     )
                     continue
 
-            # Handle nested objects
-            if (
-                isinstance(request[_param], dict)
-                and param_schema.get("type") == "object"
-            ):
+            # Handle nested objects (including anyOf/oneOf/allOf with object variants)
+            resolved_schema = self._resolve_object_schema(param_schema)
+            if isinstance(request[_param], dict) and resolved_schema is not None:
                 request[_param] = self._substitute_file_uploads_recursively(
-                    schema=param_schema,
+                    schema=resolved_schema,
                     request=request[_param],
                     tool=tool,
                 )
                 continue
 
             # Handle arrays with file_uploadable items
+            resolved_array_schema = self._resolve_array_schema(param_schema)
             if (
                 isinstance(request[_param], list)
-                and param_schema.get("type") == "array"
-                and "items" in param_schema
+                and resolved_array_schema is not None
+                and "items" in resolved_array_schema
             ):
-                items_schema = param_schema["items"]
+                items_schema = resolved_array_schema["items"]
                 if isinstance(items_schema, dict):
                     processed_items: t.List[t.Any] = []
                     for item in request[_param]:
@@ -884,22 +907,24 @@ class FileHelper(WithLogger):
                     )
                     continue
 
-            # Handle nested objects
-            if isinstance(param_value, dict) and param_schema.get("type") == "object":
+            # Handle nested objects (including anyOf/oneOf/allOf with object variants)
+            resolved_schema = self._resolve_object_schema(param_schema)
+            if isinstance(param_value, dict) and resolved_schema is not None:
                 request[_param] = self._substitute_file_downloads_recursively(
-                    schema=param_schema,
+                    schema=resolved_schema,
                     request=param_value,
                     tool=tool,
                 )
                 continue
 
             # Handle arrays with file_downloadable items
+            resolved_array_schema = self._resolve_array_schema(param_schema)
             if (
                 isinstance(param_value, list)
-                and param_schema.get("type") == "array"
-                and "items" in param_schema
+                and resolved_array_schema is not None
+                and "items" in resolved_array_schema
             ):
-                items_schema = param_schema["items"]
+                items_schema = resolved_array_schema["items"]
                 if isinstance(items_schema, dict):
                     processed_items: t.List[t.Any] = []
                     for item in param_value:

--- a/python/composio/core/models/_files.py
+++ b/python/composio/core/models/_files.py
@@ -686,26 +686,16 @@ class FileHelper(WithLogger):
 
         return None
 
-    def _resolve_object_schema(self, schema: t.Dict) -> t.Optional[t.Dict]:
-        """Resolve a schema (or variant) that is an object."""
-        if schema.get("type") == "object":
+    def _resolve_schema_by_type(
+        self, schema: t.Dict, type_name: str
+    ) -> t.Optional[t.Dict]:
+        """Resolve a schema (or combiner variant) matching the given type."""
+        if schema.get("type") == type_name:
             return schema
 
         for key in ("anyOf", "oneOf", "allOf"):
             for variant in schema.get(key, []):
-                if isinstance(variant, dict) and variant.get("type") == "object":
-                    return variant
-
-        return None
-
-    def _resolve_array_schema(self, schema: t.Dict) -> t.Optional[t.Dict]:
-        """Resolve a schema (or variant) that is an array."""
-        if schema.get("type") == "array":
-            return schema
-
-        for key in ("anyOf", "oneOf", "allOf"):
-            for variant in schema.get(key, []):
-                if isinstance(variant, dict) and variant.get("type") == "array":
+                if isinstance(variant, dict) and variant.get("type") == type_name:
                     return variant
 
         return None
@@ -771,7 +761,7 @@ class FileHelper(WithLogger):
                     continue
 
             # Handle nested objects (including anyOf/oneOf/allOf with object variants)
-            resolved_schema = self._resolve_object_schema(param_schema)
+            resolved_schema = self._resolve_schema_by_type(param_schema, "object")
             if isinstance(request[_param], dict) and resolved_schema is not None:
                 request[_param] = self._substitute_file_uploads_recursively(
                     schema=resolved_schema,
@@ -781,7 +771,7 @@ class FileHelper(WithLogger):
                 continue
 
             # Handle arrays with file_uploadable items
-            resolved_array_schema = self._resolve_array_schema(param_schema)
+            resolved_array_schema = self._resolve_schema_by_type(param_schema, "array")
             if (
                 isinstance(request[_param], list)
                 and resolved_array_schema is not None
@@ -908,7 +898,7 @@ class FileHelper(WithLogger):
                     continue
 
             # Handle nested objects (including anyOf/oneOf/allOf with object variants)
-            resolved_schema = self._resolve_object_schema(param_schema)
+            resolved_schema = self._resolve_schema_by_type(param_schema, "object")
             if isinstance(param_value, dict) and resolved_schema is not None:
                 request[_param] = self._substitute_file_downloads_recursively(
                     schema=resolved_schema,
@@ -918,7 +908,7 @@ class FileHelper(WithLogger):
                 continue
 
             # Handle arrays with file_downloadable items
-            resolved_array_schema = self._resolve_array_schema(param_schema)
+            resolved_array_schema = self._resolve_schema_by_type(param_schema, "array")
             if (
                 isinstance(param_value, list)
                 and resolved_array_schema is not None


### PR DESCRIPTION
## Summary

Schemas using `anyOf`/`oneOf`/`allOf` without a top-level `"type"` key were silently skipped during recursive file upload/download processing in `FileHelper`. This meant nested objects or arrays wrapped in combiners never got their `file_uploadable`/`file_downloadable` properties processed.

Fixes #3145

## Changes

- Added `_resolve_object_schema` helper that returns the first `{"type": "object"}` variant from `anyOf`/`oneOf`/`allOf`, or the schema itself if it already has `"type": "object"`
- Added `_resolve_array_schema` helper with the same pattern for arrays
- Updated `_substitute_file_uploads_recursively` to use these helpers for nested object and array handling
- Updated `_substitute_file_downloads_recursively` with the same fix

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [ ] Documentation
- [ ] Breaking change

## How Has This Been Tested?

Traced through the code paths manually with the MRE schema from the issue:

```json
{
  "anyOf": [
    {"type": "object", "properties": {"x": {"type": "string"}}},
    {"type": "null"}
  ]
}
```

Before: `_resolve_object_schema` did not exist. `param_schema.get("type")` returned `None` for this schema, skipping recursion entirely.

After: `_resolve_object_schema` finds the `{"type": "object"}` variant and returns it. The recursive function processes nested properties correctly.

## Checklist

- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed
- [ ] I updated documentation as needed
- [x] I added tests or explain why not applicable
- [ ] I added a changeset if this change affects published packages

## Additional context

The `KeyError: 'type'` mentioned in the issue title has already been mitigated in the current `next` branch code (uses `.get("type")` instead of `["type"]`). This PR fixes the remaining functional gap where schemas without a top-level type were silently skipped rather than being resolved through their combiner variants.

The two new helpers follow the same iteration pattern as the existing `_find_uploadable_schema_variant` method (lines 667-687).

[![CE](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)