### PR TITLE
feat(openai): add Qianfan helpers and docs on the existing OpenAI-compatible path

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ The following table shows which AI frameworks and platforms are supported in eac
 
 > **Don't see your provider?** Learn how to [build a custom provider](https://docs.composio.dev/sdk/typescript/custom-providers) to integrate with any AI framework.
 
+OpenAI-compatible vendors such as Baidu Qianfan are supported through the existing OpenAI provider path.
+
 ## Packages
 
 ### Core Packages

--- a/docs/content/docs/providers/openai.mdx
+++ b/docs/content/docs/providers/openai.mdx
@@ -298,6 +298,67 @@ console.log(response.choices[0].message.content);
 
 </IntegrationTabs>
 
+## Use with Baidu Qianfan
+
+Baidu Qianfan is supported through the existing OpenAI-compatible provider path. Use the same `OpenAIProvider` or `OpenAIResponsesProvider`, and point your OpenAI client at Qianfan with the helper defaults below.
+
+<Callout type="info">
+This path keeps Qianfan on the existing OpenAI provider surface instead of introducing a separate provider package.
+</Callout>
+
+<Tabs groupId="language" items={["Python", "TypeScript"]} persist>
+<Tab value="Python">
+```python
+from composio import Composio
+from composio_openai import OpenAIResponsesProvider, create_qianfan_client
+
+composio = Composio(provider=OpenAIResponsesProvider())
+client = create_qianfan_client(
+    api_key="your-qianfan-api-key",
+    appid="app-optional",
+)
+
+session = composio.create(user_id="user_123")
+tools = session.tools()
+
+response = client.responses.create(
+    model="ernie-4.5-8k-preview",
+    tools=tools,
+    input="Summarize my latest Hacker News activity.",
+)
+```
+
+For Chat Completions, keep the same client and switch the provider to `OpenAIProvider()`.
+If you prefer a more explicit helper name for the Responses API, `create_qianfan_responses_client(...)` is also available.
+</Tab>
+<Tab value="TypeScript">
+```typescript
+import { Composio } from '@composio/core';
+import { OpenAIResponsesProvider, createQianfanClient } from '@composio/openai';
+
+const composio = new Composio({
+    provider: new OpenAIResponsesProvider(),
+});
+
+const client = createQianfanClient({
+    apiKey: process.env.QIANFAN_API_KEY!,
+    appid: process.env.QIANFAN_APP_ID,
+});
+
+const session = await composio.create("user_123");
+const tools = await session.tools();
+
+const response = await client.responses.create({
+    model: "ernie-4.5-8k-preview",
+    tools,
+    input: "Summarize my latest Hacker News activity.",
+});
+```
+
+For Chat Completions, keep the same client and switch the provider to `new OpenAIProvider()`.
+</Tab>
+</Tabs>
+
 ## Multi-turn chat
 
 For multi-turn apps, create the session once and reuse it across requests with `composio.use()`. Store the session ID in your database or chat state:

