### PR TITLE
docs: workbench sandbox compute tier and link allow_multiple

### DIFF
--- a/docs/bun.lock
+++ b/docs/bun.lock
@@ -32,7 +32,7 @@
         "@anthropic-ai/sdk": "^0.71.2",
         "@composio/anthropic": "^0.5.5",
         "@composio/claude-agent-sdk": "^0.6.3",
-        "@composio/core": "^0.6.10",
+        "@composio/core": "^0.8.1",
         "@composio/google": "^0.5.5",
         "@composio/langchain": "^0.5.5",
         "@composio/llamaindex": "^0.5.5",
@@ -164,9 +164,9 @@
 
     "@composio/claude-agent-sdk": ["@composio/claude-agent-sdk@0.6.3", "", { "dependencies": { "zod": "^3.25.76" }, "peerDependencies": { "@anthropic-ai/claude-agent-sdk": ">=0.1.0", "@composio/core": "0.6.3" } }, "sha512-724KwTShuore9zQrxRvbOzVrqZ8w9Z5ZkzElKYJX6mbUq33GaVs5bFbgSomNDaRe9kkLAI7fPP8WteZJB32akA=="],
 
-    "@composio/client": ["@composio/client@0.1.0-alpha.66", "", {}, "sha512-SDHcTWzz2dgdYAew/gQsRpjHpEzHKm6sW7KM4wCoJWNJuuMuey9Ahje91ZucNjfaqpI8CFW+pXY4nWkZf5LD7Q=="],
+    "@composio/client": ["@composio/client@0.1.0-alpha.68", "", {}, "sha512-hym21PsIELzlF0Fc9RASr3PfGR1alpGE8IlbRJU3ED6UllMZz7VzREsKUZfojG4yHjZMBlVXG5QGMBzuPEue3Q=="],
 
