### PR TITLE
feat(cli): harden browserless agent onboarding

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -85,7 +85,7 @@ while [[ $# -gt 0 ]]; do
         ;;
     -h|--help)
         echo 'Usage: install.sh [--agent] [version-tag]  (e.g. "@composio/cli@0.1.32")'
-        echo '  --agent    After installing, sign up/log in as a Composio agent.'
+        echo '  --agent    After installing, create/restore an agent identity and set up detected agent hosts.'
         exit 0
         ;;
     --*)
@@ -393,9 +393,20 @@ rm -f "$install_err"
 
 if [[ $install_agent = true ]]; then
     echo
-    info "Setting up Composio agent login..."
+    info "Setting up the Composio agent identity..."
     if ! "$exe" login --agent --no-skill-install; then
         error 'Failed to sign up/log in as a Composio agent. If this CLI is already signed in as a regular user, run `composio logout` and then `composio signup` or `composio agent login <composio_agent_key>`.'
+    fi
+
+    if command -v claude >/dev/null 2>&1 || command -v codex >/dev/null 2>&1; then
+        info "Setting up detected agent hosts..."
+        # Release sequencing: both marketplace repositories referenced by `composio setup`
+        # must be publicly accessible before publishing a CLI release with this behavior.
+        if ! "$exe" setup --target auto --yes; then
+            error 'Agent login succeeded, but plugin setup failed. Verify that the Composio plugin marketplaces are reachable, then rerun `composio setup --target auto --yes`.'
+        fi
+    else
+        info "No supported agent host detected; skipping plugin setup."
     fi
 fi
 
@@ -409,7 +420,7 @@ fi
 
 info_bold "  composio --help"
 if [[ $install_agent = true ]]; then
-    info_bold "  composio agent whoami"
+    info_bold "  composio setup status"
 else
     info_bold "  composio login"
 fi

--- a/test/install-sh-release-resolution.test.sh
+++ b/test/install-sh-release-resolution.test.sh
@@ -29,6 +29,7 @@ api_base='https://api.example.test'
 archive_url="https://downloads.example.test/$valid_tag/$archive_name"
 curl_log="$tmpdir/curl.log"
 git_log="$tmpdir/git.log"
+composio_log="$tmpdir/composio.log"
 
 cat > "$bin_dir/curl" <<'EOF'
 #!/usr/bin/env bash
@@ -144,6 +145,7 @@ fi
 mkdir -p "$dest"
 cat > "$dest/composio" <<'BIN'
 #!/usr/bin/env bash
+printf '%s\n' "$*" >> "$TEST_COMPOSIO_LOG"
 case "${1:-}" in
 install)
     exit 0
@@ -172,6 +174,7 @@ chmod +x "$bin_dir/git"
 
 export TEST_CURL_LOG="$curl_log"
 export TEST_GIT_LOG="$git_log"
+export TEST_COMPOSIO_LOG="$composio_log"
 export TEST_API_BASE="$api_base"
 export TEST_ARCHIVE_NAME="$archive_name"
 export TEST_ARCHIVE_URL="$archive_url"
@@ -221,6 +224,75 @@ fi
 
 if grep -q "$tag_without_release" "$curl_log"; then
     echo 'Installer attempted to use a tag that was not present in releases.' >&2
