### PR TITLE
fix(shared): set alias to original name and check required against original in json_schema_to_pydantic_field

### DIFF
--- a/python/composio/utils/shared.py
+++ b/python/composio/utils/shared.py
@@ -210,9 +210,10 @@ def json_schema_to_pydantic_field(
         default = _coerce_default_value(default, json_schema)
 
     # Check if the field name is a reserved Pydantic name
+    original_name = name
     if name in reserved_names:
         name = f"{name}_"
-        alias = name
+        alias = original_name  # alias to the original schema key, not the renamed identifier
     else:
         alias = None
 
@@ -222,7 +223,7 @@ def json_schema_to_pydantic_field(
         "alias": alias,
     }
     if not skip_default:
-        field["default"] = ... if name in required else default
+        field["default"] = ... if original_name in required else default
 
     return (
         name,


### PR DESCRIPTION
## Summary

Fixes #3172

`json_schema_to_pydantic_field` renamed reserved Python/Pydantic field names (e.g. `validate` -> `validate_`) but had two bugs:

**Bug 1 - wrong alias**: `alias = name` was evaluated *after* the rename, so the alias was set to `validate_` instead of the original schema key `validate`. Any JSON payload containing the original key was rejected because Pydantic expected the renamed key.

**Bug 2 - required check broken**: `name in required` checked the renamed identifier against the `required` list which still contained the original name. Required fields with reserved names were silently treated as optional.

## Fix

Capture `original_name = name` before the rename block and use it for both:
- `alias = original_name` (so the field accepts the real schema key)
- `original_name in required` (so required status is preserved)

```python
original_name = name
if name in reserved_names:
    name = f"{name}_"
    alias = original_name  # original schema key, not the renamed identifier
else:
    alias = None
# ...
field["default"] = ... if original_name in required else default
```
