### PR TITLE
fix(python-sdk): handle anyOf(string, array<file>) for file_uploadable

### DIFF
--- a/python/composio/core/models/_files.py
+++ b/python/composio/core/models/_files.py
@@ -776,25 +776,46 @@ class FileHelper(WithLogger):
         self.enhance_schema_descriptions(schema)
         return schema
 
-    def _find_uploadable_schema_variant(self, schema: t.Dict) -> t.Optional[t.Dict]:
-        """Find a schema variant that contains file_uploadable properties."""
-        # Check anyOf variants
-        if "anyOf" in schema:
-            for variant in schema["anyOf"]:
-                if self._has_file_property(variant, "file_uploadable"):
-                    return variant
+    def _find_uploadable_schema_variant(
+        self, schema: t.Dict, value: t.Any = None
+    ) -> t.Optional[t.Dict]:
+        """Find a schema variant that contains file_uploadable properties.
 
-        # Check oneOf variants
-        if "oneOf" in schema:
-            for variant in schema["oneOf"]:
-                if self._has_file_property(variant, "file_uploadable"):
-                    return variant
+        When ``value`` is provided, prefer a variant whose JSON-Schema ``type``
+        matches the runtime type of the value. This makes
+        ``anyOf(string<file>, array<file>)`` work for both single paths and
+        lists of paths instead of always returning the first match (which
+        previously caused ``os.fspath(list)`` errors when the model sent an
+        array of paths to a tool whose schema accepted both shapes).
+        """
+        for key in ("anyOf", "oneOf", "allOf"):
+            if key not in schema:
+                continue
 
-        # Check allOf - merge all variants
-        if "allOf" in schema:
-            for variant in schema["allOf"]:
-                if self._has_file_property(variant, "file_uploadable"):
-                    return variant
+            candidates = [
+                v
+                for v in schema[key]
+                if self._has_file_property(v, "file_uploadable")
+            ]
+            if not candidates:
+                continue
+
+            if value is not None:
+                value_type = (
+                    "array"
+                    if isinstance(value, list)
+                    else "object"
+                    if isinstance(value, dict)
+                    else "string"
+                    if isinstance(value, str)
+                    else None
+                )
+                if value_type is not None:
+                    for c in candidates:
+                        if c.get("type") == value_type:
+                            return c
+
+            return candidates[0]
 
         return None
 
@@ -835,8 +856,15 @@ class FileHelper(WithLogger):
                 ).model_dump()
                 continue
 
-            # Check anyOf/oneOf/allOf for file_uploadable
-            uploadable_variant = self._find_uploadable_schema_variant(param_schema)
+            # Check anyOf/oneOf/allOf for file_uploadable. Pass the runtime
+            # value so the picker can match an array-of-files variant when the
+            # model sends a list, instead of always returning the first
+            # (string) variant — which previously caused ``os.fspath(list)``
+            # errors for tools like ``GMAIL_SEND_EMAIL`` whose ``attachment``
+            # field accepts ``anyOf(string<file>, array<file>)``.
+            uploadable_variant = self._find_uploadable_schema_variant(
+                param_schema, value=request[_param]
+            )
             if uploadable_variant is not None:
                 # If the variant itself is file_uploadable
                 if uploadable_variant.get("file_uploadable", False):
@@ -854,6 +882,48 @@ class FileHelper(WithLogger):
                         file_upload_allowlist=self._file_upload_allowlist,
                         before_file_upload=before_file_upload,
                     ).model_dump()
+                    continue
+
+                # Array-of-file_uploadable variant: model sent a list of paths
+                # and the schema permits an array branch with uploadable items.
+                if (
+                    uploadable_variant.get("type") == "array"
+                    and isinstance(request[_param], list)
+                    and isinstance(uploadable_variant.get("items"), dict)
+                    and self._has_file_property(
+                        uploadable_variant["items"], "file_uploadable"
+                    )
+                ):
+                    items_schema = uploadable_variant["items"]
+                    processed: t.List[t.Any] = []
+                    for item in request[_param]:
+                        if item is None or item == "":
+                            continue
+                        if items_schema.get("file_uploadable", False):
+                            processed.append(
+                                FileUploadable.from_path(
+                                    client=self._client,
+                                    file=item,
+                                    tool=tool.slug,
+                                    toolkit=tool.toolkit.slug,
+                                    sensitive_file_upload_protection=self._sensitive_file_upload_protection,
+                                    file_upload_path_deny_segments=self._file_upload_path_deny_segments,
+                                    file_upload_allowlist=self._file_upload_allowlist,
+                                    before_file_upload=before_file_upload,
+                                ).model_dump()
+                            )
+                        elif isinstance(item, dict):
+                            processed.append(
+                                self._substitute_file_uploads_recursively(
+                                    schema=items_schema,
+                                    request=item,
+                                    tool=tool,
+                                    before_file_upload=before_file_upload,
+                                )
+                            )
+                        else:
+                            processed.append(item)
+                    request[_param] = processed
                     continue
 
                 # If the variant has nested properties with file_uploadable