+    exit 1
+fi
+
+# --agent should establish the agent identity, then install plugins when a
+# supported host is present.
+cat > "$bin_dir/claude" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$bin_dir/claude"
+: > "$composio_log"
+
+agent_output=$(env \
+    PATH="$bin_dir:/usr/bin:/bin" \
+    HOME="$home_dir" \
+    SHELL="/bin/bash" \
+    COMPOSIO_INSTALL_DIR="$install_dir" \
+    COMPOSIO_GITHUB_URL='https://github.example.test' \
+    COMPOSIO_GITHUB_API_BASE_URL="$api_base" \
+    COMPOSIO_GITHUB_OWNER='FakeOwner' \
+    COMPOSIO_GITHUB_REPO='fake-repo' \
+    bash "$repo_root/install.sh" --agent 2>&1)
+
+if ! grep -qxF 'login --agent --no-skill-install' "$composio_log"; then
+    echo 'Expected install.sh --agent to establish the agent identity first.' >&2
+    cat "$composio_log" >&2
+    exit 1
+fi
+
+if ! grep -qxF 'setup --target auto --yes' "$composio_log"; then
+    echo 'Expected install.sh --agent to delegate detected hosts to composio setup.' >&2
+    cat "$composio_log" >&2
+    exit 1
+fi
+
+if ! grep -q 'composio setup status' <<<"$agent_output"; then
+    echo 'Expected agent installer output to recommend setup status.' >&2
+    exit 1
+fi
+
+# A headless/hostless machine must still get a working agent identity without
+# attempting plugin setup when there is no host to configure yet.
+rm "$bin_dir/claude"
+: > "$composio_log"
+
+hostless_output=$(env \
+    PATH="$bin_dir:/usr/bin:/bin" \
+    HOME="$home_dir" \
+    SHELL="/bin/bash" \
+    COMPOSIO_INSTALL_DIR="$install_dir" \
+    COMPOSIO_GITHUB_URL='https://github.example.test' \
+    COMPOSIO_GITHUB_API_BASE_URL="$api_base" \
+    COMPOSIO_GITHUB_OWNER='FakeOwner' \
+    COMPOSIO_GITHUB_REPO='fake-repo' \
+    bash "$repo_root/install.sh" --agent 2>&1)
+
+if ! grep -qxF 'login --agent --no-skill-install' "$composio_log"; then
+    echo 'Expected hostless install.sh --agent to fall back to identity-only login.' >&2
+    cat "$composio_log" >&2
+    exit 1
+fi
+
+if grep -qxF 'setup --target auto --yes' "$composio_log"; then
+    echo 'Expected hostless install not to invoke plugin setup.' >&2
+    exit 1
+fi
+
+if ! grep -q 'No supported agent host detected' <<<"$hostless_output"; then
+    echo 'Expected hostless fallback to be explicit in installer output.' >&2
     exit 1
 fi
 

