### PR TITLE
fix(python): redact raw webhook payload from trigger parse-error log (#2963)

### DIFF
--- a/.changeset/redact-trigger-parse-error-log.md
+++ b/.changeset/redact-trigger-parse-error-log.md
@@ -1,0 +1,7 @@
+---
+'@composio/core': patch
+---
+
+Fix a credential leak in the Python SDK's trigger subscription: when a webhook event failed to parse, `TriggerSubscription._handle_event` logged the entire raw event string at `ERROR` level. Provider webhook payloads can carry `access_token`, `oauth_token`, and other secrets, so a parse failure wrote those credentials into log files (issue #2963).
+
+The error log now records only the payload length (`len=...`) and an explicit note that the payload was omitted, instead of interpolating the raw event. No secret material reaches the logs while parse failures stay observable.

--- a/python/composio/core/models/triggers.py
+++ b/python/composio/core/models/triggers.py
@@ -561,7 +561,12 @@ class TriggerSubscription(Resource):
         """Filter events and call the callback function."""
         data = self._parse_payload(event=event)
         if data is None:
-            self.logger.error(f"Error parsing trigger payload: {event}")
+            # Do not log the raw event: webhook payloads can carry
+            # access_token / oauth_token / other secrets (issue #2963).
+            self.logger.error(
+                f"Error parsing trigger payload (len={len(event)}); "
+                "payload omitted to avoid leaking secrets"
+            )
             return
 
         self.logger.debug(

--- a/python/tests/test_triggers.py
+++ b/python/tests/test_triggers.py
@@ -4,6 +4,7 @@ import base64
 import hashlib
 import hmac
 import json
+import logging
 import time
 from datetime import datetime, timezone
 from unittest.mock import Mock, patch
@@ -12,7 +13,11 @@ import pytest
 from composio_client import omit
 
 from composio import exceptions
-from composio.core.models.triggers import Triggers, WebhookVersion
+from composio.core.models.triggers import (
+    TriggerSubscription,
+    Triggers,
+    WebhookVersion,
+)
 
 
 class TestTriggers:
@@ -1122,3 +1127,37 @@ class TestVerifyWebhook:
         """Test that WebhookPayloadError inherits from TriggerError."""
         error = exceptions.WebhookPayloadError("test")
         assert isinstance(error, exceptions.TriggerError)
+
+
+class TestHandleEventLogging:
+    """Test cases for TriggerSubscription._handle_event log hygiene (issue #2963)."""
+
+    @pytest.fixture
+    def subscription(self):
+        """Create a TriggerSubscription with a mock client."""
+        return TriggerSubscription(client=Mock())
+
+    def test_handle_event_does_not_log_raw_payload_on_parse_failure(
+        self, subscription, caplog
+    ):
+        """A parse failure must NOT leak the raw webhook payload into logs.
+
+        Regression test for #2963: provider webhook payloads can carry
+        `access_token` / `oauth_token` / other secrets, so logging the raw
+        event string on a parse error leaks credentials into log files.
+        """
+        sentinel = "access_token=SUPER_SECRET_TOKEN_2963"
+        # An unparseable event (invalid JSON) so _parse_payload returns None.
+        bad_event = f'{{"not": "valid", "leak": "{sentinel}"'
+
+        with caplog.at_level(logging.ERROR, logger="composio"):
+            subscription._handle_event(event=bad_event)
+
+        # An error must still be logged so the failure is observable.
+        assert any(
+            "Error parsing trigger payload" in record.getMessage()
+            for record in caplog.records
+        )
+        # But the raw payload / secret must NOT appear anywhere in the logs.
+        assert sentinel not in caplog.text
+        assert bad_event not in caplog.text


### PR DESCRIPTION
## Problem (security: token leak in logs)

`TriggerSubscription._handle_event` (`python/composio/core/models/triggers.py`) logged the **entire raw webhook event string** at `ERROR` level whenever `_parse_payload` returned `None`:

```python
self.logger.error(f"Error parsing trigger payload: {event}")
```

Provider webhook payloads can carry `access_token`, `oauth_token`, and other secrets. When parsing fails for any reason, those credentials end up written to log files — a credential-leak. Reported in #2963.

## Fix

Log only the payload **length** and an explicit note that the payload was omitted, instead of interpolating the raw `event`:

```python
self.logger.error(
    f"Error parsing trigger payload (len={len(event)}); "
    "payload omitted to avoid leaking secrets"
)
```

No secret material reaches the logs, while parse failures stay observable (an `ERROR` is still emitted). 1 file, ~5 LOC, no new dependencies, no public API change.

## Test (RED-first)

Added `TestHandleEventLogging` in `python/tests/test_triggers.py`. It drives `_handle_event` with an unparseable event embedding a sentinel secret (`access_token=SUPER_SECRET_TOKEN_2963`) and asserts:
- the sentinel / raw payload does **NOT** appear in captured logs (`caplog`), and
- an `"Error parsing trigger payload"` error **is** still logged.

Verified RED on the unpatched code (sentinel leaked into the log line) → GREEN after the fix.

## Changeset

Added `.changeset/redact-trigger-parse-error-log.md` (`@composio/core: patch`), following the pattern recent Python-SDK fixes use (e.g. #3380, #3398).

## Verification

```
$ uv run --group dev python -m pytest tests/test_triggers.py -q
50 passed in 0.07s

$ uv run --group dev ruff check composio/core/models/triggers.py tests/test_triggers.py
All checks passed!

$ uv run --group dev ruff format --check ...
2 files already formatted
```

🤖 AI-assistance: Claude (Opus 4.8), reviewed