### PR TITLE
fix(release): drop stale changeset for ignored `@composio/cli`

### DIFF
--- a/.changeset/cli-file-upload-denylist.md
+++ b/.changeset/cli-file-upload-denylist.md
@@ -1,7 +1,0 @@
----
-'@composio/cli': patch
----
-
-Security: the CLI's tool file-upload path now enforces the sensitive-file denylist (issue #3746 / GHSA-hp3h-89pf-5q58). Previously `composio execute`/`composio run` read and uploaded any local path a tool argument pointed at — including `~/.ssh/id_rsa`, `~/.aws/credentials`, and `.env` files — enabling credential exfiltration in agentic workflows via prompt injection. The CLI now calls the shared `assertSafeFileUploadPath` guard from `@composio/core` at the lowest-level file read. URLs and `File` objects are unaffected.
-
-Unlike the core and Python SDKs (which expose a `sensitiveFileUploadProtection` / `sensitive_file_upload_protection` opt-out), the CLI enforces the denylist **unconditionally by design** — the primary attack vector is an agent prompt-injected into supplying its own tool arguments, so a CLI override flag would hand that attacker a trivial bypass. The block error carries CLI-appropriate remediation guidance instead of pointing at the SDK-only flag.

--- a/ts/packages/cli/CHANGELOG.md
+++ b/ts/packages/cli/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 0.3.0
 
+### Security
+
+- fc17c37: Security: the CLI's tool file-upload path now enforces the sensitive-file denylist (issue #3746 / GHSA-hp3h-89pf-5q58). Previously `composio execute`/`composio run` read and uploaded any local path a tool argument pointed at — including `~/.ssh/id_rsa`, `~/.aws/credentials`, and `.env` files — enabling credential exfiltration in agentic workflows via prompt injection. The CLI now calls the shared `assertSafeFileUploadPath` guard from `@composio/core` at the lowest-level file read. URLs and `File` objects are unaffected.
+
+  Unlike the core and Python SDKs (which expose a `sensitiveFileUploadProtection` / `sensitive_file_upload_protection` opt-out), the CLI enforces the denylist **unconditionally by design** — the primary attack vector is an agent prompt-injected into supplying its own tool arguments, so a CLI override flag would hand that attacker a trivial bypass. The block error carries CLI-appropriate remediation guidance instead of pointing at the SDK-only flag.
+
 ### Minor Changes
 
 - a0bef5d: Bump `@composio/client` to `0.1.0-alpha.74`.


### PR DESCRIPTION
This PR:

- unblocks #3820 — the `0.14.0` release train (including `@composio/experimental@0.2.0` with the `./eve` export) is versioned on `next` but was never published to npm
- deletes `.changeset/cli-file-upload-denylist.md`: it targets `@composio/cli`, which is in the changesets `ignore` list (since #3676), so `changeset version` never consumes it
- the leftover changeset makes `changesets/action` pick version-PR mode over publish mode on every push to `next`, then fail with `No commits between next and changeset-release/next` because the versioning no-ops — see the [failed run](https://github.com/ComposioHQ/composio/actions/runs/29449907252/job/87469539026); the publish step never executes
- ports the security note from the deleted changeset into the `0.3.0` section of `ts/packages/cli/CHANGELOG.md` — the fix commit (fc17c37bf, #3763) is part of the `0.3.0` tree, and `@composio/cli@0.3.0` has no tag/release yet

## Context

Once this merges, the next `TS SDK Release` run on `next` will find no pending changesets, take the publish path (`pnpm changeset:release`), and push the pending versions to npm.

Follow-up worth considering (not in this PR): a CI check that rejects changesets referencing packages in the `ignore` list, since any such changeset permanently wedges the release train.