### PR TITLE
docs(auth): OAuth callback identity verification

### DIFF
--- a/docs/content/changelog/07-17-26-oauth-callback-identity-verification.mdx
+++ b/docs/content/changelog/07-17-26-oauth-callback-identity-verification.mdx
@@ -1,0 +1,60 @@
+---
+title: 'OAuth callback identity verification'
+description: 'Opt-in per-project verification that confirms which user an OAuth connection belongs to before it activates. Off by default; existing connections are unaffected.'
+date: '2026-07-17'
+---
+
+OAuth callback identity verification lets your own server confirm which user a returning OAuth flow belongs to before Composio activates the connected account. It is opt-in per project and off by default, so existing projects and connections keep working unchanged.
+
+### Why it exists
+
+An OAuth callback carries an authorization code back to Composio, but the callback itself does not prove which of your users is completing it. When verification is enabled, Composio pauses activation and hands the flow to your server, which asserts the user from its own authenticated session. The connection activates only when that assertion matches the user it was initiated for.
+
+### How it works
+
+1. A user starts an OAuth connection as usual, initiated with your `user_id`.
+2. After the provider redirects back, Composio redirects the user's browser to your verifier URL with a single-use `session_uri` and nothing else.
+3. Your server identifies the signed-in user and calls `POST /api/v3.1/connected_accounts/complete_auth` with the `session_uri` and that `user_id`.
+4. Composio confirms the `user_id` matches the connection owner, completes the token exchange, and returns the now-active connected account.
+
+### Completing a verification
+
+```bash
+curl -X POST "https://backend.composio.dev/api/v3.1/connected_accounts/complete_auth" \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "session_uri": "session_xxx",
+    "user_id": "user_123"
+  }'
+```
+
+**Response:**
+
+```json
+{
+  "connected_account": {
+    "id": "ca_your-connected-account-id",
+    "user_id": "user_123",
+    "status": "ACTIVE",
+    "toolkit": { "slug": "github" },
+    "auth_config": {
+      "id": "ac_your-auth-config-id",
+      "auth_scheme": "OAUTH2",
+      "is_composio_managed": true
+    }
+  }
+}
+```
+
+The `session_uri` is single-use. A request whose `user_id` does not match the connection owner is rejected with a `400`, and an unknown, expired, or already-consumed session returns a `404`.
+
+### Enabling
+
+Verification is configured per project and is off by default. Once enabled for a project, connections must be initiated with a real `user_id` — a connection started for the default user cannot be verified.
+
+<Callout type="info">
+No action is required for existing projects. Verification applies only after you enable it, and connections initiated without it continue to activate as before.
+</Callout>
+
+See the [OAuth callback identity verification guide](/docs/oauth-callback-identity-verification) for the full flow and setup.

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -21,6 +21,7 @@
     "programmatic-auth-configs",
     "controlling-scopes",
     "white-labeling-authentication",
+    "oauth-callback-identity-verification",
     "---Triggers---",
     "triggers",
     "setting-up-triggers/creating-triggers",

--- a/docs/content/docs/oauth-callback-identity-verification.mdx
+++ b/docs/content/docs/oauth-callback-identity-verification.mdx
@@ -1,0 +1,86 @@
+---
+title: OAuth callback identity verification
+description: Confirm which user an OAuth connection belongs to before it activates
+keywords: [oauth, callback, identity verification, connection security, user_id]
+---
+
+OAuth callback identity verification is an opt-in, per-project control that adds a check between the OAuth provider's redirect and the activation of a connected account. Before Composio finalizes the connection, your own server confirms which of your users is completing the flow.
+
+It is off by default. Existing projects and connections are unaffected until you enable it.
+
+## Why you might want it
+
+When a user authorizes a toolkit, the OAuth provider redirects back to Composio with an authorization code. That code proves the user approved access, but it does not prove *which* of your users is holding the browser at that moment. If a callback is intercepted or replayed, a connection could be bound to the wrong user.
+
+Identity verification closes that gap. Composio pauses activation and asks your server — which already knows who is signed in — to assert the user. The connection activates only when your assertion matches the user the connection was initiated for.
+
+## How it works
+
+1. A user starts an OAuth connection as usual, initiated with your `user_id`.
+2. The user authorizes with the provider, which redirects back to Composio.
+3. Instead of activating the connection, Composio redirects the user's browser to your verifier URL with a single-use `session_uri` query parameter — and no other identifiers.
+4. Your server identifies the signed-in user, then calls `POST /api/v3.1/connected_accounts/complete_auth` with the `session_uri` and that user's `user_id`.
+5. Composio confirms the `user_id` matches the connection owner, completes the token exchange, and returns the now-active connected account.
+
+The `session_uri` deliberately carries no user or connection identifier. Your server is expected to derive the user from its own authenticated session — that independent assertion is the verification.
+
+## Enabling verification
+
+Verification is configured per project and is off by default. Enabling it sets a verifier URL for the project: the page Composio redirects users to after the provider returns.
+
+Once verification is enabled for a project, connections must be initiated with a real `user_id`. A connection started for the default user cannot be verified and is rejected at initiation, because there is no specific identity to confirm.
+
+<Callout type="info">
+Enabling verification does not change how connections are initiated — only how they are completed. Connections created before you enabled it, and any created while it is off, continue to activate directly.
+</Callout>
+
+## Completing a verification
+
+When your verifier URL receives a request with a `session_uri`, identify the signed-in user and call `complete_auth` from your server with your project API key.
+
+```bash
+curl -X POST "https://backend.composio.dev/api/v3.1/connected_accounts/complete_auth" \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "session_uri": "session_xxx",
+    "user_id": "user_123"
+  }'
+```
+
+**Response:**
+
+```json
+{
+  "connected_account": {
+    "id": "ca_your-connected-account-id",
+    "user_id": "user_123",
+    "status": "ACTIVE",
+    "toolkit": { "slug": "github" },
+    "auth_config": {
+      "id": "ac_your-auth-config-id",
+      "auth_scheme": "OAUTH2",
+      "is_composio_managed": true
+    }
+  }
+}
+```
+
+The response is the full connected account, now `ACTIVE`.
+
+### Responses to handle
+
+- **`400`** — the `user_id` does not match the user the connection was initiated for. The connection stays inactive.
+- **`404`** — the `session_uri` is unknown, expired, or already used. Sessions are single-use and short-lived, so a retried or shared link resolves here; the user restarts the connection.
+- **`200`** — verification succeeded and the connection is active.
+
+## Identifying the user at your verifier
+
+Because Composio passes only the `session_uri`, your verifier page must be able to identify the user itself. In practice this means the browser that completes the OAuth flow carries an authenticated session with your application, so your server can map the request to the correct `user_id`.
+
+Design your flow so the OAuth link is opened in a context your application can authenticate. If a user opens the link somewhere you cannot identify them, your server has no `user_id` to assert and the connection cannot be completed.
+
+## Next
+
+- [White-labeling authentication](/docs/white-labeling-authentication) — route the OAuth callback through your own domain and redirect users after authentication.
+- [Manually authenticating users](/docs/manually-authenticating) — initiate connections and check their status outside of chat.

