### PR TITLE
test(ts/e2e): cover claude agent sdk on node current

### DIFF
--- a/.github/workflows/ts.test-e2e.yml
+++ b/.github/workflows/ts.test-e2e.yml
@@ -56,6 +56,7 @@ jobs:
       COMPOSIO_BASE_URL: ${{ secrets.COMPOSIO_BASE_URL_STAGING }}
       COMPOSIO_USER_API_KEY: ${{ secrets.COMPOSIO_USER_API_KEY }}
       COMPOSIO_E2E_NODE_VERSION: ${{ matrix.node-version }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
     steps:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -333,6 +333,28 @@ importers:
         specifier: workspace:*
         version: link:../../../_utils
 
+  ts/e2e-tests/runtimes/node/claude-agent-sdk:
+    dependencies:
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: ^0.1.9
+        version: 0.1.77(zod@3.25.76)
+      '@composio/claude-agent-sdk':
+        specifier: workspace:*
+        version: link:../../../../packages/providers/claude-agent-sdk
+      '@composio/core':
+        specifier: workspace:*
+        version: link:../../../../packages/core
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
+    devDependencies:
+      '@e2e-tests/utils':
+        specifier: workspace:*
+        version: link:../../../_utils
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+
   ts/e2e-tests/runtimes/node/custom-tools:
     dependencies:
       '@composio/core':

--- a/ts/e2e-tests/README.md
+++ b/ts/e2e-tests/README.md
@@ -27,6 +27,7 @@ ts/e2e-tests/
 ├── runtimes/
     ├── node/                                # Node.js runtime tests
     │   ├── cjs-basic/                       # Node.js 22 require(esm) interop tests
+    │   ├── claude-agent-sdk/                # @composio/claude-agent-sdk + Claude Agent SDK MCP tests
     │   ├── custom-tools/                    # Custom local tools execution (session.execute, proxyExecute, Zod validation)
     │   ├── esm-basic/                       # ESM compatibility tests
     │   ├── json-schema-to-zod-v3/           # @composio/json-schema-to-zod + Zod v3 tests

--- a/ts/e2e-tests/_utils/src/const.ts
+++ b/ts/e2e-tests/_utils/src/const.ts
@@ -4,6 +4,7 @@ import toolchainVersions from '../../../../toolchain-versions.json' with { type:
  * Environment variables to automatically pass through to Docker containers.
  */
 export const WELL_KNOWN_ENV_VARS = [
+  'ANTHROPIC_API_KEY',
   'COMPOSIO_API_KEY',
   'COMPOSIO_BASE_URL',
   'OPENAI_API_KEY',

--- a/ts/e2e-tests/runtimes/node/claude-agent-sdk/README.md
+++ b/ts/e2e-tests/runtimes/node/claude-agent-sdk/README.md
@@ -1,0 +1,17 @@
+# Node.js Claude Agent SDK E2E
+
+Verifies that `@composio/claude-agent-sdk` works on the current Node.js runtime with the real `@anthropic-ai/claude-agent-sdk` package.
+
+The fixture wraps a deterministic local Composio-style tool, mounts it into an SDK MCP server, and asks Claude to call it.
+
+## Requirements
+
+```bash
+ANTHROPIC_API_KEY=...
+```
+
+## Run
+
+```bash
+pnpm --filter @e2e-tests/node-claude-agent-sdk test:e2e:node
+```

--- a/ts/e2e-tests/runtimes/node/claude-agent-sdk/e2e.test.ts
+++ b/ts/e2e-tests/runtimes/node/claude-agent-sdk/e2e.test.ts
@@ -1,0 +1,34 @@
+import { e2e, type E2ETestResult } from '@e2e-tests/utils';
+import { TIMEOUTS } from '@e2e-tests/utils/const';
+import { describe, it, expect, beforeAll } from 'bun:test';
+
+declare module 'bun' {
+  interface Env {
+    ANTHROPIC_API_KEY: string;
+  }
+}
+
+e2e(import.meta.url, {
+  versions: { node: ['current'] },
+  usesFixtures: true,
+  env: {
+    ANTHROPIC_API_KEY: Bun.env.ANTHROPIC_API_KEY,
+  },
+  defineTests: ({ runFixture }) => {
+    let result: E2ETestResult;
+
+    beforeAll(async () => {
+      result = await runFixture({ filename: 'index.mjs' });
+    }, TIMEOUTS.LLM_LONG);
+
+    describe('@composio/claude-agent-sdk on current Node.js', () => {
+      it('exits successfully', () => {
+        expect(result.exitCode).toBe(0);
+      });
+
+      it('executes the wrapped tool through Claude Agent SDK MCP', () => {
+        expect(result.stdout).toContain('claude query executed wrapped tool');
+      });
+    });
+  },
+});

--- a/ts/e2e-tests/runtimes/node/claude-agent-sdk/fixtures/index.mjs
+++ b/ts/e2e-tests/runtimes/node/claude-agent-sdk/fixtures/index.mjs
@@ -1,0 +1,101 @@
+import { ClaudeAgentSDKProvider } from '@composio/claude-agent-sdk';
+import { createSdkMcpServer, query } from '@anthropic-ai/claude-agent-sdk';
+
+const TOOL_SLUG = 'COMPOSIO_E2E_SENTINEL';
+const SENTINEL = 'COMPOSIO_CLAUDE_AGENT_SDK_NODE_CURRENT_OK';
+
+const provider = new ClaudeAgentSDKProvider();
+const calls = [];
+
+const tools = provider.wrapTools(
+  [
+    {
+      slug: TOOL_SLUG,
+      name: 'Composio E2E Sentinel',
+      description:
+        'Returns the exact Composio Claude Agent SDK e2e sentinel. Use this tool when asked for the sentinel.',
+      version: 'e2e',
+      availableVersions: ['e2e'],
+      inputParameters: {
+        type: 'object',
+        properties: {
+          label: {
+            type: 'string',
+            enum: ['node-current'],
+            description: 'The e2e runtime label.',
+          },
+          shout: {
+            type: 'boolean',
+            description: 'Whether to return the uppercase sentinel.',
+            default: true,
+          },
+        },
+        required: ['label'],
+        additionalProperties: false,
+      },
+      tags: ['e2e'],
+    },
+  ],
+  async (toolSlug, input) => {
+    calls.push({ toolSlug, input });
+
+    if (toolSlug !== TOOL_SLUG) {
+      throw new Error(`Unexpected tool slug: ${toolSlug}`);
+    }
+    if (input.label !== 'node-current') {
+      throw new Error(`Unexpected label: ${JSON.stringify(input.label)}`);
+    }
+
+    return input.shout === false ? SENTINEL.toLowerCase() : SENTINEL;
+  }
+);
+
+if (tools.length !== 1) {
+  throw new Error(`Expected exactly one wrapped tool, got ${tools.length}`);
+}
+
+const mcpServer = createSdkMcpServer({
+  name: 'composio',
+  version: '1.0.0',
+  tools,
+});
+
+let queryResult = '';
+
+for await (const message of query({
+  prompt: [
+    `Use the ${TOOL_SLUG} tool with label "node-current" and shout true.`,
+    `Reply with exactly the tool result: ${SENTINEL}`,
+    'Do not use any built-in tools.',
+  ].join('\n'),
+  options: {
+    mcpServers: { composio: mcpServer },
+    tools: [],
+    allowedTools: [`mcp__composio__${TOOL_SLUG}`],
+    permissionMode: 'bypassPermissions',
+    allowDangerouslySkipPermissions: true,
+    maxTurns: 4,
+    maxBudgetUsd: 0.25,
+    persistSession: false,
+    settingSources: [],
+  },
+})) {
+  if (message.type === 'result') {
+    if (message.subtype !== 'success') {
+      throw new Error(`Claude query failed: ${JSON.stringify(message.errors ?? message)}`);
+    }
+    queryResult = message.result;
+  }
+}
+
+const sdkCalls = calls.filter(call => call.toolSlug === TOOL_SLUG);
+
+if (sdkCalls.length < 1) {
+  throw new Error(`Expected Claude Agent SDK to call ${TOOL_SLUG}, got ${sdkCalls.length} calls`);
+}
+
+if (!queryResult.includes(SENTINEL)) {
+  throw new Error(`Expected query result to include ${SENTINEL}, got ${JSON.stringify(queryResult)}`);
+}
+
+console.log('claude query executed wrapped tool');

--- a/ts/e2e-tests/runtimes/node/claude-agent-sdk/package.json
+++ b/ts/e2e-tests/runtimes/node/claude-agent-sdk/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@e2e-tests/node-claude-agent-sdk",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test:e2e": "bun test e2e.test.ts",
+    "test:e2e:node": "bun test e2e.test.ts"
+  },
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.1.9",
+    "@composio/claude-agent-sdk": "workspace:*",
+    "@composio/core": "workspace:*",
+    "zod": "3.25.76"
+  },
+  "devDependencies": {
+    "@e2e-tests/utils": "workspace:*",
+    "typescript": "catalog:"
+  }
+}

