### PR TITLE
fix: correct alias and requiredness for reserved field names (#3172)

### DIFF
--- a/python/composio/utils/shared.py
+++ b/python/composio/utils/shared.py
@@ -209,10 +209,13 @@ def json_schema_to_pydantic_field(
     if default is not None:
         default = _coerce_default_value(default, json_schema)
 
+    # Check requiredness against the original name before any renaming
+    is_required = name in required
+
     # Check if the field name is a reserved Pydantic name
     if name in reserved_names:
+        alias = name  # alias keeps the original schema key
         name = f"{name}_"
-        alias = name
     else:
         alias = None
 
@@ -222,7 +225,7 @@ def json_schema_to_pydantic_field(
         "alias": alias,
     }
     if not skip_default:
-        field["default"] = ... if name in required else default
+        field["default"] = ... if is_required else default
 
     return (
         name,

--- a/python/tests/test_schema_parser.py
+++ b/python/tests/test_schema_parser.py
@@ -121,7 +121,57 @@ class TestJsonSchemaToPydanticField:
         )
 
         assert field_name == "validate_"  # Should be renamed
-        assert field_info.alias == "validate_"  # Should have alias
+        assert field_info.alias == "validate"  # Alias must be the ORIGINAL schema key
+
+    def test_reserved_field_name_required(self):
+        """Test that reserved field names remain required when listed in required."""
+        name = "validate"
+        json_schema = {
+            "type": "string",
+            "description": "A required field with reserved name",
+            "title": "Validate",
+        }
+        required = ["validate"]  # Original name in required list
+
+        field_name, field_type, field_info = json_schema_to_pydantic_field(
+            name, json_schema, required
+        )
+
+        assert field_name == "validate_"
+        assert field_info.alias == "validate"
+        assert field_info.default is PydanticUndefined  # Must stay required
+
+    def test_reserved_field_in_model(self):
+        """Test that json_schema_to_model handles reserved required fields end-to-end."""
+        schema = {
+            "title": "TestModel",
+            "type": "object",
+            "properties": {
+                "validate": {
+                    "type": "string",
+                    "description": "Must be required and aliased correctly",
+                },
+                "normal": {
+                    "type": "integer",
+                    "description": "A normal field",
+                },
+            },
+            "required": ["validate", "normal"],
+        }
+
+        Model = json_schema_to_model(schema)
+
+        # Both fields should be required (default is Ellipsis / PydanticUndefined)
+        validate_field = Model.model_fields["validate_"]
+        normal_field = Model.model_fields["normal"]
+        assert validate_field.default is PydanticUndefined
+        assert normal_field.default is PydanticUndefined
+        assert validate_field.alias == "validate"
+
+        # Model should accept data keyed by the original schema name
+        instance = Model(**{"validate": "hello", "normal": 42})
+        assert instance.validate_ == "hello"
+        assert instance.normal == 42
 
     def test_field_with_examples(self):
         """Test that examples are properly preserved in field info."""


### PR DESCRIPTION
# Description
Fix two bugs in `json_schema_to_pydantic_field()` when handling reserved Pydantic field names (e.g., `validate`):

1. **Wrong alias**: The alias was set to the renamed identifier (`validate_`) instead of the original schema key (`validate`). This means Pydantic couldn't map incoming data keyed by the original name.
2. **Silent optional**: Requiredness was checked after renaming, so `required=["validate"]` no longer matched the renamed `validate_`, causing required fields to silently become optional.

**Root cause**: The rename (`name = f"{name}_"`) happened before both the alias assignment and the requiredness check.

**Fix**: Save the original name for alias and requiredness checks before renaming.

Note: `pydantic_model_from_param_schema()` in the same file already handled this correctly — this fix aligns `json_schema_to_pydantic_field()` with that pattern.

Fixes #3172

# How did I test this PR
- Ran `pytest tests/test_schema_parser.py -v` — all 67 tests pass
- Updated existing `test_reserved_field_name_handling` to assert correct alias (`"validate"` not `"validate_"`)
- Added `test_reserved_field_name_required`: verifies a reserved field listed in `required` stays required after rename
- Added `test_reserved_field_in_model`: end-to-end test creating a model with a required reserved field and instantiating it with original key names

Triggered by: pranai@usefulagents.com | Source: slack
Session: https://zen-api-production-4c98.up.railway.app/dashboard/#/chat/zen-dbc5e5df72d5