### PR TITLE
fix(python-sdk): prevent cross-tenant credential access in CustomTool [SEC-365]

### DIFF
--- a/python/composio/core/models/custom_tool_execution.py
+++ b/python/composio/core/models/custom_tool_execution.py
@@ -1,6 +1,14 @@
 """Standalone functions for custom tool lookup and execution.
 
 Extracted for reuse in SessionContextImpl (sibling routing).
+
+Security invariant (CWE-639 / SEC-365): on this code path the trusted
+``user_id`` arrives via ``SessionContext`` — never via ``arguments``. The
+``arguments`` dict is LLM-supplied and is validated through the tool's
+Pydantic ``input_params`` model, which discards unknown fields, so an
+attempt to smuggle ``user_id`` (or any other identity-bearing key) inside
+``arguments`` cannot reach the tool's execute function or auth lookup.
+Keep this property when modifying ``execute_custom_tool``.
 """
 
 from __future__ import annotations

--- a/python/composio/core/models/custom_tools.py
+++ b/python/composio/core/models/custom_tools.py
@@ -1,4 +1,30 @@
-"""Custom Tools module"""
+"""Custom Tools module.
+
+Security model — SEC-365 / CWE-639 (cross-tenant credential access)
+-------------------------------------------------------------------
+
+Custom tools execute against the caller's OAuth credentials, looked up by
+``user_id``. The LLM supplies the *request* arguments for a tool call; the
+SDK supplies the ``user_id``. These two inputs MUST stay structurally
+separate — if they ever collapse into one ``**kwargs`` dict, an LLM (or a
+prompt-injection input) can set ``user_id`` and have us load another
+tenant's tokens.
+
+The trust boundary is ``CustomTools.execute(slug, request, user_id)``:
+
+  * ``request`` is treated as untrusted and is filtered through an
+    *allowlist* of fields declared on the tool's Pydantic ``request_model``,
+    so today's ``user_id`` smuggling — and any future identity-bearing key
+    that might be added to the auth path (``tenant_id``, ``org_id``, …) —
+    is dropped before it can reach credential lookup.
+  * ``user_id`` is forwarded to ``CustomTool.invoke_trusted(user_id, request_kwargs)``
+    as a structurally separate parameter.
+
+``CustomTool.__call__`` (the public ``tool(**kwargs)`` shorthand) raises
+``TypeError`` if ``user_id`` appears in ``kwargs`` — refusing the smuggled
+key loudly rather than silently using a fallback that could collide with a
+real tenant.
+"""
 
 import functools
 import inspect
@@ -133,29 +159,29 @@ class CustomTool:
     def __call__(self, **kwargs: t.Any) -> t.Any:
         """Call the custom tool with the default ``user_id``.
 
-        ``kwargs`` is treated as untrusted LLM-supplied input. ``user_id`` is
-        therefore NOT extracted from ``kwargs``: allowing an LLM (or
-        prompt-injection input) to pick which tenant's ``user_id`` is used to
-        look up OAuth credentials would let it read another tenant's tokens
-        (CWE-639, see SEC-365). Any ``user_id`` key in ``kwargs`` is dropped
-        before the request body is validated.
-
-        To use a non-default ``user_id``, call through
-        ``CustomTools.execute(slug, request, user_id)`` (the canonical entry
-        point), which sanitizes the request dict and supplies the trusted
-        ``user_id`` from server-side context.
+        Refuses ``user_id`` in ``kwargs`` with ``TypeError`` rather than
+        silently dropping it — see the module docstring for why. Use
+        ``CustomTools.execute(slug, request, user_id=...)`` (the trusted
+        entry point) when you need a non-default ``user_id``.
         """
-        kwargs.pop("user_id", None)
-        return self._invoke(user_id="default", request_kwargs=kwargs)
+        if "user_id" in kwargs:
+            raise TypeError(
+                "CustomTool.__call__ does not accept user_id; "
+                "use CustomTools.execute(slug, request, user_id=...) instead."
+            )
+        return self.invoke_trusted(user_id="default", request_kwargs=kwargs)
 
-    def _invoke(self, user_id: str, request_kwargs: t.Dict[str, t.Any]) -> t.Any:
-        """Trusted internal entry point.
+    def invoke_trusted(
+        self,
+        user_id: str,
+        request_kwargs: t.Dict[str, t.Any],
+    ) -> t.Any:
+        """Trusted entry point used by ``CustomTools.execute``.
 
