### PR TITLE
feat(cli): add Chrome DevTools local tools

### DIFF
--- a/.changeset/chrome-devtools-local-tools.md
+++ b/.changeset/chrome-devtools-local-tools.md
@@ -1,0 +1,5 @@
+---
+'@composio/cli-local-tools': patch
+---
+
+Add first-class Chrome DevTools local tools backed by the official `chrome-devtools-mcp` package and its stateful `chrome-devtools` CLI daemon.

--- a/.changeset/peekaboo-local-tools.md
+++ b/.changeset/peekaboo-local-tools.md
@@ -1,0 +1,5 @@
+---
+'@composio/cli-local-tools': patch
+---
+
+Add first-class Peekaboo macOS local tools backed by a bundled darwin-arm64 Peekaboo CLI binary.

--- a/ts/packages/cli-local-tools/local-tools-binaries/peekaboo/LICENSE.txt
+++ b/ts/packages/cli-local-tools/local-tools-binaries/peekaboo/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Peter Steinberger
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ts/packages/cli-local-tools/local-tools-binaries/peekaboo/NOTICE.md
+++ b/ts/packages/cli-local-tools/local-tools-binaries/peekaboo/NOTICE.md
@@ -1,0 +1,13 @@
+# Peekaboo bundled CLI
+
+This directory contains a macOS arm64 Peekaboo CLI binary built from the upstream
+`steipete/Peekaboo` project for local Composio CLI tools.
+
+- Upstream repository: https://github.com/steipete/Peekaboo
+- Upstream commit researched: 31e66e8d02656141d18f60bf3b46b24c2b9bc785
+- Upstream package version: 3.0.0-beta4
+- License: MIT (see LICENSE.txt)
+
+The binary is bundled as a sidecar asset and resolved at runtime by
+`@composio/cli-local-tools`. If it is unavailable, users may install Peekaboo
+separately with `brew install steipete/tap/peekaboo` and use `peekaboo` from PATH.

--- a/ts/packages/cli-local-tools/src/readiness.ts
+++ b/ts/packages/cli-local-tools/src/readiness.ts
@@ -341,6 +341,24 @@ const checkToolReadiness = async (params: {
     };
   }
 
