### PR TITLE
docs: add .use() with custom tools, update connectedAccounts to array

### DIFF
--- a/docs/content/docs/configuring-sessions.mdx
+++ b/docs/content/docs/configuring-sessions.mdx
@@ -24,7 +24,7 @@ const session = await composio.create("user_123");
 
 By default, a session has access to **all toolkits** in the Composio catalog. Your agent can discover and use any of them through `COMPOSIO_SEARCH_TOOLS`. Use the options below to restrict or customize what's available.
 
-For TypeScript sessions, you can also attach local experimental custom tools and custom toolkits that run in-process with Composio tools. See [Custom tools and toolkits](/docs/toolkits/custom-tools-and-toolkits).
+You can also attach local experimental custom tools and custom toolkits that run in-process alongside Composio tools. See [Custom tools and toolkits](/docs/toolkits/custom-tools-and-toolkits).
 
 ## Enabling toolkits
 
@@ -373,8 +373,8 @@ If a user has multiple connected accounts for the same toolkit, you can specify 
 session = composio.create(
     user_id="user_123",
     connected_accounts={
-        "gmail": "ca_work_gmail",
-        "github": "ca_personal_github"
+        "gmail": ["ca_work_gmail"],
+        "github": ["ca_personal_github"],
     }
 )
 ```
@@ -386,13 +386,15 @@ const composio = new Composio({ apiKey: 'your_api_key' });
 // ---cut---
 const session = await composio.create("user_123", {
   connectedAccounts: {
-    gmail: "ca_work_gmail",
-    github: "ca_personal_github",
+    gmail: ["ca_work_gmail"],
+    github: ["ca_personal_github"],
   },
 });
 ```
 </Tab>
 </Tabs>
+
+Only one account per toolkit is allowed when [multi-account mode](/docs/managing-multiple-connected-accounts) is disabled.
 
 ### Precedence
 

