### PR TITLE
feat(connected-accounts): namespace SHARED-connection surface under experimental

### DIFF
--- a/.changeset/connected-accounts-experimental-ts.md
+++ b/.changeset/connected-accounts-experimental-ts.md
@@ -1,0 +1,49 @@
+---
+'@composio/core': minor
+---
+
+feat(connected-accounts): namespace SHARED-connection surface under `experimental`
+
+Aligns the TypeScript SDK with the experimental wire shape used by Shared Connections. The flat `accountType` / `aclConfigForShared` options on `connectedAccounts.link()` and `session.authorize()` have moved under a single `experimental` block, and `connectedAccounts.updateAcl()` has moved off the class onto a top-level `experimental_updateAcl(composio, id, opts)` export — same precedent as `experimental_createTool` / `experimental_createToolkit`.
+
+The `experimental` namespace is the signal that the shape may change in future releases. Pinning a SHARED connection in a session config (`connectedAccounts: { gmail: [...] }`) and direct execute by `connectedAccountId` are unchanged — only the connection-create / patch / authorize surfaces are namespaced.
+
+Also surfaces the `accountType` filter on `connectedAccounts.list()` so SHARED connections can be listed without dropping to the raw client. The wire keeps this as a flat query param, so the SDK keeps it flat too.
+
+`@composio/client` bumped from `0.1.0-alpha.71` → `0.1.0-alpha.72` so the generated typed client carries the `Experimental` namespaces for `link.create`, `toolRouter.session.link`, and `connectedAccounts.patch`.
+
+Caller migration:
+
+```typescript
+// before
+await composio.connectedAccounts.link('user_id', 'auth_config_id', {
+  accountType: 'SHARED',
+  aclConfigForShared: { allowAllUsers: true },
+});
+await composio.connectedAccounts.updateAcl('ca_abc', { allowAllUsers: true });
+await session.authorize('github', {
+  accountType: 'SHARED',
+  aclConfigForShared: { allowAllUsers: true },
+});
+
+// after
+await composio.connectedAccounts.link('user_id', 'auth_config_id', {
+  experimental: {
+    accountType: 'SHARED',
+    aclConfigForShared: { allowAllUsers: true },
+  },
+});
+await experimental_updateAcl(composio, 'ca_abc', { allowAllUsers: true });
+await session.authorize('github', {
+  experimental: {
+    accountType: 'SHARED',
+    aclConfigForShared: { allowAllUsers: true },
+  },
+});
+
+// new — list SHARED connections
+const shared = await composio.connectedAccounts.list({
+  accountType: 'SHARED',
+  userIds: ['user_creator'],
+});
+```

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ catalogs:
       specifier: ^4.20250917.0
       version: 4.20260218.0
     '@composio/client':
-      specifier: 0.1.0-alpha.71
-      version: 0.1.0-alpha.71
+      specifier: 0.1.0-alpha.72
+      version: 0.1.0-alpha.72
     '@effect/cli':
       specifier: ^0.73.2
       version: 0.73.2
@@ -722,16 +722,16 @@ importers:
         version: link:../../packages/providers/llamaindex
       '@llamaindex/openai':
         specifier: ^0.4.20
-        version: 0.4.22(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(ws@8.20.0)(zod@4.3.6)
+        version: 0.4.22(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(ws@8.20.0)(zod@3.25.76)
       '@llamaindex/workflow':
         specifier: ^1.1.24
-        version: 1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono@4.11.9)(zod@4.3.6)
+        version: 1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(hono@4.11.9)(zod@3.25.76)
       dotenv:
         specifier: ^16.4.1
         version: 16.6.1
       llamaindex:
         specifier: ^0.12.0
-        version: 0.12.1(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono@4.11.9)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@4.3.6)
+        version: 0.12.1(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(hono@4.11.9)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@3.25.76)
     devDependencies:
       '@types/bun':
         specifier: ^1.2.9
@@ -1079,7 +1079,7 @@ importers:
         version: link:../cli-local-tools
       '@composio/client':
         specifier: 'catalog:'
-        version: 0.1.0-alpha.71
+        version: 0.1.0-alpha.72
       '@composio/core':
         specifier: workspace:*
         version: link:../core
@@ -1249,7 +1249,7 @@ importers:
     dependencies:
       '@composio/client':
         specifier: 'catalog:'
-        version: 0.1.0-alpha.71
+        version: 0.1.0-alpha.72
       '@composio/json-schema-to-zod':
         specifier: workspace:*
         version: link:../json-schema-to-zod
@@ -1422,7 +1422,7 @@ importers:
     dependencies:
       llamaindex:
         specifier: ^0.12.0
-        version: 0.12.1(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono@4.11.9)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@4.3.6)
+        version: 0.12.1(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@4.3.6)
     devDependencies:
       '@composio/core':
         specifier: workspace:*
@@ -1912,8 +1912,8 @@ packages:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
 
-  '@composio/client@0.1.0-alpha.71':
-    resolution: {integrity: sha512-6h1IPMbXIx5PjaU0T+a1MNnKHL/pPP7+X2nNQaler5XoENANWGm4mYePjR+7Cgtw1j6X2QkCmRLuX5q9c0INvQ==}
+  '@composio/client@0.1.0-alpha.72':
+    resolution: {integrity: sha512-2WYXgdlMvhoaJCsaSfyMAYGQ2tS5l2Fqdh2cMRqNi8NybIoOkFZy2ApBJJOoQwqfpUr41VymMW6FtiNQm7JavQ==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -7286,7 +7286,7 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@composio/client@0.1.0-alpha.71': {}
+  '@composio/client@0.1.0-alpha.72': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -8059,26 +8059,43 @@ snapshots:
       tree-sitter: 0.22.4
       web-tree-sitter: 0.24.7
 
-  '@llamaindex/openai@0.4.22(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(ws@8.20.0)(zod@4.3.6)':
+  '@llamaindex/openai@0.4.22(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(ws@8.20.0)(zod@3.25.76)':
     dependencies:
       '@llamaindex/core': 0.6.22
       '@llamaindex/env': 0.1.30
-      openai: 5.23.2(ws@8.20.0)(zod@4.3.6)
+      openai: 5.23.2(ws@8.20.0)(zod@3.25.76)
     transitivePeerDependencies:
       - ws
       - zod
 
-  '@llamaindex/workflow-core@1.3.3(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono@4.11.9)(zod@4.3.6)':
+  '@llamaindex/workflow-core@1.3.3(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(hono@4.11.9)(zod@3.25.76)':
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      '@modelcontextprotocol/sdk': 1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       hono: 4.11.9
+      zod: 3.25.76
+
+  '@llamaindex/workflow-core@1.3.3(zod@4.3.6)':
+    optionalDependencies:
       zod: 4.3.6
 
-  '@llamaindex/workflow@1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono@4.11.9)(zod@4.3.6)':
+  '@llamaindex/workflow@1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(hono@4.11.9)(zod@3.25.76)':
     dependencies:
       '@llamaindex/core': 0.6.22
       '@llamaindex/env': 0.1.30
-      '@llamaindex/workflow-core': 1.3.3(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono@4.11.9)(zod@4.3.6)
+      '@llamaindex/workflow-core': 1.3.3(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(hono@4.11.9)(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - hono
+      - next
+      - p-retry
+      - rxjs
+      - zod
+
+  '@llamaindex/workflow@1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(zod@4.3.6)':
+    dependencies:
+      '@llamaindex/core': 0.6.22
+      '@llamaindex/env': 0.1.30
+      '@llamaindex/workflow-core': 1.3.3(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - hono
@@ -9104,6 +9121,14 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@22.19.11)(tsx@4.21.0)(yaml@2.8.2)
 
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.10.13)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@24.10.13)(tsx@4.21.0)(yaml@2.8.2)
+
   '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
@@ -9133,7 +9158,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@22.19.11)(@vitest/ui@3.2.4)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 3.2.4(@types/node@24.10.13)(@vitest/ui@3.2.4)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -10585,12 +10610,34 @@ snapshots:
       rfdc: 1.4.1
       wrap-ansi: 9.0.2
 
-  llamaindex@0.12.1(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono@4.11.9)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@4.3.6):
+  llamaindex@0.12.1(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(hono@4.11.9)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@3.25.76):
     dependencies:
       '@llamaindex/core': 0.6.22
       '@llamaindex/env': 0.1.30
       '@llamaindex/node-parser': 2.0.22(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)
-      '@llamaindex/workflow': 1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono@4.11.9)(zod@4.3.6)
+      '@llamaindex/workflow': 1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(hono@4.11.9)(zod@3.25.76)
+      '@types/lodash': 4.17.23
+      '@types/node': 24.10.13
+      lodash: 4.17.23
+      magic-bytes.js: 1.13.0
+    transitivePeerDependencies:
+      - '@huggingface/transformers'
+      - '@modelcontextprotocol/sdk'
+      - gpt-tokenizer
+      - hono
+      - next
+      - p-retry
+      - rxjs
+      - tree-sitter
+      - web-tree-sitter
+      - zod
+
+  llamaindex@0.12.1(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@4.3.6):
+    dependencies:
+      '@llamaindex/core': 0.6.22
+      '@llamaindex/env': 0.1.30
+      '@llamaindex/node-parser': 2.0.22(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)
+      '@llamaindex/workflow': 1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(zod@4.3.6)
       '@types/lodash': 4.17.23
       '@types/node': 24.10.13
       lodash: 4.17.23
@@ -10873,6 +10920,11 @@ snapshots:
       define-lazy-prop: 3.0.0
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
+
+  openai@5.23.2(ws@8.20.0)(zod@3.25.76):
+    optionalDependencies:
+      ws: 8.20.0
+      zod: 3.25.76
 
   openai@5.23.2(ws@8.20.0)(zod@4.3.6):
     optionalDependencies:
@@ -11972,7 +12024,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@22.19.11)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.10.13)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,7 +22,7 @@ catalog:
   '@clack/prompts': '^1.0.1'
   '@cloudflare/vitest-pool-workers': ^0.9.2
   '@cloudflare/workers-types': ^4.20250917.0
-  '@composio/client': 0.1.0-alpha.71
+  '@composio/client': 0.1.0-alpha.72
   '@effect/cli': ^0.73.2
   '@effect/eslint-plugin': ^0.3.2
   '@effect/language-service': ^0.74.0

