### PR TITLE
changelog: link Workbench session reference to the sessions doc

### DIFF
--- a/docs/content/changelog/06-04-26-security-reliability-hardening.mdx
+++ b/docs/content/changelog/06-04-26-security-reliability-hardening.mdx
@@ -23,7 +23,7 @@ A summary of recent security, API, and platform changes you may need to act on. 
 - Reiterating: Composio-managed OAuth connections are moving from `initiate` to `link`. The cutover for remaining organizations is July 3, 2026.
 
 ### Workbench
-- Code execution through the remote workbench (`COMPOSIO_REMOTE_WORKBENCH`, `COMPOSIO_REMOTE_BASH_TOOL`) now runs only inside a Composio session. If your code execution stopped working, run it within a Composio session.
+- Code execution through the remote workbench (`COMPOSIO_REMOTE_WORKBENCH`, `COMPOSIO_REMOTE_BASH_TOOL`) now runs only inside a [Composio session](https://docs.composio.dev/docs/how-composio-works). If your code execution stopped working, run it within a Composio session.
 
 ### Webhooks
 


### PR DESCRIPTION
Small follow-up to #3517 (merged). Adds a docs link to the **Workbench** changelog item — the only outstanding ask from the review thread (Karan/Palash):

> Code execution through the remote workbench … now runs only inside a [Composio session](https://docs.composio.dev/docs/how-composio-works).

No other changes; the rest of the entry is as merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)