### PR TITLE
fix(anthropic): sanitize illegal/over-long tool property keys for Messages API

### DIFF
--- a/ts/packages/providers/anthropic/src/index.ts
+++ b/ts/packages/providers/anthropic/src/index.ts
@@ -18,6 +18,7 @@ import {
 } from '@composio/core';
 import Anthropic from '@anthropic-ai/sdk';
 import { AnthropicTool, InputSchema } from './types';
+import { sanitizeSchemaPropertyKeys, restoreOriginalKeys, KeyMapping } from './sanitize-keys';
 
 export type AnthropicMcpServerGetResponse = {
   type: 'url';
@@ -58,6 +59,15 @@ export class AnthropicProvider extends BaseNonAgenticProvider<
 > {
   readonly name = 'anthropic';
   private chacheTools: boolean = false;
+
+  /**
+   * Per-tool `sanitized -> original` property-key mappings, populated by
+   * {@link wrapTool} whenever a tool's schema contains keys that violate
+   * Anthropic's `^[a-zA-Z0-9_.-]{1,64}$` constraint. Used by
+   * {@link executeToolCall} to restore the original parameter names before the
+   * call reaches the Composio backend.
+   */
+  private toolKeyMappings: Map<string, KeyMapping> = new Map();
 
   /**
    * Creates a new instance of the AnthropicProvider.
@@ -118,14 +128,29 @@ export class AnthropicProvider extends BaseNonAgenticProvider<
    * ```
    */
   override wrapTool(tool: ComposioTool): AnthropicTool {
+    const rawSchema = (tool.inputParameters || {
+      type: 'object',
+      properties: {},
+      required: [],
+    }) as InputSchema;
+
+    // Anthropic rejects the whole `tools` array if any property key falls outside
+    // `^[a-zA-Z0-9_.-]{1,64}$` (e.g. OData params like `$top`, `@odata.type`, or
+    // over-long flattened keys). Rewrite offending keys and remember how to undo it.
+    const { schema, mapping } = sanitizeSchemaPropertyKeys(
+      rawSchema as unknown as Record<string, unknown>
+    );
+
+    if (Object.keys(mapping).length > 0) {
+      this.toolKeyMappings.set(tool.slug, mapping);
+    } else {
+      this.toolKeyMappings.delete(tool.slug);
+    }
+
     return {
       name: tool.slug,
       description: tool.description || '',
-      input_schema: (tool.inputParameters || {
-        type: 'object',
-        properties: {},
-        required: [],
-      }) as InputSchema,
+      input_schema: schema as unknown as InputSchema,
       cache_control: this.chacheTools ? { type: 'ephemeral' } : undefined,
     };
   }
@@ -210,8 +235,15 @@ export class AnthropicProvider extends BaseNonAgenticProvider<
     options?: ExecuteToolFnOptions,
     modifiers?: ExecuteToolModifiers
   ): Promise<string> {
+    // Undo any key sanitization applied in `wrapTool` so the backend receives the
+    // tool's original parameter names (e.g. `dollar_top` -> `$top`).
+    const mapping = this.toolKeyMappings.get(toolUse.name);
+    const toolArguments = mapping
+      ? (restoreOriginalKeys(toolUse.input, mapping) as Record<string, unknown>)
+      : toolUse.input;
+
     const payload: ToolExecuteParams = {
-      arguments: toolUse.input,
+      arguments: toolArguments,
       connectedAccountId: options?.connectedAccountId,
       customAuthParams: options?.customAuthParams,
       customConnectionData: options?.customConnectionData,

--- a/ts/packages/providers/anthropic/src/sanitize-keys.ts
+++ b/ts/packages/providers/anthropic/src/sanitize-keys.ts
@@ -1,0 +1,191 @@
+/**
+ * Anthropic tool-schema key sanitization.
+ *
+ * Anthropic's Messages API validates every tool `input_schema` property key
+ * against the pattern `^[a-zA-Z0-9_.-]{1,64}$`. A single non-conforming key
+ * makes the API reject the entire `tools` array with HTTP 400, so one bad tool
+ * takes down every other tool in the same request.
+ *
+ * Composio tools can surface keys that break this pattern in two ways:
+ *  - **Illegal characters** — e.g. the OneDrive toolkit exposes Microsoft Graph
+ *    OData parameters such as `$top`, `$filter` or `@microsoft.graph.conflictBehavior`
+ *    whose `$` and `@` are outside the allowed set.
+ *  - **Length** — flattening nested objects with `__` separators can produce keys
+ *    longer than 64 characters (e.g. several Zoom tools).
+ *
+ * This module rewrites offending keys to conforming aliases before the schema is
+ * sent to Anthropic, and records a reverse mapping so the original parameter names
+ * can be restored before a tool call is executed against the Composio backend.
+ *
+ * @packageDocumentation
+ * @module providers/anthropic/sanitize-keys
+ */
+
+/** Anthropic's allowed property-key pattern. */
+const VALID_KEY_RE = /^[a-zA-Z0-9_.-]{1,64}$/;
+
+/** Maximum length Anthropic accepts for a property key. */
+const MAX_KEY_LENGTH = 64;
+
+/**
+ * Readable replacements for the most common illegal characters so aliases stay
+ * recognizable (e.g. `$top` -> `dollar_top`, `@odata.type` -> `at_odata.type`).
+ * Any other illegal character falls back to `_`. Mirrors the Python SDK's
+ * sanitization for cross-language consistency.
+ */
+const ILLEGAL_CHAR_MAP: Record<string, string> = {
+  $: 'dollar_',
+  '@': 'at_',
+};
+
+/** Mapping of sanitized key -> original key, used to restore names at execution. */
+export type KeyMapping = Record<string, string>;
+
+/**
+ * Deterministic, dependency-free hash (djb2) rendered as a short base-36 string.
+ * Used as a uniqueness suffix when truncating long keys or resolving collisions.
+ */
+function shortHash(input: string): string {
+  let hash = 5381;
+  for (let i = 0; i < input.length; i++) {
+    hash = (hash * 33) ^ input.charCodeAt(i);
+  }
+  // Force unsigned and keep it short but collision-resistant enough for keys.
+  return (hash >>> 0).toString(36).slice(0, 7);
+}
+
+/** Whether a key is already valid for Anthropic and needs no rewriting. */
+function isValidKey(name: string): boolean {
+  return VALID_KEY_RE.test(name);
+}
+
+/**
+ * Rewrites a single key so it matches Anthropic's pattern. Replaces known illegal
+ * characters with readable aliases, any remaining illegal character with `_`, and
+ * truncates keys over 64 characters with a deterministic hash suffix.
+ */
+function sanitizeKey(name: string): string {
+  let sanitized = name;
+  for (const [char, replacement] of Object.entries(ILLEGAL_CHAR_MAP)) {
+    sanitized = sanitized.split(char).join(replacement);
+  }
+  sanitized = sanitized.replace(/[^a-zA-Z0-9_.-]/g, '_');
+
+  if (sanitized.length > MAX_KEY_LENGTH) {
+    const suffix = `_${shortHash(name)}`;
+    sanitized = sanitized.slice(0, MAX_KEY_LENGTH - suffix.length) + suffix;
+  }
+
+  return sanitized;
+}
+
+/** Returns a sanitized key guaranteed to be unique within `taken`. */
+function uniqueSanitizedKey(name: string, taken: Set<string>): string {
+  let candidate = sanitizeKey(name);
+  if (!taken.has(candidate)) {
+    return candidate;
+  }
+  // Collision (different originals mapping to the same alias) — append a hash.
+  const suffix = `_${shortHash(name)}`;
+  const base = candidate.slice(0, MAX_KEY_LENGTH - suffix.length);
+  candidate = base + suffix;
+  while (taken.has(candidate)) {
+    candidate = `${candidate.slice(0, MAX_KEY_LENGTH - 1)}_`;
+  }
+  return candidate;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Recursively sanitizes the property keys of a JSON-schema node, collecting a
+ * sanitized -> original mapping. Only the `properties` of object schemas are
+ * traversed, matching how Composio nests its tool parameters.
+ *
+ * The input node is never mutated; a new node is returned.
+ */
+function sanitizeNode(node: Record<string, unknown>, mapping: KeyMapping): Record<string, unknown> {
+  const result: Record<string, unknown> = { ...node };
+  const properties = node.properties;
+
+  if (!isPlainObject(properties)) {
+    return result;
+  }
+
+  const newProperties: Record<string, unknown> = {};
+  const renamed: Record<string, string> = {}; // original -> sanitized (this level)
+
+  // Reserve all already-valid keys up front so they keep their exact names and
+  // sanitized aliases are generated around them (a valid `dollar_top` must not be
+  // clobbered by a sanitized `$top`).
+  const taken = new Set<string>();
+  for (const key of Object.keys(properties)) {
+    if (isValidKey(key)) {
+      taken.add(key);
+    }
+  }
+
+  for (const [key, rawValue] of Object.entries(properties)) {
+    const value = isPlainObject(rawValue) ? sanitizeNode(rawValue, mapping) : rawValue;
+    const safeKey = isValidKey(key) ? key : uniqueSanitizedKey(key, taken);
+
+    taken.add(safeKey);
+    newProperties[safeKey] = value;
+
+    if (safeKey !== key) {
+      renamed[key] = safeKey;
+      mapping[safeKey] = key;
+    }
+  }
+
+  result.properties = newProperties;
+
+  // Keep `required` in sync with the renamed keys at this level.
+  if (Array.isArray(node.required)) {
+    result.required = node.required.map(name =>
+      typeof name === 'string' && renamed[name] ? renamed[name] : name
+    );
+  }
+
+  return result;
+}
+
+/**
+ * Sanitizes a tool `input_schema` so all property keys conform to Anthropic's
+ * pattern.
+ *
+ * @param schema - The tool input schema to sanitize.
+ * @returns The sanitized schema (a copy) and a `sanitized -> original` key mapping.
+ *          The mapping is empty when nothing needed rewriting.
+ */
+export function sanitizeSchemaPropertyKeys<T extends Record<string, unknown>>(
+  schema: T
+): { schema: T; mapping: KeyMapping } {
+  const mapping: KeyMapping = {};
+  const sanitized = sanitizeNode(schema, mapping) as T;
+  return { schema: sanitized, mapping };
+}
+
+/**
+ * Restores original property names in a tool-call argument object using the
+ * mapping produced by {@link sanitizeSchemaPropertyKeys}. Nested objects and
+ * arrays are walked recursively. Returns a new value; the input is not mutated.
+ */
+export function restoreOriginalKeys(value: unknown, mapping: KeyMapping): unknown {
+  if (Array.isArray(value)) {
+    return value.map(item => restoreOriginalKeys(item, mapping));
+  }
+
+  if (isPlainObject(value)) {
+    const restored: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      const originalKey = mapping[key] ?? key;
+      restored[originalKey] = restoreOriginalKeys(val, mapping);
+    }
+    return restored;
+  }
+
+  return value;
+}

--- a/ts/packages/providers/anthropic/test/sanitize-keys.test.ts
+++ b/ts/packages/providers/anthropic/test/sanitize-keys.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, vi } from 'vitest';
+import { AnthropicProvider } from '../src';
+import type { AnthropicTool } from '../src/types';
+import type { Tool } from '@composio/core';
+import { sanitizeSchemaPropertyKeys, restoreOriginalKeys } from '../src/sanitize-keys';
+
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: vi.fn().mockImplementation(() => ({ messages: { create: vi.fn() } })),
+}));
+
+const ANTHROPIC_KEY_RE = /^[a-zA-Z0-9_.-]{1,64}$/;
+
+describe('sanitizeSchemaPropertyKeys', () => {
+  it('leaves already-valid keys untouched and reports no mapping', () => {
+    const schema = {
+      type: 'object',
+      properties: { query: { type: 'string' }, limit: { type: 'number' } },
+      required: ['query'],
+    };
+
+    const { schema: out, mapping } = sanitizeSchemaPropertyKeys(schema);
+
+    expect(out).toEqual(schema);
+    expect(mapping).toEqual({});
+  });
+
+  it('rewrites OData keys with illegal `$` and `@` characters', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        $top: { type: 'integer' },
+        $filter: { type: 'string' },
+        '@microsoft.graph.conflictBehavior': { type: 'string' },
+      },
+      required: ['$top', '@microsoft.graph.conflictBehavior'],
+    };
+
+    const { schema: out, mapping } = sanitizeSchemaPropertyKeys(schema);
+    const props = out.properties as Record<string, unknown>;
+
+    // Every emitted key must satisfy Anthropic's pattern.
+    for (const key of Object.keys(props)) {
+      expect(key).toMatch(ANTHROPIC_KEY_RE);
+    }
+
+    expect(props).toHaveProperty('dollar_top');
+    expect(props).toHaveProperty('dollar_filter');
+    expect(props).toHaveProperty('at_microsoft.graph.conflictBehavior');
+
+    // Mapping points sanitized keys back to the originals.
+    expect(mapping['dollar_top']).toBe('$top');
+    expect(mapping['at_microsoft.graph.conflictBehavior']).toBe(
+      '@microsoft.graph.conflictBehavior'
+    );
+
+    // `required` is rewritten to match the sanitized keys.
+    expect(out.required).toEqual(['dollar_top', 'at_microsoft.graph.conflictBehavior']);
+
+    // Property values are preserved.
+    expect(props['dollar_top']).toEqual({ type: 'integer' });
+  });
+
+  it('preserves the legal `.` and `-` characters Anthropic allows', () => {
+    const schema = {
+      type: 'object',
+      properties: { 'a.b-c': { type: 'string' } },
+    };
+
+    const { schema: out, mapping } = sanitizeSchemaPropertyKeys(schema);
+
+    expect(out.properties).toHaveProperty('a.b-c');
+    expect(mapping).toEqual({});
+  });
+
+  it('truncates keys longer than 64 characters to a deterministic alias', () => {
+    const longKey = 'settings__continuous__meeting__chat__auto__add__invited__external__users';
+    expect(longKey.length).toBeGreaterThan(64);
+
+    const schema = { type: 'object', properties: { [longKey]: { type: 'boolean' } } };
+
+    const first = sanitizeSchemaPropertyKeys(schema);
+    const second = sanitizeSchemaPropertyKeys(schema);
+
+    const [aliasA] = Object.keys(first.schema.properties as Record<string, unknown>);
+    const [aliasB] = Object.keys(second.schema.properties as Record<string, unknown>);
+
+    expect(aliasA).toMatch(ANTHROPIC_KEY_RE);
+    expect(aliasA.length).toBeLessThanOrEqual(64);
+    expect(aliasA).toBe(aliasB); // deterministic
+    expect(first.mapping[aliasA]).toBe(longKey);
+  });
+
+  it('keeps distinct originals distinct when they would collide', () => {
+    const schema = {
+      type: 'object',
+      properties: { $top: { type: 'integer' }, dollar_top: { type: 'string' } },
+    };
+
+    const { schema: out } = sanitizeSchemaPropertyKeys(schema);
+    const keys = Object.keys(out.properties as Record<string, unknown>);
+
+    expect(keys).toHaveLength(2);
+    expect(new Set(keys).size).toBe(2);
+    keys.forEach(k => expect(k).toMatch(ANTHROPIC_KEY_RE));
+  });
+
+  it('sanitizes nested object properties recursively', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        options: {
+          type: 'object',
+          properties: { $skip: { type: 'integer' } },
+          required: ['$skip'],
+        },
+      },
+    };
+
+    const { schema: out, mapping } = sanitizeSchemaPropertyKeys(schema);
+    const nested = (out.properties as any).options;
+
+    expect(nested.properties).toHaveProperty('dollar_skip');
+    expect(nested.required).toEqual(['dollar_skip']);
+    expect(mapping['dollar_skip']).toBe('$skip');
+  });
+
+  it('does not mutate the input schema', () => {
+    const schema = {
+      type: 'object',
+      properties: { $top: { type: 'integer' } },
+      required: ['$top'],
+    };
+    const snapshot = JSON.parse(JSON.stringify(schema));
+
+    sanitizeSchemaPropertyKeys(schema);
+
+    expect(schema).toEqual(snapshot);
+  });
+});
+
+describe('restoreOriginalKeys', () => {
+  it('restores sanitized keys back to their originals, including nested values', () => {
+    const mapping = { dollar_top: '$top', dollar_skip: '$skip' };
+    const args = { dollar_top: 10, nested: { dollar_skip: 5, keep: 'x' } };
+
+    expect(restoreOriginalKeys(args, mapping)).toEqual({
+      $top: 10,
+      nested: { $skip: 5, keep: 'x' },
+    });
+  });
+
+  it('passes through values with no mapping entry', () => {
+    const args = { query: 'hello', items: [1, 2, 3] };
+    expect(restoreOriginalKeys(args, {})).toEqual(args);
+  });
+});
+
+describe('AnthropicProvider key sanitization', () => {
+  const odataTool: Tool = {
+    slug: 'list_drive_item_activities',
+    name: 'List drive item activities',
+    description: 'Lists activities on a OneDrive item',
+    inputParameters: {
+      type: 'object',
+      properties: {
+        $top: { type: 'integer' },
+        $filter: { type: 'string' },
+      },
+      required: ['$top'],
+    },
+    tags: [],
+  } as unknown as Tool;
+
+  it('emits an Anthropic-compatible schema from wrapTool', () => {
+    const provider = new AnthropicProvider();
+    const wrapped = provider.wrapTool(odataTool) as AnthropicTool;
+    const props = wrapped.input_schema.properties as Record<string, unknown>;
+
+    for (const key of Object.keys(props)) {
+      expect(key).toMatch(ANTHROPIC_KEY_RE);
+    }
+    expect(props).toHaveProperty('dollar_top');
+  });
+
+  it('restores original OData keys before executing the tool call', async () => {
+    const provider = new AnthropicProvider();
+    const executeToolFn = vi
+      .fn()
+      .mockResolvedValue({ data: { ok: true }, error: null, successful: true });
+    provider._setExecuteToolFn(executeToolFn);
+
+    // Wrapping registers the reverse mapping for this tool slug.
+    provider.wrapTool(odataTool);
+
+    // The model calls the tool using the sanitized key names.
+    await provider.executeToolCall('user-1', {
+      type: 'tool_use',
+      id: 'tu_1',
+      name: 'list_drive_item_activities',
+      input: { dollar_top: 25 },
+    });
+
+    expect(executeToolFn).toHaveBeenCalledTimes(1);
+    const [, payload] = executeToolFn.mock.calls[0];
+    expect(payload.arguments).toEqual({ $top: 25 });
+  });
+
+  it('leaves arguments untouched for tools without sanitized keys', async () => {
+    const provider = new AnthropicProvider();
+    const executeToolFn = vi
+      .fn()
+      .mockResolvedValue({ data: { ok: true }, error: null, successful: true });
+    provider._setExecuteToolFn(executeToolFn);
+
+    const plainTool: Tool = {
+      slug: 'plain-tool',
+      name: 'Plain',
+      description: 'no illegal keys',
+      inputParameters: { type: 'object', properties: { query: { type: 'string' } } },
+      tags: [],
+    } as unknown as Tool;
+
+    provider.wrapTool(plainTool);
+    await provider.executeToolCall('user-1', {
+      type: 'tool_use',
+      id: 'tu_2',
+      name: 'plain-tool',
+      input: { query: 'hello' },
+    });
+
+    const [, payload] = executeToolFn.mock.calls[0];
+    expect(payload.arguments).toEqual({ query: 'hello' });
+  });
+});


