### PR TITLE
Document version-placeholder project API key permission endpoints

### DIFF
--- a/docs/content/reference/authentication/project-api-key-permissions.mdx
+++ b/docs/content/reference/authentication/project-api-key-permissions.mdx
@@ -23,6 +23,8 @@ Default project API keys keep full project API key access. Scoped project API ke
 
 Some read routes use `POST` because the request body carries filters or lookup input. The access level is based on what the route does, not only the HTTP method.
 
+Endpoint paths use `{version}` as a placeholder for the API version.
+
 ## Permission areas
 
 Jump to each permission area to see the routes it covers.
@@ -46,12 +48,12 @@ View and modify auth configs.
 
 | Access | Method | Endpoint |
 |---|---|---|
-| Read | `GET` | `/api/v3/auth_configs` |
-| Read | `GET` | `/api/v3/auth_configs/{nanoid}` |
-| Write | `POST` | `/api/v3/auth_configs` |
-| Write | `PATCH` | `/api/v3/auth_configs/{nanoid}` |
-| Write | `DELETE` | `/api/v3/auth_configs/{nanoid}` |
-| Write | `PATCH` | `/api/v3/auth_configs/{nanoid}/{status}` |
+| Read | `GET` | `/api/{version}/auth_configs` |
+| Read | `GET` | `/api/{version}/auth_configs/{nanoid}` |
+| Write | `POST` | `/api/{version}/auth_configs` |
+| Write | `PATCH` | `/api/{version}/auth_configs/{nanoid}` |
+| Write | `DELETE` | `/api/{version}/auth_configs/{nanoid}` |
+| Write | `PATCH` | `/api/{version}/auth_configs/{nanoid}/{status}` |
 
 ## Connected accounts
 
@@ -59,15 +61,15 @@ View and manage connected accounts.
 
 | Access | Method | Endpoint |
 |---|---|---|
-| Read | `GET` | `/api/v3/connected_accounts` |
-| Read | `GET` | `/api/v3/connected_accounts/{nanoid}` |
-| Write | `POST` | `/api/v3/connected_accounts` |
-| Write | `POST` | `/api/v3/connected_accounts/link` |
-| Write | `PATCH` | `/api/v3/connected_accounts/{nanoid}` |
-| Write | `PATCH` | `/api/v3/connected_accounts/{nanoid}/status` |
-| Write | `POST` | `/api/v3/connected_accounts/{nanoid}/refresh` |
-| Write | `DELETE` | `/api/v3/connected_accounts/{nanoid}` |
-| Write | `POST` | `/api/v3.1/connected_accounts/{nanoid}/revoke` |
+| Read | `GET` | `/api/{version}/connected_accounts` |
+| Read | `GET` | `/api/{version}/connected_accounts/{nanoid}` |
+| Write | `POST` | `/api/{version}/connected_accounts` |
+| Write | `POST` | `/api/{version}/connected_accounts/link` |
+| Write | `PATCH` | `/api/{version}/connected_accounts/{nanoid}` |
+| Write | `PATCH` | `/api/{version}/connected_accounts/{nanoid}/status` |
+| Write | `POST` | `/api/{version}/connected_accounts/{nanoid}/refresh` |
+| Write | `DELETE` | `/api/{version}/connected_accounts/{nanoid}` |
+| Write | `POST` | `/api/{version}/connected_accounts/{nanoid}/revoke` |
 
 ## Tools
 
@@ -75,19 +77,13 @@ View tool definitions, inputs, scopes, and versions.
 
 | Access | Method | Endpoint |
 |---|---|---|
-| Read | `GET` | `/api/v3/tools` |
-| Read | `GET` | `/api/v3/tools/enum` |
-| Read | `GET` | `/api/v3/tools/{tool_slug}` |
-| Read | `GET` | `/api/v3/tools/{tool_slug}/get_latest_version` |
-| Read | `GET` | `/api/v3/tools/scopes/required` |
-| Read | `GET` | `/api/v3/tools/get_scopes_required` |
-| Read | `POST` | `/api/v3/tools/execute/{tool_slug}/input` |
-| Read | `GET` | `/api/v3.1/tools` |
-| Read | `GET` | `/api/v3.1/tools/enum` |
-| Read | `GET` | `/api/v3.1/tools/{tool_slug}` |
-| Read | `GET` | `/api/v3.1/tools/scopes/required` |
-| Read | `GET` | `/api/v3.1/tools/get_scopes_required` |
-| Read | `POST` | `/api/v3.1/tools/execute/{tool_slug}/input` |
+| Read | `GET` | `/api/{version}/tools` |
+| Read | `GET` | `/api/{version}/tools/enum` |
+| Read | `GET` | `/api/{version}/tools/{tool_slug}` |
+| Read | `GET` | `/api/{version}/tools/{tool_slug}/get_latest_version` |
+| Read | `GET` | `/api/{version}/tools/scopes/required` |
+| Read | `GET` | `/api/{version}/tools/get_scopes_required` |
+| Read | `POST` | `/api/{version}/tools/execute/{tool_slug}/input` |
 
 ## Tool execution
 
