### PR TITLE
fix(docs): resolve changelog links and Vercel deploys

### DIFF
--- a/docs/bun.lock
+++ b/docs/bun.lock
@@ -17,7 +17,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "diff": "^9.0.0",
-        "eve": "^0.13.3",
+        "eve": "0.18.0",
         "framer-motion": "^12.39.0",
         "fumadocs-core": "^16.4.2",
         "fumadocs-mdx": "^14.2.4",
@@ -1341,7 +1341,7 @@
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
 
-    "eve": ["eve@0.13.3", "", { "dependencies": { "nitro": "3.0.260610-beta" }, "peerDependencies": { "@opentelemetry/api": "^1.0.0", "@sveltejs/kit": "^2.0.0", "ai": "7.0.0-beta.178", "braintrust": "^3.0.0", "just-bash": "^3.0.0", "microsandbox": "^0.5.0", "next": "^16.0.0", "nuxt": "^4.0.0", "react": "^19.0.0", "svelte": "^5.0.0", "vite": "^8.0.0", "vue": "^3.5.0" }, "optionalPeers": ["@opentelemetry/api", "@sveltejs/kit", "braintrust", "just-bash", "microsandbox", "next", "nuxt", "react", "svelte", "vite", "vue"], "bin": { "eve": "./bin/eve.js" } }, "sha512-UeDjzBq+j6XhECSW5FJjz8Lin4yw75rOchxbI/rmeRj9c9ldERwH/tb+aQRRzh3ZhnkFITzsBpNyF2arYcEjXQ=="],
+    "eve": ["eve@0.18.0", "", { "dependencies": { "nitro": "3.0.260610-beta" }, "peerDependencies": { "@opentelemetry/api": "^1.0.0", "ai": "^7.0.0", "braintrust": "^3.0.0", "just-bash": "^3.0.0", "microsandbox": "^0.5.0" }, "optionalPeers": ["@opentelemetry/api", "braintrust", "just-bash", "microsandbox"], "bin": { "eve": "./bin/eve.js" } }, "sha512-vEYiZe5D3m1s0UvuS5oSsNaJ10PD3oXzmwY1dLxlRncPjHZNGlmb84fG//KOU/HI6AsQuL3/gvgxUuS48jCRnw=="],
 
     "eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 

--- a/docs/components/copy-link.tsx
+++ b/docs/components/copy-link.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { Link, Check } from 'lucide-react';
+import { resolveCopyLinkUrl } from '@/lib/copy-link';
 
 interface CopyLinkProps {
   href: string;
@@ -13,7 +14,7 @@ export function CopyLink({ href, children, className }: CopyLinkProps) {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = async () => {
-    const fullUrl = `${window.location.origin}${href}`;
+    const fullUrl = resolveCopyLinkUrl(href, window.location.href);
     await navigator.clipboard.writeText(fullUrl);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);

--- a/docs/evals/docs-agent/grounded-answers.eval.ts
+++ b/docs/evals/docs-agent/grounded-answers.eval.ts
@@ -32,7 +32,7 @@ export default cases.map(row =>
     async test(t) {
       await t.send(row.prompt);
 
-      t.completed();
+      t.succeeded();
       t.noFailedActions();
       // The docs channel now injects eager search context before the model step,
       // so a good answer may not need an explicit search_docs tool call.

--- a/docs/evals/docs-agent/out-of-scope.eval.ts
+++ b/docs/evals/docs-agent/out-of-scope.eval.ts
@@ -9,7 +9,7 @@ export default defineEval({
   async test(t) {
     await t.send('Can you check whether my latest Composio invoice has been paid?');
 
-    t.completed();
+    t.succeeded();
     t.noFailedActions();
     t.usedNoTools();
     t.messageIncludes(/support|dashboard|billing|account/i);

--- a/docs/lib/copy-link.ts
+++ b/docs/lib/copy-link.ts
@@ -1,0 +1,3 @@
+export function resolveCopyLinkUrl(href: string, currentUrl: string): string {
+  return new URL(href, currentUrl).href;
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -39,7 +39,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "diff": "^9.0.0",
-    "eve": "^0.13.3",
+    "eve": "0.18.0",
     "framer-motion": "^12.39.0",
     "fumadocs-core": "^16.4.2",
     "fumadocs-mdx": "^14.2.4",

--- a/docs/tests/static/copy-link.test.ts
+++ b/docs/tests/static/copy-link.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { resolveCopyLinkUrl } from "../../lib/copy-link";
+
+describe("resolveCopyLinkUrl", () => {
+  test("keeps the current pathname for anchor links", () => {
+    expect(
+      resolveCopyLinkUrl(
+        "#2026-04-08",
+        "https://docs.composio.dev/reference/changelog"
+      )
+    ).toBe("https://docs.composio.dev/reference/changelog#2026-04-08");
+  });
+
+  test("resolves site-relative links from the docs origin", () => {
+    expect(
+      resolveCopyLinkUrl(
+        "/docs/changelog/2026/04/08",
+        "https://docs.composio.dev/reference/changelog"
+      )
+    ).toBe("https://docs.composio.dev/docs/changelog/2026/04/08");
+  });
+});


### PR DESCRIPTION
This PR:
- fixes copied changelog date URLs so they stay on `/reference/changelog` and target the selected date
- resolves fragment links against the current page while preserving full site-relative links
- upgrades the docs app to Vercel-supported `eve@0.18.0`
- migrates docs-agent evals from the removed `t.completed()` assertion to `t.succeeded()`
- verifies the docs static suite, TypeScript type-check, and production build

