### PR TITLE
Add CLI runtime headers to Composio client

### DIFF
--- a/ts/packages/cli/src/services/composio-clients.ts
+++ b/ts/packages/cli/src/services/composio-clients.ts
@@ -26,6 +26,7 @@ import {
 } from 'src/effects/toolkit-version-overrides';
 import { Session, RetrievedSession } from 'src/models/session';
 import { TriggerType, TriggerTypes, TriggerTypesAsEnums } from 'src/models/trigger-types';
+import * as constants from 'src/constants';
 import { ComposioUserContext, ComposioUserContextLive } from './user-context';
 import { ProjectContext } from './project-context';
 import type { NoSuchElementException } from 'effect/Cause';
@@ -1306,12 +1307,28 @@ export const findDeveloperProjectByName = (params: {
 const normalizeApiKey = (rawApiKey?: string): string | undefined =>
   typeof rawApiKey === 'string' && rawApiKey.trim().length > 0 ? rawApiKey : undefined;
 
+const detectCliRuntime = (): string => {
+  if (typeof Bun !== 'undefined') {
+    return 'BUN';
+  }
+
+  if (typeof process !== 'undefined' && process.versions?.node) {
+    return 'NODEJS';
+  }
+
+  return 'UNKNOWN';
+};
+
 const buildDefaultHeaders = (params: {
   userApiKey?: string;
   orgId?: string;
   projectId?: string;
 }): Record<string, string> | undefined => {
   const defaultHeaders = {
+    'x-framework': 'cli',
+    'x-source': 'CLI',
+    'x-runtime': detectCliRuntime(),
+    'x-sdk-version': constants.APP_VERSION,
     ...(params.userApiKey
       ? ({ 'x-user-api-key': params.userApiKey } satisfies Record<string, string>)
       : {}),

--- a/ts/packages/cli/test/src/services/composio-client-singleton.test.ts
+++ b/ts/packages/cli/test/src/services/composio-client-singleton.test.ts
@@ -4,6 +4,7 @@ import { ConfigProvider, Effect, Layer, Option } from 'effect';
 import { execSync } from 'node:child_process';
 import * as tempy from 'tempy';
 import { ComposioClientSingleton } from 'src/services/composio-clients';
+import { APP_VERSION } from 'src/constants';
 import { defaultNodeOs, NodeOs } from 'src/services/node-os';
 import { extendConfigProvider } from 'src/services/config';
 
@@ -72,6 +73,10 @@ describe('ComposioClientSingleton headers', () => {
 
     expect(headers.get('x-user-api-key')).toBe('uak_from_user_env');
     expect(headers.has('x-api-key')).toBe(false);
+    expect(headers.get('x-framework')).toBe('cli');
+    expect(headers.get('x-source')).toBe('CLI');
+    expect(headers.get('x-runtime')).toBe('NODEJS');
+    expect(headers.get('x-sdk-version')).toBe(APP_VERSION);
   });
 
   it('does not read COMPOSIO_API_KEY for user auth', async () => {
@@ -104,5 +109,6 @@ describe('ComposioClientSingleton headers', () => {
 
     expect(headers.get('x-user-api-key')).toBeNull();
     expect(headers.has('x-api-key')).toBe(false);
+    expect(headers.get('x-source')).toBe('CLI');
   });
 });


### PR DESCRIPTION
## Summary
- Add CLI-specific default headers to Composio client requests, including `x-framework`, `x-source`, `x-runtime`, and `x-sdk-version`.
- Detect runtime as `BUN`, `NODEJS`, or `UNKNOWN` when building headers.
- Extend singleton tests to verify the new headers are present for user-auth requests.

## Testing
- Added unit test coverage for CLI header construction in `ts/packages/cli/test/src/services/composio-client-singleton.test.ts`.
- Verified `x-runtime` resolves to `NODEJS` in the test environment.
- Not run: full package test suite / CI.