### PR TITLE
docs: update CLAUDE.md for composio SDK

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,404 +1,111 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for Claude Code working on the Composio SDK monorepo (TypeScript + Python SDKs, the `@composio/cli`, and the docs site).
 
-## Overview
+## Layout
 
-This is the Composio SDK v3 repository containing both TypeScript and Python SDKs. The main development focus is on the TypeScript SDK located in `/ts/` directory. The project uses a monorepo structure with multiple packages and examples.
-
-## Memories and Notes
-
-- For documentation tasks, refer to `docs/CLAUDE.md`
-
-## Effect.ts Reference Source
-
-The CLI package (`@composio/cli`) is built on the Effect.ts ecosystem. A local copy of the Effect source code is available as a git submodule:
-
-- **Location:** `ts/vendor/effect/`
-- **Repo:** [Effect-TS/effect](https://github.com/Effect-TS/effect)
-- **Branch:** `main`
-
-When working on CLI code, reference the Effect source for accurate patterns:
-- `ts/vendor/effect/packages/effect/src/` — core Effect runtime
-- `ts/vendor/effect/packages/cli/src/` — @effect/cli (Command, Options, Args)
-- `ts/vendor/effect/packages/platform/src/` — @effect/platform (FileSystem, Terminal)
-
-**Important:** The submodule is for **read-only reference only**. Do not modify files in `ts/vendor/`. The CLI's actual dependencies come from npm via `pnpm install`.
-
-## Clack Reference Source
-
-The CLI uses [`@clack/prompts`](https://github.com/bombshell-dev/clack) for interactive terminal UI. A local copy of the Clack source code is available as a git submodule:
-
-- **Location:** `ts/vendor/clack/`
-- **Repo:** [bombshell-dev/clack](https://github.com/bombshell-dev/clack)
-
-When working on CLI prompts and terminal UI, reference the Clack source for accurate APIs:
-- `ts/vendor/clack/packages/prompts/src/` — `@clack/prompts` (high-level API: text, select, confirm, spinner, etc.)
-- `ts/vendor/clack/packages/core/src/` — `@clack/core` (low-level primitives)
-
-See `ts/packages/cli/AGENTS.md` for detailed Clack usage guidelines.
-
-**Important:** The submodule is for **read-only reference only**. Do not modify files in `ts/vendor/`. The CLI's actual `@clack/prompts` dependency comes from npm via `pnpm install`.
-
-## Common Development Commands
-
-### Build and Development
-```bash
-# Build all packages
-pnpm build
-
-# Build only TypeScript packages  
-pnpm build:packages
-
-# Clean build artifacts
-pnpm clean
-pnpm clean:workspace
-
-# Lint code
-pnpm lint
-pnpm lint:fix
-
-# Format code
-pnpm format
-
-# Run tests
-pnpm test
-```
-
-### Package Management
-```bash
-# Install dependencies
-pnpm install
-
-# Check peer dependencies
-pnpm check:peer-deps
-
-# Update peer dependencies  
-pnpm update:peer-deps
-```
-
-### Creating New Components
-```bash
-# Create a new provider
-pnpm create:provider <provider-name> [--agentic]
-
-# Create a new example
-pnpm create:example <example-name>
-```
-
-### Release Management
-```bash
-# Create changeset for releases
-pnpm changeset
-
-# Version packages
-pnpm changeset:version
-
-# Publish packages
-pnpm changeset:release
-```
-
-## Project Architecture
-
-### Repository Structure
 ```
 composio/
-├── ts/                      # TypeScript SDK (main development)
+├── ts/
 │   ├── packages/
-│   │   ├── core/           # Core SDK functionality
-│   │   ├── providers/      # AI provider integrations (OpenAI, Anthropic, etc.)
-│   │   ├── cli/           # Command-line interface
-│   │   ├── json-schema-to-zod/ # Schema conversion utility
-│   │   └── ts-builders/   # TypeScript code generation utilities
-│   └── examples/          # Usage examples for different providers
-├── python/                # Python SDK
-├── docs/                  # Documentation (Fumadocs)
-└── examples/              # Cross-platform examples
+│   │   ├── core/                    # @composio/core SDK
+│   │   ├── cli/                     # @composio/cli (Effect.ts + Bun)
+│   │   ├── cli-keyring/             # OS-keyring API key storage for the CLI
+│   │   ├── providers/{anthropic,openai,openai-agents,google,langchain,llamaindex,mastra,vercel,cloudflare,claude-agent-sdk}/
+│   │   ├── json-schema-to-zod/
+│   │   └── ts-builders/
+│   ├── examples/                    # Per-provider/feature example apps
+│   ├── e2e-tests/{cli,runtimes/{node,deno,cloudflare}}/
+│   └── vendor/{effect,clack}/       # Read-only git submodules for reference
+├── python/                          # Python SDK (uv + nox + Make)
+└── docs/                            # Fumadocs site (see docs/CLAUDE.md)
 ```
 
-### Core Packages
+Workspaces are declared in `pnpm-workspace.yaml` (note: providers are at `ts/packages/providers/*`, not `ts/packages/wrappers/*` — older docs may say wrappers). Default branch is `next` — base all PRs against `next`.
 
-**@composio/core** - Main SDK functionality:
-- `src/composio.ts` - Main Composio class
-- `src/models/` - Core models (Tools, Toolkits, ConnectedAccounts, etc.)
-- `src/provider/` - Base provider implementations
-- `src/services/` - Internal services (telemetry, pusher)
-- `src/types/` - TypeScript type definitions
-- `src/utils/` - Utility functions and helpers
+## TypeScript / pnpm Commands
 
-**Provider Packages** - AI integrations:
-- `@composio/openai` - OpenAI integration
-- `@composio/anthropic` - Anthropic integration
-- `@composio/google` - Google GenAI integration
-- `@composio/langchain` - LangChain integration
-- `@composio/vercel` - Vercel AI integration
-- `@composio/mastra` - Mastra integration
+Run from repo root unless noted. Toolchain is pinned: Node via `.nvmrc`, Bun via `.bun-version`, pnpm via `package.json#packageManager`.
 
-### Key Concepts
+```bash
+pnpm install                          # If preinstall fails on Bun version mismatch: BYPASS_BUN_VERSION_CHECK=1 pnpm install
+pnpm build                            # turbo build, all packages
+pnpm build:packages                   # only ts/packages/**
+pnpm typecheck                        # turbo typecheck (uses tsgo / @typescript/native-preview)
+pnpm typecheck:tsc                    # fallback to stock tsc
+pnpm lint        / pnpm lint:fix
+pnpm format
+pnpm test                             # turbo test across packages + validate examples
+pnpm test:e2e[:node|:deno|:cli|:cloudflare]
+pnpm create:provider <name> [--agentic]
+pnpm create:example <name>
+pnpm changeset / pnpm changeset:version / pnpm changeset:release
+```
 
-**Tools** - Individual functions that can be executed (e.g., GITHUB_CREATE_REPO, GMAIL_SEND_EMAIL)
+Per-package work: `cd ts/packages/<pkg> && pnpm test` / `pnpm typecheck`.
 
-**Toolkits** - Collections of related tools grouped by service (e.g., github, gmail, slack)
+## CLI (`@composio/cli`)
 
-**Connected Accounts** - User authentication/authorization for external services
+Built on Effect.ts + Bun. See `ts/packages/cli/CLAUDE.md` for command-by-command details. **When you touch anything under `ts/packages/cli/src/commands/`, run `pnpm typecheck` from repo root before declaring done** — the CLI uses `tsgo` and Effect's strict types catch wiring errors that runtime tests miss.
 
-**Auth Configs** - Configuration for different authentication methods
+API keys are stored in the OS keyring via `@composio/cli-keyring` (migrated from plaintext in `~/.composio/`). The `composio agent` family (signup/login/whoami/inbox/claim) is the unattended-agent auth path; `composio login` is the interactive browser flow.
 
-**Custom Tools** - User-defined tools with custom logic
+## Python SDK
 
-**Providers** - Integrations with AI frameworks (OpenAI, Anthropic, etc.)
+Lives in `python/`. Uses `uv` + `nox` + a `Makefile`. The repo-root `pyproject.toml` is for tooling only; the SDK itself is `python/pyproject.toml`. Always activate the venv before `pytest`/`ruff`.
 
-**Modifiers** - Middleware to transform tool inputs/outputs
+```bash
+cd python
+make env && source .venv/bin/activate # First-time setup (creates .venv, installs deps + providers)
+make sync                             # Re-sync dependencies
+make provider                         # Install all provider sub-packages editable
+make fmt   # ruff format       (nox -s fmt)
+make chk   # ruff + mypy       (nox -s chk)
+make tst   # pytest            (nox -s tst)
+make snt   # sanity tests      (nox -s snt)
+pytest -m core|openai|langchain|agno  # Marker-scoped test runs
+```
 
-## Development Workflow
+Python ≥3.10. Linter/formatter config: `python/config/ruff.toml`. Type checker: `python/config/mypy.ini`.
 
-### For Tool Development
-1. Tools are auto-generated from OpenAPI specifications
-2. Custom tools can be created using the Custom Tools API
-3. Tool execution happens through the main Composio class
+## Vendored Reference Sources
 
-### For Provider Development
-1. Use `pnpm create:provider <name>` to scaffold new providers
-2. Implement required methods: `wrapTool`, `wrapTools`
-3. For agentic providers, also implement execution handlers
-4. Add comprehensive tests and documentation
+`ts/vendor/effect/` and `ts/vendor/clack/` are git submodules used as **read-only** references when working on the CLI. Never modify files under `ts/vendor/`; the actual deps come from npm. Useful paths:
 
-### Testing
-- Unit tests use Vitest
-- Run tests with `pnpm test`
-- Tests are located in `test/` directories within each package
-- Mock implementations are available in `test/utils/mocks/`
-
-### Code Quality
-- ESLint configuration in `eslint.config.mjs`
-- Prettier for code formatting
-- TypeScript strict mode enabled
-- Comprehensive TSDoc documentation required
-- Husky pre-commit hooks for quality checks
+- `ts/vendor/effect/packages/{effect,cli,platform}/src/`
+- `ts/vendor/clack/packages/{prompts,core}/src/`
 
 ## Environment Variables
 
-```bash
-COMPOSIO_API_KEY          # Required: Your Composio API key
-COMPOSIO_BASE_URL         # Optional: Custom API base URL
-COMPOSIO_LOG_LEVEL        # Optional: Logging level (silent, error, warn, info, debug)
-COMPOSIO_DISABLE_TELEMETRY # Optional: Set to "true" to disable telemetry
-DEVELOPMENT               # Development mode flag
-CI                       # CI environment flag
+```
+COMPOSIO_API_KEY               # Required for SDK + CLI calls
+COMPOSIO_BASE_URL              # Override API base (defaults to backend.composio.dev)
+COMPOSIO_LOG_LEVEL             # silent|error|warn|info|debug
+COMPOSIO_DISABLE_TELEMETRY     # "true" to disable
+COMPOSIO_TOOLKIT_VERSION_<NAME># Pin a toolkit version (CLI generate)
+COMPOSIO_E2E_NODE_VERSION      # Pin Node version for e2e (e.g. 22.12.0)
+COMPOSIO_E2E_DENO_VERSION      # Pin Deno version for e2e
+DEBUG_OVERRIDE_VERSION         # CLI debug overrides (DEBUG_OVERRIDE_*)
+FORCE_USE_CACHE                # CLI: force cached toolkits/tools
+BYPASS_BUN_VERSION_CHECK       # Skip preinstall Bun-version pin check
 ```
 
-## Key Files and Locations
+## Gotchas
 
-- **Main SDK Entry**: `ts/packages/core/src/index.ts`
-- **Core Composio Class**: `ts/packages/core/src/composio.ts`
-- **Type Definitions**: `ts/packages/core/src/types/`
-- **Error Classes**: `ts/packages/core/src/errors/`
-- **Examples**: `ts/examples/` and `examples/`
-- **Documentation**: `docs/`
-- **Build Configs**: `turbo.jsonc`, `tsconfig.base.json`, `tsdown.config.base.ts`
-- **E2E Tests**: `ts/e2e-tests/`
+- **Default branch is `next`, not `main`/`master`.** PRs and rebases must target `next`.
+- **Bun pin is hard**: `pnpm install`'s preinstall hook fails when `bun --version` ≠ `.bun-version`. Use `BYPASS_BUN_VERSION_CHECK=1` in sandboxes; CI sets this automatically.
+- **Don't hand-edit generated TS** — anything under `@composio/core/generated` and CLI `tools-as-enums.json` / `toolkits.json` caches comes from `composio generate` or CI; regenerate instead.
+- **Provider packages are at `providers/*`, not `wrappers/*`** despite `pnpm-workspace.yaml` listing both globs (only `providers/*` exists today).
+- **`docs/` builds and ships independently** with Bun, not pnpm. Read `docs/CLAUDE.md` before touching MDX/links/changelog entries — code blocks are type-checked at build time.
+- **GitHub Actions tool versions**: when editing `.github/workflows/`, also update the Prerequisites section in `ts/docs/internal/release.md` to match `.nvmrc`, `.bun-version`, and `package.json#packageManager`.
+- **CLI release channels**: pushes to `next` that touch `ts/packages/cli/**` auto-publish a beta to GitHub Releases. Stable releases only land via a merged Changeset version-bump PR. Details in `ts/packages/cli/CLAUDE.md`.
 
-## Maintenance Tasks
+## When Updating GitHub Actions
 
-### When Updating GitHub Actions
-
-When modifying files in `.github/workflows/`, update the "Prerequisites" section in `ts/docs/internal/release.md` with the current tool versions:
-
-- **Node.js**: `cat .nvmrc`
-- **Bun**: `cat .bun-version`
-- **pnpm**: `cat package.json | jq -r .packageManager | cut -d'@' -f2`
-
-## Testing Commands
+Update `ts/docs/internal/release.md` Prerequisites with current versions:
 
 ```bash
-# Run all tests
-pnpm test
-
-# Run tests for core package only
-cd ts/packages/core && pnpm test
-
-# Run tests with UI
-pnpm test:ui
-```
-
-### TypeScript E2E Tests
-
-E2E tests for `@composio/core` are located in `ts/e2e-tests/` and test runtime compatibility across different JavaScript environments.
-
-```bash
-# Run all e2e tests (Node.js + Deno + Cloudflare)
-pnpm test:e2e
-
-# Run only Node.js e2e tests (CJS/ESM compatibility, runs in Docker)
-pnpm test:e2e:node
-
-# Run only Deno e2e tests (npm: specifier compatibility, runs in Docker)
-pnpm test:e2e:deno
-
-# Run only Cloudflare Workers e2e tests
-pnpm test:e2e:cloudflare
-
-# Run Node.js tests with a specific Node version
-COMPOSIO_E2E_NODE_VERSION=22.12.0 pnpm test:e2e:node
-
-# Run Deno tests with a specific Deno version
-COMPOSIO_E2E_DENO_VERSION=2.6.7 pnpm test:e2e:deno
-```
-
-**E2E Test Structure:**
-```
-ts/e2e-tests/
-├── _utils/                    # Shared Docker infrastructure
-├── runtimes/
-│   ├── node/                  # Node.js runtime tests
-│   │   ├── cjs-basic/         # CommonJS compatibility
-│   │   └── esm-basic/         # ESM compatibility
-│   ├── deno/                  # Deno runtime tests
-│   │   └── esm-basic/         # npm: specifier compatibility
-│   └── cloudflare/            # Cloudflare runtime tests
-│       └── cf-workers-basic/  # Cloudflare Workers tests
-└── README.md                  # E2E test documentation
-```
-
-> **Note:** When adding new e2e tests, update `ts/e2e-tests/README.md` with the new test information.
-
-## Common Patterns
-
-### Tool Execution
-```typescript
-const composio = new Composio({ apiKey: 'your-key' });
-const result = await composio.tools.execute('TOOL_NAME', {
-  userId: 'user-id',
-  arguments: { /* tool args */ }
-});
-```
-
-### Provider Integration
-```typescript
-import { OpenAIProvider } from '@composio/openai';
-const provider = new OpenAIProvider({ apiKey: 'openai-key' });
-const tools = await composio.tools.get('user-id', { toolkits: ['github'] });
-const wrappedTools = provider.wrapTools(tools);
-```
-
-### Custom Tool Creation
-```typescript
-import { z } from 'zod';
-
-const customTool = await composio.tools.createCustomTool({
-  name: 'My Tool',
-  description: 'Tool description',
-  slug: 'MY_TOOL',
-  inputParams: z.object({
-    param: z.string().describe('Parameter description')
-  }),
-  execute: async (input) => {
-    // Implementation
-    return {
-      data: { result: input.param },
-      error: null,
-      successful: true
-    };
-  }
-});
-```
-
-This monorepo uses pnpm workspaces and Turbo for efficient builds and development.
-
-## Python SDK Development
-
-### Setup
-The Python SDK is located in the `/python/` directory and uses `uv` for dependency management and `nox` for automation.
-
-### Environment Setup
-```bash
-# Create and setup Python development environment
-cd python
-make env
-source .venv/bin/activate
-```
-
-### Python Development Commands
-```bash
-# Setup environment (creates virtual env with all dependencies)
-make env
-
-# Sync dependencies (when in an existing environment)
-make sync
-
-# Install provider packages
-make provider
-
-# Format code using ruff
-make fmt
-# Or directly: nox -s fmt
-
-# Check linting and type issues
-make chk
-# Or directly: nox -s chk
-
-# Fix linting issues
-nox -s fix
-
-# Run tests (requires implementing tst session)
-make tst
-# Or directly: nox -s tst
-
-# Run sanity tests (requires implementing snt session)  
-make snt
-# Or directly: nox -s snt
-
-# Clean build artifacts
-make clean-build
-
-# Bump version
-make bump
-
-# Build packages
-make build
-```
-
-### Python Project Structure
-```
-python/
-├── composio/           # Main SDK package
-├── providers/          # Provider implementations
-├── tests/             # Test suite
-├── examples/          # Usage examples
-├── scripts/           # Development scripts
-├── config/            # Configuration files
-│   ├── pytest.ini     # Pytest configuration
-│   ├── mypy.ini       # MyPy type checking config
-│   ├── ruff.toml     # Ruff linter/formatter config
-│   └── codecov.yml   # Code coverage config
-├── Makefile          # Development shortcuts
-├── noxfile.py        # Nox automation sessions
-└── pyproject.toml    # Project configuration
-```
-
-### Python Code Quality
-- **Formatter**: Ruff (Black-compatible, 88 char line length)
-- **Linter**: Ruff with custom configuration
-- **Type Checker**: mypy with strict optional typing
-- **Test Framework**: pytest with custom markers (core, openai, langchain, agno)
-- **Python Version**: >=3.10, <4
-- **Dependency Managers**: uv
-
-### Python Testing
-```bash
-# Run tests with pytest markers
-pytest -m core        # Run core tests only
-pytest -m openai      # Run OpenAI provider tests
-pytest -m langchain   # Run LangChain provider tests
-pytest -m agno       # Run Agno provider tests
-```
-
-### Python Package Dependencies
-- Core: `pysher`, `pydantic>=2.6.4`, `composio-client==1.4.0`, `typing-extensions>=4.0.0`, `openai`
-- Dev: `nox`, `pytest`, `ruff`, `langchain_openai`, `fastapi`, `twine`, `click`, `semver`
-
-### Python Environment Variables
-Same as TypeScript SDK, with additional:
-```bash
-OPENAI_API_KEY    # Required for OpenAI provider examples
+cat .nvmrc                                            # Node
+cat .bun-version                                      # Bun
+jq -r .packageManager package.json | cut -d'@' -f2    # pnpm
 ```

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,107 +1,55 @@
-# Composio Documentation
+# Composio Docs (`docs/`)
 
-Documentation site for Composio, built with [Fumadocs](https://fumadocs.dev/).
+Fumadocs (Next.js 16 + Bun) site for `docs.composio.dev`. Detailed Claude context lives under `docs/.claude/{context,guides,decisions,agents}/`.
 
-## Quick Reference
+## Commands
 
 ```bash
