### PR TITLE
fix(docs): paginate toolkits fetch so the full catalog reaches the site

### DIFF
--- a/.github/workflows/docs-update-data.yml
+++ b/.github/workflows/docs-update-data.yml
@@ -96,14 +96,14 @@ jobs:
         id: changes
         run: |
           cd ..
-          git add -N docs/public/data/ docs/public/openapi.json docs/public/openapi-v3.json docs/content/reference/api-reference/ docs/content/reference/v3/api-reference/ docs/content/reference/meta-tools/ 2>/dev/null || true
-          if git diff --quiet docs/public/data/ docs/public/openapi.json docs/public/openapi-v3.json docs/content/reference/api-reference/ docs/content/reference/v3/api-reference/ docs/content/reference/meta-tools/ 2>/dev/null; then
+          git add -N docs/public/data/ docs/public/openapi.json docs/public/openapi-v3.json docs/content/reference/api-reference/ docs/content/reference/v3/api-reference/ docs/content/toolkits/meta-tools/ 2>/dev/null || true
+          if git diff --quiet docs/public/data/ docs/public/openapi.json docs/public/openapi-v3.json docs/content/reference/api-reference/ docs/content/reference/v3/api-reference/ docs/content/toolkits/meta-tools/ 2>/dev/null; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
             echo "No changes detected"
           else
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
             echo "Changes detected:"
-            git diff --stat docs/public/data/ docs/public/openapi.json docs/public/openapi-v3.json docs/content/reference/api-reference/ docs/content/reference/v3/api-reference/ docs/content/reference/meta-tools/ 2>/dev/null || true
+            git diff --stat docs/public/data/ docs/public/openapi.json docs/public/openapi-v3.json docs/content/reference/api-reference/ docs/content/reference/v3/api-reference/ docs/content/toolkits/meta-tools/ 2>/dev/null || true
           fi
 
       - name: Create Pull Request
@@ -122,7 +122,7 @@ jobs:
             - **Toolkit catalog** (`docs/public/data/toolkits.json`, `toolkits-list.json`) — refreshed list of available toolkits, auth schemes, and tools from the backend API
             - **OpenAPI specs** (`docs/public/openapi.json`, `docs/public/openapi-v3.json`) — latest v3.1 and v3.0 API specifications fetched from staging
             - **API reference pages** (`docs/content/reference/api-reference/`, `docs/content/reference/v3/api-reference/`) — regenerated index pages for both API versions
-            - **Meta tools reference** (`docs/public/data/meta-tools.json`, `docs/content/reference/meta-tools/*.mdx`) — updated meta tool schemas and reference docs
+            - **Meta tools reference** (`docs/public/data/meta-tools.json`, `docs/content/toolkits/meta-tools/*.mdx`) — updated meta tool schemas and reference docs
           branch: docs/auto-update-data
           base: next
           add-paths: |
@@ -131,7 +131,7 @@ jobs:
             docs/public/openapi-v3.json
             docs/content/reference/api-reference/
             docs/content/reference/v3/api-reference/
-            docs/content/reference/meta-tools/
+            docs/content/toolkits/meta-tools/
 
       - name: Request review from trigger actor
         if: steps.create-pr.outputs.pull-request-number

--- a/docs/scripts/README.md
+++ b/docs/scripts/README.md
@@ -9,8 +9,9 @@ responses, honors the `Retry-After` header when present, otherwise falls back to
 exponential backoff with jitter, and caps attempts so CI still fails fast when
 the backend is genuinely down.
 
-This matters because `generate-toolkits.ts` issues ~3000 requests per run
-(2 + 3 per toolkit), which exceeds the staging limit of 2000 requests/minute.
+This matters because `generate-toolkits.ts` issues ~6500 requests per run
+(a few catalog pages + 3 per toolkit across a ~2.1k catalog), which exceeds the
+staging limit of 2000 requests/minute.
 Before this helper, runs failed with `429`, and `generate-meta-tools.ts` — which
 runs immediately after — inherited the exhausted rate-limit window.
 

--- a/docs/scripts/fetch-with-retry.ts
+++ b/docs/scripts/fetch-with-retry.ts
@@ -13,8 +13,9 @@
  * Network-level errors thrown by `fetch` (DNS, connection reset, …) are retried
  * the same way and re-thrown once attempts are exhausted.
  *
- * Why this exists: `generate-toolkits.ts` issues ~3000 requests per run, which
- * exceeds the staging limit of 2000 requests/minute. Without backoff the run
+ * Why this exists: `generate-toolkits.ts` issues ~6500 requests per run (3 per
+ * toolkit across a ~2.1k catalog), which exceeds the staging limit of 2000
+ * requests/minute. Without backoff the run
  * fails with `429`, and `generate-meta-tools.ts` (which runs next) inherits the
  * exhausted window. See docs/scripts/README.md.
  *

