### PR TITLE
chore: CLI 0.2.31 patch release

### DIFF
--- a/.changeset/cli-fish-completions-and-permission-expiry.md
+++ b/.changeset/cli-fish-completions-and-permission-expiry.md
@@ -1,0 +1,6 @@
+---
+"@composio/cli": patch
+---
+
+fix: route fish shell completions to `~/.config/fish/completions/composio.fish` (instead of the rc file) and sanitize completion lines that could break parsing.
+fix: permission "allow" decisions now expire after 1 hour — the prompt action is relabeled "Allow for 1 hr" and cached decisions are pruned on expiry.


### PR DESCRIPTION
## Changes since `@composio/cli@0.2.30`

### Features
- **feat(cli): `composio upgrade <version>`** (#3428) — install a specific stable or beta release (`0.13.1`, `0.13.1-beta.42`, or full tag). No-arg behavior unchanged; `--beta` still controls the latest-prerelease case.
- **feat(cli): send `x-cli-session-id` header** (#3430) — attach the per-cwd CLI session id to every client request so tool execution logs can be grouped by CLI session.
- **feat(cli): refresh approval fallback page** (#3431) — browser fallback tool-approval prompt restyled in the CLI landing-page visual language and served directly from the loopback callback server; native macOS sidecar remains preferred.

### Fixes
- **fix(cli): make output more LLM-friendly** (#3450) — route logger output to stderr, gate human-only notices/prompts on interactive TTYs, keep `composio run` helper/subagent logs off stdout.
- **fix(cli): permission allows expire after 1 hour** (#3449) — prompt action relabeled "Allow for 1 hr"; cached allow decisions expire after 1h with stale-entry pruning.
- **fix: fish completion install paths** (#3162) — write completions to `~/.config/fish/completions/composio.fish` and sanitize lines that could break parsing.

## Changeset

A single patch bump (`@composio/cli` → 0.2.31) aggregated from the pending changesets:
- `.changeset/cli-upgrade-version-arg.md`
- `.changeset/cli-session-id-header.md`
- `.changeset/cli-permission-fallback-design.md`
- `.changeset/quiet-llm-friendly-cli.md`
- `.changeset/cli-fish-completions-and-permission-expiry.md` (new — covers #3162 and #3449)

## Testing

### Phase 1: CI Types/Lint
- N/A for this branch — `ts.typecheck` / `ts.test` / `ts.build` are gated on `paths: ts/**`, and this branch only adds a `.changeset/*.md`. Each underlying CLI PR (#3428/#3430/#3431/#3449/#3450/#3162) already passed CI when merged to `next`.

### Phase 2: Local Binary Test ✅
Built from source (`pnpm turbo build` → `build:binary`) and tested:
- `composio version` → `0.2.30` ✅ · `composio whoami` → JSON ✅ · `composio --help` ✅
- `composio run 'console.log(...)'` → clean stdout (LLM-friendly stderr routing confirmed, #3450) ✅
- `composio upgrade` `<version>` arg wired (`normalizeReleaseTag`, #3428) ✅
- `SLACK_SEND_MESSAGE` input validation correctly rejects unknown keys (LLM-friendly errors) ✅
- **Slack integration test** ✅ — `SLACK_FIND_CHANNELS` → `SLACK_SEND_MESSAGE` → `SLACK_FETCH_CONVERSATION_HISTORY` → `experimental_subAgent` (structured output via `z` schema + `result.prompt()`) → summary posted to `#buzz-skill-based-cli-testing`.

### Phase 3: Bundled Binary (CI) ✅ pipeline unblocked
The CI binary pipeline was briefly blocked by a new org policy requiring SHA-pinned actions — **already resolved on `next` by #3531** (`chore(ci): pin GitHub Actions to SHAs`). A validation `build-beta` on an identically-pinned branch confirmed the fix: "Resolve Release Metadata" passes and binaries build/test green across platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)