### PR TITLE
feat(connected-accounts-py): rename update_acl to update_sharing

### DIFF
--- a/python/composio/core/models/experimental.py
+++ b/python/composio/core/models/experimental.py
@@ -8,7 +8,7 @@ releases. Two flavours live here today:
   Implementation details for these still live in :mod:`custom_tool`;
   this module just exposes them on the namespace.
 - Experimental SDK methods that take a Composio client
-  (``composio.experimental.update_acl``).
+  (``composio.experimental.update_sharing``).
 
 Anything new on the ``composio.experimental`` namespace should land here,
 not on the underlying model modules.
@@ -33,10 +33,9 @@ from .custom_tool import (
     _infer_tool_from_function,
 )
 
-# Server-side 400 message the API uses to reject ACL writes against a
-# PRIVATE connection. Substring-matched in `update_acl` here and in the
-# sibling `link()` / `authorize()` call sites — kept as a single constant
-# so a server-side message tweak only requires one edit.
+# API error fragment returned when ACL fields are sent for a connection
+# that is not SHARED. Substring-matched in `update_sharing` here and in
+# the sibling `link()` / `authorize()` call sites.
 ACL_ONLY_FOR_SHARED_ERROR_FRAGMENT = "acl_config_for_shared is only valid on SHARED"
 
 
@@ -53,38 +52,77 @@ class ExperimentalAPI:
     def __init__(self, client: t.Optional[HttpClient] = None) -> None:
         self._client = client
 
