### PR TITLE
fix: auto-paginate tools.get() when no limit specified

### DIFF
--- a/python/composio/core/models/tools.py
+++ b/python/composio/core/models/tools.py
@@ -190,15 +190,40 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
 
         # Search tools by toolkit slugs and search term
         if toolkits is not None or search is not None:
-            tools_list.extend(
-                self._client.tools.list(
-                    toolkit_slug=none_to_omit(",".join(toolkits) if toolkits else None),
-                    search=none_to_omit(search),
-                    scopes=scopes,
-                    limit=limit,
-                    toolkit_versions=none_to_omit(self._toolkit_versions),
-                ).items
-            )
+            toolkit_slug = none_to_omit(",".join(toolkits) if toolkits else None)
+            search_param = none_to_omit(search)
+            toolkit_versions = none_to_omit(self._toolkit_versions)
+
+            if limit is not None:
+                # User specified a limit — make a single request
+                tools_list.extend(
+                    self._client.tools.list(
+                        toolkit_slug=toolkit_slug,
+                        search=search_param,
+                        scopes=scopes,
+                        limit=limit,
+                        toolkit_versions=toolkit_versions,
+                    ).items
+                )
+            else:
+                # No limit specified — auto-paginate to fetch all tools.
+                # The server defaults to 20 items per page, which silently
+                # truncates results when multiple toolkits are requested.
+                page_limit = 1000
+                cursor = None
+                while True:
+                    result = self._client.tools.list(
+                        toolkit_slug=toolkit_slug,
+                        search=search_param,
+                        scopes=scopes,
+                        limit=page_limit,
+                        cursor=none_to_omit(cursor),
+                        toolkit_versions=toolkit_versions,
+                    )
+                    tools_list.extend(result.items)
+                    cursor = result.next_cursor
+                    if not cursor or len(result.items) < page_limit:
+                        break
         return tools_list
 
     def get_raw_tool_router_meta_tools(


### PR DESCRIPTION
# Description
Fix `tools.get(toolkits=[...])` silently returning only one toolkit's tools when multiple toolkits are requested (T-9867).

**User report:** calling `composio.tools.get(user_id=..., toolkits=["github","gmail","slack","google_calendar","google_drive","notion","linear","hubspot","asana","google_sheets"])` only returns Asana tools (20 ASANA_* functions). The other 9 toolkits are completely ignored.

**Root cause:** The SDK's `get_raw_composio_tools()` makes a **single API call** without specifying a `limit`. The server (Apollo) defaults to `limit=20`. Tools are sorted alphabetically by slug in the DB (`ORDER BY slug ASC`), so the first 20 results are all `ASANA_*` tools. The remaining toolkits' tools exist but are on later pages that the SDK never fetches.

Even setting `limit=1000` (the API maximum) is insufficient — with 1,416 total tools across 7 active toolkits, only 4 toolkits fit in a single page (GitHub alone has 823 tools). The SDK must auto-paginate.

**Investigation summary:**
- Thermos backend: **No bug.** Correctly splits comma-separated toolkit slugs, uses SQL `IN`/`OR` clauses for all toolkits, returns paginated results. Verified by tracing `GetLatestToolkitsBySlugs()` and `ListToolsByGroupWithVersions()` in Go.
- Apollo: **No bug.** Correctly passes `toolkit_slug` string to Thermos. Default limit=20 is a design choice, not a bug.
- SDK (`get_raw_composio_tools`): **Bug.** Makes a single request with no limit and no pagination. This is the root cause.

**Fix:** When no `limit` is specified by the caller, auto-paginate through all pages using cursor-based pagination (page size 1000) to fetch every tool across all requested toolkits. When the user explicitly passes a `limit`, the existing single-request behavior is preserved.

**Before:**
```
tools.get(toolkits=["github","gmail","slack","asana",...]) → 20 items, all from Asana
tools.get(toolkits=[...], limit=1000) → 1000 items, 4/7 toolkits (still truncated)
```

**After:**
```
tools.get(toolkits=["github","gmail","slack","asana",...]) → 1416 items, all 7 active toolkits
tools.get(toolkits=[...], limit=5) → 5 items (explicit limit respected)
```

# How did I test this PR
**Reproduction (against production API with key `ak_mux3cK0nk1G2UUkThfmk`):**
- `client.tools.list(toolkit_slug="github,gmail,...,asana,...")` with no limit → **20 items, 100% Asana** ✅ bug reproduced
- Same with `limit=1000` → **1000 items, 4 toolkits** (github:823, asana:84, hubspot:70, gmail:23) — still missing 3 toolkits
- HTTP request captured: `GET /api/v3/tools?toolkit_slug=github%2Cgmail%2C...` — no limit param sent → server defaults to 20

**Fix validation:**
- Auto-pagination test: page 1 → 1000 items, page 2 → 416 items = **1416 total across 7 toolkits** (asana:84, github:823, gmail:23, hubspot:304, linear:21, notion:28, slack:133)
- 3 toolkits with 0 tools (`google_calendar`, `google_drive`, `google_sheets`) confirmed to have no registered tools — separate from this bug
- Verified `none_to_omit(cursor)` correctly omits cursor on first page and passes cursor string on subsequent pages
- `ruff check` and `ruff format` pass