+  if (tool.execution.kind === 'native' && tool.execution.readiness) {
+    const command = await checkCommand(
+      commandOverride ?? tool.execution.readiness.command,
+      tool.execution.readiness.args
+    );
+    return {
+      ...base,
+      status: command.found ? 'ready' : 'missing',
+      command,
+      messages: command.found
+        ? [
+            `Native wrapper prerequisite found: ${command.path ?? command.command}; app-specific runtime checks still happen at execution time.`,
+          ]
+        : [`Native wrapper prerequisite not found on PATH: ${command.command}.`],
+      hints: command.found ? [] : setupHintsForToolkit(toolkit),
+    };
+  }
+
   if (tool.execution.kind === 'native' && toolkit.bundledBinaries?.length) {
     const bundledChecks = await Promise.all(
       toolkit.bundledBinaries.map(async binary => ({

--- a/ts/packages/cli-local-tools/src/registry.test.ts
+++ b/ts/packages/cli-local-tools/src/registry.test.ts
@@ -43,7 +43,7 @@ const findToolkit = (
 describe('@composio/cli-local-tools registry', () => {
   it('registers concrete local toolkits in the integration layer', () => {
     expect(localToolkitDeclarations.map(toolkit => toolkit.slug)).toEqual(
-      expect.arrayContaining(['BEEPER_IMESSAGE', 'CHROME_DEVTOOLS'])
+      expect.arrayContaining(['BEEPER_IMESSAGE', 'CHROME_DEVTOOLS', 'PEEKABOO'])
     );
     expect(
       localToolkitDeclarations
@@ -55,6 +55,11 @@ describe('@composio/cli-local-tools registry', () => {
         .find(toolkit => toolkit.slug === 'CHROME_DEVTOOLS')
         ?.tools.map(tool => tool.slug)
     ).toEqual(expect.arrayContaining(['LIST_PAGES', 'NEW_PAGE', 'EVALUATE_SCRIPT']));
+    expect(
+      localToolkitDeclarations
+        .find(toolkit => toolkit.slug === 'PEEKABOO')
+        ?.tools.map(tool => tool.slug)
+    ).toEqual(expect.arrayContaining(['PERMISSIONS_STATUS', 'SEE', 'CLICK']));
   });
 
   it('normalizes local tool slugs to the Tool Router LOCAL_<TOOLKIT>_<TOOL> shape', () => {

--- a/ts/packages/cli-local-tools/src/registry.test.ts
+++ b/ts/packages/cli-local-tools/src/registry.test.ts
@@ -41,13 +41,20 @@ const findToolkit = (
 ) => payload?.custom_toolkits?.find(toolkit => toolkit.slug === slug);
 
 describe('@composio/cli-local-tools registry', () => {
-  it('registers the Beeper iMessage local toolkit in the concrete integration layer', () => {
-    expect(localToolkitDeclarations.map(toolkit => toolkit.slug)).toContain('BEEPER_IMESSAGE');
+  it('registers concrete local toolkits in the integration layer', () => {
+    expect(localToolkitDeclarations.map(toolkit => toolkit.slug)).toEqual(
+      expect.arrayContaining(['BEEPER_IMESSAGE', 'CHROME_DEVTOOLS'])
+    );
     expect(
       localToolkitDeclarations
         .find(toolkit => toolkit.slug === 'BEEPER_IMESSAGE')
         ?.tools.map(tool => tool.slug)
     ).toEqual(expect.arrayContaining(['LIST_THREADS', 'SEND_MESSAGE', 'AUTHORIZE']));
+    expect(
+      localToolkitDeclarations
+        .find(toolkit => toolkit.slug === 'CHROME_DEVTOOLS')
+        ?.tools.map(tool => tool.slug)
+    ).toEqual(expect.arrayContaining(['LIST_PAGES', 'NEW_PAGE', 'EVALUATE_SCRIPT']));
   });
 
   it('normalizes local tool slugs to the Tool Router LOCAL_<TOOLKIT>_<TOOL> shape', () => {

--- a/ts/packages/cli-local-tools/src/registry.ts
+++ b/ts/packages/cli-local-tools/src/registry.ts
@@ -1,5 +1,6 @@
 import zodToJsonSchema from 'zod-to-json-schema';
 import { beeperImessageToolkit } from './toolkits/beeper-imessage';
+import { chromeDevtoolsToolkit } from './toolkits/chrome-devtools';
 import type { z } from 'zod/v3';
 import { formatSupportedPlatforms, detectCliPlatform, supportsCliPlatform } from './platform';
 import { executeLocalTool } from './runtime';
@@ -37,6 +38,7 @@ interface LocalCustomToolkit {
  */
 export const localToolkitDeclarations: ReadonlyArray<LocalToolkitDeclaration> = [
   beeperImessageToolkit,
+  chromeDevtoolsToolkit,
 ];
 
 const normalizeSegment = (value: string): string =>

--- a/ts/packages/cli-local-tools/src/registry.ts
+++ b/ts/packages/cli-local-tools/src/registry.ts
@@ -1,6 +1,7 @@
 import zodToJsonSchema from 'zod-to-json-schema';
 import { beeperImessageToolkit } from './toolkits/beeper-imessage';
 import { chromeDevtoolsToolkit } from './toolkits/chrome-devtools';
+import { peekabooToolkit } from './toolkits/peekaboo';
 import type { z } from 'zod/v3';
 import { formatSupportedPlatforms, detectCliPlatform, supportsCliPlatform } from './platform';
 import { executeLocalTool } from './runtime';
@@ -39,6 +40,7 @@ interface LocalCustomToolkit {
 export const localToolkitDeclarations: ReadonlyArray<LocalToolkitDeclaration> = [
   beeperImessageToolkit,
   chromeDevtoolsToolkit,
+  peekabooToolkit,
 ];
 
 const normalizeSegment = (value: string): string =>

--- a/ts/packages/cli-local-tools/src/toolkits/chrome-devtools.test.ts
+++ b/ts/packages/cli-local-tools/src/toolkits/chrome-devtools.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { executeLocalToolBySlug, getLocalToolInputDefinition } from '../registry';
+import { chromeDevtoolsToolkit } from './chrome-devtools';
+
+describe('@composio/cli-local-tools Chrome DevTools toolkit', () => {
+  it('exposes first-class schemas for documented Chrome DevTools tools', () => {
+    expect(chromeDevtoolsToolkit.source?.type).toBe('mcp');
+    expect(chromeDevtoolsToolkit.tools.map(tool => tool.slug)).toEqual(
+      expect.arrayContaining([
+        'LIST_PAGES',
+        'NEW_PAGE',
+        'NAVIGATE_PAGE',
+        'TAKE_SNAPSHOT',
+        'EVALUATE_SCRIPT',
+        'CLICK',
+        'DRAG',
+        'HANDLE_DIALOG',
+        'LIST_NETWORK_REQUESTS',
+        'LIST_EXTENSIONS',
+      ])
+    );
+
+    const newPageSchema = getLocalToolInputDefinition('LOCAL_CHROME_DEVTOOLS_NEW_PAGE');
+    expect(newPageSchema?.schema.properties).toHaveProperty('url');
+    expect(newPageSchema?.schema.required).toContain('url');
+
+    const evaluateSchema = getLocalToolInputDefinition('LOCAL_CHROME_DEVTOOLS_EVALUATE_SCRIPT');
+    expect(evaluateSchema?.schema.properties).toHaveProperty('function');
+    expect(evaluateSchema?.schema.properties).toHaveProperty('args');
+  });
+
+  it.runIf(process.env.COMPOSIO_REAL_LOCAL_TOOLS_TESTS === '1')(
+    'validates against a real chrome-devtools-mcp daemon',
+    async () => {
+      try {
+        const start = await executeLocalToolBySlug('LOCAL_CHROME_DEVTOOLS_START_DAEMON', {
+          headless: true,
+          usageStatistics: false,
+          performanceCrux: false,
+        });
+        expect(start?.ok).toBe(true);
+
+        const page = await executeLocalToolBySlug('LOCAL_CHROME_DEVTOOLS_NEW_PAGE', {
+          url: 'data:text/html,<title>Composio Chrome Local Tools</title><h1>Hello from Chrome</h1>',
+        });
+        expect(page?.ok).toBe(true);
+
+        const evaluated = await executeLocalToolBySlug('LOCAL_CHROME_DEVTOOLS_EVALUATE_SCRIPT', {
+          function: '() => document.title',
+        });
+        expect(evaluated?.result).toEqual(
+          expect.objectContaining({
+            message: expect.stringContaining('Composio Chrome Local Tools'),
+          })
+        );
+
+        const pages = await executeLocalToolBySlug('LOCAL_CHROME_DEVTOOLS_LIST_PAGES', {});
+        expect(pages?.result).toEqual(expect.objectContaining({ pages: expect.any(Array) }));
+      } finally {
+        await executeLocalToolBySlug('LOCAL_CHROME_DEVTOOLS_STOP_DAEMON', {});
+      }
+    },
+    120_000
+  );
+});

--- a/ts/packages/cli-local-tools/src/toolkits/chrome-devtools.ts
+++ b/ts/packages/cli-local-tools/src/toolkits/chrome-devtools.ts
@@ -1,0 +1,788 @@
+import { z } from 'zod/v3';
+import { runLocalCommand } from '../runtime';
+import type {
+  LocalCommandExecution,
+  LocalExecutionContext,
+  LocalExecutionResult,
+  LocalToolkitDeclaration,
+  LocalToolDeclaration,
+} from '../types';
+
+const CHROME_DEVTOOLS_MCP_VERSION = '0.24.0';
+const COMMAND_TIMEOUT_MS = 180_000;
+
+const cliOutput = z.object({
+  ok: z.boolean(),
+  commandName: z.string(),
+  result: z.unknown().optional(),
+  resultText: z.string().optional(),
+  stdout: z.string(),
+  stderr: z.string(),
+});
+
+const baseInput = z.object({
+  debug: z.boolean().default(false).describe('Set DEBUG=* for the chrome-devtools command.'),
+  sessionId: z
+    .string()
+    .optional()
+    .describe('Optional upstream chrome-devtools CLI session id for isolated daemon state.'),
+});
+
+const pageId = z.number().int().nonnegative().describe('Page ID from LIST_PAGES.');
+const uid = z.string().min(1).describe('Element uid from TAKE_SNAPSHOT.');
+
+const npxArgs = [
+  '-y',
+  '--package',
+  `chrome-devtools-mcp@${CHROME_DEVTOOLS_MCP_VERSION}`,
+  'chrome-devtools',
+];
+
+const addOption = (args: string[], name: string, value: unknown): string[] => {
+  if (value === undefined || value === null || value === '') return args;
+  args.push(`--${name}`, String(value));
+  return args;
+};
+
+const addBooleanFlag = (args: string[], name: string, value: unknown): string[] => {
+  if (value === true) args.push(`--${name}`);
+  return args;
+};
+
+const addBooleanOption = (args: string[], name: string, value: unknown): string[] => {
+  if (value === true) args.push(`--${name}`);
+  if (value === false) args.push(`--no-${name}`);
+  return args;
+};
+
+const addRepeated = (args: string[], name: string, values: unknown): string[] => {
+  if (!Array.isArray(values)) return args;
+  for (const value of values) {
+    if (value === undefined || value === null || value === '') continue;
+    args.push(`--${name}`, String(value));
+  }
+  return args;
+};
+
+const extractJson = (text: string): unknown | undefined => {
+  const candidates = [text.indexOf('{'), text.indexOf('[')].filter(index => index >= 0);
+  if (!candidates.length) return undefined;
+
+  const start = Math.min(...candidates);
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let index = start; index < text.length; index += 1) {
+    const char = text[index];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+    if (char === '{' || char === '[') {
+      depth += 1;
+      continue;
+    }
+    if (char === '}' || char === ']') {
+      depth -= 1;
+      if (depth === 0) {
+        try {
+          return JSON.parse(text.slice(start, index + 1)) as unknown;
+        } catch {
+          return undefined;
+        }
+      }
+    }
+  }
+
+  return undefined;
+};
+
+const parseChromeDevtoolsOutput = (
+  commandName: string,
+  stdout: string,
+  stderr: string,
+  parseJson: boolean
+): LocalExecutionResult => {
+  const trimmed = stdout.trim();
+  const result = parseJson ? extractJson(trimmed) : undefined;
+  return {
+    ok: true,
+    commandName,
+    ...(result !== undefined ? { result } : {}),
+    ...(result === undefined && trimmed ? { resultText: trimmed } : {}),
+    stdout,
+    stderr,
+  };
+};
+
+const runChromeDevtools = async (
+  commandName: string,
+  commandArgs: ReadonlyArray<string>,
+  input: Record<string, unknown>,
+  context: LocalExecutionContext,
+  options: { readonly json?: boolean } = { json: true }
+): Promise<LocalExecutionResult> => {
+  const args = [...npxArgs];
+  addOption(args, 'sessionId', input.sessionId);
+  args.push(commandName, ...commandArgs);
+  if (options.json !== false) args.push('--output-format=json');
+  const execution: LocalCommandExecution = {
+    kind: 'command',
+    command: 'npx',
+    args,
+    env: {
+      CHROME_DEVTOOLS_MCP_NO_UPDATE_CHECKS: '1',
+      ...(input.usageStatistics === true ? {} : { CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS: '1' }),
+      ...(input.debug === true ? { DEBUG: '*' } : {}),
+    },
+    timeoutMs: COMMAND_TIMEOUT_MS,
+  };
+  const result = await runLocalCommand(execution, input, context);
+  return parseChromeDevtoolsOutput(
+    commandName,
+    String(result.stdout ?? ''),
+    String(result.stderr ?? ''),
+    options.json !== false
+  );
+};
+
+const commandTool = <TInput extends z.ZodTypeAny>(definition: {
+  readonly slug: string;
+  readonly name: string;
+  readonly description: string;
+  readonly inputParams: TInput;
+  readonly command: string;
+  readonly args: (input: z.infer<TInput>) => ReadonlyArray<string>;
+  readonly json?: boolean;
+}): LocalToolDeclaration<TInput> => ({
+  slug: definition.slug,
+  name: definition.name,
+  description: definition.description,
+  platforms: ['darwin-arm64', 'darwin-x64', 'linux-arm64', 'linux-x64', 'win32-arm64', 'win32-x64'],
+  inputParams: definition.inputParams,
+  outputParams: cliOutput,
+  execution: {
+    kind: 'native',
+    readiness: {
+      command: 'npx',
+      args: npxArgs,
+    },
+    execute: (input, context) =>
+      runChromeDevtools(
+        definition.command,
+        definition.args(input as z.infer<TInput>),
+        input,
+        context,
+        { json: definition.json }
+      ),
+  },
+});
+
+export const chromeDevtoolsToolkit: LocalToolkitDeclaration = {
+  slug: 'CHROME_DEVTOOLS',
+  name: 'Chrome DevTools (local)',
+  description:
+    'Local Chrome automation and debugging tools backed by the official chrome-devtools-mcp package and its chrome-devtools CLI daemon.',
+  platforms: ['darwin-arm64', 'darwin-x64', 'linux-arm64', 'linux-x64', 'win32-arm64', 'win32-x64'],
+  source: {
+    type: 'mcp',
+    package: `chrome-devtools-mcp@${CHROME_DEVTOOLS_MCP_VERSION}`,
+    repository: 'https://github.com/ChromeDevTools/chrome-devtools-mcp',
+    command: `npx -y --package chrome-devtools-mcp@${CHROME_DEVTOOLS_MCP_VERSION} chrome-devtools`,
+  },
+  setup: {
+    install: `Requires Node.js/npm and a supported Chrome installation. Tools run via npx --package chrome-devtools-mcp@${CHROME_DEVTOOLS_MCP_VERSION} chrome-devtools.`,
+    commandOverrides: [],
+    notes: [
+      'The upstream chrome-devtools CLI automatically starts and reuses a background chrome-devtools-mcp daemon for stateful browser sessions.',
+      'Use START_DAEMON to configure headless/browserUrl/userDataDir before invoking page tools, or let the first tool auto-start the daemon with upstream defaults.',
+      'Use STOP_DAEMON when finished to close the background MCP/browser process.',
+      'Chrome DevTools MCP can inspect and modify browser contents; avoid using it on sensitive sessions.',
+    ],
+  },
+  tools: [
+    commandTool({
+      slug: 'START_DAEMON',
+      name: 'Start Chrome DevTools MCP daemon',
+      description:
+        'Start or restart the background chrome-devtools-mcp daemon and browser with optional launch settings.',
+      inputParams: baseInput.extend({
+        browserUrl: z
+          .string()
+          .optional()
+          .describe('Connect to an existing debuggable Chrome URL, e.g. http://127.0.0.1:9222.'),
+        wsEndpoint: z
+          .string()
+          .optional()
+          .describe('Connect to an existing Chrome DevTools WebSocket endpoint.'),
+        headless: z.boolean().optional().describe('Run Chrome headless. Upstream default is true.'),
+        executablePath: z.string().optional().describe('Custom Chrome executable path.'),
+        userDataDir: z.string().optional().describe('Chrome user data directory.'),
+        channel: z
+          .enum(['canary', 'dev', 'beta', 'stable'])
+          .optional()
+          .describe('Chrome release channel.'),
+        isolated: z.boolean().optional().describe('Use an isolated temporary user data dir.'),
+        acceptInsecureCerts: z
+          .boolean()
+          .optional()
+          .describe('Ignore self-signed/expired certificate errors.'),
+        proxyServer: z.string().optional().describe('Chrome proxy server setting.'),
+        performanceCrux: z
+          .boolean()
+          .optional()
+          .describe('Allow CrUX field data lookups for performance tools.'),
+        usageStatistics: z
+          .boolean()
+          .optional()
+          .describe('Allow Google usage statistics for the MCP server.'),
+        slim: z.boolean().optional().describe('Expose the upstream slim tool set.'),
+        categoryExtensions: z
+          .boolean()
+          .optional()
+          .describe('Enable or disable Chrome extension tools in the upstream daemon.'),
+      }),
+      command: 'start',
+      json: false,
+      args: input => {
+        const args: string[] = [];
+        addOption(args, 'browserUrl', input.browserUrl);
+        addOption(args, 'wsEndpoint', input.wsEndpoint);
+        addBooleanOption(args, 'headless', input.headless);
+        addOption(args, 'executablePath', input.executablePath);
+        addOption(args, 'userDataDir', input.userDataDir);
+        addOption(args, 'channel', input.channel);
+        addBooleanOption(args, 'isolated', input.isolated);
+        addBooleanFlag(args, 'acceptInsecureCerts', input.acceptInsecureCerts);
+        addOption(args, 'proxyServer', input.proxyServer);
+        addBooleanOption(args, 'performanceCrux', input.performanceCrux);
+        addBooleanOption(args, 'usageStatistics', input.usageStatistics);
+        addBooleanFlag(args, 'slim', input.slim);
+        addBooleanOption(args, 'categoryExtensions', input.categoryExtensions);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'STOP_DAEMON',
+      name: 'Stop Chrome DevTools MCP daemon',
+      description: 'Stop the background chrome-devtools-mcp daemon/browser if running.',
+      inputParams: baseInput,
+      command: 'stop',
+      json: false,
+      args: () => [],
+    }),
+    commandTool({
+      slug: 'STATUS_DAEMON',
+      name: 'Get Chrome DevTools MCP daemon status',
+      description: 'Check whether the chrome-devtools-mcp daemon is running.',
+      inputParams: baseInput,
+      command: 'status',
+      json: false,
+      args: () => [],
+    }),
+    commandTool({
+      slug: 'LIST_PAGES',
+      name: 'List Chrome pages',
+      description: 'Get pages open in the browser controlled by Chrome DevTools MCP.',
+      inputParams: baseInput,
+      command: 'list_pages',
+      args: () => [],
+    }),
+    commandTool({
+      slug: 'NEW_PAGE',
+      name: 'Open new Chrome page',
+      description: 'Open a new Chrome tab and load a URL.',
+      inputParams: baseInput.extend({
+        url: z.string().url().describe('URL to load in a new page.'),
+        background: z.boolean().optional().describe('Open in background.'),
+        isolatedContext: z.string().optional().describe('Named isolated browser context.'),
+        timeout: z
+          .number()
+          .int()
+          .nonnegative()
+          .optional()
+          .describe('Maximum wait time in milliseconds.'),
+      }),
+      command: 'new_page',
+      args: input => {
+        const args = [input.url];
+        addBooleanFlag(args, 'background', input.background);
+        addOption(args, 'isolatedContext', input.isolatedContext);
+        addOption(args, 'timeout', input.timeout);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'NAVIGATE_PAGE',
+      name: 'Navigate Chrome page',
+      description: 'Navigate selected page by URL, back, forward, or reload.',
+      inputParams: baseInput.extend({
+        type: z.enum(['url', 'back', 'forward', 'reload']).optional().describe('Navigation type.'),
+        url: z.string().optional().describe('Target URL for type=url.'),
+        ignoreCache: z.boolean().optional().describe('Ignore cache on reload.'),
+        handleBeforeUnload: z
+          .enum(['accept', 'decline'])
+          .optional()
+          .describe('Handle beforeunload dialogs.'),
+        initScript: z
+          .string()
+          .optional()
+          .describe('Script to run before the next navigation document loads.'),
+        timeout: z
+          .number()
+          .int()
+          .nonnegative()
+          .optional()
+          .describe('Maximum wait time in milliseconds.'),
+      }),
+      command: 'navigate_page',
+      args: input => {
+        const args: string[] = [];
+        addOption(args, 'type', input.type);
+        addOption(args, 'url', input.url);
+        addBooleanFlag(args, 'ignoreCache', input.ignoreCache);
+        addOption(args, 'handleBeforeUnload', input.handleBeforeUnload);
+        addOption(args, 'initScript', input.initScript);
+        addOption(args, 'timeout', input.timeout);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'SELECT_PAGE',
+      name: 'Select Chrome page',
+      description: 'Select a page as context for future Chrome DevTools tool calls.',
+      inputParams: baseInput.extend({ pageId, bringToFront: z.boolean().optional() }),
+      command: 'select_page',
+      args: input => {
+        const args = [String(input.pageId)];
+        addBooleanFlag(args, 'bringToFront', input.bringToFront);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'CLOSE_PAGE',
+      name: 'Close Chrome page',
+      description: 'Close a page by ID. The last open page cannot be closed.',
+      inputParams: baseInput.extend({ pageId }),
+      command: 'close_page',
+      args: input => [String(input.pageId)],
+    }),
+    commandTool({
+      slug: 'TAKE_SNAPSHOT',
+      name: 'Take Chrome accessibility snapshot',
+      description:
+        'Take a text snapshot of the selected page, including element uids for automation.',
+      inputParams: baseInput.extend({
+        filePath: z.string().optional().describe('Optional path to save the snapshot.'),
+        verbose: z.boolean().optional().describe('Include all a11y tree details.'),
+      }),
+      command: 'take_snapshot',
+      args: input => {
+        const args: string[] = [];
+        addOption(args, 'filePath', input.filePath);
+        addBooleanFlag(args, 'verbose', input.verbose);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'TAKE_SCREENSHOT',
+      name: 'Take Chrome screenshot',
+      description: 'Take a screenshot of the selected page or element.',
+      inputParams: baseInput.extend({
+        filePath: z.string().optional(),
+        format: z.enum(['png', 'jpeg', 'webp']).optional(),
+        quality: z.number().min(0).max(100).optional(),
+        fullPage: z.boolean().optional(),
+        uid: z.string().optional(),
+      }),
+      command: 'take_screenshot',
+      args: input => {
+        const args: string[] = [];
+        addOption(args, 'filePath', input.filePath);
+        addOption(args, 'format', input.format);
+        addOption(args, 'quality', input.quality);
+        addBooleanFlag(args, 'fullPage', input.fullPage);
+        addOption(args, 'uid', input.uid);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'EVALUATE_SCRIPT',
+      name: 'Evaluate JavaScript in Chrome page',
+      description:
+        'Evaluate a JavaScript function in the selected page and return a JSON-serializable result.',
+      inputParams: baseInput.extend({
+        function: z.string().min(1).describe('Function declaration, e.g. () => document.title.'),
+        args: z.array(z.unknown()).optional().describe('Arguments passed to the function.'),
+        dialogAction: z
+          .string()
+          .optional()
+          .describe('Dialog action: accept, dismiss, or prompt response.'),
+      }),
+      command: 'evaluate_script',
+      args: input => {
+        const args = [input.function];
+        if (input.args !== undefined) addOption(args, 'args', JSON.stringify(input.args));
+        addOption(args, 'dialogAction', input.dialogAction);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'LIST_CONSOLE_MESSAGES',
+      name: 'List Chrome console messages',
+      description: 'List console messages for the selected page since the last navigation.',
+      inputParams: baseInput.extend({
+        pageSize: z.number().int().positive().optional(),
+        pageIdx: z.number().int().nonnegative().optional(),
+        types: z.array(z.string()).optional(),
+        includePreservedMessages: z.boolean().optional(),
+      }),
+      command: 'list_console_messages',
+      args: input => {
+        const args: string[] = [];
+        addOption(args, 'pageSize', input.pageSize);
+        addOption(args, 'pageIdx', input.pageIdx);
+        addRepeated(args, 'types', input.types);
+        addBooleanFlag(args, 'includePreservedMessages', input.includePreservedMessages);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'GET_CONSOLE_MESSAGE',
+      name: 'Get Chrome console message',
+      description: 'Get a console message by ID from LIST_CONSOLE_MESSAGES.',
+      inputParams: baseInput.extend({ msgid: z.number().int().nonnegative() }),
+      command: 'get_console_message',
+      args: input => [String(input.msgid)],
+    }),
+    commandTool({
+      slug: 'LIST_NETWORK_REQUESTS',
+      name: 'List Chrome network requests',
+      description: 'List network requests for the selected page since the last navigation.',
+      inputParams: baseInput.extend({
+        pageSize: z.number().int().positive().optional(),
+        pageIdx: z.number().int().nonnegative().optional(),
+        resourceTypes: z.array(z.string()).optional(),
+        includePreservedRequests: z.boolean().optional(),
+      }),
+      command: 'list_network_requests',
+      args: input => {
+        const args: string[] = [];
+        addOption(args, 'pageSize', input.pageSize);
+        addOption(args, 'pageIdx', input.pageIdx);
+        addRepeated(args, 'resourceTypes', input.resourceTypes);
+        addBooleanFlag(args, 'includePreservedRequests', input.includePreservedRequests);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'GET_NETWORK_REQUEST',
+      name: 'Get Chrome network request',
+      description:
+        'Get a selected or specific network request and optionally save bodies to files.',
+      inputParams: baseInput.extend({
+        reqid: z.number().int().nonnegative().optional(),
+        requestFilePath: z.string().optional(),
+        responseFilePath: z.string().optional(),
+      }),
+      command: 'get_network_request',
+      args: input => {
+        const args: string[] = [];
+        addOption(args, 'reqid', input.reqid);
+        addOption(args, 'requestFilePath', input.requestFilePath);
+        addOption(args, 'responseFilePath', input.responseFilePath);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'CLICK',
+      name: 'Click Chrome page element',
+      description: 'Click an element by uid from TAKE_SNAPSHOT.',
+      inputParams: baseInput.extend({
+        uid,
+        dblClick: z.boolean().optional(),
+        includeSnapshot: z.boolean().optional(),
+      }),
+      command: 'click',
+      args: input => {
+        const args = [input.uid];
+        addBooleanFlag(args, 'dblClick', input.dblClick);
+        addBooleanFlag(args, 'includeSnapshot', input.includeSnapshot);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'FILL',
+      name: 'Fill Chrome page field',
+      description: 'Fill an input, textarea, or select element by uid from TAKE_SNAPSHOT.',
+      inputParams: baseInput.extend({
+        uid,
+        value: z.string(),
+        includeSnapshot: z.boolean().optional(),
+      }),
+      command: 'fill',
+      args: input => {
+        const args = [input.uid, input.value];
+        addBooleanFlag(args, 'includeSnapshot', input.includeSnapshot);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'DRAG',
+      name: 'Drag Chrome page element',
+      description: 'Drag an element by uid onto another element by uid.',
+      inputParams: baseInput.extend({
+        from_uid: z.string().min(1).describe('Uid of the element to drag.'),
+        to_uid: z.string().min(1).describe('Uid of the drop target element.'),
+        includeSnapshot: z.boolean().optional(),
+      }),
+      command: 'drag',
+      args: input => {
+        const args = [input.from_uid, input.to_uid];
+        addBooleanFlag(args, 'includeSnapshot', input.includeSnapshot);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'HANDLE_DIALOG',
+      name: 'Handle Chrome dialog',
+      description: 'Accept or dismiss a browser dialog, optionally providing prompt text.',
+      inputParams: baseInput.extend({
+        action: z.enum(['accept', 'dismiss']),
+        promptText: z.string().optional(),
+      }),
+      command: 'handle_dialog',
+      args: input => {
+        const args = [input.action];
+        addOption(args, 'promptText', input.promptText);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'HOVER',
+      name: 'Hover Chrome page element',
+      description: 'Hover an element by uid from TAKE_SNAPSHOT.',
+      inputParams: baseInput.extend({ uid, includeSnapshot: z.boolean().optional() }),
+      command: 'hover',
+      args: input => {
+        const args = [input.uid];
+        addBooleanFlag(args, 'includeSnapshot', input.includeSnapshot);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'PRESS_KEY',
+      name: 'Press key in Chrome page',
+      description: 'Press a key or key combination in the selected page.',
+      inputParams: baseInput.extend({
+        key: z.string().min(1),
+        includeSnapshot: z.boolean().optional(),
+      }),
+      command: 'press_key',
+      args: input => {
+        const args = [input.key];
+        addBooleanFlag(args, 'includeSnapshot', input.includeSnapshot);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'TYPE_TEXT',
+      name: 'Type text in Chrome page',
+      description: 'Type text with the keyboard into the currently focused input.',
+      inputParams: baseInput.extend({
+        text: z.string(),
+        submitKey: z
+          .string()
+          .optional()
+          .describe('Optional key pressed after typing, e.g. Enter, Tab, Escape.'),
+      }),
+      command: 'type_text',
+      args: input => {
+        const args = [input.text];
+        addOption(args, 'submitKey', input.submitKey);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'UPLOAD_FILE',
+      name: 'Upload file in Chrome page',
+      description: 'Upload a local file through a file input or element that opens a file chooser.',
+      inputParams: baseInput.extend({
+        uid,
+        filePath: z.string().min(1),
+        includeSnapshot: z.boolean().optional(),
+      }),
+      command: 'upload_file',
+      args: input => {
+        const args = [input.uid, input.filePath];
+        addBooleanFlag(args, 'includeSnapshot', input.includeSnapshot);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'RESIZE_PAGE',
+      name: 'Resize Chrome page',
+      description: 'Resize the selected page window to specific dimensions.',
+      inputParams: baseInput.extend({
+        width: z.number().positive(),
+        height: z.number().positive(),
+      }),
+      command: 'resize_page',
+      args: input => [String(input.width), String(input.height)],
+    }),
+    commandTool({
+      slug: 'EMULATE',
+      name: 'Emulate Chrome page conditions',
+      description:
+        'Emulate color scheme, CPU/network throttling, geolocation, user agent, or viewport.',
+      inputParams: baseInput.extend({
+        colorScheme: z.enum(['dark', 'light', 'auto']).optional(),
+        cpuThrottlingRate: z.number().positive().optional(),
+        geolocation: z
+          .string()
+          .optional()
+          .describe('Latitude/longitude as <latitude>x<longitude>, or omit to clear.'),
+        networkConditions: z
+          .enum(['Offline', 'Slow 3G', 'Fast 3G', 'Slow 4G', 'Fast 4G'])
+          .optional(),
+        userAgent: z.string().optional(),
+        viewport: z
+          .string()
+          .optional()
+          .describe('<width>x<height>x<devicePixelRatio>[,mobile][,touch][,landscape].'),
+      }),
+      command: 'emulate',
+      args: input => {
+        const args: string[] = [];
+        addOption(args, 'colorScheme', input.colorScheme);
+        addOption(args, 'cpuThrottlingRate', input.cpuThrottlingRate);
+        addOption(args, 'geolocation', input.geolocation);
+        addOption(args, 'networkConditions', input.networkConditions);
+        addOption(args, 'userAgent', input.userAgent);
+        addOption(args, 'viewport', input.viewport);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'LIGHTHOUSE_AUDIT',
+      name: 'Run Chrome Lighthouse audit',
+      description:
+        'Run an accessibility/SEO/best-practices/agentic-browsing Lighthouse audit on the selected page.',
+      inputParams: baseInput.extend({
+        mode: z.enum(['navigation', 'snapshot']).optional(),
+        device: z.enum(['desktop', 'mobile']).optional(),
+        outputDirPath: z.string().optional(),
+      }),
+      command: 'lighthouse_audit',
+      args: input => {
+        const args: string[] = [];
+        addOption(args, 'mode', input.mode);
+        addOption(args, 'device', input.device);
+        addOption(args, 'outputDirPath', input.outputDirPath);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'PERFORMANCE_START_TRACE',
+      name: 'Start Chrome performance trace',
+      description: 'Start a Chrome DevTools performance trace on the selected page.',
+      inputParams: baseInput.extend({
+        reload: z.boolean().optional(),
+        autoStop: z.boolean().optional(),
+        filePath: z.string().optional(),
+      }),
+      command: 'performance_start_trace',
+      args: input => {
+        const args: string[] = [];
+        addBooleanFlag(args, 'reload', input.reload);
+        addBooleanFlag(args, 'autoStop', input.autoStop);
+        addOption(args, 'filePath', input.filePath);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'PERFORMANCE_STOP_TRACE',
+      name: 'Stop Chrome performance trace',
+      description: 'Stop the active Chrome DevTools performance trace and return insights.',
+      inputParams: baseInput.extend({ filePath: z.string().optional() }),
+      command: 'performance_stop_trace',
+      args: input => {
+        const args: string[] = [];
+        addOption(args, 'filePath', input.filePath);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'PERFORMANCE_ANALYZE_INSIGHT',
+      name: 'Analyze Chrome performance insight',
+      description:
+        'Return detailed information for a specific performance insight from a trace result.',
+      inputParams: baseInput.extend({
+        insightSetId: z.string().min(1),
+        insightName: z.string().min(1),
+      }),
+      command: 'performance_analyze_insight',
+      args: input => [input.insightSetId, input.insightName],
+    }),
+    commandTool({
+      slug: 'LIST_EXTENSIONS',
+      name: 'List Chrome extensions',
+      description: 'List Chrome extensions installed in the controlled browser.',
+      inputParams: baseInput,
+      command: 'list_extensions',
+      args: () => [],
+    }),
+    commandTool({
+      slug: 'INSTALL_EXTENSION',
+      name: 'Install Chrome extension',
+      description: 'Install an unpacked Chrome extension from an absolute local path.',
+      inputParams: baseInput.extend({ path: z.string().min(1) }),
+      command: 'install_extension',
+      args: input => [input.path],
+    }),
+    commandTool({
+      slug: 'RELOAD_EXTENSION',
+      name: 'Reload Chrome extension',
+      description: 'Reload an unpacked Chrome extension by extension id.',
+      inputParams: baseInput.extend({ id: z.string().min(1) }),
+      command: 'reload_extension',
+      args: input => [input.id],
+    }),
+    commandTool({
+      slug: 'TRIGGER_EXTENSION_ACTION',
+      name: 'Trigger Chrome extension action',
+      description: 'Trigger the default toolbar action for a Chrome extension by id.',
+      inputParams: baseInput.extend({ id: z.string().min(1) }),
+      command: 'trigger_extension_action',
+      args: input => [input.id],
+    }),
+    commandTool({
+      slug: 'UNINSTALL_EXTENSION',
+      name: 'Uninstall Chrome extension',
+      description: 'Uninstall a Chrome extension by extension id.',
+      inputParams: baseInput.extend({ id: z.string().min(1) }),
+      command: 'uninstall_extension',
+      args: input => [input.id],
+    }),
+    commandTool({
+      slug: 'TAKE_MEMORY_SNAPSHOT',
+      name: 'Take Chrome memory snapshot',
+      description:
+        'Capture a heap snapshot of the selected page to a local file for memory analysis.',
+      inputParams: baseInput.extend({ filePath: z.string().min(1) }),
+      command: 'take_memory_snapshot',
+      args: input => [input.filePath],
+    }),
+  ],
+};

--- a/ts/packages/cli-local-tools/src/toolkits/peekaboo.test.ts
+++ b/ts/packages/cli-local-tools/src/toolkits/peekaboo.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { resolveBundledBinary } from '../bundled-binaries';
+import { executeLocalToolBySlug, getLocalToolInputDefinition } from '../registry';
+import { peekabooToolkit } from './peekaboo';
+
+describe('@composio/cli-local-tools Peekaboo toolkit', () => {
+  it('exposes first-class schemas for Peekaboo tools', () => {
+    expect(peekabooToolkit.tools.map(tool => tool.slug)).toEqual(
+      expect.arrayContaining([
+        'PERMISSIONS_STATUS',
+        'LIST_APPS',
+        'SEE',
+        'IMAGE',
+        'CLICK',
+        'TYPE',
+        'WINDOW_FOCUS',
+        'APP_LAUNCH',
+      ])
+    );
+
+    const seeSchema = getLocalToolInputDefinition('LOCAL_PEEKABOO_SEE');
+    expect(seeSchema?.schema.properties).toHaveProperty('app');
+    expect(seeSchema?.schema.properties).toHaveProperty('annotate');
+
+    const clickSchema = getLocalToolInputDefinition('LOCAL_PEEKABOO_CLICK');
+    expect(clickSchema?.schema.properties).toHaveProperty('on');
+    expect(clickSchema?.schema.properties).toHaveProperty('coords');
+  });
+
+  it.runIf(process.platform === 'darwin' && process.arch === 'arm64')(
+    'resolves bundled Peekaboo CLI and executes version without permissions',
+    async () => {
+      const resolved = await resolveBundledBinary(
+        peekabooToolkit,
+        { bundledBinary: 'peekaboo-cli' },
+        { currentPlatform: 'darwin-arm64' }
+      );
+      expect(resolved?.exists).toBe(true);
+
+      const result = await executeLocalToolBySlug('LOCAL_PEEKABOO_VERSION', {});
+      expect(result?.resultText).toContain('Peekaboo 3.0.0');
+    }
+  );
+
+  it.runIf(
+    process.env.COMPOSIO_REAL_LOCAL_TOOLS_TESTS === '1' &&
+      process.platform === 'darwin' &&
+      process.arch === 'arm64'
+  )(
+    'validates against real Peekaboo permission and app-list commands',
+    async () => {
+      const permissions = await executeLocalToolBySlug('LOCAL_PEEKABOO_PERMISSIONS_STATUS', {});
+      expect(permissions?.result).toEqual(expect.objectContaining({ success: true }));
+
+      const apps = await executeLocalToolBySlug('LOCAL_PEEKABOO_LIST_APPS', {});
+      expect(apps?.result).toEqual(
+        expect.objectContaining({
+          data: expect.objectContaining({ applications: expect.any(Array) }),
+        })
+      );
+    },
+    120_000
+  );
+});

--- a/ts/packages/cli-local-tools/src/toolkits/peekaboo.ts
+++ b/ts/packages/cli-local-tools/src/toolkits/peekaboo.ts
@@ -1,0 +1,961 @@
+import { z } from 'zod/v3';
+import { runLocalCommand } from '../runtime';
+import type {
+  LocalCommandExecution,
+  LocalExecutionContext,
+  LocalExecutionResult,
+  LocalToolkitDeclaration,
+  LocalToolDeclaration,
+} from '../types';
+
+const PEEKABOO_VERSION = '3.0.0-beta4';
+const COMMAND_TIMEOUT_MS = 180_000;
+
+const cliOutput = z.object({
+  ok: z.boolean(),
+  commandName: z.string(),
+  result: z.unknown().optional(),
+  resultText: z.string().optional(),
+  stdout: z.string(),
+  stderr: z.string(),
+});
+
+const baseInput = z.object({
+  verbose: z.boolean().default(false).describe('Enable verbose Peekaboo logging.'),
+  noRemote: z
+    .boolean()
+    .default(false)
+    .describe('Force local Peekaboo services and skip the XPC helper.'),
+  logLevel: z
+    .enum(['trace', 'verbose', 'debug', 'info', 'warning', 'error', 'critical'])
+    .optional(),
+  xpcService: z.string().optional().describe('Override Peekaboo XPC helper mach service name.'),
+});
+
+const targetInput = {
+  app: z.string().optional().describe('Application name, bundle id, or PID:1234 target.'),
+  pid: z.number().int().positive().optional().describe('Target application process id.'),
+  windowTitle: z.string().optional().describe('Target window title.'),
+  windowIndex: z.number().int().nonnegative().optional().describe('0-based target window index.'),
+} as const;
+
+const focusInput = {
+  noAutoFocus: z.boolean().optional().describe('Disable automatic focus before interaction.'),
+  spaceSwitch: z.boolean().optional().describe("Switch to the target window's Space if needed."),
+  bringToCurrentSpace: z
+    .boolean()
+    .optional()
+    .describe('Move target window to current Space instead.'),
+  focusTimeoutSeconds: z.number().positive().optional(),
+  focusRetryCountValue: z.number().int().nonnegative().optional(),
+} as const;
+
+const extractJson = (text: string): unknown | undefined => {
+  const candidates = [text.indexOf('{'), text.indexOf('[')].filter(index => index >= 0);
+  if (!candidates.length) return undefined;
+
+  const start = Math.min(...candidates);
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let index = start; index < text.length; index += 1) {
+    const char = text[index];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+    if (char === '{' || char === '[') {
+      depth += 1;
+      continue;
+    }
+    if (char === '}' || char === ']') {
+      depth -= 1;
+      if (depth === 0) {
+        try {
+          return JSON.parse(text.slice(start, index + 1)) as unknown;
+        } catch {
+          return undefined;
+        }
+      }
+    }
+  }
+
+  return undefined;
+};
+
+const addOption = (args: string[], name: string, value: unknown): string[] => {
+  if (value === undefined || value === null || value === '') return args;
+  args.push(`--${name}`, String(value));
+  return args;
+};
+
+const addBooleanFlag = (args: string[], name: string, value: unknown): string[] => {
+  if (value === true) args.push(`--${name}`);
+  return args;
+};
+
+const addRepeated = (args: string[], name: string, values: unknown): string[] => {
+  if (!Array.isArray(values)) return args;
+  for (const value of values) {
+    if (value === undefined || value === null || value === '') continue;
+    args.push(`--${name}`, String(value));
+  }
+  return args;
+};
+
+const addGlobalOptions = (args: string[], input: Record<string, unknown>, json: boolean) => {
+  if (json) args.push('--json');
+  addBooleanFlag(args, 'verbose', input.verbose);
+  addBooleanFlag(args, 'no-remote', input.noRemote);
+  addOption(args, 'log-level', input.logLevel);
+  addOption(args, 'xpc-service', input.xpcService);
+};
+
+const addTargetOptions = (args: string[], input: Record<string, unknown>) => {
+  addOption(args, 'app', input.app);
+  addOption(args, 'pid', input.pid);
+  addOption(args, 'window-title', input.windowTitle);
+  addOption(args, 'window-index', input.windowIndex);
+};
+
+const addFocusOptions = (args: string[], input: Record<string, unknown>) => {
+  addBooleanFlag(args, 'no-auto-focus', input.noAutoFocus);
+  addBooleanFlag(args, 'space-switch', input.spaceSwitch);
+  addBooleanFlag(args, 'bring-to-current-space', input.bringToCurrentSpace);
+  addOption(args, 'focus-timeout-seconds', input.focusTimeoutSeconds);
+  addOption(args, 'focus-retry-count-value', input.focusRetryCountValue);
+};
+
+const parsePeekabooOutput = (
+  commandName: string,
+  stdout: string,
+  stderr: string,
+  parseJson: boolean
+): LocalExecutionResult => {
+  const trimmed = stdout.trim();
+  const result = parseJson ? extractJson(trimmed) : undefined;
+  return {
+    ok: true,
+    commandName,
+    ...(result !== undefined ? { result } : {}),
+    ...(result === undefined && trimmed ? { resultText: trimmed } : {}),
+    stdout,
+    stderr,
+  };
+};
+
+const runPeekaboo = async (
+  commandName: string,
+  commandArgs: ReadonlyArray<string>,
+  input: Record<string, unknown>,
+  context: LocalExecutionContext,
+  options: { readonly json?: boolean } = { json: true }
+): Promise<LocalExecutionResult> => {
+  const args = [...commandArgs];
+  const parseJson = options.json !== false;
+  addGlobalOptions(args, input, parseJson);
+  const execution: LocalCommandExecution = {
+    kind: 'command',
+    command: { bundledBinary: 'peekaboo-cli', fallbackCommand: 'peekaboo' },
+    args,
+    timeoutMs: COMMAND_TIMEOUT_MS,
+  };
+  const result = await runLocalCommand(execution, input, context);
+  return parsePeekabooOutput(
+    commandName,
+    String(result.stdout ?? ''),
+    String(result.stderr ?? ''),
+    parseJson
+  );
+};
+
+const commandTool = <TInput extends z.ZodTypeAny>(definition: {
+  readonly slug: string;
+  readonly name: string;
+  readonly description: string;
+  readonly inputParams: TInput;
+  readonly args: (input: z.infer<TInput>) => ReadonlyArray<string>;
+  readonly json?: boolean;
+}): LocalToolDeclaration<TInput> => ({
+  slug: definition.slug,
+  name: definition.name,
+  description: definition.description,
+  platforms: ['darwin-arm64'],
+  inputParams: definition.inputParams,
+  outputParams: cliOutput,
+  execution: {
+    kind: 'native',
+    execute: (input, context) =>
+      runPeekaboo(definition.slug, definition.args(input as z.infer<TInput>), input, context, {
+        json: definition.json,
+      }),
+  },
+});
+
+const listDetails = z
+  .array(z.enum(['bounds', 'ids', 'off_screen']))
+  .optional()
+  .describe('Window details to include when listing windows.');
+
+export const peekabooToolkit: LocalToolkitDeclaration = {
+  slug: 'PEEKABOO',
+  name: 'Peekaboo (local)',
+  description: 'Local macOS screen capture and GUI automation tools backed by the Peekaboo CLI.',
+  platforms: ['darwin-arm64'],
+  source: {
+    type: 'cli',
+    package: `@steipete/peekaboo@${PEEKABOO_VERSION}`,
+    repository: 'https://github.com/steipete/Peekaboo',
+    command: 'peekaboo',
+  },
+  bundledBinaries: [
+    {
+      id: 'peekaboo-cli',
+      description: 'Peekaboo macOS automation CLI',
+      targets: [
+        {
+          platforms: ['darwin-arm64'],
+          path: 'peekaboo/darwin-arm64/peekaboo',
+        },
+      ],
+    },
+  ],
+  setup: {
+    install:
+      'Requires macOS 15+, Screen Recording permission for capture/read tools, and Accessibility permission for click/type/window/menu automation. A darwin-arm64 Peekaboo binary is bundled; alternatively install with `brew install steipete/tap/peekaboo`.',
+    commandOverrides: [],
+    notes: [
+      'Run PERMISSIONS_STATUS before UI automation and grant missing permissions in System Settings.',
+      'Use SEE to capture a snapshot and element ids before CLICK, TYPE, SCROLL, MOVE, or DRAG.',
+      'Most tools are one-shot CLI wrappers that return Peekaboo JSON output when upstream supports --json.',
+      'Automation tools can control the local GUI; avoid sensitive screens unless intended.',
+    ],
+  },
+  tools: [
+    commandTool({
+      slug: 'VERSION',
+      name: 'Get Peekaboo version',
+      description: 'Return the bundled or installed Peekaboo CLI version.',
+      inputParams: baseInput,
+      json: false,
+      args: () => ['--version'],
+    }),
+    commandTool({
+      slug: 'PERMISSIONS_STATUS',
+      name: 'Check Peekaboo permissions',
+      description: 'Check macOS Screen Recording, Accessibility, and Automation permissions.',
+      inputParams: baseInput,
+      args: () => ['permissions', 'status'],
+    }),
+    commandTool({
+      slug: 'PERMISSIONS_GRANT',
+      name: 'Show Peekaboo permission grant instructions',
+      description: 'Return grant instructions for missing macOS permissions.',
+      inputParams: baseInput,
+      args: () => ['permissions', 'grant'],
+    }),
+    commandTool({
+      slug: 'LIST_APPS',
+      name: 'List running macOS apps',
+      description: 'Enumerate running GUI applications with process and focus metadata.',
+      inputParams: baseInput,
+      args: () => ['list', 'apps'],
+    }),
+    commandTool({
+      slug: 'LIST_WINDOWS',
+      name: 'List macOS app windows',
+      description: 'List windows for a target application with optional bounds/id details.',
+      inputParams: baseInput.extend({
+        app: z.string().min(1).describe('Application name, bundle id, or PID:1234.'),
+        includeDetails: listDetails,
+      }),
+      args: input => {
+        const args = ['list', 'windows'];
+        addOption(args, 'app', input.app);
+        if (input.includeDetails?.length)
+          addOption(args, 'include-details', input.includeDetails.join(','));
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'LIST_SCREENS',
+      name: 'List macOS screens',
+      description: 'List connected displays, resolution, scaling, and main/secondary state.',
+      inputParams: baseInput,
+      args: () => ['list', 'screens'],
+    }),
+    commandTool({
+      slug: 'LIST_MENUBAR',
+      name: 'List macOS menu bar items',
+      description: 'List menu bar/status items and indices for menu-bar automation.',
+      inputParams: baseInput,
+      args: () => ['list', 'menubar'],
+    }),
+    commandTool({
+      slug: 'LIST_PERMISSIONS',
+      name: 'List Peekaboo permission status',
+      description: 'List the same permission state exposed by `peekaboo list permissions`.',
+      inputParams: baseInput,
+      args: () => ['list', 'permissions'],
+    }),
+    commandTool({
+      slug: 'TOOLS',
+      name: 'List Peekaboo tool catalog',
+      description: 'Return Peekaboo native/MCP tool catalog for discovery and auditing.',
+      inputParams: baseInput.extend({ noSort: z.boolean().optional() }),
+      args: input => {
+        const args = ['tools'];
+        addBooleanFlag(args, 'no-sort', input.noSort);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'SEE',
+      name: 'Capture annotated UI snapshot',
+      description:
+        'Capture UI accessibility metadata and optional annotated screenshot for automation.',
+      inputParams: baseInput.extend({
+        app: z.string().optional(),
+        pid: z.number().int().positive().optional(),
+        windowTitle: z.string().optional(),
+        mode: z.enum(['screen', 'window', 'frontmost']).optional(),
+        path: z.string().optional(),
+        captureEngine: z.enum(['auto', 'classic', 'cg', 'modern', 'sckit']).optional(),
+        screenIndex: z.number().int().nonnegative().optional(),
+        analyze: z.string().optional(),
+        annotate: z.boolean().optional(),
+      }),
+      args: input => {
+        const args = ['see'];
+        addOption(args, 'app', input.app);
+        addOption(args, 'pid', input.pid);
+        addOption(args, 'window-title', input.windowTitle);
+        addOption(args, 'mode', input.mode);
+        addOption(args, 'path', input.path);
+        addOption(args, 'capture-engine', input.captureEngine);
+        addOption(args, 'screen-index', input.screenIndex);
+        addOption(args, 'analyze', input.analyze);
+        addBooleanFlag(args, 'annotate', input.annotate);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'IMAGE',
+      name: 'Capture raw screenshot',
+      description: 'Capture a screen/window/frontmost image and optionally save or analyze it.',
+      inputParams: baseInput.extend({
+        app: z.string().optional(),
+        pid: z.number().int().positive().optional(),
+        path: z.string().optional(),
+        mode: z.enum(['auto', 'screen', 'window', 'frontmost']).optional(),
+        windowTitle: z.string().optional(),
+        windowIndex: z.number().int().nonnegative().optional(),
+        screenIndex: z.number().int().nonnegative().optional(),
+        format: z.enum(['png', 'jpg']).optional(),
+        captureFocus: z.enum(['auto', 'background', 'foreground']).optional(),
+        analyze: z.string().optional(),
+        retina: z.boolean().optional(),
+      }),
+      args: input => {
+        const args = ['image'];
+        addOption(args, 'app', input.app);
+        addOption(args, 'pid', input.pid);
+        addOption(args, 'path', input.path);
+        addOption(args, 'mode', input.mode);
+        addOption(args, 'window-title', input.windowTitle);
+        addOption(args, 'window-index', input.windowIndex);
+        addOption(args, 'screen-index', input.screenIndex);
+        addOption(args, 'format', input.format);
+        addOption(args, 'capture-focus', input.captureFocus);
+        addOption(args, 'analyze', input.analyze);
+        addBooleanFlag(args, 'retina', input.retina);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'CLICK',
+      name: 'Click UI element or coordinates',
+      description: 'Click by fuzzy query, Peekaboo element id, or x,y coordinates.',
+      inputParams: baseInput.extend({
+        query: z.string().optional(),
+        session: z.string().optional(),
+        on: z.string().optional().describe('Element id from SEE.'),
+        id: z.string().optional().describe('Alias for on.'),
+        app: z.string().optional(),
+        coords: z.string().optional().describe('Coordinates as x,y.'),
+        waitFor: z.number().int().positive().optional(),
+        double: z.boolean().optional(),
+        right: z.boolean().optional(),
+        ...focusInput,
+      }),
+      args: input => {
+        const args = ['click'];
+        if (input.query) args.push(input.query);
+        addOption(args, 'session', input.session);
+        addOption(args, 'on', input.on);
+        addOption(args, 'id', input.id);
+        addOption(args, 'app', input.app);
+        addOption(args, 'coords', input.coords);
+        addOption(args, 'wait-for', input.waitFor);
+        addBooleanFlag(args, 'double', input.double);
+        addBooleanFlag(args, 'right', input.right);
+        addFocusOptions(args, input);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'TYPE',
+      name: 'Type text or keyboard input',
+      description: 'Type text, clear fields, and append return/tab/escape/delete key actions.',
+      inputParams: baseInput.extend({
+        text: z.string().optional(),
+        session: z.string().optional(),
+        delay: z.number().int().nonnegative().optional(),
+        profile: z.enum(['human', 'linear']).optional(),
+        wpm: z.number().int().min(80).max(220).optional(),
+        tab: z.number().int().positive().optional(),
+        app: z.string().optional(),
+        return: z.boolean().optional(),
+        escape: z.boolean().optional(),
+        delete: z.boolean().optional(),
+        clear: z.boolean().optional(),
+        ...focusInput,
+      }),
+      args: input => {
+        const args = ['type'];
+        if (input.text) args.push(input.text);
+        addOption(args, 'session', input.session);
+        addOption(args, 'delay', input.delay);
+        addOption(args, 'profile', input.profile);
+        addOption(args, 'wpm', input.wpm);
+        addOption(args, 'tab', input.tab);
+        addOption(args, 'app', input.app);
+        addBooleanFlag(args, 'return', input.return);
+        addBooleanFlag(args, 'escape', input.escape);
+        addBooleanFlag(args, 'delete', input.delete);
+        addBooleanFlag(args, 'clear', input.clear);
+        addFocusOptions(args, input);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'PRESS',
+      name: 'Press special keys',
+      description: 'Press one or more special keys such as return, tab, arrows, or function keys.',
+      inputParams: baseInput.extend({
+        keys: z.array(z.string().min(1)).min(1),
+        count: z.number().int().positive().optional(),
+        delay: z.number().int().nonnegative().optional(),
+        hold: z.number().int().nonnegative().optional(),
+        session: z.string().optional(),
+        app: z.string().optional(),
+        ...focusInput,
+      }),
+      args: input => {
+        const args = ['press', ...input.keys];
+        addOption(args, 'count', input.count);
+        addOption(args, 'delay', input.delay);
+        addOption(args, 'hold', input.hold);
+        addOption(args, 'session', input.session);
+        addOption(args, 'app', input.app);
+        addFocusOptions(args, input);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'HOTKEY',
+      name: 'Press key combination',
+      description: 'Press modifier combos such as cmd,c or cmd,shift,t.',
+      inputParams: baseInput.extend({
+        keys: z.string().min(1).describe('Comma- or space-separated key combo.'),
+        holdDuration: z.number().int().nonnegative().optional(),
+        app: z.string().optional(),
+        snapshot: z.string().optional(),
+        ...focusInput,
+      }),
+      args: input => {
+        const args = ['hotkey', input.keys];
+        addOption(args, 'hold-duration', input.holdDuration);
+        addOption(args, 'app', input.app);
+        addOption(args, 'snapshot', input.snapshot);
+        addFocusOptions(args, input);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'SCROLL',
+      name: 'Scroll UI',
+      description: 'Scroll up, down, left, or right at pointer position or a captured element.',
+      inputParams: baseInput.extend({
+        direction: z.enum(['up', 'down', 'left', 'right']),
+        amount: z.number().int().positive().optional(),
+        on: z.string().optional(),
+        snapshot: z.string().optional(),
+        app: z.string().optional(),
+        delay: z.number().int().nonnegative().optional(),
+        smooth: z.boolean().optional(),
+        ...focusInput,
+      }),
+      args: input => {
+        const args = ['scroll'];
+        addOption(args, 'direction', input.direction);
+        addOption(args, 'amount', input.amount);
+        addOption(args, 'on', input.on);
+        addOption(args, 'snapshot', input.snapshot);
+        addOption(args, 'app', input.app);
+        addOption(args, 'delay', input.delay);
+        addBooleanFlag(args, 'smooth', input.smooth);
+        addFocusOptions(args, input);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'MOVE',
+      name: 'Move cursor',
+      description: 'Move cursor to coordinates, element id/query, or screen center.',
+      inputParams: baseInput.extend({
+        coords: z.string().optional().describe('Coordinates as x,y.'),
+        id: z.string().optional(),
+        to: z.string().optional().describe('Fuzzy element query.'),
+        center: z.boolean().optional(),
+        snapshot: z.string().optional(),
+        app: z.string().optional(),
+        smooth: z.boolean().optional(),
+        duration: z.number().int().nonnegative().optional(),
+        steps: z.number().int().positive().optional(),
+        profile: z.enum(['linear', 'human']).optional(),
+        ...focusInput,
+      }),
+      args: input => {
+        const args = ['move'];
+        if (input.coords) args.push(input.coords);
+        addOption(args, 'id', input.id);
+        addOption(args, 'to', input.to);
+        addBooleanFlag(args, 'center', input.center);
+        addOption(args, 'snapshot', input.snapshot);
+        addOption(args, 'app', input.app);
+        addBooleanFlag(args, 'smooth', input.smooth);
+        addOption(args, 'duration', input.duration);
+        addOption(args, 'steps', input.steps);
+        addOption(args, 'profile', input.profile);
+        addFocusOptions(args, input);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'DRAG',
+      name: 'Drag and drop',
+      description: 'Drag from an element/coordinate to another element/coordinate or app.',
+      inputParams: baseInput.extend({
+        from: z.string().optional(),
+        fromCoords: z.string().optional().describe('Start coordinates as x,y.'),
+        to: z.string().optional(),
+        toCoords: z.string().optional().describe('End coordinates as x,y.'),
+        toApp: z.string().optional(),
+        snapshot: z.string().optional(),
+        app: z.string().optional(),
+        duration: z.number().int().nonnegative().optional(),
+        steps: z.number().int().positive().optional(),
+        modifiers: z.string().optional().describe('Comma-separated modifiers such as cmd,shift.'),
+        profile: z.enum(['linear', 'human']).optional(),
+        ...focusInput,
+      }),
+      args: input => {
+        const args = ['drag'];
+        addOption(args, 'from', input.from);
+        addOption(args, 'from-coords', input.fromCoords);
+        addOption(args, 'to', input.to);
+        addOption(args, 'to-coords', input.toCoords);
+        addOption(args, 'to-app', input.toApp);
+        addOption(args, 'snapshot', input.snapshot);
+        addOption(args, 'app', input.app);
+        addOption(args, 'duration', input.duration);
+        addOption(args, 'steps', input.steps);
+        addOption(args, 'modifiers', input.modifiers);
+        addOption(args, 'profile', input.profile);
+        addFocusOptions(args, input);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'APP_LAUNCH',
+      name: 'Launch macOS app',
+      description: 'Launch an app by name/path or bundle id and optionally open documents/URLs.',
+      inputParams: baseInput.extend({
+        app: z.string().optional(),
+        bundleId: z.string().optional(),
+        open: z.array(z.string()).optional(),
+        waitUntilReady: z.boolean().optional(),
+        noFocus: z.boolean().optional(),
+      }),
+      args: input => {
+        const args = ['app', 'launch'];
+        if (input.app) args.push(input.app);
+        addOption(args, 'bundle-id', input.bundleId);
+        addRepeated(args, 'open', input.open);
+        addBooleanFlag(args, 'wait-until-ready', input.waitUntilReady);
+        addBooleanFlag(args, 'no-focus', input.noFocus);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'APP_QUIT',
+      name: 'Quit macOS app',
+      description: 'Quit one target app or all regular apps with exclusions.',
+      inputParams: baseInput.extend({
+        app: z.string().optional(),
+        pid: z.number().int().positive().optional(),
+        all: z.boolean().optional(),
+        except: z.string().optional().describe('Comma-separated app exclusions when all=true.'),
+        force: z.boolean().optional(),
+      }),
+      args: input => {
+        const args = ['app', 'quit'];
+        addOption(args, 'app', input.app);
+        addOption(args, 'pid', input.pid);
+        addBooleanFlag(args, 'all', input.all);
+        addOption(args, 'except', input.except);
+        addBooleanFlag(args, 'force', input.force);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'APP_SWITCH',
+      name: 'Switch macOS app',
+      description: 'Activate a specific app or cycle with Cmd+Tab behavior.',
+      inputParams: baseInput.extend({ to: z.string().optional(), cycle: z.boolean().optional() }),
+      args: input => {
+        const args = ['app', 'switch'];
+        addOption(args, 'to', input.to);
+        addBooleanFlag(args, 'cycle', input.cycle);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'WINDOW_FOCUS',
+      name: 'Focus macOS window',
+      description: 'Bring a target app/window to foreground with optional Space handling.',
+      inputParams: baseInput.extend({ ...targetInput, ...focusInput }),
+      args: input => {
+        const args = ['window', 'focus'];
+        addTargetOptions(args, input);
+        addFocusOptions(args, input);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'WINDOW_MOVE',
+      name: 'Move macOS window',
+      description: 'Move a target window to a new x,y origin.',
+      inputParams: baseInput.extend({ ...targetInput, x: z.number(), y: z.number() }),
+      args: input => {
+        const args = ['window', 'move'];
+        addTargetOptions(args, input);
+        addOption(args, 'x', input.x);
+        addOption(args, 'y', input.y);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'WINDOW_RESIZE',
+      name: 'Resize macOS window',
+      description: 'Resize a target window while keeping its origin.',
+      inputParams: baseInput.extend({ ...targetInput, width: z.number(), height: z.number() }),
+      args: input => {
+        const args = ['window', 'resize'];
+        addTargetOptions(args, input);
+        addOption(args, 'width', input.width);
+        addOption(args, 'height', input.height);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'WINDOW_SET_BOUNDS',
+      name: 'Set macOS window bounds',
+      description: 'Set target window origin and size in one operation.',
+      inputParams: baseInput.extend({
+        ...targetInput,
+        x: z.number(),
+        y: z.number(),
+        width: z.number(),
+        height: z.number(),
+      }),
+      args: input => {
+        const args = ['window', 'set-bounds'];
+        addTargetOptions(args, input);
+        addOption(args, 'x', input.x);
+        addOption(args, 'y', input.y);
+        addOption(args, 'width', input.width);
+        addOption(args, 'height', input.height);
+        return args;
+      },
+    }),
+    ...(['close', 'minimize', 'maximize'] as const).map(action =>
+      commandTool({
+        slug: `WINDOW_${action.toUpperCase()}`,
+        name: `${action[0]?.toUpperCase()}${action.slice(1)} macOS window`,
+        description: `${action[0]?.toUpperCase()}${action.slice(1)} a target macOS window.`,
+        inputParams: baseInput.extend(targetInput),
+        args: input => {
+          const args = ['window', action];
+          addTargetOptions(args, input);
+          return args;
+        },
+      })
+    ),
+    commandTool({
+      slug: 'MENU_LIST',
+      name: 'List app menus',
+      description: 'List menu tree for a target app.',
+      inputParams: baseInput.extend({ ...targetInput, includeDisabled: z.boolean().optional() }),
+      args: input => {
+        const args = ['menu', 'list'];
+        addTargetOptions(args, input);
+        addBooleanFlag(args, 'include-disabled', input.includeDisabled);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'MENU_CLICK',
+      name: 'Click app menu item',
+      description: 'Click an application menu item by item name or path such as File > Save.',
+      inputParams: baseInput.extend({
+        ...targetInput,
+        ...focusInput,
+        item: z.string().optional(),
+        path: z.string().optional(),
+      }),
+      args: input => {
+        const args = ['menu', 'click'];
+        addTargetOptions(args, input);
+        addFocusOptions(args, input);
+        addOption(args, 'item', input.item);
+        addOption(args, 'path', input.path);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'MENU_LIST_ALL',
+      name: 'List frontmost menus and menu extras',
+      description: 'Snapshot frontmost app menus and system menu extras.',
+      inputParams: baseInput.extend({
+        includeDisabled: z.boolean().optional(),
+        includeFrames: z.boolean().optional(),
+      }),
+      args: input => {
+        const args = ['menu', 'list-all'];
+        addBooleanFlag(args, 'include-disabled', input.includeDisabled);
+        addBooleanFlag(args, 'include-frames', input.includeFrames);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'CLIPBOARD',
+      name: 'Read or write macOS clipboard',
+      description: 'Get, set, clear, save, restore, or load macOS clipboard contents.',
+      inputParams: baseInput.extend({
+        action: z.enum(['get', 'set', 'clear', 'save', 'restore', 'load']),
+        text: z.string().optional(),
+        filePath: z.string().optional(),
+        imagePath: z.string().optional(),
+        dataBase64: z.string().optional(),
+        uti: z.string().optional(),
+        prefer: z.string().optional(),
+        output: z.string().optional(),
+        slot: z.string().optional(),
+        alsoText: z.string().optional(),
+        allowLarge: z.boolean().optional(),
+        verify: z.boolean().optional(),
+      }),
+      args: input => {
+        const args = ['clipboard'];
+        addOption(args, 'action', input.action);
+        addOption(args, 'text', input.text);
+        addOption(args, 'file-path', input.filePath);
+        addOption(args, 'image-path', input.imagePath);
+        addOption(args, 'data-base64', input.dataBase64);
+        addOption(args, 'uti', input.uti);
+        addOption(args, 'prefer', input.prefer);
+        addOption(args, 'output', input.output);
+        addOption(args, 'slot', input.slot);
+        addOption(args, 'also-text', input.alsoText);
+        addBooleanFlag(args, 'allow-large', input.allowLarge);
+        addBooleanFlag(args, 'verify', input.verify);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'APP_HIDE',
+      name: 'Hide macOS app',
+      description: 'Hide a target application.',
+      inputParams: baseInput.extend({ app: z.string().min(1) }),
+      args: input => ['app', 'hide', '--app', input.app],
+    }),
+    commandTool({
+      slug: 'APP_UNHIDE',
+      name: 'Unhide macOS app',
+      description: 'Show/unhide a target application.',
+      inputParams: baseInput.extend({ app: z.string().min(1) }),
+      args: input => ['app', 'unhide', '--app', input.app],
+    }),
+    commandTool({
+      slug: 'APP_RELAUNCH',
+      name: 'Relaunch macOS app',
+      description: 'Quit and relaunch a target application.',
+      inputParams: baseInput.extend({
+        app: z.string().min(1),
+        wait: z.number().nonnegative().optional(),
+        force: z.boolean().optional(),
+        waitUntilReady: z.boolean().optional(),
+      }),
+      args: input => {
+        const args = ['app', 'relaunch', input.app];
+        addOption(args, 'wait', input.wait);
+        addBooleanFlag(args, 'force', input.force);
+        addBooleanFlag(args, 'wait-until-ready', input.waitUntilReady);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'DIALOG',
+      name: 'Interact with system dialog',
+      description: 'List, click, input into, select files for, or dismiss system dialogs.',
+      inputParams: baseInput.extend({
+        action: z.enum(['list', 'click', 'input', 'file', 'dismiss']),
+        button: z.string().optional(),
+        text: z.string().optional(),
+        field: z.string().optional(),
+        path: z.string().optional(),
+        name: z.string().optional(),
+        select: z.string().optional(),
+        force: z.boolean().optional(),
+      }),
+      args: input => {
+        const args = ['dialog', input.action];
+        addOption(args, 'button', input.button);
+        addOption(args, 'text', input.text);
+        addOption(args, 'field', input.field);
+        addOption(args, 'path', input.path);
+        addOption(args, 'name', input.name);
+        addOption(args, 'select', input.select);
+        addBooleanFlag(args, 'force', input.force);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'DOCK',
+      name: 'Interact with macOS Dock',
+      description:
+        'List Dock items, launch apps from Dock, right-click items, or show/hide the Dock.',
+      inputParams: baseInput.extend({
+        action: z.enum(['list', 'launch', 'right-click', 'hide', 'show']),
+        app: z.string().optional(),
+        select: z.string().optional(),
+      }),
+      args: input => {
+        const args = ['dock', input.action];
+        if (input.action === 'launch' && input.app) args.push(input.app);
+        if (input.action !== 'launch') addOption(args, 'app', input.app);
+        addOption(args, 'select', input.select);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'SPACE',
+      name: 'Manage macOS Spaces',
+      description: 'List Spaces, switch Spaces, or move windows between Spaces.',
+      inputParams: baseInput.extend({
+        action: z.enum(['list', 'switch', 'move-window']),
+        to: z.number().int().positive().optional(),
+        toCurrent: z.boolean().optional(),
+        ...targetInput,
+      }),
+      args: input => {
+        const args = ['space', input.action];
+        addOption(args, 'to', input.to);
+        addBooleanFlag(args, 'to-current', input.toCurrent);
+        addTargetOptions(args, input);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'MENUBAR',
+      name: 'Interact with macOS menu bar items',
+      description: 'List or click status/menu-bar items by name or index.',
+      inputParams: baseInput.extend({
+        action: z.enum(['list', 'click']),
+        itemName: z.string().optional(),
+        index: z.number().int().nonnegative().optional(),
+        includeRawDebug: z.boolean().optional(),
+      }),
+      args: input => {
+        const args = ['menubar', input.action];
+        if (input.itemName) args.push(input.itemName);
+        addOption(args, 'index', input.index);
+        addBooleanFlag(args, 'include-raw-debug', input.includeRawDebug);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'OPEN',
+      name: 'Open URL or file',
+      description: 'Open a URL or local file with its default or specified application.',
+      inputParams: baseInput.extend({
+        target: z.string().min(1),
+        app: z.string().optional(),
+        bundleId: z.string().optional(),
+        waitUntilReady: z.boolean().optional(),
+        noFocus: z.boolean().optional(),
+      }),
+      args: input => {
+        const args = ['open', input.target];
+        addOption(args, 'app', input.app);
+        addOption(args, 'bundle-id', input.bundleId);
+        addBooleanFlag(args, 'wait-until-ready', input.waitUntilReady);
+        addBooleanFlag(args, 'no-focus', input.noFocus);
+        return args;
+      },
+    }),
+    commandTool({
+      slug: 'SLEEP',
+      name: 'Sleep in Peekaboo flow',
+      description: 'Pause for a number of milliseconds between GUI actions.',
+      inputParams: baseInput.extend({ duration: z.number().int().nonnegative() }),
+      args: input => ['sleep', String(input.duration)],
+    }),
+    commandTool({
+      slug: 'CLEAN',
+      name: 'Clean Peekaboo caches',
+      description: 'Prune Peekaboo session cache and temporary files.',
+      inputParams: baseInput.extend({
+        allSessions: z.boolean().optional(),
+        olderThan: z
+          .number()
+          .positive()
+          .optional()
+          .describe('Remove sessions older than this many hours.'),
+        session: z.string().optional(),
+        dryRun: z.boolean().optional(),
+      }),
+      args: input => {
+        const args = ['clean'];
+        addBooleanFlag(args, 'all-sessions', input.allSessions);
+        addOption(args, 'older-than', input.olderThan);
+        addOption(args, 'session', input.session);
+        addBooleanFlag(args, 'dry-run', input.dryRun);
+        return args;
+      },
+    }),
+  ],
+};

--- a/ts/packages/cli-local-tools/src/types.ts
+++ b/ts/packages/cli-local-tools/src/types.ts
@@ -76,6 +76,8 @@ export interface LocalCommandExecution {
 
 export interface LocalNativeExecution {
   readonly kind: 'native';
+  /** Optional prerequisite command used by `composio local-tools doctor` for native wrappers. */
+  readonly readiness?: LocalCommandInvocation;
   readonly execute: (
     input: Record<string, unknown>,
     context: LocalExecutionContext

--- a/ts/packages/cli/test/src/commands/local-tools.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/local-tools.cmd.test.ts
@@ -42,7 +42,7 @@ describe('CLI: composio local-tools', () => {
         expect(payload.currentPlatform).toBeTruthy();
         expect(payload.metadataPath).toContain('local_tools.json');
         expect(payload.toolkits.map(toolkit => toolkit.slug)).toEqual(
-          expect.arrayContaining(['BEEPER_IMESSAGE', 'CHROME_DEVTOOLS'])
+          expect.arrayContaining(['BEEPER_IMESSAGE', 'CHROME_DEVTOOLS', 'PEEKABOO'])
         );
       })
     );
@@ -59,7 +59,7 @@ describe('CLI: composio local-tools', () => {
 
         expect(payload.metadataPath).toContain('local_tools.json');
         expect(payload.toolkits.map(toolkit => toolkit.slug)).toEqual(
-          expect.arrayContaining(['BEEPER_IMESSAGE', 'CHROME_DEVTOOLS'])
+          expect.arrayContaining(['BEEPER_IMESSAGE', 'CHROME_DEVTOOLS', 'PEEKABOO'])
         );
       })
     );

--- a/ts/packages/cli/test/src/commands/local-tools.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/local-tools.cmd.test.ts
@@ -28,7 +28,7 @@ const withLocalToolsPath = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
 
 describe('CLI: composio local-tools', () => {
   layer(TestLive())(it => {
-    it.scoped('[Given] --json [Then] lists bundled Beeper iMessage toolkit', () =>
+    it.scoped('[Given] --json [Then] lists bundled local toolkits', () =>
       Effect.gen(function* () {
         yield* cli(['local-tools', 'list', '--json', '--all-platforms']);
 
@@ -41,25 +41,27 @@ describe('CLI: composio local-tools', () => {
 
         expect(payload.currentPlatform).toBeTruthy();
         expect(payload.metadataPath).toContain('local_tools.json');
-        expect(payload.toolkits.map(toolkit => toolkit.slug)).toContain('BEEPER_IMESSAGE');
+        expect(payload.toolkits.map(toolkit => toolkit.slug)).toEqual(
+          expect.arrayContaining(['BEEPER_IMESSAGE', 'CHROME_DEVTOOLS'])
+        );
       })
     );
 
-    it.scoped(
-      '[Given] doctor --json [Then] reports bundled Beeper iMessage toolkit readiness',
-      () =>
-        Effect.gen(function* () {
-          yield* cli(['local-tools', 'doctor', '--json', '--all-platforms']);
+    it.scoped('[Given] doctor --json [Then] reports local toolkit readiness', () =>
+      Effect.gen(function* () {
+        yield* cli(['local-tools', 'doctor', '--json', '--all-platforms']);
 
-          const lines = yield* MockConsole.getLines({ stripAnsi: true });
-          const payload = JSON.parse(lines.at(-1) ?? '') as {
-            metadataPath: string;
-            toolkits: Array<{ slug: string }>;
-          };
+        const lines = yield* MockConsole.getLines({ stripAnsi: true });
+        const payload = JSON.parse(lines.at(-1) ?? '') as {
+          metadataPath: string;
+          toolkits: Array<{ slug: string }>;
+        };
 
-          expect(payload.metadataPath).toContain('local_tools.json');
-          expect(payload.toolkits.map(toolkit => toolkit.slug)).toContain('BEEPER_IMESSAGE');
-        })
+        expect(payload.metadataPath).toContain('local_tools.json');
+        expect(payload.toolkits.map(toolkit => toolkit.slug)).toEqual(
+          expect.arrayContaining(['BEEPER_IMESSAGE', 'CHROME_DEVTOOLS'])
+        );
+      })
     );
 
     it.scoped('[Given] meta --init --json [Then] writes local metadata file', () =>


### PR DESCRIPTION
## Summary
- add a first-class `CHROME_DEVTOOLS` local toolkit backed by the official `chrome-devtools-mcp@0.24.0` package and its stateful `chrome-devtools` CLI daemon
- expose documented Chrome DevTools automation/debugging tools as `LOCAL_CHROME_DEVTOOLS_*` commands (pages, navigation, snapshots/screenshots, input, console, network, performance, Lighthouse, extensions, memory snapshot)
- add optional native-wrapper readiness checks so `local-tools doctor` can report the `npx` prerequisite while runtime-specific Chrome checks remain execution-time
- wire Chrome DevTools into local toolkit registry/list/doctor tests and add an env-gated real-daemon smoke test

## Upstream validation
- Researched `ChromeDevTools/chrome-devtools-mcp` at `510ec0f48bbfc7cad3d5d1f9805e901cc992ea89` (`chrome-devtools-mcp` package version `0.24.0`)
- Read upstream README, CLI docs, tool reference, generated CLI entrypoint/options, and tool registry sources
- Verified upstream launcher with `npx -y --package chrome-devtools-mcp@0.24.0 chrome-devtools --help`

## Tests
- `pnpm --filter @composio/cli-local-tools test`
- `pnpm --filter @composio/cli-local-tools typecheck:tsc`
- `pnpm --filter @composio/cli typecheck:tsc`
- `cd ts/packages/cli && pnpm exec vitest run test/src/commands/local-tools.cmd.test.ts test/src/commands/tools/tools.search.cmd.test.ts`
- `COMPOSIO_REAL_LOCAL_TOOLS_TESTS=1 pnpm --filter @composio/cli-local-tools test -- src/toolkits/chrome-devtools.test.ts`
- `pnpm --filter @composio/cli-local-tools build && pnpm --filter @composio/cli build`
- `pnpm turbo build`
- Built CLI smoke: `COMPOSIO_CACHE_DIR=<tmp-config-with-local_tools-enabled> bun ts/packages/cli/dist/bin.mjs execute LOCAL_CHROME_DEVTOOLS_LIST_PAGES -d '{"sessionId":"composio-cli-smoke"}' --skip-checks`
- Built CLI smoke cleanup: `COMPOSIO_CACHE_DIR=<tmp-config-with-local_tools-enabled> bun ts/packages/cli/dist/bin.mjs execute LOCAL_CHROME_DEVTOOLS_STOP_DAEMON -d '{"sessionId":"composio-cli-smoke"}' --skip-checks`

## Notes / risks
- Requires `local_tools` experimental feature enabled on stable CLI builds (`composio config experimental local_tools on`).
- Requires Node.js/npm and a supported Chrome installation; tools invoke `npx -y --package chrome-devtools-mcp@0.24.0 chrome-devtools`.
- Chrome DevTools MCP can inspect and modify browser contents; avoid sensitive browser sessions.
- The first tool call can auto-start the upstream daemon; use `LOCAL_CHROME_DEVTOOLS_START_DAEMON` for explicit headless/browserUrl/userDataDir configuration and `STOP_DAEMON` to clean up.
- Performance trace tooling may use upstream CrUX behavior unless the daemon is started with `performanceCrux: false`.

Stacked after #3341.