### PR DESCRIPTION
## Problem

Anthropic's Messages API validates every tool `input_schema` property key against `^[a-zA-Z0-9_.-]{1,64}$`. A single non-conforming key makes the API reject the **entire** `tools` array with HTTP 400, so one bad tool takes down every other tool in the same request (e.g. a Claude Code subagent that loads all MCP schemas up front dies before running anything).

The TypeScript `@composio/anthropic` provider's `wrapTool()` passes `tool.inputParameters` straight through as `input_schema` with **no key sanitization**, so two real cases break:

- **Illegal characters** — the OneDrive toolkit exposes Microsoft Graph OData parameters as schema keys: `list_drive_item_activities` has `$top`/`$filter`/`$skip`/`$orderby`, and `copy_item` has `@microsoft.graph.conflictBehavior`. `$` and `@` are not in Anthropic's allowed set.
- **Length** — `__`-flattened nested keys can exceed 64 characters (several Zoom tools).

This is the TypeScript-side counterpart to the Python fix in #3504 (which only touches `python/composio/utils/shared.py`). TS SDK users with the Anthropic provider still hit the 400 today.

Refs #3500 (and the earlier #2330 / closed #3067 for the length case, which never landed in the provider).

## What this changes

- New `sanitize-keys.ts`:
  - `sanitizeSchemaPropertyKeys(schema)` rewrites offending keys to conforming aliases (`$` → `dollar_`, `@` → `at_`, any other illegal char → `_`, keys > 64 chars truncated with a deterministic hash suffix), recurses into nested object schemas, keeps `required` in sync, and never mutates the input. It returns a `sanitized → original` mapping. The legal `.` and `-` characters are preserved (Anthropic allows them), so `@microsoft.graph.conflictBehavior` → `at_microsoft.graph.conflictBehavior`.
  - `restoreOriginalKeys(args, mapping)` reverses the rename on tool-call arguments.
- `AnthropicProvider.wrapTool()` sanitizes the schema and stores the per-tool reverse mapping; `executeToolCall()` restores the original parameter names before the call reaches the Composio backend, so the model sees `dollar_top` but Graph still receives `$top`.

Already-valid schemas are returned unchanged with an empty mapping, so there is no behavior change for tools whose keys already conform.

## Why this approach

This mirrors the accepted Python design in #3504 (sanitize on the way out, reverse-map on execution) and the previously-proposed provider-level approach in #3067 (which was closed only for lacking a linked issue, not on technical grounds). Keeping the alias scheme identical to the Python SDK (`dollar_`/`at_`, hash-suffixed truncation) keeps the two SDKs consistent. The fix is scoped to the Anthropic provider since the `[a-zA-Z0-9_.-]{1,64}` constraint is Anthropic-specific.

## Testing

`pnpm --filter @composio/anthropic test` — 31 passing (19 existing + 12 new). New tests cover illegal-character rewriting, `.`/`-` preservation, length truncation determinism, collision handling, recursion, no-mutation, and the `wrapTool` → `executeToolCall` round-trip that restores original OData keys. `pnpm typecheck`, `tsdown` build, eslint and prettier are clean.