### PR TITLE
fix: use allowed_tools instead of custom_tools in MCP.update()

### DIFF
--- a/python/composio/core/models/mcp.py
+++ b/python/composio/core/models/mcp.py
@@ -370,7 +370,11 @@ class MCP(Resource):
                 update_params["auth_config_ids"] = auth_config_ids
 
             if allowed_tools is not None:
-                update_params["custom_tools"] = allowed_tools
+                # Use "allowed_tools" to match what _client.mcp.update() expects.
+                # Note: create() uses "custom_tools" because it calls a different
+                # endpoint (mcp.custom.create). The update endpoint expects
+                # "allowed_tools". See https://github.com/ComposioHQ/composio/issues/2161
+                update_params["allowed_tools"] = allowed_tools
 
             if manually_manage_connections is not None:
                 update_params[


### PR DESCRIPTION
The update() method was passing custom_tools to _client.mcp.update(), but that endpoint expects allowed_tools. The custom_tools key is only correct for the create endpoint (mcp.custom.create). This caused a TypeError whenever allowed_tools was passed to MCP.update().

Fixes #2161

## Summary
Explain the motivation and context for this change. Link to any related issues.

Fixes #

## Changes
- 
- 

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [ ] Documentation
- [ ] Breaking change

## How Has This Been Tested?
Describe the tests you ran and instructions so reviewers can reproduce. Include any relevant config/versions.

## Screenshots (if applicable)

## Checklist
- [ ] I have read the Code of Conduct and this PR adheres to it
- [ ] I ran linters/tests locally and they passed
- [ ] I updated documentation as needed
- [ ] I added tests or explain why not applicable
- [ ] I added a changeset if this change affects published packages

## Additional context
