### PR TITLE
docs: dark mode, navbar polish, scroll reset, platform→dashboard rename

### DIFF
--- a/docs/app/global.css
+++ b/docs/app/global.css
@@ -677,13 +677,17 @@ body {
   --hero-shimmer: #0a0a0a;
 }
 .dark {
-  --hero-surface: #141416;
-  --hero-surface-2: #1c1c20;
-  --hero-bubble: #25262a;
+  /* Aligned with --color-fd-card / --color-fd-muted so the hero chat
+     panel sits at the same grey as the feature cards below it; the
+     darker `#141416` chat surface used to read as a shadow patch
+     against the page bg. */
+  --hero-surface: #1c1c1c;
+  --hero-surface-2: #222222;
+  --hero-bubble: #262626;
   --hero-text: rgba(245, 245, 247, 0.92);
   --hero-text-muted: rgba(245, 245, 247, 0.5);
-  --hero-border: rgba(255, 255, 255, 0.14);
-  --hero-border-soft: rgba(255, 255, 255, 0.06);
+  --hero-border: rgba(255, 255, 255, 0.08);
+  --hero-border-soft: rgba(255, 255, 255, 0.04);
   --hero-shimmer: #f5f5f7;
 }
 

--- a/docs/app/global.css
+++ b/docs/app/global.css
@@ -133,15 +133,20 @@ html {
 }
 
 .dark {
+  /* Lift the brand blue on dark backgrounds — `#0007cd` is too dark
+     against `#0f0f0f`. */
+  --composio-brand: #5B8BF0;
+  --composio-orange: var(--composio-brand);
+
   --composio-sidebar: #0f0f0f;
 
   /* Fumadocs overrides - Dark */
   --color-fd-background: #0f0f0f;
   --color-fd-foreground: #fbfbfb;
-  --color-fd-muted: #1a1a1a;
+  --color-fd-muted: #1f1f1f;
   --color-fd-muted-foreground: #b4b4b4;
-  --color-fd-border: rgba(255, 255, 255, 0.10);
-  --color-fd-card: #141414;
+  --color-fd-border: rgba(255, 255, 255, 0.06);
+  --color-fd-card: #1c1c1c;
   --color-fd-card-foreground: #fbfbfb;
   --color-fd-popover: #1a1a1a;
   --color-fd-popover-foreground: #fbfbfb;
@@ -167,7 +172,7 @@ html {
   --accent: oklch(0.269 0 0);
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.637 0.208 25.3);
-  --border: oklch(1 0 0 / 10%);
+  --border: oklch(1 0 0 / 6%);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.745 0.128 275);
   --chart-1: oklch(0.488 0.243 264.376);
@@ -181,7 +186,7 @@ html {
   --sidebar-primary-foreground: oklch(0.985 0 0);
   --sidebar-accent: oklch(0.269 0 0);
   --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-border: oklch(1 0 0 / 6%);
   --sidebar-ring: oklch(0.556 0 0);
 }
 
