### PR TITLE
docs: update CLAUDE.md for composio SDK

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,404 +1,121 @@
-# CLAUDE.md
+# Composio SDK
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Monorepo containing the TypeScript SDK (primary), Python SDK, CLI, and docs site.
 
-## Overview
+> For documentation tasks, see `docs/CLAUDE.md`.
+> For CLI work, see `ts/packages/cli/CLAUDE.md` (aliased from `AGENTS.md`).
 
-This is the Composio SDK v3 repository containing both TypeScript and Python SDKs. The main development focus is on the TypeScript SDK located in `/ts/` directory. The project uses a monorepo structure with multiple packages and examples.
+## Default Branch
 
-## Memories and Notes
+**Default branch is `next`** (not `master` or `main`). Base all branches and PRs off `next`.
 
-- For documentation tasks, refer to `docs/CLAUDE.md`
+## Repository Structure
 
-## Effect.ts Reference Source
-
-The CLI package (`@composio/cli`) is built on the Effect.ts ecosystem. A local copy of the Effect source code is available as a git submodule:
-
-- **Location:** `ts/vendor/effect/`
-- **Repo:** [Effect-TS/effect](https://github.com/Effect-TS/effect)
-- **Branch:** `main`
-
-When working on CLI code, reference the Effect source for accurate patterns:
-- `ts/vendor/effect/packages/effect/src/` — core Effect runtime
-- `ts/vendor/effect/packages/cli/src/` — @effect/cli (Command, Options, Args)
-- `ts/vendor/effect/packages/platform/src/` — @effect/platform (FileSystem, Terminal)
-
-**Important:** The submodule is for **read-only reference only**. Do not modify files in `ts/vendor/`. The CLI's actual dependencies come from npm via `pnpm install`.
-
-## Clack Reference Source
-
-The CLI uses [`@clack/prompts`](https://github.com/bombshell-dev/clack) for interactive terminal UI. A local copy of the Clack source code is available as a git submodule:
-
-- **Location:** `ts/vendor/clack/`
-- **Repo:** [bombshell-dev/clack](https://github.com/bombshell-dev/clack)
-
-When working on CLI prompts and terminal UI, reference the Clack source for accurate APIs:
-- `ts/vendor/clack/packages/prompts/src/` — `@clack/prompts` (high-level API: text, select, confirm, spinner, etc.)
-- `ts/vendor/clack/packages/core/src/` — `@clack/core` (low-level primitives)
-
-See `ts/packages/cli/AGENTS.md` for detailed Clack usage guidelines.
-
-**Important:** The submodule is for **read-only reference only**. Do not modify files in `ts/vendor/`. The CLI's actual `@clack/prompts` dependency comes from npm via `pnpm install`.
-
-## Common Development Commands
-
-### Build and Development
-```bash
-# Build all packages
-pnpm build
-
-# Build only TypeScript packages  
-pnpm build:packages
-
-# Clean build artifacts
-pnpm clean
-pnpm clean:workspace
-
-# Lint code
-pnpm lint
-pnpm lint:fix
-
-# Format code
-pnpm format
-
-# Run tests
-pnpm test
-```
-
-### Package Management
-```bash
-# Install dependencies
-pnpm install
-
-# Check peer dependencies
-pnpm check:peer-deps
-
-# Update peer dependencies  
-pnpm update:peer-deps
-```
-
-### Creating New Components
-```bash
-# Create a new provider
-pnpm create:provider <provider-name> [--agentic]
-
-# Create a new example
-pnpm create:example <example-name>
-```
-
-### Release Management
-```bash
-# Create changeset for releases
-pnpm changeset
-
-# Version packages
-pnpm changeset:version
-
-# Publish packages
-pnpm changeset:release
-```
-
-## Project Architecture
-
-### Repository Structure
 ```
 composio/
-├── ts/                      # TypeScript SDK (main development)
+├── ts/
 │   ├── packages/
-│   │   ├── core/           # Core SDK functionality
-│   │   ├── providers/      # AI provider integrations (OpenAI, Anthropic, etc.)
-│   │   ├── cli/           # Command-line interface
-│   │   ├── json-schema-to-zod/ # Schema conversion utility
-│   │   └── ts-builders/   # TypeScript code generation utilities
-│   └── examples/          # Usage examples for different providers
-├── python/                # Python SDK
-├── docs/                  # Documentation (Fumadocs)
-└── examples/              # Cross-platform examples
+│   │   ├── core/                 # @composio/core — main SDK (src/composio.ts)
+│   │   ├── cli/                  # @composio/cli — Effect.ts + Bun, ships as binary
+│   │   ├── cli-keyring/          # OS keyring integration for CLI API key storage
+│   │   ├── providers/*/          # @composio/{openai,anthropic,google,langchain,vercel,mastra,...}
+│   │   ├── json-schema-to-zod/   # Schema conversion utility
+│   │   └── ts-builders/          # TypeScript AST code generation (for CLI `generate`)
+│   ├── examples/                 # Per-provider examples (openai, anthropic, langchain, vercel, mcp, ...)
+│   ├── e2e-tests/                # Runtime compat tests: node-*, deno-*, cf-*, cli-*
+│   └── vendor/                   # Read-only git submodules: effect/, clack/ (reference only)
+├── python/
+│   ├── composio/                 # Main package (sdk.py, client, core, types.py)
+│   ├── providers/*/              # openai, anthropic, langchain, langgraph, crewai, google, ...
+│   └── noxfile.py                # Nox automation (fmt, chk, fix, tst, snt)
+├── docs/                         # Fumadocs site (Bun); see docs/CLAUDE.md
+└── plans/                        # In-flight design docs
 ```
 
-### Core Packages
+## TypeScript SDK Commands
 
-**@composio/core** - Main SDK functionality:
-- `src/composio.ts` - Main Composio class
-- `src/models/` - Core models (Tools, Toolkits, ConnectedAccounts, etc.)
-- `src/provider/` - Base provider implementations
-- `src/services/` - Internal services (telemetry, pusher)
-- `src/types/` - TypeScript type definitions
-- `src/utils/` - Utility functions and helpers
+```bash
+pnpm install                    # Install all workspaces
+pnpm build                      # Build everything via Turbo
+pnpm build:packages             # Build only ts/packages/**
+pnpm typecheck                  # Turbo typecheck — REQUIRED after CLI command changes
+pnpm lint / pnpm lint:fix       # ESLint over ts/packages
+pnpm format                     # Prettier
+pnpm test                       # Vitest across packages + validate examples
+pnpm test:e2e:node              # Docker-based Node CJS/ESM compat
+pnpm test:e2e:deno              # Docker-based Deno `npm:` specifier
+pnpm test:e2e:cloudflare        # Cloudflare Workers runtime
+pnpm test:e2e:cli               # CLI binary e2e
 
-**Provider Packages** - AI integrations:
-- `@composio/openai` - OpenAI integration
-- `@composio/anthropic` - Anthropic integration
-- `@composio/google` - Google GenAI integration
-- `@composio/langchain` - LangChain integration
-- `@composio/vercel` - Vercel AI integration
-- `@composio/mastra` - Mastra integration
+pnpm create:provider <name> [--agentic]   # Scaffold new provider
+pnpm create:example <name>                # Scaffold new example
+pnpm check:peer-deps                      # Verify provider peer deps align
+```
 
-### Key Concepts
+Package manager: `pnpm@10.28.0`. Node via `.nvmrc`, Bun via `.bun-version`.
 
-**Tools** - Individual functions that can be executed (e.g., GITHUB_CREATE_REPO, GMAIL_SEND_EMAIL)
+## Python SDK Commands
 
-**Toolkits** - Collections of related tools grouped by service (e.g., github, gmail, slack)
+```bash
+cd python
+make env                        # Create .venv with uv, sync deps, install providers
+source .venv/bin/activate       # REQUIRED before any Python command
+make sync                       # Re-sync deps into existing venv
+make fmt                        # ruff format
+make chk                        # ruff lint + mypy (strict optional)
+nox -s fix                      # Auto-fix lint
+pytest -m core                  # Markers: core, openai, langchain, agno
+```
 
-**Connected Accounts** - User authentication/authorization for external services
+Requires Python >=3.10,<4. Deps managed by `uv`, automation by `nox`.
 
-**Auth Configs** - Configuration for different authentication methods
+## Release Management
 
-**Custom Tools** - User-defined tools with custom logic
+```bash
+pnpm changeset                  # Add a changeset for a PR
+pnpm changeset:version          # Version bump (normally done by bot)
+pnpm changeset:release          # Build + publish to npm
+```
 
-**Providers** - Integrations with AI frameworks (OpenAI, Anthropic, etc.)
-
-**Modifiers** - Middleware to transform tool inputs/outputs
-
-## Development Workflow
-
-### For Tool Development
-1. Tools are auto-generated from OpenAPI specifications
-2. Custom tools can be created using the Custom Tools API
-3. Tool execution happens through the main Composio class
-
-### For Provider Development
-1. Use `pnpm create:provider <name>` to scaffold new providers
-2. Implement required methods: `wrapTool`, `wrapTools`
-3. For agentic providers, also implement execution handlers
-4. Add comprehensive tests and documentation
-
-### Testing
-- Unit tests use Vitest
-- Run tests with `pnpm test`
-- Tests are located in `test/` directories within each package
-- Mock implementations are available in `test/utils/mocks/`
-
-### Code Quality
-- ESLint configuration in `eslint.config.mjs`
-- Prettier for code formatting
-- TypeScript strict mode enabled
-- Comprehensive TSDoc documentation required
-- Husky pre-commit hooks for quality checks
+CLI has its own two-channel release system (beta auto, stable via changeset). See `ts/packages/cli/CLAUDE.md`.
 
 ## Environment Variables
 
-```bash
-COMPOSIO_API_KEY          # Required: Your Composio API key
-COMPOSIO_BASE_URL         # Optional: Custom API base URL
-COMPOSIO_LOG_LEVEL        # Optional: Logging level (silent, error, warn, info, debug)
-COMPOSIO_DISABLE_TELEMETRY # Optional: Set to "true" to disable telemetry
-DEVELOPMENT               # Development mode flag
-CI                       # CI environment flag
+```
+COMPOSIO_API_KEY              # API key (required for most operations)
+COMPOSIO_BASE_URL             # Override API base URL
+COMPOSIO_LOG_LEVEL            # silent | error | warn | info | debug
+COMPOSIO_DISABLE_TELEMETRY    # "true" disables telemetry
+COMPOSIO_CACHE_DIR            # Override CLI cache dir (default ~/.composio/)
+DEBUG_OVERRIDE_VERSION        # CLI debug: pretend to be a specific version
+FORCE_USE_CACHE               # CLI: skip API, use stale cache
+COMPOSIO_TOOLKIT_VERSION_<NAME>  # Pin a toolkit to a specific version
 ```
 
-## Key Files and Locations
+## Reference Submodules (Read-Only)
 
-- **Main SDK Entry**: `ts/packages/core/src/index.ts`
-- **Core Composio Class**: `ts/packages/core/src/composio.ts`
-- **Type Definitions**: `ts/packages/core/src/types/`
-- **Error Classes**: `ts/packages/core/src/errors/`
-- **Examples**: `ts/examples/` and `examples/`
-- **Documentation**: `docs/`
-- **Build Configs**: `turbo.jsonc`, `tsconfig.base.json`, `tsdown.config.base.ts`
-- **E2E Tests**: `ts/e2e-tests/`
+The CLI ecosystem is built on Effect and Clack. Source code is vendored at `ts/vendor/` as submodules for reference — **never modify** these; the actual deps come from npm.
 
-## Maintenance Tasks
+- `ts/vendor/effect/packages/{effect,cli,platform}/src/` — Effect runtime, @effect/cli, @effect/platform
+- `ts/vendor/clack/packages/{prompts,core}/src/` — @clack/prompts, @clack/core
 
-### When Updating GitHub Actions
+## Gotchas
 
-When modifying files in `.github/workflows/`, update the "Prerequisites" section in `ts/docs/internal/release.md` with the current tool versions:
+- **PRs target `next`**, not `master`. The docs site, changesets, and CLI build pipeline all key off `next`.
+- **Don't modify `ts/vendor/`** — it's submoduled for reference only.
+- **Always activate `python/.venv`** before running any Python command — system Python lacks deps.
+- **TS code blocks in MDX are type-checked at build time** (twoslash). `bun run build` in `docs/` catches these; `bun dev` does not.
+- **CLI typecheck is mandatory** when touching `ts/packages/cli/src/commands/` — run `pnpm typecheck` from repo root.
+- **E2E tests run in Docker** — they are slow and require Docker daemon. Scope to the runtime you changed.
+- **Examples are tutorial code** — reviewed for clarity, not production-readiness. See `docs/CLAUDE.md`.
+- **`ts/packages/cli/CLAUDE.md` and `AGENTS.md` are the same file** — keep them in sync (or symlink if the tooling allows).
 
-- **Node.js**: `cat .nvmrc`
-- **Bun**: `cat .bun-version`
-- **pnpm**: `cat package.json | jq -r .packageManager | cut -d'@' -f2`
+## GitHub Actions Maintenance
 
-## Testing Commands
-
-```bash
-# Run all tests
-pnpm test
-
-# Run tests for core package only
-cd ts/packages/core && pnpm test
-
-# Run tests with UI
-pnpm test:ui
-```
-
-### TypeScript E2E Tests
-
-E2E tests for `@composio/core` are located in `ts/e2e-tests/` and test runtime compatibility across different JavaScript environments.
+When modifying files in `.github/workflows/`, update the "Prerequisites" section in `ts/docs/internal/release.md` with current tool versions:
 
 ```bash
-# Run all e2e tests (Node.js + Deno + Cloudflare)
-pnpm test:e2e
-
-# Run only Node.js e2e tests (CJS/ESM compatibility, runs in Docker)
-pnpm test:e2e:node
-
-# Run only Deno e2e tests (npm: specifier compatibility, runs in Docker)
-pnpm test:e2e:deno
-
-# Run only Cloudflare Workers e2e tests
-pnpm test:e2e:cloudflare
-
-# Run Node.js tests with a specific Node version
-COMPOSIO_E2E_NODE_VERSION=22.12.0 pnpm test:e2e:node
-
-# Run Deno tests with a specific Deno version
-COMPOSIO_E2E_DENO_VERSION=2.6.7 pnpm test:e2e:deno
-```
-
-**E2E Test Structure:**
-```
-ts/e2e-tests/
-├── _utils/                    # Shared Docker infrastructure
-├── runtimes/
-│   ├── node/                  # Node.js runtime tests
-│   │   ├── cjs-basic/         # CommonJS compatibility
-│   │   └── esm-basic/         # ESM compatibility
-│   ├── deno/                  # Deno runtime tests
-│   │   └── esm-basic/         # npm: specifier compatibility
-│   └── cloudflare/            # Cloudflare runtime tests
-│       └── cf-workers-basic/  # Cloudflare Workers tests
-└── README.md                  # E2E test documentation
-```
-
-> **Note:** When adding new e2e tests, update `ts/e2e-tests/README.md` with the new test information.
-
-## Common Patterns
-
-### Tool Execution
-```typescript
-const composio = new Composio({ apiKey: 'your-key' });
-const result = await composio.tools.execute('TOOL_NAME', {
-  userId: 'user-id',
-  arguments: { /* tool args */ }
-});
-```
-
-### Provider Integration
-```typescript
-import { OpenAIProvider } from '@composio/openai';
-const provider = new OpenAIProvider({ apiKey: 'openai-key' });
-const tools = await composio.tools.get('user-id', { toolkits: ['github'] });
-const wrappedTools = provider.wrapTools(tools);
-```
-
-### Custom Tool Creation
-```typescript
-import { z } from 'zod';
-
-const customTool = await composio.tools.createCustomTool({
-  name: 'My Tool',
-  description: 'Tool description',
-  slug: 'MY_TOOL',
-  inputParams: z.object({
-    param: z.string().describe('Parameter description')
-  }),
-  execute: async (input) => {
-    // Implementation
-    return {
-      data: { result: input.param },
-      error: null,
-      successful: true
-    };
-  }
-});
-```
-
-This monorepo uses pnpm workspaces and Turbo for efficient builds and development.
-
-## Python SDK Development
-
-### Setup
-The Python SDK is located in the `/python/` directory and uses `uv` for dependency management and `nox` for automation.
-
-### Environment Setup
-```bash
-# Create and setup Python development environment
-cd python
-make env
-source .venv/bin/activate
-```
-
-### Python Development Commands
-```bash
-# Setup environment (creates virtual env with all dependencies)
-make env
-
-# Sync dependencies (when in an existing environment)
-make sync
-
-# Install provider packages
-make provider
-
-# Format code using ruff
-make fmt
-# Or directly: nox -s fmt
-
-# Check linting and type issues
-make chk
-# Or directly: nox -s chk
-
-# Fix linting issues
-nox -s fix
-
-# Run tests (requires implementing tst session)
-make tst
-# Or directly: nox -s tst
-
-# Run sanity tests (requires implementing snt session)  
-make snt
-# Or directly: nox -s snt
-
-# Clean build artifacts
-make clean-build
-
-# Bump version
-make bump
-
-# Build packages
-make build
-```
-
-### Python Project Structure
-```
-python/
-├── composio/           # Main SDK package
-├── providers/          # Provider implementations
-├── tests/             # Test suite
-├── examples/          # Usage examples
-├── scripts/           # Development scripts
-├── config/            # Configuration files
-│   ├── pytest.ini     # Pytest configuration
-│   ├── mypy.ini       # MyPy type checking config
-│   ├── ruff.toml     # Ruff linter/formatter config
-│   └── codecov.yml   # Code coverage config
-├── Makefile          # Development shortcuts
-├── noxfile.py        # Nox automation sessions
-└── pyproject.toml    # Project configuration
-```
-
-### Python Code Quality
-- **Formatter**: Ruff (Black-compatible, 88 char line length)
-- **Linter**: Ruff with custom configuration
-- **Type Checker**: mypy with strict optional typing
-- **Test Framework**: pytest with custom markers (core, openai, langchain, agno)
-- **Python Version**: >=3.10, <4
-- **Dependency Managers**: uv
-
-### Python Testing
-```bash
-# Run tests with pytest markers
-pytest -m core        # Run core tests only
-pytest -m openai      # Run OpenAI provider tests
-pytest -m langchain   # Run LangChain provider tests
-pytest -m agno       # Run Agno provider tests
-```
-
-### Python Package Dependencies
-- Core: `pysher`, `pydantic>=2.6.4`, `composio-client==1.4.0`, `typing-extensions>=4.0.0`, `openai`
-- Dev: `nox`, `pytest`, `ruff`, `langchain_openai`, `fastapi`, `twine`, `click`, `semver`
-
-### Python Environment Variables
-Same as TypeScript SDK, with additional:
-```bash
-OPENAI_API_KEY    # Required for OpenAI provider examples
+cat .nvmrc                                        # Node.js
+cat .bun-version                                  # Bun
+jq -r .packageManager package.json | cut -d'@' -f2  # pnpm
 ```

--- a/ts/packages/cli/AGENTS.md
+++ b/ts/packages/cli/AGENTS.md
@@ -1,379 +1,180 @@
-# AGENTS.md
+# @composio/cli — Agent Instructions
 
-Instructions for AI agents working on `@composio/cli`.
+> This file is mirrored to `AGENTS.md` — keep both in sync.
 
-## Architecture Overview
-
-The CLI is built on the **Effect.ts ecosystem** and runs on **Bun**. It follows a service-oriented architecture with dependency injection via Effect layers, generator-based control flow (`Effect.gen`), and structured error handling.
+Built on the **Effect.ts ecosystem**, runs on **Bun**, ships as a standalone binary. Service-oriented with dependency injection via Effect layers, generator control flow (`Effect.gen`), and structured error capture.
 
 ## Required Checks
 
-When you touch CLI commands (anything under `ts/packages/cli/src/commands/`), you must run `pnpm typecheck` from the repo root. If it fails, fix the issues before proceeding.
+When touching anything under `src/commands/`, `src/services/`, `src/effects/`, or `src/cli-main.ts`:
 
-### Entry Point
+```bash
+pnpm typecheck        # From REPO ROOT (turbo-scoped). MUST pass before commit.
+pnpm --filter @composio/cli test
+pnpm --filter @composio/cli lint
+```
 
-`src/bin.ts` bootstraps the CLI by composing Effect layers and running the root command via `BunRuntime.runMain()`:
+For binary-level smoke tests: `pnpm test:e2e:cli` (Docker-based).
 
-- `CliConfigLive` — @effect/cli behavior (case-sensitive, no auto-correct, no built-ins)
-- `ComposioUserContextLive` — User authentication state from `~/.composio/`
-- `ComposioSessionRepositoryLive` — OAuth2 session management
-- `ComposioToolkitsRepositoryCachedLive` — Cached API client for toolkits/tools
-- `UpgradeBinaryLive` — Self-update from GitHub releases
-- `BunFileSystem.layer`, `BunContext.layer` — Bun runtime integration
+## Entry Points
 
-Errors are captured via the custom `effect-errors/` module, which provides source-mapped stack traces, Effect span timelines, and formatted output.
+- `src/bin.ts` — thin wrapper, delegates to `cli-main.ts`
+- `src/cli-main.ts` — composes Effect layers, runs root command via `BunRuntime.runMain()`
+- `src/commands/index.ts` — `buildRootCommand()` wires every command and subcommand
 
-### Commands (`src/commands/`)
+Core layers composed in `cli-main.ts`:
+- `ComposioCliConfig` / `ComposioCliUserConfigLive` — config sources
+- `ComposioUserContextLive` — auth state (`~/.composio/`)
+- `ComposioSessionRepository`, `ComposioClientSingleton`, `ComposioToolkitsRepository(Cached)` — API clients
+- `TerminalUILive` — Clack-backed UI (see Output Conventions)
+- `TriggersRealtime`, `ToolsExecutorLive`, `ProjectContext`, `ProjectEnvironmentDetector`, `CommandRunner`, `UpgradeBinary`
+- `BunFileSystem.layer`, `BunContext.layer`, `FetchHttpClient.layer`
 
-Each command is declared with `@effect/cli`'s `Command.make()` pattern:
+Errors flow through `effect-errors/` → source-mapped stack traces, span timelines, colored pretty print.
 
-| Command                                                  | Description                                                                           |
-| -------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| `composio version`                                       | Display CLI version                                                                   |
-| `composio whoami`                                        | Show logged-in user's API key                                                         |
-| `composio login [--no-browser] [--no-wait] [--key text] [--user-api-key text] [--org text]` | Login with browser redirect or direct user API key                                    |
-| `composio logout`                                        | Clear stored API key                                                                  |
-| `composio upgrade`                                       | Self-update binary from GitHub releases                                               |
-| `composio generate`                                      | Auto-detect project language, delegate to `ts` or `py`                                |
-| `composio generate ts`                                   | Generate TypeScript type stubs for toolkits/tools/triggers                            |
-| `composio generate py`                                   | Generate Python type stubs                                                            |
-| `composio manage <command>`                              | Manage Composio resources (toolkits, tools, accounts, triggers, logs, orgs, projects) |
+## Commands (`src/commands/`)
 
-Options use `Options.text()`, `Options.boolean()`, `Options.choice()`, `Options.directory()` with Effect Schema validation.
+Top-level `.cmd.ts` files: `version`, `whoami`, `login`, `logout`, `upgrade`, `install`, `init`, `listen`, `proxy`, `run`, `artifacts`, `dev`.
 
-### Services (`src/services/`)
+Subcommand groups (each is a directory):
 
-| Service                            | Purpose                                                                      |
-| ---------------------------------- | ---------------------------------------------------------------------------- |
-| `ComposioUserContext`              | Auth state — reads/writes `~/.composio/user-config.json`, merges env vars    |
-| `ComposioSessionRepository`        | Creates OAuth2 sessions, polls until `linked` state                          |
-| `ComposioToolkitsRepository`       | API client — fetches toolkits, tools, trigger types; validates versions      |
-| `ComposioToolkitsRepositoryCached` | Decorator over base repository with file-based caching and graceful fallback |
-| `NodeOs`                           | OS abstraction (`homedir`, `platform`, `arch`)                               |
-| `EnvLangDetector`                  | Detects project language (TS/Python) from config files and lock files        |
-| `JsPackageManagerDetector`         | Detects npm/pnpm/yarn/bun for helpful install instructions                   |
-| `UpgradeBinary`                    | Fetches latest release from GitHub, downloads and replaces binary            |
+| Group                | Key subcommands                                                |
+| -------------------- | -------------------------------------------------------------- |
+| `auth-configs/`      | list, get, create (manage OAuth/API auth configs)              |
+| `config/`            | config / `config experimental` (toggle experimental features)  |
+| `connected-accounts/`| list, get, link, delete                                        |
+| `connections/`       | `connections list` (new — PR #3206)                            |
+| `generate/`          | `generate`, `generate ts`, `generate py`                       |
+| `logs-cmd/`          | `logs list`, `logs get` — tool execution logs                  |
+| `orgs/`              | Org-level operations                                           |
+| `projects/`          | Project-level operations                                       |
+| `toolkits/`          | list, get                                                      |
+| `tools/`             | list, search, execute (also available at root: `composio execute`) |
+| `triggers/`          | list, get, enable/disable (also at root: `composio triggers`)  |
+| `py/`, `ts/`         | Language-specific generate helpers                             |
 
-### Effects (`src/effects/`)
+Options declared via `Options.text()`, `Options.boolean()`, `Options.choice()`, `Options.directory()` with Effect Schema.
 
-Reusable Effect computations for cross-cutting concerns:
+Root-level help verbosity is handled by `root-help.ts` — supports `--help`, `--help=more`, `--help=all`.
 
-| Effect                         | Purpose                                                               |
-| ------------------------------ | --------------------------------------------------------------------- |
-| `app-config`                   | Reads `COMPOSIO_*` env vars (API_KEY, BASE_URL, CACHE_DIR, etc.)      |
-| `debug-config`                 | Debug overrides (DEBUG_OVERRIDE_VERSION, etc.)                        |
-| `force-config`                 | Force flags (FORCE_USE_CACHE)                                         |
-| `setup-cache-dir`              | Ensures `~/.composio/` directory exists                               |
-| `toolkit-version-overrides`    | Parses `COMPOSIO_TOOLKIT_VERSION_<NAME>=<ver>` env vars               |
-| `validate-toolkit-versions`    | Validates overrides against available API versions                    |
-| `with-log-level`               | Configures logger from CLI flag or env var                            |
-| `find-composio-core-generated` | Locates `@composio/core` in node_modules (handles pnpm virtual store) |
-| `version`                      | Resolves CLI version from package.json                                |
-| `compare-semver`               | Semantic version comparison for upgrade checks                        |
-| `log-metrics`                  | Formats and logs API request count and bytes transferred              |
+## Services (`src/services/`)
 
-### Models (`src/models/`)
+| Service                            | Role                                                          |
+| ---------------------------------- | ------------------------------------------------------------- |
+| `config`                           | Merged config (env → user config → defaults)                  |
+| `cli-user-config`                  | Reads/writes `~/.composio/user-config.json`                   |
+| `user-context`                     | Auth state, API key resolution (now via OS keyring)           |
+| `composio-clients` / `-cached`     | API client + file-cached decorator                            |
+| `composio-error-overrides`         | Friendly messages for common API errors                       |
+| `session-artifacts`                | Tool-router session artifact storage                          |
+| `terminal-ui`                      | Clack-backed UI abstraction (stdout/stderr split, see below)  |
+| `tools-executor`                   | Parallel tool execution with typed input validation           |
+| `tool-input-validation`            | Schema-based argument validation                              |
+| `tool-file-uploads`                | File/URL input normalization                                  |
+| `tool-router-session-connections`  | Preloads custom auth connections into sessions                |
+| `triggers-realtime`                | Live trigger event stream (Pusher-backed, for `composio listen`) |
+| `command-runner` / `command-hints` | Subcommand dispatch + hint graph rendering                    |
+| `command-project`, `project-*`     | Detects project root, language, runtime                       |
+| `env-lang-detector`                | TS vs Python detection from config/lock files                 |
+| `js-package-manager-detector`      | npm / pnpm / yarn / bun detection                             |
+| `upgrade-binary`                   | GitHub release self-update (stable + beta channels)           |
+| `update-check`                     | Background version check                                      |
+| `run-subagent-*`                   | `composio run` subagent runtime (ACP, legacy, output-MCP)     |
+| `run-companion-modules`            | Bundled helper modules for `run` subagent                     |
+| `stdin`, `node-os`, `node-process` | Platform/IO abstractions                                      |
 
-Effect Schema definitions for type-safe serialization:
+`@composio/cli-keyring` (workspace package) backs OS-native keyring storage for the API key (PR #3202 migrated from plaintext).
 
-- `Toolkit` — name, slug, auth_schemes, is_local_toolkit, meta
-- `Tool` — name, slug, available_versions, input/output_parameters, description, tags
-- `TriggerType` — slug, name, description, input/output parameters
-- `UserData` — apiKey, baseURL, webURL (with defaults)
-- `Session` — id, status (pending|linked), retrieved session with api_key
+## Effects (`src/effects/`)
 
-Each model has `fromJSON`/`toJSON` helpers using `JSONTransformSchema()`.
+Cross-cutting Effect computations: `app-config`, `debug-config`, `force-config`, `setup-cache-dir`, `toolkit-version-overrides`, `validate-toolkit-versions`, `with-log-level`, `find-composio-core-generated`, `version`, `compare-semver`, `log-metrics`.
 
-### Code Generation (`src/generation/`)
+## Code Generation (`src/generation/`)
 
-Multi-stage pipeline for `composio generate ts` and `composio generate py`:
+Pipeline for `composio generate {ts,py}`:
 
-1. **Fetch** — Toolkits, tools, trigger types from API (optionally filtered by `--toolkits`)
-2. **Index** — Groups tools/triggers by toolkit prefix into a `ToolkitIndex` map
-3. **Generate** — Builds TypeScript/Python source using `@composio/ts-builders` AST builders
-4. **Transpile** — Optionally converts TS → ESM JS (when writing to @composio/core/generated)
+1. Fetch toolkits/tools/triggers (optional `--toolkits` filter)
+2. Index by toolkit prefix → `ToolkitIndex` map
+3. Generate source via `@composio/ts-builders` AST builders
+4. Optionally transpile TS → ESM JS (writing into `@composio/core/generated`)
 
-Generated output includes toolkit objects, tool/trigger enums, and optionally full type definitions (with `--type-tools`).
+With `--type-tools`, emits full parameter type definitions.
 
-### Error Handling (`src/effect-errors/`)
-
-Custom error capture and formatting system:
-
-- **Capture** — Extracts error chain from Effect's `Cause`, handles interrupts separately
-- **Source maps** — Maps compiled `.mjs` stack traces back to TypeScript source
-- **Spans** — Extracts timing from Effect spans for execution timeline display
-- **Pretty print** — Colored, boxed error output with source context and suggestions
-
-### UI & Output (`src/ui/`)
-
-- `picocolors` and `ansis` for colored terminal output
-- Respects `NO_COLOR` env var
-- `@clack/prompts` symbols (`S_BAR`, `S_BAR_H`, `unicodeOr`) for box-drawing in formatted output
-- Effect's `Console.log()` / `Console.error()` for output
-
-### Configuration (`src/cli-config.ts`, `src/constants.ts`)
-
-- CLI behavior: `showBuiltIns: false`, `autoCorrectLimit: 0`, `isCaseSensitive: true`
-- Prefixes: `COMPOSIO_` for app config, `DEBUG_OVERRIDE_` for debug
-- User config stored in `~/.composio/`
-- Cache files: `toolkits.json`, `tools.json`, `tools-as-enums.json`, `trigger-types.json`
-
-### Effect.ts Patterns
-
-The CLI uses the generator-based syntax throughout:
+## Effect.ts Patterns
 
 ```typescript
 Effect.gen(function* () {
-  const service = yield* ServiceName; // resolve dependency
-  const result = yield* someEffect; // await computation
-  yield* Effect.log('message'); // side effect
+  const svc = yield* ServiceName;
+  const result = yield* someEffect;
+  yield* Effect.log('...');
   return result;
 });
 ```
 
-Key patterns:
-
 - `Effect.all([...], { concurrency: 'unbounded' })` for parallel fetches
-- `Layer.provide()` for dependency composition
-- `Effect.mapError()` / `Effect.catchTag()` for typed error handling
+- `Layer.provide()` for dep composition
+- `Effect.mapError()` / `Effect.catchTag()` for typed errors
 - `Effect.scoped` for resource cleanup
 
-### Key Dependencies
+## Output Conventions (Composable CLI)
 
-| Package                 | Role                                                                |
-| ----------------------- | ------------------------------------------------------------------- |
-| `effect`                | Core runtime, data types, concurrency                               |
-| `@effect/cli`           | Command, Options, Args declaration and parsing                      |
-| `@effect/platform`      | FileSystem, Terminal abstraction                                    |
-| `@effect/platform-bun`  | Bun runtime layer                                                   |
-| `@clack/prompts`        | Terminal UI — prompts, spinners, logs, notes (all output to stderr) |
-| `ansis`, `picocolors`   | Colored output                                                      |
-| `@composio/client`      | Raw Composio API client                                             |
-| `@composio/core`        | Core SDK types and constants                                        |
-| `@composio/ts-builders` | TypeScript AST code generation                                      |
-| `semver`                | Version comparison for upgrades                                     |
-| `open`                  | Opens URLs in browser (login flow)                                  |
-| `decompress`            | Extracts downloaded binaries                                        |
+`TerminalUI` enforces Unix-style stream separation:
 
----
+- **stdout** — data only (`ui.output(value)`)
+- **stderr** — all decoration (Clack intro/outro/spinner/log/note)
 
-## Output Conventions: Composable CLI Output
+Rules:
 
-The CLI follows the Unix convention of separating human-readable decoration from machine-readable data:
+1. `ui.output()` writes to stdout ONLY when piped (`!process.stdout.isTTY`); no-op in interactive mode (human sees decoration instead).
+2. In piped mode, all decoration is suppressed. `composio whoami | pbcopy` gives a clean key.
+3. Action commands (logout, upgrade) produce no stdout.
+4. Data commands (whoami, version, login, generate) call both decoration and `ui.output()`.
+5. Never write data to stderr; never write decoration to stdout.
 
-- **stdout** — data output only (`ui.output()`). This is what scripts and pipes capture.
-- **stderr** — all decoration (Clack spinners, logs, notes, intro/outro). Visible in terminal, invisible in pipes.
+When adding a command, ask: "Should a script capture this value?" Yes → `ui.output()` + decoration. No → decoration only.
 
-### Rules
+## Reference Submodules (Read-Only)
 
-1. **All `TerminalUI` methods except `output()` write to stderr** via Clack's `{ output: process.stderr }` option — but only in interactive mode.
-2. **`ui.output(data)` writes to stdout only when piped** — it checks `process.stdout.isTTY` and is a no-op in interactive terminals (the human already sees the data via decoration on stderr).
-3. **When stdout is piped, ALL decoration is suppressed** — `isInteractive` (`process.stdout.isTTY`) gates every decoration method. Only `ui.output()` writes in piped mode. This keeps `composio whoami | pbcopy` completely silent.
-4. **Action commands** (logout, upgrade) produce no stdout data — their output is purely decorative.
-5. **Data commands** (whoami, version, login, generate) call both decoration (stderr) and `ui.output()` (stdout). In interactive mode, only decoration is visible. In pipes/scripts, only the raw data is captured.
-6. **Never write data to stderr** — decoration methods are for human context only.
-7. **Never write decoration to stdout** — it breaks pipes, `$(...)` captures, and `> file` redirects.
+- `ts/vendor/effect/packages/{effect,cli,platform}/src/` — Effect, @effect/cli, @effect/platform
+- `ts/vendor/clack/packages/{prompts,core}/src/` — @clack/prompts, @clack/core
 
-### Pattern
-
-```typescript
-// Data command (e.g., whoami):
-yield * ui.note(apiKey, 'API Key'); // Decoration → stderr (human sees pretty box)
-yield * ui.output(apiKey); // Data → stdout (scripts capture plain value)
-
-// Action command (e.g., login):
-yield * ui.intro('composio login'); // Decoration → stderr
-yield * ui.log.step('Redirecting'); // Decoration → stderr
-// No ui.output() call — nothing for scripts to capture
-```
-
-### How it works in practice
-
-The CLI checks `process.stdout.isTTY` once at startup to determine the output mode:
-
-- **Interactive** (`stdout` is TTY): decoration visible on stderr, `ui.output()` is a no-op.
-- **Piped** (`stdout` is NOT TTY): decoration suppressed, `ui.output()` writes raw data to stdout.
-
-```bash
-composio whoami              # Pretty box only (interactive)
-composio whoami | pbcopy     # Silent — clipboard gets clean key
-API_KEY=$(composio whoami)   # Silent — variable gets clean key
-composio whoami > file.txt   # Silent — file gets clean key
-
-composio version             # Decorated version (interactive)
-composio version | cat       # Raw version string
-
-composio login               # All decoration visible, browser opens
-composio login 2>/dev/null   # Silent (but still opens browser, polls API)
-```
-
-### Adding new commands
-
-When creating a new command, ask: "Does this command produce a value that scripts should capture?"
-
-- **Yes** → Use `ui.output(value)` for the data, `ui.log.*` / `ui.note()` for context
-- **No** → Use only `ui.log.*` / `ui.note()` / `ui.intro()` / `ui.outro()` — everything goes to stderr automatically
-
----
-
-## Clack Reference Source
-
-The CLI uses [`@clack/prompts`](https://github.com/bombshell-dev/clack) for interactive terminal UI (prompts, spinners, logs, etc.). A local copy of the Clack source code is available as a git submodule:
-
-- **Location:** `ts/vendor/clack/`
-- **Repo:** [bombshell-dev/clack](https://github.com/bombshell-dev/clack)
-
-When working on CLI code that involves terminal UI, reference the Clack source for accurate APIs and patterns:
-
-- `ts/vendor/clack/packages/prompts/src/` — `@clack/prompts` (the high-level API used by this CLI)
-- `ts/vendor/clack/packages/core/src/` — `@clack/core` (low-level primitives underlying prompts)
-
-### Key modules in `@clack/prompts`
-
-| Module                  | Purpose                                                |
-| ----------------------- | ------------------------------------------------------ |
-| `text.ts`               | Text input prompt                                      |
-| `password.ts`           | Password input prompt                                  |
-| `confirm.ts`            | Yes/no confirmation prompt                             |
-| `select.ts`             | Single-select list prompt                              |
-| `multi-select.ts`       | Multi-select list prompt                               |
-| `group-multi-select.ts` | Grouped multi-select prompt                            |
-| `autocomplete.ts`       | Autocomplete/search prompt                             |
-| `spinner.ts`            | Loading spinner                                        |
-| `progress-bar.ts`       | Progress bar                                           |
-| `log.ts`                | Styled log messages                                    |
-| `note.ts`               | Boxed note output                                      |
-| `task.ts`               | Task runner with status                                |
-| `task-log.ts`           | Task with streaming log output                         |
-| `stream.ts`             | Streaming text output                                  |
-| `box.ts`                | Box drawing utility                                    |
-| `messages.ts`           | Intro/outro messages                                   |
-| `common.ts`             | Shared symbols (`S_BAR`, `S_BAR_H`, `unicodeOr`, etc.) |
-
-### Current clack usage in the CLI
-
-The CLI currently imports from `@clack/prompts`:
-
-- `S_BAR`, `S_BAR_H`, `unicodeOr` — Unicode box-drawing symbols for custom formatted output
-
-### Guidelines
-
-- The submodule is for **read-only reference only**. Do not modify files in `ts/vendor/clack/`.
-- The CLI's actual dependency comes from npm (`@clack/prompts` v1.0.1) via `pnpm install`.
-- When adding new interactive prompts or terminal UI, consult the source in `ts/vendor/clack/packages/prompts/src/` for the correct API surface and available options.
-- Prefer `@clack/prompts` (high-level) over `@clack/core` (low-level) unless you need custom prompt behavior.
-
----
-
-## Effect.ts Reference Source
-
-The CLI is built on the Effect.ts ecosystem. A local copy of the Effect source code is available as a git submodule:
-
-- **Location:** `ts/vendor/effect/`
-- **Repo:** [Effect-TS/effect](https://github.com/Effect-TS/effect)
-- **Branch:** `main`
-
-When working on CLI code, reference the Effect source for accurate patterns:
-
-- `ts/vendor/effect/packages/effect/src/` — core Effect runtime
-- `ts/vendor/effect/packages/cli/src/` — @effect/cli (Command, Options, Args)
-- `ts/vendor/effect/packages/platform/src/` — @effect/platform (FileSystem, Terminal)
-
-### Guidelines
-
-- The submodule is for **read-only reference only**. Do not modify files in `ts/vendor/effect/`.
-- The CLI's actual dependencies come from npm via `pnpm install`.
-
----
-
-## CLI Design Guidelines
-
-For principles on how to design CLI interactions (arguments, flags, help text, output, errors, interactivity, config precedence), see:
-
-- **Cursor rules**: `ts/packages/cli/.cursor/rules/cli-design-guidelines.mdc`
-- **Claude skill**: `.claude/skills/create-cli/SKILL.md` (standalone, trimmed for Claude Code context)
-
-Use these guidelines when adding new commands, designing flag interfaces, or making UX decisions for the CLI.
-
----
+Don't modify these; actual deps come from npm. Consult for API shapes when adding prompts/commands.
 
 ## Recording CLI Demos
 
-New commands should have VHS recordings for documentation. The recording script produces SVGs and asciicasts that demonstrate the CLI in action.
+New commands should have VHS recordings:
 
-### Adding Recordings
+1. Add entry to `recordings/recordings.yaml` under the appropriate group
+2. Run `bun scripts/record.ts` (requires `COMPOSIO_API_KEY` + `vhs` on PATH)
 
-1. Add entries to `recordings/recordings.yaml` under the appropriate group
-2. Run `bun scripts/record.ts` (requires `COMPOSIO_API_KEY` and `vhs` on PATH)
-
-### Recording Config
-
-Each entry in `recordings.yaml` accepts:
-
-| Field             | Required | Description                                                                             |
-| ----------------- | -------- | --------------------------------------------------------------------------------------- |
-| `name`            | Yes      | Filename stem (`<name>.svg`, `<name>.ascii`, `<name>.tape`)                             |
-| `command`         | Yes      | Shell command to record                                                                 |
-| `description`     | No       | Comment shown instantly above the command (via VHS `Hide`/`Show`)                       |
-| `sleepAfterEnter` | No       | Wait time after Enter (default: `6s` from `vhs.sleepAfterEnter`)                        |
-| `height`          | No       | `'dynamic'` for two-pass auto-sizing, or a fixed pixel number. Omit for default (750px) |
-
-Use `height: dynamic` for commands with long output (help text, full listings). The recorder probes with 2x height, parses the SVG to measure content, then re-records at the computed height (capped at `vhs.height * 2`).
-
-### Output Structure
-
-```
-recordings/
-├── recordings.yaml                    # Config
-├── tapes/<group>/<name>.tape          # Generated VHS tape files
-├── svgs/<group>/<name>.svg            # SVG recordings
-└── ascii/<group>/<name>.ascii         # Asciicast recordings
-```
-
-### Key Files
-
-- **Config**: `recordings/recordings.yaml`
-- **Script**: `scripts/record.ts` — Bun + Effect.ts, parallel VHS execution
-- **Shared tape**: `recordings/tapes/shared-config.tape` — common VHS settings (auto-generated)
-
----
+Per-entry fields: `name`, `command`, `description` (comment above command), `sleepAfterEnter` (default `6s`), `height` (`'dynamic'` | pixels). Output lands in `recordings/{tapes,svgs,ascii}/<group>/<name>.*`.
 
 ## Release Workflow
 
-CLI releases use a two-channel system: **beta** (automatic) and **stable** (manual promotion).
+Two-channel system.
 
-### Beta Releases (automatic)
+**Beta (automatic):** Every push to `next` touching `ts/packages/cli/**` triggers `.github/workflows/build-cli-binaries.yml`:
+- Finds latest stable `@composio/cli@X.Y.Z`, computes `X.Y.(Z+1)`
+- Builds cross-platform binaries (linux-x64, linux-aarch64, darwin-x64, darwin-aarch64)
+- Publishes GitHub prerelease tagged `@composio/cli@X.Y.(Z+1)-beta.<run_number>`
+- Users install via `composio upgrade --beta`
+- Also triggerable from any branch via `workflow_dispatch` → `build-beta`
 
-Every push to `next` that touches `ts/packages/cli/**` automatically triggers `.github/workflows/build-cli-binaries.yml`, which:
+**Stable (via changeset):**
+1. Create `.changeset/<name>.md` with `"@composio/cli": patch`
+2. Merge into `next`
+3. Changeset bot opens "Release: update version" PR; merge it
+4. Push to `next` with new `package.json` version → stable build (`@composio/cli@X.Y.Z`, `latest`) + npm publish via `ts.release.yml`
 
-1. Finds the latest stable `@composio/cli@X.Y.Z` release
-2. Computes the next patch version (`X.Y.Z+1`)
-3. Builds cross-platform binaries (linux-x64, linux-aarch64, darwin-x64, darwin-aarch64)
-4. Creates a GitHub prerelease tagged `@composio/cli@X.Y.(Z+1)-beta.<run_number>`
+**Manual promote:** `workflow_dispatch` → `promote-stable` with beta tag (e.g. `@composio/cli@0.2.20-beta.42`).
 
-You can also trigger a beta build from **any branch** via `workflow_dispatch` → `build-beta`.
+Key files: `.github/workflows/build-cli-binaries.yml`, `.github/workflows/ts.release.yml`, `.github/workflows/cli.test-installation.yml`, `.changeset/config.json`.
 
-Users install beta releases with `composio upgrade --beta`.
+## CLI Design Guidelines
 
-### Stable Releases (via changeset)
+For flag/argument/help/output UX principles, see:
 
-To promote to a stable release:
+- Cursor rules: `ts/packages/cli/.cursor/rules/cli-design-guidelines.mdc`
+- Claude skill: `.claude/skills/create-cli/SKILL.md`
 
-1. Create a changeset PR (`.changeset/<name>.md` with `"@composio/cli": patch`)
-2. Merge it into `next`
-3. The changeset bot creates a "Release: update version" PR that bumps `package.json`
-4. Merge that PR → the push to `next` detects the `package.json` version changed → builds a **stable** release (`@composio/cli@X.Y.Z`, marked as `latest`)
-5. `ts.release.yml` also publishes to npm
-
-### Manual Promotion
-
-You can also promote an existing beta to stable via `workflow_dispatch` → `promote-stable` with the beta tag (e.g. `@composio/cli@0.2.20-beta.42`).
-
-### Key Files
-
-| File                                          | Purpose                          |
-| --------------------------------------------- | -------------------------------- |
-| `.github/workflows/build-cli-binaries.yml`    | Binary build + release workflow  |
-| `.github/workflows/ts.release.yml`            | Changeset bot + npm publish      |
-| `.github/workflows/cli.test-installation.yml` | Post-release install smoke tests |
-| `.changeset/config.json`                      | Changeset configuration          |
+Use these when adding commands or shaping flag interfaces.


### PR DESCRIPTION
# Description
Weekly CLAUDE.md refresh — rebased on next. No drift updates required this run (branch parent already at origin/next tip).

# How did I test this PR
- Verified line counts (root CLAUDE.md=121, docs/CLAUDE.md=107, ts/packages/cli AGENTS.md=180).
- Confirmed ts/packages/cli/CLAUDE.md symlink to AGENTS.md is intact.
- Clean rebase onto origin/next, no conflicts.

Origin: cron-update-claude-docs / [zen-cron-6f62a90519fc](https://zen-api-production-4c98.up.railway.app/dashboard/#/chat/zen-cron-6f62a90519fc)
Triggered by: karan@composio.dev | Source: cron
Session: https://zen-api-production-4c98.up.railway.app/dashboard/#/chat/zen-cron-6f62a90519fc