### PR TITLE
fix(examples): give the Mastra agents a step budget so tool-router returns output

### DIFF
--- a/ts/examples/mastra/src/index.ts
+++ b/ts/examples/mastra/src/index.ts
@@ -16,6 +16,7 @@ import { openai } from '@ai-sdk/openai';
 import { Composio } from '@composio/core';
 import { MastraProvider } from '@composio/mastra';
 import { Agent } from '@mastra/core/agent';
+import { stepCountIs } from 'ai';
 import 'dotenv/config';
 
 const composio = new Composio({
@@ -44,9 +45,11 @@ const agent = new Agent({
   tools,
 });
 
-const { text } = await agent.generate([
-  { role: 'user', content: 'Tell me about the HackerNews user `pg`.' },
-]);
+// Allow the agent a few steps to call the tool and then summarize the result.
+const { text } = await agent.generate(
+  [{ role: 'user', content: 'Tell me about the HackerNews user `pg`.' }],
+  { stopWhen: stepCountIs(10) }
+);
 
 // This example doubles as a test: a healthy run returns non-empty text.
 if (!text || text.trim().length === 0) {

--- a/ts/examples/mastra/src/tool-router.ts
+++ b/ts/examples/mastra/src/tool-router.ts
@@ -19,6 +19,7 @@ import { openai } from '@ai-sdk/openai';
 import { Composio } from '@composio/core';
 import { MastraProvider } from '@composio/mastra';
 import { Agent } from '@mastra/core/agent';
+import { stepCountIs } from 'ai';
 import 'dotenv/config';
 
 const composio = new Composio({
@@ -43,9 +44,14 @@ const agent = new Agent({
   tools,
 });
 
-const { text } = await agent.generate([
-  { role: 'user', content: 'What are the current top 3 HackerNews stories? Give me their titles.' },
-]);
+// Tool Router is a multi-step flow: the agent calls the router's search +
+// multi-execute meta-tools, then summarizes. Without a step budget the run
+// stops after the first tool call and returns empty text, so allow several
+// steps (matches the Mastra tool-router e2e reference).
+const { text } = await agent.generate(
+  [{ role: 'user', content: 'What are the current top 3 HackerNews stories? Give me their titles.' }],
+  { stopWhen: stepCountIs(10) }
+);
 
 // This example doubles as a test: a healthy run returns non-empty text.
 if (!text || text.trim().length === 0) {


### PR DESCRIPTION
## What

Add `stopWhen: stepCountIs(10)` to both Mastra example agent entries (`src/index.ts`, `src/tool-router.ts`).

## Why

The first nightly `workflow_dispatch` run of `ts.examples-nightly` (after #3788 merged) failed on the **tool-router** example with `Agent returned empty output`. `agent.generate(...)` had no step budget, so the multi-step Tool Router flow (router `search` + `multi-execute` meta-tools, then summarize) stopped after the first tool call and produced no final text. The non-empty-output assertion added in #3788 turned that silent no-op into a loud failure — working as intended.

Every other tool-router example/e2e in the repo already sets a step budget; this matches the Mastra tool-router e2e reference (`ts/e2e-tests/runtimes/node/mastra-tool-router-zod-v4/e2e.test.ts` → `stopWhen: stepCountIs(10)`).

## Verification

- `pnpm run lint:examples` and `pnpm run typecheck:examples` green.
- Nightly re-dispatch to confirm the tool-router example now returns non-empty output against staging (follow-up once merged).

## Notes

- No changeset — example package is private/unpublished.
- `index.ts` passed without the budget but gets the same `stepCountIs(10)` for robustness/consistency.