### PR TITLE
feat(cli): scaffold local tools package

### DIFF
--- a/.changeset/cli-local-tools.md
+++ b/.changeset/cli-local-tools.md
@@ -1,0 +1,6 @@
+---
+"@composio/cli": patch
+"@composio/cli-local-tools": patch
+---
+
+Scaffold bundled CLI local tools and wire them into CLI search/execute sessions.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "ts/packages/core",
     "ts/packages/json-schema-to-zod",
     "ts/packages/cli",
+    "ts/packages/cli-keyring",
+    "ts/packages/cli-local-tools",
     "ts/packages/providers/*"
   ],
   "scripts": {
@@ -53,6 +55,7 @@
     "@arethetypeswrong/cli": "catalog:",
     "@changesets/cli": "^2.29.8",
     "@composio/anthropic": "workspace:*",
+    "@composio/cli-local-tools": "workspace:*",
     "@composio/core": "workspace:*",
     "@composio/openai": "workspace:*",
     "@types/bun": "^1.3.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,9 @@ importers:
       '@composio/anthropic':
         specifier: workspace:*
         version: link:ts/packages/providers/anthropic
+      '@composio/cli-local-tools':
+        specifier: workspace:*
+        version: link:ts/packages/cli-local-tools
       '@composio/core':
         specifier: workspace:*
         version: link:ts/packages/core
@@ -1071,6 +1074,9 @@ importers:
       '@composio/cli-keyring':
         specifier: workspace:*
         version: link:../cli-keyring
+      '@composio/cli-local-tools':
+        specifier: workspace:*
+        version: link:../cli-local-tools
       '@composio/client':
         specifier: 'catalog:'
         version: 0.1.0-alpha.68
@@ -1195,6 +1201,31 @@ importers:
       effect:
         specifier: 'catalog:'
         version: 3.19.18
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.18.4(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260403.1)(publint@0.3.17)(typescript@5.9.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.4(@types/node@24.10.13)(@vitest/ui@3.2.4)(tsx@4.21.0)(yaml@2.8.2)
+
+  ts/packages/cli-local-tools:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.26.0
+        version: 1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
+      zod-to-json-schema:
+        specifier: 'catalog:'
+        version: 3.25.1(zod@4.3.6)
+    devDependencies:
+      '@types/node':
+        specifier: ^24.0.1
+        version: 24.10.13
       tsdown:
         specifier: 'catalog:'
         version: 0.18.4(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260403.1)(publint@0.3.17)(typescript@5.9.3)
@@ -8236,7 +8267,7 @@ snapshots:
       zod: 3.25.76
       zod-from-json-schema: 0.5.2
       zod-from-json-schema-v3: zod-from-json-schema@0.0.5
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
 
   '@mastra/schema-compat@1.1.0(zod@4.3.6)':
     dependencies:
@@ -8244,7 +8275,7 @@ snapshots:
       zod: 4.3.6
       zod-from-json-schema: 0.5.2
       zod-from-json-schema-v3: zod-from-json-schema@0.0.5
-      zod-to-json-schema: 3.25.1(zod@4.3.6)
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
 
   '@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,7 @@ packages:
   - ts/examples/*
   - ts/packages/cli
   - ts/packages/cli-keyring
+  - ts/packages/cli-local-tools
   - ts/packages/core
   - ts/packages/json-schema-to-zod
   - ts/packages/providers/*

--- a/ts/packages/cli-local-tools/package.json
+++ b/ts/packages/cli-local-tools/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@composio/cli-local-tools",
+  "version": "0.0.1",
+  "description": "Local tool and toolkit declarations for the Composio CLI.",
+  "type": "module",
+  "main": "dist/index.mjs",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.mts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      },
+      "default": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ComposioHQ/composio.git",
+    "directory": "ts/packages/cli-local-tools"
+  },
+  "license": "ISC",
+  "files": [
+    "dist"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "clean": "git clean -xdf node_modules",
+    "build": "pnpm exec tsdown",
+    "test": "vitest run",
+    "typecheck": "pnpm exec tsgo --noEmit -p ./tsconfig.src.json",
+    "typecheck:tsc": "tsc --noEmit -p ./tsconfig.src.json"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.26.0",
+    "zod": "catalog:",
+    "zod-to-json-schema": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.1",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/ts/packages/cli-local-tools/src/index.ts
+++ b/ts/packages/cli-local-tools/src/index.ts
@@ -1,0 +1,8 @@
+export * from './types';
+export * from './platform';
+export * from './meta';
+export * from './runtime';
+export * from './registry';
+export { beeperImessageToolkit } from './toolkits/beeper-imessage';
+export { chromeDevtoolsToolkit } from './toolkits/chrome-devtools';
+export { peekabooToolkit } from './toolkits/peekaboo';

--- a/ts/packages/cli-local-tools/src/meta.ts
+++ b/ts/packages/cli-local-tools/src/meta.ts
@@ -1,0 +1,158 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+export const LOCAL_TOOLS_META_VERSION = 1;
+
+export interface LocalToolMetaEntry {
+  readonly authenticated?: boolean;
+  readonly auth?: {
+    readonly type?: string;
+    readonly account?: string;
+    readonly env?: Record<string, string>;
+    readonly data?: Record<string, unknown>;
+  };
+  readonly installation?: {
+    /** Override the command/binary used by CLI-backed local tools. */
+    readonly command?: string;
+    readonly path?: string;
+    readonly version?: string;
+  };
+  readonly disabled?: boolean;
+  readonly notes?: string;
+  readonly updatedAt?: string;
+  readonly metadata?: Record<string, unknown>;
+}
+
+export type LocalToolkitMetaEntry = LocalToolMetaEntry;
+
+export interface LocalToolsMetaFile {
+  readonly version: number;
+  readonly updatedAt?: string;
+  readonly tools: Record<string, LocalToolMetaEntry>;
+  readonly toolkits: Record<string, LocalToolkitMetaEntry>;
+}
+
+export interface LocalToolsMetaOptions {
+  readonly homeDir?: string;
+  readonly path?: string;
+}
+
+export const getLocalToolsMetaPath = (options: LocalToolsMetaOptions = {}): string =>
+  options.path ?? path.join(options.homeDir ?? os.homedir(), 'composio', 'local_tools.json');
+
+export const createEmptyLocalToolsMeta = (): LocalToolsMetaFile => ({
+  version: LOCAL_TOOLS_META_VERSION,
+  tools: {},
+  toolkits: {},
+});
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const parseLocalToolsMeta = (raw: string): LocalToolsMetaFile => {
+  const parsed = JSON.parse(raw) as unknown;
+  if (!isRecord(parsed)) {
+    return createEmptyLocalToolsMeta();
+  }
+  return {
+    version: typeof parsed.version === 'number' ? parsed.version : LOCAL_TOOLS_META_VERSION,
+    updatedAt: typeof parsed.updatedAt === 'string' ? parsed.updatedAt : undefined,
+    tools: isRecord(parsed.tools)
+      ? (parsed.tools as Record<string, LocalToolMetaEntry>)
+      : {},
+    toolkits: isRecord(parsed.toolkits)
+      ? (parsed.toolkits as Record<string, LocalToolkitMetaEntry>)
+      : {},
+  };
+};
+
+export const readLocalToolsMeta = async (
+  options: LocalToolsMetaOptions = {}
+): Promise<LocalToolsMetaFile> => {
+  const filePath = getLocalToolsMetaPath(options);
+  try {
+    return parseLocalToolsMeta(await fs.readFile(filePath, 'utf8'));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return createEmptyLocalToolsMeta();
+    }
+    throw error;
+  }
+};
+
+export const writeLocalToolsMeta = async (
+  meta: LocalToolsMetaFile,
+  options: LocalToolsMetaOptions = {}
+): Promise<void> => {
+  const filePath = getLocalToolsMetaPath(options);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  const next: LocalToolsMetaFile = {
+    ...meta,
+    version: LOCAL_TOOLS_META_VERSION,
+    updatedAt: new Date().toISOString(),
+  };
+  await fs.writeFile(filePath, `${JSON.stringify(next, null, 2)}\n`, 'utf8');
+};
+
+export const getLocalToolMeta = async (
+  finalSlug: string,
+  options: LocalToolsMetaOptions = {}
+): Promise<LocalToolMetaEntry | undefined> => {
+  const meta = await readLocalToolsMeta(options);
+  return meta.tools[finalSlug.toUpperCase()] ?? meta.tools[finalSlug];
+};
+
+export const getLocalToolkitMeta = async (
+  toolkitSlug: string,
+  options: LocalToolsMetaOptions = {}
+): Promise<LocalToolkitMetaEntry | undefined> => {
+  const meta = await readLocalToolsMeta(options);
+  return meta.toolkits[toolkitSlug.toLowerCase()] ?? meta.toolkits[toolkitSlug];
+};
+
+export const updateLocalToolMeta = async (
+  finalSlug: string,
+  patch: LocalToolMetaEntry,
+  options: LocalToolsMetaOptions = {}
+): Promise<LocalToolsMetaFile> => {
+  const meta = await readLocalToolsMeta(options);
+  const key = finalSlug.toUpperCase();
+  const previous = meta.tools[key] ?? {};
+  const next: LocalToolsMetaFile = {
+    ...meta,
+    tools: {
+      ...meta.tools,
+      [key]: {
+        ...previous,
+        ...patch,
+        updatedAt: new Date().toISOString(),
+      },
+    },
+  };
+  await writeLocalToolsMeta(next, options);
+  return next;
+};
+
+export const updateLocalToolkitMeta = async (
+  toolkitSlug: string,
+  patch: LocalToolkitMetaEntry,
+  options: LocalToolsMetaOptions = {}
+): Promise<LocalToolsMetaFile> => {
+  const meta = await readLocalToolsMeta(options);
+  const key = toolkitSlug.toLowerCase();
+  const previous = meta.toolkits[key] ?? {};
+  const next: LocalToolsMetaFile = {
+    ...meta,
+    toolkits: {
+      ...meta.toolkits,
+      [key]: {
+        ...previous,
+        ...patch,
+        updatedAt: new Date().toISOString(),
+      },
+    },
+  };
+  await writeLocalToolsMeta(next, options);
+  return next;
+};

