### PR TITLE
feat(cli): add `composio connections list` command

### DIFF
--- a/ts/packages/cli/README.md
+++ b/ts/packages/cli/README.md
@@ -38,6 +38,7 @@ composio [--log-level all|trace|debug|info|warning|error|fatal|none]
 - `composio proxy <url> --toolkit <toolkit> [-X method] [-H header]... [-d data]`: Call a toolkit API directly through Composio using a connected account.
 - `composio tools list|info`: Inspect available tools and their cached schemas.
 - `composio triggers list <toolkit>|info`: Inspect toolkit-scoped trigger types and their schemas.
+- `composio connections list [--toolkit <toolkit>]`: Print toolkit connection statuses as JSON.
 - `composio artifacts cwd`: Print the cwd-scoped CLI session artifacts directory.
 - `composio dev <subcommand>`: Developer workflows for init, playground execution, logs, toolkits, auth configs, accounts, triggers, orgs, and projects.
 - `composio generate [-o, --output-dir <directory>] [--toolkits <toolkit>] [--type-tools]`: Auto-detect the project language (Python or TypeScript) and generate type stubs for toolkits, tools, and triggers.

--- a/ts/packages/cli/src/commands/connections/commands/connections.list.cmd.ts
+++ b/ts/packages/cli/src/commands/connections/commands/connections.list.cmd.ts
@@ -20,7 +20,7 @@ const formatConnectionsJson = (items: ReadonlyArray<ConnectedAccountItem>): stri
     items.map(item => ({
       toolkit: item.toolkit.slug,
       status: item.status,
-      ...(toolkitCounts.get(item.toolkit.slug)! > 1 && item.alias ? { alias: item.alias } : {}),
+      ...(toolkitCounts.get(item.toolkit.slug)! > 1 ? { alias: item.alias ?? null } : {}),
     })),
     null,
     2

--- a/ts/packages/cli/src/commands/connections/commands/connections.list.cmd.ts
+++ b/ts/packages/cli/src/commands/connections/commands/connections.list.cmd.ts
@@ -1,0 +1,55 @@
+import { Command, Options } from '@effect/cli';
+import { Effect, Option } from 'effect';
+import { requireAuth } from 'src/effects/require-auth';
+import type { ConnectedAccountItem } from 'src/models/connected-accounts';
+import { ComposioToolkitsRepository } from 'src/services/composio-clients';
+import { TerminalUI } from 'src/services/terminal-ui';
+
+const toolkit = Options.text('toolkit').pipe(
+  Options.withDescription('Filter by toolkit slug (e.g. "gmail")'),
+  Options.optional
+);
+
+const formatConnectionsJson = (items: ReadonlyArray<ConnectedAccountItem>): string => {
+  const toolkitCounts = items.reduce<Map<string, number>>((acc, item) => {
+    acc.set(item.toolkit.slug, (acc.get(item.toolkit.slug) ?? 0) + 1);
+    return acc;
+  }, new Map());
+
+  return JSON.stringify(
+    items.map(item => ({
+      toolkit: item.toolkit.slug,
+      status: item.status,
+      ...(toolkitCounts.get(item.toolkit.slug)! > 1 && item.alias ? { alias: item.alias } : {}),
+    })),
+    null,
+    2
+  );
+};
+
+export const connectionsCmd$List = Command.make(
+  'list',
+  { toolkit },
+  ({ toolkit }) =>
+    Effect.gen(function* () {
+      if (!(yield* requireAuth)) return;
+
+      const ui = yield* TerminalUI;
+      const repo = yield* ComposioToolkitsRepository;
+      const toolkitSlug = Option.getOrUndefined(toolkit);
+
+      const result = yield* ui.withSpinner(
+        'Fetching connections...',
+        repo.listConnectedAccounts({
+          toolkit_slugs: toolkitSlug ? [toolkitSlug] : undefined,
+          limit: 1000,
+        })
+      );
+
+      yield* ui.output(formatConnectionsJson(result.items));
+    })
+).pipe(
+  Command.withDescription(
+    'List connection statuses as JSON. Includes aliases when a toolkit has multiple connections.'
+  )
+);

