### PR TITLE
fix(cli): patch BetterSwiftAX constants for binary builds

### DIFF
--- a/.github/workflows/build-cli-binaries.yml
+++ b/.github/workflows/build-cli-binaries.yml
@@ -275,7 +275,20 @@ jobs:
 
       - name: Create archive
         working-directory: ts/packages/cli
+        env:
+          RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
         run: pnpm build:binary:package
+
+      - name: Verify release metadata in archive
+        working-directory: ts/packages/cli
+        run: unzip -p dist/binaries/${{ matrix.artifact }}.zip ${{ matrix.artifact }}/release-tag.txt | grep -Fx '${{ needs.prepare.outputs.release_tag }}'
+
+      - name: Verify local-tool sidecars in archive
+        if: matrix.local_tools_target != ''
+        working-directory: ts/packages/cli
+        run: |
+          unzip -Z1 dist/binaries/${{ matrix.artifact }}.zip | grep -F "local-tools-binaries/beeper-imessage/${{ matrix.local_tools_target }}/imessage-cli"
+          unzip -Z1 dist/binaries/${{ matrix.artifact }}.zip | grep -F "local-tools-binaries/peekaboo/${{ matrix.local_tools_target }}/peekaboo"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v6

--- a/.github/workflows/build-cli-binaries.yml
+++ b/.github/workflows/build-cli-binaries.yml
@@ -231,6 +231,16 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Setup Swift 6.2 for local-tool sidecars
+        if: matrix.local_tools_target != ''
+        uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: '6.2'
+
+      - name: Verify Swift toolchain
+        if: matrix.local_tools_target != ''
+        run: swift --version
+
       - name: Build packages
         run: pnpm build:packages
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1216,6 +1216,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.26.0
         version: 1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      decompress:
+        specifier: ^4.2.1
+        version: 4.2.1
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -1223,6 +1226,9 @@ importers:
         specifier: 'catalog:'
         version: 3.25.1(zod@4.3.6)
     devDependencies:
+      '@types/decompress':
+        specifier: ^4.2.7
+        version: 4.2.7
       '@types/node':
         specifier: ^24.0.1
         version: 24.10.13

