### PR TITLE
fix(sdk): use attach endpoint for existing sessions

### DIFF
--- a/.changeset/v31-customs-use-attach.md
+++ b/.changeset/v31-customs-use-attach.md
@@ -4,6 +4,6 @@
 
 Add custom tools support to `composio.use()`.
 
-- **`composio.use(id, { customTools, customToolkits })`**: Attach custom tools to an existing session. Binds local tools for search and execution. When called without custom tools, falls back to the standard session retrieve.
+- **`composio.use(id, { customTools, customToolkits })`**: Attach to an existing session through the v3.1 attach endpoint. When custom tools are provided, binds local tools for search and execution; when called without custom tools, it still uses attach with an empty body so session reuse has one backend path.
 - **Inline custom tools payload**: `use()` now correctly passes `inlineCustomToolsPayload` and `preloadedCustomToolSlugs` to the session, enabling custom tool execution and preloading on rehydrated sessions.
 - **`CustomToolsMap.tools`**: The map now caches the raw `CustomTool[]` array for future inline re-injection on v3.1 search/execute requests.

--- a/.changeset/v31-customs-use-attach.md
+++ b/.changeset/v31-customs-use-attach.md
@@ -4,6 +4,6 @@
 
 Add custom tools support to `composio.use()`.
 
-- **`composio.use(id, { customTools, customToolkits })`**: Attach to an existing session through the v3.1 attach endpoint. When custom tools are provided, binds local tools for search and execution; when called without custom tools, it still uses attach with an empty body so session reuse has one backend path.
+- **`composio.use(id, { customTools, customToolkits })`**: Reuse an existing session and optionally bind SDK-local custom tools for search and execution.
 - **Inline custom tools payload**: `use()` now correctly passes `inlineCustomToolsPayload` and `preloadedCustomToolSlugs` to the session, enabling custom tool execution and preloading on rehydrated sessions.
 - **`CustomToolsMap.tools`**: The map now caches the raw `CustomTool[]` array for future inline re-injection on v3.1 search/execute requests.

--- a/python/composio/core/models/tool_router.py
+++ b/python/composio/core/models/tool_router.py
@@ -998,15 +998,14 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
         custom_toolkits: t.Optional[t.List[ExperimentalToolkit]] = None,
     ) -> ToolRouterSession[TTool, TToolCollection]:
         """
-        Retrieve and use an existing tool router session, optionally attaching custom tools.
+        Use an existing tool router session.
 
-        The SDK always attaches to the session endpoint. When ``custom_tools``
-        or ``custom_toolkits`` are provided, they are included so they are
-        available for search and execution.
+        Provide ``custom_tools`` or ``custom_toolkits`` to bind SDK-local tools
+        to the session for search and execution.
 
-        :param session_id: The session ID to retrieve
-        :param custom_tools: Optional custom tools to attach to the session.
-        :param custom_toolkits: Optional custom toolkits to attach to the session.
+        :param session_id: The session ID to use.
+        :param custom_tools: Optional custom tools to bind to the session.
+        :param custom_toolkits: Optional custom toolkits to bind to the session.
         :return: Tool router session object
 
         Example:
@@ -1015,10 +1014,10 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
 
             composio = Composio()
 
-            # Simple rehydration
+            # Use an existing session
             session = composio.use('session_123')
 
-            # Rehydration with custom tools
+            # Use an existing session with custom tools
             session = composio.use(
                 'session_123',
                 custom_tools=[my_tool],

--- a/python/composio/core/models/tool_router.py
+++ b/python/composio/core/models/tool_router.py
@@ -1000,9 +1000,9 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
         """
         Retrieve and use an existing tool router session, optionally attaching custom tools.
 
-        When ``custom_tools`` or ``custom_toolkits`` are provided, the SDK
-        attaches them to the session so they are available for search and
-        execution.  Without customs it simply rehydrates the existing session.
+        The SDK always attaches to the session endpoint. When ``custom_tools``
+        or ``custom_toolkits`` are provided, they are included so they are
+        available for search and execution.
 
         :param session_id: The session ID to retrieve
         :param custom_tools: Optional custom tools to attach to the session.