--- a/ts/packages/cli-local-tools/src/platform.ts
+++ b/ts/packages/cli-local-tools/src/platform.ts
@@ -1,0 +1,40 @@
+import type { LocalCliPlatform } from './types';
+
+export interface DetectPlatformInput {
+  readonly platform?: NodeJS.Platform;
+  readonly arch?: NodeJS.Architecture | string;
+}
+
+export const detectCliPlatform = (input: DetectPlatformInput = {}): LocalCliPlatform => {
+  const platform = input.platform ?? process.platform;
+  const arch = input.arch ?? process.arch;
+  if (platform === 'darwin') {
+    return arch === 'x64' ? 'darwin-x64' : 'darwin-arm64';
+  }
+  if (platform === 'linux') {
+    return arch === 'arm64' ? 'linux-arm64' : 'linux-x64';
+  }
+  if (platform === 'win32') {
+    return arch === 'arm64' ? 'win32-arm64' : 'win32-x64';
+  }
+  return 'all';
+};
+
+const platformFamily = (platform: LocalCliPlatform): LocalCliPlatform => {
+  if (platform.startsWith('darwin')) return 'darwin';
+  if (platform.startsWith('linux')) return 'linux';
+  if (platform.startsWith('win32')) return 'win32';
+  return platform;
+};
+
+export const supportsCliPlatform = (
+  supportedPlatforms: ReadonlyArray<LocalCliPlatform>,
+  currentPlatform: LocalCliPlatform = detectCliPlatform()
+): boolean => {
+  if (supportedPlatforms.includes('all')) return true;
+  if (supportedPlatforms.includes(currentPlatform)) return true;
+  return supportedPlatforms.includes(platformFamily(currentPlatform));
+};
+
+export const formatSupportedPlatforms = (platforms: ReadonlyArray<LocalCliPlatform>): string =>
+  platforms.includes('all') ? 'all CLI platforms' : platforms.join(', ');

--- a/ts/packages/cli-local-tools/src/registry.test.ts
+++ b/ts/packages/cli-local-tools/src/registry.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createLocalToolRouterExperimentalPayload,
+  getLocalToolkitDeclarations,
+  getLocalToolInputDefinition,
+  normalizeLocalToolSlug,
+} from './registry';
+
+const findToolkit = (payload: ReturnType<typeof createLocalToolRouterExperimentalPayload>, slug: string) =>
+  payload?.custom_toolkits?.find(toolkit => toolkit.slug === slug);
+
+describe('@composio/cli-local-tools registry', () => {
+  it('normalizes local tool slugs to the Tool Router LOCAL_<TOOLKIT>_<TOOL> shape', () => {
+    expect(normalizeLocalToolSlug('RUN_CLI', 'BEEPER_IMESSAGE')).toBe(
+      'LOCAL_BEEPER_IMESSAGE_RUN_CLI'
+    );
+  });
+
+  it('filters declarations by platform', () => {
+    expect(
+      getLocalToolkitDeclarations({ currentPlatform: 'linux-x64' }).map(toolkit => toolkit.slug)
+    ).toEqual(['CHROME_DEVTOOLS']);
+    expect(
+      getLocalToolkitDeclarations({ currentPlatform: 'darwin-arm64' }).map(toolkit => toolkit.slug)
+    ).toEqual(['BEEPER_IMESSAGE', 'CHROME_DEVTOOLS', 'PEEKABOO']);
+  });
+
+  it('builds Tool Router custom toolkit payloads for supported local toolkits', () => {
+    const payload = createLocalToolRouterExperimentalPayload({
+      currentPlatform: 'darwin-arm64',
+      toolkits: ['chrome_devtools'],
+    });
+
+    expect(payload?.custom_toolkits).toHaveLength(1);
+    expect(findToolkit(payload, 'CHROME_DEVTOOLS')?.tools.map(tool => tool.slug)).toEqual([
+      'LIST_TOOLS',
+      'CALL_TOOL',
+    ]);
+  });
+
+  it('exposes local input schemas for CLI --get-schema and dry-run validation', () => {
+    const definition = getLocalToolInputDefinition('LOCAL_BEEPER_IMESSAGE_RUN_CLI');
+    expect(definition?.version).toBe('local');
+    expect(definition?.schema.properties).toHaveProperty('args');
+  });
+});

