### PR TITLE
fix(py): resolve toolkit versions case-insensitively

### DIFF
--- a/python/composio/utils/toolkit_version.py
+++ b/python/composio/utils/toolkit_version.py
@@ -23,9 +23,12 @@ def get_toolkit_version(
     if isinstance(toolkit_versions, str):
         return toolkit_versions
 
-    # If toolkit_versions is a dict mapping, look up the specific toolkit version
+    # If toolkit_versions is a dict mapping, look up the specific toolkit version.
+    # Keys are normalized to lowercase when the mapping is built (see
+    # get_toolkit_versions), so lowercase the slug here to keep the lookup
+    # case-insensitive and avoid a silent fallback to 'latest'.
     if isinstance(toolkit_versions, dict) and len(toolkit_versions) > 0:
-        return toolkit_versions.get(toolkit_slug, "latest")
+        return toolkit_versions.get(toolkit_slug.lower(), "latest")
 
     # Else use 'latest'
     return "latest"

--- a/python/tests/test_toolkit_version.py
+++ b/python/tests/test_toolkit_version.py
@@ -124,6 +124,19 @@ class TestToolkitVersion:
         expected = {"github": "v1.0.0", "slack": "v2.0.0", "openai": "v3.0.0"}
         assert result == expected
 
+    def test_get_toolkit_version_lookup_is_case_insensitive(self):
+        """Test that the lookup slug is matched case-insensitively.
+
+        get_toolkit_versions normalizes keys to lowercase, so a pin configured
+        under a mixed/upper-case key must still resolve regardless of the case
+        of the slug used for retrieval, instead of silently returning 'latest'.
+        """
+        versions = get_toolkit_versions({"GitHub": "v1.0.0"})
+
+        assert get_toolkit_version("GITHUB", versions) == "v1.0.0"
+        assert get_toolkit_version("GitHub", versions) == "v1.0.0"
+        assert get_toolkit_version("github", versions) == "v1.0.0"
+
     def test_priority_order_matches_typescript(self):
         """Test that priority order matches TypeScript implementation.
 


### PR DESCRIPTION

`get_toolkit_versions` normalizes every configured key to lowercase when it
builds the version map: env vars via `toolkit_name.lower()` and user-supplied
dicts via `{key.lower(): value}`. But `get_toolkit_version` looked the value up
with the raw `toolkit_slug`, so a version pinned under a mixed or upper-case key
(for example `{"GitHub": "20250101_00"}` or `COMPOSIO_TOOLKIT_VERSION_GITHUB`),
or a non-lowercase slug coming from the caller, missed the map and silently fell
back to `"latest"`. `Tools.execute` then raises `ToolVersionRequiredError` for
`"latest"` (unless `dangerously_skip_version_check` is set), so the user's
explicit pin is discarded and the call errors instead of using the requested
version.

This lowercases the lookup key to match how the map is built, restoring the
write/read round-trip so the pin resolves regardless of the case used to
configure or request it. The write side is untouched.