### PR DESCRIPTION
## Summary

The Python SDK's `file_uploadable` resolver was breaking on tools whose schema accepts both a single path and a list of paths (e.g. the new `GMAIL_SEND_EMAIL.attachment` schema):

```json
"attachment": {
  "anyOf": [
    { "type": "string", "format": "path", "file_uploadable": true },
    { "type": "array",  "items": { "type": "string", "format": "path", "file_uploadable": true } }
  ]
}
```

When the model picked the array branch and sent `[\"/p1\", \"/p2\", \"/p3\"]`, the SDK always returned the **first** matching `anyOf` variant from `_find_uploadable_schema_variant` (the string one), then called `FileUploadable.from_path(file=<list>)` and crashed with:

```
argument should be a str or an os.PathLike object where __fspath__ returns a str, not 'list'
```

This affects every tool exposing `anyOf(file, array<file>)` — Gmail multi-attachment, Slack `SLACK_UPLOAD_OR_CREATE_A_FILE_IN_SLACK` when the model batches files into one call, etc.

Fixes #<add issue number if any>

## Changes

- `_find_uploadable_schema_variant` is now value-aware. When a runtime `value` is passed in, it prefers the `anyOf`/`oneOf`/`allOf` variant whose JSON-Schema `type` matches the value's Python type (`array` for `list`, `string` for `str`, `object` for `dict`). Falls back to first match if no value or no type match — preserves existing behavior for callers that pass `value=None`.
- New array-of-`file_uploadable` branch in `_substitute_file_uploads_recursively`: when the picker returns an array variant whose items are `file_uploadable`, iterate the list and upload each file via `FileUploadable.from_path`, replacing the parameter with `[{name, mimetype, s3key}, ...]`. The existing security/allowlist/before-hook kwargs (`sensitive_file_upload_protection`, `file_upload_path_deny_segments`, `file_upload_allowlist`, `before_file_upload`) are threaded through to each upload.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [ ] Documentation
- [ ] Breaking change

## How Has This Been Tested?

Repro before the fix:

```python
composio = Composio(provider=OpenAIAgentsProvider(), dangerously_allow_auto_upload_download_files=True)
tools = composio.tools.get(user_id=\"<user>\", tools=[\"GMAIL_SEND_EMAIL\"])
agent = Agent(name=\"Email\", instructions=\"...\", tools=tools)
await Runner.run(starting_agent=agent, input=\"send an email to x@y.com with these attachments /a.png /b.jpg /c.png\")
```

**Before:**
- Model calls `GMAIL_SEND_EMAIL` once with `attachment=['/a.png','/b.jpg','/c.png']`
- Tool returns `successful=false` with `\"argument should be a str or an os.PathLike object where __fspath__ returns a str, not 'list'\"`

**After:**
- Same model call, but the SDK now uploads all three files individually and forwards `attachment=[{name, mimetype, s3key}, ...]` to the backend executor.
- Email is sent with all three attachments.

Manual verification done against `backend.composio.dev` with the live `GMAIL_SEND_EMAIL` schema. Existing single-path call sites (`attachment='/a.png'`) are unaffected because the picker still returns the string variant for non-list values.

I'd like to add unit tests in `python/tests/test_auto_upload_download_files.py` covering both branches (single path vs list) before this leaves draft — happy to do that here or as a follow-up depending on what reviewers prefer.

## Checklist
- [x] I have read the Code of Conduct and this PR adheres to it
- [ ] I ran linters/tests locally and they passed _(local manual repro only — please run CI)_
- [ ] I updated documentation as needed _(no public API surface change)_
- [ ] I added tests or explain why not applicable _(see note above — happy to add before un-drafting)_
- [ ] I added a changeset if this change affects published packages _(python pkg — let me know if a changeset is required for python-only fixes; I didn't see one in recent python-sdk fix commits)_

## Additional context

Originally surfaced while debugging a multi-attachment Gmail send. The toolkit-side `attachment` schema was already updated to `anyOf(string<file>, array<file>)`; this PR fixes the matching SDK-side resolver so the new schema is actually usable end-to-end.

Made with [Cursor](https://cursor.com)