### PR TITLE
fix(docs): simplify staging data sync URLs

### DIFF
--- a/.github/workflows/docs-update-data.yml
+++ b/.github/workflows/docs-update-data.yml
@@ -55,16 +55,10 @@ jobs:
             exit 1
           fi
 
-          if [[ "$staging_base" == */api/v3 ]]; then
-            staging_v3_base="$staging_base"
-            staging_v31_base="${staging_base%/api/v3}/api/v3.1"
-          elif [[ "$staging_base" == */api/v3.1 ]]; then
-            staging_v3_base="${staging_base%/api/v3.1}/api/v3"
-            staging_v31_base="$staging_base"
-          else
-            staging_v3_base="$staging_base/api/v3"
-            staging_v31_base="$staging_base/api/v3.1"
-          fi
+          staging_origin="${staging_base%/api/v3.1}"
+          staging_origin="${staging_origin%/api/v3}"
+          staging_v3_base="$staging_origin/api/v3"
+          staging_v31_base="$staging_origin/api/v3.1"
 
           {
             echo "COMPOSIO_API_BASE=$staging_v3_base"
@@ -108,6 +102,7 @@ jobs:
         if: steps.changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
+          token: ${{ secrets.CI_BOT_TOKEN }}
           commit-message: 'docs: update toolkits and API data'
           title: 'docs: update toolkits, API spec, and meta tools data'
           body: |
@@ -133,7 +128,7 @@ jobs:
         if: steps.create-pr.outputs.pull-request-number
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
           PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
           AUTHOR: ${{ github.actor }}
         run: |


### PR DESCRIPTION
This PR:

- simplifies `COMPOSIO_BASE_URL_STAGING` handling by stripping optional `/api/v3` or `/api/v3.1` suffixes before deriving both docs API endpoints
- removes the URL-shape branching that rejected the current staging secret
- keeps the production backend guard so the update-data workflow does not use `https://backend.composio.dev`
- uses `CI_BOT_TOKEN` for `peter-evans/create-pull-request` and reviewer requests because `GITHUB_TOKEN` cannot create pull requests in this repo
- verified with `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/docs-update-data.yml`, `git diff --check`, and shell URL derivation checks