### PR TITLE
fix: return Optional[Any] for null-only anyOf schemas in schema_converter

### DIFF
--- a/python/composio/utils/schema_converter.py
+++ b/python/composio/utils/schema_converter.py
@@ -270,7 +270,7 @@ def _build_union_from_options(options: t.List[t.Dict[str, t.Any]]) -> t.Type:
         pydantic_types.append(ptype)
 
     if len(pydantic_types) == 0:
-        return str  # Fallback
+        return t.Optional[t.Any] if has_null else str  # type: ignore
 
     if len(pydantic_types) == 1:
         base_type = pydantic_types[0]


### PR DESCRIPTION
## Summary

`_build_union_from_options` in `python/composio/utils/schema_converter.py` returned `str` as a fallback when `pydantic_types` was empty, even when `has_null` was `True`. This happened for `anyOf` schemas containing only a null entry, e.g. `{"anyOf": [{"type": "null"}]}`.

**Root cause:** lines 272-273:
```python
# before
if len(pydantic_types) == 0:
    return str  # Fallback

# after
if len(pydantic_types) == 0:
    return t.Optional[t.Any] if has_null else str  # type: ignore
```

When the only option in an `anyOf` is `null`, the correct Python type is `Optional[Any]`, not `str`. The previous code silently accepted any string where `None` was the only valid value.

## Test plan

- [ ] Run schema converter tests: `pytest python/tests/`
- [ ] Verify `{"anyOf": [{"type": "null"}]}` converts to `Optional[Any]` not `str`

Fixes #3171