### PR TITLE
fix(py): disable retries on non-idempotent tool writes to prevent duplicate side effects

### DIFF
--- a/python/composio/client/__init__.py
+++ b/python/composio/client/__init__.py
@@ -182,6 +182,50 @@ class HttpClient(BaseComposio, WithLogger):
                 "provider": provider,
             },
         )
+        # Lazily-built sibling client with retries disabled; see `without_retries`.
+        self._without_retries: t.Optional["HttpClient"] = None
+
+    def copy(  # type: ignore[override]
+        self,
+        *,
+        _extra_kwargs: t.Mapping[str, t.Any] = {},
+        **kwargs: t.Any,
+    ) -> te.Self:
+        """
+        Clone the client, re-injecting the required ``provider`` keyword.
+
+        The Stainless-generated ``copy`` rebuilds the client via
+        ``self.__class__(...)`` without passing ``provider``, which this subclass
+        requires — so the inherited ``copy``/``with_options`` raise ``TypeError``.
+        Threading ``provider`` through ``_extra_kwargs`` makes them work again
+        (e.g. ``with_options(max_retries=0)``).
+        """
+        return super().copy(  # type: ignore[misc]
+            _extra_kwargs={"provider": self.provider, **_extra_kwargs},
+            **kwargs,
+        )
+
+    # Re-alias `with_options` to this override. The base class binds
+    # `with_options = copy` at class-definition time, so without this it would
+    # still resolve to the base `copy` and miss the `provider` re-injection.
+    with_options = copy
+
+    @property
+    def without_retries(self) -> "HttpClient":
+        """
+        A cached sibling client that never retries requests.
+
+        Used for non-idempotent writes (``tools.execute`` / ``tools.proxy``),
+        where a silent retry after a read timeout can duplicate a side effect
+        (e.g. send an email twice). Reads keep the default retry behaviour.
+
+        The sibling is cached rather than rebuilt per call: each clone creates a
+        new ``ContextVar``, and dynamically-created ``ContextVar``s are never
+        garbage-collected.
+        """
+        if self._without_retries is None:
+            self._without_retries = self.with_options(max_retries=0)
+        return self._without_retries
 
     def _prepare_request(self, request: Request) -> None:
         """

--- a/python/composio/core/models/tools.py
+++ b/python/composio/core/models/tools.py
@@ -582,7 +582,9 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
 
         return t.cast(
             ToolExecutionResponse,
-            self._client.tools.execute(
+            # Disable retries: tool execution is a non-idempotent write, and a
+            # silent retry after a read timeout can duplicate the side effect.
+            self._client.without_retries.tools.execute(
                 tool_slug=slug,
                 arguments=arguments,
                 connected_account_id=none_to_omit(connected_account_id),
@@ -740,7 +742,9 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
         ] = None,
     ) -> tool_proxy_response.ToolProxyResponse:
         """Proxy a tool call to the Composio API"""
-        return self._client.tools.proxy(
+        # Disable retries: a proxied call is a non-idempotent write, and a silent
+        # retry after a read timeout can duplicate the side effect.
+        return self._client.without_retries.tools.proxy(
             endpoint=endpoint,
             method=method,
             body=body if body is not None else omit,

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -62,10 +62,23 @@ def load_golden_signatures() -> dict:
         return json.load(f)
 
 
+def mock_http_client() -> Mock:
+    """Build a mock ``HttpClient`` for tool-execution tests.
+
+    Production routes non-idempotent writes through ``client.without_retries``
+    (a retry-disabled clone of the client). The mock mirrors that by returning
+    itself for ``without_retries``, so assertions on ``client.tools.execute`` and
+    ``client.tools.proxy`` still observe the call.
+    """
+    client = Mock()
+    client.without_retries = client
+    return client
+
+
 @pytest.fixture
 def mock_client() -> Mock:
     """Create a mock HTTP client."""
-    client = Mock()
+    client = mock_http_client()
     client.triggers_types = Mock()
     client.trigger_instances = Mock()
     client.trigger_instances.manage = Mock()

--- a/python/tests/test_auto_upload_download_files.py
+++ b/python/tests/test_auto_upload_download_files.py
@@ -12,6 +12,8 @@ from composio.client.types import Tool, tool_list_response
 from composio.core.models.base import allow_tracking
 from composio.core.models.tools import Tools
 
+from tests.conftest import mock_http_client
+
 
 @pytest.fixture(autouse=True)
 def disable_telemetry():
@@ -24,7 +26,7 @@ def disable_telemetry():
 @pytest.fixture
 def mock_client():
     """Create a mock HTTP client."""
-    return Mock()
+    return mock_http_client()
 
 
 @pytest.fixture

--- a/python/tests/test_no_retry_writes.py
+++ b/python/tests/test_no_retry_writes.py
@@ -1,0 +1,161 @@
+"""Non-idempotent tool writes (``tools.execute`` / ``tools.proxy``) must not retry.
+
+A POST that times out while the backend is still processing it is unsafe to
+retry: the request may already have taken effect, so a silent re-send can
+duplicate the side effect (e.g. send an email twice). ``Tools.execute`` and
+``Tools.proxy`` therefore route through ``client.without_retries`` (a
+retry-disabled clone), while reads keep the default retry behaviour.
+"""
+
+import typing as t
+from unittest.mock import Mock, patch
+
+import httpx
+import pytest
+from composio_client import DEFAULT_MAX_RETRIES, APIError
+
+from composio.client import HttpClient
+from composio.core.models.base import allow_tracking
+from composio.core.models.tools import Tools
+
+
+@pytest.fixture(autouse=True)
+def disable_telemetry():
+    """Disable telemetry for all tests to prevent thread issues."""
+    token = allow_tracking.set(False)
+    yield
+    allow_tracking.reset(token)
+
+
+@pytest.fixture
+def no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Neutralise retry backoff so retry tests run instantly."""
+    import composio_client._base_client as base
+
+    monkeypatch.setattr(base.time, "sleep", lambda *args, **kwargs: None)
+
+
+def _client_with_transport(
+    handler: t.Callable[[httpx.Request], httpx.Response],
+) -> HttpClient:
+    """Build an ``HttpClient`` whose HTTP requests are served by ``handler``.
+
+    ``base_url`` is passed explicitly so the test does not depend on
+    ``COMPOSIO_BASE_URL`` possibly being set in the environment.
+    """
+    return HttpClient(
+        provider="test",
+        api_key="sk-test",
+        base_url="https://backend.invalid",
+        http_client=httpx.Client(transport=httpx.MockTransport(handler)),
+    )
+
+
+class TestCopyOverride:
+    """Guards the ``HttpClient.copy()`` override that makes ``with_options`` work."""
+
+    def test_with_options_does_not_raise_and_overrides_max_retries(self) -> None:
+        client = HttpClient(
+            provider="myprovider",
+            api_key="sk-test",
+            base_url="https://backend.invalid",
+        )
+
+        # Without the copy() override this raises:
+        # TypeError: missing required keyword-only argument 'provider'.
+        clone = client.with_options(max_retries=0)
+
+        assert isinstance(clone, HttpClient)
+        assert clone.max_retries == 0
+        assert clone.provider == "myprovider"
+        assert clone.request_ctx.get()["provider"] == "myprovider"
+        # The original client keeps its retries.
+        assert client.max_retries == DEFAULT_MAX_RETRIES
+
+    def test_without_retries_is_a_cached_zero_retry_sibling(self) -> None:
+        client = HttpClient(
+            provider="test",
+            api_key="sk-test",
+            base_url="https://backend.invalid",
+        )
+
+        assert client.without_retries.max_retries == 0
+        # Cached: repeated access returns the same instance (no per-call clone).
+        assert client.without_retries is client.without_retries
+        # Reads on the original client keep retrying.
+        assert client.max_retries == DEFAULT_MAX_RETRIES
+
+
+class TestWritePathDoesNotRetry:
+    """``execute`` / ``proxy`` must reach the transport exactly once."""
+
+    def test_execute_does_not_retry_on_transient_error(self, no_sleep: None) -> None:
+        attempts: t.List[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            attempts.append(request)
+            return httpx.Response(500, json={"error": {"message": "boom"}})
+
+        client = _client_with_transport(handler)
+        tools = Tools(client=client, provider=Mock())
+
+        # Avoid the (read) tool-schema lookup hitting the transport.
+        mock_tool = Mock()
+        mock_tool.toolkit.slug = "gmail"
+        with patch.object(
+            tools, "get_raw_composio_tool_by_slug", return_value=mock_tool
+        ):
+            with pytest.raises(APIError):
+                tools._execute_tool(
+                    slug="GMAIL_SEND_EMAIL",
+                    arguments={},
+                    version="1.0.0",
+                )
+
+        assert len(attempts) == 1
+
+    def test_proxy_does_not_retry_on_transient_error(self, no_sleep: None) -> None:
+        attempts: t.List[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            attempts.append(request)
+            return httpx.Response(500, json={"error": {"message": "boom"}})
+
+        client = _client_with_transport(handler)
+        tools = Tools(client=client, provider=Mock())
+
+        with pytest.raises(APIError):
+            tools.proxy(endpoint="/any", method="POST")
+
+        assert len(attempts) == 1
+
+
+class TestReadPathStillRetries:
+    """Reads keep the default retry behaviour — only writes are scoped to no-retry."""
+
+    def test_read_retries_then_succeeds(self, no_sleep: None) -> None:
+        attempts: t.List[httpx.Request] = []
+        responses = [
+            httpx.Response(503, json={"error": {"message": "transient"}}),
+            httpx.Response(
+                200,
+                json={
+                    "current_page": 1,
+                    "items": [],
+                    "total_items": 0,
+                    "total_pages": 1,
+                },
+            ),
+        ]
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            attempts.append(request)
+            return responses[len(attempts) - 1]
+
+        client = _client_with_transport(handler)
+
+        result = client.tools.list()
+
+        # First attempt 503, retried, second attempt 200 -> success.
+        assert len(attempts) == 2
+        assert result.total_items == 0

--- a/python/tests/test_provider.py
+++ b/python/tests/test_provider.py
@@ -15,6 +15,7 @@ from composio.client.types import Tool, tool_list_response
 from composio.core.models.base import allow_tracking
 from composio.core.models.tools import Tools
 from composio.core.provider import AgenticProvider, NonAgenticProvider
+from tests.conftest import mock_http_client
 
 
 @pytest.fixture(autouse=True)
@@ -98,7 +99,7 @@ class TestProviderExecuteToolSetup:
 
     def test_execute_tool_set_during_tools_initialization_non_agentic(self):
         """Test that execute_tool is set during Tools initialization for non-agentic providers."""
-        mock_client = Mock()
+        mock_client = mock_http_client()
         from composio.core.provider._openai import OpenAIProvider
 
         provider = OpenAIProvider()
@@ -117,7 +118,7 @@ class TestProviderExecuteToolSetup:
 
     def test_execute_tool_set_during_tools_initialization_agentic(self):
         """Test that execute_tool is set during Tools initialization for agentic providers."""
-        mock_client = Mock()
+        mock_client = mock_http_client()
 
         class TestAgenticProvider(AgenticProvider, name="test_agentic"):
             def wrap_tool(self, tool, execute_tool):
@@ -142,7 +143,7 @@ class TestProviderExecuteToolSetup:
 
     def test_execute_tool_available_immediately_after_initialization(self):
         """Test that execute_tool is available immediately after initialization, before get() is called."""
-        mock_client = Mock()
+        mock_client = mock_http_client()
         from composio.core.provider._openai import OpenAIProvider
 
         provider = OpenAIProvider()
@@ -160,7 +161,7 @@ class TestProviderExecuteToolSetup:
 
     def test_execute_tool_signature_matches_protocol(self):
         """Test that execute_tool has the correct signature matching ExecuteToolFn protocol."""
-        mock_client = Mock()
+        mock_client = mock_http_client()
         from composio.core.provider._openai import OpenAIProvider
 
         provider = OpenAIProvider()
@@ -202,7 +203,7 @@ class TestProviderExecuteToolFunctionality:
 
     def test_execute_tool_executes_composio_tool(self):
         """Test that provider.execute_tool executes Composio tools correctly."""
-        mock_client = Mock()
+        mock_client = mock_http_client()
         from composio.core.provider._openai import OpenAIProvider
 
         provider = OpenAIProvider()
@@ -236,7 +237,7 @@ class TestProviderExecuteToolFunctionality:
 
     def test_execute_tool_uses_dangerously_skip_version_check(self):
         """Test that execute_tool automatically sets dangerously_skip_version_check=True."""
-        mock_client = Mock()
+        mock_client = mock_http_client()
         from composio.core.provider._openai import OpenAIProvider
 
         provider = OpenAIProvider()
@@ -269,7 +270,7 @@ class TestProviderExecuteToolFunctionality:
 
     def test_execute_tool_passes_user_id(self):
         """Test that execute_tool correctly passes user_id parameter."""
-        mock_client = Mock()
+        mock_client = mock_http_client()
         from composio.core.provider._openai import OpenAIProvider
 
         provider = OpenAIProvider()
@@ -306,7 +307,7 @@ class TestProviderExecuteToolFunctionality:
         """Test that execute_tool correctly passes modifiers."""
         from composio.core.models._modifiers import before_execute
 
-        mock_client = Mock()
+        mock_client = mock_http_client()
         from composio.core.provider._openai import OpenAIProvider
 
         provider = OpenAIProvider()
@@ -347,7 +348,7 @@ class TestProviderExecuteToolFunctionality:
 
     def test_execute_tool_with_toolkit_versions(self):
         """Test that execute_tool uses configured toolkit versions."""
-        mock_client = Mock()
+        mock_client = mock_http_client()
         from composio.core.provider._openai import OpenAIProvider
 
         provider = OpenAIProvider()
@@ -390,7 +391,7 @@ class TestNonAgenticProviderHelperMethods:
             Function,
         )
 
-        mock_client = Mock()
+        mock_client = mock_http_client()
         from composio.core.provider._openai import OpenAIProvider
 
         provider = OpenAIProvider()
@@ -439,7 +440,7 @@ class TestNonAgenticProviderHelperMethods:
             Function,
         )
 
