### PR TITLE
fix(gemini): reinstate reserved-keyword param names in handle_response

### DIFF
--- a/python/providers/gemini/composio_gemini/provider.py
+++ b/python/providers/gemini/composio_gemini/provider.py
@@ -83,6 +83,7 @@ class GeminiProvider(AgenticProvider[t.Callable, list[t.Callable]], name="gemini
     def __init__(self, **kwargs: t.Any):
         super().__init__(**kwargs)
         self._executors: t.Dict[str, AgenticProviderExecuteFn] = {}
+        self._keywords: t.Dict[str, dict] = {}
 
     def wrap_tool(
         self,
@@ -103,6 +104,9 @@ class GeminiProvider(AgenticProvider[t.Callable, list[t.Callable]], name="gemini
         schema_params, keywords = substitute_reserved_python_keywords(
             schema=tool.input_parameters
         )
+        # Remember the mapping so the backward-compat manual path
+        # (``handle_response``) can reinstate the original names too.
+        self._keywords[tool.slug] = keywords
 
         def function(**kwargs: t.Any) -> t.Dict:
             """Composio tool execution wrapper."""
@@ -190,8 +194,14 @@ class GeminiProvider(AgenticProvider[t.Callable, list[t.Callable]], name="gemini
             if fc.name not in self._executors:
                 continue
 
+            # Restore reserved-keyword parameter names: the model sees the
+            # substituted names, but the backend expects the originals, matching
+            # the AFC execution wrapper above.
+            arguments = reinstate_reserved_python_keywords(
+                request=dict(fc.args), keywords=self._keywords.get(fc.name, {})
+            )
             result = self._executors[fc.name](
-                slug=fc.name, arguments=normalize_tool_arguments(dict(fc.args))
+                slug=fc.name, arguments=normalize_tool_arguments(arguments)
             )
             processed = _process_execution_result(result)
 

--- a/python/tests/test_gemini_provider.py
+++ b/python/tests/test_gemini_provider.py
@@ -576,6 +576,39 @@ class TestHandleResponse:
             arguments={"repo": "composio/composio"},
         )
 
+    def test_reinstates_reserved_keyword_args(self):
+        """handle_response must reinstate reserved-keyword param names like the
+        AFC path, so the backend receives the original name, not the substituted one."""
+        from composio_gemini import GeminiProvider
+
+        provider = GeminiProvider()
+        tool = create_mock_tool(
+            "TOOL_WITH_RESERVED",
+            "test",
+            input_parameters={
+                "type": "object",
+                "properties": {
+                    "for": {"type": "string"},
+                    "name": {"type": "string"},
+                },
+                "required": [],
+            },
+        )
+        execute_tool = create_mock_execute_tool()
+        provider.wrap_tools([tool], execute_tool)
+
+        # The model returns the substituted name ("for_rs"); the backend expects "for".
+        response = self._create_mock_response(
+            [("TOOL_WITH_RESERVED", {"for_rs": "test_value", "name": "hello"})]
+        )
+        function_responses, executed = provider.handle_response(response)
+
+        assert executed is True
+        execute_tool.assert_called_once_with(
+            slug="TOOL_WITH_RESERVED",
+            arguments={"for": "test_value", "name": "hello"},
+        )
+
     def test_no_function_calls(self):
         from composio_gemini import GeminiProvider
 


### PR DESCRIPTION
## Summary

`GeminiProvider` substitutes reserved Python keyword parameter names (e.g. `from`, `for`) so they can be valid Python signature parameters, and reinstates the original names before execution. The **AFC execution wrapper** does this correctly (substitute in `wrap_tool`, reinstate before `execute_tool`). But the backward-compat **manual function-calling** path, `handle_response`, forwards `fc.args` straight to the executor **without reinstating** — so for a tool whose schema has a reserved-keyword property, the model returns the *substituted* name (e.g. `for_rs`) and the backend receives the wrong key (`for_rs` instead of `for`), silently dropping/renaming the argument.

The AFC path's own `reinstate_reserved_python_keywords(...)` before `execute_tool` confirms the backend expects the original names, and every sibling provider that substitutes (`langchain`, `langgraph`, `llamaindex`, `autogen`) also reinstates before execute. `handle_response` was the one execution path missing it.

## Fix

Store the per-tool substitution map in `wrap_tool` (`self._keywords[tool.slug]`) and reinstate it in `handle_response` before dispatching to the executor, mirroring the AFC wrapper.

## Testing

Added `TestHandleResponse::test_reinstates_reserved_keyword_args`: a tool with a `for` property dispatched via `handle_response` with the substituted arg name — before the fix the executor receives `{"for_rs": ...}` (fails); after, it receives `{"for": ...}`. Full `test_gemini_provider.py`: **32 passed**.