@@ -95,11 +91,10 @@ Execute predefined Composio tools.
 
 | Access | Method | Endpoint |
 |---|---|---|
-| Write | `POST` | `/api/v3/tools/execute/{tool_slug}` |
-| Write | `POST` | `/api/v3.1/tools/execute/{tool_slug}` |
-| Write | `POST` | `/api/v3/files/upload/request` |
-| Write | `POST` | `/api/v3/files/upload/response` |
-| Write | `GET` | `/api/v3/files/list` |
+| Write | `POST` | `/api/{version}/tools/execute/{tool_slug}` |
+| Write | `POST` | `/api/{version}/files/upload/request` |
+| Write | `POST` | `/api/{version}/files/upload/response` |
+| Write | `GET` | `/api/{version}/files/list` |
 
 ## Proxy execute
 
@@ -109,8 +104,8 @@ Proxy execute is separate from tool execution. Grant it only when your applicati
 
 | Access | Method | Endpoint |
 |---|---|---|
-| Write | `POST` | `/api/v3.1/tools/execute/proxy` |
-| Write | `POST` | `/api/v3/tool_router/session/{session_id}/proxy_execute` |
+| Write | `POST` | `/api/{version}/tools/execute/proxy` |
+| Write | `POST` | `/api/{version}/tool_router/session/{session_id}/proxy_execute` |
 
 ## Toolkits
 
@@ -118,11 +113,11 @@ View and install toolkits.
 
 | Access | Method | Endpoint |
 |---|---|---|
-| Read | `GET` | `/api/v3/toolkits` |
-| Read | `GET` | `/api/v3/toolkits/{slug}` |
-| Read | `GET` | `/api/v3/toolkits/categories` |
-| Read | `GET` | `/api/v3/toolkits/changelog` |
-| Write | `POST` | `/api/v3/toolkits/multi` |
+| Read | `GET` | `/api/{version}/toolkits` |
+| Read | `GET` | `/api/{version}/toolkits/{slug}` |
+| Read | `GET` | `/api/{version}/toolkits/categories` |
+| Read | `GET` | `/api/{version}/toolkits/changelog` |
+| Write | `POST` | `/api/{version}/toolkits/multi` |
 
 ## Triggers
 
@@ -130,17 +125,17 @@ View trigger types, manage trigger instances, and subscribe to trigger events. T
 
 | Access | Method | Endpoint |
 |---|---|---|
-| Read | `GET` | `/api/v3/triggers_types` |
-| Read | `GET` | `/api/v3/triggers_types/{slug}` |
-| Read | `GET` | `/api/v3/triggers_types/list/enum` |
-| Read | `GET` | `/api/v3/trigger_instances/active` |
-| Read | `GET` | `/api/v3/cli/realtime/credentials` |
-| Read | `POST` | `/api/v3/cli/realtime/auth` |
-| Read | `GET` | `/api/v3/internal/sdk/realtime/credentials` |
-| Read | `POST` | `/api/v3/internal/sdk/realtime/auth` |
-| Write | `POST` | `/api/v3/trigger_instances/{slug}/upsert` |
-| Write | `PATCH` | `/api/v3/trigger_instances/manage/{triggerId}` |
-| Write | `DELETE` | `/api/v3/trigger_instances/manage/{triggerId}` |
+| Read | `GET` | `/api/{version}/triggers_types` |
+| Read | `GET` | `/api/{version}/triggers_types/{slug}` |
+| Read | `GET` | `/api/{version}/triggers_types/list/enum` |
+| Read | `GET` | `/api/{version}/trigger_instances/active` |
+| Read | `GET` | `/api/{version}/cli/realtime/credentials` |
+| Read | `POST` | `/api/{version}/cli/realtime/auth` |
+| Read | `GET` | `/api/{version}/internal/sdk/realtime/credentials` |
+| Read | `POST` | `/api/{version}/internal/sdk/realtime/auth` |
+| Write | `POST` | `/api/{version}/trigger_instances/{slug}/upsert` |
+| Write | `PATCH` | `/api/{version}/trigger_instances/manage/{triggerId}` |
+| Write | `DELETE` | `/api/{version}/trigger_instances/manage/{triggerId}` |
 
 ## Webhooks
 
@@ -148,20 +143,20 @@ View and manage webhook endpoints and subscriptions.
 
 | Access | Method | Endpoint |
 |---|---|---|
