### PR TITLE
docs(python): remove legacy v0 SDK references from package READMEs

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -20,31 +20,48 @@ The Composio Python SDK allows you to interact with the Composio Platform. It pr
 
 ```bash
 pip install composio
-# or
-pip install composio-core
 ```
+
+> **Note:** `composio-core` is the legacy SDK and is no longer maintained. Install `composio` for the current SDK.
 
 ### Provider-Specific Installations
 
-For specific AI framework integrations:
+For specific AI framework integrations, install the matching provider package alongside `composio`:
 
 ```bash
 # OpenAI integration
-pip install composio-openai
+pip install composio composio-openai
 
-# LangChain integration  
-pip install composio-langchain
+# OpenAI Agents SDK integration
+pip install composio composio-openai-agents
+
+# Anthropic (Claude) integration
+pip install composio composio-anthropic
+
+# Claude Agent SDK integration
+pip install composio composio-claude-agent-sdk
+
+# LangChain integration
+pip install composio composio-langchain
+
+# LangGraph integration
+pip install composio composio-langgraph
 
 # CrewAI integration
-pip install composio-crewai
+pip install composio composio-crewai
 
-# Anthropic integration
-pip install composio-anthropic
+# LlamaIndex integration
+pip install composio composio-llamaindex
+
+# Google GenAI / Gemini integration
+pip install composio composio-google
+pip install composio composio-gemini
+
+# Google ADK integration
+pip install composio composio-google-adk
 
 # AutoGen integration
-pip install composio-autogen
-
-# And many more...
+pip install composio composio-autogen
 ```
 
 ## Getting Started
@@ -162,33 +179,25 @@ print(result)
 #### LangChain Integration
 
 ```python
-from composio_langchain import ComposioToolSet
+from composio import Composio
+from composio_langchain import LangchainProvider
+from langchain.agents import create_agent
 from langchain_openai import ChatOpenAI
 
-# Initialize the toolset
-toolset = ComposioToolSet()
+# Initialize Composio with the LangChain provider
+composio = Composio(provider=LangchainProvider())
 
 # Get tools for a specific toolkit
-tools = toolset.get_tools(toolkits=["GITHUB"])
+tools = composio.tools.get(user_id="default", toolkits=["GITHUB"])
 
 # Initialize LLM
 llm = ChatOpenAI(model="gpt-4o")
 
 # Create agent with tools
-from langchain.agents import create_openai_functions_agent, AgentExecutor
-from langchain.prompts import ChatPromptTemplate
-
-prompt = ChatPromptTemplate.from_messages([
-    ("system", "You are a helpful assistant"),
-    ("user", "{input}"),
-    ("assistant", "{agent_scratchpad}")
-])
-
-agent = create_openai_functions_agent(llm, tools, prompt)
-agent_executor = AgentExecutor(agent=agent, tools=tools)
+agent = create_agent(model=llm, tools=tools, system_prompt="You are a helpful assistant")
 
 # Execute task
-result = agent_executor.invoke({"input": "Star the composiohq/composio repository"})
+result = agent.invoke({"messages": [{"role": "user", "content": "Star the composiohq/composio repository"}]})
 print(result)
 ```
 
@@ -198,7 +207,7 @@ The Composio constructor accepts the following configuration options:
 
 ```python
 from composio import Composio
-from composio.core.provider import OpenAIProvider
+from composio_openai import OpenAIProvider
 
 composio = Composio(
     api_key="your-api-key",  # Your Composio API key

--- a/python/README.md
+++ b/python/README.md
@@ -53,8 +53,10 @@ pip install composio composio-crewai
 # LlamaIndex integration
 pip install composio composio-llamaindex
 
-# Google GenAI / Gemini integration
+# Google Vertex AI integration
 pip install composio composio-google
+
+# Google GenAI / Gemini integration
 pip install composio composio-gemini
 
 # Google ADK integration
@@ -207,7 +209,6 @@ The Composio constructor accepts the following configuration options:
 
 ```python
 from composio import Composio
