### PR TITLE
fix(docs): use app token for SDK docs sync PRs

### DIFF
--- a/.github/workflows/docs.sdk-change-sync.yml
+++ b/.github/workflows/docs.sdk-change-sync.yml
@@ -24,7 +24,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          client-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
 
       - name: Checkout repository

--- a/.github/workflows/docs.sdk-change-sync.yml
+++ b/.github/workflows/docs.sdk-change-sync.yml
@@ -20,9 +20,17 @@ jobs:
       id-token: write
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Get SDK diff
@@ -76,6 +84,7 @@ jobs:
         if: steps.diff.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: 'docs: update guides for SDK changes'
           title: 'docs: update guides for SDK changes'
           body: |
@@ -97,8 +106,9 @@ jobs:
 
       - name: Request review from pusher
         if: steps.create-pr.outputs.pull-request-number
+        continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
           AUTHOR: ${{ github.actor }}
         run: gh pr edit "$PR_NUMBER" --add-reviewer "$AUTHOR"


### PR DESCRIPTION
This PR:
- fixes the `Docs - Sync guides on SDK changes` workflow failure from https://github.com/ComposioHQ/composio/actions/runs/28332657149/job/83933412114
- mints the existing release-bot GitHub App token before checkout
- uses that token for checkout, `peter-evans/create-pull-request`, and reviewer requests
- keeps reviewer assignment non-blocking so a successful docs PR is not failed by reviewer-request edge cases
- verifies the workflow file with `ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); puts "yaml ok"' .github/workflows/docs.sdk-change-sync.yml`, `mise exec -- pnpm exec prettier --check .github/workflows/docs.sdk-change-sync.yml`, and `git diff --check -- .github/workflows/docs.sdk-change-sync.yml`