--- a/ts/packages/cli-local-tools/src/registry.ts
+++ b/ts/packages/cli-local-tools/src/registry.ts
@@ -1,0 +1,249 @@
+import zodToJsonSchema from 'zod-to-json-schema';
+import type { z } from 'zod/v3';
+import { formatSupportedPlatforms, detectCliPlatform, supportsCliPlatform } from './platform';
+import { executeLocalTool } from './runtime';
+import type {
+  LocalCliPlatform,
+  LocalToolkitDeclaration,
+  LocalToolDeclaration,
+  LocalToolResolution,
+  LocalToolRouterExperimentalPayload,
+} from './types';
+import { beeperImessageToolkit } from './toolkits/beeper-imessage';
+import { chromeDevtoolsToolkit } from './toolkits/chrome-devtools';
+import { peekabooToolkit } from './toolkits/peekaboo';
+
+export const LOCAL_TOOL_PREFIX = 'LOCAL_';
+
+interface LocalCustomTool {
+  readonly slug: string;
+  readonly name: string;
+  readonly description: string;
+  readonly inputSchema: Record<string, unknown>;
+  readonly outputSchema?: Record<string, unknown>;
+}
+
+interface LocalCustomToolkit {
+  readonly slug: string;
+  readonly name: string;
+  readonly description: string;
+  readonly tools: ReadonlyArray<LocalCustomTool>;
+}
+
+export const localToolkitDeclarations: ReadonlyArray<LocalToolkitDeclaration> = [
+  beeperImessageToolkit,
+  chromeDevtoolsToolkit,
+  peekabooToolkit,
+];
+
+const normalizeSegment = (value: string): string =>
+  value
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+
+export const normalizeLocalToolSlug = (toolSlug: string, toolkitSlug?: string): string =>
+  toolkitSlug
+    ? `${LOCAL_TOOL_PREFIX}${normalizeSegment(toolkitSlug)}_${normalizeSegment(toolSlug)}`
+    : `${LOCAL_TOOL_PREFIX}${normalizeSegment(toolSlug)}`;
+
+const descriptionWithPlatform = (
+  description: string,
+  platforms: ReadonlyArray<LocalCliPlatform>
+): string => `${description}\n\nLocal CLI platforms: ${formatSupportedPlatforms(platforms)}.`;
+
+const zodObjectToJsonSchema = (schema: z.ZodTypeAny): Record<string, unknown> => {
+  const converted = zodToJsonSchema(schema, { name: 'input' }) as {
+    definitions?: { input?: Record<string, unknown> };
+  } & Record<string, unknown>;
+  const inputDefinition = converted.definitions?.input ?? converted;
+  return {
+    type: 'object',
+    properties:
+      inputDefinition.properties && typeof inputDefinition.properties === 'object'
+        ? (inputDefinition.properties as Record<string, unknown>)
+        : {},
+    ...(Array.isArray(inputDefinition.required) ? { required: inputDefinition.required } : {}),
+  };
+};
+
+const zodToOutputJsonSchema = (schema: z.ZodTypeAny): Record<string, unknown> => {
+  const converted = zodToJsonSchema(schema, { name: 'output' }) as {
+    definitions?: { output?: Record<string, unknown> };
+  } & Record<string, unknown>;
+  return converted.definitions?.output ?? converted;
+};
+
+const toCustomTool = (
+  toolkit: LocalToolkitDeclaration,
+  tool: LocalToolDeclaration
+): LocalCustomTool => ({
+  slug: tool.slug,
+  name: tool.name,
+  description: descriptionWithPlatform(tool.description, tool.platforms),
+  inputSchema: zodObjectToJsonSchema(tool.inputParams as z.ZodTypeAny),
+  ...(tool.outputParams ? { outputSchema: zodToOutputJsonSchema(tool.outputParams) } : {}),
+});
+
+const toCustomToolkit = (
+  toolkit: LocalToolkitDeclaration,
+  tools: ReadonlyArray<LocalCustomTool>
+): LocalCustomToolkit => ({
+  slug: toolkit.slug,
+  name: toolkit.name,
+  description: descriptionWithPlatform(toolkit.description, toolkit.platforms),
+  tools,
+});
+
+const toolkitMatchesFilter = (
+  toolkit: LocalToolkitDeclaration,
+  requestedToolkits?: ReadonlyArray<string>
+): boolean => {
+  if (!requestedToolkits || requestedToolkits.length === 0) return true;
+  const requested = new Set(requestedToolkits.map(slug => slug.toLowerCase()));
+  return requested.has(toolkit.slug.toLowerCase());
+};
+
+export const getAllLocalToolkitSlugs = (): ReadonlyArray<string> =>
+  localToolkitDeclarations.map(toolkit => toolkit.slug.toLowerCase());
+
+export const isLocalToolkitSlug = (toolkitSlug: string | undefined): boolean => {
+  if (!toolkitSlug) return false;
+  const lower = toolkitSlug.toLowerCase();
+  return getAllLocalToolkitSlugs().includes(lower);
+};
+
+export const isLocalToolSlug = (toolSlug: string): boolean => {
+  const upper = toolSlug.toUpperCase();
+  if (!upper.startsWith(LOCAL_TOOL_PREFIX)) return false;
+  return resolveLocalTool(toolSlug, { includeUnsupported: true }) !== null;
+};
+
+export const getLocalToolkitDeclarations = (options: {
+  readonly currentPlatform?: LocalCliPlatform;
+  readonly toolkits?: ReadonlyArray<string>;
+} = {}): ReadonlyArray<LocalToolkitDeclaration> => {
+  const currentPlatform = options.currentPlatform ?? detectCliPlatform();
+  return localToolkitDeclarations
+    .filter(toolkit => toolkitMatchesFilter(toolkit, options.toolkits))
+    .filter(toolkit => supportsCliPlatform(toolkit.platforms, currentPlatform))
+    .map(toolkit => ({
+      ...toolkit,
+      tools: toolkit.tools.filter(tool => supportsCliPlatform(tool.platforms, currentPlatform)),
+    }))
+    .filter(toolkit => toolkit.tools.length > 0);
+};
+
+export const getLocalCustomToolkits = (options: {
+  readonly currentPlatform?: LocalCliPlatform;
+  readonly toolkits?: ReadonlyArray<string>;
+} = {}): ReadonlyArray<LocalCustomToolkit> =>
+  getLocalToolkitDeclarations(options).map(toolkit =>
+    toCustomToolkit(
+      toolkit,
+      toolkit.tools.map(tool => toCustomTool(toolkit, tool))
+    )
+  );
+
+const customToolkitToPayload = (
+  toolkit: LocalCustomToolkit
+): NonNullable<LocalToolRouterExperimentalPayload['custom_toolkits']>[number] => ({
+  slug: toolkit.slug,
+  name: toolkit.name,
+  description: toolkit.description,
+  tools: toolkit.tools.map(tool => ({
+    slug: tool.slug,
+    name: tool.name,
+    description: tool.description,
+    input_schema: tool.inputSchema,
+    ...(tool.outputSchema ? { output_schema: tool.outputSchema } : {}),
+  })),
+});
+
+export const createLocalToolRouterExperimentalPayload = (options: {
+  readonly currentPlatform?: LocalCliPlatform;
+  readonly toolkits?: ReadonlyArray<string>;
+} = {}): LocalToolRouterExperimentalPayload | undefined => {
+  const customToolkits = getLocalCustomToolkits(options).map(customToolkitToPayload);
+  if (customToolkits.length === 0) return undefined;
+  return { custom_toolkits: customToolkits };
+};
+
+export const resolveLocalTool = (
+  slug: string,
+  options: {
+    readonly currentPlatform?: LocalCliPlatform;
+    readonly includeUnsupported?: boolean;
+  } = {}
+): LocalToolResolution | null => {
+  const currentPlatform = options.currentPlatform ?? detectCliPlatform();
+  const target = normalizeSegment(slug);
+
+  for (const toolkit of localToolkitDeclarations) {
+    for (const tool of toolkit.tools) {
+      const finalSlug = normalizeLocalToolSlug(tool.slug, toolkit.slug);
+      const matches =
+        normalizeSegment(finalSlug) === target ||
+        normalizeSegment(tool.slug) === target ||
+        normalizeSegment(`${toolkit.slug}_${tool.slug}`) === target;
+      if (!matches) continue;
+
+      const supported =
+        supportsCliPlatform(toolkit.platforms, currentPlatform) &&
+        supportsCliPlatform(tool.platforms, currentPlatform);
+      if (!supported && !options.includeUnsupported) return null;
+      return { toolkit, tool, finalSlug, supported, currentPlatform };
+    }
+  }
+
+  return null;
+};
+
+export const getLocalToolInputDefinition = (
+  slug: string
+):
+  | {
+      readonly finalSlug: string;
+      readonly toolkit: string;
+      readonly schema: Record<string, unknown>;
+      readonly version: 'local';
+    }
+  | null => {
+  const resolution = resolveLocalTool(slug, { includeUnsupported: true });
+  if (!resolution) return null;
+  return {
+    finalSlug: resolution.finalSlug,
+    toolkit: resolution.toolkit.slug,
+    schema: toCustomTool(resolution.toolkit, resolution.tool).inputSchema,
+    version: 'local',
+  };
+};
+
+export const executeLocalToolBySlug = async (
+  slug: string,
+  args: Record<string, unknown>
+): Promise<Record<string, unknown> | null> => {
+  const resolution = resolveLocalTool(slug, { includeUnsupported: true });
+  if (!resolution) return null;
+  if (!resolution.supported) {
+    throw new Error(
+      `Local tool ${resolution.finalSlug} is not supported on ${resolution.currentPlatform}. Supported platforms: ${formatSupportedPlatforms(resolution.tool.platforms)}.`
+    );
+  }
+
+  const parsed = resolution.tool.inputParams.safeParse(args);
+  if (!parsed.success) {
+    throw new Error(
+      `Invalid arguments for local tool ${resolution.finalSlug}: ${parsed.error.issues
+        .map(issue => `${issue.path.join('.') || '<root>'}: ${issue.message}`)
+        .join('; ')}`
+    );
+  }
+
+  return executeLocalTool(resolution.tool.execution, parsed.data as Record<string, unknown>, {
+    toolkit: resolution.toolkit,
+    tool: resolution.tool,
+    finalSlug: resolution.finalSlug,
+    platform: resolution.currentPlatform,
+  });
+};

