### PR TITLE
refactor(ts): unify ID generation

### DIFF
--- a/.changeset/unify-id-generation.md
+++ b/.changeset/unify-id-generation.md
@@ -1,0 +1,5 @@
+---
+'@composio/core': patch
+---
+
+Unify internal ID generation across the TypeScript SDK.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,7 +173,7 @@ importers:
         version: 7.8.5
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27)
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
       tsx:
         specifier: 'catalog:'
         version: 4.23.0
@@ -1252,7 +1252,7 @@ importers:
         version: 3.2.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27)
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
       tsx:
         specifier: 'catalog:'
         version: 4.23.0
@@ -1276,7 +1276,7 @@ importers:
         version: 3.21.4
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27)
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1310,7 +1310,7 @@ importers:
         version: 1.5.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27)
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1356,7 +1356,7 @@ importers:
         version: 7.7.1
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27)
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
       tsx:
         specifier: 'catalog:'
         version: 4.23.0
@@ -1393,7 +1393,7 @@ importers:
         version: 0.12.3(@opentelemetry/api@1.9.0)(ai@7.0.0-beta.178(zod@4.4.3))(dotenv@17.4.2)(jiti@2.7.0)(lru-cache@11.5.1)(miniflare@4.20260701.0)(rollup@4.62.2)(vite@7.3.1(@types/node@26.1.0)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))(wrangler@4.107.0(@cloudflare/workers-types@4.20260702.1))
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27)
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
       tsx:
         specifier: 'catalog:'
         version: 4.23.0
@@ -1414,7 +1414,7 @@ importers:
         version: 26.1.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27)
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1444,7 +1444,7 @@ importers:
         version: 6.0.219(zod@4.4.3)
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27)
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1466,7 +1466,7 @@ importers:
         version: link:../../core
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27)
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1485,7 +1485,7 @@ importers:
         version: link:../../core
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27)
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1504,7 +1504,7 @@ importers:
         version: link:../../core
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27)
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1519,7 +1519,7 @@ importers:
         version: 1.2.1(@opentelemetry/api@1.9.1)(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.62)(@smithy/signature-v4@5.6.2)(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27)
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1541,7 +1541,7 @@ importers:
         version: link:../../core
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27)
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1563,7 +1563,7 @@ importers:
         version: 6.0.219(zod@4.4.3)
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27)
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1585,7 +1585,7 @@ importers:
         version: link:../../core
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27)
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1603,7 +1603,7 @@ importers:
         version: 0.12.0(@aws-sdk/credential-provider-node@3.972.62)(@cfworker/json-schema@4.1.1)(@smithy/signature-v4@5.6.2)(supports-color@10.2.2)(ws@8.21.0)(zod@4.4.3)
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27)
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1624,7 +1624,7 @@ importers:
         version: 7.0.14(zod@4.4.3)
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27)
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1658,6 +1658,9 @@ importers:
       semver:
         specifier: ^7.8.5
         version: 7.8.5
+      uniku:
+        specifier: ^0.3.1
+        version: 0.3.1
       zod:
         specifier: '>=3.25.76 <5'
         version: 4.4.3
@@ -1683,7 +1686,7 @@ importers:
         version: link:@types/@babel/helper-validator-identifier
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27)
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(@vitest/ui@4.1.10)(vite@7.3.1(@types/node@26.1.0)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -12392,7 +12395,7 @@ snapshots:
       '@ts-morph/common': 0.29.0
       code-block-writer: 13.0.3
 
-  tsdown@0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27):
+  tsdown@0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)):
     dependencies:
       ansis: 4.3.1
       cac: 7.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,7 +97,7 @@ catalogs:
       specifier: ^6.0.3
       version: 6.0.3
     uniku:
-      specifier: ^0.3.1
+      specifier: 0.3.1
       version: 0.3.1
     vitest:
       specifier: ^4.1.10

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,7 +173,7 @@ importers:
         version: 7.8.5
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 'catalog:'
         version: 4.23.0
@@ -1195,6 +1195,9 @@ importers:
       ts-morph:
         specifier: ^28.0.0
         version: 28.0.0