--- a/python/providers/openai/README.md
+++ b/python/providers/openai/README.md
@@ -34,6 +34,32 @@ from openai import OpenAI
 openai_client = OpenAI()
 ```
 
+### Using Baidu Qianfan
+
+Qianfan is supported through the existing OpenAI-compatible path in `composio_openai`. Use the same Composio provider classes and create an OpenAI client with Qianfan defaults:
+
+```python
+from composio import Composio
+from composio_openai import OpenAIResponsesProvider, create_qianfan_client
+
+composio = Composio(provider=OpenAIResponsesProvider())
+client = create_qianfan_client(
+    api_key="your-qianfan-api-key",
+    appid="app-optional",
+)
+
+session = composio.create(user_id="user_123")
+tools = session.tools()
+
+response = client.responses.create(
+    model="ernie-4.5-8k-preview",
+    tools=tools,
+    input="Summarize my latest Hacker News activity.",
+)
+```
+
+For Chat Completions, keep the same client and switch the provider to `OpenAIProvider()`. If you want a Responses-specific helper name, `create_qianfan_responses_client(...)` is also exported.
+
 ### Step 2: Integrating GitHub Tools with Composio
 
 This step involves fetching and integrating GitHub tools provided by Composio, enabling enhanced functionality for LangChain operations.

--- a/python/providers/openai/composio_openai/__init__.py
+++ b/python/providers/openai/composio_openai/__init__.py
@@ -1,3 +1,15 @@
-from composio_openai.provider import OpenAIProvider, OpenAIResponsesProvider
+from composio_openai.provider import (
+    OpenAIProvider,
+    OpenAIResponsesProvider,
+    QIANFAN_BASE_URL,
+    create_qianfan_client,
+    create_qianfan_responses_client,
+)
 
-__all__ = ("OpenAIProvider", "OpenAIResponsesProvider")
+__all__ = (
+    "OpenAIProvider",
+    "OpenAIResponsesProvider",
+    "QIANFAN_BASE_URL",
+    "create_qianfan_client",
+    "create_qianfan_responses_client",
+)

--- a/python/providers/openai/composio_openai/provider.py
+++ b/python/providers/openai/composio_openai/provider.py
@@ -11,7 +11,7 @@ from openai import OpenAI
 from composio.core.provider._openai import OpenAIProvider
 from composio.core.provider._openai_responses import OpenAIResponsesProvider
 
-QIANFAN_BASE_URL = "https://qianfan.baidubce.com/v2"
+QIANFAN_BASE_URL = "https://qianfan.baidubce.com/v2/"
 
 
 def _build_qianfan_headers(
@@ -48,10 +48,11 @@ def create_qianfan_responses_client(
     default_headers: dict[str, str] | None = None,
     **kwargs: t.Any,
 ) -> OpenAI:
-    return OpenAI(
+    return create_qianfan_client(
         api_key=api_key,
+        appid=appid,
         base_url=base_url,
-        default_headers=_build_qianfan_headers(appid, default_headers),
+        default_headers=default_headers,
         **kwargs,
     )
 

--- a/python/providers/openai/composio_openai/provider.py
+++ b/python/providers/openai/composio_openai/provider.py
@@ -2,7 +2,64 @@
 OpenAI Provider for composio SDK.
 """
 
+from __future__ import annotations
+
+import typing as t
+
+from openai import OpenAI
+
 from composio.core.provider._openai import OpenAIProvider
 from composio.core.provider._openai_responses import OpenAIResponsesProvider
 
-__all__ = ["OpenAIProvider", "OpenAIResponsesProvider"]
+QIANFAN_BASE_URL = "https://qianfan.baidubce.com/v2"
+
+
+def _build_qianfan_headers(
+    appid: str | None = None,
+    default_headers: dict[str, str] | None = None,
+) -> dict[str, str]:
+    headers = dict(default_headers or {})
+    if appid:
+        headers["appid"] = appid
+    return headers
+
+
+def create_qianfan_client(
+    *,
+    api_key: str,
+    appid: str | None = None,
+    base_url: str = QIANFAN_BASE_URL,
+    default_headers: dict[str, str] | None = None,
+    **kwargs: t.Any,
+) -> OpenAI:
+    return OpenAI(
+        api_key=api_key,
+        base_url=base_url,
+        default_headers=_build_qianfan_headers(appid, default_headers),
+        **kwargs,
+    )
+
+
+def create_qianfan_responses_client(
+    *,
+    api_key: str,
+    appid: str | None = None,
+    base_url: str = QIANFAN_BASE_URL,
+    default_headers: dict[str, str] | None = None,
+    **kwargs: t.Any,
+) -> OpenAI:
+    return OpenAI(
+        api_key=api_key,
+        base_url=base_url,
+        default_headers=_build_qianfan_headers(appid, default_headers),
+        **kwargs,
+    )
+
+
+__all__ = [
+    "OpenAIProvider",
+    "OpenAIResponsesProvider",
+    "QIANFAN_BASE_URL",
+    "create_qianfan_client",
+    "create_qianfan_responses_client",
+]

--- a/python/tests/test_qianfan_openai_helpers.py
+++ b/python/tests/test_qianfan_openai_helpers.py
@@ -1,0 +1,34 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(
+    0, str(Path(__file__).resolve().parents[1] / "providers" / "openai")
+)
+
+from composio_openai import create_qianfan_client, create_qianfan_responses_client
+
+
+def test_create_qianfan_client_uses_qianfan_base_url():
+    client = create_qianfan_client(api_key="test-key")
+    assert str(client.base_url) == "https://qianfan.baidubce.com/v2/"
+
+
+def test_create_qianfan_client_adds_appid_header_when_present():
+    client = create_qianfan_client(api_key="test-key", appid="app-123")
+    assert client.default_headers["appid"] == "app-123"
+
+
+def test_create_qianfan_client_merges_extra_headers():
+    client = create_qianfan_client(
+        api_key="test-key",
+        appid="app-123",
+        default_headers={"x-trace-id": "trace-1"},
+    )
+    assert client.default_headers["appid"] == "app-123"
+    assert client.default_headers["x-trace-id"] == "trace-1"
+
+
+def test_create_qianfan_responses_client_uses_same_defaults():
+    client = create_qianfan_responses_client(api_key="test-key", appid="app-123")
+    assert str(client.base_url) == "https://qianfan.baidubce.com/v2/"
+    assert client.default_headers["appid"] == "app-123"

--- a/ts/packages/providers/openai/README.md
+++ b/ts/packages/providers/openai/README.md
@@ -34,6 +34,34 @@ Optional environment variables:
 - `OPENAI_API_BASE`: Custom API base URL (for Azure OpenAI)
 - `OPENAI_ORGANIZATION`: OpenAI organization ID
 
+## Using Baidu Qianfan
+
+Qianfan is supported through the existing OpenAI-compatible path in `@composio/openai`. Use the same provider classes and create an OpenAI client with the Qianfan helper defaults:
+
+```typescript
+import { Composio } from '@composio/core';
+import { OpenAIResponsesProvider, createQianfanClient } from '@composio/openai';
+
+const composio = new Composio({
+  provider: new OpenAIResponsesProvider(),
+});
+
+const client = createQianfanClient({
+  apiKey: process.env.QIANFAN_API_KEY!,
+  appid: process.env.QIANFAN_APP_ID,
+});
+
+const tools = await composio.tools.get('user123', 'HACKERNEWS_GET_USER');
+
+const response = await client.responses.create({
+  model: 'ernie-4.5-8k-preview',
+  input: 'Tell me about the user `pg` in hackernews',
+  tools,
+});
+```
+
+For Chat Completions, keep the same client and switch the provider to `new OpenAIProvider()`. If you only need the config object, `createQianfanConfig(...)` returns plain OpenAI client options.
+
 ## Quick Start
 
 ```typescript

