### PR TITLE
docs(changelog): introduce connected_accounts revoke endpoint

### DIFF
--- a/docs/content/changelog/05-12-26-connected-accounts-revoke.mdx
+++ b/docs/content/changelog/05-12-26-connected-accounts-revoke.mdx
@@ -1,0 +1,60 @@
+---
+title: "New Endpoint: Revoke OAuth 2.0 Tokens for a Connected Account"
+description: "Programmatically revoke a connected account's tokens at the upstream provider"
+date: "2026-05-12"
+---
+
+You can now programmatically revoke a connected account's OAuth 2.0 tokens at the upstream provider, giving you explicit control over when credentials are killed at the third-party — instead of relying on deletion or natural token expiry.
+
+### The Endpoint
+
+```http
+POST /api/v3.1/connected_accounts/{nanoid}/revoke
+```
+
+On success, the connection transitions to `REVOKED` and the response reports which token subjects were killed at the provider on this call.
+
+**Example request:**
+
+```bash
+curl -X POST 'https://backend.composio.dev/api/v3.1/connected_accounts/ca_1a2b3c4d5e6f/revoke' \
+  --header 'x-api-key: <YOUR_API_KEY>'
+```
+
+**Example response (`200 OK`):**
+
+```json
+{
+  "revoked_tokens": ["access_token", "refresh_token"],
+  "connected_account": {
+    "id": "ca_1a2b3c4d5e6f",
+    "status": "REVOKED"
+  }
+}
+```
+
+The `revoked_tokens` array lists the subjects revoked at the provider during this call. An empty array means the connection was already in a revoked state and no upstream dispatch was issued.
+
+### Status Codes
+
+| Code | Meaning |
+|------|---------|
+| `200` | Connection revoked (or already revoked — see `revoked_tokens`) |
+| `400` | Toolkit is not OAuth 2.0 or has no revoke configuration |
+| `404` | Connected account does not exist or its parent auth config was removed |
+| `409` | Connection is not in a revokable state (only `ACTIVE` and already-`REVOKED` are accepted) |
+| `500` | Database failure or every upstream revoke dispatch failed |
+
+### Revoke Is Not Automatic on Delete (Today)
+
+Deleting a connected account or a project does **not** currently revoke tokens at the upstream provider — the credentials are removed from Composio but may remain live at the third-party until they expire naturally. If you need credentials killed at the provider, follow **revoke-then-delete** semantics: call `POST /revoke` first, then issue the delete.
+
+In a future release, we may extend delete to cascade into revoke automatically. We'll announce this separately before changing the behavior; until then, treat the two steps as independent.
+
+### Revoke Is Best-Effort
+
+Some providers do not expose a programmatic way to revoke one or both token subjects (for example, an access token but no refresh-token revoke route, or no revoke endpoint at all). In those cases, Composio revokes whatever the provider supports and the `revoked_tokens` array reflects exactly what was killed. Always read `revoked_tokens` to confirm which subjects were affected — do not assume both `access_token` and `refresh_token` were revoked on every call.
+
+### Externally Revoked Tokens
+
+If a user revokes the connection directly with the provider (for example, removing the app from their account on the provider's website), the upstream revoke call from this endpoint may return an error. Such connections are eventually detected and marked as `EXPIRED` by the platform — you do not need to take additional action, but you should expect the revoke call itself to fail in that window.

--- a/docs/content/changelog/05-12-26-connected-accounts-revoke.mdx
+++ b/docs/content/changelog/05-12-26-connected-accounts-revoke.mdx
@@ -40,16 +40,14 @@ The `revoked_tokens` array lists the subjects revoked at the provider during thi
 | Code | Meaning |
 |------|---------|
 | `200` | Connection revoked (or already revoked — see `revoked_tokens`) |
-| `400` | Toolkit is not OAuth 2.0 or has no revoke configuration |
-| `404` | Connected account does not exist or its parent auth config was removed |
+| `400` | Revoke is not supported for this toolkit |
+| `404` | Connected account does not exist |
 | `409` | Connection is not in a revokable state (only `ACTIVE` and already-`REVOKED` are accepted) |
-| `500` | Database failure or every upstream revoke dispatch failed |
+| `500` | Server error — revocation could not be completed |
 
-### Revoke Is Not Automatic on Delete (Today)
+### Revoke Is Not Automatic on Delete
 
-Deleting a connected account or a project does **not** currently revoke tokens at the upstream provider — the credentials are removed from Composio but may remain live at the third-party until they expire naturally. If you need credentials killed at the provider, follow **revoke-then-delete** semantics: call `POST /revoke` first, then issue the delete.
-
-In a future release, we may extend delete to cascade into revoke automatically. We'll announce this separately before changing the behavior; until then, treat the two steps as independent.
+Deleting a connected account or a project does **not** revoke tokens at the upstream provider — the credentials are removed from Composio but may remain live at the third-party until they expire naturally. If you need credentials killed at the provider, follow **revoke-then-delete** semantics: call `POST /revoke` first, then issue the delete.
 
 ### Revoke Is Best-Effort
 
@@ -57,4 +55,4 @@ Some providers do not expose a programmatic way to revoke one or both token subj
 
 ### Externally Revoked Tokens
 
-If a user revokes the connection directly with the provider (for example, removing the app from their account on the provider's website), the upstream revoke call from this endpoint may return an error. Such connections are eventually detected and marked as `EXPIRED` by the platform — you do not need to take additional action, but you should expect the revoke call itself to fail in that window.
+If a user revokes the connection directly with the provider (for example, removing the app from their account on the provider's website), the upstream revoke call from this endpoint may return an error. Handle this case by treating the connection as already revoked on your side.


### PR DESCRIPTION
# Description

Adds a customer-facing changelog entry announcing the new `POST /api/v3.1/connected_accounts/{nanoid}/revoke` endpoint.

The entry covers:

- The endpoint shape, an example request, and an example `200 OK` response (with the `revoked_tokens` array reflecting which token subjects were killed at the provider on this call)
- Full status code table (`200` / `400` / `404` / `409` / `500`)
- **Revoke-then-delete semantics**: deleting a connected account does NOT currently cascade to upstream revoke — customers should call `/revoke` first if they need credentials killed at the provider. A future release may cascade automatically; we'll announce separately
- **Best-effort behavior**: some providers don't expose revoke for one or both token subjects; customers should always read `revoked_tokens` rather than assume both were revoked
- **Externally revoked tokens**: if a user revokes via the provider's UI, the revoke call may fail — such connections are eventually marked `EXPIRED` by the platform

Endpoint path and response shape verified against `apps/apollo/src/pages/api/v3.1/connected_accounts/[nanoId]/revoke.ts` in hermes.

Follows `docs/.claude/guides/changelog.md` conventions (filename `MM-DD-YY-suffix.mdx`, frontmatter with `title` + `date` + `description`, sections start at `###`, no top-level `#`, no emojis).

> Note: SDK / public OpenAPI visibility for this endpoint is being added in parallel in hermes — by the time this entry publishes, the endpoint will be reachable from `backend.composio.dev` for customer projects.

# How did I test this PR

- Verified file location, filename pattern, and frontmatter against `docs/.claude/guides/changelog.md` and a recent peer entry (`12-30-25-proxy-binary-data.mdx`)
- Cross-checked the documented request path, response schema, and status codes against `apps/apollo/src/pages/api/v3.1/connected_accounts/[nanoId]/revoke.ts` (route definition, `RevokeConnectedAccountResponseSchema`, declared response codes)
- The repo's Fumadocs build (`bun run build`) validates MDX and will catch any syntax / link issues in CI