### PR TITLE
fix(core): qualify custom toolkit child slug lookups

### DIFF
--- a/ts/packages/core/src/models/CustomTool.ts
+++ b/ts/packages/core/src/models/CustomTool.ts
@@ -270,6 +270,47 @@ function buildFinalSlug(toolSlug: string, toolkitSlug?: string): string {
     : `${LOCAL_TOOL_PREFIX}${upper}`;
 }
 
+const qualifiedOriginalSlugKey = (toolkit: string | undefined, originalSlug: string): string =>
+  `${toolkit?.toUpperCase() ?? ''}::${originalSlug.toUpperCase()}`;
+
+const canShareOriginalSlug = (existing: CustomToolsMapEntry, next: CustomToolsMapEntry): boolean =>
+  !!existing.toolkit &&
+  !!next.toolkit &&
+  existing.toolkit.toLowerCase() !== next.toolkit.toLowerCase();
+
+const addOriginalSlugAlias = (params: {
+  byOriginalSlug: Map<string, CustomToolsMapEntry>;
+  ambiguousOriginalSlugs: Set<string>;
+  originalSlug: string;
+  entry: CustomToolsMapEntry;
+}) => {
+  const originalSlugKey = params.originalSlug.toUpperCase();
+  if (params.ambiguousOriginalSlugs.has(originalSlugKey)) {
+    return;
+  }
+
+  const existing = params.byOriginalSlug.get(originalSlugKey);
+  if (!existing) {
+    params.byOriginalSlug.set(originalSlugKey, params.entry);
+    return;
+  }
+
+  if (existing.finalSlug.toUpperCase() === params.entry.finalSlug.toUpperCase()) {
+    return;
+  }
+
+  if (canShareOriginalSlug(existing, params.entry)) {
+    params.byOriginalSlug.delete(originalSlugKey);
+    params.ambiguousOriginalSlugs.add(originalSlugKey);
+    return;
+  }
+
+  throw new ValidationError(
+    `Custom tool slug collision: original slug "${params.originalSlug}" maps to multiple final slugs. ` +
+      `"${existing.finalSlug}" and "${params.entry.finalSlug}" both resolve from "${originalSlugKey}".`
+  );
+};
+
 /**
  * Build a CustomToolsMap from custom tools and toolkits.
  * Used internally by ToolRouter.create() to construct the per-session routing map.
@@ -286,6 +327,8 @@ export function buildCustomToolsMap(
 ): CustomToolsMap {
   const byFinalSlug = new Map<string, CustomToolsMapEntry>();
   const byOriginalSlug = new Map<string, CustomToolsMapEntry>();
+  const byToolkitAndOriginalSlug = new Map<string, CustomToolsMapEntry>();
+  const ambiguousOriginalSlugs = new Set<string>();
 
   const addEntry = (handle: CustomTool, finalSlug: string, toolkit?: string) => {
     const originalSlug = handle.slug.toUpperCase();
@@ -307,17 +350,17 @@ export function buildCustomToolsMap(
       );
     }
 
-    // Check cross-group collisions on original slug
-    if (byOriginalSlug.has(originalSlug)) {
+    const qualifiedKey = qualifiedOriginalSlugKey(toolkit, originalSlug);
+    if (byToolkitAndOriginalSlug.has(qualifiedKey)) {
       throw new ValidationError(
-        `Custom tool slug collision: original slug "${handle.slug}" maps to multiple final slugs. ` +
-          `"${byOriginalSlug.get(originalSlug)!.finalSlug}" and "${finalSlug}" both resolve from "${originalSlug}".`
+        `Custom tool slug collision: original slug "${handle.slug}" is already registered for toolkit "${toolkit ?? 'custom'}".`
       );
     }
 
     const entry: CustomToolsMapEntry = { handle, finalSlug, toolkit };
     byFinalSlug.set(finalSlugKey, entry);
-    byOriginalSlug.set(originalSlug, entry);
+    byToolkitAndOriginalSlug.set(qualifiedKey, entry);
+    addOriginalSlugAlias({ byOriginalSlug, ambiguousOriginalSlugs, originalSlug, entry });
   };
 
   // Process standalone tools
@@ -337,6 +380,8 @@ export function buildCustomToolsMap(
   return {
     byFinalSlug,
     byOriginalSlug,
+    byToolkitAndOriginalSlug,
+    ...(ambiguousOriginalSlugs.size ? { ambiguousOriginalSlugs } : {}),
     toolkits,
     tools: tools.length ? tools : undefined,
   };
@@ -443,34 +488,64 @@ export function buildCustomToolsMapFromResponse(
 ): CustomToolsMap {
   const byFinalSlug = new Map<string, CustomToolsMapEntry>();
   const byOriginalSlug = new Map<string, CustomToolsMapEntry>();
+  const byToolkitAndOriginalSlug = new Map<string, CustomToolsMapEntry>();
+  const ambiguousOriginalSlugs = new Set<string>();
 
-  // Build a lookup from original slug → custom tool handle (for matching response items)
-  const handlesByOriginalSlug = new Map<string, { handle: CustomTool; toolkit?: string }>();
+  type HandleMatch = { handle: CustomTool; toolkit?: string };
+  const handlesByQualifiedOriginalSlug = new Map<string, HandleMatch>();
+  const handlesByOriginalSlug = new Map<string, HandleMatch[]>();
+
+  const registerHandle = (handle: CustomTool, toolkit?: string) => {
+    const originalSlug = handle.slug.toUpperCase();
+    const match = { handle, toolkit };
+    handlesByQualifiedOriginalSlug.set(qualifiedOriginalSlugKey(toolkit, originalSlug), match);
+    const existing = handlesByOriginalSlug.get(originalSlug) ?? [];
+    existing.push(match);
+    handlesByOriginalSlug.set(originalSlug, existing);
+  };
+
   for (const handle of tools) {
-    handlesByOriginalSlug.set(handle.slug.toUpperCase(), {
-      handle,
-      toolkit: handle.extendsToolkit,
-    });
+    registerHandle(handle, handle.extendsToolkit);
   }
   if (toolkits) {
     for (const tk of toolkits) {
       for (const handle of tk.tools) {
-        handlesByOriginalSlug.set(handle.slug.toUpperCase(), { handle, toolkit: tk.slug });
+        registerHandle(handle, tk.slug);
       }
     }
   }
 
-  const addEntry = (finalSlug: string, originalSlug: string, toolkit?: string) => {
-    const match = handlesByOriginalSlug.get(originalSlug.toUpperCase());
+  const findHandle = (originalSlug: string, toolkit?: string): HandleMatch | undefined => {
+    const originalSlugKey = originalSlug.toUpperCase();
+    const qualifiedMatch = handlesByQualifiedOriginalSlug.get(
+      qualifiedOriginalSlugKey(toolkit, originalSlugKey)
+    );
+    if (qualifiedMatch) return qualifiedMatch;
+
+    const bareMatches = handlesByOriginalSlug.get(originalSlugKey) ?? [];
+    return bareMatches.length === 1 ? bareMatches[0] : undefined;
+  };
+
+  const addEntry = (finalSlug: string, originalSlug: string, toolkit?: string | null) => {
+    const resolvedToolkit = toolkit ?? undefined;
+    const match = findHandle(originalSlug, resolvedToolkit);
     if (!match) return; // Response tool not found in our handles (shouldn't happen)
+
+    const finalSlugKey = finalSlug.toUpperCase();
+    if (byFinalSlug.has(finalSlugKey)) {
+      throw new ValidationError(
+        `Custom tool slug collision: "${finalSlug}" is already registered.`
+      );
+    }
 
     const entry: CustomToolsMapEntry = {
       handle: match.handle,
       finalSlug,
-      toolkit: toolkit ?? match.toolkit,
+      toolkit: resolvedToolkit ?? match.toolkit,
     };
-    byFinalSlug.set(finalSlug.toUpperCase(), entry);
-    byOriginalSlug.set(originalSlug.toUpperCase(), entry);
+    byFinalSlug.set(finalSlugKey, entry);
+    byToolkitAndOriginalSlug.set(qualifiedOriginalSlugKey(entry.toolkit, originalSlug), entry);
+    addOriginalSlugAlias({ byOriginalSlug, ambiguousOriginalSlugs, originalSlug, entry });
   };
 
   // Map standalone custom tools from response
@@ -492,6 +567,8 @@ export function buildCustomToolsMapFromResponse(
   return {
     byFinalSlug,
     byOriginalSlug,
+    byToolkitAndOriginalSlug,
+    ...(ambiguousOriginalSlugs.size ? { ambiguousOriginalSlugs } : {}),
     toolkits,
     tools: tools.length ? tools : undefined,
   };
@@ -507,6 +584,19 @@ export function findCustomToolMapEntryByFinalSlug(
   slug: string
 ): CustomToolsMapEntry | undefined {
   return customToolsMap?.byFinalSlug.get(slug.toUpperCase());
+}
+
+/**
+ * Find a custom toolkit tool entry by toolkit slug and original tool slug.
+ *
+ * @internal
+ */
+export function findCustomToolMapEntryByToolkitAndOriginalSlug(
+  customToolsMap: CustomToolsMap | undefined,
+  toolkit: string | undefined,
+  slug: string
+): CustomToolsMapEntry | undefined {
+  return customToolsMap?.byToolkitAndOriginalSlug?.get(qualifiedOriginalSlugKey(toolkit, slug));
 }
 
 /**
@@ -531,6 +621,7 @@ export function assertNoCustomToolSlugsInPreload(
     return (
       normalized.startsWith(LOCAL_TOOL_PREFIX) ||
       customToolsMap?.byOriginalSlug.has(normalized) ||
+      customToolsMap?.ambiguousOriginalSlugs?.has(normalized) ||
       customToolsMap?.byFinalSlug.has(normalized)
     );
   });

--- a/ts/packages/core/src/models/ToolRouterSession.ts
+++ b/ts/packages/core/src/models/ToolRouterSession.ts
@@ -46,7 +46,10 @@ import type {
 import { SessionProxyExecuteParamsSchema } from '../types/toolRouter.types';
 import { SessionContextImpl } from './SessionContext';
 import { findCustomTool, executeCustomTool } from './customToolExecution';
-import { findCustomToolMapEntryByFinalSlug } from './CustomTool';
+import {
+  findCustomToolMapEntryByFinalSlug,
+  findCustomToolMapEntryByToolkitAndOriginalSlug,
+} from './CustomTool';
 import { transformProxyParams } from './proxyParamsTransform';
 import { inlineCustomToolsExperimental } from './inlineCustomToolsPayload';
 
@@ -144,7 +147,7 @@ export class ToolRouterSession<
           toolSlug,
           input,
           modifiers,
-          toolBySlug.get(toolSlug.toUpperCase()),
+          toolBySlug.get(toolSlug.toUpperCase())
         );
       };
 
@@ -272,8 +275,11 @@ export class ToolRouterSession<
       name: tk.name,
       description: tk.description,
       tools: tk.tools.map(tool => {
-        // Look up the entry to get the final slug
-        const entry = this.customToolsMap!.byOriginalSlug.get(tool.slug.toUpperCase());
+        // Look up by toolkit + original slug so toolkits can safely reuse common names
+        // like VERSION, CLICK, or SEARCH without losing the backend-assigned final slug.
+        const entry =
+          findCustomToolMapEntryByToolkitAndOriginalSlug(this.customToolsMap, tk.slug, tool.slug) ??
+          this.customToolsMap!.byOriginalSlug.get(tool.slug.toUpperCase());
         return {
           slug: entry?.finalSlug ?? tool.slug,
           name: tool.name,

--- a/ts/packages/core/src/models/customToolExecution.ts
+++ b/ts/packages/core/src/models/customToolExecution.ts
@@ -2,7 +2,11 @@
  * @fileoverview Standalone functions for custom tool lookup and execution.
  * Extracted from ToolRouterSession for reuse in SessionContextImpl (sibling routing).
  */
