### PR TITLE
feat(openai): add executable provider example

### DIFF
--- a/.github/workflows/ts.examples-nightly.yml
+++ b/.github/workflows/ts.examples-nightly.yml
@@ -25,10 +25,11 @@ jobs:
   examples-staging:
     name: ${{ matrix.provider }} examples against staging
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
-        provider: [mastra]
+        provider: [mastra, openai]
 
     steps:
       - name: Checkout Code
@@ -45,13 +46,13 @@ jobs:
       - name: Build SDK packages
         run: pnpm run build:packages
 
-      # On the schedule the secret must be present. Without this, a rotated/renamed/
-      # empty COMPOSIO_API_KEY would make smoke self-skip (exit 0) and every LLM step
-      # no-op, leaving the whole "regression net" green while testing nothing.
-      - name: Require COMPOSIO_API_KEY on scheduled runs
-        if: ${{ github.event_name == 'schedule' && env.COMPOSIO_API_KEY == '' }}
+      # Both secrets must be present for scheduled and manually dispatched
+      # validation. Otherwise smoke can self-skip and the LLM steps can no-op,
+      # leaving the whole regression net green while testing nothing.
+      - name: Require staging credentials
+        if: ${{ env.COMPOSIO_API_KEY == '' || env.OPENAI_API_KEY == '' }}
         run: |
-          echo "::error::COMPOSIO_API_KEY is empty on a scheduled run — smoke would no-op and mask regressions."
+          echo "::error::COMPOSIO_API_KEY and OPENAI_API_KEY are required for examples validation."
           exit 1
 
       # Deterministic regression net — needs only COMPOSIO_API_KEY, no LLM.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -885,12 +885,18 @@ importers:
         specifier: 'catalog:'
         version: 3.25.2(zod@4.4.3)
     devDependencies:
+      '@cloudflare/workers-types':
+        specifier: 'catalog:'
+        version: 4.20260702.1
       '@types/bun':
         specifier: 'catalog:'
         version: 1.3.14
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
+      wrangler:
+        specifier: 'catalog:'
+        version: 4.107.0(@cloudflare/workers-types@4.20260702.1)
 
   ts/examples/session-management:
     dependencies:

--- a/ts/examples/openai/README.md
+++ b/ts/examples/openai/README.md
@@ -1,0 +1,47 @@
+# OpenAI × Composio
+
+Runnable references for using Composio tools with OpenAI Chat Completions. The
+canonical examples use the unauthenticated `HACKERNEWS` toolkit, so no connected
+account is required.
+
+These examples double as tests: the package is typechecked and linted on every
+PR, and its smoke and agent entries run nightly against the staging backend.
+
+## Setup
+
+```bash
+pnpm install
+cp ts/examples/openai/.env.example ts/examples/openai/.env
+```
+
+Set `COMPOSIO_API_KEY` and `OPENAI_API_KEY` in `.env` before running an agent.
+
+## Canonical examples
+
+| File                 | What it shows                                                    | Run                                        |
+| -------------------- | ---------------------------------------------------------------- | ------------------------------------------ |
+| `src/index.ts`       | Direct tools with a bounded OpenAI function-calling loop         | `pnpm --filter openai-example start`       |
+| `src/tool-router.ts` | Tool Router tools executed through the session that created them | `pnpm --filter openai-example tool-router` |
+| `src/smoke.ts`       | Provider and Tool Router wrapping without an OpenAI request      | `pnpm --filter openai-example run smoke`   |
+| `src/cloudflare.ts`  | The Tool Router agent on the Cloudflare Workers runtime          | `pnpm --filter openai-example run cf:dev`  |
+
+The direct and Tool Router agents are separate modules under
+`src/hackernews-agent/`. Each loop is capped at ten model turns and rejects an
+empty final response.
+
+## Existing examples
+
+The existing Chat Completions, Responses API, OpenAI Agents SDK, and MCP
+experiments remain under `src/` and keep their existing package scripts.
+
+## Cloudflare Workers
+
+The Worker reads credentials from its `env` binding rather than `process.env`.
+Configure both secrets before deployment:
+
+```bash
+pnpm --filter openai-example exec wrangler secret put COMPOSIO_API_KEY
+pnpm --filter openai-example exec wrangler secret put OPENAI_API_KEY
+```
+
+CI validates the Worker bundle with `wrangler deploy --dry-run`.

