### PR TITLE
feat(python): file upload hardening (parity with core)

### DIFF
--- a/python/composio/core/models/_files.py
+++ b/python/composio/core/models/_files.py
@@ -18,10 +18,12 @@ from composio.client.types import Tool
 from composio.exceptions import (
     ErrorDownloadingFile,
     ErrorUploadingFile,
+    FileUploadAbortedError,
     ResponseTooLargeError,
     SDKFileNotFoundError,
 )
 from composio.utils import mimetypes
+from composio.utils.sensitive_file_upload_paths import assert_safe_local_file_upload_path
 from composio.utils.logging import WithLogger
 
 if t.TYPE_CHECKING:
@@ -416,6 +418,12 @@ class FileUploadable(BaseModel):
         file: t.Union[str, Path],
         tool: str,
         toolkit: str,
+        *,
+        sensitive_file_upload_protection: bool = True,
+        file_upload_path_deny_segments: t.Optional[t.Sequence[str]] = None,
+        before_file_upload: t.Optional[
+            t.Callable[[str, str, str], t.Union[str, bool]]
+        ] = None,
     ) -> te.Self:
         """Create a FileUploadable from a local file path or public URL.
 
@@ -427,14 +435,44 @@ class FileUploadable(BaseModel):
         :param file: Local file path or public URL
         :param tool: The tool slug
         :param toolkit: The toolkit slug
+        :param sensitive_file_upload_protection: When True, block paths on the built-in denylist.
+        :param file_upload_path_deny_segments: Extra path segment names to merge with the built-in list.
+        :param before_file_upload: Optional ``(path, tool, toolkit) -> str | bool``; return a new path string, or False to abort.
         :return: FileUploadable instance with S3 key
         """
+        file_str = str(file) if isinstance(file, Path) else file
+
         # Check if it's a URL
-        if isinstance(file, str) and _is_url(file):
-            return cls.from_url(client=client, url=file, tool=tool, toolkit=toolkit)
+        if isinstance(file_str, str) and _is_url(file_str):
+            path_in = file_str
+            if before_file_upload is not None:
+                out = before_file_upload(path_in, tool, toolkit)
+                if out is False:
+                    raise FileUploadAbortedError(
+                        "File upload was aborted because before_file_upload returned False."
+                    )
+                if isinstance(out, str):
+                    path_in = out
+            return cls.from_url(client=client, url=path_in, tool=tool, toolkit=toolkit)
+
+        path_in = file_str
+        if before_file_upload is not None:
+            out = before_file_upload(path_in, tool, toolkit)
+            if out is False:
+                raise FileUploadAbortedError(
+                    "File upload was aborted because before_file_upload returned False."
+                )
+            if isinstance(out, str):
+                path_in = out
+
+        assert_safe_local_file_upload_path(
+            path_in,
+            enabled=sensitive_file_upload_protection,
+            additional_deny_segments=file_upload_path_deny_segments,
+        )
 
         # Handle as local file path
-        file = Path(file)
+        file = Path(path_in)
         if not file.exists():
             raise SDKFileNotFoundError(
                 f"File not found: {file}. Please provide a valid file path."
@@ -487,11 +525,25 @@ class FileDownloadable(BaseModel):
         return outfile
 
 
+BeforeFileUpload = t.Callable[[str, str, str], t.Union[str, bool]]
+
+
 class FileHelper(WithLogger):
-    def __init__(self, client: HttpClient, outdir: t.Optional[str] = None):
+    def __init__(
+        self,
+        client: HttpClient,
+        outdir: t.Optional[str] = None,
+        *,
+        sensitive_file_upload_protection: bool = True,
+        file_upload_path_deny_segments: t.Optional[t.Sequence[str]] = None,
+        before_file_upload: t.Optional[BeforeFileUpload] = None,
+    ) -> None:
         super().__init__()
         self._client = client
         self._outdir = Path(outdir or LOCAL_OUTPUT_FILE_DIRECTORY)
+        self._sensitive_file_upload_protection = sensitive_file_upload_protection
+        self._file_upload_path_deny_segments = file_upload_path_deny_segments
+        self._before_file_upload = before_file_upload
 
     def _has_file_property(
         self, schema: t.Dict, property_name: str = "file_uploadable"
@@ -691,6 +743,8 @@ class FileHelper(WithLogger):
         tool: Tool,
         schema: t.Dict,
         request: t.Dict,
+        *,
+        before_file_upload: t.Optional[BeforeFileUpload] = None,
     ) -> t.Dict:
         if "properties" not in schema:
             return request
@@ -714,6 +768,9 @@ class FileHelper(WithLogger):
                     file=request[_param],
                     tool=tool.slug,
                     toolkit=tool.toolkit.slug,
+                    sensitive_file_upload_protection=self._sensitive_file_upload_protection,
+                    file_upload_path_deny_segments=self._file_upload_path_deny_segments,
+                    before_file_upload=before_file_upload,
                 ).model_dump()
                 continue
 
@@ -731,6 +788,9 @@ class FileHelper(WithLogger):
                         file=request[_param],
                         tool=tool.slug,
                         toolkit=tool.toolkit.slug,
+                        sensitive_file_upload_protection=self._sensitive_file_upload_protection,
+                        file_upload_path_deny_segments=self._file_upload_path_deny_segments,
+                        before_file_upload=before_file_upload,
                     ).model_dump()
                     continue
 
@@ -743,6 +803,7 @@ class FileHelper(WithLogger):
                         schema=uploadable_variant,
                         request=request[_param],
                         tool=tool,
+                        before_file_upload=before_file_upload,
                     )
                     continue
 
@@ -755,6 +816,7 @@ class FileHelper(WithLogger):
                     schema=param_schema,
                     request=request[_param],
                     tool=tool,
+                    before_file_upload=before_file_upload,
                 )
                 continue
 
@@ -777,6 +839,9 @@ class FileHelper(WithLogger):
                                             file=item,
                                             tool=tool.slug,
                                             toolkit=tool.toolkit.slug,
+                                            sensitive_file_upload_protection=self._sensitive_file_upload_protection,
+                                            file_upload_path_deny_segments=self._file_upload_path_deny_segments,
+                                            before_file_upload=before_file_upload,
                                         ).model_dump()
                                     )
                             elif isinstance(item, dict):
@@ -785,6 +850,7 @@ class FileHelper(WithLogger):
                                         schema=items_schema,
                                         request=item,
                                         tool=tool,