-import type { CustomToolsMap, CustomToolsMapEntry, SessionContext } from '../types/customTool.types';
+import type {
+  CustomToolsMap,
+  CustomToolsMapEntry,
+  SessionContext,
+} from '../types/customTool.types';
 import type { ToolExecuteResponse } from '../types/tool.types';
 
 /**
@@ -15,7 +19,10 @@ export function findCustomTool(
 ): CustomToolsMapEntry | undefined {
   if (!map) return undefined;
   const upper = slug.toUpperCase();
-  return map.byFinalSlug.get(upper) ?? map.byOriginalSlug.get(upper);
+  const finalSlugMatch = map.byFinalSlug.get(upper);
+  if (finalSlugMatch) return finalSlugMatch;
+  if (map.ambiguousOriginalSlugs?.has(upper)) return undefined;
+  return map.byOriginalSlug.get(upper);
 }
 
 /**

--- a/ts/packages/core/src/types/customTool.types.ts
+++ b/ts/packages/core/src/types/customTool.types.ts
@@ -262,8 +262,12 @@ export type CustomToolsMapEntry = {
 export type CustomToolsMap = {
   /** Lookup by final slug (e.g. LOCAL_GET_USER_CONTEXT) — used for agent execution path */
   byFinalSlug: Map<string, CustomToolsMapEntry>;
