### PR TITLE
feat(cli): add local tools commands

### DIFF
--- a/.changeset/cli-local-tools.md
+++ b/.changeset/cli-local-tools.md
@@ -1,6 +1,6 @@
 ---
-"@composio/cli": patch
-"@composio/cli-local-tools": patch
+'@composio/cli': patch
+'@composio/cli-local-tools': patch
 ---
 
-Scaffold bundled CLI local tools and wire them into CLI search/execute sessions.
+Scaffold bundled CLI local tools, wire them into CLI search/execute sessions, and expose `composio local-tools list|meta` for discovery and local metadata state.

--- a/ts/packages/cli/src/commands/index.ts
+++ b/ts/packages/cli/src/commands/index.ts
@@ -14,6 +14,7 @@ import { runCmd } from './run.cmd';
 import { proxyCmd } from './proxy.cmd';
 import { artifactsCmd } from './artifacts.cmd';
 import { installCmd } from './install.cmd';
+import { localToolsCmd } from './local-tools/local-tools.cmd';
 import { generateCmd } from './generate/generate.cmd';
 import { buildDevCommand } from './dev.cmd';
 import {
@@ -69,6 +70,7 @@ const ROOT_COMMANDS: ReadonlyArray<TaggedValue<Command.Command<any, any, any, an
   tagged(proxyCmd),
   tagged(artifactsCmd),
   tagged(installCmd),
+  tagged(localToolsCmd),
   tagged(rootToolsCmd),
   tagged(rootTriggersCmd),
   tagged(rootToolsCmd$Search),

--- a/ts/packages/cli/src/commands/local-tools/commands/local-tools.list.cmd.ts
+++ b/ts/packages/cli/src/commands/local-tools/commands/local-tools.list.cmd.ts
@@ -1,0 +1,158 @@
+import { Command, Options } from '@effect/cli';
+import {
+  detectCliPlatform,
+  formatSupportedPlatforms,
+  getLocalToolkitDeclarations,
+  getLocalToolsMetaPath,
+  localToolkitDeclarations,
+  normalizeLocalToolSlug,
+  supportsCliPlatform,
+} from '@composio/cli-local-tools';
+import { Effect, Option } from 'effect';
+import { TerminalUI } from 'src/services/terminal-ui';
+import { bold, gray } from 'src/ui/colors';
+import { truncate } from 'src/ui/truncate';
+
+const json = Options.boolean('json').pipe(
+  Options.withDefault(false),
+  Options.withDescription('Print local tool declarations as JSON')
+);
+
+const allPlatforms = Options.boolean('all-platforms').pipe(
+  Options.withDefault(false),
+  Options.withDescription('Include local toolkits that are not supported on this CLI platform')
+);
+
+const toolkits = Options.text('toolkits').pipe(
+  Options.optional,
+  Options.withDescription('Filter by local toolkit slugs, comma-separated')
+);
+
+const parseToolkitFilter = (value: Option.Option<string>): ReadonlyArray<string> | undefined => {
+  const raw = Option.getOrUndefined(value);
+  if (!raw?.trim()) return undefined;
+  return raw
+    .split(',')
+    .map(part => part.trim())
+    .filter(Boolean);
+};
+
+const toolkitMatchesFilter = (
+  toolkitSlug: string,
+  toolkitFilter: ReadonlyArray<string> | undefined
+): boolean => {
+  if (!toolkitFilter || toolkitFilter.length === 0) return true;
+  const allowed = new Set(toolkitFilter.map(slug => slug.toLowerCase()));
+  return allowed.has(toolkitSlug.toLowerCase());
+};
+
+const buildLocalToolkitRows = (params: {
+  readonly includeAllPlatforms: boolean;
+  readonly toolkitFilter?: ReadonlyArray<string>;
+}) => {
+  const currentPlatform = detectCliPlatform();
+  const sourceToolkits = params.includeAllPlatforms
+    ? localToolkitDeclarations.filter(toolkit =>
+        toolkitMatchesFilter(toolkit.slug, params.toolkitFilter)
+      )
+    : getLocalToolkitDeclarations({ toolkits: params.toolkitFilter });
+
+  return sourceToolkits.map(toolkit => {
+    const toolkitSupported = supportsCliPlatform(toolkit.platforms, currentPlatform);
+    return {
+      slug: toolkit.slug,
+      name: toolkit.name,
+      description: toolkit.description,
+      platforms: toolkit.platforms,
+      supported: toolkitSupported,
+      source: toolkit.source,
+      tools: toolkit.tools.map(tool => ({
+        slug: tool.slug,
+        finalSlug: normalizeLocalToolSlug(tool.slug, toolkit.slug),
+        name: tool.name,
+        description: tool.description,
+        platforms: tool.platforms,
+        supported: toolkitSupported && supportsCliPlatform(tool.platforms, currentPlatform),
+        executionKind: tool.execution.kind,
+        tags: tool.tags ?? [],
+      })),
+    };
+  });
+};
+
+const formatHumanRows = (
+  rows: ReturnType<typeof buildLocalToolkitRows>,
+  metaPath: string
+): string => {
+  const lines: string[] = [];
+  const currentPlatform = detectCliPlatform();
+  lines.push(`${bold('Local tools')} (${currentPlatform})`);
+  lines.push(`${gray('Metadata:')} ${metaPath}`);
+
+  if (rows.length === 0) {
+    lines.push('No bundled local toolkits match this platform/filter.');
+    return lines.join('\n');
+  }
+
+  for (const toolkit of rows) {
+    const supportLabel = toolkit.supported ? 'supported' : 'unsupported';
+    lines.push('');
+    lines.push(
+      `${bold(toolkit.slug)} ${gray(`(${toolkit.name}; ${supportLabel}; ${formatSupportedPlatforms(toolkit.platforms)})`)}`
+    );
+    lines.push(`  ${gray(truncate(toolkit.description, 96))}`);
+    if (toolkit.source?.repository) {
+      lines.push(`  ${gray('source:')} ${toolkit.source.repository}`);
+    } else if (toolkit.source?.package) {
+      lines.push(`  ${gray('source:')} ${toolkit.source.package}`);
+    }
+
+    for (const tool of toolkit.tools) {
+      const toolSupport = tool.supported ? '' : ` ${gray('(unsupported)')}`;
+      lines.push(
+        `  ${tool.finalSlug.padEnd(36)} ${truncate(tool.name, 24).padEnd(24)} ${gray(tool.executionKind)}${toolSupport}`
+      );
+    }
+  }
+
+  return lines.join('\n');
+};
+
+export const localToolsCmd$List = Command.make(
+  'list',
+  { json, allPlatforms, toolkits },
+  ({ json, allPlatforms, toolkits }) =>
+    Effect.gen(function* () {
+      const ui = yield* TerminalUI;
+      const toolkitFilter = parseToolkitFilter(toolkits);
+      const rows = buildLocalToolkitRows({
+        includeAllPlatforms: allPlatforms,
+        toolkitFilter,
+      });
+      const metaPath = getLocalToolsMetaPath();
+
+      const payload = {
+        currentPlatform: detectCliPlatform(),
+        metadataPath: metaPath,
+        toolkits: rows,
+      };
+
+      if (json) {
+        yield* ui.output(JSON.stringify(payload, null, 2), { force: true });
+        return;
+      }
+
+      yield* ui.log.message(formatHumanRows(rows, metaPath));
+    })
+).pipe(
+  Command.withDescription(
+    [
+      'List bundled local CLI toolkits and tools that can be injected into Tool Router search sessions.',
+      '',
+      'Examples:',
+      '  composio local-tools list',
+      '  composio local-tools list --json',
+      '  composio local-tools list --toolkits chrome_devtools --all-platforms',
+    ].join('\n')
+  )
+);

--- a/ts/packages/cli/src/commands/local-tools/commands/local-tools.meta.cmd.ts
+++ b/ts/packages/cli/src/commands/local-tools/commands/local-tools.meta.cmd.ts
@@ -1,0 +1,82 @@
+import { Command, Options } from '@effect/cli';
+import {
+  createEmptyLocalToolsMeta,
+  getLocalToolsMetaPath,
+  readLocalToolsMeta,
+  writeLocalToolsMeta,
+} from '@composio/cli-local-tools';
+import { Effect } from 'effect';
+import { TerminalUI } from 'src/services/terminal-ui';
+import { bold, gray } from 'src/ui/colors';
+
+const json = Options.boolean('json').pipe(
+  Options.withDefault(false),
+  Options.withDescription('Print the metadata file contents as JSON')
+);
+
+const init = Options.boolean('init').pipe(
+  Options.withDefault(false),
+  Options.withDescription('Create ~/composio/local_tools.json if it does not exist')
+);
+
+export const localToolsCmd$Meta = Command.make('meta', { json, init }, ({ json, init }) =>
+  Effect.gen(function* () {
+    const ui = yield* TerminalUI;
+    const metadataPath = getLocalToolsMetaPath();
+    const meta = init
+      ? yield* Effect.tryPromise(async () => {
+          const existing = await readLocalToolsMeta();
+          const next =
+            Object.keys(existing.tools).length === 0 && Object.keys(existing.toolkits).length === 0
+              ? createEmptyLocalToolsMeta()
+              : existing;
+          await writeLocalToolsMeta(next);
+          return next;
+        })
+      : yield* Effect.tryPromise(() => readLocalToolsMeta());
+
+    const payload = {
+      metadataPath,
+      ...meta,
+    };
+
+    if (json) {
+      yield* ui.output(JSON.stringify(payload, null, 2), { force: true });
+      return;
+    }
+
+    yield* ui.log.message(
+      [
+        `${bold('Local tools metadata')}`,
+        `${gray('Path:')} ${metadataPath}`,
+        `${gray('Version:')} ${meta.version}`,
+        `${gray('Toolkits:')} ${Object.keys(meta.toolkits).length}`,
+        `${gray('Tools:')} ${Object.keys(meta.tools).length}`,
+        init ? `${gray('Status:')} initialized` : undefined,
+        '',
+        'Use this file for local auth/install state, for example:',
+        '{',
+        '  "toolkits": {',
+        '    "peekaboo": { "installation": { "command": "/opt/homebrew/bin/peekaboo" } }',
+        '  },',
+        '  "tools": {',
+        '    "LOCAL_BEEPER_IMESSAGE_RUN_CLI": { "authenticated": true }',
+        '  }',
+        '}',
+      ]
+        .filter((line): line is string => line !== undefined)
+        .join('\n')
+    );
+  })
+).pipe(
+  Command.withDescription(
+    [
+      'Inspect or initialize the local tools metadata file at ~/composio/local_tools.json.',
+      '',
+      'Examples:',
+      '  composio local-tools meta',
+      '  composio local-tools meta --init',
+      '  composio local-tools meta --json',
+    ].join('\n')
+  )
+);

--- a/ts/packages/cli/src/commands/local-tools/local-tools.cmd.ts
+++ b/ts/packages/cli/src/commands/local-tools/local-tools.cmd.ts
@@ -1,0 +1,8 @@
+import { Command } from '@effect/cli';
+import { localToolsCmd$List } from './commands/local-tools.list.cmd';
+import { localToolsCmd$Meta } from './commands/local-tools.meta.cmd';
+
+export const localToolsCmd = Command.make('local-tools').pipe(
+  Command.withDescription('Inspect and configure bundled local CLI tools.'),
+  Command.withSubcommands([localToolsCmd$List, localToolsCmd$Meta])
+);

--- a/ts/packages/cli/src/commands/root-help.ts
+++ b/ts/packages/cli/src/commands/root-help.ts
@@ -182,6 +182,8 @@ const FULL_COMMANDS: ReadonlyArray<TaggedValue<CompactCommand>> = [
   full({ name: 'triggers info', description: 'Inspect a trigger type and schema summary' }),
   full({ name: 'connections list', description: 'Print toolkit connection statuses as JSON' }),
   full({ name: 'connections remove', description: 'Interactively remove a toolkit connection' }),
+  full({ name: 'local-tools list', description: 'List bundled local CLI toolkits and tools' }),
+  full({ name: 'local-tools meta', description: 'Inspect or initialize local tools metadata' }),
   full({ name: 'generate ts', description: 'Generate TypeScript stubs for selected toolkits' }),
   full({ name: 'generate py', description: 'Generate Python stubs for selected toolkits' }),
   full({
@@ -570,6 +572,52 @@ const SUBCOMMAND_HELP: Record<string, SubcommandHelp | TaggedValue<SubcommandHel
     seeAlso: [
       'composio connections list                Find connection selectors',
       'composio link <toolkit>                  Reconnect a toolkit account',
+    ],
+  },
+  'local-tools': {
+    usage: 'composio local-tools <list|meta>',
+    description:
+      'Inspect local CLI tools that the Tool Router can search and execute alongside hosted Composio tools.',
+    examples: [
+      'composio local-tools list',
+      'composio local-tools list --json',
+      'composio local-tools meta --init',
+    ],
+    seeAlso: [
+      'composio search "chrome page" --toolkits chrome_devtools    Search local Chrome DevTools tools',
+      'composio execute LOCAL_PEEKABOO_HELP                        Execute a local tool',
+    ],
+  },
+  'local-tools list': {
+    usage: 'composio local-tools list [--json] [--all-platforms] [--toolkits <text>]',
+    description:
+      'List bundled local toolkits and the exact LOCAL_* tool slugs exposed to Tool Router.',
+    options: [
+      { name: '--json', description: 'Print structured declarations' },
+      {
+        name: '--all-platforms',
+        description: 'Include unsupported toolkits for the current platform',
+      },
+      { name: '--toolkits <text>', description: 'Comma-separated local toolkit slug filter' },
+    ],
+    examples: [
+      'composio local-tools list',
+      'composio local-tools list --json',
+      'composio local-tools list --toolkits chrome_devtools --all-platforms',
+    ],
+    seeAlso: ['composio local-tools meta              Inspect local metadata state'],
+  },
+  'local-tools meta': {
+    usage: 'composio local-tools meta [--json] [--init]',
+    description: 'Inspect or initialize ~/composio/local_tools.json for local auth/install state.',
+    options: [
+      { name: '--json', description: 'Print metadata state as JSON' },
+      { name: '--init', description: 'Create the metadata file if needed' },
+    ],
+    examples: [
+      'composio local-tools meta',
+      'composio local-tools meta --init',
+      'composio local-tools meta --json',
     ],
   },
   run: {

--- a/ts/packages/cli/test/src/commands/local-tools.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/local-tools.cmd.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, layer } from '@effect/vitest';
+import { Effect } from 'effect';
+import { cli, MockConsole, TestLive } from 'test/__utils__';
+
+describe('CLI: composio local-tools', () => {
+  layer(TestLive())(it => {
+    it.scoped('[Given] --json [Then] lists bundled local toolkits', () =>
+      Effect.gen(function* () {
+        yield* cli(['local-tools', 'list', '--json', '--all-platforms']);
+
+        const lines = yield* MockConsole.getLines({ stripAnsi: true });
+        const payload = JSON.parse(lines.at(-1) ?? '') as {
+          currentPlatform: string;
+          metadataPath: string;
+          toolkits: Array<{
+            slug: string;
+            tools: Array<{ finalSlug: string; executionKind: string }>;
+          }>;
+        };
+
+        expect(payload.currentPlatform).toBeTruthy();
+        expect(payload.metadataPath).toContain('local_tools.json');
+        expect(payload.toolkits.map(toolkit => toolkit.slug)).toEqual(
+          expect.arrayContaining(['BEEPER_IMESSAGE', 'CHROME_DEVTOOLS', 'PEEKABOO'])
+        );
+        expect(
+          payload.toolkits.flatMap(toolkit => toolkit.tools.map(tool => tool.finalSlug))
+        ).toEqual(
+          expect.arrayContaining(['LOCAL_CHROME_DEVTOOLS_LIST_TOOLS', 'LOCAL_PEEKABOO_HELP'])
+        );
+      })
+    );
+
+    it.scoped(
+      '[Given] toolkit filter [Then] only returns matching local toolkit declarations',
+      () =>
+        Effect.gen(function* () {
+          yield* cli([
+            'local-tools',
+            'list',
+            '--json',
+            '--all-platforms',
+            '--toolkits',
+            'chrome_devtools',
+          ]);
+
+          const lines = yield* MockConsole.getLines({ stripAnsi: true });
+          const payload = JSON.parse(lines.at(-1) ?? '') as { toolkits: Array<{ slug: string }> };
+
+          expect(payload.toolkits.map(toolkit => toolkit.slug)).toEqual(['CHROME_DEVTOOLS']);
+        })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add `composio local-tools list` to show bundled local toolkit/tool declarations, platform support, execution kind, and `LOCAL_*` slugs.
- Add `composio local-tools meta` to inspect or initialize `~/composio/local_tools.json` for local auth/install metadata.
- Register local-tools help entries and add command tests for JSON list/filter behavior.

## Stack
- Builds on #3336 / `pi/make-worktree-738f2b96`.

## Tests
- `pnpm exec eslint ts/packages/cli/src/commands/local-tools/local-tools.cmd.ts ts/packages/cli/src/commands/local-tools/commands/local-tools.list.cmd.ts ts/packages/cli/src/commands/local-tools/commands/local-tools.meta.cmd.ts ts/packages/cli/test/src/commands/local-tools.cmd.test.ts ts/packages/cli/src/commands/index.ts ts/packages/cli/src/commands/root-help.ts --quiet`
- `pnpm --filter @composio/cli typecheck:tsc`
- `cd ts/packages/cli && pnpm exec vitest run test/src/commands/local-tools.cmd.test.ts`
- `cd ts/packages/cli && pnpm exec tsdown --config-loader unrun`

## Notes
- `pnpm --filter @composio/cli build` still hits the existing tsdown native config-loader issue in this checkout, so the build was verified with `--config-loader unrun`.
