### PR TITLE
chore(cli): land Effect-first guidelines and inert guardrail rule groups

### DIFF
--- a/.agents/skills/cli-command/references/implementation.md
+++ b/.agents/skills/cli-command/references/implementation.md
@@ -25,6 +25,18 @@ export const myCmd = Command.make('my-command', {}, () =>
 
 Follow existing local patterns before introducing new service abstractions.
 
+## Effect Platform Boundaries
+
+`node:path`, `node:fs`, `node:os`, `node:child_process`, `process.env`, and `try`/`catch` are banned policy for new code in `src/` (ESLint rule groups are defined in the root `eslint.config.mjs` and activated group-by-group over the guardrails PR stack):
+
+- Path arithmetic → `Path` service from `@effect/platform` (`const path = yield* Path.Path`).
+- Filesystem I/O → `FileSystem` service from `@effect/platform`.
+- homedir/tmpdir/platform/arch → the `NodeOs` service; subprocesses → platform `Command`.
+- Environment reads → `effect/Config`; sync fallible ops (`JSON.parse`, `new URL`) → `Either.try` with a `Data.TaggedError`.
+- Helpers that cannot become Effects (sync callbacks, promise pipelines) take the resolved service instance as a plain parameter instead of importing Node builtins.
+
+Never add an `eslint-disable` for these rules in new code — thread the service instead. Full policy: `ts/packages/cli/AGENTS.md`.
+
 ## Required Checks
 
 For CLI source changes, run from the repo root:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,10 +1,123 @@
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
+const portableRestrictedImportPaths = [
+  {
+    name: 'crypto',
+    message: 'Use Web Crypto API instead.',
+  },
+  {
+    name: 'node:crypto',
+    message: 'Use Web Crypto API instead.',
+  },
+  {
+    name: 'buffer',
+    message: 'Use Uint8Array instead.',
+  },
+  {
+    name: 'node:buffer',
+    message: 'Use Uint8Array instead.',
+  },
+];
+
+const cliRestrictedSyntax = [
+  {
+    selector: 'TryStatement',
+    message:
+      'Use Effect.try, Effect.tryPromise, or typed Effect error recovery instead of try/catch.',
+  },
+  {
+    selector: "MemberExpression[object.name='process'][property.name='env']",
+    message: 'Read environment variables through effect/Config instead of process.env.',
+  },
+];
+
+const cliProcessStreamRestrictions = [
+  {
+    selector: "MemberExpression[object.name='process'][property.name='stdout']",
+    message: 'Write output and read terminal capabilities through TerminalUI.',
+  },
+  {
+    selector: "MemberExpression[object.name='process'][property.name='stderr']",
+    message: 'Write errors and read terminal capabilities through TerminalUI.',
+  },
+];
+
+const cliRestrictedImportPaths = [
+  ...portableRestrictedImportPaths,
+  {
+    name: 'child_process',
+    message: 'Use Command from @effect/platform instead.',
+  },
+  {
+    name: 'node:child_process',
+    message: 'Use Command from @effect/platform instead.',
+  },
+  {
+    name: 'node:fs',
+    message: 'Use FileSystem from @effect/platform instead.',
+  },
+  {
+    name: 'node:os',
+    message: 'Use an Effect service instead of importing node:os directly.',
+  },
+  {
+    name: 'node:path',
+    message: 'Use Path from @effect/platform instead.',
+  },
+];
+
+const cliRestrictedImportPatterns = [
+  {
+    group: ['node:fs/*'],
+    message: 'Use FileSystem from @effect/platform instead.',
+  },
+];
+
+const cliDescriptorSeamMessage =
+  'CommandDescriptor/Usage introspection is the @effect/cli v4 seam. Use the helpers in ts/packages/cli/src/commands/command-introspection.ts instead.';
+
+const cliDescriptorSeamRestrictedImportPaths = [
+  {
+    name: '@effect/cli',
+    importNames: ['CommandDescriptor', 'Usage'],
+    message: cliDescriptorSeamMessage,
+  },
+];
+
+const cliDescriptorSeamRestrictedImportPatterns = [
+  {
+    group: ['@effect/cli/CommandDescriptor', '@effect/cli/Usage'],
+    message: cliDescriptorSeamMessage,
+  },
+];
+
+const effectSchemaRestrictedImportPaths = [
+  {
+    name: 'zod',
+    message: 'Use Schema from effect for tool input validation.',
+  },
+];
+
+const effectSchemaRestrictedImportPatterns = [
+  {
+    group: ['zod/*'],
+    message: 'Use Schema from effect for tool input validation.',
+  },
+];
+
 /** @type {import('eslint').Linter.Config[]} */
 export default [
   {
     ignores: [
+      '**/.venv/**',
+      '**/.next/**',
+      '**/site-packages/**',
+      '**/__fixtures__/**',
+      '**/fixtures/**',
+      'docs/.source/**',
+      'ts/vendor/**',
+      'ts/packages/cli-local-tools/vendor/**',
       'ts/packages/**/dist/**',
       'ts/packages/**/.generated/**',
       'ts/packages/**/acp-adapters/**',
@@ -14,6 +127,13 @@ export default [
       'ts/examples/**/dist-worker/**',
       'scripts/**',
       '**/test/**',
+      // uncommented by the test-rules PR of this stack: the CLI test sources
+      // become linted (unlike other packages' tests) so the @effect/vitest
+      // guardrail below is actually enforced. Fixtures and the test/__utils__
+      // harness glue stay unlinted.
+      // '!ts/packages/cli/test/**',
+      // 'ts/packages/cli/test/__fixtures__/**',
+      // 'ts/packages/cli/test/__utils__/**',
     ],
   },
   { files: ['ts/packages/**/*.ts', 'ts/examples/**/*.ts'] },
@@ -23,26 +143,7 @@ export default [
     rules: {
       // "@typescript-eslint/no-var-requires": "off",
       'no-restricted-globals': ['error', 'Buffer'],
-      "no-restricted-imports": ["error", {
-        "paths": [
-          {
-            "name": "crypto",
-            "message": "Use Web Crypto API instead.",
-          },
-          {
-            "name": "node:crypto",
-            "message": "Use Web Crypto API instead.",
-          },
-          {
-            "name": "buffer",
-            "message": "Use Uint8Array instead.",
-          },
-          {
-            "name": "node:buffer",
-            "message": "Use Uint8Array instead.",
-          },
-        ],
-      }],
+      'no-restricted-imports': ['error', { paths: portableRestrictedImportPaths }],
       '@typescript-eslint/no-require-imports': 'warn',
       '@typescript-eslint/no-unsafe-function-type': 'off',
       'no-prototype-builtins': 'off',
@@ -70,6 +171,87 @@ export default [
       ],
     },
   },
+  {
+    files: ['ts/packages/cli/src/**/*.{ts,tsx}'],
+    rules: {
+      // uncommented by the platform-imports PR of this stack (the
+      // CommandDescriptor/Usage seam entries by the seam-rules PR).
+      // 'no-restricted-imports': [
+      //   'error',
+      //   {
+      //     paths: [...cliRestrictedImportPaths, ...cliDescriptorSeamRestrictedImportPaths],
+      //     patterns: [...cliRestrictedImportPatterns, ...cliDescriptorSeamRestrictedImportPatterns],
+      //   },
+      // ],
+      // uncommented by the terminal-streams PR of this stack (the try/catch and
+      // process.env entries by the boundary-ratchet PR).
+      // 'no-restricted-syntax': ['error', ...cliRestrictedSyntax, ...cliProcessStreamRestrictions],
+    },
+  },
+  // uncommented by the test-rules PR of this stack.
+  // {
+  //   // Tests exercise Effects through @effect/vitest (it.effect, it.scoped,
+  //   // it.live) so failures surface as typed Exits instead of thrown
+  //   // FiberFailures. The test/__utils__ harness glue (vitest setup files,
+  //   // TestLayer runner) is intentionally outside this glob: it is the one
+  //   // boundary allowed to run Effects directly.
+  //   files: ['ts/packages/cli/test/src/**/*.{ts,tsx}'],
+  //   rules: {
+  //     // Vitest suites are one long describe() block by design, and mock
+  //     // plumbing casts freely; the SUT's own types carry the safety.
+  //     'max-lines-per-function': 'off',
+  //     '@typescript-eslint/no-explicit-any': 'off',
+  //     'no-restricted-syntax': [
+  //       'error',
+  //       {
+  //         selector: "MemberExpression[object.name='Effect'][property.name=/^run/]",
+  //         message:
+  //           'Run Effects through @effect/vitest (it.effect, it.scoped, it.live) instead of Effect.run* in tests.',
+  //       },
+  //       {
+  //         selector: "CallExpression[callee.object.name='Date'][callee.property.name='now']",
+  //         message:
+  //           'Tests must be deterministic: pin time with vi.setSystemTime / TestClock-relative fixtures, use crypto.randomUUID() for unique names.',
+  //       },
+  //     ],
+  //   },
+  // },
+  // uncommented by the seam-rules PR of this stack.
+  // {
+  //   // The one file allowed to touch @effect/cli's CommandDescriptor/Usage
+  //   // modules (the Effect CLI v4 redesign seam).
+  //   files: ['ts/packages/cli/src/commands/command-introspection.ts'],
+  //   rules: {
+  //     'no-restricted-imports': [
+  //       'error',
+  //       {
+  //         paths: cliRestrictedImportPaths,
+  //         patterns: cliRestrictedImportPatterns,
+  //       },
+  //     ],
+  //   },
+  // },
+  // uncommented by the seam-rules PR of this stack.
+  // {
+  //   files: ['ts/packages/cli/src/services/tool-input-validation.ts'],
+  //   rules: {
+  //     'no-restricted-imports': [
+  //       'error',
+  //       {
+  //         paths: [...cliRestrictedImportPaths, ...effectSchemaRestrictedImportPaths],
+  //         patterns: [...cliRestrictedImportPatterns, ...effectSchemaRestrictedImportPatterns],
+  //       },
+  //     ],
+  //   },
+  // },
+  // uncommented by the terminal-streams PR of this stack.
+  // {
+  //   files: ['ts/packages/cli/src/services/terminal-ui.ts'],
+  //   rules: {
+  //     // TerminalUI is the sole CLI boundary for Node's stdout and stderr streams.
+  //     'no-restricted-syntax': ['error', ...cliRestrictedSyntax],
+  //   },
+  // },
   {
     // Examples are console-driven references. Keep type-safety rules
     // (no-explicit-any, unused-vars) but drop console noise. The Buffer/crypto

--- a/ts/packages/cli/AGENTS.md
+++ b/ts/packages/cli/AGENTS.md
@@ -27,34 +27,34 @@ Errors are captured via the custom `effect-errors/` module (source-mapped stack 
 
 Each command uses `@effect/cli`'s `Command.make()` pattern. Top-level command files end in `.cmd.ts`; nested command groups live in their own subdirectory with a `<group>.cmd.ts` entry. Current top-level commands:
 
-| Group / Command      | Purpose                                                                                                              |
+| Group / Command | Purpose |
 | -------------------- | -------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
-| `version`            | Display CLI version                                                                                                  |
-| `whoami`             | Show logged-in user info (writes raw API key to stdout when piped — see Output Conventions)                          |
-| `login`              | Login with browser redirect or direct user/API key (`--no-browser`, `--no-wait`, `--key`, `--user-api-key`, `--org`) |
-| `logout`             | Clear stored API key                                                                                                 |
-| `signup`             | Create a Composio account                                                                                            |
-| `upgrade`            | Self-update binary from GitHub releases                                                                              |
-| `init`               | Bootstrap a Composio project in the current directory                                                                |
-| `install`            | Install local-tool integrations                                                                                      |
-| `generate {ts        | py}`                                                                                                                 | Generate type stubs (auto-detects project language if no subcommand) |
-| `agent`              | Manage AI agent presets                                                                                              |
-| `toolkits`           | List / inspect / version toolkits                                                                                    |
-| `tools`              | List / inspect / `execute` tools                                                                                     |
-| `triggers`           | List / manage trigger types                                                                                          |
-| `auth-configs`       | Manage auth-config resources (`ac_*`)                                                                                |
-| `connected-accounts` | Manage connected accounts (`ca_*`)                                                                                   |
-| `connections`        | Alias / helper for connected-account flows                                                                           |
-| `orgs`               | Manage organizations                                                                                                 |
-| `projects`           | Manage projects                                                                                                      |
-| `local-tools`        | Manage local toolkits (via `@composio/cli-local-tools`)                                                              |
-| `logs`               | View tool-execution logs (`logs-cmd/`)                                                                               |
-| `config`             | Read/write CLI config                                                                                                |
-| `listen`             | Listen for events                                                                                                    |
-| `proxy`              | Proxy authenticated API requests                                                                                     |
-| `run`                | Run a saved script / preset                                                                                          |
-| `dev`                | Developer-only utilities                                                                                             |
-| `artifacts`          | Manage generated artifacts                                                                                           |
+| `version` | Display CLI version |
+| `whoami` | Show logged-in user info (writes raw API key to stdout when piped — see Output Conventions) |
+| `login` | Login with browser redirect or direct user/API key (`--no-browser`, `--no-wait`, `--key`, `--user-api-key`, `--org`) |
+| `logout` | Clear stored API key |
+| `signup` | Create a Composio account |
+| `upgrade` | Self-update binary from GitHub releases |
+| `init` | Bootstrap a Composio project in the current directory |
+| `install` | Install local-tool integrations |
+| `generate {ts        | py}` | Generate type stubs (auto-detects project language if no subcommand) |
+| `agent` | Manage AI agent presets |
+| `toolkits` | List / inspect / version toolkits |
+| `tools` | List / inspect / `execute` tools |
+| `triggers` | List / manage trigger types |
+| `auth-configs` | Manage auth-config resources (`ac_*`) |
+| `connected-accounts` | Manage connected accounts (`ca_*`) |
+| `connections` | Alias / helper for connected-account flows |
+| `orgs` | Manage organizations |
+| `projects` | Manage projects |
+| `local-tools` | Manage local toolkits (via `@composio/cli-local-tools`) |
+| `logs` | View tool-execution logs (`logs-cmd/`) |
+| `config` | Read/write CLI config |
+| `listen` | Listen for events |
+| `proxy` | Proxy authenticated API requests |
+| `run` | Run a saved script / preset |
+| `dev` | Developer-only utilities |
+| `artifacts` | Manage generated artifacts |
 
 Options use `Options.text()`, `Options.boolean()`, `Options.choice()`, `Options.directory()` with Effect Schema validation. Feature flags live in `feature-tags.ts` and `experimental-features.ts`.
 
@@ -135,6 +135,15 @@ Effect.gen(function* () {
 ```
 
 Key patterns: `Effect.all([...], { concurrency: 'unbounded' })` for parallel work, `Layer.provide()` for dependency composition, `Effect.mapError()` / `Effect.catchTag()` for typed errors, `Effect.scoped` for resource cleanup.
+
+### Effect safety and migration seams
+
+- Never branch on an Effect value's internal tag field directly. Use the owning module's public refinement or matcher (`Option`, `Either`, `Exit`, `Cause`, `ValidationError`), `Match.valueTags` for exhaustive unions, or `Predicate.isTagged` for a single narrowing guard.
+- Do not wrap a plain `Error` in `Effect.fail` for expected failures. Give the failure a meaningful `Data.TaggedError` type with structured fields and a preserved cause, then recover with `catchTag` / `catchTags`. Reserve `Effect.die` and `Effect.dieMessage` for impossible invariants.
+- Treat `unknown`, JSON, persisted state, and API payloads as trust boundaries. Decode them with `Schema` or narrow them with `Predicate`; an `as` assertion is not validation.
+- Do not inspect private `@effect/cli` descriptor shapes. Use public `CommandDescriptor` operations or keep declarative command metadata that can move to Effect v4's public command tree.
+- Prefer `Effect.mapError`, `Effect.matchEffect`, and typed recovery over `catchAll` blocks that flatten distinct failures into one message-only error.
+- Prefer Effect services over Node builtins for platform access in new code: `Path`/`FileSystem`/`Command` from `@effect/platform` instead of `node:path`/`node:fs`/`node:child_process`, and `effect/Config` instead of `process.env`. These rules are policy for new CLI code effective now; the matching ESLint rule groups are defined (commented out) in the root `eslint.config.mjs` and are activated group-by-group over the guardrails PR stack as existing code migrates.
 
 ## Vendor Reference Sources
 


### PR DESCRIPTION
This PR:
- opens the CLI Effect-guardrails stack that re-slices https://github.com/ComposioHQ/composio/pull/3859 into reviewable PRs
- rewrites the CLI `AGENTS.md` Effect guidance: typed `Data.TaggedError` failures, `Schema`/`Predicate` decoding at trust boundaries, and Effect platform services over Node builtins — policy for new code effective now
- adds the matching "Effect Platform Boundaries" section to the `cli-command` skill reference
- defines every new ESLint rule group (platform imports, terminal streams, descriptor seam, zod ban, test rules, try/catch + `process.env`) as live constants in the root `eslint.config.mjs`, with the entries applying them commented out and annotated with the stack PR that activates each group
- bumps the vendored `ts/vendor/effect` reference to the pin used across the stack (CI never initializes submodules)

No CLI source is touched; `pnpm lint` stays green with the rules inert.
---

**Stack** (re-slice of https://github.com/ComposioHQ/composio/pull/3859; each PR targets its parent and auto-retargets to `next` as parents merge):

1. https://github.com/ComposioHQ/composio/pull/3877 — guidelines + inert rule groups ← **this PR**
2. https://github.com/ComposioHQ/composio/pull/3878 — `new Function()` eval security fix
3. https://github.com/ComposioHQ/composio/pull/3879 — behavioral fix pack
4. https://github.com/ComposioHQ/composio/pull/3880 — platform-imports rule + migration
5. https://github.com/ComposioHQ/composio/pull/3881 — terminal-streams rule + TerminalUI boundary
6. https://github.com/ComposioHQ/composio/pull/3882 — descriptor seam + zod→Schema
7. https://github.com/ComposioHQ/composio/pull/3883 — test-tree lint + deterministic suites
8. https://github.com/ComposioHQ/composio/pull/3884 — typed error boundaries + v4 seams
9. https://github.com/ComposioHQ/composio/pull/3885 — try/catch+env ban + boundary ratchet

On stacked bases CI runs lint/build and the CLI Docker e2e job; unit tests and typecheck are verified locally per PR and re-verified by full CI when each PR is retargeted to `next`.