### PR TITLE
feat(cli): add local tools doctor

### DIFF
--- a/.changeset/cli-local-tools.md
+++ b/.changeset/cli-local-tools.md
@@ -3,4 +3,4 @@
 '@composio/cli-local-tools': patch
 ---
 
-Scaffold bundled CLI local tools, wire them into CLI search/execute sessions, and expose `composio local-tools list|meta` for discovery and local metadata state.
+Scaffold bundled CLI local tools, wire them into CLI search/execute sessions, and expose `composio local-tools list|doctor|meta` for discovery, readiness checks, setup hints, and local metadata state.

--- a/ts/packages/cli-local-tools/src/index.ts
+++ b/ts/packages/cli-local-tools/src/index.ts
@@ -2,6 +2,7 @@ export * from './types';
 export * from './platform';
 export * from './meta';
 export * from './runtime';
+export * from './readiness';
 export * from './registry';
 export { beeperImessageToolkit } from './toolkits/beeper-imessage';
 export { chromeDevtoolsToolkit } from './toolkits/chrome-devtools';

--- a/ts/packages/cli-local-tools/src/readiness.ts
+++ b/ts/packages/cli-local-tools/src/readiness.ts
@@ -1,0 +1,367 @@
+import { constants as fsConstants } from 'node:fs';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { detectCliPlatform, formatSupportedPlatforms, supportsCliPlatform } from './platform';
+import { readLocalToolsMeta, type LocalToolsMetaOptions } from './meta';
+import { localToolkitDeclarations, normalizeLocalToolSlug } from './registry';
+import type {
+  LocalCliPlatform,
+  LocalCommandInvocation,
+  LocalMcpServerSpec,
+  LocalToolkitDeclaration,
+  LocalToolDeclaration,
+  LocalToolExecution,
+} from './types';
+
+export type LocalReadinessStatus =
+  | 'ready'
+  | 'unsupported'
+  | 'disabled'
+  | 'missing'
+  | 'not_implemented'
+  | 'unknown';
+
+export interface LocalCommandReadiness {
+  readonly command: string;
+  readonly args?: ReadonlyArray<string>;
+  readonly found: boolean;
+  readonly path?: string;
+}
+
+export interface LocalToolReadiness {
+  readonly finalSlug: string;
+  readonly slug: string;
+  readonly name: string;
+  readonly toolkitSlug: string;
+  readonly executionKind: LocalToolExecution['kind'];
+  readonly platforms: ReadonlyArray<LocalCliPlatform>;
+  readonly supported: boolean;
+  readonly status: LocalReadinessStatus;
+  readonly command?: LocalCommandReadiness;
+  readonly messages: ReadonlyArray<string>;
+  readonly hints: ReadonlyArray<string>;
+}
+
+export interface LocalToolkitReadiness {
+  readonly slug: string;
+  readonly name: string;
+  readonly description: string;
+  readonly platforms: ReadonlyArray<LocalCliPlatform>;
+  readonly supported: boolean;
+  readonly status: LocalReadinessStatus;
+  readonly source?: LocalToolkitDeclaration['source'];
+  readonly setup?: LocalToolkitDeclaration['setup'];
+  readonly tools: ReadonlyArray<LocalToolReadiness>;
+  readonly messages: ReadonlyArray<string>;
+  readonly hints: ReadonlyArray<string>;
+}
+
+export interface LocalToolsReadinessReport {
+  readonly currentPlatform: LocalCliPlatform;
+  readonly toolkits: ReadonlyArray<LocalToolkitReadiness>;
+}
+
+const toolkitMatchesFilter = (
+  toolkit: LocalToolkitDeclaration,
+  requestedToolkits?: ReadonlyArray<string>
+): boolean => {
+  if (!requestedToolkits || requestedToolkits.length === 0) return true;
+  const requested = new Set(requestedToolkits.map(slug => slug.toLowerCase()));
+  return requested.has(toolkit.slug.toLowerCase());
+};
+
+const statusPriority: Record<LocalReadinessStatus, number> = {
+  ready: 0,
+  unknown: 1,
+  not_implemented: 2,
+  missing: 3,
+  disabled: 4,
+  unsupported: 5,
+};
+
+const aggregateStatus = (statuses: ReadonlyArray<LocalReadinessStatus>): LocalReadinessStatus => {
+  if (statuses.length === 0) return 'unknown';
+  return statuses.reduce((current, next) =>
+    statusPriority[next] > statusPriority[current] ? next : current
+  );
+};
+
+const resolveValue = <T>(
+  value: T | ((input: Record<string, unknown>) => T),
+  input: Record<string, unknown> = {}
+): T =>
+  typeof value === 'function' ? (value as (input: Record<string, unknown>) => T)(input) : value;
+
+const splitPathEntries = (pathValue: string | undefined): ReadonlyArray<string> =>
+  (pathValue ?? '')
+    .split(path.delimiter)
+    .map(entry => entry.trim())
+    .filter(Boolean);
+
+const hasPathSeparator = (command: string): boolean =>
+  command.includes('/') || command.includes('\\');
+
+const executableCandidates = (command: string): ReadonlyArray<string> => {
+  if (process.platform !== 'win32') return [command];
+  const extensions = (process.env.PATHEXT ?? '.EXE;.CMD;.BAT;.COM')
+    .split(';')
+    .map(ext => ext.trim())
+    .filter(Boolean);
+  if (extensions.some(ext => command.toUpperCase().endsWith(ext.toUpperCase()))) return [command];
+  return extensions.map(ext => `${command}${ext}`);
+};
+
+const canExecute = async (filePath: string): Promise<boolean> => {
+  try {
+    await fs.access(filePath, fsConstants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export const findExecutableOnPath = async (command: string): Promise<string | undefined> => {
+  const trimmed = command.trim();
+  if (!trimmed) return undefined;
+
+  if (path.isAbsolute(trimmed) || hasPathSeparator(trimmed)) {
+    for (const candidate of executableCandidates(trimmed)) {
+      if (await canExecute(candidate)) return candidate;
+    }
+    return undefined;
+  }
+
+  for (const pathEntry of splitPathEntries(process.env.PATH)) {
+    for (const candidate of executableCandidates(path.join(pathEntry, trimmed))) {
+      if (await canExecute(candidate)) return candidate;
+    }
+  }
+
+  return undefined;
+};
+
+const getToolkitMeta = (
+  meta: Awaited<ReturnType<typeof readLocalToolsMeta>>,
+  toolkitSlug: string
+) => meta.toolkits[toolkitSlug.toLowerCase()] ?? meta.toolkits[toolkitSlug];
+
+const getToolMeta = (meta: Awaited<ReturnType<typeof readLocalToolsMeta>>, finalSlug: string) =>
+  meta.tools[finalSlug.toUpperCase()] ?? meta.tools[finalSlug];
+
+const resolveCommandSpec = (
+  execution: Extract<LocalToolExecution, { kind: 'command' }>,
+  commandOverride?: string
+): LocalCommandInvocation => {
+  const commandValue = resolveValue(execution.command);
+  const invocation: LocalCommandInvocation =
+    typeof commandValue === 'string' ? { command: commandValue } : commandValue;
+  return {
+    ...invocation,
+    command: commandOverride ?? invocation.command,
+    args: invocation.args ?? (execution.args ? resolveValue(execution.args) : undefined),
+  };
+};
+
+const resolveMcpServer = (
+  execution: Extract<LocalToolExecution, { kind: 'mcp' }>
+): LocalMcpServerSpec => resolveValue(execution.server);
+
+const setupHintsForToolkit = (toolkit: LocalToolkitDeclaration): ReadonlyArray<string> => [
+  ...(toolkit.setup?.install ? [toolkit.setup.install] : []),
+  ...(toolkit.setup?.commandOverrides ?? []),
+  ...(toolkit.setup?.notes ?? []),
+];
+
+const checkCommand = async (
+  command: string,
+  args?: ReadonlyArray<string>
+): Promise<LocalCommandReadiness> => {
+  const executablePath = await findExecutableOnPath(command);
+  return {
+    command,
+    ...(args ? { args } : {}),
+    found: executablePath !== undefined,
+    ...(executablePath ? { path: executablePath } : {}),
+  };
+};
+
+const checkToolReadiness = async (params: {
+  readonly toolkit: LocalToolkitDeclaration;
+  readonly tool: LocalToolDeclaration;
+  readonly currentPlatform: LocalCliPlatform;
+  readonly toolkitDisabled: boolean;
+  readonly commandOverride?: string;
+  readonly toolDisabled: boolean;
+}): Promise<LocalToolReadiness> => {
+  const { toolkit, tool, currentPlatform, toolkitDisabled, commandOverride, toolDisabled } = params;
+  const finalSlug = normalizeLocalToolSlug(tool.slug, toolkit.slug);
+  const supported =
+    supportsCliPlatform(toolkit.platforms, currentPlatform) &&
+    supportsCliPlatform(tool.platforms, currentPlatform);
+  const base = {
+    finalSlug,
+    slug: tool.slug,
+    name: tool.name,
+    toolkitSlug: toolkit.slug,
+    executionKind: tool.execution.kind,
+    platforms: tool.platforms,
+    supported,
+  } as const;
+
+  if (!supported) {
+    return {
+      ...base,
+      status: 'unsupported',
+      messages: [
+        `Unsupported on ${currentPlatform}; tool platforms: ${formatSupportedPlatforms(tool.platforms)}.`,
+      ],
+      hints: setupHintsForToolkit(toolkit),
+    };
+  }
+
+  if (toolkitDisabled || toolDisabled) {
+    return {
+      ...base,
+      status: 'disabled',
+      messages: ['Disabled by ~/composio/local_tools.json metadata.'],
+      hints: ['Remove disabled=true from the toolkit/tool metadata entry to re-enable it.'],
+    };
+  }
+
+  if (tool.execution.kind === 'command') {
+    try {
+      const invocation = resolveCommandSpec(tool.execution, commandOverride);
+      const command = await checkCommand(invocation.command, invocation.args);
+      return {
+        ...base,
+        status: command.found ? 'ready' : 'missing',
+        command,
+        messages: command.found
+          ? [`Command found: ${command.path ?? command.command}.`]
+          : [`Command not found on PATH: ${command.command}.`],
+        hints: command.found
+          ? []
+          : [
+              ...setupHintsForToolkit(toolkit),
+              `Set ${finalSlug}.installation.command or ${toolkit.slug.toLowerCase()}.installation.command in ~/composio/local_tools.json to override the binary.`,
+            ],
+      };
+    } catch (error) {
+      return {
+        ...base,
+        status: 'unknown',
+        messages: [
+          `Could not resolve command wrapper: ${error instanceof Error ? error.message : String(error)}.`,
+        ],
+        hints: setupHintsForToolkit(toolkit),
+      };
+    }
+  }
+
+  if (tool.execution.kind === 'mcp') {
+    try {
+      const server = resolveMcpServer(tool.execution);
+      const command = await checkCommand(server.command, server.args);
+      return {
+        ...base,
+        status: command.found ? 'ready' : 'missing',
+        command,
+        messages: command.found
+          ? [`MCP server launcher found: ${command.path ?? command.command}.`]
+          : [`MCP server launcher not found on PATH: ${command.command}.`],
+        hints: command.found ? (toolkit.setup?.notes ?? []) : setupHintsForToolkit(toolkit),
+      };
+    } catch (error) {
+      return {
+        ...base,
+        status: 'unknown',
+        messages: [
+          `Could not resolve MCP server wrapper: ${error instanceof Error ? error.message : String(error)}.`,
+        ],
+        hints: setupHintsForToolkit(toolkit),
+      };
+    }
+  }
+
+  if (tool.execution.kind === 'ffi') {
+    return {
+      ...base,
+      status: 'not_implemented',
+      messages: ['FFI execution is scaffolded but not implemented yet.'],
+      hints: setupHintsForToolkit(toolkit),
+    };
+  }
+
+  return {
+    ...base,
+    status: 'unknown',
+    messages: ['Native local tool wrapper will self-check at execution time.'],
+    hints: setupHintsForToolkit(toolkit),
+  };
+};
+
+export const checkLocalToolkitsReadiness = async (
+  options: {
+    readonly currentPlatform?: LocalCliPlatform;
+    readonly toolkits?: ReadonlyArray<string>;
+    readonly includeUnsupported?: boolean;
+    readonly metaOptions?: LocalToolsMetaOptions;
+  } = {}
+): Promise<LocalToolsReadinessReport> => {
+  const currentPlatform = options.currentPlatform ?? detectCliPlatform();
+  const meta = await readLocalToolsMeta(options.metaOptions);
+  const toolkits = localToolkitDeclarations.filter(toolkit =>
+    toolkitMatchesFilter(toolkit, options.toolkits)
+  );
+  const visibleToolkits = options.includeUnsupported
+    ? toolkits
+    : toolkits.filter(toolkit => supportsCliPlatform(toolkit.platforms, currentPlatform));
+
+  const reports = await Promise.all(
+    visibleToolkits.map(async toolkit => {
+      const toolkitMeta = getToolkitMeta(meta, toolkit.slug);
+      const toolkitSupported = supportsCliPlatform(toolkit.platforms, currentPlatform);
+      const toolkitDisabled = toolkitMeta?.disabled === true;
+      const tools = await Promise.all(
+        toolkit.tools.map(tool => {
+          const finalSlug = normalizeLocalToolSlug(tool.slug, toolkit.slug);
+          const toolMeta = getToolMeta(meta, finalSlug);
+          return checkToolReadiness({
+            toolkit,
+            tool,
+            currentPlatform,
+            toolkitDisabled,
+            toolDisabled: toolMeta?.disabled === true,
+            commandOverride: toolMeta?.installation?.command ?? toolkitMeta?.installation?.command,
+          });
+        })
+      );
+      const status = toolkitSupported
+        ? toolkitDisabled
+          ? 'disabled'
+          : aggregateStatus(tools.map(tool => tool.status))
+        : 'unsupported';
+      return {
+        slug: toolkit.slug,
+        name: toolkit.name,
+        description: toolkit.description,
+        platforms: toolkit.platforms,
+        supported: toolkitSupported,
+        status,
+        source: toolkit.source,
+        setup: toolkit.setup,
+        tools,
+        messages: toolkitSupported
+          ? toolkitDisabled
+            ? ['Disabled by ~/composio/local_tools.json metadata.']
+            : []
+          : [
+              `Unsupported on ${currentPlatform}; toolkit platforms: ${formatSupportedPlatforms(toolkit.platforms)}.`,
+            ],
+        hints: status === 'ready' ? [] : setupHintsForToolkit(toolkit),
+      } satisfies LocalToolkitReadiness;
+    })
+  );
+
+  return { currentPlatform, toolkits: reports };
+};

--- a/ts/packages/cli-local-tools/src/registry.test.ts
+++ b/ts/packages/cli-local-tools/src/registry.test.ts
@@ -1,3 +1,5 @@
+import os from 'node:os';
+import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   createLocalToolRouterExperimentalPayload,
@@ -5,9 +7,12 @@ import {
   getLocalToolInputDefinition,
   normalizeLocalToolSlug,
 } from './registry';
+import { checkLocalToolkitsReadiness } from './readiness';
 
-const findToolkit = (payload: ReturnType<typeof createLocalToolRouterExperimentalPayload>, slug: string) =>
-  payload?.custom_toolkits?.find(toolkit => toolkit.slug === slug);
+const findToolkit = (
+  payload: ReturnType<typeof createLocalToolRouterExperimentalPayload>,
+  slug: string
+) => payload?.custom_toolkits?.find(toolkit => toolkit.slug === slug);
 
 describe('@composio/cli-local-tools registry', () => {
   it('normalizes local tool slugs to the Tool Router LOCAL_<TOOLKIT>_<TOOL> shape', () => {
@@ -42,5 +47,24 @@ describe('@composio/cli-local-tools registry', () => {
     const definition = getLocalToolInputDefinition('LOCAL_BEEPER_IMESSAGE_RUN_CLI');
     expect(definition?.version).toBe('local');
     expect(definition?.schema.properties).toHaveProperty('args');
+  });
+
+  it('reports platform readiness for bundled local toolkits', async () => {
+    const report = await checkLocalToolkitsReadiness({
+      currentPlatform: 'linux-x64',
+      includeUnsupported: true,
+      metaOptions: {
+        path: path.join(os.tmpdir(), `composio-local-tools-test-${Date.now()}.json`),
+      },
+    });
+
+    expect(report.toolkits.find(toolkit => toolkit.slug === 'BEEPER_IMESSAGE')?.status).toBe(
+      'unsupported'
+    );
+    expect(report.toolkits.find(toolkit => toolkit.slug === 'CHROME_DEVTOOLS')?.tools).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ finalSlug: 'LOCAL_CHROME_DEVTOOLS_LIST_TOOLS' }),
+      ])
+    );
   });
 });

