### PR TITLE
docs: note webhook endpoints must be publicly accessible

### DIFF
--- a/docs/content/docs/setting-up-triggers/subscribing-to-events.mdx
+++ b/docs/content/docs/setting-up-triggers/subscribing-to-events.mdx
@@ -26,6 +26,10 @@ curl -X POST https://backend.composio.dev/api/v3.1/webhook_subscriptions \
   }'
 ```
 
+<Callout>
+Your webhook endpoint must be publicly accessible — Composio's outbound IPs are dynamic, so IP allowlisting and private/VPN-only endpoints will not work. Use [signature verification](/docs/webhook-verification) to authenticate payloads instead.
+</Callout>
+
 <Callout type="warn">
 The response includes a `secret` for [verifying webhook signatures](/docs/webhook-verification). This is only returned at creation time or when you [rotate the secret](/reference/api-reference/webhooks/postWebhookSubscriptionsByIdRotateSecret). Store it securely.
 </Callout>


### PR DESCRIPTION
# Description

Adds a one-line callout to the trigger-subscription docs page clarifying that user webhook endpoints must be publicly reachable. Composio's outbound webhook delivery runs on Cloudflare Workers, which use dynamic egress IPs — so IP allowlisting and private/VPN-only endpoints will silently drop webhook payloads (both `composio.trigger.message` and `composio.connected_account.expired`).

The callout points readers to signature verification as the intended authentication mechanism instead.

Placed on `subscribing-to-events.mdx` directly after the `POST /webhook_subscriptions` example, where users are actually setting their webhook URL.

# How did I test this PR

- Verified the claim by tracing webhook egress in `hermes`: cloud delivery flows through `defaultDeliveryService` → `sendComposioProxyRequest` → Cloudflare Workers external-proxy (`/workspace/hermes/wrangler/external-proxy/`); self-hosted goes through `directHttpDeliveryService`. Both `TRIGGER_MESSAGE_EVENT_TYPE` and `CONNECTION_EXPIRED_EVENT_TYPE` share this path (`apps/apollo/src/lib/events/handlers/webhook/handler.ts:86-90, 241-255`). No static-IP infrastructure exists for the Workers egress.
- Confirmed the linked `/docs/webhook-verification` route already exists in the same file (line 30), so no new links were introduced.
- Content-only MDX change (no TypeScript code blocks added), so twoslash type-checking is unaffected.