-bun install          # Install dependencies
-bun run dev          # Dev server (http://localhost:3000)
-bun run build        # Production build (validates TS code blocks)
-bun run types:check  # Type check
+bun install                       # postinstall runs `fumadocs-mdx`
+bun run dev                       # localhost:3000
+bun run build                     # production build — type-checks all TS code blocks (twoslash)
+bun run types:check               # fumadocs-mdx + next typegen + tsc --noEmit
+bun run lint
+bun run lint:links                # validate-links.ts (needs bunfig.toml preload)
+bun run generate:toolkits         # regenerate public/data/toolkits.json
+bun run generate:meta-tools       # regenerate public/data/meta-tools.json + content/reference/meta-tools/
+bun run generate:api-index        # regenerate API reference index pages
+bun run test                      # bun test tests/static/
+bun run test:integration          # bun test tests/integration/ (--timeout 30000)
 ```
 
-## Project Structure
+## Layout
 
 ```
 docs/
-├── app/                  # Next.js app router
-├── content/              # MDX content
-│   ├── docs/             # Main documentation
-│   ├── cookbooks/        # Cookbooks & guides
-│   ├── changelog/        # Release notes
-│   ├── reference/        # SDK & API reference
-│   └── toolkits/         # Toolkit docs + faq/ snippets
-├── components/           # React components
-├── lib/                  # Utilities
-├── public/               # Static assets
-├── scripts/              # Build scripts (link checker, etc.)
-└── .claude/              # Claude context (see below)
+├── app/                      # Next.js app router (group: (home))
+├── content/{docs,cookbooks,changelog,reference,toolkits}/
+├── components/, lib/, public/, scripts/, tests/
+├── .claude/{context,guides,decisions,agents}/   # Domain knowledge (read these first)
+└── source.config.ts          # Fumadocs source config
 ```
 
-## Claude Context
+## Git workflow
 
-Detailed documentation for Claude is organized in `.claude/`:
+Docs branches and PRs always target `next` (not `master`). Branch from `next`.
 
-### Context (Domain Knowledge)
-- [fumadocs.md](.claude/context/fumadocs.md) - Framework patterns, design tokens, MDX components
-- [twoslash.md](.claude/context/twoslash.md) - TypeScript code block type checking
-- [sdk-reference.md](.claude/context/sdk-reference.md) - SDK doc generation
-- [api-reference.md](.claude/context/api-reference.md) - API reference customizations (schema rendering, CSS overrides, upgrade notes)
-- [pipelines.md](.claude/context/pipelines.md) - CI/CD workflows reference (cron jobs, auto-PR, AI agents)
+## Sacred rules
 
-### Guides (How-To)
-- [changelog.md](.claude/guides/changelog.md) - Writing changelog entries
+1. **TS code blocks are type-checked at build time** (twoslash) — `bun dev` does not catch this; `bun run build` does. See `.claude/context/twoslash.md`.
+2. **Run `bun run lint:links` before pushing** — needs `bunfig.toml` preload to load fumadocs-mdx outside Next.
+3. **Internal links must be relative** (`/docs/...`, `/reference/...`, `/assets/images/...`). Never absolute (`https://docs.composio.dev/...`) — the link checker silently skips absolute URLs and they rot. API-reference operationIDs are camelCase; copy exact `href` from `<ApiEndpointsTable>` in `content/reference/api-reference/<resource>/index.mdx`. Changelog paths use zero-padded `YYYY/MM/DD`.
+4. **CSS variables**: use `var(--composio-orange)`, not `var(--orange)`. Defined in `app/global.css`.
+5. **Changelog dates**: `YYYY-MM-DD`, lowercase filenames `MM-DD-YY.mdx`.
+6. **Toolkits / meta-tools data files** (`public/data/toolkits.json`, `public/data/meta-tools.json`) are required at build time and CI-regenerated. Do NOT register `MetaToolDetailServer` in `mdx-components.tsx` — it reads JSON via `fs` and would leak into the client bundle.
+7. **Toolkit FAQ snippets** at `content/toolkits/faq/{slug}.md` are plain markdown (no frontmatter) embedded into toolkit pages at build time. They're excluded from the Fumadocs source via `files: ['**/*', '!faq/**']` but the link checker still scans them via the `content/**/*.md` glob.
+8. **AI-first docs**: prefer cURL over UI instructions ("click X"); most traffic is AI crawlers. Every `.md` endpoint appends invisible LLM guardrails — controlled by `llmGuardrails` frontmatter (see `.claude/decisions/llm-guardrails.md`).
+9. **`docs/examples/` is tutorial code** — review for correctness/clarity, not production-readiness. Skip a11y/error-boundary/i18n nitpicks.
+10. **Mobile**: Fumadocs nav differs on mobile — don't assume horizontal layout.
 
-### Decisions (ADRs)
-- [toolkits.md](.claude/decisions/toolkits.md) - Toolkits page implementation
-- [examples.md](.claude/decisions/examples.md) - Examples/cookbooks page plan
-- [feedback.md](.claude/decisions/feedback.md) - Feedback system
-- [llm-guardrails.md](.claude/decisions/llm-guardrails.md) - LLM guardrails system (frontmatter-scoped, pipeline-injected)
+## API versioning
 
-## Git Workflow
-
-**Docs branches are always based off `next` and PRs target `next`** (not `master`). When creating a new branch for docs work, branch from `next`. When opening a PR, set the base to `next`.
-
-## Key Rules
-
-1. **TypeScript code blocks are type-checked** - All TS code in MDX is validated at build time. See [twoslash.md](.claude/context/twoslash.md).
-
-2. **Run build before pushing** - `bun run build` catches type errors that `bun dev` misses. Also run `bun run scripts/validate-links.ts` to catch broken internal links.
-
-3. **CSS variables** - Use `var(--composio-orange)` not `var(--orange)`. Check `app/global.css`.
-
-4. **Date format** - Changelog dates must be YYYY-MM-DD format.
-
-5. **Toolkits data** - `public/data/toolkits.json` must exist; errors are thrown, not ignored.
-
-6. **Meta tools data** - `public/data/meta-tools.json` and `content/reference/meta-tools/` are auto-generated by `bun run generate:meta-tools` (fetches from Tool Router API). Updated by CI alongside toolkits data. The `MetaToolDetailServer` component reads from the JSON at build time — do NOT register it in `mdx-components.tsx` (causes `fs` to leak into client bundle).
-
-7. **Test on mobile** - Fumadocs nav differs on mobile. Avoid assumptions about horizontal layout.
-
-8. **Toolkit FAQ files** - FAQ snippets live in `content/toolkits/faq/{slug}.md`. They're plain markdown (no frontmatter) embedded in toolkit pages at build time, not standalone Fumadocs pages. They're excluded from the toolkits Fumadocs source via `files: ['**/*', '!faq/**']` in `source.config.ts` but still scanned by the link checker.
-
-9. **Link checker** - `scripts/validate-links.ts` validates all internal links. It needs `bunfig.toml` (Bun preload for fumadocs-mdx) to run. Key details:
-   - Populate keys use `(home)/` prefix to match the `app/(home)/` route group
-   - Fragment validation falls back to parsing raw markdown headings (since `data.toc` is unavailable outside Next.js)
-   - Dynamic toolkit pages are validated against slugs from `public/data/toolkits.json`
-   - Non-Fumadocs `.md` files (like FAQ snippets) are picked up via `content/**/*.md` glob
-
-10. **Internal links use relative paths, never absolute** - Write `/docs/<section>/<page>`, `/reference/api-reference/<resource>/<operationId>`, `/reference/sdk-reference/<lang>/<page>`, `/docs/changelog/YYYY/MM/DD`, `/assets/images/<file>`. Never `https://docs.composio.dev/...`. The link checker (rule 9) only validates relative links; absolute URLs silently bypass it and rot over time. API-reference operation IDs are **camelCase** (`getConnectedAccountsByNanoid`, `postAuthConfigs`) — do not guess them; copy the exact `href` from `<ApiEndpointsTable>` in `content/reference/api-reference/<resource>/index.mdx`. Previous changelog entries use zero-padded month/day (`/docs/changelog/2026/04/21`, not `2026/4/21`).
+Side-by-side v3.1 (default, `/reference/api-reference/...`) and v3.0 (`/reference/v3/api-reference/...`). Non-API v3 pages (overview, authentication, errors, rate-limits) are manual copies — update both. API index pages and OpenAPI specs are auto-regenerated by CI (`docs-update-data.yml`). SDK Reference and Meta Tools are shared. Full architecture in `.claude/context/api-reference.md`.
 
 ## Glossary
 
