### PR TITLE
feat(sdk): native user_id on triggers.create (drop 2FA bridges)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,7 +22,7 @@ catalog:
   '@clack/prompts': '^1.0.1'
   '@cloudflare/vitest-pool-workers': 0.16.12
   '@cloudflare/workers-types': ^4.20250917.0
-  '@composio/client': 0.1.0-alpha.72
+  '@composio/client': 0.1.0-alpha.74
   '@effect/cli': ^0.73.2
   '@effect/eslint-plugin': ^0.3.2
   '@effect/language-service': ^0.74.0

--- a/python/composio/core/models/triggers.py
+++ b/python/composio/core/models/triggers.py
@@ -1006,11 +1006,6 @@ class Triggers(Resource):
                 "please provide valid `connected_account` or `user_id`"
             )
 
-        # Forward user_id so 2FA-enabled projects can verify the pinned connected
-        # account belongs to this user (backends without 2FA ignore it). Sent via
-        # extra_body until composio-client regenerates with the field.
-        extra_body = {"user_id": user_id} if user_id is not None else {}
-
         return self._client.trigger_instances.upsert(
             slug=slug,
             connected_account_id=connected_account_id,
@@ -1018,7 +1013,9 @@ class Triggers(Resource):
             body_trigger_config_1=(
                 trigger_config if trigger_config is not None else omit
             ),
-            extra_body=extra_body,
+            # Forward user_id so 2FA-enabled projects verify the pinned connected
+            # account belongs to this user (ignored by non-2FA backends).
+            user_id=user_id if user_id is not None else omit,
         )
 
     def _get_connected_account_for_user(self, trigger: str, user_id: str) -> str:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.10,<4"
 dependencies = [
     "pysher>=1.0.8",
     "pydantic>=2.6.4",
-    "composio-client==1.39.0",
+    "composio-client==1.41.0",
     "typing-extensions>=4.0.0",
     "openai",
     "json-schema-to-pydantic>=0.4.8",

--- a/python/tests/test_triggers.py
+++ b/python/tests/test_triggers.py
@@ -255,7 +255,7 @@ class TestTriggers:
         assert call_kwargs["connected_account_id"] == "conn-456"
         assert call_kwargs["toolkit_versions"] is None
         # user_id forwarded for trigger 2FA ownership verification
-        assert call_kwargs["extra_body"] == {"user_id": "user-123"}
+        assert call_kwargs["user_id"] == "user-123"
         assert result == mock_response
 
     def test_create_with_custom_toolkit_versions(

--- a/ts/packages/core/src/models/Triggers.ts
+++ b/ts/packages/core/src/models/Triggers.ts
@@ -231,12 +231,8 @@ export class Triggers<TProvider extends BaseComposioProvider<unknown, unknown, u
     }
 
     // Forward user_id so 2FA-enabled projects can verify the pinned connected
-    // account is owned by this user (backends without 2FA ignore it). The
-    // `& { user_id }` bridges until @composio/client regenerates from the
-    // updated OpenAPI spec; drop it once the field lands on the generated type.
-    const upsertParams: ClientTriggerInstanceUpsertParams & {
-      user_id?: string;
-    } = {
+    // account is owned by this user (ignored by non-2FA backends).
+    const upsertParams: ClientTriggerInstanceUpsertParams = {
       connected_account_id: connectedAccountId,
       trigger_config: parsedBody.data.triggerConfig,
       toolkit_versions: this.toolkitVersions,


### PR DESCRIPTION
## What

Follow-up to #3576 (which forwarded `user_id` via interim bridges). Now that hermes 2FA-for-triggers is **in production** and the OpenAPI spec exposes `user_id` on `/api/v3/trigger_instances/{slug}/upsert`, the regenerated clients add `user_id` to `TriggerInstanceUpsertParams` natively.

This swaps both SDKs to the **native typed param** and removes the bridges:
- **TS** (`Triggers.ts`): drops the `& { user_id?: string }` cast.
- **Python** (`triggers.py`): drops the `extra_body` escape hatch; passes `user_id=` (omit when only `connected_account_id` given).

## ⚠️ Draft — merge-gated on client releases

Pins bumped to the versions that add `user_id`, **not yet published**:
- `@composio/client` `0.1.0-alpha.72 → 0.1.0-alpha.74` — pending **ComposioHQ/composio-base-ts#84**
- `composio-client` `1.39.0 → 1.41.0` — pending **ComposioHQ/composio-base-py#69**

CI install/typecheck stays red until both publish. Mark ready + merge once they land (lockfiles refresh on install).

## Tests
- TS: upsert-body assertion includes `user_id`.
- Python: `test_create_with_user_id` asserts the native `user_id` kwarg.

Completes the SDK follow-up for PLEN-2580 the proper (non-bridge) way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)