### PR TITLE
Polish ToolRouter preload docs structure

### DIFF
--- a/docs/content/changelog/05-07-26-toolrouter-preload-direct-tools.mdx
+++ b/docs/content/changelog/05-07-26-toolrouter-preload-direct-tools.mdx
@@ -4,12 +4,13 @@ description: "Sessions can now expose frequently used tools directly from sessio
 date: "2026-05-07"
 ---
 
-Sessions now support preloading known tools into `session.tools()` and the
-session MCP tool list. This works for Composio-managed tools, while SDK custom
-tools can be exposed directly from `session.tools()` with `preload: true`.
+Sessions now support preloading frequently used tools into `session.tools()` and
+the session MCP tool list, so agents can call them without searching each time.
+This works for Composio-managed tools, while SDK custom tools can be exposed
+directly from `session.tools()` with `preload: true`.
 
-Use preloading for small, stable tool sets. Keep the preloaded set focused,
-generally fewer than 20 tools, to avoid context bloat.
+Keep the preloaded set focused, generally fewer than 20 tools, to avoid context
+bloat.
 
 ### SDK versions
 

--- a/docs/content/docs/configuring-sessions.mdx
+++ b/docs/content/docs/configuring-sessions.mdx
@@ -176,7 +176,7 @@ Use the `preload.tools = "all"` shortcut (`preload={"tools": "all"}` in Python,
 session filters. The `all` shorthand works for both Composio tools and SDK
 custom tools.
 
-### Direct tools preset
+## Direct tools preset
 
 The direct tools preset preloads every tool allowed by session filters into the
 session's tool list and disables session meta tools by default. This can be


### PR DESCRIPTION
## Summary
- Promote the direct tools preset section to a top-level Configuring Sessions section.
- Tighten the changelog intro to explain preloading frequently used tools without searching each time.

## Validation
- bun run types:check
- git diff --check