### PR TITLE
chore: add changesets for v3.1 customs and connectedAccounts coercion

### DIFF
--- a/.changeset/v31-connected-accounts-array.md
+++ b/.changeset/v31-connected-accounts-array.md
@@ -1,0 +1,7 @@
+---
+'@composio/core': minor
+---
+
+Update `connectedAccounts` from `Record<string, string>` to `Record<string, string[]>`.
+
+Matches the v3.1 API where each toolkit maps to an array of connected account IDs. Only one account per toolkit is allowed when multi-account mode is disabled. Bumps `@composio/client` to `0.1.0-alpha.70`.

--- a/.changeset/v31-connected-accounts-array.md
+++ b/.changeset/v31-connected-accounts-array.md
@@ -2,6 +2,6 @@
 '@composio/core': minor
 ---
 
-Update `connectedAccounts` from `Record<string, string>` to `Record<string, string[]>`.
+`connectedAccounts` now accepts both `string` and `string[]` per toolkit.
 
-Matches the v3.1 API where each toolkit maps to an array of connected account IDs. Only one account per toolkit is allowed when multi-account mode is disabled. Bumps `@composio/client` to `0.1.0-alpha.70`.
+A single string is automatically coerced to an array to match the v3.1 API wire format. Existing callers passing `{ gmail: "ca_xxx" }` continue to work without changes. Only one account per toolkit is allowed when multi-account mode is disabled. Bumps `@composio/client` to `0.1.0-alpha.70`.

--- a/.changeset/v31-customs-use-attach.md
+++ b/.changeset/v31-customs-use-attach.md
@@ -4,6 +4,6 @@
 
 Add custom tools support to `composio.use()`.
 
-- **`composio.use(id, { customTools, customToolkits })`**: Attach custom tools to an existing session. Calls the v3.1 `/attach` endpoint to bind local tools for search and execution. Without customs, falls back to the standard session retrieve.
+- **`composio.use(id, { customTools, customToolkits })`**: Attach custom tools to an existing session. Binds local tools for search and execution. When called without custom tools, falls back to the standard session retrieve.
 - **Inline custom tools payload**: `use()` now correctly passes `inlineCustomToolsPayload` and `preloadedCustomToolSlugs` to the session, enabling custom tool execution and preloading on rehydrated sessions.
 - **`CustomToolsMap.tools`**: The map now caches the raw `CustomTool[]` array for future inline re-injection on v3.1 search/execute requests.

--- a/.changeset/v31-customs-use-attach.md
+++ b/.changeset/v31-customs-use-attach.md
@@ -2,10 +2,8 @@
 '@composio/core': minor
 ---
 
-Add custom tools support to `composio.use()` and update `connectedAccounts` to array type.
+Add custom tools support to `composio.use()`.
 
 - **`composio.use(id, { customTools, customToolkits })`**: Attach custom tools to an existing session. Calls the v3.1 `/attach` endpoint to bind local tools for search and execution. Without customs, falls back to the standard session retrieve.
 - **Inline custom tools payload**: `use()` now correctly passes `inlineCustomToolsPayload` and `preloadedCustomToolSlugs` to the session, enabling custom tool execution and preloading on rehydrated sessions.
-- **`connectedAccounts` type change**: Updated from `Record<string, string>` to `Record<string, string[]>` to match the v3.1 API. Only one account per toolkit is allowed when multi-account mode is disabled.
 - **`CustomToolsMap.tools`**: The map now caches the raw `CustomTool[]` array for future inline re-injection on v3.1 search/execute requests.
-- **`@composio/client`**: Bumped to `0.1.0-alpha.70`.

--- a/.changeset/v31-customs-use-attach.md
+++ b/.changeset/v31-customs-use-attach.md
@@ -1,0 +1,11 @@
+---
+'@composio/core': minor
+---
+
+Add custom tools support to `composio.use()` and update `connectedAccounts` to array type.
+
+- **`composio.use(id, { customTools, customToolkits })`**: Attach custom tools to an existing session. Calls the v3.1 `/attach` endpoint to bind local tools for search and execution. Without customs, falls back to the standard session retrieve.
+- **Inline custom tools payload**: `use()` now correctly passes `inlineCustomToolsPayload` and `preloadedCustomToolSlugs` to the session, enabling custom tool execution and preloading on rehydrated sessions.
+- **`connectedAccounts` type change**: Updated from `Record<string, string>` to `Record<string, string[]>` to match the v3.1 API. Only one account per toolkit is allowed when multi-account mode is disabled.
+- **`CustomToolsMap.tools`**: The map now caches the raw `CustomTool[]` array for future inline re-injection on v3.1 search/execute requests.
+- **`@composio/client`**: Bumped to `0.1.0-alpha.70`.

--- a/python/composio/core/models/tool_router.py
+++ b/python/composio/core/models/tool_router.py
@@ -537,7 +537,7 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
             t.Union[bool, ToolRouterManageConnectionsConfig]
         ] = None,
         auth_configs: t.Optional[t.Dict[str, str]] = None,
-        connected_accounts: t.Optional[t.Dict[str, t.List[str]]] = None,
+        connected_accounts: t.Optional[t.Dict[str, t.Union[str, t.List[str]]]] = None,
         workbench: t.Optional[ToolRouterWorkbenchConfig] = None,
         multi_account: t.Optional[ToolRouterMultiAccountConfig] = None,
         preload: t.Optional[ToolRouterPreloadConfig] = None,
