### PR TITLE
feat(connected-accounts): rename experimental updateAcl to updateSharing

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ catalogs:
       specifier: ^4.20250917.0
       version: 4.20260218.0
     '@composio/client':
-      specifier: 0.1.0-alpha.72
-      version: 0.1.0-alpha.72
+      specifier: 0.1.0-alpha.73
+      version: 0.1.0-alpha.73
     '@effect/cli':
       specifier: ^0.73.2
       version: 0.73.2
@@ -1079,7 +1079,7 @@ importers:
         version: link:../cli-local-tools
       '@composio/client':
         specifier: 'catalog:'
-        version: 0.1.0-alpha.72
+        version: 0.1.0-alpha.73
       '@composio/core':
         specifier: workspace:*
         version: link:../core
@@ -1249,7 +1249,7 @@ importers:
     dependencies:
       '@composio/client':
         specifier: 'catalog:'
-        version: 0.1.0-alpha.72
+        version: 0.1.0-alpha.73
       '@composio/json-schema-to-zod':
         specifier: workspace:*
         version: link:../json-schema-to-zod
@@ -1912,8 +1912,8 @@ packages:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
 
-  '@composio/client@0.1.0-alpha.72':
-    resolution: {integrity: sha512-2WYXgdlMvhoaJCsaSfyMAYGQ2tS5l2Fqdh2cMRqNi8NybIoOkFZy2ApBJJOoQwqfpUr41VymMW6FtiNQm7JavQ==}
+  '@composio/client@0.1.0-alpha.73':
+    resolution: {integrity: sha512-tG7qJOqymqPC2PwHcB8iqZUdAVj2R3RtUXO6o+wS4PCMt8yk9ysPH54luEsnLIObeMSnp9kA87BzTBGoRHelOA==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -7286,7 +7286,7 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@composio/client@0.1.0-alpha.72': {}
+  '@composio/client@0.1.0-alpha.73': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,7 +22,7 @@ catalog:
   '@clack/prompts': '^1.0.1'
   '@cloudflare/vitest-pool-workers': ^0.9.2
   '@cloudflare/workers-types': ^4.20250917.0
-  '@composio/client': 0.1.0-alpha.72
+  '@composio/client': 0.1.0-alpha.73
   '@effect/cli': ^0.73.2
   '@effect/eslint-plugin': ^0.3.2
   '@effect/language-service': ^0.74.0

--- a/ts/packages/core/CHANGELOG.md
+++ b/ts/packages/core/CHANGELOG.md
@@ -37,14 +37,14 @@
   });
   await composio.experimental.updateSharing('ca_abc', { allowAllUsers: true });
 
-  // new — promote without re-auth and grant access atomically
+  // new — promote without re-auth and grant access in one call
   await composio.experimental.updateSharing('ca_abc', {
     accountType: 'SHARED',
     allowAllUsers: true,
     notAllowedUserIds: ['user_bob'],
   });
 
-  // new — demote; backend clears stored ACL atomically
+  // new — demote and clear ACL settings
   await composio.experimental.updateSharing('ca_abc', { accountType: 'PRIVATE' });
   await session.authorize('github', {
     experimental: {

--- a/ts/packages/core/CHANGELOG.md
+++ b/ts/packages/core/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - 42ebff3: feat(connected-accounts): namespace SHARED-connection surface under `experimental`
 
-  Aligns the TypeScript SDK with the experimental wire shape used by Shared Connections. The flat `accountType` / `aclConfigForShared` options on `connectedAccounts.link()` and `session.authorize()` have moved under a single `experimental` block, and `connectedAccounts.updateAcl()` has moved off the class onto a top-level `experimental_updateAcl(composio, id, opts)` export — same precedent as `experimental_createTool` / `experimental_createToolkit`.
+  Aligns the TypeScript SDK with the experimental wire shape used by Shared Connections. The flat `accountType` / `aclConfigForShared` options on `connectedAccounts.link()` and `session.authorize()` have moved under a single `experimental` block, and `connectedAccounts.updateAcl()` has moved off the class onto `composio.experimental.updateSharing(id, opts)`.
 
   The `experimental` namespace is the signal that the shape may change in future releases. Pinning a SHARED connection in a session config (`connectedAccounts: { gmail: [...] }`) and direct execute by `connectedAccountId` are unchanged — only the connection-create / patch / authorize surfaces are namespaced.
 
@@ -35,7 +35,17 @@
       aclConfigForShared: { allowAllUsers: true },
     },
   });
