### PR TITLE
fix(schema): normalize duplicate required entries

### DIFF
--- a/.changeset/bright-ants-wink.md
+++ b/.changeset/bright-ants-wink.md
@@ -1,0 +1,5 @@
+---
+'@composio/anthropic': patch
+---
+
+Ensure Anthropic tool schemas contain unique `required` entries at every nesting level.

--- a/.changeset/bright-ants-wink.md
+++ b/.changeset/bright-ants-wink.md
@@ -1,5 +1,10 @@
 ---
 '@composio/anthropic': patch
+'@composio/core': patch
+'@composio/openai': patch
+'@composio/google': patch
+'@composio/cloudflare': patch
+'@composio/openai-agents': patch
 ---
 
-Ensure Anthropic tool schemas contain unique `required` entries at every nesting level.
+Normalize duplicate JSON Schema `required` entries before provider tool schemas are emitted.

--- a/ts/packages/core/src/index.ts
+++ b/ts/packages/core/src/index.ts
@@ -6,6 +6,7 @@ export { BaseNonAgenticProvider, BaseAgenticProvider } from './provider/BaseProv
 export type { BaseComposioProvider } from './provider/BaseProvider';
 export {
   dereferenceJsonSchema,
+  deduplicateJsonSchemaRequiredArrays,
   jsonSchemaToZodSchema,
   removeNonRequiredProperties,
 } from './utils/jsonSchema';

--- a/ts/packages/core/src/provider/OpenAIProvider.ts
+++ b/ts/packages/core/src/provider/OpenAIProvider.ts
@@ -16,6 +16,7 @@ import { ExecuteToolModifiers } from '../types/modifiers.types';
 import { ExecuteToolFnOptions } from '../types/provider.types';
 import { McpUrlResponse, McpServerGetResponse } from '../types/mcp.types';
 import { normalizeToolArguments } from '../utils/toolArguments';
+import { deduplicateJsonSchemaRequiredArrays } from '../utils/jsonSchema';
 
 export type OpenAiTool = OpenAI.ChatCompletionTool;
 export type OpenAiToolCollection = Array<OpenAiTool>;