-  /** Lookup by original slug (e.g. GET_USER_CONTEXT) — used for programmatic session.execute() */
+  /** Lookup by unique original slug (e.g. GET_USER_CONTEXT) — used for programmatic session.execute() */
   byOriginalSlug: Map<string, CustomToolsMapEntry>;
+  /** Lookup by resolved toolkit + original slug — used when multiple custom toolkits reuse tool names */
+  byToolkitAndOriginalSlug?: Map<string, CustomToolsMapEntry>;
+  /** Original slugs that appear in multiple toolkits and cannot be resolved safely without the final slug */
+  ambiguousOriginalSlugs?: Set<string>;
   /** The original custom toolkits passed at session creation — used for session.customToolkits() */
   toolkits?: CustomToolkit[];
   /** The original standalone custom tools passed at session creation — kept for inline re-injection on subsequent v3.1 requests. */

--- a/ts/packages/core/test/models/customTool.test.ts
+++ b/ts/packages/core/test/models/customTool.test.ts
@@ -4,6 +4,7 @@ import {
   createCustomTool,
   createCustomToolkit,
   buildCustomToolsMap,
+  buildCustomToolsMapFromResponse,
   serializeCustomTools,
   serializeCustomToolkits,
   LOCAL_TOOL_PREFIX,
@@ -330,6 +331,65 @@ describe('buildCustomToolsMap', () => {
 
       expect(map.byFinalSlug.has('LOCAL_DEV_TOOLS_SED')).toBe(true);
       expect(map.byOriginalSlug.has('SED')).toBe(true);
+    });
+
+    it('should allow different custom toolkits to reuse the same child tool slug', () => {
+      const versionA = makeTool('VERSION');
+      const versionB = makeTool('VERSION');
+      const toolkitA: CustomToolkit = {
+        slug: 'APP_A',
+        name: 'App A',
+        description: 'Dummy toolkit A',
+        tools: [versionA],
+      };
+      const toolkitB: CustomToolkit = {
+        slug: 'APP_B',
+        name: 'App B',
+        description: 'Dummy toolkit B',
+        tools: [versionB],
+      };
+
+      const map = buildCustomToolsMap([], [toolkitA, toolkitB]);
+
+      expect(map.byFinalSlug.get('LOCAL_APP_A_VERSION')?.handle).toBe(versionA);
+      expect(map.byFinalSlug.get('LOCAL_APP_B_VERSION')?.handle).toBe(versionB);
+    });
+
+    it('should match duplicate custom toolkit child slugs using the parent toolkit from the response', () => {
+      const versionA = makeTool('VERSION');
+      const versionB = makeTool('VERSION');
+      const toolkitA: CustomToolkit = {
+        slug: 'APP_A',
+        name: 'App A',
+        description: 'Dummy toolkit A',
+        tools: [versionA],
+      };
+      const toolkitB: CustomToolkit = {
+        slug: 'APP_B',
+        name: 'App B',
+        description: 'Dummy toolkit B',
+        tools: [versionB],
+      };
+
+      const map = buildCustomToolsMapFromResponse([], [toolkitA, toolkitB], {
+        custom_toolkits: [
+          {
+            slug: 'APP_A',
+            name: 'App A',
+            description: 'Dummy toolkit A',
+            tools: [{ slug: 'LOCAL_APP_A_VERSION', original_slug: 'VERSION' }],
+          },
+          {
+            slug: 'APP_B',
+            name: 'App B',
+            description: 'Dummy toolkit B',
+            tools: [{ slug: 'LOCAL_APP_B_VERSION', original_slug: 'VERSION' }],
+          },
+        ],
+      });
+
+      expect(map.byFinalSlug.get('LOCAL_APP_A_VERSION')?.handle).toBe(versionA);
+      expect(map.byFinalSlug.get('LOCAL_APP_B_VERSION')?.handle).toBe(versionB);
     });
   });
 

