### PR TITLE
fix(python-sdk): handle file upload list unions

### DIFF
--- a/python/composio/core/models/_files.py
+++ b/python/composio/core/models/_files.py
@@ -58,6 +58,8 @@ Connect timeout is short to fail fast on unreachable hosts.
 Read timeout is longer to allow for slower file transfers.
 """
 
+_DELETE_VALUE = object()
+
 LOCAL_CACHE_DIRECTORY_NAME = ".composio"
 """
 Local cache directory name for composio CLI
@@ -776,27 +778,171 @@ class FileHelper(WithLogger):
         self.enhance_schema_descriptions(schema)
         return schema
 
-    def _find_uploadable_schema_variant(self, schema: t.Dict) -> t.Optional[t.Dict]:
+    def _schema_variants(self, schema: t.Dict) -> t.List[t.Dict]:
+        """Return composed schema variants in the SDK's historical order."""
+        variants: t.List[t.Dict] = []
+        for key in ("anyOf", "oneOf", "allOf"):
+            schema_variants = schema.get(key)
+            if not isinstance(schema_variants, list):
+                continue
+            variants.extend(v for v in schema_variants if isinstance(v, dict))
+        return variants
+
+    def _json_schema_type_matches_value(self, schema: t.Dict, value: t.Any) -> bool:
+        """Best-effort runtime shape match for selecting composed schemas."""
+        schema_type = schema.get("type")
+        if isinstance(schema_type, list):
+            return any(
+                self._json_schema_type_matches_value({**schema, "type": tpe}, value)
+                for tpe in schema_type
+            )
+
+        if schema_type is None:
+            if "properties" in schema:
+                return isinstance(value, dict)
+            if "items" in schema:
+                return isinstance(value, list)
+            return False
+
+        if schema_type == "array":
+            return isinstance(value, list)
+        if schema_type == "object":
+            return isinstance(value, dict)
+        if schema_type == "string":
+            return isinstance(value, str)
+        if schema_type == "integer":
+            return isinstance(value, int) and not isinstance(value, bool)
+        if schema_type == "number":
+            return isinstance(value, (int, float)) and not isinstance(value, bool)
+        if schema_type == "boolean":
+            return isinstance(value, bool)
+        if schema_type == "null":
+            return value is None
+
+        return False
+
+    def _find_schema_variant_with_file_property(
+        self,
+        schema: t.Dict,
+        property_name: str,
+        value: t.Any = None,
+    ) -> t.Optional[t.Dict]:
+        """Find the composed schema variant that should process a file value.
+
+        ``anyOf``, ``oneOf`` and ``allOf`` are intentionally treated the same
+        here, matching the SDK's existing convention. When a runtime value is
+        available, prefer the file-bearing variant with the matching JSON Schema
+        shape; otherwise keep the historical first-match behavior.
+        """
+        candidates = [
+            variant
+            for variant in self._schema_variants(schema)
+            if self._has_file_property(variant, property_name)
+        ]
+        if not candidates:
+            return None
+
+        if value is not None:
+            for candidate in candidates:
+                if self._json_schema_type_matches_value(candidate, value):
+                    return candidate
+
+        return candidates[0]
+
+    def _find_uploadable_schema_variant(
+        self, schema: t.Dict, value: t.Any = None
+    ) -> t.Optional[t.Dict]:
         """Find a schema variant that contains file_uploadable properties."""
-        # Check anyOf variants
-        if "anyOf" in schema:
-            for variant in schema["anyOf"]:
-                if self._has_file_property(variant, "file_uploadable"):
-                    return variant
+        return self._find_schema_variant_with_file_property(
+            schema=schema,
+            property_name="file_uploadable",
+            value=value,
+        )
 
-        # Check oneOf variants
-        if "oneOf" in schema:
-            for variant in schema["oneOf"]:
-                if self._has_file_property(variant, "file_uploadable"):
-                    return variant
+    def _upload_file_value(
+        self,
+        value: t.Any,
+        tool: Tool,
+        before_file_upload: t.Optional[BeforeFileUpload],
+    ) -> t.Any:
+        if value is None or value == "":
+            return _DELETE_VALUE
 
