### PR TITLE
fix(py): correct without_retries rationale, preserve strict validation, pin copy() contract

### DIFF
--- a/python/composio/client/__init__.py
+++ b/python/composio/client/__init__.py
@@ -183,7 +183,7 @@ class HttpClient(BaseComposio, WithLogger):
             },
         )
         # Lazily-built sibling client with retries disabled; see `without_retries`.
-        self._without_retries: t.Optional["HttpClient"] = None
+        self._without_retries: t.Optional[te.Self] = None
 
     def copy(  # type: ignore[override]
         self,
@@ -201,7 +201,15 @@ class HttpClient(BaseComposio, WithLogger):
         (e.g. ``with_options(max_retries=0)``).
         """
         return super().copy(  # type: ignore[misc]
-            _extra_kwargs={"provider": self.provider, **_extra_kwargs},
+            _extra_kwargs={
+                "provider": self.provider,
+                # The generated `copy` does not re-pass `_strict_response_validation`,
+                # so without this the clone would silently fall back to the default
+                # (False) even when the original had it enabled — keeping the sibling
+                # a faithful copy that differs from the parent only in `max_retries`.
+                "_strict_response_validation": self._strict_response_validation,
+                **_extra_kwargs,
+            },
             **kwargs,
         )
 
@@ -211,7 +219,7 @@ class HttpClient(BaseComposio, WithLogger):
     with_options = copy
 
     @property
-    def without_retries(self) -> "HttpClient":
+    def without_retries(self) -> te.Self:
         """
         A cached sibling client that never retries requests.
 
@@ -219,9 +227,16 @@ class HttpClient(BaseComposio, WithLogger):
         where a silent retry after a read timeout can duplicate a side effect
         (e.g. send an email twice). Reads keep the default retry behaviour.
 
-        The sibling is cached rather than rebuilt per call: each clone creates a
-        new ``ContextVar``, and dynamically-created ``ContextVar``s are never
-        garbage-collected.
+        Scope: only ``tools.execute`` / ``tools.proxy`` route through this today.
+        Other non-idempotent writes (``auth_configs.create`` / ``update`` /
+        ``delete``, ``mcp.update`` / ``delete``, ``connected_accounts.delete`` /
+        ``refresh``, ``link.create``) keep the default retries — most are
+        naturally idempotent on retry, and the durable fix is backend-honoured
+        idempotency keys.
+
+        The sibling is cached rather than rebuilt per call so a fresh client is
+        not constructed on every execute/proxy (the hottest path); its options
+        never change, so one per client suffices.
         """
         if self._without_retries is None:
             self._without_retries = self.with_options(max_retries=0)
@@ -240,4 +255,4 @@ class HttpClient(BaseComposio, WithLogger):
         try:
             request.headers["x-sdk-version"] = version("composio")
         except Exception:
-            request.headers["x-sdk-version"] = "unknwon"
+            request.headers["x-sdk-version"] = "unknown"

--- a/python/tests/test_no_retry_writes.py
+++ b/python/tests/test_no_retry_writes.py
@@ -7,12 +7,14 @@ duplicate the side effect (e.g. send an email twice). ``Tools.execute`` and
 retry-disabled clone), while reads keep the default retry behaviour.
 """
 
+import inspect
 import typing as t
 from unittest.mock import Mock, patch
 
 import httpx
 import pytest
 from composio_client import DEFAULT_MAX_RETRIES, APIError
+from composio_client import Composio as BaseComposio
 
 from composio.client import HttpClient
 from composio.core.models.base import allow_tracking
@@ -85,6 +87,37 @@ class TestCopyOverride:
         # Reads on the original client keep retrying.
         assert client.max_retries == DEFAULT_MAX_RETRIES
 
+    def test_clone_preserves_strict_response_validation(self) -> None:
+        # The generated `copy` drops `_strict_response_validation`; the override
+        # re-injects it so the sibling differs from the parent only in retries.
+        client = HttpClient(
+            provider="test",
+            api_key="sk-test",
+            base_url="https://backend.invalid",
+            _strict_response_validation=True,
+        )
+
+        assert client.without_retries._strict_response_validation is True
+
+
+class TestStainlessCopyContract:
+    """Pin the generated-client internals the ``copy()`` override depends on.
+
+    These guard the contract so a ``composio_client`` regen that breaks it fails
+    as an obvious assertion here rather than a cryptic ``TypeError`` raised deep
+    inside ``with_options`` at runtime.
+    """
+
+    def test_base_copy_accepts_extra_kwargs(self) -> None:
+        # The override threads `provider` (and `_strict_response_validation`)
+        # through `_extra_kwargs`; the base `copy` must still accept it.
+        assert "_extra_kwargs" in inspect.signature(BaseComposio.copy).parameters
+
+    def test_with_options_is_aliased_to_our_copy_override(self) -> None:
+        # The base binds `with_options = copy` at class-definition time, so the
+        # subclass must re-alias it to the override that re-injects `provider`.
+        assert HttpClient.with_options is HttpClient.copy
+
 
 class TestWritePathDoesNotRetry:
     """``execute`` / ``proxy`` must reach the transport exactly once."""
@@ -124,6 +157,8 @@ class TestWritePathDoesNotRetry:
         client = _client_with_transport(handler)
         tools = Tools(client=client, provider=Mock())
 
+        # `proxy` does no tool-schema lookup, so the only transport hit is the
+        # write itself — no read to patch out (unlike the execute test above).
         with pytest.raises(APIError):
             tools.proxy(endpoint="/any", method="POST")
 


### PR DESCRIPTION
Review follow-up to #3657 (squash-merged before these review fixes could land on it). No behaviour change to the retry scoping itself — this tightens correctness, docs, and test coverage around the `without_retries` mechanism.

- **Correct the `without_retries` caching rationale.** The previous docstring justified caching with "each clone creates a new `ContextVar`, and dynamically-created `ContextVar`s are never garbage-collected." That is false for this code path: `request_ctx` is only ever `.get()`, never `.set()`, so it is reclaimed by refcounting on drop (measured: 500k get-only clones leak ~0 KiB; the CPython leak only occurs with `.set()`). Caching is kept because it avoids constructing a fresh `HttpClient` on every `execute`/`proxy` (the hottest path) — the real, stated justification now.
- **Preserve `_strict_response_validation` on the clone.** The Stainless-generated `copy()` drops it, so the no-retry sibling silently reverted to the default (`False`) even when the parent had it enabled. The `copy()` override now threads it through `_extra_kwargs` alongside `provider`, so the sibling differs from the parent only in `max_retries`.
- **Document the scope boundary.** The `without_retries` docstring now states that only `tools.execute` / `tools.proxy` are de-retried; other non-idempotent writes (`auth_configs.create`/`update`/`delete`, `mcp.update`/`delete`, `connected_accounts.delete`/`refresh`, `link.create`) keep the default retries (most are naturally idempotent on retry; the durable fix is backend idempotency keys).
- **Add regression coverage:** the clone preserves `_strict_response_validation`, plus contract guards pinning the Stainless `copy`/`_extra_kwargs`/`with_options` internals the override relies on — so a `composio_client` regen that breaks the contract fails as an obvious assertion rather than a cryptic `TypeError`.
- Minor: fix the `x-sdk-version` `"unknwon"` → `"unknown"` typo and tighten `te.Self` typing on the cache field/property.

No changeset (Python-only change; changesets are TypeScript-only).
