### PR TITLE
fix(core): drop manual Content-Length in S3 upload PUT for compat with strict undici dispatcher (refs #3548)

### DIFF
--- a/ts/packages/core/src/utils/fileUtils.node.ts
+++ b/ts/packages/core/src/utils/fileUtils.node.ts
@@ -209,12 +209,16 @@ const uploadFileToS3 = async (
   const uploadBuffer = new Uint8Array(contentBytes.byteLength);
   uploadBuffer.set(contentBytes);
 
+  // Note: do not set `Content-Length` manually. Node.js's built-in fetch (undici)
+  // computes it from `body` and rejects any user-supplied value with
+  // `InvalidArgumentError: invalid content-length header`, which surfaces as
+  // `TypeError: fetch failed` and breaks every `file_uploadable` connector tool
+  // on Node 22+.
   const uploadResponse = await fetch(signedURL, {
     method: 'PUT',
     body: uploadBuffer,
     headers: {
       'Content-Type': mimeType,
-      'Content-Length': contentBytes.length.toString(),
     },
   });
 


### PR DESCRIPTION
## Summary

Remove the manual `Content-Length` header from the presigned-URL PUT in `uploadFileToS3`. Node.js's built-in fetch (undici) computes `Content-Length` from the request body itself and rejects any user-supplied value with `InvalidArgumentError: invalid content-length header` (`UND_ERR_INVALID_ARG`), which surfaces as `TypeError: fetch failed`.

The result is that **`composio.files.upload()` has been broken on Node 22+ since the feature was introduced** (commit 84d4381 / PR #1670, shipped in `0.1.29` on 2025-06-19), which in turn broke every `file_uploadable` connector tool that relies on the BE staging path — Instagram media (`INSTAGRAM_POST_IG_USER_MEDIA` with `image_file`), Drive uploads, Slack file shares, etc.

Fixes #3548.

## What changed

```diff
   const uploadResponse = await fetch(signedURL, {
     method: 'PUT',
     body: uploadBuffer,
     headers: {
       'Content-Type': mimeType,
-      'Content-Length': contentBytes.length.toString(),
     },
   });
```

I left a short comment above the call so this isn't reintroduced by a future "let's set the headers explicitly" cleanup.

## Why this works

Per the WHATWG Fetch spec, `Content-Length` is computed by the implementation from the body. undici enforces this strictly: a user-supplied `Content-Length` is treated as an invalid argument and the request is rejected before any bytes leave the client. Dropping the manual header lets fetch derive the correct value from `uploadBuffer` automatically.

## Verification

End-to-end against `@composio/core@0.10.0` with this change applied to a patched `node_modules`:

- `composio.files.upload({ file, toolSlug: 'INSTAGRAM_UPLOAD_FILE', toolkitSlug: 'INSTAGRAM' })` with a ~760 KB JPEG → R2 PUT succeeds, `s3key` returned.
- Downstream `INSTAGRAM_POST_IG_USER_MEDIA` with `image_file: { name, mimetype, s3key }` posts successfully.
- Reproduces the original failure (`TypeError: fetch failed` / `InvalidArgumentError: invalid content-length header`) on `@composio/core@0.10.0` without this change on Node v24.16.0 and v22.x.

Sequence observed in production logs (matching threads in our DB):

| step | image arg | result |
| --- | --- | --- |
| before fix | `image_file: { maisonai_file: ... }` → staged via `composio.files.upload` | **ERROR** (`invalid content-length header`) |
| after fix | same | **SUCCESS** (R2 PUT → `s3key` → `INSTAGRAM_POST_IG_USER_MEDIA` → publish) |

## Notes

- The bug went unnoticed for ~12 months. From a quick scan of the test suite and issue tracker, the existing file-upload tests use very small payloads where undici sometimes lets a manual `Content-Length` through; anything close to a real-world image consistently fails. Might be worth a regression test with a non-trivial payload, but I left that out of this PR to keep the diff minimal.
- Happy to add a regression test if maintainers prefer.

## References

- Issue: #3548
- Affected file: `ts/packages/core/src/utils/fileUtils.node.ts`
- Introducing commit: 84d4381 (PR #1670)
- WHATWG Fetch — forbidden request headers: https://fetch.spec.whatwg.org/#forbidden-request-header
- undici: https://github.com/nodejs/undici
