### PR TITLE
feat(examples): add Dakera self-hosted persistent memory agent example

### DIFF
--- a/python/examples/dakera_memory_agent.py
+++ b/python/examples/dakera_memory_agent.py
@@ -1,0 +1,266 @@
+"""Dakera persistent memory — custom toolkit example.
+
+Shows how to give a Composio agent cross-session memory using
+`Dakera <https://dakera.ai>`_ — a self-hosted, decay-weighted vector
+memory server.
+
+The three tools registered here (``STORE_MEMORY``, ``SEARCH_MEMORY``,
+``FORGET_MEMORY``) are in-process ``experimental`` tools: they run inside
+the Python process and call the Dakera REST API directly.  No Composio
+cloud connection is needed for the Dakera calls.
+
+Quick start
+-----------
+1. Start a local Dakera instance::
+
+       docker run -d -p 3300:3300 \\
+         -e DAKERA_API_KEY=demo \\
+         ghcr.io/dakera-ai/dakera:latest
+
+2. Set environment variables::
+
+       export COMPOSIO_API_KEY=...
+       export OPENAI_API_KEY=...
+       export DAKERA_API_KEY=demo
+       export DAKERA_BASE_URL=http://localhost:3300   # default
+
+3. Run::
+
+       python examples/dakera_memory_agent.py
+
+REST API reference
+------------------
+POST /v1/memory/store
+    Body: {content, agent_id, session_id?, importance?, tags?, metadata?}
+    Returns: {memory: {id, content, agent_id, ...}}
+
+POST /v1/memory/search
+    Body: {agent_id, query, top_k?, session_id?}
+    Returns: {memories: [{memory: {id, content, ...}, score}]}
+
+POST /v1/memory/forget
+    Body: {agent_id, memory_ids?}
+    Returns: {success: true}
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import typing as t
+
+import httpx
+from agents import Agent, Runner
+from pydantic import BaseModel, Field
+
+from composio import Composio
+from composio_openai_agents import OpenAIAgentsProvider
+
+# ---------------------------------------------------------------------------
+# Configuration (read from environment at call time)
+# ---------------------------------------------------------------------------
+
+_DAKERA_BASE_URL = os.environ.get("DAKERA_BASE_URL", "http://localhost:3300").rstrip("/")
+_DAKERA_API_KEY = os.environ.get("DAKERA_API_KEY", "")
+_AGENT_ID = "composio-demo-agent"
+
+
+def _dakera_headers() -> dict[str, str]:
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+    if _DAKERA_API_KEY:
+        headers["Authorization"] = f"Bearer {_DAKERA_API_KEY}"
+    return headers
+
+
+# ---------------------------------------------------------------------------
+# Dakera HTTP helpers
+# ---------------------------------------------------------------------------
+
+
+def _dakera_post(path: str, payload: dict[str, t.Any]) -> dict[str, t.Any]:
+    """Call a Dakera REST endpoint and return the parsed JSON response."""
+    with httpx.Client(base_url=_DAKERA_BASE_URL, headers=_dakera_headers(), timeout=30.0) as c:
+        resp = c.post(path, json=payload)
+        if resp.is_error:
+            raise RuntimeError(f"Dakera {path} returned HTTP {resp.status_code}: {resp.text}")
+        return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# Composio setup
+# ---------------------------------------------------------------------------
+
+composio = Composio(provider=OpenAIAgentsProvider())
+
+
+# ---------------------------------------------------------------------------
+# Custom tool input models
+# ---------------------------------------------------------------------------
+
+
+class StoreMemoryInput(BaseModel):
+    content: str = Field(description="The text to remember.")
+    session_id: t.Optional[str] = Field(
+        default=None,
+        description="Optional session scope for this memory.",
+    )
+    importance: float = Field(
+        default=0.5,
+        ge=0.0,
+        le=1.0,
+        description="Initial importance score [0–1]. Higher values decay more slowly.",
+    )
+    tags: t.Optional[t.List[str]] = Field(
+        default=None,
+        description="Optional tags for later filtering (e.g. ['preference', 'decision']).",
+    )
+
+
+class SearchMemoryInput(BaseModel):
+    query: str = Field(description="Natural-language query to search past memories.")
+    top_k: int = Field(
+        default=5,
+        ge=1,
+        le=20,
+        description="Number of memories to return, ranked by relevance.",
+    )
+
+
+class ForgetMemoryInput(BaseModel):
+    memory_ids: t.Optional[t.List[str]] = Field(
+        default=None,
+        description=(
+            "Specific memory IDs to delete. "
+            "Omit to wipe ALL memories for this agent."
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool definitions using @composio.experimental.tool()
+# ---------------------------------------------------------------------------
+
+
+@composio.experimental.tool(
+    slug="STORE_MEMORY",
+    name="Store Memory",
+    description=(
+        "Persist a new text memory to long-term storage. "
+        "Call this when you learn something important that should be remembered "
+        "in future conversations — user preferences, decisions, or key facts."
+    ),
+)
+def store_memory(input: StoreMemoryInput, ctx: t.Any) -> dict[str, t.Any]:
+    """Store a memory record in Dakera."""
+    payload: dict[str, t.Any] = {
+        "content": input.content,
+        "agent_id": _AGENT_ID,
+        "importance": input.importance,
+    }
+    if input.session_id:
+        payload["session_id"] = input.session_id
+    if input.tags:
+        payload["tags"] = input.tags
+
+    data = _dakera_post("/v1/memory/store", payload)
+    memory = data.get("memory", {})
+    return {
+        "id": memory.get("id", ""),
+        "content": memory.get("content", input.content),
+        "stored": True,
+    }
+
+
+@composio.experimental.tool(
+    slug="SEARCH_MEMORY",
+    name="Search Memory",
+    description=(
+        "Retrieve relevant memories from long-term storage using semantic search. "
+        "Call this at the start of a conversation to recall what you know about "
+        "the user or the current topic."
+    ),
+)
+def search_memory(input: SearchMemoryInput, ctx: t.Any) -> dict[str, t.Any]:
+    """Retrieve the most semantically relevant memories for a query."""
+    data = _dakera_post(
+        "/v1/memory/search",
+        {
+            "agent_id": _AGENT_ID,
+            "query": input.query,
+            "top_k": input.top_k,
+        },
+    )
+    memories = [
+        {
+            "id": hit["memory"]["id"],
+            "content": hit["memory"]["content"],
+            "score": round(hit["score"], 4),
+        }
+        for hit in data.get("memories", [])
+    ]
+    return {"memories": memories, "count": len(memories)}
+
+
+@composio.experimental.tool(
+    slug="FORGET_MEMORY",
+    name="Forget Memory",
+    description=(
+        "Delete specific memories or wipe all memories for this agent. "
+        "Use when a memory is outdated, incorrect, or should be removed at "
+        "the user's request."
+    ),
+)
+def forget_memory(input: ForgetMemoryInput, ctx: t.Any) -> dict[str, t.Any]:
+    """Delete one or more memories from Dakera."""
+    payload: dict[str, t.Any] = {"agent_id": _AGENT_ID}
+    if input.memory_ids:
+        payload["memory_ids"] = input.memory_ids
+
+    _dakera_post("/v1/memory/forget", payload)
+    return {"success": True, "deleted": input.memory_ids or "all"}
+
+
+# ---------------------------------------------------------------------------
+# Agent definition
+# ---------------------------------------------------------------------------
+
+SYSTEM_PROMPT = """You are a helpful assistant with access to persistent memory.
+
+At the start of each conversation, search your memory for relevant context.
+When you learn something important about the user, store it for future recall.
+When the user asks you to forget something, call forget_memory.
+
+Use the memory tools proactively — the user should not have to repeat themselves."""
+
+agent = Agent(
+    name="Dakera Memory Agent",
+    instructions=SYSTEM_PROMPT,
+    tools=composio.experimental.get_tools(
+        tools=["STORE_MEMORY", "SEARCH_MEMORY", "FORGET_MEMORY"]
+    ),
+)
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+async def main() -> None:
+    print("Dakera Memory Agent — type 'quit' to exit.\n")
+
+    session_id = "demo-session"
+
+    while True:
+        user_input = input("You: ").strip()
+        if not user_input or user_input.lower() in {"quit", "exit"}:
+            break
+
+        result = await Runner.run(
+            agent,
+            input=f"[session:{session_id}] {user_input}",
+        )
+        print(f"\nAgent: {result.final_output}\n")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/examples/dakera_memory_agent.py
+++ b/python/examples/dakera_memory_agent.py
@@ -62,20 +62,22 @@ from composio import SESSION_PRESET_DIRECT_TOOLS, Composio
 from composio_openai_agents import OpenAIAgentsProvider
 
 # ---------------------------------------------------------------------------
-# Configuration (read from environment at call time)
+# Configuration — read from the environment at call time (not captured at
+# import), so changing DAKERA_BASE_URL / DAKERA_API_KEY after import is honoured.
 # ---------------------------------------------------------------------------
 
-_DAKERA_BASE_URL = os.environ.get("DAKERA_BASE_URL", "http://localhost:3000").rstrip(
-    "/"
-)
-_DAKERA_API_KEY = os.environ.get("DAKERA_API_KEY", "")
 _AGENT_ID = "composio-demo-agent"
+
+
+def _dakera_base_url() -> str:
+    return os.environ.get("DAKERA_BASE_URL", "http://localhost:3000").rstrip("/")
 
 
 def _dakera_headers() -> dict[str, str]:
     headers: dict[str, str] = {"Content-Type": "application/json"}
-    if _DAKERA_API_KEY:
-        headers["Authorization"] = f"Bearer {_DAKERA_API_KEY}"
+    api_key = os.environ.get("DAKERA_API_KEY", "")
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
     return headers
 
 
@@ -87,7 +89,7 @@ def _dakera_headers() -> dict[str, str]:
 def _dakera_post(path: str, payload: dict[str, t.Any]) -> dict[str, t.Any]:
     """Call a Dakera REST endpoint and return the parsed JSON response."""
     with httpx.Client(
-        base_url=_DAKERA_BASE_URL, headers=_dakera_headers(), timeout=30.0
+        base_url=_dakera_base_url(), headers=_dakera_headers(), timeout=30.0
     ) as c:
         resp = c.post(path, json=payload)
         if resp.is_error:

--- a/python/examples/dakera_memory_agent.py
+++ b/python/examples/dakera_memory_agent.py
@@ -213,7 +213,7 @@ def search_memory(input: SearchMemoryInput, ctx: t.Any) -> dict[str, t.Any]:
 def forget_memory(input: ForgetMemoryInput, ctx: t.Any) -> dict[str, t.Any]:
     """Delete one or more memories from Dakera."""
     payload: dict[str, t.Any] = {"agent_id": _AGENT_ID}
-    if input.memory_ids:
+    if input.memory_ids is not None:
         payload["memory_ids"] = input.memory_ids
 
     _dakera_post("/v1/memory/forget", payload)
@@ -235,9 +235,7 @@ Use the memory tools proactively — the user should not have to repeat themselv
 agent = Agent(
     name="Dakera Memory Agent",
     instructions=SYSTEM_PROMPT,
-    tools=composio.experimental.get_tools(
-        tools=["STORE_MEMORY", "SEARCH_MEMORY", "FORGET_MEMORY"]
-    ),
+    tools=[store_memory, search_memory, forget_memory],
 )
 
 # ---------------------------------------------------------------------------

--- a/python/examples/dakera_memory_agent.py
+++ b/python/examples/dakera_memory_agent.py
@@ -4,46 +4,51 @@ Shows how to give a Composio agent cross-session memory using
 `Dakera <https://dakera.ai>`_ — a self-hosted, decay-weighted vector
 memory server.
 
-The three tools registered here (``STORE_MEMORY``, ``SEARCH_MEMORY``,
-``FORGET_MEMORY``) are in-process ``experimental`` tools: they run inside
-the Python process and call the Dakera REST API directly.  No Composio
-cloud connection is needed for the Dakera calls.
+Three in-process custom tools (``STORE_MEMORY``, ``RECALL_MEMORY``,
+``FORGET_MEMORY``) are registered on a Composio tool-router session and
+handed to an OpenAI Agents SDK agent.  The tool bodies run inside this
+Python process and call the Dakera REST API directly — Dakera itself
+needs no Composio cloud connection.  Registering the tools into the
+agent does use a Composio session, so ``COMPOSIO_API_KEY`` is required.
 
 Quick start
 -----------
-1. Start a local Dakera instance::
+1. Start a local Dakera instance.  The server needs an object store, so
+   run the ``dakera-deploy`` docker-compose stack rather than a bare
+   ``docker run`` (compose provisions the storage the server depends on)::
 
-       docker run -d -p 3300:3300 \\
-         -e DAKERA_API_KEY=demo \\
-         ghcr.io/dakera-ai/dakera:latest
+       git clone https://github.com/dakera-ai/dakera-deploy
+       cd dakera-deploy && docker compose up -d   # serves on http://localhost:3000
 
 2. Set environment variables::
 
        export COMPOSIO_API_KEY=...
        export OPENAI_API_KEY=...
-       export DAKERA_API_KEY=demo
-       export DAKERA_BASE_URL=http://localhost:3300   # default
+       export DAKERA_API_KEY=dk-...                    # the key you configured
+       export DAKERA_BASE_URL=http://localhost:3000    # default
 
 3. Run::
 
        python examples/dakera_memory_agent.py
 
-REST API reference
-------------------
+REST API reference (grounded on the Dakera server)
+--------------------------------------------------
 POST /v1/memory/store
-    Body: {content, agent_id, session_id?, importance?, tags?, metadata?}
-    Returns: {memory: {id, content, agent_id, ...}}
+    Body: {content, agent_id, session_id?, importance?, tags?}
+    Returns: {memory: {id, content, agent_id, ...}, embedding_time_ms}
 
-POST /v1/memory/search
+POST /v1/memory/recall
     Body: {agent_id, query, top_k?, session_id?}
-    Returns: {memories: [{memory: {id, content, ...}, score}]}
+    Returns: {memories: [{memory: {id, content, ...}, score}], ...}
+    Recall is importance-weighted and decay-aware — stale memories
+    surface below fresh, relevant ones.
 
 POST /v1/memory/forget
-    Body: {agent_id, memory_ids?}
-    Returns: {success: true}
+    Body: {agent_id, memory_ids, ...}  (at least one selector required)
+    Returns: {deleted_count}
+    The server rejects an unfiltered forget, so it can never wipe an
+    agent's whole memory by accident.
 """