--- a/ts/packages/cli-local-tools/src/toolkits/beeper-imessage.ts
+++ b/ts/packages/cli-local-tools/src/toolkits/beeper-imessage.ts
@@ -16,6 +16,14 @@ export const beeperImessageToolkit: LocalToolkitDeclaration = {
     repository: 'https://github.com/beeper/platform-imessage',
     command: 'imessage',
   },
+  setup: {
+    install:
+      'Build/install Beeper platform-imessage from https://github.com/beeper/platform-imessage and expose its CLI binary on PATH.',
+    commandOverrides: [
+      'Set COMPOSIO_BEEPER_IMESSAGE_CLI=/path/to/imessage or toolkits.beeper_imessage.installation.command in ~/composio/local_tools.json.',
+    ],
+    notes: ['Requires macOS Messages/iMessage local account state.'],
+  },
   tools: [
     {
       slug: 'SEND_MESSAGE',
@@ -24,7 +32,9 @@ export const beeperImessageToolkit: LocalToolkitDeclaration = {
         'Draft mapping for sending an iMessage through the local Beeper/platform-imessage CLI. Override the binary or use RUN_CLI if your local build exposes different subcommands.',
       platforms: darwin,
       inputParams: z.object({
-        recipient: z.string().describe('Phone number, email, handle, or chat identifier to send to.'),
+        recipient: z
+          .string()
+          .describe('Phone number, email, handle, or chat identifier to send to.'),
         text: z.string().describe('Message body.'),
       }),
       execution: {

--- a/ts/packages/cli-local-tools/src/toolkits/chrome-devtools.ts
+++ b/ts/packages/cli-local-tools/src/toolkits/chrome-devtools.ts
@@ -21,6 +21,14 @@ export const chromeDevtoolsToolkit: LocalToolkitDeclaration = {
     package: 'chrome-devtools-mcp@latest',
     command: 'npx -y chrome-devtools-mcp@latest --autoConnect',
   },
+  setup: {
+    install:
+      'Install Node.js/npm. The default launcher runs `npx -y chrome-devtools-mcp@latest --autoConnect`.',
+    commandOverrides: [
+      'Set COMPOSIO_CHROME_DEVTOOLS_MCP_COMMAND=/path/to/launcher to replace the default npx launcher.',
+    ],
+    notes: ['Start Chrome before executing CALL_TOOL if autoConnect cannot find a browser target.'],
+  },
   tools: [
     {
       slug: 'LIST_TOOLS',
@@ -41,8 +49,13 @@ export const chromeDevtoolsToolkit: LocalToolkitDeclaration = {
         'Call any tool exposed by chrome-devtools-mcp. Use LIST_TOOLS first when you need exact MCP tool names and input shapes.',
       platforms: all,
       inputParams: z.object({
-        toolName: z.string().describe('MCP tool name to call, for example navigate_page or evaluate_script.'),
-        arguments: z.record(z.unknown()).default({}).describe('Arguments for the selected MCP tool.'),
+        toolName: z
+          .string()
+          .describe('MCP tool name to call, for example navigate_page or evaluate_script.'),
+        arguments: z
+          .record(z.unknown())
+          .default({})
+          .describe('Arguments for the selected MCP tool.'),
       }),
       execution: {
         kind: 'mcp',

--- a/ts/packages/cli-local-tools/src/toolkits/peekaboo.ts
+++ b/ts/packages/cli-local-tools/src/toolkits/peekaboo.ts
@@ -16,6 +16,16 @@ export const peekabooToolkit: LocalToolkitDeclaration = {
     repository: 'https://github.com/steipete/Peekaboo',
     command: 'peekaboo',
   },
+  setup: {
+    install:
+      'Install Peekaboo from https://github.com/steipete/Peekaboo and expose the `peekaboo` CLI on PATH.',
+    commandOverrides: [
+      'Set COMPOSIO_PEEKABOO_CLI=/path/to/peekaboo or toolkits.peekaboo.installation.command in ~/composio/local_tools.json.',
+    ],
+    notes: [
+      'Requires macOS Screen Recording and Accessibility permissions for many UI automation actions.',
+    ],
+  },
   tools: [
     {
       slug: 'RUN_CLI',

--- a/ts/packages/cli-local-tools/src/types.ts
+++ b/ts/packages/cli-local-tools/src/types.ts
@@ -107,6 +107,11 @@ export interface LocalToolkitDeclaration {
     readonly repository?: string;
     readonly command?: string;
   };
+  readonly setup?: {
+    readonly install?: string;
+    readonly commandOverrides?: ReadonlyArray<string>;
+    readonly notes?: ReadonlyArray<string>;
+  };
 }
 
 export interface LocalToolResolution {

--- a/ts/packages/cli/src/commands/local-tools/commands/local-tools.doctor.cmd.ts
+++ b/ts/packages/cli/src/commands/local-tools/commands/local-tools.doctor.cmd.ts
@@ -1,0 +1,148 @@
+import { Command, Options } from '@effect/cli';
+import {
+  checkLocalToolkitsReadiness,
+  formatSupportedPlatforms,
+  getLocalToolsMetaPath,
+  type LocalReadinessStatus,
+  type LocalToolsReadinessReport,
+} from '@composio/cli-local-tools';
+import { Effect, Option } from 'effect';
+import { TerminalUI } from 'src/services/terminal-ui';
+import { bold, gray, green, red } from 'src/ui/colors';
+import { truncate } from 'src/ui/truncate';
+
+const json = Options.boolean('json').pipe(
+  Options.withDefault(false),
+  Options.withDescription('Print readiness report as JSON')
+);
+
+const allPlatforms = Options.boolean('all-platforms').pipe(
+  Options.withDefault(false),
+  Options.withDescription('Include local toolkits that are not supported on this CLI platform')
+);
+
+const strict = Options.boolean('strict').pipe(
+  Options.withDefault(false),
+  Options.withDescription('Exit with an error when any visible local tool is not ready')
+);
+
+const toolkits = Options.text('toolkits').pipe(
+  Options.optional,
+  Options.withDescription('Filter by local toolkit slugs, comma-separated')
+);
+
+const parseToolkitFilter = (value: Option.Option<string>): ReadonlyArray<string> | undefined => {
+  const raw = Option.getOrUndefined(value);
+  if (!raw?.trim()) return undefined;
+  return raw
+    .split(',')
+    .map(part => part.trim())
+    .filter(Boolean);
+};
+
+const statusIcon = (status: LocalReadinessStatus): string => {
+  switch (status) {
+    case 'ready':
+      return green('✓');
+    case 'unsupported':
+      return gray('○');
+    case 'unknown':
+      return gray('?');
+    default:
+      return red('✗');
+  }
+};
+
+const statusLabel = (status: LocalReadinessStatus): string => {
+  if (status === 'ready') return green(status);
+  if (status === 'unsupported' || status === 'unknown') return gray(status);
+  return red(status);
+};
+
+const hasProblems = (report: LocalToolsReadinessReport): boolean =>
+  report.toolkits.some(toolkit =>
+    toolkit.tools.some(tool => tool.status !== 'ready' && tool.status !== 'unsupported')
+  );
+
+const formatDoctorReport = (report: LocalToolsReadinessReport, metadataPath: string): string => {
+  const lines: string[] = [];
+  lines.push(`${bold('Local tools doctor')} (${report.currentPlatform})`);
+  lines.push(`${gray('Metadata:')} ${metadataPath}`);
+
+  if (report.toolkits.length === 0) {
+    lines.push('No bundled local toolkits match this platform/filter.');
+    return lines.join('\n');
+  }
+
+  for (const toolkit of report.toolkits) {
+    lines.push('');
+    lines.push(
+      `${statusIcon(toolkit.status)} ${bold(toolkit.slug)} ${gray(`(${toolkit.name}; ${statusLabel(toolkit.status)}; ${formatSupportedPlatforms(toolkit.platforms)})`)}`
+    );
+    lines.push(`  ${gray(truncate(toolkit.description, 96))}`);
+    for (const message of toolkit.messages) {
+      lines.push(`  ${gray('note:')} ${message}`);
+    }
+
+    for (const tool of toolkit.tools) {
+      const command = tool.command
+        ? tool.command.found
+          ? `${tool.command.command}${tool.command.path ? gray(` -> ${tool.command.path}`) : ''}`
+          : `${tool.command.command} ${red('(missing)')}`
+        : tool.executionKind;
+      lines.push(
+        `  ${statusIcon(tool.status)} ${tool.finalSlug.padEnd(36)} ${statusLabel(tool.status).padEnd(15)} ${gray(command)}`
+      );
+      for (const message of tool.messages) {
+        lines.push(`      ${gray(message)}`);
+      }
+    }
+
+    const hints = [...new Set([...toolkit.hints, ...toolkit.tools.flatMap(tool => tool.hints)])];
+    for (const hint of hints) {
+      lines.push(`  ${gray('hint:')} ${hint}`);
+    }
+  }
+
+  return lines.join('\n');
+};
+
+export const localToolsCmd$Doctor = Command.make(
+  'doctor',
+  { json, allPlatforms, strict, toolkits },
+  ({ json, allPlatforms, strict, toolkits }) =>
+    Effect.gen(function* () {
+      const ui = yield* TerminalUI;
+      const toolkitFilter = parseToolkitFilter(toolkits);
+      const metadataPath = getLocalToolsMetaPath();
+      const report = yield* Effect.tryPromise(() =>
+        checkLocalToolkitsReadiness({
+          includeUnsupported: allPlatforms,
+          toolkits: toolkitFilter,
+        })
+      );
+
+      if (json) {
+        yield* ui.output(JSON.stringify({ metadataPath, ...report }, null, 2), { force: true });
+      } else {
+        yield* ui.log.message(formatDoctorReport(report, metadataPath));
+      }
+
+      if (strict && hasProblems(report)) {
+        return yield* Effect.fail(
+          new Error('One or more local tools are not ready. Run without --strict for setup hints.')
+        );
+      }
+    })
+).pipe(
+  Command.withDescription(
+    [
+      'Check whether bundled local toolkits have the commands and platform support needed to run.',
+      '',
+      'Examples:',
+      '  composio local-tools doctor',
+      '  composio local-tools doctor --json',
+      '  composio local-tools doctor --toolkits chrome_devtools --strict',
+    ].join('\n')
+  )
+);

--- a/ts/packages/cli/src/commands/local-tools/local-tools.cmd.ts
+++ b/ts/packages/cli/src/commands/local-tools/local-tools.cmd.ts
@@ -1,8 +1,9 @@
 import { Command } from '@effect/cli';
+import { localToolsCmd$Doctor } from './commands/local-tools.doctor.cmd';
 import { localToolsCmd$List } from './commands/local-tools.list.cmd';
 import { localToolsCmd$Meta } from './commands/local-tools.meta.cmd';
 
 export const localToolsCmd = Command.make('local-tools').pipe(
   Command.withDescription('Inspect and configure bundled local CLI tools.'),
-  Command.withSubcommands([localToolsCmd$List, localToolsCmd$Meta])
+  Command.withSubcommands([localToolsCmd$List, localToolsCmd$Doctor, localToolsCmd$Meta])
 );

--- a/ts/packages/cli/src/commands/root-help.ts
+++ b/ts/packages/cli/src/commands/root-help.ts
@@ -183,6 +183,10 @@ const FULL_COMMANDS: ReadonlyArray<TaggedValue<CompactCommand>> = [
   full({ name: 'connections list', description: 'Print toolkit connection statuses as JSON' }),
   full({ name: 'connections remove', description: 'Interactively remove a toolkit connection' }),
   full({ name: 'local-tools list', description: 'List bundled local CLI toolkits and tools' }),
+  full({
+    name: 'local-tools doctor',
+    description: 'Check local toolkit readiness and setup hints',
+  }),
   full({ name: 'local-tools meta', description: 'Inspect or initialize local tools metadata' }),
   full({ name: 'generate ts', description: 'Generate TypeScript stubs for selected toolkits' }),
   full({ name: 'generate py', description: 'Generate Python stubs for selected toolkits' }),
@@ -580,7 +584,7 @@ const SUBCOMMAND_HELP: Record<string, SubcommandHelp | TaggedValue<SubcommandHel
       'Inspect local CLI tools that the Tool Router can search and execute alongside hosted Composio tools.',
     examples: [
       'composio local-tools list',
-      'composio local-tools list --json',
+      'composio local-tools doctor',
       'composio local-tools meta --init',
     ],
     seeAlso: [
@@ -604,6 +608,26 @@ const SUBCOMMAND_HELP: Record<string, SubcommandHelp | TaggedValue<SubcommandHel
       'composio local-tools list',
       'composio local-tools list --json',
       'composio local-tools list --toolkits chrome_devtools --all-platforms',
+    ],
+    seeAlso: ['composio local-tools meta              Inspect local metadata state'],
+  },
+  'local-tools doctor': {
+    usage: 'composio local-tools doctor [--json] [--all-platforms] [--toolkits <text>] [--strict]',
+    description:
+      'Check command availability, platform support, and setup hints for bundled local toolkits.',
+    options: [
+      { name: '--json', description: 'Print structured readiness report' },
+      {
+        name: '--all-platforms',
+        description: 'Include unsupported toolkits for the current platform',
+      },
+      { name: '--toolkits <text>', description: 'Comma-separated local toolkit slug filter' },
+      { name: '--strict', description: 'Exit non-zero if any visible local tool is not ready' },
+    ],
+    examples: [
+      'composio local-tools doctor',
+      'composio local-tools doctor --json',
+      'composio local-tools doctor --toolkits chrome_devtools --strict',
     ],
     seeAlso: ['composio local-tools meta              Inspect local metadata state'],
   },

--- a/ts/packages/cli/test/src/commands/local-tools.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/local-tools.cmd.test.ts
@@ -50,5 +50,32 @@ describe('CLI: composio local-tools', () => {
           expect(payload.toolkits.map(toolkit => toolkit.slug)).toEqual(['CHROME_DEVTOOLS']);
         })
     );
+
+    it.scoped('[Given] doctor --json [Then] reports local readiness statuses', () =>
+      Effect.gen(function* () {
+        yield* cli(['local-tools', 'doctor', '--json', '--all-platforms']);
+
+        const lines = yield* MockConsole.getLines({ stripAnsi: true });
+        const payload = JSON.parse(lines.at(-1) ?? '') as {
+          metadataPath: string;
+          toolkits: Array<{
+            slug: string;
+            status: string;
+            tools: Array<{ finalSlug: string; status: string; command?: { command: string } }>;
+          }>;
+        };
+
+        expect(payload.metadataPath).toContain('local_tools.json');
+        expect(payload.toolkits.map(toolkit => toolkit.slug)).toEqual(
+          expect.arrayContaining(['BEEPER_IMESSAGE', 'CHROME_DEVTOOLS', 'PEEKABOO'])
+        );
+        expect(payload.toolkits.flatMap(toolkit => toolkit.tools.map(tool => tool.status))).toEqual(
+          expect.arrayContaining([expect.any(String)])
+        );
+        expect(
+          payload.toolkits.flatMap(toolkit => toolkit.tools.map(tool => tool.finalSlug))
+        ).toContain('LOCAL_CHROME_DEVTOOLS_CALL_TOOL');
+      })
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Add readiness/doctor helpers to `@composio/cli-local-tools` for platform support, disabled metadata, command availability, MCP launcher availability, and setup hints.
- Add `composio local-tools doctor` with human/JSON output and `--strict` for scriptable readiness checks.
- Add setup hints for Beeper iMessage, Chrome DevTools MCP, and Peekaboo declarations.
- Extend local-tools tests to cover doctor JSON output and package readiness reports.

## Stack
- Builds on #3337 / `pi/local-tools-cli-8b540253`, which builds on #3336.

## Tests
- `pnpm exec eslint ts/packages/cli-local-tools/src/readiness.ts ts/packages/cli-local-tools/src/types.ts ts/packages/cli-local-tools/src/index.ts ts/packages/cli-local-tools/src/toolkits/beeper-imessage.ts ts/packages/cli-local-tools/src/toolkits/chrome-devtools.ts ts/packages/cli-local-tools/src/toolkits/peekaboo.ts ts/packages/cli-local-tools/src/registry.test.ts ts/packages/cli/src/commands/local-tools/commands/local-tools.doctor.cmd.ts ts/packages/cli/src/commands/local-tools/local-tools.cmd.ts ts/packages/cli/src/commands/root-help.ts ts/packages/cli/test/src/commands/local-tools.cmd.test.ts --quiet`
- `pnpm --filter @composio/cli-local-tools typecheck:tsc`
- `pnpm --filter @composio/cli-local-tools test`
- `pnpm --filter @composio/cli-local-tools build`
- `pnpm --filter @composio/cli typecheck:tsc`
- `cd ts/packages/cli && pnpm exec vitest run test/src/commands/local-tools.cmd.test.ts`
- `cd ts/packages/cli && pnpm exec tsdown --config-loader unrun`

## Notes
- The normal CLI build script still hits the repo-local tsdown native config-loader issue in this checkout, so the CLI bundle was verified with `--config-loader unrun`.
