### PR TITLE
fix(ci): repair CLI binary and docs sync workflows

### DIFF
--- a/.github/workflows/docs.sdk-change-sync.yml
+++ b/.github/workflows/docs.sdk-change-sync.yml
@@ -47,18 +47,19 @@ jobs:
             python/composio/ > /tmp/sdk-diff.patch
 
           if [ ! -s /tmp/sdk-diff.patch ]; then
-            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
           else
-            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
             echo "$(wc -l < /tmp/sdk-diff.patch) lines of SDK changes"
           fi
 
       - name: Check docs for staleness
         if: steps.diff.outputs.has_changes == 'true'
-        uses: anthropics/claude-code-action@fbda2eb1bdc90d319b8d853f5deb53bca199a7c1 # v1.0.140
+        uses: anthropics/claude-code-action/base-action@fbda2eb1bdc90d319b8d853f5deb53bca199a7c1 # v1.0.140
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          allowed_tools: "Read,Write,Edit,Glob,Grep"
+          claude_args: |
+            --allowedTools "Read,Write,Edit,Glob,Grep"
           prompt: |
             SDK source code was just updated. Check if any documentation needs to change.
 

--- a/ts/packages/cli-local-tools/scripts/build-peekaboo-binaries.ts
+++ b/ts/packages/cli-local-tools/scripts/build-peekaboo-binaries.ts
@@ -4,6 +4,7 @@ import { $ } from 'bun';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { patchSwiftSystemAtResolveBeneathGuard } from './swift-system-patches';
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.resolve(scriptDir, '..');
@@ -172,9 +173,26 @@ const patchSwiftConfigurationForCurrentToolchain = async () => {
   }
 };
 
