### PR TITLE
fix(mastra): resolve $ref in tool schemas before applyCompatLayer [PLEN-2244]

### DIFF
--- a/.changeset/fix-mastra-ref-dereference.md
+++ b/.changeset/fix-mastra-ref-dereference.md
@@ -8,5 +8,3 @@ Resolve internal JSON Schema `$ref` pointers (`#/$defs/...` and `#/definitions/.
 - New `dereferenceJsonSchema` helper exported from `@composio/core` performs the inline expansion. It deep-clones the input, walks every applicator reflectively (so future JSON Schema keywords are covered), shallow-merges sibling keywords next to `$ref` per Draft 2020-12 semantics, breaks cycles with `{ type: 'object', additionalProperties: true }` (matching the upstream guidance in [mastra-ai/mastra#15341](https://github.com/mastra-ai/mastra/issues/15341)), and strips `$defs`/`definitions` once everything reachable is inlined. External (`http://`/`https://`) `$ref` pointers are left untouched.
 - `@composio/mastra` calls the helper inside `wrapTool` for both `inputParameters` and `outputParameters`.
 - `@mastra/schema-compat` dependency floor raised to `^1.2.9` so users automatically receive [PR #15400](https://github.com/mastra-ai/mastra/pull/15400)'s recursive-`$ref` handling.
-
-Closes [PLEN-2244](https://linear.app/composio/issue/PLEN-2244/mastra-provider-schema-validation-error-cant-resolve-reference).

--- a/.changeset/fix-mastra-ref-dereference.md
+++ b/.changeset/fix-mastra-ref-dereference.md
@@ -1,0 +1,12 @@
+---
+'@composio/core': patch
+'@composio/mastra': patch
+---
+
+Resolve internal JSON Schema `$ref` pointers (`#/$defs/...` and `#/definitions/...`) before handing tool parameters to `@mastra/schema-compat`. Composio tools whose schemas use `$defs`/`definitions` — legal under Draft 7 and 2020-12 — no longer trigger the AJV `can't resolve reference …` error, and the resolved type information from `$defs` survives the JSON-Schema → Zod → JSON-Schema round-trip instead of being silently degraded to a permissive `anyOf`.
+
+- New `dereferenceJsonSchema` helper exported from `@composio/core` performs the inline expansion. It deep-clones the input, walks every applicator reflectively (so future JSON Schema keywords are covered), shallow-merges sibling keywords next to `$ref` per Draft 2020-12 semantics, breaks cycles with `{ type: 'object', additionalProperties: true }` (matching the upstream guidance in [mastra-ai/mastra#15341](https://github.com/mastra-ai/mastra/issues/15341)), and strips `$defs`/`definitions` once everything reachable is inlined. External (`http://`/`https://`) `$ref` pointers are left untouched.
+- `@composio/mastra` calls the helper inside `wrapTool` for both `inputParameters` and `outputParameters`.
+- `@mastra/schema-compat` dependency floor raised to `^1.2.9` so users automatically receive [PR #15400](https://github.com/mastra-ai/mastra/pull/15400)'s recursive-`$ref` handling.
+
+Closes [PLEN-2244](https://linear.app/composio/issue/PLEN-2244/mastra-provider-schema-validation-error-cant-resolve-reference).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1397,8 +1397,8 @@ importers:
   ts/packages/providers/mastra:
     dependencies:
       '@mastra/schema-compat':
-        specifier: ^1.0.0
-        version: 1.1.0(zod@4.3.6)
+        specifier: ^1.2.9
+        version: 1.2.9(zod@4.3.6)
     devDependencies:
       '@composio/core':
         specifier: workspace:*
@@ -3000,6 +3000,12 @@ packages:
 
   '@mastra/schema-compat@1.1.0':
     resolution: {integrity: sha512-2v8nTaAC/279jHs0ux2Emp+lNgBFq3QeNbZCGSHFeeBhbqqM5aWJCPY2Xgw8Z/dY3mTpFxBbmXQz3oRyYStnqg==}
+    engines: {node: '>=22.13.0'}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+
+  '@mastra/schema-compat@1.2.9':
+    resolution: {integrity: sha512-1/RgazXqi1Wdyx8aR81CVS+sRyzlTGUL1YhhHkSULoEY8aXs58bvWkH/6iixlYsY0xGvn+0OPLCeSRkBCtDx4Q==}
     engines: {node: '>=22.13.0'}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -8245,6 +8251,14 @@ snapshots:
       zod-from-json-schema: 0.5.2
       zod-from-json-schema-v3: zod-from-json-schema@0.0.5
       zod-to-json-schema: 3.25.1(zod@4.3.6)
+
+  '@mastra/schema-compat@1.2.9(zod@4.3.6)':
+    dependencies:
+      json-schema-to-zod: 2.7.0
+      zod: 4.3.6
+      zod-from-json-schema: 0.5.2
+      zod-from-json-schema-v3: zod-from-json-schema@0.0.5
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
 
   '@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:

--- a/ts/packages/core/src/errors/ValidationErrors.ts
+++ b/ts/packages/core/src/errors/ValidationErrors.ts
@@ -9,6 +9,7 @@ import { ComposioError, ComposioErrorOptions } from './ComposioError';
 export const ValidationErrorCodes = {
   VALIDATION_ERROR: 'VALIDATION_ERROR',
   JSON_SCHEMA_TO_ZOD_ERROR: 'JSON_SCHEMA_TO_ZOD_ERROR',
+  JSON_SCHEMA_REF_RESOLUTION_ERROR: 'JSON_SCHEMA_REF_RESOLUTION_ERROR',
 } as const;
 
 export class ValidationError extends ComposioError {
@@ -76,6 +77,23 @@ export class JsonSchemaToZodError extends ComposioError {
     super(message, {
       ...options,
       code: options.code || ValidationErrorCodes.JSON_SCHEMA_TO_ZOD_ERROR,
+    });
+  }
+}
+
+/**
+ * Thrown when a JSON Schema `$ref` pointer cannot be resolved against the
+ * document. Used by `dereferenceJsonSchema` to surface malformed pointers,
+ * missing `$defs`/`definitions` targets, or chains exceeding the depth cap.
+ */
+export class JsonSchemaRefResolutionError extends ComposioError {
+  constructor(
+    message: string = 'Failed to resolve JSON Schema $ref',
+    options: ComposioErrorOptions = {}
+  ) {
+    super(message, {
+      ...options,
+      code: options.code || ValidationErrorCodes.JSON_SCHEMA_REF_RESOLUTION_ERROR,
     });
   }
 }

--- a/ts/packages/core/src/index.ts
+++ b/ts/packages/core/src/index.ts
@@ -4,7 +4,11 @@ export { OpenAIProvider } from './provider/OpenAIProvider';
 export { ComposioProvider } from './provider/ComposioProvider';
 export { BaseNonAgenticProvider, BaseAgenticProvider } from './provider/BaseProvider';
 export type { BaseComposioProvider } from './provider/BaseProvider';
-export { jsonSchemaToZodSchema, removeNonRequiredProperties } from './utils/jsonSchema';
+export {
+  dereferenceJsonSchema,
+  jsonSchemaToZodSchema,
+  removeNonRequiredProperties,
+} from './utils/jsonSchema';
 export { getExtensionFromMimeType } from './utils/mime';
 export { AuthScheme } from './models/AuthScheme';
 export { MCP } from './models/MCP';

--- a/ts/packages/core/src/utils/jsonSchema.ts
+++ b/ts/packages/core/src/utils/jsonSchema.ts
@@ -4,51 +4,41 @@ import { jsonSchemaToZod } from '@composio/json-schema-to-zod';
 
 const MAX_REF_CHAIN_DEPTH = 100;
 const MAX_NODE_DEPTH = 512;
-const CYCLE_BREAK_SENTINEL = Object.freeze({ type: 'object', additionalProperties: true });
-const INTERNAL_REF_PREFIX = '#';
+const CYCLE_BREAK_SENTINEL = { type: 'object', additionalProperties: true } as const;
 
 const decodePointerSegment = (segment: string): string =>
   segment.replace(/~1/g, '/').replace(/~0/g, '~');
 
-const resolvePointer = (
-  root: Record<string, unknown>,
-  pointer: string
-): { target: unknown; canonical: string } => {
-  if (pointer === '#' || pointer === '') {
-    return { target: root, canonical: '#' };
+const failResolution = (pointer: string, segment: string): never => {
+  throw new JsonSchemaRefResolutionError(`Cannot resolve $ref ${pointer}`, {
+    meta: { ref: pointer, failedAt: segment },
+  });
+};
+
+const stepInto = (cursor: unknown, segment: string, pointer: string): unknown => {
+  if (cursor === null || typeof cursor !== 'object') failResolution(pointer, segment);
+  if (Array.isArray(cursor)) {
+    const i = Number(segment);
+    if (!Number.isInteger(i) || i < 0 || i >= cursor.length) failResolution(pointer, segment);
+    return cursor[i];
   }
+  const obj = cursor as Record<string, unknown>;
+  if (!Object.prototype.hasOwnProperty.call(obj, segment)) failResolution(pointer, segment);
+  return obj[segment];
+};
+
+const resolvePointer = (root: Record<string, unknown>, pointer: string): unknown => {
+  if (pointer === '#' || pointer === '') return root;
   if (!pointer.startsWith('#/')) {
     throw new JsonSchemaRefResolutionError(`Unsupported $ref pointer: ${pointer}`, {
       meta: { ref: pointer },
     });
   }
-  const segments = pointer.slice(2).split('/').map(decodePointerSegment);
-  let cursor: unknown = root;
-  for (const segment of segments) {
-    if (cursor === null || typeof cursor !== 'object') {
-      throw new JsonSchemaRefResolutionError(`Cannot resolve $ref ${pointer}`, {
-        meta: { ref: pointer, failedAt: segment },
-      });
-    }
-    if (Array.isArray(cursor)) {
-      const index = Number(segment);
-      if (!Number.isInteger(index) || index < 0 || index >= cursor.length) {
-        throw new JsonSchemaRefResolutionError(`Cannot resolve $ref ${pointer}`, {
-          meta: { ref: pointer, failedAt: segment },
-        });
-      }
-      cursor = cursor[index];
-    } else {
-      const obj = cursor as Record<string, unknown>;
-      if (!Object.prototype.hasOwnProperty.call(obj, segment)) {
-        throw new JsonSchemaRefResolutionError(`Cannot resolve $ref ${pointer}`, {
-          meta: { ref: pointer, failedAt: segment },
-        });
-      }
-      cursor = obj[segment];
-    }
-  }
-  return { target: cursor, canonical: pointer };
+  return pointer
+    .slice(2)
+    .split('/')
+    .map(decodePointerSegment)
+    .reduce<unknown>((cursor, seg) => stepInto(cursor, seg, pointer), root);
 };
 
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
@@ -105,7 +95,24 @@ export function dereferenceJsonSchema<T = unknown>(schema: T): T {
   const root = schema as Record<string, unknown>;
   const visiting = new WeakSet<object>();
 
-  const walk = (node: unknown, path: string[], depth: number, nodeDepth: number): unknown => {
+  const cloneChildren = (
+    obj: Record<string, unknown>,
+    visitedRefs: ReadonlySet<string>,
+    chainDepth: number,
+    nodeDepth: number
+  ): Record<string, unknown> =>
+    Object.fromEntries(
+      Object.entries(obj).map(([k, v]) => [k, walk(v, visitedRefs, chainDepth, nodeDepth + 1)])
+    );
+
+  // Function declaration so `cloneChildren` can reference `walk` despite being
+  // declared earlier (function declarations are hoisted within the closure).
+  function walk(
+    node: unknown,
+    visitedRefs: ReadonlySet<string>,
+    chainDepth: number,
+    nodeDepth: number
+  ): unknown {
     if (nodeDepth >= MAX_NODE_DEPTH) {
       throw new JsonSchemaRefResolutionError(
         `JSON Schema node depth exceeded cap (${MAX_NODE_DEPTH})`
@@ -115,9 +122,7 @@ export function dereferenceJsonSchema<T = unknown>(schema: T): T {
       if (visiting.has(node)) return { ...CYCLE_BREAK_SENTINEL };
       visiting.add(node);
       try {
-        return node.map((item, index) =>
-          walk(item, [...path, String(index)], depth, nodeDepth + 1)
-        );
+        return node.map(item => walk(item, visitedRefs, chainDepth, nodeDepth + 1));
       } finally {
         visiting.delete(node);
       }
@@ -126,62 +131,39 @@ export function dereferenceJsonSchema<T = unknown>(schema: T): T {
     if (visiting.has(node)) return { ...CYCLE_BREAK_SENTINEL };
     visiting.add(node);
     try {
-      if (typeof node.$ref === 'string') {
-        const ref = node.$ref;
-        // External refs are out of scope; leave them alone.
-        if (!ref.startsWith(INTERNAL_REF_PREFIX)) {
-          const cloned: Record<string, unknown> = {};
-          for (const [key, value] of Object.entries(node)) {
-            cloned[key] = walk(value, [...path, key], depth, nodeDepth + 1);
-          }
-          return cloned;
-        }
-
-        if (depth >= MAX_REF_CHAIN_DEPTH) {
-          throw new JsonSchemaRefResolutionError(
-            `JSON Schema $ref chain exceeded depth cap (${MAX_REF_CHAIN_DEPTH}): ${ref}`,
-            { meta: { ref } }
-          );
-        }
-
-        // Cycle detection: if `ref` already appears in the current path, this
-        // resolution would re-enter itself. Break the cycle.
-        if (path.includes(`@ref:${ref}`)) {
-          return { ...CYCLE_BREAK_SENTINEL };
-        }
-
-        const { target } = resolvePointer(root, ref);
-        const resolved = walk(target, [...path, `@ref:${ref}`], depth + 1, nodeDepth + 1);
-
-        // Shallow-merge sibling keywords (Draft 2020-12 semantics: siblings win
-        // on collision). Draft 7 ignores siblings entirely, but the Composio
-        // tool surface admits both drafts so we honor siblings for safety.
-        const { $ref: _omit, ...siblings } = node;
-        void _omit;
-        if (Object.keys(siblings).length === 0) {
-          return resolved;
-        }
-        if (!isPlainObject(resolved)) {
-          return resolved;
-        }
-        const merged: Record<string, unknown> = { ...resolved };
-        for (const [key, value] of Object.entries(siblings)) {
-          merged[key] = walk(value, [...path, key], depth, nodeDepth + 1);
-        }
-        return merged;
+      const ref = typeof node.$ref === 'string' ? node.$ref : null;
+      // External refs and non-$ref nodes both pass through the same clone path.
+      if (ref === null || !ref.startsWith('#')) {
+        return cloneChildren(node, visitedRefs, chainDepth, nodeDepth);
       }
 
-      const cloned: Record<string, unknown> = {};
-      for (const [key, value] of Object.entries(node)) {
-        cloned[key] = walk(value, [...path, key], depth, nodeDepth + 1);
+      if (chainDepth >= MAX_REF_CHAIN_DEPTH) {
+        throw new JsonSchemaRefResolutionError(
+          `JSON Schema $ref chain exceeded depth cap (${MAX_REF_CHAIN_DEPTH}): ${ref}`,
+          { meta: { ref } }
+        );
       }
-      return cloned;
+      if (visitedRefs.has(ref)) return { ...CYCLE_BREAK_SENTINEL };
+
+      const target = resolvePointer(root, ref);
+      const nextRefs = new Set(visitedRefs).add(ref);
+      const resolved = walk(target, nextRefs, chainDepth + 1, nodeDepth + 1);
+
+      // Shallow-merge sibling keywords (Draft 2020-12 semantics: siblings win
+      // on collision). Draft 7 ignores siblings entirely, but the Composio
+      // tool surface admits both drafts so we honor siblings for safety.
+      const siblings: Record<string, unknown> = { ...node };
+      delete siblings.$ref;
+      if (Object.keys(siblings).length === 0 || !isPlainObject(resolved)) {
+        return resolved;
+      }
+      return { ...resolved, ...cloneChildren(siblings, visitedRefs, chainDepth, nodeDepth) };
     } finally {
       visiting.delete(node);
     }
-  };
+  }
 
-  const out = walk(root, [], 0, 0);
+  const out = walk(root, new Set(), 0, 0);
   if (isPlainObject(out)) {
     delete out.$defs;
     delete out.definitions;

--- a/ts/packages/core/src/utils/jsonSchema.ts
+++ b/ts/packages/core/src/utils/jsonSchema.ts
@@ -1,6 +1,173 @@
 import { z } from 'zod/v3';
-import { JsonSchemaToZodError } from '../errors';
+import { JsonSchemaRefResolutionError, JsonSchemaToZodError } from '../errors';
 import { jsonSchemaToZod } from '@composio/json-schema-to-zod';
+
+const MAX_REF_CHAIN_DEPTH = 100;
+const CYCLE_BREAK_SENTINEL = Object.freeze({ type: 'object', additionalProperties: true });
+const INTERNAL_REF_PREFIX = '#';
+
+const decodePointerSegment = (segment: string): string =>
+  segment.replace(/~1/g, '/').replace(/~0/g, '~');
+
+const resolvePointer = (
+  root: Record<string, unknown>,
+  pointer: string
+): { target: unknown; canonical: string } => {
+  if (pointer === '#' || pointer === '') {
+    return { target: root, canonical: '#' };
+  }
+  if (!pointer.startsWith('#/')) {
+    throw new JsonSchemaRefResolutionError(`Unsupported $ref pointer: ${pointer}`, {
+      meta: { ref: pointer },
+    });
+  }
+  const segments = pointer.slice(2).split('/').map(decodePointerSegment);
+  let cursor: unknown = root;
+  for (const segment of segments) {
+    if (cursor === null || typeof cursor !== 'object') {
+      throw new JsonSchemaRefResolutionError(`Cannot resolve $ref ${pointer}`, {
+        meta: { ref: pointer, failedAt: segment },
+      });
+    }
+    if (Array.isArray(cursor)) {
+      const index = Number(segment);
+      if (!Number.isInteger(index) || index < 0 || index >= cursor.length) {
+        throw new JsonSchemaRefResolutionError(`Cannot resolve $ref ${pointer}`, {
+          meta: { ref: pointer, failedAt: segment },
+        });
+      }
+      cursor = cursor[index];
+    } else {
+      const obj = cursor as Record<string, unknown>;
+      if (!Object.prototype.hasOwnProperty.call(obj, segment)) {
+        throw new JsonSchemaRefResolutionError(`Cannot resolve $ref ${pointer}`, {
+          meta: { ref: pointer, failedAt: segment },
+        });
+      }
+      cursor = obj[segment];
+    }
+  }
+  return { target: cursor, canonical: pointer };
+};
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === 'object' && !Array.isArray(value);
+
+/**
+ * Inlines internal JSON Schema `$ref` pointers (`#/$defs/...` and the
+ * legacy `#/definitions/...`) so the returned schema can be safely handed
+ * to consumers — like AJV in `@mastra/schema-compat` — that don't tolerate
+ * unresolved references.
+ *
+ * The traversal is reflective (no allow-list of JSON Schema keywords), so
+ * future applicators (`unevaluatedProperties`, `dependentSchemas`, …) are
+ * covered automatically. Sibling keywords next to `$ref` are shallow-merged
+ * per Draft 2020-12 semantics — the sibling wins on collision so a caller's
+ * `description` or `default` overrides the target's. Recursive `$ref`
+ * chains are broken with `{ type: 'object', additionalProperties: true }`,
+ * matching the upstream Mastra recommendation in
+ * {@link https://github.com/mastra-ai/mastra/issues/15341 mastra-ai/mastra#15341}.
+ *
+ * The input schema is not mutated: every node is deep-cloned. `$defs` and
+ * `definitions` are stripped from the returned root once everything
+ * reachable is inlined — AJV strict-mode otherwise complains about unused
+ * definitions.
+ *
+ * External `$ref` pointers (`http://`, `https://`, `file://`, …) are left
+ * untouched: the caller may forward them to a consumer that resolves them
+ * natively.
+ *
+ * @param schema - The JSON Schema to dereference. May be any plain object.
+ * @returns A new schema with internal `$ref` pointers inlined.
+ *
+ * @throws {JsonSchemaRefResolutionError} When an internal pointer is
+ * malformed, points at a missing target, or chains past the depth cap.
+ *
+ * @example
+ * ```ts
+ * dereferenceJsonSchema({
+ *   type: 'object',
+ *   properties: { user: { $ref: '#/$defs/User' } },
+ *   $defs: { User: { type: 'object', properties: { id: { type: 'string' } } } },
+ * });
+ * // {
+ * //   type: 'object',
+ * //   properties: {
+ * //     user: { type: 'object', properties: { id: { type: 'string' } } },
+ * //   },
+ * // }
+ * ```
+ */
+export function dereferenceJsonSchema<T = unknown>(schema: T): T {
+  if (!isPlainObject(schema)) return schema;
+
+  const root = schema as Record<string, unknown>;
+
+  const walk = (node: unknown, path: string[], depth: number): unknown => {
+    if (Array.isArray(node)) {
+      return node.map((item, index) => walk(item, [...path, String(index)], depth));
+    }
+    if (!isPlainObject(node)) return node;
+
+    if (typeof node.$ref === 'string') {
+      const ref = node.$ref;
+      // External refs are out of scope; leave them alone.
+      if (!ref.startsWith(INTERNAL_REF_PREFIX)) {
+        const cloned: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(node)) {
+          cloned[key] = walk(value, [...path, key], depth);
+        }
+        return cloned;
+      }
+
+      if (depth >= MAX_REF_CHAIN_DEPTH) {
+        throw new JsonSchemaRefResolutionError(
+          `JSON Schema $ref chain exceeded depth cap (${MAX_REF_CHAIN_DEPTH}): ${ref}`,
+          { meta: { ref } }
+        );
+      }
+
+      // Cycle detection: if `ref` already appears in the current path, this
+      // resolution would re-enter itself. Break the cycle.
+      if (path.includes(`@ref:${ref}`)) {
+        return { ...CYCLE_BREAK_SENTINEL };
+      }
+
+      const { target } = resolvePointer(root, ref);
+      const resolved = walk(target, [...path, `@ref:${ref}`], depth + 1);
+
+      // Shallow-merge sibling keywords (Draft 2020-12 semantics: siblings win
+      // on collision). Draft 7 ignores siblings entirely, but the Composio
+      // tool surface admits both drafts so we honor siblings for safety.
+      const { $ref: _omit, ...siblings } = node;
+      void _omit;
+      if (Object.keys(siblings).length === 0) {
+        return resolved;
+      }
+      if (!isPlainObject(resolved)) {
+        return resolved;
+      }
+      const merged: Record<string, unknown> = { ...resolved };
+      for (const [key, value] of Object.entries(siblings)) {
+        merged[key] = walk(value, [...path, key], depth);
+      }
+      return merged;
+    }
+
+    const cloned: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(node)) {
+      cloned[key] = walk(value, [...path, key], depth);
+    }
+    return cloned;
+  };
+
+  const out = walk(root, [], 0);
+  if (isPlainObject(out)) {
+    delete out.$defs;
+    delete out.definitions;
+  }
+  return out as T;
+}
 
 /**
  * Removes all non-required properties from the schema

--- a/ts/packages/core/src/utils/jsonSchema.ts
+++ b/ts/packages/core/src/utils/jsonSchema.ts
@@ -51,49 +51,15 @@ const resolvePointer = (root: Record<string, unknown>, pointer: string): unknown
 };
 
 /**
- * Inlines internal JSON Schema `$ref` pointers (`#/$defs/...` and the
- * legacy `#/definitions/...`) so the returned schema can be safely handed
- * to consumers — like AJV in `@mastra/schema-compat` — that don't tolerate
- * unresolved references.
+ * Inlines internal JSON Schema `$ref` pointers (`#/$defs/...` and legacy
+ * `#/definitions/...`) so the returned schema can be safely handed to
+ * consumers that don't tolerate unresolved references (e.g. AJV in
+ * `@mastra/schema-compat`). External (`http://`, `https://`, …) refs are
+ * left untouched. Cycles are broken with `{ type: 'object',
+ * additionalProperties: true }`. The input is never mutated.
  *
- * The traversal is reflective (no allow-list of JSON Schema keywords), so
- * future applicators (`unevaluatedProperties`, `dependentSchemas`, …) are
- * covered automatically. Sibling keywords next to `$ref` are shallow-merged
- * per Draft 2020-12 semantics — the sibling wins on collision so a caller's
- * `description` or `default` overrides the target's. Recursive `$ref`
- * chains are broken with `{ type: 'object', additionalProperties: true }`,
- * matching the upstream Mastra recommendation in
- * {@link https://github.com/mastra-ai/mastra/issues/15341 mastra-ai/mastra#15341}.
- *
- * The input schema is not mutated: every node is deep-cloned. `$defs` and
- * `definitions` are stripped from the returned root once everything
- * reachable is inlined — AJV strict-mode otherwise complains about unused
- * definitions.
- *
- * External `$ref` pointers (`http://`, `https://`, `file://`, …) are left
- * untouched: the caller may forward them to a consumer that resolves them
- * natively.
- *
- * @param schema - The JSON Schema to dereference. May be any plain object.
- * @returns A new schema with internal `$ref` pointers inlined.
- *
- * @throws {JsonSchemaRefResolutionError} When an internal pointer is
- * malformed, points at a missing target, or chains past the depth cap.
- *
- * @example
- * ```ts
- * dereferenceJsonSchema({
- *   type: 'object',
- *   properties: { user: { $ref: '#/$defs/User' } },
- *   $defs: { User: { type: 'object', properties: { id: { type: 'string' } } } },
- * });
- * // {
- * //   type: 'object',
- * //   properties: {
- * //     user: { type: 'object', properties: { id: { type: 'string' } } },
- * //   },
- * // }
- * ```
+ * @throws {JsonSchemaRefResolutionError} on malformed pointers, missing
+ * targets, or chains past the depth cap.
  */
 export function dereferenceJsonSchema<T = unknown>(schema: T): T {
   if (!isPlainObject(schema)) return schema;
@@ -101,9 +67,8 @@ export function dereferenceJsonSchema<T = unknown>(schema: T): T {
   const root = schema as Record<string, unknown>;
   const visiting = new WeakSet<object>();
 
-  // Filter `__proto__`/`constructor`/`prototype` keys to avoid altering the
-  // prototype of the cloned output node (which can break downstream
-  // `Object.keys` / `in` checks even though the global prototype is safe).
+  // POLLUTING_KEYS filter prevents an attacker-shaped $defs entry from altering
+  // the cloned node's prototype.
   const cloneChildren = (
     obj: Record<string, unknown>,
     visitedRefs: ReadonlySet<string>,
@@ -116,8 +81,7 @@ export function dereferenceJsonSchema<T = unknown>(schema: T): T {
         .map(([k, v]) => [k, walk(v, visitedRefs, chainDepth, nodeDepth + 1)])
     );
 
-  // Function declaration so `cloneChildren` can reference `walk` despite being
-  // declared earlier (function declarations are hoisted within the closure).
+  // `function` (not `const`) so `cloneChildren` above can call it via hoisting.
   function walk(
     node: unknown,
     visitedRefs: ReadonlySet<string>,

--- a/ts/packages/core/src/utils/jsonSchema.ts
+++ b/ts/packages/core/src/utils/jsonSchema.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod/v3';
 import { JsonSchemaRefResolutionError, JsonSchemaToZodError } from '../errors';
 import { jsonSchemaToZod } from '@composio/json-schema-to-zod';
+import { isPlainObject } from './modifiers/FileToolModifier.utils.neutral';
 
 const MAX_REF_CHAIN_DEPTH = 100;
 const MAX_NODE_DEPTH = 512;
@@ -40,9 +41,6 @@ const resolvePointer = (root: Record<string, unknown>, pointer: string): unknown
     .map(decodePointerSegment)
     .reduce<unknown>((cursor, seg) => stepInto(cursor, seg, pointer), root);
 };
-
-const isPlainObject = (value: unknown): value is Record<string, unknown> =>
-  value !== null && typeof value === 'object' && !Array.isArray(value);
 
 /**
  * Inlines internal JSON Schema `$ref` pointers (`#/$defs/...` and the

--- a/ts/packages/core/src/utils/jsonSchema.ts
+++ b/ts/packages/core/src/utils/jsonSchema.ts
@@ -3,6 +3,7 @@ import { JsonSchemaRefResolutionError, JsonSchemaToZodError } from '../errors';
 import { jsonSchemaToZod } from '@composio/json-schema-to-zod';
 
 const MAX_REF_CHAIN_DEPTH = 100;
+const MAX_NODE_DEPTH = 512;
 const CYCLE_BREAK_SENTINEL = Object.freeze({ type: 'object', additionalProperties: true });
 const INTERNAL_REF_PREFIX = '#';
 
@@ -102,66 +103,85 @@ export function dereferenceJsonSchema<T = unknown>(schema: T): T {
   if (!isPlainObject(schema)) return schema;
 
   const root = schema as Record<string, unknown>;
+  const visiting = new WeakSet<object>();
 
-  const walk = (node: unknown, path: string[], depth: number): unknown => {
+  const walk = (node: unknown, path: string[], depth: number, nodeDepth: number): unknown => {
+    if (nodeDepth >= MAX_NODE_DEPTH) {
+      throw new JsonSchemaRefResolutionError(
+        `JSON Schema node depth exceeded cap (${MAX_NODE_DEPTH})`
+      );
+    }
     if (Array.isArray(node)) {
-      return node.map((item, index) => walk(item, [...path, String(index)], depth));
+      if (visiting.has(node)) return { ...CYCLE_BREAK_SENTINEL };
+      visiting.add(node);
+      try {
+        return node.map((item, index) =>
+          walk(item, [...path, String(index)], depth, nodeDepth + 1)
+        );
+      } finally {
+        visiting.delete(node);
+      }
     }
     if (!isPlainObject(node)) return node;
-
-    if (typeof node.$ref === 'string') {
-      const ref = node.$ref;
-      // External refs are out of scope; leave them alone.
-      if (!ref.startsWith(INTERNAL_REF_PREFIX)) {
-        const cloned: Record<string, unknown> = {};
-        for (const [key, value] of Object.entries(node)) {
-          cloned[key] = walk(value, [...path, key], depth);
+    if (visiting.has(node)) return { ...CYCLE_BREAK_SENTINEL };
+    visiting.add(node);
+    try {
+      if (typeof node.$ref === 'string') {
+        const ref = node.$ref;
+        // External refs are out of scope; leave them alone.
+        if (!ref.startsWith(INTERNAL_REF_PREFIX)) {
+          const cloned: Record<string, unknown> = {};
+          for (const [key, value] of Object.entries(node)) {
+            cloned[key] = walk(value, [...path, key], depth, nodeDepth + 1);
+          }
+          return cloned;
         }
-        return cloned;
+
+        if (depth >= MAX_REF_CHAIN_DEPTH) {
+          throw new JsonSchemaRefResolutionError(
+            `JSON Schema $ref chain exceeded depth cap (${MAX_REF_CHAIN_DEPTH}): ${ref}`,
+            { meta: { ref } }
+          );
+        }
+
+        // Cycle detection: if `ref` already appears in the current path, this
+        // resolution would re-enter itself. Break the cycle.
+        if (path.includes(`@ref:${ref}`)) {
+          return { ...CYCLE_BREAK_SENTINEL };
+        }
+
+        const { target } = resolvePointer(root, ref);
+        const resolved = walk(target, [...path, `@ref:${ref}`], depth + 1, nodeDepth + 1);
+
+        // Shallow-merge sibling keywords (Draft 2020-12 semantics: siblings win
+        // on collision). Draft 7 ignores siblings entirely, but the Composio
+        // tool surface admits both drafts so we honor siblings for safety.
+        const { $ref: _omit, ...siblings } = node;
+        void _omit;
+        if (Object.keys(siblings).length === 0) {
+          return resolved;
+        }
+        if (!isPlainObject(resolved)) {
+          return resolved;
+        }
+        const merged: Record<string, unknown> = { ...resolved };
+        for (const [key, value] of Object.entries(siblings)) {
+          merged[key] = walk(value, [...path, key], depth, nodeDepth + 1);
+        }
+        return merged;
       }
 
-      if (depth >= MAX_REF_CHAIN_DEPTH) {
-        throw new JsonSchemaRefResolutionError(
-          `JSON Schema $ref chain exceeded depth cap (${MAX_REF_CHAIN_DEPTH}): ${ref}`,
-          { meta: { ref } }
-        );
+      const cloned: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(node)) {
+        cloned[key] = walk(value, [...path, key], depth, nodeDepth + 1);
       }
-
-      // Cycle detection: if `ref` already appears in the current path, this
-      // resolution would re-enter itself. Break the cycle.
-      if (path.includes(`@ref:${ref}`)) {
-        return { ...CYCLE_BREAK_SENTINEL };
-      }
-
-      const { target } = resolvePointer(root, ref);
-      const resolved = walk(target, [...path, `@ref:${ref}`], depth + 1);
-
-      // Shallow-merge sibling keywords (Draft 2020-12 semantics: siblings win
-      // on collision). Draft 7 ignores siblings entirely, but the Composio
-      // tool surface admits both drafts so we honor siblings for safety.
-      const { $ref: _omit, ...siblings } = node;
-      void _omit;
-      if (Object.keys(siblings).length === 0) {
-        return resolved;
-      }
-      if (!isPlainObject(resolved)) {
-        return resolved;
-      }
-      const merged: Record<string, unknown> = { ...resolved };
-      for (const [key, value] of Object.entries(siblings)) {
-        merged[key] = walk(value, [...path, key], depth);
-      }
-      return merged;
+      return cloned;
+    } finally {
+      visiting.delete(node);
     }
-
-    const cloned: Record<string, unknown> = {};
-    for (const [key, value] of Object.entries(node)) {
-      cloned[key] = walk(value, [...path, key], depth);
-    }
-    return cloned;
   };
 
-  const out = walk(root, [], 0);
+  const out = walk(root, [], 0, 0);
   if (isPlainObject(out)) {
     delete out.$defs;
     delete out.definitions;

--- a/ts/packages/core/src/utils/jsonSchema.ts
+++ b/ts/packages/core/src/utils/jsonSchema.ts
@@ -1,11 +1,17 @@
 import { z } from 'zod/v3';
 import { JsonSchemaRefResolutionError, JsonSchemaToZodError } from '../errors';
 import { jsonSchemaToZod } from '@composio/json-schema-to-zod';
+import logger from './logger';
 import { isPlainObject } from './modifiers/FileToolModifier.utils.neutral';
 
 const MAX_REF_CHAIN_DEPTH = 100;
 const MAX_NODE_DEPTH = 512;
 const CYCLE_BREAK_SENTINEL = { type: 'object', additionalProperties: true } as const;
+const POLLUTING_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+const REF_RESOLUTION_FIXES = [
+  'Ensure the $ref pointer matches a path in $defs or definitions',
+  'External $ref pointers (http://, https://, file://, …) are not resolved by the SDK',
+];
 
 const decodePointerSegment = (segment: string): string =>
   segment.replace(/~1/g, '/').replace(/~0/g, '~');
@@ -13,6 +19,7 @@ const decodePointerSegment = (segment: string): string =>
 const failResolution = (pointer: string, segment: string): never => {
   throw new JsonSchemaRefResolutionError(`Cannot resolve $ref ${pointer}`, {
     meta: { ref: pointer, failedAt: segment },
+    possibleFixes: REF_RESOLUTION_FIXES,
   });
 };
 
@@ -33,6 +40,7 @@ const resolvePointer = (root: Record<string, unknown>, pointer: string): unknown
   if (!pointer.startsWith('#/')) {
     throw new JsonSchemaRefResolutionError(`Unsupported $ref pointer: ${pointer}`, {
       meta: { ref: pointer },
+      possibleFixes: REF_RESOLUTION_FIXES,
     });
   }
   return pointer
@@ -93,6 +101,9 @@ export function dereferenceJsonSchema<T = unknown>(schema: T): T {
   const root = schema as Record<string, unknown>;
   const visiting = new WeakSet<object>();
 
+  // Filter `__proto__`/`constructor`/`prototype` keys to avoid altering the
+  // prototype of the cloned output node (which can break downstream
+  // `Object.keys` / `in` checks even though the global prototype is safe).
   const cloneChildren = (
     obj: Record<string, unknown>,
     visitedRefs: ReadonlySet<string>,
@@ -100,7 +111,9 @@ export function dereferenceJsonSchema<T = unknown>(schema: T): T {
     nodeDepth: number
   ): Record<string, unknown> =>
     Object.fromEntries(
-      Object.entries(obj).map(([k, v]) => [k, walk(v, visitedRefs, chainDepth, nodeDepth + 1)])
+      Object.entries(obj)
+        .filter(([k]) => !POLLUTING_KEYS.has(k))
+        .map(([k, v]) => [k, walk(v, visitedRefs, chainDepth, nodeDepth + 1)])
     );
 
   // Function declaration so `cloneChildren` can reference `walk` despite being
@@ -113,7 +126,8 @@ export function dereferenceJsonSchema<T = unknown>(schema: T): T {
   ): unknown {
     if (nodeDepth >= MAX_NODE_DEPTH) {
       throw new JsonSchemaRefResolutionError(
-        `JSON Schema node depth exceeded cap (${MAX_NODE_DEPTH})`
+        `JSON Schema node depth exceeded cap (${MAX_NODE_DEPTH})`,
+        { possibleFixes: REF_RESOLUTION_FIXES }
       );
     }
     if (Array.isArray(node)) {
@@ -132,13 +146,18 @@ export function dereferenceJsonSchema<T = unknown>(schema: T): T {
       const ref = typeof node.$ref === 'string' ? node.$ref : null;
       // External refs and non-$ref nodes both pass through the same clone path.
       if (ref === null || !ref.startsWith('#')) {
+        if (ref !== null) {
+          // Audit signal for security-sensitive deployments: a downstream
+          // resolver may fetch this and trigger SSRF or local-file disclosure.
+          logger.warn(`Leaving external $ref untouched: ${ref}`);
+        }
         return cloneChildren(node, visitedRefs, chainDepth, nodeDepth);
       }
 
       if (chainDepth >= MAX_REF_CHAIN_DEPTH) {
         throw new JsonSchemaRefResolutionError(
           `JSON Schema $ref chain exceeded depth cap (${MAX_REF_CHAIN_DEPTH}): ${ref}`,
-          { meta: { ref } }
+          { meta: { ref }, possibleFixes: REF_RESOLUTION_FIXES }
         );
       }
       if (visitedRefs.has(ref)) return { ...CYCLE_BREAK_SENTINEL };

--- a/ts/packages/core/test/utils/jsonSchema.test.ts
+++ b/ts/packages/core/test/utils/jsonSchema.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { dereferenceJsonSchema } from '../../src/utils/jsonSchema';
 import { JsonSchemaRefResolutionError } from '../../src/errors/ValidationErrors';
+import logger from '../../src/utils/logger';
 
 const containsRef = (value: unknown): boolean => {
   if (value === null || typeof value !== 'object') return false;
@@ -198,15 +199,41 @@ describe('dereferenceJsonSchema', () => {
     expect(out.properties.self).toEqual({ type: 'object', additionalProperties: true });
   });
 
-  it('leaves external $ref pointers untouched', () => {
+  it('leaves external $ref pointers untouched and warns once for audit', () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    try {
+      const out = dereferenceJsonSchema({
+        type: 'object',
+        properties: { v: { $ref: 'https://example.com/Foo' } },
+      });
+
+      expect((out as { properties: { v: { $ref: string } } }).properties.v.$ref).toBe(
+        'https://example.com/Foo'
+      );
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('https://example.com/Foo'));
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('filters prototype-pollution keys when cloning', () => {
     const out = dereferenceJsonSchema({
       type: 'object',
-      properties: { v: { $ref: 'https://example.com/Foo' } },
-    });
+      properties: {
+        v: { $ref: '#/$defs/User' },
+      },
+      $defs: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        User: { type: 'object', __proto__: { polluted: true } } as any,
+      },
+    } as Record<string, unknown>);
 
-    expect((out as { properties: { v: { $ref: string } } }).properties.v.$ref).toBe(
-      'https://example.com/Foo'
-    );
+    const v = (out as { properties: { v: Record<string, unknown> } }).properties.v;
+    expect('__proto__' in v && (v as Record<string, unknown>).__proto__).not.toEqual({
+      polluted: true,
+    });
+    // The cloned node's prototype should remain Object.prototype.
+    expect(Object.getPrototypeOf(v)).toBe(Object.prototype);
   });
 
   it('does not mutate the input schema', () => {

--- a/ts/packages/core/test/utils/jsonSchema.test.ts
+++ b/ts/packages/core/test/utils/jsonSchema.test.ts
@@ -170,6 +170,34 @@ describe('dereferenceJsonSchema', () => {
     ).toThrow(JsonSchemaRefResolutionError);
   });
 
+  it('throws JsonSchemaRefResolutionError on pathologically deep object nesting', () => {
+    // Build { properties: { x: { properties: { x: { ... } } } } } 1000 levels deep.
+    // Without a node-depth cap this would blow the V8 stack; with the cap, it throws
+    // a typed error before recursion grows unbounded.
+    type Nested = { type: 'object'; properties: { x: Nested | { type: 'string' } } };
+    let leaf: Nested | { type: 'string' } = { type: 'string' };
+    for (let i = 0; i < 1000; i++) {
+      leaf = { type: 'object', properties: { x: leaf } } as Nested;
+    }
+    expect(() => dereferenceJsonSchema(leaf)).toThrow(JsonSchemaRefResolutionError);
+  });
+
+  it('breaks JS object cycles that do not flow through a $ref', () => {
+    // Composio ingests schemas as live JS objects (custom tools, telemetry, …),
+    // so a non-$ref cycle is plausible. Without object-identity cycle detection
+    // this would infinite-loop; with it, the cycle returns the permissive sentinel.
+    const root: Record<string, unknown> = {
+      type: 'object',
+      properties: {},
+    };
+    (root.properties as Record<string, unknown>).self = root;
+
+    const out = dereferenceJsonSchema(root) as {
+      properties: { self: { type: string; additionalProperties: boolean } };
+    };
+    expect(out.properties.self).toEqual({ type: 'object', additionalProperties: true });
+  });
+
   it('leaves external $ref pointers untouched', () => {
     const out = dereferenceJsonSchema({
       type: 'object',

--- a/ts/packages/core/test/utils/jsonSchema.test.ts
+++ b/ts/packages/core/test/utils/jsonSchema.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect } from 'vitest';
+import { dereferenceJsonSchema } from '../../src/utils/jsonSchema';
+import { JsonSchemaRefResolutionError } from '../../src/errors/ValidationErrors';
+
+const containsRef = (value: unknown): boolean => {
+  if (value === null || typeof value !== 'object') return false;
+  if (Array.isArray(value)) return value.some(containsRef);
+  if ('$ref' in (value as Record<string, unknown>)) return true;
+  return Object.values(value as Record<string, unknown>).some(containsRef);
+};
+
+describe('dereferenceJsonSchema', () => {
+  it('inlines a single internal $ref under $defs', () => {
+    const out = dereferenceJsonSchema({
+      type: 'object',
+      properties: { user: { $ref: '#/$defs/User' } },
+      required: ['user'],
+      $defs: { User: { type: 'string' } },
+    });
+
+    expect(out).toEqual({
+      type: 'object',
+      properties: { user: { type: 'string' } },
+      required: ['user'],
+    });
+    expect(containsRef(out)).toBe(false);
+  });
+
+  it('resolves a chain of refs A -> B -> C', () => {
+    const out = dereferenceJsonSchema({
+      type: 'object',
+      properties: { v: { $ref: '#/$defs/A' } },
+      $defs: {
+        A: { $ref: '#/$defs/B' },
+        B: { $ref: '#/$defs/C' },
+        C: { type: 'integer' },
+      },
+    });
+
+    expect(containsRef(out)).toBe(false);
+    expect((out as { properties: { v: unknown } }).properties.v).toEqual({ type: 'integer' });
+  });
+
+  it('walks containers reflectively (items, oneOf, anyOf, allOf, not, additionalProperties, patternProperties, prefixItems)', () => {
+    const out = dereferenceJsonSchema({
+      type: 'object',
+      properties: {
+        a: { type: 'array', items: { $ref: '#/$defs/Leaf' } },
+        b: { oneOf: [{ $ref: '#/$defs/Leaf' }, { type: 'null' }] },
+        c: { anyOf: [{ $ref: '#/$defs/Leaf' }] },
+        d: { allOf: [{ $ref: '#/$defs/Leaf' }] },
+        e: { not: { $ref: '#/$defs/Leaf' } },
+        f: { type: 'object', additionalProperties: { $ref: '#/$defs/Leaf' } },
+        g: {
+          type: 'object',
+          patternProperties: { '^x_': { $ref: '#/$defs/Leaf' } },
+        },
+        h: { type: 'array', prefixItems: [{ $ref: '#/$defs/Leaf' }] },
+      },
+      $defs: { Leaf: { type: 'string' } },
+    });
+
+    expect(containsRef(out)).toBe(false);
+  });
+
+  it('resolves Draft 7 legacy `definitions`', () => {
+    const out = dereferenceJsonSchema({
+      type: 'object',
+      properties: { name: { $ref: '#/definitions/Name' } },
+      definitions: { Name: { type: 'string', minLength: 1 } },
+    });
+
+    expect(containsRef(out)).toBe(false);
+    expect((out as { properties: { name: unknown } }).properties.name).toEqual({
+      type: 'string',
+      minLength: 1,
+    });
+  });
+
+  it('mixes $defs and definitions transitively', () => {
+    const out = dereferenceJsonSchema({
+      type: 'object',
+      properties: { v: { $ref: '#/definitions/A' } },
+      definitions: { A: { $ref: '#/$defs/B' } },
+      $defs: { B: { type: 'boolean' } },
+    });
+
+    expect(containsRef(out)).toBe(false);
+    expect((out as { properties: { v: unknown } }).properties.v).toEqual({ type: 'boolean' });
+  });
+
+  it('shallow-merges sibling keywords next to $ref (Draft 2020-12 semantics; siblings win on collision)', () => {
+    const out = dereferenceJsonSchema({
+      type: 'object',
+      properties: {
+        v: {
+          $ref: '#/$defs/Foo',
+          description: 'caller override',
+          default: null,
+        },
+      },
+      $defs: {
+        Foo: { type: 'string', description: 'target description' },
+      },
+    });
+
+    const v = (out as { properties: { v: Record<string, unknown> } }).properties.v;
+    expect(v.type).toBe('string');
+    expect(v.description).toBe('caller override');
+    expect(v.default).toBeNull();
+    expect(containsRef(out)).toBe(false);
+  });
+
+  it('breaks recursive $ref cycles with a permissive object sentinel', () => {
+    const out = dereferenceJsonSchema({
+      $ref: '#/$defs/Tree',
+      $defs: {
+        Tree: {
+          type: 'object',
+          properties: {
+            children: { type: 'array', items: { $ref: '#/$defs/Tree' } },
+          },
+        },
+      },
+    });
+
+    expect((out as { type: string }).type).toBe('object');
+    const children = (
+      out as {
+        properties: { children: { items: { type: string; additionalProperties: boolean } } };
+      }
+    ).properties.children;
+    expect(children.items).toEqual({ type: 'object', additionalProperties: true });
+    expect(containsRef(out)).toBe(false);
+  });
+
+  it('strips $defs and definitions from the returned root schema', () => {
+    const out = dereferenceJsonSchema({
+      type: 'object',
+      properties: { x: { $ref: '#/$defs/Foo' } },
+      $defs: { Foo: { type: 'integer' } },
+      definitions: { Bar: { type: 'string' } },
+    }) as Record<string, unknown>;
+
+    expect(out.$defs).toBeUndefined();
+    expect(out.definitions).toBeUndefined();
+  });
+
+  it('throws JsonSchemaRefResolutionError when target is missing', () => {
+    expect(() =>
+      dereferenceJsonSchema({
+        type: 'object',
+        properties: { v: { $ref: '#/$defs/Missing' } },
+        $defs: {},
+      })
+    ).toThrow(JsonSchemaRefResolutionError);
+  });
+
+  it('throws JsonSchemaRefResolutionError when chain depth exceeds the cap', () => {
+    const $defs: Record<string, unknown> = {};
+    for (let i = 0; i < 200; i++) {
+      $defs[`A${i}`] = { $ref: i + 1 < 200 ? `#/$defs/A${i + 1}` : '#/$defs/A0' };
+    }
+    expect(() =>
+      dereferenceJsonSchema({
+        type: 'object',
+        properties: { v: { $ref: '#/$defs/A0' } },
+        $defs,
+      })
+    ).toThrow(JsonSchemaRefResolutionError);
+  });
+
+  it('leaves external $ref pointers untouched', () => {
+    const out = dereferenceJsonSchema({
+      type: 'object',
+      properties: { v: { $ref: 'https://example.com/Foo' } },
+    });
+
+    expect((out as { properties: { v: { $ref: string } } }).properties.v.$ref).toBe(
+      'https://example.com/Foo'
+    );
+  });
+
+  it('does not mutate the input schema', () => {
+    const input = {
+      type: 'object',
+      properties: { v: { $ref: '#/$defs/Foo' } },
+      $defs: { Foo: { type: 'string' } },
+    };
+    const snapshot = structuredClone(input);
+    dereferenceJsonSchema(input);
+    expect(input).toEqual(snapshot);
+  });
+
+  it('decodes JSON Pointer escape sequences (~1 -> /, ~0 -> ~) in the correct order', () => {
+    const out = dereferenceJsonSchema({
+      type: 'object',
+      properties: {
+        a: { $ref: '#/$defs/with~1slash' },
+        b: { $ref: '#/$defs/with~0tilde' },
+        c: { $ref: '#/$defs/tilde-then-slash~01' },
+      },
+      $defs: {
+        'with/slash': { type: 'string' },
+        'with~tilde': { type: 'integer' },
+        'tilde-then-slash~1': { type: 'boolean' },
+      },
+    } as unknown as Record<string, unknown>);
+
+    const props = (out as { properties: Record<string, { type: string }> }).properties;
+    expect(props.a.type).toBe('string');
+    expect(props.b.type).toBe('integer');
+    expect(props.c.type).toBe('boolean');
+  });
+
+  it('resolves array-index pointers (#/$defs/foo/oneOf/0)', () => {
+    const out = dereferenceJsonSchema({
+      type: 'object',
+      properties: { v: { $ref: '#/$defs/foo/oneOf/0' } },
+      $defs: {
+        foo: { oneOf: [{ type: 'string' }, { type: 'number' }] },
+      },
+    } as unknown as Record<string, unknown>);
+
+    expect((out as { properties: { v: { type: string } } }).properties.v.type).toBe('string');
+  });
+});

--- a/ts/packages/providers/mastra/package.json
+++ b/ts/packages/providers/mastra/package.json
@@ -57,6 +57,6 @@
     "zod": "catalog:"
   },
   "dependencies": {
-    "@mastra/schema-compat": "^1.0.0"
+    "@mastra/schema-compat": "^1.2.9"
   }
 }

--- a/ts/packages/providers/mastra/src/index.ts
+++ b/ts/packages/providers/mastra/src/index.ts
@@ -11,6 +11,7 @@ import {
   Tool,
   ExecuteToolFn,
   McpUrlResponse,
+  dereferenceJsonSchema,
   removeNonRequiredProperties,
 } from '@composio/core';
 import { applyCompatLayer } from '@mastra/schema-compat';
@@ -90,14 +91,20 @@ export class MastraProvider extends BaseAgenticProvider<
           )
         : inputParams;
 
+    // Inline internal $ref pointers before handing the schema to
+    // @mastra/schema-compat. AJV (bundled inside schema-compat) refuses to
+    // compile a schema with unresolved $ref, and the upstream JSON-Schema →
+    // Zod converter silently degrades $ref-typed properties to a permissive
+    // anyOf — losing the type info from $defs. See [PLEN-2244] and
+    // mastra-ai/mastra#15341.
     const inputSchema = applyCompatLayer({
-      schema: parameters ?? {},
+      schema: dereferenceJsonSchema(parameters ?? {}),
       compatLayers: [],
       mode: 'jsonSchema',
     });
 
     const outputSchema = applyCompatLayer({
-      schema: tool.outputParameters ?? {},
+      schema: dereferenceJsonSchema(tool.outputParameters ?? {}),
       compatLayers: [],
       mode: 'jsonSchema',
     });

--- a/ts/packages/providers/mastra/test/mastra-ref.test.ts
+++ b/ts/packages/providers/mastra/test/mastra-ref.test.ts
@@ -1,20 +1,15 @@
 /**
- * Integration test for the Mastra provider against the **real**
- * `@mastra/schema-compat` package (no `vi.mock` for it). This is the regression
- * test for [PLEN-2244]: a Composio tool whose `inputParameters` carry a `$ref`
- * (legal under both Draft 7 and 2020-12).
+ * Regression test for the Mastra provider against the **real**
+ * `@mastra/schema-compat` (no `vi.mock` for it). Without dereferencing,
+ * `applyCompatLayer` silently degrades a `$ref`-typed property to a permissive
+ * `anyOf` of all primitives — losing the type info from `$defs`. We assert
+ * the post-wrap schemas preserve the structure described by `$defs`.
  *
- * Without dereferencing, `applyCompatLayer` silently *degrades* the `$ref`-typed
- * property to a permissive `anyOf` of all primitives — losing the type
- * information from `$defs`. This test asserts the post-wrap `inputSchema`
- * preserves the structure described by `$defs`, which is only possible if
- * `$ref` is resolved before the conversion.
- *
- * Vitest mock scoping is per-file by default, so the top-level `vi.mock` for
- * `@mastra/schema-compat` in `mastra.test.ts` does **not** leak into this file.
+ * Vitest mock scoping is per-file by default, so the top-level `vi.mock`
+ * for `@mastra/schema-compat` in `mastra.test.ts` does not leak here.
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Tool } from '@composio/core';
 import { MastraProvider } from '../src';
 
@@ -27,22 +22,17 @@ const containsRef = (value: unknown): boolean => {
 
 const findProperty = (schema: unknown, key: string): Record<string, unknown> | undefined => {
   if (schema === null || typeof schema !== 'object') return undefined;
-  const node = schema as Record<string, unknown>;
-  if (node.properties && typeof node.properties === 'object') {
-    const props = node.properties as Record<string, unknown>;
-    if (key in props) return props[key] as Record<string, unknown>;
-    for (const value of Object.values(props)) {
-      const found = findProperty(value, key);
-      if (found) return found;
-    }
-  }
-  for (const value of Object.values(node)) {
+  for (const value of Object.values(schema as Record<string, unknown>)) {
     if (Array.isArray(value)) {
       for (const item of value) {
         const found = findProperty(item, key);
         if (found) return found;
       }
     } else if (typeof value === 'object' && value !== null) {
+      const props = value as Record<string, unknown> as Record<string, unknown>;
+      if (key in props && typeof props[key] === 'object') {
+        return props[key] as Record<string, unknown>;
+      }
       const found = findProperty(value, key);
       if (found) return found;
     }
@@ -63,72 +53,41 @@ const refTool: Tool = {
     properties: { user: { $ref: '#/$defs/User' } as never },
     required: ['user'],
     $defs: {
-      User: {
-        type: 'object',
-        properties: { id: { type: 'string' } },
-        required: ['id'],
-      },
+      User: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
     },
   } as unknown as Tool['inputParameters'],
   outputParameters: {
     type: 'object',
     properties: { item: { $ref: '#/definitions/Item' } as never },
     definitions: {
-      Item: {
-        type: 'object',
-        properties: { sku: { type: 'string' } },
-        required: ['sku'],
-      },
+      Item: { type: 'object', properties: { sku: { type: 'string' } }, required: ['sku'] },
     },
   } as unknown as Tool['outputParameters'],
 };
 
-describe('MastraProvider regression: PLEN-2244 ($ref in JSON Schema)', () => {
-  it('does not throw when wrapping a tool whose schema uses $ref / $defs', () => {
-    const provider = new MastraProvider();
-    const executeToolFn = vi.fn().mockResolvedValue({ data: {}, error: null, successful: true });
-    provider._setExecuteToolFn(executeToolFn);
+describe('MastraProvider regression: $ref in JSON Schema', () => {
+  let wrapped: { inputSchema: unknown; outputSchema: unknown };
 
-    expect(() => provider.wrapTool(refTool, executeToolFn)).not.toThrow();
+  beforeEach(() => {
+    const provider = new MastraProvider();
+    const exec = vi.fn().mockResolvedValue({ data: {}, error: null, successful: true });
+    provider._setExecuteToolFn(exec);
+    wrapped = provider.wrapTool(refTool, exec) as typeof wrapped;
   });
 
-  it('preserves type information from $defs (does not degrade $ref to permissive anyOf)', () => {
-    const provider = new MastraProvider();
-    const executeToolFn = vi.fn().mockResolvedValue({ data: {}, error: null, successful: true });
-    provider._setExecuteToolFn(executeToolFn);
-
-    const wrapped = provider.wrapTool(refTool, executeToolFn) as { inputSchema: unknown };
-
-    // Without the dereference step, `$ref` is silently dropped during
-    // JSON-Schema → Zod → JSON-Schema round-trip and the `id` field disappears
-    // entirely (the property gets degraded to a permissive `anyOf`).
+  it('preserves type info from $defs (no degraded permissive anyOf)', () => {
     const idProp = findProperty(wrapped.inputSchema, 'id');
     expect(idProp).toBeDefined();
     expect(idProp?.type).toBe('string');
   });
 
-  it('preserves type information from `definitions` on outputParameters (Draft 7)', () => {
-    const provider = new MastraProvider();
-    const executeToolFn = vi.fn().mockResolvedValue({ data: {}, error: null, successful: true });
-    provider._setExecuteToolFn(executeToolFn);
-
-    const wrapped = provider.wrapTool(refTool, executeToolFn) as { outputSchema: unknown };
-
+  it('preserves type info from Draft-7 `definitions` on the output schema', () => {
     const skuProp = findProperty(wrapped.outputSchema, 'sku');
     expect(skuProp).toBeDefined();
     expect(skuProp?.type).toBe('string');
   });
 
-  it('does not leave any $ref in the produced schemas', () => {
-    const provider = new MastraProvider();
-    const executeToolFn = vi.fn().mockResolvedValue({ data: {}, error: null, successful: true });
-    provider._setExecuteToolFn(executeToolFn);
-
-    const wrapped = provider.wrapTool(refTool, executeToolFn) as {
-      inputSchema: unknown;
-      outputSchema: unknown;
-    };
-
+  it('leaves no $ref in the produced schemas', () => {
     expect(containsRef(wrapped.inputSchema)).toBe(false);
     expect(containsRef(wrapped.outputSchema)).toBe(false);
   });

--- a/ts/packages/providers/mastra/test/mastra-ref.test.ts
+++ b/ts/packages/providers/mastra/test/mastra-ref.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Integration test for the Mastra provider against the **real**
+ * `@mastra/schema-compat` package (no `vi.mock` for it). This is the regression
+ * test for [PLEN-2244]: a Composio tool whose `inputParameters` carry a `$ref`
+ * (legal under both Draft 7 and 2020-12).
+ *
+ * Without dereferencing, `applyCompatLayer` silently *degrades* the `$ref`-typed
+ * property to a permissive `anyOf` of all primitives — losing the type
+ * information from `$defs`. This test asserts the post-wrap `inputSchema`
+ * preserves the structure described by `$defs`, which is only possible if
+ * `$ref` is resolved before the conversion.
+ *
+ * Vitest mock scoping is per-file by default, so the top-level `vi.mock` for
+ * `@mastra/schema-compat` in `mastra.test.ts` does **not** leak into this file.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { Tool } from '@composio/core';
+import { MastraProvider } from '../src';
+
+const containsRef = (value: unknown): boolean => {
+  if (value === null || typeof value !== 'object') return false;
+  if (Array.isArray(value)) return value.some(containsRef);
+  if ('$ref' in (value as Record<string, unknown>)) return true;
+  return Object.values(value as Record<string, unknown>).some(containsRef);
+};
+
+const findProperty = (schema: unknown, key: string): Record<string, unknown> | undefined => {
+  if (schema === null || typeof schema !== 'object') return undefined;
+  const node = schema as Record<string, unknown>;
+  if (node.properties && typeof node.properties === 'object') {
+    const props = node.properties as Record<string, unknown>;
+    if (key in props) return props[key] as Record<string, unknown>;
+    for (const value of Object.values(props)) {
+      const found = findProperty(value, key);
+      if (found) return found;
+    }
+  }
+  for (const value of Object.values(node)) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        const found = findProperty(item, key);
+        if (found) return found;
+      }
+    } else if (typeof value === 'object' && value !== null) {
+      const found = findProperty(value, key);
+      if (found) return found;
+    }
+  }
+  return undefined;
+};
+
+const refTool: Tool = {
+  slug: 'PLEN_2244_TOOL',
+  name: 'PLEN-2244 Tool',
+  description: 'Tool whose schema carries internal $ref pointers',
+  toolkit: { slug: 'plen2244', name: 'PLEN 2244' },
+  version: '20260430_00',
+  availableVersions: ['20260430_00'],
+  tags: [],
+  inputParameters: {
+    type: 'object',
+    properties: { user: { $ref: '#/$defs/User' } as never },
+    required: ['user'],
+    $defs: {
+      User: {
+        type: 'object',
+        properties: { id: { type: 'string' } },
+        required: ['id'],
+      },
+    },
+  } as unknown as Tool['inputParameters'],
+  outputParameters: {
+    type: 'object',
+    properties: { item: { $ref: '#/definitions/Item' } as never },
+    definitions: {
+      Item: {
+        type: 'object',
+        properties: { sku: { type: 'string' } },
+        required: ['sku'],
+      },
+    },
+  } as unknown as Tool['outputParameters'],
+};
+
+describe('MastraProvider regression: PLEN-2244 ($ref in JSON Schema)', () => {
+  it('does not throw when wrapping a tool whose schema uses $ref / $defs', () => {
+    const provider = new MastraProvider();
+    const executeToolFn = vi.fn().mockResolvedValue({ data: {}, error: null, successful: true });
+    provider._setExecuteToolFn(executeToolFn);
+
+    expect(() => provider.wrapTool(refTool, executeToolFn)).not.toThrow();
+  });
+
+  it('preserves type information from $defs (does not degrade $ref to permissive anyOf)', () => {
+    const provider = new MastraProvider();
+    const executeToolFn = vi.fn().mockResolvedValue({ data: {}, error: null, successful: true });
+    provider._setExecuteToolFn(executeToolFn);
+
+    const wrapped = provider.wrapTool(refTool, executeToolFn) as { inputSchema: unknown };
+
+    // Without the dereference step, `$ref` is silently dropped during
+    // JSON-Schema → Zod → JSON-Schema round-trip and the `id` field disappears
+    // entirely (the property gets degraded to a permissive `anyOf`).
+    const idProp = findProperty(wrapped.inputSchema, 'id');
+    expect(idProp).toBeDefined();
+    expect(idProp?.type).toBe('string');
+  });
+
+  it('preserves type information from `definitions` on outputParameters (Draft 7)', () => {
+    const provider = new MastraProvider();
+    const executeToolFn = vi.fn().mockResolvedValue({ data: {}, error: null, successful: true });
+    provider._setExecuteToolFn(executeToolFn);
+
+    const wrapped = provider.wrapTool(refTool, executeToolFn) as { outputSchema: unknown };
+
+    const skuProp = findProperty(wrapped.outputSchema, 'sku');
+    expect(skuProp).toBeDefined();
+    expect(skuProp?.type).toBe('string');
+  });
+
+  it('does not leave any $ref in the produced schemas', () => {
+    const provider = new MastraProvider();
+    const executeToolFn = vi.fn().mockResolvedValue({ data: {}, error: null, successful: true });
+    provider._setExecuteToolFn(executeToolFn);
+
+    const wrapped = provider.wrapTool(refTool, executeToolFn) as {
+      inputSchema: unknown;
+      outputSchema: unknown;
+    };
+
+    expect(containsRef(wrapped.inputSchema)).toBe(false);
+    expect(containsRef(wrapped.outputSchema)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Composio tools whose JSON Schema uses internal `$ref` pointers (`#/$defs/...` or the legacy `#/definitions/...`) used to lose all type information when wrapped by `MastraProvider.wrapTool`. The schema would silently round-trip `raw → applyCompatLayer → convertSchemaToZod (drops $ref → permissive anyOf) → zodToJsonSchema (no recovery)`. Customers reported the user-visible surface as *"schema validation error: can't resolve reference"* — AJV (bundled inside `@mastra/schema-compat`) refusing to compile the schema downstream when validating tool input.

This PR pre-processes the schema with a new `dereferenceJsonSchema` utility from `@composio/core` *before* it reaches `@mastra/schema-compat`, preserving the type information from `$defs`/`definitions` and avoiding the AJV failure entirely.

Closes [PLEN-2244](https://linear.app/composio/issue/PLEN-2244/mastra-provider-schema-validation-error-cant-resolve-reference).

## What changed

- **`@composio/core`** — new `dereferenceJsonSchema(schema)` helper (and `JsonSchemaRefResolutionError`):
  - walks the schema reflectively (no JSON-Schema-keyword allow-list, so future applicators are covered automatically),
  - inlines internal `$ref` pointers transitively, with a 100-hop depth cap,
  - shallow-merges sibling keywords next to `$ref` per Draft 2020-12 semantics (siblings win on collision — preserves caller's `description` / `default` / `title`),
  - breaks recursive cycles with `{ type: 'object', additionalProperties: true }` (matches upstream guidance in [mastra-ai/mastra#15341](https://github.com/mastra-ai/mastra/issues/15341)),
  - strips `$defs` / `definitions` from the returned root once everything reachable is inlined,
  - leaves external (`http://`/`https://`) `$ref` pointers untouched so callers can still forward them,
  - throws `JsonSchemaRefResolutionError` on malformed pointers, missing targets, and over-cap chains.
- **`@composio/mastra`** — `wrapTool` now runs `dereferenceJsonSchema` over both `inputParameters` and `outputParameters` before calling `applyCompatLayer`.
- **`@mastra/schema-compat`** floor bumped to `^1.2.9` so consumers automatically pick up upstream [PR #15400](https://github.com/mastra-ai/mastra/pull/15400)'s recursive-`$ref` handling and [PR #14530](https://github.com/mastra-ai/mastra/pull/14530)'s Draft-2020-12 AJV switch.
- Changeset: `.changeset/fix-mastra-ref-dereference.md` (patch bump for `@composio/core` and `@composio/mastra`).

## Test plan

Red → green TDD across two commits — the `test:` commit reproduces PLEN-2244 against the real `@mastra/schema-compat` (no `vi.mock`), the `fix:` commit makes the regression tests pass.

- [x] `ts/packages/core/test/utils/jsonSchema.test.ts` — 14 unit tests for `dereferenceJsonSchema` covering: basic resolution, chained refs, container coverage (items / oneOf / anyOf / allOf / not / additionalProperties / patternProperties / prefixItems), legacy `definitions` (Draft 7), `$defs`/`definitions` mixed transitively, sibling-keyword merge per Draft 2020-12, cycle break, `$defs`/`definitions` strip, missing-target error, depth-cap error, external `$ref` preserved, no input mutation, JSON Pointer escape decoding (`~0`/`~1`), array-index pointers.
- [x] `ts/packages/providers/mastra/test/mastra-ref.test.ts` — un-mocked integration tests against real `@mastra/schema-compat`: wrapping does not throw, type info from `$defs` survives the round-trip (the `id` field stays `type: 'string'` instead of degrading to permissive `anyOf`), same for Draft-7 `definitions` on output schema, no remaining `$ref` in the produced schemas.
- [x] `pnpm --filter @composio/core test` — 852/852 green.
- [x] `pnpm --filter @composio/mastra test` — 43/43 green (39 legacy + 4 new).
- [x] `pnpm --filter @composio/core --filter @composio/mastra typecheck` — clean.
- [x] Existing `mastra.test.ts` (which mocks `@mastra/schema-compat`) is **untouched** and still green.
- [x] Secret-hygiene scan: `git diff next..HEAD | grep -E 'sk-[A-Za-z0-9_-]{20,}|OPENAI_API_KEY=[A-Za-z]'` returns empty.

## Why it's a Mastra-only fix

The Mastra path is unique in routing JSON Schema through `@mastra/schema-compat`, which embeds AJV. Sibling providers (`openai`, `anthropic`, `vercel`, `langchain`, `google`, `llamaindex`) forward Composio's JSON Schema through `@composio/json-schema-to-zod`, which silently no-ops on unknown nodes. They are not affected today; expanding pre-processing across providers is a separate PR if it ever becomes needed.

## Caveats

- The cycle-break sentinel weakens type information for genuinely recursive tool schemas. This is the same trade-off Mastra itself made in [#15341](https://github.com/mastra-ai/mastra/issues/15341); without it the agent crashes entirely.
- External `$ref` (`http://`/`https://`) is intentionally left untouched. If a real customer schema ever needs them resolved, that's an incremental follow-up that calls into `@apidevtools/json-schema-ref-parser` only when needed.
- The cycle-break currently uses a single sentinel for any cycle; if review prefers the higher-fidelity "keep first expansion, only break on the recursion edge" pattern (mentioned in the research as a refinement), that's a small follow-up.