### PR TITLE
fix(ci): validate Python release metadata

### DIFF
--- a/.github/workflows/py.release.yml
+++ b/.github/workflows/py.release.yml
@@ -25,6 +25,17 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      - name: Setup Node.js, pnpm, Bun
+        uses: ./.github/actions/setup-node-pnpm-bun
+
+      - name: Install release metadata check dependencies
+        working-directory: .
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate Python release metadata
+        working-directory: .
+        run: pnpm test:release-workflow
+
       - name: Setup Python with UV
         uses: ./.github/actions/setup-python-uv
 


### PR DESCRIPTION
This PR:
- validates Python package versions and release-note coverage before a `py@*` tag can build or publish artifacts
- runs the existing repository release-workflow guard in the tag-release workflow
- installs the pinned Node, pnpm, and Bun toolchain only for the metadata validation step
- prevents a tag from publishing artifacts whose package, runtime, provider, or docs versions drift apart

Validation:
- `pnpm test:release-workflow`
- `pnpm exec prettier --check .github/workflows/py.release.yml`