### PR TITLE
fix(security): prevent path traversal in Python SDK FileDownloadable.download() (SEC-316)

### DIFF
--- a/python/composio/core/models/_files.py
+++ b/python/composio/core/models/_files.py
@@ -547,8 +547,19 @@ class FileDownloadable(BaseModel):
     s3url: str = Field(..., description="URL of the file.")
 
     def download(self, outdir: Path, chunk_size: int = _DEFAULT_CHUNK_SIZE) -> Path:
-        outfile = outdir / self.name
+        # SEC-316: `self.name` comes from the (potentially compromised or
+        # MITM'd) Composio API response. Strip directory components with
+        # `Path(...).name` so traversal sequences like `../../../foo` collapse
+        # to `foo`, then verify the resolved output stays under `outdir` so a
+        # name like `output_evil/foo` (sibling-prefix attack) is also rejected.
+        safe_name = Path(self.name).name
+        outfile = outdir / safe_name
         outdir.mkdir(exist_ok=True, parents=True)
+        if not outfile.resolve().is_relative_to(outdir.resolve()):
+            raise ErrorDownloadingFile(
+                f"Path traversal detected: filename '{self.name}' resolves "
+                "outside the intended output directory."
+            )
         response = requests.get(url=self.s3url, stream=True)
         if response.status_code != 200:
             raise ErrorDownloadingFile(f"Error downloading file: {self.s3url}")

--- a/python/composio/core/models/_files.py
+++ b/python/composio/core/models/_files.py
@@ -554,12 +554,12 @@ class FileDownloadable(BaseModel):
         # name like `output_evil/foo` (sibling-prefix attack) is also rejected.
         safe_name = Path(self.name).name
         outfile = outdir / safe_name
-        outdir.mkdir(exist_ok=True, parents=True)
         if not outfile.resolve().is_relative_to(outdir.resolve()):
             raise ErrorDownloadingFile(
                 f"Path traversal detected: filename '{self.name}' resolves "
                 "outside the intended output directory."
             )
+        outdir.mkdir(exist_ok=True, parents=True)
         response = requests.get(url=self.s3url, stream=True)
         if response.status_code != 200:
             raise ErrorDownloadingFile(f"Error downloading file: {self.s3url}")

