### PR TITLE
Fix invalid changeset package

### DIFF
--- a/.changeset/session-update-method.md
+++ b/.changeset/session-update-method.md
@@ -1,6 +1,5 @@
 ---
 "@composio/core": minor
-"composio": minor
 ---
 
 Add `session.update()` method for partially updating session configuration after creation. Accepts the same config shape as `create()` and mutates the session in-place. Available in both TypeScript and Python SDKs.


### PR DESCRIPTION
## Summary
- Remove the Python package name from the TypeScript changeset frontmatter.
- Keeps the `@composio/core` minor bump intact so pending patch/minor changesets collapse into one TS minor release.

## Root Cause
The TypeScript Changesets release job runs against the pnpm workspace. `.changeset/session-update-method.md` referenced `composio`, which is the Python package name and not a pnpm workspace package, so `changeset version` failed with `Found changeset session-update-method for package composio which is not in the workspace`.

## Validation
- `git diff --check`
- Confirmed no remaining `.changeset` entry references `"composio"` as a package name.

Note: a full local `pnpm changeset version` dry run was blocked in the temp worktree by missing `node_modules`; the failure is static and this removes the invalid package reference.