+                                        before_file_upload=before_file_upload,
                                     )
                                 )
                             else:
@@ -795,11 +861,23 @@ class FileHelper(WithLogger):
 
         return request
 
-    def substitute_file_uploads(self, tool: Tool, request: t.Dict) -> t.Dict:
+    def substitute_file_uploads(
+        self,
+        tool: Tool,
+        request: t.Dict,
+        *,
+        before_file_upload: t.Optional[BeforeFileUpload] = None,
+    ) -> t.Dict:
+        bfu = (
+            before_file_upload
+            if before_file_upload is not None
+            else self._before_file_upload
+        )
         return self._substitute_file_uploads_recursively(
             tool=tool,
             schema=tool.input_parameters,
             request=request,
+            before_file_upload=bfu,
         )
 
     def _is_file_downloadable(self, schema: t.Dict) -> bool:

--- a/python/composio/core/models/tool_router.py
+++ b/python/composio/core/models/tool_router.py
@@ -361,6 +361,11 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
         client: HttpClient,
         provider: t.Optional["BaseProvider[TTool, TToolCollection]"] = None,
         auto_upload_download_files: bool = True,
+        sensitive_file_upload_protection: bool = True,
+        file_upload_path_deny_segments: t.Optional[t.Sequence[str]] = None,
+        before_file_upload: t.Optional[
+            t.Callable[[str, str, str], t.Union[str, bool]]
+        ] = None,
     ):
         """
         Initialize ToolRouter instance.
@@ -368,10 +373,16 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
         :param client: HTTP client for API calls
         :param provider: Optional provider for tool wrapping
         :param auto_upload_download_files: Whether to automatically upload and download files. Defaults to True.
+        :param sensitive_file_upload_protection: When True, block local paths on the built-in sensitive-path denylist before upload.
+        :param file_upload_path_deny_segments: Extra path segment names to merge with the built-in denylist.
+        :param before_file_upload: Optional hook called before each local file is read for upload.
         """
         super().__init__(client)
         self._provider = provider
         self._auto_upload_download_files = auto_upload_download_files