-| Read | `GET` | `/api/v3/webhook_endpoints` |
-| Read | `GET` | `/api/v3/webhook_endpoints/{nano_id}` |
-| Read | `GET` | `/api/v3/webhook_endpoints/schema` |
-| Read | `GET` | `/api/v3/webhook_subscriptions` |
-| Read | `GET` | `/api/v3/webhook_subscriptions/{id}` |
-| Read | `GET` | `/api/v3/webhook_subscriptions/event_types` |
-| Write | `POST` | `/api/v3/webhook_endpoints` |
-| Write | `POST` | `/api/v3/webhook_endpoints/{nano_id}` |
-| Write | `PATCH` | `/api/v3/webhook_endpoints/{nano_id}` |
-| Write | `DELETE` | `/api/v3/webhook_endpoints/{nano_id}` |
-| Write | `POST` | `/api/v3/webhook_subscriptions` |
-| Write | `PATCH` | `/api/v3/webhook_subscriptions/{id}` |
-| Write | `DELETE` | `/api/v3/webhook_subscriptions/{id}` |
-| Write | `POST` | `/api/v3/webhook_subscriptions/{id}/rotate_secret` |
+| Read | `GET` | `/api/{version}/webhook_endpoints` |
+| Read | `GET` | `/api/{version}/webhook_endpoints/{nano_id}` |
+| Read | `GET` | `/api/{version}/webhook_endpoints/schema` |
+| Read | `GET` | `/api/{version}/webhook_subscriptions` |
+| Read | `GET` | `/api/{version}/webhook_subscriptions/{id}` |
+| Read | `GET` | `/api/{version}/webhook_subscriptions/event_types` |
+| Write | `POST` | `/api/{version}/webhook_endpoints` |
+| Write | `POST` | `/api/{version}/webhook_endpoints/{nano_id}` |
+| Write | `PATCH` | `/api/{version}/webhook_endpoints/{nano_id}` |
+| Write | `DELETE` | `/api/{version}/webhook_endpoints/{nano_id}` |
+| Write | `POST` | `/api/{version}/webhook_subscriptions` |
+| Write | `PATCH` | `/api/{version}/webhook_subscriptions/{id}` |
+| Write | `DELETE` | `/api/{version}/webhook_subscriptions/{id}` |
+| Write | `POST` | `/api/{version}/webhook_subscriptions/{id}/rotate_secret` |
 
 ## Observability
 
@@ -169,10 +164,10 @@ View execution logs and project usage summaries.
 
 | Access | Method | Endpoint |
 |---|---|---|
-| Read | `POST` | `/api/v3.1/logs/tool_execution` |
-| Read | `GET` | `/api/v3.1/logs/tool_execution/{id}` |
-| Read | `POST` | `/api/v3.1/project/usage/{entity_type}` |
-| Read | `POST` | `/api/v3.1/project/usage/summary` |
+| Read | `POST` | `/api/{version}/logs/tool_execution` |
+| Read | `GET` | `/api/{version}/logs/tool_execution/{id}` |
+| Read | `POST` | `/api/{version}/project/usage/{entity_type}` |
+| Read | `POST` | `/api/{version}/project/usage/summary` |
 
 ## Sessions
 
@@ -180,44 +175,37 @@ Create and operate sessions and MCP servers. This permission area covers MCP ser
 
 | Access | Method | Endpoint |
 |---|---|---|
-| Read | `GET` | `/api/v3/mcp/servers` |
-| Read | `GET` | `/api/v3/mcp/{id}` |
-| Read | `GET` | `/api/v3/mcp/app/{app_key}` |
-| Read | `GET` | `/api/v3/mcp/servers/{server_id}/instances` |
+| Read | `GET` | `/api/{version}/mcp/servers` |
+| Read | `GET` | `/api/{version}/mcp/{id}` |
+| Read | `GET` | `/api/{version}/mcp/app/{app_key}` |
+| Read | `GET` | `/api/{version}/mcp/servers/{server_id}/instances` |
 | Read | `GET` | `/tool_router/{session_id}/mcp` |
