### PR TITLE
fix(docs): use app token for data sync PRs

### DIFF
--- a/.github/workflows/docs-update-data.yml
+++ b/.github/workflows/docs-update-data.yml
@@ -20,8 +20,17 @@ jobs:
       COMPOSIO_API_KEY: ${{ secrets.COMPOSIO_API_KEY }}
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Log trigger source
         env:
@@ -102,7 +111,7 @@ jobs:
         if: steps.changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.CI_BOT_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: 'docs: update toolkits and API data'
           title: 'docs: update toolkits, API spec, and meta tools data'
           body: |
@@ -128,7 +137,7 @@ jobs:
         if: steps.create-pr.outputs.pull-request-number
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
           AUTHOR: ${{ github.actor }}
         run: |


### PR DESCRIPTION
This PR:

- adds the same `actions/create-github-app-token` setup used by the SDK docs generator
- checks out the repository with the generated app token
- passes the app token to `peter-evans/create-pull-request`
- uses the app token for the optional reviewer request
- fixes the current `Docs - Update Data` failure where `CI_BOT_TOKEN` cannot authenticate the git push for `docs/auto-update-data`
- verified with `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/docs-update-data.yml` and `git diff --check`