### PR TITLE
fix(core): qualify custom toolkit child slug lookups

### DIFF
--- a/ts/packages/core/src/models/CustomTool.ts
+++ b/ts/packages/core/src/models/CustomTool.ts
@@ -270,6 +270,47 @@ function buildFinalSlug(toolSlug: string, toolkitSlug?: string): string {
     : `${LOCAL_TOOL_PREFIX}${upper}`;
 }
 
+const qualifiedOriginalSlugKey = (toolkit: string | undefined, originalSlug: string): string =>
+  `${toolkit?.toUpperCase() ?? ''}::${originalSlug.toUpperCase()}`;
+
+const canShareOriginalSlug = (existing: CustomToolsMapEntry, next: CustomToolsMapEntry): boolean =>
+  !!existing.toolkit &&
+  !!next.toolkit &&
+  existing.toolkit.toLowerCase() !== next.toolkit.toLowerCase();
+
+const addOriginalSlugAlias = (params: {
+  byOriginalSlug: Map<string, CustomToolsMapEntry>;
+  ambiguousOriginalSlugs: Set<string>;
+  originalSlug: string;
+  entry: CustomToolsMapEntry;
+}) => {
+  const originalSlugKey = params.originalSlug.toUpperCase();
+  if (params.ambiguousOriginalSlugs.has(originalSlugKey)) {
+    return;
+  }
+
+  const existing = params.byOriginalSlug.get(originalSlugKey);
+  if (!existing) {
+    params.byOriginalSlug.set(originalSlugKey, params.entry);
+    return;
+  }
+
+  if (existing.finalSlug.toUpperCase() === params.entry.finalSlug.toUpperCase()) {
+    return;
+  }
+
+  if (canShareOriginalSlug(existing, params.entry)) {
+    params.byOriginalSlug.delete(originalSlugKey);
+    params.ambiguousOriginalSlugs.add(originalSlugKey);
+    return;
+  }
+
+  throw new ValidationError(
+    `Custom tool slug collision: original slug "${params.originalSlug}" maps to multiple final slugs. ` +
+      `"${existing.finalSlug}" and "${params.entry.finalSlug}" both resolve from "${originalSlugKey}".`
+  );
+};
+
 /**
  * Build a CustomToolsMap from custom tools and toolkits.
  * Used internally by ToolRouter.create() to construct the per-session routing map.
@@ -286,6 +327,8 @@ export function buildCustomToolsMap(
 ): CustomToolsMap {
   const byFinalSlug = new Map<string, CustomToolsMapEntry>();
   const byOriginalSlug = new Map<string, CustomToolsMapEntry>();
+  const byToolkitAndOriginalSlug = new Map<string, CustomToolsMapEntry>();
+  const ambiguousOriginalSlugs = new Set<string>();
 
   const addEntry = (handle: CustomTool, finalSlug: string, toolkit?: string) => {
     const originalSlug = handle.slug.toUpperCase();
@@ -307,17 +350,17 @@ export function buildCustomToolsMap(
       );
     }
 
-    // Check cross-group collisions on original slug
-    if (byOriginalSlug.has(originalSlug)) {
+    const qualifiedKey = qualifiedOriginalSlugKey(toolkit, originalSlug);
+    if (byToolkitAndOriginalSlug.has(qualifiedKey)) {
       throw new ValidationError(
-        `Custom tool slug collision: original slug "${handle.slug}" maps to multiple final slugs. ` +
-          `"${byOriginalSlug.get(originalSlug)!.finalSlug}" and "${finalSlug}" both resolve from "${originalSlug}".`
+        `Custom tool slug collision: original slug "${handle.slug}" is already registered for toolkit "${toolkit ?? 'custom'}".`
       );
     }
 
     const entry: CustomToolsMapEntry = { handle, finalSlug, toolkit };
     byFinalSlug.set(finalSlugKey, entry);
-    byOriginalSlug.set(originalSlug, entry);
+    byToolkitAndOriginalSlug.set(qualifiedKey, entry);
+    addOriginalSlugAlias({ byOriginalSlug, ambiguousOriginalSlugs, originalSlug, entry });
   };
 
   // Process standalone tools
@@ -337,6 +380,8 @@ export function buildCustomToolsMap(
   return {
     byFinalSlug,
     byOriginalSlug,
+    byToolkitAndOriginalSlug,
+    ...(ambiguousOriginalSlugs.size ? { ambiguousOriginalSlugs } : {}),
     toolkits,
     tools: tools.length ? tools : undefined,
   };
@@ -443,34 +488,64 @@ export function buildCustomToolsMapFromResponse(
 ): CustomToolsMap {
   const byFinalSlug = new Map<string, CustomToolsMapEntry>();
   const byOriginalSlug = new Map<string, CustomToolsMapEntry>();
+  const byToolkitAndOriginalSlug = new Map<string, CustomToolsMapEntry>();
+  const ambiguousOriginalSlugs = new Set<string>();
 
-  // Build a lookup from original slug → custom tool handle (for matching response items)
-  const handlesByOriginalSlug = new Map<string, { handle: CustomTool; toolkit?: string }>();
+  type HandleMatch = { handle: CustomTool; toolkit?: string };
+  const handlesByQualifiedOriginalSlug = new Map<string, HandleMatch>();
+  const handlesByOriginalSlug = new Map<string, HandleMatch[]>();
+
+  const registerHandle = (handle: CustomTool, toolkit?: string) => {
+    const originalSlug = handle.slug.toUpperCase();
+    const match = { handle, toolkit };
+    handlesByQualifiedOriginalSlug.set(qualifiedOriginalSlugKey(toolkit, originalSlug), match);
+    const existing = handlesByOriginalSlug.get(originalSlug) ?? [];
+    existing.push(match);
+    handlesByOriginalSlug.set(originalSlug, existing);
+  };
+
   for (const handle of tools) {
-    handlesByOriginalSlug.set(handle.slug.toUpperCase(), {
-      handle,
-      toolkit: handle.extendsToolkit,
-    });
+    registerHandle(handle, handle.extendsToolkit);
   }
   if (toolkits) {
     for (const tk of toolkits) {
       for (const handle of tk.tools) {
-        handlesByOriginalSlug.set(handle.slug.toUpperCase(), { handle, toolkit: tk.slug });
+        registerHandle(handle, tk.slug);
       }
     }
   }
 
-  const addEntry = (finalSlug: string, originalSlug: string, toolkit?: string) => {
-    const match = handlesByOriginalSlug.get(originalSlug.toUpperCase());
+  const findHandle = (originalSlug: string, toolkit?: string): HandleMatch | undefined => {
+    const originalSlugKey = originalSlug.toUpperCase();
+    const qualifiedMatch = handlesByQualifiedOriginalSlug.get(
+      qualifiedOriginalSlugKey(toolkit, originalSlugKey)
+    );
+    if (qualifiedMatch) return qualifiedMatch;
+
+    const bareMatches = handlesByOriginalSlug.get(originalSlugKey) ?? [];
+    return bareMatches.length === 1 ? bareMatches[0] : undefined;
+  };
+
+  const addEntry = (finalSlug: string, originalSlug: string, toolkit?: string | null) => {
+    const resolvedToolkit = toolkit ?? undefined;
+    const match = findHandle(originalSlug, resolvedToolkit);
     if (!match) return; // Response tool not found in our handles (shouldn't happen)
+
+    const finalSlugKey = finalSlug.toUpperCase();
+    if (byFinalSlug.has(finalSlugKey)) {
+      throw new ValidationError(
+        `Custom tool slug collision: "${finalSlug}" is already registered.`
+      );
+    }
 
     const entry: CustomToolsMapEntry = {
       handle: match.handle,
       finalSlug,
-      toolkit: toolkit ?? match.toolkit,
+      toolkit: resolvedToolkit ?? match.toolkit,
     };
-    byFinalSlug.set(finalSlug.toUpperCase(), entry);
-    byOriginalSlug.set(originalSlug.toUpperCase(), entry);
+    byFinalSlug.set(finalSlugKey, entry);
+    byToolkitAndOriginalSlug.set(qualifiedOriginalSlugKey(entry.toolkit, originalSlug), entry);
+    addOriginalSlugAlias({ byOriginalSlug, ambiguousOriginalSlugs, originalSlug, entry });
   };
 
   // Map standalone custom tools from response
@@ -492,6 +567,8 @@ export function buildCustomToolsMapFromResponse(
   return {
     byFinalSlug,
     byOriginalSlug,
+    byToolkitAndOriginalSlug,
+    ...(ambiguousOriginalSlugs.size ? { ambiguousOriginalSlugs } : {}),
     toolkits,
     tools: tools.length ? tools : undefined,
   };
@@ -507,6 +584,19 @@ export function findCustomToolMapEntryByFinalSlug(
   slug: string
 ): CustomToolsMapEntry | undefined {
   return customToolsMap?.byFinalSlug.get(slug.toUpperCase());
+}
+
+/**
+ * Find a custom toolkit tool entry by toolkit slug and original tool slug.
+ *
+ * @internal
+ */
+export function findCustomToolMapEntryByToolkitAndOriginalSlug(
+  customToolsMap: CustomToolsMap | undefined,
+  toolkit: string | undefined,
+  slug: string
+): CustomToolsMapEntry | undefined {
+  return customToolsMap?.byToolkitAndOriginalSlug?.get(qualifiedOriginalSlugKey(toolkit, slug));
 }
 
 /**
@@ -531,6 +621,7 @@ export function assertNoCustomToolSlugsInPreload(
     return (
       normalized.startsWith(LOCAL_TOOL_PREFIX) ||
       customToolsMap?.byOriginalSlug.has(normalized) ||
+      customToolsMap?.ambiguousOriginalSlugs?.has(normalized) ||
       customToolsMap?.byFinalSlug.has(normalized)
     );
   });

--- a/ts/packages/core/src/models/SessionContext.ts
+++ b/ts/packages/core/src/models/SessionContext.ts
@@ -18,7 +18,11 @@ import {
 } from '../types/toolRouter.types';
 import { ValidationError } from '../errors';
 import { transformProxyParams } from './proxyParamsTransform';
-import { findCustomTool, executeCustomTool } from './customToolExecution';
+import {
+  assertUnambiguousCustomToolSlug,
+  findCustomTool,
+  executeCustomTool,
+} from './customToolExecution';
 import { transformExecuteResponse } from '../utils/transformers/toolRouterResponseTransform';
 import type { SessionExecuteParams } from '@composio/client/resources/tool-router/session/session.mjs';
 import { inlineCustomToolsExperimental } from './inlineCustomToolsPayload';
@@ -66,6 +70,7 @@ export class SessionContextImpl implements SessionContext {
         logId: '',
       });
     }
+    assertUnambiguousCustomToolSlug(this.customToolsMap, toolSlug);
 
     // Fall back to remote execution
     const executeParams: SessionExecuteParams = {

--- a/ts/packages/core/src/models/ToolRouterSession.ts
+++ b/ts/packages/core/src/models/ToolRouterSession.ts
@@ -45,8 +45,15 @@ import type {
 } from '@composio/client/resources/tool-router/session/session.mjs';
 import { SessionProxyExecuteParamsSchema } from '../types/toolRouter.types';
 import { SessionContextImpl } from './SessionContext';
-import { findCustomTool, executeCustomTool } from './customToolExecution';
-import { findCustomToolMapEntryByFinalSlug } from './CustomTool';
+import {
+  assertUnambiguousCustomToolSlug,
+  findCustomTool,
+  executeCustomTool,
+} from './customToolExecution';
+import {
+  findCustomToolMapEntryByFinalSlug,
+  findCustomToolMapEntryByToolkitAndOriginalSlug,
+} from './CustomTool';
 import { transformProxyParams } from './proxyParamsTransform';
 import { inlineCustomToolsExperimental } from './inlineCustomToolsPayload';
 
@@ -139,12 +146,13 @@ export class ToolRouterSession<
         if (customTool) {
           return executeCustomTool(customTool, input, this.sessionContext!);
         }
+        assertUnambiguousCustomToolSlug(this.customToolsMap, toolSlug);
         return this.executeBackendSessionTool(
           ToolsModel,
           toolSlug,
           input,
           modifiers,
-          toolBySlug.get(toolSlug.toUpperCase()),
+          toolBySlug.get(toolSlug.toUpperCase())
         );
       };
 
@@ -272,8 +280,11 @@ export class ToolRouterSession<
       name: tk.name,
       description: tk.description,
       tools: tk.tools.map(tool => {
-        // Look up the entry to get the final slug
-        const entry = this.customToolsMap!.byOriginalSlug.get(tool.slug.toUpperCase());
+        // Look up by toolkit + original slug so toolkits can safely reuse common names
+        // like VERSION, CLICK, or SEARCH without losing the backend-assigned final slug.
+        const entry =
+          findCustomToolMapEntryByToolkitAndOriginalSlug(this.customToolsMap, tk.slug, tool.slug) ??
+          this.customToolsMap!.byOriginalSlug.get(tool.slug.toUpperCase());
         return {
           slug: entry?.finalSlug ?? tool.slug,
           name: tool.name,
@@ -412,6 +423,7 @@ export class ToolRouterSession<
         logId: '',
       };
     }
+    assertUnambiguousCustomToolSlug(this.customToolsMap, toolSlug);
 
     // Remote execution
     const executeParams: SessionExecuteParams = {
@@ -541,6 +553,7 @@ export class ToolRouterSession<
       if (entry) {
         localItems.push({ index: i, entry });
       } else {
+        assertUnambiguousCustomToolSlug(this.customToolsMap, parsed[i].tool_slug);
         remoteIndices.push(i);
       }
     }

--- a/ts/packages/core/src/models/customToolExecution.ts
+++ b/ts/packages/core/src/models/customToolExecution.ts
@@ -2,8 +2,13 @@
  * @fileoverview Standalone functions for custom tool lookup and execution.
  * Extracted from ToolRouterSession for reuse in SessionContextImpl (sibling routing).
  */
