### PR TITLE
docs: include v3 proxy execute scoped key route

### DIFF
--- a/docs/content/reference/authentication/project-api-key-permissions.mdx
+++ b/docs/content/reference/authentication/project-api-key-permissions.mdx
@@ -109,6 +109,7 @@ Proxy execute is separate from tool execution. Grant it only when your applicati
 
 | Access | Method | Endpoint |
 |---|---|---|
+| Write | `POST` | `/api/v3/tools/execute/proxy` |
 | Write | `POST` | `/api/v3.1/tools/execute/proxy` |
 | Write | `POST` | `/api/v3/tool_router/session/{session_id}/proxy_execute` |
 


### PR DESCRIPTION
## Summary\n- document that Proxy execute scoped project API key permission covers POST /api/v3/tools/execute/proxy\n- keep the existing v3.1 and tool-router proxy execute entries unchanged\n\n## Testing\n- bun run lint:links