### PR TITLE
docs: MCP servers → Sessions migration guide (twoslash-fixed re-add of #3551)

### DIFF
--- a/docs/content/docs/migration-guide/index.mdx
+++ b/docs/content/docs/migration-guide/index.mdx
@@ -12,6 +12,12 @@ description: Guides for migrating to newer versions of Composio
     [View Direct Tools migration guide →](/docs/migration-guide/direct-to-sessions)
   </Accordion>
 
+  <Accordion title="Migrating from MCP servers to Sessions">
+    Move from per-toolkit MCP server configs (`composio.mcp.create` / `composio.mcp.generate`) to sessions. Your tools, auth configs, and connected accounts carry over — no re-auth.
+
+    [View MCP servers migration guide →](/docs/migration-guide/mcp-servers-to-sessions)
+  </Accordion>
+
   <Accordion title="Migrating from Experimental Tool Router">
     Migrate from `composio.experimental.tool_router` to the stable sessions API.
 

--- a/docs/content/docs/migration-guide/mcp-servers-to-sessions.mdx
+++ b/docs/content/docs/migration-guide/mcp-servers-to-sessions.mdx
@@ -16,11 +16,10 @@ Starting fresh? Skip this guide and read [Configuring Sessions](/docs/configurin
 </Callout>
 
 <Callout type="info">
-Just connecting apps to your own AI client (Claude, Cursor, ChatGPT) for personal use — not building
-an app? You don't need the SDK. Use **[Composio For You](https://connect.composio.dev)** to connect
-across 1000+ apps in a few clicks, then point your client at the URL it gives you. Switch to it any
-time from the product switcher in the top-left of the dashboard. Reserve `session.mcp.url` for
-programmatic, in-app use.
+Just connecting apps to your own agent for personal use — not building an app? You don't need the
+SDK. Use **Composio For You** to connect across 1000+ apps in a few clicks — switch to it from the
+product switcher in the top-left of the dashboard. Reserve `session.mcp.url` for programmatic,
+in-app use.
 </Callout>
 
 ## What carries over (you keep all of this)
@@ -28,8 +27,8 @@ programmatic, in-app use.
 - **Your tools** — every tool you exposed on a server is available in a session.
 - **Your auth configs and connected accounts** — pass the same `ac_…` IDs; your users **do not
   re-authenticate**.
-- **The MCP URL pattern** — you still get a URL (`session.mcp.url`) that plugs into Claude Desktop,
-  Cursor, OpenAI Agents, Mastra — the same clients, the same protocol.
+- **The MCP URL pattern** — you still get a URL (`session.mcp.url`) that plugs into your agent — any
+  MCP-compatible client — the same way, the same protocol.
 - **Per-user isolation** — still keyed by `user_id`.
 - **Tool restriction** — you can still pin a session to an exact, fixed tool list (see Step 3).
 
@@ -118,8 +117,8 @@ re-auth.
 <Step>
 <StepTitle>Point your MCP client at the new URL</StepTitle>
 
-Swap the generated server URL for `session.mcp.url` wherever your client connects — Claude Desktop,
-Cursor, OpenAI Agents, Mastra. Nothing else about the client changes.
+Swap the generated server URL for `session.mcp.url` wherever your agent connects. Nothing else about
+the client changes.
 
 ```python
 # Before: https://backend.composio.dev/v3/mcp/<SERVER_ID>?user_id=<USER_ID>
@@ -243,8 +242,7 @@ const result = await session.execute("GITHUB_CREATE_ISSUE", {
 - **Triggers** — unchanged; continue using `composio.triggers.*` and webhooks (triggers aren't part
   of sessions yet).
 - **Dashboard** — sessions are created via the SDK. For no-code, personal app connections, use
-  [Composio For You](https://connect.composio.dev) — reachable from the product switcher in the
-  top-left of the dashboard.
+  **Composio For You** — reachable from the product switcher in the top-left of the dashboard.
 
 ## Get started
 

--- a/docs/content/docs/migration-guide/mcp-servers-to-sessions.mdx
+++ b/docs/content/docs/migration-guide/mcp-servers-to-sessions.mdx
@@ -1,0 +1,254 @@
+---
+title: Migrating from MCP servers to Sessions
+description: Move from per-toolkit MCP server configs to the sessions paradigm
+keywords: [migrate, mcp, mcp server, sessions, upgrade]
+---
+
+This guide is for developers using Composio's **MCP servers** (`composio.mcp.create` /
+`composio.mcp.generate`, the "Single Toolkit MCP" flow) who want to migrate to **sessions**.
+
+Sessions are the next generation of the same idea: you still get an MCP URL that any MCP-compatible
+client connects to — but instead of standing up and managing a separate server config per toolkit,
+you create a session that handles tool discovery, authentication, context, and versioning for you.
+
+<Callout type="info">
+Starting fresh? Skip this guide and read [Configuring Sessions](/docs/configuring-sessions).
+</Callout>
+
+<Callout type="info">
+Just connecting apps to your own AI client (Claude, Cursor, ChatGPT) for personal use — not building
+an app? You don't need the SDK. Use **[Composio For You](https://connect.composio.dev)** to connect
+across 1000+ apps in a few clicks, then point your client at the URL it gives you. Switch to it any
+time from the product switcher in the top-left of the dashboard. Reserve `session.mcp.url` for
+programmatic, in-app use.
+</Callout>
+
+## What carries over (you keep all of this)
+
+- **Your tools** — every tool you exposed on a server is available in a session.
+- **Your auth configs and connected accounts** — pass the same `ac_…` IDs; your users **do not
+  re-authenticate**.
+- **The MCP URL pattern** — you still get a URL (`session.mcp.url`) that plugs into Claude Desktop,
+  Cursor, OpenAI Agents, Mastra — the same clients, the same protocol.
+- **Per-user isolation** — still keyed by `user_id`.
+- **Tool restriction** — you can still pin a session to an exact, fixed tool list (see Step 3).
+
+## What changes
+
+| | MCP servers (today) | Sessions |
+|---|---|---|
+| **Setup** | Create + manage a server config per toolkit (`composio.mcp.create`) | One `composio.create(user_id)` — no server object to manage |
+| **Get a URL** | `composio.mcp.generate(user_id, mcp_config_id)` → `instance.url` | `session.mcp.url` |
+| **Tools** | Fixed `allowed_tools` list, baked into the server | Dynamic discovery by default, **or** a fixed list (direct-tools preset) — your choice |
+| **Multiple toolkits** | One server per toolkit | One session spans many toolkits |
+| **Context** | All allowed tools always loaded | Managed — search/preload keep the agent's context lean |
+| **Versioning** | Manual | Handled automatically |
+| **Auth** | Pre-authenticate, then generate | Carries over; in-chat auth available, or `session.authorize()` |
+
+The *why*: a session is one managed endpoint that replaces N static server configs, gives the agent
+runtime tool discovery, and keeps context small — without losing the fixed-tool-list behavior you
+have today if that's what you want.
+
+## Migrating
+
+<Steps>
+<Step>
+<StepTitle>Replace the server config + generate with a session</StepTitle>
+
+The two-step "create a server, then generate a per-user URL" collapses into a single
+`composio.create(...)`. Pass the **same** toolkit, auth config, and tool list you had on the server.
+
+<Tabs groupId="language" items={['Python', 'TypeScript']} persist>
+<Tab value="Python">
+```python
+from composio import Composio
+
+composio = Composio(api_key="YOUR_API_KEY")
+
+# Before: create a server config, then generate a per-user URL
+# server = composio.mcp.create(
+#     name="my-gmail-server",
+#     toolkits=[{"toolkit": "gmail", "auth_config": "ac_xyz123"}],
+#     allowed_tools=["GMAIL_FETCH_EMAILS", "GMAIL_SEND_EMAIL"],
+# )
+# instance = composio.mcp.generate(user_id="user-123", mcp_config_id=server.id)
+# mcp_url = instance["url"]
+
+# After: one session, same toolkit + auth config + tools
+session = composio.create(
+    user_id="user-123",
+    toolkits=["gmail"],
+    auth_configs={"gmail": "ac_xyz123"},
+    tools={"gmail": {"enable": ["GMAIL_FETCH_EMAILS", "GMAIL_SEND_EMAIL"]}},
+)
+mcp_url = session.mcp.url
+```
+</Tab>
+<Tab value="TypeScript">
+```typescript
+import { Composio } from '@composio/core';
+
+const composio = new Composio({ apiKey: process.env.COMPOSIO_API_KEY });
+
+// Before: create a server config, then generate a per-user URL
+// const server = await composio.mcp.create("my-gmail-server", {
+//   toolkits: [{ toolkit: "gmail", authConfigId: "ac_xyz123" }],
+//   allowedTools: ["GMAIL_FETCH_EMAILS", "GMAIL_SEND_EMAIL"],
+// });
+// const instance = await composio.mcp.generate("user-123", server.id);
+// const mcpUrl = instance.url;
+
+// After: one session, same toolkit + auth config + tools
+const session = await composio.create("user-123", {
+  toolkits: ["gmail"],
+  authConfigs: { gmail: "ac_xyz123" },
+  tools: { gmail: { enable: ["GMAIL_FETCH_EMAILS", "GMAIL_SEND_EMAIL"] } },
+});
+const { mcp } = session;
+const mcpUrl = mcp.url;
+```
+</Tab>
+</Tabs>
+
+Same `user_id` + same auth config → existing connected accounts are picked up automatically. No
+re-auth.
+
+</Step>
+
+<Step>
+<StepTitle>Point your MCP client at the new URL</StepTitle>
+
+Swap the generated server URL for `session.mcp.url` wherever your client connects — Claude Desktop,
+Cursor, OpenAI Agents, Mastra. Nothing else about the client changes.
+
+```python
+# Before: https://backend.composio.dev/v3/mcp/<SERVER_ID>?user_id=<USER_ID>
+# After:  session.mcp.url
+```
+
+</Step>
+
+<Step>
+<StepTitle>Keep an exact, fixed tool list (optional — closest 1:1 with your server)</StepTitle>
+
+By default a session gives the agent **dynamic** tool discovery (meta-tools). If you want the *same
+static behavior* as your old server — a fixed set of tools, no discovery — add the **direct-tools
+preset**. This preloads exactly the tools you enable and turns meta-tools off.
+
+<Tabs groupId="language" items={['Python', 'TypeScript']} persist>
+<Tab value="Python">
+```python
+from composio import Composio, SESSION_PRESET_DIRECT_TOOLS
+
+session = composio.create(
+    user_id="user-123",
+    toolkits=["gmail"],
+    auth_configs={"gmail": "ac_xyz123"},
+    tools={"gmail": {"enable": ["GMAIL_FETCH_EMAILS", "GMAIL_SEND_EMAIL"]}},
+    session_preset=SESSION_PRESET_DIRECT_TOOLS,
+)
+```
+</Tab>
+<Tab value="TypeScript">
+```typescript
+import { Composio, SessionPreset } from '@composio/core';
+
+const composio = new Composio({ apiKey: process.env.COMPOSIO_API_KEY });
+// ---cut---
+const session = await composio.create("user-123", {
+  toolkits: ["gmail"],
+  authConfigs: { gmail: "ac_xyz123" },
+  tools: { gmail: { enable: ["GMAIL_FETCH_EMAILS", "GMAIL_SEND_EMAIL"] } },
+  sessionPreset: SessionPreset.DIRECT_TOOLS,
+});
+```
+</Tab>
+</Tabs>
+
+Leave the preset off to get the upgrade: the agent discovers and loads tools at runtime, so you can
+span many toolkits without bloating context.
+
+</Step>
+</Steps>
+
+## Beyond the MCP URL
+
+A session isn't only an MCP endpoint — it's also a normal SDK object, which is handy for non-agent
+code paths.
+
+### Native tools for your framework
+
+`session.tools()` returns provider-wrapped native tools for OpenAI, Anthropic, LangChain, the Vercel
+AI SDK, and others, so you skip manual schema wiring. With the direct-tools preset it returns your
+exact fixed tool set; by default it returns the meta-tools that drive runtime discovery.
+
+<Tabs groupId="language" items={['Python', 'TypeScript']} persist>
+<Tab value="Python">
+```python
+tools = session.tools()
+```
+</Tab>
+<Tab value="TypeScript">
+```typescript
+import { Composio } from '@composio/core';
+const composio = new Composio({ apiKey: process.env.COMPOSIO_API_KEY });
+const session = await composio.create("user-123");
+// ---cut---
+const tools = await session.tools();
+```
+</Tab>
+</Tabs>
+
+### Execute a tool without an LLM
+
+For a deterministic, non-agent path, call a tool directly on the session.
+
+<Tabs groupId="language" items={['Python', 'TypeScript']} persist>
+<Tab value="Python">
+```python
+result = session.execute(
+    "GITHUB_CREATE_ISSUE",
+    arguments={"owner": "my-org", "repo": "my-repo", "title": "Fix login bug"},
+)
+```
+</Tab>
+<Tab value="TypeScript">
+```typescript
+import { Composio } from '@composio/core';
+const composio = new Composio({ apiKey: process.env.COMPOSIO_API_KEY });
+const session = await composio.create("user-123");
+// ---cut---
+const result = await session.execute("GITHUB_CREATE_ISSUE", {
+  owner: "my-org",
+  repo: "my-repo",
+  title: "Fix login bug",
+});
+```
+</Tab>
+</Tabs>
+
+## Things to know
+
+- **Multiple toolkits on one endpoint** — where you ran several single-toolkit servers, one session
+  spans them all (`toolkits=["gmail", "slack", "github"]`). Fewer moving parts.
+- **Reuse one session — don't create one per request** — sessions persist and are reusable. Create a
+  session once and keep using it across calls; see [Configuring Sessions](/docs/configuring-sessions).
+- **Sharing one account across users** — sessions support **shared connections**
+  (`account_type:"SHARED"` + an allow/deny ACL), pinned per session. See
+  [Shared connections](/docs/authenticating-users/shared-connections).
+- **Tenant-specific params** (SharePoint sub-site, Jira subdomain) — prefill them via shared
+  credentials on the auth config.
+- **White-labeling carries over** — pass the same white-labeled auth config IDs; users keep seeing
+  your branding on consent screens. See [White-labeling authentication](/docs/white-labeling-authentication).
+- **Triggers** — unchanged; continue using `composio.triggers.*` and webhooks (triggers aren't part
+  of sessions yet).
+- **Dashboard** — sessions are created via the SDK. For no-code, personal app connections, use
+  [Composio For You](https://connect.composio.dev) — reachable from the product switcher in the
+  top-left of the dashboard.
+
+## Get started
+
+<Cards>
+  <Card title="Configuring Sessions" href="/docs/configuring-sessions" description="Toolkits, auth configs, account selection, presets, and session methods" />
+  <Card title="What is a session?" href="/docs/how-composio-works" description="How sessions scope tools and connected accounts" />
+</Cards>

--- a/docs/content/docs/migration-guide/meta.json
+++ b/docs/content/docs/migration-guide/meta.json
@@ -2,6 +2,7 @@
   "title": "Migration Guide",
   "pages": [
     "direct-to-sessions",
+    "mcp-servers-to-sessions",
     "tool-router-beta",
     "toolkit-versioning",
     "new-sdk"


### PR DESCRIPTION
Re-adds the MCP servers → Sessions migration guide that landed in #3551 and was reverted in #3552 because the docs build broke.

**Root cause of the original break:** the docs site type-checks every TS code block via twoslash. The standalone snippets (direct-tools preset, `session.tools()`, `session.execute()`) referenced `composio` / `session` without declaring them → `[2552] Cannot find name 'composio'`. Fixed by adding a hidden `import` + `const composio` + `// ---cut---` setup preamble to each block (the same pattern `configuring-sessions.mdx` uses), and lifting the tools/execute examples out of nested list bullets into their own section.

**Verified locally** against latest `next`: `bun run build` → `✓ Compiled successfully` + `✓ Generating static pages (1410/1410)`, exit 0.

Files: new `docs/content/docs/migration-guide/mcp-servers-to-sessions.mdx` + registered in `migration-guide/meta.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)