### PR TITLE
Add AI issue triage workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
-docs/ @sushmithamallesh
-ts/ @haxzie
-python/ @haxzie
+docs/ @shawnesquivel @Sushmithamallesh
+ts/packages/cli/ @CryogenicPlanet
+ts/ @jkomyno
+python/ @jkomyno

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, reopened, edited]
 
 permissions:
+  contents: read
   issues: write
 
 jobs:
@@ -12,70 +13,54 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
       - name: Classify issue with Claude Sonnet
-        id: classify
-        uses: actions/github-script@v8
+        uses: anthropics/claude-code-action@v1
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_BODY: ${{ github.event.issue.body }}
         with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Read the issue title and body from the ISSUE_TITLE and ISSUE_BODY environment variables.
+
+            Classify the issue for routing and determine whether it is a bug report.
+
+            Allowed categories:
+            - docs
+            - py
+            - ts
+            - cli
+            - tool-request
+            - other
+
+            Use semantic meaning, not only keywords.
+            Choose tool-request when the issue is primarily asking for a new integration, toolkit, app, or tool.
+            Choose cli only when the issue is specifically about the CLI experience or ts/packages/cli.
+            Choose py only when the issue is primarily about the Python SDK.
+            Choose ts only when the issue is primarily about the TypeScript SDK or TS packages other than the CLI.
+            Choose docs only when the issue is primarily about documentation.
+            Set is_bug to true when the issue is primarily reporting broken behavior, a defect, an error, a regression, or unexpected behavior.
+            Set is_bug to false for feature requests, questions, maintenance, cleanup, and tool requests.
+
+            Write exactly one JSON object to `.github/issue-triage-result.json` with this schema:
+            {"category":"docs|py|ts|cli|tool-request|other","is_bug":true,"reason":"short sentence"}
+
+            Do not modify any other files.
+          claude_args: |
+            --model claude-sonnet-4-6
+            --allowedTools "Read,Write,Edit"
+
+      - name: Read triage result
+        id: classify
+        uses: actions/github-script@v8
+        with:
           script: |
-            const title = process.env.ISSUE_TITLE || "";
-            const body = process.env.ISSUE_BODY || "";
-
-            const prompt = [
-              "Classify this GitHub issue for routing and determine whether it is a bug report.",
-              "",
-              "Allowed categories:",
-              "- docs",
-              "- py",
-              "- ts",
-              "- cli",
-              "- tool-request",
-              "- other",
-              "",
-              "Use semantic meaning, not only keywords.",
-              "Choose tool-request when the issue is primarily asking for a new integration, toolkit, app, or tool.",
-              "Choose cli only when the issue is specifically about the CLI experience or ts/packages/cli.",
-              "Choose py only when the issue is primarily about the Python SDK.",
-              "Choose ts only when the issue is primarily about the TypeScript SDK or TS packages other than the CLI.",
-              "Choose docs only when the issue is primarily about documentation.",
-              "Set is_bug to true when the issue is primarily reporting broken behavior, a defect, an error, a regression, or unexpected behavior.",
-              "Set is_bug to false for feature requests, questions, maintenance, cleanup, and tool requests.",
-              "",
-              "Return strict JSON with this schema only:",
-              '{"category":"docs|py|ts|cli|tool-request|other","is_bug":true,"reason":"short sentence"}',
-              "",
-              `Title: ${title}`,
-              "",
-              "Body:",
-              body
-            ].join("\n");
-
-            const response = await fetch("https://api.anthropic.com/v1/messages", {
-              method: "POST",
-              headers: {
-                "content-type": "application/json",
-                "x-api-key": process.env.ANTHROPIC_API_KEY,
-                "anthropic-version": "2023-06-01"
-              },
-              body: JSON.stringify({
-                model: "claude-sonnet-4-20250514",
-                max_tokens: 200,
-                temperature: 0,
-                messages: [{ role: "user", content: prompt }]
-              })
-            });
-
-            if (!response.ok) {
-              const text = await response.text();
-              core.setFailed(`Anthropic classification failed: ${response.status} ${text}`);
-              return;
-            }
-
-            const data = await response.json();
-            const text = data?.content?.map((item) => item.text || "").join("").trim() || "";
+            const fs = require("fs");
+            const path = ".github/issue-triage-result.json";
+            const text = fs.readFileSync(path, "utf8").trim();
 
             let parsed;
             try {

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -3,6 +3,12 @@ name: Issue Triage
 on:
   issues:
     types: [opened, reopened, edited]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number to triage retrospectively"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -16,6 +22,36 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Load issue context for dispatch runs
+        if: github.event_name == 'workflow_dispatch'
+        id: issue-context
+        uses: actions/github-script@v8
+        env:
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
+        with:
+          script: |
+            const issue_number = Number(process.env.ISSUE_NUMBER);
+            if (!Number.isInteger(issue_number) || issue_number <= 0) {
+              core.setFailed(`Invalid issue_number: ${process.env.ISSUE_NUMBER}`);
+              return;
+            }
+
+            const { data: issue } = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+            });
+
+            if (issue.pull_request) {
+              core.setFailed(`Issue #${issue_number} is a pull request, not an issue.`);
+              return;
+            }
+
+            core.setOutput("issue_number", String(issue.number));
+            core.setOutput("issue_title", issue.title || "");
+            core.setOutput("issue_body", issue.body || "");
+            core.setOutput("issue_state", issue.state || "open");
+
       - name: Write triage schema
         run: |
           cat > /tmp/issue-triage-schema.json <<'EOF'