--- a/ts/examples/openai/package.json
+++ b/ts/examples/openai/package.json
@@ -2,11 +2,19 @@
   "name": "openai-example",
   "private": true,
   "version": "0.1.10-alpha.0",
-  "description": "",
-  "main": "index.js",
+  "type": "module",
+  "description": "Runnable OpenAI examples for Composio tools and Tool Router",
+  "main": "src/index.ts",
   "scripts": {
     "clean": "git clean -xdf node_modules",
     "start": "bun src/index.ts",
+    "tool-router": "bun src/tool-router.ts",
+    "smoke": "bun src/smoke.ts",
+    "dev": "bun --watch src/index.ts",
+    "cf:dev": "wrangler dev",
+    "cf:dry-run": "wrangler deploy --dry-run --outdir dist-worker",
+    "typecheck": "tsc --noEmit -p ./tsconfig.json && tsc --noEmit -p ./tsconfig.worker.json",
+    "lint": "eslint src --ext .ts,.tsx",
     "start:chat-completion": "bun src/chat-completions.ts",
     "start:assistant": "bun src/assistants.ts",
     "start:agents": "bun src/agents-api/index.ts",
@@ -29,7 +37,9 @@
     "zod-to-json-schema": "catalog:"
   },
   "devDependencies": {
+    "@cloudflare/workers-types": "catalog:",
     "@types/bun": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "wrangler": "catalog:"
   }
 }

