### PR TITLE
docs: package-manager picker for install commands

### DIFF
--- a/docs/components/package-install.tsx
+++ b/docs/components/package-install.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Check, Clipboard } from 'lucide-react';
+import { CodeBlock, Pre } from 'fumadocs-ui/components/codeblock';
+import { cn } from '@/lib/utils';
+
+const ECOSYSTEMS = {
+  node: [
+    { id: 'npm', install: 'npm install' },
+    { id: 'pnpm', install: 'pnpm add' },
+    { id: 'bun', install: 'bun add' },
+    { id: 'yarn', install: 'yarn add' },
+  ],
+  python: [
+    { id: 'uv', install: 'uv add' },
+    { id: 'pip', install: 'pip install' },
+  ],
+} as const;
+
+type Ecosystem = keyof typeof ECOSYSTEMS;
+
+/**
+ * Install-command code block whose copy button is a package-manager picker.
+ *
+ * Renders the first manager's command by default (`npm install …` for node,
+ * `uv add …` for python). The copy button opens a menu of managers; selecting
+ * one rewrites the displayed command for that manager and copies it. Comment
+ * lines are display-only and never copied.
+ *
+ * The menu is portaled to `document.body`: ancestors (fumadocs `Tabs`, the
+ * `CodeBlock` figure) clip overflow, and the actions container's
+ * `backdrop-blur` would make it the containing block for `position: fixed`.
+ */
+export function PackageInstall({
+  packages,
+  comment,
+  ecosystem = 'node',
+}: {
+  /** Space-separated package names, e.g. "@composio/core @openai/agents" */
+  packages: string;
+  /** Display-only `#` comment line(s) shown below the command; excluded from copy */
+  comment?: string | string[];
+  /** Which package managers to offer; defaults to node (npm/pnpm/bun/yarn) */
+  ecosystem?: Ecosystem;
+}) {
+  const managers = ECOSYSTEMS[ecosystem];
+  const [manager, setManager] = useState<string>(managers[0].id);
+  const [open, setOpen] = useState(false);
+  const [position, setPosition] = useState<{ top: number; left: number } | null>(null);
+  const [copied, setCopied] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const anchorRect = useRef<DOMRect | null>(null);
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  const toggle = () => {
+    if (open) {
+      setOpen(false);
+      return;
+    }
+    const rect = triggerRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    anchorRect.current = rect;
+    // Page coordinates; the menu is right-aligned to the trigger via -translate-x-full.
+    setPosition({ top: rect.bottom + window.scrollY + 4, left: rect.right + window.scrollX });
+    setOpen(true);
+  };
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (event: PointerEvent) => {
+      const target = event.target as Node;
+      if (!triggerRef.current?.contains(target) && !menuRef.current?.contains(target)) {
+        setOpen(false);
+      }
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpen(false);
+    };
+    // Close only when the trigger actually moved in the viewport (the menu is
+    // positioned in page coordinates); ignore spurious scroll events.
+    const onScrollOrResize = () => {
+      const rect = triggerRef.current?.getBoundingClientRect();
+      const anchor = anchorRect.current;
+      if (!rect || !anchor) return setOpen(false);
+      if (Math.abs(rect.top - anchor.top) > 1 || Math.abs(rect.left - anchor.left) > 1) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('pointerdown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    window.addEventListener('scroll', onScrollOrResize, true);
+    window.addEventListener('resize', onScrollOrResize);
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('scroll', onScrollOrResize, true);
+      window.removeEventListener('resize', onScrollOrResize);
+    };
+  }, [open]);
+
+  useEffect(() => () => clearTimeout(resetTimer.current), []);
+
+  const commandFor = (id: string) =>
+    `${managers.find((m) => m.id === id)?.install ?? managers[0].install} ${packages}`;
+
+  const select = async (id: string) => {
+    setManager(id);
+    setOpen(false);
+    try {
+      await navigator.clipboard.writeText(commandFor(id));
+      setCopied(true);
+      clearTimeout(resetTimer.current);
+      resetTimer.current = setTimeout(() => setCopied(false), 1600);
+    } catch {
+      // clipboard unavailable (e.g. insecure context); selection still applies
+    }
+  };
+
+  const comments = comment == null ? [] : Array.isArray(comment) ? comment : [comment];
+
+  return (
+    <CodeBlock
+      allowCopy={false}
+      Actions={({ className }) => (
+        <div className={className}>
+          <button
+            ref={triggerRef}
+            type="button"
+            aria-haspopup="menu"
+            aria-expanded={open}
+            aria-label={copied ? 'Copied install command' : 'Copy install command'}
+            data-checked={copied || undefined}
+            className="inline-flex items-center justify-center rounded-lg p-1.5 transition-colors hover:text-fd-accent-foreground data-checked:text-fd-accent-foreground [&_svg]:size-3.5"
+            onClick={toggle}
+          >
+            {copied ? <Check /> : <Clipboard />}
+          </button>
+          {open &&
+            position &&
+            createPortal(
+              <div
+                ref={menuRef}
+                role="menu"
+                style={{ top: position.top, left: position.left }}
+                className="absolute z-50 min-w-24 -translate-x-full rounded-lg border bg-fd-popover p-1 text-sm shadow-md"
+              >
+                {managers.map((m) => (
+                  <button
+                    key={m.id}
+                    type="button"
+                    role="menuitemradio"
+                    aria-checked={manager === m.id}
+                    className={cn(
+                      'flex w-full items-center rounded-md px-3 py-1.5 text-fd-popover-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground',
+                      manager === m.id && 'font-medium text-fd-primary',
+                    )}
+                    onClick={() => void select(m.id)}
+                  >
+                    {m.id}
+                  </button>
+                ))}
+              </div>,
+              document.body,
+            )}
+        </div>
+      )}
+    >
+      {/* No horizontal padding here: `.line` spans already carry it via shiki.css */}
+      <Pre>
+        <code>
+          <span className="line">{commandFor(manager)}</span>
+          {comments.map((line) => (
+            <span
+              key={line}
+              className="line"
+              // Inline style: fumadocs' `.shiki code span { color: var(--shiki-light) }`
+              // out-specifies Tailwind utilities, so `text-fd-muted-foreground` loses.
+              style={{ color: 'var(--color-fd-muted-foreground)' }}
+            >
+              {`# ${line}`}
+            </span>
+          ))}
+        </code>
+      </Pre>
+    </CodeBlock>
+  );
+}

