### PR TITLE
fix(core): expose string | string[] in connectedAccounts public type

### DIFF
--- a/.changeset/fix-connected-accounts-string-type.md
+++ b/.changeset/fix-connected-accounts-string-type.md
@@ -1,0 +1,7 @@
+---
+'@composio/core': patch
+---
+
+Fix `connectedAccounts` TypeScript type so a single `string` per toolkit is actually accepted by the public API.
+
+Previously the schema's `.transform()` made `ToolRouterCreateSessionConfig['connectedAccounts']` resolve to `Record<string, string[]>` (the post-transform output), so TypeScript users still got `Type 'string' is not assignable to type 'string[]'` even though the runtime accepted strings. Coercion now happens inside `ToolRouter.create`, mirroring the Python implementation, and the public type is `Record<string, string | string[]>`.

--- a/.changeset/v31-connected-accounts-array.md
+++ b/.changeset/v31-connected-accounts-array.md
@@ -4,4 +4,4 @@
 
 `connectedAccounts` now accepts both `string` and `string[]` per toolkit.
 
-A single string is automatically coerced to an array to match the v3.1 API wire format. Existing callers passing `{ gmail: "ca_xxx" }` continue to work without changes. Only one account per toolkit is allowed when multi-account mode is disabled. Bumps `@composio/client` to `0.1.0-alpha.70`.
+A single string is automatically coerced to an array to match the v3.1 API wire format. Existing callers passing `{ gmail: "ca_xxx" }` continue to work without changes. Only one account per toolkit is allowed when multi-account mode is disabled.

--- a/ts/packages/core/src/models/ToolRouter.ts
+++ b/ts/packages/core/src/models/ToolRouter.ts
@@ -179,10 +179,20 @@ export class ToolRouter<
 
     const multiAccountPayload = transformToolRouterMultiAccountParams(routerConfig.multiAccount);
 
+    const connectedAccountsPayload =
+      routerConfig.connectedAccounts === undefined
+        ? undefined
+        : Object.fromEntries(
+            Object.entries(routerConfig.connectedAccounts).map(([toolkit, ids]) => [
+              toolkit,
+              typeof ids === 'string' ? [ids] : ids,
+            ])
+          );
+
     const payload: SessionCreateParams = {
       user_id: userId,
       auth_configs: routerConfig.authConfigs,
-      connected_accounts: routerConfig.connectedAccounts,
+      connected_accounts: connectedAccountsPayload,
       toolkits: transformToolRouterToolkitsParams(routerConfig.toolkits),
       tools: transformToolRouterToolsParams(routerConfig.tools),
       tags: transformToolRouterTagsParams(routerConfig.tags),

--- a/ts/packages/core/src/types/toolRouter.types.ts
+++ b/ts/packages/core/src/types/toolRouter.types.ts
@@ -203,13 +203,6 @@ const ToolRouterCreateSessionConfigBaseSchema = z
       .default({}),
     connectedAccounts: z
       .record(z.string(), z.union([z.string(), z.array(z.string())]))
-      .transform((rec) => {
-        const out: Record<string, string[]> = {};
-        for (const [k, v] of Object.entries(rec)) {
-          out[k] = typeof v === 'string' ? [v] : v;
-        }
-        return out;
-      })
       .describe(
         'The connected accounts to use in the tool router session. The key is the toolkit slug, the value is a connected account id or an array of ids. Only one account per toolkit is allowed when multi-account mode is disabled.'
       )
@@ -344,7 +337,7 @@ export const ToolRouterCreateSessionConfigSchema = z
  * @param {Record<string, ToolRouterToolsParam | ToolRouterConfigTools>} tools - The tools to configure per toolkit (key is toolkit slug)
  * @param {Array<'readOnlyHint' | 'destructiveHint' | 'idempotentHint' | 'openWorldHint'>} tags - Global tags to filter tools by behavior
  * @param {Record<string, string>} authConfigs - The auth configs to use in the tool router session
- * @param {Record<string, string>} connectedAccounts - The connected accounts to use in the tool router session
+ * @param {Record<string, string | string[]>} connectedAccounts - The connected accounts to use in the tool router session. A single string is coerced to a single-element array before being sent to the backend.
  * @param {ToolRouterConfigManageConnectionsSchema | boolean} manageConnections - The config for the manage connections in the tool router session. Defaults to true, if set to false, you need to manage connections manually. If set to an object, you can configure the manage connections settings.
  * @param {boolean} [manageConnections.enable] - Whether to use tools to manage connections in the tool router session @default true
  * @param {string} [manageConnections.callbackUrl] - The callback url to use in the tool router session


### PR DESCRIPTION
## Summary

Follow-up to #3358. The `.transform()` added on the `connectedAccounts` Zod schema made the inferred TypeScript type resolve to the **post-transform output** (`Record<string, string[]>`), so TS users still hit `error TS2322: Type 'string' is not assignable to type 'string[]'` even though the runtime accepted strings. The runtime fix landed; the public TS surface didn't follow.

This PR moves the coercion out of the schema and into `ToolRouter.create`, mirroring the Python implementation. The public type is now `Record<string, string | string[]>` and runtime behavior is unchanged.

Linear: [PLEN-2440](https://linear.app/composio/issue/PLEN-2440/type-test-testts-in-composiocore-so-zod-inferred-public-types-are) — follow-up to type-test `test/**/*.ts` in CI so this class of regression is caught at compile time.

## Why CI didn't catch this in #3358

The PR's own test file (`toolRouter.test.ts`) already assigns a `string` to `ToolRouterCreateSessionConfig`, but `ts/packages/core/tsconfig.json` has `"include": ["src/**/*.ts"]` — `test/` is not typechecked. So `tsc --noEmit clean` was technically true while masking the issue. Verified empirically by dropping a typecheck file into `src/` on `next`:

```
src/__type_check.ts(8,7): error TS2322: Type 'string' is not assignable to type 'string[]'.
```

After this PR, the same file compiles cleanly.

## Changes

- **`ts/packages/core/src/types/toolRouter.types.ts`**: drop `.transform()` from the `connectedAccounts` schema; `z.infer` now exposes `Record<string, string | string[]>`.
- **`ts/packages/core/src/models/ToolRouter.ts`**: coerce `string → [string]` inside `create` before sending to the backend (which expects arrays). Preserves the original `connected_accounts: undefined` behavior when the field is omitted (the parent schema's `.partial()` strips the `default({})`).
- **`ts/packages/core/src/types/toolRouter.types.ts`**: fix stale `@param {Record<string, string>}` JSDoc on the same field.
- **`.changeset/v31-connected-accounts-array.md`**: drop the inaccurate *"Bumps `@composio/client` to `0.1.0-alpha.70`"* line — that bump landed in a separate commit on `next` (`7c1443838`), not in #3358's diff (`git diff 2bbd791de^1 2bbd791de` shows zero `pnpm-lock.yaml`/`package.json` changes).
- **`.changeset/fix-connected-accounts-string-type.md`**: new `patch` changeset for `@composio/core`.

## Test plan

- [x] `pnpm exec tsc --noEmit -p tsconfig.json` clean on `@composio/core`
- [x] `pnpm exec vitest run` — 883/883 tests pass (incl. 110 in `toolRouter.test.ts`)
- [x] `pnpm prettier --check` clean on touched files
- [x] Spot-checked: assigning `{ connectedAccounts: { gmail: 'ca_xxx' } }` to `ToolRouterCreateSessionConfig` now typechecks; assigning the array form still typechecks.