--- a/ts/packages/cli-local-tools/src/runtime.ts
+++ b/ts/packages/cli-local-tools/src/runtime.ts
@@ -1,0 +1,194 @@
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import type {
+  LocalCommandExecution,
+  LocalCommandInvocation,
+  LocalExecutionContext,
+  LocalExecutionResult,
+  LocalFfiExecution,
+  LocalMcpExecution,
+  LocalToolExecution,
+} from './types';
+import { getLocalToolkitMeta, getLocalToolMeta } from './meta';
+
+const toErrorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+const compactEnv = (env: Record<string, string | undefined> | undefined): Record<string, string> =>
+  Object.fromEntries(
+    Object.entries(env ?? {}).filter((entry): entry is [string, string] => entry[1] !== undefined)
+  );
+
+const resolveValue = <T>(value: T | ((input: Record<string, unknown>) => T), input: Record<string, unknown>): T =>
+  typeof value === 'function' ? (value as (input: Record<string, unknown>) => T)(input) : value;
+
+const parseJsonIfRequested = (stdout: string, parseJson: boolean): unknown => {
+  if (!parseJson || stdout.trim().length === 0) return stdout;
+  try {
+    return JSON.parse(stdout) as unknown;
+  } catch {
+    return stdout;
+  }
+};
+
+const resolveCommandInvocation = async (
+  execution: LocalCommandExecution,
+  input: Record<string, unknown>,
+  context: LocalExecutionContext
+): Promise<LocalCommandInvocation> => {
+  const commandValue = resolveValue(execution.command, input);
+  const baseInvocation: LocalCommandInvocation =
+    typeof commandValue === 'string' ? { command: commandValue } : commandValue;
+
+  const toolMeta = await getLocalToolMeta(context.finalSlug);
+  const toolkitMeta = await getLocalToolkitMeta(context.toolkit.slug);
+  const commandOverride = toolMeta?.installation?.command ?? toolkitMeta?.installation?.command;
+
+  return {
+    ...baseInvocation,
+    command: commandOverride ?? baseInvocation.command,
+    args: baseInvocation.args ?? (execution.args ? resolveValue(execution.args, input) : []),
+    env: {
+      ...compactEnv(execution.env ? resolveValue(execution.env, input) : undefined),
+      ...compactEnv(baseInvocation.env),
+    },
+    cwd: baseInvocation.cwd ?? (execution.cwd ? resolveValue(execution.cwd, input) : undefined),
+    stdin: baseInvocation.stdin ?? (execution.stdin ? resolveValue(execution.stdin, input) : undefined),
+    timeoutMs: baseInvocation.timeoutMs ?? execution.timeoutMs,
+  };
+};
+
+export const runLocalCommand = async (
+  execution: LocalCommandExecution,
+  input: Record<string, unknown>,
+  context: LocalExecutionContext
+): Promise<LocalExecutionResult> => {
+  const invocation = await resolveCommandInvocation(execution, input, context);
+  const child = spawn(invocation.command, [...(invocation.args ?? [])], {
+    cwd: invocation.cwd,
+    env: { ...process.env, ...compactEnv(invocation.env) },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  let stdout = '';
+  let stderr = '';
+  child.stdout.setEncoding('utf8');
+  child.stderr.setEncoding('utf8');
+  child.stdout.on('data', chunk => {
+    stdout += chunk;
+  });
+  child.stderr.on('data', chunk => {
+    stderr += chunk;
+  });
+
+  if (invocation.stdin !== undefined) {
+    child.stdin.end(invocation.stdin);
+  } else {
+    child.stdin.end();
+  }
+
+  let timeout: NodeJS.Timeout | undefined;
+  if (invocation.timeoutMs && invocation.timeoutMs > 0) {
+    timeout = setTimeout(() => child.kill('SIGTERM'), invocation.timeoutMs);
+  }
+
+  const exitPromise = once(child, 'exit') as Promise<[number | null, NodeJS.Signals | null]>;
+  const errorPromise = once(child, 'error').then(([error]) => {
+    throw error;
+  }) as Promise<[number | null, NodeJS.Signals | null]>;
+  const [exitCode, signal] = await Promise.race([exitPromise, errorPromise]);
+  if (timeout) clearTimeout(timeout);
+
+  if (exitCode !== 0) {
+    throw new Error(
+      [
+        `Local command failed for ${context.finalSlug}: ${invocation.command} ${(invocation.args ?? []).join(' ')}`,
+        `exitCode=${exitCode ?? 'null'} signal=${signal ?? 'null'}`,
+        stderr.trim() ? `stderr: ${stderr.trim()}` : undefined,
+      ]
+        .filter(Boolean)
+        .join('\n')
+    );
+  }
+
+  return {
+    command: invocation.command,
+    args: invocation.args ?? [],
+    stdout,
+    stderr,
+    exitCode,
+    parsed: parseJsonIfRequested(stdout, execution.parseJson ?? false),
+  };
+};
+
+export const runLocalMcpTool = async (
+  execution: LocalMcpExecution,
+  input: Record<string, unknown>
+): Promise<LocalExecutionResult> => {
+  const [{ Client }, { StdioClientTransport }] = await Promise.all([
+    import('@modelcontextprotocol/sdk/client/index.js'),
+    import('@modelcontextprotocol/sdk/client/stdio.js'),
+  ]);
+
+  const server = typeof execution.server === 'function' ? execution.server(input) : execution.server;
+  const client = new Client({ name: 'composio-cli-local-tools', version: '0.0.1' });
+  const transport = new StdioClientTransport({
+    command: server.command,
+    args: [...(server.args ?? [])],
+    env: { ...compactEnv(process.env), ...compactEnv(server.env) },
+    cwd: server.cwd,
+  });
+
+  await client.connect(transport);
+  try {
+    const toolName = execution.toolName
+      ? typeof execution.toolName === 'function'
+        ? execution.toolName(input)
+        : execution.toolName
+      : undefined;
+
+    if (!toolName) {
+      const result = await client.listTools();
+      return { tools: result.tools };
+    }
+
+    const args = execution.arguments
+      ? typeof execution.arguments === 'function'
+        ? execution.arguments(input)
+        : execution.arguments
+      : input;
+    const result = await client.callTool({ name: toolName, arguments: args });
+    return { toolName, result: result as unknown as Record<string, unknown> };
+  } finally {
+    await client.close().catch(() => undefined);
+  }
+};
+
+const runLocalFfiTool = async (execution: LocalFfiExecution): Promise<LocalExecutionResult> => {
+  throw new Error(
+    `Local FFI execution is not implemented yet (library=${execution.library}, symbol=${execution.symbol}).`
+  );
+};
+
+export const executeLocalTool = async (
+  execution: LocalToolExecution,
+  input: Record<string, unknown>,
+  context: LocalExecutionContext
+): Promise<LocalExecutionResult> => {
+  try {
+    if (execution.kind === 'native') {
+      return await execution.execute(input, context);
+    }
+    if (execution.kind === 'command') {
+      return await runLocalCommand(execution, input, context);
+    }
+    if (execution.kind === 'mcp') {
+      return await runLocalMcpTool(execution, input);
+    }
+    return await runLocalFfiTool(execution);
+  } catch (error) {
+    throw new Error(`Failed to execute local tool ${context.finalSlug}: ${toErrorMessage(error)}`, {
+      cause: error,
+    });
+  }
+};

--- a/ts/packages/cli-local-tools/src/toolkits/beeper-imessage.ts
+++ b/ts/packages/cli-local-tools/src/toolkits/beeper-imessage.ts
@@ -1,0 +1,56 @@
+import { z } from 'zod/v3';
+import type { LocalToolkitDeclaration } from '../types';
+
+const darwin = ['darwin-arm64', 'darwin-x64'] as const;
+
+const beeperCommand = () => process.env.COMPOSIO_BEEPER_IMESSAGE_CLI ?? 'imessage';
+
+export const beeperImessageToolkit: LocalToolkitDeclaration = {
+  slug: 'BEEPER_IMESSAGE',
+  name: 'Beeper iMessage',
+  description:
+    'Local macOS iMessage automation via a Beeper platform-imessage CLI build. The binary can be overridden with COMPOSIO_BEEPER_IMESSAGE_CLI or ~/composio/local_tools.json.',
+  platforms: darwin,
+  source: {
+    type: 'cli',
+    repository: 'https://github.com/beeper/platform-imessage',
+    command: 'imessage',
+  },
+  tools: [
+    {
+      slug: 'SEND_MESSAGE',
+      name: 'Send iMessage',
+      description:
+        'Draft mapping for sending an iMessage through the local Beeper/platform-imessage CLI. Override the binary or use RUN_CLI if your local build exposes different subcommands.',
+      platforms: darwin,
+      inputParams: z.object({
+        recipient: z.string().describe('Phone number, email, handle, or chat identifier to send to.'),
+        text: z.string().describe('Message body.'),
+      }),
+      execution: {
+        kind: 'command',
+        command: beeperCommand,
+        args: input => ['send', String(input.recipient), String(input.text)],
+        parseJson: true,
+      },
+    },
+    {
+      slug: 'RUN_CLI',
+      name: 'Run Beeper iMessage CLI',
+      description:
+        'Run the local Beeper/platform-imessage CLI directly. Use this for platform-imessage functionality that has not been mapped to a first-class Composio local tool yet.',
+      platforms: darwin,
+      inputParams: z.object({
+        args: z.array(z.string()).describe('Arguments to pass to the iMessage CLI binary.'),
+        stdin: z.string().optional().describe('Optional stdin to send to the process.'),
+      }),
+      execution: {
+        kind: 'command',
+        command: beeperCommand,
+        args: input => (Array.isArray(input.args) ? input.args.map(String) : []),
+        stdin: input => (typeof input.stdin === 'string' ? input.stdin : undefined),
+        parseJson: true,
+      },
+    },
+  ],
+};

--- a/ts/packages/cli-local-tools/src/toolkits/chrome-devtools.ts
+++ b/ts/packages/cli-local-tools/src/toolkits/chrome-devtools.ts
@@ -1,0 +1,58 @@
+import { z } from 'zod/v3';
+import type { LocalToolkitDeclaration } from '../types';
+
+const all = ['all'] as const;
+
+const chromeDevtoolsServer = {
+  command: process.env.COMPOSIO_CHROME_DEVTOOLS_MCP_COMMAND ?? 'npx',
+  args: process.env.COMPOSIO_CHROME_DEVTOOLS_MCP_COMMAND
+    ? []
+    : ['-y', 'chrome-devtools-mcp@latest', '--autoConnect'],
+};
+
+export const chromeDevtoolsToolkit: LocalToolkitDeclaration = {
+  slug: 'CHROME_DEVTOOLS',
+  name: 'Chrome DevTools MCP',
+  description:
+    'Local Chrome/CDP automation through chrome-devtools-mcp@latest --autoConnect. Requires Node/npm and a reachable Chrome instance.',
+  platforms: all,
+  source: {
+    type: 'mcp',
+    package: 'chrome-devtools-mcp@latest',
+    command: 'npx -y chrome-devtools-mcp@latest --autoConnect',
+  },
+  tools: [
+    {
+      slug: 'LIST_TOOLS',
+      name: 'List Chrome DevTools MCP Tools',
+      description:
+        'Start chrome-devtools-mcp and list the MCP tools available for Chrome/CDP automation.',
+      platforms: all,
+      inputParams: z.object({}),
+      execution: {
+        kind: 'mcp',
+        server: chromeDevtoolsServer,
+      },
+    },
+    {
+      slug: 'CALL_TOOL',
+      name: 'Call Chrome DevTools MCP Tool',
+      description:
+        'Call any tool exposed by chrome-devtools-mcp. Use LIST_TOOLS first when you need exact MCP tool names and input shapes.',
+      platforms: all,
+      inputParams: z.object({
+        toolName: z.string().describe('MCP tool name to call, for example navigate_page or evaluate_script.'),
+        arguments: z.record(z.unknown()).default({}).describe('Arguments for the selected MCP tool.'),
+      }),
+      execution: {
+        kind: 'mcp',
+        server: chromeDevtoolsServer,
+        toolName: input => (typeof input.toolName === 'string' ? input.toolName : undefined),
+        arguments: input =>
+          input.arguments && typeof input.arguments === 'object' && !Array.isArray(input.arguments)
+            ? (input.arguments as Record<string, unknown>)
+            : {},
+      },
+    },
+  ],
+};

--- a/ts/packages/cli-local-tools/src/toolkits/peekaboo.ts
+++ b/ts/packages/cli-local-tools/src/toolkits/peekaboo.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod/v3';
+import type { LocalToolkitDeclaration } from '../types';
+
+const darwin = ['darwin-arm64', 'darwin-x64'] as const;
+
+const peekabooCommand = () => process.env.COMPOSIO_PEEKABOO_CLI ?? 'peekaboo';
+
+export const peekabooToolkit: LocalToolkitDeclaration = {
+  slug: 'PEEKABOO',
+  name: 'Peekaboo',
+  description:
+    'Local macOS screen, app, and accessibility automation via the Peekaboo CLI by steipete. The binary can be overridden with COMPOSIO_PEEKABOO_CLI or ~/composio/local_tools.json.',
+  platforms: darwin,
+  source: {
+    type: 'cli',
+    repository: 'https://github.com/steipete/Peekaboo',
+    command: 'peekaboo',
+  },
+  tools: [
+    {
+      slug: 'RUN_CLI',
+      name: 'Run Peekaboo CLI',
+      description:
+        'Run the Peekaboo CLI directly for screenshots, app/window inspection, accessibility tree inspection, clicks, typing, and other macOS UI automation workflows.',
+      platforms: darwin,
+      inputParams: z.object({
+        args: z.array(z.string()).describe('Arguments to pass to the Peekaboo CLI binary.'),
+        stdin: z.string().optional().describe('Optional stdin to send to the process.'),
+      }),
+      execution: {
+        kind: 'command',
+        command: peekabooCommand,
+        args: input => (Array.isArray(input.args) ? input.args.map(String) : []),
+        stdin: input => (typeof input.stdin === 'string' ? input.stdin : undefined),
+        parseJson: true,
+      },
+    },
+    {
+      slug: 'HELP',
+      name: 'Peekaboo CLI Help',
+      description:
+        'Print Peekaboo CLI help so an agent can inspect the installed command surface before calling RUN_CLI.',
+      platforms: darwin,
+      inputParams: z.object({}),
+      execution: {
+        kind: 'command',
+        command: peekabooCommand,
+        args: ['--help'],
+      },
+    },
+  ],
+};

--- a/ts/packages/cli-local-tools/src/types.ts
+++ b/ts/packages/cli-local-tools/src/types.ts
@@ -1,0 +1,133 @@
+import type { z } from 'zod/v3';
+
+export type LocalCliPlatform =
+  | 'all'
+  | 'darwin'
+  | 'linux'
+  | 'win32'
+  | 'darwin-arm64'
+  | 'darwin-x64'
+  | 'linux-arm64'
+  | 'linux-x64'
+  | 'win32-arm64'
+  | 'win32-x64';
+
+export type LocalExecutionResult = Record<string, unknown>;
+
+export interface LocalExecutionContext {
+  readonly toolkit: LocalToolkitDeclaration;
+  readonly tool: LocalToolDeclaration;
+  readonly finalSlug: string;
+  readonly platform: LocalCliPlatform;
+}
+
+export interface LocalCommandInvocation {
+  readonly command: string;
+  readonly args?: ReadonlyArray<string>;
+  readonly env?: Record<string, string | undefined>;
+  readonly cwd?: string;
+  readonly stdin?: string;
+  readonly timeoutMs?: number;
+}
+
+export interface LocalCommandExecution {
+  readonly kind: 'command';
+  readonly command: string | ((input: Record<string, unknown>) => string | LocalCommandInvocation);
+  readonly args?:
+    | ReadonlyArray<string>
+    | ((input: Record<string, unknown>) => ReadonlyArray<string>);
+  readonly env?:
+    | Record<string, string | undefined>
+    | ((input: Record<string, unknown>) => Record<string, string | undefined>);
+  readonly cwd?: string | ((input: Record<string, unknown>) => string | undefined);
+  readonly stdin?: string | ((input: Record<string, unknown>) => string | undefined);
+  readonly timeoutMs?: number;
+  /** Parse stdout as JSON when possible. Defaults to false. */
+  readonly parseJson?: boolean;
+}
+
+export interface LocalNativeExecution {
+  readonly kind: 'native';
+  readonly execute: (
+    input: Record<string, unknown>,
+    context: LocalExecutionContext
+  ) => Promise<LocalExecutionResult> | LocalExecutionResult;
+}
+
+export interface LocalMcpServerSpec {
+  readonly command: string;
+  readonly args?: ReadonlyArray<string>;
+  readonly env?: Record<string, string | undefined>;
+  readonly cwd?: string;
+}
+
+export interface LocalMcpExecution {
+  readonly kind: 'mcp';
+  readonly server: LocalMcpServerSpec | ((input: Record<string, unknown>) => LocalMcpServerSpec);
+  /** Tool name to call. If omitted, the wrapper returns `listTools()`. */
+  readonly toolName?: string | ((input: Record<string, unknown>) => string | undefined);
+  readonly arguments?:
+    | Record<string, unknown>
+    | ((input: Record<string, unknown>) => Record<string, unknown>);
+}
+
+export interface LocalFfiExecution {
+  readonly kind: 'ffi';
+  readonly library: string;
+  readonly symbol: string;
+  readonly abi?: string;
+}
+
+export type LocalToolExecution =
+  | LocalCommandExecution
+  | LocalNativeExecution
+  | LocalMcpExecution
+  | LocalFfiExecution;
+
+export interface LocalToolDeclaration<TInput extends z.ZodTypeAny = z.ZodTypeAny> {
+  readonly slug: string;
+  readonly name: string;
+  readonly description: string;
+  readonly inputParams: TInput;
+  readonly outputParams?: z.ZodTypeAny;
+  readonly platforms: ReadonlyArray<LocalCliPlatform>;
+  readonly execution: LocalToolExecution;
+  readonly tags?: ReadonlyArray<string>;
+}
+
+export interface LocalToolkitDeclaration {
+  readonly slug: string;
+  readonly name: string;
+  readonly description: string;
+  readonly platforms: ReadonlyArray<LocalCliPlatform>;
+  readonly tools: ReadonlyArray<LocalToolDeclaration>;
+  readonly source?: {
+    readonly type: 'cli' | 'mcp' | 'native' | 'ffi';
+    readonly package?: string;
+    readonly repository?: string;
+    readonly command?: string;
+  };
+}
+
+export interface LocalToolResolution {
+  readonly toolkit: LocalToolkitDeclaration;
+  readonly tool: LocalToolDeclaration;
+  readonly finalSlug: string;
+  readonly supported: boolean;
+  readonly currentPlatform: LocalCliPlatform;
+}
+
+export type LocalToolRouterExperimentalPayload = {
+  custom_toolkits?: Array<{
+    slug: string;
+    name: string;
+    description: string;
+    tools: Array<{
+      slug: string;
+      name: string;
+      description: string;
+      input_schema: Record<string, unknown>;
+      output_schema?: Record<string, unknown>;
+    }>;
+  }>;
+};

--- a/ts/packages/cli-local-tools/tsconfig.json
+++ b/ts/packages/cli-local-tools/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.src.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "dist"]
+}