--- a/ts/packages/cli/src/commands/connections/commands/connections.list.cmd.ts
+++ b/ts/packages/cli/src/commands/connections/commands/connections.list.cmd.ts
@@ -16,38 +16,44 @@ const formatConnectionsJson = (items: ReadonlyArray<ConnectedAccountItem>): stri
     return acc;
   }, new Map());
 
-  return JSON.stringify(
-    items.map(item => ({
-      toolkit: item.toolkit.slug,
-      status: item.status,
-      ...(toolkitCounts.get(item.toolkit.slug)! > 1 ? { alias: item.alias ?? null } : {}),
-    })),
-    null,
-    2
+  const grouped = items.reduce<Record<string, Array<{ status: string; alias?: string | null }>>>(
+    (acc, item) => {
+      const toolkit = item.toolkit.slug;
+      const entry = {
+        status: item.status,
+        ...(toolkitCounts.get(toolkit)! > 1 ? { alias: item.alias ?? null } : {}),
+      };
+
+      if (!acc[toolkit]) {
+        acc[toolkit] = [];
+      }
+      acc[toolkit].push(entry);
+      return acc;
+    },
+    {}
   );
+
+  return JSON.stringify(grouped, null, 2);
 };
 
-export const connectionsCmd$List = Command.make(
-  'list',
-  { toolkit },
-  ({ toolkit }) =>
-    Effect.gen(function* () {
-      if (!(yield* requireAuth)) return;
+export const connectionsCmd$List = Command.make('list', { toolkit }, ({ toolkit }) =>
+  Effect.gen(function* () {
+    if (!(yield* requireAuth)) return;
 
-      const ui = yield* TerminalUI;
-      const repo = yield* ComposioToolkitsRepository;
-      const toolkitSlug = Option.getOrUndefined(toolkit);
+    const ui = yield* TerminalUI;
+    const repo = yield* ComposioToolkitsRepository;
+    const toolkitSlug = Option.getOrUndefined(toolkit);
 
-      const result = yield* ui.withSpinner(
-        'Fetching connections...',
-        repo.listConnectedAccounts({
-          toolkit_slugs: toolkitSlug ? [toolkitSlug] : undefined,
-          limit: 1000,
-        })
-      );
+    const result = yield* ui.withSpinner(
+      'Fetching connections...',
+      repo.listConnectedAccounts({
+        toolkit_slugs: toolkitSlug ? [toolkitSlug] : undefined,
+        limit: 1000,
+      })
+    );
 
-      yield* ui.output(formatConnectionsJson(result.items));
-    })
+    yield* ui.output(formatConnectionsJson(result.items));
+  })
 ).pipe(
   Command.withDescription(
     'List connection statuses as JSON. Includes aliases when a toolkit has multiple connections.'

--- a/ts/packages/cli/src/commands/connections/connections.cmd.ts
+++ b/ts/packages/cli/src/commands/connections/connections.cmd.ts
@@ -1,0 +1,7 @@
+import { Command } from '@effect/cli';
+import { connectionsCmd$List } from './commands/connections.list.cmd';
+
+export const rootConnectionsCmd = Command.make('connections').pipe(
+  Command.withDescription('Inspect connected toolkit accounts in a script-friendly format.'),
+  Command.withSubcommands([connectionsCmd$List])
+);

--- a/ts/packages/cli/src/commands/index.ts
+++ b/ts/packages/cli/src/commands/index.ts
@@ -27,6 +27,7 @@ import { rootTriggersCmd } from './triggers/root-triggers.cmd';
 import { rootConnectedAccountsCmd$Link } from './connected-accounts/commands/connected-accounts.link.cmd';
 import { orgsCmd } from './orgs/orgs.cmd';
 import { configCmd } from './config/config.cmd';
+import { rootConnectionsCmd } from './connections/connections.cmd';
 import { renderCommandHintGraph } from 'src/services/command-hints';
 import { resetRuntimeDebugFlags, setRuntimeDebugFlags } from 'src/services/runtime-debug-flags';
 import { ComposioCliUserConfig } from 'src/services/cli-user-config';
@@ -64,6 +65,7 @@ const ROOT_COMMANDS: ReadonlyArray<TaggedValue<Command.Command<any, any, any, an
   tagged(rootToolsCmd$Search),
   tagged(rootConnectedAccountsCmd$Link),
   tagged(rootToolsCmd$Execute),
+  tagged(rootConnectionsCmd),
   tagged(generateCmd),
   tagged(orgsCmd),
   tagged(configCmd),

--- a/ts/packages/cli/src/commands/root-help.ts
+++ b/ts/packages/cli/src/commands/root-help.ts
@@ -144,12 +144,12 @@ const OTHER_COMMANDS: ReadonlyArray<TaggedValue<CompactCommand>> = [
     description: 'List available trigger types in a toolkit',
   }),
   tagged({
-    name: 'composio artifacts cwd',
-    description: 'Print the cwd-scoped session artifact directory',
-  }),
-  tagged({
     name: 'composio connections list',
     description: 'Print toolkit connection statuses as JSON',
+  }),
+  tagged({
+    name: 'composio artifacts cwd',
+    description: 'Print the cwd-scoped session artifact directory',
   }),
 ];
 

--- a/ts/packages/cli/src/commands/root-help.ts
+++ b/ts/packages/cli/src/commands/root-help.ts
@@ -147,6 +147,10 @@ const OTHER_COMMANDS: ReadonlyArray<TaggedValue<CompactCommand>> = [
     name: 'composio artifacts cwd',
     description: 'Print the cwd-scoped session artifact directory',
   }),