--- a/docs/scripts/generate-toolkits.ts
+++ b/docs/scripts/generate-toolkits.ts
@@ -74,22 +74,57 @@ interface Toolkit {
   authConfigDetails?: AuthConfigDetail[];
 }
 
+// The backend silently caps `limit` at 1000 per page and defaults to usage
+// ordering, so a single request returns only the top-1000 toolkits — about half
+// the catalog. Request the cap and follow `next_cursor` until exhausted.
+// MAX_PAGES is a runaway guard well above the real catalog (~2.1k → 3 pages).
+const TOOLKITS_PAGE_LIMIT = 1000;
+const TOOLKITS_MAX_PAGES = 12;
+
 async function fetchToolkits(): Promise<any[]> {
   console.log('Fetching toolkits from API...');
 
-  const response = await fetchWithRetry(`${API_BASE}/toolkits`, {
-    headers: {
-      'Content-Type': 'application/json',
-      'x-api-key': API_KEY!,
-    },
-  });
+  const items: any[] = [];
+  // Pages can overlap when the catalog shifts between cursor fetches; keep the
+  // first occurrence so API-provided ordering stays stable.
+  const seen = new Set<string>();
+  let cursor: string | undefined;
 
-  if (!response.ok) {
-    throw new Error(`Failed to fetch toolkits: ${response.status} ${response.statusText}`);
+  for (let page = 0; page < TOOLKITS_MAX_PAGES; page++) {
+    const params = new URLSearchParams({ limit: String(TOOLKITS_PAGE_LIMIT) });
+    if (cursor) params.set('cursor', cursor);
+
+    const response = await fetchWithRetry(`${API_BASE}/toolkits?${params}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': API_KEY!,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch toolkits: ${response.status} ${response.statusText}`);
+    }
+
+    const data = await response.json();
+    const pageItems: any[] = data.items || data;
+    for (const item of pageItems) {
+      const slug = item?.slug?.toLowerCase();
+      if (slug) {
+        if (seen.has(slug)) continue;
+        seen.add(slug);
+      }
+      items.push(item);
+    }
+
+    cursor = data.next_cursor ?? undefined;
+    if (!cursor) return items;
   }
 
-  const data = await response.json();
-  return data.items || data;
+  // Failing beats silently publishing a truncated catalog — that is the exact
+  // bug this pagination loop exists to prevent.
+  throw new Error(
+    `Toolkit catalog exceeds ${TOOLKITS_MAX_PAGES} pages of ${TOOLKITS_PAGE_LIMIT}; raise TOOLKITS_MAX_PAGES`
+  );
 }
 
 async function fetchToolkitChangelog(): Promise<Map<string, string>> {


### PR DESCRIPTION
This PR:

- fixes the `docs.composio.dev/toolkits` search returning 0 results for toolkits like Workday that exist in the catalog
- paginates `fetchToolkits()` in `generate-toolkits.ts` by following `next_cursor`: `GET /api/v3/toolkits` silently caps `limit` at 1000 per page and defaults to usage ordering, so the previous single-request fetch shipped only the top-1000 toolkits — about half of the ~2.1k catalog
- dedupes across pages by slug (pages can overlap when the catalog shifts between cursor fetches) and throws instead of silently truncating if the catalog ever outgrows the page guard, mirroring the dashboard's `listToolkits` procedure
- fixes the `docs-update-data.yml` workflow, broken since the sessions-first docs rewrite (https://github.com/ComposioHQ/composio/pull/3637) moved the generated meta-tools MDX to `docs/content/toolkits/meta-tools/`: `create-pull-request` aborted on the stale `docs/content/reference/meta-tools/` pathspec, so every scheduled data sync since then failed at the Create Pull Request step and docs data went stale
- updates the request-volume notes in `fetch-with-retry.ts` and `scripts/README.md` (~3000 → ~6500 requests per run); the existing 429 backoff already absorbs the larger run

## Context

The toolkits landing page filters a build-time snapshot (`public/data/toolkits-list.json`) client-side, so every toolkit missing from the snapshot is unsearchable and its detail page has no data. The snapshot regenerates via the scheduled `docs-update-data.yml` workflow; with both fixes in place the automated data PR picks up the full catalog and the "Browse N toolkits" count grows from 1000 to the real catalog size.

Verified offline by running the script against a stubbed paginated backend (1500 toolkits across 2 pages): all pages are fetched, ordering is preserved, no duplicates. `bun run types:check` and eslint pass. A manual `workflow_dispatch` of the fixed workflow on this branch produced the full-catalog data PR.