### PR TITLE
chore: CLI 0.2.23 patch release

### DIFF
--- a/.changeset/cli-0-2-23-patch.md
+++ b/.changeset/cli-0-2-23-patch.md
@@ -2,6 +2,7 @@
 "@composio/cli": patch
 ---
 
+feat: add `simple`, `default`, and `verbose` help verbosity modes to root and subcommand help (`--help simple|verbose`); compact simple mode and richer verbose mode with additional commands (#3205)
 feat: add `composio connections list` command that groups connected accounts by toolkit and displays aliases (#3206)
 feat: migrate API key storage from plaintext `~/.composio/user_data.json` to OS keyring (macOS Keychain / Linux Secret Service); env var > keyring > legacy plaintext precedence with one-shot migration and `dangerouslySaveApiKeyInUserConfig` opt-out for headless environments (#3202)
 feat: turn `composio dev` into a real developer-mode toggle backed by CLI user config; gate the `init`, `tools execute`, `triggers listen`, `logs`, `toolkits`, `auth-configs`, `connected-accounts`, `triggers`, and `projects` subcommand tree behind the toggle, and remove deprecated destructive `delete`/`info` commands now covered by the dev-mode gate (#3181)

--- a/.changeset/cli-0-2-23-patch.md
+++ b/.changeset/cli-0-2-23-patch.md
@@ -1,0 +1,8 @@
+---
+"@composio/cli": patch
+---
+
+feat: add `composio connections list` command that groups connected accounts by toolkit and displays aliases (#3206)
+feat: migrate API key storage from plaintext `~/.composio/user_data.json` to OS keyring (macOS Keychain / Linux Secret Service); env var > keyring > legacy plaintext precedence with one-shot migration and `dangerouslySaveApiKeyInUserConfig` opt-out for headless environments (#3202)
+feat: turn `composio dev` into a real developer-mode toggle backed by CLI user config; gate the `init`, `tools execute`, `triggers listen`, `logs`, `toolkits`, `auth-configs`, `connected-accounts`, `triggers`, and `projects` subcommand tree behind the toggle, and remove deprecated destructive `delete`/`info` commands now covered by the dev-mode gate (#3181)
+feat: enable `multi_account` experimental feature by default for stable CLI builds and centralize default experimental-feature behavior so runtime config and skill reference schema stay in sync (#3163)


### PR DESCRIPTION
## Changes

Patch release bundling five CLI changes merged since 0.2.22:

### Features
- **Help verbosity modes** (#3205) — `--help simple|default|verbose` on root and subcommands; compact simple mode and richer verbose mode with additional commands
- **`composio connections list`** (#3206) — new command grouping connected accounts by toolkit with aliases
- **OS keyring API key storage** (#3202) — migrate plaintext `~/.composio/user_data.json` API keys to macOS Keychain / Linux Secret Service; one-shot migration on first run; `dangerouslySaveApiKeyInUserConfig` opt-out for headless/CI environments
- **`composio dev` mode toggle** (#3181) — `--mode on|off` switch backed by CLI user config; gates `init`, `tools execute`, `triggers listen`, `logs`, `toolkits`, `auth-configs`, `connected-accounts`, `triggers`, `projects` subcommands; removes deprecated destructive `delete`/`info` commands now covered by the gate
- **Multi-account by default on stable** (#3163) — `multi_account` experimental feature enabled by default for stable CLI builds; centralized default-feature wiring so runtime config and skill reference schema stay in sync

## Changeset

- Bump: `@composio/cli` patch (0.2.22 → 0.2.23)
- File: `.changeset/cli-0-2-23-patch.md`

## Testing

✅ Full CLI test pipeline passed

### Phase 1: CI Types/Lint
- Status: ✅ Passed on `next` HEAD prior to branching
- All TypeScript SDK CI workflows green for `20cfa6cda` and `9a6f1a0ab`

### Phase 2: Local Binary Test (built from `635205a`)
| Check | Result |
|---|---|
| `composio version` (`0.2.22`) | ✅ |
| `composio whoami` | ✅ |
| `composio --help` | ✅ |
| `composio --help simple` (new) | ✅ renders compact mode |
| `composio connections list` (new) | ✅ groups by toolkit (github, gmail, linear, googlesheets, posthog, datadog, notion, plain, intercom, googlecalendar, figma, metabase, slack, googledrive) |
| `composio dev --help` | ✅ shows new `--mode on\|off` option |
| `composio run 'console.log(...)'` | ✅ |
| `experimental_subAgent` (Slack) | ✅ posted summary to `#buzz-skill-based-cli-testing` |

### Phase 3: Bundled Binary Test (`@composio/cli@0.2.23-beta.208`)
- Build: [run 24395735335](https://github.com/ComposioHQ/composio/actions/runs/24395735335) — all 31 jobs green (4 platform builds + install/script tests on macOS 14/15, Ubuntu 22.04/24.04, ARM64/x64, bash/zsh, npm fallback on Node 18/20/22)
- Binary: darwin-aarch64

| Check | Result |
|---|---|
| `composio version` | ✅ `0.2.22` |
| `composio whoami` | ✅ |
| `composio --help` / `--help simple` | ✅ both modes render |
| `composio connections list` (new) | ✅ |
| `composio dev --help` | ✅ shows `--mode` option |
| `composio run 'console.log(...)'` | ✅ |
| `experimental_subAgent("What is 2+2?")` | ✅ returned `"4"` |
| Slack: `SLACK_FIND_CHANNELS` + `SLACK_SEND_MESSAGE` + `SLACK_FETCH_CONVERSATION_HISTORY` + `experimental_subAgent` with `z.object` schema | ✅ posted summary to `#buzz-skill-based-cli-testing` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)