### PR TITLE
fix(cli): whoami respects the org selected via `orgs switch`

### DIFF
--- a/.changeset/whoami-respect-switched-org.md
+++ b/.changeset/whoami-respect-switched-org.md
@@ -1,0 +1,5 @@
+---
+'@composio/cli': patch
+---
+
+Fix `composio whoami` reporting the wrong organization after `composio orgs switch`. The command resolved session info without the `x-org-id` header, so the backend fell back to the API key's home org and ignored the switch. It now forwards the selected global org, matching how consumer commands resolve org context.

--- a/ts/packages/cli/src/commands/whoami.cmd.ts
+++ b/ts/packages/cli/src/commands/whoami.cmd.ts
@@ -31,6 +31,8 @@ export const whoamiCmd = Command.make('whoami', {}).pipe(
               const sessionInfo = yield* getSessionInfoByUserApiKey({
                 baseURL: ctx.data.baseURL,
                 userApiKey: apiKey,
+                // Reflect the org selected via `composio orgs switch`, not the key's home org.
+                orgId: Option.getOrUndefined(ctx.data.orgId),
               }).pipe(Effect.option);
               const email = Option.map(sessionInfo, info => info.org_member.email).pipe(
                 Option.getOrUndefined

--- a/ts/packages/cli/src/services/composio-clients.ts
+++ b/ts/packages/cli/src/services/composio-clients.ts
@@ -1000,15 +1000,21 @@ export const getSessionInfo = (params: {
   });
 
 /**
- * Calls GET /api/v3/auth/session/info using only the x-user-api-key header.
- * Unlike getSessionInfo which requires org/project IDs, this variant resolves
- * session metadata from the UAK alone — useful during login before org/project
- * context is known.
+ * Calls GET /api/v3/auth/session/info using the x-user-api-key header.
+ * Unlike getSessionInfo which requires both org AND project IDs, this variant
+ * resolves session metadata from the UAK alone — useful during login before
+ * org/project context is known.
+ *
+ * When `orgId` is provided, it is forwarded as `x-org-id` so the backend
+ * resolves the session against the caller's currently-selected global org
+ * (set via `composio orgs switch`). Without it, the backend falls back to the
+ * API key's home org, which makes the response ignore any org switch.
  * Uses plain fetch since this endpoint is not available in @composio/client.
  */
 export const getSessionInfoByUserApiKey = (params: {
   baseURL: string;
   userApiKey: string;
+  orgId?: string;
 }): Effect.Effect<SessionInfoResponse, HttpServerError | HttpDecodingError> =>
   Effect.gen(function* () {
     const response = yield* Effect.tryPromise({
@@ -1018,6 +1024,7 @@ export const getSessionInfoByUserApiKey = (params: {
           redirect: 'error',
           headers: {
             'x-user-api-key': params.userApiKey,
+            ...(params.orgId ? { 'x-org-id': params.orgId } : {}),
             'User-Agent': '@composio/cli',
             Accept: '*/*',
             'Content-Type': 'application/json',

--- a/ts/packages/cli/test/src/services/composio-clients.test.ts
+++ b/ts/packages/cli/test/src/services/composio-clients.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Effect } from 'effect';
+import { getSessionInfoByUserApiKey } from 'src/services/composio-clients';
+
+const emptyOkResponse = () =>
+  new Response(JSON.stringify({}), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+describe('getSessionInfoByUserApiKey org context', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // The response body does not satisfy SessionInfoResponse, so decoding fails —
+  // but the fetch call (whose headers we assert) has already happened by then.
+  const runIgnoringDecode = (params: { baseURL: string; userApiKey: string; orgId?: string }) =>
+    Effect.runPromise(getSessionInfoByUserApiKey(params).pipe(Effect.ignore));
+
+  it('[Given] orgId [Then] forwards it as x-org-id so the backend honors the switched org', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(emptyOkResponse());
+
+    await runIgnoringDecode({
+      baseURL: 'https://backend.composio.dev',
+      userApiKey: 'uak_test',
+      orgId: 'ok_selected_org',
+    });
+
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(String(url)).toContain('/api/v3/auth/session/info');
+    const headers = new Headers((init as RequestInit).headers);
+    expect(headers.get('x-user-api-key')).toBe('uak_test');
+    expect(headers.get('x-org-id')).toBe('ok_selected_org');
+  });
+
+  it('[Given] no orgId [Then] omits x-org-id (login-time behavior is unchanged)', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(emptyOkResponse());
+
+    await runIgnoringDecode({
+      baseURL: 'https://backend.composio.dev',
+      userApiKey: 'uak_test',
+    });
+
+    const [, init] = fetchSpy.mock.calls[0]!;
+    const headers = new Headers((init as RequestInit).headers);
+    expect(headers.get('x-user-api-key')).toBe('uak_test');
+    expect(headers.has('x-org-id')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`composio whoami` reports the wrong organization after `composio orgs switch`.
It always shows the API key's home org, ignoring the switched-to org, even
though `composio orgs list` correctly reflects the selection.

**Root cause:** `whoami` resolves session info via `getSessionInfoByUserApiKey`,
which sent only `x-user-api-key` and omitted `x-org-id`. Without that header the
backend falls back to the API key's home org. Consumer commands (`search`,
`execute`, …) already forward the selected org via `resolveCommandProject`, so
only `whoami` was affected — a display bug, not an API bug.

**Verification that the backend honors the header** (direct calls to
`GET /api/v3/auth/session/info`):

| `x-org-id` | returned project/org |
|---|---|
| org A | org A |
| org B | org B |
| (omitted) | API key's home org |

## Changes

- `getSessionInfoByUserApiKey` accepts an optional `orgId` and forwards it as
  `x-org-id` when present (login-time callers pass none, so their behavior is
  unchanged).
- `whoami` passes the selected global org (`ctx.data.orgId`).
- Unit tests asserting the header is sent when an org is selected and omitted
  otherwise.

## Type of change
- [x] Bug fix

## How Has This Been Tested?

- New unit tests: `test/src/services/composio-clients.test.ts` (2 cases).
- Existing `whoami.cmd.test.ts` still passes (5 tests total green).
- Manual end-to-end with a real UAK against two orgs: a binary built from this
  branch reports the switched org correctly (`orgs switch` → `whoami`),
  whereas the released 0.2.31 binary always reported the home org.

## Checklist
- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed
- [ ] I updated documentation as needed (no user-facing docs affected)
- [x] I added tests or explain why not applicable
- [x] I added a changeset if this change affects published packages