### PR TITLE
Feature: Resume sessions with custom toolkits via composio.use()

### DIFF
--- a/ts/packages/core/src/composio.ts
+++ b/ts/packages/core/src/composio.ts
@@ -18,7 +18,11 @@ import { Files } from '#files';
 import { getDefaultHeaders } from './utils/session';
 import { ToolkitVersionParam } from './types/tool.types';
 import { ToolRouter } from './models/ToolRouter';
-import { ToolRouterCreateSessionConfig, Session } from './types/toolRouter.types';
+import {
+  ToolRouterCreateSessionConfig,
+  ToolRouterUseSessionConfig,
+  Session,
+} from './types/toolRouter.types';
 import { CONFIG_DEFAULTS } from './utils/config-defaults';
 
 export type ComposioConfig<
@@ -194,7 +198,10 @@ export class Composio<
    * @param id {string} The id of the session to use
    * @returns {Promise<Session<TToolCollection, TTool, TProvider>>} The tool router session
    */
-  use: (id: string) => Promise<Session<unknown, unknown, TProvider>>;
+  use: (
+    id: string,
+    config?: ToolRouterUseSessionConfig
+  ) => Promise<Session<unknown, unknown, TProvider>>;
 
   /**
    * Creates a new instance of the Composio SDK.

--- a/ts/packages/core/src/models/ToolRouter.ts
+++ b/ts/packages/core/src/models/ToolRouter.ts
@@ -23,6 +23,8 @@ import { BaseComposioProvider } from '../provider/BaseProvider';
 import { ComposioConfig } from '../composio';
 import {
   ToolRouterCreateSessionConfig,
+  ToolRouterUseSessionConfig,
+  ToolRouterUseSessionConfigSchema,
   Session,
   SessionExperimental,
   MCPServerType,
@@ -43,6 +45,7 @@ import {
 } from '../lib/toolRouterParams';
 import { ToolRouterSession } from './ToolRouterSession';
 import {
+  buildCustomToolsMap,
   buildCustomToolsMapFromResponse,
   serializeCustomTools,
   serializeCustomToolkits,
@@ -186,13 +189,30 @@ export class ToolRouter<
    * console.log(session.mcp.headers);
    * ```
    */
-  async use(id: string): Promise<Session<TToolCollection, TTool, TProvider>> {
+  async use(
+    id: string,
+    config?: ToolRouterUseSessionConfig
+  ): Promise<Session<TToolCollection, TTool, TProvider>> {
     const session = await this.client.toolRouter.session.retrieve(id);
+
+    const routerConfig = ToolRouterUseSessionConfigSchema.parse(config);
+    const customTools = routerConfig?.experimental?.customTools;
+    const customToolkits = routerConfig?.experimental?.customToolkits;
+    const userId = routerConfig?.userId;
+
+    let customToolsMap: CustomToolsMap | undefined;
+    if (customTools?.length || customToolkits?.length) {
+      customToolsMap = buildCustomToolsMap(customTools ?? [], customToolkits);
+    }
+
     return new ToolRouterSession<TToolCollection, TTool, TProvider>(
       this.client,
       this.config,
       session.session_id,
-      this.createMCPServerConfig(session.mcp)
+      this.createMCPServerConfig(session.mcp),
+      undefined,
+      customToolsMap,
+      userId
     );
   }
 }

--- a/ts/packages/core/src/types/toolRouter.types.ts
+++ b/ts/packages/core/src/types/toolRouter.types.ts
@@ -289,6 +289,40 @@ export const ToolRouterCreateSessionConfigSchema = z
  */
 export type ToolRouterCreateSessionConfig = z.infer<typeof ToolRouterCreateSessionConfigSchema>;
 
