### PR TITLE
docs: add missing langchain to the LangGraph Python install command

### DIFF
--- a/docs/content/docs/providers/langchain.mdx
+++ b/docs/content/docs/providers/langchain.mdx
@@ -132,7 +132,7 @@ The LangGraph provider transforms Composio tools into the same LangChain `Dynami
 <Step>
 **Install**
 
-<PackageInstall ecosystem="python" packages="composio composio_langgraph langgraph langchain_openai" />
+<PackageInstall ecosystem="python" packages="composio composio_langgraph langgraph langchain langchain_openai" />
 </Step>
 
 <Step>


### PR DESCRIPTION
## Summary
The LangGraph Python example imports from langchain.agents import create_agent, but the install command on the same page doesn't include langchain — and neither langgraph nor langchain_openai pulls it in (they only depend on langchain-core). Following the docs verbatim in a fresh environment fails on the example's first import with ModuleNotFoundError: No module named 'langchain'.

Fixes #3847 

## Changes
- docs/content/docs/providers/langchain.mdx: LangGraph Python install line gains langchain, matching the provider's own README (python/providers/langgraph/README.md).

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [x] Documentation
- [ ] Breaking change

## How Has This Been Tested?
- Fresh venv with the documented install set (langgraph==1.2.9, langchain-openai==1.3.5, Python 3.12): from langchain.agents import create_agent fails with ModuleNotFoundError.
- Same venv after adding langchain: the docs example constructs the agent via create_agent and the wrapped tool invokes correctly, with no deprecation warnings.
- Docs: bun run build and bun run lint:links from docs/: green.


## Screenshots (if applicable)

## Checklist
- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed
- [x] I updated documentation as needed
- [ ] I added tests or explain why not applicable
- [x] I added a changeset if this change affects published packages

## Additional context
No changeset: docs-only. No tests: one-word install-command fix, verified manually as above.