### PR TITLE
fix(docs): preserve inline API paths in generated SDK reference

### DIFF
--- a/docs/content/reference/sdk-reference/typescript/connected-accounts.mdx
+++ b/docs/content/reference/sdk-reference/typescript/connected-accounts.mdx
@@ -145,7 +145,7 @@ This function creates a new connected account and returns a connection request.
 Users can then wait for the connection to be established using the `waitForConnection` method.
 
 **Deprecated for Composio-managed OAuth (OAuth1, OAuth2, DCR_OAUTH).**
-The legacy `POST endpoint that this method
+The legacy `POST /api/v3/connected_accounts` endpoint that this method
 wraps is being retired for Composio-managed auth configs on redirectable
 schemes. The cutover is **2026-05-08** for new organizations and
 **2026-07-03** for all remaining organizations. After your org's cutover,

--- a/ts/packages/core/scripts/generate-docs.ts
+++ b/ts/packages/core/scripts/generate-docs.ts
@@ -226,8 +226,15 @@ function extractDescription(comment?: TypeDocReflection['comment']): string {
   if (!comment) return '';
   let desc = extractText(comment.summary);
 
-  // Clean up API paths that shouldn't be in user-facing docs
-  desc = desc.replace(/\/?api\/v\d+\/[^\s]*/g, '').trim();
+  // Clean up bare API paths that shouldn't be in user-facing docs, while
+  // preserving intentional route references inside inline code spans.
+  desc = desc
+    .split(/(`[^`]*`)/g)
+    .map(segment =>
+      segment.startsWith('`') ? segment : segment.replace(/\/?api\/v\d+\/[^\s`),.;]*/g, '')
+    )
+    .join('')
+    .trim();
 
   // Clean up multiple newlines and spaces
   desc = desc


### PR DESCRIPTION
## Summary
The TypeScript SDK reference generator (`generate-docs.ts`) strips every
`api/vN/...` substring from JSDoc descriptions to keep raw endpoint paths out
of user-facing docs. The blanket regex also strips paths that live **inside
intentional inline-code spans**, mangling them.

Concretely, `ConnectedAccounts.initiate()`'s JSDoc:

> The legacy `` `POST /api/v3/connected_accounts` `` endpoint that this method …

currently renders in the generated reference as:

> The legacy `` `POST `` endpoint that this method …

— content lost and an unclosed code span. (Visible today in
`docs/content/reference/sdk-reference/typescript/connected-accounts.mdx`.)

## Fix
In `extractDescription`, split the text on inline-code spans and only strip
bare API paths **outside** backticks; deliberate route references inside code
spans are left intact. The path regex is also tightened to stop at code-span
and punctuation boundaries (`` ` ``, `)`, `,`, `.`, `;`).

The single affected reference page is regenerated in the same commit.

## Verification
- `pnpm --filter @composio/core generate:docs` → only `connected-accounts.mdx`
  changes, restoring the full `` `POST /api/v3/connected_accounts` `` span.

## Context
Salvaged from the now-superseded #3518 — re-derived against the current
generator. The rest of #3518 (drift-gate workflow, regenerated MDX, generator
rework) is obsoleted by the post-merge auto-regeneration workflow
(`generate-sdk-docs.yml`) and #3613.