### PR TITLE
fix(py): make initiate() deprecation warn-once guard thread-safe

### DIFF
--- a/python/composio/core/models/connected_accounts.py
+++ b/python/composio/core/models/connected_accounts.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import functools
 import logging
+import threading
 import time
 import typing as t
 import warnings
@@ -32,8 +33,10 @@ _TERMINAL_CONNECTION_STATES: t.FrozenSet[str] = frozenset(
 )
 
 # One-time-per-process guard so long-running services don't spam the deprecation
-# warning on every initiate() call.
+# warning on every initiate() call. The lock makes the check-then-set atomic so
+# concurrent first calls emit the warning exactly once.
 _legacy_initiate_warning_emitted = False
+_legacy_initiate_warning_lock = threading.Lock()
 
 
 class ConnectionRequest(Resource):
@@ -598,10 +601,18 @@ class ConnectedAccounts:
         # retiring path. Header presence is a 1:1 signal — custom auth
         # configs and non-OAuth schemes get a clean response and stay silent,
         # fixing the false-positive that auth_scheme-based detection
-        # produced.
+        # produced. The check-then-set runs under a lock so concurrent first
+        # calls that both see the header still warn exactly once; warn()
+        # itself runs outside the lock to avoid holding it across arbitrary
+        # user warning handlers.
         global _legacy_initiate_warning_emitted
-        if not _legacy_initiate_warning_emitted and deprecation_header:
-            _legacy_initiate_warning_emitted = True
+        should_warn = False
+        if deprecation_header:
+            with _legacy_initiate_warning_lock:
+                if not _legacy_initiate_warning_emitted:
+                    _legacy_initiate_warning_emitted = True
+                    should_warn = True
+        if should_warn:
             warnings.warn(
                 "composio.connected_accounts.initiate() will stop working "
                 "for this auth config on or before 2026-07-03 (see Sunset "

--- a/python/tests/test_connected_accounts.py
+++ b/python/tests/test_connected_accounts.py
@@ -1,4 +1,5 @@
 import logging
+import threading
 import time
 import warnings
 from unittest.mock import Mock, patch
@@ -854,3 +855,62 @@ class TestInitiateDeprecationHeaderGate:
 
         deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
         assert len(deprecations) == 1
+
+    def test_concurrent_first_calls_warn_once_without_error(self, mock_client):
+        """Pin the lock-guarded contract under concurrency: many first calls
+        that all see the Deprecation header must not error or deadlock, must
+        emit exactly one ``DeprecationWarning``, and must leave the one-time
+        guard set.
+
+        This exercises the fixed lock-guarded path. It does not on its own
+        reproduce the pre-fix check-then-set race: the racy window is only a
+        couple of bytecodes wide and never widened here, so the unguarded code
+        would usually also emit once. It is a fixed-behavior contract test, not
+        a standalone red/green regression guard for the race.
+
+        Count real ``warnings.warn`` calls through a thread-safe counter rather
+        than ``catch_warnings``, whose recording is not thread-safe.
+        """
+        import composio.core.models.connected_accounts as ca_mod
+
+        self._no_existing_accounts(mock_client)
+        _set_initiate_response(
+            mock_client,
+            self._make_response(),
+            headers={"Deprecation": "@1776988800"},
+        )
+        connected_accounts = ConnectedAccounts(client=mock_client)
+
+        deprecation_calls = 0
+        count_lock = threading.Lock()
+        real_warn = warnings.warn
+
+        def counting_warn(message, category=UserWarning, *args, **kwargs):
+            nonlocal deprecation_calls
+            if isinstance(category, type) and issubclass(category, DeprecationWarning):
+                with count_lock:
+                    deprecation_calls += 1
+                return
+            return real_warn(message, category, *args, **kwargs)
+
+        num_threads = 16
+        start = threading.Barrier(num_threads)
+        errors: list[BaseException] = []
+
+        def worker():
+            try:
+                start.wait()
+                connected_accounts.initiate(user_id="user-1", auth_config_id="auth-1")
+            except BaseException as exc:  # noqa: BLE001 - surface to the assertion
+                errors.append(exc)
+
+        with patch.object(warnings, "warn", counting_warn):
+            threads = [threading.Thread(target=worker) for _ in range(num_threads)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+
+        assert errors == []
+        assert deprecation_calls == 1
+        assert ca_mod._legacy_initiate_warning_emitted is True


### PR DESCRIPTION


`ConnectedAccounts.initiate()` emits a one-time-per-process `DeprecationWarning`
when the response carries a `Deprecation`/`Sunset` header (the legacy retiring
path). The "warn once" behaviour is gated on the module global
`_legacy_initiate_warning_emitted` with a non-atomic check-then-set:

```python
global _legacy_initiate_warning_emitted
if not _legacy_initiate_warning_emitted and deprecation_header:
    _legacy_initiate_warning_emitted = True
    warnings.warn(...)
```

Under concurrent first calls that all see the header, more than one thread can
pass the `not _legacy_initiate_warning_emitted` check before any thread flips the
flag, so the warning fires more than once instead of exactly once. The impact is
cosmetic (duplicate deprecation output, no state corruption), but the guard's
whole purpose is to warn exactly once, which it does not reliably do in
multi-threaded use.

There is no related open issue; this is a self-identified SDK fix.

## Changes

- `python/composio/core/models/connected_accounts.py`: add a module-level
  `threading.Lock` (`_legacy_initiate_warning_lock`) and perform the
  check-then-set inside it, so the flag flips exactly once. `warnings.warn()` is
  called outside the lock so it is never held across an arbitrary user warning
  filter/handler. The lock is only acquired on the deprecation path (when
  `deprecation_header` is truthy), so the common non-deprecated call is unchanged.
- `python/tests/test_connected_accounts.py`: add
  `test_concurrent_first_calls_warn_once_without_error` to the existing
  `TestInitiateDeprecationHeaderGate` class. It drives `initiate()` from 16
  concurrent first calls that all see the header and asserts the fixed contract:
  no exception or deadlock, exactly one `DeprecationWarning` (counted through a
  thread-safe counter, because `warnings.catch_warnings` recording is not
  thread-safe), and the guard left set.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [ ] Documentation
- [ ] Breaking change

## How Has This Been Tested?

From `python/` (Python 3.11, repo `.venv`):

- `ruff check --config config/ruff.toml composio/core/models/connected_accounts.py tests/test_connected_accounts.py` -> all checks passed
- `ruff format --check --config config/ruff.toml <same files>` -> already formatted
- `mypy --config-file config/mypy.ini composio/core/models/connected_accounts.py` -> success, no issues
- `python -m pytest tests/test_connected_accounts.py -q` -> 51 passed

The new test is deterministic and green on the fix. Note (called out honestly in
the commit body too): it exercises the lock-guarded path and pins the fixed
behaviour rather than acting as a red/green race reproduction. The racy window is
only a couple of bytecodes wide and cannot be triggered deterministically from a
black-box test without artificially widening it in production code, so I did not
add a flaky or production-instrumenting reproduction. The docstring states this
plainly.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed
- [ ] I updated documentation as needed (no docs affected)
- [x] I added tests or explain why not applicable
- [ ] I added a changeset if this change affects published packages (N/A: Python-only, no published TS package changed)

## Additional context

`warnings.warn()` is intentionally kept outside the lock: holding a process-wide
lock while calling into user-registered warning filters/handlers could let user
code deadlock or serialize unexpectedly. Splitting into a `should_warn` flag set
inside the lock and the `warnings.warn()` call outside keeps the critical section
to just the flag flip.
