### PR TITLE
chore(release): exclude @composio/cli + cli-local-tools from changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -14,5 +14,5 @@
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   },
-  "ignore": []
+  "ignore": ["@composio/cli", "@composio/cli-local-tools"]
 }


### PR DESCRIPTION
## Why

`@composio/cli` ships through its own binary release pipeline (`build-cli-binaries.yml` → draft → publish → homebrew tap), not changesets. But core/slim/experimental version bumps were **cascade-bumping** the CLI in the "Release: update version" PR (#3676): `@composio/cli` 0.3.0→0.3.1 and `@composio/cli-local-tools` 0.1.0→0.1.1. These weren't direct changesets — just dependency cascades.

## Change

Add `@composio/cli` and `@composio/cli-local-tools` to `.changeset/config.json` `ignore` so changesets never versions/publishes them. `@composio/cli-keyring` stays changeset-managed.

## Effect

`changeset status` now bumps **only**:

| package | bump |
|---|---|
| @composio/core | minor (0.13.0) |
| @composio/slim | minor (0.13.0) |
| @composio/experimental | minor (0.1.0) |

No more CLI in the release. Merging this regenerates the Version Packages PR (#3676) without the CLI bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)