### PR TITLE
fix(py/triggers): disconnect pusher connection on subscribe() timeout

### DIFF
--- a/python/composio/core/models/triggers.py
+++ b/python/composio/core/models/triggers.py
@@ -864,7 +864,11 @@ class _SubcriptionBuilder(WithLogger):
         )
         pusher.connect()
 
-        # Wait for connection to get established
+        # Wait for connection to get established. If we time out, we must tear
+        # down the connection we just started; otherwise pysher's background
+        # thread keeps redialing every `reconnect_interval` for the life of the
+        # process (and, if it eventually succeeds, silently consumes events for
+        # the abandoned subscription). See issue #3858.
         deadline = time.time() + timeout
         while time.time() < deadline:
             if not self.subscription.is_alive():
@@ -873,6 +877,7 @@ class _SubcriptionBuilder(WithLogger):
 
             self.subscription._pusher = pusher  # pylint: disable=protected-access
             return self.subscription
+        pusher.disconnect()
         raise ComposioSDKTimeoutError(
             "Timed out while waiting for trigger listener to be established"
         )

--- a/python/tests/test_triggers.py
+++ b/python/tests/test_triggers.py
@@ -507,6 +507,53 @@ class TestTriggers:
             mock_builder.connect.assert_called_once_with(timeout=15.0)
             assert result == mock_subscription
 
+    def test_subscription_builder_disconnects_pusher_on_connect_timeout(
+        self, mock_client
+    ):
+        """`_SubcriptionBuilder.connect()` must disconnect the pusher connection
+        it started when it times out, otherwise pysher's background thread redials
+        forever for the life of the process. Regression test for #3858."""
+        from composio.core.models.triggers import _SubcriptionBuilder
+
+        builder = _SubcriptionBuilder(client=mock_client)
+
+        # The pusher instance returned by _get_pusher_instance: a bare Mock whose
+        # .connect() starts a (fake) connection and .disconnect() must be called
+        # on the timeout path.
+        fake_pusher = Mock()
+
+        # project info returned by internal.get_sdk_realtime_credentials().
+        fake_project_info = Mock()
+        fake_project_info.pusher_key = "pk"
+        fake_project_info.pusher_cluster = "cl"
+        fake_project_info.project_id = "proj"
+
+        with (
+            patch.object(builder, "_get_pusher_instance", return_value=fake_pusher),
+            patch.object(
+                builder.internal,
+                "get_sdk_realtime_credentials",
+                return_value=fake_project_info,
+            ),
+        ):
+            # The subscription never reports is_alive(), so the wait loop always
+            # exhausts the deadline and takes the timeout branch.
+            with (
+                patch.object(builder.subscription, "is_alive", return_value=False),
+                patch("composio.core.models.triggers.time.sleep"),
+            ):
+                # Use a tiny timeout so the deadline is immediately in the past;
+                # time.time() returns a fixed value past it so the loop exits
+                # after one iteration without relying on real time.
+                with patch("composio.core.models.triggers.time.time") as mock_time:
+                    mock_time.return_value = 1_000_000.0
+                    with pytest.raises(exceptions.ComposioSDKTimeoutError):
+                        builder.connect(timeout=0.0)
+
+            # The pusher connection we started must have been torn down.
+            fake_pusher.connect.assert_called_once()
+            fake_pusher.disconnect.assert_called_once()
+
 
 class TestVerifyWebhook:
     """Test cases for verify_webhook method."""


### PR DESCRIPTION
Fixes the subscribe()-timeout leak from #3858.

_SubcriptionBuilder.connect() starts a pusher connection and waits up to `timeout` for the subscription to come alive. When the deadline elapsed it raised ComposioSDKTimeoutError without ever calling pusher.disconnect(), so pysher's background thread kept redialing every reconnect_interval for the life of the process. Each timed-out subscribe() leaked one thread, retrying subscribe() (the natural response to a timeout) accumulated one per attempt, and a leaked connection that eventually succeeded silently consumed trigger events for the abandoned TriggerSubscription.

This adds a single pusher.disconnect() on the timeout branch before the raise, so the connection thread is torn down and no longer redials. Added a regression test that builds a real _SubcriptionBuilder, stubs the pusher instance, forces the wait loop to exhaust the deadline, and asserts both that connect() raised ComposioSDKTimeoutError and that disconnect() was called (the test fails on the unpatched code). Only the second bug from #3858 is addressed here; the stop()-from-callback deadlock is a separate lifecycle change.

Assisted-by: Hermes Agent