### PR TITLE
feat(tool-router): add direct tools SDK preset

### DIFF
--- a/.changeset/direct-tools-sdk-preset.md
+++ b/.changeset/direct-tools-sdk-preset.md
@@ -1,0 +1,5 @@
+---
+'@composio/core': patch
+---
+
+Add a Tool Router direct tools SDK preset that expands to preload all allowed tools and disables helper tool groups unless explicitly enabled.

--- a/python/composio/__init__.py
+++ b/python/composio/__init__.py
@@ -4,6 +4,7 @@ from .core.models.custom_tool_types import (
     CustomTool,
     SessionContext,
 )
+from .core.models.tool_router import SessionPreset
 from .core.models.tool_router_session_files import RemoteFile
 from .core.models.tools import (
     after_execute,
@@ -34,6 +35,7 @@ __all__ = (
     "CustomTool",
     "ExperimentalToolkit",
     "RemoteFile",
+    "SessionPreset",
     "SessionContext",
     "ConnectionExpiredEvent",
     "ConnectionState",

--- a/python/composio/core/models/__init__.py
+++ b/python/composio/core/models/__init__.py
@@ -8,7 +8,7 @@ from .custom_tool_types import (
     SessionContext,
 )
 from .mcp import MCP
-from .tool_router import ToolRouter
+from .tool_router import SessionPreset, ToolRouter
 from .tool_router_session import ToolRouterSession
 from .tool_router_session_files import RemoteFile, ToolRouterSessionFilesMount
 from .toolkits import Toolkits
@@ -38,6 +38,7 @@ __all__ = [
     "RegisteredCustomTool",
     "RegisteredCustomToolkit",
     "RemoteFile",
+    "SessionPreset",
     "SessionContext",
     "SingleConnectedAccountDetailedResponse",
     "ToolRouter",

--- a/python/composio/core/models/tool_router.py
+++ b/python/composio/core/models/tool_router.py
@@ -300,6 +300,43 @@ def _apply_direct_tools_workbench_preset(
     )
 
 
+class _SessionPresetApplication(te.TypedDict, total=False):
+    session_preset: t.Optional[SessionPreset]
+    manage_connections: t.Optional[t.Union[bool, ToolRouterManageConnectionsConfig]]
+    workbench: t.Optional[ToolRouterWorkbenchConfig]
+    preload: t.Optional[ToolRouterPreloadConfig]
+    search: t.Optional[t.Dict[str, bool]]
+    execution: t.Optional[t.Dict[str, bool]]
+
+
+def _apply_session_preset(
+    *,
+    session_preset: t.Optional[SessionPreset],
+    manage_connections: t.Optional[t.Union[bool, ToolRouterManageConnectionsConfig]],
+    workbench: t.Optional[ToolRouterWorkbenchConfig],
+    preload: t.Optional[ToolRouterPreloadConfig],
+) -> _SessionPresetApplication:
+    normalized_session_preset = _normalize_session_preset(session_preset)
+    if normalized_session_preset is not SessionPreset.DIRECT_TOOLS:
+        return {
+            "session_preset": normalized_session_preset,
+            "manage_connections": manage_connections,
+            "workbench": workbench,
+            "preload": preload,
+        }
+
+    return {
+        "session_preset": normalized_session_preset,
+        "manage_connections": _apply_direct_tools_manage_connections_preset(
+            manage_connections
+        ),
+        "workbench": _apply_direct_tools_workbench_preset(workbench),
+        "preload": preload or {"tools": ["all"]},
+        "search": {"enable": False},
+        "execution": {"enable_multi_execute": False},
+    }
+
+
 def _is_preload_all(preload: t.Optional[ToolRouterPreloadConfig]) -> bool:
     if preload is None:
         return False
@@ -747,14 +784,16 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
             toolkit_states = session.toolkits()
             ```
         """
-        normalized_session_preset = _normalize_session_preset(session_preset)
-
-        if normalized_session_preset is SessionPreset.DIRECT_TOOLS:
-            manage_connections = _apply_direct_tools_manage_connections_preset(
-                manage_connections
-            )
-            workbench = _apply_direct_tools_workbench_preset(workbench)
-            preload = preload or {"tools": ["all"]}
+        preset_application = _apply_session_preset(
+            session_preset=session_preset,
+            manage_connections=manage_connections,
+            workbench=workbench,
+            preload=preload,
+        )
+        normalized_session_preset = preset_application["session_preset"]
+        manage_connections = preset_application["manage_connections"]
+        workbench = preset_application["workbench"]
+        preload = preset_application["preload"]
 
         # Parse manage_connections config
         manage_connections = (
@@ -881,9 +920,10 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
         if preload is not None:
             create_params["preload"] = _normalize_preload_config(preload)
 
-        if normalized_session_preset is SessionPreset.DIRECT_TOOLS:
-            create_params["search"] = {"enable": False}
-            create_params["execution"] = {"enable_multi_execute": False}
+        if preset_application.get("search") is not None:
+            create_params["search"] = preset_application["search"]
+        if preset_application.get("execution") is not None:
+            create_params["execution"] = preset_application["execution"]
 
         # Build experimental config
         # Map SDK's experimental.assistive_prompt.user_timezone to API's
@@ -978,6 +1018,7 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
             preload=ToolRouterSessionPreloadConfig(
                 tools=list(session.config.preload.tools)
             ),
+            config=session.config,
         )
 
     def use(self, session_id: str) -> ToolRouterSession[TTool, TToolCollection]:
@@ -1035,6 +1076,7 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
             preload=ToolRouterSessionPreloadConfig(
                 tools=list(session.config.preload.tools)
             ),
+            config=session.config,
         )
 
 

--- a/python/composio/core/models/tool_router.py
+++ b/python/composio/core/models/tool_router.py
@@ -306,7 +306,7 @@ class _SessionPresetApplication(te.TypedDict, total=False):
     workbench: t.Optional[ToolRouterWorkbenchConfig]
     preload: t.Optional[ToolRouterPreloadConfig]
     search: t.Optional[t.Dict[str, bool]]
-    execution: t.Optional[t.Dict[str, bool]]
+    execute: t.Optional[t.Dict[str, bool]]
 
 
 def _apply_session_preset(
@@ -333,7 +333,7 @@ def _apply_session_preset(
         "workbench": _apply_direct_tools_workbench_preset(workbench),
         "preload": preload or {"tools": ["all"]},
         "search": {"enable": False},
-        "execution": {"enable_multi_execute": False},
+        "execute": {"enable_multi_execute": False},
     }
 
 
@@ -897,22 +897,22 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
             create_params["tags"] = tags_payload
 
         if workbench is not None:
-            execution_payload: t.Dict[str, t.Any] = {
+            workbench_payload: t.Dict[str, t.Any] = {
                 "enable": workbench.get("enable", True),
             }
             if "enable_proxy_execution" in workbench:
-                execution_payload["enable_proxy_execution"] = workbench[
+                workbench_payload["enable_proxy_execution"] = workbench[
                     "enable_proxy_execution"
                 ]
             if "auto_offload_threshold" in workbench:
-                execution_payload["auto_offload_threshold"] = int(
+                workbench_payload["auto_offload_threshold"] = int(
                     workbench["auto_offload_threshold"]
                 )
             if "sandbox_size" in workbench:
-                execution_payload["sandbox_size"] = workbench["sandbox_size"]
+                workbench_payload["sandbox_size"] = workbench["sandbox_size"]
 
-            if execution_payload:
-                create_params["workbench"] = execution_payload
+            if workbench_payload:
+                create_params["workbench"] = workbench_payload
 
         if multi_account is not None:
             create_params["multi_account"] = multi_account
@@ -922,8 +922,8 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
 
         if preset_application.get("search") is not None:
             create_params["search"] = preset_application["search"]
-        if preset_application.get("execution") is not None:
-            create_params["execution"] = preset_application["execution"]
+        if preset_application.get("execute") is not None:
+            create_params["execute"] = preset_application["execute"]
 
         # Build experimental config
         # Map SDK's experimental.assistive_prompt.user_timezone to API's

--- a/python/composio/core/models/tool_router.py
+++ b/python/composio/core/models/tool_router.py
@@ -14,6 +14,9 @@ from enum import Enum
 import typing_extensions as te
 from composio_client import omit
 from composio_client.types.tool_router import session_create_params
+from composio_client.types.tool_router.session_create_response import (
+    SessionCreateResponse,
+)
 
 from composio.client import HttpClient
 from composio.core.models.base import Resource
@@ -51,6 +54,12 @@ ToolRouterTag = t.Literal[
 # +----------+------+------+
 # Defaults to "standard" server-side when omitted.
 SandboxSize = t.Literal["standard", "medium", "large", "xlarge"]
+
+
+class SessionPreset(str, Enum):
+    """Opinionated SDK presets for tool router session creation."""
+
+    DIRECT_TOOLS = "direct_tools"
 
 
 class ToolRouterToolkitsEnableConfig(te.TypedDict, total=False):
@@ -214,10 +223,11 @@ class ToolRouterPreloadConfig(te.TypedDict, total=False):
 
     Attributes:
         tools: Tool slugs to expose directly in ``session.tools()`` and MCP
-               tool lists without first calling search.
+               tool lists without first calling search. Use ``"all"`` to expose
+               all tools allowed by the session filters.
     """
 
-    tools: t.List[str]
+    tools: t.Union[t.List[str], t.Literal["all", "ALL"]]
 
 
 class ToolRouterAssistivePromptConfig(te.TypedDict, total=False):
@@ -245,6 +255,69 @@ class ToolRouterExperimentalConfig(te.TypedDict, total=False):
     assistive_prompt: ToolRouterAssistivePromptConfig
     custom_tools: t.List[CustomTool]
     custom_toolkits: t.List[ExperimentalToolkit]
+
+
+def _normalize_session_preset(
+    session_preset: t.Optional[SessionPreset],
+) -> t.Optional[SessionPreset]:
+    if session_preset is None:
+        return None
+    if not isinstance(session_preset, SessionPreset):
+        raise ValueError("session_preset must be a SessionPreset enum value.")
+    return session_preset
+
+
+def _apply_direct_tools_manage_connections_preset(
+    manage_connections: t.Optional[t.Union[bool, ToolRouterManageConnectionsConfig]],
+) -> t.Union[bool, ToolRouterManageConnectionsConfig]:
+    if manage_connections is None:
+        return False
+
+    if isinstance(manage_connections, bool):
+        return manage_connections
+
+    return t.cast(
+        ToolRouterManageConnectionsConfig,
+        {
+            **manage_connections,
+            "enable": manage_connections.get("enable", False),
+        },
+    )
+
+
+def _apply_direct_tools_workbench_preset(
+    workbench: t.Optional[ToolRouterWorkbenchConfig],
+) -> ToolRouterWorkbenchConfig:
+    if workbench is None:
+        return {"enable": False}
+
+    return t.cast(
+        ToolRouterWorkbenchConfig,
+        {
+            **workbench,
+            "enable": workbench.get("enable", False),
+        },
+    )
+
+
+def _is_preload_all(preload: t.Optional[ToolRouterPreloadConfig]) -> bool:
+    if preload is None:
+        return False
+
+    tools = preload.get("tools")
+    if isinstance(tools, str):
+        return tools.lower() == "all"
+
+    return bool(len(tools or []) == 1 and (tools or [""])[0].lower() == "all")
+
+
+def _normalize_preload_config(
+    preload: ToolRouterPreloadConfig,
+) -> ToolRouterPreloadConfig:
+    if _is_preload_all(preload):
+        return {"tools": ["all"]}
+
+    return preload
 
 
 @dataclass
@@ -498,6 +571,7 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
         multi_account: t.Optional[ToolRouterMultiAccountConfig] = None,
         preload: t.Optional[ToolRouterPreloadConfig] = None,
         experimental: t.Optional[ToolRouterExperimentalConfig] = None,
+        session_preset: t.Optional[SessionPreset] = None,
     ) -> ToolRouterSession[TTool, TToolCollection]:
         """
         Create a new tool router session for a user.
@@ -579,9 +653,13 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
                               account selection when multiple accounts are connected.
                             Example: {'enable': True, 'max_accounts_per_toolkit': 3}
         :param preload: Optional preload configuration. Dict with:
-                        - 'tools' (List[str]): Tool slugs to expose directly in
-                          session.tools() and MCP tool lists.
+                        - 'tools' (List[str] | 'all' | 'ALL'): Tool slugs to expose
+                          directly in session.tools() and MCP tool lists. Use 'all'
+                          to expose all tools allowed by the session filters.
                         Example: {'tools': ['GMAIL_FETCH_EMAILS']}
+        :param session_preset: Optional SDK preset. Use SessionPreset.DIRECT_TOOLS to
+                               expose app tools directly and disable helper/meta groups
+                               unless explicitly enabled.
         :param experimental: Optional experimental configuration (ToolRouterExperimentalConfig).
                             Note: These features are experimental and may change.
                             Dict with:
@@ -669,6 +747,14 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
             toolkit_states = session.toolkits()
             ```
         """
+        normalized_session_preset = _normalize_session_preset(session_preset)
+
+        if normalized_session_preset is SessionPreset.DIRECT_TOOLS:
+            manage_connections = _apply_direct_tools_manage_connections_preset(
+                manage_connections
+            )
+            workbench = _apply_direct_tools_workbench_preset(workbench)
+            preload = preload or {"tools": ["all"]}
 
         # Parse manage_connections config
         manage_connections = (
@@ -793,7 +879,11 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
             create_params["multi_account"] = multi_account
 
         if preload is not None:
-            create_params["preload"] = preload
+            create_params["preload"] = _normalize_preload_config(preload)
+
+        if normalized_session_preset is SessionPreset.DIRECT_TOOLS:
+            create_params["search"] = {"enable": False}
+            create_params["execution"] = {"enable_multi_execute": False}
 
         # Build experimental config
         # Map SDK's experimental.assistive_prompt.user_timezone to API's
@@ -834,8 +924,20 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
                 "Please initialize ToolRouter with a provider."
             )
 
+        uses_v31_create_route = (
+            normalized_session_preset is SessionPreset.DIRECT_TOOLS
+            or _is_preload_all(preload)
+        )
+
         # Make API call to create session
-        session = self._client.tool_router.session.create(**create_params)
+        if uses_v31_create_route:
+            session = self._client.post(
+                "/api/v3.1/tool_router/session",
+                body=create_params,
+                cast_to=SessionCreateResponse,
+            )
+        else:
+            session = self._client.tool_router.session.create(**create_params)
 
         # Build custom tools routing map from backend response
         custom_tools_map: t.Optional[CustomToolsMap] = None
@@ -937,6 +1039,7 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
 
 
 __all__ = [
+    "SessionPreset",
     "ToolRouter",
     "ToolRouterSession",
     "ToolRouterSessionExperimental",

--- a/python/composio/core/models/tool_router_session.py
+++ b/python/composio/core/models/tool_router_session.py
@@ -76,6 +76,8 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
     session_id: str
     #: MCP server configuration for this session.
     mcp: t.Any
+    #: Server-returned session config, including resolved helper defaults.
+    config: t.Any
     #: Experimental capabilities available on this session.
     experimental: "ToolRouterSessionExperimental"
 
@@ -94,6 +96,7 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
         custom_tools_map: t.Optional[CustomToolsMap] = None,
         user_id: t.Optional[str] = None,
         preload: t.Optional[ToolRouterSessionPreloadConfig] = None,
+        config: t.Any = None,
     ) -> None:
         self._client = client
         self._provider = provider
@@ -103,6 +106,7 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
         self._file_upload_dirs = file_upload_dirs
         self.session_id = session_id
         self.mcp = mcp
+        self.config = config
         self.experimental = experimental
         self.preload = preload or ToolRouterSessionPreloadConfig(tools=[])
         self._custom_tools_map = custom_tools_map

--- a/python/composio/core/models/tool_router_session_api.py
+++ b/python/composio/core/models/tool_router_session_api.py
@@ -1,0 +1,41 @@
+"""Small v3.1 Tool Router helpers used until generated clients expose the routes."""
+
+from __future__ import annotations
+
+import typing as t
+from urllib.parse import quote
+
+from composio_client.types.tool_router.session_tools_response import (
+    SessionToolsResponse,
+)
+
+from composio.client import HttpClient
+
+SESSION_TOOLS_PAGE_LIMIT = 500
+
+
+def list_all_tool_router_session_tools_v31(
+    client: HttpClient,
+    session_id: str,
+) -> t.List[t.Any]:
+    tools: t.List[t.Any] = []
+    cursor: t.Optional[str] = None
+    encoded_session_id = quote(session_id, safe="")
+
+    while True:
+        params: t.Dict[str, t.Any] = {"limit": SESSION_TOOLS_PAGE_LIMIT}
+        if cursor:
+            params["cursor"] = cursor
+
+        response = t.cast(
+            SessionToolsResponse,
+            client.get(
+                f"/api/v3.1/tool_router/session/{encoded_session_id}/tools",
+                cast_to=SessionToolsResponse,
+                options={"params": params},
+            ),
+        )
+        tools.extend(response.items)
+        cursor = getattr(response, "next_cursor", None)
+        if not cursor:
+            return tools

--- a/python/composio/core/models/tools.py
+++ b/python/composio/core/models/tools.py
@@ -18,6 +18,9 @@ from composio.client.types import (
 from composio.core.models._files import FileHelper
 from composio.core.models.base import Resource
 from composio.core.models.custom_tools import CustomTools
+from composio.core.models.tool_router_session_api import (
+    list_all_tool_router_session_tools_v31,
+)
 from composio.core.provider import TTool, TToolCollection
 from composio.core.provider.agentic import AgenticProvider, AgenticProviderExecuteFn
 from composio.core.provider.base import ExecuteToolFn
@@ -274,10 +277,13 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
             )
             ```
         """
-        # Fetch session tools from the API
-        tools_response = self._client.tool_router.session.tools(session_id=session_id)
+        # Fetch session tools from the v3.1 API and auto-page so callers get all tools.
+        tools_response_items = list_all_tool_router_session_tools_v31(
+            client=self._client,
+            session_id=session_id,
+        )
         # Cast to Tool type - session.tools returns compatible Item type from different response schema
-        tools_list: t.List[Tool] = [t.cast(Tool, item) for item in tools_response.items]
+        tools_list: t.List[Tool] = [t.cast(Tool, item) for item in tools_response_items]
 
         # Apply schema modifiers if provided
         if modifiers is not None:

--- a/python/tests/test_tool_router.py
+++ b/python/tests/test_tool_router.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from composio.core.models.tool_router import (
+    SessionPreset,
     ToolkitConnectionsDetails,
     ToolkitConnectionState,
     ToolRouter,
@@ -43,6 +44,7 @@ def mock_client():
 
     client.tool_router.session.create.return_value = mock_session_response
     client.tool_router.session.retrieve.return_value = mock_session_response
+    client.post.return_value = mock_session_response
 
     # Mock link response
     mock_link_response = MagicMock()
@@ -603,6 +605,70 @@ class TestToolRouter:
         kwargs = mock_client.tool_router.session.create.call_args.kwargs
         assert kwargs["preload"] == {"tools": ["GMAIL_FETCH_EMAILS"]}
         assert session.preload.tools == ["GMAIL_FETCH_EMAILS"]
+
+    def test_create_session_with_direct_tools_preset(self, tool_router, mock_client):
+        """Direct tools preset expands into backend flags."""
+        mock_client.tool_router.session.create.return_value.config.preload.tools = [
+            "GMAIL_FETCH_EMAILS"
+        ]
+
+        session = tool_router.create(
+            user_id="user_123",
+            toolkits=["gmail"],
+            session_preset=SessionPreset.DIRECT_TOOLS,
+        )
+
+        mock_client.post.assert_called_once()
+        assert mock_client.post.call_args.args[0] == "/api/v3.1/tool_router/session"
+        body = mock_client.post.call_args.kwargs["body"]
+        assert body["toolkits"] == {"enable": ["gmail"]}
+        assert body["manage_connections"] == {"enable": False}
+        assert body["workbench"] == {"enable": False}
+        assert body["search"] == {"enable": False}
+        assert body["execution"] == {"enable_multi_execute": False}
+        assert body["preload"] == {"tools": ["all"]}
+        mock_client.tool_router.session.create.assert_not_called()
+        assert session.preload.tools == ["GMAIL_FETCH_EMAILS"]
+
+    def test_create_session_with_direct_tools_preset_helper_opt_ins(
+        self, tool_router, mock_client
+    ):
+        """Explicit helper values are preserved with the direct tools preset."""
+        tool_router.create(
+            user_id="user_123",
+            toolkits=["gmail"],
+            session_preset=SessionPreset.DIRECT_TOOLS,
+            manage_connections=True,
+            workbench={"enable": True},
+        )
+
+        body = mock_client.post.call_args.kwargs["body"]
+        assert body["manage_connections"] == {"enable": True}
+        assert body["workbench"] == {"enable": True}
+        assert body["search"] == {"enable": False}
+        assert body["execution"] == {"enable_multi_execute": False}
+        assert body["preload"] == {"tools": ["all"]}
+
+    def test_create_session_with_preload_all_uses_v31(self, tool_router, mock_client):
+        """preload.tools='ALL' is normalized and sent through v3.1."""
+        tool_router.create(
+            user_id="user_123",
+            toolkits=["gmail"],
+            preload={"tools": "ALL"},
+        )
+
+        mock_client.post.assert_called_once()
+        body = mock_client.post.call_args.kwargs["body"]
+        assert body["preload"] == {"tools": ["all"]}
+
+    def test_create_session_rejects_raw_session_preset_string(self, tool_router):
+        """The public Python surface expects SessionPreset enum values."""
+        with pytest.raises(ValueError, match="SessionPreset enum value"):
+            tool_router.create(
+                user_id="user_123",
+                toolkits=["gmail"],
+                session_preset="direct_tools",  # type: ignore[arg-type]
+            )
 
     def test_create_session_complex_config(self, tool_router, mock_client):
         """Test creating a session with complex configuration."""

--- a/python/tests/test_tool_router.py
+++ b/python/tests/test_tool_router.py
@@ -38,6 +38,10 @@ def mock_client():
     ]
     mock_session_response.config = MagicMock()
     mock_session_response.config.user_id = "user_123"
+    mock_session_response.config.manage_connections = MagicMock()
+    mock_session_response.config.manage_connections.enable = True
+    mock_session_response.config.workbench = MagicMock()
+    mock_session_response.config.workbench.enable = True
     mock_session_response.config.preload = MagicMock()
     mock_session_response.config.preload.tools = []
     mock_session_response.experimental = None  # Default to None
@@ -118,6 +122,9 @@ class TestToolRouter:
         assert callable(session.tools)
         assert callable(session.authorize)
         assert callable(session.toolkits)
+        assert (
+            session.config is mock_client.tool_router.session.create.return_value.config
+        )
 
         # Verify API was called
         mock_client.tool_router.session.create.assert_called_once()
@@ -649,6 +656,38 @@ class TestToolRouter:
         assert body["execution"] == {"enable_multi_execute": False}
         assert body["preload"] == {"tools": ["all"]}
 
+    def test_create_session_with_direct_tools_preset_partial_helper_objects(
+        self, tool_router, mock_client
+    ):
+        """Direct tools defaults helper parent enables inside partial objects."""
+        tool_router.create(
+            user_id="user_123",
+            toolkits=["gmail"],
+            session_preset=SessionPreset.DIRECT_TOOLS,
+            manage_connections={
+                "callback_url": "https://example.com/callback",
+                "wait_for_connections": True,
+            },
+            workbench={
+                "enable_proxy_execution": False,
+                "sandbox_size": "medium",
+            },
+        )
+
+        body = mock_client.post.call_args.kwargs["body"]
+        assert body["manage_connections"] == {
+            "enable": False,
+            "callback_url": "https://example.com/callback",
+            "enable_wait_for_connections": True,
+        }
+        assert body["workbench"] == {
+            "enable": False,
+            "enable_proxy_execution": False,
+            "sandbox_size": "medium",
+        }
+        assert body["search"] == {"enable": False}
+        assert body["execution"] == {"enable_multi_execute": False}
+
     def test_create_session_with_preload_all_uses_v31(self, tool_router, mock_client):
         """preload.tools='ALL' is normalized and sent through v3.1."""
         tool_router.create(
@@ -660,6 +699,8 @@ class TestToolRouter:
         mock_client.post.assert_called_once()
         body = mock_client.post.call_args.kwargs["body"]
         assert body["preload"] == {"tools": ["all"]}
+        assert "search" not in body
+        assert "execution" not in body
 
     def test_create_session_rejects_raw_session_preset_string(self, tool_router):
         """The public Python surface expects SessionPreset enum values."""

--- a/python/tests/test_tool_router.py
+++ b/python/tests/test_tool_router.py
@@ -632,7 +632,7 @@ class TestToolRouter:
         assert body["manage_connections"] == {"enable": False}
         assert body["workbench"] == {"enable": False}
         assert body["search"] == {"enable": False}
-        assert body["execution"] == {"enable_multi_execute": False}
+        assert body["execute"] == {"enable_multi_execute": False}
         assert body["preload"] == {"tools": ["all"]}
         mock_client.tool_router.session.create.assert_not_called()
         assert session.preload.tools == ["GMAIL_FETCH_EMAILS"]
@@ -653,7 +653,7 @@ class TestToolRouter:
         assert body["manage_connections"] == {"enable": True}
         assert body["workbench"] == {"enable": True}
         assert body["search"] == {"enable": False}
-        assert body["execution"] == {"enable_multi_execute": False}
+        assert body["execute"] == {"enable_multi_execute": False}
         assert body["preload"] == {"tools": ["all"]}
 
     def test_create_session_with_direct_tools_preset_partial_helper_objects(
@@ -686,7 +686,7 @@ class TestToolRouter:
             "sandbox_size": "medium",
         }
         assert body["search"] == {"enable": False}
-        assert body["execution"] == {"enable_multi_execute": False}
+        assert body["execute"] == {"enable_multi_execute": False}
 
     def test_create_session_with_preload_all_uses_v31(self, tool_router, mock_client):
         """preload.tools='ALL' is normalized and sent through v3.1."""
@@ -700,7 +700,7 @@ class TestToolRouter:
         body = mock_client.post.call_args.kwargs["body"]
         assert body["preload"] == {"tools": ["all"]}
         assert "search" not in body
-        assert "execution" not in body
+        assert "execute" not in body
 
     def test_create_session_rejects_raw_session_preset_string(self, tool_router):
         """The public Python surface expects SessionPreset enum values."""

--- a/ts/packages/core/src/composio.ts
+++ b/ts/packages/core/src/composio.ts
@@ -18,7 +18,7 @@ import { Files } from '#files';
 import { getDefaultHeaders } from './utils/session';
 import { ToolkitVersionParam } from './types/tool.types';
 import { ToolRouter } from './models/ToolRouter';
-import { ToolRouterCreateSessionConfig, Session } from './types/toolRouter.types';
+import { ToolRouterCreateSessionConfigInput, Session } from './types/toolRouter.types';
 import { CONFIG_DEFAULTS } from './utils/config-defaults';
 import { expandHomeAndResolve, expandHomeAndResolveMany } from './utils/fileDirs';
 export type ComposioConfig<
@@ -225,7 +225,7 @@ export class Composio<
    */
   create: (
     userId: string,
-    routerConfig?: ToolRouterCreateSessionConfig
+    routerConfig?: ToolRouterCreateSessionConfigInput
   ) => Promise<Session<unknown, unknown, TProvider>>;
 
   /**

--- a/ts/packages/core/src/lib/toolRouterSessionApi.ts
+++ b/ts/packages/core/src/lib/toolRouterSessionApi.ts
@@ -1,0 +1,59 @@
+import type { Composio as ComposioClient } from '@composio/client';
+import type {
+  SessionCreateParams,
+  SessionCreateResponse,
+  SessionToolsResponse,
+} from '@composio/client/resources/tool-router/session/session.mjs';
+
+const TOOL_ROUTER_SESSION_TOOLS_PAGE_LIMIT = 500;
+const encodePathSegment = (value: string): string => encodeURIComponent(value);
+
+export type SessionCreateParamsV31 = SessionCreateParams & {
+  search?: {
+    enable?: boolean;
+  };
+  execution?: {
+    enable_multi_execute?: boolean;
+  };
+};
+
+export type SessionToolsResponseV31 = SessionToolsResponse & {
+  next_cursor?: string | null;
+  total_pages?: number;
+};
+
+export const createToolRouterSessionV31 = (
+  client: ComposioClient,
+  payload: SessionCreateParamsV31
+): Promise<SessionCreateResponse> => {
+  return client.post('/api/v3.1/tool_router/session', { body: payload });
+};
+
+const listToolRouterSessionToolsV31 = (
+  client: ComposioClient,
+  sessionId: string,
+  query?: { cursor?: string | null; limit?: number }
+): Promise<SessionToolsResponseV31> => {
+  return client.get(`/api/v3.1/tool_router/session/${encodePathSegment(sessionId)}/tools`, {
+    query,
+  });
+};
+
+export const listAllToolRouterSessionToolsV31 = async (
+  client: ComposioClient,
+  sessionId: string
+): Promise<SessionToolsResponse['items']> => {
+  const items: SessionToolsResponse['items'] = [];
+  let cursor: string | null | undefined;
+
+  do {
+    const response = await listToolRouterSessionToolsV31(client, sessionId, {
+      limit: TOOL_ROUTER_SESSION_TOOLS_PAGE_LIMIT,
+      ...(cursor ? { cursor } : {}),
+    });
+    items.push(...response.items);
+    cursor = response.next_cursor;
+  } while (cursor);
+
+  return items;
+};

--- a/ts/packages/core/src/lib/toolRouterSessionApi.ts
+++ b/ts/packages/core/src/lib/toolRouterSessionApi.ts
@@ -12,7 +12,7 @@ export type SessionCreateParamsV31 = SessionCreateParams & {
   search?: {
     enable?: boolean;
   };
-  execution?: {
+  execute?: {
     enable_multi_execute?: boolean;
   };
 };

--- a/ts/packages/core/src/models/ToolRouter.ts
+++ b/ts/packages/core/src/models/ToolRouter.ts
@@ -29,7 +29,6 @@ import {
   MCPServerType,
   ToolRouterMCPServerConfig,
   ToolRouterSessionMetadata,
-  SessionPreset,
 } from '../types/toolRouter.types';
 import { ToolRouterCreateSessionConfigSchema } from '../types/toolRouter.types';
 import {
@@ -56,6 +55,7 @@ import type { CustomToolsMap } from '../types/customTool.types';
 
 function getSessionMetadata(session: SessionCreateResponse | SessionRetrieveResponse) {
   const metadata: ToolRouterSessionMetadata = {
+    config: session.config,
     preload: session.config.preload,
     configVersion: session.config_version,
     warnings: 'warnings' in session ? (session.warnings ?? []) : [],
@@ -118,9 +118,8 @@ export class ToolRouter<
     userId: string,
     config?: ToolRouterCreateSessionConfigInput
   ): Promise<Session<TToolCollection, TTool, TProvider>> {
-    const routerConfig = ToolRouterCreateSessionConfigSchema.parse(
-      applyToolRouterSessionPreset(config ?? {})
-    );
+    const presetApplication = applyToolRouterSessionPreset(config ?? {});
+    const routerConfig = ToolRouterCreateSessionConfigSchema.parse(presetApplication.config);
 
     // Extract custom tools/toolkits from experimental config
     const customTools = routerConfig.experimental?.customTools;
@@ -158,20 +157,15 @@ export class ToolRouter<
       multi_account: multiAccountPayload,
       preload: routerConfig.preload,
       experimental: Object.keys(experimentalPayload).length > 0 ? experimentalPayload : undefined,
+      ...presetApplication.v31Overrides,
     };
 
-    const isDirectToolsPreset = routerConfig.sessionPreset === SessionPreset.DirectTools;
     const isPreloadAll =
       routerConfig.preload?.tools?.length === 1 &&
       routerConfig.preload.tools[0].toLowerCase() === 'all';
 
-    if (isDirectToolsPreset) {
-      payload.search = { enable: false };
-      payload.execution = { enable_multi_execute: false };
-    }
-
     const session =
-      isDirectToolsPreset || isPreloadAll
+      presetApplication.v31Overrides || isPreloadAll
         ? await createToolRouterSessionV31(this.client, payload)
         : await this.client.toolRouter.session.create(payload);
 

--- a/ts/packages/core/src/models/ToolRouter.ts
+++ b/ts/packages/core/src/models/ToolRouter.ts
@@ -22,12 +22,14 @@ import { telemetry } from '../telemetry/Telemetry';
 import { BaseComposioProvider } from '../provider/BaseProvider';
 import { ComposioConfig } from '../composio';
 import {
-  ToolRouterCreateSessionConfig,
+  applyToolRouterSessionPreset,
+  ToolRouterCreateSessionConfigInput,
   Session,
   SessionExperimental,
   MCPServerType,
   ToolRouterMCPServerConfig,
   ToolRouterSessionMetadata,
+  SessionPreset,
 } from '../types/toolRouter.types';
 import { ToolRouterCreateSessionConfigSchema } from '../types/toolRouter.types';
 import {
@@ -43,6 +45,7 @@ import {
   transformToolRouterToolkitsParams,
   transformToolRouterMultiAccountParams,
 } from '../lib/toolRouterParams';
+import { createToolRouterSessionV31, SessionCreateParamsV31 } from '../lib/toolRouterSessionApi';
 import { ToolRouterSession } from './ToolRouterSession';
 import {
   buildCustomToolsMapFromResponse,
@@ -113,9 +116,11 @@ export class ToolRouter<
    */
   async create(
     userId: string,
-    config?: ToolRouterCreateSessionConfig
+    config?: ToolRouterCreateSessionConfigInput
   ): Promise<Session<TToolCollection, TTool, TProvider>> {
-    const routerConfig = ToolRouterCreateSessionConfigSchema.parse(config ?? {});
+    const routerConfig = ToolRouterCreateSessionConfigSchema.parse(
+      applyToolRouterSessionPreset(config ?? {})
+    );
 
     // Extract custom tools/toolkits from experimental config
     const customTools = routerConfig.experimental?.customTools;
@@ -139,7 +144,7 @@ export class ToolRouter<
 
     const multiAccountPayload = transformToolRouterMultiAccountParams(routerConfig.multiAccount);
 
-    const payload: SessionCreateParams = {
+    const payload: SessionCreateParamsV31 = {
       user_id: userId,
       auth_configs: routerConfig.authConfigs,
       connected_accounts: routerConfig.connectedAccounts,
@@ -155,7 +160,20 @@ export class ToolRouter<
       experimental: Object.keys(experimentalPayload).length > 0 ? experimentalPayload : undefined,
     };
 
-    const session = await this.client.toolRouter.session.create(payload);
+    const isDirectToolsPreset = routerConfig.sessionPreset === SessionPreset.DirectTools;
+    const isPreloadAll =
+      routerConfig.preload?.tools?.length === 1 &&
+      routerConfig.preload.tools[0].toLowerCase() === 'all';
+
+    if (isDirectToolsPreset) {
+      payload.search = { enable: false };
+      payload.execution = { enable_multi_execute: false };
+    }
+
+    const session =
+      isDirectToolsPreset || isPreloadAll
+        ? await createToolRouterSessionV31(this.client, payload)
+        : await this.client.toolRouter.session.create(payload);
 
     // Build custom tools map from the response's slug/original_slug mapping
     // instead of computing LOCAL_ prefix client-side

--- a/ts/packages/core/src/models/ToolRouterSession.ts
+++ b/ts/packages/core/src/models/ToolRouterSession.ts
@@ -16,6 +16,7 @@ import {
   ToolRouterSessionMetadata,
   ToolRouterSessionPreloadConfig,
   ToolRouterSessionWarning,
+  ToolRouterSessionConfig,
 } from '../types/toolRouter.types';
 import {
   transformSearchResponse,
@@ -55,6 +56,7 @@ export class ToolRouterSession<
   public readonly sessionId: string;
   public readonly mcp: ToolRouterMCPServerConfig;
   public readonly experimental: SessionExperimental;
+  public readonly config: ToolRouterSessionConfig;
   public readonly preload: ToolRouterSessionPreloadConfig;
   public readonly configVersion?: number;
   public readonly warnings: ToolRouterSessionWarning[];
@@ -64,7 +66,7 @@ export class ToolRouterSession<
 
   constructor(
     private readonly client: ComposioClient,
-    private readonly config: ComposioConfig<TProvider> | undefined,
+    private readonly sdkConfig: ComposioConfig<TProvider> | undefined,
     sessionId: string,
     mcp: ToolRouterMCPServerConfig,
     experimentalOverrides?: Pick<SessionExperimental, 'assistivePrompt'>,
@@ -82,6 +84,7 @@ export class ToolRouterSession<
       files: new ToolRouterSessionFilesMount(client, sessionId),
     };
     this.preload = metadata?.preload ?? { tools: [] };
+    this.config = metadata?.config ?? ({ preload: this.preload } as ToolRouterSessionConfig);
     this.configVersion = metadata?.configVersion;
     this.warnings = metadata?.warnings ?? [];
 
@@ -101,7 +104,7 @@ export class ToolRouterSession<
    * is intercepted: local tools are executed in-process, remote tools are sent to the backend.
    */
   async tools(modifiers?: SessionMetaToolOptions): Promise<ReturnType<TProvider['wrapTools']>> {
-    const ToolsModel = new Tools<TToolCollection, TTool, TProvider>(this.client, this.config);
+    const ToolsModel = new Tools<TToolCollection, TTool, TProvider>(this.client, this.sdkConfig);
     const tools = await ToolsModel.getRawToolRouterSessionTools(
       this.sessionId,
       modifiers?.modifySchema ? { modifySchema: modifiers.modifySchema } : undefined
@@ -125,13 +128,13 @@ export class ToolRouterSession<
         );
       };
 
-      if (!this.config?.provider) {
+      if (!this.sdkConfig?.provider) {
         throw new Error(
           'A provider is required when using custom tools with session.tools(). ' +
             'Pass a provider in the Composio constructor.'
         );
       }
-      return this.config.provider.wrapTools(tools, routingExecuteFn) as ReturnType<
+      return this.sdkConfig.provider.wrapTools(tools, routingExecuteFn) as ReturnType<
         TProvider['wrapTools']
       >;
     }

--- a/ts/packages/core/src/models/Tools.ts
+++ b/ts/packages/core/src/models/Tools.ts
@@ -31,6 +31,7 @@ import {
   ToolExecuteParams as ComposioToolExecuteParams,
 } from '@composio/client/resources/tools';
 import { CustomTools } from './CustomTools';
+import { listAllToolRouterSessionToolsV31 } from '../lib/toolRouterSessionApi';
 import { CustomToolInputParameter, CustomToolOptions } from '../types/customTool.types';
 import {
   afterExecuteModifier,
@@ -487,8 +488,8 @@ export class Tools<
     sessionId: string,
     options?: SchemaModifierOptions
   ): Promise<ToolList> {
-    const tools = await this.client.toolRouter.session.tools(sessionId);
-    let modifiedTools = tools.items.map(tool => this.transformToolCases(tool));
+    const tools = await listAllToolRouterSessionToolsV31(this.client, sessionId);
+    let modifiedTools = tools.map(tool => this.transformToolCases(tool));
     // apply local modifiers if they are provided
     if (options?.modifySchema) {
       const modifier = options.modifySchema;

--- a/ts/packages/core/src/types/toolRouter.types.ts
+++ b/ts/packages/core/src/types/toolRouter.types.ts
@@ -29,6 +29,12 @@ export type MCPServerType = z.infer<typeof MCPServerTypeSchema>;
 export const SandboxSizeSchema = z.enum(['standard', 'medium', 'large', 'xlarge']);
 export type SandboxSize = z.infer<typeof SandboxSizeSchema>;
 
+export enum SessionPreset {
+  DirectTools = 'direct_tools',
+}
+
+export const SessionPresetSchema = z.nativeEnum(SessionPreset);
+
 // manage connections
 export const ToolRouterConfigManageConnectionsSchema = z
   .object({
@@ -169,8 +175,31 @@ export const ToolRouterConfigToolsSchema = z
   });
 export type ToolRouterConfigTools = z.infer<typeof ToolRouterConfigToolsSchema>;
 
+const ToolRouterPreloadToolsSchema = z
+  .union([z.literal('all'), z.literal('ALL'), z.array(z.string())])
+  .optional()
+  .transform(tools => {
+    if (tools === undefined) {
+      return undefined;
+    }
+
+    if (typeof tools === 'string') {
+      return ['all'];
+    }
+
+    if (tools.length === 1 && tools[0].toLowerCase() === 'all') {
+      return ['all'];
+    }
+
+    return tools;
+  });
+
 export const ToolRouterCreateSessionConfigSchema = z
   .object({
+    sessionPreset: SessionPresetSchema.optional().describe(
+      'Opinionated SDK preset for session creation. DirectTools exposes app tools directly by using preload.tools="all" and disables helper/meta tool groups unless explicitly enabled.'
+    ),
+
     tools: z
       .record(z.string(), z.union([ToolRouterToolsParamSchema, ToolRouterConfigToolsSchema]))
       .optional()
@@ -257,12 +286,9 @@ export const ToolRouterCreateSessionConfigSchema = z
 
     preload: z
       .object({
-        tools: z
-          .array(z.string())
-          .optional()
-          .describe(
-            'Tool slugs to preload into session.tools() and the MCP tool list. The backend validates slugs against the session filters.'
-          ),
+        tools: ToolRouterPreloadToolsSchema.describe(
+          'Tool slugs to preload into session.tools() and the MCP tool list. Use "all" to expose all tools allowed by the session filters.'
+        ),
       })
       .strict()
       .optional()
@@ -299,9 +325,60 @@ export const ToolRouterCreateSessionConfigSchema = z
   })
   .partial()
   .describe('The config for the tool router session');
+
+export type ToolRouterCreateSessionConfigInput = z.input<
+  typeof ToolRouterCreateSessionConfigSchema
+>;
+
+const applyDirectToolsManageConnectionsPreset = (
+  manageConnections: ToolRouterCreateSessionConfigInput['manageConnections']
+): ToolRouterCreateSessionConfigInput['manageConnections'] => {
+  if (manageConnections === undefined) {
+    return false;
+  }
+
+  if (typeof manageConnections === 'boolean') {
+    return manageConnections;
+  }
+
+  return {
+    ...manageConnections,
+    enable: manageConnections.enable ?? false,
+  };
+};
+
+const applyDirectToolsWorkbenchPreset = (
+  workbench: ToolRouterCreateSessionConfigInput['workbench']
+): ToolRouterCreateSessionConfigInput['workbench'] => {
+  if (workbench === undefined) {
+    return { enable: false };
+  }
+
+  return {
+    ...workbench,
+    enable: workbench.enable ?? false,
+  };
+};
+
+export const applyToolRouterSessionPreset = (
+  config: ToolRouterCreateSessionConfigInput
+): ToolRouterCreateSessionConfigInput => {
+  if (config.sessionPreset !== SessionPreset.DirectTools) {
+    return config;
+  }
+
+  return {
+    ...config,
+    manageConnections: applyDirectToolsManageConnectionsPreset(config.manageConnections),
+    workbench: applyDirectToolsWorkbenchPreset(config.workbench),
+    preload: config.preload ?? { tools: ['all'] },
+  };
+};
+
 /**
  * The config for the tool router session.
  *
+ * @param {SessionPreset} [sessionPreset] - Optional SDK preset. Use SessionPreset.DirectTools to expose app tools directly and disable helper/meta groups unless explicitly enabled.
  * @param {ToolRouterToolkitsParamSchema | ToolRouterToolkitsDisabledConfigSchema | ToolRouterToolkitsEnabledConfigSchema} toolkits - The toolkits to use in the tool router session
  * @param {Record<string, ToolRouterToolsParam | ToolRouterConfigTools>} tools - The tools to configure per toolkit (key is toolkit slug)
  * @param {Array<'readOnlyHint' | 'destructiveHint' | 'idempotentHint' | 'openWorldHint'>} tags - Global tags to filter tools by behavior
@@ -320,7 +397,7 @@ export const ToolRouterCreateSessionConfigSchema = z
  * @param {number} [multiAccount.maxAccountsPerToolkit] - Max connected accounts per toolkit (2-10, default 5)
  * @param {boolean} [multiAccount.requireExplicitSelection] - When true, require explicit account selection when multiple accounts are connected
  * @param {object} [preload] - Tools to preload into session.tools() and the MCP tool list
- * @param {string[]} [preload.tools] - Tool slugs to preload. Server-side validation ensures they exist and are allowed by the session filters.
+ * @param {string[] | 'all' | 'ALL'} [preload.tools] - Tool slugs to preload. Use "all" to expose all tools allowed by the session filters.
  */
 export type ToolRouterCreateSessionConfig = z.infer<typeof ToolRouterCreateSessionConfigSchema>;
 

--- a/ts/packages/core/src/types/toolRouter.types.ts
+++ b/ts/packages/core/src/types/toolRouter.types.ts
@@ -334,7 +334,7 @@ export type ToolRouterCreateSessionV31Overrides = {
   search?: {
     enable?: boolean;
   };
-  execution?: {
+  execute?: {
     enable_multi_execute?: boolean;
   };
 };
@@ -390,7 +390,7 @@ export const applyToolRouterSessionPreset = (
     },
     v31Overrides: {
       search: { enable: false },
-      execution: { enable_multi_execute: false },
+      execute: { enable_multi_execute: false },
     },
   };
 };
@@ -639,7 +639,7 @@ export type ToolRouterSessionConfig = SessionCreateResponse.Config & {
   search?: {
     enable?: boolean;
   };
-  execution?: {
+  execute?: {
     enable_multi_execute?: boolean;
   };
 };

--- a/ts/packages/core/src/types/toolRouter.types.ts
+++ b/ts/packages/core/src/types/toolRouter.types.ts
@@ -330,6 +330,20 @@ export type ToolRouterCreateSessionConfigInput = z.input<
   typeof ToolRouterCreateSessionConfigSchema
 >;
 
+export type ToolRouterCreateSessionV31Overrides = {
+  search?: {
+    enable?: boolean;
+  };
+  execution?: {
+    enable_multi_execute?: boolean;
+  };
+};
+
+export interface ToolRouterSessionPresetApplication {
+  config: ToolRouterCreateSessionConfigInput;
+  v31Overrides?: ToolRouterCreateSessionV31Overrides;
+}
+
 const applyDirectToolsManageConnectionsPreset = (
   manageConnections: ToolRouterCreateSessionConfigInput['manageConnections']
 ): ToolRouterCreateSessionConfigInput['manageConnections'] => {
@@ -362,16 +376,22 @@ const applyDirectToolsWorkbenchPreset = (
 
 export const applyToolRouterSessionPreset = (
   config: ToolRouterCreateSessionConfigInput
-): ToolRouterCreateSessionConfigInput => {
+): ToolRouterSessionPresetApplication => {
   if (config.sessionPreset !== SessionPreset.DirectTools) {
-    return config;
+    return { config };
   }
 
   return {
-    ...config,
-    manageConnections: applyDirectToolsManageConnectionsPreset(config.manageConnections),
-    workbench: applyDirectToolsWorkbenchPreset(config.workbench),
-    preload: config.preload ?? { tools: ['all'] },
+    config: {
+      ...config,
+      manageConnections: applyDirectToolsManageConnectionsPreset(config.manageConnections),
+      workbench: applyDirectToolsWorkbenchPreset(config.workbench),
+      preload: config.preload ?? { tools: ['all'] },
+    },
+    v31Overrides: {
+      search: { enable: false },
+      execution: { enable_multi_execute: false },
+    },
   };
 };
 
@@ -615,9 +635,19 @@ export interface ToolRouterSessionExecuteOptions {
 
 export type ToolRouterSessionPreloadConfig = SessionCreateResponse.Config.Preload;
 
+export type ToolRouterSessionConfig = SessionCreateResponse.Config & {
+  search?: {
+    enable?: boolean;
+  };
+  execution?: {
+    enable_multi_execute?: boolean;
+  };
+};
+
 export type ToolRouterSessionWarning = SessionCreateResponse.Warning;
 
 export interface ToolRouterSessionMetadata {
+  config?: ToolRouterSessionConfig;
   preload?: ToolRouterSessionPreloadConfig;
   configVersion?: number;
   warnings?: ToolRouterSessionWarning[];
@@ -657,6 +687,8 @@ export interface Session<
 > {
   sessionId: string;
   mcp: ToolRouterMCPServerConfig;
+  /** Server-returned session config, including resolved helper defaults. */
+  config: ToolRouterSessionConfig;
   /** Stored preload configuration for this session. */
   preload: ToolRouterSessionPreloadConfig;
   /** Server-side config version when returned by the API. */

--- a/ts/packages/core/test/models/toolRouter.test.ts
+++ b/ts/packages/core/test/models/toolRouter.test.ts
@@ -67,6 +67,13 @@ const mockSessionCreateResponse = {
   },
   tool_router_tools: ['GMAIL_FETCH_EMAILS', 'SLACK_SEND_MESSAGE', 'GITHUB_CREATE_ISSUE'],
   config: {
+    user_id: 'user_123',
+    manage_connections: {
+      enable: true,
+    },
+    workbench: {
+      enable: true,
+    },
     preload: { tools: [] },
   },
   config_version: 1,
@@ -220,6 +227,7 @@ describe('ToolRouter', () => {
         expect(session).toHaveProperty('tools');
         expect(session).toHaveProperty('authorize');
         expect(session).toHaveProperty('toolkits');
+        expect(session.config).toEqual(mockSessionCreateResponse.config);
       });
 
       it('should create a session with empty config object', async () => {
@@ -325,6 +333,40 @@ describe('ToolRouter', () => {
         });
       });
 
+      it('should apply direct tools defaults inside partial helper objects', async () => {
+        mockClient.post.mockResolvedValueOnce(mockSessionCreateResponse);
+
+        await toolRouter.create(userId, {
+          toolkits: ['gmail'],
+          sessionPreset: SessionPreset.DirectTools,
+          manageConnections: {
+            callbackUrl: 'https://example.com/callback',
+            waitForConnections: true,
+          },
+          workbench: {
+            enableProxyExecution: false,
+            sandboxSize: 'medium',
+          },
+        });
+
+        expect(mockClient.post).toHaveBeenCalledWith('/api/v3.1/tool_router/session', {
+          body: expect.objectContaining({
+            manage_connections: {
+              enable: false,
+              callback_url: 'https://example.com/callback',
+              enable_wait_for_connections: true,
+            },
+            workbench: {
+              enable: false,
+              enable_proxy_execution: false,
+              sandbox_size: 'medium',
+            },
+            search: { enable: false },
+            execution: { enable_multi_execute: false },
+          }),
+        });
+      });
+
       it('should accept preload all variants', async () => {
         mockClient.post.mockResolvedValueOnce(mockSessionCreateResponse);
 
@@ -338,6 +380,8 @@ describe('ToolRouter', () => {
             preload: { tools: ['all'] },
           }),
         });
+        expect(mockClient.post.mock.calls[0][1].body).not.toHaveProperty('search');
+        expect(mockClient.post.mock.calls[0][1].body).not.toHaveProperty('execution');
       });
 
       it('should create a session with user ID only and verify MCP type transformation', async () => {

--- a/ts/packages/core/test/models/toolRouter.test.ts
+++ b/ts/packages/core/test/models/toolRouter.test.ts
@@ -5,7 +5,11 @@ import { telemetry } from '../../src/telemetry/Telemetry';
 import { MockProvider } from '../utils/mocks/provider.mock';
 import { Tools } from '../../src/models/Tools';
 import { ConnectedAccountStatuses } from '../../src/types/connectedAccounts.types';
-import { ToolRouterCreateSessionConfig, Session } from '../../src/types/toolRouter.types';
+import {
+  ToolRouterCreateSessionConfig,
+  Session,
+  SessionPreset,
+} from '../../src/types/toolRouter.types';
 
 // Mock dependencies
 vi.mock('../../src/telemetry/Telemetry', () => ({
@@ -25,25 +29,34 @@ vi.mock('../../src/models/Tools', () => {
 });
 
 // Create mock client with ToolRouter-related methods
-const createMockClient = () => ({
-  baseURL: 'https://api.composio.dev',
-  apiKey: 'test-api-key',
-  toolRouter: {
-    session: {
-      create: vi.fn(),
+const createMockClient = () => {
+  const client = {
+    baseURL: 'https://api.composio.dev',
+    apiKey: 'test-api-key',
+    toolRouter: {
+      session: {
+        create: vi.fn(),
+        retrieve: vi.fn(),
+        link: vi.fn(),
+        toolkits: vi.fn(),
+        search: vi.fn(),
+        execute: vi.fn(),
+      },
+    },
+    post: vi.fn(),
+    tools: {
+      list: vi.fn(),
       retrieve: vi.fn(),
-      link: vi.fn(),
-      toolkits: vi.fn(),
-      search: vi.fn(),
       execute: vi.fn(),
     },
-  },
-  tools: {
-    list: vi.fn(),
-    retrieve: vi.fn(),
-    execute: vi.fn(),
-  },
-});
+  };
+
+  client.post.mockImplementation((_path: string, options?: { body?: unknown }) =>
+    client.toolRouter.session.create(options?.body)
+  );
+
+  return client;
+};
 
 // Mock response data
 const mockSessionCreateResponse = {
@@ -260,6 +273,71 @@ describe('ToolRouter', () => {
 
         expect(session.preload.tools).toEqual(['GMAIL_FETCH_EMAILS']);
         expect(session.configVersion).toBe(2);
+      });
+
+      it('should expand the direct tools preset into backend flags', async () => {
+        mockClient.post.mockResolvedValueOnce({
+          ...mockSessionCreateResponse,
+          tool_router_tools: ['GMAIL_FETCH_EMAILS'],
+          config: {
+            preload: { tools: ['GMAIL_FETCH_EMAILS'] },
+          },
+        });
+
+        const session = await toolRouter.create(userId, {
+          toolkits: ['gmail'],
+          sessionPreset: SessionPreset.DirectTools,
+        });
+
+        expect(mockClient.post).toHaveBeenCalledWith('/api/v3.1/tool_router/session', {
+          body: expect.objectContaining({
+            user_id: userId,
+            toolkits: { enable: ['gmail'] },
+            manage_connections: { enable: false },
+            workbench: { enable: false },
+            search: { enable: false },
+            execution: { enable_multi_execute: false },
+            preload: { tools: ['all'] },
+          }),
+        });
+        expect(mockClient.toolRouter.session.create).not.toHaveBeenCalled();
+        expect(session.preload.tools).toEqual(['GMAIL_FETCH_EMAILS']);
+      });
+
+      it('should preserve explicit helper opt-ins with the direct tools preset', async () => {
+        mockClient.post.mockResolvedValueOnce(mockSessionCreateResponse);
+
+        await toolRouter.create(userId, {
+          toolkits: ['gmail'],
+          sessionPreset: SessionPreset.DirectTools,
+          manageConnections: true,
+          workbench: { enable: true },
+        });
+
+        expect(mockClient.post).toHaveBeenCalledWith('/api/v3.1/tool_router/session', {
+          body: expect.objectContaining({
+            manage_connections: { enable: true },
+            workbench: { enable: true },
+            search: { enable: false },
+            execution: { enable_multi_execute: false },
+            preload: { tools: ['all'] },
+          }),
+        });
+      });
+
+      it('should accept preload all variants', async () => {
+        mockClient.post.mockResolvedValueOnce(mockSessionCreateResponse);
+
+        await toolRouter.create(userId, {
+          toolkits: ['gmail'],
+          preload: { tools: 'ALL' },
+        });
+
+        expect(mockClient.post).toHaveBeenCalledWith('/api/v3.1/tool_router/session', {
+          body: expect.objectContaining({
+            preload: { tools: ['all'] },
+          }),
+        });
       });
 
       it('should create a session with user ID only and verify MCP type transformation', async () => {

--- a/ts/packages/core/test/models/toolRouter.test.ts
+++ b/ts/packages/core/test/models/toolRouter.test.ts
@@ -304,7 +304,7 @@ describe('ToolRouter', () => {
             manage_connections: { enable: false },
             workbench: { enable: false },
             search: { enable: false },
-            execution: { enable_multi_execute: false },
+            execute: { enable_multi_execute: false },
             preload: { tools: ['all'] },
           }),
         });
@@ -327,7 +327,7 @@ describe('ToolRouter', () => {
             manage_connections: { enable: true },
             workbench: { enable: true },
             search: { enable: false },
-            execution: { enable_multi_execute: false },
+            execute: { enable_multi_execute: false },
             preload: { tools: ['all'] },
           }),
         });
@@ -362,7 +362,7 @@ describe('ToolRouter', () => {
               sandbox_size: 'medium',
             },
             search: { enable: false },
-            execution: { enable_multi_execute: false },
+            execute: { enable_multi_execute: false },
           }),
         });
       });
@@ -381,7 +381,7 @@ describe('ToolRouter', () => {
           }),
         });
         expect(mockClient.post.mock.calls[0][1].body).not.toHaveProperty('search');
-        expect(mockClient.post.mock.calls[0][1].body).not.toHaveProperty('execution');
+        expect(mockClient.post.mock.calls[0][1].body).not.toHaveProperty('execute');
       });
 
       it('should create a session with user ID only and verify MCP type transformation', async () => {
@@ -1264,7 +1264,7 @@ describe('ToolRouter', () => {
     //         enable: true,
     //         callbackUri: 'https://myapp.com/callback',
     //       },
-    //       execution: {
+    //       workbench: {
     //         enableProxyExecution: true,
     //         autoOffloadThreshould: 30,
     //       },
@@ -1295,7 +1295,7 @@ describe('ToolRouter', () => {
     //         manageConnections: true,
     //         callbackUri: 'https://myapp.com/callback',
     //       }),
-    //       execution: {
+    //       workbench: {
     //         enable_proxy_execution: true,
     //         auto_offload_threshould: 30,
     //       },

--- a/ts/packages/core/test/tools/tools.test.ts
+++ b/ts/packages/core/test/tools/tools.test.ts
@@ -355,6 +355,43 @@ describe('Tools', () => {
     });
   });
 
+  describe('getRawToolRouterSessionTools', () => {
+    it('should auto-paginate v3.1 session tools', async () => {
+      mockClient.get
+        .mockResolvedValueOnce({
+          items: [toolMocks.rawTool],
+          next_cursor: 'cursor_2',
+        })
+        .mockResolvedValueOnce({
+          items: [
+            {
+              ...toolMocks.rawTool,
+              slug: 'COMPOSIO_TOOL_TWO',
+            },
+          ],
+          next_cursor: null,
+        });
+
+      const result = await context.tools.getRawToolRouterSessionTools('session_123');
+
+      expect(mockClient.get).toHaveBeenNthCalledWith(
+        1,
+        '/api/v3.1/tool_router/session/session_123/tools',
+        {
+          query: { limit: 500 },
+        }
+      );
+      expect(mockClient.get).toHaveBeenNthCalledWith(
+        2,
+        '/api/v3.1/tool_router/session/session_123/tools',
+        {
+          query: { limit: 500, cursor: 'cursor_2' },
+        }
+      );
+      expect(result.map(tool => tool.slug)).toEqual(['COMPOSIO_TOOL', 'COMPOSIO_TOOL_TWO']);
+    });
+  });
+
   describe('getRawComposioToolBySlug', () => {
     it('should fetch a tool by slug from the API', async () => {
       const slug = 'TOOL_SLUG';

--- a/ts/packages/core/test/utils/mocks/client.mock.ts
+++ b/ts/packages/core/test/utils/mocks/client.mock.ts
@@ -1,6 +1,8 @@
 import { vi } from 'vitest';
 
 export const mockClient = {
+  get: vi.fn(),
+  post: vi.fn(),
   tools: {
     list: vi.fn(),
     retrieve: vi.fn(),


### PR DESCRIPTION
## Summary
- Adds TS `SessionPreset.DirectTools` and Python `SessionPreset.DIRECT_TOOLS` as the SDK-facing direct-tools preset.
- Expands the preset client-side into existing session controls: preload all allowed tools, disable manage-connections/workbench by default unless explicitly enabled, and internally disable search/schema lookup plus multi-execute helper exposure.
- Keeps normal session creation on the existing generated v3 SDK flow; direct-tools preset and `preload.tools: "all"` creation go through the v3.1 create route.
- Adds v3.1 `session.tools()` auto-pagination in TS and Python so callers get all exposed tools without manual paging.
- Does not expose public SDK knobs for `search` or `execution` yet.

## Tests
- `pnpm --filter @composio/core test -- test/models/toolRouter.test.ts test/tools/tools.test.ts`
- `pnpm --filter @composio/core typecheck`
- `cd python && uv run pytest tests/test_tool_router.py`
- `cd python && uv run ruff check composio/core/models/tool_router.py composio/core/models/tool_router_session_api.py composio/core/models/tools.py composio/core/models/__init__.py composio/__init__.py tests/test_tool_router.py`