### PR TITLE
Add agent discovery metadata for docs

### DIFF
--- a/docs/app/.well-known/agent-skills/index.json/route.ts
+++ b/docs/app/.well-known/agent-skills/index.json/route.ts
@@ -1,0 +1,41 @@
+import { createHash } from 'crypto';
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+import { NextResponse } from 'next/server';
+import { AGENT_SKILLS_SCHEMA, agentSkills } from '@/lib/agent-discovery';
+
+async function digestSkill(name: string) {
+  const filePath = join(
+    process.cwd(),
+    'public',
+    '.well-known',
+    'agent-skills',
+    name,
+    'SKILL.md'
+  );
+  const raw = await readFile(filePath);
+  return `sha256:${createHash('sha256').update(raw).digest('hex')}`;
+}
+
+export async function GET() {
+  const skills = await Promise.all(
+    agentSkills.map(async (skill) => ({
+      ...skill,
+      type: 'skill-md',
+      url: `/.well-known/agent-skills/${skill.name}/SKILL.md`,
+      digest: await digestSkill(skill.name),
+    }))
+  );
+
+  return NextResponse.json(
+    {
+      $schema: AGENT_SKILLS_SCHEMA,
+      skills,
+    },
+    {
+      headers: {
+        'Cache-Control': 'public, max-age=300, stale-while-revalidate=3600',
+      },
+    }
+  );
+}

