### PR TITLE
fix(python-sdk): auto-paginate tools.get() when no explicit limit is set

### DIFF
--- a/python/composio/core/models/tools.py
+++ b/python/composio/core/models/tools.py
@@ -160,6 +160,8 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
                 ),
             )
 
+    _MAX_PAGE_SIZE = 1000
+
     def get_raw_composio_tools(
         self,
         tools: t.Optional[list[str]] = None,
@@ -170,6 +172,10 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
     ) -> list[Tool]:
         """
         Get a list of tool schemas based on the provided filters.
+
+        When no explicit limit is provided and querying by toolkits or search,
+        automatically paginates through all pages using cursor-based pagination
+        to return the complete result set.
         """
         if tools is None and search is None and toolkits is None:
             raise InvalidParams(
@@ -190,15 +196,37 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
 
         # Search tools by toolkit slugs and search term
         if toolkits is not None or search is not None:
-            tools_list.extend(
-                self._client.tools.list(
-                    toolkit_slug=none_to_omit(",".join(toolkits) if toolkits else None),
-                    search=none_to_omit(search),
-                    scopes=scopes,
-                    limit=limit,
-                    toolkit_versions=none_to_omit(self._toolkit_versions),
-                ).items
-            )
+            if limit is not None:
+                # Explicit limit: single request, backward compatible
+                tools_list.extend(
+                    self._client.tools.list(
+                        toolkit_slug=none_to_omit(
+                            ",".join(toolkits) if toolkits else None
+                        ),
+                        search=none_to_omit(search),
+                        scopes=scopes,
+                        limit=limit,
+                        toolkit_versions=none_to_omit(self._toolkit_versions),
+                    ).items
+                )
+            else:
+                # No explicit limit: auto-paginate to fetch all results
+                cursor: t.Optional[str] = None
+                while True:
+                    response = self._client.tools.list(
+                        toolkit_slug=none_to_omit(
+                            ",".join(toolkits) if toolkits else None
+                        ),
+                        search=none_to_omit(search),
+                        scopes=scopes,
+                        limit=self._MAX_PAGE_SIZE,
+                        cursor=none_to_omit(cursor),
+                        toolkit_versions=none_to_omit(self._toolkit_versions),
+                    )
+                    tools_list.extend(response.items)
+                    cursor = response.next_cursor
+                    if not cursor:
+                        break
         return tools_list
 
     def get_raw_tool_router_meta_tools(

--- a/python/composio/core/models/tools.py
+++ b/python/composio/core/models/tools.py
@@ -211,8 +211,9 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
                 )
             else:
                 # No explicit limit: auto-paginate to fetch all results
+                _MAX_PAGES = 10  # Safety cap to prevent infinite loops
                 cursor: t.Optional[str] = None
-                while True:
+                for _ in range(_MAX_PAGES):
                     response = self._client.tools.list(
                         toolkit_slug=none_to_omit(
                             ",".join(toolkits) if toolkits else None

--- a/python/tests/test_tools_pagination.py
+++ b/python/tests/test_tools_pagination.py
@@ -204,3 +204,18 @@ class TestToolsPagination:
 
         assert len(result) == 1
         assert mock_client.tools.list.call_count == 1
+
+    def test_pagination_safety_cap(self):
+        """Pagination stops after max pages to prevent infinite loops."""
+        mock_client = Mock()
+        # Always return a next_cursor — simulates a buggy API
+        mock_client.tools.list.return_value = _make_list_response(
+            [_make_tool("T")], next_cursor="always_more"
+        )
+
+        tools = _make_tools_instance(mock_client)
+        result = tools.get_raw_composio_tools(toolkits=["github"])
+
+        # Should stop after 10 pages (safety cap), not loop forever
+        assert mock_client.tools.list.call_count == 10
+        assert len(result) == 10

--- a/python/tests/test_tools_pagination.py
+++ b/python/tests/test_tools_pagination.py
@@ -1,0 +1,206 @@
+"""Test pagination in tools.get_raw_composio_tools.
+
+Verifies that the SDK auto-paginates when no explicit limit is provided,
+and respects the user's limit with a single request when one is given.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from composio.client.types import Tool, tool_list_response
+from composio.core.models.base import allow_tracking
+from composio.core.models.tools import Tools
+from composio.core.provider._openai import OpenAIProvider
+
+
+@pytest.fixture(autouse=True)
+def disable_telemetry():
+    """Disable telemetry for all tests to prevent thread issues."""
+    token = allow_tracking.set(False)
+    yield
+    allow_tracking.reset(token)
+
+
+def _make_tool(slug: str, toolkit_slug: str = "github") -> Tool:
+    """Create a minimal mock Tool."""
+    return Tool(
+        name=slug,
+        slug=slug,
+        description="test",
+        input_parameters={"type": "object", "properties": {}},
+        output_parameters={},
+        available_versions=["v1"],
+        version="v1",
+        scopes=[],
+        toolkit=tool_list_response.ItemToolkit(
+            name=toolkit_slug, slug=toolkit_slug, logo=""
+        ),
+        deprecated=tool_list_response.ItemDeprecated(
+            available_versions=["v1"],
+            displayName=slug,
+            version="v1",
+            toolkit=tool_list_response.ItemDeprecatedToolkit(logo=""),
+            is_deprecated=False,
+        ),
+        is_deprecated=False,
+        no_auth=False,
+        tags=[],
+    )
+
+
+def _make_list_response(items, next_cursor=None):
+    """Create a mock ToolListResponse."""
+    resp = Mock()
+    resp.items = items
+    resp.next_cursor = next_cursor
+    resp.total_items = len(items)
+    resp.current_page = 1
+    resp.total_pages = 1
+    return resp
+
+
+def _make_tools_instance(mock_client):
+    provider = OpenAIProvider()
+    return Tools(client=mock_client, provider=provider)
+
+
+class TestToolsPagination:
+    """Test auto-pagination when no explicit limit is provided."""
+
+    def test_single_page_no_cursor(self):
+        """When all results fit in one page, only one request is made."""
+        mock_client = Mock()
+        page_items = [_make_tool(f"TOOL_{i}") for i in range(50)]
+        mock_client.tools.list.return_value = _make_list_response(
+            page_items, next_cursor=None
+        )
+
+        tools = _make_tools_instance(mock_client)
+        result = tools.get_raw_composio_tools(toolkits=["github"])
+
+        assert len(result) == 50
+        assert mock_client.tools.list.call_count == 1
+
+    def test_multiple_pages(self):
+        """When results span multiple pages, auto-paginate until next_cursor is null."""
+        mock_client = Mock()
+        page1 = [_make_tool(f"TOOL_{i}") for i in range(1000)]
+        page2 = [_make_tool(f"TOOL_{i}") for i in range(1000, 1416)]
+
+        mock_client.tools.list.side_effect = [
+            _make_list_response(page1, next_cursor="cursor_page2"),
+            _make_list_response(page2, next_cursor=None),
+        ]
+
+        tools = _make_tools_instance(mock_client)
+        result = tools.get_raw_composio_tools(toolkits=["github", "gmail", "slack"])
+
+        assert len(result) == 1416
+        assert mock_client.tools.list.call_count == 2
+
+        # Verify first call has no cursor, second call has cursor
+        calls = mock_client.tools.list.call_args_list
+        from composio_client import omit
+
+        assert calls[0].kwargs.get("cursor") == omit
+        assert calls[1].kwargs.get("cursor") == "cursor_page2"
+
+    def test_three_pages(self):
+        """Verify pagination works with more than two pages."""
+        mock_client = Mock()
+        page1 = [_make_tool(f"T_{i}") for i in range(1000)]
+        page2 = [_make_tool(f"T_{i}") for i in range(1000, 2000)]
+        page3 = [_make_tool(f"T_{i}") for i in range(2000, 2500)]
+
+        mock_client.tools.list.side_effect = [
+            _make_list_response(page1, next_cursor="c1"),
+            _make_list_response(page2, next_cursor="c2"),
+            _make_list_response(page3, next_cursor=None),
+        ]
+
+        tools = _make_tools_instance(mock_client)
+        result = tools.get_raw_composio_tools(toolkits=["github"])
+
+        assert len(result) == 2500
+        assert mock_client.tools.list.call_count == 3
+
+    def test_explicit_limit_single_request(self):
+        """When user provides an explicit limit, make a single request."""
+        mock_client = Mock()
+        page_items = [_make_tool(f"TOOL_{i}") for i in range(10)]
+        mock_client.tools.list.return_value = _make_list_response(
+            page_items, next_cursor="some_cursor"
+        )
+
+        tools = _make_tools_instance(mock_client)
+        result = tools.get_raw_composio_tools(toolkits=["github"], limit=10)
+
+        assert len(result) == 10
+        # Only one request even though next_cursor was returned
+        assert mock_client.tools.list.call_count == 1
+
+    def test_explicit_limit_passes_through(self):
+        """Verify explicit limit is passed to the API, not overridden."""
+        mock_client = Mock()
+        mock_client.tools.list.return_value = _make_list_response([])
+
+        tools = _make_tools_instance(mock_client)
+        tools.get_raw_composio_tools(toolkits=["github"], limit=50)
+
+        assert mock_client.tools.list.call_args.kwargs["limit"] == 50
+
+    def test_auto_paginate_uses_max_page_size(self):
+        """Without explicit limit, requests use _MAX_PAGE_SIZE (1000)."""
+        mock_client = Mock()
+        mock_client.tools.list.return_value = _make_list_response(
+            [_make_tool("T")], next_cursor=None
+        )
+
+        tools = _make_tools_instance(mock_client)
+        tools.get_raw_composio_tools(toolkits=["github"])
+
+        assert mock_client.tools.list.call_args.kwargs["limit"] == 1000
+
+    def test_search_also_paginates(self):
+        """Pagination also works when using search parameter."""
+        mock_client = Mock()
+        page1 = [_make_tool(f"T_{i}") for i in range(1000)]
+        page2 = [_make_tool(f"T_{i}") for i in range(1000, 1200)]
+
+        mock_client.tools.list.side_effect = [
+            _make_list_response(page1, next_cursor="c1"),
+            _make_list_response(page2, next_cursor=None),
+        ]
+
+        tools = _make_tools_instance(mock_client)
+        result = tools.get_raw_composio_tools(search="email")
+
+        assert len(result) == 1200
+        assert mock_client.tools.list.call_count == 2
+
+    def test_tool_slugs_no_pagination(self):
+        """When fetching by tool slugs, no pagination is applied (single request)."""
+        mock_client = Mock()
+        mock_client.tools.list.return_value = _make_list_response(
+            [_make_tool("GITHUB_STAR_REPO")], next_cursor=None
+        )
+
+        tools = _make_tools_instance(mock_client)
+        result = tools.get_raw_composio_tools(tools=["GITHUB_STAR_REPO"])
+
+        assert len(result) == 1
+        assert mock_client.tools.list.call_count == 1
+
+    def test_empty_cursor_string_stops_pagination(self):
+        """An empty string cursor should also stop pagination."""
+        mock_client = Mock()
+        mock_client.tools.list.return_value = _make_list_response(
+            [_make_tool("T")], next_cursor=""
+        )
+
+        tools = _make_tools_instance(mock_client)
+        result = tools.get_raw_composio_tools(toolkits=["github"])
+
+        assert len(result) == 1
+        assert mock_client.tools.list.call_count == 1


### PR DESCRIPTION
# Description

The API endpoint `/api/v3/tools` returns max 1000 items per page with cursor-based pagination (`next_cursor`). The Python SDK's `tools.get()` was making a single request and silently truncating results when users requested multiple toolkits with >1000 total tools.

**Before:** `composio.tools.get(toolkits=["github", "gmail", "slack", "notion", "linear", "hubspot", "asana"])` returns only 1000 tools (first page).

**After:** Same call returns all 1416 tools by automatically paginating through all pages.

**Changes:**
- `get_raw_composio_tools()` now auto-paginates when no explicit `limit` is provided, using `next_cursor` from the API response
- When user provides an explicit `limit`, behavior is unchanged (single request, fully backward compatible)
- Uses `_MAX_PAGE_SIZE = 1000` (API maximum) for each page request

# How did I test this PR

- Added 9 unit tests in `tests/test_tools_pagination.py` covering:
  - Single page (no cursor) — 1 request
  - Multi-page (2 pages, 3 pages) — correct aggregation
  - Explicit limit — single request, backward compatible
  - Limit passthrough — user limit sent to API as-is
  - Auto-paginate page size — uses 1000
  - Search pagination — works with `search` param too
  - Tool slugs — no pagination (existing behavior)
  - Empty cursor string — stops pagination
- All 9 new tests pass, all 27 existing provider tests pass
- Ruff lint and format clean

```
tests/test_tools_pagination.py::TestToolsPagination::test_single_page_no_cursor PASSED
tests/test_tools_pagination.py::TestToolsPagination::test_multiple_pages PASSED
tests/test_tools_pagination.py::TestToolsPagination::test_three_pages PASSED
tests/test_tools_pagination.py::TestToolsPagination::test_explicit_limit_single_request PASSED
tests/test_tools_pagination.py::TestToolsPagination::test_explicit_limit_passes_through PASSED
tests/test_tools_pagination.py::TestToolsPagination::test_auto_paginate_uses_max_page_size PASSED
tests/test_tools_pagination.py::TestToolsPagination::test_search_also_paginates PASSED
tests/test_tools_pagination.py::TestToolsPagination::test_tool_slugs_no_pagination PASSED
tests/test_tools_pagination.py::TestToolsPagination::test_empty_cursor_string_stops_pagination PASSED
9 passed in 0.19s
```

Triggered by: Palash Kala palash@composio.dev | Source: slack
Session: https://zen-api-production-4c98.up.railway.app/dashboard/#/chat/zen-ef9bf8a793bd