### PR TITLE
fix(openai_agents): deep-copy tool schema before stripping examples/default

### DIFF
--- a/python/providers/openai_agents/composio_openai_agents/provider.py
+++ b/python/providers/openai_agents/composio_openai_agents/provider.py
@@ -1,4 +1,5 @@
 import asyncio
+import copy
 import json
 import typing as t
 
@@ -110,8 +111,12 @@ class OpenAIAgentsProvider(
                 )
 
         # Ensure the schema has additionalProperties set to false
-        # this is required by OpenAI's function validation
-        modified_schema = tool.input_parameters.copy()
+        # this is required by OpenAI's function validation.
+        # Deep-copy so the in-place edits below (additionalProperties + the
+        # examples/pattern/default removal) never mutate the caller's
+        # Tool.input_parameters, matching the deepcopy contract in
+        # composio.utils.shared.
+        modified_schema = copy.deepcopy(tool.input_parameters)
         modified_schema["additionalProperties"] = False
 
         # Apply the example removal function. This is done to optimize the

--- a/python/providers/openai_agents/tests/test_provider.py
+++ b/python/providers/openai_agents/tests/test_provider.py
@@ -1,0 +1,51 @@
+"""Tests for the OpenAI Agents provider."""
+
+import copy
+from unittest.mock import MagicMock
+
+from composio_openai_agents.provider import OpenAIAgentsProvider
+
+
+def test_wrap_tool_does_not_mutate_input_parameters():
+    """wrap_tool must not strip default/examples/pattern from the caller's schema.
+
+    ``wrap_tool`` removes ``examples``/``pattern``/``default`` from the schema it
+    hands to the OpenAI Agents SDK. It must do so on a *copy*: a shallow
+    ``dict.copy()`` left the nested ``properties`` dicts shared with the original,
+    so those in-place deletions leaked back into the caller's
+    ``Tool.input_parameters``.
+    """
+    tool = MagicMock(
+        slug="GITHUB_GET_REPO",
+        name="Github Get Repo",
+        description="Get a repository",
+        input_parameters={
+            "type": "object",
+            "properties": {
+                "owner": {"type": "string", "default": "me", "examples": ["octocat"]},
+                "repo": {"type": "string", "pattern": "^[a-z]+$"},
+            },
+            "required": ["owner"],
+        },
+    )
+    snapshot = copy.deepcopy(tool.input_parameters)
+
+    wrapped_tool = OpenAIAgentsProvider().wrap_tool(tool, lambda **kwargs: {})
+
+    # The caller's schema must be untouched.
+    assert tool.input_parameters == snapshot
+    owner = tool.input_parameters["properties"]["owner"]
+    assert owner["default"] == "me"
+    assert owner["examples"] == ["octocat"]
+    assert tool.input_parameters["properties"]["repo"]["pattern"] == "^[a-z]+$"
+
+    # The provider-local schema should still be normalized for OpenAI Agents.
+    assert wrapped_tool.params_json_schema == {
+        "type": "object",
+        "properties": {
+            "owner": {"type": "string"},
+            "repo": {"type": "string"},
+        },
+        "required": ["owner"],
+        "additionalProperties": False,
+    }


### PR DESCRIPTION
## Problem

`OpenAIAgentsProvider.wrap_tool` mutates the caller's `Tool.input_parameters`. It shallow-copies the schema and then strips keys from the nested property dicts **in place**:

```python
modified_schema = tool.input_parameters.copy()        # shallow copy
modified_schema["additionalProperties"] = False
_remove_examples_from_schema(modified_schema)          # del prop["examples"/"pattern"/"default"]
```

`_remove_examples_from_schema` recurses into `schema["properties"][*]` and does `del prop_value["examples"]`, `del prop_value["pattern"]`, `del prop_value["default"]`. Because `dict.copy()` is shallow, `modified_schema["properties"]` (and every nested property dict) is the **same object** as the original, so those deletions strip `examples`/`pattern`/**`default`** out of the caller's `Tool.input_parameters`.

Since essentially every Composio tool carries `default`/`examples` on its properties, wrapping a tool silently corrupts its schema. Wrapping the same `Tool` twice, reusing it with another provider, or inspecting it after wrapping then sees the defaults gone.

This is the only wrap path using a shallow `.copy()` + nested mutation — the rest of the codebase deep-copies before mutating schemas, e.g. `composio/utils/shared.py` (`schema = copy.deepcopy(schema)`, with the docstring *"The schema is deep-copied before any mutation so the caller's original is never modified."*) and `Tools._get` (`tool.model_copy(deep=True)`).

## Fix

Deep-copy the schema before mutating (`copy.deepcopy(tool.input_parameters)`), so `_remove_examples_from_schema` only edits the provider-local copy. One-line change + `import copy`.

## Test

Added `python/providers/openai_agents/tests/test_provider.py::test_wrap_tool_does_not_mutate_input_parameters` — builds a tool whose properties carry `default`/`examples`/`pattern`, snapshots `input_parameters`, calls `wrap_tool`, and asserts both sides of the contract:

- the caller's original `Tool.input_parameters` is unchanged
- the returned `FunctionTool.params_json_schema` is still normalized for OpenAI Agents (`additionalProperties: false`, with `default`/`examples`/`pattern` stripped)

- **Before:** the assertion fails — `owner` loses `default`/`examples`, `repo` loses `pattern`.
- **After:** `Tool.input_parameters` is untouched while the wrapped schema remains sanitized.

Verification:

- `uv run pytest python/providers/openai_agents/tests/test_provider.py -q` → **1 passed**
- `uv run ruff check python/providers/openai_agents/composio_openai_agents/provider.py python/providers/openai_agents/tests/test_provider.py` → clean
- `uv run ruff format --check python/providers/openai_agents/composio_openai_agents/provider.py python/providers/openai_agents/tests/test_provider.py` → clean
