### PR TITLE
feat(cli): animate native approvals from Mac notch

### DIFF
--- a/ts/packages/cli-local-tools/local-tools-binaries/composio-native-ui/NOTICE.md
+++ b/ts/packages/cli-local-tools/local-tools-binaries/composio-native-ui/NOTICE.md
@@ -8,4 +8,4 @@ The `composio-native-ui` binaries are built from the in-repository Swift package
   - `swift build -c release --product composio-native-ui --arch arm64`
   - `swift build -c release --product composio-native-ui --arch x86_64`
 
-The scaffold currently opens a small AppKit panel near the bottom-right corner of the active screen. Generated executables are intentionally not committed; release jobs rebuild them before packaging CLI artifacts.
+The sidecar opens a small AppKit approval panel. On built-in Mac displays with a camera housing, it appears top-center and animates out from the notch; on other displays it falls back to the bottom-right corner of the active screen. Generated executables are intentionally not committed; release jobs rebuild them before packaging CLI artifacts.

--- a/ts/packages/cli-local-tools/native/composio-native-ui/Sources/ComposioNativeUI/main.swift
+++ b/ts/packages/cli-local-tools/native/composio-native-ui/Sources/ComposioNativeUI/main.swift
@@ -1,6 +1,33 @@
 import AppKit
+import CoreGraphics
 import MetalKit
 import QuartzCore
