### PR TITLE
fix(ci): deepen CLI release-detection checkout so stable bumps are seen

### DIFF
--- a/.github/workflows/build-cli-binaries.yml
+++ b/.github/workflows/build-cli-binaries.yml
@@ -38,6 +38,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.sha }}
+          # Need HEAD^ to detect package.json version bumps for stable releases.
+          fetch-depth: 2
 
       - name: Resolve release target
         id: resolve


### PR DESCRIPTION
## Summary

The `Resolve Release Metadata` job in `build-cli-binaries.yml` decides stable vs beta by comparing `ts/packages/cli/package.json` against `HEAD^`:

```bash
current_version=$(node -p "require('./ts/packages/cli/package.json').version")
previous_version=$(git show HEAD^:ts/packages/cli/package.json 2>/dev/null | ... || echo "")

if [[ -n "\$previous_version" && "\$current_version" != "\$previous_version" ]]; then
  # stable
fi
# else → beta
```

But the checkout was using the default `fetch-depth: 1` (shallow). On a depth-1 clone, `HEAD^` doesn't exist, so `git show HEAD^:...` failed (swallowed by `2>/dev/null`), `previous_version` was empty, the condition silently fell through, and a genuine stable bump got classified as a beta.

## What broke

The `@composio/cli@0.2.23` release (merge of #3211) was misrouted this way. Binaries built from `ece9f7bb` were attached to `@composio/cli@0.2.24-beta.209` instead of the stable `0.2.23` tag, and the stable release (created separately by the changesets action) shipped empty. Recovered separately via `promote-stable`.

## Fix

Set `fetch-depth: 2` on the prepare job's checkout so `HEAD^` is available. Only 2 commits are needed — no need for a full history.

## Test plan

- [ ] Next stable release merge (changesets version PR → `next`) lands binaries on the stable tag, not on a `-beta.<N>` tag.
- [ ] Beta builds (pushes to `next` that touch CLI without a version bump) still tag as `@composio/cli@<bumped>-beta.<run>` as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)