### PR TITLE
docs: clean up observability pages for public-facing docs

### DIFF
--- a/docs/content/changelog/04-17-26.mdx
+++ b/docs/content/changelog/04-17-26.mdx
@@ -19,7 +19,7 @@ See the [tool execution logs guide](/docs/observability/logs).
 
 ## Usage metering
 
-Aggregated counts of tool calls and sessions, sourced from ClickHouse. Summary endpoints return totals; breakdown endpoints group results by tool, toolkit, user, session, or project.
+Aggregated counts of tool calls and sessions. Summary endpoints return totals; breakdown endpoints group results by tool, toolkit, user, session, or project.
 
 - `POST /api/v3.1/org/usage/summary` and `POST /api/v3.1/org/usage/{entity_type}` — org scope (`x-org-api-key` or org JWT).
 - `POST /api/v3.1/project/usage/summary` and `POST /api/v3.1/project/usage/{entity_type}` — project scope (`x-api-key` or cookie).

--- a/docs/content/docs/observability/index.mdx
+++ b/docs/content/docs/observability/index.mdx
@@ -14,7 +14,7 @@ Composio exposes two v3.1 REST APIs for inspecting activity in your org or proje
 | See how many tool calls or sessions happened in a window | [Usage summary](/docs/observability/usage#summary) |
 | Break usage down by tool, toolkit, user, or session | [Usage breakdown](/docs/observability/usage#breakdown) |
 
-Logs record **individual events** and are primarily for debugging. Usage queries return **aggregated counts** from ClickHouse and are primarily for dashboards, billing integrations, and customer-facing analytics.
+Logs record **individual events** and are primarily for debugging. Usage queries return **aggregated counts** and are primarily for dashboards, billing integrations, and customer-facing analytics.
 
 ## Authentication at a glance
 
@@ -29,8 +29,6 @@ Each endpoint family takes a specific credential. Use the right one for the scop
 The org-level usage endpoints accept a `project_id` filter so you can slice by project without rotating keys.
 
 ## Reference
-
-For full request/response schemas, see the auto-generated reference:
 
 - [Organization API reference](/reference/api-reference/organization) — org-level usage endpoints
 - [Projects API reference](/reference/api-reference/projects) — project-level usage endpoints and project-scoped APIs

--- a/docs/content/docs/observability/logs.mdx
+++ b/docs/content/docs/observability/logs.mdx
@@ -144,6 +144,10 @@ curl https://backend.composio.dev/api/v3.1/logs/tool_execution/log_-jRTWClpBoVo 
   -H "x-api-key: YOUR_PROJECT_API_KEY"
 ```
 
-## Reference
+## What to read next
 
-See the [Projects API reference](/reference/api-reference/projects) for the generated schema.
+<Cards>
+  <Card icon={<Monitor />} title="Usage metering" href="/docs/observability/usage" description="Query aggregated tool call and session counts for dashboards and billing" />
+  <Card icon={<Wrench />} title="Tools and toolkits" href="/docs/tools-and-toolkits" description="Understand how tools and toolkits work in Composio" />
+  <Card icon={<Database />} title="Projects API reference" href="/reference/api-reference/projects" description="Full request and response schemas for project-level endpoints" />
+</Cards>

--- a/docs/content/docs/observability/usage.mdx
+++ b/docs/content/docs/observability/usage.mdx
@@ -4,7 +4,7 @@ description: Query aggregated tool call and session counts for your org or proje
 keywords: ['usage', 'metering', 'analytics', 'billing', 'observability']
 ---
 
-The Usage API returns **aggregated counts** of tool calls and sessions, sourced from ClickHouse. Use it to power billing dashboards, customer-facing analytics, or internal utilization reports. For individual events, use the [Logs API](/docs/observability/logs).
+The Usage API returns **aggregated counts** of tool calls and sessions. Use it to power billing dashboards, customer-facing analytics, or internal utilization reports. For individual events, use the [Logs API](/docs/observability/logs).
 
 There are two query shapes:
 
@@ -191,13 +191,11 @@ curl -X POST https://backend.composio.dev/api/v3.1/project/usage/tool_calls \
   }'
 ```
 
-## Self-hosted deployments
+## What to read next
 
-If your Composio instance is self-hosted **without ClickHouse enabled**, the usage endpoints return `500`. The Logs API does not depend on ClickHouse and remains available.
-
-## Reference
-
-See the auto-generated reference for full schemas:
-
-- [Organization API reference](/reference/api-reference/organization) — org-level usage endpoints
-- [Projects API reference](/reference/api-reference/projects) — project-level usage endpoints
+<Cards>
+  <Card icon={<Terminal />} title="Tool execution logs" href="/docs/observability/logs" description="Debug individual tool executions with full request/response payloads" />
+  <Card icon={<Wrench />} title="Tools and toolkits" href="/docs/tools-and-toolkits" description="Understand how tools and toolkits work in Composio" />
+  <Card icon={<Database />} title="Organization API reference" href="/reference/api-reference/organization" description="Full request and response schemas for org-level usage endpoints" />
+  <Card icon={<Database />} title="Projects API reference" href="/reference/api-reference/projects" description="Full request and response schemas for project-level usage endpoints" />
+</Cards>


### PR DESCRIPTION
## Summary

Follow-up to #3235. Removes internal infrastructure details and aligns the observability docs with the rest of the docs site:

- **Remove all ClickHouse references** — mentioned in `index.mdx`, `usage.mdx`, and the changelog entry. Internal implementation detail that's confusing for developers and a potential security concern.
- **Remove self-hosted deployment caveat** — the "without ClickHouse enabled" section in `usage.mdx` exposed infrastructure details not relevant to developer docs.
- **Remove "auto-generated reference" phrasing** — from `index.mdx` and `logs.mdx`. Developers don't need to know how reference docs are produced.
- **Add "What to read next" Card sections** — `logs.mdx` and `usage.mdx` had bare bullet-point reference links. Replaced with `<Cards>` components matching the pattern used across the rest of the docs, including cross-links to related observability pages and API reference.

## Test plan

- [ ] `bun run dev` — observability pages render without errors
- [ ] Verify `/docs/observability`, `/docs/observability/logs`, `/docs/observability/usage` all load correctly
- [ ] Confirm no remaining ClickHouse or "auto-generated" references in observability section

🤖 Generated with [Claude Code](https://claude.com/claude-code)