### PR TITLE
docs: update generic v3 API references to v3.1

### DIFF
--- a/docs/content/docs/auth-configuration/custom-auth-configs.mdx
+++ b/docs/content/docs/auth-configuration/custom-auth-configs.mdx
@@ -78,7 +78,7 @@ Examples for Google and GitHub:
 When creating your OAuth app, make sure to configure the Authorized Redirect URI to point to the Composio callback URL below:
 
 ```
-https://backend.composio.dev/api/v3/toolkits/auth/callback
+https://backend.composio.dev/api/v3.1/toolkits/auth/callback
 ```
 </Step>
 

--- a/docs/content/docs/auth-configuration/programmatic-auth-configs.mdx
+++ b/docs/content/docs/auth-configuration/programmatic-auth-configs.mdx
@@ -76,7 +76,7 @@ auth_config = composio.auth_configs.create(
         "credentials": {
             "client_id": "1234567890",
             "client_secret": "1234567890",
-            "oauth_redirect_uri": "https://backend.composio.dev/api/v3/toolkits/auth/callback",
+            "oauth_redirect_uri": "https://backend.composio.dev/api/v3.1/toolkits/auth/callback",
         },
     },
 )
@@ -94,7 +94,7 @@ const authConfig = await composio.authConfigs.create("NOTION", {
     credentials: {
         client_id: "1234567890",
         client_secret: "1234567890",
-        oauth_redirect_uri: "https://backend.composio.dev/api/v3/toolkits/auth/callback",
+        oauth_redirect_uri: "https://backend.composio.dev/api/v3.1/toolkits/auth/callback",
     },
     authScheme: "OAUTH2",
 });
@@ -119,7 +119,7 @@ The **authorized redirect URI** is the URI that captures the OAuth code that is 
 While doing so, you must ensure to set the **authorized redirect URI** in the OAuth configuration to:
 
 ```
-https://backend.composio.dev/api/v3/toolkits/auth/callback
+https://backend.composio.dev/api/v3.1/toolkits/auth/callback
 ```
 
 <Tabs items={['GitHub', 'Google']}>