-        mock_client = Mock()
+        mock_client = mock_http_client()
         from composio.core.provider._openai import OpenAIProvider
 
         provider = OpenAIProvider()
@@ -523,7 +524,7 @@ class TestAgenticProviderFunctionality:
 
     def test_agentic_provider_has_execute_tool_after_initialization(self):
         """Test that agentic providers have execute_tool after Tools initialization."""
-        mock_client = Mock()
+        mock_client = mock_http_client()
 
         class TestAgenticProvider(AgenticProvider, name="test_agentic"):
             def wrap_tool(self, tool, execute_tool):
@@ -545,7 +546,7 @@ class TestAgenticProviderFunctionality:
 
     def test_agentic_provider_execute_tool_works(self):
         """Test that agentic provider's execute_tool executes tools correctly."""
-        mock_client = Mock()
+        mock_client = mock_http_client()
 
         class TestAgenticProvider(AgenticProvider, name="test_agentic"):
             def wrap_tool(self, tool, execute_tool):
@@ -583,7 +584,7 @@ class TestAgenticProviderFunctionality:
 
     def test_agentic_provider_wrapped_tools_receive_execute_function(self):
         """Test that wrapped tools from agentic providers receive the execute function."""
-        mock_client = Mock()
+        mock_client = mock_http_client()
 
         class TestAgenticProvider(AgenticProvider, name="test_agentic"):
             def wrap_tool(self, tool, execute_tool):
