### PR TITLE
fix(providers): normalize string tool input in Anthropic, Google, LangChain

### DIFF
--- a/ts/packages/providers/anthropic/src/index.ts
+++ b/ts/packages/providers/anthropic/src/index.ts
@@ -210,8 +210,13 @@ export class AnthropicProvider extends BaseNonAgenticProvider<
     options?: ExecuteToolFnOptions,
     modifiers?: ExecuteToolModifiers
   ): Promise<string> {
+    // Normalize input: some models intermittently emit tool input as a JSON
+    // string instead of an object. Let parse errors propagate to match the
+    // pattern in @composio/vercel and @composio/openai-agents.
+    // See https://github.com/ComposioHQ/composio/issues/2406
+    const input = typeof toolUse.input === 'string' ? JSON.parse(toolUse.input) : toolUse.input;
     const payload: ToolExecuteParams = {
-      arguments: toolUse.input,
+      arguments: input,
       connectedAccountId: options?.connectedAccountId,
       customAuthParams: options?.customAuthParams,
       customConnectionData: options?.customConnectionData,

--- a/ts/packages/providers/google/src/index.ts
+++ b/ts/packages/providers/google/src/index.ts
@@ -241,8 +241,13 @@ export class GoogleProvider extends BaseNonAgenticProvider<
     options?: ExecuteToolFnOptions,
     modifiers?: ExecuteToolModifiers
   ): Promise<string> {
+    // Normalize args: some models intermittently emit tool arguments as a JSON
+    // string instead of an object. Let parse errors propagate to match the
+    // pattern in @composio/vercel and @composio/openai-agents.
+    // See https://github.com/ComposioHQ/composio/issues/2406
+    const args = typeof tool.args === 'string' ? JSON.parse(tool.args) : tool.args;
     const payload: ToolExecuteParams = {
-      arguments: tool.args,
+      arguments: args,
       connectedAccountId: options?.connectedAccountId,
       customAuthParams: options?.customAuthParams,
       customConnectionData: options?.customConnectionData,

--- a/ts/packages/providers/langchain/src/index.ts
+++ b/ts/packages/providers/langchain/src/index.ts
@@ -128,7 +128,13 @@ export class LangchainProvider extends BaseAgenticProvider<
       throw new Error('App name is not defined');
     }
     const func = async (...args: unknown[]): Promise<unknown> => {
-      const result = await executeTool(toolName, args[0] as Record<string, unknown>);
+      // Normalize input: some models intermittently emit tool arguments as a JSON
+      // string instead of an object. Let parse errors propagate to match the
+      // pattern in @composio/vercel and @composio/openai-agents.
+      // See https://github.com/ComposioHQ/composio/issues/2406
+      const raw = args[0];
+      const input = typeof raw === 'string' ? JSON.parse(raw) : (raw as Record<string, unknown>);
+      const result = await executeTool(toolName, input);
       return JSON.stringify(result);
     };
     if (!tool.inputParameters) {


### PR DESCRIPTION
## Summary

- Adds defensive `typeof === 'string' ? JSON.parse() : passthrough` normalization to Anthropic, Google, and LangChain providers
- Matches the existing pattern in `@composio/vercel` (line 129) and `@composio/openai-agents` (line 135)
- Prevents downstream validation errors when AI models intermittently emit tool-call input as a JSON string instead of an object

## Problem

Some AI models (observed with Anthropic Claude and various LLMs) occasionally emit tool-call `input`/`arguments` as a serialized JSON string rather than a parsed object. This causes:
- `Input should be a valid dictionary` validation errors
- Broken streaming in AI SDK integrations
- Silent failures in tool execution pipelines

The Vercel and OpenAI Agents providers already handle this case, but three providers were missing the guard.

## Changes

| Provider | File | Change |
|----------|------|--------|
| `@composio/anthropic` | `src/index.ts` | Added string→object normalization before `toolUse.input` is passed to payload |
| `@composio/google` | `src/index.ts` | Added string→object normalization for `tool.args` |
| `@composio/langchain` | `src/index.ts` | Added string→object normalization for `args[0]` in execute function |

## Test plan

- [ ] Verify TypeScript compilation passes for all three providers
- [ ] Test with a model that emits string tool input (can force with a mock)
- [ ] Confirm normal object input still passes through unchanged

Fixes #2406