### PR TITLE
chore(ci): use OIDC for TS npm releases, add needed attributes to package.json

### DIFF
--- a/.github/workflows/ts.release.yml
+++ b/.github/workflows/ts.release.yml
@@ -9,6 +9,9 @@ jobs:
   release:
     name: Release Typescript SDK
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       # Mint a short-lived GitHub App installation token instead of a long-lived
       # PAT. App tokens don't expire out from under us (the old CI_BOT_TOKEN PAT
@@ -30,6 +33,11 @@ jobs:
 
       - name: Setup Node.js, pnpm, Bun
         uses: ./.github/actions/setup-node-pnpm-bun
+        with:
+          # TODO: Once https://github.com/ComposioHQ/composio/pull/3494 lands,
+          # centralize this trusted-publishing runtime in mise.toml and drop
+          # the release-only override.
+          node-version: '24.17.0'
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
@@ -40,8 +48,6 @@ jobs:
       - name: Run Build
         run: pnpm run build:packages
 
-      - name: Set up .npmrc
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
       - name: Create Release Pull Request & Publish packages
         id: changesets
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0

--- a/ts/packages/cli-local-tools/package.json
+++ b/ts/packages/cli-local-tools/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@composio/cli-local-tools",
   "version": "0.0.5",
+  "private": true,
   "description": "Local tool and toolkit declarations for the Composio CLI.",
   "type": "module",
   "main": "dist/index.mjs",

--- a/ts/packages/core/package.json
+++ b/ts/packages/core/package.json
@@ -167,7 +167,7 @@
   "gitHead": "4fae6e54d5c150fba955cc5fa314281da5a1e064",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ComposioHQ/composio.git",
