### PR TITLE
changelog: PostHog region is now a per-connection field

### DIFF
--- a/docs/content/changelog/06-17-26-posthog-region.mdx
+++ b/docs/content/changelog/06-17-26-posthog-region.mdx
@@ -14,4 +14,8 @@ We have already taken care of existing connections, so nothing changes for you a
 - **[Link flow](https://docs.composio.dev/reference/api-reference/connected-accounts/postConnectedAccountsLink)**: the Region field appears when the user connects, prefilled with your default and editable.
 - **[Initiate flow](https://docs.composio.dev/reference/api-reference/connected-accounts/postConnectedAccounts)**: you set the region; the end user does not see it.
 
+### Setting a default on your auth config
+
+The region default for an auth config lives in its `shared_credentials`. If you were on the default (`us`), nothing was written there. To pin a region explicitly, set `shared_credentials` when you [create an auth config](https://docs.composio.dev/reference/api-reference/auth-configs/postAuthConfigs), or update an existing one with [patch auth config](https://docs.composio.dev/reference/api-reference/auth-configs/patchAuthConfigsByNanoid).
+
 See the [PostHog toolkit docs](https://docs.composio.dev/toolkits/posthog) for the current connection fields.

--- a/docs/content/changelog/06-17-26-posthog-region.mdx
+++ b/docs/content/changelog/06-17-26-posthog-region.mdx
@@ -1,0 +1,17 @@
+---
+title: "PostHog connections: set your data region (US or EU) per connection"
+description: "The PostHog region is now a per-connection setting. Existing connections keep their current region, so nothing changes for you."
+date: "2026-06-17"
+---
+
+The PostHog **region** (`us` or `eu`) is now set on the **connection** instead of the auth config. It used to be an auth-config setting, which fixed a single region for everyone connecting through that config, but region is really per-connection: different users can be in different regions.
+
+We have already taken care of existing connections, so nothing changes for you and there is no re-auth. If a connection was on the default (`us`), it stays on the default; if it used a different region such as `eu`, we carried that value over.
+
+### Going forward
+
+- Set `us` (US Cloud) or `eu` (EU Cloud) on the connection. The host is built as `<region>.posthog.com`, so a full URL will not work, and PostHog self-hosted (on-prem) is not supported.
+- **[Link flow](https://docs.composio.dev/reference/api-reference/connected-accounts/postConnectedAccountsLink)**: the Region field appears when the user connects, prefilled with your default and editable.
+- **[Initiate flow](https://docs.composio.dev/reference/api-reference/connected-accounts/postConnectedAccounts)**: you set the region; the end user does not see it.
+
+See the [PostHog toolkit docs](https://docs.composio.dev/toolkits/posthog) for the current connection fields.


### PR DESCRIPTION
Adds a changelog entry: the PostHog **region** (`us`/`eu`) is now a per-connection field instead of an auth-config field. Existing connections were migrated (default `us` stays default; non-default values carried over), so no user action and no re-auth.

Pairs with the customer FYI email (Linear PRO-310) and Mercury PR #24717 (field relabel "Region" + corrected `us`/`eu` description).

### Before merge
- [ ] Preview renders + appears in the changelog index: `docs-git-changelog-06-17-26-posthog-region.preview.composio.dev`
- [ ] Links resolve in preview (Link/Initiate API refs, PostHog toolkit docs)
- [ ] Publish date `2026-06-17` still correct at merge time
- [ ] Mercury PR #24717 merged (so the dashboard field already reads "Region" / `us`,`eu`)

Local `bun run build` green (1412/1412 static pages).