@@ -1046,15 +1046,18 @@ class ToolRouter(Resource, t.Generic[TTool, TToolCollection]):
                     serialize_custom_toolkits(custom_toolkits)
                 )
 
-            from urllib.parse import quote
+        from urllib.parse import quote
 
-            session = self._client.post(
-                f"/api/v3.1/tool_router/session/{quote(session_id, safe='')}/attach",
-                body={"experimental": inline_custom_tools_payload},
-                cast_to=SessionRetrieveResponse,
-            )
-        else:
-            session = self._client.tool_router.session.retrieve(session_id)
+        body = (
+            {"experimental": inline_custom_tools_payload}
+            if inline_custom_tools_payload is not None
+            else {}
+        )
+        session = self._client.post(
+            f"/api/v3.1/tool_router/session/{quote(session_id, safe='')}/attach",
+            body=body,
+            cast_to=SessionRetrieveResponse,
+        )
 
         custom_tools_map: t.Optional[CustomToolsMap] = None
         user_id: t.Optional[str] = None

--- a/python/tests/test_tool_router.py
+++ b/python/tests/test_tool_router.py
@@ -5,6 +5,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 from composio_client import omit
 from pydantic import BaseModel, Field
+from composio_client.types.tool_router.session_retrieve_response import (
+    SessionRetrieveResponse,
+)
 
 from composio.exceptions import ValidationError
 from composio.core.models.custom_tool import ExperimentalAPI
@@ -56,6 +59,7 @@ def mock_client():
 
     client.tool_router.session.create.return_value = mock_session_response
     client.tool_router.session.retrieve.return_value = mock_session_response
+    client.post.return_value = mock_session_response
 
     # Mock link response
     mock_link_response = MagicMock()
@@ -933,10 +937,8 @@ class TestToolRouter:
             tool_router.use(session_id="session_123")
 
     def test_use_session(self, tool_router, mock_client):
-        """Test retrieving an existing session."""
-        mock_client.tool_router.session.retrieve.return_value.config.preload.tools = [
-            "GMAIL_FETCH_EMAILS"
-        ]
+        """Test attaching an existing session."""
+        mock_client.post.return_value.config.preload.tools = ["GMAIL_FETCH_EMAILS"]
 
         session = tool_router.use(session_id="session_123")
 
@@ -957,21 +959,63 @@ class TestToolRouter:
         assert callable(session.toolkits)
         assert session.preload.tools == ["GMAIL_FETCH_EMAILS"]
 
-        # Verify retrieve was called
-        mock_client.tool_router.session.retrieve.assert_called_once_with("session_123")
+        mock_client.post.assert_called_once_with(
+            "/api/v3.1/tool_router/session/session_123/attach",
+            body={},
+            cast_to=SessionRetrieveResponse,
+        )
+        mock_client.tool_router.session.retrieve.assert_not_called()
+
+    def test_use_session_with_custom_tools(self, tool_router, mock_client):
+        """Test attaching custom tools when reusing a session."""
+
+        @experimental_api.tool(
+            slug="GREP",
+            name="Grep",
+            description="Search local text",
+        )
+        def grep(input: GrepInput, ctx):
+            return {"matches": []}
+
+        mock_response = mock_client.post.return_value
+        mock_response.experimental = MagicMock()
+        mock_response.experimental.assistive_prompt = None
+        mock_response.experimental.custom_toolkits = []
+        mock_custom_tool = MagicMock()
+        mock_custom_tool.slug = "SERVER_GREP"
+        mock_custom_tool.original_slug = "GREP"
+        mock_custom_tool.extends_toolkit = None
+        mock_response.experimental.custom_tools = [mock_custom_tool]
+
+        session = tool_router.use(session_id="session_123", custom_tools=[grep])
+
+        mock_client.post.assert_called_once()
+        assert mock_client.post.call_args.args[0] == (
+            "/api/v3.1/tool_router/session/session_123/attach"
+        )
+        kwargs = mock_client.post.call_args.kwargs
+        assert kwargs["cast_to"] is SessionRetrieveResponse
+        assert kwargs["body"]["experimental"]["custom_tools"][0]["slug"] == "GREP"
+        assert "custom_toolkits" not in kwargs["body"]["experimental"]
+        mock_client.tool_router.session.retrieve.assert_not_called()
+        assert session.custom_tools()[0].slug == "SERVER_GREP"
+        assert session.custom_tools()[0].name == "Grep"
 
     def test_use_session_with_different_user(self, tool_router, mock_client):
         """Test that use() extracts user_id from session config."""
