### PR TITLE
docs: clarify connectedAccounts.delete() does not revoke OAuth tokens upstream (T-10452)

### DIFF
--- a/docs/content/reference/sdk-reference/typescript/connected-accounts.mdx
+++ b/docs/content/reference/sdk-reference/typescript/connected-accounts.mdx
@@ -23,8 +23,7 @@ no longer be used for API calls. It does **not** revoke OAuth tokens upstream wi
 third-party provider — any access or refresh tokens previously issued remain valid until
 they expire or are revoked by the user. To revoke upstream access, the end user must do
 so through the provider's account settings (for example,
-[https://myaccount.google.com/permissions](https://myaccount.google.com/permissions) for
-Google).
+[Google Account Permissions](https://myaccount.google.com/permissions) for Google).
 
 ```typescript
 async delete(nanoid: string): Promise<ConnectedAccountDeleteResponse>

--- a/docs/content/reference/sdk-reference/typescript/connected-accounts.mdx
+++ b/docs/content/reference/sdk-reference/typescript/connected-accounts.mdx
@@ -18,8 +18,13 @@ const result = await composio.connectedAccounts.list();
 
 Deletes a connected account.
 
-This method permanently removes a connected account from the Composio platform.
-This action cannot be undone and will revoke any access tokens associated with the account.
+This method soft-deletes the connected account record on the Composio platform so it can
+no longer be used for API calls. It does **not** revoke OAuth tokens upstream with the
+third-party provider — any access or refresh tokens previously issued remain valid until
+they expire or are revoked by the user. To revoke upstream access, the end user must do
+so through the provider's account settings (for example,
+[https://myaccount.google.com/permissions](https://myaccount.google.com/permissions) for
+Google).
 
 ```typescript
 async delete(nanoid: string): Promise<ConnectedAccountDeleteResponse>

--- a/ts/packages/core/src/models/ConnectedAccounts.ts
+++ b/ts/packages/core/src/models/ConnectedAccounts.ts
@@ -344,8 +344,12 @@ export class ConnectedAccounts {
   /**
    * Deletes a connected account.
    *
-   * This method permanently removes a connected account from the Composio platform.
-   * This action cannot be undone and will revoke any access tokens associated with the account.
+   * This method soft-deletes the connected account record on the Composio platform so it
+   * can no longer be used for API calls. It does **not** revoke OAuth tokens upstream with
+   * the third-party provider — any access or refresh tokens previously issued remain valid
+   * until they expire or are revoked by the user. To revoke upstream access, the end user
+   * must do so through the provider's account settings (for example,
+   * https://myaccount.google.com/permissions for Google).
    *
    * @param {string} nanoid - The unique identifier of the connected account to delete
    * @returns {Promise<ConnectedAccountDeleteResponse>} The deletion response


### PR DESCRIPTION
# Description

Support ticket **T-10452** reported that `connectedAccounts.delete()` does not revoke Google OAuth tokens upstream — the customer's Google grant survives indefinitely after `delete()`.

Investigation confirmed the report:

- `connectedAccounts.delete()` only soft-deletes the row in the Composio database (`prisma.connectedAccounts.update({ data: { deleted: true } })` in `hermes/apps/apollo/src/lib/connected_accounts/dbUtils/updateConnectedAccount.ts`).
- No HTTP call is ever made to the provider's `/revoke` endpoint on this code path. (A separate admin-only `/api/v3/admin/revoke` route exists but is not wired up to user-facing `delete()`.)
- The SDK TSDoc and public SDK reference page both incorrectly claimed delete "will revoke any access tokens associated with the account."

This PR corrects the documentation to match actual behavior. The runtime behavior is unchanged. Implementing real upstream revocation is a separate follow-up.

Changes:

- `ts/packages/core/src/models/ConnectedAccounts.ts` — TSDoc on `delete()` now states it soft-deletes the Composio record but does not revoke upstream OAuth tokens, and points users to the provider's account settings (e.g. https://myaccount.google.com/permissions for Google).
- `docs/content/reference/sdk-reference/typescript/connected-accounts.mdx` — same correction on the public SDK reference page.

# How did I test this PR

- Docs-only change; no runtime code touched.
- Verified the new TSDoc and MDX render the corrected language and that the rest of the file is untouched (`git diff --stat`: 2 files, +13 / -4).
- No unit tests are affected (no behavior change).