### PR TITLE
fix(cli): point CLI install URL at the next branch

### DIFF
--- a/.github/workflows/build-cli-binaries.yml
+++ b/.github/workflows/build-cli-binaries.yml
@@ -298,12 +298,12 @@ jobs:
 
           ### Linux and macOS
           ```bash
-          curl -fsSL https://raw.githubusercontent.com/ComposioHQ/composio/main/install.sh | bash
+          curl -fsSL https://raw.githubusercontent.com/ComposioHQ/composio/next/install.sh | bash
           ```
 
           ### Install specific version
           ```bash
-          curl -fsSL https://raw.githubusercontent.com/ComposioHQ/composio/main/install.sh | bash -s -- RELEASE_TAG_PLACEHOLDER
+          curl -fsSL https://raw.githubusercontent.com/ComposioHQ/composio/next/install.sh | bash -s -- RELEASE_TAG_PLACEHOLDER
           ```
 
           ## Manual Installation

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,12 +6,12 @@ This guide provides multiple ways to install the Composio CLI on your system.
 
 ### One-line Install
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ComposioHQ/composio/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/ComposioHQ/composio/next/install.sh | bash
 ```
 
 ### Install specific version
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ComposioHQ/composio/main/install.sh | bash -s -- v0.1.24
+curl -fsSL https://raw.githubusercontent.com/ComposioHQ/composio/next/install.sh | bash -s -- v0.1.24
 ```
 
 ### What the install script does:
@@ -149,13 +149,13 @@ If the download fails:
 1. **Check your internet connection**
 2. **Try again with verbose output:**
    ```bash
-   curl -v -fsSL https://raw.githubusercontent.com/ComposioHQ/composio/main/install.sh | bash
+   curl -v -fsSL https://raw.githubusercontent.com/ComposioHQ/composio/next/install.sh | bash
    ```
 
 3. **Manual download:**
    ```bash
    # Download the install script first
-   curl -O https://raw.githubusercontent.com/ComposioHQ/composio/main/install.sh
+   curl -O https://raw.githubusercontent.com/ComposioHQ/composio/next/install.sh
    
    # Review the script
    cat install.sh
@@ -189,7 +189,7 @@ The installer respects these environment variables:
 Example:
 ```bash
 export COMPOSIO_INSTALL="/usr/local"
-curl -fsSL https://raw.githubusercontent.com/ComposioHQ/composio/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/ComposioHQ/composio/next/install.sh | bash
 ```
 
 ## Development


### PR DESCRIPTION


The documented one-line CLI install command curls `install.sh` from the `main`
branch:

```bash
curl -fsSL https://raw.githubusercontent.com/ComposioHQ/composio/main/install.sh | bash
```

But the repository's default branch is `next` and there is no `main` branch.
`raw.githubusercontent.com` does not fall back to the default branch, so the
documented command returns HTTP 404 and the install fails for anyone who copies
it from `INSTALL.md`.

This replaces the `main` branch segment with `next` in the
`raw.githubusercontent.com/ComposioHQ/composio/<branch>/install.sh` URL at every
documented occurrence, so the install one-liner resolves. It matches the `next`
branch already used for the raw asset URL in `README.md`. `install.sh` itself
needs no change: it downloads binaries from release assets, not from a branch raw
URL.

Fixes #
<!-- No open issue; self-identified bug. Leave the Fixes line blank, or remove it. -->

### Changes

- `INSTALL.md`: update the 5 `.../composio/main/install.sh` URLs to
  `.../composio/next/install.sh` (One-line Install, Install specific version, and
  the Troubleshooting / manual-download / environment-variable examples).
- `.github/workflows/build-cli-binaries.yml`: same `main` -> `next` update at the
  2 URLs inside the `create-install-instructions` job's heredoc, which regenerates
  `INSTALL.md` as a GitHub Release artifact, so the released copy carries the
  working URL too and stays consistent with the checked-in file.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [x] Documentation
- [ ] Breaking change

<!-- It is a documentation URL fix that also updates the CI job which regenerates
that documentation. Marked Documentation; a reviewer may also consider it a Bug
fix. -->

### How Has This Been Tested?

No application code changed (static Markdown plus a CI heredoc), so no unit test
applies. Verified the branch/URL facts directly:

```
# Default branch is next; no main branch exists
git ls-remote --symref origin HEAD          # -> ref: refs/heads/next
git ls-remote --heads origin main next      # only refs/heads/next (+ changeset-release/next); no main

# The broken vs working URL, live
curl -s -o /dev/null -w "%{http_code}" https://raw.githubusercontent.com/ComposioHQ/composio/main/install.sh   # 404
curl -s -o /dev/null -w "%{http_code}" https://raw.githubusercontent.com/ComposioHQ/composio/next/install.sh   # 200

# After the change: 0 remaining main URLs, 7 next URLs
grep -rn "composio/main/install.sh"  INSTALL.md .github/workflows/build-cli-binaries.yml   # no matches
grep -rn "composio/next/install.sh"  INSTALL.md .github/workflows/build-cli-binaries.yml   # 7 matches

# The workflow YAML still parses cleanly after the heredoc edit
python -c "import yaml; yaml.safe_load(open('.github/workflows/build-cli-binaries.yml'))"
```

### Screenshots (if applicable)

N/A.

### Checklist

- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed <!-- YAML re-parses; grep + curl checks above -->
- [x] I updated documentation as needed <!-- this change is the documentation fix -->
- [ ] I added tests or explain why not applicable <!-- N/A: static docs URL + CI heredoc, no code path to test -->
- [ ] I added a changeset if this change affects published packages <!-- N/A: docs + CI only, no published package -->

### Additional context

The 14 `github.com/ComposioHQ/composio/tree/main/...` `homepage` fields in
`ts/**/package.json` also point at the non-existent `main` branch, but those are
published-package metadata (a different URL form that would require a changeset)
and are left out to keep this PR single-purpose. They are a reasonable follow-up.
