### PR TITLE
fix(py): handle list-valued JSON Schema type in openapi signatures

### DIFF
--- a/python/composio/utils/openapi.py
+++ b/python/composio/utils/openapi.py
@@ -42,12 +42,14 @@ def _type_to_parameter(schema: t.Dict[str, t.Any]) -> t.Any:
     if isinstance(p_type, list):
         # JSON Schema Draft 2020-12 / OpenAPI 3.1 express a nullable field as a
         # list of types, e.g. {"type": ["string", "null"]}, rather than an anyOf.
-        # A list is unhashable, so the membership test below would raise
-        # TypeError. Map each member to a Python type (falling back to t.Any for
-        # unrecognized types) and build a Union, mirroring the anyOf/oneOf path.
         if not p_type:
             return t.Any
-        return t.Union[tuple(OPENAPI_TO_PYTHON.get(member, t.Any) for member in p_type)]
+        return t.Union[
+            tuple(
+                _type_to_parameter(schema={**schema, "type": member})
+                for member in p_type
+            )
+        ]
 
     if p_type in OPENAPI_TO_PYTHON:
         return OPENAPI_TO_PYTHON[p_type]

--- a/python/composio/utils/openapi.py
+++ b/python/composio/utils/openapi.py
@@ -39,6 +39,16 @@ def _type_to_parameter(schema: t.Dict[str, t.Any]) -> t.Any:
         return _handle_enum_type(schema=schema)
 
     p_type = schema.get("type")
+    if isinstance(p_type, list):
+        # JSON Schema Draft 2020-12 / OpenAPI 3.1 express a nullable field as a
+        # list of types, e.g. {"type": ["string", "null"]}, rather than an anyOf.
+        # A list is unhashable, so the membership test below would raise
+        # TypeError. Map each member to a Python type (falling back to t.Any for
+        # unrecognized types) and build a Union, mirroring the anyOf/oneOf path.
+        if not p_type:
+            return t.Any
+        return t.Union[tuple(OPENAPI_TO_PYTHON.get(member, t.Any) for member in p_type)]
+
     if p_type in OPENAPI_TO_PYTHON:
         return OPENAPI_TO_PYTHON[p_type]
 

--- a/python/tests/test_openapi.py
+++ b/python/tests/test_openapi.py
@@ -10,6 +10,7 @@ import typing as t
 
 import pytest
 
+from composio.exceptions import InvalidSchemaError
 from composio.utils.openapi import function_signature_from_jsonschema
 
 
@@ -134,11 +135,18 @@ class TestListValuedType:
 
     @pytest.mark.unit
     @pytest.mark.schema
-    def test_unrecognized_member_falls_back_to_any(self):
-        annotation = _annotation({"type": ["file", "null"]})
-        args = t.get_args(annotation)
-        assert t.Any in args
-        assert type(None) in args
+    def test_nullable_array_preserves_items_schema(self):
+        assert (
+            _annotation({"type": ["array", "null"], "items": {"type": "string"}})
+            == t.Optional[t.List[str]]
+        )
+
+    @pytest.mark.unit
+    @pytest.mark.schema
+    @pytest.mark.parametrize("property_type", ["file", ["file", "null"]])
+    def test_unrecognized_member_raises_invalid_schema(self, property_type: t.Any):
+        with pytest.raises(InvalidSchemaError, match="Invalid property type file"):
+            _annotation({"type": property_type})
 
     @pytest.mark.unit
     @pytest.mark.schema

--- a/python/tests/test_openapi.py
+++ b/python/tests/test_openapi.py
@@ -106,3 +106,41 @@ class TestExistingShapesUnchanged:
     @pytest.mark.schema
     def test_typeless_property_is_any(self):
         assert _annotation({"description": "free form"}) is t.Any
+
+
+class TestListValuedType:
+    """A list-valued ``type`` (e.g. ``["string", "null"]``) resolves to a Union.
+
+    JSON Schema Draft 2020-12 / OpenAPI 3.1 express a nullable field as a list of
+    types rather than an ``anyOf``. A list is unhashable, so the older
+    ``p_type in OPENAPI_TO_PYTHON`` membership test raised
+    ``TypeError: unhashable type: 'list'`` and crashed tool wrapping.
+    """
+
+    @pytest.mark.unit
+    @pytest.mark.schema
+    def test_nullable_list_is_optional(self):
+        assert _annotation({"type": ["string", "null"]}) == t.Optional[str]
+
+    @pytest.mark.unit
+    @pytest.mark.schema
+    def test_single_member_list_resolves_to_that_type(self):
+        assert _annotation({"type": ["integer"]}) is int
+
+    @pytest.mark.unit
+    @pytest.mark.schema
+    def test_multiple_non_null_members_build_a_union(self):
+        assert _annotation({"type": ["string", "integer"]}) == t.Union[str, int]
+
+    @pytest.mark.unit
+    @pytest.mark.schema
+    def test_unrecognized_member_falls_back_to_any(self):
+        annotation = _annotation({"type": ["file", "null"]})
+        args = t.get_args(annotation)
+        assert t.Any in args
+        assert type(None) in args
+
+    @pytest.mark.unit
+    @pytest.mark.schema
+    def test_empty_list_resolves_to_any(self):
+        assert _annotation({"type": []}) is t.Any


### PR DESCRIPTION
`_type_to_parameter` in `python/composio/utils/openapi.py` assumed a property's
`type` was a scalar string. JSON Schema Draft 2020-12 and OpenAPI 3.1 can express
a nullable field as a list of types instead, for example
`{"type": ["string", "null"]}`. Passing that list to the scalar membership check
raised `TypeError: unhashable type: 'list'`, which could break tool signature
generation in providers such as `google_adk`.

## Changes

- Handle list-valued `type` definitions as unions.
- Re-run every member through `_type_to_parameter` with a copy of the full
  property schema and only `type` replaced. This preserves sibling fields such
  as an array's `items`, so `{"type": ["array", "null"], "items": ...}` resolves
  to `Optional[List[...]]`.
- Preserve scalar error behavior for invalid member types: an unknown type in a
  list raises `InvalidSchemaError` instead of silently becoming `Any`.
- Keep the existing empty-list fallback to `Any`.
- Add regression coverage for nullable arrays and scalar/list unknown-type
  parity alongside the existing list-valued type cases.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [ ] Documentation
- [ ] Breaking change

## Verification

From `python/`:

- `uv run pytest tests/test_openapi.py -q` — 18 passed.
- `make chk` — Ruff and mypy passed across the Python SDK, providers, tests,
  examples, and scripts.

## Checklist

- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed
- [ ] I updated documentation as needed (not applicable: internal helper)
- [x] I added regression tests
- [ ] I added a changeset (not applicable: Python-only change)
