### PR TITLE
feat(cli): support `composio upgrade <version>` for specific releases

### DIFF
--- a/.changeset/cli-upgrade-version-arg.md
+++ b/.changeset/cli-upgrade-version-arg.md
@@ -1,0 +1,5 @@
+---
+"@composio/cli": patch
+---
+
+`composio upgrade` now accepts an optional `<version>` argument so you can install a specific stable release or beta (e.g. `composio upgrade 0.13.1`, `composio upgrade 0.13.1-beta.42`, or the full tag `@composio/cli@0.13.1`). When omitted, the command continues to install the latest release on the chosen channel (`--beta` for prereleases).

--- a/ts/packages/cli/src/commands/upgrade.cmd.ts
+++ b/ts/packages/cli/src/commands/upgrade.cmd.ts
@@ -1,5 +1,5 @@
-import { Command, Options } from '@effect/cli';
-import { Effect } from 'effect';
+import { Args, Command, Options } from '@effect/cli';
+import { Effect, Option } from 'effect';
 import { APP_VERSION } from 'src/constants';
 import { UpgradeBinary } from 'src/services/upgrade-binary';
 import { installSkillSafe } from 'src/effects/install-skill';
@@ -10,20 +10,49 @@ const betaOpt = Options.boolean('beta').pipe(
   Options.withDescription('Upgrade to the latest beta CLI release instead of the stable channel')
 );
 
+const versionArg = Args.text({ name: 'version' }).pipe(
+  Args.withDescription(
+    'Install a specific CLI release (e.g. "0.13.1", "0.13.1-beta.42", or full tag "@composio/cli@0.13.1"). If omitted, installs the latest release.'
+  ),
+  Args.optional
+);
+
+const RELEASE_TAG_PREFIX = '@composio/cli@';
+
+const normalizeReleaseTag = (input: string): string => {
+  const trimmed = input.trim();
+  if (trimmed.startsWith(RELEASE_TAG_PREFIX)) return trimmed;
+  // Allow leading "v" for friendliness, e.g. "v0.13.1"
+  const stripped = trimmed.replace(/^v/, '');
+  return `${RELEASE_TAG_PREFIX}${stripped}`;
+};
+
 /**
- * CLI command to upgrade the CLI to the latest available version.
+ * CLI command to upgrade the CLI to the latest available version,
+ * or to install a specific version when one is provided.
  *
  * @example
  * ```bash
  * composio upgrade
+ * composio upgrade 0.13.1
+ * composio upgrade 0.13.1-beta.42
+ * composio upgrade --beta
  * ```
  */
-export const upgradeCmd = Command.make('upgrade', { beta: betaOpt }, ({ beta }) =>
-  Effect.gen(function* () {
-    const upgradeBinary = yield* UpgradeBinary;
-    const newReleaseTag = yield* upgradeBinary.upgrade({ prerelease: beta });
-    yield* installSkillSafe({
-      releaseTag: newReleaseTag ?? `@composio/cli@${APP_VERSION}`,
-    });
-  })
-).pipe(Command.withDescription('Upgrade your Composio CLI to the latest available version.'));
+export const upgradeCmd = Command.make(
+  'upgrade',
+  { beta: betaOpt, version: versionArg },
+  ({ beta, version }) =>
+    Effect.gen(function* () {
+      const upgradeBinary = yield* UpgradeBinary;
+      const tag = Option.isSome(version) ? normalizeReleaseTag(version.value) : undefined;
+      const newReleaseTag = yield* upgradeBinary.upgrade({ prerelease: beta, tag });
+      yield* installSkillSafe({
+        releaseTag: newReleaseTag ?? tag ?? `@composio/cli@${APP_VERSION}`,
+      });
+    })
+).pipe(
+  Command.withDescription(
+    'Upgrade your Composio CLI. Pass a version (e.g. "0.13.1" or "0.13.1-beta.42") to install a specific release, or omit it to install the latest.'
+  )
+);