--- a/docs/app/.well-known/api-catalog/route.ts
+++ b/docs/app/.well-known/api-catalog/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from 'next/server';
+import {
+  API_HEALTH_URL,
+  API_REFERENCE_URL,
+  API_V3_BASE_URL,
+  API_V3_SPEC_URL,
+  API_V31_BASE_URL,
+  API_V31_SPEC_URL,
+} from '@/lib/agent-discovery';
+
+export async function GET() {
+  return NextResponse.json(
+    {
+      linkset: [
+        {
+          anchor: API_V31_BASE_URL,
+          'service-desc': [
+            {
+              href: API_V31_SPEC_URL,
+              type: 'application/vnd.oai.openapi+json;version=3.1',
+            },
+          ],
+          'service-doc': [
+            {
+              href: API_REFERENCE_URL,
+              type: 'text/html',
+            },
+          ],
+          status: [
+            {
+              href: API_HEALTH_URL,
+              type: 'application/health+json',
+            },
+          ],
+        },
+        {
+          anchor: API_V3_BASE_URL,
+          'service-desc': [
+            {
+              href: API_V3_SPEC_URL,
+              type: 'application/vnd.oai.openapi+json;version=3.0',
+            },
+          ],
+          'service-doc': [
+            {
+              href: API_REFERENCE_URL,
+              type: 'text/html',
+            },
+          ],
+          status: [
+            {
+              href: API_HEALTH_URL,
+              type: 'application/health+json',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      headers: {
+        'Content-Type': 'application/linkset+json',
+        'Cache-Control': 'public, max-age=300, stale-while-revalidate=3600',
+      },
+    }
+  );
+}

--- a/docs/app/.well-known/mcp/server-card.json/route.ts
+++ b/docs/app/.well-known/mcp/server-card.json/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server';
+import { DOCS_BASE_URL } from '@/lib/agent-discovery';
+
+export async function GET() {
+  return NextResponse.json(
+    {
+      serverInfo: {
+        name: 'Composio MCP',
+        version: 'v3',
+      },
+      transport: {
+        type: 'streamable-http',
+        urlTemplate: 'https://backend.composio.dev/v3/mcp/{session_id}?user_id={user_id}',
+        install: {
+          url: 'https://dashboard.composio.dev/~/org/connect',
+          docs: `${DOCS_BASE_URL}/docs/configuring-sessions`,
+          instructions:
+            'Create a Composio session or use Composio For You to obtain a user or session-specific MCP URL before connecting a client.',
+        },
+      },
+      capabilities: {
+        tools: {
+          listChanged: true,
+        },
+        resources: {
+          listChanged: false,
+          subscribe: false,
+        },
+        prompts: {
+          listChanged: false,
+        },
+      },
+    },
+    {
+      headers: {
+        'Cache-Control': 'public, max-age=300, stale-while-revalidate=3600',
+      },
+    }
+  );
+}

--- a/docs/app/.well-known/oauth-authorization-server/route.ts
+++ b/docs/app/.well-known/oauth-authorization-server/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from 'next/server';
+import {
+  AUTHORIZATION_ENDPOINT,
+  AUTH_ISSUER,
+  AUTH_SCOPES,
+  END_SESSION_ENDPOINT,
+  INTROSPECTION_ENDPOINT,
+  JWKS_URI,
+  REGISTRATION_ENDPOINT,
+  REVOCATION_ENDPOINT,
+  TOKEN_ENDPOINT,
+  USERINFO_ENDPOINT,
+} from '@/lib/agent-discovery';
+
+function getAuthorizationMetadata() {
+  return {
+    scopes_supported: [...AUTH_SCOPES],
+    issuer: AUTH_ISSUER,
+    authorization_endpoint: AUTHORIZATION_ENDPOINT,
+    token_endpoint: TOKEN_ENDPOINT,
+    jwks_uri: JWKS_URI,
+    registration_endpoint: REGISTRATION_ENDPOINT,
+    introspection_endpoint: INTROSPECTION_ENDPOINT,
+    revocation_endpoint: REVOCATION_ENDPOINT,
+    response_types_supported: ['code'],
+    response_modes_supported: ['query'],
+    grant_types_supported: ['authorization_code', 'client_credentials', 'refresh_token'],
+    token_endpoint_auth_methods_supported: [
+      'none',
+      'client_secret_basic',
+      'client_secret_post',
+    ],
+    introspection_endpoint_auth_methods_supported: [
+      'client_secret_basic',
+      'client_secret_post',
+    ],
+    revocation_endpoint_auth_methods_supported: [
+      'client_secret_basic',
+      'client_secret_post',
+    ],
+    code_challenge_methods_supported: ['S256'],
+    authorization_response_iss_parameter_supported: true,
+    claims_supported: [
+      'sub',
+      'iss',
+      'aud',
+      'exp',
+      'iat',
+      'sid',
+      'scope',
+      'azp',
+      'email',
+      'email_verified',
+      'name',
+      'picture',
+      'family_name',
+      'given_name',
+    ],
+    userinfo_endpoint: USERINFO_ENDPOINT,
+    subject_types_supported: ['public'],
+    id_token_signing_alg_values_supported: ['EdDSA'],
+    end_session_endpoint: END_SESSION_ENDPOINT,
+    acr_values_supported: ['urn:mace:incommon:iap:bronze'],
+    prompt_values_supported: ['login', 'consent', 'create', 'select_account'],
+  };
+}
+
+export async function GET() {
+  return NextResponse.json(getAuthorizationMetadata(), {
+    headers: {
+      'Cache-Control': 'public, max-age=300, stale-while-revalidate=3600',
+    },
+  });
+}

--- a/docs/app/.well-known/oauth-protected-resource/route.ts
+++ b/docs/app/.well-known/oauth-protected-resource/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+import {
+  DOCS_BASE_URL,
+  API_V31_BASE_URL,
+  AUTH_ISSUER,
+  AUTH_SCOPES,
+} from '@/lib/agent-discovery';
+
+export async function GET() {
+  return NextResponse.json(
+    {
+      resource: API_V31_BASE_URL,
+      authorization_servers: [AUTH_ISSUER],
+      bearer_methods_supported: ['header', 'cookie'],
+      scopes_supported: [...AUTH_SCOPES],
+      resource_documentation: `${DOCS_BASE_URL}/docs/authentication`,
+    },
+    {
+      headers: {
+        'Cache-Control': 'public, max-age=300, stale-while-revalidate=3600',
+      },
+    }
+  );
+}

--- a/docs/app/.well-known/openid-configuration/route.ts
+++ b/docs/app/.well-known/openid-configuration/route.ts
@@ -1,0 +1,3 @@
+import { GET as getAuthorizationServerMetadata } from '../oauth-authorization-server/route';
+
+export const GET = getAuthorizationServerMetadata;

--- a/docs/app/api/health/route.ts
+++ b/docs/app/api/health/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from 'next/server';
+import {
+  API_V31_SPEC_URL,
+  AUTHORIZATION_SERVER_METADATA_URL,
+} from '@/lib/agent-discovery';
+
+async function check(url: string) {
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      cache: 'no-store',
+      redirect: 'follow',
+    });
+
+    return {
+      status: response.ok ? 'pass' : 'fail',
+      observedValue: response.status,
+      output: response.ok ? 'reachable' : `unexpected status ${response.status}`,
+      time: new Date().toISOString(),
+    };
+  } catch (error) {
+    return {
+      status: 'fail',
+      output: error instanceof Error ? error.message : 'request failed',
+      time: new Date().toISOString(),
+    };
+  }
+}
+
+export async function GET() {
+  const [specCheck, authCheck] = await Promise.all([
+    check(API_V31_SPEC_URL),
+    check(AUTHORIZATION_SERVER_METADATA_URL),
+  ]);
+
+  const passing = [specCheck, authCheck].every((entry) => entry.status === 'pass');
+  const body = {
+    status: passing ? 'pass' : 'fail',
+    version: '1',
+    serviceId: 'docs.composio.dev/agent-discovery',
+    description: 'Health status for agent discovery resources published by the Composio docs site.',
+    checks: {
+      openapi: [specCheck],
+      oauth: [authCheck],
+    },
+  };
+
+  return NextResponse.json(body, {
+    status: passing ? 200 : 503,
+    headers: {
+      'Content-Type': 'application/health+json',
+      'Cache-Control': 'public, max-age=60, stale-while-revalidate=300',
+    },
+  });
+}

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -6,6 +6,7 @@ import { Inter, IBM_Plex_Mono } from 'next/font/google';
 import { PostHogProvider } from '@/components/posthog-provider';
 import { DecimalWidget } from '@/components/decimal-widget';
 import CustomSearchDialog from '@/components/custom-search-dialog';
+import { WebMCPProvider } from '@/components/webmcp-provider';
 import { source } from '@/lib/source';
 
 const defaultLinkSlugs = [
@@ -106,6 +107,7 @@ export default function Layout({ children }: LayoutProps<'/'>) {
       </head>
       <body className="flex flex-col min-h-dvh font-sans">
         <Analytics />
+        <WebMCPProvider />
         <PostHogProvider>
           <RootProvider
             theme={{

--- a/docs/components/webmcp-provider.tsx
+++ b/docs/components/webmcp-provider.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { useEffect } from 'react';
+
+type WebMCPToolArgs = Record<string, unknown>;
+
+interface WebMCPTool {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  execute: (args: WebMCPToolArgs) => Promise<unknown>;
+}
+
+declare global {
+  interface Navigator {
+    modelContext?: {
+      provideContext?: (context: { tools: WebMCPTool[] }) => void | Promise<void>;
+    };
+  }
+}
+
+function buildTools(): WebMCPTool[] {
+  return [
+    {
+      name: 'search_composio_docs',
+      description: 'Search the Composio documentation site and return the most relevant matches.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          query: {
+            type: 'string',
+            description: 'The search query to run against the Composio docs index.',
+          },
+        },
+        required: ['query'],
+        additionalProperties: false,
+      },
+      execute: async ({ query }) => {
+        const value = typeof query === 'string' ? query.trim() : '';
+        if (!value) {
+          throw new Error('query is required');
+        }
+
+        const response = await fetch(`/api/search?query=${encodeURIComponent(value)}`);
+        if (!response.ok) {
+          throw new Error(`search failed with status ${response.status}`);
+        }
+
+        return await response.json();
+      },
+    },
+    {
+      name: 'open_composio_docs_page',
+      description: 'Open a Composio docs page in the current browser tab.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          path: {
+            type: 'string',
+            description: 'A same-origin path such as /docs/quickstart or /reference/api-reference.',
+          },
+        },
+        required: ['path'],
+        additionalProperties: false,
+      },
+      execute: async ({ path }) => {
+        const value = typeof path === 'string' ? path.trim() : '';
+        if (!value.startsWith('/')) {
+          throw new Error('path must be a same-origin absolute path');
+        }
+
+        const url = new URL(value, window.location.origin);
+        if (url.origin !== window.location.origin) {
+          throw new Error('cross-origin navigation is not allowed');
+        }
+
+        window.location.assign(url.toString());
+        return { ok: true, url: url.toString() };
+      },
+    },
+    {
+      name: 'get_composio_tool_schema',
+      description: 'Fetch the published input and output schema for a Composio tool slug.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          toolSlug: {
+            type: 'string',
+            description: 'The Composio tool slug, for example GMAIL_SEND_EMAIL.',
+          },
+          version: {
+            type: 'string',
+            description: 'Optional toolkit version. Defaults to latest.',
+          },
+        },
+        required: ['toolSlug'],
+        additionalProperties: false,
+      },
+      execute: async ({ toolSlug, version }) => {
+        const slug = typeof toolSlug === 'string' ? toolSlug.trim() : '';
+        const toolVersion = typeof version === 'string' && version.trim() ? version.trim() : 'latest';
+
+        if (!slug) {
+          throw new Error('toolSlug is required');
+        }
+
+        const response = await fetch(
+          `/api/tools/${encodeURIComponent(slug)}?version=${encodeURIComponent(toolVersion)}`
+        );
+
+        if (!response.ok) {
+          throw new Error(`tool schema lookup failed with status ${response.status}`);
+        }
+
+        return await response.json();
+      },
+    },
+  ];
+}
+
+export function WebMCPProvider() {
+  useEffect(() => {
+    const provideContext = navigator.modelContext?.provideContext;
+    if (typeof provideContext !== 'function') {
+      return;
+    }
+
+    void Promise.resolve(provideContext({ tools: buildTools() })).catch((error) => {
+      console.warn('WebMCP registration failed', error);
+    });
+  }, []);
+
+  return null;
+}