-| Read | `GET` | `/api/v3/tool_router/session/{session_id}` |
-| Read | `GET` | `/api/v3/tool_router/session/{session_id}/toolkits` |
-| Read | `GET` | `/api/v3/tool_router/session/{session_id}/tools` |
-| Read | `GET` | `/api/v3/tool_router/session/{session_id}/mounts/{mount_id}/items` |
-| Read | `GET` | `/api/v3.1/tool_router/session/{session_id}` |
-| Read | `GET` | `/api/v3.1/tool_router/session/{session_id}/config_history` |
-| Read | `GET` | `/api/v3.1/tool_router/session/{session_id}/tools` |
-| Write | `POST` | `/api/v3/mcp/servers` |
-| Write | `POST` | `/api/v3/mcp/servers/generate` |
-| Write | `POST` | `/api/v3/mcp/servers/custom` |
-| Write | `PATCH` | `/api/v3/mcp/{id}` |
-| Write | `DELETE` | `/api/v3/mcp/{id}` |
-| Write | `POST` | `/api/v3/mcp/servers/{server_id}/instances` |
-| Write | `DELETE` | `/api/v3/mcp/servers/{server_id}/instances/{instance_id}` |
-| Write | `POST` | `/api/v3/mcp/{server_id}/{transport}` |
-| Write | `DELETE` | `/api/v3/mcp/{server_id}/{transport}` |
+| Read | `GET` | `/api/{version}/tool_router/session/{session_id}` |
+| Read | `GET` | `/api/{version}/tool_router/session/{session_id}/toolkits` |
+| Read | `GET` | `/api/{version}/tool_router/session/{session_id}/tools` |
+| Read | `GET` | `/api/{version}/tool_router/session/{session_id}/mounts/{mount_id}/items` |
+| Read | `GET` | `/api/{version}/tool_router/session/{session_id}/config_history` |
+| Write | `POST` | `/api/{version}/mcp/servers` |
+| Write | `POST` | `/api/{version}/mcp/servers/generate` |
+| Write | `POST` | `/api/{version}/mcp/servers/custom` |
+| Write | `PATCH` | `/api/{version}/mcp/{id}` |
+| Write | `DELETE` | `/api/{version}/mcp/{id}` |
+| Write | `POST` | `/api/{version}/mcp/servers/{server_id}/instances` |
+| Write | `DELETE` | `/api/{version}/mcp/servers/{server_id}/instances/{instance_id}` |
+| Write | `POST` | `/api/{version}/mcp/{server_id}/{transport}` |
+| Write | `DELETE` | `/api/{version}/mcp/{server_id}/{transport}` |
 | Write | `POST` | `/tool_router/{session_id}/mcp` |
 | Write | `DELETE` | `/tool_router/{session_id}/mcp` |
-| Write | `POST` | `/api/v3/tool_router/session` |
-| Write | `POST` | `/api/v3/tool_router/session/{session_id}/execute` |
-| Write | `POST` | `/api/v3/tool_router/session/{session_id}/execute_meta` |
-| Write | `POST` | `/api/v3/tool_router/session/{session_id}/link` |
-| Write | `POST` | `/api/v3/tool_router/session/{session_id}/search` |
-| Write | `PATCH` | `/api/v3/tool_router/session/{session_id}` |
-| Write | `POST` | `/api/v3/tool_router/session/{session_id}/mounts/{mount_id}/upload_url` |
-| Write | `POST` | `/api/v3/tool_router/session/{session_id}/mounts/{mount_id}/download_url` |
-| Write | `POST` | `/api/v3/tool_router/session/{session_id}/mounts/{mount_id}/delete` |
-| Write | `POST` | `/api/v3.1/tool_router/session` |
-| Write | `POST` | `/api/v3.1/tool_router/session/{session_id}/attach` |
-| Write | `POST` | `/api/v3.1/tool_router/session/{session_id}/execute` |
-| Write | `POST` | `/api/v3.1/tool_router/session/{session_id}/execute_meta` |
-| Write | `POST` | `/api/v3.1/tool_router/session/{session_id}/search` |
-| Write | `PATCH` | `/api/v3.1/tool_router/session/{session_id}` |
+| Write | `POST` | `/api/{version}/tool_router/session` |
+| Write | `POST` | `/api/{version}/tool_router/session/{session_id}/execute` |
+| Write | `POST` | `/api/{version}/tool_router/session/{session_id}/execute_meta` |
+| Write | `POST` | `/api/{version}/tool_router/session/{session_id}/link` |
+| Write | `POST` | `/api/{version}/tool_router/session/{session_id}/search` |
+| Write | `PATCH` | `/api/{version}/tool_router/session/{session_id}` |
+| Write | `POST` | `/api/{version}/tool_router/session/{session_id}/mounts/{mount_id}/upload_url` |
+| Write | `POST` | `/api/{version}/tool_router/session/{session_id}/mounts/{mount_id}/download_url` |
+| Write | `POST` | `/api/{version}/tool_router/session/{session_id}/mounts/{mount_id}/delete` |
+| Write | `POST` | `/api/{version}/tool_router/session/{session_id}/attach` |
 
 ## What to read next
 


### PR DESCRIPTION
## Summary\n- show project API key permission endpoints with /api/{version}/... placeholders instead of duplicating versioned rows\n- keep proxy execute documented for direct and session proxy paths\n\n## Verification\n- bun run lint:links from docs/\n- git diff --check