### PR TITLE
docs(changelog): fix May 8 minimum @composio/core version (0.10.0 → 0.9.1)

### DIFF
--- a/docs/content/changelog/05-08-26-session-use-update-connected-accounts.mdx
+++ b/docs/content/changelog/05-08-26-session-use-update-connected-accounts.mdx
@@ -107,5 +107,5 @@ Only one account per toolkit is allowed when [multi-account mode](/docs/managing
 
 | SDK | Minimum version |
 | --- | --- |
-| TypeScript `@composio/core` | `0.10.0` |
+| TypeScript `@composio/core` | `0.9.1` |
 | Python `composio` | `0.13.0` |


### PR DESCRIPTION
# Description

The May 8 changelog (\`05-08-26-session-use-update-connected-accounts.mdx\`) lists the minimum TypeScript SDK version as \`@composio/core@0.10.0\` for the \`composio.use()\` / \`session.update()\` / \`connectedAccounts\` array changes. That version doesn't exist on npm — the current \`latest\` tag is \`0.9.1\` — and the public surface of \`0.9.1\` already exposes \`Composio.use(id)\`, \`Session.update()\`, and the \`connectedAccounts\` array form.

Verification:

\`\`\`bash
$ npm view @composio/core dist-tags
{ latest: '0.9.1', next: '0.1.36-next.13', ... }

$ npm pack @composio/core@0.9.1
$ tar -xzf composio-core-0.9.1.tgz -C /tmp/c91
$ grep -nE 'use\(id: string|session\.update|connectedAccounts.*ZodUnion' \\
    /tmp/c91/package/dist/*.d.cts | head
dist/composio-BnLWW0B6.d.cts:5125:  use(id: string, options?: { ... }): Promise<Session<...>>;
dist/composio-BnLWW0B6.d.cts:5328:  use: (id: string, options?: { ... }) => Promise<Session<...>>;
dist/customTool.types-BVgnEbR2.d.cts:1057:  connectedAccounts: z\$1.ZodOptional<z\$1.ZodDefault<z\$1.ZodRecord<z\$1.ZodString, z\$1.ZodUnion<[z\$1.ZodString, z\$1.ZodArray<z\$1.ZodString, "many">]>>>>;
\`\`\`

The adjacent May 7 changelog (\`05-07-26-toolrouter-preload-direct-tools.mdx\`) already pins the minimum to \`0.9.0\`, which is consistent with \`0.9.1\` being the shipped release.

# How did I test this PR

- \`grep\` over the unpacked \`@composio/core@0.9.1\` type definitions to confirm the API surface listed in the changelog (\`composio.use()\`, \`session.update()\`, \`connectedAccounts\` as \`string | string[]\`) is present.
- \`npm view\` confirms \`0.9.1\` is \`dist-tags.latest\` and \`0.10.0\` is not yet published.
- Visual diff: only the table cell value changes (`0.10.0` → `0.9.1`); no surrounding prose or code blocks are touched.

If \`0.10.0\` was intentional (e.g. an upcoming release that wasn't cut yet), feel free to close this and we'll re-pin once the package is published.