### PR TITLE
fix(python): guard enhance_schema_descriptions against empty schemas

### DIFF
--- a/.changeset/fix-mcp-empty-output-parameters.md
+++ b/.changeset/fix-mcp-empty-output-parameters.md
@@ -1,0 +1,11 @@
+---
+'@composio/core': patch
+---
+
+Fix `tools.execute` (and `tools.get` / `tools.list`) failing with a `ZodError` for every tool from an MCP-backed toolkit (e.g. `granola_mcp`, `apify_mcp`, `tavily_mcp`).
+
+MCP toolkits don't declare an output schema, and the Composio API serializes that as `output_parameters: {}`. The SDK's `ParametersSchema` required `{ type: 'object', properties: {...} }`, so `transformToolCases` rejected the response and `getRawComposioToolBySlug` — called by `execute` and the list path — threw.
+
+The SDK now normalizes empty (`{}`), `null`, and missing `input_parameters` / `output_parameters` payloads to `undefined` before validation. `outputParameters` was already declared `.optional()` in the public `Tool` type, so this preserves the contract: "undefined means no declared schema." Tools that *do* declare a schema continue to be validated strictly.
+
+No public API change; no toolkit allow-list.

--- a/python/composio/core/models/_files.py
+++ b/python/composio/core/models/_files.py
@@ -732,7 +732,13 @@ class FileHelper(WithLogger):
 
         This is separate from file processing and should always run
         regardless of `dangerously_allow_auto_upload_download_files`.
