### PR TITLE
fix(core): expose auth config list search filters

### DIFF
--- a/.changeset/auth-config-list-search.md
+++ b/.changeset/auth-config-list-search.md
@@ -1,0 +1,5 @@
+---
+'@composio/core': patch
+---
+
+Expose `search` and `showDisabled` filters on `authConfigs.list()`.

--- a/ts/docs/api/auth-configs.md
+++ b/ts/docs/api/auth-configs.md
@@ -16,6 +16,12 @@ const allAuthConfigs = await composio.authConfigs.list();
 const githubAuthConfigs = await composio.authConfigs.list({
   toolkit: 'github',
 });
+
+// Search auth configs by name or id and include disabled configs
+const searchedAuthConfigs = await composio.authConfigs.list({
+  search: 'github',
+  showDisabled: true,
+});
 ```
 
 **Parameters:**
@@ -81,8 +87,8 @@ const updatedAuthConfig = await composio.authConfigs.update('auth_config_123', {
     client_secret: 'new_client_secret',
   },
   toolAccessConfig: {
-    toolsAvailableForExecution: ['GITHUB_STAR_A_REPOSITORY_FOR_THE_AUTHENTICATED_USER']
-  }
+    toolsAvailableForExecution: ['GITHUB_STAR_A_REPOSITORY_FOR_THE_AUTHENTICATED_USER'],
+  },
 });
 
 // Update a default auth config with new scopes
@@ -90,8 +96,8 @@ const updatedDefaultAuth = await composio.authConfigs.update('auth_config_456', 
   type: 'default',
   scopes: 'read:user,repo',
   toolAccessConfig: {
-    toolsAvailableForExecution: ['GITHUB_GET_A_REPOSITORY', 'GITHUB_LIST_REPOSITORIES_FOR_A_USER']
-  }
+    toolsAvailableForExecution: ['GITHUB_GET_A_REPOSITORY', 'GITHUB_LIST_REPOSITORIES_FOR_A_USER'],
+  },
 });
 ```
 
@@ -104,7 +110,8 @@ const updatedDefaultAuth = await composio.authConfigs.update('auth_config_456', 
 
 **Returns:** Promise<AuthConfigUpdateResponse> - The updated auth config
 
-**Throws:** 
+**Throws:**
+
 - ValidationError if the update parameters are invalid
 - ComposioAuthConfigNotFoundError if the auth config cannot be found
 
@@ -133,8 +140,10 @@ await composio.authConfigs.delete('auth_config_123');
 interface AuthConfigListParams {
   cursor?: string; // Pagination cursor
   limit?: number; // Limit the number of results
-  orderBy?: string; // Order by field
+  search?: string; // Search auth configs by name or id
+  showDisabled?: boolean; // Include disabled auth configs
   toolkit?: string; // Filter by toolkit slug
+  isComposioManaged?: boolean; // Filter by Composio-managed auth configs
 }
 ```
 
@@ -184,7 +193,7 @@ interface AuthConfigCreateParams {
 
 ```typescript
 // Discriminated union type for updating auth configs
-type AuthConfigUpdateParams = 
+type AuthConfigUpdateParams =
   | {
       type: 'custom';
       credentials: Record<string, string | number | boolean | unknown>;

--- a/ts/packages/core/src/models/AuthConfigs.ts
+++ b/ts/packages/core/src/models/AuthConfigs.ts
@@ -72,6 +72,12 @@ export class AuthConfigs {
    *   toolkit: 'github'
    * });
    *
+   * // Search auth configs by name or id
+   * const searchedConfigs = await composio.authConfigs.list({
+   *   search: 'github',
+   *   showDisabled: true
+   * });
+   *
    * // List Composio-managed auth configs
    * const managedConfigs = await composio.authConfigs.list({
    *   isComposioManaged: true
@@ -84,6 +90,8 @@ export class AuthConfigs {
       cursor: parsedQuery?.cursor,
       is_composio_managed: parsedQuery?.isComposioManaged,
       limit: parsedQuery?.limit,
+      search: parsedQuery?.search,
+      show_disabled: parsedQuery?.showDisabled,
       toolkit_slug: parsedQuery?.toolkit,
     });
     return transformAuthConfigListResponse(result);

--- a/ts/packages/core/src/types/authConfigs.types.ts
+++ b/ts/packages/core/src/types/authConfigs.types.ts
@@ -125,6 +125,8 @@ export const AuthConfigListParamsSchema = z.object({
   cursor: z.string().optional(),
   isComposioManaged: z.boolean().optional(),
   limit: z.number().optional(),
+  search: z.string().optional(),
+  showDisabled: z.boolean().optional(),
   toolkit: z.string().optional(),
 });
 export type AuthConfigListParams = z.infer<typeof AuthConfigListParamsSchema>;

--- a/ts/packages/core/test/AuthConfigs/authConfigs.test.ts
+++ b/ts/packages/core/test/AuthConfigs/authConfigs.test.ts
@@ -162,6 +162,8 @@ describe('AuthConfigs', () => {
         cursor: undefined,
         is_composio_managed: undefined,
         limit: undefined,
+        search: undefined,
+        show_disabled: undefined,
         toolkit_slug: undefined,
       });
 
@@ -179,6 +181,8 @@ describe('AuthConfigs', () => {
         cursor: 'cursor_123',
         isComposioManaged: true,
         limit: 10,
+        search: 'github config',
+        showDisabled: true,
         toolkit: 'github',
       };
 
@@ -188,6 +192,8 @@ describe('AuthConfigs', () => {
         cursor: 'cursor_123',
         is_composio_managed: true,
         limit: 10,
+        search: 'github config',
+        show_disabled: true,
         toolkit_slug: 'github',
       });
 


### PR DESCRIPTION
This PR:
- exposes `search` and `showDisabled` on `authConfigs.list()`
- forwards those filters to the generated `@composio/client` as `search` and `show_disabled`
- documents the filters and adds a core changeset
- covers forwarding in `AuthConfigs` tests