### PR TITLE
fix(core): defer telemetry sends

### DIFF
--- a/.changeset/defer-telemetry-flushes.md
+++ b/.changeset/defer-telemetry-flushes.md
@@ -1,0 +1,5 @@
+---
+'@composio/core': patch
+---
+
+Defer telemetry batch and error sends so instrumentation does not wait for telemetry network requests before returning SDK results or rethrowing SDK errors.

--- a/ts/packages/core/src/services/telemetry/TelemetryService.ts
+++ b/ts/packages/core/src/services/telemetry/TelemetryService.ts
@@ -20,10 +20,7 @@ export class TelemetryService {
       });
       return result;
     } catch (error) {
-      // ignore error for now
-      // @TODO in cloudflare workers and other services, there is no way to log errors without blocking the request
-      // this is likely happening because the telemetry is batched and the request is not blocking
-      // we should find a way to log errors without blocking the request
+      // ignore error for now; telemetry failures should never affect SDK calls
       logger.debug('Error sending metric telemetry', error);
     }
   }
@@ -44,9 +41,7 @@ export class TelemetryService {
       });
       return result;
     } catch (error) {
-      // ignore error for now
-      // @TODO in cloudflare workers and other services, there is no way to log errors without blocking the request
-      // we should find a way to log errors without blocking the request
+      // ignore error for now; telemetry failures should never affect SDK calls
       logger.debug('Error sending error telemetry', error);
     }
   }

