### PR TITLE
feat(vercel): support AI SDK v7

### DIFF
--- a/.changeset/vercel-ai-sdk-7.md
+++ b/.changeset/vercel-ai-sdk-7.md
@@ -1,0 +1,5 @@
+---
+'@composio/vercel': minor
+---
+
+Add AI SDK 7 support to `@composio/vercel`. The `ai` peer dependency range is now `^6.0.0 || ^7.0.0` (AI SDK 5 is no longer supported; both v6 and v7 are covered by e2e compatibility tests).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -521,6 +521,18 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
 
+  ts/e2e-tests/runtimes/node/vercel-ai-sdk-v6:
+    devDependencies:
+      '@e2e-tests/utils':
+        specifier: workspace:*
+        version: link:../../../_utils
+
+  ts/e2e-tests/runtimes/node/vercel-ai-sdk-v7:
+    devDependencies:
+      '@e2e-tests/utils':
+        specifier: workspace:*
+        version: link:../../../_utils
+
   ts/examples/anthropic:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':

--- a/ts/e2e-tests/runtimes/node/vercel-ai-sdk-v6/README.md
+++ b/ts/e2e-tests/runtimes/node/vercel-ai-sdk-v6/README.md
@@ -1,0 +1,42 @@
+# @composio/vercel + AI SDK v6 Compatibility Test
+
+Verifies that `@composio/vercel` installs, typechecks, and executes wrapped tools with `ai@6`.
+
+## Background
+
+`@composio/vercel` declares `ai` as a peer dependency across multiple majors (`^6.0.0 || ^7.0.0`). This suite guards the AI SDK **v6** arm of that range so a future change can't silently break v6 consumers. The v7 arm is covered by the sibling `vercel-ai-sdk-v7` suite.
+
+## What It Tests
+
+| Marker                                          | Description                                                          |
+| ----------------------------------------------- | ------------------------------------------------------------------- |
+| `vercel ai sdk compatibility typecheck passed`  | The packed provider typechecks against `ai@6` (`fixtures/index.ts`) |
+| `WRAPPED_TOOL_INPUT_SCHEMA_OK`                  | `wrapTool` returns an AI SDK tool with `inputSchema` + `execute`    |
+| `OBJECT_INPUT_EXECUTION_OK`                     | Object inputs are forwarded to `executeTool`                        |
+| `STRING_INPUT_EXECUTION_OK`                     | JSON-string inputs are normalized before `executeTool`              |
+| `TOOL_SET_OK`                                   | `wrapTools` produces a `ToolSet`-compatible collection             |
+
+## Fixture
+
+```
+fixtures/
+├── index.mjs      # Executed at runtime: wraps a tool and asserts execution behavior
+├── index.ts       # Type-only (tsc --noEmit): asserts the provider's types line up with ai@6
+└── package.json   # Declares @composio/core (linked), ai@6, typescript, zod
+```
+
+The provider is installed the way consumers get it: `npm pack` of `@composio/vercel`, then install the resulting tarball — so the published `dist` and `peerDependencies` are exercised, not the workspace source.
+
+## Setup
+
+The `setup` phase runs `npm run install:vercel && npm run typecheck` in a Docker volume, then the fixture (`index.mjs`) runs with the installed `node_modules` mounted read-only.
+
+## Isolation Tool
+
+**Docker** with Node.js versions: 22.22.3, 24.17.0, 25.9.0.
+
+## Running
+
+```bash
+pnpm test:e2e
+```