+      uniku:
+        specifier: ^0.3.1
+        version: 0.3.1
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -1249,7 +1252,7 @@ importers:
         version: 3.2.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 'catalog:'
         version: 4.23.0
@@ -1273,10 +1276,13 @@ importers:
         version: 3.21.4
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
+      uniku:
+        specifier: ^0.3.1
+        version: 0.3.1
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(@vitest/ui@4.1.10)(vite@7.3.1(@types/node@26.1.0)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -1304,7 +1310,7 @@ importers:
         version: 1.5.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1335,6 +1341,9 @@ importers:
       semver:
         specifier: ^7.8.5
         version: 7.8.5
+      uniku:
+        specifier: ^0.3.1
+        version: 0.3.1
       zod-to-json-schema:
         specifier: 'catalog:'
         version: 3.25.2(zod@4.4.3)
@@ -1347,7 +1356,7 @@ importers:
         version: 7.7.1
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 'catalog:'
         version: 4.23.0
@@ -1384,7 +1393,7 @@ importers:
         version: 0.12.3(@opentelemetry/api@1.9.0)(ai@7.0.0-beta.178(zod@4.4.3))(dotenv@17.4.2)(jiti@2.7.0)(lru-cache@11.5.1)(miniflare@4.20260701.0)(rollup@4.62.2)(vite@7.3.1(@types/node@26.1.0)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))(wrangler@4.107.0(@cloudflare/workers-types@4.20260702.1))
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27)
       tsx:
         specifier: 'catalog:'
         version: 4.23.0
@@ -1405,7 +1414,7 @@ importers:
         version: 26.1.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1435,7 +1444,7 @@ importers:
         version: 6.0.219(zod@4.4.3)
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1457,7 +1466,7 @@ importers:
         version: link:../../core
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1476,7 +1485,7 @@ importers:
         version: link:../../core
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1495,7 +1504,7 @@ importers:
         version: link:../../core
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1510,7 +1519,7 @@ importers:
         version: 1.2.1(@opentelemetry/api@1.9.1)(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.62)(@smithy/signature-v4@5.6.2)(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1532,7 +1541,7 @@ importers:
         version: link:../../core
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1554,7 +1563,7 @@ importers:
         version: 6.0.219(zod@4.4.3)
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1576,7 +1585,7 @@ importers:
         version: link:../../core
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1594,7 +1603,7 @@ importers:
         version: 0.12.0(@aws-sdk/credential-provider-node@3.972.62)(@cfworker/json-schema@4.1.1)(@smithy/signature-v4@5.6.2)(supports-color@10.2.2)(ws@8.21.0)(zod@4.4.3)
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1615,7 +1624,7 @@ importers:
         version: 7.0.14(zod@4.4.3)
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1674,7 +1683,7 @@ importers:
         version: link:@types/@babel/helper-validator-identifier
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27)
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(@vitest/ui@4.1.10)(vite@7.3.1(@types/node@26.1.0)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -3321,6 +3330,10 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -6729,6 +6742,10 @@ packages:
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
+  uniku@0.3.1:
+    resolution: {integrity: sha512-lMKBDGZBceRxQT8BMfiEvbaCH2QF7EWgQhYNkoga0x/J/1GxggHNlHwOx1vNDEyx7k9PqLI/JsqIl3APbID/1w==}
+    engines: {node: '>=20.19.0'}
+
   unique-string@3.0.0:
     resolution: {integrity: sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==}
     engines: {node: '>=12'}
@@ -8992,6 +9009,8 @@ snapshots:
       '@emnapi/runtime': 1.11.1
       '@tybys/wasm-util': 0.10.3
     optional: true
+
+  '@noble/hashes@2.2.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -12373,7 +12392,7 @@ snapshots:
       '@ts-morph/common': 0.29.0
       code-block-writer: 13.0.3
 
-  tsdown@0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)):
+  tsdown@0.22.3(@arethetypeswrong/core@0.18.4)(@typescript/native-preview@7.0.0-dev.20260703.1)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)(unrun@0.2.27):
     dependencies:
       ansis: 4.3.1
       cac: 7.0.0
