### PR TITLE
feat(docs): hide deprecated API reference operations

### DIFF
--- a/docs/content/reference/api-reference/files/index.mdx
+++ b/docs/content/reference/api-reference/files/index.mdx
@@ -24,4 +24,4 @@ These endpoints use your project API key in the `x-api-key` header.
 
 ## Endpoints
 
-<ApiEndpointsTable endpoints={[{"method":"GET","pathV31":"/api/v3.1/files/list","pathV3":"/api/v3/files/list","summary":"List files with optional app and action filters (DEPRECATED)","href":"/reference/api-reference/files/getFilesList"},{"method":"POST","pathV31":"/api/v3.1/files/upload/request","pathV3":"/api/v3/files/upload/request","summary":"Create presigned URL for request file upload to S3","href":"/reference/api-reference/files/postFilesUploadRequest"}]} />
+<ApiEndpointsTable endpoints={[{"method":"POST","pathV31":"/api/v3.1/files/upload/request","pathV3":"/api/v3/files/upload/request","summary":"Create presigned URL for request file upload to S3","href":"/reference/api-reference/files/postFilesUploadRequest"}]} />

--- a/docs/content/reference/v3/api-reference/files/index.mdx
+++ b/docs/content/reference/v3/api-reference/files/index.mdx
@@ -24,4 +24,4 @@ These endpoints use your project API key in the `x-api-key` header.
 
 ## Endpoints
 
-<ApiEndpointsTable endpoints={[{"method":"GET","pathV31":"/api/v3.1/files/list","pathV3":"/api/v3/files/list","summary":"List files with optional app and action filters (DEPRECATED)","href":"/reference/v3/api-reference/files/getFilesList"},{"method":"POST","pathV31":"/api/v3.1/files/upload/request","pathV3":"/api/v3/files/upload/request","summary":"Create presigned URL for request file upload to S3","href":"/reference/v3/api-reference/files/postFilesUploadRequest"}]} />
+<ApiEndpointsTable endpoints={[{"method":"POST","pathV31":"/api/v3.1/files/upload/request","pathV3":"/api/v3/files/upload/request","summary":"Create presigned URL for request file upload to S3","href":"/reference/v3/api-reference/files/postFilesUploadRequest"}]} />

