### PR TITLE
feat(examples): add agent-trust example using TWZRD Agent Intel MCP server

### DIFF
--- a/ts/examples/agent-trust/.env.example
+++ b/ts/examples/agent-trust/.env.example
@@ -1,0 +1,2 @@
+COMPOSIO_API_KEY=your_composio_api_key_here
+OPENAI_API_KEY=your_openai_api_key_here

--- a/ts/examples/agent-trust/README.md
+++ b/ts/examples/agent-trust/README.md
@@ -1,0 +1,34 @@
+# Agent Trust Gate Example
+
+This example shows how to use the [TWZRD Agent Intel](https://intel.twzrd.xyz) MCP server
+as a trust gate before executing Composio actions.
+
+## Flow
+
+1. Call `preflight_check(wallet)` on the TWZRD Agent Intel MCP server (free, no API key).
+2. If the agent passes the trust check, proceed to execute the Composio action.
+3. If the agent fails, block execution.
+
+## Setup
+
+```bash
+pnpm install
+cp .env.example .env
+# Add COMPOSIO_API_KEY and OPENAI_API_KEY
+```
+
+## Run
+
+```bash
+pnpm start
+```
+
+## TWZRD Agent Intel Tools
+
+| Tool | Auth | Description |
+|------|------|-------------|
+| `score_agent(wallet)` | Free | Trust score 0–100 |
+| `preflight_check(wallet)` | Free | Pass/fail gate |
+| `get_trust_receipt(wallet)` | Paid (x402) | On-chain receipt |
+
+MCP endpoint: `https://intel.twzrd.xyz/mcp` (streamable-HTTP, no auth for free tools)

--- a/ts/examples/agent-trust/package.json
+++ b/ts/examples/agent-trust/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "agent-trust",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "dev": "tsx watch src/index.ts"
+  },
+  "dependencies": {
+    "@ai-sdk/openai": "latest",
+    "@composio/core": "latest",
+    "@composio/vercel": "latest",
+    "@modelcontextprotocol/sdk": "latest",
+    "ai": "latest",
+    "dotenv": "latest",
+    "tsx": "latest"
+  }
+}

--- a/ts/examples/agent-trust/src/index.ts
+++ b/ts/examples/agent-trust/src/index.ts
@@ -1,0 +1,90 @@
+/**
+ * Example: gate an agent action behind a trust check with Composio + TWZRD Agent Intel
+ *
+ * Composio executes a downstream action (e.g. GITHUB_CREATE_ISSUE) only if the
+ * requesting agent wallet passes the TWZRD Agent Intel preflight check.
+ *
+ * TWZRD Agent Intel MCP server: https://intel.twzrd.xyz
+ * - score_agent(wallet)       — free trust score 0–100
+ * - preflight_check(wallet)   — free pass/fail gate
+ * - get_trust_receipt(wallet) — paid x402 on-chain receipt
+ */
+import { openai } from "@ai-sdk/openai";
+import { Composio } from "@composio/core";
+import { VercelProvider } from "@composio/vercel";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import {
+  experimental_createMCPClient as createMCPClient,
+  stepCountIs,
+  streamText,
+} from "ai";
+import "dotenv/config";
+
+const AGENT_WALLET = "D1QkbFJKiPsymJ65RKHhF6DFB8sPMfpBaFBzuHKfJGWi";
+
+// --------------------------------------------------------------------------
+// 1. Trust check via TWZRD Agent Intel (free, no API key needed)
+// --------------------------------------------------------------------------
+const trustClient = await createMCPClient({
+  name: "twzrd-agent-intel",
+  transport: new StreamableHTTPClientTransport(
+    new URL("https://intel.twzrd.xyz/mcp"),
+  ),
+});
+
+const trustTools = await trustClient.tools();
+
+const trustStream = streamText({
+  model: openai("gpt-4o-mini"),
+  messages: [
+    {
+      role: "user",
+      content: `Run preflight_check for agent wallet ${AGENT_WALLET}. Reply with only PASS or FAIL.`,
+    },
+  ],
+  stopWhen: stepCountIs(3),
+  tools: trustTools,
+});
+
+let trustDecision = "";
+for await (const chunk of trustStream.textStream) {
+  trustDecision += chunk;
+}
+await trustClient.close();
+
+console.log("Trust decision:", trustDecision.trim());
+
+if (!trustDecision.includes("PASS")) {
+  console.error("Agent failed trust check. Blocking downstream action.");
+  process.exit(1);
+}
+
+// --------------------------------------------------------------------------
+// 2. Proceed with Composio action only if agent passed trust check
+// --------------------------------------------------------------------------
+const composio = new Composio({
+  apiKey: process.env.COMPOSIO_API_KEY,
+  provider: new VercelProvider(),
+});
+
+const actionTools = await composio.tools.get(undefined, {
+  apps: ["github"],
+  allowedTools: ["GITHUB_LIST_REPOS_FOR_AUTHENTICATED_USER"],
+});
+
+const actionStream = streamText({
+  model: openai("gpt-4o-mini"),
+  messages: [
+    {
+      role: "user",
+      content:
+        "List the top 5 public repositories for the authenticated GitHub user.",
+    },
+  ],
+  stopWhen: stepCountIs(3),
+  tools: actionTools,
+});
+
+for await (const chunk of actionStream.textStream) {
+  process.stdout.write(chunk);
+}

--- a/ts/examples/agent-trust/tsconfig.json
+++ b/ts/examples/agent-trust/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## What

Adds `ts/examples/agent-trust/` — a new TypeScript example that uses the [TWZRD Agent Intel](https://intel.twzrd.xyz) MCP server as a trust gate before executing a Composio action.

## Pattern

```
preflight_check(wallet) via TWZRD Agent Intel MCP → PASS/FAIL → Composio action
```

This demonstrates a practical agentic safety pattern: before a Composio tool executes on behalf of an AI agent, verify the requesting agent's wallet trust score.

## Why this is useful

Multi-agent pipelines need to decide whether to trust an incoming agent. TWZRD Agent Intel provides an MCP-native way to do this — no API key needed for `score_agent` and `preflight_check`, so the example works out of the box.

## New files

- `ts/examples/agent-trust/src/index.ts` — main example
- `ts/examples/agent-trust/package.json`
- `ts/examples/agent-trust/tsconfig.json`
- `ts/examples/agent-trust/.env.example`
- `ts/examples/agent-trust/README.md`

## Run

```sh
cd ts/examples/agent-trust
pnpm install
COMPOSIO_API_KEY=... OPENAI_API_KEY=... pnpm start
```