-        # Check allOf - merge all variants
-        if "allOf" in schema:
-            for variant in schema["allOf"]:
-                if self._has_file_property(variant, "file_uploadable"):
-                    return variant
+        return FileUploadable.from_path(
+            client=self._client,
+            file=value,
+            tool=tool.slug,
+            toolkit=tool.toolkit.slug,
+            sensitive_file_upload_protection=self._sensitive_file_upload_protection,
+            file_upload_path_deny_segments=self._file_upload_path_deny_segments,
+            file_upload_allowlist=self._file_upload_allowlist,
+            before_file_upload=before_file_upload,
+        ).model_dump()
 
-        return None
+    def _substitute_file_upload_value(
+        self,
+        value: t.Any,
+        schema: t.Optional[t.Dict],
+        tool: Tool,
+        *,
+        before_file_upload: t.Optional[BeforeFileUpload] = None,
+    ) -> t.Any:
+        """Return ``value`` with file-uploadable leaves staged for execution."""
+        if not isinstance(schema, dict):
+            return value
+
+        if schema.get("file_uploadable", False):
+            return self._upload_file_value(
+                value=value,
+                tool=tool,
+                before_file_upload=before_file_upload,
+            )
+
+        uploadable_variant = self._find_uploadable_schema_variant(
+            schema=schema,
+            value=value,
+        )
+        if uploadable_variant is not None:
+            return self._substitute_file_upload_value(
+                value=value,
+                schema=uploadable_variant,
+                tool=tool,
+                before_file_upload=before_file_upload,
+            )
+
+        if isinstance(value, dict) and "properties" in schema:
+            processed: t.Dict[str, t.Any] = {}
+            properties = schema["properties"]
+            for key, item in value.items():
+                item_schema = properties.get(key)
+                processed_item = self._substitute_file_upload_value(
+                    value=item,
+                    schema=item_schema,
+                    tool=tool,
+                    before_file_upload=before_file_upload,
+                )
+                if processed_item is not _DELETE_VALUE:
+                    processed[key] = processed_item
+            return processed
+
+        if isinstance(value, list) and "items" in schema:
+            items_schema = schema["items"]
+            if isinstance(items_schema, list):
+                items_schema = items_schema[0] if items_schema else None
+
+            processed_items: t.List[t.Any] = []
+            for item in value:
+                processed_item = self._substitute_file_upload_value(
+                    value=item,
+                    schema=items_schema,
+                    tool=tool,
+                    before_file_upload=before_file_upload,
+                )
+                if processed_item is not _DELETE_VALUE:
+                    processed_items.append(processed_item)
+            return processed_items
+
+        return value
 
     def _substitute_file_uploads_recursively(
         self,
@@ -806,123 +952,19 @@ class FileHelper(WithLogger):
         *,
         before_file_upload: t.Optional[BeforeFileUpload] = None,
     ) -> t.Dict:
-        if "properties" not in schema:
+        processed = self._substitute_file_upload_value(
+            value=request,
+            schema=schema,
+            tool=tool,
+            before_file_upload=before_file_upload,
+        )
+        if processed is request:
             return request
