### PR TITLE
fix(cli): write fish completions to ~/.config/fish/completions/ instead of config.fish

### DIFF
--- a/ts/packages/cli/src/commands/install.cmd.ts
+++ b/ts/packages/cli/src/commands/install.cmd.ts
@@ -254,7 +254,7 @@ export const installShellIntegration = (params: {
           ? `source ${tildify(rcPath, os.homedir)}`
           : 'exec $SHELL';
       yield* ui.note(restartHint, 'Restart your shell to apply changes');
-    } else {
+    } else if (!fishCompletionFile) {
       yield* ui.log.success('Shell integration already configured — nothing to do.');
     }
 

--- a/ts/packages/cli/src/commands/install.cmd.ts
+++ b/ts/packages/cli/src/commands/install.cmd.ts
@@ -208,10 +208,19 @@ export const installShellIntegration = (params: {
       yield* ui.log.step('PATH: already configured');
     }
 
+    // Fish uses a dedicated completions directory instead of appending to config.fish.
+    // Writing completions inline into config.fish pollutes it and can break startup
+    // due to unbalanced quotes in long completion descriptions.
+    let fishCompletionFile: string | undefined;
+
     if (shell === 'zsh') {
       yield* ui.log.step('Completions: skipped for zsh');
     } else if (!params.completions) {
       yield* ui.log.step('Completions: skipped by default (pass --completions to enable)');
+    } else if (shell === 'fish' && completionScript) {
+      // Fish completions go to ~/.config/fish/completions/composio.fish
+      fishCompletionFile = path.join(os.homedir, '.config', 'fish', 'completions', 'composio.fish');
+      yield* ui.log.step('Completions: will install to fish completions directory');
     } else if (config.completionBlock && !fileContains(existing, COMPLETIONS_MARKER)) {
       blocks.push(config.completionBlock);
       yield* ui.log.step('Completions: will install shell completions');
@@ -240,14 +249,32 @@ export const installShellIntegration = (params: {
       yield* fs.rename(tmpPath, rcPath);
 
       yield* ui.log.success(`Updated ${tildify(rcPath, os.homedir)}`);
-      yield* ui.note(
+      const restartHint =
         shell === 'fish' || shell === 'zsh'
           ? `source ${tildify(rcPath, os.homedir)}`
-          : 'exec $SHELL',
-        'Restart your shell to apply changes'
-      );
+          : 'exec $SHELL';
+      yield* ui.note(restartHint, 'Restart your shell to apply changes');
     } else {
       yield* ui.log.success('Shell integration already configured — nothing to do.');
+    }
+
+    // Write fish completions to the dedicated completions directory.
+    // Fish auto-loads files from ~/.config/fish/completions/ on demand,
+    // so we never append completion definitions into config.fish.
+    if (fishCompletionFile && completionScript) {
+      yield* fs
+        .makeDirectory(path.dirname(fishCompletionFile), { recursive: true })
+        .pipe(
+          Effect.catchAll(e =>
+            Effect.logDebug('Could not create fish completions directory:', e)
+          )
+        );
+
+      const tmpCompletionPath = `${fishCompletionFile}.composio-tmp`;
+      yield* fs.writeFileString(tmpCompletionPath, `${COMPLETIONS_MARKER}\n${completionScript}\n`);
+      yield* fs.rename(tmpCompletionPath, fishCompletionFile);
+
+      yield* ui.log.success(`Completions installed to ${tildify(fishCompletionFile, os.homedir)}`);
     }
 
     yield* ui.outro('Done');


### PR DESCRIPTION
## Summary

Fixes #3147

`composio install --completions` appends all completion definitions directly into `~/.config/fish/config.fish`. This causes:

1. **config.fish bloat** — hundreds of `complete -c composio` lines pollute the user's config
2. **Startup parse errors** — long `-d` description strings with nested quotes break fish's parser
3. **Shell startup failure** — fish can't source config.fish due to unbalanced quotes

## Fix

Write fish completions to `~/.config/fish/completions/composio.fish` — the standard fish completions directory. Fish auto-loads files from this directory on demand, so no sourcing is needed.

- PATH setup still goes to `config.fish` (correct)
- Completions go to `completions/composio.fish` (fish convention)
- Atomic write (tmp + rename) preserved
- Bash completions unchanged (still inline, since bash lacks a standard user completions dir)