-import type { CustomToolsMap, CustomToolsMapEntry, SessionContext } from '../types/customTool.types';
+import type {
+  CustomToolsMap,
+  CustomToolsMapEntry,
+  SessionContext,
+} from '../types/customTool.types';
 import type { ToolExecuteResponse } from '../types/tool.types';
+import { ValidationError } from '../errors';
 
 /**
  * Find a custom tool entry by slug.
@@ -15,7 +20,36 @@ export function findCustomTool(
 ): CustomToolsMapEntry | undefined {
   if (!map) return undefined;
   const upper = slug.toUpperCase();
-  return map.byFinalSlug.get(upper) ?? map.byOriginalSlug.get(upper);
+  const finalSlugMatch = map.byFinalSlug.get(upper);
+  if (finalSlugMatch) return finalSlugMatch;
+  if (map.ambiguousOriginalSlugs?.has(upper)) return undefined;
+  return map.byOriginalSlug.get(upper);
+}
+
+/**
+ * Reject ambiguous bare original slugs before falling through to backend execution.
+ * Agents receive final slugs (LOCAL_<TOOLKIT>_<TOOL>) from schemas, while bare original
+ * slugs are only a convenience for manual session.execute() calls when unique.
+ */
+export function assertUnambiguousCustomToolSlug(
+  map: CustomToolsMap | undefined,
+  slug: string
+): void {
+  if (!map) return;
+  const upper = slug.toUpperCase();
+  if (!map.ambiguousOriginalSlugs?.has(upper)) return;
+
+  const finalSlugs = [...map.byFinalSlug.values()]
+    .filter(entry => entry.handle.slug.toUpperCase() === upper)
+    .map(entry => entry.finalSlug)
+    .sort();
+  const hint = finalSlugs.length ? ` Use one of: ${finalSlugs.join(', ')}.` : '';
+
+  throw new ValidationError(
+    `Ambiguous custom tool slug "${slug}". Multiple custom toolkit tools share this original slug; ` +
+      `manual session.execute() by original slug is only supported when the original slug is unique.` +
+      hint
+  );
 }
 
 /**

--- a/ts/packages/core/src/types/customTool.types.ts
+++ b/ts/packages/core/src/types/customTool.types.ts
@@ -262,8 +262,12 @@ export type CustomToolsMapEntry = {
 export type CustomToolsMap = {
   /** Lookup by final slug (e.g. LOCAL_GET_USER_CONTEXT) — used for agent execution path */
   byFinalSlug: Map<string, CustomToolsMapEntry>;