--- a/docs/lib/agent-discovery.ts
+++ b/docs/lib/agent-discovery.ts
@@ -1,0 +1,44 @@
+export const DOCS_BASE_URL = 'https://docs.composio.dev';
+export const API_V31_BASE_URL = 'https://backend.composio.dev/api/v3.1';
+export const API_V3_BASE_URL = 'https://backend.composio.dev/api/v3';
+export const API_REFERENCE_URL = `${DOCS_BASE_URL}/reference/api-reference`;
+export const API_V31_SPEC_URL = `${DOCS_BASE_URL}/openapi.json`;
+export const API_V3_SPEC_URL = `${DOCS_BASE_URL}/openapi-v3.json`;
+export const API_HEALTH_URL = `${DOCS_BASE_URL}/api/health`;
+export const AUTH_ISSUER = 'https://backend.composio.dev/api/v3/auth/dash';
+export const AUTHORIZATION_SERVER_METADATA_URL =
+  'https://backend.composio.dev/.well-known/oauth-authorization-server';
+export const AUTHORIZATION_ENDPOINT = `${AUTH_ISSUER}/oauth2/authorize`;
+export const TOKEN_ENDPOINT = `${AUTH_ISSUER}/oauth2/token`;
+export const JWKS_URI = `${AUTH_ISSUER}/jwks`;
+export const USERINFO_ENDPOINT = `${AUTH_ISSUER}/oauth2/userinfo`;
+export const REGISTRATION_ENDPOINT = `${AUTH_ISSUER}/oauth2/register`;
+export const INTROSPECTION_ENDPOINT = `${AUTH_ISSUER}/oauth2/introspect`;
+export const REVOCATION_ENDPOINT = `${AUTH_ISSUER}/oauth2/revoke`;
+export const END_SESSION_ENDPOINT = `${AUTH_ISSUER}/oauth2/end-session`;
+export const AUTH_SCOPES = ['openid', 'profile', 'email', 'offline_access'] as const;
+export const AGENT_SKILLS_SCHEMA =
+  'https://schemas.agentskills.io/discovery/0.2.0/schema.json';
+
+export const agentSkills = [
+  {
+    name: 'api-discovery',
+    description:
+      'Discover the Composio REST API through the API catalog, OpenAPI descriptions, and API reference docs.',
+  },
+  {
+    name: 'oauth-authentication',
+    description:
+      'Discover how Composio documents OAuth and OIDC authentication metadata for browser and agent clients.',
+  },
+  {
+    name: 'mcp-setup',
+    description:
+      'Understand how to obtain and install a Composio MCP endpoint for a user or session-specific integration.',
+  },
+  {
+    name: 'docs-navigation',
+    description:
+      'Search the Composio docs site, open reference pages, and retrieve tool schemas from the browser surface.',
+  },
+] as const;

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -25,6 +25,38 @@ const config = {
       { source: '/:path*.mdx', destination: '/llms.mdx/:path*' },
     ];
   },
