### PR TITLE
fix(ts): point published package homepage links at the next branch

### DIFF
--- a/.changeset/fix-package-homepage-branch.md
+++ b/.changeset/fix-package-homepage-branch.md
@@ -1,0 +1,18 @@
+---
+'@composio/core': patch
+'@composio/slim': patch
+'@composio/experimental': patch
+'@composio/json-schema-to-zod': patch
+'@composio/anthropic': patch
+'@composio/claude-agent-sdk': patch
+'@composio/cloudflare': patch
+'@composio/google': patch
+'@composio/langchain': patch
+'@composio/llamaindex': patch
+'@composio/mastra': patch
+'@composio/openai': patch
+'@composio/openai-agents': patch
+'@composio/vercel': patch
+---
+
+Fix the `homepage` links in these packages' `package.json`. They pointed at `github.com/ComposioHQ/composio/tree/main/...`, but the default branch is `next` and no `main` branch exists, so every link 404'd on npm and in editor tooltips. They now point at `tree/next/...`.

--- a/ts/packages/core/package.json
+++ b/ts/packages/core/package.json
@@ -124,5 +124,5 @@
   "bugs": {
     "url": "https://github.com/ComposioHQ/composio/issues"
   },
-  "homepage": "https://github.com/ComposioHQ/composio/tree/main/ts/packages/core#readme"
+  "homepage": "https://github.com/ComposioHQ/composio/tree/next/ts/packages/core#readme"
 }

--- a/ts/packages/experimental/package.json
+++ b/ts/packages/experimental/package.json
@@ -12,7 +12,7 @@
   "bugs": {
     "url": "https://github.com/ComposioHQ/composio/issues"
   },
