### PR TITLE
feat(core): add sessions namespace and toolkit link fallback

### DIFF
--- a/.changeset/bright-lions-jam.md
+++ b/.changeset/bright-lions-jam.md
@@ -1,0 +1,5 @@
+---
+'@composio/core': patch
+---
+
+Add the first-class `composio.sessions.create()` API while keeping `composio.create()` as an alias, allow `connectedAccounts.link()` to auto-resolve a Tool-Router-compatible managed auth config from a toolkit, and include SDK docs/source in the published package.

--- a/docs/content/reference/sdk-reference/typescript/composio.mdx
+++ b/docs/content/reference/sdk-reference/typescript/composio.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Composio"
-description: "This is the core class for Composio. It is used to initialize the Composio SDK and provide a global configuration."
+title: 'Composio'
+description: 'This is the core class for Composio. It is used to initialize the Composio SDK and provide a global configuration.'
 ---
 
 ## Constructor
@@ -18,8 +18,8 @@ constructor(config?: ComposioConfig): Composio
 
 **Parameters**
 
-| Name | Type | Description |
-|------|------|-------------|
+| Name      | Type             | Description                                |
+| --------- | ---------------- | ------------------------------------------ |
 | `config?` | `ComposioConfig` | Configuration options for the Composio SDK |
 
 **Returns**
@@ -35,13 +35,13 @@ const composio = new Composio();
 // Initialize with custom API key and base URL
 const composio = new Composio({
   apiKey: 'your-api-key',
-  baseURL: 'https://api.composio.dev'
+  baseURL: 'https://api.composio.dev',
 });
 
 // Initialize with custom provider
 const composio = new Composio({
   apiKey: 'your-api-key',
-  provider: new CustomProvider()
+  provider: new CustomProvider(),
 });
 ```
 
@@ -49,11 +49,12 @@ const composio = new Composio({
 
 ## Properties
 
-| Name | Type | Description |
-|------|------|-------------|
-| `authConfigs` | `AuthConfigs` | Manage authentication configurations for toolkits |
-| `connectedAccounts` | `ConnectedAccounts` | Manage authenticated connections |
-| `create` | `object` | Creates a new tool router session for a user.
+| Name                | Type                | Description                                       |
+| ------------------- | ------------------- | ------------------------------------------------- |
+| `authConfigs`       | `AuthConfigs`       | Manage authentication configurations for toolkits |
+| `connectedAccounts` | `ConnectedAccounts` | Manage authenticated connections                  |
+| `create`            | `object`            | Creates a new tool router session for a user.     |
+
 Use `sessionPreset: SessionPreset.DIRECT_TOOLS` when all needed tools
 should be exposed directly; see `ToolRouterCreateSessionConfig`. |
 | `experimental` | `Experimental` | Experimental SDK methods whose shape may change in future releases.
@@ -63,8 +64,12 @@ take a client and perform I/O. Stateless experimental factories
 | `files` | `Files` | Upload and download files |
 | `mcp` | `MCP` | Model Context Protocol server management |
 | `provider` | `TProvider` | The tool provider instance used for wrapping tools in framework-specific formats |
+| `sessions` | `Sessions` | Create and reuse Composio sessions.
+
+Prefer `composio.sessions.create(...)` for new code. The top-level
+`composio.create(...)` method is kept as an alias. |
 | `toolkits` | `Toolkits` | Retrieve toolkit metadata and authorize user connections |
-| `toolRouter` | `ToolRouter` | Experimental feature, use with caution |
+| `toolRouter` | `ToolRouter` | Legacy alias for `composio.sessions`. |
 | `tools` | `Tools` | List, retrieve, and execute tools |
 | `triggers` | `Triggers` | Manage webhook triggers and event subscriptions |
 | `use` | `object` | Use an existing tool router session |
@@ -75,6 +80,7 @@ take a client and perform I/O. Stateless experimental factories
 
 Creates a new instance of the Composio SDK with custom request options while preserving the existing configuration.
 This method is particularly useful when you need to:
+
 - Add custom headers for specific requests
 - Track request contexts with unique identifiers
 - Override default request behavior for a subset of operations
@@ -88,8 +94,8 @@ createSession(options?: { headers?: ComposioRequestHeaders }): Composio
 
 **Parameters**
 
-| Name | Type |
-|------|------|
+| Name       | Type     |
+| ---------- | -------- |
 | `options?` | `object` |
 
 **Returns**
@@ -101,7 +107,7 @@ createSession(options?: { headers?: ComposioRequestHeaders }): Composio
 ```typescript
 // Create a base Composio instance
 const composio = new Composio({
-  apiKey: 'your-api-key'
+  apiKey: 'your-api-key',
 });
 
 // Create a session with request tracking headers
@@ -109,8 +115,8 @@ const composioWithCustomHeaders = composio.createSession({
   headers: {
     'x-request-id': '1234567890',
     'x-correlation-id': 'session-abc-123',
-    'x-custom-header': 'custom-value'
-  }
+    'x-custom-header': 'custom-value',
+  },
 });
 
 // Use the session for making API calls with the custom headers
@@ -188,6 +194,6 @@ getConfig(): Readonly<ComposioConfig>
 **Returns**
 
 `Readonly<ComposioConfig>` — The frozen configuration
-  the SDK is initialized with.
+the SDK is initialized with.
 
 ---

--- a/docs/content/reference/sdk-reference/typescript/connected-accounts.mdx
+++ b/docs/content/reference/sdk-reference/typescript/connected-accounts.mdx
@@ -1,6 +1,6 @@
 ---
-title: "ConnectedAccounts"
-description: "ConnectedAccounts class  This class is used to manage connected accounts in the Composio SDK. Connected accounts are used to authenticate with third-party services."
+title: 'ConnectedAccounts'
+description: 'ConnectedAccounts class  This class is used to manage connected accounts in the Composio SDK. Connected accounts are used to authenticate with third-party services.'
 ---
 
 ## Usage
@@ -27,8 +27,8 @@ async delete(nanoid: string): Promise<ConnectedAccountDeleteResponse>
 
 **Parameters**
 