--- a/ts/e2e-tests/runtimes/node/vercel-ai-sdk-v6/e2e.test.ts
+++ b/ts/e2e-tests/runtimes/node/vercel-ai-sdk-v6/e2e.test.ts
@@ -1,0 +1,55 @@
+/**
+ * @composio/vercel + AI SDK v6 compatibility e2e test.
+ *
+ * Verifies that @composio/vercel installs, typechecks, and executes wrapped
+ * tools with ai@6.
+ */
+
+import { e2e, type E2ETestResultWithSetup } from '@e2e-tests/utils';
+import { describe, it, expect, beforeAll } from 'bun:test';
+
+e2e(import.meta.url, {
+  versions: { node: ['22.22.3', '24.17.0', '25.9.0'] },
+  usesFixtures: true,
+  defineTests: ({ runFixture }) => {
+    let result: E2ETestResultWithSetup;
+
+    beforeAll(async () => {
+      result = await runFixture({
+        filename: 'index.mjs',
+        // `install:vercel` packs and installs the provider tarball, which reifies
+        // the full fixture dependency tree, so no separate `npm install` is needed.
+        setup: 'npm run install:vercel && npm run typecheck',
+      });
+    }, 300_000);
+
+    describe('setup', () => {
+      it('installs and typechecks successfully', () => {
+        expect(result.setup.exitCode).toBe(0);
+        expect(result.setup.stdout).toContain('vercel ai sdk compatibility typecheck passed');
+      });
+    });
+
+    describe('@composio/vercel + ai@6', () => {
+      it('exits successfully', () => {
+        expect(result.exitCode).toBe(0);
+      });
+
+      it('wraps tools using inputSchema', () => {
+        expect(result.stdout).toContain('WRAPPED_TOOL_INPUT_SCHEMA_OK');
+      });
+
+      it('executes object inputs', () => {
+        expect(result.stdout).toContain('OBJECT_INPUT_EXECUTION_OK');
+      });
+
+      it('normalizes JSON string inputs', () => {
+        expect(result.stdout).toContain('STRING_INPUT_EXECUTION_OK');
+      });
+
+      it('produces a ToolSet-compatible collection', () => {
+        expect(result.stdout).toContain('TOOL_SET_OK');
+      });
+    });
+  },
+});

--- a/ts/e2e-tests/runtimes/node/vercel-ai-sdk-v6/fixtures/index.mjs
+++ b/ts/e2e-tests/runtimes/node/vercel-ai-sdk-v6/fixtures/index.mjs
@@ -1,0 +1,56 @@
+import { VercelProvider } from '@composio/vercel';
+
+const composioTool = {
+  slug: 'TEST_TOOL',
+  name: 'Test Tool',
+  description: 'A tool used by the AI SDK compatibility fixture',
+  version: '20260625_00',
+  availableVersions: ['20260625_00'],
+  inputParameters: {
+    type: 'object',
+    properties: {
+      query: {
+        type: 'string',
+        description: 'Query text',
+      },
+    },
+    required: ['query'],
+  },
+  tags: [],
+};
+
+const calls = [];
+const executeTool = async (slug, params) => {
+  calls.push({ slug, params });
+  return {
+    data: { slug, params },
+    error: null,
+    successful: true,
+  };
+};
+
+const provider = new VercelProvider();
+const wrapped = provider.wrapTool(composioTool, executeTool);
+
+if (!wrapped || !wrapped.inputSchema || typeof wrapped.execute !== 'function') {
+  throw new Error('Wrapped tool does not match the AI SDK tool shape');
+}
+console.log('WRAPPED_TOOL_INPUT_SCHEMA_OK');
+
+await wrapped.execute({ query: 'object input' });
+if (calls.at(-1)?.slug !== 'TEST_TOOL' || calls.at(-1)?.params?.query !== 'object input') {
+  throw new Error('Object input was not forwarded to executeTool');
+}
+console.log('OBJECT_INPUT_EXECUTION_OK');
+
+await wrapped.execute(JSON.stringify({ query: 'string input' }));
+if (calls.at(-1)?.slug !== 'TEST_TOOL' || calls.at(-1)?.params?.query !== 'string input') {
+  throw new Error('String input was not normalized before executeTool');
+}
+console.log('STRING_INPUT_EXECUTION_OK');
+
+const toolSet = provider.wrapTools([composioTool], executeTool);
+if (!toolSet.TEST_TOOL) {
+  throw new Error('Wrapped tools collection is missing TEST_TOOL');
+}
+console.log('TOOL_SET_OK');

