### PR TITLE
chore(ts/packages/core): add repository, bugs, and homepage metadata to package.json

### DIFF
--- a/ts/packages/core/package.json
+++ b/ts/packages/core/package.json
@@ -140,6 +140,14 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ComposioHQ/composio.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ComposioHQ/composio/issues"
+  },
+  "homepage": "https://github.com/ComposioHQ/composio#readme",
   "packageManager": "pnpm@10.28.0",
   "devDependencies": {
     "@type-challenges/utils": "^0.1.1",
@@ -166,3 +174,4 @@
   },
   "gitHead": "4fae6e54d5c150fba955cc5fa314281da5a1e064"
 }
+


### PR DESCRIPTION
## Summary
Adds missing repository, bugs, and homepage support metadata to `@composio/core` package.json.

## Changes
- Modifies `ts/packages/core/package.json` to include repository, homepage, and bugs fields pointing to the upstream Composio repository.

## Type of change
- [x] Refactor/Chore

## How Has This Been Tested?
Checked with npm metadata validation.
