### PR TITLE
fix(py): make telemetry _setup() lazy init thread-safe

### DIFF
--- a/python/composio/core/models/_telemetry.py
+++ b/python/composio/core/models/_telemetry.py
@@ -90,36 +90,46 @@ EventQueue: t.TypeAlias = q.Queue[Event]
 _queue: t.Optional[EventQueue] = None
 _event: t.Optional[tr.Event] = None
 _thread: t.Optional[tr.Thread] = None
+_init_lock = tr.Lock()
 
 
 def _setup():
     global _queue, _event, _thread
-    if _queue is None:
-        _queue = q.Queue[Event]()
+    # Fast path: once initialized, skip the lock entirely.
+    if _thread is not None:
+        return _queue, _event, _thread
 
-    if _event is None:
-        _event = tr.Event()
+    # `push_event` runs on the trace wrapper of every public Resource method, so
+    # the first call can race across threads (the SDK itself dispatches from a
+    # ThreadPoolExecutor). Guard the check-then-init so exactly one queue/event/
+    # thread is created and a single atexit teardown is registered.
+    with _init_lock:
+        if _queue is None:
+            _queue = q.Queue[Event]()
 
-    if _thread is None:
-        _thread = tr.Thread(
-            target=_thread_loop,
-            kwargs={
-                "queue": _queue,
-                "event": _event,
-            },
-            daemon=True,
-        )
-        _thread.start()
-        atexit.register(
-            functools.partial(
-                _teardown,
-                queue=_queue,
-                event=_event,
-                thread=_thread,
+        if _event is None:
+            _event = tr.Event()
+
+        if _thread is None:
+            _thread = tr.Thread(
+                target=_thread_loop,
+                kwargs={
+                    "queue": _queue,
+                    "event": _event,
+                },
+                daemon=True,
             )
-        )
+            _thread.start()
+            atexit.register(
+                functools.partial(
+                    _teardown,
+                    queue=_queue,
+                    event=_event,
+                    thread=_thread,
+                )
+            )
 
-    return _queue, _event, _thread
+        return _queue, _event, _thread
 
 
 def _teardown(queue: EventQueue, event: tr.Event, thread: tr.Thread):

--- a/python/tests/test_telemetry.py
+++ b/python/tests/test_telemetry.py
@@ -1,0 +1,152 @@
+"""Telemetry lazy init must be thread-safe.
+
+``push_event`` runs on the trace wrapper of every public ``Resource`` method
+(see ``base.ResourceMeta``), and the SDK dispatches those methods from thread
+pools (e.g. ``triggers`` / ``tool_router_session``). The first call lazily
+initializes the module-level queue, event, and daemon consumer thread with a
+check-then-set (``if _thread is None: ... _thread.start(); atexit.register(...)``).
+
+Without a lock two threads can each observe ``_thread is None`` on first use and
+both start a daemon consumer thread and both register an ``atexit`` teardown, so
+an extra background thread leaks and the (up to 2s poll + 3s join) teardown runs
+twice at shutdown. ``_setup`` guards the init with ``_init_lock`` so exactly one
+queue/event/thread is created and a single teardown is registered.
+"""
+
+import threading
+import typing as t
+
+import pytest
+
+from composio.core.models import _telemetry
+
+
+@pytest.fixture
+def reset_telemetry() -> t.Iterator[None]:
+    """Reset the module globals so each test starts from a first-use state.
+
+    The daemon consumer thread is never actually started in these tests (the
+    ``Thread`` class is patched), so there is nothing to tear down; we only need
+    to restore the globals afterwards to avoid leaking state between tests.
+    """
+    saved = (_telemetry._queue, _telemetry._event, _telemetry._thread)
+    _telemetry._queue = None
+    _telemetry._event = None
+    _telemetry._thread = None
+    try:
+        yield
+    finally:
+        _telemetry._queue, _telemetry._event, _telemetry._thread = saved
+
+
+def _run_concurrent_setup(
+    monkeypatch: pytest.MonkeyPatch,
+    threads: int,
+) -> t.Tuple[int, int]:
+    """Run ``_setup`` from ``threads`` workers racing on first use.
+
+    ``Thread`` construction is intercepted so that the first worker to reach it
+    parks until the others have had a chance to cross the ``_thread is None``
+    guard, deterministically exercising the check-then-set window. No real
+    consumer thread is started. Returns ``(threads_created, atexit_registrations)``.
+    """
+    created: t.List[int] = []
+    atexit_registrations: t.List[t.Callable] = []
+    real_thread_cls = _telemetry.tr.Thread
+
+    release = threading.Event()
+    first_arrival = threading.Event()
+
+    class ParkingThread(real_thread_cls):  # type: ignore[valid-type, misc]
+        def __init__(self, *args: t.Any, **kwargs: t.Any) -> None:
+            created.append(1)
+            first_arrival.set()
+            # Hold inside the init window so any racing worker (only possible
+            # without the lock) can also pass the guard before we finish.
+            release.wait(timeout=5.0)
+            super().__init__(*args, **kwargs)
+
+        def start(self) -> None:  # do not run the real network loop
+            pass
+
+    barrier = threading.Barrier(threads)
+
+    def worker() -> None:
+        barrier.wait()
+        _telemetry._setup()
+
+    # Build the worker threads with the real Thread class *before* patching, so
+    # patching ``tr.Thread`` (the shared ``threading`` module) only affects the
+    # thread ``_setup`` constructs, not the harness threads themselves.
+    workers = [real_thread_cls(target=worker) for _ in range(threads)]
+
+    monkeypatch.setattr(_telemetry.tr, "Thread", ParkingThread)
+    monkeypatch.setattr(
+        _telemetry.atexit, "register", lambda func: atexit_registrations.append(func)
+    )
+
+    for th in workers:
+        th.start()
+
+    # Once one worker is parked inside the window, give the rest a moment to
+    # arrive. With the lock they stay blocked on ``_init_lock``; without it they
+    # all reach the window and each constructs a thread.
+    assert first_arrival.wait(timeout=5.0), "no worker reached _setup()"
+    threading.Event().wait(0.3)
+    release.set()
+
+    for th in workers:
+        th.join(timeout=5.0)
+        assert not th.is_alive()
+
+    return len(created), len(atexit_registrations)
+
+
+class TestSetupThreadSafety:
+    """``_setup`` initializes shared telemetry state exactly once under races."""
+
+    def test_concurrent_first_use_starts_single_thread(
+        self, reset_telemetry: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        threads_created, atexit_registrations = _run_concurrent_setup(
+            monkeypatch, threads=8
+        )
+
+        # Exactly one consumer thread and one teardown registration, no matter
+        # how many callers raced on first use.
+        assert threads_created == 1
+        assert atexit_registrations == 1
+
+    def test_setup_returns_same_singletons(
+        self, reset_telemetry: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Every caller gets the identical queue/event/thread objects."""
+        # Swallow the atexit registration so this test's teardown does not leak
+        # into the interpreter-wide registry; we join the thread ourselves.
+        monkeypatch.setattr(_telemetry.atexit, "register", lambda func: None)
+
+        results: t.List[t.Tuple[t.Any, t.Any, t.Any]] = []
+        barrier = threading.Barrier(8)
+
+        def worker() -> None:
+            barrier.wait()
+            results.append(_telemetry._setup())
+
+        workers = [threading.Thread(target=worker) for _ in range(8)]
+        for th in workers:
+            th.start()
+        for th in workers:
+            th.join(timeout=5.0)
+
+        try:
+            assert len(results) == 8
+            first = results[0]
+            assert all(result == first for result in results)
+            # A single consumer thread drains the shared queue.
+            assert first[2] is _telemetry._thread
+        finally:
+            # A real daemon consumer thread was started here; signal it to exit.
+            if _telemetry._event is not None:
+                _telemetry._event.set()
+            if _telemetry._thread is not None:
+                _telemetry._thread.join(timeout=5.0)


### PR DESCRIPTION


The telemetry background worker is initialized lazily the first time an event is
pushed. `push_event` runs on the trace wrapper that `ResourceMeta` installs on
every public `Resource` method (`python/composio/core/models/base.py`), and the
SDK dispatches those methods from thread pools (for example the
`ThreadPoolExecutor` uses in `triggers.py` and `tool_router_session.py`, and
user code calling the SDK from its own threads/async).

`_setup()` in `python/composio/core/models/_telemetry.py` initialized the
module-level `_queue`/`_event`/`_thread` with an unguarded check-then-set:

```python
if _thread is None:
    _thread = tr.Thread(...)
    _thread.start()
    atexit.register(functools.partial(_teardown, ...))
```

On concurrent first use, N threads can each observe `_thread is None` before any
of them assigns it, so each starts its own daemon consumer thread and each
registers an `atexit` teardown. The result is an extra background thread that
leaks for the life of the process, and a shutdown path (up to a 2s poll plus a
3s join per handler) that runs multiple times at exit. There is a similar window
on `_queue`/`_event` where a producer could enqueue into a queue whose consumer
thread was never started, silently dropping telemetry events.

No issue is linked; this was found by reading the initialization path.

Fixes #

## Changes

- Add a module-level `_init_lock = tr.Lock()` and wrap the `_queue`/`_event`/
  `_thread` initialization in `_setup()` with `with _init_lock:` using
  double-checked locking, so exactly one queue/event/thread is created and a
  single `atexit` teardown is registered under concurrent first use.
- Keep a lock-free fast path: once `_thread` is set, `_setup()` returns without
  acquiring the lock, so the hot path (every traced SDK call after init) stays
  cheap. `_thread` is assigned last inside the lock, so any caller that sees
  `_thread is not None` also sees a fully constructed `_queue`/`_event`.
- Add `python/tests/test_telemetry.py`, a regression test that deterministically
  parks the first caller inside the init window and races 8 first-callers through
  it, asserting exactly one thread is created and one teardown is registered.

No public API change.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [ ] Documentation
- [ ] Breaking change

## How Has This Been Tested?

Run from `python/` in the repo virtualenv (Python 3.11):

- `uv run pytest tests/test_telemetry.py -q` -> passes on this branch.
- Reverting only `python/composio/core/models/_telemetry.py` to the pre-fix
  revision makes `test_concurrent_first_use_starts_single_thread` fail with
  `assert 8 == 1` (8 threads and 8 atexit registrations), which is exactly the
  race being fixed; restoring the file makes it pass again.
- `ruff --config config/ruff.toml check` and `ruff --config config/ruff.toml
  format --check` on both changed files: clean.
- `mypy --config-file config/mypy.ini` on both changed files: no issues.
- Broader offline unit subset (`test_imports`, `test_sdk`, schema/provider/core
  type suites) passes with no regressions. Network/API-key integration tests were
  not run; they are unrelated to this change.

## Screenshots (if applicable)

N/A.

## Checklist
- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed
- [ ] I updated documentation as needed (no docs change; internal telemetry only)
- [x] I added tests or explain why not applicable
- [ ] I added a changeset if this change affects published packages (Python-only,
      no published-package change, so no changeset)

## Additional context

The fix is scoped to `_setup()`; `_teardown`, `push_event`, and the thread loop
are unchanged. The lock only serializes the one-time initialization, not steady-
state event pushing (`queue.Queue` is already thread-safe).