-
-        params = schema["properties"]
-        for _param in list(request.keys()):
-            if _param not in params:
-                continue
-
-            param_schema = params[_param]
-
-            # Direct file_uploadable check
-            if param_schema.get("file_uploadable", False):
-                # skip if the file is not provided
-                if request[_param] is None or request[_param] == "":
-                    del request[_param]
-                    continue
-
-                request[_param] = FileUploadable.from_path(
-                    client=self._client,
-                    file=request[_param],
-                    tool=tool.slug,
-                    toolkit=tool.toolkit.slug,
-                    sensitive_file_upload_protection=self._sensitive_file_upload_protection,
-                    file_upload_path_deny_segments=self._file_upload_path_deny_segments,
-                    file_upload_allowlist=self._file_upload_allowlist,
-                    before_file_upload=before_file_upload,
-                ).model_dump()
-                continue
-
-            # Check anyOf/oneOf/allOf for file_uploadable
-            uploadable_variant = self._find_uploadable_schema_variant(param_schema)
-            if uploadable_variant is not None:
-                # If the variant itself is file_uploadable
-                if uploadable_variant.get("file_uploadable", False):
-                    if request[_param] is None or request[_param] == "":
-                        del request[_param]
-                        continue
-
-                    request[_param] = FileUploadable.from_path(
-                        client=self._client,
-                        file=request[_param],
-                        tool=tool.slug,
-                        toolkit=tool.toolkit.slug,
-                        sensitive_file_upload_protection=self._sensitive_file_upload_protection,
-                        file_upload_path_deny_segments=self._file_upload_path_deny_segments,
-                        file_upload_allowlist=self._file_upload_allowlist,
-                        before_file_upload=before_file_upload,
-                    ).model_dump()
-                    continue
-
-                # If the variant has nested properties with file_uploadable
-                if (
-                    isinstance(request[_param], dict)
-                    and uploadable_variant.get("type") == "object"
-                ):
-                    request[_param] = self._substitute_file_uploads_recursively(
-                        schema=uploadable_variant,
-                        request=request[_param],
-                        tool=tool,
-                        before_file_upload=before_file_upload,
-                    )
-                    continue
-
-            # Handle nested objects
-            if (
-                isinstance(request[_param], dict)
-                and param_schema.get("type") == "object"
-            ):
-                request[_param] = self._substitute_file_uploads_recursively(
-                    schema=param_schema,
-                    request=request[_param],
-                    tool=tool,
-                    before_file_upload=before_file_upload,
-                )
-                continue
-
-            # Handle arrays with file_uploadable items
-            if (
-                isinstance(request[_param], list)
-                and param_schema.get("type") == "array"
-                and "items" in param_schema
-            ):
-                items_schema = param_schema["items"]
-                if isinstance(items_schema, dict):
-                    processed_items: t.List[t.Any] = []
-                    for item in request[_param]:
-                        if self._has_file_property(items_schema, "file_uploadable"):
-                            if items_schema.get("file_uploadable", False):
-                                if item is not None and item != "":
-                                    processed_items.append(
-                                        FileUploadable.from_path(
-                                            client=self._client,
-                                            file=item,
-                                            tool=tool.slug,
-                                            toolkit=tool.toolkit.slug,
-                                            sensitive_file_upload_protection=self._sensitive_file_upload_protection,
-                                            file_upload_path_deny_segments=self._file_upload_path_deny_segments,
-                                            file_upload_allowlist=self._file_upload_allowlist,
-                                            before_file_upload=before_file_upload,
-                                        ).model_dump()
-                                    )
-                            elif isinstance(item, dict):
-                                processed_items.append(
-                                    self._substitute_file_uploads_recursively(
-                                        schema=items_schema,
-                                        request=item,
-                                        tool=tool,
-                                        before_file_upload=before_file_upload,
-                                    )
-                                )
-                            else:
-                                processed_items.append(item)
-                        else:
-                            processed_items.append(item)
-                    request[_param] = processed_items
-
-        return request
+        if isinstance(processed, dict):
+            request.clear()
+            request.update(processed)
+            return request
+        return t.cast(t.Dict, processed)
 
     def substitute_file_uploads(
         self,
@@ -942,27 +984,74 @@ class FileHelper(WithLogger):
         """Check if a schema has file_downloadable property."""
         return self._has_file_property(schema, "file_downloadable")
 
-    def _find_downloadable_schema_variant(self, schema: t.Dict) -> t.Optional[t.Dict]:
+    def _find_downloadable_schema_variant(
+        self, schema: t.Dict, value: t.Any = None
+    ) -> t.Optional[t.Dict]:
         """Find a schema variant that contains file_downloadable properties."""
-        # Check anyOf variants
-        if "anyOf" in schema:
-            for variant in schema["anyOf"]:
-                if self._has_file_property(variant, "file_downloadable"):
-                    return variant
+        return self._find_schema_variant_with_file_property(
+            schema=schema,
+            property_name="file_downloadable",
+            value=value,
+        )
 
-        # Check oneOf variants
-        if "oneOf" in schema:
-            for variant in schema["oneOf"]:
-                if self._has_file_property(variant, "file_downloadable"):
-                    return variant
+    def _download_file_value(self, value: t.Any, tool: Tool) -> t.Any:
+        if isinstance(value, dict) and "s3url" in value:
+            return str(
+                FileDownloadable(**value).download(
+                    self._outdir / tool.toolkit.slug / tool.slug
+                )
+            )
+        return value
 
-        # Check allOf variants
-        if "allOf" in schema:
-            for variant in schema["allOf"]:
-                if self._has_file_property(variant, "file_downloadable"):
-                    return variant
+    def _substitute_file_download_value(
+        self,
+        value: t.Any,
+        schema: t.Optional[t.Dict],
+        tool: Tool,
+    ) -> t.Any:
+        """Return ``value`` with file-downloadable leaves saved locally."""
+        if not isinstance(schema, dict):
+            return value
 
-        return None
+        if schema.get("file_downloadable", False):
+            return self._download_file_value(value=value, tool=tool)
+
+        downloadable_variant = self._find_downloadable_schema_variant(
+            schema=schema,
+            value=value,
+        )
+        if downloadable_variant is not None:
+            return self._substitute_file_download_value(
+                value=value,
+                schema=downloadable_variant,
+                tool=tool,
+            )
+
+        if isinstance(value, dict) and "properties" in schema:
+            properties = schema["properties"]
+            return {
+                key: self._substitute_file_download_value(
+                    value=item,
+                    schema=properties.get(key),
+                    tool=tool,
+                )
+                for key, item in value.items()
+            }
+
+        if isinstance(value, list) and "items" in schema:
+            items_schema = schema["items"]
+            if isinstance(items_schema, list):
+                items_schema = items_schema[0] if items_schema else None
+            return [
+                self._substitute_file_download_value(
+                    value=item,
+                    schema=items_schema,
+                    tool=tool,
+                )
+                for item in value
+            ]
+
+        return value
 
     def _substitute_file_downloads_recursively(
         self,
@@ -970,121 +1059,18 @@ class FileHelper(WithLogger):
         schema: t.Dict,
         request: t.Dict,
     ) -> t.Dict:
-        if "properties" not in schema:
+        processed = self._substitute_file_download_value(
+            value=request,
+            schema=schema,
+            tool=tool,
+        )
+        if processed is request:
             return request
-
-        params = schema["properties"]
-        for _param in list(request.keys()):
-            if _param not in params:
-                continue
-
-            param_schema = params[_param]
-            param_value = request[_param]
-
-            # Skip None values
-            if param_value is None:
-                continue
-
-            # Direct file_downloadable check
-            if param_schema.get("file_downloadable", False):
-                if isinstance(param_value, dict) and "s3url" in param_value:
-                    request[_param] = str(
-                        FileDownloadable(**param_value).download(
-                            self._outdir / tool.toolkit.slug / tool.slug
-                        )
-                    )
-                continue
-
-            # Check anyOf/oneOf/allOf for file_downloadable
-            downloadable_variant = self._find_downloadable_schema_variant(param_schema)
-            if downloadable_variant is not None:
-                # If the variant itself is file_downloadable
-                if downloadable_variant.get("file_downloadable", False):
-                    if isinstance(param_value, dict) and "s3url" in param_value:
-                        request[_param] = str(
-                            FileDownloadable(**param_value).download(
-                                self._outdir / tool.toolkit.slug / tool.slug
-                            )
-                        )
-                    continue
-
-                # If the variant has nested properties with file_downloadable
-                if (
-                    isinstance(param_value, dict)
-                    and downloadable_variant.get("type") == "object"
-                ):
-                    request[_param] = self._substitute_file_downloads_recursively(
-                        schema=downloadable_variant,
-                        request=param_value,
-                        tool=tool,
-                    )
-                    continue
-
-            # Handle nested objects
-            if isinstance(param_value, dict) and param_schema.get("type") == "object":
-                request[_param] = self._substitute_file_downloads_recursively(
-                    schema=param_schema,
-                    request=param_value,
-                    tool=tool,
-                )
-                continue
-
-            # Handle arrays with file_downloadable items
-            if (
-                isinstance(param_value, list)
-                and param_schema.get("type") == "array"
-                and "items" in param_schema
-            ):
-                items_schema = param_schema["items"]
-                if isinstance(items_schema, dict):
-                    processed_items: t.List[t.Any] = []
-                    for item in param_value:
-                        if item is None:
-                            processed_items.append(item)
-                            continue
-
-                        if self._has_file_property(items_schema, "file_downloadable"):
-                            if items_schema.get("file_downloadable", False):
-                                if isinstance(item, dict) and "s3url" in item:
-                                    processed_items.append(
-                                        str(
-                                            FileDownloadable(**item).download(
-                                                self._outdir
-                                                / tool.toolkit.slug
-                                                / tool.slug
-                                            )
-                                        )
-                                    )
-                                else:
-                                    processed_items.append(item)
-                            elif isinstance(item, dict):
-                                # Check for anyOf/oneOf/allOf in items schema
-                                item_variant = self._find_downloadable_schema_variant(
-                                    items_schema
-                                )
-                                if item_variant is not None:
-                                    processed_items.append(
-                                        self._substitute_file_downloads_recursively(
-                                            schema=item_variant,
-                                            request=item,
-                                            tool=tool,
-                                        )
-                                    )
-                                else:
-                                    processed_items.append(
-                                        self._substitute_file_downloads_recursively(
-                                            schema=items_schema,
-                                            request=item,
-                                            tool=tool,
-                                        )
-                                    )
-                            else:
-                                processed_items.append(item)
-                        else:
-                            processed_items.append(item)
-                    request[_param] = processed_items
-
-        return request
+        if isinstance(processed, dict):
+            request.clear()
+            request.update(processed)
+            return request
+        return t.cast(t.Dict, processed)
 
     def substitute_file_downloads(
         self,

--- a/python/composio/core/models/_files.py
+++ b/python/composio/core/models/_files.py
@@ -58,7 +58,12 @@ Connect timeout is short to fail fast on unreachable hosts.
 Read timeout is longer to allow for slower file transfers.
 """
 
-_DELETE_VALUE = object()
+_DELETE_VALUE: t.Final = object()
+"""
+Sentinel returned by the upload walker to signal that a value should be dropped
+from its parent container. ``None`` and ``""`` are both legal payload values, so
+the walker cannot use either to mean "remove this key/item".
+"""
 
 LOCAL_CACHE_DIRECTORY_NAME = ".composio"
 """
@@ -964,7 +969,11 @@ class FileHelper(WithLogger):
             request.clear()
             request.update(processed)
             return request
-        return t.cast(t.Dict, processed)
+        assert isinstance(processed, dict), (
+            "expected dict from _substitute_file_upload_value at the root; "
+            f"got {type(processed).__name__}"
+        )
+        return processed
 
     def substitute_file_uploads(
         self,
@@ -973,6 +982,14 @@ class FileHelper(WithLogger):
         *,
         before_file_upload: t.Optional[BeforeFileUpload] = None,
     ) -> t.Dict:
+        """Stage file-uploadable leaves in ``request`` and return it.
+
+        Mutation contract: the top-level ``request`` dict is mutated in place
+        and its identity is preserved (the return value is the same object).
+        Nested dicts inside ``request`` may be replaced with fresh dicts
+        rather than mutated, so callers should not retain references to
+        nested values across this call.
+        """
         return self._substitute_file_uploads_recursively(
             tool=tool,
             schema=tool.input_parameters,
@@ -1070,13 +1087,25 @@ class FileHelper(WithLogger):
             request.clear()
             request.update(processed)
             return request
-        return t.cast(t.Dict, processed)
+        assert isinstance(processed, dict), (
+            "expected dict from _substitute_file_download_value at the root; "
+            f"got {type(processed).__name__}"
+        )
+        return processed
 
     def substitute_file_downloads(
         self,
         tool: Tool,
         response: ToolExecutionResponse,
     ) -> ToolExecutionResponse:
+        """Materialize file-downloadable leaves in ``response`` and return it.
+
+        Mutation contract: the top-level ``response`` dict is mutated in
+        place and its identity is preserved (the return value is the same
+        object). Nested dicts inside ``response`` may be replaced with
+        fresh dicts rather than mutated, so callers should not retain
+        references to nested values across this call.
+        """
         return t.cast(
             "ToolExecutionResponse",
             self._substitute_file_downloads_recursively(

--- a/python/tests/test_files.py
+++ b/python/tests/test_files.py
@@ -612,6 +612,137 @@ class TestFileUploadSubstitutionWithUnionTypes:
                 request={"content": {"attachment": "/path/to/file.pdf"}},
             )
 
+    @patch("composio.core.models._files.FileUploadable.from_path")
+    def test_substitute_upload_anyof_single_or_array_prefers_array_for_list_value(
+        self, mock_from_path, file_helper, mock_tool
+    ):
+        """List runtime values should use the array branch and upload each item."""
+        mock_tool.input_parameters = {
+            "type": "object",
+            "properties": {
+                "attachment": {
+                    "anyOf": [
+                        {"type": "string", "file_uploadable": True},
+                        {
+                            "type": "array",
+                            "items": {"type": "string", "file_uploadable": True},
+                        },
+                    ]
+                }
+            },
+        }
+
+        upload_1 = MagicMock()
+        upload_1.model_dump.return_value = {
+            "name": "a.txt",
+            "mimetype": "text/plain",
+            "s3key": "key-a",
+        }
+        upload_2 = MagicMock()
+        upload_2.model_dump.return_value = {
+            "name": "b.txt",
+            "mimetype": "text/plain",
+            "s3key": "key-b",
+        }
+        mock_from_path.side_effect = [upload_1, upload_2]
+
+        request = {"attachment": ["/tmp/a.txt", "/tmp/b.txt"]}
+        result = file_helper._substitute_file_uploads_recursively(
+            tool=mock_tool,
+            schema=mock_tool.input_parameters,
+            request=request,
+        )
+
+        assert result is request
+        assert result["attachment"] == [
+            {"name": "a.txt", "mimetype": "text/plain", "s3key": "key-a"},
+            {"name": "b.txt", "mimetype": "text/plain", "s3key": "key-b"},
+        ]
+        assert [call.kwargs["file"] for call in mock_from_path.call_args_list] == [
+            "/tmp/a.txt",
+            "/tmp/b.txt",
+        ]
+
+    @patch("composio.core.models._files.FileUploadable.from_path")
+    def test_substitute_upload_anyof_single_or_array_keeps_string_behavior(
+        self, mock_from_path, file_helper, mock_tool
+    ):
+        """String runtime values should still use the single-file branch."""
+        mock_tool.input_parameters = {
+            "type": "object",
+            "properties": {
+                "attachment": {
+                    "anyOf": [
+                        {"type": "string", "file_uploadable": True},
+                        {
+                            "type": "array",
+                            "items": {"type": "string", "file_uploadable": True},
+                        },
+                    ]
+                }
+            },
+        }
+
+        upload = MagicMock()
+        upload.model_dump.return_value = {
+            "name": "a.txt",
+            "mimetype": "text/plain",
+            "s3key": "key-a",
+        }
+        mock_from_path.return_value = upload
+
+        result = file_helper._substitute_file_uploads_recursively(
+            tool=mock_tool,
+            schema=mock_tool.input_parameters,
+            request={"attachment": "/tmp/a.txt"},
+        )
+
+        assert result["attachment"] == {
+            "name": "a.txt",
+            "mimetype": "text/plain",
+            "s3key": "key-a",
+        }
+        mock_from_path.assert_called_once()
+        assert mock_from_path.call_args.kwargs["file"] == "/tmp/a.txt"
+
+    @patch("composio.core.models._files.FileUploadable.from_path")
+    def test_substitute_upload_array_items_with_anyof_file_branch(
+        self, mock_from_path, file_helper, mock_tool
+    ):
+        """Array item schemas can contain file-uploadable union branches."""
+        mock_tool.input_parameters = {
+            "type": "object",
+            "properties": {
+                "attachments": {
+                    "type": "array",
+                    "items": {
+                        "anyOf": [
+                            {"type": "string", "file_uploadable": True},
+                            {"type": "null"},
+                        ]
+                    },
+                }
+            },
+        }
+
+        upload_1 = MagicMock()
+        upload_1.model_dump.return_value = {"s3key": "key-a"}
+        upload_2 = MagicMock()
+        upload_2.model_dump.return_value = {"s3key": "key-b"}
+        mock_from_path.side_effect = [upload_1, upload_2]
+
+        result = file_helper._substitute_file_uploads_recursively(
+            tool=mock_tool,
+            schema=mock_tool.input_parameters,
+            request={"attachments": ["/tmp/a.txt", None, "", "/tmp/b.txt"]},
+        )
+
+        assert result["attachments"] == [{"s3key": "key-a"}, {"s3key": "key-b"}]
+        assert [call.kwargs["file"] for call in mock_from_path.call_args_list] == [
+            "/tmp/a.txt",
+            "/tmp/b.txt",
+        ]
+
 
 class TestFileDownloadSubstitutionWithUnionTypes:
     """Test cases for file download substitution with anyOf, oneOf, and allOf schemas."""
@@ -792,6 +923,95 @@ class TestFileDownloadSubstitutionWithUnionTypes:
                 },
             )
 
+    @patch("composio.core.models._files.FileDownloadable.download")
+    def test_substitute_download_anyof_single_or_array_prefers_array_for_list_value(
+        self, mock_download, file_helper, mock_tool
+    ):
+        """List runtime values should use the array branch and download each item."""
+        mock_tool.output_parameters = {
+            "type": "object",
+            "properties": {
+                "attachment": {
+                    "anyOf": [
+                        {"type": "object", "file_downloadable": True},
+                        {
+                            "type": "array",
+                            "items": {"type": "object", "file_downloadable": True},
+                        },
+                    ]
+                }
+            },
+        }
+        mock_download.side_effect = ["/tmp/a.txt", "/tmp/b.txt"]
+
+        request = {
+            "attachment": [
+                {
+                    "s3url": "https://s3.example.com/a.txt",
+                    "mimetype": "text/plain",
+                    "name": "a.txt",
+                },
+                {
+                    "s3url": "https://s3.example.com/b.txt",
+                    "mimetype": "text/plain",
+                    "name": "b.txt",
+                },
+            ]
+        }
+        result = file_helper._substitute_file_downloads_recursively(
+            tool=mock_tool,
+            schema=mock_tool.output_parameters,
+            request=request,
+        )
+
+        assert result is request
+        assert result["attachment"] == ["/tmp/a.txt", "/tmp/b.txt"]
+        assert mock_download.call_count == 2
+
+    @patch("composio.core.models._files.FileDownloadable.download")
+    def test_substitute_download_array_items_with_anyof_file_branch(
+        self, mock_download, file_helper, mock_tool
+    ):
+        """Array item schemas can contain file-downloadable union branches."""
+        mock_tool.output_parameters = {
+            "type": "object",
+            "properties": {
+                "attachments": {
+                    "type": "array",
+                    "items": {
+                        "anyOf": [
+                            {"type": "object", "file_downloadable": True},
+                            {"type": "null"},
+                        ]
+                    },
+                }
+            },
+        }
+        mock_download.side_effect = ["/tmp/a.txt", "/tmp/b.txt"]
+
+        result = file_helper._substitute_file_downloads_recursively(
+            tool=mock_tool,
+            schema=mock_tool.output_parameters,
+            request={
+                "attachments": [
+                    {
+                        "s3url": "https://s3.example.com/a.txt",
+                        "mimetype": "text/plain",
+                        "name": "a.txt",
+                    },
+                    None,
+                    {
+                        "s3url": "https://s3.example.com/b.txt",
+                        "mimetype": "text/plain",
+                        "name": "b.txt",
+                    },
+                ]
+            },
+        )
+
+        assert result["attachments"] == ["/tmp/a.txt", None, "/tmp/b.txt"]
+        assert mock_download.call_count == 2
+
 
 class TestFileHelperFindVariantMethods:
     """Test cases for _find_uploadable_schema_variant and _find_downloadable_schema_variant."""
@@ -842,6 +1062,45 @@ class TestFileHelperFindVariantMethods:
         }
         result = file_helper._find_uploadable_schema_variant(schema)
         assert result is None
+
+    def test_find_uploadable_variant_prefers_runtime_value_shape(self, file_helper):
+        """Runtime values should select the matching file-bearing schema shape."""
+        schema = {
+            "anyOf": [
+                {"type": "string", "file_uploadable": True},
+                {
+                    "type": "array",
+                    "items": {"type": "string", "file_uploadable": True},
+                },
+            ]
+        }
+
+        result = file_helper._find_uploadable_schema_variant(
+            schema,
+            value=["/tmp/a.txt", "/tmp/b.txt"],
+        )
+
+        assert result is not None
+        assert result["type"] == "array"
+
+    def test_find_uploadable_variant_falls_back_to_first_file_bearing_variant(
+        self, file_helper
+    ):
+        """No runtime shape match should preserve historical first-match behavior."""
+        schema = {
+            "anyOf": [
+                {"type": "string", "file_uploadable": True},
+                {
+                    "type": "array",
+                    "items": {"type": "string", "file_uploadable": True},
+                },
+            ]
+        }
+
+        result = file_helper._find_uploadable_schema_variant(schema, value=123)
+
+        assert result is not None
+        assert result["type"] == "string"
 
     def test_find_downloadable_variant_in_anyof(self, file_helper):
         """Test finding downloadable variant in anyOf."""

--- a/python/tests/test_files.py
+++ b/python/tests/test_files.py
@@ -743,6 +743,30 @@ class TestFileUploadSubstitutionWithUnionTypes:
             "/tmp/b.txt",
         ]
 
