### PR TITLE
fix(cli-release): derive skill channel from release tag, not prerelease flag

### DIFF
--- a/.github/workflows/build-cli-binaries.yml
+++ b/.github/workflows/build-cli-binaries.yml
@@ -224,10 +224,15 @@ jobs:
       - name: Package skill files
         working-directory: ts/packages/cli
         env:
-          PRERELEASE: ${{ needs.prepare.outputs.prerelease }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
         run: |
           pnpm run validate:skills
-          if [[ "$PRERELEASE" == "true" ]]; then
+          # Derive the skill channel from the FINAL release tag — the single source of truth for
+          # release identity — not the secondary `prerelease` flag, which can drift from the tag
+          # (e.g. when a beta is promoted to stable). `beta` iff the tag carries a `-beta.` suffix,
+          # else `stable`. This makes it structurally impossible for a stable release (including a
+          # promoted-from-beta one) to ship the beta-gated skill content (e.g. `composio listen`).
+          if [[ "$RELEASE_TAG" == *-beta.* ]]; then
             channel=beta
           else
             channel=stable


### PR DESCRIPTION
## Problem
The stable `@composio/cli@0.2.31` release shipped a `composio-skill.zip` whose `SKILL.md` was stamped `<!-- release-channel: beta -->` and included the **beta-gated `composio listen` section**. Every stable consumer of the skill — the CLI's own `--install-skill` path and downstream plugins that vendor the release asset — is therefore taught commands the stable CLI doesn't enable by default.

## Root cause
The `Package skill files` step in `build-cli-binaries.yml` derived the skill `channel` from `needs.prepare.outputs.prerelease`. That flag can drift from the actual release identity — notably the **promote-stable** path (promoting an existing beta tag to a stable release). `channel` isn't cosmetic: `skills-src/composio-cli/reference-schema.ts` + `src/experimental-features.ts` gate `LISTEN`/`LOCAL_TOOLS` content on `channel === 'beta'`.

## Fix
Derive the skill channel from the **final `release_tag`** (the single source of truth for release identity — also used as the published release `version`) instead of the secondary `prerelease` flag: `beta` iff the tag contains `-beta.`, else `stable`. This makes it structurally impossible for a stable release (including promoted-from-beta) to ship beta-gated skill content.

## Verification
- Tag logic: `@composio/cli@0.2.31` → `stable`; `@composio/cli@0.2.31-beta.42` → `beta`.
- `needs.prepare.outputs.release_tag` is an existing job output, so the channel now tracks the authoritative published tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