+const patchSwiftSystemForCurrentSdk = async () => {
+  const checkoutRoot = path.join(cliPackagePath, '.build/checkouts/swift-system');
+  if (!(await exists(checkoutRoot))) {
+    throw new Error(
+      'Swift package resolution completed but the swift-system checkout was not found.'
+    );
+  }
+
+  const replacementCount = await patchSwiftSystemAtResolveBeneathGuard(checkoutRoot, exists);
+  if (replacementCount > 0) {
+    console.log(
+      `Patched ${replacementCount} swift-system AT_RESOLVE_BENEATH guards for the current macOS SDK.`
+    );
+  }
+};
+
 const buildTarget = async (target: Target) => {
   console.log(`Building peekaboo for ${target.platform} (${target.swiftArch})...`);
   await patchSwiftConfigurationForCurrentToolchain();
+  await patchSwiftSystemForCurrentSdk();
   await $`swift build --arch ${target.swiftArch} -c release -Xswiftc -Osize -Xswiftc -wmo -Xlinker -dead_strip`.cwd(
     cliPackagePath
   );

--- a/ts/packages/cli-local-tools/scripts/swift-system-patches.test.ts
+++ b/ts/packages/cli-local-tools/scripts/swift-system-patches.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { patchSwiftSystemAtResolveBeneathGuardInSource } from './swift-system-patches';
+
+describe('swift-system build patches', () => {
+  it('narrows AT_RESOLVE_BENEATH availability to FreeBSD', () => {
+    const source = `#if canImport(Darwin, _version: 346) || os(FreeBSD)
+@_alwaysEmitIntoClient
+internal var _AT_RESOLVE_BENEATH: CInt { AT_RESOLVE_BENEATH }
+#endif
+`;
+
+    const patched = patchSwiftSystemAtResolveBeneathGuardInSource(
+      source,
+      'Sources/System/Internals/Constants.swift'
+    );
+
+    expect(patched.replacementCount).toBe(1);
+    expect(patched.source).toContain('#if os(FreeBSD)');
+    expect(patched.source).not.toContain('canImport(Darwin, _version: 346)');
+  });
+
+  it('is idempotent for already patched sources', () => {
+    const source = `#if os(FreeBSD)
+@_alwaysEmitIntoClient
+internal var _AT_RESOLVE_BENEATH: CInt { AT_RESOLVE_BENEATH }
+#endif
+`;
+
+    const patched = patchSwiftSystemAtResolveBeneathGuardInSource(
+      source,
+      'Sources/System/Internals/Constants.swift'
+    );
+
+    expect(patched).toEqual({ source, replacementCount: 0 });
+  });
+});

--- a/ts/packages/cli-local-tools/scripts/swift-system-patches.ts
+++ b/ts/packages/cli-local-tools/scripts/swift-system-patches.ts
@@ -1,0 +1,60 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const swiftSystemAtResolveBeneathGuard = '#if canImport(Darwin, _version: 346) || os(FreeBSD)';
+const swiftSystemFreeBsdOnlyGuard = '#if os(FreeBSD)';
+
+// swift-system 1.7.x exposes AT_RESOLVE_BENEATH on Darwin when compiling with
+// Swift 6.2, but GitHub's macOS SDK currently omits the C constant.
+const swiftSystemAtResolveBeneathFiles = [
+  'Sources/System/Internals/Constants.swift',
+  'Sources/System/FileSystem/Stat.swift',
+] as const;
+
+const countOccurrences = (source: string, pattern: string): number =>
+  source.split(pattern).length - 1;
+
+export const patchSwiftSystemAtResolveBeneathGuardInSource = (
+  source: string,
+  filePath: string
+): { source: string; replacementCount: number } => {
+  const replacementCount = countOccurrences(source, swiftSystemAtResolveBeneathGuard);
+  if (replacementCount > 0) {
+    return {
+      source: source.replaceAll(swiftSystemAtResolveBeneathGuard, swiftSystemFreeBsdOnlyGuard),
+      replacementCount,
+    };
+  }
+
+  if (source.includes(swiftSystemFreeBsdOnlyGuard) && source.includes('AT_RESOLVE_BENEATH')) {
+    return { source, replacementCount: 0 };
+  }
+
+  throw new Error(`Unable to patch swift-system AT_RESOLVE_BENEATH guard in ${filePath}`);
+};
+
+export const patchSwiftSystemAtResolveBeneathGuard = async (
+  checkoutRoot: string,
+  exists: (filePath: string) => Promise<boolean>
+): Promise<number> => {
+  let replacementCount = 0;
+
+  for (const filePath of swiftSystemAtResolveBeneathFiles) {
+    const sourcePath = path.join(checkoutRoot, filePath);
+    if (!(await exists(sourcePath))) {
+      throw new Error(
+        `Swift package resolution completed but swift-system ${filePath} was not found.`
+      );
+    }
+
+    const source = await fs.readFile(sourcePath, 'utf8');
+    const patched = patchSwiftSystemAtResolveBeneathGuardInSource(source, filePath);
+    if (patched.replacementCount === 0) continue;
+
+    await fs.chmod(sourcePath, 0o644).catch(() => undefined);
+    await fs.writeFile(sourcePath, patched.source, 'utf8');
+    replacementCount += patched.replacementCount;
+  }
+
+  return replacementCount;
+};

--- a/ts/packages/cli-local-tools/vitest.config.ts
+++ b/ts/packages/cli-local-tools/vitest.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     },
   },
   test: {
-    include: ['src/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'scripts/**/*.test.ts'],
     exclude: ['vendor/**', 'dist/**', 'node_modules/**'],
   },
 });


### PR DESCRIPTION
This PR:
- patches the Peekaboo sidecar build to rewrite the resolved `swift-system` `AT_RESOLVE_BENEATH` Darwin guard before compiling on GitHub macOS runners
- adds regression coverage for the `swift-system` checkout patch and includes script tests in `@composio/cli-local-tools` Vitest
- switches the SDK docs sync workflow to `anthropics/claude-code-action/base-action` so push-triggered automation does not fail on unsupported event parsing
- moves Claude tool restrictions to `claude_args` and quotes `$GITHUB_OUTPUT` writes so the workflow passes `actionlint`
- verifies the changed package and workflow with targeted tests, build, formatting, YAML parsing, and `actionlint`