### PR TITLE
feat(core): surface accountType + per-user ACL on SHARED connected accounts

### DIFF
--- a/.changeset/connected-accounts-acl.md
+++ b/.changeset/connected-accounts-acl.md
@@ -8,8 +8,9 @@ Surfaces three Apollo-side features that previously had no SDK wrappers:
 
 - **`accountType` on create**: `composio.connectedAccounts.link(userId, authConfigId, { accountType: 'SHARED' })` creates a SHARED connection. Default remains `PRIVATE`. SHARED is reachable from a tool-router session by other users in the project, but only when explicitly pinned and only when the requesting `userId` passes the connection's ACL.
 - **`accountType` on retrieve**: `get()` and `list()` responses now include `accountType` (`'PRIVATE' | 'SHARED'`).
-- **`updateAcl()` method** (new): `composio.connectedAccounts.updateAcl(nanoid, { allowAllUsers, allowedUserIds, notAllowedUserIds })` writes the per-user ACL on a SHARED connection via `PATCH /connected_accounts/{id}`. Backend rejects ACL writes on PRIVATE rows with `ComposioAclOnlyForSharedError` (400). PATCH semantics — omit a field to leave it unchanged; pass an empty array to clear an allow/deny list.
-- **ACL fields on retrieve**: `get()` and `list()` responses expose `allowAllUsers`, `allowedUserIds`, `notAllowedUserIds` when the caller is the connection's creator or is using a project/org API key. Other callers see the row without these fields (left as `undefined` in the SDK shape).
+- **`aclConfigForShared` on create + retrieve**: per-user ACL block — `{ allowAllUsers, allowedUserIds, notAllowedUserIds }`. On responses the whole block is `undefined` for non-creator/non-API-key callers (the backend strips it), so callers can distinguish *"I can't see the ACL"* from *"ACL is the default deny-by-default state"*.
+- **`updateAcl()` method** (new): `composio.connectedAccounts.updateAcl(nanoid, { allowAllUsers, allowedUserIds, notAllowedUserIds })` writes the ACL via `PATCH /connected_accounts/{id}` (the SDK serialises to the wire's `acl_config_for_shared` block). Backend rejects ACL writes on PRIVATE rows with `ComposioAclOnlyForSharedError` (400). PATCH semantics — omit a field to leave it unchanged; pass an empty array to clear an allow/deny list. At least one field required.
+- **`ToolRouterSession.authorize()` options gain `accountType` + `aclConfigForShared`**, so a SHARED connection with an ACL can be created in one call from inside a tool-router session.
 
 ACL resolution rule (deny wins):
 
@@ -18,12 +19,14 @@ ACL resolution rule (deny wins):
 3. requesting `userId` ∈ `allowedUserIds` → ALLOW
 4. otherwise → DENY (deny-by-default)
 
+Backend caps: each ACL list ≤1000 entries; each `userId` 1..256 chars. The SDK enforces these caps via Zod at the input boundary.
+
 New error classes:
 
 - `ComposioSharedAccessDeniedError` (403) — surfaces from direct `connectedAccountId` execution paths when the requesting user fails the ACL.
 - `ComposioAclOnlyForSharedError` (400) — sent ACL fields on a PRIVATE row.
 - `ComposioSharedConnectionNotAccessibleError` (400) — tool-router session create / PATCH with a pinned SHARED connection the session user cannot use.
 
-No breaking changes. Existing `link()` callers without `accountType` get a `PRIVATE` connection exactly as today; existing `get()` / `list()` callers see new optional fields.
+No breaking changes. Existing `link()` callers without the new options get a `PRIVATE` connection exactly as today; existing `get()` / `list()` callers see new optional fields.
 
 Python SDK gets the matching change in the same release train.

--- a/.changeset/connected-accounts-acl.md
+++ b/.changeset/connected-accounts-acl.md
@@ -29,4 +29,4 @@ New error classes:
 
 No breaking changes. Existing `link()` callers without the new options get a `PRIVATE` connection exactly as today; existing `get()` / `list()` callers see new optional fields.
 
-Python SDK gets the matching change in the same release train.
+The Python SDK mirror ships in a separate PR — same wire contract, same release train.

--- a/.changeset/connected-accounts-acl.md
+++ b/.changeset/connected-accounts-acl.md
@@ -2,14 +2,12 @@
 '@composio/core': minor
 ---
 
-Add `accountType` and per-user ACL support for SHARED connected accounts (Hermes #9860, #9882, #9902).
+Add `accountType` and per-user ACL support for SHARED connected accounts.
 
-Surfaces three Apollo-side features that previously had no SDK wrappers:
-
-- **`accountType` on create**: `composio.connectedAccounts.link(userId, authConfigId, { accountType: 'SHARED' })` creates a SHARED connection. Default remains `PRIVATE`. SHARED is reachable from a tool-router session by other users in the project, but only when explicitly pinned and only when the requesting `userId` passes the connection's ACL.
+- **`accountType` on create**: `composio.connectedAccounts.link(userId, authConfigId, { accountType: 'SHARED' })` creates a SHARED connection. Default remains `PRIVATE`. A SHARED connection can be used by other `userId`s, but only when the connection is explicitly pinned in a tool-router session's config and only when the requesting `userId` passes the connection's ACL.
 - **`accountType` on retrieve**: `get()` and `list()` responses now include `accountType` (`'PRIVATE' | 'SHARED'`).
-- **`aclConfigForShared` on create + retrieve**: per-user ACL block — `{ allowAllUsers, allowedUserIds, notAllowedUserIds }`. On responses the whole block is `undefined` for non-creator/non-API-key callers (the backend strips it), so callers can distinguish *"I can't see the ACL"* from *"ACL is the default deny-by-default state"*.
-- **`updateAcl()` method** (new): `composio.connectedAccounts.updateAcl(nanoid, { allowAllUsers, allowedUserIds, notAllowedUserIds })` writes the ACL via `PATCH /connected_accounts/{id}` (the SDK serialises to the wire's `acl_config_for_shared` block). Backend rejects ACL writes on PRIVATE rows with `ComposioAclOnlyForSharedError` (400). PATCH semantics — omit a field to leave it unchanged; pass an empty array to clear an allow/deny list. At least one field required.
+- **`aclConfigForShared` on create + retrieve**: per-user ACL block — `{ allowAllUsers, allowedUserIds, notAllowedUserIds }`. On responses the field is `undefined` when the caller isn't authorised to see the ACL, so callers can distinguish *"I can't see the ACL"* from *"ACL is the default deny-by-default state"*.
+- **`updateAcl()` method** (new): `composio.connectedAccounts.updateAcl(nanoid, { allowAllUsers, allowedUserIds, notAllowedUserIds })` writes the ACL via `PATCH`. PATCH semantics — omit a field to leave it unchanged; pass an empty array to clear an allow/deny list. At least one field required. Calling on a PRIVATE connection raises `ComposioAclOnlyForSharedError` (400).
 - **`ToolRouterSession.authorize()` options gain `accountType` + `aclConfigForShared`**, so a SHARED connection with an ACL can be created in one call from inside a tool-router session.
 
 ACL resolution rule (deny wins):
@@ -19,14 +17,14 @@ ACL resolution rule (deny wins):
 3. requesting `userId` ∈ `allowedUserIds` → ALLOW
 4. otherwise → DENY (deny-by-default)
 
-Backend caps: each ACL list ≤1000 entries; each `userId` 1..256 chars. The SDK enforces these caps via Zod at the input boundary.
+Limits: each ACL list accepts up to 1000 entries; each `userId` is 1..256 characters. The SDK enforces these caps at the input boundary.
 
 New error classes:
 
 - `ComposioSharedAccessDeniedError` (403) — surfaces from direct `connectedAccountId` execution paths when the requesting user fails the ACL.
-- `ComposioAclOnlyForSharedError` (400) — sent ACL fields on a PRIVATE row.
+- `ComposioAclOnlyForSharedError` (400) — ACL fields sent on a PRIVATE connection.
 - `ComposioSharedConnectionNotAccessibleError` (400) — tool-router session create / PATCH with a pinned SHARED connection the session user cannot use.
 
 No breaking changes. Existing `link()` callers without the new options get a `PRIVATE` connection exactly as today; existing `get()` / `list()` callers see new optional fields.
 
-The Python SDK mirror ships in a separate PR — same wire contract, same release train.
+The Python SDK mirror ships in a separate PR.

--- a/.changeset/connected-accounts-acl.md
+++ b/.changeset/connected-accounts-acl.md
@@ -1,0 +1,29 @@
+---
+'@composio/core': minor
+---
+
+Add `accountType` and per-user ACL support for SHARED connected accounts (Hermes #9860, #9882, #9902).
+
+Surfaces three Apollo-side features that previously had no SDK wrappers:
+
+- **`accountType` on create**: `composio.connectedAccounts.link(userId, authConfigId, { accountType: 'SHARED' })` creates a SHARED connection. Default remains `PRIVATE`. SHARED is reachable from a tool-router session by other users in the project, but only when explicitly pinned and only when the requesting `userId` passes the connection's ACL.
+- **`accountType` on retrieve**: `get()` and `list()` responses now include `accountType` (`'PRIVATE' | 'SHARED'`).
+- **`updateAcl()` method** (new): `composio.connectedAccounts.updateAcl(nanoid, { allowAllUsers, allowedUserIds, notAllowedUserIds })` writes the per-user ACL on a SHARED connection via `PATCH /connected_accounts/{id}`. Backend rejects ACL writes on PRIVATE rows with `ComposioAclOnlyForSharedError` (400). PATCH semantics — omit a field to leave it unchanged; pass an empty array to clear an allow/deny list.
+- **ACL fields on retrieve**: `get()` and `list()` responses expose `allowAllUsers`, `allowedUserIds`, `notAllowedUserIds` when the caller is the connection's creator or is using a project/org API key. Other callers see the row without these fields (left as `undefined` in the SDK shape).
+
+ACL resolution rule (deny wins):
+
+1. requesting `userId` ∈ `notAllowedUserIds` → DENY
+2. `allowAllUsers === true` → ALLOW
+3. requesting `userId` ∈ `allowedUserIds` → ALLOW
+4. otherwise → DENY (deny-by-default)
+
+New error classes:
+
+- `ComposioSharedAccessDeniedError` (403) — surfaces from direct `connectedAccountId` execution paths when the requesting user fails the ACL.
+- `ComposioAclOnlyForSharedError` (400) — sent ACL fields on a PRIVATE row.
+- `ComposioSharedConnectionNotAccessibleError` (400) — tool-router session create / PATCH with a pinned SHARED connection the session user cannot use.
+
+No breaking changes. Existing `link()` callers without `accountType` get a `PRIVATE` connection exactly as today; existing `get()` / `list()` callers see new optional fields.
+
+Python SDK gets the matching change in the same release train.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ catalogs:
       specifier: ^4.20250917.0
       version: 4.20260218.0
     '@composio/client':
-      specifier: 0.1.0-alpha.70
-      version: 0.1.0-alpha.70
+      specifier: 0.1.0-alpha.71
+      version: 0.1.0-alpha.71
     '@effect/cli':
       specifier: ^0.73.2
       version: 0.73.2
@@ -1079,7 +1079,7 @@ importers:
         version: link:../cli-local-tools
       '@composio/client':
         specifier: 'catalog:'
-        version: 0.1.0-alpha.70
+        version: 0.1.0-alpha.71
       '@composio/core':
         specifier: workspace:*
         version: link:../core
@@ -1249,7 +1249,7 @@ importers:
     dependencies:
       '@composio/client':
         specifier: 'catalog:'
-        version: 0.1.0-alpha.70
+        version: 0.1.0-alpha.71
       '@composio/json-schema-to-zod':
         specifier: workspace:*
         version: link:../json-schema-to-zod
@@ -1912,8 +1912,8 @@ packages:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
 
-  '@composio/client@0.1.0-alpha.70':
-    resolution: {integrity: sha512-bANvjHL9aYwvzcrDL9S2W/uTf6EV3slIpYRL3lAv3k74tTgB1TkYzAWgxxz1OpLK86iDB5xq3RFlritVu23Erg==}
+  '@composio/client@0.1.0-alpha.71':
+    resolution: {integrity: sha512-6h1IPMbXIx5PjaU0T+a1MNnKHL/pPP7+X2nNQaler5XoENANWGm4mYePjR+7Cgtw1j6X2QkCmRLuX5q9c0INvQ==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -7286,7 +7286,7 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@composio/client@0.1.0-alpha.70': {}
+  '@composio/client@0.1.0-alpha.71': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,7 +22,7 @@ catalog:
   '@clack/prompts': '^1.0.1'
   '@cloudflare/vitest-pool-workers': ^0.9.2
   '@cloudflare/workers-types': ^4.20250917.0
-  '@composio/client': 0.1.0-alpha.70
+  '@composio/client': 0.1.0-alpha.71
   '@effect/cli': ^0.73.2
   '@effect/eslint-plugin': ^0.3.2
   '@effect/language-service': ^0.74.0

--- a/ts/packages/cli/test/__utils__/services/test-layer.ts
+++ b/ts/packages/cli/test/__utils__/services/test-layer.ts
@@ -1160,6 +1160,7 @@ export const TestLayer = (input?: TestLiveInput) =>
               connected_account_id: 'con_test_link',
               link_token: 'lt_test_token',
               redirect_url: 'https://app.composio.dev/link?token=lt_test_token',
+              account_type: 'PRIVATE' as const,
             })),
           proxyExecute:
             toolRouterOverrides?.proxyExecute ??

--- a/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.link.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.link.cmd.test.ts
@@ -96,6 +96,7 @@ describe('CLI: composio dev connected-accounts link', () => {
     connected_account_id: 'con_test_link',
     link_token: 'lt_test_token',
     redirect_url: 'https://app.composio.dev/link?token=lt_test_token',
+    account_type: 'PRIVATE' as const,
   }));
 
   afterEach(() => {
@@ -288,6 +289,7 @@ describe('CLI: composio dev connected-accounts link', () => {
           connected_account_id: '',
           link_token: 'lt_test_token',
           redirect_url: '',
+          account_type: 'PRIVATE' as const,
         }),
       },
     })
@@ -374,6 +376,7 @@ describe('CLI: composio dev connected-accounts link', () => {
           connected_account_id: 'con_second_link',
           link_token: 'lt_test_token',
           redirect_url: 'https://app.composio.dev/link?token=lt_test_token',
+          account_type: 'PRIVATE' as const,
         }),
       },
       fixture: 'global-test-user-id',

