### PR TITLE
fix(providers): normalize string tool input in LlamaIndex & Claude Agent SDK providers + add regression tests

### DIFF
--- a/.changeset/normalize-string-tool-input-providers.md
+++ b/.changeset/normalize-string-tool-input-providers.md
@@ -1,0 +1,14 @@
+---
+"@composio/llamaindex": patch
+"@composio/claude-agent-sdk": patch
+---
+
+fix(providers): normalize string tool input in LlamaIndex and Claude Agent SDK providers
+
+Models occasionally emit tool-call input as a JSON string rather than an object (issue #2406).
+`ExecuteToolFn` is typed to receive a `Record<string, unknown>`, but the LlamaIndex and Claude
+Agent SDK providers forwarded the model input unchecked, so a stringified payload reached
+execution as a raw string (`Input should be a valid dictionary`). Both now parse a string input
+to an object before forwarding — matching the guard already shipped in the vercel, cloudflare and
+openai-agents providers. Also backfills regression tests for the string path in all three
+providers (the openai-agents guard previously had no test).

--- a/ts/packages/providers/claude-agent-sdk/src/index.ts
+++ b/ts/packages/providers/claude-agent-sdk/src/index.ts
@@ -114,7 +114,11 @@ export class ClaudeAgentSDKProvider extends BaseAgenticProvider<
       inputZodShape,
       async args => {
         try {
-          const result = await executeTool(composioTool.slug, args);
+          // Models occasionally emit tool input as a JSON string rather than an object (issue #2406).
+          // ExecuteToolFn promises a Record<string, unknown>, so normalize before forwarding — mirrors
+          // the guard already shipped in the vercel/cloudflare/openai-agents providers.
+          const normalizedArgs = typeof args === 'string' ? JSON.parse(args) : args;
+          const result = await executeTool(composioTool.slug, normalizedArgs as Record<string, unknown>);
           return {
             content: [
               {

--- a/ts/packages/providers/claude-agent-sdk/src/index.ts
+++ b/ts/packages/providers/claude-agent-sdk/src/index.ts
@@ -117,7 +117,17 @@ export class ClaudeAgentSDKProvider extends BaseAgenticProvider<
           // Models occasionally emit tool input as a JSON string rather than an object (issue #2406).
           // ExecuteToolFn promises a Record<string, unknown>, so normalize before forwarding — mirrors
           // the guard already shipped in the vercel/cloudflare/openai-agents providers.
-          const normalizedArgs = typeof args === 'string' ? JSON.parse(args) : args;
+          // If the string isn't valid JSON, keep it as-is so executeTool raises a typed error instead of a SyntaxError.
+          const normalizedArgs =
+            typeof args === 'string'
+              ? (() => {
+                  try {
+                    return JSON.parse(args);
+                  } catch {
+                    return args;
+                  }
+                })()
+              : args;
           const result = await executeTool(composioTool.slug, normalizedArgs as Record<string, unknown>);
           return {
             content: [

--- a/ts/packages/providers/claude-agent-sdk/test/claude-agent-sdk.test.ts
+++ b/ts/packages/providers/claude-agent-sdk/test/claude-agent-sdk.test.ts
@@ -173,6 +173,21 @@ describe('ClaudeAgentSDKProvider', () => {
       });
     });
 
+    it('should normalize a stringified JSON input to an object before executing (issue #2406)', async () => {
+      provider.wrapTool(mockTool, mockExecuteToolFn);
+      const handler = (tool as any).mock.calls[0][3];
+      const params = { to: 'test@example.com', subject: 'Test', body: 'Hello' };
+
+      // Object input is forwarded unchanged.
+      await handler(params);
+      expect(mockExecuteToolFn).toHaveBeenCalledWith(mockTool.slug, params);
+
+      // A stringified-JSON input must be parsed to the same object, not forwarded as a raw string.
+      vi.clearAllMocks();
+      await handler(JSON.stringify(params));
+      expect(mockExecuteToolFn).toHaveBeenCalledWith(mockTool.slug, params);
+    });
+
     it('should handle string results from tool execution', async () => {
       mockExecuteToolFn.mockResolvedValueOnce('Simple string result');
       provider.wrapTool(mockTool, mockExecuteToolFn);

--- a/ts/packages/providers/claude-agent-sdk/test/claude-agent-sdk.test.ts
+++ b/ts/packages/providers/claude-agent-sdk/test/claude-agent-sdk.test.ts
@@ -188,6 +188,17 @@ describe('ClaudeAgentSDKProvider', () => {
       expect(mockExecuteToolFn).toHaveBeenCalledWith(mockTool.slug, params);
     });
 
+    it('should pass a malformed-JSON string through unchanged rather than throwing (graceful fallback)', async () => {
+      provider.wrapTool(mockTool, mockExecuteToolFn);
+      const handler = (tool as any).mock.calls[0][3];
+
+      // A string that looks like JSON but is malformed must not throw a SyntaxError at the normalize
+      // step; it falls through as the raw string so executeTool can surface its own typed error.
+      const malformed = '{"to": "test@example.com"'; // missing closing brace
+      await handler(malformed);
+      expect(mockExecuteToolFn).toHaveBeenCalledWith(mockTool.slug, malformed);
+    });
+
     it('should handle string results from tool execution', async () => {
       mockExecuteToolFn.mockResolvedValueOnce('Simple string result');
       provider.wrapTool(mockTool, mockExecuteToolFn);

--- a/ts/packages/providers/llamaindex/src/index.ts
+++ b/ts/packages/providers/llamaindex/src/index.ts
@@ -42,7 +42,17 @@ export class LlamaindexProvider extends BaseAgenticProvider<
         // Models occasionally emit tool input as a JSON string rather than an object (issue #2406).
         // ExecuteToolFn promises a Record<string, unknown>, so normalize before forwarding — mirrors
         // the guard already shipped in the vercel/cloudflare/openai-agents providers.
-        const normalizedInput = typeof input === 'string' ? JSON.parse(input) : input;
+        // If the string isn't valid JSON, keep it as-is so executeTool raises a typed error instead of a SyntaxError.
+        const normalizedInput =
+          typeof input === 'string'
+            ? (() => {
+                try {
+                  return JSON.parse(input);
+                } catch {
+                  return input;
+                }
+              })()
+            : input;
         const result = await executeTool(tool.slug, normalizedInput as Record<string, unknown>);
         return JSON.stringify(result);
       },

--- a/ts/packages/providers/llamaindex/src/index.ts
+++ b/ts/packages/providers/llamaindex/src/index.ts
@@ -39,7 +39,11 @@ export class LlamaindexProvider extends BaseAgenticProvider<
       description: tool.description ?? tool.name ?? '',
       parameters: inputParametersSchema,
       execute: async input => {
-        const result = await executeTool(tool.slug, input as Record<string, unknown>);
+        // Models occasionally emit tool input as a JSON string rather than an object (issue #2406).
+        // ExecuteToolFn promises a Record<string, unknown>, so normalize before forwarding — mirrors
+        // the guard already shipped in the vercel/cloudflare/openai-agents providers.
+        const normalizedInput = typeof input === 'string' ? JSON.parse(input) : input;
+        const result = await executeTool(tool.slug, normalizedInput as Record<string, unknown>);
         return JSON.stringify(result);
       },
     });

--- a/ts/packages/providers/llamaindex/test/llamaindex.test.ts
+++ b/ts/packages/providers/llamaindex/test/llamaindex.test.ts
@@ -105,6 +105,20 @@ describe('LlamaindexProvider', () => {
       });
     });
 
+    it('should normalize a stringified JSON input to an object before executing (issue #2406)', async () => {
+      const wrappedTool = provider.wrapTool(sampleTool, executeToolFn);
+      const searchParams = { query: 'test search' };
+
+      // Object input is forwarded unchanged.
+      await wrappedTool.call(searchParams);
+      expect(executeToolFn).toHaveBeenCalledWith(sampleTool.slug, searchParams);
+
+      // A stringified-JSON input must be parsed to the same object, not forwarded as a raw string.
+      vi.clearAllMocks();
+      await wrappedTool.call(JSON.stringify(searchParams) as unknown as Record<string, unknown>);
+      expect(executeToolFn).toHaveBeenCalledWith(sampleTool.slug, searchParams);
+    });
+
     it('should handle tools without input parameters', () => {
       const toolWithoutParams = { ...sampleTool, inputParameters: undefined };
 

--- a/ts/packages/providers/llamaindex/test/llamaindex.test.ts
+++ b/ts/packages/providers/llamaindex/test/llamaindex.test.ts
@@ -119,6 +119,16 @@ describe('LlamaindexProvider', () => {
       expect(executeToolFn).toHaveBeenCalledWith(sampleTool.slug, searchParams);
     });
 
+    it('should pass a malformed-JSON string through unchanged rather than throwing (graceful fallback)', async () => {
+      const wrappedTool = provider.wrapTool(sampleTool, executeToolFn);
+
+      // A string that looks like JSON but is malformed must not throw a SyntaxError at the normalize
+      // step; it falls through as the raw string so executeTool can surface its own typed error.
+      const malformed = '{"query": "test"'; // missing closing brace
+      await wrappedTool.call(malformed as unknown as Record<string, unknown>);
+      expect(executeToolFn).toHaveBeenCalledWith(sampleTool.slug, malformed);
+    });
+
     it('should handle tools without input parameters', () => {
       const toolWithoutParams = { ...sampleTool, inputParameters: undefined };
 

--- a/ts/packages/providers/openai-agents/test/openai-agents.test.ts
+++ b/ts/packages/providers/openai-agents/test/openai-agents.test.ts
@@ -99,6 +99,23 @@ describe('OpenAIAgentsProvider', () => {
       expect(wrapped._isMockedOpenAIAgentTool).toBe(true);
     });
 
+    it('should normalize a stringified JSON input to an object before executing (issue #2406)', async () => {
+      const wrapped = provider.wrapTool(
+        mockTool,
+        mockExecuteToolFn
+      ) as unknown as MockedOpenAIAgentTool;
+      const params = { input: 'test-value' };
+
+      // Object input is forwarded unchanged.
+      await (wrapped as any).execute(params);
+      expect(mockExecuteToolFn).toHaveBeenCalledWith(mockTool.slug, params);
+
+      // A stringified-JSON input must be parsed to the same object, not forwarded as a raw string.
+      vi.clearAllMocks();
+      await (wrapped as any).execute(JSON.stringify(params));
+      expect(mockExecuteToolFn).toHaveBeenCalledWith(mockTool.slug, params);
+    });
+
     it('should handle tools without input parameters', () => {
       const toolWithoutParams: Tool = {
         ...mockTool,


### PR DESCRIPTION
## Why
`ExecuteToolFn` is typed `(toolSlug, input: Record<string, unknown>)` — it promises an object. Per #2406, models intermittently emit tool-call input as a JSON **string**. The `llamaindex` (`input as Record<string, unknown>`) and `claude-agent-sdk` (`args` passed straight through) providers forwarded model input **unchecked**, so a stringified payload reached execution as a raw string (`Input should be a valid dictionary`).

## Changes
- **llamaindex** + **claude-agent-sdk**: normalize string→object before forwarding — `const normalized = typeof input === 'string' ? JSON.parse(input) : input;` — mirroring the guard already shipped in `vercel`/`cloudflare`/`openai-agents`.
- **Tests:** the existing `openai-agents` guard had **no** string-path test. Backfilled string→object regression tests across all three providers (`'{"x":1}'` → `{x:1}`; `{x:1}` → passthrough).
- Patch changeset for the two providers.

## Scope / honesty
- Left `langchain`/`anthropic`/`google` to in-flight #3438; didn't touch `mastra` (#3400).
- Lower-severity than the Vercel path (these Zod-validate against the tool schema before execute), so this is a defensive-consistency + coverage fix, not a hotfix.

Refs #2406.