--- a/ts/e2e-tests/runtimes/node/vercel-ai-sdk-v6/fixtures/index.ts
+++ b/ts/e2e-tests/runtimes/node/vercel-ai-sdk-v6/fixtures/index.ts
@@ -1,0 +1,35 @@
+import { VercelProvider, type VercelToolCollection } from '@composio/vercel';
+import type { Tool as ComposioTool, ExecuteToolFn } from '@composio/core';
+import type { ToolSet } from 'ai';
+
+const composioTool = {
+  slug: 'TEST_TOOL',
+  name: 'Test Tool',
+  description: 'A tool used by the AI SDK compatibility fixture',
+  version: '20260625_00',
+  availableVersions: ['20260625_00'],
+  inputParameters: {
+    type: 'object',
+    properties: {
+      query: {
+        type: 'string',
+        description: 'Query text',
+      },
+    },
+    required: ['query'],
+  },
+  tags: [],
+} satisfies ComposioTool;
+
+const executeTool = (async () => ({
+  data: { ok: true },
+  error: null,
+  successful: true,
+})) satisfies ExecuteToolFn;
+
+const provider = new VercelProvider();
+const tools = provider.wrapTools([composioTool], executeTool);
+
+// Assignability smoke check: the wrapped collection must satisfy both the
+// provider's exported type and the installed AI SDK's ToolSet.
+const _wrappedToolSet: VercelToolCollection = tools satisfies ToolSet;

--- a/ts/e2e-tests/runtimes/node/vercel-ai-sdk-v6/fixtures/package.json
+++ b/ts/e2e-tests/runtimes/node/vercel-ai-sdk-v6/fixtures/package.json
@@ -1,0 +1,14 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "install:vercel": "VERCEL_TGZ=$(npm pack /app/ts/packages/providers/vercel --pack-destination . --silent) && test -n \"$VERCEL_TGZ\" && npm install --ignore-scripts --legacy-peer-deps --package-lock=false \"./$VERCEL_TGZ\"",
+    "typecheck": "tsc --noEmit && echo vercel ai sdk compatibility typecheck passed"
+  },
+  "dependencies": {
+    "@composio/core": "file:/app/ts/packages/core",
+    "ai": "6.0.211",
+    "typescript": "5.8.3",
+    "zod": "4.4.3"
+  }
+}

--- a/ts/e2e-tests/runtimes/node/vercel-ai-sdk-v6/fixtures/tsconfig.json
+++ b/ts/e2e-tests/runtimes/node/vercel-ai-sdk-v6/fixtures/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["index.ts"]
+}

--- a/ts/e2e-tests/runtimes/node/vercel-ai-sdk-v6/package.json
+++ b/ts/e2e-tests/runtimes/node/vercel-ai-sdk-v6/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@e2e-tests/node-vercel-ai-sdk-v6",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test:e2e": "bun test e2e.test.ts",
+    "test:e2e:node": "bun test e2e.test.ts"
+  },
+  "devDependencies": {
+    "@e2e-tests/utils": "workspace:*"
+  }
+}

--- a/ts/e2e-tests/runtimes/node/vercel-ai-sdk-v6/tsconfig.json
+++ b/ts/e2e-tests/runtimes/node/vercel-ai-sdk-v6/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["e2e.test.ts"]
+}

