### PR TITLE
fix(py): apply skip_default to agentic provider signatures (langchain, langgraph, autogen)

### DIFF
--- a/.github/workflows/py.test.yml
+++ b/.github/workflows/py.test.yml
@@ -75,6 +75,7 @@ jobs:
           source .venv/bin/activate
           uv pip install -e .
           uv pip install -e providers/langchain
+          uv pip install -e providers/autogen
           uv pip install pytest pytest-mock
 
       - name: Run Import Tests
@@ -82,6 +83,10 @@ jobs:
           cd python/
           source .venv/bin/activate
           python -c "from composio import Composio; print('✓ Basic import successful')"
+          # Guards against the autogen provider becoming un-importable on a fresh
+          # install (e.g. a broken framework dependency). A hard import here fails
+          # loudly, unlike the importorskip-guarded unit tests, which would skip.
+          python -c "import composio_autogen; print('✓ Autogen provider import successful')"
 
       - name: Run Unit Tests
         run: |

--- a/python/noxfile.py
+++ b/python/noxfile.py
@@ -78,7 +78,7 @@ def tst(session: Session):
     """Run the Python unit test suite."""
     session.install(".", "--group", "dev")
     session.install("./providers/langchain")
-    session.install("./providers/langgraph")
+    session.install("./providers/autogen")
     test_paths = session.posargs or ["tests/"]
     session.run("pytest", *test_paths, "-v", "--tb=short")
 

--- a/python/noxfile.py
+++ b/python/noxfile.py
@@ -78,6 +78,7 @@ def tst(session: Session):
     """Run the Python unit test suite."""
     session.install(".", "--group", "dev")
     session.install("./providers/langchain")
+    session.install("./providers/langgraph")
     test_paths = session.posargs or ["tests/"]
     session.run("pytest", *test_paths, "-v", "--tb=short")
 

