### PR TITLE
fix(ts-builders): publish @composio/ts-builders to npm with public access

### DIFF
--- a/ts/packages/ts-builders/package.json
+++ b/ts/packages/ts-builders/package.json
@@ -12,6 +12,9 @@
       "default": "./dist/index.mjs"
     }
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ComposioHQ/composio.git",


### PR DESCRIPTION
This PR:

- fixes the npm publish failure in the TypeScript 0.x release run (`ts.release.yml` run after #3616 merged), where 14 packages published but `@composio/ts-builders@0.2.0` failed with:
  ```
  E404 404 Not Found - PUT https://registry.npmjs.org/@composio%2fts-builders
  ```
- adds the missing `publishConfig.access: "public"` to `@composio/ts-builders`

## Root cause

`@composio/ts-builders` is **not** private, is in the changeset publish set, and is a runtime `dependency` of `@composio/cli` (`"@composio/ts-builders": "workspace:*"`), so it must exist on npm. But its `package.json` had no `publishConfig`, and **scoped npm packages default to *restricted* access** — the first-ever publish of the package returns `E404` on the `PUT`. Its sibling `@composio/json-schema-to-zod` sets `publishConfig.access: "public"` and published fine.

It was the **only** publishable (`private` ≠ true) `@composio/*` package missing `access: "public"` — verified by scanning every `ts/packages/**/package.json`.

## Fix & rollout

- `publishConfig.access: "public"` only — `main`/`types`/`exports` already point at `dist`, so no override needed there.
- **No version bump**: `0.2.0` is not on npm, so on the next push to `next` `changeset publish` will publish `@composio/ts-builders@0.2.0` and skip the 14 already-published packages.

Once merged, the release workflow re-runs on `next` and completes the publish set.