### PR TITLE
docs(changelog): SEC-339 link auth migration for Composio-managed OAuth

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -24,3 +24,7 @@ be30c1c2be63d5b8651ba520779c19662d5fd6c3:docs/content/docs/observability/usage.m
 be30c1c2be63d5b8651ba520779c19662d5fd6c3:docs/content/docs/observability/usage.mdx:curl-auth-header:155
 be30c1c2be63d5b8651ba520779c19662d5fd6c3:docs/content/docs/observability/usage.mdx:curl-auth-header:171
 be30c1c2be63d5b8651ba520779c19662d5fd6c3:docs/content/docs/observability/usage.mdx:curl-auth-header:185
+
+# SEC-339 link auth migration changelog — curl examples use <YOUR_API_KEY> placeholder (not real secrets)
+eb38c367b73d0476e21de5d552252f5166ba7698:docs/content/changelog/04-24-26-link-auth-migration.mdx:curl-auth-header:38
+eb38c367b73d0476e21de5d552252f5166ba7698:docs/content/changelog/04-24-26-link-auth-migration.mdx:curl-auth-header:50

--- a/docs/content/changelog/04-24-26-link-auth-migration.mdx
+++ b/docs/content/changelog/04-24-26-link-auth-migration.mdx
@@ -1,0 +1,79 @@
+---
+title: "Link Auth Migration for Composio-Managed OAuth Connections"
+description: "POST /api/v3/connected_accounts will stop creating Composio-managed OAuth1/OAuth2/DCR_OAUTH connections. Callers must migrate to POST /api/v3/connected_accounts/link. Rollout begins the first week of May 2026 for new organizations."
+date: "2026-04-24"
+---
+
+`POST /api/v3/connected_accounts` is being retired for **Composio-managed OAuth connections**. New organizations begin migrating the first week of May 2026, and all remaining organizations follow the first week of July 2026. Once migrated, affected requests receive `400 BadRequest` with a message pointing at the replacement endpoint.
+
+This does **not** affect custom auth configs (your own OAuth app) or non-OAuth schemes (API key, bearer token, basic auth, etc.) — those continue to work on `POST /api/v3/connected_accounts` unchanged. Only the specific combination of **Composio-managed auth config + redirectable OAuth scheme** (OAuth1, OAuth2, DCR_OAUTH) is moving.
+
+<Callout type="warn">
+**Breaking Change (phased rollout)**
+
+If your integration calls `POST /api/v3/connected_accounts` for a Composio-managed OAuth1, OAuth2, or DCR_OAUTH auth config, it will start returning `400 BadRequest` on the dates below. Migrate to `POST /api/v3/connected_accounts/link` before your organization's cutover.
+
+- **First week of May 2026** — organizations created on or after this window are blocked.
+- **First week of July 2026** — all remaining organizations are blocked.
+</Callout>
+
+### What's Changing
+
+| Request | Before | After (once rollout reaches your org) |
+|---------|--------|-------------------------------------|
+| `POST /api/v3/connected_accounts`, Composio-managed + OAuth1 / OAuth2 / DCR_OAUTH | Creates a connected account (redirect URL returned) | **`400 BadRequest`** — use `/link` instead |
+| `POST /api/v3/connected_accounts`, custom auth config | Creates a connected account | Unchanged |
+| `POST /api/v3/connected_accounts`, API key / bearer / other non-OAuth | Creates a connected account | Unchanged |
+| `POST /api/v3/connected_accounts/link` | Creates a link session | Unchanged — the recommended path going forward |
+
+### Why
+
+The link endpoint is built to make it explicit to the end user that they are authorizing a third-party application, and it produces a consistent redirect URL for every redirectable scheme. Concentrating Composio-managed OAuth flows on `/link` removes the DX ambiguity of a single endpoint that either returns a redirect URL or creates a fully-initialized connection depending on inputs.
+
+### Migration
+
+**Before** — legacy create (will be rejected for Composio-managed OAuth):
+
+```bash
+curl -X POST https://backend.composio.dev/api/v3/connected_accounts \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: ak_your_api_key" \
+  -d '{
+    "auth_config": { "id": "ac_your_composio_managed_oauth_config" },
+    "connection": { "user_id": "your_end_user_id" }
+  }'
+```
+
+**After** — link session (recommended, works for all schemes including non-OAuth and custom):
+
+```bash
+curl -X POST https://backend.composio.dev/api/v3/connected_accounts/link \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: ak_your_api_key" \
+  -d '{
+    "auth_config_id": "ac_your_composio_managed_oauth_config",
+    "user_id": "your_end_user_id"
+  }'
+```
+
+The response contains a `redirect_url` (valid for 10 minutes) that the end user opens to authorize the integration, plus a `connected_account_id` you can use to poll for status or associate with your own records.
+
+### Error Response (after rollout)
+
+Requests that hit the retired combination receive:
+
+```json
+{
+  "error": {
+    "code": "BadRequest",
+    "message": "Creating connections on this endpoint for Composio-managed OAuth auth configs is no longer supported. Use POST /api/v3/connected_accounts/link instead.",
+    "suggestedFix": "Call POST /api/v3/connected_accounts/link with the same auth_config_id and user_id to get a redirect URL for the end user."
+  }
+}
+```
+
+### What to Do
+
+- **If you use Composio-managed OAuth auth configs** (OAuth1, OAuth2, or DCR_OAUTH) via `POST /api/v3/connected_accounts`: switch to `POST /api/v3/connected_accounts/link` before your org's cutover date.
+- **If you already use `/link`**: no action required.
+- **If you use custom OAuth apps (your own `client_id` / `client_secret`) or non-OAuth auth (API key, bearer, etc.)**: no action required — the legacy endpoint continues to serve those cases.

