### PR TITLE
fix(ts): normalize MCP connected account URLs

### DIFF
--- a/ts/packages/core/src/utils/transformers/mcp.ts
+++ b/ts/packages/core/src/utils/transformers/mcp.ts
@@ -23,6 +23,10 @@ import {
   McpRetrieveResponse as McpRetrieveResponseRaw,
 } from '@composio/client/resources/mcp';
 
+function normalizeConnectedAccountUrl(url: string): string {
+  return url.replace(/([?&])connected_account_ids=/g, '$1connected_account_id=');
+}
+
 /**
  * Transform MCP create response from snake_case to camelCase
  */
@@ -149,7 +153,7 @@ export function transformMcpGenerateUrlResponse(
   response: GenerateURLResponseRaw
 ): GenerateURLResponse {
   const result = GenerateURLResponseSchema.safeParse({
-    connectedAccountUrls: response.connected_account_urls,
+    connectedAccountUrls: response.connected_account_urls?.map(normalizeConnectedAccountUrl),
     userIdsUrl: response.user_ids_url,
     mcpUrl: response.mcp_url,
   });

--- a/ts/packages/core/test/utils/transformers/mcp.test.ts
+++ b/ts/packages/core/test/utils/transformers/mcp.test.ts
@@ -330,6 +330,21 @@ describe('MCP Transformers', () => {
       });
     });
 
+    it('should normalize connected account URL params for MCP transport', () => {
+      const response = {
+        connected_account_urls: [
+          'https://mcp.example.com/server?include_composio_helper_actions=true&connected_account_ids=ca_123&user_id=user_123',
+        ],
+        mcp_url: 'https://mcp.example.com/server',
+      };
+
+      const result = transformMcpGenerateUrlResponse(response);
+
+      expect(result.connectedAccountUrls).toEqual([
+        'https://mcp.example.com/server?include_composio_helper_actions=true&connected_account_id=ca_123&user_id=user_123',
+      ]);
+    });
+
     it('should throw ValidationError for missing required mcp_url', () => {
       const invalidResponse = {
         connected_account_urls: ['https://mcp.example.com/account1'],


### PR DESCRIPTION
## Summary
- normalize generated MCP connected-account URLs from `connected_account_ids` to `connected_account_id`
- keep the rest of the generated URL unchanged
- add a transformer regression test for MCP transport-compatible connected-account URLs

Fixes #3496

## Tests
- `pnpm --dir ts/packages/core test test/utils/transformers/mcp.test.ts`
- `pnpm exec prettier --check ts/packages/core/src/utils/transformers/mcp.ts ts/packages/core/test/utils/transformers/mcp.test.ts`
- `pnpm exec eslint ts/packages/core/src/utils/transformers/mcp.ts ts/packages/core/test/utils/transformers/mcp.test.ts` (passes with the test file ignored by the repo ESLint config)

## Note
- `pnpm --dir ts/packages/core typecheck` is currently blocked in this checkout by workspace package resolution: `src/utils/jsonSchema.ts(3,33): error TS2307: Cannot find module '@composio/json-schema-to-zod' or its corresponding type declarations.`
