### PR TITLE
Add tool router preload support to TS SDK

### DIFF
--- a/.changeset/tool-router-preload-sdk.md
+++ b/.changeset/tool-router-preload-sdk.md
@@ -1,0 +1,5 @@
+---
+"@composio/core": patch
+---
+
+Add Tool Router preload support in the TypeScript SDK and route session tool execution through the unified session execute endpoint.

--- a/.changeset/tool-router-preload-sdk.md
+++ b/.changeset/tool-router-preload-sdk.md
@@ -1,5 +1,0 @@
----
-"@composio/core": patch
----
-
-Add Tool Router preload support in the TypeScript SDK and route session tool execution through the unified session execute endpoint.

--- a/ts/packages/core/src/lib/toolRouterParams.ts
+++ b/ts/packages/core/src/lib/toolRouterParams.ts
@@ -128,7 +128,7 @@ export const transformToolRouterWorkbenchParams = (
 
 export const transformToolRouterMultiAccountParams = (
   params?: ToolRouterCreateSessionConfig['multiAccount']
-): Record<string, unknown> | undefined => {
+): SessionCreateParams.MultiAccount | undefined => {
   if (!params) {
     return undefined;
   }

--- a/ts/packages/core/src/models/ToolRouter.ts
+++ b/ts/packages/core/src/models/ToolRouter.ts
@@ -27,11 +27,13 @@ import {
   SessionExperimental,
   MCPServerType,
   ToolRouterMCPServerConfig,
+  ToolRouterSessionMetadata,
 } from '../types/toolRouter.types';
 import { ToolRouterCreateSessionConfigSchema } from '../types/toolRouter.types';
 import {
   SessionCreateParams,
   SessionCreateResponse,
+  SessionRetrieveResponse,
 } from '@composio/client/resources/tool-router/session/session.mjs';
 import {
   transformToolRouterTagsParams,
@@ -48,6 +50,15 @@ import {
   serializeCustomToolkits,
 } from './CustomTool';
 import type { CustomToolsMap } from '../types/customTool.types';
+
+function getSessionMetadata(session: SessionCreateResponse | SessionRetrieveResponse) {
+  const metadata: ToolRouterSessionMetadata = {
+    preload: session.config.preload,
+    configVersion: session.config_version,
+    warnings: 'warnings' in session ? (session.warnings ?? []) : [],
+  };
+  return metadata;
+}
 
 export class ToolRouter<
   TToolCollection,
@@ -128,7 +139,7 @@ export class ToolRouter<
 
     const multiAccountPayload = transformToolRouterMultiAccountParams(routerConfig.multiAccount);
 
-    const payload: SessionCreateParams & { multi_account?: Record<string, unknown> } = {
+    const payload: SessionCreateParams = {
       user_id: userId,
       auth_configs: routerConfig.authConfigs,
       connected_accounts: routerConfig.connectedAccounts,
@@ -140,6 +151,7 @@ export class ToolRouter<
       ),
       workbench: transformToolRouterWorkbenchParams(routerConfig.workbench),
       multi_account: multiAccountPayload,
+      preload: routerConfig.preload,
       experimental: Object.keys(experimentalPayload).length > 0 ? experimentalPayload : undefined,
     };
 
@@ -165,7 +177,8 @@ export class ToolRouter<
       this.createMCPServerConfig(session.mcp),
       { assistivePrompt },
       customToolsMap,
-      userId
+      userId,
+      getSessionMetadata(session)
     );
   }
 
@@ -192,7 +205,11 @@ export class ToolRouter<
       this.client,
       this.config,
       session.session_id,
-      this.createMCPServerConfig(session.mcp)
+      this.createMCPServerConfig(session.mcp),
+      undefined,
+      undefined,
+      undefined,
+      getSessionMetadata(session)
     );
   }
 }