@@ -640,7 +641,7 @@ class TestAgenticProviderFunctionality:
 
     def test_agentic_provider_wrap_tools_receives_execute_function(self):
         """Test that wrap_tools method receives the execute_tool function."""
-        mock_client = Mock()
+        mock_client = mock_http_client()
 
         class TestAgenticProvider(AgenticProvider, name="test_agentic"):
             def wrap_tool(self, tool, execute_tool):
@@ -838,7 +839,7 @@ class TestProviderEdgeCases:
 
     def test_execute_tool_with_none_parameters(self):
         """Test that execute_tool works when optional parameters are None."""
-        mock_client = Mock()
+        mock_client = mock_http_client()
         from composio.core.provider._openai import OpenAIProvider
 
         provider = OpenAIProvider()
@@ -871,7 +872,7 @@ class TestProviderEdgeCases:
 
     def test_execute_tool_with_multiple_toolkit_versions(self):
         """Test execute_tool with multiple configured toolkit versions."""
-        mock_client = Mock()
+        mock_client = mock_http_client()
         from composio.core.provider._openai import OpenAIProvider
 
         provider = OpenAIProvider()
@@ -917,7 +918,7 @@ class TestProviderIntegration:
 
     def test_provider_workflow_non_agentic(self):
         """Test complete workflow with non-agentic provider."""
