### PR TITLE
fix(tool-router): opt agentic sessions into direct offload

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ catalogs:
       specifier: ^4.20250917.0
       version: 4.20260218.0
     '@composio/client':
-      specifier: 0.1.0-alpha.67
-      version: 0.1.0-alpha.67
+      specifier: 0.1.0-alpha.68
+      version: 0.1.0-alpha.68
     '@effect/cli':
       specifier: ^0.73.2
       version: 0.73.2
@@ -1073,7 +1073,7 @@ importers:
         version: link:../cli-keyring
       '@composio/client':
         specifier: 'catalog:'
-        version: 0.1.0-alpha.67
+        version: 0.1.0-alpha.68
       '@composio/core':
         specifier: workspace:*
         version: link:../core
@@ -1209,7 +1209,7 @@ importers:
     dependencies:
       '@composio/client':
         specifier: 'catalog:'
-        version: 0.1.0-alpha.67
+        version: 0.1.0-alpha.68
       '@composio/json-schema-to-zod':
         specifier: workspace:*
         version: link:../json-schema-to-zod
@@ -1872,8 +1872,8 @@ packages:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
 
-  '@composio/client@0.1.0-alpha.67':
-    resolution: {integrity: sha512-is+P3W4I8mTPk2Wx0TaJRBbld+2sUjhXsEi8PegkX08TS4cpLTPcFzJLkEtUptSmLf0jJBbkEtmRZT9wTgpu4g==}
+  '@composio/client@0.1.0-alpha.68':
+    resolution: {integrity: sha512-hym21PsIELzlF0Fc9RASr3PfGR1alpGE8IlbRJU3ED6UllMZz7VzREsKUZfojG4yHjZMBlVXG5QGMBzuPEue3Q==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -7235,7 +7235,7 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@composio/client@0.1.0-alpha.67': {}
+  '@composio/client@0.1.0-alpha.68': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,7 +21,7 @@ catalog:
   '@clack/prompts': '^1.0.1'
   '@cloudflare/vitest-pool-workers': ^0.9.2
   '@cloudflare/workers-types': ^4.20250917.0
-  '@composio/client': 0.1.0-alpha.67
+  '@composio/client': 0.1.0-alpha.68
   '@effect/cli': ^0.73.2
   '@effect/eslint-plugin': ^0.3.2
   '@effect/language-service': ^0.74.0

--- a/python/composio/core/models/tools.py
+++ b/python/composio/core/models/tools.py
@@ -523,6 +523,9 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
                 session_id=session_id,
                 tool_slug=slug,
                 arguments=processed_arguments,
+                # Provider-wrapped session tools are agentic calls, so they opt into
+                # direct tool offload when the backend session workbench allows it.
+                extra_body={"enable_auto_workbench_offload": True},
             )
 
             # Convert response to standard format

--- a/python/composio/core/models/tools.py
+++ b/python/composio/core/models/tools.py
@@ -525,7 +525,7 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
                 arguments=processed_arguments,
                 # Provider-wrapped session tools are agentic calls, so they opt into
                 # direct tool offload when the backend session workbench allows it.
