### PR TITLE
fix(ts-builders): mark @composio/ts-builders private (do not publish to npm)

### DIFF
--- a/ts/packages/ts-builders/package.json
+++ b/ts/packages/ts-builders/package.json
@@ -2,6 +2,7 @@
   "name": "@composio/ts-builders",
   "version": "0.2.0",
   "description": "Fork of @prisma/ts-builders",
+  "private": true,
   "main": "dist/index.mjs",
   "type": "module",
   "module": "dist/index.mjs",


### PR DESCRIPTION
Replaces #3662 with the opposite (correct) approach: keep `@composio/ts-builders` **internal/unpublished**, not public.

This PR:

- marks `@composio/ts-builders` as `private: true` so changesets stops attempting to publish it to npm

## Why

`@composio/ts-builders` is an internal AST-builder helper consumed **only** by `@composio/cli` (`"@composio/ts-builders": "workspace:*"`). `@composio/cli` is itself `private: true` and is distributed as **bundled Bun binaries via GitHub releases**, not as an npm package — so it bundles its workspace deps and never resolves them from npm. **No package published to npm depends on `ts-builders`.**

It was simply missing `private: true`. With the repo-wide changeset `access` default of `restricted` and no `publishConfig.access: public` opt-in, the first-ever publish 404'd in the 2026-06-25 release:

```
E404 404 Not Found - PUT https://registry.npmjs.org/@composio%2fts-builders
```

## Consistent with existing CLI-only helpers

`@composio/cli-keyring` and `@composio/cli-local-tools` are already set up exactly this way — `private: true`, consumed by the CLI via `workspace:*`, intentionally **not on npm**. `ts-builders` now matches them.

## Effect

- `changeset publish` skips private packages, so future release runs no longer fail on `ts-builders`.
- The CLI keeps consuming it through the workspace (bundled into the binary); npm resolution is never involved.
- The 14 packages already published on 2026-06-25 don't reference `ts-builders`, so the published dependency graph is already self-consistent — this only stops the spurious publish failure going forward.

No version bump and no `publishConfig` needed.