### PR TITLE
refactor(cli): define local tools as custom toolkits

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1213,6 +1213,9 @@ importers:
 
   ts/packages/cli-local-tools:
     dependencies:
+      '@composio/core':
+        specifier: workspace:*
+        version: link:../core
       '@modelcontextprotocol/sdk':
         specifier: ^1.26.0
         version: 1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
@@ -1222,9 +1225,6 @@ importers:
       zod:
         specifier: 'catalog:'
         version: 4.3.6
-      zod-to-json-schema:
-        specifier: 'catalog:'
-        version: 3.25.1(zod@4.3.6)
     devDependencies:
       '@types/decompress':
         specifier: ^4.2.7

--- a/ts/packages/cli-local-tools/package.json
+++ b/ts/packages/cli-local-tools/package.json
@@ -44,10 +44,10 @@
     "typecheck:tsc": "tsc --noEmit -p ./tsconfig.src.json"
   },
   "dependencies": {
+    "@composio/core": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "decompress": "^4.2.1",
-    "zod": "catalog:",
-    "zod-to-json-schema": "catalog:"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@types/decompress": "^4.2.7",

--- a/ts/packages/cli-local-tools/src/registry.test.ts
+++ b/ts/packages/cli-local-tools/src/registry.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 import { z } from 'zod/v3';
 import {
   createLocalToolRouterExperimentalPayload,
+  getLocalCustomToolkits,
   getLocalToolkitDeclarations,
   getLocalToolInputDefinition,
   localToolkitDeclarations,
@@ -79,6 +80,19 @@ describe('@composio/cli-local-tools registry', () => {
         declarations: [fixtureToolkit],
       }).map(toolkit => toolkit.slug)
     ).toEqual([]);
+  });
+
+  it('builds core custom toolkit handles for supported local toolkits', () => {
+    const [toolkit] = getLocalCustomToolkits({
+      currentPlatform: 'linux-x64',
+      toolkits: ['fixture_app'],
+      declarations: [fixtureToolkit],
+    });
+
+    expect(toolkit?.slug).toBe('FIXTURE_APP');
+    expect(toolkit?.tools[0]?.slug).toBe('RUN_COMMAND');
+    expect(toolkit?.tools[0]?.inputSchema.properties).toHaveProperty('args');
+    expect(typeof toolkit?.tools[0]?.execute).toBe('function');
   });
 
   it('builds Tool Router custom toolkit payloads for supported local toolkits', () => {

--- a/ts/packages/cli-local-tools/src/registry.ts
+++ b/ts/packages/cli-local-tools/src/registry.ts
@@ -1,8 +1,11 @@
-import zodToJsonSchema from 'zod-to-json-schema';
+import {
+  experimental_createTool as createCustomTool,
+  experimental_createToolkit as createCustomToolkit,
+  type CustomToolkit,
+} from '@composio/core/experimental';
 import { beeperImessageToolkit } from './toolkits/beeper-imessage';
 import { chromeDevtoolsToolkit } from './toolkits/chrome-devtools';
 import { peekabooToolkit } from './toolkits/peekaboo';
-import type { z } from 'zod/v3';
 import { formatSupportedPlatforms, detectCliPlatform, supportsCliPlatform } from './platform';
 import { executeLocalTool } from './runtime';
 import type {
@@ -15,28 +18,7 @@ import type {
 
 export const LOCAL_TOOL_PREFIX = 'LOCAL_';
 
-interface LocalCustomTool {
-  readonly slug: string;
-  readonly name: string;
-  readonly description: string;
-  readonly inputSchema: Record<string, unknown>;
-  readonly outputSchema?: Record<string, unknown>;
-}
-
-interface LocalCustomToolkit {
-  readonly slug: string;
-  readonly name: string;
-  readonly description: string;
-  readonly tools: ReadonlyArray<LocalCustomTool>;
-}
-
-/**
- * Built-in local toolkits shipped with @composio/cli-local-tools.
- *
- * The foundation package intentionally starts empty. Concrete integrations are
- * added in separate stack PRs so each app can be reviewed and validated on its
- * own.
- */
+/** Built-in local toolkits shipped with @composio/cli-local-tools. */
 export const localToolkitDeclarations: ReadonlyArray<LocalToolkitDeclaration> = [
   beeperImessageToolkit,
   chromeDevtoolsToolkit,
@@ -59,48 +41,34 @@ const descriptionWithPlatform = (
   platforms: ReadonlyArray<LocalCliPlatform>
 ): string => `${description}\n\nLocal CLI platforms: ${formatSupportedPlatforms(platforms)}.`;
 
-const zodObjectToJsonSchema = (schema: z.ZodTypeAny): Record<string, unknown> => {
-  const converted = zodToJsonSchema(schema, { name: 'input' }) as {
-    definitions?: { input?: Record<string, unknown> };
-  } & Record<string, unknown>;
-  const inputDefinition = converted.definitions?.input ?? converted;
-  return {
-    type: 'object',
-    properties:
-      inputDefinition.properties && typeof inputDefinition.properties === 'object'
-        ? (inputDefinition.properties as Record<string, unknown>)
-        : {},
-    ...(Array.isArray(inputDefinition.required) ? { required: inputDefinition.required } : {}),
-  };
-};
-
-const zodToOutputJsonSchema = (schema: z.ZodTypeAny): Record<string, unknown> => {
-  const converted = zodToJsonSchema(schema, { name: 'output' }) as {
-    definitions?: { output?: Record<string, unknown> };
-  } & Record<string, unknown>;
-  return converted.definitions?.output ?? converted;
-};
-
 const toCustomTool = (
   toolkit: LocalToolkitDeclaration,
-  tool: LocalToolDeclaration
-): LocalCustomTool => ({
-  slug: tool.slug,
-  name: tool.name,
-  description: descriptionWithPlatform(tool.description, tool.platforms),
-  inputSchema: zodObjectToJsonSchema(tool.inputParams as z.ZodTypeAny),
-  ...(tool.outputParams ? { outputSchema: zodToOutputJsonSchema(tool.outputParams) } : {}),
-});
+  tool: LocalToolDeclaration,
+  currentPlatform: LocalCliPlatform
+) =>
+  createCustomTool(tool.slug, {
+    name: tool.name,
+    description: descriptionWithPlatform(tool.description, tool.platforms),
+    inputParams: tool.inputParams,
+    ...(tool.outputParams ? { outputParams: tool.outputParams } : {}),
+    execute: async input =>
+      executeLocalTool(tool.execution, input as Record<string, unknown>, {
+        toolkit,
+        tool,
+        finalSlug: normalizeLocalToolSlug(tool.slug, toolkit.slug),
+        platform: currentPlatform,
+      }),
+  });
 
 const toCustomToolkit = (
   toolkit: LocalToolkitDeclaration,
-  tools: ReadonlyArray<LocalCustomTool>
-): LocalCustomToolkit => ({
-  slug: toolkit.slug,
-  name: toolkit.name,
-  description: descriptionWithPlatform(toolkit.description, toolkit.platforms),
-  tools,
-});
+  currentPlatform: LocalCliPlatform
+): CustomToolkit =>
+  createCustomToolkit(toolkit.slug, {
+    name: toolkit.name,
+    description: descriptionWithPlatform(toolkit.description, toolkit.platforms),
+    tools: toolkit.tools.map(tool => toCustomTool(toolkit, tool, currentPlatform)),
+  });
 
 const toolkitMatchesFilter = (
   toolkit: LocalToolkitDeclaration,
@@ -167,16 +135,15 @@ export const getLocalCustomToolkits = (
     readonly toolkits?: ReadonlyArray<string>;
     readonly declarations?: ReadonlyArray<LocalToolkitDeclaration>;
   } = {}
-): ReadonlyArray<LocalCustomToolkit> =>
-  getLocalToolkitDeclarations(options).map(toolkit =>
-    toCustomToolkit(
-      toolkit,
-      toolkit.tools.map(tool => toCustomTool(toolkit, tool))
-    )
+): ReadonlyArray<CustomToolkit> => {
+  const currentPlatform = options.currentPlatform ?? detectCliPlatform();
+  return getLocalToolkitDeclarations({ ...options, currentPlatform }).map(toolkit =>
+    toCustomToolkit(toolkit, currentPlatform)
   );
+};
 
 const customToolkitToPayload = (
-  toolkit: LocalCustomToolkit
+  toolkit: CustomToolkit
 ): NonNullable<LocalToolRouterExperimentalPayload['custom_toolkits']>[number] => ({
   slug: toolkit.slug,
   name: toolkit.name,
@@ -250,7 +217,8 @@ export const getLocalToolInputDefinition = (
   return {
     finalSlug: resolution.finalSlug,
     toolkit: resolution.toolkit.slug,
-    schema: toCustomTool(resolution.toolkit, resolution.tool).inputSchema,
+    schema: toCustomTool(resolution.toolkit, resolution.tool, resolution.currentPlatform)
+      .inputSchema,
     version: 'local',
   };
 };

--- a/ts/packages/cli-local-tools/tsdown.config.ts
+++ b/ts/packages/cli-local-tools/tsdown.config.ts
@@ -4,5 +4,5 @@ import { baseConfig } from '../../../tsdown.config.base.ts';
 export default defineConfig({
   ...baseConfig,
   tsconfig: 'tsconfig.src.json',
-  external: [/^bun:/],
+  external: [...baseConfig.external, /^bun:/, /^@composio\/core(\/.*)?$/],
 });

--- a/ts/packages/cli-local-tools/vitest.config.ts
+++ b/ts/packages/cli-local-tools/vitest.config.ts
@@ -1,6 +1,20 @@
 import { defineConfig } from 'vitest/config';
+import path from 'node:path';
+
+const __dirname = path.resolve(path.dirname(new URL(import.meta.url).pathname));
+const coreDir = path.resolve(__dirname, '../core');
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@composio/core/experimental': path.join(coreDir, 'src/experimental/index.ts'),
+      '@composio/core': path.join(coreDir, 'src/index.ts'),
+      '#config_defaults': path.join(coreDir, 'src/utils/config-defaults/ConfigDefaults.node.ts'),
+      '#platform': path.join(coreDir, 'src/platform/node.ts'),
+      '#files': path.join(coreDir, 'src/models/Files.node.ts'),
+      '#file_tool_modifier': path.join(coreDir, 'src/utils/modifiers/FileToolModifier.node.ts'),
+    },
+  },
   test: {
     include: ['src/**/*.test.ts'],
     exclude: ['vendor/**', 'dist/**', 'node_modules/**'],

--- a/ts/packages/cli/src/commands/tools/commands/tools.search.cmd.ts
+++ b/ts/packages/cli/src/commands/tools/commands/tools.search.cmd.ts
@@ -354,20 +354,26 @@ const runToolsSearch = (params: {
           consumerUserId: resolvedUserId.value,
         });
       }
-      const { sessionId } = yield* resolveToolRouterSession(client, resolvedUserId.value, {
-        toolkits: toolkitList,
-        cacheScope:
-          resolvedProject.projectType === 'CONSUMER' && resolvedProject.consumerUserId
-            ? {
-                orgId: resolvedProject.orgId,
-                consumerUserId: resolvedProject.consumerUserId,
-              }
-            : undefined,
-      });
+      const { sessionId, localExperimentalPayload } = yield* resolveToolRouterSession(
+        client,
+        resolvedUserId.value,
+        {
+          toolkits: toolkitList,
+          cacheScope:
+            resolvedProject.projectType === 'CONSUMER' && resolvedProject.consumerUserId
+              ? {
+                  orgId: resolvedProject.orgId,
+                  consumerUserId: resolvedProject.consumerUserId,
+                }
+              : undefined,
+        }
+      );
+      const searchPayload = {
+        queries: queries.map(query => ({ use_case: query })),
+        ...(localExperimentalPayload ? { experimental: localExperimentalPayload } : {}),
+      };
       const searchResponse = yield* Effect.tryPromise(() =>
-        client.toolRouter.session.search(sessionId, {
-          queries: queries.map(query => ({ use_case: query })),
-        })
+        client.toolRouter.session.search(sessionId, searchPayload)
       );
       return {
         searchResponse,

--- a/ts/packages/cli/src/effects/create-tool-router-session.ts
+++ b/ts/packages/cli/src/effects/create-tool-router-session.ts
@@ -39,15 +39,21 @@ export interface CreateToolRouterSessionOptions {
   };
 }
 
+export interface CreatedToolRouterSession {
+  readonly sessionId: string;
+  /** Inline local-tool custom definitions that should be forwarded to v3.1 search/execute calls. */
+  readonly localExperimentalPayload?: ReturnType<typeof createLocalToolRouterExperimentalPayload>;
+}
+
 /**
  * Create an ephemeral Tool Router session for the given user ID.
- * Returns the session ID string.
+ * Returns the session id plus any local-tool custom payload bound to the session.
  *
  * Accepts a pre-resolved client instance (from ComposioClientSingleton)
  * so callers can resolve the dependency at layer construction time.
  * Used by `ToolsExecutorLive` which already holds the client reference.
  */
-export const createToolRouterSession = (
+export const createToolRouterSessionContext = (
   client: Composio,
   userId: string,
   options?: CreateToolRouterSessionOptions
@@ -169,8 +175,25 @@ export const createToolRouterSession = (
         toolkits: remoteToolkits.length > 0 ? { enable: [...remoteToolkits] } : undefined,
         experimental: localExperimentalPayload,
       })
-    ).pipe(Effect.map(session => session.session_id));
+    ).pipe(
+      Effect.map(
+        (session): CreatedToolRouterSession => ({
+          sessionId: session.session_id,
+          localExperimentalPayload,
+        })
+      )
+    );
   });
