### PR TITLE
fix(core): normalize empty output_parameters so MCP tools can execute [PLEN-2450]

### DIFF
--- a/.changeset/fix-mcp-empty-output-parameters.md
+++ b/.changeset/fix-mcp-empty-output-parameters.md
@@ -1,0 +1,11 @@
+---
+'@composio/core': patch
+---
+
+Fix `tools.execute` (and `tools.get` / `tools.list`) failing with a `ZodError` for every tool from an MCP-backed toolkit (e.g. `granola_mcp`, `apify_mcp`, `tavily_mcp`).
+
+MCP toolkits don't declare an output schema, and the Composio API serializes that as `output_parameters: {}`. The SDK's `ParametersSchema` required `{ type: 'object', properties: {...} }`, so `transformToolCases` rejected the response and `getRawComposioToolBySlug` — called by `execute` and the list path — threw.
+
+The SDK now normalizes empty (`{}`), `null`, and missing `input_parameters` / `output_parameters` payloads to `undefined` before validation. `outputParameters` was already declared `.optional()` in the public `Tool` type, so this preserves the contract: "undefined means no declared schema." Tools that *do* declare a schema continue to be validated strictly.
+
+No public API change; no toolkit allow-list.

--- a/ts/packages/core/src/models/Tools.ts
+++ b/ts/packages/core/src/models/Tools.ts
@@ -65,6 +65,29 @@ type ToolRouterSessionExecuteOptions = {
   experimental?: SessionExecuteParams.Experimental;
 };
 
