### PR TITLE
Add timeouts for Python file transfers

### DIFF
--- a/python/composio/core/models/_files.py
+++ b/python/composio/core/models/_files.py
@@ -145,7 +145,11 @@ def upload(url: str, file: Path) -> bool:
         True if upload succeeded (HTTP 200), False otherwise
     """
     with file.open("rb") as data:
-        response = requests.put(url=url, data=data)
+        response = requests.put(
+            url=url,
+            data=data,
+            timeout=(_CONNECT_TIMEOUT, _READ_TIMEOUT),
+        )
         return response.status_code == 200
 
 
@@ -378,11 +382,15 @@ def _upload_bytes_to_s3(
     )
 
     # Upload the content directly to S3
-    upload_response = requests.put(
-        url=s3meta.new_presigned_url,
-        data=content,
-        headers={"Content-Type": mimetype},
-    )
+    try:
+        upload_response = requests.put(
+            url=s3meta.new_presigned_url,
+            data=content,
+            headers={"Content-Type": mimetype},
+            timeout=(_CONNECT_TIMEOUT, _READ_TIMEOUT),
+        )
+    except requests.exceptions.RequestException as e:
+        raise ErrorUploadingFile(f"Failed to upload to S3: {e}") from e
 
     if upload_response.status_code != 200:
         raise ErrorUploadingFile(
@@ -567,13 +575,24 @@ class FileDownloadable(BaseModel):
                 "outside the intended output directory."
             )
         outdir.mkdir(exist_ok=True, parents=True)
-        response = requests.get(url=self.s3url, stream=True)
-        if response.status_code != 200:
-            raise ErrorDownloadingFile(f"Error downloading file: {self.s3url}")
+        try:
+            response = requests.get(
+                url=self.s3url,
+                stream=True,
+                timeout=(_CONNECT_TIMEOUT, _READ_TIMEOUT),
+            )
+        except requests.exceptions.RequestException as e:
+            raise ErrorDownloadingFile(f"Error downloading file: {self.s3url}") from e
 
-        with outfile.open("wb") as fd:
-            for chunk in response.iter_content(chunk_size=chunk_size):
-                fd.write(chunk)
+        try:
+            if response.status_code != 200:
+                raise ErrorDownloadingFile(f"Error downloading file: {self.s3url}")
+
+            with outfile.open("wb") as fd:
+                for chunk in response.iter_content(chunk_size=chunk_size):
+                    fd.write(chunk)
+        finally:
+            response.close()
         return outfile
 
 

--- a/python/composio/core/models/tool_router_session_files.py
+++ b/python/composio/core/models/tool_router_session_files.py
@@ -118,7 +118,18 @@ class RemoteFile:
 
     def buffer(self) -> bytes:
         """Fetch the file content as bytes."""
-        response = requests.get(self.download_url)
+        try:
+            response = requests.get(
+                self.download_url,
+                timeout=(_CONNECT_TIMEOUT, _READ_TIMEOUT),
+            )
+        except requests.exceptions.RequestException as e:
+            raise RemoteFileDownloadError(
+                f"Failed to download file: {e}",
+                download_url=self.download_url,
+                mount_relative_path=self.mount_relative_path,
+                filename=self.filename,
+            ) from e
 
         if not response.ok:
             raise RemoteFileDownloadError(
@@ -287,11 +298,15 @@ class ToolRouterSessionFilesMount:
             mimetype=mime,
         )
 
-        upload_resp = requests.put(
-            create_resp.upload_url,
-            data=content,
-            headers={"Content-Type": mime},
-        )
+        try:
+            upload_resp = requests.put(
+                create_resp.upload_url,
+                data=content,
+                headers={"Content-Type": mime},
+                timeout=(_CONNECT_TIMEOUT, _READ_TIMEOUT),
+            )
+        except requests.exceptions.RequestException as e:
+            raise ValidationError(f"Failed to upload file: {e}") from e
 
         if not upload_resp.ok:
             raise ValidationError(

--- a/python/tests/test_files.py
+++ b/python/tests/test_files.py
@@ -7,12 +7,15 @@ that use anyOf, oneOf, allOf, or $ref instead of direct 'type' properties.
 from unittest.mock import Mock, patch, MagicMock
 
 import pytest
+import requests
 
 from composio.client.types import Tool, tool_list_response
 from composio.core.models._files import (
     FileDownloadable,
     FileHelper,
     FileUploadable,
+    _CONNECT_TIMEOUT,
+    _READ_TIMEOUT,
     _is_url,
     _get_extension_from_mimetype,
     _generate_timestamped_filename,
@@ -23,7 +26,11 @@ from composio.core.models._files import (
     _MAX_FILENAME_LENGTH,
 )
 from composio.core.models.base import allow_tracking
-from composio.exceptions import ErrorUploadingFile, ResponseTooLargeError
+from composio.exceptions import (
+    ErrorDownloadingFile,
+    ErrorUploadingFile,
+    ResponseTooLargeError,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -1518,7 +1525,12 @@ class TestUploadBytesToS3:
 
         assert result == "s3-key-123"
         mock_client.post.assert_called_once()
-        mock_put.assert_called_once()
+        mock_put.assert_called_once_with(
+            url="https://s3.example.com/upload",
+            data=b"file content",
+            headers={"Content-Type": "image/jpeg"},
+            timeout=(_CONNECT_TIMEOUT, _READ_TIMEOUT),
+        )
 
     @patch("composio.core.models._files.requests.put")
     def test_upload_bytes_to_s3_failure(self, mock_put):
@@ -1544,6 +1556,26 @@ class TestUploadBytesToS3:
             )
 
         assert "Failed to upload to S3" in str(exc_info.value)
+
+    @patch("composio.core.models._files.requests.put")
+    def test_upload_bytes_to_s3_request_error(self, mock_put):
+        """Test request errors are reported as file upload failures."""
+        mock_client = MagicMock()
+        mock_s3_response = MagicMock()
+        mock_s3_response.key = "s3-key-123"
+        mock_s3_response.new_presigned_url = "https://s3.example.com/upload"
+        mock_client.post.return_value = mock_s3_response
+        mock_put.side_effect = requests.exceptions.Timeout("timed out")
+
+        with pytest.raises(ErrorUploadingFile, match="Failed to upload to S3"):
+            _upload_bytes_to_s3(
+                client=mock_client,
+                filename="test.jpg",
+                content=b"file content",
+                mimetype="image/jpeg",
+                tool="TEST_TOOL",
+                toolkit="test_toolkit",
+            )
 
 
 class TestFileUploadableFromUrl:
@@ -2360,6 +2392,37 @@ class TestFileDownloadablePathTraversal:
         assert written == outdir / "report.pdf"
         assert written.read_bytes() == b"%PDF-1.4"
 
+    def test_download_uses_request_timeout(self, tmp_path):
+        outdir = tmp_path / "safe"
+        f = FileDownloadable(
+            name="report.pdf",
+            mimetype="application/pdf",
+            s3url="https://example.com/file",
+        )
+        with patch(
+            "composio.core.models._files.requests.get",
+            return_value=self._mock_response(b"%PDF-1.4"),
+        ) as mock_get:
+            f.download(outdir)
+
+        assert mock_get.call_args.kwargs["timeout"] == (
+            _CONNECT_TIMEOUT,
+            _READ_TIMEOUT,
+        )
+
+    def test_download_request_error_raises_error_downloading_file(self, tmp_path):
+        outdir = tmp_path / "safe"
+        f = FileDownloadable(
+            name="report.pdf",
+            mimetype="application/pdf",
+            s3url="https://example.com/file",
+        )
+        with patch("composio.core.models._files.requests.get") as mock_get:
+            mock_get.side_effect = requests.exceptions.Timeout("timed out")
+
+            with pytest.raises(ErrorDownloadingFile, match="Error downloading file"):
+                f.download(outdir)
+
     def test_basename_collapse_through_subdir_is_rejected(self, tmp_path):
         """`Path('foo/..').name == '..'` — the basename strip of a name that
         traverses *through* a subdir collapses to `..`, then the