+        self._sensitive_file_upload_protection = sensitive_file_upload_protection
+        self._file_upload_path_deny_segments = file_upload_path_deny_segments
+        self._before_file_upload = before_file_upload
 
     def _create_mcp_server_config(
         self,
@@ -804,6 +815,9 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
             client=self._client,
             provider=self._provider,
             auto_upload_download_files=self._auto_upload_download_files,
+            sensitive_file_upload_protection=self._sensitive_file_upload_protection,
+            file_upload_path_deny_segments=self._file_upload_path_deny_segments,
+            before_file_upload=self._before_file_upload,
             session_id=session.session_id,
             mcp=self._create_mcp_server_config(
                 mcp_type=ToolRouterMCPServerType(session.mcp.type.lower()),
@@ -857,6 +871,9 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
             client=self._client,
             provider=self._provider,
             auto_upload_download_files=self._auto_upload_download_files,
+            sensitive_file_upload_protection=self._sensitive_file_upload_protection,
+            file_upload_path_deny_segments=self._file_upload_path_deny_segments,
+            before_file_upload=self._before_file_upload,
             session_id=session.session_id,
             mcp=self._create_mcp_server_config(
                 mcp_type=ToolRouterMCPServerType(session.mcp.type.lower()),

--- a/python/composio/core/models/tool_router_session.py
+++ b/python/composio/core/models/tool_router_session.py
@@ -77,6 +77,11 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
         client: HttpClient,
         provider: t.Optional[BaseProvider[t.Any, t.Any]],
         auto_upload_download_files: bool,
+        sensitive_file_upload_protection: bool = True,
+        file_upload_path_deny_segments: t.Optional[t.Sequence[str]] = None,
+        before_file_upload: t.Optional[
+            t.Callable[[str, str, str], t.Union[str, bool]]
+        ] = None,
         session_id: str,
         mcp: t.Any,
         experimental: "ToolRouterSessionExperimental",
@@ -86,6 +91,9 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
         self._client = client
         self._provider = provider
         self._auto_upload_download_files = auto_upload_download_files
+        self._sensitive_file_upload_protection = sensitive_file_upload_protection
+        self._file_upload_path_deny_segments = file_upload_path_deny_segments
+        self._before_file_upload = before_file_upload
         self.session_id = session_id
         self.mcp = mcp
         self.experimental = experimental
@@ -107,6 +115,18 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
         if self._custom_tools_map is None:
             return False
         return len(self._custom_tools_map.by_final_slug) > 0
+
+    def _tool_router_backend_execute(
+        self,
+        tools_model: t.Any,
+        modifiers: t.Optional["Modifiers"] = None,
+    ) -> t.Callable[..., t.Any]:
+        """Backend execute_meta wrapper with this session's file-upload settings."""
+        return tools_model._wrap_execute_tool_for_tool_router(
+            session_id=self.session_id,
+            modifiers=modifiers,
+            before_file_upload=self._before_file_upload,
+        )
 
     def tools(self, modifiers: t.Optional["Modifiers"] = None) -> TToolCollection:
         """
@@ -132,6 +152,9 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
             client=self._client,
             provider=self._provider,
             auto_upload_download_files=self._auto_upload_download_files,
+            sensitive_file_upload_protection=self._sensitive_file_upload_protection,
+            file_upload_path_deny_segments=self._file_upload_path_deny_segments,
+            before_file_upload=self._before_file_upload,
         )
 
         router_tools = tools_model.get_raw_tool_router_meta_tools(
@@ -159,9 +182,8 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
         if self._has_custom_tools():
             execute_fn = self._create_routing_execute_fn(tools_model, modifiers)
         else:
-            execute_fn = tools_model._wrap_execute_tool_for_tool_router(
-                session_id=self.session_id,
-                modifiers=modifiers,
+            execute_fn = self._tool_router_backend_execute(
+                tools_model, modifiers=modifiers
             )
 
         return t.cast(
@@ -182,9 +204,8 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
         Applies before_execute/after_execute modifiers around the overall
         COMPOSIO_MULTI_EXECUTE_TOOL call, consistent with the standard path.
         """
-        backend_execute = tools_model._wrap_execute_tool_for_tool_router(
-            session_id=self.session_id,
-            modifiers=modifiers,
+        backend_execute = self._tool_router_backend_execute(
+            tools_model, modifiers=modifiers
         )
 
         def routing_execute(slug: str, arguments: t.Dict) -> t.Dict:
@@ -251,9 +272,10 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
         tool_items = input_args.get("tools")
         if not isinstance(tool_items, list) or len(tool_items) == 0:
             # Fallback: send to backend as-is (no modifiers — caller handles them)
-            return tools_model._wrap_execute_tool_for_tool_router(
-                session_id=self.session_id,
-            )(COMPOSIO_MULTI_EXECUTE_TOOL, input_args)
+            return self._tool_router_backend_execute(tools_model)(
+                COMPOSIO_MULTI_EXECUTE_TOOL,
+                input_args,
+            )
 
         parsed = [self._parse_tool_item(item) for item in tool_items]
 
@@ -269,9 +291,10 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
 
         # All remote — just forward entire payload (no modifiers — caller handles them)
         if not local_items:
-            return tools_model._wrap_execute_tool_for_tool_router(
-                session_id=self.session_id,
-            )(COMPOSIO_MULTI_EXECUTE_TOOL, input_args)
+            return self._tool_router_backend_execute(tools_model)(
+                COMPOSIO_MULTI_EXECUTE_TOOL,
+                input_args,
+            )
 
         ctx = self._session_context
         assert ctx is not None
@@ -298,9 +321,7 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
             if remote_indices:
                 remote_tool_items = [tool_items[i] for i in remote_indices]
                 remote_input = {**input_args, "tools": remote_tool_items}
-                execute_fn = tools_model._wrap_execute_tool_for_tool_router(
-                    session_id=self.session_id,
-                )
+                execute_fn = self._tool_router_backend_execute(tools_model)
                 remote_future = pool.submit(
                     execute_fn,
                     COMPOSIO_MULTI_EXECUTE_TOOL,

--- a/python/composio/core/models/tools.py
+++ b/python/composio/core/models/tools.py
@@ -101,6 +101,11 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
         file_download_dir: t.Optional[str] = None,
         toolkit_versions: t.Optional[ToolkitVersionParam] = None,
         auto_upload_download_files: bool = True,
+        sensitive_file_upload_protection: bool = True,
+        file_upload_path_deny_segments: t.Optional[t.Sequence[str]] = None,
+        before_file_upload: t.Optional[
+            t.Callable[[str, str, str], t.Union[str, bool]]
+        ] = None,
     ):
         """
         Initialize the tools resource.
@@ -110,11 +115,20 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
         :param file_download_dir: Output directory for downloadable files
         :param toolkit_versions: The versions of the toolkits to use. Defaults to 'latest' if not provided.
         :param auto_upload_download_files: Whether to automatically upload and download files. Defaults to True.
+        :param sensitive_file_upload_protection: When True, block local paths on the built-in sensitive-path denylist before upload.
+        :param file_upload_path_deny_segments: Extra path segment names to merge with the built-in denylist.
+        :param before_file_upload: Optional ``(path, tool_slug, toolkit_slug) -> str | bool`` called before each upload.
         """
         self._client = client
         self._custom_tools = CustomTools(client)
         self._tool_schemas: t.Dict[str, Tool] = {}
-        self._file_helper = FileHelper(client=self._client, outdir=file_download_dir)
+        self._file_helper = FileHelper(
+            client=self._client,
+            outdir=file_download_dir,
+            sensitive_file_upload_protection=sensitive_file_upload_protection,
+            file_upload_path_deny_segments=file_upload_path_deny_segments,
+            before_file_upload=before_file_upload,
+        )
         self._toolkit_versions = toolkit_versions
         self._auto_upload_download_files = auto_upload_download_files
 
@@ -277,6 +291,9 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
         scopes: t.Optional[t.List[str]] = None,
         modifiers: t.Optional[Modifiers] = None,
         limit: t.Optional[int] = None,
+        before_file_upload: t.Optional[
+            t.Callable[[str, str, str], t.Union[str, bool]]
+        ] = None,
     ) -> TToolCollection:
         """Get a list of tools based on the provided filters."""
         tools_list = self.get_raw_composio_tools(
@@ -333,6 +350,7 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
                 execute_tool=self._wrap_execute_tool(
                     user_id=user_id,
                     modifiers=modifiers,
+                    before_file_upload=before_file_upload,
                 ),
             ),
         )
@@ -348,6 +366,9 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
         scopes: t.Optional[t.List[str]] = None,
         modifiers: t.Optional[Modifiers] = None,
         limit: t.Optional[int] = None,
+        before_file_upload: t.Optional[
+            t.Callable[[str, str, str], t.Union[str, bool]]
+        ] = None,
     ) -> TToolCollection:
         """
         Get a tool or list of tools based on the provided arguments.
@@ -369,7 +390,12 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
         :return: Provider-specific tool collection (TToolCollection).
         """
         if slug is not None:
-            return self._get(user_id=user_id, tools=[slug], modifiers=modifiers)
+            return self._get(
+                user_id=user_id,
+                tools=[slug],
+                modifiers=modifiers,
+                before_file_upload=before_file_upload,
+            )
         return self._get(
             user_id=user_id,
             tools=tools,
@@ -378,12 +404,16 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
             scopes=scopes,
             modifiers=modifiers,
             limit=limit,
+            before_file_upload=before_file_upload,
         )
 
     def _wrap_execute_tool(
         self,
         modifiers: t.Optional[Modifiers] = None,
         user_id: t.Optional[str] = None,
+        before_file_upload: t.Optional[
+            t.Callable[[str, str, str], t.Union[str, bool]]
+        ] = None,
     ) -> AgenticProviderExecuteFn:
         """Wrap the execute tool function"""
         return t.cast(
@@ -392,6 +422,7 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
                 self.execute,
                 modifiers=modifiers,
                 user_id=user_id,
+                before_file_upload=before_file_upload,
                 # Dangerously skip version check for agentic tool execution via providers
                 # This can be safe because most agentic flows users fetch latest version and then execute the tool
                 dangerously_skip_version_check=True,
@@ -402,6 +433,9 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
         self,
         session_id: str,
         modifiers: t.Optional[Modifiers] = None,
+        before_file_upload: t.Optional[
+            t.Callable[[str, str, str], t.Union[str, bool]]
+        ] = None,
     ) -> AgenticProviderExecuteFn:
         """
         Create an execute function for tool router that uses the session's execute_meta endpoint.
@@ -412,6 +446,7 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
 
         :param session_id: The session ID
         :param modifiers: Optional modifiers to apply before and after execution
+        :param before_file_upload: Optional hook for each file read; overrides the FileHelper default.
         :return: Execute function for tool router
         """
 
@@ -428,6 +463,30 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
             :param arguments: The tool arguments
             :return: Tool execution response
             """
+            tool = self._tool_schemas.get(slug)
+            if tool is None:
+                custom_tool = self._custom_tools.get(slug=slug)
+                if custom_tool is not None:
+                    tool = custom_tool.info
+                    self._tool_schemas[slug] = tool
+
+            if tool is None:
+                tool = t.cast(
+                    Tool,
+                    self._client.tools.retrieve(
+                        tool_slug=slug,
+                        toolkit_versions=none_to_omit(self._toolkit_versions),
+                    ),
+                )
+                self._tool_schemas[slug] = tool
+
+            if self._auto_upload_download_files:
+                arguments = self._file_helper.substitute_file_uploads(
+                    tool=tool,
+                    request=arguments,
+                    before_file_upload=before_file_upload,
+                )
+
             # Apply before_execute modifiers
             # Meta tools are always from the 'composio' toolkit
             processed_arguments = arguments
@@ -572,6 +631,9 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
         version: t.Optional[str] = None,
         dangerously_skip_version_check: t.Optional[bool] = None,
         modifiers: t.Optional[Modifiers] = None,
+        before_file_upload: t.Optional[
+            t.Callable[[str, str, str], t.Union[str, bool]]
+        ] = None,
     ) -> ToolExecutionResponse:
         """
         Execute a tool with the provided parameters.
@@ -590,6 +652,7 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
         :param version: The version of the tool to execute (overrides the SDK-level toolkit versions for this execution).
         :param dangerously_skip_version_check: Skip the version check for 'latest' version. This might cause unexpected behavior when new versions are released.
         :param modifiers: The modifiers to apply to the tool.
+        :param before_file_upload: Optional hook run before each file path is read; overrides the instance default from ``Composio()``.
         :return: The response from the tool.
         """
 
@@ -609,6 +672,13 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
                 ),
             )
             self._tool_schemas[slug] = tool
+
+        if self._auto_upload_download_files:
+            arguments = self._file_helper.substitute_file_uploads(
+                tool=tool,
+                request=arguments,
+                before_file_upload=before_file_upload,
+            )
 
         if modifiers is not None:
             type_before_exec: t.Literal["before_execute"] = "before_execute"
@@ -653,12 +723,6 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
             arguments = processed_params["arguments"]
             dangerously_skip_version_check = processed_params.get(
                 "dangerously_skip_version_check", dangerously_skip_version_check
-            )
-
-        if self._auto_upload_download_files:
-            arguments = self._file_helper.substitute_file_uploads(
-                tool=tool,
-                request=arguments,
             )
         response = (
             self._execute_custom_tool(

--- a/python/composio/exceptions.py
+++ b/python/composio/exceptions.py
@@ -168,6 +168,14 @@ class ErrorUploadingFile(FileError):
     pass
 
 
+class SensitiveFilePathBlockedError(FileError):
+    """Raised when a local file path is refused before upload (sensitive directory or credential-like name)."""
+
+
+class FileUploadAbortedError(FileError):
+    """Raised when a ``before_file_upload`` hook returns ``False``."""
+
+
 class ErrorDownloadingFile(FileError):
     pass
 

--- a/python/composio/sdk.py
+++ b/python/composio/sdk.py
@@ -41,6 +41,11 @@ class SDKConfig(te.TypedDict):
     file_download_dir: te.NotRequired[str]
     toolkit_versions: te.NotRequired[ToolkitVersionParam]
     auto_upload_download_files: te.NotRequired[bool]
+    sensitive_file_upload_protection: te.NotRequired[bool]
+    file_upload_path_deny_segments: te.NotRequired[t.Sequence[str]]
+    before_file_upload: te.NotRequired[
+        t.Callable[[str, str, str], t.Union[str, bool]]
+    ]
 
 
 class Composio(t.Generic[TTool, TToolCollection], WithLogger):
@@ -104,6 +109,9 @@ class Composio(t.Generic[TTool, TToolCollection], WithLogger):
                                 - A string (e.g., 'latest', '20250906_01') to use the same version for all toolkits
                                 - None or omitted to use 'latest' as default
         :param auto_upload_download_files: Whether to automatically upload and download files. Defaults to True.
+        :param sensitive_file_upload_protection: When True, block local paths on the built-in sensitive-path denylist before upload. Defaults to True.
+        :param file_upload_path_deny_segments: Extra path segment names merged with the built-in denylist.
+        :param before_file_upload: Optional ``(path, tool_slug, toolkit_slug) -> str | bool`` run before each local file is read for upload; return False to abort.
         """
         WithLogger.__init__(self)
         api_key = kwargs.get("api_key", os.environ.get("COMPOSIO_API_KEY"))
@@ -130,12 +138,24 @@ class Composio(t.Generic[TTool, TToolCollection], WithLogger):
             max_retries=kwargs.get("max_retries", DEFAULT_MAX_RETRIES),
         )
         self.provider = actual_provider