--- a/ts/packages/core/src/composio.ts
+++ b/ts/packages/core/src/composio.ts
@@ -5,6 +5,7 @@ import { Toolkits } from './models/Toolkits';
 import { Triggers } from './models/Triggers';
 import { AuthConfigs } from './models/AuthConfigs';
 import { ConnectedAccounts } from './models/ConnectedAccounts';
+import { Experimental } from './models/Experimental';
 import { MCP } from './models/MCP';
 import { telemetry } from './telemetry/Telemetry';
 import { getSDKConfig, getToolkitVersionsFromEnv } from './utils/sdk';
@@ -194,6 +195,14 @@ export class Composio<
   authConfigs: AuthConfigs;
   /** Manage authenticated connections */
   connectedAccounts: ConnectedAccounts;
+  /**
+   * Experimental SDK methods whose shape may change in future releases.
+   * Houses stateful operations like {@link Experimental.updateAcl} that
+   * take a client and perform I/O. Stateless experimental factories
+   * (e.g. `experimental_createTool`) stay at the top level.
+   * @experimental
+   */
+  experimental: Experimental;
   /** Model Context Protocol server management */
   mcp: MCP;
   /**
@@ -331,6 +340,7 @@ export class Composio<
       fileDownloadDir: this.config.fileDownloadDir,
     });
     this.connectedAccounts = new ConnectedAccounts(this.client);
+    this.experimental = new Experimental(this.client);
     this.toolRouter = new ToolRouter(this.client, this.config);
 
     /**

--- a/ts/packages/core/src/errors/ConnectedAccountsErrors.ts
+++ b/ts/packages/core/src/errors/ConnectedAccountsErrors.ts
@@ -74,7 +74,7 @@ export class ComposioSharedAccessDeniedError extends ComposioError {
       code: ConnectedAccountErrorCodes.SHARED_ACCESS_DENIED,
       statusCode: 403,
       possibleFixes: options.possibleFixes || [
-        "Ask the connection's creator to grant access via composio.connectedAccounts.updateAcl() — set allowAllUsers, add the userId to allowedUserIds, or remove it from notAllowedUserIds.",
+        "Ask the connection's creator to grant access via composio.experimental.updateAcl() — set allowAllUsers, add the userId to allowedUserIds, or remove it from notAllowedUserIds.",
       ],
     });
     this.name = 'ComposioSharedAccessDeniedError';
@@ -119,7 +119,7 @@ export class ComposioSharedConnectionNotAccessibleError extends ComposioError {
       code: ConnectedAccountErrorCodes.SHARED_CONNECTION_NOT_ACCESSIBLE,
       statusCode: 400,
       possibleFixes: options.possibleFixes || [
-        "Grant the session user access via composio.connectedAccounts.updateAcl() on the pinned connection, or pin a different connection the user can use.",
+        'Grant the session user access via composio.experimental.updateAcl() on the pinned connection, or pin a different connection the user can use.',
       ],
     });
     this.name = 'ComposioSharedConnectionNotAccessibleError';

--- a/ts/packages/core/src/index.ts
+++ b/ts/packages/core/src/index.ts
@@ -38,8 +38,12 @@ export { default as logger } from './utils/logger';
 export { createCustomTool as experimental_createTool } from './models/CustomTool';
 export { createCustomToolkit as experimental_createToolkit } from './models/CustomTool';
 
-// Experimental shared connected accounts — shape may change in future releases
-export { experimental_updateAcl } from './models/ConnectedAccounts';
+// Experimental shared connected accounts — shape may change in future releases.
+// `updateAcl` is mounted as a method on `composio.experimental.updateAcl(...)`
+// because it takes a client and performs I/O. The `Experimental` class
+// itself is re-exported so callers can type their own composio handles
+// (e.g. in test helpers).
+export { Experimental } from './models/Experimental';
 
 // Error handling exports
 export * from './errors';

--- a/ts/packages/core/src/index.ts
+++ b/ts/packages/core/src/index.ts
@@ -38,5 +38,8 @@ export { default as logger } from './utils/logger';
 export { createCustomTool as experimental_createTool } from './models/CustomTool';
 export { createCustomToolkit as experimental_createToolkit } from './models/CustomTool';
 
+// Experimental shared connected accounts — shape may change in future releases
+export { experimental_updateAcl } from './models/ConnectedAccounts';
+
 // Error handling exports
 export * from './errors';

--- a/ts/packages/core/src/models/ConnectedAccounts.ts
+++ b/ts/packages/core/src/models/ConnectedAccounts.ts
@@ -64,7 +64,7 @@ let _legacyInitiateWarningEmitted = false;
  * deny-by-default, but the explicit form preserves the caller's intent
  * in network traces.
  */
