### PR TITLE
fix(ts-sdk): handle file upload list unions

### DIFF
--- a/.changeset/file-uploadable-list-unions.md
+++ b/.changeset/file-uploadable-list-unions.md
@@ -1,0 +1,7 @@
+---
+'@composio/core': patch
+---
+
+Fix automatic file upload/download substitution for file schemas that accept either a single file or a list of files.
+
+The file modifier now selects composed-schema branches by runtime value shape, so `anyOf(file, array<file>)` uploads or downloads each file when the tool receives a list while preserving existing single-file behavior.

--- a/ts/packages/core/src/utils/modifiers/FileToolModifier.node.ts
+++ b/ts/packages/core/src/utils/modifiers/FileToolModifier.node.ts
@@ -193,9 +193,6 @@ const hydrateFiles = async (
   if (uploadableVariant) {
     return hydrateFiles(value, uploadableVariant, ctx);
   }
-  if (getSchemaVariants(schema).length > 0) {
-    // If no uploadable variants found, fall through to check base properties
-  }
 
   // ──────────────────────────────────────────────────────────────────────────
   // 3. Object → traverse each property

--- a/ts/packages/core/src/utils/modifiers/FileToolModifier.node.ts
+++ b/ts/packages/core/src/utils/modifiers/FileToolModifier.node.ts
@@ -22,9 +22,61 @@ import {
 import {
   isPlainObject,
   transformProperties,
-  schemaHasFileUploadable,
-  schemaHasFileDownloadable,
+  schemaHasFileProperty,
 } from './FileToolModifier.utils.neutral';
+
+const getSchemaVariants = (schema: JSONSchemaProperty | undefined): JSONSchemaProperty[] => [
+  ...(schema?.anyOf ?? []),
+  ...(schema?.oneOf ?? []),
+  ...(schema?.allOf ?? []),
+];
+
+const jsonSchemaTypeMatchesValue = (schema: JSONSchemaProperty, value: unknown): boolean => {
+  const schemaType = schema.type;
+
+  if (Array.isArray(schemaType)) {
+    return schemaType.some(type => jsonSchemaTypeMatchesValue({ ...schema, type }, value));
+  }
+
+  if (schemaType === undefined) {
+    if (schema.properties) return isPlainObject(value);
+    if (schema.items) return Array.isArray(value);
+    return false;
+  }
+
+  switch (schemaType) {
+    case 'array':
+      return Array.isArray(value);
+    case 'object':
+      return isPlainObject(value);
+    case 'string':
+      return typeof value === 'string';
+    case 'integer':
+      return Number.isInteger(value);
+    case 'number':
+      return typeof value === 'number';
+    case 'boolean':
+      return typeof value === 'boolean';
+    case 'null':
+      return value === null;
+    default:
+      return false;
+  }
+};
+
+const findSchemaVariantWithFileProperty = (
+  schema: JSONSchemaProperty | undefined,
+  property: 'file_uploadable' | 'file_downloadable',
+  value: unknown
+): JSONSchemaProperty | undefined => {
+  const candidates = getSchemaVariants(schema).filter(variant =>
+    schemaHasFileProperty(variant, property)
+  );
+
+  return (
+    candidates.find(candidate => jsonSchemaTypeMatchesValue(candidate, value)) ?? candidates[0]
+  );
+};
 
 /**
  * Recursively walks a runtime value and its matching JSON-Schema node,
@@ -128,26 +180,20 @@ const hydrateFiles = async (
   }
 
   // ──────────────────────────────────────────────────────────────────────────
-  // 2. Handle anyOf/oneOf/allOf — pick the first variant that contains a
-  // file_uploadable property and hydrate against it.
+  // 2. Handle anyOf/oneOf/allOf — pick the file-bearing variant whose
+  // JSON Schema shape matches the runtime value, then hydrate against it.
   //
   // We deliberately do NOT loop over every uploadable variant. With `oneOf`,
   // exactly one variant should apply at runtime, and applying multiple would
   // upload the same file once per variant — two presigned-URL round-trips and
-  // two S3 PUTs for a two-variant `oneOf`. Matching the Python SDK
-  // (`_find_uploadable_schema_variant`), we short-circuit on the first match.
+  // two S3 PUTs for a two-variant `oneOf`. If no runtime shape matches, fall
+  // back to the first file-bearing variant to preserve historical behavior.
   // ──────────────────────────────────────────────────────────────────────────
-  const schemaVariants = [
-    ...(schema?.anyOf ?? []),
-    ...(schema?.oneOf ?? []),
-    ...(schema?.allOf ?? []),
-  ];
-
-  if (schemaVariants.length > 0) {
-    const firstUploadableVariant = schemaVariants.find(schemaHasFileUploadable);
-    if (firstUploadableVariant) {
-      return hydrateFiles(value, firstUploadableVariant, ctx);
-    }
+  const uploadableVariant = findSchemaVariantWithFileProperty(schema, 'file_uploadable', value);
+  if (uploadableVariant) {
+    return hydrateFiles(value, uploadableVariant, ctx);
+  }
+  if (getSchemaVariants(schema).length > 0) {
     // If no uploadable variants found, fall through to check base properties
   }
 
@@ -257,28 +303,20 @@ const hydrateDownloads = async (
   // ──────────────────────────────────────────────────────────────────────────
   // 3. Handle anyOf/oneOf/allOf - try each variant that may contain file_downloadable
   // ──────────────────────────────────────────────────────────────────────────
-  const schemaVariants = [
-    ...(schema?.anyOf ?? []),
-    ...(schema?.oneOf ?? []),
-    ...(schema?.allOf ?? []),
-  ];
+  const schemaVariants = getSchemaVariants(schema);
 
   if (schemaVariants.length > 0) {
-    // Find variants that have file_downloadable properties
-    const downloadableVariants = schemaVariants.filter(schemaHasFileDownloadable);
-
-    // Process with each downloadable variant
-    let result = value;
-    for (const variant of downloadableVariants) {
-      result = await hydrateDownloads(result, variant, ctx);
+    const downloadableVariant = findSchemaVariantWithFileProperty(
+      schema,
+      'file_downloadable',
+      value
+    );
+    if (downloadableVariant) {
+      return hydrateDownloads(value, downloadableVariant, ctx);
     }
 
     // If no downloadable variants found, still traverse the value for s3url objects
-    if (downloadableVariants.length === 0) {
-      return hydrateDownloads(value, undefined, ctx);
-    }
-
-    return result;
+    return hydrateDownloads(value, undefined, ctx);
   }
 
   // ──────────────────────────────────────────────────────────────────────────

--- a/ts/packages/core/test/tools/fileModifiers.test.ts
+++ b/ts/packages/core/test/tools/fileModifiers.test.ts
@@ -790,6 +790,178 @@ describe('FileToolModifier', () => {
       expect(result.arguments?.fileInput).toEqual(mockFileData);
     });
 
+    it('should upload each file when anyOf accepts a single file or an array of files', async () => {
+      const mockFileData1 = {
+        name: 'file1.txt',
+        mimetype: 'text/plain',
+        s3key: 'uploads/file1.txt',
+      };
+      const mockFileData2 = {
+        name: 'file2.txt',
+        mimetype: 'text/plain',
+        s3key: 'uploads/file2.txt',
+      };
+      vi.mocked(fileUtils.getFileDataAfterUploadingToS3)
+        .mockResolvedValueOnce(mockFileData1)
+        .mockResolvedValueOnce(mockFileData2);
+
+      const toolWithSingleOrArrayFile: Tool = {
+        slug: 'test-tool',
+        name: 'Test Tool',
+        description: 'A test tool',
+        tags: ['test'],
+        inputParameters: {
+          type: 'object',
+          properties: {
+            attachment: {
+              anyOf: [
+                { type: 'string', file_uploadable: true },
+                {
+                  type: 'array',
+                  items: { type: 'string', file_uploadable: true },
+                },
+              ],
+            },
+          },
+        },
+        version: '20251201_01',
+        availableVersions: ['20251201_01'],
+      };
+
+      const result = await fileToolModifier.fileUploadModifier(toolWithSingleOrArrayFile, {
+        toolSlug: 'test-tool',
+        toolkitSlug: 'test-toolkit',
+        params: {
+          arguments: {
+            attachment: ['/path/to/file1.txt', '/path/to/file2.txt'],
+          },
+          userId: 'test-user',
+        },
+      });
+
+      expect(fileUtils.getFileDataAfterUploadingToS3).toHaveBeenCalledTimes(2);
+      expect(fileUtils.getFileDataAfterUploadingToS3).toHaveBeenNthCalledWith(
+        1,
+        '/path/to/file1.txt',
+        {
+          toolSlug: 'test-tool',
+          toolkitSlug: 'test-toolkit',
+          client: mockClient,
+        }
+      );
+      expect(fileUtils.getFileDataAfterUploadingToS3).toHaveBeenNthCalledWith(
+        2,
+        '/path/to/file2.txt',
+        {
+          toolSlug: 'test-tool',
+          toolkitSlug: 'test-toolkit',
+          client: mockClient,
+        }
+      );
+      expect(result.arguments?.attachment).toEqual([mockFileData1, mockFileData2]);
+    });
+
+    it('should keep single-file behavior when anyOf also accepts an array of files', async () => {
+      const mockFileData = {
+        name: 'file.txt',
+        mimetype: 'text/plain',
+        s3key: 'uploads/file.txt',
+      };
+      vi.mocked(fileUtils.getFileDataAfterUploadingToS3).mockResolvedValue(mockFileData);
+
+      const toolWithSingleOrArrayFile: Tool = {
+        slug: 'test-tool',
+        name: 'Test Tool',
+        description: 'A test tool',
+        tags: ['test'],
+        inputParameters: {
+          type: 'object',
+          properties: {
+            attachment: {
+              anyOf: [
+                { type: 'string', file_uploadable: true },
+                {
+                  type: 'array',
+                  items: { type: 'string', file_uploadable: true },
+                },
+              ],
+            },
+          },
+        },
+        version: '20251201_01',
+        availableVersions: ['20251201_01'],
+      };
+
+      const result = await fileToolModifier.fileUploadModifier(toolWithSingleOrArrayFile, {
+        toolSlug: 'test-tool',
+        toolkitSlug: 'test-toolkit',
+        params: {
+          arguments: {
+            attachment: '/path/to/file.txt',
+          },
+          userId: 'test-user',
+        },
+      });
+
+      expect(fileUtils.getFileDataAfterUploadingToS3).toHaveBeenCalledTimes(1);
+      expect(fileUtils.getFileDataAfterUploadingToS3).toHaveBeenCalledWith('/path/to/file.txt', {
+        toolSlug: 'test-tool',
+        toolkitSlug: 'test-toolkit',
+        client: mockClient,
+      });
+      expect(result.arguments?.attachment).toEqual(mockFileData);
+    });
+
+    it('should upload file array items whose item schema is an anyOf file branch', async () => {
+      const mockFileData1 = {
+        name: 'file1.txt',
+        mimetype: 'text/plain',
+        s3key: 'uploads/file1.txt',
+      };
+      const mockFileData2 = {
+        name: 'file2.txt',
+        mimetype: 'text/plain',
+        s3key: 'uploads/file2.txt',
+      };
+      vi.mocked(fileUtils.getFileDataAfterUploadingToS3)
+        .mockResolvedValueOnce(mockFileData1)
+        .mockResolvedValueOnce(mockFileData2);
+
+      const toolWithArrayItemAnyOf: Tool = {
+        slug: 'test-tool',
+        name: 'Test Tool',
+        description: 'A test tool',
+        tags: ['test'],
+        inputParameters: {
+          type: 'object',
+          properties: {
+            attachments: {
+              type: 'array',
+              items: {
+                anyOf: [{ type: 'string', file_uploadable: true }, { type: 'null' }],
+              },
+            },
+          },
+        },
+        version: '20251201_01',
+        availableVersions: ['20251201_01'],
+      };
+
+      const result = await fileToolModifier.fileUploadModifier(toolWithArrayItemAnyOf, {
+        toolSlug: 'test-tool',
+        toolkitSlug: 'test-toolkit',
+        params: {
+          arguments: {
+            attachments: ['/path/to/file1.txt', null, '/path/to/file2.txt'],
+          },
+          userId: 'test-user',
+        },
+      });
+
+      expect(fileUtils.getFileDataAfterUploadingToS3).toHaveBeenCalledTimes(2);
+      expect(result.arguments?.attachments).toEqual([mockFileData1, null, mockFileData2]);
+    });
+
     it('should not upload when value is null for anyOf with null variant', async () => {
       const toolWithAnyOf: Tool = {
         slug: 'test-tool',
@@ -1396,6 +1568,101 @@ describe('FileToolModifier', () => {
         s3url: 'https://s3.example.com/file1.txt',
         mimeType: 'text/plain',
       });
+    });
+
+    it('should download each file when anyOf accepts a single file or an array of files', async () => {
+      const mockDownloadResult1 = {
+        name: 'file1.txt',
+        mimeType: 'text/plain',
+        s3Url: 'downloads/file1.txt',
+        filePath: '/downloaded/file1.txt',
+      };
+      const mockDownloadResult2 = {
+        name: 'file2.txt',
+        mimeType: 'text/plain',
+        s3Url: 'downloads/file2.txt',
+        filePath: '/downloaded/file2.txt',
+      };
+      vi.mocked(fileUtils.downloadFileFromS3)
+        .mockResolvedValueOnce(mockDownloadResult1)
+        .mockResolvedValueOnce(mockDownloadResult2);
+
+      const toolWithSingleOrArrayFile: Tool = {
+        slug: 'test-tool',
+        name: 'Test Tool',
+        description: 'A test tool',
+        tags: ['test'],
+        outputParameters: {
+          type: 'object',
+          properties: {
+            attachment: {
+              anyOf: [
+                {
+                  type: 'object',
+                  file_downloadable: true,
+                  properties: {
+                    s3url: { type: 'string' },
+                    mimetype: { type: 'string' },
+                  },
+                },
+                {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    file_downloadable: true,
+                    properties: {
+                      s3url: { type: 'string' },
+                      mimetype: { type: 'string' },
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+        version: '20251201_01',
+        availableVersions: ['20251201_01'],
+      };
+
+      const modifiedResult = await fileToolModifier.fileDownloadModifier(
+        toolWithSingleOrArrayFile,
+        {
+          toolSlug: 'test-tool',
+          toolkitSlug: 'test-toolkit',
+          result: {
+            data: {
+              attachment: [
+                {
+                  s3url: 'https://s3.example.com/file1.txt',
+                  mimetype: 'text/plain',
+                },
+                {
+                  s3url: 'https://s3.example.com/file2.txt',
+                  mimetype: 'text/plain',
+                },
+              ],
+            },
+            error: null,
+            successful: true,
+          },
+        }
+      );
+
+      expect(fileUtils.downloadFileFromS3).toHaveBeenCalledTimes(2);
+      expect(modifiedResult.data.attachment).toEqual([
+        {
+          uri: '/downloaded/file1.txt',
+          file_downloaded: true,
+          s3url: 'https://s3.example.com/file1.txt',
+          mimeType: 'text/plain',
+        },
+        {
+          uri: '/downloaded/file2.txt',
+          file_downloaded: true,
+          s3url: 'https://s3.example.com/file2.txt',
+          mimeType: 'text/plain',
+        },
+      ]);
     });
 
     it('should not download when value is null for anyOf with null variant', async () => {


### PR DESCRIPTION
## Summary

This updates the TypeScript SDK's automatic file upload/download modifier to handle tool schemas that accept either a single file or a list of files.

Tools can expose file inputs as a composed schema such as:

```json
{
  "anyOf": [
    { "type": "object", "file_uploadable": true },
    { "type": "array", "items": { "type": "object", "file_uploadable": true } }
  ]
}
```

When auto-upload is enabled, the SDK presents those file-uploadable objects to models as file path strings. If the model supplies a list of local paths, the old upload resolver selected the first file-bearing branch, usually the single-file branch, and left the list unchanged. That means the backend could receive local paths instead of staged `{ name, mimetype, s3key }` descriptors.

## Changes

- Adds runtime-shape-aware composed-schema selection for file upload/download modifiers.
- Chooses the array branch for list values while preserving single-file behavior for string/File values.
- Preserves the existing fallback behavior: if no runtime shape matches, use the first file-bearing variant.
- Keeps `anyOf`, `oneOf`, and `allOf` on the same composed-schema path used by the SDK today.
- Adds regression coverage for single-file vs multi-file unions, array item unions, and download parity.
- Adds a patch changeset for `@composio/core`.

## Why

Some file-capable tool schemas are backward compatible at the API level by accepting both a single file and multiple files. The TypeScript SDK should transform a list of local paths into a list of staged file descriptors, just as it already does for direct array schemas.

## Verification

- `pnpm --filter @composio/core exec prettier --check src/utils/modifiers/FileToolModifier.node.ts test/tools/fileModifiers.test.ts`

Blocked locally:

- `pnpm --filter @composio/core test -- fileModifiers.test.ts` fails before collecting tests because this workspace cannot resolve the unbuilt `@composio/json-schema-to-zod` package entry.
- `pnpm --filter @composio/core typecheck:tsc` is also blocked by existing local generated-client/workspace dependency errors unrelated to this patch.