### PR TITLE
fix(py): handle list-valued JSON Schema type in tool signatures

### DIFF
--- a/python/composio/utils/shared.py
+++ b/python/composio/utils/shared.py
@@ -592,6 +592,20 @@ def get_signature_format_from_schema_params(
             else:
                 annotation = reduce(lambda a, b: t.Union[a, b], mapped_types)
             param_default = param_schema.get("default", "")
+        elif isinstance(param_type, list):
+            # JSON Schema Draft 2020-12 / OpenAPI 3.1 express a nullable field as a
+            # list of types, e.g. {"type": ["string", "null"]}. A list is unhashable,
+            # so the membership test below would raise TypeError. Map each member to a
+            # Python type (falling back to t.Any for unrecognized types) and build a
+            # Union, mirroring the anyOf/oneOf handling above.
+            mapped_types = [
+                PYDANTIC_TYPE_TO_PYTHON_TYPE.get(ptype, t.Any) for ptype in param_type
+            ]
+            if len(mapped_types) == 1:
+                annotation = mapped_types[0]
+            else:
+                annotation = reduce(lambda a, b: t.Union[a, b], mapped_types)
+            param_default = param_schema.get("default", "")
         elif param_type in PYDANTIC_TYPE_TO_PYTHON_TYPE:
             annotation = PYDANTIC_TYPE_TO_PYTHON_TYPE[param_type]
             param_default = param_schema.get("default", FALLBACK_VALUES[param_type])

--- a/python/tests/test_schema_parser.py
+++ b/python/tests/test_schema_parser.py
@@ -1602,6 +1602,49 @@ class TestGetSignatureFormatFromSchemaParams:
         assert str in args
         assert type(None) in args
 
+    @pytest.mark.unit
+    @pytest.mark.schema
+    def test_type_list_nullable_resolves(self):
+        """A list-valued 'type' (e.g. ["string", "null"]) resolves without raising.
+
+        JSON Schema Draft 2020-12 / OpenAPI 3.1 express nullable fields as a list
+        of types rather than an anyOf. A list is unhashable, so the older membership
+        test raised ``TypeError: unhashable type: 'list'`` for these schemas.
+        """
+        schema = {
+            "properties": {"branch": {"type": ["string", "null"]}},
+        }
+
+        annotation = self._annotation(schema)
+        assert t.get_origin(annotation) is t.Union
+        args = t.get_args(annotation)
+        assert str in args
+        assert type(None) in args
+
+    @pytest.mark.unit
+    @pytest.mark.schema
+    def test_type_list_single_member(self):
+        """A single-member list-valued 'type' resolves to that type directly."""
+        schema = {"properties": {"value": {"type": ["integer"]}}}
+        assert self._annotation(schema) is int
+
+    @pytest.mark.unit
+    @pytest.mark.schema
+    def test_type_list_multiple_non_null(self):
+        """A list-valued 'type' with multiple non-null members builds a Union."""
+        schema = {"properties": {"value": {"type": ["string", "integer"]}}}
+        assert self._annotation(schema) == t.Union[str, int]
+
+    @pytest.mark.unit
+    @pytest.mark.schema
+    def test_type_list_unrecognized_member_falls_back_to_any(self):
+        """An unrecognized type inside a list maps to Any instead of raising."""
+        schema = {"properties": {"value": {"type": ["file", "null"]}}}
+        annotation = self._annotation(schema)
+        args = t.get_args(annotation)
+        assert t.Any in args
+        assert type(None) in args
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION

## Summary

`get_signature_format_from_schema_params` in `python/composio/utils/shared.py` builds the
`__signature__` used to wrap tools for the agentic providers (langchain, langgraph,
autogen, llamaindex). For each property it reads `param_type = param_schema.get("type")`
and then runs the dict-membership test `elif param_type in PYDANTIC_TYPE_TO_PYTHON_TYPE:`.

JSON Schema Draft 2020-12 and OpenAPI 3.1 (the dialect Composio toolkits are derived from)
express a nullable field as a list of types, e.g. `{"type": ["string", "null"]}`, rather
than an `anyOf`. A list is unhashable, so that membership test raises
`TypeError: unhashable type: 'list'` at wrap time, which breaks the entire tool set for
those providers whenever any tool has such a parameter.

This is a follow-up to #3708 / #3710. Those made the `anyOf`/`oneOf` combiner branch
defensive, but the sibling top-level scalar `type` branch still assumed `type` is a
hashable string.

Reproduction (on `next`, before this change):

```python
from composio.utils.shared import get_signature_format_from_schema_params

get_signature_format_from_schema_params(
    {"type": "object", "properties": {"branch": {"type": ["string", "null"]}}, "required": []}
)
# TypeError: unhashable type: 'list'
```

Fixes #

## Changes

- `python/composio/utils/shared.py`: add an `elif isinstance(param_type, list):` branch
  before the crashing membership test. It maps each member via
  `PYDANTIC_TYPE_TO_PYTHON_TYPE.get(ptype, t.Any)` (falling back to `t.Any` for
  unrecognized member types), unwraps a single member, and otherwise `reduce`s the members
  into a `t.Union`, mirroring the existing `anyOf`/`oneOf` handling directly above it.
- `python/tests/test_schema_parser.py`: add four regression tests to
  `TestGetSignatureFormatFromSchemaParams` covering the nullable (`["string", "null"]`),
  single-member (`["integer"]`), multiple non-null (`["string", "integer"]`), and
  unrecognized-member (`["file", "null"]`) cases.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [ ] Documentation
- [ ] Breaking change

## How Has This Been Tested?

Python 3.11, from `python/`:

- Reproduced the crash on `next` before the change (see the Summary snippet), and
  confirmed it is resolved after: the same input now returns
  `branch: Union[str, Any, NoneType] = ''` with no error.
- `uv run pytest tests/test_schema_parser.py -q` -> 79 passed (includes the 4 new tests).
- `uv run pytest tests/test_openapi.py tests/test_files.py tests/test_json_schema.py tests/test_schema_parser.py -q`
  -> 253 passed.
- Lint: `ruff check --config config/ruff.toml` (+ `--select I` + `ruff format --check`)
  on both changed files -> clean.
- Types: `mypy --config-file config/mypy.ini composio/utils/shared.py tests/test_schema_parser.py`
  -> Success, no issues.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed
- [ ] I updated documentation as needed (no docs affected)
- [x] I added tests or explain why not applicable
- [ ] I added a changeset if this change affects published packages (Python-only change;
  changesets are only for published TypeScript packages)

## Additional context

The more robust `schema_converter` path (`json_schema_to_pydantic_type`) already handles
list-valued/nullable types; this change brings the older
`get_signature_format_from_schema_params` path (used by the langchain/langgraph/autogen/
llamaindex providers) in line with it and with the #3708 pattern. The sibling
`FALLBACK_VALUES[param_type]` `KeyError` on an unknown scalar `type` is a separate issue
and is intentionally left out of this PR to keep the diff surgical.
