### PR TITLE
feat(cli): configure local tools metadata

### DIFF
--- a/.changeset/cli-local-tools.md
+++ b/.changeset/cli-local-tools.md
@@ -3,4 +3,4 @@
 '@composio/cli-local-tools': patch
 ---
 
-Scaffold bundled CLI local tools, wire them into CLI search/execute sessions, and expose `composio local-tools list|doctor|meta` for discovery, readiness checks, setup hints, and local metadata state.
+Scaffold bundled CLI local tools, wire them into CLI search/execute sessions, and expose `composio local-tools list|doctor|configure|meta` for discovery, readiness checks, setup hints, and local metadata state.

--- a/ts/packages/cli-local-tools/src/meta.ts
+++ b/ts/packages/cli-local-tools/src/meta.ts
@@ -39,7 +39,9 @@ export interface LocalToolsMetaOptions {
 }
 
 export const getLocalToolsMetaPath = (options: LocalToolsMetaOptions = {}): string =>
-  options.path ?? path.join(options.homeDir ?? os.homedir(), 'composio', 'local_tools.json');
+  options.path ??
+  process.env.COMPOSIO_LOCAL_TOOLS_PATH ??
+  path.join(options.homeDir ?? os.homedir(), 'composio', 'local_tools.json');
 
 export const createEmptyLocalToolsMeta = (): LocalToolsMetaFile => ({
   version: LOCAL_TOOLS_META_VERSION,
@@ -58,9 +60,7 @@ const parseLocalToolsMeta = (raw: string): LocalToolsMetaFile => {
   return {
     version: typeof parsed.version === 'number' ? parsed.version : LOCAL_TOOLS_META_VERSION,
     updatedAt: typeof parsed.updatedAt === 'string' ? parsed.updatedAt : undefined,
-    tools: isRecord(parsed.tools)
-      ? (parsed.tools as Record<string, LocalToolMetaEntry>)
-      : {},
+    tools: isRecord(parsed.tools) ? (parsed.tools as Record<string, LocalToolMetaEntry>) : {},
     toolkits: isRecord(parsed.toolkits)
       ? (parsed.toolkits as Record<string, LocalToolkitMetaEntry>)
       : {},

--- a/ts/packages/cli/src/commands/local-tools/commands/local-tools.configure.cmd.ts
+++ b/ts/packages/cli/src/commands/local-tools/commands/local-tools.configure.cmd.ts
@@ -1,0 +1,180 @@
+import { Args, Command, Options } from '@effect/cli';
+import {
+  getLocalToolsMetaPath,
+  isLocalToolkitSlug,
+  resolveLocalTool,
+  updateLocalToolkitMeta,
+  updateLocalToolMeta,
+  type LocalToolMetaEntry,
+} from '@composio/cli-local-tools';
+import { Effect, Option } from 'effect';
+import { TerminalUI } from 'src/services/terminal-ui';
+import { bold, gray } from 'src/ui/colors';
+
+const selector = Args.text({ name: 'selector' }).pipe(
+  Args.withDescription('Local toolkit slug or LOCAL_* tool slug to configure')
+);
+
+const command = Options.text('command').pipe(
+  Options.optional,
+  Options.withDescription('Override the local binary/launcher command')
+);
+
+const disable = Options.boolean('disable').pipe(
+  Options.withDefault(false),
+  Options.withDescription('Disable this local toolkit/tool')
+);
+
+const enable = Options.boolean('enable').pipe(
+  Options.withDefault(false),
+  Options.withDescription('Enable this local toolkit/tool by clearing disabled=false')
+);
+
+const authenticated = Options.boolean('authenticated').pipe(
+  Options.withDefault(false),
+  Options.withDescription('Mark this local toolkit/tool as authenticated in metadata')
+);
+
+const unauthenticated = Options.boolean('unauthenticated').pipe(
+  Options.withDefault(false),
+  Options.withDescription('Mark this local toolkit/tool as unauthenticated in metadata')
+);
+
+const json = Options.boolean('json').pipe(
+  Options.withDefault(false),
+  Options.withDescription('Print the updated metadata entry as JSON')
+);
+
+type ConfigureTarget =
+  | {
+      readonly kind: 'toolkit';
+      readonly key: string;
+      readonly label: string;
+    }
+  | {
+      readonly kind: 'tool';
+      readonly key: string;
+      readonly label: string;
+      readonly toolkitSlug: string;
+    };
+
+const resolveTarget = (value: string): ConfigureTarget | null => {
+  const localTool = resolveLocalTool(value, { includeUnsupported: true });
+  if (localTool) {
+    return {
+      kind: 'tool',
+      key: localTool.finalSlug,
+      label: localTool.finalSlug,
+      toolkitSlug: localTool.toolkit.slug,
+    };
+  }
+
+  if (isLocalToolkitSlug(value)) {
+    return {
+      kind: 'toolkit',
+      key: value.toLowerCase(),
+      label: value.toUpperCase(),
+    };
+  }
+
+  return null;
+};
+
+const buildPatch = (params: {
+  readonly command: Option.Option<string>;
+  readonly disable: boolean;
+  readonly enable: boolean;
+  readonly authenticated: boolean;
+  readonly unauthenticated: boolean;
+}): LocalToolMetaEntry | { readonly error: string } => {
+  if (params.disable && params.enable) {
+    return { error: 'Pass only one of --disable or --enable.' };
+  }
+  if (params.authenticated && params.unauthenticated) {
+    return { error: 'Pass only one of --authenticated or --unauthenticated.' };
+  }
+
+  const commandOverride = Option.getOrUndefined(params.command)?.trim();
+  const hasCommandOverride = commandOverride !== undefined && commandOverride.length > 0;
+  const hasChanges =
+    hasCommandOverride ||
+    params.disable ||
+    params.enable ||
+    params.authenticated ||
+    params.unauthenticated;
+  if (!hasChanges) {
+    return {
+      error:
+        'Nothing to configure. Pass --command, --enable/--disable, or --authenticated/--unauthenticated.',
+    };
+  }
+
+  return {
+    ...(hasCommandOverride ? { installation: { command: commandOverride } } : {}),
+    ...(params.disable ? { disabled: true } : {}),
+    ...(params.enable ? { disabled: false } : {}),
+    ...(params.authenticated ? { authenticated: true } : {}),
+    ...(params.unauthenticated ? { authenticated: false } : {}),
+  };
+};
+
+const formatEntry = (target: ConfigureTarget, entry: LocalToolMetaEntry, metadataPath: string) =>
+  [
+    `${bold('Target:')} ${target.kind} ${target.label}`,
+    `${bold('Path:')} ${metadataPath}`,
+    `${bold('Command:')} ${entry.installation?.command ?? '-'}`,
+    `${bold('Disabled:')} ${entry.disabled === undefined ? '-' : String(entry.disabled)}`,
+    `${bold('Authenticated:')} ${entry.authenticated === undefined ? '-' : String(entry.authenticated)}`,
+    `${gray('Next:')} run \`composio local-tools doctor --toolkits ${target.kind === 'toolkit' ? target.key : target.toolkitSlug}\``,
+  ].join('\n');
+
+export const localToolsCmd$Configure = Command.make(
+  'configure',
+  { selector, command, disable, enable, authenticated, unauthenticated, json },
+  ({ selector, command, disable, enable, authenticated, unauthenticated, json }) =>
+    Effect.gen(function* () {
+      const ui = yield* TerminalUI;
+      const target = resolveTarget(selector);
+      if (!target) {
+        return yield* Effect.fail(
+          new Error(
+            `Unknown local toolkit/tool "${selector}". Run \`composio local-tools list --all-platforms\` to inspect valid selectors.`
+          )
+        );
+      }
+
+      const patch = buildPatch({ command, disable, enable, authenticated, unauthenticated });
+      if ('error' in patch) {
+        return yield* Effect.fail(new Error(patch.error));
+      }
+
+      const metadata = yield* Effect.tryPromise(() =>
+        target.kind === 'toolkit'
+          ? updateLocalToolkitMeta(target.key, patch)
+          : updateLocalToolMeta(target.key, patch)
+      );
+      const entry =
+        target.kind === 'toolkit' ? metadata.toolkits[target.key]! : metadata.tools[target.key]!;
+      const metadataPath = getLocalToolsMetaPath();
+      const payload = { metadataPath, target, entry };
+
+      if (json) {
+        yield* ui.output(JSON.stringify(payload, null, 2), { force: true });
+        return;
+      }
+
+      yield* ui.log.success(`Updated local ${target.kind} metadata.`);
+      yield* ui.log.message(formatEntry(target, entry, metadataPath));
+    })
+).pipe(
+  Command.withDescription(
+    [
+      'Configure local toolkit/tool metadata without hand-editing ~/composio/local_tools.json.',
+      '',
+      'Examples:',
+      '  composio local-tools configure peekaboo --command /opt/homebrew/bin/peekaboo',
+      '  composio local-tools configure LOCAL_PEEKABOO_RUN_CLI --disable',
+      '  composio local-tools configure chrome_devtools --authenticated --json',
+    ].join('\n')
+  )
+);

--- a/ts/packages/cli/src/commands/local-tools/local-tools.cmd.ts
+++ b/ts/packages/cli/src/commands/local-tools/local-tools.cmd.ts
@@ -1,9 +1,15 @@
 import { Command } from '@effect/cli';
+import { localToolsCmd$Configure } from './commands/local-tools.configure.cmd';
 import { localToolsCmd$Doctor } from './commands/local-tools.doctor.cmd';
 import { localToolsCmd$List } from './commands/local-tools.list.cmd';
 import { localToolsCmd$Meta } from './commands/local-tools.meta.cmd';
 
 export const localToolsCmd = Command.make('local-tools').pipe(
   Command.withDescription('Inspect and configure bundled local CLI tools.'),
-  Command.withSubcommands([localToolsCmd$List, localToolsCmd$Doctor, localToolsCmd$Meta])
+  Command.withSubcommands([
+    localToolsCmd$List,
+    localToolsCmd$Doctor,
+    localToolsCmd$Configure,
+    localToolsCmd$Meta,
+  ])
 );

--- a/ts/packages/cli/src/commands/root-help.ts
+++ b/ts/packages/cli/src/commands/root-help.ts
@@ -187,6 +187,10 @@ const FULL_COMMANDS: ReadonlyArray<TaggedValue<CompactCommand>> = [
     name: 'local-tools doctor',
     description: 'Check local toolkit readiness and setup hints',
   }),
+  full({
+    name: 'local-tools configure',
+    description: 'Set local toolkit/tool metadata overrides',
+  }),
   full({ name: 'local-tools meta', description: 'Inspect or initialize local tools metadata' }),
   full({ name: 'generate ts', description: 'Generate TypeScript stubs for selected toolkits' }),
   full({ name: 'generate py', description: 'Generate Python stubs for selected toolkits' }),
@@ -579,13 +583,13 @@ const SUBCOMMAND_HELP: Record<string, SubcommandHelp | TaggedValue<SubcommandHel
     ],
   },
   'local-tools': {
-    usage: 'composio local-tools <list|meta>',
+    usage: 'composio local-tools <list|doctor|configure|meta>',
     description:
       'Inspect local CLI tools that the Tool Router can search and execute alongside hosted Composio tools.',
     examples: [
       'composio local-tools list',
       'composio local-tools doctor',
-      'composio local-tools meta --init',
+      'composio local-tools configure peekaboo --command /opt/homebrew/bin/peekaboo',
     ],
     seeAlso: [
       'composio search "chrome page" --toolkits chrome_devtools    Search local Chrome DevTools tools',
@@ -630,6 +634,34 @@ const SUBCOMMAND_HELP: Record<string, SubcommandHelp | TaggedValue<SubcommandHel
       'composio local-tools doctor --toolkits chrome_devtools --strict',
     ],
     seeAlso: ['composio local-tools meta              Inspect local metadata state'],
+  },
+  'local-tools configure': {
+    usage:
+      'composio local-tools configure <selector> [--command <text>] [--enable|--disable] [--authenticated|--unauthenticated] [--json]',
+    description:
+      'Configure ~/composio/local_tools.json for a local toolkit slug or LOCAL_* tool slug without hand-editing JSON.',
+    args: [
+      {
+        name: '<selector>',
+        description: 'Local toolkit slug (peekaboo) or LOCAL_* tool slug',
+      },
+    ],
+    options: [
+      { name: '--command <text>', description: 'Override the local binary/launcher command' },
+      { name: '--json', description: 'Print the updated metadata entry as JSON' },
+    ],
+    flags: [
+      { name: '--enable', description: 'Clear disabled state' },
+      { name: '--disable', description: 'Disable this local toolkit/tool' },
+      { name: '--authenticated', description: 'Mark this local toolkit/tool authenticated' },
+      { name: '--unauthenticated', description: 'Mark this local toolkit/tool unauthenticated' },
+    ],
+    examples: [
+      'composio local-tools configure peekaboo --command /opt/homebrew/bin/peekaboo',
+      'composio local-tools configure LOCAL_PEEKABOO_RUN_CLI --disable',
+      'composio local-tools configure chrome_devtools --authenticated --json',
+    ],
+    seeAlso: ['composio local-tools doctor            Validate the configured command'],
   },
   'local-tools meta': {
     usage: 'composio local-tools meta [--json] [--init]',

--- a/ts/packages/cli/test/src/commands/local-tools.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/local-tools.cmd.test.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import { describe, expect, layer } from '@effect/vitest';
 import { Effect } from 'effect';
 import { cli, MockConsole, TestLive } from 'test/__utils__';
@@ -76,6 +79,59 @@ describe('CLI: composio local-tools', () => {
           payload.toolkits.flatMap(toolkit => toolkit.tools.map(tool => tool.finalSlug))
         ).toContain('LOCAL_CHROME_DEVTOOLS_CALL_TOOL');
       })
+    );
+
+    it.scoped('[Given] configure --json [Then] writes local metadata overrides', () =>
+      Effect.acquireUseRelease(
+        Effect.sync(() => {
+          const previous = process.env.COMPOSIO_LOCAL_TOOLS_PATH;
+          process.env.COMPOSIO_LOCAL_TOOLS_PATH = path.join(
+            os.tmpdir(),
+            `composio-local-tools-${Date.now()}.json`
+          );
+          return previous;
+        }),
+        () =>
+          Effect.gen(function* () {
+            yield* cli([
+              'local-tools',
+              'configure',
+              'peekaboo',
+              '--command',
+              '/tmp/peekaboo',
+              '--authenticated',
+              '--json',
+            ]);
+
+            const lines = yield* MockConsole.getLines({ stripAnsi: true });
+            const payload = JSON.parse(lines.at(-1) ?? '') as {
+              metadataPath: string;
+              target: { kind: string; key: string };
+              entry: { installation?: { command?: string }; authenticated?: boolean };
+            };
+            const file = JSON.parse(
+              yield* Effect.tryPromise(() => fs.readFile(payload.metadataPath, 'utf8'))
+            ) as {
+              toolkits: Record<
+                string,
+                { installation?: { command?: string }; authenticated?: boolean }
+              >;
+            };
+
+            expect(payload.target).toMatchObject({ kind: 'toolkit', key: 'peekaboo' });
+            expect(payload.entry.installation?.command).toBe('/tmp/peekaboo');
+            expect(payload.entry.authenticated).toBe(true);
+            expect(file.toolkits.peekaboo?.installation?.command).toBe('/tmp/peekaboo');
+          }),
+        previous =>
+          Effect.sync(() => {
+            if (previous === undefined) {
+              delete process.env.COMPOSIO_LOCAL_TOOLS_PATH;
+            } else {
+              process.env.COMPOSIO_LOCAL_TOOLS_PATH = previous;
+            }
+          })
+      )
     );
   });
 });


