### PR TITLE
Fix CLI file-upload path bypassing sensitive-file denylist (GHSA-hp3h-89pf-5q58)

### DIFF
--- a/ts/packages/cli/src/services/tool-file-uploads.ts
+++ b/ts/packages/cli/src/services/tool-file-uploads.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import type { Composio as RawComposioClient } from '@composio/client';
+import { assertSafeFileUploadPath } from '@composio/core';
 import { toolkitFromToolSlug } from 'src/utils/toolkit-from-tool-slug';
 
 type JsonSchema = Record<string, unknown>;
@@ -146,11 +147,14 @@ const readFileFromUrl = async (url: string) => {
   };
 };
 
-const readFileFromDisk = async (filePath: string) => ({
-  bytes: new Uint8Array(await fs.readFile(filePath)),
-  fileName: path.basename(filePath),
-  mimeType: 'application/octet-stream',
-});
+const readFileFromDisk = async (filePath: string) => {
+  assertSafeFileUploadPath(filePath);
+  return {
+    bytes: new Uint8Array(await fs.readFile(filePath)),
+    fileName: path.basename(filePath),
+    mimeType: 'application/octet-stream',
+  };
+};
 
 const readUploadSource = async (file: string | File) => {
   if (isFileLike(file)) {

--- a/ts/packages/core/src/index.ts
+++ b/ts/packages/core/src/index.ts
@@ -62,3 +62,10 @@ export { Experimental } from './models/Experimental';
 
 // Error handling exports
 export * from './errors';
+
+// File upload safety utilities
+export {
+  assertSafeFileUploadPath,
+  isBlockedSensitiveFileUploadPath,
+  BUILTIN_FILE_UPLOAD_PATH_DENY_SEGMENTS,
+} from './utils/sensitiveFileUploadPaths.node';


### PR DESCRIPTION
Fixes #3746.

## Problem

The CLI's `readFileFromDisk` helper (`ts/packages/cli/src/services/tool-file-uploads.ts:149`) called `fs.readFile(filePath)` with no path validation. When an agent or tool schema instructs the CLI to upload a local file, it reads and uploads whatever path is supplied — including `~/.ssh/id_rsa`, `~/.aws/credentials`, `.env` files, etc.

The TypeScript core SDK (`packages/core/src/utils/fileUtils.node.ts:282-286`) already guards against this with `assertSafeFileUploadPath`, which checks paths against `BUILTIN_FILE_UPLOAD_PATH_DENY_SEGMENTS` (`.ssh`, `.aws`, `.azure`, `.gnupg`, `.kube`, `.docker`, `.claude`, `.password-store`, `keychains`) and basename patterns (`/^\.env/`, `/^id_(rsa|ed25519|ecdsa|dsa)/`, etc.). The CLI code path had no equivalent guard.

## Fix

Two changes:

1. **`ts/packages/cli/src/services/tool-file-uploads.ts`** — call `assertSafeFileUploadPath(filePath)` inside `readFileFromDisk` before the `fs.readFile` call. This mirrors the guard already present in the core SDK.

2. **`ts/packages/core/src/index.ts`** — export `assertSafeFileUploadPath`, `isBlockedSensitiveFileUploadPath`, and `BUILTIN_FILE_UPLOAD_PATH_DENY_SEGMENTS` from the package's public API so CLI (and other downstream consumers) can import them without relying on internal sub-paths.