### PR TITLE
fix(cli): repair root Dockerfile for the v3 ts/ monorepo layout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,9 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Node.js, pnpm and bun
-RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && apt-get install -y nodejs \
-    && npm install -g pnpm@10.17.0 \
+    && npm install -g pnpm@11.8.0 \
     && curl -fsSL https://bun.sh/install | bash
 
 # Add bun to PATH
@@ -26,14 +26,14 @@ RUN pnpm install
 RUN pnpm build
 
 # Build the CLI binary
-WORKDIR /app/packages/cli
+WORKDIR /app/ts/packages/cli
 RUN pnpm build:binary
 
 # Stage 2: Create a minimal runtime image
 FROM debian:bookworm-slim
 
 # Copy the CLI binary from the builder stage
-COPY --from=builder /app/packages/cli/dist/composio /composio
+COPY --from=builder /app/ts/packages/cli/dist/composio /composio
 
 # Make the binary executable
 RUN chmod +x /composio


### PR DESCRIPTION


The root `Dockerfile` can no longer build the CLI. It was never updated for the
v3 `ts/` monorepo restructure or the later mise Node-24 / pnpm-11 toolchain bump,
so both its package path and its pinned versions are stale:

- After the restructure the CLI package lives at `ts/packages/cli` and there is no
  root `packages/` directory. But the builder stage does
  `WORKDIR /app/packages/cli` then `RUN pnpm build:binary`. That directory has no
  `package.json`, so the `build:binary` script is unavailable and the build fails
  there. The final `COPY --from=builder /app/packages/cli/dist/composio` points at
  a path that never exists; the real build output is `ts/packages/cli/dist/composio`
  (`ts/packages/cli/scripts/build-binary.ts` -> `--outfile ./dist/composio`, run
  from the CLI package dir).
- The image installs `pnpm@10.17.0` and Node 22 (`setup_22.x`), both drifted from
  the pinned single source of truth in `mise.toml` (`npm:pnpm = 11.8.0`,
  `node = 24.17.0`) and the `pnpm-workspace.yaml` catalog (`pnpm: ^11.8.0`).
  Per `AGENTS.md`, pnpm is owned by mise, not Corepack.

This is a build-config fix; no runtime SDK behavior changes.

Fixes #

## Changes

- `WORKDIR /app/packages/cli` -> `WORKDIR /app/ts/packages/cli` (builder stage).
- `COPY --from=builder /app/packages/cli/dist/composio` ->
  `.../ts/packages/cli/dist/composio` (runtime stage).
- `pnpm@10.17.0` -> `pnpm@11.8.0`, matching `mise.toml`.
- NodeSource `setup_22.x` -> `setup_24.x`, matching `mise.toml` (`node = 24.17.0`).

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [ ] Documentation
- [ ] Breaking change

## How Has This Been Tested?

Static validation: every path and version the corrected `Dockerfile` references was
confirmed against the tree and against `mise.toml` (the single source of truth):

- `ts/packages/cli/package.json` exists (`name: @composio/cli`, `private: true`);
  root `packages/` does not.
- `ts/packages/cli/scripts/build-binary.ts` writes `--outfile ./dist/composio`
  (CWD-relative), i.e. `ts/packages/cli/dist/composio`, exactly the corrected
  `COPY` source.
- `mise.toml` pins `node = 24.17.0` and `npm:pnpm = 11.8.0`, matching the bumped
  `setup_24.x` and `pnpm@11.8.0`.

I did not have Docker available to run the image end-to-end. A reviewer with Docker
can confirm with:

```bash
docker build -t composio-cli . && docker run --rm composio-cli
```

which builds the CLI binary and prints its version (the image entrypoint is
`/composio --version`).

## Screenshots (if applicable)

N/A.

## Checklist
- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed (lint-staged reports no matching
      task for a Dockerfile-only change; no unit suite covers the Dockerfile)
- [ ] I updated documentation as needed (no docs reference the root Dockerfile)
- [ ] I added tests or explain why not applicable (a Dockerfile build is not unit-
      testable here; validation is the `docker build` command above)
- [x] I added a changeset if this change affects published packages (not needed:
      `@composio/cli` is `private: true`, and this is build config, not a published
      package change)

## Additional context

The root `Dockerfile` appears orphaned: no CI workflow, README, docs page, or
script references it or the old `packages/cli/dist/composio` path. The CLI release
path is `.github/workflows/build-cli-binaries.yml` (cross-platform binaries), and
the only Dockerfiles wired into CI/docs are the e2e ones under
`ts/e2e-tests/_utils/`. This PR repairs the root Dockerfile so `docker build .`
works again, but if it is intentionally unused, removing it (or converting it to
the mise-based pattern in `ts/e2e-tests/_utils/`) is also reasonable. Happy to do
either, whichever you prefer.

Note: `.dockerignore` still has pre-v3 `/packages/*` patterns. It does not break
the corrected build (the CLI output is generated inside the builder stage), so I
left it untouched to keep this diff surgical. Glad to fold a cleanup in if wanted.