@@ -25,7 +61,7 @@ jobs:
             "properties": {
               "category": {
                 "type": "string",
-                "enum": ["docs", "py", "ts", "cli", "tool-request", "other"]
+                "enum": ["docs", "py", "ts", "cli", "tool-request", "feature-request", "other"]
               },
               "is_bug": {
                 "type": "boolean"
@@ -48,8 +84,8 @@ jobs:
         id: classify
         uses: anthropics/claude-code-action@v1
         env:
-          ISSUE_TITLE: ${{ github.event.issue.title }}
-          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_TITLE: ${{ github.event_name == 'workflow_dispatch' && steps.issue-context.outputs.issue_title || github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event_name == 'workflow_dispatch' && steps.issue-context.outputs.issue_body || github.event.issue.body }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
@@ -63,10 +99,12 @@ jobs:
             - ts
             - cli
             - tool-request
+            - feature-request
             - other
 
             Use semantic meaning, not only keywords.
             Choose tool-request when the issue is primarily asking for a new integration, toolkit, app, or tool.
+            Choose feature-request when the issue is asking for a product, SDK, docs, or CLI improvement that is not a tool request.
             Choose cli only when the issue is specifically about the CLI experience or ts/packages/cli.
             Choose py only when the issue is primarily about the Python SDK.
             Choose ts only when the issue is primarily about the TypeScript SDK or TS packages other than the CLI.
@@ -104,7 +142,7 @@ jobs:
               return;
             }
 
-            const allowed = new Set(["docs", "py", "ts", "cli", "tool-request", "other"]);
+            const allowed = new Set(["docs", "py", "ts", "cli", "tool-request", "feature-request", "other"]);
             if (!allowed.has(parsed.category)) {
               core.setFailed(`Unexpected category: ${parsed.category}`);
               return;
@@ -115,9 +153,14 @@ jobs:
             const reason = parsed.reason || "";
             const shouldComment = Boolean(parsed.should_comment);
             const commentBody = parsed.comment_body || "";
-            const issue_number = context.payload.issue.number;
+            const issue_number = context.eventName === "workflow_dispatch"
+              ? Number("${{ steps.issue-context.outputs.issue_number }}")
+              : context.payload.issue.number;
             const owner = context.repo.owner;
             const repo = context.repo.repo;
+            const issueState = context.eventName === "workflow_dispatch"
+              ? "${{ steps.issue-context.outputs.issue_state }}"
+              : context.payload.issue.state;
 
             const labels = [];
             const assignees = [];
@@ -138,6 +181,8 @@ jobs:
             } else if (category === "cli") {
               labels.push("cli");
               assignees.push("CryogenicPlanet");
+            } else if (category === "feature-request") {
+              labels.push("feature-request");
             } else if (category === "tool-request") {
               labels.push("tool-request");
             }
@@ -169,7 +214,7 @@ jobs:
               });
             }
 
