### PR TITLE
fix(core): accept array currentUserInfo in session.search() schema (#3103)

### DIFF
--- a/.changeset/fix-tool-router-search-schema.md
+++ b/.changeset/fix-tool-router-search-schema.md
@@ -1,0 +1,5 @@
+---
+"@composio/core": patch
+---
+
+**Fix:** `session.search()` no longer throws `ZodError` when the API returns `schemaRef` without `message` (budget-trimmed tools) or `current_user_info` as an array (multi-account toolkits like Supabase). Resolves [#3103](https://github.com/ComposioHQ/composio/issues/3103). The `toolkitConnectionStatuses[*].currentUserInfo` schema now accepts both `Record<string, unknown>` and `unknown[]`, and the snake_case transformer's `current_user_info` field type is widened accordingly.

--- a/ts/packages/core/src/types/toolRouter.types.ts
+++ b/ts/packages/core/src/types/toolRouter.types.ts
@@ -420,7 +420,9 @@ const ToolRouterSessionSearchToolkitConnectionStatusSchema = z.object({
   hasActiveConnection: z.boolean(),
   statusMessage: z.string(),
   connectionDetails: z.record(z.string(), z.unknown()).optional(),
-  currentUserInfo: z.record(z.string(), z.unknown()).optional(),
+  currentUserInfo: z
+    .union([z.record(z.string(), z.unknown()), z.array(z.unknown())])
+    .optional(),
 });
 
 export const ToolRouterSessionSearchResponseSchema = z.object({

--- a/ts/packages/core/src/utils/transformers/toolRouterResponseTransform.ts
+++ b/ts/packages/core/src/utils/transformers/toolRouterResponseTransform.ts
@@ -50,7 +50,7 @@ interface RawToolkitConnectionStatus {
   has_active_connection: boolean;
   status_message: string;
   connection_details?: Record<string, unknown>;
-  current_user_info?: Record<string, unknown>;
+  current_user_info?: Record<string, unknown> | unknown[];
 }
 
 interface RawSearchResponse {

--- a/ts/packages/core/test/models/toolRouter.test.ts
+++ b/ts/packages/core/test/models/toolRouter.test.ts
@@ -2011,6 +2011,65 @@ describe('ToolRouter', () => {
 
       await expect(session.search({ query: 'send emails' })).rejects.toThrow('Search failed');
     });
+
+    // Regression test for issue #3103: session.search() throws ZodError when the
+    // backend returns schemaRef without `message` (budget-trimmed tools) and
+    // current_user_info as an array (multi-account toolkits like Supabase).
+    it('should accept schemaRef without message and array-shaped current_user_info', async () => {
+      const supabaseResponse = {
+        success: true,
+        error: null,
+        results: [],
+        tool_schemas: {
+          SUPABASE_SELECT_FROM_TABLE: {
+            tool_slug: 'SUPABASE_SELECT_FROM_TABLE',
+            toolkit: 'supabase',
+            // schemaRef without `message` — Apollo's buildSchemaRef() never sets it
+            schemaRef: {
+              args: { tool_slugs: ['SUPABASE_SELECT_FROM_TABLE'] },
+              tool: 'COMPOSIO_GET_TOOL_SCHEMAS',
+            },
+          },
+        },
+        toolkit_connection_statuses: [
+          {
+            toolkit: 'supabase',
+            description: 'Supabase',
+            has_active_connection: true,
+            status_message: 'Connected',
+            // current_user_info as an array (multi-account shape)
+            current_user_info: [{ project_ref: 'abc' }, { project_ref: 'xyz' }],
+          },
+        ],
+        next_steps_guidance: [],
+        session: {
+          id: 'trs_123',
+          generate_id: false,
+          instructions: 'Reuse session',
+        },
+        time_info: {
+          current_time_utc: '2025-03-09T12:00:00.000Z',
+          current_time_utc_epoch_seconds: 1741521600,
+          message: 'UTC',
+        },
+      };
+
+      mockClient.toolRouter.session.create.mockResolvedValueOnce(mockSessionCreateResponse);
+      mockClient.toolRouter.session.search.mockResolvedValueOnce(supabaseResponse);
+
+      const session = await toolRouter.create(userId);
+      const result = await session.search({ query: 'list supabase tables' });
+
+      expect(result.toolSchemas.SUPABASE_SELECT_FROM_TABLE.schemaRef).toEqual({
+        args: { toolSlugs: ['SUPABASE_SELECT_FROM_TABLE'] },
+        message: undefined,
+        tool: 'COMPOSIO_GET_TOOL_SCHEMAS',
+      });
+      expect(result.toolkitConnectionStatuses[0].currentUserInfo).toEqual([
+        { project_ref: 'abc' },
+        { project_ref: 'xyz' },
+      ]);
+    });
   });
 
   describe('execute function', () => {

--- a/ts/packages/core/test/utils/toolRouterResponseTransform.test.ts
+++ b/ts/packages/core/test/utils/toolRouterResponseTransform.test.ts
@@ -94,6 +94,80 @@ describe('toolRouterResponseTransform', () => {
       });
     });
 
+    it('should transform schemaRef without message (issue #3103)', () => {
+      // Apollo's buildSchemaRef() never includes `message`. The SDK schema
+      // and transformer must accept the field being absent.
+      const raw = {
+        success: true,
+        error: null,
+        results: [],
+        tool_schemas: {
+          SUPABASE_SELECT_FROM_TABLE: {
+            tool_slug: 'SUPABASE_SELECT_FROM_TABLE',
+            toolkit: 'supabase',
+            schemaRef: {
+              args: { tool_slugs: ['SUPABASE_SELECT_FROM_TABLE'] },
+              tool: 'COMPOSIO_GET_TOOL_SCHEMAS',
+            },
+          },
+        },
+        toolkit_connection_statuses: [],
+        next_steps_guidance: [],
+        session: {
+          id: 'trs_1',
+          generate_id: true,
+          instructions: 'Use session',
+        },
+        time_info: {
+          current_time_utc: '2025-03-09T12:00:00.000Z',
+          current_time_utc_epoch_seconds: 1741521600,
+          message: 'UTC',
+        },
+      };
+
+      const result = transformSearchResponse(raw);
+      expect(result.toolSchemas.SUPABASE_SELECT_FROM_TABLE.schemaRef).toEqual({
+        args: { toolSlugs: ['SUPABASE_SELECT_FROM_TABLE'] },
+        message: undefined,
+        tool: 'COMPOSIO_GET_TOOL_SCHEMAS',
+      });
+    });
+
+    it('should pass through current_user_info when it is an array (issue #3103)', () => {
+      const raw = {
+        success: true,
+        error: null,
+        results: [],
+        tool_schemas: {},
+        toolkit_connection_statuses: [
+          {
+            toolkit: 'supabase',
+            description: 'Supabase toolkit',
+            has_active_connection: true,
+            status_message: 'Connected',
+            current_user_info: [{ project_ref: 'abc' }, { project_ref: 'xyz' }],
+          },
+        ],
+        next_steps_guidance: [],
+        session: {
+          id: 'trs_2',
+          generate_id: false,
+          instructions: 'Reuse',
+        },
+        time_info: {
+          current_time_utc: '2025-03-09T12:00:00.000Z',
+          current_time_utc_epoch_seconds: 1741521600,
+          message: 'UTC',
+        },
+      };
+
+      const result = transformSearchResponse(raw);
+      expect(result.toolkitConnectionStatuses[0].currentUserInfo).toEqual([
+        { project_ref: 'abc' },
+        { project_ref: 'xyz' },
+      ]);
+    });
+
     it('should transform schemaRef with tool_slugs to toolSlugs', () => {
       const raw = {
         success: true,


### PR DESCRIPTION
# Description

Fixes [#3103](https://github.com/ComposioHQ/composio/issues/3103). `session.search()` was throwing a `ZodError` when toolkits like Supabase were in scope because the API can return `current_user_info` as an array (multi-account shape) while the SDK schema only accepted `Record<string, unknown>`.

Two narrow changes:

1. **`ts/packages/core/src/types/toolRouter.types.ts`** — widen `toolkitConnectionStatuses[*].currentUserInfo` from `record(string, unknown)` to `union(record, array).optional()`.
2. **`ts/packages/core/src/utils/transformers/toolRouterResponseTransform.ts`** — widen `RawToolkitConnectionStatus.current_user_info` to `Record<string, unknown> | unknown[]` so the snake_case→camelCase transformer's input typing matches.

The companion `schemaRef.message` mismatch from the same issue was already fixed in [636cec51d](https://github.com/ComposioHQ/composio/commit/636cec51d) (Apr 9) — `message: z.string().optional()` is in place. The new tests still exercise the `schemaRef`-without-`message` path to lock in that behavior alongside the array fix.

# How did I test this PR

- Added regression tests at `test/utils/toolRouterResponseTransform.test.ts` covering both shapes (schemaRef without `message`, `current_user_info` as array).
- Added an end-to-end `session.search()` Zod-validation regression test at `test/models/toolRouter.test.ts` that mirrors the original issue's failing payload (Supabase-shape).
- `cd ts/packages/core && pnpm test test/utils/toolRouterResponseTransform.test.ts test/models/toolRouter.test.ts` → **99 passed (6 + 93)**, including the 3 new tests.
- `pnpm lint` shows no new warnings/errors in changed files.