+
+/** Backward-compatible helper for callers that only need the session id. */
+export const createToolRouterSession = (
+  client: Composio,
+  userId: string,
+  options?: CreateToolRouterSessionOptions
+) =>
+  createToolRouterSessionContext(client, userId, options).pipe(
+    Effect.map(session => session.sessionId)
+  );
 
 /**
  * Resolve the Composio client and create a Tool Router session in one step.
@@ -182,6 +205,6 @@ export const resolveToolRouterSession = (
   userId: string,
   options?: CreateToolRouterSessionOptions
 ) =>
-  createToolRouterSession(client, userId, options).pipe(
-    Effect.map(sessionId => ({ client, sessionId }))
+  createToolRouterSessionContext(client, userId, options).pipe(
+    Effect.map(session => ({ client, ...session }))
   );

--- a/ts/packages/cli/src/services/tools-executor.ts
+++ b/ts/packages/cli/src/services/tools-executor.ts
@@ -1,14 +1,14 @@
 import { FileSystem } from '@effect/platform';
 import { Context, Effect, Layer } from 'effect';
 import type { Composio } from '@composio/client';
-import { executeLocalToolBySlug, isLocalToolSlug } from '@composio/cli-local-tools';
+import { executeLocalToolBySlug, resolveLocalTool } from '@composio/cli-local-tools';
 import type {
   SessionExecuteResponse,
   SessionExecuteMetaResponse,
   SessionExecuteMetaParams,
 } from '@composio/client/resources/tool-router';
 import { ComposioClientSingleton } from 'src/services/composio-clients';
-import { createToolRouterSession } from 'src/effects/create-tool-router-session';
+import { createToolRouterSessionContext } from 'src/effects/create-tool-router-session';
 import {
   ComposioNoActiveConnectionError,
   mapComposioError,
@@ -142,10 +142,11 @@ export const ToolsExecutorLive = Layer.effect(
       execute: (slug, params) =>
         Effect.gen(function* () {
           const cliConfig = yield* ComposioCliUserConfig;
-          if (
-            isLocalToolSlug(slug) &&
-            !cliConfig.isExperimentalFeatureEnabled(CLI_EXPERIMENTAL_FEATURES.LOCAL_TOOLS)
-          ) {
+          const localToolResolution = resolveLocalTool(slug, { includeUnsupported: true });
+          const localToolsEnabled = cliConfig.isExperimentalFeatureEnabled(
+            CLI_EXPERIMENTAL_FEATURES.LOCAL_TOOLS
+          );
+          if (localToolResolution && !localToolsEnabled) {
             return yield* Effect.fail(
               new Error(
                 `Local tools are experimental. Enable them with \`composio config experimental ${CLI_EXPERIMENTAL_FEATURES.LOCAL_TOOLS} on\` before executing ${slug}.`
@@ -153,26 +154,32 @@ export const ToolsExecutorLive = Layer.effect(
             );
           }
 
-          const localResult = yield* Effect.tryPromise(() =>
-            executeLocalToolBySlug(slug, params.arguments)
-          );
-          if (localResult) {
-            return {
-              successful: true,
-              data: localResult as Record<string, unknown>,
-              error: null,
-              logId: '',
-            } satisfies ToolExecuteResponse;
+          if (localToolResolution) {
+            const localResult = yield* Effect.tryPromise(() =>
+              executeLocalToolBySlug(slug, params.arguments)
+            );
+            if (localResult) {
+              return {
+                successful: true,
+                data: localResult as Record<string, unknown>,
+                error: null,
+                logId: '',
+              } satisfies ToolExecuteResponse;
+            }
           }
 
           const client = yield* clientSingleton.get();
           const resolvedClient = params.client ?? client;
           // One session per invocation — CLI runs one tool per process.
-          const sessionId = yield* createToolRouterSession(resolvedClient, params.userId, {
-            manageConnections: true,
-            connectedAccounts: params.connectedAccounts,
-            cacheScope: params.cacheScope,
-          });
+          const { sessionId, localExperimentalPayload } = yield* createToolRouterSessionContext(
+            resolvedClient,
+            params.userId,
+            {
+              manageConnections: true,
+              connectedAccounts: params.connectedAccounts,
+              cacheScope: params.cacheScope,
+            }
+          );
           const normalizedArguments = isMetaToolSlug(slug)
             ? params.arguments
             : yield* getOrFetchToolInputDefinition(slug).pipe(
@@ -201,10 +208,12 @@ export const ToolsExecutorLive = Layer.effect(
                   arguments: normalizedArguments,
                 });
               }
-              return resolvedClient.toolRouter.session.execute(sessionId, {
+              const executePayload = {
                 tool_slug: slug,
                 arguments: normalizedArguments,
-              });
+                ...(localExperimentalPayload ? { experimental: localExperimentalPayload } : {}),
+              };
+              return resolvedClient.toolRouter.session.execute(sessionId, executePayload);
             }
           );
 

--- a/ts/packages/cli/test/src/commands/tools/tools.search.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/tools/tools.search.cmd.test.ts
@@ -454,9 +454,99 @@ describe('CLI: composio search', () => {
   );
 
   layer(TestLive(testLiveOptions))(
+    '[Given] local toolkit filter [Then] it is sent as a custom toolkit',
+    it => {
+      it.scoped('injects and forwards local custom toolkit payloads', () =>
+        Effect.gen(function* () {
+          let createParams: SessionCreateParams | undefined;
+          let searchParams:
+            | (SessionSearchParams & { experimental?: SessionCreateParams['experimental'] })
+            | undefined;
+
+          const live = TestLive({
+            baseConfigProvider: testConfigProvider,
+            toolkitsData,
+            fixture: 'global-test-user-id',
+            toolRouter: {
+              create: async params => {
+                createParams = params;
+                return {
+                  session_id: 'trs_test_session',
+                  config: {
+                    user_id: params.user_id,
+                    execute: {},
+                    search: {},
+                    preload: { tools: [] },
+                  },
+                  config_version: 1,
+                  mcp: { type: 'http', url: 'https://mcp.test.composio.dev' },
+                  tool_router_tools: ['COMPOSIO_SEARCH_TOOLS'],
+                };
+              },
+              search: async (_sessionId, params) => {
+                searchParams = params;
+                return {
+                  success: true,
+                  error: null,
+                  results: [
+                    {
+                      index: 1,
+                      use_case: params.queries[0]?.use_case ?? '',
+                      primary_tool_slugs: ['LOCAL_CHROME_DEVTOOLS_LIST_PAGES'],
+                      related_tool_slugs: [],
+                      toolkits: ['CHROME_DEVTOOLS'],
+                    },
+                  ],
+                  tool_schemas: {
+                    LOCAL_CHROME_DEVTOOLS_LIST_PAGES: {
+                      tool_slug: 'LOCAL_CHROME_DEVTOOLS_LIST_PAGES',
+                      toolkit: 'CHROME_DEVTOOLS',
+                      description: 'List local Chrome pages',
+                      hasFullSchema: true,
+                      input_schema: { type: 'object', properties: {} },
+                      output_schema: { type: 'object', properties: {} },
+                    },
+                  },
+                  toolkit_connection_statuses: [
+                    {
+                      toolkit: 'CHROME_DEVTOOLS',
+                      description: 'Chrome DevTools local toolkit',
+                      has_active_connection: true,
+                      status_message: 'Local toolkit available',
+                    },
+                  ],
+                  next_steps_guidance: [],
+                  session: {
+                    id: 'trs_test_session',
+                    generate_id: false,
+                    instructions: 'Reuse this session id for follow-up calls.',
+                  },
+                  time_info: {
+                    current_time_utc: '2026-01-01T00:00:00.000Z',
+                    current_time_utc_epoch_seconds: 1767225600,
+                    message: 'UTC time',
+                  },
+                };
+              },
+            },
+          });
+
+          yield* cli(['search', 'browser page', '--toolkits', 'chrome_devtools']).pipe(
+            Effect.provide(live)
+          );
+
+          expect(createParams?.toolkits).toBeUndefined();
+          expect(createParams?.experimental?.custom_toolkits?.[0]?.slug).toBe('CHROME_DEVTOOLS');
+          expect(searchParams?.experimental?.custom_toolkits?.[0]?.slug).toBe('CHROME_DEVTOOLS');
+        })
+      );
+    }
+  );
+
+  layer(TestLive(testLiveOptions))(
     '[Given] unknown local-style toolkit filter [Then] it is still sent as a remote toolkit',
     it => {
-      it.scoped('does not inject experimental custom toolkits in the foundation package', () =>
+      it.scoped('does not inject experimental custom toolkits for unknown local-style names', () =>
         Effect.gen(function* () {
           let createParams: SessionCreateParams | undefined;
 

--- a/ts/packages/cli/vitest.config.ts
+++ b/ts/packages/cli/vitest.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
       '~': path.resolve(__dirname, './'),
       src: path.resolve(__dirname, './src'),
       test: path.resolve(__dirname, './test'),
+      '@composio/core/experimental': path.join(coreDir, 'src/experimental/index.ts'),
       '@composio/core': path.join(coreDir, 'src/index.ts'),
       '@composio/ts-builders': path.join(tsBuildersDir, 'src/index.ts'),
       '@composio/json-schema-to-zod': path.join(jsonSchemaToZodDir, 'src/index.ts'),

--- a/ts/packages/core/src/models/CustomTool.ts
+++ b/ts/packages/core/src/models/CustomTool.ts
@@ -270,6 +270,47 @@ function buildFinalSlug(toolSlug: string, toolkitSlug?: string): string {
     : `${LOCAL_TOOL_PREFIX}${upper}`;
 }
 
+const qualifiedOriginalSlugKey = (toolkit: string | undefined, originalSlug: string): string =>
+  `${toolkit?.toUpperCase() ?? ''}::${originalSlug.toUpperCase()}`;
+
+const canShareOriginalSlug = (existing: CustomToolsMapEntry, next: CustomToolsMapEntry): boolean =>
+  !!existing.toolkit &&
+  !!next.toolkit &&
+  existing.toolkit.toLowerCase() !== next.toolkit.toLowerCase();
+
+const addOriginalSlugAlias = (params: {
+  byOriginalSlug: Map<string, CustomToolsMapEntry>;
+  ambiguousOriginalSlugs: Set<string>;
+  originalSlug: string;
+  entry: CustomToolsMapEntry;
+}) => {
+  const originalSlugKey = params.originalSlug.toUpperCase();
+  if (params.ambiguousOriginalSlugs.has(originalSlugKey)) {
+    return;
+  }
+
+  const existing = params.byOriginalSlug.get(originalSlugKey);
+  if (!existing) {
+    params.byOriginalSlug.set(originalSlugKey, params.entry);
+    return;
+  }
+
+  if (existing.finalSlug.toUpperCase() === params.entry.finalSlug.toUpperCase()) {
+    return;
+  }
+
+  if (canShareOriginalSlug(existing, params.entry)) {
+    params.byOriginalSlug.delete(originalSlugKey);
+    params.ambiguousOriginalSlugs.add(originalSlugKey);
+    return;
+  }
+
+  throw new ValidationError(
+    `Custom tool slug collision: original slug "${params.originalSlug}" maps to multiple final slugs. ` +
+      `"${existing.finalSlug}" and "${params.entry.finalSlug}" both resolve from "${originalSlugKey}".`
+  );
+};
+
 /**
  * Build a CustomToolsMap from custom tools and toolkits.
  * Used internally by ToolRouter.create() to construct the per-session routing map.
@@ -286,6 +327,8 @@ export function buildCustomToolsMap(
 ): CustomToolsMap {
   const byFinalSlug = new Map<string, CustomToolsMapEntry>();
   const byOriginalSlug = new Map<string, CustomToolsMapEntry>();
+  const byToolkitAndOriginalSlug = new Map<string, CustomToolsMapEntry>();
+  const ambiguousOriginalSlugs = new Set<string>();
 
   const addEntry = (handle: CustomTool, finalSlug: string, toolkit?: string) => {
     const originalSlug = handle.slug.toUpperCase();
@@ -307,17 +350,17 @@ export function buildCustomToolsMap(
       );
     }
 
-    // Check cross-group collisions on original slug
-    if (byOriginalSlug.has(originalSlug)) {
+    const qualifiedKey = qualifiedOriginalSlugKey(toolkit, originalSlug);
+    if (byToolkitAndOriginalSlug.has(qualifiedKey)) {
       throw new ValidationError(
-        `Custom tool slug collision: original slug "${handle.slug}" maps to multiple final slugs. ` +
-          `"${byOriginalSlug.get(originalSlug)!.finalSlug}" and "${finalSlug}" both resolve from "${originalSlug}".`
+        `Custom tool slug collision: original slug "${handle.slug}" is already registered for toolkit "${toolkit ?? 'custom'}".`
       );
     }
 
     const entry: CustomToolsMapEntry = { handle, finalSlug, toolkit };
     byFinalSlug.set(finalSlugKey, entry);
-    byOriginalSlug.set(originalSlug, entry);
+    byToolkitAndOriginalSlug.set(qualifiedKey, entry);
+    addOriginalSlugAlias({ byOriginalSlug, ambiguousOriginalSlugs, originalSlug, entry });
   };
 
   // Process standalone tools
@@ -337,6 +380,8 @@ export function buildCustomToolsMap(
   return {
     byFinalSlug,
     byOriginalSlug,
+    byToolkitAndOriginalSlug,
+    ...(ambiguousOriginalSlugs.size ? { ambiguousOriginalSlugs } : {}),
     toolkits,
     tools: tools.length ? tools : undefined,
   };
@@ -443,34 +488,64 @@ export function buildCustomToolsMapFromResponse(
 ): CustomToolsMap {
   const byFinalSlug = new Map<string, CustomToolsMapEntry>();
   const byOriginalSlug = new Map<string, CustomToolsMapEntry>();
+  const byToolkitAndOriginalSlug = new Map<string, CustomToolsMapEntry>();
+  const ambiguousOriginalSlugs = new Set<string>();
 
-  // Build a lookup from original slug → custom tool handle (for matching response items)
-  const handlesByOriginalSlug = new Map<string, { handle: CustomTool; toolkit?: string }>();
+  type HandleMatch = { handle: CustomTool; toolkit?: string };
+  const handlesByQualifiedOriginalSlug = new Map<string, HandleMatch>();
+  const handlesByOriginalSlug = new Map<string, HandleMatch[]>();
+
+  const registerHandle = (handle: CustomTool, toolkit?: string) => {
+    const originalSlug = handle.slug.toUpperCase();
+    const match = { handle, toolkit };
+    handlesByQualifiedOriginalSlug.set(qualifiedOriginalSlugKey(toolkit, originalSlug), match);
+    const existing = handlesByOriginalSlug.get(originalSlug) ?? [];
+    existing.push(match);
+    handlesByOriginalSlug.set(originalSlug, existing);
+  };
+
   for (const handle of tools) {
-    handlesByOriginalSlug.set(handle.slug.toUpperCase(), {
-      handle,
-      toolkit: handle.extendsToolkit,
-    });
+    registerHandle(handle, handle.extendsToolkit);
   }
   if (toolkits) {
     for (const tk of toolkits) {
       for (const handle of tk.tools) {
-        handlesByOriginalSlug.set(handle.slug.toUpperCase(), { handle, toolkit: tk.slug });
+        registerHandle(handle, tk.slug);
       }
     }
   }
 
-  const addEntry = (finalSlug: string, originalSlug: string, toolkit?: string) => {
-    const match = handlesByOriginalSlug.get(originalSlug.toUpperCase());
+  const findHandle = (originalSlug: string, toolkit?: string): HandleMatch | undefined => {
+    const originalSlugKey = originalSlug.toUpperCase();
+    const qualifiedMatch = handlesByQualifiedOriginalSlug.get(
+      qualifiedOriginalSlugKey(toolkit, originalSlugKey)
+    );
+    if (qualifiedMatch) return qualifiedMatch;
+
+    const bareMatches = handlesByOriginalSlug.get(originalSlugKey) ?? [];
+    return bareMatches.length === 1 ? bareMatches[0] : undefined;
+  };
+
+  const addEntry = (finalSlug: string, originalSlug: string, toolkit?: string | null) => {
+    const resolvedToolkit = toolkit ?? undefined;
+    const match = findHandle(originalSlug, resolvedToolkit);
     if (!match) return; // Response tool not found in our handles (shouldn't happen)
+
+    const finalSlugKey = finalSlug.toUpperCase();
+    if (byFinalSlug.has(finalSlugKey)) {
+      throw new ValidationError(
+        `Custom tool slug collision: "${finalSlug}" is already registered.`
+      );
+    }
 
     const entry: CustomToolsMapEntry = {
       handle: match.handle,
       finalSlug,
-      toolkit: toolkit ?? match.toolkit,
+      toolkit: resolvedToolkit ?? match.toolkit,
     };
-    byFinalSlug.set(finalSlug.toUpperCase(), entry);
-    byOriginalSlug.set(originalSlug.toUpperCase(), entry);
+    byFinalSlug.set(finalSlugKey, entry);
+    byToolkitAndOriginalSlug.set(qualifiedOriginalSlugKey(entry.toolkit, originalSlug), entry);
+    addOriginalSlugAlias({ byOriginalSlug, ambiguousOriginalSlugs, originalSlug, entry });
   };
 
   // Map standalone custom tools from response
@@ -492,6 +567,8 @@ export function buildCustomToolsMapFromResponse(
   return {
     byFinalSlug,
     byOriginalSlug,
+    byToolkitAndOriginalSlug,
+    ...(ambiguousOriginalSlugs.size ? { ambiguousOriginalSlugs } : {}),
     toolkits,
     tools: tools.length ? tools : undefined,
   };
@@ -507,6 +584,19 @@ export function findCustomToolMapEntryByFinalSlug(
   slug: string
 ): CustomToolsMapEntry | undefined {
   return customToolsMap?.byFinalSlug.get(slug.toUpperCase());
+}
+
+/**
+ * Find a custom toolkit tool entry by toolkit slug and original tool slug.
+ *
+ * @internal
+ */
+export function findCustomToolMapEntryByToolkitAndOriginalSlug(
+  customToolsMap: CustomToolsMap | undefined,
+  toolkit: string | undefined,
+  slug: string
+): CustomToolsMapEntry | undefined {
+  return customToolsMap?.byToolkitAndOriginalSlug?.get(qualifiedOriginalSlugKey(toolkit, slug));
 }
 
 /**
@@ -531,6 +621,7 @@ export function assertNoCustomToolSlugsInPreload(
     return (
       normalized.startsWith(LOCAL_TOOL_PREFIX) ||
       customToolsMap?.byOriginalSlug.has(normalized) ||
+      customToolsMap?.ambiguousOriginalSlugs?.has(normalized) ||
       customToolsMap?.byFinalSlug.has(normalized)
     );
   });

--- a/ts/packages/core/src/models/SessionContext.ts
+++ b/ts/packages/core/src/models/SessionContext.ts
@@ -18,7 +18,11 @@ import {
 } from '../types/toolRouter.types';
 import { ValidationError } from '../errors';
 import { transformProxyParams } from './proxyParamsTransform';
-import { findCustomTool, executeCustomTool } from './customToolExecution';
+import {
+  assertUnambiguousCustomToolSlug,
+  findCustomTool,
+  executeCustomTool,
+} from './customToolExecution';
 import { transformExecuteResponse } from '../utils/transformers/toolRouterResponseTransform';
 import type { SessionExecuteParams } from '@composio/client/resources/tool-router/session/session.mjs';
 import { inlineCustomToolsExperimental } from './inlineCustomToolsPayload';
@@ -66,6 +70,7 @@ export class SessionContextImpl implements SessionContext {
         logId: '',
       });
     }
+    assertUnambiguousCustomToolSlug(this.customToolsMap, toolSlug);
 
     // Fall back to remote execution
     const executeParams: SessionExecuteParams = {

--- a/ts/packages/core/src/models/ToolRouterSession.ts
+++ b/ts/packages/core/src/models/ToolRouterSession.ts
@@ -45,8 +45,15 @@ import type {
 } from '@composio/client/resources/tool-router/session/session.mjs';
 import { SessionProxyExecuteParamsSchema } from '../types/toolRouter.types';
 import { SessionContextImpl } from './SessionContext';
-import { findCustomTool, executeCustomTool } from './customToolExecution';
-import { findCustomToolMapEntryByFinalSlug } from './CustomTool';
+import {
+  assertUnambiguousCustomToolSlug,
+  findCustomTool,
+  executeCustomTool,
+} from './customToolExecution';
+import {
+  findCustomToolMapEntryByFinalSlug,
+  findCustomToolMapEntryByToolkitAndOriginalSlug,
+} from './CustomTool';
 import { transformProxyParams } from './proxyParamsTransform';
 import { inlineCustomToolsExperimental } from './inlineCustomToolsPayload';
 
@@ -139,12 +146,13 @@ export class ToolRouterSession<
         if (customTool) {
           return executeCustomTool(customTool, input, this.sessionContext!);
         }
+        assertUnambiguousCustomToolSlug(this.customToolsMap, toolSlug);
         return this.executeBackendSessionTool(
           ToolsModel,
           toolSlug,
           input,
           modifiers,
-          toolBySlug.get(toolSlug.toUpperCase()),
+          toolBySlug.get(toolSlug.toUpperCase())
         );
       };
 
@@ -272,8 +280,11 @@ export class ToolRouterSession<
       name: tk.name,
       description: tk.description,
       tools: tk.tools.map(tool => {
-        // Look up the entry to get the final slug
-        const entry = this.customToolsMap!.byOriginalSlug.get(tool.slug.toUpperCase());
+        // Look up by toolkit + original slug so toolkits can safely reuse common names
+        // like VERSION, CLICK, or SEARCH without losing the backend-assigned final slug.
+        const entry =
+          findCustomToolMapEntryByToolkitAndOriginalSlug(this.customToolsMap, tk.slug, tool.slug) ??
+          this.customToolsMap!.byOriginalSlug.get(tool.slug.toUpperCase());
         return {
           slug: entry?.finalSlug ?? tool.slug,
           name: tool.name,
@@ -412,6 +423,7 @@ export class ToolRouterSession<
         logId: '',
       };
     }
+    assertUnambiguousCustomToolSlug(this.customToolsMap, toolSlug);
 
     // Remote execution
     const executeParams: SessionExecuteParams = {
@@ -541,6 +553,7 @@ export class ToolRouterSession<
       if (entry) {
         localItems.push({ index: i, entry });
       } else {
+        assertUnambiguousCustomToolSlug(this.customToolsMap, parsed[i].tool_slug);
         remoteIndices.push(i);
       }
     }

--- a/ts/packages/core/src/models/customToolExecution.ts
+++ b/ts/packages/core/src/models/customToolExecution.ts
@@ -2,8 +2,13 @@
  * @fileoverview Standalone functions for custom tool lookup and execution.
  * Extracted from ToolRouterSession for reuse in SessionContextImpl (sibling routing).
  */
