### PR TITLE
fix(py): bound file transfer requests with timeouts

### DIFF
--- a/.changeset/bound-python-file-transfer-timeouts.md
+++ b/.changeset/bound-python-file-transfer-timeouts.md
@@ -1,0 +1,5 @@
+---
+'@composio/core': patch
+---
+
+Add bounded timeouts to Python SDK file upload and download requests so session files and presigned S3 transfers do not hang indefinitely.

--- a/.changeset/bound-python-file-transfer-timeouts.md
+++ b/.changeset/bound-python-file-transfer-timeouts.md
@@ -1,5 +1,0 @@
----
-'@composio/core': patch
----
-
-Add bounded timeouts to Python SDK file upload and download requests so session files and presigned S3 transfers do not hang indefinitely.

--- a/python/composio/core/models/_files.py
+++ b/python/composio/core/models/_files.py
@@ -145,7 +145,14 @@ def upload(url: str, file: Path) -> bool:
         True if upload succeeded (HTTP 200), False otherwise
     """
     with file.open("rb") as data:
-        response = requests.put(url=url, data=data)
+        try:
+            response = requests.put(
+                url=url,
+                data=data,
+                timeout=(_CONNECT_TIMEOUT, _READ_TIMEOUT),
+            )
+        except requests.exceptions.RequestException:
+            return False
         return response.status_code == 200
 
 
@@ -378,11 +385,18 @@ def _upload_bytes_to_s3(
     )
 
     # Upload the content directly to S3
-    upload_response = requests.put(
-        url=s3meta.new_presigned_url,
-        data=content,
-        headers={"Content-Type": mimetype},
-    )
+    try:
+        upload_response = requests.put(
+            url=s3meta.new_presigned_url,
+            data=content,
+            headers={"Content-Type": mimetype},
+            timeout=(_CONNECT_TIMEOUT, _READ_TIMEOUT),
+        )
+    except requests.exceptions.RequestException as e:
+        raise ErrorUploadingFile(
+            "Failed to upload to S3: "
+            f"{_sanitize_url_for_logging(s3meta.new_presigned_url)}. Error: {e}"
+        ) from e
 
     if upload_response.status_code != 200:
         raise ErrorUploadingFile(
@@ -567,13 +581,31 @@ class FileDownloadable(BaseModel):
                 "outside the intended output directory."
             )
         outdir.mkdir(exist_ok=True, parents=True)
-        response = requests.get(url=self.s3url, stream=True)
+        try:
+            response = requests.get(
+                url=self.s3url,
+                stream=True,
+                timeout=(_CONNECT_TIMEOUT, _READ_TIMEOUT),
+            )
+        except requests.exceptions.RequestException as e:
+            raise ErrorDownloadingFile(
+                "Error downloading file: "
+                f"{_sanitize_url_for_logging(self.s3url)}. Error: {e}"
+            ) from e
         if response.status_code != 200:
             raise ErrorDownloadingFile(f"Error downloading file: {self.s3url}")
 
-        with outfile.open("wb") as fd:
-            for chunk in response.iter_content(chunk_size=chunk_size):
-                fd.write(chunk)
+        try:
+            with outfile.open("wb") as fd:
+                for chunk in response.iter_content(chunk_size=chunk_size):
+                    fd.write(chunk)
+        except requests.exceptions.RequestException as e:
+            raise ErrorDownloadingFile(
+                "Error downloading file: "
+                f"{_sanitize_url_for_logging(self.s3url)}. Error: {e}"
+            ) from e
+        finally:
+            response.close()
         return outfile
 
 

--- a/python/composio/core/models/_files.py
+++ b/python/composio/core/models/_files.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 import os
 import typing as t
 from pathlib import Path
@@ -49,6 +50,8 @@ _MAX_RESPONSE_SIZE = 100 * 1024 * 1024  # 100 MB default limit
 Maximum response size in bytes when fetching files from URLs.
 Prevents memory exhaustion attacks from malicious URLs pointing to large files.
 """
+
+_logger = logging.getLogger(__name__)
 
 _CONNECT_TIMEOUT = 5  # seconds
 _READ_TIMEOUT = 60  # seconds
@@ -151,7 +154,12 @@ def upload(url: str, file: Path) -> bool:
                 data=data,
                 timeout=(_CONNECT_TIMEOUT, _READ_TIMEOUT),
             )
