### PR TITLE
chore(vercel): allow ai@7 as a peer dependency

### DIFF
--- a/.changeset/allow-ai-sdk-v7-vercel.md
+++ b/.changeset/allow-ai-sdk-v7-vercel.md
@@ -1,5 +1,5 @@
 ---
-"@composio/vercel": patch
+'@composio/vercel': patch
 ---
 
 Allow `ai@7` (AI SDK v7) as a peer dependency.

--- a/.changeset/allow-ai-sdk-v7-vercel.md
+++ b/.changeset/allow-ai-sdk-v7-vercel.md
@@ -1,0 +1,7 @@
+---
+"@composio/vercel": patch
+---
+
+Allow `ai@7` (AI SDK v7) as a peer dependency.
+
+The Vercel provider only imports `tool` and the `Tool` / `ToolSet` types from `ai`, all of which are unchanged in AI SDK v7 — `tool()` still accepts `inputSchema`, and the v7 tool-related breaking changes (`needsApproval` relocation, `ToolCallOptions` → `ToolExecutionOptions`, and removal of tool-result `media` parts) are not used by this adapter. No source changes are required; the peer-dependency range is simply widened to `^5.0.0 || ^6.0.0 || ^7.0.0`.

--- a/ts/packages/providers/vercel/package.json
+++ b/ts/packages/providers/vercel/package.json
@@ -38,7 +38,7 @@
   "license": "ISC",
   "peerDependencies": {
     "@composio/core": ">=0.10.0 <1.0.0",
-    "ai": "^5.0.0 || ^6.0.0"
+    "ai": "^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "devDependencies": {
     "@composio/core": "workspace:*",


### PR DESCRIPTION
## Summary
`@composio/vercel`'s peer dependency on `ai` is currently capped at `^5.0.0 || ^6.0.0`, which blocks downstream applications from upgrading to AI SDK v7. This widens the range to also allow `^7.0.0`. No source changes are required.

Fixes #

## Changes
- Widen the `ai` peer-dependency range to `^5.0.0 || ^6.0.0 || ^7.0.0`
- Add a changeset (`@composio/vercel: patch`)

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor/Chore
- [ ] Documentation
- [ ] Breaking change

## How Has This Been Tested?
The adapter's entire `ai` surface is `tool()` and the `Tool` / `ToolSet` types. All three are still exported by `ai@7` (verified in `ai@7.0.2`'s `dist/index.d.ts`, which re-exports `tool`, `Tool`, and `ToolSet` from `@ai-sdk/provider-utils`), `tool()` still accepts `inputSchema`, and none of the v7 tool-related breaking changes (`needsApproval` relocation, `ToolCallOptions` → `ToolExecutionOptions`, removal of tool-result `media` parts) apply to this adapter.

Verified locally on this branch:
- `pnpm --filter @composio/vercel build` — succeeds (tsdown type-check + attw + publint clean)
- `pnpm --filter @composio/vercel test` — **10/10 tests pass**
- `eslint ts/packages/providers/vercel` — clean
- `prettier --check` on the changed files — clean
- Separately, the adapter's exact `tool()/wrapTools` usage typechecks cleanly against `ai@7.0.2` + `zod@4` under `--strict` (`tsc --noEmit`, exit 0)

The published dist imports `ai` as an external peer (not bundled), so widening the declared peer range is sufficient.

## Checklist
- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed (build, vitest 10/10, eslint, prettier — see above)
- [x] I updated documentation as needed — N/A, no behavior change
- [x] I added tests or explain why not applicable — existing `test/vercel.test.ts` (10 tests) passes; no new code paths to cover
- [x] I added a changeset if this change affects published packages

## Additional context
The Vercel provider's source is unchanged. This unblocks consumers who depend on both `@composio/vercel` and `ai@7`.
