### PR TITLE
fix: preserve nullability for null-only anyOf/oneOf schemas (#3171)

### DIFF
--- a/python/composio/utils/schema_converter.py
+++ b/python/composio/utils/schema_converter.py
@@ -234,6 +234,11 @@ def _handle_toplevel_combiner(
             allow_undefined_array_items=True,
             allow_undefined_type=True,
         )
+        # A null-only anyOf/oneOf (e.g. {"anyOf": [{"type": "null"}]}) collapses to
+        # NoneType in the library, which loses the nullable-but-untyped intent.
+        # Mirror the direct {"type": "null"} mapping and return Optional[Any].
+        if result is type(None):
+            return PYDANTIC_TYPE_TO_PYTHON_TYPE["null"]
         # If result is a type (like a Union or Optional), return it directly
         # If result is a model class, return it
         return result
@@ -270,6 +275,10 @@ def _build_union_from_options(options: t.List[t.Dict[str, t.Any]]) -> t.Type:
         pydantic_types.append(ptype)
 
     if len(pydantic_types) == 0:
+        # Preserve nullability when every branch was a null branch
+        # (e.g. {"anyOf": [{"type": "null"}]}) instead of downgrading to str.
+        if has_null:
+            return t.cast(t.Type, PYDANTIC_TYPE_TO_PYTHON_TYPE["null"])
         return str  # Fallback
 
     if len(pydantic_types) == 1:

--- a/python/tests/test_schema_parser.py
+++ b/python/tests/test_schema_parser.py
@@ -615,6 +615,35 @@ class TestJsonSchemaToPydanticType:
         assert result is str
         assert not hasattr(result, "__origin__")
 
+    @pytest.mark.unit
+    @pytest.mark.schema
+    def test_anyof_null_only_preserves_nullability(self):
+        """
+        Regression test for #3171: anyOf containing only {"type": "null"}
+        must yield Optional[Any], matching the direct {"type": "null"} mapping.
+        Previously this was downgraded to str (or NoneType depending on the
+        underlying library version), erasing nullability.
+        """
+        json_schema = {"anyOf": [{"type": "null"}]}
+        result = json_schema_to_pydantic_type(json_schema)
+        assert result == t.Optional[t.Any]
+
+    @pytest.mark.unit
+    @pytest.mark.schema
+    def test_oneof_null_only_preserves_nullability(self):
+        """oneOf containing only {"type": "null"} should also yield Optional[Any]."""
+        json_schema = {"oneOf": [{"type": "null"}]}
+        result = json_schema_to_pydantic_type(json_schema)
+        assert result == t.Optional[t.Any]
+
+    @pytest.mark.unit
+    @pytest.mark.schema
+    def test_anyof_repeated_null_branches(self):
+        """Multiple null branches still collapse to a single Optional[Any]."""
+        json_schema = {"anyOf": [{"type": "null"}, {"type": "null"}]}
+        result = json_schema_to_pydantic_type(json_schema)
+        assert result == t.Optional[t.Any]
+
     def test_allof_single_option(self):
         """Test allOf with single option."""
         json_schema = {


### PR DESCRIPTION
# Description

Fixes #3171.

`json_schema_to_pydantic_type()` in `python/composio/utils/schema_converter.py` correctly maps a direct `{"type": "null"}` schema to `Optional[Any]` (via `PYDANTIC_TYPE_TO_PYTHON_TYPE`), but a null-only `anyOf` like `{"anyOf": [{"type": "null"}]}` was being downgraded — to bare `NoneType` (when the underlying library resolves the combiner) or `str` (when execution reached the manual `_build_union_from_options` fallback). Both outcomes erase the nullable-but-untyped intent.

## Root cause

Two paths hit the same gap:

1. **`_handle_toplevel_combiner`** — `json_schema_to_pydantic` library succeeds and returns `type(None)` for a null-only combiner, so we never reach the manual fallback.
2. **`_build_union_from_options`** — when every option is filtered into the `has_null=True` bucket and `pydantic_types` ends up empty, the function falls through to the generic `return str` instead of honoring `has_null`.

## Fix

- `_build_union_from_options`: when `has_null=True` and no non-null branches remain, return `Optional[Any]` instead of `str`.
- `_handle_toplevel_combiner`: when the library resolves the combiner to bare `NoneType`, normalize it to `Optional[Any]` so it matches the direct `{"type": "null"}` mapping.

# How did I test this PR

- Added 3 regression tests in `tests/test_schema_parser.py::TestJsonSchemaToPydanticType`:
  - `test_anyof_null_only_preserves_nullability` — `{"anyOf": [{"type": "null"}]}` → `Optional[Any]`
  - `test_oneof_null_only_preserves_nullability` — `{"oneOf": [{"type": "null"}]}` → `Optional[Any]`
  - `test_anyof_repeated_null_branches` — multiple null branches collapse cleanly
- Ran the full schema parser suite — 68 passed, no regressions:
  ```
  cd python && source .venv/bin/activate
  python -m pytest tests/test_schema_parser.py -v
  ```
- Manually verified the fix preserves existing mixed-type behavior:
  - `{"anyOf": [{"type": "string"}, {"type": "null"}]}` → `Optional[str]` ✓
  - `{"anyOf": [{"type": "string"}, {"type": "integer"}]}` → `Union[str, int]` ✓
  - `{"type": "null"}` → `Optional[Any]` ✓ (unchanged)

Triggered by: abhishek@composio.dev | Source: slack
Session: https://zen-api-production-4c98.up.railway.app/dashboard/#/chat/zen-e25dc264c721