-        Called by ``CustomTools.execute`` after ``request_kwargs`` has been
-        sanitized at the LLM trust boundary. ``user_id`` is supplied here as
-        a positional / keyword argument that is structurally separate from
-        the ``request_kwargs`` dict, so an LLM-controlled key inside the
-        dict cannot be promoted to override the trusted value.
+        ``user_id`` is taken as a structurally separate parameter, so an
+        LLM-controlled ``user_id`` key sitting inside ``request_kwargs``
+        cannot override it (the request model's default ``extra='ignore'``
+        means any such key is also dropped during validation).
         """
         request = self.request_model.model_validate(request_kwargs)
         if self.toolkit is None:
@@ -166,6 +192,16 @@ class CustomTool:
             execute_request=t.cast(ExecuteRequestFn, self.client.tools.proxy),
             auth_credentials=self.__get_auth_credentials(user_id),
         )
+
+
+def _allowed_request_field_names(request_model: t.Type[BaseModel]) -> t.Set[str]:
+    """Names accepted by ``request_model`` (canonical name + alias)."""
+    allowed: t.Set[str] = set()
+    for field_name, field_info in request_model.model_fields.items():
+        allowed.add(field_name)
+        if field_info.alias is not None:
+            allowed.add(field_info.alias)
+    return allowed
 
 
 class CustomTools:
@@ -226,22 +262,23 @@ class CustomTools:
         slug: str,
         request: t.Dict,
         user_id: t.Optional[str] = None,
-    ) -> t.Dict:
-        """Execute a custom tool.
+    ) -> t.Any:
+        """Execute a custom tool — the trust boundary for LLM-supplied args.
 
-        ``request`` is the LLM-supplied argument dict and is treated as
-        untrusted: any ``user_id`` key it contains is stripped here so that
-        only the explicit ``user_id`` parameter (sourced from trusted
-        server-side context) is used to look up auth credentials. Without
-        this sanitization an LLM (or prompt-injection input) could specify
-        another tenant's ``user_id`` and read their OAuth tokens
-        (CWE-639, see SEC-365).
+        ``request`` is filtered through an allowlist of fields declared on
+        the tool's Pydantic ``request_model`` (canonical names + aliases).
+        Anything else — including the historical ``user_id`` smuggling
+        vector and any future identity-bearing keys — is dropped before
+        the call reaches credential lookup. ``user_id`` is forwarded as a
+        structurally separate parameter; see the module docstring for the
+        full security model.
         """
         custom_tool = self.get(slug)
         if custom_tool is None:
             raise NotFoundError(f"Custom tool with slug {slug} not found")
-        sanitized_request = {k: v for k, v in request.items() if k != "user_id"}
-        return custom_tool._invoke(
+        allowed = _allowed_request_field_names(custom_tool.request_model)
+        sanitized_request = {k: v for k, v in request.items() if k in allowed}
+        return custom_tool.invoke_trusted(
             user_id=user_id or "default",
             request_kwargs=sanitized_request,
         )

--- a/python/composio/core/models/custom_tools.py
+++ b/python/composio/core/models/custom_tools.py
@@ -131,9 +131,33 @@ class CustomTool:
         return account.state.val.model_dump()
 
     def __call__(self, **kwargs: t.Any) -> t.Any:
-        """Call the custom tool."""
-        user_id = kwargs.pop("user_id", None) or "default"
-        request = self.request_model.model_validate(kwargs)
+        """Call the custom tool with the default ``user_id``.
+
+        ``kwargs`` is treated as untrusted LLM-supplied input. ``user_id`` is
+        therefore NOT extracted from ``kwargs``: allowing an LLM (or
+        prompt-injection input) to pick which tenant's ``user_id`` is used to
+        look up OAuth credentials would let it read another tenant's tokens
+        (CWE-639, see SEC-365). Any ``user_id`` key in ``kwargs`` is dropped
+        before the request body is validated.
+
+        To use a non-default ``user_id``, call through
+        ``CustomTools.execute(slug, request, user_id)`` (the canonical entry
+        point), which sanitizes the request dict and supplies the trusted
+        ``user_id`` from server-side context.
+        """
+        kwargs.pop("user_id", None)
+        return self._invoke(user_id="default", request_kwargs=kwargs)
+
+    def _invoke(self, user_id: str, request_kwargs: t.Dict[str, t.Any]) -> t.Any:
+        """Trusted internal entry point.
+
+        Called by ``CustomTools.execute`` after ``request_kwargs`` has been
+        sanitized at the LLM trust boundary. ``user_id`` is supplied here as
+        a positional / keyword argument that is structurally separate from
+        the ``request_kwargs`` dict, so an LLM-controlled key inside the
+        dict cannot be promoted to override the trusted value.
+        """
+        request = self.request_model.model_validate(request_kwargs)
         if self.toolkit is None:
             return t.cast(CustomToolProtocol, self.f)(request=request)
 
@@ -203,8 +227,21 @@ class CustomTools:
         request: t.Dict,
         user_id: t.Optional[str] = None,
     ) -> t.Dict:
