### PR TITLE
fix(core): stop misclassifying local paths starting with "http" as URLs

### DIFF
--- a/ts/packages/core/src/utils/fileUtils.node.ts
+++ b/ts/packages/core/src/utils/fileUtils.node.ts
@@ -39,6 +39,25 @@ export type GetFileDataAfterUploadingToS3Options = {
   signal?: AbortSignal;
 };
 
+/**
+ * Checks whether `value` is an absolute http(s) URL rather than a local path.
+ *
+ * A bare `startsWith('http')` check also matches local paths like
+ * `http_export/report.csv` or `httpdocs/.env`, which routes them into the URL
+ * fetch branch and skips the allowlist/denylist checks in
+ * {@link getFileDataAfterUploadingToS3}. `new URL()` requires a real scheme
+ * (`http:` or `https:`) followed by `//`, so relative-looking paths correctly
+ * fail to parse and are treated as local.
+ */
+export const isHttpUrl = (value: string): boolean => {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+};
+
 // Helper function to get file extension from MIME type
 const getExtensionFromMimeType = (mimeType: string): string => {
   const mimeToExt: Record<string, string> = {
@@ -248,7 +267,7 @@ const readFile = async (
       mimeType: file.type,
     };
   } else if (typeof file === 'string') {
-    if (file.startsWith('http')) {
+    if (isHttpUrl(file)) {
       return await readFileContentFromURL(file, signal);
     } else {
       return await readFileContent(file);
@@ -273,7 +292,7 @@ export const getFileDataAfterUploadingToS3 = async (
     throw new Error('Either path or blob must be provided');
   }
 
-  const isLocalPath = typeof file === 'string' && !file.startsWith('http');
+  const isLocalPath = typeof file === 'string' && !isHttpUrl(file);
 
   if (isLocalPath && fileUploadAllowlist !== undefined) {
     assertPathInsideUploadDirs(file as string, fileUploadAllowlist);

--- a/ts/packages/core/src/utils/modifiers/FileToolModifier.node.ts
+++ b/ts/packages/core/src/utils/modifiers/FileToolModifier.node.ts
@@ -18,6 +18,7 @@ import type { beforeFileUploadModifier } from '../../types/modifiers.types';
 import {
   downloadFileFromS3,
   getFileDataAfterUploadingToS3,
+  isHttpUrl,
   type GetFileDataAfterUploadingToS3Options,
 } from '../fileUtils.node';
 import {
@@ -150,7 +151,7 @@ const hydrateFiles = async (
     if (typeof value === 'string') {
       // Match the URL/local-path split used downstream in
       // getFileDataAfterUploadingToS3 so the hook sees the same categorisation.
-      const source = value.startsWith('http') ? 'url' : 'path';
+      const source = isHttpUrl(value) ? 'url' : 'path';
       const pathOrUrl = await runBeforeFileUpload(value, source);
       logger.debug(`Uploading file "${pathOrUrl}"`);
       return getFileDataAfterUploadingToS3(pathOrUrl, {

--- a/ts/packages/core/test/tools/fileModifiers.test.ts
+++ b/ts/packages/core/test/tools/fileModifiers.test.ts
@@ -16,6 +16,14 @@ import { mockClient } from '../utils/mocks/client.mock';
 vi.mock('../../src/utils/fileUtils.node', () => ({
   downloadFileFromS3: vi.fn(),
   getFileDataAfterUploadingToS3: vi.fn(),
+  isHttpUrl: (value: string): boolean => {
+    try {
+      const url = new URL(value);
+      return url.protocol === 'http:' || url.protocol === 'https:';
+    } catch {
+      return false;
+    }
+  },
 }));
 
 describe('FileToolModifier', () => {

--- a/ts/packages/core/test/utils/fileUtils.test.ts
+++ b/ts/packages/core/test/utils/fileUtils.test.ts
@@ -431,6 +431,21 @@ describe('fileUtils', () => {
       ).rejects.toThrow(ComposioSensitiveFilePathBlockedError);
     });
 
+    it('treats a local path that merely starts with "http" as a path, not a URL', async () => {
+      // Regression test: a naive `.startsWith('http')` check would misclassify
+      // this as a URL and skip the local-path denylist entirely.
+      await expect(
+        getFileDataAfterUploadingToS3(path.join('http_export', '.aws', 'creds'), {
+          toolSlug: 'test-tool',
+          toolkitSlug: 'test-toolkit',
+          client: mockClient,
+        })
+      ).rejects.toThrow(ComposioSensitiveFilePathBlockedError);
+
+      // It must not have been routed through the URL-fetch branch.
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
     it('should handle fetch errors for URLs', async () => {
       mockFetch.mockResolvedValue({
         ok: false,


### PR DESCRIPTION
This PR:
- fixes a `startsWith('http')` check in the TypeScript SDK that misclassified local paths such as `http_export/report.csv` or `http_backup/.ssh/id_rsa` as URLs
- the misclassification routed those paths through the URL-fetch branch, which skips both the upload allowlist (`assertPathInsideUploadDirs`) and the sensitive-path denylist (`assertSafeFileUploadPath`, added in #3763 for GHSA-hp3h-89pf-5q58)
- replaces the naive prefix check with `isHttpUrl()`, a `new URL()`-based check in `fileUtils.node.ts`, matching the Python SDK's existing `_is_url()` behavior (`urlparse` + scheme check), which was not affected by this bug
- updates the three call sites that used the naive check: `fileUtils.node.ts` (`readFile`, `getFileDataAfterUploadingToS3`) and `FileToolModifier.node.ts` (`beforeFileUpload` source classification)
- adds a regression test asserting a path like `http_export/.aws/creds` is still blocked by the sensitive-path denylist rather than routed to `fetch`