--- a/docs/content/docs/extending-sessions/custom-tools-and-toolkits.mdx
+++ b/docs/content/docs/extending-sessions/custom-tools-and-toolkits.mdx
@@ -24,14 +24,10 @@ Custom tools let you define tools that run in-process alongside remote Composio 
 
 <Tabs groupId="language" items={['TypeScript', 'Python']} persist>
 <Tab value="TypeScript">
-```bash
-npm install @composio/core zod
-```
+<PackageInstall packages="@composio/core zod" />
 </Tab>
 <Tab value="Python">
-```bash
-pip install composio
-```
+<PackageInstall ecosystem="python" packages="composio" />
 </Tab>
 </Tabs>
 </Step>
@@ -173,14 +169,10 @@ tools = session.tools()
 
 <Tabs groupId="language" items={['TypeScript', 'Python']} persist>
 <Tab value="TypeScript">
-```bash
-npm install @composio/core zod
-```
+<PackageInstall packages="@composio/core zod" />
 </Tab>
 <Tab value="Python">
-```bash
-pip install composio
-```
+<PackageInstall ecosystem="python" packages="composio" />
 </Tab>
 </Tabs>
 </Step>
@@ -341,14 +333,10 @@ tools = session.tools()
 
 <Tabs groupId="language" items={['TypeScript', 'Python']} persist>
 <Tab value="TypeScript">
