### PR TITLE
fix(release): register `@composio/ts-builders` in root workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "ts/packages/cli",
     "ts/packages/cli-keyring",
     "ts/packages/cli-local-tools",
+    "ts/packages/ts-builders",
     "ts/packages/providers/*"
   ],
   "scripts": {


### PR DESCRIPTION
This PR:

- fixes the `next TS SDK Release` workflow failing at `changeset version` with `Found changeset drop-commonjs-entrypoints for package @composio/ts-builders which is not in the workspace`
- adds `ts/packages/ts-builders` to the `workspaces` array in the root `package.json`

`@manypkg/get-packages` (used by changesets) detects the root `workspaces` field and treats the repo as a yarn workspace, so it ignores `pnpm-workspace.yaml` entirely. `@composio/ts-builders` was only registered in `pnpm-workspace.yaml`, so changesets never saw it. The mismatch was latent until PR #3494 became the first changeset to bump that package.

Verified `pnpm exec changeset status` now succeeds and lists all 16 packages, including `@composio/ts-builders`.