-                extra_body={"enable_auto_workbench_offload": True},
+                enable_auto_workbench_offload=True,
             )
 
             # Convert response to standard format

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.10,<4"
 dependencies = [
     "pysher>=1.0.8",
     "pydantic>=2.6.4",
-    "composio-client==1.34.0",
+    "composio-client==1.35.0",
     "typing-extensions>=4.0.0",
     "openai",
     "json-schema-to-pydantic>=0.4.8",

--- a/python/setup.py
+++ b/python/setup.py
@@ -25,7 +25,7 @@ setup(
     install_requires=[
         "pysher>=1.0.8",
         "pydantic>=2.6.4",
-        "composio-client==1.33.0",
+        "composio-client==1.35.0",
         "typing-extensions>=4.0.0",
         "openai",
         "json-schema-to-pydantic>=0.4.8",

--- a/python/tests/test_custom_tools.py
+++ b/python/tests/test_custom_tools.py
@@ -540,7 +540,11 @@ class TestSessionContextImpl:
             client=mock_client, user_id="u", session_id="s", custom_tools_map=m
         )
         ctx.execute("NONEXISTENT", {"arg": "val"})
-        mock_client.tool_router.session.execute.assert_called_once()
+        mock_client.tool_router.session.execute.assert_called_once_with(
+            session_id="s",
+            tool_slug="NONEXISTENT",
+            arguments={"arg": "val"},
+        )
 
     def test_proxy_execute(self):
         mock_client = MagicMock()
@@ -608,6 +612,11 @@ class TestToolRouterSessionCustomTools:
         s = _session(mock_session_deps)
         result = s.execute("GMAIL_SEND_EMAIL", arguments={"to": "a@b.com"})
         mock_session_deps["client"].tool_router.session.execute.assert_called_once()
+        call_args = mock_session_deps["client"].tool_router.session.execute.call_args
+        assert call_args.kwargs["session_id"] == "s"
+        assert call_args.kwargs["tool_slug"] == "GMAIL_SEND_EMAIL"
+        assert call_args.kwargs["arguments"] == {"to": "a@b.com"}
+        assert "extra_body" not in call_args.kwargs
         # Remote returns client model as-is (backward compat, supports attribute access)
         assert isinstance(result, SessionExecuteResponse)
         assert result.data == {"sent": True}

--- a/python/tests/test_custom_tools.py
+++ b/python/tests/test_custom_tools.py
@@ -617,6 +617,7 @@ class TestToolRouterSessionCustomTools:
         assert call_args.kwargs["tool_slug"] == "GMAIL_SEND_EMAIL"
         assert call_args.kwargs["arguments"] == {"to": "a@b.com"}
         assert "extra_body" not in call_args.kwargs
+        assert "enable_auto_workbench_offload" not in call_args.kwargs
         # Remote returns client model as-is (backward compat, supports attribute access)
         assert isinstance(result, SessionExecuteResponse)
         assert result.data == {"sent": True}

--- a/python/tests/test_tool_router.py
+++ b/python/tests/test_tool_router.py
@@ -1340,8 +1340,10 @@ class TestToolRouterExecution:
         call_args = mock_tools_instance._wrap_execute_tool_for_tool_router.call_args
         assert call_args.kwargs["session_id"] == "session_123"
 
-    def test_execute_endpoint_called(self, tool_router, mock_client, mock_provider):
-        """Test that session execute endpoint is called when executing tools."""
+    def test_execute_endpoint_called_with_auto_offload_opt_in(
+        self, tool_router, mock_client, mock_provider
+    ):
+        """Test that session execute is called for agentic tool execution."""
         mock_execute_response = MagicMock()
         mock_execute_response.data = {"result": "success"}
         mock_execute_response.error = None
@@ -1362,11 +1364,12 @@ class TestToolRouterExecution:
         # Execute the tool
         result = execute_fn("GMAIL_SEND_EMAIL", {"to": "test@example.com"})
 
-        # Verify execute was called with correct parameters
+        # Verify execute was called with direct offload opt-in for agentic calls
         mock_client.tool_router.session.execute.assert_called_once_with(
             session_id="session_123",
             tool_slug="GMAIL_SEND_EMAIL",
             arguments={"to": "test@example.com"},
+            extra_body={"enable_auto_workbench_offload": True},
         )
 
         # Verify result format
@@ -1424,6 +1427,7 @@ class TestToolRouterExecution:
         mock_client.tool_router.session.execute.assert_called_once()
         call_args = mock_client.tool_router.session.execute.call_args
         assert call_args.kwargs["arguments"] == {"to": "modified@example.com"}
+        assert call_args.kwargs["extra_body"] == {"enable_auto_workbench_offload": True}
 
         # Verify result was modified by after_execute
         assert result["data"] == {"modified": True}

--- a/python/tests/test_tool_router.py
+++ b/python/tests/test_tool_router.py
@@ -1369,7 +1369,7 @@ class TestToolRouterExecution:
             session_id="session_123",
             tool_slug="GMAIL_SEND_EMAIL",
             arguments={"to": "test@example.com"},
-            extra_body={"enable_auto_workbench_offload": True},
+            enable_auto_workbench_offload=True,
         )
 
         # Verify result format
@@ -1427,7 +1427,7 @@ class TestToolRouterExecution:
         mock_client.tool_router.session.execute.assert_called_once()
         call_args = mock_client.tool_router.session.execute.call_args
         assert call_args.kwargs["arguments"] == {"to": "modified@example.com"}
-        assert call_args.kwargs["extra_body"] == {"enable_auto_workbench_offload": True}
+        assert call_args.kwargs["enable_auto_workbench_offload"] is True
 
         # Verify result was modified by after_execute
         assert result["data"] == {"modified": True}

--- a/ts/packages/core/src/models/Tools.ts
+++ b/ts/packages/core/src/models/Tools.ts
@@ -58,6 +58,11 @@ import { SessionExecuteParams } from '@composio/client/resources/tool-router.mjs
 import { CONFIG_DEFAULTS } from '../utils/config-defaults';
 import { resolveEffectiveUploadAllowlist } from '../utils/fileDirs';
 import { schemaHasFileUploadable } from '../utils/modifiers/FileToolModifier.utils.neutral';
+
+type SessionExecuteParamsWithAutoOffload = SessionExecuteParams & {
+  enable_auto_workbench_offload?: boolean;
+};
+
 /**
  * This class is used to manage tools in the Composio SDK.
  * It provides methods to list, get, and execute tools.
@@ -1035,9 +1040,12 @@ export class Tools<
       });
     }
 
-    const executePayload: SessionExecuteParams = {
+    const executePayload: SessionExecuteParamsWithAutoOffload = {
       tool_slug: toolSlug,
       arguments: modifiedParams,
+      // Provider-wrapped session tools are agentic calls, so they opt into
+      // direct tool offload when the backend session workbench allows it.
+      enable_auto_workbench_offload: true,
     };
 
     const response = await this.client.toolRouter.session.execute(body.sessionId, executePayload);

--- a/ts/packages/core/src/models/Tools.ts
+++ b/ts/packages/core/src/models/Tools.ts
@@ -54,14 +54,10 @@ import { telemetry } from '../telemetry/Telemetry';
 import { ComposioConfig } from '../composio';
 import { getToolkitVersion } from '../utils/toolkitVersion';
 import { handleToolExecutionError } from '../errors/ToolErrors';
-import { SessionExecuteParams } from '@composio/client/resources/tool-router.mjs';
+import type { SessionExecuteParams } from '@composio/client/resources/tool-router.mjs';
 import { CONFIG_DEFAULTS } from '../utils/config-defaults';
 import { resolveEffectiveUploadAllowlist } from '../utils/fileDirs';
 import { schemaHasFileUploadable } from '../utils/modifiers/FileToolModifier.utils.neutral';
-
-type SessionExecuteParamsWithAutoOffload = SessionExecuteParams & {
-  enable_auto_workbench_offload?: boolean;
-};
 
 /**
  * This class is used to manage tools in the Composio SDK.
@@ -1040,7 +1036,7 @@ export class Tools<
       });
     }
 
-    const executePayload: SessionExecuteParamsWithAutoOffload = {
+    const executePayload: SessionExecuteParams = {
       tool_slug: toolSlug,
       arguments: modifiedParams,
       // Provider-wrapped session tools are agentic calls, so they opt into

--- a/ts/packages/core/test/tools/tools.test.ts
+++ b/ts/packages/core/test/tools/tools.test.ts
@@ -1038,6 +1038,7 @@ describe('Tools', () => {
         expect(mockClient.toolRouter.session.execute).toHaveBeenCalledWith(sessionId, {
           tool_slug: toolSlug,
           arguments: body.arguments,
+          enable_auto_workbench_offload: true,
         });
         expect(result).toEqual({
           data: { results: true },
@@ -1110,6 +1111,7 @@ describe('Tools', () => {
         expect(mockClient.toolRouter.session.execute).toHaveBeenCalledWith(sessionId, {
           tool_slug: toolSlug,
           arguments: { query: 'modified' },
+          enable_auto_workbench_offload: true,
         });
       });
 
@@ -1253,6 +1255,7 @@ describe('Tools', () => {
         expect(mockClient.toolRouter.session.execute).toHaveBeenCalledWith(sessionId, {
           tool_slug: 'COMPOSIO_TOOL',
           arguments: { query: 'test' },
+          enable_auto_workbench_offload: true,
         });
         expect(result).toEqual({
           data: { results: true },
@@ -1293,6 +1296,7 @@ describe('Tools', () => {
         expect(mockClient.toolRouter.session.execute).toHaveBeenCalledWith(sessionId, {
           tool_slug: 'COMPOSIO_TOOL',
           arguments: { query: 'test', modified: true },
+          enable_auto_workbench_offload: true,
         });
       });
 

--- a/uv.lock
+++ b/uv.lock
@@ -621,7 +621,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "composio-client", specifier = "==1.34.0" },
+    { name = "composio-client", specifier = "==1.35.0" },
     { name = "json-schema-to-pydantic", specifier = ">=0.4.8" },
     { name = "openai" },
     { name = "pydantic", specifier = ">=2.6.4" },
@@ -663,7 +663,7 @@ requires-dist = [
 
 [[package]]
 name = "composio-client"
-version = "1.34.0"
+version = "1.35.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -673,9 +673,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/83/f4/4d860bf054152780c39d1b8a0298dbffa807b8baaf93bdabd6e8eb16ff07/composio_client-1.34.0.tar.gz", hash = "sha256:02880cfdee87c4e62ab4091c8ec783e94949d8df112323c723234786d4413eda", size = 230198, upload-time = "2026-04-28T10:57:18.629Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/8c/986ba4eca8c54b4a4d684dd4b9af07f813a4d19cc0dcef6c3e150befcd5e/composio_client-1.35.0.tar.gz", hash = "sha256:05f195aec2f5706a057848c855ab31b94b00d78283dd9ed0d9a02d316f2acff8", size = 231383, upload-time = "2026-04-30T12:15:20.413Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/54/ddf4c1110a247c52e980dd8503f38afd813e1678f102339aed91e8b643ae/composio_client-1.34.0-py3-none-any.whl", hash = "sha256:93dc2e16b26dc64330091a24fd55858896e490bc93f9d476d7e01703db84aeab", size = 256540, upload-time = "2026-04-28T10:57:16.967Z" },
+    { url = "https://files.pythonhosted.org/packages/58/a3/5d1ab2daded174b811af8ec5539ed35a1e7f8dbcd7ab47779a787487a4fb/composio_client-1.35.0-py3-none-any.whl", hash = "sha256:59b909867a098ba89f513464c0889cfcf1817c707c729faeee665b5b2590e557", size = 257695, upload-time = "2026-04-30T12:15:18.76Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
- Opt provider-wrapped Tool Router session preloaded tools into direct tool workbench offload by sending `enable_auto_workbench_offload: true` from TS and Python agentic execution wrappers.
- Keep manual `session.execute(...)` and custom-tool `SessionContext.execute(...)` paths unchanged so they continue to receive inline responses by default.
- Bump generated clients to `@composio/client@0.1.0-alpha.68` and `composio-client==1.35.0`, then use the generated session execute request field instead of local type overrides / `extra_body`.
- Preserve the existing session execute endpoint path and modifier behavior; this PR only adds the agentic offload opt-in.

## Testing
- `pnpm --filter @composio/core test -- tools.test.ts`
- `pnpm --filter @composio/core typecheck`
- `uv run pytest python/tests/test_tool_router.py python/tests/test_custom_tools.py -q`
- `uvx uv lock --check`
- Checked SDK PR #3314 review comments: Abir's client-package/type-override comment is addressed by the latest commit.