### PR TITLE
fix: use unrun config loader for tsdown builds

### DIFF
--- a/ts/packages/cli-keyring/tsdown.config.ts
+++ b/ts/packages/cli-keyring/tsdown.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'tsdown';
-import { baseConfig } from '../../../tsdown.config.base';
+import { baseConfig } from '../../../tsdown.config.base.ts';
 
 export default defineConfig({
   ...baseConfig,

--- a/ts/packages/cli/tsdown.config.ts
+++ b/ts/packages/cli/tsdown.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'tsdown';
-import { baseConfig } from '../../../tsdown.config.base';
+import { baseConfig } from '../../../tsdown.config.base.ts';
 
 export default defineConfig({
   ...baseConfig,

--- a/ts/packages/core/package.json
+++ b/ts/packages/core/package.json
@@ -131,7 +131,7 @@
   ],
   "scripts": {
     "clean": "git clean -xdf node_modules",
-    "build": "pnpm exec tsdown",
+    "build": "pnpm exec tsdown --config-loader unrun",
     "test": "vitest run",
     "typecheck": "pnpm exec tsgo --noEmit --skipLibCheck && pnpm exec tsgo --noEmit --skipLibCheck -p tsconfig.type-tests.json",
     "typecheck:tsc": "tsc --noEmit --skipLibCheck && tsc --noEmit --skipLibCheck -p tsconfig.type-tests.json",

--- a/ts/packages/core/tsdown.config.ts
+++ b/ts/packages/core/tsdown.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig, UserConfig } from 'tsdown';
-import { baseConfig } from '../../../tsdown.config.base';
+import { baseConfig } from '../../../tsdown.config.base.ts';
 
 export default defineConfig({
   ...baseConfig,

--- a/ts/packages/json-schema-to-zod/tsdown.config.ts
+++ b/ts/packages/json-schema-to-zod/tsdown.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'tsdown';
-import { baseConfig } from '../../../tsdown.config.base';
+import { baseConfig } from '../../../tsdown.config.base.ts';
 
 export default defineConfig({
   ...baseConfig,

--- a/ts/packages/providers/anthropic/tsdown.config.ts
+++ b/ts/packages/providers/anthropic/tsdown.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'tsdown';
-import { baseConfig } from '../../../../tsdown.config.base';
+import { baseConfig } from '../../../../tsdown.config.base.ts';
 
 export default defineConfig({
   ...baseConfig,

--- a/ts/packages/providers/claude-agent-sdk/tsdown.config.ts
+++ b/ts/packages/providers/claude-agent-sdk/tsdown.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'tsdown';
-import { baseConfig } from '../../../../tsdown.config.base';
+import { baseConfig } from '../../../../tsdown.config.base.ts';
 
 export default defineConfig({
   ...baseConfig,

--- a/ts/packages/providers/cloudflare/tsdown.config.ts
+++ b/ts/packages/providers/cloudflare/tsdown.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'tsdown';
-import { baseConfig } from '../../../../tsdown.config.base';
+import { baseConfig } from '../../../../tsdown.config.base.ts';
 
 export default defineConfig({
   ...baseConfig,

--- a/ts/packages/providers/google/tsdown.config.ts
+++ b/ts/packages/providers/google/tsdown.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'tsdown';
-import { baseConfig } from '../../../../tsdown.config.base';
+import { baseConfig } from '../../../../tsdown.config.base.ts';
 
 export default defineConfig({
   ...baseConfig,

--- a/ts/packages/providers/langchain/tsdown.config.ts
+++ b/ts/packages/providers/langchain/tsdown.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'tsdown';
-import { baseConfig } from '../../../../tsdown.config.base';
+import { baseConfig } from '../../../../tsdown.config.base.ts';
 
 export default defineConfig({
   ...baseConfig,

--- a/ts/packages/providers/llamaindex/tsdown.config.ts
+++ b/ts/packages/providers/llamaindex/tsdown.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'tsdown';
-import { baseConfig } from '../../../../tsdown.config.base';
+import { baseConfig } from '../../../../tsdown.config.base.ts';
 
 export default defineConfig({
   ...baseConfig,

--- a/ts/packages/providers/mastra/tsdown.config.ts
+++ b/ts/packages/providers/mastra/tsdown.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'tsdown';
-import { baseConfig } from '../../../../tsdown.config.base';
+import { baseConfig } from '../../../../tsdown.config.base.ts';
 
 export default defineConfig({
   ...baseConfig,

--- a/ts/packages/providers/openai-agents/tsdown.config.ts
+++ b/ts/packages/providers/openai-agents/tsdown.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'tsdown';
-import { baseConfig } from '../../../../tsdown.config.base';
+import { baseConfig } from '../../../../tsdown.config.base.ts';
 
 export default defineConfig({
   ...baseConfig,

--- a/ts/packages/providers/openai/tsdown.config.ts
+++ b/ts/packages/providers/openai/tsdown.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'tsdown';
-import { baseConfig } from '../../../../tsdown.config.base';
+import { baseConfig } from '../../../../tsdown.config.base.ts';
 
 export default defineConfig({
   ...baseConfig,

--- a/ts/packages/providers/vercel/tsdown.config.ts
+++ b/ts/packages/providers/vercel/tsdown.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'tsdown';
-import { baseConfig } from '../../../../tsdown.config.base';
+import { baseConfig } from '../../../../tsdown.config.base.ts';
 
 export default defineConfig({
   ...baseConfig,

--- a/ts/packages/ts-builders/tsdown.config.ts
+++ b/ts/packages/ts-builders/tsdown.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'tsdown';
-import { baseConfig } from '../../../tsdown.config.base';
+import { baseConfig } from '../../../tsdown.config.base.ts';
 
 export default defineConfig({
   ...baseConfig,


### PR DESCRIPTION
## Summary
Fixes build failures in the TypeScript monorepo caused by tsdown config loading issues (observed on Node v24) where package builds failed unless `--config-loader unrun` was explicitly passed.

This change makes the build reproducible by baking the config loader into package build scripts instead of relying on manual CLI flags.

Fixes #N/A

---

## Changes
- Updated tsdown build scripts to use `--config-loader unrun`
- Fixed monorepo package builds that failed under the default tsdown loader
- Verified packages now build successfully via plain `pnpm build`

---

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [ ] Documentation
- [ ] Breaking change

---

## How Has This Been Tested?

Tested locally on:

- macOS
- Node v24.12.0
- pnpm 10.28.0

```bash
pnpm build

