### PR TITLE
changelog: api security updates (2026-06-04)

### DIFF
--- a/docs/content/changelog/06-04-26-security-reliability-hardening.mdx
+++ b/docs/content/changelog/06-04-26-security-reliability-hardening.mdx
@@ -11,7 +11,6 @@ A summary of recent security, API, and platform changes you may need to act on. 
 - MCP requests now require an API key or `Authorization: Bearer` token. SSE is no longer supported; use the HTTP transport.
 - API keys are now scoped. Capabilities such as Proxy Execute are enabled per key when you create it in the Dashboard, and are off by default.
 - API keys now support IP allowlisting, and we have tightened what we block and deny. Based on recent traffic we automatically added IP allowlists to some keys, so if a request is unexpectedly rejected, edit the key's allowlist or rotate the key. The API and SDK remain fully functional, and if something is blocked that should not be, let us know.
-- You can now enable multi-factor authentication (MFA) for Dashboard sign-in. It is not enabled by default.
 
 ### Connections
 

--- a/docs/content/changelog/06-04-26-security-reliability-hardening.mdx
+++ b/docs/content/changelog/06-04-26-security-reliability-hardening.mdx
@@ -1,25 +1,39 @@
 ---
 title: "Security, API, and platform updates"
-description: "Recent changes across MCP and API authentication, scoped API keys and IP allowlists, connected-account token handling, webhooks, and retired legacy endpoints."
+description: "Recent changes across MCP and API authentication, Proxy Execute, connected accounts and triggers, token redaction, webhooks, rate limits, and retired legacy endpoints."
 date: "2026-06-04"
 ---
 
-A summary of recent security, API, and platform changes you may need to act on. We are continuing to ship more.
+A summary of recent security, API, and platform changes you may need to act on. Most won't apply to you, so skim for the ones that do. We are continuing to ship more.
 
-### Authentication and API keys
+### MCP and API authentication
 
 - MCP requests now require an API key or `Authorization: Bearer` token. SSE is no longer supported; use the HTTP transport.
-- API keys are now scoped. Capabilities such as Proxy Execute are enabled per key when you create it in the Dashboard, and are off by default.
 - API keys now support IP allowlisting, and we have tightened what we block and deny. Based on recent traffic we automatically added IP allowlists to some keys, so if a request is unexpectedly rejected, edit the key's allowlist or rotate the key. The API and SDK remain fully functional, and if something is blocked that should not be, let us know.
 
-### Connections
+### Proxy Execute
+
+- Proxy Execute is now an opt-in capability on an API key. Enable "Allow proxy execute" when you create the key in the Dashboard (it is off by default and cannot be changed after creation), then use that key when you need to act on a provider directly (for example, a request our predefined tools do not cover).
+- Proxy Execute requests have a 250MB payload cap.
+
+### Connections and triggers
 
 - Composio-managed OAuth connections are moving from `initiate` to `link`. The cutover for remaining organizations is July 3, 2026.
