### PR TITLE
fix(cli): install fish completions in the fish completions directory

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,7 +18,8 @@ curl -fsSL https://raw.githubusercontent.com/ComposioHQ/composio/main/install.sh
 - Detects your platform and architecture automatically
 - Downloads the appropriate binary from GitHub releases
 - Installs to `~/.composio/bin/composio`
-- Updates your shell configuration (.bashrc, .zshrc, or .config/fish/config.fish)
+- Updates your shell configuration (.bashrc, .zshrc, or `.config/fish/config.fish`)
+- Installs fish completions in `~/.config/fish/completions/composio.fish` when `--completions` is enabled
 - Adds the binary to your PATH
 
 ## Manual Installation
@@ -130,7 +131,7 @@ If `composio` is not found after installation:
    source ~/.zshrc
    
    # For fish
-   source ~/.config/fish/config.fish
+   exec fish
    ```
 
 3. **Check if the binary exists:**
@@ -174,7 +175,8 @@ rm -rf ~/.composio
 
 # Remove from shell configuration
 # Edit ~/.bashrc, ~/.zshrc, or ~/.config/fish/config.fish
-# and remove the lines that were added by the installer:
+# and, for fish completions, ~/.config/fish/completions/composio.fish
+# then remove the lines that were added by the installer:
 # export COMPOSIO_INSTALL="$HOME/.composio"
 # export PATH="$COMPOSIO_INSTALL/bin:$PATH"
 ```

--- a/ts/packages/cli/src/commands/install.cmd.ts
+++ b/ts/packages/cli/src/commands/install.cmd.ts
@@ -32,6 +32,7 @@ type Shell = 'bash' | 'zsh' | 'fish';
 interface ShellConfig {
   readonly shell: Shell;
   readonly rcFile: string;
+  readonly completionFile: string;
   readonly pathBlock: string;
   readonly completionBlock: string | undefined;
 }
@@ -104,6 +105,11 @@ const pathBlockForShell = (shell: Shell, installDir: string): string => {
   }
 };
 
