### PR TITLE
chore: change @composio/core version bump from minor to patch

### DIFF
--- a/.changeset/connected-accounts-acl.md
+++ b/.changeset/connected-accounts-acl.md
@@ -1,5 +1,5 @@
 ---
-'@composio/core': minor
+'@composio/core': patch
 ---
 
 Add `accountType` and per-user ACL support for SHARED connected accounts.


### PR DESCRIPTION
# Description

Demote the `connected-accounts-acl` changeset from `minor` to `patch` for `@composio/core`.

Duplicate of #3403 (by @abir-taheer) — opened so the change can be merged without waiting for review on the original PR.

# How did I test this PR

- Diff is one line in `.changeset/connected-accounts-acl.md` (`'@composio/core': minor` → `'@composio/core': patch`).
- No code, tests, or runtime behavior changed — only the version-bump label that `changeset` reads at release time.
- Worth a human sanity check on the semver call: the underlying changeset description adds a new feature (`accountType` + per-user ACL for SHARED connected accounts), which is conventionally a minor bump. The changeset body itself states "No breaking changes." If we deliberately want to avoid cutting a minor here, patch is fine — just confirming this is intentional.