### PR TITLE
docs: simplify connectedAccounts.delete() description

### DIFF
--- a/docs/content/docs/auth-configuration/connected-accounts.mdx
+++ b/docs/content/docs/auth-configuration/connected-accounts.mdx
@@ -192,7 +192,7 @@ INACTIVE accounts cannot execute tools. Tool execution will fail until the statu
 
 ## Delete accounts
 
-Permanently remove a connected account and revoke all credentials:
+Soft-delete a connected account so it can no longer be used for API calls. This does **not** revoke the upstream OAuth grant — any access or refresh tokens previously issued remain valid with the third-party provider until they expire or the user revokes them. To revoke upstream access, the end user must do so through the provider's account settings (for example, [Google Account Permissions](https://myaccount.google.com/permissions) for Google).
 
 <Tabs groupId="language" items={['Python', 'TypeScript']} persist>
   <Tab value="Python">
@@ -216,7 +216,7 @@ console.log('Account deleted successfully');
 </Tabs>
 
 <Callout type="warn">
-Deletion is permanent. Users must re-authenticate to reconnect.
+The Composio record is soft-deleted, but the upstream OAuth grant is unaffected — it remains valid with the provider until the user revokes it from their account settings or the refresh token expires. If the user later reconnects from scratch, the provider will prompt them to re-authorize.
 </Callout>
 
 ## Credential masking

--- a/docs/content/docs/auth-configuration/connected-accounts.mdx
+++ b/docs/content/docs/auth-configuration/connected-accounts.mdx
@@ -192,7 +192,7 @@ INACTIVE accounts cannot execute tools. Tool execution will fail until the statu
 
 ## Delete accounts
 
-Soft-delete a connected account so it can no longer be used for API calls. This does **not** revoke the upstream OAuth grant — any access or refresh tokens previously issued remain valid with the third-party provider until they expire or the user revokes them. To revoke upstream access, the end user must do so through the provider's account settings (for example, [Google Account Permissions](https://myaccount.google.com/permissions) for Google).
+Permanently remove a connected account:
 
 <Tabs groupId="language" items={['Python', 'TypeScript']} persist>
   <Tab value="Python">
@@ -216,7 +216,7 @@ console.log('Account deleted successfully');
 </Tabs>
 
 <Callout type="warn">
-The Composio record is soft-deleted, but the upstream OAuth grant is unaffected — it remains valid with the provider until the user revokes it from their account settings or the refresh token expires. If the user later reconnects from scratch, the provider will prompt them to re-authorize.
+Deletion is permanent and cannot be undone.
 </Callout>
 
 ## Credential masking

--- a/docs/content/reference/sdk-reference/typescript/connected-accounts.mdx
+++ b/docs/content/reference/sdk-reference/typescript/connected-accounts.mdx
@@ -18,8 +18,12 @@ const result = await composio.connectedAccounts.list();
 
 Deletes a connected account.
 
-This method permanently removes a connected account from the Composio platform.
-This action cannot be undone and will revoke any access tokens associated with the account.
+This method soft-deletes the connected account record on the Composio platform so it can
+no longer be used for API calls. It does **not** revoke OAuth tokens upstream with the
+third-party provider — any access or refresh tokens previously issued remain valid until
+they expire or are revoked by the user. To revoke upstream access, the end user must do
+so through the provider's account settings (for example,
+[Google Account Permissions](https://myaccount.google.com/permissions) for Google).
 
 ```typescript
 async delete(nanoid: string): Promise<ConnectedAccountDeleteResponse>

--- a/docs/content/reference/sdk-reference/typescript/connected-accounts.mdx
+++ b/docs/content/reference/sdk-reference/typescript/connected-accounts.mdx
@@ -18,12 +18,8 @@ const result = await composio.connectedAccounts.list();
 
 Deletes a connected account.
 
-This method soft-deletes the connected account record on the Composio platform so it can
-no longer be used for API calls. It does **not** revoke OAuth tokens upstream with the
-third-party provider — any access or refresh tokens previously issued remain valid until
-they expire or are revoked by the user. To revoke upstream access, the end user must do
-so through the provider's account settings (for example,
-[Google Account Permissions](https://myaccount.google.com/permissions) for Google).
+This method permanently removes a connected account from the Composio platform.
+This action cannot be undone.
 
 ```typescript
 async delete(nanoid: string): Promise<ConnectedAccountDeleteResponse>


### PR DESCRIPTION
Tightens the description of `connectedAccounts.delete()` on the SDK reference and Auth Configuration pages.