-| Name | Type | Description |
-|------|------|-------------|
+| Name     | Type     | Description                                              |
+| -------- | -------- | -------------------------------------------------------- |
 | `nanoid` | `string` | The unique identifier of the connected account to delete |
 
 **Returns**
@@ -54,8 +54,8 @@ async disable(nanoid: string): Promise<ConnectedAccountUpdateStatusResponse>
 
 **Parameters**
 
-| Name | Type | Description |
-|------|------|-------------|
+| Name     | Type     | Description                                |
+| -------- | -------- | ------------------------------------------ |
 | `nanoid` | `string` | Unique identifier of the connected account |
 
 **Returns**
@@ -88,8 +88,8 @@ async enable(nanoid: string): Promise<ConnectedAccountUpdateStatusResponse>
 
 **Parameters**
 
-| Name | Type | Description |
-|------|------|-------------|
+| Name     | Type     | Description                                |
+| -------- | -------- | ------------------------------------------ |
 | `nanoid` | `string` | Unique identifier of the connected account |
 
 **Returns**
@@ -119,8 +119,8 @@ async get(nanoid: string): Promise<...>
 
 **Parameters**
 
-| Name | Type | Description |
-|------|------|-------------|
+| Name     | Type     | Description                                    |
+| -------- | -------- | ---------------------------------------------- |
 | `nanoid` | `string` | The unique identifier of the connected account |
 
 **Returns**
@@ -166,11 +166,11 @@ async initiate(userId: string, authConfigId: string, options?: object): Promise<
 
 **Parameters**
 
-| Name | Type | Description |
-|------|------|-------------|
-| `userId` | `string` | User ID of the connected account |
-| `authConfigId` | `string` | Auth config ID of the connected account |
-| `options?` | `object` | Options for creating a new connected account |
+| Name           | Type     | Description                                  |
+| -------------- | -------- | -------------------------------------------- |
+| `userId`       | `string` | User ID of the connected account             |
+| `authConfigId` | `string` | Auth config ID of the connected account      |
+| `options?`     | `object` | Options for creating a new connected account |
 
 **Returns**
 
@@ -180,45 +180,70 @@ async initiate(userId: string, authConfigId: string, options?: object): Promise<
 
 ```typescript
 // For OAuth2 authentication
-const connectionRequest = await composio.connectedAccounts.initiate(
-  'user_123',
-  'auth_config_123',
-  {
-    callbackUrl: 'https://your-app.com/callback',
-    config: AuthScheme.OAuth2({
-      access_token: 'your_access_token',
-      token_type: 'Bearer'
-    })
-  }
-);
+const connectionRequest = await composio.connectedAccounts.initiate('user_123', 'auth_config_123', {
+  callbackUrl: 'https://your-app.com/callback',
+  config: AuthScheme.OAuth2({
+    access_token: 'your_access_token',
+    token_type: 'Bearer',
+  }),
+});
 
 // For API Key authentication
-const connectionRequest = await composio.connectedAccounts.initiate(
-  'user_123',
-  'auth_config_123',
-  {
-    config: AuthScheme.ApiKey({
-      api_key: 'your_api_key'
-    })
-  }
-);
+const connectionRequest = await composio.connectedAccounts.initiate('user_123', 'auth_config_123', {
+  config: AuthScheme.ApiKey({
+    api_key: 'your_api_key',
+  }),
+});
 
 // For Basic authentication
-const connectionRequest = await composio.connectedAccounts.initiate(
-  'user_123',
-  'auth_config_123',
-  {
-    config: AuthScheme.Basic({
-      username: 'your_username',
-      password: 'your_password'
-    })
-  }
-);
+const connectionRequest = await composio.connectedAccounts.initiate('user_123', 'auth_config_123', {
+  config: AuthScheme.Basic({
+    username: 'your_username',
+    password: 'your_password',
+  }),
+});
 ```
 
 ---
 
 ### link()
+
+**Overload 1**
+
+```typescript
+async link(userId: string, options: object): Promise<ConnectionRequest>
+```
+
+**Parameters**
+
+| Name      | Type     | Description                                                                                |
+| --------- | -------- | ------------------------------------------------------------------------------------------ |
+| `userId`  | `string` | \{string\} - The external user ID to create the connected account for.                     |
+| `options` | `object` | \{CreateConnectedAccountLinkOptions\} - Options for creating a new connected account link. |
+
+**Returns**
+
+`Promise<ConnectionRequest>` — Connection request object
+
+**Overload 2**
+
+```typescript
+async link(userId: string, authConfigId: undefined, options: object): Promise<ConnectionRequest>
+```
+
+**Parameters**
+
+| Name           | Type        | Description                                                                                                                                                                               |
+| -------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `userId`       | `string`    | \{string\} - The external user ID to create the connected account for.                                                                                                                    |
+| `authConfigId` | `undefined` | \{string\} - The auth config ID to create the connected account for. Omit it and pass `options.toolkit` to use or create the default Tool-Router-compatible auth config for that toolkit. |
+| `options`      | `object`    | \{CreateConnectedAccountLinkOptions\} - Options for creating a new connected account link.                                                                                                |
+
+**Returns**
+
+`Promise<ConnectionRequest>` — Connection request object
+
+**Overload 3**
 
 ```typescript
 async link(userId: string, authConfigId: string, options?: object): Promise<ConnectionRequest>
@@ -226,11 +251,11 @@ async link(userId: string, authConfigId: string, options?: object): Promise<Conn
 
 **Parameters**
 
-| Name | Type | Description |
-|------|------|-------------|
-| `userId` | `string` | \{string\} - The external user ID to create the connected account for. |
-| `authConfigId` | `string` | \{string\} - The auth config ID to create the connected account for. |
-| `options?` | `object` | \{CreateConnectedAccountOptions\} - Options for creating a new connected account. |
+| Name           | Type     | Description                                                                                                                                                                               |
+| -------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `userId`       | `string` | \{string\} - The external user ID to create the connected account for.                                                                                                                    |
+| `authConfigId` | `string` | \{string\} - The auth config ID to create the connected account for. Omit it and pass `options.toolkit` to use or create the default Tool-Router-compatible auth config for that toolkit. |
+| `options?`     | `object` | \{CreateConnectedAccountLinkOptions\} - Options for creating a new connected account link.                                                                                                |
 
 **Returns**
 
@@ -245,19 +270,28 @@ const redirectUrl = connectionRequest.redirectUrl;
 console.log(`Visit: ${redirectUrl} to authenticate your account`);
 
 // Wait for the connection to be established
-const connectedAccount = await connectionRequest.waitForConnection()
+const connectedAccount = await connectionRequest.waitForConnection();
 ```
 
 ```typescript
 // create a connection request and redirect the user to the redirect url
 const connectionRequest = await composio.connectedAccounts.link('user_123', 'auth_config_123', {
-  callbackUrl: 'https://your-app.com/callback'
+  callbackUrl: 'https://your-app.com/callback',
 });
 const redirectUrl = connectionRequest.redirectUrl;
 console.log(`Visit: ${redirectUrl} to authenticate your account`);
 
 // Wait for the connection to be established
 const connectedAccount = await composio.connectedAccounts.waitForConnection(connectionRequest.id);
+```
+
+```typescript
+// Omit authConfigId and let the SDK use/create a Tool-Router-compatible
+// Composio-managed auth config for the toolkit.
+const connectionRequest = await composio.connectedAccounts.link('user_123', {
+  toolkit: 'github',
+  callbackUrl: 'https://your-app.com/callback',
+});
 ```
 
 ---
