### PR TITLE
fix(anthropic+python): deduplicate required array for JSON Schema 2020-12 and fix title-less model crash

### DIFF
--- a/python/composio/utils/shared.py
+++ b/python/composio/utils/shared.py
@@ -272,7 +272,7 @@ def json_schema_to_model(
     :param skip_default: Skip the default values when building field object
     :return: Pydantic `BaseModel` type
     """
-    model_name = json_schema.get("title") or "GeneratedModel"
+    model_name = json_schema["title"] if "title" in json_schema else "GeneratedModel"
     field_definitions = {}
     for name, prop in json_schema.get("properties", {}).items():
         updated_name, pydantic_type, pydantic_field = json_schema_to_pydantic_field(

--- a/python/composio/utils/shared.py
+++ b/python/composio/utils/shared.py
@@ -272,7 +272,7 @@ def json_schema_to_model(
     :param skip_default: Skip the default values when building field object
     :return: Pydantic `BaseModel` type
     """
-    model_name = json_schema.get("title")
+    model_name = json_schema.get("title") or "GeneratedModel"
     field_definitions = {}
     for name, prop in json_schema.get("properties", {}).items():
         updated_name, pydantic_type, pydantic_field = json_schema_to_pydantic_field(

--- a/python/tests/test_schema_parser.py
+++ b/python/tests/test_schema_parser.py
@@ -321,6 +321,7 @@ class TestJsonSchemaToModel:
         }
 
         model_class = json_schema_to_model(json_schema)
+        assert model_class.__name__ == "GeneratedModel"
         instance = model_class(name="test", value=42)
         assert instance.name == "test"
         assert instance.value == 42

--- a/python/tests/test_schema_parser.py
+++ b/python/tests/test_schema_parser.py
@@ -303,6 +303,40 @@ class TestJsonSchemaToModel:
         instance = model_class(tags=["tag1", "tag2"])
         assert instance.tags == ["tag1", "tag2"]
 
+    def test_no_title_fallback(self):
+        """Issue #2435: anonymous schemas (no 'title') must not crash with TypeError.
+
+        LangGraph/LangChain/CrewAI providers call json_schema_to_model for
+        array-item schemas that have no 'title' key.  Without a fallback,
+        create_model(None, ...) raises TypeError: type.__new__() argument 1
+        must be str, not None.
+        """
+        json_schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "value": {"type": "integer"},
+            },
+            "required": ["name"],
+        }
+
+        model_class = json_schema_to_model(json_schema)
+        instance = model_class(name="test", value=42)
+        assert instance.name == "test"
+        assert instance.value == 42
+
+    def test_no_title_required_field_still_required(self):
+        """Issue #2435: required fields in title-less schemas must stay required."""
+        json_schema = {
+            "type": "object",
+            "properties": {"required_field": {"type": "string"}},
+            "required": ["required_field"],
+        }
+
+        model_class = json_schema_to_model(json_schema)
+        with pytest.raises(Exception):
+            model_class()  # Should fail — required_field missing
+
 
 class TestPydanticModelFromParamSchema:
     """Test cases for pydantic_model_from_param_schema function."""

--- a/ts/packages/providers/anthropic/src/index.ts
+++ b/ts/packages/providers/anthropic/src/index.ts
@@ -57,7 +57,7 @@ export class AnthropicProvider extends BaseNonAgenticProvider<
   AnthropicMcpServerGetResponse
 > {
   readonly name = 'anthropic';
-  private chacheTools: boolean = false;
+  private cacheTools: boolean = false;
 
   /**
    * Creates a new instance of the AnthropicProvider.
@@ -86,8 +86,8 @@ export class AnthropicProvider extends BaseNonAgenticProvider<
    */
   constructor(options?: { cacheTools?: boolean }) {
     super();
-    this.chacheTools = options?.cacheTools ?? false;
-    logger.debug(`AnthropicProvider initialized [cacheTools: ${this.chacheTools}]`);
+    this.cacheTools = options?.cacheTools ?? false;
+    logger.debug(`AnthropicProvider initialized [cacheTools: ${this.cacheTools}]`);
   }
 
   /**
@@ -135,7 +135,7 @@ export class AnthropicProvider extends BaseNonAgenticProvider<
       name: tool.slug,
       description: tool.description || '',
       input_schema: inputSchema,
-      cache_control: this.chacheTools ? { type: 'ephemeral' } : undefined,
+      cache_control: this.cacheTools ? { type: 'ephemeral' } : undefined,
     };
   }
 
@@ -307,7 +307,7 @@ export class AnthropicProvider extends BaseNonAgenticProvider<
         type: 'tool_result',
         tool_use_id: toolUse.id,
         content: toolResult,
-        cache_control: this.chacheTools ? { type: 'ephemeral' } : undefined,
+        cache_control: this.cacheTools ? { type: 'ephemeral' } : undefined,
       });
     }
 

--- a/ts/packages/providers/anthropic/src/index.ts
+++ b/ts/packages/providers/anthropic/src/index.ts
@@ -118,14 +118,23 @@ export class AnthropicProvider extends BaseNonAgenticProvider<
    * ```
    */
   override wrapTool(tool: ComposioTool): AnthropicTool {
+    const rawSchema = tool.inputParameters || {
+      type: 'object',
+      properties: {},
+      required: [],
+    };
+
+    const inputSchema: InputSchema = Array.isArray(rawSchema.required)
+      ? {
+          ...(rawSchema as InputSchema),
+          required: [...new Set(rawSchema.required as string[])],
+        }
+      : (rawSchema as InputSchema);
+
     return {
       name: tool.slug,
       description: tool.description || '',
-      input_schema: (tool.inputParameters || {
-        type: 'object',
-        properties: {},
-        required: [],
-      }) as InputSchema,
+      input_schema: inputSchema,
       cache_control: this.chacheTools ? { type: 'ephemeral' } : undefined,
     };
   }

--- a/ts/packages/providers/anthropic/test/anthropic.test.ts
+++ b/ts/packages/providers/anthropic/test/anthropic.test.ts
@@ -105,6 +105,33 @@ describe('AnthropicProvider', () => {
         },
       });
     });