+        sensitive_file_upload_protection: bool = kwargs.get(
+            "sensitive_file_upload_protection", True
+        )
+        file_upload_path_deny_segments: t.Optional[t.Sequence[str]] = kwargs.get(
+            "file_upload_path_deny_segments"
+        )
+        before_file_upload: t.Optional[
+            t.Callable[[str, str, str], t.Union[str, bool]]
+        ] = kwargs.get("before_file_upload")
         self.tools = Tools(
             client=self._client,
             provider=actual_provider,
             file_download_dir=kwargs.get("file_download_dir"),
             toolkit_versions=toolkit_versions,
             auto_upload_download_files=kwargs.get("auto_upload_download_files", True),
+            sensitive_file_upload_protection=sensitive_file_upload_protection,
+            file_upload_path_deny_segments=file_upload_path_deny_segments,
+            before_file_upload=before_file_upload,
         )
 
         self.toolkits = Toolkits(client=self._client)
@@ -154,6 +174,9 @@ class Composio(t.Generic[TTool, TToolCollection], WithLogger):
             client=self._client,
             provider=actual_provider,
             auto_upload_download_files=kwargs.get("auto_upload_download_files", True),
+            sensitive_file_upload_protection=sensitive_file_upload_protection,
+            file_upload_path_deny_segments=file_upload_path_deny_segments,
+            before_file_upload=before_file_upload,
         )
         self.create = self.tool_router.create
         self.use = self.tool_router.use

