### PR TITLE
test(cli): cover fish completion install idempotency

### DIFF
--- a/ts/packages/cli/test/src/commands/install.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/install.cmd.test.ts
@@ -173,6 +173,43 @@ describe('CLI: composio install', () => {
     });
   });
 
+  describe('[When] fish shell installs completions twice', () => {
+    layer(TestLive())(it => {
+      it.scoped('[Then] keeps config.fish and composio.fish idempotent', () =>
+        Effect.gen(function* () {
+          const os = yield* NodeOs;
+          process.env.SHELL = '/usr/bin/fish';
+          process.env.COMPOSIO_INSTALL_DIR = path.join(os.homedir, '.composio');
+
+          yield* cli(['install', '--completions']);
+          yield* cli(['install', '--completions']);
+
+          const fs = yield* FileSystem.FileSystem;
+          const configPath = path.join(os.homedir, '.config', 'fish', 'config.fish');
+          const completionPath = path.join(
+            os.homedir,
+            '.config',
+            'fish',
+            'completions',
+            'composio.fish'
+          );
+          const configContents = yield* fs.readFileString(configPath);
+          const completionContents = yield* fs.readFileString(completionPath);
+
+          const pathMarkerCount = configContents.match(/^# Composio CLI$/gm)?.length ?? 0;
+          const configCompletionsCount =
+            configContents.match(/^# Composio CLI completions$/gm)?.length ?? 0;
+          const fishCompletionsCount =
+            completionContents.match(/^# Composio CLI completions$/gm)?.length ?? 0;
+
+          expect(pathMarkerCount).toBe(1);
+          expect(configCompletionsCount).toBe(0);
+          expect(fishCompletionsCount).toBe(1);
+        })
+      );
+    });
+  });
+
   describe('[When] --no-completions is passed', () => {
     layer(TestLive())(it => {
       it.scoped('[Then] writes PATH block but skips completions', () =>


### PR DESCRIPTION
This PR:
- follows up on https://github.com/ComposioHQ/composio/pull/3440 and credits Deepak Singh Kandari / @aptsalt from the original implementation
- builds on the fish completion fix already merged in https://github.com/ComposioHQ/composio/pull/3162
- references https://github.com/ComposioHQ/composio/issues/3147
- adds regression coverage for running `composio install --completions` twice under fish
- verifies `config.fish` keeps a single PATH marker and never receives completion markers
- verifies `~/.config/fish/completions/composio.fish` keeps one completion marker

## Testing
- `MISE_TRUSTED_CONFIG_PATHS=$PWD mise exec -- pnpm --filter @composio/cli exec vitest run test/src/commands/install.cmd.test.ts`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD mise exec -- pnpm --filter @composio/cli typecheck:test`
- `git diff --check origin/next...HEAD`