-  await experimental_updateAcl(composio, 'ca_abc', { allowAllUsers: true });
+  await composio.experimental.updateSharing('ca_abc', { allowAllUsers: true });
+
+  // new — promote without re-auth and grant access atomically
+  await composio.experimental.updateSharing('ca_abc', {
+    accountType: 'SHARED',
+    allowAllUsers: true,
+    notAllowedUserIds: ['user_bob'],
+  });
+
+  // new — demote; backend clears stored ACL atomically
+  await composio.experimental.updateSharing('ca_abc', { accountType: 'PRIVATE' });
   await session.authorize('github', {
     experimental: {
       accountType: 'SHARED',

--- a/ts/packages/core/src/composio.ts
+++ b/ts/packages/core/src/composio.ts
@@ -197,7 +197,7 @@ export class Composio<
   connectedAccounts: ConnectedAccounts;
   /**
    * Experimental SDK methods whose shape may change in future releases.
-   * Houses stateful operations like {@link Experimental.updateAcl} that
+   * Houses stateful operations like {@link Experimental.updateSharing} that
    * take a client and perform I/O. Stateless experimental factories
    * (e.g. `experimental_createTool`) stay at the top level.
    * @experimental

--- a/ts/packages/core/src/errors/ConnectedAccountsErrors.ts
+++ b/ts/packages/core/src/errors/ConnectedAccountsErrors.ts
@@ -74,7 +74,7 @@ export class ComposioSharedAccessDeniedError extends ComposioError {
       code: ConnectedAccountErrorCodes.SHARED_ACCESS_DENIED,
       statusCode: 403,
       possibleFixes: options.possibleFixes || [
-        "Ask the connection's creator to grant access via composio.experimental.updateAcl() — set allowAllUsers, add the userId to allowedUserIds, or remove it from notAllowedUserIds.",
+        "Ask the connection's creator to grant access via composio.experimental.updateSharing() — set allowAllUsers, add the userId to allowedUserIds, or remove it from notAllowedUserIds.",
       ],
     });
     this.name = 'ComposioSharedAccessDeniedError';
@@ -119,7 +119,7 @@ export class ComposioSharedConnectionNotAccessibleError extends ComposioError {
       code: ConnectedAccountErrorCodes.SHARED_CONNECTION_NOT_ACCESSIBLE,
       statusCode: 400,
       possibleFixes: options.possibleFixes || [
-        'Grant the session user access via composio.experimental.updateAcl() on the pinned connection, or pin a different connection the user can use.',
+        'Grant the session user access via composio.experimental.updateSharing() on the pinned connection, or pin a different connection the user can use.',
       ],
     });
     this.name = 'ComposioSharedConnectionNotAccessibleError';

--- a/ts/packages/core/src/index.ts
+++ b/ts/packages/core/src/index.ts
@@ -39,7 +39,7 @@ export { createCustomTool as experimental_createTool } from './models/CustomTool
 export { createCustomToolkit as experimental_createToolkit } from './models/CustomTool';
 
 // Experimental shared connected accounts — shape may change in future releases.
-// `updateAcl` is mounted as a method on `composio.experimental.updateAcl(...)`
+// `updateSharing` is mounted as a method on `composio.experimental.updateSharing(...)`
 // because it takes a client and performs I/O. The `Experimental` class
 // itself is re-exported so callers can type their own composio handles
 // (e.g. in test helpers).

--- a/ts/packages/core/src/models/ConnectedAccounts.ts
+++ b/ts/packages/core/src/models/ConnectedAccounts.ts
@@ -591,8 +591,8 @@ export class ConnectedAccounts {
   /**
    * Enable or disable a connected account. Accepts `{ enabled: boolean }`.
    *
-   * For ACL writes on SHARED connections, see
-   * `composio.experimental.updateAcl()`.
+   * For sharing model and ACL writes, see
+   * `composio.experimental.updateSharing()`.
    *
    * @param {string} nanoid - The unique identifier of the connected account
    * @param {UpdateConnectedAccountParams} params - The update parameters

--- a/ts/packages/core/src/models/Experimental.ts
+++ b/ts/packages/core/src/models/Experimental.ts
@@ -23,11 +23,9 @@ import { ComposioAclOnlyForSharedError } from '../errors';
 import { telemetry } from '../telemetry/Telemetry';
 
 /**
- * Server-side 400 message the API uses to reject ACL writes against a
- * PRIVATE connection. Substring-matched in `updateSharing` here, and in the
- * sibling `connectedAccounts.link()` / `session.authorize()` call sites
- * — kept as a single constant so a server-side message tweak only
- * requires one edit.
+ * API error fragment returned when ACL fields are sent for a connection
+ * that is not SHARED. Substring-matched in `updateSharing` here and in
+ * the sibling `connectedAccounts.link()` / `session.authorize()` call sites.
  */
 export const ACL_ONLY_FOR_SHARED_ERROR_FRAGMENT = 'acl_config_for_shared is only valid on SHARED';
 
@@ -108,11 +106,11 @@ export class Experimental {
    * **Experimental — shape may change in future releases.**
    *
    * `accountType: 'SHARED'` promotes a PRIVATE connection without re-auth.
-   * `accountType: 'PRIVATE'` demotes a SHARED connection and the backend
-   * clears its stored ACL atomically. ACL fields are only meaningful for
-   * SHARED connections — sending ACL fields on a PRIVATE connection raises
-   * `ComposioAclOnlyForSharedError` (400). Sharing writes require the
-   * connection's creator.
+   * `accountType: 'PRIVATE'` demotes a SHARED connection, revokes
+   * non-creator access, and clears existing ACL settings. ACL fields are
+   * only meaningful for SHARED connections — sending ACL fields on a
+   * PRIVATE connection raises `ComposioAclOnlyForSharedError` (400).
+   * Sharing writes require the connection's creator.
    *
    * PATCH semantics: omit a field to leave it unchanged; pass an empty
    * array to clear an allow/deny list. At least one field must be
@@ -154,7 +152,7 @@ export class Experimental {
    * // Revoke a previously-granted allow list (back to deny-by-default)
    * await composio.experimental.updateSharing('ca_abc', { allowedUserIds: [] });
    *
-   * // Demote to PRIVATE; backend clears stored ACL state
+   * // Demote to PRIVATE and clear ACL settings
    * await composio.experimental.updateSharing('ca_abc', { accountType: 'PRIVATE' });
    * ```
    *

--- a/ts/packages/core/src/models/Experimental.ts
+++ b/ts/packages/core/src/models/Experimental.ts
@@ -15,6 +15,8 @@ import {
   ConnectedAccountExperimental,
   UpdateConnectedAccountAclParams,
   UpdateConnectedAccountAclParamsSchema,
+  UpdateConnectedAccountSharingParams,
+  UpdateConnectedAccountSharingParamsSchema,
 } from '../types/connectedAccounts.types';
 import { ValidationError } from '../errors/ValidationErrors';
 import { ComposioAclOnlyForSharedError } from '../errors';
@@ -22,7 +24,7 @@ import { telemetry } from '../telemetry/Telemetry';
 
 /**
  * Server-side 400 message the API uses to reject ACL writes against a
- * PRIVATE connection. Substring-matched in `updateAcl` here, and in the
+ * PRIVATE connection. Substring-matched in `updateSharing` here, and in the
  * sibling `connectedAccounts.link()` / `session.authorize()` call sites
  * — kept as a single constant so a server-side message tweak only
  * requires one edit.
@@ -102,12 +104,15 @@ export class Experimental {
   }
 
   /**
-   * Update the per-user ACL on a SHARED connected account.
+   * Update the sharing model and/or per-user ACL on a connected account.
    * **Experimental — shape may change in future releases.**
    *
-   * Only meaningful for SHARED connections — calling this on a PRIVATE
-   * connection raises `ComposioAclOnlyForSharedError` (400). ACL writes
-   * require the connection's creator or an API key.
+   * `accountType: 'SHARED'` promotes a PRIVATE connection without re-auth.
+   * `accountType: 'PRIVATE'` demotes a SHARED connection and the backend
+   * clears its stored ACL atomically. ACL fields are only meaningful for
+   * SHARED connections — sending ACL fields on a PRIVATE connection raises
+   * `ComposioAclOnlyForSharedError` (400). Sharing writes require the
+   * connection's creator or an API key.
    *
    * PATCH semantics: omit a field to leave it unchanged; pass an empty
    * array to clear an allow/deny list. At least one field must be
@@ -125,22 +130,32 @@ export class Experimental {
    *
    * const composio = new Composio({ apiKey: '...' });
    *
+   * // Promote to SHARED and grant access in one call
+   * await composio.experimental.updateSharing('ca_abc', {
+   *   accountType: 'SHARED',
+   *   allowAllUsers: true,
+   *   notAllowedUserIds: ['user_bob'],
+   * });
+   *
    * // Allow every userId to use this connection
-   * await composio.experimental.updateAcl('ca_abc', { allowAllUsers: true });
+   * await composio.experimental.updateSharing('ca_abc', { allowAllUsers: true });
    *
    * // Everyone except a specific user
-   * await composio.experimental.updateAcl('ca_abc', {
+   * await composio.experimental.updateSharing('ca_abc', {
    *   allowAllUsers: true,
    *   notAllowedUserIds: ['user_bob'],
    * });
    *
    * // Targeted allow
-   * await composio.experimental.updateAcl('ca_abc', {
+   * await composio.experimental.updateSharing('ca_abc', {
    *   allowedUserIds: ['user_alice', 'user_bob'],
    * });
    *
    * // Revoke a previously-granted allow list (back to deny-by-default)
-   * await composio.experimental.updateAcl('ca_abc', { allowedUserIds: [] });
+   * await composio.experimental.updateSharing('ca_abc', { allowedUserIds: [] });
+   *
+   * // Demote to PRIVATE; backend clears stored ACL state
+   * await composio.experimental.updateSharing('ca_abc', { accountType: 'PRIVATE' });
    * ```
    *
    * **Empty-array semantics — read carefully.** Passing `[]` for either
@@ -157,21 +172,34 @@ export class Experimental {
    *   `composio.connectedAccounts.get(nanoid)` after the promise
    *   resolves and inspect `account.experimental?.aclConfigForShared`.
    */
-  async updateAcl(
+  async updateSharing(
     nanoid: string,
-    params: UpdateConnectedAccountAclParams
+    params: UpdateConnectedAccountSharingParams
   ): Promise<ConnectedAccountPatchResponse> {
-    const parsedParams = UpdateConnectedAccountAclParamsSchema.safeParse(params);
+    const parsedParams = UpdateConnectedAccountSharingParamsSchema.safeParse(params);
     if (!parsedParams.success) {
-      throw new ValidationError('Failed to parse connected account ACL update params', {
+      throw new ValidationError('Failed to parse connected account sharing update params', {
         cause: parsedParams.error,
       });
     }
 
+    const hasAclFields =
+      parsedParams.data.allowAllUsers !== undefined ||
+      parsedParams.data.allowedUserIds !== undefined ||
+      parsedParams.data.notAllowedUserIds !== undefined;
+    const aclWire = hasAclFields ? serializeAclConfigForWire(parsedParams.data) : undefined;
+    // Shim until the Stainless client includes
+    // `ConnectedAccountPatchParams.Experimental.account_type` from
+    // hermes#10032. The backend already accepts it under `experimental`.
+    const experimental: ExperimentalWire = {
+      ...(parsedParams.data.accountType !== undefined && {
+        account_type: parsedParams.data.accountType,
+      }),
+      ...(aclWire !== undefined && { acl_config_for_shared: aclWire }),
+    };
+
     const body: ConnectedAccountPatchParams = {
-      experimental: {
-        acl_config_for_shared: serializeAclConfigForWire(parsedParams.data),
-      },
+      experimental,
     };
 
     try {
@@ -186,5 +214,23 @@ export class Experimental {
       }
       throw error;
     }
+  }
+
+  /**
+   * @deprecated Use {@link updateSharing}. Kept as a compatibility alias for
+   * the alpha releases that exposed ACL-only updates under `updateAcl`.
+   */
+  async updateAcl(
+    nanoid: string,
+    params: UpdateConnectedAccountAclParams
+  ): Promise<ConnectedAccountPatchResponse> {
+    const parsedParams = UpdateConnectedAccountAclParamsSchema.safeParse(params);
+    if (!parsedParams.success) {
+      throw new ValidationError('Failed to parse connected account ACL update params', {
+        cause: parsedParams.error,
+      });
+    }
+
+    return this.updateSharing(nanoid, parsedParams.data);
   }
 }

--- a/ts/packages/core/src/models/Experimental.ts
+++ b/ts/packages/core/src/models/Experimental.ts
@@ -112,7 +112,7 @@ export class Experimental {
    * clears its stored ACL atomically. ACL fields are only meaningful for
    * SHARED connections — sending ACL fields on a PRIVATE connection raises
    * `ComposioAclOnlyForSharedError` (400). Sharing writes require the
-   * connection's creator or an API key.
+   * connection's creator.
    *
    * PATCH semantics: omit a field to leave it unchanged; pass an empty
    * array to clear an allow/deny list. At least one field must be

--- a/ts/packages/core/src/models/Experimental.ts
+++ b/ts/packages/core/src/models/Experimental.ts
@@ -188,15 +188,13 @@ export class Experimental {
       parsedParams.data.allowedUserIds !== undefined ||
       parsedParams.data.notAllowedUserIds !== undefined;
     const aclWire = hasAclFields ? serializeAclConfigForWire(parsedParams.data) : undefined;
-    // Shim until the Stainless client includes
-    // `ConnectedAccountPatchParams.Experimental.account_type` from
-    // hermes#10032. The backend already accepts it under `experimental`.
-    const experimental: ExperimentalWire = {
-      ...(parsedParams.data.accountType !== undefined && {
-        account_type: parsedParams.data.accountType,
-      }),
-      ...(aclWire !== undefined && { acl_config_for_shared: aclWire }),
-    };
+    const experimental: ConnectedAccountPatchParams.Experimental = {};
+    if (parsedParams.data.accountType !== undefined) {
+      experimental.account_type = parsedParams.data.accountType;
+    }
+    if (aclWire !== undefined) {
+      experimental.acl_config_for_shared = aclWire;
+    }
 
     const body: ConnectedAccountPatchParams = {
       experimental,

--- a/ts/packages/core/src/types/connectedAccounts.types.ts
+++ b/ts/packages/core/src/types/connectedAccounts.types.ts
@@ -370,7 +370,7 @@ export const UpdateConnectedAccountParamsSchema = z.object({
 const UpdateConnectedAccountSharingParamsBaseSchema = ConnectedAccountAclConfigSchema.extend({
   /**
    * Sharing model toggle. `SHARED` promotes a PRIVATE connection without
-   * re-auth; `PRIVATE` demotes and the backend clears stored ACL state.
+   * re-auth; `PRIVATE` demotes and clears existing ACL settings.
    */
   accountType: ConnectedAccountTypeSchema.optional(),
 });

--- a/ts/packages/core/src/types/connectedAccounts.types.ts
+++ b/ts/packages/core/src/types/connectedAccounts.types.ts
@@ -367,10 +367,19 @@ export const UpdateConnectedAccountParamsSchema = z.object({
   enabled: z.boolean(),
 });
 
+const UpdateConnectedAccountSharingParamsBaseSchema = ConnectedAccountAclConfigSchema.extend({
+  /**
+   * Sharing model toggle. `SHARED` promotes a PRIVATE connection without
+   * re-auth; `PRIVATE` demotes and the backend clears stored ACL state.
+   */
+  accountType: ConnectedAccountTypeSchema.optional(),
+});
+
 /**
- * Params for `composio.connectedAccounts.updateAcl()`. Mirrors the inner
+ * Params for `composio.experimental.updateSharing()`. Mirrors the inner
  * shape of the wire's `acl_config_for_shared` block — the SDK adds the
- * outer nesting at the boundary, so callers pass the three fields flat.
+ * outer nesting at the boundary, so callers pass the account type and ACL
+ * fields flat.
  *
  * PATCH-style semantics — omit a field to leave it unchanged; pass an
  * empty array to clear an allow/deny list. Raises
@@ -379,10 +388,32 @@ export const UpdateConnectedAccountParamsSchema = z.object({
  * Each field is optional, but at least one must be provided — passing an
  * empty object is rejected as a no-op.
  */
-// NOTE: `UpdateConnectedAccountAclParamsSchema` is a ZodEffects (because of
+// NOTE: `UpdateConnectedAccountSharingParamsSchema` is a ZodEffects (because of
 // the `.refine` below) — it does not expose `.shape`. If you need to reuse
 // individual ACL fields elsewhere, pull them from
 // `ConnectedAccountAclConfigSchema.shape` (the unrefined base) instead.
+export const UpdateConnectedAccountSharingParamsSchema =
+  UpdateConnectedAccountSharingParamsBaseSchema.refine(
+    acl =>
+      acl.accountType !== undefined ||
+      acl.allowAllUsers !== undefined ||
+      acl.allowedUserIds !== undefined ||
+      acl.notAllowedUserIds !== undefined,
+    {
+      message:
+        'At least one of accountType, allowAllUsers, allowedUserIds, or notAllowedUserIds must be provided',
+    }
+  );
+export type UpdateConnectedAccountSharingParams = z.infer<
+  typeof UpdateConnectedAccountSharingParamsSchema
+>;
+
+/**
+ * Params for `composio.experimental.updateAcl()`.
+ *
+ * @deprecated Use `UpdateConnectedAccountSharingParams` with
+ * `composio.experimental.updateSharing()`.
+ */
 export const UpdateConnectedAccountAclParamsSchema = ConnectedAccountAclConfigSchema.refine(
   acl =>
     acl.allowAllUsers !== undefined ||

--- a/ts/packages/core/test/connectedAccounts/connectedAccounts.test.ts
+++ b/ts/packages/core/test/connectedAccounts/connectedAccounts.test.ts
@@ -1678,7 +1678,7 @@ describe('ConnectedAccounts', () => {
     });
   });
 
-  describe('composio.experimental.updateAcl', () => {
+  describe('composio.experimental.updateSharing', () => {
     let experimental: Experimental;
 
     beforeEach(() => {
@@ -1692,7 +1692,7 @@ describe('ConnectedAccounts', () => {
         success: true,
       });
 
-      const result = await experimental.updateAcl('ca_abc', {
+      const result = await experimental.updateSharing('ca_abc', {
         allowAllUsers: true,
         notAllowedUserIds: ['user_bob'],
       });
@@ -1715,7 +1715,7 @@ describe('ConnectedAccounts', () => {
         success: true,
       });
 
-      await experimental.updateAcl('ca_abc', { allowedUserIds: ['user_alice'] });
+      await experimental.updateSharing('ca_abc', { allowedUserIds: ['user_alice'] });
 
       expect(extendedMockClient.connectedAccounts.patch).toHaveBeenCalledWith('ca_abc', {
         experimental: {
@@ -1731,7 +1731,7 @@ describe('ConnectedAccounts', () => {
         success: true,
       });
 
-      await experimental.updateAcl('ca_abc', { allowedUserIds: [] });
+      await experimental.updateSharing('ca_abc', { allowedUserIds: [] });
 
       expect(extendedMockClient.connectedAccounts.patch).toHaveBeenCalledWith('ca_abc', {
         experimental: { acl_config_for_shared: { allowed_user_ids: [] } },
@@ -1739,10 +1739,48 @@ describe('ConnectedAccounts', () => {
     });
 
     it('rejects an empty params object via the refine', async () => {
-      await expect(experimental.updateAcl('ca_abc', {})).rejects.toMatchObject({
+      await expect(experimental.updateSharing('ca_abc', {})).rejects.toMatchObject({
         name: 'ValidationError',
       });
       expect(extendedMockClient.connectedAccounts.patch).not.toHaveBeenCalled();
+    });
+
+    it('promotes to SHARED with ACL in one PATCH', async () => {
+      extendedMockClient.connectedAccounts.patch.mockResolvedValueOnce({
+        id: 'ca_abc',
+        status: 'ACTIVE',
+        success: true,
+      });
+
+      await experimental.updateSharing('ca_abc', {
+        accountType: 'SHARED',
+        allowAllUsers: true,
+        notAllowedUserIds: ['user_bob'],
+      });
+
+      expect(extendedMockClient.connectedAccounts.patch).toHaveBeenCalledWith('ca_abc', {
+        experimental: {
+          account_type: 'SHARED',
+          acl_config_for_shared: {
+            allow_all_users: true,
+            not_allowed_user_ids: ['user_bob'],
+          },
+        },
+      });
+    });
+
+    it('demotes to PRIVATE without ACL fields', async () => {
+      extendedMockClient.connectedAccounts.patch.mockResolvedValueOnce({
+        id: 'ca_abc',
+        status: 'ACTIVE',
+        success: true,
+      });
+
+      await experimental.updateSharing('ca_abc', { accountType: 'PRIVATE' });
+
+      expect(extendedMockClient.connectedAccounts.patch).toHaveBeenCalledWith('ca_abc', {
+        experimental: { account_type: 'PRIVATE' },
+      });
     });
 
     it('maps 400 AclOnlyForShared to ComposioAclOnlyForSharedError', async () => {
@@ -1756,7 +1794,7 @@ describe('ConnectedAccounts', () => {
       );
 
       await expect(
-        experimental.updateAcl('ca_abc', { allowAllUsers: true })
+        experimental.updateSharing('ca_abc', { allowAllUsers: true })
       ).rejects.toBeInstanceOf(ComposioAclOnlyForSharedError);
     });
 
@@ -1764,9 +1802,25 @@ describe('ConnectedAccounts', () => {
       const otherError = new Error('connection lost');
       extendedMockClient.connectedAccounts.patch.mockRejectedValueOnce(otherError);
 
-      await expect(experimental.updateAcl('ca_abc', { allowAllUsers: true })).rejects.toBe(
+      await expect(experimental.updateSharing('ca_abc', { allowAllUsers: true })).rejects.toBe(
         otherError
       );
+    });
+
+    it('keeps updateAcl as a deprecated compatibility alias', async () => {
+      extendedMockClient.connectedAccounts.patch.mockResolvedValueOnce({
+        id: 'ca_abc',
+        status: 'ACTIVE',
+        success: true,
+      });
+
+      await experimental.updateAcl('ca_abc', { allowedUserIds: ['user_alice'] });
+
+      expect(extendedMockClient.connectedAccounts.patch).toHaveBeenCalledWith('ca_abc', {
+        experimental: {
+          acl_config_for_shared: { allowed_user_ids: ['user_alice'] },
+        },
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

TypeScript SDK update for connected-account sharing. This updates the experimental connected-account PATCH helper so callers can change the sharing model without re-authing an existing connection. Python equivalent: #3434.

- `composio.experimental.updateAcl(...)` is renamed to `composio.experimental.updateSharing(...)`
- `updateSharing()` accepts `accountType: 'PRIVATE' | 'SHARED'` alongside the existing ACL fields
- the PATCH body forwards `account_type` and `acl_config_for_shared` under `experimental`
- keeps `updateAcl()` as a deprecated compatibility alias for ACL-only alpha callers
- updates error hints, API comments, changelog text, and connected-account tests

## Caller migration

```typescript
// before
await composio.experimental.updateAcl('ca_abc', {
  allowAllUsers: true,
});

// after: edit ACL on an already-SHARED connection
await composio.experimental.updateSharing('ca_abc', {
  allowAllUsers: true,
});

// new: promote without re-auth and grant access in one call
await composio.experimental.updateSharing('ca_abc', {
  accountType: 'SHARED',
  allowAllUsers: true,
  notAllowedUserIds: ['user_bob'],
});

// new: demote and clear ACL settings
await composio.experimental.updateSharing('ca_abc', {
  accountType: 'PRIVATE',
});
```

## Tests

- `updateSharing()` body construction for ACL-only updates
- `updateSharing({ accountType: 'SHARED', ... })` promote + ACL in one call
- `updateSharing({ accountType: 'PRIVATE' })` demote-only call
- empty params validation
- ACL-only 400 maps to `ComposioAclOnlyForSharedError`
- unrelated errors re-raise
- deprecated `updateAcl()` alias still forwards ACL-only updates

## Test plan

- [x] `pnpm --filter @composio/core test -- test/connectedAccounts/connectedAccounts.test.ts` → 926 passed
- [x] `pnpm --filter @composio/core typecheck:tsc` → clean