### PR TITLE
feat(cli): send x-cli-session-id header on every request

### DIFF
--- a/.changeset/cli-session-id-header.md
+++ b/.changeset/cli-session-id-header.md
@@ -1,0 +1,5 @@
+---
+"@composio/cli": patch
+---
+
+CLI now sends its per-cwd session id as the `x-cli-session-id` header on every request. The backend uses this to tag tool execution logs with `session_info.cli_session_id`, so all tool executions from a single CLI session (one cwd, one user) can be grouped together in the logs UI.

--- a/ts/packages/cli/src/services/composio-clients.ts
+++ b/ts/packages/cli/src/services/composio-clients.ts
@@ -28,6 +28,7 @@ import {
 import { Session, RetrievedSession } from 'src/models/session';
 import { TriggerType, TriggerTypes, TriggerTypesAsEnums } from 'src/models/trigger-types';
 import * as constants from 'src/constants';
+import { getCurrentCwdSessionId } from 'src/analytics/dispatch';
 import { ComposioUserContext, ComposioUserContextLive } from './user-context';
 import { ProjectContext } from './project-context';
 import type { NoSuchElementException } from 'effect/Cause';
@@ -1325,6 +1326,7 @@ const buildDefaultHeaders = (params: {
   orgId?: string;
   projectId?: string;
 }): Record<string, string> | undefined => {
+  const cliSessionId = getCurrentCwdSessionId();
   const defaultHeaders = {
     'x-framework': 'cli',
     'x-source': 'CLI',
@@ -1338,6 +1340,9 @@ const buildDefaultHeaders = (params: {
           'x-org-id': params.orgId,
           'x-project-id': params.projectId,
         } satisfies Record<string, string>)
+      : {}),
+    ...(cliSessionId
+      ? ({ 'x-cli-session-id': cliSessionId } satisfies Record<string, string>)
       : {}),
   };
 


### PR DESCRIPTION
## Summary

- Pulls the per-cwd CLI session id (already generated by `getCurrentCwdSessionId()` and used as `cli_session_id` on analytics events) and attaches it as the `x-cli-session-id` header on every request from the composio client.
- Backend reads the header off `requestInfo`, threads it through `enrichSessionInfo`, and writes `session_info.cli_session_id` on every tool execution log row.

Companion hermes PR: ComposioHQ/hermes#9990

## Why

The CLI already tracks a stable per-cwd session id for analytics, but tool execution logs are blind to it — there's no way to filter the logs UI / retool back to a single CLI session. Wiring the header through lets us group all tool calls from one CLI workflow together.

## Test plan

- [x] `pnpm --filter @composio/cli typecheck` clean
- [ ] Run `composio tools execute <slug>` against a build with the hermes companion deployed, confirm ClickHouse tool log has `session_info.cli_session_id`
- [ ] Confirm header is absent (and log field absent) when no cwd session is cached

🤖 Generated with [Claude Code](https://claude.com/claude-code)