### PR TITLE
docs: pin Changelog directly under Overview in API reference sidebar

### DIFF
--- a/docs/app/(home)/reference/(v31)/layout.tsx
+++ b/docs/app/(home)/reference/(v31)/layout.tsx
@@ -7,10 +7,11 @@ export default async function Layout({ children }: { children: ReactNode }) {
   const source = await getReferenceSource();
   const tree = prepareTree(source.pageTree, '3.1');
   const changelogPage = { type: 'page' as const, name: 'Changelog', url: '/reference/changelog' };
-  const errorsIdx = tree.children.findIndex(
-    (child: { type: string; name?: string }) => child.type === 'page' && child.name === 'Errors'
+  // Pin Changelog directly beneath Overview (the first/top entry) in the sidebar.
+  const overviewIdx = tree.children.findIndex(
+    (child: { type: string; name?: string }) => child.type === 'page' && child.name === 'Overview'
   );
-  const insertIdx = errorsIdx === -1 ? Math.min(4, tree.children.length) : errorsIdx + 1;
+  const insertIdx = overviewIdx === -1 ? Math.min(1, tree.children.length) : overviewIdx + 1;
   const pageTree = {
     ...tree,
     children: [


### PR DESCRIPTION
## What
Move the **Changelog** entry in the API Reference sidebar so it sits **immediately below Overview** (second item from the top), instead of after **Errors**.

## Why
Requested placement — Changelog should be pinned right under Overview at the top of the Reference nav for visibility.

## How
The Changelog node is injected programmatically in `app/(home)/reference/(v31)/layout.tsx` (it's not a `meta.json` page). Previously it was inserted at `errorsIdx + 1`; now it's inserted at `overviewIdx + 1`, with a safe fallback to position 1 if "Overview" isn't found.

Before: `Overview → Authentication → Rate Limits → Errors → Changelog → API Reference → …`
After: `Overview → Changelog → Authentication → Rate Limits → Errors → API Reference → …`

Only affects the v3.1 (default) Reference layout; the v3 layout doesn't inject a Changelog node.

## Verification
- `bun run types:check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)