-        mock_client = Mock()
+        mock_client = mock_http_client()
         from composio.core.provider._openai import OpenAIProvider
 
         provider = OpenAIProvider()
@@ -969,7 +970,7 @@ class TestProviderIntegration:
 
     def test_provider_workflow_agentic(self):
         """Test complete workflow with agentic provider."""
-        mock_client = Mock()
+        mock_client = mock_http_client()
 
         class TestAgenticProvider(AgenticProvider, name="test_agentic"):
             def wrap_tool(self, tool, execute_tool):

--- a/python/tests/test_tool_execution.py
+++ b/python/tests/test_tool_execution.py
@@ -12,6 +12,8 @@ from composio.core.models.base import allow_tracking
 from composio.core.models.tools import Tools, _serialize_arguments, _needs_serialization
 from composio.exceptions import ToolVersionRequiredError
 
+from tests.conftest import mock_http_client
+
 
 @pytest.fixture(autouse=True)
 def disable_telemetry():
@@ -52,7 +54,7 @@ class TestToolExecution:
 
     def test_get_raw_tool_router_meta_tools_fetches_all_pages(self):
         """Test that ToolRouter session tools are fetched across all pages."""
-        mock_client = Mock()
+        mock_client = mock_http_client()
         mock_provider = Mock()
         tools = Tools(client=mock_client, provider=mock_provider)
 
