### PR TITLE
fix(ts): disable publint pack under Turbo to fix flaky build ENOENT

### DIFF
--- a/tsdown.config.base.ts
+++ b/tsdown.config.base.ts
@@ -1,7 +1,10 @@
 import type { UserConfig } from 'tsdown';
 
-// Turbo task execution triggers a tsdown ATTW tarball path bug for scoped packages.
-// Keep ATTW for direct package builds, but disable it for workspace builds.
+// Turbo task execution triggers a tsdown tarball-pack path bug for scoped packages:
+// an intermittent ENOENT while reading the packed `.tgz` (e.g. composio-anthropic-*.tgz).
+// tsdown packs the tarball once and shares it between ATTW and publint, and only runs the
+// pack when at least one of them is enabled — so BOTH must be disabled to skip the pack
+// under Turbo. Keep both checks for direct package builds; disable them for workspace builds.
 const isTurboTask = Boolean(process.env.TURBO_HASH);
 
 /**
@@ -88,7 +91,7 @@ export const baseConfig = {
    * Configuration for publint.
    */
   publint: {
-    enabled: true,
+    enabled: !isTurboTask,
     level: 'error',
     pack: 'pnpm',
   },


### PR DESCRIPTION
This PR:

- fixes the intermittent `E2E Test CLI (scratch)` → **Build** failure seen on the changeset release PR #3616, where `@composio/anthropic#build` died with:
  ```
  Error: ENOENT: no such file or directory, open '/tmp/tsdown-pack-XXXXXX/composio-anthropic-0.10.0.tgz'
  ```
- gates `publint` with `!isTurboTask` in `tsdown.config.base.ts`, mirroring the existing ATTW workaround, so neither publish-readiness check packs a tarball under Turbo

## Root cause

`tsdown.config.base.ts` already disabled **ATTW** under Turbo to dodge a "tarball path bug for scoped packages", but left **publint** enabled with `pack: 'pnpm'`. In tsdown the pack is shared and runs whenever *either* check is enabled:

```js
if (publintConfigs.length || attwConfigs.length) {
  const tarball = await packTarball(pkg.packageJsonPath); // pnpm pack → temp dir → readdir → readFile
  ...
}
```

So disabling ATTW alone did **not** stop the pack — publint kept triggering it, and with it the intermittent `readdir`-then-`readFile` race where the packed `.tgz` is gone by the time `readFile` runs. It's flaky: this run it hit `@composio/anthropic` while 14 sibling scoped packages packed fine.

## Fix

`publint.enabled: true` → `publint.enabled: !isTurboTask`. With both ATTW and publint disabled under Turbo, `packTarball()` is never called in workspace/CI builds, eliminating the race. Direct package builds (no `TURBO_HASH`) keep running both checks with packing — where the bug does not occur.

## Verification (local, `--force` to bypass cache)

- **Turbo build before:** `[publint]` runs for every package (packs the tarball) → race surface present.
- **Turbo build after:** `0` publint runs, `3 successful, 3 total`, all `🙏 Build succeeded!` → pack step gone.
- **Direct build after** (`env -u TURBO_HASH pnpm build` in `providers/anthropic`): both `✔ [attw]` and `✔ [publint]` run and pass → coverage retained off-Turbo.