@@ -96,7 +97,7 @@ export class OpenAIProvider extends BaseNonAgenticProvider<
     const formattedSchema: OpenAI.FunctionDefinition = {
       name: tool.slug,
       description: tool.description,
-      parameters: tool.inputParameters,
+      parameters: deduplicateJsonSchemaRequiredArrays(tool.inputParameters),
     };
     return {
       type: 'function',

--- a/ts/packages/core/src/types/tool.types.ts
+++ b/ts/packages/core/src/types/tool.types.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod/v3';
 import { CustomConnectionDataSchema } from './connectedAccountAuthStates.types';
 import { TransformToolSchemaModifier } from './modifiers.types';
+import { deduplicateJsonSchemaRequiredArrays } from '../utils/jsonSchema';
 
 /**
  * Toolkit is the collection of tools,
@@ -86,38 +87,41 @@ export const JSONSchemaPropertySchema: z.ZodType<any> = z.object({
 export type JSONSchemaProperty = z.infer<typeof JSONSchemaPropertySchema>;
 
 // Schema for parameters (input/output)
-const ParametersSchema = z.object({
-  type: z.literal('object'),
-  anyOf: z.array(JSONSchemaPropertySchema).optional(),
-  oneOf: z.array(JSONSchemaPropertySchema).optional(),
-  allOf: z.array(JSONSchemaPropertySchema).optional(),
-  not: JSONSchemaPropertySchema.optional(),
-  properties: z.record(z.string(), JSONSchemaPropertySchema),
-  required: z.array(z.string()).optional(),
-  title: z.string().optional(),
-  default: z.any().optional(),
-  nullable: z.boolean().optional(),
-  description: z.string().optional(),
-  additionalProperties: z.boolean().default(false).optional(),
-  // Definition blocks targeted by `$ref` pointers. The Composio API ships
-  // these at the parameters root (e.g. `data` → `$ref` → `#/$defs/...`), but
-  // because `z.object` strips unknown keys they were being dropped on parse —
-  // leaving every nested `$ref` dangling and unresolvable downstream
-  // (providers, file modifiers). `JSONSchemaPropertySchema` already accepts
-  // both keywords; the parameters root must too.
-  $defs: z
-    .record(
-      z.string(),
-      z.lazy(() => JSONSchemaPropertySchema)
-    )
-    .optional(),
-  definitions: z
-    .record(
-      z.string(),
-      z.lazy(() => JSONSchemaPropertySchema)
-    )
-    .optional(),
-});
+const ParametersSchema = z.preprocess(
+  deduplicateJsonSchemaRequiredArrays,
+  z.object({
+    type: z.literal('object'),
+    anyOf: z.array(JSONSchemaPropertySchema).optional(),
+    oneOf: z.array(JSONSchemaPropertySchema).optional(),
+    allOf: z.array(JSONSchemaPropertySchema).optional(),
+    not: JSONSchemaPropertySchema.optional(),
+    properties: z.record(z.string(), JSONSchemaPropertySchema),
+    required: z.array(z.string()).optional(),
+    title: z.string().optional(),
+    default: z.any().optional(),
+    nullable: z.boolean().optional(),
+    description: z.string().optional(),
+    additionalProperties: z.boolean().default(false).optional(),
+    // Definition blocks targeted by `$ref` pointers. The Composio API ships
+    // these at the parameters root (e.g. `data` → `$ref` → `#/$defs/...`), but
+    // because `z.object` strips unknown keys they were being dropped on parse —
+    // leaving every nested `$ref` dangling and unresolvable downstream
+    // (providers, file modifiers). `JSONSchemaPropertySchema` already accepts
+    // both keywords; the parameters root must too.
+    $defs: z
+      .record(
+        z.string(),
+        z.lazy(() => JSONSchemaPropertySchema)
+      )
+      .optional(),
+    definitions: z
+      .record(
+        z.string(),
+        z.lazy(() => JSONSchemaPropertySchema)
+      )
+      .optional(),
+  })
+);
 
 /**
  * Tool is a single action that can be performed by a toolkit.

--- a/ts/packages/core/src/utils/jsonSchema.ts
+++ b/ts/packages/core/src/utils/jsonSchema.ts
@@ -269,16 +269,26 @@ export function dereferenceJsonSchema<T = unknown>(
  * reapply it at their own emission boundary.
  */
 export function deduplicateJsonSchemaRequiredArrays<T = unknown>(schema: T): T {
-  const seen = new WeakMap<object, unknown>();
+  const seenSchemaValues = new WeakMap<object, unknown>();
+  const seenInstanceValues = new WeakMap<object, unknown>();
+  const instanceValueKeywords = new Set(['const', 'default', 'enum', 'examples']);
 
-  function walk(value: unknown): unknown {
+  function walk(value: unknown, isSchema: boolean, depth = 0): unknown {
+    if (depth > MAX_NODE_DEPTH) {
+      throw new RangeError(`JSON Schema exceeds maximum nesting depth of ${MAX_NODE_DEPTH}`);
+    }
+
+    const seen = isSchema ? seenSchemaValues : seenInstanceValues;
+
     if (Array.isArray(value)) {
       const existing = seen.get(value);
       if (existing) return existing;
 
       const clone: unknown[] = [];
       seen.set(value, clone);
-      clone.push(...value.map(walk));
+      for (const item of value) {
+        clone.push(walk(item, isSchema, depth + 1));
+      }
       return clone;
     }
 
@@ -293,14 +303,17 @@ export function deduplicateJsonSchemaRequiredArrays<T = unknown>(schema: T): T {
       Object.defineProperty(clone, key, {
         configurable: true,
         enumerable: true,
-        value: key === 'required' && Array.isArray(child) ? [...new Set(child)] : walk(child),
+        value:
+          isSchema && key === 'required' && Array.isArray(child)
+            ? [...new Set(walk(child, false, depth + 1) as unknown[])]
+            : walk(child, isSchema && !instanceValueKeywords.has(key), depth + 1),
         writable: true,
       });
     }
     return clone;
   }
 
-  return walk(schema) as T;
+  return walk(schema, true) as T;
 }
 
 /**

--- a/ts/packages/core/src/utils/jsonSchema.ts
+++ b/ts/packages/core/src/utils/jsonSchema.ts
@@ -259,6 +259,51 @@ export function dereferenceJsonSchema<T = unknown>(
 }
 
 /**
+ * Returns a deep-cloned JSON Schema whose `required` arrays contain each entry
+ * at most once. Duplicate entries are invalid in JSON Schema 2020-12 but do
+ * not change the schema's meaning, so preserving the first occurrence is safe.
+ *
+ * Tool schemas originate both from the Composio API and direct provider calls.
+ * Keeping this normalization provider-agnostic lets every SDK provider receive
+ * canonical API schemas, while providers that further transform a schema can
+ * reapply it at their own emission boundary.
+ */
+export function deduplicateJsonSchemaRequiredArrays<T = unknown>(schema: T): T {
+  const seen = new WeakMap<object, unknown>();
+
+  function walk(value: unknown): unknown {
+    if (Array.isArray(value)) {
+      const existing = seen.get(value);
+      if (existing) return existing;
+
+      const clone: unknown[] = [];
+      seen.set(value, clone);
+      clone.push(...value.map(walk));
+      return clone;
+    }
+
+    if (!isPlainObject(value)) return value;
+
+    const existing = seen.get(value);
+    if (existing) return existing;
+
+    const clone: Record<string, unknown> = {};
+    seen.set(value, clone);
+    for (const [key, child] of Object.entries(value)) {
+      Object.defineProperty(clone, key, {
+        configurable: true,
+        enumerable: true,
+        value: key === 'required' && Array.isArray(child) ? [...new Set(child)] : walk(child),
+        writable: true,
+      });
+    }
+    return clone;
+  }
+
+  return walk(schema) as T;
+}
+
+/**
  * Removes all non-required properties from the schema
  *
  * if no items are required, the schema is returned as is

--- a/ts/packages/core/test/provider/openai-provider.test.ts
+++ b/ts/packages/core/test/provider/openai-provider.test.ts
@@ -64,6 +64,35 @@ describe('OpenAIProvider', () => {
         },
       });
     });
+
+    it('deduplicates required entries without mutating the input schema', () => {
+      const tool = {
+        ...mockTool,
+        inputParameters: {
+          type: 'object',
+          properties: {
+            query: { type: 'string' },
+            filters: {
+              type: 'object',
+              properties: { status: { type: 'string' } },
+              required: ['status', 'status'],
+            },
+          },
+          required: ['query', 'query'],
+        },
+      } as Tool;
+
+      const wrapped = provider.wrapTool(tool);
+
+      expect(wrapped.function.parameters).toMatchObject({
+        required: ['query'],
+        properties: { filters: { required: ['status'] } },
+      });
+      expect(tool.inputParameters).toMatchObject({
+        required: ['query', 'query'],
+        properties: { filters: { required: ['status', 'status'] } },
+      });
+    });
   });
 
   describe('wrapTools', () => {

--- a/ts/packages/core/test/utils/jsonSchema.test.ts
+++ b/ts/packages/core/test/utils/jsonSchema.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi } from 'vitest';
-import { dereferenceJsonSchema } from '../../src/utils/jsonSchema';
+import {
+  deduplicateJsonSchemaRequiredArrays,
+  dereferenceJsonSchema,
+} from '../../src/utils/jsonSchema';
 import { JsonSchemaRefResolutionError } from '../../src/errors/ValidationErrors';
 import logger from '../../src/utils/logger';
+import { ToolSchema } from '../../src/types/tool.types';
 
 const containsRef = (value: unknown): boolean => {
   if (value === null || typeof value !== 'object') return false;
@@ -482,5 +486,59 @@ describe('dereferenceJsonSchema', () => {
       expect(out.properties.resolved).toEqual({ type: 'integer' });
       expect(out.properties.dangling).toEqual(PERMISSIVE);
     });
+  });
+});
+
+describe('deduplicateJsonSchemaRequiredArrays', () => {
+  it('deduplicates every required array without mutating the input schema', () => {
+    const schema = {
+      type: 'object',
+      required: ['owner', 'name', 'owner'],
+      properties: {
+        options: {
+          type: 'object',
+          required: ['enabled', 'enabled'],
+          properties: { enabled: { type: 'boolean' } },
+        },
+      },
+    };
+
+    const normalized = deduplicateJsonSchemaRequiredArrays(schema);
+
+    expect(normalized).toEqual({
+      type: 'object',
+      required: ['owner', 'name'],
+      properties: {
+        options: {
+          type: 'object',
+          required: ['enabled'],
+          properties: { enabled: { type: 'boolean' } },
+        },
+      },
+    });
+    expect(schema.required).toEqual(['owner', 'name', 'owner']);
+    expect(schema.properties.options.required).toEqual(['enabled', 'enabled']);
+  });
+
+  it('normalizes schemas at the shared ToolSchema API boundary', () => {
+    const tool = ToolSchema.parse({
+      slug: 'TEST_TOOL',
+      name: 'Test tool',
+      inputParameters: {
+        type: 'object',
+        required: ['name', 'name'],
+        properties: {
+          name: { type: 'string' },
+          options: {
+            type: 'object',
+            required: ['enabled', 'enabled'],
+            properties: { enabled: { type: 'boolean' } },
+          },
+        },
+      },
+    });
+
+    expect(tool.inputParameters?.required).toEqual(['name']);
+    expect(tool.inputParameters?.properties.options.required).toEqual(['enabled']);
   });
 });

--- a/ts/packages/core/test/utils/jsonSchema.test.ts
+++ b/ts/packages/core/test/utils/jsonSchema.test.ts
@@ -520,6 +520,59 @@ describe('deduplicateJsonSchemaRequiredArrays', () => {
     expect(schema.properties.options.required).toEqual(['enabled', 'enabled']);
   });
 
+  it('does not normalize literal instance values', () => {
+    const sharedValue = {
+      type: 'object',
+      required: ['preserve', 'preserve'],
+      properties: { preserve: { type: 'string' } },
+    };
+    const schema = {
+      type: 'object',
+      required: ['value', 'value'],
+      properties: {
+        schemaValue: sharedValue,
+        value: {
+          const: sharedValue,
+          default: { required: ['preserve', 'preserve'] },
+          enum: [{ required: ['preserve', 'preserve'] }],
+          examples: [{ required: ['preserve', 'preserve'] }],
+        },
+      },
+    };
+
+    const normalized = deduplicateJsonSchemaRequiredArrays(schema);
+
+    expect(normalized).toMatchObject({
+      required: ['value'],
+      properties: {
+        schemaValue: { required: ['preserve'] },
+        value: {
+          const: { required: ['preserve', 'preserve'] },
+          default: { required: ['preserve', 'preserve'] },
+          enum: [{ required: ['preserve', 'preserve'] }],
+          examples: [{ required: ['preserve', 'preserve'] }],
+        },
+      },
+    });
+    expect(normalized.properties.value.const).not.toBe(schema.properties.value.const);
+  });
+
+  it('fails predictably for schemas nested beyond the supported depth', () => {
+    const defaultValue: Record<string, unknown> = {};
+    let cursor = defaultValue;
+    for (let i = 0; i <= 512; i++) {
+      cursor.child = {};
+      cursor = cursor.child as Record<string, unknown>;
+    }
+
+    expect(() =>
+      deduplicateJsonSchemaRequiredArrays({
+        type: 'object',
+        properties: { value: { default: defaultValue } },
+      })
+    ).toThrow('JSON Schema exceeds maximum nesting depth of 512');
+  });
+
   it('normalizes schemas at the shared ToolSchema API boundary', () => {
     const tool = ToolSchema.parse({
       slug: 'TEST_TOOL',

--- a/ts/packages/providers/AGENTS.md
+++ b/ts/packages/providers/AGENTS.md
@@ -25,5 +25,6 @@ pnpm build:packages
 
 - Keep provider-specific behavior inside the provider package.
 - Preserve framework-native tool shapes and naming conventions.
+- Tool schemas obtained through `ToolSchema` are normalized by core. If a provider transforms a raw schema before emitting it, reapply `deduplicateJsonSchemaRequiredArrays` from `@composio/core` at that final schema boundary.
 - Add tests that cover wrapping, execution handling, and version-specific compatibility.
 - Update examples or docs when provider setup or public usage changes.

--- a/ts/packages/providers/AGENTS.md
+++ b/ts/packages/providers/AGENTS.md
@@ -25,6 +25,6 @@ pnpm build:packages
 
 - Keep provider-specific behavior inside the provider package.
 - Preserve framework-native tool shapes and naming conventions.
-- Tool schemas obtained through `ToolSchema` are normalized by core. If a provider transforms a raw schema before emitting it, reapply `deduplicateJsonSchemaRequiredArrays` from `@composio/core` at that final schema boundary.
+- Tool schemas obtained through `ToolSchema` are normalized by core. Every provider that accepts a raw `Tool` must call `deduplicateJsonSchemaRequiredArrays` from `@composio/core` immediately before emitting a vendor JSON Schema, after any provider-specific schema transformations. A ToolSchema-normalized API tool needs no additional call unless it is transformed afterward.
 - Add tests that cover wrapping, execution handling, and version-specific compatibility.
 - Update examples or docs when provider setup or public usage changes.

--- a/ts/packages/providers/anthropic/src/index.ts
+++ b/ts/packages/providers/anthropic/src/index.ts
@@ -39,6 +39,30 @@ export type AnthropicMcpServerGetResponse = {
 export type AnthropicToolCollection = AnthropicTool[];
 
 /**
+ * JSON Schema 2020-12 requires every `required` array to contain unique
+ * entries. Normalize the complete schema because object schemas can occur at
+ * any nesting level, including inside arrays and composition keywords.
+ */
+function deduplicateRequiredArrays(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(deduplicateRequiredArrays);
+  }
+
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, child]) => [
+      key,
+      key === 'required' && Array.isArray(child)
+        ? [...new Set(child)]
+        : deduplicateRequiredArrays(child),
+    ])
+  );
+}
+
+/**
  * Type for Anthropic tool use block in message content
  */
 export interface AnthropicToolUseBlock {
@@ -65,7 +89,7 @@ export class AnthropicProvider extends BaseNonAgenticProvider<
   AnthropicMcpServerGetResponse
 > {
   readonly name = 'anthropic';
-  private chacheTools: boolean = false;
+  private cacheTools: boolean = false;
 
   /**
    * Per-tool reverse key mappings (`sanitized -> original`, shaped like the
@@ -117,8 +141,8 @@ export class AnthropicProvider extends BaseNonAgenticProvider<
    */
   constructor(options?: { cacheTools?: boolean }) {
     super();
-    this.chacheTools = options?.cacheTools ?? false;
-    logger.debug(`AnthropicProvider initialized [cacheTools: ${this.chacheTools}]`);
+    this.cacheTools = options?.cacheTools ?? false;
+    logger.debug(`AnthropicProvider initialized [cacheTools: ${this.cacheTools}]`);
   }
 
   /**
@@ -171,7 +195,8 @@ export class AnthropicProvider extends BaseNonAgenticProvider<
     // Anthropic rejects the whole `tools` array if any property key falls outside
     // `^[a-zA-Z0-9_.-]{1,64}$` (e.g. OData params like `$top`, `@odata.type`, or
     // over-long flattened keys). Rewrite offending keys and remember how to undo it.
-    const { schema, mapping } = sanitizeSchemaPropertyKeys(dereferenced);
+    const { schema: sanitizedSchema, mapping } = sanitizeSchemaPropertyKeys(dereferenced);
+    const schema = deduplicateRequiredArrays(sanitizedSchema) as InputSchema;
 
     if (mappingHasRenames(mapping)) {
       this.toolKeyMappings.set(tool.slug, mapping);
@@ -189,7 +214,7 @@ export class AnthropicProvider extends BaseNonAgenticProvider<
       name: tool.slug,
       description: tool.description || '',
       input_schema: schema,
-      cache_control: this.chacheTools ? { type: 'ephemeral' } : undefined,
+      cache_control: this.cacheTools ? { type: 'ephemeral' } : undefined,
     };
   }
 
@@ -377,7 +402,7 @@ export class AnthropicProvider extends BaseNonAgenticProvider<
         type: 'tool_result',
         tool_use_id: toolUse.id,
         content: toolResult,
-        cache_control: this.chacheTools ? { type: 'ephemeral' } : undefined,
+        cache_control: this.cacheTools ? { type: 'ephemeral' } : undefined,
       });
     }
 

--- a/ts/packages/providers/anthropic/src/index.ts
+++ b/ts/packages/providers/anthropic/src/index.ts
@@ -17,6 +17,7 @@ import {
   McpUrlResponse,
   normalizeToolArguments,
   dereferenceJsonSchema,
+  deduplicateJsonSchemaRequiredArrays,
 } from '@composio/core';
 import Anthropic from '@anthropic-ai/sdk';
 import { AnthropicTool, InputSchema } from './types';
@@ -37,30 +38,6 @@ export type AnthropicMcpServerGetResponse = {
  * Collection of Anthropic tools
  */
 export type AnthropicToolCollection = AnthropicTool[];
-
-/**
- * JSON Schema 2020-12 requires every `required` array to contain unique
- * entries. Normalize the complete schema because object schemas can occur at
- * any nesting level, including inside arrays and composition keywords.
- */
-function deduplicateRequiredArrays(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.map(deduplicateRequiredArrays);
-  }
-
-  if (value === null || typeof value !== 'object') {
-    return value;
-  }
-
-  return Object.fromEntries(
-    Object.entries(value).map(([key, child]) => [
-      key,
-      key === 'required' && Array.isArray(child)
-        ? [...new Set(child)]
-        : deduplicateRequiredArrays(child),
-    ])
-  );
-}
 
 /**
  * Type for Anthropic tool use block in message content
@@ -196,7 +173,7 @@ export class AnthropicProvider extends BaseNonAgenticProvider<
     // `^[a-zA-Z0-9_.-]{1,64}$` (e.g. OData params like `$top`, `@odata.type`, or
     // over-long flattened keys). Rewrite offending keys and remember how to undo it.
     const { schema: sanitizedSchema, mapping } = sanitizeSchemaPropertyKeys(dereferenced);
-    const schema = deduplicateRequiredArrays(sanitizedSchema) as InputSchema;
+    const schema = deduplicateJsonSchemaRequiredArrays(sanitizedSchema) as InputSchema;
 
     if (mappingHasRenames(mapping)) {
       this.toolKeyMappings.set(tool.slug, mapping);

--- a/ts/packages/providers/anthropic/test/anthropic.test.ts
+++ b/ts/packages/providers/anthropic/test/anthropic.test.ts
@@ -105,6 +105,37 @@ describe('AnthropicProvider', () => {
         },
       });
     });
+
+    it('deduplicates required entries at every object-schema level', () => {
+      const toolWithDuplicateRequired: Tool = {
+        ...mockTool,
+        inputParameters: {
+          type: 'object',
+          properties: {
+            owner: { type: 'string' },
+            options: {
+              type: 'object',
+              properties: {
+                name: { type: 'string' },
+              },
+              required: ['name', 'name'],
+            },
+          },
+          required: ['owner', 'options', 'owner'],
+        },
+      };
+
+      const wrapped = provider.wrapTool(toolWithDuplicateRequired) as AnthropicTool;
+      const properties = wrapped.input_schema.properties as Record<
+        string,
+        {
+          required?: string[];
+        }
+      >;
+
+      expect(wrapped.input_schema.required).toEqual(['owner', 'options']);
+      expect(properties.options?.required).toEqual(['name']);
+    });
   });
 
   describe('wrapTools', () => {

--- a/ts/packages/providers/cloudflare/src/index.ts
+++ b/ts/packages/providers/cloudflare/src/index.ts
@@ -19,6 +19,7 @@ import {
   McpUrlResponse,
   McpServerGetResponse,
   normalizeToolArguments,
+  deduplicateJsonSchemaRequiredArrays,
 } from '@composio/core';
 
 type AiToolCollection = Record<string, AiTextGenerationToolInput>;
@@ -97,10 +98,11 @@ export class CloudflareProvider extends BaseNonAgenticProvider<
    * ```
    */
   wrapTool(tool: Tool): AiTextGenerationToolInput {
+    const inputParameters = deduplicateJsonSchemaRequiredArrays(tool.inputParameters);
     const formattedSchema: AiTextGenerationToolInput['function'] = {
       name: tool.slug!,
       description: tool.description!,
-      parameters: tool.inputParameters as unknown as {
+      parameters: inputParameters as unknown as {
         type: 'object';
         properties: {
           [key: string]: {

--- a/ts/packages/providers/cloudflare/test/cloudflare.test.ts
+++ b/ts/packages/providers/cloudflare/test/cloudflare.test.ts
@@ -124,6 +124,18 @@ describe('CloudflareProvider', () => {
         },
       });
     });
+
+    it('deduplicates required entries for directly wrapped tools', () => {
+      const wrapped = provider.wrapTool({
+        ...mockTool,
+        inputParameters: {
+          ...mockTool.inputParameters!,
+          required: ['input', 'input'],
+        },
+      }) as MockedCloudflareToolInput;
+
+      expect(wrapped.function.parameters.required).toEqual(['input']);
+    });
   });
 
   describe('wrapTools', () => {

--- a/ts/packages/providers/google/src/index.ts
+++ b/ts/packages/providers/google/src/index.ts
@@ -16,6 +16,7 @@ import {
   McpUrlResponse,
   McpServerGetResponse,
   normalizeToolArguments,
+  deduplicateJsonSchemaRequiredArrays,
 } from '@composio/core';
 import { FunctionDeclaration, Schema } from '@google/genai';
 
@@ -127,14 +128,16 @@ export class GoogleProvider extends BaseNonAgenticProvider<
    * ```
    */
   wrapTool(tool: Tool): GoogleTool {
+    const inputParameters = deduplicateJsonSchemaRequiredArrays(tool.inputParameters);
+
     return {
       name: tool.slug,
       description: tool.description || '',
       parameters: {
         type: 'object',
         description: tool.description || '',
-        properties: tool.inputParameters?.properties || {},
-        required: tool.inputParameters?.required || [],
+        properties: inputParameters?.properties || {},
+        required: inputParameters?.required || [],
       } as unknown as Schema,
     };
   }

--- a/ts/packages/providers/google/test/google.test.ts
+++ b/ts/packages/providers/google/test/google.test.ts
@@ -84,6 +84,18 @@ describe('GoogleProvider', () => {
         },
       });
     });
+
+    it('deduplicates required entries for directly wrapped tools', () => {
+      const wrapped = provider.wrapTool({
+        ...mockTool,
+        inputParameters: {
+          ...mockTool.inputParameters!,
+          required: ['input', 'input'],
+        },
+      });
+
+      expect(wrapped.parameters?.required).toEqual(['input']);
+    });
   });
 
   describe('wrapTools', () => {

--- a/ts/packages/providers/openai-agents/src/index.ts
+++ b/ts/packages/providers/openai-agents/src/index.ts
@@ -17,6 +17,7 @@ import {
   McpUrlResponse,
   McpServerGetResponse,
   normalizeToolArguments,
+  deduplicateJsonSchemaRequiredArrays,
 } from '@composio/core';
 import type { Tool as OpenAIAgentTool } from '@openai/agents';
 import { tool as createOpenAIAgentTool } from '@openai/agents';
@@ -122,13 +123,15 @@ export class OpenAIAgentsProvider extends BaseAgenticProvider<
    * ```
    */
   wrapTool(composioTool: ComposioTool, executeTool: ExecuteToolFn): OpenAIAgentTool {
+    const inputParameters = deduplicateJsonSchemaRequiredArrays(composioTool.inputParameters);
+
     return createOpenAIAgentTool({
       name: composioTool.slug,
       description: composioTool.description ?? '',
       parameters: {
         type: 'object',
-        properties: composioTool.inputParameters?.properties || {},
-        required: composioTool.inputParameters?.required || [],
+        properties: inputParameters?.properties || {},
+        required: inputParameters?.required || [],
         additionalProperties: true,
       },
       strict: false,

--- a/ts/packages/providers/openai-agents/test/openai-agents.test.ts
+++ b/ts/packages/providers/openai-agents/test/openai-agents.test.ts
@@ -113,6 +113,25 @@ describe('OpenAIAgentsProvider', () => {
       expect(wrapped._isMockedOpenAIAgentTool).toBe(true);
     });
 
+    it('deduplicates required entries for directly wrapped tools', () => {
+      provider.wrapTool(
+        {
+          ...mockTool,
+          inputParameters: {
+            ...mockTool.inputParameters!,
+            required: ['input', 'input'],
+          },
+        },
+        mockExecuteToolFn
+      );
+
+      expect(createOpenAIAgentTool).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parameters: expect.objectContaining({ required: ['input'] }),
+        })
+      );
+    });
+
     it('should normalize a stringified-JSON input to an object before executing (issue #2406)', async () => {
       const wrapped = provider.wrapTool(
         mockTool,

--- a/ts/packages/providers/openai/src/OpenAIResponsesProvider.ts
+++ b/ts/packages/providers/openai/src/OpenAIResponsesProvider.ts
@@ -19,6 +19,7 @@ import {
   removeNonRequiredProperties,
   McpUrlResponse,
   normalizeToolArguments,
+  deduplicateJsonSchemaRequiredArrays,
 } from '@composio/core';
 
 export type OpenAiTool = OpenAI.Responses.FunctionTool;
@@ -119,7 +120,7 @@ export class OpenAIResponsesProvider extends BaseNonAgenticProvider<
    * ```
    */
   override wrapTool(tool: Tool): OpenAiTool {
-    const inputParams = tool.inputParameters;
+    const inputParams = deduplicateJsonSchemaRequiredArrays(tool.inputParameters);
 
     const parameters =
       this.strict && inputParams?.type === 'object'

--- a/ts/packages/providers/openai/test/opeanai-responses.test.ts
+++ b/ts/packages/providers/openai/test/opeanai-responses.test.ts
@@ -111,7 +111,23 @@ describe('OpenAIResponsesProvider', () => {
       const wrapped = strictProvider.wrapTool(mockTool) as MockedOpenAITool;
 
       expect(wrapped.strict).toBe(true);
-      expect(wrapped.parameters).toEqual(mockTool.inputParameters);
+      expect(wrapped.parameters).toEqual({
+        ...mockTool.inputParameters,
+        additionalProperties: false,
+      });
+      expect(mockTool.inputParameters).not.toHaveProperty('additionalProperties');
+    });
+
+    it('deduplicates required entries for directly wrapped tools', () => {
+      const wrapped = provider.wrapTool({
+        ...mockTool,
+        inputParameters: {
+          ...mockTool.inputParameters!,
+          required: ['input', 'input'],
+        },
+      }) as MockedOpenAITool;
+
+      expect(wrapped.parameters.required).toEqual(['input']);
     });
   });
 

--- a/ts/packages/providers/openai/test/openai.test.ts
+++ b/ts/packages/providers/openai/test/openai.test.ts
@@ -122,6 +122,18 @@ describe('OpenAIProvider', () => {
         },
       });
     });
+
+    it('deduplicates required entries for directly wrapped tools', () => {
+      const wrapped = provider.wrapTool({
+        ...mockTool,
+        inputParameters: {
+          ...mockTool.inputParameters!,
+          required: ['input', 'input'],
+        },
+      }) as MockedOpenAIChatCompletionTool;
+
+      expect(wrapped.function.parameters.required).toEqual(['input']);
+    });
   });
 
   describe('wrapTools', () => {


### PR DESCRIPTION
## Summary

- Normalize duplicate JSON Schema `required` entries at the shared `ToolSchema` ingress boundary.
- Reapply normalization immediately before direct providers emit vendor schemas (Anthropic, OpenAI, OpenAI Responses, Google, Cloudflare, and OpenAI Agents).
- Preserve literal `const`/`default`/`enum`/`examples` values, tolerate aliasing safely, and fail predictably on pathological nesting.
- Document the provider-boundary rule in `ts/packages/providers/AGENTS.md`.

Co-authored-by: @MatinGathani

## Verification

- `pnpm changeset status`
- `pnpm --filter @composio/core build`
- Focused core and affected-provider Vitest suites (1,151 tests)
- `pnpm typecheck`
- `pnpm lint` (passes with 71 pre-existing warnings)