### PR TITLE
feat(cli): install plugins from the CLI installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -75,7 +75,14 @@ command -v curl  >/dev/null || error 'curl is required to install Composio CLI'
 command -v unzip >/dev/null || error 'unzip is required to install Composio CLI'
 
 install_agent=false
+install_plugins=true
 version_arg=""
+
+case "${COMPOSIO_INSTALL_PLUGINS:-1}" in
+1) ;;
+0) install_plugins=false ;;
+*) error 'COMPOSIO_INSTALL_PLUGINS must be 1 or 0' ;;
+esac
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -83,9 +90,15 @@ while [[ $# -gt 0 ]]; do
         install_agent=true
         shift
         ;;
+    --no-plugins)
+        install_plugins=false
+        shift
+        ;;
     -h|--help)
-        echo 'Usage: install.sh [--agent] [version-tag]  (e.g. "@composio/cli@0.1.32")'
-        echo '  --agent    After installing, sign up/log in as a Composio agent.'
+        echo 'Usage: install.sh [--agent] [--no-plugins] [version-tag]  (e.g. "@composio/cli@0.1.32")'
+        echo '  --agent       After installing, sign up/log in as a Composio agent.'
+        echo '  --no-plugins  Skip installing plugins for detected agent hosts.'
+        echo '  Set COMPOSIO_INSTALL_PLUGINS=0 to skip plugin installation in automation.'
         exit 0
         ;;
     --*)
@@ -93,7 +106,7 @@ while [[ $# -gt 0 ]]; do
         ;;
     *)
         if [[ -n "$version_arg" ]]; then
-            error 'Too many arguments. Usage: install.sh [--agent] [version-tag]  (e.g. "@composio/cli@0.1.32")'
+            error 'Too many arguments. Usage: install.sh [--agent] [--no-plugins] [version-tag]  (e.g. "@composio/cli@0.1.32")'
         fi
         version_arg=$1
         shift
@@ -390,6 +403,14 @@ else
 
 fi
 rm -f "$install_err"
+
+if [[ $install_plugins = true ]]; then
+    echo
+    info "Checking for supported agent hosts..."
+    if ! "$exe" setup --target auto --yes --if-present; then
+        error 'Composio CLI was installed, but agent plugin setup failed. Retry with `composio setup --target auto --yes`.'
+    fi
+fi
 
 if [[ $install_agent = true ]]; then
     echo

--- a/test/install-sh-release-resolution.test.sh
+++ b/test/install-sh-release-resolution.test.sh
@@ -29,6 +29,7 @@ api_base='https://api.example.test'
 archive_url="https://downloads.example.test/$valid_tag/$archive_name"
 curl_log="$tmpdir/curl.log"
 git_log="$tmpdir/git.log"
+composio_log="$tmpdir/composio.log"
 
 cat > "$bin_dir/curl" <<'EOF'
 #!/usr/bin/env bash
@@ -144,9 +145,16 @@ fi
 mkdir -p "$dest"
 cat > "$dest/composio" <<'BIN'
 #!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >> "$TEST_COMPOSIO_LOG"
+
 case "${1:-}" in
 install)
     exit 0
+    ;;
+setup)
+    exit "${TEST_SETUP_EXIT:-0}"
     ;;
 --version|version)
     echo 'composio fake 98.0.0'
@@ -172,6 +180,7 @@ chmod +x "$bin_dir/git"
 
 export TEST_CURL_LOG="$curl_log"
 export TEST_GIT_LOG="$git_log"
+export TEST_COMPOSIO_LOG="$composio_log"
 export TEST_API_BASE="$api_base"
 export TEST_ARCHIVE_NAME="$archive_name"
 export TEST_ARCHIVE_URL="$archive_url"
@@ -179,16 +188,26 @@ export TEST_VALID_TAG="$valid_tag"
 export TEST_MISSING_ASSET_TAG="$missing_asset_tag"
 export TEST_TAG_WITHOUT_RELEASE="$tag_without_release"
 
-output=$(env \
-    PATH="$bin_dir:$PATH" \
-    HOME="$home_dir" \
-    SHELL="/bin/bash" \
-    COMPOSIO_INSTALL_DIR="$install_dir" \
-    COMPOSIO_GITHUB_URL='https://github.example.test' \
-    COMPOSIO_GITHUB_API_BASE_URL="$api_base" \
-    COMPOSIO_GITHUB_OWNER='FakeOwner' \
-    COMPOSIO_GITHUB_REPO='fake-repo' \
-    bash "$repo_root/install.sh" 2>&1)
+run_installer() {
+    local test_home="$1"
+    local test_install_dir="$2"
+    shift 2
+
+    env \
+        PATH="$bin_dir:$PATH" \
+        HOME="$test_home" \
+        SHELL="/bin/bash" \
+        COMPOSIO_INSTALL_DIR="$test_install_dir" \
+        COMPOSIO_INSTALL_PLUGINS="${COMPOSIO_INSTALL_PLUGINS:-1}" \
+        COMPOSIO_GITHUB_URL='https://github.example.test' \
+        COMPOSIO_GITHUB_API_BASE_URL="$api_base" \
+        COMPOSIO_GITHUB_OWNER='FakeOwner' \
+        COMPOSIO_GITHUB_REPO='fake-repo' \
+        TEST_SETUP_EXIT="${TEST_SETUP_EXIT:-0}" \
+        bash "$repo_root/install.sh" "$@"
+}
+
+output=$(run_installer "$home_dir" "$install_dir" 2>&1)
 
 printf '%s\n' "$output"
 
@@ -224,4 +243,47 @@ if grep -q "$tag_without_release" "$curl_log"; then
     exit 1
 fi
 
-printf 'install.sh release fallback test passed\n'
+expected_setup='setup --target auto --yes --if-present'
+if ! grep -qxF "$expected_setup" "$composio_log"; then
+    echo "Expected installer to invoke: composio $expected_setup" >&2
+    cat "$composio_log" >&2
+    exit 1
+fi
+
+no_plugins_home="$tmpdir/home-no-plugins"
+no_plugins_install="$tmpdir/install-no-plugins"
+mkdir -p "$no_plugins_home" "$no_plugins_install"
+: > "$composio_log"
+run_installer "$no_plugins_home" "$no_plugins_install" --no-plugins >/dev/null 2>&1
+if grep -q '^setup ' "$composio_log"; then
+    echo 'Expected --no-plugins to skip agent plugin setup.' >&2
+    cat "$composio_log" >&2
+    exit 1
+fi
+
+env_opt_out_home="$tmpdir/home-env-opt-out"
+env_opt_out_install="$tmpdir/install-env-opt-out"
+mkdir -p "$env_opt_out_home" "$env_opt_out_install"
+: > "$composio_log"
+COMPOSIO_INSTALL_PLUGINS=0 run_installer "$env_opt_out_home" "$env_opt_out_install" >/dev/null 2>&1
+if grep -q '^setup ' "$composio_log"; then
+    echo 'Expected COMPOSIO_INSTALL_PLUGINS=0 to skip agent plugin setup.' >&2
+    cat "$composio_log" >&2
+    exit 1
+fi
+
+failed_setup_home="$tmpdir/home-failed-setup"
+failed_setup_install="$tmpdir/install-failed-setup"
+mkdir -p "$failed_setup_home" "$failed_setup_install"
+: > "$composio_log"
+if failed_output=$(TEST_SETUP_EXIT=23 run_installer "$failed_setup_home" "$failed_setup_install" 2>&1); then
+    echo 'Expected installer to fail when detected agent plugin setup fails.' >&2
+    exit 1
+fi
+if ! grep -q 'Composio CLI was installed, but agent plugin setup failed' <<<"$failed_output"; then
+    echo 'Expected installer to explain how to retry failed plugin setup.' >&2
+    printf '%s\n' "$failed_output" >&2
+    exit 1
+fi
+
+printf 'install.sh release fallback and plugin setup tests passed\n'