-from composio_openai import OpenAIProvider
 
 composio = Composio(
     api_key="your-api-key",  # Your Composio API key
@@ -216,7 +217,7 @@ composio = Composio(
     max_retries=3,  # Maximum number of retries
     allow_tracking=True,  # Enable/disable telemetry (default: True)
     file_download_dir="./downloads",  # Directory for file downloads
-    provider=OpenAIProvider(),  # Custom provider (default: OpenAIProvider)
+    # provider=OpenAIProvider(),  # Default; install `composio-openai` to import explicitly
     toolkit_versions={ "github": "12202025_01" }  # Toolkit versions to use
 )
 ```

--- a/python/providers/anthropic/README.md
+++ b/python/providers/anthropic/README.md
@@ -11,12 +11,10 @@ Facilitate the integration of Anthropic's Claude with Composio to empower Claude
 Ensure you have the necessary packages installed and connect your GitHub account to allow your agents to utilize GitHub functionalities.
 
 ```bash
-# Install Composio core and the Anthropic provider
 pip install composio composio-anthropic anthropic
-
-# Connect your GitHub account (also available in the dashboard)
-composio link github
 ```
+
+Connect your GitHub account from the [Composio dashboard](https://platform.composio.dev/) before running the example.
 
 > Looking for the Claude Agent SDK? See `composio-claude-agent-sdk` instead.
 

--- a/python/providers/anthropic/README.md
+++ b/python/providers/anthropic/README.md
@@ -14,11 +14,8 @@ Ensure you have the necessary packages installed and connect your GitHub account
 # Install Composio core and the Anthropic provider
 pip install composio composio-anthropic anthropic
 
-# Connect your GitHub account
-composio add github
-
-# View available toolkits you can connect with
-composio toolkits
+# Connect your GitHub account (also available in the dashboard)
+composio link github
 ```
 
 > Looking for the Claude Agent SDK? See `composio-claude-agent-sdk` instead.

--- a/python/providers/anthropic/README.md
+++ b/python/providers/anthropic/README.md
@@ -1,71 +1,77 @@
 ## 🚀🔗 Leveraging Claude with Composio
 
-Facilitate the integration of Claude with Composio to empower Claude models to directly interact with external applications, broadening their capabilities and application scope.
+Facilitate the integration of Anthropic's Claude with Composio to empower Claude models to directly interact with external applications, broadening their capabilities and application scope.
 
 ### Objective
 
-- **Automate starring a GitHub repository** using conversational instructions via Claude Function Calls.
+- **Automate starring a GitHub repository** using conversational instructions via Claude tool use.
 
 ### Installation and Setup
 
 Ensure you have the necessary packages installed and connect your GitHub account to allow your agents to utilize GitHub functionalities.
 
 ```bash
-# Install Composio LangChain package
-pip install composio-claude
+# Install Composio core and the Anthropic provider
+pip install composio composio-anthropic anthropic
 
 # Connect your GitHub account
-composio-cli add github
+composio add github
 
-# View available applications you can connect with
-composio-cli show-apps
+# View available toolkits you can connect with
+composio toolkits
 ```
+
+> Looking for the Claude Agent SDK? See `composio-claude-agent-sdk` instead.
 
 ### Usage Steps
 
 #### 1. Import Base Packages
 
-Prepare your environment by initializing necessary imports from Claude and setting up your client.
+Prepare your environment by initializing necessary imports from Anthropic and Composio.
 
 ```python
 import anthropic
 
+from composio import Composio
+from composio_anthropic import AnthropicProvider
+
 # Initialize Claude client
 client = anthropic.Anthropic()
+
+# Initialize Composio with the Anthropic provider
+composio = Composio(provider=AnthropicProvider())
 ```
 
 ### Step 2: Integrating GitHub Tools with Composio
 
-This step involves fetching and integrating GitHub tools provided by Composio, enabling enhanced functionality for LangChain operations.
-```python
-from composio_claude import App, ComposioToolSet
+Fetch GitHub tools for the user from Composio. Tools are returned in the Claude tool-use format, ready to pass to `messages.create`.
 
-toolset = ComposioToolSet()
-actions = toolset.get_tools(tools=App.GITHUB)
+```python
+tools = composio.tools.get(user_id="default", toolkits=["GITHUB"])
 ```
 
 ### Step 3: Agent Execution
 
-This step involves configuring and executing the agent to carry out actions, such as starring a GitHub repository.
+Send a request to Claude with the Composio-provided tools.
 
 ```python
-my_task = "Star a repo composiohq/composio on GitHub"
+task = "Star me composiohq/composio repo in github."
 
-# Create a chat completion request to decide on the action
-response = client.beta.tools.messages.create(
+response = client.messages.create(
     model="claude-3-opus-20240229",
     max_tokens=1024,
-    tools= actions,
-    messages=[{"role": "user", "content": "Star me composiohq/composio repo in github."}],
+    tools=tools,
+    messages=[{"role": "user", "content": task}],
 )
-pprint(response)
+
+print(response)
 ```
 
 ### Step 4: Validate Execution Response
 
-Execute the following code to validate the response, ensuring that the intended task has been successfully completed.
+Have Composio handle any tool calls the model produced and return the results.
 
 ```python
-result = toolset.handle_tool_calls(response)
-pprint(result)
+result = composio.provider.handle_tool_calls(user_id="default", response=response)
+print(result)
 ```

--- a/python/providers/gemini/README.md
+++ b/python/providers/gemini/README.md
@@ -1,69 +1,64 @@
 ## 🚀🔗 Integrating Composio with Google's Gemini SDK
 
-Streamline the integration of Composio with Google AI Python to enhance the capabilities of Gemini models, allowing them to interact directly with external applications and expanding their operational scope.
+Streamline the integration of Composio with the Google GenAI (Gemini) SDK to enhance the capabilities of Gemini models, allowing them to interact directly with external applications and expanding their operational scope.
 
 ### Objective
 
-- **Automate starring a GitHub repository** using conversational instructions via Google AI Python's Function Calling feature.
+- **Automate starring a GitHub repository** using conversational instructions via Gemini's function-calling feature.
 
 ### Installation and Setup
 
 Ensure you have the necessary packages installed and connect your GitHub account to allow your agents to utilize GitHub functionalities.
 
 ```bash
-# Install Composio Gemini package
-pip install composio-gemini
+# Install Composio core and the Gemini provider
+pip install composio composio-gemini google-genai
 
 # Connect your GitHub account
 composio add github
 
-# View available applications you can connect with
-composio apps
+# View available toolkits you can connect with
+composio toolkits
 ```
 
 ### Usage Steps
 
 #### 1. Import Base Packages
 
-Prepare your environment by initializing necessary imports from Google AI Python and setting up your client.
+Prepare your environment by initializing necessary imports from Google's GenAI SDK and Composio.
 
 ```python
 from google import genai
+from google.genai import types
 
-# Create google client
+from composio import Composio
+from composio_gemini import GeminiProvider
+
+# Initialize Composio with the Gemini provider
+composio = Composio(provider=GeminiProvider())
+
+# Create the Google GenAI client
 client = genai.Client()
 ```
 
 ### Step 2: Integrating GitHub Tools with Composio
 
-This step involves fetching and integrating GitHub tools provided by Composio, enabling enhanced functionality for Google AI Python operations.
+Fetch a specific GitHub tool from Composio and attach it to a Gemini config.
+
 ```python
-from google.genai import types
-
-from composio_gemini import Action, ComposioToolSet
-
-# Create composio client
-toolset = ComposioToolSet()
-
-# Create tools
-tools = toolset.get_tools(
-    actions=[
-        Action.GITHUB_STAR_A_REPOSITORY_FOR_THE_AUTHENTICATED_USER,
-    ]
-)
-
-# Create genai client config
 config = types.GenerateContentConfig(
-    tools=tools,  # type: ignore    
+    tools=composio.tools.get(
+        user_id="default",
+        tools=["GITHUB_STAR_A_REPOSITORY_FOR_THE_AUTHENTICATED_USER"],
+    )
 )
 ```
 
 ### Step 3: Agent Execution
 
-This step involves configuring and executing the agent to carry out actions, such as starring a GitHub repository.
+Use the chat interface to talk to Gemini.
 
 ```python
-# Use the chat interface.
 chat = client.chats.create(model="gemini-2.0-flash", config=config)
 response = chat.send_message(
     "Can you star composiohq/composio repository on github",

--- a/python/providers/gemini/README.md
+++ b/python/providers/gemini/README.md
@@ -11,12 +11,10 @@ Streamline the integration of Composio with the Google GenAI (Gemini) SDK to enh
 Ensure you have the necessary packages installed and connect your GitHub account to allow your agents to utilize GitHub functionalities.
 
 ```bash
-# Install Composio core and the Gemini provider
 pip install composio composio-gemini google-genai
-
-# Connect your GitHub account (also available in the dashboard)
-composio link github
 ```
+
+Connect your GitHub account from the [Composio dashboard](https://platform.composio.dev/) before running the example.
 
 ### Usage Steps
 

--- a/python/providers/gemini/README.md
+++ b/python/providers/gemini/README.md
@@ -14,11 +14,8 @@ Ensure you have the necessary packages installed and connect your GitHub account
 # Install Composio core and the Gemini provider
 pip install composio composio-gemini google-genai
 
-# Connect your GitHub account
-composio add github
-
-# View available toolkits you can connect with
-composio toolkits
+# Connect your GitHub account (also available in the dashboard)
+composio link github
 ```
 
 ### Usage Steps

--- a/python/providers/google/README.md
+++ b/python/providers/google/README.md
@@ -14,11 +14,8 @@ Ensure you have the necessary packages installed and connect your GitHub account
 # Install Composio core and the Google (Vertex AI) provider
 pip install composio composio-google google-cloud-aiplatform
 
-# Connect your GitHub account
-composio add github
-
-# View available toolkits you can connect with
-composio toolkits
+# Connect your GitHub account (also available in the dashboard)
+composio link github
 ```
 
 > Using the standalone `google-genai` SDK instead? See the `composio-gemini` provider.

--- a/python/providers/google/README.md
+++ b/python/providers/google/README.md
@@ -41,9 +41,9 @@ composio = Composio(provider=GoogleProvider())
 Fetch GitHub tools for the user from Composio and attach them to a Gemini model.
 
 ```python
-tool = composio.tools.get(user_id="default", toolkits=["GITHUB"])
+tools = composio.tools.get(user_id="default", toolkits=["GITHUB"])
 
-model = GenerativeModel("gemini-1.5-pro", tools=[tool])
+model = GenerativeModel("gemini-1.5-pro", tools=tools)
 chat = model.start_chat()
 ```
 

--- a/python/providers/google/README.md
+++ b/python/providers/google/README.md
@@ -11,12 +11,10 @@ Streamline the integration of Composio with Google AI Python to enhance the capa
 Ensure you have the necessary packages installed and connect your GitHub account to allow your agents to utilize GitHub functionalities.
 
 ```bash
-# Install Composio core and the Google (Vertex AI) provider
 pip install composio composio-google google-cloud-aiplatform
-
-# Connect your GitHub account (also available in the dashboard)
-composio link github
 ```
+
+Connect your GitHub account from the [Composio dashboard](https://platform.composio.dev/) before running the example.
 
 > Using the standalone `google-genai` SDK instead? See the `composio-gemini` provider.
 
@@ -27,7 +25,7 @@ composio link github
 Prepare your environment by initializing necessary imports from Google AI Python and Composio.
 
 ```python
-from vertexai.generative_models import GenerativeModel
+from vertexai.generative_models import GenerativeModel, Tool
 
 from composio import Composio
 from composio_google import GoogleProvider
@@ -38,12 +36,17 @@ composio = Composio(provider=GoogleProvider())
 
 ### Step 2: Integrating GitHub Tools with Composio
 
-Fetch GitHub tools for the user from Composio and attach them to a Gemini model.
+Fetch GitHub tools for the user from Composio. `GoogleProvider` returns
+`vertexai.generative_models.FunctionDeclaration` objects, so wrap them in a
+`Tool` before handing them to `GenerativeModel`.
 
 ```python
-tools = composio.tools.get(user_id="default", toolkits=["GITHUB"])
+declarations = composio.tools.get(user_id="default", toolkits=["GITHUB"])
 
-model = GenerativeModel("gemini-1.5-pro", tools=tools)
+model = GenerativeModel(
+    "gemini-1.5-pro",
+    tools=[Tool(function_declarations=declarations)],
+)
 chat = model.start_chat()
 ```
 

--- a/python/providers/google/README.md
+++ b/python/providers/google/README.md
@@ -1,66 +1,71 @@
-## 🚀🔗 Integrating Composio with Google AI Python
+## 🚀🔗 Integrating Composio with Google AI Python (Vertex AI)
 
-Streamline the integration of Composio with Google AI Python to enhance the capabilities of Gemini models, allowing them to interact directly with external applications and expanding their operational scope.
+Streamline the integration of Composio with Google AI Python to enhance the capabilities of Gemini models on Vertex AI, allowing them to interact directly with external applications and expanding their operational scope.
 
 ### Objective
 
-- **Automate starring a GitHub repository** using conversational instructions via Google AI Python's Function Calling feature.
+- **Automate starring a GitHub repository** using conversational instructions via Gemini's function-calling feature on Vertex AI.
 
 ### Installation and Setup
 
 Ensure you have the necessary packages installed and connect your GitHub account to allow your agents to utilize GitHub functionalities.
 
 ```bash
-# Install Composio LangChain package
-pip install composio-google
+# Install Composio core and the Google (Vertex AI) provider
+pip install composio composio-google google-cloud-aiplatform
 
 # Connect your GitHub account
-composio-cli add github
+composio add github
 
-# View available applications you can connect with
-composio-cli show-apps
+# View available toolkits you can connect with
+composio toolkits
 ```
+
+> Using the standalone `google-genai` SDK instead? See the `composio-gemini` provider.
 
 ### Usage Steps
 
 #### 1. Import Base Packages
 
-Prepare your environment by initializing necessary imports from Google AI Python and setting up your client.
+Prepare your environment by initializing necessary imports from Google AI Python and Composio.
 
 ```python
 from vertexai.generative_models import GenerativeModel
 
-# Initialize Google AI Python client
-model = GenerativeModel("gemini-pro")
+from composio import Composio
+from composio_google import GoogleProvider
+
+# Initialize Composio with the Google provider
+composio = Composio(provider=GoogleProvider())
 ```
 
 ### Step 2: Integrating GitHub Tools with Composio
 
-This step involves fetching and integrating GitHub tools provided by Composio, enabling enhanced functionality for Google AI Python operations.
-```python
-from composio_google import App, ComposioToolset
+Fetch GitHub tools for the user from Composio and attach them to a Gemini model.
 
-toolset = ComposioToolset()
-actions = toolset.get_tools(apps=[App.GITHUB])
+```python
+tool = composio.tools.get(user_id="default", toolkits=["GITHUB"])
+
+model = GenerativeModel("gemini-1.5-pro", tools=[tool])
+chat = model.start_chat()
 ```
 
 ### Step 3: Agent Execution
 
-This step involves configuring and executing the agent to carry out actions, such as starring a GitHub repository.
+Send a message to Gemini.
 
 ```python
-# Define task
 task = "Star a repo composiohq/composio on GitHub"
 
-# Send a message to the model
 response = chat.send_message(task)
+print(response)
 ```
 
 ### Step 4: Validate Execution Response
 
-Execute the following code to validate the response, ensuring that the intended task has been successfully completed.
+Have Composio handle any tool calls the model produced and return the results.
 
 ```python
-result = composio_toolset.handle_response(response)
+result = composio.provider.handle_response(user_id="default", response=response)
 print("Function call result:", result)
 ```

--- a/python/providers/langgraph/README.md
+++ b/python/providers/langgraph/README.md
@@ -11,12 +11,10 @@ Integrate Composio with LangGraph agentic workflows and enable them to interact 
 Ensure you have the necessary packages installed and connect your GitHub account to allow your agents to utilize GitHub functionalities.
 
 ```bash
-# Install Composio core and the LangGraph provider
 pip install composio composio-langgraph langgraph langchain_openai
-
-# Connect your GitHub account (also available in the dashboard)
-composio link github
 ```
+
+Connect your GitHub account from the [Composio dashboard](https://platform.composio.dev/) before running the example.
 
 ### Usage Steps
 

--- a/python/providers/langgraph/README.md
+++ b/python/providers/langgraph/README.md
@@ -1,31 +1,31 @@
 ## 🦜🕸️ Using Composio With LangGraph
 
-Integrate Composio with LangGraph Agentic workflows & enable them to interact seamlessly with external apps, enhancing their functionality and reach.
+Integrate Composio with LangGraph agentic workflows and enable them to interact seamlessly with external apps, enhancing their functionality and reach.
 
 ### Goal
 
-- **Star a repository on GitHub** using natural language commands through a LangGraph Agent.
+- **Star a repository on GitHub** using natural-language commands through a LangGraph agent.
 
 ### Installation and Setup
 
 Ensure you have the necessary packages installed and connect your GitHub account to allow your agents to utilize GitHub functionalities.
 
 ```bash
-# Install Composio LangGraph package
-pip install composio-langgraph
+# Install Composio core and the LangGraph provider
+pip install composio composio-langgraph langgraph langchain_openai
 
 # Connect your GitHub account
-composio-cli add github
+composio add github
 
-# View available applications you can connect with
-composio-cli show-apps
+# View available toolkits you can connect with
+composio toolkits
 ```
 
 ### Usage Steps
 
 #### 1. Import Base Packages
 
-Prepare your environment by initializing necessary imports from LangGraph & LangChain for setting up your agent.
+Prepare your environment by initializing necessary imports from LangGraph, LangChain, and Composio.
 
 ```python
 from typing import Literal
@@ -33,36 +33,40 @@ from typing import Literal
 from langchain_openai import ChatOpenAI
 from langgraph.graph import MessagesState, StateGraph
 from langgraph.prebuilt import ToolNode
+
+from composio import Composio
+from composio_langgraph import LanggraphProvider
 ```
 
-#### 2. Fetch GitHub LangGraph Tools via Composio
+#### 2. Fetch GitHub Tools via Composio
 
-Access GitHub tools provided by Composio for LangGraph, initialize a `ToolNode` with necessary tools obtaned from `ComposioToolSet`.
+Initialize Composio with the `LanggraphProvider` and fetch the GitHub tools you want the agent to use, then wrap them in a `ToolNode`.
 
 ```python
-from composio_langgraph import Action, ComposioToolSet
+composio = Composio(provider=LanggraphProvider())
 
-# Initialize the toolset for GitHub
-composio_toolset = ComposioToolSet()
-tools = composio_toolset.get_actions(
-    actions=[
-        Action.GITHUB_ACTIVITY_STAR_REPO_FOR_AUTHENTICATED_USER,
-        Action.GITHUB_USERS_GET_AUTHENTICATED,
-    ])
+tools = composio.tools.get(
+    user_id="default",
+    tools=[
+        "GITHUB_STAR_A_REPOSITORY_FOR_THE_AUTHENTICATED_USER",
+        "GITHUB_GET_THE_AUTHENTICATED_USER",
+    ],
+)
 tool_node = ToolNode(tools)
 ```
 
-#### 3. Prepare the model
+#### 3. Prepare the Model
 
-Initialize the LLM class and bind obtained tools to the model.
+Initialize the LLM and bind the Composio-provided tools to it.
 
 ```python
 model = ChatOpenAI(temperature=0, streaming=True)
-model_with_tools = model.bind_tools(functions)
+model_with_tools = model.bind_tools(tools)
 ```
+
 #### 4. Define the Graph Nodes
 
-LangGraph expects you to define different nodes of the agentic workflow as separate functions. Here we define a node for calling the LLM model.
+LangGraph expects each agentic step to be a function. Define the LLM-call node here.
 
 ```python
 def call_model(state: MessagesState):
@@ -70,9 +74,10 @@ def call_model(state: MessagesState):
     response = model_with_tools.invoke(messages)
     return {"messages": [response]}
 ```
-#### 5. Define the Graph Nodes and Edges
 
-To establish the agent's workflow, we begin by initializing the workflow with `agent` and `tools` node, followed by specifying the connecting edges between nodes, finally compiling the workflow. These edges can be straightforward or conditional, depending on the workflow requirements.
+#### 5. Wire Up the Graph
+
+Add the `agent` and `tools` nodes, connect them with edges, and compile.
 
 ```python
 def should_continue(state: MessagesState) -> Literal["tools", "__end__"]:
@@ -84,33 +89,23 @@ def should_continue(state: MessagesState) -> Literal["tools", "__end__"]:
 
 
 workflow = StateGraph(MessagesState)
-
-# Define the two nodes we will cycle between
 workflow.add_node("agent", call_model)
 workflow.add_node("tools", tool_node)
 
 workflow.add_edge("__start__", "agent")
-workflow.add_conditional_edges(
-    "agent",
-    should_continue,
-)
+workflow.add_conditional_edges("agent", should_continue)
 workflow.add_edge("tools", "agent")
 
 app = workflow.compile()
 ```
-#### 6. Invoke & Check Response
 
-After the compilation of workflow, we invoke the LLM with a task, and stream the response.
+#### 6. Invoke and Stream the Response
 
 ```python
 for chunk in app.stream(
     {
         "messages": [
-            (
-                "human",
-                # "Star the Github Repository composiohq/composio",
-                "Get my information.",
-            )
+            ("human", "Star the GitHub repository composiohq/composio"),
         ]
     },
     stream_mode="values",

--- a/python/providers/langgraph/README.md
+++ b/python/providers/langgraph/README.md
@@ -14,11 +14,8 @@ Ensure you have the necessary packages installed and connect your GitHub account
 # Install Composio core and the LangGraph provider
 pip install composio composio-langgraph langgraph langchain_openai
 
-# Connect your GitHub account
-composio add github
-
-# View available toolkits you can connect with
-composio toolkits
+# Connect your GitHub account (also available in the dashboard)
+composio link github
 ```
 
 ### Usage Steps

--- a/python/providers/openai/README.md
+++ b/python/providers/openai/README.md
@@ -11,12 +11,10 @@ Facilitate the integration of OpenAI with Composio to empower OpenAI models to d
 Ensure you have the necessary packages installed and connect your GitHub account to allow your agents to utilize GitHub functionalities.
 
 ```bash
-# Install Composio core and the OpenAI provider
 pip install composio composio-openai openai
-
-# Connect your GitHub account (also available in the dashboard)
-composio link github
 ```
+
+Connect your GitHub account from the [Composio dashboard](https://platform.composio.dev/) before running the example.
 
 ### Usage Steps
 

--- a/python/providers/openai/README.md
+++ b/python/providers/openai/README.md
@@ -11,63 +11,69 @@ Facilitate the integration of OpenAI with Composio to empower OpenAI models to d
 Ensure you have the necessary packages installed and connect your GitHub account to allow your agents to utilize GitHub functionalities.
 
 ```bash
-# Install Composio LangChain package
-pip install composio-openai
+# Install Composio core and the OpenAI provider
+pip install composio composio-openai openai
 
 # Connect your GitHub account
-composio-cli add github
+composio add github
 
-# View available applications you can connect with
-composio-cli show-apps
+# View available toolkits you can connect with
+composio toolkits
 ```
 
 ### Usage Steps
 
 #### 1. Import Base Packages
 
-Prepare your environment by initializing necessary imports from OpenAI and setting up your client.
+Prepare your environment by initializing necessary imports from OpenAI and Composio.
 
 ```python
 from openai import OpenAI
 
+from composio import Composio
+from composio_openai import OpenAIProvider
+
 # Initialize OpenAI client
 openai_client = OpenAI()
+
+# Initialize Composio with the OpenAI provider
+composio = Composio(provider=OpenAIProvider())
 ```
+
+> Tip: For OpenAI's Responses API, swap `OpenAIProvider` for `OpenAIResponsesProvider` (also exported from `composio_openai`).
 
 ### Step 2: Integrating GitHub Tools with Composio
 
-This step involves fetching and integrating GitHub tools provided by Composio, enabling enhanced functionality for LangChain operations.
-```python
-from composio_openai import App, ComposioToolSet
+Fetch GitHub tools for the user from Composio. Tools are returned in OpenAI's function-calling format, ready to pass to `chat.completions.create`.
 
-toolset = ComposioToolSet()
-actions = toolset.get_tools(apps=[App.GITHUB])
+```python
+tools = composio.tools.get(user_id="default", toolkits=["GITHUB"])
 ```
 
 ### Step 3: Agent Execution
 
-This step involves configuring and executing the agent to carry out actions, such as starring a GitHub repository.
+Send a request to OpenAI with the Composio-provided tools.
 
 ```python
-my_task = "Star a repo composiohq/composio on GitHub"
+task = "Star a repo composiohq/composio on GitHub"
 
-# Create a chat completion request to decide on the action
-response = openai_client.chat.completions.create(model="gpt-5",
-    tools=actions, # Passing actions we fetched earlier.
+response = openai_client.chat.completions.create(
+    model="gpt-4o-mini",
+    tools=tools,
     messages=[
-            {"role": "system", "content": "You are a helpful assistant."},
-            {"role": "user", "content": my_task}
-        ]
-    )
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": task},
+    ],
+)
 
-pprint(response)
+print(response)
 ```
 
 ### Step 4: Validate Execution Response
 
-Execute the following code to validate the response, ensuring that the intended task has been successfully completed.
+Have Composio handle any tool calls the model produced and return the results.
 
 ```python
-result = toolset.handle_tool_calls(response)
-pprint(result)
+result = composio.provider.handle_tool_calls(response=response, user_id="default")
+print(result)
 ```

--- a/python/providers/openai/README.md
+++ b/python/providers/openai/README.md
@@ -14,11 +14,8 @@ Ensure you have the necessary packages installed and connect your GitHub account
 # Install Composio core and the OpenAI provider
 pip install composio composio-openai openai
 
-# Connect your GitHub account
-composio add github
-
-# View available toolkits you can connect with
-composio toolkits
+# Connect your GitHub account (also available in the dashboard)
+composio link github
 ```
 
 ### Usage Steps

--- a/python/providers/openai_agents/README.md
+++ b/python/providers/openai_agents/README.md
@@ -5,26 +5,31 @@ This package integrates the OpenAI Agents framework with Composio, allowing you 
 ## Installation
 
 ```bash
-pip install composio_openai_agents
+pip install composio composio-openai-agents openai-agents
 ```
 
 ## Usage
 
 ```python
 import asyncio
+
 import dotenv
 from agents import Agent, Runner
 
-from composio_openai_agents import Action, ComposioToolSet
+from composio import Composio
+from composio_openai_agents import OpenAIAgentsProvider
 
 # Load environment variables from .env
 dotenv.load_dotenv()
 
-# Initialize Composio toolset
-composio_toolset = ComposioToolSet()
+# Initialize Composio with the OpenAI Agents provider
+composio = Composio(provider=OpenAIAgentsProvider())
 
 # Get all the tools
-tools = composio_toolset.get_tools(actions=[Action.GITHUB_STAR_A_REPOSITORY_FOR_THE_AUTHENTICATED_USER])
+tools = composio.tools.get(
+    user_id="default",
+    tools=["GITHUB_STAR_A_REPOSITORY_FOR_THE_AUTHENTICATED_USER"],
+)
 
 # Create an agent with the tools
 agent = Agent(
@@ -33,10 +38,15 @@ agent = Agent(
     tools=tools,
 )
 
+
 # Run the agent
 async def main():
-    result = await Runner.run(agent, "Star the repository composiohq/composio on GitHub")
+    result = await Runner.run(
+        starting_agent=agent,
+        input="Star the repository composiohq/composio on GitHub",
+    )
     print(result.final_output)
+
 
 asyncio.run(main())
 ```
@@ -51,7 +61,7 @@ asyncio.run(main())
 
 ## Requirements
 
-- Python 3.9+
+- Python 3.10+
 - OpenAI Agents framework
 - Composio (with valid API key)
 

--- a/python/providers/openai_agents/README.md
+++ b/python/providers/openai_agents/README.md
@@ -61,7 +61,7 @@ asyncio.run(main())
 
 ## Requirements
 
-- Python 3.10+
+- Python 3.9+
 - OpenAI Agents framework
 - Composio (with valid API key)
 


### PR DESCRIPTION
# Description

The Python package READMEs that ship to PyPI were still showing the legacy v0 SDK (`composio-core`, `ComposioToolSet`, `Action.X` / `App.X` enums, `toolset.get_tools(actions=[...])`). New users landing on the `composio` PyPI page or any provider PyPI page were copy-pasting v0 code into v1/v3 projects.

This PR rewrites those READMEs so the entry-point examples match the current SDK pattern (`Composio(provider=…)` + `composio.tools.get(user_id=…, toolkits=[…])` + `composio.provider.handle_tool_calls(…)`).

Files updated:

- `python/README.md`
  - Drop the `pip install composio-core` alternative and add a one-line note marking it as the legacy SDK.
  - Refresh the provider install list to cover the actual current provider packages (openai, openai-agents, anthropic, claude-agent-sdk, langchain, langgraph, crewai, llamaindex, google, gemini, google-adk, autogen). Each now installs `composio` alongside the provider.
  - Rewrite the LangChain example to `LangchainProvider` + `composio.tools.get` + `create_agent`, instead of the old `ComposioToolSet` pattern.
  - Fix `from composio.core.provider import OpenAIProvider` → `from composio_openai import OpenAIProvider` in the configuration snippet (the old import path doesn't exist).
- `python/providers/openai/README.md` — rewrite to `OpenAIProvider` (mention `OpenAIResponsesProvider` for Responses API).
- `python/providers/anthropic/README.md` — fix wrong package name (`composio-claude` → `composio-anthropic`, `composio_claude` → `composio_anthropic`) and rewrite to `AnthropicProvider`.
- `python/providers/google/README.md` — rewrite to `GoogleProvider` + `handle_response`. Now correctly points users at `composio-gemini` for the standalone google-genai SDK.
- `python/providers/gemini/README.md` — rewrite to `GeminiProvider` with string tool slugs (no more `Action.GITHUB_…` enum).
- `python/providers/langgraph/README.md` — rewrite to `LanggraphProvider` with string tool slugs; `model.bind_tools(tools)` instead of `bind_functions(functions)`.
- `python/providers/openai_agents/README.md` — rewrite to `OpenAIAgentsProvider` with string tool slugs.

Out of scope (intentionally left alone):

- `docs/content/docs/quickstart.mdx` — the `composio_core` references there sit inside `<PromptBanner>` "DO NOT use" blocks acting as LLM guardrails. They steer users away from v0, not toward it.
- `docs/content/docs/migration-guide/new-sdk.mdx` — the v0 snippets there are intentional "Python (previous)" / "TypeScript (previous)" tabs in a migration guide.
- `docs/content/changelog/*.mdx` — historical changelog entries.

# How did I test this PR

- `grep -nE "composio-core|composio_core|ComposioToolSet|App\.[A-Z_]+|Action\.[A-Z_]+|toolset\.get_tools|composio-cli" python/README.md python/providers/{openai,anthropic,google,gemini,langgraph,openai_agents}/README.md` — only match left is the new "legacy SDK" note in `python/README.md`.
- Cross-checked every code example against the canonical demo for that provider in `python/providers/<name>/<name>_demo.py` so the import paths, class names, and method signatures all match what's actually exported today.
- Verified each install command corresponds to a real `[project] name = …` in the matching `python/providers/<name>/pyproject.toml`.