### PR TITLE
docs: update CLAUDE.md for composio SDK

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,404 +1,123 @@
-# CLAUDE.md
+# Composio SDK
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Monorepo for the Composio SDK v3 (TypeScript + Python). Default branch is **`next`** — branch from `next`, target PRs at `next`, not `master`.
 
-## Overview
+`AGENTS.md` covers the same architecture for generic agents — keep them in sync when changing repo-wide structure. Per-area details live in `docs/CLAUDE.md` and `ts/packages/cli/CLAUDE.md`.
 
-This is the Composio SDK v3 repository containing both TypeScript and Python SDKs. The main development focus is on the TypeScript SDK located in `/ts/` directory. The project uses a monorepo structure with multiple packages and examples.
+## Layout
 
-## Memories and Notes
-
-- For documentation tasks, refer to `docs/CLAUDE.md`
-
-## Effect.ts Reference Source
-
-The CLI package (`@composio/cli`) is built on the Effect.ts ecosystem. A local copy of the Effect source code is available as a git submodule:
-
-- **Location:** `ts/vendor/effect/`
-- **Repo:** [Effect-TS/effect](https://github.com/Effect-TS/effect)
-- **Branch:** `main`
-
-When working on CLI code, reference the Effect source for accurate patterns:
-- `ts/vendor/effect/packages/effect/src/` — core Effect runtime
-- `ts/vendor/effect/packages/cli/src/` — @effect/cli (Command, Options, Args)
-- `ts/vendor/effect/packages/platform/src/` — @effect/platform (FileSystem, Terminal)
-
-**Important:** The submodule is for **read-only reference only**. Do not modify files in `ts/vendor/`. The CLI's actual dependencies come from npm via `pnpm install`.
-
-## Clack Reference Source
-
-The CLI uses [`@clack/prompts`](https://github.com/bombshell-dev/clack) for interactive terminal UI. A local copy of the Clack source code is available as a git submodule:
-
-- **Location:** `ts/vendor/clack/`
-- **Repo:** [bombshell-dev/clack](https://github.com/bombshell-dev/clack)
-
-When working on CLI prompts and terminal UI, reference the Clack source for accurate APIs:
-- `ts/vendor/clack/packages/prompts/src/` — `@clack/prompts` (high-level API: text, select, confirm, spinner, etc.)
-- `ts/vendor/clack/packages/core/src/` — `@clack/core` (low-level primitives)
-
-See `ts/packages/cli/AGENTS.md` for detailed Clack usage guidelines.
-
-**Important:** The submodule is for **read-only reference only**. Do not modify files in `ts/vendor/`. The CLI's actual `@clack/prompts` dependency comes from npm via `pnpm install`.
-
-## Common Development Commands
-
-### Build and Development
-```bash
-# Build all packages
-pnpm build
-
-# Build only TypeScript packages  
-pnpm build:packages
-
-# Clean build artifacts
-pnpm clean
-pnpm clean:workspace
-
-# Lint code
-pnpm lint
-pnpm lint:fix
-
-# Format code
-pnpm format
-
-# Run tests
-pnpm test
-```
-
-### Package Management
-```bash
-# Install dependencies
-pnpm install
-
-# Check peer dependencies
-pnpm check:peer-deps
-
-# Update peer dependencies  
-pnpm update:peer-deps
-```
-
-### Creating New Components
-```bash
-# Create a new provider
-pnpm create:provider <provider-name> [--agentic]
-
-# Create a new example
-pnpm create:example <example-name>
-```
-
-### Release Management
-```bash
-# Create changeset for releases
-pnpm changeset
-
-# Version packages
-pnpm changeset:version
-
-# Publish packages
-pnpm changeset:release
-```
-
-## Project Architecture
-
-### Repository Structure
 ```
 composio/
-├── ts/                      # TypeScript SDK (main development)
+├── ts/                         # TypeScript SDK (primary)
 │   ├── packages/
-│   │   ├── core/           # Core SDK functionality
-│   │   ├── providers/      # AI provider integrations (OpenAI, Anthropic, etc.)
-│   │   ├── cli/           # Command-line interface
+│   │   ├── core/               # @composio/core — main SDK
+│   │   ├── cli/                # @composio/cli — Effect.ts + Bun binary
+│   │   ├── cli-keyring/        # OS keychain access for the CLI
+│   │   ├── cli-local-tools/    # Local tool execution for the CLI
+│   │   ├── providers/          # @composio/{anthropic,openai,openai-agents,
+│   │   │                       #  claude-agent-sdk,google,langchain,llamaindex,
+│   │   │                       #  mastra,vercel,cloudflare}
 │   │   ├── json-schema-to-zod/ # Schema conversion utility
-│   │   └── ts-builders/   # TypeScript code generation utilities
-│   └── examples/          # Usage examples for different providers
-├── python/                # Python SDK
-├── docs/                  # Documentation (Fumadocs)
-└── examples/              # Cross-platform examples
+│   │   └── ts-builders/        # TS AST builders (used by CLI codegen)
+│   ├── e2e-tests/              # Node CJS/ESM, Deno, Cloudflare Workers, CLI E2E
+│   ├── examples/, scripts/
+│   └── vendor/                 # READ-ONLY git submodules (Effect, Clack) — reference only
+├── python/                     # Python SDK (uv + nox)
+├── docs/                       # Fumadocs site (see docs/CLAUDE.md)
+└── examples/                   # Cross-language examples
 ```
 
-### Core Packages
+## Toolchain
 
-**@composio/core** - Main SDK functionality:
-- `src/composio.ts` - Main Composio class
-- `src/models/` - Core models (Tools, Toolkits, ConnectedAccounts, etc.)
-- `src/provider/` - Base provider implementations
-- `src/services/` - Internal services (telemetry, pusher)
-- `src/types/` - TypeScript type definitions
-- `src/utils/` - Utility functions and helpers
+- Node `cat .nvmrc` (currently 20.20.2), pnpm `cat package.json | jq -r .packageManager` (10.28.2), Bun `cat .bun-version` (1.3.10)
+- Python `cat .python-version`, managed via `uv` + `nox`
+- When editing `.github/workflows/`, also bump the version table in `ts/docs/internal/release.md`.
 
-**Provider Packages** - AI integrations:
-- `@composio/openai` - OpenAI integration
-- `@composio/anthropic` - Anthropic integration
-- `@composio/google` - Google GenAI integration
-- `@composio/langchain` - LangChain integration
-- `@composio/vercel` - Vercel AI integration
-- `@composio/mastra` - Mastra integration
-
-### Key Concepts
-
-**Tools** - Individual functions that can be executed (e.g., GITHUB_CREATE_REPO, GMAIL_SEND_EMAIL)
-
-**Toolkits** - Collections of related tools grouped by service (e.g., github, gmail, slack)
-
-**Connected Accounts** - User authentication/authorization for external services
-
-**Auth Configs** - Configuration for different authentication methods
-
-**Custom Tools** - User-defined tools with custom logic
-
-**Providers** - Integrations with AI frameworks (OpenAI, Anthropic, etc.)
-
-**Modifiers** - Middleware to transform tool inputs/outputs
-
-## Development Workflow
-
-### For Tool Development
-1. Tools are auto-generated from OpenAPI specifications
-2. Custom tools can be created using the Custom Tools API
-3. Tool execution happens through the main Composio class
-
-### For Provider Development
-1. Use `pnpm create:provider <name>` to scaffold new providers
-2. Implement required methods: `wrapTool`, `wrapTools`
-3. For agentic providers, also implement execution handlers
-4. Add comprehensive tests and documentation
-
-### Testing
-- Unit tests use Vitest
-- Run tests with `pnpm test`
-- Tests are located in `test/` directories within each package
-- Mock implementations are available in `test/utils/mocks/`
-
-### Code Quality
-- ESLint configuration in `eslint.config.mjs`
-- Prettier for code formatting
-- TypeScript strict mode enabled
-- Comprehensive TSDoc documentation required
-- Husky pre-commit hooks for quality checks
-
-## Environment Variables
+## TypeScript commands
 
 ```bash
-COMPOSIO_API_KEY          # Required: Your Composio API key
-COMPOSIO_BASE_URL         # Optional: Custom API base URL
-COMPOSIO_LOG_LEVEL        # Optional: Logging level (silent, error, warn, info, debug)
-COMPOSIO_DISABLE_TELEMETRY # Optional: Set to "true" to disable telemetry
-DEVELOPMENT               # Development mode flag
-CI                       # CI environment flag
+pnpm install                    # Install (uses BYPASS_BUN_VERSION_CHECK=1 if Bun mismatch)
+pnpm build                      # Turbo build everything
+pnpm build:packages             # Just ts/packages/**
+pnpm typecheck                  # Turbo typecheck (run before pushing CLI changes)
+pnpm lint                       # eslint ts/packages
+pnpm format                     # prettier
+pnpm test                       # Vitest across packages + validate-examples
+pnpm test:ui                    # Vitest UI
+pnpm create:provider <name> [--agentic]
+pnpm create:example <name>
+pnpm check:peer-deps
+pnpm changeset                  # Required for any version-bumping PR
 ```
 
-## Key Files and Locations
-
-- **Main SDK Entry**: `ts/packages/core/src/index.ts`
-- **Core Composio Class**: `ts/packages/core/src/composio.ts`
-- **Type Definitions**: `ts/packages/core/src/types/`
-- **Error Classes**: `ts/packages/core/src/errors/`
-- **Examples**: `ts/examples/` and `examples/`
-- **Documentation**: `docs/`
-- **Build Configs**: `turbo.jsonc`, `tsconfig.base.json`, `tsdown.config.base.ts`
-- **E2E Tests**: `ts/e2e-tests/`
-
-## Maintenance Tasks
-
-### When Updating GitHub Actions
-
-When modifying files in `.github/workflows/`, update the "Prerequisites" section in `ts/docs/internal/release.md` with the current tool versions:
-
-- **Node.js**: `cat .nvmrc`
-- **Bun**: `cat .bun-version`
-- **pnpm**: `cat package.json | jq -r .packageManager | cut -d'@' -f2`
-
-## Testing Commands
+E2E suites are Docker-based (Node + Deno) or Wrangler-based (Cloudflare):
 
 ```bash
-# Run all tests
-pnpm test
-
-# Run tests for core package only
-cd ts/packages/core && pnpm test
-
-# Run tests with UI
-pnpm test:ui
+pnpm test:e2e                   # All runtimes
+pnpm test:e2e:node              # CJS + ESM Node compatibility
+pnpm test:e2e:deno              # npm: specifier compatibility
+pnpm test:e2e:cloudflare        # Cloudflare Workers
+pnpm test:e2e:cli               # CLI binary E2E
+COMPOSIO_E2E_NODE_VERSION=22.12.0 pnpm test:e2e:node   # Pin runtime version
 ```
 
-### TypeScript E2E Tests
+E2E tree:
 
-E2E tests for `@composio/core` are located in `ts/e2e-tests/` and test runtime compatibility across different JavaScript environments.
-
-```bash
-# Run all e2e tests (Node.js + Deno + Cloudflare)
-pnpm test:e2e
-
-# Run only Node.js e2e tests (CJS/ESM compatibility, runs in Docker)
-pnpm test:e2e:node
-
-# Run only Deno e2e tests (npm: specifier compatibility, runs in Docker)
-pnpm test:e2e:deno
-
-# Run only Cloudflare Workers e2e tests
-pnpm test:e2e:cloudflare
-
-# Run Node.js tests with a specific Node version
-COMPOSIO_E2E_NODE_VERSION=22.12.0 pnpm test:e2e:node
-
-# Run Deno tests with a specific Deno version
-COMPOSIO_E2E_DENO_VERSION=2.6.7 pnpm test:e2e:deno
-```
-
-**E2E Test Structure:**
 ```
 ts/e2e-tests/
-├── _utils/                    # Shared Docker infrastructure
-├── runtimes/
-│   ├── node/                  # Node.js runtime tests
-│   │   ├── cjs-basic/         # CommonJS compatibility
-│   │   └── esm-basic/         # ESM compatibility
-│   ├── deno/                  # Deno runtime tests
-│   │   └── esm-basic/         # npm: specifier compatibility
-│   └── cloudflare/            # Cloudflare runtime tests
-│       └── cf-workers-basic/  # Cloudflare Workers tests
-└── README.md                  # E2E test documentation
+├── _utils/                   # Shared Docker infra
+├── runtimes/{node,deno,cloudflare}/<scenario>/
+└── cli/                      # Used by /cli-test-with-bundling
 ```
 
-> **Note:** When adding new e2e tests, update `ts/e2e-tests/README.md` with the new test information.
+Update `ts/e2e-tests/README.md` when adding new E2E scenarios.
 
-## Common Patterns
+## Python SDK
 
-### Tool Execution
-```typescript
-const composio = new Composio({ apiKey: 'your-key' });
-const result = await composio.tools.execute('TOOL_NAME', {
-  userId: 'user-id',
-  arguments: { /* tool args */ }
-});
-```
-
-### Provider Integration
-```typescript
-import { OpenAIProvider } from '@composio/openai';
-const provider = new OpenAIProvider({ apiKey: 'openai-key' });
-const tools = await composio.tools.get('user-id', { toolkits: ['github'] });
-const wrappedTools = provider.wrapTools(tools);
-```
-
-### Custom Tool Creation
-```typescript
-import { z } from 'zod';
-
-const customTool = await composio.tools.createCustomTool({
-  name: 'My Tool',
-  description: 'Tool description',
-  slug: 'MY_TOOL',
-  inputParams: z.object({
-    param: z.string().describe('Parameter description')
-  }),
-  execute: async (input) => {
-    // Implementation
-    return {
-      data: { result: input.param },
-      error: null,
-      successful: true
-    };
-  }
-});
-```
-
-This monorepo uses pnpm workspaces and Turbo for efficient builds and development.
-
-## Python SDK Development
-
-### Setup
-The Python SDK is located in the `/python/` directory and uses `uv` for dependency management and `nox` for automation.
-
-### Environment Setup
 ```bash
-# Create and setup Python development environment
 cd python
-make env
+make env                         # uv venv + sync (dev) + install all providers
 source .venv/bin/activate
+make sync                        # Re-sync after pulling
+make provider                    # Reinstall provider packages
+make fmt                         # nox -s fmt (ruff)
+make chk                         # nox -s chk (ruff + mypy across modules) — chk and fmt are the only nox sessions
+nox -s fix                       # ruff --fix
+nox -s type_inference            # Verify provider type-inference works (full provider install)
+make build                       # Build wheels
+make bump                        # Version bump
 ```
 
-### Python Development Commands
-```bash
-# Setup environment (creates virtual env with all dependencies)
-make env
+Python layout: `python/{composio,providers/*,tests,examples,scripts,config/{pytest.ini,mypy.ini,ruff.toml}}`.
 
-# Sync dependencies (when in an existing environment)
-make sync
+Pytest markers (defined in `python/pytest.ini`): `slow`, `integration`, `unit`, `schema`. The old `core|openai|langchain|agno` markers no longer exist — use the current set.
 
-# Install provider packages
-make provider
+Providers shipped: `anthropic, autogen, claude_agent_sdk, crewai, gemini, google, google_adk, langchain, langgraph, llamaindex, openai, openai_agents`.
 
-# Format code using ruff
-make fmt
-# Or directly: nox -s fmt
+Python deps pinned in `python/pyproject.toml` — current core: `pysher`, `pydantic>=2.6.4`, `composio-client==1.37.0`, `typing-extensions>=4.0.0`, `openai`, `json-schema-to-pydantic>=0.4.8`. Requires Python `>=3.10,<4`.
 
-# Check linting and type issues
-make chk
-# Or directly: nox -s chk
+## Vendored references
 
-# Fix linting issues
-nox -s fix
+`ts/vendor/effect/` and `ts/vendor/clack/` are git submodules cloned **read-only** for reference (Effect.ts and `@clack/prompts` source). Do NOT modify. CLI runtime deps come from npm. See `ts/packages/cli/CLAUDE.md` for usage.
 
-# Run tests (requires implementing tst session)
-make tst
-# Or directly: nox -s tst
+## Environment
 
-# Run sanity tests (requires implementing snt session)  
-make snt
-# Or directly: nox -s snt
-
-# Clean build artifacts
-make clean-build
-
-# Bump version
-make bump
-
-# Build packages
-make build
+```
+COMPOSIO_API_KEY                 # Required
+COMPOSIO_BASE_URL                # Override API base
+COMPOSIO_LOG_LEVEL               # silent | error | warn | info | debug
+COMPOSIO_DISABLE_TELEMETRY=true  # Opt out of telemetry
+DEVELOPMENT, CI                  # Mode flags
+OPENAI_API_KEY                   # For OpenAI provider examples
 ```
 
-### Python Project Structure
-```
-python/
-├── composio/           # Main SDK package
-├── providers/          # Provider implementations
-├── tests/             # Test suite
-├── examples/          # Usage examples
-├── scripts/           # Development scripts
-├── config/            # Configuration files
-│   ├── pytest.ini     # Pytest configuration
-│   ├── mypy.ini       # MyPy type checking config
-│   ├── ruff.toml     # Ruff linter/formatter config
-│   └── codecov.yml   # Code coverage config
-├── Makefile          # Development shortcuts
-├── noxfile.py        # Nox automation sessions
-└── pyproject.toml    # Project configuration
-```
+## Release gotchas
 
-### Python Code Quality
-- **Formatter**: Ruff (Black-compatible, 88 char line length)
-- **Linter**: Ruff with custom configuration
-- **Type Checker**: mypy with strict optional typing
-- **Test Framework**: pytest with custom markers (core, openai, langchain, agno)
-- **Python Version**: >=3.10, <4
-- **Dependency Managers**: uv
+- pnpm preinstall enforces Bun version against `.bun-version`. If the sandbox Bun is newer, use `BYPASS_BUN_VERSION_CHECK=1 pnpm install`. CI sets this automatically.
+- Any version-bumping change requires a `pnpm changeset` entry — the changeset bot opens the release PR; merging that PR triggers npm publish + (for `@composio/cli`) a stable binary build.
+- See `ts/packages/cli/CLAUDE.md` for the CLI-specific beta/stable two-channel release flow.
 
-### Python Testing
-```bash
-# Run tests with pytest markers
-pytest -m core        # Run core tests only
-pytest -m openai      # Run OpenAI provider tests
-pytest -m langchain   # Run LangChain provider tests
-pytest -m agno       # Run Agno provider tests
-```
+## Docs and CLI subprojects
 
-### Python Package Dependencies
-- Core: `pysher`, `pydantic>=2.6.4`, `composio-client==1.4.0`, `typing-extensions>=4.0.0`, `openai`
-- Dev: `nox`, `pytest`, `ruff`, `langchain_openai`, `fastapi`, `twine`, `click`, `semver`
-
-### Python Environment Variables
-Same as TypeScript SDK, with additional:
-```bash
-OPENAI_API_KEY    # Required for OpenAI provider examples
-```
+- Docs site (Fumadocs, Bun-based): `docs/` — see `docs/CLAUDE.md`.
+- CLI (Effect.ts, Bun binary): `ts/packages/cli/` — see `ts/packages/cli/CLAUDE.md`. Required: `pnpm typecheck` from repo root before pushing CLI command changes.

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,107 +1,69 @@
 # Composio Documentation
 
-Documentation site for Composio, built with [Fumadocs](https://fumadocs.dev/).
+Fumadocs site for Composio. Branch off **`next`** and target PRs at **`next`** (not `master`).
 
-## Quick Reference
+## Commands
 
 ```bash
-bun install          # Install dependencies
-bun run dev          # Dev server (http://localhost:3000)
-bun run build        # Production build (validates TS code blocks)
-bun run types:check  # Type check
+bun install                     # Install
+bun run dev                     # Dev server (http://localhost:3000)
+bun run build                   # Production build — validates twoslash TS blocks
+bun run types:check             # Type check
+bun run lint:links              # Internal link validator (scripts/validate-links.ts)
+bun run generate:toolkits       # Refresh public/data/toolkits.json
+bun run generate:meta-tools     # Refresh public/data/meta-tools.json + content/reference/meta-tools/
+bun run generate:api-index      # Refresh API reference index pages
+bun test tests/static/          # Static checks
+bun test tests/integration/     # Integration tests (30s timeout)
 ```
 
-## Project Structure
+`bun dev` does NOT type-check MDX twoslash blocks — only `bun run build` does. Always build before pushing.
+
+## Layout
 
 ```
 docs/
-├── app/                  # Next.js app router
-├── content/              # MDX content
-│   ├── docs/             # Main documentation
-│   ├── cookbooks/        # Cookbooks & guides
-│   ├── changelog/        # Release notes
-│   ├── reference/        # SDK & API reference
-│   └── toolkits/         # Toolkit docs + faq/ snippets
-├── components/           # React components
-├── lib/                  # Utilities
-├── public/               # Static assets
-├── scripts/              # Build scripts (link checker, etc.)
-└── .claude/              # Claude context (see below)
+├── content/                 # MDX content
+│   ├── docs/                # Main documentation + glossary.mdx
+│   ├── cookbooks/, examples/
+│   ├── changelog/           # Release notes (YYYY-MM-DD format)
+│   ├── reference/           # SDK & API reference (v3.0 lives under reference/v3/)
+│   └── toolkits/            # Toolkit docs; faq/ snippets are plain .md (no frontmatter)
+├── scripts/                 # generate-{toolkits,meta-tools,api-index}.ts, validate-links.ts, fetch-openapi.mjs
+├── tests/{static,integration}/
+├── components/, lib/, app/, public/, examples/
+└── .claude/                 # Detailed agent context (see below)
 ```
 
-## Claude Context
+## Deeper context (`.claude/`)
 
-Detailed documentation for Claude is organized in `.claude/`:
+- `context/` — `fumadocs.md` (framework + design tokens), `twoslash.md` (TS code-block validation), `sdk-reference.md`, `api-reference.md` (schema rendering, CSS, upgrade notes), `pipelines.md` (CI/cron workflows)
+- `guides/changelog.md` — writing changelog entries
+- `decisions/{toolkits,examples,feedback,llm-guardrails}.md` — ADRs
+- `agents/{changelog-docs-updater,connect-clients-sync,docs-reviewer}.md` — agent prompts invoked by GH Actions
 
-### Context (Domain Knowledge)
-- [fumadocs.md](.claude/context/fumadocs.md) - Framework patterns, design tokens, MDX components
-- [twoslash.md](.claude/context/twoslash.md) - TypeScript code block type checking
-- [sdk-reference.md](.claude/context/sdk-reference.md) - SDK doc generation
-- [api-reference.md](.claude/context/api-reference.md) - API reference customizations (schema rendering, CSS overrides, upgrade notes)
-- [pipelines.md](.claude/context/pipelines.md) - CI/CD workflows reference (cron jobs, auto-PR, AI agents)
+## Rules that cause real bugs
 
-### Guides (How-To)
-- [changelog.md](.claude/guides/changelog.md) - Writing changelog entries
-
-### Decisions (ADRs)
-- [toolkits.md](.claude/decisions/toolkits.md) - Toolkits page implementation
-- [examples.md](.claude/decisions/examples.md) - Examples/cookbooks page plan
-- [feedback.md](.claude/decisions/feedback.md) - Feedback system
-- [llm-guardrails.md](.claude/decisions/llm-guardrails.md) - LLM guardrails system (frontmatter-scoped, pipeline-injected)
-
-## Git Workflow
-
-**Docs branches are always based off `next` and PRs target `next`** (not `master`). When creating a new branch for docs work, branch from `next`. When opening a PR, set the base to `next`.
-
-## Key Rules
-
-1. **TypeScript code blocks are type-checked** - All TS code in MDX is validated at build time. See [twoslash.md](.claude/context/twoslash.md).
-
-2. **Run build before pushing** - `bun run build` catches type errors that `bun dev` misses. Also run `bun run scripts/validate-links.ts` to catch broken internal links.
-
-3. **CSS variables** - Use `var(--composio-orange)` not `var(--orange)`. Check `app/global.css`.
-
-4. **Date format** - Changelog dates must be YYYY-MM-DD format.
-
-5. **Toolkits data** - `public/data/toolkits.json` must exist; errors are thrown, not ignored.
-
-6. **Meta tools data** - `public/data/meta-tools.json` and `content/reference/meta-tools/` are auto-generated by `bun run generate:meta-tools` (fetches from Tool Router API). Updated by CI alongside toolkits data. The `MetaToolDetailServer` component reads from the JSON at build time — do NOT register it in `mdx-components.tsx` (causes `fs` to leak into client bundle).
-
-7. **Test on mobile** - Fumadocs nav differs on mobile. Avoid assumptions about horizontal layout.
-
-8. **Toolkit FAQ files** - FAQ snippets live in `content/toolkits/faq/{slug}.md`. They're plain markdown (no frontmatter) embedded in toolkit pages at build time, not standalone Fumadocs pages. They're excluded from the toolkits Fumadocs source via `files: ['**/*', '!faq/**']` in `source.config.ts` but still scanned by the link checker.
-
-9. **Link checker** - `scripts/validate-links.ts` validates all internal links. It needs `bunfig.toml` (Bun preload for fumadocs-mdx) to run. Key details:
-   - Populate keys use `(home)/` prefix to match the `app/(home)/` route group
-   - Fragment validation falls back to parsing raw markdown headings (since `data.toc` is unavailable outside Next.js)
-   - Dynamic toolkit pages are validated against slugs from `public/data/toolkits.json`
-   - Non-Fumadocs `.md` files (like FAQ snippets) are picked up via `content/**/*.md` glob
-
-10. **Internal links use relative paths, never absolute** - Write `/docs/<section>/<page>`, `/reference/api-reference/<resource>/<operationId>`, `/reference/sdk-reference/<lang>/<page>`, `/docs/changelog/YYYY/MM/DD`, `/assets/images/<file>`. Never `https://docs.composio.dev/...`. The link checker (rule 9) only validates relative links; absolute URLs silently bypass it and rot over time. API-reference operation IDs are **camelCase** (`getConnectedAccountsByNanoid`, `postAuthConfigs`) — do not guess them; copy the exact `href` from `<ApiEndpointsTable>` in `content/reference/api-reference/<resource>/index.mdx`. Previous changelog entries use zero-padded month/day (`/docs/changelog/2026/04/21`, not `2026/4/21`).
+1. **TS blocks are twoslash-validated at build** — `bun run dev` doesn't catch this. Run `bun run build` before pushing.
+2. **CSS vars are namespaced** — use `var(--composio-orange)`, not `var(--orange)`. See `app/global.css`.
+3. **Changelog dates are zero-padded YYYY-MM-DD** — `/docs/changelog/2026/04/21` not `/2026/4/21`.
+4. **Internal links are relative, never absolute** — `/docs/...`, `/reference/...`, `/assets/...`. Absolute `https://docs.composio.dev/...` silently bypasses the link checker and rots. API-reference operationIds are **camelCase** (`getConnectedAccountsByNanoid`, `postAuthConfigs`) — copy from `<ApiEndpointsTable>` in `content/reference/api-reference/<resource>/index.mdx`; do not guess.
+5. **Generated data is required, not optional** — `public/data/toolkits.json` and `public/data/meta-tools.json` are loaded synchronously; missing → build throws (not warns).
+6. **`MetaToolDetailServer` is server-only** — do NOT register it in `mdx-components.tsx` or `fs` leaks into the client bundle.
+7. **FAQ snippets** live at `content/toolkits/faq/{slug}.md` as plain markdown (no frontmatter). Excluded from the Fumadocs toolkits source via `files: ['**/*', '!faq/**']` in `source.config.ts`, but the link checker still scans them via `content/**/*.md`.
+8. **Link checker (`scripts/validate-links.ts`) needs `bunfig.toml` preload** for fumadocs-mdx. Populate keys use the `(home)/` prefix; fragment validation falls back to parsing raw markdown headings outside Next.js; dynamic toolkit pages validate against `public/data/toolkits.json`.
+9. **`docs/examples/` is tutorial code** — review for correctness/clarity, not production hardening. Skip a11y, error boundaries, i18n unless they teach the integration.
+10. **Mobile rendering differs** — Fumadocs nav swaps layout. Don't assume horizontal space.
 
 ## Glossary
 
-`content/docs/glossary.mdx` defines key Composio terms (auth config, session, toolkit, etc.) using `<Glossary>` and `<GlossaryTerm name="...">` components (`components/glossary.tsx`). The component renders a filterable two-column table. The markdown converter in `lib/source.ts` converts `<GlossaryTerm>` tags to `### Term` headings for LLM-friendly output. When adding new Composio concepts, add a `<GlossaryTerm>` entry and update the `keywords` frontmatter array.
+`content/docs/glossary.mdx` uses `<Glossary>` + `<GlossaryTerm name="…">` (`components/glossary.tsx`) to render a filterable table. `lib/source.ts`'s markdown converter rewrites `<GlossaryTerm>` to `### Term` headings for LLM consumption. When adding a new Composio concept, add a `<GlossaryTerm>` and update the page's `keywords` frontmatter.
 
-## API Versioning
+## API versioning
 
-The API reference supports v3.1 (latest, default) and v3.0 side-by-side:
-- **v3.1:** `/reference/api-reference/...` (default, all existing URLs unchanged)
-- **v3.0:** `/reference/v3/api-reference/...`
+v3.1 (default) and v3.0 (`/reference/v3/...`) live side-by-side; switcher is in the top nav. Non-API v3 pages (overview, authentication, errors, rate-limits) are manual copies — update both when content changes. API index pages and OpenAPI specs are auto-generated by CI (`docs-update-data.yml`); meta tools + SDK reference are shared, not duplicated.
 
-Version selector in the top nav switches between them. See [api-reference.md](.claude/context/api-reference.md) for full architecture.
+## AI-native conventions
 
-Key maintenance notes:
-- Non-API pages under `content/reference/v3/` (overview, authentication, errors, rate-limits) are manual copies — update both when content changes
-- API index pages and OpenAPI specs are auto-generated by CI (`docs-update-data.yml`)
-- SDK Reference and Meta Tools are shared across both versions (not duplicated)
-
-## Code Review Guidelines
-
-**`docs/examples/` is tutorial code.** Review for correctness and clarity, not production-readiness. Skip accessibility (aria attributes, focus management), error boundaries, i18n, comprehensive error handling, and similar concerns that add noise to a teaching example. The goal is to teach Composio integration with minimal code.
-
-## AI-Native Documentation
-
-**Prefer cURL over "click"** - Most docs traffic comes from AI crawlers. When documenting API interactions, prefer showing cURL commands over UI instructions like "click this button" or "navigate to settings". cURL is machine-readable and can be directly executed by AI agents.
-
-**LLM guardrails** - Every `.md` endpoint appends invisible guardrails steering AI code generators toward the session-based pattern. Controlled via `llmGuardrails` frontmatter field. See [llm-guardrails.md](.claude/decisions/llm-guardrails.md).
+- **Prefer cURL over "click X"** — most traffic comes from AI crawlers; cURL is directly executable.
+- **LLM guardrails** — every `.md` endpoint appends invisible guardrails steering AI code generators toward the session-based pattern. Controlled via the `llmGuardrails` frontmatter field. See `.claude/decisions/llm-guardrails.md`.

--- a/ts/packages/cli/AGENTS.md
+++ b/ts/packages/cli/AGENTS.md
@@ -1,379 +1,135 @@
-# AGENTS.md
+# @composio/cli — Agent Guide
 
-Instructions for AI agents working on `@composio/cli`.
+Effect.ts CLI built on Bun, distributed as cross-platform single-file binaries. This file is symlinked as `CLAUDE.md`, so it serves both Codex and Claude Code.
 
-## Architecture Overview
+## Required check (blocking)
 
-The CLI is built on the **Effect.ts ecosystem** and runs on **Bun**. It follows a service-oriented architecture with dependency injection via Effect layers, generator-based control flow (`Effect.gen`), and structured error handling.
+When touching anything under `src/commands/`, run `pnpm typecheck` from the **repo root** (not the package). CLI imports cross-package types from `@composio/core` and `@composio/client`; package-local `tsc` misses regressions. Don't push without it.
 
-## Required Checks
+## Architecture
 
-When you touch CLI commands (anything under `ts/packages/cli/src/commands/`), you must run `pnpm typecheck` from the repo root. If it fails, fix the issues before proceeding.
+Built on the **Effect.ts** ecosystem on **Bun**. Service-oriented with DI via Effect layers, generator-based control flow (`Effect.gen`), and structured error handling. `src/bin.ts` composes layers and runs the root command via `BunRuntime.runMain()`:
 
-### Entry Point
+- `CliConfigLive` — `@effect/cli` behavior (case-sensitive, no auto-correct, no built-ins)
+- `ComposioUserContextLive` — auth state read from `~/.composio/user-config.json`
+- `ComposioToolkitsRepositoryCachedLive` — API client + file-cache decorator
+- `UpgradeBinaryLive` — self-update from GitHub releases
+- `BunFileSystem.layer`, `BunContext.layer` — Bun platform layers
 
-`src/bin.ts` bootstraps the CLI by composing Effect layers and running the root command via `BunRuntime.runMain()`:
+Errors are captured by the custom `effect-errors/` module — source-mapped stack traces, Effect span timelines, boxed pretty output.
 
-- `CliConfigLive` — @effect/cli behavior (case-sensitive, no auto-correct, no built-ins)
-- `ComposioUserContextLive` — User authentication state from `~/.composio/`
-- `ComposioSessionRepositoryLive` — OAuth2 session management
-- `ComposioToolkitsRepositoryCachedLive` — Cached API client for toolkits/tools
-- `UpgradeBinaryLive` — Self-update from GitHub releases
-- `BunFileSystem.layer`, `BunContext.layer` — Bun runtime integration
+## Layout
 
-Errors are captured via the custom `effect-errors/` module, which provides source-mapped stack traces, Effect span timelines, and formatted output.
+```
+src/
+├── bin.ts, cli-main.ts, cli-config.ts, constants.ts, type-utils.ts
+├── commands/                # one *.cmd.ts per command, registered in commands/index.ts
+│   ├── $default.cmd.ts, version.cmd.ts, whoami.cmd.ts, login.cmd.ts, signup.cmd.ts,
+│   │   logout.cmd.ts, upgrade.cmd.ts, run.cmd.ts, proxy.cmd.ts, artifacts.cmd.ts,
+│   │   install.cmd.ts, listen.cmd.ts, dev.cmd.ts, init.cmd.ts
+│   ├── agent/               # agent {login, signup, claim, inbox, whoami}
+│   ├── tools/               # tools {list, info, search, execute}
+│   ├── triggers/            # triggers {create, enable, disable, list, listen, info, status}
+│   ├── connected-accounts/, connections/, auth-configs/
+│   ├── orgs/, projects/, toolkits/, logs-cmd/, local-tools/, config/
+│   ├── generate/            # generate ts|py (delegates per detected language)
+│   └── root-help.ts, feature-tags.ts
+├── services/                # ~30 services: user-context, composio-clients(-cached),
+│                            # terminal-ui, command-project, tools-executor,
+│                            # triggers-realtime, agents, env-lang-detector,
+│                            # connected-account-selection, run-subagent-{acp,legacy,
+│                            # output-mcp,shared}, run-companion-modules, etc.
+├── effects/                 # app-config, github-config, require-auth, install-skill,
+│                            # validate-toolkit-versions, detect-platform, log-metrics,
+│                            # select-org-project, toolkit-version-overrides, setup-cache-dir
+├── generation/              # `generate ts|py` pipeline: fetch → index → emit via
+│                            # @composio/ts-builders → optional TS→ESM transpile
+├── effect-errors/           # Cause capture + source-mapped pretty printing
+├── analytics/, models/, ui/, utils/
+└── feature-tags.ts          # tagged()/experimental() — gates by CLI_EXPERIMENTAL_FEATURES
+```
 
-### Commands (`src/commands/`)
+Root commands are wired in `src/commands/index.ts`'s `ROOT_COMMANDS` array — add new top-level commands there, gated with `tagged()` (always visible) or `experimental(flag, …)` (gated by feature flag from `src/constants.ts`).
 
-Each command is declared with `@effect/cli`'s `Command.make()` pattern:
+## Models (`src/models/`)
 
-| Command                                                  | Description                                                                           |
-| -------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| `composio version`                                       | Display CLI version                                                                   |
-| `composio whoami`                                        | Show logged-in user's API key                                                         |
-| `composio login [--no-browser] [--no-wait] [--key text] [--user-api-key text] [--org text]` | Login with browser redirect or direct user API key                                    |
-| `composio logout`                                        | Clear stored API key                                                                  |
-| `composio upgrade`                                       | Self-update binary from GitHub releases                                               |
-| `composio generate`                                      | Auto-detect project language, delegate to `ts` or `py`                                |
-| `composio generate ts`                                   | Generate TypeScript type stubs for toolkits/tools/triggers                            |
-| `composio generate py`                                   | Generate Python type stubs                                                            |
-| `composio manage <command>`                              | Manage Composio resources (toolkits, tools, accounts, triggers, logs, orgs, projects) |
+Effect Schema types with `fromJSON`/`toJSON` via `JSONTransformSchema()`: `Toolkit`, `Tool` (with `available_versions`, `input/output_parameters`), `TriggerType`, `UserData`, `Session`.
 
-Options use `Options.text()`, `Options.boolean()`, `Options.choice()`, `Options.directory()` with Effect Schema validation.
-
-### Services (`src/services/`)
-
-| Service                            | Purpose                                                                      |
-| ---------------------------------- | ---------------------------------------------------------------------------- |
-| `ComposioUserContext`              | Auth state — reads/writes `~/.composio/user-config.json`, merges env vars    |
-| `ComposioSessionRepository`        | Creates OAuth2 sessions, polls until `linked` state                          |
-| `ComposioToolkitsRepository`       | API client — fetches toolkits, tools, trigger types; validates versions      |
-| `ComposioToolkitsRepositoryCached` | Decorator over base repository with file-based caching and graceful fallback |
-| `NodeOs`                           | OS abstraction (`homedir`, `platform`, `arch`)                               |
-| `EnvLangDetector`                  | Detects project language (TS/Python) from config files and lock files        |
-| `JsPackageManagerDetector`         | Detects npm/pnpm/yarn/bun for helpful install instructions                   |
-| `UpgradeBinary`                    | Fetches latest release from GitHub, downloads and replaces binary            |
-
-### Effects (`src/effects/`)
-
-Reusable Effect computations for cross-cutting concerns:
-
-| Effect                         | Purpose                                                               |
-| ------------------------------ | --------------------------------------------------------------------- |
-| `app-config`                   | Reads `COMPOSIO_*` env vars (API_KEY, BASE_URL, CACHE_DIR, etc.)      |
-| `debug-config`                 | Debug overrides (DEBUG_OVERRIDE_VERSION, etc.)                        |
-| `force-config`                 | Force flags (FORCE_USE_CACHE)                                         |
-| `setup-cache-dir`              | Ensures `~/.composio/` directory exists                               |
-| `toolkit-version-overrides`    | Parses `COMPOSIO_TOOLKIT_VERSION_<NAME>=<ver>` env vars               |
-| `validate-toolkit-versions`    | Validates overrides against available API versions                    |
-| `with-log-level`               | Configures logger from CLI flag or env var                            |
-| `find-composio-core-generated` | Locates `@composio/core` in node_modules (handles pnpm virtual store) |
-| `version`                      | Resolves CLI version from package.json                                |
-| `compare-semver`               | Semantic version comparison for upgrade checks                        |
-| `log-metrics`                  | Formats and logs API request count and bytes transferred              |
-
-### Models (`src/models/`)
-
-Effect Schema definitions for type-safe serialization:
-
-- `Toolkit` — name, slug, auth_schemes, is_local_toolkit, meta
-- `Tool` — name, slug, available_versions, input/output_parameters, description, tags
-- `TriggerType` — slug, name, description, input/output parameters
-- `UserData` — apiKey, baseURL, webURL (with defaults)
-- `Session` — id, status (pending|linked), retrieved session with api_key
-
-Each model has `fromJSON`/`toJSON` helpers using `JSONTransformSchema()`.
-
-### Code Generation (`src/generation/`)
-
-Multi-stage pipeline for `composio generate ts` and `composio generate py`:
-
-1. **Fetch** — Toolkits, tools, trigger types from API (optionally filtered by `--toolkits`)
-2. **Index** — Groups tools/triggers by toolkit prefix into a `ToolkitIndex` map
-3. **Generate** — Builds TypeScript/Python source using `@composio/ts-builders` AST builders
-4. **Transpile** — Optionally converts TS → ESM JS (when writing to @composio/core/generated)
-
-Generated output includes toolkit objects, tool/trigger enums, and optionally full type definitions (with `--type-tools`).
-
-### Error Handling (`src/effect-errors/`)
-
-Custom error capture and formatting system:
-
-- **Capture** — Extracts error chain from Effect's `Cause`, handles interrupts separately
-- **Source maps** — Maps compiled `.mjs` stack traces back to TypeScript source
-- **Spans** — Extracts timing from Effect spans for execution timeline display
-- **Pretty print** — Colored, boxed error output with source context and suggestions
-
-### UI & Output (`src/ui/`)
-
-- `picocolors` and `ansis` for colored terminal output
-- Respects `NO_COLOR` env var
-- `@clack/prompts` symbols (`S_BAR`, `S_BAR_H`, `unicodeOr`) for box-drawing in formatted output
-- Effect's `Console.log()` / `Console.error()` for output
-
-### Configuration (`src/cli-config.ts`, `src/constants.ts`)
-
-- CLI behavior: `showBuiltIns: false`, `autoCorrectLimit: 0`, `isCaseSensitive: true`
-- Prefixes: `COMPOSIO_` for app config, `DEBUG_OVERRIDE_` for debug
-- User config stored in `~/.composio/`
-- Cache files: `toolkits.json`, `tools.json`, `tools-as-enums.json`, `trigger-types.json`
-
-### Effect.ts Patterns
-
-The CLI uses the generator-based syntax throughout:
+## Effect.ts patterns
 
 ```typescript
 Effect.gen(function* () {
-  const service = yield* ServiceName; // resolve dependency
-  const result = yield* someEffect; // await computation
-  yield* Effect.log('message'); // side effect
+  const service = yield* ServiceName;     // resolve dependency
+  const result = yield* someEffect;       // await computation
+  yield* Effect.log('message');           // side effect
   return result;
 });
 ```
 
-Key patterns:
+Common: `Effect.all([...], { concurrency: 'unbounded' })`, `Layer.provide()`, `Effect.mapError()`/`Effect.catchTag()`, `Effect.scoped`. Options validated with Effect Schema via `Options.text/boolean/choice/directory()`.
 
-- `Effect.all([...], { concurrency: 'unbounded' })` for parallel fetches
-- `Layer.provide()` for dependency composition
-- `Effect.mapError()` / `Effect.catchTag()` for typed error handling
-- `Effect.scoped` for resource cleanup
+## Output conventions (sacred)
 
-### Key Dependencies
+Unix split: **stdout = data only, stderr = decoration**.
 
-| Package                 | Role                                                                |
-| ----------------------- | ------------------------------------------------------------------- |
-| `effect`                | Core runtime, data types, concurrency                               |
-| `@effect/cli`           | Command, Options, Args declaration and parsing                      |
-| `@effect/platform`      | FileSystem, Terminal abstraction                                    |
-| `@effect/platform-bun`  | Bun runtime layer                                                   |
-| `@clack/prompts`        | Terminal UI — prompts, spinners, logs, notes (all output to stderr) |
-| `ansis`, `picocolors`   | Colored output                                                      |
-| `@composio/client`      | Raw Composio API client                                             |
-| `@composio/core`        | Core SDK types and constants                                        |
-| `@composio/ts-builders` | TypeScript AST code generation                                      |
-| `semver`                | Version comparison for upgrades                                     |
-| `open`                  | Opens URLs in browser (login flow)                                  |
-| `decompress`            | Extracts downloaded binaries                                        |
+- `ui.output(value)` writes raw data to stdout **only** when piped (`!process.stdout.isTTY`); it's a no-op in interactive mode (the human already saw the decoration).
+- Every other `TerminalUI` method (`intro`, `outro`, `log.*`, `note`, `spinner`) writes to stderr via Clack's `{ output: process.stderr }`.
+- When stdout is piped, **all** decoration is suppressed — `composio whoami | pbcopy` puts a clean key on the clipboard with zero noise.
+- Data commands: `ui.output()` + decoration via `ui.log.*` / `ui.note()`. Action-only commands (logout, upgrade) skip `ui.output()` entirely.
+- **Never** write data to stderr or decoration to stdout — breaks `$(...)`, `> file`, and pipes.
 
----
-
-## Output Conventions: Composable CLI Output
-
-The CLI follows the Unix convention of separating human-readable decoration from machine-readable data:
-
-- **stdout** — data output only (`ui.output()`). This is what scripts and pipes capture.
-- **stderr** — all decoration (Clack spinners, logs, notes, intro/outro). Visible in terminal, invisible in pipes.
-
-### Rules
-
-1. **All `TerminalUI` methods except `output()` write to stderr** via Clack's `{ output: process.stderr }` option — but only in interactive mode.
-2. **`ui.output(data)` writes to stdout only when piped** — it checks `process.stdout.isTTY` and is a no-op in interactive terminals (the human already sees the data via decoration on stderr).
-3. **When stdout is piped, ALL decoration is suppressed** — `isInteractive` (`process.stdout.isTTY`) gates every decoration method. Only `ui.output()` writes in piped mode. This keeps `composio whoami | pbcopy` completely silent.
-4. **Action commands** (logout, upgrade) produce no stdout data — their output is purely decorative.
-5. **Data commands** (whoami, version, login, generate) call both decoration (stderr) and `ui.output()` (stdout). In interactive mode, only decoration is visible. In pipes/scripts, only the raw data is captured.
-6. **Never write data to stderr** — decoration methods are for human context only.
-7. **Never write decoration to stdout** — it breaks pipes, `$(...)` captures, and `> file` redirects.
-
-### Pattern
-
-```typescript
-// Data command (e.g., whoami):
-yield * ui.note(apiKey, 'API Key'); // Decoration → stderr (human sees pretty box)
-yield * ui.output(apiKey); // Data → stdout (scripts capture plain value)
-
-// Action command (e.g., login):
-yield * ui.intro('composio login'); // Decoration → stderr
-yield * ui.log.step('Redirecting'); // Decoration → stderr
-// No ui.output() call — nothing for scripts to capture
-```
-
-### How it works in practice
-
-The CLI checks `process.stdout.isTTY` once at startup to determine the output mode:
-
-- **Interactive** (`stdout` is TTY): decoration visible on stderr, `ui.output()` is a no-op.
-- **Piped** (`stdout` is NOT TTY): decoration suppressed, `ui.output()` writes raw data to stdout.
+Examples:
 
 ```bash
-composio whoami              # Pretty box only (interactive)
+composio whoami              # Pretty box on stderr (interactive)
 composio whoami | pbcopy     # Silent — clipboard gets clean key
 API_KEY=$(composio whoami)   # Silent — variable gets clean key
-composio whoami > file.txt   # Silent — file gets clean key
-
-composio version             # Decorated version (interactive)
-composio version | cat       # Raw version string
-
-composio login               # All decoration visible, browser opens
-composio login 2>/dev/null   # Silent (but still opens browser, polls API)
+composio login               # All decoration on stderr, browser opens
+composio login 2>/dev/null   # Silent (still opens browser, polls API)
 ```
 
-### Adding new commands
+## Key dependencies
 
-When creating a new command, ask: "Does this command produce a value that scripts should capture?"
+`effect`, `@effect/cli`, `@effect/platform`, `@effect/platform-bun`, `@clack/prompts` (all UI to stderr), `ansis`+`picocolors` (respects `NO_COLOR`), `@composio/client`, `@composio/core`, `@composio/ts-builders`, `semver`, `open`, `decompress`.
 
-- **Yes** → Use `ui.output(value)` for the data, `ui.log.*` / `ui.note()` for context
-- **No** → Use only `ui.log.*` / `ui.note()` / `ui.intro()` / `ui.outro()` — everything goes to stderr automatically
+## Vendored Effect / Clack source
 
----
+`ts/vendor/effect/` and `ts/vendor/clack/` are read-only git submodules — reference only. Real deps come from npm via `pnpm install`.
 
-## Clack Reference Source
+- `ts/vendor/effect/packages/cli/src/` — `@effect/cli` (Command, Options, Args)
+- `ts/vendor/effect/packages/effect/src/` — core runtime
+- `ts/vendor/effect/packages/platform/src/` — FileSystem, Terminal
+- `ts/vendor/clack/packages/prompts/src/` — high-level prompts (`text`, `select`, `spinner`, `note`, etc.)
+- `ts/vendor/clack/packages/core/src/` — low-level prompt primitives
 
-The CLI uses [`@clack/prompts`](https://github.com/bombshell-dev/clack) for interactive terminal UI (prompts, spinners, logs, etc.). A local copy of the Clack source code is available as a git submodule:
+Current Clack usage is mostly `S_BAR`, `S_BAR_H`, `unicodeOr` for box-drawing in custom formatted output. Prefer `@clack/prompts` over `@clack/core` unless you need custom prompt behavior.
 
-- **Location:** `ts/vendor/clack/`
-- **Repo:** [bombshell-dev/clack](https://github.com/bombshell-dev/clack)
+## CLI design guidelines
 
-When working on CLI code that involves terminal UI, reference the Clack source for accurate APIs and patterns:
+Argument/flag/help/output conventions: `ts/packages/cli/.cursor/rules/cli-design-guidelines.mdc` and the Claude skill at `.claude/skills/create-cli/SKILL.md`. Read before adding flags or designing UX.
 
-- `ts/vendor/clack/packages/prompts/src/` — `@clack/prompts` (the high-level API used by this CLI)
-- `ts/vendor/clack/packages/core/src/` — `@clack/core` (low-level primitives underlying prompts)
+## Demo recordings (VHS)
 
-### Key modules in `@clack/prompts`
+New user-facing commands get a VHS recording. Add an entry to `recordings/recordings.yaml`, then `bun scripts/record.ts` (needs `COMPOSIO_API_KEY` + `vhs` on PATH). Use `height: dynamic` for long output — the recorder probes 2x height, parses the SVG, then re-records at the computed height (capped at `vhs.height * 2`).
 
-| Module                  | Purpose                                                |
-| ----------------------- | ------------------------------------------------------ |
-| `text.ts`               | Text input prompt                                      |
-| `password.ts`           | Password input prompt                                  |
-| `confirm.ts`            | Yes/no confirmation prompt                             |
-| `select.ts`             | Single-select list prompt                              |
-| `multi-select.ts`       | Multi-select list prompt                               |
-| `group-multi-select.ts` | Grouped multi-select prompt                            |
-| `autocomplete.ts`       | Autocomplete/search prompt                             |
-| `spinner.ts`            | Loading spinner                                        |
-| `progress-bar.ts`       | Progress bar                                           |
-| `log.ts`                | Styled log messages                                    |
-| `note.ts`               | Boxed note output                                      |
-| `task.ts`               | Task runner with status                                |
-| `task-log.ts`           | Task with streaming log output                         |
-| `stream.ts`             | Streaming text output                                  |
-| `box.ts`                | Box drawing utility                                    |
-| `messages.ts`           | Intro/outro messages                                   |
-| `common.ts`             | Shared symbols (`S_BAR`, `S_BAR_H`, `unicodeOr`, etc.) |
+YAML fields per entry: `name` (filename stem), `command`, optional `description` (shown above command via VHS `Hide`/`Show`), optional `sleepAfterEnter` (default `6s`), optional `height` (number or `'dynamic'`).
 
-### Current clack usage in the CLI
+Outputs: `recordings/{tapes,svgs,ascii}/<group>/<name>.{tape,svg,ascii}`. Shared VHS settings at `recordings/tapes/shared-config.tape` (auto-generated).
 
-The CLI currently imports from `@clack/prompts`:
+## Release workflow (two channels)
 
-- `S_BAR`, `S_BAR_H`, `unicodeOr` — Unicode box-drawing symbols for custom formatted output
+- **Beta (automatic):** every push to `next` touching `ts/packages/cli/**` runs `.github/workflows/build-cli-binaries.yml` → finds latest stable `@composio/cli@X.Y.Z` → computes patch bump `X.Y.Z+1` → builds linux/darwin × x64/aarch64 binaries → cuts a GitHub prerelease tagged `@composio/cli@X.Y.(Z+1)-beta.<run_number>`. Trigger from any branch via `workflow_dispatch` → `build-beta`. Users opt in via `composio upgrade --beta`.
+- **Stable (manual promotion):** changeset PR (`.changeset/<name>.md` with `"@composio/cli": patch`) → merge into `next` → changeset bot opens "Release: update version" PR bumping `package.json` → merge that PR → push to `next` detects version bump → builds **stable** release (`@composio/cli@X.Y.Z`, marked `latest`); `ts.release.yml` also publishes to npm. Promote existing beta via `workflow_dispatch` → `promote-stable`.
 
-### Guidelines
+Key workflow files: `.github/workflows/build-cli-binaries.yml`, `.github/workflows/ts.release.yml`, `.github/workflows/cli.test-installation.yml`, `.changeset/config.json`.
 
-- The submodule is for **read-only reference only**. Do not modify files in `ts/vendor/clack/`.
-- The CLI's actual dependency comes from npm (`@clack/prompts` v1.0.1) via `pnpm install`.
-- When adding new interactive prompts or terminal UI, consult the source in `ts/vendor/clack/packages/prompts/src/` for the correct API surface and available options.
-- Prefer `@clack/prompts` (high-level) over `@clack/core` (low-level) unless you need custom prompt behavior.
+## Skills
 
----
+`skills-src/` is built into shippable skills via `pnpm build:skills` (validated by `pnpm validate:skills`). Users install with `composio install`.
 
-## Effect.ts Reference Source
+## Configuration
 
-The CLI is built on the Effect.ts ecosystem. A local copy of the Effect source code is available as a git submodule:
-
-- **Location:** `ts/vendor/effect/`
-- **Repo:** [Effect-TS/effect](https://github.com/Effect-TS/effect)
-- **Branch:** `main`
-
-When working on CLI code, reference the Effect source for accurate patterns:
-
-- `ts/vendor/effect/packages/effect/src/` — core Effect runtime
-- `ts/vendor/effect/packages/cli/src/` — @effect/cli (Command, Options, Args)
-- `ts/vendor/effect/packages/platform/src/` — @effect/platform (FileSystem, Terminal)
-
-### Guidelines
-
-- The submodule is for **read-only reference only**. Do not modify files in `ts/vendor/effect/`.
-- The CLI's actual dependencies come from npm via `pnpm install`.
-
----
-
-## CLI Design Guidelines
-
-For principles on how to design CLI interactions (arguments, flags, help text, output, errors, interactivity, config precedence), see:
-
-- **Cursor rules**: `ts/packages/cli/.cursor/rules/cli-design-guidelines.mdc`
-- **Claude skill**: `.claude/skills/create-cli/SKILL.md` (standalone, trimmed for Claude Code context)
-
-Use these guidelines when adding new commands, designing flag interfaces, or making UX decisions for the CLI.
-
----
-
-## Recording CLI Demos
-
-New commands should have VHS recordings for documentation. The recording script produces SVGs and asciicasts that demonstrate the CLI in action.
-
-### Adding Recordings
-
-1. Add entries to `recordings/recordings.yaml` under the appropriate group
-2. Run `bun scripts/record.ts` (requires `COMPOSIO_API_KEY` and `vhs` on PATH)
-
-### Recording Config
-
-Each entry in `recordings.yaml` accepts:
-
-| Field             | Required | Description                                                                             |
-| ----------------- | -------- | --------------------------------------------------------------------------------------- |
-| `name`            | Yes      | Filename stem (`<name>.svg`, `<name>.ascii`, `<name>.tape`)                             |
-| `command`         | Yes      | Shell command to record                                                                 |
-| `description`     | No       | Comment shown instantly above the command (via VHS `Hide`/`Show`)                       |
-| `sleepAfterEnter` | No       | Wait time after Enter (default: `6s` from `vhs.sleepAfterEnter`)                        |
-| `height`          | No       | `'dynamic'` for two-pass auto-sizing, or a fixed pixel number. Omit for default (750px) |
-
-Use `height: dynamic` for commands with long output (help text, full listings). The recorder probes with 2x height, parses the SVG to measure content, then re-records at the computed height (capped at `vhs.height * 2`).
-
-### Output Structure
-
-```
-recordings/
-├── recordings.yaml                    # Config
-├── tapes/<group>/<name>.tape          # Generated VHS tape files
-├── svgs/<group>/<name>.svg            # SVG recordings
-└── ascii/<group>/<name>.ascii         # Asciicast recordings
-```
-
-### Key Files
-
-- **Config**: `recordings/recordings.yaml`
-- **Script**: `scripts/record.ts` — Bun + Effect.ts, parallel VHS execution
-- **Shared tape**: `recordings/tapes/shared-config.tape` — common VHS settings (auto-generated)
-
----
-
-## Release Workflow
-
-CLI releases use a two-channel system: **beta** (automatic) and **stable** (manual promotion).
-
-### Beta Releases (automatic)
-
-Every push to `next` that touches `ts/packages/cli/**` automatically triggers `.github/workflows/build-cli-binaries.yml`, which:
-
-1. Finds the latest stable `@composio/cli@X.Y.Z` release
-2. Computes the next patch version (`X.Y.Z+1`)
-3. Builds cross-platform binaries (linux-x64, linux-aarch64, darwin-x64, darwin-aarch64)
-4. Creates a GitHub prerelease tagged `@composio/cli@X.Y.(Z+1)-beta.<run_number>`
-
-You can also trigger a beta build from **any branch** via `workflow_dispatch` → `build-beta`.
-
-Users install beta releases with `composio upgrade --beta`.
-
-### Stable Releases (via changeset)
-
-To promote to a stable release:
-
-1. Create a changeset PR (`.changeset/<name>.md` with `"@composio/cli": patch`)
-2. Merge it into `next`
-3. The changeset bot creates a "Release: update version" PR that bumps `package.json`
-4. Merge that PR → the push to `next` detects the `package.json` version changed → builds a **stable** release (`@composio/cli@X.Y.Z`, marked as `latest`)
-5. `ts.release.yml` also publishes to npm
-
-### Manual Promotion
-
-You can also promote an existing beta to stable via `workflow_dispatch` → `promote-stable` with the beta tag (e.g. `@composio/cli@0.2.20-beta.42`).
-
-### Key Files
-
-| File                                          | Purpose                          |
-| --------------------------------------------- | -------------------------------- |
-| `.github/workflows/build-cli-binaries.yml`    | Binary build + release workflow  |
-| `.github/workflows/ts.release.yml`            | Changeset bot + npm publish      |
-| `.github/workflows/cli.test-installation.yml` | Post-release install smoke tests |
-| `.changeset/config.json`                      | Changeset configuration          |
+- CLI behavior: `showBuiltIns: false`, `autoCorrectLimit: 0`, `isCaseSensitive: true` (in `cli-config.ts`)
+- Env-var prefixes: `COMPOSIO_*` for app config, `DEBUG_OVERRIDE_*` for debug, `FORCE_*` for force flags
+- User config: `~/.composio/user-config.json` (apiKey, baseURL, webURL)
+- Cache files: `~/.composio/{toolkits,tools,tools-as-enums,trigger-types}.json`


### PR DESCRIPTION
# Description

Refresh the three CLAUDE.md files in this repo to reflect current reality. They had drifted significantly since their last update — the root file (last updated 2026-02-19) and `ts/packages/cli/CLAUDE.md` (2026-02-18) both predated the large CLI expansion (new `agent/`, `tools/`, `triggers/`, `connected-accounts/`, `orgs/`, `projects/`, `toolkits/`, `logs-cmd/`, `local-tools/`, `config/`, `auth-configs/`, `connections/`, `signup`, `proxy`, `artifacts`, `install`, `listen`, `init`, `dev`, `run` commands), the ~30-service refactor, and the new VHS recording / two-channel release workflow. `docs/CLAUDE.md` (2026-04-21) had moderate drift, mostly verbosity.

Specific corrections:

- **Root CLAUDE.md**: Updated package list (adds `cli-keyring`, `cli-local-tools`; expands provider list to include `claude-agent-sdk`, `openai-agents`, `llamaindex`, `cloudflare`). Replaced obsolete Python nox sessions (`tst`, `snt` — neither exist anymore) with the current `fmt`/`chk`/`fix`/`type_inference` set. Replaced obsolete pytest markers (`core|openai|langchain|agno`) with the current set in `python/pytest.ini` (`slow`, `integration`, `unit`, `schema`). Updated `composio-client` pin to current 1.37.0 (was 1.4.0) and added `json-schema-to-pydantic` to the deps list. Added the BYPASS_BUN_VERSION_CHECK gotcha and the E2E test split (added `test:e2e:cli`).
- **docs/CLAUDE.md**: Tightened to fit the 30-70 line target while preserving every gotcha (link checker rules, MetaToolDetailServer `fs` leak, faq snippet location, CSS var namespacing, twoslash, glossary, v3.1/v3.0 versioning, llm-guardrails). Added the missing `generate:*` and `lint:links` commands and the `.claude/agents/*.md` index.
- **ts/packages/cli/CLAUDE.md** (symlinked to AGENTS.md): Updated full command/service layout to match `src/commands/index.ts` ROOT_COMMANDS today. Kept the sacred output convention rules (stdout=data, stderr=decoration) and the two-channel release workflow. Removed the duplicated tutorial-style Effect/Clack tables (those live in the vendored submodules now). Made `pnpm typecheck from repo root` the headlining required check since this is the #1 thing CLI authors miss.

# How did I test this PR

This is docs-only — no tests/lint/CI run locally per the cron prompt's instructions. Verified line counts:

| File | Before | After | Target |
|------|--------|-------|--------|
| `CLAUDE.md` | 403 | 123 | 60–150 (root) |
| `docs/CLAUDE.md` | 107 | 69 | 30–70 (directory) |
| `ts/packages/cli/CLAUDE.md` (symlink → AGENTS.md) | 379 | 135 | 30–70 directory target stretched because the file doubles as the canonical AGENTS.md reference |

Also verified:
- `git remote get-url origin` resolves to `ComposioHQ/composio` (correct repo, not `composio_dashboard`).
- Symlink `ts/packages/cli/CLAUDE.md -> AGENTS.md` is preserved (writes to either target both).
- PR base is `next` (composio's default branch).

Origin: cron-update-claude-docs / [zen-cron-c38de98cf7a0](https://zen-api-production-4c98.up.railway.app/dashboard/#/chat/zen-cron-c38de98cf7a0)
Triggered by: karan@composio.dev | Source: cron
Session: https://zen-api-production-4c98.up.railway.app/dashboard/#/chat/zen-cron-c38de98cf7a0