### PR TITLE
chore(cli): bump @composio/cli to 0.2.24 to realign with GitHub release

### DIFF
--- a/ts/packages/cli/CHANGELOG.md
+++ b/ts/packages/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @composio/cli
 
+## 0.2.24
+
+Manual version bump to realign with the GitHub release tag. The 0.2.23 release workflow misclassified the version-bump merge as a beta due to a shallow-checkout bug in `.github/workflows/build-cli-binaries.yml`, so binaries built from that commit landed on `@composio/cli@0.2.24-beta.209` and, after `promote-stable`, on the GitHub tag `@composio/cli@0.2.24`. npm was left at 0.2.23. This release bumps npm to 0.2.24 so the published package and the GitHub release match. Fix for the underlying workflow bug: #3212.
+
 ## 0.2.23
 
 ### Patch Changes

--- a/ts/packages/cli/package.json
+++ b/ts/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/cli",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "description": "Composio CLI",
   "main": "./dist/bin.mjs",
   "private": true,


### PR DESCRIPTION
## Summary

Manual version bump from 0.2.23 → 0.2.24 to realign npm with the GitHub release tag. No changeset on purpose — this is a recovery bump, not a feature/fix release.

## Background

The 0.2.23 release workflow misclassified the changeset version-bump merge (`ece9f7bb`) as a beta because `Resolve Release Metadata` in `build-cli-binaries.yml` did `git show HEAD^:...` on a depth-1 shallow clone. `previous_version` came back empty, the stable-detection branch silently fell through, and binaries built from `ece9f7bb` landed on `@composio/cli@0.2.24-beta.209`. Running `promote-stable` then created GitHub release `@composio/cli@0.2.24` (since `promote-stable` extracts the stable version from the beta tag).

Result: npm has `0.2.23` (from changesets), GitHub has `0.2.24` (from promote-stable), both built from the same commit. This PR bumps npm to `0.2.24` so they line up.

- Recovery: GitHub release `@composio/cli@0.2.23` has been manually created with assets mirrored from `@composio/cli@0.2.24` (same commit, so the binaries are byte-identical).
- Workflow fix: #3212 (set `fetch-depth: 2` on the prepare checkout).

## Changes

- `ts/packages/cli/package.json`: `0.2.23` → `0.2.24`
- `ts/packages/cli/CHANGELOG.md`: documents the manual bump

## Follow-up

After merge, publish `@composio/cli@0.2.24` to npm manually (no changeset → no automatic publish). Future stable releases should route normally through the changeset flow once #3212 is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)