### PR TITLE
ci: allow more bots to trigger Claude review workflows

### DIFF
--- a/.github/workflows/claude-code-doc-review.yml
+++ b/.github/workflows/claude-code-doc-review.yml
@@ -36,7 +36,7 @@ jobs:
       with:
         anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
         track_progress: true # Forces tag mode with tracking comments
-        allowed_bots: "devin-ai-integration[bot]"
+        allowed_bots: "devin-ai-integration[bot],decimal-pr-bot[bot],github-actions[bot],dependabot[bot],zen-agent"
 
         # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
         # model: "claude-opus-4-20250514"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,7 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          allowed_bots: "devin-ai-integration[bot]"
+          allowed_bots: "devin-ai-integration[bot],decimal-pr-bot[bot],github-actions[bot],dependabot[bot],zen-agent"
 
           # Optional: Custom settings and environment variables for Claude
           # settings: |


### PR DESCRIPTION
## Summary
- Adds `decimal-pr-bot[bot]`, `github-actions[bot]`, `dependabot[bot]`, and `zen-agent` to `allowed_bots` in both `.github/workflows/claude.yml` and `.github/workflows/claude-code-doc-review.yml`.
- So Claude review runs on PRs opened by our CI bots (docs/SDK auto-update, dep bumps) and by the decimal and zen agents.

Motivation: #3224 (decimal-pr-bot) did not get a Claude review because it wasn't in the allowlist.

## Test plan
- [ ] Merge and confirm Claude review fires on the next `github-actions[bot]` docs-update PR.
- [ ] Retrigger Claude on #3224 (or wait for the next decimal-pr-bot PR) and confirm it runs.
- [ ] Confirm it runs on the next dependabot PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)