### PR TITLE
docs: update chat-app cookbook and examples to use composio.use()

### DIFF
--- a/docs/content/cookbooks/chat-app.mdx
+++ b/docs/content/cookbooks/chat-app.mdx
@@ -54,7 +54,7 @@ A **session** scopes tools and credentials to a specific user. Create `app/api/c
 
 <include meta='title="app/api/chat/route.ts"'>../../examples/chat-app/route.ts</include>
 
-That's the entire backend. `composio.create("user_123")` creates a session that lets the agent search for tools, authenticate users, and execute actions. This ID scopes all connections and credentials to this user. In production, use the user ID from your auth system.
+That's the entire backend. On the first request, `composio.create("user_123")` creates a session that lets the agent search for tools, authenticate users, and execute actions. Subsequent requests reuse the same session via `composio.use(sessionId)` so the agent keeps its context across messages. In production, store the session ID per user in your database and use the user ID from your auth system.
 
 ## Build the chat UI
 

--- a/docs/content/cookbooks/chat-app.mdx
+++ b/docs/content/cookbooks/chat-app.mdx
@@ -54,7 +54,7 @@ A **session** scopes tools and credentials to a specific user. Create `app/api/c
 
 <include meta='title="app/api/chat/route.ts"'>../../examples/chat-app/route.ts</include>
 
-That's the entire backend. On the first request, `composio.create("user_123")` creates a session that lets the agent search for tools, authenticate users, and execute actions. Subsequent requests reuse the same session via `composio.use(sessionId)` so the agent keeps its context across messages. In production, store the session ID per user in your database and use the user ID from your auth system.
+That's the entire backend. On the first request, `composio.create("user_123")` creates a session that lets the agent search for tools, authenticate users, and execute actions. Subsequent requests reuse the same session via `composio.use(sessionId)` so tool access and connected accounts carry over. In production, store the session ID per user in your database and use the user ID from your auth system.
 
 ## Build the chat UI
 

--- a/docs/content/docs/users-and-sessions.mdx
+++ b/docs/content/docs/users-and-sessions.mdx
@@ -131,7 +131,38 @@ const tools = await session.tools();
 </Tab>
 </Tabs>
 
-This returns the same session with the same toolkits, auth configs, and connected accounts. The session's configuration is fixed at creation — to change toolkits or auth, create a new session.
+This returns the same session with the same toolkits, auth configs, and connected accounts.
+
+### Updating a session
+
+Use `session.update()` to modify a session's configuration without creating a new one. Only the fields you pass are changed — everything else is preserved.
+
+<Tabs groupId="language" items={['Python', 'TypeScript']} persist>
+<Tab value="Python">
+```python
+session.update(
+    toolkits=["gmail", "slack"],
+    auth_configs={"gmail": "ac_new_config"},
+    connected_accounts={"slack": ["ca_work_slack"]},
+)
+```
+</Tab>
+<Tab value="TypeScript">
+```typescript
+import { Composio } from '@composio/core';
+const composio = new Composio({ apiKey: 'your_api_key' });
+const session = await composio.create("user_123");
+// ---cut---
+await session.update({
+  toolkits: ["gmail", "slack"],
+  authConfigs: { gmail: "ac_new_config" },
+  connectedAccounts: { slack: ["ca_work_slack"] },
+});
+```
+</Tab>
+</Tabs>
+
+You can update toolkits, auth configs, connected accounts, workbench settings, multi-account config, manage connections, tags, tools, and preload. See [Configuring Sessions](/docs/configuring-sessions) for the full list of options.
 
 ### Connected accounts persist across sessions
 

--- a/docs/examples/chat-app/route.ts
+++ b/docs/examples/chat-app/route.ts
@@ -11,10 +11,18 @@ import {
 
 const composio = new Composio({ provider: new VercelProvider() });
 
+// In production, store session IDs per user in your database
+let sessionId: string | null = null;
+
 export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json();
 
-  const session = await composio.create("user_123");
+  // Reuse existing session or create a new one
+  const session = sessionId
+    ? await composio.use(sessionId)
+    : await composio.create("user_123");
+  sessionId = session.sessionId;
+
   const tools = await session.tools();
 
   const result = streamText({


### PR DESCRIPTION
## Summary

Follow-up to #3357 per Dhawal's review comments.

- **Chat-app cookbook**: Updated `route.ts` to create session once and reuse via `composio.use(sessionId)` across requests — the correct pattern for multi-turn chat apps
- Updated cookbook description to explain the create-once/reuse pattern

### What was checked but didn't need changes
- **Quickstart**: Single-turn examples, `.use()` doesn't apply
- **Provider docs** (OpenAI, Vercel, Anthropic, etc.): Already updated with multi-turn sections in #3357
- **Other cookbook examples** (gmail-labeler, pr-review-agent, etc.): Single-shot scripts, not multi-turn

## Test plan
- [ ] Verify docs build passes
- [ ] Check chat-app example renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)