### PR TITLE
rename scoped API key reference

### DIFF
--- a/docs/content/docs/projects.mdx
+++ b/docs/content/docs/projects.mdx
@@ -96,7 +96,7 @@ You can also view and update these from **Settings > Project Settings** in the [
 
 <Cards>
   <Card icon={<Key />} title="Authentication" href="/docs/authentication" description="Auth configs are scoped to projects — learn how Composio manages auth" />
-  <Card icon={<Key />} title="Project API key permissions" href="/reference/authentication/project-api-key-permissions" description="Choose scoped access levels for project API keys" />
+  <Card icon={<Key />} title="Scoped project API keys" href="/reference/authentication/project-api-key-permissions" description="Choose scoped access levels for project API keys" />
   <Card icon={<Database />} title="What is a session?" href="/docs/how-composio-works" description="Connected accounts and sessions live within a project" />
   <Card icon={<Zap />} title="Triggers" href="/docs/triggers" description="Webhook configurations are project-scoped" />
 </Cards>

--- a/docs/content/reference/authentication/index.mdx
+++ b/docs/content/reference/authentication/index.mdx
@@ -47,7 +47,7 @@ curl https://backend.composio.dev/api/v3.1/org/projects \
 ```
 
 <Cards>
-  <Card title="Project API key permissions" href="/reference/authentication/project-api-key-permissions">
+  <Card title="Scoped project API keys" href="/reference/authentication/project-api-key-permissions">
     Scoped project API key access levels and covered routes
   </Card>
   <Card title="Errors" href="/reference/errors">

--- a/docs/content/reference/authentication/project-api-key-permissions.mdx
+++ b/docs/content/reference/authentication/project-api-key-permissions.mdx
@@ -1,5 +1,5 @@
 ---
-title: Project API key permissions
+title: Scoped project API keys
 description: Choose which project resources a scoped API key can access.
 keywords: [project api keys, scoped api keys, permissions, access levels]
 ---


### PR DESCRIPTION
## Summary
- Rename the scoped key reference page title to `Scoped project API keys`
- Update the two cards that link to the page so the visible label is consistent

## Validation
- `bun run lint:links`
- `bun run types:check`