### PR TITLE
Pass link aliases through tool router session creation

### DIFF
--- a/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
+++ b/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
@@ -224,6 +224,20 @@ const getConsumerCacheScope = (resolvedProject: {
 
 const normalizeAlias = (rawAlias: string) => rawAlias.trim();
 
+const resolveNormalizedAliasOption = (alias: Option.Option<string>) =>
+  Effect.gen(function* () {
+    if (Option.isNone(alias)) {
+      return Option.none<string>();
+    }
+
+    const normalizedAlias = normalizeAlias(alias.value);
+    if (normalizedAlias.length === 0) {
+      return yield* Effect.fail(new Error('`--alias` cannot be empty.'));
+    }
+
+    return Option.some(normalizedAlias);
+  });
+
 const listActiveConnectedAccounts = (params: {
   readonly client: RawComposioClient;
   readonly userId: string;
@@ -287,32 +301,6 @@ const ensureAliasForAdditionalAccount = (params: {
       'Existing accounts'
     );
     return false as const;
-  });
-
-const patchConnectedAccountAlias = (params: {
-  readonly ui: TerminalUI;
-  readonly client: RawComposioClient;
-  readonly connectedAccountId: string;
-  readonly alias: Option.Option<string>;
-}) =>
-  Effect.gen(function* () {
-    if (Option.isNone(params.alias)) {
-      return;
-    }
-
-    const normalizedAlias = normalizeAlias(params.alias.value);
-    if (normalizedAlias.length === 0) {
-      return yield* Effect.fail(new Error('`--alias` cannot be empty.'));
-    }
-
-    yield* params.ui.withSpinner(
-      `Assigning alias "${normalizedAlias}"...`,
-      Effect.tryPromise(() =>
-        params.client.patch(`/api/v3/connected_accounts/${params.connectedAccountId}`, {
-          body: { alias: normalizedAlias },
-        })
-      )
-    );
   });
 
 const resolveLinkUserId = (params: {
@@ -533,6 +521,7 @@ const handleLegacyAuthConfigLink = (params: {
       orgId: resolvedProject.orgId,
       projectId: resolvedProject.projectId,
     });
+    const normalizedAlias = yield* resolveNormalizedAliasOption(params.alias);
     const existingAccounts = yield* listActiveConnectedAccounts({
       client,
       userId: resolvedUserId.value,
@@ -545,6 +534,7 @@ const handleLegacyAuthConfigLink = (params: {
           client.link.create({
             auth_config_id: params.authConfigId,
             user_id: resolvedUserId.value,
+            ...(Option.isSome(normalizedAlias) && { alias: normalizedAlias.value }),
           })
         )
       )
@@ -572,19 +562,12 @@ const handleLegacyAuthConfigLink = (params: {
     const { connectedAccountId, redirectUrl } = validatedLink.value;
     const canContinue = yield* ensureAliasForAdditionalAccount({
       ui: params.ui,
-      alias: params.alias,
+      alias: normalizedAlias,
       connectedAccountId,
       existingAccounts,
       scopeDescription: `user "${resolvedUserId.value}" in auth config "${params.authConfigId}"`,
     });
     if (!canContinue) return;
-
-    yield* patchConnectedAccountAlias({
-      ui: params.ui,
-      client,
-      connectedAccountId,
-      alias: params.alias,
-    });
 
     if (params.noWait) {
       yield* showRedirectUrl(params.ui, redirectUrl);
@@ -627,6 +610,7 @@ const runConnectedAccountsLink = (params: {
     )
       ? params.alias
       : Option.none<string>();
+    const normalizedAliasOption = yield* resolveNormalizedAliasOption(aliasOption);
 
     const ui = yield* TerminalUI;
     const clientSingleton = yield* ComposioClientSingleton;
@@ -729,9 +713,18 @@ const runConnectedAccountsLink = (params: {
           const { sessionId } = yield* resolveToolRouterSession(client, resolvedUserId.value, {
             manageConnections: true,
             cacheScope: getConsumerCacheScope(resolvedProject),
+            excludeConnectedAccountsForToolkits: [toolkitSlug],
+            multiAccount: Option.isSome(normalizedAliasOption)
+              ? {
+                  enable: true,
+                }
+              : undefined,
           });
           return yield* Effect.tryPromise(() =>
-            client.toolRouter.session.link(sessionId, { toolkit: toolkitSlug })
+            client.toolRouter.session.link(sessionId, {
+              toolkit: toolkitSlug,
+              ...(Option.isSome(normalizedAliasOption) && { alias: normalizedAliasOption.value }),
+            })
           );
         })
       )
@@ -767,19 +760,12 @@ const runConnectedAccountsLink = (params: {
     const { connectedAccountId: connAccountId, redirectUrl } = validatedLink.value;
     const canContinue = yield* ensureAliasForAdditionalAccount({
       ui,
-      alias: aliasOption,
+      alias: normalizedAliasOption,
       connectedAccountId: connAccountId,
       existingAccounts,
       scopeDescription: `user "${resolvedUserId.value}" in toolkit "${toolkitSlug}"`,
     });
     if (!canContinue) return;
-
-    yield* patchConnectedAccountAlias({
-      ui,
-      client,
-      connectedAccountId: connAccountId,
-      alias: aliasOption,
-    });
 
     if (params.noWait) {
       yield* showRedirectUrl(ui, redirectUrl);

--- a/ts/packages/cli/src/effects/create-tool-router-session.ts
+++ b/ts/packages/cli/src/effects/create-tool-router-session.ts
@@ -19,6 +19,14 @@ export interface CreateToolRouterSessionOptions {
   };
   /** Explicit connected-account pins by toolkit slug. */
   readonly connectedAccounts?: Record<string, string>;
+  /** Toolkits whose connected-account pins should be omitted from the session. */
+  readonly excludeConnectedAccountsForToolkits?: ReadonlyArray<string>;
+  /** Enable Tool Router multi-account mode for this session. */
+  readonly multiAccount?: {
+    readonly enable?: boolean;
+    readonly maxAccountsPerToolkit?: number;
+    readonly requireExplicitSelection?: boolean;
+  };
 }
 
 /**
@@ -38,6 +46,16 @@ export const createToolRouterSession = (
     const mergeConnectedAccounts = (...mappings: Array<Record<string, string> | undefined>) => {
       const merged = Object.assign({}, ...mappings.filter(Boolean));
       return Object.keys(merged).length > 0 ? merged : undefined;
+    };
+    const excludedToolkits = new Set(
+      (options?.excludeConnectedAccountsForToolkits ?? []).map(toolkit => toolkit.toLowerCase())
+    );
+    const filterConnectedAccounts = (mapping: Record<string, string> | undefined) => {
+      if (!mapping) return undefined;
+      const filtered = Object.fromEntries(
+        Object.entries(mapping).filter(([toolkit]) => !excludedToolkits.has(toolkit.toLowerCase()))
+      );
+      return Object.keys(filtered).length > 0 ? filtered : undefined;
     };
 
     const cachedAuthConfigs = options?.cacheScope
@@ -60,9 +78,11 @@ export const createToolRouterSession = (
           connectedToolkits: options?.toolkits ?? [],
           authConfigs: cachedAuthConfigs.value.authConfigs,
           connectedAccounts: mergeConnectedAccounts(
-            Option.isSome(cachedConnectedAccounts)
-              ? cachedConnectedAccounts.value.connectedAccounts
-              : undefined,
+            filterConnectedAccounts(
+              Option.isSome(cachedConnectedAccounts)
+                ? cachedConnectedAccounts.value.connectedAccounts
+                : undefined
+            ),
             options?.connectedAccounts
           ),
           availableConnectedAccounts: Option.isSome(cachedConnectedAccounts)
@@ -75,7 +95,7 @@ export const createToolRouterSession = (
           Effect.map(connectionContext => ({
             ...connectionContext,
             connectedAccounts: mergeConnectedAccounts(
-              connectionContext.connectedAccounts,
+              filterConnectedAccounts(connectionContext.connectedAccounts),
               options?.connectedAccounts
             ),
           }))
@@ -102,6 +122,13 @@ export const createToolRouterSession = (
         auth_configs: connectionContext.authConfigs,
         connected_accounts: connectionContext.connectedAccounts,
         manage_connections: { enable: options?.manageConnections ?? false },
+        multi_account: options?.multiAccount
+          ? {
+              enable: options.multiAccount.enable,
+              max_accounts_per_toolkit: options.multiAccount.maxAccountsPerToolkit,
+              require_explicit_selection: options.multiAccount.requireExplicitSelection,
+            }
+          : undefined,
         toolkits:
           options?.toolkits && options.toolkits.length > 0
             ? { enable: [...options.toolkits] }

--- a/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.link.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.link.cmd.test.ts
@@ -80,7 +80,17 @@ const RecordingTerminalUI = TerminalUI.of({
 });
 
 describe('CLI: composio dev connected-accounts link', () => {
-  const aliasPatchSpy = vi.fn();
+  const toolRouterCreateSpy = vi.fn(async () => ({
+    session_id: 'trs_test_session',
+    config: { user_id: 'consumer-user-org_test' },
+    mcp: { type: 'http' as const, url: 'https://mcp.test.composio.dev' },
+    tool_router_tools: ['COMPOSIO_SEARCH_TOOLS', 'COMPOSIO_MANAGE_CONNECTIONS'],
+  }));
+  const toolRouterLinkSpy = vi.fn(async () => ({
+    connected_account_id: 'con_test_link',
+    link_token: 'lt_test_token',
+    redirect_url: 'https://app.composio.dev/link?token=lt_test_token',
+  }));
 
   afterEach(() => {
     vi.clearAllMocks();
@@ -319,20 +329,31 @@ describe('CLI: composio dev connected-accounts link', () => {
       baseConfigProvider: testConfigProvider,
       connectedAccountsData: makeConnectedAccountsData({
         items: [makeConnectedAccount({ status: 'INITIATED' })],
-        onPatch: params => {
-          aliasPatchSpy(params);
-        },
       }),
+      toolRouter: {
+        create: toolRouterCreateSpy,
+        link: toolRouterLinkSpy,
+      },
       fixture: 'global-test-user-id',
     })
-  )('[Given] --alias [Then] it patches the created connected account alias', it => {
-    it.scoped('updates the connected account alias through the patch API', () =>
+  )('[Given] --alias [Then] it passes alias during link creation', it => {
+    it.scoped('sends alias to the tool router link API instead of patching afterward', () =>
       Effect.gen(function* () {
         yield* cli(['link', 'gmail', '--alias', 'work', '--no-wait']);
-
-        expect(aliasPatchSpy).toHaveBeenCalledWith({
-          path: '/api/v3/connected_accounts/con_test_link',
-          body: { alias: 'work' },
+        expect(toolRouterCreateSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            connected_accounts: undefined,
+            manage_connections: { enable: true },
+            multi_account: {
+              enable: true,
+              max_accounts_per_toolkit: undefined,
+              require_explicit_selection: undefined,
+            },
+          })
+        );
+        expect(toolRouterLinkSpy).toHaveBeenCalledWith('trs_test_session', {
+          toolkit: 'gmail',
+          alias: 'work',
         });
       })
     );


### PR DESCRIPTION
## Summary
- Pass `--alias` through tool router session creation so linked accounts keep their alias without a follow-up patch.
- Enable multi-account mode for alias-driven links and exclude the linked toolkit from inherited connected-account pins.
- Refresh CLI docs and generated metadata to reflect the updated multi-account behavior and session schema.

## Testing
- Added/updated CLI tests for alias handling in `connected-accounts link`.
- Updated singleton/header tests to match the removed client header behavior.
- Not run