### PR TITLE
docs: clarify file URL TTL and cleanup

### DIFF
--- a/docs/api-overviews/files.mdx
+++ b/docs/api-overviews/files.mdx
@@ -11,6 +11,10 @@ This keeps large payloads out of request bodies. Tools receive a file reference 
 File uploads are a two-step flow. Call the upload-request endpoint to mint a presigned URL, then upload the file contents directly to that URL. The API never receives the raw bytes.
 </Callout>
 
+Presigned URLs expire separately from the underlying staged file. By default, signed file URLs are valid for 1 hour (`3600` seconds). You can change this URL TTL in **Project Settings > File TTL**.
+
+Files staged for tool execution are stored in temporary object storage and automatically cleaned up after 24 hours. If a presigned URL expires before the file is cleaned up, request a fresh URL or re-run the tool.
+
 If your agent works with files inside a session, prefer the session file mount, where the sandbox exposes uploaded files to running code. See the [remote sandbox](/docs/sandbox/remote) for the sandbox helpers (`upload_local_file`, `smart_file_extract`) that build on this storage.
 
 These endpoints use your project API key in the `x-api-key` header.

--- a/docs/content/docs/how-composio-works.mdx
+++ b/docs/content/docs/how-composio-works.mdx
@@ -84,6 +84,8 @@ Handle large responses and bulk operations in the remote sandbox. Instead of stu
 
 The sandbox is scoped to the session, so files, variables, helper functions, and intermediate results stay available while the agent works through a task.
 
+The session record can persist without expiring, but sandbox resources have their own lifecycle. See the [remote sandbox](/docs/sandbox/remote) for sandbox and `/mnt/files/` retention details.
+
 ## How sessions behave
 
 Every `create()` call returns a new session ID. Use it for a fresh task context.