-```bash
-npm install @composio/core zod
-```
+<PackageInstall packages="@composio/core zod" />
 </Tab>
 <Tab value="Python">
-```bash
-pip install composio
-```
+<PackageInstall ecosystem="python" packages="composio" />
 </Tab>
 </Tabs>
 </Step>

--- a/docs/content/docs/migration-guide/new-sdk.mdx
+++ b/docs/content/docs/migration-guide/new-sdk.mdx
@@ -76,9 +76,7 @@ pip install -U composio
 ```
   </Tab>
   <Tab value="TypeScript">
-```bash
-npm install @composio/core
-```
+<PackageInstall packages="@composio/core" />
   </Tab>
 </Tabs>
 

--- a/docs/content/docs/migration-guide/tool-router-beta.mdx
+++ b/docs/content/docs/migration-guide/tool-router-beta.mdx
@@ -25,9 +25,7 @@ pip install --upgrade composio
 ```
 </Tab>
 <Tab value="TypeScript">
-```bash
-npm install @composio/core@latest
-```
+<PackageInstall packages="@composio/core@latest" />
 </Tab>
 </Tabs>
 </Step>

--- a/docs/content/docs/providers/anthropic.mdx
+++ b/docs/content/docs/providers/anthropic.mdx
@@ -26,14 +26,10 @@ The `AnthropicProvider` transforms Composio tools into the format the Claude Mes
 
 <Tabs groupId="language" items={["Python", "TypeScript"]} persist>
 <Tab value="Python">
-```bash
-pip install composio composio_anthropic anthropic
-```
+<PackageInstall ecosystem="python" packages="composio composio_anthropic anthropic" />
 </Tab>
 <Tab value="TypeScript">
-```bash
-npm install @composio/core @composio/anthropic @anthropic-ai/sdk
-```
+<PackageInstall packages="@composio/core @composio/anthropic @anthropic-ai/sdk" />
 </Tab>
 </Tabs>
 </Step>
@@ -175,14 +171,10 @@ The `ClaudeAgentSDKProvider` exposes your Composio tools to the Claude Agent SDK
 
 <Tabs groupId="language" items={["Python", "TypeScript"]} persist>
 <Tab value="Python">
-```bash
-pip install composio composio_claude_agent_sdk claude-agent-sdk
-```
+<PackageInstall ecosystem="python" packages="composio composio_claude_agent_sdk claude-agent-sdk" />
 </Tab>
 <Tab value="TypeScript">
-```bash
-npm install @composio/core @composio/claude-agent-sdk @anthropic-ai/claude-agent-sdk
-```
+<PackageInstall packages="@composio/core @composio/claude-agent-sdk @anthropic-ai/claude-agent-sdk" />
 </Tab>
 </Tabs>
 </Step>

