### PR TITLE
fix(core): disable retries on non-idempotent `tools.execute`/`proxyExecute`

### DIFF
--- a/.changeset/disable-retries-execute-proxy.md
+++ b/.changeset/disable-retries-execute-proxy.md
@@ -1,0 +1,5 @@
+---
+'@composio/core': patch
+---
+
+Disable client retries on `tools.execute` and `tools.proxyExecute`. These are non-idempotent writes, so a silent retry after a read timeout could duplicate the side effect (e.g. send the same email more than once). Both now route through a sibling client built with `maxRetries: 0`; reads keep the default retry behaviour.

--- a/ts/packages/core/src/models/Tools.ts
+++ b/ts/packages/core/src/models/Tools.ts
@@ -114,6 +114,11 @@ export class Tools<
    */
   private readonly warnedAutoUploadDisabledForTool = new Set<string>();
 
+  /**
+   * Lazily-built sibling client with retries disabled; see `clientWithoutRetries`.
+   */
+  private clientWithoutRetriesCache?: ComposioClient;
+
   constructor(client: ComposioClient, config?: ComposioConfig<TProvider>) {
     if (!client) {
       throw new Error('ComposioClient is required');
@@ -144,6 +149,27 @@ export class Tools<
     this.getRawComposioTools = this.getRawComposioTools.bind(this);
 
     telemetry.instrument(this, 'Tools');
+  }
+
+  /**
+   * A cached sibling client that never retries requests, mirroring Python's
+   * `client.without_retries`.
+   *
+   * Used for non-idempotent writes (`tools.execute` / `tools.proxy`), where a
+   * silent retry after a read timeout can duplicate a side effect (e.g. send an
+   * email twice). Reads keep the default retry behaviour, and so do other writes
+   * (`toolRouter.session.execute`, auth-config and connected-account mutations):
+   * the durable fix there is backend-honoured idempotency keys, tracked
+   * separately.
+   *
+   * Cached rather than rebuilt per call because `withOptions` constructs a fresh
+   * client; its options never change, so one per `Tools` instance suffices.
+   */
+  private get clientWithoutRetries(): ComposioClient {
+    if (!this.clientWithoutRetriesCache) {
+      this.clientWithoutRetriesCache = this.client.withOptions({ maxRetries: 0 });
+    }
+    return this.clientWithoutRetriesCache;
   }
 
   /**
@@ -919,7 +945,9 @@ export class Tools<
         text: body.text,
       };
       const result = await withCancellation(
-        () => this.client.tools.execute(tool.slug, executeBody, requestOptions),
+        // Disable retries: tool execution is a non-idempotent write, and a
+        // silent retry after a read timeout can duplicate the side effect.
+        () => this.clientWithoutRetries.tools.execute(tool.slug, executeBody, requestOptions),
         requestOptions?.signal
       );
       // transform the response to the ToolExecuteResponse format
@@ -1253,7 +1281,9 @@ export class Tools<
       custom_connection_data: toolProxyParams.data.customConnectionData,
     } as ComposioToolProxyParams;
     return withCancellation(
-      () => this.client.tools.proxy(proxyBody, requestOptions),
+      // Disable retries: a proxied call is a non-idempotent write, and a silent
+      // retry after a read timeout can duplicate the side effect.
+      () => this.clientWithoutRetries.tools.proxy(proxyBody, requestOptions),
       requestOptions?.signal
     );
   }

--- a/ts/packages/core/test/tools/tools.test.ts
+++ b/ts/packages/core/test/tools/tools.test.ts
@@ -2403,3 +2403,62 @@ describe('Tools', () => {
     });
   });
 });
+
+describe('retries disabled on non-idempotent writes', () => {
+  // Regression: a timed-out, non-idempotent tools.execute / tools.proxy must not
+  // be silently retried — a retry after a server-side success duplicates the side
+  // effect (e.g. sends the same email up to 3 times). Both route through a sibling
+  // client built with maxRetries: 0; reads keep the client's default retries.
+  // See https://github.com/ComposioHQ/composio/issues/3586 (TS parity with Python).
+  const context = createTestContext();
+  setupTest(context);
+
+  it('routes tools.execute through a client with maxRetries: 0', async () => {
+    await mockToolExecution(context.tools);
+
+    await context.tools.execute('COMPOSIO_TOOL', {
+      userId: 'test-user',
+      arguments: { query: 'test' },
+      dangerouslySkipVersionCheck: true,
+    });
+
+    expect(mockClient.withOptions).toHaveBeenCalledWith({ maxRetries: 0 });
+    expect(mockClient.tools.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes tools.proxyExecute through a client with maxRetries: 0', async () => {
+    mockClient.tools.proxy.mockResolvedValueOnce({ data: {}, successful: true });
+
+    await context.tools.proxyExecute({
+      endpoint: '/api/test',
+      method: 'POST' as const,
+      body: { data: 'test' },
+      connectedAccountId: 'test-account-id',
+    });
+
+    expect(mockClient.withOptions).toHaveBeenCalledWith({ maxRetries: 0 });
+    expect(mockClient.tools.proxy).toHaveBeenCalledTimes(1);
+  });
+
+  it('reuses one no-retries sibling client across executes (cached per instance)', async () => {
+    const { getRawComposioToolBySlugSpy } = await mockToolExecution(context.tools);
+
+    await context.tools.execute('COMPOSIO_TOOL', {
+      userId: 'test-user',
+      arguments: { query: 'test' },
+      dangerouslySkipVersionCheck: true,
+    });
+
+    // Queue a second execute; mockToolExecution only primed one response.
+    getRawComposioToolBySlugSpy.mockResolvedValueOnce(toolMocks.transformedTool as unknown as Tool);
+    mockClient.tools.execute.mockResolvedValueOnce(toolMocks.rawToolExecuteResponse);
+    await context.tools.execute('COMPOSIO_TOOL', {
+      userId: 'test-user',
+      arguments: { query: 'test again' },
+      dangerouslySkipVersionCheck: true,
+    });
+
+    expect(mockClient.tools.execute).toHaveBeenCalledTimes(2);
+    expect(mockClient.withOptions).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ts/packages/core/test/utils/mocks/client.mock.ts
+++ b/ts/packages/core/test/utils/mocks/client.mock.ts
@@ -1,6 +1,6 @@
 import { vi } from 'vitest';
 
-export const mockClient = {
+const mockClientBase = {
   tools: {
     list: vi.fn(),
     retrieve: vi.fn(),
@@ -37,3 +37,14 @@ export const mockClient = {
     },
   },
 };
+
+// `withOptions` returns the same mock so chained calls (e.g.
+// `client.withOptions({ maxRetries: 0 }).tools.execute(...)`) still record on
+// the same spies. Mirrors the real client's `withOptions`.
+//
+// This implementation is load-bearing: tests rely on `vi.clearAllMocks()`
+// (which preserves implementations), not `vi.resetAllMocks()` (which would wipe
+// it and make chained `.tools.*` calls throw on `undefined`).
+export const mockClient = Object.assign(mockClientBase, {
+  withOptions: vi.fn(() => mockClientBase),
+});


### PR DESCRIPTION
This PR:

- Closes https://github.com/ComposioHQ/composio/issues/3586
- disables client retries on `tools.execute` and `tools.proxyExecute` — the two non-idempotent writes — so a request that succeeds server-side but times out client-side is no longer silently replayed (the cause of duplicate `GMAIL_SEND_EMAIL` sends)
- routes both through a sibling client built with `withOptions({ maxRetries: 0 })`; reads keep the client's default retries (`maxRetries: 2`)
- caches that sibling per `Tools` instance (`clientWithoutRetries`) since `withOptions` constructs a fresh client and execute/proxy is the hottest path; mirrors the Python SDK's `client.without_retries`
- adds regression tests asserting both paths route through `maxRetries: 0` and that the sibling is built once across multiple executes

## Context

The original hang on attachments larger than ~25 KB was a backend defect and has already been fixed server-side. The remaining gap was a cross-SDK parity one: the Python SDK already disabled retries on these non-idempotent writes, but `@composio/core` still inherited the client default of 2 retries (3 attempts total), with no public knob to turn them off. This is the TypeScript parity port — scoped to exactly `tools.execute` / `tools.proxy`, leaving `toolRouter.session.execute` and all reads on their default retry behaviour, matching Python.