### PR TITLE
Support SDK-local custom tool preload for v3.1

### DIFF
--- a/python/composio/core/models/custom_tool.py
+++ b/python/composio/core/models/custom_tool.py
@@ -54,8 +54,10 @@ from .custom_tool_types import (
     SLUG_REGEX,
     CustomTool,
     CustomToolExecuteFn,
+    CustomToolkitWireDefinition,
     CustomToolsMap,
     CustomToolsMapEntry,
+    CustomToolWireDefinition,
 )
 
 if t.TYPE_CHECKING:
@@ -572,27 +574,25 @@ def _serialized_preload_value(
     inherited_preload: t.Optional[bool],
     default_preload: bool,
 ) -> t.Optional[bool]:
-    resolved = (
-        preload
-        if preload is not None
-        else inherited_preload
-        if inherited_preload is not None
-        else default_preload
+    inherited_or_default = (
+        inherited_preload if inherited_preload is not None else default_preload
     )
-    if preload is not None or inherited_preload is not None or default_preload:
-        return resolved
-    return None
+    if preload is not None:
+        return preload if preload or inherited_or_default else None
+    if inherited_preload is not None:
+        return inherited_preload if inherited_preload or default_preload else None
+    return True if default_preload else None
 
 
 def serialize_custom_tools(
     tools: t.List[CustomTool],
     *,
     default_preload: bool = False,
-) -> t.List[t.Dict[str, t.Any]]:
+) -> t.List[CustomToolWireDefinition]:
     """Serialize custom tools into the format expected by the backend."""
-    result = []
+    result: t.List[CustomToolWireDefinition] = []
     for tool in tools:
