### PR TITLE
fix(docs): publish production API URLs and guard against staging leaks

### DIFF
--- a/.github/workflows/docs-update-data.yml
+++ b/.github/workflows/docs-update-data.yml
@@ -51,34 +51,11 @@ jobs:
       - name: Setup Node.js, pnpm, Bun
         uses: ./.github/actions/setup-node-pnpm-bun
 
-      - name: Configure staging API endpoints
-        env:
-          COMPOSIO_BASE_URL_STAGING: ${{ secrets.COMPOSIO_BASE_URL_STAGING }}
-        run: |
-          staging_base="${COMPOSIO_BASE_URL_STAGING%/}"
-
-          if [ -z "$staging_base" ]; then
-            echo "::error::COMPOSIO_BASE_URL_STAGING is not set"
-            exit 1
-          fi
-
-          if [[ "$staging_base" == "https://backend.composio.dev" || "$staging_base" == "https://backend.composio.dev/"* ]]; then
-            echo "::error::COMPOSIO_BASE_URL_STAGING points at production"
-            exit 1
-          fi
-
-          staging_origin="${staging_base%/api/v3.1}"
-          staging_origin="${staging_origin%/api/v3}"
-          staging_v3_base="$staging_origin/api/v3"
-          staging_v31_base="$staging_origin/api/v3.1"
-
-          {
-            echo "COMPOSIO_API_BASE=$staging_v3_base"
-            echo "OPENAPI_SPEC_URL=$staging_v3_base/openapi.json"
-            echo "OPENAPI_V31_SPEC_URL=$staging_v31_base/openapi.json"
-          } >> "$GITHUB_ENV"
-
-          echo "Configured staging API endpoints"
+      # Docs must reflect PRODUCTION. No base-URL override is set here: the
+      # generators default to the production API (docs/scripts/production-api.mjs).
+      # Previously this step pointed the fetch at STAGING, which published staging
+      # hosts (and unreleased content) into the committed docs.
+      # NOTE: requires COMPOSIO_API_KEY to have PRODUCTION read access.
 
       - name: Cache bun dependencies
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -131,7 +108,7 @@ jobs:
 
             ## What changed
             - **Toolkit catalog** (`docs/public/data/toolkits.json`, `toolkits-list.json`) — refreshed list of available toolkits, auth schemes, and tools from the backend API
-            - **OpenAPI specs** (`docs/public/openapi.json`, `docs/public/openapi-v3.json`) — latest v3.1 and v3.0 API specifications fetched from staging
+            - **OpenAPI specs** (`docs/public/openapi.json`, `docs/public/openapi-v3.json`) — latest v3.1 and v3.0 API specifications fetched from production
             - **API reference pages** (`docs/content/reference/api-reference/`, `docs/content/reference/v3/api-reference/`) — regenerated index pages for both API versions
             - **Meta tools reference** (`docs/public/data/meta-tools.json`, `docs/content/toolkits/meta-tools/*.mdx`) — updated meta tool schemas and reference docs
           branch: docs/auto-update-data