+  async headers() {
+    const discoveryLinks = [
+      '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"',
+      '</openapi.json>; rel="service-desc"; type="application/vnd.oai.openapi+json;version=3.1"',
+      '</reference/api-reference>; rel="service-doc"; type="text/html"',
+      '</.well-known/agent-skills/index.json>; rel="describedby"; type="application/json"',
+      '</.well-known/mcp/server-card.json>; rel="describedby"; type="application/json"',
+      '</.well-known/openid-configuration>; rel="describedby"; type="application/json"',
+      '</.well-known/oauth-protected-resource>; rel="describedby"; type="application/json"',
+    ].join(', ');
+
+    return [
+      {
+        source: '/',
+        headers: [
+          {
+            key: 'Link',
+            value: discoveryLinks,
+          },
+        ],
+      },
+      {
+        source: '/docs',
+        headers: [
+          {
+            key: 'Link',
+            value: discoveryLinks,
+          },
+        ],
+      },
+    ];
+  },
   async redirects() {
     return [
       {

--- a/docs/public/.well-known/agent-skills/api-discovery/SKILL.md
+++ b/docs/public/.well-known/agent-skills/api-discovery/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: api-discovery
+description: Discover the Composio REST API through the API catalog, OpenAPI descriptions, and API reference docs.
+---
+
+# API Discovery
+
+Use this skill when you need to understand the Composio API surface without guessing endpoints.
+
+## Entry points
+
+- Read `https://docs.composio.dev/.well-known/api-catalog` first.
+- Prefer the v3.1 OpenAPI description at `https://docs.composio.dev/openapi.json`.
+- Use the human-readable reference at `https://docs.composio.dev/reference/api-reference` for examples and endpoint context.
+
+## Guidance
+
+- Treat `https://backend.composio.dev/api/v3.1` as the canonical current REST API base URL.
+- Fall back to `https://docs.composio.dev/openapi-v3.json` only when you need the legacy v3 schema.
+- Use `https://docs.composio.dev/api/health` to verify that the discovery surface is healthy before relying on it.

--- a/docs/public/.well-known/agent-skills/docs-navigation/SKILL.md
+++ b/docs/public/.well-known/agent-skills/docs-navigation/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: docs-navigation
+description: Search the Composio docs site, open reference pages, and retrieve tool schemas from the browser surface.
+---
+
+# Docs Navigation
+
+Use this skill when you need to work with the Composio documentation site as an interactive tool surface.
+
+## Entry points
+
+- Search API: `https://docs.composio.dev/api/search`
+- Tool schema endpoint: `https://docs.composio.dev/api/tools/{TOOL_SLUG}`
+- Markdown docs index: `https://docs.composio.dev/llms.txt`
+
+## Guidance
+
+- Search docs first when you know the concept but not the exact page path.
+- Use `/api/tools/{TOOL_SLUG}` when you need only input and output schemas for a specific tool.
+- Prefer `.md` endpoints and `llms.txt` when you need plain text documentation for agent consumption.

--- a/docs/public/.well-known/agent-skills/mcp-setup/SKILL.md
+++ b/docs/public/.well-known/agent-skills/mcp-setup/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: mcp-setup
+description: Understand how to obtain and install a Composio MCP endpoint for a user or session-specific integration.
+---
+
+# MCP Setup
+
+Use this skill when you need to connect an MCP-compatible client to Composio.
+
+## Entry points
+
+- MCP Server Card: `https://docs.composio.dev/.well-known/mcp/server-card.json`
+- Session configuration docs: `https://docs.composio.dev/docs/configuring-sessions`
+- Connect flow: `https://dashboard.composio.dev/~/org/connect`
+
+## Guidance
+
+- Treat MCP endpoints as user-specific or session-specific resources.
+- Use the server card for capability discovery, but follow the install URL to obtain a concrete endpoint before attempting a connection.
+- Prefer the documented `backend.composio.dev` session-based MCP URL pattern over deprecated `mcp.composio.dev` endpoints.

--- a/docs/public/.well-known/agent-skills/oauth-authentication/SKILL.md
+++ b/docs/public/.well-known/agent-skills/oauth-authentication/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: oauth-authentication
+description: Discover how Composio documents OAuth and OIDC authentication metadata for browser and agent clients.
+---
+
+# OAuth Authentication
+
+Use this skill when you need machine-readable authentication metadata for Composio.
+
+## Entry points
+
+- Authorization server metadata: `https://docs.composio.dev/.well-known/oauth-authorization-server`
+- OpenID Connect discovery metadata: `https://docs.composio.dev/.well-known/openid-configuration`
+- Protected resource metadata: `https://docs.composio.dev/.well-known/oauth-protected-resource`
+
+## Guidance
+
+- Use the issuer published in the metadata instead of inferring it from docs prose.
+- Read `authorization_endpoint`, `token_endpoint`, and `jwks_uri` from discovery metadata rather than hardcoding them.
+- Use `resource_documentation` to jump to the human-readable authentication guide when you need product context.

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,6 +1,12 @@
 # Composio Docs - https://docs.composio.dev
+#
+# The Content-Signal directive declares how automated systems may use site content:
+# - search: search indexing and search result snippets
+# - ai-input: retrieval or grounding input for AI-generated answers
+# - ai-train: model training or fine-tuning
 
 User-agent: *
+Content-Signal: ai-train=no, search=yes, ai-input=yes
 Allow: /
 
 # Sitemaps

--- a/docs/tests/integration/agent-discovery.test.ts
+++ b/docs/tests/integration/agent-discovery.test.ts
@@ -1,0 +1,77 @@
+import { describe, test, expect } from "bun:test";
+import { fetchNoRedirect, fetchPage } from "./helpers";
+
+describe("Agent discovery headers", () => {
+  test("homepage redirect exposes Link headers", async () => {
+    const res = await fetchNoRedirect("/");
+    expect(res.status).toBe(307);
+
+    const link = res.headers.get("link") || "";
+    expect(link).toContain('rel="api-catalog"');
+    expect(link).toContain('rel="service-desc"');
+    expect(link).toContain('rel="service-doc"');
+  });
+
+  test("docs home exposes Link headers", async () => {
+    const res = await fetchPage("/docs");
+    expect(res.status).toBe(200);
+
+    const link = res.headers.get("link") || "";
+    expect(link).toContain("/.well-known/api-catalog");
+    expect(link).toContain("/.well-known/mcp/server-card.json");
+  });
+});
+
+describe("Agent discovery endpoints", () => {
+  test("api catalog returns application/linkset+json", async () => {
+    const res = await fetchPage("/.well-known/api-catalog");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/linkset+json");
+
+    const data = await res.json();
+    expect(Array.isArray(data.linkset)).toBe(true);
+    expect(data.linkset.length).toBeGreaterThan(0);
+  });
+
+  test("openid configuration exposes issuer and endpoints", async () => {
+    const res = await fetchPage("/.well-known/openid-configuration");
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(data).toHaveProperty("issuer");
+    expect(data).toHaveProperty("authorization_endpoint");
+    expect(data).toHaveProperty("token_endpoint");
+    expect(data).toHaveProperty("jwks_uri");
+  });
+
+  test("oauth protected resource metadata exposes auth servers", async () => {
+    const res = await fetchPage("/.well-known/oauth-protected-resource");
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(Array.isArray(data.authorization_servers)).toBe(true);
+    expect(data.authorization_servers.length).toBeGreaterThan(0);
+  });
+
+  test("mcp server card publishes nested metadata", async () => {
+    const res = await fetchPage("/.well-known/mcp/server-card.json");
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(data).toHaveProperty("serverInfo.name");
+    expect(data).toHaveProperty("serverInfo.version");
+    expect(data).toHaveProperty("transport.type");
+    expect(data).toHaveProperty("capabilities.tools");
+  });
+
+  test("agent skills index publishes digests", async () => {
+    const res = await fetchPage("/.well-known/agent-skills/index.json");
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(data.$schema).toContain("agentskills.io");
+    expect(Array.isArray(data.skills)).toBe(true);
+    expect(data.skills.length).toBeGreaterThan(0);
+    expect(data.skills[0].digest).toContain("sha256:");
+  });
+});

--- a/docs/tests/static/agent-discovery.test.ts
+++ b/docs/tests/static/agent-discovery.test.ts
@@ -1,0 +1,27 @@
+import { describe, test, expect } from "bun:test";
+import { access, readFile } from "fs/promises";
+import { constants } from "fs";
+import { join } from "path";
+
+const PUBLIC_DIR = join(import.meta.dir, "../../public");
+
+describe("Agent discovery static assets", () => {
+  test("robots.txt declares Content-Signal preferences", async () => {
+    const robots = await readFile(join(PUBLIC_DIR, "robots.txt"), "utf-8");
+    expect(robots).toContain("Content-Signal: ai-train=no, search=yes, ai-input=yes");
+  });
+
+  test("agent skill markdown artifacts exist", async () => {
+    const skillNames = [
+      "api-discovery",
+      "oauth-authentication",
+      "mcp-setup",
+      "docs-navigation",
+    ];
+
+    for (const name of skillNames) {
+      const filePath = join(PUBLIC_DIR, ".well-known", "agent-skills", name, "SKILL.md");
+      await expect(access(filePath, constants.R_OK)).resolves.toBeNull();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Added machine-readable discovery endpoints for API catalog, MCP server metadata, OAuth/OIDC metadata, and protected resource metadata.
- Published `.well-known/agent-skills` artifacts and discovery headers so agents can find docs, schemas, and setup guidance more reliably.
- Added a health endpoint plus integration and static tests to validate the new discovery surface.
- Registered a lightweight browser-side WebMCP provider for docs search, page navigation, and tool schema lookup.

## Testing
- `bun test docs/tests/integration/agent-discovery.test.ts`
- `bun test docs/tests/static/agent-discovery.test.ts`
- Not run: full repository test suite
- Not run: production build verification