### PR TITLE
fix(cli): require binary asset for update notice

### DIFF
--- a/ts/packages/cli/src/services/update-check.ts
+++ b/ts/packages/cli/src/services/update-check.ts
@@ -1,6 +1,6 @@
 import { readFileSync, mkdirSync } from 'node:fs';
 import { writeFile } from 'node:fs/promises';
-import { homedir } from 'node:os';
+import { arch as getArch, homedir, platform as getPlatform } from 'node:os';
 import { dirname, join } from 'node:path';
 import semver from 'semver';
 import { bold, cyanBright, dim } from 'src/ui/colors';
@@ -16,16 +16,22 @@ import { APP_VERSION, GITHUB_REPO } from '../constants';
  *   checkForUpdateInBackground()    — fire-and-forget fetch, no await
  *
  * Strategy:
- *   Uses GitHub's `git/matching-refs` API with the prefix
- *   `tags/@composio/cli@` so only CLI tags are returned (tiny payload,
- *   no monorepo noise). The result is cached to ~/.composio/update-check.json
- *   and refreshed at most once every 24 hours.
+ *   Uses GitHub's releases API and only considers stable @composio/cli releases
+ *   that include the binary asset for the current platform. The result is cached
+ *   to ~/.composio/update-check.json and refreshed at most once every 24 hours.
  */
 
 const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
 