--- a/python/providers/autogen/composio_autogen/provider.py
+++ b/python/providers/autogen/composio_autogen/provider.py
@@ -95,6 +95,7 @@ class AutogenProvider(
         # Set signature and annotations
         params = get_signature_format_from_schema_params(
             schema_params=schema_params,
+            skip_default=self.skip_default,
         )
         function.__doc__ = tool.description
         setattr(function, "__signature__", Signature(parameters=params))

--- a/python/providers/langchain/composio_langchain/provider.py
+++ b/python/providers/langchain/composio_langchain/provider.py
@@ -63,7 +63,8 @@ class LangchainProvider(
         )
         action_func.__signature__ = Signature(  # type: ignore
             parameters=get_signature_format_from_schema_params(
-                schema_params=schema_params
+                schema_params=schema_params,
+                skip_default=self.skip_default,
             )
         )
         action_func.__doc__ = tool.description

--- a/python/providers/langgraph/composio_langgraph/provider.py
+++ b/python/providers/langgraph/composio_langgraph/provider.py
@@ -59,7 +59,8 @@ class LanggraphProvider(
         )
         action_func.__signature__ = Signature(  # type: ignore
             parameters=get_signature_format_from_schema_params(
-                schema_params=schema_params
+                schema_params=schema_params,
+                skip_default=self.skip_default,
             )
         )
         action_func.__doc__ = description

--- a/python/tests/test_provider.py
+++ b/python/tests/test_provider.py
@@ -1110,13 +1110,20 @@ class TestProviderIntegration:
 
 
 class TestAgenticSkipDefaultsParity:
-    """Regression: __signature__ and args_schema must agree on defaults.
+    """Regression: agentic providers must honor skip_defaults in __signature__.
 
     The langchain and langgraph providers strip schema defaults from
-    args_schema when schema_config={"skip_defaults": True}. They must apply
-    the same skip_default to the function signature, otherwise the signature
-    keeps the default while args_schema requires the field. See the sibling
-    llamaindex provider, which already passes skip_default to both.
+    args_schema when schema_config={"skip_defaults": True}, but kept the
+    defaults in the function __signature__, so the signature and args_schema
+    disagreed about which optional params were required. They now pass the
+    same skip_default to both, matching the sibling llamaindex provider.
+
+    autogen only builds __signature__ (no args_schema), so it never had the
+    mismatch, but its signature likewise ignored skip_defaults; it is aligned
+    too and checked on the signature alone.
+
+    Provider packages are optional (the unit-test job installs langchain and
+    autogen), so each case skips via importorskip when its provider is absent.
     """
 
     def _make_tool_with_default(self):
@@ -1154,11 +1161,13 @@ class TestAgenticSkipDefaultsParity:
         )
 
     def _provider(self, name, schema_config=None):
-        if name == "langchain":
-            from composio_langchain import LangchainProvider as P
-        else:
-            from composio_langgraph import LanggraphProvider as P
-        return P(schema_config=schema_config) if schema_config else P()
+        module = pytest.importorskip(f"composio_{name}")
+        provider_cls = getattr(module, f"{name.capitalize()}Provider")
+        return (
+            provider_cls(schema_config=schema_config)
+            if schema_config
+            else provider_cls()
+        )
 
     @pytest.mark.parametrize("name", ["langchain", "langgraph"])
     def test_skip_defaults_signature_matches_args_schema(self, name):
@@ -1179,3 +1188,20 @@ class TestAgenticSkipDefaultsParity:
         limit = wrapped.func.__signature__.parameters["limit"]
         assert limit.default == 5
         assert not wrapped.args_schema.model_fields["limit"].is_required()
+
+    def test_autogen_signature_honors_skip_defaults(self):
+        from inspect import Parameter
+
+        provider = self._provider("autogen", {"skip_defaults": True})
+        wrapped = provider.wrap_tool(self._make_tool_with_default(), Mock())
+
+        # autogen exposes the wrapped function as `_func` and has no args_schema.
+        limit = wrapped._func.__signature__.parameters["limit"]
+        assert limit.default is Parameter.empty
+
+    def test_autogen_signature_preserves_default(self):
+        provider = self._provider("autogen")
+        wrapped = provider.wrap_tool(self._make_tool_with_default(), Mock())
+
+        limit = wrapped._func.__signature__.parameters["limit"]
+        assert limit.default == 5

--- a/python/tests/test_provider.py
+++ b/python/tests/test_provider.py
@@ -1107,3 +1107,75 @@ class TestProviderIntegration:
 
         assert result2["successful"] is True
         assert result2["data"]["starred"] is True
+
+
+class TestAgenticSkipDefaultsParity:
+    """Regression: __signature__ and args_schema must agree on defaults.
+
+    The langchain and langgraph providers strip schema defaults from
+    args_schema when schema_config={"skip_defaults": True}. They must apply
+    the same skip_default to the function signature, otherwise the signature
+    keeps the default while args_schema requires the field. See the sibling
+    llamaindex provider, which already passes skip_default to both.
+    """
+
+    def _make_tool_with_default(self):
+        return Tool(
+            name="Test Tool",
+            slug="TEST_TOOL",
+            description="A tool with a defaulted optional param",
+            input_parameters={
+                "type": "object",
+                "title": "TestToolRequest",
+                "properties": {
+                    "limit": {
+                        "type": "integer",
+                        "description": "Max results",
+                        "default": 5,
+                    },
+                },
+                "required": [],
+            },
+            output_parameters={},
+            available_versions=["12012025_00"],
+            version="12012025_00",
+            scopes=[],
+            toolkit=tool_list_response.ItemToolkit(name="Test", slug="test", logo=""),
+            deprecated=tool_list_response.ItemDeprecated(
+                available_versions=["12012025_00"],
+                displayName="Test Tool",
+                version="12012025_00",
+                toolkit=tool_list_response.ItemDeprecatedToolkit(logo=""),
+                is_deprecated=False,
+            ),
+            is_deprecated=False,
+            no_auth=False,
+            tags=[],
+        )
+
+    def _provider(self, name, schema_config=None):
+        if name == "langchain":
+            from composio_langchain import LangchainProvider as P
+        else:
+            from composio_langgraph import LanggraphProvider as P
+        return P(schema_config=schema_config) if schema_config else P()
+
+    @pytest.mark.parametrize("name", ["langchain", "langgraph"])
+    def test_skip_defaults_signature_matches_args_schema(self, name):
+        from inspect import Parameter
+
+        provider = self._provider(name, {"skip_defaults": True})
+        wrapped = provider.wrap_tool(self._make_tool_with_default(), Mock())
+
+        limit = wrapped.func.__signature__.parameters["limit"]
+        assert limit.default is Parameter.empty
+        assert wrapped.args_schema.model_fields["limit"].is_required()
+
+    @pytest.mark.parametrize("name", ["langchain", "langgraph"])
+    def test_default_preserved_without_skip_defaults(self, name):
+        provider = self._provider(name)
+        wrapped = provider.wrap_tool(self._make_tool_with_default(), Mock())
+
+        limit = wrapped.func.__signature__.parameters["limit"]
+        assert limit.default == 5
+        assert not wrapped.args_schema.model_fields["limit"].is_required()


### PR DESCRIPTION
## Summary

Agentic providers honor `schema_config={"skip_defaults": True}` for `args_schema` (defaults stripped, fields become required) but were **not** applying the same `skip_default` to the function `__signature__`, so the wrapped tool's signature and `args_schema` disagreed about which defaulted params were optional. The sibling `llamaindex` provider already passed it to both.

**Supersedes #3727.** This is the polished version, now that the ag2 migration (#3729) landed and `composio-autogen` imports again — so the autogen case uses a real import instead of the earlier source-load stub, and the parity tests run in CI.

## Changes

- **langchain / langgraph** (original commit by @anxkhn): pass `skip_default=self.skip_default` to `get_signature_format_from_schema_params`.
- **autogen**: same one-line alignment. autogen builds **only** `__signature__` (no `args_schema`), so it never had the *mismatch* — but its signature still ignored `skip_defaults`. Aligned for consistency; verified on the signature alone.
- **tests**: `TestAgenticSkipDefaultsParity` guards each provider with `pytest.importorskip`; adds real-import autogen regression tests (no stub).
- **CI + nox**: install `providers/autogen` in the unit-test job (`py.test.yml`) and the nox `tst` session so the autogen parity tests actually run, plus a **hard `import composio_autogen` smoke check** in CI.

## Why the CI import guard (not just the tests)

The `importorskip`-guarded unit tests **skip** when a provider can't be imported — which is the correct behavior for optional providers, but means they'd *silently skip* if autogen broke on a fresh install (exactly the failure that #3729 just fixed). The extra `python -c "import composio_autogen"` in the import step is a **hard** check that fails loudly, so a future dependency breakage can't slip through as a green build.

`providers/langchain` + `providers/autogen` co-install cleanly (verified: 59 packages, ag2 0.14.0, no conflict). langgraph continues to skip in CI — its code path is identical to langchain's, which runs.

## Type of change

- [x] Bug fix

## How Has This Been Tested?

- Base venv (langchain only): langchain parity **passes**, langgraph + autogen **skip** (no error).
- CI-mirror (langchain + autogen, editable): **4 passed, 2 skipped (langgraph)** — autogen tests actually run and pass.
- Regression proof, each provider: reverting only the provider line fails the skip-defaults case with `assert 5 is Parameter.empty`; restoring passes. Verified for langchain **and** autogen.
- `ruff check`, `ruff format --check`, `mypy`, and full `tests/test_provider.py` (29 passed, 4 skipped) → clean. `py.test.yml` parses.

## Checklist

- [x] I ran linters/tests locally and they passed
- [x] I added tests: langchain/langgraph parity + regression, and autogen parity that runs in CI
- [ ] Changeset: not applicable — Python-only change.

## Credits

Original fix by @anxkhn (#3713 → #3727), preserved as the first commit and co-authored on the follow-up.