--- a/ts/e2e-tests/runtimes/node/vercel-ai-sdk-v7/README.md
+++ b/ts/e2e-tests/runtimes/node/vercel-ai-sdk-v7/README.md
@@ -1,0 +1,43 @@
+# @composio/vercel + AI SDK v7 Compatibility Test
+
+Verifies that `@composio/vercel` installs, typechecks, and executes wrapped tools with `ai@7`.
+
+## Background
+
+`@composio/vercel` declares `ai` as a peer dependency across multiple majors (`^6.0.0 || ^7.0.0`). This suite guards the AI SDK **v7** arm of that range, including the v7-specific `ToolExecutionOptions` shape passed to `tool.execute`. The v6 arm is covered by the sibling `vercel-ai-sdk-v6` suite.
+
+## What It Tests
+
+| Marker                                          | Description                                                          |
+| ----------------------------------------------- | ------------------------------------------------------------------- |
+| `vercel ai sdk compatibility typecheck passed`  | The packed provider typechecks against `ai@7` (`fixtures/index.ts`) |
+| `WRAPPED_TOOL_INPUT_SCHEMA_OK`                  | `wrapTool` returns an AI SDK tool with `inputSchema` + `execute`    |
+| `OBJECT_INPUT_EXECUTION_OK`                     | Object inputs are forwarded to `executeTool`                        |
+| `STRING_INPUT_EXECUTION_OK`                     | JSON-string inputs are normalized before `executeTool`              |
+| `V7_EXECUTION_OPTIONS_OK`                       | A wrapped tool accepts AI SDK v7 `ToolExecutionOptions`            |
+| `TOOL_SET_OK`                                   | `wrapTools` produces a `ToolSet`-compatible collection             |
+
+## Fixture
+
+```
+fixtures/
+├── index.mjs      # Executed at runtime: wraps a tool and asserts execution behavior
+├── index.ts       # Type-only (tsc --noEmit): asserts the provider's types line up with ai@7
+└── package.json   # Declares @composio/core (linked), ai@7, typescript, zod
+```
+
+The provider is installed the way consumers get it: `npm pack` of `@composio/vercel`, then install the resulting tarball — so the published `dist` and `peerDependencies` are exercised, not the workspace source.
+
+## Setup
+
+The `setup` phase runs `npm run install:vercel && npm run typecheck` in a Docker volume, then the fixture (`index.mjs`) runs with the installed `node_modules` mounted read-only.
+
+## Isolation Tool
+
+**Docker** with Node.js versions: 22.22.3, 24.17.0, 25.9.0.
+
+## Running
+
+```bash
+pnpm test:e2e
+```

--- a/ts/e2e-tests/runtimes/node/vercel-ai-sdk-v7/e2e.test.ts
+++ b/ts/e2e-tests/runtimes/node/vercel-ai-sdk-v7/e2e.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @composio/vercel + AI SDK v7 compatibility e2e test.
+ *
+ * Verifies that @composio/vercel installs, typechecks, and executes wrapped
+ * tools with ai@7.
+ */
+
+import { e2e, type E2ETestResultWithSetup } from '@e2e-tests/utils';
+import { describe, it, expect, beforeAll } from 'bun:test';
+
+e2e(import.meta.url, {
+  versions: { node: ['22.22.3', '24.17.0', '25.9.0'] },
+  usesFixtures: true,
+  defineTests: ({ runFixture }) => {
+    let result: E2ETestResultWithSetup;
+
+    beforeAll(async () => {
+      result = await runFixture({
+        filename: 'index.mjs',
+        // `install:vercel` packs and installs the provider tarball, which reifies
+        // the full fixture dependency tree, so no separate `npm install` is needed.
+        setup: 'npm run install:vercel && npm run typecheck',
+      });
+    }, 300_000);
+
+    describe('setup', () => {
+      it('installs and typechecks successfully', () => {
+        expect(result.setup.exitCode).toBe(0);
+        expect(result.setup.stdout).toContain('vercel ai sdk compatibility typecheck passed');
+      });
+    });
+
+    describe('@composio/vercel + ai@7', () => {
+      it('exits successfully', () => {
+        expect(result.exitCode).toBe(0);
+      });
+
+      it('wraps tools using inputSchema', () => {
+        expect(result.stdout).toContain('WRAPPED_TOOL_INPUT_SCHEMA_OK');
+      });
+
+      it('executes object inputs', () => {
+        expect(result.stdout).toContain('OBJECT_INPUT_EXECUTION_OK');
+      });
+
+      it('normalizes JSON string inputs', () => {
+        expect(result.stdout).toContain('STRING_INPUT_EXECUTION_OK');
+      });
+
+      it('accepts AI SDK v7 execution options', () => {
+        expect(result.stdout).toContain('V7_EXECUTION_OPTIONS_OK');
+      });
+
+      it('produces a ToolSet-compatible collection', () => {
+        expect(result.stdout).toContain('TOOL_SET_OK');
+      });
+    });
+  },
+});