--- a/ts/e2e-tests/cli/setup-plugins/e2e.test.ts
+++ b/ts/e2e-tests/cli/setup-plugins/e2e.test.ts
@@ -48,6 +48,7 @@ e2e(import.meta.url, {
     let claude: E2ETestResultWithFiles<'first-run.log' | 'second-run.log'>;
     let codex: E2ETestResultWithFiles<'first-run.log' | 'second-run.log'>;
     let unavailable: E2ETestResult;
+    let skippedUnavailable: E2ETestResult;
 
     beforeAll(async () => {
       // The shared E2E runner derives container names from Date.now(), so keep
@@ -61,6 +62,7 @@ e2e(import.meta.url, {
         files: ['first-run.log', 'second-run.log'],
       });
       unavailable = await runCmd('composio setup --target auto --yes');
+      skippedUnavailable = await runCmd('composio setup --target auto --yes --if-present');
     }, TIMEOUTS.FIXTURE);
 
     describe.each([
@@ -115,6 +117,12 @@ e2e(import.meta.url, {
         expect(unavailable.exitCode).not.toBe(0);
         expect(unavailable.stdout).toBe('');
         expect(unavailable.stderr).toContain('No supported agent host was detected');
+      });
+
+      it('can skip cleanly when invoked by an installer', () => {
+        expect(skippedUnavailable.exitCode).toBe(0);
+        expect(skippedUnavailable.stdout).toBe('');
+        expect(skippedUnavailable.stderr).toBe('');
       });
     });
   },

--- a/ts/e2e-tests/cli/setup-plugins/e2e.test.ts
+++ b/ts/e2e-tests/cli/setup-plugins/e2e.test.ts
@@ -31,10 +31,12 @@ composio setup --target ${host} --yes
 cp /tmp/host-state/commands.log first-run.log
 : > /tmp/host-state/commands.log
 composio setup --target ${host} --yes
+composio setup --uninstall --target ${host} --yes
+composio setup --uninstall --target ${host} --yes
 ${
   host === 'claude'
-    ? `test -L /tmp/.claude/skills/composio-cli
-test -r /tmp/.claude/skills/composio-cli/SKILL.md`
+    ? `test ! -L /tmp/.claude/skills/composio-cli
+test ! -e /tmp/.agents/skills/composio-cli`
     : ''
 }
 cp /tmp/host-state/commands.log second-run.log
@@ -49,6 +51,7 @@ e2e(import.meta.url, {
     let codex: E2ETestResultWithFiles<'first-run.log' | 'second-run.log'>;
     let unavailable: E2ETestResult;
     let skippedUnavailable: E2ETestResult;
+    let skippedUnavailableUninstall: E2ETestResult;
 
     beforeAll(async () => {
       // The shared E2E runner derives container names from Date.now(), so keep
@@ -63,6 +66,9 @@ e2e(import.meta.url, {
       });
       unavailable = await runCmd('composio setup --target auto --yes');
       skippedUnavailable = await runCmd('composio setup --target auto --yes --if-present');
+      skippedUnavailableUninstall = await runCmd(
+        'composio setup --uninstall --target auto --yes --if-present'
+      );
     }, TIMEOUTS.FIXTURE);
 
     describe.each([
@@ -73,6 +79,7 @@ e2e(import.meta.url, {
           'claude plugin marketplace add https://github.com/ComposioHQ/composio-plugin-cc.git --scope user',
         installCommand: 'claude plugin install composio@composio --scope user',
         additionalMutationCommands: ['claude plugin enable composio@composio --scope user'],
+        uninstallCommand: 'claude plugin uninstall composio@composio --scope user --yes',
       },
       {
         host: 'codex' as const,
@@ -81,11 +88,18 @@ e2e(import.meta.url, {
           'codex plugin marketplace add https://github.com/ComposioHQ/composio-plugin-openai.git --json',
         installCommand: 'codex plugin add composio@composio --json',
         additionalMutationCommands: [],
+        uninstallCommand: 'codex plugin remove composio@composio --json',
       },
     ])(
       '$host setup',
-      ({ result, marketplaceCommand, installCommand, additionalMutationCommands }) => {
-        it('configures the plugin on the first run and is idempotent', () => {
+      ({
+        result,
+        marketplaceCommand,
+        installCommand,
+        additionalMutationCommands,
+        uninstallCommand,
+      }) => {
+        it('installs once and uninstalls once with idempotent reruns', () => {
           const execution = result();
           expect(execution.exitCode).toBe(0);
           expect(execution.stdout).toBe('');
@@ -108,6 +122,7 @@ e2e(import.meta.url, {
               mutationCommands.some(mutation => mutation === command)
             )
           ).toEqual([]);
+          expect(secondRunCommands.filter(command => command === uninstallCommand)).toHaveLength(1);
         });
       }
     );
@@ -123,6 +138,12 @@ e2e(import.meta.url, {
         expect(skippedUnavailable.exitCode).toBe(0);
         expect(skippedUnavailable.stdout).toBe('');
         expect(skippedUnavailable.stderr).toBe('');
+      });
+
+      it('can skip uninstall cleanly when no host is present', () => {
+        expect(skippedUnavailableUninstall.exitCode).toBe(0);
+        expect(skippedUnavailableUninstall.stdout).toBe('');
+        expect(skippedUnavailableUninstall.stderr).toBe('');
       });
     });
   },

--- a/ts/e2e-tests/cli/setup-plugins/fixtures/fake-agent-host.sh
+++ b/ts/e2e-tests/cli/setup-plugins/fixtures/fake-agent-host.sh
@@ -35,6 +35,9 @@ case "$host:$command" in
   "claude:plugin enable composio@composio --scope user")
     touch "$state_dir/claude-plugin"
     ;;
+  "claude:plugin uninstall composio@composio --scope user --yes")
+    rm -f "$state_dir/claude-plugin"
+    ;;
   "codex:--version")
     printf '%s\n' 'codex-cli 0.144.1'
     ;;
@@ -57,6 +60,9 @@ case "$host:$command" in
     ;;
   "codex:plugin add composio@composio --json")
     touch "$state_dir/codex-plugin"
+    ;;
+  "codex:plugin remove composio@composio --json")
+    rm -f "$state_dir/codex-plugin"
     ;;
   *)
     printf 'Unexpected fake host command: %s %s\n' "$host" "$command" >&2