--- a/ts/packages/cli-local-tools/package.json
+++ b/ts/packages/cli-local-tools/package.json
@@ -45,10 +45,12 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.26.0",
+    "decompress": "^4.2.1",
     "zod": "catalog:",
     "zod-to-json-schema": "catalog:"
   },
   "devDependencies": {
+    "@types/decompress": "^4.2.7",
     "@types/node": "^24.0.1",
     "chrome-devtools-mcp": "0.24.0",
     "tsdown": "catalog:",

--- a/ts/packages/cli-local-tools/scripts/build-beeper-imessage-binaries.ts
+++ b/ts/packages/cli-local-tools/scripts/build-beeper-imessage-binaries.ts
@@ -38,46 +38,33 @@ const exists = async (filePath: string): Promise<boolean> =>
 const readJson = async <T>(filePath: string): Promise<T> =>
   JSON.parse(await fs.readFile(filePath, 'utf8')) as T;
 
-// BetterSwiftAX 0.1.0 references AXWebConstants added in newer macOS SDKs.
-// The constants are plain CFString subrole names, so patch the resolved package
-// checkout to string literals before building on GitHub macos-15 runners.
-const betterSwiftAxSubroleFallbacks = [
-  ['kAXLandmarkComplementarySubrole', 'AXLandmarkComplementary'],
-  ['kAXLandmarkContentInfoSubrole', 'AXLandmarkContentInfo'],
-  ['kAXLandmarkMainSubrole', 'AXLandmarkMain'],
-  ['kAXLandmarkNavigationSubrole', 'AXLandmarkNavigation'],
-  ['kAXLandmarkRegionSubrole', 'AXLandmarkRegion'],
-  ['kAXLandmarkSearchSubrole', 'AXLandmarkSearch'],
-  ['kAXMathFenceOperatorSubrole', 'AXMathFenceOperator'],
-  ['kAXMathFencedSubrole', 'AXMathFenced'],
-  ['kAXMathFractionSubrole', 'AXMathFraction'],
-  ['kAXMathIdentifierSubrole', 'AXMathIdentifier'],
-  ['kAXMathMultiscriptSubrole', 'AXMathMultiscript'],
-  ['kAXMathNumberSubrole', 'AXMathNumber'],
-  ['kAXMathOperatorSubrole', 'AXMathOperator'],
-  ['kAXMathRootSubrole', 'AXMathRoot'],
-  ['kAXMathRowSubrole', 'AXMathRow'],
-  ['kAXMathSeparatorOperatorSubrole', 'AXMathSeparatorOperator'],
-  ['kAXMathSquareRootSubrole', 'AXMathSquareRoot'],
-  ['kAXMathSubscriptSuperscriptSubrole', 'AXMathSubscriptSuperscript'],
-  ['kAXMathTableCellSubrole', 'AXMathTableCell'],
-  ['kAXMathTableRowSubrole', 'AXMathTableRow'],
-  ['kAXMathTableSubrole', 'AXMathTable'],
-  ['kAXMathTextSubrole', 'AXMathText'],
-  ['kAXMathUnderOverSubrole', 'AXMathUnderOver'],
-  ['kAXMeterSubrole', 'AXMeter'],
-  ['kAXRubyInlineSubrole', 'AXRubyInline'],
-  ['kAXRubyTextSubrole', 'AXRubyText'],
-  ['kAXSubscriptStyleGroupSubrole', 'AXSubscriptStyleGroup'],
-  ['kAXSummarySubrole', 'AXSummary'],
-  ['kAXSuperscriptStyleGroupSubrole', 'AXSuperscriptStyleGroup'],
-  ['kAXTabPanelSubrole', 'AXTabPanel'],
-  ['kAXTermSubrole', 'AXTerm'],
-  ['kAXTimeGroupSubrole', 'AXTimeGroup'],
-  ['kAXUserInterfaceTooltipSubrole', 'AXUserInterfaceTooltip'],
-  ['kAXVideoSubrole', 'AXVideo'],
-  ['kAXWebApplicationSubrole', 'AXWebApplication'],
+// BetterSwiftAX 0.1.0 references Accessibility constants that are not
+// consistently exported by the macOS SDK on GitHub runners. Swift exposes AX
+// constants as Strings whose values are the constant name without the `k` prefix
+// and category suffix, so patch the resolved package checkout to literals before
+// compiling sidecar binaries.
+const betterSwiftAxFallbackFiles = [
+  'Accessibility+Action.swift',
+  'Accessibility+AttributeKey.swift',
+  'Accessibility+Notification.swift',
+  'Accessibility+ParameterizedAttributeKey.swift',
+  'Accessibility+Role.swift',
+  'Accessibility+Subrole.swift',
+  'Accessibility+Value.swift',
 ] as const;
+
+const betterSwiftAxConstantReferencePattern =
+  /\bkAX[A-Za-z0-9]+(?:Action|ParameterizedAttribute|Attribute|Notification|Subrole|Role|Value)\b/g;
+const betterSwiftAxConstantPattern =
+  /^kAX(.+?)(Action|ParameterizedAttribute|Attribute|Notification|Subrole|Role|Value)$/;
+
+const betterSwiftAxConstantLiteral = (constantName: string): string => {
+  const match = betterSwiftAxConstantPattern.exec(constantName);
+  if (!match) {
+    throw new Error(`Unsupported BetterSwiftAX constant fallback: ${constantName}`);
+  }
+  return `"AX${match[1]}"`;
+};
 
 const ensurePlatform = () => {
   if (process.platform !== 'darwin') {
@@ -125,26 +112,43 @@ const copyLicense = async () => {
 const patchBetterSwiftAxForCurrentSdk = async () => {
   await $`swift package resolve`.cwd(submodulePath);
 
-  const sourcePath = path.join(
+  const checkoutRoot = path.join(
     submodulePath,
-    '.build/checkouts/BetterSwiftAX/Sources/AccessibilityControl/Accessibility+Subrole.swift'
+    '.build/checkouts/BetterSwiftAX/Sources/AccessibilityControl'
   );
-  if (!(await exists(sourcePath))) {
+  if (!(await exists(checkoutRoot))) {
     throw new Error(
-      'Swift package resolution completed but BetterSwiftAX Accessibility+Subrole.swift was not found.'
+      'Swift package resolution completed but the BetterSwiftAX AccessibilityControl checkout was not found.'
     );
   }
 
-  const source = await fs.readFile(sourcePath, 'utf8');
-  let patched = source;
-  for (const [constantName, stringValue] of betterSwiftAxSubroleFallbacks) {
-    patched = patched.replaceAll(`= ${constantName}`, `= ("${stringValue}" as CFString)`);
+  let replacementCount = 0;
+  for (const fileName of betterSwiftAxFallbackFiles) {
+    const sourcePath = path.join(checkoutRoot, fileName);
+    if (!(await exists(sourcePath))) {
+      throw new Error(
+        `Swift package resolution completed but BetterSwiftAX ${fileName} was not found.`
+      );
+    }
+
+    const source = await fs.readFile(sourcePath, 'utf8');
+    let fileReplacementCount = 0;
+    const patched = source.replace(betterSwiftAxConstantReferencePattern, constantName => {
+      fileReplacementCount += 1;
+      return betterSwiftAxConstantLiteral(constantName);
+    });
+
+    if (patched !== source) {
+      await fs.chmod(sourcePath, 0o644).catch(() => undefined);
+      await fs.writeFile(sourcePath, patched, 'utf8');
+      replacementCount += fileReplacementCount;
+    }
   }
 
-  if (patched !== source) {
-    await fs.chmod(sourcePath, 0o644).catch(() => undefined);
-    await fs.writeFile(sourcePath, patched, 'utf8');
-    console.log('Patched BetterSwiftAX subrole constants for older macOS SDKs.');
+  if (replacementCount > 0) {
+    console.log(
+      `Patched ${replacementCount} BetterSwiftAX Accessibility constants for the current macOS SDK.`
+    );
   }
 };
 

--- a/ts/packages/cli-local-tools/scripts/build-peekaboo-binaries.ts
+++ b/ts/packages/cli-local-tools/scripts/build-peekaboo-binaries.ts
@@ -39,6 +39,54 @@ const exists = async (filePath: string): Promise<boolean> =>
 const readJson = async <T>(filePath: string): Promise<T> =>
   JSON.parse(await fs.readFile(filePath, 'utf8')) as T;
 
+const swiftConfigurationPatchReplacements = [
+  {
+    filePath: 'Sources/Configuration/Providers/Files/FileProvider.swift',
+    oldText: `self._snapshot = try snapshotType.init(
+                data: fileContents!.bytes,
+                providerName: providerName,
+                parsingOptions: parsingOptions
+            )`,
+    newText: `self._snapshot = try fileContents!.withUnsafeBytes { bytes in
+                try snapshotType.init(
+                    data: RawSpan(_unsafeBytes: bytes),
+                    providerName: providerName,
+                    parsingOptions: parsingOptions
+                )
+            }`,
+  },
+  {
+    filePath: 'Sources/Configuration/Providers/Files/ReloadingFileProvider.swift',
+    oldText: `initialSnapshot = try snapshotType.init(
+                data: data.bytes,
+                providerName: providerName,
+                parsingOptions: parsingOptions
+            )`,
+    newText: `initialSnapshot = try data.withUnsafeBytes { bytes in
+                try snapshotType.init(
+                    data: RawSpan(_unsafeBytes: bytes),
+                    providerName: providerName,
+                    parsingOptions: parsingOptions
+                )
+            }`,
+  },
+  {
+    filePath: 'Sources/Configuration/Providers/Files/ReloadingFileProvider.swift',
+    oldText: `newSnapshot = try Snapshot.init(
+                data: data.bytes,
+                providerName: providerName,
+                parsingOptions: parsingOptions
+            )`,
+    newText: `newSnapshot = try data.withUnsafeBytes { bytes in
+                try Snapshot.init(
+                    data: RawSpan(_unsafeBytes: bytes),
+                    providerName: providerName,
+                    parsingOptions: parsingOptions
+                )
+            }`,
+  },
+] as const;
+
 const ensurePlatform = () => {
   if (process.platform !== 'darwin') {
     throw new Error(
@@ -91,8 +139,47 @@ const copyLicense = async () => {
   throw new Error('No upstream license file found in Peekaboo submodule.');
 };
 
+const patchSwiftConfigurationForCurrentToolchain = async () => {
+  await $`swift package resolve`.cwd(cliPackagePath);
+
+  const checkoutRoot = path.join(cliPackagePath, '.build/checkouts/swift-configuration');
+  if (!(await exists(checkoutRoot))) {
+    throw new Error(
+      'Swift package resolution completed but the swift-configuration checkout was not found.'
+    );
+  }
+
+  let replacementCount = 0;
+  for (const replacement of swiftConfigurationPatchReplacements) {
+    const sourcePath = path.join(checkoutRoot, replacement.filePath);
+    if (!(await exists(sourcePath))) {
+      throw new Error(
+        `Swift package resolution completed but ${replacement.filePath} was not found.`
+      );
+    }
+
+    const source = await fs.readFile(sourcePath, 'utf8');
+    if (!source.includes(replacement.oldText)) {
+      if (source.includes(replacement.newText)) continue;
+      throw new Error(`Unable to patch swift-configuration file: ${replacement.filePath}`);
+    }
+
+    const patched = source.replaceAll(replacement.oldText, replacement.newText);
+    await fs.chmod(sourcePath, 0o644).catch(() => undefined);
+    await fs.writeFile(sourcePath, patched, 'utf8');
+    replacementCount += 1;
+  }
+
+  if (replacementCount > 0) {
+    console.log(
+      `Patched ${replacementCount} swift-configuration Data.bytes usages for the current Swift toolchain.`
+    );
+  }
+};
+
 const buildTarget = async (target: Target) => {
   console.log(`Building peekaboo for ${target.platform} (${target.swiftArch})...`);
+  await patchSwiftConfigurationForCurrentToolchain();
   await $`swift build --arch ${target.swiftArch} -c release -Xswiftc -Osize -Xswiftc -wmo -Xlinker -dead_strip`.cwd(
     cliPackagePath
   );

--- a/ts/packages/cli-local-tools/src/bundled-binaries.ts
+++ b/ts/packages/cli-local-tools/src/bundled-binaries.ts
@@ -1,7 +1,9 @@
 import fsSync from 'node:fs';
 import fs from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import decompress from 'decompress';
 import { detectCliPlatform, supportsCliPlatform } from './platform';
 import type {
   LocalBundledBinaryDeclaration,
@@ -11,6 +13,25 @@ import type {
 } from './types';
 
 const DEFAULT_BUNDLE_DIR = 'local-tools-binaries';
+const RELEASE_TAG_FILENAME = 'release-tag.txt';
+
+const DEFAULT_GITHUB_CONFIG = {
+  apiBaseUrl: 'https://api.github.com',
+  owner: 'ComposioHQ',
+  repo: 'composio',
+} as const;
+
+type GitHubReleaseAsset = {
+  readonly name: string;
+  readonly browser_download_url: string;
+};
+
+type GitHubRelease = {
+  readonly tag_name: string;
+  readonly assets: ReadonlyArray<GitHubReleaseAsset>;
+};
+
+let localToolsRepairPromise: Promise<boolean> | null = null;
 
 export interface LocalBundledBinaryResolution {
   readonly id: string;
@@ -56,6 +77,185 @@ const binaryExists = async (filePath: string): Promise<boolean> => {
   }
 };
 
+const readTextFileIfPresent = async (filePath: string): Promise<string | undefined> => {
+  try {
+    const value = (await fs.readFile(filePath, 'utf8')).trim();
+    return value.length > 0 ? value : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+const resolveBinaryAssetName = (): string | undefined => {
+  switch (`${process.platform}-${process.arch}`) {
+    case 'darwin-arm64':
+      return 'composio-darwin-aarch64.zip';
+    case 'darwin-x64':
+      return 'composio-darwin-x64.zip';
+    case 'linux-x64':
+      return 'composio-linux-x64.zip';
+    case 'linux-arm64':
+      return 'composio-linux-aarch64.zip';
+    default:
+      return undefined;
+  }
+};
+
+const fetchGitHubJson = async <T>({
+  url,
+  accessToken,
+}: {
+  readonly url: string;
+  readonly accessToken?: string;
+}): Promise<T> => {
+  const response = await fetch(url, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'composio-cli-local-tools-repair',
+      ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`GitHub request failed: HTTP ${response.status}`);
+  }
+  return (await response.json()) as T;
+};
+
+const downloadAsset = async (
+  asset: GitHubReleaseAsset,
+  accessToken?: string
+): Promise<Uint8Array> => {
+  const response = await fetch(asset.browser_download_url, {
+    headers: accessToken ? { Authorization: `Bearer ${accessToken}` } : undefined,
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to download ${asset.name}: HTTP ${response.status}`);
+  }
+  return new Uint8Array(await response.arrayBuffer());
+};
+
+const fetchChecksums = async (
+  release: GitHubRelease,
+  accessToken?: string
+): Promise<Map<string, string> | undefined> => {
+  const checksumsAsset = release.assets.find(asset => asset.name === 'checksums.txt');
+  if (!checksumsAsset) return undefined;
+
+  const response = await fetch(checksumsAsset.browser_download_url, {
+    headers: accessToken ? { Authorization: `Bearer ${accessToken}` } : undefined,
+  });
+  if (!response.ok) return undefined;
+
+  const checksums = new Map<string, string>();
+  const text = await response.text();
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const parts = trimmed.split(/\s+/);
+    if (parts.length >= 2) {
+      checksums.set(parts[1]!, parts[0]!);
+    }
+  }
+  return checksums;
+};
+
+const verifyChecksum = async ({
+  data,
+  expectedHash,
+  fileName,
+}: {
+  readonly data: Uint8Array;
+  readonly expectedHash: string;
+  readonly fileName: string;
+}): Promise<void> => {
+  const digest = await crypto.subtle.digest('SHA-256', data.slice().buffer);
+  const actualHash = Array.from(new Uint8Array(digest))
+    .map(byte => byte.toString(16).padStart(2, '0'))
+    .join('');
+  if (actualHash !== expectedHash) {
+    throw new Error(
+      `Checksum mismatch while repairing ${fileName}\n  Expected: ${expectedHash}\n  Actual:   ${actualHash}`
+    );
+  }
+};
+
+const isStandaloneBunExecutable = (): boolean => {
+  const currentFilePath = fileURLToPath(import.meta.url);
+  return currentFilePath.startsWith('/$bunfs/');
+};
+
+const repairInstalledLocalToolsBundle = async (): Promise<boolean> => {
+  if (process.env.COMPOSIO_LOCAL_TOOLS_BIN_DIR?.trim() || !isStandaloneBunExecutable()) {
+    return false;
+  }
+
+  const installDirectory = path.dirname(process.execPath);
+  const releaseTag =
+    process.env.GITHUB_TAG?.trim() ||
+    (await readTextFileIfPresent(path.join(installDirectory, RELEASE_TAG_FILENAME)));
+  if (!releaseTag) return false;
+
+  const assetName = resolveBinaryAssetName();
+  if (!assetName) return false;
+
+  const githubConfig = {
+    apiBaseUrl:
+      process.env.GITHUB_API_BASE_URL ||
+      process.env.COMPOSIO_GITHUB_API_BASE_URL ||
+      DEFAULT_GITHUB_CONFIG.apiBaseUrl,
+    owner:
+      process.env.GITHUB_OWNER || process.env.COMPOSIO_GITHUB_OWNER || DEFAULT_GITHUB_CONFIG.owner,
+    repo: process.env.GITHUB_REPO || process.env.COMPOSIO_GITHUB_REPO || DEFAULT_GITHUB_CONFIG.repo,
+    accessToken: process.env.GITHUB_ACCESS_TOKEN || process.env.COMPOSIO_GITHUB_ACCESS_TOKEN,
+  };
+
+  const release = await fetchGitHubJson<GitHubRelease>({
+    url: `${githubConfig.apiBaseUrl}/repos/${githubConfig.owner}/${githubConfig.repo}/releases/tags/${encodeURIComponent(releaseTag)}`,
+    accessToken: githubConfig.accessToken,
+  });
+  const asset = release.assets.find(candidate => candidate.name === assetName);
+  if (!asset) return false;
+
+  const archiveData = await downloadAsset(asset, githubConfig.accessToken);
+  const expectedChecksum = (await fetchChecksums(release, githubConfig.accessToken))?.get(
+    asset.name
+  );
+  if (expectedChecksum) {
+    await verifyChecksum({
+      data: archiveData,
+      expectedHash: expectedChecksum,
+      fileName: asset.name,
+    });
+  }
+
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'composio-local-tools-repair-'));
+  try {
+    const zipPath = path.join(tempDir, asset.name);
+    const extractDir = path.join(tempDir, 'extract');
+    await fs.writeFile(zipPath, archiveData);
+    await decompress(zipPath, extractDir);
+
+    const archiveBundleRoot = path.join(
+      extractDir,
+      path.parse(asset.name).name,
+      DEFAULT_BUNDLE_DIR
+    );
+    if (!(await binaryExists(archiveBundleRoot))) return false;
+
+    const installBundleRoot = path.join(installDirectory, DEFAULT_BUNDLE_DIR);
+    await fs.rm(installBundleRoot, { force: true, recursive: true });
+    await fs.cp(archiveBundleRoot, installBundleRoot, { recursive: true });
+    return true;
+  } finally {
+    await fs.rm(tempDir, { force: true, recursive: true });
+  }
+};
+
+const maybeRepairInstalledLocalToolsBundle = async (): Promise<boolean> => {
+  localToolsRepairPromise ??= repairInstalledLocalToolsBundle().catch(() => false);
+  return localToolsRepairPromise;
+};
+
 const findDeclaration = (
   toolkit: LocalToolkitDeclaration,
   id: string
@@ -90,6 +290,20 @@ export const resolveBundledBinary = async (
         exists: true,
         source: 'bundled',
       };
+    }
+  }
+
+  if (bundledPaths.length > 0 && (await maybeRepairInstalledLocalToolsBundle())) {
+    for (const bundledPath of bundledPaths) {
+      if (await binaryExists(bundledPath)) {
+        return {
+          id: ref.bundledBinary,
+          path: bundledPath,
+          platform: currentPlatform,
+          exists: true,
+          source: 'bundled',
+        };
+      }
     }
   }
 

--- a/ts/packages/cli/scripts/package-binaries.ts
+++ b/ts/packages/cli/scripts/package-binaries.ts
@@ -19,13 +19,14 @@ import { Config, ConfigProvider, Console, Effect, Logger, Layer, LogLevel } from
 import { BunContext, BunRuntime } from '@effect/platform-bun';
 import { LOCAL_TOOLS_BINARY_ASSET_DIRNAME, teardown } from './_shared';
 import { $ } from 'bun';
-import { readdir, stat } from 'node:fs/promises';
+import { readdir, stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { collectExpectedRunCompanionAssetRelativePaths } from '../src/services/run-companion-modules';
 
 const BINARIES_DIR = './dist/binaries';
 const COMPANIONS_DIR = path.join(BINARIES_DIR, 'companions');
 const LOCAL_TOOLS_BINARY_ASSETS_DIR = path.join(BINARIES_DIR, LOCAL_TOOLS_BINARY_ASSET_DIRNAME);
+const RELEASE_TAG = process.env.RELEASE_TAG?.trim();
 
 /**
  * Known binary artifact names (without extension).
@@ -81,8 +82,14 @@ export function packageBinaries() {
           await $`mkdir -p ${targetDirectory}`.quiet();
           await $`cp ${path.join(COMPANIONS_DIR, relativePath)} ${path.join(nestedDir, relativePath)}`.quiet();
         }
-        if (await Bun.file(LOCAL_TOOLS_BINARY_ASSETS_DIR).exists()) {
+        const hasLocalToolsBinaryAssets = await stat(LOCAL_TOOLS_BINARY_ASSETS_DIR)
+          .then(stats => stats.isDirectory())
+          .catch(() => false);
+        if (hasLocalToolsBinaryAssets) {
           await $`cp -R ${LOCAL_TOOLS_BINARY_ASSETS_DIR} ${path.join(nestedDir, LOCAL_TOOLS_BINARY_ASSET_DIRNAME)}`.quiet();
+        }
+        if (RELEASE_TAG) {
+          await writeFile(path.join(nestedDir, 'release-tag.txt'), `${RELEASE_TAG}\n`, 'utf8');
         }
         const previousCwd = process.cwd();
         process.chdir(tempDir);

--- a/ts/packages/cli/src/commands/tools/commands/tools.execute.cmd.ts
+++ b/ts/packages/cli/src/commands/tools/commands/tools.execute.cmd.ts
@@ -973,19 +973,55 @@ const resolveExplicitConnectedAccount = (params: {
 
 const resolveExecuteContext = (params: RunToolsExecuteParams) =>
   Effect.gen(function* () {
+    const ui = yield* TerminalUI;
+    const executor = yield* ToolsExecutor;
+    const input = (yield* resolveInput(params.data)) ?? '{}';
+    const parsedArgs = yield* parseArguments(input);
+    const cliConfig = yield* ComposioCliUserConfig;
+
+    if (
+      isLocalToolSlug(params.slug) &&
+      !cliConfig.isExperimentalFeatureEnabled(CLI_EXPERIMENTAL_FEATURES.LOCAL_TOOLS)
+    ) {
+      return yield* Effect.fail(
+        new Error(
+          `Local tools are experimental. Enable them with \`composio config experimental ${CLI_EXPERIMENTAL_FEATURES.LOCAL_TOOLS} on\` before executing ${params.slug}.`
+        )
+      );
+    }
+
+    if (isLocalToolSlug(params.slug)) {
+      if (Option.isSome(params.file)) {
+        return yield* Effect.fail(new Error('--file is not supported for local tools yet.'));
+      }
+      return {
+        ui,
+        executor,
+        resolvedProject: {
+          orgId: 'local',
+          projectId: 'local',
+          projectType: 'DEVELOPER',
+        },
+        args: parsedArgs,
+        resolvedUserId: 'local',
+        selectedConnectedAccountId: undefined,
+        executeOutputDir: process.env.COMPOSIO_RUN_OUTPUT_DIR?.trim() || undefined,
+        executeParams: {
+          userId: 'local',
+          arguments: parsedArgs,
+        },
+      } satisfies ResolvedExecuteContext;
+    }
+
     const resolvedProject = yield* resolveCommandProject({
       mode: params.projectMode,
       projectName:
         params.surface === 'root' ? undefined : Option.getOrUndefined(params.projectName),
     }).pipe(Effect.mapError(formatResolveCommandProjectError));
-    const ui = yield* TerminalUI;
-    const executor = yield* ToolsExecutor;
     const clientSingleton = yield* ComposioClientSingleton;
     const userContext = yield* ComposioUserContext;
     const projectContext = yield* ProjectContext;
 
-    const input = (yield* resolveInput(params.data)) ?? '{}';
-    const parsedArgs = yield* parseArguments(input);
     const localProjectContext = yield* projectContext.resolve.pipe(
       Effect.catchAll(() => Effect.succeed(Option.none()))
     );
@@ -1012,17 +1048,6 @@ const resolveExecuteContext = (params: RunToolsExecuteParams) =>
       orgId: resolvedProject.orgId,
       projectId: resolvedProject.projectId,
     });
-    const cliConfig = yield* ComposioCliUserConfig;
-    if (
-      isLocalToolSlug(params.slug) &&
-      !cliConfig.isExperimentalFeatureEnabled(CLI_EXPERIMENTAL_FEATURES.LOCAL_TOOLS)
-    ) {
-      return yield* Effect.fail(
-        new Error(
-          `Local tools are experimental. Enable them with \`composio config experimental ${CLI_EXPERIMENTAL_FEATURES.LOCAL_TOOLS} on\` before executing ${params.slug}.`
-        )
-      );
-    }
     const accountSelector = cliConfig.isExperimentalFeatureEnabled(
       CLI_EXPERIMENTAL_FEATURES.MULTI_ACCOUNT
     )
@@ -1219,7 +1244,8 @@ const runExecuteWithSpinner = (params: {
   readonly skipChecks: boolean;
 }) =>
   Effect.gen(function* () {
-    const verificationDisabled = params.skipChecks || params.skipToolParamsCheck;
+    const verificationDisabled =
+      params.skipChecks || params.skipToolParamsCheck || isLocalToolSlug(params.slug);
     const cachedDefinition = verificationDisabled
       ? null
       : yield* getCachedToolInputDefinition(params.slug);
@@ -1464,7 +1490,7 @@ const runExecuteWithSpinner = (params: {
 
 const runToolsExecute = (params: RunToolsExecuteParams) =>
   Effect.gen(function* () {
-    if (!(yield* requireAuth)) return;
+    if (!isLocalToolSlug(params.slug) && !(yield* requireAuth)) return;
 
     const cliConfig = yield* ComposioCliUserConfig;
     if (

--- a/ts/packages/cli/src/effects/version.ts
+++ b/ts/packages/cli/src/effects/version.ts
@@ -1,8 +1,9 @@
 import { Effect, Option } from 'effect';
 import { DEBUG_OVERRIDE_CONFIG } from 'src/effects/debug-config';
 import * as constants from 'src/constants';
+import { resolveInstalledCliVersion } from 'src/services/run-companion-modules';
 
 export const getVersion = Effect.map(
   DEBUG_OVERRIDE_CONFIG.VERSION,
-  Option.getOrElse(() => constants.APP_VERSION)
+  Option.getOrElse(() => resolveInstalledCliVersion(process.execPath, constants.APP_VERSION))
 );

--- a/ts/packages/cli/src/services/run-companion-modules.ts
+++ b/ts/packages/cli/src/services/run-companion-modules.ts
@@ -250,6 +250,20 @@ export const readInstalledReleaseTag = (execPath: string) =>
     path.join(resolveCompanionInstallDirectory(execPath), RUN_COMPANION_RELEASE_TAG_FILENAME)
   );
 
+export const normalizeCliReleaseVersion = (releaseIdentifier: string): string => {
+  const trimmed = releaseIdentifier.trim();
+  if (trimmed.startsWith('@composio/cli@')) {
+    return trimmed.slice('@composio/cli@'.length);
+  }
+  if (/^v\d+\.\d+\.\d+(?:[-+].*)?$/.test(trimmed)) {
+    return trimmed.slice(1);
+  }
+  return trimmed;
+};
+
+export const resolveInstalledCliVersion = (execPath: string, fallbackVersion: string): string =>
+  normalizeCliReleaseVersion(readInstalledReleaseTag(execPath) ?? fallbackVersion);
+
 export const writeInstalledReleaseTag = (installDir: string, releaseTag: string) => {
   fs.writeFileSync(
     path.join(installDir, RUN_COMPANION_RELEASE_TAG_FILENAME),

--- a/ts/packages/cli/src/services/update-check.ts
+++ b/ts/packages/cli/src/services/update-check.ts
@@ -5,6 +5,7 @@ import { dirname, join } from 'node:path';
 import semver from 'semver';
 import { bold, cyanBright, dim } from 'src/ui/colors';
 import { APP_VERSION, GITHUB_REPO } from '../constants';
+import { resolveInstalledCliVersion } from './run-companion-modules';
 
 /**
  * Background update check for @composio/cli.
@@ -66,7 +67,7 @@ function getCurrentBinaryAssetName(): string | undefined {
 
 const defaultConfig: UpdateCheckConfig = {
   stateFile: join(_home, 'update-check.json'),
-  currentVersion: APP_VERSION,
+  currentVersion: resolveInstalledCliVersion(process.execPath, APP_VERSION),
   checkIntervalMs: CHECK_INTERVAL_MS,
   releasesUrl: `${GITHUB_REPO.API_BASE_URL}/repos/${GITHUB_REPO.OWNER}/${GITHUB_REPO.REPO}/releases?per_page=100`,
   binaryAssetName: getCurrentBinaryAssetName(),

--- a/ts/packages/cli/src/services/upgrade-binary.ts
+++ b/ts/packages/cli/src/services/upgrade-binary.ts
@@ -1,6 +1,7 @@
 import { Data, Effect, Config, Option } from 'effect';
 import { HttpClient, FileSystem } from '@effect/platform';
 import * as path from 'node:path';
+import { cp as copyPath, rm as removePath } from 'node:fs/promises';
 import { APP_VERSION } from '../constants';
 import { DEBUG_OVERRIDE_CONFIG } from 'src/effects/debug-config';
 import { GITHUB_CONFIG } from 'src/effects/github-config';
@@ -28,6 +29,7 @@ export class UpgradeBinaryError extends Data.TaggedError('services/UpgradeBinary
  * CLI binary name constant
  */
 export const CLI_BINARY_NAME = 'composio';
+const LOCAL_TOOLS_BINARY_ASSET_DIRNAME = 'local-tools-binaries';
 
 const getBinaryAssetName = (platformArch: PlatformArch) =>
   `${CLI_BINARY_NAME}-${platformArch.platform}-${platformArch.arch}.zip`;
@@ -492,6 +494,28 @@ export class UpgradeBinary extends Effect.Service<UpgradeBinary>()('services/Upg
                 )
               )
             );
+        }
+
+        const localToolsAssetSource = path.join(sourceDirectory, LOCAL_TOOLS_BINARY_ASSET_DIRNAME);
+        const localToolsAssetExists = yield* fs
+          .exists(localToolsAssetSource)
+          .pipe(Effect.catchAll(() => Effect.succeed(false)));
+        if (localToolsAssetExists) {
+          const localToolsAssetTarget = path.join(
+            targetDirectory,
+            LOCAL_TOOLS_BINARY_ASSET_DIRNAME
+          );
+          yield* Effect.tryPromise({
+            try: async () => {
+              await removePath(localToolsAssetTarget, { recursive: true, force: true });
+              await copyPath(localToolsAssetSource, localToolsAssetTarget, { recursive: true });
+            },
+            catch: error =>
+              new UpgradeBinaryError({
+                cause: error as Error,
+                message: 'Failed to replace local-tool binary assets',
+              }),
+          });
         }
 
         if (options.releaseTag) {

--- a/ts/packages/cli/test/src/commands/tools/tools.execute.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/tools/tools.execute.cmd.test.ts
@@ -67,6 +67,34 @@ describe('CLI: composio execute', () => {
 
   layer(
     TestLive({
+      stdin: { isTTY: true, data: '' },
+      toolsExecutor: {
+        respondWith: {
+          successful: true,
+          data: { ok: true, echoed: 'local' },
+          error: null,
+          logId: '',
+        },
+      },
+    })
+  )('[Given] a local tool slug without auth [Then] it executes locally', it => {
+    it.scoped('does not require login or Tool Router context', () =>
+      Effect.gen(function* () {
+        yield* cli(['execute', 'LOCAL_BEEPER_IMESSAGE_VERSION', '-d', '{ value: 1 }']);
+
+        const lines = yield* MockConsole.getLines({ stripAnsi: true });
+        const output = parseLastJson(lines);
+        expect(output).toMatchObject({
+          successful: true,
+          data: { ok: true, echoed: 'local' },
+          error: null,
+        });
+      })
+    );
+  });
+
+  layer(
+    TestLive({
       baseConfigProvider: testConfigProvider,
       fixture: 'global-test-user-id',
       stdin: { isTTY: true, data: '' },

--- a/ts/packages/cli/test/src/services/cli-user-config.test.ts
+++ b/ts/packages/cli/test/src/services/cli-user-config.test.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import * as tempy from 'tempy';
 import fs from 'node:fs';
-import { describe, it } from '@effect/vitest';
+import { describe, it, vi } from '@effect/vitest';
 import { assertEquals } from '@effect/vitest/utils';
 import { FileSystem } from '@effect/platform';
 import { BunFileSystem } from '@effect/platform-bun';
@@ -41,6 +41,32 @@ describe('ComposioCliUserConfig', () => {
 
       const fs = yield* FileSystem.FileSystem;
       assertEquals(yield* fs.exists(path.join(cwd, '.composio', 'config.json')), true);
+    }).pipe(Effect.provide(CliUserConfigTest));
+  });
+
+  it.scoped('uses installed beta release metadata for experimental defaults', () => {
+    const cwd = tempy.temporaryDirectory();
+    const installDir = tempy.temporaryDirectory();
+    const fakeExecPath = path.join(installDir, 'composio');
+    fs.writeFileSync(fakeExecPath, 'fake binary');
+    fs.writeFileSync(path.join(installDir, 'release-tag.txt'), '@composio/cli@1.2.4-beta.5\n');
+    const execPathSpy = vi.spyOn(process, 'execPath', 'get').mockReturnValue(fakeExecPath);
+    const map = new Map() satisfies Map<string, string>;
+    const NodeOsTest = Layer.succeed(NodeOs, defaultNodeOs({ homedir: cwd }));
+    const CliUserConfigTest = Layer.provideMerge(
+      ComposioCliUserConfigLive,
+      Layer.mergeAll(BunFileSystem.layer, NodeOsTest, withMapConfigProvider(map))
+    );
+
+    return Effect.gen(function* () {
+      try {
+        const config = yield* ComposioCliUserConfig;
+        assertEquals(config.channel, 'beta');
+        assertEquals(config.isExperimentalFeatureEnabled('listen'), true);
+        assertEquals(config.isExperimentalFeatureEnabled('local_tools'), true);
+      } finally {
+        execPathSpy.mockRestore();
+      }
     }).pipe(Effect.provide(CliUserConfigTest));
   });
 

--- a/ts/packages/cli/test/src/services/upgrade-binary.test.ts
+++ b/ts/packages/cli/test/src/services/upgrade-binary.test.ts
@@ -2,13 +2,14 @@ import { describe, expect, it, vi } from '@effect/vitest';
 import { ConfigProvider, Effect, Layer } from 'effect';
 import { FetchHttpClient } from '@effect/platform';
 import { BunFileSystem } from '@effect/platform-bun';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { withHttpServer } from 'test/__utils__/http-server';
 import { TerminalUI } from 'src/services/terminal-ui';
 import { UpgradeBinary, UpgradeBinaryError } from 'src/services/upgrade-binary';
 import { NodeOs } from 'src/services/node-os';
+import { collectExpectedRunCompanionAssetRelativePaths } from 'src/services/run-companion-modules';
 
 const TerminalUINoop = Layer.succeed(
   TerminalUI,
@@ -342,6 +343,54 @@ describe('UpgradeBinary', () => {
           expect(String(error.cause)).toContain('beta-3.zip');
         }
       );
+    } finally {
+      execPathSpy.mockRestore();
+      vi.unstubAllGlobals();
+      vi.restoreAllMocks();
+    }
+  });
+
+  it('copies local-tool bundled binary assets during local-target upgrades', async () => {
+    const installDir = mkdtempSync(path.join(tmpdir(), 'composio-local-tool-upgrade-target-'));
+    const sourceDir = mkdtempSync(path.join(tmpdir(), 'composio-local-tool-upgrade-source-'));
+    const fakeExecPath = path.join(installDir, 'composio');
+    const sourceBinaryPath = path.join(sourceDir, 'composio');
+    const sourceLocalToolPath = path.join(
+      sourceDir,
+      'local-tools-binaries',
+      'beeper-imessage',
+      'darwin-arm64',
+      'imessage-cli'
+    );
+    const installedLocalToolPath = path.join(
+      installDir,
+      'local-tools-binaries',
+      'beeper-imessage',
+      'darwin-arm64',
+      'imessage-cli'
+    );
+
+    writeFileSync(fakeExecPath, 'old-binary');
+    writeFileSync(sourceBinaryPath, 'new-binary');
+    mkdirSync(path.dirname(sourceLocalToolPath), { recursive: true });
+    writeFileSync(sourceLocalToolPath, 'imessage-sidecar');
+
+    for (const relativePath of collectExpectedRunCompanionAssetRelativePaths(sourceDir)) {
+      const companionPath = path.join(sourceDir, relativePath);
+      mkdirSync(path.dirname(companionPath), { recursive: true });
+      writeFileSync(companionPath, 'support-file');
+    }
+
+    vi.stubGlobal('Bun', { which: vi.fn(() => null) });
+    const execPathSpy = vi.spyOn(process, 'execPath', 'get').mockReturnValue(fakeExecPath);
+
+    try {
+      const result = await runUpgradeSuccess([['DEBUG_OVERRIDE_UPGRADE_TARGET', sourceBinaryPath]]);
+
+      expect(result).toBeUndefined();
+      expect(readFileSync(fakeExecPath, 'utf8')).toBe('new-binary');
+      expect(existsSync(installedLocalToolPath)).toBe(true);
+      expect(readFileSync(installedLocalToolPath, 'utf8')).toBe('imessage-sidecar');
     } finally {
       execPathSpy.mockRestore();
       vi.unstubAllGlobals();


### PR DESCRIPTION
## Summary
- Broaden the Beeper iMessage macOS build patch so BetterSwiftAX `kAX...` constants compile on GitHub `macos-15`/`macos-15-intel`.
- Pin the fixed `platform-imessage` submodule source and add Swift 6.2 / Peekaboo dependency patching for the CLI binary workflow.
- Package and verify macOS local-tool sidecars plus `release-tag.txt` in CLI release zips.
- Fix installed beta metadata/upgrade behavior so `--version`, update checks, and beta-default experimental flags use the installed release tag.
- Let `LOCAL_*` execution bypass remote auth/project/schema validation.
- Add runtime self-heal for missing installed `local-tools-binaries`: if an old upgrader installs the fixed beta binary without sidecars, first local-tool execution downloads the matching release zip, verifies checksum when available, and restores the sidecars.

## Validation
- `pnpm --filter @composio/cli-local-tools build:beeper-imessage -- --target darwin-arm64`
- `pnpm --filter @composio/cli-local-tools build:beeper-imessage -- --target darwin-x64`
- `pnpm --filter @composio/cli-local-tools build:peekaboo -- --target darwin-arm64`
- `pnpm --filter @composio/cli-local-tools build:peekaboo -- --target darwin-x64`
- `pnpm --filter @composio/cli-local-tools typecheck:tsc`
- `pnpm --filter @composio/cli-local-tools test`
- `pnpm --filter @composio/cli typecheck:tsc`
- `pnpm --filter @composio/cli build:binary`
- Targeted CLI tests for execute/config/upgrade/version/update-check paths.
- Packaged binary smoke test confirmed bundled Beeper sidecar works.
- Repair smoke test: copied only the new `composio` binary plus `release-tag.txt` into a temp install with no `local-tools-binaries`; `execute LOCAL_BEEPER_IMESSAGE_VERSION -d '{}'` restored sidecars from `@composio/cli@0.2.29-beta.235` and succeeded.

## Release workflow
- Beta build run `25405049712` succeeded for commit `9d0910c909b7b257d0f17b6d082980952d1e6c59` and published `@composio/cli@0.2.29-beta.235`.
- This PR now includes one follow-up commit (`2c32cff4c`) to cover the old-upgrader/missing-sidecars incremental upgrade path; normal branch CI and beta build run `25406984535` are running again.