--- a/ts/packages/providers/openai/src/index.ts
+++ b/ts/packages/providers/openai/src/index.ts
@@ -14,3 +14,9 @@
  */
 export { OpenAIProvider } from '@composio/core';
 export { OpenAIResponsesProvider } from './OpenAIResponsesProvider';
+export {
+  QIANFAN_BASE_URL,
+  createQianfanClient,
+  createQianfanConfig,
+  type QianfanConfigOptions,
+} from './qianfan';

--- a/ts/packages/providers/openai/src/qianfan.ts
+++ b/ts/packages/providers/openai/src/qianfan.ts
@@ -1,0 +1,28 @@
+import { OpenAI } from 'openai';
+
+export const QIANFAN_BASE_URL = 'https://qianfan.baidubce.com/v2/';
+
+export type QianfanConfigOptions = {
+  apiKey: string;
+  appid?: string;
+  baseURL?: string;
+  defaultHeaders?: Record<string, string>;
+};
+
+export function createQianfanConfig(options: QianfanConfigOptions) {
+  const defaultHeaders = { ...(options.defaultHeaders ?? {}) };
+
+  if (options.appid) {
+    defaultHeaders.appid = options.appid;
+  }
+
+  return {
+    apiKey: options.apiKey,
+    baseURL: options.baseURL ?? QIANFAN_BASE_URL,
+    defaultHeaders,
+  };
+}
+
+export function createQianfanClient(options: QianfanConfigOptions) {
+  return new OpenAI(createQianfanConfig(options));
+}

--- a/ts/packages/providers/openai/test/opeanai-responses.test.ts
+++ b/ts/packages/providers/openai/test/opeanai-responses.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { OpenAIResponsesProvider } from '../src';
+import { createQianfanClient, OpenAIResponsesProvider } from '../src';
 import { Tool } from '@composio/core';
 import { OpenAI } from 'openai';
 