--- a/docs/content/docs/configuring-sessions.mdx
+++ b/docs/content/docs/configuring-sessions.mdx
@@ -394,7 +394,9 @@ const session = await composio.create("user_123", {
 </Tab>
 </Tabs>
 
-Only one account per toolkit is allowed when [multi-account mode](/docs/managing-multiple-connected-accounts) is disabled.
+<Callout type="info">
+Arrays are the preferred format for `connectedAccounts`. A single string (e.g. `"ca_work_gmail"`) is still accepted for backwards compatibility and is automatically coerced to a single-element array. Only one account per toolkit is allowed when [multi-account mode](/docs/managing-multiple-connected-accounts) is disabled.
+</Callout>
 
 ### Precedence
 

--- a/docs/content/docs/glossary.mdx
+++ b/docs/content/docs/glossary.mdx
@@ -40,7 +40,7 @@ The object returned when you initiate authentication. Contains the Connect Link 
 </GlossaryTerm>
 
 <GlossaryTerm name="Custom Tool">
-A user-defined tool used alongside Composio's built-in tools. For sessions, use local experimental custom tools and custom toolkits (TypeScript only) via [Custom tools and toolkits](/docs/toolkits/custom-tools-and-toolkits). For direct execution, see [Creating custom tools](/docs/tools-direct/custom-tools).
+A user-defined tool used alongside Composio's built-in tools. For sessions, use local experimental custom tools and custom toolkits via [Custom tools and toolkits](/docs/toolkits/custom-tools-and-toolkits). For direct execution, see [Creating custom tools](/docs/tools-direct/custom-tools).
 </GlossaryTerm>
 
 <GlossaryTerm name="In-Chat Authentication">

--- a/docs/content/docs/managing-multiple-connected-accounts.mdx
+++ b/docs/content/docs/managing-multiple-connected-accounts.mdx
@@ -192,8 +192,8 @@ Pin a session to specific accounts by passing their IDs in the session config. T
 session = composio.create(
     user_id="user_123",
     connected_accounts={
-        "gmail": "ca_work_gmail_id",
-        "github": "ca_personal_github_id",
+        "gmail": ["ca_work_gmail_id"],
+        "github": ["ca_personal_github_id"],
     },
 )
 ```
@@ -206,8 +206,8 @@ const composio = new Composio({ apiKey: 'your_api_key' });
 // ---cut---
 const session = await composio.create("user_123", {
   connectedAccounts: {
-    gmail: "ca_work_gmail_id",
-    github: "ca_personal_github_id",
+    gmail: ["ca_work_gmail_id"],
+    github: ["ca_personal_github_id"],
   },
 });
 ```

--- a/docs/content/docs/migration-guide/direct-to-sessions.mdx
+++ b/docs/content/docs/migration-guide/direct-to-sessions.mdx
@@ -241,7 +241,7 @@ session = composio.create(
         "gmail": "ac_your_gmail_config"
     },
     connected_accounts={
-        "gmail": "ca_work_gmail"
+        "gmail": ["ca_work_gmail"]
     }
 )
 ```
@@ -256,7 +256,7 @@ const session = await composio.create("user_123", {
     gmail: "ac_your_gmail_config",
   },
   connectedAccounts: {
-    gmail: "ca_work_gmail",
+    gmail: ["ca_work_gmail"],
   },
 });
 ```

--- a/docs/content/docs/providers/anthropic.mdx
+++ b/docs/content/docs/providers/anthropic.mdx
@@ -148,3 +148,41 @@ for (const block of response.content) {
 </Tabs>
 </Step>
 </Steps>
+
+## Multi-turn chat
+
+For multi-turn apps, create the session once and reuse it across requests with `composio.use()`:
+
+<Tabs groupId="language" items={["Python", "TypeScript"]} persist>
+<Tab value="Python">
+```python
+from composio import Composio
+
+composio = Composio()
+
+# First request — create and store the session ID
+session = composio.create(user_id="user_123")
+session_id = session.session_id
+# store session_id in your database or chat state
+
+# Subsequent requests — reuse the session
+session = composio.use(session_id)
+tools = session.tools()
+```
+</Tab>
+<Tab value="TypeScript">
+```typescript
+import { Composio } from '@composio/core';
+const composio = new Composio({ apiKey: 'your_api_key' });
+// ---cut---
+// First request — create and store the session ID
+const session = await composio.create("user_123");
+const sessionId = session.sessionId;
+// store sessionId in your database or chat state
+
+// Subsequent requests — reuse the session
+const session2 = await composio.use(sessionId);
+const tools = await session2.tools();
+```
+</Tab>
+</Tabs>

--- a/docs/content/docs/providers/openai.mdx
+++ b/docs/content/docs/providers/openai.mdx
@@ -297,3 +297,41 @@ console.log(response.choices[0].message.content);
 </IntegrationContent>
 
 </IntegrationTabs>
+
+## Multi-turn chat
+
+For multi-turn apps, create the session once and reuse it across requests with `composio.use()`. Store the session ID in your database or chat state:
+
+<Tabs groupId="language" items={["Python", "TypeScript"]} persist>
+<Tab value="Python">
+```python
+from composio import Composio
+
+composio = Composio()
+
+# First request — create and store the session ID
+session = composio.create(user_id="user_123")
+session_id = session.session_id
+# store session_id in your database or chat state
+
+# Subsequent requests — reuse the session
+session = composio.use(session_id)
+tools = session.tools()
+```
+</Tab>
+<Tab value="TypeScript">
+```typescript
+import { Composio } from '@composio/core';
+const composio = new Composio({ apiKey: 'your_api_key' });
+// ---cut---
+// First request — create and store the session ID
+const session = await composio.create("user_123");
+const sessionId = session.sessionId;
+// store sessionId in your database or chat state
+
+// Subsequent requests — reuse the session
+const session2 = await composio.use(sessionId);
+const tools = await session2.tools();
+```
+</Tab>
+</Tabs>

--- a/docs/content/docs/providers/vercel.mdx
+++ b/docs/content/docs/providers/vercel.mdx
@@ -56,3 +56,32 @@ console.log(text);
 ```
 </Step>
 </Steps>
+
+## Multi-turn chat
+
+For multi-turn apps, create the session once and reuse it across requests with `composio.use()`:
+
+```typescript
+import { anthropic } from "@ai-sdk/anthropic";
+import { Composio } from "@composio/core";
+import { VercelProvider } from "@composio/vercel";
+import { generateText, stepCountIs } from "ai";
+
+const composio = new Composio({ provider: new VercelProvider() });
+
+// First request — create and store the session ID
+const session = await composio.create("user_123");
+const sessionId = session.sessionId;
+// store sessionId in your database or chat state
+
+// Subsequent requests — reuse the session
+const session2 = await composio.use(sessionId);
+const tools = await session2.tools();
+
+const { text } = await generateText({
+  model: anthropic("claude-opus-4-6"),
+  tools,
+  prompt: "What emails did I get today?",
+  stopWhen: stepCountIs(10),
+});
+```

--- a/docs/content/docs/sessions-vs-direct-execution.mdx
+++ b/docs/content/docs/sessions-vs-direct-execution.mdx
@@ -89,7 +89,7 @@ session = composio.create(
     user_id="user_123",
     toolkits=["github", "gmail"],
     auth_configs={"github": "ac_my_config"},
-    connected_accounts={"gmail": "ca_work"},
+    connected_accounts={"gmail": ["ca_work"]},
 )
 ```
 </Tab>
@@ -101,7 +101,7 @@ const composio = new Composio({ apiKey: 'your_api_key' });
 const session = await composio.create("user_123", {
   toolkits: ["github", "gmail"],
   authConfigs: { github: "ac_my_config" },
-  connectedAccounts: { gmail: "ca_work" },
+  connectedAccounts: { gmail: ["ca_work"] },
 });
 ```
 </Tab>

--- a/docs/content/docs/toolkits/custom-tools-and-toolkits.mdx
+++ b/docs/content/docs/toolkits/custom-tools-and-toolkits.mdx
@@ -636,6 +636,66 @@ custom_toolkits = session.custom_toolkits()
 </Tab>
 </Tabs>
 
+## Attaching custom tools to an existing session
+
+Use `composio.use()` to rehydrate an existing session and attach custom tools to it. This is useful when you have a session ID from a previous `create()` call and want to bind custom tools in a different process or request.
+
+<Tabs groupId="language" items={['TypeScript', 'Python']} persist>
+<Tab value="TypeScript">
+```typescript
+// @noErrors
+import { Composio, experimental_createTool } from "@composio/core";
+import { z } from "zod/v3";
+
+declare const getUserProfile: ReturnType<typeof experimental_createTool>;
+const composio = new Composio({ apiKey: "your_api_key" });
+// ---cut---
+
+// Rehydrate with custom tools
+const session = await composio.use("session_id", {
+  customTools: [getUserProfile],
+});
+
+const tools = await session.tools();
+```
+</Tab>
+<Tab value="Python">
+```python
+from composio import Composio
+
+composio = Composio(api_key="your_api_key")
+
+# Rehydrate with custom tools
+session = composio.use(
+    "session_id",
+    custom_tools=[get_user_profile],
+)
+
+tools = session.tools()
+```
+</Tab>
+</Tabs>
+
+Without custom tools, `composio.use()` simply rehydrates the session:
+
+<Tabs groupId="language" items={['TypeScript', 'Python']} persist>
+<Tab value="TypeScript">
+```typescript
+// @noErrors
+import { Composio } from "@composio/core";
+const composio = new Composio({ apiKey: "your_api_key" });
+// ---cut---
+
+const session = await composio.use("session_id");
+```
+</Tab>
+<Tab value="Python">
+```python
+session = composio.use("session_id")
+```
+</Tab>
+</Tabs>
+
 ## Programmatic execution
 
 Use `session.execute()` to run custom tools directly, outside of an agent loop. Custom tools execute in-process; remote tools are sent to the backend automatically.

--- a/docs/content/docs/toolkits/custom-tools-and-toolkits.mdx
+++ b/docs/content/docs/toolkits/custom-tools-and-toolkits.mdx
@@ -636,9 +636,9 @@ custom_toolkits = session.custom_toolkits()
 </Tab>
 </Tabs>
 
-## Attaching custom tools to an existing session
+## Reusing a session with custom tools
 
-Use `composio.use()` to rehydrate an existing session and attach custom tools to it. This is useful when you have a session ID from a previous `create()` call and want to bind custom tools in a different process or request.
+When [reusing a session](/docs/users-and-sessions#reusing-a-session) via `composio.use()`, you can attach custom tools at the same time:
 
 <Tabs groupId="language" items={['TypeScript', 'Python']} persist>
 <Tab value="TypeScript">
@@ -650,12 +650,9 @@ declare const getUserProfile: ReturnType<typeof experimental_createTool>;
 const composio = new Composio({ apiKey: "your_api_key" });
 // ---cut---
 
-// Rehydrate with custom tools
 const session = await composio.use("session_id", {
   customTools: [getUserProfile],
 });
-
-const tools = await session.tools();
 ```
 </Tab>
 <Tab value="Python">
@@ -664,32 +661,10 @@ from composio import Composio
 
 composio = Composio(api_key="your_api_key")
 
-# Rehydrate with custom tools
 session = composio.use(
     "session_id",
     custom_tools=[get_user_profile],
 )
-
-tools = session.tools()
-```
-</Tab>
-</Tabs>
-
-Without custom tools, `composio.use()` simply rehydrates the session:
-
-<Tabs groupId="language" items={['TypeScript', 'Python']} persist>
-<Tab value="TypeScript">
-```typescript
-import { Composio } from "@composio/core";
-const composio = new Composio({ apiKey: "your_api_key" });
-// ---cut---
-
-const session = await composio.use("session_id");
-```
-</Tab>
-<Tab value="Python">
-```python
-session = composio.use("session_id")
 ```
 </Tab>
 </Tabs>

--- a/docs/content/docs/toolkits/custom-tools-and-toolkits.mdx
+++ b/docs/content/docs/toolkits/custom-tools-and-toolkits.mdx
@@ -643,7 +643,6 @@ Use `composio.use()` to rehydrate an existing session and attach custom tools to
 <Tabs groupId="language" items={['TypeScript', 'Python']} persist>
 <Tab value="TypeScript">
 ```typescript
-// @noErrors
 import { Composio, experimental_createTool } from "@composio/core";
 import { z } from "zod/v3";
 
@@ -681,7 +680,6 @@ Without custom tools, `composio.use()` simply rehydrates the session:
 <Tabs groupId="language" items={['TypeScript', 'Python']} persist>
 <Tab value="TypeScript">
 ```typescript
-// @noErrors
 import { Composio } from "@composio/core";
 const composio = new Composio({ apiKey: "your_api_key" });
 // ---cut---

--- a/docs/content/docs/users-and-sessions.mdx
+++ b/docs/content/docs/users-and-sessions.mdx
@@ -107,9 +107,11 @@ A session ties together a user, a set of available toolkits, auth configuration 
 
 You don't need to cache session IDs, manage session lifetimes, or worry about expiration. Sessions persist on the server and don't expire. Just call `create()` with what you need.
 
-### Sessions are immutable
+### Session configuration is fixed at creation
 
-A session's configuration is fixed at creation. You cannot change the toolkits, auth configs, or connected accounts on an existing session.
+A session's toolkits, auth configs, and connected accounts are fixed at creation. You cannot change them on an existing session.
+
+The one exception is [custom tools](/docs/toolkits/custom-tools-and-toolkits): you can attach custom tools to an existing session via `composio.use(sessionId, { customTools: [...] })`.
 
 This means the boundary for a new session isn't a new chat or a new request. It's when the contract changes. If a user starts with "search my personal Gmail" and then says "actually use my work email," that's a different session because the auth changed.
 

--- a/docs/content/docs/users-and-sessions.mdx
+++ b/docs/content/docs/users-and-sessions.mdx
@@ -107,13 +107,29 @@ A session ties together a user, a set of available toolkits, auth configuration 
 
 You don't need to cache session IDs, manage session lifetimes, or worry about expiration. Sessions persist on the server and don't expire. Just call `create()` with what you need.
 
-### Session configuration is fixed at creation
+### Reusing a session
 
-A session's toolkits, auth configs, and connected accounts are fixed at creation. You cannot change them on an existing session.
+In multi-turn chat apps, you create a session once and reuse it across requests. Store the session ID and call `composio.use()` to rehydrate it:
 
-The one exception is [custom tools](/docs/toolkits/custom-tools-and-toolkits): you can attach custom tools to an existing session via `composio.use(sessionId, { customTools: [...] })`.
+<Tabs groupId="language" items={['Python', 'TypeScript']} persist>
+<Tab value="Python">
+```python
+session = composio.use("session_id")
+tools = session.tools()
+```
+</Tab>
+<Tab value="TypeScript">
+```typescript
+import { Composio } from '@composio/core';
+const composio = new Composio({ apiKey: 'your_api_key' });
+// ---cut---
+const session = await composio.use("session_id");
+const tools = await session.tools();
+```
+</Tab>
+</Tabs>
 
-This means the boundary for a new session isn't a new chat or a new request. It's when the contract changes. If a user starts with "search my personal Gmail" and then says "actually use my work email," that's a different session because the auth changed.
+This returns the same session with the same toolkits, auth configs, and connected accounts. The session's configuration is fixed at creation — to change toolkits or auth, create a new session.
 
 ### Connected accounts persist across sessions
 
@@ -121,7 +137,7 @@ Connections are tied to the user ID, not the session. A user who connected Gmail
 
 <Accordions>
 <Accordion title="When should I create a new session?">
-Create a new session when the config changes: different toolkits, different auth config, or a different connected account. You don't need to store or manage session IDs. Just call `create()` each time.
+Create a new session when the config changes: different toolkits, different auth config, or a different connected account. For multi-turn conversations where the config stays the same, reuse the session with `composio.use()`.
 </Accordion>
 </Accordions>
 

--- a/docs/content/docs/users-and-sessions.mdx
+++ b/docs/content/docs/users-and-sessions.mdx
@@ -103,9 +103,11 @@ const toolkits = await session.toolkits();
 
 ## How sessions behave
 
-A session ties together a user, a set of available toolkits, auth configuration for those toolkits, and connected accounts. Call `create()` whenever you want to do a task. Each session is designed for a particular agentic task, and if you want to change the context of the task, create a new session.
+A session ties together a user, a set of available toolkits, auth configuration for those toolkits, and connected accounts. Each session is designed for a particular agentic task.
 
-You don't need to cache session IDs, manage session lifetimes, or worry about expiration. Sessions persist on the server and don't expire. Just call `create()` with what you need.
+Every call to `create()` returns a new session ID, even if the configuration is identical. This gives you clean isolation between tasks and makes it easy to trace activity back to a specific session in logs and analytics.
+
+Sessions persist on the server and don't expire. For multi-turn conversations, store the session ID and reuse it with `composio.use()` rather than calling `create()` again.
 
 ### Reusing a session
 

--- a/docs/content/docs/users-and-sessions.mdx
+++ b/docs/content/docs/users-and-sessions.mdx
@@ -137,7 +137,7 @@ Connections are tied to the user ID, not the session. A user who connected Gmail
 
 <Accordions>
 <Accordion title="When should I create a new session?">
-Create a new session when the config changes: different toolkits, different auth config, or a different connected account. For multi-turn conversations where the config stays the same, reuse the session with `composio.use()`.
+Reuse a session with `composio.use()` for multi-turn conversations. Create a new session when you need a fundamentally different setup (e.g., a different user or a completely different set of toolkits).
 </Accordion>
 </Accordions>
 


### PR DESCRIPTION
## Summary
- Added "Attaching custom tools to an existing session" section to custom-tools-and-toolkits.mdx showing `composio.use()` with TS + Python examples
- Updated all `connectedAccounts` examples from string to array format (`string[]`) matching the v3.1 SDK types shipped in #3350
- Noted multi-account restriction: only one account per toolkit when multi-account mode is disabled
- Updated users-and-sessions: session config is fixed at creation, except custom tools can be attached via `.use()`
- Removed TypeScript-only qualifier for custom tools (Python now supported)

## Files changed
- `docs/content/docs/toolkits/custom-tools-and-toolkits.mdx`
- `docs/content/docs/configuring-sessions.mdx`
- `docs/content/docs/users-and-sessions.mdx`
- `docs/content/docs/managing-multiple-connected-accounts.mdx`
- `docs/content/docs/sessions-vs-direct-execution.mdx`
- `docs/content/docs/migration-guide/direct-to-sessions.mdx`

## Test plan
- [ ] Verify docs build passes
- [ ] Check new .use() section renders correctly with TS/Python tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)