### PR TITLE
fix(ts/e2e): stabilize Tool Router e2e tests

### DIFF
--- a/ts/e2e-tests/runtimes/cloudflare/cf-workers-basic/test/platform.spec.ts
+++ b/ts/e2e-tests/runtimes/cloudflare/cf-workers-basic/test/platform.spec.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from 'vitest';
 import app from '../src/index';
 
 const IncomingRequest = Request<unknown, IncomingRequestCfProperties>;
+const LIVE_API_TEST_TIMEOUT_MS = 30_000;
 
 describe('@composio/core Cloudflare Workers compatibility', () => {
   it('should list the available endpoints', async () => {
@@ -89,29 +90,33 @@ describe('@composio/core Cloudflare Workers compatibility', () => {
     expect(body.error).toContain('not supported in Cloudflare Workers');
   });
 
-  it('should fetch HackerNews user pg successfully', async () => {
-    const request = new IncomingRequest('http://localhost/test/hackernews');
-    const ctx = createExecutionContext();
-    const response = await app.fetch(request, env, ctx);
-    await waitOnExecutionContext(ctx);
+  it(
+    'should fetch HackerNews user pg successfully',
+    async () => {
+      const request = new IncomingRequest('http://localhost/test/hackernews');
+      const ctx = createExecutionContext();
+      const response = await app.fetch(request, env, ctx);
+      await waitOnExecutionContext(ctx);
 
-    const body = (await response.json()) as {
-      success: boolean;
-      message?: string;
-      error?: string;
-      data?: {
-        username: string;
-        karma: number;
-        about?: string;
+      const body = (await response.json()) as {
+        success: boolean;
+        message?: string;
+        error?: string;
+        data?: {
+          username: string;
+          karma: number;
+          about?: string;
+        };
       };
-    };
 
-    console.log('HackerNews response:', JSON.stringify(body, null, 2));
+      console.log('HackerNews response:', JSON.stringify(body, null, 2));
 
-    expect(response.status).toBe(200);
-    expect(body.success).toBe(true);
-    expect(body.message).toContain('pg');
-    expect(body.data?.username).toBe('pg');
-    expect(body.data?.karma).toBeGreaterThan(0);
-  });
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.message).toContain('pg');
+      expect(body.data?.username).toBe('pg');
+      expect(body.data?.karma).toBeGreaterThan(0);
+    },
+    LIVE_API_TEST_TIMEOUT_MS
+  );
 });

--- a/ts/e2e-tests/runtimes/cloudflare/cf-workers-tool-router-ai/src/index.ts
+++ b/ts/e2e-tests/runtimes/cloudflare/cf-workers-tool-router-ai/src/index.ts
@@ -147,7 +147,7 @@ app.get('/test/agent', async c => {
     model: openai('gpt-5.1-codex'),
     prompt: `Look up the HackerNews user "pg" with HACKERNEWS_GET_USER.`,
     toolChoice: { type: 'tool', toolName: 'HACKERNEWS_GET_USER' },
-    stopWhen: stepCountIs(10),
+    stopWhen: stepCountIs(1),
     tools,
   });
 

--- a/ts/e2e-tests/runtimes/cloudflare/cf-workers-tool-router-ai/src/index.ts
+++ b/ts/e2e-tests/runtimes/cloudflare/cf-workers-tool-router-ai/src/index.ts
@@ -7,9 +7,8 @@ import { createOpenAI } from '@ai-sdk/openai';
 import { createMCPClient } from '@ai-sdk/mcp';
 import { Composio } from '@composio/core';
 import { VercelProvider } from '@composio/vercel';
-import { generateText, Output, stepCountIs } from 'ai';
+import { generateText, stepCountIs } from 'ai';
 import { Hono } from 'hono';
-import { z } from 'zod/v4';
 
 type Bindings = {
   COMPOSIO_API_KEY: string;
@@ -146,12 +145,7 @@ app.get('/test/agent', async c => {
 
   const result = await generateText({
     model: openai('gpt-5.1-codex'),
-    prompt: `Look up the HackerNews user "pg" with HACKERNEWS_GET_USER. Return the exact karma value from that tool result.`,
-    output: Output.object({
-      schema: z.object({
-        karma: z.number(),
-      }),
-    }),
+    prompt: `Look up the HackerNews user "pg" with HACKERNEWS_GET_USER.`,
     toolChoice: { type: 'tool', toolName: 'HACKERNEWS_GET_USER' },
     stopWhen: stepCountIs(10),
     tools,
@@ -175,7 +169,7 @@ app.get('/test/agent', async c => {
     toolCalls,
     toolResults,
     observedKarma,
-    response: result.output,
+    response: { karma: observedKarma },
   });
 });
 

--- a/ts/e2e-tests/runtimes/cloudflare/cf-workers-tool-router-ai/src/index.ts
+++ b/ts/e2e-tests/runtimes/cloudflare/cf-workers-tool-router-ai/src/index.ts
@@ -121,6 +121,7 @@ app.get('/test/agent', async c => {
   const session = await composio.create('default', {
     toolkits: ['hackernews'],
     manageConnections: true,
+    preload: { tools: ['HACKERNEWS_GET_USER'] },
     tools: {
       hackernews: {
         enable: ['HACKERNEWS_GET_USER'],
@@ -145,12 +146,13 @@ app.get('/test/agent', async c => {
 
   const result = await generateText({
     model: openai('gpt-5.1-codex'),
-    prompt: `Use the available tools to look up the HackerNews user "pg". Return the exact karma value from the HackerNews tool result.`,
+    prompt: `Look up the HackerNews user "pg" with HACKERNEWS_GET_USER. Return the exact karma value from that tool result.`,
     output: Output.object({
       schema: z.object({
         karma: z.number(),
       }),
     }),
+    toolChoice: { type: 'tool', toolName: 'HACKERNEWS_GET_USER' },
     stopWhen: stepCountIs(10),
     tools,
   });

--- a/ts/e2e-tests/runtimes/cloudflare/cf-workers-tool-router-ai/src/index.ts
+++ b/ts/e2e-tests/runtimes/cloudflare/cf-workers-tool-router-ai/src/index.ts
@@ -19,6 +19,21 @@ type Bindings = {
 
 const app = new Hono<{ Bindings: Bindings }>();
 
+const hackerNewsUserOutputSchema = z
+  .union([
+    z.object({
+      username: z.string().optional(),
+      karma: z.number(),
+    }),
+    z.object({
+      data: z.object({
+        username: z.string().optional(),
+        karma: z.number(),
+      }),
+    }),
+  ])
+  .transform(output => ('data' in output ? output.data : output));
+
 /**
  * Default route - lists available test endpoints
  */
@@ -104,7 +119,16 @@ app.get('/test/agent', async c => {
   // Intentionally do not close the HTTP MCP client here: in workerd, @ai-sdk/mcp
   // aborts the pending stream and Vitest reports it as an unhandled rejection.
 
-  const tools = await mcpClient.tools();
+  const tools = await mcpClient.tools({
+    schemas: {
+      HACKERNEWS_GET_USER: {
+        inputSchema: z.object({
+          username: z.string(),
+        }),
+        outputSchema: hackerNewsUserOutputSchema,
+      },
+    },
+  });
   const openai = createOpenAI({ apiKey: c.env.OPENAI_API_KEY });
 
   const result = await generateText({

--- a/ts/e2e-tests/runtimes/cloudflare/cf-workers-tool-router-ai/src/index.ts
+++ b/ts/e2e-tests/runtimes/cloudflare/cf-workers-tool-router-ai/src/index.ts
@@ -17,6 +17,43 @@ type Bindings = {
   OPENAI_API_KEY: string;
 };
 
+const findNumberProperty = (value: unknown, propertyName: string): number | undefined => {
+  if (typeof value === 'string') {
+    try {
+      return findNumberProperty(JSON.parse(value), propertyName);
+    } catch {
+      return undefined;
+    }
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const nestedValue = findNumberProperty(item, propertyName);
+      if (nestedValue !== undefined) {
+        return nestedValue;
+      }
+    }
+  }
+
+  if (typeof value !== 'object' || value === null) {
+    return undefined;
+  }
+
+  const record = value as Record<string, unknown>;
+  if (typeof record[propertyName] === 'number') {
+    return record[propertyName];
+  }
+
+  for (const nestedValue of Object.values(record)) {
+    const result = findNumberProperty(nestedValue, propertyName);
+    if (result !== undefined) {
+      return result;
+    }
+  }
+
+  return undefined;
+};
+
 const app = new Hono<{ Bindings: Bindings }>();
 
 /**
@@ -25,10 +62,7 @@ const app = new Hono<{ Bindings: Bindings }>();
 app.get('/', c => {
   return c.json({
     message: 'Tool Router AI E2E Test Worker',
-    endpoints: [
-      '/test/mcp-client',
-      '/test/agent',
-    ],
+    endpoints: ['/test/mcp-client', '/test/agent'],
   });
 });
 
@@ -55,15 +89,15 @@ app.get('/test/mcp-client', async c => {
 
   const { mcp } = session;
 
-  const mcpClient = await createMCPClient({
+  await createMCPClient({
     transport: {
       type: 'http',
       url: mcp.url,
       headers: mcp.headers,
     },
   });
-
-  c.executionCtx.waitUntil(mcpClient.close());
+  // Intentionally do not close the HTTP MCP client here: in workerd, @ai-sdk/mcp
+  // aborts the pending stream and Vitest reports it as an unhandled rejection.
 
   return c.json({
     message: 'MCP client connected successfully',
@@ -74,7 +108,7 @@ app.get('/test/mcp-client', async c => {
 /**
  * Test: Agent Execution
  * Tests the full workflow: create session, get tools, run agent with generateText.
- * 
+ *
  * Note: this takes ~40s locally.
  */
 app.get('/test/agent', async c => {
@@ -103,37 +137,44 @@ app.get('/test/agent', async c => {
       headers: mcp.headers,
     },
   });
+  // Intentionally do not close the HTTP MCP client here: in workerd, @ai-sdk/mcp
+  // aborts the pending stream and Vitest reports it as an unhandled rejection.
 
-  try {
-    const tools = await mcpClient.tools();
-    const openai = createOpenAI({ apiKey: c.env.OPENAI_API_KEY });
-  
-    const result = await generateText({
-      model: openai('gpt-5.1-codex'),
-      prompt: `Look up the HackerNews user "pg", and tell me their karma score.`,
-      output: Output.object({
-        schema: z.object({
-          karma: z.number(),
-        }),
+  const tools = await mcpClient.tools();
+  const openai = createOpenAI({ apiKey: c.env.OPENAI_API_KEY });
+
+  const result = await generateText({
+    model: openai('gpt-5.1-codex'),
+    prompt: `Use the available tools to look up the HackerNews user "pg". Return the exact karma value from the HackerNews tool result.`,
+    output: Output.object({
+      schema: z.object({
+        karma: z.number(),
       }),
-      stopWhen: stepCountIs(10),
-      tools,
-    });
-  
-    const toolCalls = result.steps.flatMap(step =>
-      step.toolCalls.map(tc => ({ toolName: tc.toolName }))
-    );
+    }),
+    stopWhen: stepCountIs(10),
+    tools,
+  });
 
-    return c.json({
-      message: 'Agent executed successfully',
-      sessionId,
-      toolCount: Object.keys(tools).length,
-      toolCalls,
-      response: result.output,
-    });
-  } finally {
-    c.executionCtx.waitUntil(mcpClient.close());
-  }
+  const toolCalls = result.steps.flatMap(step =>
+    step.toolCalls.map(toolCall => ({ toolName: toolCall.toolName }))
+  );
+  const toolResults = result.steps.flatMap(step =>
+    step.toolResults.map(toolResult => ({
+      toolName: toolResult.toolName,
+      output: toolResult.output,
+    }))
+  );
+  const observedKarma = findNumberProperty(toolResults, 'karma');
+
+  return c.json({
+    message: 'Agent executed successfully',
+    sessionId,
+    toolCount: Object.keys(tools).length,
+    toolCalls,
+    toolResults,
+    observedKarma,
+    response: result.output,
+  });
 });
 
 export default app;

--- a/ts/e2e-tests/runtimes/cloudflare/cf-workers-tool-router-ai/src/index.ts
+++ b/ts/e2e-tests/runtimes/cloudflare/cf-workers-tool-router-ai/src/index.ts
@@ -7,8 +7,9 @@ import { createOpenAI } from '@ai-sdk/openai';
 import { createMCPClient } from '@ai-sdk/mcp';
 import { Composio } from '@composio/core';
 import { VercelProvider } from '@composio/vercel';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, Output, stepCountIs } from 'ai';
 import { Hono } from 'hono';
+import { z } from 'zod/v4';
 
 type Bindings = {
   COMPOSIO_API_KEY: string;
@@ -145,9 +146,23 @@ app.get('/test/agent', async c => {
 
   const result = await generateText({
     model: openai('gpt-5.1-codex'),
-    prompt: `Look up the HackerNews user "pg" with HACKERNEWS_GET_USER.`,
-    toolChoice: { type: 'tool', toolName: 'HACKERNEWS_GET_USER' },
-    stopWhen: stepCountIs(1),
+    prompt: `Look up the HackerNews user "pg" with HACKERNEWS_GET_USER, then return the exact karma value from that tool result.`,
+    output: Output.object({
+      schema: z.object({
+        karma: z.number(),
+      }),
+    }),
+    prepareStep: ({ stepNumber }) =>
+      stepNumber === 0
+        ? {
+            activeTools: ['HACKERNEWS_GET_USER'],
+            toolChoice: { type: 'tool', toolName: 'HACKERNEWS_GET_USER' },
+          }
+        : {
+            activeTools: [],
+            toolChoice: 'none',
+          },
+    stopWhen: stepCountIs(2),
     tools,
   });
 
@@ -169,7 +184,7 @@ app.get('/test/agent', async c => {
     toolCalls,
     toolResults,
     observedKarma,
-    response: { karma: observedKarma },
+    response: result.output,
   });
 });
 

--- a/ts/e2e-tests/runtimes/cloudflare/cf-workers-tool-router-ai/src/index.ts
+++ b/ts/e2e-tests/runtimes/cloudflare/cf-workers-tool-router-ai/src/index.ts
@@ -17,43 +17,6 @@ type Bindings = {
   OPENAI_API_KEY: string;
 };
 
-const findNumberProperty = (value: unknown, propertyName: string): number | undefined => {
-  if (typeof value === 'string') {
-    try {
-      return findNumberProperty(JSON.parse(value), propertyName);
-    } catch {
-      return undefined;
-    }
-  }
-
-  if (Array.isArray(value)) {
-    for (const item of value) {
-      const nestedValue = findNumberProperty(item, propertyName);
-      if (nestedValue !== undefined) {
-        return nestedValue;
-      }
-    }
-  }
-
-  if (typeof value !== 'object' || value === null) {
-    return undefined;
-  }
-
-  const record = value as Record<string, unknown>;
-  if (typeof record[propertyName] === 'number') {
-    return record[propertyName];
-  }
-
-  for (const nestedValue of Object.values(record)) {
-    const result = findNumberProperty(nestedValue, propertyName);
-    if (result !== undefined) {
-      return result;
-    }
-  }
-
-  return undefined;
-};
-
 const app = new Hono<{ Bindings: Bindings }>();
 
 /**
@@ -152,17 +115,7 @@ app.get('/test/agent', async c => {
         karma: z.number(),
       }),
     }),
-    prepareStep: ({ stepNumber }) =>
-      stepNumber === 0
-        ? {
-            activeTools: ['HACKERNEWS_GET_USER'],
-            toolChoice: { type: 'tool', toolName: 'HACKERNEWS_GET_USER' },
-          }
-        : {
-            activeTools: [],
-            toolChoice: 'none',
-          },
-    stopWhen: stepCountIs(2),
+    stopWhen: stepCountIs(10),
     tools,
   });
 
@@ -175,7 +128,6 @@ app.get('/test/agent', async c => {
       output: toolResult.output,
     }))
   );
-  const observedKarma = findNumberProperty(toolResults, 'karma');
 
   return c.json({
     message: 'Agent executed successfully',
@@ -183,7 +135,6 @@ app.get('/test/agent', async c => {
     toolCount: Object.keys(tools).length,
     toolCalls,
     toolResults,
-    observedKarma,
     response: result.output,
   });
 });

--- a/ts/e2e-tests/runtimes/cloudflare/cf-workers-tool-router-ai/test/tool-router-ai.spec.ts
+++ b/ts/e2e-tests/runtimes/cloudflare/cf-workers-tool-router-ai/test/tool-router-ai.spec.ts
@@ -75,6 +75,7 @@ describe('Tool Router AI - Cloudflare Workers compatibility', () => {
     expect(typeof body.response.karma).toEqual('number');
     expect(body.toolResults).toBeDefined();
     expect(body.observedKarma).toBeGreaterThan(150_000);
+    expect(body.response.karma).toBe(body.observedKarma);
 
     expect(body.toolCalls).toContainEqual({ toolName: 'HACKERNEWS_GET_USER' });
   });

--- a/ts/e2e-tests/runtimes/cloudflare/cf-workers-tool-router-ai/test/tool-router-ai.spec.ts
+++ b/ts/e2e-tests/runtimes/cloudflare/cf-workers-tool-router-ai/test/tool-router-ai.spec.ts
@@ -76,6 +76,6 @@ describe('Tool Router AI - Cloudflare Workers compatibility', () => {
     expect(body.toolResults).toBeDefined();
     expect(body.observedKarma).toBeGreaterThan(150_000);
 
-    expect(body.toolCalls).toContainEqual({ toolName: 'COMPOSIO_SEARCH_TOOLS' });
+    expect(body.toolCalls).toContainEqual({ toolName: 'HACKERNEWS_GET_USER' });
   });
 });

--- a/ts/e2e-tests/runtimes/cloudflare/cf-workers-tool-router-ai/test/tool-router-ai.spec.ts
+++ b/ts/e2e-tests/runtimes/cloudflare/cf-workers-tool-router-ai/test/tool-router-ai.spec.ts
@@ -59,7 +59,6 @@ describe('Tool Router AI - Cloudflare Workers compatibility', () => {
       toolCount?: number;
       toolCalls?: Array<{ toolName: string }>;
       toolResults?: Array<{ toolName: string; output: unknown }>;
-      observedKarma?: number;
       response: {
         karma: number;
       };
@@ -74,9 +73,6 @@ describe('Tool Router AI - Cloudflare Workers compatibility', () => {
     expect(body.response.karma).toBeDefined();
     expect(typeof body.response.karma).toEqual('number');
     expect(body.toolResults).toBeDefined();
-    expect(body.observedKarma).toBeGreaterThan(150_000);
-    expect(body.response.karma).toBe(body.observedKarma);
-
-    expect(body.toolCalls).toContainEqual({ toolName: 'HACKERNEWS_GET_USER' });
+    expect(body.response.karma).toBeGreaterThan(150_000);
   });
 });

--- a/ts/e2e-tests/runtimes/cloudflare/cf-workers-tool-router-ai/test/tool-router-ai.spec.ts
+++ b/ts/e2e-tests/runtimes/cloudflare/cf-workers-tool-router-ai/test/tool-router-ai.spec.ts
@@ -4,6 +4,11 @@ import app from '../src/index';
 
 const IncomingRequest = Request<unknown, IncomingRequestCfProperties>;
 
+type HackerNewsUserOutput = {
+  username?: string;
+  karma: number;
+};
+
 describe('Tool Router AI - Cloudflare Workers compatibility', () => {
   it('should list the available endpoints', async () => {
     const request = new IncomingRequest('http://localhost/');
@@ -58,7 +63,7 @@ describe('Tool Router AI - Cloudflare Workers compatibility', () => {
       sessionId?: string;
       toolCount?: number;
       toolCalls?: Array<{ toolName: string }>;
-      toolResults?: Array<{ toolName: string; output: unknown }>;
+      toolResults?: Array<{ toolName: string; output: HackerNewsUserOutput }>;
       response: {
         karma: number;
       };
@@ -72,7 +77,15 @@ describe('Tool Router AI - Cloudflare Workers compatibility', () => {
     expect(body.response).toBeDefined();
     expect(body.response.karma).toBeDefined();
     expect(typeof body.response.karma).toEqual('number');
-    expect(body.toolResults).toBeDefined();
     expect(body.response.karma).toBeGreaterThan(150_000);
+
+    expect(body.toolCalls).toContainEqual({ toolName: 'HACKERNEWS_GET_USER' });
+
+    const hackerNewsToolResult = body.toolResults?.find(
+      toolResult => toolResult.toolName === 'HACKERNEWS_GET_USER'
+    );
+
+    expect(hackerNewsToolResult).toBeDefined();
+    expect(hackerNewsToolResult?.output.karma).toBe(body.response.karma);
   });
 });

--- a/ts/e2e-tests/runtimes/cloudflare/cf-workers-tool-router-ai/test/tool-router-ai.spec.ts
+++ b/ts/e2e-tests/runtimes/cloudflare/cf-workers-tool-router-ai/test/tool-router-ai.spec.ts
@@ -58,6 +58,8 @@ describe('Tool Router AI - Cloudflare Workers compatibility', () => {
       sessionId?: string;
       toolCount?: number;
       toolCalls?: Array<{ toolName: string }>;
+      toolResults?: Array<{ toolName: string; output: unknown }>;
+      observedKarma?: number;
       response: {
         karma: number;
       };
@@ -71,7 +73,8 @@ describe('Tool Router AI - Cloudflare Workers compatibility', () => {
     expect(body.response).toBeDefined();
     expect(body.response.karma).toBeDefined();
     expect(typeof body.response.karma).toEqual('number');
-    expect(body.response.karma).toBeGreaterThan(150_000);
+    expect(body.toolResults).toBeDefined();
+    expect(body.observedKarma).toBeGreaterThan(150_000);
 
     expect(body.toolCalls).toContainEqual({ toolName: 'COMPOSIO_SEARCH_TOOLS' });
   });

--- a/ts/e2e-tests/runtimes/node/mastra-tool-router-zod-v3/e2e.test.ts
+++ b/ts/e2e-tests/runtimes/node/mastra-tool-router-zod-v3/e2e.test.ts
@@ -2,7 +2,7 @@
  * @composio/mastra + openai + zod 3
  *
  * Verifies that @composio/mastra works correctly with zod@3.
- * 
+ *
  * See: https://github.com/ComposioHQ/composio/issues/2109.
  */
 
@@ -16,6 +16,8 @@ import { describe, it, expect } from 'bun:test';
 import { createOpenAI } from '@ai-sdk/openai';
 import { stepCountIs } from 'ai';
 import { z } from 'zod';
+
+const MCP_CONNECT_TIMEOUT_MS = 15_000;
 
 declare module 'bun' {
   interface Env {
@@ -31,74 +33,80 @@ e2e(import.meta.url, {
     OPENAI_API_KEY: Bun.env.OPENAI_API_KEY,
   },
   defineTests: () => {
-    describe('@composio/mastra + openai + zod 4', () => {
-
+    describe('@composio/mastra + openai + zod 3', () => {
       const composio = new Composio({
         apiKey: Bun.env.COMPOSIO_API_KEY,
         provider: new MastraProvider(),
       });
-      
-      it('should work with Tool Router', async () => {
-        const session = await composio.create('default', {
-          toolkits: ['hackernews'],
-          manageConnections: true,
-          tools: {
-            hackernews: {
-              enable: ['HACKERNEWS_GET_USER'],
-            },
-          },
-        });
 
-        const { mcp, sessionId } = session;
-        expect(sessionId).toBeDefined();
-
-        // Create a client with an HTTP server (tries Streamable HTTP, falls back to SSE)
-        const mcpClient = new MCPClient({
-          servers: {
-            myHttpClient: {
-              url: new URL(mcp.url),
-              requestInit: {
-                headers: mcp.headers,
+      it(
+        'should work with Tool Router',
+        async () => {
+          const session = await composio.create('default', {
+            toolkits: ['hackernews'],
+            manageConnections: true,
+            tools: {
+              hackernews: {
+                enable: ['HACKERNEWS_GET_USER'],
               },
             },
-          },
-        });
+          });
 
-        const tools = await mcpClient.listTools();
-        const openai = createOpenAI({ apiKey: Bun.env.OPENAI_API_KEY });
+          const { mcp, sessionId } = session;
+          expect(sessionId).toBeDefined();
 
-        const hackernewsAgent = new Agent({
-          id: 'test',
-          name: 'test',
-          instructions: `You're a helpful Hackernews agent, able to finding information about users.`,
-          model: openai('gpt-5.1'),
-          tools,
-        });
+          // Create a client with an HTTP server (tries Streamable HTTP, falls back to SSE)
+          const mcpClient = new MCPClient({
+            timeout: TIMEOUTS.LLM_SHORT,
+            servers: {
+              myHttpClient: {
+                url: new URL(mcp.url),
+                connectTimeout: MCP_CONNECT_TIMEOUT_MS,
+                requestInit: {
+                  headers: mcp.headers,
+                },
+              },
+            },
+          });
 
-        const result = await hackernewsAgent.generate('Look up user "pg", and tell me their karma score.', {
-          structuredOutput: {
-            schema: z.object({
-              karma: z.number(),
-            }),
-          },
-          stopWhen: stepCountIs(10),
-        });
+          const tools = await mcpClient.listTools();
+          const openai = createOpenAI({ apiKey: Bun.env.OPENAI_API_KEY });
 
-        const toolCalls = result.toolCalls.flatMap(toolCall =>
-          toolCall.payload.toolName
-        );
-        const toolCount = Object.keys(tools).length;
+          const hackernewsAgent = new Agent({
+            id: 'test',
+            name: 'test',
+            instructions: `You're a helpful Hackernews agent, able to finding information about users.`,
+            model: openai('gpt-5.1'),
+            tools,
+          });
 
-        expect(toolCount).toBeGreaterThan(0);
-        expect(toolCalls).toBeDefined();
-        expect(result.error).toBeUndefined();
-        expect(result.object).toBeDefined();
-        expect(result.object.karma).toBeGreaterThan(0);
-      
-        await mcpClient.disconnect();
-      }, {
-        timeout: TIMEOUTS.LLM_SHORT,
-      });
+          const result = await hackernewsAgent.generate(
+            'Look up user "pg", and tell me their karma score.',
+            {
+              structuredOutput: {
+                schema: z.object({
+                  karma: z.number(),
+                }),
+              },
+              stopWhen: stepCountIs(10),
+            }
+          );
+
+          const toolCalls = result.toolCalls.flatMap(toolCall => toolCall.payload.toolName);
+          const toolCount = Object.keys(tools).length;
+
+          expect(toolCount).toBeGreaterThan(0);
+          expect(toolCalls).toBeDefined();
+          expect(result.error).toBeUndefined();
+          expect(result.object).toBeDefined();
+          expect(result.object.karma).toBeGreaterThan(0);
+
+          await mcpClient.disconnect();
+        },
+        {
+          timeout: TIMEOUTS.LLM_SHORT,
+        }
+      );
     });
-  }
+  },
 });

--- a/ts/e2e-tests/runtimes/node/mastra-tool-router-zod-v3/e2e.test.ts
+++ b/ts/e2e-tests/runtimes/node/mastra-tool-router-zod-v3/e2e.test.ts
@@ -57,7 +57,7 @@ e2e(import.meta.url, {
 
           // Create a client with an HTTP server (tries Streamable HTTP, falls back to SSE)
           const mcpClient = new MCPClient({
-            timeout: TIMEOUTS.LLM_SHORT,
+            timeout: TIMEOUTS.LLM_LONG,
             servers: {
               myHttpClient: {
                 url: new URL(mcp.url),
@@ -104,7 +104,7 @@ e2e(import.meta.url, {
           await mcpClient.disconnect();
         },
         {
-          timeout: TIMEOUTS.LLM_SHORT,
+          timeout: TIMEOUTS.LLM_LONG,
         }
       );
     });

--- a/ts/e2e-tests/runtimes/node/mastra-tool-router-zod-v4/e2e.test.ts
+++ b/ts/e2e-tests/runtimes/node/mastra-tool-router-zod-v4/e2e.test.ts
@@ -2,7 +2,7 @@
  * @composio/mastra + openai + zod 4
  *
  * Verifies that @composio/mastra works correctly with zod@4.
- * 
+ *
  * See: https://github.com/ComposioHQ/composio/issues/2109.
  */
 
@@ -16,6 +16,8 @@ import { describe, it, expect } from 'bun:test';
 import { createOpenAI } from '@ai-sdk/openai';
 import { stepCountIs } from 'ai';
 import { z } from 'zod';
+
+const MCP_CONNECT_TIMEOUT_MS = 15_000;
 
 declare module 'bun' {
   interface Env {
@@ -32,73 +34,79 @@ e2e(import.meta.url, {
   },
   defineTests: () => {
     describe('@composio/mastra + openai + zod 4', () => {
-
       const composio = new Composio({
         apiKey: Bun.env.COMPOSIO_API_KEY,
         provider: new MastraProvider(),
       });
-      
-      it('should work with Tool Router', async () => {
-        const session = await composio.create('default', {
-          toolkits: ['hackernews'],
-          manageConnections: true,
-          tools: {
-            hackernews: {
-              enable: ['HACKERNEWS_GET_USER'],
-            },
-          },
-        });
 
-        const { mcp, sessionId } = session;
-        expect(sessionId).toBeDefined();
-
-        // Create a client with an HTTP server (tries Streamable HTTP, falls back to SSE)
-        const mcpClient = new MCPClient({
-          servers: {
-            myHttpClient: {
-              url: new URL(mcp.url),
-              requestInit: {
-                headers: mcp.headers,
+      it(
+        'should work with Tool Router',
+        async () => {
+          const session = await composio.create('default', {
+            toolkits: ['hackernews'],
+            manageConnections: true,
+            tools: {
+              hackernews: {
+                enable: ['HACKERNEWS_GET_USER'],
               },
             },
-          },
-        });
+          });
 
-        const tools = await mcpClient.listTools();
-        const openai = createOpenAI({ apiKey: Bun.env.OPENAI_API_KEY });
+          const { mcp, sessionId } = session;
+          expect(sessionId).toBeDefined();
 
-        const hackernewsAgent = new Agent({
-          id: 'test',
-          name: 'test',
-          instructions: `You're a helpful Hackernews agent, able to finding information about users.`,
-          model: openai('gpt-5.1'),
-          tools,
-        });
+          // Create a client with an HTTP server (tries Streamable HTTP, falls back to SSE)
+          const mcpClient = new MCPClient({
+            timeout: TIMEOUTS.LLM_SHORT,
+            servers: {
+              myHttpClient: {
+                url: new URL(mcp.url),
+                connectTimeout: MCP_CONNECT_TIMEOUT_MS,
+                requestInit: {
+                  headers: mcp.headers,
+                },
+              },
+            },
+          });
 
-        const result = await hackernewsAgent.generate('Look up user "pg", and tell me their karma score.', {
-          structuredOutput: {
-            schema: z.object({
-              karma: z.number(),
-            }),
-          },
-          stopWhen: stepCountIs(10),
-        });
+          const tools = await mcpClient.listTools();
+          const openai = createOpenAI({ apiKey: Bun.env.OPENAI_API_KEY });
 
-        const toolCalls = result.toolCalls.flatMap(toolCall =>
-          toolCall.payload.toolName
-        );
-        const toolCount = Object.keys(tools).length;
+          const hackernewsAgent = new Agent({
+            id: 'test',
+            name: 'test',
+            instructions: `You're a helpful Hackernews agent, able to finding information about users.`,
+            model: openai('gpt-5.1'),
+            tools,
+          });
 
-        expect(toolCount).toBeGreaterThan(0);
-        expect(toolCalls).toBeDefined();
-        expect(result.error).toBeUndefined();
-        expect(result.object).toBeDefined();
-        expect(result.object.karma).toBeGreaterThanOrEqual(0);
-      
-        await mcpClient.disconnect();
-      }, {
-        timeout: TIMEOUTS.LLM_SHORT,
-      });
+          const result = await hackernewsAgent.generate(
+            'Look up user "pg", and tell me their karma score.',
+            {
+              structuredOutput: {
+                schema: z.object({
+                  karma: z.number(),
+                }),
+              },
+              stopWhen: stepCountIs(10),
+            }
+          );
+
+          const toolCalls = result.toolCalls.flatMap(toolCall => toolCall.payload.toolName);
+          const toolCount = Object.keys(tools).length;
+
+          expect(toolCount).toBeGreaterThan(0);
+          expect(toolCalls).toBeDefined();
+          expect(result.error).toBeUndefined();
+          expect(result.object).toBeDefined();
+          expect(result.object.karma).toBeGreaterThanOrEqual(0);
+
+          await mcpClient.disconnect();
+        },
+        {
+          timeout: TIMEOUTS.LLM_SHORT,
+        }
+      );
     });
-  }
+  },
 });

--- a/ts/e2e-tests/runtimes/node/mastra-tool-router-zod-v4/e2e.test.ts
+++ b/ts/e2e-tests/runtimes/node/mastra-tool-router-zod-v4/e2e.test.ts
@@ -57,7 +57,7 @@ e2e(import.meta.url, {
 
           // Create a client with an HTTP server (tries Streamable HTTP, falls back to SSE)
           const mcpClient = new MCPClient({
-            timeout: TIMEOUTS.LLM_SHORT,
+            timeout: TIMEOUTS.LLM_LONG,
             servers: {
               myHttpClient: {
                 url: new URL(mcp.url),
@@ -104,7 +104,7 @@ e2e(import.meta.url, {
           await mcpClient.disconnect();
         },
         {
-          timeout: TIMEOUTS.LLM_SHORT,
+          timeout: TIMEOUTS.LLM_LONG,
         }
       );
     });


### PR DESCRIPTION
This PR:

- addresses the Mastra Tool Router E2E timeout seen in https://github.com/ComposioHQ/composio/actions/runs/27758637694/job/82126898492
- addresses the Cloudflare Tool Router AI failure seen in https://github.com/ComposioHQ/composio/actions/runs/27759741357/job/82130692480
- addresses the follow-up Cloudflare basic timeout seen in https://github.com/ComposioHQ/composio/actions/runs/27760548665/job/82133483582
- uses the existing `TIMEOUTS.LLM_LONG` live-LLM budget for both Mastra Tool Router zod-v3 and zod-v4 suites
- raises the HTTP MCP connection-phase timeout from Mastra's implicit 3s default to 15s in both zod-v3 and zod-v4 suites
- keeps the Cloudflare AI test's `Output.object({ karma })` structured output and validates the returned `response.karma`
- asserts that `HACKERNEWS_GET_USER` was called and that `response.karma` equals the structured MCP tool output
- removes the extra Cloudflare `prepareStep` steering and `findNumberProperty` extraction helper
- avoids explicit `@ai-sdk/mcp` HTTP client close calls in workerd because the close path aborts the pending stream and Vitest reports it as unhandled
- gives the live Cloudflare HackerNews compatibility test a 30s budget while leaving the fast smoke tests on Vitest's default timeout
- fixes the zod-v3 test label so it reports `zod 3` instead of `zod 4`

Verification:

- `./ts/e2e-tests/_utils/node_modules/.bin/tsc --noEmit -p ts/e2e-tests/runtimes/node/mastra-tool-router-zod-v3/tsconfig.json`
- `./ts/e2e-tests/_utils/node_modules/.bin/tsc --noEmit -p ts/e2e-tests/runtimes/node/mastra-tool-router-zod-v4/tsconfig.json`
- `pnpm exec vitest run -t "should connect to MCP server"` from `ts/e2e-tests/runtimes/cloudflare/cf-workers-tool-router-ai`
- `pnpm exec tsc --noEmit --target es2022 --lib es2022 --module es2022 --moduleResolution Bundler --resolveJsonModule --allowSyntheticDefaultImports --strict --skipLibCheck --types @cloudflare/workers-types src/index.ts` from `ts/e2e-tests/runtimes/cloudflare/cf-workers-tool-router-ai`
- `pnpm exec vitest run -t "should fetch HackerNews user pg successfully"` from `ts/e2e-tests/runtimes/cloudflare/cf-workers-basic`
- `pnpm exec vitest run` from `ts/e2e-tests/runtimes/cloudflare/cf-workers-basic`
- `pnpm exec prettier --check ts/e2e-tests/runtimes/cloudflare/cf-workers-basic/test/platform.spec.ts`
- `pnpm exec prettier --check ts/e2e-tests/runtimes/cloudflare/cf-workers-tool-router-ai/src/index.ts ts/e2e-tests/runtimes/cloudflare/cf-workers-tool-router-ai/test/tool-router-ai.spec.ts ts/e2e-tests/runtimes/node/mastra-tool-router-zod-v3/e2e.test.ts ts/e2e-tests/runtimes/node/mastra-tool-router-zod-v4/e2e.test.ts`
- `git diff --check`

CI:

- `E2E Test Typescript SDK` passed on https://github.com/ComposioHQ/composio/actions/runs/27768379357

Note: the full Cloudflare AI test was not run locally because this checkout's local `OPENAI_API_KEY` is invalid; CI has the repo secret for that path.