@@ -2400,7 +2463,7 @@ class TestFileDownloadablePathTraversal:
             "composio.core.models._files.requests.get",
             return_value=self._mock_response(b"x"),
         ):
-            with pytest.raises(IsADirectoryError):
+            with pytest.raises(OSError):
                 f.download(outdir)
         # outdir got created (mkdir runs after the check, which passed),
         # but no file was written inside it.

--- a/python/tests/test_tool_router_session_files.py
+++ b/python/tests/test_tool_router_session_files.py
@@ -4,8 +4,11 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 
 from composio.core.models.tool_router_session_files import (
+    _CONNECT_TIMEOUT,
+    _READ_TIMEOUT,
     RemoteFile,
     ToolRouterSessionFilesMount,
 )
@@ -101,6 +104,12 @@ class TestToolRouterSessionFilesMount:
 
             assert isinstance(result, RemoteFile)
             assert result.mount_relative_path == "output/test.txt"
+            mock_put.assert_called_once_with(
+                "https://s3.example.com/upload",
+                data=b"hello world",
+                headers={"Content-Type": "text/plain"},
+                timeout=(_CONNECT_TIMEOUT, _READ_TIMEOUT),
+            )
             mock_client.tool_router.session.files.create_upload_url.assert_called_once()
             mock_client.tool_router.session.files.create_download_url.assert_called_once()
 