-`content/docs/glossary.mdx` defines key Composio terms (auth config, session, toolkit, etc.) using `<Glossary>` and `<GlossaryTerm name="...">` components (`components/glossary.tsx`). The component renders a filterable two-column table. The markdown converter in `lib/source.ts` converts `<GlossaryTerm>` tags to `### Term` headings for LLM-friendly output. When adding new Composio concepts, add a `<GlossaryTerm>` entry and update the `keywords` frontmatter array.
-
-## API Versioning
-
-The API reference supports v3.1 (latest, default) and v3.0 side-by-side:
-- **v3.1:** `/reference/api-reference/...` (default, all existing URLs unchanged)
-- **v3.0:** `/reference/v3/api-reference/...`
-
-Version selector in the top nav switches between them. See [api-reference.md](.claude/context/api-reference.md) for full architecture.
-
-Key maintenance notes:
-- Non-API pages under `content/reference/v3/` (overview, authentication, errors, rate-limits) are manual copies — update both when content changes
-- API index pages and OpenAPI specs are auto-generated by CI (`docs-update-data.yml`)
-- SDK Reference and Meta Tools are shared across both versions (not duplicated)
-
-## Code Review Guidelines
-
-**`docs/examples/` is tutorial code.** Review for correctness and clarity, not production-readiness. Skip accessibility (aria attributes, focus management), error boundaries, i18n, comprehensive error handling, and similar concerns that add noise to a teaching example. The goal is to teach Composio integration with minimal code.
-
-## AI-Native Documentation
-
-**Prefer cURL over "click"** - Most docs traffic comes from AI crawlers. When documenting API interactions, prefer showing cURL commands over UI instructions like "click this button" or "navigate to settings". cURL is machine-readable and can be directly executed by AI agents.
-
-**LLM guardrails** - Every `.md` endpoint appends invisible guardrails steering AI code generators toward the session-based pattern. Controlled via `llmGuardrails` frontmatter field. See [llm-guardrails.md](.claude/decisions/llm-guardrails.md).
+`content/docs/glossary.mdx` uses `<Glossary>` / `<GlossaryTerm name="...">` (`components/glossary.tsx`). The markdown converter in `lib/source.ts` rewrites `<GlossaryTerm>` to `### Term` for LLM output. When adding a Composio concept, add a `<GlossaryTerm>` and update the page's `keywords` frontmatter.