-        mock_retrieve_response = MagicMock()
-        mock_retrieve_response.session_id = "session_456"
-        mock_retrieve_response.mcp = MagicMock()
-        mock_retrieve_response.mcp.type = "http"
-        mock_retrieve_response.mcp.url = "https://mcp.example.com/session_456"
-        mock_retrieve_response.tool_router_tools = ["TOOL_1"]
-        mock_retrieve_response.config = MagicMock()
-        mock_retrieve_response.config.user_id = "custom_user_789"
+        mock_attach_response = MagicMock()
+        mock_attach_response.session_id = "session_456"
+        mock_attach_response.mcp = MagicMock()
+        mock_attach_response.mcp.type = "http"
+        mock_attach_response.mcp.url = "https://mcp.example.com/session_456"
+        mock_attach_response.tool_router_tools = ["TOOL_1"]
+        mock_attach_response.config = MagicMock()
+        mock_attach_response.config.user_id = "custom_user_789"
+        mock_attach_response.config.preload = MagicMock()
+        mock_attach_response.config.preload.tools = []
+        mock_attach_response.experimental = None
 
-        mock_client.tool_router.session.retrieve.return_value = mock_retrieve_response
+        mock_client.post.return_value = mock_attach_response
 
         session = tool_router.use(session_id="session_456")
 
@@ -979,10 +1023,8 @@ class TestToolRouter:
         assert session.mcp.type == ToolRouterMCPServerType.HTTP
 
     def test_use_session_throws_error_on_failure(self, tool_router, mock_client):
-        """Test that use() throws error if retrieve fails."""
-        mock_client.tool_router.session.retrieve.side_effect = Exception(
-            "Session not found"
-        )
+        """Test that use() throws error if attach fails."""
+        mock_client.post.side_effect = Exception("Session not found")
 
         with pytest.raises(Exception, match="Session not found"):
             tool_router.use(session_id="invalid_session")
@@ -1376,7 +1418,7 @@ class TestToolRouter:
 
     def test_use_vs_create_independence(self, tool_router, mock_client):
         """Test that use() and create() are independent."""
-        # Setup different responses for create and retrieve
+        # Setup different responses for create and attach
         mock_create_response = MagicMock()
         mock_create_response.session_id = "created_session"
         mock_create_response.mcp = MagicMock()
@@ -1384,17 +1426,20 @@ class TestToolRouter:
         mock_create_response.mcp.url = "https://mcp.example.com/created"
         mock_create_response.tool_router_tools = ["TOOL_1"]
 
-        mock_retrieve_response = MagicMock()
-        mock_retrieve_response.session_id = "retrieved_session"
-        mock_retrieve_response.mcp = MagicMock()
-        mock_retrieve_response.mcp.type = "http"
-        mock_retrieve_response.mcp.url = "https://mcp.example.com/retrieved"
-        mock_retrieve_response.tool_router_tools = ["TOOL_2"]
-        mock_retrieve_response.config = MagicMock()
-        mock_retrieve_response.config.user_id = "user_456"
+        mock_attach_response = MagicMock()
+        mock_attach_response.session_id = "retrieved_session"
+        mock_attach_response.mcp = MagicMock()
+        mock_attach_response.mcp.type = "http"
+        mock_attach_response.mcp.url = "https://mcp.example.com/retrieved"
+        mock_attach_response.tool_router_tools = ["TOOL_2"]
+        mock_attach_response.config = MagicMock()
+        mock_attach_response.config.user_id = "user_456"
+        mock_attach_response.config.preload = MagicMock()
+        mock_attach_response.config.preload.tools = []
+        mock_attach_response.experimental = None
 
         mock_client.tool_router.session.create.return_value = mock_create_response
-        mock_client.tool_router.session.retrieve.return_value = mock_retrieve_response
+        mock_client.post.return_value = mock_attach_response
 
         # Create a new session
         created_session = tool_router.create(user_id="user_123")