-    def update_acl(
+    def update_sharing(
         self,
         nanoid: str,
         *,
+        account_type: t.Optional[t.Literal["PRIVATE", "SHARED"]] = None,
         allow_all_users: t.Optional[bool] = None,
         allowed_user_ids: t.Optional[t.List[str]] = None,
         not_allowed_user_ids: t.Optional[t.List[str]] = None,
     ) -> connected_account_patch_response.ConnectedAccountPatchResponse:
         """
-        Update the per-user ACL on a SHARED connected account. Experimental —
-        shape may change in future releases.
+        Update the sharing model and/or per-user ACL of a connected account.
+        Experimental — shape may change in future releases.
 
-        Only valid on SHARED connections; raises
-        ``ComposioAclOnlyForSharedError`` on a PRIVATE connection. Omit a
-        parameter to leave it unchanged; pass an empty list to clear an
-        allow/deny list. At least one parameter must be provided.
+        Two knobs in one call:
+
+        - ``account_type`` toggles the sharing model:
+
+          * ``"SHARED"`` promotes a PRIVATE connection to SHARED without
+            re-auth. Optionally pass ACL fields in the same call to grant
+            initial access.
+          * ``"PRIVATE"`` demotes a SHARED connection back to PRIVATE.
+            Non-creator access is revoked and existing ACL settings are
+            cleared. Sending ACL fields in the same call raises
+            ``ComposioAclOnlyForSharedError``.
+
+        - ACL fields (``allow_all_users`` / ``allowed_user_ids`` /
+          ``not_allowed_user_ids``) edit the per-user grants on a SHARED
+          connection. PATCH semantics — omit a field to leave it
+          unchanged; pass an empty list to clear an allow/deny list.
+
+        Demotion silently revokes access from everyone the creator
+        previously granted. Confirm the action on the frontend (showing
+        an explicit "you're about to revoke access from N users" prompt)
+        before calling this with ``account_type="PRIVATE"``.
+
+        At least one field must be provided.
 
         :param nanoid: The connected account ID (``ca_xxx``).
+        :param account_type: ``"SHARED"`` to promote (no re-auth needed),
+            ``"PRIVATE"`` to demote and clear existing ACL settings. Omit to
+            leave the sharing model unchanged.
         :param allow_all_users: When True, any ``user_id`` may use this
             SHARED connection (subject to the deny list).
-        :param allowed_user_ids: Explicit list of allowed ``user_id`` strings.
-            Pass ``[]`` to clear.
-        :param not_allowed_user_ids: Explicit deny list (wins over allow on
-            conflict). Pass ``[]`` to clear — note that clearing the deny
-            list silently re-grants access to previously-blocked users.
+        :param allowed_user_ids: Explicit list of allowed ``user_id``
+            strings. Pass ``[]`` to clear.
+        :param not_allowed_user_ids: Explicit deny list (wins over allow
+            on conflict). Pass ``[]`` to clear — clearing the deny list
+            silently re-grants access to previously-blocked users.
         :return: Response with ``id``, ``status``, and ``success``.
 
-        Example:
-            composio.experimental.update_acl(
+        Examples::
+
+            # Promote a PRIVATE connection to SHARED and grant access in
+            # one call (no re-auth).
+            composio.experimental.update_sharing(
                 'ca_abc',
+                account_type='SHARED',
                 allow_all_users=True,
                 not_allowed_user_ids=['user_bob'],
+            )
+
+            # Edit ACL on a connection that's already SHARED.
+            composio.experimental.update_sharing(
+                'ca_abc',
+                allowed_user_ids=['user_alice'],
+            )
+
+            # Demote — revokes all non-creator access and clears ACL settings.
+            composio.experimental.update_sharing(
+                'ca_abc',
+                account_type='PRIVATE',
             )
         """
         from composio_client import BadRequestError
@@ -93,20 +131,21 @@ class ExperimentalAPI:
 
         if self._client is None:
             raise exceptions.ValidationError(
-                "update_acl requires a Composio client. Access it via "
-                "composio.experimental.update_acl(...)."
+                "update_sharing requires a Composio client. Access it via "
+                "composio.experimental.update_sharing(...)."
             )
         if (
-            allow_all_users is None
+            account_type is None
+            and allow_all_users is None
             and allowed_user_ids is None
             and not_allowed_user_ids is None
         ):
             raise exceptions.ValidationError(
-                "update_acl requires at least one of allow_all_users, "
-                "allowed_user_ids, or not_allowed_user_ids"
+                "update_sharing requires at least one of account_type, "
+                "allow_all_users, allowed_user_ids, or not_allowed_user_ids"
             )
 
-        acl: t.Dict[str, t.Any] = {}
+        acl: connected_account_patch_params.ExperimentalACLConfigForShared = {}
         if allow_all_users is not None:
             acl["allow_all_users"] = allow_all_users
         if allowed_user_ids is not None:
@@ -114,15 +153,16 @@ class ExperimentalAPI:
         if not_allowed_user_ids is not None:
             acl["not_allowed_user_ids"] = not_allowed_user_ids
 
+        experimental_body: connected_account_patch_params.Experimental = {}
+        if account_type is not None:
+            experimental_body["account_type"] = account_type
+        if acl:
+            experimental_body["acl_config_for_shared"] = acl
+
         try:
             return self._client.connected_accounts.patch(
                 nanoid,
-                experimental={
-                    "acl_config_for_shared": t.cast(
-                        connected_account_patch_params.ExperimentalACLConfigForShared,
-                        acl,
-                    ),
-                },
+                experimental=experimental_body,
             )
         except BadRequestError as error:
             message = str(error)

--- a/python/composio/core/models/experimental.py
+++ b/python/composio/core/models/experimental.py
@@ -170,6 +170,27 @@ class ExperimentalAPI:
                 raise exceptions.ComposioAclOnlyForSharedError(message) from error
             raise
 
+    def update_acl(
+        self,
+        nanoid: str,
+        *,
+        allow_all_users: t.Optional[bool] = None,
+        allowed_user_ids: t.Optional[t.List[str]] = None,
+        not_allowed_user_ids: t.Optional[t.List[str]] = None,
+    ) -> connected_account_patch_response.ConnectedAccountPatchResponse:
+        """
+        Deprecated compatibility alias for ``update_sharing()``.
+
+        Use ``update_sharing()`` for new code. This alias only accepts the
+        ACL fields exposed by the older experimental helper.
+        """
+        return self.update_sharing(
+            nanoid,
+            allow_all_users=allow_all_users,
+            allowed_user_ids=allowed_user_ids,
+            not_allowed_user_ids=not_allowed_user_ids,
+        )
+
     @t.overload
     def tool(self, fn: t.Callable[..., t.Any], /) -> CustomTool: ...
 

--- a/python/composio/exceptions.py
+++ b/python/composio/exceptions.py
@@ -353,7 +353,7 @@ class ComposioSharedAccessDeniedError(ConnectedAccountError):
     going through a tool-router session.
 
     Fix: ask the connection's creator to grant access via
-    ``composio.experimental.update_acl()`` — set ``allow_all_users``,
+    ``composio.experimental.update_sharing()`` — set ``allow_all_users``,
     add the ``user_id`` to ``allowed_user_ids``, or remove it from
     ``not_allowed_user_ids``.
     """
@@ -368,7 +368,7 @@ class ComposioSharedConnectionNotAccessibleError(ConnectedAccountError):
     that fails mid-execution.
 
     Fix: grant the session user access via
-    ``composio.experimental.update_acl()`` on the pinned connection,
+    ``composio.experimental.update_sharing()`` on the pinned connection,
     or pin a different connection the user can use.
     """
 

--- a/python/composio/sdk.py
+++ b/python/composio/sdk.py
@@ -180,7 +180,7 @@ class Composio(t.Generic[TTool, TToolCollection], WithLogger):
         self.mcp = MCP(client=self._client)
 
         # experimental API — decorators for custom tools and toolkits,
-        # plus experimental SDK methods (e.g. update_acl)
+        # plus experimental SDK methods (e.g. update_sharing)
         from composio.core.models.experimental import ExperimentalAPI
 
         self.experimental = ExperimentalAPI(client=self._client)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.10,<4"
 dependencies = [
     "pysher>=1.0.8",
     "pydantic>=2.6.4",
-    "composio-client==1.39.0",
+    "composio-client==1.40.0",
     "typing-extensions>=4.0.0",
     "openai",
     "json-schema-to-pydantic>=0.4.8",

--- a/python/tests/test_connected_accounts.py
+++ b/python/tests/test_connected_accounts.py
@@ -788,6 +788,16 @@ class TestConnectedAccountsAcl:
             experimental={"account_type": "SHARED"},
         )
 
+    def test_update_acl_alias_forwards_acl_fields(self, experimental, mock_client):
+        experimental.update_acl("ca_abc", allowed_user_ids=["user_alice"])
+
+        mock_client.connected_accounts.patch.assert_called_once_with(
+            "ca_abc",
+            experimental={
+                "acl_config_for_shared": {"allowed_user_ids": ["user_alice"]}
+            },
+        )
+
     # -- list(account_type=...) — flat experimental filter -----------------
 
     def test_list_forwards_account_type_filter(self, connected_accounts, mock_client):

--- a/python/tests/test_connected_accounts.py
+++ b/python/tests/test_connected_accounts.py
@@ -544,7 +544,7 @@ def _make_bad_request_error(message: str):
 
 class TestConnectedAccountsAcl:
     """Tests for SHARED accounts surface on ``link()`` and
-    ``composio.experimental.update_acl()``."""
+    ``composio.experimental.update_sharing()``."""
 
     @pytest.fixture
     def mock_client(self):
@@ -664,16 +664,16 @@ class TestConnectedAccountsAcl:
                 user_id="user_creator", auth_config_id="auth_config_123"
             )
 
-    # -- experimental.update_acl() body construction + mapper ---------------
+    # -- experimental.update_sharing() body construction + mapper -----------
 
-    def test_update_acl_serializes_nested_body(self, experimental, mock_client):
+    def test_update_sharing_serializes_nested_body(self, experimental, mock_client):
         response = Mock()
         response.id = "ca_abc"
         response.status = "ACTIVE"
         response.success = True
         mock_client.connected_accounts.patch.return_value = response
 
-        result = experimental.update_acl(
+        result = experimental.update_sharing(
             "ca_abc",
             allow_all_users=True,
             not_allowed_user_ids=["user_bob"],
@@ -690,8 +690,8 @@ class TestConnectedAccountsAcl:
         )
         assert result is response
 
-    def test_update_acl_omits_absent_fields(self, experimental, mock_client):
-        experimental.update_acl("ca_abc", allowed_user_ids=["user_alice"])
+    def test_update_sharing_omits_absent_fields(self, experimental, mock_client):
+        experimental.update_sharing("ca_abc", allowed_user_ids=["user_alice"])
 
         mock_client.connected_accounts.patch.assert_called_once_with(
             "ca_abc",
@@ -700,20 +700,20 @@ class TestConnectedAccountsAcl:
             },
         )
 
-    def test_update_acl_preserves_empty_array(self, experimental, mock_client):
-        experimental.update_acl("ca_abc", allowed_user_ids=[])
+    def test_update_sharing_preserves_empty_array(self, experimental, mock_client):
+        experimental.update_sharing("ca_abc", allowed_user_ids=[])
 
         mock_client.connected_accounts.patch.assert_called_once_with(
             "ca_abc",
             experimental={"acl_config_for_shared": {"allowed_user_ids": []}},
         )
 
-    def test_update_acl_rejects_all_none(self, experimental, mock_client):
+    def test_update_sharing_rejects_all_none(self, experimental, mock_client):
         with pytest.raises(exceptions.ValidationError):
-            experimental.update_acl("ca_abc")
+            experimental.update_sharing("ca_abc")
         mock_client.connected_accounts.patch.assert_not_called()
 
-    def test_update_acl_maps_acl_only_for_shared_to_typed_error(
+    def test_update_sharing_maps_acl_only_for_shared_to_typed_error(
         self, experimental, mock_client
     ):
         mock_client.connected_accounts.patch.side_effect = _make_bad_request_error(
@@ -721,9 +721,9 @@ class TestConnectedAccountsAcl:
         )
 
         with pytest.raises(exceptions.ComposioAclOnlyForSharedError):
-            experimental.update_acl("ca_abc", allow_all_users=True)
+            experimental.update_sharing("ca_abc", allow_all_users=True)
 
-    def test_update_acl_rethrows_non_acl_bad_request_errors(
+    def test_update_sharing_rethrows_non_acl_bad_request_errors(
         self, experimental, mock_client
     ):
         unrelated = _make_bad_request_error("some other 400")
@@ -732,13 +732,61 @@ class TestConnectedAccountsAcl:
         from composio_client import BadRequestError
 
         with pytest.raises(BadRequestError):
-            experimental.update_acl("ca_abc", allow_all_users=True)
+            experimental.update_sharing("ca_abc", allow_all_users=True)
 
-    def test_update_acl_requires_client(self):
+    def test_update_sharing_requires_client(self):
         from composio.core.models.experimental import ExperimentalAPI
 
         with pytest.raises(exceptions.ValidationError):
-            ExperimentalAPI().update_acl("ca_abc", allow_all_users=True)
+            ExperimentalAPI().update_sharing("ca_abc", allow_all_users=True)
+
+    # -- experimental.update_sharing() account_type promotion / demotion ----
+
+    def test_update_sharing_promotes_with_acl_in_one_call(
+        self, experimental, mock_client
+    ):
+        """PRIVATE → SHARED with an ACL grant in the same request."""
+        response = Mock()
+        response.id = "ca_abc"
+        response.status = "ACTIVE"
+        response.success = True
+        mock_client.connected_accounts.patch.return_value = response
+
+        experimental.update_sharing(
+            "ca_abc",
+            account_type="SHARED",
+            allow_all_users=True,
+            not_allowed_user_ids=["user_bob"],
+        )
+
+        mock_client.connected_accounts.patch.assert_called_once_with(
+            "ca_abc",
+            experimental={
+                "account_type": "SHARED",
+                "acl_config_for_shared": {
+                    "allow_all_users": True,
+                    "not_allowed_user_ids": ["user_bob"],
+                },
+            },
+        )
+
+    def test_update_sharing_demote_only(self, experimental, mock_client):
+        """SHARED → PRIVATE with no ACL fields."""
+        experimental.update_sharing("ca_abc", account_type="PRIVATE")
+
+        mock_client.connected_accounts.patch.assert_called_once_with(
+            "ca_abc",
+            experimental={"account_type": "PRIVATE"},
+        )
+
+    def test_update_sharing_promote_only_no_acl(self, experimental, mock_client):
+        """PRIVATE → SHARED without ACL fields."""
+        experimental.update_sharing("ca_abc", account_type="SHARED")
+
+        mock_client.connected_accounts.patch.assert_called_once_with(
+            "ca_abc",
+            experimental={"account_type": "SHARED"},
+        )
 
     # -- list(account_type=...) — flat experimental filter -----------------
 

--- a/uv.lock
+++ b/uv.lock
@@ -621,7 +621,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "composio-client", specifier = "==1.39.0" },
+    { name = "composio-client", specifier = "==1.40.0" },
     { name = "json-schema-to-pydantic", specifier = ">=0.4.8" },
     { name = "openai" },
     { name = "pydantic", specifier = ">=2.6.4" },
@@ -663,7 +663,7 @@ requires-dist = [
 
 [[package]]
 name = "composio-client"
-version = "1.39.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -673,9 +673,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0d/78/efc71b2df0d580c4550ee60644193644ae3ddc06fc89f3fc92998db6393c/composio_client-1.39.0.tar.gz", hash = "sha256:2086493925117b956a3166da18414925cb50829172c8211591137fcdc3d60c7d", size = 248246, upload-time = "2026-05-12T14:28:13.071Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/5a/f715690c950b40b5a2b5a801d27abed6dde3f1e9925e5a486813b677b7ec/composio_client-1.40.0.tar.gz", hash = "sha256:ccfb46c5909e3411fe63fa6275df1f3f7af180ae4bcd82d509e14470c615b0d3", size = 248822, upload-time = "2026-05-19T16:01:17.905Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/59/f4ddca56b9f02c8fed3277584111a687c9be986d0d2e8b421c80a20caa03/composio_client-1.39.0-py3-none-any.whl", hash = "sha256:bf6050dc0d523bd1e9d52e39e162f5b23bd029aa441b5c4a18e1751aae58571d", size = 284163, upload-time = "2026-05-12T14:28:11.681Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/5d/aa520ecaaf143f69b8d3e1dab5945aeecd25b1b068a9093b9164408fabbd/composio_client-1.40.0-py3-none-any.whl", hash = "sha256:1785bd210f948496d034059b3d5133c5f480a07f55fb4c2f8bfe5a1612f249e5", size = 284567, upload-time = "2026-05-19T16:01:16.597Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Python SDK update for connected-account sharing. This updates the experimental connected-account PATCH helper so callers can change the sharing model without sending the user through auth again.

- `composio.experimental.update_acl(...)` is renamed to `composio.experimental.update_sharing(...)`
- `update_sharing()` accepts `account_type='PRIVATE' | 'SHARED'` alongside the existing ACL kwargs
- the PATCH body forwards `account_type` and `acl_config_for_shared` under the generated `experimental={...}` block
- keeps `update_acl()` as a deprecated compatibility alias for ACL-only alpha callers
- keeps the same `AclOnlyForShared` 400 mapping for ACL-on-PRIVATE failures

## Caller migration

```python
# before
composio.experimental.update_acl(
    "ca_abc",
    allow_all_users=True,
)

# after: edit ACL on an already-SHARED connection
composio.experimental.update_sharing(
    "ca_abc",
    allow_all_users=True,
)

# new: promote without re-auth and grant access in one call
composio.experimental.update_sharing(
    "ca_abc",
    account_type="SHARED",
    allow_all_users=True,
    not_allowed_user_ids=["user_bob"],
)

# new: demote and clear ACL settings
composio.experimental.update_sharing(
    "ca_abc",
    account_type="PRIVATE",
)
```

## Tests

- `update_sharing()` body construction for ACL-only updates
- `update_sharing(account_type="SHARED", ...)` promote + ACL in one call
- `update_sharing(account_type="PRIVATE")` demote-only call
- empty params validation
- no-client validation
- ACL-only 400 maps to `ComposioAclOnlyForSharedError`
- unrelated 400s re-raise
- deprecated `update_acl()` alias still forwards ACL-only updates

## Test plan

- [x] `cd python && uv run pytest tests/test_connected_accounts.py -q` → 54 passed
- [x] `cd python && uv run ruff check composio/core/models/experimental.py tests/test_connected_accounts.py` → clean