### PR TITLE
chore(ci): use GitHub App client ID input

### DIFF
--- a/.github/workflows/docs-update-data.yml
+++ b/.github/workflows/docs-update-data.yml
@@ -24,7 +24,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          client-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
 
       - name: Checkout repository

--- a/.github/workflows/generate-sdk-docs.yml
+++ b/.github/workflows/generate-sdk-docs.yml
@@ -27,7 +27,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          client-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
 
       - name: Checkout Code
@@ -77,7 +77,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          client-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
 
       - name: Checkout Code

--- a/.github/workflows/ts.release.yml
+++ b/.github/workflows/ts.release.yml
@@ -26,7 +26,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          client-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
 
       - name: Checkout Code


### PR DESCRIPTION
This PR:
- replaces the deprecated `app-id` input for `actions/create-github-app-token` with `client-id`
- reads the public release bot Client ID from the `RELEASE_BOT_CLIENT_ID` repo variable
- keeps `RELEASE_BOT_APP_PRIVATE_KEY` as the only GitHub App secret used by these token steps
- updates token generation in docs data sync, SDK reference generation, and TypeScript release workflows
- pairs with the one-line update already pushed to https://github.com/ComposioHQ/composio/pull/3706 for the SDK docs sync workflow

## Verification
- `rg -n 'app-id:' .github || true`
- `rg -n 'client-id:' .github/workflows`
- parsed edited workflow YAML with Ruby/Psych
- confirmed `RELEASE_BOT_CLIENT_ID` exists as a repo variable
- workflow-dispatch smoke run for #3706 passed with `client-id` and no `app-id` deprecation warning: https://github.com/ComposioHQ/composio/actions/runs/28358680527