--- a/ts/packages/cli/src/services/upgrade-binary.ts
+++ b/ts/packages/cli/src/services/upgrade-binary.ts
@@ -103,11 +103,13 @@ export class UpgradeBinary extends Effect.Service<UpgradeBinary>()('services/Upg
       platformArch: PlatformArch,
       options: {
         prerelease?: boolean;
+        tag?: string;
       } = {}
     ): Effect.Effect<GitHubRelease, UpgradeBinaryError, never> =>
       Effect.gen(function* () {
         const prerelease = options.prerelease ?? false;
-        const release = yield* githubConfig.TAG.pipe(
+        const explicitTag = options.tag ? Option.some(options.tag) : githubConfig.TAG;
+        const release = yield* explicitTag.pipe(
           Option.match({
             onNone: Effect.fn(function* () {
               yield* Effect.logDebug(
@@ -536,6 +538,7 @@ export class UpgradeBinary extends Effect.Service<UpgradeBinary>()('services/Upg
     const upgrade = (
       options: {
         prerelease?: boolean;
+        tag?: string;
       } = {}
     ) =>
       Effect.gen(function* () {
@@ -543,6 +546,7 @@ export class UpgradeBinary extends Effect.Service<UpgradeBinary>()('services/Upg
         const upgradeTargetOpt = yield* DEBUG_OVERRIDE_CONFIG['UPGRADE_TARGET'];
         const currentPath = yield* getCurrentExecutablePath();
         const prerelease = options.prerelease ?? false;
+        const explicitTag = options.tag;
         const currentReleaseIdentifier = resolveCurrentReleaseIdentifier(currentPath);
         yield* Effect.logDebug(`Current executable path: ${currentPath}`);
         yield* Effect.logDebug(`Current release identifier: ${currentReleaseIdentifier}`);
@@ -560,15 +564,26 @@ export class UpgradeBinary extends Effect.Service<UpgradeBinary>()('services/Upg
         const didUpgrade = yield* ui.useMakeSpinner('Checking for updates...', spinner =>
           Effect.gen(function* () {
             const platformArch = yield* detectPlatform;
-            const release = yield* fetchLatestRelease(platformArch, { prerelease });
-            const updateAvailable = yield* isUpdateAvailable(release, currentReleaseIdentifier);
-            if (!updateAvailable) {
-              yield* spinner.stop('You are already running the latest version!');
-              return false;
+            const release = yield* fetchLatestRelease(platformArch, {
+              prerelease,
+              tag: explicitTag,
+            });
+            if (!explicitTag) {
+              const updateAvailable = yield* isUpdateAvailable(release, currentReleaseIdentifier);
+              if (!updateAvailable) {
+                yield* spinner.stop('You are already running the latest version!');
+                return false;
+              }
+            } else if (release.tag_name === currentReleaseIdentifier) {
+              yield* Effect.logDebug(
+                `Already running ${release.tag_name}; re-installing as requested`
+              );
             }
 
             yield* spinner.message(
-              `New version available: ${release.tag_name} (current: ${currentReleaseIdentifier}). Downloading...`
+              explicitTag
+                ? `Installing ${release.tag_name} (current: ${currentReleaseIdentifier})...`
+                : `New version available: ${release.tag_name} (current: ${currentReleaseIdentifier}). Downloading...`
             );
 
             const { name, data } = yield* downloadBinary(release, platformArch);


### PR DESCRIPTION
## Summary

- `composio upgrade` now accepts an optional `<version>` argument so users can install any published CLI release — stable or beta — without having to wait for the channel pointer to move.
- Accepts `0.13.1`, `v0.13.1`, `0.13.1-beta.42`, or the full `@composio/cli@0.13.1` tag (normalized internally).
- When a version is provided, the "already on latest" guard is skipped so the command also supports downgrades and reinstalls. `--beta` continues to control the no-arg case.

## Examples

```bash
composio upgrade                       # latest stable (unchanged)
composio upgrade --beta                # latest beta (unchanged)
composio upgrade 0.13.1                # pin to a specific stable
composio upgrade 0.13.1-beta.42        # install a specific beta
composio upgrade @composio/cli@0.13.1  # full release tag also accepted
```

## Implementation

- `upgrade.cmd.ts`: added optional `version` Args, normalizes input to a `@composio/cli@<semver>` release tag, passes it through to the service.
- `upgrade-binary.ts`: `upgrade`/`fetchLatestRelease` now accept a `tag` option that fetches the GitHub release directly via `/releases/tags/<tag>`, bypassing the channel resolver. When a tag is explicit, the update-availability check is skipped.
- Falls back to the explicit tag for `installSkillSafe` when the upgrade completes without returning one.

## Test plan

- [x] `pnpm typecheck` (CLI package) — clean
- [x] `pnpm test` in `ts/packages/cli` — 703 passed, 1 skipped, no regressions in `upgrade-binary.test.ts`
- [ ] Manual: `composio upgrade 0.13.0` from a newer beta to confirm downgrade path works against real GitHub releases
- [ ] Manual: `composio upgrade --beta` still resolves the latest beta when no version is given

🤖 Generated with [Claude Code](https://claude.com/claude-code)