### PR TITLE
fix(py): apply skip_default to agentic provider signatures (langchain, langgraph, autogen)

### DIFF
--- a/python/noxfile.py
+++ b/python/noxfile.py
@@ -78,7 +78,6 @@ def tst(session: Session):
     """Run the Python unit test suite."""
     session.install(".", "--group", "dev")
     session.install("./providers/langchain")
-    session.install("./providers/langgraph")
     test_paths = session.posargs or ["tests/"]
     session.run("pytest", *test_paths, "-v", "--tb=short")
 

--- a/python/noxfile.py
+++ b/python/noxfile.py
@@ -78,6 +78,7 @@ def tst(session: Session):
     """Run the Python unit test suite."""
     session.install(".", "--group", "dev")
     session.install("./providers/langchain")
+    session.install("./providers/langgraph")
     test_paths = session.posargs or ["tests/"]
     session.run("pytest", *test_paths, "-v", "--tb=short")
 

--- a/python/providers/autogen/composio_autogen/provider.py
+++ b/python/providers/autogen/composio_autogen/provider.py
@@ -95,6 +95,7 @@ class AutogenProvider(
         # Set signature and annotations
         params = get_signature_format_from_schema_params(
             schema_params=schema_params,
+            skip_default=self.skip_default,
         )
         function.__doc__ = tool.description
         setattr(function, "__signature__", Signature(parameters=params))

--- a/python/providers/langchain/composio_langchain/provider.py
+++ b/python/providers/langchain/composio_langchain/provider.py
@@ -63,7 +63,8 @@ class LangchainProvider(
         )
         action_func.__signature__ = Signature(  # type: ignore
             parameters=get_signature_format_from_schema_params(
-                schema_params=schema_params
+                schema_params=schema_params,
+                skip_default=self.skip_default,
             )
         )
         action_func.__doc__ = tool.description

--- a/python/providers/langgraph/composio_langgraph/provider.py
+++ b/python/providers/langgraph/composio_langgraph/provider.py
@@ -59,7 +59,8 @@ class LanggraphProvider(
         )
         action_func.__signature__ = Signature(  # type: ignore
             parameters=get_signature_format_from_schema_params(
-                schema_params=schema_params
+                schema_params=schema_params,
+                skip_default=self.skip_default,
             )
         )
         action_func.__doc__ = description

--- a/python/tests/test_provider.py
+++ b/python/tests/test_provider.py
@@ -1110,13 +1110,26 @@ class TestProviderIntegration:
 
 
 class TestAgenticSkipDefaultsParity:
-    """Regression: __signature__ and args_schema must agree on defaults.
+    """Regression: agentic providers must honor skip_defaults in __signature__.
 
     The langchain and langgraph providers strip schema defaults from
-    args_schema when schema_config={"skip_defaults": True}. They must apply
-    the same skip_default to the function signature, otherwise the signature
-    keeps the default while args_schema requires the field. See the sibling
-    llamaindex provider, which already passes skip_default to both.
+    args_schema when schema_config={"skip_defaults": True}, but kept the
+    defaults in the function __signature__, so the signature and args_schema
+    disagreed about which optional params were required. They now pass the
+    same skip_default to both, matching the sibling llamaindex provider.
+
+    The langchain/langgraph packages live outside the uv workspace and are not
+    always installed (the unit-test CI job installs only langchain), so those
+    cases skip via importorskip when the provider is absent instead of erroring.
+
+    autogen shares the same __signature__ code path and was likewise dropping
+    skip_default; it only builds __signature__ (no args_schema), so it never had
+    the mismatch, but its signature still ignored skip_defaults. It cannot be
+    imported normally in CI (the provider needs both pyautogen and autogen-core,
+    and the declared pin resolves pyautogen 0.10, which ships no top-level
+    `autogen` module), so its case execs the provider source with the two
+    external symbols it imports stubbed -- exercising the real wrap_tool without
+    installing the autogen stack. See _load_autogen_provider.
     """
 
     def _make_tool_with_default(self):
@@ -1154,11 +1167,13 @@ class TestAgenticSkipDefaultsParity:
         )
 
     def _provider(self, name, schema_config=None):
-        if name == "langchain":
-            from composio_langchain import LangchainProvider as P
-        else:
-            from composio_langgraph import LanggraphProvider as P
-        return P(schema_config=schema_config) if schema_config else P()
+        module = pytest.importorskip(f"composio_{name}")
+        provider_cls = getattr(module, f"{name.capitalize()}Provider")
+        return (
+            provider_cls(schema_config=schema_config)
+            if schema_config
+            else provider_cls()
+        )
 
     @pytest.mark.parametrize("name", ["langchain", "langgraph"])
     def test_skip_defaults_signature_matches_args_schema(self, name):
@@ -1179,3 +1194,65 @@ class TestAgenticSkipDefaultsParity:
         limit = wrapped.func.__signature__.parameters["limit"]
         assert limit.default == 5
         assert not wrapped.args_schema.model_fields["limit"].is_required()
+
+    def _load_autogen_provider(self):
+        """Exec the autogen provider source with its external deps stubbed.
+
+        See the class docstring: autogen is not importable in CI. We stand in
+        for the two symbols the provider imports (autogen / autogen_core) so the
+        real AutogenProvider.wrap_tool runs without the autogen stack installed.
+        """
+        import sys
+        from importlib.util import module_from_spec, spec_from_file_location
+        from pathlib import Path
+        from types import ModuleType
+        from unittest.mock import patch
+
+        class FunctionTool:
+            def __init__(self, func, **kwargs):
+                self._func = func
+
+        def stub(name, **attrs):
+            module = ModuleType(name)
+            module.__dict__.update(attrs)
+            return module
+
+        stubs = {
+            "autogen": stub("autogen"),
+            "autogen.agentchat": stub("autogen.agentchat"),
+            "autogen.agentchat.conversable_agent": stub(
+                "autogen.agentchat.conversable_agent", ConversableAgent=object
+            ),
+            "autogen_core": stub("autogen_core"),
+            "autogen_core.tools": stub("autogen_core.tools", FunctionTool=FunctionTool),
+        }
+        source = (
+            Path(__file__).resolve().parents[1]
+            / "providers/autogen/composio_autogen/provider.py"
+        )
+        if not source.exists():
+            pytest.skip(f"autogen provider source not found at {source}")
+
+        with patch.dict(sys.modules, stubs):
+            spec = spec_from_file_location(
+                "composio_autogen_provider_under_test", source
+            )
+            module = module_from_spec(spec)
+            spec.loader.exec_module(module)
+        return module.AutogenProvider
+
+    def test_autogen_signature_honors_skip_defaults(self):
+        from inspect import Parameter
+
+        provider = self._load_autogen_provider()(schema_config={"skip_defaults": True})
+        wrapped = provider.wrap_tool(self._make_tool_with_default(), Mock())
+
+        limit = wrapped._func.__signature__.parameters["limit"]
+        assert limit.default is Parameter.empty
+
+    def test_autogen_signature_preserves_default(self):
+        provider = self._load_autogen_provider()()
+        wrapped = provider.wrap_tool(self._make_tool_with_default(), Mock())
+
+        limit = wrapped._func.__signature__.parameters["limit"]
+        assert limit.default == 5

--- a/python/tests/test_provider.py
+++ b/python/tests/test_provider.py
@@ -1107,3 +1107,75 @@ class TestProviderIntegration:
 
         assert result2["successful"] is True
         assert result2["data"]["starred"] is True
+
+
+class TestAgenticSkipDefaultsParity:
+    """Regression: __signature__ and args_schema must agree on defaults.
+
+    The langchain and langgraph providers strip schema defaults from
+    args_schema when schema_config={"skip_defaults": True}. They must apply
+    the same skip_default to the function signature, otherwise the signature
+    keeps the default while args_schema requires the field. See the sibling
+    llamaindex provider, which already passes skip_default to both.
+    """
+
+    def _make_tool_with_default(self):
+        return Tool(
+            name="Test Tool",
+            slug="TEST_TOOL",
+            description="A tool with a defaulted optional param",
+            input_parameters={
+                "type": "object",
+                "title": "TestToolRequest",
+                "properties": {
+                    "limit": {
+                        "type": "integer",
+                        "description": "Max results",
+                        "default": 5,
+                    },
+                },
+                "required": [],
+            },
+            output_parameters={},
+            available_versions=["12012025_00"],
+            version="12012025_00",
+            scopes=[],
+            toolkit=tool_list_response.ItemToolkit(name="Test", slug="test", logo=""),
+            deprecated=tool_list_response.ItemDeprecated(
+                available_versions=["12012025_00"],
+                displayName="Test Tool",
+                version="12012025_00",
+                toolkit=tool_list_response.ItemDeprecatedToolkit(logo=""),
+                is_deprecated=False,
+            ),
+            is_deprecated=False,
+            no_auth=False,
+            tags=[],
+        )
+
+    def _provider(self, name, schema_config=None):
+        if name == "langchain":
+            from composio_langchain import LangchainProvider as P
+        else:
+            from composio_langgraph import LanggraphProvider as P
+        return P(schema_config=schema_config) if schema_config else P()
+
+    @pytest.mark.parametrize("name", ["langchain", "langgraph"])
+    def test_skip_defaults_signature_matches_args_schema(self, name):
+        from inspect import Parameter
+
+        provider = self._provider(name, {"skip_defaults": True})
+        wrapped = provider.wrap_tool(self._make_tool_with_default(), Mock())
+
+        limit = wrapped.func.__signature__.parameters["limit"]
+        assert limit.default is Parameter.empty
+        assert wrapped.args_schema.model_fields["limit"].is_required()
+
+    @pytest.mark.parametrize("name", ["langchain", "langgraph"])
+    def test_default_preserved_without_skip_defaults(self, name):
+        provider = self._provider(name)
+        wrapped = provider.wrap_tool(self._make_tool_with_default(), Mock())
+
+        limit = wrapped.func.__signature__.parameters["limit"]
+        assert limit.default == 5
+        assert not wrapped.args_schema.model_fields["limit"].is_required()


### PR DESCRIPTION
## Summary

Agentic providers honor `schema_config={"skip_defaults": True}` for `args_schema` (defaults stripped, fields become required) but were **not** applying the same `skip_default` to the function `__signature__`. The result: the wrapped tool's `__signature__` and `args_schema` disagreed about defaulted optional params — the signature said `limit=5`, the schema said `limit` is required. The sibling `llamaindex` provider already passed `skip_default` to both; the others were the outliers.

This supersedes #3713. It keeps @anxkhn's original `langchain` / `langgraph` fix (cherry-picked, authorship preserved) and adds two review follow-ups.

## Changes

- **langchain / langgraph** (original commit by @anxkhn): pass `skip_default=self.skip_default` to `get_signature_format_from_schema_params`, which was already passed to `json_schema_to_model` for `args_schema`.
- **autogen**: same one-line alignment in `composio_autogen/provider.py`. Circumstances worth clarifying: `autogen` builds **only** `__signature__` (no `args_schema`), so it could never exhibit the signature/schema *mismatch* the other two had — but it was still silently ignoring `skip_defaults` on its signature. Aligned for consistency.
- **tests**: `TestAgenticSkipDefaultsParity` now guards langchain/langgraph with `pytest.importorskip` so absent providers **skip** instead of erroring; adds a dedicated **autogen regression test** (see below).
- **noxfile**: reverted the `./providers/langgraph` install added to the core `tst` session in #3713 (see below).

## Why the test/noxfile change (review finding)

The noxfile change in #3713 does **not** affect the actual unit-test CI job: `.github/workflows/py.test.yml` installs only `providers/langchain` and runs `python -m pytest tests/` directly — it never invokes `nox`. So the `langgraph` parametrized case would hit `ModuleNotFoundError` and **error in CI**. Guarding with `pytest.importorskip` makes the core suite install-agnostic: langchain runs, langgraph skips gracefully where absent.

## Testing autogen (the interesting part)

autogen can't be imported in CI: the provider requires both `pyautogen` and `autogen-core`, and under the declared pin (`pyautogen>=0.2.19,<0.11`) uv resolves **pyautogen 0.10**, which ships **no top-level `autogen` module** — so `import autogen` fails regardless of install. Rather than ship an unverifiable/always-skipping test, the autogen case **execs the provider source with the two symbols it imports (`autogen`, `autogen_core.tools.FunctionTool`) stubbed**, so the *real* `AutogenProvider.wrap_tool` + `get_signature_format_from_schema_params` run with **zero install**. It runs green in the same langchain-only CI env as everything else.

## Type of change

- [x] Bug fix

## How Has This Been Tested?

- `pytest TestAgenticSkipDefaultsParity` in the base venv (CI-like, langchain-only) → **4 passed, langgraph skipped** (langchain + both autogen cases pass; langgraph skips, no error).
- `uv run --with ./providers/langgraph pytest -k langgraph` → **2 passed**.
- Regression proof (both providers): reverting only the provider line fails the skip-defaults case with `assert 5 is Parameter.empty`; restoring passes. Verified for langchain **and** autogen.
- `ruff check`, `ruff format --check`, and `mypy` (via the `chk` config) on the changed test file → clean.

## Checklist

- [x] I ran linters/tests locally and they passed
- [x] I added tests: langchain/langgraph parity + regression, and an autogen regression test that runs in CI without the (unimportable) autogen stack
- [ ] Changeset: **not applicable** — Python-only change. The clarification of the autogen circumstances lives in this description, the commit message, and the test docstring rather than a JS changeset.

## Credits

Original fix by @anxkhn (#3713), preserved as the first commit and co-authored on the follow-up.