--- a/ts/examples/openai/src/agents-api/experiment.tool-router.ts
+++ b/ts/examples/openai/src/agents-api/experiment.tool-router.ts
@@ -13,9 +13,11 @@ const composio = new Composio({
 
 const externalUserId = 'default';
 
-// 2. Create an tool router session
+// 2. Create a tool router session.
+// HACKERNEWS is unauthenticated, so it works with the repository's shared
+// staging key without requiring a connected Gmail or GitHub account.
 const session = await composio.sessions.create(externalUserId, {
-  toolkits: ['gmail', 'github'],
+  toolkits: ['hackernews'],
   mcp: true,
 });
 
@@ -27,7 +29,7 @@ const tools: HostedMCPTool[] = [
     serverUrl: session.mcp.url,
     requireApproval: {
       never: {
-        toolNames: ['GMAIL_FETCH_EMAILS'],
+        toolNames: ['HACKERNEWS_GET_USER_BY_USERNAME'],
       },
     },
   }),
@@ -35,26 +37,25 @@ const tools: HostedMCPTool[] = [
 
 // 4. Pass tools to OpenAI-specific Agent.
 const agent = new OpenAIAgent({
-  name: 'Gmail Assistant',
+  name: 'HackerNews Assistant',
   instructions: `
-    You are a helpful Gmail assistant that fetches and summarizes emails.
-    When fetching emails, provide a clear summary of the results including sender, subject, and date.
-    Be concise and provide actionable information based on the email content.
+    You are a helpful HackerNews assistant that looks up user profiles.
+    Be concise and summarize the user's HackerNews profile clearly.
   `,
   model: 'gpt-4o-mini',
   tools: tools,
 });
 
 // 5. Execute the OpenAI-specific agent.
-// Fetch and summarize recent emails
-console.log('\n=== Fetching and Summarizing Recent Emails ===');
-const emailResponse = await run(
+// Fetch a HackerNews user profile.
+console.log('\n=== Fetching HackerNews User Profile ===');
+const response = await run(
   agent,
-  'Fetch the latest 2 emails and provide a detailed summary with sender, subject, date, and brief content overview for each email'
+  'Look up the HackerNews user `pg` and summarize their profile.'
 );
-console.log('\n📬 Email Summary:');
+console.log('\n📰 HackerNews Profile:');
 
-const output = emailResponse.output.filter(({ type }) => type === 'message').at(0);
+const output = response.output.filter(({ type }) => type === 'message').at(0);
 
 // @ts-ignore
 console.log(output?.content[0].text);

--- a/ts/examples/openai/src/agents-api/experiment.tool-router.ts
+++ b/ts/examples/openai/src/agents-api/experiment.tool-router.ts
@@ -14,8 +14,9 @@ const composio = new Composio({
 const externalUserId = 'default';
 
 // 2. Create an tool router session
-const mcpSession = await composio.experimental.toolRouter.createSession(externalUserId, {
-  toolkits: ["gmail", "github"],
+const session = await composio.sessions.create(externalUserId, {
+  toolkits: ['gmail', 'github'],
+  mcp: true,
 });
 
 // 3. Retrieve the MCP server instance for the tool router
@@ -23,7 +24,7 @@ const mcpSession = await composio.experimental.toolRouter.createSession(external
 const tools: HostedMCPTool[] = [
   hostedMcpTool({
     serverLabel: 'composio tool router',
-    serverUrl: mcpSession.url,
+    serverUrl: session.mcp.url,
     requireApproval: {
       never: {
         toolNames: ['GMAIL_FETCH_EMAILS'],

--- a/ts/examples/openai/src/cloudflare.ts
+++ b/ts/examples/openai/src/cloudflare.ts
@@ -1,0 +1,22 @@
+/**
+ * OpenAI × Composio — Cloudflare Workers
+ *
+ * Runs the same Tool Router agent path used by the Node entrypoint with
+ * credentials supplied through Worker bindings.
+ */
+import {
+  runToolRouterHackerNewsAgent,
+  type ToolRouterHackerNewsAgentEnvironment,
+} from './hackernews-agent/tool-router';
+
+export type Env = Required<ToolRouterHackerNewsAgentEnvironment>;
+
+export default {
+  async fetch(_request: Request, env: Env): Promise<Response> {
+    const text = await runToolRouterHackerNewsAgent(env);
+
+    return new Response(text, {
+      headers: { 'content-type': 'text/plain; charset=utf-8' },
+    });
+  },
+};

--- a/ts/examples/openai/src/hackernews-agent/direct.ts
+++ b/ts/examples/openai/src/hackernews-agent/direct.ts
@@ -1,0 +1,97 @@
+import { Composio } from '@composio/core';
+import { OpenAIProvider } from '@composio/openai';
+import OpenAI from 'openai';
+
+const MODEL = 'gpt-5-mini';
+const USER_ID = 'example-user';
+const MAX_STEPS = 10;
+
+interface DirectHackerNewsAgentEnvironment {
+  COMPOSIO_API_KEY?: string;
+  OPENAI_API_KEY?: string;
+}
+
+function requireKey(
+  env: DirectHackerNewsAgentEnvironment,
+  name: keyof DirectHackerNewsAgentEnvironment
+): string {
+  const value = env[name];
+  if (!value) {
+    throw new Error(`${name} is required to run the HackerNews agent.`);
+  }
+
+  return value;
+}
+
+export async function runDirectHackerNewsAgent(
+  env: DirectHackerNewsAgentEnvironment
+): Promise<string> {
+  const composioApiKey = requireKey(env, 'COMPOSIO_API_KEY');
+  const openaiApiKey = requireKey(env, 'OPENAI_API_KEY');
+  const openai = new OpenAI({
+    apiKey: openaiApiKey,
+    maxRetries: 1,
+    timeout: 60_000,
+  });
+  const composio = new Composio({
+    apiKey: composioApiKey,
+    provider: new OpenAIProvider(),
+  });
+  const tools = await composio.tools.get(USER_ID, 'HACKERNEWS_GET_USER_BY_USERNAME');
+  const messages: OpenAI.ChatCompletionMessageParam[] = [
+    {
+      role: 'system',
+      content: 'You are a helpful assistant that looks up HackerNews users.',
+    },
+    { role: 'user', content: 'Tell me about the HackerNews user `pg`.' },
+  ];
+  let hasSuccessfulToolExecution = false;
+
+  for (let step = 0; step < MAX_STEPS; step += 1) {
+    let toolChoice: 'auto' | 'required' = 'auto';
+    if (!hasSuccessfulToolExecution) {
+      toolChoice = 'required';
+    }
+
+    const response = await openai.chat.completions.create({
+      model: MODEL,
+      messages,
+      tools,
+      tool_choice: toolChoice,
+    });
+    const message = response.choices[0]?.message;
+    if (!message) {
+      throw new Error('OpenAI returned no assistant message.');
+    }
+
+    messages.push(message);
+    if (!message.tool_calls?.length) {
+      if (!hasSuccessfulToolExecution) {
+        throw new Error('Agent returned without successfully executing a Composio tool.');
+      }
+
+      const text = message.content?.trim();
+      if (!text) {
+        throw new Error('Agent returned empty output — expected a non-empty response.');
+      }
+      return text;
+    }
+
+    const toolMessages = await composio.provider.handleToolCalls(USER_ID, response, undefined, {
+      beforeExecute: ({ toolSlug, params }) => {
+        console.log(`🔧 executing ${toolSlug} with ${JSON.stringify(params.arguments)}`);
+        return params;
+      },
+      afterExecute: ({ toolSlug, result }) => {
+        if (result.successful) {
+          hasSuccessfulToolExecution = true;
+        }
+        console.log(`✅ ${toolSlug} finished`);
+        return result;
+      },
+    });
+    messages.push(...toolMessages);
+  }
+
+  throw new Error(`Agent exceeded the ${MAX_STEPS}-step tool-call budget.`);
+}

--- a/ts/examples/openai/src/hackernews-agent/tool-router.ts
+++ b/ts/examples/openai/src/hackernews-agent/tool-router.ts
@@ -1,0 +1,108 @@
+import { Composio, normalizeToolArguments } from '@composio/core';
+import { OpenAIProvider } from '@composio/openai';
+import OpenAI from 'openai';
+
+const MODEL = 'gpt-5-mini';
+const USER_ID = 'example-user';
+const MAX_STEPS = 10;
+
+export interface ToolRouterHackerNewsAgentEnvironment {
+  COMPOSIO_API_KEY?: string;
+  OPENAI_API_KEY?: string;
+}
+
+function requireKey(
+  env: ToolRouterHackerNewsAgentEnvironment,
+  name: keyof ToolRouterHackerNewsAgentEnvironment
+): string {
+  const value = env[name];
+  if (!value) {
+    throw new Error(`${name} is required to run the HackerNews agent.`);
+  }
+
+  return value;
+}
+
+export async function runToolRouterHackerNewsAgent(
+  env: ToolRouterHackerNewsAgentEnvironment
+): Promise<string> {
+  const composioApiKey = requireKey(env, 'COMPOSIO_API_KEY');
+  const openaiApiKey = requireKey(env, 'OPENAI_API_KEY');
+  const openai = new OpenAI({
+    apiKey: openaiApiKey,
+    maxRetries: 1,
+    timeout: 60_000,
+  });
+  const composio = new Composio({
+    apiKey: composioApiKey,
+    provider: new OpenAIProvider(),
+  });
+  const session = await composio.sessions.create(USER_ID, {
+    toolkits: ['hackernews'],
+  });
+  const tools = await session.tools();
+  const messages: OpenAI.ChatCompletionMessageParam[] = [
+    {
+      role: 'system',
+      content:
+        'You are a helpful assistant. Use the available Composio tools to search for and read HackerNews data before answering.',
+    },
+    {
+      role: 'user',
+      content: 'What are the current top 3 HackerNews stories? Give me their titles.',
+    },
+  ];
+  let hasSuccessfulToolExecution = false;
+
+  for (let step = 0; step < MAX_STEPS; step += 1) {
+    let toolChoice: 'auto' | 'required' = 'auto';
+    if (!hasSuccessfulToolExecution) {
+      toolChoice = 'required';
+    }
+
+    const response = await openai.chat.completions.create({
+      model: MODEL,
+      messages,
+      tools,
+      tool_choice: toolChoice,
+    });
+    const message = response.choices[0]?.message;
+    if (!message) {
+      throw new Error('OpenAI returned no assistant message.');
+    }
+
+    messages.push(message);
+    if (!message.tool_calls?.length) {
+      if (!hasSuccessfulToolExecution) {
+        throw new Error('Agent returned without successfully executing a Composio tool.');
+      }
+
+      const text = message.content?.trim();
+      if (!text) {
+        throw new Error('Agent returned empty output — expected a non-empty response.');
+      }
+      return text;
+    }
+
+    for (const toolCall of message.tool_calls) {
+      if (toolCall.type !== 'function') {
+        throw new Error(`Unsupported OpenAI tool call type: ${toolCall.type}`);
+      }
+
+      const result = await session.execute(
+        toolCall.function.name,
+        normalizeToolArguments(toolCall.function.arguments, toolCall.function.name)
+      );
+      if (!result.error) {
+        hasSuccessfulToolExecution = true;
+      }
+      messages.push({
+        role: 'tool',
+        tool_call_id: toolCall.id,
+        content: JSON.stringify(result),
+      });
+    }
+  }
+
+  throw new Error(`Agent exceeded the ${MAX_STEPS}-step tool-call budget.`);
+}

--- a/ts/examples/openai/src/index.ts
+++ b/ts/examples/openai/src/index.ts
@@ -1,58 +1,21 @@
-import { Composio } from '@composio/core';
-import { OpenAI } from 'openai';
-
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-});
-
 /**
- * Initialize Composio
- * OpenAI Provider is automatically installed and initialized
+ * OpenAI × Composio — direct tools
+ *
+ * Fetches a Composio tool in OpenAI function-calling format and runs a bounded
+ * Chat Completions tool loop.
+ *
+ * Prerequisites:
+ *   - COMPOSIO_API_KEY   (https://app.composio.dev)
+ *   - OPENAI_API_KEY
+ *
+ * Run:
+ *   bun ts/examples/openai/src/index.ts
  */
-const composio = new Composio({
-  apiKey: process.env.COMPOSIO_API_KEY,
-});
+import 'dotenv/config';
 
-/**
- * Get the tools
- * This tool is automatically typed and wrapped with the OpenAI Provider
- */
-const tools = await composio.tools.get('default', 'HACKERNEWS_GET_USER');
-/**
- * Define a task for the assistant based on the tools in hand
- */
-const task = "Fetch the details of the user 'haxzie'";
+import { runDirectHackerNewsAgent } from './hackernews-agent/direct';
 
-/**
- * Define the messages for the assistant
- */
-const messages: OpenAI.ChatCompletionMessageParam[] = [
-  { role: 'system', content: 'You are a helpful assistant that can help with tasks.' },
-  { role: 'user', content: task },
-];
+const text = await runDirectHackerNewsAgent(process.env);
 
-/**
- * Create a chat completion
- */
-const response = await openai.chat.completions.create({
-  model: 'gpt-4o-mini',
-  messages,
-  tools: tools,
-  tool_choice: 'auto',
-});
-
-/**
- * If the assistant has tool calls, execute them and log the result
- */
-if (
-  response.choices[0].message.tool_calls &&
-  response.choices[0].message.tool_calls[0].type === 'function'
-) {
-  console.log(JSON.stringify(response, null, 2));
-  const toolCall = response.choices[0].message.tool_calls[0];
-  if (toolCall.type === 'function') {
-    console.log(`✅ Calling tool ${response.choices[0].message.tool_calls[0].function.name}`);
-  }
-  const result = await composio.provider.handleToolCalls('default', response);
-  console.log(result);
-}
+console.log('\n🤖 Agent response:\n');
+console.log(text);

--- a/ts/examples/openai/src/responses-api/index.ts
+++ b/ts/examples/openai/src/responses-api/index.ts
@@ -41,7 +41,8 @@ console.log(`🔄 Submitting tool outputs to OpenAI...`);
 console.log(JSON.stringify(modelInputs, null, 2));
 const finalResponse = await openai.responses.create({
   model: 'gpt-4.1',
-  input: [...initialResponse.output, ...modelInputs],
+  previous_response_id: initialResponse.id,
+  input: modelInputs,
   tools,
 });
 

--- a/ts/examples/openai/src/smoke.ts
+++ b/ts/examples/openai/src/smoke.ts
@@ -1,0 +1,68 @@
+/**
+ * Deterministic smoke test for the OpenAI example.
+ *
+ * Exercises direct provider wrapping and Tool Router session wrapping against
+ * a real backend without making an LLM request. It needs only
+ * COMPOSIO_API_KEY and skips cleanly when that key is absent.
+ *
+ * Run: bun ts/examples/openai/src/smoke.ts
+ */
+import { Composio } from '@composio/core';
+import { OpenAIProvider } from '@composio/openai';
+import type OpenAI from 'openai';
+import 'dotenv/config';
+
+const TOOLKIT = 'hackernews';
+const USER_ID = 'examples-smoke';
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(`SMOKE FAIL: ${message}`);
+  }
+}
+
+function assertJsonSerializable(value: unknown, source: string): void {
+  try {
+    JSON.stringify(value);
+  } catch {
+    throw new Error(`SMOKE FAIL: ${source} is not JSON-serializable`);
+  }
+}
+
+function assertOpenAITools(
+  tools: unknown,
+  source: string
+): asserts tools is OpenAI.ChatCompletionTool[] {
+  assert(Array.isArray(tools), `${source} did not return an array`);
+  assert(tools.length > 0, `${source} returned 0 tools`);
+
+  for (const tool of tools) {
+    assert(tool.type === 'function', `${source} returned a non-function tool`);
+    assert(tool.function.name.length > 0, `${source} returned a tool without a name`);
+    assert(tool.function.parameters != null, `${source} tool ${tool.function.name} has no schema`);
+    assertJsonSerializable(tool.function.parameters, `${source} tool ${tool.function.name} schema`);
+  }
+}
+
+if (!process.env.COMPOSIO_API_KEY) {
+  console.log('⏭️  COMPOSIO_API_KEY not set — skipping OpenAI smoke.');
+  process.exit(0);
+}
+
+console.log(`Backend: ${process.env.COMPOSIO_BASE_URL ?? '(default/production)'}`);
+
+const composio = new Composio({
+  apiKey: process.env.COMPOSIO_API_KEY,
+  provider: new OpenAIProvider(),
+});
+
+const wrapped = await composio.tools.get(USER_ID, { toolkits: [TOOLKIT] });
+assertOpenAITools(wrapped, 'openai direct wrapping');
+console.log(`  ✓ direct wrapping: ${wrapped.length} tools`);
+
+const session = await composio.sessions.create(USER_ID, { toolkits: [TOOLKIT] });
+const sessionTools = await session.tools();
+assertOpenAITools(sessionTools, 'openai session.tools()');
+console.log(`  ✓ tool-router session: ${sessionTools.length} tools`);
+
+console.log('\n✅ OpenAI smoke passed.');

--- a/ts/examples/openai/src/tool-router.ts
+++ b/ts/examples/openai/src/tool-router.ts
@@ -1,0 +1,21 @@
+/**
+ * OpenAI × Composio — Tool Router
+ *
+ * Creates a HackerNews-scoped session, gives the session's router tools to
+ * OpenAI, and executes every model-requested tool through that same session.
+ *
+ * Prerequisites:
+ *   - COMPOSIO_API_KEY   (https://app.composio.dev)
+ *   - OPENAI_API_KEY
+ *
+ * Run:
+ *   bun ts/examples/openai/src/tool-router.ts
+ */
+import 'dotenv/config';
+
+import { runToolRouterHackerNewsAgent } from './hackernews-agent/tool-router';
+
+const text = await runToolRouterHackerNewsAgent(process.env);
+
+console.log('\n🤖 Agent response:\n');
+console.log(text);

--- a/ts/examples/openai/tsconfig.json
+++ b/ts/examples/openai/tsconfig.json
@@ -12,5 +12,6 @@
     "moduleResolution": "bundler",
     "skipLibCheck": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/cloudflare.ts"]
 }

--- a/ts/examples/openai/tsconfig.worker.json
+++ b/ts/examples/openai/tsconfig.worker.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["es2022"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["src/cloudflare.ts"]
+}

--- a/ts/examples/openai/wrangler.jsonc
+++ b/ts/examples/openai/wrangler.jsonc
@@ -1,0 +1,20 @@
+/**
+ * Wrangler config for the OpenAI × Composio Workers example.
+ * https://developers.cloudflare.com/workers/wrangler/configuration/
+ */
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "openai-composio-example",
+  "main": "src/cloudflare.ts",
+  "compatibility_date": "2025-06-20",
+  "compatibility_flags": ["nodejs_compat"],
+  "observability": {
+    "enabled": true,
+  },
+  /**
+   * COMPOSIO_API_KEY and OPENAI_API_KEY are provided as Worker secrets, not
+   * committed here:
+   *   wrangler secret put COMPOSIO_API_KEY
+   *   wrangler secret put OPENAI_API_KEY
+   */
+}


### PR DESCRIPTION
This PR:

- builds on top of https://github.com/ComposioHQ/composio/pull/3790
- makes the OpenAI example executable in direct-tools, Tool Router, smoke, and Cloudflare Workers modes
- keeps direct and Tool Router agents in separate files so each execution model is explicit and readable
- requires a successful Composio tool execution before either agent can accept a final model response
- adds OpenAI to the nightly staging matrix without weakening the existing Mastra coverage
- updates two stale experimental OpenAI usages so the complete example package typechecks against current SDK APIs

## Testing

- `pnpm --filter openai-example run typecheck`
- `pnpm --filter openai-example run lint` (0 errors; 4 pre-existing warnings)
- `pnpm --filter openai-example run smoke` (staging: 5 direct tools and 6 Tool Router tools)
- `pnpm --filter openai-example run cf:dry-run`
- `pnpm run typecheck`
- `./node_modules/.bin/eslint ts/packages --ext .ts,.tsx`
- `pnpm run typecheck:examples`
- `pnpm run lint:examples`
- `pnpm exec turbo cf:dry-run --filter='./ts/examples/*'`
- [branch nightly](https://github.com/ComposioHQ/composio/actions/runs/29079263571): OpenAI and Mastra both passed smoke, direct-tools, and Tool Router against staging

## Post-deploy validation

- dispatch `ts.examples-nightly.yml` on `next` after merge and confirm both matrix legs stay green
- healthy runs finish within the 20-minute job budget and log successful tool-backed responses for both agent modes
- revert this PR if the OpenAI leg blocks the nightly; examples maintainers own the first post-merge run and the next 06:00 UTC schedule

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