### PR DESCRIPTION
## Summary
- Add `composio local-tools configure` for metadata updates without hand-editing `~/composio/local_tools.json`.
- Support toolkit/tool command overrides, enable/disable, authenticated/unauthenticated metadata, and JSON output.
- Add `COMPOSIO_LOCAL_TOOLS_PATH` override for tests and scripted local-tools metadata workflows.
- Extend local-tools help and tests for configure writes.

## Stack
- Builds on #3338 / `pi/local-tools-doctor-f9dff868`, which builds on #3337 and #3336.

## Tests
- `pnpm exec eslint ts/packages/cli-local-tools/src/meta.ts ts/packages/cli/src/commands/local-tools/commands/local-tools.configure.cmd.ts ts/packages/cli/src/commands/local-tools/local-tools.cmd.ts ts/packages/cli/src/commands/root-help.ts ts/packages/cli/test/src/commands/local-tools.cmd.test.ts --quiet`
- `pnpm --filter @composio/cli-local-tools typecheck:tsc`
- `pnpm --filter @composio/cli-local-tools test`
- `pnpm --filter @composio/cli-local-tools build`
- `pnpm --filter @composio/cli typecheck:tsc`
- `cd ts/packages/cli && pnpm exec vitest run test/src/commands/local-tools.cmd.test.ts`
- `cd ts/packages/cli && pnpm exec tsdown --config-loader unrun`

## Notes
- The normal CLI build script still hits the repo-local tsdown native config-loader issue in this checkout, so the CLI bundle was verified with `--config-loader unrun`.
