### PR TITLE
fix(cli): address bugbot review findings from the guardrails stack

### DIFF
--- a/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
+++ b/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
@@ -24,7 +24,7 @@ import {
   groupCachedConnectedAccountsByToolkit,
   resolveDefaultConnectedAccountsByToolkit,
 } from 'src/services/connected-account-selection';
-import { decodeConnectedAccountItemsWithFallback } from 'src/effects/decode-connected-account-list';
+import { decodeConnectedAccountItems } from 'src/effects/decode-connected-account-list';
 
 class ConnectionPollingError extends Data.TaggedError('commands/ConnectionPollingError')<{
   readonly message: string;
@@ -538,7 +538,7 @@ const handleListConnectedAccounts = (params: {
           }),
       })
     );
-    const connectedAccounts = yield* decodeConnectedAccountItemsWithFallback(accounts.items).pipe(
+    const connectedAccounts = yield* decodeConnectedAccountItems(accounts.items).pipe(
       Effect.mapError(
         cause =>
           new ConnectedAccountsDecodeError({

--- a/ts/packages/cli/src/commands/listen.cmd.ts
+++ b/ts/packages/cli/src/commands/listen.cmd.ts
@@ -23,7 +23,7 @@ import { parseJsonRecord } from 'src/utils/parse-json';
 import { toolkitFromToolSlug } from 'src/utils/toolkit-from-tool-slug';
 import { matchesTriggerListenFilters } from './triggers/filter';
 import { parseTriggerListenEvent } from './triggers/parse';
-import { decodeConnectedAccountItemsWithFallback } from 'src/effects/decode-connected-account-list';
+import { decodeConnectedAccountItems } from 'src/effects/decode-connected-account-list';
 
 type TriggerCreateParams = NonNullable<
   Parameters<RawComposioClient['triggerInstances']['upsert']>[1]
@@ -177,9 +177,7 @@ const resolveConnectedAccountIdForTrigger = (params: {
           cause,
         }),
     });
-    const selectableAccounts = yield* decodeConnectedAccountItemsWithFallback(
-      connectedAccounts.items
-    ).pipe(
+    const selectableAccounts = yield* decodeConnectedAccountItems(connectedAccounts.items).pipe(
       Effect.mapError(
         cause =>
           new ListenCommandError({

--- a/ts/packages/cli/src/commands/login.cmd.ts
+++ b/ts/packages/cli/src/commands/login.cmd.ts
@@ -94,7 +94,7 @@ type PendingLoginSession = Schema.Schema.Type<typeof PendingLoginSession>;
 
 class PendingLoginError extends Data.TaggedError('commands/PendingLoginError')<{
   readonly message: string;
-  readonly reason: 'invalid' | 'missing' | 'expired';
+  readonly reason: 'invalid' | 'io' | 'missing' | 'expired';
   readonly cause?: unknown;
 }> {}
 
@@ -151,8 +151,19 @@ const readPendingLoginSession = Effect.gen(function* () {
     });
   }
 
-  const session = yield* fs.readFileString(filePath, 'utf8').pipe(
-    Effect.flatMap(Schema.decodeUnknown(Schema.parseJson(PendingLoginSession))),
+  const rawSession = yield* fs.readFileString(filePath, 'utf8').pipe(
+    Effect.mapError(
+      cause =>
+        new PendingLoginError({
+          message: 'Failed to read pending login cache',
+          reason: 'io',
+          cause,
+        })
+    )
+  );
+  const session = yield* Schema.decodeUnknown(Schema.parseJson(PendingLoginSession))(
+    rawSession
+  ).pipe(
     Effect.mapError(
       cause =>
         new PendingLoginError({

--- a/ts/packages/cli/src/effects/decode-connected-account-list.ts
+++ b/ts/packages/cli/src/effects/decode-connected-account-list.ts
@@ -1,8 +1,7 @@
-import { Effect, Schema } from 'effect';
-import type { ParseResult } from 'effect';
+import { Effect, ParseResult, Schema } from 'effect';
 import {
   ConnectedAccountItems,
-  ConnectedAccountItemsPermissive,
+  isKnownConnectedAccountStatus,
 } from 'src/models/connected-accounts';
 import {
   ConnectedAccountListResponse,
@@ -11,16 +10,48 @@ import {
 import { TerminalUI } from 'src/services/terminal-ui';
 
 /**
+ * Renders a `ParseError` as `path: kind` pairs only — never the failing
+ * values. A container-level failure would otherwise echo the raw payload,
+ * which can include credential-bearing fields (`state`, `data`, ...) the
+ * connected-account schemas deliberately exclude.
+ */
+const formatParseErrorRedacted = (error: ParseResult.ParseError): string =>
+  ParseResult.ArrayFormatter.formatErrorSync(error)
+    .map(issue => `${issue.path.join('.') || '(root)'}: ${issue._tag}`)
+    .join(', ');
+
+/**
+ * Warns when the server returned `status` values newer than this CLI build's
+ * known set. Status values are non-credential by design, so printing them
+ * verbatim is safe — and exactly what the user needs to act on.
+ */
+const warnOnUnknownStatuses = (
+  items: ReadonlyArray<{ readonly status: string }>
+): Effect.Effect<void, never, TerminalUI> =>
+  Effect.gen(function* () {
+    const unknown = [
+      ...new Set(items.map(item => item.status).filter(s => !isKnownConnectedAccountStatus(s))),
+    ];
+    if (unknown.length === 0) return;
+    const ui = yield* TerminalUI;
+    yield* ui.log.warn(
+      `Server returned connected account status(es) this CLI does not ` +
+        `recognize: ${unknown.join(', ')}. Run "composio upgrade" to pick up ` +
+        `the latest CLI.`
+    );
+  });
+
+/**
  * Decodes a raw `client.connectedAccounts.list(...)` response against
  * `ConnectedAccountListResponse`, falling back to the raw payload on
  * `ParseError`.
  *
- * Forward-compat: a future Apollo status would otherwise brick the caller
- * via the closed `Schema.Literal(...)`. On decode failure we warn via
- * `ui.log.warn` (pointing the user at `composio upgrade`) and return the
- * unvalidated raw response — safe because the three current call sites
- * only render non-credential fields (`id`, `alias`, `word_id`,
- * `toolkit.slug`, `status`, ...).
+ * `status` is an open enum (`ConnectedAccountStatus`), so a status newer than
+ * this CLI build decodes fine and only triggers the "composio upgrade"
+ * warning. The raw fallback remains for other shape skew (pagination fields,
+ * renames, ...) — safe because the three current call sites only render
+ * non-credential fields (`id`, `alias`, `word_id`, `toolkit.slug`,
+ * `status`, ...).
  */
 export const decodeConnectedAccountListWithFallback = (
   rawResult: unknown
@@ -28,13 +59,14 @@ export const decodeConnectedAccountListWithFallback = (
   Effect.gen(function* () {
     const ui = yield* TerminalUI;
     return yield* Schema.decodeUnknown(ConnectedAccountListResponse)(rawResult).pipe(
+      Effect.tap(result => warnOnUnknownStatuses(result.items)),
       Effect.catchTag('ParseError', error =>
         Effect.gen(function* () {
           yield* ui.log.warn(
-            `Server returned a connection field this CLI does not recognize ` +
-              `(likely a newly-added status). Run "composio upgrade" to pick up ` +
-              `the latest schema. Continuing with raw response.\n\n` +
-              `Decode error: ${error.message}`
+            `Server response did not match the shape this CLI expects. Run ` +
+              `"composio upgrade" to pick up the latest CLI. Continuing with ` +
+              `raw response.\n\n` +
+              `Mismatched fields: ${formatParseErrorRedacted(error)}`
           );
           // Safe: callers only read non-credential fields.
           return rawResult as ConnectedAccountListResponseType;
@@ -46,34 +78,19 @@ export const decodeConnectedAccountListWithFallback = (
 /**
  * Item-level variant of {@link decodeConnectedAccountListWithFallback} for
  * call sites that decode `response.items` rather than the whole list
- * response. Same forward-compat contract: on `ParseError` (e.g. a status
- * value newer than this CLI's closed `Schema.Literal(...)`) warn via
- * `ui.log.warn` and retry with `status` widened to `Schema.String`.
+ * response.
  *
- * Unlike the list-response helper above, this one must NOT fall back to the
- * raw payload: `link --list` JSON-dumps the decoded items to stdout, so the
+ * `status` is an open enum, so a status newer than this CLI build decodes
+ * instead of failing — we just warn, pointing at `composio upgrade`. Unlike
+ * the list-response helper above, this one must NOT fall back to the raw
+ * payload: `link --list` JSON-dumps the decoded items to stdout, so the
  * schema's field allowlist is what keeps credential-bearing fields (`state`,
- * `data`, ...) out of pipeable output. The permissive re-decode preserves
- * that allowlist; truly malformed data still fails with `ParseError`.
+ * `data`, ...) out of pipeable output. Truly malformed data fails with
+ * `ParseError`.
  */
-export const decodeConnectedAccountItemsWithFallback = (
+export const decodeConnectedAccountItems = (
   rawItems: unknown
 ): Effect.Effect<ConnectedAccountItems, ParseResult.ParseError, TerminalUI> =>
-  Effect.gen(function* () {
-    const ui = yield* TerminalUI;
-    return yield* Schema.decodeUnknown(ConnectedAccountItems)(rawItems).pipe(
-      Effect.catchTag('ParseError', error =>
-        Effect.gen(function* () {
-          yield* ui.log.warn(
-            `Server returned a connection field this CLI does not recognize ` +
-              `(likely a newly-added status). Run "composio upgrade" to pick up ` +
-              `the latest schema. Continuing with a permissive schema.\n\n` +
-              `Decode error: ${error.message}`
-          );
-          const permissive = yield* Schema.decodeUnknown(ConnectedAccountItemsPermissive)(rawItems);
-          // Identical shape modulo the widened `status`; callers render it as text.
-          return permissive as ConnectedAccountItems;
-        })
-      )
-    );
-  });
+  Schema.decodeUnknown(ConnectedAccountItems)(rawItems).pipe(
+    Effect.tap(items => warnOnUnknownStatuses(items))
+  );

--- a/ts/packages/cli/src/models/connected-accounts.ts
+++ b/ts/packages/cli/src/models/connected-accounts.ts
@@ -1,6 +1,33 @@
 import { Schema } from 'effect';
 
 /**
+ * Statuses this CLI build knows about. The server owns this enum and may add
+ * values at any time, so schemas must stay open (see
+ * {@link ConnectedAccountStatus}) — use {@link isKnownConnectedAccountStatus}
+ * to detect values newer than this build.
+ */
+export const KnownConnectedAccountStatus = Schema.Literal(
+  'INITIALIZING',
+  'INITIATED',
+  'ACTIVE',
+  'FAILED',
+  'EXPIRED',
+  'INACTIVE',
+  'REVOKED'
+);
+export type KnownConnectedAccountStatus = typeof KnownConnectedAccountStatus.Type;
+
+export const isKnownConnectedAccountStatus = Schema.is(KnownConnectedAccountStatus);
+
+/**
+ * Open enum for the server-owned account status: the known literals document
+ * the values this build understands, the `Schema.String` branch lets a newer
+ * status decode instead of failing the whole payload. Callers only compare
+ * against literals or render the value as text, so widening is safe.
+ */
+export const ConnectedAccountStatus = Schema.Union(KnownConnectedAccountStatus, Schema.String);
+
+/**
  * A connected account item from the list or retrieve endpoints.
  * Field names match the raw API response (snake_case).
  *
@@ -13,15 +40,7 @@ export const ConnectedAccountItem = Schema.Struct({
   id: Schema.String,
   word_id: Schema.optional(Schema.NullOr(Schema.String)),
   alias: Schema.optional(Schema.NullOr(Schema.String)),
-  status: Schema.Literal(
-    'INITIALIZING',
-    'INITIATED',
-    'ACTIVE',
-    'FAILED',
-    'EXPIRED',
-    'INACTIVE',
-    'REVOKED'
-  ),
+  status: ConnectedAccountStatus,
   status_reason: Schema.optionalWith(Schema.NullOr(Schema.String), { default: () => null }),
   is_disabled: Schema.Boolean,
   user_id: Schema.String,
@@ -42,15 +61,3 @@ export type ConnectedAccountItem = Schema.Schema.Type<typeof ConnectedAccountIte
 
 export const ConnectedAccountItems = Schema.Array(ConnectedAccountItem);
 export type ConnectedAccountItems = Schema.Schema.Type<typeof ConnectedAccountItems>;
-
-/**
- * Forward-compatible variant of {@link ConnectedAccountItem}: identical field
- * allowlist (same credential-stripping guarantee as above) with `status`
- * widened to accept values newer than this CLI build's closed literal union.
- */
-export const ConnectedAccountItemPermissive = Schema.Struct({
-  ...ConnectedAccountItem.fields,
-  status: Schema.String,
-}).annotations({ identifier: 'ConnectedAccountItemPermissive' });
-
-export const ConnectedAccountItemsPermissive = Schema.Array(ConnectedAccountItemPermissive);

--- a/ts/packages/cli/src/services/connected-account-selection.ts
+++ b/ts/packages/cli/src/services/connected-account-selection.ts
@@ -1,16 +1,15 @@
 import type { Composio } from '@composio/client';
 import { Data, Effect, Option, Schema } from 'effect';
 import type { ConnectedAccountItem } from 'src/models/connected-accounts';
-import { decodeConnectedAccountItemsWithFallback } from 'src/effects/decode-connected-account-list';
+import { decodeConnectedAccountItems } from 'src/effects/decode-connected-account-list';
 import type { TerminalUI } from 'src/services/terminal-ui';
 
-// `ConnectedAccountItem` widened with an `'UNKNOWN'` sentinel for statuses
-// the closed schema doesn't yet know about. Selection only picks `'ACTIVE'`,
-// so unknown rows still drop out — but without falsely labeling them
+// `status` is an open enum, so this is shape-identical to
+// `ConnectedAccountItem`; tool-router rows normalize statuses outside the
+// known set to an `'UNKNOWN'` sentinel. Selection only picks `'ACTIVE'`, so
+// unknown rows still drop out — but without falsely labeling them
 // `'INACTIVE'` (= user-disabled).
-export type SelectableConnectedAccount = Omit<ConnectedAccountItem, 'status'> & {
-  readonly status: ConnectedAccountItem['status'] | 'UNKNOWN';
-};
+export type SelectableConnectedAccount = ConnectedAccountItem;
 
 export const CachedConnectedAccountSummarySchema = Schema.Struct({
   id: Schema.String,
@@ -171,7 +170,7 @@ export const resolveConnectedAccountForToolkit = (params: {
           cause,
         }),
     });
-    const selectableAccounts = yield* decodeConnectedAccountItemsWithFallback(accounts.items).pipe(
+    const selectableAccounts = yield* decodeConnectedAccountItems(accounts.items).pipe(
       Effect.mapError(
         cause =>
           new ConnectedAccountResolutionError({

--- a/ts/packages/cli/src/services/tool-router-session-connections.ts
+++ b/ts/packages/cli/src/services/tool-router-session-connections.ts
@@ -1,6 +1,6 @@
-import { Data, Effect, Schema } from 'effect';
+import { Data, Effect } from 'effect';
 import type { Composio } from '@composio/client';
-import { ConnectedAccountItem } from 'src/models/connected-accounts';
+import { isKnownConnectedAccountStatus } from 'src/models/connected-accounts';
 import {
   compareNewestFirst,
   groupCachedConnectedAccountsByToolkit,
@@ -48,9 +48,6 @@ export type ToolRouterSessionConnectionContext = {
     }>
   >;
 };
-
-// Derived from the model schema so the known-status list can't drift from it.
-const isKnownConnectedAccountStatus = Schema.is(ConnectedAccountItem.fields.status);
 
 const normalizeConnectedAccountStatus = (
   status?: string | null

--- a/ts/packages/cli/test/__utils__/http-server.ts
+++ b/ts/packages/cli/test/__utils__/http-server.ts
@@ -1,4 +1,4 @@
-import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
 import { Effect } from 'effect';
 
 /**
@@ -42,44 +42,47 @@ export async function withHttpServer(
 }
 
 /**
- * Effect variant of {@link withHttpServer}: the server lifecycle is managed
- * with acquireUseRelease so `use` can be an Effect run by @effect/vitest.
+ * Spin up a local HTTP server on an ephemeral port as a scoped resource and
+ * return its base URL. Scope closure tears the server down.
+ */
+export const startTestHttpServer = (handler: (req: IncomingMessage, res: ServerResponse) => void) =>
+  Effect.map(
+    Effect.acquireRelease(
+      Effect.promise(
+        () =>
+          new Promise<Server>((resolve, reject) => {
+            const server = createServer(handler);
+            server.once('error', reject);
+            server.listen({ port: 0, host: '127.0.0.1' }, () => {
+              server.off('error', reject);
+              resolve(server);
+            });
+          })
+      ),
+      server =>
+        Effect.promise(
+          () =>
+            new Promise<void>((resolve, reject) => {
+              server.close(error => (error ? reject(error) : resolve()));
+            })
+        )
+    ),
+    server => {
+      const address = server.address();
+      if (address === null || typeof address === 'string') {
+        throw new Error('Failed to bind test server to an ephemeral port');
+      }
+      return `http://127.0.0.1:${address.port}`;
+    }
+  );
+
+/**
+ * Effect variant of {@link withHttpServer}: the server lifecycle comes from
+ * {@link startTestHttpServer} so `use` can be an Effect run by @effect/vitest.
  */
 export function withHttpServerEffect<A, E, R>(
   handler: (req: IncomingMessage, res: ServerResponse) => void,
   use: (baseUrl: string) => Effect.Effect<A, E, R>
 ): Effect.Effect<A, E, R> {
-  return Effect.acquireUseRelease(
-    Effect.promise(async () => {
-      const server = createServer(handler);
-      await new Promise<void>((resolve, reject) => {
-        server.once('error', reject);
-        server.listen({ port: 0, host: '127.0.0.1' }, () => {
-          server.off('error', reject);
-          resolve();
-        });
-      });
-
-      const address = server.address();
-      if (address === null || typeof address === 'string') {
-        throw new Error('Failed to bind test server to an ephemeral port');
-      }
-
-      return { server, baseUrl: `http://127.0.0.1:${address.port}` };
-    }),
-    ({ baseUrl }) => use(baseUrl),
-    ({ server }) =>
-      Effect.promise(
-        () =>
-          new Promise<void>((resolve, reject) => {
-            server.close(error => {
-              if (error) {
-                reject(error);
-                return;
-              }
-              resolve();
-            });
-          })
-      )
-  );
+  return Effect.scoped(Effect.flatMap(startTestHttpServer(handler), use));
 }

--- a/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.list.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.list.cmd.test.ts
@@ -233,8 +233,8 @@ describe('CLI: composio dev connected-accounts list', () => {
     {
       ...testConnectedAccounts[0],
       id: 'con_future_status',
-      // Cast bypasses the closed status literal — that's the point.
-      status: 'FUTURE_NOT_YET_KNOWN' as ConnectedAccountItem['status'],
+      // Open enum: a status newer than this build decodes as a plain string.
+      status: 'FUTURE_NOT_YET_KNOWN',
     },
   ];
 

--- a/ts/packages/cli/test/src/commands/login.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/login.cmd.test.ts
@@ -335,6 +335,29 @@ describe('CLI: composio login', () => {
   });
 
   layer(TestLive())(it => {
+    it.scoped(
+      '[Given] an unreadable pending login cache [Then] poll reports the read failure, not a decode failure',
+      () =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const cacheDir = yield* setupCacheDir;
+          // A directory at the cache path passes the exists check but fails the read.
+          yield* fs.makeDirectory(path.join(cacheDir, 'pending-login-session.json'), {
+            recursive: true,
+          });
+
+          const error = yield* cli(['login', '--poll']).pipe(Effect.flip);
+
+          expect(error).toMatchObject({
+            _tag: 'commands/PendingLoginError',
+            reason: 'io',
+            message: 'Failed to read pending login cache',
+          });
+        })
+    );
+  });
+
+  layer(TestLive())(it => {
     it.scoped('[When] logging in with --user-api-key --org [Then] stores the chosen org', () =>
       Effect.gen(function* () {
         vi.spyOn(globalThis, 'fetch').mockImplementation(

--- a/ts/packages/cli/test/src/effects/compare-semver.test.ts
+++ b/ts/packages/cli/test/src/effects/compare-semver.test.ts
@@ -281,9 +281,13 @@ describe('compare-semver.ts', () => {
             }
           }
 
-          // Since we can't actually use the Effect in Array.sort, just verify
-          // the comparison results are consistent with sort expectations
-          expect(comparisons.length).toBe(3); // 3 comparisons for 3 elements
+          // Since we can't actually use the Effect in Array.sort, verify each
+          // pairwise result carries the polarity an ascending sort relies on
+          expect(comparisons).toEqual([
+            { versions: ['2.0.0', '1.0.0'], result: 1 },
+            { versions: ['2.0.0', '3.0.0'], result: -1 },
+            { versions: ['1.0.0', '3.0.0'], result: -1 },
+          ]);
         })
       );
     });

--- a/ts/packages/cli/test/src/effects/decode-connected-account-list.test.ts
+++ b/ts/packages/cli/test/src/effects/decode-connected-account-list.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, layer } from '@effect/vitest';
 import { Console, Effect, Layer, ParseResult } from 'effect';
-import { decodeConnectedAccountItemsWithFallback } from 'src/effects/decode-connected-account-list';
-import type { ConnectedAccountItem } from 'src/models/connected-accounts';
+import {
+  decodeConnectedAccountItems,
+  decodeConnectedAccountListWithFallback,
+} from 'src/effects/decode-connected-account-list';
 import { MockConsole } from 'test/__utils__';
 import { TerminalUITest } from 'test/__utils__/services/terminal-ui-test';
 
@@ -32,11 +34,11 @@ const makeItem = (overrides?: Record<string, unknown>) => ({
   ...overrides,
 });
 
-describe('decodeConnectedAccountItemsWithFallback', () => {
-  layer(TestLayer)('[Given] items matching the strict schema', it => {
+describe('decodeConnectedAccountItems', () => {
+  layer(TestLayer)('[Given] items with statuses this CLI build knows', it => {
     it.effect('decodes without warning', () =>
       Effect.gen(function* () {
-        const items = yield* decodeConnectedAccountItemsWithFallback([makeItem()]);
+        const items = yield* decodeConnectedAccountItems([makeItem()]);
 
         expect(items).toStrictEqual([makeItem()]);
         expect(yield* MockConsole.getLines()).toStrictEqual([]);
@@ -45,7 +47,7 @@ describe('decodeConnectedAccountItemsWithFallback', () => {
   });
 
   layer(TestLayer)('[Given] a status newer than this CLI build', it => {
-    it.effect('warns, keeps the unknown status, and still strips credential fields', () =>
+    it.effect('decodes, warns with only the status value, and still strips credential fields', () =>
       Effect.gen(function* () {
         const raw = makeItem({
           status: 'QUANTUM_LINKED',
@@ -53,28 +55,74 @@ describe('decodeConnectedAccountItemsWithFallback', () => {
           data: { refresh_token: 'must-not-leak' },
         });
 
-        const items = yield* decodeConnectedAccountItemsWithFallback([raw]);
+        const items = yield* decodeConnectedAccountItems([raw]);
 
-        expect(items).toStrictEqual([
-          makeItem({ status: 'QUANTUM_LINKED' }) as unknown as ConnectedAccountItem,
-        ]);
+        expect(items).toStrictEqual([makeItem({ status: 'QUANTUM_LINKED' })]);
         expect(JSON.stringify(items)).not.toContain('must-not-leak');
 
         const output = (yield* MockConsole.getLines()).join('\n');
-        expect(output).toContain('does not recognize');
+        expect(output).toContain('QUANTUM_LINKED');
+        expect(output).toContain('composio upgrade');
+        expect(output).not.toContain('must-not-leak');
+      })
+    );
+  });
+
+  layer(TestLayer)('[Given] a malformed payload', it => {
+    it.effect('fails with ParseError', () =>
+      Effect.gen(function* () {
+        const error = yield* Effect.flip(
+          decodeConnectedAccountItems([{ definitely: 'not-an-account' }])
+        );
+
+        expect(ParseResult.isParseError(error)).toBe(true);
+      })
+    );
+  });
+});
+
+describe('decodeConnectedAccountListWithFallback', () => {
+  layer(TestLayer)('[Given] a response with a status newer than this CLI build', it => {
+    it.effect('decodes and warns instead of falling back to the raw payload', () =>
+      Effect.gen(function* () {
+        const result = yield* decodeConnectedAccountListWithFallback({
+          items: [makeItem({ status: 'QUANTUM_LINKED' })],
+          total_items: 1,
+          total_pages: 1,
+          current_page: 1,
+          next_cursor: null,
+        });
+
+        expect(result.items).toStrictEqual([makeItem({ status: 'QUANTUM_LINKED' })]);
+
+        const output = (yield* MockConsole.getLines()).join('\n');
+        expect(output).toContain('QUANTUM_LINKED');
         expect(output).toContain('composio upgrade');
       })
     );
   });
 
-  layer(TestLayer)('[Given] a payload the permissive schema cannot decode', it => {
-    it.effect('fails with ParseError instead of leaking the raw payload', () =>
+  layer(TestLayer)('[Given] a shape-skewed response carrying credential fields', it => {
+    it.effect('falls back to raw but never echoes payload values in the warning', () =>
       Effect.gen(function* () {
-        const error = yield* Effect.flip(
-          decodeConnectedAccountItemsWithFallback([{ definitely: 'not-an-account' }])
-        );
+        // `items` is not an array: the decode fails at the container level,
+        // where an unredacted formatter would print the whole actual value.
+        const raw = {
+          items: { 0: makeItem({ state: { access_token: 'must-not-leak' } }) },
+          total_items: 1,
+          total_pages: 1,
+          current_page: 1,
+          next_cursor: null,
+        };
 
-        expect(ParseResult.isParseError(error)).toBe(true);
+        const result = yield* decodeConnectedAccountListWithFallback(raw);
+
+        expect(result).toBe(raw);
+
+        const output = (yield* MockConsole.getLines()).join('\n');
+        expect(output).toContain('composio upgrade');
+        expect(output).toContain('items');
+        expect(output).not.toContain('must-not-leak');
       })
     );
   });

--- a/ts/packages/cli/test/src/effects/install-skill.test.ts
+++ b/ts/packages/cli/test/src/effects/install-skill.test.ts
@@ -1,4 +1,3 @@
-import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
 import { describe, expect, it, vi } from '@effect/vitest';
 import { Config, ConfigProvider, Effect, Exit, Layer } from 'effect';
 import { FetchHttpClient, FileSystem, HttpClient, Path } from '@effect/platform';
@@ -6,6 +5,7 @@ import type * as PlatformError from '@effect/platform/Error';
 import { BunFileSystem, BunPath } from '@effect/platform-bun';
 import * as tempy from 'tempy';
 import { TerminalUITest } from 'test/__utils__/services/terminal-ui-test';
+import { startTestHttpServer } from 'test/__utils__/http-server';
 import {
   inferSkillReleaseChannel,
   installSkill,
@@ -54,41 +54,6 @@ const makeInstallEffect = (
       )
     ),
     Effect.scoped
-  );
-
-/**
- * Spin up a local HTTP server on an ephemeral port as a scoped resource and
- * return its base URL. Scope closure tears the server down.
- */
-const startTestHttpServer = (handler: (req: IncomingMessage, res: ServerResponse) => void) =>
-  Effect.map(
-    Effect.acquireRelease(
-      Effect.promise(
-        () =>
-          new Promise<Server>((resolve, reject) => {
-            const server = createServer(handler);
-            server.once('error', reject);
-            server.listen({ port: 0, host: '127.0.0.1' }, () => {
-              server.off('error', reject);
-              resolve(server);
-            });
-          })
-      ),
-      server =>
-        Effect.promise(
-          () =>
-            new Promise<void>((resolve, reject) => {
-              server.close(error => (error ? reject(error) : resolve()));
-            })
-        )
-    ),
-    server => {
-      const address = server.address();
-      if (address === null || typeof address === 'string') {
-        throw new Error('Failed to bind test server to an ephemeral port');
-      }
-      return `http://127.0.0.1:${address.port}`;
-    }
   );
 
 const startSkillReleaseServer = (skillZip: Uint8Array) =>

--- a/ts/packages/cli/test/src/services/composio-client-singleton.test.ts
+++ b/ts/packages/cli/test/src/services/composio-client-singleton.test.ts
@@ -23,6 +23,9 @@ const okResponse = () =>
     headers: { 'Content-Type': 'application/json' },
   });
 
+// Mirrors the module-private `cwdHash` in src/services/consumer-short-term-cache.ts
+// (djb2Hash + base36): the seeded cache key below must be byte-identical to what
+// the service computes for process.cwd() when it looks up the CLI session.
 const cwdHash = (cwd: string): string => {
   let hash = 5381;
   for (let index = 0; index < cwd.length; index += 1) {


### PR DESCRIPTION
Follow-up to https://github.com/ComposioHQ/composio/pull/3885, which is now merged into `next`.

This PR:
- reports pending-login cache read failures as I/O errors instead of masking them as decode failures (`composio login --poll`)
- restores pairwise polarity assertions for the `semverComparator` Array.sort compatibility case
- consolidates the duplicated ephemeral HTTP server test helper in `test/__utils__/http-server.ts`
- makes server-owned connected-account statuses forward-compatible while preserving the credential-stripping schema allowlist
- redacts raw payload values from connected-account parse warnings and adds regression coverage for unknown statuses and secret-bearing malformed payloads
- documents why the client-singleton test re-derives the consumer cache cwd hash

## Rebase notes

Rebased onto `origin/next` at `ef1ec9148`.

- Dropped the empty `GITHUB_*` compatibility commit; that contract is already present on `next` through https://github.com/ComposioHQ/composio/pull/3880.
- Adapted the connected-account decoder rename to the service extracted upstream in `connected-account-selection.ts`.

## Context

Fix-forward PR for actionable Cursor Bugbot findings on the guardrails stack (#3877–#3885). The stale decode-error string match and unused release helper were already resolved upstream, and the `vi.stubEnv(..., undefined)` concern is not actionable on Vitest 4.1.10.