--- a/ts/packages/core/src/telemetry/BatchProcessor.ts
+++ b/ts/packages/core/src/telemetry/BatchProcessor.ts
@@ -8,7 +8,7 @@ export class BatchProcessor {
   private time: number;
   private batchSize: number;
   private processBatchCallback: (data: TelemetryMetricPayloadBody) => Promise<void>;
-  private timer: NodeJS.Timeout | null = null;
+  private timer: ReturnType<typeof setTimeout> | null = null;
   private pendingBatches: Set<Promise<void>> = new Set();
 
   constructor(
@@ -35,15 +35,28 @@ export class BatchProcessor {
     if (this.batch.length > 0) {
       const batchToProcess = this.batch;
       this.batch = [];
-      const pending = this.processBatchCallback(batchToProcess)
-        .catch(() => {
-          // Silently ignore errors - they should be handled by the callback
-        })
-        .finally(() => {
-          this.pendingBatches.delete(pending);
-        });
+
+      const pending = new Promise<void>(resolve => {
+        const run = () => {
+          Promise.resolve()
+            .then(() => this.processBatchCallback(batchToProcess))
+            .catch(() => {
+              // Silently ignore errors - they should be handled by the callback
+            })
+            .finally(resolve);
+        };
+
+        if (typeof queueMicrotask === 'function') {
+          queueMicrotask(run);
+        } else {
+          setTimeout(run, 0);
+        }
+      });
 
       this.pendingBatches.add(pending);
+      pending.finally(() => {
+        this.pendingBatches.delete(pending);
+      });
     }
     if (this.timer) {
       clearTimeout(this.timer);

--- a/ts/packages/core/src/telemetry/Telemetry.ts
+++ b/ts/packages/core/src/telemetry/Telemetry.ts
@@ -43,6 +43,7 @@ export class TelemetryTransport {
   private readonly telemetryServiceName = 'sdk';
   private readonly telemetryLanguage = 'typescript';
   private exitHandlersRegistered = false;
+  private pendingImmediateTelemetry: Set<Promise<void>> = new Set();
 
   private batchProcessor = new BatchProcessor(200, 10, async (data: TelemetryMetricPayloadBody) => {
     logger.debug('Sending batch of telemetry metrics', data);
@@ -63,20 +64,22 @@ export class TelemetryTransport {
     // Register exit handlers to automatically flush telemetry before process exit
     this.registerExitHandlers();
 
-    // send telemetry event for SDK initialization
-    this.sendMetric([
-      {
-        functionName: TELEMETRY_EVENTS.SDK_INITIALIZED,
-        durationMs: 0,
-        timestamp: Date.now() / 1000,
-        props: {},
-        source: this.telemetrySource,
-        metadata: {
-          provider: this.telemetryMetadata?.provider ?? 'openai',
+    // send telemetry event for SDK initialization without blocking setup
+    this.deferTelemetry(() =>
+      this.sendMetric([
+        {
+          functionName: TELEMETRY_EVENTS.SDK_INITIALIZED,
+          durationMs: 0,
+          timestamp: Date.now() / 1000,
+          props: {},
+          source: this.telemetrySource,
+          metadata: {
+            provider: this.telemetryMetadata?.provider ?? 'openai',
+          },
+          error: undefined,
         },
-        error: undefined,
-      },
-    ]);
+      ])
+    );
   }
 
   /**
@@ -144,7 +147,7 @@ export class TelemetryTransport {
               // Only send error telemetry if telemetry is enabled
               if (telemetryEnabled && startTime !== undefined) {
                 const durationMs = Date.now() - startTime;
-                await this.prepareAndSendErrorTelemetry(
+                this.prepareAndSendErrorTelemetry(
                   error,
                   instrumentedClassName,
                   name,
@@ -178,15 +181,13 @@ export class TelemetryTransport {
   /**
    * Prepare and send the error telemetry.
    *
-   * @TODO This currently blocks the thread and sends the telemetry to the server.
-   *
    * @param {unknown} error - The error to send.
    * @param {string} instrumentedClassName - The class name of the instrumented class.
    * @param {string} name - The name of the method that threw the error.
    * @param {number} startTime - The start time of the method invocation in milliseconds.
    * @param {number} durationMs - The duration of the method invocation in milliseconds.
    */
-  private async prepareAndSendErrorTelemetry(
+  private prepareAndSendErrorTelemetry(
     error: unknown,
     instrumentedClassName: string,
     name: string,
@@ -231,7 +232,37 @@ export class TelemetryTransport {
       };
     }
 
-    await this.sendErrorTelemetry(telemetryPayload);
+    this.deferTelemetry(() => this.sendErrorTelemetry(telemetryPayload));
+  }
+
+  private deferTelemetry(callback: () => Promise<void>): void {
+    const pending = new Promise<void>(resolve => {
+      const run = () => {
+        Promise.resolve()
+          .then(callback)
+          .catch(error => {
+            logger.debug('Error sending deferred telemetry', error);
+          })
+          .finally(resolve);
+      };
+
+      if (typeof queueMicrotask === 'function') {
+        queueMicrotask(run);
+      } else {
+        setTimeout(run, 0);
+      }
+    });
+
+    this.pendingImmediateTelemetry.add(pending);
+    pending.finally(() => {
+      this.pendingImmediateTelemetry.delete(pending);
+    });
+  }
+
+  private async flushImmediateTelemetry(): Promise<void> {
+    while (this.pendingImmediateTelemetry.size > 0) {
+      await Promise.all(Array.from(this.pendingImmediateTelemetry));
+    }
   }
 
   /**
@@ -271,6 +302,7 @@ export class TelemetryTransport {
    */
   async flush(): Promise<void> {
     await this.batchProcessor.flush();
+    await this.flushImmediateTelemetry();
   }
 
   /**

--- a/ts/packages/core/test/telemetry/TelemetryService.test.ts
+++ b/ts/packages/core/test/telemetry/TelemetryService.test.ts
@@ -5,6 +5,11 @@ import { TelemetryService } from '../../src/services/telemetry/TelemetryService'
 import type { TelemetryPayload } from '../../src/services/telemetry/TelemetryService.types';
 import { TelemetryMetadata } from '../../src/types/telemetry.types';
 
+const flushMicrotasks = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
 // Helper to create a mock telemetry payload
 const createPayload = (overrides: Partial<TelemetryPayload> = {}): TelemetryPayload => ({
   functionName: 'TestClass.testMethod',
@@ -35,9 +40,13 @@ describe('BatchProcessor', () => {
     vi.useRealTimers();
   });
 
-  it('should batch items and call callback when batch size is reached', () => {
+  it('should batch items and defer callback when batch size is reached', async () => {
     const payloads = [createPayload(), createPayload(), createPayload()];
     payloads.forEach(p => processor.pushItem(p));
+    expect(callback).not.toHaveBeenCalled();
+
+    await flushMicrotasks();
+
     expect(callback).toHaveBeenCalledOnce();
     expect(callback).toHaveBeenCalledWith(payloads);
   });
@@ -48,6 +57,8 @@ describe('BatchProcessor', () => {
     payloads.forEach(p => processor.pushItem(p));
     expect(callback).not.toHaveBeenCalled();
     vi.advanceTimersByTime(60);
+    await flushMicrotasks();
+
     expect(callback).toHaveBeenCalledOnce();
     expect(callback).toHaveBeenCalledWith(payloads);
   });
@@ -75,6 +86,8 @@ describe('BatchProcessor', () => {
       const payloads = [createPayload(), createPayload()];
       payloads.forEach(p => asyncProcessor.pushItem(p));
 
+      await flushMicrotasks();
+
       expect(asyncCallback).toHaveBeenCalledOnce();
       expect(asyncCallback).toHaveBeenCalledWith(payloads);
 
@@ -98,6 +111,7 @@ describe('BatchProcessor', () => {
       // @ts-expect-error: private access for test
       expect(asyncProcessor.pendingBatches.size).toBe(1);
 
+      await flushMicrotasks();
       resolveCallback!();
       await asyncProcessor.flush();
 
@@ -132,6 +146,7 @@ describe('BatchProcessor', () => {
       // @ts-expect-error: private access for test
       expect(asyncProcessor.batch).toEqual([]);
 
+      await flushMicrotasks();
       resolveCallback!();
       await asyncProcessor.flush();
     });
@@ -172,6 +187,7 @@ describe('BatchProcessor', () => {
       const flushPromise = asyncProcessor.flush();
       expect(callbackCompleted).toBe(false);
 
+      await flushMicrotasks();
       resolveCallback!();
       await flushPromise;
 
@@ -231,6 +247,8 @@ describe('BatchProcessor', () => {
       asyncProcessor.pushItem(createPayload());
       asyncProcessor.pushItem(createPayload());
 
+      await flushMicrotasks();
+
       expect(asyncCallback).toHaveBeenCalledTimes(2);
 
       // @ts-expect-error: private access for test
@@ -278,6 +296,8 @@ describe('BatchProcessor', () => {
       asyncProcessor.pushItem(createPayload({ functionName: 'batch2' }));
       asyncProcessor.pushItem(createPayload({ functionName: 'batch3' }));
 
+      await flushMicrotasks();
+
       expect(asyncCallback).toHaveBeenCalledTimes(3);
 
       // @ts-expect-error: private access for test
@@ -308,11 +328,12 @@ describe('TelemetryTransport', () => {
     provider: 'test',
   };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     sendMetricSpy = vi.spyOn(TelemetryService, 'sendMetric').mockResolvedValue({} as any);
     sendErrorLogSpy = vi.spyOn(TelemetryService, 'sendErrorLog').mockResolvedValue({} as any);
     transport = new TelemetryTransport();
     transport.setup(metadata);
+    await transport.flush();
   });
 
   afterEach(() => {
@@ -361,7 +382,42 @@ describe('TelemetryTransport', () => {
     const instance = new TestClass();
     const instrumented = transport.instrument(instance);
     await expect(instrumented.fail()).rejects.toThrow('fail!');
+    await transport.flush();
     expect(sendErrorLogSpy).toHaveBeenCalled();
+  });
+
+  it('should not wait for deferred error telemetry before rejecting instrumented errors', async () => {
+    let resolveTelemetry: (() => void) | undefined;
+    sendErrorLogSpy.mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          resolveTelemetry = () => resolve({} as any);
+        })
+    );
+
+    class TestClass {
+      async fail() {
+        throw new Error('fail!');
+      }
+    }
+    const instance = new TestClass();
+    const instrumented = transport.instrument(instance);
+
+    await expect(
+      Promise.race([
+        instrumented.fail().then(
+          () => 'resolved',
+          () => 'rejected'
+        ),
+        new Promise(resolve => setTimeout(() => resolve('timeout'), 20)),
+      ])
+    ).resolves.toBe('rejected');
+
+    await flushMicrotasks();
+    expect(sendErrorLogSpy).toHaveBeenCalled();
+
+    resolveTelemetry?.();
+    await transport.flush();
   });
 
   it('should flush pending telemetry when flush is called', async () => {


### PR DESCRIPTION
## Summary
- Defer telemetry batch processing via microtask scheduling so reaching the batch size no longer starts telemetry network work inline with SDK calls.
- Defer SDK init/error telemetry sends and make `flush()` wait for both deferred sends and pending batches.
- Remove stale blocking TODOs and add regression coverage for deferred batch/error telemetry behavior.

Fixes #3442

## Tests
- `pnpm --filter @composio/json-schema-to-zod build`
- `pnpm --filter @composio/core typecheck`
- `pnpm --dir ts/packages/core exec vitest run test/telemetry/TelemetryService.test.ts`
- `pnpm --filter @composio/core test`
- `pnpm exec eslint ts/packages/core/src/telemetry/BatchProcessor.ts ts/packages/core/src/telemetry/Telemetry.ts ts/packages/core/src/services/telemetry/TelemetryService.ts`

## CI
- GitHub checks are pending on PR creation; initial `gh pr checks 3447` showed required jobs queued/in progress.