@@ -73,6 +73,18 @@ describe('OpenAIResponsesProvider', () => {
   describe('name property', () => {
     it('should have the correct name', () => {
       expect(provider.name).toBe('openai');
+    });
+  });
+
+  describe('Qianfan helper client', () => {
+    it('creates an OpenAI client with Qianfan defaults', () => {
+      createQianfanClient({ apiKey: 'test-key', appid: 'app-123' });
+
+      expect(OpenAI).toHaveBeenCalledWith({
+        apiKey: 'test-key',
+        baseURL: 'https://qianfan.baidubce.com/v2/',
+        defaultHeaders: { appid: 'app-123' },
+      });
     });
   });
 

--- a/ts/packages/providers/openai/test/openai.test.ts
+++ b/ts/packages/providers/openai/test/openai.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { OpenAIProvider } from '../src';
+import { createQianfanConfig, OpenAIProvider } from '../src';
 import { Tool } from '@composio/core';
 import { OpenAI } from 'openai';
 
@@ -159,6 +159,26 @@ describe('OpenAIProvider', () => {
     it('should return an empty array for empty tools array', () => {
       const wrapped = provider.wrapTools([]);
       expect(wrapped).toEqual([]);
+    });
+  });
+
+  describe('Qianfan helper config', () => {
+    it('uses the Qianfan baseURL by default', () => {
+      const config = createQianfanConfig({ apiKey: 'test-key' });
+      expect(config.baseURL).toBe('https://qianfan.baidubce.com/v2/');
+    });
+
+    it('adds appid and merges custom headers', () => {
+      const config = createQianfanConfig({
+        apiKey: 'test-key',
+        appid: 'app-123',
+        defaultHeaders: { 'x-trace-id': 'trace-1' },
+      });
+
+      expect(config.defaultHeaders).toEqual({
+        appid: 'app-123',
+        'x-trace-id': 'trace-1',
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

This PR adds small Qianfan helper APIs on top of the existing OpenAI-compatible provider path, along with documentation and tests for both Python and TypeScript.

The goal is to make Qianfan a documented and tested path in the OpenAI providers without introducing a separate Qianfan provider package or changing the default OpenAI behavior.

## Why

Qianfan already exposes an OpenAI-compatible API surface, including the standard SDK pattern of setting a custom base URL.

Given the current provider boundaries in this repository, adding a separate Qianfan provider would duplicate the existing OpenAI-compatible path. This PR keeps Qianfan on that existing path, but removes repeated boilerplate by providing small helper constructors/config builders and first-party docs.

In short, this turns a custom base URL workaround into an officially documented and tested integration path.

## What changed

### Python

Added the following exports in `composio_openai`:

- `QIANFAN_BASE_URL`
- `create_qianfan_client(...)`
- `create_qianfan_responses_client(...)`

These helpers:

- default to the Qianfan base URL
- add the optional `appid` header when provided
- merge additional headers without changing existing OpenAI defaults

### TypeScript

Added the following exports in `@composio/openai`:

- `QIANFAN_BASE_URL`
- `createQianfanConfig(...)`
- `createQianfanClient(...)`

These helpers provide the same behavior as the Python helpers and return plain OpenAI client configuration where appropriate.

### Docs

Added Qianfan guidance to:

- the OpenAI provider docs page
- the Python OpenAI provider README
- the TypeScript OpenAI provider README
- the root README (brief note only)

The docs explicitly position Qianfan as supported through the existing OpenAI-compatible path rather than as a separate provider.

### Tests

Added deterministic tests for the new helper behavior:

- Python tests for default base URL, `appid`, and header merging
- TypeScript tests for helper config/client defaults

## Out of scope

This PR intentionally does not include:

- a new standalone Qianfan provider package
- a broader vendor-profile abstraction
- streaming-specific compatibility changes
- online integration tests that require a real Qianfan API key

## Verification

Ran the following checks locally:

```bash
uv run pytest tests/test_qianfan_openai_helpers.py -v
pnpm --filter @composio/openai test
```

Results:

- Python: `4 passed`
- TypeScript: `32 passed`