-        """Execute a custom tool."""
+        """Execute a custom tool.
+
+        ``request`` is the LLM-supplied argument dict and is treated as
+        untrusted: any ``user_id`` key it contains is stripped here so that
+        only the explicit ``user_id`` parameter (sourced from trusted
+        server-side context) is used to look up auth credentials. Without
+        this sanitization an LLM (or prompt-injection input) could specify
+        another tenant's ``user_id`` and read their OAuth tokens
+        (CWE-639, see SEC-365).
+        """
         custom_tool = self.get(slug)
         if custom_tool is None:
             raise NotFoundError(f"Custom tool with slug {slug} not found")
-        return custom_tool(**request, user_id=user_id)
+        sanitized_request = {k: v for k, v in request.items() if k != "user_id"}
+        return custom_tool._invoke(
+            user_id=user_id or "default",
+            request_kwargs=sanitized_request,
+        )

--- a/python/tests/test_custom_tools_security.py
+++ b/python/tests/test_custom_tools_security.py
@@ -6,18 +6,20 @@ Before the fix, ``CustomTool.__call__`` extracted ``user_id`` from the same
 ``**kwargs`` dict that carried LLM-supplied tool arguments, and
 ``CustomTools.execute`` happily forwarded that LLM-controlled dict via
 ``custom_tool(**request, user_id=user_id)``. An LLM (or prompt-injection
-input) could therefore set ``user_id`` to another tenant's identifier —
-either getting it forwarded into ``CustomTool.__call__`` directly or
-relying on Python's duplicate-kwarg ``TypeError`` to leak whose tokens
-were nearly looked up.
+input) could therefore set ``user_id`` to another tenant's identifier and
+have ``CustomTool.__get_auth_credentials`` look up that victim's OAuth
+tokens.
 
-The fix:
-    * ``CustomTools.execute`` strips ``user_id`` from the LLM-supplied
-      ``request`` dict at the trust boundary, so only the trusted, explicit
-      ``user_id`` parameter reaches the credential lookup.
-    * ``CustomTool.__call__`` exposes ``user_id`` as a keyword-only
-      parameter and drops any ``user_id`` left in ``kwargs`` before the
-      request body is validated.
+After the fix:
+    * ``CustomTools.execute`` filters the LLM-supplied ``request`` through
+      an *allowlist* of fields declared on the tool's Pydantic
+      ``request_model`` — ``user_id`` and any other unexpected key are
+      dropped before they can influence credential lookup or reach the
+      tool's execute function.
+    * ``CustomTool.invoke_trusted`` is the structurally separate trusted
+      entry point; ``user_id`` cannot be smuggled inside ``request_kwargs``.
+    * ``CustomTool.__call__`` raises ``TypeError`` if ``user_id`` appears
+      in ``kwargs`` rather than silently using a fallback.
 """
 
 from unittest.mock import MagicMock
@@ -33,9 +35,9 @@ class _IssueInput(BaseModel):
     issue_number: int = Field(description="GitHub issue number")
 
 
-def _make_mock_client() -> MagicMock:
-    """Build a mock HttpClient suitable for CustomTool.__get_auth_credentials."""
-
+@pytest.fixture
+def mock_http_client() -> MagicMock:
+    """Mock HttpClient that returns a single connected account on lookup."""
     state = MagicMock()
     state.val.model_dump.return_value = {"access_token": "trusted-token"}
 
@@ -52,144 +54,221 @@ def _make_mock_client() -> MagicMock:
     return client
 
 
-def test_execute_strips_user_id_from_llm_request() -> None:
-    """``CustomTools.execute`` MUST strip ``user_id`` from the request dict."""
-    client = _make_mock_client()
-    tools = CustomTools(client=client)
+@pytest.fixture
+def github_tool(mock_http_client: MagicMock) -> CustomTool:
+    """A registered ``github`` custom tool whose handler echoes the auth token."""
 
     def github_tool(request: _IssueInput, execute_request, auth_credentials):
         """Fetch issue info."""
-        return {"token": auth_credentials["access_token"]}
+        return {
+            "issue_number": request.issue_number,
+            "token": auth_credentials["access_token"],
+        }
 
-    tools.register(toolkit="github")(github_tool)
+    return CustomTool(f=github_tool, client=mock_http_client, toolkit="github")
 
-    result = tools.execute(
-        slug="GITHUB_GITHUB_TOOL",
+
+@pytest.fixture
+def custom_tools(mock_http_client: MagicMock, github_tool: CustomTool) -> CustomTools:
+    """A ``CustomTools`` registry pre-loaded with ``github_tool``."""
+    tools = CustomTools(client=mock_http_client)
+    tools.custom_tools_registry[github_tool.slug] = github_tool
+    return tools
+
+
+def test_execute_strips_user_id_from_llm_request(
+    mock_http_client: MagicMock, custom_tools: CustomTools, github_tool: CustomTool
+) -> None:
+    """``CustomTools.execute`` MUST drop ``user_id`` from the request dict."""
+    result = custom_tools.execute(
+        slug=github_tool.slug,
         request={"issue_number": 1, "user_id": "victim-user"},
         user_id="trusted-user",
     )
 
-    assert result == {"token": "trusted-token"}
-    # Only the trusted, explicit user_id reaches the credential lookup.
-    client.connected_accounts.list.assert_called_once_with(
+    assert result == {"issue_number": 1, "token": "trusted-token"}
+    mock_http_client.connected_accounts.list.assert_called_once_with(
         toolkit_slugs=["github"],
         user_ids=["trusted-user"],
     )
 
 
-def test_execute_falls_back_to_default_when_user_id_missing() -> None:
-    """If the caller forgets a trusted ``user_id``, fall back to ``"default"``.
+def test_execute_strips_unexpected_fields_via_allowlist(
+    mock_http_client: MagicMock, custom_tools: CustomTools, github_tool: CustomTool
+) -> None:
+    """The allowlist is durable: any non-declared key is dropped, not just user_id.
 
-    Specifically, ``execute`` must NOT silently use the LLM-supplied
-    ``user_id`` from ``request`` as a fallback — that would re-introduce
-    the SEC-365 vulnerability under a different code path.
+    Pins the allowlist behaviour so a future identity-bearing key in the
+    auth path (``tenant_id``, ``org_id``, ``connected_account_id``, …)
+    cannot re-introduce CWE-639 by being smuggled through ``request``.
     """