-  "homepage": "https://github.com/ComposioHQ/composio/tree/main/ts/packages/experimental#readme",
+  "homepage": "https://github.com/ComposioHQ/composio/tree/next/ts/packages/experimental#readme",
   "publishConfig": {
     "access": "public",
     "main": "dist/index.mjs",

--- a/ts/packages/json-schema-to-zod/package.json
+++ b/ts/packages/json-schema-to-zod/package.json
@@ -12,7 +12,7 @@
   "bugs": {
     "url": "https://github.com/ComposioHQ/composio/issues"
   },
-  "homepage": "https://github.com/ComposioHQ/composio/tree/main/ts/packages/json-schema-to-zod#readme",
+  "homepage": "https://github.com/ComposioHQ/composio/tree/next/ts/packages/json-schema-to-zod#readme",
   "publishConfig": {
     "access": "public",
     "main": "dist/index.mjs",

--- a/ts/packages/providers/anthropic/package.json
+++ b/ts/packages/providers/anthropic/package.json
@@ -12,7 +12,7 @@
   "bugs": {
     "url": "https://github.com/ComposioHQ/composio/issues"
   },
-  "homepage": "https://github.com/ComposioHQ/composio/tree/main/ts/packages/providers/anthropic#readme",
+  "homepage": "https://github.com/ComposioHQ/composio/tree/next/ts/packages/providers/anthropic#readme",
   "publishConfig": {
     "access": "public",
     "main": "dist/index.mjs",

--- a/ts/packages/providers/claude-agent-sdk/package.json
+++ b/ts/packages/providers/claude-agent-sdk/package.json
@@ -12,7 +12,7 @@
   "bugs": {
     "url": "https://github.com/ComposioHQ/composio/issues"
   },
-  "homepage": "https://github.com/ComposioHQ/composio/tree/main/ts/packages/providers/claude-agent-sdk#readme",
+  "homepage": "https://github.com/ComposioHQ/composio/tree/next/ts/packages/providers/claude-agent-sdk#readme",
   "publishConfig": {
     "access": "public",
     "main": "dist/index.mjs",

--- a/ts/packages/providers/cloudflare/package.json
+++ b/ts/packages/providers/cloudflare/package.json
@@ -12,7 +12,7 @@
   "bugs": {
     "url": "https://github.com/ComposioHQ/composio/issues"
   },
-  "homepage": "https://github.com/ComposioHQ/composio/tree/main/ts/packages/providers/cloudflare#readme",
+  "homepage": "https://github.com/ComposioHQ/composio/tree/next/ts/packages/providers/cloudflare#readme",
   "publishConfig": {
     "access": "public",
     "main": "dist/index.mjs",

--- a/ts/packages/providers/google/package.json
+++ b/ts/packages/providers/google/package.json
@@ -12,7 +12,7 @@
   "bugs": {
     "url": "https://github.com/ComposioHQ/composio/issues"
   },
-  "homepage": "https://github.com/ComposioHQ/composio/tree/main/ts/packages/providers/google#readme",
+  "homepage": "https://github.com/ComposioHQ/composio/tree/next/ts/packages/providers/google#readme",
   "publishConfig": {
     "access": "public",
     "main": "dist/index.mjs",

--- a/ts/packages/providers/langchain/package.json
+++ b/ts/packages/providers/langchain/package.json
@@ -12,7 +12,7 @@
   "bugs": {
     "url": "https://github.com/ComposioHQ/composio/issues"
   },
-  "homepage": "https://github.com/ComposioHQ/composio/tree/main/ts/packages/providers/langchain#readme",
+  "homepage": "https://github.com/ComposioHQ/composio/tree/next/ts/packages/providers/langchain#readme",
   "publishConfig": {
     "access": "public",
     "main": "dist/index.mjs",

--- a/ts/packages/providers/llamaindex/package.json
+++ b/ts/packages/providers/llamaindex/package.json
@@ -12,7 +12,7 @@
   "bugs": {
     "url": "https://github.com/ComposioHQ/composio/issues"
   },
-  "homepage": "https://github.com/ComposioHQ/composio/tree/main/ts/packages/providers/llamaindex#readme",
+  "homepage": "https://github.com/ComposioHQ/composio/tree/next/ts/packages/providers/llamaindex#readme",
   "publishConfig": {
     "access": "public",
     "main": "dist/index.mjs",

--- a/ts/packages/providers/mastra/package.json
+++ b/ts/packages/providers/mastra/package.json
@@ -12,7 +12,7 @@
   "bugs": {
     "url": "https://github.com/ComposioHQ/composio/issues"
   },
-  "homepage": "https://github.com/ComposioHQ/composio/tree/main/ts/packages/providers/mastra#readme",
+  "homepage": "https://github.com/ComposioHQ/composio/tree/next/ts/packages/providers/mastra#readme",
   "publishConfig": {
     "access": "public",
     "main": "dist/index.mjs",

--- a/ts/packages/providers/openai-agents/package.json
+++ b/ts/packages/providers/openai-agents/package.json
@@ -12,7 +12,7 @@
   "bugs": {
     "url": "https://github.com/ComposioHQ/composio/issues"
   },
-  "homepage": "https://github.com/ComposioHQ/composio/tree/main/ts/packages/providers/openai-agents#readme",
+  "homepage": "https://github.com/ComposioHQ/composio/tree/next/ts/packages/providers/openai-agents#readme",
   "publishConfig": {
     "access": "public",
     "main": "dist/index.mjs",

--- a/ts/packages/providers/openai/package.json
+++ b/ts/packages/providers/openai/package.json
@@ -12,7 +12,7 @@
   "bugs": {
     "url": "https://github.com/ComposioHQ/composio/issues"
   },
-  "homepage": "https://github.com/ComposioHQ/composio/tree/main/ts/packages/providers/openai#readme",
+  "homepage": "https://github.com/ComposioHQ/composio/tree/next/ts/packages/providers/openai#readme",
   "publishConfig": {
     "access": "public",
     "main": "dist/index.mjs",

--- a/ts/packages/providers/vercel/package.json
+++ b/ts/packages/providers/vercel/package.json
@@ -12,7 +12,7 @@
   "bugs": {
     "url": "https://github.com/ComposioHQ/composio/issues"
   },
-  "homepage": "https://github.com/ComposioHQ/composio/tree/main/ts/packages/providers/vercel#readme",
+  "homepage": "https://github.com/ComposioHQ/composio/tree/next/ts/packages/providers/vercel#readme",
   "publishConfig": {
     "access": "public",
     "main": "dist/index.mjs",

--- a/ts/packages/slim/package.json
+++ b/ts/packages/slim/package.json
@@ -115,5 +115,5 @@
   "bugs": {
     "url": "https://github.com/ComposioHQ/composio/issues"
   },
-  "homepage": "https://github.com/ComposioHQ/composio/tree/main/ts/packages/slim#readme"
+  "homepage": "https://github.com/ComposioHQ/composio/tree/next/ts/packages/slim#readme"
 }


### PR DESCRIPTION

The `homepage` field in every published TypeScript package points at
`https://github.com/ComposioHQ/composio/tree/main/ts/packages/<pkg>#readme`. The
repository's default branch is `next` and there is no `main` branch, and GitHub
does not redirect `tree/<branch>` paths to the default branch when that branch
does not exist. As a result each of these homepage links returns a 404 wherever
it is surfaced (the package page on npmjs.com, editor/IntelliSense hovers, and
`npm view <pkg> homepage`).

This repoints each `homepage` to `tree/next/...` so the links resolve. The
`repository.url` (plain `.git` URL) and `bugs.url` fields were already correct
and are left untouched.

The metadata was originally added in #3611; this only corrects the branch in the
`homepage` URLs.

Fixes #

## Changes
- Update the `homepage` field from `tree/main/...` to `tree/next/...` in the 14
  published packages that carry one: `@composio/core`, `@composio/slim`,
  `@composio/experimental`, `@composio/json-schema-to-zod`, and the providers
  `@composio/anthropic`, `@composio/claude-agent-sdk`, `@composio/cloudflare`,
  `@composio/google`, `@composio/langchain`, `@composio/llamaindex`,
  `@composio/mastra`, `@composio/openai`, `@composio/openai-agents`,
  `@composio/vercel`.
- Add a Changeset (patch) covering those 14 published packages.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [ ] Documentation
- [ ] Breaking change

## How Has This Been Tested?
Metadata-only change, so there is no unit test to add. Verified with:

- Confirmed the target branch: `git ls-remote --symref origin HEAD` reports
  `refs/heads/next`, and `git ls-remote --heads origin main` is empty (no `main`).
- Confirmed the links resolve: `https://github.com/ComposioHQ/composio/tree/main/ts/packages/core`
  returns HTTP 404 while `.../tree/next/ts/packages/core` returns HTTP 200
  (same for the provider packages).
- All 14 edited `package.json` files still parse as valid JSON.
- `pnpm exec prettier --check` on the 14 `package.json` files and the changeset:
  all pass.
- `pnpm changeset status --since=origin/next` lists exactly these 14 packages
  bumping at `patch` (no missing or extra packages), so the changeset CI check is
  satisfied.

Environment: node 26, pnpm 10.28.0.

## Screenshots (if applicable)

## Checklist
- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed
- [ ] I updated documentation as needed
- [x] I added tests or explain why not applicable
- [x] I added a changeset if this change affects published packages

## Additional context
The `homepage` URLs pin an explicit branch (`tree/<branch>`), so they will break
again if the default branch is ever renamed. If you would prefer a
branch-agnostic form (for example dropping the `tree/<branch>` segment so the URL
tracks the default branch, or linking to the published README), I am happy to
switch to that instead; I went with the smallest correct fix of pointing at the
actual default branch.

