### PR TITLE
docs: add formula workbook custom tool cookbook

### DIFF
--- a/docs/content/cookbooks/formula-workbook-tool.mdx
+++ b/docs/content/cookbooks/formula-workbook-tool.mdx
@@ -1,0 +1,90 @@
+---
+title: Formula Workbook Tool
+description: Give an agent a deterministic pricing workbook tool using Composio custom tools and Bilig WorkPaper
+keywords: [custom tool, formula workbook, spreadsheet formulas, workpaper, pricing agent]
+---
+
+[View source on GitHub](https://github.com/ComposioHQ/composio/tree/next/docs/examples/formula-workbook-tool)
+
+This cookbook shows how to expose spreadsheet-style business logic as a local Composio custom tool. The agent writes inputs into a Bilig WorkPaper, reads recalculated formula outputs, and returns a small proof that the workbook state can be exported as JSON.
+
+Use this pattern when your team already reviews pricing, payout, quota, or finance logic as spreadsheet formulas, but your agent should not drive Excel, Google Sheets, or a browser UI to get a computed value.
+
+## Prerequisites
+
+- Node.js 24+
+- [Composio API key](https://dashboard.composio.dev/settings)
+- [OpenAI API key](https://platform.openai.com/api-keys)
+
+## Project setup
+
+Create a new project and install the dependencies:
+
+```bash
+mkdir formula-workbook-tool && cd formula-workbook-tool
+npm init -y
+npm install @composio/core @composio/vercel @ai-sdk/openai ai @bilig/workpaper zod dotenv tsx
+```
+
+Add your API keys to a `.env` file:
+
+```bash title=".env"
+COMPOSIO_API_KEY=your_composio_api_key
+OPENAI_API_KEY=your_openai_api_key
+COMPOSIO_USER_ID=formula-workbook-demo
+```
+
+## Build the workbook
+
+The workbook has one input sheet and one formula sheet. Bilig recalculates formulas in process, so the agent gets computed values without opening a spreadsheet app.
+
+<include meta="no-twoslash">../../examples/formula-workbook-tool/server.ts#workbook</include>
+
+## Register the custom tool
+
+`experimental_createTool` turns the workbook into an agent-callable tool. The tool writes only the input cells, then reads the formula outputs and exports the WorkPaper snapshot as a persistence check.
+
+<include meta="no-twoslash">../../examples/formula-workbook-tool/server.ts#custom-tool</include>
+
+## Add it to a session
+
+Pass the custom tool into the Composio session. `preload: true` makes this tool available immediately alongside any remote tools the session can discover.
+
+<include meta="no-twoslash">../../examples/formula-workbook-tool/server.ts#session</include>
+
+## Run the agent
+
+Ask the agent to calculate a quote. The model calls the local workbook tool, then summarizes the formula output.
+
+<include meta="no-twoslash">../../examples/formula-workbook-tool/server.ts#run</include>
+
+## Complete script
+
+<include meta='no-twoslash title="server.ts"'>../../examples/formula-workbook-tool/server.ts</include>
+
+## Run it
+
+```bash
+npx tsx server.ts
+```
+
+You should see the agent report the net revenue and approval result from the workbook formulas.
+
+## Take it further
+
+- Load the workbook definition from a saved WorkPaper JSON file instead of building it inline.
+- Store the exported snapshot after every run so later agents can inspect what changed.
+- Add Composio toolkits such as Slack, Gmail, or GitHub to send the approved quote or open a follow-up issue.
+
+<Cards>
+  <Card
+    title="Custom Tools and Toolkits"
+    href="/docs/toolkits/custom-tools-and-toolkits"
+    description="Define local tools that run in process alongside remote Composio tools"
+  />
+  <Card
+    title="Background Agent"
+    href="/cookbooks/background-agent"
+    description="Run scheduled agents with Composio sessions"
+  />
+</Cards>

--- a/docs/content/cookbooks/index.mdx
+++ b/docs/content/cookbooks/index.mdx
@@ -33,6 +33,7 @@ Browse open-source templates or follow step-by-step guides below.
 
 <Cards>
   <Card title="PR Review Agent" href="/cookbooks/pr-review-agent" description="AI reviewer that reads your CLAUDE.md and posts structured feedback on every PR" />
+  <Card title="Formula Workbook Tool" href="/cookbooks/formula-workbook-tool" description="Expose spreadsheet-style business logic as a deterministic local agent tool" />
 </Cards>
 
 ## Behind the Curtain

--- a/docs/content/cookbooks/meta.json
+++ b/docs/content/cookbooks/meta.json
@@ -17,6 +17,7 @@
     "supabase-sql-agent",
     "---Developer Tools---",
     "pr-review-agent",
+    "formula-workbook-tool",
     "---Behind the Curtain---",
     "tool-generator"
   ]

--- a/docs/examples/formula-workbook-tool/server.ts
+++ b/docs/examples/formula-workbook-tool/server.ts
@@ -1,0 +1,112 @@
+import 'dotenv/config';
+import { openai } from '@ai-sdk/openai';
+import { Composio, experimental_createTool } from '@composio/core';
+import { VercelProvider } from '@composio/vercel';
+import { generateText, stepCountIs } from 'ai';
+import { z } from 'zod/v3';
+import { WorkPaper } from '@bilig/workpaper';
+
+// #region workbook
+const pricingWorkbook = WorkPaper.buildFromSheets({
+  Inputs: [
+    ['Metric', 'Value'],
+    ['Units', 50],
+    ['Unit price', 1200],
+    ['Discount rate', 0.1],
+    ['Approval threshold', 50000],
+  ],
+  Summary: [
+    ['Metric', 'Value'],
+    ['Gross revenue', '=Inputs!B2*Inputs!B3'],
+    ['Discount amount', '=B2*Inputs!B4'],
+    ['Net revenue', '=B2-B3'],
+    ['Approved', '=IF(B4>=Inputs!B5,"yes","no")'],
+  ],
+});
+
+const inputsSheet = pricingWorkbook.getSheetId('Inputs');
+const summarySheet = pricingWorkbook.getSheetId('Summary');
+
+if (inputsSheet === undefined || summarySheet === undefined) {
+  throw new Error('Pricing workbook did not initialize correctly');
+}
+// #endregion workbook
+
+function readNumberCell(row: number): number {
+  const value = pricingWorkbook.getCellValue({ sheet: summarySheet, row, col: 1 });
+  if (typeof value !== 'number') {
+    throw new Error(`Expected Summary row ${row + 1} to contain a number`);
+  }
+  return value;
+}
+
+function readTextCell(row: number): string {
+  const value = pricingWorkbook.getCellValue({ sheet: summarySheet, row, col: 1 });
+  if (typeof value !== 'string') {
+    throw new Error(`Expected Summary row ${row + 1} to contain text`);
+  }
+  return value;
+}
+
+// #region custom-tool
+const runPricingWorkbook = experimental_createTool('RUN_PRICING_WORKBOOK', {
+  name: 'Run pricing workbook',
+  description:
+    'Write pricing inputs into a formula workbook, recalculate the dependent formulas, and return computed outputs with JSON persistence proof.',
+  preload: true,
+  inputParams: z.object({
+    units: z.number().int().positive().describe('Number of units in the quote'),
+    unitPrice: z.number().positive().describe('Price per unit'),
+    discountRate: z.number().min(0).max(1).describe('Discount rate as a decimal'),
+  }),
+  outputParams: z.object({
+    grossRevenue: z.number(),
+    discountAmount: z.number(),
+    netRevenue: z.number(),
+    approved: z.string(),
+    exportedWorkPaper: z.boolean(),
+  }),
+  execute: async input => {
+    pricingWorkbook.setCellContents({ sheet: inputsSheet, row: 1, col: 1 }, input.units);
+    pricingWorkbook.setCellContents({ sheet: inputsSheet, row: 2, col: 1 }, input.unitPrice);
+    pricingWorkbook.setCellContents({ sheet: inputsSheet, row: 3, col: 1 }, input.discountRate);
+
+    return {
+      grossRevenue: readNumberCell(1),
+      discountAmount: readNumberCell(2),
+      netRevenue: readNumberCell(3),
+      approved: readTextCell(4),
+      exportedWorkPaper: Boolean(pricingWorkbook.exportSnapshot()),
+    };
+  },
+});
+// #endregion custom-tool
+
+// #region session
+const composio = new Composio({ provider: new VercelProvider() });
+const userId = process.env.COMPOSIO_USER_ID ?? 'formula-workbook-demo';
+
+const session = await composio.create(userId, {
+  experimental: {
+    customTools: [runPricingWorkbook],
+  },
+});
+
+const tools = await session.tools();
+// #endregion session
+
+// #region run
+try {
+  const result = await generateText({
+    model: openai('gpt-5.4'),
+    tools,
+    stopWhen: stepCountIs(6),
+    prompt:
+      'Run the pricing workbook for 80 units at $1,500 with a 20% discount. Report the net revenue and whether the quote is approved.',
+  });
+
+  console.log(result.text);
+} finally {
+  pricingWorkbook.dispose();
+}
+// #endregion run


### PR DESCRIPTION
## Summary
Adds a cookbook for exposing spreadsheet-style business logic as a local Composio custom tool using Bilig WorkPaper. The example writes pricing inputs, reads recalculated outputs, and returns JSON persistence proof.

## Changes

- Add `/cookbooks/formula-workbook-tool`
- Add `docs/examples/formula-workbook-tool/server.ts`
- Link the cookbook from the cookbooks index and metadata

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [x] Documentation
- [ ] Breaking change

## How Has This Been Tested?

- `git diff --check`
- `bun install --frozen-lockfile`
- `bun run lint:links`
- `bun run types:check`
- `bun run build`

Current Bilig package sanity check:

```bash
npm exec --yes --package @bilig/workpaper@latest -- bilig-evaluate --door agent-mcp --json
```

That returned `verified: true` on `@bilig/workpaper@0.157.0`: it listed 8 MCP tools, edited `Inputs!B3`, recalculated ARR from `60000` to `96000`, persisted the WorkPaper JSON, restored readback at `96000`, and verified restart readback at `96000`.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed
- [x] I updated documentation as needed
- [x] I added tests or explain why not applicable: docs-only cookbook; docs link/type/build checks passed
- [x] I added a changeset if this change affects published packages: not applicable, docs-only

## Additional context

This uses Composio custom tools for local in-process business logic. The workbook package is only installed by the cookbook project; the Composio docs app does not add a new dependency.

The visible Vercel status currently needs Composio team authorization for the preview deployment. The local docs checks above passed before opening the PR.



