### PR TITLE
fix(ci): use app token for SDK docs PRs

### DIFF
--- a/.github/workflows/generate-sdk-docs.yml
+++ b/.github/workflows/generate-sdk-docs.yml
@@ -21,8 +21,17 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
+
       - name: Checkout Code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js, pnpm, Bun
         uses: ./.github/actions/setup-node-pnpm-bun
@@ -35,6 +44,7 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: 'docs: auto-generate TypeScript SDK reference'
           title: 'docs: update TypeScript SDK reference from source'
           body: |
@@ -49,7 +59,7 @@ jobs:
       - name: Request review from pusher
         if: steps.create-pr.outputs.pull-request-number
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
           AUTHOR: ${{ github.actor }}
         run: gh pr edit "$PR_NUMBER" --add-reviewer "$AUTHOR"
@@ -61,8 +71,17 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
+
       - name: Checkout Code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Python with UV
         uses: ./.github/actions/setup-python-uv
@@ -73,6 +92,7 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: 'docs: auto-generate Python SDK reference'
           title: 'docs: update Python SDK reference from source'
           body: |
@@ -87,7 +107,7 @@ jobs:
       - name: Request review from pusher
         if: steps.create-pr.outputs.pull-request-number
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
           AUTHOR: ${{ github.actor }}
         run: gh pr edit "$PR_NUMBER" --add-reviewer "$AUTHOR"


### PR DESCRIPTION
This PR:
- fixes https://github.com/ComposioHQ/composio/actions/runs/27606982132/job/81621371312
- mints the existing release-bot GitHub App token in both SDK docs jobs
- passes the App token to checkout and `peter-evans/create-pull-request`
- uses the same App token for the reviewer-assignment `gh pr edit` step
- keeps the TypeScript and Python docs generation commands unchanged

Verification:
- `git diff --check`
- `ruby -e \"require 'yaml'; YAML.load_file('.github/workflows/generate-sdk-docs.yml'); puts 'yaml ok'\"`
- `bash .github/scripts/check-action-repos.sh`
- confirmed `RELEASE_BOT_APP_ID` and `RELEASE_BOT_APP_PRIVATE_KEY` exist in repo secrets