+const completionFileForShell = (shell: Shell, rcFile: string): string =>
+  shell === 'fish'
+    ? path.join(path.dirname(rcFile), 'completions', 'composio.fish')
+    : rcFile;
+
 const buildShellConfig = (
   shell: Shell,
   rcFile: string,
@@ -112,6 +118,7 @@ const buildShellConfig = (
 ): ShellConfig => ({
   shell,
   rcFile,
+  completionFile: completionFileForShell(shell, rcFile),
   pathBlock: pathBlockForShell(shell, installDir),
   completionBlock: completionScript ? `${COMPLETIONS_MARKER}\n${completionScript}` : undefined,
 });
@@ -122,6 +129,16 @@ const fileContains = (contents: string, marker: string): boolean =>
 
 const tildify = (p: string, homedir: string): string =>
   p.startsWith(homedir + '/') ? `~/${p.slice(homedir.length + 1)}` : p;
+
+const readOrEmpty = (
+  targetPath: string,
+  fs: FileSystem.FileSystem
+): Effect.Effect<string, never> =>
+  fs.readFileString(targetPath).pipe(
+    Effect.catchAll(e =>
+      Effect.logDebug('Managed shell file does not exist yet, will create:', e).pipe(Effect.as(''))
+    )
+  );
 
 // ---------------------------------------------------------------------------
 // Exported logic (reusable from install.sh post-install delegation)
@@ -189,21 +206,17 @@ export const installShellIntegration = (params: {
     const rcFile = yield* resolveRcFile(rcFileCandidates(shell, os.homedir), fs);
     const config = buildShellConfig(shell, rcFile, installDir, completionScript);
 
-    // Read existing rc file (or empty if it doesn't exist yet)
     const rcPath = config.rcFile;
-    const existing = yield* fs
-      .readFileString(rcPath)
-      .pipe(
-        Effect.catchAll(e =>
-          Effect.logDebug('RC file does not exist yet, will create:', e).pipe(Effect.as(''))
-        )
-      );
+    const completionPath = config.completionFile;
+    const existingRc = yield* readOrEmpty(rcPath, fs);
+    const existingCompletions =
+      completionPath === rcPath ? existingRc : yield* readOrEmpty(completionPath, fs);
 
-    // Build blocks to append (idempotently)
-    const blocks: string[] = [];
+    const rcBlocks: string[] = [];
+    const completionBlocks: string[] = [];
 
-    if (!fileContains(existing, MARKER)) {
-      blocks.push(config.pathBlock);
+    if (!fileContains(existingRc, MARKER)) {
+      rcBlocks.push(config.pathBlock);
       yield* ui.log.step(`PATH: will add ${tildify(installDir, os.homedir)} to $PATH`);
     } else {
       yield* ui.log.step('PATH: already configured');
@@ -213,38 +226,56 @@ export const installShellIntegration = (params: {
       yield* ui.log.step('Completions: skipped for zsh');
     } else if (!params.completions) {
       yield* ui.log.step('Completions: skipped by default (pass --completions to enable)');
-    } else if (config.completionBlock && !fileContains(existing, COMPLETIONS_MARKER)) {
-      blocks.push(config.completionBlock);
-      yield* ui.log.step('Completions: will install shell completions');
+    } else if (config.completionBlock && !fileContains(existingCompletions, COMPLETIONS_MARKER)) {
+      completionBlocks.push(config.completionBlock);
+      const targetLabel =
+        shell === 'fish'
+          ? ` at ${tildify(completionPath, os.homedir)}`
+          : '';
+      yield* ui.log.step(`Completions: will install shell completions${targetLabel}`);
     } else if (!config.completionBlock) {
       yield* ui.log.step('Completions: not available for this shell');
     } else {
       yield* ui.log.step('Completions: already configured');
     }
 
-    if (blocks.length > 0) {
-      // Ensure parent directory exists (for fish config)
-      yield* fs
-        .makeDirectory(path.dirname(rcPath), { recursive: true })
-        .pipe(
-          Effect.catchAll(e =>
-            Effect.logDebug('Could not create parent directory (may already exist):', e)
-          )
-        );
+    const writes = [
+      { targetPath: rcPath, existing: existingRc, blocks: rcBlocks },
+      ...(completionPath === rcPath
+        ? []
+        : [{ targetPath: completionPath, existing: existingCompletions, blocks: completionBlocks }]),
+    ];
 
-      const appendContent = '\n' + blocks.join('\n\n') + '\n';
+    if (completionPath === rcPath && completionBlocks.length > 0) {
+      writes[0]!.blocks.push(...completionBlocks);
+    }
 
-      // Atomic write: write to a temp file then rename, so a crash mid-write
-      // cannot leave the user's rc file truncated/corrupted.
-      const tmpPath = `${rcPath}.composio-tmp`;
-      yield* fs.writeFileString(tmpPath, existing + appendContent);
-      yield* fs.rename(tmpPath, rcPath);
+    const pendingWrites = writes.filter(write => write.blocks.length > 0);
 
-      yield* ui.log.success(`Updated ${tildify(rcPath, os.homedir)}`);
+    if (pendingWrites.length > 0) {
+      for (const write of pendingWrites) {
+        yield* fs
+          .makeDirectory(path.dirname(write.targetPath), { recursive: true })
+          .pipe(
+            Effect.catchAll(e =>
+              Effect.logDebug('Could not create parent directory (may already exist):', e)
+            )
+          );
+
+        const appendContent = '\n' + write.blocks.join('\n\n') + '\n';
+        const tmpPath = `${write.targetPath}.composio-tmp`;
+        yield* fs.writeFileString(tmpPath, write.existing + appendContent);
+        yield* fs.rename(tmpPath, write.targetPath);
+
+        yield* ui.log.success(`Updated ${tildify(write.targetPath, os.homedir)}`);
+      }
+
       yield* ui.note(
-        shell === 'fish' || shell === 'zsh'
-          ? `source ${tildify(rcPath, os.homedir)}`
-          : 'exec $SHELL',
+        shell === 'fish'
+          ? 'exec fish'
+          : shell === 'zsh'
+            ? `source ${tildify(rcPath, os.homedir)}`
+            : 'exec $SHELL',
         'Restart your shell to apply changes'
       );
     } else {

--- a/ts/packages/cli/src/commands/install.cmd.ts
+++ b/ts/packages/cli/src/commands/install.cmd.ts
@@ -133,11 +133,12 @@ const tildify = (p: string, homedir: string): string =>
 const readOrEmpty = (
   targetPath: string,
   fs: FileSystem.FileSystem
-): Effect.Effect<string, never> =>
-  fs.readFileString(targetPath).pipe(
-    Effect.catchAll(e =>
-      Effect.logDebug('Managed shell file does not exist yet, will create:', e).pipe(Effect.as(''))
-    )
+): Effect.Effect<string, PlatformError> =>
+  Effect.catchIf(
+    fs.readFileString(targetPath),
+    (error): error is PlatformError =>
+      error._tag === 'SystemError' && error.reason === 'NotFound',
+    error => Effect.logDebug('Managed shell file does not exist yet, will create:', error).pipe(Effect.as(''))
   );
 
 // ---------------------------------------------------------------------------
@@ -211,6 +212,9 @@ export const installShellIntegration = (params: {
     const existingRc = yield* readOrEmpty(rcPath, fs);
     const existingCompletions =
       completionPath === rcPath ? existingRc : yield* readOrEmpty(completionPath, fs);
+    const hasExistingCompletions =
+      fileContains(existingCompletions, COMPLETIONS_MARKER) ||
+      (completionPath !== rcPath && fileContains(existingRc, COMPLETIONS_MARKER));
 
     const rcBlocks: string[] = [];
     const completionBlocks: string[] = [];
@@ -226,7 +230,7 @@ export const installShellIntegration = (params: {
       yield* ui.log.step('Completions: skipped for zsh');
     } else if (!params.completions) {
       yield* ui.log.step('Completions: skipped by default (pass --completions to enable)');
-    } else if (config.completionBlock && !fileContains(existingCompletions, COMPLETIONS_MARKER)) {
+    } else if (config.completionBlock && !hasExistingCompletions) {
       completionBlocks.push(config.completionBlock);
       const targetLabel =
         shell === 'fish'

--- a/ts/packages/cli/src/effects/shell-completions.ts
+++ b/ts/packages/cli/src/effects/shell-completions.ts
@@ -3,6 +3,28 @@ import { Effect } from 'effect';
 
 type Shell = 'bash' | 'zsh' | 'fish';
 
+const sanitizeFishDescription = (description: string): string =>
+  description
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"');
+
+const sanitizeFishCompletionLine = (line: string): string => {
+  const normalized = line.replace(/\s*\n\s*/g, ' ');
+  const descriptionMarker = " -d '";
+  const descriptionIndex = normalized.indexOf(descriptionMarker);
+
+  if (descriptionIndex === -1 || !normalized.endsWith("'")) {
+    return normalized;
+  }
+
+  const prefix = normalized.slice(0, descriptionIndex);
+  const description = normalized.slice(descriptionIndex + descriptionMarker.length, -1);
+
+  return `${prefix} -d "${sanitizeFishDescription(description)}"`;
+};
+
 /**
  * Generate a shell completion script for the given command tree and shell type.
  * Uses @effect/cli's built-in completion generators.
@@ -17,6 +39,8 @@ export const getCompletionScript = <Name extends string, R, E, A>(
     case 'zsh':
       return Command.getZshCompletions(command, 'composio');
     case 'fish':
-      return Command.getFishCompletions(command, 'composio');
+      return Command.getFishCompletions(command, 'composio').pipe(
+        Effect.map(lines => lines.map(sanitizeFishCompletionLine))
+      );
   }
 };

--- a/ts/packages/cli/src/effects/shell-completions.ts
+++ b/ts/packages/cli/src/effects/shell-completions.ts
@@ -8,7 +8,10 @@ const sanitizeFishDescription = (description: string): string =>
     .replace(/\s+/g, ' ')
     .trim()
     .replace(/\\/g, '\\\\')
-    .replace(/"/g, '\\"');
+    .replace(/"/g, '\\"')
+    .replace(/\$/g, '\\$')
+    .replace(/\(/g, '\\(')
+    .replace(/\)/g, '\\)');
 
 const sanitizeFishCompletionLine = (line: string): string => {
   const normalized = line.replace(/\s*\n\s*/g, ' ');

--- a/ts/packages/cli/test/src/commands/install.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/install.cmd.test.ts
@@ -106,6 +106,46 @@ describe('CLI: composio install', () => {
     });
   });
 
+  describe('[When] shell is fish and --completions is passed', () => {
+    layer(TestLive())(it => {
+      it.scoped('[Then] keeps PATH in config.fish and writes completions to composio.fish', () =>
+        Effect.gen(function* () {
+          const os = yield* NodeOs;
+          process.env.SHELL = '/usr/bin/fish';
+          process.env.COMPOSIO_INSTALL_DIR = path.join(os.homedir, '.composio');
+
+          yield* cli(['install', '--completions']);
+
+          const fs = yield* FileSystem.FileSystem;
+          const rcPath = path.join(os.homedir, '.config', 'fish', 'config.fish');
+          const completionsPath = path.join(
+            os.homedir,
+            '.config',
+            'fish',
+            'completions',
+            'composio.fish'
+          );
+          const rcContents = yield* fs.readFileString(rcPath);
+          const completionContents = yield* fs.readFileString(completionsPath);
+
+          expect(rcContents).toContain('# Composio CLI');
+          expect(rcContents).toContain('set --export COMPOSIO_INSTALL_DIR');
+          expect(rcContents).not.toContain('# Composio CLI completions');
+
+          expect(completionContents).toContain('# Composio CLI completions');
+          expect(completionContents).toContain('complete -c composio');
+
+          const lines = yield* MockConsole.getLines();
+          const output = lines.join('\n');
+          expect(output).toContain('Completions: will install shell completions at ~/.config/fish/completions/composio.fish');
+          expect(output).toContain('Updated ~/.config/fish/config.fish');
+          expect(output).toContain('Updated ~/.config/fish/completions/composio.fish');
+          expect(output).toContain('exec fish');
+        })
+      );
+    });
+  });
+
   describe('[When] --completions is passed', () => {
     layer(TestLive())(it => {
       it.scoped('[Then] writes PATH block and installs completions', () =>

--- a/ts/packages/cli/test/src/commands/install.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/install.cmd.test.ts
@@ -146,6 +146,47 @@ describe('CLI: composio install', () => {
     });
   });
 
+  describe('[When] fish already has legacy completions in config.fish', () => {
+    layer(TestLive())(it => {
+      it.scoped('[Then] does not duplicate completions into composio.fish', () =>
+        Effect.gen(function* () {
+          const os = yield* NodeOs;
+          const fs = yield* FileSystem.FileSystem;
+          process.env.SHELL = '/usr/bin/fish';
+          process.env.COMPOSIO_INSTALL_DIR = path.join(os.homedir, '.composio');
+
+          const rcPath = path.join(os.homedir, '.config', 'fish', 'config.fish');
+          const completionsPath = path.join(
+            os.homedir,
+            '.config',
+            'fish',
+            'completions',
+            'composio.fish'
+          );
+
+          yield* fs.writeFileString(
+            rcPath,
+            '# existing config\n# Composio CLI\nset --export COMPOSIO_INSTALL_DIR /old\n# Composio CLI completions\ncomplete -c composio -f\n'
+          );
+
+          yield* cli(['install', '--completions']);
+
+          const rcContents = yield* fs.readFileString(rcPath);
+          expect(rcContents.match(/^# Composio CLI completions$/gm)?.length ?? 0).toBe(1);
+
+          const completionsExists = yield* fs.exists(completionsPath);
+          expect(completionsExists).toBe(false);
+
+          const lines = yield* MockConsole.getLines();
+          const output = lines.join('\n');
+          expect(output).toContain('PATH: already configured');
+          expect(output).toContain('Completions: already configured');
+          expect(output).toContain('Shell integration already configured');
+        })
+      );
+    });
+  });
+
   describe('[When] --completions is passed', () => {
     layer(TestLive())(it => {
       it.scoped('[Then] writes PATH block and installs completions', () =>

--- a/ts/packages/cli/test/src/effects/shell-completions.test.ts
+++ b/ts/packages/cli/test/src/effects/shell-completions.test.ts
@@ -6,7 +6,7 @@ import { getCompletionScript } from 'src/effects/shell-completions';
 describe('shell-completions', () => {
   it('sanitizes fish completion descriptions with quotes and newlines', async () => {
     const query = Options.text('query').pipe(
-      Options.withDescription("User's query\nCan span multiple lines")
+      Options.withDescription('User says "$HOME"\nCan run (date)')
     );
 
     const command = Command.make('demo', { query }, () => Effect.void).pipe(
@@ -17,6 +17,6 @@ describe('shell-completions', () => {
     const joined = lines.join('\n');
 
     expect(lines.every(line => !line.includes('\n'))).toBe(true);
-    expect(joined).toContain(`-d "User's query Can span multiple lines"`);
+    expect(joined).toContain(`-d "User says \\\"\\$HOME\\\" Can run \\(date\\)"`);
   });
 });

--- a/ts/packages/cli/test/src/effects/shell-completions.test.ts
+++ b/ts/packages/cli/test/src/effects/shell-completions.test.ts
@@ -1,0 +1,22 @@
+import { Command, Options } from '@effect/cli';
+import { describe, expect, it } from 'vitest';
+import { Effect } from 'effect';
+import { getCompletionScript } from 'src/effects/shell-completions';
+
+describe('shell-completions', () => {
+  it('sanitizes fish completion descriptions with quotes and newlines', async () => {
+    const query = Options.text('query').pipe(
+      Options.withDescription("User's query\nCan span multiple lines")
+    );
+
+    const command = Command.make('demo', { query }, () => Effect.void).pipe(
+      Command.withDescription("Demo command's help\nwith multiple lines")
+    );
+
+    const lines = await Effect.runPromise(getCompletionScript(command, 'fish'));
+    const joined = lines.join('\n');
+
+    expect(lines.every(line => !line.includes('\n'))).toBe(true);
+    expect(joined).toContain(`-d "User's query Can span multiple lines"`);
+  });
+});


### PR DESCRIPTION
## Summary
This fixes `composio install --completions` for fish by keeping PATH setup in `~/.config/fish/config.fish` and writing completions to `~/.config/fish/completions/composio.fish`. It also normalizes fish completion descriptions so embedded newlines and quotes do not generate broken completion lines.

I updated the install tests for the fish-specific path split and added a focused completion sanitization test, then refreshed the install guide to match the new behavior.

## Validation
- `pnpm exec vitest run test/src/effects/shell-completions.test.ts`
- `git diff --check`

I also attempted to run the existing install command test file locally, but it is currently blocked in this checkout by a pre-existing package resolution issue around `@composio/cli-keyring`.

Made with [Cursor](https://cursor.com)