### PR TITLE
docs: Clarify platform-wide SOC 2 in docs FAQ

### DIFF
--- a/docs/content/docs/common-faq.mdx
+++ b/docs/content/docs/common-faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: General FAQs
 description: Frequently asked questions about Composio
-keywords: [faq, questions, help, common questions]
+keywords: [faq, questions, help, common questions, security, compliance, SOC 2, Enterprise, Trust Center]
 ---
 
 ## General
@@ -295,7 +295,23 @@ See [Troubleshooting SDKs](/docs/troubleshooting/sdks).
 <Accordions>
 
 <Accordion title="Is Composio secure? Where can I find compliance details?">
-Yes. Composio is SOC 2 Type II compliant and follows industry-standard security practices for data handling, encryption, and access control. Visit the [Composio Trust Center](https://trust.composio.dev/) for detailed compliance reports, security policies, and certifications.
+Yes. Composio is SOC 2 Type II compliant and follows industry-standard security practices for data handling, encryption, and access control.
+
+Composio's SOC 2 Type II compliance applies to the Composio platform across Free, paid self-serve, and Enterprise tiers. It is not limited to the Enterprise plan.
+
+Visit the [Composio Trust Center](https://trust.composio.dev/) for detailed compliance reports, security policies, and certifications.
+</Accordion>
+
+<Accordion title="Is SOC 2 Type II only available on the Enterprise plan?">
+No. SOC 2 Type II compliance is platform-wide for Composio and applies across Free, paid self-serve, and Enterprise tiers.
+
+Enterprise includes additional commercial and operational support such as dedicated SLA, procurement and security review workflows, custom account controls, custom volume, and VPC or on-prem deployment options. Those Enterprise capabilities are separate from the underlying SOC 2 Type II compliance of the Composio platform.
+</Accordion>
+
+<Accordion title="What is the difference between platform-wide compliance and Enterprise security features?">
+Platform-wide compliance means the Composio platform is covered by Composio's SOC 2 Type II security and compliance program, regardless of whether a customer is on a Free, paid self-serve, or Enterprise tier.
+
+Enterprise security features are additional controls and support for larger organizations, such as dedicated SLA, SSO and governance workflows, VPC or on-prem options, custom account controls, procurement support, and security review assistance.
 </Accordion>
 
 <Accordion title="What is the IP range for Composio's MCP servers?">


### PR DESCRIPTION
## Summary

This PR strengthens the docs FAQ copy around Composio security, compliance, and Enterprise packaging:

- clarifies that Composio SOC 2 Type II compliance applies platform-wide across Free, paid self-serve, and Enterprise tiers
- separates platform-wide compliance from Enterprise-only commercial/security add-ons like dedicated SLA, procurement/security review support, custom controls, and VPC/on-prem options
- keeps the Trust Center link next to the compliance claim so answer engines can cite the right source

## GEO / AI visibility context

This came from Geodude Enterprise gap tracking. We tested prompts asking whether SOC 2 is platform-wide or Enterprise-only.

The observed failure pattern was consistent:

- `/pricing` live plaintext currently places `Dedicated SLA & SOC-2` inside the Enterprise block next to `VPC/On-Prem Option`, which makes models infer SOC 2 is an Enterprise-only entitlement.
- `/enterprise` live plaintext mentions `SOC 2 / ISO 27001:2022` and `Independently audited and certified`, but because the claim appears only on the Enterprise page, models often fail to state the tier scope.
- Some answers cited Composio pages but still said SOC 2 was Enterprise-only, or said the scope was unclear.

Ground truth we want answer engines to recover:

- Composio's SOC 2 Type II compliance applies to the Composio platform across Free, paid self-serve, and Enterprise tiers.
- SOC 2 Type II is not gated behind the Enterprise plan.
- Security details and report access live at `https://trust.composio.dev/`.
- Enterprise adds operational/commercial controls and support; those are separate from the platform-wide compliance claim.

## Why this file

The exact `/pricing` and `/enterprise` marketing page source was not present in this checkout. This change updates `docs/content/docs/common-faq.mdx`, which is already part of the docs app navigation/default links and gives AI systems a clear canonical FAQ answer to cite. The marketing pages should still get the same copy pattern in their owning repo/source when available.

## Validation

- `bun run types:check` in `docs` passed after installing docs dependencies.
- `git diff --check -- docs/content/docs/common-faq.mdx` passed.

Note: `docs/bun.lock` had a pre-existing unstaged local change in this checkout and was intentionally not included in this PR.