--- a/ts/packages/core/src/errors/ConnectedAccountsErrors.ts
+++ b/ts/packages/core/src/errors/ConnectedAccountsErrors.ts
@@ -57,19 +57,6 @@ export class ComposioFailedToCreateConnectedAccountLink extends ComposioError {
 }
 
 /**
- * Thrown by `composio.connectedAccounts.initiate()` when the legacy
- * `POST /api/v3/connected_accounts` endpoint rejects a Composio-managed
- * OAuth (OAuth1, OAuth2, DCR_OAUTH) auth-config request.
- *
- * The retiring path is being phased out — new orgs from 2026-05-08 and
- * all remaining orgs from 2026-07-03. Migrate the call to
- * `composio.connectedAccounts.link()`, which works for every redirectable
- * scheme regardless of whether the auth config is Composio-managed or
- * custom.
- *
- * See: https://docs.composio.dev/docs/changelog/2026/04/24
- */
-/**
  * Thrown when a tool execution attempts to use a SHARED connected account
  * but the requesting `userId` is not allowed by the connection's ACL.
  *
@@ -146,6 +133,19 @@ export class ComposioSharedConnectionNotAccessibleError extends ComposioError {
   }
 }
 
+/**
+ * Thrown by `composio.connectedAccounts.initiate()` when the legacy
+ * `POST /api/v3/connected_accounts` endpoint rejects a Composio-managed
+ * OAuth (OAuth1, OAuth2, DCR_OAUTH) auth-config request.
+ *
+ * The retiring path is being phased out — new orgs from 2026-05-08 and
+ * all remaining orgs from 2026-07-03. Migrate the call to
+ * `composio.connectedAccounts.link()`, which works for every redirectable
+ * scheme regardless of whether the auth config is Composio-managed or
+ * custom.
+ *
+ * See: https://docs.composio.dev/docs/changelog/2026/04/24
+ */
 export class ComposioLegacyConnectedAccountsEndpointRetiredError extends ComposioError {
   constructor(
     message: string = 'POST /api/v3/connected_accounts is no longer supported for Composio-managed OAuth auth configs. Use composio.connectedAccounts.link() instead.',

--- a/ts/packages/core/src/errors/ConnectedAccountsErrors.ts
+++ b/ts/packages/core/src/errors/ConnectedAccountsErrors.ts
@@ -96,7 +96,7 @@ export class ComposioAclOnlyForSharedError extends ComposioError {
       code: ConnectedAccountErrorCodes.ACL_ONLY_FOR_SHARED,
       statusCode: 400,
       possibleFixes: options.possibleFixes || [
-        'Set accountType: "SHARED" at create time, or omit ACL fields when creating/updating a PRIVATE connection.',
+        'Use accountType: "SHARED", or omit ACL fields when creating/updating a PRIVATE connection.',
       ],
     });
     this.name = 'ComposioAclOnlyForSharedError';
@@ -104,9 +104,10 @@ export class ComposioAclOnlyForSharedError extends ComposioError {
 }
 
 /**
- * Thrown by tool-router session create / PATCH when the session's `userId`
- * cannot use a pinned SHARED connection — caught at session-create time
- * so the session never enters a state that fails mid-execution.
+ * Thrown by `toolRouter.session.create()` / `session.patch()` when the
+ * session's `userId` cannot use a pinned SHARED connection. Raised at
+ * session-create time so the session never enters a state that fails
+ * mid-execution.
  */
 export class ComposioSharedConnectionNotAccessibleError extends ComposioError {
   constructor(

--- a/ts/packages/core/src/errors/ConnectedAccountsErrors.ts
+++ b/ts/packages/core/src/errors/ConnectedAccountsErrors.ts
@@ -60,12 +60,9 @@ export class ComposioFailedToCreateConnectedAccountLink extends ComposioError {
  * Thrown when a tool execution attempts to use a SHARED connected account
  * but the requesting `userId` is not allowed by the connection's ACL.
  *
- * Surfaces from the matching layer when a SHARED connection is reached
- * directly (e.g. via `composio.tools.execute(slug, { connectedAccountId })`)
- * without going through a tool-router session that already pre-flighted the
- * ACL at session-create time.
- *
- * Backend response: 403 with code `ConnectedAccount_SharedAccessDenied`.
+ * Surfaces when a SHARED connection is reached directly (e.g. via
+ * `composio.tools.execute(slug, { connectedAccountId })`) without going
+ * through a tool-router session.
  */
 export class ComposioSharedAccessDeniedError extends ComposioError {
   constructor(
@@ -86,11 +83,8 @@ export class ComposioSharedAccessDeniedError extends ComposioError {
 
 /**
  * Thrown when ACL fields (`allowAllUsers`, `allowedUserIds`,
- * `notAllowedUserIds`) are sent on a `PRIVATE` connection — at create time
- * or via PATCH. ACL is only meaningful for `SHARED` connections; the
- * matching layer never reads it for PRIVATE.
- *
- * Backend response: 400 with code `ConnectedAccount_AclOnlyForShared`.
+ * `notAllowedUserIds`) are sent on a `PRIVATE` connection — at create
+ * time or via PATCH. ACL is only meaningful for `SHARED` connections.
  */
 export class ComposioAclOnlyForSharedError extends ComposioError {
   constructor(
@@ -111,10 +105,8 @@ export class ComposioAclOnlyForSharedError extends ComposioError {
 
 /**
  * Thrown by tool-router session create / PATCH when the session's `userId`
- * cannot use a pinned SHARED connection — caught at session-create time so
- * the session never enters a state that 4xxs mid-execution.
- *
- * Backend response: 400 with code `ToolRouterV2_SharedConnectionNotAccessible`.
+ * cannot use a pinned SHARED connection — caught at session-create time
+ * so the session never enters a state that fails mid-execution.
  */
 export class ComposioSharedConnectionNotAccessibleError extends ComposioError {
   constructor(

--- a/ts/packages/core/src/errors/ConnectedAccountsErrors.ts
+++ b/ts/packages/core/src/errors/ConnectedAccountsErrors.ts
@@ -5,6 +5,9 @@ export const ConnectedAccountErrorCodes = {
   MULTIPLE_CONNECTED_ACCOUNTS: 'MULTIPLE_CONNECTED_ACCOUNTS',
   FAILED_TO_CREATE_CONNECTED_ACCOUNT_LINK: 'FAILED_TO_CREATE_CONNECTED_ACCOUNT_LINK',
   LEGACY_CONNECTED_ACCOUNTS_ENDPOINT_RETIRED: 'LEGACY_CONNECTED_ACCOUNTS_ENDPOINT_RETIRED',
+  SHARED_ACCESS_DENIED: 'SHARED_ACCESS_DENIED',
+  ACL_ONLY_FOR_SHARED: 'ACL_ONLY_FOR_SHARED',
+  SHARED_CONNECTION_NOT_ACCESSIBLE: 'SHARED_CONNECTION_NOT_ACCESSIBLE',
 } as const;
 
 export class ComposioConnectedAccountNotFoundError extends ComposioError {
@@ -66,6 +69,83 @@ export class ComposioFailedToCreateConnectedAccountLink extends ComposioError {
  *
  * See: https://docs.composio.dev/docs/changelog/2026/04/24
  */
+/**
+ * Thrown when a tool execution attempts to use a SHARED connected account
+ * but the requesting `userId` is not allowed by the connection's ACL.
+ *
+ * Surfaces from the matching layer when a SHARED connection is reached
+ * directly (e.g. via `composio.tools.execute(slug, { connectedAccountId })`)
+ * without going through a tool-router session that already pre-flighted the
+ * ACL at session-create time.
+ *
+ * Backend response: 403 with code `ConnectedAccount_SharedAccessDenied`.
+ */
+export class ComposioSharedAccessDeniedError extends ComposioError {
+  constructor(
+    message: string = 'Access denied: this SHARED connected account is not available to the requesting user',
+    options: Omit<ComposioErrorOptions, 'code' | 'statusCode'> = {}
+  ) {
+    super(message, {
+      ...options,
+      code: ConnectedAccountErrorCodes.SHARED_ACCESS_DENIED,
+      statusCode: 403,
+      possibleFixes: options.possibleFixes || [
+        "Ask the connection's creator to grant access via composio.connectedAccounts.updateAcl() — set allowAllUsers, add the userId to allowedUserIds, or remove it from notAllowedUserIds.",
+      ],
+    });
+    this.name = 'ComposioSharedAccessDeniedError';
+  }
+}
+
+/**
+ * Thrown when ACL fields (`allowAllUsers`, `allowedUserIds`,
+ * `notAllowedUserIds`) are sent on a `PRIVATE` connection — at create time
+ * or via PATCH. ACL is only meaningful for `SHARED` connections; the
+ * matching layer never reads it for PRIVATE.
+ *
+ * Backend response: 400 with code `ConnectedAccount_AclOnlyForShared`.
+ */
+export class ComposioAclOnlyForSharedError extends ComposioError {
+  constructor(
+    message: string = 'ACL fields are only valid on SHARED connected accounts',
+    options: Omit<ComposioErrorOptions, 'code' | 'statusCode'> = {}
+  ) {
+    super(message, {
+      ...options,
+      code: ConnectedAccountErrorCodes.ACL_ONLY_FOR_SHARED,
+      statusCode: 400,
+      possibleFixes: options.possibleFixes || [
+        'Set accountType: "SHARED" at create time, or omit ACL fields when creating/updating a PRIVATE connection.',
+      ],
+    });
+    this.name = 'ComposioAclOnlyForSharedError';
+  }
+}
+
+/**
+ * Thrown by tool-router session create / PATCH when the session's `userId`
+ * cannot use a pinned SHARED connection — caught at session-create time so
+ * the session never enters a state that 4xxs mid-execution.
+ *
+ * Backend response: 400 with code `ToolRouterV2_SharedConnectionNotAccessible`.
+ */
+export class ComposioSharedConnectionNotAccessibleError extends ComposioError {
+  constructor(
+    message: string = 'A SHARED connected account pinned in the session config is not accessible to the session user',
+    options: Omit<ComposioErrorOptions, 'code' | 'statusCode'> = {}
+  ) {
+    super(message, {
+      ...options,
+      code: ConnectedAccountErrorCodes.SHARED_CONNECTION_NOT_ACCESSIBLE,
+      statusCode: 400,
+      possibleFixes: options.possibleFixes || [
+        "Grant the session user access via composio.connectedAccounts.updateAcl() on the pinned connection, or pin a different connection the user can use.",
+      ],
+    });
+    this.name = 'ComposioSharedConnectionNotAccessibleError';
+  }
+}
+
 export class ComposioLegacyConnectedAccountsEndpointRetiredError extends ComposioError {
   constructor(
     message: string = 'POST /api/v3/connected_accounts is no longer supported for Composio-managed OAuth auth configs. Use composio.connectedAccounts.link() instead.',

--- a/ts/packages/core/src/models/ConnectedAccounts.ts
+++ b/ts/packages/core/src/models/ConnectedAccounts.ts
@@ -52,10 +52,17 @@ import { ConnectionData } from '../types/connectedAccountAuthStates.types';
 // warning on every initiate() call.
 let _legacyInitiateWarningEmitted = false;
 
-// Wire-level fields added by Hermes #9860 / #9882 (account_type) and #9902
-// (ACL). Once @composio/client is regenerated against a backend spec that
-// includes these, this local extension can be removed and we can rely on the
-// generated `LinkCreateParams` directly.
+// Wire-level fields added by Hermes #9860 / #9882 (account_type) and
+// merged #9902 (ACL). 9902 nests ACL under a single `acl_config_for_shared`
+// object (single JSONB column under the hood). Once @composio/client is
+// regenerated against the post-9902 backend spec, this local extension can
+// be removed and we can rely on the generated `LinkCreateParams` directly.
+type AclConfigWireShape = {
+  allow_all_users?: boolean;
+  allowed_user_ids?: string[];
+  not_allowed_user_ids?: string[];
+};
+
 type LinkCreateBodyWithAcl = ConnectedAccountCreateParamsRaw extends never
   ? never
   : Record<string, unknown> & {
@@ -64,20 +71,39 @@ type LinkCreateBodyWithAcl = ConnectedAccountCreateParamsRaw extends never
       alias?: string;
       callback_url?: string;
       account_type?: 'PRIVATE' | 'SHARED';
-      allow_all_users?: boolean;
-      allowed_user_ids?: string[];
-      not_allowed_user_ids?: string[];
+      acl_config_for_shared?: AclConfigWireShape;
     };
 
-// Wire-level body for PATCH /connected_accounts/{id} with ACL fields
-// (Hermes #9902). Mirrors the same forward-compat pattern as
-// `LinkCreateBodyWithAcl` above.
+// Wire-level body for PATCH /connected_accounts/{id} with ACL.
 type ConnectedAccountPatchBodyWithAcl = {
   alias?: string;
-  allow_all_users?: boolean;
-  allowed_user_ids?: string[];
-  not_allowed_user_ids?: string[];
+  acl_config_for_shared?: AclConfigWireShape;
 };
+
+/**
+ * Serialise the SDK's `aclConfigForShared` (camelCase, top-level optional)
+ * to the wire's `acl_config_for_shared` block. Returns `undefined` when the
+ * caller didn't pass anything (PATCH-style "don't touch ACL"); returns
+ * `{}` when the caller passed an explicit empty object (also "no fields to
+ * change", but encodes the explicit intent — the backend treats both the
+ * same way today).
+ */
+function serializeAclConfigForWire(
+  acl:
+    | {
+        allowAllUsers?: boolean;
+        allowedUserIds?: string[];
+        notAllowedUserIds?: string[];
+      }
+    | undefined
+): AclConfigWireShape | undefined {
+  if (acl === undefined) return undefined;
+  return {
+    ...(acl.allowAllUsers !== undefined && { allow_all_users: acl.allowAllUsers }),
+    ...(acl.allowedUserIds !== undefined && { allowed_user_ids: acl.allowedUserIds }),
+    ...(acl.notAllowedUserIds !== undefined && { not_allowed_user_ids: acl.notAllowedUserIds }),
+  };
+}
 
 /**
  * ConnectedAccounts class
@@ -396,17 +422,14 @@ export class ConnectedAccounts {
     }
 
     const opts = requestOptions.data;
+    const aclWire = serializeAclConfigForWire(opts.aclConfigForShared);
     const body: LinkCreateBodyWithAcl = {
       auth_config_id: authConfigId,
       user_id: userId,
       ...(opts.callbackUrl && { callback_url: opts.callbackUrl }),
       ...(opts.alias != null && { alias: opts.alias }),
       ...(opts.accountType !== undefined && { account_type: opts.accountType }),
-      ...(opts.allowAllUsers !== undefined && { allow_all_users: opts.allowAllUsers }),
-      ...(opts.allowedUserIds !== undefined && { allowed_user_ids: opts.allowedUserIds }),
-      ...(opts.notAllowedUserIds !== undefined && {
-        not_allowed_user_ids: opts.notAllowedUserIds,
-      }),
+      ...(aclWire !== undefined && { acl_config_for_shared: aclWire }),
     };
 
     try {
@@ -683,18 +706,10 @@ export class ConnectedAccounts {
     }
 
     const body: ConnectedAccountPatchBodyWithAcl = {
-      ...(parsedParams.data.allowAllUsers !== undefined && {
-        allow_all_users: parsedParams.data.allowAllUsers,
-      }),
-      ...(parsedParams.data.allowedUserIds !== undefined && {
-        allowed_user_ids: parsedParams.data.allowedUserIds,
-      }),
-      ...(parsedParams.data.notAllowedUserIds !== undefined && {
-        not_allowed_user_ids: parsedParams.data.notAllowedUserIds,
-      }),
+      acl_config_for_shared: serializeAclConfigForWire(parsedParams.data),
     };
 
-    // Cast retained until @composio/client adds ACL fields to
+    // Cast retained until @composio/client adds acl_config_for_shared to
     // ConnectedAccountPatchParams.
     await this.client.connectedAccounts.patch(
       nanoid,

--- a/ts/packages/core/src/models/ConnectedAccounts.ts
+++ b/ts/packages/core/src/models/ConnectedAccounts.ts
@@ -9,6 +9,8 @@ import ComposioClient, { BadRequestError } from '@composio/client';
 import {
   ConnectedAccountCreateResponse,
   ConnectedAccountDeleteResponse,
+  ConnectedAccountPatchParams,
+  ConnectedAccountPatchResponse,
   ConnectedAccountRefreshParams,
   ConnectedAccountRefreshResponse,
   ConnectedAccountUpdateStatusParams,
@@ -16,6 +18,7 @@ import {
   ConnectedAccountListParams as ConnectedAccountListParamsRaw,
   ConnectedAccountCreateParams as ConnectedAccountCreateParamsRaw,
 } from '@composio/client/resources/connected-accounts';
+import { LinkCreateParams } from '@composio/client/resources/link';
 import {
   CreateConnectedAccountOptions,
   ConnectedAccountRetrieveResponse,
@@ -41,6 +44,7 @@ import {
   transformConnectedAccountResponse,
 } from '../utils/transformers/connectedAccounts';
 import {
+  ComposioAclOnlyForSharedError,
   ComposioFailedToCreateConnectedAccountLink,
   ComposioLegacyConnectedAccountsEndpointRetiredError,
   ComposioMultipleConnectedAccountsError,
@@ -52,41 +56,13 @@ import { ConnectionData } from '../types/connectedAccountAuthStates.types';
 // warning on every initiate() call.
 let _legacyInitiateWarningEmitted = false;
 
-// Wire-level fields added by Hermes #9860 / #9882 (account_type) and
-// merged #9902 (ACL). 9902 nests ACL under a single `acl_config_for_shared`
-// object (single JSONB column under the hood). Once @composio/client is
-// regenerated against the post-9902 backend spec, this local extension can
-// be removed and we can rely on the generated `LinkCreateParams` directly.
-type AclConfigWireShape = {
-  allow_all_users?: boolean;
-  allowed_user_ids?: string[];
-  not_allowed_user_ids?: string[];
-};
-
-type LinkCreateBodyWithAcl = ConnectedAccountCreateParamsRaw extends never
-  ? never
-  : Record<string, unknown> & {
-      auth_config_id: string;
-      user_id: string;
-      alias?: string;
-      callback_url?: string;
-      account_type?: 'PRIVATE' | 'SHARED';
-      acl_config_for_shared?: AclConfigWireShape;
-    };
-
-// Wire-level body for PATCH /connected_accounts/{id} with ACL.
-type ConnectedAccountPatchBodyWithAcl = {
-  alias?: string;
-  acl_config_for_shared?: AclConfigWireShape;
-};
-
 /**
  * Serialise the SDK's `aclConfigForShared` (camelCase, top-level optional)
  * to the wire's `acl_config_for_shared` block. Returns `undefined` when the
  * caller didn't pass anything (PATCH-style "don't touch ACL"); returns
- * `{}` when the caller passed an explicit empty object (also "no fields to
- * change", but encodes the explicit intent — the backend treats both the
- * same way today).
+ * `{}` when the caller passed an explicit empty object (the backend treats
+ * both the same way today — deny-by-default — but the explicit form is
+ * preserved so the intent is visible in network traces).
  */
 function serializeAclConfigForWire(
   acl:
@@ -96,7 +72,7 @@ function serializeAclConfigForWire(
         notAllowedUserIds?: string[];
       }
     | undefined
-): AclConfigWireShape | undefined {
+): LinkCreateParams.ACLConfigForShared | undefined {
   if (acl === undefined) return undefined;
   return {
     ...(acl.allowAllUsers !== undefined && { allow_all_users: acl.allowAllUsers }),
@@ -423,21 +399,17 @@ export class ConnectedAccounts {
 
     const opts = requestOptions.data;
     const aclWire = serializeAclConfigForWire(opts.aclConfigForShared);
-    const body: LinkCreateBodyWithAcl = {
+    const body: LinkCreateParams = {
       auth_config_id: authConfigId,
       user_id: userId,
-      ...(opts.callbackUrl && { callback_url: opts.callbackUrl }),
-      ...(opts.alias != null && { alias: opts.alias }),
+      ...(opts.callbackUrl !== undefined && { callback_url: opts.callbackUrl }),
+      ...(opts.alias !== undefined && { alias: opts.alias }),
       ...(opts.accountType !== undefined && { account_type: opts.accountType }),
       ...(aclWire !== undefined && { acl_config_for_shared: aclWire }),
     };
 
     try {
-      // Cast retained until @composio/client adds account_type / ACL fields
-      // to LinkCreateParams.
-      const response = await this.client.link.create(body as unknown as Parameters<
-        typeof this.client.link.create
-      >[0]);
+      const response = await this.client.link.create(body);
 
       const connectionRequest = createConnectionRequest(
         this.client,
@@ -447,6 +419,16 @@ export class ConnectedAccounts {
       );
       return connectionRequest;
     } catch (error) {
+      // Backend rejects ACL fields on PRIVATE connections with a 400 +
+      // `ConnectedAccount_AclOnlyForShared`. Surface it as a typed error so
+      // callers can `instanceof` instead of grepping messages.
+      if (
+        error instanceof BadRequestError &&
+        typeof error.message === 'string' &&
+        error.message.includes('acl_config_for_shared is only valid on SHARED')
+      ) {
+        throw new ComposioAclOnlyForSharedError(error.message, { cause: error });
+      }
       throw new ComposioFailedToCreateConnectedAccountLink(
         'Failed to create connected account link',
         {
@@ -634,7 +616,11 @@ export class ConnectedAccounts {
   }
 
   /**
-   * Update a connected account's alias and/or credentials.
+   * Enable or disable a connected account (wraps the `/status` endpoint
+   * — accepts only `{ enabled: boolean }` despite the historical JSDoc
+   * mentioning "alias and/or credentials"). For ACL writes on SHARED
+   * connections, see {@link updateAcl}. Alias / credential PATCH isn't
+   * surfaced on the SDK yet.
    *
    * @param {string} nanoid - The unique identifier of the connected account
    * @param {UpdateConnectedAccountParams} params - The update parameters
@@ -696,8 +682,24 @@ export class ConnectedAccounts {
    * // Revoke a previously-granted allow list (back to deny-by-default)
    * await composio.connectedAccounts.updateAcl('ca_abc', { allowedUserIds: [] });
    * ```
+   *
+   * **Empty-array semantics — read carefully.** Passing `[]` for either
+   * list **replaces** the list, it does not extend it:
+   *
+   * - `allowedUserIds: []` → revoke all previously-granted user IDs (state
+   *   reverts to deny-by-default unless `allowAllUsers` is true).
+   * - `notAllowedUserIds: []` → **clears the deny list**, which silently
+   *   re-grants access to users you previously blocked. Always pair an
+   *   empty deny list with a deliberate audit of the allow side.
+   *
+   * @returns The PATCH response (`{ id, status, success }`). To read the
+   * updated `aclConfigForShared` block, call `get(nanoid)` after the
+   * promise resolves.
    */
-  async updateAcl(nanoid: string, params: UpdateConnectedAccountAclParams): Promise<void> {
+  async updateAcl(
+    nanoid: string,
+    params: UpdateConnectedAccountAclParams
+  ): Promise<ConnectedAccountPatchResponse> {
     const parsedParams = UpdateConnectedAccountAclParamsSchema.safeParse(params);
     if (!parsedParams.success) {
       throw new ValidationError('Failed to parse connected account ACL update params', {
@@ -705,15 +707,23 @@ export class ConnectedAccounts {
       });
     }
 
-    const body: ConnectedAccountPatchBodyWithAcl = {
+    const body: ConnectedAccountPatchParams = {
       acl_config_for_shared: serializeAclConfigForWire(parsedParams.data),
     };
 
-    // Cast retained until @composio/client adds acl_config_for_shared to
-    // ConnectedAccountPatchParams.
-    await this.client.connectedAccounts.patch(
-      nanoid,
-      body as unknown as Parameters<typeof this.client.connectedAccounts.patch>[1]
-    );
+    try {
+      return await this.client.connectedAccounts.patch(nanoid, body);
+    } catch (error) {
+      // Same `AclOnlyForShared` 400 the create path can hit — backend
+      // rejects ACL writes on a PRIVATE row at PATCH-time too.
+      if (
+        error instanceof BadRequestError &&
+        typeof error.message === 'string' &&
+        error.message.includes('acl_config_for_shared is only valid on SHARED')
+      ) {
+        throw new ComposioAclOnlyForSharedError(error.message, { cause: error });
+      }
+      throw error;
+    }
   }
 }

--- a/ts/packages/core/src/models/ConnectedAccounts.ts
+++ b/ts/packages/core/src/models/ConnectedAccounts.ts
@@ -57,12 +57,12 @@ import { ConnectionData } from '../types/connectedAccountAuthStates.types';
 let _legacyInitiateWarningEmitted = false;
 
 /**
- * Serialise the SDK's `aclConfigForShared` (camelCase, top-level optional)
- * to the wire's `acl_config_for_shared` block. Returns `undefined` when the
- * caller didn't pass anything (PATCH-style "don't touch ACL"); returns
- * `{}` when the caller passed an explicit empty object (the backend treats
- * both the same way today — deny-by-default — but the explicit form is
- * preserved so the intent is visible in network traces).
+ * Serialise the SDK's `aclConfigForShared` (camelCase) to the wire's
+ * `acl_config_for_shared` block. Returns `undefined` when the caller
+ * didn't pass anything (PATCH-style "don't touch ACL"); returns `{}`
+ * when the caller passed an explicit empty object — both mean
+ * deny-by-default, but the explicit form preserves the caller's intent
+ * in network traces.
  */
 function serializeAclConfigForWire(
   acl:
@@ -419,9 +419,8 @@ export class ConnectedAccounts {
       );
       return connectionRequest;
     } catch (error) {
-      // Backend rejects ACL fields on PRIVATE connections with a 400 +
-      // `ConnectedAccount_AclOnlyForShared`. Surface it as a typed error so
-      // callers can `instanceof` instead of grepping messages.
+      // The server rejects ACL on PRIVATE connections — surface that as a
+      // typed error so callers can `instanceof` instead of grepping messages.
       if (
         error instanceof BadRequestError &&
         typeof error.message === 'string' &&
@@ -616,11 +615,9 @@ export class ConnectedAccounts {
   }
 
   /**
-   * Enable or disable a connected account (wraps the `/status` endpoint
-   * — accepts only `{ enabled: boolean }` despite the historical JSDoc
-   * mentioning "alias and/or credentials"). For ACL writes on SHARED
-   * connections, see {@link updateAcl}. Alias / credential PATCH isn't
-   * surfaced on the SDK yet.
+   * Enable or disable a connected account. Accepts `{ enabled: boolean }`.
+   *
+   * For ACL writes on SHARED connections, see {@link updateAcl}.
    *
    * @param {string} nanoid - The unique identifier of the connected account
    * @param {UpdateConnectedAccountParams} params - The update parameters
@@ -649,23 +646,23 @@ export class ConnectedAccounts {
   /**
    * Update the per-user ACL on a SHARED connected account.
    *
-   * Only meaningful for SHARED connections — the backend rejects ACL writes
-   * on PRIVATE rows with `ComposioAclOnlyForSharedError` (400). Auth gate is
-   * creator-or-API-key (a non-creator project member updating an alias on a
-   * SHARED row still works via {@link update}, but ACL writes do not).
+   * Only meaningful for SHARED connections — calling this on a PRIVATE
+   * connection raises `ComposioAclOnlyForSharedError` (400). ACL writes
+   * require the connection's creator or an API key; alias edits via
+   * {@link update} are governed separately.
    *
    * PATCH semantics: omit a field to leave it unchanged; pass an empty array
    * to clear an allow/deny list. At least one field must be provided.
    *
    * Resolution rule (deny wins):
-   *   1. requesting userId in `notAllowedUserIds` → DENY
-   *   2. `allowAllUsers === true`                 → ALLOW
-   *   3. requesting userId in `allowedUserIds`    → ALLOW
-   *   4. otherwise                                → DENY
+   *   1. requesting `userId` in `notAllowedUserIds` → DENY
+   *   2. `allowAllUsers === true`                   → ALLOW
+   *   3. requesting `userId` in `allowedUserIds`    → ALLOW
+   *   4. otherwise                                  → DENY
    *
    * @example
    * ```typescript
-   * // Open access to everyone in the project
+   * // Allow every userId to use this connection
    * await composio.connectedAccounts.updateAcl('ca_abc', { allowAllUsers: true });
    *
    * // Everyone except a specific user
@@ -714,8 +711,8 @@ export class ConnectedAccounts {
     try {
       return await this.client.connectedAccounts.patch(nanoid, body);
     } catch (error) {
-      // Same `AclOnlyForShared` 400 the create path can hit — backend
-      // rejects ACL writes on a PRIVATE row at PATCH-time too.
+      // Same ACL-on-PRIVATE rejection the create path can hit — surface
+      // it as a typed error.
       if (
         error instanceof BadRequestError &&
         typeof error.message === 'string' &&

--- a/ts/packages/core/src/models/ConnectedAccounts.ts
+++ b/ts/packages/core/src/models/ConnectedAccounts.ts
@@ -29,6 +29,8 @@ import {
   ConnectedAccountRefreshOptionsSchema,
   UpdateConnectedAccountParams,
   UpdateConnectedAccountParamsSchema,
+  UpdateConnectedAccountAclParams,
+  UpdateConnectedAccountAclParamsSchema,
 } from '../types/connectedAccounts.types';
 import { ConnectionRequest } from '../types/connectionRequest.types';
 import { createConnectionRequest } from './ConnectionRequest';
@@ -49,6 +51,33 @@ import { ConnectionData } from '../types/connectedAccountAuthStates.types';
 // One-time-per-process guard so long-running services don't spam the deprecation
 // warning on every initiate() call.
 let _legacyInitiateWarningEmitted = false;
+
+// Wire-level fields added by Hermes #9860 / #9882 (account_type) and #9902
+// (ACL). Once @composio/client is regenerated against a backend spec that
+// includes these, this local extension can be removed and we can rely on the
+// generated `LinkCreateParams` directly.
+type LinkCreateBodyWithAcl = ConnectedAccountCreateParamsRaw extends never
+  ? never
+  : Record<string, unknown> & {
+      auth_config_id: string;
+      user_id: string;
+      alias?: string;
+      callback_url?: string;
+      account_type?: 'PRIVATE' | 'SHARED';
+      allow_all_users?: boolean;
+      allowed_user_ids?: string[];
+      not_allowed_user_ids?: string[];
+    };
+
+// Wire-level body for PATCH /connected_accounts/{id} with ACL fields
+// (Hermes #9902). Mirrors the same forward-compat pattern as
+// `LinkCreateBodyWithAcl` above.
+type ConnectedAccountPatchBodyWithAcl = {
+  alias?: string;
+  allow_all_users?: boolean;
+  allowed_user_ids?: string[];
+  not_allowed_user_ids?: string[];
+};
 
 /**
  * ConnectedAccounts class
@@ -366,13 +395,26 @@ export class ConnectedAccounts {
       );
     }
 
+    const opts = requestOptions.data;
+    const body: LinkCreateBodyWithAcl = {
+      auth_config_id: authConfigId,
+      user_id: userId,
+      ...(opts.callbackUrl && { callback_url: opts.callbackUrl }),
+      ...(opts.alias != null && { alias: opts.alias }),
+      ...(opts.accountType !== undefined && { account_type: opts.accountType }),
+      ...(opts.allowAllUsers !== undefined && { allow_all_users: opts.allowAllUsers }),
+      ...(opts.allowedUserIds !== undefined && { allowed_user_ids: opts.allowedUserIds }),
+      ...(opts.notAllowedUserIds !== undefined && {
+        not_allowed_user_ids: opts.notAllowedUserIds,
+      }),
+    };
+
     try {
-      const response = await this.client.link.create({
-        auth_config_id: authConfigId,
-        user_id: userId,
-        ...(requestOptions?.data.callbackUrl && { callback_url: requestOptions.data.callbackUrl }),
-        ...(requestOptions?.data.alias != null && { alias: requestOptions.data.alias }),
-      });
+      // Cast retained until @composio/client adds account_type / ACL fields
+      // to LinkCreateParams.
+      const response = await this.client.link.create(body as unknown as Parameters<
+        typeof this.client.link.create
+      >[0]);
 
       const connectionRequest = createConnectionRequest(
         this.client,
@@ -593,5 +635,70 @@ export class ConnectedAccounts {
     }
 
     return this.client.connectedAccounts.updateStatus(nanoid, parsedParams.data);
+  }
+
+  /**
+   * Update the per-user ACL on a SHARED connected account.
+   *
+   * Only meaningful for SHARED connections — the backend rejects ACL writes
+   * on PRIVATE rows with `ComposioAclOnlyForSharedError` (400). Auth gate is
+   * creator-or-API-key (a non-creator project member updating an alias on a
+   * SHARED row still works via {@link update}, but ACL writes do not).
+   *
+   * PATCH semantics: omit a field to leave it unchanged; pass an empty array
+   * to clear an allow/deny list. At least one field must be provided.
+   *
+   * Resolution rule (deny wins):
+   *   1. requesting userId in `notAllowedUserIds` → DENY
+   *   2. `allowAllUsers === true`                 → ALLOW
+   *   3. requesting userId in `allowedUserIds`    → ALLOW
+   *   4. otherwise                                → DENY
+   *
+   * @example
+   * ```typescript
+   * // Open access to everyone in the project
+   * await composio.connectedAccounts.updateAcl('ca_abc', { allowAllUsers: true });
+   *
+   * // Everyone except a specific user
+   * await composio.connectedAccounts.updateAcl('ca_abc', {
+   *   allowAllUsers: true,
+   *   notAllowedUserIds: ['user_bob'],
+   * });
+   *
+   * // Targeted allow
+   * await composio.connectedAccounts.updateAcl('ca_abc', {
+   *   allowedUserIds: ['user_alice', 'user_bob'],
+   * });
+   *
+   * // Revoke a previously-granted allow list (back to deny-by-default)
+   * await composio.connectedAccounts.updateAcl('ca_abc', { allowedUserIds: [] });
+   * ```
+   */
+  async updateAcl(nanoid: string, params: UpdateConnectedAccountAclParams): Promise<void> {
+    const parsedParams = UpdateConnectedAccountAclParamsSchema.safeParse(params);
+    if (!parsedParams.success) {
+      throw new ValidationError('Failed to parse connected account ACL update params', {
+        cause: parsedParams.error,
+      });
+    }
+
+    const body: ConnectedAccountPatchBodyWithAcl = {
+      ...(parsedParams.data.allowAllUsers !== undefined && {
+        allow_all_users: parsedParams.data.allowAllUsers,
+      }),
+      ...(parsedParams.data.allowedUserIds !== undefined && {
+        allowed_user_ids: parsedParams.data.allowedUserIds,
+      }),
+      ...(parsedParams.data.notAllowedUserIds !== undefined && {
+        not_allowed_user_ids: parsedParams.data.notAllowedUserIds,
+      }),
+    };
+
+    // Cast retained until @composio/client adds ACL fields to
+    // ConnectedAccountPatchParams.
+    await this.client.connectedAccounts.patch(
+      nanoid,
+      body as unknown as Parameters<typeof this.client.connectedAccounts.patch>[1]
+    );
   }
 }

--- a/ts/packages/core/src/models/ToolRouterSession.ts
+++ b/ts/packages/core/src/models/ToolRouterSession.ts
@@ -1,5 +1,5 @@
 import { telemetry } from '../telemetry/Telemetry';
-import { Composio as ComposioClient } from '@composio/client';
+import { Composio as ComposioClient, BadRequestError } from '@composio/client';
 import { BaseComposioProvider } from '../provider/BaseProvider';
 import { ComposioConfig } from '../composio';
 import {
@@ -33,7 +33,7 @@ import {
 } from '../types/connectedAccounts.types';
 import { transform } from '../utils/transform';
 import { ToolkitConnectionStateSchema } from '../types/toolRouter.types';
-import { ValidationError } from '../errors';
+import { ComposioAclOnlyForSharedError, ValidationError } from '../errors';
 import { Tools } from './Tools';
 import { ToolRouterSessionFilesMount } from './ToolRouterSessionFileMount';
 import type {
@@ -47,6 +47,7 @@ import type { Tool, ToolExecuteResponse } from '../types/tool.types';
 import type { SessionProxyExecuteParams } from '../types/toolRouter.types';
 import type {
   SessionExecuteParams,
+  SessionLinkParams,
   SessionSearchParams,
 } from '@composio/client/resources/tool-router/session/session.mjs';
 import { SessionProxyExecuteParamsSchema } from '../types/toolRouter.types';
@@ -321,7 +322,7 @@ export class ToolRouterSession<
       aclConfigForShared?: ConnectedAccountAclConfig;
     }
   ): Promise<ConnectionRequest> {
-    const aclWire =
+    const aclWire: SessionLinkParams.ACLConfigForShared | undefined =
       options?.aclConfigForShared === undefined
         ? undefined
         : {
@@ -335,19 +336,30 @@ export class ToolRouterSession<
               not_allowed_user_ids: options.aclConfigForShared.notAllowedUserIds,
             }),
           };
-    // Cast retained until @composio/client adds account_type +
-    // acl_config_for_shared to SessionLinkParams (Hermes #9860 + #9902).
-    const body = {
+    const body: SessionLinkParams = {
       toolkit,
-      ...(options?.callbackUrl && { callback_url: options.callbackUrl }),
-      ...(options?.alias != null && { alias: options.alias }),
+      ...(options?.callbackUrl !== undefined && { callback_url: options.callbackUrl }),
+      ...(options?.alias !== undefined && { alias: options.alias }),
       ...(options?.accountType !== undefined && { account_type: options.accountType }),
       ...(aclWire !== undefined && { acl_config_for_shared: aclWire }),
     };
-    const response = await this.client.toolRouter.session.link(
-      this.sessionId,
-      body as unknown as Parameters<typeof this.client.toolRouter.session.link>[1]
-    );
+
+    let response;
+    try {
+      response = await this.client.toolRouter.session.link(this.sessionId, body);
+    } catch (error) {
+      // Backend rejects ACL fields on PRIVATE connections with a 400 +
+      // `ConnectedAccount_AclOnlyForShared`. Surface it as a typed error
+      // mirroring `composio.connectedAccounts.link()`.
+      if (
+        error instanceof BadRequestError &&
+        typeof error.message === 'string' &&
+        error.message.includes('acl_config_for_shared is only valid on SHARED')
+      ) {
+        throw new ComposioAclOnlyForSharedError(error.message, { cause: error });
+      }
+      throw error;
+    }
 
     return createConnectionRequest(
       this.client,

--- a/ts/packages/core/src/models/ToolRouterSession.ts
+++ b/ts/packages/core/src/models/ToolRouterSession.ts
@@ -26,7 +26,11 @@ import {
 import { SessionMetaToolOptions } from '../types/modifiers.types';
 import { ConnectionRequest } from '../types/connectionRequest.types';
 import { createConnectionRequest } from './ConnectionRequest';
-import { ConnectedAccountStatuses } from '../types/connectedAccounts.types';
+import {
+  ConnectedAccountStatuses,
+  ConnectedAccountType,
+  ConnectedAccountAclConfig,
+} from '../types/connectedAccounts.types';
 import { transform } from '../utils/transform';
 import { ToolkitConnectionStateSchema } from '../types/toolRouter.types';
 import { ValidationError } from '../errors';
@@ -303,16 +307,47 @@ export class ToolRouterSession<
   /**
    * Initiate an authorization flow for a toolkit.
    * Returns a ConnectionRequest with a redirect URL for the user.
+   *
+   * `accountType` and `aclConfigForShared` (Hermes #9860, #9902) let the
+   * caller create a SHARED connection with a per-user ACL in one flow.
+   * Default behaviour (omit both) creates a PRIVATE connection.
    */
   async authorize(
     toolkit: string,
-    options?: { callbackUrl?: string; alias?: string }
+    options?: {
+      callbackUrl?: string;
+      alias?: string;
+      accountType?: ConnectedAccountType;
+      aclConfigForShared?: ConnectedAccountAclConfig;
+    }
   ): Promise<ConnectionRequest> {
-    const response = await this.client.toolRouter.session.link(this.sessionId, {
+    const aclWire =
+      options?.aclConfigForShared === undefined
+        ? undefined
+        : {
+            ...(options.aclConfigForShared.allowAllUsers !== undefined && {
+              allow_all_users: options.aclConfigForShared.allowAllUsers,
+            }),
+            ...(options.aclConfigForShared.allowedUserIds !== undefined && {
+              allowed_user_ids: options.aclConfigForShared.allowedUserIds,
+            }),
+            ...(options.aclConfigForShared.notAllowedUserIds !== undefined && {
+              not_allowed_user_ids: options.aclConfigForShared.notAllowedUserIds,
+            }),
+          };
+    // Cast retained until @composio/client adds account_type +
+    // acl_config_for_shared to SessionLinkParams (Hermes #9860 + #9902).
+    const body = {
       toolkit,
       ...(options?.callbackUrl && { callback_url: options.callbackUrl }),
       ...(options?.alias != null && { alias: options.alias }),
-    });
+      ...(options?.accountType !== undefined && { account_type: options.accountType }),
+      ...(aclWire !== undefined && { acl_config_for_shared: aclWire }),
+    };
+    const response = await this.client.toolRouter.session.link(
+      this.sessionId,
+      body as unknown as Parameters<typeof this.client.toolRouter.session.link>[1]
+    );
 
     return createConnectionRequest(
       this.client,

--- a/ts/packages/core/src/models/ToolRouterSession.ts
+++ b/ts/packages/core/src/models/ToolRouterSession.ts
@@ -27,10 +27,13 @@ import { SessionMetaToolOptions } from '../types/modifiers.types';
 import { ConnectionRequest } from '../types/connectionRequest.types';
 import { createConnectionRequest } from './ConnectionRequest';
 import {
+  ConnectedAccountAclConfigSchema,
   ConnectedAccountStatuses,
   ConnectedAccountType,
+  ConnectedAccountTypeSchema,
   ConnectedAccountAclConfig,
 } from '../types/connectedAccounts.types';
+import { z } from 'zod/v3';
 import { transform } from '../utils/transform';
 import { ToolkitConnectionStateSchema } from '../types/toolRouter.types';
 import { ComposioAclOnlyForSharedError, ValidationError } from '../errors';
@@ -68,6 +71,21 @@ import { transformToolRouterUpdateParams } from '../lib/toolRouterParams';
 const COMPOSIO_MULTI_EXECUTE_TOOL = 'COMPOSIO_MULTI_EXECUTE_TOOL';
 export const DIRECT_CUSTOM_TOOL_DESCRIPTION_PREFIX =
   '[Direct tool - call directly, no search needed beforehand.]';
+
+/**
+ * Options accepted by {@link ToolRouterSession.authorize}.
+ *
+ * Validated at the SDK boundary so callers get clear `ValidationError`s for
+ * oversized ACL lists or invalid user IDs — same Zod caps as the equivalent
+ * `composio.connectedAccounts.link()` path (≤1000 entries per list, each
+ * user_id 1..256 chars). Caught Bugbot review.
+ */
+const AuthorizeOptionsSchema = z.object({
+  callbackUrl: z.string().optional(),
+  alias: z.string().optional(),
+  accountType: ConnectedAccountTypeSchema.optional(),
+  aclConfigForShared: ConnectedAccountAclConfigSchema.optional(),
+});
 
 export class ToolRouterSession<
   TToolCollection,
@@ -312,6 +330,12 @@ export class ToolRouterSession<
    * `accountType` and `aclConfigForShared` (Hermes #9860, #9902) let the
    * caller create a SHARED connection with a per-user ACL in one flow.
    * Default behaviour (omit both) creates a PRIVATE connection.
+   *
+   * `aclConfigForShared` is validated through `ConnectedAccountAclConfigSchema`
+   * — same Zod caps as `composio.connectedAccounts.link()` (≤1000 entries
+   * per list, each user_id 1..256 chars). Invalid input throws
+   * `ValidationError` at the SDK boundary instead of hitting an opaque
+   * backend 400.
    */
   async authorize(
     toolkit: string,
@@ -322,25 +346,32 @@ export class ToolRouterSession<
       aclConfigForShared?: ConnectedAccountAclConfig;
     }
   ): Promise<ConnectionRequest> {
+    const requestOptions = AuthorizeOptionsSchema.safeParse(options ?? {});
+    if (!requestOptions.success) {
+      throw new ValidationError('Failed to parse tool router authorize options', {
+        cause: requestOptions.error,
+      });
+    }
+    const opts = requestOptions.data;
     const aclWire: SessionLinkParams.ACLConfigForShared | undefined =
-      options?.aclConfigForShared === undefined
+      opts.aclConfigForShared === undefined
         ? undefined
         : {
-            ...(options.aclConfigForShared.allowAllUsers !== undefined && {
-              allow_all_users: options.aclConfigForShared.allowAllUsers,
+            ...(opts.aclConfigForShared.allowAllUsers !== undefined && {
+              allow_all_users: opts.aclConfigForShared.allowAllUsers,
             }),
-            ...(options.aclConfigForShared.allowedUserIds !== undefined && {
-              allowed_user_ids: options.aclConfigForShared.allowedUserIds,
+            ...(opts.aclConfigForShared.allowedUserIds !== undefined && {
+              allowed_user_ids: opts.aclConfigForShared.allowedUserIds,
             }),
-            ...(options.aclConfigForShared.notAllowedUserIds !== undefined && {
-              not_allowed_user_ids: options.aclConfigForShared.notAllowedUserIds,
+            ...(opts.aclConfigForShared.notAllowedUserIds !== undefined && {
+              not_allowed_user_ids: opts.aclConfigForShared.notAllowedUserIds,
             }),
           };
     const body: SessionLinkParams = {
       toolkit,
-      ...(options?.callbackUrl !== undefined && { callback_url: options.callbackUrl }),
-      ...(options?.alias !== undefined && { alias: options.alias }),
-      ...(options?.accountType !== undefined && { account_type: options.accountType }),
+      ...(opts.callbackUrl !== undefined && { callback_url: opts.callbackUrl }),
+      ...(opts.alias !== undefined && { alias: opts.alias }),
+      ...(opts.accountType !== undefined && { account_type: opts.accountType }),
       ...(aclWire !== undefined && { acl_config_for_shared: aclWire }),
     };
 

--- a/ts/packages/core/src/models/ToolRouterSession.ts
+++ b/ts/packages/core/src/models/ToolRouterSession.ts
@@ -76,9 +76,9 @@ export const DIRECT_CUSTOM_TOOL_DESCRIPTION_PREFIX =
  * Options accepted by {@link ToolRouterSession.authorize}.
  *
  * Validated at the SDK boundary so callers get clear `ValidationError`s for
- * oversized ACL lists or invalid user IDs — same Zod caps as the equivalent
+ * oversized ACL lists or invalid `userId`s — same caps as the equivalent
  * `composio.connectedAccounts.link()` path (≤1000 entries per list, each
- * user_id 1..256 chars). Caught Bugbot review.
+ * `userId` 1..256 characters).
  */
 const AuthorizeOptionsSchema = z.object({
   callbackUrl: z.string().optional(),
@@ -327,15 +327,14 @@ export class ToolRouterSession<
    * Initiate an authorization flow for a toolkit.
    * Returns a ConnectionRequest with a redirect URL for the user.
    *
-   * `accountType` and `aclConfigForShared` (Hermes #9860, #9902) let the
-   * caller create a SHARED connection with a per-user ACL in one flow.
-   * Default behaviour (omit both) creates a PRIVATE connection.
+   * Use `accountType` and `aclConfigForShared` to create a SHARED connection
+   * with a per-user ACL in one flow. Default behaviour (omit both) creates
+   * a PRIVATE connection.
    *
-   * `aclConfigForShared` is validated through `ConnectedAccountAclConfigSchema`
-   * — same Zod caps as `composio.connectedAccounts.link()` (≤1000 entries
-   * per list, each user_id 1..256 chars). Invalid input throws
-   * `ValidationError` at the SDK boundary instead of hitting an opaque
-   * backend 400.
+   * `aclConfigForShared` is validated against the same caps as
+   * `composio.connectedAccounts.link()` (≤1000 entries per list, each
+   * `userId` 1..256 characters). Invalid input throws `ValidationError`
+   * at the SDK boundary.
    */
   async authorize(
     toolkit: string,
@@ -379,9 +378,8 @@ export class ToolRouterSession<
     try {
       response = await this.client.toolRouter.session.link(this.sessionId, body);
     } catch (error) {
-      // Backend rejects ACL fields on PRIVATE connections with a 400 +
-      // `ConnectedAccount_AclOnlyForShared`. Surface it as a typed error
-      // mirroring `composio.connectedAccounts.link()`.
+      // The server rejects ACL on PRIVATE connections — surface that as a
+      // typed error mirroring `composio.connectedAccounts.link()`.
       if (
         error instanceof BadRequestError &&
         typeof error.message === 'string' &&

--- a/ts/packages/core/src/types/connectedAccounts.types.ts
+++ b/ts/packages/core/src/types/connectedAccounts.types.ts
@@ -34,8 +34,7 @@ export type ConnectedAccountStatusEnum = z.infer<typeof ConnectedAccountStatusSc
  * - `SHARED`: can be used by other `userId`s, but only when the connection
  *   is explicitly pinned in a tool-router session's config and only when
  *   the requesting `userId` passes the connection's ACL (see
- *   `allowAllUsers` / `allowedUserIds` / `notAllowedUserIds`). Set at
- *   creation time only — cannot be changed later.
+ *   `allowAllUsers` / `allowedUserIds` / `notAllowedUserIds`).
  */
 export const ConnectedAccountTypes = {
   PRIVATE: 'PRIVATE',
@@ -298,7 +297,7 @@ export const CreateConnectedAccountLinkOptionsSchema = z.object({
    * by the owning `userId`. `SHARED` can be used by other `userId`s — but
    * only when the connection is explicitly pinned in a tool-router session's
    * config and only when the requesting `userId` passes the connection's
-   * ACL. Set at creation time only.
+   * ACL.
    */
   accountType: ConnectedAccountTypeSchema.optional(),
   /**

--- a/ts/packages/core/src/types/connectedAccounts.types.ts
+++ b/ts/packages/core/src/types/connectedAccounts.types.ts
@@ -302,8 +302,8 @@ export const CreateConnectedAccountLinkOptionsSchema = z.object({
   accountType: ConnectedAccountTypeSchema.optional(),
   /**
    * Per-user ACL for SHARED connections. Only valid when
-   * `accountType === 'SHARED'` — the backend rejects ACL on a PRIVATE
-   * connection with `ComposioAclOnlyForSharedError` (400).
+   * `accountType === 'SHARED'`; raises `ComposioAclOnlyForSharedError`
+   * on a PRIVATE connection.
    *
    * Omit the block (or pass `{}`) to keep the deny-by-default state: only the
    * creator can use the connection. Grant access by setting
@@ -342,8 +342,8 @@ export const UpdateConnectedAccountParamsSchema = z.object({
  * outer nesting at the boundary, so callers pass the three fields flat.
  *
  * PATCH-style semantics — omit a field to leave it unchanged; pass an
- * empty array to clear an allow/deny list. Backend rejects ACL writes on
- * a PRIVATE connection with `ComposioAclOnlyForSharedError` (400).
+ * empty array to clear an allow/deny list. Raises
+ * `ComposioAclOnlyForSharedError` on a PRIVATE connection.
  *
  * Each field is optional, but at least one must be provided — passing an
  * empty object is rejected as a no-op.

--- a/ts/packages/core/src/types/connectedAccounts.types.ts
+++ b/ts/packages/core/src/types/connectedAccounts.types.ts
@@ -347,6 +347,10 @@ export const UpdateConnectedAccountParamsSchema = z.object({
  * Each field is optional, but at least one must be provided — passing an
  * empty object is rejected as a no-op.
  */
+// NOTE: `UpdateConnectedAccountAclParamsSchema` is a ZodEffects (because of
+// the `.refine` below) — it does not expose `.shape`. If you need to reuse
+// individual ACL fields elsewhere, pull them from
+// `ConnectedAccountAclConfigSchema.shape` (the unrefined base) instead.
 export const UpdateConnectedAccountAclParamsSchema = ConnectedAccountAclConfigSchema.refine(
   acl =>
     acl.allowAllUsers !== undefined ||

--- a/ts/packages/core/src/types/connectedAccounts.types.ts
+++ b/ts/packages/core/src/types/connectedAccounts.types.ts
@@ -51,35 +51,58 @@ export type ConnectedAccountType =
 /**
  * Per-user access control for a SHARED connected account. Inert for PRIVATE.
  *
+ * On the wire this lives under `acl_config_for_shared` — a single JSONB
+ * column on `connected_accounts`. The SDK exposes the inner shape as
+ * `aclConfigForShared` on inputs and responses (omit the block to mean
+ * "don't touch ACL" on create / PATCH; absence on a response means the
+ * caller isn't allowed to see the ACL).
+ *
  * Resolution rule (deny wins):
  *   1. requesting userId in `notAllowedUserIds` → DENY
  *   2. `allowAllUsers === true`                 → ALLOW
  *   3. requesting userId in `allowedUserIds`    → ALLOW
  *   4. otherwise                                → DENY  (deny-by-default)
  *
- * Default state (`allowAllUsers=false`, both arrays empty) means only the
- * connection's creator can use it. The creator must grant access explicitly.
+ * Default state (block omitted or `{}`) means only the connection's creator
+ * can use it. The creator must grant access explicitly.
  *
- * Lists are capped at 1000 entries each by the backend.
+ * Backend caps: each list ≤1000 entries; each user_id 1..256 chars.
  */
-const ACL_LIST_LIMIT = 1000;
-export const ConnectedAccountAclSchema = z.object({
+const ACL_LIST_MAX_LENGTH = 1000;
+const ACL_USER_ID_MAX_LENGTH = 256;
+const aclUserIdString = z.string().min(1).max(ACL_USER_ID_MAX_LENGTH);
+
+export const ConnectedAccountAclConfigSchema = z.object({
   allowAllUsers: z
     .boolean()
     .optional()
     .describe('Wildcard "any user_id in the project" allow toggle. Default false.'),
   allowedUserIds: z
-    .array(z.string())
-    .max(ACL_LIST_LIMIT)
+    .array(aclUserIdString)
+    .max(ACL_LIST_MAX_LENGTH)
     .optional()
     .describe('Explicit allow list (developer-assigned user_id strings). Default [].'),
   notAllowedUserIds: z
-    .array(z.string())
-    .max(ACL_LIST_LIMIT)
+    .array(aclUserIdString)
+    .max(ACL_LIST_MAX_LENGTH)
     .optional()
     .describe('Explicit deny list. Wins over allow on conflict. Default [].'),
 });
-export type ConnectedAccountAcl = z.infer<typeof ConnectedAccountAclSchema>;
+export type ConnectedAccountAclConfig = z.infer<typeof ConnectedAccountAclConfigSchema>;
+
+/**
+ * Resolved ACL as it appears on responses (creator / API-key callers).
+ * All three fields are populated when the block is visible; the block
+ * itself is absent for non-creator cookie callers.
+ */
+export const ConnectedAccountAclConfigResponseSchema = z.object({
+  allowAllUsers: z.boolean(),
+  allowedUserIds: z.array(z.string()),
+  notAllowedUserIds: z.array(z.string()),
+});
+export type ConnectedAccountAclConfigResponse = z.infer<
+  typeof ConnectedAccountAclConfigResponseSchema
+>;
 
 export const CreateConnectedAccountParamsSchema = z.object({
   authConfig: z.object({
@@ -163,9 +186,7 @@ export const ConnectedAccountRetrieveResponseSchema: z.ZodType<{
   createdAt: string;
   updatedAt: string;
   accountType?: ConnectedAccountType;
-  allowAllUsers?: boolean;
-  allowedUserIds?: string[];
-  notAllowedUserIds?: string[];
+  aclConfigForShared?: ConnectedAccountAclConfigResponse;
 }> = z.object({
   id: z.string(),
   authConfig: ConnectedAccountAuthConfigSchema,
@@ -190,12 +211,12 @@ export const ConnectedAccountRetrieveResponseSchema: z.ZodType<{
   createdAt: z.string(),
   updatedAt: z.string(),
   accountType: ConnectedAccountTypeSchema.optional(),
-  // ACL fields are only present on responses when the caller is the creator
-  // or is using a project/org API key — cookie callers who can use the
-  // connection but aren't its creator see the row without these fields.
-  allowAllUsers: z.boolean().optional(),
-  allowedUserIds: z.array(z.string()).optional(),
-  notAllowedUserIds: z.array(z.string()).optional(),
+  // `acl_config_for_shared` is only present on responses when the caller is
+  // the connection's creator or is using a project/org API key. Non-creator
+  // cookie callers see the row without this block — left as `undefined`
+  // here so callers can distinguish "I can't see the ACL" from "ACL is the
+  // default deny-by-default state".
+  aclConfigForShared: ConnectedAccountAclConfigResponseSchema.optional(),
 });
 
 export type ConnectedAccountRetrieveResponse = z.infer<
@@ -279,16 +300,16 @@ export const CreateConnectedAccountLinkOptionsSchema = z.object({
    */
   accountType: ConnectedAccountTypeSchema.optional(),
   /**
-   * ACL for SHARED connections. Ignored when `accountType !== 'SHARED'`; the
-   * backend rejects ACL fields on a `PRIVATE` connection with `AclOnlyForShared`.
+   * Per-user ACL for SHARED connections. Only valid when
+   * `accountType === 'SHARED'` — the backend rejects ACL on a PRIVATE
+   * connection with `ComposioAclOnlyForSharedError` (400).
    *
-   * Default (deny-by-default): only the creator can use the connection. Grant
-   * access by setting `allowAllUsers: true` or by listing user IDs in
-   * `allowedUserIds`. `notAllowedUserIds` always wins over allow.
+   * Omit the block (or pass `{}`) to keep the deny-by-default state: only the
+   * creator can use the connection. Grant access by setting
+   * `allowAllUsers: true` or listing user IDs in `allowedUserIds`.
+   * `notAllowedUserIds` always wins over allow.
    */
-  allowAllUsers: ConnectedAccountAclSchema.shape.allowAllUsers,
-  allowedUserIds: ConnectedAccountAclSchema.shape.allowedUserIds,
-  notAllowedUserIds: ConnectedAccountAclSchema.shape.notAllowedUserIds,
+  aclConfigForShared: ConnectedAccountAclConfigSchema.optional(),
 });
 export type CreateConnectedAccountLinkOptions = z.infer<
   typeof CreateConnectedAccountLinkOptionsSchema
@@ -315,16 +336,18 @@ export const UpdateConnectedAccountParamsSchema = z.object({
 });
 
 /**
- * Params for `composio.connectedAccounts.updateAcl()`.
+ * Params for `composio.connectedAccounts.updateAcl()`. Mirrors the inner
+ * shape of the wire's `acl_config_for_shared` block — the SDK adds the
+ * outer nesting at the boundary, so callers pass the three fields flat.
  *
- * PATCH-style semantics — omit a field to leave it unchanged; pass an empty
- * array to clear an allow/deny list. Backend rejects ACL writes on a
- * `PRIVATE` connection with `AclOnlyForShared` (400).
+ * PATCH-style semantics — omit a field to leave it unchanged; pass an
+ * empty array to clear an allow/deny list. Backend rejects ACL writes on
+ * a PRIVATE connection with `ComposioAclOnlyForSharedError` (400).
  *
  * Each field is optional, but at least one must be provided — passing an
  * empty object is rejected as a no-op.
  */
-export const UpdateConnectedAccountAclParamsSchema = ConnectedAccountAclSchema.refine(
+export const UpdateConnectedAccountAclParamsSchema = ConnectedAccountAclConfigSchema.refine(
   acl =>
     acl.allowAllUsers !== undefined ||
     acl.allowedUserIds !== undefined ||

--- a/ts/packages/core/src/types/connectedAccounts.types.ts
+++ b/ts/packages/core/src/types/connectedAccounts.types.ts
@@ -27,6 +27,60 @@ export type ConnectedAccountStatus =
   (typeof ConnectedAccountStatuses)[keyof typeof ConnectedAccountStatuses];
 export type ConnectedAccountStatusEnum = z.infer<typeof ConnectedAccountStatusSchema>;
 
+/**
+ * Sharing model for a connected account.
+ *
+ * - `PRIVATE` (default): only the owning `userId` can use the connection.
+ * - `SHARED`: reachable from a tool-router session by other users in the
+ *   project, but only when explicitly pinned in the session config and only
+ *   when the requesting `userId` passes the connection's ACL (see
+ *   `allowAllUsers` / `allowedUserIds` / `notAllowedUserIds`). Set at create
+ *   time only — cannot be changed later.
+ */
+export const ConnectedAccountTypes = {
+  PRIVATE: 'PRIVATE',
+  SHARED: 'SHARED',
+} as const;
+export const ConnectedAccountTypeSchema = z.enum([
+  ConnectedAccountTypes.PRIVATE,
+  ConnectedAccountTypes.SHARED,
+]);
+export type ConnectedAccountType =
+  (typeof ConnectedAccountTypes)[keyof typeof ConnectedAccountTypes];
+
+/**
+ * Per-user access control for a SHARED connected account. Inert for PRIVATE.
+ *
+ * Resolution rule (deny wins):
+ *   1. requesting userId in `notAllowedUserIds` → DENY
+ *   2. `allowAllUsers === true`                 → ALLOW
+ *   3. requesting userId in `allowedUserIds`    → ALLOW
+ *   4. otherwise                                → DENY  (deny-by-default)
+ *
+ * Default state (`allowAllUsers=false`, both arrays empty) means only the
+ * connection's creator can use it. The creator must grant access explicitly.
+ *
+ * Lists are capped at 1000 entries each by the backend.
+ */
+const ACL_LIST_LIMIT = 1000;
+export const ConnectedAccountAclSchema = z.object({
+  allowAllUsers: z
+    .boolean()
+    .optional()
+    .describe('Wildcard "any user_id in the project" allow toggle. Default false.'),
+  allowedUserIds: z
+    .array(z.string())
+    .max(ACL_LIST_LIMIT)
+    .optional()
+    .describe('Explicit allow list (developer-assigned user_id strings). Default [].'),
+  notAllowedUserIds: z
+    .array(z.string())
+    .max(ACL_LIST_LIMIT)
+    .optional()
+    .describe('Explicit deny list. Wins over allow on conflict. Default [].'),
+});
+export type ConnectedAccountAcl = z.infer<typeof ConnectedAccountAclSchema>;
+
 export const CreateConnectedAccountParamsSchema = z.object({
   authConfig: z.object({
     id: z.string(),
@@ -108,6 +162,10 @@ export const ConnectedAccountRetrieveResponseSchema: z.ZodType<{
   isDisabled: boolean;
   createdAt: string;
   updatedAt: string;
+  accountType?: ConnectedAccountType;
+  allowAllUsers?: boolean;
+  allowedUserIds?: string[];
+  notAllowedUserIds?: string[];
 }> = z.object({
   id: z.string(),
   authConfig: ConnectedAccountAuthConfigSchema,
@@ -131,6 +189,13 @@ export const ConnectedAccountRetrieveResponseSchema: z.ZodType<{
   isDisabled: z.boolean(),
   createdAt: z.string(),
   updatedAt: z.string(),
+  accountType: ConnectedAccountTypeSchema.optional(),
+  // ACL fields are only present on responses when the caller is the creator
+  // or is using a project/org API key — cookie callers who can use the
+  // connection but aren't its creator see the row without these fields.
+  allowAllUsers: z.boolean().optional(),
+  allowedUserIds: z.array(z.string()).optional(),
+  notAllowedUserIds: z.array(z.string()).optional(),
 });
 
 export type ConnectedAccountRetrieveResponse = z.infer<
@@ -205,6 +270,25 @@ export const CreateConnectedAccountLinkOptionsSchema = z.object({
    * `multiAccount` config to disambiguate at execution time.
    */
   allowMultiple: z.boolean().optional(),
+  /**
+   * Sharing model for the new connection. `PRIVATE` (default) is usable only by
+   * the owning `userId`. `SHARED` is reachable from a tool-router session by
+   * other users in the project — but only when explicitly pinned and only when
+   * the requesting `userId` passes the connection's ACL. Set at create time
+   * only.
+   */
+  accountType: ConnectedAccountTypeSchema.optional(),
+  /**
+   * ACL for SHARED connections. Ignored when `accountType !== 'SHARED'`; the
+   * backend rejects ACL fields on a `PRIVATE` connection with `AclOnlyForShared`.
+   *
+   * Default (deny-by-default): only the creator can use the connection. Grant
+   * access by setting `allowAllUsers: true` or by listing user IDs in
+   * `allowedUserIds`. `notAllowedUserIds` always wins over allow.
+   */
+  allowAllUsers: ConnectedAccountAclSchema.shape.allowAllUsers,
+  allowedUserIds: ConnectedAccountAclSchema.shape.allowedUserIds,
+  notAllowedUserIds: ConnectedAccountAclSchema.shape.notAllowedUserIds,
 });
 export type CreateConnectedAccountLinkOptions = z.infer<
   typeof CreateConnectedAccountLinkOptionsSchema
@@ -229,3 +313,25 @@ export type { ConnectedAccountUpdateStatusParams as UpdateConnectedAccountParams
 export const UpdateConnectedAccountParamsSchema = z.object({
   enabled: z.boolean(),
 });
+
+/**
+ * Params for `composio.connectedAccounts.updateAcl()`.
+ *
+ * PATCH-style semantics — omit a field to leave it unchanged; pass an empty
+ * array to clear an allow/deny list. Backend rejects ACL writes on a
+ * `PRIVATE` connection with `AclOnlyForShared` (400).
+ *
+ * Each field is optional, but at least one must be provided — passing an
+ * empty object is rejected as a no-op.
+ */
+export const UpdateConnectedAccountAclParamsSchema = ConnectedAccountAclSchema.refine(
+  acl =>
+    acl.allowAllUsers !== undefined ||
+    acl.allowedUserIds !== undefined ||
+    acl.notAllowedUserIds !== undefined,
+  {
+    message:
+      'At least one of allowAllUsers, allowedUserIds, or notAllowedUserIds must be provided',
+  }
+);
+export type UpdateConnectedAccountAclParams = z.infer<typeof UpdateConnectedAccountAclParamsSchema>;

--- a/ts/packages/core/src/types/connectedAccounts.types.ts
+++ b/ts/packages/core/src/types/connectedAccounts.types.ts
@@ -31,11 +31,11 @@ export type ConnectedAccountStatusEnum = z.infer<typeof ConnectedAccountStatusSc
  * Sharing model for a connected account.
  *
  * - `PRIVATE` (default): only the owning `userId` can use the connection.
- * - `SHARED`: reachable from a tool-router session by other users in the
- *   project, but only when explicitly pinned in the session config and only
- *   when the requesting `userId` passes the connection's ACL (see
- *   `allowAllUsers` / `allowedUserIds` / `notAllowedUserIds`). Set at create
- *   time only — cannot be changed later.
+ * - `SHARED`: can be used by other `userId`s, but only when the connection
+ *   is explicitly pinned in a tool-router session's config and only when
+ *   the requesting `userId` passes the connection's ACL (see
+ *   `allowAllUsers` / `allowedUserIds` / `notAllowedUserIds`). Set at
+ *   creation time only — cannot be changed later.
  */
 export const ConnectedAccountTypes = {
   PRIVATE: 'PRIVATE',
@@ -49,24 +49,26 @@ export type ConnectedAccountType =
   (typeof ConnectedAccountTypes)[keyof typeof ConnectedAccountTypes];
 
 /**
- * Per-user access control for a SHARED connected account. Inert for PRIVATE.
+ * Per-user access control for a SHARED connected account. Ignored for
+ * PRIVATE.
  *
- * On the wire this lives under `acl_config_for_shared` — a single JSONB
- * column on `connected_accounts`. The SDK exposes the inner shape as
- * `aclConfigForShared` on inputs and responses (omit the block to mean
- * "don't touch ACL" on create / PATCH; absence on a response means the
- * caller isn't allowed to see the ACL).
+ * Pass `aclConfigForShared` on create / PATCH to grant access; omit it
+ * to leave the ACL unchanged (on PATCH) or to keep the default
+ * deny-by-default state (on create). On responses, the field is
+ * `undefined` when the caller isn't authorised to see the ACL —
+ * distinguish that from an empty/default state explicitly.
  *
  * Resolution rule (deny wins):
- *   1. requesting userId in `notAllowedUserIds` → DENY
- *   2. `allowAllUsers === true`                 → ALLOW
- *   3. requesting userId in `allowedUserIds`    → ALLOW
- *   4. otherwise                                → DENY  (deny-by-default)
+ *   1. requesting `userId` in `notAllowedUserIds` → DENY
+ *   2. `allowAllUsers === true`                   → ALLOW
+ *   3. requesting `userId` in `allowedUserIds`    → ALLOW
+ *   4. otherwise                                  → DENY  (deny-by-default)
  *
- * Default state (block omitted or `{}`) means only the connection's creator
- * can use it. The creator must grant access explicitly.
+ * Default state (block omitted or `{}`) means only the connection's
+ * creator can use it. The creator must grant access explicitly.
  *
- * Backend caps: each list ≤1000 entries; each user_id 1..256 chars.
+ * Limits: each list accepts up to 1000 entries; each `userId` is
+ * 1..256 characters.
  */
 const ACL_LIST_MAX_LENGTH = 1000;
 const ACL_USER_ID_MAX_LENGTH = 256;
@@ -76,24 +78,24 @@ export const ConnectedAccountAclConfigSchema = z.object({
   allowAllUsers: z
     .boolean()
     .optional()
-    .describe('Wildcard "any user_id in the project" allow toggle. Default false.'),
+    .describe('When true, any `userId` may use this SHARED connection (subject to the deny list). Default false.'),
   allowedUserIds: z
     .array(aclUserIdString)
     .max(ACL_LIST_MAX_LENGTH)
     .optional()
-    .describe('Explicit allow list (developer-assigned user_id strings). Default [].'),
+    .describe('Explicit list of `userId` strings allowed to use this SHARED connection. Default [].'),
   notAllowedUserIds: z
     .array(aclUserIdString)
     .max(ACL_LIST_MAX_LENGTH)
     .optional()
-    .describe('Explicit deny list. Wins over allow on conflict. Default [].'),
+    .describe('Explicit list of `userId` strings denied access. Wins over allow on conflict. Default [].'),
 });
 export type ConnectedAccountAclConfig = z.infer<typeof ConnectedAccountAclConfigSchema>;
 
 /**
- * Resolved ACL as it appears on responses (creator / API-key callers).
- * All three fields are populated when the block is visible; the block
- * itself is absent for non-creator cookie callers.
+ * Resolved ACL as it appears on responses. All three fields are populated
+ * when the field is visible; the field itself is `undefined` for callers
+ * not authorised to see it.
  */
 export const ConnectedAccountAclConfigResponseSchema = z.object({
   allowAllUsers: z.boolean(),
@@ -211,11 +213,11 @@ export const ConnectedAccountRetrieveResponseSchema: z.ZodType<{
   createdAt: z.string(),
   updatedAt: z.string(),
   accountType: ConnectedAccountTypeSchema.optional(),
-  // `acl_config_for_shared` is only present on responses when the caller is
-  // the connection's creator or is using a project/org API key. Non-creator
-  // cookie callers see the row without this block — left as `undefined`
-  // here so callers can distinguish "I can't see the ACL" from "ACL is the
-  // default deny-by-default state".
+  // `aclConfigForShared` is only present on the response when the caller
+  // is authorised to see the ACL — otherwise the block is absent and the
+  // field is `undefined`. Callers can distinguish "I can't see the ACL"
+  // from "ACL is the default deny-by-default state" by checking for the
+  // presence of the field.
   aclConfigForShared: ConnectedAccountAclConfigResponseSchema.optional(),
 });
 
@@ -292,11 +294,11 @@ export const CreateConnectedAccountLinkOptionsSchema = z.object({
    */
   allowMultiple: z.boolean().optional(),
   /**
-   * Sharing model for the new connection. `PRIVATE` (default) is usable only by
-   * the owning `userId`. `SHARED` is reachable from a tool-router session by
-   * other users in the project — but only when explicitly pinned and only when
-   * the requesting `userId` passes the connection's ACL. Set at create time
-   * only.
+   * Sharing model for the new connection. `PRIVATE` (default) is usable only
+   * by the owning `userId`. `SHARED` can be used by other `userId`s — but
+   * only when the connection is explicitly pinned in a tool-router session's
+   * config and only when the requesting `userId` passes the connection's
+   * ACL. Set at creation time only.
    */
   accountType: ConnectedAccountTypeSchema.optional(),
   /**

--- a/ts/packages/core/src/utils/transformers/connectedAccounts.ts
+++ b/ts/packages/core/src/utils/transformers/connectedAccounts.ts
@@ -18,13 +18,15 @@ type RawConnectedAccountResponseWithLabels = (
 ) & {
   word_id?: string | null;
   alias?: string | null;
-  // account_type / ACL fields are added by Hermes #9860, #9882, #9902.
-  // Cast lives here until @composio/client regenerates against a backend
-  // spec that contains them.
+  // account_type / acl_config_for_shared are added by Hermes #9860, #9882,
+  // and the merged #9902. Cast lives here until @composio/client regenerates
+  // against a backend spec that contains them.
   account_type?: 'PRIVATE' | 'SHARED';
-  allow_all_users?: boolean;
-  allowed_user_ids?: string[];
-  not_allowed_user_ids?: string[];
+  acl_config_for_shared?: {
+    allow_all_users: boolean;
+    allowed_user_ids: string[];
+    not_allowed_user_ids: string[];
+  };
 };
 
 /**
@@ -78,13 +80,18 @@ export function transformConnectedAccountResponse(
       updatedAt: response.updated_at,
       testRequestEndpoint: response.test_request_endpoint,
       accountType: responseWithLabels.account_type,
-      // ACL fields are conditionally visible — backend strips them for
-      // non-creator/non-API-key callers. Forward `undefined` when absent
-      // rather than synthesising defaults, so callers can distinguish "I
-      // can't see the ACL" from "ACL is empty".
-      allowAllUsers: responseWithLabels.allow_all_users,
-      allowedUserIds: responseWithLabels.allowed_user_ids,
-      notAllowedUserIds: responseWithLabels.not_allowed_user_ids,
+      // `acl_config_for_shared` is conditionally visible — backend strips
+      // the whole block for non-creator/non-API-key callers. Forward
+      // `undefined` when absent rather than synthesising defaults, so
+      // callers can distinguish "I can't see the ACL" from "ACL is the
+      // default deny-by-default state".
+      aclConfigForShared: responseWithLabels.acl_config_for_shared
+        ? {
+            allowAllUsers: responseWithLabels.acl_config_for_shared.allow_all_users,
+            allowedUserIds: responseWithLabels.acl_config_for_shared.allowed_user_ids,
+            notAllowedUserIds: responseWithLabels.acl_config_for_shared.not_allowed_user_ids,
+          }
+        : undefined,
     }));
 }
 

--- a/ts/packages/core/src/utils/transformers/connectedAccounts.ts
+++ b/ts/packages/core/src/utils/transformers/connectedAccounts.ts
@@ -18,15 +18,6 @@ type RawConnectedAccountResponseWithLabels = (
 ) & {
   word_id?: string | null;
   alias?: string | null;
-  // account_type / acl_config_for_shared are added by Hermes #9860, #9882,
-  // and the merged #9902. Cast lives here until @composio/client regenerates
-  // against a backend spec that contains them.
-  account_type?: 'PRIVATE' | 'SHARED';
-  acl_config_for_shared?: {
-    allow_all_users: boolean;
-    allowed_user_ids: string[];
-    not_allowed_user_ids: string[];
-  };
 };
 
 /**
@@ -80,11 +71,11 @@ export function transformConnectedAccountResponse(
       updatedAt: response.updated_at,
       testRequestEndpoint: response.test_request_endpoint,
       accountType: responseWithLabels.account_type,
-      // `acl_config_for_shared` is conditionally visible — backend strips
-      // the whole block for non-creator/non-API-key callers. Forward
-      // `undefined` when absent rather than synthesising defaults, so
-      // callers can distinguish "I can't see the ACL" from "ACL is the
-      // default deny-by-default state".
+      // `acl_config_for_shared` is conditionally visible — the field is
+      // absent when the caller isn't authorised to see it. Forward
+      // `undefined` rather than synthesising defaults so callers can
+      // distinguish "I can't see the ACL" from "ACL is the default
+      // deny-by-default state".
       aclConfigForShared: responseWithLabels.acl_config_for_shared
         ? {
             allowAllUsers: responseWithLabels.acl_config_for_shared.allow_all_users,

--- a/ts/packages/core/src/utils/transformers/connectedAccounts.ts
+++ b/ts/packages/core/src/utils/transformers/connectedAccounts.ts
@@ -18,6 +18,13 @@ type RawConnectedAccountResponseWithLabels = (
 ) & {
   word_id?: string | null;
   alias?: string | null;
+  // account_type / ACL fields are added by Hermes #9860, #9882, #9902.
+  // Cast lives here until @composio/client regenerates against a backend
+  // spec that contains them.
+  account_type?: 'PRIVATE' | 'SHARED';
+  allow_all_users?: boolean;
+  allowed_user_ids?: string[];
+  not_allowed_user_ids?: string[];
 };
 
 /**
@@ -70,6 +77,14 @@ export function transformConnectedAccountResponse(
       createdAt: response.created_at,
       updatedAt: response.updated_at,
       testRequestEndpoint: response.test_request_endpoint,
+      accountType: responseWithLabels.account_type,
+      // ACL fields are conditionally visible — backend strips them for
+      // non-creator/non-API-key callers. Forward `undefined` when absent
+      // rather than synthesising defaults, so callers can distinguish "I
+      // can't see the ACL" from "ACL is empty".
+      allowAllUsers: responseWithLabels.allow_all_users,
+      allowedUserIds: responseWithLabels.allowed_user_ids,
+      notAllowedUserIds: responseWithLabels.not_allowed_user_ids,
     }));
 }
 

--- a/ts/packages/core/test/connectedAccounts/connectedAccounts.test.ts
+++ b/ts/packages/core/test/connectedAccounts/connectedAccounts.test.ts
@@ -4,9 +4,11 @@ import { ConnectedAccounts } from '../../src/models/ConnectedAccounts';
 import ComposioClient from '@composio/client';
 import { ConnectedAccountRetrieveResponse } from '@composio/client/resources/connected-accounts.mjs';
 import {
+  ComposioAclOnlyForSharedError,
   ComposioConnectedAccountNotFoundError,
   ComposioFailedToCreateConnectedAccountLink,
 } from '../../src/errors';
+import { BadRequestError } from '@composio/client';
 import { ConnectedAccountStatuses } from '../../src/types/connectedAccounts.types';
 import { ComposioMultipleConnectedAccountsError } from '../../src/errors';
 import { AuthSchemeTypes } from '../../src/types/authConfigs.types';
@@ -22,6 +24,7 @@ const extendedMockClient = {
     retrieve: vi.fn(),
     delete: vi.fn(),
     refresh: vi.fn(),
+    patch: vi.fn(),
     updateStatus: vi.fn(),
     createConnectedAccountLink: vi.fn(),
   },
@@ -1515,6 +1518,179 @@ describe('ConnectedAccounts', () => {
         alias: 'work-gmail',
       });
       expect(connectionRequest).toHaveProperty('id', 'conn_new');
+    });
+  });
+
+  describe('link with accountType + ACL (Hermes #9860, #9902)', () => {
+    beforeEach(() => {
+      extendedMockClient.connectedAccounts.list.mockResolvedValue({
+        items: [],
+        next_cursor: null,
+        total_pages: 0,
+      });
+      extendedMockClient.link.create.mockResolvedValue({
+        connected_account_id: 'conn_shared_abc',
+        redirect_url: 'https://connect.composio.dev/auth?token=xyz',
+      });
+    });
+
+    it('forwards accountType=SHARED + nested aclConfigForShared to client.link.create', async () => {
+      await connectedAccounts.link('user_123', 'auth_config_123', {
+        accountType: 'SHARED',
+        aclConfigForShared: {
+          allowAllUsers: true,
+          notAllowedUserIds: ['user_bob'],
+        },
+      });
+
+      expect(extendedMockClient.link.create).toHaveBeenCalledWith({
+        auth_config_id: 'auth_config_123',
+        user_id: 'user_123',
+        account_type: 'SHARED',
+        acl_config_for_shared: {
+          allow_all_users: true,
+          not_allowed_user_ids: ['user_bob'],
+        },
+      });
+    });
+
+    it('omits acl_config_for_shared when aclConfigForShared is undefined', async () => {
+      await connectedAccounts.link('user_123', 'auth_config_123', { accountType: 'SHARED' });
+
+      const body = extendedMockClient.link.create.mock.calls[0][0];
+      expect(body.account_type).toBe('SHARED');
+      expect('acl_config_for_shared' in body).toBe(false);
+    });
+
+    it('serializes only the fields the caller provided (PATCH-style on inner block)', async () => {
+      await connectedAccounts.link('user_123', 'auth_config_123', {
+        accountType: 'SHARED',
+        aclConfigForShared: { allowedUserIds: ['user_alice'] },
+      });
+
+      expect(extendedMockClient.link.create).toHaveBeenCalledWith({
+        auth_config_id: 'auth_config_123',
+        user_id: 'user_123',
+        account_type: 'SHARED',
+        acl_config_for_shared: { allowed_user_ids: ['user_alice'] },
+      });
+    });
+
+    it('preserves explicit empty arrays in the serialized body', async () => {
+      await connectedAccounts.link('user_123', 'auth_config_123', {
+        accountType: 'SHARED',
+        aclConfigForShared: { allowedUserIds: [], notAllowedUserIds: [] },
+      });
+
+      expect(extendedMockClient.link.create).toHaveBeenCalledWith({
+        auth_config_id: 'auth_config_123',
+        user_id: 'user_123',
+        account_type: 'SHARED',
+        acl_config_for_shared: {
+          allowed_user_ids: [],
+          not_allowed_user_ids: [],
+        },
+      });
+    });
+
+    it('maps 400 AclOnlyForShared to ComposioAclOnlyForSharedError', async () => {
+      extendedMockClient.link.create.mockReset();
+      extendedMockClient.link.create.mockRejectedValueOnce(
+        Object.assign(new BadRequestError(400, undefined, 'acl_config_for_shared is only valid on SHARED connections.', {}), {})
+      );
+
+      await expect(
+        connectedAccounts.link('user_123', 'auth_config_123', {
+          accountType: 'PRIVATE',
+          aclConfigForShared: { allowAllUsers: true },
+        })
+      ).rejects.toBeInstanceOf(ComposioAclOnlyForSharedError);
+    });
+
+    it('falls back to ComposioFailedToCreateConnectedAccountLink on unrelated errors', async () => {
+      extendedMockClient.link.create.mockReset();
+      extendedMockClient.link.create.mockRejectedValueOnce(new Error('network died'));
+
+      await expect(connectedAccounts.link('user_123', 'auth_config_123')).rejects.toBeInstanceOf(
+        ComposioFailedToCreateConnectedAccountLink
+      );
+    });
+  });
+
+  describe('updateAcl', () => {
+    it('serializes PATCH body with nested acl_config_for_shared', async () => {
+      extendedMockClient.connectedAccounts.patch.mockResolvedValueOnce({
+        id: 'ca_abc',
+        status: 'ACTIVE',
+        success: true,
+      });
+
+      const result = await connectedAccounts.updateAcl('ca_abc', {
+        allowAllUsers: true,
+        notAllowedUserIds: ['user_bob'],
+      });
+
+      expect(extendedMockClient.connectedAccounts.patch).toHaveBeenCalledWith('ca_abc', {
+        acl_config_for_shared: {
+          allow_all_users: true,
+          not_allowed_user_ids: ['user_bob'],
+        },
+      });
+      expect(result).toEqual({ id: 'ca_abc', status: 'ACTIVE', success: true });
+    });
+
+    it('omits absent fields from the inner block (PATCH semantics)', async () => {
+      extendedMockClient.connectedAccounts.patch.mockResolvedValueOnce({
+        id: 'ca_abc',
+        status: 'ACTIVE',
+        success: true,
+      });
+
+      await connectedAccounts.updateAcl('ca_abc', { allowedUserIds: ['user_alice'] });
+
+      expect(extendedMockClient.connectedAccounts.patch).toHaveBeenCalledWith('ca_abc', {
+        acl_config_for_shared: { allowed_user_ids: ['user_alice'] },
+      });
+    });
+
+    it('preserves empty array to clear a list', async () => {
+      extendedMockClient.connectedAccounts.patch.mockResolvedValueOnce({
+        id: 'ca_abc',
+        status: 'ACTIVE',
+        success: true,
+      });
+
+      await connectedAccounts.updateAcl('ca_abc', { allowedUserIds: [] });
+
+      expect(extendedMockClient.connectedAccounts.patch).toHaveBeenCalledWith('ca_abc', {
+        acl_config_for_shared: { allowed_user_ids: [] },
+      });
+    });
+
+    it('rejects an empty params object via the refine', async () => {
+      await expect(connectedAccounts.updateAcl('ca_abc', {})).rejects.toMatchObject({
+        name: 'ValidationError',
+      });
+      expect(extendedMockClient.connectedAccounts.patch).not.toHaveBeenCalled();
+    });
+
+    it('maps 400 AclOnlyForShared to ComposioAclOnlyForSharedError', async () => {
+      extendedMockClient.connectedAccounts.patch.mockRejectedValueOnce(
+        new BadRequestError(400, undefined, 'acl_config_for_shared is only valid on SHARED connections.', {})
+      );
+
+      await expect(
+        connectedAccounts.updateAcl('ca_abc', { allowAllUsers: true })
+      ).rejects.toBeInstanceOf(ComposioAclOnlyForSharedError);
+    });
+
+    it('rethrows non-AclOnlyForShared errors unchanged', async () => {
+      const otherError = new Error('connection lost');
+      extendedMockClient.connectedAccounts.patch.mockRejectedValueOnce(otherError);
+
+      await expect(
+        connectedAccounts.updateAcl('ca_abc', { allowAllUsers: true })
+      ).rejects.toBe(otherError);
     });
   });
 });

--- a/ts/packages/core/test/connectedAccounts/connectedAccounts.test.ts
+++ b/ts/packages/core/test/connectedAccounts/connectedAccounts.test.ts
@@ -1521,7 +1521,7 @@ describe('ConnectedAccounts', () => {
     });
   });
 
-  describe('link with accountType + ACL (Hermes #9860, #9902)', () => {
+  describe('link with accountType + ACL', () => {
     beforeEach(() => {
       extendedMockClient.connectedAccounts.list.mockResolvedValue({
         items: [],

--- a/ts/packages/core/test/models/toolRouter.test.ts
+++ b/ts/packages/core/test/models/toolRouter.test.ts
@@ -1849,9 +1849,8 @@ describe('ToolRouter', () => {
       expect(typeof connectionRequest.waitForConnection).toBe('function');
     });
 
-    // Bugbot-flagged gap: authorize() was passing aclConfigForShared straight
-    // to the wire while link() validated through Zod. These tests pin the
-    // parity — same 1000-entry list cap, same 256-char user_id cap.
+    // authorize() validates aclConfigForShared at the SDK boundary, same
+    // caps as link() — 1000-entry list, 256-char user_id.
     it('forwards accountType + nested acl_config_for_shared on the wire', async () => {
       mockClient.toolRouter.session.link.mockResolvedValueOnce(mockLinkResponse);
 

--- a/ts/packages/core/test/models/toolRouter.test.ts
+++ b/ts/packages/core/test/models/toolRouter.test.ts
@@ -1848,6 +1848,72 @@ describe('ToolRouter', () => {
       expect(connectionRequest).toHaveProperty('toString');
       expect(typeof connectionRequest.waitForConnection).toBe('function');
     });
+
+    // Bugbot-flagged gap: authorize() was passing aclConfigForShared straight
+    // to the wire while link() validated through Zod. These tests pin the
+    // parity — same 1000-entry list cap, same 256-char user_id cap.
+    it('forwards accountType + nested acl_config_for_shared on the wire', async () => {
+      mockClient.toolRouter.session.link.mockResolvedValueOnce(mockLinkResponse);
+
+      const session = await toolRouter.create(userId);
+      await session.authorize(toolkit, {
+        accountType: 'SHARED',
+        aclConfigForShared: {
+          allowAllUsers: true,
+          notAllowedUserIds: ['user_bob'],
+        },
+      });
+
+      expect(mockClient.toolRouter.session.link).toHaveBeenCalledWith(sessionId, {
+        toolkit,
+        account_type: 'SHARED',
+        acl_config_for_shared: {
+          allow_all_users: true,
+          not_allowed_user_ids: ['user_bob'],
+        },
+      });
+    });
+
+    it('throws ValidationError when allowedUserIds exceeds the 1000-entry cap', async () => {
+      const session = await toolRouter.create(userId);
+      const oversizedList = Array.from({ length: 1001 }, (_, i) => `user_${i}`);
+
+      await expect(
+        session.authorize(toolkit, {
+          accountType: 'SHARED',
+          aclConfigForShared: { allowedUserIds: oversizedList },
+        })
+      ).rejects.toMatchObject({ name: 'ValidationError' });
+
+      expect(mockClient.toolRouter.session.link).not.toHaveBeenCalled();
+    });
+
+    it('throws ValidationError when a user_id exceeds the 256-char length cap', async () => {
+      const session = await toolRouter.create(userId);
+      const tooLongUserId = 'u'.repeat(257);
+
+      await expect(
+        session.authorize(toolkit, {
+          accountType: 'SHARED',
+          aclConfigForShared: { allowedUserIds: [tooLongUserId] },
+        })
+      ).rejects.toMatchObject({ name: 'ValidationError' });
+
+      expect(mockClient.toolRouter.session.link).not.toHaveBeenCalled();
+    });
+
+    it('throws ValidationError when a user_id is empty', async () => {
+      const session = await toolRouter.create(userId);
+
+      await expect(
+        session.authorize(toolkit, {
+          accountType: 'SHARED',
+          aclConfigForShared: { notAllowedUserIds: [''] },
+        })
+      ).rejects.toMatchObject({ name: 'ValidationError' });
+
+      expect(mockClient.toolRouter.session.link).not.toHaveBeenCalled();
+    });
   });
 
   describe('toolkits function', () => {


### PR DESCRIPTION
## Summary

SDK wrappers for the Apollo-side Shared Accounts feature shipped across four Hermes PRs:

- [hermes#9860](https://github.com/ComposioHQ/hermes/pull/9860) — `account_type` enum (PRIVATE / SHARED) + pin-only invariant
- [hermes#9882](https://github.com/ComposioHQ/hermes/pull/9882) — echo `account_type` in create-flow responses
- [hermes#9887](https://github.com/ComposioHQ/hermes/pull/9887) — echo `account_type` in internal link-session GET (no public docs surface)
- [hermes#9902](https://github.com/ComposioHQ/hermes/pull/9902) — per-user ACL for SHARED connections, nested under `acl_config_for_shared`

Ready for review — Apollo, the OpenAPI spec, and `@composio/client@0.1.0-alpha.71` (published from [composio-base-ts#77](https://github.com/ComposioHQ/composio-base-ts/pull/77)) all carry the merged contract.

## Implemented

### Types (`types/connectedAccounts.types.ts`)
- `ConnectedAccountTypes` constants + `ConnectedAccountTypeSchema` Zod enum + `ConnectedAccountType` TS type.
- `ConnectedAccountAclConfigSchema` (input — all 3 fields optional) and `ConnectedAccountAclConfigResponseSchema` (output — fields populated when block visible). Per-list cap **1000 entries**, per-`userId` length cap **1..256 chars** — matches Apollo's `aclConfig.ts`.
- Extended `CreateConnectedAccountLinkOptionsSchema` with `accountType` + `aclConfigForShared` (nested object).
- Extended `ConnectedAccountRetrieveResponseSchema` with `accountType` + optional `aclConfigForShared` (`undefined` when caller can't see ACL — distinguishes hidden-ACL from default-state).
- New `UpdateConnectedAccountAclParamsSchema`, refined to require ≥1 field (rejects no-op `{}`). Inline comment notes the ZodEffects `.shape` quirk for future maintainers.

### Model (`models/ConnectedAccounts.ts`)
- `link(userId, authConfigId, options)` — forwards `accountType` and serializes `aclConfigForShared` to the nested `acl_config_for_shared` wire block via a new internal `serializeAclConfigForWire` helper. Default behaviour (no options) creates a PRIVATE connection exactly as today.
- **New** `updateAcl(nanoid, params)` — wraps `client.connectedAccounts.patch` (PATCH `/connected_accounts/{id}`), serialising flat camelCase params into the nested wire block. PATCH semantics: omit a field to leave unchanged; pass `[]` to clear an allow/deny list. JSDoc flags the empty-array footgun (`notAllowedUserIds: []` silently re-grants previously-blocked users). Returns `ConnectedAccountPatchResponse` to match sibling-method ergonomics.
- Clarifying JSDoc on existing `update()` pointing readers at `updateAcl()` for ACL and noting the historical "alias and/or credentials" doc is inaccurate (separate cleanup PR).

### Model (`models/ToolRouterSession.ts`)
- `authorize(toolkit, options)` — options gain `accountType` + `aclConfigForShared`. The `/tool_router/session/{session_id}/link` endpoint accepts the same fields, so a SHARED connection with an ACL can be created in one call from inside a tool-router session.

### Transformer (`utils/transformers/connectedAccounts.ts`)
- Maps `account_type` → `accountType`.
- Maps `acl_config_for_shared` (nested) → `aclConfigForShared` (nested camelCase). Forwards `undefined` when the block is absent so callers can distinguish *"I can't see the ACL"* (cookie caller, non-creator) from *"ACL is the default deny-by-default state"*.

### Errors (`errors/ConnectedAccountsErrors.ts`)
- `ComposioAclOnlyForSharedError` (400) — **wired** at three call sites: `link()`, `updateAcl()`, `ToolRouterSession.authorize()`. Substring match on `'acl_config_for_shared is only valid on SHARED'` (verified against Apollo's `createConnectedAccount.ts` in hermes#9902).
- `ComposioSharedAccessDeniedError` (403) — exported, **not yet wrapped by SDK code**. Will be wrapped when `Tools.execute()`/direct-execute error mapping lands in a follow-up. For now, callers seeing this from a raw `BadRequestError`/`ForbiddenError` can match on message substring.
- `ComposioSharedConnectionNotAccessibleError` (400) — same status. Will be wrapped when `ToolRouterSession.create()`/`update()` session-validator error mapping lands.

### Tests (`test/connectedAccounts/connectedAccounts.test.ts`)
- 12 new behaviour tests covering `link()` ACL forwarding (5), `updateAcl()` body construction + empty-object refine + AclOnlyForShared mapping (6), and `link()` error-mapping fallback (1). 911 tests pass (up from 899).

### Changeset
- `.changeset/connected-accounts-acl.md` — `@composio/core: minor` (additive surface, no breaking changes), describes the nested shape and resolution rule.

## Not implemented (deliberate scope cuts)

| Skipped | Why | Where it lands |
|---|---|---|
| **Python SDK mirror** | `composio-client@1.38.0` (from [composio-base-py#66](https://github.com/ComposioHQ/composio-base-py/pull/66)) now exposes the same fields. Better as its own PR scoped to `python/composio/` so Python's release cadence stays independent. | Separate PR, same release train (called out in changeset). |
| **Docs cookbook entry** ("share a connection with specific users") | Needs `@composio/core` to be published before the TS code samples can `twoslash`-typecheck against the new methods. | Separate PR under `docs/content/cookbooks/`. |
| **`docs/public/openapi*.json` spec refresh** | Auto-PR [#3399](https://github.com/ComposioHQ/composio/pull/3399) already opened against `next` with the post-9902 spec. | Mergeable independently from this PR. |
| **`update()` → real PATCH endpoint** | Pre-existing — JSDoc says "alias and/or credentials" but implementation calls `updateStatus`. The new JSDoc explicitly disclaims it; the behaviour-change rewrite is unrelated to ACL. | Separate cleanup PR. |
| **`ComposioSharedAccessDeniedError` + `ComposioSharedConnectionNotAccessibleError` wiring** | Need to map at `Tools.execute()` and `ToolRouterSession.create()`/`update()`/`patch()`. Out of scope for a connected-accounts PR — the failure modes are in different SDK touchpoints. Exported now so the public-API contract is stable, JSDocs explicit about when they'll start being thrown. | Follow-up PR scoped to execute/session error mapping. |
| **Internal link-session GET (hermes#9887)** | Endpoint is `/api/v3/internal/...` and filtered out of the public spec by `docs/scripts/fetch-openapi.mjs`. Dashboard UI consumes it, not the SDK. | N/A — internal only. |
| **Cast tightening / shared wire-ACL fragment** (review P3-13, P3-14) | Casts and local body types are gone (commit `483af3607`). Shared fragment was already extracted as `AclConfigWireShape` in commit `752efd886` — now removed since it lives in the generated types. | Done. |
| **Duplicate-account guard extraction** (review P3-16) | Reviewer explicitly says "parity-by-copy is fine for this PR" — `link()` and `initiate()` share a 14-line guard. Extracting `assertNoActiveConnections()` is mechanical and unrelated. | Follow-up. |

## Commits

1. [`84a3a074`](https://github.com/ComposioHQ/composio/pull/3392/commits/84a3a074b) — initial draft against the flat-field shape described in 9902's PR body.
2. [`752efd88`](https://github.com/ComposioHQ/composio/pull/3392/commits/752efd886) — reshape to the nested `aclConfigForShared` shape that actually merged in 9902. Verified against `staging-backend.composio.dev`'s spec.
3. [`483af3607`](https://github.com/ComposioHQ/composio/pull/3392/commits/483af3607) — bump `@composio/client` to `0.1.0-alpha.71`, drop the three casts + local body types, apply the 9 in-scope multi-agent review fixes, wire `ComposioAclOnlyForSharedError` at three call sites, add 12 behaviour tests.

## Test plan

- [x] `pnpm --filter @composio/core typecheck` — clean
- [x] `pnpm --filter @composio/core test` — 911/911 pass (12 new, 899 pre-existing)
- [x] `pnpm --filter @composio/core build` — `publint` + `attw` clean
- [x] Wire contract spot-checked against prod spec for all five endpoints (POST link, POST connected_accounts, PATCH, GET single, GET list, tool_router/session link)
- [x] All forward-compat casts removed; SDK now uses `LinkCreateParams`, `ConnectedAccountPatchParams`, `SessionLinkParams` from the generated client directly
- [ ] **Manual smoke (reviewer or merger):** create SHARED → `updateAcl({ allowAllUsers: true, notAllowedUserIds: ['user_bob'] })` → verify `get()` returns `aclConfigForShared` for creator, returns `undefined` for non-creator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)