-- Connected-account tokens are redacted in API responses, for both Composio-managed and custom auth configs. If you need to act on the provider directly (for example, a request our predefined tools do not cover), use [Proxy Execute](https://docs.composio.dev/docs/proxy-execute) with a scoped API key that has proxy execute enabled.
+- Code execution through the remote workbench (`COMPOSIO_REMOTE_WORKBENCH`, `COMPOSIO_REMOTE_BASH_TOOL`) now runs only inside a Composio session. If your code execution stopped working, run it within a Composio session.
+
+### Token redaction
+
+- Connected-account tokens are redacted in API responses, for both Composio-managed and custom auth configs.
+- Tokens are also redacted in tool responses and trigger payloads. If you previously parsed raw URLs or tokens out of those, use [Proxy Execute](https://docs.composio.dev/docs/proxy-execute) instead.
 
 ### Webhooks
 
-- Webhook URLs must be publicly reachable, and deliveries are now signed; verify the `webhook-signature` header. Manage subscriptions with the [Webhook Subscriptions API](https://docs.composio.dev/reference/api-reference/webhook-subscriptions).
+- Webhook URLs must be publicly reachable; internal and loopback targets are now rejected.
+- Deliveries are now signed (verify the `webhook-signature` header), and there is a new `composio.trigger.disabled` event. Manage subscriptions with the [Webhook Subscriptions API](https://docs.composio.dev/reference/api-reference/webhook-subscriptions).
+
+### Rate limits
+
+- Per-IP rate limits now apply. If you see `429` responses, tell us your throughput and we will help.
 
 ### Endpoints
 

--- a/docs/content/changelog/06-04-26-security-reliability-hardening.mdx
+++ b/docs/content/changelog/06-04-26-security-reliability-hardening.mdx
@@ -6,25 +6,24 @@ date: "2026-06-04"
 
 A summary of recent security, API, and platform changes you may need to act on. Most won't apply to you, so skim for the ones that do. We are continuing to ship more.
 
-### MCP and API authentication
+### Legacy MCP Config routes
+- MCP requests now require an API key or `Authorization: Bearer` token. We recommend moving to `composio.create` 
 
-- MCP requests now require an API key or `Authorization: Bearer` token. SSE is no longer supported; use the HTTP transport.
-- API keys now support IP allowlisting, and we have tightened what we block and deny. Based on recent traffic we automatically added IP allowlists to some keys, so if a request is unexpectedly rejected, edit the key's allowlist or rotate the key. The API and SDK remain fully functional.
+### API Keys
+- IP whitelisting, choose which ip address can work from your api keys.
+- Scoped API Key are slowly being rolled out with first preset for `proxyExecute`. You will be able to control what actions your api keys can take.
 
 ### Proxy Execute
-
-- Proxy Execute is now an opt-in capability on an API key. Enable "Allow proxy execute" when you create the key in the Dashboard (it is off by default and cannot be changed after creation), then use that key when you need to act on a provider directly (for example, a request our predefined tools do not cover).
+- Proxy Execute is disabled on `v3` api, please use `v3.1` or update your sdks.
+- Proxy Execute is now an opt-in capability on an API key, it is a superset of regular capabilities + proxy execute.
 - Proxy Execute requests have a 250MB payload cap.
 
-### Connections and triggers
+### Connections 
+- Connected-account tokens are redacted in API responses, for both Composio-managed and custom auth configs. Please use [Proxy Execute](https://docs.composio.dev/docs/proxy-execute) instead. If you need this for some special case please reach out to support.
+- Reiterating: Composio-managed OAuth connections are moving from `initiate` to `link`. The cutover for remaining organizations is July 3, 2026.
 
-- Composio-managed OAuth connections are moving from `initiate` to `link`. The cutover for remaining organizations is July 3, 2026.
+### Workbench
 - Code execution through the remote workbench (`COMPOSIO_REMOTE_WORKBENCH`, `COMPOSIO_REMOTE_BASH_TOOL`) now runs only inside a Composio session. If your code execution stopped working, run it within a Composio session.
-
-### Token redaction
-
-- Connected-account tokens are redacted in API responses, for both Composio-managed and custom auth configs.
-- Tokens are also redacted in tool responses and trigger payloads. If you previously parsed raw URLs or tokens out of those, use [Proxy Execute](https://docs.composio.dev/docs/proxy-execute) instead.
 
 ### Webhooks
 
@@ -37,4 +36,4 @@ A summary of recent security, API, and platform changes you may need to act on. 
 
 ### Endpoints
 
-- The legacy v1 and v2 endpoints, deprecated last year, have now been removed. They were superseded by v3 and rerouted behind the scenes, taken out of the docs, and their SDKs were left unmaintained for several months. Remaining calls to `/api/rerouted/v1` and `/v2` now return `410`; move to v3.1.
+- The legacy v1 and v2 endpoints, deprecated last year, have now been removed. Any calls to `/v1` or `v2` endpoints now return `410`, please use the class of `v3` and `v3.1` endpoints, if you need a guide to migration you can use [this](https://docs.composio.dev/docs/migration-guide/new-sdk)

--- a/docs/content/changelog/06-04-26-security-reliability-hardening.mdx
+++ b/docs/content/changelog/06-04-26-security-reliability-hardening.mdx
@@ -9,7 +9,7 @@ A summary of recent security, API, and platform changes you may need to act on. 
 ### MCP and API authentication
 
 - MCP requests now require an API key or `Authorization: Bearer` token. SSE is no longer supported; use the HTTP transport.
-- API keys now support IP allowlisting, and we have tightened what we block and deny. Based on recent traffic we automatically added IP allowlists to some keys, so if a request is unexpectedly rejected, edit the key's allowlist or rotate the key. The API and SDK remain fully functional, and if something is blocked that should not be, let us know.
+- API keys now support IP allowlisting, and we have tightened what we block and deny. Based on recent traffic we automatically added IP allowlists to some keys, so if a request is unexpectedly rejected, edit the key's allowlist or rotate the key. The API and SDK remain fully functional.
 
 ### Proxy Execute
 
@@ -33,7 +33,7 @@ A summary of recent security, API, and platform changes you may need to act on. 
 
 ### Rate limits
 
-- Per-IP rate limits now apply. If you see `429` responses, tell us your throughput and we will help.
+- Per-IP rate limits now apply; requests that exceed them receive `429` responses.
 
 ### Endpoints
 

--- a/docs/content/changelog/06-04-26-security-reliability-hardening.mdx
+++ b/docs/content/changelog/06-04-26-security-reliability-hardening.mdx
@@ -1,24 +1,22 @@
 ---
-title: "Security and reliability hardening: what changed and what to do"
-description: "Post-incident changes across authentication, API keys (scoping and IP allowlists), connected-account token redaction, webhooks, retired endpoints, and the Dashboard."
+title: "Security, API, and platform updates"
+description: "Recent changes across MCP and API authentication, scoped API keys and IP allowlists, connected-account token handling, webhooks, and retired legacy endpoints."
 date: "2026-06-04"
 ---
 
-Following the [May 2026 security incident](https://composio.dev/blog/composio-may-2026-security-incident), we shipped a wave of security and reliability changes across authentication, API keys, connected accounts, and webhooks. This is a short summary of changes so far, and we are continuing to ship more.
+A summary of recent security, API, and platform changes you may need to act on. We are continuing to ship more.
 
 ### Authentication and API keys
 
 - MCP requests now require an API key or `Authorization: Bearer` token. SSE is no longer supported; use the HTTP transport.
-- Cookie and session auth on `/api/v3.1/*` is removed. Use `x-api-key` or `x-user-api-key`.
-- API keys are non-recoverable, so copy them at creation.
 - API keys are now scoped. Capabilities such as Proxy Execute are enabled per key when you create it in the Dashboard, and are off by default.
-- Based on recent traffic, we automatically added IP allowlists to some API keys. You can edit the allowlist on a key, or rotate the key, in the API Keys dashboard.
+- API keys now support IP allowlisting, and we have tightened what we block and deny. Based on recent traffic we automatically added IP allowlists to some keys, so if a request is unexpectedly rejected, edit the key's allowlist or rotate the key. The API and SDK remain fully functional, and if something is blocked that should not be, let us know.
 - You can now enable multi-factor authentication (MFA) for Dashboard sign-in. It is not enabled by default.
 
 ### Connections
 
 - Composio-managed OAuth connections are moving from `initiate` to `link`. The cutover for remaining organizations is July 3, 2026.
-- Connected-account tokens are redacted in API responses, for both Composio-managed and custom auth configs. When you need to act on the provider, use [Proxy Execute](https://docs.composio.dev/docs/proxy-execute).
+- Connected-account tokens are redacted in API responses, for both Composio-managed and custom auth configs. If you need to act on the provider directly (for example, a request our predefined tools do not cover), use [Proxy Execute](https://docs.composio.dev/docs/proxy-execute) with a scoped API key that has proxy execute enabled.
 
 ### Webhooks
 
@@ -26,10 +24,4 @@ Following the [May 2026 security incident](https://composio.dev/blog/composio-ma
 
 ### Endpoints
 
-- The legacy `/api/rerouted/v1` and `/v2` paths are retired and return `410`. Move to v3.1.
-
-### Dashboard
-
-- The previous dashboard at `https://platform.composio.dev` is deprecated and now redirects to the new dashboard at `https://dashboard.composio.dev`.
-- We are still restoring some parts of the Dashboard. While we finish, you may see occasional `401 Unauthorized` responses. Please don't worry, we will help you fix those quickly, and the API and SDK remain fully functional throughout.
-- The MCP configurations view has been removed from the Dashboard. You can manage MCP configs through the [MCP API](https://docs.composio.dev/reference/api-reference/mcp), and if you use these we highly recommend moving to [Composio sessions](https://docs.composio.dev/docs/how-composio-works).
+- The legacy v1 and v2 endpoints, deprecated last year, have now been removed. They were superseded by v3 and rerouted behind the scenes, taken out of the docs, and their SDKs were left unmaintained for several months. Remaining calls to `/api/rerouted/v1` and `/v2` now return `410`; move to v3.1.

--- a/docs/content/changelog/06-04-26-security-reliability-hardening.mdx
+++ b/docs/content/changelog/06-04-26-security-reliability-hardening.mdx
@@ -1,0 +1,35 @@
+---
+title: "Security and reliability hardening: what changed and what to do"
+description: "Post-incident changes across authentication, API keys (scoping and IP allowlists), connected-account token redaction, webhooks, retired endpoints, and the Dashboard."
+date: "2026-06-04"
+---
+
+Following the [May 2026 security incident](https://composio.dev/blog/composio-may-2026-security-incident), we shipped a wave of security and reliability changes across authentication, API keys, connected accounts, and webhooks. This is a short summary of changes so far, and we are continuing to ship more.
+
+### Authentication and API keys
+
+- MCP requests now require an API key or `Authorization: Bearer` token. SSE is no longer supported; use the HTTP transport.
+- Cookie and session auth on `/api/v3.1/*` is removed. Use `x-api-key` or `x-user-api-key`.
+- API keys are non-recoverable, so copy them at creation.
+- API keys are now scoped. Capabilities such as Proxy Execute are enabled per key when you create it in the Dashboard, and are off by default.
+- Based on recent traffic, we automatically added IP allowlists to some API keys. You can edit the allowlist on a key, or rotate the key, in the API Keys dashboard.
+- You can now enable multi-factor authentication (MFA) for Dashboard sign-in. It is not enabled by default.
+
+### Connections
+
+- Composio-managed OAuth connections are moving from `initiate` to `link`. The cutover for remaining organizations is July 3, 2026.
+- Connected-account tokens are redacted in API responses, for both Composio-managed and custom auth configs. When you need to act on the provider, use [Proxy Execute](https://docs.composio.dev/docs/proxy-execute).
+
+### Webhooks
+
+- Webhook URLs must be publicly reachable, and deliveries are now signed; verify the `webhook-signature` header. Manage subscriptions with the [Webhook Subscriptions API](https://docs.composio.dev/reference/api-reference/webhook-subscriptions).
+
+### Endpoints
+
+- The legacy `/api/rerouted/v1` and `/v2` paths are retired and return `410`. Move to v3.1.
+
+### Dashboard
+
+- The previous dashboard at `https://platform.composio.dev` is deprecated and now redirects to the new dashboard at `https://dashboard.composio.dev`.
+- We are still restoring some parts of the Dashboard. While we finish, you may see occasional `401 Unauthorized` responses. Please don't worry, we will help you fix those quickly, and the API and SDK remain fully functional throughout.
+- The MCP configurations view has been removed from the Dashboard. You can manage MCP configs through the [MCP API](https://docs.composio.dev/reference/api-reference/mcp), and if you use these we highly recommend moving to [Composio sessions](https://docs.composio.dev/docs/how-composio-works).


### PR DESCRIPTION
Adds one concise changelog entry: `docs/content/changelog/06-04-26-security-reliability-hardening.mdx`.

Summarizes the post-incident wave of changes, link-forward (no migration-guide links), matching the existing `docs/content/changelog/*.mdx` format. Source of truth + rationale live in Linear PRO-255 (Customer Comms).

### What it covers
- **Auth / API keys:** MCP auth required, cookie/session auth removed on v3.1, non-recoverable keys, **scoped API keys** (Proxy Execute opt-in at creation, off by default), auto-added IP allowlists, **MFA available for Dashboard sign-in (off by default)**.
- **Connections:** managed-OAuth `initiate` → `link` (Jul 3 cutover), token redaction across **managed + custom** auth configs, Proxy Execute for provider actions.
- **Webhooks / Endpoints:** public-URL + signed deliveries; `/api/rerouted/v1` and `/v2` retired (`410`).
- **Dashboard:** `platform.composio.dev` → `dashboard.composio.dev` redirect, restoration-period `401`s (API/SDK stay functional), MCP configs view removed (use the MCP API / move to Composio sessions).

### Before merge (reviewer checks)
- [ ] Confirm links resolve: Proxy Execute, Webhook Subscriptions API, MCP API reference, Composio sessions.
- [ ] Re-confirm live state: MFA is opt-in (not required); destructive-tool denylist was re-enabled.
- [ ] Confirm the per-project two-factor toggle is intentionally excluded (distinct from Dashboard MFA).
- [ ] Confirm publish date (`2026-06-04`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)