@@ -82,7 +84,7 @@ class TestToolExecution:
     def test_tool_execution_uses_toolkit_version(self):
         """Test that tool execution resolves toolkit version correctly."""
         # Mock client and provider
-        mock_client = Mock()
+        mock_client = mock_http_client()
         mock_provider = Mock()
         mock_provider.name = "test_provider"
 
@@ -128,7 +130,7 @@ class TestToolExecution:
     def test_tool_execution_with_explicit_version(self):
         """Test that explicit version overrides toolkit version."""
         # Mock client and provider
-        mock_client = Mock()
+        mock_client = mock_http_client()
         mock_provider = Mock()
         mock_provider.name = "test_provider"
 
@@ -177,7 +179,7 @@ class TestToolExecution:
     def test_tool_execution_unknown_toolkit_fallback(self):
         """Test that unknown toolkit falls back to 'latest'."""
         # Mock client and provider
-        mock_client = Mock()
+        mock_client = mock_http_client()
         mock_provider = Mock()
         mock_provider.name = "test_provider"
 
@@ -226,7 +228,7 @@ class TestToolExecution:
     def test_tool_execution_with_global_version_string(self):
         """Test that global version string is used for all toolkits."""
         # Mock client and provider
-        mock_client = Mock()
+        mock_client = mock_http_client()
         mock_provider = Mock()
         mock_provider.name = "test_provider"
 