+    @patch("composio.core.models._files.FileUploadable.from_path")
+    def test_substitute_upload_array_drops_all_null_and_empty_items(
+        self, mock_from_path, file_helper, mock_tool
+    ):
+        """Array of file-uploadable items collapses to [] when every item is null/empty."""
+        mock_tool.input_parameters = {
+            "type": "object",
+            "properties": {
+                "attachments": {
+                    "type": "array",
+                    "items": {"type": "string", "file_uploadable": True},
+                }
+            },
+        }
+
+        result = file_helper._substitute_file_uploads_recursively(
+            tool=mock_tool,
+            schema=mock_tool.input_parameters,
+            request={"attachments": [None, "", None]},
+        )
+
+        assert result["attachments"] == []
+        mock_from_path.assert_not_called()
+
 
 class TestFileDownloadSubstitutionWithUnionTypes:
     """Test cases for file download substitution with anyOf, oneOf, and allOf schemas."""


### PR DESCRIPTION
## Summary

This updates the Python SDK's automatic file upload/download substitution so it can handle tool schemas that accept either a single file or a list of files.

Tools can expose file inputs as a union such as:

```json
{
  "anyOf": [
    { "type": "object", "file_uploadable": true },
    { "type": "array", "items": { "type": "object", "file_uploadable": true } }
  ]
}
```