@@ -12497,6 +12516,10 @@ snapshots:
       is-plain-obj: 4.1.0
       trough: 2.2.0
       vfile: 6.0.3
+
+  uniku@0.3.1:
+    dependencies:
+      '@noble/hashes': 2.2.0
 
   unique-string@3.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,8 +97,8 @@ catalogs:
       specifier: ^6.0.3
       version: 6.0.3
     uniku:
-      specifier: 0.3.1
-      version: 0.3.1
+      specifier: 0.2.0
+      version: 0.2.0
     vitest:
       specifier: ^4.1.10
       version: 4.1.10
@@ -1200,7 +1200,7 @@ importers:
         version: 28.0.0
       uniku:
         specifier: 'catalog:'
-        version: 0.3.1
+        version: 0.2.0
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -1285,7 +1285,7 @@ importers:
         version: 6.0.3
       uniku:
         specifier: 'catalog:'
-        version: 0.3.1
+        version: 0.2.0
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(@vitest/ui@4.1.10)(vite@7.3.1(@types/node@26.1.0)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -1346,7 +1346,7 @@ importers:
         version: 7.8.5
       uniku:
         specifier: 'catalog:'
-        version: 0.3.1
+        version: 0.2.0
       zod-to-json-schema:
         specifier: 'catalog:'
         version: 3.25.2(zod@4.4.3)
@@ -1663,7 +1663,7 @@ importers:
         version: 7.8.5
       uniku:
         specifier: 'catalog:'
-        version: 0.3.1
+        version: 0.2.0
       zod:
         specifier: '>=3.25.76 <5'
         version: 4.4.3
@@ -6748,8 +6748,8 @@ packages:
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
-  uniku@0.3.1:
-    resolution: {integrity: sha512-lMKBDGZBceRxQT8BMfiEvbaCH2QF7EWgQhYNkoga0x/J/1GxggHNlHwOx1vNDEyx7k9PqLI/JsqIl3APbID/1w==}
+  uniku@0.2.0:
+    resolution: {integrity: sha512-zZMrf9a0gV4QwtiabwH19Kz/2ifJvU7vUjH8lBFBoZyWzMS7jZ+qbsP8/y83YOp4mO34zXDjspuLBwk0uK30Rw==}
     engines: {node: '>=20.19.0'}
 
   unique-string@3.0.0:
@@ -12523,7 +12523,7 @@ snapshots:
       trough: 2.2.0
       vfile: 6.0.3
 
-  uniku@0.3.1:
+  uniku@0.2.0:
     dependencies:
       '@noble/hashes': 2.2.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ catalogs:
     typescript:
       specifier: ^6.0.3
       version: 6.0.3
+    uniku:
+      specifier: ^0.3.1
+      version: 0.3.1
     vitest:
       specifier: ^4.1.10
       version: 4.1.10
@@ -1196,7 +1199,7 @@ importers:
         specifier: ^28.0.0
         version: 28.0.0
       uniku:
-        specifier: ^0.3.1
+        specifier: 'catalog:'
         version: 0.3.1
       zod:
         specifier: 'catalog:'
@@ -1281,7 +1284,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       uniku:
-        specifier: ^0.3.1
+        specifier: 'catalog:'
         version: 0.3.1
       vitest:
         specifier: 'catalog:'
@@ -1342,7 +1345,7 @@ importers:
         specifier: ^7.8.5
         version: 7.8.5
       uniku:
-        specifier: ^0.3.1
+        specifier: 'catalog:'
         version: 0.3.1
       zod-to-json-schema:
         specifier: 'catalog:'
@@ -1659,7 +1662,7 @@ importers:
         specifier: ^7.8.5
         version: 7.8.5
       uniku:
-        specifier: ^0.3.1
+        specifier: 'catalog:'
         version: 0.3.1
       zod:
         specifier: '>=3.25.76 <5'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -57,7 +57,7 @@ catalog:
   tsdown: ^0.22.3
   tsx: ^4.23.0
   typescript: ^6.0.3
-  uniku: ^0.3.1
+  uniku: 0.3.1
   '@vitest/ui': ^4.1.10
   vitest: ^4.1.10
   wrangler: ^4.107.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -57,7 +57,7 @@ catalog:
   tsdown: ^0.22.3
   tsx: ^4.23.0
   typescript: ^6.0.3
-  uniku: 0.3.1
+  uniku: 0.2.0
   '@vitest/ui': ^4.1.10
   vitest: ^4.1.10
   wrangler: ^4.107.0
@@ -70,7 +70,6 @@ minimumReleaseAgeExclude:
   - '@mastra/core'
   - '@composio/client'
   - chrome-devtools-mcp
-  - uniku
 
 peerDependencyRules:
   allowedVersions:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -69,6 +69,7 @@ minimumReleaseAgeExclude:
   - '@mastra/core'
   - '@composio/client'
   - chrome-devtools-mcp
+  - uniku
 
 peerDependencyRules:
   allowedVersions:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -57,6 +57,7 @@ catalog:
   tsdown: ^0.22.3
   tsx: ^4.23.0
   typescript: ^6.0.3
+  uniku: ^0.3.1
   '@vitest/ui': ^4.1.10
   vitest: ^4.1.10
   wrangler: ^4.107.0

--- a/ts/packages/cli-keyring/package.json
+++ b/ts/packages/cli-keyring/package.json
@@ -56,6 +56,7 @@
     "effect": "^3.21.4",
     "tsdown": "catalog:",
     "typescript": "catalog:",
+    "uniku": "^0.3.1",
     "vitest": "catalog:"
   },
   "peerDependencies": {

--- a/ts/packages/cli-keyring/package.json
+++ b/ts/packages/cli-keyring/package.json
@@ -56,7 +56,7 @@
     "effect": "^3.21.4",
     "tsdown": "catalog:",
     "typescript": "catalog:",
-    "uniku": "^0.3.1",
+    "uniku": "catalog:",
     "vitest": "catalog:"
   },
   "peerDependencies": {

--- a/ts/packages/cli-keyring/test/e2e.test.ts
+++ b/ts/packages/cli-keyring/test/e2e.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, it, expect, afterAll, beforeAll } from 'vitest';
-import { randomUUID } from 'node:crypto';
+import { uuidv4 } from 'uniku/uuid/v4';
 import { Entry } from '../src/core/entry';
 import { KeyringError } from '../src/core/errors';
 import { createDefaultStore, setDefaultStore } from '../src/index';