--- a/docs/public/data/toolkits.json
+++ b/docs/public/data/toolkits.json
@@ -374,7 +374,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -5136,7 +5136,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -5483,7 +5483,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -5834,7 +5834,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -6269,7 +6269,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -7219,7 +7219,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -7948,7 +7948,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -9609,7 +9609,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -10215,7 +10215,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -10767,7 +10767,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -11099,7 +11099,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -12405,7 +12405,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -12799,7 +12799,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -13053,7 +13053,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -14011,7 +14011,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -14715,7 +14715,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -15332,7 +15332,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -18325,7 +18325,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -18975,7 +18975,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -19157,7 +19157,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -19369,7 +19369,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -19712,7 +19712,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -20066,7 +20066,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -21019,7 +21019,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -21848,7 +21848,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -23103,7 +23103,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -23254,7 +23254,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -25096,7 +25096,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -26009,7 +26009,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -28276,7 +28276,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -28535,7 +28535,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -28717,7 +28717,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -29271,7 +29271,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -31083,7 +31083,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -31990,7 +31990,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -33178,7 +33178,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -33592,7 +33592,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -40317,7 +40317,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -40512,7 +40512,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -42798,7 +42798,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -44013,7 +44013,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -45637,7 +45637,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -46255,7 +46255,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -46396,7 +46396,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -46809,7 +46809,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -47946,7 +47946,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -49214,7 +49214,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -53347,7 +53347,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -54299,7 +54299,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -58481,7 +58481,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -58798,7 +58798,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -59196,7 +59196,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -59382,7 +59382,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -61737,7 +61737,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -61882,7 +61882,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -62290,7 +62290,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -64927,7 +64927,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -66655,7 +66655,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -68052,7 +68052,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -68324,7 +68324,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -70243,7 +70243,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -70463,7 +70463,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -71544,7 +71544,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -72101,7 +72101,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -75307,7 +75307,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -75514,7 +75514,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -75579,7 +75579,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -76444,7 +76444,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -77132,7 +77132,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -77309,7 +77309,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -78740,7 +78740,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -79105,7 +79105,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -79444,7 +79444,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -79805,7 +79805,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -80064,7 +80064,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -80449,7 +80449,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -81108,7 +81108,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -81393,7 +81393,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -81780,7 +81780,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -81868,7 +81868,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -82219,7 +82219,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -83828,7 +83828,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -84059,7 +84059,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -84621,7 +84621,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -84735,7 +84735,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -85182,7 +85182,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -85860,7 +85860,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -87229,7 +87229,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -88882,7 +88882,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -89302,7 +89302,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -89661,7 +89661,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -90193,7 +90193,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -90258,7 +90258,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -90485,7 +90485,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -90944,7 +90944,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -91436,7 +91436,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -91657,7 +91657,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -91731,7 +91731,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -97913,7 +97913,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -98084,7 +98084,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -99222,7 +99222,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -99520,7 +99520,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -99851,7 +99851,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -99925,7 +99925,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -100745,7 +100745,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -100958,7 +100958,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -101142,7 +101142,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -101520,7 +101520,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -101625,7 +101625,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -101771,7 +101771,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -102130,7 +102130,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -102285,7 +102285,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -102642,7 +102642,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -102816,7 +102816,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -103103,7 +103103,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -103168,7 +103168,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -103233,7 +103233,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -103493,7 +103493,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -104174,7 +104174,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -104325,7 +104325,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -104656,7 +104656,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -104792,7 +104792,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -104857,7 +104857,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -104972,7 +104972,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -105078,7 +105078,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -106781,7 +106781,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -106966,7 +106966,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -107469,7 +107469,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -108240,7 +108240,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -109396,7 +109396,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -109986,7 +109986,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -110051,7 +110051,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -110143,7 +110143,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -110646,7 +110646,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -111498,7 +111498,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -112218,7 +112218,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -112534,7 +112534,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -112816,7 +112816,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -114926,7 +114926,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -116998,7 +116998,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -117073,7 +117073,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -117291,7 +117291,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -117452,7 +117452,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -118544,7 +118544,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -119275,7 +119275,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -121080,7 +121080,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -124930,7 +124930,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -125260,7 +125260,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -126276,7 +126276,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -130367,7 +130367,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -131318,7 +131318,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -132162,7 +132162,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -138847,7 +138847,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -144073,7 +144073,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -146833,7 +146833,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -148927,7 +148927,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -151115,7 +151115,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -154511,7 +154511,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -155843,7 +155843,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -157725,7 +157725,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -160187,7 +160187,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -162609,7 +162609,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -164540,7 +164540,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -169364,7 +169364,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -170416,7 +170416,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -174539,7 +174539,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -175564,7 +175564,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -176018,7 +176018,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -176887,7 +176887,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -180342,7 +180342,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -181092,7 +181092,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -181778,7 +181778,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -182400,7 +182400,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -182523,7 +182523,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -184089,7 +184089,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -186363,7 +186363,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -187861,7 +187861,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -188452,7 +188452,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -188791,7 +188791,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -189167,7 +189167,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -189233,7 +189233,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -189322,7 +189322,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -189596,7 +189596,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -189716,7 +189716,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -189828,7 +189828,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -189894,7 +189894,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -190143,7 +190143,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -190259,7 +190259,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -191227,7 +191227,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -191345,7 +191345,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -192191,7 +192191,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -194484,7 +194484,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -196613,7 +196613,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -198585,7 +198585,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -201188,7 +201188,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -203752,7 +203752,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -204271,7 +204271,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -204592,7 +204592,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -209367,7 +209367,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -210801,7 +210801,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -212340,7 +212340,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -213271,7 +213271,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -216562,7 +216562,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -216668,7 +216668,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -219440,7 +219440,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -219870,7 +219870,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -220516,7 +220516,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -221078,7 +221078,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -221183,7 +221183,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -224036,7 +224036,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -225346,7 +225346,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -226693,7 +226693,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -226922,7 +226922,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -231442,7 +231442,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -234125,7 +234125,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -234307,7 +234307,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -234437,7 +234437,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -234592,7 +234592,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -235432,7 +235432,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -236221,7 +236221,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -236337,7 +236337,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -240199,7 +240199,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -240444,7 +240444,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -241083,7 +241083,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -245135,7 +245135,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -246578,7 +246578,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -248012,7 +248012,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -248789,7 +248789,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -249224,7 +249224,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -249778,7 +249778,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -250231,7 +250231,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -250642,7 +250642,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -251372,7 +251372,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -256479,7 +256479,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -259531,7 +259531,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -259726,7 +259726,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -260091,7 +260091,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -261232,7 +261232,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -263158,7 +263158,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -265284,7 +265284,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -266377,7 +266377,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -270507,7 +270507,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -271021,7 +271021,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -271589,7 +271589,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -272663,7 +272663,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -272830,7 +272830,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -273732,7 +273732,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -274304,7 +274304,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -274594,7 +274594,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -277682,7 +277682,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -278068,7 +278068,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -279279,7 +279279,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -279679,7 +279679,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -281340,7 +281340,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -281499,7 +281499,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -281706,7 +281706,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -283028,7 +283028,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -285490,7 +285490,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -285668,7 +285668,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -289723,7 +289723,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -289885,7 +289885,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -291069,7 +291069,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -291463,7 +291463,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -291715,7 +291715,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -294372,7 +294372,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -295037,7 +295037,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -295611,7 +295611,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -296186,7 +296186,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",
@@ -296610,7 +296610,7 @@
                 "type": "string",
                 "description": "Add this Redirect URL to your app's OAuth allow list.",
                 "required": false,
