### PR TITLE
fix(core): resolve $ref/$defs so file flags behind a reference aren't dropped

### DIFF
--- a/.changeset/file-modifier-dereference-ref.md
+++ b/.changeset/file-modifier-dereference-ref.md
@@ -2,9 +2,4 @@
 '@composio/core': patch
 ---
 
-Resolve `$ref`/`$defs` indirection for tool file handling so `file_uploadable` / `file_downloadable` flags hidden behind a reference are no longer silently ignored.
-
-Two coupled causes were defeating reference resolution for tools whose parameter schemas use `$ref`/`$defs` (e.g. `GMAIL_GET_ATTACHMENT`, whose `output_parameters` express the downloadable field as `data` → `$ref` → `#/$defs/GetAttachmentResponse` → `file` → `$ref` → `#/$defs/FileDownloadable`):
-
-- `ParametersSchema` is a strict `z.object` and omitted `$defs`/`definitions`, so `ToolSchema.parse` dropped the root definition block on every tool — leaving each nested `$ref` dangling and unresolvable for all downstream consumers (providers that pass `inputParameters` straight to the model, the file modifier, etc.). `JSONSchemaPropertySchema` already accepted both keywords; the parameters root now does too.
-- The file tool modifier's schema walkers (`transformProperties`, `schemaHasFileProperty`, and the upload/download hydration) recurse `properties`/`anyOf`/`oneOf`/`allOf`/`items` but never dereferenced `$ref`. A `file_uploadable` field reachable only through a `$ref` was therefore invisible, so the local path was forwarded as-is and the backend rejected the call. The modifier now dereferences `inputParameters`/`outputParameters` (via `dereferenceJsonSchema` in `'sentinel'` mode) before walking, so refs are inlined while tools that ship a `$ref` without a matching `$defs` target keep working instead of throwing.
+Preserve root `$defs` / `definitions` blocks on tool parameter schemas and dereference them in the Node file modifier, so auto file upload/download detection works when `file_uploadable` or `file_downloadable` is hidden behind an internal `$ref`.

--- a/.changeset/file-modifier-dereference-ref.md
+++ b/.changeset/file-modifier-dereference-ref.md
@@ -1,0 +1,10 @@
+---
+'@composio/core': patch
+---
+
+Resolve `$ref`/`$defs` indirection for tool file handling so `file_uploadable` / `file_downloadable` flags hidden behind a reference are no longer silently ignored.
+
+Two coupled causes were defeating reference resolution for tools whose parameter schemas use `$ref`/`$defs` (e.g. `GMAIL_GET_ATTACHMENT`, whose `output_parameters` express the downloadable field as `data` → `$ref` → `#/$defs/GetAttachmentResponse` → `file` → `$ref` → `#/$defs/FileDownloadable`):
+
+- `ParametersSchema` is a strict `z.object` and omitted `$defs`/`definitions`, so `ToolSchema.parse` dropped the root definition block on every tool — leaving each nested `$ref` dangling and unresolvable for all downstream consumers (providers that pass `inputParameters` straight to the model, the file modifier, etc.). `JSONSchemaPropertySchema` already accepted both keywords; the parameters root now does too.
+- The file tool modifier's schema walkers (`transformProperties`, `schemaHasFileProperty`, and the upload/download hydration) recurse `properties`/`anyOf`/`oneOf`/`allOf`/`items` but never dereferenced `$ref`. A `file_uploadable` field reachable only through a `$ref` was therefore invisible, so the local path was forwarded as-is and the backend rejected the call. The modifier now dereferences `inputParameters`/`outputParameters` (via `dereferenceJsonSchema` in `'sentinel'` mode) before walking, so refs are inlined while tools that ship a `$ref` without a matching `$defs` target keep working instead of throwing.

