### PR TITLE
fix(google_adk): handle reserved Python keyword param names in wrap_tool

### DIFF
--- a/python/providers/google_adk/composio_google_adk/provider.py
+++ b/python/providers/google_adk/composio_google_adk/provider.py
@@ -8,7 +8,11 @@ from composio.client.types import Tool
 from composio.core.provider import AgenticProvider
 from composio.core.provider.agentic import AgenticProviderExecuteFn
 from composio.utils.openapi import function_signature_from_jsonschema
-from composio.utils.shared import normalize_tool_arguments
+from composio.utils.shared import (
+    normalize_tool_arguments,
+    reinstate_reserved_python_keywords,
+    substitute_reserved_python_keywords,
+)
 
 
 class GoogleAdkProvider(
@@ -36,6 +40,12 @@ class GoogleAdkProvider(
                 "required": [],
             },
         )
+        # Reserved Python keywords (e.g. a ``from`` property) are not valid
+        # parameter names; substitute them before building the signature and
+        # restore them at execution time, mirroring the other agentic providers.
+        schema_params, reserved_keywords = substitute_reserved_python_keywords(
+            schema=input_parameters
+        )
         properties = t.cast(
             t.Dict[str, t.Dict[str, t.Any]],
             input_parameters.get("properties", {}),
@@ -50,6 +60,10 @@ class GoogleAdkProvider(
         docstring += "\n    A dictionary containing response from the action"
 
         def _execute(**kwargs: t.Any) -> t.Dict:
+            # Restore any reserved-keyword parameter names before execution.
+            kwargs = reinstate_reserved_python_keywords(
+                request=kwargs, keywords=reserved_keywords
+            )
             # Normalize defensively so a stringified payload is coerced to a dict (issue #2406).
             return execute_tool(
                 slug=tool.slug, arguments=normalize_tool_arguments(kwargs)
@@ -62,7 +76,7 @@ class GoogleAdkProvider(
             closure=_execute.__closure__,
         )
         parameters = function_signature_from_jsonschema(
-            schema=input_parameters,
+            schema=schema_params,
             skip_default=self.skip_default,
         )
         setattr(function, "__signature__", Signature(parameters=parameters))


### PR DESCRIPTION
## Summary

`GoogleAdkProvider.wrap_tool` builds the wrapped function's signature directly from the tool's raw input schema via `function_signature_from_jsonschema(...)` **without first substituting reserved Python keywords**. If a tool declares a property whose name is a Python keyword — e.g. a `from` field, common in email / calendar / transfer tools — then `inspect.Parameter(name="from", ...)` raises `ValueError: 'from' is not a valid parameter name`, so the whole `composio.tools.get(...)` call crashes when that tool is wrapped for Google ADK.

Every **other** agentic provider that builds a Python signature already guards this with `substitute_reserved_python_keywords` / `reinstate_reserved_python_keywords` — `gemini` (`provider.py:103`/`110`), `langchain`, `langgraph`, `llamaindex`, `autogen`. `google_adk` is the only one of the six that omits it.

This PR mirrors the siblings: substitute reserved keywords before building the signature, and reinstate them in the execution wrapper before `execute_tool`.

## Reproduction

```python
from composio.utils.openapi import function_signature_from_jsonschema
from composio.utils.shared import substitute_reserved_python_keywords

schema = {"type": "object",
          "properties": {"from": {"type": "string"}, "to": {"type": "string"}},
          "required": ["from"]}

# Before (what google_adk passed straight through) -> raises:
function_signature_from_jsonschema(schema=schema, skip_default=True)
# ValueError: 'from' is not a valid parameter name

# After (substitute first, as the sibling providers do) -> ok:
sub, _ = substitute_reserved_python_keywords(schema=schema)
function_signature_from_jsonschema(schema=sub, skip_default=True)   # -> [to, from_rs]
```

Happy to add a provider test / changeset if that's preferred — the `google_adk` package doesn't currently ship a test harness.