+    "url": "https://github.com/ComposioHQ/composio.git",
     "directory": "ts/packages/core"
   },
   "bugs": {

--- a/ts/packages/json-schema-to-zod/package.json
+++ b/ts/packages/json-schema-to-zod/package.json
@@ -3,6 +3,15 @@
   "version": "0.1.20",
   "description": "",
   "main": "src/index.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ComposioHQ/composio.git",
+    "directory": "ts/packages/json-schema-to-zod"
+  },
+  "bugs": {
+    "url": "https://github.com/ComposioHQ/composio/issues"
+  },
+  "homepage": "https://github.com/ComposioHQ/composio/tree/main/ts/packages/json-schema-to-zod#readme",
   "publishConfig": {
     "access": "public",
     "main": "dist/index.mjs",

--- a/ts/packages/providers/anthropic/package.json
+++ b/ts/packages/providers/anthropic/package.json
@@ -3,6 +3,15 @@
   "version": "0.9.3",
   "description": "Non-Agentic Provider for Anthropic in Composio SDK",
   "main": "src/index.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ComposioHQ/composio.git",
+    "directory": "ts/packages/providers/anthropic"
+  },
+  "bugs": {
+    "url": "https://github.com/ComposioHQ/composio/issues"
+  },
+  "homepage": "https://github.com/ComposioHQ/composio/tree/main/ts/packages/providers/anthropic#readme",
   "publishConfig": {
     "access": "public",
     "main": "dist/index.mjs",

--- a/ts/packages/providers/claude-agent-sdk/package.json
+++ b/ts/packages/providers/claude-agent-sdk/package.json
@@ -3,6 +3,15 @@
   "version": "0.9.3",
   "description": "Composio provider for Claude Agent SDK",
   "main": "src/index.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ComposioHQ/composio.git",
+    "directory": "ts/packages/providers/claude-agent-sdk"
+  },
+  "bugs": {
+    "url": "https://github.com/ComposioHQ/composio/issues"
+  },
+  "homepage": "https://github.com/ComposioHQ/composio/tree/main/ts/packages/providers/claude-agent-sdk#readme",
   "publishConfig": {
     "access": "public",
     "main": "dist/index.mjs",

--- a/ts/packages/providers/cloudflare/package.json
+++ b/ts/packages/providers/cloudflare/package.json
@@ -3,6 +3,15 @@
   "version": "0.9.3",
   "description": "",
   "main": "src/index.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ComposioHQ/composio.git",
+    "directory": "ts/packages/providers/cloudflare"
+  },
+  "bugs": {
+    "url": "https://github.com/ComposioHQ/composio/issues"
+  },
+  "homepage": "https://github.com/ComposioHQ/composio/tree/main/ts/packages/providers/cloudflare#readme",
   "publishConfig": {
     "access": "public",
     "main": "dist/index.mjs",

--- a/ts/packages/providers/google/package.json
+++ b/ts/packages/providers/google/package.json
@@ -3,6 +3,15 @@
   "version": "0.9.3",
   "description": "Google GenAI Provider for Composio SDK",
   "main": "src/index.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ComposioHQ/composio.git",
+    "directory": "ts/packages/providers/google"
+  },
+  "bugs": {
+    "url": "https://github.com/ComposioHQ/composio/issues"
+  },
+  "homepage": "https://github.com/ComposioHQ/composio/tree/main/ts/packages/providers/google#readme",
   "publishConfig": {
     "access": "public",
     "main": "dist/index.mjs",

--- a/ts/packages/providers/langchain/package.json
+++ b/ts/packages/providers/langchain/package.json
@@ -3,6 +3,15 @@
   "version": "0.9.3",
   "description": "",
   "main": "dist/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ComposioHQ/composio.git",
+    "directory": "ts/packages/providers/langchain"
+  },
+  "bugs": {
+    "url": "https://github.com/ComposioHQ/composio/issues"
+  },
+  "homepage": "https://github.com/ComposioHQ/composio/tree/main/ts/packages/providers/langchain#readme",
   "publishConfig": {
     "access": "public",
     "main": "dist/index.mjs",

--- a/ts/packages/providers/llamaindex/package.json
+++ b/ts/packages/providers/llamaindex/package.json
@@ -3,6 +3,15 @@
   "version": "0.9.3",
   "description": "Agentic Provider for llamaindex in Composio SDK",
   "main": "src/index.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ComposioHQ/composio.git",
+    "directory": "ts/packages/providers/llamaindex"
+  },
+  "bugs": {
+    "url": "https://github.com/ComposioHQ/composio/issues"
+  },
+  "homepage": "https://github.com/ComposioHQ/composio/tree/main/ts/packages/providers/llamaindex#readme",
   "publishConfig": {
     "access": "public",
     "main": "dist/index.mjs",

--- a/ts/packages/providers/mastra/package.json
+++ b/ts/packages/providers/mastra/package.json
@@ -3,6 +3,15 @@
   "version": "0.9.3",
   "description": "Agentic Provider for mastra in Composio SDK",
   "main": "src/index.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ComposioHQ/composio.git",
+    "directory": "ts/packages/providers/mastra"
+  },
+  "bugs": {
+    "url": "https://github.com/ComposioHQ/composio/issues"
+  },
+  "homepage": "https://github.com/ComposioHQ/composio/tree/main/ts/packages/providers/mastra#readme",
   "publishConfig": {
     "access": "public",
     "main": "dist/index.mjs",

--- a/ts/packages/providers/openai-agents/package.json
+++ b/ts/packages/providers/openai-agents/package.json
@@ -3,6 +3,15 @@
   "version": "0.9.3",
   "description": "",
   "main": "src/index.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ComposioHQ/composio.git",
+    "directory": "ts/packages/providers/openai-agents"
+  },
+  "bugs": {
+    "url": "https://github.com/ComposioHQ/composio/issues"
+  },
+  "homepage": "https://github.com/ComposioHQ/composio/tree/main/ts/packages/providers/openai-agents#readme",
   "publishConfig": {
     "access": "public",
     "main": "dist/index.mjs",

--- a/ts/packages/providers/openai/package.json
+++ b/ts/packages/providers/openai/package.json
@@ -3,6 +3,15 @@
   "version": "0.9.3",
   "description": "",
   "main": "src/index.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ComposioHQ/composio.git",
+    "directory": "ts/packages/providers/openai"
+  },
+  "bugs": {
+    "url": "https://github.com/ComposioHQ/composio/issues"
+  },
+  "homepage": "https://github.com/ComposioHQ/composio/tree/main/ts/packages/providers/openai#readme",
   "publishConfig": {
     "access": "public",
     "main": "dist/index.mjs",

--- a/ts/packages/providers/vercel/package.json
+++ b/ts/packages/providers/vercel/package.json
@@ -3,6 +3,15 @@
   "version": "0.9.3",
   "description": "",
   "main": "src/index.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ComposioHQ/composio.git",
+    "directory": "ts/packages/providers/vercel"
+  },
+  "bugs": {
+    "url": "https://github.com/ComposioHQ/composio/issues"
+  },
+  "homepage": "https://github.com/ComposioHQ/composio/tree/main/ts/packages/providers/vercel#readme",
   "publishConfig": {
     "access": "public",
     "main": "dist/index.mjs",


### PR DESCRIPTION
This PR:

- configures the TS release workflow to request GitHub Actions OIDC ID tokens
- runs the TS release publish path on Node 24.17.0 so npm supports trusted publishing
- leaves a TODO to centralize that release runtime in `mise.toml` after https://github.com/ComposioHQ/composio/pull/3494 lands
- removes the long-lived `NPM_TOKEN` `.npmrc` setup before `changeset publish`
- adds npm package support metadata (`repository.url`, `bugs.url`, and `homepage`) for every public TS release workspace that Changesets can publish
- marks `@composio/cli-local-tools` private so Changesets does not try to publish it