-            if (category === "tool-request" && context.payload.issue.state === "open") {
+            if (category === "tool-request" && issueState === "open") {
               await github.rest.issues.createComment({
                 owner,
                 repo,

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,165 @@
+name: Issue Triage
+
+on:
+  issues:
+    types: [opened, reopened, edited]
+
+permissions:
+  issues: write
+
+jobs:
+  classify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Classify issue with Claude Sonnet
+        id: classify
+        uses: actions/github-script@v8
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+        with:
+          script: |
+            const title = process.env.ISSUE_TITLE || "";
+            const body = process.env.ISSUE_BODY || "";
+
+            const prompt = [
+              "Classify this GitHub issue into exactly one category.",
+              "",
+              "Allowed categories:",
+              "- docs",
+              "- py",
+              "- ts",
+              "- cli",
+              "- tool-request",
+              "- other",
+              "",
+              "Use semantic meaning, not only keywords.",
+              "Choose tool-request when the issue is primarily asking for a new integration, toolkit, app, or tool.",
+              "Choose cli only when the issue is specifically about the CLI experience or ts/packages/cli.",
+              "Choose py only when the issue is primarily about the Python SDK.",
+              "Choose ts only when the issue is primarily about the TypeScript SDK or TS packages other than the CLI.",
+              "Choose docs only when the issue is primarily about documentation.",
+              "",
+              "Return strict JSON with this schema only:",
+              '{"category":"docs|py|ts|cli|tool-request|other","reason":"short sentence"}',
+              "",
+              `Title: ${title}`,
+              "",
+              "Body:",
+              body
+            ].join("\n");
+
+            const response = await fetch("https://api.anthropic.com/v1/messages", {
+              method: "POST",
+              headers: {
+                "content-type": "application/json",
+                "x-api-key": process.env.ANTHROPIC_API_KEY,
+                "anthropic-version": "2023-06-01"
+              },
+              body: JSON.stringify({
+                model: "claude-sonnet-4-20250514",
+                max_tokens: 200,
+                temperature: 0,
+                messages: [{ role: "user", content: prompt }]
+              })
+            });
+
+            if (!response.ok) {
+              const text = await response.text();
+              core.setFailed(`Anthropic classification failed: ${response.status} ${text}`);
+              return;
+            }
+
+            const data = await response.json();
+            const text = data?.content?.map((item) => item.text || "").join("").trim() || "";
+
+            let parsed;
+            try {
+              parsed = JSON.parse(text);
+            } catch (error) {
+              core.setFailed(`Could not parse classifier output as JSON: ${text}`);
+              return;
+            }
+
+            const allowed = new Set(["docs", "py", "ts", "cli", "tool-request", "other"]);
+            if (!allowed.has(parsed.category)) {
+              core.setFailed(`Unexpected category: ${parsed.category}`);
+              return;
+            }
+
+            core.setOutput("category", parsed.category);
+            core.setOutput("reason", parsed.reason || "");
+
+      - name: Apply labels, assignees, and tool-request handling
+        uses: actions/github-script@v8
+        env:
+          CATEGORY: ${{ steps.classify.outputs.category }}
+          REASON: ${{ steps.classify.outputs.reason }}
+        with:
+          script: |
+            const category = process.env.CATEGORY;
+            const reason = process.env.REASON;
+            const issue_number = context.payload.issue.number;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const labels = [];
+            const assignees = [];
+
+            if (category === "docs") {
+              labels.push("docs");
+              assignees.push("shawnesquivel", "Sushmithamallesh");
+            } else if (category === "py") {
+              labels.push("py");
+              assignees.push("jkomyno");
+            } else if (category === "ts") {
+              labels.push("ts");
+              assignees.push("jkomyno");
+            } else if (category === "cli") {
+              labels.push("cli");
+              assignees.push("CryogenicPlanet");
+            } else if (category === "tool-request") {
+              labels.push("tool-request");
+            }
+
+            if (labels.length > 0) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number,
+                labels,
+              });
+            }
+
+            if (assignees.length > 0) {
+              await github.rest.issues.addAssignees({
+                owner,
+                repo,
+                issue_number,
+                assignees,
+              });
+            }
+
+            if (category === "tool-request" && context.payload.issue.state === "open") {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body: [
+                  "Hey, please ask for tool requests here https://request.composio.dev/boards/tool-requests",
+                  "",
+                  "I've tagged this as `tool-request` and I'm closing it here.",
+                  "",
+                  `Classifier note: ${reason}`
+                ].join("\n"),
+              });
+
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number,
+                state: "closed",
+              });
+            }

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -16,7 +16,36 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Write triage schema
+        run: |
+          cat > /tmp/issue-triage-schema.json <<'EOF'
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "category": {
+                "type": "string",
+                "enum": ["docs", "py", "ts", "cli", "tool-request", "other"]
+              },
+              "is_bug": {
+                "type": "boolean"
+              },
+              "reason": {
+                "type": "string"
+              },
+              "should_comment": {
+                "type": "boolean"
+              },
+              "comment_body": {
+                "type": "string"
+              }
+            },
+            "required": ["category", "is_bug", "reason", "should_comment", "comment_body"]
+          }
+          EOF
+
       - name: Classify issue with Claude Sonnet