@@ -1406,7 +1451,12 @@ class TestToolRouter:
 
         # Verify both methods were called
         mock_client.tool_router.session.create.assert_called_once()
-        mock_client.tool_router.session.retrieve.assert_called_once()
+        mock_client.post.assert_called_once_with(
+            "/api/v3.1/tool_router/session/retrieved_session/attach",
+            body={},
+            cast_to=SessionRetrieveResponse,
+        )
+        mock_client.tool_router.session.retrieve.assert_not_called()
 
 
 class TestToolRouterTypes:
@@ -1755,13 +1805,13 @@ class TestToolRouterIntegration:
         assert tools == ["tool1", "tool2"]
 
     def test_create_and_use_same_session(self, tool_router, mock_client):
-        """Test creating a session and then retrieving it."""
+        """Test creating a session and then attaching it."""
         # Create session
         created_session = tool_router.create(user_id="user_123")
         created_session_id = created_session.session_id
 
-        # Setup retrieve to return the same session
-        mock_client.tool_router.session.retrieve.return_value = (
+        # Setup attach to return the same session
+        mock_client.post.return_value = (
             mock_client.tool_router.session.create.return_value
         )
 

--- a/ts/examples/tool-router/src/custom-tools-agent.ts
+++ b/ts/examples/tool-router/src/custom-tools-agent.ts
@@ -12,6 +12,7 @@
  *
  * Usage:
  *   COMPOSIO_API_KEY=... OPENAI_API_KEY=... bun src/custom-tools-agent.ts
+ *   COMPOSIO_SESSION_ID=... bun src/custom-tools-agent.ts  # reuse a session
  */
 import "dotenv/config";
 import { Composio, experimental_createTool, experimental_createToolkit } from "@composio/core";
@@ -161,6 +162,9 @@ const userManagement = experimental_createToolkit("USER_MANAGEMENT", {
   tools: [setUserRole, updateUserStatus],
 });
 
+const customTools = [getUserDetails, listUserKeys, formatGmailEmail];
+const customToolkits = [userManagement];
+
 // ── Agent ─────────────────────────────────────────────────────────
 
 const composio = new Composio({
@@ -169,16 +173,19 @@ const composio = new Composio({
   provider: new OpenAIAgentsProvider(),
 });
 
-const session = await composio.create("custom-tools-agent-user", {
-  toolkits: ["weathermap", "gmail"],
-  manageConnections: false,
-  experimental: {
-    customTools: [getUserDetails, listUserKeys, formatGmailEmail],
-    customToolkits: [userManagement],
-  },
-});
+const existingSessionId = process.env.COMPOSIO_SESSION_ID;
+const session = existingSessionId
+  ? await composio.use(existingSessionId, { customTools, customToolkits })
+  : await composio.create("custom-tools-agent-user", {
+      toolkits: ["weathermap", "gmail"],
+      manageConnections: false,
+      experimental: {
+        customTools,
+        customToolkits,
+      },
+    });
 
-console.log(`Session: ${session.sessionId}\n`);
+console.log(`${existingSessionId ? "Reused" : "Created"} session: ${session.sessionId}\n`);
 const tools = await session.tools();
 
 const agent = new Agent({

--- a/ts/examples/tool-router/src/custom-tools-e2e.ts
+++ b/ts/examples/tool-router/src/custom-tools-e2e.ts
@@ -139,6 +139,9 @@ const userManagement = experimental_createToolkit("USER_MANAGEMENT", {
   tools: [setUserRole, updateUserStatus],
 });
 
+const customTools = [getUserDetails, listUserKeys, formatGmailEmail];
+const customToolkits = [userManagement];
+
 // ────────────────────────────────────────────────────────────────
 // Run tests
 // ────────────────────────────────────────────────────────────────
@@ -157,8 +160,8 @@ async function main() {
       toolkits: ["weathermap", "gmail"],
       manageConnections: false,
       experimental: {
-        customTools: [getUserDetails, listUserKeys, formatGmailEmail],
-        customToolkits: [userManagement],
+        customTools,
+        customToolkits,
       },
     });
     ok(`Session created: ${session.sessionId}`);
@@ -166,6 +169,16 @@ async function main() {
     fail("Session creation", err);
     console.error("\nCannot continue without a session.");
     process.exit(1);
+  }
+
+  // ── Existing session reuse with local custom definitions ──
+  try {
+    const reusedSession = await composio.use(session.sessionId, { customTools, customToolkits });
+    const result = await reusedSession.execute("GET_USER_DETAILS", { user_id: "user-1" });
+    if (result.data?.name !== "Alice Johnson") throw new Error(`Unexpected: ${JSON.stringify(result.data)}`);
+    ok("Use: existing session binds custom tools for local execution");
+  } catch (err) {
+    fail("Use: existing session with custom tools", err);
   }
 
   // ════════════════════════════════════════════════════════════════

--- a/ts/packages/core/src/models/ToolRouter.ts
+++ b/ts/packages/core/src/models/ToolRouter.ts
@@ -35,7 +35,11 @@ import {
   SessionCreateResponse,
   SessionRetrieveResponse,
 } from '@composio/client/resources/tool-router/session/session.mjs';
-import type { CustomTool, CustomToolkit, InlineCustomToolsWirePayload } from '../types/customTool.types';
+import type {
+  CustomTool,
+  CustomToolkit,
+  InlineCustomToolsWirePayload,
+} from '../types/customTool.types';
 import {
   transformToolRouterTagsParams,
   transformToolRouterToolsParams,
@@ -252,7 +256,6 @@ export class ToolRouter<
     const customToolkits = options?.customToolkits;
     const hasCustoms = !!(customTools?.length || customToolkits?.length);
 
-    let session: SessionRetrieveResponse;
     let inlineCustomToolsPayload: InlineCustomToolsWirePayload | undefined;
 
     if (hasCustoms) {
@@ -265,14 +268,12 @@ export class ToolRouter<
         custom_tools: serializedTools,
         custom_toolkits: serializedToolkits,
       };
-
-      session = await this.client.post<SessionRetrieveResponse>(
-        `/api/v3.1/tool_router/session/${encodeURIComponent(id)}/attach`,
-        { body: { experimental: inlineCustomToolsPayload } }
-      );
-    } else {
-      session = await this.client.toolRouter.session.retrieve(id);
     }
+
+    const session = await this.client.post<SessionRetrieveResponse>(
+      `/api/v3.1/tool_router/session/${encodeURIComponent(id)}/attach`,
+      { body: inlineCustomToolsPayload ? { experimental: inlineCustomToolsPayload } : {} }
+    );
 
     let customToolsMap: CustomToolsMap | undefined;
     let userId: string | undefined;

--- a/ts/packages/core/src/models/ToolRouter.ts
+++ b/ts/packages/core/src/models/ToolRouter.ts
@@ -265,8 +265,8 @@ export class ToolRouter<
         : undefined;
 
       inlineCustomToolsPayload = {
-        custom_tools: serializedTools,
-        custom_toolkits: serializedToolkits,
+        ...(serializedTools ? { custom_tools: serializedTools } : {}),
+        ...(serializedToolkits ? { custom_toolkits: serializedToolkits } : {}),
       };
     }
 

--- a/ts/packages/core/test/models/toolRouter.test.ts
+++ b/ts/packages/core/test/models/toolRouter.test.ts
@@ -2972,10 +2972,12 @@ describe('ToolRouter', () => {
         body: {
           experimental: {
             custom_tools: [expect.objectContaining({ slug: 'GREP' })],
-            custom_toolkits: undefined,
           },
         },
       });
+      expect(mockClient.post.mock.calls[0][1].body.experimental).not.toHaveProperty(
+        'custom_toolkits'
+      );
       expect(mockClient.toolRouter.session.retrieve).not.toHaveBeenCalled();
       expect(session.customTools()).toEqual([
         expect.objectContaining({

--- a/ts/packages/core/test/models/toolRouter.test.ts
+++ b/ts/packages/core/test/models/toolRouter.test.ts
@@ -31,6 +31,7 @@ vi.mock('../../src/models/Tools', () => {
 const createMockClient = () => ({
   baseURL: 'https://api.composio.dev',
   apiKey: 'test-api-key',
+  post: vi.fn(),
   toolRouter: {
     session: {
       create: vi.fn(),
@@ -2918,13 +2919,16 @@ describe('ToolRouter', () => {
 
   describe('use method', () => {
     const sessionId = 'session_123';
+    const attachEndpoint = (id: string) =>
+      `/api/v3.1/tool_router/session/${encodeURIComponent(id)}/attach`;
 
-    it('should retrieve an existing session by ID', async () => {
-      mockClient.toolRouter.session.retrieve.mockResolvedValueOnce(mockSessionRetrieveResponse);
+    it('should attach an existing session by ID', async () => {
+      mockClient.post.mockResolvedValueOnce(mockSessionRetrieveResponse);
 
       const session = await toolRouter.use(sessionId);
 
-      expect(mockClient.toolRouter.session.retrieve).toHaveBeenCalledWith(sessionId);
+      expect(mockClient.post).toHaveBeenCalledWith(attachEndpoint(sessionId), { body: {} });
+      expect(mockClient.toolRouter.session.retrieve).not.toHaveBeenCalled();
       expect(session).toHaveProperty('sessionId', 'session_123');
       expect(session).toHaveProperty('mcp');
       expect(session.mcp).toEqual({
@@ -2941,6 +2945,46 @@ describe('ToolRouter', () => {
       expect(session.configVersion).toBe(7);
     });
 
+    it('should attach custom tools when provided', async () => {
+      const grepTool = createCustomTool('GREP', {
+        name: 'Grep',
+        description: 'Search local text',
+        inputParams: z.object({ pattern: z.string() }),
+        execute: vi.fn(async () => ({ matches: [] })),
+      });
+
+      mockClient.post.mockResolvedValueOnce({
+        ...mockSessionRetrieveResponse,
+        experimental: {
+          custom_tools: [
+            {
+              slug: 'SERVER_GREP',
+              original_slug: 'GREP',
+              extends_toolkit: null,
+            },
+          ],
+        },
+      });
+
+      const session = await toolRouter.use(sessionId, { customTools: [grepTool] });
+
+      expect(mockClient.post).toHaveBeenCalledWith(attachEndpoint(sessionId), {
+        body: {
+          experimental: {
+            custom_tools: [expect.objectContaining({ slug: 'GREP' })],
+            custom_toolkits: undefined,
+          },
+        },
+      });
+      expect(mockClient.toolRouter.session.retrieve).not.toHaveBeenCalled();
+      expect(session.customTools()).toEqual([
+        expect.objectContaining({
+          slug: 'SERVER_GREP',
+          name: 'Grep',
+        }),
+      ]);
+    });
+
     it('should return a session with correct session ID', async () => {
       const customResponse = {
         ...mockSessionRetrieveResponse,
@@ -2950,7 +2994,7 @@ describe('ToolRouter', () => {
         },
       };
 
-      mockClient.toolRouter.session.retrieve.mockResolvedValueOnce(customResponse);
+      mockClient.post.mockResolvedValueOnce(customResponse);
 
       const session = await toolRouter.use(sessionId);
 
@@ -2960,7 +3004,7 @@ describe('ToolRouter', () => {
     });
 
     it('should return a session with working tools function', async () => {
-      mockClient.toolRouter.session.retrieve.mockResolvedValueOnce(mockSessionRetrieveResponse);
+      mockClient.post.mockResolvedValueOnce(mockSessionRetrieveResponse);
 
       const session = await toolRouter.use(sessionId);
 
@@ -2979,7 +3023,7 @@ describe('ToolRouter', () => {
     });
 
     it('should return a session with working authorize function', async () => {
-      mockClient.toolRouter.session.retrieve.mockResolvedValueOnce(mockSessionRetrieveResponse);
+      mockClient.post.mockResolvedValueOnce(mockSessionRetrieveResponse);
       mockClient.toolRouter.session.link.mockResolvedValueOnce(mockLinkResponse);
 
       const session = await toolRouter.use(sessionId);
@@ -2994,7 +3038,7 @@ describe('ToolRouter', () => {
     });
 
     it('should return a session with working toolkits function', async () => {
-      mockClient.toolRouter.session.retrieve.mockResolvedValueOnce(mockSessionRetrieveResponse);
+      mockClient.post.mockResolvedValueOnce(mockSessionRetrieveResponse);
       mockClient.toolRouter.session.toolkits.mockResolvedValueOnce(mockToolkitsResponse);
 
       const session = await toolRouter.use(sessionId);
@@ -3022,7 +3066,7 @@ describe('ToolRouter', () => {
         session_id: 'session_2',
       };
 
-      mockClient.toolRouter.session.retrieve
+      mockClient.post
         .mockResolvedValueOnce(session1Response)
         .mockResolvedValueOnce(session2Response);
 
@@ -3031,11 +3075,13 @@ describe('ToolRouter', () => {
 
       expect(session1.sessionId).toBe('session_1');
       expect(session2.sessionId).toBe('session_2');
-      expect(mockClient.toolRouter.session.retrieve).toHaveBeenCalledTimes(2);
+      expect(mockClient.post).toHaveBeenCalledTimes(2);
+      expect(mockClient.post).toHaveBeenNthCalledWith(1, attachEndpoint('session_1'), { body: {} });
+      expect(mockClient.post).toHaveBeenNthCalledWith(2, attachEndpoint('session_2'), { body: {} });
     });
 
     it('should handle MCP server type correctly', async () => {
-      mockClient.toolRouter.session.retrieve.mockResolvedValueOnce(mockSessionRetrieveResponse);
+      mockClient.post.mockResolvedValueOnce(mockSessionRetrieveResponse);
 
       const session = await toolRouter.use(sessionId);
 
@@ -3043,21 +3089,21 @@ describe('ToolRouter', () => {
       expect(session.mcp.url).toBe('https://mcp.example.com/session_123');
     });
 
-    it('should throw error if session retrieve fails', async () => {
+    it('should throw error if session attach fails', async () => {
       const error = new Error('Session not found');
-      mockClient.toolRouter.session.retrieve.mockRejectedValueOnce(error);
+      mockClient.post.mockRejectedValueOnce(error);
 
       await expect(toolRouter.use(sessionId)).rejects.toThrow('Session not found');
-      expect(mockClient.toolRouter.session.retrieve).toHaveBeenCalledWith(sessionId);
+      expect(mockClient.post).toHaveBeenCalledWith(attachEndpoint(sessionId), { body: {} });
     });
 
-    it('should handle retrieve with different tool lists', async () => {
+    it('should handle attach with different tool lists', async () => {
       const customResponse = {
         ...mockSessionRetrieveResponse,
         tool_router_tools: ['CUSTOM_TOOL_1', 'CUSTOM_TOOL_2'],
       };
 
-      mockClient.toolRouter.session.retrieve.mockResolvedValueOnce(customResponse);
+      mockClient.post.mockResolvedValueOnce(customResponse);
 
       const session = await toolRouter.use(sessionId);
 
@@ -3067,7 +3113,7 @@ describe('ToolRouter', () => {
 
     it('should be independent from create method', async () => {
       mockClient.toolRouter.session.create.mockResolvedValueOnce(mockSessionCreateResponse);
-      mockClient.toolRouter.session.retrieve.mockResolvedValueOnce(mockSessionRetrieveResponse);
+      mockClient.post.mockResolvedValueOnce(mockSessionRetrieveResponse);
 
       // Create a new session
       const createdSession = await toolRouter.create('user_123');
@@ -3079,7 +3125,8 @@ describe('ToolRouter', () => {
 
       // Both should have been called once
       expect(mockClient.toolRouter.session.create).toHaveBeenCalledTimes(1);
-      expect(mockClient.toolRouter.session.retrieve).toHaveBeenCalledTimes(1);
+      expect(mockClient.post).toHaveBeenCalledTimes(1);
+      expect(mockClient.toolRouter.session.retrieve).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Route TypeScript `session.use()` through `/attach` even when no custom tools are supplied
- Apply the same `/attach` behavior to Python `ToolRouter.use()`
- Update focused TypeScript/Python tests and the unreleased changeset note

## Tests
- `pnpm --dir ts/packages/core test test/models/toolRouter.test.ts`
- `../.venv/bin/ruff check composio/core/models/tool_router.py tests/test_tool_router.py` from `python/`
- `../.venv/bin/python -m pytest tests/test_tool_router.py` from `python/`