### PR TITLE
feat(cli): add --no-browser flag to link command

### DIFF
--- a/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
+++ b/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
@@ -51,6 +51,13 @@ const noWait = Options.boolean('no-wait').pipe(
   Options.withDescription('Do not wait for authorization; only print link info')
 );
 
+const noBrowser = Options.boolean('no-browser').pipe(
+  Options.withDefault(false),
+  Options.withDescription(
+    'Do not open the browser automatically; print the URL to open manually'
+  )
+);
+
 const alias = Options.text('alias').pipe(
   Options.withDescription(
     'Alias to assign to the connected account. Required when creating an additional account for the same toolkit/auth config.'
@@ -82,7 +89,8 @@ const waitForActiveConnection = (
   ui: TerminalUI,
   client: RawComposioClient,
   connectedAccountId: string,
-  redirectUrl: string
+  redirectUrl: string,
+  noBrowser: boolean
 ) =>
   Effect.gen(function* () {
     yield* showRedirectUrl(ui, redirectUrl);
@@ -98,6 +106,8 @@ const waitForActiveConnection = (
     if (!urlSchemeValid) {
       yield* ui.log.warn(`Redirect URL has an unexpected scheme: ${redirectUrl}`);
       yield* ui.log.info('Open the URL manually if you trust the source.');
+    } else if (noBrowser) {
+      yield* ui.log.info('Open the URL above in your browser to authorize.');
     } else {
       yield* Effect.tryPromise(() => open(redirectUrl, { wait: false })).pipe(
         Effect.catchAll(error =>
@@ -178,7 +188,7 @@ const validateLinkResponse = (
     });
   });
 
-const handleNoManagedAuth = (ui: TerminalUI, toolkitSlug: string) =>
+const handleNoManagedAuth = (ui: TerminalUI, toolkitSlug: string, noBrowser: boolean) =>
   Effect.gen(function* () {
     const userContext = yield* ComposioUserContext;
     const webURL = userContext.data.webURL.replace(/\/+$/, '');
@@ -202,12 +212,14 @@ const handleNoManagedAuth = (ui: TerminalUI, toolkitSlug: string) =>
     const dashboardUrl = `${webURL}/${encodeURIComponent(orgName)}/~/connect/apps/${encodeURIComponent(toolkitSlug)}?open=true`;
 
     yield* ui.log.warn(
-      `Composio does not manage auth for "${toolkitSlug}" — opening the dashboard to connect manually.`
+      `Composio does not manage auth for "${toolkitSlug}" — ${noBrowser ? 'open the dashboard' : 'opening the dashboard'} to connect manually.`
     );
 
-    yield* Effect.tryPromise(() => open(dashboardUrl, { wait: false })).pipe(
-      Effect.catchAll(() => ui.log.warn('Could not open the browser automatically.'))
-    );
+    if (!noBrowser) {
+      yield* Effect.tryPromise(() => open(dashboardUrl, { wait: false })).pipe(
+        Effect.catchAll(() => ui.log.warn('Could not open the browser automatically.'))
+      );
+    }
 
     yield* ui.note(dashboardUrl, 'Dashboard URL');
     yield* ui.output(dashboardUrl);
@@ -468,6 +480,7 @@ const handleLegacyAuthConfigLink = (params: {
   readonly requestedUserId: Option.Option<string>;
   readonly projectName: Option.Option<string>;
   readonly noWait: boolean;
+  readonly noBrowser: boolean;
   readonly alias: Option.Option<string>;
   readonly ui: TerminalUI;
   readonly clientSingleton: {
@@ -593,7 +606,13 @@ const handleLegacyAuthConfigLink = (params: {
       return;
     }
 
-    yield* waitForActiveConnection(params.ui, client, connectedAccountId, redirectUrl);
+    yield* waitForActiveConnection(
+      params.ui,
+      client,
+      connectedAccountId,
+      redirectUrl,
+      params.noBrowser
+    );
   });
 
 const runConnectedAccountsLink = (params: {
@@ -602,6 +621,7 @@ const runConnectedAccountsLink = (params: {
   userId: Option.Option<string>;
   projectName: Option.Option<string>;
   noWait: boolean;
+  noBrowser: boolean;
   alias: Option.Option<string>;
   list: boolean;
   rootOnly: boolean;
@@ -673,6 +693,7 @@ const runConnectedAccountsLink = (params: {
         requestedUserId: params.userId,
         projectName: params.projectName,
         noWait: params.noWait,
+        noBrowser: params.noBrowser,
         alias: aliasOption,
         ui,
         clientSingleton,
@@ -740,7 +761,7 @@ const runConnectedAccountsLink = (params: {
             const slug = extractSlug(error);
 
             if (slug === 'ToolRouterV2_NoManagedAuth') {
-              yield* handleNoManagedAuth(ui, toolkitSlug);
+              yield* handleNoManagedAuth(ui, toolkitSlug, params.noBrowser);
               return Option.none();
             }
 
@@ -802,7 +823,7 @@ const runConnectedAccountsLink = (params: {
         },
       }).pipe(Effect.catchAll(() => Effect.void));
     } else {
-      yield* waitForActiveConnection(ui, client, connAccountId, redirectUrl);
+      yield* waitForActiveConnection(ui, client, connAccountId, redirectUrl, params.noBrowser);
       yield* appendCliSessionHistory({
         orgId: resolvedProject.projectType === 'CONSUMER' ? resolvedProject.orgId : undefined,
         consumerUserId:
@@ -820,14 +841,15 @@ const runConnectedAccountsLink = (params: {
 
 export const connectedAccountsCmd$Link = Command.make(
   'link',
-  { toolkit, authConfig, userId, projectName, noWait, alias, list },
-  ({ toolkit, authConfig, userId, projectName, noWait, alias, list }) =>
+  { toolkit, authConfig, userId, projectName, noWait, noBrowser, alias, list },
+  ({ toolkit, authConfig, userId, projectName, noWait, noBrowser, alias, list }) =>
     runConnectedAccountsLink({
       toolkit,
       authConfig,
       userId,
       projectName,
       noWait,
+      noBrowser,
       alias,
       list,
       rootOnly: false,
@@ -852,14 +874,15 @@ export const connectedAccountsCmd$Link = Command.make(
 
 export const rootConnectedAccountsCmd$Link = Command.make(
   'link',
-  { toolkit, noWait, alias, list },
-  ({ toolkit, noWait, alias, list }) =>
+  { toolkit, noWait, noBrowser, alias, list },
+  ({ toolkit, noWait, noBrowser, alias, list }) =>
     runConnectedAccountsLink({
       toolkit,
       authConfig: Option.none(),
       userId: Option.none(),
       projectName: Option.none(),
       noWait,
+      noBrowser,
       alias,
       list,
       rootOnly: true,

--- a/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
+++ b/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
@@ -75,10 +75,14 @@ const list = Options.boolean('list').pipe(
 const showRedirectUrl = (
   ui: TerminalUI,
   redirectUrl: string,
-  options?: { readonly emitRaw?: boolean }
+  options?: { readonly emitRaw?: boolean; readonly manual?: boolean }
 ) =>
   Effect.gen(function* () {
-    yield* ui.log.step('Redirecting you to the authorization page');
+    yield* ui.log.step(
+      options?.manual
+        ? 'Open this URL in your browser to authorize'
+        : 'Redirecting you to the authorization page'
+    );
     yield* ui.note(redirectUrl, 'Redirect URL');
     if (options?.emitRaw) {
       yield* ui.output(redirectUrl);
@@ -93,7 +97,7 @@ const waitForActiveConnection = (
   noBrowser: boolean
 ) =>
   Effect.gen(function* () {
-    yield* showRedirectUrl(ui, redirectUrl);
+    yield* showRedirectUrl(ui, redirectUrl, { manual: noBrowser });
 
     let urlSchemeValid = false;
     try {
@@ -106,9 +110,7 @@ const waitForActiveConnection = (
     if (!urlSchemeValid) {
       yield* ui.log.warn(`Redirect URL has an unexpected scheme: ${redirectUrl}`);
       yield* ui.log.info('Open the URL manually if you trust the source.');
-    } else if (noBrowser) {
-      yield* ui.log.info('Open the URL above in your browser to authorize.');
-    } else {
+    } else if (!noBrowser) {
       yield* Effect.tryPromise(() => open(redirectUrl, { wait: false })).pipe(
         Effect.catchAll(error =>
           Effect.gen(function* () {

--- a/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
+++ b/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
@@ -590,7 +590,7 @@ const handleLegacyAuthConfigLink = (params: {
     if (!canContinue) return;
 
     if (params.noWait) {
-      yield* showRedirectUrl(params.ui, redirectUrl);
+      yield* showRedirectUrl(params.ui, redirectUrl, { manual: true });
       yield* params.ui.output(
         JSON.stringify(
           {
@@ -796,7 +796,7 @@ const runConnectedAccountsLink = (params: {
     if (!canContinue) return;
 
     if (params.noWait) {
-      yield* showRedirectUrl(ui, redirectUrl);
+      yield* showRedirectUrl(ui, redirectUrl, { manual: true });
       yield* ui.output(
         JSON.stringify(
           {

--- a/ts/packages/cli/src/commands/root-help.ts
+++ b/ts/packages/cli/src/commands/root-help.ts
@@ -528,7 +528,7 @@ const SUBCOMMAND_HELP: Record<string, SubcommandHelp | TaggedValue<SubcommandHel
     ],
   }),
   link: {
-    usage: 'composio link [<toolkit>] [--no-wait] [--alias text] [--list]',
+    usage: 'composio link [<toolkit>] [--no-wait] [--no-browser] [--alias text] [--list]',
     description:
       'Connect an external account (GitHub, Gmail, Slack, etc.) so tools can act on your behalf. Opens a browser for OAuth authorization and waits for confirmation.',
     args: [{ name: '<toolkit>', description: 'Toolkit slug to link (e.g. "github", "gmail")' }],
@@ -543,6 +543,10 @@ const SUBCOMMAND_HELP: Record<string, SubcommandHelp | TaggedValue<SubcommandHel
       {
         name: '--no-wait',
         description: 'Print link info and exit without waiting for authorization',
+      },
+      {
+        name: '--no-browser',
+        description: 'Do not open the browser automatically; print the URL to open manually',
       },
       {
         name: '--list',

--- a/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.link.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.link.cmd.test.ts
@@ -131,6 +131,29 @@ describe('CLI: composio dev connected-accounts link', () => {
       connectedAccountsData: makeConnectedAccountsData(),
       fixture: 'global-test-user-id',
     })
+  )('[Given] --no-browser [Then] waits for ACTIVE without opening the browser', it => {
+    it.scoped('prints the URL and waits without calling open', () =>
+      Effect.gen(function* () {
+        yield* cli(['link', 'gmail', '--no-browser']);
+        const lines = yield* MockConsole.getLines({ stripAnsi: true });
+        const output = lines.join('\n');
+        const parsed = extractJsonObject(output);
+
+        expect(parsed).not.toBeNull();
+        expect(parsed?.status).toBe('success');
+        expect(parsed?.connected_account_id).toBe('con_test_link');
+        expect(output).toContain('https://app.composio.dev/link?token=lt_test_token');
+        expect(vi.mocked(open)).not.toHaveBeenCalled();
+      })
+    );
+  });
+
+  layer(
+    TestLive({
+      baseConfigProvider: testConfigProvider,
+      connectedAccountsData: makeConnectedAccountsData(),
+      fixture: 'global-test-user-id',
+    })
   )('[Given] --list [Then] it shows existing accounts without opening a new link', it => {
     it.scoped('lists alias and word_id for existing accounts', () =>
       Effect.gen(function* () {

--- a/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.link.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.link.cmd.test.ts
@@ -143,6 +143,8 @@ describe('CLI: composio dev connected-accounts link', () => {
         expect(parsed?.status).toBe('success');
         expect(parsed?.connected_account_id).toBe('con_test_link');
         expect(output).toContain('https://app.composio.dev/link?token=lt_test_token');
+        expect(output).toContain('Open this URL in your browser to authorize');
+        expect(output).not.toContain('Redirecting you to the authorization page');
         expect(vi.mocked(open)).not.toHaveBeenCalled();
       })
     );


### PR DESCRIPTION
## Summary

Adds a `--no-browser` flag to `composio link` (and `composio dev connected-accounts link`) that skips auto-opening the browser and prints the authorization URL for the user to open manually, while still waiting for the connection to become `ACTIVE`.

Previously the only way to suppress the browser auto-open was `--no-wait`, which also exits without waiting for authorization. `--no-browser` fills the gap for users (and remote/SSH sessions) who want to click the link themselves but still get the wait-for-ACTIVE confirmation — matching the existing `composio login --no-browser` behavior.

## Changes

- New `--no-browser` boolean option on both the root `link` command and the `dev connected-accounts link` variant
- `waitForActiveConnection` skips `open()` and tells the user to open the printed URL when the flag is set
- The unmanaged-auth dashboard fallback (`ToolRouterV2_NoManagedAuth`) also respects the flag
- Root help (`root-help.ts`) documents the new flag
- Test: `link gmail --no-browser` waits for ACTIVE and never calls `open`

No VHS recording added — this is a small flag addition to an existing command surface, not a new documented workflow.

## Verification

- `pnpm typecheck` — passes
- `pnpm --filter @composio/cli test` — 81 files, 725 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)