+
+        Schemas with no `properties` key (e.g. `{}` for tools that declare
+        no input parameters — common with MCP-backed toolkits) are returned
+        unchanged, matching the sibling `process_file_uploadable_schema`.
         """
+        if "properties" not in schema:
+            return schema
         required = schema.get("required") or []
         for _param, _schema in schema["properties"].items():
             if _schema.get("type") in ["string", "integer", "number", "boolean"]:

--- a/python/tests/test_files.py
+++ b/python/tests/test_files.py
@@ -2123,3 +2123,69 @@ class TestFileDownloadablePathTraversal:
         # but no file was written inside it.
         assert outdir.is_dir()
         assert list(outdir.iterdir()) == []
+
+
+class TestEnhanceSchemaDescriptionsEmptySchema:
+    """Regression tests for the empty-input-parameters crash.
+
+    MCP-backed toolkits can return `input_parameters: {}` for tools with no
+    required arguments (the same convention the API uses for missing output
+    schemas). Before the fix, `FileHelper.enhance_schema_descriptions` —
+    called unconditionally on every fetched tool's input_parameters from
+    `Tools._get()` — raised `KeyError: 'properties'` on that shape,
+    crashing the public `Composio.tools.get(...)` call.
+
+    The sibling `FileHelper.process_file_uploadable_schema` already guarded
+    this with `if "properties" not in schema: return schema`. This adds the
+    same guard to `enhance_schema_descriptions`.
+
+    See https://github.com/ComposioHQ/composio/issues/3354 for the related
+    TS-side issue.
+    """
+
+    def test_empty_schema_does_not_raise(self, file_helper):
+        """schema={} must not raise — it means 'no declared schema'."""
+        # Pre-fix: KeyError: 'properties'
+        result = file_helper.enhance_schema_descriptions(schema={})
+        assert result == {}
+
+    def test_schema_without_properties_returns_unchanged(self, file_helper):
+        """A schema with metadata but no `properties` key is returned as-is.
+
+        Mirrors how `process_file_uploadable_schema` treats the same input.
+        """
+        schema = {"type": "object", "additionalProperties": False}
+        result = file_helper.enhance_schema_descriptions(schema=schema)
+        assert result == {"type": "object", "additionalProperties": False}
+
+    def test_schema_with_empty_properties_dict_is_handled(self, file_helper):
+        """`properties: {}` is valid JSON Schema (declares no fields).
+
+        The loop iterates zero times and the schema is returned unchanged.
+        """
+        schema = {"type": "object", "properties": {}}
+        result = file_helper.enhance_schema_descriptions(schema=schema)
+        assert result == {"type": "object", "properties": {}}
+
+    def test_populated_schema_still_enhanced(self, file_helper):
+        """Non-empty schemas continue to receive type-hint enhancements.
+
+        Guard against regressing the enhancement behavior while fixing
+        the empty-schema crash.
+        """
+        schema = {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Search term"},
+            },
+            "required": ["query"],
+        }
+        result = file_helper.enhance_schema_descriptions(schema=schema)
+        description = result["properties"]["query"]["description"]
+        # The description must have been mutated from the input and must
+        # mention the type and the required-marker. Assertions are token-
+        # based to avoid coupling to the exact phrasing in
+        # enhance_schema_descriptions.
+        assert description != "Search term"
+        assert "string" in description
+        assert "required" in description

--- a/ts/packages/core/src/models/Tools.ts
+++ b/ts/packages/core/src/models/Tools.ts
@@ -65,6 +65,29 @@ type ToolRouterSessionExecuteOptions = {
   experimental?: SessionExecuteParams.Experimental;
 };
 
+type RawToolParameters =
+  | ToolRetrieveResponse['input_parameters']
+  | ComposioToolListResponse['items'][0]['input_parameters'];
+
+/**
+ * Normalize a raw `input_parameters` / `output_parameters` payload returned by
+ * the Composio API. Maps `null`, `undefined`, and empty `{}` — all of which
+ * mean "no declared schema" — to `undefined` so the strict `ParametersSchema`
+ * validator never sees them. Non-empty objects pass through unchanged and
+ * remain subject to strict Zod validation.
+ *
+ * MCP-backed toolkits (granola_mcp, apify_mcp, tavily_mcp, …) have no
+ * declared output schema and the API serializes that as `{}`, which would
+ * otherwise trip `ParametersSchema`. See
+ * https://github.com/ComposioHQ/composio/issues/3354.
+ */
+function normalizeRawToolParameters(
+  params: RawToolParameters | null | undefined
+): RawToolParameters | undefined {
+  if (params == null || Object.keys(params).length === 0) return undefined;
+  return params;
+}
+
 /**
  * This class is used to manage tools in the Composio SDK.
  * It provides methods to list, get, and execute tools.
@@ -142,8 +165,8 @@ export class Tools<
   ): Tool {
     return ToolSchema.parse({
       ...tool,
-      inputParameters: tool.input_parameters,
-      outputParameters: tool.output_parameters,
+      inputParameters: normalizeRawToolParameters(tool.input_parameters),
+      outputParameters: normalizeRawToolParameters(tool.output_parameters),
       availableVersions: tool.available_versions,
       isDeprecated: tool.deprecated?.is_deprecated ?? false,
       isNoAuth: tool.no_auth,

--- a/ts/packages/core/test/tools/tools.test.ts
+++ b/ts/packages/core/test/tools/tools.test.ts
@@ -544,6 +544,65 @@ describe('Tools', () => {
     });
   });
 
+  // MCP-backed toolkits (granola_mcp, apify_mcp, tavily_mcp, …) have no
+  // declared output schema, so the Composio API returns
+  // output_parameters: {}. Before the fix, transformToolCases ran that
+  // through ParametersSchema (which requires { type: 'object', properties:
+  // {...} }) and threw a ZodError, breaking every tools.execute /
+  // tools.list call for these toolkits. See
+  // https://github.com/ComposioHQ/composio/issues/3354.
+  describe('MCP-shaped tool metadata', () => {
+    it('should normalize output_parameters: {} to undefined on the transformed Tool', async () => {
+      const slug = 'GRANOLA_MCP_LIST_MEETINGS';
+      mockClient.tools.retrieve.mockResolvedValueOnce(toolMocks.mcpRawTool);
+
+      const tool = await context.tools.getRawComposioToolBySlug(slug);
+
+      expect(tool.outputParameters).toBeUndefined();
+      expect(tool.inputParameters).toEqual(toolMocks.mcpRawTool.input_parameters);
+    });
+
+    it('should normalize both empty input and output parameters to undefined', async () => {
+      const slug = 'SOME_MCP_PING';
+      mockClient.tools.retrieve.mockResolvedValueOnce(toolMocks.mcpRawToolBothEmpty);
+
+      const tool = await context.tools.getRawComposioToolBySlug(slug);
+
+      expect(tool.inputParameters).toBeUndefined();
+      expect(tool.outputParameters).toBeUndefined();
+    });
+
+    it('should also tolerate empty output_parameters in tools.list responses', async () => {
+      mockClient.tools.list.mockResolvedValueOnce({
+        items: [toolMocks.mcpRawTool],
+        totalPages: 1,
+      });
+
+      const result = await context.tools.getRawComposioTools({ toolkits: ['granola_mcp'] });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].slug).toEqual('GRANOLA_MCP_LIST_MEETINGS');
+      expect(result[0].outputParameters).toBeUndefined();
+      expect(result[0].inputParameters).toEqual(toolMocks.mcpRawTool.input_parameters);
+    });
+
+    it('should execute an MCP tool whose metadata has empty output_parameters', async () => {
+      // End-to-end: tools.execute → getRawComposioToolBySlug →
+      // transformToolCases → executeComposioTool → client.tools.execute.
+      mockClient.tools.retrieve.mockResolvedValueOnce(toolMocks.mcpRawTool);
+      mockClient.tools.execute.mockResolvedValueOnce(toolMocks.rawToolExecuteResponse);
+
+      const result = await context.tools.execute('GRANOLA_MCP_LIST_MEETINGS', {
+        userId: 'pg-test-9f4d0df7-a59d-4341-ad00-887b2c58004b',
+        arguments: { time_range: 'last_30_days' },
+        version: '20260206_00',
+      });
+
+      expect(mockClient.tools.execute).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(toolMocks.toolExecuteResponse);
+    });
+  });
+
   describe('get', () => {
     it('should get a single tool by slug and wrap it with provider as a collection', async () => {
       const userId = 'test-user';

--- a/ts/packages/core/test/utils/mocks/data.mock.ts
+++ b/ts/packages/core/test/utils/mocks/data.mock.ts
@@ -90,6 +90,47 @@ export const toolMocks = {
       additionalProperties: false,
     },
   },
+  // Fixture for the MCP-shaped metadata regression tests (see
+  // normalizeRawToolParameters in models/Tools.ts).
+  mcpRawTool: {
+    slug: 'GRANOLA_MCP_LIST_MEETINGS',
+    name: 'List Meetings',
+    description: 'Lists Granola meetings via MCP',
+    input_parameters: {
+      type: 'object',
+      properties: {
+        time_range: {
+          type: 'string',
+          description: 'Window to query',
+        },
+      },
+      additionalProperties: false,
+    },
+    output_parameters: {},
+    toolkit: {
+      logo: 'https://example.com/granola.png',
+      slug: 'granola_mcp',
+      name: 'Granola MCP',
+    },
+    version: '20260206_00',
+  },
+
+  // Both inputs and outputs empty — pins the both-empty branch of
+  // normalizeRawToolParameters.
+  mcpRawToolBothEmpty: {
+    slug: 'SOME_MCP_PING',
+    name: 'Ping',
+    description: 'Trivial MCP tool with no inputs and no outputs',
+    input_parameters: {},
+    output_parameters: {},
+    toolkit: {
+      logo: 'https://example.com/x.png',
+      slug: 'some_mcp',
+      name: 'Some MCP',
+    },
+    version: '20260206_00',
+  },
+
   // transformed response from the sdk
   toolExecuteResponse: {
     data: {


### PR DESCRIPTION
Stacked on #3397 · refs https://github.com/ComposioHQ/composio/issues/3354

## Summary

The TS fix in #3397 handled the reported case (`output_parameters: {}` from MCP toolkits) by normalizing empty schemas at `transformToolCases`. While verifying the Python SDK didn't have the equivalent Zod check, I found an **adjacent** crash on the input side.

The Python SDK does not have the same Pydantic check** — `composio_client` types `input_parameters` / `output_parameters` as `Dict[str, Optional[object]]`, which accepts `{}` trivially.
However, `Tools._get()` pipes every fetched tool's `input_parameters` unconditionally through `FileHelper.enhance_schema_descriptions` (`python/composio/core/models/tools.py:361-363`), which does:

```python
for _param, _schema in schema["properties"].items():
```

That crashes with `KeyError: 'properties'` on `schema={}`. Not reachable for the specific `granola_mcp` tools in the original report (they all have populated `input_parameters`), but it's the same API contract — any MCP tool with no required inputs would hit this through the public `Composio.tools.get(...)` call.

The sibling `FileHelper.process_file_uploadable_schema` (`_files.py:760`) already guards this with `if "properties" not in schema: return schema`. This applies the same guard to `enhance_schema_descriptions`.

## Fix

```diff
 def enhance_schema_descriptions(self, schema: t.Dict) -> t.Dict:
     ...
+    if "properties" not in schema:
+        return schema
     required = schema.get("required") or []
     for _param, _schema in schema["properties"].items():
```

## Testing

Red → green confirmed locally. New `TestEnhanceSchemaDescriptionsEmptySchema` class in `tests/test_files.py` covers:

1. `schema={}` → returns `{}` (the bug repro).
2. Schema with metadata but no `properties` key → returned unchanged (mirrors the sibling method).
3. Schema with `properties: {}` (empty dict) → already works today; pinning behavior.
4. Populated schema → still enhanced (regression guard for the type-hint / required-marker enhancement).

Cases 1–2 **fail on `next`** with `KeyError: 'properties'`. All 4 pass with the guard. Full `tests/test_files.py` stays green (116 tests).

```bash
cd python
.venv/bin/python -m pytest tests/test_files.py::TestEnhanceSchemaDescriptionsEmptySchema -v   # → 4 passed
.venv/bin/python -m pytest tests/test_files.py -q                                              # → 116 passed
```

## Stacked PR notes

- Base: `jkomyno/fix-mcp-empty-output-parameters` (#3397).
- This PR's diff against that base shows **only** the Python changes (`_files.py` + `tests/test_files.py`).
- After #3397 merges, this should be retargeted to `next` (or rebased automatically by GitHub).