+/**
+ * Config for resuming an existing tool router session via `composio.use()`.
+ *
+ * Provide `userId` and `experimental.customTools` / `experimental.customToolkits`
+ * to restore custom-tool routing on a resumed session. `userId` is required when
+ * any custom tools or toolkits are supplied.
+ */
+export const ToolRouterUseSessionConfigSchema = z
+  .object({
+    /** User ID — required when experimental.customTools or experimental.customToolkits are provided. */
+    userId: z.string().optional(),
+    experimental: z
+      .object({
+        customTools: z
+          .array(z.custom<CustomTool>())
+          .optional()
+          .describe(
+            'Custom tools to restore in this session. Created via experimental_createTool() from @composio/core.'
+          ),
+        customToolkits: z
+          .array(z.custom<CustomToolkit>())
+          .optional()
+          .describe(
+            'Custom toolkits to restore in this session. Created via experimental_createToolkit() from @composio/core.'
+          ),
+      })
+      .optional()
+      .describe('Experimental features — not stable, may be modified or removed'),
+  })
+  .optional()
+  .describe('Config for resuming an existing tool router session');
+
+export type ToolRouterUseSessionConfig = z.infer<typeof ToolRouterUseSessionConfigSchema>;
+
 export const ToolkitConnectionStateSchema = z
   .object({
     slug: z.string().describe('The slug of a toolkit'),

--- a/ts/packages/core/test/models/toolRouter.test.ts
+++ b/ts/packages/core/test/models/toolRouter.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { z } from 'zod/v3';
 import { ToolRouter } from '../../src/models/ToolRouter';
 import ComposioClient from '@composio/client';
 import { telemetry } from '../../src/telemetry/Telemetry';
@@ -6,6 +7,7 @@ import { MockProvider } from '../utils/mocks/provider.mock';
 import { Tools } from '../../src/models/Tools';
 import { ConnectedAccountStatuses } from '../../src/types/connectedAccounts.types';
 import { ToolRouterCreateSessionConfig, Session } from '../../src/types/toolRouter.types';
+import { createCustomTool, createCustomToolkit } from '../../src/models/CustomTool';
 
 // Mock dependencies
 vi.mock('../../src/telemetry/Telemetry', () => ({
@@ -2493,6 +2495,96 @@ describe('ToolRouter', () => {
       // Both should have been called once
       expect(mockClient.toolRouter.session.create).toHaveBeenCalledTimes(1);
       expect(mockClient.toolRouter.session.retrieve).toHaveBeenCalledTimes(1);
+    });
+
+    it('should support custom tools when resuming a session', async () => {
+      mockClient.toolRouter.session.retrieve.mockResolvedValueOnce(mockSessionRetrieveResponse);
+
+      const execute = vi.fn().mockResolvedValue({ result: 'ok' });
+      const customTool = createCustomTool('MY_TOOL', {
+        name: 'My Tool',
+        description: 'A test custom tool',
+        inputParams: z.object({ value: z.string() }),
+        execute,
+      });
+
+      const session = await toolRouter.use(sessionId, {
+        userId: 'user_123',
+        experimental: { customTools: [customTool] },
+      });
+
+      const registered = session.customTools();
+      expect(registered).toHaveLength(1);
+      expect(registered[0].slug).toBe('LOCAL_MY_TOOL');
+      expect(registered[0].name).toBe('My Tool');
+    });
+
+    it('should support custom toolkits when resuming a session', async () => {
+      mockClient.toolRouter.session.retrieve.mockResolvedValueOnce(mockSessionRetrieveResponse);
+
+      const toolInKit = createCustomTool('KIT_TOOL', {
+        name: 'Kit Tool',
+        description: 'A tool inside a toolkit',
+        inputParams: z.object({ x: z.number() }),
+        execute: vi.fn().mockResolvedValue({ x: 1 }),
+      });
+      const customToolkit = createCustomToolkit('MY_KIT', {
+        name: 'My Kit',
+        description: 'A test toolkit',
+        tools: [toolInKit],
+      });
+
+      const session = await toolRouter.use(sessionId, {
+        userId: 'user_123',
+        experimental: { customToolkits: [customToolkit] },
+      });
+
+      const registeredKits = session.customToolkits();
+      expect(registeredKits).toHaveLength(1);
+      expect(registeredKits[0].slug).toBe('MY_KIT');
+
+      const registeredTools = session.customTools();
+      expect(registeredTools).toHaveLength(1);
+      expect(registeredTools[0].slug).toBe('LOCAL_MY_KIT_KIT_TOOL');
+    });
+
+    it('should throw if custom tools are provided without userId', async () => {
+      mockClient.toolRouter.session.retrieve.mockResolvedValueOnce(mockSessionRetrieveResponse);
+
+      const customTool = createCustomTool('NO_USER_TOOL', {
+        name: 'No User Tool',
+        description: 'Tool without userId',
+        inputParams: z.object({ v: z.string() }),
+        execute: vi.fn().mockResolvedValue({}),
+      });
+
+      await expect(
+        toolRouter.use(sessionId, {
+          experimental: { customTools: [customTool] },
+        })
+      ).rejects.toThrow('userId is required when custom tools are bound to a session.');
+    });
+
+    it('should execute a custom tool when resuming a session', async () => {
+      mockClient.toolRouter.session.retrieve.mockResolvedValueOnce(mockSessionRetrieveResponse);
+
+      const execute = vi.fn().mockResolvedValue({ output: 'hello' });
+      const customTool = createCustomTool('EXEC_TOOL', {
+        name: 'Exec Tool',
+        description: 'Executable custom tool',
+        inputParams: z.object({ msg: z.string() }),
+        execute,
+      });
+
+      const session = await toolRouter.use(sessionId, {
+        userId: 'user_123',
+        experimental: { customTools: [customTool] },
+      });
+
+      const result = await session.execute('LOCAL_EXEC_TOOL', { msg: 'hello' });
+
+      expect(execute).toHaveBeenCalledWith({ msg: 'hello' }, expect.objectContaining({ userId: 'user_123' }));
+      expect(result).toMatchObject({ data: { output: 'hello' }, error: null });
     });
   });
 });


### PR DESCRIPTION
## Summary

Stateless backends (e.g. a chat API where each HTTP request is independent) need to resume the
same session across user turns to preserve workbench state — accumulated files, execution context,
etc. The correct pattern is to call `composio.create()` once, store the `sessionId`, then call
`composio.use(sessionId)` on every subsequent turn.

This pattern broke silently when experimental custom toolkits were involved: `composio.create()`
accepted `experimental.customTools` / `experimental.customToolkits`, but `composio.use()` only
took a session ID and had no way to restore the custom-tool routing. Developers were forced to call
`create()` on every turn instead, which may return a different session ID and silently lose
workbench files.

Fixes #

## Changes
- Added `ToolRouterUseSessionConfig` type (and its Zod schema) to `toolRouter.types.ts` with
  `userId` and `experimental.customTools` / `experimental.customToolkits` fields
- Updated `ToolRouter.use()` to accept an optional second config argument — when custom
  tools/toolkits are provided, it builds the `CustomToolsMap` client-side using the existing
  deterministic `buildCustomToolsMap()` and passes it to `ToolRouterSession` (no extra API calls)
- Updated the `use` property type on the `Composio` class to match the new signature
- Added 4 tests to the `use method` describe block: custom tools, custom toolkits,
  missing-`userId` guard, and tool execution on a resumed session

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor/Chore
- [ ] Documentation
- [ ] Breaking change

## How Has This Been Tested?

Added unit tests in `ts/packages/core/test/models/toolRouter.test.ts` inside the existing
`use method` describe block:

```bash
cd ts/packages/core
node_modules/.bin/vitest run test/models/toolRouter.test.ts
# 96 passed
