### PR TITLE
fix(core): run all parallel OpenAI tool calls from the first choice

### DIFF
--- a/.changeset/openai-parallel-tool-calls.md
+++ b/.changeset/openai-parallel-tool-calls.md
@@ -3,3 +3,7 @@
 ---
 
 Execute every parallel tool call in `OpenAIProvider.handleToolCalls`. It previously only ran the first tool call in each assistant message, so parallel tool calls (on by default) dropped the rest and left their `tool_call_id`s unanswered, failing the next request.
+
+The calls are run sequentially, in the order the model returned them — here "parallel" means the model issued several calls in one turn, not that they execute concurrently — so each `tool_call_id` is answered exactly once and the tool messages come back in a deterministic order.
+
+Only the first choice is handled. Tool results are fed back into a single assistant turn, so with `n > 1` iterating over every choice would run each tool call once per choice and orphan the `tool_call_id`s from the alternative completions.

--- a/.changeset/openai-parallel-tool-calls.md
+++ b/.changeset/openai-parallel-tool-calls.md
@@ -1,0 +1,5 @@
+---
+'@composio/core': patch
+---
+
+Execute every parallel tool call in `OpenAIProvider.handleToolCalls`. It previously only ran the first tool call in each assistant message, so parallel tool calls (on by default) dropped the rest and left their `tool_call_id`s unanswered, failing the next request.