-  /** Lookup by original slug (e.g. GET_USER_CONTEXT) — used for programmatic session.execute() */
+  /** Lookup by unique original slug (e.g. GET_USER_CONTEXT) — used for programmatic session.execute() */
   byOriginalSlug: Map<string, CustomToolsMapEntry>;
+  /** Lookup by resolved toolkit + original slug — used when multiple custom toolkits reuse tool names */
+  byToolkitAndOriginalSlug?: Map<string, CustomToolsMapEntry>;
+  /** Original slugs that appear in multiple toolkits and cannot be resolved safely without the final slug */
+  ambiguousOriginalSlugs?: Set<string>;
   /** The original custom toolkits passed at session creation — used for session.customToolkits() */
   toolkits?: CustomToolkit[];
   /** The original standalone custom tools passed at session creation — kept for inline re-injection on subsequent v3.1 requests. */


### PR DESCRIPTION
## Summary
- Fixes SDK custom-tool mapping for custom toolkits that reuse the same child tool slug, e.g. `APP_A.VERSION` and `APP_B.VERSION`.
- Adds toolkit-qualified lookup (`toolkit + original slug`) while keeping bare original-slug lookup only when it is unambiguous.
- Throws a client-side ambiguity error for manual `session.execute('VERSION')` when multiple custom toolkit tools share `VERSION`, instead of falling through to backend execution.
- Keeps `session.customToolkits()` / `session.customTools()` mapped to the backend-assigned final slugs for duplicate child names.

## Repro / validation
Validated locally with a temporary Tool Router script (not committed) using two dummy custom toolkits that both define `VERSION`:

- Current `next` SDK fails before high-level use with `Custom tool slug collision: original slug "VERSION" maps to multiple final slugs...`.
- Tool Router backend accepts the same payload and returns both `LOCAL_DUMMY_APP_A_REPRO_VERSION` and `LOCAL_DUMMY_APP_B_REPRO_VERSION`.
- This branch builds the SDK map successfully and high-level SDK execution routes each final slug to its own internal handler:
  - `LOCAL_DUMMY_APP_A_REPRO_VERSION` -> `{ app: "A", version: "1.0.0" }`
  - `LOCAL_DUMMY_APP_B_REPRO_VERSION` -> `{ app: "B", version: "2.0.0" }`

## Tests
- `pnpm --filter @composio/core typecheck`
- `pnpm --filter @composio/core exec vitest run test/models/customTool.test.ts test/models/toolRouter.test.ts test/models/customToolRouting.test.ts`