@@ -758,5 +763,14 @@ body {
   100% {
     background-position: -100% 0;
   }
+}
+
+/* Square the navbar theme toggle (and its inner icons) to match the
+   zero-radius search input. Fumadocs hard-codes `rounded-full` via
+   Tailwind utilities, so the override needs !important to beat the
+   utility layer's specificity. */
+[data-theme-toggle],
+[data-theme-toggle] > * {
+  border-radius: 0 !important;
 }
 

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -114,9 +114,9 @@ export default function Layout({ children }: LayoutProps<'/'>) {
         <PostHogProvider>
           <RootProvider
             theme={{
-              defaultTheme: 'light',
+              defaultTheme: 'system',
               attribute: 'class',
-              enableSystem: false,
+              enableSystem: true,
             }}
             search={{
               SearchDialog: CustomSearchDialog,

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -7,6 +7,7 @@ import localFont from 'next/font/local';
 import { PostHogProvider } from '@/components/posthog-provider';
 import { DecimalWidget } from '@/components/decimal-widget';
 import CustomSearchDialog from '@/components/custom-search-dialog';
+import { ScrollReset } from '@/components/scroll-reset';
 import { source } from '@/lib/source';
 
 const defaultLinkSlugs = [
@@ -108,6 +109,7 @@ export default function Layout({ children }: LayoutProps<'/'>) {
         />
       </head>
       <body className="flex flex-col min-h-dvh font-sans">
+        <ScrollReset />
         <Analytics />
         <PostHogProvider>
           <RootProvider
@@ -115,7 +117,6 @@ export default function Layout({ children }: LayoutProps<'/'>) {
               defaultTheme: 'light',
               attribute: 'class',
               enableSystem: false,
-              forcedTheme: 'light',
             }}
             search={{
               SearchDialog: CustomSearchDialog,

--- a/docs/components/ask-ai-button.tsx
+++ b/docs/components/ask-ai-button.tsx
@@ -76,7 +76,7 @@ export function SearchAndAskAI() {
         <button
           type="button"
           data-search-full=""
-          className="inline-flex items-center gap-2 rounded-full border bg-fd-secondary/50 p-1.5 ps-2.5 text-sm text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground w-full max-w-[240px]"
+          className="inline-flex items-center gap-2 rounded-none border bg-fd-secondary/50 p-1.5 ps-2.5 text-sm text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground w-full max-w-[240px]"
           onClick={() => setOpenSearch(true)}
         >
           <Search className="size-4" />

--- a/docs/components/docs-hero.tsx
+++ b/docs/components/docs-hero.tsx
@@ -11,7 +11,7 @@ import { DocsHeroV2 } from './docs-hero-v2';
  */
 export function DocsHero() {
   return (
-    <div className="not-prose mb-10 bg-fd-background">
+    <div className="not-prose mb-10">
       <DocsHeroV2 />
       {/* <HeroSection /> */}
     </div>

--- a/docs/components/home-surfaces.tsx
+++ b/docs/components/home-surfaces.tsx
@@ -14,15 +14,39 @@ import {
 import { useState, type ReactNode, type MouseEvent } from 'react';
 import { SectionHeading } from './home-features';
 
-const PROVIDERS = [
-  { name: 'Anthropic', logo: '/images/providers/anthropic-logo.svg' },
-  { name: 'OpenAI', logo: '/images/providers/openai-logo.svg' },
-  { name: 'Vercel AI', logo: '/images/providers/vercel-logo.svg' },
+// Some provider logos ship a dedicated `-dark` variant (white-on-dark
+// or stroke-inverted). Use those in dark mode instead of inverting the
+// light SVG via CSS — `dark:invert` mangles full-colour logos
+// (Google's primary palette, LlamaIndex's gradient, CrewAI's brand).
+const PROVIDERS: { name: string; logo: string; logoDark?: string }[] = [
+  {
+    name: 'Anthropic',
+    logo: '/images/providers/anthropic-logo.svg',
+    logoDark: '/images/providers/anthropic-logo-dark.svg',
+  },
+  {
+    name: 'OpenAI',
+    logo: '/images/providers/openai-logo.svg',
+    logoDark: '/images/providers/openai-logo-dark.svg',
+  },
+  {
+    name: 'Vercel AI',
+    logo: '/images/providers/vercel-logo.svg',
+    logoDark: '/images/providers/vercel-logo-dark.svg',
+  },
   { name: 'Google', logo: '/images/providers/google-logo.svg' },
-  { name: 'LangChain', logo: '/images/providers/langchain-logo.svg' },
+  {
+    name: 'LangChain',
+    logo: '/images/providers/langchain-logo.svg',
+    logoDark: '/images/providers/langchain-logo-dark.svg',
+  },
   { name: 'CrewAI', logo: '/images/providers/crewai-logo.svg' },
   { name: 'LlamaIndex', logo: '/images/providers/llamaIndex-logo.svg' },
-  { name: 'Mastra', logo: '/images/providers/mastra-logo.svg' },
+  {
+    name: 'Mastra',
+    logo: '/images/providers/mastra-logo.svg',
+    logoDark: '/images/providers/mastra-logo-dark.svg',
+  },
 ];
 
 const CLIENTS: { name: string; logo: string; h: number }[] = [
@@ -211,13 +235,33 @@ function ProviderStrip() {
           className="flex h-10 items-center justify-center gap-2 rounded-md border border-fd-border bg-fd-card px-3"
           title={p.name}
         >
-          <Image
-            alt={p.name}
-            className="h-4 w-auto object-contain dark:invert"
-            height={16}
-            src={p.logo}
-            width={64}
-          />
+          {p.logoDark ? (
+            <>
+              <Image
+                alt={p.name}
+                className="h-4 w-auto object-contain dark:hidden"
+                height={16}
+                src={p.logo}
+                width={64}
+              />
+              <Image
+                alt=""
+                aria-hidden="true"
+                className="hidden h-4 w-auto object-contain dark:block"
+                height={16}
+                src={p.logoDark}
+                width={64}
+              />
+            </>
+          ) : (
+            <Image
+              alt={p.name}
+              className="h-4 w-auto object-contain"
+              height={16}
+              src={p.logo}
+              width={64}
+            />
+          )}
           <span className="text-[12px] text-fd-foreground/75">{p.name}</span>
         </div>
       ))}

--- a/docs/components/scroll-reset.tsx
+++ b/docs/components/scroll-reset.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { useEffect, useRef } from 'react';
+
+/**
+ * Force scroll-to-top on every pathname change.
+ *
+ * Next.js App Router skips its built-in scroll reset when the new
+ * route resolves to the same `page.tsx` segment as the current one
+ * (e.g. navigating between two pages handled by
+ * `app/(home)/docs/[[...slug]]/page.tsx`). The welcome page links to
+ * many such siblings, so users would land mid-page on the new route.
+ */
+export function ScrollReset() {
+  const pathname = usePathname();
+  const firstRender = useRef(true);
+
+  useEffect(() => {
+    if (firstRender.current) {
+      firstRender.current = false;
+      return;
+    }
+    if (window.location.hash) return;
+    window.scrollTo({ top: 0, left: 0, behavior: 'instant' });
+  }, [pathname]);
+
+  return null;
+}

--- a/docs/content/changelog/01-08-26-mcp-api-key-enforcement.mdx
+++ b/docs/content/changelog/01-08-26-mcp-api-key-enforcement.mdx
@@ -54,7 +54,7 @@ curl -X POST "https://mcp.composio.dev/{your_mcp_server_url}" \
 
 ### Via Dashboard
 
-1. Navigate to [Project Settings](https://platform.composio.dev/{workspace}/{project}/settings)
+1. Navigate to [Project Settings](https://dashboard.composio.dev/{workspace}/{project}/settings)
 2. Go to the **Project Configuration** tab
 3. Find the **"Require API Key for MCP"** toggle
 4. Enable the toggle

--- a/docs/content/changelog/02-15-26-webhook-v3-default-new-orgs.mdx
+++ b/docs/content/changelog/02-15-26-webhook-v3-default-new-orgs.mdx
@@ -21,7 +21,7 @@ Starting today, every new organization created on Composio will automatically us
 Nothing changes for existing organizations. If your organization was created before today:
 
 - You will continue to receive webhooks in your current format (V1 or V2)
-- You can opt-in to V3 at any time through your [project settings](https://platform.composio.dev)
+- You can opt-in to V3 at any time through your [project settings](https://dashboard.composio.dev)
 
 ## V3 Payload Recap
 
@@ -46,7 +46,7 @@ Nothing changes for existing organizations. If your organization was created bef
 
 ## How to Switch to V3 (Existing Organizations)
 
-1. Go to your project settings in the [Composio dashboard](https://platform.composio.dev)
+1. Go to your project settings in the [Composio dashboard](https://dashboard.composio.dev)
 2. Navigate to the Webhooks section
 3. Select **Webhook Payload Version: V3**
 4. Update your webhook handlers using the [migration guide](/docs/changelog/2025/12/30#migration-guide)

--- a/docs/content/changelog/03-04-26-mcp-api-key-default-new-orgs.mdx
+++ b/docs/content/changelog/03-04-26-mcp-api-key-default-new-orgs.mdx
@@ -23,7 +23,7 @@ From **March 5, 2026**, all projects in newly created organizations will have `r
 Nothing changes for existing organizations. If your organization was created before March 5, 2026:
 
 - Your current `require_mcp_api_key` setting remains unchanged
-- You can opt in at any time through your [project settings](https://platform.composio.dev) or via the API
+- You can opt in at any time through your [project settings](https://dashboard.composio.dev) or via the API
 
 ### Opting Out (New Organizations)
 

--- a/docs/content/changelog/09-15-25.mdx
+++ b/docs/content/changelog/09-15-25.mdx
@@ -85,7 +85,7 @@ const connectionRequest = await composio.connectedAccounts.link('user_123', 'aut
 
 ### Customisation
 
-You can customise the app logo and name showed in the authentication page via the dashboard. Head over your project via `platform.composio.dev`  and choose Settings → Auth Links to upload a new logo and change the name. 
+You can customise the app logo and name showed in the authentication page via the dashboard. Head over your project via `dashboard.composio.dev`  and choose Settings → Auth Links to upload a new logo and change the name. 
 
 ### Migration Note
 This feature replaces manual authentication form development with a simple redirect-based approach, significantly reducing integration time and complexity while providing a better user experience. Auth links are drop in replacement for `composio.connectedAccounts.initate`, you can safely swap this to `composio.connectedAccounts.link`

--- a/docs/content/changelog/11-05-25.mdx
+++ b/docs/content/changelog/11-05-25.mdx
@@ -32,17 +32,17 @@ This change ensures that:
 
 **Before:**
 ```
-https://platform.composio.dev/v3/mcp/{id}
+https://dashboard.composio.dev/v3/mcp/{id}
 ```
 
 **After (with user_id):**
 ```
-https://platform.composio.dev/v3/mcp/{id}?user_id=user_123
+https://dashboard.composio.dev/v3/mcp/{id}?user_id=user_123
 ```
 
 **After (with connected_account_id):**
 ```
-https://platform.composio.dev/v3/mcp/{id}?connected_account_id=ca_xyz
+https://dashboard.composio.dev/v3/mcp/{id}?connected_account_id=ca_xyz
 ```
 
 ### Migration Guide

--- a/docs/content/changelog/12-10-25.mdx
+++ b/docs/content/changelog/12-10-25.mdx
@@ -95,9 +95,9 @@ youtube
 }
 ```
 
-For the exact field mapping per toolkit, open `platform.composio.dev` → Toolkits → List Messages (or the relevant tool).
+For the exact field mapping per toolkit, open `dashboard.composio.dev` → Toolkits → List Messages (or the relevant tool).
 
 ### Migration Notes
 - Breaking change for consumers on the `latest` version who post-process the old nested `response_data` shape: outputs are now flattened and explicitly typed.
 - New and modified fields include richer descriptions and examples; some legacy placeholders were removed.
-- Re-fetch schemas for your tool/version to see the typed definitions. Use the toolkit view in `platform.composio.dev` for authoritative field details.
+- Re-fetch schemas for your tool/version to see the typed definitions. Use the toolkit view in `dashboard.composio.dev` for authoritative field details.

--- a/docs/content/cookbooks/app-connections-dashboard.mdx
+++ b/docs/content/cookbooks/app-connections-dashboard.mdx
@@ -15,7 +15,7 @@ description: Build a dashboard for managing user app connections and auth status
 ## Prerequisites
 
 - [Bun](https://bun.sh) (or Node.js 18+)
-- [Composio API key](https://platform.composio.dev/settings)
+- [Composio API key](https://dashboard.composio.dev/settings)
 
 **Stack:** Next.js, `@composio/core`
 

--- a/docs/content/cookbooks/background-agent.mdx
+++ b/docs/content/cookbooks/background-agent.mdx
@@ -12,7 +12,7 @@ Run it manually, put it on a cron, or deploy it. The agent does the rest.
 ## Prerequisites
 
 * Node.js 18+
-* [Composio API key](https://platform.composio.dev/settings)
+* [Composio API key](https://dashboard.composio.dev/settings)
 * [OpenAI API key](https://platform.openai.com/api-keys)
 
 ## Project setup

--- a/docs/content/cookbooks/chat-app.mdx
+++ b/docs/content/cookbooks/chat-app.mdx
@@ -16,7 +16,7 @@ Give your AI agent access to Gmail, GitHub, Slack, Notion, and 1000+ other apps.
 ## Prerequisites
 
 - [Bun](https://bun.sh) (or Node.js 18+)
-- [Composio API key](https://platform.composio.dev/settings)
+- [Composio API key](https://dashboard.composio.dev/settings)
 - [OpenAI API key](https://platform.openai.com/api-keys)
 
 **Stack:** Next.js, Vercel AI SDK, OpenAI, Composio
@@ -32,7 +32,7 @@ bun add @composio/core @composio/vercel @ai-sdk/openai ai @ai-sdk/react
 ```
 
 <Callout type="info">
-Get your `COMPOSIO_API_KEY` from [Settings](https://platform.composio.dev/settings) and `OPENAI_API_KEY` from [OpenAI](https://platform.openai.com/api-keys).
+Get your `COMPOSIO_API_KEY` from [Settings](https://dashboard.composio.dev/settings) and `OPENAI_API_KEY` from [OpenAI](https://platform.openai.com/api-keys).
 </Callout>
 
 Add your API keys to a `.env.local` file in the project root:

--- a/docs/content/cookbooks/fast-api.mdx
+++ b/docs/content/cookbooks/fast-api.mdx
@@ -11,7 +11,7 @@ This cookbook builds a FastAPI server where users can chat with an AI agent that
 
 * Python 3.10+
 * [UV](https://docs.astral.sh/uv/getting-started/installation/)
-* [Composio API key](https://platform.composio.dev/settings)
+* [Composio API key](https://dashboard.composio.dev/settings)
 * [OpenAI API key](https://platform.openai.com/api-keys)
 
 ## Project setup

--- a/docs/content/cookbooks/gmail-labeler.mdx
+++ b/docs/content/cookbooks/gmail-labeler.mdx
@@ -11,7 +11,7 @@ This cookbook builds a Python script that connects to Gmail, listens for new mes
 
 * Python 3.10+
 * [UV](https://docs.astral.sh/uv/getting-started/installation/)
-* [Composio API key](https://platform.composio.dev/settings)
+* [Composio API key](https://dashboard.composio.dev/settings)
 * [Anthropic API key](https://console.anthropic.com/settings/keys)
 
 ## Project setup

--- a/docs/content/cookbooks/hono.mdx
+++ b/docs/content/cookbooks/hono.mdx
@@ -10,7 +10,7 @@ This cookbook builds a Hono.js server where users can chat with an AI agent that
 ## Prerequisites
 
 * Node.js 18+
-* [Composio API key](https://platform.composio.dev/settings)
+* [Composio API key](https://dashboard.composio.dev/settings)
 * [OpenAI API key](https://platform.openai.com/api-keys)
 
 ## Project setup

--- a/docs/content/cookbooks/pr-review-agent.mdx
+++ b/docs/content/cookbooks/pr-review-agent.mdx
@@ -16,7 +16,7 @@ Build a PR review agent that runs on every pull request, reads your repo's `CLAU
 ## Prerequisites
 
 - Python 3.10+
-- [Composio API key](https://platform.composio.dev/settings)
+- [Composio API key](https://dashboard.composio.dev/settings)
 - [OpenAI API key](https://platform.openai.com/api-keys)
 - A GitHub repository where you have admin access (for adding secrets and workflows)
 
@@ -32,7 +32,7 @@ pip install composio composio-openai-agents openai-agents
 ```
 
 <Callout type="info">
-Get your `COMPOSIO_API_KEY` from [Settings](https://platform.composio.dev/settings) and `OPENAI_API_KEY` from [OpenAI](https://platform.openai.com/api-keys).
+Get your `COMPOSIO_API_KEY` from [Settings](https://dashboard.composio.dev/settings) and `OPENAI_API_KEY` from [OpenAI](https://platform.openai.com/api-keys).
 </Callout>
 
 Set your API keys:

--- a/docs/content/cookbooks/slack-summariser.mdx
+++ b/docs/content/cookbooks/slack-summariser.mdx
@@ -11,7 +11,7 @@ This cookbook builds a standalone Python script that connects to a Slack workspa
 
 * Python 3.10+
 * [UV](https://docs.astral.sh/uv/getting-started/installation/)
-* [Composio API key](https://platform.composio.dev/settings)
+* [Composio API key](https://dashboard.composio.dev/settings)
 * [OpenAI API key](https://platform.openai.com/api-keys)
 
 ## Project setup

--- a/docs/content/cookbooks/supabase-sql-agent.mdx
+++ b/docs/content/cookbooks/supabase-sql-agent.mdx
@@ -11,7 +11,7 @@ This cookbook builds a CLI agent that connects to your Supabase account and lets
 
 * Python 3.10+
 * [UV](https://docs.astral.sh/uv/getting-started/installation/)
-* [Composio API key](https://platform.composio.dev/settings)
+* [Composio API key](https://dashboard.composio.dev/settings)
 * [OpenAI API key](https://platform.openai.com/api-keys)
 
 ## Project setup

--- a/docs/content/cookbooks/support-agent.mdx
+++ b/docs/content/cookbooks/support-agent.mdx
@@ -11,7 +11,7 @@ This cookbook builds an **agentic RAG** system: an interactive CLI agent that tr
 
 * Python 3.10+
 * [UV](https://docs.astral.sh/uv/getting-started/installation/)
-* [Composio API key](https://platform.composio.dev/settings)
+* [Composio API key](https://dashboard.composio.dev/settings)
 * [OpenAI API key](https://platform.openai.com/api-keys)
 
 ## Project setup

--- a/docs/content/cookbooks/tool-generator.mdx
+++ b/docs/content/cookbooks/tool-generator.mdx
@@ -11,7 +11,7 @@ This cookbook shows how to access the raw tool definitions and toolkit metadata 
 
 * Python 3.10+
 * [UV](https://docs.astral.sh/uv/getting-started/installation/)
-* [Composio API key](https://platform.composio.dev/settings)
+* [Composio API key](https://dashboard.composio.dev/settings)
 
 ## Project setup
 

--- a/docs/content/cookbooks/workplace-search.mdx
+++ b/docs/content/cookbooks/workplace-search.mdx
@@ -17,7 +17,7 @@ Build a search agent that queries across your workplace tools and returns answer
 
 - Python 3.10+
 - [UV](https://docs.astral.sh/uv/getting-started/installation/)
-- [Composio API key](https://platform.composio.dev/settings)
+- [Composio API key](https://dashboard.composio.dev/settings)
 - [OpenAI API key](https://platform.openai.com/api-keys)
 
 ## Project setup

--- a/docs/content/docs/auth-configuration/white-labeling.mdx
+++ b/docs/content/docs/auth-configuration/white-labeling.mdx
@@ -67,7 +67,7 @@ Step-by-step guides: [Google](https://composio.dev/auth/googleapps) | [Slack](ht
 <Step>
 <StepTitle>Create an auth config in Composio</StepTitle>
 
-In the [Composio dashboard](https://platform.composio.dev):
+In the [Composio dashboard](https://dashboard.composio.dev):
 
 1. Go to **Authentication management** → **Create Auth Config**
 2. Select the toolkit (e.g., GitHub)

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -35,7 +35,7 @@ npm install @composio/core @composio/openai-agents @openai/agents
 <StepTitle>Configure API Keys</StepTitle>
 
 <Callout type="info">
-Get your `COMPOSIO_API_KEY` from [Settings](https://platform.composio.dev/settings) and `OPENAI_API_KEY` from [OpenAI](https://platform.openai.com/api-keys).
+Get your `COMPOSIO_API_KEY` from [Settings](https://dashboard.composio.dev/settings) and `OPENAI_API_KEY` from [OpenAI](https://platform.openai.com/api-keys).
 </Callout>
 
 ```bash title=".env"
@@ -177,7 +177,7 @@ npm install dotenv @composio/core @openai/agents zod@3
 <StepTitle>Configure API Keys</StepTitle>
 
 <Callout type="info">
-Get your `COMPOSIO_API_KEY` from [Settings](https://platform.composio.dev/settings) and `OPENAI_API_KEY` from [OpenAI](https://platform.openai.com/api-keys).
+Get your `COMPOSIO_API_KEY` from [Settings](https://dashboard.composio.dev/settings) and `OPENAI_API_KEY` from [OpenAI](https://platform.openai.com/api-keys).
 </Callout>
 
 ```bash title=".env"
@@ -337,7 +337,7 @@ npm install dotenv @composio/core @composio/claude-agent-sdk @anthropic-ai/claud
 <StepTitle>Configure API Keys</StepTitle>
 
 <Callout type="info">
-Get your `COMPOSIO_API_KEY` from [Settings](https://platform.composio.dev/settings) and `ANTHROPIC_API_KEY` from [Anthropic](https://console.anthropic.com/settings/keys).
+Get your `COMPOSIO_API_KEY` from [Settings](https://dashboard.composio.dev/settings) and `ANTHROPIC_API_KEY` from [Anthropic](https://console.anthropic.com/settings/keys).
 </Callout>
 
 ```bash title=".env"
@@ -503,7 +503,7 @@ npm install dotenv @composio/core @anthropic-ai/claude-agent-sdk
 <StepTitle>Configure API Keys</StepTitle>
 
 <Callout type="info">
-Get your `COMPOSIO_API_KEY` from [Settings](https://platform.composio.dev/settings) and `ANTHROPIC_API_KEY` from [Anthropic](https://console.anthropic.com/settings/keys).
+Get your `COMPOSIO_API_KEY` from [Settings](https://dashboard.composio.dev/settings) and `ANTHROPIC_API_KEY` from [Anthropic](https://console.anthropic.com/settings/keys).
 </Callout>
 
 ```bash title=".env"
@@ -677,7 +677,7 @@ npm install @composio/core @composio/vercel ai @ai-sdk/anthropic
 <StepTitle>Configure API Keys</StepTitle>
 
 <Callout type="info">
-Get your `COMPOSIO_API_KEY` from [Settings](https://platform.composio.dev/settings) and `ANTHROPIC_API_KEY` from [Anthropic](https://console.anthropic.com/settings/keys).
+Get your `COMPOSIO_API_KEY` from [Settings](https://dashboard.composio.dev/settings) and `ANTHROPIC_API_KEY` from [Anthropic](https://console.anthropic.com/settings/keys).
 </Callout>
 
 ```bash title=".env"
@@ -771,7 +771,7 @@ npm install dotenv @composio/core ai @ai-sdk/anthropic @ai-sdk/mcp
 <StepTitle>Configure API Keys</StepTitle>
 
 <Callout type="info">
-Get your `COMPOSIO_API_KEY` from [Settings](https://platform.composio.dev/settings) and `ANTHROPIC_API_KEY` from [Anthropic](https://console.anthropic.com/settings/keys).
+Get your `COMPOSIO_API_KEY` from [Settings](https://dashboard.composio.dev/settings) and `ANTHROPIC_API_KEY` from [Anthropic](https://console.anthropic.com/settings/keys).
 </Callout>
 
 ```bash title=".env"

--- a/docs/content/docs/toolkits/fetching-tools-and-toolkits.mdx
+++ b/docs/content/docs/toolkits/fetching-tools-and-toolkits.mdx
@@ -118,7 +118,7 @@ To restrict which toolkits or tools are discoverable by the meta tools, configur
 
 ## Browsing the catalog
 
-Before configuring a session, you may want to explore what toolkits and tools are available. You can browse visually at [platform.composio.dev](https://platform.composio.dev) or in the [docs](/toolkits), or fetch programmatically:
+Before configuring a session, you may want to explore what toolkits and tools are available. You can browse visually at [dashboard.composio.dev](https://dashboard.composio.dev) or in the [docs](/toolkits), or fetch programmatically:
 
 <Tabs groupId="language" items={['Python', 'TypeScript']} persist>
 <Tab value="Python">

--- a/docs/content/docs/tools-direct/fetching-tools.mdx
+++ b/docs/content/docs/tools-direct/fetching-tools.mdx
@@ -60,7 +60,7 @@ const tool = await composio.tools.getRawComposioToolBySlug("GMAIL_SEND_EMAIL");
 Generate type-safe code for direct SDK execution with [`composio generate`](/docs/cli#generate-type-definitions). This creates TypeScript or Python types from tool schemas.
 
 <Callout type="info">
-View tool parameters and schemas visually in the [Composio platform](https://platform.composio.dev). Navigate to any toolkit and select a tool to see its input/output parameters.
+View tool parameters and schemas visually in the [Composio platform](https://dashboard.composio.dev). Navigate to any toolkit and select a tool to see its input/output parameters.
 </Callout>
 
 ## Filtering tools

--- a/docs/content/docs/tools-direct/toolkit-versioning.mdx
+++ b/docs/content/docs/tools-direct/toolkit-versioning.mdx
@@ -11,7 +11,7 @@ If you're building an agent, we recommend using [sessions](/docs/configuring-ses
 
 Toolkit versioning ensures your tools behave consistently across deployments. You can pin specific versions in production, test new releases in development, and roll back when needed.
 
-To view available versions, go to [Dashboard](https://platform.composio.dev) > **All Toolkits** > select a toolkit. The version dropdown shows the latest and all available versions:
+To view available versions, go to [Dashboard](https://dashboard.composio.dev) > **All Toolkits** > select a toolkit. The version dropdown shows the latest and all available versions:
 
 ![Toolkit version selector on the Composio dashboard](/images/toolkit-version-dashboard.png)
 
@@ -24,7 +24,7 @@ Starting from Python SDK v0.9.0 and TypeScript SDK v0.2.0, specifying versions i
 ## Default version behavior
 
 <Callout type="warn">
-When no version is specified, the API defaults to the base version (`00000000_00`), **not** the latest version. This means the response may contain fewer tools than what's shown on the [platform UI](https://platform.composio.dev). To get all available tools including ones added in newer versions, explicitly set `toolkit_versions` to `"latest"` or a specific version.
+When no version is specified, the API defaults to the base version (`00000000_00`), **not** the latest version. This means the response may contain fewer tools than what's shown on the [platform UI](https://dashboard.composio.dev). To get all available tools including ones added in newer versions, explicitly set `toolkit_versions` to `"latest"` or a specific version.
 </Callout>
 
 This applies to both the SDK and direct REST API calls:

--- a/docs/content/docs/troubleshooting/index.mdx
+++ b/docs/content/docs/troubleshooting/index.mdx
@@ -18,13 +18,13 @@ See [Troubleshooting tools](/docs/troubleshooting/tools#reporting-tool-issues) f
 </Accordion>
 
 <Accordion title="How do I find my auth config ID or connected account ID?">
-Go to the [dashboard](https://platform.composio.dev) and navigate to **Auth Configs** for your auth config ID, or **Connected Accounts** for the connected account ID. Both IDs are visible in the detail view of each entry.
+Go to the [dashboard](https://dashboard.composio.dev) and navigate to **Auth Configs** for your auth config ID, or **Connected Accounts** for the connected account ID. Both IDs are visible in the detail view of each entry.
 
 See [Troubleshooting authentication](/docs/troubleshooting/authentication#reporting-authentication-issues) for screenshots.
 </Accordion>
 
 <Accordion title="How do I find my MCP server ID?">
-Your MCP server ID is the UUID in the server URL (e.g., `https://backend.composio.dev/v3/mcp/<UUID>/mcp`). You can also find it in the [dashboard](https://platform.composio.dev) under your MCP server's detail page.
+Your MCP server ID is the UUID in the server URL (e.g., `https://backend.composio.dev/v3/mcp/<UUID>/mcp`). You can also find it in the [dashboard](https://dashboard.composio.dev) under your MCP server's detail page.
 
 See [Troubleshooting MCP](/docs/troubleshooting/mcp#reporting-mcp-issues) for a visual guide.
 </Accordion>
@@ -42,7 +42,7 @@ Generate a UUID at [uuidgenerator.net](https://www.uuidgenerator.net/). See [Tro
 </Accordion>
 
 <Accordion title="How do I find the trigger ID for a trigger instance?">
-Go to the [dashboard](https://platform.composio.dev) and navigate to **Active Triggers**. The trigger ID is shown for each trigger instance.
+Go to the [dashboard](https://dashboard.composio.dev) and navigate to **Active Triggers**. The trigger ID is shown for each trigger instance.
 
 See [Troubleshooting triggers](/docs/troubleshooting/triggers#reporting-issues) for a screenshot.
 </Accordion>

--- a/docs/content/docs/troubleshooting/tools.mdx
+++ b/docs/content/docs/troubleshooting/tools.mdx
@@ -21,7 +21,7 @@ Verify the connected account has necessary permissions:
 
 ## API returning fewer tools than expected
 
-If the Get Tools API (`GET /api/v3.1/tools`) returns fewer tools than what's shown on the [platform UI](https://platform.composio.dev), you likely need to specify a toolkit version.
+If the Get Tools API (`GET /api/v3.1/tools`) returns fewer tools than what's shown on the [platform UI](https://dashboard.composio.dev), you likely need to specify a toolkit version.
 
 When `toolkit_versions` is not provided, the API defaults to the base version (`00000000_00`), which only includes tools from the initial release. Tools added in later versions won't appear.
 

--- a/docs/content/reference/errors.mdx
+++ b/docs/content/reference/errors.mdx
@@ -52,7 +52,7 @@ Composio uses two types of API keys:
 
 | Error | Cause |
 |-------|-------|
-| Invalid API key | The API key is incorrect or revoked. Verify in [Settings](https://platform.composio.dev/settings). |
+| Invalid API key | The API key is incorrect or revoked. Verify in [Settings](https://dashboard.composio.dev/settings). |
 | No authentication provided | The request is missing the `x-api-key` or `x-org-api-key` header. |
 | Invalid organization key | The organization API key is incorrect or revoked. Verify in Organization Settings. |
 | Insufficient permissions | The API key doesn't have access to this resource. |

--- a/docs/content/reference/v3/errors.mdx
+++ b/docs/content/reference/v3/errors.mdx
@@ -52,7 +52,7 @@ Composio uses two types of API keys:
 
 | Error | Cause |
 |-------|-------|
-| Invalid API key | The API key is incorrect or revoked. Verify in [Settings](https://platform.composio.dev/settings). |
+| Invalid API key | The API key is incorrect or revoked. Verify in [Settings](https://dashboard.composio.dev/settings). |
 | No authentication provided | The request is missing the `x-api-key` or `x-org-api-key` header. |
 | Invalid organization key | The organization API key is incorrect or revoked. Verify in Organization Settings. |
 | Insufficient permissions | The API key doesn't have access to this resource. |

--- a/docs/lib/layout.shared.tsx
+++ b/docs/lib/layout.shared.tsx
@@ -36,7 +36,7 @@ export function baseOptions(): BaseLayoutProps {
       title: <ComposioLogo />,
       transparentMode: 'top',
     },
-    themeSwitch: { enabled: false },
+    themeSwitch: { enabled: true, mode: 'light-dark' },
     searchToggle: {
       components: {
         lg: <SearchAndAskAI />,

--- a/docs/lib/layout.shared.tsx
+++ b/docs/lib/layout.shared.tsx
@@ -36,7 +36,7 @@ export function baseOptions(): BaseLayoutProps {
       title: <ComposioLogo />,
       transparentMode: 'top',
     },
-    themeSwitch: { enabled: true, mode: 'light-dark' },
+    themeSwitch: { enabled: true, mode: 'light-dark-system' },
     searchToggle: {
       components: {
         lg: <SearchAndAskAI />,

--- a/docs/lib/llm-guardrails/direct-execution.ts
+++ b/docs/lib/llm-guardrails/direct-execution.ts
@@ -18,7 +18,7 @@ export const DIRECT_EXECUTION_GUARDRAILS = `
 
 ### Authenticating Users
 
-Create an **Auth Config** on [platform.composio.dev](https://platform.composio.dev), then use the auth config ID to generate a hosted auth URL:
+Create an **Auth Config** on [dashboard.composio.dev](https://dashboard.composio.dev), then use the auth config ID to generate a hosted auth URL:
 
 \`\`\`python
 from composio import Composio


### PR DESCRIPTION
## Summary

- **Dark/light theme switcher** in the navbar. Drops `forcedTheme: 'light'` so the toggle actually flips themes; sidebar footer toggle stays disabled so there's only one switcher.
- **Dark mode color pass.** `--composio-brand` lifts to a muted `#5B8BF0` (the deep `#0007cd` brand reads as unlit text on `#0f0f0f`). Card / muted greys nudge to `#1c1c1c` / `#1f1f1f`. Borders drop from 10% white to 6% so card edges sit back. `--border` / `--sidebar-border` follow suit.
- **Square navbar.** Search input and the new theme toggle render with `border-radius: 0` to match the rest of the navbar.
- **Welcome-page scroll reset.** New `ScrollReset` client component wired into the root layout. Next.js App Router skips its built-in scroll reset when the new route resolves to the same dynamic `page.tsx` segment — every link from the welcome page to a `/docs/*` page hits this case, so users were landing mid-page on the new route. Now `usePathname()` change ⇒ `window.scrollTo(0, 0)` (skips first render and any hash-bearing navigation).
- **`platform.composio.dev` → `dashboard.composio.dev`** across docs content + the direct-execution LLM guardrail (28 files). `docs/public/openapi*.json` left alone — auto-generated, and the surviving reference is literally to the legacy dashboard.

## Test plan

- [ ] Toggle theme from the navbar; verify both light and dark render
- [ ] In dark mode, confirm "Docs" nav active state, chip icons, "CONNECTED" labels, and Ask AI button read clearly against `#0f0f0f`
- [ ] Scroll to the bottom of `/docs`, click any link in HomeResources / HomeSurfaces / HomeFeatures — the new page should land at scroll 0
- [ ] Click a TOC `#anchor` link inside a docs page — should still scroll to the anchor (not get clobbered to 0)
- [ ] Spot-check a few rewritten URLs in cookbooks / quickstart — all `platform.composio.dev` should now be `dashboard.composio.dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)