### PR TITLE
fix(cli): drop recipe meta-tool slugs removed from @composio/client

### DIFF
--- a/.changeset/cli-drop-recipe-meta-tool-slugs.md
+++ b/.changeset/cli-drop-recipe-meta-tool-slugs.md
@@ -1,0 +1,5 @@
+---
+'@composio/cli': patch
+---
+
+Drop `COMPOSIO_UPSERT_RECIPE` and `COMPOSIO_GET_RECIPE` from the CLI meta-tool list. These slugs were removed from `@composio/client` (alpha.74), so listing them broke the type-checked CLI build.

--- a/ts/packages/cli/src/services/tools-executor.ts
+++ b/ts/packages/cli/src/services/tools-executor.ts
@@ -82,8 +82,6 @@ const META_TOOL_SLUG_LIST = [
   'COMPOSIO_REMOTE_WORKBENCH',
   'COMPOSIO_REMOTE_BASH_TOOL',
   'COMPOSIO_GET_TOOL_SCHEMAS',
-  'COMPOSIO_UPSERT_RECIPE',
-  'COMPOSIO_GET_RECIPE',
 ] as const satisfies ReadonlyArray<SessionExecuteMetaParams['slug']>;
 
 const META_TOOL_SLUGS: ReadonlySet<string> = new Set(META_TOOL_SLUG_LIST);


### PR DESCRIPTION
This PR:

- cherry-picks the CLI fix from https://github.com/ComposioHQ/composio/pull/3494 so `next` is unblocked independently of that larger ESM-only PR
- fixes the `@composio/cli#build` typecheck failure on `next` (`TS2322` in `ts/packages/cli/src/services/tools-executor.ts`) that is currently breaking the **TS SDK Release** workflow
- `@composio/client` alpha.74 (https://github.com/ComposioHQ/composio/pull/3609) removed `COMPOSIO_UPSERT_RECIPE` and `COMPOSIO_GET_RECIPE` from `SessionExecuteMetaParams['slug']`, but `META_TOOL_SLUG_LIST` (declared `satisfies ReadonlyArray<SessionExecuteMetaParams['slug']>`) still listed them, so the build no longer type-checked
- adds a `@composio/cli` patch changeset

Verified locally: `pnpm --filter @composio/cli typecheck` passes.