### PR TITLE
feat(cli): scaffold native UI sidecar

### DIFF
--- a/.github/workflows/build-cli-binaries.yml
+++ b/.github/workflows/build-cli-binaries.yml
@@ -5,6 +5,7 @@ on:
     branches: [next]
     paths:
       - 'ts/packages/cli/**'
+      - 'ts/packages/cli-local-tools/**'
   workflow_dispatch:
     inputs:
       action:
@@ -253,6 +254,7 @@ jobs:
         run: |
           test -x ts/packages/cli-local-tools/local-tools-binaries/beeper-imessage/${{ matrix.local_tools_target }}/imessage-cli
           test -x ts/packages/cli-local-tools/local-tools-binaries/peekaboo/${{ matrix.local_tools_target }}/peekaboo
+          test -x ts/packages/cli-local-tools/local-tools-binaries/composio-native-ui/${{ matrix.local_tools_target }}/composio-native-ui
 
       - name: Cross-compile CLI binary
         working-directory: ts/packages/cli
@@ -289,6 +291,7 @@ jobs:
         run: |
           unzip -Z1 dist/binaries/${{ matrix.artifact }}.zip | grep -F "local-tools-binaries/beeper-imessage/${{ matrix.local_tools_target }}/imessage-cli"
           unzip -Z1 dist/binaries/${{ matrix.artifact }}.zip | grep -F "local-tools-binaries/peekaboo/${{ matrix.local_tools_target }}/peekaboo"
+          unzip -Z1 dist/binaries/${{ matrix.artifact }}.zip | grep -F "local-tools-binaries/composio-native-ui/${{ matrix.local_tools_target }}/composio-native-ui"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v6

--- a/ts/packages/cli-local-tools/local-tools-binaries/.gitignore
+++ b/ts/packages/cli-local-tools/local-tools-binaries/.gitignore
@@ -2,3 +2,4 @@
 # Keep notices/licenses in git, but never commit generated executables.
 /beeper-imessage/darwin-*/imessage-cli
 /peekaboo/darwin-*/peekaboo
+/composio-native-ui/darwin-*/composio-native-ui

--- a/ts/packages/cli-local-tools/local-tools-binaries/README.md
+++ b/ts/packages/cli-local-tools/local-tools-binaries/README.md
@@ -1,6 +1,6 @@
 # Local tool binary assets
 
-Platform-specific executable and dynamic-library assets for first-party local tool integrations are generated into this directory during local-tool binary builds.
+Platform-specific executable and dynamic-library assets for first-party local tool integrations and CLI native sidecars are generated into this directory during local-tool binary builds.
 
 Do not commit generated executables. Keep notices/licenses in git, pin source with git submodules under `ts/packages/cli-local-tools/vendor/`, and regenerate binaries in CLI release jobs before packaging artifacts.
 
@@ -8,6 +8,7 @@ Current native binary sources:
 
 - Beeper iMessage: `vendor/platform-imessage` (`https://github.com/ComposioHQ/platform-imessage`)
 - Peekaboo: `vendor/peekaboo` (`https://github.com/steipete/Peekaboo`)
+- Composio native UI sidecar: `native/composio-native-ui` (in-repository Swift package)
 
 Build macOS sidecars for the current host/target with:
 

--- a/ts/packages/cli-local-tools/local-tools-binaries/composio-native-ui/NOTICE.md
+++ b/ts/packages/cli-local-tools/local-tools-binaries/composio-native-ui/NOTICE.md
@@ -1,0 +1,11 @@
+# Composio native UI sidecar
+
+The `composio-native-ui` binaries are built from the in-repository Swift package at `ts/packages/cli-local-tools/native/composio-native-ui`.
+
+- Purpose: native macOS UI surface that the Bun-compiled Composio CLI can spawn for auth flows, tool pickers, and other desktop affordances.
+- Build command: `pnpm --filter @composio/cli-local-tools build:composio-native-ui -- --target <darwin-arm64|darwin-x64>`
+- Underlying Swift build commands:
+  - `swift build -c release --product composio-native-ui --arch arm64`
+  - `swift build -c release --product composio-native-ui --arch x86_64`
+
+The scaffold currently opens a small AppKit panel near the bottom-right corner of the active screen. Generated executables are intentionally not committed; release jobs rebuild them before packaging CLI artifacts.

--- a/ts/packages/cli-local-tools/native/composio-native-ui/.gitignore
+++ b/ts/packages/cli-local-tools/native/composio-native-ui/.gitignore
@@ -1,0 +1,2 @@
+.build/
+.swiftpm/

--- a/ts/packages/cli-local-tools/native/composio-native-ui/Package.swift
+++ b/ts/packages/cli-local-tools/native/composio-native-ui/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "ComposioNativeUI",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .executable(name: "composio-native-ui", targets: ["ComposioNativeUI"])
+    ],
+    targets: [
+        .executableTarget(
+            name: "ComposioNativeUI",
+            path: "Sources/ComposioNativeUI"
+        )
+    ]
+)

--- a/ts/packages/cli-local-tools/native/composio-native-ui/Sources/ComposioNativeUI/main.swift
+++ b/ts/packages/cli-local-tools/native/composio-native-ui/Sources/ComposioNativeUI/main.swift
@@ -1,0 +1,422 @@
+import AppKit
+import MetalKit
+import QuartzCore
+
+struct Configuration {
+    var title = "Composio"
+    var message = "Native UI sidecar scaffold"
+    var detail = "This window is rendered by a Swift sidecar bundled with the CLI."
+    var width: CGFloat = 560
+    var height: CGFloat = 320
+    var margin: CGFloat = 24
+    var timeoutSeconds: TimeInterval?
+
+    init(arguments: [String]) {
+        var index = 0
+        while index < arguments.count {
+            let argument = arguments[index]
+            let value = index + 1 < arguments.count ? arguments[index + 1] : nil
+
+            switch argument {
+            case "--title":
+                if let value {
+                    title = value
+                    index += 1
+                }
+            case "--message":
+                if let value {
+                    message = value
+                    index += 1
+                }
+            case "--detail":
+                if let value {
+                    detail = value
+                    index += 1
+                }
+            case "--width":
+                if let value, let parsed = Double(value) {
+                    width = CGFloat(parsed)
+                    index += 1
+                }
+            case "--height":
+                if let value, let parsed = Double(value) {
+                    height = CGFloat(parsed)
+                    index += 1
+                }
+            case "--margin":
+                if let value, let parsed = Double(value) {
+                    margin = CGFloat(parsed)
+                    index += 1
+                }
+            case "--timeout":
+                if let value, let parsed = Double(value), parsed > 0 {
+                    timeoutSeconds = parsed
+                    index += 1
+                }
+            case "--help", "-h":
+                print("""
+                Usage: composio-native-ui [options]
+
+                Options:
+                  --title <text>     Window title. Default: Composio
+                  --message <text>   Primary text. Default: Native UI sidecar scaffold
+                  --detail <text>    Secondary text.
+                  --width <points>   Window width. Default: 560
+                  --height <points>  Window height. Default: 320
+                  --margin <points>  Margin from visible screen edges. Default: 24
+                  --timeout <secs>   Auto-close after the given number of seconds.
+                """)
+                Foundation.exit(0)
+            default:
+                break
+            }
+
+            index += 1
+        }
+    }
+}
+
+final class ShaderRenderer: NSObject, MTKViewDelegate {
+    private let commandQueue: MTLCommandQueue
+    private let pipelineState: MTLRenderPipelineState
+    private let startTime = CACurrentMediaTime()
+
+    init?(device: MTLDevice, pixelFormat: MTLPixelFormat) {
+        guard let commandQueue = device.makeCommandQueue() else { return nil }
+        self.commandQueue = commandQueue
+
+        let source = """
+        #include <metal_stdlib>
+        using namespace metal;
+
+        struct VertexOut {
+            float4 position [[position]];
+            float2 uv;
+        };
+
+        vertex VertexOut vertex_main(uint vertexID [[vertex_id]]) {
+            float2 positions[3] = {
+                float2(-1.0, -1.0),
+                float2( 3.0, -1.0),
+                float2(-1.0,  3.0)
+            };
+            VertexOut out;
+            out.position = float4(positions[vertexID], 0.0, 1.0);
+            out.uv = positions[vertexID] * 0.5 + 0.5;
+            return out;
+        }
+
+        float hash21(float2 p) {
+            p = fract(p * float2(123.34, 456.21));
+            p += dot(p, p + 45.32);
+            return fract(p.x * p.y);
+        }
+
+        float noise(float2 p) {
+            float2 i = floor(p);
+            float2 f = fract(p);
+            f = f * f * (3.0 - 2.0 * f);
+            float a = hash21(i);
+            float b = hash21(i + float2(1.0, 0.0));
+            float c = hash21(i + float2(0.0, 1.0));
+            float d = hash21(i + float2(1.0, 1.0));
+            return mix(mix(a, b, f.x), mix(c, d, f.x), f.y);
+        }
+
+        fragment float4 fragment_main(VertexOut in [[stage_in]], constant float &time [[buffer(0)]]) {
+            float2 uv = in.uv;
+            float2 centered = uv - 0.5;
+
+            // Make the liquid field broad instead of squashed/ripple-dense.
+            float2 p = centered;
+            p.x *= 1.10;
+            p.y *= 0.74;
+
+            float t = time * 0.38;
+            float pulse = 0.5 + 0.5 * sin(time * 0.82);
+
+            // Slow domain warp: this gives the water/glass impression without
+            // turning into obvious tight rings.
+            float2 warp = p;
+            warp += 0.080 * float2(
+                sin(p.y * 4.2 + t * 1.7),
+                cos(p.x * 3.8 - t * 1.4)
+            );
+            warp += 0.050 * float2(
+                noise(p * 2.0 + t) - 0.5,
+                noise(p * 2.0 - t + 4.0) - 0.5
+            );
+
+            float sheet = sin((warp.x + warp.y * 0.42) * 8.0 + time * 0.95);
+            sheet += 0.55 * sin((warp.x * -0.55 + warp.y) * 6.2 - time * 0.72);
+            float caustic = smoothstep(0.70, 1.32, sheet);
+            caustic = pow(caustic, 1.8);
+
+            // Extremely soft oval mask. Alpha reaches zero only outside the
+            // visible area, so there should be no readable border or bar.
+            float r = length(float2(centered.x * 0.78, centered.y * 1.12));
+            float edge = smoothstep(1.02, 0.20, r);
+            float edgeFeather = smoothstep(0.0, 0.24, uv.x) * smoothstep(1.0, 0.76, uv.x)
+                              * smoothstep(0.0, 0.22, uv.y) * smoothstep(1.0, 0.78, uv.y);
+
+            float alpha = edge * edgeFeather * (0.22 + 0.10 * pulse + 0.13 * caustic);
+
+            float3 cyan = float3(0.16, 0.78, 1.0);
+            float3 violet = float3(0.55, 0.25, 1.0);
+            float3 warm = float3(1.0, 0.42, 0.72);
+            float colorMix = 0.5 + 0.5 * sin(warp.x * 3.2 + warp.y * 2.0 + time * 0.32);
+            float3 color = mix(violet, cyan, colorMix);
+            color = mix(color, warm, 0.18 + 0.18 * pulse);
+            color += caustic * float3(0.30, 0.42, 0.55);
+
+            return float4(color * alpha, alpha);
+        }
+        """
+
+        do {
+            let library = try device.makeLibrary(source: source, options: nil)
+            let descriptor = MTLRenderPipelineDescriptor()
+            descriptor.vertexFunction = library.makeFunction(name: "vertex_main")
+            descriptor.fragmentFunction = library.makeFunction(name: "fragment_main")
+            descriptor.colorAttachments[0].pixelFormat = pixelFormat
+            descriptor.colorAttachments[0].isBlendingEnabled = true
+            descriptor.colorAttachments[0].sourceRGBBlendFactor = .one
+            descriptor.colorAttachments[0].destinationRGBBlendFactor = .oneMinusSourceAlpha
+            descriptor.colorAttachments[0].sourceAlphaBlendFactor = .one
+            descriptor.colorAttachments[0].destinationAlphaBlendFactor = .oneMinusSourceAlpha
+            self.pipelineState = try device.makeRenderPipelineState(descriptor: descriptor)
+        } catch {
+            fputs("Failed to compile Metal shader: \(error)\n", stderr)
+            return nil
+        }
+
+        super.init()
+    }
+
+    func mtkView(_ view: MTKView, drawableSizeWillChange size: CGSize) {}
+
+    func draw(in view: MTKView) {
+        guard
+            let descriptor = view.currentRenderPassDescriptor,
+            let drawable = view.currentDrawable,
+            let commandBuffer = commandQueue.makeCommandBuffer(),
+            let encoder = commandBuffer.makeRenderCommandEncoder(descriptor: descriptor)
+        else { return }
+
+        var elapsed = Float(CACurrentMediaTime() - startTime)
+        encoder.setRenderPipelineState(pipelineState)
+        encoder.setFragmentBytes(&elapsed, length: MemoryLayout<Float>.stride, index: 0)
+        encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 3)
+        encoder.endEncoding()
+        commandBuffer.present(drawable)
+        commandBuffer.commit()
+    }
+}
+
+@MainActor
+final class SoftGlassView: NSVisualEffectView {
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        blendingMode = .behindWindow
+        material = .hudWindow
+        state = .active
+        wantsLayer = true
+        layer?.opacity = 0.58
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layout() {
+        super.layout()
+
+        let mask = CAGradientLayer()
+        mask.type = .radial
+        mask.frame = bounds
+        mask.startPoint = CGPoint(x: 0.5, y: 0.5)
+        mask.endPoint = CGPoint(x: 1.0, y: 1.0)
+        mask.colors = [
+            NSColor.white.withAlphaComponent(0.86).cgColor,
+            NSColor.white.withAlphaComponent(0.56).cgColor,
+            NSColor.white.withAlphaComponent(0.0).cgColor,
+        ]
+        mask.locations = [0.0, 0.48, 1.0]
+        layer?.mask = mask
+    }
+}
+
+@MainActor
+final class MetalBackgroundView: MTKView {
+    private var shaderRenderer: ShaderRenderer?
+
+    init(frame: CGRect) {
+        let device = MTLCreateSystemDefaultDevice()
+        super.init(frame: frame, device: device)
+
+        wantsLayer = true
+        layer?.isOpaque = false
+        colorPixelFormat = .bgra8Unorm
+        framebufferOnly = false
+        isPaused = false
+        enableSetNeedsDisplay = false
+        preferredFramesPerSecond = 60
+        clearColor = MTLClearColor(red: 0, green: 0, blue: 0, alpha: 0)
+
+        if let device, let renderer = ShaderRenderer(device: device, pixelFormat: colorPixelFormat) {
+            shaderRenderer = renderer
+            delegate = renderer
+        }
+    }
+
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+@MainActor
+final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
+    private let configuration: Configuration
+    private var window: NSWindow?
+
+    init(configuration: Configuration) {
+        self.configuration = configuration
+        super.init()
+    }
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        NSApp.setActivationPolicy(.accessory)
+        createWindow()
+
+        if let timeoutSeconds = configuration.timeoutSeconds {
+            Timer.scheduledTimer(withTimeInterval: timeoutSeconds, repeats: false) { _ in
+                Task { @MainActor in
+                    NSApp.terminate(nil)
+                }
+            }
+        }
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        NSApp.terminate(nil)
+    }
+
+    private func createWindow() {
+        let frame = bottomRightFrame()
+
+        let panel = NSPanel(
+            contentRect: frame,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = false
+        panel.ignoresMouseEvents = true
+        panel.isMovableByWindowBackground = true
+        panel.isFloatingPanel = true
+        panel.animationBehavior = .none
+        panel.level = .floating
+        panel.collectionBehavior = [.moveToActiveSpace, .fullScreenAuxiliary]
+        panel.delegate = self
+        panel.contentView = makeContentView()
+        panel.setFrame(frame, display: true, animate: false)
+        panel.orderFrontRegardless()
+
+        DispatchQueue.main.async { [weak panel] in
+            panel?.setFrame(self.bottomRightFrame(), display: true, animate: false)
+        }
+
+        window = panel
+    }
+
+    private func bottomRightFrame() -> NSRect {
+        let screen = screenForPlacement()
+        let visibleFrame = screen.visibleFrame
+        let size = NSSize(width: configuration.width, height: configuration.height)
+        let origin = NSPoint(
+            x: visibleFrame.maxX - size.width - configuration.margin,
+            y: visibleFrame.minY + configuration.margin
+        )
+        return NSRect(origin: origin, size: size)
+    }
+
+    private func screenForPlacement() -> NSScreen {
+        let mouseLocation = NSEvent.mouseLocation
+        if let containingMouse = NSScreen.screens.first(where: { NSMouseInRect(mouseLocation, $0.frame, false) }) {
+            return containingMouse
+        }
+        return NSScreen.main ?? NSScreen.screens.first ?? NSScreen()
+    }
+
+    private func makeContentView() -> NSView {
+        let root = NSView(frame: NSRect(x: 0, y: 0, width: configuration.width, height: configuration.height))
+        root.wantsLayer = true
+        root.layer?.backgroundColor = NSColor.clear.cgColor
+
+        let glass = SoftGlassView(frame: root.bounds)
+        glass.translatesAutoresizingMaskIntoConstraints = false
+        root.addSubview(glass)
+
+        let background = MetalBackgroundView(frame: root.bounds)
+        background.translatesAutoresizingMaskIntoConstraints = false
+        root.addSubview(background)
+
+        let stack = NSStackView()
+        stack.orientation = .vertical
+        stack.alignment = .centerX
+        stack.spacing = 10
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        let badge = NSTextField(labelWithString: "COMPOSIO")
+        badge.font = NSFont.monospacedSystemFont(ofSize: 11, weight: .semibold)
+        badge.textColor = NSColor.white.withAlphaComponent(0.72)
+        badge.alignment = .center
+
+        let title = NSTextField(labelWithString: configuration.message)
+        title.font = NSFont.systemFont(ofSize: 19, weight: .semibold)
+        title.textColor = NSColor.white
+        title.alignment = .center
+        title.lineBreakMode = .byWordWrapping
+        title.maximumNumberOfLines = 2
+
+        let detail = NSTextField(labelWithString: configuration.detail)
+        detail.font = NSFont.systemFont(ofSize: 13, weight: .regular)
+        detail.textColor = NSColor.white.withAlphaComponent(0.76)
+        detail.alignment = .center
+        detail.lineBreakMode = .byWordWrapping
+        detail.maximumNumberOfLines = 3
+
+        stack.addArrangedSubview(badge)
+        stack.addArrangedSubview(title)
+        stack.addArrangedSubview(detail)
+        root.addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            glass.leadingAnchor.constraint(equalTo: root.leadingAnchor),
+            glass.trailingAnchor.constraint(equalTo: root.trailingAnchor),
+            glass.topAnchor.constraint(equalTo: root.topAnchor),
+            glass.bottomAnchor.constraint(equalTo: root.bottomAnchor),
+
+            background.leadingAnchor.constraint(equalTo: root.leadingAnchor),
+            background.trailingAnchor.constraint(equalTo: root.trailingAnchor),
+            background.topAnchor.constraint(equalTo: root.topAnchor),
+            background.bottomAnchor.constraint(equalTo: root.bottomAnchor),
+
+            stack.centerXAnchor.constraint(equalTo: root.centerXAnchor),
+            stack.centerYAnchor.constraint(equalTo: root.centerYAnchor),
+            stack.widthAnchor.constraint(lessThanOrEqualToConstant: 430),
+            stack.leadingAnchor.constraint(greaterThanOrEqualTo: root.leadingAnchor, constant: 32),
+            stack.trailingAnchor.constraint(lessThanOrEqualTo: root.trailingAnchor, constant: -32),
+        ])
+
+        return root
+    }
+}
+
+let configuration = Configuration(arguments: Array(CommandLine.arguments.dropFirst()))
+let application = NSApplication.shared
+let delegate = AppDelegate(configuration: configuration)
+application.delegate = delegate
+application.run()