+type RawToolParameters =
+  | ToolRetrieveResponse['input_parameters']
+  | ComposioToolListResponse['items'][0]['input_parameters'];
+
+/**
+ * Normalize a raw `input_parameters` / `output_parameters` payload returned by
+ * the Composio API. Maps `null`, `undefined`, and empty `{}` — all of which
+ * mean "no declared schema" — to `undefined` so the strict `ParametersSchema`
+ * validator never sees them. Non-empty objects pass through unchanged and
+ * remain subject to strict Zod validation.
+ *
+ * MCP-backed toolkits (granola_mcp, apify_mcp, tavily_mcp, …) have no
+ * declared output schema and the API serializes that as `{}`, which would
+ * otherwise trip `ParametersSchema`. See
+ * https://github.com/ComposioHQ/composio/issues/3354.
+ */
+function normalizeRawToolParameters(
+  params: RawToolParameters | null | undefined
+): RawToolParameters | undefined {
+  if (params == null || Object.keys(params).length === 0) return undefined;
+  return params;
+}
+
 /**
  * This class is used to manage tools in the Composio SDK.
  * It provides methods to list, get, and execute tools.
@@ -142,8 +165,8 @@ export class Tools<
   ): Tool {
     return ToolSchema.parse({
       ...tool,
-      inputParameters: tool.input_parameters,
-      outputParameters: tool.output_parameters,
+      inputParameters: normalizeRawToolParameters(tool.input_parameters),
+      outputParameters: normalizeRawToolParameters(tool.output_parameters),
       availableVersions: tool.available_versions,
       isDeprecated: tool.deprecated?.is_deprecated ?? false,
       isNoAuth: tool.no_auth,

--- a/ts/packages/core/test/tools/tools.test.ts
+++ b/ts/packages/core/test/tools/tools.test.ts
@@ -544,6 +544,65 @@ describe('Tools', () => {
     });
   });
 
+  // MCP-backed toolkits (granola_mcp, apify_mcp, tavily_mcp, …) have no
+  // declared output schema, so the Composio API returns
+  // output_parameters: {}. Before the fix, transformToolCases ran that
+  // through ParametersSchema (which requires { type: 'object', properties:
+  // {...} }) and threw a ZodError, breaking every tools.execute /
+  // tools.list call for these toolkits. See
+  // https://github.com/ComposioHQ/composio/issues/3354.
+  describe('MCP-shaped tool metadata', () => {
+    it('should normalize output_parameters: {} to undefined on the transformed Tool', async () => {
+      const slug = 'GRANOLA_MCP_LIST_MEETINGS';
+      mockClient.tools.retrieve.mockResolvedValueOnce(toolMocks.mcpRawTool);
+
+      const tool = await context.tools.getRawComposioToolBySlug(slug);
+
+      expect(tool.outputParameters).toBeUndefined();
+      expect(tool.inputParameters).toEqual(toolMocks.mcpRawTool.input_parameters);
+    });
+
+    it('should normalize both empty input and output parameters to undefined', async () => {
+      const slug = 'SOME_MCP_PING';
+      mockClient.tools.retrieve.mockResolvedValueOnce(toolMocks.mcpRawToolBothEmpty);
+
+      const tool = await context.tools.getRawComposioToolBySlug(slug);
+
+      expect(tool.inputParameters).toBeUndefined();
+      expect(tool.outputParameters).toBeUndefined();
+    });
+
+    it('should also tolerate empty output_parameters in tools.list responses', async () => {
+      mockClient.tools.list.mockResolvedValueOnce({
+        items: [toolMocks.mcpRawTool],
+        totalPages: 1,
+      });
+
+      const result = await context.tools.getRawComposioTools({ toolkits: ['granola_mcp'] });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].slug).toEqual('GRANOLA_MCP_LIST_MEETINGS');
+      expect(result[0].outputParameters).toBeUndefined();
+      expect(result[0].inputParameters).toEqual(toolMocks.mcpRawTool.input_parameters);
+    });
+
+    it('should execute an MCP tool whose metadata has empty output_parameters', async () => {
+      // End-to-end: tools.execute → getRawComposioToolBySlug →
+      // transformToolCases → executeComposioTool → client.tools.execute.
+      mockClient.tools.retrieve.mockResolvedValueOnce(toolMocks.mcpRawTool);
+      mockClient.tools.execute.mockResolvedValueOnce(toolMocks.rawToolExecuteResponse);
+
+      const result = await context.tools.execute('GRANOLA_MCP_LIST_MEETINGS', {
+        userId: 'pg-test-9f4d0df7-a59d-4341-ad00-887b2c58004b',
+        arguments: { time_range: 'last_30_days' },
+        version: '20260206_00',
+      });
+
+      expect(mockClient.tools.execute).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(toolMocks.toolExecuteResponse);
+    });
+  });
+
   describe('get', () => {
     it('should get a single tool by slug and wrap it with provider as a collection', async () => {
       const userId = 'test-user';

--- a/ts/packages/core/test/utils/mocks/data.mock.ts
+++ b/ts/packages/core/test/utils/mocks/data.mock.ts
@@ -90,6 +90,47 @@ export const toolMocks = {
       additionalProperties: false,
     },
   },
+  // Fixture for the MCP-shaped metadata regression tests (see
+  // normalizeRawToolParameters in models/Tools.ts).
+  mcpRawTool: {
+    slug: 'GRANOLA_MCP_LIST_MEETINGS',
+    name: 'List Meetings',
+    description: 'Lists Granola meetings via MCP',
+    input_parameters: {
+      type: 'object',
+      properties: {
+        time_range: {
+          type: 'string',
+          description: 'Window to query',
+        },
+      },
+      additionalProperties: false,
+    },
+    output_parameters: {},
+    toolkit: {
+      logo: 'https://example.com/granola.png',
+      slug: 'granola_mcp',
+      name: 'Granola MCP',
+    },
+    version: '20260206_00',
+  },
+
+  // Both inputs and outputs empty — pins the both-empty branch of
+  // normalizeRawToolParameters.
+  mcpRawToolBothEmpty: {
+    slug: 'SOME_MCP_PING',
+    name: 'Ping',
+    description: 'Trivial MCP tool with no inputs and no outputs',
+    input_parameters: {},
+    output_parameters: {},
+    toolkit: {
+      logo: 'https://example.com/x.png',
+      slug: 'some_mcp',
+      name: 'Some MCP',
+    },
+    version: '20260206_00',
+  },
+
   // transformed response from the sdk
   toolExecuteResponse: {
     data: {


### PR DESCRIPTION
Closes [PLEN-2450](https://linear.app/composio/issue/PLEN-2450/toolsexecute-fails-for-all-mcp-toolkits-strict-zod-validation-rejects) · refs https://github.com/ComposioHQ/composio/issues/3354

## Summary

`composio.tools.execute('<MCP_TOOL>', ...)` currently throws a `ZodError` for **every** tool from an MCP-backed toolkit (`granola_mcp`, `apify_mcp`, `tavily_mcp`, …) on `@composio/core` 0.6.x–0.9.x. The reporter on #3354 confirmed all three versions hit the identical failure; users are working around it by dropping to `@composio/client` and losing modifiers, custom-tool routing, version checks, and provider wrapping.

**Root cause** (`ts/packages/core/src/models/Tools.ts` + `src/types/tool.types.ts`):
- `tools.execute` and `tools.get` both run the API response through `transformToolCases → ToolSchema.parse`.
- `ParametersSchema` requires `{ type: 'object', properties: {...} }`.
- The API returns `output_parameters: {}` for MCP tools that have no declared output schema, so the validator throws.

**Fix:** a tiny module-private `normalizeRawToolParameters` helper applied to both `input_parameters` and `output_parameters` inside `transformToolCases`. `null` / `undefined` / `{}` all map to `undefined`; everything else passes through to strict Zod validation. This:

- Preserves the existing `outputParameters: undefined` ⇒ "no declared schema" contract — `outputParameters` was already optional in the public `Tool` type, so no public API change.
- Fixes both `tools.execute` and `tools.list` (single funnel covers both paths).
- Doesn't relax `ParametersSchema` — tools that actually declare a schema remain strictly validated.
- Forward-compatible for every present / future `*_mcp` toolkit with no toolkit allow-list.

## Testing

Red → green confirmed locally. New `describe('MCP-shaped tool metadata (PLEN-2450)')` block in `tools.test.ts` covers:

1. `getRawComposioToolBySlug` does not throw `ZodError` for `output_parameters: {}`.
2. Empty `output_parameters` is normalized to `undefined` on the transformed `Tool`.
3. Both-empty edge case (`input_parameters: {}` + `output_parameters: {}`).
4. `tools.list` path also tolerates empty `output_parameters`.
5. End-to-end `tools.execute` succeeds against an MCP-shaped fixture.

All five tests **fail** on `next` without the helper (reproducing the exact `ZodError` from the report) and **pass** with it. Full `@composio/core` suite: **904 / 904 green**.

```bash
cd ts/packages/core
pnpm vitest run tools.test -t "MCP-shaped tool metadata"   # → PASS (5) FAIL (0)
pnpm vitest run                                            # → PASS (904) FAIL (0)
```

## Test plan

- [x] Red phase confirmed: 5 new tests fail with the exact `ZodError` from the report.
- [x] Green phase confirmed: 5 new tests pass after the helper lands.
- [x] Full `@composio/core` test suite stays green (904 tests).
- [x] `pnpm typecheck` clean.
- [ ] Optional live sanity: build a tarball and run the reporter's `repro.mjs` against a sandbox user (`pg-test-9f4d0df7-…`) — not blocking; the mocked end-to-end test pins the same path.

## Follow-ups (out of scope)

- **Python SDK** — verify whether `composio` Python has the same over-strict Pydantic check and apply the equivalent normalization if so.

> Note: not proposing an API-side change. `output_parameters: {}` is the correct JSON Schema for "no declared schema" (the empty schema validates anything); the bug was the SDK's Zod validator being over-strict, not the API. The fix belongs at the SDK layer, where it now lives.