@@ -596,10 +596,11 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
                                     Example: {'enable': True, 'callback_url': 'https://example.com/callback', 'wait_for_connections': True}
         :param auth_configs: Optional mapping of toolkit slug to auth config ID.
                            Example: {'github': 'ac_xxx', 'slack': 'ac_yyy'}
-        :param connected_accounts: Optional mapping of toolkit slug to connected account IDs.
+        :param connected_accounts: Optional mapping of toolkit slug to connected account ID(s).
+                                  Accepts a single string or a list of strings per toolkit.
                                   Only one account per toolkit is allowed when multi-account
                                   mode is disabled.
-                                  Example: {'github': ['ca_xxx'], 'slack': ['ca_yyy']}
+                                  Example: {'github': 'ca_xxx', 'slack': ['ca_yyy']}
         :param workbench: Optional workbench configuration. Dict with:
                          - 'enable' (bool): Whether to enable the workbench entirely.
                            Defaults to True. When set to False, no code execution tools
@@ -831,7 +832,10 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
             create_params["auth_configs"] = auth_configs
 
         if connected_accounts is not None:
-            create_params["connected_accounts"] = connected_accounts
+            create_params["connected_accounts"] = {
+                k: [v] if isinstance(v, str) else v
+                for k, v in connected_accounts.items()
+            }
 
         if toolkits_payload is not None:
             create_params["toolkits"] = toolkits_payload

--- a/python/tests/test_tool_router.py
+++ b/python/tests/test_tool_router.py
@@ -509,7 +509,10 @@ class TestToolRouter:
 
         call_args = mock_client.tool_router.session.create.call_args
         kwargs = call_args.kwargs
-        assert kwargs["connected_accounts"] == {"github": ["ca_xxx"], "slack": ["ca_yyy"]}
+        assert kwargs["connected_accounts"] == {
+            "github": ["ca_xxx"],
+            "slack": ["ca_yyy"],
+        }
 
     def test_create_session_with_workbench_config(self, tool_router, mock_client):
         """Test creating a session with workbench configuration."""

--- a/python/tests/test_tool_router.py
+++ b/python/tests/test_tool_router.py
@@ -509,7 +509,7 @@ class TestToolRouter:
 
         call_args = mock_client.tool_router.session.create.call_args
         kwargs = call_args.kwargs
-        assert kwargs["connected_accounts"] == {"github": "ca_xxx", "slack": "ca_yyy"}
+        assert kwargs["connected_accounts"] == {"github": ["ca_xxx"], "slack": ["ca_yyy"]}
 
     def test_create_session_with_workbench_config(self, tool_router, mock_client):
         """Test creating a session with workbench configuration."""

--- a/ts/packages/core/src/types/toolRouter.types.ts
+++ b/ts/packages/core/src/types/toolRouter.types.ts
@@ -202,9 +202,16 @@ const ToolRouterCreateSessionConfigBaseSchema = z
       )
       .default({}),
     connectedAccounts: z
-      .record(z.string(), z.array(z.string()))
+      .record(z.string(), z.union([z.string(), z.array(z.string())]))
+      .transform((rec) => {
+        const out: Record<string, string[]> = {};
+        for (const [k, v] of Object.entries(rec)) {
+          out[k] = typeof v === 'string' ? [v] : v;
+        }
+        return out;
+      })
       .describe(
-        'The connected accounts to use in the tool router session. The key is the toolkit slug, the value is an array of connected account ids. Only one account per toolkit is allowed when multi-account mode is disabled.'
+        'The connected accounts to use in the tool router session. The key is the toolkit slug, the value is a connected account id or an array of ids. Only one account per toolkit is allowed when multi-account mode is disabled.'
       )
       .default({}),
     manageConnections: z

--- a/ts/packages/core/test/models/toolRouter.test.ts
+++ b/ts/packages/core/test/models/toolRouter.test.ts
@@ -1031,12 +1031,12 @@ describe('ToolRouter', () => {
         });
       });
 
-      it('should create a session with connectedAccounts', async () => {
+      it('should create a session with connectedAccounts (string coerced to array)', async () => {
         mockClient.toolRouter.session.create.mockResolvedValueOnce(mockSessionCreateResponse);
 
         const config: ToolRouterCreateSessionConfig = {
           connectedAccounts: {
-            gmail: ['conn_123'],
+            gmail: 'conn_123',
             slack: ['conn_456'],
           },
         };
@@ -1066,7 +1066,7 @@ describe('ToolRouter', () => {
             gmail: 'auth_config_123',
           },
           connectedAccounts: {
-            slack: ['conn_456'],
+            slack: 'conn_456',
           },
         };
 


### PR DESCRIPTION
## Summary
Adds missing changesets for #3350 and updates `connectedAccounts` to accept both `string` and `string[]` (non-breaking).

### Changesets (`@composio/core` minor)
1. **`v31-customs-use-attach`** — `composio.use()` with custom tools via v3.1 `/attach`
2. **`v31-connected-accounts-array`** — `connectedAccounts` accepts `string | string[]`, coerced to array

### connectedAccounts coercion
- TS: Zod schema accepts `string | string[]` per toolkit, `.transform()` normalizes to `string[]`
- Python: type is `Union[str, List[str]]`, coerced to list before passing to the API
- Existing callers passing `{ gmail: "ca_xxx" }` continue to work without changes
- Only one account per toolkit is allowed when multi-account mode is disabled

## Test plan
- [x] TS: 109/109 `toolRouter.test.ts` pass (tests both string and array forms)
- [x] Python: 65/65 `test_custom_tools.py` pass
- [x] `tsc --noEmit` clean
- [x] `ruff` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)