--- a/ts/e2e-tests/runtimes/node/claude-agent-sdk/tsconfig.json
+++ b/ts/e2e-tests/runtimes/node/claude-agent-sdk/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["e2e.test.ts"]
+}

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -24,12 +24,12 @@
     },
     "test:e2e": {
       "dependsOn": ["^build"],
-      "env": ["COMPOSIO_API_KEY", "COMPOSIO_BASE_URL", "COMPOSIO_USER_API_KEY", "OPENAI_API_KEY"],
+      "env": ["ANTHROPIC_API_KEY", "COMPOSIO_API_KEY", "COMPOSIO_BASE_URL", "COMPOSIO_USER_API_KEY", "OPENAI_API_KEY"],
       "cache": false
     },
     "test:e2e:node": {
       "dependsOn": ["^build"],
-      "env": ["COMPOSIO_API_KEY", "COMPOSIO_BASE_URL", "COMPOSIO_USER_API_KEY", "COMPOSIO_E2E_NODE_VERSION", "OPENAI_API_KEY"],
+      "env": ["ANTHROPIC_API_KEY", "COMPOSIO_API_KEY", "COMPOSIO_BASE_URL", "COMPOSIO_USER_API_KEY", "COMPOSIO_E2E_NODE_VERSION", "OPENAI_API_KEY"],
       "cache": false
     },
     "test:e2e:deno": {


### PR DESCRIPTION
This PR:
- builds on top of https://github.com/ComposioHQ/composio/pull/3495
- adds a Node.js `current` e2e suite for `@composio/claude-agent-sdk`
- exercises the packaged provider through Claude Agent SDK `createSdkMcpServer` / `query()` with a deterministic local tool
- forwards `ANTHROPIC_API_KEY` through Turbo, Docker e2e env passthrough, and the Node e2e workflow