@@ -275,7 +277,7 @@ class TestToolExecution:
         # version: body.version ?? getToolkitVersion(tool.toolkit?.slug ?? 'unknown', this.toolkitVersions)
 
         # Mock client and provider
-        mock_client = Mock()
+        mock_client = mock_http_client()
         mock_provider = Mock()
         mock_provider.name = "test_provider"
 
@@ -353,7 +355,7 @@ class TestToolExecution:
     def test_execute_raises_error_when_version_is_latest_without_skip_flag(self):
         """Test that execute raises ToolVersionRequiredError when version is 'latest' without skip flag."""
         # Mock client and provider
-        mock_client = Mock()
+        mock_client = mock_http_client()
         mock_provider = Mock()
         mock_provider.name = "test_provider"
 
@@ -382,7 +384,7 @@ class TestToolExecution:
     def test_execute_allows_latest_with_dangerously_skip_version_check(self):
         """Test that execute allows 'latest' version when dangerously_skip_version_check is True."""
         # Mock client and provider
-        mock_client = Mock()
+        mock_client = mock_http_client()
         mock_provider = Mock()
         mock_provider.name = "test_provider"
 
@@ -429,7 +431,7 @@ class TestToolExecution:
     def test_execute_with_specific_version_no_error(self):
         """Test that execute works with specific version without raising error."""
         # Mock client and provider
-        mock_client = Mock()
+        mock_client = mock_http_client()
         mock_provider = Mock()
         mock_provider.name = "test_provider"
 
@@ -475,7 +477,7 @@ class TestToolExecution:
     def test_execute_uses_instance_toolkit_versions(self):
         """Test that execute method uses instance-level toolkit versions."""
         # Mock client and provider
-        mock_client = Mock()
+        mock_client = mock_http_client()
         mock_provider = Mock()
         mock_provider.name = "test_provider"
 
@@ -524,7 +526,7 @@ class TestToolExecution:
     def test_execute_version_parameter_overrides_toolkit_versions(self):
         """Test that explicit version parameter overrides instance toolkit versions."""
         # Mock client and provider
-        mock_client = Mock()
+        mock_client = mock_http_client()
         mock_provider = Mock()
         mock_provider.name = "test_provider"
 
@@ -574,7 +576,7 @@ class TestToolExecution:
     def test_execute_with_connected_account_id(self):
         """Test that execute passes connected_account_id correctly."""
         # Mock client and provider
-        mock_client = Mock()
+        mock_client = mock_http_client()
         mock_provider = Mock()
         mock_provider.name = "test_provider"
 
@@ -621,7 +623,7 @@ class TestToolExecution:
     def test_execute_with_custom_auth_params(self):
         """Test that execute passes custom_auth_params correctly."""
         # Mock client and provider
-        mock_client = Mock()
+        mock_client = mock_http_client()
         mock_provider = Mock()
         mock_provider.name = "test_provider"
 
@@ -669,7 +671,7 @@ class TestToolExecution:
     def test_execute_with_user_id_and_text(self):
         """Test that execute passes user_id and text parameters correctly."""
         # Mock client and provider
-        mock_client = Mock()
+        mock_client = mock_http_client()
         mock_provider = Mock()
         mock_provider.name = "test_provider"
 
@@ -720,7 +722,7 @@ class TestToolExecution:
         from composio.core.models._modifiers import before_execute
 
         # Mock client and provider
-        mock_client = Mock()
+        mock_client = mock_http_client()
         mock_provider = Mock()
         mock_provider.name = "test_provider"
 
