### PR TITLE
docs: add Notion connection expiry FAQ

### DIFF
--- a/docs/content/toolkits/faq/notion.md
+++ b/docs/content/toolkits/faq/notion.md
@@ -14,6 +14,12 @@ No. Notion controls access by granting integrations access to specific pages and
 
 It depends on the integration type. OAuth apps (public) let users select which pages to share during authorization. Internal integrations (API key) have page access managed in the integration settings.
 
+## Reasons for Notion Connection expiry
+
+- **The user disconnects the integration from Notion.** Notion documents that OAuth-installed public connections appear under `Settings` -> `Connections` and can be disconnected from the workspace. If a user removes the Composio-managed or custom Notion app there, the existing token set should be treated as revoked, and the user should reconnect Notion. See Notion's official guide to [adding and managing workspace connections](https://www.notion.com/help/add-and-manage-connections-with-the-api).
+
+- **The same Notion user connects again through the same Notion app.** When a Notion user connects to a Notion app, Notion issues a new `access_token` and `refresh_token` pair for that connection. If the same user connects to the same Notion app again, whether it is Composio-managed or custom, Notion can issue a new token pair and invalidate the older `refresh_token`. The older `access_token` may continue working for some time, but once it expires, the older connection can no longer refresh and should be treated as expired. To avoid this, keep one active Notion connection per real user for a given Notion app, reuse that existing connection in your product, and avoid asking users to reconnect repeatedly. For production Notion integrations, we strongly recommend using your own Notion app so your users' tokens are isolated to your product. Follow the [Notion OAuth setup guide](https://composio.dev/auth/notion).
+
 ## How do I set up the Notion webhook ingress endpoint?
 
 With Composio-managed Notion credentials, the webhook ingress endpoint is already provisioned — just create the trigger. If you bring your own Notion OAuth app, the verification flow runs in reverse from Slack's: Notion sends a verification token to the ingress endpoint, and you paste that token back into Notion to finalize.


### PR DESCRIPTION
## Summary
- Add a Notion FAQ entry for connection expiry reasons.
- Cover user-initiated revocation/removal from Notion workspace connections.
- Cover the same-user/same-OAuth-app reconnection pattern that can leave older Composio-managed connections with stale tokens.

## Validation
- `git diff --check`
- `bun run scripts/validate-links.ts` could not run because `bun install --frozen-lockfile` fails with existing docs lockfile drift: `lockfile had changes, but lockfile is frozen`.