+  tagged({
+    name: 'composio connections list',
+    description: 'Print toolkit connection statuses as JSON',
+  }),
 ];
 
 const GENERATE_COMMAND: TaggedValue<CompactCommand> = tagged({
@@ -474,6 +478,17 @@ const SUBCOMMAND_HELP: Record<string, SubcommandHelp | TaggedValue<SubcommandHel
       'composio search "<query>"               Find tools to use after linking',
       "composio execute <slug> -d '{ ... }'    Execute a tool with your connected account",
       'composio config experimental             Manage experimental features',
+    ],
+  },
+  'connections list': {
+    usage: 'composio connections list [--toolkit <text>]',
+    description:
+      'Print connected toolkit statuses as JSON. Adds aliases when a toolkit has multiple connections.',
+    options: [{ name: '--toolkit <text>', description: 'Filter to a single toolkit slug' }],
+    examples: ['composio connections list', 'composio connections list --toolkit gmail'],
+    seeAlso: [
+      'composio link <toolkit>                 Connect a new account for a toolkit',
+      'composio dev connected-accounts list    Inspect the full connected-account table',
     ],
   },
   run: {

--- a/ts/packages/cli/test/src/commands/$default.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/$default.cmd.test.ts
@@ -71,6 +71,7 @@ describe('CLI: composio', () => {
         const output = lines.join('\n');
         expect(output).toContain('Usage:');
         expect(output).toContain('composio');
+        expect(output).toContain('composio connections list');
       })
     );
   });

--- a/ts/packages/cli/test/src/commands/connections/connections.list.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/connections/connections.list.cmd.test.ts
@@ -1,10 +1,22 @@
 import { describe, expect, layer } from '@effect/vitest';
 import { ConfigProvider, Effect } from 'effect';
-import { afterEach, vi } from 'vitest';
 import type { ConnectedAccountItem } from 'src/models/connected-accounts';
 import { extendConfigProvider } from 'src/services/config';
-import { cli, TestLive } from 'test/__utils__';
+import { cli, TestLive, MockConsole } from 'test/__utils__';
 import type { TestLiveInput } from 'test/__utils__/services/test-layer';