--- a/ts/packages/cli-local-tools/native/composio-native-ui/Sources/ComposioNativeUI/main.swift
+++ b/ts/packages/cli-local-tools/native/composio-native-ui/Sources/ComposioNativeUI/main.swift
@@ -6,7 +6,7 @@ struct Configuration {
     // Content (programmatic):
     var tool: String = "GMAIL_GET_PROFILE"
     var account: String = "gmail_pall-seba"
-    var callerAgent: String = "composio"           // claude | codex | openclaw | composio
+    var callerAgent: String? = nil                 // claude | codex | openclaw | composio (omit → CLI mode)
     var callerName: String? = nil                  // overrides agent.displayName
     var title: String? = nil                       // overrides the auto-built title
     var subtitle: String? = nil                    // overrides the auto-built subtitle
@@ -25,8 +25,8 @@ struct Configuration {
     // button press, 1 for dismissed / timeout / window-close.
     var callbackFile: String?
 
-    var resolvedAgent: Agent { Agents.resolve(callerAgent) }
-    var resolvedCallerName: String { callerName ?? resolvedAgent.displayName }
+    var resolvedAgent: Agent? { callerAgent.map(Agents.resolve) }
+    var resolvedCallerName: String { callerName ?? resolvedAgent?.displayName ?? "The composio cli" }
 
     // Sentinel used when no custom --title is supplied; makeContentView
     // builds an attributed string with an inline agent logo at this point.
@@ -54,7 +54,7 @@ struct Configuration {
                 if let value { callerAgent = value; index += 1 }
             case "--caller-name":
                 if let value { callerName = value; index += 1 }
-            case "--title":
+            case "--title", "--message":
                 if let value { title = value; index += 1 }
             case "--subtitle", "--detail":
                 if let value { subtitle = value; index += 1 }
@@ -87,6 +87,7 @@ struct Configuration {
                   --caller-agent <id>       Agent calling the tool. claude | codex | openclaw | composio (default).
                   --caller-name <text>      Override the agent display name shown in the title.
                   --title <text>            Override the auto-built title entirely.
+                  --message <text>          Alias for --title, used by CLI dev previews.
                   --subtitle <text>         Subtitle / description line.
                   --deny-label <text>       Override the "Deny" button label.
                   --allow-session-label <text>
@@ -707,9 +708,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                 titleAttr.addAttribute(.font, value: monoFont,
                                        range: NSRange(r, in: customTitle))
             }
-        } else {
+        } else if let agent = configuration.resolvedAgent {
             // Inline agent logo as the subject of the sentence.
-            if let agentImage = configuration.resolvedAgent.makeImage() {
+            if let agentImage = agent.makeImage() {
                 let attachment = NSTextAttachment()
                 attachment.image = agentImage
                 attachment.bounds = CGRect(x: 0, y: -7, width: 28, height: 28)
@@ -717,6 +718,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                 titleAttr.append(NSAttributedString(string: "  ", attributes: textAttrs))
             }
             titleAttr.append(NSAttributedString(string: "wants to use ", attributes: textAttrs))
+            titleAttr.append(NSAttributedString(string: toolSlug, attributes: monoAttrs))
+        } else {
+            // No caller agent — plain CLI-mode sentence, no inline logo.
+            titleAttr.append(NSAttributedString(string: "The composio cli wants to execute ", attributes: textAttrs))
             titleAttr.append(NSAttributedString(string: toolSlug, attributes: monoAttrs))
         }
 

--- a/ts/packages/cli-local-tools/native/composio-native-ui/Sources/ComposioNativeUI/main.swift
+++ b/ts/packages/cli-local-tools/native/composio-native-ui/Sources/ComposioNativeUI/main.swift
@@ -76,6 +76,8 @@ struct Configuration {
     }
 }
 
+// MARK: - Shader
+
 final class ShaderRenderer: NSObject, MTKViewDelegate {
     private let commandQueue: MTLCommandQueue
     private let pipelineState: MTLRenderPipelineState
@@ -106,13 +108,14 @@ final class ShaderRenderer: NSObject, MTKViewDelegate {
             return out;
         }
 
+        // -- hash / value-noise / fbm --------------------------------
         float hash21(float2 p) {
-            p = fract(p * float2(123.34, 456.21));
-            p += dot(p, p + 45.32);
+            p = fract(p * float2(234.34, 435.345));
+            p += dot(p, p + 34.23);
             return fract(p.x * p.y);
         }
 
-        float noise(float2 p) {
+        float vnoise(float2 p) {
             float2 i = floor(p);
             float2 f = fract(p);
             f = f * f * (3.0 - 2.0 * f);
@@ -123,53 +126,112 @@ final class ShaderRenderer: NSObject, MTKViewDelegate {
             return mix(mix(a, b, f.x), mix(c, d, f.x), f.y);
         }
 
+        // Rotated-octave FBM — kills the obvious axis-aligned grid.
+        float fbm(float2 p) {
+            const float2x2 rot = float2x2(0.80, 0.60, -0.60, 0.80);
+            float v = 0.0;
+            float a = 0.55;
+            for (int i = 0; i < 6; ++i) {
+                v += a * vnoise(p);
+                p = rot * p * 2.05;
+                a *= 0.5;
+            }
+            return v;
+        }
+
+        // IQ cosine palette — iridescent, smooth.
+        float3 palette(float t, float3 a, float3 b, float3 c, float3 d) {
+            return a + b * cos(6.28318 * (c * t + d));
+        }
+
+        // Per-channel soft-light blend (Photoshop formula).
+        float softLight1(float s, float d) {
+            return (s < 0.5)
+                ? d - (1.0 - 2.0 * s) * d * (1.0 - d)
+                : ((d < 0.25)
+                    ? d + (2.0 * s - 1.0) * d * ((16.0 * d - 12.0) * d + 3.0)
+                    : d + (2.0 * s - 1.0) * (sqrt(d) - d));
+        }
+        float3 softLight(float3 s, float3 d) {
+            return float3(softLight1(s.x, d.x),
+                          softLight1(s.y, d.y),
+                          softLight1(s.z, d.z));
+        }
+
+        // Built using Shadertoy idioms: aspect-corrected coords,
+        // domain-warped FBM ("warp the warp"), IQ palette, soft-light
+        // blend over an ink base, vignette, dither, gamma.
         fragment float4 fragment_main(VertexOut in [[stage_in]], constant float &time [[buffer(0)]]) {
+            // Aspect-corrected, centered coords. 560x320 ≈ 1.75 aspect.
             float2 uv = in.uv;
-            float2 centered = uv - 0.5;
+            float aspect = 1.75;
+            float2 p = (uv - 0.5) * float2(aspect, 1.0);
 
-            // Make the liquid field broad instead of squashed/ripple-dense.
-            float2 p = centered;
-            p.x *= 1.10;
-            p.y *= 0.74;
+            float t = time * 0.085;
 
-            float t = time * 0.38;
-            float pulse = 0.5 + 0.5 * sin(time * 0.82);
-
-            // Slow domain warp: this gives the water/glass impression without
-            // turning into obvious tight rings.
-            float2 warp = p;
-            warp += 0.080 * float2(
-                sin(p.y * 4.2 + t * 1.7),
-                cos(p.x * 3.8 - t * 1.4)
+            // -- Warp-the-warp: two layers of vector FBM, then a final field.
+            float2 q = float2(
+                fbm(p * 1.4 + float2(0.0, t * 1.3)),
+                fbm(p * 1.4 + float2(5.2, -t * 1.1))
             );
-            warp += 0.050 * float2(
-                noise(p * 2.0 + t) - 0.5,
-                noise(p * 2.0 - t + 4.0) - 0.5
+            float2 r = float2(
+                fbm(p * 1.9 + 3.4 * q + float2(1.7, 9.2) + t * 0.7),
+                fbm(p * 1.9 + 3.4 * q + float2(8.3, 2.8) - t * 0.6)
             );
+            float f = fbm(p * 2.4 + 4.0 * r);
 
-            float sheet = sin((warp.x + warp.y * 0.42) * 8.0 + time * 0.95);
-            sheet += 0.55 * sin((warp.x * -0.55 + warp.y) * 6.2 - time * 0.72);
-            float caustic = smoothstep(0.70, 1.32, sheet);
-            caustic = pow(caustic, 1.8);
+            // Wisp highlights — narrow ridges where the field crests.
+            float wisps = smoothstep(0.55, 0.92, f);
+            wisps = wisps * wisps;
 
-            // Extremely soft oval mask. Alpha reaches zero only outside the
-            // visible area, so there should be no readable border or bar.
-            float r = length(float2(centered.x * 0.78, centered.y * 1.12));
-            float edge = smoothstep(1.02, 0.20, r);
-            float edgeFeather = smoothstep(0.0, 0.24, uv.x) * smoothstep(1.0, 0.76, uv.x)
-                              * smoothstep(0.0, 0.22, uv.y) * smoothstep(1.0, 0.78, uv.y);
+            // Two IQ palettes layered: a hot magenta/amber and a cool teal/indigo.
+            float3 hot  = palette(0.15 + 0.65 * f + 0.12 * sin(t * 1.7),
+                                  float3(0.55, 0.35, 0.45),
+                                  float3(0.45, 0.32, 0.42),
+                                  float3(1.00, 0.90, 0.85),
+                                  float3(0.00, 0.18, 0.38));
+            float3 cold = palette(0.25 + 0.50 * length(r) - 0.08 * cos(t * 1.1),
+                                  float3(0.20, 0.32, 0.45),
+                                  float3(0.18, 0.28, 0.40),
+                                  float3(1.00, 1.00, 1.10),
+                                  float3(0.55, 0.40, 0.20));
 
-            float alpha = edge * edgeFeather * (0.22 + 0.10 * pulse + 0.13 * caustic);
+            float mixFactor = smoothstep(0.25, 0.85, f + 0.2 * r.x);
+            float3 plasma = mix(cold, hot, mixFactor);
 
-            float3 cyan = float3(0.16, 0.78, 1.0);
-            float3 violet = float3(0.55, 0.25, 1.0);
-            float3 warm = float3(1.0, 0.42, 0.72);
-            float colorMix = 0.5 + 0.5 * sin(warp.x * 3.2 + warp.y * 2.0 + time * 0.32);
-            float3 color = mix(violet, cyan, colorMix);
-            color = mix(color, warm, 0.18 + 0.18 * pulse);
-            color += caustic * float3(0.30, 0.42, 0.55);
+            // Wisp specular highlight — soft white-warm.
+            plasma += wisps * float3(1.05, 0.86, 0.62) * 0.45;
 
-            return float4(color * alpha, alpha);
+            // -- Composition mask: push energy toward the right side
+            //    so the left-aligned text stays readable.
+            float2 c = uv - float2(0.62, 0.45);
+            float radial = exp(-dot(c * float2(0.9, 1.25), c * float2(0.9, 1.25)) * 4.2);
+            float leftFade = smoothstep(-0.35, 0.55, p.x);  // dim left edge
+            float intensity = radial * (0.35 + 0.65 * leftFade);
+
+            // Deep warm ink base — slightly violet so the cool wisps separate.
+            float3 ink = float3(0.030, 0.032, 0.050);
+
+            // Soft-light compose: plasma tints the ink instead of replacing it.
+            float3 color = softLight(plasma * intensity, ink);
+            color = mix(ink, color, 0.55 + 0.45 * intensity);
+
+            // Additive wisp bloom on top — the "spark" highlights.
+            color += wisps * intensity * float3(1.0, 0.78, 0.52) * 0.35;
+
+            // Vignette (Shadertoy idiom, but aspect aware).
+            float2 vv = uv * (1.0 - uv.yx);
+            float vig = pow(clamp(vv.x * vv.y * 16.0, 0.0, 1.0), 0.32);
+            color *= 0.55 + 0.50 * vig;
+
+            // Dither + grain — kills banding, adds film-tooth.
+            float n = hash21(in.position.xy + time * 60.0);
+            color += (n - 0.5) * 0.022;
+
+            // Gentle gamma — preserves blacks for UI readability.
+            color = pow(max(color, 0.0), float3(0.94));
+
+            return float4(color, 1.0);
         }
         """
 
@@ -179,11 +241,7 @@ final class ShaderRenderer: NSObject, MTKViewDelegate {
             descriptor.vertexFunction = library.makeFunction(name: "vertex_main")
             descriptor.fragmentFunction = library.makeFunction(name: "fragment_main")
             descriptor.colorAttachments[0].pixelFormat = pixelFormat
-            descriptor.colorAttachments[0].isBlendingEnabled = true
-            descriptor.colorAttachments[0].sourceRGBBlendFactor = .one
-            descriptor.colorAttachments[0].destinationRGBBlendFactor = .oneMinusSourceAlpha
-            descriptor.colorAttachments[0].sourceAlphaBlendFactor = .one
-            descriptor.colorAttachments[0].destinationAlphaBlendFactor = .oneMinusSourceAlpha
+            descriptor.colorAttachments[0].isBlendingEnabled = false
             self.pipelineState = try device.makeRenderPipelineState(descriptor: descriptor)
         } catch {
             fputs("Failed to compile Metal shader: \(error)\n", stderr)
@@ -214,39 +272,6 @@ final class ShaderRenderer: NSObject, MTKViewDelegate {
 }
 
 @MainActor
-final class SoftGlassView: NSVisualEffectView {
-    override init(frame frameRect: NSRect) {
-        super.init(frame: frameRect)
-        blendingMode = .behindWindow
-        material = .hudWindow
-        state = .active
-        wantsLayer = true
-        layer?.opacity = 0.58
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override func layout() {
-        super.layout()
-
-        let mask = CAGradientLayer()
-        mask.type = .radial
-        mask.frame = bounds
-        mask.startPoint = CGPoint(x: 0.5, y: 0.5)
-        mask.endPoint = CGPoint(x: 1.0, y: 1.0)
-        mask.colors = [
-            NSColor.white.withAlphaComponent(0.86).cgColor,
-            NSColor.white.withAlphaComponent(0.56).cgColor,
-            NSColor.white.withAlphaComponent(0.0).cgColor,
-        ]
-        mask.locations = [0.0, 0.48, 1.0]
-        layer?.mask = mask
-    }
-}
-
-@MainActor
 final class MetalBackgroundView: MTKView {
     private var shaderRenderer: ShaderRenderer?
 
@@ -255,13 +280,13 @@ final class MetalBackgroundView: MTKView {
         super.init(frame: frame, device: device)
 
         wantsLayer = true
-        layer?.isOpaque = false
+        layer?.isOpaque = true
         colorPixelFormat = .bgra8Unorm
-        framebufferOnly = false
+        framebufferOnly = true
         isPaused = false
         enableSetNeedsDisplay = false
         preferredFramesPerSecond = 60
-        clearColor = MTLClearColor(red: 0, green: 0, blue: 0, alpha: 0)
+        clearColor = MTLClearColor(red: 0, green: 0, blue: 0, alpha: 1)
 
         if let device, let renderer = ShaderRenderer(device: device, pixelFormat: colorPixelFormat) {
             shaderRenderer = renderer
@@ -273,6 +298,215 @@ final class MetalBackgroundView: MTKView {
         fatalError("init(coder:) has not been implemented")
     }
 }
+
+// MARK: - Tokens
+
+enum Palette {
+    static let amber = NSColor(srgbRed: 0.95, green: 0.71, blue: 0.31, alpha: 1.0)
+    static let amberDeep = NSColor(srgbRed: 0.78, green: 0.50, blue: 0.18, alpha: 1.0)
+    static let inkDeep = NSColor(srgbRed: 0.04, green: 0.04, blue: 0.055, alpha: 1.0)
+    static let textPrimary = NSColor.white
+    static let textSecondary = NSColor.white.withAlphaComponent(0.62)
+    static let textMuted = NSColor.white.withAlphaComponent(0.38)
+    static let hairline = NSColor.white.withAlphaComponent(0.08)
+}
+
+// MARK: - Card chrome
+
+@MainActor
+final class CardView: NSView {
+    private let topHairline = CALayer()
+    private let innerStroke = CAShapeLayer()
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        layer?.cornerRadius = 18
+        layer?.cornerCurve = .continuous
+        layer?.masksToBounds = true
+
+        topHairline.backgroundColor = NSColor.white.withAlphaComponent(0.14).cgColor
+        layer?.addSublayer(topHairline)
+
+        innerStroke.fillColor = NSColor.clear.cgColor
+        innerStroke.strokeColor = NSColor.white.withAlphaComponent(0.06).cgColor
+        innerStroke.lineWidth = 1
+        layer?.addSublayer(innerStroke)
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func layout() {
+        super.layout()
+        topHairline.frame = NSRect(x: 0, y: bounds.height - 1, width: bounds.width, height: 1)
+        innerStroke.frame = bounds
+        innerStroke.path = CGPath(
+            roundedRect: bounds.insetBy(dx: 0.5, dy: 0.5),
+            cornerWidth: 17.5, cornerHeight: 17.5, transform: nil
+        )
+    }
+}
+
+@MainActor
+final class PulsingDot: NSView {
+    private let core = CALayer()
+    private let halo = CALayer()
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+
+        halo.backgroundColor = Palette.amber.withAlphaComponent(0.35).cgColor
+        halo.cornerRadius = 6
+        layer?.addSublayer(halo)
+
+        core.backgroundColor = Palette.amber.cgColor
+        core.cornerRadius = 3
+        core.shadowColor = Palette.amber.cgColor
+        core.shadowOpacity = 0.9
+        core.shadowRadius = 4
+        core.shadowOffset = .zero
+        layer?.addSublayer(core)
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    override var intrinsicContentSize: NSSize { NSSize(width: 12, height: 12) }
+
+    override func layout() {
+        super.layout()
+        let cx = bounds.midX, cy = bounds.midY
+        core.frame = NSRect(x: cx - 3, y: cy - 3, width: 6, height: 6)
+        halo.frame = NSRect(x: cx - 6, y: cy - 6, width: 12, height: 12)
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        guard window != nil else { return }
+        let pulse = CABasicAnimation(keyPath: "opacity")
+        pulse.fromValue = 0.50
+        pulse.toValue = 0.10
+        pulse.duration = 1.6
+        pulse.autoreverses = true
+        pulse.repeatCount = .infinity
+        pulse.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+        halo.add(pulse, forKey: "pulse")
+    }
+}
+
+@MainActor
+final class AccentButton: NSButton {
+    private let action_: () -> Void
+    private let fill = CALayer()
+    private let topGloss = CAGradientLayer()
+    private let glow = CALayer()
+    private var isHovering = false
+    private var isPressed = false
+
+    init(title: String, action: @escaping () -> Void) {
+        self.action_ = action
+        super.init(frame: .zero)
+        self.title = ""
+        isBordered = false
+        wantsLayer = true
+        layer?.masksToBounds = false
+        focusRingType = .none
+
+        glow.backgroundColor = Palette.amber.withAlphaComponent(0.0).cgColor
+        glow.shadowColor = Palette.amber.cgColor
+        glow.shadowOpacity = 0.0
+        glow.shadowRadius = 18
+        glow.shadowOffset = .zero
+        layer?.addSublayer(glow)
+
+        fill.backgroundColor = Palette.amber.cgColor
+        fill.cornerRadius = 11
+        fill.cornerCurve = .continuous
+        layer?.addSublayer(fill)
+
+        topGloss.colors = [
+            NSColor.white.withAlphaComponent(0.28).cgColor,
+            NSColor.white.withAlphaComponent(0.0).cgColor,
+        ]
+        topGloss.startPoint = CGPoint(x: 0.5, y: 1.0)
+        topGloss.endPoint = CGPoint(x: 0.5, y: 0.0)
+        topGloss.cornerRadius = 11
+        topGloss.cornerCurve = .continuous
+        layer?.addSublayer(topGloss)
+
+        let arrow = "\u{2197}"
+        let attr = NSMutableAttributedString(string: title + "  " + arrow, attributes: [
+            .font: NSFont.systemFont(ofSize: 12.5, weight: .semibold),
+            .foregroundColor: NSColor(srgbRed: 0.10, green: 0.07, blue: 0.04, alpha: 1.0),
+            .kern: 0.4,
+        ])
+        attr.addAttribute(.font,
+                          value: NSFont.systemFont(ofSize: 12.5, weight: .medium),
+                          range: NSRange(location: title.count + 2, length: 1))
+        attributedTitle = attr
+
+        target = self
+        self.action = #selector(invoke)
+
+        let tracking = NSTrackingArea(rect: .zero,
+                                      options: [.mouseEnteredAndExited, .inVisibleRect, .activeInActiveApp],
+                                      owner: self, userInfo: nil)
+        addTrackingArea(tracking)
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    override var intrinsicContentSize: NSSize {
+        let base = super.intrinsicContentSize
+        return NSSize(width: base.width + 36, height: 34)
+    }
+
+    override func layout() {
+        super.layout()
+        fill.frame = bounds
+        topGloss.frame = NSRect(x: 0, y: bounds.height * 0.5, width: bounds.width, height: bounds.height * 0.5)
+        glow.frame = bounds
+        glow.shadowPath = CGPath(roundedRect: bounds, cornerWidth: 11, cornerHeight: 11, transform: nil)
+    }
+
+    override func resetCursorRects() {
+        addCursorRect(bounds, cursor: .pointingHand)
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        isHovering = true
+        setState(hover: true, pressed: isPressed)
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        isHovering = false
+        setState(hover: false, pressed: false)
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        isPressed = true
+        setState(hover: isHovering, pressed: true)
+        super.mouseDown(with: event)
+        isPressed = false
+        setState(hover: isHovering, pressed: false)
+    }
+
+    private func setState(hover: Bool, pressed: Bool) {
+        CATransaction.begin()
+        CATransaction.setAnimationDuration(0.14)
+        let scale: CGFloat = pressed ? 0.97 : 1.0
+        layer?.transform = CATransform3DMakeScale(scale, scale, 1)
+        glow.shadowOpacity = hover ? 0.55 : 0.0
+        fill.backgroundColor = (hover
+            ? NSColor(srgbRed: 0.98, green: 0.76, blue: 0.36, alpha: 1.0)
+            : Palette.amber).cgColor
+        CATransaction.commit()
+    }
+
+    @objc private func invoke() { action_() }
+}
+
+// MARK: - App
 
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
@@ -313,7 +547,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         panel.isOpaque = false
         panel.backgroundColor = .clear
         panel.hasShadow = false
-        panel.ignoresMouseEvents = true
+        panel.ignoresMouseEvents = false
         panel.isMovableByWindowBackground = true
         panel.isFloatingPanel = true
         panel.animationBehavior = .none
@@ -354,61 +588,57 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         let root = NSView(frame: NSRect(x: 0, y: 0, width: configuration.width, height: configuration.height))
         root.wantsLayer = true
         root.layer?.backgroundColor = NSColor.clear.cgColor
+        root.layer?.masksToBounds = false
 
-        let glass = SoftGlassView(frame: root.bounds)
-        glass.translatesAutoresizingMaskIntoConstraints = false
-        root.addSubview(glass)
-
-        let background = MetalBackgroundView(frame: root.bounds)
+        let background = MetalBackgroundView(frame: .zero)
         background.translatesAutoresizingMaskIntoConstraints = false
         root.addSubview(background)
 
-        let stack = NSStackView()
-        stack.orientation = .vertical
-        stack.alignment = .centerX
-        stack.spacing = 10
-        stack.translatesAutoresizingMaskIntoConstraints = false
+        // Small label.
+        let kicker = NSTextField(labelWithString: "COMPOSIO WANTS TO RUN")
+        let kickerAttr = NSMutableAttributedString(string: kicker.stringValue, attributes: [
+            .font: NSFont.monospacedSystemFont(ofSize: 10.5, weight: .semibold),
+            .foregroundColor: Palette.textSecondary,
+            .kern: 3.0,
+        ])
+        kicker.attributedStringValue = kickerAttr
+        kicker.alignment = .center
+        kicker.translatesAutoresizingMaskIntoConstraints = false
+        root.addSubview(kicker)
 
-        let badge = NSTextField(labelWithString: "COMPOSIO")
-        badge.font = NSFont.monospacedSystemFont(ofSize: 11, weight: .semibold)
-        badge.textColor = NSColor.white.withAlphaComponent(0.72)
-        badge.alignment = .center
+        // Big headline.
+        let headline = NSTextField(labelWithString: "Read Email")
+        let headlineAttr = NSMutableAttributedString(string: "Read Email", attributes: [
+            .font: NSFont.systemFont(ofSize: 38, weight: .semibold),
+            .foregroundColor: Palette.textPrimary,
+            .kern: -0.6,
+        ])
+        headline.attributedStringValue = headlineAttr
+        headline.alignment = .center
+        headline.translatesAutoresizingMaskIntoConstraints = false
+        root.addSubview(headline)
 
-        let title = NSTextField(labelWithString: configuration.message)
-        title.font = NSFont.systemFont(ofSize: 19, weight: .semibold)
-        title.textColor = NSColor.white
-        title.alignment = .center
-        title.lineBreakMode = .byWordWrapping
-        title.maximumNumberOfLines = 2
-
-        let detail = NSTextField(labelWithString: configuration.detail)
-        detail.font = NSFont.systemFont(ofSize: 13, weight: .regular)
-        detail.textColor = NSColor.white.withAlphaComponent(0.76)
-        detail.alignment = .center
-        detail.lineBreakMode = .byWordWrapping
-        detail.maximumNumberOfLines = 3
-
-        stack.addArrangedSubview(badge)
-        stack.addArrangedSubview(title)
-        stack.addArrangedSubview(detail)
-        root.addSubview(stack)
+        let button = AccentButton(title: "Continue") {
+            fputs("button:continue\n", stdout)
+            fflush(stdout)
+            NSApp.terminate(nil)
+        }
+        button.translatesAutoresizingMaskIntoConstraints = false
+        root.addSubview(button)
 
         NSLayoutConstraint.activate([
-            glass.leadingAnchor.constraint(equalTo: root.leadingAnchor),
-            glass.trailingAnchor.constraint(equalTo: root.trailingAnchor),
-            glass.topAnchor.constraint(equalTo: root.topAnchor),
-            glass.bottomAnchor.constraint(equalTo: root.bottomAnchor),
-
             background.leadingAnchor.constraint(equalTo: root.leadingAnchor),
             background.trailingAnchor.constraint(equalTo: root.trailingAnchor),
             background.topAnchor.constraint(equalTo: root.topAnchor),
             background.bottomAnchor.constraint(equalTo: root.bottomAnchor),
 
-            stack.centerXAnchor.constraint(equalTo: root.centerXAnchor),
-            stack.centerYAnchor.constraint(equalTo: root.centerYAnchor),
-            stack.widthAnchor.constraint(lessThanOrEqualToConstant: 430),
-            stack.leadingAnchor.constraint(greaterThanOrEqualTo: root.leadingAnchor, constant: 32),
-            stack.trailingAnchor.constraint(lessThanOrEqualTo: root.trailingAnchor, constant: -32),
+            kicker.centerXAnchor.constraint(equalTo: root.centerXAnchor),
+            headline.centerXAnchor.constraint(equalTo: root.centerXAnchor),
+            button.centerXAnchor.constraint(equalTo: root.centerXAnchor),
+
+            headline.centerYAnchor.constraint(equalTo: root.centerYAnchor, constant: -10),
+            kicker.bottomAnchor.constraint(equalTo: headline.topAnchor, constant: -14),
+            button.topAnchor.constraint(equalTo: headline.bottomAnchor, constant: 26),
         ])
 
         return root

--- a/ts/packages/cli-local-tools/native/composio-native-ui/Sources/ComposioNativeUI/main.swift
+++ b/ts/packages/cli-local-tools/native/composio-native-ui/Sources/ComposioNativeUI/main.swift
@@ -6,8 +6,10 @@ struct Configuration {
     // Content (programmatic):
     var tool: String = "GMAIL_GET_PROFILE"
     var account: String = "gmail_pall-seba"
-    var title: String? = nil           // overrides the auto-built title
-    var subtitle: String = "Approve once, for the rest of this session, or deny."
+    var callerAgent: String = "composio"           // claude | codex | openclaw | composio
+    var callerName: String? = nil                  // overrides agent.displayName
+    var title: String? = nil                       // overrides the auto-built title
+    var subtitle: String? = nil                    // overrides the auto-built subtitle
     var denyLabel: String = "Deny"
     var allowSessionLabel: String = "Allow for session"
     var allowOnceLabel: String = "Allow once"
@@ -23,9 +25,18 @@ struct Configuration {
     // button press, 1 for dismissed / timeout / window-close.
     var callbackFile: String?
 
+    var resolvedAgent: Agent { Agents.resolve(callerAgent) }
+    var resolvedCallerName: String { callerName ?? resolvedAgent.displayName }
+
+    // Sentinel used when no custom --title is supplied; makeContentView
+    // builds an attributed string with an inline agent logo at this point.
     var resolvedTitle: String {
-        if let title, !title.isEmpty { return title }
-        return "Allow \(tool) on \(account)?"
+        title ?? ""
+    }
+
+    var resolvedSubtitle: String {
+        if let subtitle, !subtitle.isEmpty { return subtitle }
+        return "Approve once, for the rest of this session, or deny."
     }
 
     init(arguments: [String]) {
@@ -39,6 +50,10 @@ struct Configuration {
                 if let value { tool = value; index += 1 }
             case "--account":
                 if let value { account = value; index += 1 }
+            case "--caller-agent", "--agent":
+                if let value { callerAgent = value; index += 1 }
+            case "--caller-name":
+                if let value { callerName = value; index += 1 }
             case "--title":
                 if let value { title = value; index += 1 }
             case "--subtitle", "--detail":
@@ -69,6 +84,8 @@ struct Configuration {
                 Content:
                   --tool <slug>             Tool slug shown in the title. Default: GMAIL_GET_PROFILE
                   --account <name>          Account identifier. Default: gmail_pall-seba
+                  --caller-agent <id>       Agent calling the tool. claude | codex | openclaw | composio (default).
+                  --caller-name <text>      Override the agent display name shown in the title.
                   --title <text>            Override the auto-built title entirely.
                   --subtitle <text>         Subtitle / description line.
                   --deny-label <text>       Override the "Deny" button label.
@@ -254,9 +271,22 @@ final class MetalBackgroundView: MTKView {
 
 // MARK: - Tokens
 
-// Composio logomark — embedded as SVG so the sidecar stays a single binary
-// with no asset bundle. macOS NSImage can decode SVG directly.
-enum Logo {
+// SVG logos for each caller agent — embedded so the sidecar remains a
+// single binary with no asset bundle. macOS NSImage decodes SVG directly.
+
+struct Agent {
+    let id: String
+    let displayName: String
+    let svg: String
+
+    func makeImage() -> NSImage? {
+        guard let data = svg.data(using: .utf8),
+              let image = NSImage(data: data) else { return nil }
+        return image
+    }
+}
+
+enum Agents {
     static let composioSVG = #"""
     <svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
     <g clip-path="url(#clip0_2367_5)">
@@ -271,11 +301,33 @@ enum Logo {
     </svg>
     """#
 
-    static func makeImage() -> NSImage? {
-        guard let data = composioSVG.data(using: .utf8),
-              let image = NSImage(data: data) else { return nil }
-        image.isTemplate = false
-        return image
+    static let claudeSVG = #"""
+    <svg preserveAspectRatio="xMidYMid" viewBox="0 0 256 257" xmlns="http://www.w3.org/2000/svg"><path fill="#D97757" d="m50.228 170.321 50.357-28.257.843-2.463-.843-1.361h-2.462l-8.426-.518-28.775-.778-24.952-1.037-24.175-1.296-6.092-1.297L0 125.796l.583-3.759 5.12-3.434 7.324.648 16.202 1.101 24.304 1.685 17.629 1.037 26.118 2.722h4.148l.583-1.685-1.426-1.037-1.101-1.037-25.147-17.045-27.22-18.017-14.258-10.37-7.713-5.25-3.888-4.925-1.685-10.758 7-7.713 9.397.649 2.398.648 9.527 7.323 20.35 15.75L94.817 91.9l3.889 3.24 1.555-1.102.195-.777-1.75-2.917-14.453-26.118-15.425-26.572-6.87-11.018-1.814-6.61c-.648-2.723-1.102-4.991-1.102-7.778l7.972-10.823L71.42 0 82.05 1.426l4.472 3.888 6.61 15.101 10.694 23.786 16.591 32.34 4.861 9.592 2.592 8.879.973 2.722h1.685v-1.556l1.36-18.211 2.528-22.36 2.463-28.776.843-8.1 4.018-9.722 7.971-5.25 6.222 2.981 5.12 7.324-.713 4.73-3.046 19.768-5.962 30.98-3.889 20.739h2.268l2.593-2.593 10.499-13.934 17.628-22.036 7.778-8.749 9.073-9.657 5.833-4.601h11.018l8.1 12.055-3.628 12.443-11.342 14.388-9.398 12.184-13.48 18.147-8.426 14.518.778 1.166 2.01-.194 30.46-6.481 16.462-2.982 19.637-3.37 8.88 4.148.971 4.213-3.5 8.62-20.998 5.184-24.628 4.926-36.682 8.685-.454.324.519.648 16.526 1.555 7.065.389h17.304l32.21 2.398 8.426 5.574 5.055 6.805-.843 5.184-12.962 6.611-17.498-4.148-40.83-9.721-14-3.5h-1.944v1.167l11.666 11.406 21.387 19.314 26.767 24.887 1.36 6.157-3.434 4.86-3.63-.518-23.526-17.693-9.073-7.972-20.545-17.304h-1.36v1.814l4.73 6.935 25.017 37.59 1.296 11.536-1.814 3.76-6.481 2.268-7.13-1.297-14.647-20.544-15.1-23.138-12.185-20.739-1.49.843-7.194 77.448-3.37 3.953-7.778 2.981-6.48-4.925-3.436-7.972 3.435-15.749 4.148-20.544 3.37-16.333 3.046-20.285 1.815-6.74-.13-.454-1.49.194-15.295 20.999-23.267 31.433-18.406 19.702-4.407 1.75-7.648-3.954.713-7.064 4.277-6.286 25.47-32.405 15.36-20.092 9.917-11.6-.065-1.686h-.583L44.07 198.125l-12.055 1.555-5.185-4.86.648-7.972 2.463-2.593 20.35-13.999-.064.065Z"/></svg>
+    """#
+
+    // Codex glyph — original artwork is white-on-dark; we recolor to near-black
+    // so it reads on the light card without a containing dark plate.
+    static let codexSVG = #"""
+    <svg fill="#0A0A0A" fill-rule="evenodd" style="flex:none;line-height:1" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path clip-rule="evenodd" d="M8.086.457a6.105 6.105 0 013.046-.415c1.333.153 2.521.72 3.564 1.7a.117.117 0 00.107.029c1.408-.346 2.762-.224 4.061.366l.063.03.154.076c1.357.703 2.33 1.77 2.918 3.198.278.679.418 1.388.421 2.126a5.655 5.655 0 01-.18 1.631.167.167 0 00.04.155 5.982 5.982 0 011.578 2.891c.385 1.901-.01 3.615-1.183 5.14l-.182.22a6.063 6.063 0 01-2.934 1.851.162.162 0 00-.108.102c-.255.736-.511 1.364-.987 1.992-1.199 1.582-2.962 2.462-4.948 2.451-1.583-.008-2.986-.587-4.21-1.736a.145.145 0 00-.14-.032c-.518.167-1.04.191-1.604.185a5.924 5.924 0 01-2.595-.622 6.058 6.058 0 01-2.146-1.781c-.203-.269-.404-.522-.551-.821a7.74 7.74 0 01-.495-1.283 6.11 6.11 0 01-.017-3.064.166.166 0 00.008-.074.115.115 0 00-.037-.064 5.958 5.958 0 01-1.38-2.202 5.196 5.196 0 01-.333-1.589 6.915 6.915 0 01.188-2.132c.45-1.484 1.309-2.648 2.577-3.493.282-.188.55-.334.802-.438.286-.12.573-.22.861-.304a.129.129 0 00.087-.087A6.016 6.016 0 015.635 2.31C6.315 1.464 7.132.846 8.086.457zm-.804 7.85a.848.848 0 00-1.473.842l1.694 2.965-1.688 2.848a.849.849 0 001.46.864l1.94-3.272a.849.849 0 00.007-.854l-1.94-3.393zm5.446 6.24a.849.849 0 000 1.695h4.848a.849.849 0 000-1.696h-4.848z"/></svg>
+    """#
+
+    static let openclawSVG = #"""
+    <svg viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg"><defs><linearGradient id="openclaw__lobster-gradient" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#ff4d4d"/><stop offset="100%" stop-color="#991b1b"/></linearGradient></defs><path d="M60 10 C30 10 15 35 15 55 C15 75 30 95 45 100 L45 110 L55 110 L55 100 C55 100 60 102 65 100 L65 110 L75 110 L75 100 C90 95 105 75 105 55 C105 35 90 10 60 10Z" fill="url(#openclaw__lobster-gradient)"/><path d="M20 45 C5 40 0 50 5 60 C10 70 20 65 25 55 C28 48 25 45 20 45Z" fill="url(#openclaw__lobster-gradient)"/><path d="M100 45 C115 40 120 50 115 60 C110 70 100 65 95 55 C92 48 95 45 100 45Z" fill="url(#openclaw__lobster-gradient)"/><path d="M45 15 Q35 5 30 8" stroke="#ff4d4d" stroke-width="3" stroke-linecap="round"/><path d="M75 15 Q85 5 90 8" stroke="#ff4d4d" stroke-width="3" stroke-linecap="round"/><circle cx="45" cy="35" r="6" fill="#050810"/><circle cx="75" cy="35" r="6" fill="#050810"/><circle cx="46" cy="34" r="2.5" fill="#00e5cc"/><circle cx="76" cy="34" r="2.5" fill="#00e5cc"/></svg>
+    """#
+
+    static let composio = Agent(id: "composio", displayName: "Composio", svg: composioSVG)
+    static let claude   = Agent(id: "claude",   displayName: "Claude",   svg: claudeSVG)
+    static let codex    = Agent(id: "codex",    displayName: "Codex",    svg: codexSVG)
+    static let openclaw = Agent(id: "openclaw", displayName: "OpenClaw", svg: openclawSVG)
+
+    static func resolve(_ id: String) -> Agent {
+        switch id.lowercased() {
+        case "claude", "claude-code", "claudecode": return claude
+        case "codex": return codex
+        case "openclaw", "open-claw": return openclaw
+        case "composio", "": return composio
+        default: return composio
+        }
     }
 }
 
@@ -617,49 +669,78 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         wash.translatesAutoresizingMaskIntoConstraints = false
         card.addSubview(wash)
 
-        // --- Logo (left rail).
+        // --- Bottom-left brand mark is always Composio.
         let logoView = NSImageView()
-        logoView.image = Logo.makeImage()
+        logoView.image = Agents.composio.makeImage()
         logoView.imageScaling = .scaleProportionallyUpOrDown
         logoView.imageAlignment = .alignCenter
         logoView.translatesAutoresizingMaskIntoConstraints = false
         card.addSubview(logoView)
 
-        // --- Header: title with inline mono tool slug + account, muted subtitle.
+        // --- Title: "[agent-icon]  wants to use TOOL with ACCOUNT".
+        // Agent logo is inlined into the attributed string via NSTextAttachment,
+        // so it sits on the same baseline as the rest of the title.
         let toolSlug = configuration.tool
         let account = configuration.account
-        let titleString = configuration.resolvedTitle
-        let title = NSTextField(labelWithString: titleString)
-        let titleAttr = NSMutableAttributedString(string: titleString, attributes: [
-            .font: NSFont.systemFont(ofSize: 15, weight: .semibold),
+        let titleFont = NSFont.systemFont(ofSize: 15, weight: .semibold)
+        let monoFont  = NSFont.monospacedSystemFont(ofSize: 13, weight: .semibold)
+        let textAttrs: [NSAttributedString.Key: Any] = [
+            .font: titleFont,
             .foregroundColor: Palette.textPrimary,
             .kern: -0.2,
-        ])
-        let monoFont = NSFont.monospacedSystemFont(ofSize: 13, weight: .semibold)
-        if let slugRange = titleString.range(of: toolSlug) {
-            titleAttr.addAttribute(.font, value: monoFont,
-                                   range: NSRange(slugRange, in: titleString))
+        ]
+        let monoAttrs: [NSAttributedString.Key: Any] = [
+            .font: monoFont,
+            .foregroundColor: Palette.textPrimary,
+        ]
+
+        let titleAttr = NSMutableAttributedString()
+        if let customTitle = configuration.title, !customTitle.isEmpty {
+            // Caller supplied a verbatim title — render as-is, still
+            // monospacing the tool/account if they appear.
+            titleAttr.append(NSAttributedString(string: customTitle, attributes: textAttrs))
+            if let r = customTitle.range(of: toolSlug) {
+                titleAttr.addAttribute(.font, value: monoFont,
+                                       range: NSRange(r, in: customTitle))
+            }
+            if let r = customTitle.range(of: account) {
+                titleAttr.addAttribute(.font, value: monoFont,
+                                       range: NSRange(r, in: customTitle))
+            }
+        } else {
+            // Inline agent logo as the subject of the sentence.
+            if let agentImage = configuration.resolvedAgent.makeImage() {
+                let attachment = NSTextAttachment()
+                attachment.image = agentImage
+                attachment.bounds = CGRect(x: 0, y: -7, width: 28, height: 28)
+                titleAttr.append(NSAttributedString(attachment: attachment))
+                titleAttr.append(NSAttributedString(string: "  ", attributes: textAttrs))
+            }
+            titleAttr.append(NSAttributedString(string: "wants to use ", attributes: textAttrs))
+            titleAttr.append(NSAttributedString(string: toolSlug, attributes: monoAttrs))
         }
-        if let acctRange = titleString.range(of: account) {
-            titleAttr.addAttribute(.font, value: monoFont,
-                                   range: NSRange(acctRange, in: titleString))
-        }
-        title.attributedStringValue = titleAttr
+
+        let title = NSTextField(labelWithAttributedString: titleAttr)
         title.lineBreakMode = .byTruncatingTail
         title.maximumNumberOfLines = 2
         title.translatesAutoresizingMaskIntoConstraints = false
         card.addSubview(title)
 
-        let subtitle = NSTextField(labelWithString: configuration.subtitle)
-        let subtitleAttr = NSMutableAttributedString(string: configuration.subtitle, attributes: [
+        // --- Account line: "Account: <account>"
+        let accountAttr = NSMutableAttributedString()
+        accountAttr.append(NSAttributedString(string: "Account: ", attributes: [
             .font: NSFont.systemFont(ofSize: 12, weight: .regular),
             .foregroundColor: Palette.textSecondary,
-        ])
-        subtitle.attributedStringValue = subtitleAttr
-        subtitle.lineBreakMode = .byWordWrapping
-        subtitle.maximumNumberOfLines = 2
-        subtitle.translatesAutoresizingMaskIntoConstraints = false
-        card.addSubview(subtitle)
+        ]))
+        accountAttr.append(NSAttributedString(string: account, attributes: [
+            .font: NSFont.monospacedSystemFont(ofSize: 12, weight: .semibold),
+            .foregroundColor: Palette.textPrimary,
+        ]))
+        let accountField = NSTextField(labelWithAttributedString: accountAttr)
+        accountField.lineBreakMode = .byTruncatingTail
+        accountField.maximumNumberOfLines = 1
+        accountField.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(accountField)
 
         // --- Three actions matching the elicitation oneOf decisions.
         let denyButton = AccentButton(title: configuration.denyLabel, style: .secondary) {
@@ -717,9 +798,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             title.trailingAnchor.constraint(lessThanOrEqualTo: card.trailingAnchor, constant: -hPad),
             title.topAnchor.constraint(equalTo: card.topAnchor, constant: headerTop),
 
-            subtitle.leadingAnchor.constraint(equalTo: title.leadingAnchor),
-            subtitle.trailingAnchor.constraint(lessThanOrEqualTo: card.trailingAnchor, constant: -hPad),
-            subtitle.topAnchor.constraint(equalTo: title.bottomAnchor, constant: 4),
+            accountField.leadingAnchor.constraint(equalTo: title.leadingAnchor),
+            accountField.trailingAnchor.constraint(lessThanOrEqualTo: card.trailingAnchor, constant: -hPad),
+            accountField.topAnchor.constraint(equalTo: title.bottomAnchor, constant: 6),
 
             buttonRow.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -hPad),
             buttonRow.bottomAnchor.constraint(equalTo: card.bottomAnchor, constant: -bodyBottom),

--- a/ts/packages/cli-local-tools/native/composio-native-ui/Sources/ComposioNativeUI/main.swift
+++ b/ts/packages/cli-local-tools/native/composio-native-ui/Sources/ComposioNativeUI/main.swift
@@ -3,13 +3,30 @@ import MetalKit
 import QuartzCore
 
 struct Configuration {
-    var title = "Composio"
-    var message = "Native UI sidecar scaffold"
-    var detail = "This window is rendered by a Swift sidecar bundled with the CLI."
-    var width: CGFloat = 560
-    var height: CGFloat = 320
+    // Content (programmatic):
+    var tool: String = "GMAIL_GET_PROFILE"
+    var account: String = "gmail_pall-seba"
+    var title: String? = nil           // overrides the auto-built title
+    var subtitle: String = "Approve once, for the rest of this session, or deny."
+    var denyLabel: String = "Deny"
+    var allowSessionLabel: String = "Allow for session"
+    var allowOnceLabel: String = "Allow once"
+
+    // Window:
+    var width: CGFloat = 460
+    var height: CGFloat = 200
     var margin: CGFloat = 24
     var timeoutSeconds: TimeInterval?
+
+    // Result channel: if set, the decision JSON is written to this file path.
+    // Otherwise it is written to stdout. Either way the process exits 0 for a
+    // button press, 1 for dismissed / timeout / window-close.
+    var callbackFile: String?
+
+    var resolvedTitle: String {
+        if let title, !title.isEmpty { return title }
+        return "Allow \(tool) on \(account)?"
+    }
 
     init(arguments: [String]) {
         var index = 0
@@ -18,36 +35,28 @@ struct Configuration {
             let value = index + 1 < arguments.count ? arguments[index + 1] : nil
 
             switch argument {
+            case "--tool":
+                if let value { tool = value; index += 1 }
+            case "--account":
+                if let value { account = value; index += 1 }
             case "--title":
-                if let value {
-                    title = value
-                    index += 1
-                }
-            case "--message":
-                if let value {
-                    message = value
-                    index += 1
-                }
-            case "--detail":
-                if let value {
-                    detail = value
-                    index += 1
-                }
+                if let value { title = value; index += 1 }
+            case "--subtitle", "--detail":
+                if let value { subtitle = value; index += 1 }
+            case "--deny-label":
+                if let value { denyLabel = value; index += 1 }
+            case "--allow-session-label":
+                if let value { allowSessionLabel = value; index += 1 }
+            case "--allow-once-label":
+                if let value { allowOnceLabel = value; index += 1 }
+            case "--callback-file":
+                if let value { callbackFile = value; index += 1 }
             case "--width":
-                if let value, let parsed = Double(value) {
-                    width = CGFloat(parsed)
-                    index += 1
-                }
+                if let value, let parsed = Double(value) { width = CGFloat(parsed); index += 1 }
             case "--height":
-                if let value, let parsed = Double(value) {
-                    height = CGFloat(parsed)
-                    index += 1
-                }
+                if let value, let parsed = Double(value) { height = CGFloat(parsed); index += 1 }
             case "--margin":
-                if let value, let parsed = Double(value) {
-                    margin = CGFloat(parsed)
-                    index += 1
-                }
+                if let value, let parsed = Double(value) { margin = CGFloat(parsed); index += 1 }
             case "--timeout":
                 if let value, let parsed = Double(value), parsed > 0 {
                     timeoutSeconds = parsed
@@ -57,14 +66,28 @@ struct Configuration {
                 print("""
                 Usage: composio-native-ui [options]
 
-                Options:
-                  --title <text>     Window title. Default: Composio
-                  --message <text>   Primary text. Default: Native UI sidecar scaffold
-                  --detail <text>    Secondary text.
-                  --width <points>   Window width. Default: 560
-                  --height <points>  Window height. Default: 320
-                  --margin <points>  Margin from visible screen edges. Default: 24
-                  --timeout <secs>   Auto-close after the given number of seconds.
+                Content:
+                  --tool <slug>             Tool slug shown in the title. Default: GMAIL_GET_PROFILE
+                  --account <name>          Account identifier. Default: gmail_pall-seba
+                  --title <text>            Override the auto-built title entirely.
+                  --subtitle <text>         Subtitle / description line.
+                  --deny-label <text>       Override the "Deny" button label.
+                  --allow-session-label <text>
+                  --allow-once-label <text> Override the action button labels.
+
+                Window:
+                  --width <points>          Window width. Default: 460
+                  --height <points>         Window height. Default: 200
+                  --margin <points>         Margin from visible screen edges. Default: 24
+                  --timeout <secs>          Auto-close after the given number of seconds.
+
+                Result:
+                  --callback-file <path>    Write the decision JSON to this file. If omitted, JSON is printed to stdout.
+
+                Emits a single JSON line:
+                  {"decision":"allow_once|allow_session|deny|dismissed","tool":"...","account":"..."}
+
+                Exit code: 0 on button press, 1 on dismissed/timeout/window-close.
                 """)
                 Foundation.exit(0)
             default:
@@ -108,129 +131,59 @@ final class ShaderRenderer: NSObject, MTKViewDelegate {
             return out;
         }
 
-        // -- hash / value-noise / fbm --------------------------------
-        float hash21(float2 p) {
-            p = fract(p * float2(234.34, 435.345));
-            p += dot(p, p + 34.23);
-            return fract(p.x * p.y);
+        // Ordered 8x8 Bayer matrix, normalised to [0,1).
+        float bayer8(int2 p) {
+            const int M[64] = {
+                 0, 32,  8, 40,  2, 34, 10, 42,
+                48, 16, 56, 24, 50, 18, 58, 26,
+                12, 44,  4, 36, 14, 46,  6, 38,
+                60, 28, 52, 20, 62, 30, 54, 22,
+                 3, 35, 11, 43,  1, 33,  9, 41,
+                51, 19, 59, 27, 49, 17, 57, 25,
+                15, 47,  7, 39, 13, 45,  5, 37,
+                63, 31, 55, 23, 61, 29, 53, 21
+            };
+            int x = ((p.x % 8) + 8) % 8;
+            int y = ((p.y % 8) + 8) % 8;
+            return float(M[y * 8 + x]) / 64.0;
         }
 
-        float vnoise(float2 p) {
-            float2 i = floor(p);
-            float2 f = fract(p);
-            f = f * f * (3.0 - 2.0 * f);
-            float a = hash21(i);
-            float b = hash21(i + float2(1.0, 0.0));
-            float c = hash21(i + float2(0.0, 1.0));
-            float d = hash21(i + float2(1.0, 1.0));
-            return mix(mix(a, b, f.x), mix(c, d, f.x), f.y);
-        }
-
-        // Rotated-octave FBM — kills the obvious axis-aligned grid.
-        float fbm(float2 p) {
-            const float2x2 rot = float2x2(0.80, 0.60, -0.60, 0.80);
-            float v = 0.0;
-            float a = 0.55;
-            for (int i = 0; i < 6; ++i) {
-                v += a * vnoise(p);
-                p = rot * p * 2.05;
-                a *= 0.5;
-            }
-            return v;
-        }
-
-        // IQ cosine palette — iridescent, smooth.
-        float3 palette(float t, float3 a, float3 b, float3 c, float3 d) {
-            return a + b * cos(6.28318 * (c * t + d));
-        }
-
-        // Per-channel soft-light blend (Photoshop formula).
-        float softLight1(float s, float d) {
-            return (s < 0.5)
-                ? d - (1.0 - 2.0 * s) * d * (1.0 - d)
-                : ((d < 0.25)
-                    ? d + (2.0 * s - 1.0) * d * ((16.0 * d - 12.0) * d + 3.0)
-                    : d + (2.0 * s - 1.0) * (sqrt(d) - d));
-        }
-        float3 softLight(float3 s, float3 d) {
-            return float3(softLight1(s.x, d.x),
-                          softLight1(s.y, d.y),
-                          softLight1(s.z, d.z));
-        }
-
-        // Built using Shadertoy idioms: aspect-corrected coords,
-        // domain-warped FBM ("warp the warp"), IQ palette, soft-light
-        // blend over an ink base, vignette, dither, gamma.
+        // Matches the dashboard's <Dither + SineWave> composition:
+        //   colorB="#c2c2c2"  pattern="bayer8"  pixelSize=2
+        //   spread=0.8  threshold=0.59
+        //   SineWave amplitude=0.1 angle=162 frequency=0.5 softness=1 speed=-0.4
         fragment float4 fragment_main(VertexOut in [[stage_in]], constant float &time [[buffer(0)]]) {
-            // Aspect-corrected, centered coords. 560x320 ≈ 1.75 aspect.
+            const float PI = 3.14159265;
             float2 uv = in.uv;
-            float aspect = 1.75;
-            float2 p = (uv - 0.5) * float2(aspect, 1.0);
 
-            float t = time * 0.085;
+            // SineWave field across the canvas. Angle 162° from horizontal.
+            float ang = 162.0 * PI / 180.0;
+            float2 dir = float2(cos(ang), sin(ang));
+            float frequency = 0.5;
+            float amplitude = 0.10;
+            float softness  = 1.0;
+            float speed     = -0.4;
 
-            // -- Warp-the-warp: two layers of vector FBM, then a final field.
-            float2 q = float2(
-                fbm(p * 1.4 + float2(0.0, t * 1.3)),
-                fbm(p * 1.4 + float2(5.2, -t * 1.1))
-            );
-            float2 r = float2(
-                fbm(p * 1.9 + 3.4 * q + float2(1.7, 9.2) + t * 0.7),
-                fbm(p * 1.9 + 3.4 * q + float2(8.3, 2.8) - t * 0.6)
-            );
-            float f = fbm(p * 2.4 + 4.0 * r);
+            float coord = dot(uv - 0.5, dir) * frequency * 6.28318 + time * speed * 3.0;
+            float wave  = 0.5 + 0.5 * sin(coord);          // 0..1
+            // softness=1 → broad, gentle band; softness<1 would sharpen.
+            wave = pow(wave, 1.0 / max(softness, 0.001));
+            // amplitude=0.1 modulates a small swing around 0.5.
+            float sineValue = 0.5 + (wave - 0.5) * (amplitude * 4.0);
 
-            // Wisp highlights — narrow ridges where the field crests.
-            float wisps = smoothstep(0.55, 0.92, f);
-            wisps = wisps * wisps;
+            // Bayer-ordered dither at pixelSize=2.
+            int2 pix = int2(floor(in.position.xy * 0.5));
+            float b = bayer8(pix);
+            float spread    = 0.80;
+            float threshold = 0.59;
 
-            // Two IQ palettes layered: a hot magenta/amber and a cool teal/indigo.
-            float3 hot  = palette(0.15 + 0.65 * f + 0.12 * sin(t * 1.7),
-                                  float3(0.55, 0.35, 0.45),
-                                  float3(0.45, 0.32, 0.42),
-                                  float3(1.00, 0.90, 0.85),
-                                  float3(0.00, 0.18, 0.38));
-            float3 cold = palette(0.25 + 0.50 * length(r) - 0.08 * cos(t * 1.1),
-                                  float3(0.20, 0.32, 0.45),
-                                  float3(0.18, 0.28, 0.40),
-                                  float3(1.00, 1.00, 1.10),
-                                  float3(0.55, 0.40, 0.20));
+            // Standard ordered-dither comparison.
+            float mask = step(threshold, sineValue + (b - 0.5) * spread);
 
-            float mixFactor = smoothstep(0.25, 0.85, f + 0.2 * r.x);
-            float3 plasma = mix(cold, hot, mixFactor);
+            float3 white = float3(1.0, 1.0, 1.0);
+            float3 grey  = float3(0.7607, 0.7607, 0.7607); // #c2c2c2
 
-            // Wisp specular highlight — soft white-warm.
-            plasma += wisps * float3(1.05, 0.86, 0.62) * 0.45;
-
-            // -- Composition mask: push energy toward the right side
-            //    so the left-aligned text stays readable.
-            float2 c = uv - float2(0.62, 0.45);
-            float radial = exp(-dot(c * float2(0.9, 1.25), c * float2(0.9, 1.25)) * 4.2);
-            float leftFade = smoothstep(-0.35, 0.55, p.x);  // dim left edge
-            float intensity = radial * (0.35 + 0.65 * leftFade);
-
-            // Deep warm ink base — slightly violet so the cool wisps separate.
-            float3 ink = float3(0.030, 0.032, 0.050);
-
-            // Soft-light compose: plasma tints the ink instead of replacing it.
-            float3 color = softLight(plasma * intensity, ink);
-            color = mix(ink, color, 0.55 + 0.45 * intensity);
-
-            // Additive wisp bloom on top — the "spark" highlights.
-            color += wisps * intensity * float3(1.0, 0.78, 0.52) * 0.35;
-
-            // Vignette (Shadertoy idiom, but aspect aware).
-            float2 vv = uv * (1.0 - uv.yx);
-            float vig = pow(clamp(vv.x * vv.y * 16.0, 0.0, 1.0), 0.32);
-            color *= 0.55 + 0.50 * vig;
-
-            // Dither + grain — kills banding, adds film-tooth.
-            float n = hash21(in.position.xy + time * 60.0);
-            color += (n - 0.5) * 0.022;
-
-            // Gentle gamma — preserves blacks for UI readability.
-            color = pow(max(color, 0.0), float3(0.94));
-
+            float3 color = mix(grey, white, mask);
             return float4(color, 1.0);
         }
         """
@@ -301,35 +254,61 @@ final class MetalBackgroundView: MTKView {
 
 // MARK: - Tokens
 
+// Composio logomark — embedded as SVG so the sidecar stays a single binary
+// with no asset bundle. macOS NSImage can decode SVG directly.
+enum Logo {
+    static let composioSVG = #"""
+    <svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <g clip-path="url(#clip0_2367_5)">
+    <path d="M91.7032 28.1801L35.3611 16.6572C31.6669 15.8988 28.1929 18.7367 28.1929 22.5043V49.1954V50.6144V77.3052C28.1929 81.0729 31.6669 83.9112 35.3611 83.1526L91.7032 71.6296" stroke="black" stroke-width="2.8556" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M48.1992 7.38531C48.1993 2.09223 53.6097 -1.44765 58.4546 0.57874L58.6851 0.679333L58.6902 0.68227L88.8308 14.6023C91.4759 15.7947 93.1338 18.4366 93.1346 21.3053V33.0975C93.1346 37.3994 89.4707 40.797 85.1902 40.4658L51.0547 37.918V61.8914L85.185 59.3435L85.585 59.323C89.6842 59.2231 93.1331 62.5334 93.109 66.6876V78.4797C93.109 81.3707 91.4075 83.9737 88.8105 85.1812L88.806 85.1827L58.691 99.0774L58.6917 99.0782C53.7808 101.351 48.1992 97.7714 48.1992 92.3759V81.1383C47.9779 81.2256 47.741 81.2834 47.4921 81.3015L30.8347 82.5007C29.4429 82.6007 28.2584 81.4977 28.2582 80.1023V67.7354C28.2583 67.256 28.4014 66.8063 28.6474 66.4277L14.9439 67.4513H14.9388C10.6701 67.7539 7.00001 64.3671 7 60.0823V39.7271C7.00031 35.4239 10.6671 32.0248 14.9491 32.3589H14.9483L28.3486 33.3589C28.2905 33.152 28.2583 32.9345 28.2582 32.7099V19.6826C28.2582 17.7807 29.9597 16.3299 31.8377 16.6304L47.6992 19.168C47.8735 19.1959 48.0404 19.2435 48.1992 19.3059V7.38531ZM85.4075 62.191H85.4023L51.0547 64.755V79.6601L90.2541 71.4669V66.6774L90.2496 66.435C90.1323 63.9438 87.9489 61.9928 85.4075 62.191ZM27.7075 36.1748C27.9471 36.5495 28.0863 36.9936 28.0864 37.4678V62.7813C28.0864 63.0748 28.0314 63.3559 27.9344 63.6169L48.1992 62.1044V37.7043L27.7075 36.1748ZM51.0547 35.0544L85.4023 37.6183L85.4075 37.6191L85.6511 37.6316C88.1632 37.6928 90.279 35.6595 90.279 33.0975V28.1405L51.0547 19.9411V35.0544Z" fill="black"/>
+    </g>
+    <defs>
+    <clipPath id="clip0_2367_5">
+    <rect width="86.4662" height="100" fill="white" transform="translate(7)"/>
+    </clipPath>
+    </defs>
+    </svg>
+    """#
+
+    static func makeImage() -> NSImage? {
+        guard let data = composioSVG.data(using: .utf8),
+              let image = NSImage(data: data) else { return nil }
+        image.isTemplate = false
+        return image
+    }
+}
+
+// Matches the dashboard's light theme (oklch tokens flattened to sRGB).
 enum Palette {
-    static let amber = NSColor(srgbRed: 0.95, green: 0.71, blue: 0.31, alpha: 1.0)
-    static let amberDeep = NSColor(srgbRed: 0.78, green: 0.50, blue: 0.18, alpha: 1.0)
-    static let inkDeep = NSColor(srgbRed: 0.04, green: 0.04, blue: 0.055, alpha: 1.0)
-    static let textPrimary = NSColor.white
-    static let textSecondary = NSColor.white.withAlphaComponent(0.62)
-    static let textMuted = NSColor.white.withAlphaComponent(0.38)
-    static let hairline = NSColor.white.withAlphaComponent(0.08)
+    static let cardBg = NSColor.white.withAlphaComponent(0.86)   // bg-card/80
+    static let border = NSColor(white: 0.0, alpha: 0.10)         // border-border
+    static let divider = NSColor(white: 0.0, alpha: 0.08)
+    static let textPrimary = NSColor(white: 0.07, alpha: 1.0)    // near-black
+    static let textSecondary = NSColor(white: 0.40, alpha: 1.0)  // text-muted-foreground
+    static let textMuted = NSColor(white: 0.55, alpha: 1.0)
+    static let primary = NSColor(white: 0.09, alpha: 1.0)        // primary button
+    static let primaryHover = NSColor(white: 0.18, alpha: 1.0)
+    static let onPrimary = NSColor.white
 }
 
 // MARK: - Card chrome
 
+// Light-theme card: rounded-2xl + border + subtle inner stroke, like
+// `border-border bg-card/80 rounded-2xl shadow-* backdrop-blur-md`.
 @MainActor
 final class CardView: NSView {
-    private let topHairline = CALayer()
     private let innerStroke = CAShapeLayer()
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
         wantsLayer = true
-        layer?.cornerRadius = 18
+        layer?.cornerRadius = 16
         layer?.cornerCurve = .continuous
         layer?.masksToBounds = true
 
-        topHairline.backgroundColor = NSColor.white.withAlphaComponent(0.14).cgColor
-        layer?.addSublayer(topHairline)
-
         innerStroke.fillColor = NSColor.clear.cgColor
-        innerStroke.strokeColor = NSColor.white.withAlphaComponent(0.06).cgColor
+        innerStroke.strokeColor = Palette.border.cgColor
         innerStroke.lineWidth = 1
         layer?.addSublayer(innerStroke)
     }
@@ -338,73 +317,32 @@ final class CardView: NSView {
 
     override func layout() {
         super.layout()
-        topHairline.frame = NSRect(x: 0, y: bounds.height - 1, width: bounds.width, height: 1)
         innerStroke.frame = bounds
         innerStroke.path = CGPath(
             roundedRect: bounds.insetBy(dx: 0.5, dy: 0.5),
-            cornerWidth: 17.5, cornerHeight: 17.5, transform: nil
+            cornerWidth: 15.5, cornerHeight: 15.5, transform: nil
         )
     }
 }
 
-@MainActor
-final class PulsingDot: NSView {
-    private let core = CALayer()
-    private let halo = CALayer()
-
-    override init(frame frameRect: NSRect) {
-        super.init(frame: frameRect)
-        wantsLayer = true
-
-        halo.backgroundColor = Palette.amber.withAlphaComponent(0.35).cgColor
-        halo.cornerRadius = 6
-        layer?.addSublayer(halo)
-
-        core.backgroundColor = Palette.amber.cgColor
-        core.cornerRadius = 3
-        core.shadowColor = Palette.amber.cgColor
-        core.shadowOpacity = 0.9
-        core.shadowRadius = 4
-        core.shadowOffset = .zero
-        layer?.addSublayer(core)
-    }
-
-    required init?(coder: NSCoder) { fatalError() }
-
-    override var intrinsicContentSize: NSSize { NSSize(width: 12, height: 12) }
-
-    override func layout() {
-        super.layout()
-        let cx = bounds.midX, cy = bounds.midY
-        core.frame = NSRect(x: cx - 3, y: cy - 3, width: 6, height: 6)
-        halo.frame = NSRect(x: cx - 6, y: cy - 6, width: 12, height: 12)
-    }
-
-    override func viewDidMoveToWindow() {
-        super.viewDidMoveToWindow()
-        guard window != nil else { return }
-        let pulse = CABasicAnimation(keyPath: "opacity")
-        pulse.fromValue = 0.50
-        pulse.toValue = 0.10
-        pulse.duration = 1.6
-        pulse.autoreverses = true
-        pulse.repeatCount = .infinity
-        pulse.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
-        halo.add(pulse, forKey: "pulse")
-    }
+enum AccentStyle {
+    case primary    // dark filled, white text
+    case secondary  // transparent w/ border, dark text
 }
 
 @MainActor
 final class AccentButton: NSButton {
     private let action_: () -> Void
+    private let style: AccentStyle
     private let fill = CALayer()
-    private let topGloss = CAGradientLayer()
+    private let stroke = CAShapeLayer()
     private let glow = CALayer()
     private var isHovering = false
     private var isPressed = false
 
-    init(title: String, action: @escaping () -> Void) {
+    init(title: String, style: AccentStyle = .primary, action: @escaping () -> Void) {
         self.action_ = action
+        self.style = style
         super.init(frame: .zero)
         self.title = ""
         isBordered = false
@@ -412,37 +350,38 @@ final class AccentButton: NSButton {
         layer?.masksToBounds = false
         focusRingType = .none
 
-        glow.backgroundColor = Palette.amber.withAlphaComponent(0.0).cgColor
-        glow.shadowColor = Palette.amber.cgColor
+        glow.backgroundColor = NSColor.clear.cgColor
+        glow.shadowColor = NSColor.black.cgColor
         glow.shadowOpacity = 0.0
-        glow.shadowRadius = 18
-        glow.shadowOffset = .zero
+        glow.shadowRadius = 12
+        glow.shadowOffset = CGSize(width: 0, height: 2)
         layer?.addSublayer(glow)
 
-        fill.backgroundColor = Palette.amber.cgColor
-        fill.cornerRadius = 11
+        fill.cornerRadius = 8
         fill.cornerCurve = .continuous
         layer?.addSublayer(fill)
 
-        topGloss.colors = [
-            NSColor.white.withAlphaComponent(0.28).cgColor,
-            NSColor.white.withAlphaComponent(0.0).cgColor,
-        ]
-        topGloss.startPoint = CGPoint(x: 0.5, y: 1.0)
-        topGloss.endPoint = CGPoint(x: 0.5, y: 0.0)
-        topGloss.cornerRadius = 11
-        topGloss.cornerCurve = .continuous
-        layer?.addSublayer(topGloss)
+        stroke.fillColor = NSColor.clear.cgColor
+        stroke.lineWidth = 1
+        layer?.addSublayer(stroke)
 
-        let arrow = "\u{2197}"
-        let attr = NSMutableAttributedString(string: title + "  " + arrow, attributes: [
-            .font: NSFont.systemFont(ofSize: 12.5, weight: .semibold),
-            .foregroundColor: NSColor(srgbRed: 0.10, green: 0.07, blue: 0.04, alpha: 1.0),
-            .kern: 0.4,
+        let textColor: NSColor
+        switch style {
+        case .primary:
+            fill.backgroundColor = Palette.primary.cgColor
+            stroke.strokeColor = NSColor.clear.cgColor
+            textColor = Palette.onPrimary
+        case .secondary:
+            fill.backgroundColor = NSColor.white.withAlphaComponent(0.55).cgColor
+            stroke.strokeColor = Palette.border.cgColor
+            textColor = Palette.textPrimary
+        }
+
+        let attr = NSMutableAttributedString(string: title, attributes: [
+            .font: NSFont.systemFont(ofSize: 12.5, weight: .medium),
+            .foregroundColor: textColor,
+            .kern: 0.1,
         ])
-        attr.addAttribute(.font,
-                          value: NSFont.systemFont(ofSize: 12.5, weight: .medium),
-                          range: NSRange(location: title.count + 2, length: 1))
         attributedTitle = attr
 
         target = self
@@ -458,15 +397,19 @@ final class AccentButton: NSButton {
 
     override var intrinsicContentSize: NSSize {
         let base = super.intrinsicContentSize
-        return NSSize(width: base.width + 36, height: 34)
+        return NSSize(width: base.width + 22, height: 30)
     }
 
     override func layout() {
         super.layout()
         fill.frame = bounds
-        topGloss.frame = NSRect(x: 0, y: bounds.height * 0.5, width: bounds.width, height: bounds.height * 0.5)
         glow.frame = bounds
-        glow.shadowPath = CGPath(roundedRect: bounds, cornerWidth: 11, cornerHeight: 11, transform: nil)
+        glow.shadowPath = CGPath(roundedRect: bounds, cornerWidth: 8, cornerHeight: 8, transform: nil)
+        stroke.frame = bounds
+        stroke.path = CGPath(
+            roundedRect: bounds.insetBy(dx: 0.5, dy: 0.5),
+            cornerWidth: 7.5, cornerHeight: 7.5, transform: nil
+        )
     }
 
     override func resetCursorRects() {
@@ -496,14 +439,68 @@ final class AccentButton: NSButton {
         CATransaction.setAnimationDuration(0.14)
         let scale: CGFloat = pressed ? 0.97 : 1.0
         layer?.transform = CATransform3DMakeScale(scale, scale, 1)
-        glow.shadowOpacity = hover ? 0.55 : 0.0
-        fill.backgroundColor = (hover
-            ? NSColor(srgbRed: 0.98, green: 0.76, blue: 0.36, alpha: 1.0)
-            : Palette.amber).cgColor
+        switch style {
+        case .primary:
+            glow.shadowOpacity = hover ? 0.18 : 0.0
+            fill.backgroundColor = (hover ? Palette.primaryHover : Palette.primary).cgColor
+        case .secondary:
+            glow.shadowOpacity = 0.0
+            fill.backgroundColor = (hover
+                ? NSColor.white.withAlphaComponent(0.85)
+                : NSColor.white.withAlphaComponent(0.55)).cgColor
+        }
         CATransaction.commit()
     }
 
     @objc private func invoke() { action_() }
+}
+
+// MARK: - Decision callback
+
+enum Decision: String {
+    case deny = "deny"
+    case allowOnce = "allow_once"
+    case allowSession = "allow_session"
+    case dismissed = "dismissed"
+}
+
+@MainActor
+final class DecisionSink {
+    static let shared = DecisionSink()
+    private var hasEmitted = false
+    private var configuration: Configuration?
+
+    func configure(_ config: Configuration) {
+        self.configuration = config
+    }
+
+    func emitAndExit(_ decision: Decision) {
+        guard !hasEmitted, let config = configuration else {
+            Foundation.exit(decision == .dismissed ? 1 : 0)
+        }
+        hasEmitted = true
+
+        let payload: [String: Any] = [
+            "decision": decision.rawValue,
+            "tool": config.tool,
+            "account": config.account,
+        ]
+        let line: String
+        if let data = try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys]),
+           let json = String(data: data, encoding: .utf8) {
+            line = json + "\n"
+        } else {
+            line = "{\"decision\":\"\(decision.rawValue)\"}\n"
+        }
+
+        if let path = config.callbackFile {
+            try? line.write(toFile: path, atomically: true, encoding: .utf8)
+        } else {
+            FileHandle.standardOutput.write(Data(line.utf8))
+        }
+
+        Foundation.exit(decision == .dismissed ? 1 : 0)
+    }
 }
 
 // MARK: - App
@@ -520,19 +517,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.accessory)
+        DecisionSink.shared.configure(configuration)
         createWindow()
 
         if let timeoutSeconds = configuration.timeoutSeconds {
             Timer.scheduledTimer(withTimeInterval: timeoutSeconds, repeats: false) { _ in
                 Task { @MainActor in
-                    NSApp.terminate(nil)
+                    DecisionSink.shared.emitAndExit(.dismissed)
                 }
             }
         }
     }
 
     func windowWillClose(_ notification: Notification) {
-        NSApp.terminate(nil)
+        DecisionSink.shared.emitAndExit(.dismissed)
     }
 
     private func createWindow() {
@@ -590,55 +588,141 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         root.layer?.backgroundColor = NSColor.clear.cgColor
         root.layer?.masksToBounds = false
 
+        // Soft drop shadow behind the card.
+        let shadowHost = NSView()
+        shadowHost.wantsLayer = true
+        shadowHost.translatesAutoresizingMaskIntoConstraints = false
+        if let l = shadowHost.layer {
+            l.shadowColor = NSColor.black.cgColor
+            l.shadowOpacity = 0.18
+            l.shadowRadius = 30
+            l.shadowOffset = CGSize(width: 0, height: -12)
+            l.masksToBounds = false
+        }
+        root.addSubview(shadowHost)
+
+        let card = CardView()
+        card.translatesAutoresizingMaskIntoConstraints = false
+        shadowHost.addSubview(card)
+
+        // Dithered sine-wave shader — fills the card.
         let background = MetalBackgroundView(frame: .zero)
         background.translatesAutoresizingMaskIntoConstraints = false
-        root.addSubview(background)
+        card.addSubview(background)
 
-        // Small label.
-        let kicker = NSTextField(labelWithString: "COMPOSIO WANTS TO RUN")
-        let kickerAttr = NSMutableAttributedString(string: kicker.stringValue, attributes: [
-            .font: NSFont.monospacedSystemFont(ofSize: 10.5, weight: .semibold),
-            .foregroundColor: Palette.textSecondary,
-            .kern: 3.0,
-        ])
-        kicker.attributedStringValue = kickerAttr
-        kicker.alignment = .center
-        kicker.translatesAutoresizingMaskIntoConstraints = false
-        root.addSubview(kicker)
+        // Translucent white wash so the dither reads more softly under text.
+        let wash = NSView()
+        wash.wantsLayer = true
+        wash.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.55).cgColor
+        wash.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(wash)
 
-        // Big headline.
-        let headline = NSTextField(labelWithString: "Read Email")
-        let headlineAttr = NSMutableAttributedString(string: "Read Email", attributes: [
-            .font: NSFont.systemFont(ofSize: 38, weight: .semibold),
+        // --- Logo (left rail).
+        let logoView = NSImageView()
+        logoView.image = Logo.makeImage()
+        logoView.imageScaling = .scaleProportionallyUpOrDown
+        logoView.imageAlignment = .alignCenter
+        logoView.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(logoView)
+
+        // --- Header: title with inline mono tool slug + account, muted subtitle.
+        let toolSlug = configuration.tool
+        let account = configuration.account
+        let titleString = configuration.resolvedTitle
+        let title = NSTextField(labelWithString: titleString)
+        let titleAttr = NSMutableAttributedString(string: titleString, attributes: [
+            .font: NSFont.systemFont(ofSize: 15, weight: .semibold),
             .foregroundColor: Palette.textPrimary,
-            .kern: -0.6,
+            .kern: -0.2,
         ])
-        headline.attributedStringValue = headlineAttr
-        headline.alignment = .center
-        headline.translatesAutoresizingMaskIntoConstraints = false
-        root.addSubview(headline)
-
-        let button = AccentButton(title: "Continue") {
-            fputs("button:continue\n", stdout)
-            fflush(stdout)
-            NSApp.terminate(nil)
+        let monoFont = NSFont.monospacedSystemFont(ofSize: 13, weight: .semibold)
+        if let slugRange = titleString.range(of: toolSlug) {
+            titleAttr.addAttribute(.font, value: monoFont,
+                                   range: NSRange(slugRange, in: titleString))
         }
-        button.translatesAutoresizingMaskIntoConstraints = false
-        root.addSubview(button)
+        if let acctRange = titleString.range(of: account) {
+            titleAttr.addAttribute(.font, value: monoFont,
+                                   range: NSRange(acctRange, in: titleString))
+        }
+        title.attributedStringValue = titleAttr
+        title.lineBreakMode = .byTruncatingTail
+        title.maximumNumberOfLines = 2
+        title.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(title)
+
+        let subtitle = NSTextField(labelWithString: configuration.subtitle)
+        let subtitleAttr = NSMutableAttributedString(string: configuration.subtitle, attributes: [
+            .font: NSFont.systemFont(ofSize: 12, weight: .regular),
+            .foregroundColor: Palette.textSecondary,
+        ])
+        subtitle.attributedStringValue = subtitleAttr
+        subtitle.lineBreakMode = .byWordWrapping
+        subtitle.maximumNumberOfLines = 2
+        subtitle.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(subtitle)
+
+        // --- Three actions matching the elicitation oneOf decisions.
+        let denyButton = AccentButton(title: configuration.denyLabel, style: .secondary) {
+            DecisionSink.shared.emitAndExit(.deny)
+        }
+        let allowSessionButton = AccentButton(title: configuration.allowSessionLabel, style: .secondary) {
+            DecisionSink.shared.emitAndExit(.allowSession)
+        }
+        let allowOnceButton = AccentButton(title: configuration.allowOnceLabel, style: .primary) {
+            DecisionSink.shared.emitAndExit(.allowOnce)
+        }
+        // Enter triggers the default action.
+        allowOnceButton.keyEquivalent = "\r"
+
+        let buttonRow = NSStackView(views: [denyButton, allowSessionButton, allowOnceButton])
+        buttonRow.orientation = .horizontal
+        buttonRow.alignment = .centerY
+        buttonRow.spacing = 8
+        buttonRow.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(buttonRow)
+
+        let hPad: CGFloat = 22
+        let headerTop: CGFloat = 20
+        let bodyBottom: CGFloat = 18
+        let logoSize: CGFloat = 32
 
         NSLayoutConstraint.activate([
-            background.leadingAnchor.constraint(equalTo: root.leadingAnchor),
-            background.trailingAnchor.constraint(equalTo: root.trailingAnchor),
-            background.topAnchor.constraint(equalTo: root.topAnchor),
-            background.bottomAnchor.constraint(equalTo: root.bottomAnchor),
+            shadowHost.leadingAnchor.constraint(equalTo: root.leadingAnchor),
+            shadowHost.trailingAnchor.constraint(equalTo: root.trailingAnchor),
+            shadowHost.topAnchor.constraint(equalTo: root.topAnchor),
+            shadowHost.bottomAnchor.constraint(equalTo: root.bottomAnchor),
 
-            kicker.centerXAnchor.constraint(equalTo: root.centerXAnchor),
-            headline.centerXAnchor.constraint(equalTo: root.centerXAnchor),
-            button.centerXAnchor.constraint(equalTo: root.centerXAnchor),
+            card.leadingAnchor.constraint(equalTo: shadowHost.leadingAnchor),
+            card.trailingAnchor.constraint(equalTo: shadowHost.trailingAnchor),
+            card.topAnchor.constraint(equalTo: shadowHost.topAnchor),
+            card.bottomAnchor.constraint(equalTo: shadowHost.bottomAnchor),
 
-            headline.centerYAnchor.constraint(equalTo: root.centerYAnchor, constant: -10),
-            kicker.bottomAnchor.constraint(equalTo: headline.topAnchor, constant: -14),
-            button.topAnchor.constraint(equalTo: headline.bottomAnchor, constant: 26),
+            background.leadingAnchor.constraint(equalTo: card.leadingAnchor),
+            background.trailingAnchor.constraint(equalTo: card.trailingAnchor),
+            background.topAnchor.constraint(equalTo: card.topAnchor),
+            background.bottomAnchor.constraint(equalTo: card.bottomAnchor),
+
+            wash.leadingAnchor.constraint(equalTo: card.leadingAnchor),
+            wash.trailingAnchor.constraint(equalTo: card.trailingAnchor),
+            wash.topAnchor.constraint(equalTo: card.topAnchor),
+            wash.bottomAnchor.constraint(equalTo: card.bottomAnchor),
+
+            // Logo anchored to the bottom-left, aligned with button row baseline.
+            logoView.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: hPad),
+            logoView.bottomAnchor.constraint(equalTo: card.bottomAnchor, constant: -bodyBottom - 4),
+            logoView.widthAnchor.constraint(equalToConstant: logoSize),
+            logoView.heightAnchor.constraint(equalToConstant: logoSize),
+
+            title.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: hPad),
+            title.trailingAnchor.constraint(lessThanOrEqualTo: card.trailingAnchor, constant: -hPad),
+            title.topAnchor.constraint(equalTo: card.topAnchor, constant: headerTop),
+
+            subtitle.leadingAnchor.constraint(equalTo: title.leadingAnchor),
+            subtitle.trailingAnchor.constraint(lessThanOrEqualTo: card.trailingAnchor, constant: -hPad),
+            subtitle.topAnchor.constraint(equalTo: title.bottomAnchor, constant: 4),
+
+            buttonRow.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -hPad),
+            buttonRow.bottomAnchor.constraint(equalTo: card.bottomAnchor, constant: -bodyBottom),
         ])
 
         return root

--- a/ts/packages/cli-local-tools/package.json
+++ b/ts/packages/cli-local-tools/package.json
@@ -38,6 +38,7 @@
     "build": "pnpm exec tsdown",
     "build:beeper-imessage": "bun run ./scripts/build-beeper-imessage-binaries.ts",
     "build:peekaboo": "bun run ./scripts/build-peekaboo-binaries.ts",
+    "build:composio-native-ui": "bun run ./scripts/build-composio-native-ui-binaries.ts",
     "build:local-tool-binaries": "bun run ./scripts/build-local-tool-binaries.ts",
     "test": "vitest run",
     "typecheck": "pnpm exec tsgo --noEmit -p ./tsconfig.src.json",

--- a/ts/packages/cli-local-tools/scripts/build-composio-native-ui-binaries.ts
+++ b/ts/packages/cli-local-tools/scripts/build-composio-native-ui-binaries.ts
@@ -1,0 +1,113 @@
+#!/usr/bin/env bun
+
+import { $ } from 'bun';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(scriptDir, '..');
+const repoRoot = path.resolve(packageRoot, '../../..');
+const swiftPackagePath = path.join(packageRoot, 'native/composio-native-ui');
+const outputRoot = path.join(packageRoot, 'local-tools-binaries/composio-native-ui');
+
+const targets = [
+  {
+    platform: 'darwin-arm64',
+    swiftArch: 'arm64',
+    buildPath: '.build/arm64-apple-macosx/release/composio-native-ui',
+  },
+  {
+    platform: 'darwin-x64',
+    swiftArch: 'x86_64',
+    buildPath: '.build/x86_64-apple-macosx/release/composio-native-ui',
+  },
+] as const;
+
+type Target = (typeof targets)[number];
+
+const exists = async (filePath: string): Promise<boolean> =>
+  fs
+    .access(filePath)
+    .then(() => true)
+    .catch(() => false);
+
+const ensurePlatform = () => {
+  if (process.platform !== 'darwin') {
+    throw new Error(
+      'Building the Composio native UI sidecar requires macOS and the Swift toolchain.'
+    );
+  }
+};
+
+const buildTarget = async (target: Target) => {
+  console.log(`Building composio-native-ui for ${target.platform} (${target.swiftArch})...`);
+  await $`swift build -c release --product composio-native-ui --arch ${target.swiftArch}`.cwd(
+    swiftPackagePath
+  );
+
+  const builtBinary = path.join(swiftPackagePath, target.buildPath);
+  if (!(await exists(builtBinary))) {
+    throw new Error(`Swift build completed but ${target.buildPath} was not produced.`);
+  }
+
+  const targetDir = path.join(outputRoot, target.platform);
+  const outputBinary = path.join(targetDir, 'composio-native-ui');
+  await fs.mkdir(targetDir, { recursive: true });
+  await fs.copyFile(builtBinary, outputBinary);
+  await fs.chmod(outputBinary, 0o755);
+  console.log(`Wrote ${path.relative(repoRoot, outputBinary)}`);
+};
+
+const writeNotice = async () => {
+  const notice = `# Composio native UI sidecar
+
+The \`composio-native-ui\` binaries are built from the in-repository Swift package at \`ts/packages/cli-local-tools/native/composio-native-ui\`.
+
+- Purpose: native macOS UI surface that the Bun-compiled Composio CLI can spawn for auth flows, tool pickers, and other desktop affordances.
+- Build command: \`pnpm --filter @composio/cli-local-tools build:composio-native-ui -- --target <darwin-arm64|darwin-x64>\`
+- Underlying Swift build commands:
+  - \`swift build -c release --product composio-native-ui --arch arm64\`
+  - \`swift build -c release --product composio-native-ui --arch x86_64\`
+
+The scaffold currently opens a small AppKit panel near the bottom-right corner of the active screen. Generated executables are intentionally not committed; release jobs rebuild them before packaging CLI artifacts.
+`;
+  await fs.writeFile(path.join(outputRoot, 'NOTICE.md'), notice, 'utf8');
+};
+
+const parseTargets = (): ReadonlyArray<Target> => {
+  const rawArgs = process.argv.slice(2).filter(arg => arg !== '--');
+  const targetIndex = rawArgs.indexOf('--target');
+  const args =
+    targetIndex >= 0 && rawArgs[targetIndex + 1]
+      ? [rawArgs[targetIndex + 1]!]
+      : rawArgs.filter(arg => !arg.startsWith('--'));
+
+  if (args.length === 0 || args.includes('all')) return targets;
+
+  const selected = targets.filter(target => args.includes(target.platform));
+  const unknown = args.filter(arg => !targets.some(target => target.platform === arg));
+  if (unknown.length > 0) {
+    throw new Error(
+      `Unknown target(s): ${unknown.join(', ')}. Expected one of: all, ${targets
+        .map(target => target.platform)
+        .join(', ')}`
+    );
+  }
+  return selected;
+};
+
+const main = async () => {
+  ensurePlatform();
+  await fs.mkdir(outputRoot, { recursive: true });
+  const selectedTargets = parseTargets();
+  for (const target of selectedTargets) {
+    await buildTarget(target);
+  }
+  await writeNotice();
+};
+
+main().catch(error => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/ts/packages/cli-local-tools/scripts/build-local-tool-binaries.ts
+++ b/ts/packages/cli-local-tools/scripts/build-local-tool-binaries.ts
@@ -69,6 +69,7 @@ const main = async () => {
   console.log(`Building native local-tool binaries for ${target}...`);
   await runScript('build-beeper-imessage-binaries.ts', target);
   await runScript('build-peekaboo-binaries.ts', target);
+  await runScript('build-composio-native-ui-binaries.ts', target);
 };
 
 main().catch(error => {

--- a/ts/packages/cli/src/commands/dev.cmd.ts
+++ b/ts/packages/cli/src/commands/dev.cmd.ts
@@ -9,6 +9,7 @@ import { authConfigsCmd } from './auth-configs/auth-configs.cmd';
 import { connectedAccountsCmd } from './connected-accounts/connected-accounts.cmd';
 import { triggersCmd } from './triggers/triggers.cmd';
 import { projectsCmd } from './projects/projects.cmd';
+import { devNativeUiCmd } from './dev/dev.native-ui.cmd';
 import { ComposioCliUserConfig, resolveCliConfigPathSync } from 'src/services/cli-user-config';
 import { Stdin } from 'src/services/stdin';
 import { TerminalUI } from 'src/services/terminal-ui';
@@ -29,6 +30,7 @@ const devSubcommands = [
   connectedAccountsCmd,
   triggersCmd,
   projectsCmd,
+  devNativeUiCmd,
 ] as const;
 
 const describeCurrentMode = (enabled: boolean) =>

--- a/ts/packages/cli/src/commands/dev/dev.native-ui.cmd.ts
+++ b/ts/packages/cli/src/commands/dev/dev.native-ui.cmd.ts
@@ -1,0 +1,102 @@
+import { Command, Options } from '@effect/cli';
+import { Effect, Option } from 'effect';
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  detectCliPlatform,
+  ensureBundledBinaryExecutable,
+  getLocalToolsBundleRootCandidates,
+} from '@composio/cli-local-tools';
+import { TerminalUI } from 'src/services/terminal-ui';
+
+const title = Options.text('title').pipe(
+  Options.withDefault('Composio'),
+  Options.withDescription('Title for the native sidecar window.')
+);
+
+const message = Options.text('message').pipe(
+  Options.withDefault('Native UI sidecar scaffold'),
+  Options.withDescription('Primary text displayed in the native sidecar window.')
+);
+
+const detail = Options.text('detail').pipe(
+  Options.withDefault('This window is rendered by a Swift sidecar bundled with the CLI.'),
+  Options.withDescription('Secondary text displayed in the native sidecar window.')
+);
+
+const timeout = Options.optional(Options.text('timeout')).pipe(
+  Options.withDescription('Optional auto-close timeout in seconds.')
+);
+
+const NATIVE_UI_BINARY_NAME = 'composio-native-ui';
+
+const resolveNativeUiBinary = () => {
+  const platform = detectCliPlatform();
+  if (!platform.startsWith('darwin-')) {
+    return {
+      _tag: 'unsupported' as const,
+      platform,
+    };
+  }
+
+  const candidates = getLocalToolsBundleRootCandidates().map(root =>
+    path.join(root, NATIVE_UI_BINARY_NAME, platform, NATIVE_UI_BINARY_NAME)
+  );
+  const binaryPath = candidates.find(candidate => fs.existsSync(candidate));
+
+  return binaryPath
+    ? {
+        _tag: 'found' as const,
+        binaryPath,
+      }
+    : {
+        _tag: 'missing' as const,
+        platform,
+        candidates,
+      };
+};
+
+export const devNativeUiCmd = Command.make('native-ui', { title, message, detail, timeout }).pipe(
+  Command.withDescription('Open the experimental native macOS UI sidecar.'),
+  Command.withHandler(({ title, message, detail, timeout }) =>
+    Effect.gen(function* () {
+      const ui = yield* TerminalUI;
+      const resolved = resolveNativeUiBinary();
+
+      if (resolved._tag === 'unsupported') {
+        yield* ui.log.error(
+          `The native UI sidecar is currently only available on macOS (detected ${resolved.platform}).`
+        );
+        return;
+      }
+
+      if (resolved._tag === 'missing') {
+        yield* ui.log.error('The native UI sidecar binary was not found.');
+        yield* ui.log.step(
+          `Build it with: pnpm --filter @composio/cli-local-tools build:composio-native-ui -- --target ${resolved.platform}`
+        );
+        yield* ui.log.step(`Checked: ${resolved.candidates.join(', ')}`);
+        return;
+      }
+
+      yield* Effect.tryPromise(() => ensureBundledBinaryExecutable(resolved.binaryPath));
+
+      const args = ['--title', title, '--message', message, '--detail', detail];
+      const timeoutValue = Option.getOrUndefined(timeout)?.trim();
+      if (timeoutValue) {
+        args.push('--timeout', timeoutValue);
+      }
+
+      yield* Effect.sync(() => {
+        const child = spawn(resolved.binaryPath, args, {
+          detached: true,
+          stdio: 'ignore',
+        });
+        child.unref();
+      });
+
+      yield* ui.log.success('Opened native UI sidecar.');
+    })
+  )
+);


### PR DESCRIPTION
## Summary
- Scaffold a macOS Swift `composio-native-ui` sidecar with a borderless floating native overlay and Metal-driven pulsing/liquid-glass visual treatment.
- Add a hidden/dev `composio dev native-ui` command that spawns the bundled sidecar from CLI local-tool assets.
- Wire the sidecar into local-tool binary build scripts and CLI binary release packaging checks for Darwin artifacts.

## Tests
- `pnpm install --frozen-lockfile`
- `pnpm typecheck`
- `pnpm --filter @composio/cli build`
- `pnpm --filter @composio/cli-local-tools build:composio-native-ui -- --target darwin-arm64`
- Manual launch via `COMPOSIO_LOCAL_TOOLS_BIN_DIR=../cli-local-tools/local-tools-binaries bun dist/bin.mjs dev native-ui --timeout 35`

## Notes / Risks
- This is a scaffold/prototype and is intentionally opened as a draft PR.
- The visual effect uses a transparent AppKit panel, `NSVisualEffectView`, and a Metal overlay. True optical distortion of arbitrary content behind the window would require a different approach such as ScreenCaptureKit/backdrop sampling and associated permissions.
- Generated sidecar executables remain ignored; release jobs rebuild them before packaging artifacts.