@@ -776,7 +778,7 @@ class TestToolExecution:
         from composio.core.models._modifiers import after_execute
 
         # Mock client and provider
-        mock_client = Mock()
+        mock_client = mock_http_client()
         mock_provider = Mock()
         mock_provider.name = "test_provider"
 
@@ -958,7 +960,7 @@ class TestToolExecution:
         """``before_file_upload`` in ``modifiers`` is composed into substitute_file_uploads."""
         from composio.core.models._modifiers import before_file_upload
 
-        mock_client = Mock()
+        mock_client = mock_http_client()
         mock_provider = Mock()
         mock_provider.name = "test_provider"
 
@@ -1019,7 +1021,7 @@ class TestToolExecution:
         import os
 
         # Mock client and provider
-        mock_client = Mock()
+        mock_client = mock_http_client()
         mock_provider = Mock()
         mock_provider.name = "test_provider"
 
@@ -1074,7 +1076,7 @@ class TestToolExecution:
         import os
 
         # Mock client and provider
-        mock_client = Mock()
+        mock_client = mock_http_client()
         mock_provider = Mock()
         mock_provider.name = "test_provider"
 
@@ -1109,7 +1111,7 @@ class TestToolExecution:
     def test_execute_with_custom_connection_data(self):
         """Test that execute passes custom_connection_data correctly."""
         # Mock client and provider
-        mock_client = Mock()
+        mock_client = mock_http_client()
         mock_provider = Mock()
         mock_provider.name = "test_provider"
 
@@ -1213,7 +1215,7 @@ class TestSerializeArguments:
     def test_execute_tool_serializes_pydantic_arguments(self):
         """Regression test for PLEN-1514: Pydantic models in arguments must be
         serialized to plain dicts before being sent to the API."""
-        mock_client = Mock()
+        mock_client = mock_http_client()
         mock_provider = Mock()
         mock_provider.name = "test_provider"
 


### PR DESCRIPTION
This PR:

- stops the Python SDK from silently retrying `tools.execute` and `tools.proxy`, which are non-idempotent POST writes. The Stainless-generated client retries POSTs by default (`max_retries=2`) on read timeouts, 429, 5xx, and connection errors. A read timeout is unsafe to retry — the request may already be in flight on the backend — so a retry can duplicate the side effect, e.g. send an email twice. Reported in https://github.com/ComposioHQ/composio/issues/3586
- routes both write paths through a new `client.without_retries` — a cached, retry-disabled (`max_retries=0`) clone of the `HttpClient`. Reads and lists keep the default retries, so resilience is unchanged for idempotent calls
- overrides `HttpClient.copy()` to re-inject the required `provider` keyword (and `_strict_response_validation`, which the generated `copy()` otherwise drops) and re-aliases `with_options`, since the generated `copy()` rebuilds via `self.__class__(...)` without them — previously `with_options(max_retries=0)` raised `TypeError` on the subclass
- caches the no-retry sibling instead of cloning per call so a fresh `HttpClient` isn't constructed on every execute/proxy (the hottest SDK path); the sibling's options never change, so one per client suffices
- **scope:** only `tools.execute` / `tools.proxy` are de-retried here. Other non-idempotent writes (`auth_configs.create`/`update`/`delete`, `mcp.update`/`delete`, `connected_accounts.delete`/`refresh`, `link.create`) keep the default retries — most are naturally idempotent on retry, and the durable idempotency-key fix below covers the rest
- adds `tests/test_no_retry_writes.py`: writes hit the transport exactly once on a retryable 5xx, reads still retry-then-succeed (proving the scoping), plus regression guards for the `copy()` override (provider + strict-validation re-injection) and for the Stainless `copy`/`with_options` contract the override depends on
- interim fix only — the durable solution is idempotency keys, tracked in https://github.com/ComposioHQ/composio/issues/3654 (gated on backend support), which supersedes this once available

No changeset (Python-only change; changesets are TypeScript-only).