-/** Matches `refs/tags/@composio/cli@<semver>` — excludes prereleases. */
-const CLI_REF_RE = /^refs\/tags\/@composio\/cli@(\d+\.\d+\.\d+)$/;
+/** Matches `@composio/cli@<semver>` — excludes prereleases. */
+const CLI_RELEASE_TAG_RE = /^@composio\/cli@(\d+\.\d+\.\d+)$/;
+
+export interface UpdateCheckRelease {
+  tag_name?: unknown;
+  prerelease?: unknown;
+  draft?: unknown;
+  assets?: unknown;
+}
 
 export interface UpdateCheckState {
   lastChecked: string; // ISO-8601
@@ -39,34 +45,63 @@ export interface UpdateCheckConfig {
   readonly stateFile: string;
   readonly currentVersion: string;
   readonly checkIntervalMs: number;
-  readonly refsUrl: string;
+  readonly releasesUrl: string;
+  readonly binaryAssetName: string | undefined;
   readonly accessToken: string | undefined;
   readonly fetchFn: (url: string, init?: RequestInit) => Promise<Response>;
 }
 
 const _home = join(homedir(), '.composio');
 
+function getCurrentBinaryAssetName(): string | undefined {
+  const platform = getPlatform();
+  const rawArch = getArch();
+  if (platform !== 'darwin' && platform !== 'linux') return undefined;
+
+  const arch = rawArch === 'arm64' || rawArch === 'aarch64' ? 'aarch64' : rawArch;
+  if (arch !== 'x64' && arch !== 'aarch64') return undefined;
+
+  return `composio-${platform}-${arch}.zip`;
+}
+
 const defaultConfig: UpdateCheckConfig = {
   stateFile: join(_home, 'update-check.json'),
   currentVersion: APP_VERSION,
   checkIntervalMs: CHECK_INTERVAL_MS,
-  refsUrl: `${GITHUB_REPO.API_BASE_URL}/repos/${GITHUB_REPO.OWNER}/${GITHUB_REPO.REPO}/git/matching-refs/tags/@composio/cli@`,
+  releasesUrl: `${GITHUB_REPO.API_BASE_URL}/repos/${GITHUB_REPO.OWNER}/${GITHUB_REPO.REPO}/releases?per_page=100`,
+  binaryAssetName: getCurrentBinaryAssetName(),
   accessToken: process.env.COMPOSIO_GITHUB_ACCESS_TOKEN,
   fetchFn: fetch,
 };
 
 // ── Pure helpers ────────────────────────────────────────────────────────
 
-/** Extract the highest stable semver from a GitHub matching-refs response. */
-export function parseLatestVersionFromRefs(refs: unknown): string | undefined {
-  if (!Array.isArray(refs)) return undefined;
+/** Extract the highest stable semver from GitHub releases that include the required binary. */
+export function parseLatestVersionFromReleases(
+  releases: unknown,
+  binaryAssetName: string | undefined
+): string | undefined {
+  if (!binaryAssetName || !Array.isArray(releases)) return undefined;
 
   let latest: string | undefined;
-  for (const ref of refs) {
-    if (typeof ref !== 'object' || ref === null || !('ref' in ref) || typeof ref.ref !== 'string')
-      continue;
+  for (const release of releases) {
+    if (typeof release !== 'object' || release === null) continue;
 
-    const match = CLI_REF_RE.exec(ref.ref);
+    const candidate = release as UpdateCheckRelease;
+    if (typeof candidate.tag_name !== 'string') continue;
+    if (candidate.prerelease === true || candidate.draft === true) continue;
+    if (!Array.isArray(candidate.assets)) continue;
+
+    const hasRequiredBinary = candidate.assets.some(
+      asset =>
+        typeof asset === 'object' &&
+        asset !== null &&
+        'name' in asset &&
+        asset.name === binaryAssetName
+    );
+    if (!hasRequiredBinary) continue;
+
+    const match = CLI_RELEASE_TAG_RE.exec(candidate.tag_name);
     if (!match) continue;
 
     const version = match[1];
@@ -105,8 +140,8 @@ export function createUpdateChecker(config: UpdateCheckConfig) {
   }
 
   /**
-   * Fetch the latest @composio/cli tag from GitHub via the lightweight
-   * `git/matching-refs` endpoint, then write the result to the state file.
+   * Fetch the latest @composio/cli release from GitHub, requiring the current
+   * platform binary asset before writing the result to the state file.
    *
    * Returns the internal promise so tests can await completion.
    * The public wrapper discards it (fire-and-forget).
@@ -135,7 +170,7 @@ export function createUpdateChecker(config: UpdateCheckConfig) {
       }
 
       // Always persist lastChecked to prevent retry loops when the fetch
-      // fails or returns no matching tags.
+      // fails or returns no matching releases with a matching binary.
       const writeState = (latestVersion?: string): Promise<void> => {
         try {
           const stateDir = dirname(config.stateFile);
@@ -154,13 +189,13 @@ export function createUpdateChecker(config: UpdateCheckConfig) {
       };
 
       return config
-        .fetchFn(config.refsUrl, { headers, signal: AbortSignal.timeout(10_000) })
+        .fetchFn(config.releasesUrl, { headers, signal: AbortSignal.timeout(10_000) })
         .then(res => {
           if (!res.ok) throw new Error(`HTTP ${res.status}`);
           return res.json();
         })
-        .then((refs: unknown) => {
-          const latestVersion = parseLatestVersionFromRefs(refs);
+        .then((releases: unknown) => {
+          const latestVersion = parseLatestVersionFromReleases(releases, config.binaryAssetName);
           return writeState(latestVersion);
         })
         .catch(() => {

--- a/ts/packages/cli/test/src/services/update-check.test.ts
+++ b/ts/packages/cli/test/src/services/update-check.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import { withHttpServer } from 'test/__utils__/http-server';
 import {
   createUpdateChecker,
-  parseLatestVersionFromRefs,
+  parseLatestVersionFromReleases,
   type UpdateCheckConfig,
   type UpdateCheckState,
 } from 'src/services/update-check';
@@ -27,7 +27,8 @@ function makeConfig(overrides?: Partial<UpdateCheckConfig>): UpdateCheckConfig {
     stateFile: join(tempDir, '.composio', 'update-check.json'),
     currentVersion: '0.2.0',
     checkIntervalMs: 24 * 60 * 60 * 1000,
-    refsUrl: 'http://unused.test',
+    releasesUrl: 'http://unused.test',
+    binaryAssetName: 'composio-darwin-aarch64.zip',
     accessToken: undefined,
     fetchFn: () => Promise.reject(new Error('fetch not configured')),
     ...overrides,
@@ -40,63 +41,90 @@ function writeState(config: UpdateCheckConfig, state: UpdateCheckState): void {
   writeFileSync(config.stateFile, JSON.stringify(state));
 }
 
-/** Create a GitHub matching-refs response body. */
-function makeRefsPayload(versions: string[]) {
+/** Create a GitHub releases response body. */
+function makeReleasesPayload(versions: string[], assetName = 'composio-darwin-aarch64.zip') {
   return versions.map(v => ({
-    ref: `refs/tags/@composio/cli@${v}`,
-    node_id: 'unused',
-    url: 'unused',
-    object: { sha: 'abc', type: 'tag', url: 'unused' },
+    tag_name: `@composio/cli@${v}`,
+    prerelease: v.includes('-'),
+    draft: false,
+    assets: [{ name: assetName, browser_download_url: 'unused' }],
   }));
 }
 
-// ── parseLatestVersionFromRefs (pure) ───────────────────────────────────
+// ── parseLatestVersionFromReleases (pure) ───────────────────────────────
 
-describe('parseLatestVersionFromRefs', () => {
+describe('parseLatestVersionFromReleases', () => {
+  const binaryAssetName = 'composio-darwin-aarch64.zip';
+
   it('returns undefined for non-array input', () => {
-    expect(parseLatestVersionFromRefs(null)).toBeUndefined();
-    expect(parseLatestVersionFromRefs('string')).toBeUndefined();
-    expect(parseLatestVersionFromRefs(42)).toBeUndefined();
+    expect(parseLatestVersionFromReleases(null, binaryAssetName)).toBeUndefined();
+    expect(parseLatestVersionFromReleases('string', binaryAssetName)).toBeUndefined();
+    expect(parseLatestVersionFromReleases(42, binaryAssetName)).toBeUndefined();
   });
 
-  it('returns undefined when no refs match the CLI pattern', () => {
-    const refs = [
-      { ref: 'refs/tags/@composio/core@1.0.0' },
-      { ref: 'refs/tags/v1.0.0' },
-      { ref: 'refs/heads/main' },
+  it('returns undefined when no releases match the CLI pattern', () => {
+    const releases = [
+      { tag_name: '@composio/core@1.0.0', assets: [{ name: binaryAssetName }] },
+      { tag_name: 'v1.0.0', assets: [{ name: binaryAssetName }] },
+      { tag_name: '@composio/cli@0.2.0-beta.1', assets: [{ name: binaryAssetName }] },
     ];
-    expect(parseLatestVersionFromRefs(refs)).toBeUndefined();
+    expect(parseLatestVersionFromReleases(releases, binaryAssetName)).toBeUndefined();
   });
 
   it('returns the single matching version', () => {
-    const refs = makeRefsPayload(['0.2.1']);
-    expect(parseLatestVersionFromRefs(refs)).toBe('0.2.1');
+    const releases = makeReleasesPayload(['0.2.1']);
+    expect(parseLatestVersionFromReleases(releases, binaryAssetName)).toBe('0.2.1');
   });
 
-  it('returns the highest semver, not the last element', () => {
-    // GitHub returns refs sorted lexicographically — 0.10.0 < 0.9.0 lexically
-    // but 0.10.0 > 0.9.0 in semver.
-    const refs = makeRefsPayload(['0.1.0', '0.10.0', '0.9.0', '0.2.0']);
-    expect(parseLatestVersionFromRefs(refs)).toBe('0.10.0');
+  it('returns the highest semver, not the first element', () => {
+    const releases = makeReleasesPayload(['0.1.0', '0.10.0', '0.9.0', '0.2.0']);
+    expect(parseLatestVersionFromReleases(releases, binaryAssetName)).toBe('0.10.0');
   });
 
-  it('excludes prerelease tags', () => {
-    const refs = [
-      { ref: 'refs/tags/@composio/cli@0.2.0' },
-      { ref: 'refs/tags/@composio/cli@0.3.0-beta.1' },
+  it('excludes prerelease and draft releases', () => {
+    const releases = [
+      ...makeReleasesPayload(['0.2.0']),
+      {
+        tag_name: '@composio/cli@0.3.0',
+        prerelease: true,
+        draft: false,
+        assets: [{ name: binaryAssetName }],
+      },
+      {
+        tag_name: '@composio/cli@0.4.0',
+        prerelease: false,
+        draft: true,
+        assets: [{ name: binaryAssetName }],
+      },
     ];
-    expect(parseLatestVersionFromRefs(refs)).toBe('0.2.0');
+    expect(parseLatestVersionFromReleases(releases, binaryAssetName)).toBe('0.2.0');
   });
 
-  it('skips malformed ref objects', () => {
-    const refs = [
+  it('requires the platform binary asset', () => {
+    const releases = [
+      ...makeReleasesPayload(['0.4.0'], 'composio-linux-x64.zip'),
+      ...makeReleasesPayload(['0.3.0']),
+    ];
+    expect(parseLatestVersionFromReleases(releases, binaryAssetName)).toBe('0.3.0');
+  });
+
+  it('returns undefined when no binary asset name is known', () => {
+    expect(
+      parseLatestVersionFromReleases(makeReleasesPayload(['0.2.1']), undefined)
+    ).toBeUndefined();
+  });
+
+  it('skips malformed release objects', () => {
+    const releases = [
       null,
       42,
-      { noRef: true },
-      { ref: 123 },
-      { ref: 'refs/tags/@composio/cli@0.5.0' },
+      { noTagName: true },
+      { tag_name: 123 },
+      { tag_name: '@composio/cli@0.5.0' },
+      { tag_name: '@composio/cli@0.6.0', assets: [{ noName: true }] },
+      { tag_name: '@composio/cli@0.7.0', assets: [{ name: binaryAssetName }] },
     ];
-    expect(parseLatestVersionFromRefs(refs)).toBe('0.5.0');
+    expect(parseLatestVersionFromReleases(releases, binaryAssetName)).toBe('0.7.0');
   });
 });
 
@@ -201,7 +229,7 @@ describe('checkForUpdate', () => {
     const config = makeConfig({
       fetchFn: vi.fn().mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve(makeRefsPayload(['0.3.0'])),
+        json: () => Promise.resolve(makeReleasesPayload(['0.3.0'])),
       }) as unknown as typeof fetch,
     });
     writeState(config, { lastChecked: stale, latestVersion: '0.2.0' });
@@ -218,7 +246,7 @@ describe('checkForUpdate', () => {
     const config = makeConfig({
       fetchFn: vi.fn().mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve(makeRefsPayload(['0.4.0', '0.3.0'])),
+        json: () => Promise.resolve(makeReleasesPayload(['0.4.0', '0.3.0'])),
       }) as unknown as typeof fetch,
     });
     const { checkForUpdate } = createUpdateChecker(config);
@@ -234,7 +262,7 @@ describe('checkForUpdate', () => {
     const config = makeConfig({
       fetchFn: vi.fn().mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve(makeRefsPayload(['0.5.0'])),
+        json: () => Promise.resolve(makeReleasesPayload(['0.5.0'])),
       }) as unknown as typeof fetch,
     });
     mkdirSync(dirname(config.stateFile), { recursive: true });
@@ -247,11 +275,14 @@ describe('checkForUpdate', () => {
     expect(state.latestVersion).toBe('0.5.0');
   });
 
-  it('still writes lastChecked when no CLI tags are found', async () => {
+  it('still writes lastChecked when no CLI releases with the required binary are found', async () => {
     const config = makeConfig({
       fetchFn: vi.fn().mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve([{ ref: 'refs/tags/@composio/core@1.0.0' }]),
+        json: () =>
+          Promise.resolve([
+            { tag_name: '@composio/core@1.0.0', assets: [{ name: 'composio-darwin-aarch64.zip' }] },
+          ]),
       }) as unknown as typeof fetch,
     });
     const { checkForUpdate } = createUpdateChecker(config);
@@ -261,15 +292,18 @@ describe('checkForUpdate', () => {
     expect(existsSync(config.stateFile)).toBe(true);
     const state: UpdateCheckState = JSON.parse(readFileSync(config.stateFile, 'utf-8'));
     expect(state.lastChecked).toBeDefined();
-    // Falls back to currentVersion since no previous state and no tags found
+    // Falls back to currentVersion since no previous state and no matching releases found
     expect(state.latestVersion).toBe(config.currentVersion);
   });
 
-  it('preserves previous latestVersion when no CLI tags are found', async () => {
+  it('preserves previous latestVersion when no CLI releases with the required binary are found', async () => {
     const config = makeConfig({
       fetchFn: vi.fn().mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve([{ ref: 'refs/tags/@composio/core@1.0.0' }]),
+        json: () =>
+          Promise.resolve([
+            { tag_name: '@composio/core@1.0.0', assets: [{ name: 'composio-darwin-aarch64.zip' }] },
+          ]),
       }) as unknown as typeof fetch,
     });
     const stale = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
@@ -318,7 +352,7 @@ describe('checkForUpdate', () => {
   it('sends Authorization header when accessToken is set', async () => {
     const fetchFn = vi.fn().mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve(makeRefsPayload(['0.2.1'])),
+      json: () => Promise.resolve(makeReleasesPayload(['0.2.1'])),
     });
     const config = makeConfig({
       accessToken: 'ghp_secret123',
@@ -336,7 +370,7 @@ describe('checkForUpdate', () => {
   it('does not send Authorization header when accessToken is undefined', async () => {
     const fetchFn = vi.fn().mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve(makeRefsPayload(['0.2.1'])),
+      json: () => Promise.resolve(makeReleasesPayload(['0.2.1'])),
     });
     const config = makeConfig({
       accessToken: undefined,
@@ -358,10 +392,10 @@ describe('checkForUpdate with real HTTP', () => {
     await withHttpServer(
       (_req, res) => {
         res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify(makeRefsPayload(['0.1.26', '0.2.0', '0.2.1'])));
+        res.end(JSON.stringify(makeReleasesPayload(['0.1.26', '0.2.0', '0.2.1'])));
       },
       async baseUrl => {
-        const config = makeConfig({ refsUrl: baseUrl, fetchFn: fetch });
+        const config = makeConfig({ releasesUrl: baseUrl, fetchFn: fetch });
         const { checkForUpdate } = createUpdateChecker(config);
 
         await checkForUpdate();
@@ -379,11 +413,11 @@ describe('checkForUpdate with real HTTP', () => {
       (req, res) => {
         receivedAuth = req.headers.authorization;
         res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify(makeRefsPayload(['0.2.1'])));
+        res.end(JSON.stringify(makeReleasesPayload(['0.2.1'])));
       },
       async baseUrl => {
         const config = makeConfig({
-          refsUrl: baseUrl,
+          releasesUrl: baseUrl,
           accessToken: 'ghp_test_token',
           fetchFn: fetch,
         });


### PR DESCRIPTION
## Summary\n- switch the passive CLI update check from tag refs to GitHub releases\n- only cache/show a latest CLI version when the stable release includes the current platform binary asset\n- update update-check tests for release asset filtering\n\n## Tests\n- pnpm --filter @composio/cli typecheck\n- pnpm --filter @composio/cli test -- test/src/services/update-check.test.ts\n\n## Notes\n- No worktree was created per request; changes are on branch pi/update-check-release-binary-guard.