--- a/ts/packages/cli-local-tools/tsconfig.options.json
+++ b/ts/packages/cli-local-tools/tsconfig.options.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "verbatimModuleSyntax": true,
+    "pretty": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["**/dist", "test/__fixtures__/**"]
+}

--- a/ts/packages/cli-local-tools/tsconfig.src.json
+++ b/ts/packages/cli-local-tools/tsconfig.src.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.options.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": ".",
+    "paths": {
+      "src/*": ["./src/*"]
+    }
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/ts/packages/cli-local-tools/tsdown.config.ts
+++ b/ts/packages/cli-local-tools/tsdown.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'tsdown';
+import { baseConfig } from '../../../tsdown.config.base.ts';
+
+export default defineConfig({
+  ...baseConfig,
+  tsconfig: 'tsconfig.src.json',
+});

--- a/ts/packages/cli/package.json
+++ b/ts/packages/cli/package.json
@@ -78,6 +78,7 @@
     "@clack/core": "catalog:",
     "@clack/prompts": "catalog:",
     "@composio/cli-keyring": "workspace:*",
+    "@composio/cli-local-tools": "workspace:*",
     "@composio/client": "catalog:",
     "@composio/core": "workspace:*",
     "@composio/json-schema-to-zod": "workspace:*",

--- a/ts/packages/cli/src/commands/tools/commands/tools.execute.cmd.ts
+++ b/ts/packages/cli/src/commands/tools/commands/tools.execute.cmd.ts
@@ -1,5 +1,6 @@
 import { Args, Command, Options } from '@effect/cli';
 import type { Composio } from '@composio/client';