+        id: classify
         uses: anthropics/claude-code-action@v1
         env:
           ISSUE_TITLE: ${{ github.event.issue.title }}
@@ -44,29 +73,34 @@ jobs:
             Choose docs only when the issue is primarily about documentation.
             Set is_bug to true when the issue is primarily reporting broken behavior, a defect, an error, a regression, or unexpected behavior.
             Set is_bug to false for feature requests, questions, maintenance, cleanup, and tool requests.
+            Set should_comment to true only when the issue appears incorrect, non-actionable, or missing the information needed to reproduce or investigate.
+            Set should_comment to false otherwise.
 
-            Write exactly one JSON object to `.github/issue-triage-result.json` with this schema:
-            {"category":"docs|py|ts|cli|tool-request|other","is_bug":true,"reason":"short sentence"}
+            If should_comment is true, provide comment_body as a short issue comment addressed to the reporter.
+            The comment must:
+            - clearly say it is an automated Claude triage note
+            - clearly say Claude cannot reply back in a conversation
+            - ask for the specific missing details needed to investigate, especially repro steps, expected behavior, actual behavior, environment, logs, or screenshots when relevant
+            - stay concise and professional
 
-            Do not modify any other files.
+            If should_comment is false, set comment_body to an empty string.
           claude_args: |
             --model claude-sonnet-4-6
-            --allowedTools "Read,Write,Edit"
+            --json-schema /tmp/issue-triage-schema.json
 
-      - name: Read triage result
-        id: classify
+      - name: Apply labels, assignees, and tool-request handling
         uses: actions/github-script@v8
+        env:
+          STRUCTURED_OUTPUT: ${{ steps.classify.outputs.structured_output }}
         with:
           script: |
-            const fs = require("fs");
-            const path = ".github/issue-triage-result.json";
-            const text = fs.readFileSync(path, "utf8").trim();
-
+            const text = process.env.STRUCTURED_OUTPUT || "";
             let parsed;
+
             try {
               parsed = JSON.parse(text);
             } catch (error) {
-              core.setFailed(`Could not parse classifier output as JSON: ${text}`);
+              core.setFailed(`Could not parse structured_output as JSON: ${text}`);
               return;
             }
 
@@ -76,21 +110,11 @@ jobs:
               return;
             }
 
-            core.setOutput("category", parsed.category);
-            core.setOutput("is_bug", parsed.is_bug ? "true" : "false");
-            core.setOutput("reason", parsed.reason || "");
-
-      - name: Apply labels, assignees, and tool-request handling
-        uses: actions/github-script@v8
-        env:
-          CATEGORY: ${{ steps.classify.outputs.category }}
-          IS_BUG: ${{ steps.classify.outputs.is_bug }}
-          REASON: ${{ steps.classify.outputs.reason }}
-        with:
-          script: |
-            const category = process.env.CATEGORY;
-            const isBug = process.env.IS_BUG === "true";
-            const reason = process.env.REASON;
+            const category = parsed.category;
+            const isBug = Boolean(parsed.is_bug);
+            const reason = parsed.reason || "";
+            const shouldComment = Boolean(parsed.should_comment);
+            const commentBody = parsed.comment_body || "";
             const issue_number = context.payload.issue.number;
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -133,6 +157,15 @@ jobs:
                 repo,
                 issue_number,
                 assignees,
+              });
+            }
+
+            if (category !== "tool-request" && shouldComment && commentBody.trim().length > 0) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body: commentBody.trim(),
               });
             }
 

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -25,7 +25,7 @@ jobs:
             const body = process.env.ISSUE_BODY || "";
 
             const prompt = [
-              "Classify this GitHub issue into exactly one category.",
+              "Classify this GitHub issue for routing and determine whether it is a bug report.",
               "",
               "Allowed categories:",
               "- docs",
@@ -41,9 +41,11 @@ jobs:
               "Choose py only when the issue is primarily about the Python SDK.",
               "Choose ts only when the issue is primarily about the TypeScript SDK or TS packages other than the CLI.",
               "Choose docs only when the issue is primarily about documentation.",
+              "Set is_bug to true when the issue is primarily reporting broken behavior, a defect, an error, a regression, or unexpected behavior.",
+              "Set is_bug to false for feature requests, questions, maintenance, cleanup, and tool requests.",
               "",
               "Return strict JSON with this schema only:",
-              '{"category":"docs|py|ts|cli|tool-request|other","reason":"short sentence"}',
+              '{"category":"docs|py|ts|cli|tool-request|other","is_bug":true,"reason":"short sentence"}',
               "",
               `Title: ${title}`,
               "",
@@ -90,16 +92,19 @@ jobs:
             }
 
             core.setOutput("category", parsed.category);
