### PR TITLE
docs: embed walkthrough video + scoped API key creation steps

### DIFF
--- a/docs/content/reference/authenticating-to-composio/project-api-key-permissions.mdx
+++ b/docs/content/reference/authenticating-to-composio/project-api-key-permissions.mdx
@@ -5,6 +5,8 @@ keywords: [project api keys, scoped api keys, permissions, access levels]
 isNew: true
 ---
 
+<YouTube id="ySMu9lljkWg" title="Scoped Project API Key walkthrough" />
+
 A scoped project API key lets you choose which project resources the key can access. Reach for one when a key needs only a subset of your project, such as executing tools, reading logs, or managing connected accounts.
 
 <Callout type="warn">
@@ -14,6 +16,31 @@ You pick a key's permissions when you create it, and they can't be changed after
 <Callout type="info">
 Default project API keys keep full project API key access. Scoped keys use the permission areas and access levels on this page.
 </Callout>
+
+## Create a scoped API key
+
+Create a scoped key from the dashboard:
+
+<Steps>
+<Step>
+Go to the [Composio Dashboard](https://dashboard.composio.dev).
+</Step>
+<Step>
+Select **Platform**.
+</Step>
+<Step>
+Select your project.
+</Step>
+<Step>
+Go to **Settings**.
+</Step>
+<Step>
+Open the **API Keys** tab.
+</Step>
+<Step>
+Click **Create API Key**, then choose the permission areas and access levels below.
+</Step>
+</Steps>
 
 ## Access levels
 


### PR DESCRIPTION
## What

Updates the **Scoped Project API Key** reference page ([`project-api-key-permissions.mdx`](https://docs.composio.dev/reference/authenticating-to-composio/project-api-key-permissions)):

- Embeds a YouTube walkthrough video at the top of the page (using the existing `<YouTube>` MDX component — lazy-loaded iframe, no layout shift).
- Adds a short **"Create a scoped API key"** section with dashboard steps (Dashboard → Platform → project → Settings → API Keys → Create API Key).

## Preview

<!-- Shawn: drag the localhost screenshot here -->

## Notes

- Single-file content change; no component or config edits.

<img width="1920" height="956" alt="image" src="https://github.com/user-attachments/assets/9d419ce1-d193-40f6-a669-0a3f2d0dd206" />


<img width="1899" height="985" alt="image" src="https://github.com/user-attachments/assets/ee126ac4-459b-4c08-ad22-2c99116165fb" />
