### PR TITLE
Fix triage classification for broken tools

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -117,8 +117,10 @@ jobs:
           Choose py only when the issue is primarily about the Python SDK.
           Choose ts only when the issue is primarily about the TypeScript SDK or TS packages other than the CLI.
           Choose docs only when the issue is primarily about documentation.
+          Never choose tool-request for a broken existing integration or tool. Those are bugs, not tool requests, even if the title/body mentions a tool name or toolkit slug.
+          If an issue reports broken behavior in an existing tool or integration and it does not clearly belong to docs, py, ts, or cli, choose other.
           Set is_bug to true when the issue is primarily reporting broken behavior, a defect, an error, a regression, or unexpected behavior.
-          Set is_bug to false for feature requests, questions, maintenance, cleanup, and tool requests.
+          Set is_bug to false for feature requests, questions, maintenance, cleanup, and true new-tool requests.
           Set should_comment to true only when the issue appears incorrect, non-actionable, or missing the information needed to reproduce or investigate.
           Set should_comment to false otherwise.
 
@@ -195,7 +197,7 @@ jobs:
               return;
             }
 
-            const category = parsed.category;
+            let category = parsed.category;
             const isBug = Boolean(parsed.is_bug);
             const reason = parsed.reason || "";
             const shouldComment = Boolean(parsed.should_comment);
@@ -211,6 +213,14 @@ jobs:
 
             const labels = [];
             const assignees = [];
+
+            // A broken existing tool/integration is a bug, not a new tool request.
+            if (isBug && category === "tool-request") {
+              category = "other";
+              core.info(
+                `Normalizing contradictory classifier output for issue #${issue_number}: bug reports cannot be categorized as tool-request. Original reason: ${reason}`
+              );
+            }
 
             if (isBug) {
               labels.push("bug");

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -118,7 +118,6 @@ jobs:
           Choose ts only when the issue is primarily about the TypeScript SDK or TS packages other than the CLI.
           Choose docs only when the issue is primarily about documentation.
           Never choose tool-request for a broken existing integration or tool. Those are bugs, not tool requests, even if the title/body mentions a tool name or toolkit slug.
-          If an issue reports broken behavior in an existing tool or integration and it does not clearly belong to docs, py, ts, or cli, choose other.
           Set is_bug to true when the issue is primarily reporting broken behavior, a defect, an error, a regression, or unexpected behavior.
           Set is_bug to false for feature requests, questions, maintenance, cleanup, and true new-tool requests.
           Set should_comment to true only when the issue appears incorrect, non-actionable, or missing the information needed to reproduce or investigate.
@@ -197,7 +196,7 @@ jobs:
               return;
             }
 
-            let category = parsed.category;
+            const category = parsed.category;
             const isBug = Boolean(parsed.is_bug);
             const reason = parsed.reason || "";
             const shouldComment = Boolean(parsed.should_comment);
@@ -213,12 +212,11 @@ jobs:
 
             const labels = [];
             const assignees = [];
+            const suppressToolRequestHandling = isBug && category === "tool-request";
 
-            // A broken existing tool/integration is a bug, not a new tool request.
-            if (isBug && category === "tool-request") {
-              category = "other";
+            if (suppressToolRequestHandling) {
               core.info(
-                `Normalizing contradictory classifier output for issue #${issue_number}: bug reports cannot be categorized as tool-request. Original reason: ${reason}`
+                `Suppressing tool-request handling for issue #${issue_number} because it is classified as a bug. Original reason: ${reason}`
               );
             }
 
@@ -240,7 +238,7 @@ jobs:
               assignees.push("CryogenicPlanet");
             } else if (category === "feature-request") {
               labels.push("feature-request");
-            } else if (category === "tool-request") {
+            } else if (category === "tool-request" && !suppressToolRequestHandling) {
               labels.push("tool-request");
             }
 
@@ -262,7 +260,11 @@ jobs:
               });
             }
 
-            if (category !== "tool-request" && shouldComment && commentBody.trim().length > 0) {
+            if (
+              (category !== "tool-request" || suppressToolRequestHandling) &&
+              shouldComment &&
+              commentBody.trim().length > 0
+            ) {
               await github.rest.issues.createComment({
                 owner,
                 repo,
@@ -271,7 +273,7 @@ jobs:
               });
             }
 
-            if (category === "tool-request" && issueState === "open") {
+            if (category === "tool-request" && !suppressToolRequestHandling && issueState === "open") {
               await github.rest.issues.createComment({
                 owner,
                 repo,


### PR DESCRIPTION
## Summary
- Normalize triage output so bug reports are never classified as `tool-request`.
- Treat broken existing integrations or tools as bugs instead of new integration requests.
- Preserve existing label, assignee, and auto-close behavior for genuine tool requests.

## Testing
- Not run (workflow-only change).
- Reviewed the updated triage logic to confirm bug reports fall back to `other` when the classifier emits `tool-request`.
- Verified the issue comment and close-path behavior remain unchanged for valid tool requests.