--- a/docs/content/docs/auth-configuration/white-labeling.mdx
+++ b/docs/content/docs/auth-configuration/white-labeling.mdx
@@ -56,7 +56,7 @@ Only white-label toolkits where users see a consent screen (Google, GitHub, Slac
 Register a new OAuth app with the toolkit. Set the callback URL to:
 
 ```
-https://backend.composio.dev/api/v3/toolkits/auth/callback
+https://backend.composio.dev/api/v3.1/toolkits/auth/callback
 ```
 
 You'll get a **Client ID** and **Client Secret**.
@@ -214,7 +214,7 @@ app = FastAPI()
 
 @app.get("/api/composio-redirect")
 def composio_redirect(request: Request):
-    composio_url = "https://backend.composio.dev/api/v3/toolkits/auth/callback"
+    composio_url = "https://backend.composio.dev/api/v3.1/toolkits/auth/callback"
     return RedirectResponse(url=f"{composio_url}?{request.url.query}")
 ```
 </Tab>
@@ -224,7 +224,7 @@ def composio_redirect(request: Request):
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  const composioUrl = "https://backend.composio.dev/api/v3/toolkits/auth/callback";
+  const composioUrl = "https://backend.composio.dev/api/v3.1/toolkits/auth/callback";
   const params = new URLSearchParams(req.query as Record<string, string>);
   res.redirect(302, `${composioUrl}?${params.toString()}`);
 }

--- a/docs/content/docs/custom-app-vs-managed-app.mdx
+++ b/docs/content/docs/custom-app-vs-managed-app.mdx
@@ -35,7 +35,7 @@ Bring your own credentials when any of these apply:
 Go to the toolkit's developer portal and register a new OAuth app. You'll need to set the authorized redirect URI to:
 
 ```
-https://backend.composio.dev/api/v3/toolkits/auth/callback
+https://backend.composio.dev/api/v3.1/toolkits/auth/callback
 ```
 
 Once registered, copy your **Client ID** and **Client Secret**.

--- a/docs/content/docs/importing-existing-connections.mdx
+++ b/docs/content/docs/importing-existing-connections.mdx
@@ -205,7 +205,7 @@ await composio.connectedAccounts.update('ca_your_connection_id', {
 </Tab>
 <Tab value="curl">
 ```bash
-curl -X PATCH https://backend.composio.dev/api/v3/connected_accounts/ca_xxx \
+curl -X PATCH https://backend.composio.dev/api/v3.1/connected_accounts/ca_xxx \
   -H 'x-api-key: YOUR_API_KEY' \
   -H 'Content-Type: application/json' \
   -d '{"connection":{"state":{"authScheme":"BEARER_TOKEN","val":{"token":"new-access-token"}}}}'
@@ -245,7 +245,7 @@ await composio.connectedAccounts.update('ca_your_connection_id', {
 </Tab>
 <Tab value="curl">
 ```bash
-curl -X PATCH https://backend.composio.dev/api/v3/connected_accounts/ca_xxx \
+curl -X PATCH https://backend.composio.dev/api/v3.1/connected_accounts/ca_xxx \
   -H 'x-api-key: YOUR_API_KEY' \
   -H 'Content-Type: application/json' \
   -d '{"connection":{"state":{"authScheme":"API_KEY","val":{"generic_api_key":"new-api-key"}}}}'
@@ -285,7 +285,7 @@ await composio.connectedAccounts.update('ca_your_connection_id', {
 </Tab>
 <Tab value="curl">
 ```bash
-curl -X PATCH https://backend.composio.dev/api/v3/connected_accounts/ca_xxx \
+curl -X PATCH https://backend.composio.dev/api/v3.1/connected_accounts/ca_xxx \
   -H 'x-api-key: YOUR_API_KEY' \
   -H 'Content-Type: application/json' \
   -d '{"connection":{"state":{"authScheme":"BASIC","val":{"username":"user@example.com","password":"new-password"}}}}'

--- a/docs/content/docs/troubleshooting/mcp.mdx
+++ b/docs/content/docs/troubleshooting/mcp.mdx
@@ -13,7 +13,7 @@ This error occurs when MCP cannot find a valid connected account for authenticat
   - Account status is `ACTIVE` (not deleted)
   - Account belongs to the same auth config used to create the MCP server. MCP servers only resolve connected accounts through their bound auth configs, so connections under a different auth config will not be found.
 
-To fix a mismatched auth config, update the MCP server's `auth_config_ids` using the [`PATCH /api/v3/mcp/{id}`](/reference/api-reference/mcp/patchMcpById) endpoint.
+To fix a mismatched auth config, update the MCP server's `auth_config_ids` using the [`PATCH /api/v3.1/mcp/{id}`](/reference/api-reference/mcp/patchMcpById) endpoint.
 
 Learn more: [Single Toolkit MCP](/docs/single-toolkit-mcp)
 

--- a/docs/content/docs/white-labeling-authentication.mdx
+++ b/docs/content/docs/white-labeling-authentication.mdx
@@ -50,7 +50,7 @@ Only white-label toolkits where users see a consent screen (Google, GitHub, Slac
 Register a new OAuth app with the toolkit. Set the callback URL to:
 
 ```
-https://backend.composio.dev/api/v3/toolkits/auth/callback
+https://backend.composio.dev/api/v3.1/toolkits/auth/callback
 ```
 
 You'll get a **Client ID** and **Client Secret**.
@@ -193,7 +193,7 @@ app = FastAPI()
 
 @app.get("/api/composio-redirect")
 def composio_redirect(request: Request):
-    composio_url = "https://backend.composio.dev/api/v3/toolkits/auth/callback"
+    composio_url = "https://backend.composio.dev/api/v3.1/toolkits/auth/callback"
     return RedirectResponse(url=f"{composio_url}?{request.url.query}")
 ```
 </Tab>
@@ -203,7 +203,7 @@ def composio_redirect(request: Request):
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  const composioUrl = "https://backend.composio.dev/api/v3/toolkits/auth/callback";
+  const composioUrl = "https://backend.composio.dev/api/v3.1/toolkits/auth/callback";
   const params = new URLSearchParams(req.query as Record<string, string>);
   res.redirect(302, `${composioUrl}?${params.toString()}`);
 }

--- a/docs/content/toolkits/faq/slack.md
+++ b/docs/content/toolkits/faq/slack.md
@@ -24,7 +24,7 @@ Update the redirect URL in your Slack App under OAuth & Permissions → Redirect
 
 ## How do I set up Slack event webhooks?
 
-Enable Event Subscriptions in your Slack app. Set the Request URL to `https://backend.composio.dev/api/v3/trigger_instances/slack/default/handle`. Add events (e.g., `reaction_added`) to Subscribe to Bot Events and save. If using the Slackbot integration, add the bot to the channels you want to monitor.
+Enable Event Subscriptions in your Slack app. Set the Request URL to `https://backend.composio.dev/api/v3.1/trigger_instances/slack/default/handle`. Add events (e.g., `reaction_added`) to Subscribe to Bot Events and save. If using the Slackbot integration, add the bot to the channels you want to monitor.
 
 ## Why am I getting scope errors on Slack?
 


### PR DESCRIPTION
# Description

Updates generic feature documentation to reference `/api/v3.1/` instead of `/api/v3/` so users are pointed at the current default API version. Explicit v3 references (changelog entries, `reference/v3/*` pages, the v3 → v3.1 explainer, and the SDK migration guide) are intentionally left untouched.

**Files updated:**

- `docs/content/docs/auth-configuration/custom-auth-configs.mdx` — OAuth callback URL
- `docs/content/docs/auth-configuration/programmatic-auth-configs.mdx` — OAuth callback URL (3 occurrences)
- `docs/content/docs/auth-configuration/white-labeling.mdx` — OAuth callback URL + FastAPI/Next.js proxy examples
- `docs/content/docs/custom-app-vs-managed-app.mdx` — OAuth callback URL
- `docs/content/docs/importing-existing-connections.mdx` — `PATCH /api/v3/connected_accounts/ca_xxx` cURL examples (3 occurrences)
- `docs/content/docs/troubleshooting/mcp.mdx` — `PATCH /api/v3/mcp/{id}` endpoint reference
- `docs/content/docs/white-labeling-authentication.mdx` — OAuth callback URL + proxy examples (3 occurrences)
- `docs/content/toolkits/faq/slack.md` — Slack event webhook Request URL

**Intentionally kept as v3:**

- `https://backend.composio.dev/api/v3/s/...` shortlink URLs in `white-labeling.mdx` — Apollo returns a hardcoded v3 literal for these shortlinks.
- `/v3/mcp/<UUID>` MCP server URL pattern in `troubleshooting/mcp.mdx` — this is a Next.js App Router path (not an API route covered by the v3.1 proxy rewrite).
- All `content/changelog/*`, `content/reference/v3/*`, `migration-guide/new-sdk.mdx`, and the `04-08-26-v31-api.mdx` v3-vs-v3.1 explainer.

All rewritten paths are already supported by Apollo's v3.1 proxy (non-tool routes rewrite to the same v3 handlers), so behavior is unchanged — this is a pure doc-hygiene update.

# How did I test this PR

- `bun run scripts/validate-links.ts` → `0 errored file, 0 errors`
- `bun run build` → completed successfully, 1375/1375 static pages generated (the `[Toolkits] Failed to fetch ... 401` warnings are unrelated local-env API auth noise)
- `git diff --stat` shows 8 files, +16 / -16 (symmetric replacements only)

Triggered by: rahul.lingala@composio.dev | Source: web
Session: https://zen-api-production-4c98.up.railway.app/dashboard/#/chat/zen-89ea2024437f