--- a/docs/content/changelog/04-24-26-link-auth-migration.mdx
+++ b/docs/content/changelog/04-24-26-link-auth-migration.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Link Auth Migration for Composio-Managed OAuth Connections"
-description: "POST /api/v3/connected_accounts will stop creating Composio-managed OAuth1/OAuth2/DCR_OAUTH connections. Callers must migrate to POST /api/v3/connected_accounts/link. Rollout begins the first week of May 2026 for new organizations."
+description: "POST /api/v3/connected_accounts will stop creating Composio-managed OAuth1/OAuth2/DCR_OAUTH connections. Callers must migrate to POST /api/v3/connected_accounts/link. Rollout begins Friday, May 1, 2026 for new organizations."
 date: "2026-04-24"
 ---
 
-`POST /api/v3/connected_accounts` is being retired for **Composio-managed OAuth connections**. New organizations begin migrating the first week of May 2026, and all remaining organizations follow the first week of July 2026. Once migrated, affected requests receive `400 BadRequest` with a message pointing at the replacement endpoint.
+`POST /api/v3/connected_accounts` is being retired for **Composio-managed OAuth connections**. New organizations begin migrating on **Friday, May 1, 2026**, and all remaining organizations follow on **Friday, July 3, 2026**. Once migrated, affected requests receive `400 BadRequest` with a message pointing at the replacement endpoint.
 
 This does **not** affect custom auth configs (your own OAuth app) or non-OAuth schemes (API key, bearer token, basic auth, etc.) — those continue to work on `POST /api/v3/connected_accounts` unchanged. Only the specific combination of **Composio-managed auth config + redirectable OAuth scheme** (OAuth1, OAuth2, DCR_OAUTH) is moving.
 
@@ -13,8 +13,8 @@ This does **not** affect custom auth configs (your own OAuth app) or non-OAuth s
 
 If your integration calls `POST /api/v3/connected_accounts` for a Composio-managed OAuth1, OAuth2, or DCR_OAUTH auth config, it will start returning `400 BadRequest` on the dates below. Migrate to `POST /api/v3/connected_accounts/link` before your organization's cutover.
 
-- **First week of May 2026** — organizations created on or after this window are blocked.
-- **First week of July 2026** — all remaining organizations are blocked.
+- **Friday, May 1, 2026 (00:00 UTC)** — organizations created on or after this timestamp are blocked.
+- **Friday, July 3, 2026 (00:00 UTC)** — all remaining organizations are blocked.
 </Callout>
 
 ### What's Changing
@@ -28,7 +28,9 @@ If your integration calls `POST /api/v3/connected_accounts` for a Composio-manag
 
 ### Why
 
