### PR TITLE
chore(deps): bump pnpm 10.28.0 -> 10.28.2 (CVE-2026-24056)

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "clean": "git clean -xdf .turbo node_modules ts/packages/**/.turbo ts/packages/**/node_modules ts/packages/**/dist",
     "clean:workspace": "pnpm turbo clean"
   },
-  "packageManager": "pnpm@10.28.0",
+  "packageManager": "pnpm@10.28.2",
   "devDependencies": {
     "@arethetypeswrong/cli": "catalog:",
     "@changesets/cli": "^2.29.8",


### PR DESCRIPTION
# Description

Bumps the `packageManager` pin from `pnpm@10.28.0` to `pnpm@10.28.2`,
the smallest release that fixes [**CVE-2026-24056**](https://nvd.nist.gov/vuln/detail/CVE-2026-24056) — a symlink
attack in pnpm where installing a malicious `file:` (directory) or `git:`
dependency that contains a symlink to an absolute path causes pnpm to
copy that target file's contents (e.g. `~/.ssh/id_rsa`, `/etc/passwd`)
into `node_modules`, enabling local data exfiltration on developer
machines and CI runners.

Practical risk for this repo is **LOW** — we only install
registry-pinned dependencies with `minimumReleaseAge: 4320` (72-hour
cooldown) configured in `pnpm-workspace.yaml`, so the attacker would
need a malicious package to (a) be added as a dependency, and (b) sit
unnoticed for 72h. The fix is nevertheless a one-line defensive bump
that aligns this repo with the rest of the monorepo:

| repo               | pnpm version | status |
|--------------------|-------------|--------|
| hermes             | `10.33.0`   | safe   |
| composio_dashboard | `10.28.2`   | safe   |
| frontend           | `10.28.2`   | safe   |
| **composio (this PR)** | `10.28.0` -> `10.28.2` | **fix** |
| metrics.composio.io | `10.18.2`  | flagged separately (no CI) |

Discovered during the daily Zen security audit cron.

# How did I test this PR

- Diff is a single character bump (`10.28.0` -> `10.28.2`) in
  `package.json` `packageManager`. No code, lockfile, or workflow
  changes — `pnpm install` will simply use the newer pnpm via Corepack.
- Verified `composio_dashboard` and `frontend` already pin `pnpm@10.28.2`
  successfully across their CI workflows.
- No GHA file modified, so the pnpm-version reference in
  `ts/docs/internal/release.md` (per `CLAUDE.md` maintenance task) does
  not need to be updated by this PR.

---

Triggered by: dhawal@composio.dev | Source: cron-48e51eab745f
Session: https://zen-api-production-4c98.up.railway.app/dashboard/#/chat/zen-cron-16acec0fd729
Origin: cron-48e51eab745f / [zen-cron-16acec0fd729](https://zen-api-production-4c98.up.railway.app/dashboard/#/chat/zen-cron-16acec0fd729)