-        entry: t.Dict[str, t.Any] = {
+        entry: CustomToolWireDefinition = {
             "slug": tool.slug,
             "name": tool.name,
             "description": tool.description,
@@ -615,13 +615,13 @@ def serialize_custom_toolkits(
     toolkits: t.Sequence[ExperimentalToolkit],
     *,
     default_preload: bool = False,
-) -> t.List[t.Dict[str, t.Any]]:
+) -> t.List[CustomToolkitWireDefinition]:
     """Serialize custom toolkits into the format expected by the backend."""
-    result = []
+    result: t.List[CustomToolkitWireDefinition] = []
     for tk in toolkits:
-        toolkit_tools = []
+        toolkit_tools: t.List[CustomToolWireDefinition] = []
         for tool in tk.tools:
-            entry: t.Dict[str, t.Any] = {
+            entry: CustomToolWireDefinition = {
                 "slug": tool.slug,
                 "name": tool.name,
                 "description": tool.description,
@@ -637,7 +637,7 @@ def serialize_custom_toolkits(
             if preload is not None:
                 entry["preload"] = preload
             toolkit_tools.append(entry)
-        toolkit_entry: t.Dict[str, t.Any] = {
+        toolkit_entry: CustomToolkitWireDefinition = {
             "slug": tk.slug,
             "name": tk.name,
             "description": tk.description,
@@ -669,6 +669,7 @@ def build_custom_tools_map(
         handle: CustomTool, final_slug: str, toolkit: t.Optional[str]
     ) -> None:
         original_slug = handle.slug.upper()
+        # Custom tool slugs are matched case-insensitively across local and response maps.
         final_slug_key = final_slug.upper()
 
         if len(final_slug) > MAX_SLUG_LENGTH:
@@ -795,6 +796,12 @@ def assert_no_custom_tool_slugs_in_preload(
     """Reject legacy top-level preload of custom tool slugs."""
     if preload_tools is None or preload_tools == "all":
         return
+    if isinstance(preload_tools, str):
+        raise ValidationError(
+            'preload.tools must be a list of Composio tool slugs or "all". '
+            "Set preload=True on the SDK custom tool or custom toolkit "
+            "definition to expose custom tools directly."
+        )
 
     custom_preload_slugs = []
     for slug in preload_tools:

--- a/python/composio/core/models/custom_tool.py
+++ b/python/composio/core/models/custom_tool.py
@@ -156,6 +156,7 @@ def _create_tool(
     execute: CustomToolExecuteFn,
     extends_toolkit: t.Optional[str] = None,
     output_params: t.Optional[t.Type[BaseModel]] = None,
+    preload: t.Optional[bool] = None,
 ) -> CustomTool:
     """Internal: create and validate a CustomTool."""
     context = "experimental.tool"
@@ -218,6 +219,7 @@ def _create_tool(
         output_schema=output_schema,
         input_params=input_params,
         execute=execute,
+        preload=preload,
     )
 
 
@@ -258,6 +260,7 @@ def _infer_tool_from_function(
     description: t.Optional[str] = None,
     extends_toolkit: t.Optional[str] = None,
     output_params: t.Optional[t.Type[BaseModel]] = None,
+    preload: t.Optional[bool] = None,
     annotation_locals: t.Optional[t.Mapping[str, t.Any]] = None,
 ) -> CustomTool:
     """Create a CustomTool by inferring metadata from a decorated function.
@@ -341,6 +344,7 @@ def _infer_tool_from_function(
         execute=execute,
         extends_toolkit=extends_toolkit,
         output_params=output_params,
+        preload=preload,
     )
 
 
@@ -372,7 +376,14 @@ class ExperimentalToolkit:
             return {"results": []}
     """
 
-    def __init__(self, *, slug: str, name: str, description: str) -> None:
+    def __init__(
+        self,
+        *,
+        slug: str,
+        name: str,
+        description: str,
+        preload: t.Optional[bool] = None,
+    ) -> None:
         context = "experimental.Toolkit"
         _validate_slug(slug, context)
         if not name:
@@ -383,6 +394,7 @@ class ExperimentalToolkit:
         self.slug = slug
         self.name = name
         self.description = description
+        self.preload = preload
         self._tools: t.List[CustomTool] = []
 
     @property
@@ -400,6 +412,7 @@ class ExperimentalToolkit:
         name: t.Optional[str] = None,
         description: t.Optional[str] = None,
         output_params: t.Optional[t.Type[BaseModel]] = None,
+        preload: t.Optional[bool] = None,
     ) -> t.Callable[[t.Callable[..., t.Any]], CustomTool]: ...
 
     def tool(
@@ -410,6 +423,7 @@ class ExperimentalToolkit:
         name: t.Optional[str] = None,
         description: t.Optional[str] = None,
         output_params: t.Optional[t.Type[BaseModel]] = None,
+        preload: t.Optional[bool] = None,
     ) -> t.Union[CustomTool, t.Callable[[t.Callable[..., t.Any]], CustomTool]]:
         """Decorator to add a tool to this toolkit.
 
@@ -425,6 +439,7 @@ class ExperimentalToolkit:
                 name=name,
                 description=description,
                 output_params=output_params,
+                preload=preload,
                 annotation_locals=annotation_locals,
                 # No extends_toolkit for toolkit tools
             )
@@ -441,6 +456,7 @@ class ExperimentalToolkit:
                 name=name,
                 description=description,
                 output_params=output_params,
+                preload=preload,
                 annotation_locals=_get_caller_locals(),
             )
             _validate_slug_length(
@@ -479,6 +495,7 @@ class ExperimentalAPI:
         description: t.Optional[str] = None,
         extends_toolkit: t.Optional[str] = None,
         output_params: t.Optional[t.Type[BaseModel]] = None,
+        preload: t.Optional[bool] = None,
     ) -> t.Callable[[t.Callable[..., t.Any]], CustomTool]: ...
 
     def tool(
@@ -490,6 +507,7 @@ class ExperimentalAPI:
         description: t.Optional[str] = None,
         extends_toolkit: t.Optional[str] = None,
         output_params: t.Optional[t.Type[BaseModel]] = None,
+        preload: t.Optional[bool] = None,
     ) -> t.Union[CustomTool, t.Callable[[t.Callable[..., t.Any]], CustomTool]]:
         """Decorator to create a custom tool from a function.
 
@@ -526,6 +544,7 @@ class ExperimentalAPI:
                 description=description,
                 extends_toolkit=extends_toolkit,
                 output_params=output_params,
+                preload=preload,
                 annotation_locals=annotation_locals,
             )
 
@@ -537,6 +556,7 @@ class ExperimentalAPI:
                 description=description,
                 extends_toolkit=extends_toolkit,
                 output_params=output_params,
+                preload=preload,
                 annotation_locals=_get_caller_locals(),
             )
         return decorator
@@ -547,7 +567,28 @@ class ExperimentalAPI:
 # ────────────────────────────────────────────────────────────────
 
 
-def serialize_custom_tools(tools: t.List[CustomTool]) -> t.List[t.Dict[str, t.Any]]:
+def _serialized_preload_value(
+    preload: t.Optional[bool],
+    inherited_preload: t.Optional[bool],
+    default_preload: bool,
+) -> t.Optional[bool]:
+    resolved = (
+        preload
+        if preload is not None
+        else inherited_preload
+        if inherited_preload is not None
+        else default_preload
+    )
+    if preload is not None or inherited_preload is not None or default_preload:
+        return resolved
+    return None
+
+
+def serialize_custom_tools(
+    tools: t.List[CustomTool],
+    *,
+    default_preload: bool = False,
+) -> t.List[t.Dict[str, t.Any]]:
     """Serialize custom tools into the format expected by the backend."""
     result = []
     for tool in tools:
@@ -561,12 +602,19 @@ def serialize_custom_tools(tools: t.List[CustomTool]) -> t.List[t.Dict[str, t.An
             entry["output_schema"] = tool.output_schema
         if tool.extends_toolkit:
             entry["extends_toolkit"] = tool.extends_toolkit
+        preload = _serialized_preload_value(
+            tool.preload, inherited_preload=None, default_preload=default_preload
+        )
+        if preload is not None:
+            entry["preload"] = preload
         result.append(entry)
     return result
 
 
 def serialize_custom_toolkits(
     toolkits: t.Sequence[ExperimentalToolkit],
+    *,
+    default_preload: bool = False,
 ) -> t.List[t.Dict[str, t.Any]]:
     """Serialize custom toolkits into the format expected by the backend."""
     result = []
@@ -581,15 +629,26 @@ def serialize_custom_toolkits(
             }
             if tool.output_schema:
                 entry["output_schema"] = tool.output_schema
+            preload = _serialized_preload_value(
+                tool.preload,
+                inherited_preload=tk.preload,
+                default_preload=default_preload,
+            )
+            if preload is not None:
+                entry["preload"] = preload
             toolkit_tools.append(entry)
-        result.append(
-            {
-                "slug": tk.slug,
-                "name": tk.name,
-                "description": tk.description,
-                "tools": toolkit_tools,
-            }
+        toolkit_entry: t.Dict[str, t.Any] = {
+            "slug": tk.slug,
+            "name": tk.name,
+            "description": tk.description,
+            "tools": toolkit_tools,
+        }
+        preload = _serialized_preload_value(
+            tk.preload, inherited_preload=None, default_preload=default_preload
         )
+        if preload is not None:
+            toolkit_entry["preload"] = preload
+        result.append(toolkit_entry)
     return result
 
 
@@ -729,23 +788,63 @@ def find_custom_tool_map_entry_by_final_slug(
     return custom_tools_map.by_final_slug.get(slug.upper())
 
 
-def get_preloaded_custom_tool_slugs(
-    tool_router_tools: t.Optional[t.Iterable[str]],
+def assert_no_custom_tool_slugs_in_preload(
+    preload_tools: t.Union[t.Sequence[str], t.Literal["all"], None],
     custom_tools_map: t.Optional[CustomToolsMap],
+) -> None:
+    """Reject legacy top-level preload of custom tool slugs."""
+    if preload_tools is None or preload_tools == "all":
+        return
+
+    custom_preload_slugs = []
+    for slug in preload_tools:
+        normalized = slug.upper()
+        if normalized.startswith(LOCAL_TOOL_PREFIX) or (
+            custom_tools_map is not None
+            and (
+                normalized in custom_tools_map.by_original_slug
+                or normalized in custom_tools_map.by_final_slug
+            )
+        ):
+            custom_preload_slugs.append(slug)
+
+    if custom_preload_slugs:
+        raise ValidationError(
+            "Custom tool slugs are not supported in preload.tools: "
+            f"{', '.join(custom_preload_slugs)}. Set preload=True on the SDK "
+            "custom tool or custom toolkit definition instead."
+        )
+
+
+def get_preloaded_custom_tool_slugs(
+    custom_tools_map: t.Optional[CustomToolsMap],
+    *,
+    default_preload: bool = False,
 ) -> t.List[str]:
-    """Return final custom tool slugs selected by the backend for preload."""
-    if tool_router_tools is None or custom_tools_map is None:
+    """Return final custom tool slugs selected locally for preload."""
+    if custom_tools_map is None:
         return []
 
     seen: t.Set[str] = set()
     custom_tool_slugs: t.List[str] = []
 
-    for slug in tool_router_tools:
-        entry = find_custom_tool_map_entry_by_final_slug(
-            custom_tools_map,
-            str(slug),
+    for entry in custom_tools_map.by_final_slug.values():
+        toolkit = next(
+            (
+                tk
+                for tk in custom_tools_map.toolkits or []
+                if entry.toolkit and tk.slug.lower() == entry.toolkit.lower()
+            ),
+            None,
         )
-        if entry is None:
+        should_preload = (
+            entry.handle.preload
+            if entry.handle.preload is not None
+            else toolkit.preload
+            if toolkit is not None and toolkit.preload is not None
+            else default_preload
+        )
+        if not should_preload:
             continue
 
         final_slug_key = entry.final_slug.upper()

--- a/python/composio/core/models/custom_tool.py
+++ b/python/composio/core/models/custom_tool.py
@@ -610,6 +610,7 @@ def build_custom_tools_map(
         handle: CustomTool, final_slug: str, toolkit: t.Optional[str]
     ) -> None:
         original_slug = handle.slug.upper()
+        final_slug_key = final_slug.upper()
 
         if len(final_slug) > MAX_SLUG_LENGTH:
             raise ValidationError(
@@ -617,7 +618,7 @@ def build_custom_tools_map(
                 f'"{final_slug}" which exceeds {MAX_SLUG_LENGTH} characters.'
             )
 
-        if final_slug in by_final_slug:
+        if final_slug_key in by_final_slug:
             raise ValidationError(
                 f'Custom tool slug collision: "{final_slug}" is already registered.'
             )
@@ -634,7 +635,7 @@ def build_custom_tools_map(
         entry = CustomToolsMapEntry(
             handle=handle, final_slug=final_slug, toolkit=toolkit
         )
-        by_final_slug[final_slug] = entry
+        by_final_slug[final_slug_key] = entry
         by_original_slug[original_slug] = entry
 
     # Process standalone tools
@@ -716,3 +717,42 @@ def build_custom_tools_map_from_response(
         by_original_slug=by_original_slug,
         toolkits=list(toolkits) if toolkits else None,
     )
+
+
+def find_custom_tool_map_entry_by_final_slug(
+    custom_tools_map: t.Optional[CustomToolsMap],
+    slug: str,
+) -> t.Optional[CustomToolsMapEntry]:
+    """Find a custom tool entry by final slug only."""
+    if custom_tools_map is None:
+        return None
+    return custom_tools_map.by_final_slug.get(slug.upper())
+
+
+def get_preloaded_custom_tool_slugs(
+    tool_router_tools: t.Optional[t.Iterable[str]],
+    custom_tools_map: t.Optional[CustomToolsMap],
+) -> t.List[str]:
+    """Return final custom tool slugs selected by the backend for preload."""
+    if tool_router_tools is None or custom_tools_map is None:
+        return []
+
+    seen: t.Set[str] = set()
+    custom_tool_slugs: t.List[str] = []
+
+    for slug in tool_router_tools:
+        entry = find_custom_tool_map_entry_by_final_slug(
+            custom_tools_map,
+            str(slug),
+        )
+        if entry is None:
+            continue
+
+        final_slug_key = entry.final_slug.upper()
+        if final_slug_key in seen:
+            continue
+
+        seen.add(final_slug_key)
+        custom_tool_slugs.append(entry.final_slug)
+
+    return custom_tool_slugs

--- a/python/composio/core/models/custom_tool_types.py
+++ b/python/composio/core/models/custom_tool_types.py
@@ -106,6 +106,7 @@ class CustomTool:
     execute: CustomToolExecuteFn
     extends_toolkit: t.Optional[str] = None
     output_schema: t.Optional[t.Dict[str, t.Any]] = None
+    preload: t.Optional[bool] = None
 
 
 # ────────────────────────────────────────────────────────────────

--- a/python/composio/core/models/custom_tool_types.py
+++ b/python/composio/core/models/custom_tool_types.py
@@ -109,6 +109,29 @@ class CustomTool:
     preload: t.Optional[bool] = None
 
 
+class CustomToolWireDefinition(te.TypedDict, total=False):
+    slug: te.Required[str]
+    name: te.Required[str]
+    description: te.Required[str]
+    input_schema: te.Required[t.Dict[str, t.Any]]
+    extends_toolkit: str
+    output_schema: t.Dict[str, t.Any]
+    preload: bool
+
+
+class CustomToolkitWireDefinition(te.TypedDict, total=False):
+    slug: te.Required[str]
+    name: te.Required[str]
+    description: te.Required[str]
+    tools: te.Required[t.List[CustomToolWireDefinition]]
+    preload: bool
+
+
+class InlineCustomToolsWirePayload(te.TypedDict, total=False):
+    custom_tools: t.List[CustomToolWireDefinition]
+    custom_toolkits: t.List[CustomToolkitWireDefinition]
+
+
 # ────────────────────────────────────────────────────────────────
 # Internal routing map types
 # ────────────────────────────────────────────────────────────────

--- a/python/composio/core/models/inline_custom_tools_payload.py
+++ b/python/composio/core/models/inline_custom_tools_payload.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import typing as t
+
+from composio_client import Omit, omit
+from composio_client.types.tool_router import (
+    session_execute_params,
+    session_search_params,
+)
+
+from composio.core.models.custom_tool_types import InlineCustomToolsWirePayload
+
+
+def inline_custom_tools_execute_experimental(
+    payload: t.Optional[InlineCustomToolsWirePayload],
+) -> t.Union[session_execute_params.Experimental, Omit]:
+    if payload is None:
+        return omit
+    # The SDK wire payload is a structural subset of Stainless' endpoint-specific
+    # experimental payloads, with input-only preload hints on custom definitions.
+    return t.cast(session_execute_params.Experimental, payload)
+
+
+def inline_custom_tools_search_experimental(
+    payload: t.Optional[InlineCustomToolsWirePayload],
+) -> t.Union[session_search_params.Experimental, Omit]:
+    if payload is None:
+        return omit
+    # The SDK wire payload is a structural subset of Stainless' endpoint-specific
+    # experimental payloads, with input-only preload hints on custom definitions.
+    return t.cast(session_search_params.Experimental, payload)

--- a/python/composio/core/models/session_context.py
+++ b/python/composio/core/models/session_context.py
@@ -16,8 +16,6 @@ from composio_client.types.tool_router.session_execute_response import (
 from composio_client.types.tool_router.session_proxy_execute_response import (
     SessionProxyExecuteResponse,
 )
-from composio_client.types.tool_router import session_execute_params
-
 from composio.client import HttpClient
 from composio.core.models.custom_tool_execution import (
     execute_custom_tool,
@@ -26,6 +24,9 @@ from composio.core.models.custom_tool_execution import (
 from composio.core.models.custom_tool_types import (
     CustomToolsMap,
     InlineCustomToolsWirePayload,
+)
+from composio.core.models.inline_custom_tools_payload import (
+    inline_custom_tools_execute_experimental,
 )
 from composio.core.models.tools import _serialize_arguments
 from composio.exceptions import ValidationError
@@ -141,22 +142,13 @@ class SessionContextImpl:
         # Serialize any Pydantic model instances before sending to remote API
         serialized = _serialize_arguments(arguments)
 
-        # Fall back to remote execution
-        if self._inline_custom_tools_payload is not None:
-            return self._client.tool_router.session.execute(
-                session_id=self._session_id,
-                tool_slug=tool_slug,
-                arguments=serialized,
-                experimental=t.cast(
-                    session_execute_params.Experimental,
-                    self._inline_custom_tools_payload,
-                ),
-            )
-
         return self._client.tool_router.session.execute(
             session_id=self._session_id,
             tool_slug=tool_slug,
             arguments=serialized,
+            experimental=inline_custom_tools_execute_experimental(
+                self._inline_custom_tools_payload
+            ),
         )
 
     def proxy_execute(

--- a/python/composio/core/models/session_context.py
+++ b/python/composio/core/models/session_context.py
@@ -16,13 +16,17 @@ from composio_client.types.tool_router.session_execute_response import (
 from composio_client.types.tool_router.session_proxy_execute_response import (
     SessionProxyExecuteResponse,
 )
+from composio_client.types.tool_router import session_execute_params
 
 from composio.client import HttpClient
 from composio.core.models.custom_tool_execution import (
     execute_custom_tool,
     find_custom_tool,
 )
-from composio.core.models.custom_tool_types import CustomToolsMap
+from composio.core.models.custom_tool_types import (
+    CustomToolsMap,
+    InlineCustomToolsWirePayload,
+)
 from composio.core.models.tools import _serialize_arguments
 from composio.exceptions import ValidationError
 
@@ -99,11 +103,13 @@ class SessionContextImpl:
         user_id: str,
         session_id: str,
         custom_tools_map: t.Optional[CustomToolsMap] = None,
+        inline_custom_tools_payload: t.Optional[InlineCustomToolsWirePayload] = None,
     ) -> None:
         self._client = client
         self._user_id = user_id
         self._session_id = session_id
         self._custom_tools_map = custom_tools_map
+        self._inline_custom_tools_payload = inline_custom_tools_payload
 
     @property
     def user_id(self) -> str:
@@ -136,11 +142,18 @@ class SessionContextImpl:
         serialized = _serialize_arguments(arguments)
 
         # Fall back to remote execution
-        return self._client.tool_router.session.execute(
-            session_id=self._session_id,
-            tool_slug=tool_slug,
-            arguments=serialized,
-        )
+        execute_kwargs: t.Dict[str, t.Any] = {
+            "session_id": self._session_id,
+            "tool_slug": tool_slug,
+            "arguments": serialized,
+        }
+        if self._inline_custom_tools_payload is not None:
+            execute_kwargs["experimental"] = t.cast(
+                session_execute_params.Experimental,
+                self._inline_custom_tools_payload,
+            )
+
+        return self._client.tool_router.session.execute(**execute_kwargs)
 
     def proxy_execute(
         self,

--- a/python/composio/core/models/session_context.py
+++ b/python/composio/core/models/session_context.py
@@ -142,18 +142,22 @@ class SessionContextImpl:
         serialized = _serialize_arguments(arguments)
 
         # Fall back to remote execution
-        execute_kwargs: t.Dict[str, t.Any] = {
-            "session_id": self._session_id,
-            "tool_slug": tool_slug,
-            "arguments": serialized,
-        }
         if self._inline_custom_tools_payload is not None:
-            execute_kwargs["experimental"] = t.cast(
-                session_execute_params.Experimental,
-                self._inline_custom_tools_payload,
+            return self._client.tool_router.session.execute(
+                session_id=self._session_id,
+                tool_slug=tool_slug,
+                arguments=serialized,
+                experimental=t.cast(
+                    session_execute_params.Experimental,
+                    self._inline_custom_tools_payload,
+                ),
             )
 
-        return self._client.tool_router.session.execute(**execute_kwargs)
+        return self._client.tool_router.session.execute(
+            session_id=self._session_id,
+            tool_slug=tool_slug,
+            arguments=serialized,
+        )
 
     def proxy_execute(
         self,

--- a/python/composio/core/models/tool_router.py
+++ b/python/composio/core/models/tool_router.py
@@ -226,24 +226,19 @@ class ToolRouterPreloadConfig(te.TypedDict, total=False):
 
 
 class _SessionPreloadLike(te.Protocol):
-    tools: t.Union[t.List[str], t.Literal["all"], None]
-
-
-class _SessionConfigLike(te.Protocol):
-    preload: _SessionPreloadLike
-
-
-class _SessionWithPreloadConfig(te.Protocol):
-    config: _SessionConfigLike
+    @property
+    def tools(self) -> t.Union[t.List[str], str, None]: ...
 
 
 def _session_preload_config(
-    session: _SessionWithPreloadConfig,
+    preload: _SessionPreloadLike,
 ) -> ToolRouterSessionPreloadConfig:
-    tools = session.config.preload.tools
-    return ToolRouterSessionPreloadConfig(
-        tools=tools if isinstance(tools, str) else list(tools or [])
-    )
+    tools = preload.tools
+    if tools == "all":
+        return ToolRouterSessionPreloadConfig(tools="all")
+    if isinstance(tools, list):
+        return ToolRouterSessionPreloadConfig(tools=t.cast(t.List[str], tools))
+    return ToolRouterSessionPreloadConfig(tools=[])
 
 
 def _apply_session_preset_defaults(
@@ -925,9 +920,9 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
                         "custom_tools"
                     ]
                 if "custom_toolkits" in experimental_payload:
-                    inline_custom_tools_payload["custom_toolkits"] = experimental_payload[
-                        "custom_toolkits"
-                    ]
+                    inline_custom_tools_payload["custom_toolkits"] = (
+                        experimental_payload["custom_toolkits"]
+                    )
 
             if experimental_payload:
                 create_params["experimental"] = experimental_payload
@@ -981,7 +976,7 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
             experimental=experimental_response,
             custom_tools_map=custom_tools_map,
             user_id=user_id,
-            preload=_session_preload_config(session),
+            preload=_session_preload_config(session.config.preload),
             preloaded_custom_tool_slugs=preloaded_custom_tool_slugs,
             inline_custom_tools_payload=inline_custom_tools_payload,
         )
@@ -1038,7 +1033,7 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
                 url=session.mcp.url,
             ),
             experimental=experimental_response,
-            preload=_session_preload_config(session),
+            preload=_session_preload_config(session.config.preload),
         )
 
 

--- a/python/composio/core/models/tool_router.py
+++ b/python/composio/core/models/tool_router.py
@@ -29,6 +29,7 @@ from composio.core.models.custom_tool import (
 from composio.core.models.custom_tool_types import (
     CustomTool,
     CustomToolsMap,
+    InlineCustomToolsWirePayload,
 )
 from composio.core.models.tool_router_session import (
     ToolRouterSession,
@@ -221,10 +222,24 @@ class ToolRouterPreloadConfig(te.TypedDict, total=False):
                tool lists without first calling search.
     """
 
-    tools: t.Union[t.List[str], str]
+    tools: t.Union[t.List[str], t.Literal["all"]]
 
 
-def _session_preload_config(session: t.Any) -> ToolRouterSessionPreloadConfig:
+class _SessionPreloadLike(te.Protocol):
+    tools: t.Union[t.List[str], t.Literal["all"], None]
+
+
+class _SessionConfigLike(te.Protocol):
+    preload: _SessionPreloadLike
+
+
+class _SessionWithPreloadConfig(te.Protocol):
+    config: _SessionConfigLike
+
+
+def _session_preload_config(
+    session: _SessionWithPreloadConfig,
+) -> ToolRouterSessionPreloadConfig:
     tools = session.config.preload.tools
     return ToolRouterSessionPreloadConfig(
         tools=tools if isinstance(tools, str) else list(tools or [])
@@ -723,6 +738,10 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
             preload=preload,
         )
         default_custom_preload = preload is not None and preload.get("tools") == "all"
+        assert_no_custom_tool_slugs_in_preload(
+            preload.get("tools") if preload is not None else None,
+            None,
+        )
 
         # Parse manage_connections config
         manage_connections = (
@@ -859,7 +878,7 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
         custom_tools: t.Optional[t.List[CustomTool]] = None
         custom_toolkits: t.Optional[t.List[ExperimentalToolkit]] = None
         local_custom_tools_map: t.Optional[CustomToolsMap] = None
-        inline_custom_tools_payload: t.Optional[t.Dict[str, t.Any]] = None
+        inline_custom_tools_payload: t.Optional[InlineCustomToolsWirePayload] = None
 
         if experimental is not None:
             experimental_payload: t.Dict[str, t.Any] = {}
@@ -900,10 +919,15 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
                 "custom_tools" in experimental_payload
                 or "custom_toolkits" in experimental_payload
             ):
-                inline_custom_tools_payload = {
-                    "custom_tools": experimental_payload.get("custom_tools"),
-                    "custom_toolkits": experimental_payload.get("custom_toolkits"),
-                }
+                inline_custom_tools_payload = {}
+                if "custom_tools" in experimental_payload:
+                    inline_custom_tools_payload["custom_tools"] = experimental_payload[
+                        "custom_tools"
+                    ]
+                if "custom_toolkits" in experimental_payload:
+                    inline_custom_tools_payload["custom_toolkits"] = experimental_payload[
+                        "custom_toolkits"
+                    ]
 
             if experimental_payload:
                 create_params["experimental"] = experimental_payload

--- a/python/composio/core/models/tool_router.py
+++ b/python/composio/core/models/tool_router.py
@@ -19,6 +19,8 @@ from composio.client import HttpClient
 from composio.core.models.base import Resource
 from composio.core.models.custom_tool import (
     ExperimentalToolkit,
+    assert_no_custom_tool_slugs_in_preload,
+    build_custom_tools_map,
     build_custom_tools_map_from_response,
     get_preloaded_custom_tool_slugs,
     serialize_custom_tools,
@@ -627,6 +629,10 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
                             - 'assistive_prompt' (dict): Configuration for assistive prompt generation.
                               - 'user_timezone' (str): IANA timezone identifier
                                 (e.g., "America/New_York", "Europe/London").
+                            - 'custom_tools' / 'custom_toolkits': SDK custom tools.
+                              Set preload=True on a custom tool or toolkit to expose
+                              it directly from session.tools(); otherwise custom tools
+                              remain search-only.
                             Example: {'assistive_prompt': {'user_timezone': 'America/New_York'}}
         :return: Tool router session object
 
@@ -716,6 +722,7 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
             workbench=workbench,
             preload=preload,
         )
+        default_custom_preload = preload is not None and preload.get("tools") == "all"
 
         # Parse manage_connections config
         manage_connections = (
@@ -851,6 +858,8 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
         # experimental.assistive_prompt_config.user_timezone
         custom_tools: t.Optional[t.List[CustomTool]] = None
         custom_toolkits: t.Optional[t.List[ExperimentalToolkit]] = None
+        local_custom_tools_map: t.Optional[CustomToolsMap] = None
+        inline_custom_tools_payload: t.Optional[t.Dict[str, t.Any]] = None
 
         if experimental is not None:
             experimental_payload: t.Dict[str, t.Any] = {}
@@ -866,15 +875,35 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
             # Serialize custom tools and toolkits for the backend
             custom_tools = experimental.get("custom_tools")
             custom_toolkits = experimental.get("custom_toolkits")
+            if custom_tools or custom_toolkits:
+                local_custom_tools_map = build_custom_tools_map(
+                    custom_tools or [],
+                    custom_toolkits,
+                )
+                assert_no_custom_tool_slugs_in_preload(
+                    preload.get("tools") if preload is not None else None,
+                    local_custom_tools_map,
+                )
 
             if custom_tools:
                 experimental_payload["custom_tools"] = serialize_custom_tools(
-                    custom_tools
+                    custom_tools,
+                    default_preload=default_custom_preload,
                 )
             if custom_toolkits:
                 experimental_payload["custom_toolkits"] = serialize_custom_toolkits(
-                    custom_toolkits
+                    custom_toolkits,
+                    default_preload=default_custom_preload,
                 )
+
+            if (
+                "custom_tools" in experimental_payload
+                or "custom_toolkits" in experimental_payload
+            ):
+                inline_custom_tools_payload = {
+                    "custom_tools": experimental_payload.get("custom_tools"),
+                    "custom_toolkits": experimental_payload.get("custom_toolkits"),
+                }
 
             if experimental_payload:
                 create_params["experimental"] = experimental_payload
@@ -897,8 +926,8 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
                 experimental=session.experimental,
             )
         preloaded_custom_tool_slugs = get_preloaded_custom_tool_slugs(
-            getattr(session, "tool_router_tools", None),
             custom_tools_map,
+            default_preload=default_custom_preload,
         )
 
         # Transform experimental response:
@@ -930,6 +959,7 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
             user_id=user_id,
             preload=_session_preload_config(session),
             preloaded_custom_tool_slugs=preloaded_custom_tool_slugs,
+            inline_custom_tools_payload=inline_custom_tools_payload,
         )
 
     def use(self, session_id: str) -> ToolRouterSession[TTool, TToolCollection]:

--- a/python/composio/core/models/tool_router.py
+++ b/python/composio/core/models/tool_router.py
@@ -20,6 +20,7 @@ from composio.core.models.base import Resource
 from composio.core.models.custom_tool import (
     ExperimentalToolkit,
     build_custom_tools_map_from_response,
+    get_preloaded_custom_tool_slugs,
     serialize_custom_tools,
     serialize_custom_toolkits,
 )
@@ -51,6 +52,7 @@ ToolRouterTag = t.Literal[
 # +----------+------+------+
 # Defaults to "standard" server-side when omitted.
 SandboxSize = t.Literal["standard", "medium", "large", "xlarge"]
+SessionPreset = t.Literal["direct_tools"]
 
 
 class ToolRouterToolkitsEnableConfig(te.TypedDict, total=False):
@@ -217,7 +219,34 @@ class ToolRouterPreloadConfig(te.TypedDict, total=False):
                tool lists without first calling search.
     """
 
-    tools: t.List[str]
+    tools: t.Union[t.List[str], str]
+
+
+def _session_preload_config(session: t.Any) -> ToolRouterSessionPreloadConfig:
+    tools = session.config.preload.tools
+    return ToolRouterSessionPreloadConfig(
+        tools=tools if isinstance(tools, str) else list(tools or [])
+    )
+
+
+def _apply_session_preset_defaults(
+    session_preset: t.Optional[SessionPreset],
+    manage_connections: t.Optional[t.Union[bool, ToolRouterManageConnectionsConfig]],
+    workbench: t.Optional[ToolRouterWorkbenchConfig],
+    preload: t.Optional[ToolRouterPreloadConfig],
+) -> t.Tuple[
+    t.Optional[t.Union[bool, ToolRouterManageConnectionsConfig]],
+    t.Optional[ToolRouterWorkbenchConfig],
+    t.Optional[ToolRouterPreloadConfig],
+]:
+    if session_preset != "direct_tools":
+        return manage_connections, workbench, preload
+
+    return (
+        False if manage_connections is None else manage_connections,
+        {"enable": False} if workbench is None else workbench,
+        {"tools": "all"} if preload is None else preload,
+    )
 
 
 class ToolRouterAssistivePromptConfig(te.TypedDict, total=False):
@@ -497,6 +526,7 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
         workbench: t.Optional[ToolRouterWorkbenchConfig] = None,
         multi_account: t.Optional[ToolRouterMultiAccountConfig] = None,
         preload: t.Optional[ToolRouterPreloadConfig] = None,
+        session_preset: t.Optional[SessionPreset] = None,
         experimental: t.Optional[ToolRouterExperimentalConfig] = None,
     ) -> ToolRouterSession[TTool, TToolCollection]:
         """
@@ -553,8 +583,7 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
                            Example: {'github': 'ac_xxx', 'slack': 'ac_yyy'}
         :param connected_accounts: Optional mapping of toolkit slug to connected account ID.
                                   Example: {'github': 'ca_xxx', 'slack': 'ca_yyy'}
-        :param workbench: Optional workbench configuration (ToolRouterWorkbenchConfig).
-                         Dict with:
+        :param workbench: Optional workbench configuration. Dict with:
                          - 'enable' (bool): Whether to enable the workbench entirely.
                            Defaults to True. When set to False, no code execution tools
                            (COMPOSIO_REMOTE_WORKBENCH, COMPOSIO_REMOTE_BASH_TOOL) are
@@ -579,9 +608,19 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
                               account selection when multiple accounts are connected.
                             Example: {'enable': True, 'max_accounts_per_toolkit': 3}
         :param preload: Optional preload configuration. Dict with:
-                        - 'tools' (List[str]): Tool slugs to expose directly in
-                          session.tools() and MCP tool lists.
+                        - 'tools' (List[str] | 'all'): Tool slugs to expose directly in
+                          session.tools() and MCP tool lists. 'all' exposes every app
+                          tool allowed by positive session filters such as toolkits,
+                          tools, or tags; the backend validates and caps the final set.
                         Example: {'tools': ['GMAIL_FETCH_EMAILS']}
+        :param session_preset: Optional session preset. 'direct_tools' exposes all tools
+                              allowed by the session filters directly in session.tools()
+                              and the MCP tool list, and disables meta tools by default
+                              (search, multi-execute, manage-connections, and workbench).
+                              Use when all needed tools are known upfront and helper/meta
+                              tools are not needed. Without this preset, ToolRouter uses
+                              the default configuration with meta tools enabled. Loading
+                              many tools can increase model context usage.
         :param experimental: Optional experimental configuration (ToolRouterExperimentalConfig).
                             Note: These features are experimental and may change.
                             Dict with:
@@ -669,6 +708,14 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
             toolkit_states = session.toolkits()
             ```
         """
+
+        direct_tools_preset = session_preset == "direct_tools"
+        manage_connections, workbench, preload = _apply_session_preset_defaults(
+            session_preset=session_preset,
+            manage_connections=manage_connections,
+            workbench=workbench,
+            preload=preload,
+        )
 
         # Parse manage_connections config
         manage_connections = (
@@ -795,6 +842,10 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
         if preload is not None:
             create_params["preload"] = preload
 
+        if direct_tools_preset:
+            create_params["search"] = {"enable": False}
+            create_params["execute"] = {"enable_multi_execute": False}
+
         # Build experimental config
         # Map SDK's experimental.assistive_prompt.user_timezone to API's
         # experimental.assistive_prompt_config.user_timezone
@@ -845,6 +896,10 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
                 toolkits=custom_toolkits,
                 experimental=session.experimental,
             )
+        preloaded_custom_tool_slugs = get_preloaded_custom_tool_slugs(
+            getattr(session, "tool_router_tools", None),
+            custom_tools_map,
+        )
 
         # Transform experimental response:
         # API's assistive_prompt -> SDK's assistive_prompt
@@ -873,9 +928,8 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
             experimental=experimental_response,
             custom_tools_map=custom_tools_map,
             user_id=user_id,
-            preload=ToolRouterSessionPreloadConfig(
-                tools=list(session.config.preload.tools)
-            ),
+            preload=_session_preload_config(session),
+            preloaded_custom_tool_slugs=preloaded_custom_tool_slugs,
         )
 
     def use(self, session_id: str) -> ToolRouterSession[TTool, TToolCollection]:
@@ -930,9 +984,7 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
                 url=session.mcp.url,
             ),
             experimental=experimental_response,
-            preload=ToolRouterSessionPreloadConfig(
-                tools=list(session.config.preload.tools)
-            ),
+            preload=_session_preload_config(session),
         )
 
 
@@ -952,6 +1004,7 @@ __all__ = [
     "ToolRouterManageConnectionsConfig",
     "ToolRouterWorkbenchConfig",
     "SandboxSize",
+    "SessionPreset",
     "ToolRouterMultiAccountConfig",
     "ToolRouterPreloadConfig",
     "ToolRouterExperimentalConfig",

--- a/python/composio/core/models/tool_router_session.py
+++ b/python/composio/core/models/tool_router_session.py
@@ -105,6 +105,7 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
         user_id: t.Optional[str] = None,
         preload: t.Optional[ToolRouterSessionPreloadConfig] = None,
         preloaded_custom_tool_slugs: t.Optional[t.List[str]] = None,
+        inline_custom_tools_payload: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> None:
         self._client = client
         self._provider = provider
@@ -119,6 +120,7 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
         self._custom_tools_map = custom_tools_map
         self._user_id = user_id
         self._preloaded_custom_tool_slugs = preloaded_custom_tool_slugs or []
+        self._inline_custom_tools_payload = inline_custom_tools_payload
 
         # Create singleton session context if custom tools are bound
         self._session_context: t.Optional[SessionContextImpl] = None
@@ -634,11 +636,14 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
 
         Returns relevant tools for the given query with schemas and guidance.
         """
-        return self._client.tool_router.session.search(
-            session_id=self.session_id,
-            queries=[{"use_case": query}],
-            model=model if model else omit,
-        )
+        params: t.Dict[str, t.Any] = {
+            "session_id": self.session_id,
+            "queries": [{"use_case": query}],
+            "model": model if model else omit,
+        }
+        if self._inline_custom_tools_payload is not None:
+            params["experimental"] = self._inline_custom_tools_payload
+        return self._client.tool_router.session.search(**params)
 
     def execute(
         self,
@@ -676,12 +681,15 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
             )
 
         # Remote execution
-        return self._client.tool_router.session.execute(
-            session_id=self.session_id,
-            tool_slug=tool_slug,
-            arguments=arguments if arguments is not None else omit,
-            account=account if account is not None else omit,
-        )
+        params: t.Dict[str, t.Any] = {
+            "session_id": self.session_id,
+            "tool_slug": tool_slug,
+            "arguments": arguments if arguments is not None else omit,
+            "account": account if account is not None else omit,
+        }
+        if self._inline_custom_tools_payload is not None:
+            params["experimental"] = self._inline_custom_tools_payload
+        return self._client.tool_router.session.execute(**params)
 
     def custom_tools(
         self, *, toolkit: t.Optional[str] = None

--- a/python/composio/core/models/tool_router_session.py
+++ b/python/composio/core/models/tool_router_session.py
@@ -28,6 +28,7 @@ from composio_client.types.tool_router.session_proxy_execute_response import (
 from composio_client.types.tool_router.session_search_response import (
     SessionSearchResponse,
 )
+from composio_client.types.tool_router import session_search_params
 
 from composio.client import HttpClient
 from composio.core.models.connected_accounts import ConnectionRequest
@@ -39,6 +40,7 @@ from composio.core.models.custom_tool_execution import (
 from composio.core.models.custom_tool_types import (
     CustomToolsMap,
     CustomToolsMapEntry,
+    InlineCustomToolsWirePayload,
     RegisteredCustomTool,
     RegisteredCustomToolkit,
 )
@@ -65,7 +67,7 @@ MAX_PARALLEL_WORKERS = 5
 class ToolRouterSessionPreloadConfig:
     """Preloaded tools configured for a tool router session."""
 
-    tools: t.Union[t.List[str], str]
+    tools: t.Union[t.List[str], t.Literal["all"]]
 
 
 class ToolRouterSession(t.Generic[TTool, TToolCollection]):
@@ -105,7 +107,7 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
         user_id: t.Optional[str] = None,
         preload: t.Optional[ToolRouterSessionPreloadConfig] = None,
         preloaded_custom_tool_slugs: t.Optional[t.List[str]] = None,
-        inline_custom_tools_payload: t.Optional[t.Dict[str, t.Any]] = None,
+        inline_custom_tools_payload: t.Optional[InlineCustomToolsWirePayload] = None,
     ) -> None:
         self._client = client
         self._provider = provider
@@ -636,14 +638,19 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
 
         Returns relevant tools for the given query with schemas and guidance.
         """
-        params: t.Dict[str, t.Any] = {
-            "session_id": self.session_id,
-            "queries": [{"use_case": query}],
-            "model": model if model else omit,
-        }
-        if self._inline_custom_tools_payload is not None:
-            params["experimental"] = self._inline_custom_tools_payload
-        return self._client.tool_router.session.search(**params)
+        return self._client.tool_router.session.search(
+            session_id=self.session_id,
+            queries=[{"use_case": query}],
+            model=model if model else omit,
+            experimental=(
+                t.cast(
+                    session_search_params.Experimental,
+                    self._inline_custom_tools_payload,
+                )
+                if self._inline_custom_tools_payload is not None
+                else omit
+            ),
+        )
 
     def execute(
         self,
@@ -681,15 +688,12 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
             )
 
         # Remote execution
-        params: t.Dict[str, t.Any] = {
-            "session_id": self.session_id,
-            "tool_slug": tool_slug,
-            "arguments": arguments if arguments is not None else omit,
-            "account": account if account is not None else omit,
-        }
-        if self._inline_custom_tools_payload is not None:
-            params["experimental"] = self._inline_custom_tools_payload
-        return self._client.tool_router.session.execute(**params)
+        return self._client.tool_router.session.execute(
+            session_id=self.session_id,
+            tool_slug=tool_slug,
+            arguments=arguments if arguments is not None else omit,
+            account=account if account is not None else omit,
+        )
 
     def custom_tools(
         self, *, toolkit: t.Optional[str] = None

--- a/python/composio/core/models/tool_router_session.py
+++ b/python/composio/core/models/tool_router_session.py
@@ -356,10 +356,13 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
                 return result
             entry = find_custom_tool(self._custom_tools_map, slug)
             if entry:
-                return execute_custom_tool(
-                    entry,
-                    arguments,
-                    t.cast(SessionContextImpl, self._session_context),
+                return t.cast(
+                    t.Dict[str, t.Any],
+                    execute_custom_tool(
+                        entry,
+                        arguments,
+                        t.cast(SessionContextImpl, self._session_context),
+                    ),
                 )
             # Non-multi-execute meta tools always go to backend
             return backend_execute(slug, arguments)

--- a/python/composio/core/models/tool_router_session.py
+++ b/python/composio/core/models/tool_router_session.py
@@ -28,10 +28,6 @@ from composio_client.types.tool_router.session_proxy_execute_response import (
 from composio_client.types.tool_router.session_search_response import (
     SessionSearchResponse,
 )
-from composio_client.types.tool_router import (
-    session_execute_params,
-    session_search_params,
-)
 
 from composio.client import HttpClient
 from composio.core.models.connected_accounts import ConnectionRequest
@@ -46,6 +42,10 @@ from composio.core.models.custom_tool_types import (
     InlineCustomToolsWirePayload,
     RegisteredCustomTool,
     RegisteredCustomToolkit,
+)
+from composio.core.models.inline_custom_tools_payload import (
+    inline_custom_tools_execute_experimental,
+    inline_custom_tools_search_experimental,
 )
 from composio.core.models._modifiers import Modifiers, apply_modifier_by_type
 from composio.core.models.session_context import SessionContextImpl, proxy_execute_impl
@@ -657,13 +657,8 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
             session_id=self.session_id,
             queries=[{"use_case": query}],
             model=model if model else omit,
-            experimental=(
-                t.cast(
-                    session_search_params.Experimental,
-                    self._inline_custom_tools_payload,
-                )
-                if self._inline_custom_tools_payload is not None
-                else omit
+            experimental=inline_custom_tools_search_experimental(
+                self._inline_custom_tools_payload
             ),
         )
 
@@ -702,24 +697,14 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
                 log_id="",
             )
 
-        # Remote execution
-        if self._inline_custom_tools_payload is not None:
-            return self._client.tool_router.session.execute(
-                session_id=self.session_id,
-                tool_slug=tool_slug,
-                arguments=arguments if arguments is not None else omit,
-                account=account if account is not None else omit,
-                experimental=t.cast(
-                    session_execute_params.Experimental,
-                    self._inline_custom_tools_payload,
-                ),
-            )
-
         return self._client.tool_router.session.execute(
             session_id=self.session_id,
             tool_slug=tool_slug,
             arguments=arguments if arguments is not None else omit,
             account=account if account is not None else omit,
+            experimental=inline_custom_tools_execute_experimental(
+                self._inline_custom_tools_payload
+            ),
         )
 
     def custom_tools(

--- a/python/composio/core/models/tool_router_session.py
+++ b/python/composio/core/models/tool_router_session.py
@@ -28,7 +28,10 @@ from composio_client.types.tool_router.session_proxy_execute_response import (
 from composio_client.types.tool_router.session_search_response import (
     SessionSearchResponse,
 )
-from composio_client.types.tool_router import session_search_params
+from composio_client.types.tool_router import (
+    session_execute_params,
+    session_search_params,
+)
 
 from composio.client import HttpClient
 from composio.core.models.connected_accounts import ConnectionRequest
@@ -132,6 +135,7 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
                 user_id=user_id,
                 session_id=session_id,
                 custom_tools_map=custom_tools_map,
+                inline_custom_tools_payload=inline_custom_tools_payload,
             )
 
     def _has_custom_tools(self) -> bool:
@@ -149,6 +153,7 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
         return tools_model._wrap_execute_tool_for_tool_router(
             session_id=self.session_id,
             modifiers=modifiers,
+            inline_custom_tools_payload=self._inline_custom_tools_payload,
         )
 
     def tools(self, modifiers: t.Optional["Modifiers"] = None) -> TToolCollection:
@@ -698,12 +703,19 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
             )
 
         # Remote execution
-        return self._client.tool_router.session.execute(
-            session_id=self.session_id,
-            tool_slug=tool_slug,
-            arguments=arguments if arguments is not None else omit,
-            account=account if account is not None else omit,
-        )
+        execute_kwargs: t.Dict[str, t.Any] = {
+            "session_id": self.session_id,
+            "tool_slug": tool_slug,
+            "arguments": arguments if arguments is not None else omit,
+            "account": account if account is not None else omit,
+        }
+        if self._inline_custom_tools_payload is not None:
+            execute_kwargs["experimental"] = t.cast(
+                session_execute_params.Experimental,
+                self._inline_custom_tools_payload,
+            )
+
+        return self._client.tool_router.session.execute(**execute_kwargs)
 
     def custom_tools(
         self, *, toolkit: t.Optional[str] = None

--- a/python/composio/core/models/tool_router_session.py
+++ b/python/composio/core/models/tool_router_session.py
@@ -354,6 +354,13 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
                     )
 
                 return result
+            entry = find_custom_tool(self._custom_tools_map, slug)
+            if entry:
+                return execute_custom_tool(
+                    entry,
+                    arguments,
+                    t.cast(SessionContextImpl, self._session_context),
+                )
             # Non-multi-execute meta tools always go to backend
             return backend_execute(slug, arguments)
 

--- a/python/composio/core/models/tool_router_session.py
+++ b/python/composio/core/models/tool_router_session.py
@@ -13,6 +13,12 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 
 from composio_client import omit
+from composio.client.types import Tool
+from composio_client.types.tool_list_response import (
+    ItemDeprecated,
+    ItemDeprecatedToolkit,
+    ItemToolkit,
+)
 from composio_client.types.tool_router.session_execute_response import (
     SessionExecuteResponse,
 )
@@ -25,6 +31,7 @@ from composio_client.types.tool_router.session_search_response import (
 
 from composio.client import HttpClient
 from composio.core.models.connected_accounts import ConnectionRequest
+from composio.core.models.custom_tool import find_custom_tool_map_entry_by_final_slug
 from composio.core.models.custom_tool_execution import (
     execute_custom_tool,
     find_custom_tool,
@@ -48,6 +55,9 @@ if t.TYPE_CHECKING:
     )
 
 COMPOSIO_MULTI_EXECUTE_TOOL = "COMPOSIO_MULTI_EXECUTE_TOOL"
+DIRECT_CUSTOM_TOOL_DESCRIPTION_PREFIX = (
+    "[Direct tool - call directly, no search or connection check needed beforehand.]"
+)
 MAX_PARALLEL_WORKERS = 5
 
 
@@ -55,7 +65,7 @@ MAX_PARALLEL_WORKERS = 5
 class ToolRouterSessionPreloadConfig:
     """Preloaded tools configured for a tool router session."""
 
-    tools: t.List[str]
+    tools: t.Union[t.List[str], str]
 
 
 class ToolRouterSession(t.Generic[TTool, TToolCollection]):
@@ -94,6 +104,7 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
         custom_tools_map: t.Optional[CustomToolsMap] = None,
         user_id: t.Optional[str] = None,
         preload: t.Optional[ToolRouterSessionPreloadConfig] = None,
+        preloaded_custom_tool_slugs: t.Optional[t.List[str]] = None,
     ) -> None:
         self._client = client
         self._provider = provider
@@ -107,6 +118,7 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
         self.preload = preload or ToolRouterSessionPreloadConfig(tools=[])
         self._custom_tools_map = custom_tools_map
         self._user_id = user_id
+        self._preloaded_custom_tool_slugs = preloaded_custom_tool_slugs or []
 
         # Create singleton session context if custom tools are bound
         self._session_context: t.Optional[SessionContextImpl] = None
@@ -168,6 +180,7 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
             session_id=self.session_id,
             modifiers=modifiers,
         )
+        router_tools = self._add_preloaded_custom_tools(router_tools, modifiers)
 
         for tool in router_tools:
             tool.input_parameters = (
@@ -200,6 +213,95 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
                 execute_tool=execute_fn,
             ),
         )
+
+    def _add_preloaded_custom_tools(
+        self,
+        tools: t.List[Tool],
+        modifiers: t.Optional["Modifiers"],
+    ) -> t.List[Tool]:
+        custom_tools = self._get_preloaded_custom_tool_schemas(modifiers)
+        if not custom_tools:
+            return tools
+
+        existing_slugs = {tool.slug.upper() for tool in tools}
+        appended_tools = [
+            tool for tool in custom_tools if tool.slug.upper() not in existing_slugs
+        ]
+        if not appended_tools:
+            return tools
+
+        return [*tools, *appended_tools]
+
+    def _get_preloaded_custom_tool_schemas(
+        self,
+        modifiers: t.Optional["Modifiers"],
+    ) -> t.List[Tool]:
+        if not self._custom_tools_map or not self._preloaded_custom_tool_slugs:
+            return []
+
+        tools: t.List[Tool] = []
+        for slug in self._preloaded_custom_tool_slugs:
+            entry = find_custom_tool_map_entry_by_final_slug(
+                self._custom_tools_map,
+                slug,
+            )
+            if entry is None:
+                continue
+
+            tool = self._custom_tool_entry_to_tool(entry)
+            if modifiers is not None:
+                tool = t.cast(
+                    Tool,
+                    apply_modifier_by_type(
+                        modifiers=modifiers,
+                        toolkit=tool.toolkit.slug,
+                        tool=tool.slug,
+                        type="schema",
+                        schema=tool,
+                    ),
+                )
+            tools.append(tool)
+
+        return tools
+
+    def _custom_tool_entry_to_tool(self, entry: CustomToolsMapEntry) -> Tool:
+        toolkit_slug = entry.toolkit or "custom"
+        toolkit_name = (
+            self._custom_toolkit_name(toolkit_slug) or entry.toolkit or "Custom"
+        )
+
+        return Tool(
+            available_versions=[],
+            deprecated=ItemDeprecated(
+                available_versions=[],
+                displayName=entry.handle.name,
+                is_deprecated=False,
+                toolkit=ItemDeprecatedToolkit(logo=""),
+                version="latest",
+            ),
+            description=(
+                f"{DIRECT_CUSTOM_TOOL_DESCRIPTION_PREFIX}\n{entry.handle.description}"
+            ),
+            input_parameters=entry.handle.input_schema,
+            is_deprecated=False,
+            name=entry.handle.name,
+            no_auth=entry.handle.extends_toolkit is None,
+            output_parameters=entry.handle.output_schema or {},
+            scopes=[],
+            slug=entry.final_slug,
+            tags=[],
+            toolkit=ItemToolkit(logo="", name=toolkit_name, slug=toolkit_slug),
+            version="latest",
+        )
+
+    def _custom_toolkit_name(self, toolkit_slug: str) -> t.Optional[str]:
+        if self._custom_tools_map is None:
+            return None
+
+        for toolkit in self._custom_tools_map.toolkits or []:
+            if toolkit.slug.lower() == toolkit_slug.lower():
+                return toolkit.name
+        return None
 
     def _create_routing_execute_fn(
         self,

--- a/python/composio/core/models/tool_router_session.py
+++ b/python/composio/core/models/tool_router_session.py
@@ -703,19 +703,24 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
             )
 
         # Remote execution
-        execute_kwargs: t.Dict[str, t.Any] = {
-            "session_id": self.session_id,
-            "tool_slug": tool_slug,
-            "arguments": arguments if arguments is not None else omit,
-            "account": account if account is not None else omit,
-        }
         if self._inline_custom_tools_payload is not None:
-            execute_kwargs["experimental"] = t.cast(
-                session_execute_params.Experimental,
-                self._inline_custom_tools_payload,
+            return self._client.tool_router.session.execute(
+                session_id=self.session_id,
+                tool_slug=tool_slug,
+                arguments=arguments if arguments is not None else omit,
+                account=account if account is not None else omit,
+                experimental=t.cast(
+                    session_execute_params.Experimental,
+                    self._inline_custom_tools_payload,
+                ),
             )
 
-        return self._client.tool_router.session.execute(**execute_kwargs)
+        return self._client.tool_router.session.execute(
+            session_id=self.session_id,
+            tool_slug=tool_slug,
+            arguments=arguments if arguments is not None else omit,
+            account=account if account is not None else omit,
+        )
 
     def custom_tools(
         self, *, toolkit: t.Optional[str] = None

--- a/python/composio/core/models/tools.py
+++ b/python/composio/core/models/tools.py
@@ -15,11 +15,13 @@ from composio.client.types import (
     tool_proxy_params,
     tool_proxy_response,
 )
-from composio_client.types.tool_router import session_execute_params
 from composio.core.models._files import FileHelper
 from composio.core.models.base import Resource
 from composio.core.models.custom_tool_types import InlineCustomToolsWirePayload
 from composio.core.models.custom_tools import CustomTools
+from composio.core.models.inline_custom_tools_payload import (
+    inline_custom_tools_execute_experimental,
+)
 from composio.core.provider import TTool, TToolCollection
 from composio.core.provider.agentic import AgenticProvider, AgenticProviderExecuteFn
 from composio.core.provider.base import ExecuteToolFn
@@ -536,28 +538,17 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
             # Serialize any Pydantic model instances before sending to the API
             processed_arguments = _serialize_arguments(processed_arguments)
 
-            if inline_custom_tools_payload is not None:
-                response = self._client.tool_router.session.execute(
-                    session_id=session_id,
-                    tool_slug=slug,
-                    arguments=processed_arguments,
-                    # Provider-wrapped session tools are agentic calls, so they opt into
-                    # direct tool offload when the backend session workbench allows it.
-                    enable_auto_workbench_offload=True,
-                    experimental=t.cast(
-                        session_execute_params.Experimental,
-                        inline_custom_tools_payload,
-                    ),
-                )
-            else:
-                response = self._client.tool_router.session.execute(
-                    session_id=session_id,
-                    tool_slug=slug,
-                    arguments=processed_arguments,
-                    # Provider-wrapped session tools are agentic calls, so they opt into
-                    # direct tool offload when the backend session workbench allows it.
-                    enable_auto_workbench_offload=True,
-                )
+            response = self._client.tool_router.session.execute(
+                session_id=session_id,
+                tool_slug=slug,
+                arguments=processed_arguments,
+                # Provider-wrapped session tools are agentic calls, so they opt into
+                # direct tool offload when the backend session workbench allows it.
+                enable_auto_workbench_offload=True,
+                experimental=inline_custom_tools_execute_experimental(
+                    inline_custom_tools_payload
+                ),
+            )
 
             # Convert response to standard format
             result: ToolExecutionResponse = {

--- a/python/composio/core/models/tools.py
+++ b/python/composio/core/models/tools.py
@@ -536,21 +536,28 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
             # Serialize any Pydantic model instances before sending to the API
             processed_arguments = _serialize_arguments(processed_arguments)
 
-            execute_kwargs: t.Dict[str, t.Any] = {
-                "session_id": session_id,
-                "tool_slug": slug,
-                "arguments": processed_arguments,
-                # Provider-wrapped session tools are agentic calls, so they opt into
-                # direct tool offload when the backend session workbench allows it.
-                "enable_auto_workbench_offload": True,
-            }
             if inline_custom_tools_payload is not None:
-                execute_kwargs["experimental"] = t.cast(
-                    session_execute_params.Experimental,
-                    inline_custom_tools_payload,
+                response = self._client.tool_router.session.execute(
+                    session_id=session_id,
+                    tool_slug=slug,
+                    arguments=processed_arguments,
+                    # Provider-wrapped session tools are agentic calls, so they opt into
+                    # direct tool offload when the backend session workbench allows it.
+                    enable_auto_workbench_offload=True,
+                    experimental=t.cast(
+                        session_execute_params.Experimental,
+                        inline_custom_tools_payload,
+                    ),
                 )
-
-            response = self._client.tool_router.session.execute(**execute_kwargs)
+            else:
+                response = self._client.tool_router.session.execute(
+                    session_id=session_id,
+                    tool_slug=slug,
+                    arguments=processed_arguments,
+                    # Provider-wrapped session tools are agentic calls, so they opt into
+                    # direct tool offload when the backend session workbench allows it.
+                    enable_auto_workbench_offload=True,
+                )
 
             # Convert response to standard format
             result: ToolExecutionResponse = {

--- a/python/composio/core/models/tools.py
+++ b/python/composio/core/models/tools.py
@@ -15,8 +15,10 @@ from composio.client.types import (
     tool_proxy_params,
     tool_proxy_response,
 )
+from composio_client.types.tool_router import session_execute_params
 from composio.core.models._files import FileHelper
 from composio.core.models.base import Resource
+from composio.core.models.custom_tool_types import InlineCustomToolsWirePayload
 from composio.core.models.custom_tools import CustomTools
 from composio.core.provider import TTool, TToolCollection
 from composio.core.provider.agentic import AgenticProvider, AgenticProviderExecuteFn
@@ -456,6 +458,7 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
         self,
         session_id: str,
         modifiers: t.Optional[Modifiers] = None,
+        inline_custom_tools_payload: t.Optional[InlineCustomToolsWirePayload] = None,
     ) -> AgenticProviderExecuteFn:
         """
         Create an execute function for tool router session tools.
@@ -533,14 +536,21 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
             # Serialize any Pydantic model instances before sending to the API
             processed_arguments = _serialize_arguments(processed_arguments)
 
-            response = self._client.tool_router.session.execute(
-                session_id=session_id,
-                tool_slug=slug,
-                arguments=processed_arguments,
+            execute_kwargs: t.Dict[str, t.Any] = {
+                "session_id": session_id,
+                "tool_slug": slug,
+                "arguments": processed_arguments,
                 # Provider-wrapped session tools are agentic calls, so they opt into
                 # direct tool offload when the backend session workbench allows it.
-                enable_auto_workbench_offload=True,
-            )
+                "enable_auto_workbench_offload": True,
+            }
+            if inline_custom_tools_payload is not None:
+                execute_kwargs["experimental"] = t.cast(
+                    session_execute_params.Experimental,
+                    inline_custom_tools_payload,
+                )
+
+            response = self._client.tool_router.session.execute(**execute_kwargs)
 
             # Convert response to standard format
             result: ToolExecutionResponse = {

--- a/python/examples/tool_router/direct_tools_preset.py
+++ b/python/examples/tool_router/direct_tools_preset.py
@@ -32,7 +32,7 @@ composio = Composio(
 require_env("OPENAI_API_KEY")
 
 session = composio.create(
-    user_id=f"direct-tools-example-{os.getpid()}",
+    user_id="direct-tools-example-user",
     session_preset="direct_tools",
     toolkits=["hackernews"],
     tools={"hackernews": {"enable": ["HACKERNEWS_GET_USER"]}},

--- a/python/examples/tool_router/direct_tools_preset.py
+++ b/python/examples/tool_router/direct_tools_preset.py
@@ -27,6 +27,7 @@ def require_env(name: str) -> str:
 
 composio = Composio(
     api_key=require_env("COMPOSIO_API_KEY"),
+    base_url=os.environ.get("COMPOSIO_BASE_URL"),
     provider=OpenAIAgentsProvider(),
 )
 require_env("OPENAI_API_KEY")

--- a/python/examples/tool_router/direct_tools_preset.py
+++ b/python/examples/tool_router/direct_tools_preset.py
@@ -1,0 +1,60 @@
+"""
+Tool Router direct_tools session preset with OpenAI Agents.
+
+session_preset="direct_tools" is a shortcut for sessions where the full allowed
+tool set is known upfront. It disables Tool Router meta/helper tools by default
+and loads all tools allowed by the filters directly into session.tools() and the
+MCP tool list.
+
+Usage:
+    COMPOSIO_API_KEY=... OPENAI_API_KEY=... python examples/tool_router/direct_tools_preset.py
+"""
+
+import os
+
+from agents import Agent, Runner
+from composio_openai_agents import OpenAIAgentsProvider
+
+from composio import Composio
+
+
+def require_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(f"Set {name} before running this example.")
+    return value
+
+
+composio = Composio(
+    api_key=require_env("COMPOSIO_API_KEY"),
+    provider=OpenAIAgentsProvider(),
+)
+require_env("OPENAI_API_KEY")
+
+session = composio.create(
+    user_id=f"direct-tools-example-{os.getpid()}",
+    session_preset="direct_tools",
+    toolkits=["hackernews"],
+    tools={"hackernews": {"enable": ["HACKERNEWS_GET_USER"]}},
+)
+
+tools = session.tools()
+print("Direct tools exposed to the agent:")
+for tool in tools:
+    print(f"- {tool.name}")
+
+agent = Agent(
+    name="Direct Tools Demo Agent",
+    instructions=(
+        "Use the provided direct tools. The session is configured without Tool "
+        "Router meta/helper tools."
+    ),
+    model=os.environ.get("OPENAI_MODEL", "gpt-4.1-mini"),
+    tools=tools,
+)
+
+result = Runner.run_sync(
+    agent,
+    'Use the Hacker News tool to look up user "pg" and report their karma.',
+)
+print(result.final_output)

--- a/python/examples/tool_router/direct_tools_preset.py
+++ b/python/examples/tool_router/direct_tools_preset.py
@@ -49,7 +49,7 @@ agent = Agent(
         "Use the provided direct tools. The session is configured without Tool "
         "Router meta/helper tools."
     ),
-    model=os.environ.get("OPENAI_MODEL", "gpt-4.1-mini"),
+    model=os.environ.get("OPENAI_MODEL", "gpt-5.5"),
     tools=tools,
 )
 

--- a/python/examples/tool_router/preload.py
+++ b/python/examples/tool_router/preload.py
@@ -131,7 +131,7 @@ def get_account_audit_log(input: AccountInput, ctx):
 
 
 session = composio.create(
-    user_id=f"preload-example-{os.getpid()}",
+    user_id="preload-example-user",
     toolkits=["hackernews"],
     tools={"hackernews": {"enable": ["HACKERNEWS_GET_USER"]}},
     preload={"tools": ["HACKERNEWS_GET_USER"]},

--- a/python/examples/tool_router/preload.py
+++ b/python/examples/tool_router/preload.py
@@ -58,6 +58,7 @@ INTERNAL_USERS = {
 
 composio = Composio(
     api_key=require_env("COMPOSIO_API_KEY"),
+    base_url=os.environ.get("COMPOSIO_BASE_URL"),
     provider=OpenAIAgentsProvider(),
 )
 require_env("OPENAI_API_KEY")

--- a/python/examples/tool_router/preload.py
+++ b/python/examples/tool_router/preload.py
@@ -153,7 +153,7 @@ agent = Agent(
         "Use the provided direct tools. Do not search for tools first; the "
         "needed tools are already loaded."
     ),
-    model=os.environ.get("OPENAI_MODEL", "gpt-4.1-mini"),
+    model=os.environ.get("OPENAI_MODEL", "gpt-5.5"),
     tools=tools,
 )
 

--- a/python/examples/tool_router/preload.py
+++ b/python/examples/tool_router/preload.py
@@ -1,0 +1,165 @@
+"""
+Tool Router preload with OpenAI Agents.
+
+Shows direct tool exposure for:
+1. Composio tools via preload["tools"].
+2. SDK custom tools via preload=True on the custom tool or toolkit.
+3. A nested custom tool override with preload=False inside a preloaded toolkit.
+
+Usage:
+    COMPOSIO_API_KEY=... OPENAI_API_KEY=... python examples/tool_router/preload.py
+"""
+
+import os
+
+from agents import Agent, Runner
+from composio_openai_agents import OpenAIAgentsProvider
+from pydantic import BaseModel, Field
+
+from composio import Composio
+
+
+def require_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(f"Set {name} before running this example.")
+    return value
+
+
+class UserLookupInput(BaseModel):
+    user_id: str = Field(description="Internal user ID, for example user-1")
+
+
+class TeamSearchInput(BaseModel):
+    team: str = Field(description="Team name to search for")
+
+
+class AccountInput(BaseModel):
+    user_id: str = Field(description="Internal user ID")
+
+
+INTERNAL_USERS = {
+    "user-1": {
+        "id": "user-1",
+        "name": "Ada Lovelace",
+        "email": "ada@example.com",
+        "team": "platform",
+        "plan": "enterprise",
+    },
+    "user-2": {
+        "id": "user-2",
+        "name": "Grace Hopper",
+        "email": "grace@example.com",
+        "team": "developer-tools",
+        "plan": "startup",
+    },
+}
+
+
+composio = Composio(
+    api_key=require_env("COMPOSIO_API_KEY"),
+    provider=OpenAIAgentsProvider(),
+)
+require_env("OPENAI_API_KEY")
+
+
+@composio.experimental.tool(
+    slug="LOOKUP_INTERNAL_USER",
+    name="Lookup internal user",
+    description="Look up an internal demo user profile by user ID.",
+    preload=True,
+)
+def lookup_internal_user(input: UserLookupInput, ctx):
+    user = INTERNAL_USERS.get(input.user_id)
+    if not user:
+        raise ValueError(f'User "{input.user_id}" not found')
+    return user
+
+
+@composio.experimental.tool(
+    slug="SEARCH_INTERNAL_USERS",
+    name="Search internal users",
+    description=(
+        "Search demo internal users by team. This custom tool is search-only "
+        "because preload is not enabled."
+    ),
+)
+def search_internal_users(input: TeamSearchInput, ctx):
+    return {
+        "results": [
+            user for user in INTERNAL_USERS.values() if user["team"] == input.team
+        ]
+    }
+
+
+internal_admin = composio.experimental.Toolkit(
+    slug="INTERNAL_ADMIN",
+    name="Internal admin",
+    description="Demo internal administration tools.",
+    preload=True,
+)
+
+
+@internal_admin.tool(
+    slug="GET_ACCOUNT_HEALTH",
+    name="Get account health",
+    description="Return internal account health details for a user.",
+)
+def get_account_health(input: AccountInput, ctx):
+    return {
+        "user_id": input.user_id,
+        "health": "green",
+        "open_incidents": 0,
+        "renewal_risk": "low",
+    }
+
+
+@internal_admin.tool(
+    slug="GET_ACCOUNT_AUDIT_LOG",
+    name="Get account audit log",
+    description=(
+        "Return internal account audit events. This overrides the toolkit "
+        "preload default and remains search-only."
+    ),
+    preload=False,
+)
+def get_account_audit_log(input: AccountInput, ctx):
+    return {
+        "user_id": input.user_id,
+        "events": ["login", "settings_viewed"],
+    }
+
+
+session = composio.create(
+    user_id=f"preload-example-{os.getpid()}",
+    toolkits=["hackernews"],
+    tools={"hackernews": {"enable": ["HACKERNEWS_GET_USER"]}},
+    preload={"tools": ["HACKERNEWS_GET_USER"]},
+    manage_connections=False,
+    experimental={
+        "custom_tools": [lookup_internal_user, search_internal_users],
+        "custom_toolkits": [internal_admin],
+    },
+)
+
+tools = session.tools()
+print("Direct tools exposed to the agent:")
+for tool in tools:
+    print(f"- {tool.name}")
+
+agent = Agent(
+    name="Preload Demo Agent",
+    instructions=(
+        "Use the provided direct tools. Do not search for tools first; the "
+        "needed tools are already loaded."
+    ),
+    model=os.environ.get("OPENAI_MODEL", "gpt-4.1-mini"),
+    tools=tools,
+)
+
+prompt = (
+    'Look up Hacker News user "pg", then look up internal user user-1 and '
+    "their account health. Summarize the useful facts."
+)
+result = Runner.run_sync(agent, prompt)
+print(result.final_output)

--- a/python/tests/test_custom_tools.py
+++ b/python/tests/test_custom_tools.py
@@ -422,6 +422,11 @@ class TestSerialization:
         result = serialize_custom_tools([preloaded])
         assert result[0]["preload"] is True
 
+    def test_serialize_custom_tool_omits_redundant_preload_false(self, grep_tool):
+        search_only = replace(grep_tool, preload=False)
+        result = serialize_custom_tools([search_only])
+        assert "preload" not in result[0]
+
     def test_serialize_toolkit(self, role_toolkit):
         result = serialize_custom_toolkits([role_toolkit])
         assert len(result) == 1

--- a/python/tests/test_custom_tools.py
+++ b/python/tests/test_custom_tools.py
@@ -12,6 +12,7 @@ Covers:
 - Multi-execute routing (all-local, all-remote, mixed, parallel)
 """
 
+from dataclasses import replace
 from unittest.mock import MagicMock
 
 import pytest
@@ -144,6 +145,14 @@ class TestDecoratorTool:
             return {}
 
         assert fetch_mail.extends_toolkit == "gmail"
+
+    def test_decorator_with_preload(self):
+        @exp.tool(preload=True)
+        def fetch_context(input: GrepInput, ctx):
+            """Fetch context."""
+            return {}
+
+        assert fetch_context.preload is True
 
     def test_decorator_explicit_overrides(self):
         @exp.tool(slug="CUSTOM", name="Custom Name", description="Custom desc")
@@ -408,11 +417,22 @@ class TestSerialization:
         result = serialize_custom_tools([email_tool])
         assert result[0]["extends_toolkit"] == "gmail"
 
+    def test_serialize_custom_tool_preload_hint(self, grep_tool):
+        preloaded = replace(grep_tool, preload=True)
+        result = serialize_custom_tools([preloaded])
+        assert result[0]["preload"] is True
+
     def test_serialize_toolkit(self, role_toolkit):
         result = serialize_custom_toolkits([role_toolkit])
         assert len(result) == 1
         assert result[0]["slug"] == "ROLE_MANAGER"
         assert len(result[0]["tools"]) == 1
+
+    def test_serialize_toolkit_preload_hint(self, role_toolkit):
+        role_toolkit.preload = True
+        result = serialize_custom_toolkits([role_toolkit])
+        assert result[0]["preload"] is True
+        assert result[0]["tools"][0]["preload"] is True
 
 
 # ────────────────────────────────────────────────────────────────

--- a/python/tests/test_custom_tools.py
+++ b/python/tests/test_custom_tools.py
@@ -571,6 +571,35 @@ class TestSessionContextImpl:
             arguments={"arg": "val"},
         )
 
+    def test_remote_fallback_passes_inline_custom_tools(self):
+        mock_client = MagicMock()
+        mock_client.tool_router.session.execute.return_value = SessionExecuteResponse(
+            data={"remote": True}, error=None, log_id="log_123"
+        )
+        inline_payload = {
+            "custom_tools": [
+                {
+                    "slug": "GREP",
+                    "name": "Grep",
+                    "description": "Search local text",
+                    "input_schema": {"type": "object", "properties": {}},
+                }
+            ]
+        }
+        ctx = SessionContextImpl(
+            client=mock_client,
+            user_id="u",
+            session_id="s",
+            inline_custom_tools_payload=inline_payload,
+        )
+        ctx.execute("GMAIL_SEND_EMAIL", {"to": "a@b.com"})
+        mock_client.tool_router.session.execute.assert_called_once_with(
+            session_id="s",
+            tool_slug="GMAIL_SEND_EMAIL",
+            arguments={"to": "a@b.com"},
+            experimental=inline_payload,
+        )
+
     def test_proxy_execute(self):
         mock_client = MagicMock()
         mock_client.tool_router.session.proxy_execute.return_value = (
@@ -648,6 +677,29 @@ class TestToolRouterSessionCustomTools:
         assert result.data == {"sent": True}
         assert result.log_id == "log_123"
 
+    def test_execute_remote_passes_inline_custom_tools(self, mock_session_deps):
+        mock_response = SessionExecuteResponse(
+            data={"sent": True}, error=None, log_id="log_123"
+        )
+        mock_session_deps[
+            "client"
+        ].tool_router.session.execute.return_value = mock_response
+        inline_payload = {
+            "custom_tools": [
+                {
+                    "slug": "GREP",
+                    "name": "Grep",
+                    "description": "Search local text",
+                    "input_schema": {"type": "object", "properties": {}},
+                }
+            ]
+        }
+        s = _session(mock_session_deps, inline_custom_tools_payload=inline_payload)
+        s.execute("GMAIL_SEND_EMAIL", arguments={"to": "a@b.com"})
+
+        call_args = mock_session_deps["client"].tool_router.session.execute.call_args
+        assert call_args.kwargs["experimental"] == inline_payload
+
     def test_proxy_execute(self, mock_session_deps):
         mock_session_deps[
             "client"
@@ -693,7 +745,7 @@ class TestToolRouterSessionCustomTools:
 
 
 class TestMultiExecuteRouting:
-    def _make_session(self, *tools):
+    def _make_session(self, *tools, inline_custom_tools_payload=None):
         m = build_custom_tools_map(list(tools))
         return ToolRouterSession(
             client=MagicMock(),
@@ -704,6 +756,7 @@ class TestMultiExecuteRouting:
             experimental=MagicMock(),
             custom_tools_map=m,
             user_id="u",
+            inline_custom_tools_payload=inline_custom_tools_payload,
         )
 
     def test_single_local(self, grep_tool):
@@ -724,6 +777,31 @@ class TestMultiExecuteRouting:
             {"tools": [{"tool_slug": "REMOTE", "arguments": {}}]}, tm
         )
         assert result == remote
+
+    def test_all_remote_passes_inline_custom_tools(self, grep_tool):
+        inline_payload = {
+            "custom_tools": [
+                {
+                    "slug": "GREP",
+                    "name": "Grep",
+                    "description": "Search local text",
+                    "input_schema": {"type": "object", "properties": {}},
+                }
+            ]
+        }
+        s = self._make_session(grep_tool, inline_custom_tools_payload=inline_payload)
+        tm = MagicMock()
+        remote = {"data": {"results": []}, "error": None, "successful": True}
+        tm._wrap_execute_tool_for_tool_router.return_value = lambda slug, args: remote
+        s._route_multi_execute(
+            {"tools": [{"tool_slug": "REMOTE", "arguments": {}}]}, tm
+        )
+
+        tm._wrap_execute_tool_for_tool_router.assert_called_once_with(
+            session_id="s",
+            modifiers=None,
+            inline_custom_tools_payload=inline_payload,
+        )
 
     def test_mixed(self, grep_tool):
         s = self._make_session(grep_tool)

--- a/python/tests/test_custom_tools.py
+++ b/python/tests/test_custom_tools.py
@@ -16,6 +16,7 @@ from dataclasses import replace
 from unittest.mock import MagicMock
 
 import pytest
+from composio_client import omit
 from composio_client.types.tool_router.session_execute_response import (
     SessionExecuteResponse,
 )
@@ -569,6 +570,7 @@ class TestSessionContextImpl:
             session_id="s",
             tool_slug="NONEXISTENT",
             arguments={"arg": "val"},
+            experimental=omit,
         )
 
     def test_remote_fallback_passes_inline_custom_tools(self):

--- a/python/tests/test_tool_router.py
+++ b/python/tests/test_tool_router.py
@@ -652,6 +652,20 @@ class TestToolRouter:
 
         mock_client.tool_router.session.create.assert_not_called()
 
+    def test_create_session_rejects_bare_string_preload_tools(
+        self, tool_router, mock_client
+    ):
+        with pytest.raises(
+            ValidationError,
+            match='preload.tools must be a list of Composio tool slugs or "all"',
+        ):
+            tool_router.create(
+                user_id="user_123",
+                preload={"tools": "GMAIL_FETCH_EMAILS"},
+            )
+
+        mock_client.tool_router.session.create.assert_not_called()
+
     def test_create_session_with_direct_tools_preset(self, tool_router, mock_client):
         """direct_tools applies SDK-side defaults for direct tool exposure."""
         mock_client.tool_router.session.create.return_value.config.preload.tools = "all"

--- a/python/tests/test_tool_router.py
+++ b/python/tests/test_tool_router.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from pydantic import BaseModel, Field
 
+from composio.exceptions import ValidationError
 from composio.core.models.custom_tool import ExperimentalAPI
 from composio.core.models.tool_router import (
     ToolkitConnectionsDetails,
@@ -628,6 +629,29 @@ class TestToolRouter:
         assert kwargs["preload"] == {"tools": "all"}
         assert session.preload.tools == "all"
 
+    def test_create_session_rejects_custom_slug_in_top_level_preload(
+        self, tool_router, mock_client
+    ):
+        @experimental_api.tool(
+            slug="GREP",
+            name="Grep",
+            description="Search local text",
+        )
+        def grep(input: GrepInput, ctx):
+            return {"matches": []}
+
+        with pytest.raises(
+            ValidationError,
+            match="Set preload=True on the SDK custom tool",
+        ):
+            tool_router.create(
+                user_id="user_123",
+                preload={"tools": ["GREP"]},
+                experimental={"custom_tools": [grep]},
+            )
+
+        mock_client.tool_router.session.create.assert_not_called()
+
     def test_create_session_with_direct_tools_preset(self, tool_router, mock_client):
         """direct_tools applies SDK-side defaults for direct tool exposure."""
         mock_client.tool_router.session.create.return_value.config.preload.tools = "all"
@@ -671,6 +695,42 @@ class TestToolRouter:
         assert kwargs["search"] == {"enable": False}
         assert kwargs["execute"] == {"enable_multi_execute": False}
         assert session.preload.tools == ["GITHUB_CREATE_ISSUE"]
+
+    def test_direct_tools_does_not_default_custom_preload_when_preload_overridden(
+        self, tool_router, mock_client
+    ):
+        """Explicit preload config also overrides the custom-tool preload default."""
+
+        @experimental_api.tool(
+            slug="GREP",
+            name="Grep",
+            description="Search local text",
+        )
+        def grep(input: GrepInput, ctx):
+            return {"matches": []}
+
+        mock_response = mock_client.tool_router.session.create.return_value
+        mock_response.config.preload.tools = ["GITHUB_CREATE_ISSUE"]
+        mock_response.experimental = MagicMock()
+        mock_response.experimental.assistive_prompt = None
+        mock_response.experimental.custom_toolkits = []
+        mock_custom_tool = MagicMock()
+        mock_custom_tool.slug = "SERVER_GREP"
+        mock_custom_tool.original_slug = "GREP"
+        mock_custom_tool.extends_toolkit = None
+        mock_response.experimental.custom_tools = [mock_custom_tool]
+
+        tool_router.create(
+            user_id="user_123",
+            session_preset="direct_tools",
+            toolkits=["github"],
+            preload={"tools": ["GITHUB_CREATE_ISSUE"]},
+            experimental={"custom_tools": [grep]},
+        )
+
+        kwargs = mock_client.tool_router.session.create.call_args.kwargs
+        assert kwargs["preload"] == {"tools": ["GITHUB_CREATE_ISSUE"]}
+        assert "preload" not in kwargs["experimental"]["custom_tools"][0]
 
     def test_create_session_complex_config(self, tool_router, mock_client):
         """Test creating a session with complex configuration."""
@@ -1149,18 +1209,19 @@ class TestToolRouter:
         mock_client,
         mock_provider,
     ):
-        """Custom tools preloaded by the create response are exposed locally."""
+        """Custom tools with SDK preload enabled are exposed locally."""
 
         @experimental_api.tool(
             slug="GREP",
             name="Grep",
             description="Search local text",
+            preload=True,
         )
         def grep(input: GrepInput, ctx):
             return {"matches": []}
 
         mock_response = mock_client.tool_router.session.create.return_value
-        mock_response.tool_router_tools = ["COMPOSIO_SEARCH_TOOLS", "server_grep"]
+        mock_response.tool_router_tools = ["COMPOSIO_SEARCH_TOOLS"]
         mock_response.experimental = MagicMock()
         mock_response.experimental.assistive_prompt = None
         mock_response.experimental.custom_toolkits = []

--- a/python/tests/test_tool_router.py
+++ b/python/tests/test_tool_router.py
@@ -1583,6 +1583,47 @@ class TestToolRouterExecution:
         assert result["error"] is None
         assert result["successful"] is True
 
+    def test_execute_endpoint_passes_inline_custom_tools(
+        self, tool_router, mock_client, mock_provider
+    ):
+        """Provider-wrapped session tools pass inline custom definitions."""
+        mock_execute_response = MagicMock()
+        mock_execute_response.data = {"result": "success"}
+        mock_execute_response.error = None
+        mock_client.tool_router.session.execute.return_value = mock_execute_response
+
+        from composio.core.models.tools import Tools as RealTools
+
+        inline_payload = {
+            "custom_tools": [
+                {
+                    "slug": "GREP",
+                    "name": "Grep",
+                    "description": "Search local text",
+                    "input_schema": {"type": "object", "properties": {}},
+                }
+            ]
+        }
+        real_tools = RealTools(
+            client=mock_client,
+            provider=mock_provider,
+            dangerously_allow_auto_upload_download_files=False,
+        )
+        execute_fn = real_tools._wrap_execute_tool_for_tool_router(
+            session_id="session_123",
+            inline_custom_tools_payload=inline_payload,
+        )
+
+        execute_fn("GMAIL_SEND_EMAIL", {"to": "test@example.com"})
+
+        mock_client.tool_router.session.execute.assert_called_once_with(
+            session_id="session_123",
+            tool_slug="GMAIL_SEND_EMAIL",
+            arguments={"to": "test@example.com"},
+            enable_auto_workbench_offload=True,
+            experimental=inline_payload,
+        )
+
     def test_modifiers_applied_in_tool_router_execution(
         self, tool_router, mock_client, mock_provider
     ):

--- a/python/tests/test_tool_router.py
+++ b/python/tests/test_tool_router.py
@@ -3,7 +3,9 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pydantic import BaseModel, Field
 
+from composio.core.models.custom_tool import ExperimentalAPI
 from composio.core.models.tool_router import (
     ToolkitConnectionsDetails,
     ToolkitConnectionState,
@@ -16,6 +18,15 @@ from composio.core.models.tool_router import (
     ToolRouterToolkitsDisableConfig,
     ToolRouterToolkitsEnableConfig,
 )
+from composio.core.models.tool_router_session import (
+    DIRECT_CUSTOM_TOOL_DESCRIPTION_PREFIX,
+)
+
+experimental_api = ExperimentalAPI()
+
+
+class GrepInput(BaseModel):
+    pattern: str = Field(description="Pattern to search for")
 
 
 @pytest.fixture
@@ -604,6 +615,63 @@ class TestToolRouter:
         assert kwargs["preload"] == {"tools": ["GMAIL_FETCH_EMAILS"]}
         assert session.preload.tools == ["GMAIL_FETCH_EMAILS"]
 
+    def test_create_session_with_preload_all(self, tool_router, mock_client):
+        """preload tools='all' is forwarded and exposed on the session."""
+        mock_client.tool_router.session.create.return_value.config.preload.tools = "all"
+
+        session = tool_router.create(
+            user_id="user_123",
+            preload={"tools": "all"},
+        )
+
+        kwargs = mock_client.tool_router.session.create.call_args.kwargs
+        assert kwargs["preload"] == {"tools": "all"}
+        assert session.preload.tools == "all"
+
+    def test_create_session_with_direct_tools_preset(self, tool_router, mock_client):
+        """direct_tools applies SDK-side defaults for direct tool exposure."""
+        mock_client.tool_router.session.create.return_value.config.preload.tools = "all"
+
+        session = tool_router.create(
+            user_id="user_123",
+            session_preset="direct_tools",
+            toolkits=["github"],
+        )
+
+        kwargs = mock_client.tool_router.session.create.call_args.kwargs
+        assert kwargs["toolkits"] == {"enable": ["github"]}
+        assert kwargs["manage_connections"] == {"enable": False}
+        assert kwargs["workbench"] == {"enable": False}
+        assert kwargs["preload"] == {"tools": "all"}
+        assert kwargs["search"] == {"enable": False}
+        assert kwargs["execute"] == {"enable_multi_execute": False}
+        assert session.preload.tools == "all"
+
+    def test_create_session_with_direct_tools_preset_overrides(
+        self, tool_router, mock_client
+    ):
+        """Explicit user fields override direct_tools defaults."""
+        mock_client.tool_router.session.create.return_value.config.preload.tools = [
+            "GITHUB_CREATE_ISSUE"
+        ]
+
+        session = tool_router.create(
+            user_id="user_123",
+            session_preset="direct_tools",
+            toolkits=["github"],
+            manage_connections=True,
+            workbench={"enable": True},
+            preload={"tools": ["GITHUB_CREATE_ISSUE"]},
+        )
+
+        kwargs = mock_client.tool_router.session.create.call_args.kwargs
+        assert kwargs["manage_connections"] == {"enable": True}
+        assert kwargs["workbench"] == {"enable": True}
+        assert kwargs["preload"] == {"tools": ["GITHUB_CREATE_ISSUE"]}
+        assert kwargs["search"] == {"enable": False}
+        assert kwargs["execute"] == {"enable_multi_execute": False}
+        assert session.preload.tools == ["GITHUB_CREATE_ISSUE"]
+
     def test_create_session_complex_config(self, tool_router, mock_client):
         """Test creating a session with complex configuration."""
         session = tool_router.create(
@@ -1072,6 +1140,60 @@ class TestToolRouter:
         wrapped_tools = mock_provider.wrap_tools.call_args.kwargs["tools"]
         assert [tool.slug for tool in wrapped_tools] == ["GMAIL_FETCH_EMAILS"]
         assert result == "mocked-wrapped-tools"
+
+    @patch("composio.core.models.tools.Tools")
+    def test_tools_function_includes_preloaded_custom_tools(
+        self,
+        mock_tools_class,
+        tool_router,
+        mock_client,
+        mock_provider,
+    ):
+        """Custom tools preloaded by the create response are exposed locally."""
+
+        @experimental_api.tool(
+            slug="GREP",
+            name="Grep",
+            description="Search local text",
+        )
+        def grep(input: GrepInput, ctx):
+            return {"matches": []}
+
+        mock_response = mock_client.tool_router.session.create.return_value
+        mock_response.tool_router_tools = ["COMPOSIO_SEARCH_TOOLS", "server_grep"]
+        mock_response.experimental = MagicMock()
+        mock_response.experimental.assistive_prompt = None
+        mock_response.experimental.custom_toolkits = []
+        mock_custom_tool = MagicMock()
+        mock_custom_tool.slug = "SERVER_GREP"
+        mock_custom_tool.original_slug = "GREP"
+        mock_custom_tool.extends_toolkit = None
+        mock_response.experimental.custom_tools = [mock_custom_tool]
+
+        mock_tools_instance = MagicMock()
+        mock_tool = MagicMock()
+        mock_tool.slug = "COMPOSIO_SEARCH_TOOLS"
+        mock_tool.toolkit.slug = "composio"
+        mock_tool.input_parameters = {}
+        mock_tools_instance.get_raw_tool_router_meta_tools.return_value = [mock_tool]
+        mock_tools_instance._file_helper.enhance_schema_descriptions.return_value = {}
+        mock_tools_class.return_value = mock_tools_instance
+        mock_provider.wrap_tools.return_value = "mocked-custom-tools"
+
+        session = tool_router.create(
+            user_id="user_123",
+            experimental={"custom_tools": [grep]},
+        )
+        result = session.tools()
+
+        wrapped_tools = mock_provider.wrap_tools.call_args.kwargs["tools"]
+        assert [tool.slug for tool in wrapped_tools] == [
+            "COMPOSIO_SEARCH_TOOLS",
+            "SERVER_GREP",
+        ]
+        assert DIRECT_CUSTOM_TOOL_DESCRIPTION_PREFIX in wrapped_tools[1].description
+        assert wrapped_tools[1].toolkit.slug == "custom"
+        assert result == "mocked-custom-tools"
 
     @patch("composio.core.models.tools.Tools")
     def test_tools_function_with_modifiers(

--- a/python/tests/test_tool_router.py
+++ b/python/tests/test_tool_router.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from composio_client import omit
 from pydantic import BaseModel, Field
 
 from composio.exceptions import ValidationError
@@ -1003,6 +1004,7 @@ class TestToolRouter:
             tool_slug="GMAIL_FETCH_EMAILS",
             arguments={"max_results": 1},
             account="work",
+            experimental=omit,
         )
 
     def test_authorize_function(self, tool_router, mock_client):
@@ -1576,6 +1578,7 @@ class TestToolRouterExecution:
             tool_slug="GMAIL_SEND_EMAIL",
             arguments={"to": "test@example.com"},
             enable_auto_workbench_offload=True,
+            experimental=omit,
         )
 
         # Verify result format

--- a/python/tests/test_tool_router.py
+++ b/python/tests/test_tool_router.py
@@ -1232,7 +1232,7 @@ class TestToolRouter:
             preload=True,
         )
         def grep(input: GrepInput, ctx):
-            return {"matches": []}
+            return {"matches": [input.pattern]}
 
         mock_response = mock_client.tool_router.session.create.return_value
         mock_response.tool_router_tools = ["COMPOSIO_SEARCH_TOOLS"]
@@ -1269,6 +1269,15 @@ class TestToolRouter:
         assert DIRECT_CUSTOM_TOOL_DESCRIPTION_PREFIX in wrapped_tools[1].description
         assert wrapped_tools[1].toolkit.slug == "custom"
         assert result == "mocked-custom-tools"
+
+        execute_tool = mock_provider.wrap_tools.call_args.kwargs["execute_tool"]
+        local_result = execute_tool(slug="SERVER_GREP", arguments={"pattern": "needle"})
+        assert local_result == {
+            "data": {"matches": ["needle"]},
+            "error": None,
+            "successful": True,
+        }
+        mock_client.tool_router.session.execute.assert_not_called()
 
     @patch("composio.core.models.tools.Tools")
     def test_tools_function_with_modifiers(

--- a/ts/examples/tool-router/.env.example
+++ b/ts/examples/tool-router/.env.example
@@ -1,6 +1,11 @@
 # Composio API Key - Get it from https://app.composio.dev
 COMPOSIO_API_KEY=your_composio_api_key_here
 
+# OpenAI API Key - Required for OpenAI Agents examples
+OPENAI_API_KEY=your_openai_api_key_here
+
+# Optional: override the model used by OpenAI Agents examples
+# OPENAI_MODEL=gpt-5.1
+
 # Add other environment variables as needed for your example
-# OPENAI_API_KEY=your_openai_api_key_here
 # ANTHROPIC_API_KEY=your_anthropic_api_key_here

--- a/ts/examples/tool-router/.env.example
+++ b/ts/examples/tool-router/.env.example
@@ -5,7 +5,7 @@ COMPOSIO_API_KEY=your_composio_api_key_here
 OPENAI_API_KEY=your_openai_api_key_here
 
 # Optional: override the model used by OpenAI Agents examples
-# OPENAI_MODEL=gpt-5.1
+# OPENAI_MODEL=gpt-5.5
 
 # Add other environment variables as needed for your example
 # ANTHROPIC_API_KEY=your_anthropic_api_key_here

--- a/ts/examples/tool-router/README.md
+++ b/ts/examples/tool-router/README.md
@@ -5,13 +5,11 @@ This example demonstrates how to use Composio SDK for tool-router.
 ## Setup
 
 1. **Install dependencies:**
-
    ```bash
    pnpm install
    ```
 
 2. **Configure environment:**
-
    ```bash
    cp .env.example .env
    ```
@@ -48,7 +46,6 @@ pnpm direct-tools
 ## Customization
 
 Edit `src/index.ts` to:
-
 - Add specific apps you want to integrate with
 - Implement your business logic
 - Add error handling and logging

--- a/ts/examples/tool-router/README.md
+++ b/ts/examples/tool-router/README.md
@@ -5,17 +5,21 @@ This example demonstrates how to use Composio SDK for tool-router.
 ## Setup
 
 1. **Install dependencies:**
+
    ```bash
    pnpm install
    ```
 
 2. **Configure environment:**
+
    ```bash
    cp .env.example .env
    ```
-   
+
    Then edit `.env` and add your API keys:
    - `COMPOSIO_API_KEY`: Get it from [Composio Dashboard](https://app.composio.dev)
+   - `OPENAI_API_KEY`: Required for OpenAI Agents examples
+   - `OPENAI_MODEL`: Optional model override for OpenAI Agents examples
 
 ## Running the Example
 
@@ -25,6 +29,12 @@ pnpm start
 
 # Run in development mode (with file watching)
 pnpm dev
+
+# Explicit preload for app tools and SDK custom tools
+pnpm preload
+
+# Direct-tools preset for sessions where all tools are known upfront
+pnpm direct-tools
 ```
 
 ## What This Example Does
@@ -32,10 +42,13 @@ pnpm dev
 - Initializes Composio SDK
 - Fetches available tools
 - Demonstrates basic usage patterns
+- Shows how to preload selected app tools and SDK-local custom tools into `session.tools()`
+- Shows `sessionPreset: "direct_tools"` for loading all tools allowed by session filters without meta/helper tools
 
 ## Customization
 
 Edit `src/index.ts` to:
+
 - Add specific apps you want to integrate with
 - Implement your business logic
 - Add error handling and logging

--- a/ts/examples/tool-router/package.json
+++ b/ts/examples/tool-router/package.json
@@ -7,6 +7,8 @@
   "scripts": {
     "start": "bun src/index.ts",
     "dev": "bun --watch src/index.ts",
+    "preload": "bun src/preload.ts",
+    "direct-tools": "bun src/direct-tools-preset.ts",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [

--- a/ts/examples/tool-router/src/custom-tools-agent.ts
+++ b/ts/examples/tool-router/src/custom-tools-agent.ts
@@ -169,7 +169,7 @@ const composio = new Composio({
   provider: new OpenAIAgentsProvider(),
 });
 
-const session = await composio.create(`agent-e2e-${Date.now()}`, {
+const session = await composio.create("custom-tools-agent-user", {
   toolkits: ["weathermap", "gmail"],
   manageConnections: false,
   experimental: {

--- a/ts/examples/tool-router/src/custom-tools-agent.ts
+++ b/ts/examples/tool-router/src/custom-tools-agent.ts
@@ -184,7 +184,7 @@ const tools = await session.tools();
 const agent = new Agent({
   name: "Custom Tools Agent",
   instructions: "You are a helpful assistant. Use Composio tools to execute tasks.",
-  model: "gpt-5.5",
+  model: "gpt-5.2",
   tools,
 });
 

--- a/ts/examples/tool-router/src/custom-tools-agent.ts
+++ b/ts/examples/tool-router/src/custom-tools-agent.ts
@@ -184,7 +184,7 @@ const tools = await session.tools();
 const agent = new Agent({
   name: "Custom Tools Agent",
   instructions: "You are a helpful assistant. Use Composio tools to execute tasks.",
-  model: "gpt-5.2",
+  model: "gpt-5.5",
   tools,
 });
 

--- a/ts/examples/tool-router/src/custom-tools-e2e.ts
+++ b/ts/examples/tool-router/src/custom-tools-e2e.ts
@@ -146,7 +146,7 @@ const userManagement = experimental_createToolkit("USER_MANAGEMENT", {
 const composio = new Composio({ apiKey, baseURL: baseURL ?? undefined });
 
 async function main() {
-  const userId = `e2e-custom-${Date.now()}`;
+  const userId = "custom-tools-e2e-user";
   console.log(`\nCreating session for user: ${userId}`);
   console.log(`Base URL: ${baseURL ?? "(default)"}\n`);
 

--- a/ts/examples/tool-router/src/direct-tools-preset.ts
+++ b/ts/examples/tool-router/src/direct-tools-preset.ts
@@ -31,7 +31,7 @@ const composio = new Composio({
   provider: new OpenAIAgentsProvider(),
 });
 
-const session = await composio.create(`direct-tools-example-${Date.now()}`, {
+const session = await composio.create('direct-tools-example-user', {
   sessionPreset: 'direct_tools',
   toolkits: ['hackernews'],
   tools: {
@@ -51,7 +51,7 @@ const agent = new Agent({
   name: 'Direct Tools Demo Agent',
   instructions:
     'Use the provided direct tools. The session is configured without Tool Router meta/helper tools.',
-  model: process.env.OPENAI_MODEL ?? 'gpt-5.1',
+  model: process.env.OPENAI_MODEL ?? 'gpt-5.5',
   tools,
 });
 

--- a/ts/examples/tool-router/src/direct-tools-preset.ts
+++ b/ts/examples/tool-router/src/direct-tools-preset.ts
@@ -1,0 +1,64 @@
+/**
+ * Tool Router direct_tools session preset with OpenAI Agents
+ *
+ * `sessionPreset: "direct_tools"` is a shortcut for sessions where the full
+ * allowed tool set is known upfront. It disables Tool Router meta/helper tools
+ * by default and loads all tools allowed by the filters directly into
+ * `session.tools()` and the MCP tool list.
+ *
+ * Usage:
+ *   COMPOSIO_API_KEY=... OPENAI_API_KEY=... bun src/direct-tools-preset.ts
+ */
+import 'dotenv/config';
+import { Composio } from '@composio/core';
+import { OpenAIAgentsProvider } from '@composio/openai-agents';
+import { Agent, run } from '@openai/agents';
+
+function requireEnv(name: 'COMPOSIO_API_KEY' | 'OPENAI_API_KEY'): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Set ${name} before running this example.`);
+  }
+  return value;
+}
+
+const composioApiKey = requireEnv('COMPOSIO_API_KEY');
+requireEnv('OPENAI_API_KEY');
+
+const composio = new Composio({
+  apiKey: composioApiKey,
+  baseURL: process.env.COMPOSIO_BASE_URL || undefined,
+  provider: new OpenAIAgentsProvider(),
+});
+
+const session = await composio.create(`direct-tools-example-${Date.now()}`, {
+  sessionPreset: 'direct_tools',
+  toolkits: ['hackernews'],
+  tools: {
+    hackernews: {
+      enable: ['HACKERNEWS_GET_USER'],
+    },
+  },
+});
+
+const tools = await session.tools();
+console.log('Direct tools exposed to the agent:');
+for (const tool of tools) {
+  console.log(`- ${tool.name}`);
+}
+
+const agent = new Agent({
+  name: 'Direct Tools Demo Agent',
+  instructions:
+    'Use the provided direct tools. The session is configured without Tool Router meta/helper tools.',
+  model: process.env.OPENAI_MODEL ?? 'gpt-5.1',
+  tools,
+});
+
+const prompt =
+  process.argv.slice(2).join(' ') ||
+  'Use the Hacker News tool to look up user "pg" and report their karma.';
+
+console.log(`\nUser: ${prompt}\n`);
+const result = await run(agent, prompt);
+console.log(`Assistant: ${result.finalOutput}`);

--- a/ts/examples/tool-router/src/preload.ts
+++ b/ts/examples/tool-router/src/preload.ts
@@ -111,7 +111,7 @@ const composio = new Composio({
   provider: new OpenAIAgentsProvider(),
 });
 
-const session = await composio.create(`preload-example-${Date.now()}`, {
+const session = await composio.create('preload-example-user', {
   toolkits: ['hackernews'],
   tools: {
     hackernews: {
@@ -138,7 +138,7 @@ const agent = new Agent({
   name: 'Preload Demo Agent',
   instructions:
     'Use the provided direct tools. Do not search for tools first; the needed tools are already loaded.',
-  model: process.env.OPENAI_MODEL ?? 'gpt-5.1',
+  model: process.env.OPENAI_MODEL ?? 'gpt-5.5',
   tools,
 });
 

--- a/ts/examples/tool-router/src/preload.ts
+++ b/ts/examples/tool-router/src/preload.ts
@@ -84,11 +84,25 @@ const getAccountHealth = experimental_createTool('GET_ACCOUNT_HEALTH', {
   }),
 });
 
+const getAccountAuditLog = experimental_createTool('GET_ACCOUNT_AUDIT_LOG', {
+  name: 'Get account audit log',
+  description:
+    'Return internal account audit events. This overrides the toolkit preload default and remains search-only.',
+  preload: false,
+  inputParams: z.object({
+    user_id: z.string().describe('Internal user ID'),
+  }),
+  execute: async ({ user_id }) => ({
+    user_id,
+    events: ['login', 'settings_viewed'],
+  }),
+});
+
 const internalAdmin = experimental_createToolkit('INTERNAL_ADMIN', {
   name: 'Internal admin',
   description: 'Demo internal administration tools.',
   preload: true,
-  tools: [getAccountHealth],
+  tools: [getAccountHealth, getAccountAuditLog],
 });
 
 const composio = new Composio({

--- a/ts/examples/tool-router/src/preload.ts
+++ b/ts/examples/tool-router/src/preload.ts
@@ -1,0 +1,137 @@
+/**
+ * Tool Router preload with OpenAI Agents
+ *
+ * Shows direct tool exposure for:
+ * 1. Composio tools via `preload.tools`
+ * 2. SDK custom tools via `preload: true` on the custom tool or toolkit
+ *
+ * Usage:
+ *   COMPOSIO_API_KEY=... OPENAI_API_KEY=... bun src/preload.ts
+ */
+import 'dotenv/config';
+import { Composio, experimental_createTool, experimental_createToolkit } from '@composio/core';
+import { OpenAIAgentsProvider } from '@composio/openai-agents';
+import { Agent, run } from '@openai/agents';
+import { z } from 'zod/v3';
+
+function requireEnv(name: 'COMPOSIO_API_KEY' | 'OPENAI_API_KEY'): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Set ${name} before running this example.`);
+  }
+  return value;
+}
+
+const composioApiKey = requireEnv('COMPOSIO_API_KEY');
+requireEnv('OPENAI_API_KEY');
+
+const internalUsers: Record<string, Record<string, unknown>> = {
+  'user-1': {
+    id: 'user-1',
+    name: 'Ada Lovelace',
+    email: 'ada@example.com',
+    team: 'platform',
+    plan: 'enterprise',
+  },
+  'user-2': {
+    id: 'user-2',
+    name: 'Grace Hopper',
+    email: 'grace@example.com',
+    team: 'developer-tools',
+    plan: 'startup',
+  },
+};
+
+const lookupInternalUser = experimental_createTool('LOOKUP_INTERNAL_USER', {
+  name: 'Lookup internal user',
+  description: 'Look up an internal demo user profile by user ID.',
+  preload: true,
+  inputParams: z.object({
+    user_id: z.string().describe('Internal user ID, for example user-1'),
+  }),
+  execute: async ({ user_id }) => {
+    const user = internalUsers[user_id];
+    if (!user) {
+      throw new Error(`User "${user_id}" not found`);
+    }
+    return user;
+  },
+});
+
+const searchInternalUsers = experimental_createTool('SEARCH_INTERNAL_USERS', {
+  name: 'Search internal users',
+  description:
+    'Search demo internal users by team. This custom tool is search-only because preload is not enabled.',
+  inputParams: z.object({
+    team: z.string().describe('Team name to search for'),
+  }),
+  execute: async ({ team }) => ({
+    results: Object.values(internalUsers).filter(user => user.team === team),
+  }),
+});
+
+const getAccountHealth = experimental_createTool('GET_ACCOUNT_HEALTH', {
+  name: 'Get account health',
+  description: 'Return internal account health details for a user.',
+  inputParams: z.object({
+    user_id: z.string().describe('Internal user ID'),
+  }),
+  execute: async ({ user_id }) => ({
+    user_id,
+    health: 'green',
+    open_incidents: 0,
+    renewal_risk: 'low',
+  }),
+});
+
+const internalAdmin = experimental_createToolkit('INTERNAL_ADMIN', {
+  name: 'Internal admin',
+  description: 'Demo internal administration tools.',
+  preload: true,
+  tools: [getAccountHealth],
+});
+
+const composio = new Composio({
+  apiKey: composioApiKey,
+  baseURL: process.env.COMPOSIO_BASE_URL || undefined,
+  provider: new OpenAIAgentsProvider(),
+});
+
+const session = await composio.create(`preload-example-${Date.now()}`, {
+  toolkits: ['hackernews'],
+  tools: {
+    hackernews: {
+      enable: ['HACKERNEWS_GET_USER'],
+    },
+  },
+  preload: {
+    tools: ['HACKERNEWS_GET_USER'],
+  },
+  manageConnections: false,
+  experimental: {
+    customTools: [lookupInternalUser, searchInternalUsers],
+    customToolkits: [internalAdmin],
+  },
+});
+
+const tools = await session.tools();
+console.log('Direct tools exposed to the agent:');
+for (const tool of tools) {
+  console.log(`- ${tool.name}`);
+}
+
+const agent = new Agent({
+  name: 'Preload Demo Agent',
+  instructions:
+    'Use the provided direct tools. Do not search for tools first; the needed tools are already loaded.',
+  model: process.env.OPENAI_MODEL ?? 'gpt-5.1',
+  tools,
+});
+
+const prompt =
+  process.argv.slice(2).join(' ') ||
+  'Look up Hacker News user "pg", then look up internal user user-1 and their account health. Summarize the useful facts.';
+
+console.log(`\nUser: ${prompt}\n`);
+const result = await run(agent, prompt);
+console.log(`Assistant: ${result.finalOutput}`);

--- a/ts/packages/core/src/lib/toolRouterParams.ts
+++ b/ts/packages/core/src/lib/toolRouterParams.ts
@@ -114,7 +114,7 @@ export const transformToolRouterManageConnectionsParams = (
 export const transformToolRouterWorkbenchParams = (
   params?: ToolRouterCreateSessionConfig['workbench']
 ): SessionCreateParams.Workbench | undefined => {
-  if (params === undefined) {
+  if (!params) {
     return undefined;
   }
 

--- a/ts/packages/core/src/lib/toolRouterParams.ts
+++ b/ts/packages/core/src/lib/toolRouterParams.ts
@@ -114,7 +114,7 @@ export const transformToolRouterManageConnectionsParams = (
 export const transformToolRouterWorkbenchParams = (
   params?: ToolRouterCreateSessionConfig['workbench']
 ): SessionCreateParams.Workbench | undefined => {
-  if (!params) {
+  if (params === undefined) {
     return undefined;
   }
 

--- a/ts/packages/core/src/models/CustomTool.ts
+++ b/ts/packages/core/src/models/CustomTool.ts
@@ -286,6 +286,7 @@ export function buildCustomToolsMap(
 
   const addEntry = (handle: CustomTool, finalSlug: string, toolkit?: string) => {
     const originalSlug = handle.slug.toUpperCase();
+    // Custom tool slugs are matched case-insensitively across local and response maps.
     const finalSlugKey = finalSlug.toUpperCase();
 
     // Length validated early in createCustomTool/createCustomToolkit, but check as safety net
@@ -351,11 +352,14 @@ function shouldSerializePreload(
   inheritedPreload: boolean | undefined,
   defaultPreload: boolean
 ): boolean | undefined {
-  const resolved = preload ?? inheritedPreload ?? defaultPreload;
-  if (preload !== undefined || inheritedPreload !== undefined || defaultPreload) {
-    return resolved;
+  const inheritedOrDefault = inheritedPreload ?? defaultPreload;
+  if (preload !== undefined) {
+    return preload || inheritedOrDefault ? preload : undefined;
   }
-  return undefined;
+  if (inheritedPreload !== undefined) {
+    return inheritedPreload || defaultPreload ? inheritedPreload : undefined;
+  }
+  return defaultPreload ? true : undefined;
 }
 
 function preloadWireProperty(

--- a/ts/packages/core/src/models/CustomTool.ts
+++ b/ts/packages/core/src/models/CustomTool.ts
@@ -32,8 +32,8 @@ import {
   type CustomToolExecuteFn,
   type CustomToolsMap,
   type CustomToolsMapEntry,
-  type CustomToolDefinition,
-  type CustomToolkitDefinition,
+  type CustomToolWireDefinition,
+  type CustomToolkitWireDefinition,
   type InputParamsSchema,
 } from '../types/customTool.types';
 import type { SessionCreateResponse } from '@composio/client/resources/tool-router/session/session.mjs';
@@ -184,6 +184,7 @@ export function createCustomTool<T extends z.ZodType>(
     name: validated.name,
     description: validated.description,
     extendsToolkit: validated.extendsToolkit,
+    preload: validated.preload,
     inputSchema,
     outputSchema,
     inputParams,
@@ -250,6 +251,7 @@ export function createCustomToolkit(
     slug: slugResult.data,
     name: validated.name,
     description: validated.description,
+    preload: validated.preload,
     tools: options.tools,
   };
 }
@@ -340,7 +342,36 @@ export function buildCustomToolsMap(
  * @param tools - The custom tools to serialize
  * @returns Array of CustomToolDefinition for the API payload
  */
-export function serializeCustomTools(tools: CustomTool[]): CustomToolDefinition[] {
+type CustomToolSerializationOptions = {
+  defaultPreload?: boolean;
+};
+
+function shouldSerializePreload(
+  preload: boolean | undefined,
+  inheritedPreload: boolean | undefined,
+  defaultPreload: boolean
+): boolean | undefined {
+  const resolved = preload ?? inheritedPreload ?? defaultPreload;
+  if (preload !== undefined || inheritedPreload !== undefined || defaultPreload) {
+    return resolved;
+  }
+  return undefined;
+}
+
+function preloadWireProperty(
+  preload: boolean | undefined,
+  inheritedPreload: boolean | undefined,
+  defaultPreload: boolean
+): { preload?: boolean } {
+  const serializedPreload = shouldSerializePreload(preload, inheritedPreload, defaultPreload);
+  return serializedPreload === undefined ? {} : { preload: serializedPreload };
+}
+
+export function serializeCustomTools(
+  tools: CustomTool[],
+  options: CustomToolSerializationOptions = {}
+): CustomToolWireDefinition[] {
+  const defaultPreload = options.defaultPreload ?? false;
   return tools.map(handle => ({
     slug: handle.slug,
     name: handle.name,
@@ -348,6 +379,7 @@ export function serializeCustomTools(tools: CustomTool[]): CustomToolDefinition[
     input_schema: handle.inputSchema,
     ...(handle.outputSchema ? { output_schema: handle.outputSchema } : {}),
     ...(handle.extendsToolkit ? { extends_toolkit: handle.extendsToolkit } : {}),
+    ...preloadWireProperty(handle.preload, undefined, defaultPreload),
   }));
 }
 
@@ -358,17 +390,23 @@ export function serializeCustomTools(tools: CustomTool[]): CustomToolDefinition[
  * @param toolkits - The custom toolkits to serialize
  * @returns Array of CustomToolkitDefinition for the API payload
  */
-export function serializeCustomToolkits(toolkits: CustomToolkit[]): CustomToolkitDefinition[] {
+export function serializeCustomToolkits(
+  toolkits: CustomToolkit[],
+  options: CustomToolSerializationOptions = {}
+): CustomToolkitWireDefinition[] {
+  const defaultPreload = options.defaultPreload ?? false;
   return toolkits.map(tk => ({
     slug: tk.slug,
     name: tk.name,
     description: tk.description,
+    ...preloadWireProperty(tk.preload, undefined, defaultPreload),
     tools: tk.tools.map(t => ({
       slug: t.slug,
       name: t.name,
       description: t.description,
       input_schema: t.inputSchema,
       ...(t.outputSchema ? { output_schema: t.outputSchema } : {}),
+      ...preloadWireProperty(t.preload, tk.preload, defaultPreload),
     })),
   }));
 }
@@ -452,28 +490,62 @@ export function findCustomToolMapEntryByFinalSlug(
 }
 
 /**
- * Resolve custom tools that the backend selected for direct preload.
+ * Reject legacy attempts to preload custom tools through top-level preload.tools.
  *
- * The backend is the source of truth for preload expansion, including "all".
- * The SDK only keeps the final custom slugs it can serve locally because
- * the session tools endpoint only returns backend-managed tool schemas.
+ * Custom tool direct exposure is controlled by CustomTool.preload /
+ * CustomToolkit.preload so it follows the current SDK-provided custom
+ * definitions instead of stale session config.
+ *
+ * @internal
+ */
+export function assertNoCustomToolSlugsInPreload(
+  preloadTools: readonly string[] | 'all' | undefined,
+  customToolsMap: CustomToolsMap | undefined
+): void {
+  if (!preloadTools || preloadTools === 'all') {
+    return;
+  }
+
+  const customPreloadSlugs = preloadTools.filter(slug => {
+    const normalized = slug.toUpperCase();
+    return (
+      normalized.startsWith(LOCAL_TOOL_PREFIX) ||
+      customToolsMap?.byOriginalSlug.has(normalized) ||
+      customToolsMap?.byFinalSlug.has(normalized)
+    );
+  });
+
+  if (customPreloadSlugs.length) {
+    throw new ValidationError(
+      `Custom tool slugs are not supported in preload.tools: ${customPreloadSlugs.join(
+        ', '
+      )}. Set preload: true on the SDK custom tool or custom toolkit definition instead.`
+    );
+  }
+}
+
+/**
+ * Resolve custom tools that the SDK should expose directly from session.tools().
  *
  * @internal
  */
 export function getPreloadedCustomToolSlugs(
-  toolRouterTools: readonly string[] | undefined,
-  customToolsMap: CustomToolsMap | undefined
+  customToolsMap: CustomToolsMap | undefined,
+  defaultPreload = false
 ): string[] {
-  if (!toolRouterTools?.length || !customToolsMap) {
+  if (!customToolsMap) {
     return [];
   }
 
   const seen = new Set<string>();
   const customToolSlugs: string[] = [];
 
-  for (const slug of toolRouterTools) {
-    const entry = findCustomToolMapEntryByFinalSlug(customToolsMap, slug);
-    if (!entry) {
+  for (const entry of customToolsMap.byFinalSlug.values()) {
+    const toolkit = customToolsMap.toolkits?.find(
+      tk => entry.toolkit && tk.slug.toLowerCase() === entry.toolkit.toLowerCase()
+    );
+    const shouldPreload = entry.handle.preload ?? toolkit?.preload ?? defaultPreload;
+    if (!shouldPreload) {
       continue;
     }
 

--- a/ts/packages/core/src/models/CustomTool.ts
+++ b/ts/packages/core/src/models/CustomTool.ts
@@ -284,6 +284,7 @@ export function buildCustomToolsMap(
 
   const addEntry = (handle: CustomTool, finalSlug: string, toolkit?: string) => {
     const originalSlug = handle.slug.toUpperCase();
+    const finalSlugKey = finalSlug.toUpperCase();
 
     // Length validated early in createCustomTool/createCustomToolkit, but check as safety net
     if (finalSlug.length > MAX_SLUG_LENGTH) {
@@ -294,7 +295,7 @@ export function buildCustomToolsMap(
     }
 
     // Check cross-group collisions on final slug
-    if (byFinalSlug.has(finalSlug)) {
+    if (byFinalSlug.has(finalSlugKey)) {
       throw new ValidationError(
         `Custom tool slug collision: "${finalSlug}" is already registered.`
       );
@@ -309,7 +310,7 @@ export function buildCustomToolsMap(
     }
 
     const entry: CustomToolsMapEntry = { handle, finalSlug, toolkit };
-    byFinalSlug.set(finalSlug, entry);
+    byFinalSlug.set(finalSlugKey, entry);
     byOriginalSlug.set(originalSlug, entry);
   };
 
@@ -415,7 +416,7 @@ export function buildCustomToolsMapFromResponse(
       finalSlug,
       toolkit: toolkit ?? match.toolkit,
     };
-    byFinalSlug.set(finalSlug, entry);
+    byFinalSlug.set(finalSlug.toUpperCase(), entry);
     byOriginalSlug.set(originalSlug.toUpperCase(), entry);
   };
 
@@ -436,4 +437,54 @@ export function buildCustomToolsMapFromResponse(
   }
 
   return { byFinalSlug, byOriginalSlug, toolkits };
+}
+
+/**
+ * Find a custom tool entry by final slug only.
+ *
+ * @internal
+ */
+export function findCustomToolMapEntryByFinalSlug(
+  customToolsMap: CustomToolsMap | undefined,
+  slug: string
+): CustomToolsMapEntry | undefined {
+  return customToolsMap?.byFinalSlug.get(slug.toUpperCase());
+}
+
+/**
+ * Resolve custom tools that the backend selected for direct preload.
+ *
+ * The backend is the source of truth for preload expansion, including "all".
+ * The SDK only keeps the final custom slugs it can serve locally because
+ * the session tools endpoint only returns backend-managed tool schemas.
+ *
+ * @internal
+ */
+export function getPreloadedCustomToolSlugs(
+  toolRouterTools: readonly string[] | undefined,
+  customToolsMap: CustomToolsMap | undefined
+): string[] {
+  if (!toolRouterTools?.length || !customToolsMap) {
+    return [];
+  }
+
+  const seen = new Set<string>();
+  const customToolSlugs: string[] = [];
+
+  for (const slug of toolRouterTools) {
+    const entry = findCustomToolMapEntryByFinalSlug(customToolsMap, slug);
+    if (!entry) {
+      continue;
+    }
+
+    const finalSlugKey = entry.finalSlug.toUpperCase();
+    if (seen.has(finalSlugKey)) {
+      continue;
+    }
+
+    seen.add(finalSlugKey);
+    customToolSlugs.push(entry.finalSlug);
+  }
+
+  return customToolSlugs;
 }

--- a/ts/packages/core/src/models/SessionContext.ts
+++ b/ts/packages/core/src/models/SessionContext.ts
@@ -21,6 +21,7 @@ import { transformProxyParams } from './proxyParamsTransform';
 import { findCustomTool, executeCustomTool } from './customToolExecution';
 import { transformExecuteResponse } from '../utils/transformers/toolRouterResponseTransform';
 import type { SessionExecuteParams } from '@composio/client/resources/tool-router/session/session.mjs';
+import { inlineCustomToolsExperimental } from './inlineCustomToolsPayload';
 
 /**
  * Concrete implementation of SessionContext.
@@ -71,9 +72,11 @@ export class SessionContextImpl implements SessionContext {
       tool_slug: toolSlug,
       arguments: arguments_,
     };
-    if (this.inlineCustomToolsPayload) {
-      executeParams.experimental =
-        this.inlineCustomToolsPayload as SessionExecuteParams.Experimental;
+    const experimental = inlineCustomToolsExperimental<SessionExecuteParams.Experimental>(
+      this.inlineCustomToolsPayload
+    );
+    if (experimental) {
+      executeParams.experimental = experimental;
     }
 
     const response = await this.client.toolRouter.session.execute(this.sessionId, executeParams);

--- a/ts/packages/core/src/models/SessionContext.ts
+++ b/ts/packages/core/src/models/SessionContext.ts
@@ -71,17 +71,13 @@ export class SessionContextImpl implements SessionContext {
       tool_slug: toolSlug,
       arguments: arguments_,
     };
-    const experimental = this.inlineExecuteExperimental();
-    if (experimental) {
-      executeParams.experimental = experimental;
+    if (this.inlineCustomToolsPayload) {
+      executeParams.experimental =
+        this.inlineCustomToolsPayload as SessionExecuteParams.Experimental;
     }
 
     const response = await this.client.toolRouter.session.execute(this.sessionId, executeParams);
     return ToolRouterSessionExecuteResponseSchema.parse(transformExecuteResponse(response));
-  }
-
-  private inlineExecuteExperimental(): SessionExecuteParams.Experimental | undefined {
-    return this.inlineCustomToolsPayload as SessionExecuteParams.Experimental | undefined;
   }
 
   /**

--- a/ts/packages/core/src/models/SessionContext.ts
+++ b/ts/packages/core/src/models/SessionContext.ts
@@ -2,7 +2,11 @@
  * @fileoverview Session context implementation injected into custom tool execute functions.
  */
 import { Composio as ComposioClient } from '@composio/client';
-import type { SessionContext, CustomToolsMap } from '../types/customTool.types';
+import type {
+  SessionContext,
+  CustomToolsMap,
+  InlineCustomToolsWirePayload,
+} from '../types/customTool.types';
 import type {
   SessionProxyExecuteParams,
   ToolRouterSessionExecuteResponse,
@@ -16,6 +20,7 @@ import { ValidationError } from '../errors';
 import { transformProxyParams } from './proxyParamsTransform';
 import { findCustomTool, executeCustomTool } from './customToolExecution';
 import { transformExecuteResponse } from '../utils/transformers/toolRouterResponseTransform';
+import type { SessionExecuteParams } from '@composio/client/resources/tool-router/session/session.mjs';
 
 /**
  * Concrete implementation of SessionContext.
@@ -33,7 +38,8 @@ export class SessionContextImpl implements SessionContext {
     private readonly client: ComposioClient,
     userId: string,
     private readonly sessionId: string,
-    private readonly customToolsMap?: CustomToolsMap
+    private readonly customToolsMap?: CustomToolsMap,
+    private readonly inlineCustomToolsPayload?: InlineCustomToolsWirePayload
   ) {
     this.userId = userId;
   }
@@ -61,11 +67,21 @@ export class SessionContextImpl implements SessionContext {
     }
 
     // Fall back to remote execution
-    const response = await this.client.toolRouter.session.execute(this.sessionId, {
+    const executeParams: SessionExecuteParams = {
       tool_slug: toolSlug,
       arguments: arguments_,
-    });
+    };
+    const experimental = this.inlineExecuteExperimental();
+    if (experimental) {
+      executeParams.experimental = experimental;
+    }
+
+    const response = await this.client.toolRouter.session.execute(this.sessionId, executeParams);
     return ToolRouterSessionExecuteResponseSchema.parse(transformExecuteResponse(response));
+  }
+
+  private inlineExecuteExperimental(): SessionExecuteParams.Experimental | undefined {
+    return this.inlineCustomToolsPayload as SessionExecuteParams.Experimental | undefined;
   }
 
   /**

--- a/ts/packages/core/src/models/ToolRouter.ts
+++ b/ts/packages/core/src/models/ToolRouter.ts
@@ -163,8 +163,12 @@ export class ToolRouter<
     const inlineCustomToolsPayload =
       experimentalPayload.custom_tools || experimentalPayload.custom_toolkits
         ? {
-            custom_tools: experimentalPayload.custom_tools,
-            custom_toolkits: experimentalPayload.custom_toolkits,
+            ...(experimentalPayload.custom_tools
+              ? { custom_tools: experimentalPayload.custom_tools }
+              : {}),
+            ...(experimentalPayload.custom_toolkits
+              ? { custom_toolkits: experimentalPayload.custom_toolkits }
+              : {}),
           }
         : undefined;
 

--- a/ts/packages/core/src/models/ToolRouter.ts
+++ b/ts/packages/core/src/models/ToolRouter.ts
@@ -45,6 +45,8 @@ import {
 } from '../lib/toolRouterParams';
 import { ToolRouterSession } from './ToolRouterSession';
 import {
+  assertNoCustomToolSlugsInPreload,
+  buildCustomToolsMap,
   buildCustomToolsMapFromResponse,
   getPreloadedCustomToolSlugs,
   serializeCustomTools,
@@ -111,6 +113,9 @@ export class ToolRouter<
    *   },
    * });
    *
+   * // Custom tools are searched by default. Set `preload: true` on a custom
+   * // tool or toolkit to expose it directly from `session.tools()`.
+   *
    * // Expose all tools allowed by filters directly, without meta/helper tools.
    * // `preload.tools = "all"` requires a positive filter such as `toolkits`.
    * const directSession = await composio.create('user_123', {
@@ -129,6 +134,12 @@ export class ToolRouter<
     // Extract custom tools/toolkits from experimental config
     const customTools = routerConfig.experimental?.customTools;
     const customToolkits = routerConfig.experimental?.customToolkits;
+    const defaultCustomPreload = routerConfig.preload?.tools === 'all';
+    const localCustomToolsMap =
+      customTools?.length || customToolkits?.length
+        ? buildCustomToolsMap(customTools ?? [], customToolkits)
+        : undefined;
+    assertNoCustomToolSlugsInPreload(routerConfig.preload?.tools, localCustomToolsMap);
 
     // Build the typed experimental payload for the backend
     const experimentalPayload: SessionCreateParams['experimental'] = {};
@@ -140,11 +151,22 @@ export class ToolRouter<
     }
 
     if (customTools?.length) {
-      experimentalPayload.custom_tools = serializeCustomTools(customTools);
+      experimentalPayload.custom_tools = serializeCustomTools(customTools, {
+        defaultPreload: defaultCustomPreload,
+      });
     }
     if (customToolkits?.length) {
-      experimentalPayload.custom_toolkits = serializeCustomToolkits(customToolkits);
+      experimentalPayload.custom_toolkits = serializeCustomToolkits(customToolkits, {
+        defaultPreload: defaultCustomPreload,
+      });
     }
+    const inlineCustomToolsPayload =
+      experimentalPayload.custom_tools || experimentalPayload.custom_toolkits
+        ? {
+            custom_tools: experimentalPayload.custom_tools,
+            custom_toolkits: experimentalPayload.custom_toolkits,
+          }
+        : undefined;
 
     const multiAccountPayload = transformToolRouterMultiAccountParams(routerConfig.multiAccount);
 
@@ -182,10 +204,8 @@ export class ToolRouter<
     }
     const metadata = {
       ...getSessionMetadata(session),
-      preloadedCustomToolSlugs: getPreloadedCustomToolSlugs(
-        session.tool_router_tools,
-        customToolsMap
-      ),
+      preloadedCustomToolSlugs: getPreloadedCustomToolSlugs(customToolsMap, defaultCustomPreload),
+      inlineCustomToolsPayload,
     };
 
     const assistivePrompt = session.experimental?.assistive_prompt;

--- a/ts/packages/core/src/models/ToolRouter.ts
+++ b/ts/packages/core/src/models/ToolRouter.ts
@@ -46,6 +46,7 @@ import {
 import { ToolRouterSession } from './ToolRouterSession';
 import {
   buildCustomToolsMapFromResponse,
+  getPreloadedCustomToolSlugs,
   serializeCustomTools,
   serializeCustomToolkits,
 } from './CustomTool';
@@ -109,6 +110,13 @@ export class ToolRouter<
    *     customToolkits: [myToolkit],
    *   },
    * });
+   *
+   * // Expose all tools allowed by filters directly, without meta/helper tools.
+   * // `preload.tools = "all"` requires a positive filter such as `toolkits`.
+   * const directSession = await composio.create('user_123', {
+   *   sessionPreset: 'direct_tools',
+   *   toolkits: ['github'],
+   * });
    * ```
    */
   async create(
@@ -116,6 +124,7 @@ export class ToolRouter<
     config?: ToolRouterCreateSessionConfig
   ): Promise<Session<TToolCollection, TTool, TProvider>> {
     const routerConfig = ToolRouterCreateSessionConfigSchema.parse(config ?? {});
+    const isDirectToolsPreset = routerConfig.sessionPreset === 'direct_tools';
 
     // Extract custom tools/toolkits from experimental config
     const customTools = routerConfig.experimental?.customTools;
@@ -152,6 +161,10 @@ export class ToolRouter<
       workbench: transformToolRouterWorkbenchParams(routerConfig.workbench),
       multi_account: multiAccountPayload,
       preload: routerConfig.preload,
+      ...(isDirectToolsPreset && {
+        search: { enable: false },
+        execute: { enable_multi_execute: false },
+      }),
       experimental: Object.keys(experimentalPayload).length > 0 ? experimentalPayload : undefined,
     };
 
@@ -167,6 +180,13 @@ export class ToolRouter<
         session.experimental
       );
     }
+    const metadata = {
+      ...getSessionMetadata(session),
+      preloadedCustomToolSlugs: getPreloadedCustomToolSlugs(
+        session.tool_router_tools,
+        customToolsMap
+      ),
+    };
 
     const assistivePrompt = session.experimental?.assistive_prompt;
 
@@ -178,7 +198,7 @@ export class ToolRouter<
       { assistivePrompt },
       customToolsMap,
       userId,
-      getSessionMetadata(session)
+      metadata
     );
   }
 

--- a/ts/packages/core/src/models/ToolRouterSession.ts
+++ b/ts/packages/core/src/models/ToolRouterSession.ts
@@ -39,7 +39,10 @@ import type {
 } from '../types/customTool.types';
 import type { Tool, ToolExecuteResponse } from '../types/tool.types';
 import type { SessionProxyExecuteParams } from '../types/toolRouter.types';
-import type { SessionExecuteParams } from '@composio/client/resources/tool-router/session/session.mjs';
+import type {
+  SessionExecuteParams,
+  SessionSearchParams,
+} from '@composio/client/resources/tool-router/session/session.mjs';
 import { SessionProxyExecuteParamsSchema } from '../types/toolRouter.types';
 import { SessionContextImpl } from './SessionContext';
 import { findCustomTool, executeCustomTool } from './customToolExecution';
@@ -62,6 +65,7 @@ export class ToolRouterSession<
   public readonly configVersion?: number;
   public readonly warnings: ToolRouterSessionWarning[];
   private readonly preloadedCustomToolSlugs: string[];
+  private readonly inlineCustomToolsPayload: ToolRouterSessionMetadata['inlineCustomToolsPayload'];
 
   /** Singleton session context — shared across all custom tool executions */
   private readonly sessionContext?: SessionContext;
@@ -89,6 +93,7 @@ export class ToolRouterSession<
     this.configVersion = metadata?.configVersion;
     this.warnings = metadata?.warnings ?? [];
     this.preloadedCustomToolSlugs = metadata?.preloadedCustomToolSlugs ?? [];
+    this.inlineCustomToolsPayload = metadata?.inlineCustomToolsPayload;
 
     // Create singleton session context if custom tools are bound
     if (customToolsMap && userId) {
@@ -354,10 +359,12 @@ export class ToolRouterSession<
     query: string;
     toolkits?: string[];
   }): Promise<ToolRouterSessionSearchResponse> {
-    const response = await this.client.toolRouter.session.search(this.sessionId, {
+    const searchParams: SessionSearchParams & { toolkits?: string[] } = {
       queries: [{ use_case: params.query }],
       ...(params.toolkits?.length ? { toolkits: params.toolkits } : {}),
-    });
+      ...(this.inlineCustomToolsPayload ? { experimental: this.inlineCustomToolsPayload } : {}),
+    };
+    const response = await this.client.toolRouter.session.search(this.sessionId, searchParams);
     const transformed = transformSearchResponse(response);
     return ToolRouterSessionSearchResponseSchema.parse(transformed);
   }
@@ -395,6 +402,7 @@ export class ToolRouterSession<
     const executeParams: SessionExecuteParams = {
       tool_slug: toolSlug,
       arguments: arguments_ ?? {},
+      ...(this.inlineCustomToolsPayload ? { experimental: this.inlineCustomToolsPayload } : {}),
     };
     if (options?.account) {
       executeParams.account = options.account;

--- a/ts/packages/core/src/models/ToolRouterSession.ts
+++ b/ts/packages/core/src/models/ToolRouterSession.ts
@@ -39,10 +39,7 @@ import type {
 } from '../types/customTool.types';
 import type { Tool, ToolExecuteResponse } from '../types/tool.types';
 import type { SessionProxyExecuteParams } from '../types/toolRouter.types';
-import type {
-  SessionExecuteParams,
-  SessionSearchParams,
-} from '@composio/client/resources/tool-router/session/session.mjs';
+import type { SessionExecuteParams } from '@composio/client/resources/tool-router/session/session.mjs';
 import { SessionProxyExecuteParamsSchema } from '../types/toolRouter.types';
 import { SessionContextImpl } from './SessionContext';
 import { findCustomTool, executeCustomTool } from './customToolExecution';
@@ -359,7 +356,7 @@ export class ToolRouterSession<
     query: string;
     toolkits?: string[];
   }): Promise<ToolRouterSessionSearchResponse> {
-    const searchParams: SessionSearchParams & { toolkits?: string[] } = {
+    const searchParams = {
       queries: [{ use_case: params.query }],
       ...(params.toolkits?.length ? { toolkits: params.toolkits } : {}),
       ...(this.inlineCustomToolsPayload ? { experimental: this.inlineCustomToolsPayload } : {}),
@@ -402,7 +399,6 @@ export class ToolRouterSession<
     const executeParams: SessionExecuteParams = {
       tool_slug: toolSlug,
       arguments: arguments_ ?? {},
-      ...(this.inlineCustomToolsPayload ? { experimental: this.inlineCustomToolsPayload } : {}),
     };
     if (options?.account) {
       executeParams.account = options.account;

--- a/ts/packages/core/src/models/ToolRouterSession.ts
+++ b/ts/packages/core/src/models/ToolRouterSession.ts
@@ -138,12 +138,12 @@ export class ToolRouterSession<
         if (customTool) {
           return executeCustomTool(customTool, input, this.sessionContext!);
         }
-        return ToolsModel.executeSessionTool(
+        return this.executeBackendSessionTool(
+          ToolsModel,
           toolSlug,
-          { sessionId: this.sessionId, arguments: input },
+          input,
           modifiers,
           toolBySlug.get(toolSlug.toUpperCase()),
-          { experimental: this.inlineExecuteExperimental() }
         );
       };
 
@@ -481,6 +481,21 @@ export class ToolRouterSession<
     return this.inlineCustomToolsPayload as SessionSearchParams.Experimental | undefined;
   }
 
+  private executeBackendSessionTool(
+    ToolsModel: Tools<TToolCollection, TTool, TProvider>,
+    toolSlug: string,
+    input: Record<string, unknown>,
+    modifiers?: SessionMetaToolOptions,
+    tool?: Tool
+  ): Promise<ToolExecuteResponse> {
+    const body = { sessionId: this.sessionId, arguments: input };
+    const experimental = this.inlineExecuteExperimental();
+    if (experimental) {
+      return ToolsModel.executeSessionTool(toolSlug, body, modifiers, tool, { experimental });
+    }
+    return ToolsModel.executeSessionTool(toolSlug, body, modifiers, tool);
+  }
+
   /** Parse an individual tool item from COMPOSIO_MULTI_EXECUTE_TOOL's tools array */
   private parseToolItem(item: unknown): { tool_slug: string; arguments: Record<string, unknown> } {
     if (typeof item !== 'object' || item === null) {
@@ -508,12 +523,12 @@ export class ToolRouterSession<
     const toolItems = input.tools as unknown[];
     if (!Array.isArray(toolItems) || toolItems.length === 0) {
       // Fallback: send to backend as-is
-      return ToolsModel.executeSessionTool(
+      return this.executeBackendSessionTool(
+        ToolsModel,
         COMPOSIO_MULTI_EXECUTE_TOOL,
-        { sessionId: this.sessionId, arguments: input },
+        input,
         modifiers,
-        multiExecuteTool,
-        { experimental: this.inlineExecuteExperimental() }
+        multiExecuteTool
       );
     }
 
@@ -533,12 +548,12 @@ export class ToolRouterSession<
 
     // All remote — just forward entire payload
     if (localItems.length === 0) {
-      return ToolsModel.executeSessionTool(
+      return this.executeBackendSessionTool(
+        ToolsModel,
         COMPOSIO_MULTI_EXECUTE_TOOL,
-        { sessionId: this.sessionId, arguments: input },
+        input,
         modifiers,
-        multiExecuteTool,
-        { experimental: this.inlineExecuteExperimental() }
+        multiExecuteTool
       );
     }
 
@@ -554,12 +569,12 @@ export class ToolRouterSession<
     if (remoteIndices.length > 0) {
       const remoteToolItems = remoteIndices.map(i => toolItems[i]);
       const remoteInput = { ...input, tools: remoteToolItems };
-      remotePromise = ToolsModel.executeSessionTool(
+      remotePromise = this.executeBackendSessionTool(
+        ToolsModel,
         COMPOSIO_MULTI_EXECUTE_TOOL,
-        { sessionId: this.sessionId, arguments: remoteInput },
+        remoteInput,
         modifiers,
-        multiExecuteTool,
-        { experimental: this.inlineExecuteExperimental() }
+        multiExecuteTool
       );
     }
 

--- a/ts/packages/core/src/models/ToolRouterSession.ts
+++ b/ts/packages/core/src/models/ToolRouterSession.ts
@@ -473,22 +473,12 @@ export class ToolRouterSession<
     return (this.customToolsMap?.byFinalSlug.size ?? 0) > 0;
   }
 
-  private withInlineCustomToolsExperimental<T extends object>(experimental?: T): T | undefined {
-    if (!this.inlineCustomToolsPayload) {
-      return experimental;
-    }
-    return {
-      ...(experimental ?? {}),
-      ...this.inlineCustomToolsPayload,
-    } as T;
-  }
-
   private inlineExecuteExperimental(): SessionExecuteParams.Experimental | undefined {
-    return this.withInlineCustomToolsExperimental<SessionExecuteParams.Experimental>();
+    return this.inlineCustomToolsPayload as SessionExecuteParams.Experimental | undefined;
   }
 
   private inlineSearchExperimental(): SessionSearchParams.Experimental | undefined {
-    return this.withInlineCustomToolsExperimental<SessionSearchParams.Experimental>();
+    return this.inlineCustomToolsPayload as SessionSearchParams.Experimental | undefined;
   }
 
   /** Parse an individual tool item from COMPOSIO_MULTI_EXECUTE_TOOL's tools array */

--- a/ts/packages/core/src/models/ToolRouterSession.ts
+++ b/ts/packages/core/src/models/ToolRouterSession.ts
@@ -43,9 +43,12 @@ import type { SessionExecuteParams } from '@composio/client/resources/tool-route
 import { SessionProxyExecuteParamsSchema } from '../types/toolRouter.types';
 import { SessionContextImpl } from './SessionContext';
 import { findCustomTool, executeCustomTool } from './customToolExecution';
+import { findCustomToolMapEntryByFinalSlug } from './CustomTool';
 import { transformProxyParams } from './proxyParamsTransform';
 
 const COMPOSIO_MULTI_EXECUTE_TOOL = 'COMPOSIO_MULTI_EXECUTE_TOOL';
+export const DIRECT_CUSTOM_TOOL_DESCRIPTION_PREFIX =
+  '[Direct tool - call directly, no search or connection check needed beforehand.]';
 
 export class ToolRouterSession<
   TToolCollection,
@@ -58,6 +61,7 @@ export class ToolRouterSession<
   public readonly preload: ToolRouterSessionPreloadConfig;
   public readonly configVersion?: number;
   public readonly warnings: ToolRouterSessionWarning[];
+  private readonly preloadedCustomToolSlugs: string[];
 
   /** Singleton session context — shared across all custom tool executions */
   private readonly sessionContext?: SessionContext;
@@ -84,6 +88,7 @@ export class ToolRouterSession<
     this.preload = metadata?.preload ?? { tools: [] };
     this.configVersion = metadata?.configVersion;
     this.warnings = metadata?.warnings ?? [];
+    this.preloadedCustomToolSlugs = metadata?.preloadedCustomToolSlugs ?? [];
 
     // Create singleton session context if custom tools are bound
     if (customToolsMap && userId) {
@@ -106,7 +111,8 @@ export class ToolRouterSession<
       this.sessionId,
       modifiers?.modifySchema ? { modifySchema: modifiers.modifySchema } : undefined
     );
-    const toolBySlug = new Map(tools.map(tool => [tool.slug.toUpperCase(), tool]));
+    const sessionTools = await this.addPreloadedCustomTools(tools, modifiers);
+    const toolBySlug = new Map(sessionTools.map(tool => [tool.slug.toUpperCase(), tool]));
 
     if (this.hasCustomTools()) {
       // Create an execute function that splits local/remote tools in COMPOSIO_MULTI_EXECUTE_TOOL
@@ -115,7 +121,7 @@ export class ToolRouterSession<
         input: Record<string, unknown>
       ): Promise<ToolExecuteResponse> => {
         if (toolSlug === COMPOSIO_MULTI_EXECUTE_TOOL) {
-          return this.routeMultiExecute(input, ToolsModel, tools, modifiers);
+          return this.routeMultiExecute(input, ToolsModel, sessionTools, modifiers);
         }
         return ToolsModel.executeSessionTool(
           toolSlug,
@@ -131,14 +137,82 @@ export class ToolRouterSession<
             'Pass a provider in the Composio constructor.'
         );
       }
-      return this.config.provider.wrapTools(tools, routingExecuteFn) as ReturnType<
+      return this.config.provider.wrapTools(sessionTools, routingExecuteFn) as ReturnType<
         TProvider['wrapTools']
       >;
     }
 
     // Standard path (no local tools)
-    const wrappedTools = ToolsModel.wrapToolsForToolRouter(this.sessionId, tools, modifiers);
+    const wrappedTools = ToolsModel.wrapToolsForToolRouter(this.sessionId, sessionTools, modifiers);
     return wrappedTools as ReturnType<TProvider['wrapTools']>;
+  }
+
+  private async addPreloadedCustomTools(
+    tools: Tool[],
+    modifiers?: SessionMetaToolOptions
+  ): Promise<Tool[]> {
+    const customTools = await this.getPreloadedCustomToolSchemas(modifiers);
+    if (!customTools.length) {
+      return tools;
+    }
+
+    const existingSlugs = new Set(tools.map(tool => tool.slug.toUpperCase()));
+    const appendedTools = customTools.filter(tool => !existingSlugs.has(tool.slug.toUpperCase()));
+    if (!appendedTools.length) {
+      return tools;
+    }
+
+    return [...tools, ...appendedTools];
+  }
+
+  private async getPreloadedCustomToolSchemas(modifiers?: SessionMetaToolOptions): Promise<Tool[]> {
+    if (!this.customToolsMap || !this.preloadedCustomToolSlugs.length) {
+      return [];
+    }
+
+    const tools: Tool[] = [];
+    for (const slug of this.preloadedCustomToolSlugs) {
+      const entry = findCustomToolMapEntryByFinalSlug(this.customToolsMap, slug);
+      if (!entry) {
+        continue;
+      }
+
+      let tool = this.customToolEntryToTool(entry);
+      if (modifiers?.modifySchema) {
+        tool = await modifiers.modifySchema({
+          toolSlug: tool.slug,
+          toolkitSlug: tool.toolkit?.slug ?? 'custom',
+          schema: tool,
+        });
+      }
+      tools.push(tool);
+    }
+    return tools;
+  }
+
+  private customToolEntryToTool(entry: CustomToolsMapEntry): Tool {
+    const toolkitSlug = entry.toolkit ?? 'custom';
+    const customToolkit = this.customToolsMap?.toolkits?.find(
+      toolkit => toolkit.slug.toLowerCase() === toolkitSlug.toLowerCase()
+    );
+    const toolkitName = customToolkit?.name ?? entry.toolkit ?? 'Custom';
+
+    return {
+      slug: entry.finalSlug,
+      name: entry.handle.name,
+      description: `${DIRECT_CUSTOM_TOOL_DESCRIPTION_PREFIX}\n${entry.handle.description}`,
+      inputParameters: entry.handle.inputSchema as Tool['inputParameters'],
+      outputParameters: entry.handle.outputSchema as Tool['outputParameters'],
+      tags: [],
+      toolkit: {
+        slug: toolkitSlug,
+        name: toolkitName,
+      },
+      isDeprecated: false,
+      availableVersions: [],
+      scopes: [],
+      isNoAuth: !entry.handle.extendsToolkit,
+    };
   }
 
   /**

--- a/ts/packages/core/src/models/ToolRouterSession.ts
+++ b/ts/packages/core/src/models/ToolRouterSession.ts
@@ -48,6 +48,7 @@ import { SessionContextImpl } from './SessionContext';
 import { findCustomTool, executeCustomTool } from './customToolExecution';
 import { findCustomToolMapEntryByFinalSlug } from './CustomTool';
 import { transformProxyParams } from './proxyParamsTransform';
+import { inlineCustomToolsExperimental } from './inlineCustomToolsPayload';
 
 const COMPOSIO_MULTI_EXECUTE_TOOL = 'COMPOSIO_MULTI_EXECUTE_TOOL';
 export const DIRECT_CUSTOM_TOOL_DESCRIPTION_PREFIX =
@@ -370,7 +371,9 @@ export class ToolRouterSession<
     query: string;
     toolkits?: string[];
   }): Promise<ToolRouterSessionSearchResponse> {
-    const experimental = this.inlineSearchExperimental();
+    const experimental = inlineCustomToolsExperimental<SessionSearchParams.Experimental>(
+      this.inlineCustomToolsPayload
+    );
     const searchParams = {
       queries: [{ use_case: params.query }],
       ...(params.toolkits?.length ? { toolkits: params.toolkits } : {}),
@@ -418,7 +421,9 @@ export class ToolRouterSession<
     if (options?.account) {
       executeParams.account = options.account;
     }
-    const experimental = this.inlineExecuteExperimental();
+    const experimental = inlineCustomToolsExperimental<SessionExecuteParams.Experimental>(
+      this.inlineCustomToolsPayload
+    );
     if (experimental) {
       executeParams.experimental = experimental;
     }
@@ -473,14 +478,6 @@ export class ToolRouterSession<
     return (this.customToolsMap?.byFinalSlug.size ?? 0) > 0;
   }
 
-  private inlineExecuteExperimental(): SessionExecuteParams.Experimental | undefined {
-    return this.inlineCustomToolsPayload as SessionExecuteParams.Experimental | undefined;
-  }
-
-  private inlineSearchExperimental(): SessionSearchParams.Experimental | undefined {
-    return this.inlineCustomToolsPayload as SessionSearchParams.Experimental | undefined;
-  }
-
   private executeBackendSessionTool(
     ToolsModel: Tools<TToolCollection, TTool, TProvider>,
     toolSlug: string,
@@ -489,7 +486,9 @@ export class ToolRouterSession<
     tool?: Tool
   ): Promise<ToolExecuteResponse> {
     const body = { sessionId: this.sessionId, arguments: input };
-    const experimental = this.inlineExecuteExperimental();
+    const experimental = inlineCustomToolsExperimental<SessionExecuteParams.Experimental>(
+      this.inlineCustomToolsPayload
+    );
     if (experimental) {
       return ToolsModel.executeSessionTool(toolSlug, body, modifiers, tool, { experimental });
     }

--- a/ts/packages/core/src/models/ToolRouterSession.ts
+++ b/ts/packages/core/src/models/ToolRouterSession.ts
@@ -125,6 +125,10 @@ export class ToolRouterSession<
         if (toolSlug === COMPOSIO_MULTI_EXECUTE_TOOL) {
           return this.routeMultiExecute(input, ToolsModel, sessionTools, modifiers);
         }
+        const customTool = findCustomTool(this.customToolsMap, toolSlug);
+        if (customTool) {
+          return executeCustomTool(customTool, input, this.sessionContext!);
+        }
         return ToolsModel.executeSessionTool(
           toolSlug,
           { sessionId: this.sessionId, arguments: input },

--- a/ts/packages/core/src/models/ToolRouterSession.ts
+++ b/ts/packages/core/src/models/ToolRouterSession.ts
@@ -39,7 +39,10 @@ import type {
 } from '../types/customTool.types';
 import type { Tool, ToolExecuteResponse } from '../types/tool.types';
 import type { SessionProxyExecuteParams } from '../types/toolRouter.types';
-import type { SessionExecuteParams } from '@composio/client/resources/tool-router/session/session.mjs';
+import type {
+  SessionExecuteParams,
+  SessionSearchParams,
+} from '@composio/client/resources/tool-router/session/session.mjs';
 import { SessionProxyExecuteParamsSchema } from '../types/toolRouter.types';
 import { SessionContextImpl } from './SessionContext';
 import { findCustomTool, executeCustomTool } from './customToolExecution';
@@ -94,7 +97,13 @@ export class ToolRouterSession<
 
     // Create singleton session context if custom tools are bound
     if (customToolsMap && userId) {
-      this.sessionContext = new SessionContextImpl(client, userId, sessionId, customToolsMap);
+      this.sessionContext = new SessionContextImpl(
+        client,
+        userId,
+        sessionId,
+        customToolsMap,
+        this.inlineCustomToolsPayload
+      );
     }
 
     telemetry.instrument(this, 'ToolRouterSession');
@@ -133,7 +142,8 @@ export class ToolRouterSession<
           toolSlug,
           { sessionId: this.sessionId, arguments: input },
           modifiers,
-          toolBySlug.get(toolSlug.toUpperCase())
+          toolBySlug.get(toolSlug.toUpperCase()),
+          { experimental: this.inlineExecuteExperimental() }
         );
       };
 
@@ -360,10 +370,11 @@ export class ToolRouterSession<
     query: string;
     toolkits?: string[];
   }): Promise<ToolRouterSessionSearchResponse> {
+    const experimental = this.inlineSearchExperimental();
     const searchParams = {
       queries: [{ use_case: params.query }],
       ...(params.toolkits?.length ? { toolkits: params.toolkits } : {}),
-      ...(this.inlineCustomToolsPayload ? { experimental: this.inlineCustomToolsPayload } : {}),
+      ...(experimental ? { experimental } : {}),
     };
     const response = await this.client.toolRouter.session.search(this.sessionId, searchParams);
     const transformed = transformSearchResponse(response);
@@ -406,6 +417,10 @@ export class ToolRouterSession<
     };
     if (options?.account) {
       executeParams.account = options.account;
+    }
+    const experimental = this.inlineExecuteExperimental();
+    if (experimental) {
+      executeParams.experimental = experimental;
     }
 
     const response = await this.client.toolRouter.session.execute(this.sessionId, executeParams);
@@ -458,6 +473,24 @@ export class ToolRouterSession<
     return (this.customToolsMap?.byFinalSlug.size ?? 0) > 0;
   }
 
+  private withInlineCustomToolsExperimental<T extends object>(experimental?: T): T | undefined {
+    if (!this.inlineCustomToolsPayload) {
+      return experimental;
+    }
+    return {
+      ...(experimental ?? {}),
+      ...this.inlineCustomToolsPayload,
+    } as T;
+  }
+
+  private inlineExecuteExperimental(): SessionExecuteParams.Experimental | undefined {
+    return this.withInlineCustomToolsExperimental<SessionExecuteParams.Experimental>();
+  }
+
+  private inlineSearchExperimental(): SessionSearchParams.Experimental | undefined {
+    return this.withInlineCustomToolsExperimental<SessionSearchParams.Experimental>();
+  }
+
   /** Parse an individual tool item from COMPOSIO_MULTI_EXECUTE_TOOL's tools array */
   private parseToolItem(item: unknown): { tool_slug: string; arguments: Record<string, unknown> } {
     if (typeof item !== 'object' || item === null) {
@@ -489,7 +522,8 @@ export class ToolRouterSession<
         COMPOSIO_MULTI_EXECUTE_TOOL,
         { sessionId: this.sessionId, arguments: input },
         modifiers,
-        multiExecuteTool
+        multiExecuteTool,
+        { experimental: this.inlineExecuteExperimental() }
       );
     }
 
@@ -513,7 +547,8 @@ export class ToolRouterSession<
         COMPOSIO_MULTI_EXECUTE_TOOL,
         { sessionId: this.sessionId, arguments: input },
         modifiers,
-        multiExecuteTool
+        multiExecuteTool,
+        { experimental: this.inlineExecuteExperimental() }
       );
     }
 
@@ -533,7 +568,8 @@ export class ToolRouterSession<
         COMPOSIO_MULTI_EXECUTE_TOOL,
         { sessionId: this.sessionId, arguments: remoteInput },
         modifiers,
-        multiExecuteTool
+        multiExecuteTool,
+        { experimental: this.inlineExecuteExperimental() }
       );
     }
 

--- a/ts/packages/core/src/models/Tools.ts
+++ b/ts/packages/core/src/models/Tools.ts
@@ -54,12 +54,16 @@ import { telemetry } from '../telemetry/Telemetry';
 import { ComposioConfig } from '../composio';
 import { getToolkitVersion } from '../utils/toolkitVersion';
 import { handleToolExecutionError } from '../errors/ToolErrors';
-import type { SessionExecuteParams } from '@composio/client/resources/tool-router.mjs';
+import type { SessionExecuteParams } from '@composio/client/resources/tool-router/session/session.mjs';
 import { CONFIG_DEFAULTS } from '../utils/config-defaults';
 import { resolveEffectiveUploadAllowlist } from '../utils/fileDirs';
 import { schemaHasFileUploadable } from '../utils/modifiers/FileToolModifier.utils.neutral';
 
 const TOOL_ROUTER_SESSION_TOOLS_PAGE_LIMIT = 500;
+
+type ToolRouterSessionExecuteOptions = {
+  experimental?: SessionExecuteParams.Experimental;
+};
 
 /**
  * This class is used to manage tools in the Composio SDK.
@@ -1028,7 +1032,8 @@ export class Tools<
     toolSlug: string,
     body: ToolExecuteMetaParams,
     modifiers?: SessionExecuteMetaModifiers,
-    tool?: Tool
+    tool?: Tool,
+    options?: ToolRouterSessionExecuteOptions
   ): Promise<ToolExecuteResponse> {
     const executeParams = ToolExecuteMetaParamsSchema.safeParse(body);
     if (!executeParams.success) {
@@ -1056,6 +1061,9 @@ export class Tools<
       // direct tool offload when the backend session workbench allows it.
       enable_auto_workbench_offload: true,
     };
+    if (options?.experimental) {
+      executePayload.experimental = options.experimental;
+    }
 
     const response = await this.client.toolRouter.session.execute(body.sessionId, executePayload);
 

--- a/ts/packages/core/src/models/inlineCustomToolsPayload.ts
+++ b/ts/packages/core/src/models/inlineCustomToolsPayload.ts
@@ -1,0 +1,17 @@
+import type {
+  SessionExecuteParams,
+  SessionSearchParams,
+} from '@composio/client/resources/tool-router/session/session.mjs';
+import type { InlineCustomToolsWirePayload } from '../types/customTool.types';
+
+type InlineCustomToolsExperimental =
+  | SessionExecuteParams.Experimental
+  | SessionSearchParams.Experimental;
+
+export function inlineCustomToolsExperimental<TExperimental extends InlineCustomToolsExperimental>(
+  payload?: InlineCustomToolsWirePayload
+): TExperimental | undefined {
+  // The SDK wire payload is a structural subset of Stainless' endpoint-specific
+  // experimental payloads, with input-only preload hints on custom definitions.
+  return payload as TExperimental | undefined;
+}

--- a/ts/packages/core/src/types/customTool.types.ts
+++ b/ts/packages/core/src/types/customTool.types.ts
@@ -135,6 +135,12 @@ export const CreateCustomToolBaseSchema = z.object({
    * Leave empty for tools that don't need any Composio-managed authentication.
    */
   extendsToolkit: z.string().optional(),
+  preload: z
+    .boolean()
+    .optional()
+    .describe(
+      'When true, expose this custom tool directly from session.tools(). This is SDK-local for custom tools and is sent to v3.1 as an input-only hint.'
+    ),
 });
 
 /** Options for creating a custom tool via `createCustomTool()`. */
@@ -163,6 +169,11 @@ export interface CustomTool {
    * Undefined means the tool doesn't need any Composio-managed authentication.
    */
   readonly extendsToolkit?: string;
+  /**
+   * Whether this custom tool should be exposed directly from session.tools().
+   * This is SDK-local for custom tools and is sent to v3.1 as an input-only hint.
+   */
+  readonly preload?: boolean;
   readonly inputSchema: Record<string, unknown>;
   /** JSON Schema representation of the output (for backend documentation) */
   readonly outputSchema?: Record<string, unknown>;
@@ -175,6 +186,10 @@ export interface CustomTool {
 /** Serialized tool definition sent to backend for search indexing. Uses official client type. */
 export type CustomToolDefinition = SessionCreateParams.Experimental.CustomTool;
 
+export type CustomToolWireDefinition = CustomToolDefinition & {
+  preload?: boolean;
+};
+
 // ────────────────────────────────────────────────────────────────
 // Custom toolkit types
 // ────────────────────────────────────────────────────────────────
@@ -186,6 +201,12 @@ export type CustomToolDefinition = SessionCreateParams.Experimental.CustomTool;
 export const CreateCustomToolkitBaseSchema = z.object({
   name: z.string().min(1, 'createCustomToolkit: name is required'),
   description: z.string().min(1, 'createCustomToolkit: description is required'),
+  preload: z
+    .boolean()
+    .optional()
+    .describe(
+      'When true, expose tools in this custom toolkit directly from session.tools(). Tool-level preload values override this default.'
+    ),
 });
 
 /** Options for creating a custom toolkit via `createCustomToolkit()`. */
@@ -202,11 +223,26 @@ export interface CustomToolkit {
   readonly slug: string;
   readonly name: string;
   readonly description: string;
+  /**
+   * Default direct-exposure setting for tools in this custom toolkit.
+   * Tool-level preload values override this default.
+   */
+  readonly preload?: boolean;
   readonly tools: readonly CustomTool[];
 }
 
 /** Serialized toolkit definition sent to backend. Uses official client type. */
 export type CustomToolkitDefinition = SessionCreateParams.Experimental.CustomToolkit;
+
+export type CustomToolkitWireDefinition = Omit<CustomToolkitDefinition, 'tools'> & {
+  preload?: boolean;
+  tools: Array<CustomToolkitDefinition['tools'][number] & { preload?: boolean }>;
+};
+
+export interface InlineCustomToolsWirePayload {
+  custom_tools?: CustomToolWireDefinition[];
+  custom_toolkits?: CustomToolkitWireDefinition[];
+}
 
 // ────────────────────────────────────────────────────────────────
 // Internal routing types

--- a/ts/packages/core/src/types/customTool.types.ts
+++ b/ts/packages/core/src/types/customTool.types.ts
@@ -139,7 +139,7 @@ export const CreateCustomToolBaseSchema = z.object({
     .boolean()
     .optional()
     .describe(
-      'When true, expose this custom tool directly from session.tools(). This is SDK-local for custom tools and is sent to v3.1 as an input-only hint.'
+      'When true, expose this custom tool directly from session.tools(). This is SDK-local for custom tools and is sent to v3.1 with the inline custom definition.'
     ),
 });
 
@@ -171,7 +171,8 @@ export interface CustomTool {
   readonly extendsToolkit?: string;
   /**
    * Whether this custom tool should be exposed directly from session.tools().
-   * This is SDK-local for custom tools and is sent to v3.1 as an input-only hint.
+   * This is SDK-local for custom tools and is sent to v3.1 with the inline
+   * custom definition.
    */
   readonly preload?: boolean;
   readonly inputSchema: Record<string, unknown>;

--- a/ts/packages/core/src/types/toolRouter.types.ts
+++ b/ts/packages/core/src/types/toolRouter.types.ts
@@ -7,6 +7,7 @@ import type { SessionCreateResponse } from '@composio/client/resources/tool-rout
 import type {
   CustomTool,
   CustomToolkit,
+  InlineCustomToolsWirePayload,
   RegisteredCustomTool,
   RegisteredCustomToolkit,
 } from './customTool.types';
@@ -575,6 +576,7 @@ export interface ToolRouterSessionMetadata {
   configVersion?: number;
   warnings?: ToolRouterSessionWarning[];
   preloadedCustomToolSlugs?: string[];
+  inlineCustomToolsPayload?: InlineCustomToolsWirePayload;
 }
 
 export const SessionProxyExecuteParamsSchema = z.object({

--- a/ts/packages/core/src/types/toolRouter.types.ts
+++ b/ts/packages/core/src/types/toolRouter.types.ts
@@ -169,8 +169,15 @@ export const ToolRouterConfigToolsSchema = z
   });
 export type ToolRouterConfigTools = z.infer<typeof ToolRouterConfigToolsSchema>;
 
-export const ToolRouterCreateSessionConfigSchema = z
+const ToolRouterCreateSessionConfigBaseSchema = z
   .object({
+    sessionPreset: z
+      .literal('direct_tools')
+      .optional()
+      .describe(
+        'Shortcut to expose every tool allowed by the session filters directly in session.tools() and the MCP tool list. This disables meta tools by default (search, multi-execute, manage-connections, and workbench). Use when all tools are known upfront and helper/meta tools are not needed. Without this preset, ToolRouter uses its default configuration with meta tools enabled.'
+      ),
+
     tools: z
       .record(z.string(), z.union([ToolRouterToolsParamSchema, ToolRouterConfigToolsSchema]))
       .optional()
@@ -225,7 +232,7 @@ export const ToolRouterCreateSessionConfigSchema = z
             'The auto offload threshold in characters for the tool execution to be moved into workbench'
           ),
         sandboxSize: SandboxSizeSchema.optional().describe(
-          'Sandbox compute tier for the workbench. One of "standard" (1 vCPU / 1 GB), "medium" (2 vCPU / 2 GB), "large" (4 vCPU / 4 GB), or "xlarge" (8 vCPU / 8 GB). Defaults to "standard" server-side. Changing this on an existing session recreates the sandbox on next access; the session\'s in-memory FS is lost, but /mnt/files/ persists.'
+          'Sandbox compute tier for the workbench. One of "standard" (1 vCPU / 1 GB), "medium" (2 vCPU / 2 GB), "large" (4 vCPU / 4 GB), or "xlarge" (8 vCPU / 8 GB). Defaults to "standard" server-side. Changing this on an existing session recreates the session\'s workbench sandbox on next access; the in-memory FS is lost, but /mnt/files/ persists.'
         ),
       })
       .optional()
@@ -258,10 +265,10 @@ export const ToolRouterCreateSessionConfigSchema = z
     preload: z
       .object({
         tools: z
-          .array(z.string())
+          .union([z.array(z.string()), z.literal('all')])
           .optional()
           .describe(
-            'Tool slugs to preload into session.tools() and the MCP tool list. The backend validates slugs against the session filters.'
+            'Tool slugs to preload into session.tools() and the MCP tool list, or "all" to preload every app tool allowed by the session filters. "all" requires a positive filter such as toolkits, tools, or tags; the backend validates and caps the final tool set.'
           ),
       })
       .strict()
@@ -299,9 +306,32 @@ export const ToolRouterCreateSessionConfigSchema = z
   })
   .partial()
   .describe('The config for the tool router session');
+
+const applyDirectToolsPresetDefaults = (value: unknown): unknown => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return value;
+  }
+
+  const config = value as Record<string, unknown>;
+  if (config.sessionPreset !== 'direct_tools') {
+    return value;
+  }
+
+  return {
+    ...config,
+    manageConnections: config.manageConnections === undefined ? false : config.manageConnections,
+    workbench: config.workbench === undefined ? { enable: false } : config.workbench,
+    preload: config.preload === undefined ? { tools: 'all' } : config.preload,
+  };
+};
+
+export const ToolRouterCreateSessionConfigSchema = z
+  .preprocess(applyDirectToolsPresetDefaults, ToolRouterCreateSessionConfigBaseSchema)
+  .describe('The config for the tool router session');
 /**
  * The config for the tool router session.
  *
+ * @param {'direct_tools'} [sessionPreset] - Shortcut that exposes every tool allowed by the session filters directly in session.tools() and the MCP tool list. Disables search, multi-execute, manage-connections, and workbench by default; explicit overrides for supported fields still win. Without this preset, ToolRouter uses the default configuration with meta tools enabled.
  * @param {ToolRouterToolkitsParamSchema | ToolRouterToolkitsDisabledConfigSchema | ToolRouterToolkitsEnabledConfigSchema} toolkits - The toolkits to use in the tool router session
  * @param {Record<string, ToolRouterToolsParam | ToolRouterConfigTools>} tools - The tools to configure per toolkit (key is toolkit slug)
  * @param {Array<'readOnlyHint' | 'destructiveHint' | 'idempotentHint' | 'openWorldHint'>} tags - Global tags to filter tools by behavior
@@ -320,7 +350,7 @@ export const ToolRouterCreateSessionConfigSchema = z
  * @param {number} [multiAccount.maxAccountsPerToolkit] - Max connected accounts per toolkit (2-10, default 5)
  * @param {boolean} [multiAccount.requireExplicitSelection] - When true, require explicit account selection when multiple accounts are connected
  * @param {object} [preload] - Tools to preload into session.tools() and the MCP tool list
- * @param {string[]} [preload.tools] - Tool slugs to preload. Server-side validation ensures they exist and are allowed by the session filters.
+ * @param {string[] | 'all'} [preload.tools] - Tool slugs to preload, or "all" to preload every app tool allowed by the session filters. "all" requires a positive filter such as toolkits, tools, or tags; the backend validates and caps the final tool set.
  */
 export type ToolRouterCreateSessionConfig = z.infer<typeof ToolRouterCreateSessionConfigSchema>;
 
@@ -544,6 +574,7 @@ export interface ToolRouterSessionMetadata {
   preload?: ToolRouterSessionPreloadConfig;
   configVersion?: number;
   warnings?: ToolRouterSessionWarning[];
+  preloadedCustomToolSlugs?: string[];
 }
 
 export const SessionProxyExecuteParamsSchema = z.object({

--- a/ts/packages/core/test/models/customTool.test.ts
+++ b/ts/packages/core/test/models/customTool.test.ts
@@ -570,6 +570,34 @@ describe('SessionContextImpl', () => {
     });
   });
 
+  it('should pass inline custom tools when delegating execute() to backend', async () => {
+    mockClient.toolRouter.session.execute.mockResolvedValue({
+      data: { result: 'ok' },
+      error: null,
+      log_id: 'log_1',
+    });
+
+    const ctx = new SessionContextImpl(mockClient as any, 'user_1', 'sess_1', undefined, {
+      custom_tools: [
+        {
+          slug: 'GREP',
+          name: 'Grep',
+          description: 'Search local text',
+          input_schema: { type: 'object', properties: {} },
+        },
+      ],
+    });
+    await ctx.execute('GMAIL_SEND_EMAIL', { to: 'test@test.com' });
+
+    expect(mockClient.toolRouter.session.execute).toHaveBeenCalledWith('sess_1', {
+      tool_slug: 'GMAIL_SEND_EMAIL',
+      arguments: { to: 'test@test.com' },
+      experimental: {
+        custom_tools: [expect.objectContaining({ slug: 'GREP' })],
+      },
+    });
+  });
+
   it('should preserve logId and error when execute() returns an error', async () => {
     mockClient.toolRouter.session.execute.mockResolvedValue({
       data: {},

--- a/ts/packages/core/test/models/customToolRouting.test.ts
+++ b/ts/packages/core/test/models/customToolRouting.test.ts
@@ -166,6 +166,25 @@ describe('ToolRouter.create() with customTools', () => {
     expect(payload.experimental.custom_tools[0].extends_toolkit).toBe('meta_ads');
   });
 
+  it('should send custom tool preload hints under experimental', async () => {
+    const preloadedTool = createCustomTool('PINNED_CONTEXT', {
+      name: 'Pinned context',
+      description: 'Retrieve pinned user context',
+      preload: true,
+      inputParams: z.object({}),
+      execute: localExecute,
+    });
+
+    await router.create('user_1', {
+      experimental: {
+        customTools: [preloadedTool],
+      },
+    });
+
+    const payload = mockClient.toolRouter.session.create.mock.calls[0][0];
+    expect(payload.experimental.custom_tools[0].preload).toBe(true);
+  });
+
   it('should not send experimental.custom_tools when customTools is omitted or empty', async () => {
     await router.create('user_1', { toolkits: ['gmail'] });
     const payload1 = mockClient.toolRouter.session.create.mock.calls[0][0];

--- a/ts/packages/core/test/models/customToolRouting.test.ts
+++ b/ts/packages/core/test/models/customToolRouting.test.ts
@@ -185,6 +185,25 @@ describe('ToolRouter.create() with customTools', () => {
     expect(payload.experimental.custom_tools[0].preload).toBe(true);
   });
 
+  it('should omit redundant custom tool preload false', async () => {
+    const searchOnlyTool = createCustomTool('SEARCH_ONLY_CONTEXT', {
+      name: 'Search-only context',
+      description: 'Retrieve context through search',
+      preload: false,
+      inputParams: z.object({}),
+      execute: localExecute,
+    });
+
+    await router.create('user_1', {
+      experimental: {
+        customTools: [searchOnlyTool],
+      },
+    });
+
+    const payload = mockClient.toolRouter.session.create.mock.calls[0][0];
+    expect(payload.experimental.custom_tools[0]).not.toHaveProperty('preload');
+  });
+
   it('should not send experimental.custom_tools when customTools is omitted or empty', async () => {
     await router.create('user_1', { toolkits: ['gmail'] });
     const payload1 = mockClient.toolRouter.session.create.mock.calls[0][0];

--- a/ts/packages/core/test/models/toolRouter.test.ts
+++ b/ts/packages/core/test/models/toolRouter.test.ts
@@ -2253,7 +2253,6 @@ describe('ToolRouter', () => {
               preload: true,
             }),
           ],
-          custom_toolkits: undefined,
         },
       });
     });

--- a/ts/packages/core/test/models/toolRouter.test.ts
+++ b/ts/packages/core/test/models/toolRouter.test.ts
@@ -296,6 +296,23 @@ describe('ToolRouter', () => {
         expect(session.preload.tools).toBe('all');
       });
 
+      it('should reject custom tool slugs in top-level preload', async () => {
+        const grepTool = createCustomTool('GREP', {
+          name: 'Grep',
+          description: 'Search local text',
+          inputParams: z.object({ pattern: z.string() }),
+          execute: vi.fn(async () => ({ matches: [] })),
+        });
+
+        await expect(
+          toolRouter.create(userId, {
+            preload: { tools: ['GREP'] },
+            experimental: { customTools: [grepTool] },
+          })
+        ).rejects.toThrow('Set preload: true on the SDK custom tool');
+        expect(mockClient.toolRouter.session.create).not.toHaveBeenCalled();
+      });
+
       it('should apply the direct_tools session preset defaults', async () => {
         mockClient.toolRouter.session.create.mockResolvedValueOnce({
           ...mockSessionCreateResponse,
@@ -363,6 +380,42 @@ describe('ToolRouter', () => {
           experimental: undefined,
         });
         expect(session.preload.tools).toEqual(['GITHUB_CREATE_ISSUE']);
+      });
+
+      it('should not apply direct_tools custom preload default when preload is explicitly overridden', async () => {
+        const grepTool = createCustomTool('GREP', {
+          name: 'Grep',
+          description: 'Search local text',
+          inputParams: z.object({ pattern: z.string() }),
+          execute: vi.fn(async () => ({ matches: [] })),
+        });
+
+        mockClient.toolRouter.session.create.mockResolvedValueOnce({
+          ...mockSessionCreateResponse,
+          config: {
+            preload: { tools: ['GITHUB_CREATE_ISSUE'] },
+          },
+          experimental: {
+            custom_tools: [
+              {
+                slug: 'SERVER_GREP',
+                original_slug: 'GREP',
+                extends_toolkit: null,
+              },
+            ],
+          },
+        });
+
+        await toolRouter.create(userId, {
+          sessionPreset: 'direct_tools',
+          toolkits: ['github'],
+          preload: { tools: ['GITHUB_CREATE_ISSUE'] },
+          experimental: { customTools: [grepTool] },
+        });
+
+        const payload = mockClient.toolRouter.session.create.mock.calls[0][0];
+        expect(payload.preload).toEqual({ tools: ['GITHUB_CREATE_ISSUE'] });
+        expect(payload.experimental?.custom_tools?.[0]).not.toHaveProperty('preload');
       });
 
       it('should create a session with user ID only and verify MCP type transformation', async () => {
@@ -2164,6 +2217,47 @@ describe('ToolRouter', () => {
       });
     });
 
+    it('should pass inline custom tools to search', async () => {
+      const grepTool = createCustomTool('GREP', {
+        name: 'Grep',
+        description: 'Search local text',
+        preload: true,
+        inputParams: z.object({ pattern: z.string() }),
+        execute: vi.fn(async () => ({ matches: [] })),
+      });
+      mockClient.toolRouter.session.create.mockResolvedValueOnce({
+        ...mockSessionCreateResponse,
+        experimental: {
+          custom_tools: [
+            {
+              slug: 'LOCAL_GREP',
+              original_slug: 'GREP',
+              extends_toolkit: null,
+            },
+          ],
+        },
+      });
+      mockClient.toolRouter.session.search.mockResolvedValueOnce(mockSearchResponse);
+
+      const session = await toolRouter.create(userId, {
+        experimental: { customTools: [grepTool] },
+      });
+      await session.search({ query: 'search local text' });
+
+      expect(mockClient.toolRouter.session.search).toHaveBeenCalledWith(sessionId, {
+        queries: [{ use_case: 'search local text' }],
+        experimental: {
+          custom_tools: [
+            expect.objectContaining({
+              slug: 'GREP',
+              preload: true,
+            }),
+          ],
+          custom_toolkits: undefined,
+        },
+      });
+    });
+
     it('should propagate search API errors', async () => {
       mockClient.toolRouter.session.create.mockResolvedValueOnce(mockSessionCreateResponse);
       mockClient.toolRouter.session.search.mockRejectedValueOnce(new Error('Search failed'));
@@ -2343,10 +2437,11 @@ describe('ToolRouter', () => {
       expect(tools).toBe('mocked-wrapped-tools');
     });
 
-    it('should include preloaded custom tools selected by the create response', async () => {
+    it('should include custom tools with preload enabled locally', async () => {
       const grepTool = createCustomTool('GREP', {
         name: 'Grep',
         description: 'Search local text',
+        preload: true,
         inputParams: z.object({
           pattern: z.string().describe('Pattern to search for'),
         }),
@@ -2355,7 +2450,7 @@ describe('ToolRouter', () => {
 
       mockClient.toolRouter.session.create.mockResolvedValueOnce({
         ...mockSessionCreateResponse,
-        tool_router_tools: ['COMPOSIO_SEARCH_TOOLS', 'server_grep'],
+        tool_router_tools: ['COMPOSIO_SEARCH_TOOLS'],
         experimental: {
           custom_tools: [
             {
@@ -2385,7 +2480,41 @@ describe('ToolRouter', () => {
       expect(tools).toBe('mocked-custom-tools');
     });
 
-    it('should not expose custom tools unless the backend preloaded them', async () => {
+    it('should not expose custom tools unless SDK preload selects them', async () => {
+      const grepTool = createCustomTool('GREP', {
+        name: 'Grep',
+        description: 'Search local text',
+        inputParams: z.object({
+          pattern: z.string(),
+        }),
+        execute: vi.fn(async () => ({ matches: [] })),
+      });
+
+      mockClient.toolRouter.session.create.mockResolvedValueOnce({
+        ...mockSessionCreateResponse,
+        tool_router_tools: ['COMPOSIO_SEARCH_TOOLS'],
+        experimental: {
+          custom_tools: [
+            {
+              slug: 'LOCAL_GREP',
+              original_slug: 'GREP',
+              extends_toolkit: null,
+            },
+          ],
+        },
+      });
+      mockProvider.wrapTools.mockReturnValue('mocked-custom-tools');
+
+      const session = await toolRouter.create(userId, {
+        experimental: { customTools: [grepTool] },
+      });
+      await session.tools();
+
+      const wrappedTools = mockProvider.wrapTools.mock.calls[0][0] as Array<{ slug: string }>;
+      expect(wrappedTools.map(tool => tool.slug)).toEqual(['COMPOSIO_SEARCH_TOOLS']);
+    });
+
+    it('should expose custom tools by default for preload all', async () => {
       const grepTool = createCustomTool('GREP', {
         name: 'Grep',
         description: 'Search local text',
@@ -2417,7 +2546,7 @@ describe('ToolRouter', () => {
       await session.tools();
 
       const wrappedTools = mockProvider.wrapTools.mock.calls[0][0] as Array<{ slug: string }>;
-      expect(wrappedTools.map(tool => tool.slug)).toEqual(['COMPOSIO_SEARCH_TOOLS']);
+      expect(wrappedTools.map(tool => tool.slug)).toEqual(['COMPOSIO_SEARCH_TOOLS', 'LOCAL_GREP']);
     });
 
     it('should handle tools fetching errors', async () => {

--- a/ts/packages/core/test/models/toolRouter.test.ts
+++ b/ts/packages/core/test/models/toolRouter.test.ts
@@ -2332,6 +2332,41 @@ describe('ToolRouter', () => {
         account: 'work',
       });
     });
+
+    it('should pass inline custom tools to remote execute when custom tools are bound', async () => {
+      const grepTool = createCustomTool('GREP', {
+        name: 'Grep',
+        description: 'Search local text',
+        inputParams: z.object({ pattern: z.string() }),
+        execute: vi.fn(async () => ({ matches: [] })),
+      });
+      mockClient.toolRouter.session.create.mockResolvedValueOnce({
+        ...mockSessionCreateResponse,
+        experimental: {
+          custom_tools: [
+            {
+              slug: 'LOCAL_GREP',
+              original_slug: 'GREP',
+              extends_toolkit: null,
+            },
+          ],
+        },
+      });
+      mockClient.toolRouter.session.execute.mockResolvedValueOnce(mockExecuteResponse);
+
+      const session = await toolRouter.create(userId, {
+        experimental: { customTools: [grepTool] },
+      });
+      await session.execute('GMAIL_SEND_EMAIL', { to: 'user@example.com' });
+
+      expect(mockClient.toolRouter.session.execute).toHaveBeenCalledWith(sessionId, {
+        tool_slug: 'GMAIL_SEND_EMAIL',
+        arguments: { to: 'user@example.com' },
+        experimental: {
+          custom_tools: [expect.objectContaining({ slug: 'GREP' })],
+        },
+      });
+    });
   });
 
   describe('tools function', () => {
@@ -2493,6 +2528,121 @@ describe('ToolRouter', () => {
       });
       expect(executeGrep).toHaveBeenCalledWith({ pattern: 'needle' }, expect.anything());
       expect(mockClient.toolRouter.session.execute).not.toHaveBeenCalled();
+    });
+
+    it('should pass inline custom tools when routing remote provider executions', async () => {
+      const grepTool = createCustomTool('GREP', {
+        name: 'Grep',
+        description: 'Search local text',
+        inputParams: z.object({ pattern: z.string() }),
+        execute: vi.fn(async () => ({ matches: [] })),
+      });
+      const executeSessionTool = vi.fn().mockResolvedValue({
+        data: { ok: true },
+        error: null,
+        successful: true,
+      });
+      (Tools as any).mockImplementation(() => ({
+        getRawToolRouterSessionTools: vi
+          .fn()
+          .mockResolvedValue([
+            { slug: 'COMPOSIO_SEARCH_TOOLS' },
+            { slug: 'GMAIL_SEND_EMAIL', toolkit: { slug: 'gmail', name: 'Gmail' } },
+          ]),
+        executeSessionTool,
+      }));
+      mockClient.toolRouter.session.create.mockResolvedValueOnce({
+        ...mockSessionCreateResponse,
+        experimental: {
+          custom_tools: [
+            {
+              slug: 'LOCAL_GREP',
+              original_slug: 'GREP',
+              extends_toolkit: null,
+            },
+          ],
+        },
+      });
+      mockProvider.wrapTools.mockReturnValue('mocked-custom-tools');
+
+      const session = await toolRouter.create(userId, {
+        experimental: { customTools: [grepTool] },
+      });
+      await session.tools();
+      const routingExecute = mockProvider.wrapTools.mock.calls[0][1] as (
+        toolSlug: string,
+        input: Record<string, unknown>
+      ) => Promise<unknown>;
+      await routingExecute('GMAIL_SEND_EMAIL', { to: 'user@example.com' });
+
+      expect(executeSessionTool).toHaveBeenCalledWith(
+        'GMAIL_SEND_EMAIL',
+        { sessionId, arguments: { to: 'user@example.com' } },
+        undefined,
+        { slug: 'GMAIL_SEND_EMAIL', toolkit: { slug: 'gmail', name: 'Gmail' } },
+        {
+          experimental: {
+            custom_tools: [expect.objectContaining({ slug: 'GREP' })],
+          },
+        }
+      );
+    });
+
+    it('should pass inline custom tools when routing remote multi-execute batches', async () => {
+      const grepTool = createCustomTool('GREP', {
+        name: 'Grep',
+        description: 'Search local text',
+        inputParams: z.object({ pattern: z.string() }),
+        execute: vi.fn(async () => ({ matches: [] })),
+      });
+      const executeSessionTool = vi.fn().mockResolvedValue({
+        data: { results: [] },
+        error: null,
+        successful: true,
+      });
+      const multiExecuteTool = { slug: 'COMPOSIO_MULTI_EXECUTE_TOOL' };
+      (Tools as any).mockImplementation(() => ({
+        getRawToolRouterSessionTools: vi
+          .fn()
+          .mockResolvedValue([{ slug: 'COMPOSIO_SEARCH_TOOLS' }, multiExecuteTool]),
+        executeSessionTool,
+      }));
+      mockClient.toolRouter.session.create.mockResolvedValueOnce({
+        ...mockSessionCreateResponse,
+        experimental: {
+          custom_tools: [
+            {
+              slug: 'LOCAL_GREP',
+              original_slug: 'GREP',
+              extends_toolkit: null,
+            },
+          ],
+        },
+      });
+      mockProvider.wrapTools.mockReturnValue('mocked-custom-tools');
+
+      const session = await toolRouter.create(userId, {
+        experimental: { customTools: [grepTool] },
+      });
+      await session.tools();
+      const routingExecute = mockProvider.wrapTools.mock.calls[0][1] as (
+        toolSlug: string,
+        input: Record<string, unknown>
+      ) => Promise<unknown>;
+      const input = { tools: [{ tool_slug: 'GMAIL_SEND_EMAIL', arguments: { to: 'a@b.com' } }] };
+      await routingExecute('COMPOSIO_MULTI_EXECUTE_TOOL', input);
+
+      expect(executeSessionTool).toHaveBeenCalledWith(
+        'COMPOSIO_MULTI_EXECUTE_TOOL',
+        { sessionId, arguments: input },
+        undefined,
+        multiExecuteTool,
+        {
+          experimental: {
+            custom_tools: [expect.objectContaining({ slug: 'GREP' })],
+          },
+        }
+      );
     });
 
     it('should not expose custom tools unless SDK preload selects them', async () => {

--- a/ts/packages/core/test/models/toolRouter.test.ts
+++ b/ts/packages/core/test/models/toolRouter.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { z } from 'zod/v3';
 import { ToolRouter } from '../../src/models/ToolRouter';
 import ComposioClient from '@composio/client';
 import { telemetry } from '../../src/telemetry/Telemetry';
@@ -6,6 +7,8 @@ import { MockProvider } from '../utils/mocks/provider.mock';
 import { Tools } from '../../src/models/Tools';
 import { ConnectedAccountStatuses } from '../../src/types/connectedAccounts.types';
 import { ToolRouterCreateSessionConfig, Session } from '../../src/types/toolRouter.types';
+import { createCustomTool } from '../../src/models/CustomTool';
+import { DIRECT_CUSTOM_TOOL_DESCRIPTION_PREFIX } from '../../src/models/ToolRouterSession';
 
 // Mock dependencies
 vi.mock('../../src/telemetry/Telemetry', () => ({
@@ -260,6 +263,106 @@ describe('ToolRouter', () => {
 
         expect(session.preload.tools).toEqual(['GMAIL_FETCH_EMAILS']);
         expect(session.configVersion).toBe(2);
+      });
+
+      it('should create a session with preload all', async () => {
+        mockClient.toolRouter.session.create.mockResolvedValueOnce({
+          ...mockSessionCreateResponse,
+          config: {
+            preload: { tools: 'all' },
+          },
+          config_version: 2,
+        });
+
+        const session = await toolRouter.create(userId, {
+          toolkits: ['github'],
+          preload: { tools: 'all' },
+        });
+
+        expect(mockClient.toolRouter.session.create).toHaveBeenCalledWith({
+          user_id: userId,
+          toolkits: {
+            enable: ['github'],
+          },
+          auth_configs: undefined,
+          connected_accounts: undefined,
+          tools: undefined,
+          tags: undefined,
+          manage_connections: createExpectedManageConnections(),
+          workbench: undefined,
+          preload: { tools: 'all' },
+        });
+
+        expect(session.preload.tools).toBe('all');
+      });
+
+      it('should apply the direct_tools session preset defaults', async () => {
+        mockClient.toolRouter.session.create.mockResolvedValueOnce({
+          ...mockSessionCreateResponse,
+          config: {
+            preload: { tools: 'all' },
+          },
+        });
+
+        const session = await toolRouter.create(userId, {
+          sessionPreset: 'direct_tools',
+          toolkits: ['github'],
+        });
+
+        expect(mockClient.toolRouter.session.create).toHaveBeenCalledWith({
+          user_id: userId,
+          toolkits: {
+            enable: ['github'],
+          },
+          auth_configs: undefined,
+          connected_accounts: undefined,
+          tools: undefined,
+          tags: undefined,
+          manage_connections: { enable: false },
+          workbench: { enable: false },
+          multi_account: undefined,
+          preload: { tools: 'all' },
+          search: { enable: false },
+          execute: { enable_multi_execute: false },
+          experimental: undefined,
+        });
+        expect(session.preload.tools).toBe('all');
+      });
+
+      it('should respect explicit overrides with the direct_tools session preset', async () => {
+        mockClient.toolRouter.session.create.mockResolvedValueOnce({
+          ...mockSessionCreateResponse,
+          config: {
+            preload: { tools: ['GITHUB_CREATE_ISSUE'] },
+          },
+        });
+
+        const session = await toolRouter.create(userId, {
+          sessionPreset: 'direct_tools',
+          toolkits: ['github'],
+          manageConnections: true,
+          workbench: { enable: true },
+          preload: { tools: ['GITHUB_CREATE_ISSUE'] },
+        });
+
+        expect(mockClient.toolRouter.session.create).toHaveBeenCalledWith({
+          user_id: userId,
+          toolkits: {
+            enable: ['github'],
+          },
+          auth_configs: undefined,
+          connected_accounts: undefined,
+          tools: undefined,
+          tags: undefined,
+          manage_connections: { enable: true },
+          workbench: { enable: true },
+          multi_account: undefined,
+          preload: { tools: ['GITHUB_CREATE_ISSUE'] },
+          search: { enable: false },
+          execute: { enable_multi_execute: false },
+          experimental: undefined,
+        });
+        expect(session.preload.tools).toEqual(['GITHUB_CREATE_ISSUE']);
       });
 
       it('should create a session with user ID only and verify MCP type transformation', async () => {
@@ -2238,6 +2341,83 @@ describe('ToolRouter', () => {
         undefined
       );
       expect(tools).toBe('mocked-wrapped-tools');
+    });
+
+    it('should include preloaded custom tools selected by the create response', async () => {
+      const grepTool = createCustomTool('GREP', {
+        name: 'Grep',
+        description: 'Search local text',
+        inputParams: z.object({
+          pattern: z.string().describe('Pattern to search for'),
+        }),
+        execute: vi.fn(async () => ({ matches: [] })),
+      });
+
+      mockClient.toolRouter.session.create.mockResolvedValueOnce({
+        ...mockSessionCreateResponse,
+        tool_router_tools: ['COMPOSIO_SEARCH_TOOLS', 'server_grep'],
+        experimental: {
+          custom_tools: [
+            {
+              slug: 'SERVER_GREP',
+              original_slug: 'GREP',
+              extends_toolkit: null,
+            },
+          ],
+        },
+      });
+      mockProvider.wrapTools.mockReturnValue('mocked-custom-tools');
+
+      const session = await toolRouter.create(userId, {
+        experimental: { customTools: [grepTool] },
+      });
+      const tools = await session.tools();
+
+      expect(mockProvider.wrapTools).toHaveBeenCalledTimes(1);
+      const wrappedTools = mockProvider.wrapTools.mock.calls[0][0] as Array<{
+        slug: string;
+        description?: string;
+        toolkit?: { slug: string; name: string };
+      }>;
+      expect(wrappedTools.map(tool => tool.slug)).toEqual(['COMPOSIO_SEARCH_TOOLS', 'SERVER_GREP']);
+      expect(wrappedTools[1].description).toContain(DIRECT_CUSTOM_TOOL_DESCRIPTION_PREFIX);
+      expect(wrappedTools[1].toolkit).toEqual({ slug: 'custom', name: 'Custom' });
+      expect(tools).toBe('mocked-custom-tools');
+    });
+
+    it('should not expose custom tools unless the backend preloaded them', async () => {
+      const grepTool = createCustomTool('GREP', {
+        name: 'Grep',
+        description: 'Search local text',
+        inputParams: z.object({
+          pattern: z.string(),
+        }),
+        execute: vi.fn(async () => ({ matches: [] })),
+      });
+
+      mockClient.toolRouter.session.create.mockResolvedValueOnce({
+        ...mockSessionCreateResponse,
+        tool_router_tools: ['COMPOSIO_SEARCH_TOOLS'],
+        experimental: {
+          custom_tools: [
+            {
+              slug: 'LOCAL_GREP',
+              original_slug: 'GREP',
+              extends_toolkit: null,
+            },
+          ],
+        },
+      });
+      mockProvider.wrapTools.mockReturnValue('mocked-custom-tools');
+
+      const session = await toolRouter.create(userId, {
+        preload: { tools: 'all' },
+        experimental: { customTools: [grepTool] },
+      });
+      await session.tools();
+
+      const wrappedTools = mockProvider.wrapTools.mock.calls[0][0] as Array<{ slug: string }>;
+      expect(wrappedTools.map(tool => tool.slug)).toEqual(['COMPOSIO_SEARCH_TOOLS']);
     });
 
     it('should handle tools fetching errors', async () => {

--- a/ts/packages/core/test/models/toolRouter.test.ts
+++ b/ts/packages/core/test/models/toolRouter.test.ts
@@ -2437,6 +2437,9 @@ describe('ToolRouter', () => {
     });
 
     it('should include custom tools with preload enabled locally', async () => {
+      const executeGrep = vi.fn(async ({ pattern }: { pattern: string }) => ({
+        matches: [pattern],
+      }));
       const grepTool = createCustomTool('GREP', {
         name: 'Grep',
         description: 'Search local text',
@@ -2444,7 +2447,7 @@ describe('ToolRouter', () => {
         inputParams: z.object({
           pattern: z.string().describe('Pattern to search for'),
         }),
-        execute: vi.fn(async () => ({ matches: [] })),
+        execute: executeGrep,
       });
 
       mockClient.toolRouter.session.create.mockResolvedValueOnce({
@@ -2477,6 +2480,19 @@ describe('ToolRouter', () => {
       expect(wrappedTools[1].description).toContain(DIRECT_CUSTOM_TOOL_DESCRIPTION_PREFIX);
       expect(wrappedTools[1].toolkit).toEqual({ slug: 'custom', name: 'Custom' });
       expect(tools).toBe('mocked-custom-tools');
+
+      const routingExecute = mockProvider.wrapTools.mock.calls[0][1] as (
+        toolSlug: string,
+        input: Record<string, unknown>
+      ) => Promise<unknown>;
+      const result = await routingExecute('SERVER_GREP', { pattern: 'needle' });
+      expect(result).toEqual({
+        data: { matches: ['needle'] },
+        error: null,
+        successful: true,
+      });
+      expect(executeGrep).toHaveBeenCalledWith({ pattern: 'needle' }, expect.anything());
+      expect(mockClient.toolRouter.session.execute).not.toHaveBeenCalled();
     });
 
     it('should not expose custom tools unless SDK preload selects them', async () => {

--- a/ts/packages/core/test/tools/tools.test.ts
+++ b/ts/packages/core/test/tools/tools.test.ts
@@ -1073,6 +1073,42 @@ describe('Tools', () => {
         });
       });
 
+      it('should pass inline custom tools to tool router session execute', async () => {
+        const toolSlug = 'COMPOSIO_TOOL';
+        const body = {
+          sessionId,
+          arguments: { query: 'test' },
+        };
+
+        mockClient.toolRouter.session.execute.mockResolvedValueOnce({
+          data: { results: true },
+          error: null,
+          log_id: '123',
+        });
+
+        await context.tools.executeSessionTool(toolSlug, body, undefined, undefined, {
+          experimental: {
+            custom_tools: [
+              {
+                slug: 'GREP',
+                name: 'Grep',
+                description: 'Search local text',
+                input_schema: { type: 'object', properties: {} },
+              },
+            ],
+          },
+        });
+
+        expect(mockClient.toolRouter.session.execute).toHaveBeenCalledWith(sessionId, {
+          tool_slug: toolSlug,
+          arguments: body.arguments,
+          enable_auto_workbench_offload: true,
+          experimental: {
+            custom_tools: [expect.objectContaining({ slug: 'GREP' })],
+          },
+        });
+      });
+
       it('should throw validation error for invalid parameters', async () => {
         const invalidBody = {
           // missing sessionId


### PR DESCRIPTION
## Summary
- Add `preload` on TS/Python custom tools and custom toolkits so SDK-created sessions can expose selected custom schemas directly from `session.tools()`.
- Keep top-level `preload.tools` for backend-owned Composio tool slugs / `all`; reject custom slugs there with guidance to use the SDK custom definition flag, and reject bare-string Python misuse except `"all"`.
- Pass inline custom definitions on create/search so backend validation/search has current definitions without persisting them; direct `session.execute(...)` remains generated-client typed and does not carry custom payload.
- Preserve `sessionPreset: "direct_tools"` / `session_preset="direct_tools"`, including explicit override precedence; direct-tools uses `preload.tools = "all"` only when the caller does not override preload.
- Add OpenAI Agents SDK examples for explicit preload and `sessionPreset: "direct_tools"` in TS and Python, including toolkit-level preload with a nested `preload: false` / `preload=False` override.

## Validation
- `pnpm --dir ts/packages/core test test/models/toolRouter.test.ts test/models/customToolRouting.test.ts`
- `pnpm --dir ts/packages/core typecheck`
- `env COMPOSIO_CACHE_DIR=/private/tmp/composio-cache python/.nox/chk/bin/python -m pytest python/tests/test_custom_tools.py python/tests/test_tool_router.py`
- `python/.nox/chk/bin/python -m ruff check python/examples/tool_router/preload.py python/examples/tool_router/direct_tools_preset.py python/composio/core/models/custom_tool.py python/composio/core/models/custom_tool_types.py python/composio/core/models/tool_router.py python/composio/core/models/tool_router_session.py python/tests/test_custom_tools.py python/tests/test_tool_router.py`
- `python/.nox/chk/bin/python -m py_compile python/examples/tool_router/preload.py python/examples/tool_router/direct_tools_preset.py`
- `pnpm --dir ts/examples/tool-router exec tsc --noEmit --skipLibCheck --target ES2022 --module ESNext --moduleResolution Bundler --allowSyntheticDefaultImports --strict src/preload.ts src/direct-tools-preset.ts`
- `git diff --check`