--- a/python/composio/core/provider/_openai.py
+++ b/python/composio/core/provider/_openai.py
@@ -82,10 +82,14 @@ class OpenAIProvider(
         :return: A list of output objects from the function calls.
         """
         outputs = []
-        for choice in response.choices:
-            if choice.message.tool_calls is None:
-                continue
-
+        # Only the first choice is actionable: its tool results feed back into a
+        # single assistant turn. With n > 1, iterating every choice would run each
+        # tool call once per choice and orphan the tool_call_ids belonging to the
+        # alternative completions.
+        choice = response.choices[0] if response.choices else None
+        # A single assistant message can carry several tool calls (parallel tool
+        # calls, on by default); each one needs its own tool result.
+        if choice is not None and choice.message.tool_calls is not None:
             for tool_call in choice.message.tool_calls:
                 outputs.append(
                     self.execute_tool_call(

--- a/python/tests/test_provider.py
+++ b/python/tests/test_provider.py
@@ -500,6 +500,74 @@ class TestNonAgenticProviderHelperMethods:
         assert results[0]["successful"] is True
         assert results[0]["data"]["starred"] is True
 
+    def test_openai_provider_handle_tool_calls_only_first_choice(self):
+        """Only the first choice runs; n > 1 alternatives would orphan tool_call_ids."""
+        from openai.types.chat import ChatCompletion
+        from openai.types.chat.chat_completion import Choice
+        from openai.types.chat.chat_completion_message import ChatCompletionMessage
+        from openai.types.chat.chat_completion_message_tool_call import (
+            ChatCompletionMessageToolCall,
+            Function,
+        )
+
+        mock_client = mock_http_client()
+        from composio.core.provider._openai import OpenAIProvider
+
+        provider = OpenAIProvider()
+
+        Tools(
+            client=mock_client,
+            provider=provider,
+            toolkit_versions={"github": "12012025_00"},
+        )
+
+        github_tool = create_mock_tool("GITHUB_STAR_REPO", "github", "12012025_00")
+        mock_client.tools.retrieve.return_value = github_tool
+
+        mock_execute_response = Mock()
+        mock_execute_response.model_dump.return_value = {
+            "data": {"starred": True},
+            "error": None,
+            "successful": True,
+        }
+        mock_client.tools.execute.return_value = mock_execute_response
+
+        def make_choice(index: int, call_id: str) -> Choice:
+            return Choice(
+                finish_reason="tool_calls",
+                index=index,
+                message=ChatCompletionMessage(
+                    role="assistant",
+                    content=None,
+                    tool_calls=[
+                        ChatCompletionMessageToolCall(
+                            id=call_id,
+                            function=Function(
+                                name="GITHUB_STAR_REPO",
+                                arguments='{"repo": "composio/composio"}',
+                            ),
+                            type="function",
+                        )
+                    ],
+                ),
+            )
+
+        completion = ChatCompletion(
+            id="chatcmpl-123",
+            choices=[make_choice(0, "call_first"), make_choice(1, "call_second")],
+            created=1234567890,
+            model="gpt-4",
+            object="chat.completion",
+        )
+
+        results = provider.handle_tool_calls(
+            user_id="test-user",
+            response=completion,
+        )
+
+        assert len(results) == 1
+        assert mock_client.tools.execute.call_count == 1
+
     def test_openai_provider_wrap_tools(self):
         """Test that OpenAIProvider.wrap_tools creates proper tool definitions."""
         from composio.core.provider._openai import OpenAIProvider

--- a/ts/packages/core/src/provider/OpenAIProvider.ts
+++ b/ts/packages/core/src/provider/OpenAIProvider.ts
@@ -246,17 +246,18 @@ export class OpenAIProvider extends BaseNonAgenticProvider<
     modifiers?: ExecuteToolModifiers
   ): Promise<OpenAI.ChatCompletionToolMessageParam[]> {
     const outputs: OpenAI.ChatCompletionToolMessageParam[] = [];
-    for (const message of chatCompletion.choices) {
-      if (message.message.tool_calls && message.message.tool_calls[0].type === 'function') {
-        const toolResult = await this.executeToolCall(
-          userId,
-          message.message.tool_calls[0],
-          options,
-          modifiers
-        );
+    for (const choice of chatCompletion.choices) {
+      // A single assistant message can carry several tool calls (parallel tool
+      // calls, on by default). Each one needs its own tool result, otherwise the
+      // next request fails since some tool_call_ids go unanswered.
+      for (const toolCall of choice.message.tool_calls ?? []) {
+        if (toolCall.type !== 'function') {
+          continue;
+        }
+        const toolResult = await this.executeToolCall(userId, toolCall, options, modifiers);
         outputs.push({
           role: 'tool',
-          tool_call_id: message.message.tool_calls[0].id,
+          tool_call_id: toolCall.id,
           content: toolResult,
         });
       }

--- a/ts/packages/core/src/provider/OpenAIProvider.ts
+++ b/ts/packages/core/src/provider/OpenAIProvider.ts
@@ -246,21 +246,24 @@ export class OpenAIProvider extends BaseNonAgenticProvider<
     modifiers?: ExecuteToolModifiers
   ): Promise<OpenAI.ChatCompletionToolMessageParam[]> {
     const outputs: OpenAI.ChatCompletionToolMessageParam[] = [];
-    for (const choice of chatCompletion.choices) {
-      // A single assistant message can carry several tool calls (parallel tool
-      // calls, on by default). Each one needs its own tool result, otherwise the
-      // next request fails since some tool_call_ids go unanswered.
-      for (const toolCall of choice.message.tool_calls ?? []) {
-        if (toolCall.type !== 'function') {
-          continue;
-        }
-        const toolResult = await this.executeToolCall(userId, toolCall, options, modifiers);
-        outputs.push({
-          role: 'tool',
-          tool_call_id: toolCall.id,
-          content: toolResult,
-        });
+    // Only the first choice is actionable: its tool results feed back into a
+    // single assistant turn. With n > 1, iterating every choice would run each
+    // tool call once per choice and orphan the tool_call_ids belonging to the
+    // alternative completions.
+    const [choice] = chatCompletion.choices;
+    // A single assistant message can carry several tool calls (parallel tool
+    // calls, on by default). Each one needs its own tool result, otherwise the
+    // next request fails since some tool_call_ids go unanswered.
+    for (const toolCall of choice?.message.tool_calls ?? []) {
+      if (toolCall.type !== 'function') {
+        continue;
       }
+      const toolResult = await this.executeToolCall(userId, toolCall, options, modifiers);
+      outputs.push({
+        role: 'tool',
+        tool_call_id: toolCall.id,
+        content: toolResult,
+      });
     }
     return outputs;
   }

--- a/ts/packages/core/test/provider/openai-provider.test.ts
+++ b/ts/packages/core/test/provider/openai-provider.test.ts
@@ -278,6 +278,57 @@ describe('OpenAIProvider', () => {
         { role: 'tool', tool_call_id: 'call-456', content: JSON.stringify({ result: 'success' }) },
       ]);
     });
+
+    it('should only handle tool calls from the first choice when n > 1', async () => {
+      const userId = 'test-user';
+      const makeChoice = (index: number, callId: string) => ({
+        message: {
+          role: 'assistant',
+          content: null,
+          tool_calls: [
+            {
+              id: callId,
+              type: 'function',
+              function: {
+                name: 'test-tool',
+                arguments: JSON.stringify({ input: 'value' }),
+              },
+            } as const,
+          ],
+          refusal: null,
+        },
+        index,
+        finish_reason: 'tool_calls',
+      });
+      const chatCompletion = {
+        id: 'chat-123',
+        model: 'gpt-4',
+        created: 123456789,
+        object: 'chat.completion',
+        // n > 1: alternative completions the caller never continues. Only the
+        // first choice's tool calls should run; the rest would orphan their ids.
+        choices: [makeChoice(0, 'call-first'), makeChoice(1, 'call-second')],
+        usage: {
+          prompt_tokens: 10,
+          completion_tokens: 20,
+          total_tokens: 30,
+        },
+      } as OpenAI.ChatCompletion;
+
+      const executeToolCallSpy = vi.spyOn(provider, 'executeToolCall');
+      executeToolCallSpy.mockResolvedValue(JSON.stringify({ result: 'success' }));
+
+      const results = await provider.handleToolCalls(userId, chatCompletion);
+
+      expect(executeToolCallSpy).toHaveBeenCalledTimes(1);
+      expect(results).toEqual([
+        {
+          role: 'tool',
+          tool_call_id: 'call-first',
+          content: JSON.stringify({ result: 'success' }),
+        },
+      ]);
+    });
   });
 
   describe('handleAssistantMessage', () => {

--- a/ts/packages/core/test/provider/openai-provider.test.ts
+++ b/ts/packages/core/test/provider/openai-provider.test.ts
@@ -222,9 +222,8 @@ describe('OpenAIProvider', () => {
       ]);
     });
 
-    it('should handle multiple tool calls', async () => {
+    it('should handle multiple parallel tool calls in a single message', async () => {
       const userId = 'test-user';
-      // Create a mock with correct TypeScript type but using casting to avoid property errors
       const chatCompletion = {
         id: 'chat-123',
         model: 'gpt-4',
@@ -241,7 +240,15 @@ describe('OpenAIProvider', () => {
                   type: 'function',
                   function: {
                     name: 'test-tool',
-                    arguments: JSON.stringify({ input: 'test-value' }),
+                    arguments: JSON.stringify({ input: 'first' }),
+                  },
+                } as const,
+                {
+                  id: 'call-456',
+                  type: 'function',
+                  function: {
+                    name: 'other-tool',
+                    arguments: JSON.stringify({ input: 'second' }),
                   },
                 } as const,
               ],
@@ -263,9 +270,12 @@ describe('OpenAIProvider', () => {
 
       const results = await provider.handleToolCalls(userId, chatCompletion);
 
-      expect(executeToolCallSpy).toHaveBeenCalledTimes(1);
+      // Every parallel tool call must be executed and answered, one tool message
+      // per tool_call_id — otherwise the follow-up request errors on the unanswered ids.
+      expect(executeToolCallSpy).toHaveBeenCalledTimes(2);
       expect(results).toEqual([
         { role: 'tool', tool_call_id: 'call-123', content: JSON.stringify({ result: 'success' }) },
+        { role: 'tool', tool_call_id: 'call-456', content: JSON.stringify({ result: 'success' }) },
       ]);
     });
   });

--- a/ts/packages/providers/openai/test/openai.test.ts
+++ b/ts/packages/providers/openai/test/openai.test.ts
@@ -291,7 +291,7 @@ describe('OpenAIProvider', () => {
       ]);
     });
 
-    it('should handle multiple tool calls', async () => {
+    it('should handle multiple parallel tool calls in a single message', async () => {
       const userId = 'test-user';
       const chatCompletion = {
         id: 'chat-123',
@@ -303,6 +303,8 @@ describe('OpenAIProvider', () => {
             message: {
               role: 'assistant',
               content: null,
+              // Parallel tool calls arrive as several entries in one message's
+              // tool_calls array (on by default), not as separate choices.
               tool_calls: [
                 {
                   id: 'call-123',
@@ -312,16 +314,6 @@ describe('OpenAIProvider', () => {
                     arguments: JSON.stringify({ input: 'test-value-1' }),
                   },
                 } as const,
-              ],
-            },
-            index: 0,
-            finish_reason: 'tool_calls' as const,
-          },
-          {
-            message: {
-              role: 'assistant',
-              content: null,
-              tool_calls: [
                 {
                   id: 'call-456',
                   type: 'function',
@@ -332,7 +324,7 @@ describe('OpenAIProvider', () => {
                 } as const,
               ],
             },
-            index: 1,
+            index: 0,
             finish_reason: 'tool_calls' as const,
           },
         ],
@@ -361,7 +353,7 @@ describe('OpenAIProvider', () => {
       expect(executeToolCallSpy).toHaveBeenNthCalledWith(
         2,
         userId,
-        chatCompletion.choices[1].message.tool_calls![0],
+        chatCompletion.choices[0].message.tool_calls![1],
         undefined,
         undefined
       );
@@ -375,6 +367,56 @@ describe('OpenAIProvider', () => {
           role: 'tool',
           tool_call_id: 'call-456',
           content: JSON.stringify({ result: 'success-2' }),
+        },
+      ]);
+    });
+
+    it('should only handle tool calls from the first choice when n > 1', async () => {
+      const userId = 'test-user';
+      const makeChoice = (index: number, callId: string) => ({
+        message: {
+          role: 'assistant',
+          content: null,
+          tool_calls: [
+            {
+              id: callId,
+              type: 'function',
+              function: {
+                name: 'test-tool',
+                arguments: JSON.stringify({ input: 'value' }),
+              },
+            } as const,
+          ],
+        },
+        index,
+        finish_reason: 'tool_calls' as const,
+      });
+      const chatCompletion = {
+        id: 'chat-123',
+        model: 'gpt-4',
+        created: 123456789,
+        object: 'chat.completion',
+        // n > 1: alternative completions the caller never continues. Only the
+        // first choice's tool calls should run; the rest would orphan their ids.
+        choices: [makeChoice(0, 'call-first'), makeChoice(1, 'call-second')],
+        usage: {
+          prompt_tokens: 10,
+          completion_tokens: 20,
+          total_tokens: 30,
+        },
+      } as OpenAI.ChatCompletion;
+
+      const executeToolCallSpy = vi.spyOn(provider, 'executeToolCall');
+      executeToolCallSpy.mockResolvedValue(JSON.stringify({ result: 'success' }));
+
+      const results = await provider.handleToolCalls(userId, chatCompletion);
+
+      expect(executeToolCallSpy).toHaveBeenCalledTimes(1);
+      expect(results).toEqual([
+        {
+          role: 'tool',
+          tool_call_id: 'call-first',
+          content: JSON.stringify({ result: 'success' }),
         },
       ]);
     });


### PR DESCRIPTION
This PR:

- supersedes https://github.com/ComposioHQ/composio/pull/3712, preserving the original commits by @serhiizghama (kept as author/co-author)
- fixes `OpenAIProvider.handleToolCalls` to execute **every** tool call in an assistant message — it previously only read `tool_calls[0]`, so parallel tool calls (on by default) were dropped and their `tool_call_id`s went unanswered, failing the next request with the "must be followed by tool messages responding to each `tool_call_id`" error
- limits execution to the **first choice** — with `n > 1` the previous loop ran each tool call once per choice and orphaned the `tool_call_id`s belonging to the alternative completions
- aligns the Python SDK (`OpenAIProvider.handle_tool_calls`) with the same first-choice behavior so both SDKs stay in parity
- fixes the stale `@composio/openai` test that modeled "multiple tool calls" as separate `n` choices rather than one message's `tool_calls` array
- clarifies in the changeset that the calls run **sequentially**, in the order the model returned them (here "parallel" means the model issued several calls in one turn, not concurrent execution), so each `tool_call_id` is answered exactly once and deterministically
- adds regression tests (TS + Python): both calls run for parallel tool calls in one message, and only the first choice runs when `n > 1`

Full `@composio/core` (996) and `@composio/openai` suites green; Python `handle_tool_calls` tests, Ruff, and mypy clean; `tsc` clean.