--- a/ts/packages/cli/src/commands/root-help.ts
+++ b/ts/packages/cli/src/commands/root-help.ts
@@ -162,7 +162,7 @@ const GENERATE_COMMAND: TaggedValue<CompactCommand> = tagged({
 // ── Account commands ───────────────────────────────────────────────────
 
 const ACCOUNT_COMMANDS: ReadonlyArray<TaggedValue<CompactCommand>> = [
-  tagged({ name: 'setup', description: 'Install agent plugins' }),
+  tagged({ name: 'setup', description: 'Install or uninstall agent plugins' }),
   tagged({ name: 'login', description: 'Log in to Composio' }),
   tagged({ name: 'logout', description: 'Log out from Composio' }),
   tagged({ name: 'whoami', description: 'Show current account info' }),
@@ -874,16 +874,21 @@ const SUBCOMMAND_HELP: Record<string, SubcommandHelp | TaggedValue<SubcommandHel
     description: 'Display your account information.',
   },
   setup: {
-    usage: 'composio setup [--target auto|claude|codex|all] [--yes] [--if-present]',
-    description: 'Install plugins for supported agent hosts.',
+    usage: 'composio setup [--target auto|claude|codex|all] [--uninstall] [--yes] [--if-present]',
+    description: 'Install or uninstall plugins for supported agent hosts.',
     examples: [
       'composio setup',
       'composio setup --target auto --yes',
+      'composio setup --uninstall --target auto --yes',
       'composio setup --target all',
     ],
     options: [
       { name: '--target <target>', description: 'auto, claude, codex, or all' },
       { name: '-y, --yes', description: 'Accept setup changes without prompting' },
+      {
+        name: '--uninstall',
+        description: 'Uninstall Composio plugins instead of installing them',
+      },
       {
         name: '--if-present',
         description: 'Exit successfully when automatic detection finds no supported host',

--- a/ts/packages/cli/src/commands/root-help.ts
+++ b/ts/packages/cli/src/commands/root-help.ts
@@ -874,7 +874,7 @@ const SUBCOMMAND_HELP: Record<string, SubcommandHelp | TaggedValue<SubcommandHel
     description: 'Display your account information.',
   },
   setup: {
-    usage: 'composio setup [--target auto|claude|codex|all] [--yes]',
+    usage: 'composio setup [--target auto|claude|codex|all] [--yes] [--if-present]',
     description: 'Install plugins for supported agent hosts.',
     examples: [
       'composio setup',
@@ -884,6 +884,10 @@ const SUBCOMMAND_HELP: Record<string, SubcommandHelp | TaggedValue<SubcommandHel
     options: [
       { name: '--target <target>', description: 'auto, claude, codex, or all' },
       { name: '-y, --yes', description: 'Accept setup changes without prompting' },
+      {
+        name: '--if-present',
+        description: 'Exit successfully when automatic detection finds no supported host',
+      },
     ],
   },
   version: {

--- a/ts/packages/cli/src/commands/setup.cmd.ts
+++ b/ts/packages/cli/src/commands/setup.cmd.ts
@@ -7,6 +7,7 @@ import {
   isSetupPluginReady,
   isSetupReady,
   SETUP_TARGETS,
+  uninstallSetupTargets,
   type AgentHost,
   type SetupTarget,
 } from 'src/services/setup';
@@ -29,6 +30,11 @@ const ifPresent = Options.boolean('if-present').pipe(
   Options.withDescription('Exit successfully when automatic detection finds no supported host')
 );
 
+const uninstall = Options.boolean('uninstall').pipe(
+  Options.withDefault(false),
+  Options.withDescription('Uninstall Composio plugins instead of installing them')
+);
+
 const TARGET_LABELS: Readonly<Record<AgentHost, string>> = {
   claude: 'Claude Code',
   codex: 'Codex',
@@ -39,11 +45,11 @@ const formatTargets = (targets: ReadonlyArray<AgentHost>): string =>
 
 const setupBaseCmd = Command.make(
   'setup',
-  { target, yes, ifPresent },
-  ({ target, yes, ifPresent }) =>
+  { target, yes, ifPresent, uninstall },
+  ({ target, yes, ifPresent, uninstall }) =>
     Effect.gen(function* () {
       const ui = yield* TerminalUI;
-      yield* ui.intro('composio setup');
+      yield* ui.intro(uninstall ? 'composio setup --uninstall' : 'composio setup');
 
       const detections = yield* detectSetupTargets(target);
       const detected = detections.filter(result => result.available).map(result => result.target);
@@ -61,15 +67,61 @@ const setupBaseCmd = Command.make(
         if (!ifPresent || target !== 'auto') {
           return yield* Effect.fail(
             new Error(
-              'No supported agent host was detected. Install Claude Code or Codex, then rerun `composio setup`.'
+              `No supported agent host was detected. Install Claude Code or Codex, then rerun \`composio setup${uninstall ? ' --uninstall' : ''}\`.`
             )
           );
         }
-        yield* ui.outro('No supported agent host detected; plugin setup skipped.');
+        yield* ui.outro(
+          `No supported agent host detected; plugin ${uninstall ? 'uninstall' : 'setup'} skipped.`
+        );
         return;
       }
 
-      const inspected = yield* inspectSetupTargets(detections);
+      const inspected = yield* inspectSetupTargets(detections, {
+        allowMarketplaceConflict: uninstall,
+      });
+      if (uninstall) {
+        const installed = inspected.filter(status => status.plugin_installed);
+        const notInstalled = inspected.filter(status => !status.plugin_installed);
+
+        for (const status of installed) {
+          yield* ui.log.success(
+            `The Composio plugin for ${TARGET_LABELS[status.target]} is installed.`
+          );
+        }
+        for (const status of notInstalled) {
+          yield* ui.log.info(
+            `The Composio plugin for ${TARGET_LABELS[status.target]} is not installed.`
+          );
+        }
+
+        if (!yes && installed.length > 0) {
+          if (!isInteractiveTerminal()) {
+            return yield* Effect.fail(
+              new Error('Non-interactive uninstall requires `--yes` to approve local changes.')
+            );
+          }
+          const confirmed = yield* ui.confirm(
+            `Uninstall the Composio plugin for ${formatTargets(installed.map(status => status.target))}?`,
+            { defaultValue: false }
+          );
+          if (!confirmed) {
+            yield* ui.outro('Uninstall cancelled.');
+            return;
+          }
+        }
+
+        const results = yield* uninstallSetupTargets(inspected);
+        for (const result of results) {
+          if (!result.plugin_changed) continue;
+          yield* ui.log.success(
+            `Successfully uninstalled the Composio plugin for ${TARGET_LABELS[result.target]}.`
+          );
+        }
+        yield* ui.outro('Composio plugin uninstall complete.');
+        return;
+      }
+
       for (const status of inspected.filter(isSetupPluginReady)) {
         yield* ui.log.success(
           `The Composio plugin for ${TARGET_LABELS[status.target]} is already installed and enabled.`
@@ -116,5 +168,5 @@ const setupBaseCmd = Command.make(
 );
 
 export const setupCmd = setupBaseCmd.pipe(
-  Command.withDescription('Install Composio plugins for supported agent hosts.')
+  Command.withDescription('Install or uninstall Composio plugins for supported agent hosts.')
 );

--- a/ts/packages/cli/src/commands/setup.cmd.ts
+++ b/ts/packages/cli/src/commands/setup.cmd.ts
@@ -1,9 +1,13 @@
 import { Command, Options } from '@effect/cli';
 import { Effect } from 'effect';
 import {
+  detectSetupTargets,
+  inspectSetupTargets,
   installSetupTargets,
-  resolveSetupTargets,
+  isSetupPluginReady,
+  isSetupReady,
   SETUP_TARGETS,
+  type AgentHost,
   type SetupTarget,
 } from 'src/services/setup';
 import { TerminalUI } from 'src/services/terminal-ui';
@@ -25,6 +29,14 @@ const ifPresent = Options.boolean('if-present').pipe(
   Options.withDescription('Exit successfully when automatic detection finds no supported host')
 );
 
+const TARGET_LABELS: Readonly<Record<AgentHost, string>> = {
+  claude: 'Claude Code',
+  codex: 'Codex',
+};
+
+const formatTargets = (targets: ReadonlyArray<AgentHost>): string =>
+  targets.map(target => TARGET_LABELS[target]).join(' and ');
+
 const setupBaseCmd = Command.make(
   'setup',
   { target, yes, ifPresent },
@@ -33,34 +45,70 @@ const setupBaseCmd = Command.make(
       const ui = yield* TerminalUI;
       yield* ui.intro('composio setup');
 
-      if (!yes && !isInteractiveTerminal()) {
-        return yield* Effect.fail(
-          new Error('Non-interactive setup requires `--yes` to approve local changes.')
-        );
-      }
+      const detections = yield* detectSetupTargets(target);
+      const detected = detections.filter(result => result.available).map(result => result.target);
+      const notDetected = detections
+        .filter(result => !result.available)
+        .map(result => result.target);
 
-      const targets = yield* resolveSetupTargets(target, { allowEmpty: ifPresent });
-      if (targets.length === 0) {
+      if (detected.length > 0) {
+        yield* ui.log.success(`${formatTargets(detected)} detected.`);
+      }
+      if (notDetected.length > 0) {
+        yield* ui.log.info(`${formatTargets(notDetected)} not detected.`);
+      }
+      if (detected.length === 0) {
+        if (!ifPresent || target !== 'auto') {
+          return yield* Effect.fail(
+            new Error(
+              'No supported agent host was detected. Install Claude Code or Codex, then rerun `composio setup`.'
+            )
+          );
+        }
         yield* ui.outro('No supported agent host detected; plugin setup skipped.');
         return;
       }
-      if (!yes) {
-        const confirmed = yield* ui.confirm(`Install Composio for ${targets.join(' and ')}?`, {
-          defaultValue: true,
-        });
+
+      const inspected = yield* inspectSetupTargets(detections);
+      for (const status of inspected.filter(isSetupPluginReady)) {
+        yield* ui.log.success(
+          `The Composio plugin for ${TARGET_LABELS[status.target]} is already installed and enabled.`
+        );
+      }
+
+      const pending = inspected.filter(status => !isSetupReady(status));
+      if (pending.length === 0) {
+        yield* ui.outro('Composio setup complete.');
+        return;
+      }
+
+      const pendingPlugins = pending.filter(status => !isSetupPluginReady(status));
+      if (!yes && pendingPlugins.length > 0) {
+        if (!isInteractiveTerminal()) {
+          return yield* Effect.fail(
+            new Error('Non-interactive setup requires `--yes` to approve local changes.')
+          );
+        }
+
+        const prompt = `Install the Composio plugin for ${formatTargets(pendingPlugins.map(status => status.target))}?`;
+        const confirmed = yield* ui.confirm(prompt, { defaultValue: true });
         if (!confirmed) {
           yield* ui.outro('Setup cancelled.');
           return;
         }
       }
 
-      const results = yield* installSetupTargets(targets);
+      const results = yield* installSetupTargets(pending);
       for (const result of results) {
-        let pluginMessage = `The Composio plugin for ${result.target} is already installed and enabled.`;
-        if (result.plugin_changed) {
-          pluginMessage = `Configured and enabled the Composio plugin for ${result.target}.`;
-        }
-        yield* ui.log.success(pluginMessage);
+        if (!result.plugin_changed) continue;
+
+        const initial = pending.find(status => status.target === result.target)!;
+        let action = 'configured and enabled';
+        if (!initial.plugin_installed) action = 'installed and enabled';
+        else if (!initial.plugin_enabled) action = 'enabled';
+        yield* ui.log.success(
+          `Successfully ${action} the Composio plugin for ${TARGET_LABELS[result.target]}.`
+        );
       }
 
       yield* ui.outro('Composio setup complete.');

--- a/ts/packages/cli/src/commands/setup.cmd.ts
+++ b/ts/packages/cli/src/commands/setup.cmd.ts
@@ -157,14 +157,17 @@ const setupBaseCmd = Command.make(
       }
 
       const pendingPlugins = pending.filter(status => !isSetupPluginReady(status));
-      if (!yes && pendingPlugins.length > 0) {
+      if (!yes) {
         if (!isInteractiveTerminal()) {
           return yield* Effect.fail(
             new Error('Non-interactive setup requires `--yes` to approve local changes.')
           );
         }
 
-        const prompt = `Install the Composio plugin for ${formatTargets(pendingPlugins.map(status => status.target))}?`;
+        const prompt =
+          pendingPlugins.length === pending.length
+            ? `Install the Composio plugin for ${formatTargets(pendingPlugins.map(status => status.target))}?`
+            : `Finish Composio setup for ${formatTargets(pending.map(status => status.target))}?`;
         const confirmed = yield* ui.confirm(prompt, { defaultValue: true });
         if (!confirmed) {
           yield* ui.outro('Setup cancelled.');

--- a/ts/packages/cli/src/commands/setup.cmd.ts
+++ b/ts/packages/cli/src/commands/setup.cmd.ts
@@ -12,6 +12,7 @@ import {
   type SetupTarget,
 } from 'src/services/setup';
 import { TerminalUI } from 'src/services/terminal-ui';
+import { SetupSkillInstaller } from 'src/services/setup-skill-installer';
 import { isInteractiveTerminal } from 'src/utils/stdio';
 
 const target = Options.choice('target', SETUP_TARGETS).pipe(
@@ -97,6 +98,13 @@ const setupBaseCmd = Command.make(
       if (uninstall) {
         const installed = inspected.filter(status => status.plugin_installed);
         const notInstalled = inspected.filter(status => !status.plugin_installed);
+        const skillInstaller = yield* SetupSkillInstaller;
+        const hasManagedClaudeSkill = inspected.some(status => status.target === 'claude')
+          ? yield* skillInstaller.hasManagedClaudeSkill
+          : false;
+        const removable = inspected.filter(
+          status => status.plugin_installed || (status.target === 'claude' && hasManagedClaudeSkill)
+        );
 
         for (const status of installed) {
           yield* ui.log.success(
@@ -109,14 +117,14 @@ const setupBaseCmd = Command.make(
           );
         }
 
-        if (!yes && installed.length > 0) {
+        if (!yes && removable.length > 0) {
           if (!isInteractiveTerminal()) {
             return yield* Effect.fail(
               new Error('Non-interactive uninstall requires `--yes` to approve local changes.')
             );
           }
           const confirmed = yield* ui.confirm(
-            `Uninstall the Composio plugin for ${formatTargets(installed.map(status => status.target))}?`,
+            `Remove Composio from ${formatTargets(removable.map(status => status.target))}?`,
             { defaultValue: false }
           );
           if (!confirmed) {

--- a/ts/packages/cli/src/commands/setup.cmd.ts
+++ b/ts/packages/cli/src/commands/setup.cmd.ts
@@ -61,14 +61,6 @@ const setupBaseCmd = Command.make(
           pluginMessage = `Configured and enabled the Composio plugin for ${result.target}.`;
         }
         yield* ui.log.success(pluginMessage);
-
-        if (result.target === 'codex') {
-          yield* ui.log.success('The Codex plugin includes the composio-cli skill.');
-          continue;
-        }
-        if (!result.skill_changed) {
-          yield* ui.log.success('The composio-cli skill for Claude Code is already installed.');
-        }
       }
 
       yield* ui.outro('Composio setup complete.');

--- a/ts/packages/cli/src/commands/setup.cmd.ts
+++ b/ts/packages/cli/src/commands/setup.cmd.ts
@@ -71,6 +71,13 @@ const setupBaseCmd = Command.make(
         );
       }
       if (detected.length === 0) {
+        if (target === 'claude' || target === 'codex') {
+          return yield* Effect.fail(
+            new Error(
+              `${target} is not installed or not available on PATH. Install it and rerun \`composio setup${uninstall ? ' --uninstall' : ''} --target ${target}\`.`
+            )
+          );
+        }
         if (!ifPresent || target !== 'auto') {
           return yield* Effect.fail(
             new Error(

--- a/ts/packages/cli/src/commands/setup.cmd.ts
+++ b/ts/packages/cli/src/commands/setup.cmd.ts
@@ -20,47 +20,59 @@ const yes = Options.boolean('yes').pipe(
   Options.withDescription('Accept setup changes without prompting')
 );
 
-const setupBaseCmd = Command.make('setup', { target, yes }, ({ target, yes }) =>
-  Effect.gen(function* () {
-    const ui = yield* TerminalUI;
-    yield* ui.intro('composio setup');
+const ifPresent = Options.boolean('if-present').pipe(
+  Options.withDefault(false),
+  Options.withDescription('Exit successfully when automatic detection finds no supported host')
+);
 
-    if (!yes && !isInteractiveTerminal()) {
-      return yield* Effect.fail(
-        new Error('Non-interactive setup requires `--yes` to approve local changes.')
-      );
-    }
+const setupBaseCmd = Command.make(
+  'setup',
+  { target, yes, ifPresent },
+  ({ target, yes, ifPresent }) =>
+    Effect.gen(function* () {
+      const ui = yield* TerminalUI;
+      yield* ui.intro('composio setup');
 
-    const targets = yield* resolveSetupTargets(target);
-    if (!yes) {
-      const confirmed = yield* ui.confirm(`Install Composio for ${targets.join(' and ')}?`, {
-        defaultValue: true,
-      });
-      if (!confirmed) {
-        yield* ui.outro('Setup cancelled.');
+      if (!yes && !isInteractiveTerminal()) {
+        return yield* Effect.fail(
+          new Error('Non-interactive setup requires `--yes` to approve local changes.')
+        );
+      }
+
+      const targets = yield* resolveSetupTargets(target, { allowEmpty: ifPresent });
+      if (targets.length === 0) {
+        yield* ui.outro('No supported agent host detected; plugin setup skipped.');
         return;
       }
-    }
-
-    const results = yield* installSetupTargets(targets);
-    for (const result of results) {
-      let pluginMessage = `The Composio plugin for ${result.target} is already installed and enabled.`;
-      if (result.plugin_changed) {
-        pluginMessage = `Configured and enabled the Composio plugin for ${result.target}.`;
+      if (!yes) {
+        const confirmed = yield* ui.confirm(`Install Composio for ${targets.join(' and ')}?`, {
+          defaultValue: true,
+        });
+        if (!confirmed) {
+          yield* ui.outro('Setup cancelled.');
+          return;
+        }
       }
-      yield* ui.log.success(pluginMessage);
 
-      if (result.target === 'codex') {
-        yield* ui.log.success('The Codex plugin includes the composio-cli skill.');
-        continue;
-      }
-      if (!result.skill_changed) {
-        yield* ui.log.success('The composio-cli skill for Claude Code is already installed.');
-      }
-    }
+      const results = yield* installSetupTargets(targets);
+      for (const result of results) {
+        let pluginMessage = `The Composio plugin for ${result.target} is already installed and enabled.`;
+        if (result.plugin_changed) {
+          pluginMessage = `Configured and enabled the Composio plugin for ${result.target}.`;
+        }
+        yield* ui.log.success(pluginMessage);
 
-    yield* ui.outro('Composio setup complete.');
-  })
+        if (result.target === 'codex') {
+          yield* ui.log.success('The Codex plugin includes the composio-cli skill.');
+          continue;
+        }
+        if (!result.skill_changed) {
+          yield* ui.log.success('The composio-cli skill for Claude Code is already installed.');
+        }
+      }
+
+      yield* ui.outro('Composio setup complete.');
+    })
 );
 
 export const setupCmd = setupBaseCmd.pipe(

--- a/ts/packages/cli/src/commands/setup.cmd.ts
+++ b/ts/packages/cli/src/commands/setup.cmd.ts
@@ -63,6 +63,13 @@ const setupBaseCmd = Command.make(
       if (notDetected.length > 0) {
         yield* ui.log.info(`${formatTargets(notDetected)} not detected.`);
       }
+      if (target === 'all' && notDetected.length > 0) {
+        return yield* Effect.fail(
+          new Error(
+            `\`--target all\` requires Claude Code and Codex. Missing: ${formatTargets(notDetected)}. Install the missing agent host, or use \`--target auto\` to operate on detected hosts only.`
+          )
+        );
+      }
       if (detected.length === 0) {
         if (!ifPresent || target !== 'auto') {
           return yield* Effect.fail(

--- a/ts/packages/cli/src/effects/install-skill.ts
+++ b/ts/packages/cli/src/effects/install-skill.ts
@@ -119,6 +119,7 @@ export const installSkill = (options?: {
   readonly channel?: SkillReleaseChannel;
   readonly target?: SkillInstallTarget;
   readonly skillName?: string;
+  readonly silent?: boolean;
 }) =>
   Effect.gen(function* () {
     const os = yield* NodeOs;
@@ -216,7 +217,9 @@ export const installSkill = (options?: {
       Effect.ensuring(fs.remove(tmpDir, { recursive: true, force: true }).pipe(Effect.orDie))
     );
 
-    yield* ui.log.success(`Installed ${skillName} skill for ${resolveTargetLabel(target)}`);
+    if (!options?.silent) {
+      yield* ui.log.success(`Installed ${skillName} skill for ${resolveTargetLabel(target)}`);
+    }
   });
 
 /**
@@ -227,6 +230,7 @@ export const installSkillSafe = (options?: {
   readonly channel?: SkillReleaseChannel;
   readonly target?: SkillInstallTarget;
   readonly skillName?: string;
+  readonly silent?: boolean;
 }) =>
   installSkill(options).pipe(
     Effect.sandbox,

--- a/ts/packages/cli/src/services/setup-skill-installer.ts
+++ b/ts/packages/cli/src/services/setup-skill-installer.ts
@@ -63,6 +63,7 @@ export class SetupSkillInstaller extends Effect.Service<SetupSkillInstaller>()(
           yield* installSkill({
             target: 'claude',
             releaseTag,
+            silent: true,
           });
           return true;
         }),

--- a/ts/packages/cli/src/services/setup-skill-installer.ts
+++ b/ts/packages/cli/src/services/setup-skill-installer.ts
@@ -44,6 +44,43 @@ export const isClaudeSkillCurrent = (home: string, releaseTag: string) =>
     return yield* checkClaudeSkillCurrent(fs, path, home, releaseTag);
   });
 
+const isLinkedTo = (fs: FileSystem.FileSystem, path: Path.Path, source: string, target: string) =>
+  fs.readLink(source).pipe(
+    Effect.map(link => path.resolve(path.dirname(source), link) === target),
+    Effect.catchAll(() => Effect.succeed(false))
+  );
+
+export const removeManagedClaudeSkill = (home: string) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const skillName = resolveInstalledSkillName();
+    const canonicalSkill = path.join(home, '.agents', 'skills', skillName);
+    const claudeSkill = resolveTargetSkillPath({ home, path, skillName, target: 'claude' });
+
+    let changed = false;
+    if (yield* isLinkedTo(fs, path, claudeSkill, canonicalSkill)) {
+      yield* fs.remove(claudeSkill, { recursive: true, force: true });
+      changed = true;
+    }
+
+    const isManaged = yield* fs.exists(path.join(canonicalSkill, SKILL_RELEASE_TAG_FILENAME));
+    if (!isManaged) return changed;
+
+    const otherTargets = (['codex', 'openclaw'] as const).map(target =>
+      resolveTargetSkillPath({ home, path, skillName, target })
+    );
+    const references = yield* Effect.all(
+      otherTargets.map(target => isLinkedTo(fs, path, target, canonicalSkill))
+    );
+    const stillReferenced = references.some(Boolean);
+    if (!stillReferenced) {
+      yield* fs.remove(canonicalSkill, { recursive: true, force: true });
+      changed = true;
+    }
+    return changed;
+  }).pipe(Effect.uninterruptible);
+
 export class SetupSkillInstaller extends Effect.Service<SetupSkillInstaller>()(
   'services/SetupSkillInstaller',
   {
@@ -67,6 +104,7 @@ export class SetupSkillInstaller extends Effect.Service<SetupSkillInstaller>()(
           });
           return true;
         }),
+        removeClaudeSkill: removeManagedClaudeSkill(os.homedir),
       };
     }),
     dependencies: [],

--- a/ts/packages/cli/src/services/setup-skill-installer.ts
+++ b/ts/packages/cli/src/services/setup-skill-installer.ts
@@ -50,6 +50,27 @@ const isLinkedTo = (fs: FileSystem.FileSystem, path: Path.Path, source: string, 
     Effect.catchAll(() => Effect.succeed(false))
   );
 
+export const hasManagedClaudeSkill = (home: string) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const skillName = resolveInstalledSkillName();
+    const canonicalSkill = path.join(home, '.agents', 'skills', skillName);
+    const claudeSkill = resolveTargetSkillPath({ home, path, skillName, target: 'claude' });
+
+    if (yield* isLinkedTo(fs, path, claudeSkill, canonicalSkill)) return true;
+    const isManaged = yield* fs.exists(path.join(canonicalSkill, SKILL_RELEASE_TAG_FILENAME));
+    if (!isManaged) return false;
+
+    const otherTargets = (['codex', 'openclaw'] as const).map(target =>
+      resolveTargetSkillPath({ home, path, skillName, target })
+    );
+    const references = yield* Effect.all(
+      otherTargets.map(target => isLinkedTo(fs, path, target, canonicalSkill))
+    );
+    return !references.some(Boolean);
+  });
+
 export const removeManagedClaudeSkill = (home: string) =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
@@ -93,6 +114,7 @@ export class SetupSkillInstaller extends Effect.Service<SetupSkillInstaller>()(
 
       return {
         isClaudeSkillReady: isCurrent(resolveSetupSkillReleaseTag()),
+        hasManagedClaudeSkill: hasManagedClaudeSkill(os.homedir),
         ensureClaudeSkill: Effect.gen(function* () {
           const releaseTag = resolveSetupSkillReleaseTag();
           if (yield* isCurrent(releaseTag)) return false;

--- a/ts/packages/cli/src/services/setup.ts
+++ b/ts/packages/cli/src/services/setup.ts
@@ -19,7 +19,7 @@ const CODEX_PLUGIN_MARKETPLACE = {
   plugin: 'composio@composio',
 } as const;
 
-interface SetupTargetStatus {
+export interface SetupTargetStatus {
   readonly target: AgentHost;
   readonly available: boolean;
   readonly marketplace_configured: boolean;
@@ -29,7 +29,7 @@ interface SetupTargetStatus {
   readonly cli_skill_ready: boolean;
 }
 
-interface SetupTargetResult extends SetupTargetStatus {
+export interface SetupTargetResult extends SetupTargetStatus {
   readonly changed: boolean;
   readonly plugin_changed: boolean;
   readonly skill_changed: boolean;
@@ -51,7 +51,7 @@ interface SetupTargetAdapter {
   readonly skillSource: 'bundled' | 'standalone';
 }
 
-interface InspectedSetupTarget extends SetupTargetStatus {
+export interface InspectedSetupTarget extends SetupTargetStatus {
   readonly marketplace_conflict: boolean;
 }
 
@@ -265,10 +265,10 @@ const requireInspection = <T>(
   return Effect.succeed(inspected);
 };
 
-const inspectAdapter = (adapter: SetupTargetAdapter) =>
+const inspectAdapter = (adapter: SetupTargetAdapter, knownAvailable?: boolean) =>
   Effect.gen(function* () {
     const skillInstaller = yield* SetupSkillInstaller;
-    const available = yield* isAdapterAvailable(adapter);
+    const available = knownAvailable ?? (yield* isAdapterAvailable(adapter));
     if (!available) {
       return {
         target: adapter.target,
@@ -331,12 +331,14 @@ const pluginRepairStep = (
   return undefined;
 };
 
-const isSetupReady = (status: SetupTargetStatus): boolean =>
+export const isSetupPluginReady = (status: SetupTargetStatus): boolean =>
   status.available &&
   status.marketplace_configured &&
   status.plugin_installed &&
-  status.plugin_enabled &&
-  status.cli_skill_ready;
+  status.plugin_enabled;
+
+export const isSetupReady = (status: SetupTargetStatus): boolean =>
+  isSetupPluginReady(status) && status.cli_skill_ready;
 
 const runRequired = (adapter: SetupTargetAdapter, args: ReadonlyArray<string>, operation: string) =>
   Effect.gen(function* () {
@@ -420,39 +422,37 @@ const FIXED_TARGETS: Readonly<Partial<Record<SetupTarget, ReadonlyArray<AgentHos
   all: ['claude', 'codex'],
 };
 
-export const resolveSetupTargets = (
-  target: SetupTarget,
-  options: { readonly allowEmpty?: boolean } = {}
-) =>
-  Effect.gen(function* () {
-    const fixedTargets = FIXED_TARGETS[target];
-    if (fixedTargets) return fixedTargets;
+export interface SetupTargetDetection {
+  readonly target: AgentHost;
+  readonly available: boolean;
+}
 
-    const statuses = yield* Effect.all(
-      ADAPTER_LIST.map(adapter =>
-        isAdapterAvailable(adapter).pipe(
-          Effect.map(available => ({ target: adapter.target, available }))
+export const detectSetupTargets = (target: SetupTarget) =>
+  Effect.gen(function* () {
+    const targets = FIXED_TARGETS[target] ?? ADAPTER_LIST.map(adapter => adapter.target);
+    return yield* Effect.all(
+      targets.map(target =>
+        isAdapterAvailable(ADAPTERS[target]).pipe(
+          Effect.map(available => ({ target, available }) satisfies SetupTargetDetection)
         )
       )
     );
-    const detected = statuses.filter(status => status.available).map(status => status.target);
-    if (detected.length === 0) {
-      if (options.allowEmpty) return detected;
-      return yield* Effect.fail(
-        new Error(
-          'No supported agent host was detected. Install Claude Code or Codex, or pass `--target claude|codex` after installing it.'
-        )
-      );
-    }
-    return detected;
   });
 
-export const installSetupTargets = (targets: ReadonlyArray<AgentHost>) =>
+export const inspectSetupTargets = (detections: ReadonlyArray<SetupTargetDetection>) =>
   Effect.gen(function* () {
-    const inspected = yield* Effect.forEach(targets, target => inspectAdapter(ADAPTERS[target]));
+    const inspected = yield* Effect.forEach(
+      detections.filter(detection => detection.available),
+      detection => inspectAdapter(ADAPTERS[detection.target], true)
+    );
     yield* Effect.forEach(inspected, status =>
       validateInitialState(ADAPTERS[status.target], status)
     );
+    return inspected;
+  });
+
+export const installSetupTargets = (inspected: ReadonlyArray<InspectedSetupTarget>) =>
+  Effect.gen(function* () {
     const completed: SetupTargetResult[] = [];
     for (const status of inspected) {
       const result = yield* installAdapter(ADAPTERS[status.target], status).pipe(

--- a/ts/packages/cli/src/services/setup.ts
+++ b/ts/packages/cli/src/services/setup.ts
@@ -44,6 +44,7 @@ interface SetupTargetAdapter {
   readonly marketplaceAddArgs: ReadonlyArray<string>;
   readonly pluginInstallArgs: ReadonlyArray<string>;
   readonly pluginEnableArgs: ReadonlyArray<string>;
+  readonly pluginUninstallArgs: ReadonlyArray<string>;
   readonly marketplaceRecordsKey?: string;
   readonly pluginRecordsKey?: string;
   readonly pluginScope?: string;
@@ -72,6 +73,14 @@ const ADAPTERS: Readonly<Record<AgentHost, SetupTargetAdapter>> = {
     ],
     pluginInstallArgs: ['plugin', 'install', CLAUDE_PLUGIN_MARKETPLACE.plugin, '--scope', 'user'],
     pluginEnableArgs: ['plugin', 'enable', CLAUDE_PLUGIN_MARKETPLACE.plugin, '--scope', 'user'],
+    pluginUninstallArgs: [
+      'plugin',
+      'uninstall',
+      CLAUDE_PLUGIN_MARKETPLACE.plugin,
+      '--scope',
+      'user',
+      '--yes',
+    ],
     pluginScope: 'user',
     marketplaceRemoveCommand: 'claude plugin marketplace remove composio --scope user',
     skillSource: 'standalone',
@@ -86,6 +95,7 @@ const ADAPTERS: Readonly<Record<AgentHost, SetupTargetAdapter>> = {
     pluginInstallArgs: ['plugin', 'add', CODEX_PLUGIN_MARKETPLACE.plugin, '--json'],
     // Codex has no separate enable command. Re-adding is its native install/repair path.
     pluginEnableArgs: ['plugin', 'add', CODEX_PLUGIN_MARKETPLACE.plugin, '--json'],
+    pluginUninstallArgs: ['plugin', 'remove', CODEX_PLUGIN_MARKETPLACE.plugin, '--json'],
     marketplaceRecordsKey: 'marketplaces',
     pluginRecordsKey: 'installed',
     marketplaceRemoveCommand: 'codex plugin marketplace remove composio --json',
@@ -416,6 +426,46 @@ const installAdapter = (adapter: SetupTargetAdapter, initial: InspectedSetupTarg
     } satisfies SetupTargetResult;
   });
 
+const uninstallAdapter = (adapter: SetupTargetAdapter, initial: InspectedSetupTarget) =>
+  Effect.gen(function* () {
+    let pluginChanged = false;
+    if (initial.plugin_installed) {
+      yield* runRequired(
+        adapter,
+        adapter.pluginUninstallArgs,
+        `Uninstalling the ${adapter.target} plugin`
+      );
+      pluginChanged = true;
+    }
+
+    const skillInstaller = yield* SetupSkillInstaller;
+    let skillChanged = false;
+    if (adapter.skillSource === 'standalone') {
+      skillChanged = yield* skillInstaller.removeClaudeSkill;
+    }
+
+    const final = yield* inspectAdapter(adapter);
+    if (final.plugin_installed || (adapter.skillSource === 'standalone' && final.cli_skill_ready)) {
+      return yield* Effect.fail(
+        new Error(
+          `Uninstall commands completed, but ${adapter.target} still reports Composio as installed. Rerun \`composio setup --uninstall --target ${adapter.target}\` or inspect the native ${adapter.target} plugin configuration.`
+        )
+      );
+    }
+
+    return {
+      target: adapter.target,
+      available: final.available,
+      marketplace_configured: final.marketplace_configured,
+      plugin_installed: final.plugin_installed,
+      plugin_enabled: final.plugin_enabled,
+      cli_skill_ready: final.cli_skill_ready,
+      changed: pluginChanged || skillChanged,
+      plugin_changed: pluginChanged,
+      skill_changed: skillChanged,
+    } satisfies SetupTargetResult;
+  });
+
 const FIXED_TARGETS: Readonly<Partial<Record<SetupTarget, ReadonlyArray<AgentHost>>>> = {
   claude: ['claude'],
   codex: ['codex'],
@@ -439,15 +489,20 @@ export const detectSetupTargets = (target: SetupTarget) =>
     );
   });
 
-export const inspectSetupTargets = (detections: ReadonlyArray<SetupTargetDetection>) =>
+export const inspectSetupTargets = (
+  detections: ReadonlyArray<SetupTargetDetection>,
+  options: { readonly allowMarketplaceConflict?: boolean } = {}
+) =>
   Effect.gen(function* () {
     const inspected = yield* Effect.forEach(
       detections.filter(detection => detection.available),
       detection => inspectAdapter(ADAPTERS[detection.target], true)
     );
-    yield* Effect.forEach(inspected, status =>
-      validateInitialState(ADAPTERS[status.target], status)
-    );
+    if (!options.allowMarketplaceConflict) {
+      yield* Effect.forEach(inspected, status =>
+        validateInitialState(ADAPTERS[status.target], status)
+      );
+    }
     return inspected;
   });
 
@@ -461,6 +516,24 @@ export const installSetupTargets = (inspected: ReadonlyArray<InspectedSetupTarge
           const targets = completed.map(item => item.target).join(', ');
           return new Error(
             `Setup completed for ${targets} before a later target failed: ${errorMessage(error)}`
+          );
+        })
+      );
+      completed.push(result);
+    }
+    return completed;
+  });
+
+export const uninstallSetupTargets = (inspected: ReadonlyArray<InspectedSetupTarget>) =>
+  Effect.gen(function* () {
+    const completed: SetupTargetResult[] = [];
+    for (const status of inspected) {
+      const result = yield* uninstallAdapter(ADAPTERS[status.target], status).pipe(
+        Effect.mapError(error => {
+          if (completed.length === 0) return error;
+          const targets = completed.map(item => item.target).join(', ');
+          return new Error(
+            `Uninstall completed for ${targets} before a later target failed: ${errorMessage(error)}`
           );
         })
       );

--- a/ts/packages/cli/src/services/setup.ts
+++ b/ts/packages/cli/src/services/setup.ts
@@ -420,7 +420,10 @@ const FIXED_TARGETS: Readonly<Partial<Record<SetupTarget, ReadonlyArray<AgentHos
   all: ['claude', 'codex'],
 };
 
-export const resolveSetupTargets = (target: SetupTarget) =>
+export const resolveSetupTargets = (
+  target: SetupTarget,
+  options: { readonly allowEmpty?: boolean } = {}
+) =>
   Effect.gen(function* () {
     const fixedTargets = FIXED_TARGETS[target];
     if (fixedTargets) return fixedTargets;
@@ -434,6 +437,7 @@ export const resolveSetupTargets = (target: SetupTarget) =>
     );
     const detected = statuses.filter(status => status.available).map(status => status.target);
     if (detected.length === 0) {
+      if (options.allowEmpty) return detected;
       return yield* Effect.fail(
         new Error(
           'No supported agent host was detected. Install Claude Code or Codex, or pass `--target claude|codex` after installing it.'

--- a/ts/packages/cli/src/services/setup.ts
+++ b/ts/packages/cli/src/services/setup.ts
@@ -445,10 +445,10 @@ const uninstallAdapter = (adapter: SetupTargetAdapter, initial: InspectedSetupTa
     }
 
     const final = yield* inspectAdapter(adapter);
-    if (final.plugin_installed || (adapter.skillSource === 'standalone' && final.cli_skill_ready)) {
+    if (final.plugin_installed) {
       return yield* Effect.fail(
         new Error(
-          `Uninstall commands completed, but ${adapter.target} still reports Composio as installed. Rerun \`composio setup --uninstall --target ${adapter.target}\` or inspect the native ${adapter.target} plugin configuration.`
+          `Uninstall commands completed, but ${adapter.target} still reports the Composio plugin as installed. Rerun \`composio setup --uninstall --target ${adapter.target}\` or inspect the native ${adapter.target} plugin configuration.`
         )
       );
     }

--- a/ts/packages/cli/test/__utils__/services/test-layer.ts
+++ b/ts/packages/cli/test/__utils__/services/test-layer.ts
@@ -1257,6 +1257,7 @@ export const TestLayer = (input?: TestLiveInput) =>
       input?.setupSkillInstaller ??
         new SetupSkillInstaller({
           isClaudeSkillReady: Effect.succeed(false),
+          hasManagedClaudeSkill: Effect.succeed(false),
           ensureClaudeSkill: Effect.succeed(false),
           removeClaudeSkill: Effect.succeed(false),
         })

--- a/ts/packages/cli/test/__utils__/services/test-layer.ts
+++ b/ts/packages/cli/test/__utils__/services/test-layer.ts
@@ -1258,6 +1258,7 @@ export const TestLayer = (input?: TestLiveInput) =>
         new SetupSkillInstaller({
           isClaudeSkillReady: Effect.succeed(false),
           ensureClaudeSkill: Effect.succeed(false),
+          removeClaudeSkill: Effect.succeed(false),
         })
     );
 

--- a/ts/packages/cli/test/src/commands/setup.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/setup.cmd.test.ts
@@ -4,7 +4,7 @@ import { Cause, Effect, Exit, Fiber, TestClock } from 'effect';
 import { afterEach, vi } from 'vitest';
 import { CommandRunner } from 'src/services/command-runner';
 import { SetupSkillInstaller } from 'src/services/setup-skill-installer';
-import { cli, TestLive } from 'test/__utils__';
+import { cli, MockConsole, TestLive } from 'test/__utils__';
 
 type AgentHost = 'claude' | 'codex';
 type MarketplaceState = 'missing' | 'canonical' | 'conflict';
@@ -322,12 +322,21 @@ describe('CLI: composio setup', () => {
       setupSkillInstaller: makeSkillInstaller(true),
     })
   )('automatic setup with both hosts', it => {
-    it.scoped('selects both detected hosts', () =>
+    it.scoped('selects both detected hosts and reports only plugin status', () =>
       Effect.gen(function* () {
         yield* cli(['setup', '--target', 'auto', '--yes']);
 
         expect(autoBoth.commands.some(parts => parts[0] === 'claude')).toBe(true);
         expect(autoBoth.commands.some(parts => parts[0] === 'codex')).toBe(true);
+
+        const output = (yield* MockConsole.getLines()).join('\n');
+        expect(output).toContain(
+          'The Composio plugin for claude is already installed and enabled.'
+        );
+        expect(output).toContain(
+          'The Composio plugin for codex is already installed and enabled.'
+        );
+        expect(output).not.toContain('composio-cli skill');
       })
     );
   });

--- a/ts/packages/cli/test/src/commands/setup.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/setup.cmd.test.ts
@@ -99,6 +99,7 @@ const makeSkillInstaller = (initiallyReady = false, failInstall = false) => {
   };
   return new SetupSkillInstaller({
     isClaudeSkillReady: Effect.sync(() => ready),
+    hasManagedClaudeSkill: Effect.sync(() => ready),
     ensureClaudeSkill: ensureClaudeSkill(),
     removeClaudeSkill: Effect.sync(() => {
       const changed = ready;
@@ -264,6 +265,7 @@ describe('CLI: composio setup', () => {
   let staleSkillReady = false;
   const staleSkillInstaller = new SetupSkillInstaller({
     isClaudeSkillReady: Effect.sync(() => staleSkillReady),
+    hasManagedClaudeSkill: Effect.succeed(true),
     ensureClaudeSkill: Effect.sync(() => {
       staleSkillRepaired = true;
       staleSkillReady = true;
@@ -521,6 +523,39 @@ describe('CLI: composio setup', () => {
       );
     }
   );
+
+  const orphanedClaudeSkill = makeFakeHosts({
+    claude: { available: true, marketplace: 'canonical', plugin: 'missing' },
+  });
+  let managedClaudeSkill = true;
+  layer(
+    TestLive({
+      commandRunner: orphanedClaudeSkill.runner,
+      setupSkillInstaller: new SetupSkillInstaller({
+        isClaudeSkillReady: Effect.sync(() => managedClaudeSkill),
+        hasManagedClaudeSkill: Effect.sync(() => managedClaudeSkill),
+        ensureClaudeSkill: Effect.succeed(false),
+        removeClaudeSkill: Effect.sync(() => {
+          const changed = managedClaudeSkill;
+          managedClaudeSkill = false;
+          return changed;
+        }),
+      }),
+    })
+  )('uninstall with an orphaned managed Claude skill', it => {
+    it.scoped('requires approval before removing the managed skill', () =>
+      Effect.gen(function* () {
+        const withoutApproval = yield* Effect.exit(
+          cli(['setup', '--uninstall', '--target', 'claude'])
+        );
+        expect(Exit.isFailure(withoutApproval)).toBe(true);
+        expect(managedClaudeSkill).toBe(true);
+
+        yield* cli(['setup', '--uninstall', '--target', 'claude', '--yes']);
+        expect(managedClaudeSkill).toBe(false);
+      })
+    );
+  });
 
   const nonInteractiveUninstall = makeFakeHosts({
     claude: { available: true, marketplace: 'canonical', plugin: 'enabled' },

--- a/ts/packages/cli/test/src/commands/setup.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/setup.cmd.test.ts
@@ -221,6 +221,12 @@ describe('CLI: composio setup', () => {
           marketplace: 'canonical',
           plugin: 'enabled',
         });
+
+        const output = (yield* MockConsole.getLines()).join('\n');
+        expect(output).toContain('Claude Code detected.');
+        expect(output).toContain(
+          'Successfully installed and enabled the Composio plugin for Claude Code.'
+        );
       })
     );
   });
@@ -234,6 +240,39 @@ describe('CLI: composio setup', () => {
         yield* cli(['setup', '--target', 'codex', '--yes']);
 
         expect(existingCodex.commands.some(parts => parts.includes('add'))).toBe(false);
+      })
+    );
+  });
+
+  const existingClaudeWithStaleSkill = makeFakeHosts({
+    claude: { available: true, marketplace: 'canonical', plugin: 'enabled' },
+  });
+  let staleSkillRepaired = false;
+  let staleSkillReady = false;
+  const staleSkillInstaller = new SetupSkillInstaller({
+    isClaudeSkillReady: Effect.sync(() => staleSkillReady),
+    ensureClaudeSkill: Effect.sync(() => {
+      staleSkillRepaired = true;
+      staleSkillReady = true;
+      return true;
+    }),
+  });
+  layer(
+    TestLive({
+      commandRunner: existingClaudeWithStaleSkill.runner,
+      setupSkillInstaller: staleSkillInstaller,
+    })
+  )('existing Claude plugin with stale skill', it => {
+    it.scoped('repairs the skill silently without requiring plugin approval', () =>
+      Effect.gen(function* () {
+        yield* cli(['setup', '--target', 'claude']);
+
+        expect(staleSkillRepaired).toBe(true);
+        const output = (yield* MockConsole.getLines()).join('\n');
+        expect(output).toContain(
+          'The Composio plugin for Claude Code is already installed and enabled.'
+        );
+        expect(output).not.toContain('skill');
       })
     );
   });
@@ -308,6 +347,10 @@ describe('CLI: composio setup', () => {
         expect(
           autoClaude.commands.some(parts => parts[0] === 'codex' && parts[1] !== '--version')
         ).toBe(false);
+
+        const output = (yield* MockConsole.getLines()).join('\n');
+        expect(output).toContain('Claude Code detected.');
+        expect(output).toContain('Codex not detected.');
       })
     );
   });
@@ -324,18 +367,17 @@ describe('CLI: composio setup', () => {
   )('automatic setup with both hosts', it => {
     it.scoped('selects both detected hosts and reports only plugin status', () =>
       Effect.gen(function* () {
-        yield* cli(['setup', '--target', 'auto', '--yes']);
+        yield* cli(['setup', '--target', 'auto']);
 
         expect(autoBoth.commands.some(parts => parts[0] === 'claude')).toBe(true);
         expect(autoBoth.commands.some(parts => parts[0] === 'codex')).toBe(true);
 
         const output = (yield* MockConsole.getLines()).join('\n');
+        expect(output).toContain('Claude Code and Codex detected.');
         expect(output).toContain(
-          'The Composio plugin for claude is already installed and enabled.'
+          'The Composio plugin for Claude Code is already installed and enabled.'
         );
-        expect(output).toContain(
-          'The Composio plugin for codex is already installed and enabled.'
-        );
+        expect(output).toContain('The Composio plugin for Codex is already installed and enabled.');
         expect(output).not.toContain('composio-cli skill');
       })
     );
@@ -438,6 +480,18 @@ describe('CLI: composio setup', () => {
           cli(['setup', '--target', 'auto', '--yes', '--if-present'])
         );
         expect(Exit.isSuccess(exit)).toBe(true);
+
+        const output = (yield* MockConsole.getLines()).join('\n');
+        expect(output).toContain('Claude Code and Codex not detected.');
+      })
+    );
+
+    it.scoped('does not skip an explicitly requested missing host', () =>
+      Effect.gen(function* () {
+        const exit = yield* Effect.exit(
+          cli(['setup', '--target', 'claude', '--yes', '--if-present'])
+        );
+        expect(Exit.isFailure(exit)).toBe(true);
       })
     );
   });
@@ -576,12 +630,18 @@ describe('CLI: composio setup', () => {
 
   const nonInteractive = makeFakeHosts({ claude: { available: true } });
   layer(TestLive({ commandRunner: nonInteractive.runner }))('non-interactive approval', it => {
-    it.scoped('requires --yes before inspecting or mutating hosts', () =>
+    it.scoped('inspects first but requires --yes before mutating hosts', () =>
       Effect.gen(function* () {
         const exit = yield* Effect.exit(cli(['setup', '--target', 'claude']));
 
         expect(Exit.isFailure(exit)).toBe(true);
-        expect(nonInteractive.commands).toHaveLength(0);
+        expect(nonInteractive.commands).toContainEqual(['claude', '--version']);
+        expect(nonInteractive.commands).toContainEqual(['claude', 'plugin', 'list', '--json']);
+        expect(
+          nonInteractive.commands.some(parts =>
+            ['add', 'install', 'enable'].some(operation => parts.includes(operation))
+          )
+        ).toBe(false);
       })
     );
   });

--- a/ts/packages/cli/test/src/commands/setup.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/setup.cmd.test.ts
@@ -427,6 +427,29 @@ describe('CLI: composio setup', () => {
     );
   });
 
+  const partialAllTargets = makeFakeHosts({ claude: { available: true } });
+  layer(TestLive({ commandRunner: partialAllTargets.runner }))(
+    'explicit all-host setup with a missing host',
+    it => {
+      it.scoped('fails before mutating the detected host', () =>
+        Effect.gen(function* () {
+          const exit = yield* Effect.exit(cli(['setup', '--target', 'all', '--yes']));
+
+          expect(Exit.isFailure(exit)).toBe(true);
+          expect(partialAllTargets.state.claude).toMatchObject({
+            marketplace: 'missing',
+            plugin: 'missing',
+          });
+          expect(
+            partialAllTargets.commands.some(parts =>
+              ['marketplace', 'install', 'enable'].some(operation => parts.includes(operation))
+            )
+          ).toBe(false);
+        })
+      );
+    }
+  );
+
   const uninstallBoth = makeFakeHosts({
     claude: { available: true, marketplace: 'canonical', plugin: 'enabled' },
     codex: { available: true, marketplace: 'canonical', plugin: 'enabled' },

--- a/ts/packages/cli/test/src/commands/setup.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/setup.cmd.test.ts
@@ -283,9 +283,13 @@ describe('CLI: composio setup', () => {
       setupSkillInstaller: staleSkillInstaller,
     })
   )('existing Claude plugin with stale skill', it => {
-    it.scoped('repairs the skill silently without requiring plugin approval', () =>
+    it.scoped('requires approval, then repairs the skill without extra output', () =>
       Effect.gen(function* () {
-        yield* cli(['setup', '--target', 'claude']);
+        const withoutApproval = yield* Effect.exit(cli(['setup', '--target', 'claude']));
+        expect(Exit.isFailure(withoutApproval)).toBe(true);
+        expect(staleSkillRepaired).toBe(false);
+
+        yield* cli(['setup', '--target', 'claude', '--yes']);
 
         expect(staleSkillRepaired).toBe(true);
         const output = (yield* MockConsole.getLines()).join('\n');

--- a/ts/packages/cli/test/src/commands/setup.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/setup.cmd.test.ts
@@ -100,6 +100,11 @@ const makeSkillInstaller = (initiallyReady = false, failInstall = false) => {
   return new SetupSkillInstaller({
     isClaudeSkillReady: Effect.sync(() => ready),
     ensureClaudeSkill: ensureClaudeSkill(),
+    removeClaudeSkill: Effect.sync(() => {
+      const changed = ready;
+      ready = false;
+      return changed;
+    }),
   });
 };
 
@@ -165,6 +170,14 @@ const makeFakeHosts = (
     }
     if (!options.noOp && command.includes('plugin marketplace add')) {
       state[host].marketplace = 'canonical';
+    }
+    if (
+      !options.noOp &&
+      (command === 'claude plugin uninstall composio@composio --scope user --yes' ||
+        command === 'codex plugin remove composio@composio --json')
+    ) {
+      state[host].plugin = 'missing';
+      return {};
     }
     if (
       !options.noOp &&
@@ -255,6 +268,11 @@ describe('CLI: composio setup', () => {
       staleSkillRepaired = true;
       staleSkillReady = true;
       return true;
+    }),
+    removeClaudeSkill: Effect.sync(() => {
+      const changed = staleSkillReady;
+      staleSkillReady = false;
+      return changed;
     }),
   });
   layer(
@@ -405,6 +423,142 @@ describe('CLI: composio setup', () => {
           marketplace: 'canonical',
           plugin: 'enabled',
         });
+      })
+    );
+  });
+
+  const uninstallBoth = makeFakeHosts({
+    claude: { available: true, marketplace: 'canonical', plugin: 'enabled' },
+    codex: { available: true, marketplace: 'canonical', plugin: 'enabled' },
+  });
+  layer(
+    TestLive({
+      commandRunner: uninstallBoth.runner,
+      setupSkillInstaller: makeSkillInstaller(true),
+    })
+  )('uninstall from both hosts', it => {
+    it.scoped('uses native removal commands and is idempotent', () =>
+      Effect.gen(function* () {
+        yield* cli(['setup', '--uninstall', '--target', 'all', '--yes']);
+        yield* cli(['setup', '--uninstall', '--target', 'all', '--yes']);
+
+        expect(uninstallBoth.commands).toContainEqual([
+          'claude',
+          'plugin',
+          'uninstall',
+          'composio@composio',
+          '--scope',
+          'user',
+          '--yes',
+        ]);
+        expect(uninstallBoth.commands).toContainEqual([
+          'codex',
+          'plugin',
+          'remove',
+          'composio@composio',
+          '--json',
+        ]);
+        expect(
+          uninstallBoth.commands.filter(
+            parts =>
+              parts.join(' ') === 'claude plugin uninstall composio@composio --scope user --yes'
+          )
+        ).toHaveLength(1);
+        expect(
+          uninstallBoth.commands.filter(
+            parts => parts.join(' ') === 'codex plugin remove composio@composio --json'
+          )
+        ).toHaveLength(1);
+        expect(uninstallBoth.state.claude.plugin).toBe('missing');
+        expect(uninstallBoth.state.codex.plugin).toBe('missing');
+
+        const output = (yield* MockConsole.getLines()).join('\n');
+        expect(output).toContain('Successfully uninstalled the Composio plugin for Claude Code.');
+        expect(output).toContain('Successfully uninstalled the Composio plugin for Codex.');
+        expect(output).not.toContain('skill');
+      })
+    );
+  });
+
+  const uninstallMissing = makeFakeHosts({
+    claude: { available: true, marketplace: 'canonical', plugin: 'missing' },
+    codex: { available: true, marketplace: 'canonical', plugin: 'missing' },
+  });
+  layer(TestLive({ commandRunner: uninstallMissing.runner }))(
+    'uninstall when plugins are absent',
+    it => {
+      it.scoped('reports the idempotent state without requiring approval', () =>
+        Effect.gen(function* () {
+          yield* cli(['setup', '--uninstall', '--target', 'all']);
+
+          const output = (yield* MockConsole.getLines()).join('\n');
+          expect(output).toContain('The Composio plugin for Claude Code is not installed.');
+          expect(output).toContain('The Composio plugin for Codex is not installed.');
+        })
+      );
+    }
+  );
+
+  const nonInteractiveUninstall = makeFakeHosts({
+    claude: { available: true, marketplace: 'canonical', plugin: 'enabled' },
+  });
+  layer(
+    TestLive({
+      commandRunner: nonInteractiveUninstall.runner,
+      setupSkillInstaller: makeSkillInstaller(true),
+    })
+  )('non-interactive uninstall approval', it => {
+    it.scoped('requires --yes before removing an installed plugin', () =>
+      Effect.gen(function* () {
+        const exit = yield* Effect.exit(cli(['setup', '--uninstall', '--target', 'claude']));
+
+        expect(Exit.isFailure(exit)).toBe(true);
+        expect(nonInteractiveUninstall.commands.some(parts => parts.includes('uninstall'))).toBe(
+          false
+        );
+      })
+    );
+  });
+
+  const conflictingUninstall = makeFakeHosts({
+    claude: { available: true, marketplace: 'conflict', plugin: 'enabled' },
+  });
+  layer(
+    TestLive({
+      commandRunner: conflictingUninstall.runner,
+      setupSkillInstaller: makeSkillInstaller(true),
+    })
+  )('uninstall with a conflicting marketplace', it => {
+    it.scoped('removes the installed plugin without replacing the marketplace', () =>
+      Effect.gen(function* () {
+        yield* cli(['setup', '--uninstall', '--target', 'claude', '--yes']);
+
+        expect(conflictingUninstall.state.claude.plugin).toBe('missing');
+        expect(conflictingUninstall.state.claude.marketplace).toBe('conflict');
+      })
+    );
+  });
+
+  const failedUninstall = makeFakeHosts(
+    { claude: { available: true, marketplace: 'canonical', plugin: 'enabled' } },
+    { failOn: 'plugin uninstall' }
+  );
+  layer(
+    TestLive({
+      commandRunner: failedUninstall.runner,
+      setupSkillInstaller: makeSkillInstaller(true),
+    })
+  )('native uninstall failure', it => {
+    it.scoped('fails without reporting the plugin as removed', () =>
+      Effect.gen(function* () {
+        const exit = yield* Effect.exit(
+          cli(['setup', '--uninstall', '--target', 'claude', '--yes'])
+        );
+
+        expect(Exit.isFailure(exit)).toBe(true);
+        expect(failedUninstall.state.claude.plugin).toBe('enabled');
+        const output = (yield* MockConsole.getLines()).join('\n');
+        expect(output).not.toContain('Successfully uninstalled');
       })
     );
   });

--- a/ts/packages/cli/test/src/commands/setup.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/setup.cmd.test.ts
@@ -669,6 +669,11 @@ describe('CLI: composio setup', () => {
           cli(['setup', '--target', 'claude', '--yes', '--if-present'])
         );
         expect(Exit.isFailure(exit)).toBe(true);
+        if (Exit.isFailure(exit)) {
+          expect(Cause.pretty(exit.cause)).toContain(
+            'claude is not installed or not available on PATH'
+          );
+        }
       })
     );
   });

--- a/ts/packages/cli/test/src/commands/setup.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/setup.cmd.test.ts
@@ -422,6 +422,15 @@ describe('CLI: composio setup', () => {
         expect(Exit.isFailure(exit)).toBe(true);
       })
     );
+
+    it.scoped('can skip automatic setup for installer integration', () =>
+      Effect.gen(function* () {
+        const exit = yield* Effect.exit(
+          cli(['setup', '--target', 'auto', '--yes', '--if-present'])
+        );
+        expect(Exit.isSuccess(exit)).toBe(true);
+      })
+    );
   });
 
   const conflict = makeFakeHosts({

--- a/ts/packages/cli/test/src/commands/setup.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/setup.cmd.test.ts
@@ -561,6 +561,31 @@ describe('CLI: composio setup', () => {
     );
   });
 
+  const uninstallWithUnmanagedClaudeSkill = makeFakeHosts({
+    claude: { available: true, marketplace: 'canonical', plugin: 'enabled' },
+  });
+  layer(
+    TestLive({
+      commandRunner: uninstallWithUnmanagedClaudeSkill.runner,
+      setupSkillInstaller: new SetupSkillInstaller({
+        isClaudeSkillReady: Effect.succeed(true),
+        hasManagedClaudeSkill: Effect.succeed(false),
+        ensureClaudeSkill: Effect.succeed(false),
+        removeClaudeSkill: Effect.succeed(false),
+      }),
+    })
+  )('uninstall with an unmanaged Claude skill', it => {
+    it.scoped('preserves the skill without treating plugin removal as a failure', () =>
+      Effect.gen(function* () {
+        yield* cli(['setup', '--uninstall', '--target', 'claude', '--yes']);
+
+        expect(uninstallWithUnmanagedClaudeSkill.state.claude.plugin).toBe('missing');
+        const output = (yield* MockConsole.getLines()).join('\n');
+        expect(output).toContain('Successfully uninstalled the Composio plugin for Claude Code.');
+      })
+    );
+  });
+
   const nonInteractiveUninstall = makeFakeHosts({
     claude: { available: true, marketplace: 'canonical', plugin: 'enabled' },
   });

--- a/ts/packages/cli/test/src/services/setup-skill-installer.test.ts
+++ b/ts/packages/cli/test/src/services/setup-skill-installer.test.ts
@@ -5,6 +5,7 @@ import { Effect, Layer } from 'effect';
 import * as tempy from 'tempy';
 import { SKILL_RELEASE_TAG_FILENAME } from 'src/effects/install-skill';
 import {
+  hasManagedClaudeSkill,
   isClaudeSkillCurrent,
   removeManagedClaudeSkill,
   resolveSetupSkillReleaseTag,
@@ -105,7 +106,9 @@ describe('SetupSkillInstaller', () => {
         yield* fs.makeDirectory(path.dirname(claude), { recursive: true });
         yield* fs.symlink(path.relative(path.dirname(claude), canonical), claude);
 
+        expect(yield* hasManagedClaudeSkill(home)).toBe(true);
         expect(yield* removeManagedClaudeSkill(home)).toBe(true);
+        expect(yield* hasManagedClaudeSkill(home)).toBe(false);
         expect(yield* fs.exists(claude)).toBe(false);
         expect(yield* fs.exists(canonical)).toBe(false);
       })
@@ -129,7 +132,9 @@ describe('SetupSkillInstaller', () => {
         yield* fs.symlink(path.relative(path.dirname(claude), canonical), claude);
         yield* fs.symlink(path.relative(path.dirname(openclaw), canonical), openclaw);
 
+        expect(yield* hasManagedClaudeSkill(home)).toBe(true);
         expect(yield* removeManagedClaudeSkill(home)).toBe(true);
+        expect(yield* hasManagedClaudeSkill(home)).toBe(false);
         expect(yield* fs.exists(claude)).toBe(false);
         expect(yield* fs.exists(canonical)).toBe(true);
         expect(yield* fs.exists(openclaw)).toBe(true);

--- a/ts/packages/cli/test/src/services/setup-skill-installer.test.ts
+++ b/ts/packages/cli/test/src/services/setup-skill-installer.test.ts
@@ -6,6 +6,7 @@ import * as tempy from 'tempy';
 import { SKILL_RELEASE_TAG_FILENAME } from 'src/effects/install-skill';
 import {
   isClaudeSkillCurrent,
+  removeManagedClaudeSkill,
   resolveSetupSkillReleaseTag,
 } from 'src/services/setup-skill-installer';
 
@@ -86,6 +87,52 @@ describe('SetupSkillInstaller', () => {
         );
 
         expect(yield* isClaudeSkillCurrent(home, '@composio/cli@0.3.0')).toBe(false);
+      })
+    );
+
+    it.effect('removes the CLI-managed Claude skill and canonical copy', () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const home = tempy.temporaryDirectory();
+        const canonical = path.join(home, '.agents', 'skills', 'composio-cli');
+        const claude = path.join(home, '.claude', 'skills', 'composio-cli');
+        yield* fs.makeDirectory(canonical, { recursive: true });
+        yield* fs.writeFileString(
+          path.join(canonical, SKILL_RELEASE_TAG_FILENAME),
+          '@composio/cli@0.3.0\n'
+        );
+        yield* fs.makeDirectory(path.dirname(claude), { recursive: true });
+        yield* fs.symlink(path.relative(path.dirname(claude), canonical), claude);
+
+        expect(yield* removeManagedClaudeSkill(home)).toBe(true);
+        expect(yield* fs.exists(claude)).toBe(false);
+        expect(yield* fs.exists(canonical)).toBe(false);
+      })
+    );
+
+    it.effect('keeps the canonical skill while another agent references it', () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const home = tempy.temporaryDirectory();
+        const canonical = path.join(home, '.agents', 'skills', 'composio-cli');
+        const claude = path.join(home, '.claude', 'skills', 'composio-cli');
+        const openclaw = path.join(home, '.openclaw', 'skills', 'composio-cli');
+        yield* fs.makeDirectory(canonical, { recursive: true });
+        yield* fs.writeFileString(
+          path.join(canonical, SKILL_RELEASE_TAG_FILENAME),
+          '@composio/cli@0.3.0\n'
+        );
+        yield* fs.makeDirectory(path.dirname(claude), { recursive: true });
+        yield* fs.makeDirectory(path.dirname(openclaw), { recursive: true });
+        yield* fs.symlink(path.relative(path.dirname(claude), canonical), claude);
+        yield* fs.symlink(path.relative(path.dirname(openclaw), canonical), openclaw);
+
+        expect(yield* removeManagedClaudeSkill(home)).toBe(true);
+        expect(yield* fs.exists(claude)).toBe(false);
+        expect(yield* fs.exists(canonical)).toBe(true);
+        expect(yield* fs.exists(openclaw)).toBe(true);
       })
     );
   });


### PR DESCRIPTION
## Summary

- run plugin setup automatically from the canonical `install.sh` flow after shell integration
- configure every detected Claude Code and Codex host through the setup engine from #3835
- add `composio setup --if-present` so installer automation succeeds when no supported host is installed
- support `--no-plugins` and `COMPOSIO_INSTALL_PLUGINS=0` as explicit opt-outs
- fail visibly with an exact retry command when a detected host cannot be configured

## Stack

This is a deliberately small follow-up to #3835 and targets `jk/cli-plugin-setup-review`. It should be rebased onto `next` after #3835 merges.

## Behavior

The installer invokes the newly installed binary directly, so it does not depend on the current shell reloading `PATH`:

```bash
"$exe" setup --target auto --yes --if-present
```

No detected host is a successful no-op. A detected host setup failure leaves the CLI installed but fails the installer with `composio setup --target auto --yes` as the retry path.

## Validation

- install.sh release-resolution, automatic setup, opt-out, and setup-failure harness passed
- focused setup suite: 25 tests passed
- full CLI suite: 83 files passed; 761 tests passed; 1 skipped
- direct CLI source and test typechecks passed
- stable and beta skill validation passed
- focused ESLint, shell syntax checks, and `git diff --check` passed
- packaged setup E2E updated for the no-host installer path; local launch is blocked by missing `mise`, so scratch-container CI is the authoritative packaged check

## Recording

No VHS recording: this is installer orchestration plus a non-interactive automation flag, covered at the shell-installer and packaged CLI boundaries.