@@ -274,8 +308,8 @@ async list(query?: object): Promise<...>
 
 **Parameters**
 
-| Name | Type | Description |
-|------|------|-------------|
+| Name     | Type     | Description                                                |
+| -------- | -------- | ---------------------------------------------------------- |
 | `query?` | `object` | Optional query parameters for filtering connected accounts |
 
 **Returns**
@@ -290,12 +324,12 @@ const allAccounts = await composio.connectedAccounts.list();
 
 // List accounts for a specific user
 const userAccounts = await composio.connectedAccounts.list({
-  userIds: ['user123']
+  userIds: ['user123'],
 });
 
 // List accounts for a specific toolkit
 const githubAccounts = await composio.connectedAccounts.list({
-  toolkitSlugs: ['github']
+  toolkitSlugs: ['github'],
 });
 ```
 
@@ -314,10 +348,10 @@ async refresh(nanoid: string, options?: { redirectUrl?: string; validateCredenti
 
 **Parameters**
 
-| Name | Type | Description |
-|------|------|-------------|
-| `nanoid` | `string` | The unique identifier of the connected account to refresh |
-| `options?` | `object` |  |
+| Name       | Type     | Description                                               |
+| ---------- | -------- | --------------------------------------------------------- |
+| `nanoid`   | `string` | The unique identifier of the connected account to refresh |
+| `options?` | `object` |                                                           |
 
 **Returns**
 
@@ -345,10 +379,10 @@ async update(nanoid: string, params: ConnectedAccountUpdateStatusParams): Promis
 
 **Parameters**
 
-| Name | Type | Description |
-|------|------|-------------|
-| `nanoid` | `string` | The unique identifier of the connected account |
-| `params` | `ConnectedAccountUpdateStatusParams` | The update parameters |
+| Name     | Type                                 | Description                                    |
+| -------- | ------------------------------------ | ---------------------------------------------- |
+| `nanoid` | `string`                             | The unique identifier of the connected account |
+| `params` | `ConnectedAccountUpdateStatusParams` | The update parameters                          |
 
 **Returns**
 
@@ -373,10 +407,10 @@ async updateStatus(nanoid: string, params: ConnectedAccountUpdateStatusParams): 
 
 **Parameters**
 
-| Name | Type | Description |
-|------|------|-------------|
-| `nanoid` | `string` | Unique identifier of the connected account |
-| `params` | `ConnectedAccountUpdateStatusParams` | Parameters for updating the status |
+| Name     | Type                                 | Description                                |
+| -------- | ------------------------------------ | ------------------------------------------ |
+| `nanoid` | `string`                             | Unique identifier of the connected account |
+| `params` | `ConnectedAccountUpdateStatusParams` | Parameters for updating the status         |
 
 **Returns**
 
@@ -387,13 +421,13 @@ async updateStatus(nanoid: string, params: ConnectedAccountUpdateStatusParams): 
 ```typescript
 // Enable a connected account
 const updatedAccount = await composio.connectedAccounts.updateStatus('conn_abc123', {
-  enabled: true
+  enabled: true,
 });
 
 // Disable a connected account with a reason
 const disabledAccount = await composio.connectedAccounts.updateStatus('conn_abc123', {
   enabled: false,
-  reason: 'Token expired'
+  reason: 'Token expired',
 });
 ```
 
@@ -412,10 +446,10 @@ async waitForConnection(connectedAccountId: string, timeout?: number): Promise<.
 
 **Parameters**
 
-| Name | Type | Description |
-|------|------|-------------|
-| `connectedAccountId` | `string` | The ID of the connected account to wait for |
-| `timeout?` | `number` | Maximum time to wait in milliseconds (default: 60 seconds) |
+| Name                 | Type     | Description                                                |
+| -------------------- | -------- | ---------------------------------------------------------- |
+| `connectedAccountId` | `string` | The ID of the connected account to wait for                |
+| `timeout?`           | `number` | Maximum time to wait in milliseconds (default: 60 seconds) |
 
 **Returns**
 

--- a/docs/content/reference/sdk-reference/typescript/index.mdx
+++ b/docs/content/reference/sdk-reference/typescript/index.mdx
@@ -1,49 +1,34 @@
 ---
-title: "TypeScript SDK Reference"
-description: "Complete API reference for the Composio TypeScript SDK (@composio/core)."
+title: 'TypeScript SDK Reference'
+description: 'Complete API reference for the Composio TypeScript SDK (@composio/core).'
 ---
 
 ## Installation
 
 <Tabs groupId="package-manager" items={['npm', 'pnpm', 'yarn', 'bun']} persist>
-<Tab value="npm">
-```bash
-npm install @composio/core
-```
-</Tab>
-<Tab value="pnpm">
-```bash
-pnpm add @composio/core
-```
-</Tab>
-<Tab value="yarn">
-```bash
-yarn add @composio/core
-```
-</Tab>
-<Tab value="bun">
-```bash
-bun add @composio/core
-```
-</Tab>
+  <Tab value="npm">```bash npm install @composio/core ```</Tab>
+  <Tab value="pnpm">```bash pnpm add @composio/core ```</Tab>
+  <Tab value="yarn">```bash yarn add @composio/core ```</Tab>
+  <Tab value="bun">```bash bun add @composio/core ```</Tab>
 </Tabs>
 
 ## Classes
 
-| Class | Description |
-|-------|-------------|
-| [`Composio`](/reference/sdk-reference/typescript/composio) | This is the core class for Composio. |
-| [`AuthConfigs`](/reference/sdk-reference/typescript/auth-configs) | AuthConfigs class |
-| [`ConnectedAccounts`](/reference/sdk-reference/typescript/connected-accounts) | ConnectedAccounts class |
-| [`Experimental`](/reference/sdk-reference/typescript/experimental) | `composio.experimental` namespace. Mirrors the Python SDK's |
-| [`MCP`](/reference/sdk-reference/typescript/mcp) | MCP (Model Control Protocol) class |
-| [`RemoteFile`](/reference/sdk-reference/typescript/remote-file) | Represents a file stored in a tool router session's file mount. |
-| [`SessionContextImpl`](/reference/sdk-reference/typescript/session-context-impl) | Concrete implementation of SessionContext. |
-| [`Toolkits`](/reference/sdk-reference/typescript/toolkits) | Toolkits class |
-| [`ToolRouterSession`](/reference/sdk-reference/typescript/tool-router-session) | ToolRouterSession API |
-| [`ToolRouterSessionFilesMount`](/reference/sdk-reference/typescript/tool-router-session-files-mount) | ToolRouterSessionFilesMount API |
-| [`Tools`](/reference/sdk-reference/typescript/tools) | This class is used to manage tools in the Composio SDK. |
-| [`Triggers`](/reference/sdk-reference/typescript/triggers) | Trigger (Instance) class |
+| Class                                                                                                | Description                                                     |
+| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| [`Composio`](/reference/sdk-reference/typescript/composio)                                           | This is the core class for Composio.                            |
+| [`AuthConfigs`](/reference/sdk-reference/typescript/auth-configs)                                    | AuthConfigs class                                               |
+| [`ConnectedAccounts`](/reference/sdk-reference/typescript/connected-accounts)                        | ConnectedAccounts class                                         |
+| [`Experimental`](/reference/sdk-reference/typescript/experimental)                                   | `composio.experimental` namespace. Mirrors the Python SDK's     |
+| [`MCP`](/reference/sdk-reference/typescript/mcp)                                                     | MCP (Model Control Protocol) class                              |
+| [`RemoteFile`](/reference/sdk-reference/typescript/remote-file)                                      | Represents a file stored in a tool router session's file mount. |
+| [`SessionContextImpl`](/reference/sdk-reference/typescript/session-context-impl)                     | Concrete implementation of SessionContext.                      |
+| [`Sessions`](/reference/sdk-reference/typescript/sessions)                                           | First-class API for creating and reusing Composio sessions.     |
+| [`Toolkits`](/reference/sdk-reference/typescript/toolkits)                                           | Toolkits class                                                  |
+| [`ToolRouterSession`](/reference/sdk-reference/typescript/tool-router-session)                       | ToolRouterSession API                                           |
+| [`ToolRouterSessionFilesMount`](/reference/sdk-reference/typescript/tool-router-session-files-mount) | ToolRouterSessionFilesMount API                                 |
+| [`Tools`](/reference/sdk-reference/typescript/tools)                                                 | This class is used to manage tools in the Composio SDK.         |
+| [`Triggers`](/reference/sdk-reference/typescript/triggers)                                           | Trigger (Instance) class                                        |
 
 ## Quick Start
 
@@ -51,17 +36,17 @@ bun add @composio/core
 import { Composio } from '@composio/core';
 
 const composio = new Composio({
-  apiKey: process.env.COMPOSIO_API_KEY
+  apiKey: process.env.COMPOSIO_API_KEY,
 });
 
 // Get tools for a user
 const tools = await composio.tools.get('user-123', {
-  toolkits: ['github']
+  toolkits: ['github'],
 });
 
 // Execute a tool
 const result = await composio.tools.execute('GITHUB_GET_REPOS', {
   userId: 'user-123',
-  arguments: { owner: 'composio' }
+  arguments: { owner: 'composio' },
 });
 ```