-
-from __future__ import annotations
 
 import asyncio
 import os
@@ -60,7 +65,9 @@ from composio_openai_agents import OpenAIAgentsProvider
 # Configuration (read from environment at call time)
 # ---------------------------------------------------------------------------
 
-_DAKERA_BASE_URL = os.environ.get("DAKERA_BASE_URL", "http://localhost:3300").rstrip("/")
+_DAKERA_BASE_URL = os.environ.get("DAKERA_BASE_URL", "http://localhost:3000").rstrip(
+    "/"
+)
 _DAKERA_API_KEY = os.environ.get("DAKERA_API_KEY", "")
 _AGENT_ID = "composio-demo-agent"
 
@@ -79,10 +86,14 @@ def _dakera_headers() -> dict[str, str]:
 
 def _dakera_post(path: str, payload: dict[str, t.Any]) -> dict[str, t.Any]:
     """Call a Dakera REST endpoint and return the parsed JSON response."""
-    with httpx.Client(base_url=_DAKERA_BASE_URL, headers=_dakera_headers(), timeout=30.0) as c:
+    with httpx.Client(
+        base_url=_DAKERA_BASE_URL, headers=_dakera_headers(), timeout=30.0
+    ) as c:
         resp = c.post(path, json=payload)
         if resp.is_error:
-            raise RuntimeError(f"Dakera {path} returned HTTP {resp.status_code}: {resp.text}")
+            raise RuntimeError(
+                f"Dakera {path} returned HTTP {resp.status_code}: {resp.text}"
+            )
         return resp.json()
 
 
@@ -116,8 +127,8 @@ class StoreMemoryInput(BaseModel):
     )
 
 
-class SearchMemoryInput(BaseModel):
-    query: str = Field(description="Natural-language query to search past memories.")
+class RecallMemoryInput(BaseModel):
+    query: str = Field(description="Natural-language query to recall past memories.")
     top_k: int = Field(
         default=5,
         ge=1,
@@ -127,11 +138,11 @@ class SearchMemoryInput(BaseModel):
 
 
 class ForgetMemoryInput(BaseModel):
-    memory_ids: t.Optional[t.List[str]] = Field(
-        default=None,
+    memory_ids: t.List[str] = Field(
         description=(
-            "Specific memory IDs to delete. "
-            "Omit to wipe ALL memories for this agent."
+            "IDs of specific memories to delete (as returned by recall_memory). "
+            "At least one ID is required — the Dakera server rejects an "
+            "unfiltered forget to guard against accidental bulk deletion."
         ),
     )
 
@@ -172,18 +183,18 @@ def store_memory(input: StoreMemoryInput, ctx: t.Any) -> dict[str, t.Any]:
 
 
 @composio.experimental.tool(
-    slug="SEARCH_MEMORY",
-    name="Search Memory",
+    slug="RECALL_MEMORY",
+    name="Recall Memory",
     description=(
-        "Retrieve relevant memories from long-term storage using semantic search. "
-        "Call this at the start of a conversation to recall what you know about "
-        "the user or the current topic."
+        "Retrieve relevant memories from long-term storage using semantic, "
+        "importance-weighted recall. Call this at the start of a conversation "
+        "to recall what you know about the user or the current topic."
     ),
 )
-def search_memory(input: SearchMemoryInput, ctx: t.Any) -> dict[str, t.Any]:
-    """Retrieve the most semantically relevant memories for a query."""
+def recall_memory(input: RecallMemoryInput, ctx: t.Any) -> dict[str, t.Any]:
+    """Recall the most relevant memories for a query (decay-weighted)."""
     data = _dakera_post(
-        "/v1/memory/search",
+        "/v1/memory/recall",
         {
             "agent_id": _AGENT_ID,
             "query": input.query,
@@ -205,19 +216,24 @@ def search_memory(input: SearchMemoryInput, ctx: t.Any) -> dict[str, t.Any]:
     slug="FORGET_MEMORY",
     name="Forget Memory",
     description=(
-        "Delete specific memories or wipe all memories for this agent. "
+        "Delete specific memories by ID (as returned by recall_memory). "
         "Use when a memory is outdated, incorrect, or should be removed at "
         "the user's request."
     ),
 )
 def forget_memory(input: ForgetMemoryInput, ctx: t.Any) -> dict[str, t.Any]:
-    """Delete one or more memories from Dakera."""
-    payload: dict[str, t.Any] = {"agent_id": _AGENT_ID}
-    if input.memory_ids is not None:
-        payload["memory_ids"] = input.memory_ids
+    """Delete one or more memories from Dakera by ID."""
+    ids = [mid for mid in input.memory_ids if mid]
+    if not ids:
+        # Never send an empty/absent selector: the server would reject it, and
+        # deleting nothing is the safe no-op — we must never risk a bulk wipe.
+        return {"deleted_count": 0, "memory_ids": []}
 
-    _dakera_post("/v1/memory/forget", payload)
-    return {"success": True, "deleted": input.memory_ids or "all"}
+    data = _dakera_post(
+        "/v1/memory/forget",
+        {"agent_id": _AGENT_ID, "memory_ids": ids},
+    )
+    return {"deleted_count": data.get("deleted_count", 0), "memory_ids": ids}
 
 
 # ---------------------------------------------------------------------------
@@ -226,17 +242,34 @@ def forget_memory(input: ForgetMemoryInput, ctx: t.Any) -> dict[str, t.Any]:
 
 SYSTEM_PROMPT = """You are a helpful assistant with access to persistent memory.
 
-At the start of each conversation, search your memory for relevant context.
+At the start of each conversation, recall relevant context from memory.
 When you learn something important about the user, store it for future recall.
-When the user asks you to forget something, call forget_memory.
+When the user asks you to forget something, recall it first to get its ID,
+then call forget_memory with that ID.
 
 Use the memory tools proactively — the user should not have to repeat themselves."""
 
-agent = Agent(
-    name="Dakera Memory Agent",
-    instructions=SYSTEM_PROMPT,
-    tools=[store_memory, search_memory, forget_memory],
-)
+
+def _build_agent() -> Agent:
+    """Register the custom tools on a Composio session and build the agent.
+
+    Custom tools are registered inline via ``experimental.custom_tools``;
+    ``session.tools()`` returns the ``FunctionTool`` instances the OpenAI
+    Agents SDK expects (passing the raw decorated tools to ``Agent`` would
+    not be invokable).
+    """
+    session = composio.create(
+        user_id="default",
+        experimental={
+            "custom_tools": [store_memory, recall_memory, forget_memory],
+        },
+    )
+    return Agent(
+        name="Dakera Memory Agent",
+        instructions=SYSTEM_PROMPT,
+        tools=session.tools(),
+    )
+
 
 # ---------------------------------------------------------------------------
 # Main
@@ -246,6 +279,7 @@ agent = Agent(
 async def main() -> None:
     print("Dakera Memory Agent — type 'quit' to exit.\n")
 
+    agent = _build_agent()
     session_id = "demo-session"
 
     while True:

--- a/python/examples/dakera_memory_agent.py
+++ b/python/examples/dakera_memory_agent.py
@@ -58,7 +58,7 @@ import httpx
 from agents import Agent, Runner
 from pydantic import BaseModel, Field
 
-from composio import Composio
+from composio import SESSION_PRESET_DIRECT_TOOLS, Composio
 from composio_openai_agents import OpenAIAgentsProvider
 
 # ---------------------------------------------------------------------------
@@ -253,13 +253,17 @@ Use the memory tools proactively — the user should not have to repeat themselv
 def _build_agent() -> Agent:
     """Register the custom tools on a Composio session and build the agent.
 
-    Custom tools are registered inline via ``experimental.custom_tools``;
-    ``session.tools()`` returns the ``FunctionTool`` instances the OpenAI
-    Agents SDK expects (passing the raw decorated tools to ``Agent`` would
-    not be invokable).
+    Custom tools are registered inline via ``experimental.custom_tools``.
+    The ``direct_tools`` session preset exposes them straight from
+    ``session.tools()`` as OpenAI Agents ``FunctionTool`` instances (and
+    disables the router's search/multi-execute meta-tools), so the agent
+    sees exactly STORE_MEMORY / RECALL_MEMORY / FORGET_MEMORY. Without the
+    preset, inline custom tools are search-only and would not be directly
+    invokable as the system prompt expects.
     """
     session = composio.create(
         user_id="default",
+        session_preset=SESSION_PRESET_DIRECT_TOOLS,
         experimental={
             "custom_tools": [store_memory, recall_memory, forget_memory],
         },


### PR DESCRIPTION
## Summary

Adds `python/examples/dakera_memory_agent.py` — a self-contained example showing how to give Composio agents persistent, cross-session memory backed by [Dakera](https://dakera.ai).

Closes #3718

## What this PR adds

A single example file that registers three in-process `experimental` tools:

| Tool slug | Dakera endpoint | Purpose |
|---|---|---|
| `STORE_MEMORY` | `POST /v1/memory/store` | Persist a new memory record |
| `SEARCH_MEMORY` | `POST /v1/memory/search` | Semantic recall (top-K ranked) |
| `FORGET_MEMORY` | `POST /v1/memory/forget` | Delete specific or all memories |

## Quick start

```bash
# 1. Start Dakera locally
docker run -d -p 3300:3300 -e DAKERA_API_KEY=demo \
  ghcr.io/dakera-ai/dakera:latest

# 2. Run the example
COMPOSIO_API_KEY=... OPENAI_API_KEY=... DAKERA_API_KEY=demo \
  python examples/dakera_memory_agent.py
```

## How it works

All Dakera calls are in-process via `httpx` — no cloud memory dependency.
`DAKERA_API_KEY` and `DAKERA_BASE_URL` are read from environment at call time.

The agent system prompt instructs the LLM to proactively search memory at
the start of each turn and store new learnings, so users don't repeat themselves across sessions.

## Checklist

- [x] No new dependencies (`httpx` already present; `pydantic` is a Composio dep)
- [x] Reads credentials from environment — no hardcoded secrets
- [x] Same pattern as `custom_tools_agent_test.py` (OpenAI Agents SDK provider)
- [x] Documented inline with a quick-start section and REST API reference