-The link endpoint is built to make it explicit to the end user that they are authorizing a third-party application, and it produces a consistent redirect URL for every redirectable scheme. Concentrating Composio-managed OAuth flows on `/link` removes the DX ambiguity of a single endpoint that either returns a redirect URL or creates a fully-initialized connection depending on inputs.
+When a connection is initiated through a default (Composio-managed) auth config, a Composio-owned OAuth application is acting on behalf of your integration. We want the end user to explicitly understand and acknowledge, at the moment of connection, that they are granting a third-party application access to their account on the external service. That acknowledgement is enforced by the `/link` flow, which routes the user through a consent screen before the connection is created. The legacy `POST /api/v3/connected_accounts` path allowed that step to be bypassed when credentials were passed in directly, which this change closes.
+
+Custom auth configs are unaffected because they are backed by your own OAuth application — the consent screen is served by your app, so you already own that experience. This change is scoped specifically to default auth configs on redirectable schemes, where the third-party relationship is with Composio rather than with the developer.
 
 ### Migration
 
@@ -74,6 +76,6 @@ Requests that hit the retired combination receive:
 
 ### What to Do
 
-- **If you use Composio-managed OAuth auth configs** (OAuth1, OAuth2, or DCR_OAUTH) via `POST /api/v3/connected_accounts`: switch to `POST /api/v3/connected_accounts/link` before your org's cutover date.
+- **If you use Composio-managed OAuth auth configs** (OAuth1, OAuth2, or DCR_OAUTH) via `POST /api/v3/connected_accounts`: switch to `POST /api/v3/connected_accounts/link` before your org's cutover — **Friday, May 1, 2026** for organizations created on or after that date, **Friday, July 3, 2026** for all others.
 - **If you already use `/link`**: no action required.
 - **If you use custom OAuth apps (your own `client_id` / `client_secret`) or non-OAuth auth (API key, bearer, etc.)**: no action required — the legacy endpoint continues to serve those cases.

--- a/docs/content/changelog/04-24-26-link-auth-migration.mdx
+++ b/docs/content/changelog/04-24-26-link-auth-migration.mdx
@@ -39,7 +39,7 @@ Custom auth configs are unaffected because they are backed by your own OAuth app
 ```bash
 curl -X POST https://backend.composio.dev/api/v3/connected_accounts \
   -H "Content-Type: application/json" \
-  -H "x-api-key: ak_your_api_key" \
+  -H "x-api-key: <YOUR_API_KEY>" \
   -d '{
     "auth_config": { "id": "ac_your_composio_managed_oauth_config" },
     "connection": { "user_id": "your_end_user_id" }
@@ -51,7 +51,7 @@ curl -X POST https://backend.composio.dev/api/v3/connected_accounts \
 ```bash
 curl -X POST https://backend.composio.dev/api/v3/connected_accounts/link \
   -H "Content-Type: application/json" \
-  -H "x-api-key: ak_your_api_key" \
+  -H "x-api-key: <YOUR_API_KEY>" \
   -d '{
     "auth_config_id": "ac_your_composio_managed_oauth_config",
     "user_id": "your_end_user_id"

--- a/docs/content/changelog/04-24-26-link-auth-migration.mdx
+++ b/docs/content/changelog/04-24-26-link-auth-migration.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Link Auth Migration for Composio-Managed OAuth Connections"
-description: "POST /api/v3/connected_accounts will stop creating Composio-managed OAuth1/OAuth2/DCR_OAUTH connections. Callers must migrate to POST /api/v3/connected_accounts/link. Rollout begins Friday, May 1, 2026 for new organizations."
+description: "POST /api/v3/connected_accounts will stop creating Composio-managed OAuth1/OAuth2/DCR_OAUTH connections. Callers must migrate to POST /api/v3/connected_accounts/link. Rollout begins Friday, May 8, 2026 for new organizations."
 date: "2026-04-24"
 ---
 