+            core.setOutput("is_bug", parsed.is_bug ? "true" : "false");
             core.setOutput("reason", parsed.reason || "");
 
       - name: Apply labels, assignees, and tool-request handling
         uses: actions/github-script@v8
         env:
           CATEGORY: ${{ steps.classify.outputs.category }}
+          IS_BUG: ${{ steps.classify.outputs.is_bug }}
           REASON: ${{ steps.classify.outputs.reason }}
         with:
           script: |
             const category = process.env.CATEGORY;
+            const isBug = process.env.IS_BUG === "true";
             const reason = process.env.REASON;
             const issue_number = context.payload.issue.number;
             const owner = context.repo.owner;
@@ -107,6 +112,10 @@ jobs:
 
             const labels = [];
             const assignees = [];
+
+            if (isBug) {
+              labels.push("bug");
+            }
 
             if (category === "docs") {
               labels.push("docs");

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,24 +20,24 @@ jobs:
           # General settings
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 60
-          days-before-close: 2
+          days-before-close: 0
           ascending: true
 
           # Issue settings
           stale-issue-label: "stale"
           exempt-issue-labels: "pinned,security,bug,needs-triage,roadmap,enhancement,good first issue"
           stale-issue-message: |
-            beep boop inactive for 60 days, closing in 48 hours
+            Closing due to 60 days of inactivity. Comment here if this still needs attention.
           close-issue-message: |
-            closed due to inactivity. feel free to reopen if the issue persists.
+            Closed due to inactivity. Reopen if this is still relevant.
 
           # Pull request settings
           stale-pr-label: "stale"
           exempt-pr-labels: "pinned,security,needs-review,work-in-progress,dependencies"
           stale-pr-message: |
-            beep boop inactive for 60 days, closing in 48 hours
+            Closing due to 60 days of inactivity. Comment here if this still needs attention.
           close-pr-message: |
-            closed due to inactivity. feel free to reopen if still relevant.
+            Closed due to inactivity. Reopen if this is still relevant.
 
           # Optional: Remove stale label when updated
           remove-stale-when-updated: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,24 +20,24 @@ jobs:
           # General settings
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 60
-          days-before-close: 0
+          days-before-close: 2
           ascending: true
 
           # Issue settings
           stale-issue-label: "stale"
           exempt-issue-labels: "pinned,security,bug,needs-triage,roadmap,enhancement,good first issue"
           stale-issue-message: |
-            Closing due to 60 days of inactivity. Comment here if this still needs attention.
+            beep boop inactive for 60 days, closing in 48 hours
           close-issue-message: |
-            Closed due to inactivity. Reopen if this is still relevant.
+            closed due to inactivity. feel free to reopen if the issue persists.
 
           # Pull request settings
           stale-pr-label: "stale"
           exempt-pr-labels: "pinned,security,needs-review,work-in-progress,dependencies"
           stale-pr-message: |
-            Closing due to 60 days of inactivity. Comment here if this still needs attention.
+            beep boop inactive for 60 days, closing in 48 hours
           close-pr-message: |
-            Closed due to inactivity. Reopen if this is still relevant.
+            closed due to inactivity. feel free to reopen if still relevant.
 
           # Optional: Remove stale label when updated
           remove-stale-when-updated: true


### PR DESCRIPTION
## Summary
- Add a new GitHub issue triage workflow that classifies incoming issues with Claude Sonnet into `docs`, `py`, `ts`, `cli`, `tool-request`, or `other`.
- Automatically applies labels and assignees for the matching area, and closes `tool-request` issues after posting a redirect comment.
- Update `CODEOWNERS` to reflect current ownership for docs, TS, and Python.
- Tighten the stale workflow messaging and close issues immediately after the stale period.

## Testing
- Not run (workflow and config changes only).
- Verified the new workflow YAML is syntactically structured and uses strict JSON classification output.
- Reviewed the stale workflow diff to confirm the stale/close timing and message text changes.