### PR TITLE
docs: fix Gemini Python example to use composio_gemini with google-genai

### DIFF
--- a/docs/content/docs/providers/google.mdx
+++ b/docs/content/docs/providers/google.mdx
@@ -13,7 +13,7 @@ The Google provider formats Composio tools for [Gemini](https://ai.google.dev/) 
 
 <IntegrationContent value="gemini">
 
-The Google Generative AI provider transforms Composio tools into Gemini function declarations. Gemini is non-agentic, so the model returns function calls and you run the loop: execute each call with `composio.provider.executeToolCall`, feed the result back, and repeat until the model replies with text.
+In Python, the Gemini provider (`composio_gemini`) wraps Composio tools as typed callables, and the `google-genai` SDK's Automatic Function Calling executes tool calls inside the chat loop for you. In TypeScript, the Google provider transforms Composio tools into Gemini function declarations, and you run the loop: execute each call with `composio.provider.executeToolCall`, feed the result back, and repeat until the model replies with text.
 
 <Steps>
 <Step>
@@ -21,7 +21,7 @@ The Google Generative AI provider transforms Composio tools into Gemini function
 
 <Tabs groupId="language" items={["Python", "TypeScript"]} persist>
 <Tab value="Python">
-<PackageInstall ecosystem="python" packages="composio composio_google google-genai" />
+<PackageInstall ecosystem="python" packages="composio composio_gemini google-genai" />
 </Tab>
 <Tab value="TypeScript">
 <PackageInstall packages="@composio/core @composio/google @google/genai" />
@@ -49,11 +49,11 @@ GOOGLE_API_KEY=xxxxxxxxx
 <Tab value="Python">
 ```python
 from composio import Composio
-from composio_google import GoogleProvider
+from composio_gemini import GeminiProvider
 from google import genai
 from google.genai import types
 
-composio = Composio(provider=GoogleProvider())
+composio = Composio(provider=GeminiProvider())
 client = genai.Client()
 
 # Create a session for your user
@@ -62,16 +62,11 @@ tools = session.tools()
 
 config = types.GenerateContentConfig(tools=tools)
 chat = client.chats.create(model="gemini-3-pro-preview", config=config)
-response = chat.send_message("Send an email to john@example.com with the subject 'Hello' and body 'Hello from Composio!'")
 
-# Agentic loop: keep executing tool calls until the model responds with text
-while response.function_calls:
-    parts = []
-    for fc in response.function_calls:
-        result = composio.provider.execute_tool_call(user_id="user_123", function_call=fc)
-        parts.append(types.Part.from_function_response(name=fc.name, response=result))
-    response = chat.send_message(parts)
-
+# Automatic Function Calling executes tool calls inside the chat loop
+response = chat.send_message(
+    "Send an email to john@example.com with the subject 'Hello' and body 'Hello from Composio!'"
+)
 print(response.text)
 ```
 </Tab>

--- a/docs/tests/static/content.test.ts
+++ b/docs/tests/static/content.test.ts
@@ -11,6 +11,7 @@ import { join, relative } from "path";
 const DOCS_DIR = join(import.meta.dir, "../../content/docs");
 const EXAMPLES_DIR = join(import.meta.dir, "../../content/examples");
 const CHANGELOG_DIR = join(import.meta.dir, "../../content/changelog");
+const GOOGLE_PROVIDER_DOC = join(DOCS_DIR, "providers/google.mdx");
 
 /** Recursively find all .mdx files */
 async function findMdxFiles(dir: string): Promise<string[]> {
@@ -97,6 +98,19 @@ describe("Content - no empty pages", () => {
     }
 
     expect(empty).toEqual([]);
+  });
+});
+
+describe("Content - provider compatibility", () => {
+  test("Gemini Python docs use the google-genai-compatible provider", async () => {
+    const content = await readFile(GOOGLE_PROVIDER_DOC, "utf-8");
+
+    expect(content).toContain(
+      '<PackageInstall ecosystem="python" packages="composio composio_gemini google-genai" />',
+    );
+    expect(content).toContain("from composio_gemini import GeminiProvider");
+    expect(content).toContain("Composio(provider=GeminiProvider())");
+    expect(content).not.toContain("composio_google google-genai");
   });
 });
 


### PR DESCRIPTION
## Summary
The Gemini Python example paired composio_google (which wraps tools as VertexAI FunctionDeclaration objects) with google-genai client. GenerateContentConfig silently coerces those VertexAI objects into an empty genai Tool ({}), so the documented flow sends requests with no tool schemas at all - the model never sees or calls any Composio tool, with no error surfaced anywhere.

Fixes #3836 

## Changes
- docs/content/docs/providers/google.mdx (Gemini tab, Python only):
  - install line: composio_google → composio_gemini
  - example: GeminiProvider + Automatic Function Calling; the manual while response.function_calls: loop is gone because the google-genai SDK executes the wrapped callables itself
  - intro paragraph updated to describe the Python (AFC) and TypeScript (manual loop) flows separately

The TypeScript tab and the Google ADK section are untouched; both already target the right SDKs. The new Python example matches the existing quickstart in python/providers/gemini/README.md.


## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [x] Documentation
- [ ] Breaking change

## How Has This Been Tested?
- Offline repro of the bug (issue #3836): with composio_google, config.tools[0].model_dump(exclude_none=True) is {} and genai's _transformers.t_tools raises AttributeError on the vertexai type.
- Offline verification of the fix: the exact construction path of the new example (GeminiProvider().wrap_tools → GenerateContentConfig → chats.create → t_tools) serializes a complete FunctionDeclaration (name, description, parameters) with composio==0.17.1, google-genai==2.11.0, Python 3.12.
- Docs: bun run build and bun run lint:links from docs/: green.

## Screenshots (if applicable)

## Checklist
- [x] I have read the Code of Conduct, and this PR adheres to it
- [x] I ran linters/tests locally, and they passed
- [x] I updated documentation as needed
- [x] I added tests or explain why not applicable
- [x] I added a changeset if this change affects published packages

## Additional context
No changeset: docs-only change, no published package affected. Regression coverage: `docs/tests/static/content.test.ts` now guards the documented `composio_gemini` + `google-genai` pairing; the example's construction path was also exercised offline as described above.

The underlying provider split (composio_google targeting the upstream-deprecated vertexai generative_models SDK vs composio_gemini targeting google-genai) is flagged in #3836 as an open question for maintainers; this PR is the docs-only fix.