--- a/ts/packages/cli/AGENTS.md
+++ b/ts/packages/cli/AGENTS.md
@@ -1,379 +1,66 @@
-# AGENTS.md
+# `@composio/cli`
 
-Instructions for AI agents working on `@composio/cli`.
+Effect.ts + Bun CLI. Service-oriented with layer-injected dependencies, generator-based control flow. Errors flow through the in-tree `effect-errors/` (source-mapped traces, Effect span timelines).
 
-## Architecture Overview
+## Required check
 
-The CLI is built on the **Effect.ts ecosystem** and runs on **Bun**. It follows a service-oriented architecture with dependency injection via Effect layers, generator-based control flow (`Effect.gen`), and structured error handling.
+When you touch anything under `src/commands/`, run `pnpm typecheck` from the **repo root**. CLI uses `tsgo` (`@typescript/native-preview`) — Effect's strict types catch wiring errors that runtime tests miss.
 
-## Required Checks
-
-When you touch CLI commands (anything under `ts/packages/cli/src/commands/`), you must run `pnpm typecheck` from the repo root. If it fails, fix the issues before proceeding.
-
-### Entry Point
-
-`src/bin.ts` bootstraps the CLI by composing Effect layers and running the root command via `BunRuntime.runMain()`:
-
-- `CliConfigLive` — @effect/cli behavior (case-sensitive, no auto-correct, no built-ins)
-- `ComposioUserContextLive` — User authentication state from `~/.composio/`
-- `ComposioSessionRepositoryLive` — OAuth2 session management
-- `ComposioToolkitsRepositoryCachedLive` — Cached API client for toolkits/tools
-- `UpgradeBinaryLive` — Self-update from GitHub releases
-- `BunFileSystem.layer`, `BunContext.layer` — Bun runtime integration
-
-Errors are captured via the custom `effect-errors/` module, which provides source-mapped stack traces, Effect span timelines, and formatted output.
-
-### Commands (`src/commands/`)
-
-Each command is declared with `@effect/cli`'s `Command.make()` pattern:
-
-| Command                                                  | Description                                                                           |
-| -------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| `composio version`                                       | Display CLI version                                                                   |
-| `composio whoami`                                        | Show logged-in user's API key                                                         |
-| `composio login [--no-browser] [--no-wait] [--key text] [--user-api-key text] [--org text]` | Login with browser redirect or direct user API key                                    |
-| `composio logout`                                        | Clear stored API key                                                                  |
-| `composio upgrade`                                       | Self-update binary from GitHub releases                                               |
-| `composio generate`                                      | Auto-detect project language, delegate to `ts` or `py`                                |
-| `composio generate ts`                                   | Generate TypeScript type stubs for toolkits/tools/triggers                            |
-| `composio generate py`                                   | Generate Python type stubs                                                            |
-| `composio manage <command>`                              | Manage Composio resources (toolkits, tools, accounts, triggers, logs, orgs, projects) |
-
-Options use `Options.text()`, `Options.boolean()`, `Options.choice()`, `Options.directory()` with Effect Schema validation.
-
-### Services (`src/services/`)
-
-| Service                            | Purpose                                                                      |
-| ---------------------------------- | ---------------------------------------------------------------------------- |
-| `ComposioUserContext`              | Auth state — reads/writes `~/.composio/user-config.json`, merges env vars    |
-| `ComposioSessionRepository`        | Creates OAuth2 sessions, polls until `linked` state                          |
-| `ComposioToolkitsRepository`       | API client — fetches toolkits, tools, trigger types; validates versions      |
-| `ComposioToolkitsRepositoryCached` | Decorator over base repository with file-based caching and graceful fallback |
-| `NodeOs`                           | OS abstraction (`homedir`, `platform`, `arch`)                               |
-| `EnvLangDetector`                  | Detects project language (TS/Python) from config files and lock files        |
-| `JsPackageManagerDetector`         | Detects npm/pnpm/yarn/bun for helpful install instructions                   |
-| `UpgradeBinary`                    | Fetches latest release from GitHub, downloads and replaces binary            |
-
-### Effects (`src/effects/`)
-
-Reusable Effect computations for cross-cutting concerns:
-
-| Effect                         | Purpose                                                               |
-| ------------------------------ | --------------------------------------------------------------------- |
-| `app-config`                   | Reads `COMPOSIO_*` env vars (API_KEY, BASE_URL, CACHE_DIR, etc.)      |
-| `debug-config`                 | Debug overrides (DEBUG_OVERRIDE_VERSION, etc.)                        |
-| `force-config`                 | Force flags (FORCE_USE_CACHE)                                         |
-| `setup-cache-dir`              | Ensures `~/.composio/` directory exists                               |
-| `toolkit-version-overrides`    | Parses `COMPOSIO_TOOLKIT_VERSION_<NAME>=<ver>` env vars               |
-| `validate-toolkit-versions`    | Validates overrides against available API versions                    |
-| `with-log-level`               | Configures logger from CLI flag or env var                            |
-| `find-composio-core-generated` | Locates `@composio/core` in node_modules (handles pnpm virtual store) |
-| `version`                      | Resolves CLI version from package.json                                |
-| `compare-semver`               | Semantic version comparison for upgrade checks                        |
-| `log-metrics`                  | Formats and logs API request count and bytes transferred              |
-
-### Models (`src/models/`)
-
-Effect Schema definitions for type-safe serialization:
-
-- `Toolkit` — name, slug, auth_schemes, is_local_toolkit, meta
-- `Tool` — name, slug, available_versions, input/output_parameters, description, tags
-- `TriggerType` — slug, name, description, input/output parameters
-- `UserData` — apiKey, baseURL, webURL (with defaults)
-- `Session` — id, status (pending|linked), retrieved session with api_key
-
-Each model has `fromJSON`/`toJSON` helpers using `JSONTransformSchema()`.
-
-### Code Generation (`src/generation/`)
-
-Multi-stage pipeline for `composio generate ts` and `composio generate py`:
-
-1. **Fetch** — Toolkits, tools, trigger types from API (optionally filtered by `--toolkits`)
-2. **Index** — Groups tools/triggers by toolkit prefix into a `ToolkitIndex` map
-3. **Generate** — Builds TypeScript/Python source using `@composio/ts-builders` AST builders
-4. **Transpile** — Optionally converts TS → ESM JS (when writing to @composio/core/generated)
-
-Generated output includes toolkit objects, tool/trigger enums, and optionally full type definitions (with `--type-tools`).
-
-### Error Handling (`src/effect-errors/`)
-
-Custom error capture and formatting system:
-
-- **Capture** — Extracts error chain from Effect's `Cause`, handles interrupts separately
-- **Source maps** — Maps compiled `.mjs` stack traces back to TypeScript source
-- **Spans** — Extracts timing from Effect spans for execution timeline display
-- **Pretty print** — Colored, boxed error output with source context and suggestions
-
-### UI & Output (`src/ui/`)
-
-- `picocolors` and `ansis` for colored terminal output
-- Respects `NO_COLOR` env var
-- `@clack/prompts` symbols (`S_BAR`, `S_BAR_H`, `unicodeOr`) for box-drawing in formatted output
-- Effect's `Console.log()` / `Console.error()` for output
-
-### Configuration (`src/cli-config.ts`, `src/constants.ts`)
-
-- CLI behavior: `showBuiltIns: false`, `autoCorrectLimit: 0`, `isCaseSensitive: true`
-- Prefixes: `COMPOSIO_` for app config, `DEBUG_OVERRIDE_` for debug
-- User config stored in `~/.composio/`
-- Cache files: `toolkits.json`, `tools.json`, `tools-as-enums.json`, `trigger-types.json`
-
-### Effect.ts Patterns
-
-The CLI uses the generator-based syntax throughout:
-
-```typescript
-Effect.gen(function* () {
-  const service = yield* ServiceName; // resolve dependency
-  const result = yield* someEffect; // await computation
-  yield* Effect.log('message'); // side effect
-  return result;
-});
-```
-
-Key patterns:
-
-- `Effect.all([...], { concurrency: 'unbounded' })` for parallel fetches
-- `Layer.provide()` for dependency composition
-- `Effect.mapError()` / `Effect.catchTag()` for typed error handling
-- `Effect.scoped` for resource cleanup
-
-### Key Dependencies
-
-| Package                 | Role                                                                |
-| ----------------------- | ------------------------------------------------------------------- |
-| `effect`                | Core runtime, data types, concurrency                               |
-| `@effect/cli`           | Command, Options, Args declaration and parsing                      |
-| `@effect/platform`      | FileSystem, Terminal abstraction                                    |
-| `@effect/platform-bun`  | Bun runtime layer                                                   |
-| `@clack/prompts`        | Terminal UI — prompts, spinners, logs, notes (all output to stderr) |
-| `ansis`, `picocolors`   | Colored output                                                      |
-| `@composio/client`      | Raw Composio API client                                             |
-| `@composio/core`        | Core SDK types and constants                                        |
-| `@composio/ts-builders` | TypeScript AST code generation                                      |
-| `semver`                | Version comparison for upgrades                                     |
-| `open`                  | Opens URLs in browser (login flow)                                  |
-| `decompress`            | Extracts downloaded binaries                                        |
-
----
-
-## Output Conventions: Composable CLI Output
-
-The CLI follows the Unix convention of separating human-readable decoration from machine-readable data:
-
-- **stdout** — data output only (`ui.output()`). This is what scripts and pipes capture.
-- **stderr** — all decoration (Clack spinners, logs, notes, intro/outro). Visible in terminal, invisible in pipes.
-
-### Rules
-
-1. **All `TerminalUI` methods except `output()` write to stderr** via Clack's `{ output: process.stderr }` option — but only in interactive mode.
-2. **`ui.output(data)` writes to stdout only when piped** — it checks `process.stdout.isTTY` and is a no-op in interactive terminals (the human already sees the data via decoration on stderr).
-3. **When stdout is piped, ALL decoration is suppressed** — `isInteractive` (`process.stdout.isTTY`) gates every decoration method. Only `ui.output()` writes in piped mode. This keeps `composio whoami | pbcopy` completely silent.
-4. **Action commands** (logout, upgrade) produce no stdout data — their output is purely decorative.
-5. **Data commands** (whoami, version, login, generate) call both decoration (stderr) and `ui.output()` (stdout). In interactive mode, only decoration is visible. In pipes/scripts, only the raw data is captured.
-6. **Never write data to stderr** — decoration methods are for human context only.
-7. **Never write decoration to stdout** — it breaks pipes, `$(...)` captures, and `> file` redirects.
-
-### Pattern
-
-```typescript
-// Data command (e.g., whoami):
-yield * ui.note(apiKey, 'API Key'); // Decoration → stderr (human sees pretty box)
-yield * ui.output(apiKey); // Data → stdout (scripts capture plain value)
-
-// Action command (e.g., login):
-yield * ui.intro('composio login'); // Decoration → stderr
-yield * ui.log.step('Redirecting'); // Decoration → stderr
-// No ui.output() call — nothing for scripts to capture
-```
-
-### How it works in practice
-
-The CLI checks `process.stdout.isTTY` once at startup to determine the output mode:
-
-- **Interactive** (`stdout` is TTY): decoration visible on stderr, `ui.output()` is a no-op.
-- **Piped** (`stdout` is NOT TTY): decoration suppressed, `ui.output()` writes raw data to stdout.
+## Commands
 
 ```bash
-composio whoami              # Pretty box only (interactive)
-composio whoami | pbcopy     # Silent — clipboard gets clean key
-API_KEY=$(composio whoami)   # Silent — variable gets clean key
-composio whoami > file.txt   # Silent — file gets clean key
-
-composio version             # Decorated version (interactive)
-composio version | cat       # Raw version string
-
-composio login               # All decoration visible, browser opens
-composio login 2>/dev/null   # Silent (but still opens browser, polls API)
+pnpm cli <args>             # bun run src/bin.ts (dev)
+pnpm build                  # tsdown to dist/
+pnpm build:binary[:all]     # Bun binary → dist/composio (all = linux/darwin × x64/aarch64)
+pnpm install:binary         # install built binary locally
+pnpm test                   # validate:skills + vitest run
+pnpm typecheck              # tsgo --noEmit (REQUIRED before commit)
+pnpm typecheck:tsc          # fallback to stock tsc
+pnpm record                 # regenerate VHS recordings (recordings/recordings.yaml)
+pnpm validate:skills        # check skill bundle integrity
 ```
 