--- a/ts/packages/core/src/models/ToolRouterSession.ts
+++ b/ts/packages/core/src/models/ToolRouterSession.ts
@@ -12,6 +12,10 @@ import {
   ToolRouterSessionExecuteResponse,
   ToolRouterSessionExecuteResponseSchema,
   ToolRouterSessionProxyExecuteResponse,
+  ToolRouterSessionExecuteOptions,
+  ToolRouterSessionMetadata,
+  ToolRouterSessionPreloadConfig,
+  ToolRouterSessionWarning,
 } from '../types/toolRouter.types';
 import {
   transformSearchResponse,
@@ -33,8 +37,9 @@ import type {
   RegisteredCustomTool,
   RegisteredCustomToolkit,
 } from '../types/customTool.types';
-import type { ToolExecuteResponse } from '../types/tool.types';
+import type { Tool, ToolExecuteResponse } from '../types/tool.types';
 import type { SessionProxyExecuteParams } from '../types/toolRouter.types';
+import type { SessionExecuteParams } from '@composio/client/resources/tool-router/session/session.mjs';
 import { SessionProxyExecuteParamsSchema } from '../types/toolRouter.types';
 import { SessionContextImpl } from './SessionContext';
 import { findCustomTool, executeCustomTool } from './customToolExecution';
@@ -50,6 +55,9 @@ export class ToolRouterSession<
   public readonly sessionId: string;
   public readonly mcp: ToolRouterMCPServerConfig;
   public readonly experimental: SessionExperimental;
+  public readonly preload: ToolRouterSessionPreloadConfig;
+  public readonly configVersion?: number;
+  public readonly warnings: ToolRouterSessionWarning[];
 
   /** Singleton session context — shared across all custom tool executions */
   private readonly sessionContext?: SessionContext;
@@ -61,7 +69,8 @@ export class ToolRouterSession<
     mcp: ToolRouterMCPServerConfig,
     experimentalOverrides?: Pick<SessionExperimental, 'assistivePrompt'>,
     private readonly customToolsMap?: CustomToolsMap,
-    private readonly userId?: string
+    private readonly userId?: string,
+    metadata?: ToolRouterSessionMetadata
   ) {
     if (customToolsMap && !userId) {
       throw new Error('userId is required when custom tools are bound to a session.');
@@ -72,6 +81,9 @@ export class ToolRouterSession<
       assistivePrompt: experimentalOverrides?.assistivePrompt,
       files: new ToolRouterSessionFilesMount(client, sessionId),
     };
+    this.preload = metadata?.preload ?? { tools: [] };
+    this.configVersion = metadata?.configVersion;
+    this.warnings = metadata?.warnings ?? [];
 
     // Create singleton session context if custom tools are bound
     if (customToolsMap && userId) {
@@ -90,10 +102,11 @@ export class ToolRouterSession<
    */
   async tools(modifiers?: SessionMetaToolOptions): Promise<ReturnType<TProvider['wrapTools']>> {
     const ToolsModel = new Tools<TToolCollection, TTool, TProvider>(this.client, this.config);
-    const tools = await ToolsModel.getRawToolRouterMetaTools(
+    const tools = await ToolsModel.getRawToolRouterSessionTools(
       this.sessionId,
       modifiers?.modifySchema ? { modifySchema: modifiers.modifySchema } : undefined
     );
+    const toolBySlug = new Map(tools.map(tool => [tool.slug.toUpperCase(), tool]));
 
     if (this.hasCustomTools()) {
       // Create an execute function that splits local/remote tools in COMPOSIO_MULTI_EXECUTE_TOOL
@@ -102,13 +115,13 @@ export class ToolRouterSession<
         input: Record<string, unknown>
       ): Promise<ToolExecuteResponse> => {
         if (toolSlug === COMPOSIO_MULTI_EXECUTE_TOOL) {
-          return this.routeMultiExecute(input, ToolsModel, modifiers);
+          return this.routeMultiExecute(input, ToolsModel, tools, modifiers);
         }
-        // Non-multi-execute meta tools always go to backend
-        return ToolsModel.executeMetaTool(
+        return ToolsModel.executeSessionTool(
           toolSlug,
           { sessionId: this.sessionId, arguments: input },
-          modifiers
+          modifiers,
+          toolBySlug.get(toolSlug.toUpperCase())
         );
       };
 
@@ -284,11 +297,14 @@ export class ToolRouterSession<
    *
    * @param toolSlug - The tool slug to execute
    * @param arguments_ - Optional tool arguments
+   * @param options - Optional execution options
+   * @param options.account - Account identifier for direct app tool execution in multi-account sessions. Helper/meta tools either ignore this top-level field or define their own account-selection fields.
    * @returns The tool execution result
    */
   async execute(
     toolSlug: string,
-    arguments_?: Record<string, unknown>
+    arguments_?: Record<string, unknown>,
+    options?: ToolRouterSessionExecuteOptions
   ): Promise<ToolRouterSessionExecuteResponse> {
     // Check if this is a local tool (by original or final slug)
     const entry = findCustomTool(this.customToolsMap, toolSlug);
@@ -302,10 +318,15 @@ export class ToolRouterSession<
     }
 
     // Remote execution
-    const response = await this.client.toolRouter.session.execute(this.sessionId, {
+    const executeParams: SessionExecuteParams = {
       tool_slug: toolSlug,
       arguments: arguments_ ?? {},
-    });
+    };
+    if (options?.account) {
+      executeParams.account = options.account;
+    }
+
+    const response = await this.client.toolRouter.session.execute(this.sessionId, executeParams);
     const transformed = transformExecuteResponse(response);
     return ToolRouterSessionExecuteResponseSchema.parse(transformed);
   }
@@ -375,15 +396,18 @@ export class ToolRouterSession<
   private async routeMultiExecute(
     input: Record<string, unknown>,
     ToolsModel: Tools<TToolCollection, TTool, TProvider>,
+    tools: Tool[],
     modifiers?: SessionMetaToolOptions
   ): Promise<ToolExecuteResponse> {
+    const multiExecuteTool = tools.find(tool => tool.slug === COMPOSIO_MULTI_EXECUTE_TOOL);
     const toolItems = input.tools as unknown[];
     if (!Array.isArray(toolItems) || toolItems.length === 0) {
       // Fallback: send to backend as-is
-      return ToolsModel.executeMetaTool(
+      return ToolsModel.executeSessionTool(
         COMPOSIO_MULTI_EXECUTE_TOOL,
         { sessionId: this.sessionId, arguments: input },
-        modifiers
+        modifiers,
+        multiExecuteTool
       );
     }
 
@@ -403,10 +427,11 @@ export class ToolRouterSession<
 
     // All remote — just forward entire payload
     if (localItems.length === 0) {
-      return ToolsModel.executeMetaTool(
+      return ToolsModel.executeSessionTool(
         COMPOSIO_MULTI_EXECUTE_TOOL,
         { sessionId: this.sessionId, arguments: input },
-        modifiers
+        modifiers,
+        multiExecuteTool
       );
     }
 
@@ -422,10 +447,11 @@ export class ToolRouterSession<
     if (remoteIndices.length > 0) {
       const remoteToolItems = remoteIndices.map(i => toolItems[i]);
       const remoteInput = { ...input, tools: remoteToolItems };
-      remotePromise = ToolsModel.executeMetaTool(
+      remotePromise = ToolsModel.executeSessionTool(
         COMPOSIO_MULTI_EXECUTE_TOOL,
         { sessionId: this.sessionId, arguments: remoteInput },
-        modifiers
+        modifiers,
+        multiExecuteTool
       );
     }
 

--- a/ts/packages/core/src/models/Tools.ts
+++ b/ts/packages/core/src/models/Tools.ts
@@ -15,6 +15,7 @@ import {
   ToolkitVersionParam,
   SchemaModifierOptions,
   ToolRetrievalOptions,
+  ToolExecuteMetaParams,
   ToolExecuteMetaParamsSchema,
 } from '../types/tool.types';
 import {
@@ -53,8 +54,7 @@ import { telemetry } from '../telemetry/Telemetry';
 import { ComposioConfig } from '../composio';
 import { getToolkitVersion } from '../utils/toolkitVersion';
 import { handleToolExecutionError } from '../errors/ToolErrors';
-import { ToolExecuteMetaParams } from '../types/tool.types';
-import { SessionExecuteMetaParams } from '@composio/client/resources/tool-router.mjs';
+import { SessionExecuteParams } from '@composio/client/resources/tool-router.mjs';
 import { CONFIG_DEFAULTS } from '../utils/config-defaults';
 import { resolveEffectiveUploadAllowlist } from '../utils/fileDirs';
 import { schemaHasFileUploadable } from '../utils/modifiers/FileToolModifier.utils.neutral';
@@ -467,22 +467,22 @@ export class Tools<
   }
 
   /**
-   * Fetches the meta tools for a tool router session.
-   * This method fetches the meta tools from the Composio API and transforms them to the expected format.
-   * It provides access to the underlying meta tool data without provider-specific wrapping.
+   * Fetches tools exposed by a tool router session.
+   * This includes helper/meta tools plus any tools preloaded into the session.
+   * It provides access to the underlying tool data without provider-specific wrapping.
    *
-   * @param sessionId {string} The session id to get the meta tools for
+   * @param sessionId {string} The session id to get tools for
    * @param options {SchemaModifierOptions} Optional configuration for tool retrieval
    * @param {TransformToolSchemaModifier} [options.modifySchema] - Function to transform the tool schema
-   * @returns {Promise<ToolList>} The list of meta tools
+   * @returns {Promise<ToolList>} The list of session tools
    *
    * @example
    * ```typescript
-   * const metaTools = await composio.tools.getRawToolRouterMetaTools('session_123');
-   * console.log(metaTools);
+   * const sessionTools = await composio.tools.getRawToolRouterSessionTools('session_123');
+   * console.log(sessionTools);
    * ```
    */
-  async getRawToolRouterMetaTools(
+  async getRawToolRouterSessionTools(
     sessionId: string,
     options?: SchemaModifierOptions
   ): Promise<ToolList> {
@@ -759,7 +759,7 @@ export class Tools<
     tools: Tool[],
     modifiers?: SessionExecuteMetaModifiers
   ): Tool[] {
-    const executeToolFn = this.createExecuteToolFnForToolRouter(sessionId, modifiers);
+    const executeToolFn = this.createExecuteToolFnForToolRouter(sessionId, tools, modifiers);
     return this.provider.wrapTools(tools, executeToolFn) as Tool[];
   }
 
@@ -800,19 +800,22 @@ export class Tools<
    */
   private createExecuteToolFnForToolRouter(
     sessionId: string,
+    tools: Tool[],
     modifiers?: SessionExecuteMetaModifiers
   ): ExecuteToolFn {
+    const toolBySlug = new Map(tools.map(tool => [tool.slug.toUpperCase(), tool]));
     const executeToolFn = async (
       toolSlug: string,
       input: Record<string, unknown>
     ): Promise<ToolExecuteResponse> => {
-      return await this.executeMetaTool(
+      return await this.executeSessionTool(
         toolSlug,
         {
           sessionId,
           arguments: input,
         },
-        modifiers
+        modifiers,
+        toolBySlug.get(toolSlug.toUpperCase())
       );
     };
     return executeToolFn;
@@ -997,44 +1000,47 @@ export class Tools<
   }
 
   /**
-   * Executes a composio meta tool based on tool router session
+   * Executes a tool based on a tool router session.
    *
    * @param {string} toolSlug - The slug of the tool to execute
    * @param {ToolExecuteMetaParams} body - The execution parameters
    * @param {string} body.sessionId - The session id to execute the tool for
    * @param {Record<string, unknown>} body.arguments - The input to pass to the tool
    * @param {SessionExecuteMetaModifiers} modifiers - The modifiers to apply to the tool
+   * @param {Tool} tool - Optional tool schema used to resolve toolkit metadata for modifiers
    * @returns {Promise<ToolExecuteResponse>} The response from the tool execution
    */
-  async executeMetaTool(
+  async executeSessionTool(
     toolSlug: string,
     body: ToolExecuteMetaParams,
-    modifiers?: SessionExecuteMetaModifiers
+    modifiers?: SessionExecuteMetaModifiers,
+    tool?: Tool
   ): Promise<ToolExecuteResponse> {
-    const executeMetaParams = ToolExecuteMetaParamsSchema.safeParse(body);
-    if (!executeMetaParams.success) {
-      throw new ValidationError('Invalid tool execute meta parameters', {
-        cause: executeMetaParams.error,
+    const executeParams = ToolExecuteMetaParamsSchema.safeParse(body);
+    if (!executeParams.success) {
+      throw new ValidationError('Invalid tool execute session parameters', {
+        cause: executeParams.error,
       });
     }
 
     // Apply beforeExecute modifier if provided
     let modifiedParams = body.arguments ?? {};
+    const toolkitSlug = tool?.toolkit?.slug ?? 'composio';
     if (modifiers?.beforeExecute) {
       modifiedParams = await modifiers.beforeExecute({
         toolSlug,
-        toolkitSlug: 'composio',
+        toolkitSlug,
         sessionId: body.sessionId,
         params: modifiedParams,
       });
     }
 
-    // Execute the meta tool
-    const response = await this.client.toolRouter.session.executeMeta(body.sessionId, {
-      // assert this because backend might keep adding more tool slugs
-      slug: toolSlug as SessionExecuteMetaParams['slug'],
+    const executePayload: SessionExecuteParams = {
+      tool_slug: toolSlug,
       arguments: modifiedParams,
-    });
+    };
+
+    const response = await this.client.toolRouter.session.execute(body.sessionId, executePayload);
 
     // Prepare the result
     let result: ToolExecuteResponse = {
@@ -1048,7 +1054,7 @@ export class Tools<
     if (modifiers?.afterExecute) {
       result = await modifiers.afterExecute({
         toolSlug,
-        toolkitSlug: 'composio',
+        toolkitSlug,
         sessionId: body.sessionId,
         result,
       });

--- a/ts/packages/core/src/types/modifiers.types.ts
+++ b/ts/packages/core/src/types/modifiers.types.ts
@@ -424,29 +424,29 @@ export type ExecuteToolModifiers = {
 } & BeforeFileUploadHook;
 
 /**
- * Type alias for meta tool execution arguments.
- * Represents the arguments passed to a meta tool during execution.
+ * Type alias for session tool execution arguments.
+ * Represents the arguments passed to a tool during session execution.
  * This is derived from ToolExecuteMetaParams but guaranteed to be non-null.
  */
 export type MetaToolArguments = NonNullable<ToolExecuteMetaParams['arguments']>;
 
 /**
- * Modifier for altering the meta tool execute parameters before execution in a session context.
+ * Modifier for altering tool execute parameters before execution in a session context.
  *
- * This function is specifically designed for meta tools executed within a tool router session,
- * allowing you to intercept and modify the parameters before execution. Meta tools are
- * grouped under the 'composio' toolkit slug for organizational purposes.
+ * This function is specifically designed for tools executed within a tool router session,
+ * allowing you to intercept and modify the parameters before execution. Helper tools use
+ * the 'composio' toolkit slug; preloaded app tools use their own toolkit slug when available.
  *
- * @param {string} toolSlug - The slug identifier of the meta tool being executed
- * @param {string} toolkitSlug - The toolkit slug (always 'composio' for meta tools)
+ * @param {string} toolSlug - The slug identifier of the tool being executed
+ * @param {string} toolkitSlug - The toolkit slug for this tool
  * @param {string} sessionId - The session ID for the tool router context
- * @param {MetaToolArguments} params - The parameters being passed to the meta tool
+ * @param {MetaToolArguments} params - The parameters being passed to the tool
  * @returns {MetaToolArguments} The modified parameters
  *
  * @example
  * ```typescript
  * const beforeExecuteMeta = ({ toolSlug, toolkitSlug, sessionId, params }) => {
- *   console.log(`Executing ${toolkitSlug} meta tool ${toolSlug} in session ${sessionId}`);
+ *   console.log(`Executing ${toolkitSlug} tool ${toolSlug} in session ${sessionId}`);
  *
  *   // Add or modify parameters
  *   return {
@@ -464,14 +464,14 @@ export type beforeExecuteMetaModifier = (context: {
 }) => Promise<MetaToolArguments> | MetaToolArguments;
 
 /**
- * Modifier for altering the meta tool execution response after execution completes in a session context.
+ * Modifier for altering a tool execution response after execution completes in a session context.
  *
- * This function is specifically designed for meta tools executed within a tool router session,
+ * This function is specifically designed for tools executed within a tool router session,
  * allowing you to intercept and modify the response after execution. This is useful for
  * session-specific transformations, logging, or error handling.
  *
- * @param {string} toolSlug - The slug identifier of the meta tool that was executed
- * @param {string} toolkitSlug - The toolkit slug (always 'composio' for meta tools)
+ * @param {string} toolSlug - The slug identifier of the tool that was executed
+ * @param {string} toolkitSlug - The toolkit slug for this tool
  * @param {string} sessionId - The session ID for the tool router context
  * @param {ToolExecuteResponse} result - The original execution response
  * @returns {ToolExecuteResponse} The modified execution response
@@ -480,7 +480,7 @@ export type beforeExecuteMetaModifier = (context: {
  * ```typescript
  * const afterExecuteMeta = ({ toolSlug, toolkitSlug, sessionId, result }) => {
  *   // Log session-specific execution
- *   console.log(`${toolkitSlug} meta tool ${toolSlug} completed in session ${sessionId}`);
+ *   console.log(`${toolkitSlug} tool ${toolSlug} completed in session ${sessionId}`);
  *
  *   if (!result.successful) {
  *     console.error(`Session ${sessionId} error:`, result.error);
@@ -498,15 +498,15 @@ export type afterExecuteMetaModifier = (context: {
 }) => Promise<ToolExecuteResponse> | ToolExecuteResponse;
 
 /**
- * Modifiers specifically for meta tool execution within a session context.
+ * Modifiers specifically for tool execution within a session context.
  *
- * These modifiers are designed for tool router session-based meta tool execution,
- * providing hooks to intercept and modify both the request and response of meta tools.
- * Meta tools are grouped under the 'composio' toolkit for organizational consistency.
+ * These modifiers are designed for tool router session-based execution,
+ * providing hooks to intercept and modify both the request and response of helper
+ * tools and preloaded app tools.
  *
  * @example
  * ```typescript
- * const metaModifiers: SessionExecuteMetaModifiers = {
+ * const sessionModifiers: SessionExecuteMetaModifiers = {
  *   beforeExecute: ({ toolSlug, toolkitSlug, sessionId, params }) => {
  *     // Add session tracking
  *     console.log(`Executing ${toolkitSlug}/${toolSlug}`);
@@ -536,13 +536,13 @@ export type afterExecuteMetaModifier = (context: {
  */
 export type SessionExecuteMetaModifiers = {
   /**
-   * Function to intercept and modify meta tool execution parameters before the tool is executed.
+   * Function to intercept and modify session tool execution parameters before the tool is executed.
    * This allows customizing the request based on session-specific needs.
    */
   beforeExecute?: beforeExecuteMetaModifier;
 
   /**
-   * Function to intercept and modify meta tool execution responses after the tool has executed.
+   * Function to intercept and modify session tool execution responses after the tool has executed.
    * This allows transforming the response or implementing custom session-specific handling.
    */
   afterExecute?: afterExecuteMetaModifier;
@@ -587,15 +587,15 @@ export type SessionExecuteMetaModifiers = {
 export type AgenticToolOptions = ToolOptions & ExecuteToolModifiers;
 
 /**
- * Options for session-based meta tool configuration in tool router contexts.
+ * Options for session-based tool configuration in tool router contexts.
  *
  * These options combine schema modification capabilities with session-specific execution
  * behavior customization, providing control over both the definition and execution
- * of meta tools within a tool router session. Meta tools are grouped under the 'composio' toolkit.
+ * of tools within a tool router session.
  *
  * @example
  * ```typescript
- * // Configure meta tools with schema and session-specific execution modifications
+ * // Configure session tools with schema and session-specific execution modifications
  * const sessionTools = await toolRouter.getTools(sessionId, {
  *   modifySchema: (context) => {
  *     return {
@@ -604,7 +604,7 @@ export type AgenticToolOptions = ToolOptions & ExecuteToolModifiers;
  *     };
  *   },
  *
- *   // Intercept before meta tool execution
+ *   // Intercept before session tool execution
  *   beforeExecute: ({ toolSlug, toolkitSlug, sessionId, params }) => {
  *     // Add session tracking
  *     console.log(`Executing ${toolkitSlug}/${toolSlug}`);
@@ -614,7 +614,7 @@ export type AgenticToolOptions = ToolOptions & ExecuteToolModifiers;
  *     };
  *   },
  *
- *   // Transform after meta tool execution
+ *   // Transform after session tool execution
  *   afterExecute: ({ toolSlug, toolkitSlug, sessionId, result }) => {
  *     // Log session results
  *     if (!result.successful) {

--- a/ts/packages/core/src/types/toolRouter.types.ts
+++ b/ts/packages/core/src/types/toolRouter.types.ts
@@ -3,6 +3,7 @@ import type { BaseComposioProvider } from '../provider/BaseProvider';
 import { SessionMetaToolOptions } from './modifiers.types';
 import { ConnectionRequest } from './connectionRequest.types';
 import type { ToolRouterSessionFilesMount } from '../models/ToolRouterSessionFileMount';
+import type { SessionCreateResponse } from '@composio/client/resources/tool-router/session/session.mjs';
 import type {
   CustomTool,
   CustomToolkit,
@@ -254,6 +255,19 @@ export const ToolRouterCreateSessionConfigSchema = z
       .optional()
       .describe('Multi-account configuration for this session'),
 
+    preload: z
+      .object({
+        tools: z
+          .array(z.string())
+          .optional()
+          .describe(
+            'Tool slugs to preload into session.tools() and the MCP tool list. The backend validates slugs against the session filters.'
+          ),
+      })
+      .strict()
+      .optional()
+      .describe('Preload configuration for tools that should be exposed without search.'),
+
     experimental: z
       .object({
         assistivePrompt: z
@@ -305,6 +319,8 @@ export const ToolRouterCreateSessionConfigSchema = z
  * @param {boolean} [multiAccount.enable] - When true, enables multi-account mode. Falls back to org/project-level config when not set.
  * @param {number} [multiAccount.maxAccountsPerToolkit] - Max connected accounts per toolkit (2-10, default 5)
  * @param {boolean} [multiAccount.requireExplicitSelection] - When true, require explicit account selection when multiple accounts are connected
+ * @param {object} [preload] - Tools to preload into session.tools() and the MCP tool list
+ * @param {string[]} [preload.tools] - Tool slugs to preload. Server-side validation ensures they exist and are allowed by the session filters.
  */
 export type ToolRouterCreateSessionConfig = z.infer<typeof ToolRouterCreateSessionConfigSchema>;
 
@@ -506,8 +522,29 @@ export type ToolRouterSessionSearchFn = (params: {
 
 export type ToolRouterSessionExecuteFn = (
   toolSlug: string,
-  arguments_?: Record<string, unknown>
+  arguments_?: Record<string, unknown>,
+  options?: ToolRouterSessionExecuteOptions
 ) => Promise<ToolRouterSessionExecuteResponse>;
+
+export interface ToolRouterSessionExecuteOptions {
+  /**
+   * Account identifier for direct app tool execution in multi-account sessions.
+   * Meta/helper tools either ignore this top-level field or define
+   * their own account-selection fields, for example
+   * COMPOSIO_MULTI_EXECUTE_TOOL.tools[].account.
+   */
+  account?: string;
+}
+
+export type ToolRouterSessionPreloadConfig = SessionCreateResponse.Config.Preload;
+
+export type ToolRouterSessionWarning = SessionCreateResponse.Warning;
+
+export interface ToolRouterSessionMetadata {
+  preload?: ToolRouterSessionPreloadConfig;
+  configVersion?: number;
+  warnings?: ToolRouterSessionWarning[];
+}
 
 export const SessionProxyExecuteParamsSchema = z.object({
   /** The toolkit whose connected account to use for auth (e.g. 'gmail', 'github') */
@@ -543,6 +580,12 @@ export interface Session<
 > {
   sessionId: string;
   mcp: ToolRouterMCPServerConfig;
+  /** Stored preload configuration for this session. */
+  preload: ToolRouterSessionPreloadConfig;
+  /** Server-side config version when returned by the API. */
+  configVersion?: number;
+  /** Non-blocking session creation warnings returned by the API. */
+  warnings: ToolRouterSessionWarning[];
   tools: ToolRouterToolsFn<TToolCollection, TTool, TProvider>;
   authorize: ToolRouterAuthorizeFn;
   toolkits: ToolRouterToolkitsFn;

--- a/ts/packages/core/test/models/customToolRouting.test.ts
+++ b/ts/packages/core/test/models/customToolRouting.test.ts
@@ -16,12 +16,12 @@ vi.mock('../../src/telemetry/Telemetry', () => ({
 // Mock Tools class
 vi.mock('../../src/models/Tools', () => ({
   Tools: vi.fn().mockImplementation(() => ({
-    getRawToolRouterMetaTools: vi.fn().mockResolvedValue([
+    getRawToolRouterSessionTools: vi.fn().mockResolvedValue([
       { slug: 'COMPOSIO_SEARCH_TOOLS', name: 'Search Tools' },
       { slug: 'COMPOSIO_MULTI_EXECUTE_TOOL', name: 'Multi Execute' },
     ]),
     wrapToolsForToolRouter: vi.fn().mockReturnValue('wrapped-tools'),
-    executeMetaTool: vi.fn().mockResolvedValue({
+    executeSessionTool: vi.fn().mockResolvedValue({
       data: { remote: true },
       error: null,
       successful: true,
@@ -38,13 +38,17 @@ const createMockClient = () => ({
     session: {
       create: vi.fn().mockResolvedValue({
         session_id: 'sess_123',
+        config: {
+          preload: { tools: [] },
+          user_id: 'user_1',
+        },
+        config_version: 1,
         mcp: { type: 'http', url: 'https://mcp.example.com/sess_123' },
         tool_router_tools: [],
       }),
       retrieve: vi.fn(),
       link: vi.fn(),
       toolkits: vi.fn(),
-      executeMeta: vi.fn(),
       search: vi.fn(),
       proxyExecute: vi.fn().mockResolvedValue({
         status: 200,
@@ -504,7 +508,7 @@ describe('ToolRouterSession execution routing', () => {
       expect(localExecute).not.toHaveBeenCalled();
     });
 
-    it('should route non-MULTI_EXECUTE meta tools to backend', async () => {
+    it('should route non-MULTI_EXECUTE session tools to backend', async () => {
       const provider = new MockProvider();
       captureExecuteFn(provider);
       const session = createSessionWithProvider(mockClient, provider, [customToolHandle]);
@@ -578,7 +582,7 @@ describe('ToolRouterSession execution routing', () => {
     it('should append local results to remote results array', async () => {
       const { executeFn, toolsInstance } = await setupMultiExecute(mockClient, [customToolHandle]);
 
-      toolsInstance.executeMetaTool.mockResolvedValueOnce(
+      toolsInstance.executeSessionTool.mockResolvedValueOnce(
         backendResponse([{ tool_slug: 'GMAIL_SEND_EMAIL', data: { sent: true } }])
       );
 
@@ -635,7 +639,7 @@ describe('ToolRouterSession execution routing', () => {
         sessionToolHandle,
       ]);
 
-      toolsInstance.executeMetaTool.mockResolvedValueOnce(
+      toolsInstance.executeSessionTool.mockResolvedValueOnce(
         backendResponse([
           { tool_slug: 'GMAIL_SEND_EMAIL', data: { sent: true } },
           { tool_slug: 'SLACK_POST_MESSAGE', data: { ts: '999' } },
@@ -659,7 +663,7 @@ describe('ToolRouterSession execution routing', () => {
       expect(findResult(results, 'GMAIL_SEND_EMAIL')).toBeDefined();
       expect(findResult(results, 'SLACK_POST_MESSAGE')).toBeDefined();
 
-      const backendTools = toolsInstance.executeMetaTool.mock.calls[0][1].arguments.tools;
+      const backendTools = toolsInstance.executeSessionTool.mock.calls[0][1].arguments.tools;
       expect(backendTools).toHaveLength(2);
       expect(backendTools.map((t: any) => t.tool_slug)).toEqual([
         'GMAIL_SEND_EMAIL',
@@ -674,7 +678,7 @@ describe('ToolRouterSession execution routing', () => {
     it('should recompute remote counters when local results are merged', async () => {
       const { executeFn, toolsInstance } = await setupMultiExecute(mockClient, [customToolHandle]);
 
-      toolsInstance.executeMetaTool.mockResolvedValueOnce(
+      toolsInstance.executeSessionTool.mockResolvedValueOnce(
         backendResponse([{ tool_slug: 'GMAIL_SEND_EMAIL', data: { sent: true } }])
       );
 
@@ -694,7 +698,7 @@ describe('ToolRouterSession execution routing', () => {
     it('should handle remote null data without crashing', async () => {
       const { executeFn, toolsInstance } = await setupMultiExecute(mockClient, [customToolHandle]);
 
-      toolsInstance.executeMetaTool.mockResolvedValueOnce({
+      toolsInstance.executeSessionTool.mockResolvedValueOnce({
         data: null,
         error: null,
         successful: true,
@@ -728,7 +732,7 @@ describe('ToolRouterSession execution routing', () => {
         throwingHandle,
       ]);
 
-      toolsInstance.executeMetaTool.mockResolvedValueOnce(
+      toolsInstance.executeSessionTool.mockResolvedValueOnce(
         backendResponse([
           { tool_slug: 'GMAIL_SEND_EMAIL', data: { sent: true } },
           {
@@ -770,7 +774,7 @@ describe('ToolRouterSession execution routing', () => {
     it('should preserve batch-level remote errors when no per-tool remote results exist', async () => {
       const { executeFn, toolsInstance } = await setupMultiExecute(mockClient, [customToolHandle]);
 
-      toolsInstance.executeMetaTool.mockResolvedValueOnce({
+      toolsInstance.executeSessionTool.mockResolvedValueOnce({
         data: null,
         error: 'Remote batch failed before per-tool results were produced',
         successful: false,
@@ -796,20 +800,21 @@ describe('ToolRouterSession execution routing', () => {
         sync_response_to_workbench: false,
       });
 
-      expect(toolsInstance.executeMetaTool).toHaveBeenCalledWith(
+      expect(toolsInstance.executeSessionTool).toHaveBeenCalledWith(
         'COMPOSIO_MULTI_EXECUTE_TOOL',
         expect.objectContaining({
           sessionId: 'sess_123',
           arguments: expect.objectContaining({ tools: [] }),
         }),
-        undefined
+        undefined,
+        expect.objectContaining({ slug: 'COMPOSIO_MULTI_EXECUTE_TOOL' })
       );
     });
 
     it('should handle non-object items in tools array gracefully', async () => {
       const { executeFn, toolsInstance } = await setupMultiExecute(mockClient, [customToolHandle]);
 
-      toolsInstance.executeMetaTool.mockResolvedValueOnce(backendResponse([]));
+      toolsInstance.executeSessionTool.mockResolvedValueOnce(backendResponse([]));
 
       const result = await executeFn('COMPOSIO_MULTI_EXECUTE_TOOL', {
         tools: [
@@ -851,7 +856,7 @@ describe('ToolRouterSession execution routing', () => {
       const toolsInstance = (Tools as any).mock.results[(Tools as any).mock.results.length - 1]
         .value;
 
-      toolsInstance.executeMetaTool.mockImplementation(async () => {
+      toolsInstance.executeSessionTool.mockImplementation(async () => {
         callOrder.push('remote-start');
         await new Promise(r => setTimeout(r, 50));
         callOrder.push('remote-end');
@@ -906,7 +911,7 @@ describe('ToolRouterSession execution routing', () => {
       const latestToolsInstance = (Tools as any).mock.results[
         (Tools as any).mock.results.length - 1
       ].value;
-      latestToolsInstance.executeMetaTool.mockResolvedValueOnce({
+      latestToolsInstance.executeSessionTool.mockResolvedValueOnce({
         data: {
           results: [
             {

--- a/ts/packages/core/test/models/toolRouter.test.ts
+++ b/ts/packages/core/test/models/toolRouter.test.ts
@@ -18,7 +18,7 @@ vi.mock('../../src/models/Tools', () => {
   return {
     Tools: vi.fn().mockImplementation(() => ({
       getRawComposioTools: vi.fn().mockResolvedValue([{ slug: 'GMAIL_FETCH_EMAILS' }]),
-      getRawToolRouterMetaTools: vi.fn().mockResolvedValue([{ slug: 'COMPOSIO_SEARCH_TOOLS' }]),
+      getRawToolRouterSessionTools: vi.fn().mockResolvedValue([{ slug: 'COMPOSIO_SEARCH_TOOLS' }]),
       wrapToolsForToolRouter: vi.fn().mockReturnValue('mocked-wrapped-tools'),
     })),
   };
@@ -34,7 +34,6 @@ const createMockClient = () => ({
       retrieve: vi.fn(),
       link: vi.fn(),
       toolkits: vi.fn(),
-      executeMeta: vi.fn(),
       search: vi.fn(),
       execute: vi.fn(),
     },
@@ -54,6 +53,10 @@ const mockSessionCreateResponse = {
     url: 'https://mcp.example.com/session_123',
   },
   tool_router_tools: ['GMAIL_FETCH_EMAILS', 'SLACK_SEND_MESSAGE', 'GITHUB_CREATE_ISSUE'],
+  config: {
+    preload: { tools: [] },
+  },
+  config_version: 1,
 };
 
 const mockLinkResponse = {
@@ -76,7 +79,9 @@ const mockSessionRetrieveResponse = {
     manage_connections: {
       enable: true,
     },
+    preload: { tools: ['GMAIL_FETCH_EMAILS'] },
   },
+  config_version: 7,
 };
 
 const mockToolkitsResponse = {
@@ -221,6 +226,40 @@ describe('ToolRouter', () => {
         });
 
         expect(session.sessionId).toBe('session_123');
+        expect(session.preload.tools).toEqual([]);
+        expect(session.configVersion).toBe(1);
+      });
+
+      it('should create a session with preloaded tools', async () => {
+        mockClient.toolRouter.session.create.mockResolvedValueOnce({
+          ...mockSessionCreateResponse,
+          config: {
+            preload: { tools: ['GMAIL_FETCH_EMAILS'] },
+          },
+          config_version: 2,
+        });
+
+        const session = await toolRouter.create(userId, {
+          toolkits: ['gmail'],
+          preload: { tools: ['GMAIL_FETCH_EMAILS'] },
+        });
+
+        expect(mockClient.toolRouter.session.create).toHaveBeenCalledWith({
+          user_id: userId,
+          toolkits: {
+            enable: ['gmail'],
+          },
+          auth_configs: undefined,
+          connected_accounts: undefined,
+          tools: undefined,
+          tags: undefined,
+          manage_connections: createExpectedManageConnections(),
+          workbench: undefined,
+          preload: { tools: ['GMAIL_FETCH_EMAILS'] },
+        });
+
+        expect(session.preload.tools).toEqual(['GMAIL_FETCH_EMAILS']);
+        expect(session.configVersion).toBe(2);
       });
 
       it('should create a session with user ID only and verify MCP type transformation', async () => {
@@ -2083,6 +2122,20 @@ describe('ToolRouter', () => {
         arguments: {},
       });
     });
+
+    it('should pass account option to session execute', async () => {
+      mockClient.toolRouter.session.create.mockResolvedValueOnce(mockSessionCreateResponse);
+      mockClient.toolRouter.session.execute.mockResolvedValueOnce(mockExecuteResponse);
+
+      const session = await toolRouter.create(userId);
+      await session.execute('GMAIL_SEND_EMAIL', { to: 'user@example.com' }, { account: 'work' });
+
+      expect(mockClient.toolRouter.session.execute).toHaveBeenCalledWith(sessionId, {
+        tool_slug: 'GMAIL_SEND_EMAIL',
+        arguments: { to: 'user@example.com' },
+        account: 'work',
+      });
+    });
   });
 
   describe('tools function', () => {
@@ -2094,7 +2147,9 @@ describe('ToolRouter', () => {
       vi.clearAllMocks();
       (Tools as any).mockImplementation(() => ({
         getRawComposioTools: vi.fn().mockResolvedValue([{ slug: 'GMAIL_FETCH_EMAILS' }]),
-        getRawToolRouterMetaTools: vi.fn().mockResolvedValue([{ slug: 'COMPOSIO_SEARCH_TOOLS' }]),
+        getRawToolRouterSessionTools: vi
+          .fn()
+          .mockResolvedValue([{ slug: 'COMPOSIO_SEARCH_TOOLS' }]),
         wrapToolsForToolRouter: vi.fn().mockReturnValue('mocked-wrapped-tools'),
       }));
     });
@@ -2111,7 +2166,7 @@ describe('ToolRouter', () => {
       });
 
       const toolsInstance = (Tools as any).mock.results[0].value;
-      expect(toolsInstance.getRawToolRouterMetaTools).toHaveBeenCalledWith(sessionId, undefined);
+      expect(toolsInstance.getRawToolRouterSessionTools).toHaveBeenCalledWith(sessionId, undefined);
       expect(toolsInstance.wrapToolsForToolRouter).toHaveBeenCalledWith(
         sessionId,
         [{ slug: 'COMPOSIO_SEARCH_TOOLS' }],
@@ -2136,7 +2191,7 @@ describe('ToolRouter', () => {
       const tools = await session.tools(modifiers);
 
       const toolsInstance = (Tools as any).mock.results[0].value;
-      expect(toolsInstance.getRawToolRouterMetaTools).toHaveBeenCalledWith(sessionId, {
+      expect(toolsInstance.getRawToolRouterSessionTools).toHaveBeenCalledWith(sessionId, {
         modifySchema: modifiers.modifySchema,
       });
       expect(toolsInstance.wrapToolsForToolRouter).toHaveBeenCalledWith(
@@ -2148,12 +2203,49 @@ describe('ToolRouter', () => {
       expect(tools).toBe('mocked-wrapped-tools');
     });
 
+    it('should include preloaded tools returned by the session tools endpoint', async () => {
+      mockClient.toolRouter.session.create.mockResolvedValueOnce({
+        ...mockSessionCreateResponse,
+        config: {
+          preload: { tools: ['GMAIL_FETCH_EMAILS'] },
+        },
+      });
+
+      (Tools as any).mockImplementation(() => ({
+        getRawComposioTools: vi.fn().mockResolvedValue([{ slug: 'GMAIL_FETCH_EMAILS' }]),
+        getRawToolRouterSessionTools: vi
+          .fn()
+          .mockResolvedValue([
+            { slug: 'COMPOSIO_SEARCH_TOOLS' },
+            { slug: 'GMAIL_FETCH_EMAILS', toolkit: { slug: 'gmail', name: 'Gmail' } },
+          ]),
+        wrapToolsForToolRouter: vi.fn().mockReturnValue('mocked-wrapped-tools'),
+      }));
+
+      const session = await toolRouter.create(userId, {
+        toolkits: ['gmail'],
+        preload: { tools: ['GMAIL_FETCH_EMAILS'] },
+      });
+      const tools = await session.tools();
+
+      const toolsInstance = (Tools as any).mock.results[0].value;
+      expect(toolsInstance.wrapToolsForToolRouter).toHaveBeenCalledWith(
+        sessionId,
+        [
+          { slug: 'COMPOSIO_SEARCH_TOOLS' },
+          { slug: 'GMAIL_FETCH_EMAILS', toolkit: { slug: 'gmail', name: 'Gmail' } },
+        ],
+        undefined
+      );
+      expect(tools).toBe('mocked-wrapped-tools');
+    });
+
     it('should handle tools fetching errors', async () => {
       mockClient.toolRouter.session.create.mockResolvedValueOnce(mockSessionCreateResponse);
 
       (Tools as any).mockImplementation(() => ({
         getRawComposioTools: vi.fn().mockRejectedValue(new Error('Failed to fetch tools')),
-        getRawToolRouterMetaTools: vi.fn().mockRejectedValue(new Error('Failed to fetch tools')),
+        getRawToolRouterSessionTools: vi.fn().mockRejectedValue(new Error('Failed to fetch tools')),
         wrapToolsForToolRouter: vi.fn().mockReturnValue('mocked-wrapped-tools'),
       }));
 
@@ -2178,7 +2270,7 @@ describe('ToolRouter', () => {
       expect(Tools).toHaveBeenCalledTimes(2);
 
       const firstToolsInstance = (Tools as any).mock.results[0].value;
-      expect(firstToolsInstance.getRawToolRouterMetaTools).toHaveBeenCalledWith(sessionId, {
+      expect(firstToolsInstance.getRawToolRouterSessionTools).toHaveBeenCalledWith(sessionId, {
         modifySchema: modifier1.modifySchema,
       });
       expect(firstToolsInstance.wrapToolsForToolRouter).toHaveBeenCalledWith(
@@ -2188,7 +2280,7 @@ describe('ToolRouter', () => {
       );
 
       const secondToolsInstance = (Tools as any).mock.results[1].value;
-      expect(secondToolsInstance.getRawToolRouterMetaTools).toHaveBeenCalledWith(sessionId, {
+      expect(secondToolsInstance.getRawToolRouterSessionTools).toHaveBeenCalledWith(sessionId, {
         modifySchema: modifier2.modifySchema,
       });
       expect(secondToolsInstance.wrapToolsForToolRouter).toHaveBeenCalledWith(
@@ -2215,7 +2307,7 @@ describe('ToolRouter', () => {
         apiKey: 'test-api-key',
       });
       const toolsInstance = (Tools as any).mock.results[0].value;
-      expect(toolsInstance.getRawToolRouterMetaTools).toHaveBeenCalledWith(
+      expect(toolsInstance.getRawToolRouterSessionTools).toHaveBeenCalledWith(
         'custom_session_123',
         undefined
       );
@@ -2243,7 +2335,7 @@ describe('ToolRouter', () => {
         apiKey: 'test-api-key',
       });
       const toolsInstance = (Tools as any).mock.results[0].value;
-      expect(toolsInstance.getRawToolRouterMetaTools).toHaveBeenCalledWith(
+      expect(toolsInstance.getRawToolRouterSessionTools).toHaveBeenCalledWith(
         'empty_session_123',
         undefined
       );
@@ -2371,6 +2463,8 @@ describe('ToolRouter', () => {
       expect(session).toHaveProperty('tools');
       expect(session).toHaveProperty('authorize');
       expect(session).toHaveProperty('toolkits');
+      expect(session.preload.tools).toEqual(['GMAIL_FETCH_EMAILS']);
+      expect(session.configVersion).toBe(7);
     });
 
     it('should return a session with correct session ID', async () => {
@@ -2402,7 +2496,7 @@ describe('ToolRouter', () => {
       expect(Tools).toHaveBeenCalled();
 
       const toolsInstance = (Tools as any).mock.results[0].value;
-      expect(toolsInstance.getRawToolRouterMetaTools).toHaveBeenCalledWith(sessionId, undefined);
+      expect(toolsInstance.getRawToolRouterSessionTools).toHaveBeenCalledWith(sessionId, undefined);
       expect(toolsInstance.wrapToolsForToolRouter).toHaveBeenCalledWith(
         sessionId,
         [{ slug: 'COMPOSIO_SEARCH_TOOLS' }],

--- a/ts/packages/core/test/tools/tools.test.ts
+++ b/ts/packages/core/test/tools/tools.test.ts
@@ -1019,7 +1019,7 @@ describe('Tools', () => {
   describe('Tool Router Execution', () => {
     const sessionId = 'test-session-123';
 
-    describe('executeMetaTool', () => {
+    describe('executeSessionTool', () => {
       it('should execute a tool via tool router session', async () => {
         const toolSlug = 'COMPOSIO_TOOL';
         const body = {
@@ -1027,21 +1027,16 @@ describe('Tools', () => {
           arguments: { query: 'test' },
         };
 
-        const getRawComposioToolBySlugSpy = vi.spyOn(context.tools, 'getRawComposioToolBySlug');
-        getRawComposioToolBySlugSpy.mockResolvedValueOnce(
-          toolMocks.transformedTool as unknown as Tool
-        );
-
-        mockClient.toolRouter.session.executeMeta.mockResolvedValueOnce({
+        mockClient.toolRouter.session.execute.mockResolvedValueOnce({
           data: { results: true },
           error: null,
           log_id: '123',
         });
 
-        const result = await context.tools.executeMetaTool(toolSlug, body);
+        const result = await context.tools.executeSessionTool(toolSlug, body);
 
-        expect(mockClient.toolRouter.session.executeMeta).toHaveBeenCalledWith(sessionId, {
-          slug: toolSlug,
+        expect(mockClient.toolRouter.session.execute).toHaveBeenCalledWith(sessionId, {
+          tool_slug: toolSlug,
           arguments: body.arguments,
         });
         expect(result).toEqual({
@@ -1058,17 +1053,17 @@ describe('Tools', () => {
           arguments: { query: 'test' },
         } as any;
 
-        await expect(context.tools.executeMetaTool('COMPOSIO_TOOL', invalidBody)).rejects.toThrow(
-          'Invalid tool execute meta parameters'
-        );
+        await expect(
+          context.tools.executeSessionTool('COMPOSIO_TOOL', invalidBody)
+        ).rejects.toThrow('Invalid tool execute session parameters');
       });
 
       it('should throw error if tool is not found', async () => {
         const apiError = new Error('Tool not found');
-        mockClient.toolRouter.session.executeMeta.mockRejectedValueOnce(apiError);
+        mockClient.toolRouter.session.execute.mockRejectedValueOnce(apiError);
 
         await expect(
-          context.tools.executeMetaTool('NONEXISTENT_TOOL', {
+          context.tools.executeSessionTool('NONEXISTENT_TOOL', {
             sessionId,
             arguments: { query: 'test' },
           })
@@ -1087,10 +1082,7 @@ describe('Tools', () => {
           toolkit: { slug: 'test-toolkit', name: 'Test Toolkit' },
         };
 
-        const getRawComposioToolBySlugSpy = vi.spyOn(context.tools, 'getRawComposioToolBySlug');
-        getRawComposioToolBySlugSpy.mockResolvedValueOnce(toolWithToolkit as unknown as Tool);
-
-        mockClient.toolRouter.session.executeMeta.mockResolvedValueOnce({
+        mockClient.toolRouter.session.execute.mockResolvedValueOnce({
           data: { results: true },
           error: null,
           log_id: '123',
@@ -1101,17 +1093,22 @@ describe('Tools', () => {
           query: 'modified',
         }));
 
-        await context.tools.executeMetaTool(toolSlug, body, { beforeExecute });
+        await context.tools.executeSessionTool(
+          toolSlug,
+          body,
+          { beforeExecute },
+          toolWithToolkit as unknown as Tool
+        );
 
         expect(beforeExecute).toHaveBeenCalledWith({
           toolSlug,
-          toolkitSlug: 'composio',
+          toolkitSlug: 'test-toolkit',
           sessionId,
           params: { query: 'original' },
         });
 
-        expect(mockClient.toolRouter.session.executeMeta).toHaveBeenCalledWith(sessionId, {
-          slug: toolSlug,
+        expect(mockClient.toolRouter.session.execute).toHaveBeenCalledWith(sessionId, {
+          tool_slug: toolSlug,
           arguments: { query: 'modified' },
         });
       });
@@ -1128,10 +1125,7 @@ describe('Tools', () => {
           toolkit: { slug: 'test-toolkit', name: 'Test Toolkit' },
         };
 
-        const getRawComposioToolBySlugSpy = vi.spyOn(context.tools, 'getRawComposioToolBySlug');
-        getRawComposioToolBySlugSpy.mockResolvedValueOnce(toolWithToolkit as unknown as Tool);
-
-        mockClient.toolRouter.session.executeMeta.mockResolvedValueOnce({
+        mockClient.toolRouter.session.execute.mockResolvedValueOnce({
           data: { results: true },
           error: null,
           log_id: '123',
@@ -1142,11 +1136,16 @@ describe('Tools', () => {
           data: { results: 'modified result' },
         }));
 
-        const result = await context.tools.executeMetaTool(toolSlug, body, { afterExecute });
+        const result = await context.tools.executeSessionTool(
+          toolSlug,
+          body,
+          { afterExecute },
+          toolWithToolkit as unknown as Tool
+        );
 
         expect(afterExecute).toHaveBeenCalledWith({
           toolSlug,
-          toolkitSlug: 'composio',
+          toolkitSlug: 'test-toolkit',
           sessionId,
           result: {
             data: { results: true },
@@ -1166,18 +1165,13 @@ describe('Tools', () => {
           arguments: { query: 'test' },
         };
 
-        const getRawComposioToolBySlugSpy = vi.spyOn(context.tools, 'getRawComposioToolBySlug');
-        getRawComposioToolBySlugSpy.mockResolvedValueOnce(
-          toolMocks.transformedTool as unknown as Tool
-        );
-
-        mockClient.toolRouter.session.executeMeta.mockResolvedValueOnce({
+        mockClient.toolRouter.session.execute.mockResolvedValueOnce({
           data: null,
           error: 'Something went wrong',
           log_id: '456',
         });
 
-        const result = await context.tools.executeMetaTool(toolSlug, body);
+        const result = await context.tools.executeSessionTool(toolSlug, body);
 
         expect(result).toEqual({
           data: null,
@@ -1199,10 +1193,7 @@ describe('Tools', () => {
           toolkit: undefined,
         };
 
-        const getRawComposioToolBySlugSpy = vi.spyOn(context.tools, 'getRawComposioToolBySlug');
-        getRawComposioToolBySlugSpy.mockResolvedValueOnce(toolWithoutToolkit as unknown as Tool);
-
-        mockClient.toolRouter.session.executeMeta.mockResolvedValueOnce({
+        mockClient.toolRouter.session.execute.mockResolvedValueOnce({
           data: { results: true },
           error: null,
           log_id: '123',
@@ -1210,7 +1201,12 @@ describe('Tools', () => {
 
         const beforeExecute = vi.fn().mockImplementation(({ params }) => params);
 
-        await context.tools.executeMetaTool(toolSlug, body, { beforeExecute });
+        await context.tools.executeSessionTool(
+          toolSlug,
+          body,
+          { beforeExecute },
+          toolWithoutToolkit as unknown as Tool
+        );
 
         expect(beforeExecute).toHaveBeenCalledWith({
           toolSlug,
@@ -1233,7 +1229,7 @@ describe('Tools', () => {
         expect(result).toBe('wrapped-tools');
       });
 
-      it('should create execute function that calls executeMetaTool', async () => {
+      it('should create execute function that calls executeSessionTool', async () => {
         const tools = [toolMocks.transformedTool as unknown as Tool];
 
         let capturedExecuteFn: (toolSlug: string, input: Record<string, unknown>) => Promise<any>;
@@ -1245,13 +1241,7 @@ describe('Tools', () => {
 
         context.tools.wrapToolsForToolRouter(sessionId, tools);
 
-        // Setup mocks for execution
-        const getRawComposioToolBySlugSpy = vi.spyOn(context.tools, 'getRawComposioToolBySlug');
-        getRawComposioToolBySlugSpy.mockResolvedValueOnce(
-          toolMocks.transformedTool as unknown as Tool
-        );
-
-        mockClient.toolRouter.session.executeMeta.mockResolvedValueOnce({
+        mockClient.toolRouter.session.execute.mockResolvedValueOnce({
           data: { results: true },
           error: null,
           log_id: '123',
@@ -1260,8 +1250,8 @@ describe('Tools', () => {
         // Call the captured execute function
         const result = await capturedExecuteFn!('COMPOSIO_TOOL', { query: 'test' });
 
-        expect(mockClient.toolRouter.session.executeMeta).toHaveBeenCalledWith(sessionId, {
-          slug: 'COMPOSIO_TOOL',
+        expect(mockClient.toolRouter.session.execute).toHaveBeenCalledWith(sessionId, {
+          tool_slug: 'COMPOSIO_TOOL',
           arguments: { query: 'test' },
         });
         expect(result).toEqual({
@@ -1290,13 +1280,7 @@ describe('Tools', () => {
 
         context.tools.wrapToolsForToolRouter(sessionId, tools, modifiers);
 
-        // Setup mocks for execution
-        const getRawComposioToolBySlugSpy = vi.spyOn(context.tools, 'getRawComposioToolBySlug');
-        getRawComposioToolBySlugSpy.mockResolvedValueOnce(
-          toolMocks.transformedTool as unknown as Tool
-        );
-
-        mockClient.toolRouter.session.executeMeta.mockResolvedValueOnce({
+        mockClient.toolRouter.session.execute.mockResolvedValueOnce({
           data: { results: true },
           error: null,
           log_id: '123',
@@ -1306,8 +1290,8 @@ describe('Tools', () => {
         await capturedExecuteFn!('COMPOSIO_TOOL', { query: 'test' });
 
         expect(modifiers.beforeExecute).toHaveBeenCalled();
-        expect(mockClient.toolRouter.session.executeMeta).toHaveBeenCalledWith(sessionId, {
-          slug: 'COMPOSIO_TOOL',
+        expect(mockClient.toolRouter.session.execute).toHaveBeenCalledWith(sessionId, {
+          tool_slug: 'COMPOSIO_TOOL',
           arguments: { query: 'test', modified: true },
         });
       });

--- a/ts/packages/core/test/utils/mocks/client.mock.ts
+++ b/ts/packages/core/test/utils/mocks/client.mock.ts
@@ -18,7 +18,7 @@ export const mockClient = {
   },
   toolRouter: {
     session: {
-      executeMeta: vi.fn(),
+      execute: vi.fn(),
     },
   },
 };


### PR DESCRIPTION
## Summary
- Add `preload.tools` support to `ToolRouter.create()` using generated `@composio/client@0.1.0-alpha.67` session fields.
- Expose returned session preload/config metadata on `ToolRouterSession` and ensure `session.tools()` includes preloaded tools from the backend session tools endpoint.
- Route provider-wrapped session tool execution through the unified session `/execute` endpoint while preserving toolkit slugs for modifiers when schemas are available.
- Add `session.execute(..., { account })` forwarding for direct app tool execution in multi-account sessions.

## Tests
- `pnpm exec vitest run test/models/toolRouter.test.ts test/models/customToolRouting.test.ts` from `ts/packages/core`
- `pnpm --filter @composio/core typecheck`
