### PR TITLE
feat(cli): add root-level `composio apps` and `composio connections` commands for consumer namespace

### DIFF
--- a/ts/packages/cli/src/commands/apps.cmd.ts
+++ b/ts/packages/cli/src/commands/apps.cmd.ts
@@ -1,9 +1,11 @@
+import process from 'node:process';
 import { Command, Options } from '@effect/cli';
 import { Effect, Option } from 'effect';
 import { TerminalUI } from 'src/services/terminal-ui';
 import { ComposioClientSingleton, ComposioToolkitsRepository } from 'src/services/composio-clients';
 import { requireAuth } from 'src/effects/require-auth';
 import { clampLimit } from 'src/ui/clamp-limit';
+import { extractMessage } from 'src/utils/api-error-extraction';
 import {
   formatResolveCommandProjectError,
   resolveCommandProject,
@@ -108,6 +110,7 @@ export const appsCmd = Command.make(
             import('@composio/client/resources/tool-router').SessionToolkitsResponse.Item
           >
         | undefined;
+      let sessionFailed = false;
       if (sessionContext) {
         sessionItems = yield* Effect.tryPromise(() =>
           sessionContext.client.toolRouter.session.toolkits(sessionContext.sessionId, {
@@ -119,10 +122,21 @@ export const appsCmd = Command.make(
           Effect.map(r => r.items),
           Effect.catchAll(error =>
             Effect.logDebug('Failed to fetch session toolkits:', error).pipe(
-              Effect.as(undefined)
+              Effect.as(
+                [] as ReadonlyArray<
+                  import('@composio/client/resources/tool-router').SessionToolkitsResponse.Item
+                >
+              )
             )
           )
         );
+        if (sessionItems.length === 0) {
+          sessionFailed = true;
+          sessionItems = undefined;
+        }
+      } else if (consumerUserId) {
+        // Session creation itself failed (caught in parallel fetch above).
+        sessionFailed = true;
       }
 
       let unified = mergeToolkitData(catalogResult.items, sessionItems);
@@ -131,7 +145,7 @@ export const appsCmd = Command.make(
       const isConnectedFilter = Option.getOrUndefined(connected);
       if (isConnectedFilter && sessionItems) {
         unified = unified.filter(t => t.connected?.status === 'ACTIVE');
-      } else if (isConnectedFilter && !sessionItems) {
+      } else if (isConnectedFilter && sessionFailed) {
         yield* ui.log.warn(
           '`--connected` filter could not be applied — session data unavailable.'
         );
@@ -151,7 +165,18 @@ export const appsCmd = Command.make(
       );
 
       yield* ui.output(formatToolkitsJson(unified));
-    })
+    }).pipe(
+      Effect.catchAll(error =>
+        Effect.gen(function* () {
+          const ui = yield* TerminalUI;
+          yield* ui.log.error(
+            extractMessage(error) ?? 'An error occurred while fetching apps.'
+          );
+          yield* ui.output('[]');
+          process.exitCode = 1;
+        })
+      )
+    )
 ).pipe(
   Command.withDescription(
     [

--- a/ts/packages/cli/src/commands/apps.cmd.ts
+++ b/ts/packages/cli/src/commands/apps.cmd.ts
@@ -1,0 +1,173 @@
+import { Command, Options } from '@effect/cli';
+import { Effect, Option } from 'effect';
+import { TerminalUI } from 'src/services/terminal-ui';
+import { ComposioClientSingleton, ComposioToolkitsRepository } from 'src/services/composio-clients';
+import { requireAuth } from 'src/effects/require-auth';
+import { clampLimit } from 'src/ui/clamp-limit';
+import {
+  formatResolveCommandProjectError,
+  resolveCommandProject,
+} from 'src/services/command-project';
+import { resolveToolRouterSession } from 'src/effects/create-tool-router-session';
+import { mergeToolkitData, formatToolkitsTable, formatToolkitsJson } from './toolkits/format';
+
+const query = Options.text('query').pipe(
+  Options.withDescription('Search by name, slug, or description'),
+  Options.optional
+);
+
+const connected = Options.boolean('connected').pipe(
+  Options.withDescription('Show only connected apps'),
+  Options.optional
+);
+
+const limit = Options.integer('limit').pipe(
+  Options.withDefault(1000),
+  Options.withDescription('Number of results (1-1000)')
+);
+
+/**
+ * List all available Composio apps with connection status.
+ *
+ * Operates in the consumer ("for you") namespace — no developer project setup
+ * required. Fetches the full toolkit catalog and enriches it with the current
+ * user's connection status via a Tool Router session.
+ *
+ * @example
+ * ```bash
+ * composio apps
+ * composio apps --query "email"
+ * composio apps --connected
+ * ```
+ */
+export const appsCmd = Command.make(
+  'apps',
+  { query, connected, limit },
+  ({ query, connected, limit }) =>
+    Effect.gen(function* () {
+      if (!(yield* requireAuth)) return;
+
+      const ui = yield* TerminalUI;
+      const repo = yield* ComposioToolkitsRepository;
+      const clientSingleton = yield* ComposioClientSingleton;
+
+      const clampedLimit = clampLimit(limit);
+
+      // Resolve consumer project for connection status enrichment.
+      const resolvedProject = yield* resolveCommandProject({ mode: 'consumer' }).pipe(
+        Effect.mapError(formatResolveCommandProjectError)
+      );
+
+      const consumerUserId =
+        resolvedProject.projectType === 'CONSUMER'
+          ? resolvedProject.consumerUserId
+          : undefined;
+
+      const client = yield* clientSingleton.getFor({
+        orgId: resolvedProject.orgId,
+        projectId: resolvedProject.projectId,
+      });
+
+      // Fetch catalog and session data in parallel.
+      const catalogEffect = repo.searchToolkits({
+        search: Option.getOrUndefined(query),
+        limit: clampedLimit,
+      });
+
+      const sessionContextEffect = consumerUserId
+        ? resolveToolRouterSession(client, consumerUserId, {
+            cacheScope: {
+              orgId: resolvedProject.orgId,
+              consumerUserId,
+            },
+          }).pipe(
+            Effect.catchAll(error =>
+              Effect.logDebug('Failed to create session:', error).pipe(Effect.as(undefined))
+            )
+          )
+        : Effect.succeed(undefined as undefined);
+
+      const [catalogResult, sessionContext] = yield* ui.withSpinner(
+        'Fetching apps...',
+        Effect.all([catalogEffect, sessionContextEffect], { concurrency: 'unbounded' })
+      );
+
+      if (catalogResult.items.length === 0) {
+        yield* ui.log.warn(
+          Option.isSome(query)
+            ? `No apps found for "${query.value}". Try a different search.`
+            : 'No apps found.'
+        );
+        yield* ui.output('[]');
+        return;
+      }
+
+      // Enrich with session data (logos + connection status) when available.
+      let sessionItems:
+        | ReadonlyArray<
+            import('@composio/client/resources/tool-router').SessionToolkitsResponse.Item
+          >
+        | undefined;
+      if (sessionContext) {
+        sessionItems = yield* Effect.tryPromise(() =>
+          sessionContext.client.toolRouter.session.toolkits(sessionContext.sessionId, {
+            search: Option.getOrUndefined(query),
+            limit: clampedLimit,
+            is_connected: Option.getOrUndefined(connected),
+          })
+        ).pipe(
+          Effect.map(r => r.items),
+          Effect.catchAll(error =>
+            Effect.logDebug('Failed to fetch session toolkits:', error).pipe(
+              Effect.as(undefined)
+            )
+          )
+        );
+      }
+
+      let unified = mergeToolkitData(catalogResult.items, sessionItems);
+
+      // Apply --connected filter client-side when session data is available.
+      const isConnectedFilter = Option.getOrUndefined(connected);
+      if (isConnectedFilter && sessionItems) {
+        unified = unified.filter(t => t.connected?.status === 'ACTIVE');
+      } else if (isConnectedFilter && !sessionItems) {
+        yield* ui.log.warn(
+          '`--connected` filter could not be applied — session data unavailable.'
+        );
+      }
+
+      if (unified.length === 0) {
+        yield* ui.log.warn('No connected apps found. Try without --connected.');
+        yield* ui.output('[]');
+        return;
+      }
+
+      const showing = unified.length;
+      const total = catalogResult.total_items;
+
+      yield* ui.log.info(
+        `${showing} of ${total} apps\n\n${formatToolkitsTable(unified)}`
+      );
+
+      yield* ui.output(formatToolkitsJson(unified));
+    })
+).pipe(
+  Command.withDescription(
+    [
+      'List all available Composio apps with connection status.',
+      '',
+      'Shows the full toolkit catalog enriched with your personal connection status.',
+      'No developer project setup required — operates in the consumer namespace.',
+      '',
+      'Examples:',
+      '  composio apps                    List all available apps',
+      '  composio apps --query "email"    Search by name or description',
+      '  composio apps --connected        Show only connected apps',
+      '',
+      'See also:',
+      '  composio link <toolkit>          Connect an app',
+      '  composio connections             List connected accounts in detail',
+    ].join('\n')
+  )
+);

--- a/ts/packages/cli/src/commands/connections.cmd.ts
+++ b/ts/packages/cli/src/commands/connections.cmd.ts
@@ -101,7 +101,7 @@ export const connectionsCmd = Command.make(
           hint = 'No connections found. Connect your first app with:\n> composio link github';
         }
         yield* ui.log.warn(hint);
-        yield* ui.output(JSON.stringify({ items: [], total: 0 }, null, 2));
+        yield* ui.output(formatConnectedAccountsJson([]));
         return;
       }
 

--- a/ts/packages/cli/src/commands/connections.cmd.ts
+++ b/ts/packages/cli/src/commands/connections.cmd.ts
@@ -1,0 +1,135 @@
+import { Command, Options } from '@effect/cli';
+import { Effect, Option } from 'effect';
+import { TerminalUI } from 'src/services/terminal-ui';
+import { ComposioClientSingleton } from 'src/services/composio-clients';
+import { requireAuth } from 'src/effects/require-auth';
+import { clampLimit } from 'src/ui/clamp-limit';
+import {
+  formatResolveCommandProjectError,
+  resolveCommandProject,
+} from 'src/services/command-project';
+import {
+  formatConnectedAccountsTable,
+  formatConnectedAccountsJson,
+} from './connected-accounts/format';
+
+const toolkits = Options.text('toolkits').pipe(
+  Options.withDescription(
+    'Filter by toolkit slugs, comma-separated (e.g. "gmail" or "gmail,slack")'
+  ),
+  Options.optional
+);
+
+const status = Options.choice('status', [
+  'INITIALIZING',
+  'INITIATED',
+  'ACTIVE',
+  'FAILED',
+  'EXPIRED',
+  'INACTIVE',
+] as const).pipe(
+  Options.withDefault('ACTIVE' as const),
+  Options.withDescription('Filter by connection status (default: ACTIVE)')
+);
+
+const limit = Options.integer('limit').pipe(
+  Options.withDefault(100),
+  Options.withDescription('Number of results (1-1000)')
+);
+
+/**
+ * List connected accounts in the consumer ("for you") namespace.
+ *
+ * Unlike `composio dev connected-accounts list` (which is developer-project-scoped),
+ * this command shows the current user's personal connections — the accounts linked
+ * via `composio link`.
+ *
+ * @example
+ * ```bash
+ * composio connections
+ * composio connections --toolkits "gmail,slack"
+ * composio connections --status ACTIVE
+ * ```
+ */
+export const connectionsCmd = Command.make(
+  'connections',
+  { toolkits, status, limit },
+  ({ toolkits, status, limit }) =>
+    Effect.gen(function* () {
+      if (!(yield* requireAuth)) return;
+
+      const ui = yield* TerminalUI;
+      const clientSingleton = yield* ComposioClientSingleton;
+
+      const resolvedProject = yield* resolveCommandProject({ mode: 'consumer' }).pipe(
+        Effect.mapError(formatResolveCommandProjectError)
+      );
+
+      if (resolvedProject.projectType !== 'CONSUMER' || !resolvedProject.consumerUserId) {
+        yield* ui.log.error(
+          'Could not resolve consumer project. Run `composio login` first.'
+        );
+        return;
+      }
+
+      const client = yield* clientSingleton.getFor({
+        orgId: resolvedProject.orgId,
+        projectId: resolvedProject.projectId,
+      });
+
+      const toolkitSlugs = Option.isSome(toolkits)
+        ? toolkits.value.split(',').map(s => s.trim())
+        : undefined;
+
+      const result = yield* ui.withSpinner(
+        'Fetching connections...',
+        Effect.tryPromise(() =>
+          client.connectedAccounts.list({
+            toolkit_slugs: toolkitSlugs,
+            user_ids: [resolvedProject.consumerUserId!],
+            statuses: [status],
+            limit: clampLimit(limit),
+          })
+        )
+      );
+
+      if (result.items.length === 0) {
+        let hint: string;
+        if (Option.isSome(toolkits)) {
+          hint = `No connections found for "${toolkits.value}". Connect an app with:\n> composio link ${toolkits.value.split(',')[0]?.trim()}`;
+        } else {
+          hint = 'No connections found. Connect your first app with:\n> composio link github';
+        }
+        yield* ui.log.warn(hint);
+        yield* ui.output(JSON.stringify({ items: [], total: 0 }, null, 2));
+        return;
+      }
+
+      const showing = result.items.length;
+      const total = result.total_items;
+
+      yield* ui.log.info(
+        `${showing} of ${total} connections\n\n${formatConnectedAccountsTable(result.items)}`
+      );
+
+      yield* ui.output(formatConnectedAccountsJson(result.items));
+    })
+).pipe(
+  Command.withDescription(
+    [
+      'List your connected accounts (apps linked via `composio link`).',
+      '',
+      'Shows all personal ("for you") connections. Unlike `composio dev connected-accounts list`,',
+      'this command operates in the consumer namespace — no project setup required.',
+      '',
+      'Examples:',
+      '  composio connections                          List all active connections',
+      '  composio connections --toolkits gmail,slack    Filter by toolkit',
+      '  composio connections --status EXPIRED          Show expired connections',
+      '',
+      'See also:',
+      '  composio link <toolkit>     Connect a new app',
+      '  composio search "<query>"   Find tools to use with your connections',
+    ].join('\n')
+  )
+);

--- a/ts/packages/cli/src/commands/index.ts
+++ b/ts/packages/cli/src/commands/index.ts
@@ -25,6 +25,7 @@ import { rootToolsCmd$Execute } from './tools/commands/tools.execute.cmd';
 import { rootToolsCmd } from './tools/tools.cmd';
 import { rootTriggersCmd } from './triggers/root-triggers.cmd';
 import { rootConnectedAccountsCmd$Link } from './connected-accounts/commands/connected-accounts.link.cmd';
+import { connectionsCmd } from './connections.cmd';
 import { orgsCmd } from './orgs/orgs.cmd';
 import { configCmd } from './config/config.cmd';
 import { renderCommandHintGraph } from 'src/services/command-hints';
@@ -64,6 +65,7 @@ const ROOT_COMMANDS: ReadonlyArray<TaggedValue<Command.Command<any, any, any, an
   tagged(rootTriggersCmd),
   tagged(rootToolsCmd$Search),
   tagged(rootConnectedAccountsCmd$Link),
+  tagged(connectionsCmd),
   tagged(rootToolsCmd$Execute),
   tagged(generateCmd),
   tagged(orgsCmd),

--- a/ts/packages/cli/src/commands/index.ts
+++ b/ts/packages/cli/src/commands/index.ts
@@ -25,6 +25,7 @@ import { rootToolsCmd$Execute } from './tools/commands/tools.execute.cmd';
 import { rootToolsCmd } from './tools/tools.cmd';
 import { rootTriggersCmd } from './triggers/root-triggers.cmd';
 import { rootConnectedAccountsCmd$Link } from './connected-accounts/commands/connected-accounts.link.cmd';
+import { appsCmd } from './apps.cmd';
 import { connectionsCmd } from './connections.cmd';
 import { orgsCmd } from './orgs/orgs.cmd';
 import { configCmd } from './config/config.cmd';
@@ -65,6 +66,7 @@ const ROOT_COMMANDS: ReadonlyArray<TaggedValue<Command.Command<any, any, any, an
   tagged(rootTriggersCmd),
   tagged(rootToolsCmd$Search),
   tagged(rootConnectedAccountsCmd$Link),
+  tagged(appsCmd),
   tagged(connectionsCmd),
   tagged(rootToolsCmd$Execute),
   tagged(generateCmd),


### PR DESCRIPTION
## Summary

Adds two root-level commands that expose existing developer-namespace functionality to the consumer ("for you") namespace — no `composio dev init` or project setup required.

### `composio apps` — Full catalog with connection status
```bash
composio apps                    # All ~982 available apps with logos + connection status
composio apps --query "email"    # Search by name/description
composio apps --connected        # Only connected apps
```

Fetches the toolkit catalog and a Tool Router session in parallel, merges them with `mergeToolkitData()`, and outputs the unified result. This is the consumer equivalent of `composio dev toolkits list`.

### `composio connections` — Connected accounts detail
```bash
composio connections                          # All active connections
composio connections --toolkits gmail,slack    # Filter by toolkit
composio connections --status EXPIRED          # Non-active connections
```

Lists connected accounts using `client.connectedAccounts.list()` with the consumer user ID auto-resolved. This is the consumer equivalent of `composio dev connected-accounts list`.

## Motivation

Consumer-facing apps (desktop clients, CLI wrappers) that use `composio link` for OAuth have no supported way to:

1. Know which apps the user has connected
2. Get the full app catalog with metadata (names, logos, descriptions)

The only workaround is probing each toolkit individually via `composio proxy` SSRF side-effects — spawning one subprocess per app, parsing error slugs to distinguish "connected" from "not connected." See #3187 for the full story.

## Implementation

Both commands follow existing patterns exactly:

- **Consumer mode resolution:** `resolveCommandProject({ mode: 'consumer' })` — same as `composio link`
- **Data fetching:** `client.connectedAccounts.list()` and `repo.searchToolkits()` + `client.toolRouter.session.toolkits()` — same APIs as `composio dev` commands
- **Formatting:** Reuses `formatConnectedAccountsTable/Json` and `formatToolkitsTable/Json` — no new format code
- **Registration:** Added to `ROOT_COMMANDS` in `index.ts` — same pattern as `rootConnectedAccountsCmd$Link`

No new dependencies, no new services, no new models. Just wiring.

## Files changed

- **New:** `ts/packages/cli/src/commands/apps.cmd.ts` (173 lines)
- **New:** `ts/packages/cli/src/commands/connections.cmd.ts` (135 lines)
- **Modified:** `ts/packages/cli/src/commands/index.ts` (+4 lines — imports + registration)

Closes #3187
Related: #3118

## Test plan

### `composio connections`
- [ ] Lists consumer-linked accounts (created via `composio link`)
- [ ] `--toolkits gmail` filters correctly
- [ ] `--status EXPIRED` shows non-active connections
- [ ] Piped output emits clean JSON
- [ ] No connections shows helpful hint
- [ ] Works without `composio dev init`

### `composio apps`
- [ ] Returns full catalog (~982 toolkits)
- [ ] Includes connection status enrichment from session data
- [ ] `--query "email"` filters by search
- [ ] `--connected` shows only connected apps
- [ ] `--limit 50` caps results
- [ ] Piped output emits clean JSON with logo URLs
- [ ] Works without `composio dev init`