### PR TITLE
fix(python): handle title-less top-level schemas

### DIFF
--- a/python/composio/utils/shared.py
+++ b/python/composio/utils/shared.py
@@ -272,7 +272,7 @@ def json_schema_to_model(
     :param skip_default: Skip the default values when building field object
     :return: Pydantic `BaseModel` type
     """
-    model_name = json_schema.get("title")
+    model_name = json_schema.get("title") or "GeneratedModel"
     field_definitions = {}
     for name, prop in json_schema.get("properties", {}).items():
         updated_name, pydantic_type, pydantic_field = json_schema_to_pydantic_field(

--- a/python/composio/utils/shared.py
+++ b/python/composio/utils/shared.py
@@ -446,6 +446,8 @@ def json_schema_to_model(
     :return: Pydantic `BaseModel` type
     """
     model_name = json_schema.get("title")
+    if model_name is None:
+        model_name = "GeneratedModel"
     field_definitions = {}
     for name, prop in json_schema.get("properties", {}).items():
         updated_name, pydantic_type, pydantic_field = json_schema_to_pydantic_field(

--- a/python/tests/test_schema_parser.py
+++ b/python/tests/test_schema_parser.py
@@ -303,6 +303,40 @@ class TestJsonSchemaToModel:
         instance = model_class(tags=["tag1", "tag2"])
         assert instance.tags == ["tag1", "tag2"]
 
+    def test_no_title_fallback(self):
+        """Issue #2435: anonymous schemas (no 'title') must not crash with TypeError.
+
+        LangGraph/LangChain/CrewAI providers call json_schema_to_model for
+        array-item schemas that have no 'title' key.  Without a fallback,
+        create_model(None, ...) raises TypeError: type.__new__() argument 1
+        must be str, not None.
+        """
+        json_schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "value": {"type": "integer"},
+            },
+            "required": ["name"],
+        }
+
+        model_class = json_schema_to_model(json_schema)
+        instance = model_class(name="test", value=42)
+        assert instance.name == "test"
+        assert instance.value == 42
+
+    def test_no_title_required_field_still_required(self):
+        """Issue #2435: required fields in title-less schemas must stay required."""
+        json_schema = {
+            "type": "object",
+            "properties": {"required_field": {"type": "string"}},
+            "required": ["required_field"],
+        }
+
+        model_class = json_schema_to_model(json_schema)
+        with pytest.raises(Exception):
+            model_class()  # Should fail — required_field missing
+
 
 class TestPydanticModelFromParamSchema:
     """Test cases for pydantic_model_from_param_schema function."""

--- a/python/tests/test_schema_parser.py
+++ b/python/tests/test_schema_parser.py
@@ -8,7 +8,7 @@ particularly focusing on the required field propagation bug that was fixed.
 import typing as t
 
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from pydantic.fields import PydanticUndefined
 
 from composio.utils.shared import (
@@ -322,6 +322,35 @@ class TestJsonSchemaToModel:
         model_class = json_schema_to_model(json_schema)
         instance = model_class(tags=["tag1", "tag2"])
         assert instance.tags == ["tag1", "tag2"]
+
+    @pytest.mark.parametrize(
+        ("title", "expected_model_name"),
+        [
+            ({}, "GeneratedModel"),
+            ({"title": None}, "GeneratedModel"),
+            ({"title": ""}, ""),
+        ],
+    )
+    def test_title_uses_expected_model_name(self, title, expected_model_name):
+        """Missing or null titles must not reach Pydantic's model factory."""
+        json_schema = {
+            **title,
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "value": {"type": "integer"},
+            },
+            "required": ["name"],
+        }
+
+        model_class = json_schema_to_model(json_schema)
+        assert model_class.__name__ == expected_model_name
+        instance = model_class(name="test", value=42)
+        assert instance.name == "test"
+        assert instance.value == 42
+
+        with pytest.raises(ValidationError):
+            model_class()
 
 
 class TestPydanticModelFromParamSchema:


### PR DESCRIPTION
## Summary

Fixes `json_schema_to_model` when a top-level JSON schema omits `title` or sets it to `null`. This is the remaining direct-helper path; anonymous nested objects from #2435 are already handled by `schema_converter.py`.

- falls back to `GeneratedModel` only when the title is `None`, preserving intentionally empty string titles
- adds regression coverage for missing, `null`, and empty titles, model construction, and required-field validation

## Validation

- `ruff format --check python/composio/utils/shared.py python/tests/test_schema_parser.py`
- `ruff check python/composio/utils/shared.py python/tests/test_schema_parser.py`
- `PYTHONPATH="$PWD/python" /Users/jkomyno/work/composio/composio2/.venv/bin/pytest -q python/tests/test_schema_parser.py`

This is a follow-up to #2435; it intentionally does not close that already-resolved issue.