### PR TITLE
ci: use GitHub App token for the release bot (replaces expired CI_BOT_TOKEN)

### DIFF
--- a/.github/workflows/ts.release.yml
+++ b/.github/workflows/ts.release.yml
@@ -5,18 +5,28 @@ on:
   push:
     branches: [next]
 
-env:
-  GITHUB_ACCESS_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
-
 jobs:
   release:
     name: Release Typescript SDK
     runs-on: ubuntu-latest
     steps:
+      # Mint a short-lived GitHub App installation token instead of a long-lived
+      # PAT. App tokens don't expire out from under us (the old CI_BOT_TOKEN PAT
+      # did), and — unlike the default GITHUB_TOKEN — events they create (the
+      # "Release: update version" PR and its eventual merge) still trigger
+      # downstream workflows like build-cli-binaries.yml, so publishing fires.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
+
       - name: Checkout Code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0 # Required for git show HEAD^ when comparing published package versions
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js, pnpm, Bun
         uses: ./.github/actions/setup-node-pnpm-bun
@@ -37,7 +47,8 @@ jobs:
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         if: github.event_name != 'workflow_dispatch' # only run on master merges
         env:
-          GITHUB_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_ACCESS_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           publish: pnpm changeset:release
           commit: 'Release: update version'


### PR DESCRIPTION
## Problem

The changeset release bot (`ts.release.yml` → `changesets/action`) authenticated with the **`CI_BOT_TOKEN`** personal access token. That PAT expired, so **every "TS SDK Release" run since 2026-06-04 failed** with:

```
HttpError: Bad credentials - https://docs.github.com/rest
```

`changeset version` ran fine, but the GitHub API call to create/update the "Release: update version" PR failed — so no version PR, no publish. (This is why 0.2.31 had to be shipped via a manual version bump in #3538.)

## Fix

Mint a **short-lived GitHub App installation token** with [`actions/create-github-app-token`](https://github.com/actions/create-github-app-token) (pinned to `bcd2ba4` / v3.2.0) and use it for both `checkout` and the `changesets/action` step, instead of the PAT.

Why an App token over a PAT or the default `GITHUB_TOKEN`:
- **No silent expiry** — minted per run; nothing to rotate manually (exactly what just broke).
- **Triggers downstream workflows** — the default `GITHUB_TOKEN` is blocked from triggering other workflows, so the version-PR merge would never kick off `build-cli-binaries.yml` to publish. App-token-created events *do* trigger them (same as a PAT, better hygiene).
- **Not tied to a personal account.**

(OIDC was considered but doesn't apply here — it authenticates to *external* services like cloud/npm trusted-publishing, not GitHub-internal PR/push operations.)

## Required setup before this lands

Create a **GitHub App** (org-owned), installed on this repo, with repository permissions:
- **Contents: Read & write**
- **Pull requests: Read & write**

Then add two repo secrets:
- `RELEASE_BOT_APP_ID` — the App's ID
- `RELEASE_BOT_APP_PRIVATE_KEY` — a generated private key (full PEM)

Once those exist, the next push to `next` with pending changesets will regenerate the "Release: update version" PR correctly. `CI_BOT_TOKEN` can then be deleted.

## Out of scope / follow-up

`docs.sync-connect-clients.yml` also uses `CI_BOT_TOKEN` (as `GH_TOKEN`). It can be migrated to the same App token in a follow-up; left untouched here to keep this focused on the release pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)