--- a/python/composio/core/models/tool_router_session_files.py
+++ b/python/composio/core/models/tool_router_session_files.py
@@ -142,13 +142,22 @@ class RemoteFile:
         If path is omitted, saves to ~/.composio/files/ using the filename.
         """
         content = self.buffer()
-        home = Path.home()
         save_path: Path
 
         if path is not None:
             save_path = Path(path)
         else:
-            save_path = home / COMPOSIO_DIR / TEMP_FILES_DIRECTORY_NAME / self.filename
+            # SEC-316 defense-in-depth: `self.filename` is `Path(mount_relative_path).name`,
+            # so directory components are already stripped — but verify the resolved
+            # default-location path stays inside the cache dir to reject residual `..`
+            # cases (e.g. ``mount_relative_path == ".."`` keeps ``filename == ".."``).
+            default_dir = Path.home() / COMPOSIO_DIR / TEMP_FILES_DIRECTORY_NAME
+            save_path = default_dir / self.filename
+            if not save_path.resolve().is_relative_to(default_dir.resolve()):
+                raise ValidationError(
+                    f"Path traversal detected: filename {self.filename!r} resolves "
+                    "outside the intended output directory."
+                )
 
         save_path.parent.mkdir(parents=True, exist_ok=True)
         save_path.write_bytes(content)

--- a/python/tests/test_files.py
+++ b/python/tests/test_files.py
@@ -10,6 +10,7 @@ import pytest
 
 from composio.client.types import Tool, tool_list_response
 from composio.core.models._files import (
+    FileDownloadable,
     FileHelper,
     FileUploadable,
     _is_url,
@@ -1992,3 +1993,78 @@ class TestUrlSanitization:
         url = "https://example.com/file.jpg"
         sanitized = _sanitize_url_for_logging(url)
         assert "[REDACTED]" not in sanitized
+
+
+class TestFileDownloadablePathTraversal:
+    """SEC-316: server-controlled `name` must not escape the output dir."""
+
+    def _mock_response(self, content: bytes = b"data") -> MagicMock:
+        response = MagicMock()
+        response.status_code = 200
+        response.iter_content = lambda chunk_size: [content]
+        return response
+
+    def test_relative_traversal_is_neutralized(self, tmp_path):
+        outdir = tmp_path / "safe"
+        # outdir does not need to exist yet — download() creates it.
+        f = FileDownloadable(
+            name="../../../PWNED.sh",
+            mimetype="application/octet-stream",
+            s3url="https://example.com/file",
+        )
+        with patch("composio.core.models._files.requests.get",
+                   return_value=self._mock_response(b"#!/bin/sh\n")):
+            written = f.download(outdir)
+
+        # Traversal sequence collapsed to basename and stayed inside outdir.
+        assert written == outdir / "PWNED.sh"
+        assert written.resolve().is_relative_to(outdir.resolve())
+        assert not (tmp_path / "PWNED.sh").exists()
+        assert written.read_bytes() == b"#!/bin/sh\n"
+
+    def test_absolute_path_is_neutralized(self, tmp_path):
+        outdir = tmp_path / "safe"
+        f = FileDownloadable(
+            name="/etc/passwd",
+            mimetype="application/octet-stream",
+            s3url="https://example.com/file",
+        )
+        with patch("composio.core.models._files.requests.get",
+                   return_value=self._mock_response(b"x")):
+            written = f.download(outdir)
+
+        # `Path('/etc/passwd').name == 'passwd'` — absolute path is stripped.
+        assert written == outdir / "passwd"
+        assert written.resolve().is_relative_to(outdir.resolve())
+
+    def test_dotdot_only_name_is_rejected(self, tmp_path):
+        """`Path('..').name == '..'`. Basename strip alone wouldn't catch it,
+        but the second-line `is_relative_to()` check does."""
+        from composio.exceptions import ErrorDownloadingFile
+
+        outdir = tmp_path / "safe"
+        f = FileDownloadable(
+            name="..",
+            mimetype="application/octet-stream",
+            s3url="https://example.com/file",
+        )
+        with patch("composio.core.models._files.requests.get",
+                   return_value=self._mock_response()):
+            with pytest.raises(ErrorDownloadingFile, match="Path traversal detected"):
+                f.download(outdir)
+        # No file was written under the parent.
+        assert not (tmp_path / "x").exists()
+
+    def test_safe_filename_passes_through(self, tmp_path):
+        outdir = tmp_path / "safe"
+        f = FileDownloadable(
+            name="report.pdf",
+            mimetype="application/pdf",
+            s3url="https://example.com/file",
+        )
+        with patch("composio.core.models._files.requests.get",
+                   return_value=self._mock_response(b"%PDF-1.4")):
+            written = f.download(outdir)
+
+        assert written == outdir / "report.pdf"
+        assert written.read_bytes() == b"%PDF-1.4"

--- a/python/tests/test_files.py
+++ b/python/tests/test_files.py
@@ -2076,3 +2076,50 @@ class TestFileDownloadablePathTraversal:
 
         assert written == outdir / "report.pdf"
         assert written.read_bytes() == b"%PDF-1.4"
+
+    def test_basename_collapse_through_subdir_is_rejected(self, tmp_path):
+        """`Path('foo/..').name == '..'` — the basename strip of a name that
+        traverses *through* a subdir collapses to `..`, then the
+        `is_relative_to()` check rejects it. Explicit coverage of the
+        residual-`..` path through basename normalization (the plain `..`
+        test covers the no-subdir case)."""
+        from composio.exceptions import ErrorDownloadingFile
+
+        outdir = tmp_path / "safe"
+        f = FileDownloadable(
+            name="foo/..",
+            mimetype="application/octet-stream",
+            s3url="https://example.com/file",
+        )
+        with patch(
+            "composio.core.models._files.requests.get",
+            return_value=self._mock_response(),
+        ):
+            with pytest.raises(ErrorDownloadingFile, match="Path traversal detected"):
+                f.download(outdir)
+        # SEC-316 P3.1: check runs before mkdir, so outdir is not created
+        # as a side effect of a rejected payload.
+        assert not outdir.exists()
+
+    def test_empty_name_safe_fails_at_write_time(self, tmp_path):
+        """`Path('').name == ''` — `outdir / ''` resolves to `outdir` itself,
+        which passes the containment check (a path is relative to itself).
+        The write then fails with `IsADirectoryError` because the target is
+        the directory. Documents the safe-fail behavior so a future change
+        to the check cannot silently weaken it without breaking this test."""
+        outdir = tmp_path / "safe"
+        f = FileDownloadable(
+            name="",
+            mimetype="application/octet-stream",
+            s3url="https://example.com/file",
+        )
+        with patch(
+            "composio.core.models._files.requests.get",
+            return_value=self._mock_response(b"x"),
+        ):
+            with pytest.raises(IsADirectoryError):
+                f.download(outdir)
+        # outdir got created (mkdir runs after the check, which passed),
+        # but no file was written inside it.
+        assert outdir.is_dir()
+        assert list(outdir.iterdir()) == []

--- a/python/tests/test_files.py
+++ b/python/tests/test_files.py
@@ -2012,8 +2012,10 @@ class TestFileDownloadablePathTraversal:
             mimetype="application/octet-stream",
             s3url="https://example.com/file",
         )
-        with patch("composio.core.models._files.requests.get",
-                   return_value=self._mock_response(b"#!/bin/sh\n")):
+        with patch(
+            "composio.core.models._files.requests.get",
+            return_value=self._mock_response(b"#!/bin/sh\n"),
+        ):
             written = f.download(outdir)
 
         # Traversal sequence collapsed to basename and stayed inside outdir.
@@ -2029,8 +2031,10 @@ class TestFileDownloadablePathTraversal:
             mimetype="application/octet-stream",
             s3url="https://example.com/file",
         )
-        with patch("composio.core.models._files.requests.get",
-                   return_value=self._mock_response(b"x")):
+        with patch(
+            "composio.core.models._files.requests.get",
+            return_value=self._mock_response(b"x"),
+        ):
             written = f.download(outdir)
 
         # `Path('/etc/passwd').name == 'passwd'` — absolute path is stripped.
@@ -2048,8 +2052,10 @@ class TestFileDownloadablePathTraversal:
             mimetype="application/octet-stream",
             s3url="https://example.com/file",
         )
-        with patch("composio.core.models._files.requests.get",
-                   return_value=self._mock_response()):
+        with patch(
+            "composio.core.models._files.requests.get",
+            return_value=self._mock_response(),
+        ):
             with pytest.raises(ErrorDownloadingFile, match="Path traversal detected"):
                 f.download(outdir)
         # No file was written under the parent.
@@ -2062,8 +2068,10 @@ class TestFileDownloadablePathTraversal:
             mimetype="application/pdf",
             s3url="https://example.com/file",
         )
-        with patch("composio.core.models._files.requests.get",
-                   return_value=self._mock_response(b"%PDF-1.4")):
+        with patch(
+            "composio.core.models._files.requests.get",
+            return_value=self._mock_response(b"%PDF-1.4"),
+        ):
             written = f.download(outdir)
 
         assert written == outdir / "report.pdf"

--- a/python/tests/test_tool_router_session_files.py
+++ b/python/tests/test_tool_router_session_files.py
@@ -234,3 +234,23 @@ class TestRemoteFile:
         expected = tmp_path / ".composio" / "files" / "report.pdf"
         assert Path(out_path) == expected
         assert expected.read_bytes() == b"pdf content"
+
+    def test_save_default_location_rejects_dotdot_filename(self, tmp_path):
+        """SEC-316 defense-in-depth: a server-controlled ``mount_relative_path``
+        whose basename is ``..`` (e.g. ``"foo/.."``) must be rejected before
+        any bytes touch the disk, not silently fail with ``IsADirectoryError``."""
+        rf = RemoteFile(
+            expires_at="2026-01-01",
+            mount_relative_path="foo/..",
+            sandbox_mount_prefix="/mnt/files",
+            download_url="https://example.com/file",
+        )
+        assert rf.filename == ".."  # `Path("foo/..").name == ".."`
+
+        with patch.object(rf, "buffer", return_value=b"should not be written"):
+            with patch("pathlib.Path.home", return_value=tmp_path):
+                with pytest.raises(ValidationError, match="Path traversal detected"):
+                    rf.save()
+
+        # The check raises before mkdir/write, so nothing was written under tmp_path.
+        assert not (tmp_path / ".composio").exists()


### PR DESCRIPTION
# Description

Fixes [SEC-316](https://linear.app/composio/issue/SEC-316/composio-path-traversal-in-composio-python-sdk-allows-arbitrary-file) — **HIGH severity (CVSS 8.2)** path traversal in the Composio Python SDK.

`FileDownloadable.download()` in `python/composio/core/models/_files.py` constructed the output path as `outdir / self.name`, where `self.name` comes directly from the Composio API response. A compromised or man-in-the-middle'd API server can return a filename like `../../../../PWNED.sh` and write arbitrary files outside the configured cache directory on the user's machine — leading to potential code execution, configuration tampering, or data compromise.

The TypeScript SDK is **not** vulnerable: `downloadFileFromS3` in `ts/packages/core/src/utils/fileUtils.node.ts` generates its own filename via `generateTimestampedFilename()` and `saveFile` strips path components with `platform.basename()` (line 428).

## What changed

`FileDownloadable.download()`:

- Strip directory components from `self.name` via `Path(...).name` so traversal sequences (`../`, absolute paths, `\` on POSIX) collapse to a basename.
- As a second-line defense, verify the resolved output path is contained within `outdir` using `Path.is_relative_to()` (correct directory-containment semantics — naive `str.startswith()` would be vulnerable to sibling-prefix attacks like `outdir_evil/`).

This mirrors the equivalent fix already landed in `mercury`'s legacy `FileDownloadable` (commits `e3915b82c3` + `c3d675dbcc` from PRs ComposioHQ/mercury#20641 and #20654).

## How did I test this PR

- Added 4 unit tests in `TestFileDownloadablePathTraversal` covering:
  - **Relative traversal** (`../../../PWNED.sh`) — collapsed to basename, written inside `outdir`, file does NOT appear at the parent path.
  - **Absolute path** (`/etc/passwd`) — basename strip yields `passwd`, written inside `outdir`.
  - **Dotdot-only name** (`..`) — `Path('..').name == '..'` survives basename strip; the `is_relative_to()` check then rejects it with `ErrorDownloadingFile`.
  - **Safe filename** (`report.pdf`) — pass-through unchanged.
- Ran `pytest tests/test_files.py -v` (110/110 passing — full file, no regressions).

```
$ python -m pytest tests/test_files.py::TestFileDownloadablePathTraversal -v
tests/test_files.py::TestFileDownloadablePathTraversal::test_relative_traversal_is_neutralized PASSED
tests/test_files.py::TestFileDownloadablePathTraversal::test_absolute_path_is_neutralized PASSED
tests/test_files.py::TestFileDownloadablePathTraversal::test_dotdot_only_name_is_rejected PASSED
tests/test_files.py::TestFileDownloadablePathTraversal::test_safe_filename_passes_through PASSED
========================= 4 passed in 0.18s ==========================
```

## Reference

- CWE-22: https://cwe.mitre.org/data/definitions/22.html
- CVSS Vector: `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:H/A:N`

---
Triggered by: srujan@composio.dev | Source: slack
Session: https://zen-api-production-4c98.up.railway.app/dashboard/#/chat/zen-3b30311d7b50