@@ -25,7 +25,7 @@ suite('e2e: real OS keystore', () => {
     setDefaultStore(await createDefaultStore());
   });
 
-  const service = `com.composio.cli.test.${randomUUID()}`;
+  const service = `com.composio.cli.test.${uuidv4()}`;
   const user = 'default';
   const entry = new Entry(service, user);
 
@@ -40,7 +40,7 @@ suite('e2e: real OS keystore', () => {
   });
 
   it('roundtrips a password', async () => {
-    const password = `test-${randomUUID()}`;
+    const password = `test-${uuidv4()}`;
     await entry.setPassword(password);
     expect(await entry.getPassword()).toBe(password);
   });

--- a/ts/packages/cli-keyring/test/ffi.test.ts
+++ b/ts/packages/cli-keyring/test/ffi.test.ts
@@ -18,7 +18,7 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { randomUUID } from 'node:crypto';
+import { uuidv4 } from 'uniku/uuid/v4';
 import { Entry } from '../src/core/entry';
 import { KeyringError } from '../src/core/errors';
 import { setDefaultStore, unsetDefaultStore } from '../src/core/store';
@@ -48,9 +48,9 @@ suite('ffi: MacOSSecurityFFIStore roundtrip', () => {
   });
 
   it('roundtrips a password', async () => {
-    const entry = new Entry(`com.composio.cli.ffi.${randomUUID()}`, 'default');
+    const entry = new Entry(`com.composio.cli.ffi.${uuidv4()}`, 'default');
     try {
-      const password = `ffi-${randomUUID()}`;
+      const password = `ffi-${uuidv4()}`;
       await entry.setPassword(password);
       expect(await entry.getPassword()).toBe(password);
     } finally {
@@ -63,7 +63,7 @@ suite('ffi: MacOSSecurityFFIStore roundtrip', () => {
   });
 
   it('overwrites on repeated setPassword without duplicate error', async () => {
-    const entry = new Entry(`com.composio.cli.ffi.${randomUUID()}`, 'default');
+    const entry = new Entry(`com.composio.cli.ffi.${uuidv4()}`, 'default');
     try {
       await entry.setPassword('first');
       await entry.setPassword('second');
@@ -79,14 +79,14 @@ suite('ffi: MacOSSecurityFFIStore roundtrip', () => {
   });
 
   it('throws NoEntry for a missing credential', async () => {
-    const entry = new Entry(`com.composio.cli.ffi.nonexistent.${randomUUID()}`, 'default');
+    const entry = new Entry(`com.composio.cli.ffi.nonexistent.${uuidv4()}`, 'default');
     await expect(entry.getPassword()).rejects.toSatisfy(
       (err: unknown) => err instanceof KeyringError && err.kind === 'NoEntry'
     );
   });
 
   it('roundtrips arbitrary binary bytes', async () => {
-    const entry = new Entry(`com.composio.cli.ffi.bin.${randomUUID()}`, 'default');
+    const entry = new Entry(`com.composio.cli.ffi.bin.${uuidv4()}`, 'default');
     try {
       const bytes = new Uint8Array(256);
       for (let i = 0; i < 256; i++) bytes[i] = i;
@@ -103,7 +103,7 @@ suite('ffi: MacOSSecurityFFIStore roundtrip', () => {
   });
 
   it('delete then read throws NoEntry', async () => {
-    const entry = new Entry(`com.composio.cli.ffi.del.${randomUUID()}`, 'default');
+    const entry = new Entry(`com.composio.cli.ffi.del.${uuidv4()}`, 'default');
     await entry.setPassword('x');
     await entry.deleteCredential();
     await expect(entry.getPassword()).rejects.toSatisfy(

--- a/ts/packages/cli/package.json
+++ b/ts/packages/cli/package.json
@@ -107,6 +107,7 @@
     "source-map-js": "^1.2.1",
     "superjson": "^2.2.6",
     "ts-morph": "^28.0.0",
+    "uniku": "^0.3.1",
     "zod": "catalog:"
   },
   "gitHead": "4fae6e54d5c150fba955cc5fa314281da5a1e064",

--- a/ts/packages/cli/package.json
+++ b/ts/packages/cli/package.json
@@ -107,7 +107,7 @@
     "source-map-js": "^1.2.1",
     "superjson": "^2.2.6",
     "ts-morph": "^28.0.0",
-    "uniku": "^0.3.1",
+    "uniku": "catalog:",
     "zod": "catalog:"
   },
   "gitHead": "4fae6e54d5c150fba955cc5fa314281da5a1e064",

--- a/ts/packages/cli/src/analytics/dispatch.ts
+++ b/ts/packages/cli/src/analytics/dispatch.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import process from 'node:process';
 import { spawn } from 'node:child_process';
 import { Effect } from 'effect';
+import { uuidv4 } from 'uniku/uuid/v4';
 import type { AnalyticsEnvelope, TrackEvent } from './types';
 import * as constants from 'src/constants';
 
@@ -124,7 +125,7 @@ const getOrCreateInstallId = (): string => {
         return parsed.install_id;
       }
     }
-    const installId = crypto.randomUUID();
+    const installId = uuidv4();
     fs.writeFileSync(
       filePath,
       JSON.stringify(
@@ -139,7 +140,7 @@ const getOrCreateInstallId = (): string => {
     );
     return installId;
   } catch {
-    return crypto.randomUUID();
+    return uuidv4();
   }
 };
 

--- a/ts/packages/cli/src/analytics/events.ts
+++ b/ts/packages/cli/src/analytics/events.ts
@@ -1,4 +1,5 @@
 import type { CliCommandTelemetryContext, TrackEvent } from './types';
+import { uuidv4 } from 'uniku/uuid/v4';
 import { ToolInputValidationError } from 'src/services/tool-input-validation';
 import { toolkitFromToolSlug } from 'src/utils/toolkit-from-tool-slug';
 
@@ -347,7 +348,7 @@ export const createCliCommandTelemetryContext = (
   startedAt: Date.now(),
   runId:
     extractCommandPath(argv) === 'run'
-      ? (process.env.COMPOSIO_CLI_PARENT_RUN_ID ?? crypto.randomUUID())
+      ? (process.env.COMPOSIO_CLI_PARENT_RUN_ID ?? uuidv4())
       : undefined,
 });
 

--- a/ts/packages/cli/src/commands/listen.cmd.ts
+++ b/ts/packages/cli/src/commands/listen.cmd.ts
@@ -3,6 +3,7 @@ import { FileSystem } from '@effect/platform';
 import type { Composio as RawComposioClient } from '@composio/client';
 import { Deferred, Effect, Option, Runtime } from 'effect';
 import path from 'node:path';
+import { nanoid } from 'uniku/nanoid';
 import { requireAuth } from 'src/effects/require-auth';
 import { resolveOptionalTextInput } from 'src/effects/resolve-optional-text-input';
 import { ComposioClientSingleton } from 'src/services/composio-clients';
@@ -185,7 +186,7 @@ const extractEventFileId = (eventData: Record<string, unknown>): string => {
     }
   }
 
-  return `${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
+  return `${Date.now()}-${nanoid(8)}`;
 };
 
 const resolveFallbackArtifactsDir = () => resolveArtifactsRoot();

--- a/ts/packages/cli/src/commands/run.cmd.ts
+++ b/ts/packages/cli/src/commands/run.cmd.ts
@@ -6,6 +6,7 @@ import { pathToFileURL } from 'node:url';
 import { Args, Command, Options } from '@effect/cli';
 import { Effect, Option } from 'effect';
 import { ts } from 'ts-morph';
+import { uuidv4 } from 'uniku/uuid/v4';
 import { APP_VERSION } from 'src/constants';
 import { resolveCommandProject } from 'src/services/command-project';
 import { type RunHelperContext } from 'src/services/run-helpers-runtime';
@@ -417,7 +418,7 @@ export const runCmd = Command.make('run', {
       args,
     }) =>
       Effect.gen(function* () {
-        const runId = process.env.COMPOSIO_CLI_PARENT_RUN_ID ?? crypto.randomUUID();
+        const runId = process.env.COMPOSIO_CLI_PARENT_RUN_ID ?? uuidv4();
         const perfDebug = isPerfDebugEnabled();
         const toolDebug = isToolDebugEnabled();
         const acpOnly = process.env.COMPOSIO_RUN_ACP_ONLY === '1';

--- a/ts/packages/cli/src/commands/triggers/commands/triggers.listen.cmd.ts
+++ b/ts/packages/cli/src/commands/triggers/commands/triggers.listen.cmd.ts
@@ -2,6 +2,7 @@ import { Command, Options } from '@effect/cli';
 import { FileSystem } from '@effect/platform';
 import { Deferred, Effect, Option, Runtime } from 'effect';
 import path from 'node:path';
+import { uuidv4 } from 'uniku/uuid/v4';
 import { requireAuth } from 'src/effects/require-auth';
 import { TerminalUI } from 'src/services/terminal-ui';
 import { TriggersRealtime } from 'src/services/triggers-realtime';
@@ -77,7 +78,7 @@ const out = Options.text('out').pipe(
   Options.optional
 );
 
-const randomUUID = () => crypto.randomUUID();
+const generateUuid = () => uuidv4();
 
 const signWebhookPayload = async ({
   secret,
@@ -183,7 +184,7 @@ export const triggersCmd$Listen = Command.make(
       const realtime = yield* TriggersRealtime;
       const runtime = yield* Effect.runtime<never>();
       const forwardUrl = Option.getOrUndefined(forward);
-      const generatedWebhookSecret = `composio-forward-secret-${randomUUID()}`;
+      const generatedWebhookSecret = `composio-forward-secret-${generateUuid()}`;
       const webhookSecret = process.env.COMPOSIO_WEBHOOK_SECRET ?? generatedWebhookSecret;
       const outputFilePathOption = Option.getOrUndefined(out);
       const outputFilePath = outputFilePathOption ? path.resolve(outputFilePathOption) : undefined;
@@ -282,7 +283,7 @@ export const triggersCmd$Listen = Command.make(
                 const webhookId =
                   typeof eventData.id === 'string' && eventData.id.length > 0
                     ? eventData.id
-                    : randomUUID();
+                    : generateUuid();
                 const webhookTimestamp = `${Math.floor(Date.now() / 1000)}`;
                 const webhookSignature = yield* Effect.tryPromise({
                   try: () =>

--- a/ts/packages/cli/src/services/cli-session-artifacts.ts
+++ b/ts/packages/cli/src/services/cli-session-artifacts.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { Effect, Option } from 'effect';
+import { nanoid } from 'uniku/nanoid';
 import { getOrCreateProbablyMyCliSessionIdForCurrentCwd } from 'src/services/consumer-short-term-cache';
 import { resolveCliConfigPathSync } from 'src/services/cli-user-config';
 
@@ -32,7 +33,7 @@ export type CliSessionArtifacts = {
   readonly historyFilePath: string;
 };
 
-const randomToken = (length = 8) => crypto.randomUUID().replace(/-/g, '').slice(0, length);
+const randomToken = (length = 8) => nanoid(length);
 
 const sanitizeArtifactName = (value: string): string =>
   value.replace(/[^A-Z0-9_]+/gi, '_').replace(/^_+|_+$/g, '') || 'ARTIFACT';

--- a/ts/packages/cli/src/services/consumer-short-term-cache.ts
+++ b/ts/packages/cli/src/services/consumer-short-term-cache.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import { FileSystem } from '@effect/platform';
 import { Effect, Option } from 'effect';
+import { nanoid } from 'uniku/nanoid';
 import { APP_CONFIG } from 'src/effects/app-config';
 import { setupCacheDir } from 'src/effects/setup-cache-dir';
 import { NodeProcess } from 'src/services/node-process';
@@ -60,7 +61,7 @@ const cwdHash = (cwd: string): string => {
 };
 
 const createProbablyMyCliSessionId = (cwd: string): string => {
-  const random = crypto.randomUUID().replace(/-/g, '').slice(0, 10);
+  const random = nanoid(10);
   return `cli_s_${cwdHash(cwd)}_${random}`;
 };
 

--- a/ts/packages/cli/src/services/run-helpers-runtime.ts
+++ b/ts/packages/cli/src/services/run-helpers-runtime.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import process from 'node:process';
+import { nanoid } from 'uniku/nanoid';
 import { z } from 'zod';
 import { resolveCliConfigPathSync } from 'src/services/cli-user-config';
 import type { MasterKind } from 'src/services/master-detector';
@@ -188,7 +189,7 @@ export const installRunHelpers = async ({
     helperContext.toolDebug === true || process.env.COMPOSIO_TOOL_DEBUG === '1';
   const perfDebugStart = Date.now();
   let perfDebugSeq = 0;
-  const executeId = () => crypto.randomUUID().slice(0, 8);
+  const executeId = () => nanoid(8);
   const proxySessionCache = new Map<string, string>();
   const composioBaseURL = (helperContext.baseURL || 'https://backend.composio.dev').replace(
     /\/$/,

--- a/ts/packages/cli/src/services/tool-permissions.ts
+++ b/ts/packages/cli/src/services/tool-permissions.ts
@@ -5,6 +5,7 @@ import open from 'open';
 import { detectCliPlatform } from '@composio/cli-local-tools';
 import { Effect, Option } from 'effect';
 import { resolveCliConfigDirectorySync } from 'src/services/cli-user-config';
+import { uuidv4 } from 'uniku/uuid/v4';
 import {
   detectNativeUiCallerAgent,
   requestNativeUiPermissionDecision,
@@ -119,7 +120,7 @@ const writeCacheFile = async (cache: CacheFile): Promise<void> => {
   const targetPath = cachePath();
   await fs.mkdir(path.dirname(targetPath), { recursive: true });
 
-  const tempPath = `${targetPath}.${process.pid}.${Date.now()}.${crypto.randomUUID()}.tmp`;
+  const tempPath = `${targetPath}.${process.pid}.${Date.now()}.${uuidv4()}.tmp`;
   try {
     await fs.writeFile(
       tempPath,
@@ -766,7 +767,7 @@ const requestPermissionInBrowser = (params: {
   readonly agent: NativeUiCallerAgent;
 }): Promise<PermissionDecision> =>
   new Promise((resolve, reject) => {
-    const token = crypto.randomUUID();
+    const token = uuidv4();
     let settled = false;
 
     const settle = (decision: PermissionDecision) => {

--- a/ts/packages/core/package.json
+++ b/ts/packages/core/package.json
@@ -113,6 +113,7 @@
     "picocolors": "catalog:",
     "pusher-js": "^8.5.0",
     "semver": "^7.8.5",
+    "uniku": "^0.3.1",
     "zod-to-json-schema": "catalog:"
   },
   "gitHead": "4fae6e54d5c150fba955cc5fa314281da5a1e064",

--- a/ts/packages/core/package.json
+++ b/ts/packages/core/package.json
@@ -113,7 +113,7 @@
     "picocolors": "catalog:",
     "pusher-js": "^8.5.0",
     "semver": "^7.8.5",
-    "uniku": "^0.3.1",
+    "uniku": "catalog:",
     "zod-to-json-schema": "catalog:"
   },
   "gitHead": "4fae6e54d5c150fba955cc5fa314281da5a1e064",

--- a/ts/packages/core/src/utils/uuid.ts
+++ b/ts/packages/core/src/utils/uuid.ts
@@ -1,7 +1,10 @@
+import { nanoid } from 'uniku/nanoid';
+import { uuidv4 } from 'uniku/uuid/v4';
+
 export function getRandomUUID(): string {
-  return globalThis.crypto.randomUUID();
+  return uuidv4();
 }
 
 export function getRandomShortId(): string {
-  return getRandomUUID().slice(0, 8).replace(/-/g, '');
+  return nanoid(8);
 }

--- a/ts/packages/core/test/utils/uuid.test.ts
+++ b/ts/packages/core/test/utils/uuid.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { getRandomShortId, getRandomUUID } from '../../src/utils/uuid';
+
+describe('UUID utilities', () => {
+  it('generates UUID v4 values', () => {
+    expect(getRandomUUID()).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    );
+  });
+
+  it('generates eight-character URL-safe identifiers', () => {
+    expect(getRandomShortId()).toMatch(/^[A-Za-z0-9_-]{8}$/);
+  });
+});

--- a/ts/packages/slim/package.json
+++ b/ts/packages/slim/package.json
@@ -105,6 +105,7 @@
     "picocolors": "catalog:",
     "pusher-js": "^8.5.0",
     "semver": "^7.8.5",
+    "uniku": "^0.3.1",
     "zod-to-json-schema": "catalog:"
   },
   "repository": {

--- a/ts/packages/slim/package.json
+++ b/ts/packages/slim/package.json
@@ -105,7 +105,7 @@
     "picocolors": "catalog:",
     "pusher-js": "^8.5.0",
     "semver": "^7.8.5",
-    "uniku": "^0.3.1",
+    "uniku": "catalog:",
     "zod-to-json-schema": "catalog:"
   },
   "repository": {


### PR DESCRIPTION
This PR:
- unifies how IDs are generated, replacing the current mixture of platform APIs and derived strings
- preserves UUID v4 values for run, analytics, webhook, and permission identifiers
- uses compact URL-safe identifiers for generated filenames, paths, and session artifacts without increasing their lengths
- keeps the Slim package's copied Core runtime importable by mirroring its runtime dependencies
- adds coverage for the UUID and short-ID utility contracts