--- a/ts/e2e-tests/runtimes/node/vercel-ai-sdk-v7/fixtures/index.mjs
+++ b/ts/e2e-tests/runtimes/node/vercel-ai-sdk-v7/fixtures/index.mjs
@@ -1,0 +1,69 @@
+import { VercelProvider } from '@composio/vercel';
+
+const composioTool = {
+  slug: 'TEST_TOOL',
+  name: 'Test Tool',
+  description: 'A tool used by the AI SDK compatibility fixture',
+  version: '20260625_00',
+  availableVersions: ['20260625_00'],
+  inputParameters: {
+    type: 'object',
+    properties: {
+      query: {
+        type: 'string',
+        description: 'Query text',
+      },
+    },
+    required: ['query'],
+  },
+  tags: [],
+};
+
+const calls = [];
+const executeTool = async (slug, params) => {
+  calls.push({ slug, params });
+  return {
+    data: { slug, params },
+    error: null,
+    successful: true,
+  };
+};
+
+const provider = new VercelProvider();
+const wrapped = provider.wrapTool(composioTool, executeTool);
+
+if (!wrapped || !wrapped.inputSchema || typeof wrapped.execute !== 'function') {
+  throw new Error('Wrapped tool does not match the AI SDK tool shape');
+}
+console.log('WRAPPED_TOOL_INPUT_SCHEMA_OK');
+
+await wrapped.execute({ query: 'object input' });
+if (calls.at(-1)?.slug !== 'TEST_TOOL' || calls.at(-1)?.params?.query !== 'object input') {
+  throw new Error('Object input was not forwarded to executeTool');
+}
+console.log('OBJECT_INPUT_EXECUTION_OK');
+
+await wrapped.execute(JSON.stringify({ query: 'string input' }));
+if (calls.at(-1)?.slug !== 'TEST_TOOL' || calls.at(-1)?.params?.query !== 'string input') {
+  throw new Error('String input was not normalized before executeTool');
+}
+console.log('STRING_INPUT_EXECUTION_OK');
+
+await wrapped.execute(
+  { query: 'options input' },
+  {
+    toolCallId: 'call_1',
+    messages: [],
+    context: {},
+  }
+);
+if (calls.at(-1)?.slug !== 'TEST_TOOL' || calls.at(-1)?.params?.query !== 'options input') {
+  throw new Error('AI SDK v7 execution options were not accepted');
+}
+console.log('V7_EXECUTION_OPTIONS_OK');
+
+const toolSet = provider.wrapTools([composioTool], executeTool);
+if (!toolSet.TEST_TOOL) {
+  throw new Error('Wrapped tools collection is missing TEST_TOOL');
+}
+console.log('TOOL_SET_OK');

--- a/ts/e2e-tests/runtimes/node/vercel-ai-sdk-v7/fixtures/index.ts
+++ b/ts/e2e-tests/runtimes/node/vercel-ai-sdk-v7/fixtures/index.ts
@@ -1,0 +1,46 @@
+import { VercelProvider, type VercelToolCollection } from '@composio/vercel';
+import type { Tool as ComposioTool, ExecuteToolFn } from '@composio/core';
+import type { ToolExecutionOptions, ToolSet } from 'ai';
+
+const composioTool = {
+  slug: 'TEST_TOOL',
+  name: 'Test Tool',
+  description: 'A tool used by the AI SDK compatibility fixture',
+  version: '20260625_00',
+  availableVersions: ['20260625_00'],
+  inputParameters: {
+    type: 'object',
+    properties: {
+      query: {
+        type: 'string',
+        description: 'Query text',
+      },
+    },
+    required: ['query'],
+  },
+  tags: [],
+} satisfies ComposioTool;
+
+const executeTool = (async () => ({
+  data: { ok: true },
+  error: null,
+  successful: true,
+})) satisfies ExecuteToolFn;
+
+const provider = new VercelProvider();
+const wrapped = provider.wrapTool(composioTool, executeTool);
+const tools = provider.wrapTools([composioTool], executeTool);
+
+// Assignability smoke check: the wrapped collection must satisfy both the
+// provider's exported type and the installed AI SDK's ToolSet.
+const _wrappedToolSet: VercelToolCollection = tools satisfies ToolSet;
+
+if (wrapped.execute) {
+  const options = {
+    toolCallId: 'call_1',
+    messages: [],
+    context: {},
+  } satisfies ToolExecutionOptions<unknown>;
+
+  await wrapped.execute({ query: 'typed input' }, options);
+}