--- a/python/composio/utils/sensitive_file_upload_paths.py
+++ b/python/composio/utils/sensitive_file_upload_paths.py
@@ -14,13 +14,12 @@ BUILTIN_FILE_UPLOAD_PATH_DENY_SEGMENTS: t.Tuple[str, ...] = (
     ".gnupg",
     ".kube",
     ".docker",
+    ".claude",  # may contain API keys and project context read by assistants
     ".password-store",
     "keychains",
 )
 
-_SECRET_LIKE_BASENAME = re.compile(
-    r"^(\.env(\.|$)|\.netrc$|\.pgpass$)", re.IGNORECASE
-)
+_SECRET_LIKE_BASENAME = re.compile(r"^(\.env(\.|$)|\.netrc$|\.pgpass$)", re.IGNORECASE)
 _DEFAULT_PRIVATE_KEY_BASENAME = re.compile(
     r"^id_(rsa|ed25519|ecdsa|dsa|ecdsa_sk)(\.old)?$", re.IGNORECASE
 )
@@ -48,8 +47,9 @@ def _get_block_reason(
     deny.update(s.lower() for s in extra)
 
     segments = _normalize_path_segments(file_path)
-    for seg in segments:
-        if seg.lower() in deny:
+    # Case-insensitive segment match: lower each path component once per check.
+    for seg, key in zip(segments, (s.lower() for s in segments), strict=True):
+        if key in deny:
             return f'path segment "{seg}" is in the sensitive file upload denylist'
 
     if not segments:

--- a/python/composio/utils/sensitive_file_upload_paths.py
+++ b/python/composio/utils/sensitive_file_upload_paths.py
@@ -1,0 +1,93 @@
+"""Block accidental upload of local files from well-known secret/credential locations."""
+
+from __future__ import annotations
+
+import re
+import typing as t
+from pathlib import Path
+
+# Path components that indicate a sensitive directory anywhere in a resolved local path.
+BUILTIN_FILE_UPLOAD_PATH_DENY_SEGMENTS: t.Tuple[str, ...] = (
+    ".ssh",
+    ".aws",
+    ".azure",
+    ".gnupg",
+    ".kube",
+    ".docker",
+    ".password-store",
+    "keychains",
+)
+
+_SECRET_LIKE_BASENAME = re.compile(
+    r"^(\.env(\.|$)|\.netrc$|\.pgpass$)", re.IGNORECASE
+)
+_DEFAULT_PRIVATE_KEY_BASENAME = re.compile(
+    r"^id_(rsa|ed25519|ecdsa|dsa|ecdsa_sk)(\.old)?$", re.IGNORECASE
+)
+
+
+def _normalize_path_segments(file_path: t.Union[str, Path]) -> t.List[str]:
+    p = Path(file_path).expanduser()
+    try:
+        resolved = p.resolve()
+    except OSError:
+        resolved = p
+    parts = [part for part in resolved.as_posix().split("/") if part]
+    if parts and parts[0].endswith(":"):
+        # Windows path: "C:/Users/..." -> drop drive letter segment
+        parts = parts[1:]
+    return parts
+
+
+def _get_block_reason(
+    file_path: t.Union[str, Path],
+    additional_deny_segments: t.Optional[t.Sequence[str]] = None,
+) -> t.Optional[str]:
+    extra = [s.strip() for s in (additional_deny_segments or []) if s and s.strip()]
+    deny: t.Set[str] = {s.lower() for s in BUILTIN_FILE_UPLOAD_PATH_DENY_SEGMENTS}
+    deny.update(s.lower() for s in extra)
+
+    segments = _normalize_path_segments(file_path)
+    for seg in segments:
+        if seg.lower() in deny:
+            return f'path segment "{seg}" is in the sensitive file upload denylist'
+
+    if not segments:
+        return None
+    basename = segments[-1]
+    if _SECRET_LIKE_BASENAME.search(basename) or _DEFAULT_PRIVATE_KEY_BASENAME.match(
+        basename
+    ):
+        return (
+            f'file name "{basename}" looks like a credential, env, or private key file'
+        )
+    if basename.lower() == "credentials":
+        return 'file name "credentials" is often used for cloud/API credential stores'
+    return None
+
+
+def is_blocked_sensitive_file_upload_path(
+    file_path: t.Union[str, Path],
+    additional_deny_segments: t.Optional[t.Sequence[str]] = None,
+) -> bool:
+    return _get_block_reason(file_path, additional_deny_segments) is not None
+
+
+def assert_safe_local_file_upload_path(
+    file_path: t.Union[str, Path],
+    *,
+    enabled: bool = True,
+    additional_deny_segments: t.Optional[t.Sequence[str]] = None,
+) -> None:
+    """Raise SensitiveFilePathBlockedError if *file_path* matches the denylist."""
+    if not enabled:
+        return
+    reason = _get_block_reason(file_path, additional_deny_segments)
+    if reason:
+        from composio.exceptions import SensitiveFilePathBlockedError
+
+        raise SensitiveFilePathBlockedError(
+            f"Refusing to upload: {reason}. "
+            "Set sensitive_file_upload_protection=False on Composio if you must "
+            "(not recommended), or use a copy outside sensitive locations."
+        )

--- a/python/providers/anthropic/pyproject.toml
+++ b/python/providers/anthropic/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio-anthropic"
-version = "0.11.5"
+version = "0.11.6"
 description = "Use Composio to get an array of tools with your Anthropic LLMs."
 readme = "README.md"
 requires-python = ">=3.10,<4"

--- a/python/providers/anthropic/setup.py
+++ b/python/providers/anthropic/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 
 setup(
     name="composio_anthropic",
-    version="0.11.5",
+    version="0.11.6",
     author="Composio",
     author_email="tech@composio.dev",
     description="Use Composio to get an array of tools with your Anthropic LLMs.",

--- a/python/providers/autogen/pyproject.toml
+++ b/python/providers/autogen/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio-autogen"
-version = "0.11.5"
+version = "0.11.6"
 description = "Use Composio to get an array of tools with your autogen agent."
 readme = "README.md"
 requires-python = ">=3.9,<4"

--- a/python/providers/autogen/setup.py
+++ b/python/providers/autogen/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 
 setup(
     name="composio_autogen",
-    version="0.11.5",
+    version="0.11.6",
     author="Composio",
     author_email="tech@composio.dev",
     description="Use Composio to get an array of tools with your Autogen agent.",

--- a/python/providers/claude_agent_sdk/pyproject.toml
+++ b/python/providers/claude_agent_sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio-claude-agent-sdk"
-version = "0.11.5"
+version = "0.11.6"
 description = "Use Composio to get an array of tools with Claude Code Agents SDK."
 readme = "README.md"
 requires-python = ">=3.10,<4"

--- a/python/providers/claude_agent_sdk/setup.py
+++ b/python/providers/claude_agent_sdk/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="composio_claude_agent_sdk",
-    version="0.11.5",
+    version="0.11.6",
     author="Composio",
     author_email="tech@composio.dev",
     description="Use Composio to get array of tools for Claude Agent SDK",

--- a/python/providers/crewai/pyproject.toml
+++ b/python/providers/crewai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio-crewai"
-version = "0.11.5"
+version = "0.11.6"
 description = "Use Composio to get an array of tools with your CrewAI agent."
 readme = "README.md"
 requires-python = ">=3.9,<4"

--- a/python/providers/crewai/setup.py
+++ b/python/providers/crewai/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 setup(
     name="composio_crewai",
-    version="0.11.5",
+    version="0.11.6",
     author="Composio",
     author_email="tech@composio.dev",
     description="Use Composio to get an array of tools with your CrewAI agent.",

--- a/python/providers/gemini/pyproject.toml
+++ b/python/providers/gemini/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio-gemini"
-version = "0.11.5"
+version = "0.11.6"
 description = "Use Composio to get an array of tools with your Gemini agent."
 readme = "README.md"
 requires-python = ">=3.9,<4"

--- a/python/providers/gemini/setup.py
+++ b/python/providers/gemini/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 
 setup(
     name="composio_gemini",
-    version="0.11.5",
+    version="0.11.6",
     author="Composio",
     author_email="tech@composio.dev",
     description="Use Composio to get an array of tools with your Gemini agent.",

--- a/python/providers/google/pyproject.toml
+++ b/python/providers/google/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio-google"
-version = "0.11.5"
+version = "0.11.6"
 description = "Use Composio to get an array of tools with your Google AI Python Gemini model."
 readme = "README.md"
 requires-python = ">=3.9,<4"

--- a/python/providers/google/setup.py
+++ b/python/providers/google/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 
 setup(
     name="composio_google",
-    version="0.11.5",
+    version="0.11.6",
     author="Composio",
     author_email="tech@composio.dev",
     description="Use Composio to get an array of tools with your Google AI Python Gemini model.",

--- a/python/providers/google_adk/pyproject.toml
+++ b/python/providers/google_adk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio-google-adk"
-version = "0.11.5"
+version = "0.11.6"
 description = "Use Composio to get an array of tools with your Google AI Python Gemini model."
 readme = "README.md"
 requires-python = ">=3.9,<4"

--- a/python/providers/google_adk/setup.py
+++ b/python/providers/google_adk/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 
 setup(
     name="composio_google_adk",
-    version="0.11.5",
+    version="0.11.6",
     author="Composio",
     author_email="tech@composio.dev",
     description="Use Composio to get an array of tools with your Google AI Python Gemini model.",

--- a/python/providers/langchain/pyproject.toml
+++ b/python/providers/langchain/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio-langchain"
-version = "0.11.5"
+version = "0.11.6"
 description = "Use Composio to get an array of tools with your Langchain agent."
 readme = "README.md"
 requires-python = ">=3.9,<4"

--- a/python/providers/langchain/setup.py
+++ b/python/providers/langchain/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 
 setup(
     name="composio_langchain",
-    version="0.11.5",
+    version="0.11.6",
     author="composio",
     author_email="tech@composio.dev",
     description="Use Composio to get an array of tools with your Langchain agent.",

--- a/python/providers/langgraph/pyproject.toml
+++ b/python/providers/langgraph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio-langgraph"
-version = "0.11.5"
+version = "0.11.6"
 description = "Use Composio to get array of tools with LangGraph Agent Workflows."
 readme = "README.md"
 requires-python = ">=3.9,<4"

--- a/python/providers/langgraph/setup.py
+++ b/python/providers/langgraph/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 
 setup(
     name="composio_langgraph",
-    version="0.11.5",
+    version="0.11.6",
     author="composio",
     author_email="tech@composio.dev",
     description="Use Composio to get array of tools with LangGraph Agent Workflows",

--- a/python/providers/llamaindex/pyproject.toml
+++ b/python/providers/llamaindex/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio-llamaindex"
-version = "0.11.5"
+version = "0.11.6"
 description = "Use Composio to get array of tools with LlamaIndex Agent Workflows."
 readme = "README.md"
 requires-python = ">=3.9,<4"

--- a/python/providers/llamaindex/setup.py
+++ b/python/providers/llamaindex/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 
 setup(
     name="composio_llamaindex",
-    version="0.11.5",
+    version="0.11.6",
     author="composio",
     author_email="tech@composio.dev",
     description="Use Composio to get array of tools with LlamaIndex Agent Workflows",

--- a/python/providers/openai/pyproject.toml
+++ b/python/providers/openai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio-openai"
-version = "0.11.5"
+version = "0.11.6"
 description = "Use Composio to get an array of tools with your OpenAI Function Call."
 readme = "README.md"
 requires-python = ">=3.9,<4"

--- a/python/providers/openai/setup.py
+++ b/python/providers/openai/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 
 setup(
     name="composio_openai",
-    version="0.11.5",
+    version="0.11.6",
     author="Composio",
     author_email="tech@composio.dev",
     description="Use Composio to get an array of tools with your OpenAI Function Call.",

--- a/python/providers/openai_agents/pyproject.toml
+++ b/python/providers/openai_agents/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio-openai-agents"
-version = "0.11.5"
+version = "0.11.6"
 description = "Use Composio to get array of strongly typed tools for OpenAI Agents"
 readme = "README.md"
 requires-python = ">=3.9,<4"

--- a/python/providers/openai_agents/setup.py
+++ b/python/providers/openai_agents/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="composio_openai_agents",
-    version="0.11.5",
+    version="0.11.6",
     author="Composio",
     author_email="tech@composio.dev",
     description="Use Composio to get array of strongly typed tools for OpenAI Agents",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "composio"
-version = "0.11.5"
+version = "0.11.6"
 description = "SDK for integrating Composio with your applications."
 readme = "README.md"
 requires-python = ">=3.10,<4"

--- a/python/tests/test_auto_upload_download_files.py
+++ b/python/tests/test_auto_upload_download_files.py
@@ -173,6 +173,71 @@ class TestAutoUploadDownloadFilesEnabled:
 
                 mock_upload.assert_called_once()
 
+    def test_execute_runs_substitute_before_before_execute(
+        self, mock_client, mock_provider
+    ):
+        """File substitution runs before before_execute modifiers (same order as TypeScript)."""
+        from composio.core.models._modifiers import Modifier
+
+        tools = Tools(
+            client=mock_client,
+            provider=mock_provider,
+            auto_upload_download_files=True,
+            toolkit_versions={"test_toolkit": "20251201_01"},
+        )
+
+        mock_tool = create_mock_tool(
+            slug="TEST_TOOL",
+            toolkit_slug="test_toolkit",
+            input_parameters={
+                "type": "object",
+                "properties": {
+                    "file": {"type": "string", "file_uploadable": True},
+                },
+            },
+            output_parameters={"type": "object", "properties": {}},
+        )
+        tools._tool_schemas["TEST_TOOL"] = mock_tool
+
+        seen_in_modifier: list = []
+
+        def before_modifier(tool: str, toolkit: str, params):  # type: ignore[no-untyped-def]
+            seen_in_modifier.append(dict(params["arguments"]))
+            return params
+
+        modifiers = [
+            Modifier(
+                modifier=before_modifier, type_="before_execute", tools=[], toolkits=[]
+            ),
+        ]
+
+        with patch.object(
+            tools._file_helper,
+            "substitute_file_uploads",
+            return_value={"file": "after_substitute"},
+        ) as mock_sub:
+            mock_execute_response = Mock()
+            mock_execute_response.model_dump.return_value = {
+                "data": {},
+                "error": None,
+                "successful": True,
+            }
+            mock_client.tools.execute.return_value = mock_execute_response
+
+            with patch.object(
+                tools, "get_raw_composio_tool_by_slug", return_value=mock_tool
+            ):
+                tools.execute(
+                    slug="TEST_TOOL",
+                    arguments={"file": "/tmp/x"},
+                    modifiers=modifiers,
+                    dangerously_skip_version_check=True,
+                )
+
+        mock_sub.assert_called_once()
+        assert len(seen_in_modifier) == 1
+        assert seen_in_modifier[0] == {"file": "after_substitute"}
+
     def test_execute_calls_substitute_file_downloads(self, mock_client, mock_provider):
         """Test that execute calls substitute_file_downloads when enabled."""
         tools = Tools(

--- a/python/tests/test_sensitive_file_upload_paths.py
+++ b/python/tests/test_sensitive_file_upload_paths.py
@@ -1,0 +1,79 @@
+"""Tests for composio.utils.sensitive_file_upload_paths."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from composio.exceptions import SensitiveFilePathBlockedError
+from composio.utils.sensitive_file_upload_paths import (
+    assert_safe_local_file_upload_path,
+    is_blocked_sensitive_file_upload_path,
+)
+
+
+def test_allows_normal_project_files() -> None:
+    p = Path("/tmp") / "composio-test" / "document.pdf"
+    assert is_blocked_sensitive_file_upload_path(p) is False
+    assert_safe_local_file_upload_path(p)
+
+
+def test_blocks_common_credential_directory_segments() -> None:
+    home = Path.home()
+    assert is_blocked_sensitive_file_upload_path(home / ".aws" / "credentials") is True
+    assert is_blocked_sensitive_file_upload_path(home / ".ssh" / "id_ed25519") is True
+    assert (
+        is_blocked_sensitive_file_upload_path(home / ".claude" / "settings.json")
+        is True
+    )
+
+
+def test_blocks_env_style_basenames() -> None:
+    assert is_blocked_sensitive_file_upload_path(Path("/app/repo/.env")) is True
+    assert is_blocked_sensitive_file_upload_path(Path("/app/repo/.env.local")) is True
+
+
+def test_blocks_default_private_key_basenames() -> None:
+    assert is_blocked_sensitive_file_upload_path(Path("/tmp/id_ed25519")) is True
+
+
+def test_allows_public_key_by_basename() -> None:
+    assert is_blocked_sensitive_file_upload_path(Path("/tmp/id_ed25519.pub")) is False
+
+
+def test_honors_additional_deny_segments() -> None:
+    assert (
+        is_blocked_sensitive_file_upload_path(
+            Path("/data/secrets/x.txt"), additional_deny_segments=["secrets"]
+        )
+        is True
+    )
+    assert (
+        is_blocked_sensitive_file_upload_path(
+            Path("/data/ok/x.txt"), additional_deny_segments=["secrets"]
+        )
+        is False
+    )
+
+
+def test_blocks_after_symlink_resolves_to_sensitive_dir() -> None:
+    with tempfile.TemporaryDirectory() as root:
+        root_p = Path(root)
+        aws_dir = root_p / "nested" / ".aws"
+        aws_dir.mkdir(parents=True)
+        target = aws_dir / "creds"
+        target.write_text("x", encoding="utf-8")
+        link = root_p / "innocent-name"
+        try:
+            link.symlink_to(target)
+        except OSError:
+            pytest.skip("symlinks not supported")
+        assert is_blocked_sensitive_file_upload_path(link) is True
+
+
+def test_assert_safe_raises() -> None:
+    p = Path.home() / ".ssh" / "id_rsa"
+    with pytest.raises(SensitiveFilePathBlockedError):
+        assert_safe_local_file_upload_path(p)

--- a/python/tests/test_tool_router.py
+++ b/python/tests/test_tool_router.py
@@ -968,7 +968,12 @@ class TestToolRouter:
 
         # Verify Tools was instantiated
         mock_tools_class.assert_called_once_with(
-            client=mock_client, provider=mock_provider, auto_upload_download_files=True
+            client=mock_client,
+            provider=mock_provider,
+            auto_upload_download_files=True,
+            sensitive_file_upload_protection=True,
+            file_upload_path_deny_segments=None,
+            before_file_upload=None,
         )
 
         # Verify get_raw_tool_router_meta_tools was called
@@ -1260,7 +1265,11 @@ class TestToolRouterExecution:
         # Create a real Tools instance to test the execute function
         from composio.core.models.tools import Tools as RealTools
 
-        real_tools = RealTools(client=mock_client, provider=mock_provider)
+        real_tools = RealTools(
+            client=mock_client,
+            provider=mock_provider,
+            auto_upload_download_files=False,
+        )
         execute_fn = real_tools._wrap_execute_tool_for_tool_router(
             session_id="session_123"
         )
@@ -1307,7 +1316,11 @@ class TestToolRouterExecution:
         from composio.core.models._modifiers import Modifier
         from composio.core.models.tools import Tools as RealTools
 
-        real_tools = RealTools(client=mock_client, provider=mock_provider)
+        real_tools = RealTools(
+            client=mock_client,
+            provider=mock_provider,
+            auto_upload_download_files=False,
+        )
 
         modifiers = [
             Modifier(
@@ -1346,7 +1359,11 @@ class TestToolRouterExecution:
         # Create a real execute function
         from composio.core.models.tools import Tools as RealTools
 
-        real_tools = RealTools(client=mock_client, provider=mock_provider)
+        real_tools = RealTools(
+            client=mock_client,
+            provider=mock_provider,
+            auto_upload_download_files=False,
+        )
         execute_fn = real_tools._wrap_execute_tool_for_tool_router(
             session_id="session_123"
         )

--- a/uv.lock
+++ b/uv.lock
@@ -591,7 +591,7 @@ wheels = [
 
 [[package]]
 name = "composio"
-version = "0.11.2"
+version = "0.11.6"
 source = { virtual = "python" }
 dependencies = [
     { name = "composio-client" },
@@ -621,7 +621,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "composio-client", specifier = "==1.28.0" },
+    { name = "composio-client", specifier = "==1.33.0" },
     { name = "json-schema-to-pydantic", specifier = ">=0.4.8" },
     { name = "openai" },
     { name = "pydantic", specifier = ">=2.6.4" },
@@ -648,7 +648,7 @@ dev = [
 
 [[package]]
 name = "composio-anthropic"
-version = "0.11.2"
+version = "0.11.6"
 source = { virtual = "python/providers/anthropic" }
 dependencies = [
     { name = "anthropic" },
@@ -663,7 +663,7 @@ requires-dist = [
 
 [[package]]
 name = "composio-client"
-version = "1.28.0"
+version = "1.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -673,14 +673,14 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/99/45/5f063d364bef7879252c3dab517a42a9f3fdf1ad8943895f5b718c27fd31/composio_client-1.28.0.tar.gz", hash = "sha256:787869c1fba543f07aa26d1f64e5f37e4909465b37af24ec4b5a01fd73115045", size = 209918 }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/11/88d09721f03431deb8b055fe39cedb79697e5a72d4342fa033d277b1eb70/composio_client-1.33.0.tar.gz", hash = "sha256:3b92400383ca2454a361e3ad8d55e2b447b47ed3c4cd4910f61466e5933554c1", size = 225669 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/8c/901f59aaf8674f8bda6da1fbae087eb5209f11a9b26f6118c2be49702d0c/composio_client-1.28.0-py3-none-any.whl", hash = "sha256:8f037d8e66b3bfb3aa701b4d26c8a242d22638031b938a363874ebc41e4710ee", size = 239827 },
+    { url = "https://files.pythonhosted.org/packages/93/bc/83efc07964e39109c4471f8873dda98cd16137c8e4e2d4456a8a5d8f9c42/composio_client-1.33.0-py3-none-any.whl", hash = "sha256:8c01f096772272398760f5c553b3444b5706e346b294856f613b092f1d3afd6b", size = 252699 },
 ]
 
 [[package]]
 name = "composio-crewai"
-version = "0.11.2"
+version = "0.11.6"
 source = { virtual = "python/providers/crewai" }
 dependencies = [
     { name = "composio" },
@@ -695,7 +695,7 @@ requires-dist = [
 
 [[package]]
 name = "composio-gemini"
-version = "0.11.2"
+version = "0.11.6"
 source = { virtual = "python/providers/gemini" }
 dependencies = [
     { name = "composio" },
@@ -710,7 +710,7 @@ requires-dist = [
 
 [[package]]
 name = "composio-google"
-version = "0.11.2"
+version = "0.11.6"
 source = { virtual = "python/providers/google" }
 dependencies = [
     { name = "composio" },
@@ -725,7 +725,7 @@ requires-dist = [
 
 [[package]]
 name = "composio-google-adk"
-version = "0.11.2"
+version = "0.11.6"
 source = { virtual = "python/providers/google_adk" }
 dependencies = [
     { name = "composio" },
@@ -740,7 +740,7 @@ requires-dist = [
 
 [[package]]
 name = "composio-langchain"
-version = "0.11.2"
+version = "0.11.6"
 source = { virtual = "python/providers/langchain" }
 dependencies = [
     { name = "composio" },
@@ -755,7 +755,7 @@ requires-dist = [
 
 [[package]]
 name = "composio-openai"
-version = "0.11.2"
+version = "0.11.6"
 source = { virtual = "python/providers/openai" }
 dependencies = [
     { name = "composio" },
@@ -770,7 +770,7 @@ requires-dist = [
 
 [[package]]
 name = "composio-openai-agents"
-version = "0.11.2"
+version = "0.11.6"
 source = { virtual = "python/providers/openai_agents" }
 dependencies = [
     { name = "composio" },


### PR DESCRIPTION
## Summary
Stacks Python SDK changes on [`haxzie/feat/patch-sdk-to-prevent-files-from-being-uploaded-downloaded-2026-04-23`](https://github.com/ComposioHQ/composio/tree/haxzie/feat/patch-sdk-to-prevent-files-from-being-uploaded-downloaded-2026-04-23) (TypeScript sensitive-path protection and `beforeFileUpload`).

## Changes
- Built-in sensitive path denylist, optional extra deny segments, and `before_file_upload` hook; wire through `Composio`, `ToolRouter`, `ToolRouterSession`, and file helpers.
- Run `substitute_file_uploads` **before** `before_execute` modifiers (including tool router `execute_meta` path), matching TypeScript behavior.
- New errors: `SensitiveFilePathBlockedError`, `FileUploadAbortedError`.
- Patch bump Python packages to **0.11.6**.

## Tests
- `ruff check` on touched Python paths; `pytest` for `test_tool_router`, `test_auto_upload_download_files`, `test_files`, `test_custom_tools` (run locally).

Made with [Cursor](https://cursor.com)