-function serializeAclConfigForWire(
+export function serializeAclConfigForWire(
   acl:
     | {
         allowAllUsers?: boolean;
@@ -72,13 +72,33 @@ function serializeAclConfigForWire(
         notAllowedUserIds?: string[];
       }
     | undefined
-): LinkCreateParams.ACLConfigForShared | undefined {
+): LinkCreateParams.Experimental.ACLConfigForShared | undefined {
   if (acl === undefined) return undefined;
   return {
     ...(acl.allowAllUsers !== undefined && { allow_all_users: acl.allowAllUsers }),
     ...(acl.allowedUserIds !== undefined && { allowed_user_ids: acl.allowedUserIds }),
     ...(acl.notAllowedUserIds !== undefined && { not_allowed_user_ids: acl.notAllowedUserIds }),
   };
+}
+
+/**
+ * Serialise the SDK's `experimental` block (camelCase) into the wire's
+ * `experimental` block (snake_case). Returns `undefined` when the caller
+ * didn't pass anything.
+ */
+function serializeExperimentalForWire(
+  experimental: import('../types/connectedAccounts.types').ConnectedAccountExperimental | undefined
+): LinkCreateParams.Experimental | undefined {
+  if (experimental === undefined) return undefined;
+  const aclWire = serializeAclConfigForWire(experimental.aclConfigForShared);
+  const wire: LinkCreateParams.Experimental = {};
+  if (experimental.accountType !== undefined) {
+    wire.account_type = experimental.accountType;
+  }
+  if (aclWire !== undefined) {
+    wire.acl_config_for_shared = aclWire;
+  }
+  return wire;
 }
 
 /**
@@ -141,6 +161,9 @@ export class ConnectedAccounts {
         statuses: parsedQuery.data.statuses as ConnectedAccountListParamsRaw['statuses'],
         toolkit_slugs: parsedQuery.data.toolkitSlugs,
         user_ids: parsedQuery.data.userIds,
+        ...(parsedQuery.data.accountType !== undefined && {
+          account_type: parsedQuery.data.accountType,
+        }),
       };
     }
 
@@ -398,14 +421,13 @@ export class ConnectedAccounts {
     }
 
     const opts = requestOptions.data;
-    const aclWire = serializeAclConfigForWire(opts.aclConfigForShared);
+    const experimentalWire = serializeExperimentalForWire(opts.experimental);
     const body: LinkCreateParams = {
       auth_config_id: authConfigId,
       user_id: userId,
       ...(opts.callbackUrl !== undefined && { callback_url: opts.callbackUrl }),
       ...(opts.alias !== undefined && { alias: opts.alias }),
-      ...(opts.accountType !== undefined && { account_type: opts.accountType }),
-      ...(aclWire !== undefined && { acl_config_for_shared: aclWire }),
+      ...(experimentalWire !== undefined && { experimental: experimentalWire }),
     };
 
     try {
@@ -617,7 +639,8 @@ export class ConnectedAccounts {
   /**
    * Enable or disable a connected account. Accepts `{ enabled: boolean }`.
    *
-   * For ACL writes on SHARED connections, see {@link updateAcl}.
+   * For ACL writes on SHARED connections, see `experimental_updateAcl`
+   * exported at the top level of `@composio/core`.
    *
    * @param {string} nanoid - The unique identifier of the connected account
    * @param {UpdateConnectedAccountParams} params - The update parameters
@@ -642,85 +665,93 @@ export class ConnectedAccounts {
 
     return this.client.connectedAccounts.updateStatus(nanoid, parsedParams.data);
   }
+}
 
-  /**
-   * Update the per-user ACL on a SHARED connected account.
-   *
-   * Only meaningful for SHARED connections — calling this on a PRIVATE
-   * connection raises `ComposioAclOnlyForSharedError` (400). ACL writes
-   * require the connection's creator or an API key; alias edits via
-   * {@link update} are governed separately.
-   *
-   * PATCH semantics: omit a field to leave it unchanged; pass an empty array
-   * to clear an allow/deny list. At least one field must be provided.
-   *
-   * Resolution rule (deny wins):
-   *   1. requesting `userId` in `notAllowedUserIds` → DENY
-   *   2. `allowAllUsers === true`                   → ALLOW
-   *   3. requesting `userId` in `allowedUserIds`    → ALLOW
-   *   4. otherwise                                  → DENY
-   *
-   * @example
-   * ```typescript
-   * // Allow every userId to use this connection
-   * await composio.connectedAccounts.updateAcl('ca_abc', { allowAllUsers: true });
-   *
-   * // Everyone except a specific user
-   * await composio.connectedAccounts.updateAcl('ca_abc', {
-   *   allowAllUsers: true,
-   *   notAllowedUserIds: ['user_bob'],
-   * });
-   *
-   * // Targeted allow
-   * await composio.connectedAccounts.updateAcl('ca_abc', {
-   *   allowedUserIds: ['user_alice', 'user_bob'],
-   * });
-   *
-   * // Revoke a previously-granted allow list (back to deny-by-default)
-   * await composio.connectedAccounts.updateAcl('ca_abc', { allowedUserIds: [] });
-   * ```
-   *
-   * **Empty-array semantics — read carefully.** Passing `[]` for either
-   * list **replaces** the list, it does not extend it:
-   *
-   * - `allowedUserIds: []` → revoke all previously-granted user IDs (state
-   *   reverts to deny-by-default unless `allowAllUsers` is true).
-   * - `notAllowedUserIds: []` → **clears the deny list**, which silently
-   *   re-grants access to users you previously blocked. Always pair an
-   *   empty deny list with a deliberate audit of the allow side.
-   *
-   * @returns The PATCH response (`{ id, status, success }`). To read the
-   * updated `aclConfigForShared` block, call `get(nanoid)` after the
-   * promise resolves.
-   */
-  async updateAcl(
-    nanoid: string,
-    params: UpdateConnectedAccountAclParams
-  ): Promise<ConnectedAccountPatchResponse> {
-    const parsedParams = UpdateConnectedAccountAclParamsSchema.safeParse(params);
-    if (!parsedParams.success) {
-      throw new ValidationError('Failed to parse connected account ACL update params', {
-        cause: parsedParams.error,
-      });
-    }
+/**
+ * Update the per-user ACL on a SHARED connected account. Experimental —
+ * shape may change in future releases.
+ *
+ * Only meaningful for SHARED connections — calling this on a PRIVATE
+ * connection raises `ComposioAclOnlyForSharedError` (400). ACL writes
+ * require the connection's creator or an API key.
+ *
+ * PATCH semantics: omit a field to leave it unchanged; pass an empty array
+ * to clear an allow/deny list. At least one field must be provided.
+ *
+ * Resolution rule (deny wins):
+ *   1. requesting `userId` in `notAllowedUserIds` → DENY
+ *   2. `allowAllUsers === true`                   → ALLOW
+ *   3. requesting `userId` in `allowedUserIds`    → ALLOW
+ *   4. otherwise                                  → DENY
+ *
+ * @example
+ * ```typescript
+ * import { Composio, experimental_updateAcl } from '@composio/core';
+ *
+ * const composio = new Composio({ apiKey: '...' });
+ *
+ * // Allow every userId to use this connection
+ * await experimental_updateAcl(composio, 'ca_abc', { allowAllUsers: true });
+ *
+ * // Everyone except a specific user
+ * await experimental_updateAcl(composio, 'ca_abc', {
+ *   allowAllUsers: true,
+ *   notAllowedUserIds: ['user_bob'],
+ * });
+ *
+ * // Targeted allow
+ * await experimental_updateAcl(composio, 'ca_abc', {
+ *   allowedUserIds: ['user_alice', 'user_bob'],
+ * });
+ *
+ * // Revoke a previously-granted allow list (back to deny-by-default)
+ * await experimental_updateAcl(composio, 'ca_abc', { allowedUserIds: [] });
+ * ```
+ *
+ * **Empty-array semantics — read carefully.** Passing `[]` for either
+ * list **replaces** the list, it does not extend it:
+ *
+ * - `allowedUserIds: []` → revoke all previously-granted user IDs (state
+ *   reverts to deny-by-default unless `allowAllUsers` is true).
+ * - `notAllowedUserIds: []` → **clears the deny list**, which silently
+ *   re-grants access to users you previously blocked. Always pair an
+ *   empty deny list with a deliberate audit of the allow side.
+ *
+ * @returns The PATCH response (`{ id, status, success }`). To read the
+ *   updated ACL block, call `composio.connectedAccounts.get(nanoid)`
+ *   after the promise resolves and inspect `account.experimental?.aclConfigForShared`.
+ */
+export async function experimental_updateAcl(
+  composio: { getClient: () => ComposioClient },
+  nanoid: string,
+  params: UpdateConnectedAccountAclParams
+): Promise<ConnectedAccountPatchResponse> {
+  const parsedParams = UpdateConnectedAccountAclParamsSchema.safeParse(params);
+  if (!parsedParams.success) {
+    throw new ValidationError('Failed to parse connected account ACL update params', {
+      cause: parsedParams.error,
+    });
+  }
 
-    const body: ConnectedAccountPatchParams = {
+  const client = composio.getClient();
+  const body: ConnectedAccountPatchParams = {
+    experimental: {
       acl_config_for_shared: serializeAclConfigForWire(parsedParams.data),
-    };
+    },
+  };
 
-    try {
-      return await this.client.connectedAccounts.patch(nanoid, body);
-    } catch (error) {
-      // Same ACL-on-PRIVATE rejection the create path can hit — surface
-      // it as a typed error.
-      if (
-        error instanceof BadRequestError &&
-        typeof error.message === 'string' &&
-        error.message.includes('acl_config_for_shared is only valid on SHARED')
-      ) {
-        throw new ComposioAclOnlyForSharedError(error.message, { cause: error });
-      }
-      throw error;
+  try {
+    return await client.connectedAccounts.patch(nanoid, body);
+  } catch (error) {
+    // Same ACL-on-PRIVATE rejection the create path can hit — surface
+    // it as a typed error.
+    if (
+      error instanceof BadRequestError &&
+      typeof error.message === 'string' &&
+      error.message.includes('acl_config_for_shared is only valid on SHARED')
+    ) {
+      throw new ComposioAclOnlyForSharedError(error.message, { cause: error });
     }
+    throw error;
   }
 }

--- a/ts/packages/core/src/models/ConnectedAccounts.ts
+++ b/ts/packages/core/src/models/ConnectedAccounts.ts
@@ -9,8 +9,6 @@ import ComposioClient, { BadRequestError } from '@composio/client';
 import {
   ConnectedAccountCreateResponse,
   ConnectedAccountDeleteResponse,
-  ConnectedAccountPatchParams,
-  ConnectedAccountPatchResponse,
   ConnectedAccountRefreshParams,
   ConnectedAccountRefreshResponse,
   ConnectedAccountUpdateStatusParams,
@@ -32,11 +30,10 @@ import {
   ConnectedAccountRefreshOptionsSchema,
   UpdateConnectedAccountParams,
   UpdateConnectedAccountParamsSchema,
-  UpdateConnectedAccountAclParams,
-  UpdateConnectedAccountAclParamsSchema,
 } from '../types/connectedAccounts.types';
 import { ConnectionRequest } from '../types/connectionRequest.types';
 import { createConnectionRequest } from './ConnectionRequest';
+import { ACL_ONLY_FOR_SHARED_ERROR_FRAGMENT, serializeExperimentalForWire } from './Experimental';
 import { ValidationError } from '../errors/ValidationErrors';
 import { telemetry } from '../telemetry/Telemetry';
 import {
@@ -55,51 +52,6 @@ import { ConnectionData } from '../types/connectedAccountAuthStates.types';
 // One-time-per-process guard so long-running services don't spam the deprecation
 // warning on every initiate() call.
 let _legacyInitiateWarningEmitted = false;
-
-/**
- * Serialise the SDK's `aclConfigForShared` (camelCase) to the wire's
- * `acl_config_for_shared` block. Returns `undefined` when the caller
- * didn't pass anything (PATCH-style "don't touch ACL"); returns `{}`
- * when the caller passed an explicit empty object — both mean
- * deny-by-default, but the explicit form preserves the caller's intent
- * in network traces.
- */
-export function serializeAclConfigForWire(
-  acl:
-    | {
-        allowAllUsers?: boolean;
-        allowedUserIds?: string[];
-        notAllowedUserIds?: string[];
-      }
-    | undefined
-): LinkCreateParams.Experimental.ACLConfigForShared | undefined {
-  if (acl === undefined) return undefined;
-  return {
-    ...(acl.allowAllUsers !== undefined && { allow_all_users: acl.allowAllUsers }),
-    ...(acl.allowedUserIds !== undefined && { allowed_user_ids: acl.allowedUserIds }),
-    ...(acl.notAllowedUserIds !== undefined && { not_allowed_user_ids: acl.notAllowedUserIds }),
-  };
-}
-
-/**
- * Serialise the SDK's `experimental` block (camelCase) into the wire's
- * `experimental` block (snake_case). Returns `undefined` when the caller
- * didn't pass anything.
- */
-function serializeExperimentalForWire(
-  experimental: import('../types/connectedAccounts.types').ConnectedAccountExperimental | undefined
-): LinkCreateParams.Experimental | undefined {
-  if (experimental === undefined) return undefined;
-  const aclWire = serializeAclConfigForWire(experimental.aclConfigForShared);
-  const wire: LinkCreateParams.Experimental = {};
-  if (experimental.accountType !== undefined) {
-    wire.account_type = experimental.accountType;
-  }
-  if (aclWire !== undefined) {
-    wire.acl_config_for_shared = aclWire;
-  }
-  return wire;
-}
 
 /**
  * ConnectedAccounts class
@@ -446,7 +398,7 @@ export class ConnectedAccounts {
       if (
         error instanceof BadRequestError &&
         typeof error.message === 'string' &&
-        error.message.includes('acl_config_for_shared is only valid on SHARED')
+        error.message.includes(ACL_ONLY_FOR_SHARED_ERROR_FRAGMENT)
       ) {
         throw new ComposioAclOnlyForSharedError(error.message, { cause: error });
       }
@@ -639,8 +591,8 @@ export class ConnectedAccounts {
   /**
    * Enable or disable a connected account. Accepts `{ enabled: boolean }`.
    *
-   * For ACL writes on SHARED connections, see `experimental_updateAcl`
-   * exported at the top level of `@composio/core`.
+   * For ACL writes on SHARED connections, see
+   * `composio.experimental.updateAcl()`.
    *
    * @param {string} nanoid - The unique identifier of the connected account
    * @param {UpdateConnectedAccountParams} params - The update parameters
@@ -664,94 +616,5 @@ export class ConnectedAccounts {
     }
 
     return this.client.connectedAccounts.updateStatus(nanoid, parsedParams.data);
-  }
-}
-
-/**
- * Update the per-user ACL on a SHARED connected account. Experimental —
- * shape may change in future releases.
- *
- * Only meaningful for SHARED connections — calling this on a PRIVATE
- * connection raises `ComposioAclOnlyForSharedError` (400). ACL writes
- * require the connection's creator or an API key.
- *
- * PATCH semantics: omit a field to leave it unchanged; pass an empty array
- * to clear an allow/deny list. At least one field must be provided.
- *
- * Resolution rule (deny wins):
- *   1. requesting `userId` in `notAllowedUserIds` → DENY
- *   2. `allowAllUsers === true`                   → ALLOW
- *   3. requesting `userId` in `allowedUserIds`    → ALLOW
- *   4. otherwise                                  → DENY
- *
- * @example
- * ```typescript
- * import { Composio, experimental_updateAcl } from '@composio/core';
- *
- * const composio = new Composio({ apiKey: '...' });
- *
- * // Allow every userId to use this connection
- * await experimental_updateAcl(composio, 'ca_abc', { allowAllUsers: true });
- *
- * // Everyone except a specific user
- * await experimental_updateAcl(composio, 'ca_abc', {
- *   allowAllUsers: true,
- *   notAllowedUserIds: ['user_bob'],
- * });
- *
- * // Targeted allow
- * await experimental_updateAcl(composio, 'ca_abc', {
- *   allowedUserIds: ['user_alice', 'user_bob'],
- * });
- *
- * // Revoke a previously-granted allow list (back to deny-by-default)
- * await experimental_updateAcl(composio, 'ca_abc', { allowedUserIds: [] });
- * ```
- *
- * **Empty-array semantics — read carefully.** Passing `[]` for either
- * list **replaces** the list, it does not extend it:
- *
- * - `allowedUserIds: []` → revoke all previously-granted user IDs (state
- *   reverts to deny-by-default unless `allowAllUsers` is true).
- * - `notAllowedUserIds: []` → **clears the deny list**, which silently
- *   re-grants access to users you previously blocked. Always pair an
- *   empty deny list with a deliberate audit of the allow side.
- *
- * @returns The PATCH response (`{ id, status, success }`). To read the
- *   updated ACL block, call `composio.connectedAccounts.get(nanoid)`
- *   after the promise resolves and inspect `account.experimental?.aclConfigForShared`.
- */
-export async function experimental_updateAcl(
-  composio: { getClient: () => ComposioClient },
-  nanoid: string,
-  params: UpdateConnectedAccountAclParams
-): Promise<ConnectedAccountPatchResponse> {
-  const parsedParams = UpdateConnectedAccountAclParamsSchema.safeParse(params);
-  if (!parsedParams.success) {
-    throw new ValidationError('Failed to parse connected account ACL update params', {
-      cause: parsedParams.error,
-    });
-  }
-
-  const client = composio.getClient();
-  const body: ConnectedAccountPatchParams = {
-    experimental: {
-      acl_config_for_shared: serializeAclConfigForWire(parsedParams.data),
-    },
-  };
-
-  try {
-    return await client.connectedAccounts.patch(nanoid, body);
-  } catch (error) {
-    // Same ACL-on-PRIVATE rejection the create path can hit — surface
-    // it as a typed error.
-    if (
-      error instanceof BadRequestError &&
-      typeof error.message === 'string' &&
-      error.message.includes('acl_config_for_shared is only valid on SHARED')
-    ) {
-      throw new ComposioAclOnlyForSharedError(error.message, { cause: error });
-    }
-    throw error;
   }
 }

--- a/ts/packages/core/src/models/Experimental.ts
+++ b/ts/packages/core/src/models/Experimental.ts
@@ -10,10 +10,7 @@ import ComposioClient, { BadRequestError } from '@composio/client';
 import {
   ConnectedAccountPatchParams,
   ConnectedAccountPatchResponse,
-  ConnectedAccountListParams as ConnectedAccountListParamsRaw,
 } from '@composio/client/resources/connected-accounts';
-import { LinkCreateParams } from '@composio/client/resources/link';
-import { SessionLinkParams } from '@composio/client/resources/tool-router/session/session';
 import {
   ConnectedAccountExperimental,
   UpdateConnectedAccountAclParams,
@@ -34,8 +31,9 @@ export const ACL_ONLY_FOR_SHARED_ERROR_FRAGMENT = 'acl_config_for_shared is only
 
 /**
  * Structural shape of the wire's experimental block on requests. Both
- * `LinkCreateParams.Experimental` and `SessionLinkParams.Experimental`
- * (Stainless-generated, nominally distinct) accept this shape.
+ * the `link.create` and `tool_router.session.link` wire types are
+ * Stainless-generated as nominally distinct namespaces but accept this
+ * shape — sharing one structural type keeps the SDK helpers reusable.
  */
 type ExperimentalWire = {
   account_type?: 'PRIVATE' | 'SHARED';
@@ -190,9 +188,3 @@ export class Experimental {
     }
   }
 }
-
-// Re-exports so the wire-shape helpers stay reachable from the existing
-// callsites in `models/` without bouncing through `experimental.ts` —
-// the canonical home is here, but the imports look unchanged at the
-// caller.
-export type { LinkCreateParams, SessionLinkParams, ConnectedAccountListParamsRaw };

--- a/ts/packages/core/src/models/Experimental.ts
+++ b/ts/packages/core/src/models/Experimental.ts
@@ -1,0 +1,198 @@
+/**
+ * @fileoverview The `composio.experimental` namespace. Houses experimental
+ * SDK methods whose shape may change in future releases.
+ *
+ * For experimental stateless factories (e.g. `experimental_createTool`),
+ * see the top-level `experimental_*` exports from `@composio/core`.
+ * Anything that takes a Composio client and performs I/O belongs here.
+ */
+import ComposioClient, { BadRequestError } from '@composio/client';
+import {
+  ConnectedAccountPatchParams,
+  ConnectedAccountPatchResponse,
+  ConnectedAccountListParams as ConnectedAccountListParamsRaw,
+} from '@composio/client/resources/connected-accounts';
+import { LinkCreateParams } from '@composio/client/resources/link';
+import { SessionLinkParams } from '@composio/client/resources/tool-router/session/session';
+import {
+  ConnectedAccountExperimental,
+  UpdateConnectedAccountAclParams,
+  UpdateConnectedAccountAclParamsSchema,
+} from '../types/connectedAccounts.types';
+import { ValidationError } from '../errors/ValidationErrors';
+import { ComposioAclOnlyForSharedError } from '../errors';
+import { telemetry } from '../telemetry/Telemetry';
+
+/**
+ * Server-side 400 message the API uses to reject ACL writes against a
+ * PRIVATE connection. Substring-matched in `updateAcl` here, and in the
+ * sibling `connectedAccounts.link()` / `session.authorize()` call sites
+ * — kept as a single constant so a server-side message tweak only
+ * requires one edit.
+ */
+export const ACL_ONLY_FOR_SHARED_ERROR_FRAGMENT = 'acl_config_for_shared is only valid on SHARED';
+
+/**
+ * Structural shape of the wire's experimental block on requests. Both
+ * `LinkCreateParams.Experimental` and `SessionLinkParams.Experimental`
+ * (Stainless-generated, nominally distinct) accept this shape.
+ */
+type ExperimentalWire = {
+  account_type?: 'PRIVATE' | 'SHARED';
+  acl_config_for_shared?: {
+    allow_all_users?: boolean;
+    allowed_user_ids?: string[];
+    not_allowed_user_ids?: string[];
+  };
+};
+
+/**
+ * Serialise the SDK's `aclConfigForShared` (camelCase) to the wire's
+ * `acl_config_for_shared` block. Returns `undefined` when the caller
+ * didn't pass anything (PATCH-style "don't touch ACL"); returns `{}`
+ * when the caller passed an explicit empty object.
+ */
+export function serializeAclConfigForWire(
+  acl:
+    | {
+        allowAllUsers?: boolean;
+        allowedUserIds?: string[];
+        notAllowedUserIds?: string[];
+      }
+    | undefined
+): NonNullable<ExperimentalWire['acl_config_for_shared']> | undefined {
+  if (acl === undefined) return undefined;
+  return {
+    ...(acl.allowAllUsers !== undefined && { allow_all_users: acl.allowAllUsers }),
+    ...(acl.allowedUserIds !== undefined && { allowed_user_ids: acl.allowedUserIds }),
+    ...(acl.notAllowedUserIds !== undefined && { not_allowed_user_ids: acl.notAllowedUserIds }),
+  };
+}
+
+/**
+ * Serialise the SDK's `experimental` options block (camelCase) to the
+ * wire's `experimental` block (snake_case). Used by both
+ * `connectedAccounts.link()` and `session.authorize()`. Returns
+ * `undefined` when the caller didn't pass the block at all.
+ */
+export function serializeExperimentalForWire(
+  experimental: ConnectedAccountExperimental | undefined
+): ExperimentalWire | undefined {
+  if (experimental === undefined) return undefined;
+  const aclWire = serializeAclConfigForWire(experimental.aclConfigForShared);
+  const wire: ExperimentalWire = {};
+  if (experimental.accountType !== undefined) {
+    wire.account_type = experimental.accountType;
+  }
+  if (aclWire !== undefined) {
+    wire.acl_config_for_shared = aclWire;
+  }
+  return wire;
+}
+
+/**
+ * `composio.experimental` namespace. Mirrors the Python SDK's
+ * `composio.experimental` mount, with one method per experimental
+ * surface. **Shape may change in future releases.**
+ */
+export class Experimental {
+  private client: ComposioClient;
+
+  constructor(client: ComposioClient) {
+    this.client = client;
+    telemetry.instrument(this, 'Experimental');
+  }
+
+  /**
+   * Update the per-user ACL on a SHARED connected account.
+   * **Experimental — shape may change in future releases.**
+   *
+   * Only meaningful for SHARED connections — calling this on a PRIVATE
+   * connection raises `ComposioAclOnlyForSharedError` (400). ACL writes
+   * require the connection's creator or an API key.
+   *
+   * PATCH semantics: omit a field to leave it unchanged; pass an empty
+   * array to clear an allow/deny list. At least one field must be
+   * provided.
+   *
+   * Resolution rule (deny wins):
+   *   1. requesting `userId` in `notAllowedUserIds` → DENY
+   *   2. `allowAllUsers === true`                   → ALLOW
+   *   3. requesting `userId` in `allowedUserIds`    → ALLOW
+   *   4. otherwise                                  → DENY
+   *
+   * @example
+   * ```typescript
+   * import { Composio } from '@composio/core';
+   *
+   * const composio = new Composio({ apiKey: '...' });
+   *
+   * // Allow every userId to use this connection
+   * await composio.experimental.updateAcl('ca_abc', { allowAllUsers: true });
+   *
+   * // Everyone except a specific user
+   * await composio.experimental.updateAcl('ca_abc', {
+   *   allowAllUsers: true,
+   *   notAllowedUserIds: ['user_bob'],
+   * });
+   *
+   * // Targeted allow
+   * await composio.experimental.updateAcl('ca_abc', {
+   *   allowedUserIds: ['user_alice', 'user_bob'],
+   * });
+   *
+   * // Revoke a previously-granted allow list (back to deny-by-default)
+   * await composio.experimental.updateAcl('ca_abc', { allowedUserIds: [] });
+   * ```
+   *
+   * **Empty-array semantics — read carefully.** Passing `[]` for either
+   * list **replaces** the list, it does not extend it:
+   *
+   * - `allowedUserIds: []` → revoke all previously-granted user IDs (state
+   *   reverts to deny-by-default unless `allowAllUsers` is true).
+   * - `notAllowedUserIds: []` → **clears the deny list**, which silently
+   *   re-grants access to users you previously blocked. Always pair an
+   *   empty deny list with a deliberate audit of the allow side.
+   *
+   * @returns The PATCH response (`{ id, status, success }`). To read
+   *   the updated ACL block, call
+   *   `composio.connectedAccounts.get(nanoid)` after the promise
+   *   resolves and inspect `account.experimental?.aclConfigForShared`.
+   */
+  async updateAcl(
+    nanoid: string,
+    params: UpdateConnectedAccountAclParams
+  ): Promise<ConnectedAccountPatchResponse> {
+    const parsedParams = UpdateConnectedAccountAclParamsSchema.safeParse(params);
+    if (!parsedParams.success) {
+      throw new ValidationError('Failed to parse connected account ACL update params', {
+        cause: parsedParams.error,
+      });
+    }
+
+    const body: ConnectedAccountPatchParams = {
+      experimental: {
+        acl_config_for_shared: serializeAclConfigForWire(parsedParams.data),
+      },
+    };
+
+    try {
+      return await this.client.connectedAccounts.patch(nanoid, body);
+    } catch (error) {
+      if (
+        error instanceof BadRequestError &&
+        typeof error.message === 'string' &&
+        error.message.includes(ACL_ONLY_FOR_SHARED_ERROR_FRAGMENT)
+      ) {
+        throw new ComposioAclOnlyForSharedError(error.message, { cause: error });
+      }
+      throw error;
+    }
+  }
+}
+
+// Re-exports so the wire-shape helpers stay reachable from the existing
+// callsites in `models/` without bouncing through `experimental.ts` —
+// the canonical home is here, but the imports look unchanged at the
+// caller.
+export type { LinkCreateParams, SessionLinkParams, ConnectedAccountListParamsRaw };

--- a/ts/packages/core/src/models/ToolRouterSession.ts
+++ b/ts/packages/core/src/models/ToolRouterSession.ts
@@ -27,12 +27,12 @@ import { SessionMetaToolOptions } from '../types/modifiers.types';
 import { ConnectionRequest } from '../types/connectionRequest.types';
 import { createConnectionRequest } from './ConnectionRequest';
 import {
-  ConnectedAccountAclConfigSchema,
+  ConnectedAccountExperimentalSchema,
   ConnectedAccountStatuses,
   ConnectedAccountType,
-  ConnectedAccountTypeSchema,
   ConnectedAccountAclConfig,
 } from '../types/connectedAccounts.types';
+import { ACL_ONLY_FOR_SHARED_ERROR_FRAGMENT, serializeExperimentalForWire } from './Experimental';
 import { z } from 'zod/v3';
 import { transform } from '../utils/transform';
 import { ToolkitConnectionStateSchema } from '../types/toolRouter.types';
@@ -83,12 +83,7 @@ export const DIRECT_CUSTOM_TOOL_DESCRIPTION_PREFIX =
 const AuthorizeOptionsSchema = z.object({
   callbackUrl: z.string().optional(),
   alias: z.string().optional(),
-  experimental: z
-    .object({
-      accountType: ConnectedAccountTypeSchema.optional(),
-      aclConfigForShared: ConnectedAccountAclConfigSchema.optional(),
-    })
-    .optional(),
+  experimental: ConnectedAccountExperimentalSchema.optional(),
 });
 
 export class ToolRouterSession<
@@ -360,35 +355,14 @@ export class ToolRouterSession<
       });
     }
     const opts = requestOptions.data;
-    const experimentalIn = opts.experimental;
-    const aclWire: SessionLinkParams.Experimental.ACLConfigForShared | undefined =
-      experimentalIn?.aclConfigForShared === undefined
-        ? undefined
-        : {
-            ...(experimentalIn.aclConfigForShared.allowAllUsers !== undefined && {
-              allow_all_users: experimentalIn.aclConfigForShared.allowAllUsers,
-            }),
-            ...(experimentalIn.aclConfigForShared.allowedUserIds !== undefined && {
-              allowed_user_ids: experimentalIn.aclConfigForShared.allowedUserIds,
-            }),
-            ...(experimentalIn.aclConfigForShared.notAllowedUserIds !== undefined && {
-              not_allowed_user_ids: experimentalIn.aclConfigForShared.notAllowedUserIds,
-            }),
-          };
-    const experimentalWire: SessionLinkParams.Experimental | undefined =
-      experimentalIn === undefined
-        ? undefined
-        : {
-            ...(experimentalIn.accountType !== undefined && {
-              account_type: experimentalIn.accountType,
-            }),
-            ...(aclWire !== undefined && { acl_config_for_shared: aclWire }),
-          };
+    const experimentalWire = serializeExperimentalForWire(opts.experimental);
     const body: SessionLinkParams = {
       toolkit,
       ...(opts.callbackUrl !== undefined && { callback_url: opts.callbackUrl }),
       ...(opts.alias !== undefined && { alias: opts.alias }),
-      ...(experimentalWire !== undefined && { experimental: experimentalWire }),
+      ...(experimentalWire !== undefined && {
+        experimental: experimentalWire as SessionLinkParams.Experimental,
+      }),
     };
 
     let response;
@@ -400,7 +374,7 @@ export class ToolRouterSession<
       if (
         error instanceof BadRequestError &&
         typeof error.message === 'string' &&
-        error.message.includes('acl_config_for_shared is only valid on SHARED')
+        error.message.includes(ACL_ONLY_FOR_SHARED_ERROR_FRAGMENT)
       ) {
         throw new ComposioAclOnlyForSharedError(error.message, { cause: error });
       }

--- a/ts/packages/core/src/models/ToolRouterSession.ts
+++ b/ts/packages/core/src/models/ToolRouterSession.ts
@@ -83,8 +83,12 @@ export const DIRECT_CUSTOM_TOOL_DESCRIPTION_PREFIX =
 const AuthorizeOptionsSchema = z.object({
   callbackUrl: z.string().optional(),
   alias: z.string().optional(),
-  accountType: ConnectedAccountTypeSchema.optional(),
-  aclConfigForShared: ConnectedAccountAclConfigSchema.optional(),
+  experimental: z
+    .object({
+      accountType: ConnectedAccountTypeSchema.optional(),
+      aclConfigForShared: ConnectedAccountAclConfigSchema.optional(),
+    })
+    .optional(),
 });
 
 export class ToolRouterSession<
@@ -327,9 +331,11 @@ export class ToolRouterSession<
    * Initiate an authorization flow for a toolkit.
    * Returns a ConnectionRequest with a redirect URL for the user.
    *
-   * Use `accountType` and `aclConfigForShared` to create a SHARED connection
-   * with a per-user ACL in one flow. Default behaviour (omit both) creates
-   * a PRIVATE connection.
+   * Pass `experimental: { accountType: 'SHARED', aclConfigForShared }` to
+   * create a SHARED connection with a per-user ACL in one flow. Default
+   * behaviour (omit the block) creates a PRIVATE connection.
+   *
+   * Experimental — shape may change in future releases.
    *
    * `aclConfigForShared` is validated against the same caps as
    * `composio.connectedAccounts.link()` (≤1000 entries per list, each
@@ -341,8 +347,10 @@ export class ToolRouterSession<
     options?: {
       callbackUrl?: string;
       alias?: string;
-      accountType?: ConnectedAccountType;
-      aclConfigForShared?: ConnectedAccountAclConfig;
+      experimental?: {
+        accountType?: ConnectedAccountType;
+        aclConfigForShared?: ConnectedAccountAclConfig;
+      };
     }
   ): Promise<ConnectionRequest> {
     const requestOptions = AuthorizeOptionsSchema.safeParse(options ?? {});
@@ -352,26 +360,35 @@ export class ToolRouterSession<
       });
     }
     const opts = requestOptions.data;
-    const aclWire: SessionLinkParams.ACLConfigForShared | undefined =
-      opts.aclConfigForShared === undefined
+    const experimentalIn = opts.experimental;
+    const aclWire: SessionLinkParams.Experimental.ACLConfigForShared | undefined =
+      experimentalIn?.aclConfigForShared === undefined
         ? undefined
         : {
-            ...(opts.aclConfigForShared.allowAllUsers !== undefined && {
-              allow_all_users: opts.aclConfigForShared.allowAllUsers,
+            ...(experimentalIn.aclConfigForShared.allowAllUsers !== undefined && {
+              allow_all_users: experimentalIn.aclConfigForShared.allowAllUsers,
             }),
-            ...(opts.aclConfigForShared.allowedUserIds !== undefined && {
-              allowed_user_ids: opts.aclConfigForShared.allowedUserIds,
+            ...(experimentalIn.aclConfigForShared.allowedUserIds !== undefined && {
+              allowed_user_ids: experimentalIn.aclConfigForShared.allowedUserIds,
             }),
-            ...(opts.aclConfigForShared.notAllowedUserIds !== undefined && {
-              not_allowed_user_ids: opts.aclConfigForShared.notAllowedUserIds,
+            ...(experimentalIn.aclConfigForShared.notAllowedUserIds !== undefined && {
+              not_allowed_user_ids: experimentalIn.aclConfigForShared.notAllowedUserIds,
             }),
+          };
+    const experimentalWire: SessionLinkParams.Experimental | undefined =
+      experimentalIn === undefined
+        ? undefined
+        : {
+            ...(experimentalIn.accountType !== undefined && {
+              account_type: experimentalIn.accountType,
+            }),
+            ...(aclWire !== undefined && { acl_config_for_shared: aclWire }),
           };
     const body: SessionLinkParams = {
       toolkit,
       ...(opts.callbackUrl !== undefined && { callback_url: opts.callbackUrl }),
       ...(opts.alias !== undefined && { alias: opts.alias }),
-      ...(opts.accountType !== undefined && { account_type: opts.accountType }),
-      ...(aclWire !== undefined && { acl_config_for_shared: aclWire }),
+      ...(experimentalWire !== undefined && { experimental: experimentalWire }),
     };
 
     let response;

--- a/ts/packages/core/src/types/connectedAccounts.types.ts
+++ b/ts/packages/core/src/types/connectedAccounts.types.ts
@@ -77,17 +77,23 @@ export const ConnectedAccountAclConfigSchema = z.object({
   allowAllUsers: z
     .boolean()
     .optional()
-    .describe('When true, any `userId` may use this SHARED connection (subject to the deny list). Default false.'),
+    .describe(
+      'When true, any `userId` may use this SHARED connection (subject to the deny list). Default false.'
+    ),
   allowedUserIds: z
     .array(aclUserIdString)
     .max(ACL_LIST_MAX_LENGTH)
     .optional()
-    .describe('Explicit list of `userId` strings allowed to use this SHARED connection. Default [].'),
+    .describe(
+      'Explicit list of `userId` strings allowed to use this SHARED connection. Default [].'
+    ),
   notAllowedUserIds: z
     .array(aclUserIdString)
     .max(ACL_LIST_MAX_LENGTH)
     .optional()
-    .describe('Explicit list of `userId` strings denied access. Wins over allow on conflict. Default [].'),
+    .describe(
+      'Explicit list of `userId` strings denied access. Wins over allow on conflict. Default [].'
+    ),
 });
 export type ConnectedAccountAclConfig = z.infer<typeof ConnectedAccountAclConfigSchema>;
 
@@ -103,6 +109,32 @@ export const ConnectedAccountAclConfigResponseSchema = z.object({
 });
 export type ConnectedAccountAclConfigResponse = z.infer<
   typeof ConnectedAccountAclConfigResponseSchema
+>;
+
+/**
+ * Experimental options for SHARED connections, passed at create / link time.
+ *
+ * **Experimental — shape may change in future releases.** Wrapped under a
+ * dedicated `experimental` block on every input and response so the
+ * experimental status is visible at every call site.
+ */
+export const ConnectedAccountExperimentalSchema = z.object({
+  accountType: ConnectedAccountTypeSchema.optional(),
+  aclConfigForShared: ConnectedAccountAclConfigSchema.optional(),
+});
+export type ConnectedAccountExperimental = z.infer<typeof ConnectedAccountExperimentalSchema>;
+
+/**
+ * Resolved experimental block on retrieve / list responses. `accountType`
+ * is always present when the block is; `aclConfigForShared` is only
+ * present when the caller is authorised to see the ACL.
+ */
+export const ConnectedAccountExperimentalResponseSchema = z.object({
+  accountType: ConnectedAccountTypeSchema.optional(),
+  aclConfigForShared: ConnectedAccountAclConfigResponseSchema.optional(),
+});
+export type ConnectedAccountExperimentalResponse = z.infer<
+  typeof ConnectedAccountExperimentalResponseSchema
 >;
 
 export const CreateConnectedAccountParamsSchema = z.object({
@@ -186,8 +218,7 @@ export const ConnectedAccountRetrieveResponseSchema: z.ZodType<{
   isDisabled: boolean;
   createdAt: string;
   updatedAt: string;
-  accountType?: ConnectedAccountType;
-  aclConfigForShared?: ConnectedAccountAclConfigResponse;
+  experimental?: ConnectedAccountExperimentalResponse;
 }> = z.object({
   id: z.string(),
   authConfig: ConnectedAccountAuthConfigSchema,
@@ -211,13 +242,10 @@ export const ConnectedAccountRetrieveResponseSchema: z.ZodType<{
   isDisabled: z.boolean(),
   createdAt: z.string(),
   updatedAt: z.string(),
-  accountType: ConnectedAccountTypeSchema.optional(),
-  // `aclConfigForShared` is only present on the response when the caller
-  // is authorised to see the ACL — otherwise the block is absent and the
-  // field is `undefined`. Callers can distinguish "I can't see the ACL"
-  // from "ACL is the default deny-by-default state" by checking for the
-  // presence of the field.
-  aclConfigForShared: ConnectedAccountAclConfigResponseSchema.optional(),
+  // Experimental — shape may change in future releases. `aclConfigForShared`
+  // inside this block is only populated when the caller is authorised to
+  // see the ACL.
+  experimental: ConnectedAccountExperimentalResponseSchema.optional(),
 });
 
 export type ConnectedAccountRetrieveResponse = z.infer<
@@ -256,6 +284,13 @@ export const ConnectedAccountListParamsSchema = z.object({
     .nullable()
     .optional()
     .describe('The user ids of the connected accounts'),
+  /**
+   * Experimental — shape may change in future releases. Filter by sharing
+   * model. Default (omitted) returns PRIVATE only. Pass `'SHARED'` for only
+   * shared accounts, or `'ALL'` for `PRIVATE` + `SHARED`. Kept flat because
+   * the wire is a query string and can't carry nested objects.
+   */
+  accountType: z.enum(['PRIVATE', 'SHARED', 'ALL']).optional(),
 });
 export type ConnectedAccountListParams = z.infer<typeof ConnectedAccountListParamsSchema>;
 
@@ -293,24 +328,20 @@ export const CreateConnectedAccountLinkOptionsSchema = z.object({
    */
   allowMultiple: z.boolean().optional(),
   /**
-   * Sharing model for the new connection. `PRIVATE` (default) is usable only
-   * by the owning `userId`. `SHARED` can be used by other `userId`s — but
-   * only when the connection is explicitly pinned in a tool-router session's
-   * config and only when the requesting `userId` passes the connection's
-   * ACL.
-   */
-  accountType: ConnectedAccountTypeSchema.optional(),
-  /**
-   * Per-user ACL for SHARED connections. Only valid when
-   * `accountType === 'SHARED'`; raises `ComposioAclOnlyForSharedError`
-   * on a PRIVATE connection.
+   * Experimental options for SHARED connections. Pass `accountType: 'SHARED'`
+   * (and optionally `aclConfigForShared`) to create a connection that can
+   * be reached by other `userId`s when pinned in a session.
    *
-   * Omit the block (or pass `{}`) to keep the deny-by-default state: only the
-   * creator can use the connection. Grant access by setting
+   * Experimental — shape may change in future releases.
+   *
+   * `aclConfigForShared` is only valid when `accountType === 'SHARED'`;
+   * raises `ComposioAclOnlyForSharedError` on a PRIVATE connection. Omit
+   * the inner block (or pass `{}`) to keep the deny-by-default state: only
+   * the creator can use the connection. Grant access by setting
    * `allowAllUsers: true` or listing user IDs in `allowedUserIds`.
    * `notAllowedUserIds` always wins over allow.
    */
-  aclConfigForShared: ConnectedAccountAclConfigSchema.optional(),
+  experimental: ConnectedAccountExperimentalSchema.optional(),
 });
 export type CreateConnectedAccountLinkOptions = z.infer<
   typeof CreateConnectedAccountLinkOptionsSchema
@@ -358,8 +389,7 @@ export const UpdateConnectedAccountAclParamsSchema = ConnectedAccountAclConfigSc
     acl.allowedUserIds !== undefined ||
     acl.notAllowedUserIds !== undefined,
   {
-    message:
-      'At least one of allowAllUsers, allowedUserIds, or notAllowedUserIds must be provided',
+    message: 'At least one of allowAllUsers, allowedUserIds, or notAllowedUserIds must be provided',
   }
 );
 export type UpdateConnectedAccountAclParams = z.infer<typeof UpdateConnectedAccountAclParamsSchema>;

--- a/ts/packages/core/src/utils/transformers/connectedAccounts.ts
+++ b/ts/packages/core/src/utils/transformers/connectedAccounts.ts
@@ -70,17 +70,25 @@ export function transformConnectedAccountResponse(
       createdAt: response.created_at,
       updatedAt: response.updated_at,
       testRequestEndpoint: response.test_request_endpoint,
-      accountType: responseWithLabels.account_type,
-      // `acl_config_for_shared` is conditionally visible — the field is
-      // absent when the caller isn't authorised to see it. Forward
-      // `undefined` rather than synthesising defaults so callers can
-      // distinguish "I can't see the ACL" from "ACL is the default
-      // deny-by-default state".
-      aclConfigForShared: responseWithLabels.acl_config_for_shared
+      // Experimental — shape may change in future releases. Pass the
+      // nested `experimental` block straight through; the inner
+      // `aclConfigForShared` is conditionally visible (absent when the
+      // caller isn't authorised to see the ACL), so distinguish "I can't
+      // see the ACL" from "ACL is the default deny-by-default state" by
+      // checking field presence.
+      experimental: responseWithLabels.experimental
         ? {
-            allowAllUsers: responseWithLabels.acl_config_for_shared.allow_all_users,
-            allowedUserIds: responseWithLabels.acl_config_for_shared.allowed_user_ids,
-            notAllowedUserIds: responseWithLabels.acl_config_for_shared.not_allowed_user_ids,
+            accountType: responseWithLabels.experimental.account_type,
+            aclConfigForShared: responseWithLabels.experimental.acl_config_for_shared
+              ? {
+                  allowAllUsers:
+                    responseWithLabels.experimental.acl_config_for_shared.allow_all_users,
+                  allowedUserIds:
+                    responseWithLabels.experimental.acl_config_for_shared.allowed_user_ids,
+                  notAllowedUserIds:
+                    responseWithLabels.experimental.acl_config_for_shared.not_allowed_user_ids,
+                }
+              : undefined,
           }
         : undefined,
     }));

--- a/ts/packages/core/test/connectedAccounts/connectedAccounts.test.ts
+++ b/ts/packages/core/test/connectedAccounts/connectedAccounts.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mockClient } from '../utils/mocks/client.mock';
-import { ConnectedAccounts, experimental_updateAcl } from '../../src/models/ConnectedAccounts';
+import { ConnectedAccounts } from '../../src/models/ConnectedAccounts';
+import { Experimental } from '../../src/models/Experimental';
 import ComposioClient from '@composio/client';
 import { ConnectedAccountRetrieveResponse } from '@composio/client/resources/connected-accounts.mjs';
 import {
@@ -1677,11 +1678,11 @@ describe('ConnectedAccounts', () => {
     });
   });
 
-  describe('experimental_updateAcl', () => {
-    let composioHandle: { getClient: () => typeof extendedMockClient };
+  describe('composio.experimental.updateAcl', () => {
+    let experimental: Experimental;
 
     beforeEach(() => {
-      composioHandle = { getClient: () => extendedMockClient };
+      experimental = new Experimental(extendedMockClient as unknown as ComposioClient);
     });
 
     it('serializes PATCH body under experimental.acl_config_for_shared', async () => {
@@ -1691,7 +1692,7 @@ describe('ConnectedAccounts', () => {
         success: true,
       });
 
-      const result = await experimental_updateAcl(composioHandle, 'ca_abc', {
+      const result = await experimental.updateAcl('ca_abc', {
         allowAllUsers: true,
         notAllowedUserIds: ['user_bob'],
       });
@@ -1714,7 +1715,7 @@ describe('ConnectedAccounts', () => {
         success: true,
       });
 
-      await experimental_updateAcl(composioHandle, 'ca_abc', { allowedUserIds: ['user_alice'] });
+      await experimental.updateAcl('ca_abc', { allowedUserIds: ['user_alice'] });
 
       expect(extendedMockClient.connectedAccounts.patch).toHaveBeenCalledWith('ca_abc', {
         experimental: {
@@ -1730,7 +1731,7 @@ describe('ConnectedAccounts', () => {
         success: true,
       });
 
-      await experimental_updateAcl(composioHandle, 'ca_abc', { allowedUserIds: [] });
+      await experimental.updateAcl('ca_abc', { allowedUserIds: [] });
 
       expect(extendedMockClient.connectedAccounts.patch).toHaveBeenCalledWith('ca_abc', {
         experimental: { acl_config_for_shared: { allowed_user_ids: [] } },
@@ -1738,7 +1739,7 @@ describe('ConnectedAccounts', () => {
     });
 
     it('rejects an empty params object via the refine', async () => {
-      await expect(experimental_updateAcl(composioHandle, 'ca_abc', {})).rejects.toMatchObject({
+      await expect(experimental.updateAcl('ca_abc', {})).rejects.toMatchObject({
         name: 'ValidationError',
       });
       expect(extendedMockClient.connectedAccounts.patch).not.toHaveBeenCalled();
@@ -1755,7 +1756,7 @@ describe('ConnectedAccounts', () => {
       );
 
       await expect(
-        experimental_updateAcl(composioHandle, 'ca_abc', { allowAllUsers: true })
+        experimental.updateAcl('ca_abc', { allowAllUsers: true })
       ).rejects.toBeInstanceOf(ComposioAclOnlyForSharedError);
     });
 
@@ -1763,9 +1764,9 @@ describe('ConnectedAccounts', () => {
       const otherError = new Error('connection lost');
       extendedMockClient.connectedAccounts.patch.mockRejectedValueOnce(otherError);
 
-      await expect(
-        experimental_updateAcl(composioHandle, 'ca_abc', { allowAllUsers: true })
-      ).rejects.toBe(otherError);
+      await expect(experimental.updateAcl('ca_abc', { allowAllUsers: true })).rejects.toBe(
+        otherError
+      );
     });
   });
 });

--- a/ts/packages/core/test/connectedAccounts/connectedAccounts.test.ts
+++ b/ts/packages/core/test/connectedAccounts/connectedAccounts.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mockClient } from '../utils/mocks/client.mock';
-import { ConnectedAccounts } from '../../src/models/ConnectedAccounts';
+import { ConnectedAccounts, experimental_updateAcl } from '../../src/models/ConnectedAccounts';
 import ComposioClient from '@composio/client';
 import { ConnectedAccountRetrieveResponse } from '@composio/client/resources/connected-accounts.mjs';
 import {
@@ -1521,7 +1521,7 @@ describe('ConnectedAccounts', () => {
     });
   });
 
-  describe('link with accountType + ACL', () => {
+  describe('link with experimental block (SHARED + ACL)', () => {
     beforeEach(() => {
       extendedMockClient.connectedAccounts.list.mockResolvedValue({
         items: [],
@@ -1534,61 +1534,82 @@ describe('ConnectedAccounts', () => {
       });
     });
 
-    it('forwards accountType=SHARED + nested aclConfigForShared to client.link.create', async () => {
+    it('forwards experimental block with accountType + aclConfigForShared to client.link.create', async () => {
       await connectedAccounts.link('user_123', 'auth_config_123', {
-        accountType: 'SHARED',
-        aclConfigForShared: {
-          allowAllUsers: true,
-          notAllowedUserIds: ['user_bob'],
+        experimental: {
+          accountType: 'SHARED',
+          aclConfigForShared: {
+            allowAllUsers: true,
+            notAllowedUserIds: ['user_bob'],
+          },
         },
       });
 
       expect(extendedMockClient.link.create).toHaveBeenCalledWith({
         auth_config_id: 'auth_config_123',
         user_id: 'user_123',
-        account_type: 'SHARED',
-        acl_config_for_shared: {
-          allow_all_users: true,
-          not_allowed_user_ids: ['user_bob'],
+        experimental: {
+          account_type: 'SHARED',
+          acl_config_for_shared: {
+            allow_all_users: true,
+            not_allowed_user_ids: ['user_bob'],
+          },
         },
       });
     });
 
-    it('omits acl_config_for_shared when aclConfigForShared is undefined', async () => {
-      await connectedAccounts.link('user_123', 'auth_config_123', { accountType: 'SHARED' });
+    it('omits the inner acl block when aclConfigForShared is undefined', async () => {
+      await connectedAccounts.link('user_123', 'auth_config_123', {
+        experimental: { accountType: 'SHARED' },
+      });
 
       const body = extendedMockClient.link.create.mock.calls[0][0];
-      expect(body.account_type).toBe('SHARED');
-      expect('acl_config_for_shared' in body).toBe(false);
+      expect(body.experimental).toEqual({ account_type: 'SHARED' });
+      expect('acl_config_for_shared' in body.experimental).toBe(false);
     });
 
-    it('serializes only the fields the caller provided (PATCH-style on inner block)', async () => {
+    it('omits the experimental block entirely when not provided', async () => {
+      await connectedAccounts.link('user_123', 'auth_config_123');
+
+      const body = extendedMockClient.link.create.mock.calls[0][0];
+      expect('experimental' in body).toBe(false);
+    });
+
+    it('serializes only the inner ACL fields the caller provided', async () => {
       await connectedAccounts.link('user_123', 'auth_config_123', {
-        accountType: 'SHARED',
-        aclConfigForShared: { allowedUserIds: ['user_alice'] },
+        experimental: {
+          accountType: 'SHARED',
+          aclConfigForShared: { allowedUserIds: ['user_alice'] },
+        },
       });
 
       expect(extendedMockClient.link.create).toHaveBeenCalledWith({
         auth_config_id: 'auth_config_123',
         user_id: 'user_123',
-        account_type: 'SHARED',
-        acl_config_for_shared: { allowed_user_ids: ['user_alice'] },
+        experimental: {
+          account_type: 'SHARED',
+          acl_config_for_shared: { allowed_user_ids: ['user_alice'] },
+        },
       });
     });
 
     it('preserves explicit empty arrays in the serialized body', async () => {
       await connectedAccounts.link('user_123', 'auth_config_123', {
-        accountType: 'SHARED',
-        aclConfigForShared: { allowedUserIds: [], notAllowedUserIds: [] },
+        experimental: {
+          accountType: 'SHARED',
+          aclConfigForShared: { allowedUserIds: [], notAllowedUserIds: [] },
+        },
       });
 
       expect(extendedMockClient.link.create).toHaveBeenCalledWith({
         auth_config_id: 'auth_config_123',
         user_id: 'user_123',
-        account_type: 'SHARED',
-        acl_config_for_shared: {
-          allowed_user_ids: [],
-          not_allowed_user_ids: [],
+        experimental: {
+          account_type: 'SHARED',
+          acl_config_for_shared: {
+            allowed_user_ids: [],
+            not_allowed_user_ids: [],
+          },
         },
       });
     });
@@ -1596,13 +1617,23 @@ describe('ConnectedAccounts', () => {
     it('maps 400 AclOnlyForShared to ComposioAclOnlyForSharedError', async () => {
       extendedMockClient.link.create.mockReset();
       extendedMockClient.link.create.mockRejectedValueOnce(
-        Object.assign(new BadRequestError(400, undefined, 'acl_config_for_shared is only valid on SHARED connections.', {}), {})
+        Object.assign(
+          new BadRequestError(
+            400,
+            undefined,
+            'acl_config_for_shared is only valid on SHARED connections.',
+            {}
+          ),
+          {}
+        )
       );
 
       await expect(
         connectedAccounts.link('user_123', 'auth_config_123', {
-          accountType: 'PRIVATE',
-          aclConfigForShared: { allowAllUsers: true },
+          experimental: {
+            accountType: 'PRIVATE',
+            aclConfigForShared: { allowAllUsers: true },
+          },
         })
       ).rejects.toBeInstanceOf(ComposioAclOnlyForSharedError);
     });
@@ -1617,23 +1648,60 @@ describe('ConnectedAccounts', () => {
     });
   });
 
-  describe('updateAcl', () => {
-    it('serializes PATCH body with nested acl_config_for_shared', async () => {
+  describe('list with accountType filter', () => {
+    it('forwards accountType to the wire as a flat query param', async () => {
+      extendedMockClient.connectedAccounts.list.mockResolvedValue({
+        items: [],
+        next_cursor: null,
+        total_pages: 0,
+      });
+
+      await connectedAccounts.list({ accountType: 'SHARED', userIds: ['user_creator'] });
+
+      const callArg = extendedMockClient.connectedAccounts.list.mock.calls[0][0];
+      expect(callArg.account_type).toBe('SHARED');
+      expect(callArg.user_ids).toEqual(['user_creator']);
+    });
+
+    it('omits account_type when accountType is not provided', async () => {
+      extendedMockClient.connectedAccounts.list.mockResolvedValue({
+        items: [],
+        next_cursor: null,
+        total_pages: 0,
+      });
+
+      await connectedAccounts.list({ userIds: ['user_creator'] });
+
+      const callArg = extendedMockClient.connectedAccounts.list.mock.calls[0][0];
+      expect('account_type' in callArg).toBe(false);
+    });
+  });
+
+  describe('experimental_updateAcl', () => {
+    let composioHandle: { getClient: () => typeof extendedMockClient };
+
+    beforeEach(() => {
+      composioHandle = { getClient: () => extendedMockClient };
+    });
+
+    it('serializes PATCH body under experimental.acl_config_for_shared', async () => {
       extendedMockClient.connectedAccounts.patch.mockResolvedValueOnce({
         id: 'ca_abc',
         status: 'ACTIVE',
         success: true,
       });
 
-      const result = await connectedAccounts.updateAcl('ca_abc', {
+      const result = await experimental_updateAcl(composioHandle, 'ca_abc', {
         allowAllUsers: true,
         notAllowedUserIds: ['user_bob'],
       });
 
       expect(extendedMockClient.connectedAccounts.patch).toHaveBeenCalledWith('ca_abc', {
-        acl_config_for_shared: {
-          allow_all_users: true,
-          not_allowed_user_ids: ['user_bob'],
+        experimental: {
+          acl_config_for_shared: {
+            allow_all_users: true,
+            not_allowed_user_ids: ['user_bob'],
+          },
         },
       });
       expect(result).toEqual({ id: 'ca_abc', status: 'ACTIVE', success: true });
@@ -1646,10 +1714,12 @@ describe('ConnectedAccounts', () => {
         success: true,
       });
 
-      await connectedAccounts.updateAcl('ca_abc', { allowedUserIds: ['user_alice'] });
+      await experimental_updateAcl(composioHandle, 'ca_abc', { allowedUserIds: ['user_alice'] });
 
       expect(extendedMockClient.connectedAccounts.patch).toHaveBeenCalledWith('ca_abc', {
-        acl_config_for_shared: { allowed_user_ids: ['user_alice'] },
+        experimental: {
+          acl_config_for_shared: { allowed_user_ids: ['user_alice'] },
+        },
       });
     });
 
@@ -1660,15 +1730,15 @@ describe('ConnectedAccounts', () => {
         success: true,
       });
 
-      await connectedAccounts.updateAcl('ca_abc', { allowedUserIds: [] });
+      await experimental_updateAcl(composioHandle, 'ca_abc', { allowedUserIds: [] });
 
       expect(extendedMockClient.connectedAccounts.patch).toHaveBeenCalledWith('ca_abc', {
-        acl_config_for_shared: { allowed_user_ids: [] },
+        experimental: { acl_config_for_shared: { allowed_user_ids: [] } },
       });
     });
 
     it('rejects an empty params object via the refine', async () => {
-      await expect(connectedAccounts.updateAcl('ca_abc', {})).rejects.toMatchObject({
+      await expect(experimental_updateAcl(composioHandle, 'ca_abc', {})).rejects.toMatchObject({
         name: 'ValidationError',
       });
       expect(extendedMockClient.connectedAccounts.patch).not.toHaveBeenCalled();
@@ -1676,11 +1746,16 @@ describe('ConnectedAccounts', () => {
 
     it('maps 400 AclOnlyForShared to ComposioAclOnlyForSharedError', async () => {
       extendedMockClient.connectedAccounts.patch.mockRejectedValueOnce(
-        new BadRequestError(400, undefined, 'acl_config_for_shared is only valid on SHARED connections.', {})
+        new BadRequestError(
+          400,
+          undefined,
+          'acl_config_for_shared is only valid on SHARED connections.',
+          {}
+        )
       );
 
       await expect(
-        connectedAccounts.updateAcl('ca_abc', { allowAllUsers: true })
+        experimental_updateAcl(composioHandle, 'ca_abc', { allowAllUsers: true })
       ).rejects.toBeInstanceOf(ComposioAclOnlyForSharedError);
     });
 
@@ -1689,7 +1764,7 @@ describe('ConnectedAccounts', () => {
       extendedMockClient.connectedAccounts.patch.mockRejectedValueOnce(otherError);
 
       await expect(
-        connectedAccounts.updateAcl('ca_abc', { allowAllUsers: true })
+        experimental_updateAcl(composioHandle, 'ca_abc', { allowAllUsers: true })
       ).rejects.toBe(otherError);
     });
   });

--- a/ts/packages/core/test/models/toolRouter.test.ts
+++ b/ts/packages/core/test/models/toolRouter.test.ts
@@ -1849,28 +1849,42 @@ describe('ToolRouter', () => {
       expect(typeof connectionRequest.waitForConnection).toBe('function');
     });
 
-    // authorize() validates aclConfigForShared at the SDK boundary, same
-    // caps as link() — 1000-entry list, 256-char user_id.
-    it('forwards accountType + nested acl_config_for_shared on the wire', async () => {
+    // authorize() validates experimental.aclConfigForShared at the SDK
+    // boundary — same caps as link() (1000-entry list, 256-char user_id).
+    it('forwards the experimental block to the wire', async () => {
       mockClient.toolRouter.session.link.mockResolvedValueOnce(mockLinkResponse);
 
       const session = await toolRouter.create(userId);
       await session.authorize(toolkit, {
-        accountType: 'SHARED',
-        aclConfigForShared: {
-          allowAllUsers: true,
-          notAllowedUserIds: ['user_bob'],
+        experimental: {
+          accountType: 'SHARED',
+          aclConfigForShared: {
+            allowAllUsers: true,
+            notAllowedUserIds: ['user_bob'],
+          },
         },
       });
 
       expect(mockClient.toolRouter.session.link).toHaveBeenCalledWith(sessionId, {
         toolkit,
-        account_type: 'SHARED',
-        acl_config_for_shared: {
-          allow_all_users: true,
-          not_allowed_user_ids: ['user_bob'],
+        experimental: {
+          account_type: 'SHARED',
+          acl_config_for_shared: {
+            allow_all_users: true,
+            not_allowed_user_ids: ['user_bob'],
+          },
         },
       });
+    });
+
+    it('omits the experimental block entirely when not provided', async () => {
+      mockClient.toolRouter.session.link.mockResolvedValueOnce(mockLinkResponse);
+
+      const session = await toolRouter.create(userId);
+      await session.authorize(toolkit);
+
+      const body = mockClient.toolRouter.session.link.mock.calls[0][1];
+      expect('experimental' in body).toBe(false);
     });
 
     it('throws ValidationError when allowedUserIds exceeds the 1000-entry cap', async () => {
@@ -1879,8 +1893,10 @@ describe('ToolRouter', () => {
 
       await expect(
         session.authorize(toolkit, {
-          accountType: 'SHARED',
-          aclConfigForShared: { allowedUserIds: oversizedList },
+          experimental: {
+            accountType: 'SHARED',
+            aclConfigForShared: { allowedUserIds: oversizedList },
+          },
         })
       ).rejects.toMatchObject({ name: 'ValidationError' });
 
@@ -1893,8 +1909,10 @@ describe('ToolRouter', () => {
 
       await expect(
         session.authorize(toolkit, {
-          accountType: 'SHARED',
-          aclConfigForShared: { allowedUserIds: [tooLongUserId] },
+          experimental: {
+            accountType: 'SHARED',
+            aclConfigForShared: { allowedUserIds: [tooLongUserId] },
+          },
         })
       ).rejects.toMatchObject({ name: 'ValidationError' });
 
@@ -1906,8 +1924,10 @@ describe('ToolRouter', () => {
 
       await expect(
         session.authorize(toolkit, {
-          accountType: 'SHARED',
-          aclConfigForShared: { notAllowedUserIds: [''] },
+          experimental: {
+            accountType: 'SHARED',
+            aclConfigForShared: { notAllowedUserIds: [''] },
+          },
         })
       ).rejects.toMatchObject({ name: 'ValidationError' });
 


### PR DESCRIPTION
## Summary

Moves the SHARED connected-accounts surface in the TypeScript SDK under the `experimental` namespace, mirroring the wire-level restructure of the same fields. Same precedent as `experimental_createTool` / `experimental_createToolkit` — the namespace tells callers the shape may still change. Python equivalent: #3412.

- `connectedAccounts.link()` and `session.authorize()`: flat `accountType` / `aclConfigForShared` options → single `experimental: {...}` block
- `composio.connectedAccounts.updateAcl(...)` → top-level `experimental_updateAcl(composio, id, opts)` export
- `composio.connectedAccounts.list(...)` now exposes `accountType: 'PRIVATE' | 'SHARED' | 'ALL'` (flat — the wire keeps this as a query param)
- `@composio/client` bumped `0.1.0-alpha.71` → `0.1.0-alpha.72` so the generated typed client carries the `Experimental` namespaces

Pinning a SHARED connection in a session (`connectedAccounts: { gmail: [...] }`) and direct execute by `connectedAccountId` are unchanged — only the connection-create / patch / authorize surfaces moved.

## Caller migration

```typescript
// before
await composio.connectedAccounts.link('user_id', 'auth_config_id', {
  accountType: 'SHARED',
  aclConfigForShared: { allowAllUsers: true },
});
await composio.connectedAccounts.updateAcl('ca_abc', { allowAllUsers: true });
await session.authorize('github', {
  accountType: 'SHARED',
  aclConfigForShared: { allowAllUsers: true },
});

// after
import { experimental_updateAcl } from '@composio/core';

await composio.connectedAccounts.link('user_id', 'auth_config_id', {
  experimental: {
    accountType: 'SHARED',
    aclConfigForShared: { allowAllUsers: true },
  },
});
await experimental_updateAcl(composio, 'ca_abc', { allowAllUsers: true });
await session.authorize('github', {
  experimental: {
    accountType: 'SHARED',
    aclConfigForShared: { allowAllUsers: true },
  },
});

// new — list SHARED connections
const shared = await composio.connectedAccounts.list({
  accountType: 'SHARED',
  userIds: ['user_creator'],
});
```

## Tests

- `link()` forwards the experimental block / omits it when not provided / preserves explicit empty arrays
- `link()` maps the `acl_config_for_shared is only valid on SHARED` 400 to `ComposioAclOnlyForSharedError`; unrelated errors fall back to `ComposioFailedToCreateConnectedAccountLink`
- `experimental_updateAcl()` PATCH body construction, deny-list handling, `ValidationError` when no fields provided, same 400-mapper as `link()`
- `authorize()` forwards the experimental block; ACL caps (1000-entry list, 256-char userId, non-empty) still enforced
- `list({ accountType: 'SHARED' })` delegates the flat filter through to the client

## Test plan

- [ ] `pnpm typecheck` clean (core)
- [ ] `pnpm test` → 919 passed
- [ ] Once published, follow-up docs PR (#3406) removes `// @noErrors` directives from TypeScript code samples

🤖 Generated with [Claude Code](https://claude.com/claude-code)