--- a/ts/packages/core/src/types/tool.types.ts
+++ b/ts/packages/core/src/types/tool.types.ts
@@ -99,6 +99,24 @@ const ParametersSchema = z.object({
   nullable: z.boolean().optional(),
   description: z.string().optional(),
   additionalProperties: z.boolean().default(false).optional(),
+  // Definition blocks targeted by `$ref` pointers. The Composio API ships
+  // these at the parameters root (e.g. `data` → `$ref` → `#/$defs/...`), but
+  // because `z.object` strips unknown keys they were being dropped on parse —
+  // leaving every nested `$ref` dangling and unresolvable downstream
+  // (providers, file modifiers). `JSONSchemaPropertySchema` already accepts
+  // both keywords; the parameters root must too.
+  $defs: z
+    .record(
+      z.string(),
+      z.lazy(() => JSONSchemaPropertySchema)
+    )
+    .optional(),
+  definitions: z
+    .record(
+      z.string(),
+      z.lazy(() => JSONSchemaPropertySchema)
+    )
+    .optional(),
 });
 
 /**

--- a/ts/packages/core/src/utils/modifiers/FileToolModifier.node.ts
+++ b/ts/packages/core/src/utils/modifiers/FileToolModifier.node.ts
@@ -24,6 +24,22 @@ import {
   transformProperties,
   schemaHasFileProperty,
 } from './FileToolModifier.utils.neutral';
+import { dereferenceJsonSchema } from '../jsonSchema';
+
+/**
+ * Inlines internal `$ref` pointers so the file walkers below can see the
+ * `file_uploadable` / `file_downloadable` flags that live behind a
+ * `$ref`/`$defs` indirection (e.g. `GMAIL_GET_ATTACHMENT`). The walkers only
+ * recurse `properties`/`anyOf`/`oneOf`/`allOf`/`items` and never dereference,
+ * so without this a flagged field reachable only through a `$ref` is silently
+ * missed — the file is never staged/downloaded. `'sentinel'` mode keeps tools
+ * whose schema omits the `$defs` target working (see
+ * https://github.com/ComposioHQ/composio/issues/3307) instead of throwing.
+ */
+const resolveFileSchema = (
+  schema: JSONSchemaProperty | undefined
+): JSONSchemaProperty | undefined =>
+  schema ? dereferenceJsonSchema(schema, { onUnresolved: 'sentinel' }) : schema;
 
 const getSchemaVariants = (schema: JSONSchemaProperty | undefined): JSONSchemaProperty[] => [
   ...(schema?.anyOf ?? []),
@@ -370,12 +386,14 @@ export class FileToolModifier {
       return schema;
     }
 
-    const properties = transformProperties(schema.inputParameters.properties);
+    const inputParameters = resolveFileSchema(schema.inputParameters)!;
+    const properties = transformProperties(inputParameters.properties!);
 
     return {
       ...schema,
       inputParameters: {
-        ...schema.inputParameters,
+        ...inputParameters,
+        type: 'object',
         properties,
       },
     };
@@ -396,7 +414,7 @@ export class FileToolModifier {
 
     // Recursively transform the arguments tree without mutating the caller’s copy
     try {
-      const newArgs = await hydrateFiles(args, tool.inputParameters, {
+      const newArgs = await hydrateFiles(args, resolveFileSchema(tool.inputParameters), {
         toolSlug,
         toolkitSlug,
         client: this.client,
@@ -429,10 +447,14 @@ export class FileToolModifier {
     const { result, toolSlug } = options;
 
     // Walk result.data without mutating the original, using output schema for guidance
-    const dataWithDownloads = await hydrateDownloads(result.data, tool.outputParameters, {
-      toolSlug,
-      fileDownloadDir: this.fileUploadPathOptions.fileDownloadDir,
-    });
+    const dataWithDownloads = await hydrateDownloads(
+      result.data,
+      resolveFileSchema(tool.outputParameters),
+      {
+        toolSlug,
+        fileDownloadDir: this.fileUploadPathOptions.fileDownloadDir,
+      }
+    );
 
     return { ...result, data: dataWithDownloads as typeof result.data };
   }

--- a/ts/packages/core/test/tools/fileModifiers.test.ts
+++ b/ts/packages/core/test/tools/fileModifiers.test.ts
@@ -1732,6 +1732,7 @@ describe('FileToolModifier', () => {
           type: 'object',
           properties: {
             attachment: { $ref: '#/$defs/Attachment' },
+            legacyAttachment: { $ref: '#/definitions/LegacyAttachment' },
             text: { type: 'string' },
           },
           $defs: {
@@ -1741,6 +1742,13 @@ describe('FileToolModifier', () => {
               description: 'Local path to attach',
             },
           },
+          definitions: {
+            LegacyAttachment: {
+              type: 'string',
+              file_uploadable: true,
+              description: 'Legacy local path to attach',
+            },
+          },
         },
       };
 
@@ -1748,6 +1756,11 @@ describe('FileToolModifier', () => {
 
       expect(result.inputParameters?.properties?.attachment).toHaveProperty('format', 'path');
       expect(result.inputParameters?.properties?.attachment).toHaveProperty(
+        'file_uploadable',
+        true
+      );
+      expect(result.inputParameters?.properties?.legacyAttachment).toHaveProperty('format', 'path');
+      expect(result.inputParameters?.properties?.legacyAttachment).toHaveProperty(
         'file_uploadable',
         true
       );

--- a/ts/packages/core/test/tools/fileModifiers.test.ts
+++ b/ts/packages/core/test/tools/fileModifiers.test.ts
@@ -1713,6 +1713,113 @@ describe('FileToolModifier', () => {
       expect(modifiedResult.data.fileOutput).toBeNull();
     });
   });
+
+  // The schema walkers recurse properties/anyOf/oneOf/allOf/items but never
+  // dereference `$ref`. Composio toolkits express file flags through a
+  // `$ref`/`$defs` indirection (e.g. GMAIL_GET_ATTACHMENT), so without
+  // dereferencing the flag is invisible and the file is silently skipped.
+  // See https://github.com/ComposioHQ/composio/issues/3506.
+  describe('$ref / $defs indirection', () => {
+    it('marks a file_uploadable behind a $ref/$defs as format: "path" in modifyToolSchema', async () => {
+      const schema: Tool = {
+        slug: 'test-tool',
+        name: 'Test Tool',
+        description: 'A test tool',
+        tags: ['test'],
+        version: '20251201_01',
+        availableVersions: ['20251201_01'],
+        inputParameters: {
+          type: 'object',
+          properties: {
+            attachment: { $ref: '#/$defs/Attachment' },
+            text: { type: 'string' },
+          },
+          $defs: {
+            Attachment: {
+              type: 'string',
+              file_uploadable: true,
+              description: 'Local path to attach',
+            },
+          },
+        },
+      };
+
+      const result = await fileToolModifier.modifyToolSchema(schema);
+
+      expect(result.inputParameters?.properties?.attachment).toHaveProperty('format', 'path');
+      expect(result.inputParameters?.properties?.attachment).toHaveProperty(
+        'file_uploadable',
+        true
+      );
+      expect(result.inputParameters?.properties?.text).not.toHaveProperty('format');
+    });
+
+    it('uploads a file whose file_uploadable flag is reachable only via $ref/$defs', async () => {
+      const mockFileData = {
+        name: 'doc.pdf',
+        mimetype: 'application/pdf',
+        s3key: 'uploads/doc.pdf',
+      };
+      vi.mocked(fileUtils.getFileDataAfterUploadingToS3).mockResolvedValue(mockFileData);
+
+      const toolWithRef: Tool = {
+        slug: 'test-tool',
+        name: 'Test Tool',
+        description: 'A test tool',
+        tags: ['test'],
+        version: '20251201_01',
+        availableVersions: ['20251201_01'],
+        inputParameters: {
+          type: 'object',
+          properties: {
+            attachment: { $ref: '#/$defs/Attachment' },
+          },
+          $defs: {
+            Attachment: { type: 'string', file_uploadable: true },
+          },
+        },
+      };
+
+      const result = await fileToolModifier.fileUploadModifier(toolWithRef, {
+        toolSlug: 'test-tool',
+        toolkitSlug: 'test-toolkit',
+        params: {
+          arguments: { attachment: '/path/to/doc.pdf' },
+          userId: 'test-user',
+        },
+      });
+
+      expect(fileUtils.getFileDataAfterUploadingToS3).toHaveBeenCalledWith('/path/to/doc.pdf', {
+        toolSlug: 'test-tool',
+        toolkitSlug: 'test-toolkit',
+        client: mockClient,
+      });
+      expect(result.arguments?.attachment).toEqual(mockFileData);
+    });
+
+    it('degrades gracefully when a $ref has no matching $defs target', async () => {
+      // Some toolkits ship a `$ref` without ever declaring `$defs`
+      // (https://github.com/ComposioHQ/composio/issues/3307). The modifier
+      // must not throw; the unresolved branch simply carries no file flag.
+      const schema: Tool = {
+        slug: 'test-tool',
+        name: 'Test Tool',
+        description: 'A test tool',
+        tags: ['test'],
+        version: '20251201_01',
+        availableVersions: ['20251201_01'],
+        inputParameters: {
+          type: 'object',
+          properties: {
+            attachment: { $ref: '#/$defs/Missing' },
+          },
+        },
+      };
+
+      const result = await fileToolModifier.modifyToolSchema(schema);
+      expect(result.inputParameters?.properties?.attachment).not.toHaveProperty('format');
+    });
+  });
 });
 
 describe('Tools with dangerouslyAllowAutoUploadDownloadFiles', () => {

--- a/ts/packages/core/test/tools/tools.test.ts
+++ b/ts/packages/core/test/tools/tools.test.ts
@@ -593,6 +593,7 @@ describe('Tools', () => {
         type: 'object',
         properties: {
           data: { $ref: '#/$defs/GetAttachmentResponse' },
+          legacy_data: { $ref: '#/definitions/LegacyAttachmentResponse' },
         },
         $defs: {
           GetAttachmentResponse: {
@@ -600,6 +601,17 @@ describe('Tools', () => {
             properties: { file: { $ref: '#/$defs/FileDownloadable' } },
           },
           FileDownloadable: {
+            type: 'object',
+            file_downloadable: true,
+            properties: { s3url: { type: 'string' } },
+          },
+        },
+        definitions: {
+          LegacyAttachmentResponse: {
+            type: 'object',
+            properties: { file: { $ref: '#/definitions/LegacyFileDownloadable' } },
+          },
+          LegacyFileDownloadable: {
             type: 'object',
             file_downloadable: true,
             properties: { s3url: { type: 'string' } },
@@ -619,8 +631,14 @@ describe('Tools', () => {
       expect(tool.outputParameters?.$defs?.FileDownloadable).toMatchObject({
         file_downloadable: true,
       });
+      expect(tool.outputParameters?.definitions?.LegacyFileDownloadable).toMatchObject({
+        file_downloadable: true,
+      });
       expect(tool.outputParameters?.properties?.data).toEqual({
         $ref: '#/$defs/GetAttachmentResponse',
+      });
+      expect(tool.outputParameters?.properties?.legacy_data).toEqual({
+        $ref: '#/definitions/LegacyAttachmentResponse',
       });
     });
   });

--- a/ts/packages/core/test/tools/tools.test.ts
+++ b/ts/packages/core/test/tools/tools.test.ts
@@ -573,6 +573,58 @@ describe('Tools', () => {
     });
   });
 
+  // `ParametersSchema` is a strict `z.object`, so any key it doesn't declare is
+  // dropped on parse. It previously omitted `$defs`/`definitions`, so a tool
+  // whose parameters root carries those blocks (the `$ref` targets) lost them —
+  // leaving every nested `$ref` dangling and unresolvable for providers and the
+  // file modifier. See https://github.com/ComposioHQ/composio/issues/3506.
+  describe('$ref / $defs preservation on tool parameters', () => {
+    const rawToolWithDefs = {
+      slug: 'GMAIL_GET_ATTACHMENT',
+      name: 'Get Attachment',
+      description: 'Fetch a Gmail attachment',
+      input_parameters: {
+        type: 'object',
+        properties: {
+          message_id: { type: 'string' },
+        },
+      },
+      output_parameters: {
+        type: 'object',
+        properties: {
+          data: { $ref: '#/$defs/GetAttachmentResponse' },
+        },
+        $defs: {
+          GetAttachmentResponse: {
+            type: 'object',
+            properties: { file: { $ref: '#/$defs/FileDownloadable' } },
+          },
+          FileDownloadable: {
+            type: 'object',
+            file_downloadable: true,
+            properties: { s3url: { type: 'string' } },
+          },
+        },
+      },
+      toolkit: { logo: 'https://example.com/gmail.png', slug: 'gmail', name: 'Gmail' },
+      version: '20260515_00',
+    };
+
+    it('keeps the root $defs block so nested $ref pointers stay resolvable', async () => {
+      mockClient.tools.retrieve.mockResolvedValueOnce(rawToolWithDefs);
+
+      const tool = await context.tools.getRawComposioToolBySlug('GMAIL_GET_ATTACHMENT');
+
+      expect(tool.outputParameters?.$defs).toBeDefined();
+      expect(tool.outputParameters?.$defs?.FileDownloadable).toMatchObject({
+        file_downloadable: true,
+      });
+      expect(tool.outputParameters?.properties?.data).toEqual({
+        $ref: '#/$defs/GetAttachmentResponse',
+      });
+    });
+  });
+
   describe('get', () => {
     it('should get a single tool by slug and wrap it with provider as a collection', async () => {
       const userId = 'test-user';


### PR DESCRIPTION
## Problem

Tools whose parameter schemas express their file fields through a `$ref`/`$defs` indirection lose auto file handling: with `dangerouslyAllowAutoUploadDownloadFiles` enabled, a `file_uploadable` input behind a `$ref` is never staged (the local path is forwarded as-is and the backend rejects it), and the `format: "path"` hint never reaches the model.

`GMAIL_GET_ATTACHMENT` is the canonical shape — its parameters nest the file flag two `$ref` hops deep:

```
data → $ref → #/$defs/GetAttachmentResponse → file → $ref → #/$defs/FileDownloadable   (file_downloadable: true)
```

This is the TypeScript-SDK counterpart of #3506 (the Python side is handled separately in #3545).

Two coupled causes defeat reference resolution:

1. **`$defs` is dropped on parse.** `ParametersSchema` (`src/types/tool.types.ts`) is a strict `z.object` that never declared `$defs`/`definitions`, so `ToolSchema.parse` stripped the root definition block off every tool. Each nested `$ref` was then dangling and unresolvable for *all* downstream consumers — providers that pass `inputParameters` straight to the model (e.g. `OpenAIProvider`) and the file modifier alike. (`JSONSchemaPropertySchema` already accepts both keywords; the root did not.)
2. **The file modifier never dereferences.** `transformProperties`, `schemaHasFileProperty`, and the upload/download hydration recurse `properties`/`anyOf`/`oneOf`/`allOf`/`items` but skip `$ref`, so a flag reachable only through a reference is invisible to the walk.

## Solution

- Add `$defs`/`definitions` to `ParametersSchema` so the root definition block survives parsing and `$ref` pointers stay resolvable.
- Dereference `inputParameters`/`outputParameters` in `FileToolModifier` (node runtime) before walking, via the existing `dereferenceJsonSchema` helper in `'sentinel'` mode — the same mode `MastraProvider` already uses. Tools that ship a `$ref` without a matching `$defs` target (#3307) degrade to a permissive object instead of throwing, exactly as today.

No new dependencies; `dereferenceJsonSchema` already exists and is exercised by the Mastra provider. The edge (`workerd`) modifier is unchanged — its upload/download paths already throw as unsupported.

## Testing

- `pnpm typecheck` — clean.
- `pnpm test` (core) — 926 passing, including new cases:
  - `$ref`-indirected `file_uploadable` is marked `format: "path"` by `modifyToolSchema`.
  - `fileUploadModifier` stages a file whose flag is reachable only via `$ref`/`$defs`.
  - a `$ref` with no matching `$defs` target degrades gracefully (no throw).
  - root `$defs` survives `ToolSchema.parse` and nested `$ref` pointers remain intact.
- Provider suites unaffected: `mastra` (51), `openai` (29), `vercel` (10), `anthropic` (19) all green.