--- a/ts/e2e-tests/runtimes/node/vercel-ai-sdk-v7/fixtures/package.json
+++ b/ts/e2e-tests/runtimes/node/vercel-ai-sdk-v7/fixtures/package.json
@@ -1,0 +1,14 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "install:vercel": "VERCEL_TGZ=$(npm pack /app/ts/packages/providers/vercel --pack-destination . --silent) && test -n \"$VERCEL_TGZ\" && npm install --ignore-scripts --legacy-peer-deps --package-lock=false \"./$VERCEL_TGZ\"",
+    "typecheck": "tsc --noEmit && echo vercel ai sdk compatibility typecheck passed"
+  },
+  "dependencies": {
+    "@composio/core": "file:/app/ts/packages/core",
+    "ai": "7.0.2",
+    "typescript": "5.8.3",
+    "zod": "4.4.3"
+  }
+}

--- a/ts/e2e-tests/runtimes/node/vercel-ai-sdk-v7/fixtures/tsconfig.json
+++ b/ts/e2e-tests/runtimes/node/vercel-ai-sdk-v7/fixtures/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["index.ts"]
+}

--- a/ts/e2e-tests/runtimes/node/vercel-ai-sdk-v7/package.json
+++ b/ts/e2e-tests/runtimes/node/vercel-ai-sdk-v7/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@e2e-tests/node-vercel-ai-sdk-v7",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test:e2e": "bun test e2e.test.ts",
+    "test:e2e:node": "bun test e2e.test.ts"
+  },
+  "devDependencies": {
+    "@e2e-tests/utils": "workspace:*"
+  }
+}

--- a/ts/e2e-tests/runtimes/node/vercel-ai-sdk-v7/tsconfig.json
+++ b/ts/e2e-tests/runtimes/node/vercel-ai-sdk-v7/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["e2e.test.ts"]
+}

--- a/ts/packages/providers/vercel/package.json
+++ b/ts/packages/providers/vercel/package.json
@@ -38,7 +38,7 @@
   "license": "ISC",
   "peerDependencies": {
     "@composio/core": ">=0.10.0 <1.0.0",
-    "ai": "^5.0.0 || ^6.0.0"
+    "ai": "^6.0.0 || ^7.0.0"
   },
   "devDependencies": {
     "@composio/core": "workspace:*",


### PR DESCRIPTION
This PR:

- widens the `ai` peer dependency of `@composio/vercel` to `^6.0.0 || ^7.0.0`, adding AI SDK v7 support and dropping the previously-untested v5 arm
- adds Docker-based Node e2e compatibility suites for AI SDK v6 and v7 under `ts/e2e-tests/runtimes/node/vercel-ai-sdk-v{6,7}`, auto-discovered by the existing e2e matrix (so PR CI exercises them)
  - each installs the packed `@composio/vercel` tarball, typechecks the provider against the target `ai` major, and asserts runtime tool wrapping/execution (object inputs, JSON-string normalization via `normalizeToolArguments`, `ToolSet` shape)
  - the v7 suite additionally exercises v7's `ToolExecutionOptions` passed to `tool.execute`
- ships a `minor` changeset (the peer-range narrowing removes a previously-supported major)
- breaking:
  - `ai@5` is no longer an accepted peer of `@composio/vercel`; v5 consumers should stay on the prior minor