+
+const parseJsonFromLines = (lines: ReadonlyArray<string>) => {
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    const line = lines[i];
+    if (!line) continue;
+    try {
+      return JSON.parse(line) as Record<string, Array<Record<string, string>>>;
+    } catch {
+      // continue
+    }
+  }
+  throw new Error('Expected JSON output but none found');
+};
 
 const testConnections: ConnectedAccountItem[] = [
   {
@@ -75,21 +87,13 @@ const testConfigProvider = ConfigProvider.fromMap(
 ).pipe(extendConfigProvider);
 
 describe('CLI: composio connections list', () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   layer(TestLive({ baseConfigProvider: testConfigProvider, connectedAccountsData }))(it => {
     it.scoped('[Given] no filter [Then] prints connection JSON with aliases for duplicates', () =>
       Effect.gen(function* () {
-        const write = vi
-          .spyOn(process.stdout, 'write')
-          .mockImplementation((() => true) as typeof process.stdout.write);
-
         yield* cli(['connections', 'list']);
 
-        const output = write.mock.calls.map(call => String(call[0])).join('');
-        const parsed = JSON.parse(output) as Record<string, Array<Record<string, string>>>;
+        const lines = yield* MockConsole.getLines({ stripAnsi: true });
+        const parsed = parseJsonFromLines(lines);
 
         expect(parsed).toEqual({
           gmail: [{ status: 'ACTIVE' }],
@@ -105,14 +109,10 @@ describe('CLI: composio connections list', () => {
   layer(TestLive({ baseConfigProvider: testConfigProvider, connectedAccountsData }))(it => {
     it.scoped('[Given] --toolkit github [Then] filters the JSON output', () =>
       Effect.gen(function* () {
-        const write = vi
-          .spyOn(process.stdout, 'write')
-          .mockImplementation((() => true) as typeof process.stdout.write);
-
         yield* cli(['connections', 'list', '--toolkit', 'github']);
 
-        const output = write.mock.calls.map(call => String(call[0])).join('');
-        const parsed = JSON.parse(output) as Record<string, Array<Record<string, string>>>;
+        const lines = yield* MockConsole.getLines({ stripAnsi: true });
+        const parsed = parseJsonFromLines(lines);
 
         expect(parsed).toEqual({
           github: [

--- a/ts/packages/cli/test/src/commands/connections/connections.list.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/connections/connections.list.cmd.test.ts
@@ -89,13 +89,15 @@ describe('CLI: composio connections list', () => {
         yield* cli(['connections', 'list']);
 
         const output = write.mock.calls.map(call => String(call[0])).join('');
-        const parsed = JSON.parse(output) as Array<Record<string, string>>;
+        const parsed = JSON.parse(output) as Record<string, Array<Record<string, string>>>;
 
-        expect(parsed).toEqual([
-          { toolkit: 'gmail', status: 'ACTIVE' },
-          { toolkit: 'github', status: 'ACTIVE', alias: 'work' },
-          { toolkit: 'github', status: 'FAILED', alias: 'personal' },
-        ]);
+        expect(parsed).toEqual({
+          gmail: [{ status: 'ACTIVE' }],
+          github: [
+            { status: 'ACTIVE', alias: 'work' },
+            { status: 'FAILED', alias: 'personal' },
+          ],
+        });
       })
     );
   });
@@ -110,12 +112,14 @@ describe('CLI: composio connections list', () => {
         yield* cli(['connections', 'list', '--toolkit', 'github']);
 
         const output = write.mock.calls.map(call => String(call[0])).join('');
-        const parsed = JSON.parse(output) as Array<Record<string, string>>;
+        const parsed = JSON.parse(output) as Record<string, Array<Record<string, string>>>;
 
-        expect(parsed).toEqual([
-          { toolkit: 'github', status: 'ACTIVE', alias: 'work' },
-          { toolkit: 'github', status: 'FAILED', alias: 'personal' },
-        ]);
+        expect(parsed).toEqual({
+          github: [
+            { status: 'ACTIVE', alias: 'work' },
+            { status: 'FAILED', alias: 'personal' },
+          ],
+        });
       })
     );
   });

--- a/ts/packages/cli/test/src/commands/connections/connections.list.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/connections/connections.list.cmd.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, layer } from '@effect/vitest';
+import { ConfigProvider, Effect } from 'effect';
+import { afterEach, vi } from 'vitest';
+import type { ConnectedAccountItem } from 'src/models/connected-accounts';
+import { extendConfigProvider } from 'src/services/config';
+import { cli, TestLive } from 'test/__utils__';
+import type { TestLiveInput } from 'test/__utils__/services/test-layer';
+
+const testConnections: ConnectedAccountItem[] = [
+  {
+    id: 'con_gmail_active',
+    alias: null,
+    word_id: null,
+    status: 'ACTIVE',
+    status_reason: null,
+    is_disabled: false,
+    user_id: 'default',
+    toolkit: { slug: 'gmail' },
+    auth_config: {
+      id: 'ac_gmail_oauth',
+      auth_scheme: 'OAUTH2',
+      is_composio_managed: true,
+      is_disabled: false,
+    },
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-15T00:00:00Z',
+    test_request_endpoint: '',
+  },
+  {
+    id: 'con_github_work',
+    alias: 'work',
+    word_id: null,
+    status: 'ACTIVE',
+    status_reason: null,
+    is_disabled: false,
+    user_id: 'default',
+    toolkit: { slug: 'github' },
+    auth_config: {
+      id: 'ac_github_oauth',
+      auth_scheme: 'OAUTH2',
+      is_composio_managed: true,
+      is_disabled: false,
+    },
+    created_at: '2026-02-01T00:00:00Z',
+    updated_at: '2026-02-10T00:00:00Z',
+    test_request_endpoint: '',
+  },
+  {
+    id: 'con_github_personal',
+    alias: 'personal',
+    word_id: null,
+    status: 'FAILED',
+    status_reason: 'Token expired',
+    is_disabled: false,
+    user_id: 'default',
+    toolkit: { slug: 'github' },
+    auth_config: {
+      id: 'ac_github_oauth_2',
+      auth_scheme: 'OAUTH2',
+      is_composio_managed: true,
+      is_disabled: false,
+    },
+    created_at: '2026-02-03T00:00:00Z',
+    updated_at: '2026-02-12T00:00:00Z',
+    test_request_endpoint: '',
+  },
+];
+
+const connectedAccountsData = {
+  items: testConnections,
+} satisfies TestLiveInput['connectedAccountsData'];
+
+const testConfigProvider = ConfigProvider.fromMap(
+  new Map([['COMPOSIO_USER_API_KEY', 'test_api_key']])
+).pipe(extendConfigProvider);
+
+describe('CLI: composio connections list', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  layer(TestLive({ baseConfigProvider: testConfigProvider, connectedAccountsData }))(it => {
+    it.scoped('[Given] no filter [Then] prints connection JSON with aliases for duplicates', () =>
+      Effect.gen(function* () {
+        const write = vi
+          .spyOn(process.stdout, 'write')
+          .mockImplementation((() => true) as typeof process.stdout.write);
+
+        yield* cli(['connections', 'list']);
+
+        const output = write.mock.calls.map(call => String(call[0])).join('');
+        const parsed = JSON.parse(output) as Array<Record<string, string>>;
+
+        expect(parsed).toEqual([
+          { toolkit: 'gmail', status: 'ACTIVE' },
+          { toolkit: 'github', status: 'ACTIVE', alias: 'work' },
+          { toolkit: 'github', status: 'FAILED', alias: 'personal' },
+        ]);
+      })
+    );
+  });
+
+  layer(TestLive({ baseConfigProvider: testConfigProvider, connectedAccountsData }))(it => {
+    it.scoped('[Given] --toolkit github [Then] filters the JSON output', () =>
+      Effect.gen(function* () {
+        const write = vi
+          .spyOn(process.stdout, 'write')
+          .mockImplementation((() => true) as typeof process.stdout.write);
+
+        yield* cli(['connections', 'list', '--toolkit', 'github']);
+
+        const output = write.mock.calls.map(call => String(call[0])).join('');
+        const parsed = JSON.parse(output) as Array<Record<string, string>>;
+
+        expect(parsed).toEqual([
+          { toolkit: 'github', status: 'ACTIVE', alias: 'work' },
+          { toolkit: 'github', status: 'FAILED', alias: 'personal' },
+        ]);
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `composio connections list` command that groups connected accounts by toolkit and displays aliases
- New command file at `ts/packages/cli/src/commands/connections/commands/connections.list.cmd.ts` with test coverage
- Registers the command under the `connections` group and in root help

## Stacked on
This PR is stacked on #3202 (`cli/keyring-migration`).

## Test plan
- [ ] `pnpm --filter @composio/cli test` (connections.list.cmd.test.ts)
- [ ] Manual: `composio connections list` with a logged-in account shows grouped toolkit output with aliases

🤖 Generated with [Claude Code](https://claude.com/claude-code)