### PR TITLE
docs(examples): add local sandbox on Tenki example

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -482,10 +482,10 @@ importers:
         version: link:../../../../packages/providers/mastra
       '@mastra/core':
         specifier: 'catalog:'
-        version: 1.52.1(@cfworker/json-schema@4.1.1)(ai@6.0.241(zod@3.25.76))(express@5.2.1)(zod@3.25.76)
+        version: 1.52.1(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(ai@6.0.241(zod@3.25.76))(express@5.2.1)(zod@3.25.76)
       '@mastra/mcp':
         specifier: ^1.15.0
-        version: 1.15.0(@cfworker/json-schema@4.1.1)(@mastra/core@1.52.1(@cfworker/json-schema@4.1.1)(ai@6.0.241(zod@3.25.76))(express@5.2.1)(zod@3.25.76))(supports-color@10.2.2)(zod@3.25.76)
+        version: 1.15.0(@cfworker/json-schema@4.1.1)(@mastra/core@1.52.1(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(ai@6.0.241(zod@3.25.76))(express@5.2.1)(zod@3.25.76))(supports-color@10.2.2)(zod@3.25.76)
       ai:
         specifier: ^6.0.241
         version: 6.0.241(zod@3.25.76)
@@ -510,10 +510,10 @@ importers:
         version: link:../../../../packages/providers/mastra
       '@mastra/core':
         specifier: 'catalog:'
-        version: 1.52.1(@cfworker/json-schema@4.1.1)(ai@6.0.241(zod@4.4.3))(express@5.2.1)(zod@4.4.3)
+        version: 1.52.1(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(ai@6.0.241(zod@4.4.3))(express@5.2.1)(zod@4.4.3)
       '@mastra/mcp':
         specifier: ^1.15.0
-        version: 1.15.0(@cfworker/json-schema@4.1.1)(@mastra/core@1.52.1(@cfworker/json-schema@4.1.1)(ai@6.0.241(zod@4.4.3))(express@5.2.1)(zod@4.4.3))(zod@4.4.3)
+        version: 1.15.0(@cfworker/json-schema@4.1.1)(@mastra/core@1.52.1(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(ai@6.0.241(zod@4.4.3))(express@5.2.1)(zod@4.4.3))(zod@4.4.3)
       ai:
         specifier: ^6.0.241
         version: 6.0.241(zod@4.4.3)
@@ -600,10 +600,10 @@ importers:
         version: link:../../packages/core
       '@mastra/core':
         specifier: 'catalog:'
-        version: 1.52.1(@cfworker/json-schema@4.1.1)(ai@6.0.241(zod@4.4.3))(express@5.2.1)(zod@4.4.3)
+        version: 1.52.1(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(ai@6.0.241(zod@4.4.3))(express@5.2.1)(zod@4.4.3)
       '@mastra/mcp':
         specifier: ^1.15.0
-        version: 1.15.0(@cfworker/json-schema@4.1.1)(@mastra/core@1.52.1(@cfworker/json-schema@4.1.1)(ai@6.0.241(zod@4.4.3))(express@5.2.1)(zod@4.4.3))(zod@4.4.3)
+        version: 1.15.0(@cfworker/json-schema@4.1.1)(@mastra/core@1.52.1(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(ai@6.0.241(zod@4.4.3))(express@5.2.1)(zod@4.4.3))(zod@4.4.3)
       ai:
         specifier: ^6.0.241
         version: 6.0.241(zod@4.4.3)
@@ -806,6 +806,28 @@ importers:
         specifier: 'catalog:'
         version: 7.0.2
 
+  ts/examples/local-sandbox-tenki:
+    dependencies:
+      '@composio/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@composio/experimental':
+        specifier: workspace:*
+        version: link:../../packages/experimental
+      '@tenkicloud/sandbox':
+        specifier: ^0.3.6
+        version: 0.3.7
+      dotenv:
+        specifier: 'catalog:'
+        version: 17.4.2
+    devDependencies:
+      '@types/bun':
+        specifier: 'catalog:'
+        version: 1.3.14
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+
   ts/examples/mastra:
     dependencies:
       '@ai-sdk/openai':
@@ -819,7 +841,7 @@ importers:
         version: link:../../packages/providers/mastra
       '@mastra/core':
         specifier: 'catalog:'
-        version: 1.52.1(@cfworker/json-schema@4.1.1)(ai@6.0.241(zod@4.4.3))(express@5.2.1)(zod@4.4.3)
+        version: 1.52.1(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(ai@6.0.241(zod@4.4.3))(express@5.2.1)(zod@4.4.3)
       ai:
         specifier: ^6.0.241
         version: 6.0.241(zod@4.4.3)
@@ -1501,10 +1523,10 @@ importers:
         version: link:../../core
       '@mastra/core':
         specifier: 'catalog:'
-        version: 1.52.1(@cfworker/json-schema@4.1.1)(ai@6.0.241(zod@4.4.3))(express@5.2.1)(zod@4.4.3)
+        version: 1.52.1(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(ai@6.0.241(zod@4.4.3))(express@5.2.1)(zod@4.4.3)
       '@mastra/mcp':
         specifier: ^1.15.0
-        version: 1.15.0(@cfworker/json-schema@4.1.1)(@mastra/core@1.52.1(@cfworker/json-schema@4.1.1)(ai@6.0.241(zod@4.4.3))(express@5.2.1)(zod@4.4.3))(zod@4.4.3)
+        version: 1.15.0(@cfworker/json-schema@4.1.1)(@mastra/core@1.52.1(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(ai@6.0.241(zod@4.4.3))(express@5.2.1)(zod@4.4.3))(zod@4.4.3)
       ai:
         specifier: ^6.0.241
         version: 6.0.241(zod@4.4.3)
@@ -1623,7 +1645,7 @@ importers:
         version: link:../../core
       '@mastra/core':
         specifier: 'catalog:'
-        version: 1.52.1(@cfworker/json-schema@4.1.1)(ai@6.0.241(zod@4.4.3))(express@5.2.1)(zod@4.4.3)
+        version: 1.52.1(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(ai@6.0.241(zod@4.4.3))(express@5.2.1)(zod@4.4.3)
       ai:
         specifier: ^6.0.241
         version: 6.0.241(zod@4.4.3)
@@ -2080,6 +2102,9 @@ packages:
   '@braidai/lang@1.1.2':
     resolution: {integrity: sha512-qBcknbBufNHlui137Hft8xauQMTZDKdophmLFv05r2eNmdIv/MlPuP4TdUknHG68UdWLgVZwgxVe735HzJNIwA==}
 
+  '@bufbuild/protobuf@2.12.1':
+    resolution: {integrity: sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==}
+
   '@cfworker/json-schema@4.1.1':
     resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
 
@@ -2235,6 +2260,18 @@ packages:
 
   '@composio/client@0.1.0-alpha.76':
     resolution: {integrity: sha512-MXC5JGRVdiQ4EgLricy9o/mqBa1+1T7wHFZ6Q4ZJkrjzZqOMvxTgy21Zlb5J/1oGkB2bg9UDzpH8PkXCp/D4zA==}
+
+  '@connectrpc/connect-node@2.1.2':
+    resolution: {integrity: sha512-+i/aAOpsI8sIx1mbYp6d99zvxaUSF6t/jP9Ux9maAmjsZPgmIQ3JuIeYi0zJIP9zlCnBlJjkpPosshCgdRuThQ==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.7.0
+      '@connectrpc/connect': 2.1.2
+
+  '@connectrpc/connect@2.1.2':
+    resolution: {integrity: sha512-MXkBijtcX09R10Eb6sFeIetc6w6746eio6xtfuyVOH7oQAacT1X0GzMIQFux6Qy8cq3W/T5qX5Bei8YbFtmRGA==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.7.0
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -4016,6 +4053,10 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tenkicloud/sandbox@0.3.7':
+    resolution: {integrity: sha512-gvRLKRpHOANjaPJW6T0CyXBDAjarxsSJvasdY3Uo/5+CHXh3YwGbc4n5ap8F8n7RT68MrXK2sr6B/gF7zKOnZg==}
+    engines: {node: '>=18'}
 
   '@ts-morph/common@0.29.0':
     resolution: {integrity: sha512-35oUmphHbJvQ/+UTwFNme/t2p3FoKiGJ5auTjjpNTop2dyREspirjMy82PLSC1pnDJ8ah1GU98hwpVt64YXQsg==}
@@ -7126,10 +7167,11 @@ packages:
 
 snapshots:
 
-  '@a2a-js/sdk@0.3.14(express@5.2.1)':
+  '@a2a-js/sdk@0.3.14(@bufbuild/protobuf@2.12.1)(express@5.2.1)':
     dependencies:
       uuid: 11.1.1
     optionalDependencies:
+      '@bufbuild/protobuf': 2.12.1
       express: 5.2.1
 
   '@agentclientprotocol/sdk@0.14.1(zod@4.4.3)':
@@ -7633,6 +7675,8 @@ snapshots:
 
   '@braidai/lang@1.1.2': {}
 
+  '@bufbuild/protobuf@2.12.1': {}
+
   '@cfworker/json-schema@4.1.1': {}
 
   '@changesets/apply-release-plan@7.1.1':
@@ -7849,6 +7893,15 @@ snapshots:
     optional: true
 
   '@composio/client@0.1.0-alpha.76': {}
+
+  '@connectrpc/connect-node@2.1.2(@bufbuild/protobuf@2.12.1)(@connectrpc/connect@2.1.2(@bufbuild/protobuf@2.12.1))':
+    dependencies:
+      '@bufbuild/protobuf': 2.12.1
+      '@connectrpc/connect': 2.1.2(@bufbuild/protobuf@2.12.1)
+
+  '@connectrpc/connect@2.1.2(@bufbuild/protobuf@2.12.1)':
+    dependencies:
+      '@bufbuild/protobuf': 2.12.1
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -8586,9 +8639,9 @@ snapshots:
       '@mariozechner/clipboard-win32-x64-msvc': 0.3.9
     optional: true
 
-  '@mastra/core@1.52.1(@cfworker/json-schema@4.1.1)(ai@6.0.241(zod@3.25.76))(express@5.2.1)(zod@3.25.76)':
+  '@mastra/core@1.52.1(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(ai@6.0.241(zod@3.25.76))(express@5.2.1)(zod@3.25.76)':
     dependencies:
-      '@a2a-js/sdk': 0.3.14(express@5.2.1)
+      '@a2a-js/sdk': 0.3.14(@bufbuild/protobuf@2.12.1)(express@5.2.1)
       '@ai-sdk/provider-utils-v5': '@ai-sdk/provider-utils@3.0.30(zod@3.25.76)'
       '@ai-sdk/provider-utils-v6': '@ai-sdk/provider-utils@4.0.40(zod@3.25.76)'
       '@ai-sdk/provider-utils-v7': '@ai-sdk/provider-utils@5.0.11(zod@3.25.76)'
@@ -8632,9 +8685,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@mastra/core@1.52.1(@cfworker/json-schema@4.1.1)(ai@6.0.241(zod@4.4.3))(express@5.2.1)(zod@4.4.3)':
+  '@mastra/core@1.52.1(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(ai@6.0.241(zod@4.4.3))(express@5.2.1)(zod@4.4.3)':
     dependencies:
-      '@a2a-js/sdk': 0.3.14(express@5.2.1)
+      '@a2a-js/sdk': 0.3.14(@bufbuild/protobuf@2.12.1)(express@5.2.1)
       '@ai-sdk/provider-utils-v5': '@ai-sdk/provider-utils@3.0.30(zod@4.4.3)'
       '@ai-sdk/provider-utils-v6': '@ai-sdk/provider-utils@4.0.40(zod@4.4.3)'
       '@ai-sdk/provider-utils-v7': '@ai-sdk/provider-utils@5.0.11(zod@4.4.3)'
@@ -8678,9 +8731,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@mastra/mcp@1.15.0(@cfworker/json-schema@4.1.1)(@mastra/core@1.52.1(@cfworker/json-schema@4.1.1)(ai@6.0.241(zod@3.25.76))(express@5.2.1)(zod@3.25.76))(supports-color@10.2.2)(zod@3.25.76)':
+  '@mastra/mcp@1.15.0(@cfworker/json-schema@4.1.1)(@mastra/core@1.52.1(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(ai@6.0.241(zod@3.25.76))(express@5.2.1)(zod@3.25.76))(supports-color@10.2.2)(zod@3.25.76)':
     dependencies:
-      '@mastra/core': 1.52.1(@cfworker/json-schema@4.1.1)(ai@6.0.241(zod@3.25.76))(express@5.2.1)(zod@3.25.76)
+      '@mastra/core': 1.52.1(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(ai@6.0.241(zod@3.25.76))(express@5.2.1)(zod@3.25.76)
       '@modelcontextprotocol/ext-apps': 1.7.5(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(zod@3.25.76))(zod@3.25.76)
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(zod@3.25.76)
       exit-hook: 5.1.0
@@ -8692,9 +8745,9 @@ snapshots:
       - supports-color
       - zod
 
-  '@mastra/mcp@1.15.0(@cfworker/json-schema@4.1.1)(@mastra/core@1.52.1(@cfworker/json-schema@4.1.1)(ai@6.0.241(zod@4.4.3))(express@5.2.1)(zod@4.4.3))(zod@4.4.3)':
+  '@mastra/mcp@1.15.0(@cfworker/json-schema@4.1.1)(@mastra/core@1.52.1(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(ai@6.0.241(zod@4.4.3))(express@5.2.1)(zod@4.4.3))(zod@4.4.3)':
     dependencies:
-      '@mastra/core': 1.52.1(@cfworker/json-schema@4.1.1)(ai@6.0.241(zod@4.4.3))(express@5.2.1)(zod@4.4.3)
+      '@mastra/core': 1.52.1(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(ai@6.0.241(zod@4.4.3))(express@5.2.1)(zod@4.4.3)
       '@modelcontextprotocol/ext-apps': 1.7.5(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(zod@4.4.3)
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
       exit-hook: 5.1.0
@@ -9490,6 +9543,16 @@ snapshots:
   '@stablelib/base64@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@tenkicloud/sandbox@0.3.7':
+    dependencies:
+      '@bufbuild/protobuf': 2.12.1
+      '@connectrpc/connect': 2.1.2(@bufbuild/protobuf@2.12.1)
+      '@connectrpc/connect-node': 2.1.2(@bufbuild/protobuf@2.12.1)(@connectrpc/connect@2.1.2(@bufbuild/protobuf@2.12.1))
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@ts-morph/common@0.29.0':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -815,8 +815,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/experimental
       '@tenkicloud/sandbox':
-        specifier: ^0.3.6
-        version: 0.3.7
+        specifier: ^0.5.4
+        version: 0.5.4
       dotenv:
         specifier: 'catalog:'
         version: 17.4.2
@@ -4054,8 +4054,8 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@tenkicloud/sandbox@0.3.7':
-    resolution: {integrity: sha512-gvRLKRpHOANjaPJW6T0CyXBDAjarxsSJvasdY3Uo/5+CHXh3YwGbc4n5ap8F8n7RT68MrXK2sr6B/gF7zKOnZg==}
+  '@tenkicloud/sandbox@0.5.4':
+    resolution: {integrity: sha512-U/oV8TAB1rjpXHuo9DIrpxnd2tlO2MojNjzLjqKgx4+zkD4NjgpR6QzRv5awoXib0DND3bnu0qoQCIgsfcXTCw==}
     engines: {node: '>=18'}
 
   '@ts-morph/common@0.29.0':
@@ -9544,12 +9544,12 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@tenkicloud/sandbox@0.3.7':
+  '@tenkicloud/sandbox@0.5.4':
     dependencies:
       '@bufbuild/protobuf': 2.12.1
       '@connectrpc/connect': 2.1.2(@bufbuild/protobuf@2.12.1)
       '@connectrpc/connect-node': 2.1.2(@bufbuild/protobuf@2.12.1)(@connectrpc/connect@2.1.2(@bufbuild/protobuf@2.12.1))
-      ws: 8.21.0
+      ws: 8.21.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate

--- a/ts/examples/local-sandbox-tenki/.env.example
+++ b/ts/examples/local-sandbox-tenki/.env.example
@@ -1,0 +1,5 @@
+# Composio API Key - Get it from https://app.composio.dev
+COMPOSIO_API_KEY=your_composio_api_key_here
+
+# Tenki API Key - Get it from https://app.tenki.cloud (workspace Settings -> API Keys)
+TENKI_API_KEY=your_tenki_api_key_here

--- a/ts/examples/local-sandbox-tenki/README.md
+++ b/ts/examples/local-sandbox-tenki/README.md
@@ -1,0 +1,66 @@
+# Local Sandbox on Tenki Example
+
+Run [Composio's local sandbox](https://docs.composio.dev/docs/sandbox/local) on [Tenki](https://tenki.cloud) — disposable Linux microVMs that boot in ~2 seconds, purpose-built for AI agents.
+
+A **local sandbox** is a Composio session with the remote sandbox disabled: Composio still does managed auth and tool discovery, but code execution happens in a box _you_ own. This example uses a Tenki microVM as that box, so each run gets hardware-isolated, per-second-billed compute that is destroyed at the end.
+
+## How it works
+
+1. Create a Composio session with `sandbox: { enable: false }`.
+2. `experimental_createLocalWorkbenchSession` returns the two pieces you run yourself: a Python **helper** (`composio_helper.py`) and the **env** it needs.
+3. Boot a Tenki microVM with that env and write the helper into it.
+4. Run agent code inside the guest. It imports the helper and calls `run_composio_tool(...)` — every call routes back through the Tool Router under the session's connections, so auth stays managed while execution stays inside your boundary.
+5. Terminate the microVM.
+
+The agent here calls a HackerNews tool because that toolkit needs no OAuth connection, so the example runs with just the two API keys.
+
+## Setup
+
+1. **Install dependencies** (from the repository root):
+
+   ```bash
+   pnpm install
+   ```
+
+2. **Configure environment:**
+
+   ```bash
+   cp .env.example .env
+   ```
+
+   Then edit `.env`:
+   - `COMPOSIO_API_KEY`: Get it from [Composio Dashboard](https://app.composio.dev)
+   - `TENKI_API_KEY`: Get it from [Tenki Cloud](https://app.tenki.cloud) (workspace Settings → API Keys)
+
+## Running the Example
+
+```bash
+# Run the example
+pnpm start
+
+# Run in development mode (with file watching)
+pnpm dev
+```
+
+Expected output: the Composio session id, the microVM boot time, the guest's hostname, and the HackerNews tool response printed from inside the microVM.
+
+## Security note
+
+The `env` returned by `experimental_createLocalWorkbenchSession` contains your Composio **project** API key, and this example injects it into the sandbox. Anything running there can read it. Treat the sandbox as your trust boundary: use a key scoped to what the run needs, and rotate it if a run could have leaked it. Tenki microVMs are destroyed on `close()`, and each session is isolated from every other.
+
+## Swapping the runtime
+
+Tenki is one way to honor the local-sandbox contract. The contract itself is small: create a box, write `helperSource` into it as `composio_helper.py`, pass `env` to the process, and tear down on your schedule. See the [local sandbox docs](https://docs.composio.dev/docs/sandbox/local) for the details.
+
+## Related Examples
+
+- [Tool Router Example](../tool-router) - Session-based tool routing
+- [Tools Example](../tools) - Direct tool execution
+- [More Examples](../) - Browse all available examples
+
+## Support
+
+- [Composio Documentation](https://docs.composio.dev)
+- [Tenki Sandbox Documentation](https://tenki.cloud/docs/sandbox/quick-start-sandbox)
+- [Discord Community](https://discord.gg/composio)
+- [GitHub Issues](https://github.com/ComposioHQ/composio/issues)

--- a/ts/examples/local-sandbox-tenki/README.md
+++ b/ts/examples/local-sandbox-tenki/README.md
@@ -8,9 +8,9 @@ A **local sandbox** is a Composio session with the remote sandbox disabled: Comp
 
 1. Create a Composio session with `sandbox: { enable: false }`.
 2. `experimental_createLocalWorkbenchSession` returns the two pieces you run yourself: a Python **helper** (`composio_helper.py`) and the **env** it needs.
-3. Boot a Tenki microVM with that env and write the helper into it.
+3. `createTenkiSandbox` (in `src/sandbox/tenki.ts`) boots a microVM and injects the helper. It implements the same `UserSandbox` contract as the canonical local-sandbox example's E2B runner — `writeFile`, `run`, `teardown` — so Tenki specifics never leak past that one file.
 4. Run agent code inside the guest. It imports the helper and calls `run_composio_tool(...)` — every call routes back through the Tool Router under the session's connections, so auth stays managed while execution stays inside your boundary.
-5. Terminate the microVM.
+5. `teardown()` terminates the microVM. Boot is failure-atomic (a session that fails readiness is terminated, not leaked), and a `maxDurationMs` backstop makes the VM self-terminate even if the host process crashes before teardown.
 
 The agent here calls a HackerNews tool because that toolkit needs no OAuth connection, so the example runs with just the two API keys.
 
@@ -50,7 +50,7 @@ The `env` returned by `experimental_createLocalWorkbenchSession` contains your C
 
 ## Swapping the runtime
 
-Tenki is one way to honor the local-sandbox contract. The contract itself is small: create a box, write `helperSource` into it as `composio_helper.py`, pass `env` to the process, and tear down on your schedule. See the [local sandbox docs](https://docs.composio.dev/docs/sandbox/local) for the details.
+Tenki is one way to honor the local-sandbox contract, and it is deliberately isolated in `src/sandbox/tenki.ts` behind the `UserSandbox` interface (`writeFile`, `run`, `teardown`). To run on your own VM, container, or CI worker, replace `createTenkiSandbox` with any factory that honors the same contract: create a box, write `helperSource` into it as `composio_helper.py`, pass `env` to the process, and tear down on your schedule. See the [local sandbox docs](https://docs.composio.dev/docs/sandbox/local) for the details.
 
 ## Related Examples
 

--- a/ts/examples/local-sandbox-tenki/package.json
+++ b/ts/examples/local-sandbox-tenki/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "local-sandbox-tenki-example",
+  "private": true,
+  "version": "0.1.0",
+  "description": "Run Composio's local sandbox on Tenki disposable Linux microVMs",
+  "main": "src/index.ts",
+  "scripts": {
+    "start": "bun src/index.ts",
+    "dev": "bun --watch src/index.ts",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "composio",
+    "example",
+    "tenki",
+    "local-sandbox",
+    "sandbox",
+    "microvm"
+  ],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@composio/core": "workspace:*",
+    "@composio/experimental": "workspace:*",
+    "@tenkicloud/sandbox": "^0.3.6",
+    "dotenv": "catalog:"
+  },
+  "devDependencies": {
+    "@types/bun": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/ts/examples/local-sandbox-tenki/package.json
+++ b/ts/examples/local-sandbox-tenki/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@composio/core": "workspace:*",
     "@composio/experimental": "workspace:*",
-    "@tenkicloud/sandbox": "^0.3.6",
+    "@tenkicloud/sandbox": "^0.5.4",
     "dotenv": "catalog:"
   },
   "devDependencies": {

--- a/ts/examples/local-sandbox-tenki/src/index.ts
+++ b/ts/examples/local-sandbox-tenki/src/index.ts
@@ -6,13 +6,18 @@
  * example uses Tenki (https://tenki.cloud) as that sandbox: a disposable
  * Linux microVM that boots in ~2 seconds and is destroyed at the end.
  *
+ * Tenki is isolated behind the sandbox contract in `src/sandbox/tenki.ts`
+ * (`createTenkiSandbox` -> `UserSandbox`), the same shape as the canonical
+ * local-sandbox example's E2B runner — swap the factory to run on any box
+ * that honors the contract.
+ *
  * Flow:
  *   1. Create a Composio session with the remote sandbox disabled
  *   2. Get the local-workbench pieces: a Python helper + the env it needs
- *   3. Boot a Tenki microVM with that env, inject the helper
+ *   3. Boot a Tenki microVM behind the sandbox contract (helper injected)
  *   4. Run agent code inside the guest — it calls Composio tools through
  *      the helper, so execution stays inside your security boundary
- *   5. Terminate the microVM
+ *   5. Tear the microVM down (a max-duration backstop covers host crashes)
  *
  * Prerequisites:
  *   - COMPOSIO_API_KEY (https://app.composio.dev)
@@ -24,16 +29,14 @@
  */
 import { Composio } from '@composio/core';
 import { experimental_createLocalWorkbenchSession } from '@composio/experimental/workbench';
-import { TenkiSandbox } from '@tenkicloud/sandbox';
 import 'dotenv/config';
-
-const GUEST_HOME = '/home/tenki';
+import { commandErrorText, createTenkiSandbox } from './sandbox/tenki';
 
 /**
- * Agent code that runs *inside* the Tenki microVM. The injected
- * composio_helper.py is the only Composio-specific thing the guest carries:
- * tool calls route back through the Tool Router session created by the host,
- * so auth and discovery stay managed while execution happens in your box.
+ * Agent code that runs *inside* the microVM. The injected composio_helper.py
+ * is the only Composio-specific thing the guest carries: tool calls route
+ * back through the Tool Router session created by the host, so auth and
+ * discovery stay managed while execution happens in your box.
  */
 const AGENT_SCRIPT = `"""Agent code running inside the Tenki microVM."""
 import json
@@ -52,34 +55,6 @@ print("[guest] tool response:")
 print(json.dumps(response, indent=2))
 `;
 
-/**
- * Boot a Tenki microVM. Session creation needs a project; discover one from
- * the API key's identity (override with TENKI_WORKSPACE_ID / TENKI_PROJECT_ID).
- */
-async function createTenkiMicroVm(tenki: TenkiSandbox, env: Record<string, string>) {
-  const identity = await tenki.whoAmI();
-  const workspace =
-    identity.workspaces.find(ws => ws.id === process.env.TENKI_WORKSPACE_ID) ??
-    identity.workspaces[0];
-  const project =
-    workspace?.projects.find(p => p.id === process.env.TENKI_PROJECT_ID) ?? workspace?.projects[0];
-  if (!workspace || !project) {
-    throw new Error('No Tenki workspace/project visible for this API key');
-  }
-
-  return tenki.createAndWait({
-    name: 'composio-local-sandbox',
-    workspaceId: workspace.id,
-    projectId: project.id,
-    // The helper calls Composio's backend from inside the guest.
-    allowOutbound: true,
-    // SECURITY: this env contains your Composio *project* API key. Anything
-    // running in the sandbox can read it — treat the sandbox as your trust
-    // boundary and rotate the key if a run could have leaked it.
-    env,
-  });
-}
-
 async function main() {
   for (const name of ['COMPOSIO_API_KEY', 'TENKI_API_KEY']) {
     if (!process.env[name]) {
@@ -94,6 +69,10 @@ async function main() {
   const session = await composio.sessions.create('default', {
     toolkits: ['hackernews'], // no OAuth needed, so the example runs as-is
     sandbox: { enable: false }, // code execution happens in OUR box instead
+    // `mcp: true` only affects the *type* of the returned session (the hosted
+    // MCP endpoint exists at runtime either way); it yields the full `Session`
+    // that experimental_createLocalWorkbenchSession expects.
+    mcp: true,
   });
   console.log(`✅ Session: ${session.sessionId}`);
 
@@ -101,36 +80,43 @@ async function main() {
   const { helperSource, env } = await experimental_createLocalWorkbenchSession(composio, session);
 
   console.log('🚀 Booting a Tenki microVM...');
-  const tenki = new TenkiSandbox(); // reads TENKI_API_KEY from the environment
   const startedAt = Date.now();
-  const microVm = await createTenkiMicroVm(tenki, env);
+  const sandbox = await createTenkiSandbox({
+    apiKey: process.env.TENKI_API_KEY!,
+    timeoutMs: 120_000, // creation + readiness budget; failed boots are terminated
+    maxDurationMs: 15 * 60_000, // backstop if this host dies before teardown()
+    remoteDir: '/home/tenki/composio',
+    helperSource,
+    // SECURITY: this env contains your Composio *project* API key and is
+    // passed to the process running in the sandbox. Anything running there
+    // can read it — treat the sandbox as your trust boundary and rotate the
+    // key if a run could have leaked it.
+    env,
+    workspaceId: process.env.TENKI_WORKSPACE_ID,
+    projectId: process.env.TENKI_PROJECT_ID,
+  });
   console.log(`✅ microVM ready in ${((Date.now() - startedAt) / 1000).toFixed(1)}s`);
 
   try {
-    const python = await microVm.exec('bash', { args: ['-lc', 'command -v python3'] });
-    if (python.exitCode !== 0) {
-      throw new Error('python3 not found in the guest image; pick an image that ships Python 3');
-    }
-
-    console.log('📄 Injecting composio_helper.py and the agent script...');
-    await microVm.writeFile(`${GUEST_HOME}/composio_helper.py`, helperSource);
-    await microVm.writeFile(`${GUEST_HOME}/agent.py`, AGENT_SCRIPT);
+    console.log('📄 Injecting the agent script...');
+    await sandbox.writeFile(`${sandbox.remoteDir}/agent.py`, AGENT_SCRIPT);
 
     console.log('🤖 Running the agent inside the microVM...\n');
-    const result = await microVm.exec('python3', {
-      args: [`${GUEST_HOME}/agent.py`],
+    await sandbox.run(`cd ${sandbox.remoteDir} && python3 agent.py`, {
       timeoutMs: 120_000,
-      onOutput: chunk => process.stdout.write(chunk.data),
+      env: sandbox.env,
+      onStdout: chunk => process.stdout.write(chunk),
+      onStderr: chunk => process.stderr.write(chunk),
     });
-    if (result.exitCode !== 0) {
-      throw new Error(`agent exited with code ${result.exitCode}`);
-    }
 
     console.log('\n✅ Done. Tool execution ran inside your microVM;');
     console.log('   auth and tool discovery stayed managed by Composio.');
+  } catch (error) {
+    console.error(`❌ Agent run failed: ${commandErrorText(error)}`);
+    process.exitCode = 1;
   } finally {
     console.log('🧹 Terminating the microVM...');
-    await microVm.close();
+    await sandbox.teardown();
   }
 }
 

--- a/ts/examples/local-sandbox-tenki/src/index.ts
+++ b/ts/examples/local-sandbox-tenki/src/index.ts
@@ -1,0 +1,140 @@
+/**
+ * Local Sandbox on Tenki Example
+ *
+ * Composio's local sandbox lets you run tool-calling code inside a sandbox
+ * *you* own, while Composio keeps managed auth and tool discovery. This
+ * example uses Tenki (https://tenki.cloud) as that sandbox: a disposable
+ * Linux microVM that boots in ~2 seconds and is destroyed at the end.
+ *
+ * Flow:
+ *   1. Create a Composio session with the remote sandbox disabled
+ *   2. Get the local-workbench pieces: a Python helper + the env it needs
+ *   3. Boot a Tenki microVM with that env, inject the helper
+ *   4. Run agent code inside the guest — it calls Composio tools through
+ *      the helper, so execution stays inside your security boundary
+ *   5. Terminate the microVM
+ *
+ * Prerequisites:
+ *   - COMPOSIO_API_KEY (https://app.composio.dev)
+ *   - TENKI_API_KEY    (https://app.tenki.cloud)
+ *
+ * Docs:
+ *   - https://docs.composio.dev/docs/sandbox/local
+ *   - https://tenki.cloud/docs/sandbox/sdk
+ */
+import { Composio } from '@composio/core';
+import { experimental_createLocalWorkbenchSession } from '@composio/experimental/workbench';
+import { TenkiSandbox } from '@tenkicloud/sandbox';
+import 'dotenv/config';
+
+const GUEST_HOME = '/home/tenki';
+
+/**
+ * Agent code that runs *inside* the Tenki microVM. The injected
+ * composio_helper.py is the only Composio-specific thing the guest carries:
+ * tool calls route back through the Tool Router session created by the host,
+ * so auth and discovery stay managed while execution happens in your box.
+ */
+const AGENT_SCRIPT = `"""Agent code running inside the Tenki microVM."""
+import json
+import platform
+
+from composio_helper import run_composio_tool
+
+print(f"[guest] hello from {platform.node()} ({platform.system()} {platform.release()})")
+print("[guest] calling HACKERNEWS_GET_USER through the Composio Tool Router...")
+
+response, error = run_composio_tool("HACKERNEWS_GET_USER", {"username": "pg"})
+if error:
+    raise SystemExit(f"[guest] tool call failed: {error}")
+
+print("[guest] tool response:")
+print(json.dumps(response, indent=2))
+`;
+
+/**
+ * Boot a Tenki microVM. Session creation needs a project; discover one from
+ * the API key's identity (override with TENKI_WORKSPACE_ID / TENKI_PROJECT_ID).
+ */
+async function createTenkiMicroVm(tenki: TenkiSandbox, env: Record<string, string>) {
+  const identity = await tenki.whoAmI();
+  const workspace =
+    identity.workspaces.find(ws => ws.id === process.env.TENKI_WORKSPACE_ID) ??
+    identity.workspaces[0];
+  const project =
+    workspace?.projects.find(p => p.id === process.env.TENKI_PROJECT_ID) ?? workspace?.projects[0];
+  if (!workspace || !project) {
+    throw new Error('No Tenki workspace/project visible for this API key');
+  }
+
+  return tenki.createAndWait({
+    name: 'composio-local-sandbox',
+    workspaceId: workspace.id,
+    projectId: project.id,
+    // The helper calls Composio's backend from inside the guest.
+    allowOutbound: true,
+    // SECURITY: this env contains your Composio *project* API key. Anything
+    // running in the sandbox can read it — treat the sandbox as your trust
+    // boundary and rotate the key if a run could have leaked it.
+    env,
+  });
+}
+
+async function main() {
+  for (const name of ['COMPOSIO_API_KEY', 'TENKI_API_KEY']) {
+    if (!process.env[name]) {
+      console.error(`❌ Missing ${name}. Copy .env.example to .env and fill it in.`);
+      process.exit(1);
+    }
+  }
+
+  const composio = new Composio({ apiKey: process.env.COMPOSIO_API_KEY });
+
+  console.log('🚀 Creating a Composio session with the remote sandbox disabled...');
+  const session = await composio.sessions.create('default', {
+    toolkits: ['hackernews'], // no OAuth needed, so the example runs as-is
+    sandbox: { enable: false }, // code execution happens in OUR box instead
+  });
+  console.log(`✅ Session: ${session.sessionId}`);
+
+  // The two pieces you run yourself: a Python helper (source) + its env.
+  const { helperSource, env } = await experimental_createLocalWorkbenchSession(composio, session);
+
+  console.log('🚀 Booting a Tenki microVM...');
+  const tenki = new TenkiSandbox(); // reads TENKI_API_KEY from the environment
+  const startedAt = Date.now();
+  const microVm = await createTenkiMicroVm(tenki, env);
+  console.log(`✅ microVM ready in ${((Date.now() - startedAt) / 1000).toFixed(1)}s`);
+
+  try {
+    const python = await microVm.exec('bash', { args: ['-lc', 'command -v python3'] });
+    if (python.exitCode !== 0) {
+      throw new Error('python3 not found in the guest image; pick an image that ships Python 3');
+    }
+
+    console.log('📄 Injecting composio_helper.py and the agent script...');
+    await microVm.writeFile(`${GUEST_HOME}/composio_helper.py`, helperSource);
+    await microVm.writeFile(`${GUEST_HOME}/agent.py`, AGENT_SCRIPT);
+
+    console.log('🤖 Running the agent inside the microVM...\n');
+    const result = await microVm.exec('python3', {
+      args: [`${GUEST_HOME}/agent.py`],
+      timeoutMs: 120_000,
+      onOutput: chunk => process.stdout.write(chunk.data),
+    });
+    if (result.exitCode !== 0) {
+      throw new Error(`agent exited with code ${result.exitCode}`);
+    }
+
+    console.log('\n✅ Done. Tool execution ran inside your microVM;');
+    console.log('   auth and tool discovery stayed managed by Composio.');
+  } finally {
+    console.log('🧹 Terminating the microVM...');
+    await microVm.close();
+  }
+}
+
+main().catch(error => {
+  console.error('❌ Error running example:', error);
+  process.exit(1);
+});

--- a/ts/examples/local-sandbox-tenki/src/index.ts
+++ b/ts/examples/local-sandbox-tenki/src/index.ts
@@ -92,8 +92,6 @@ async function main() {
     // can read it — treat the sandbox as your trust boundary and rotate the
     // key if a run could have leaked it.
     env,
-    workspaceId: process.env.TENKI_WORKSPACE_ID,
-    projectId: process.env.TENKI_PROJECT_ID,
   });
   console.log(`✅ microVM ready in ${((Date.now() - startedAt) / 1000).toFixed(1)}s`);
 

--- a/ts/examples/local-sandbox-tenki/src/sandbox/tenki.ts
+++ b/ts/examples/local-sandbox-tenki/src/sandbox/tenki.ts
@@ -72,13 +72,30 @@ export async function createTenkiSandbox(options: SandboxOptions): Promise<UserS
   const tenki = new TenkiSandbox({ authToken: options.apiKey });
 
   // Session creation requires a project; resolve one from the key's identity.
+  // Pinned ids must match exactly — a mistyped id fails loudly instead of
+  // silently booting the microVM in whatever workspace/project comes first.
   const identity = await tenki.whoAmI();
-  const workspace =
-    identity.workspaces.find(ws => ws.id === options.workspaceId) ?? identity.workspaces[0];
-  const project =
-    workspace?.projects.find(p => p.id === options.projectId) ?? workspace?.projects[0];
-  if (!workspace || !project) {
-    throw new Error('No Tenki workspace/project visible for this API key');
+  const workspace = options.workspaceId
+    ? identity.workspaces.find(ws => ws.id === options.workspaceId)
+    : identity.workspaces[0];
+  if (!workspace) {
+    throw new Error(
+      options.workspaceId
+        ? `Tenki workspace ${options.workspaceId} not visible to this API key ` +
+            `(visible: ${identity.workspaces.map(ws => ws.id).join(', ') || 'none'})`
+        : 'No Tenki workspace visible to this API key'
+    );
+  }
+  const project = options.projectId
+    ? workspace.projects.find(p => p.id === options.projectId)
+    : workspace.projects[0];
+  if (!project) {
+    throw new Error(
+      options.projectId
+        ? `Tenki project ${options.projectId} not found in workspace "${workspace.name}" ` +
+            `(visible: ${workspace.projects.map(p => p.id).join(', ') || 'none'})`
+        : `No Tenki project visible in workspace "${workspace.name}"`
+    );
   }
 
   // Failure-atomic boot: take the session handle *before* waiting for

--- a/ts/examples/local-sandbox-tenki/src/sandbox/tenki.ts
+++ b/ts/examples/local-sandbox-tenki/src/sandbox/tenki.ts
@@ -27,9 +27,6 @@ export interface SandboxOptions {
   remoteDir: string;
   helperSource: string;
   env: Record<string, string>;
-  /** Optional pins; default to the first workspace/project visible to the API key. */
-  workspaceId?: string;
-  projectId?: string;
 }
 
 export interface UserSandbox {
@@ -71,40 +68,11 @@ export function commandErrorText(error: unknown): string {
 export async function createTenkiSandbox(options: SandboxOptions): Promise<UserSandbox> {
   const tenki = new TenkiSandbox({ authToken: options.apiKey });
 
-  // Session creation requires a project; resolve one from the key's identity.
-  // Pinned ids must match exactly — a mistyped id fails loudly instead of
-  // silently booting the microVM in whatever workspace/project comes first.
-  const identity = await tenki.whoAmI();
-  const workspace = options.workspaceId
-    ? identity.workspaces.find(ws => ws.id === options.workspaceId)
-    : identity.workspaces[0];
-  if (!workspace) {
-    throw new Error(
-      options.workspaceId
-        ? `Tenki workspace ${options.workspaceId} not visible to this API key ` +
-            `(visible: ${identity.workspaces.map(ws => ws.id).join(', ') || 'none'})`
-        : 'No Tenki workspace visible to this API key'
-    );
-  }
-  const project = options.projectId
-    ? workspace.projects.find(p => p.id === options.projectId)
-    : workspace.projects[0];
-  if (!project) {
-    throw new Error(
-      options.projectId
-        ? `Tenki project ${options.projectId} not found in workspace "${workspace.name}" ` +
-            `(visible: ${workspace.projects.map(p => p.id).join(', ') || 'none'})`
-        : `No Tenki project visible in workspace "${workspace.name}"`
-    );
-  }
-
   // Failure-atomic boot: take the session handle *before* waiting for
   // readiness, so a failed or timed-out boot can still be terminated instead
   // of leaking a running microVM. `maxDurationMs` covers the host-crash case.
   const session = await tenki.create({
     name: 'composio-local-sandbox',
-    workspaceId: workspace.id,
-    projectId: project.id,
     allowOutbound: true, // the Composio helper calls the Tool Router from inside the guest
     maxDurationMs: options.maxDurationMs,
     waitReady: false,

--- a/ts/examples/local-sandbox-tenki/src/sandbox/tenki.ts
+++ b/ts/examples/local-sandbox-tenki/src/sandbox/tenki.ts
@@ -1,0 +1,166 @@
+import {
+  isReady,
+  isTerminal,
+  stderrText,
+  stdoutText,
+  TenkiSandbox,
+  type Session,
+} from '@tenkicloud/sandbox';
+
+/**
+ * Tenki implementation of the local-sandbox contract.
+ *
+ * The interfaces below (`SandboxOptions`, `UserSandbox`, `RunOptions`) mirror
+ * the canonical sandbox adapter from Composio's local-sandbox example, so this
+ * file is swappable with any other runner that honors the same contract. Tenki
+ * specifics never leak past this module.
+ */
+export interface SandboxOptions {
+  apiKey: string;
+  /** Budget for session creation + readiness. A boot that exceeds it is terminated. */
+  timeoutMs: number;
+  /**
+   * Hard backstop: the microVM self-terminates after this duration even if the
+   * host process crashes or is SIGKILLed before `teardown()` runs.
+   */
+  maxDurationMs: number;
+  remoteDir: string;
+  helperSource: string;
+  env: Record<string, string>;
+  /** Optional pins; default to the first workspace/project visible to the API key. */
+  workspaceId?: string;
+  projectId?: string;
+}
+
+export interface UserSandbox {
+  remoteDir: string;
+  env: Record<string, string>;
+  writeFile(path: string, contents: string): Promise<void>;
+  run(command: string, options?: RunOptions): Promise<void>;
+  teardown(): Promise<void>;
+}
+
+export interface RunOptions {
+  timeoutMs?: number;
+  env?: Record<string, string>;
+  onStdout?: (chunk: string) => void;
+  onStderr?: (chunk: string) => void;
+}
+
+type CommandError = {
+  result?: {
+    exitCode?: number;
+    stdout?: string;
+    stderr?: string;
+  };
+};
+
+export function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+export function commandErrorText(error: unknown): string {
+  const result = (error as CommandError).result;
+  if (result) {
+    const output = result.stderr || result.stdout || '';
+    return `exit ${result.exitCode ?? 'unknown'}\n${output.slice(-1200)}`;
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function createTenkiSandbox(options: SandboxOptions): Promise<UserSandbox> {
+  const tenki = new TenkiSandbox({ authToken: options.apiKey });
+
+  // Session creation requires a project; resolve one from the key's identity.
+  const identity = await tenki.whoAmI();
+  const workspace =
+    identity.workspaces.find(ws => ws.id === options.workspaceId) ?? identity.workspaces[0];
+  const project =
+    workspace?.projects.find(p => p.id === options.projectId) ?? workspace?.projects[0];
+  if (!workspace || !project) {
+    throw new Error('No Tenki workspace/project visible for this API key');
+  }
+
+  // Failure-atomic boot: take the session handle *before* waiting for
+  // readiness, so a failed or timed-out boot can still be terminated instead
+  // of leaking a running microVM. `maxDurationMs` covers the host-crash case.
+  const session = await tenki.create({
+    name: 'composio-local-sandbox',
+    workspaceId: workspace.id,
+    projectId: project.id,
+    allowOutbound: true, // the Composio helper calls the Tool Router from inside the guest
+    maxDurationMs: options.maxDurationMs,
+    waitReady: false,
+  });
+
+  try {
+    await waitUntilReady(session, options.timeoutMs);
+    await exec(session, `mkdir -p ${shellQuote(options.remoteDir)}`, { timeoutMs: 30_000 });
+    await session.writeFile(`${options.remoteDir}/composio_helper.py`, options.helperSource);
+  } catch (error) {
+    // Best-effort cleanup; never mask the original boot error.
+    await session.closeIfOpen().catch(() => {});
+    throw error;
+  }
+
+  return {
+    remoteDir: options.remoteDir,
+    env: options.env,
+    async writeFile(path, contents) {
+      await session.writeFile(path, contents);
+    },
+    async run(command, runOptions = {}) {
+      await exec(session, command, runOptions);
+    },
+    async teardown() {
+      await session.closeIfOpen();
+    },
+  };
+}
+
+/**
+ * Poll until the session accepts commands, using unary calls only.
+ * (`session.waitReady()` uses a server-streaming RPC that Bun's node:http2
+ * implementation closes prematurely; polling `refresh()` is runtime-agnostic.)
+ */
+async function waitUntilReady(session: Session, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    await session.refresh();
+    if (isReady(session.state)) return;
+    if (isTerminal(session.state)) {
+      throw new Error(`session entered terminal state ${session.state} while booting`);
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(`session not ready after ${timeoutMs}ms (state: ${session.state})`);
+    }
+    await new Promise(resolve => setTimeout(resolve, 500));
+  }
+}
+
+async function exec(session: Session, command: string, runOptions: RunOptions): Promise<void> {
+  const result = await session.exec('bash', {
+    args: ['-lc', command],
+    timeoutMs: runOptions.timeoutMs,
+    env: runOptions.env,
+    onOutput: output => {
+      const text = new TextDecoder().decode(output.data);
+      if (output.isStderr) {
+        runOptions.onStderr?.(text);
+      } else {
+        runOptions.onStdout?.(text);
+      }
+    },
+  });
+
+  if (result.exitCode !== 0) {
+    // Normalize into the same shape `commandErrorText` understands.
+    throw Object.assign(new Error(`command failed: ${command}`), {
+      result: {
+        exitCode: result.exitCode,
+        stdout: stdoutText(result),
+        stderr: stderrText(result),
+      },
+    } satisfies CommandError);
+  }
+}

--- a/ts/examples/local-sandbox-tenki/tsconfig.json
+++ b/ts/examples/local-sandbox-tenki/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "esnext",
+    "declaration": true,
+    "declarationDir": "./dist",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
<!-- PR title: docs(examples): add local sandbox on Tenki example -->

## Summary

Adds `ts/examples/local-sandbox-tenki`: a runnable TypeScript example that runs Composio's experimental **local sandbox** on a [Tenki](https://tenki.cloud) disposable Linux microVM.

The [local sandbox docs](https://docs.composio.dev/docs/sandbox/local) describe a small contract — create a session with the remote sandbox disabled, write the generated `composio_helper.py` into a box you own, pass the returned `env` to the process — and note the runtime is swappable. There is currently no in-repo runnable example for `@composio/experimental/workbench` / `experimental_createLocalWorkbenchSession`; this adds one, with Tenki as the runtime:

1. `composio.sessions.create(userId, { toolkits: ['hackernews'], sandbox: { enable: false }, mcp: true })`
2. `experimental_createLocalWorkbenchSession(composio, session)` → `helperSource` + `env`
3. `createTenkiSandbox(...)` boots a microVM behind a `UserSandbox` adapter (`writeFile` / `run` / `teardown`), interface-identical to the canonical local-sandbox example's E2B runner, so Tenki specifics never leak past `src/sandbox/tenki.ts`
4. Agent code inside the guest calls `run_composio_tool("HACKERNEWS_GET_USER", ...)` — execution stays inside the user's boundary while auth and discovery stay managed by Composio
5. `teardown()` terminates the microVM; boot is failure-atomic and a `maxDurationMs` backstop covers host crash/SIGKILL

The example needs no OAuth connection (HackerNews toolkit) and no LLM key — just `COMPOSIO_API_KEY` and `TENKI_API_KEY` — so it runs end-to-end as-is.

## Changes

- `ts/examples/local-sandbox-tenki/` — package.json, tsconfig.json, .env.example, README.md, `src/index.ts` (host orchestration), `src/sandbox/tenki.ts` (sandbox adapter); follows the `create:example` scaffold conventions
- `pnpm-lock.yaml` — new example workspace importer + `@tenkicloud/sandbox`

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [x] Documentation
- [ ] Breaking change

## How Has This Been Tested?

- `pnpm test:examples` — example-structure validation passes (21 packages)
- `tsc --noEmit` under the example's tsconfig — clean
- Prettier with the repo config — clean
- Live end-to-end run (Bun 1.3.10, `@tenkicloud/sandbox` 0.3.6): session created with the sandbox disabled → microVM booted in ~2–4s → helper injected → guest executed `HACKERNEWS_GET_USER` through the Tool Router and printed the live response → microVM terminated

To reproduce: `cd ts/examples/local-sandbox-tenki && cp .env.example .env` (fill `COMPOSIO_API_KEY` + `TENKI_API_KEY`, the latter from [app.tenki.cloud](https://app.tenki.cloud)) and `bun src/index.ts`.

## Screenshots (if applicable)

<details>
<summary>Example run output</summary>

```
🚀 Creating a Composio session with the remote sandbox disabled...
✅ Session: trs_...
🚀 Booting a Tenki microVM...
✅ microVM ready in 2.4s
📄 Injecting the agent script...
🤖 Running the agent inside the microVM...

[guest] hello from 019f61d4-... (Linux 6.18.29)
[guest] calling HACKERNEWS_GET_USER through the Composio Tool Router...
[guest] tool response:
{
  "data": { "about": "Bug fixer.", "karma": 157316, "username": "pg" },
  "error": null,
  "log_id": "log_..."
}

✅ Done. Tool execution ran inside your microVM;
   auth and tool discovery stayed managed by Composio.
🧹 Terminating the microVM...
```

</details>

## Checklist

- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed
- [x] I updated documentation as needed (the example ships its own README with setup, security notes, and the runtime-swap contract)
- [x] I added tests or explain why not applicable — example packages carry no unit tests by repo convention; covered by `pnpm test:examples` structure validation plus the live end-to-end run above
- [x] I added a changeset if this change affects published packages — not applicable: examples are `private: true`, nothing published changes

## Additional context

- The example was review-hardened before submission (internal review on the fork): Tenki is isolated behind the same `SandboxOptions`/`UserSandbox`/`RunOptions` contract as the canonical E2B runner including `commandErrorText` normalization; boot holds the session handle before readiness (`waitReady: false`) and terminates on failed boot instead of leaking a microVM.
- Implementation note: readiness is polled via unary `refresh()` + the SDK's `isReady`/`isTerminal` helpers rather than `session.waitReady()`, whose server-streaming RPC Bun's `node:http2` closes prematurely (`ERR_STREAM_PREMATURE_CLOSE`) — examples run under Bun.
- While fixing types we noticed the snippet in `docs/sandbox/local.mdx` creates its session without `{ mcp: true }`, so it returns `SessionWithoutMcp` and wouldn't typecheck against `experimental_createLocalWorkbenchSession`'s `Session` parameter. Happy to send a small follow-up PR widening that parameter (e.g., accepting `Omit<Session<...>, 'mcp'>`) if you'd take it.
- The README carries the same security callout as the local-sandbox docs: the injected `env` contains the project API key, so the sandbox is the trust boundary.
- Happy to adjust naming, example placement, or add a docs-site mention if you'd like one.
