### PR TITLE
Bump generated clients for v3.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ catalogs:
       specifier: ^4.20250917.0
       version: 4.20260218.0
     '@composio/client':
-      specifier: 0.1.0-alpha.68
-      version: 0.1.0-alpha.68
+      specifier: 0.1.0-alpha.69
+      version: 0.1.0-alpha.69
     '@effect/cli':
       specifier: ^0.73.2
       version: 0.73.2
@@ -1079,7 +1079,7 @@ importers:
         version: link:../cli-local-tools
       '@composio/client':
         specifier: 'catalog:'
-        version: 0.1.0-alpha.68
+        version: 0.1.0-alpha.69
       '@composio/core':
         specifier: workspace:*
         version: link:../core
@@ -1243,7 +1243,7 @@ importers:
     dependencies:
       '@composio/client':
         specifier: 'catalog:'
-        version: 0.1.0-alpha.68
+        version: 0.1.0-alpha.69
       '@composio/json-schema-to-zod':
         specifier: workspace:*
         version: link:../json-schema-to-zod
@@ -1906,8 +1906,8 @@ packages:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
 
-  '@composio/client@0.1.0-alpha.68':
-    resolution: {integrity: sha512-hym21PsIELzlF0Fc9RASr3PfGR1alpGE8IlbRJU3ED6UllMZz7VzREsKUZfojG4yHjZMBlVXG5QGMBzuPEue3Q==}
+  '@composio/client@0.1.0-alpha.69':
+    resolution: {integrity: sha512-DMqjIrDbKJaIimuaC4iPDmIbYlcHcXY2LcjTr0hgP+bq0NiN0vzasrK9pwWdGwMEExpGXBHeAff3VvJvpY/r5w==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -7274,7 +7274,7 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@composio/client@0.1.0-alpha.68': {}
+  '@composio/client@0.1.0-alpha.69': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,7 +22,7 @@ catalog:
   '@clack/prompts': '^1.0.1'
   '@cloudflare/vitest-pool-workers': ^0.9.2
   '@cloudflare/workers-types': ^4.20250917.0
-  '@composio/client': 0.1.0-alpha.68
+  '@composio/client': 0.1.0-alpha.69
   '@effect/cli': ^0.73.2
   '@effect/eslint-plugin': ^0.3.2
   '@effect/language-service': ^0.74.0

--- a/python/composio/core/models/tools.py
+++ b/python/composio/core/models/tools.py
@@ -40,6 +40,8 @@ from ._modifiers import (
     schema_modifier,
 )
 
+TOOL_ROUTER_SESSION_TOOLS_PAGE_LIMIT = 500
+
 
 def _needs_serialization(obj: t.Any) -> bool:
     """Check if an object contains any Pydantic model instances."""
@@ -275,9 +277,21 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
             ```
         """
         # Fetch session tools from the API
-        tools_response = self._client.tool_router.session.tools(session_id=session_id)
-        # Cast to Tool type - session.tools returns compatible Item type from different response schema
-        tools_list: t.List[Tool] = [t.cast(Tool, item) for item in tools_response.items]
+        tools_list: t.List[Tool] = []
+        cursor: t.Optional[str] = None
+
+        while True:
+            tools_response = self._client.tool_router.session.tools(
+                session_id=session_id,
+                cursor=none_to_omit(cursor),
+                limit=TOOL_ROUTER_SESSION_TOOLS_PAGE_LIMIT,
+            )
+            # Cast to Tool type - session.tools returns compatible Item type from different response schema
+            tools_list.extend(t.cast(Tool, item) for item in tools_response.items)
+
+            cursor = getattr(tools_response, "next_cursor", None)
+            if not cursor:
+                break
 
         # Apply schema modifiers if provided
         if modifiers is not None:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.10,<4"
 dependencies = [
     "pysher>=1.0.8",
     "pydantic>=2.6.4",
-    "composio-client==1.35.0",
+    "composio-client==1.36.0",
     "typing-extensions>=4.0.0",
     "openai",
     "json-schema-to-pydantic>=0.4.8",

--- a/python/setup.py
+++ b/python/setup.py
@@ -25,7 +25,7 @@ setup(
     install_requires=[
         "pysher>=1.0.8",
         "pydantic>=2.6.4",
-        "composio-client==1.35.0",
+        "composio-client==1.36.0",
         "typing-extensions>=4.0.0",
         "openai",
         "json-schema-to-pydantic>=0.4.8",

--- a/python/tests/test_tool_execution.py
+++ b/python/tests/test_tool_execution.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 from pydantic import BaseModel, RootModel
+from composio_client import omit
 
 from composio.client.types import Tool, tool_list_response
 from composio.core.models.base import allow_tracking
@@ -47,6 +48,35 @@ class TestToolExecution:
             is_deprecated=False,
             no_auth=False,
             tags=[],
+        )
+
+    def test_get_raw_tool_router_meta_tools_fetches_all_pages(self):
+        """Test that ToolRouter session tools are fetched across all pages."""
+        mock_client = Mock()
+        mock_provider = Mock()
+        tools = Tools(client=mock_client, provider=mock_provider)
+
+        first_tool = self.create_mock_tool("FIRST_TOOL", "github")
+        second_tool = self.create_mock_tool("SECOND_TOOL", "slack")
+        first_response = Mock(items=[first_tool], next_cursor="next_page")
+        second_response = Mock(items=[second_tool], next_cursor=None)
+        mock_client.tool_router.session.tools.side_effect = [
+            first_response,
+            second_response,
+        ]
+
+        result = tools.get_raw_tool_router_meta_tools("session_123")
+
+        assert [tool.slug for tool in result] == ["FIRST_TOOL", "SECOND_TOOL"]
+        mock_client.tool_router.session.tools.assert_any_call(
+            session_id="session_123",
+            cursor=omit,
+            limit=500,
+        )
+        mock_client.tool_router.session.tools.assert_any_call(
+            session_id="session_123",
+            limit=500,
+            cursor="next_page",
         )
 
     def test_tool_execution_uses_toolkit_version(self):

--- a/ts/e2e-tests/cli/toolkits/info/e2e.test.ts
+++ b/ts/e2e-tests/cli/toolkits/info/e2e.test.ts
@@ -149,10 +149,8 @@ e2e(import.meta.url, {
 
     describe('mock API usage', () => {
       it('requests the detailed toolkit route for known and unknown slugs', () => {
-        expect(server.requests).toContain('GET /api/v3/toolkits/gmail');
-        expect(server.requests).toContain(
-          'GET /api/v3/toolkits/nonexistent_toolkit_xyz12345'
-        );
+        expect(server.requests).toContain('GET /api/v3.1/toolkits/gmail');
+        expect(server.requests).toContain('GET /api/v3.1/toolkits/nonexistent_toolkit_xyz12345');
       });
     });
   },

--- a/ts/e2e-tests/cli/toolkits/list/e2e.test.ts
+++ b/ts/e2e-tests/cli/toolkits/list/e2e.test.ts
@@ -5,12 +5,7 @@
  * supports deterministic `--query` filtering, and respects `--limit`.
  */
 
-import {
-  e2e,
-  sanitizeOutput,
-  parseJsonStdout,
-  type E2ETestResult,
-} from '@e2e-tests/utils';
+import { e2e, sanitizeOutput, parseJsonStdout, type E2ETestResult } from '@e2e-tests/utils';
 import { TIMEOUTS } from '@e2e-tests/utils/const';
 import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
 import {
@@ -39,7 +34,9 @@ e2e(import.meta.url, {
 
       exactResult = await runCmd(`${envPrefix} composio dev toolkits list --query gmail --limit 1`);
       prefixResult = await runCmd(`${envPrefix} composio dev toolkits list --query gmai --limit 1`);
-      noFuzzyResult = await runCmd(`${envPrefix} composio dev toolkits list --query gmal --limit 1`);
+      noFuzzyResult = await runCmd(
+        `${envPrefix} composio dev toolkits list --query gmal --limit 1`
+      );
     }, TIMEOUTS.FIXTURE);
 
     afterAll(async () => {
@@ -117,9 +114,9 @@ e2e(import.meta.url, {
 
     describe('mock API usage', () => {
       it('requests the toolkit catalog for each search term', () => {
-        expect(server.requests).toContain('GET /api/v3/toolkits?search=gmail&limit=1');
-        expect(server.requests).toContain('GET /api/v3/toolkits?search=gmai&limit=1');
-        expect(server.requests).toContain('GET /api/v3/toolkits?search=gmal&limit=1');
+        expect(server.requests).toContain('GET /api/v3.1/toolkits?search=gmail&limit=1');
+        expect(server.requests).toContain('GET /api/v3.1/toolkits?search=gmai&limit=1');
+        expect(server.requests).toContain('GET /api/v3.1/toolkits?search=gmal&limit=1');
       });
     });
   },

--- a/ts/e2e-tests/cli/toolkits/search/e2e.test.ts
+++ b/ts/e2e-tests/cli/toolkits/search/e2e.test.ts
@@ -144,10 +144,10 @@ e2e(import.meta.url, {
 
     describe('mock API usage', () => {
       it('requests the toolkit catalog for each search scenario', () => {
-        expect(server.requests).toContain('GET /api/v3/toolkits?search=gmail&limit=10');
-        expect(server.requests).toContain('GET /api/v3/toolkits?search=gmail&limit=1');
+        expect(server.requests).toContain('GET /api/v3.1/toolkits?search=gmail&limit=10');
+        expect(server.requests).toContain('GET /api/v3.1/toolkits?search=gmail&limit=1');
         expect(server.requests).toContain(
-          'GET /api/v3/toolkits?search=xyznonexistent_abc_12345&limit=10'
+          'GET /api/v3.1/toolkits?search=xyznonexistent_abc_12345&limit=10'
         );
       });
     });

--- a/ts/packages/cli/scripts/mock-toolkits-server.ts
+++ b/ts/packages/cli/scripts/mock-toolkits-server.ts
@@ -94,10 +94,11 @@ export async function startMockToolkitsListServer(options?: {
 
   const server = createServer((req, res) => {
     const url = new URL(req.url ?? '/', `http://${req.headers.host ?? '127.0.0.1'}`);
-    requests.push(`${req.method ?? 'GET'} ${url.pathname}${url.search}`);
+    const method = req.method ?? 'GET';
+    requests.push(`${method} ${url.pathname}${url.search}`);
 
     if (
-      (req.method ?? 'GET') === 'GET' &&
+      method === 'GET' &&
       (url.pathname === '/api/v3/toolkits' || url.pathname === '/api/v3.1/toolkits')
     ) {
       const items = matchingToolkits(url.searchParams.get('search')).slice(0, parseLimit(req));
@@ -112,7 +113,7 @@ export async function startMockToolkitsListServer(options?: {
     }
 
     if (
-      (req.method ?? 'GET') === 'GET' &&
+      method === 'GET' &&
       (url.pathname === '/api/v3/toolkits/gmail' || url.pathname === '/api/v3.1/toolkits/gmail')
     ) {
       sendJson(res, 200, GMAIL_TOOLKIT_DETAILED);
@@ -120,7 +121,7 @@ export async function startMockToolkitsListServer(options?: {
     }
 
     if (
-      (req.method ?? 'GET') === 'GET' &&
+      method === 'GET' &&
       (url.pathname.startsWith('/api/v3/toolkits/') ||
         url.pathname.startsWith('/api/v3.1/toolkits/'))
     ) {
@@ -130,13 +131,13 @@ export async function startMockToolkitsListServer(options?: {
       return;
     }
 
-    if ((req.method ?? 'GET') === 'POST' && url.pathname === '/api/v3/cli/analytics') {
+    if (method === 'POST' && url.pathname === '/api/v3/cli/analytics') {
       sendJson(res, 204, {});
       return;
     }
 
     sendJson(res, 404, {
-      error: `Unhandled mock route: ${req.method ?? 'GET'} ${url.pathname}`,
+      error: `Unhandled mock route: ${method} ${url.pathname}`,
     });
   });
 

--- a/ts/packages/cli/scripts/mock-toolkits-server.ts
+++ b/ts/packages/cli/scripts/mock-toolkits-server.ts
@@ -96,7 +96,10 @@ export async function startMockToolkitsListServer(options?: {
     const url = new URL(req.url ?? '/', `http://${req.headers.host ?? '127.0.0.1'}`);
     requests.push(`${req.method ?? 'GET'} ${url.pathname}${url.search}`);
 
-    if ((req.method ?? 'GET') === 'GET' && url.pathname === '/api/v3/toolkits') {
+    if (
+      (req.method ?? 'GET') === 'GET' &&
+      (url.pathname === '/api/v3/toolkits' || url.pathname === '/api/v3.1/toolkits')
+    ) {
       const items = matchingToolkits(url.searchParams.get('search')).slice(0, parseLimit(req));
       sendJson(res, 200, {
         items,
@@ -108,12 +111,19 @@ export async function startMockToolkitsListServer(options?: {
       return;
     }
 
-    if ((req.method ?? 'GET') === 'GET' && url.pathname === '/api/v3/toolkits/gmail') {
+    if (
+      (req.method ?? 'GET') === 'GET' &&
+      (url.pathname === '/api/v3/toolkits/gmail' || url.pathname === '/api/v3.1/toolkits/gmail')
+    ) {
       sendJson(res, 200, GMAIL_TOOLKIT_DETAILED);
       return;
     }
 
-    if ((req.method ?? 'GET') === 'GET' && url.pathname.startsWith('/api/v3/toolkits/')) {
+    if (
+      (req.method ?? 'GET') === 'GET' &&
+      (url.pathname.startsWith('/api/v3/toolkits/') ||
+        url.pathname.startsWith('/api/v3.1/toolkits/'))
+    ) {
       sendJson(res, 404, {
         error: `Toolkit not found: ${url.pathname.split('/').at(-1) ?? 'unknown'}`,
       });

--- a/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.link.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.link.cmd.test.ts
@@ -82,7 +82,12 @@ const RecordingTerminalUI = TerminalUI.of({
 describe('CLI: composio dev connected-accounts link', () => {
   const toolRouterCreateSpy = vi.fn(async () => ({
     session_id: 'trs_test_session',
-    config: { user_id: 'consumer-user-org_test', preload: { tools: [] } },
+    config: {
+      user_id: 'consumer-user-org_test',
+      execute: {},
+      search: {},
+      preload: { tools: [] },
+    },
     config_version: 1,
     mcp: { type: 'http' as const, url: 'https://mcp.test.composio.dev' },
     tool_router_tools: ['COMPOSIO_SEARCH_TOOLS', 'COMPOSIO_MANAGE_CONNECTIONS'],

--- a/ts/packages/cli/test/src/commands/proxy.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/proxy.cmd.test.ts
@@ -56,7 +56,12 @@ describe('CLI: composio proxy', () => {
                 createParams = params;
                 return {
                   session_id: 'trs_proxy_test',
-                  config: { user_id: params.user_id, preload: { tools: [] } },
+                  config: {
+                    user_id: params.user_id,
+                    execute: {},
+                    search: {},
+                    preload: { tools: [] },
+                  },
                   config_version: 1,
                   mcp: { type: 'http' as const, url: 'https://mcp.test.composio.dev' },
                   tool_router_tools: [],
@@ -142,7 +147,12 @@ describe('CLI: composio proxy', () => {
                 createCalled = true;
                 return {
                   session_id: 'trs_proxy_test',
-                  config: { user_id: 'global_test_user_id', preload: { tools: [] } },
+                  config: {
+                    user_id: 'global_test_user_id',
+                    execute: {},
+                    search: {},
+                    preload: { tools: [] },
+                  },
                   config_version: 1,
                   mcp: { type: 'http' as const, url: 'https://mcp.test.composio.dev' },
                   tool_router_tools: [],

--- a/ts/packages/cli/test/src/commands/tools/tools.execute.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/tools/tools.execute.cmd.test.ts
@@ -188,7 +188,12 @@ describe('CLI: composio execute', () => {
           recordedSessionCreateParams.push(params as unknown as Record<string, unknown>);
           return {
             session_id: 'trs_gmail_default_session',
-            config: { user_id: params.user_id, preload: { tools: [] } },
+            config: {
+              user_id: params.user_id,
+              execute: {},
+              search: {},
+              preload: { tools: [] },
+            },
             config_version: 1,
             mcp: { type: 'http' as const, url: 'https://mcp.test.composio.dev' },
             tool_router_tools: ['COMPOSIO_SEARCH_TOOLS', 'COMPOSIO_MANAGE_CONNECTIONS'],
@@ -271,7 +276,12 @@ describe('CLI: composio execute', () => {
           recordedSessionCreateParams.push(params as unknown as Record<string, unknown>);
           return {
             session_id: 'trs_gmail_explicit_session',
-            config: { user_id: params.user_id, preload: { tools: [] } },
+            config: {
+              user_id: params.user_id,
+              execute: {},
+              search: {},
+              preload: { tools: [] },
+            },
             config_version: 1,
             mcp: { type: 'http' as const, url: 'https://mcp.test.composio.dev' },
             tool_router_tools: ['COMPOSIO_SEARCH_TOOLS', 'COMPOSIO_MANAGE_CONNECTIONS'],
@@ -335,7 +345,12 @@ describe('CLI: composio execute', () => {
           recordedSessionCreateParams.push(params as unknown as Record<string, unknown>);
           return {
             session_id: 'trs_posthog_test_session',
-            config: { user_id: params.user_id, preload: { tools: [] } },
+            config: {
+              user_id: params.user_id,
+              execute: {},
+              search: {},
+              preload: { tools: [] },
+            },
             config_version: 1,
             mcp: { type: 'http' as const, url: 'https://mcp.test.composio.dev' },
             tool_router_tools: ['COMPOSIO_SEARCH_TOOLS', 'COMPOSIO_MANAGE_CONNECTIONS'],
@@ -387,7 +402,12 @@ describe('CLI: composio execute', () => {
           recordedSessionCreateParams.push(params as unknown as Record<string, unknown>);
           return {
             session_id: 'trs_posthog_cached_session',
-            config: { user_id: params.user_id, preload: { tools: [] } },
+            config: {
+              user_id: params.user_id,
+              execute: {},
+              search: {},
+              preload: { tools: [] },
+            },
             config_version: 1,
             mcp: { type: 'http' as const, url: 'https://mcp.test.composio.dev' },
             tool_router_tools: ['COMPOSIO_SEARCH_TOOLS', 'COMPOSIO_MANAGE_CONNECTIONS'],

--- a/ts/packages/cli/test/src/commands/tools/tools.search.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/tools/tools.search.cmd.test.ts
@@ -384,7 +384,12 @@ describe('CLI: composio search', () => {
                 createParams = params;
                 return {
                   session_id: 'trs_test_session',
-                  config: { user_id: params.user_id, preload: { tools: [] } },
+                  config: {
+                    user_id: params.user_id,
+                    execute: {},
+                    search: {},
+                    preload: { tools: [] },
+                  },
                   config_version: 1,
                   mcp: { type: 'http', url: 'https://mcp.test.composio.dev' },
                   tool_router_tools: ['COMPOSIO_SEARCH_TOOLS'],
@@ -464,7 +469,12 @@ describe('CLI: composio search', () => {
                 createParams = params;
                 return {
                   session_id: 'trs_test_session',
-                  config: { user_id: params.user_id, preload: { tools: [] } },
+                  config: {
+                    user_id: params.user_id,
+                    execute: {},
+                    search: {},
+                    preload: { tools: [] },
+                  },
                   config_version: 1,
                   mcp: { type: 'http', url: 'https://mcp.test.composio.dev' },
                   tool_router_tools: ['COMPOSIO_SEARCH_TOOLS'],
@@ -652,7 +662,12 @@ describe('CLI: composio search', () => {
                 createParams = params;
                 return {
                   session_id: 'trs_test_session',
-                  config: { user_id: params.user_id, preload: { tools: [] } },
+                  config: {
+                    user_id: params.user_id,
+                    execute: {},
+                    search: {},
+                    preload: { tools: [] },
+                  },
                   config_version: 1,
                   mcp: { type: 'http', url: 'https://mcp.test.composio.dev' },
                   tool_router_tools: ['COMPOSIO_SEARCH_TOOLS'],

--- a/ts/packages/core/src/models/ConnectionRequest.ts
+++ b/ts/packages/core/src/models/ConnectionRequest.ts
@@ -73,12 +73,36 @@ export function createConnectionRequest(
   async function waitForConnection(
     timeout: number = 60000
   ): Promise<ConnectedAccountRetrieveResponse> {
+    const terminalErrorStates: ConnectedAccountStatus[] = [
+      ConnectedAccountStatuses.FAILED,
+      ConnectedAccountStatuses.EXPIRED,
+      ConnectedAccountStatuses.REVOKED,
+    ];
+    const failIfTerminal = (response: {
+      status: ConnectedAccountStatus;
+      status_reason?: string | null;
+    }) => {
+      if (terminalErrorStates.includes(response.status)) {
+        throw new ConnectionRequestFailedError(
+          `Connection request failed with status: ${response.status}${response.status_reason ? `, reason: ${response.status_reason}` : ''}`,
+          {
+            meta: {
+              connectedAccountId: state.id,
+              status: response.status,
+              statusReason: response.status_reason,
+            },
+          }
+        );
+      }
+    };
+
     try {
       const response = await client.connectedAccounts.retrieve(state.id);
       if (response.status === ConnectedAccountStatuses.ACTIVE) {
         state.status = ConnectedAccountStatuses.ACTIVE;
         return transformConnectedAccountResponse(response);
       }
+      failIfTerminal(response);
     } catch (error) {
       if (error instanceof ComposioClient.NotFoundError) {
         throw new ComposioConnectedAccountNotFoundError(
@@ -94,11 +118,6 @@ export function createConnectionRequest(
       }
     }
 
-    const terminalErrorStates: ConnectedAccountStatus[] = [
-      ConnectedAccountStatuses.FAILED,
-      ConnectedAccountStatuses.EXPIRED,
-    ];
-
     const start = Date.now();
     const pollInterval = 1000;
 
@@ -111,18 +130,7 @@ export function createConnectionRequest(
           return transformConnectedAccountResponse(response);
         }
 
-        if (terminalErrorStates.includes(response.status)) {
-          throw new ConnectionRequestFailedError(
-            `Connection request failed with status: ${response.status}${response.status_reason ? `, reason: ${response.status_reason}` : ''}`,
-            {
-              meta: {
-                connectedAccountId: state.id,
-                status: response.status,
-                statusReason: response.status_reason,
-              },
-            }
-          );
-        }
+        failIfTerminal(response);
 
         await new Promise(resolve => setTimeout(resolve, pollInterval));
       } catch (error) {

--- a/ts/packages/core/src/models/Tools.ts
+++ b/ts/packages/core/src/models/Tools.ts
@@ -59,6 +59,8 @@ import { CONFIG_DEFAULTS } from '../utils/config-defaults';
 import { resolveEffectiveUploadAllowlist } from '../utils/fileDirs';
 import { schemaHasFileUploadable } from '../utils/modifiers/FileToolModifier.utils.neutral';
 
+const TOOL_ROUTER_SESSION_TOOLS_PAGE_LIMIT = 500;
+
 /**
  * This class is used to manage tools in the Composio SDK.
  * It provides methods to list, get, and execute tools.
@@ -487,8 +489,19 @@ export class Tools<
     sessionId: string,
     options?: SchemaModifierOptions
   ): Promise<ToolList> {
-    const tools = await this.client.toolRouter.session.tools(sessionId);
-    let modifiedTools = tools.items.map(tool => this.transformToolCases(tool));
+    const tools: ToolList = [];
+    let cursor: string | null | undefined;
+
+    do {
+      const response = await this.client.toolRouter.session.tools(sessionId, {
+        limit: TOOL_ROUTER_SESSION_TOOLS_PAGE_LIMIT,
+        ...(cursor ? { cursor } : {}),
+      });
+      tools.push(...response.items.map(tool => this.transformToolCases(tool)));
+      cursor = response.next_cursor;
+    } while (cursor);
+
+    let modifiedTools = tools;
     // apply local modifiers if they are provided
     if (options?.modifySchema) {
       const modifier = options.modifySchema;

--- a/ts/packages/core/src/types/connectedAccounts.types.ts
+++ b/ts/packages/core/src/types/connectedAccounts.types.ts
@@ -12,6 +12,7 @@ export const ConnectedAccountStatuses = {
   FAILED: 'FAILED',
   EXPIRED: 'EXPIRED',
   INACTIVE: 'INACTIVE',
+  REVOKED: 'REVOKED',
 } as const;
 export const ConnectedAccountStatusSchema = z.enum([
   ConnectedAccountStatuses.INITIALIZING,
@@ -20,6 +21,7 @@ export const ConnectedAccountStatusSchema = z.enum([
   ConnectedAccountStatuses.FAILED,
   ConnectedAccountStatuses.EXPIRED,
   ConnectedAccountStatuses.INACTIVE,
+  ConnectedAccountStatuses.REVOKED,
 ]);
 export type ConnectedAccountStatus =
   (typeof ConnectedAccountStatuses)[keyof typeof ConnectedAccountStatuses];

--- a/ts/packages/core/test/connectedAccounts/connectedAccounts.test.ts
+++ b/ts/packages/core/test/connectedAccounts/connectedAccounts.test.ts
@@ -594,6 +594,33 @@ describe('ConnectedAccounts', () => {
       expect(result.wordId).toBe('castle');
       expect(result.alias).toBe('Work Gmail');
     });
+
+    it('should accept revoked connected account status from the generated client', async () => {
+      const nanoid = 'conn_revoked';
+      const mockResponse = {
+        id: nanoid,
+        status: ConnectedAccountStatuses.REVOKED,
+        auth_config: {
+          id: 'test-auth-config',
+          is_composio_managed: true,
+          is_disabled: false,
+        },
+        is_disabled: false,
+        created_at: '2023-01-01T00:00:00Z',
+        updated_at: '2023-01-01T00:00:00Z',
+        status_reason: 'revoked by user',
+        toolkit: {
+          slug: 'gmail',
+        },
+      };
+
+      extendedMockClient.connectedAccounts.retrieve.mockResolvedValueOnce(mockResponse);
+
+      const result = await connectedAccounts.get(nanoid);
+
+      expect(result.status).toBe(ConnectedAccountStatuses.REVOKED);
+      expect(result.statusReason).toBe('revoked by user');
+    });
   });
 
   describe('delete', () => {

--- a/ts/packages/core/test/connectedAccounts/connectionRequest.test.ts
+++ b/ts/packages/core/test/connectedAccounts/connectionRequest.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createConnectionRequest } from '../../src/models/ConnectionRequest';
 import { ConnectionRequest } from '../../src/types/connectionRequest.types';
 import ComposioClient, { ComposioError } from '@composio/client';
-import { ConnectionRequestTimeoutError } from '../../src/errors';
+import { ConnectionRequestFailedError, ConnectionRequestTimeoutError } from '../../src/errors';
 import { ConnectedAccountStatuses } from '../../src/types/connectedAccounts.types';
 import { AuthSchemeTypes } from '../../src/types/authConfigs.types';
 
@@ -222,6 +222,26 @@ describe('ConnectionRequest', () => {
 
       // Now check for the rejection
       await expect(connectionPromise).rejects.toBe(apiError);
+    });
+
+    it('should fail when the connection is revoked while polling', async () => {
+      connectionRequest = createConnectionRequest(
+        mockClient as unknown as ComposioClient,
+        connectedAccountId,
+        ConnectedAccountStatuses.INITIATED,
+        redirectUrl
+      );
+
+      const revokedResponse = {
+        id: connectedAccountId,
+        status: ConnectedAccountStatuses.REVOKED,
+        status_reason: 'revoked by user',
+      };
+      mockClient.connectedAccounts.retrieve.mockResolvedValueOnce(revokedResponse);
+
+      await expect(connectionRequest.waitForConnection(3000)).rejects.toThrow(
+        ConnectionRequestFailedError
+      );
     });
   });
 

--- a/ts/packages/core/test/tools/tools.test.ts
+++ b/ts/packages/core/test/tools/tools.test.ts
@@ -355,6 +355,31 @@ describe('Tools', () => {
     });
   });
 
+  describe('getRawToolRouterSessionTools', () => {
+    it('should fetch all paginated session tool pages', async () => {
+      mockClient.toolRouter.session.tools
+        .mockResolvedValueOnce({
+          items: [{ ...toolMocks.rawTool, slug: 'FIRST_TOOL' }],
+          next_cursor: 'next_page',
+        })
+        .mockResolvedValueOnce({
+          items: [{ ...toolMocks.rawTool, slug: 'SECOND_TOOL' }],
+          next_cursor: null,
+        });
+
+      const result = await context.tools.getRawToolRouterSessionTools('session_123');
+
+      expect(result.map(tool => tool.slug)).toEqual(['FIRST_TOOL', 'SECOND_TOOL']);
+      expect(mockClient.toolRouter.session.tools).toHaveBeenNthCalledWith(1, 'session_123', {
+        limit: 500,
+      });
+      expect(mockClient.toolRouter.session.tools).toHaveBeenNthCalledWith(2, 'session_123', {
+        limit: 500,
+        cursor: 'next_page',
+      });
+    });
+  });
+
   describe('getRawComposioToolBySlug', () => {
     it('should fetch a tool by slug from the API', async () => {
       const slug = 'TOOL_SLUG';

--- a/ts/packages/core/test/utils/mocks/client.mock.ts
+++ b/ts/packages/core/test/utils/mocks/client.mock.ts
@@ -19,6 +19,7 @@ export const mockClient = {
   toolRouter: {
     session: {
       execute: vi.fn(),
+      tools: vi.fn(),
     },
   },
 };

--- a/uv.lock
+++ b/uv.lock
@@ -621,7 +621,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "composio-client", specifier = "==1.35.0" },
+    { name = "composio-client", specifier = "==1.36.0" },
     { name = "json-schema-to-pydantic", specifier = ">=0.4.8" },
     { name = "openai" },
     { name = "pydantic", specifier = ">=2.6.4" },
@@ -663,7 +663,7 @@ requires-dist = [
 
 [[package]]
 name = "composio-client"
-version = "1.35.0"
+version = "1.36.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -673,9 +673,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/8c/986ba4eca8c54b4a4d684dd4b9af07f813a4d19cc0dcef6c3e150befcd5e/composio_client-1.35.0.tar.gz", hash = "sha256:05f195aec2f5706a057848c855ab31b94b00d78283dd9ed0d9a02d316f2acff8", size = 231383, upload-time = "2026-04-30T12:15:20.413Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/1c/ad526e950c1fb51ba2dc67e0467c58a8d8fd66991284c6fc8e8f08868aa9/composio_client-1.36.0.tar.gz", hash = "sha256:924e97c8e1069fb6815a382a724d9ab5992f4f393881146416eec68b66189885", size = 241263, upload-time = "2026-05-05T08:40:16.697Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/a3/5d1ab2daded174b811af8ec5539ed35a1e7f8dbcd7ab47779a787487a4fb/composio_client-1.35.0-py3-none-any.whl", hash = "sha256:59b909867a098ba89f513464c0889cfcf1817c707c729faeee665b5b2590e557", size = 257695, upload-time = "2026-04-30T12:15:18.76Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/bc/f5bb734d1e6abf246130f4549de745b87ced2957839a315479cacc6d31bb/composio_client-1.36.0-py3-none-any.whl", hash = "sha256:820961ec9001b1967273970e406f8469386c71fa378a0f4dd1c36864eff8819b", size = 277167, upload-time = "2026-05-05T08:40:15.344Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- bump generated TS client to @composio/client 0.1.0-alpha.69 and Python client to composio-client 1.36.0
- page through ToolRouter session tools in TS/Python using the generated v3.1 cursor response
- accept generated connected account status REVOKED and fail connection waits immediately for terminal states

## Validation
- pnpm --filter @composio/core typecheck
- pnpm --filter @composio/core test -- test/tools/tools.test.ts test/models/toolRouter.test.ts test/connectedAccounts/connectedAccounts.test.ts test/connectedAccounts/connectionRequest.test.ts
- uv run --frozen ruff check python/composio/core/models/tools.py python/tests/test_tool_execution.py
- uv run --frozen pytest python/tests/test_tool_execution.py::TestToolExecution::test_get_raw_tool_router_meta_tools_fetches_all_pages python/tests/test_tool_router.py

Note: pnpm install --frozen-lockfile hits the repo preinstall Bun guard locally because this machine has Bun 1.2.10 and the branch expects 1.3.10; dependency sync was completed with --ignore-scripts for local verification.