When auto-upload is enabled, the SDK presents those file-uploadable objects to models as file path strings. If the model supplies a list of local paths, the old resolver selected the first file-bearing union branch, usually the single-file branch, and attempted to upload the entire Python list as one path. That fails before the backend ever receives the intended list of staged file descriptors.

## Changes

- Refactors upload substitution into a value/schema recursive walker via `_substitute_file_upload_value`.
- Adds the same value/schema traversal shape for downloads via `_substitute_file_download_value`.
- Selects composed-schema variants by runtime shape when possible, so list values choose array branches and string/dict values keep the single-value behavior.
- Preserves the existing fallback behavior: if no runtime shape matches, use the first file-bearing variant.
- Treats `anyOf`, `oneOf`, and `allOf` consistently with the SDK's existing composed-schema convention.
- Preserves root request/response dict mutation behavior for existing call sites.
- Adds regression coverage for single-file vs multi-file unions, nested array-item unions, download parity, and first-match fallback.

## Why

This is needed for file-capable tool schemas that are backward compatible at the API level by accepting both a single file and multiple files. The Python SDK should transform a list of local paths into a list of staged `{name, mimetype, s3key}` descriptors, just as it already does for direct array schemas.

## Verification

- `python -m ruff check python/tests/test_files.py python/composio/core/models/_files.py`
- `python -m pytest python/tests/test_files.py -q` -> 119 passed
- `python -m pytest python/tests/test_files.py python/tests/test_auto_upload_download_files.py python/tests/test_upload_dir_allowlist.py python/tests/test_tool_router_session_files.py -q` -> 166 passed
- Manual playground verification with a Gmail send using two local attachments: both files were staged and sent successfully as an attachment array.

Note: a full local `python/tests` run still has three unrelated failures because `composio_langchain` is not installed in this environment; the affected file-upload suites pass.