@@ -116,10 +125,26 @@ class TestToolRouterSessionFilesMount:
             result = files_mount.upload(str(test_file))
 
             assert isinstance(result, RemoteFile)
+            assert mock_put.call_args.kwargs["timeout"] == (
+                _CONNECT_TIMEOUT,
+                _READ_TIMEOUT,
+            )
             call_kwargs = (
                 mock_client.tool_router.session.files.create_upload_url.call_args[1]
             )
             assert call_kwargs["mount_relative_path"] == "report.pdf"
+
+    def test_upload_request_error_raises_validation_error(self, files_mount):
+        """Test upload wraps request errors in ValidationError."""
+        with patch("requests.put") as mock_put:
+            mock_put.side_effect = requests.exceptions.Timeout("timed out")
+
+            with pytest.raises(ValidationError, match="Failed to upload file"):
+                files_mount.upload(
+                    b"hello world",
+                    remote_path="data.txt",
+                    mimetype="text/plain",
+                )
 
     def test_download(self, files_mount, mock_client):
         """Test download returns RemoteFile."""
@@ -174,6 +199,10 @@ class TestRemoteFile:
 
             result = rf.buffer()
             assert result == b"file content"
+            mock_get.assert_called_once_with(
+                "https://example.com/file",
+                timeout=(_CONNECT_TIMEOUT, _READ_TIMEOUT),
+            )
 
     def test_buffer_failure_raises_remote_file_download_error(self):
         """Test buffer() raises RemoteFileDownloadError on HTTP error."""
@@ -192,6 +221,23 @@ class TestRemoteFile:
                 rf.buffer()
 
             assert exc_info.value.status_code == 404
+            assert exc_info.value.filename == "test.txt"
+
+    def test_buffer_request_error_raises_remote_file_download_error(self):
+        """Test buffer() wraps request errors in RemoteFileDownloadError."""
+        rf = RemoteFile(
+            expires_at="2026-01-01",
+            mount_relative_path="test.txt",
+            sandbox_mount_prefix="/mnt/files",
+            download_url="https://example.com/file",
+        )
+        with patch("requests.get") as mock_get:
+            mock_get.side_effect = requests.exceptions.Timeout("timed out")
+
+            with pytest.raises(RemoteFileDownloadError) as exc_info:
+                rf.buffer()
+
+            assert exc_info.value.download_url == "https://example.com/file"
             assert exc_info.value.filename == "test.txt"
 
     def test_text(self):


### PR DESCRIPTION
## Summary

Adds bounded connect/read timeouts to Python SDK file transfer paths that previously called `requests` without a local deadline.

Covered paths:

- `RemoteFile.buffer()` session file downloads
- `ToolRouterSessionFilesMount.upload()` presigned session file uploads
- `FileDownloadable.download()` S3/presigned file downloads
- adjacent Python file upload helpers that send bytes to presigned S3 URLs

Request-level failures are translated into the SDK's existing file errors instead of leaking raw `requests` exceptions.

Fixes #3560
Fixes #3561
Fixes #3562

## Tests

- `.venv\Scripts\python.exe -m pytest python\tests\test_tool_router_session_files.py python\tests\test_files.py -q`
- `.venv\Scripts\python.exe -m ruff check python\composio\core\models\tool_router_session_files.py python\composio\core\models\_files.py python\tests\test_tool_router_session_files.py python\tests\test_files.py`
- `git diff --check`