+
+private enum WindowPlacement {
+    case bottomRight
+    case topNotch
+}
+
+private extension NSScreen {
+    var composioDisplayID: CGDirectDisplayID? {
+        let key = NSDeviceDescriptionKey("NSScreenNumber")
+        if let displayID = deviceDescription[key] as? CGDirectDisplayID { return displayID }
+        if let number = deviceDescription[key] as? NSNumber { return number.uint32Value }
+        return nil
+    }
+
+    var composioIsBuiltInDisplay: Bool {
+        guard let displayID = composioDisplayID else { return false }
+        return CGDisplayIsBuiltin(displayID) != 0
+    }
+
+    var composioHasCameraHousing: Bool {
+        if #available(macOS 12.0, *) {
+            return composioIsBuiltInDisplay && safeAreaInsets.top > 0
+        }
+        return false
+    }
+}
 
 struct Configuration {
     // Content (programmatic):
@@ -587,10 +614,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     }
 
     private func createWindow() {
-        let frame = bottomRightFrame()
+        let screen = screenForPlacement()
+        let placement = placement(for: screen)
+        let finalFrame = frame(for: placement, on: screen)
+        let initialFrame = initialFrame(for: placement, on: screen, finalFrame: finalFrame)
 
         let panel = NSPanel(
-            contentRect: frame,
+            contentRect: initialFrame,
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
@@ -606,18 +636,42 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         panel.collectionBehavior = [.moveToActiveSpace, .fullScreenAuxiliary]
         panel.delegate = self
         panel.contentView = makeContentView()
-        panel.setFrame(frame, display: true, animate: false)
+        panel.setFrame(initialFrame, display: true, animate: false)
+        panel.alphaValue = placement == .topNotch ? 0.01 : 1
         panel.orderFrontRegardless()
 
-        DispatchQueue.main.async { [weak panel] in
-            panel?.setFrame(self.bottomRightFrame(), display: true, animate: false)
+        if placement == .topNotch {
+            animateFromNotch(panel, to: finalFrame)
+        } else {
+            panel.setFrame(finalFrame, display: true, animate: false)
         }
 
         window = panel
     }
 
-    private func bottomRightFrame() -> NSRect {
-        let screen = screenForPlacement()
+    private func placement(for screen: NSScreen) -> WindowPlacement {
+        screen.composioHasCameraHousing ? .topNotch : .bottomRight
+    }
+
+    private func frame(for placement: WindowPlacement, on screen: NSScreen) -> NSRect {
+        switch placement {
+        case .topNotch:
+            return topNotchFrame(on: screen)
+        case .bottomRight:
+            return bottomRightFrame(on: screen)
+        }
+    }
+
+    private func initialFrame(for placement: WindowPlacement, on screen: NSScreen, finalFrame: NSRect) -> NSRect {
+        switch placement {
+        case .topNotch:
+            return collapsedNotchFrame(on: screen, finalFrame: finalFrame)
+        case .bottomRight:
+            return finalFrame
+        }
+    }
+
+    private func bottomRightFrame(on screen: NSScreen) -> NSRect {
         let visibleFrame = screen.visibleFrame
         let size = NSSize(width: configuration.width, height: configuration.height)
         let origin = NSPoint(
@@ -625,6 +679,39 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             y: visibleFrame.minY + configuration.margin
         )
         return NSRect(origin: origin, size: size)
+    }
+
+    private func topNotchFrame(on screen: NSScreen) -> NSRect {
+        let visibleFrame = screen.visibleFrame
+        let size = NSSize(width: configuration.width, height: configuration.height)
+        let horizontalMargin = max(configuration.margin, 12)
+        let topGap: CGFloat = min(max(configuration.margin * 0.5, 10), 18)
+        let unclampedX = screen.frame.midX - size.width / 2
+        let minX = visibleFrame.minX + horizontalMargin
+        let maxX = visibleFrame.maxX - size.width - horizontalMargin
+        let x = maxX >= minX ? min(max(unclampedX, minX), maxX) : visibleFrame.midX - size.width / 2
+        let y = max(visibleFrame.minY + configuration.margin, visibleFrame.maxY - size.height - topGap)
+        return NSRect(origin: NSPoint(x: x, y: y), size: size)
+    }
+
+    private func collapsedNotchFrame(on screen: NSScreen, finalFrame: NSRect) -> NSRect {
+        let width = min(max(configuration.width * 0.38, 180), 260)
+        let height: CGFloat = 42
+        let topGap: CGFloat = 6
+        let origin = NSPoint(
+            x: finalFrame.midX - width / 2,
+            y: screen.frame.maxY - height - topGap
+        )
+        return NSRect(origin: origin, size: NSSize(width: width, height: height))
+    }
+
+    private func animateFromNotch(_ panel: NSPanel, to finalFrame: NSRect) {
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.38
+            context.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            panel.animator().alphaValue = 1
+            panel.animator().setFrame(finalFrame, display: true)
+        }
     }
 
     private func screenForPlacement() -> NSScreen {

--- a/ts/packages/cli-local-tools/scripts/build-composio-native-ui-binaries.ts
+++ b/ts/packages/cli-local-tools/scripts/build-composio-native-ui-binaries.ts
@@ -64,7 +64,7 @@ The \`composio-native-ui\` binaries are built from the in-repository Swift packa
 - Underlying Swift build commands:
   - \`swift build -c release --product composio-native-ui --arch arm64\`
 
-The scaffold currently opens a small AppKit panel near the bottom-right corner of the active screen. Generated executables are intentionally not committed; release jobs rebuild them before packaging CLI artifacts.
+The sidecar opens a small AppKit approval panel. On built-in Mac displays with a camera housing, it appears top-center and animates out from the notch; on other displays it falls back to the bottom-right corner of the active screen. Generated executables are intentionally not committed; release jobs rebuild them before packaging CLI artifacts.
 `;
   await fs.writeFile(path.join(outputRoot, 'NOTICE.md'), notice, 'utf8');
 };


### PR DESCRIPTION
## Summary
- Detect built-in macOS displays with a camera housing via the native sidecar screen metadata.
- Place approval prompts top-center on notched built-in displays and animate them from a collapsed notch-sized pill into the full approval card.
- Preserve the existing bottom-right placement for external and non-notched displays, and update native UI notices.

## Tests
- `swift build --product composio-native-ui`
- `.build/debug/composio-native-ui --tool TEST_TOOL --account test --caller-agent codex --timeout 1 --callback-file <tmp>` (exits dismissed after timeout)
- `swift build -c release --product composio-native-ui --arch arm64`
- `git diff --check`

## Notes
- `pnpm --filter @composio/cli-local-tools typecheck` could not run in this isolated worktree because `node_modules` is not installed and `tsgo` is unavailable.