--- a/ts/packages/core/test/models/toolRouter.test.ts
+++ b/ts/packages/core/test/models/toolRouter.test.ts
@@ -7,7 +7,7 @@ import { MockProvider } from '../utils/mocks/provider.mock';
 import { Tools } from '../../src/models/Tools';
 import { ConnectedAccountStatuses } from '../../src/types/connectedAccounts.types';
 import { ToolRouterCreateSessionConfig, Session } from '../../src/types/toolRouter.types';
-import { createCustomTool } from '../../src/models/CustomTool';
+import { createCustomTool, createCustomToolkit } from '../../src/models/CustomTool';
 import { DIRECT_CUSTOM_TOOL_DESCRIPTION_PREFIX } from '../../src/models/ToolRouterSession';
 
 // Mock dependencies
@@ -2255,6 +2255,64 @@ describe('ToolRouter', () => {
           ],
         },
       });
+    });
+
+    it('should keep duplicate nested custom toolkit tool names addressable by final slug', async () => {
+      const versionA = createCustomTool('VERSION', {
+        name: 'Version A',
+        description: 'Get version for dummy app A',
+        inputParams: z.object({}),
+        execute: vi.fn(async () => ({ version: 'a' })),
+      });
+      const versionB = createCustomTool('VERSION', {
+        name: 'Version B',
+        description: 'Get version for dummy app B',
+        inputParams: z.object({}),
+        execute: vi.fn(async () => ({ version: 'b' })),
+      });
+      const toolkitA = createCustomToolkit('APP_A', {
+        name: 'App A',
+        description: 'Dummy toolkit A',
+        tools: [versionA],
+      });
+      const toolkitB = createCustomToolkit('APP_B', {
+        name: 'App B',
+        description: 'Dummy toolkit B',
+        tools: [versionB],
+      });
+
+      mockClient.toolRouter.session.create.mockResolvedValueOnce({
+        ...mockSessionCreateResponse,
+        experimental: {
+          custom_toolkits: [
+            {
+              slug: 'APP_A',
+              name: 'App A',
+              description: 'Dummy toolkit A',
+              tools: [{ slug: 'LOCAL_APP_A_VERSION', original_slug: 'VERSION' }],
+            },
+            {
+              slug: 'APP_B',
+              name: 'App B',
+              description: 'Dummy toolkit B',
+              tools: [{ slug: 'LOCAL_APP_B_VERSION', original_slug: 'VERSION' }],
+            },
+          ],
+        },
+      });
+
+      const session = await toolRouter.create(userId, {
+        experimental: { customToolkits: [toolkitA, toolkitB] },
+      });
+
+      expect(session.customToolkits().map(toolkit => toolkit.slug)).toEqual(['APP_A', 'APP_B']);
+      expect(
+        session.customToolkits().flatMap(toolkit => toolkit.tools.map(tool => tool.slug))
+      ).toEqual(['LOCAL_APP_A_VERSION', 'LOCAL_APP_B_VERSION']);
+      expect(session.customTools().map(tool => tool.slug)).toEqual([
+        'LOCAL_APP_A_VERSION',
+        'LOCAL_APP_B_VERSION',
+      ]);
     });
 
     it('should propagate search API errors', async () => {


### PR DESCRIPTION
## Summary
- Adds a minimal dummy-tool regression repro for two custom toolkits that both define a child tool named `VERSION` (`APP_A.VERSION` and `APP_B.VERSION`).
- Fixes core custom-tool mapping so nested custom toolkit tools are keyed by `toolkit + original slug`, while bare original slug lookup remains available only when unambiguous.
- Keeps `session.customToolkits()` / `session.customTools()` returning the backend-assigned final slugs for duplicate child names.

## Repro
The first commit in this PR is intentionally just the repro test. Running it against current `next` fails with:

- `Custom tool slug collision: original slug "VERSION" maps to multiple final slugs...`
- response mapping assigns `LOCAL_APP_A_VERSION` to the wrong dummy tool handle when both child tools have `original_slug: "VERSION"`

## Tests
- `pnpm --filter @composio/core typecheck`
- `pnpm --filter @composio/core exec vitest run test/models/customTool.test.ts test/models/toolRouter.test.ts test/models/customToolRouting.test.ts`