--- a/docs/content/docs/sandbox/remote.mdx
+++ b/docs/content/docs/sandbox/remote.mdx
@@ -6,6 +6,8 @@ keywords: [sandbox, remote sandbox, workbench, remote execution, bulk operations
 
 The **sandbox** is a persistent Python environment where your agent writes and executes code. It has programmatic access to all Composio tools, plus helper functions for calling LLMs, uploading files, and making API requests. State persists across calls within a [session](/docs/how-composio-works). Your agent runs code in it through the `COMPOSIO_REMOTE_WORKBENCH` meta tool, and shell commands through `COMPOSIO_REMOTE_BASH_TOOL`.
 
+Sandbox state is durable for the task, not permanent storage. Idle sandboxes can be paused and resumed, but a paused sandbox may be reclaimed after 12 hours of inactivity. Keep files you need across sandbox restarts in `/mnt/files/`, and move anything you need long term to your own storage.
+
 <Callout title="Renamed from workbench">
 This feature used to be called the **workbench**. The preferred session config key is now `sandbox`, but `workbench` still works as a fully supported alias, in both SDKs and on the wire. It isn't deprecated, so existing code keeps running unchanged. The `COMPOSIO_REMOTE_WORKBENCH` and `COMPOSIO_REMOTE_BASH_TOOL` meta tools keep their names.
 </Callout>
@@ -64,6 +66,8 @@ Larger tiers require `@composio/core` ≥ `0.8.1` or `composio` ≥ `0.12.1`. Se
 
 The sandbox has a persistent file mount at `/mnt/files/`. Code running in the sandbox reads and writes files there, and the mount survives sandbox restarts: changing the [compute tier](#compute-tier) recreates the sandbox and clears in-memory state, but `/mnt/files/` persists.
 
+Files in `/mnt/files/` are backed by temporary object storage and are automatically cleaned up after 24 hours. This cleanup window is separate from presigned download URL expiry: a `RemoteFile.expiresAt` value tells you when that download link expires, not when the stored file is removed.
+
 Move files between your app and the mount with `session.experimental.files`. Upload an input file and the agent reads it at `/mnt/files/<path>`. When the agent writes a result, download it from your app.
 
 <Callout>
@@ -113,7 +117,7 @@ The mount exposes four methods:
 | `download(path, options?)` | Fetch a file from the mount as a `RemoteFile`. |
 | `delete(path, options?)` | Remove a file or directory from the mount. |
 
-A `RemoteFile` carries the file's bytes and a presigned `downloadUrl`. Read it with `text()` or `buffer()`, or write it to disk with `save(path)`. Its `expiresAt` is when that download link expires, not a TTL on the file: the mount itself has no expiry you set.
+A `RemoteFile` carries the file's bytes and a presigned `downloadUrl`. Read it with `text()` or `buffer()`, or write it to disk with `save(path)`. Its `expiresAt` is when that download link expires, not the storage cleanup time for the file.
 
 Every file lives on the session's default `files` mount, surfaced at `/mnt/files/`. Each method takes a `mountId` to address a mount by ID, but there's no SDK call to create custom mounts today, so you'll normally work with `files`.
 

--- a/docs/content/reference/api-reference/files/index.mdx
+++ b/docs/content/reference/api-reference/files/index.mdx
@@ -18,6 +18,10 @@ This keeps large payloads out of request bodies. Tools receive a file reference 
 File uploads are a two-step flow. Call the upload-request endpoint to mint a presigned URL, then upload the file contents directly to that URL. The API never receives the raw bytes.
 </Callout>
 
+Presigned URLs expire separately from the underlying staged file. By default, signed file URLs are valid for 1 hour (`3600` seconds). You can change this URL TTL in **Project Settings > File TTL**.
+
+Files staged for tool execution are stored in temporary object storage and automatically cleaned up after 24 hours. If a presigned URL expires before the file is cleaned up, request a fresh URL or re-run the tool.
+
 If your agent works with files inside a session, prefer the session file mount, where the sandbox exposes uploaded files to running code. See the [remote sandbox](/docs/sandbox/remote) for the sandbox helpers (`upload_local_file`, `smart_file_extract`) that build on this storage.
 
 These endpoints use your project API key in the `x-api-key` header.

--- a/docs/content/reference/sdk-reference/typescript/remote-file.mdx
+++ b/docs/content/reference/sdk-reference/typescript/remote-file.mdx
@@ -21,6 +21,8 @@ const result = await composio.remoteFile.list();
 | `mountRelativePath` | `string` | Relative path within the mount (e.g. "report.pdf") |
 | `sandboxMountPrefix` | `string` | Absolute mount path inside the sandbox (e.g. /mnt/files) |
 
+`expiresAt` is the expiry time for the presigned download URL, not the storage cleanup time for the file. See the [remote sandbox](/docs/sandbox/remote#files-and-mounts) for mount retention details.
+
 ## Methods
 
 ### blob()

--- a/docs/content/reference/v3/api-reference/files/index.mdx
+++ b/docs/content/reference/v3/api-reference/files/index.mdx
@@ -18,6 +18,10 @@ This keeps large payloads out of request bodies. Tools receive a file reference 
 File uploads are a two-step flow. Call the upload-request endpoint to mint a presigned URL, then upload the file contents directly to that URL. The API never receives the raw bytes.
 </Callout>
 
+Presigned URLs expire separately from the underlying staged file. By default, signed file URLs are valid for 1 hour (`3600` seconds). You can change this URL TTL in **Project Settings > File TTL**.
+
+Files staged for tool execution are stored in temporary object storage and automatically cleaned up after 24 hours. If a presigned URL expires before the file is cleaned up, request a fresh URL or re-run the tool.
+
 If your agent works with files inside a session, prefer the session file mount, where the sandbox exposes uploaded files to running code. See the [remote sandbox](/docs/sandbox/remote) for the sandbox helpers (`upload_local_file`, `smart_file_extract`) that build on this storage.
 
 These endpoints use your project API key in the `x-api-key` header.


### PR DESCRIPTION
## Summary
- document default presigned file URL TTL and 24-hour staged-file cleanup in the Files API overview
- clarify Remote sandbox `/mnt/files` cleanup and sandbox inactivity lifecycle
- add lightweight cross-links from session and `RemoteFile` docs to the sandbox retention details

## Validation
- `bun run generate:api-index`
- `bun run lint:links`
- `bun run test`
- `bun run build`

Note: `bun run build` passed with existing warnings about missing `COMPOSIO_API_KEY` for detailed toolkit fetches and repeated Fumadocs OpenAPI v3 document warnings.