-                "default": "https://staging-backend.composio.dev/api/v1/auth-apps/add"
+                "default": "https://backend.composio.dev/api/v1/auth-apps/add"
               },
               {
                 "name": "scopes",

--- a/docs/scripts/fetch-openapi.mjs
+++ b/docs/scripts/fetch-openapi.mjs
@@ -10,9 +10,10 @@
 import { writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { PRODUCTION_BASE_URL, PRODUCTION_API_V3_URL, PRODUCTION_API_V31_URL } from './production-api.mjs';
 
-const OPENAPI_V3_URL = process.env.OPENAPI_SPEC_URL || 'https://backend.composio.dev/api/v3/openapi.json';
-const OPENAPI_V31_URL = process.env.OPENAPI_V31_SPEC_URL || 'https://backend.composio.dev/api/v3.1/openapi.json';
+const OPENAPI_V3_URL = process.env.OPENAPI_SPEC_URL || `${PRODUCTION_API_V3_URL}/openapi.json`;
+const OPENAPI_V31_URL = process.env.OPENAPI_V31_SPEC_URL || `${PRODUCTION_API_V31_URL}/openapi.json`;
 
 // Tags to ignore (internal/admin)
 const IGNORED_TAGS = [
@@ -95,7 +96,7 @@ function postProcessSpec(spec) {
   // staging server URL into the committed reference).
   spec.servers = [
     {
-      url: 'https://backend.composio.dev',
+      url: PRODUCTION_BASE_URL,
       description: 'PRODUCTION API',
     },
   ];

--- a/docs/scripts/generate-meta-tools.ts
+++ b/docs/scripts/generate-meta-tools.ts
@@ -20,8 +20,9 @@ import { writeFile, mkdir, readdir, unlink } from 'fs/promises';
 import { join } from 'path';
 import { fetchWithRetry } from './fetch-with-retry';
 import { META_TOOL_OVERRIDES } from '../lib/meta-tool-overrides';
+import { PRODUCTION_API_V3_URL, stripStagingHosts } from './production-api.mjs';
 
-const API_BASE = process.env.COMPOSIO_API_BASE || 'https://backend.composio.dev/api/v3';
+const API_BASE = process.env.COMPOSIO_API_BASE || PRODUCTION_API_V3_URL;
 const API_KEY = process.env.COMPOSIO_API_KEY;
 
 if (!API_KEY) {
@@ -221,7 +222,7 @@ async function main() {
   metaTools.sort((a, b) => a.slug.localeCompare(b.slug));
 
   // 1. Write JSON data
-  await writeFile(join(DATA_DIR, 'meta-tools.json'), JSON.stringify(metaTools, null, 2));
+  await writeFile(join(DATA_DIR, 'meta-tools.json'), stripStagingHosts(JSON.stringify(metaTools, null, 2)));
   console.log(`\nWrote public/data/meta-tools.json (~${Math.round(JSON.stringify(metaTools).length / 1024)}KB)`);
 
   // 2. Clean old generated MDX files and regenerate

--- a/docs/scripts/generate-toolkits.ts
+++ b/docs/scripts/generate-toolkits.ts
@@ -11,8 +11,9 @@
 import { mkdir, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { fetchWithRetry } from './fetch-with-retry';
+import { PRODUCTION_API_V3_URL, stripStagingHosts } from './production-api.mjs';
 
-const API_BASE = process.env.COMPOSIO_API_BASE || 'https://backend.composio.dev/api/v3';
+const API_BASE = process.env.COMPOSIO_API_BASE || PRODUCTION_API_V3_URL;
 const API_KEY = process.env.COMPOSIO_API_KEY;
 
 if (!API_KEY) {
@@ -332,10 +333,13 @@ async function main() {
 
   console.log('\n');
 
-  // Write full file (for detail pages - read from filesystem)
+  // Write full file (for detail pages - read from filesystem).
+  // Rewrite any staging host to production: this data is fetched from staging in
+  // the docs-update workflow, and auth-config `default` URLs would otherwise
+  // publish staging endpoints. The light file below carries no URLs.
   await writeFile(
     join(OUTPUT_DIR, 'toolkits.json'),
-    JSON.stringify(toolkits, null, 2)
+    stripStagingHosts(JSON.stringify(toolkits, null, 2))
   );
 
   // Write light file (for landing page - imported in client component)

--- a/docs/scripts/production-api.mjs
+++ b/docs/scripts/production-api.mjs
@@ -1,0 +1,36 @@
+/**
+ * Single source of truth for the Composio production API URL used by the docs
+ * generators (fetch-openapi.mjs, generate-toolkits.ts, generate-meta-tools.ts).
+ *
+ * The "Docs - Update Data" workflow (.github/workflows/docs-update-data.yml)
+ * fetches the OpenAPI specs and toolkit data from STAGING. Without a guard,
+ * staging hosts leak into the committed, published docs artifacts — e.g. the
+ * OpenAPI `servers[0].url` (curl base URL) and toolkit auth-config `default`
+ * URLs. The generators pin/rewrite these to production before writing;
+ * tests/static/production-urls.test.ts is the independent CI guard.
+ *
+ * The guard test deliberately does NOT import from this module: an oracle must
+ * verify against an independently-stated expectation, so a wrong edit here fails
+ * the test instead of silently moving both sides together.
+ */
+
+export const PRODUCTION_HOST = 'backend.composio.dev';
+export const PRODUCTION_BASE_URL = `https://${PRODUCTION_HOST}`;
+export const PRODUCTION_API_V3_URL = `${PRODUCTION_BASE_URL}/api/v3`;
+export const PRODUCTION_API_V31_URL = `${PRODUCTION_BASE_URL}/api/v3.1`;
+
+/** Non-production hosts that must never appear in published docs data. */
+export const STAGING_HOSTS = ['staging-backend.composio.dev', 'staging-apollo.composio.dev'];
+
+/**
+ * Rewrite any staging host in a serialized JSON string to the production host,
+ * so a spec/data payload fetched from staging publishes production URLs.
+ * Operates on the serialized string to avoid disturbing typed data pipelines.
+ */
+export function stripStagingHosts(text) {
+  let out = text;
+  for (const host of STAGING_HOSTS) {
+    out = out.split(host).join(PRODUCTION_HOST);
+  }
+  return out;
+}

--- a/docs/tests/static/production-urls.test.ts
+++ b/docs/tests/static/production-urls.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Production-URL guard for published docs artifacts.
+ *
+ * The "Docs - Update Data" workflow fetches the OpenAPI specs and toolkit data
+ * from STAGING every ~5h and auto-commits the regenerated files. Staging hosts
+ * have leaked into the committed docs before (the API-reference curl base URL
+ * pointed at `http://staging-apollo.composio.dev`), so this test fails CI on any
+ * regeneration PR that ships a non-production host.
+ *
+ * This is an independent oracle: the expected production URL and the banned
+ * staging hosts are stated here directly and are intentionally NOT imported from
+ * scripts/production-api.mjs. A wrong edit to that generator constant must make
+ * this test fail, not move the expectation with it.
+ */
+import { describe, test, expect } from "bun:test";
+import { readFile, readdir } from "fs/promises";
+import { join } from "path";
+
+const PUBLIC_DIR = join(import.meta.dir, "../../public");
+const DATA_DIR = join(PUBLIC_DIR, "data");
+
+const EXPECTED_SERVER = {
+  url: "https://backend.composio.dev",
+  description: "PRODUCTION API",
+};
+
+// Any non-production Composio host must never appear in published data.
+const STAGING_HOST_RE = /staging-[a-z0-9-]*\.composio\.dev/gi;
+
+const OPENAPI_SPECS = ["openapi.json", "openapi-v3.json"];
+
+/** Read a file and return the distinct staging hosts it mentions, if any. */
+async function findStagingHosts(absPath: string): Promise<string[]> {
+  const contents = await readFile(absPath, "utf-8");
+  const matches = contents.match(STAGING_HOST_RE) ?? [];
+  const distinctHosts = [...new Set(matches)];
+  return distinctHosts;
+}
+
+describe("OpenAPI specs - production server", () => {
+  test.each(OPENAPI_SPECS)("%s servers[0] is the production API", async (spec) => {
+    const raw = await readFile(join(PUBLIC_DIR, spec), "utf-8");
+    const { servers } = JSON.parse(raw);
+    expect(servers).toEqual([EXPECTED_SERVER]);
+  });
+});
+
+describe("Published docs data - no staging hosts", () => {
+  test.each(OPENAPI_SPECS)("%s has no staging host", async (spec) => {
+    const stagingHosts = await findStagingHosts(join(PUBLIC_DIR, spec));
+    expect(stagingHosts).toEqual([]);
+  });
+
+  test("every public/data/*.json has no staging host", async () => {
+    const jsonFiles = (await readdir(DATA_DIR)).filter((file) => file.endsWith(".json"));
+
+    const offenders: string[] = [];
+    for (const file of jsonFiles) {
+      const stagingHosts = await findStagingHosts(join(DATA_DIR, file));
+      if (stagingHosts.length > 0) {
+        offenders.push(`${file}: ${stagingHosts.join(", ")}`);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What was wrong

The API reference docs were shipping staging URLs to users. There were two separate leaks, both from the same source: the scheduled `docs-update-data` workflow fetches the OpenAPI specs and toolkit data from staging every 5 hours and auto-commits them.

The first leak was the curl base URL. `servers[0].url` in `openapi.json` and `openapi-v3.json` rendered as `http://staging-apollo.composio.dev` in every curl example. That is what https://github.com/ComposioHQ/composio/pull/3761 tried to fix.

The second leak was in the toolkit data. `toolkits.json` carried 269 `https://staging-backend.composio.dev/api/v1/auth-apps/add` default values, surfaced in the white-labeling and auth-config docs. #3761 never touched this file.

## Which PR caused it

Karan asked on Slack whether we could pin down the PR that introduced this. We can. It was https://github.com/ComposioHQ/composio/pull/3426 (commit `a3e58a421`, merged 2026-07-03), which flipped `servers[0].url` from `https://backend.composio.dev` / `PRODUCTION API` to `http://staging-apollo.composio.dev` / `STAGING API` in both specs.

It was not a hand-written change. #3426 is itself an auto-generated PR from this same `docs-update-data` workflow, opened by `github-actions[bot]` on the `docs/auto-update-data` branch. The workflow fetched from staging, staging serves the staging server URL in its spec, and the value landed in the committed files where nobody caught it inside a large auto-generated diff. That is the reason the real fix belongs in the generator and the workflow, not in a one-off edit to the JSON.

## Why #3761 was not enough

#3761 pinned `spec.servers` to production inside `fetch-openapi.mjs`. That closed the first leak, but three things stayed open.

It only covered the OpenAPI specs. The 269 staging hosts in `toolkits.json` come from a different generator, `generate-toolkits.ts`, and stayed live on the docs site.

It added no CI guard. The fix was a single line in a generator with nothing asserting it. A later refactor that dropped or reordered that line would republish staging on the next 5-hour regeneration, which is precisely the recurring failure that produced the original report.

And it scrubbed the symptom rather than the source. The workflow kept fetching from staging; the pin just rewrote one field afterward.

## The fix

I addressed it at four layers, so no single regression brings staging back.

**Source.** `docs-update-data.yml` no longer overrides the base URL to staging. The generators default to production, so the docs reflect production.

**Generators.** The production URL now lives in one place, `docs/scripts/production-api.mjs`. The toolkit and meta-tools generators sanitize any staging host to production before writing, so a staging fetch can no longer republish staging.

**Committed data.** I rewrote the 269 staging hosts already in `toolkits.json` to production.

**Guard.** `docs/tests/static/production-urls.test.ts` asserts the OpenAPI `servers` is production and scans both specs and every `public/data/*.json` for any `staging-*.composio.dev` host. It is an independent oracle: it hardcodes the expected value and deliberately does not import the generator constants, so a wrong edit there fails CI instead of moving both sides together. I verified it catches both the original `staging-apollo` and the `staging-backend` leaks.

## One thing to confirm before merge

`COMPOSIO_API_KEY` is paired with `COMPOSIO_BASE_URL_STAGING` in every other workflow, so it is most likely a staging key. If that is the case, provision a production-capable key before the next scheduled run. Otherwise that run fails on auth, which is loud and safe, rather than silently republishing staging. The generator sanitizer and the guard keep the output correct regardless of which environment the fetch hits, so there is no risk in the interim.

## Testing

- `bun test tests/static/` passes 21 of 21 (16 existing, 5 new).
- The shared module loads and all three generators build under bun.
- No `staging-*.composio.dev` host remains under `docs/public/`.
- `docs-update-data.yml` re-validated as valid YAML.