--- a/docs/content/reference/sdk-reference/typescript/meta.json
+++ b/docs/content/reference/sdk-reference/typescript/meta.json
@@ -8,6 +8,7 @@
     "mcp",
     "remote-file",
     "session-context-impl",
+    "sessions",
     "toolkits",
     "tool-router-session",
     "tool-router-session-files-mount",

--- a/docs/content/reference/sdk-reference/typescript/sessions.mdx
+++ b/docs/content/reference/sdk-reference/typescript/sessions.mdx
@@ -1,0 +1,98 @@
+---
+title: 'Sessions'
+description: 'First-class API for creating and reusing Composio sessions.  `composio.sessions.create(...)` is the canonical session creation entrypoint. The top-level `composio.create(...)` method remains as a backwards-compatible alias for `composio.sessions.create(...)`.'
+---
+
+## Usage
+
+Access this class through the `composio.sessions` property:
+
+```typescript
+import { Composio } from '@composio/core';
+
+const composio = new Composio({ apiKey: 'your-api-key' });
+const session = await composio.sessions.create('user_123', {
+  toolkits: ['github'],
+});
+
+// Backwards-compatible alias:
+const same = await composio.create('user_123', {
+  toolkits: ['github'],
+});
+```
+
+## Methods
+
+### create()
+
+Creates a new tool router session for a user.
+Use `sessionPreset: SessionPreset.DIRECT_TOOLS` when all needed tools
+should be exposed directly; see `ToolRouterCreateSessionConfig`.
+
+```typescript
+async create(userId: string, config?: object): Promise<Session<TToolCollection, TTool, TProvider>>
+```
+
+**Parameters**
+
+| Name      | Type     | Description                                                              |
+| --------- | -------- | ------------------------------------------------------------------------ |
+| `userId`  | `string` | \{string\} The user id to create the session for                         |
+| `config?` | `object` | \{ToolRouterCreateSessionConfig\} The config for the tool router session |
+
+**Returns**
+
+`Promise<Session<TToolCollection, TTool, TProvider>>` — The tool router session
+
+**Example**
+
+```typescript
+import { Composio } from '@composio/core';
+
+const composio = new Composio();
+
+const session = await composio.sessions.create('user_123', {
+  toolkits: ['gmail'],
+  manageConnections: true,
+  experimental: {
+    customTools: [myCustomTool],
+    customToolkits: [myToolkit],
+  },
+});
+```
+
+---
+
+### use()
+
+Use an existing session
+
+```typescript
+async use(id: string, options?: { customToolkits?: CustomToolkit[]; customTools?: CustomTool[] }): Promise<Session<TToolCollection, TTool, TProvider>>
+```
+
+**Parameters**
+
+| Name       | Type     | Description                             |
+| ---------- | -------- | --------------------------------------- |
+| `id`       | `string` | \{string\} The id of the session to use |
+| `options?` | `object` |                                         |
+
+**Returns**
+
+`Promise<Session<TToolCollection, TTool, TProvider>>` — The tool router session
+
+**Example**
+
+```typescript
+import { Composio } from '@composio/core';
+
+const composio = new Composio();
+const id = 'session_123';
+const session = await composio.sessions.use(id);
+
+console.log(session.mcp.url);
+console.log(session.mcp.headers);
+```
+
+---

