### PR TITLE
docs(py): add 0.13.1 entry to CHANGELOG

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to the Composio Python SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+> Versions between `0.8.11` and `0.13.0` were released without CHANGELOG entries. See the [Git commit log](https://github.com/ComposioHQ/composio/commits/next/python) for changes in that window.
+
+## [0.13.1] - 2026-05-13
+
+### Added
+- **SHARED connected accounts (experimental)**: Connections can now be marked SHARED at create time and reached from a tool-router session by other `user_id`s when explicitly pinned and authorised via a per-user ACL. Mirrors the TypeScript SDK's `@composio/core@0.10.0` release.
+  - `composio.connected_accounts.link(..., experimental={"account_type": "SHARED", "acl_config_for_shared": {...}})` to create.
+  - `composio.experimental.update_acl(nanoid, allow_all_users=..., allowed_user_ids=[...], not_allowed_user_ids=[...])` to update the per-user ACL on an existing SHARED connection. PATCH semantics: omit a field to leave it unchanged; pass `[]` to clear an allow/deny list.
+  - `session.authorize(toolkit, experimental={...})` for the same flow inside a tool-router session.
+  - `composio.connected_accounts.list(account_type='PRIVATE' | 'SHARED' | 'ALL')` filter.
+  - New typed errors: `ComposioAclOnlyForSharedError`, `ComposioSharedAccessDeniedError`, `ComposioSharedConnectionNotAccessibleError`.
+  - **Experimental — shape may change in future releases.** Pinning a SHARED connection in a session config and direct execute by `connected_account_id` are unchanged.
+- **`composio.experimental` namespace**: new module housing experimental SDK methods that take a client (`update_acl`) alongside the existing decorators (`tool`, `Toolkit`).
+
+### Fixed
+- **`initiate()` deprecation warning false-positives**: the legacy `POST /api/v3/connected_accounts` deprecation warning is now gated on the response `Deprecation` HTTP header (RFC 9745) rather than the `auth_scheme` of the request. Custom auth configs and non-OAuth schemes no longer trigger a spurious warning. The legacy endpoint's retired-path 400 is also surfaced as a typed `ComposioLegacyConnectedAccountsEndpointRetiredError`. See https://docs.composio.dev/docs/changelog/2026/04/24.
+- **Schema converter nullability**: `null`-only `anyOf` blocks now preserve nullability instead of dropping to a bare `str` fallback.
+
+### Changed
+- Bumped `composio-client` dependency from `1.36.0` → `1.39.0` so the generated typed client carries the `Experimental` TypedDicts for the SHARED-connection surface.
+
 ## [0.8.11] - 2025-09-10
 
 ### Added


### PR DESCRIPTION
Adds a `0.13.1` entry to `python/CHANGELOG.md` covering the changes accumulated on `next` since the last Python release (`py@0.13.0`, May 7).

The CHANGELOG had been quietly abandoned since `0.8.11` (Sept 2025); rather than try to backfill the 4-minor gap, this PR draws a line and adds a banner pointing readers at the git log for that window. Future releases start fresh from here.

## What's in 0.13.1

- **SHARED connected accounts (experimental)** — `composio.experimental.update_acl`, `experimental={...}` on `link()` / `session.authorize()`, `account_type` filter on `list()`. Mirrors `@composio/core@0.10.0` shipping in #3425.
- **`initiate()` deprecation warning** — gated on response `Deprecation` header (RFC 9745) instead of `auth_scheme`, eliminating false positives for custom auth configs and non-OAuth schemes.
- **Schema converter** — preserves nullability on `null`-only `anyOf` blocks.
- **Dep bump** — `composio-client` 1.36.0 → 1.39.0.

## Release plan

Documentation only — does NOT trigger a release on its own. The Python release flow is tag-triggered:

```bash
# After this PR merges and after #3425 ships:
git tag py@0.13.1 <next HEAD sha>
git push origin py@0.13.1
```

That fires `.github/workflows/py.release.yml` which builds and publishes to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)