### PR TITLE
fix: return Optional[Any] for null-only anyOf/oneOf schemas

### DIFF
--- a/python/composio/utils/schema_converter.py
+++ b/python/composio/utils/schema_converter.py
@@ -236,6 +236,9 @@ def _handle_toplevel_combiner(
         )
         # If result is a type (like a Union or Optional), return it directly
         # If result is a model class, return it
+        # Fix: library returns NoneType for null-only combiners; promote to Optional[Any]
+        if result is type(None):
+            return t.Optional[t.Any]  # type: ignore
         return result
     except (SchemaError, CombinerError):
         pass
@@ -270,7 +273,7 @@ def _build_union_from_options(options: t.List[t.Dict[str, t.Any]]) -> t.Type:
         pydantic_types.append(ptype)
 
     if len(pydantic_types) == 0:
-        return str  # Fallback
+        return t.Optional[t.Any] if has_null else str  # type: ignore
 
     if len(pydantic_types) == 1:
         base_type = pydantic_types[0]

--- a/python/tests/test_schema_parser.py
+++ b/python/tests/test_schema_parser.py
@@ -1120,9 +1120,7 @@ class TestNullOnlyCombiner:
     @pytest.mark.schema
     def test_anyof_false_and_null(self):
         """anyOf with false + null should return Optional[Any] after filtering."""
-        result = json_schema_to_pydantic_type(
-            {"anyOf": [False, {"type": "null"}]}
-        )
+        result = json_schema_to_pydantic_type({"anyOf": [False, {"type": "null"}]})
         assert result == t.Optional[t.Any]
 
     @pytest.mark.unit

--- a/python/tests/test_schema_parser.py
+++ b/python/tests/test_schema_parser.py
@@ -1099,6 +1099,49 @@ class TestBooleanSchemas:
         assert result.__origin__ is t.Union
 
 
+class TestNullOnlyCombiner:
+    """Regression tests for null-only anyOf/oneOf schemas (GH-3171)."""
+
+    @pytest.mark.unit
+    @pytest.mark.schema
+    def test_anyof_null_only(self):
+        """anyOf with only null branch should return Optional[Any]."""
+        result = json_schema_to_pydantic_type({"anyOf": [{"type": "null"}]})
+        assert result == t.Optional[t.Any]
+
+    @pytest.mark.unit
+    @pytest.mark.schema
+    def test_oneof_null_only(self):
+        """oneOf with only null branch should return Optional[Any]."""
+        result = json_schema_to_pydantic_type({"oneOf": [{"type": "null"}]})
+        assert result == t.Optional[t.Any]
+
+    @pytest.mark.unit
+    @pytest.mark.schema
+    def test_anyof_false_and_null(self):
+        """anyOf with false + null should return Optional[Any] after filtering."""
+        result = json_schema_to_pydantic_type(
+            {"anyOf": [False, {"type": "null"}]}
+        )
+        assert result == t.Optional[t.Any]
+
+    @pytest.mark.unit
+    @pytest.mark.schema
+    def test_direct_null_still_works(self):
+        """Direct null type should still return Optional[Any]."""
+        result = json_schema_to_pydantic_type({"type": "null"})
+        assert result == t.Optional[t.Any]
+
+    @pytest.mark.unit
+    @pytest.mark.schema
+    def test_anyof_string_and_null_not_affected(self):
+        """anyOf with string + null should still return Optional[str]."""
+        result = json_schema_to_pydantic_type(
+            {"anyOf": [{"type": "string"}, {"type": "null"}]}
+        )
+        assert result == t.Optional[str]
+
+
 class TestBooleanDefaultCoercion:
     """Regression tests for PLEN-1311 - Boolean default type mismatch in LangchainProvider."""
 


### PR DESCRIPTION
# Description
Fixes #3171. When an `anyOf`/`oneOf` combiner contains only null branches (e.g., `{"anyOf": [{"type": "null"}]}`), the schema converter incorrectly returned `NoneType` or `str` instead of `Optional[Any]`.

**Root cause — two code paths affected:**

1. **`_handle_toplevel_combiner`** (primary path): The `json-schema-to-pydantic` library successfully converts null-only combiners but returns `NoneType`. Added a post-check to promote `NoneType` to `Optional[Any]`.

2. **`_build_union_from_options`** (fallback path): When the library fails, this helper correctly detects `has_null=True` but returns `str` when no non-null types remain. Changed to return `Optional[Any]` when `has_null` is True.

Both paths now return `Optional[Any]`, consistent with direct `{"type": "null"}` handling.

# How did I test this PR
- Ran `pytest tests/test_schema_parser.py -v` — **70 tests passed** (including 5 new ones)
- Added `TestNullOnlyCombiner` test class covering:
  - `anyOf` with only null branch
  - `oneOf` with only null branch
  - `anyOf` with `false` + null (boolean schema filtering)
  - Direct null type (regression check)
  - `anyOf` with string + null (regression check)
- Manual verification of all bug reproduction cases from the issue

Triggered by: pranai@usefulagents.com | Source: slack
Session: https://zen-api-production-4c98.up.railway.app/dashboard/#/chat/zen-665d73af4a52