--- a/ts/packages/core/package.json
+++ b/ts/packages/core/package.json
@@ -73,9 +73,10 @@
   },
   "files": [
     "README.md",
+    "docs",
     "dist",
     "generated",
-    "src/platform"
+    "src"
   ],
   "scripts": {
     "clean": "git clean -xdf node_modules",

--- a/ts/packages/core/src/composio.ts
+++ b/ts/packages/core/src/composio.ts
@@ -19,6 +19,7 @@ import { Files } from '#files';
 import { getDefaultHeaders } from './utils/session';
 import { ToolkitVersionParam } from './types/tool.types';
 import { ToolRouter } from './models/ToolRouter';
+import { Sessions } from './models/Sessions';
 import { ToolRouterCreateSessionConfig, Session } from './types/toolRouter.types';
 import type { CustomTool, CustomToolkit } from './types/customTool.types';
 import { CONFIG_DEFAULTS } from './utils/config-defaults';
@@ -206,8 +207,15 @@ export class Composio<
   /** Model Context Protocol server management */
   mcp: MCP;
   /**
-   * Experimental feature, use with caution
-   * @experimental
+   * Create and reuse Composio sessions.
+   *
+   * Prefer `composio.sessions.create(...)` for new code. The top-level
+   * `composio.create(...)` method is kept as an alias.
+   */
+  sessions: Sessions<unknown, unknown, TProvider>;
+  /**
+   * Legacy alias for `composio.sessions`.
+   * @deprecated Use `composio.sessions` instead.
    */
   toolRouter: ToolRouter<unknown, unknown, TProvider>;
   /**
@@ -226,7 +234,12 @@ export class Composio<
    * const composio = new Composio();
    * const userId = 'user_123';
    *
-   * const session = await composio.create(userId, {
+   * const session = await composio.sessions.create(userId, {
+   *  manageConnections: true,
+   * });
+   *
+   * // Backwards-compatible alias:
+   * const same = await composio.create(userId, {
    *  manageConnections: true,
    * });
    *
@@ -341,14 +354,15 @@ export class Composio<
     });
     this.connectedAccounts = new ConnectedAccounts(this.client);
     this.experimental = new Experimental(this.client);
-    this.toolRouter = new ToolRouter(this.client, this.config);
+    this.sessions = new Sessions(this.client, this.config);
+    this.toolRouter = this.sessions;
 
     /**
-     * Initialize tool router methods
-     * Properly bind the methods to maintain the correct 'this' context
+     * Initialize session aliases.
+     * Properly bind the methods to maintain the correct 'this' context.
      */
-    this.create = this.toolRouter.create.bind(this.toolRouter);
-    this.use = this.toolRouter.use.bind(this.toolRouter);
+    this.create = this.sessions.create.bind(this.sessions);
+    this.use = this.sessions.use.bind(this.sessions);
 
     /**
      * Initialize the client telemetry.

--- a/ts/packages/core/src/index.ts
+++ b/ts/packages/core/src/index.ts
@@ -21,6 +21,7 @@ export { MCP } from './models/MCP';
 export { RemoteFile } from './models/RemoteFile';
 export { createConnectionRequest } from './models/ConnectionRequest';
 export { ToolRouterSession } from './models/ToolRouterSession';
+export { Sessions } from './models/Sessions';
 export * from './types/provider.types';
 export * from './types/customTool.types';
 export * from './types/tool.types';

--- a/ts/packages/core/src/models/ConnectedAccounts.ts
+++ b/ts/packages/core/src/models/ConnectedAccounts.ts
@@ -53,6 +53,8 @@ import { ConnectionData } from '../types/connectedAccountAuthStates.types';
 // warning on every initiate() call.
 let _legacyInitiateWarningEmitted = false;
 
+const TOOL_ROUTER_AUTH_CONFIG_LIST_LIMIT = 100;
+
 /**
  * ConnectedAccounts class
  *
@@ -65,6 +67,38 @@ export class ConnectedAccounts {
   constructor(client: ComposioClient) {
     this.client = client;
     telemetry.instrument(this, 'ConnectedAccounts');
+  }
+
+  /**
+   * Resolve the Composio-managed auth config that Tool Router would use for a
+   * toolkit, creating one when the project does not have a compatible config yet.
+   */
+  private async resolveToolRouterAuthConfigId(toolkit: string): Promise<string> {
+    const existing = await this.client.authConfigs.list({
+      toolkit_slug: toolkit,
+      is_composio_managed: true,
+      limit: TOOL_ROUTER_AUTH_CONFIG_LIST_LIMIT,
+    });
+
+    const compatible = existing.items.find(
+      authConfig =>
+        authConfig.id &&
+        authConfig.is_enabled_for_tool_router !== false &&
+        authConfig.status !== 'DISABLED'
+    );
+    if (compatible?.id) {
+      return compatible.id;
+    }
+
+    const created = await this.client.authConfigs.create({
+      toolkit: { slug: toolkit },
+      auth_config: {
+        type: 'use_composio_managed_auth',
+        is_enabled_for_tool_router: true,
+      },
+    });
+
+    return created.auth_config.id;
   }
 
   /**
@@ -314,8 +348,8 @@ export class ConnectedAccounts {
    * @docs https://docs.composio.dev/reference/connected-accounts/create-connected-account#create-a-composio-connect-link
    *
    * @param userId {string} - The external user ID to create the connected account for.
-   * @param authConfigId {string} - The auth config ID to create the connected account for.
-   * @param options {CreateConnectedAccountOptions} - Options for creating a new connected account.
+   * @param authConfigId {string} - The auth config ID to create the connected account for. Omit it and pass `options.toolkit` to use or create the default Tool-Router-compatible auth config for that toolkit.
+   * @param options {CreateConnectedAccountLinkOptions} - Options for creating a new connected account link.
    * @param options.callbackUrl {string} - The url to redirect the user to post connecting their account.
    * @returns {ConnectionRequest} Connection request object
    *
@@ -342,17 +376,61 @@ export class ConnectedAccounts {
    * // Wait for the connection to be established
    * const connectedAccount = await composio.connectedAccounts.waitForConnection(connectionRequest.id);
    * ```
+   *
+   * @example
+   * ```typescript
+   * // Omit authConfigId and let the SDK use/create a Tool-Router-compatible
+   * // Composio-managed auth config for the toolkit.
+   * const connectionRequest = await composio.connectedAccounts.link('user_123', {
+   *   toolkit: 'github',
+   *   callbackUrl: 'https://your-app.com/callback'
+   * });
+   * ```
    */
+  async link(
+    userId: string,
+    options: CreateConnectedAccountLinkOptions & { toolkit: string }
+  ): Promise<ConnectionRequest>;
+  async link(
+    userId: string,
+    authConfigId: undefined,
+    options: CreateConnectedAccountLinkOptions & { toolkit: string }
+  ): Promise<ConnectionRequest>;
   async link(
     userId: string,
     authConfigId: string,
     options?: CreateConnectedAccountLinkOptions
+  ): Promise<ConnectionRequest>;
+  async link(
+    userId: string,
+    authConfigIdOrOptions?: string | CreateConnectedAccountLinkOptions,
+    options?: CreateConnectedAccountLinkOptions
   ): Promise<ConnectionRequest> {
-    const requestOptions = await CreateConnectedAccountLinkOptionsSchema.safeParse(options || {});
+    const rawOptions =
+      typeof authConfigIdOrOptions === 'string' || authConfigIdOrOptions === undefined
+        ? options
+        : authConfigIdOrOptions;
+    const requestOptions = await CreateConnectedAccountLinkOptionsSchema.safeParse(
+      rawOptions || {}
+    );
     if (!requestOptions.success) {
       throw new ValidationError('Failed to parse create connected account link options', {
         cause: requestOptions.error,
       });
+    }
+
+    const opts = requestOptions.data;
+    const authConfigId =
+      typeof authConfigIdOrOptions === 'string'
+        ? authConfigIdOrOptions
+        : opts.toolkit
+          ? await this.resolveToolRouterAuthConfigId(opts.toolkit)
+          : undefined;
+
+    if (!authConfigId) {
+      throw new ValidationError(
+        'authConfigId is required unless options.toolkit is provided to connectedAccounts.link()'
+      );
     }
 
     // Mirror initiate(): guard against silently creating extra connections on
@@ -372,7 +450,6 @@ export class ConnectedAccounts {
       );
     }
 
-    const opts = requestOptions.data;
     const experimentalWire = serializeExperimentalForWire(opts.experimental);
     const body: LinkCreateParams = {
       auth_config_id: authConfigId,

--- a/ts/packages/core/src/models/Sessions.ts
+++ b/ts/packages/core/src/models/Sessions.ts
@@ -1,0 +1,21 @@
+import type { Composio as ComposioClient } from '@composio/client';
+import type { BaseComposioProvider } from '../provider/BaseProvider';
+import type { ComposioConfig } from '../composio';
+import { ToolRouter } from './ToolRouter';
+
+/**
+ * First-class API for creating and reusing Composio sessions.
+ *
+ * `composio.sessions.create(...)` is the canonical session creation entrypoint.
+ * The top-level `composio.create(...)` method remains as a backwards-compatible
+ * alias for `composio.sessions.create(...)`.
+ */
+export class Sessions<
+  TToolCollection,
+  TTool,
+  TProvider extends BaseComposioProvider<TToolCollection, TTool, unknown>,
+> extends ToolRouter<TToolCollection, TTool, TProvider> {
+  constructor(client: ComposioClient, config?: ComposioConfig<TProvider>) {
+    super(client, config);
+  }
+}

--- a/ts/packages/core/src/models/ToolRouter.ts
+++ b/ts/packages/core/src/models/ToolRouter.ts
@@ -9,7 +9,7 @@
  * const composio = new Composio();
  * const userId = 'user_123';
  *
- * const session = await composio.experimental.create(userId, {
+ * const session = await composio.sessions.create(userId, {
  *   toolkits: ['gmail'],
  *   manageConnections: true
  * });
@@ -19,8 +19,8 @@
  */
 import { Composio as ComposioClient } from '@composio/client';
 import { telemetry } from '../telemetry/Telemetry';
-import { BaseComposioProvider } from '../provider/BaseProvider';
-import { ComposioConfig } from '../composio';
+import type { BaseComposioProvider } from '../provider/BaseProvider';
+import type { ComposioConfig } from '../composio';
 import {
   ToolRouterCreateSessionConfig,
   Session,
@@ -155,7 +155,7 @@ export class ToolRouter<
    *
    * const composio = new Composio();
    *
-   * const session = await composio.create('user_123', {
+   * const session = await composio.sessions.create('user_123', {
    *   toolkits: ['gmail'],
    *   manageConnections: true,
    *   experimental: {
@@ -274,7 +274,7 @@ export class ToolRouter<
    *
    * const composio = new Composio();
    * const id = 'session_123';
-   * const session = await composio.toolRouter.use(id);
+   * const session = await composio.sessions.use(id);
    *
    * console.log(session.mcp.url);
    * console.log(session.mcp.headers);

--- a/ts/packages/core/src/models/ToolRouterSession.ts
+++ b/ts/packages/core/src/models/ToolRouterSession.ts
@@ -1,7 +1,7 @@
 import { telemetry } from '../telemetry/Telemetry';
 import { Composio as ComposioClient, BadRequestError } from '@composio/client';
-import { BaseComposioProvider } from '../provider/BaseProvider';
-import { ComposioConfig } from '../composio';
+import type { BaseComposioProvider } from '../provider/BaseProvider';
+import type { ComposioConfig } from '../composio';
 import {
   ToolRouterMCPServerConfig,
   SessionExperimental,

--- a/ts/packages/core/src/models/Tools.ts
+++ b/ts/packages/core/src/models/Tools.ts
@@ -37,7 +37,7 @@ import {
   ProviderOptions,
   TransformToolSchemaModifier,
 } from '../types/modifiers.types';
-import { BaseComposioProvider } from '../provider/BaseProvider';
+import type { BaseComposioProvider } from '../provider/BaseProvider';
 import logger from '../utils/logger';
 import { ExecuteToolFn, GlobalExecuteToolFn } from '../types/provider.types';
 import {
@@ -48,7 +48,7 @@ import {
 } from '../errors/ToolErrors';
 import { ValidationError } from '../errors/ValidationErrors';
 import { telemetry } from '../telemetry/Telemetry';
-import { ComposioConfig } from '../composio';
+import type { ComposioConfig } from '../composio';
 import { getToolkitVersion } from '../utils/toolkitVersion';
 import { handleToolExecutionError } from '../errors/ToolErrors';
 import type { SessionExecuteParams } from '@composio/client/resources/tool-router/session/session.mjs';

--- a/ts/packages/core/src/models/Triggers.ts
+++ b/ts/packages/core/src/models/Triggers.ts
@@ -49,8 +49,8 @@ import {
   transformTriggerTypeRetrieveResponse,
 } from '../utils/transformers/triggers';
 import { ToolkitVersionParam } from '../types/tool.types';
-import { ComposioConfig } from '../composio';
-import { BaseComposioProvider } from '../provider/BaseProvider';
+import type { ComposioConfig } from '../composio';
+import type { BaseComposioProvider } from '../provider/BaseProvider';
 import { hmacSha256Base64, timingSafeEqual } from '../utils/crypto';
 import { CONFIG_DEFAULTS } from '../utils/config-defaults';
 

--- a/ts/packages/core/src/types/connectedAccounts.types.ts
+++ b/ts/packages/core/src/types/connectedAccounts.types.ts
@@ -306,6 +306,12 @@ export type ConnectedAccountListResponse = z.infer<typeof ConnectedAccountListRe
 
 export const CreateConnectedAccountLinkOptionsSchema = z.object({
   /**
+   * Toolkit slug to connect when `authConfigId` is omitted from
+   * `connectedAccounts.link()`. The SDK will reuse an existing Composio-managed,
+   * Tool-Router-enabled auth config for this toolkit, or create one if needed.
+   */
+  toolkit: z.string().optional(),
+  /**
    * The url to redirect the user to post connecting their account.
    *
    * For successful connections, you will get a query param called status=success

--- a/ts/packages/core/src/utils/session.ts
+++ b/ts/packages/core/src/utils/session.ts
@@ -1,6 +1,6 @@
-import { BaseComposioProvider } from '../provider/BaseProvider';
+import type { BaseComposioProvider } from '../provider/BaseProvider';
 import { version } from '../../package.json';
-import { ComposioRequestHeaders } from '../types/composio.types';
+import type { ComposioRequestHeaders } from '../types/composio.types';
 
 /**
  * Extended globalThis interface for runtime detection

--- a/ts/packages/core/src/utils/transform.ts
+++ b/ts/packages/core/src/utils/transform.ts
@@ -12,7 +12,7 @@
  * ```
  */
 import { ZodTypeAny, z } from 'zod/v3';
-import { logger } from '..';
+import logger from './logger';
 
 export function transform<RawInput>(raw: RawInput) {
   return {

--- a/ts/packages/core/test/connectedAccounts/connectedAccounts.test.ts
+++ b/ts/packages/core/test/connectedAccounts/connectedAccounts.test.ts
@@ -32,6 +32,10 @@ const extendedMockClient = {
   link: {
     create: vi.fn(),
   },
+  authConfigs: {
+    list: vi.fn(),
+    create: vi.fn(),
+  },
 };
 
 describe('ConnectedAccounts', () => {
@@ -1155,6 +1159,101 @@ describe('ConnectedAccounts', () => {
       );
       expect(connectionRequest).toHaveProperty('waitForConnection');
       expect(typeof connectionRequest.waitForConnection).toBe('function');
+    });
+
+    it('should use an existing Tool-Router-compatible managed auth config when authConfigId is omitted', async () => {
+      const userId = 'user_123';
+
+      extendedMockClient.authConfigs.list.mockResolvedValueOnce({
+        items: [
+          {
+            id: 'auth_config_managed_github',
+            status: 'ENABLED',
+            is_enabled_for_tool_router: true,
+            is_composio_managed: true,
+            toolkit: { slug: 'github' },
+          },
+        ],
+        next_cursor: null,
+        total_pages: 1,
+      });
+      extendedMockClient.link.create.mockResolvedValueOnce({
+        connected_account_id: 'conn_456def',
+        redirect_url: 'https://connect.composio.dev/auth?token=abc123',
+      });
+
+      const connectionRequest = await connectedAccounts.link(userId, {
+        toolkit: 'github',
+        callbackUrl: 'https://example.com/callback',
+      });
+
+      expect(extendedMockClient.authConfigs.list).toHaveBeenCalledWith({
+        toolkit_slug: 'github',
+        is_composio_managed: true,
+        limit: 100,
+      });
+      expect(extendedMockClient.authConfigs.create).not.toHaveBeenCalled();
+      expect(extendedMockClient.connectedAccounts.list).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user_ids: [userId],
+          auth_config_ids: ['auth_config_managed_github'],
+          statuses: [ConnectedAccountStatuses.ACTIVE],
+        })
+      );
+      expect(extendedMockClient.link.create).toHaveBeenCalledWith({
+        auth_config_id: 'auth_config_managed_github',
+        user_id: userId,
+        callback_url: 'https://example.com/callback',
+      });
+      expect(connectionRequest).toHaveProperty('id', 'conn_456def');
+    });
+
+    it('should create a Tool-Router-compatible managed auth config when authConfigId is omitted and none exists', async () => {
+      const userId = 'user_123';
+
+      extendedMockClient.authConfigs.list.mockResolvedValueOnce({
+        items: [],
+        next_cursor: null,
+        total_pages: 0,
+      });
+      extendedMockClient.authConfigs.create.mockResolvedValueOnce({
+        auth_config: {
+          id: 'auth_config_created_github',
+          auth_scheme: 'OAUTH2',
+          is_composio_managed: true,
+        },
+        toolkit: { slug: 'github' },
+      });
+      extendedMockClient.link.create.mockResolvedValueOnce({
+        connected_account_id: 'conn_created',
+        redirect_url: 'https://connect.composio.dev/auth?token=created',
+      });
+
+      const connectionRequest = await connectedAccounts.link(userId, undefined, {
+        toolkit: 'github',
+      });
+
+      expect(extendedMockClient.authConfigs.create).toHaveBeenCalledWith({
+        toolkit: { slug: 'github' },
+        auth_config: {
+          type: 'use_composio_managed_auth',
+          is_enabled_for_tool_router: true,
+        },
+      });
+      expect(extendedMockClient.link.create).toHaveBeenCalledWith({
+        auth_config_id: 'auth_config_created_github',
+        user_id: userId,
+      });
+      expect(connectionRequest).toHaveProperty('id', 'conn_created');
+    });
+
+    it('should require options.toolkit when authConfigId is omitted', async () => {
+      await expect(
+        connectedAccounts.link('user_123', undefined as any, {
+          callbackUrl: 'https://example.com/callback',
+        })
+      ).rejects.toThrow('authConfigId is required unless options.toolkit is provided');
+      expect(extendedMockClient.link.create).not.toHaveBeenCalled();
     });
 
     it('should create a connected account link with callback URL and return a ConnectionRequest', async () => {

--- a/ts/packages/core/test/core/session.test.ts
+++ b/ts/packages/core/test/core/session.test.ts
@@ -109,6 +109,38 @@ describe('Composio Session Management', () => {
       'x-sdk-version': version,
     });
   });
+
+  it('should expose sessions.create and keep composio.create as a bound alias', async () => {
+    const composio = new Composio(baseConfig);
+    const client = composio.getClient() as any;
+    client.toolRouter.session.create = vi.fn().mockResolvedValue({
+      session_id: 'session_123',
+      mcp: {
+        type: 'http',
+        url: 'https://mcp.example.com/session_123',
+      },
+      config: {
+        preload: { tools: [] },
+      },
+      config_version: 1,
+    });
+
+    expect(composio.toolRouter).toBe(composio.sessions);
+
+    const sessionFromCanonicalApi = await composio.sessions.create('user_123');
+    const sessionFromAlias = await composio.create('user_456');
+
+    expect(client.toolRouter.session.create).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ user_id: 'user_123' })
+    );
+    expect(client.toolRouter.session.create).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ user_id: 'user_456' })
+    );
+    expect(sessionFromCanonicalApi.sessionId).toBe('session_123');
+    expect(sessionFromAlias.sessionId).toBe('session_123');
+  });
 });
 
 describe('Session Headers Generation', () => {

--- a/ts/packages/core/tsdown.config.ts
+++ b/ts/packages/core/tsdown.config.ts
@@ -4,7 +4,15 @@ import { baseConfig } from '../../../tsdown.config.base.ts';
 export default defineConfig({
   ...baseConfig,
   tsconfig: 'tsconfig.build.json',
-  copy: [{ from: 'pack/generated/*', to: '.', flatten: false }],
+  copy: [
+    { from: 'pack/generated/*', to: '.', flatten: false },
+    { from: 'docs/**/*', to: 'dist/docs', flatten: false },
+    {
+      from: '../../../docs/content/reference/sdk-reference/typescript/*',
+      to: 'dist/docs/reference/sdk-reference/typescript',
+      flatten: true,
+    },
+  ],
   entry: [
     'src/index.ts',
     'src/experimental/index.ts',


### PR DESCRIPTION
## Summary
- Add `composio.sessions.create()` / `composio.sessions.use()` as the first-class sessions namespace while keeping `composio.create()` and `composio.use()` as bound aliases.
- Allow `composio.connectedAccounts.link(userId, { toolkit, ... })` (or `link(userId, undefined, { toolkit, ... })`) to reuse or create a Composio-managed Tool-Router-compatible auth config before creating the Connect link.
- Include TypeScript source and SDK docs in the packed `@composio/core` package, and copy generated TypeScript reference docs into `dist/docs` during the core build.
- Regenerate TypeScript SDK reference docs and add a changeset for `@composio/core`.

## Tests / checks
- `pnpm install --frozen-lockfile --ignore-scripts` (after the normal install hit the existing local `mise` preinstall requirement)
- `pnpm --filter @composio/json-schema-to-zod build`
- `pnpm --filter @composio/core generate:docs`
- `pnpm --filter @composio/core typecheck`
- `pnpm --filter @composio/core test`
- `pnpm --filter @composio/core build`
- `npm pack --dry-run --json` from `ts/packages/core` and verified `src/composio.ts`, `src/models/Sessions.ts`, `docs/error-consistency.md`, `dist/docs/reference/sdk-reference/typescript/sessions.mdx`, and `dist/index.mjs` are included.

## Notes
- This prepares the package contents for an `experimental-rahul` npm dist-tag. I did not publish to npm from this PR; release/publish should use the desired dist-tag, e.g. `npm publish --tag experimental-rahul`, after approval.
- CI watch was not started per workspace policy.
