### PR TITLE
docs(toolkits/slack): add OAuth install/approval FAQs

### DIFF
--- a/docs/content/toolkits/faq/slack.md
+++ b/docs/content/toolkits/faq/slack.md
@@ -10,28 +10,28 @@ Composio executes API calls on behalf of your connected account. All data is enc
 
 For a step-by-step guide on creating and configuring your own Slack OAuth credentials with Composio, see [How to create OAuth credentials for Slack](https://composio.dev/auth/slack).
 
-## Why do users see "This app isn't listed in the Slack Marketplace…" during install?
+## When do users see "This app isn't listed in the Slack Marketplace…"?
 
-This appears when a workspace **member** tries to install a non-Marketplace app and the workspace has **"Require apps from Slack Marketplace"** enabled. To resolve, either have a workspace **owner** install/authorize the app, disable **"Require apps from Slack Marketplace"** in the workspace's app management settings, or — recommended — use your own OAuth app credentials. See [How to create OAuth credentials for Slack](https://composio.dev/auth/slack).
+When a member of a Slack workspace tries to install a non-Marketplace app.
+
+**How to resolve:** Disable **Require apps from Slack Marketplace** in the workspace's app management settings:
+
+`Settings → Apps & Workflows → App Management Settings`
 
 ## Do I have to be a Workspace Owner to install the app?
 
-Only if the workspace blocks non-Marketplace apps. If **"Require apps from Slack Marketplace"** is enabled, then yes — a workspace owner must install our app. Otherwise, a member may proceed with the install themselves.
+In some cases — yes. For example, when installing non-Marketplace apps, you'll need to be an owner to install directly and complete the connection. As a member, you'd need to either request approval, or ask the owner to disable **Require approved apps**.
 
 ## Why am I being asked to submit a request during auth?
 
-The workspace has **"Require approved apps"** enabled, so Slack is asking an admin or owner to approve the install before it can be completed. An admin must approve the request, or the setting must be disabled, before the connection can finish.
+Because **Require approved apps** is enabled. Slack is asking for admin/owner approval before completing the install.
 
 ## How can a workspace member complete the connection without asking for permissions or approvals?
 
-There are two ways:
+Two ways:
 
-- Disable both **"Require apps from Slack Marketplace"** and **"Require approved apps"** in the workspace's app management settings.
-- Use the workspace's own OAuth app credentials (recommended — see below).
-
-## What's the recommended solution for Slack install/approval friction?
-
-Use your own OAuth app credentials. It's the safest option and avoids repeated owner/admin involvement on every install. See [How to create OAuth credentials for Slack](https://composio.dev/auth/slack).
+- Disable both **Require apps from Slack Marketplace** and **Require approved apps** in the workspace's app management settings.
+- Use the workspace's own OAuth app — recommended and safest. See [How to create OAuth credentials for Slack](https://composio.dev/auth/slack).
 
 ## What is the difference between Slack and Slackbot toolkits?
 

--- a/docs/content/toolkits/faq/slack.md
+++ b/docs/content/toolkits/faq/slack.md
@@ -10,6 +10,29 @@ Composio executes API calls on behalf of your connected account. All data is enc
 
 For a step-by-step guide on creating and configuring your own Slack OAuth credentials with Composio, see [How to create OAuth credentials for Slack](https://composio.dev/auth/slack).
 
+## Why do users see "This app isn't listed in the Slack Marketplace…" during install?
+
+This appears when a workspace **member** tries to install a non-Marketplace app and the workspace has **"Require apps from Slack Marketplace"** enabled. To resolve, either have a workspace **owner** install/authorize the app, disable **"Require apps from Slack Marketplace"** in the workspace's app management settings, or — recommended — use your own OAuth app credentials. See [How to create OAuth credentials for Slack](https://composio.dev/auth/slack).
+
+## Do I have to be a Workspace Owner to install the app?
+
+Only if the workspace blocks non-Marketplace apps. If **"Require apps from Slack Marketplace"** is enabled, then yes — a workspace owner must install our app. Otherwise, a member may proceed with the install themselves.
+
+## Why am I being asked to submit a request during auth?
+
+The workspace has **"Require approved apps"** enabled, so Slack is asking an admin or owner to approve the install before it can be completed. An admin must approve the request, or the setting must be disabled, before the connection can finish.
+
+## How can a workspace member complete the connection without asking for permissions or approvals?
+
+There are two ways:
+
+- Disable both **"Require apps from Slack Marketplace"** and **"Require approved apps"** in the workspace's app management settings.
+- Use the workspace's own OAuth app credentials (recommended — see below).
+
+## What's the recommended solution for Slack install/approval friction?
+
+Use your own OAuth app credentials. It's the safest option and avoids repeated owner/admin involvement on every install. See [How to create OAuth credentials for Slack](https://composio.dev/auth/slack).
+
 ## What is the difference between Slack and Slackbot toolkits?
 
 Slack is for workspace-level API access (channels, files, users) while Slackbot is bot-centric (messaging, interactivity). Slack triggers cover workspace events; Slackbot covers bot entry points like app mentions, DMs, and slash commands. Slack can post as the app; Slackbot posts as the bot user.

--- a/docs/content/toolkits/faq/slack.md
+++ b/docs/content/toolkits/faq/slack.md
@@ -24,7 +24,7 @@ In some cases — yes. For example, when installing non-Marketplace apps, you'll
 
 ## Why am I being asked to submit a request during auth?
 
-Because **Require approved apps** is enabled. Slack is asking for admin/owner approval before completing the install.
+Because **Require approved apps** is enabled in the workspace's **App Management Settings**. Slack is asking for admin/owner approval before completing the install.
 
 ## How can a workspace member complete the connection without asking for permissions or approvals?
 


### PR DESCRIPTION
# Description

Adds five FAQs to the Slack toolkit FAQ snippet (`docs/content/toolkits/faq/slack.md`) covering the most common Slack OAuth install/approval friction points:

1. Why users see "This app isn't listed in the Slack Marketplace…" during install
2. Whether workspace owner is required to install the app
3. Why Slack asks the user to submit a request during auth
4. How a workspace member can complete the connection without permissions/approvals
5. The recommended solution (custom OAuth app)

These FAQs are placed right after the existing "How do I set up custom OAuth credentials for Slack?" entry, since they're all about the OAuth install flow and the resolution path consistently points back to using a custom OAuth app.

Format follows the existing snippet style: plain markdown, `## Question?` headers, paragraph or short bullet-list answers, `**bold**` for UI/setting names, relative/external links matching what's already in the file. No frontmatter (matches the rest of `content/toolkits/faq/`).

# How did I test this PR

- Read existing FAQ snippets (`slack.md`, `gmail.md`, `notion.md`) to match style — short headers, `**bold**` for Slack setting names, no Fumadocs components, ends with `---`
- Verified the file structure is unchanged: 5 new `## Question?` sections inserted between the existing custom-OAuth question (line 9) and the Slack-vs-Slackbot question; closing `---` separator still present at EOF
- All links in the new content point to `https://composio.dev/auth/slack`, which already exists in the same file — no new link surface introduced
- Confirmed `bun run scripts/validate-links.ts` failure is pre-existing on `origin/next` (sandbox dependency mismatch on `fumadocs-core/content/md/frontmatter`), not caused by this change
- No code blocks added, so Twoslash type-check is not affected

Triggered by: uday@composio.dev | Source: slack
Session: https://zen-api-production-4c98.up.railway.app/dashboard/#/chat/zen-7f4c8629aad8