--- a/ts/packages/cli/src/commands/root-help.ts
+++ b/ts/packages/cli/src/commands/root-help.ts
@@ -163,6 +163,8 @@ const GENERATE_COMMAND: TaggedValue<CompactCommand> = tagged({
 
 const ACCOUNT_COMMANDS: ReadonlyArray<TaggedValue<CompactCommand>> = [
   tagged({ name: 'login', description: 'Log in to Composio' }),
+  tagged({ name: 'signup', description: 'Create and log in with a Composio agent identity' }),
+  tagged({ name: 'agent', description: 'Manage a Composio agent identity' }),
   tagged({ name: 'logout', description: 'Log out from Composio' }),
   tagged({ name: 'whoami', description: 'Show current account info' }),
   tagged({ name: 'orgs', description: 'Manage current organization context (list, switch)' }),
@@ -829,7 +831,7 @@ const SUBCOMMAND_HELP: Record<string, SubcommandHelp | TaggedValue<SubcommandHel
 
   login: {
     usage:
-      'composio login [--no-browser] [--poll] [--no-wait] [--key text] [--user-api-key text] [--org text] [-y, --yes] [--no-skill-install]',
+      'composio login [--agent] [--no-browser] [--poll] [--no-wait] [--key text] [--user-api-key text] [--org text] [-y, --yes] [--no-skill-install]',
     description:
       'Log in to the Composio CLI session. By default, also installs the composio-cli skill for Claude Code.',
     options: [
@@ -847,6 +849,10 @@ const SUBCOMMAND_HELP: Record<string, SubcommandHelp | TaggedValue<SubcommandHel
       },
     ],
     flags: [
+      {
+        name: '--agent',
+        description: 'Restore or create a browserless Composio agent identity and log in',
+      },
       { name: '--no-browser', description: 'Login without browser interaction' },
       {
         name: '--poll',

--- a/ts/packages/cli/src/commands/whoami.cmd.ts
+++ b/ts/packages/cli/src/commands/whoami.cmd.ts
@@ -1,3 +1,4 @@
+import process from 'node:process';
 import { Command } from '@effect/cli';
 import { Effect, Option } from 'effect';
 import { getSessionInfoByUserApiKey } from 'src/services/composio-clients';
@@ -25,7 +26,20 @@ export const whoamiCmd = Command.make('whoami', {}).pipe(
 
       yield* ctx.data.apiKey.pipe(
         Option.match({
-          onNone: () => ui.log.warn('You are not logged in yet. Please run `composio login`.'),
+          onNone: () =>
+            Effect.gen(function* () {
+              process.exitCode = 1;
+              yield* ui.log.warn('You are not logged in yet. Please run `composio login`.');
+              yield* ui.output(
+                JSON.stringify({
+                  authenticated: false,
+                  account_type: null,
+                  email: null,
+                  current_org_name: null,
+                  enhanced_controls_enabled: null,
+                })
+              );
+            }),
           onSome: apiKey =>
             Effect.gen(function* () {
               const sessionInfo = yield* getSessionInfoByUserApiKey({
@@ -71,6 +85,7 @@ export const whoamiCmd = Command.make('whoami', {}).pipe(
               );
               yield* ui.output(
                 JSON.stringify({
+                  authenticated: true,
                   account_type: accountType,
                   email: email ?? null,
                   current_org_name: orgName ?? null,

--- a/ts/packages/cli/src/services/agents.ts
+++ b/ts/packages/cli/src/services/agents.ts
@@ -4,8 +4,11 @@ import path from 'node:path';
 import { setupCacheDir } from 'src/effects/setup-cache-dir';
 import { ComposioUserContext } from 'src/services/user-context';
 import { primeConsumerConnectedToolkitsCacheInBackground } from 'src/services/consumer-short-term-cache';
+import { NodeOs } from 'src/services/node-os';
 
 export const AGENT_CONFIG_FILE_NAME = 'agent.json';
+export const LEGACY_AGENT_CONFIG_FILE_NAME = 'anonymous_user_data.json';
+export const AGENT_SIGNUP_IDEMPOTENCY_FILE_NAME = 'agent-signup-idempotency-key';
 export const DEFAULT_AGENTS_BASE_URL = 'https://agents.composio.dev';
 
 export type AgentStatus = 'READY' | 'PENDING' | 'UNKNOWN';
@@ -123,37 +126,100 @@ export const agentConfigPath = Effect.gen(function* () {
   return path.join(cacheDir, AGENT_CONFIG_FILE_NAME);
 });
 
+const restrictPrivateFilePermissions = (filePath: string) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const os = yield* NodeOs;
+    const restrictPermissions = fs.chmod(filePath, 0o600);
+    yield* os.platform === 'win32'
+      ? restrictPermissions.pipe(
+          Effect.catchAll(error =>
+            Effect.logDebug(`Could not restrict permissions for ${filePath}:`, error)
+          )
+        )
+      : restrictPermissions;
+  });
+
+const writePrivateFileString = (filePath: string, contents: string) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    yield* fs.writeFileString(filePath, contents, { mode: 0o600 });
+    yield* restrictPrivateFilePermissions(filePath);
+  });
+
+const readAgentIdentityFile = (filePath: string) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    return yield* fs.readFileString(filePath, 'utf8').pipe(
+      Effect.map(raw => Option.some(normalizeAgentIdentity(readJson(raw)))),
+      Effect.catchAll(error =>
+        Effect.gen(function* () {
+          yield* Effect.logDebug(`Failed to read agent identity from ${filePath}:`, error);
+          return Option.none<AgentIdentity>();
+        })
+      )
+    );
+  });
+
 export const readStoredAgentIdentity = Effect.gen(function* () {
   const fs = yield* FileSystem.FileSystem;
+  const cacheDir = yield* setupCacheDir;
   const configPath = yield* agentConfigPath;
 
   const exists = yield* fs.exists(configPath);
-  if (!exists) return Option.none<AgentIdentity>();
+  if (exists) {
+    yield* restrictPrivateFilePermissions(configPath);
+    return yield* readAgentIdentityFile(configPath);
+  }
 
-  return yield* fs.readFileString(configPath, 'utf8').pipe(
-    Effect.map(raw => Option.some(normalizeAgentIdentity(readJson(raw)))),
-    Effect.catchAll(error =>
-      Effect.gen(function* () {
-        yield* Effect.logDebug('Failed to read agent identity:', error);
-        return Option.none<AgentIdentity>();
-      })
-    )
-  );
+  const legacyPath = path.join(cacheDir, LEGACY_AGENT_CONFIG_FILE_NAME);
+  if (!(yield* fs.exists(legacyPath))) return Option.none<AgentIdentity>();
+
+  yield* restrictPrivateFilePermissions(legacyPath);
+  const legacy = yield* readAgentIdentityFile(legacyPath);
+  if (Option.isNone(legacy) || !getAgentKey(legacy.value)) {
+    return Option.none<AgentIdentity>();
+  }
+
+  const migrated = yield* writeStoredAgentIdentity(legacy.value);
+  return Option.some(migrated);
 });
 
 export const writeStoredAgentIdentity = (identity: AgentIdentity) =>
   Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
     const configPath = yield* agentConfigPath;
     const normalized = normalizeAgentIdentity(identity);
-    yield* fs.writeFileString(configPath, `${JSON.stringify(normalized, null, 2)}\n`);
+    yield* writePrivateFileString(configPath, `${JSON.stringify(normalized, null, 2)}\n`);
     return normalized;
   });
 
 export const removeStoredAgentIdentity = Effect.gen(function* () {
   const fs = yield* FileSystem.FileSystem;
+  const cacheDir = yield* setupCacheDir;
   const configPath = yield* agentConfigPath;
-  yield* fs.remove(configPath).pipe(Effect.catchAll(() => Effect.void));
+  const legacyPath = path.join(cacheDir, LEGACY_AGENT_CONFIG_FILE_NAME);
+  yield* Effect.all(
+    [configPath, legacyPath].map(filePath =>
+      fs.remove(filePath).pipe(Effect.catchAll(() => Effect.void))
+    )
+  );
+});
+
+const getOrCreateAgentSignupIdempotencyKey = Effect.gen(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const cacheDir = yield* setupCacheDir;
+  const keyPath = path.join(cacheDir, AGENT_SIGNUP_IDEMPOTENCY_FILE_NAME);
+  if (yield* fs.exists(keyPath)) {
+    const existing = (yield* fs.readFileString(keyPath, 'utf8')).trim();
+    if (existing) {
+      yield* writePrivateFileString(keyPath, `${existing}\n`);
+      return { key: existing, keyPath };
+    }
+  }
+
+  const key = globalThis.crypto.randomUUID();
+  yield* writePrivateFileString(keyPath, `${key}\n`);
+  return { key, keyPath };
 });
 
 const fetchAgentJson = (pathname: string, init: RequestInit = {}) =>
@@ -185,12 +251,17 @@ const fetchAgentJson = (pathname: string, init: RequestInit = {}) =>
 
 export const signupAgent = (params: { wait?: boolean } = {}) =>
   Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
     const wait = params.wait ?? true;
+    const idempotency = yield* getOrCreateAgentSignupIdempotencyKey;
     const payload = yield* fetchAgentJson(`/api/signup${wait ? '' : '?wait=0'}`, {
       method: 'POST',
+      headers: { 'Idempotency-Key': idempotency.key },
       body: JSON.stringify({}),
     });
-    return yield* writeStoredAgentIdentity(normalizeAgentIdentity(payload));
+    const identity = yield* writeStoredAgentIdentity(normalizeAgentIdentity(payload));
+    yield* fs.remove(idempotency.keyPath).pipe(Effect.catchAll(() => Effect.void));
+    return identity;
   });
 
 export const fetchAgentWhoami = (agentKey: string) =>

--- a/ts/packages/cli/test/src/commands/agent.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/agent.cmd.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, layer } from '@effect/vitest';
 import { FileSystem } from '@effect/platform';
-import { Effect, Option } from 'effect';
+import { Effect, Exit, Option } from 'effect';
 import path from 'node:path';
 import { afterEach, vi } from 'vitest';
 import * as constants from 'src/constants';
 import { setupCacheDir } from 'src/effects/setup-cache-dir';
-import { writeStoredAgentIdentity } from 'src/services/agents';
+import {
+  AGENT_SIGNUP_IDEMPOTENCY_FILE_NAME,
+  getOrSignupReadyAgent,
+  LEGACY_AGENT_CONFIG_FILE_NAME,
+  signupAgent,
+  writeStoredAgentIdentity,
+} from 'src/services/agents';
 import { ComposioUserContext } from 'src/services/user-context';
 import { cli, MockConsole, TestLive } from 'test/__utils__';
 
@@ -83,6 +89,7 @@ describe('CLI: composio agent', () => {
           'utf8'
         );
         const agentConfigRaw = yield* fs.readFileString(path.join(cacheDir, 'agent.json'), 'utf8');
+        const agentConfigInfo = yield* fs.stat(path.join(cacheDir, 'agent.json'));
 
         expect(JSON.parse(userConfigRaw)).toMatchObject({
           api_key: 'uak_agent',
@@ -93,6 +100,90 @@ describe('CLI: composio agent', () => {
           agent_key: 'cak_test_agent',
           composio: { user_api_key: 'uak_agent' },
         });
+        if (process.platform !== 'win32') {
+          expect(agentConfigInfo.mode & 0o777).toBe(0o600);
+        }
+      })
+    );
+  });
+
+  layer(TestLive())(it => {
+    it.scoped('stores a failed signup idempotency key with owner-only permissions', () =>
+      Effect.gen(function* () {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+          new Response(JSON.stringify({ message: 'signup unavailable' }), {
+            status: 503,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        );
+
+        const exit = yield* Effect.exit(signupAgent());
+        expect(Exit.isFailure(exit)).toBe(true);
+
+        const fs = yield* FileSystem.FileSystem;
+        const cacheDir = yield* setupCacheDir;
+        const info = yield* fs.stat(path.join(cacheDir, AGENT_SIGNUP_IDEMPOTENCY_FILE_NAME));
+        if (process.platform !== 'win32') {
+          expect(info.mode & 0o777).toBe(0o600);
+        }
+      })
+    );
+  });
+
+  layer(TestLive())(it => {
+    it.scoped('migrates and refreshes a legacy identity instead of minting a duplicate', () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const cacheDir = yield* setupCacheDir;
+        const legacyPath = path.join(cacheDir, LEGACY_AGENT_CONFIG_FILE_NAME);
+        const canonicalPath = path.join(cacheDir, 'agent.json');
+        yield* fs.writeFileString(
+          legacyPath,
+          JSON.stringify({
+            ...agentSignupResponse,
+            agent_key: 'cak_legacy',
+            composio_agent_key: undefined,
+          })
+        );
+        yield* fs.chmod(legacyPath, 0o644);
+
+        let signupRequested = false;
+        vi.spyOn(globalThis, 'fetch').mockImplementation(async (requestInput, init) => {
+          const url =
+            typeof requestInput === 'string'
+              ? requestInput
+              : requestInput instanceof URL
+                ? requestInput.toString()
+                : requestInput.url;
+          if (url.includes('/api/signup')) signupRequested = true;
+          if (url.includes('/api/whoami')) {
+            expect(new Headers(init?.headers).get('authorization')).toBe('Bearer cak_legacy');
+            return new Response(
+              JSON.stringify({
+                ...agentSignupResponse,
+                agent_key: 'cak_legacy',
+                composio_agent_key: 'cak_legacy',
+              }),
+              { status: 200, headers: { 'Content-Type': 'application/json' } }
+            );
+          }
+          return new Response(JSON.stringify({ message: 'unexpected request' }), { status: 500 });
+        });
+
+        const identity = yield* getOrSignupReadyAgent();
+        expect(identity.agent_key).toBe('cak_legacy');
+        expect(signupRequested).toBe(false);
+        expect(yield* fs.exists(legacyPath)).toBe(true);
+        expect(JSON.parse(yield* fs.readFileString(canonicalPath, 'utf8'))).toMatchObject({
+          agent_key: 'cak_legacy',
+          composio_agent_key: 'cak_legacy',
+        });
+        if (process.platform !== 'win32') {
+          const info = yield* fs.stat(canonicalPath);
+          expect(info.mode & 0o777).toBe(0o600);
+          const legacyInfo = yield* fs.stat(legacyPath);
+          expect(legacyInfo.mode & 0o777).toBe(0o600);
+        }
       })
     );
   });

--- a/ts/packages/cli/test/src/commands/logout.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/logout.cmd.test.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import * as constants from 'src/constants';
 import { setupCacheDir } from 'src/effects/setup-cache-dir';
 import { UserDataWithDefaults } from 'src/models/user-data';
-import { writeStoredAgentIdentity } from 'src/services/agents';
+import { LEGACY_AGENT_CONFIG_FILE_NAME, writeStoredAgentIdentity } from 'src/services/agents';
 import { extendConfigProvider } from 'src/services/config';
 import { TerminalUI } from 'src/services/terminal-ui';
 import { ComposioUserContext } from 'src/services/user-context';
@@ -155,12 +155,15 @@ describe('CLI: composio logout', () => {
       it.scoped('[Then] --force removes user and agent credentials', () =>
         Effect.gen(function* () {
           const ctx = yield* setupLoggedInAgent;
+          const fs = yield* FileSystem.FileSystem;
+          const cacheDir = yield* setupCacheDir;
+          const legacyPath = path.join(cacheDir, LEGACY_AGENT_CONFIG_FILE_NAME);
+          yield* fs.writeFileString(legacyPath, '{"agent_key":"cak_legacy"}\n');
 
           yield* cli(['logout', '--force']);
 
-          const fs = yield* FileSystem.FileSystem;
-          const cacheDir = yield* setupCacheDir;
           const agentConfigExists = yield* fs.exists(path.join(cacheDir, 'agent.json'));
+          const legacyAgentConfigExists = yield* fs.exists(legacyPath);
           const userConfigRaw = yield* fs.readFileString(
             path.join(cacheDir, constants.USER_CONFIG_FILE_NAME),
             'utf8'
@@ -170,6 +173,7 @@ describe('CLI: composio logout', () => {
           expect(output).toContain('removed stored Composio agent key');
           expect(ctx.isLoggedIn()).toBeFalsy();
           expect(agentConfigExists).toBe(false);
+          expect(legacyAgentConfigExists).toBe(false);
           expect(JSON.parse(userConfigRaw)).toHaveProperty('api_key', null);
         })
       );

--- a/ts/packages/cli/test/src/commands/whoami.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/whoami.cmd.test.ts
@@ -7,6 +7,20 @@ import { afterEach, vi } from 'vitest';
 describe('CLI: composio whoami', () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    process.exitCode = undefined;
+  });
+
+  layer(TestLive())('without credentials', it => {
+    it.scoped('[Given] a clean home [Then] exits nonzero and prints unauthenticated JSON', () =>
+      Effect.gen(function* () {
+        yield* cli(['whoami']);
+
+        const output = (yield* MockConsole.getLines()).join('\n');
+        expect(output).toContain('You are not logged in yet');
+        expect(output).toContain('"authenticated":false');
+        expect(process.exitCode).toBe(1);
+      })
+    );
   });
 
   const testConfigProvider = ConfigProvider.fromMap(


### PR DESCRIPTION
## Summary
- make browserless agent signup retry-safe with a persisted idempotency key
- store canonical and legacy agent identity files with owner-only permissions on Unix
- migrate a legacy anonymous agent identity without minting a duplicate, and remove both identity files on logout
- make `composio whoami` return `authenticated: false` and a nonzero status when signed out
- expose the existing `signup`, `agent`, and `login --agent` flows in root help
- make `install.sh --agent` establish the agent identity first and then delegate detected Claude/Codex hosts to `composio setup`
- keep hostless installation useful by skipping plugin setup when neither supported host is present

## Independent scope
This PR is based directly on `next`, so its review diff is not stacked on the plugin-install PR.

It has an explicit merge-order dependency: merge #3807 first because the installer invokes the `composio setup` command introduced there. No release changeset is included; stable CLI promotion remains a separate release step.

There is no third bridge PR.

## External dependency
Do not merge until `agents.composio.dev` is restored and clean-machine tests confirm live signup, retry/restore, whoami refresh, logout, and installer behavior. Before release, both plugin marketplace repositories must also be publicly accessible.

## Validation available without the service
- focused agent, logout, and whoami suite: 3 files passed, 18 tests passed
- functional `install.sh` release-resolution and agent-orchestration test
- shell syntax checks for the installer and its test
- repository root `pnpm typecheck`: 12/12 tasks passed
- Prettier, ESLint, and `git diff --check`

## Recording
No VHS recording is included yet because the live agent-onboarding path cannot be exercised while `agents.composio.dev` is unavailable. Record the complete installer flow after the service is restored.