--- a/docs/content/docs/providers/autogen.mdx
+++ b/docs/content/docs/providers/autogen.mdx
@@ -10,9 +10,7 @@ The AutoGen provider turns Composio tools into AutoGen [`FunctionTool`](https://
 <Step>
 **Install**
 
-```bash
-pip install composio composio_autogen autogen-agentchat
-```
+<PackageInstall ecosystem="python" packages="composio composio_autogen autogen-agentchat" />
 </Step>
 
 <Step>

--- a/docs/content/docs/providers/crewai.mdx
+++ b/docs/content/docs/providers/crewai.mdx
@@ -10,9 +10,7 @@ The CrewAI provider turns Composio tools into CrewAI [`BaseTool`](https://docs.c
 <Step>
 **Install**
 
-```bash
-pip install composio composio_crewai crewai
-```
+<PackageInstall ecosystem="python" packages="composio composio_crewai crewai" />
 </Step>
 
 <Step>

--- a/docs/content/docs/providers/google.mdx
+++ b/docs/content/docs/providers/google.mdx
@@ -21,14 +21,10 @@ The Google Generative AI provider transforms Composio tools into Gemini function
 
 <Tabs groupId="language" items={["Python", "TypeScript"]} persist>
 <Tab value="Python">
-```bash
-pip install composio composio_google google-genai
-```
+<PackageInstall ecosystem="python" packages="composio composio_google google-genai" />
 </Tab>
 <Tab value="TypeScript">
-```bash
-npm install @composio/core @composio/google @google/genai
-```
+<PackageInstall packages="@composio/core @composio/google @google/genai" />
 </Tab>
 </Tabs>
 </Step>
@@ -141,9 +137,7 @@ The Google ADK provider transforms Composio tools into ADK's `FunctionTool` form
 <Step>
 **Install**
 
-```bash
-pip install composio composio_google_adk google-adk
-```
+<PackageInstall ecosystem="python" packages="composio composio_google_adk google-adk" />
 </Step>
 
 <Step>

--- a/docs/content/docs/providers/langchain.mdx
+++ b/docs/content/docs/providers/langchain.mdx
@@ -21,14 +21,10 @@ The LangChain provider transforms each Composio tool into a LangChain [`DynamicS
 
 <Tabs groupId="language" items={["Python", "TypeScript"]} persist>
 <Tab value="Python">
-```bash
-pip install composio composio_langchain langchain langchain_openai
-```
+<PackageInstall ecosystem="python" packages="composio composio_langchain langchain langchain_openai" />
 </Tab>
 <Tab value="TypeScript">
-```bash
-npm install @composio/core @composio/langchain @langchain/openai @langchain/langgraph @langchain/core
-```
+<PackageInstall packages="@composio/core @composio/langchain @langchain/openai @langchain/langgraph @langchain/core" />
 </Tab>
 </Tabs>
 </Step>
@@ -136,9 +132,7 @@ The LangGraph provider transforms Composio tools into the same LangChain `Dynami
 <Step>
 **Install**
 
-```bash
-pip install composio composio_langgraph langgraph langchain_openai
-```
+<PackageInstall ecosystem="python" packages="composio composio_langgraph langgraph langchain_openai" />
 </Step>
 
 <Step>

--- a/docs/content/docs/providers/llamaindex.mdx
+++ b/docs/content/docs/providers/llamaindex.mdx
@@ -12,14 +12,10 @@ The LlamaIndex provider turns Composio tools into LlamaIndex [`FunctionTool`](ht
 
 <Tabs groupId="language" items={["Python", "TypeScript"]} persist>
 <Tab value="Python">
-```bash
-pip install composio composio_llamaindex llama-index llama-index-llms-openai
-```
+<PackageInstall ecosystem="python" packages="composio composio_llamaindex llama-index llama-index-llms-openai" />
 </Tab>
 <Tab value="TypeScript">
-```bash
-npm install @composio/core @composio/llamaindex @llamaindex/openai @llamaindex/workflow
-```
+<PackageInstall packages="@composio/core @composio/llamaindex @llamaindex/openai @llamaindex/workflow" />
 </Tab>
 </Tabs>
 </Step>

--- a/docs/content/docs/providers/mastra.mdx
+++ b/docs/content/docs/providers/mastra.mdx
@@ -10,9 +10,7 @@ The Mastra provider transforms Composio tools into [Mastra's tool format](https:
 <Step>
 **Install**
 
-```bash
-npm install @composio/core @composio/mastra @mastra/core @ai-sdk/openai
-```
+<PackageInstall packages="@composio/core @composio/mastra @mastra/core @ai-sdk/openai" />
 </Step>
 
 <Step>

--- a/docs/content/docs/providers/openai.mdx
+++ b/docs/content/docs/providers/openai.mdx
@@ -28,14 +28,10 @@ The `OpenAIResponsesProvider` transforms Composio tools into OpenAI's function-c
 
 <Tabs groupId="language" items={["Python", "TypeScript"]} persist>
 <Tab value="Python">
-```bash
-pip install composio composio_openai openai
-```
+<PackageInstall ecosystem="python" packages="composio composio_openai openai" />
 </Tab>
 <Tab value="TypeScript">
-```bash
-npm install @composio/core @composio/openai openai
-```
+<PackageInstall packages="@composio/core @composio/openai openai" />
 </Tab>
 </Tabs>
 </Step>
@@ -176,14 +172,10 @@ The `OpenAIProvider` targets the Chat Completions API and is the default provide
 
 <Tabs groupId="language" items={["Python", "TypeScript"]} persist>
 <Tab value="Python">
-```bash
-pip install composio composio_openai openai
-```
+<PackageInstall ecosystem="python" packages="composio composio_openai openai" />
 </Tab>
 <Tab value="TypeScript">
-```bash
-npm install @composio/core @composio/openai openai
-```
+<PackageInstall packages="@composio/core @composio/openai openai" />
 </Tab>
 </Tabs>
 </Step>
@@ -314,14 +306,10 @@ The `OpenAIAgentsProvider` transforms Composio tools into the Agents SDK tool fo
 
 <Tabs groupId="language" items={["Python", "TypeScript"]} persist>
 <Tab value="Python">
-```bash
-pip install composio composio-openai-agents openai-agents
-```
+<PackageInstall ecosystem="python" packages="composio composio-openai-agents openai-agents" />
 </Tab>
 <Tab value="TypeScript">
-```bash
-npm install @composio/core @composio/openai-agents @openai/agents
-```
+<PackageInstall packages="@composio/core @composio/openai-agents @openai/agents" />
 </Tab>
 </Tabs>
 </Step>

--- a/docs/content/docs/providers/pi.mdx
+++ b/docs/content/docs/providers/pi.mdx
@@ -19,9 +19,7 @@ For most Pi apps, expose the dynamic helper tools. They let the model discover e
 <Step>
 **Install**
 
-```bash
-npm install @composio/core @composio/experimental @earendil-works/pi-coding-agent
-```
+<PackageInstall packages="@composio/core @composio/experimental @earendil-works/pi-coding-agent" />
 
 </Step>
 

--- a/docs/content/docs/providers/vercel.mdx
+++ b/docs/content/docs/providers/vercel.mdx
@@ -10,9 +10,7 @@ The Vercel AI SDK provider transforms Composio tools into Vercel's [tool format]
 <Step>
 **Install**
 
-```bash
-npm install @composio/core @composio/vercel ai @ai-sdk/anthropic
-```
+<PackageInstall packages="@composio/core @composio/vercel ai @ai-sdk/anthropic" />
 </Step>
 
 <Step>

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -16,14 +16,17 @@ Build your first AI agent with Composio Tools. You'll create a [session](/docs/h
 
 <Tabs groupId="language" items={['Python', 'TypeScript']} persist>
 <Tab value="Python">
-```bash
-pip install python-dotenv composio composio-openai-agents openai-agents
-```
+<PackageInstall ecosystem="python" packages="python-dotenv composio composio-openai-agents openai-agents" />
 </Tab>
 <Tab value="TypeScript">
-```bash
-npm install @composio/core @composio/openai-agents @openai/agents
-```
+<PackageInstall
+  packages="@composio/core @composio/openai-agents @openai/agents"
+  comment={[
+    '@composio/core ships its docs and TypeScript source in the package,',
+    'so it is inspectable to coding agents.',
+    'Use @composio/slim for a smaller install with the same API.',
+  ]}
+/>
 </Tab>
 </Tabs>
 </Step>
@@ -159,14 +162,17 @@ readline.close();
 
 <Tabs groupId="language" items={['Python', 'TypeScript']} persist>
 <Tab value="Python">
-```bash
-pip install python-dotenv composio composio-claude-agent-sdk claude-agent-sdk
-```
+<PackageInstall ecosystem="python" packages="python-dotenv composio composio-claude-agent-sdk claude-agent-sdk" />
 </Tab>
 <Tab value="TypeScript">
-```bash
-npm install dotenv @composio/core @composio/claude-agent-sdk @anthropic-ai/claude-agent-sdk
-```
+<PackageInstall
+  packages="dotenv @composio/core @composio/claude-agent-sdk @anthropic-ai/claude-agent-sdk"
+  comment={[
+    '@composio/core ships its docs and TypeScript source in the package,',
+    'so it is inspectable to coding agents.',
+    'Use @composio/slim for a smaller install with the same API.',
+  ]}
+/>
 </Tab>
 </Tabs>
 </Step>
@@ -324,9 +330,14 @@ readline.close();
 <Step>
 <StepTitle>Install</StepTitle>
 
-```bash
-npm install @composio/core @composio/vercel ai @ai-sdk/anthropic
-```
+<PackageInstall
+  packages="@composio/core @composio/vercel ai @ai-sdk/anthropic"
+  comment={[
+    '@composio/core ships its docs and TypeScript source in the package,',
+    'so it is inspectable to coding agents.',
+    'Use @composio/slim for a smaller install with the same API.',
+  ]}
+/>
 </Step>
 
 <Step>

--- a/docs/content/docs/single-toolkit-mcp.mdx
+++ b/docs/content/docs/single-toolkit-mcp.mdx
@@ -13,14 +13,10 @@ For most use cases, use a regular [session](/docs/configuring-sessions) instead.
 
 <Tabs groupId="language" items={['Python', 'TypeScript']} persist>
   <Tab value="Python">
-```bash
-pip install composio
-```
+<PackageInstall ecosystem="python" packages="composio" />
   </Tab>
   <Tab value="TypeScript">
-```bash
-npm install @composio/core
-```
+<PackageInstall packages="@composio/core" />
   </Tab>
 </Tabs>
 

--- a/docs/content/examples/standup-slackbot.mdx
+++ b/docs/content/examples/standup-slackbot.mdx
@@ -53,9 +53,7 @@ The Slack bot itself follows a deterministic flow: the same menu every day. When
 
 You need a [Composio API key](https://dashboard.composio.dev/~/project/settings/api-keys), a Slack workspace you can install an app into, and Node with [tsx](https://nodejs.org). The finished bot deploys to [Vercel](https://vercel.com) as two serverless functions, a cron and an interactivity handler, so there's no long-running server.
 
-```bash
-npm install @composio/core @composio/vercel ai dayjs
-```
+<PackageInstall packages="@composio/core @composio/vercel ai dayjs" />
 
 ## Make your custom Slack bot
 

--- a/docs/content/reference/sdk-reference/python/index.mdx
+++ b/docs/content/reference/sdk-reference/python/index.mdx
@@ -9,15 +9,7 @@ Complete API reference for the `composio` Python package.
 
 ## Installation
 
-```bash
-pip install composio
-```
-
-Or with uv:
-
-```bash
-uv add composio
-```
+<PackageInstall ecosystem="python" packages="composio" />
 
 ## Classes
 

--- a/docs/content/reference/sdk-reference/typescript/index.mdx
+++ b/docs/content/reference/sdk-reference/typescript/index.mdx
@@ -5,28 +5,7 @@ description: "Complete API reference for the Composio TypeScript SDK (@composio/
 
 ## Installation
 
-<Tabs groupId="package-manager" items={['npm', 'pnpm', 'yarn', 'bun']} persist>
-<Tab value="npm">
-```bash
-npm install @composio/core
-```
-</Tab>
-<Tab value="pnpm">
-```bash
-pnpm add @composio/core
-```
-</Tab>
-<Tab value="yarn">
-```bash
-yarn add @composio/core
-```
-</Tab>
-<Tab value="bun">
-```bash
-bun add @composio/core
-```
-</Tab>
-</Tabs>
+<PackageInstall packages="@composio/core" />
 
 ## Classes
 

--- a/docs/mdx-components.tsx
+++ b/docs/mdx-components.tsx
@@ -45,6 +45,7 @@ import { ApiEndpointsTable } from '@/components/api-endpoints-table';
 import { ClaudeMockUI } from '@/components/claude-mock-ui';
 import { InChatAuthTerminal } from '@/components/in-chat-auth-terminal';
 import { MediaSplit } from '@/components/media-split';
+import { PackageInstall } from '@/components/package-install';
 import { ManageConnectionsVisual } from '@/components/manage-connections-visual';
 import { ConnectionRefreshVisual } from '@/components/connection-refresh-visual';
 import {
@@ -143,6 +144,7 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     ClaudeMockUI,
     InChatAuthTerminal,
     MediaSplit,
+    PackageInstall,
     ManageConnectionsVisual,
     ConnectionRefreshVisual,
     // Lucide icons

--- a/python/scripts/generate-docs.py
+++ b/python/scripts/generate-docs.py
@@ -528,15 +528,7 @@ Complete API reference for the `composio` Python package.
 
 ## Installation
 
-```bash
-pip install composio
-```
-
-Or with uv:
-
-```bash
-uv add composio
-```
+<PackageInstall ecosystem="python" packages="composio" />
 
 ## Classes
 

--- a/ts/packages/core/scripts/generate-docs.ts
+++ b/ts/packages/core/scripts/generate-docs.ts
@@ -1220,28 +1220,7 @@ description: ${formatYamlFrontmatterString('Complete API reference for the Compo
 
 ## Installation
 
-<Tabs groupId="package-manager" items={['npm', 'pnpm', 'yarn', 'bun']} persist>
-<Tab value="npm">
-\`\`\`bash
-npm install @composio/core
-\`\`\`
-</Tab>
-<Tab value="pnpm">
-\`\`\`bash
-pnpm add @composio/core
-\`\`\`
-</Tab>
-<Tab value="yarn">
-\`\`\`bash
-yarn add @composio/core
-\`\`\`
-</Tab>
-<Tab value="bun">
-\`\`\`bash
-bun add @composio/core
-\`\`\`
-</Tab>
-</Tabs>
+<PackageInstall packages="@composio/core" />
 
 ## Classes
 


### PR DESCRIPTION
## What

Two changes to the docs install experience:

**1. Package-manager picker on install code blocks.** New `PackageInstall` client component (`docs/components/package-install.tsx`): the code block's copy button opens a dropdown of package managers. Selecting one rewrites the displayed command and copies it to the clipboard.

- TypeScript blocks: npm (default, `npm install`) / pnpm / bun / yarn (`<pm> add`)
- Python blocks: uv (default, `uv add`) / pip (`pip install`)
- The menu is portaled to `document.body` so it isn't clipped by the `Tabs`/`CodeBlock` overflow containers, and closes on outside click, Escape, or real scroll movement.

**2. `@composio/slim` callout in the quickstart.** The quickstart TypeScript install blocks carry display-only `#` comment lines noting that `@composio/core` ships its docs and TypeScript source in the package (inspectable to coding agents) and that `@composio/slim` is the smaller install with the same API. Comment lines are rendered muted and are **never copied** — the picker copies only the command.

## Where

Converted every plain `npm install` / `pip install` code block under `docs/content` (quickstart, all provider pages, single-toolkit MCP, custom tools, migration guides, standup example, SDK reference indexes). The TS reference index's manual npm/pnpm/yarn/bun tabs collapse into one picker. The two SDK-reference generators (`ts/packages/core/scripts/generate-docs.ts`, `python/scripts/generate-docs.py`) emit the new component so regeneration keeps it. Flagged upgrade commands (`pip install -U/--upgrade`) and the bun-first examples were left as-is.

## Verification

- `bun run types:check` — pass
- `bun run build` — pass
- `eslint` on touched TS files — clean (remaining repo lint errors are pre-existing on `next`)
- Visual check via dev server + browser: comment lines render muted below the command, picker opens npm/pnpm/bun/yarn (uv/pip on Python tabs), selecting a manager rewrites the command, and the clipboard receives exactly the command with no comment lines.

Docs-only behavior change; no changeset (generator-script edits don't touch published code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)