+import { isLocalToolSlug } from '@composio/cli-local-tools';
 import util from 'node:util';
 import { Effect, Option, Either, Exit, Fiber, Cause } from 'effect';
 import { encodingForModel } from 'js-tiktoken';
@@ -1017,7 +1018,7 @@ const resolveExecuteContext = (params: RunToolsExecuteParams) =>
     )
       ? params.account
       : Option.none<string>();
-    const toolkitSlug = toolkitFromToolSlug(params.slug);
+    const toolkitSlug = isLocalToolSlug(params.slug) ? undefined : toolkitFromToolSlug(params.slug);
     const selectedConnectedAccountId = yield* resolveExplicitConnectedAccount({
       client,
       toolkitSlug,
@@ -1111,6 +1112,7 @@ const runConnectedToolkitFailFast = (params: {
       return;
     }
     if (params.resolvedProject.projectType !== 'CONSUMER') return;
+    if (isLocalToolSlug(params.slug)) return;
 
     perfDebugLog('execute.connected_toolkits.refresh_start', {
       slug: params.slug,
@@ -1697,6 +1699,7 @@ const checkConnectedToolkitOrFail = (params: {
   Effect.gen(function* () {
     if (params.skipConnectionCheck || params.skipChecks) return;
     if (params.resolvedProject.projectType !== 'CONSUMER') return;
+    if (isLocalToolSlug(params.slug)) return;
 
     yield* refreshConsumerConnectedToolkitsCache({
       orgId: params.resolvedProject.orgId,

--- a/ts/packages/cli/src/commands/tools/commands/tools.search.cmd.ts
+++ b/ts/packages/cli/src/commands/tools/commands/tools.search.cmd.ts
@@ -1,4 +1,5 @@
 import { Args, Command, Options } from '@effect/cli';
+import { isLocalToolkitSlug } from '@composio/cli-local-tools';
 import { Effect, Option } from 'effect';
 import { TerminalUI } from 'src/services/terminal-ui';
 import { requireAuth } from 'src/effects/require-auth';
@@ -153,7 +154,7 @@ const buildSearchNextSteps = (params: {
   rootOnly: boolean;
 }) => {
   const steps: Array<{ action: string; command: string }> = [];
-  if (params.firstToolkit) {
+  if (params.firstToolkit && !isLocalToolkitSlug(params.firstToolkit)) {
     steps.push({
       action: 'Link a user account',
       command: params.rootOnly
@@ -282,7 +283,8 @@ const emitHumanSearchOutput = (params: {
             userId: '<user-id>',
             data: params.firstDataArg,
           });
-      yield* params.ui.log.step([linkHint, executeHint].join('\n'));
+      const steps = params.firstSlug.startsWith('LOCAL_') ? [executeHint] : [linkHint, executeHint];
+      yield* params.ui.log.step(steps.join('\n'));
     }
 
     if (params.error) {

--- a/ts/packages/cli/src/effects/create-tool-router-session.ts
+++ b/ts/packages/cli/src/effects/create-tool-router-session.ts
@@ -1,6 +1,10 @@
 import { Effect, Option } from 'effect';
 import type { Composio } from '@composio/client';
 import {
+  createLocalToolRouterExperimentalPayload,
+  getAllLocalToolkitSlugs,
+} from '@composio/cli-local-tools';
+import {
   getFreshConsumerToolRouterAuthConfigsFromCache,
   getFreshConsumerToolRouterConnectedAccountsFromCache,
   writeConsumerConnectedToolkitsCache,
@@ -27,6 +31,10 @@ export interface CreateToolRouterSessionOptions {
     readonly maxAccountsPerToolkit?: number;
     readonly requireExplicitSelection?: boolean;
   };
+  /** Include bundled local CLI toolkits as Tool Router custom toolkits. Default: true. */
+  readonly localTools?: {
+    readonly enable?: boolean;
+  };
 }
 
 /**
@@ -47,6 +55,22 @@ export const createToolRouterSession = (
       const merged = Object.assign({}, ...mappings.filter(Boolean));
       return Object.keys(merged).length > 0 ? merged : undefined;
     };
+    const requestedToolkits = options?.toolkits ?? [];
+    const localToolkitSlugs = new Set(getAllLocalToolkitSlugs());
+    const requestedLocalToolkits = requestedToolkits.filter(toolkit =>
+      localToolkitSlugs.has(toolkit.toLowerCase())
+    );
+    const remoteToolkits = requestedToolkits.filter(
+      toolkit => !localToolkitSlugs.has(toolkit.toLowerCase())
+    );
+    const shouldIncludeLocalToolkits =
+      requestedToolkits.length === 0 || requestedLocalToolkits.length > 0;
+    const localExperimentalPayload =
+      options?.localTools?.enable === false || !shouldIncludeLocalToolkits
+        ? undefined
+        : createLocalToolRouterExperimentalPayload({
+            toolkits: requestedToolkits.length > 0 ? requestedLocalToolkits : undefined,
+          });
     const excludedToolkits = new Set(
       (options?.excludeConnectedAccountsForToolkits ?? []).map(toolkit => toolkit.toLowerCase())
     );
@@ -62,20 +86,20 @@ export const createToolRouterSession = (
       ? yield* getFreshConsumerToolRouterAuthConfigsFromCache({
           orgId: options.cacheScope.orgId,
           consumerUserId: options.cacheScope.consumerUserId,
-          toolkits: options.toolkits,
+          toolkits: remoteToolkits.length > 0 ? remoteToolkits : undefined,
         })
       : Option.none();
     const cachedConnectedAccounts = options?.cacheScope
       ? yield* getFreshConsumerToolRouterConnectedAccountsFromCache({
           orgId: options.cacheScope.orgId,
           consumerUserId: options.cacheScope.consumerUserId,
-          toolkits: options.toolkits,
+          toolkits: remoteToolkits.length > 0 ? remoteToolkits : undefined,
         })
       : Option.none();
 
     const connectionContext = Option.isSome(cachedAuthConfigs)
       ? {
-          connectedToolkits: options?.toolkits ?? [],
+          connectedToolkits: remoteToolkits,
           authConfigs: cachedAuthConfigs.value.authConfigs,
           connectedAccounts: mergeConnectedAccounts(
             filterConnectedAccounts(
@@ -90,7 +114,7 @@ export const createToolRouterSession = (
             : undefined,
         }
       : yield* resolveToolRouterSessionConnections(client, userId, {
-          toolkits: options?.toolkits,
+          toolkits: remoteToolkits.length > 0 ? remoteToolkits : undefined,
         }).pipe(
           Effect.map(connectionContext => ({
             ...connectionContext,
@@ -129,10 +153,8 @@ export const createToolRouterSession = (
               require_explicit_selection: options.multiAccount.requireExplicitSelection,
             }
           : undefined,
-        toolkits:
-          options?.toolkits && options.toolkits.length > 0
-            ? { enable: [...options.toolkits] }
-            : undefined,
+        toolkits: remoteToolkits.length > 0 ? { enable: [...remoteToolkits] } : undefined,
+        experimental: localExperimentalPayload,
       })
     ).pipe(Effect.map(session => session.session_id));
   });

--- a/ts/packages/cli/src/services/tool-input-validation.ts
+++ b/ts/packages/cli/src/services/tool-input-validation.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { FileSystem } from '@effect/platform';
 import { Effect, Option } from 'effect';
 import { jsonSchemaToZodSchema } from '@composio/core';
+import { getLocalToolInputDefinition } from '@composio/cli-local-tools';
 import { z } from 'zod/v3';
 import { setupCacheDir } from 'src/effects/setup-cache-dir';
 import { ComposioToolkitsRepository, getLatestToolVersion } from 'src/services/composio-clients';
@@ -170,8 +171,24 @@ const fetchAndCacheToolInputDefinition = (
     const fs = yield* FileSystem.FileSystem;
     const repo = yield* ComposioToolkitsRepository;
     const cacheDir = yield* setupCacheDir;
-    const schemaPath = toolDefinitionPath(cacheDir, slug);
+    const localDefinition = getLocalToolInputDefinition(slug);
+    const schemaPath = toolDefinitionPath(cacheDir, localDefinition?.finalSlug ?? slug);
     yield* ensureToolDefinitionsDir(fs, cacheDir);
+
+    if (localDefinition) {
+      yield* fs.writeFileString(
+        schemaPath,
+        serializeCachedToolDefinition({
+          version: localDefinition.version,
+          inputSchema: localDefinition.schema,
+        })
+      );
+      return {
+        schemaPath,
+        schema: localDefinition.schema,
+        version: localDefinition.version,
+      };
+    }
 
     const tool = yield* repo.getToolDetailed(slug);
     toolDebugLog('tool_detail', {

--- a/ts/packages/cli/src/services/tools-executor.ts
+++ b/ts/packages/cli/src/services/tools-executor.ts
@@ -1,6 +1,7 @@
 import { FileSystem } from '@effect/platform';
 import { Context, Effect, Layer } from 'effect';
 import type { Composio } from '@composio/client';
+import { executeLocalToolBySlug } from '@composio/cli-local-tools';
 import type {
   SessionExecuteResponse,
   SessionExecuteMetaResponse,
@@ -133,6 +134,18 @@ export const ToolsExecutorLive = Layer.effect(
     return ToolsExecutor.of({
       execute: (slug, params) =>
         Effect.gen(function* () {
+          const localResult = yield* Effect.tryPromise(() =>
+            executeLocalToolBySlug(slug, params.arguments)
+          );
+          if (localResult) {
+            return {
+              successful: true,
+              data: localResult as Record<string, unknown>,
+              error: null,
+              logId: '',
+            } satisfies ToolExecuteResponse;
+          }
+
           const client = yield* clientSingleton.get();
           const resolvedClient = params.client ?? client;
           // One session per invocation — CLI runs one tool per process.

--- a/ts/packages/cli/test/src/commands/tools/tools.search.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/tools/tools.search.cmd.test.ts
@@ -441,7 +441,46 @@ describe('CLI: composio search', () => {
           yield* cli(['search', 'send', '--toolkits', 'gmail,outlook']).pipe(Effect.provide(live));
 
           expect(createParams?.toolkits).toEqual({ enable: ['gmail', 'outlook'] });
+          expect(createParams?.experimental).toBeUndefined();
           expect(searchParams?.queries[0]?.use_case).toBe('send');
+        })
+      );
+    }
+  );
+
+  layer(TestLive(testLiveOptions))(
+    '[Given] local toolkit filter [Then] it is sent as custom toolkits, not remote toolkits',
+    it => {
+      it.scoped('passes bundled local toolkits through the experimental session payload', () =>
+        Effect.gen(function* () {
+          let createParams: SessionCreateParams | undefined;
+
+          const live = TestLive({
+            baseConfigProvider: testConfigProvider,
+            toolkitsData,
+            fixture: 'global-test-user-id',
+            toolRouter: {
+              create: async params => {
+                createParams = params;
+                return {
+                  session_id: 'trs_test_session',
+                  config: { user_id: params.user_id, preload: { tools: [] } },
+                  config_version: 1,
+                  mcp: { type: 'http', url: 'https://mcp.test.composio.dev' },
+                  tool_router_tools: ['COMPOSIO_SEARCH_TOOLS'],
+                };
+              },
+            },
+          });
+
+          yield* cli(['search', 'inspect chrome', '--toolkits', 'chrome_devtools']).pipe(
+            Effect.provide(live)
+          );
+
+          expect(createParams?.toolkits).toBeUndefined();
+          expect(createParams?.experimental?.custom_toolkits?.map(toolkit => toolkit.slug)).toEqual([
+            'CHROME_DEVTOOLS',
+          ]);
         })
       );
     }

--- a/ts/packages/cli/tsconfig.src.json
+++ b/ts/packages/cli/tsconfig.src.json
@@ -11,7 +11,8 @@
     "rootDir": ".",
     "paths": {
       "src/*": ["./src/*"],
-      "effect-errors/*": ["./src/effect-errors/*"]
+      "effect-errors/*": ["./src/effect-errors/*"],
+      "@composio/cli-local-tools": ["../cli-local-tools/src/index.ts"]
     },
     "types": ["@types/bun"]
   },

--- a/ts/packages/cli/tsconfig.test.json
+++ b/ts/packages/cli/tsconfig.test.json
@@ -11,6 +11,7 @@
     "paths": {
       "src/*": ["./src/*"],
       "effect-errors/*": ["./src/effect-errors/*"],
+      "@composio/cli-local-tools": ["../cli-local-tools/src/index.ts"],
       "test/*": ["./test/*"]
     },
     "types": ["@types/bun", "vitest/importMeta"]

--- a/ts/packages/cli/tsdown.config.ts
+++ b/ts/packages/cli/tsdown.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
   external: undefined,
   noExternal: [
     '@composio/core',
+    '@composio/cli-local-tools',
     /^zod(?:\/.*)?$/,
     /^@agentclientprotocol\/sdk(?:\/.*)?$/,
     /^@modelcontextprotocol\/sdk(?:\/.*)?$/,

--- a/ts/packages/cli/vitest.config.ts
+++ b/ts/packages/cli/vitest.config.ts
@@ -5,6 +5,7 @@ const __dirname = path.resolve(path.dirname(new URL(import.meta.url).pathname));
 const coreDir = path.resolve(__dirname, '../core');
 const tsBuildersDir = path.resolve(__dirname, '../ts-builders');
 const jsonSchemaToZodDir = path.resolve(__dirname, '../json-schema-to-zod');
+const cliLocalToolsDir = path.resolve(__dirname, '../cli-local-tools');
 
 export default defineConfig({
   resolve: {
@@ -15,6 +16,7 @@ export default defineConfig({
       '@composio/core': path.join(coreDir, 'src/index.ts'),
       '@composio/ts-builders': path.join(tsBuildersDir, 'src/index.ts'),
       '@composio/json-schema-to-zod': path.join(jsonSchemaToZodDir, 'src/index.ts'),
+      '@composio/cli-local-tools': path.join(cliLocalToolsDir, 'src/index.ts'),
       'effect-errors/*': path.resolve(__dirname, './src/effect-errors'),
       // @composio/core uses package.json "imports" (#config_defaults, #platform, etc.)
       // Vitest/Vite does not resolve these for workspace deps, so alias them explicitly


### PR DESCRIPTION
## Summary
- Add `@composio/cli-local-tools` with platform-aware local toolkit declarations, local metadata storage at `~/composio/local_tools.json`, and command/MCP/native/FFI execution abstractions.
- Scaffold first local toolkits for Beeper iMessage, Chrome DevTools MCP, and Peekaboo.
- Wire CLI Tool Router session creation to include supported local custom toolkits for `composio search`, and intercept local tool slugs during `composio execute`.
- Add local schema caching/validation support and skip account-link hints/checks for local tools.

## Hermes search prioritization notes
- Hermes searches custom/local tools with in-memory BM25, filters by toolkit config, boosts custom toolkits or connected-extension custom tools, and injects matching local tools into reranker candidates with competitive scores.
- The reranker prompt explicitly treats `LOCAL_` tools as user-provided workflow tools and applies toolkit priority ordering: query-mentioned, connected, no-auth, featured, then others.

## Tests
- `pnpm --filter @composio/cli-local-tools typecheck:tsc`
- `pnpm --filter @composio/cli-local-tools test`
- `pnpm --filter @composio/cli-local-tools build`
- `pnpm exec eslint ts/packages/cli-local-tools/src ts/packages/cli/src/effects/create-tool-router-session.ts ts/packages/cli/src/services/tools-executor.ts ts/packages/cli/src/services/tool-input-validation.ts ts/packages/cli/src/commands/tools/commands/tools.search.cmd.ts ts/packages/cli/src/commands/tools/commands/tools.execute.cmd.ts --quiet`
- `cd ts/packages/cli-keyring && pnpm exec tsdown --config-loader unrun >/tmp/cli-keyring-build.log && cd ../cli && pnpm exec vitest run test/src/commands/tools/tools.search.cmd.test.ts test/src/commands/tools/tools.execute.cmd.test.ts`

## Notes
- CLI local tools are only registered into Tool Router sessions on supported platforms; unsupported local toolkits are omitted from search payloads.
- The FFI execution kind is typed and scaffolded but intentionally returns a not-implemented error for this first draft.
