### PR TITLE
docs: clarify bearer token self-managed OAuth responsibility

### DIFF
--- a/docs/content/docs/importing-existing-connections.mdx
+++ b/docs/content/docs/importing-existing-connections.mdx
@@ -74,9 +74,11 @@ console.log('Connected:', connection.id);
 
 ## Bearer tokens
 
-If you already have an access token for a service (e.g., from an OAuth flow you manage), you can pass it directly to Composio as a bearer token. This works with **all toolkits that support OAuth2 or S2S auth** — Gmail, GitHub, Slack, Google Docs, and more. Any additional parameters the toolkit supports (e.g., `subdomain`, `base_url`) work the same way.
+If you manage your own OAuth flow and already have an access token for a service, you can pass it directly to Composio as a bearer token instead of setting up OAuth through Composio. This works with **all toolkits that support OAuth2 or S2S auth** — Gmail, GitHub, Slack, Google Docs, and more. Any additional parameters the toolkit supports (e.g., `subdomain`, `base_url`) work the same way.
 
-After [creating an auth config](/docs/auth-configuration/programmatic-auth-configs) with `authScheme: "BEARER_TOKEN"`, use the snippet below to create a connected account. Since access tokens typically expire, use the [PATCH endpoint](#updating-credentials) to push a refreshed token whenever it changes on your end.
+**Important:** When you import a bearer token this way, Composio will **not** handle OAuth token refresh for you. You are responsible for refreshing the token on your end and updating it in Composio via the [PATCH method](#updating-credentials) whenever it changes.
+
+After [creating an auth config](/docs/auth-configuration/programmatic-auth-configs) with `authScheme: "BEARER_TOKEN"`, use the snippet below to create a connected account:
 
 <Tabs groupId="language" items={['Python', 'TypeScript']} persist>
 <Tab value="Python">

--- a/docs/content/docs/importing-existing-connections.mdx
+++ b/docs/content/docs/importing-existing-connections.mdx
@@ -74,9 +74,9 @@ console.log('Connected:', connection.id);
 
 ## Bearer tokens
 
-If you manage your own OAuth flow and already have an access token for a service, you can pass it directly to Composio as a bearer token instead of setting up OAuth through Composio. This works with **all toolkits that support OAuth2 or S2S auth** — Gmail, GitHub, Slack, Google Docs, and more. Any additional parameters the toolkit supports (e.g., `subdomain`, `base_url`) work the same way.
+If you manage your own OAuth flow and already have an access token for a service, you can import it into Composio as a bearer token. This lets you bring existing OAuth connections into Composio without re-authenticating your users. It works with **all toolkits that support OAuth2 or S2S auth** — Gmail, GitHub, Slack, Google Docs, and more. Any additional parameters the toolkit supports (e.g., `subdomain`, `base_url`) work the same way.
 
-**Important:** When you import a bearer token this way, Composio will **not** handle OAuth token refresh for you. You are responsible for refreshing the token on your end and updating it in Composio via the [PATCH method](#updating-credentials) whenever it changes.
+Since you're providing your own token, Composio won't handle OAuth refresh — you're responsible for refreshing the token on your end and pushing the updated value to Composio via the [PATCH method](#updating-credentials) whenever it changes.
 
 After [creating an auth config](/docs/auth-configuration/programmatic-auth-configs) with `authScheme: "BEARER_TOKEN"`, use the snippet below to create a connected account:
 


### PR DESCRIPTION
# Description
Updates the bearer tokens section of the "Importing existing connections" doc to:
- Clarify that importing a bearer token means you're managing your own OAuth flow
- Explicitly state that Composio will **not** handle token refresh — it's the user's responsibility to refresh and update via the PATCH method
- Clean up the wording for coherence and brevity

# How did I test this PR
- Read the updated MDX file and verified the markdown renders correctly
- Confirmed all internal links (`#updating-credentials`, auth config link) are intact

Triggered by: dhawal dhawal@composio.dev | Source: slack
Session: https://zen-api-production-4c98.up.railway.app/dashboard/#/chat/zen-bda41bd0b99b