-    client = _make_mock_client()
-    tools = CustomTools(client=client)
+    captured: dict = {}
 
-    def github_tool(request: _IssueInput, execute_request, auth_credentials):
-        """Fetch issue info."""
+    def echo_tool(request: _IssueInput, execute_request, auth_credentials):
+        """Echo back the validated request."""
+        captured["fields"] = request.model_dump()
         return {"ok": True}
 
-    tools.register(toolkit="github")(github_tool)
+    tools = CustomTools(client=mock_http_client)
+    tool = CustomTool(f=echo_tool, client=mock_http_client, toolkit="github")
+    tools.custom_tools_registry[tool.slug] = tool
 
     tools.execute(
-        slug="GITHUB_GITHUB_TOOL",
+        slug=tool.slug,
+        request={
+            "issue_number": 1,
+            "user_id": "victim-user",
+            "tenant_id": "evil-tenant",
+            "connected_account_id": "ca_evil",
+            "extra_garbage": "xyz",
+        },
+        user_id="trusted-user",
+    )
+
+    assert captured["fields"] == {"issue_number": 1}
+    mock_http_client.connected_accounts.list.assert_called_once_with(
+        toolkit_slugs=["github"],
+        user_ids=["trusted-user"],
+    )
+
+
+def test_execute_keeps_aliases_declared_on_request_model(
+    mock_http_client: MagicMock,
+) -> None:
+    """Aliases declared on the request model are honoured by the allowlist."""
+
+    class _AliasedInput(BaseModel):
+        issue_number: int = Field(alias="issueNumber")
+
+    captured: dict = {}
+
+    def aliased_tool(request: _AliasedInput, execute_request, auth_credentials):
+        """Echo back the validated request."""
+        captured["fields"] = request.model_dump()
+        return {"ok": True}
+
+    tools = CustomTools(client=mock_http_client)
+    tool = CustomTool(f=aliased_tool, client=mock_http_client, toolkit="github")
+    tools.custom_tools_registry[tool.slug] = tool
+
+    tools.execute(
+        slug=tool.slug,
+        request={"issueNumber": 5, "user_id": "victim"},
+        user_id="trusted-user",
+    )
+
+    assert captured["fields"] == {"issue_number": 5}
+
+
+def test_execute_falls_back_to_default_when_user_id_missing(
+    mock_http_client: MagicMock, custom_tools: CustomTools, github_tool: CustomTool
+) -> None:
+    """If no trusted ``user_id`` is provided, ``execute`` MUST use ``"default"``.
+
+    Specifically, ``execute`` MUST NOT silently use the LLM-supplied
+    ``user_id`` from ``request`` as a fallback — that would re-introduce
+    SEC-365 under a different code path.
+    """
+    custom_tools.execute(
+        slug=github_tool.slug,
         request={"issue_number": 1, "user_id": "victim-user"},
         user_id=None,
     )
 
