### PR TITLE
fix(py): handle 4+ option and typeless anyOf/oneOf unions in tool signatures

### DIFF
--- a/python/composio/utils/shared.py
+++ b/python/composio/utils/shared.py
@@ -9,6 +9,7 @@ import json
 import keyword
 import typing as t
 import uuid
+from functools import reduce
 from inspect import Parameter
 
 from pydantic import BaseModel, Field, create_model
@@ -580,21 +581,16 @@ def get_signature_format_from_schema_params(
             param_type = param_allOf[0].get("type", None)
         if param_oneOf is not None or param_anyOf is not None:
             param_types = [ptype.get("type") for ptype in (param_oneOf or param_anyOf)]
-            if len(param_types) == 1:
-                annotation = PYDANTIC_TYPE_TO_PYTHON_TYPE[param_types[0]]
-            elif len(param_types) == 2:
-                # Check as redefinition and union was incompatible
-                # @karan to check if this is the right way to do it
-                t1: t.Type = PYDANTIC_TYPE_TO_PYTHON_TYPE[param_types[0]]  # type: ignore
-                t2: t.Type = PYDANTIC_TYPE_TO_PYTHON_TYPE[param_types[1]]  # type: ignore
-                annotation: t.Type = t.Union[t1, t2]  # type: ignore
-            elif len(param_types) == 3:
-                t1: t.Type = PYDANTIC_TYPE_TO_PYTHON_TYPE[param_types[0]]  # type: ignore
-                t2: t.Type = PYDANTIC_TYPE_TO_PYTHON_TYPE[param_types[1]]  # type: ignore
-                t3: t.Type = PYDANTIC_TYPE_TO_PYTHON_TYPE[param_types[2]]  # type: ignore
-                annotation: t.Type = t.Union[t1, t2, t3]  # type: ignore
+            # Map each option to a Python type, falling back to t.Any for options
+            # that are missing a "type" key or use an unrecognized type, then build
+            # a Union for any count of members (no 1/2/3-member cap).
+            mapped_types: t.List[t.Any] = [
+                PYDANTIC_TYPE_TO_PYTHON_TYPE.get(ptype, t.Any) for ptype in param_types
+            ]
+            if len(mapped_types) == 1:
+                annotation = mapped_types[0]
             else:
-                raise ValueError("Invalid 'oneOf' schema")
+                annotation = reduce(lambda a, b: t.Union[a, b], mapped_types)
             param_default = param_schema.get("default", "")
         elif param_type in PYDANTIC_TYPE_TO_PYTHON_TYPE:
             annotation = PYDANTIC_TYPE_TO_PYTHON_TYPE[param_type]

--- a/python/tests/test_schema_parser.py
+++ b/python/tests/test_schema_parser.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel
 from pydantic.fields import PydanticUndefined
 
 from composio.utils.shared import (
+    get_signature_format_from_schema_params,
     json_schema_to_fields_dict,
     json_schema_to_model,
     json_schema_to_pydantic_field,
@@ -1460,6 +1461,146 @@ class TestBooleanDefaultCoercion:
             assert prop.get("default") is expected_bool, (
                 f"Expected '{string_value}' to coerce to {expected_bool}"
             )
+
+
+class TestGetSignatureFormatFromSchemaParams:
+    """Test cases for get_signature_format_from_schema_params union handling."""
+
+    @staticmethod
+    def _annotation(schema):
+        params = get_signature_format_from_schema_params(schema)
+        assert len(params) == 1
+        return params[0].annotation
+
+    @pytest.mark.unit
+    @pytest.mark.schema
+    def test_oneof_four_members(self):
+        """oneOf with 4 options builds a Union instead of raising ValueError."""
+        schema = {
+            "properties": {
+                "value": {
+                    "oneOf": [
+                        {"type": "string"},
+                        {"type": "integer"},
+                        {"type": "boolean"},
+                        {"type": "number"},
+                    ]
+                }
+            }
+        }
+
+        annotation = self._annotation(schema)
+        assert t.get_origin(annotation) is t.Union
+        assert set(t.get_args(annotation)) == {str, int, bool, float}
+
+    @pytest.mark.unit
+    @pytest.mark.schema
+    def test_oneof_five_members(self):
+        """oneOf with more than four options is also supported (no 3-member cap)."""
+        schema = {
+            "properties": {
+                "value": {
+                    "oneOf": [
+                        {"type": "string"},
+                        {"type": "integer"},
+                        {"type": "boolean"},
+                        {"type": "number"},
+                        {"type": "array"},
+                    ]
+                }
+            }
+        }
+
+        annotation = self._annotation(schema)
+        assert t.get_origin(annotation) is t.Union
+        assert len(t.get_args(annotation)) == 5
+
+    @pytest.mark.unit
+    @pytest.mark.schema
+    def test_anyof_option_missing_type(self):
+        """An anyOf option without a 'type' key maps to Any instead of raising KeyError."""
+        schema = {
+            "properties": {
+                "value": {
+                    "anyOf": [
+                        {"description": "free-form value"},
+                        {"type": "string"},
+                    ]
+                }
+            }
+        }
+
+        annotation = self._annotation(schema)
+        assert t.get_origin(annotation) is t.Union
+        args = t.get_args(annotation)
+        assert t.Any in args
+        assert str in args
+
+    @pytest.mark.unit
+    @pytest.mark.schema
+    def test_anyof_all_options_missing_type(self):
+        """anyOf where every option lacks a 'type' collapses to a single Any annotation."""
+        schema = {
+            "properties": {
+                "value": {
+                    "anyOf": [
+                        {"description": "a"},
+                        {"description": "b"},
+                    ]
+                }
+            }
+        }
+
+        assert self._annotation(schema) is t.Any
+
+    @pytest.mark.unit
+    @pytest.mark.schema
+    def test_oneof_single_member(self):
+        """oneOf with a single option resolves to that type directly (unchanged)."""
+        schema = {"properties": {"value": {"oneOf": [{"type": "string"}]}}}
+        assert self._annotation(schema) is str
+
+    @pytest.mark.unit
+    @pytest.mark.schema
+    def test_oneof_two_members(self):
+        """Two-member oneOf behavior is preserved (Union of the two types)."""
+        schema = {
+            "properties": {
+                "value": {"oneOf": [{"type": "string"}, {"type": "integer"}]}
+            }
+        }
+        assert self._annotation(schema) == t.Union[str, int]
+
+    @pytest.mark.unit
+    @pytest.mark.schema
+    def test_oneof_three_members(self):
+        """Three-member oneOf behavior is preserved (Union of the three types)."""
+        schema = {
+            "properties": {
+                "value": {
+                    "oneOf": [
+                        {"type": "string"},
+                        {"type": "integer"},
+                        {"type": "boolean"},
+                    ]
+                }
+            }
+        }
+        assert self._annotation(schema) == t.Union[str, int, bool]
+
+    @pytest.mark.unit
+    @pytest.mark.schema
+    def test_anyof_with_null_member_still_resolves(self):
+        """Nullable anyOf [type, null] continues to resolve without raising."""
+        schema = {
+            "properties": {"value": {"anyOf": [{"type": "string"}, {"type": "null"}]}}
+        }
+
+        annotation = self._annotation(schema)
+        assert t.get_origin(annotation) is t.Union
+        args = t.get_args(annotation)
+        assert str in args
+        assert type(None) in args
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
`get_signature_format_from_schema_params` in `python/composio/utils/shared.py` builds the `__signature__` for the tool wrappers used by the langchain, langgraph, llamaindex, and autogen providers. Its `oneOf`/`anyOf` handling hardcoded a ladder for exactly 1, 2, or 3 union members and raised `ValueError("Invalid 'oneOf' schema")` for any union with four or more options. It also indexed `PYDANTIC_TYPE_TO_PYTHON_TYPE[ptype.get("type")]` directly, so any combiner option missing a `type` key produced `None` and raised `KeyError(None)`.

Both shapes are valid JSON Schema and appear in real tool input schemas, so a tool with a 4-way union, or a combiner option without an explicit `type`, makes those four providers raise at tool-wrap time. This replaces the ladder with a single map + `functools.reduce` path that mirrors the existing `_build_union_from_options` in `schema_converter.py`, keeping the 1/2/3-member and nullable `[type, null]` outputs identical to before.

Fixes #

## Changes
- `python/composio/utils/shared.py`: in `get_signature_format_from_schema_params`, replace the 1/2/3-member `oneOf`/`anyOf` ladder (which raised `ValueError` for 4+ members) with a map-each-option-to-a-Python-type + `functools.reduce` Union build that supports any member count. Unknown/missing option types map to `typing.Any` instead of raising `KeyError`. Adds `from functools import reduce` and removes three now-unnecessary `# type: ignore` comments.
- `python/tests/test_schema_parser.py`: add `TestGetSignatureFormatFromSchemaParams` (8 cases) covering 4- and 5-member unions, an `anyOf` option missing `type`, an all-typeless `anyOf`, and regressions for the previously supported single/2/3-member and nullable `[type, null]` shapes.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [ ] Documentation
- [ ] Breaking change

## How Has This Been Tested?
From `python/`:

```
uv run pytest tests/test_schema_parser.py::TestGetSignatureFormatFromSchemaParams -v   # 8 passed
uv run pytest tests/test_schema_parser.py -q                                           # 75 passed
make chk   # ruff + mypy -> clean, no new ignores
```

To confirm the tests guard the fix, the new test class was also run against the unmodified `shared.py`: 4 of the 8 fail there (`ValueError`/`KeyError` on the 4+/typeless cases), and all 8 pass with this change. The nullable `anyOf [type, null]` case still resolves to `Union[str, Any, NoneType]` (its pre-existing behavior); collapsing `null` into `Optional` lives in `schema_converter` and is intentionally left out of this minimal fix, with the test documenting current behavior.

## Screenshots (if applicable)
N/A

## Checklist
- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed
- [ ] I updated documentation as needed
- [x] I added tests or explain why not applicable
- [ ] I added a changeset if this change affects published packages

## Additional context
No linked issue: this is a self-identified, reproduced bug in the older schema->signature path. The fix deliberately mirrors `schema_converter._build_union_from_options` so the two schema paths agree on N-ary union handling. The same bug family exists in `python/composio/utils/openapi.py` (`function_signature_from_jsonschema`, used by the google_adk provider) but is kept out of this PR to stay single-purpose; happy to follow up on it separately.