-`POST /api/v3/connected_accounts` is being retired for **Composio-managed OAuth connections**. New organizations begin migrating on **Friday, May 1, 2026**, and all remaining organizations follow on **Friday, July 3, 2026**. Once migrated, affected requests receive `400 BadRequest` with a message pointing at the replacement endpoint.
+`POST /api/v3/connected_accounts` is being retired for **Composio-managed OAuth connections**. New organizations begin migrating on **Friday, May 8, 2026**, and all remaining organizations follow on **Friday, July 3, 2026**. Once migrated, affected requests receive `400 BadRequest` with a message pointing at the replacement endpoint.
 
 This does **not** affect custom auth configs (your own OAuth app) or non-OAuth schemes (API key, bearer token, basic auth, etc.) — those continue to work on `POST /api/v3/connected_accounts` unchanged. Only the specific combination of **Composio-managed auth config + redirectable OAuth scheme** (OAuth1, OAuth2, DCR_OAUTH) is moving.
 
@@ -13,7 +13,7 @@ This does **not** affect custom auth configs (your own OAuth app) or non-OAuth s
 
 If your integration calls `POST /api/v3/connected_accounts` for a Composio-managed OAuth1, OAuth2, or DCR_OAUTH auth config, it will start returning `400 BadRequest` on the dates below. Migrate to `POST /api/v3/connected_accounts/link` before your organization's cutover.
 
-- **Friday, May 1, 2026 (00:00 UTC)** — organizations created on or after this timestamp are blocked.
+- **Friday, May 8, 2026 (00:00 UTC)** — organizations created on or after this timestamp are blocked.
 - **Friday, July 3, 2026 (00:00 UTC)** — all remaining organizations are blocked.
 </Callout>
 
@@ -76,6 +76,6 @@ Requests that hit the retired combination receive:
 
 ### What to Do
 
-- **If you use Composio-managed OAuth auth configs** (OAuth1, OAuth2, or DCR_OAUTH) via `POST /api/v3/connected_accounts`: switch to `POST /api/v3/connected_accounts/link` before your org's cutover — **Friday, May 1, 2026** for organizations created on or after that date, **Friday, July 3, 2026** for all others.
+- **If you use Composio-managed OAuth auth configs** (OAuth1, OAuth2, or DCR_OAUTH) via `POST /api/v3/connected_accounts`: switch to `POST /api/v3/connected_accounts/link` before your org's cutover — **Friday, May 8, 2026** for organizations created on or after that date, **Friday, July 3, 2026** for all others.
 - **If you already use `/link`**: no action required.
 - **If you use custom OAuth apps (your own `client_id` / `client_secret`) or non-OAuth auth (API key, bearer, etc.)**: no action required — the legacy endpoint continues to serve those cases.


### PR DESCRIPTION
## Summary

Adds a changelog entry announcing the phased retirement of `POST /api/v3/connected_accounts` for Composio-managed + redirectable-OAuth auth configs. Callers should migrate to `POST /api/v3/connected_accounts/link`.

Paired with the backend change in [ComposioHQ/hermes#9608](https://github.com/ComposioHQ/hermes/pull/9608) — that PR implements the block; this PR is the customer-facing announcement.

## What the entry covers

- Which requests change (Composio-managed OAuth1 / OAuth2 / DCR_OAUTH on the legacy endpoint) and which do not (custom auth configs, non-OAuth schemes, anything already on `/link`).
- Phased rollout dates: **first week of May 2026** (new orgs), **first week of July 2026** (all remaining orgs).
- Migration block with before/after cURL to move from the legacy endpoint to `/link`.
- The exact `400 BadRequest` error body affected callers will see after rollout.
- A short "what to do" checklist per audience.

## Preview

File: `docs/content/changelog/04-24-26-link-auth-migration.mdx`

The entry follows the existing conventions in `docs/.claude/guides/changelog.md`: no `#` heading, sections start at `###`, `<Callout type="warn">` for the breaking change, table for before/after API behavior, no emoji.

## Base branch

Targeting `next` per the docs git workflow (`docs/CLAUDE.md` rule: docs branches branch off `next` and PRs target `next`).

## Testing

- Inspected rendering structure against the sibling entry `docs/content/changelog/04-24-26-proxy-execute-same-domain.mdx` (same date, same breaking-change shape) to match tone, headings, and callout style.
- No internal docs links in the new file, so the link checker path is not exercised.