### PR TITLE
fix: normalize file extension case in guess() MIME lookup

### DIFF
--- a/python/composio/utils/mimetypes.py
+++ b/python/composio/utils/mimetypes.py
@@ -507,7 +507,7 @@ _types = {
 
 
 def guess(file: t.Union[str, Path]) -> str:
-    return _types.get(Path(file).suffix, _default)
+    return _types.get(Path(file).suffix.lower(), _default)
 
 
 # MIME type -> extension (no leading dot). Used when deriving filenames from

--- a/python/tests/test_mimetypes.py
+++ b/python/tests/test_mimetypes.py
@@ -33,9 +33,11 @@ class TestGuess:
         """A known extension resolves to its MIME type."""
         assert guess(filename) == expected
 
-    def test_extension_lookup_is_case_sensitive(self) -> None:
-        """The extension table is lower-case, so an upper-case suffix misses."""
-        assert guess("photo.PNG") == _default
+    def test_extension_lookup_is_case_insensitive(self) -> None:
+        """Uppercase extensions resolve the same as lowercase."""
+        assert guess("photo.PNG") == "image/png"
+        assert guess("report.PDF") == "application/pdf"
+        assert guess("style.CSS") == "text/css"
 
     def test_unknown_extension_returns_default(self) -> None:
         assert guess("file.unknownext") == _default


### PR DESCRIPTION
## Summary

`composio/utils/mimetypes.py` has two functions that together form the file/MIME utility, but they disagree on case handling.

`get_extension_from_mime_type()` is deliberately case-insensitive — it lowercases its input. However `guess()` looks up `Path(file).suffix` against the lowercase `_types` table without normalizing case, so uppercase suffixes miss the table:

```python
guess("photo.PNG")   # -> "application/octet-stream", not "image/png"
guess("report.PDF")  # -> "application/octet-stream", not "application/pdf"
```

## Fix

Added `.lower()` to the suffix lookup in `guess()`, one-line change:

```python
return _types.get(Path(file).suffix.lower(), _default)
```

Updated the existing test `test_extension_lookup_is_case_sensitive` → `test_extension_lookup_is_case_insensitive` to assert that uppercase extensions resolve correctly.

Closes #3857