--- a/docs/content/docs/white-labeling-authentication.mdx
+++ b/docs/content/docs/white-labeling-authentication.mdx
@@ -155,3 +155,5 @@ After authentication, Composio redirects the user to your callback URL instead o
 ## Next
 
 <Card icon={<Key />} title="Managed vs custom auth" href="/docs/custom-app-vs-managed-app" description="Set up auth configs for OAuth apps, API keys, and toolkits without managed auth" />
+
+<Card icon={<ShieldCheck />} title="OAuth callback identity verification" href="/docs/oauth-callback-identity-verification" description="Confirm which user an OAuth connection belongs to before it activates" />


### PR DESCRIPTION
## Summary

Documents **OAuth callback identity verification** — the opt-in, per-project verifier that confirms which user an OAuth connection belongs to before it activates (source: platform PR ComposioHQ/platform#11189).

- **Changelog** `content/changelog/07-17-26-oauth-callback-identity-verification.mdx` — why it exists, the flow, a cURL example for `complete_auth`, and an opt-in / no-action-required callout. Modeled on `02-06-26-webhook-subscriptions-api` (new capability + public endpoint) and `04-09-26-multi-account-aliases` (opt-in phrasing).
- **Guide** `content/docs/oauth-callback-identity-verification.mdx` — full flow, the security rationale, how to complete a verification, response handling, and the operational requirement that the completing browser be authenticated by your app so you can assert the right `user_id`. Filed under "Customizing auth", after `white-labeling-authentication`.
- **Nav** — registered in `content/docs/meta.json`.
- **Companion** — cross-link Card added to `white-labeling-authentication.mdx` (the page where callback routing is configured).

Every code reference is verified against platform source: `complete_auth` is `POST /api/v3.1/connected_accounts/complete_auth`, public (`API_DOCS` + `SDK`, project API key), request `{ session_uri, user_id }`, and the response is the standard connected-account object.

## Hold before merge — this is a draft

- **The feature is not GA.** Source PR #11189 is not merged; do not publish until it ships.
- **Ship date is a placeholder.** Filename `07-17-26` / frontmatter `2026-07-17` must be reset to the real ship date at merge.
- **Enabling is not a public API.** `oauthCallbackVerifierUrl` is set only via a dashboard-internal route (cloud, admin role) or a self-hosted cookie route — there is no project-API-key way to turn it on, and no SDK method. The docs therefore describe enabling as a per-project setting, not an API call. **Confirm the exact enable UX (dashboard control) before GA** — that's the one part written at concept altitude rather than click-level.
- **`complete_auth` is not yet in the generated API reference**, so it's documented inline with cURL (no `/reference/...` link, which would fail link validation). Add the API-ref link once the OpenAPI spec regenerates post-merge.

## Validation

Ran the docs CI equivalents locally from `docs/`: `lint:links` (0 errors), static tests (33 pass / 0 fail), `types:check` (frontmatter schema + `tsc` clean). Production `build` not run locally (no `ts` code blocks in these files, so Twoslash has nothing to check); CI runs the full build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
