### PR TITLE
fix(py): guard URL uploads and redact telemetry

### DIFF
--- a/python/composio/core/models/_files.py
+++ b/python/composio/core/models/_files.py
@@ -25,6 +25,7 @@ from composio.exceptions import (
 )
 from composio.utils import mimetypes
 from composio.utils.json_schema import dereference_json_schema
+from composio.utils.url_safety import assert_safe_fetch_target
 from composio.utils.sensitive_file_upload_paths import (
     assert_safe_local_file_upload_path,
 )
@@ -281,6 +282,8 @@ def _fetch_file_from_url(
         ResponseTooLargeError: If response exceeds max_size
         ErrorUploadingFile: If fetch fails for other reasons
     """
+    assert_safe_fetch_target(url)
+
     # Make request without following redirects
     try:
         response = requests.get(

--- a/python/composio/core/models/base.py
+++ b/python/composio/core/models/base.py
@@ -11,6 +11,7 @@ import typing as t
 
 from composio.__version__ import __version__
 from composio.client import HttpClient
+from composio.utils.redaction import redact_sensitive_text
 from composio.utils.logging import WithLogger
 
 from ._telemetry import Event, create_event, push_event
@@ -56,8 +57,8 @@ def trace_method(method: t.Callable, name: str) -> t.Callable:
             _, payload = event
             payload["error"] = {
                 "name": e.__class__.__name__,
-                "message": str(e),
-                "stack": traceback.format_exc(),
+                "message": redact_sensitive_text(str(e)),
+                "stack": redact_sensitive_text(traceback.format_exc()),
             }
             event = ("error", payload)
             raise e

--- a/python/composio/core/models/tool_router_session_files.py
+++ b/python/composio/core/models/tool_router_session_files.py
@@ -24,6 +24,7 @@ from composio_client.types.tool_router.session.file_list_response import (
 from composio.client import HttpClient
 from composio.exceptions import RemoteFileDownloadError, ValidationError
 from composio.utils.mimetypes import get_extension_from_mime_type
+from composio.utils.url_safety import assert_safe_fetch_target
 from composio.utils.uuid import generate_short_id
 
 DEFAULT_TOOL_ROUTER_SESSION_FILES_MOUNT_ID = "files"
@@ -46,6 +47,7 @@ def _is_url(value: str) -> bool:
 
 def _fetch_from_url(url: str) -> t.Tuple[bytes, str]:
     """Fetch file content from URL. Returns (content, mimetype)."""
+    assert_safe_fetch_target(url)
     try:
         response = requests.get(
             url,

--- a/python/composio/exceptions.py
+++ b/python/composio/exceptions.py
@@ -187,6 +187,10 @@ class ErrorUploadingFile(FileError):
     pass
 
 
+class BlockedInternalUrlError(FileError):
+    """Raised when a URL file input resolves to a non-public network address."""
+
+
 class SensitiveFilePathBlockedError(FileError):
     """Raised when a local file path is refused before upload (sensitive directory or credential-like name)."""
 

--- a/python/composio/utils/redaction.py
+++ b/python/composio/utils/redaction.py
@@ -1,0 +1,20 @@
+"""Best-effort secret redaction for free-form telemetry text."""
+
+from __future__ import annotations
+
+import re
+
+_REDACTED = "[REDACTED]"
+_URL_QUERY = re.compile(r"(\bhttps?://[^\s?#'\"]+)\?[^\s'\"]*", re.IGNORECASE)
+_AUTHORIZATION = re.compile(r"\b(bearer|basic)\s+[A-Za-z0-9._~+/=-]+", re.IGNORECASE)
+_SECRET_PAIR = re.compile(
+    r"\b(authorization|api[-_]?key|apikey|x-api-key|access[-_]?token|refresh[-_]?token|client[-_]?secret|secret|password|passwd|pwd)\b(\s*[:=]+\s*)([\"']?)([^\s\"',}&]+)\3",
+    re.IGNORECASE,
+)
+
+
+def redact_sensitive_text(value: str) -> str:
+    """Remove common URL, authorization, and key-value secret shapes."""
+    value = _URL_QUERY.sub(rf"\1?{_REDACTED}", value)
+    value = _AUTHORIZATION.sub(rf"\1 {_REDACTED}", value)
+    return _SECRET_PAIR.sub(rf"\1\2\3{_REDACTED}\3", value)

--- a/python/composio/utils/url_safety.py
+++ b/python/composio/utils/url_safety.py
@@ -16,8 +16,16 @@ def is_blocked_ip(value: str) -> bool:
     except ValueError:
         return True
 
-    if isinstance(address, ipaddress.IPv6Address) and address.ipv4_mapped:
-        return is_blocked_ip(str(address.ipv4_mapped))
+    if isinstance(address, ipaddress.IPv6Address):
+        embedded_ipv4 = address.ipv4_mapped
+        if embedded_ipv4 is None and address.packed[:12] in {
+            b"\x00" * 12,
+            b"\x00d\xff\x9b" + b"\x00" * 8,
+        }:
+            embedded_ipv4 = ipaddress.IPv4Address(address.packed[-4:])
+        if embedded_ipv4 is not None:
+            return is_blocked_ip(str(embedded_ipv4))
+
     return not address.is_global
 
 
@@ -28,9 +36,14 @@ def assert_safe_fetch_target(url: str) -> None:
         raise BlockedInternalUrlError("Refusing to fetch a non-http(s) URL")
 
     try:
-        addresses = {
-            result[4][0] for result in socket.getaddrinfo(parsed.hostname, None)
-        }
+        addresses: set[str] = set()
+        for result in socket.getaddrinfo(parsed.hostname, None):
+            address = result[4][0]
+            if not isinstance(address, str):
+                raise BlockedInternalUrlError(
+                    f'Could not resolve host "{parsed.hostname}"'
+                )
+            addresses.add(address)
     except socket.gaierror as error:
         raise BlockedInternalUrlError(
             f'Could not resolve host "{parsed.hostname}"'

--- a/python/composio/utils/url_safety.py
+++ b/python/composio/utils/url_safety.py
@@ -1,0 +1,43 @@
+"""SSRF protections for user-supplied URL file inputs."""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+from composio.exceptions import BlockedInternalUrlError
+
+
+def is_blocked_ip(value: str) -> bool:
+    """Return whether an address is non-publicly-routable."""
+    try:
+        address = ipaddress.ip_address(value)
+    except ValueError:
+        return True
+
+    if isinstance(address, ipaddress.IPv6Address) and address.ipv4_mapped:
+        return is_blocked_ip(str(address.ipv4_mapped))
+    return not address.is_global
+
+
+def assert_safe_fetch_target(url: str) -> None:
+    """Refuse non-HTTP(S) URLs and hosts that resolve to internal addresses."""
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise BlockedInternalUrlError("Refusing to fetch a non-http(s) URL")
+
+    try:
+        addresses = {
+            result[4][0] for result in socket.getaddrinfo(parsed.hostname, None)
+        }
+    except socket.gaierror as error:
+        raise BlockedInternalUrlError(
+            f'Could not resolve host "{parsed.hostname}"'
+        ) from error
+
+    for address in addresses:
+        if is_blocked_ip(address):
+            raise BlockedInternalUrlError(
+                f'Refusing to fetch "{parsed.hostname}" because it resolves to a non-public address'
+            )

--- a/python/tests/test_files.py
+++ b/python/tests/test_files.py
@@ -2204,8 +2204,9 @@ class TestTruncateFilename:
 class TestFetchFileFromUrlWithTruncation:
     """Test cases for _fetch_file_from_url with filename truncation."""
 
+    @patch("composio.core.models._files.assert_safe_fetch_target")
     @patch("composio.core.models._files.requests.get")
-    def test_fetch_truncates_long_filename(self, mock_get):
+    def test_fetch_truncates_long_filename(self, mock_get, _mock_safe_fetch_target):
         """Long filenames from URLs should be truncated."""
         mock_response = MagicMock()
         mock_response.ok = True
@@ -2244,8 +2245,11 @@ class TestFetchFileFromUrlWithTruncation:
 
         assert filename == "photo.jpg"
 
+    @patch("composio.core.models._files.assert_safe_fetch_target")
     @patch("composio.core.models._files.requests.get")
-    def test_fetch_truncates_after_adding_extension(self, mock_get):
+    def test_fetch_truncates_after_adding_extension(
+        self, mock_get, _mock_safe_fetch_target
+    ):
         """Truncation should happen after extension is appended."""
         mock_response = MagicMock()
         mock_response.ok = True

--- a/python/tests/test_redaction.py
+++ b/python/tests/test_redaction.py
@@ -1,0 +1,15 @@
+"""Tests for telemetry secret redaction."""
+
+from composio.utils.redaction import redact_sensitive_text
+
+
+def test_redacts_url_queries_authorization_and_secret_pairs() -> None:
+    redacted = redact_sensitive_text(
+        "https://example.com/file?signature=secret Bearer token123 api_key=abc password: hunter2"
+    )
+
+    assert "signature=secret" not in redacted
+    assert "token123" not in redacted
+    assert "api_key=abc" not in redacted
+    assert "password: hunter2" not in redacted
+    assert redacted.count("[REDACTED]") == 4

--- a/python/tests/test_url_safety.py
+++ b/python/tests/test_url_safety.py
@@ -1,0 +1,62 @@
+"""Regression tests for URL file-upload SSRF protections."""
+
+from __future__ import annotations
+
+import socket
+from unittest.mock import patch
+
+import pytest
+
+from composio.exceptions import BlockedInternalUrlError
+from composio.utils.url_safety import assert_safe_fetch_target, is_blocked_ip
+
+
+@pytest.mark.parametrize(
+    "address",
+    [
+        "127.0.0.1",
+        "10.0.0.5",
+        "169.254.169.254",
+        "100.64.0.1",
+        "::1",
+        "fc00::1",
+        "::ffff:127.0.0.1",
+    ],
+)
+def test_blocks_non_public_addresses(address: str) -> None:
+    assert is_blocked_ip(address) is True
+
+
+@pytest.mark.parametrize(
+    "address", ["8.8.8.8", "93.184.216.34", "2606:4700:4700::1111"]
+)
+def test_allows_public_addresses(address: str) -> None:
+    assert is_blocked_ip(address) is False
+
+
+@pytest.mark.parametrize(
+    "url", ["file:///etc/passwd", "ftp://example.com/file", "not a url"]
+)
+def test_rejects_non_http_urls(url: str) -> None:
+    with pytest.raises(BlockedInternalUrlError):
+        assert_safe_fetch_target(url)
+
+
+@patch("composio.utils.url_safety.socket.getaddrinfo")
+def test_rejects_internal_dns_answers(mock_getaddrinfo) -> None:
+    mock_getaddrinfo.return_value = [
+        (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0)),
+        (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 0)),
+    ]
+
+    with pytest.raises(BlockedInternalUrlError):
+        assert_safe_fetch_target("https://example.com/file.pdf")
+
+
+@patch("composio.utils.url_safety.socket.getaddrinfo")
+def test_allows_public_dns_answers(mock_getaddrinfo) -> None:
+    mock_getaddrinfo.return_value = [
+        (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0)),
+    ]
+
+    assert_safe_fetch_target("https://example.com/file.pdf")

--- a/python/tests/test_url_safety.py
+++ b/python/tests/test_url_safety.py
@@ -21,6 +21,11 @@ from composio.utils.url_safety import assert_safe_fetch_target, is_blocked_ip
         "::1",
         "fc00::1",
         "::ffff:127.0.0.1",
+        "::127.0.0.1",
+        "::7f00:1",
+        "::169.254.169.254",
+        "64:ff9b::7f00:1",
+        "64:ff9b::a9fe:a9fe",
     ],
 )
 def test_blocks_non_public_addresses(address: str) -> None:
@@ -28,7 +33,14 @@ def test_blocks_non_public_addresses(address: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "address", ["8.8.8.8", "93.184.216.34", "2606:4700:4700::1111"]
+    "address",
+    [
+        "8.8.8.8",
+        "93.184.216.34",
+        "2606:4700:4700::1111",
+        "::8.8.8.8",
+        "64:ff9b::8.8.8.8",
+    ],
 )
 def test_allows_public_addresses(address: str) -> None:
     assert is_blocked_ip(address) is False


### PR DESCRIPTION
This PR:
- ports the TypeScript SDK's public-network guard to Python URL file uploads
- rejects non-HTTP(S), private, loopback, link-local, reserved, and mixed DNS targets before a request is made
- applies the guard to both `FileUploadable.from_url()` and Tool Router session-file URL uploads
- redacts URL queries, Authorization credentials, and secret-like key/value pairs before error telemetry leaves the process
- adds focused SSRF and redaction regressions alongside the existing file-upload coverage

Validation:
- `uv run --frozen pytest tests/test_url_safety.py tests/test_redaction.py tests/test_files.py -q`
- `uv run --frozen ruff check …`
- `uv run --frozen ruff format --check …`