--- a/docs/lib/deprecated-ops.mjs
+++ b/docs/lib/deprecated-ops.mjs
@@ -92,7 +92,11 @@ function tagsWithSurvivingOps(spec) {
 }
 
 /**
- * Reference URLs for every deprecated operation in a single spec.
+ * Reference URLs for every deprecated operation in a single spec. Because
+ * fumadocs-openapi is configured with `groupBy: 'tag'`, an operation renders one
+ * page per tag it carries, so a URL is derived for *each* of the op's tags
+ * (mirroring `scripts/generate-api-index.ts`, which drops the op from every
+ * tag's table) — not just `tags[0]`.
  * @param {OpenAPISpec} spec
  * @param {string} baseDir e.g. `api-reference` (v3.1) or `v3/api-reference` (v3.0)
  * @returns {string[]}
@@ -102,19 +106,21 @@ export function deprecatedUrlsFromSpec(spec, baseDir) {
   const urls = [];
   for (const operation of operations(spec)) {
     if (operation.deprecated !== true) continue;
-    const tag = operation.tags?.[0];
     const operationId = operation.operationId;
-    if (!tag || !operationId) continue;
-    urls.push(`/reference/${baseDir}/${slugify(tag)}/${operationId}`);
+    if (!operationId) continue;
+    for (const tag of operation.tags ?? []) {
+      urls.push(`/reference/${baseDir}/${slugify(tag)}/${operationId}`);
+    }
   }
   return urls;
 }
 
 /**
- * Redirect entries for every deprecated operation in a single spec. Each
- * deprecated op URL 308-redirects to its tag section index; if that tag has no
- * surviving non-deprecated op (its index page was removed), it falls back to
- * `/reference` (KTD-2).
+ * Redirect entries for every deprecated operation in a single spec. Because
+ * `groupBy: 'tag'` renders one page per tag, a redirect is emitted for each of
+ * the op's tags. Each deprecated op URL 308-redirects to that tag's section
+ * index; if the tag has no surviving non-deprecated op (its index page was
+ * removed), it falls back to `/reference`.
  * @param {OpenAPISpec} spec
  * @param {string} baseDir
  * @returns {RedirectEntry[]}
@@ -126,17 +132,18 @@ export function deprecatedRedirectsFromSpec(spec, baseDir) {
   const seen = new Set();
   for (const operation of operations(spec)) {
     if (operation.deprecated !== true) continue;
-    const tag = operation.tags?.[0];
     const operationId = operation.operationId;
-    if (!tag || !operationId) continue;
-    const tagSlug = slugify(tag);
-    const source = `/reference/${baseDir}/${tagSlug}/${operationId}`;
-    if (seen.has(source)) continue;
-    seen.add(source);
-    const destination = surviving.has(tagSlug)
-      ? `/reference/${baseDir}/${tagSlug}`
-      : '/reference';
-    redirects.push({ source, destination, permanent: true });
+    if (!operationId) continue;
+    for (const tag of operation.tags ?? []) {
+      const tagSlug = slugify(tag);
+      const source = `/reference/${baseDir}/${tagSlug}/${operationId}`;
+      if (seen.has(source)) continue;
+      seen.add(source);
+      const destination = surviving.has(tagSlug)
+        ? `/reference/${baseDir}/${tagSlug}`
+        : '/reference';
+      redirects.push({ source, destination, permanent: true });
+    }
   }
   return redirects;
 }

--- a/docs/lib/deprecated-ops.mjs
+++ b/docs/lib/deprecated-ops.mjs
@@ -1,0 +1,205 @@
+/**
+ * Shared derivation of deprecated API-reference URLs and their redirects.
+ *
+ * The committed OpenAPI specs (`public/openapi.json`, `public/openapi-v3.json`)
+ * retain operations flagged `deprecated: true`. This module is the single place
+ * that turns that flag into (a) the set of reference URLs to hide and (b) the
+ * redirects that keep old deep links from 404ing. It is plain ESM (`.mjs`) so
+ * both `next.config.mjs` (redirects) and the TypeScript app code (tree + page
+ * filters) import the *same* derivation, and the static tests import its pure
+ * functions directly without dragging in the Next config wrappers.
+ *
+ * `operation.deprecated === true` is the single source of truth — there is no
+ * allowlist/denylist of operationIds, so a future deprecation is hidden and
+ * redirected on the next spec refresh with no code change.
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * @typedef {Object} OpenAPIOperation
+ * @property {boolean} [deprecated]
+ * @property {string[]} [tags]
+ * @property {string} [operationId]
+ */
+
+/**
+ * @typedef {Object} OpenAPISpec
+ * @property {Record<string, Record<string, OpenAPIOperation>>} [paths]
+ */
+
+/**
+ * @typedef {Object} RedirectEntry
+ * @property {string} source
+ * @property {string} destination
+ * @property {true} permanent
+ */
+
+/**
+ * The two committed specs and the URL base each mounts under:
+ * v3.1 (default) at `api-reference`, v3.0 at `v3/api-reference`.
+ * @type {ReadonlyArray<{ file: string, baseDir: string }>}
+ */
+const SPEC_SOURCES = [
+  { file: 'public/openapi.json', baseDir: 'api-reference' },
+  { file: 'public/openapi-v3.json', baseDir: 'v3/api-reference' },
+];
+
+/**
+ * Slugify a tag name into a URL segment. Mirrors the `slugify` in
+ * `scripts/generate-api-index.ts` so derived hidden URLs line up exactly with
+ * the generated operation and index hrefs.
+ * @param {string} text
+ * @returns {string}
+ */
+export function slugify(text) {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+/**
+ * Iterate every operation in a spec's `paths`.
+ * @param {OpenAPISpec} spec
+ * @returns {Generator<OpenAPIOperation>}
+ */
+function* operations(spec) {
+  for (const methods of Object.values(spec?.paths ?? {})) {
+    for (const operation of Object.values(methods ?? {})) {
+      if (operation && typeof operation === 'object') yield operation;
+    }
+  }
+}
+
+/**
+ * Tag slugs that still have at least one non-deprecated operation. A tag's
+ * overview index page survives (and is a valid redirect target) only if some
+ * surviving operation lists it.
+ * @param {OpenAPISpec} spec
+ * @returns {Set<string>}
+ */
+function tagsWithSurvivingOps(spec) {
+  const surviving = new Set();
+  for (const operation of operations(spec)) {
+    if (operation.deprecated === true) continue;
+    for (const tag of operation.tags ?? []) {
+      surviving.add(slugify(tag));
+    }
+  }
+  return surviving;
+}
+
+/**
+ * Reference URLs for every deprecated operation in a single spec.
+ * @param {OpenAPISpec} spec
+ * @param {string} baseDir e.g. `api-reference` (v3.1) or `v3/api-reference` (v3.0)
+ * @returns {string[]}
+ */
+export function deprecatedUrlsFromSpec(spec, baseDir) {
+  /** @type {string[]} */
+  const urls = [];
+  for (const operation of operations(spec)) {
+    if (operation.deprecated !== true) continue;
+    const tag = operation.tags?.[0];
+    const operationId = operation.operationId;
+    if (!tag || !operationId) continue;
+    urls.push(`/reference/${baseDir}/${slugify(tag)}/${operationId}`);
+  }
+  return urls;
+}
+
+/**
+ * Redirect entries for every deprecated operation in a single spec. Each
+ * deprecated op URL 308-redirects to its tag section index; if that tag has no
+ * surviving non-deprecated op (its index page was removed), it falls back to
+ * `/reference` (KTD-2).
+ * @param {OpenAPISpec} spec
+ * @param {string} baseDir
+ * @returns {RedirectEntry[]}
+ */
+export function deprecatedRedirectsFromSpec(spec, baseDir) {
+  const surviving = tagsWithSurvivingOps(spec);
+  /** @type {RedirectEntry[]} */
+  const redirects = [];
+  const seen = new Set();
+  for (const operation of operations(spec)) {
+    if (operation.deprecated !== true) continue;
+    const tag = operation.tags?.[0];
+    const operationId = operation.operationId;
+    if (!tag || !operationId) continue;
+    const tagSlug = slugify(tag);
+    const source = `/reference/${baseDir}/${tagSlug}/${operationId}`;
+    if (seen.has(source)) continue;
+    seen.add(source);
+    const destination = surviving.has(tagSlug)
+      ? `/reference/${baseDir}/${tagSlug}`
+      : '/reference';
+    redirects.push({ source, destination, permanent: true });
+  }
+  return redirects;
+}
+
+/**
+ * Read a committed spec relative to the project root, or `null` if absent.
+ * @param {string} file
+ * @returns {OpenAPISpec | null}
+ */
+function readSpec(file) {
+  const path = join(process.cwd(), file);
+  if (!existsSync(path)) return null;
+  return JSON.parse(readFileSync(path, 'utf-8'));
+}
+
+/** @type {ReadonlySet<string> | null} */
+let _deprecatedUrls = null;
+
+/**
+ * Memoized combined set of deprecated reference URLs across both committed
+ * specs (v3.1 + v3.0). Mirrors the `_referenceSource` memo in `lib/source.ts`
+ * so the tree filter (`filter-api-version.ts`) and flat page-list filter
+ * (`source.ts`) stay in sync from one spec read.
+ * @returns {ReadonlySet<string>}
+ */
+export function getDeprecatedReferenceUrls() {
+  if (_deprecatedUrls === null) {
+    /** @type {Set<string>} */
+    const urls = new Set();
+    for (const { file, baseDir } of SPEC_SOURCES) {
+      const spec = readSpec(file);
+      if (!spec) continue;
+      for (const url of deprecatedUrlsFromSpec(spec, baseDir)) urls.add(url);
+    }
+    _deprecatedUrls = urls;
+  }
+  return _deprecatedUrls;
+}
+
+/** @type {ReadonlyArray<RedirectEntry> | null} */
+let _deprecatedRedirects = null;
+
+/**
+ * Memoized combined redirect entries across both committed specs, deduped by
+ * `source` (v3.1 and v3.0 URLs differ by the `/v3/` prefix, so no real
+ * collision — the dedupe is defensive). Spread into `next.config.mjs`.
+ * @returns {ReadonlyArray<RedirectEntry>}
+ */
+export function getDeprecatedReferenceRedirects() {
+  if (_deprecatedRedirects === null) {
+    /** @type {RedirectEntry[]} */
+    const all = [];
+    const seen = new Set();
+    for (const { file, baseDir } of SPEC_SOURCES) {
+      const spec = readSpec(file);
+      if (!spec) continue;
+      for (const redirect of deprecatedRedirectsFromSpec(spec, baseDir)) {
+        if (seen.has(redirect.source)) continue;
+        seen.add(redirect.source);
+        all.push(redirect);
+      }
+    }
+    _deprecatedRedirects = all;
+  }
+  return _deprecatedRedirects;
+}

--- a/docs/lib/filter-api-version.ts
+++ b/docs/lib/filter-api-version.ts
@@ -67,7 +67,10 @@ function isHiddenTagUrlOrDeprecated(url: string): boolean {
   return isHiddenTagUrl(url) || getDeprecatedReferenceUrls().has(url);
 }
 
-/** True if a node (page or folder) belongs entirely to a hidden tag. */
+/**
+ * True if a node (page or folder) is hidden — a page belonging to a hidden tag
+ * or a deprecated operation, or a folder whose index/every child is hidden.
+ */
 function isHiddenTagNode(node: PageTreeNode): boolean {
   if (node.type === 'page' && typeof node.url === 'string') {
     return isHiddenTagUrlOrDeprecated(node.url);
@@ -81,7 +84,10 @@ function isHiddenTagNode(node: PageTreeNode): boolean {
   return false;
 }
 
-/** Recursively drops folders/pages whose tag slug is in HIDDEN_API_TAGS. */
+/**
+ * Recursively drops hidden nodes: pages whose tag slug is in HIDDEN_API_TAGS,
+ * deprecated operation pages, and folders that contain only such pages.
+ */
 function filterHiddenTags(nodes: PageTreeNode[]): PageTreeNode[] {
   return nodes
     .filter((node) => !isHiddenTagNode(node))

--- a/docs/lib/filter-api-version.ts
+++ b/docs/lib/filter-api-version.ts
@@ -7,6 +7,8 @@
  * For v3.0: lift V3 folder contents to the top, hide v3.1-only nodes.
  */
 
+import { getDeprecatedReferenceUrls } from './deprecated-ops.mjs';
+
 interface PageTreeNode {
   type: 'page' | 'folder' | 'separator';
   name?: unknown;
@@ -25,12 +27,14 @@ interface PageTreeRoot {
  * API-reference tags that we intentionally hide on our side even though the
  * upstream OpenAPI spec (from hermes) still includes them. Matched by tag slug.
  *
- * Hiding happens in two places that must stay in sync:
- *  - `scripts/generate-api-index.ts` skips generating (and deletes) their
- *    `index.mdx` overview pages.
- *  - `filterHiddenTags` (below) drops their folders/pages from the reference
- *    page tree so the fumadocs-openapi operation pages disappear from the
- *    sidebar, llms.txt walk, and search.
+ * Hiding happens in two places that must stay in sync, and now covers both
+ * hidden tags *and* individually deprecated operations:
+ *  - `scripts/generate-api-index.ts` skips generating (and deletes) hidden
+ *    tags' `index.mdx` overview pages, and skips deprecated ops' table rows.
+ *  - `filterHiddenTags` (below) drops hidden tags' folders/pages *and*
+ *    deprecated operation pages from the reference page tree so the
+ *    fumadocs-openapi operation pages disappear from the sidebar, llms.txt
+ *    walk, and search.
  */
 export const HIDDEN_API_TAGS: ReadonlySet<string> = new Set([
   'consumer',
@@ -53,10 +57,20 @@ function isHiddenTagUrl(url: string): boolean {
   return false;
 }
 
+/**
+ * True if a URL should be hidden from the reference — either it belongs to a
+ * hidden tag or it is a `deprecated: true` operation URL (derived from the
+ * committed specs via `lib/deprecated-ops.mjs`). Kept in sync with the flat
+ * page-list filter `isHiddenReferenceUrl` in `lib/source.ts`.
+ */
+function isHiddenTagUrlOrDeprecated(url: string): boolean {
+  return isHiddenTagUrl(url) || getDeprecatedReferenceUrls().has(url);
+}
+
 /** True if a node (page or folder) belongs entirely to a hidden tag. */
 function isHiddenTagNode(node: PageTreeNode): boolean {
   if (node.type === 'page' && typeof node.url === 'string') {
-    return isHiddenTagUrl(node.url);
+    return isHiddenTagUrlOrDeprecated(node.url);
   }
   if (node.type === 'folder') {
     if (node.index && isHiddenTagNode(node.index)) return true;

--- a/docs/lib/source.ts
+++ b/docs/lib/source.ts
@@ -5,15 +5,22 @@ import { openapi, openapiV3 } from './openapi';
 import { openapiSource, openapiPlugin } from 'fumadocs-openapi/server';
 import { getGuardrails } from './llm-guardrails';
 import { HIDDEN_API_TAGS } from './filter-api-version';
+import { getDeprecatedReferenceUrls } from './deprecated-ops.mjs';
 
 /**
- * True if a reference URL belongs to an intentionally-hidden API tag
- * (consumer, invite-codes) in either v3.1 or v3.0. These tags exist in the
- * upstream OpenAPI spec but are hidden on our side. The page tree is filtered
- * via `prepareTree` (lib/filter-api-version.ts); this mirror keeps the flat
+ * True if a reference URL should be hidden from the flat page list — either it
+ * belongs to an intentionally-hidden API tag (consumer, invite-codes) or it is
+ * a `deprecated: true` operation URL (derived from the committed specs via
+ * `lib/deprecated-ops.mjs`), in either v3.1 or v3.0. Hidden tags exist in the
+ * upstream OpenAPI spec but are hidden on our side; deprecated ops are retained
+ * in the spec but hidden per-operation. The page tree is filtered via
+ * `prepareTree` (lib/filter-api-version.ts); this mirror keeps the flat
  * `getPages()` list (consumed by validate-links, llms.mdx, sitemap) in sync.
  */
 function isHiddenReferenceUrl(url: string): boolean {
+  if (getDeprecatedReferenceUrls().has(url)) {
+    return true;
+  }
   for (const tag of HIDDEN_API_TAGS) {
     if (
       url.startsWith(`/reference/api-reference/${tag}/`) ||
@@ -85,10 +92,11 @@ export async function getReferenceSource() {
       },
     });
 
-    // Exclude intentionally-hidden API tags (consumer, invite-codes) from the
-    // flat page list so validate-links, llms.mdx, llms.txt, and sitemap skip
-    // their fumadocs-openapi operation pages. The sidebar tree is filtered
-    // separately via prepareTree (lib/filter-api-version.ts).
+    // Exclude intentionally-hidden API tags (consumer, invite-codes) and
+    // deprecated operations from the flat page list so validate-links,
+    // llms.mdx, llms.txt, and sitemap skip their fumadocs-openapi operation
+    // pages. The sidebar tree is filtered separately via prepareTree
+    // (lib/filter-api-version.ts).
     const originalGetPages = loaded.getPages.bind(loaded);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (loaded as any).getPages = (...args: Parameters<typeof originalGetPages>) =>

--- a/docs/lib/source.ts
+++ b/docs/lib/source.ts
@@ -17,7 +17,7 @@ import { getDeprecatedReferenceUrls } from './deprecated-ops.mjs';
  * `prepareTree` (lib/filter-api-version.ts); this mirror keeps the flat
  * `getPages()` list (consumed by validate-links, llms.mdx, sitemap) in sync.
  */
-function isHiddenReferenceUrl(url: string): boolean {
+export function isHiddenReferenceUrl(url: string): boolean {
   if (getDeprecatedReferenceUrls().has(url)) {
     return true;
   }

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -2,6 +2,7 @@ import { dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { createMDX } from 'fumadocs-mdx/next';
 import { withEve } from 'eve/next';
+import { getDeprecatedReferenceRedirects } from './lib/deprecated-ops.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const withMDX = createMDX();
@@ -407,6 +408,11 @@ const config = {
         destination: '/docs/providers/custom-providers/python',
         permanent: true,
       },
+      // Deprecated OpenAPI operations are hidden from the reference; their old
+      // deep links 308-redirect to the operation's tag section index (derived
+      // from `operation.deprecated === true` in the committed specs, so future
+      // deprecations redirect with no code change). See lib/deprecated-ops.mjs.
+      ...getDeprecatedReferenceRedirects(),
       // API reference redirects
       {
         source: '/api-reference',

--- a/docs/scripts/generate-api-index.ts
+++ b/docs/scripts/generate-api-index.ts
@@ -31,6 +31,7 @@ interface OpenAPIOperation {
   tags?: string[];
   description?: string;
   operationId?: string;
+  deprecated?: boolean;
   'x-api-version'?: string;
 }
 
@@ -77,6 +78,11 @@ function getOperationsByTag(spec: OpenAPISpec): Record<string, OperationEntry[]>
 
   for (const [path, methods] of Object.entries(spec.paths)) {
     for (const [method, operation] of Object.entries(methods)) {
+      // Deprecated operations are hidden from the reference (mirrors the
+      // per-tag HIDDEN_TAGS skip below, but keyed off `operation.deprecated`).
+      // Dropping the op here removes its row from the endpoints table and,
+      // transitively, from activeTagSlugs when a tag is left with zero ops.
+      if (operation.deprecated === true) continue;
       if (operation.tags) {
         for (const tag of operation.tags) {
           if (!tagOps[tag]) tagOps[tag] = [];

--- a/docs/tests/integration/redirects.test.ts
+++ b/docs/tests/integration/redirects.test.ts
@@ -37,6 +37,10 @@ const REDIRECTS = [
   { from: "/docs/sandbox", to: "/docs/sandbox/remote" },
   { from: "/docs/custom-tools-and-toolkits", to: "/docs/extending-sessions/custom-tools-and-toolkits" },
   { from: "/docs/proxy-execute", to: "/docs/extending-sessions/proxy-execute" },
+  // Deprecated OpenAPI operations redirect to their tag section index
+  // (derived from operation.deprecated in the committed specs).
+  { from: "/reference/api-reference/files/getFilesList", to: "/reference/api-reference/files" },
+  { from: "/reference/v3/api-reference/files/getFilesList", to: "/reference/v3/api-reference/files" },
 ];
 
 describe("Redirects - key patterns", () => {

--- a/docs/tests/static/deprecated-ops.test.ts
+++ b/docs/tests/static/deprecated-ops.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Deprecated API-reference operation tests.
+ *
+ * `operation.deprecated === true` in the committed specs is the single source
+ * of truth for hiding operations from the reference and redirecting their old
+ * URLs. These assertions are spec-driven (they iterate whatever ops are
+ * deprecated today rather than hard-coding one operationId), plus a targeted
+ * regression for the current `getFilesList` case.
+ *
+ * Covers:
+ *  - U1 / R2: deprecated ops absent from the generated per-tag overview tables.
+ *  - U2 / R1: derived hidden-URL set + page-tree filtering.
+ *  - U3 / R3: derived tag-index redirects (308 permanent).
+ */
+import { describe, test, expect } from "bun:test";
+import { readdir, readFile } from "fs/promises";
+import { join } from "path";
+import {
+  slugify,
+  deprecatedUrlsFromSpec,
+  deprecatedRedirectsFromSpec,
+  getDeprecatedReferenceUrls,
+  getDeprecatedReferenceRedirects,
+} from "../../lib/deprecated-ops.mjs";
+import { prepareTree } from "../../lib/filter-api-version";
+
+const DOCS_ROOT = join(import.meta.dir, "../..");
+const REFERENCE_DIR = join(DOCS_ROOT, "content/reference");
+
+/** The two committed specs and the URL base each mounts under. */
+const SPECS = [
+  { file: "public/openapi.json", baseDir: "api-reference" },
+  { file: "public/openapi-v3.json", baseDir: "v3/api-reference" },
+];
+
+async function loadSpec(file: string): Promise<any> {
+  return JSON.parse(await readFile(join(DOCS_ROOT, file), "utf-8"));
+}
+
+/** Deprecated reference URLs across both committed specs. */
+async function allDeprecatedUrls(): Promise<string[]> {
+  const urls: string[] = [];
+  for (const { file, baseDir } of SPECS) {
+    urls.push(...deprecatedUrlsFromSpec(await loadSpec(file), baseDir));
+  }
+  return urls;
+}
+
+/** Recursively find every index.mdx under content/reference. */
+async function findIndexMdx(dir: string): Promise<string[]> {
+  const results: string[] = [];
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) results.push(...(await findIndexMdx(full)));
+    else if (entry.name === "index.mdx") results.push(full);
+  }
+  return results;
+}
+
+/** Collect every page URL reachable from a page-tree node. */
+function collectUrls(node: any): string[] {
+  const urls: string[] = [];
+  const visit = (n: any) => {
+    if (n?.url) urls.push(n.url);
+    if (n?.index) visit(n.index);
+    for (const child of n?.children ?? []) visit(child);
+  };
+  visit(node);
+  return urls;
+}
+
+describe("Deprecated ops — overview table (U1, R2/R4)", () => {
+  test("no deprecated op URL appears in any generated index.mdx", async () => {
+    const urls = await allDeprecatedUrls();
+    const indexFiles = await findIndexMdx(REFERENCE_DIR);
+    const contents = await Promise.all(indexFiles.map((f) => readFile(f, "utf-8")));
+    const offending = urls.filter((url) => contents.some((c) => c.includes(url)));
+    expect(offending).toEqual([]);
+  });
+
+  test("files index (v3.1 + v3.0) drops getFilesList and its (DEPRECATED) summary", async () => {
+    const files = [
+      "content/reference/api-reference/files/index.mdx",
+      "content/reference/v3/api-reference/files/index.mdx",
+    ];
+    const contents = await Promise.all(
+      files.map((f) => readFile(join(DOCS_ROOT, f), "utf-8")),
+    );
+    expect(contents.some((c) => c.includes("getFilesList"))).toBe(false);
+    expect(contents.some((c) => c.includes("(DEPRECATED)"))).toBe(false);
+    // The tag survives (it still has non-deprecated ops), so its index remains.
+    expect(contents.every((c) => c.includes("postFilesUploadRequest"))).toBe(true);
+  });
+});
+
+describe("Deprecated ops — hidden URLs + tree filter (U2, R1/R4/R5)", () => {
+  test("getDeprecatedReferenceUrls returns exactly the two getFilesList URLs", () => {
+    expect([...getDeprecatedReferenceUrls()].sort()).toEqual([
+      "/reference/api-reference/files/getFilesList",
+      "/reference/v3/api-reference/files/getFilesList",
+    ]);
+  });
+
+  test("deprecated set contains deprecated URLs and excludes a normal op URL", () => {
+    const set = getDeprecatedReferenceUrls();
+    expect(set.has("/reference/api-reference/files/getFilesList")).toBe(true);
+    expect(set.has("/reference/api-reference/files/postFilesUploadRequest")).toBe(false);
+  });
+
+  test("prepareTree drops the deprecated page, keeps its sibling (v3.1)", () => {
+    const tree = {
+      children: [
+        {
+          type: "folder",
+          name: "files",
+          children: [
+            { type: "page", name: "getFilesList", url: "/reference/api-reference/files/getFilesList" },
+            { type: "page", name: "upload", url: "/reference/api-reference/files/postFilesUploadRequest" },
+          ],
+        },
+      ],
+    };
+    const urls = collectUrls(prepareTree(tree as never, "3.1"));
+    expect(urls).toContain("/reference/api-reference/files/postFilesUploadRequest");
+    expect(urls).not.toContain("/reference/api-reference/files/getFilesList");
+  });
+
+  test("prepareTree drops the deprecated page, keeps its sibling (v3.0)", () => {
+    const tree = {
+      children: [
+        {
+          type: "folder",
+          name: "v3",
+          children: [
+            {
+              type: "folder",
+              name: "files",
+              children: [
+                { type: "page", name: "getFilesList", url: "/reference/v3/api-reference/files/getFilesList" },
+                { type: "page", name: "upload", url: "/reference/v3/api-reference/files/postFilesUploadRequest" },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const urls = collectUrls(prepareTree(tree as never, "3.0"));
+    expect(urls).toContain("/reference/v3/api-reference/files/postFilesUploadRequest");
+    expect(urls).not.toContain("/reference/v3/api-reference/files/getFilesList");
+  });
+
+  test("edge: a spec with no deprecated ops yields no hidden URLs", () => {
+    const spec = { paths: { "/x": { get: { operationId: "getX", tags: ["Files"] } } } };
+    expect(deprecatedUrlsFromSpec(spec, "api-reference")).toEqual([]);
+  });
+
+  test("edge: tree with no deprecated nodes is left intact", () => {
+    const tree = {
+      children: [
+        { type: "page", name: "upload", url: "/reference/api-reference/files/postFilesUploadRequest" },
+      ],
+    };
+    const urls = collectUrls(prepareTree(tree as never, "3.1"));
+    expect(urls).toContain("/reference/api-reference/files/postFilesUploadRequest");
+  });
+});
+
+describe("Deprecated ops — redirects (U3, R3/R4/R5)", () => {
+  test("every deprecated op URL has exactly one 308 redirect to its tag index", async () => {
+    const redirects = getDeprecatedReferenceRedirects();
+    const urls = await allDeprecatedUrls();
+    for (const url of urls) {
+      const matches = redirects.filter((r) => r.source === url);
+      expect(matches.length).toBe(1);
+      const tagIndex = url.split("/").slice(0, -1).join("/");
+      // tag index when the tag has surviving ops, else the /reference fallback
+      expect([tagIndex, "/reference"]).toContain(matches[0].destination);
+      expect(matches[0].permanent).toBe(true);
+    }
+  });
+
+  test("regression: getFilesList redirects to the files tag index in both versions", () => {
+    const redirects = getDeprecatedReferenceRedirects();
+    expect(redirects).toContainEqual({
+      source: "/reference/api-reference/files/getFilesList",
+      destination: "/reference/api-reference/files",
+      permanent: true,
+    });
+    expect(redirects).toContainEqual({
+      source: "/reference/v3/api-reference/files/getFilesList",
+      destination: "/reference/v3/api-reference/files",
+      permanent: true,
+    });
+  });
+
+  test("edge: an all-deprecated tag falls back to /reference", () => {
+    const spec = {
+      paths: { "/x": { get: { deprecated: true, operationId: "getX", tags: ["Ghost"] } } },
+    };
+    expect(deprecatedRedirectsFromSpec(spec, "api-reference")).toEqual([
+      { source: "/reference/api-reference/ghost/getX", destination: "/reference", permanent: true },
+    ]);
+  });
+});
+
+describe("Deprecated ops — slugify parity", () => {
+  test("slugify lowercases and hyphenates tag names", () => {
+    expect(slugify("Files")).toBe("files");
+    expect(slugify("Invite Codes")).toBe("invite-codes");
+  });
+});

--- a/docs/tests/static/deprecated-ops.test.ts
+++ b/docs/tests/static/deprecated-ops.test.ts
@@ -23,6 +23,7 @@ import {
   getDeprecatedReferenceRedirects,
 } from "../../lib/deprecated-ops.mjs";
 import { prepareTree } from "../../lib/filter-api-version";
+import { isHiddenReferenceUrl } from "../../lib/source";
 
 const DOCS_ROOT = join(import.meta.dir, "../..");
 const REFERENCE_DIR = join(DOCS_ROOT, "content/reference");
@@ -155,6 +156,81 @@ describe("Deprecated ops — hidden URLs + tree filter (U2, R1/R4/R5)", () => {
     expect(deprecatedUrlsFromSpec(spec, "api-reference")).toEqual([]);
   });
 
+  test("multi-tag deprecated op is hidden under every tag it carries", () => {
+    // groupBy:'tag' renders one page per tag, so both tag URLs must be hidden.
+    const spec = {
+      paths: {
+        "/x": {
+          get: { deprecated: true, operationId: "getX", tags: ["Alpha", "Beta"] },
+          post: { operationId: "postX", tags: ["Beta"] },
+        },
+      },
+    };
+    expect(deprecatedUrlsFromSpec(spec, "api-reference")).toEqual([
+      "/reference/api-reference/alpha/getX",
+      "/reference/api-reference/beta/getX",
+    ]);
+  });
+
+  test("all-deprecated folder (index + every child deprecated) is dropped, sibling survives (v3.1)", () => {
+    const tree = {
+      children: [
+        {
+          type: "folder",
+          name: "files",
+          index: { type: "page", name: "i", url: "/reference/api-reference/files/getFilesList" },
+          children: [
+            { type: "page", name: "g", url: "/reference/api-reference/files/getFilesList" },
+          ],
+        },
+        {
+          type: "folder",
+          name: "projects",
+          children: [
+            { type: "page", name: "p", url: "/reference/api-reference/projects/getProjects" },
+          ],
+        },
+      ],
+    };
+    const result = prepareTree(tree as never, "3.1") as { children: Array<{ name?: string }> };
+    const urls = collectUrls(result);
+    expect(urls).not.toContain("/reference/api-reference/files/getFilesList");
+    expect(urls).toContain("/reference/api-reference/projects/getProjects");
+    // The whole folder is removed, not left as a dead empty sidebar entry.
+    expect(result.children.some((n) => n.name === "files")).toBe(false);
+  });
+
+  test("all-deprecated folder is dropped, sibling survives (v3.0)", () => {
+    const tree = {
+      children: [
+        {
+          type: "folder",
+          name: "v3",
+          children: [
+            {
+              type: "folder",
+              name: "files",
+              index: { type: "page", name: "i", url: "/reference/v3/api-reference/files/getFilesList" },
+              children: [
+                { type: "page", name: "g", url: "/reference/v3/api-reference/files/getFilesList" },
+              ],
+            },
+            {
+              type: "folder",
+              name: "projects",
+              children: [
+                { type: "page", name: "p", url: "/reference/v3/api-reference/projects/getProjects" },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const urls = collectUrls(prepareTree(tree as never, "3.0"));
+    expect(urls).not.toContain("/reference/v3/api-reference/files/getFilesList");
+    expect(urls).toContain("/reference/v3/api-reference/projects/getProjects");
+  });
+
   test("edge: tree with no deprecated nodes is left intact", () => {
     const tree = {
       children: [
@@ -201,6 +277,32 @@ describe("Deprecated ops — redirects (U3, R3/R4/R5)", () => {
     expect(deprecatedRedirectsFromSpec(spec, "api-reference")).toEqual([
       { source: "/reference/api-reference/ghost/getX", destination: "/reference", permanent: true },
     ]);
+  });
+
+  test("multi-tag deprecated op redirects per tag, respecting the per-tag survivor check", () => {
+    const spec = {
+      paths: {
+        "/x": {
+          get: { deprecated: true, operationId: "getX", tags: ["Alpha", "Beta"] },
+          post: { operationId: "postX", tags: ["Beta"] },
+        },
+      },
+    };
+    // Beta keeps a surviving op (postX) -> tag index; Alpha is all-deprecated -> /reference.
+    expect(deprecatedRedirectsFromSpec(spec, "api-reference")).toEqual([
+      { source: "/reference/api-reference/alpha/getX", destination: "/reference", permanent: true },
+      { source: "/reference/api-reference/beta/getX", destination: "/reference/api-reference/beta", permanent: true },
+    ]);
+  });
+});
+
+describe("Deprecated ops — flat page-list filter (U2, source.ts)", () => {
+  test("isHiddenReferenceUrl hides deprecated URLs (both versions) and hidden tags, not normal ops", () => {
+    expect(isHiddenReferenceUrl("/reference/api-reference/files/getFilesList")).toBe(true);
+    expect(isHiddenReferenceUrl("/reference/v3/api-reference/files/getFilesList")).toBe(true);
+    expect(isHiddenReferenceUrl("/reference/api-reference/files/postFilesUploadRequest")).toBe(false);
+    // Pre-existing hidden-tag behavior is preserved alongside the new deprecated check.
+    expect(isHiddenReferenceUrl("/reference/api-reference/consumer/getConsumer")).toBe(true);
   });
 });
 


### PR DESCRIPTION
This PR:

- hides every operation flagged `deprecated: true` in the committed OpenAPI specs from the reference page tree, sidebar, per-tag overview table, and the flat page list that feeds `llms.mdx`/`llms.txt`, the sitemap, search, and `validate-links`
- 308-redirects each hidden deprecated op URL to its tag section index in both v3.1 and v3.0 (e.g. `/reference/api-reference/files/getFilesList` -> `/reference/api-reference/files`, and the `/reference/v3/...` twin) so existing deep links don't 404
- adds `docs/lib/deprecated-ops.mjs` — one plain-ESM module deriving the deprecated URLs and redirects from the specs, consumed by the tree filter (`filter-api-version.ts`), the `getPages()` filter (`source.ts`), and `next.config.mjs`
- makes `operation.deprecated === true` the single source of truth: a future deprecation is hidden and redirected on the next spec refresh with **no code change** (tests iterate all deprecated ops rather than hard-coding `getFilesList`)
- handles multi-tag deprecated ops (fumadocs `groupBy: 'tag'` renders a page per tag, so a URL/redirect is derived for every tag) and falls back to `/reference` when a tag's only ops are deprecated
- regenerates `files/index.mdx` (v3.1 + v3.0) to drop the `getFilesList (DEPRECATED)` row

Docs-only; no backend spec or endpoint changes. Verified with `types:check`, `lint`, `bun test tests/static/` (new `deprecated-ops.test.ts`), and `lint:links` — all green.