### PR TITLE
fix(py): migrate composio-autogen off abandoned pyautogen to ag2

### DIFF
--- a/python/providers/autogen/pyproject.toml
+++ b/python/providers/autogen/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "pyautogen>=0.2.19,<0.11",
+    "ag2>=0.14,<1.0",
     "flaml==2.6.0",
     "autogen_core>=0.7.5",
     "composio",

--- a/python/providers/autogen/setup.py
+++ b/python/providers/autogen/setup.py
@@ -22,7 +22,7 @@ setup(
     ],
     python_requires=">=3.10,<4",
     install_requires=[
-        "pyautogen>=0.2.19,<0.11",
+        "ag2>=0.14,<1.0",
         "flaml==2.6.0",
         "autogen_core>=0.7.5",
         "composio",


### PR DESCRIPTION
## Summary

`composio-autogen` fails to import on a fresh install: the provider depended on the abandoned `pyautogen` distribution, whose latest release (`0.10.0`) ships **no top-level `autogen` module**. The pin `pyautogen>=0.2.19,<0.11` resolves straight to it, so `import composio_autogen` raises `ModuleNotFoundError: No module named 'autogen'`.

The autogen 0.2 lineage moved to the **`ag2`** distribution (`0.14.x`), which provides the same `autogen` package the provider uses (`ConversableAgent`, `autogen.agentchat.register_function`) alongside `autogen-core`. This swaps the dependency.

Closes #3728.

## Changes

- `providers/autogen/pyproject.toml` and `providers/autogen/setup.py`: `pyautogen>=0.2.19,<0.11` → `ag2>=0.14,<1.0`. `flaml` and `autogen_core` unchanged.

**No provider code changes** — the imports and runtime API are identical across the two distributions.

## Type of change

- [x] Bug fix

## How Has This Been Tested?

Verified in isolation via `uv run --with ./providers/autogen` (a real fresh install of the provider with its new deps → resolves `ag2 0.14.0`):

1. **Import** — `import composio_autogen` now succeeds (previously `ModuleNotFoundError`).
2. **`wrap_tool`** — returns a real `autogen_core.tools.FunctionTool` with the expected signature.
3. **`register_tools` → `autogen.agentchat.register_function`** — the AG2 runtime path works end to end:
   - caller (LLM side): `caller.llm_config.tools` advertises the tool,
   - executor (execution side): the function lands in `executor._function_map`.

`flaml==2.6.0` + `autogen-core==0.7.5` resolve cleanly alongside `ag2 0.14` (no conflict).

## Notes / follow-up

This class of bug (a provider silently un-importable on fresh install) slipped through because **CI never installs or imports the autogen provider** — the unit-test job only installs `providers/langchain`. Worth a small follow-up: add a fresh-install import smoke test for the agentic providers so this can't recur silently. Left out here to keep this PR to the dependency fix and avoid adding ag2's install weight to the main test matrix.

## Checklist

- [x] I ran the migration verification locally (isolation) and it passed
- [ ] Changeset: not applicable — Python-only change.