-    client.connected_accounts.list.assert_called_once_with(
+    mock_http_client.connected_accounts.list.assert_called_once_with(
         toolkit_slugs=["github"],
         user_ids=["default"],
     )
 
 
-def test_execute_does_not_mutate_caller_request_dict() -> None:
+def test_execute_does_not_mutate_caller_request_dict(
+    custom_tools: CustomTools, github_tool: CustomTool
+) -> None:
     """Sanitization MUST NOT mutate the caller's ``request`` dict in place."""
-    client = _make_mock_client()
-    tools = CustomTools(client=client)
-
-    def github_tool(request: _IssueInput, execute_request, auth_credentials):
-        """Fetch issue info."""
-        return {"ok": True}
-
-    tools.register(toolkit="github")(github_tool)
-
     request_dict = {"issue_number": 1, "user_id": "victim-user"}
-    tools.execute(
-        slug="GITHUB_GITHUB_TOOL",
+    custom_tools.execute(
+        slug=github_tool.slug,
         request=request_dict,
         user_id="trusted-user",
     )
 
-    # The original dict is untouched (the SDK should not surprise the caller).
     assert request_dict == {"issue_number": 1, "user_id": "victim-user"}
 
 
-def test_call_drops_user_id_smuggled_in_kwargs_dict() -> None:
-    """``CustomTool.__call__`` MUST ignore any ``user_id`` smuggled in kwargs.
+def test_call_raises_typeerror_when_user_id_smuggled_in_kwargs(
+    github_tool: CustomTool,
+) -> None:
+    """``CustomTool.__call__`` MUST refuse a ``user_id`` kwarg loudly.
 
-    A caller might unpack a partially-trusted dict like ``tool(**llm_dict)``
-    without realizing that the LLM controls every key in it. Before the fix,
-    a ``user_id`` key in that dict was popped and used to look up OAuth
-    credentials — letting an LLM read another tenant's tokens. After the fix,
-    ``__call__`` always uses the safe ``"default"`` user_id and the smuggled
-    value is dropped before request validation.
+    Silent fallbacks expand blast radius: a tool that quietly transacts
+    against ``"default"`` could end up using a real tenant who happens to
+    be registered under that id. Failing fast also surfaces prompt-injection
+    attempts instead of swallowing them.
     """
-    client = _make_mock_client()
-
-    def github_tool(request: _IssueInput, execute_request, auth_credentials):
-        """Fetch issue info."""
-        return {"ok": True}
-
-    tool = CustomTool(f=github_tool, client=client, toolkit="github")
-
     smuggled_kwargs = {"issue_number": 1, "user_id": "victim-user"}
-    tool(**smuggled_kwargs)
 
-    client.connected_accounts.list.assert_called_once_with(
-        toolkit_slugs=["github"],
-        user_ids=["default"],
+    with pytest.raises(TypeError, match="user_id"):
+        github_tool(**smuggled_kwargs)
+
+
+def test_invoke_trusted_uses_explicit_user_id_over_smuggled_one(
+    mock_http_client: MagicMock, github_tool: CustomTool
+) -> None:
+    """``invoke_trusted``'s explicit ``user_id`` MUST win over a smuggled key.
+
+    The auth-path argument is structurally separate from ``request_kwargs``,
+    so an LLM-controlled ``user_id`` inside ``request_kwargs`` cannot
+    override the trusted parameter. This pins the docstring contract.
+    """
+    github_tool.invoke_trusted(
+        user_id="trusted-user",
+        request_kwargs={"issue_number": 7, "user_id": "victim-user"},
     )
 
-
-def test_invoke_uses_trusted_user_id_separate_from_request() -> None:
-    """``_invoke`` takes ``user_id`` separately from the request dict.
-
-    This is the trusted internal entry point used by ``CustomTools.execute``.
-    Even if the LLM-controlled ``request_kwargs`` happens to contain a
-    ``user_id`` key (and somehow gets past the sanitization in ``execute``),
-    the ``user_id`` argument here is structurally separate, so the trusted
-    value is what reaches the credential lookup.
-    """
-    client = _make_mock_client()
-
-    captured: dict = {}
-
-    def github_tool(request: _IssueInput, execute_request, auth_credentials):
-        """Fetch issue info."""
-        captured["request"] = request
-        return {"ok": True}
-
-    tool = CustomTool(f=github_tool, client=client, toolkit="github")
-    tool._invoke(user_id="trusted-user", request_kwargs={"issue_number": 7})
-
-    client.connected_accounts.list.assert_called_once_with(
+    mock_http_client.connected_accounts.list.assert_called_once_with(
         toolkit_slugs=["github"],
         user_ids=["trusted-user"],
     )
-    assert captured["request"].issue_number == 7
 
 
-def test_execute_unknown_slug_raises() -> None:
+def test_execute_unknown_slug_raises(custom_tools: CustomTools) -> None:
     """Sanity check: unknown slugs still surface ``NotFoundError``."""
-    client = _make_mock_client()
-    tools = CustomTools(client=client)
-
     with pytest.raises(NotFoundError):
-        tools.execute(
+        custom_tools.execute(
             slug="DOES_NOT_EXIST",
             request={"foo": "bar"},
             user_id="trusted-user",
         )
+
+
+def test_tools_execute_e2e_strips_user_id_through_full_stack(
+    mock_http_client: MagicMock, custom_tools: CustomTools, github_tool: CustomTool
+) -> None:
+    """End-to-end check through ``Tools.execute`` (the public SDK entry point).
+
+    ``Tools._execute_tool`` routes custom-tool calls into
+    ``CustomTools.execute``. The modifier-hook block can also overwrite
+    ``arguments`` and ``user_id`` from a ``processed_params`` dict, so we
+    pin that the sanitization still applies after that path.
+    """
+    from composio.core.models.tools import Tools
+
+    provider = MagicMock()
+    provider.name = "test"
+
+    tools = Tools(client=mock_http_client, provider=provider)
+    tools._custom_tools = custom_tools
+
+    response = tools.execute(
+        slug=github_tool.slug,
+        arguments={"issue_number": 1, "user_id": "victim-user"},
+        user_id="trusted-user",
+    )
+
+    assert response["successful"] is True
+    assert response["data"]["issue_number"] == 1
+    assert response["data"]["token"] == "trusted-token"
+    mock_http_client.connected_accounts.list.assert_called_once_with(
+        toolkit_slugs=["github"],
+        user_ids=["trusted-user"],
+    )

--- a/python/tests/test_custom_tools_security.py
+++ b/python/tests/test_custom_tools_security.py
@@ -1,0 +1,195 @@
+"""Security tests for the legacy ``CustomTool`` / ``CustomTools`` API.
+
+Regression tests for SEC-365 (CWE-639, cross-tenant credential access).
+
+Before the fix, ``CustomTool.__call__`` extracted ``user_id`` from the same
+``**kwargs`` dict that carried LLM-supplied tool arguments, and
+``CustomTools.execute`` happily forwarded that LLM-controlled dict via
+``custom_tool(**request, user_id=user_id)``. An LLM (or prompt-injection
+input) could therefore set ``user_id`` to another tenant's identifier —
+either getting it forwarded into ``CustomTool.__call__`` directly or
+relying on Python's duplicate-kwarg ``TypeError`` to leak whose tokens
+were nearly looked up.
+
+The fix:
+    * ``CustomTools.execute`` strips ``user_id`` from the LLM-supplied
+      ``request`` dict at the trust boundary, so only the trusted, explicit
+      ``user_id`` parameter reaches the credential lookup.
+    * ``CustomTool.__call__`` exposes ``user_id`` as a keyword-only
+      parameter and drops any ``user_id`` left in ``kwargs`` before the
+      request body is validated.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import BaseModel, Field
+
+from composio.core.models.custom_tools import CustomTool, CustomTools
+from composio.exceptions import NotFoundError
+
+
+class _IssueInput(BaseModel):
+    issue_number: int = Field(description="GitHub issue number")
+
+
+def _make_mock_client() -> MagicMock:
+    """Build a mock HttpClient suitable for CustomTool.__get_auth_credentials."""
+
+    state = MagicMock()
+    state.val.model_dump.return_value = {"access_token": "trusted-token"}
+
+    account = MagicMock()
+    account.created_at = "2026-01-01T00:00:00Z"
+    account.state = state
+
+    response = MagicMock()
+    response.items = [account]
+
+    client = MagicMock()
+    client.connected_accounts.list.return_value = response
+    client.tools.proxy = MagicMock()
+    return client
+
+
+def test_execute_strips_user_id_from_llm_request() -> None:
+    """``CustomTools.execute`` MUST strip ``user_id`` from the request dict."""
+    client = _make_mock_client()
+    tools = CustomTools(client=client)
+
+    def github_tool(request: _IssueInput, execute_request, auth_credentials):
+        """Fetch issue info."""
+        return {"token": auth_credentials["access_token"]}
+
+    tools.register(toolkit="github")(github_tool)
+
+    result = tools.execute(
+        slug="GITHUB_GITHUB_TOOL",
+        request={"issue_number": 1, "user_id": "victim-user"},
+        user_id="trusted-user",
+    )
+
+    assert result == {"token": "trusted-token"}
+    # Only the trusted, explicit user_id reaches the credential lookup.
+    client.connected_accounts.list.assert_called_once_with(
+        toolkit_slugs=["github"],
+        user_ids=["trusted-user"],
+    )
+
+
+def test_execute_falls_back_to_default_when_user_id_missing() -> None:
+    """If the caller forgets a trusted ``user_id``, fall back to ``"default"``.
+
+    Specifically, ``execute`` must NOT silently use the LLM-supplied
+    ``user_id`` from ``request`` as a fallback — that would re-introduce
+    the SEC-365 vulnerability under a different code path.
+    """
+    client = _make_mock_client()
+    tools = CustomTools(client=client)
+
+    def github_tool(request: _IssueInput, execute_request, auth_credentials):
+        """Fetch issue info."""
+        return {"ok": True}
+
+    tools.register(toolkit="github")(github_tool)
+
+    tools.execute(
+        slug="GITHUB_GITHUB_TOOL",
+        request={"issue_number": 1, "user_id": "victim-user"},
+        user_id=None,
+    )
+
+    client.connected_accounts.list.assert_called_once_with(
+        toolkit_slugs=["github"],
+        user_ids=["default"],
+    )
+
+
+def test_execute_does_not_mutate_caller_request_dict() -> None:
+    """Sanitization MUST NOT mutate the caller's ``request`` dict in place."""
+    client = _make_mock_client()
+    tools = CustomTools(client=client)
+
+    def github_tool(request: _IssueInput, execute_request, auth_credentials):
+        """Fetch issue info."""
+        return {"ok": True}
+
+    tools.register(toolkit="github")(github_tool)
+
+    request_dict = {"issue_number": 1, "user_id": "victim-user"}
+    tools.execute(
+        slug="GITHUB_GITHUB_TOOL",
+        request=request_dict,
+        user_id="trusted-user",
+    )
+
+    # The original dict is untouched (the SDK should not surprise the caller).
+    assert request_dict == {"issue_number": 1, "user_id": "victim-user"}
+
+
+def test_call_drops_user_id_smuggled_in_kwargs_dict() -> None:
+    """``CustomTool.__call__`` MUST ignore any ``user_id`` smuggled in kwargs.
+
+    A caller might unpack a partially-trusted dict like ``tool(**llm_dict)``
+    without realizing that the LLM controls every key in it. Before the fix,
+    a ``user_id`` key in that dict was popped and used to look up OAuth
+    credentials — letting an LLM read another tenant's tokens. After the fix,
+    ``__call__`` always uses the safe ``"default"`` user_id and the smuggled
+    value is dropped before request validation.
+    """
+    client = _make_mock_client()
+
+    def github_tool(request: _IssueInput, execute_request, auth_credentials):
+        """Fetch issue info."""
+        return {"ok": True}
+
+    tool = CustomTool(f=github_tool, client=client, toolkit="github")
+
+    smuggled_kwargs = {"issue_number": 1, "user_id": "victim-user"}
+    tool(**smuggled_kwargs)
+
+    client.connected_accounts.list.assert_called_once_with(
+        toolkit_slugs=["github"],
+        user_ids=["default"],
+    )
+
+
+def test_invoke_uses_trusted_user_id_separate_from_request() -> None:
+    """``_invoke`` takes ``user_id`` separately from the request dict.
+
+    This is the trusted internal entry point used by ``CustomTools.execute``.
+    Even if the LLM-controlled ``request_kwargs`` happens to contain a
+    ``user_id`` key (and somehow gets past the sanitization in ``execute``),
+    the ``user_id`` argument here is structurally separate, so the trusted
+    value is what reaches the credential lookup.
+    """
+    client = _make_mock_client()
+
+    captured: dict = {}
+
+    def github_tool(request: _IssueInput, execute_request, auth_credentials):
+        """Fetch issue info."""
+        captured["request"] = request
+        return {"ok": True}
+
+    tool = CustomTool(f=github_tool, client=client, toolkit="github")
+    tool._invoke(user_id="trusted-user", request_kwargs={"issue_number": 7})
+
+    client.connected_accounts.list.assert_called_once_with(
+        toolkit_slugs=["github"],
+        user_ids=["trusted-user"],
+    )
+    assert captured["request"].issue_number == 7
+
+
+def test_execute_unknown_slug_raises() -> None:
+    """Sanity check: unknown slugs still surface ``NotFoundError``."""
+    client = _make_mock_client()
+    tools = CustomTools(client=client)
+
+    with pytest.raises(NotFoundError):
+        tools.execute(
+            slug="DOES_NOT_EXIST",
+            request={"foo": "bar"},
+            user_id="trusted-user",
+        )


### PR DESCRIPTION
# Description

Fixes the cross-tenant credential access vulnerability tracked in [SEC-365](https://linear.app/composio/issue/SEC-365/cross-tenant-credential-access) (CWE-639) reported against `python/composio/core/models/custom_tools.py`.

## What was wrong

`CustomTool.__call__` extracted `user_id` directly from the same `**kwargs` dict that carries LLM-supplied tool arguments:

```python
def __call__(self, **kwargs: t.Any) -> t.Any:
    user_id = kwargs.pop("user_id", None) or "default"  # untrusted!
    request = self.request_model.model_validate(kwargs)
    ...
    auth_credentials=self.__get_auth_credentials(user_id),
```

Pydantic's `model_validate` ignores fields not declared in the schema, so an LLM (or prompt-injection input) could include `user_id` in its tool-call arguments and `__get_auth_credentials` would happily look up that other tenant's OAuth tokens.

## What changed

- **`CustomTools.execute`** strips `user_id` from the LLM-supplied `request` dict at the trust boundary, so only the explicit, server-side `user_id` parameter reaches credential lookup. The original caller-owned dict is left untouched.
- **`CustomTool`** now exposes a trusted internal entry point `_invoke(user_id, request_kwargs)` where `user_id` is passed structurally separate from the request kwargs dict (so an LLM-controlled key inside the dict can never be promoted to override the trusted value).
- **`CustomTool.__call__`** no longer reads `user_id` from `**kwargs` at all and always uses the safe `"default"` user, with a docstring directing direct callers to `CustomTools.execute` for trusted multi-tenant use.

# How did I test this PR

Added `python/tests/test_custom_tools_security.py` with six regression tests:

- `test_execute_strips_user_id_from_llm_request` — request dict containing `user_id="victim-user"` is stripped; lookup uses the trusted `user_id="trusted-user"`.
- `test_execute_falls_back_to_default_when_user_id_missing` — when no trusted `user_id` is supplied, lookup uses `"default"` (NOT the LLM-supplied value).
- `test_execute_does_not_mutate_caller_request_dict` — sanitization is non-destructive on the caller's dict.
- `test_call_drops_user_id_smuggled_in_kwargs_dict` — `tool(**llm_dict)` with `user_id` smuggled inside falls back to `"default"`.
- `test_invoke_uses_trusted_user_id_separate_from_request` — trusted internal entry point passes the explicit `user_id` through.
- `test_execute_unknown_slug_raises` — sanity check, unknown slugs still surface `NotFoundError`.

```bash
$ source .venv/bin/activate
$ python -m pytest tests/test_custom_tools_security.py -v
============================== 6 passed in 0.04s ===============================
```

Full Python test suite (excluding type-inference-only sessions, which require all provider packages and run via `nox -s type_inference`):

```bash
$ python -m pytest tests/ --ignore=tests/test_type_inference_*
============================== 639 passed, 1 warning in 5.09s ==============================
```

Lint + type-check on changed files:

```bash
$ ruff check  --config config/ruff.toml composio/core/models/custom_tools.py tests/test_custom_tools_security.py
All checks passed!
$ ruff format --config config/ruff.toml --check composio/core/models/custom_tools.py tests/test_custom_tools_security.py
2 files already formatted
$ mypy --config-file config/mypy.ini composio/core/models/custom_tools.py tests/test_custom_tools_security.py
Success: no issues found in 2 source files
```

Triggered by: srujan@composio.dev | Source: slack
Session: https://zen-api-production-4c98.up.railway.app/dashboard/#/chat/zen-34868b976538