+
+    it('should deduplicate required array to comply with JSON Schema 2020-12 (#2933)', () => {
+      // Anthropic rejects schemas where required has duplicate entries
+      const toolWithDuplicateRequired: Tool = {
+        ...mockTool,
+        inputParameters: {
+          type: 'object',
+          properties: {
+            owner: { type: 'string' },
+            name: { type: 'string' },
+          },
+          required: ['owner', 'name', 'owner'] as string[], // duplicate 'owner'
+        },
+      };
+
+      const wrapped = provider.wrapTool(toolWithDuplicateRequired) as AnthropicTool;
+
+      expect((wrapped.input_schema as { required: string[] }).required).toEqual(['owner', 'name']);
+    });
+
+    it('should leave required array unchanged when no duplicates', () => {
+      const wrapped = provider.wrapTool(mockTool) as AnthropicTool;
+
+      expect((wrapped.input_schema as { required: string[] }).required).toEqual(
+        mockTool.inputParameters!.required,
+      );
+    });
   });
 
   describe('wrapTools', () => {


### PR DESCRIPTION
## Summary

This PR contains two related schema correctness fixes:

### Fix 1: Anthropic provider — duplicate `required` entries rejected (#2933)

The Anthropic API enforces JSON Schema 2020-12 uniqueness constraints on `required` arrays. When Composio tool schemas contain duplicate entries (e.g. `required: ['owner', 'name', 'owner']`), the Anthropic SDK rejects the **entire tool batch** — not just the offending tool.

**Root cause:** `AnthropicProvider.wrapTool()` passed `inputParameters` directly without deduplicating `required`.

**Fix:** Deduplicate via `[...new Set(required)]` before constructing the tool schema.

Also fixes a pre-existing typo: `chacheTools` → `cacheTools` (private field name, no public API change).

### Fix 2: Python — `json_schema_to_model` crashes on title-less schemas (#2435)

Providers like LangGraph/LangChain/CrewAI pass nested object schemas without a `title` field. This caused `pydantic.create_model(None, ...)` to raise a `TypeError`, making the entire tool call fail.

**Root cause:** `json_schema_to_model` did `model_name = json_schema.get("title")` with no fallback.

**Fix:** Use `json_schema["title"] if "title" in json_schema else "GeneratedModel"` — consistent with `schema_converter.py`'s `if "title" not in schema` pattern.

> **Note:** The Python fix is also in PR #3325, which covers only the Python change. This PR includes it because the branch was built on top of it. If you prefer a clean separation, #3325 can be merged first and this branch rebased to exclude the Python commits.

## Test plan

- [ ] Anthropic: `wrapTool` with duplicate `required` entries returns deduplicated array
- [ ] Anthropic: `wrapTool` with no duplicates returns array unchanged
- [ ] Python: title-less schema produces a valid Pydantic model with name `"GeneratedModel"`
- [ ] Python: required fields in title-less schemas remain required
- [ ] All TypeScript tests pass (`pnpm test --filter @composio/anthropic`)
- [ ] Python tests pass (`pytest python/tests/test_schema_parser.py -v`)

Closes #2933
Closes #2435