### PR TITLE
fix(release): register slim+experimental in root workspaces (unblocks changeset release)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [],
+  "fixed": [["@composio/core", "@composio/slim"]],
   "linked": [],
   "access": "restricted",
   "privatePackages": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "description": "",
   "workspaces": [
     "ts/packages/core",
+    "ts/packages/experimental",
+    "ts/packages/slim",
     "ts/packages/json-schema-to-zod",
     "ts/packages/cli",
     "ts/packages/cli-keyring",


### PR DESCRIPTION
## Why

The changeset release on `next` (run after #3637 merged) **failed**, so no "Release: update version" PR was created and nothing published:

```
🦋 error Found changeset add-slim-package for package @composio/slim which is not in the workspace
```

## Root cause

Changesets' package discovery (`@manypkg/get-packages`) reads the **root `package.json` `workspaces`** field, which was stale — it was missing `ts/packages/slim` and `ts/packages/experimental`. Both are present in `pnpm-workspace.yaml`, so pnpm/turbo saw them but changesets did not, and `changeset version` aborts entirely when a changeset references an undiscovered package.

## Fix

- `package.json`: add `ts/packages/experimental` + `ts/packages/slim` to `workspaces`.
- `.changeset/config.json`: `fixed` `@composio/core` ↔ `@composio/slim` so slim always ships the **same version as core** (slim mirrors the built core runtime).

## Verified locally

`changeset version` now resolves cleanly:

| package | version |
|---|---|
| @composio/core | 0.13.0 |
| @composio/slim | 0.13.0 (1-1 with core) |
| @composio/experimental | 0.1.0 |

Merging this re-triggers the TS SDK Release workflow, which will create the Version Packages PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)