-    "@composio/core": ["@composio/core@0.6.10", "", { "dependencies": { "@composio/client": "0.1.0-alpha.66", "@composio/json-schema-to-zod": "0.1.20", "@types/json-schema": "^7.0.15", "chalk": "^4.1.2", "openai": "^6.16.0", "pusher-js": "^8.4.0", "semver": "^7.7.2", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-T/9MfYcmPs2EcSXhrJWvm0UFTfa79FcTo1L8vO13d5C5kX8/I4hLYLu+1wc4n7WGBSE9hq7o1g9L3FXJrOrlSQ=="],
+    "@composio/core": ["@composio/core@0.8.1", "", { "dependencies": { "@composio/client": "0.1.0-alpha.68", "@composio/json-schema-to-zod": "0.1.20", "@types/json-schema": "^7.0.15", "chalk": "^4.1.2", "openai": "^6.16.0", "pusher-js": "^8.4.0", "semver": "^7.7.2", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-jgnpri5gVp8EbkbaoZxCWCHK4U2nPqq4LYK+JDHljme1Ruhtr0jFc/nV2hZwoquaIfvnLoNKMyADNBcDLf84Hw=="],
 
     "@composio/google": ["@composio/google@0.5.5", "", { "peerDependencies": { "@composio/core": "0.5.5", "@google/genai": "^1.1.0" } }, "sha512-0W+WZANsVSVAkhaRxbUUpuHJ52O3BbknAEV/C38/1yZq3mmvzx/DlRjGf/tiDRaS7Pxr8WhYwGUKgeyzYR4qAw=="],
 

--- a/docs/content/changelog/04-28-26-sdk-link-allow-multiple.mdx
+++ b/docs/content/changelog/04-28-26-sdk-link-allow-multiple.mdx
@@ -9,7 +9,7 @@ date: '2026-04-28'
 <Callout type="warn">
 **Behavior change**
 
-Before: `link()` would happily create a second `ACTIVE` connection for the same `(user_id, auth_config_id)` pair without a follow-up patch.
+Before: `link()` would happily create a second `ACTIVE` connection for the same `(user_id, auth_config_id)` pair without checking for an existing `ACTIVE` connection first.
 
 After: `link()` first calls `connectedAccounts.list({ userIds, authConfigIds, statuses: ['ACTIVE'] })`. If any active connection exists, `link()` throws `ComposioMultipleConnectedAccountsError` unless the caller passes `allowMultiple: true` (TypeScript) / `allow_multiple=True` (Python).
 </Callout>

--- a/docs/content/changelog/04-28-26-sdk-link-allow-multiple.mdx
+++ b/docs/content/changelog/04-28-26-sdk-link-allow-multiple.mdx
@@ -40,7 +40,6 @@ connection_request = composio.connected_accounts.link(
 </Tab>
 <Tab value="TypeScript">
 ```typescript
-// @noErrors
 import { Composio } from '@composio/core';
 const composio = new Composio({ apiKey: process.env.COMPOSIO_API_KEY! });
 // ---cut---

--- a/docs/content/changelog/04-28-26-sdk-link-allow-multiple.mdx
+++ b/docs/content/changelog/04-28-26-sdk-link-allow-multiple.mdx
@@ -4,7 +4,7 @@ description: 'TypeScript and Python `connectedAccounts.link()` now refuse to cre
 date: '2026-04-28'
 ---
 
-`composio.connectedAccounts.link()` (TypeScript) and `composio.connected_accounts.link()` (Python) now match the multi-connection guard that `initiate()` already had. With Composio-managed redirectable-OAuth callers being [migrated off `POST /api/v3/connected_accounts` onto `POST /api/v3/connected_accounts/link`](/docs/changelog/2026/04/24/link-auth-migration), the guard moves with them — so the migration doesn't quietly drop the duplicate-connection check.
+`composio.connectedAccounts.link()` (TypeScript) and `composio.connected_accounts.link()` (Python) now match the multi-connection guard that `initiate()` already had. With Composio-managed redirectable-OAuth callers being [migrated off `POST /api/v3/connected_accounts` onto `POST /api/v3/connected_accounts/link`](/docs/changelog/2026/04/24), the guard moves with them — so the migration doesn't quietly drop the duplicate-connection check.
 
 <Callout type="warn">
 **Behavior change**
@@ -52,9 +52,9 @@ const connectionRequest = await composio.connectedAccounts.link(
 </Tab>
 </Tabs>
 
-Pair with a session-level `multiAccount` / `multi_account` config so the agent can disambiguate at execution time. See [Configuring Sessions](/docs/configuring-sessions) for the session shape.
+Pair with a session-level `multiAccount` / `multi_account` config so the agent can disambiguate at execution time. See [Managing multiple connected accounts](/docs/managing-multiple-connected-accounts) for the session shape.
 
-**2. You're migrating from `initiate()` to `link()`** as part of the [Composio-managed OAuth migration](/docs/changelog/2026/04/24/link-auth-migration). Pass `allow_multiple` / `allowMultiple` through unchanged — same flag name, same default (`False`), same exception (`ComposioMultipleConnectedAccountsError`).
+**2. You're migrating from `initiate()` to `link()`** as part of the [Composio-managed OAuth migration](/docs/changelog/2026/04/24). Pass `allow_multiple` / `allowMultiple` through unchanged — same flag name, same default (`False`), same exception (`ComposioMultipleConnectedAccountsError`).
 
 ### Why
 

--- a/docs/content/changelog/04-28-26-sdk-link-allow-multiple.mdx
+++ b/docs/content/changelog/04-28-26-sdk-link-allow-multiple.mdx
@@ -1,0 +1,62 @@
+---
+title: 'SDKs: `link()` matches `initiate()` for the multi-connection guard'
+description: 'TypeScript and Python `connectedAccounts.link()` now refuse to create a second active connection on the same auth config unless `allowMultiple` / `allow_multiple` is set, mirroring `initiate()`. Patch releases.'
+date: '2026-04-28'
+---
+
+`composio.connectedAccounts.link()` (TypeScript) and `composio.connected_accounts.link()` (Python) now match the multi-connection guard that `initiate()` already had. With Composio-managed redirectable-OAuth callers being [migrated off `POST /api/v3/connected_accounts` onto `POST /api/v3/connected_accounts/link`](/docs/changelog/2026/04/24/link-auth-migration), the guard moves with them — so the migration doesn't quietly drop the duplicate-connection check.
+
+<Callout type="warn">
+**Behavior change**
+
+Before: `link()` would happily create a second `ACTIVE` connection for the same `(user_id, auth_config_id)` pair without a follow-up patch.
+
+After: `link()` first calls `connectedAccounts.list({ userIds, authConfigIds, statuses: ['ACTIVE'] })`. If any active connection exists, `link()` throws `ComposioMultipleConnectedAccountsError` unless the caller passes `allowMultiple: true` (TypeScript) / `allow_multiple=True` (Python).
+</Callout>
+
+### SDK versions (patch releases)
+
+| Package | Previous | This release |
+| ------- | -------- | ------------ |
+| TypeScript `@composio/core` | v0.8.0 | **v0.8.1** |
+| Python `composio` | v0.12.0 | **v0.12.1** |
+
+### Migration
+
+Most callers don't need to do anything — `link()` raised an unrelated error or succeeded by accident in the duplicate-connection case before, and now raises a typed error you can handle. Two scenarios that need attention:
+
+**1. You intentionally create multiple connections per `(user, auth_config)`** — for example, two Gmail accounts for the same user. Opt in:
+
+<Tabs groupId="language" items={['Python', 'TypeScript']} persist>
+<Tab value="Python">
+```python
+connection_request = composio.connected_accounts.link(
+    user_id="user_123",
+    auth_config_id="ac_xxx",
+    alias="work-gmail",
+    allow_multiple=True,
+)
+```
+</Tab>
+<Tab value="TypeScript">
+```typescript
+// @noErrors
+import { Composio } from '@composio/core';
+const composio = new Composio({ apiKey: process.env.COMPOSIO_API_KEY! });
+// ---cut---
+const connectionRequest = await composio.connectedAccounts.link(
+  'user_123',
+  'ac_xxx',
+  { alias: 'work-gmail', allowMultiple: true },
+);
+```
+</Tab>
+</Tabs>
+
+Pair with a session-level `multiAccount` / `multi_account` config so the agent can disambiguate at execution time. See [Configuring Sessions](/docs/configuring-sessions) for the session shape.
+
+**2. You're migrating from `initiate()` to `link()`** as part of the [Composio-managed OAuth migration](/docs/changelog/2026/04/24/link-auth-migration). Pass `allow_multiple` / `allowMultiple` through unchanged — same flag name, same default (`False`), same exception (`ComposioMultipleConnectedAccountsError`).
+
+### Why
+
+The migration changelog moves callers off `connected_accounts/create` onto `/link`. `initiate()` had `allow_multiple` and the duplicate-connection check; `link()` didn't. Without this fix, every customer who migrates would silently lose the guard and start creating duplicate `ACTIVE` connections on auth configs that were never meant to hold more than one. This release closes that gap.

--- a/docs/content/changelog/04-28-26-sdk-sandbox-size.mdx
+++ b/docs/content/changelog/04-28-26-sdk-sandbox-size.mdx
@@ -31,12 +31,12 @@ The field is optional and defaults to `standard` server-side when omitted, so ex
 **TypeScript** (camelCase on the SDK surface):
 
 ```typescript
-// @noErrors
 import { Composio } from '@composio/core';
 const composio = new Composio({ apiKey: process.env.COMPOSIO_API_KEY! });
 
 const session = await composio.create('user_123', {
   workbench: {
+    enable: true,
     sandboxSize: 'large',
   },
 });

--- a/docs/content/changelog/04-28-26-sdk-sandbox-size.mdx
+++ b/docs/content/changelog/04-28-26-sdk-sandbox-size.mdx
@@ -26,8 +26,6 @@ The field is optional and defaults to `standard` server-side when omitted, so ex
 | TypeScript `@composio/core` | v0.8.0 | **v0.8.1** |
 | Python `composio` | v0.12.0 | **v0.12.1** |
 
-Stainless clients are bumped in the same release: `@composio/client` to `0.1.0-alpha.67` and `composio-client` to `1.34.0`.
-
 ### Usage
 
 **TypeScript** (camelCase on the SDK surface):
@@ -59,8 +57,8 @@ session = composio.create(
 
 The `SandboxSize` literal alias is available at `composio.core.models.tool_router.SandboxSize`.
 
-### Behavior on patch
+### Updating an existing session
 
-Changing `sandbox_size` on an existing session recreates the sandbox on next access. The sandbox's in-memory filesystem state is lost, but the persistent `/mnt/files/` mount survives the restart.
+Calling `session.update()` (or the equivalent `PATCH /api/v3/tool_router/sessions/{id}`) with a different `sandbox_size` recreates the sandbox on next access. The sandbox's in-memory filesystem state is lost, but the persistent `/mnt/files/` mount survives the restart.
 
 See [Configuring Sessions → Sandbox compute tier](/docs/configuring-sessions#sandbox-compute-tier) for the full reference.

--- a/docs/content/changelog/04-28-26-sdk-sandbox-size.mdx
+++ b/docs/content/changelog/04-28-26-sdk-sandbox-size.mdx
@@ -1,0 +1,66 @@
+---
+title: 'SDKs add sandbox compute tier for Tool Router workbench'
+description: 'TypeScript and Python SDKs gain `workbench.sandboxSize` / `workbench.sandbox_size` to pick the workbench sandbox tier (standard, medium, large, xlarge). Patch releases.'
+date: '2026-04-28'
+---
+
+The Composio SDKs now let you pick the compute tier of the [workbench](/docs/workbench) sandbox when creating a Tool Router session. Heavier code execution and larger in-memory data benefit from a bigger sandbox.
+
+| Tier       | vCPU | RAM   |
+| ---------- | ---- | ----- |
+| `standard` | 1    | 1 GB  |
+| `medium`   | 2    | 2 GB  |
+| `large`    | 4    | 4 GB  |
+| `xlarge`   | 8    | 8 GB  |
+
+The field is optional and defaults to `standard` server-side when omitted, so existing code keeps working unchanged.
+
+<Callout type="info">
+**Pricing:** Sandboxes are not billed today. Composio plans to begin billing for sandbox usage soon (metered by tier and runtime). Pick a tier that matches your workload — but expect future pricing to track actual usage.
+</Callout>
+
+### SDK versions (patch releases)
+
+| Package | Previous | This release |
+| ------- | -------- | ------------ |
+| TypeScript `@composio/core` | v0.8.0 | **v0.8.1** |
+| Python `composio` | v0.12.0 | **v0.12.1** |
+
+Stainless clients are bumped in the same release: `@composio/client` to `0.1.0-alpha.67` and `composio-client` to `1.34.0`.
+
+### Usage
+
+**TypeScript** (camelCase on the SDK surface):
+
+```typescript
+// @noErrors
+import { Composio } from '@composio/core';
+const composio = new Composio({ apiKey: process.env.COMPOSIO_API_KEY! });
+
+const session = await composio.create('user_123', {
+  workbench: {
+    sandboxSize: 'large',
+  },
+});
+```
+
+The `SandboxSize` literal type and `SandboxSizeSchema` zod enum are exported from `@composio/core`.
+
+**Python** (snake_case throughout):
+
+```python
+session = composio.create(
+    user_id="user_123",
+    workbench={
+        "sandbox_size": "large",
+    },
+)
+```
+
+The `SandboxSize` literal alias is available at `composio.core.models.tool_router.SandboxSize`.
+
+### Behavior on patch
+
+Changing `sandbox_size` on an existing session recreates the sandbox on next access. The sandbox's in-memory filesystem state is lost, but the persistent `/mnt/files/` mount survives the restart.
+
+See [Configuring Sessions → Sandbox compute tier](/docs/configuring-sessions#sandbox-compute-tier) for the full reference.

--- a/docs/content/docs/configuring-sessions.mdx
+++ b/docs/content/docs/configuring-sessions.mdx
@@ -209,6 +209,11 @@ When disabled:
 
 The workbench runs in a per-session sandbox. You can pick a compute tier to match the workload — heavier code execution or larger in-memory data benefits from a bigger sandbox. The tier is passed via `workbench.sandbox_size` (snake_case on the wire; `sandboxSize` in the TypeScript SDK).
 
+<Callout type="info">
+Requires `@composio/core` ≥ `0.8.1` (TypeScript) or `composio` ≥ `0.12.1` (Python). Older SDKs reject `sandboxSize` (TypeScript) or silently drop `sandbox_size` (Python). See the [release notes](/docs/changelog/2026/04/28).
+</Callout>
+
+
 | Tier       | vCPU | RAM   |
 | ---------- | ---- | ----- |
 | `standard` | 1    | 1 GB  |

--- a/docs/content/docs/configuring-sessions.mdx
+++ b/docs/content/docs/configuring-sessions.mdx
@@ -14,7 +14,6 @@ session = composio.create(user_id="user_123")
 </Tab>
 <Tab value="TypeScript">
 ```typescript
-// @noErrors
 import { Composio } from '@composio/core';
 const composio = new Composio({ apiKey: 'your_api_key' });
 // ---cut---
@@ -49,7 +48,6 @@ session = composio.create(
 </Tab>
 <Tab value="TypeScript">
 ```typescript
-// @noErrors
 import { Composio } from '@composio/core';
 const composio = new Composio({ apiKey: 'your_api_key' });
 // ---cut---
@@ -81,7 +79,6 @@ session = composio.create(
 </Tab>
 <Tab value="TypeScript">
 ```typescript
-// @noErrors
 import { Composio } from '@composio/core';
 const composio = new Composio({ apiKey: 'your_api_key' });
 // ---cut---
@@ -110,7 +107,6 @@ session = composio.create(
 </Tab>
 <Tab value="TypeScript">
 ```typescript
-// @noErrors
 import { Composio } from '@composio/core';
 const composio = new Composio({ apiKey: 'your_api_key' });
 // ---cut---
@@ -144,7 +140,6 @@ session = composio.create(
 </Tab>
 <Tab value="TypeScript">
 ```typescript
-// @noErrors
 import { Composio } from '@composio/core';
 const composio = new Composio({ apiKey: 'your_api_key' });
 // ---cut---
@@ -187,7 +182,6 @@ session = composio.create(
 </Tab>
 <Tab value="TypeScript">
 ```typescript
-// @noErrors
 import { Composio } from '@composio/core';
 const composio = new Composio({ apiKey: 'your_api_key' });
 // ---cut---
@@ -236,12 +230,12 @@ session = composio.create(
 </Tab>
 <Tab value="TypeScript">
 ```typescript
-// @noErrors
 import { Composio } from '@composio/core';
 const composio = new Composio({ apiKey: 'your_api_key' });
 // ---cut---
 const session = await composio.create("user_123", {
   workbench: {
+    enable: true,
     sandboxSize: "large",
   },
 });
@@ -269,7 +263,6 @@ mcp_url = session.mcp.url
 </Tab>
 <Tab value="TypeScript">
 ```typescript
-// @noErrors
 import { Composio } from '@composio/core';
 const composio = new Composio({ apiKey: 'your_api_key' });
 const session = await composio.create("user_123");
@@ -294,7 +287,6 @@ tools = session.tools()
 </Tab>
 <Tab value="TypeScript">
 ```typescript
-// @noErrors
 import { Composio } from '@composio/core';
 const composio = new Composio({ apiKey: 'your_api_key' });
 const session = await composio.create("user_123");
@@ -320,7 +312,6 @@ connected_account = connection_request.wait_for_connection()
 </Tab>
 <Tab value="TypeScript">
 ```typescript
-// @noErrors
 import { Composio } from '@composio/core';
 const composio = new Composio({ apiKey: 'your_api_key' });
 const session = await composio.create("user_123");
@@ -354,7 +345,6 @@ for toolkit in toolkits.items:
 </Tab>
 <Tab value="TypeScript">
 ```typescript
-// @noErrors
 import { Composio } from '@composio/core';
 const composio = new Composio({ apiKey: 'your_api_key' });
 const session = await composio.create("user_123");

--- a/docs/content/docs/configuring-sessions.mdx
+++ b/docs/content/docs/configuring-sessions.mdx
@@ -205,6 +205,51 @@ When disabled:
 - Workbench-related system prompt lines are stripped
 - Direct workbench calls are rejected with a 400 error
 
+## Sandbox compute tier
+
+The workbench runs in a per-session sandbox. You can pick a compute tier to match the workload — heavier code execution or larger in-memory data benefits from a bigger sandbox. The tier is passed via `workbench.sandbox_size` (snake_case on the wire; `sandboxSize` in the TypeScript SDK).
+
+| Tier       | vCPU | RAM   |
+| ---------- | ---- | ----- |
+| `standard` | 1    | 1 GB  |
+| `medium`   | 2    | 2 GB  |
+| `large`    | 4    | 4 GB  |
+| `xlarge`   | 8    | 8 GB  |
+
+Defaults to `standard` when omitted.
+
+<Tabs groupId="language" items={['Python', 'TypeScript']} persist>
+<Tab value="Python">
+```python
+session = composio.create(
+    user_id="user_123",
+    workbench={
+        "sandbox_size": "large",
+    },
+)
+```
+</Tab>
+<Tab value="TypeScript">
+```typescript
+// @noErrors
+import { Composio } from '@composio/core';
+const composio = new Composio({ apiKey: 'your_api_key' });
+// ---cut---
+const session = await composio.create("user_123", {
+  workbench: {
+    sandboxSize: "large",
+  },
+});
+```
+</Tab>
+</Tabs>
+
+<Callout type="info">
+**Pricing:** Sandboxes are not billed today. Composio plans to begin billing for sandbox usage soon (metered by tier and runtime). Pick a tier that matches your workload — but expect future pricing to track actual usage.
+</Callout>
+
+Changing `sandbox_size` on an existing session recreates the sandbox on next access. The sandbox's in-memory filesystem state is lost, but the persistent `/mnt/files/` mount survives the restart.
+
 ## Session methods
 
 ### mcp

--- a/docs/content/docs/toolkits/fetching-tools-and-toolkits.mdx
+++ b/docs/content/docs/toolkits/fetching-tools-and-toolkits.mdx
@@ -83,7 +83,7 @@ const allToolkits: any[] = [];
 let cursor: string | undefined;
 
 do {
-  const { items, nextCursor } = await session.toolkits({ limit: 20, nextCursor: cursor });
+  const { items, cursor: nextCursor } = await session.toolkits({ limit: 20, cursor });
   allToolkits.push(...items);
   cursor = nextCursor;
 } while (cursor);

--- a/docs/content/docs/workbench.mdx
+++ b/docs/content/docs/workbench.mdx
@@ -57,7 +57,7 @@ The sandbox runs as a persistent Jupyter notebook. Variables, imports, files, an
 
 ### Compute tier
 
-Sandboxes default to `standard` (1 vCPU / 1 GB RAM). For heavier workloads — large dataframes, ML preprocessing, big bulk operations — pick a larger tier when creating the session via `workbench.sandboxSize` (TypeScript) / `workbench.sandbox_size` (Python). Available tiers: `standard`, `medium` (2 vCPU / 2 GB), `large` (4 vCPU / 4 GB), `xlarge` (8 vCPU / 8 GB). See [Configuring Sessions → Sandbox compute tier](/docs/configuring-sessions#sandbox-compute-tier) for examples.
+Sandboxes default to `standard` (1 vCPU / 1 GB RAM). For heavier workloads — large dataframes, ML preprocessing, big bulk operations — pick a larger tier when creating the session via `workbench.sandboxSize` (TypeScript) / `workbench.sandbox_size` (Python). Available tiers: `standard`, `medium` (2 vCPU / 2 GB), `large` (4 vCPU / 4 GB), `xlarge` (8 vCPU / 8 GB). Requires `@composio/core` ≥ `0.8.1` or `composio` ≥ `0.12.1`. See [Configuring Sessions → Sandbox compute tier](/docs/configuring-sessions#sandbox-compute-tier) for examples.
 
 <Callout type="info">
 **Pricing:** Sandboxes are not billed today. Composio plans to begin billing for sandbox usage soon (metered by tier and runtime).

--- a/docs/content/docs/workbench.mdx
+++ b/docs/content/docs/workbench.mdx
@@ -57,7 +57,7 @@ The sandbox runs as a persistent Jupyter notebook. Variables, imports, files, an
 
 ### Compute tier
 
-Sandboxes default to `standard` (1 vCPU / 1 GB RAM). For heavier workloads — large dataframes, ML preprocessing, big bulk operations — pick a larger tier when creating the session via `workbench.sandbox_size`. Available tiers: `standard`, `medium` (2 vCPU / 2 GB), `large` (4 vCPU / 4 GB), `xlarge` (8 vCPU / 8 GB). See [Configuring Sessions → Sandbox compute tier](/docs/configuring-sessions#sandbox-compute-tier) for examples.
+Sandboxes default to `standard` (1 vCPU / 1 GB RAM). For heavier workloads — large dataframes, ML preprocessing, big bulk operations — pick a larger tier when creating the session via `workbench.sandboxSize` (TypeScript) / `workbench.sandbox_size` (Python). Available tiers: `standard`, `medium` (2 vCPU / 2 GB), `large` (4 vCPU / 4 GB), `xlarge` (8 vCPU / 8 GB). See [Configuring Sessions → Sandbox compute tier](/docs/configuring-sessions#sandbox-compute-tier) for examples.
 
 <Callout type="info">
 **Pricing:** Sandboxes are not billed today. Composio plans to begin billing for sandbox usage soon (metered by tier and runtime).

--- a/docs/content/docs/workbench.mdx
+++ b/docs/content/docs/workbench.mdx
@@ -55,6 +55,14 @@ The workbench corrects common mistakes in the code your agent generates. For exa
 
 The sandbox runs as a persistent Jupyter notebook. Variables, imports, files, and in-memory state from one call are available in the next.
 
+### Compute tier
+
+Sandboxes default to `standard` (1 vCPU / 1 GB RAM). For heavier workloads — large dataframes, ML preprocessing, big bulk operations — pick a larger tier when creating the session via `workbench.sandbox_size`. Available tiers: `standard`, `medium` (2 vCPU / 2 GB), `large` (4 vCPU / 4 GB), `xlarge` (8 vCPU / 8 GB). See [Configuring Sessions → Sandbox compute tier](/docs/configuring-sessions#sandbox-compute-tier) for examples.
+
+<Callout type="info">
+**Pricing:** Sandboxes are not billed today. Composio plans to begin billing for sandbox usage soon (metered by tier and runtime).
+</Callout>
+
 ## Common patterns
 
 ### Bulk operations across apps

--- a/docs/package.json
+++ b/docs/package.json
@@ -44,7 +44,7 @@
     "@anthropic-ai/sdk": "^0.71.2",
     "@composio/anthropic": "^0.5.5",
     "@composio/claude-agent-sdk": "^0.6.3",
-    "@composio/core": "^0.6.10",
+    "@composio/core": "^0.8.1",
     "@composio/google": "^0.5.5",
     "@composio/langchain": "^0.5.5",
     "@composio/llamaindex": "^0.5.5",


### PR DESCRIPTION
# Description

User-facing docs split off from the SDK PRs so the docs land alongside the SDK release.

- Configuring Sessions: new "Sandbox compute tier" section with the tier table (standard/medium/large/xlarge), TS + Python examples, and a Callout flagging that sandboxes are not billed today but usage-based pricing is planned.
- Workbench: new "Compute tier" subsection cross-linking to Configuring Sessions, with the same billing note.
- Changelog: 04-28-26-sdk-sandbox-size — patch release covering the workbench sandbox tier addition.
- Changelog: 04-28-26-sdk-link-allow-multiple — patch release covering the `allow_multiple` parity guard on `connectedAccounts.link()`, flagged as a behavior change with a migration block.

**Now that `@composio/core@0.8.1` is published**, this PR also:
- Bumps the `@composio/core` devDependency in `docs/` from `^0.6.10` to `^0.8.1` so the new snippets type-check end-to-end via twoslash.
- Drops the `// @noErrors` escape hatches that were only there while the SDK predated `sandboxSize` / `allowMultiple`.
- Adds explicit `enable: true` to the workbench examples that set `sandboxSize` (the inferred config type requires `enable`).
- Fixes the unrelated `session.toolkits()` pagination snippet in `fetching-tools-and-toolkits.mdx` for the 0.6 → 0.8 rename of `nextCursor` → `cursor` (surfaced by the SDK bump).

# How did I test this PR

- `cd docs && bun install` to pick up `@composio/core@0.8.1`.
- `bun run build` — full Next.js + twoslash build succeeds; no twoslash type errors on any of the changed code blocks (previously failed with `2741` on the workbench example and `2339`/`2353` on the toolkits cursor example).
- `bun run types:check` — `tsc --noEmit` clean.
- `grep -n '@noErrors' content/changelog/04-28-26-sdk-link-allow-multiple.mdx content/changelog/04-28-26-sdk-sandbox-size.mdx content/docs/configuring-sessions.mdx` — confirmed all 13 directives removed from this branch's content.

Triggered by: abir@composio.dev | Source: web
Session: https://zen-api-production-4c98.up.railway.app/dashboard/#/chat/zen-f1f3a784610f