-### Adding new commands
+## Source layout (`src/`)
 
-When creating a new command, ask: "Does this command produce a value that scripts should capture?"
+`bin.ts` (entry, composes layers, `BunRuntime.runMain`), `cli-config.ts` (case-sensitive, no auto-correct, no built-ins), `cli-main.ts`, `commands/` (one folder/file per command), `services/` (`ComposioUserContext`, `ComposioSessionRepository`, `ComposioToolkitsRepository[+Cached]`, `UpgradeBinary`, `CliUserConfig` (keyring-backed), `EnvLangDetector`, `JsPackageManagerDetector`, `ProjectContext`, `NodeOs`, …), `effects/` (`app-config`, `debug-config`, `force-config`, `setup-cache-dir`, `toolkit-version-overrides`, `validate-toolkit-versions`, `find-composio-core-generated`, `version`, `compare-semver`), `generation/` (composio generate ts|py — fetch → index → build via `@composio/ts-builders` → transpile), `models/` (Effect Schema: Toolkit/Tool/TriggerType/UserData/Session), `effect-errors/`, `analytics/`, `ui/`.
 
-- **Yes** → Use `ui.output(value)` for the data, `ui.log.*` / `ui.note()` for context
-- **No** → Use only `ui.log.*` / `ui.note()` / `ui.intro()` / `ui.outro()` — everything goes to stderr automatically
+## Top-level commands
 