-import type { CustomToolsMap, CustomToolsMapEntry, SessionContext } from '../types/customTool.types';
+import type {
+  CustomToolsMap,
+  CustomToolsMapEntry,
+  SessionContext,
+} from '../types/customTool.types';
 import type { ToolExecuteResponse } from '../types/tool.types';
+import { ValidationError } from '../errors';
 
 /**
  * Find a custom tool entry by slug.
@@ -15,7 +20,36 @@ export function findCustomTool(
 ): CustomToolsMapEntry | undefined {
   if (!map) return undefined;
   const upper = slug.toUpperCase();
-  return map.byFinalSlug.get(upper) ?? map.byOriginalSlug.get(upper);
+  const finalSlugMatch = map.byFinalSlug.get(upper);
+  if (finalSlugMatch) return finalSlugMatch;
+  if (map.ambiguousOriginalSlugs?.has(upper)) return undefined;
+  return map.byOriginalSlug.get(upper);
+}
+
+/**
+ * Reject ambiguous bare original slugs before falling through to backend execution.
+ * Agents receive final slugs (LOCAL_<TOOLKIT>_<TOOL>) from schemas, while bare original
+ * slugs are only a convenience for manual session.execute() calls when unique.
+ */
+export function assertUnambiguousCustomToolSlug(
+  map: CustomToolsMap | undefined,
+  slug: string
+): void {
+  if (!map) return;
+  const upper = slug.toUpperCase();
+  if (!map.ambiguousOriginalSlugs?.has(upper)) return;
+
+  const finalSlugs = [...map.byFinalSlug.values()]
+    .filter(entry => entry.handle.slug.toUpperCase() === upper)
+    .map(entry => entry.finalSlug)
+    .sort();
+  const hint = finalSlugs.length ? ` Use one of: ${finalSlugs.join(', ')}.` : '';
+
+  throw new ValidationError(
+    `Ambiguous custom tool slug "${slug}". Multiple custom toolkit tools share this original slug; ` +
+      `manual session.execute() by original slug is only supported when the original slug is unique.` +
+      hint
+  );
 }
 
 /**

--- a/ts/packages/core/src/types/customTool.types.ts
+++ b/ts/packages/core/src/types/customTool.types.ts
@@ -262,8 +262,12 @@ export type CustomToolsMapEntry = {
 export type CustomToolsMap = {
   /** Lookup by final slug (e.g. LOCAL_GET_USER_CONTEXT) — used for agent execution path */
   byFinalSlug: Map<string, CustomToolsMapEntry>;