-        except requests.exceptions.RequestException:
+        except requests.exceptions.RequestException as e:
+            _logger.debug(
+                "Upload to %s failed: %s",
+                _sanitize_url_for_logging(url),
+                type(e).__name__,
+            )
             return False
         return response.status_code == 200
 
@@ -395,7 +403,8 @@ def _upload_bytes_to_s3(
     except requests.exceptions.RequestException as e:
         raise ErrorUploadingFile(
             "Failed to upload to S3: "
-            f"{_sanitize_url_for_logging(s3meta.new_presigned_url)}. Error: {e}"
+            f"{_sanitize_url_for_logging(s3meta.new_presigned_url)}. "
+            f"Error: {type(e).__name__}"
         ) from e
 
     if upload_response.status_code != 200:
@@ -590,10 +599,13 @@ class FileDownloadable(BaseModel):
         except requests.exceptions.RequestException as e:
             raise ErrorDownloadingFile(
                 "Error downloading file: "
-                f"{_sanitize_url_for_logging(self.s3url)}. Error: {e}"
+                f"{_sanitize_url_for_logging(self.s3url)}. Error: {type(e).__name__}"
             ) from e
         if response.status_code != 200:
-            raise ErrorDownloadingFile(f"Error downloading file: {self.s3url}")
+            response.close()
+            raise ErrorDownloadingFile(
+                f"Error downloading file: {_sanitize_url_for_logging(self.s3url)}"
+            )
 
         try:
             with outfile.open("wb") as fd:
@@ -602,7 +614,7 @@ class FileDownloadable(BaseModel):
         except requests.exceptions.RequestException as e:
             raise ErrorDownloadingFile(
                 "Error downloading file: "
-                f"{_sanitize_url_for_logging(self.s3url)}. Error: {e}"
+                f"{_sanitize_url_for_logging(self.s3url)}. Error: {type(e).__name__}"
             ) from e
         finally:
             response.close()

--- a/python/composio/core/models/tool_router_session_files.py
+++ b/python/composio/core/models/tool_router_session_files.py
@@ -118,7 +118,18 @@ class RemoteFile:
 
     def buffer(self) -> bytes:
         """Fetch the file content as bytes."""
-        response = requests.get(self.download_url)
+        try:
+            response = requests.get(
+                self.download_url,
+                timeout=(_CONNECT_TIMEOUT, _READ_TIMEOUT),
+            )
+        except requests.exceptions.RequestException as e:
+            raise RemoteFileDownloadError(
+                f"Failed to download file: {e}",
+                download_url=self.download_url,
+                mount_relative_path=self.mount_relative_path,
+                filename=self.filename,
+            ) from e
 
         if not response.ok:
             raise RemoteFileDownloadError(
@@ -287,11 +298,15 @@ class ToolRouterSessionFilesMount:
             mimetype=mime,
         )
 
-        upload_resp = requests.put(
-            create_resp.upload_url,
-            data=content,
-            headers={"Content-Type": mime},
-        )
+        try:
+            upload_resp = requests.put(
+                create_resp.upload_url,
+                data=content,
+                headers={"Content-Type": mime},
+                timeout=(_CONNECT_TIMEOUT, _READ_TIMEOUT),
+            )
+        except requests.exceptions.RequestException as e:
+            raise ValidationError(f"Failed to upload file: {e}") from e
 
         if not upload_resp.ok:
             raise ValidationError(

--- a/python/composio/core/models/tool_router_session_files.py
+++ b/python/composio/core/models/tool_router_session_files.py
@@ -125,7 +125,7 @@ class RemoteFile:
             )
         except requests.exceptions.RequestException as e:
             raise RemoteFileDownloadError(
-                f"Failed to download file: {e}",
+                f"Failed to download file: {type(e).__name__}",
                 download_url=self.download_url,
                 mount_relative_path=self.mount_relative_path,
                 filename=self.filename,
@@ -306,7 +306,7 @@ class ToolRouterSessionFilesMount:
                 timeout=(_CONNECT_TIMEOUT, _READ_TIMEOUT),
             )
         except requests.exceptions.RequestException as e:
-            raise ValidationError(f"Failed to upload file: {e}") from e
+            raise ValidationError(f"Failed to upload file: {type(e).__name__}") from e
 
         if not upload_resp.ok:
             raise ValidationError(

--- a/python/tests/test_files.py
+++ b/python/tests/test_files.py
@@ -7,6 +7,7 @@ that use anyOf, oneOf, allOf, or $ref instead of direct 'type' properties.
 from unittest.mock import Mock, patch, MagicMock
 
 import pytest
+import requests
 
 from composio.client.types import Tool, tool_list_response
 from composio.core.models._files import (
@@ -23,7 +24,11 @@ from composio.core.models._files import (
     _MAX_FILENAME_LENGTH,
 )
 from composio.core.models.base import allow_tracking
-from composio.exceptions import ErrorUploadingFile, ResponseTooLargeError
+from composio.exceptions import (
+    ErrorDownloadingFile,
+    ErrorUploadingFile,
+    ResponseTooLargeError,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -1518,7 +1523,12 @@ class TestUploadBytesToS3:
 
         assert result == "s3-key-123"
         mock_client.post.assert_called_once()
-        mock_put.assert_called_once()
+        mock_put.assert_called_once_with(
+            url="https://s3.example.com/upload",
+            data=b"file content",
+            headers={"Content-Type": "image/jpeg"},
+            timeout=(5, 60),
+        )
 
     @patch("composio.core.models._files.requests.put")
     def test_upload_bytes_to_s3_failure(self, mock_put):
@@ -1544,6 +1554,29 @@ class TestUploadBytesToS3:
             )
 
         assert "Failed to upload to S3" in str(exc_info.value)
+
+    @patch("composio.core.models._files.requests.put")
+    def test_upload_bytes_to_s3_timeout(self, mock_put):
+        """Test request timeouts are reported as upload errors."""
+        mock_client = MagicMock()
+        mock_s3_response = MagicMock()
+        mock_s3_response.key = "s3-key-123"
+        mock_s3_response.new_presigned_url = "https://s3.example.com/upload?token=abc"
+        mock_client.post.return_value = mock_s3_response
+        mock_put.side_effect = requests.exceptions.Timeout("timeout")
+
+        with pytest.raises(ErrorUploadingFile) as exc_info:
+            _upload_bytes_to_s3(
+                client=mock_client,
+                filename="test.jpg",
+                content=b"file content",
+                mimetype="image/jpeg",
+                tool="TEST_TOOL",
+                toolkit="test_toolkit",
+            )
+
+        assert "Failed to upload to S3" in str(exc_info.value)
+        assert "token=abc" not in str(exc_info.value)
 
 
 class TestFileUploadableFromUrl:
@@ -2285,6 +2318,7 @@ class TestFileDownloadablePathTraversal:
         response = MagicMock()
         response.status_code = 200
         response.iter_content = lambda chunk_size: [content]
+        response.close = MagicMock()
         return response
 
     def test_relative_traversal_is_neutralized(self, tmp_path):
@@ -2359,6 +2393,64 @@ class TestFileDownloadablePathTraversal:
 
         assert written == outdir / "report.pdf"
         assert written.read_bytes() == b"%PDF-1.4"
+
+    def test_download_uses_timeout(self, tmp_path):
+        outdir = tmp_path / "safe"
+        f = FileDownloadable(
+            name="report.pdf",
+            mimetype="application/pdf",
+            s3url="https://example.com/file",
+        )
+        with patch(
+            "composio.core.models._files.requests.get",
+            return_value=self._mock_response(b"%PDF-1.4"),
+        ) as mock_get:
+            f.download(outdir)
+
+        mock_get.assert_called_once_with(
+            url="https://example.com/file",
+            stream=True,
+            timeout=(5, 60),
+        )
+
+    def test_download_timeout_raises_error(self, tmp_path):
+        outdir = tmp_path / "safe"
+        f = FileDownloadable(
+            name="report.pdf",
+            mimetype="application/pdf",
+            s3url="https://example.com/file?token=abc",
+        )
+        with patch(
+            "composio.core.models._files.requests.get",
+            side_effect=requests.exceptions.Timeout("timeout"),
+        ):
+            with pytest.raises(ErrorDownloadingFile) as exc_info:
+                f.download(outdir)
+
+        assert "Error downloading file" in str(exc_info.value)
+        assert "token=abc" not in str(exc_info.value)
+
+    def test_download_stream_timeout_raises_error(self, tmp_path):
+        outdir = tmp_path / "safe"
+        response = self._mock_response()
+        response.iter_content = MagicMock(
+            side_effect=requests.exceptions.ReadTimeout("timeout")
+        )
+        f = FileDownloadable(
+            name="report.pdf",
+            mimetype="application/pdf",
+            s3url="https://example.com/file?token=abc",
+        )
+        with patch(
+            "composio.core.models._files.requests.get",
+            return_value=response,
+        ):
+            with pytest.raises(ErrorDownloadingFile) as exc_info:
+                f.download(outdir)
+
+        assert "Error downloading file" in str(exc_info.value)
+        assert "token=abc" not in str(exc_info.value)
+        response.close.assert_called_once()
 
     def test_basename_collapse_through_subdir_is_rejected(self, tmp_path):
         """`Path('foo/..').name == '..'` — the basename strip of a name that

--- a/python/tests/test_files.py
+++ b/python/tests/test_files.py
@@ -1563,7 +1563,12 @@ class TestUploadBytesToS3:
         mock_s3_response.key = "s3-key-123"
         mock_s3_response.new_presigned_url = "https://s3.example.com/upload?token=abc"
         mock_client.post.return_value = mock_s3_response
-        mock_put.side_effect = requests.exceptions.Timeout("timeout")
+        # The exception text itself carries the presigned URL (incl. token), as
+        # real urllib3 errors do — the SDK must not surface it in the message.
+        mock_put.side_effect = requests.exceptions.Timeout(
+            "HTTPSConnectionPool(host='s3.example.com', port=443): "
+            "Max retries exceeded with url: /upload?token=abc"
+        )
 
         with pytest.raises(ErrorUploadingFile) as exc_info:
             _upload_bytes_to_s3(
@@ -2422,7 +2427,9 @@ class TestFileDownloadablePathTraversal:
         )
         with patch(
             "composio.core.models._files.requests.get",
-            side_effect=requests.exceptions.Timeout("timeout"),
+            side_effect=requests.exceptions.Timeout(
+                "Max retries exceeded with url: /file?token=abc"
+            ),
         ):
             with pytest.raises(ErrorDownloadingFile) as exc_info:
                 f.download(outdir)
@@ -2434,7 +2441,9 @@ class TestFileDownloadablePathTraversal:
         outdir = tmp_path / "safe"
         response = self._mock_response()
         response.iter_content = MagicMock(
-            side_effect=requests.exceptions.ReadTimeout("timeout")
+            side_effect=requests.exceptions.ReadTimeout(
+                "Max retries exceeded with url: /file?token=abc"
+            )
         )
         f = FileDownloadable(
             name="report.pdf",
@@ -2449,6 +2458,25 @@ class TestFileDownloadablePathTraversal:
                 f.download(outdir)
 
         assert "Error downloading file" in str(exc_info.value)
+        assert "token=abc" not in str(exc_info.value)
+        response.close.assert_called_once()
+
+    def test_download_non_200_redacts_url_and_closes(self, tmp_path):
+        outdir = tmp_path / "safe"
+        response = self._mock_response()
+        response.status_code = 403
+        f = FileDownloadable(
+            name="report.pdf",
+            mimetype="application/pdf",
+            s3url="https://example.com/file?token=abc",
+        )
+        with patch(
+            "composio.core.models._files.requests.get",
+            return_value=response,
+        ):
+            with pytest.raises(ErrorDownloadingFile) as exc_info:
+                f.download(outdir)
+
         assert "token=abc" not in str(exc_info.value)
         response.close.assert_called_once()
 

--- a/python/tests/test_tool_router_session_files.py
+++ b/python/tests/test_tool_router_session_files.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 
 from composio.core.models.tool_router_session_files import (
     RemoteFile,
@@ -101,8 +102,24 @@ class TestToolRouterSessionFilesMount:
 
             assert isinstance(result, RemoteFile)
             assert result.mount_relative_path == "output/test.txt"
+            mock_put.assert_called_once_with(
+                "https://s3.example.com/upload",
+                data=b"hello world",
+                headers={"Content-Type": "text/plain"},
+                timeout=(5, 60),
+            )
             mock_client.tool_router.session.files.create_upload_url.assert_called_once()
             mock_client.tool_router.session.files.create_download_url.assert_called_once()
+
+    def test_upload_raises_validation_error_on_timeout(self, files_mount):
+        """Test upload converts request timeouts to ValidationError."""
+        with patch("requests.put", side_effect=requests.exceptions.Timeout("timeout")):
+            with pytest.raises(ValidationError, match="Failed to upload file"):
+                files_mount.upload(
+                    b"hello world",
+                    remote_path="data.txt",
+                    mimetype="text/plain",
+                )
 
     def test_upload_from_local_file(self, files_mount, mock_client, tmp_path):
         """Test upload from local file path."""
@@ -174,6 +191,10 @@ class TestRemoteFile:
 
             result = rf.buffer()
             assert result == b"file content"
+            mock_get.assert_called_once_with(
+                "https://example.com/file",
+                timeout=(5, 60),
+            )
 
     def test_buffer_failure_raises_remote_file_download_error(self):
         """Test buffer() raises RemoteFileDownloadError on HTTP error."""
@@ -193,6 +214,21 @@ class TestRemoteFile:
 
             assert exc_info.value.status_code == 404
             assert exc_info.value.filename == "test.txt"
+
+    def test_buffer_timeout_raises_remote_file_download_error(self):
+        """Test buffer() converts request timeouts to RemoteFileDownloadError."""
+        rf = RemoteFile(
+            expires_at="2026-01-01",
+            mount_relative_path="test.txt",
+            sandbox_mount_prefix="/mnt/files",
+            download_url="https://example.com/file",
+        )
+        with patch("requests.get", side_effect=requests.exceptions.Timeout("timeout")):
+            with pytest.raises(RemoteFileDownloadError) as exc_info:
+                rf.buffer()
+
+            assert exc_info.value.filename == "test.txt"
+            assert exc_info.value.download_url == "https://example.com/file"
 
     def test_text(self):
         """Test text() decodes UTF-8."""


### PR DESCRIPTION
## Summary
- add bounded `(connect, read)` timeouts to Python SDK session file downloads and uploads
- add the same timeout coverage to presigned S3 upload/download paths used by file helpers
- convert timeout/request failures into the SDK's existing file errors and cover them with tests

Fixes #3560
Fixes #3561
Fixes #3562

## Changes
- `RemoteFile.buffer()` now uses the existing file transfer timeout constants and preserves file context on request failures
- `ToolRouterSessionFilesMount.upload()` and S3 upload helpers now bound presigned `PUT` requests
- `FileDownloadable.download()` now bounds streaming `GET` requests, wraps streaming read failures, and closes the response
- added regression tests for request timeouts and timeout arguments
- added a changeset for the published SDK change

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [ ] Documentation
- [ ] Breaking change

## How Has This Been Tested?
- [x] `D:\anaconda3\envs\yolov12\python.exe -m ruff check python\composio\core\models\tool_router_session_files.py python\composio\core\models\_files.py python\tests\test_tool_router_session_files.py python\tests\test_files.py`
- [x] `D:\anaconda3\envs\yolov12\python.exe -m ruff format --check python\composio\core\models\tool_router_session_files.py python\composio\core\models\_files.py python\tests\test_tool_router_session_files.py python\tests\test_files.py`
- [x] `COMPOSIO_CACHE_DIR=<repo>\.tmp-composio-cache D:\anaconda3\envs\yolov12\python.exe -m pytest python\tests\test_tool_router_session_files.py python\tests\test_files.py::TestUploadBytesToS3 python\tests\test_files.py::TestFileDownloadablePathTraversal::test_safe_filename_passes_through python\tests\test_files.py::TestFileDownloadablePathTraversal::test_download_uses_timeout python\tests\test_files.py::TestFileDownloadablePathTraversal::test_download_timeout_raises_error python\tests\test_files.py::TestFileDownloadablePathTraversal::test_download_stream_timeout_raises_error`

Note: I also ran the full `python\tests\test_tool_router_session_files.py python\tests\test_files.py` pair locally. The new and related tests passed, but the full run has one pre-existing Windows-specific failure in `TestFileDownloadablePathTraversal::test_empty_name_safe_fails_at_write_time`: opening a directory for writing raises `PermissionError` on Windows instead of the test's expected `IsADirectoryError`.

## Screenshots (if applicable)
N/A

## Checklist
- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed
- [ ] I updated documentation as needed
- [x] I added tests or explain why not applicable
- [x] I added a changeset if this change affects published packages

## Additional context
This keeps the existing `(5s connect, 60s read)` timeout convention already used by the Python SDK's URL fetch helpers.