----
+`version`, `whoami`, `login`, `logout`, `signup`, `upgrade`, `init`, `install`, `dev`, `proxy`, `run`, `listen`, `artifacts`, `generate {ts|py}`, `agent {signup|login|whoami|inbox|claim}`, `config`, `connections list`, `connected-accounts ...`, `auth-configs ...`, `toolkits ...`, `tools ...`, `triggers ...`, `orgs ...`, `projects ...`, `logs ...`. Help verbosity: `-h` / `--help` / `--help-full`. `composio agent` is the unattended-agent auth path; `composio login` is the interactive browser flow.
 
-## Clack Reference Source
+API keys: keyring-backed via `@composio/cli-keyring` (migrated from plaintext). Cache files stay in `~/.composio/`: `toolkits.json`, `tools.json`, `tools-as-enums.json`, `trigger-types.json`.
 
-The CLI uses [`@clack/prompts`](https://github.com/bombshell-dev/clack) for interactive terminal UI (prompts, spinners, logs, etc.). A local copy of the Clack source code is available as a git submodule:
+## Output conventions (composable CLI)
 
-- **Location:** `ts/vendor/clack/`
-- **Repo:** [bombshell-dev/clack](https://github.com/bombshell-dev/clack)
+Unix split between data and decoration:
 
-When working on CLI code that involves terminal UI, reference the Clack source for accurate APIs and patterns:
+- **stdout** — data only via `ui.output(value)`. No-op when stdout is a TTY; writes raw value when piped.
+- **stderr** — all decoration: `ui.intro/outro/note/log.*`, Clack spinners. Suppressed when piped (gated on `process.stdout.isTTY`).
 
-- `ts/vendor/clack/packages/prompts/src/` — `@clack/prompts` (the high-level API used by this CLI)
-- `ts/vendor/clack/packages/core/src/` — `@clack/core` (low-level primitives underlying prompts)
+Rules: never write data to stderr; never write decoration to stdout. `composio whoami | pbcopy` must be silent and capture only the key. Action commands (logout, upgrade) produce no stdout. Data commands (whoami, version, login, generate) call both `ui.output()` and decoration helpers — only one is ever visible at a time.
 
-### Key modules in `@clack/prompts`
+## Effect.ts patterns
 
-| Module                  | Purpose                                                |
-| ----------------------- | ------------------------------------------------------ |
-| `text.ts`               | Text input prompt                                      |
-| `password.ts`           | Password input prompt                                  |
-| `confirm.ts`            | Yes/no confirmation prompt                             |
-| `select.ts`             | Single-select list prompt                              |
-| `multi-select.ts`       | Multi-select list prompt                               |
-| `group-multi-select.ts` | Grouped multi-select prompt                            |
-| `autocomplete.ts`       | Autocomplete/search prompt                             |
-| `spinner.ts`            | Loading spinner                                        |
-| `progress-bar.ts`       | Progress bar                                           |
-| `log.ts`                | Styled log messages                                    |
-| `note.ts`               | Boxed note output                                      |
-| `task.ts`               | Task runner with status                                |
-| `task-log.ts`           | Task with streaming log output                         |
-| `stream.ts`             | Streaming text output                                  |
-| `box.ts`                | Box drawing utility                                    |
-| `messages.ts`           | Intro/outro messages                                   |
-| `common.ts`             | Shared symbols (`S_BAR`, `S_BAR_H`, `unicodeOr`, etc.) |
+`Effect.gen(function* () { … yield* svc; yield* Effect.log(…) })`. Use `Effect.all([...], { concurrency: 'unbounded' })` for parallel fetches, `Layer.provide()` for composition, `Effect.mapError`/`catchTag` for typed errors, `Effect.scoped` for cleanup.
 
-### Current clack usage in the CLI
+## Vendored references (read-only)
 
-The CLI currently imports from `@clack/prompts`:
+- `ts/vendor/effect/packages/{effect,cli,platform}/src/` — Effect runtime, `@effect/cli`, `@effect/platform`
+- `ts/vendor/clack/packages/{prompts,core}/src/` — high-level prompts (`text`, `select`, `spinner`, …) + low-level primitives. CLI uses `S_BAR`, `S_BAR_H`, `unicodeOr` for box-drawing.
 
-- `S_BAR`, `S_BAR_H`, `unicodeOr` — Unicode box-drawing symbols for custom formatted output
+Never edit files under `ts/vendor/`; real deps come from npm.
 
-### Guidelines
+## VHS recordings
 
-- The submodule is for **read-only reference only**. Do not modify files in `ts/vendor/clack/`.
-- The CLI's actual dependency comes from npm (`@clack/prompts` v1.0.1) via `pnpm install`.
-- When adding new interactive prompts or terminal UI, consult the source in `ts/vendor/clack/packages/prompts/src/` for the correct API surface and available options.
-- Prefer `@clack/prompts` (high-level) over `@clack/core` (low-level) unless you need custom prompt behavior.
+New commands should ship a recording. Add to `recordings/recordings.yaml` (fields: `name`, `command`, `description`, `sleepAfterEnter`, `height` — use `dynamic` for long output). Run `bun scripts/record.ts` (needs `vhs` on PATH + `COMPOSIO_API_KEY`). Output: `recordings/{tapes,svgs,ascii}/<group>/<name>.{tape,svg,ascii}`.
 
----
+## Release workflow
 
-## Effect.ts Reference Source
+- **Beta (automatic)**: pushes to `next` touching `ts/packages/cli/**` trigger `.github/workflows/build-cli-binaries.yml` — bumps from latest stable `X.Y.Z` to `X.Y.(Z+1)-beta.<run_number>`, builds linux/darwin × x64/aarch64 binaries, publishes a GitHub prerelease. Users install with `composio upgrade --beta`. Manual from any branch: `workflow_dispatch` → `build-beta`.
+- **Stable (changeset-driven)**: open a Changeset PR (`.changeset/<name>.md` with `"@composio/cli": patch`), merge to `next`. The bot opens a "Release: update version" PR; merging it triggers a stable build (`@composio/cli@X.Y.Z`, `latest`) and `ts.release.yml` publishes to npm. Promote an existing beta via `workflow_dispatch` → `promote-stable` with the beta tag.
 
-The CLI is built on the Effect.ts ecosystem. A local copy of the Effect source code is available as a git submodule:
+Key workflows: `.github/workflows/build-cli-binaries.yml`, `ts.release.yml`, `cli.test-installation.yml`. Changeset config: `.changeset/config.json`.
 
-- **Location:** `ts/vendor/effect/`
-- **Repo:** [Effect-TS/effect](https://github.com/Effect-TS/effect)
-- **Branch:** `main`
+## CLI design guidelines
 
-When working on CLI code, reference the Effect source for accurate patterns:
-
-- `ts/vendor/effect/packages/effect/src/` — core Effect runtime
-- `ts/vendor/effect/packages/cli/src/` — @effect/cli (Command, Options, Args)
-- `ts/vendor/effect/packages/platform/src/` — @effect/platform (FileSystem, Terminal)
-
-### Guidelines
-
-- The submodule is for **read-only reference only**. Do not modify files in `ts/vendor/effect/`.
-- The CLI's actual dependencies come from npm via `pnpm install`.
-
----
-
-## CLI Design Guidelines
-
-For principles on how to design CLI interactions (arguments, flags, help text, output, errors, interactivity, config precedence), see:
-
-- **Cursor rules**: `ts/packages/cli/.cursor/rules/cli-design-guidelines.mdc`
-- **Claude skill**: `.claude/skills/create-cli/SKILL.md` (standalone, trimmed for Claude Code context)
-
-Use these guidelines when adding new commands, designing flag interfaces, or making UX decisions for the CLI.
-
----
-
-## Recording CLI Demos
-
-New commands should have VHS recordings for documentation. The recording script produces SVGs and asciicasts that demonstrate the CLI in action.
-
-### Adding Recordings
-
-1. Add entries to `recordings/recordings.yaml` under the appropriate group
-2. Run `bun scripts/record.ts` (requires `COMPOSIO_API_KEY` and `vhs` on PATH)
-
-### Recording Config
-
-Each entry in `recordings.yaml` accepts:
-
-| Field             | Required | Description                                                                             |
-| ----------------- | -------- | --------------------------------------------------------------------------------------- |
-| `name`            | Yes      | Filename stem (`<name>.svg`, `<name>.ascii`, `<name>.tape`)                             |
-| `command`         | Yes      | Shell command to record                                                                 |
-| `description`     | No       | Comment shown instantly above the command (via VHS `Hide`/`Show`)                       |
-| `sleepAfterEnter` | No       | Wait time after Enter (default: `6s` from `vhs.sleepAfterEnter`)                        |
-| `height`          | No       | `'dynamic'` for two-pass auto-sizing, or a fixed pixel number. Omit for default (750px) |
-
-Use `height: dynamic` for commands with long output (help text, full listings). The recorder probes with 2x height, parses the SVG to measure content, then re-records at the computed height (capped at `vhs.height * 2`).
-
-### Output Structure
-
-```
-recordings/
-├── recordings.yaml                    # Config
-├── tapes/<group>/<name>.tape          # Generated VHS tape files
-├── svgs/<group>/<name>.svg            # SVG recordings
-└── ascii/<group>/<name>.ascii         # Asciicast recordings
-```
-
-### Key Files
-
-- **Config**: `recordings/recordings.yaml`
-- **Script**: `scripts/record.ts` — Bun + Effect.ts, parallel VHS execution
-- **Shared tape**: `recordings/tapes/shared-config.tape` — common VHS settings (auto-generated)
-
----
-
-## Release Workflow
-
-CLI releases use a two-channel system: **beta** (automatic) and **stable** (manual promotion).
-
-### Beta Releases (automatic)
-
-Every push to `next` that touches `ts/packages/cli/**` automatically triggers `.github/workflows/build-cli-binaries.yml`, which:
-
-1. Finds the latest stable `@composio/cli@X.Y.Z` release
-2. Computes the next patch version (`X.Y.Z+1`)
-3. Builds cross-platform binaries (linux-x64, linux-aarch64, darwin-x64, darwin-aarch64)
-4. Creates a GitHub prerelease tagged `@composio/cli@X.Y.(Z+1)-beta.<run_number>`
-
-You can also trigger a beta build from **any branch** via `workflow_dispatch` → `build-beta`.
-
-Users install beta releases with `composio upgrade --beta`.
-
-### Stable Releases (via changeset)
-
-To promote to a stable release:
-
-1. Create a changeset PR (`.changeset/<name>.md` with `"@composio/cli": patch`)
-2. Merge it into `next`
-3. The changeset bot creates a "Release: update version" PR that bumps `package.json`
-4. Merge that PR → the push to `next` detects the `package.json` version changed → builds a **stable** release (`@composio/cli@X.Y.Z`, marked as `latest`)
-5. `ts.release.yml` also publishes to npm
-
-### Manual Promotion
-
-You can also promote an existing beta to stable via `workflow_dispatch` → `promote-stable` with the beta tag (e.g. `@composio/cli@0.2.20-beta.42`).
-
-### Key Files
-
-| File                                          | Purpose                          |
-| --------------------------------------------- | -------------------------------- |
-| `.github/workflows/build-cli-binaries.yml`    | Binary build + release workflow  |
-| `.github/workflows/ts.release.yml`            | Changeset bot + npm publish      |
-| `.github/workflows/cli.test-installation.yml` | Post-release install smoke tests |
-| `.changeset/config.json`                      | Changeset configuration          |
+`.cursor/rules/cli-design-guidelines.mdc` and `.claude/skills/create-cli/SKILL.md`.


### PR DESCRIPTION
# Description

Refresh the three stale CLAUDE.md files in the composio SDK monorepo so they match the current state of the codebase. Last touched 2026-02-18 / 02-19 / 04-21 — significant CLI command/structure churn (agent commands, keyring storage, multi-account, logs/connections/auth-configs subcommands, tsgo typecheck), provider package renaming, docs build script changes, and v3.1 API reference split since.

Scope is documentation-only; no source files modified.

# How did I test this PR

Verified each updated file is within the writing-guidelines target range:

| File | Before | After | Target |
|---|---|---|---|
| `CLAUDE.md` (root) | 403 | 111 | 60-150 |
| `docs/CLAUDE.md` | 107 | 55 | 30-70 |
| `ts/packages/cli/AGENTS.md` (CLAUDE.md is a symlink to it) | 379 | 66 | 30-70 |

- Spot-checked that all commands listed in the new docs exist in `package.json` / per-package `package.json` / `Makefile`.
- Confirmed every command/path referenced is present in the current tree (`ts/packages/cli/src/commands/`, `docs/scripts/`, `python/`, `ts/vendor/`).
- `prettier --write` ran via lint-staged on commit; no formatting drift remains.

Origin: cron-update-claude-docs / [zen-cron-0210c336dd13](https://zen-api-production-4c98.up.railway.app/dashboard/#/chat/zen-cron-0210c336dd13)
Triggered by: karan@composio.dev | Source: cron
Session: https://zen-api-production-4c98.up.railway.app/dashboard/#/chat/zen-cron-0210c336dd13