-  /** Lookup by original slug (e.g. GET_USER_CONTEXT) — used for programmatic session.execute() */
+  /** Lookup by unique original slug (e.g. GET_USER_CONTEXT) — used for programmatic session.execute() */
   byOriginalSlug: Map<string, CustomToolsMapEntry>;
+  /** Lookup by resolved toolkit + original slug — used when multiple custom toolkits reuse tool names */
+  byToolkitAndOriginalSlug?: Map<string, CustomToolsMapEntry>;
+  /** Original slugs that appear in multiple toolkits and cannot be resolved safely without the final slug */
+  ambiguousOriginalSlugs?: Set<string>;
   /** The original custom toolkits passed at session creation — used for session.customToolkits() */
   toolkits?: CustomToolkit[];
   /** The original standalone custom tools passed at session creation — kept for inline re-injection on subsequent v3.1 requests. */


### PR DESCRIPTION
## Summary
- Stacks this local-tools PR on top of #3360, which contains the core duplicate custom-toolkit child slug fix.
- Refactors `@composio/cli-local-tools` to define bundled local toolkits with core `experimental_createTool` / `experimental_createToolkit` handles instead of hand-rolled schema objects.
- Keeps Tool Router v3.1 inline custom toolkit definitions attached to session create/search/execute calls so bundled local tools remain searchable/executable.
- Adds CLI/local-tools test coverage for forwarding local custom toolkit payloads and for core custom toolkit handles from the local registry.

## Stack
- Base PR: #3360 (`fix(core): qualify custom toolkit child slug lookups`)
- This PR should now show only CLI/local-tools changes relative to #3360.

## Tests
- `pnpm --filter @composio/core typecheck`
- `pnpm --filter @composio/cli-local-tools typecheck`
- `pnpm --filter @composio/cli typecheck`
- `pnpm --filter @composio/cli-local-tools test`
- `pnpm --filter @composio/cli-local-tools build`
- `pnpm --filter @composio/cli exec vitest run test/src/commands/tools/tools.search.cmd.test.ts test/src/commands/tools/tools.execute.cmd.test.ts`
- `pnpm --filter @composio/core exec vitest run test/models/customTool.test.ts test/models/toolRouter.test.ts test/models/customToolRouting.test.ts`