### PR TITLE
fix: correct typos 'sucessfull' and 'satus' in callbackUrl JSDoc

### DIFF
--- a/ts/packages/core/src/types/connectedAccounts.types.ts
+++ b/ts/packages/core/src/types/connectedAccounts.types.ts
@@ -308,8 +308,8 @@ export const CreateConnectedAccountLinkOptionsSchema = z.object({
   /**
    * The url to redirect the user to post connecting their account.
    *
-   * For sucessfull connections, you will get a query param called status=success
-   * And for failed connections you will get a query param called satus=failed
+   * For successful connections, you will get a query param called status=success
+   * And for failed connections you will get a query param called status=failed
    *
    * @example https://your-app.com/callback
    *


### PR DESCRIPTION
## Summary

Fixes #3475

Two typos in the JSDoc comment for `CreateConnectedAccountLinkOptionsSchema.callbackUrl` in `ts/packages/core/src/types/connectedAccounts.types.ts`:

- `sucessfull` → `successful`
- `satus=failed` → `status=failed`