### PR TITLE
fix(cli): stabilize multi-account selection

### DIFF
--- a/ts/packages/cli/CHANGELOG.md
+++ b/ts/packages/cli/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Patch Changes
 
+- Make multi-account selection a stable CLI feature: `execute`, `listen`, and `link --alias` no longer honor the old experimental toggle; `proxy` now accepts `--account <alias|word_id|connected-account-id>`; and duplicate-alias link errors explain how to select the existing account.
 - 8467efd: Fix `composio whoami` reporting the API key's home organization after `composio orgs switch`. Session info requests now forward the selected global organization.
 - 5f004ff: Drop `COMPOSIO_UPSERT_RECIPE` and `COMPOSIO_GET_RECIPE` from the CLI meta-tool list. These slugs were removed from `@composio/client` (alpha.74), so listing them broke the type-checked CLI build.
 - 23f9053: Remove the unused `ansis` dependency from the CLI. Colored output is already handled by `picocolors`, so `ansis` was a dead production dependency that shipped with the package.

--- a/ts/packages/cli/skills-src/composio-cli/index.ts
+++ b/ts/packages/cli/skills-src/composio-cli/index.ts
@@ -76,7 +76,6 @@ const commands: SkillCommand[] = [
         name: '`--account`',
         description:
           'Select which connected account to use by alias, word_id, or account id when multiple accounts exist for the same toolkit.',
-        features: [CLI_EXPERIMENTAL_FEATURES.MULTI_ACCOUNT],
       },
     ],
     examples: [
@@ -136,7 +135,6 @@ const commands: SkillCommand[] = [
         name: '`--alias`',
         description:
           'Assign an alias to the connected account. Required when creating an additional account for the same toolkit.',
-        features: [CLI_EXPERIMENTAL_FEATURES.MULTI_ACCOUNT],
       },
     ],
     notes: ['Retry the original `execute` command after linking succeeds.'],
@@ -169,7 +167,6 @@ const commands: SkillCommand[] = [
       {
         name: '`--account`',
         description: 'Select which connected account to use by alias, word_id, or account id.',
-        features: [CLI_EXPERIMENTAL_FEATURES.MULTI_ACCOUNT],
       },
     ],
     notes: [
@@ -183,7 +180,13 @@ const commands: SkillCommand[] = [
       'Use `proxy` when a toolkit supports a raw API operation that is easier than finding a dedicated tool slug.',
     examples: [
       {
-        code: 'composio proxy https://api.github.com/user --toolkit github --method GET </dev/null',
+        code: 'composio proxy https://api.github.com/user --toolkit github --account work --method GET </dev/null',
+      },
+    ],
+    flags: [
+      {
+        name: '`--account`',
+        description: 'Select which connected account to use by alias, word_id, or account id.',
       },
     ],
   },

--- a/ts/packages/cli/skills-src/composio-cli/reference-schema.ts
+++ b/ts/packages/cli/skills-src/composio-cli/reference-schema.ts
@@ -67,10 +67,6 @@ export const resolveSkillBuildContext = (
       CLI_EXPERIMENTAL_FEATURES.LOCAL_TOOLS,
       channel
     ),
-    [CLI_EXPERIMENTAL_FEATURES.MULTI_ACCOUNT]: isExperimentalFeatureEnabledByDefault(
-      CLI_EXPERIMENTAL_FEATURES.MULTI_ACCOUNT,
-      channel
-    ),
     ...overrides,
   },
 });

--- a/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
+++ b/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
@@ -337,18 +337,6 @@ const formatExistingAccountLabels = (
     })
     .join(', ');
 
-const isAliasConflictMessage = (message: string): boolean => {
-  const normalized = message.toLowerCase();
-  return (
-    normalized.includes('alias') &&
-    (normalized.includes('already') ||
-      normalized.includes('in use') ||
-      normalized.includes('exists') ||
-      normalized.includes('taken') ||
-      normalized.includes('duplicate'))
-  );
-};
-
 const showAliasConflictGuidance = (params: {
   readonly ui: TerminalUI;
   readonly alias: string;
@@ -362,6 +350,37 @@ const showAliasConflictGuidance = (params: {
     ].join('\n'),
     'Tips'
   );
+
+const ensureAliasIsAvailable = (params: {
+  readonly ui: TerminalUI;
+  readonly alias: Option.Option<string>;
+  readonly existingAccounts: ReadonlyArray<{
+    readonly id: string;
+    readonly alias?: string | null;
+  }>;
+  readonly executeCommand: string;
+  readonly listCommand: string;
+}) =>
+  Effect.gen(function* () {
+    if (Option.isNone(params.alias)) return true as const;
+
+    const normalizedAlias = params.alias.value.toLowerCase();
+    const existing = params.existingAccounts.find(
+      item => item.alias?.trim().toLowerCase() === normalizedAlias
+    );
+    if (!existing) return true as const;
+
+    yield* params.ui.log.error(
+      `Alias "${params.alias.value}" is already in use by connected account "${existing.id}".`
+    );
+    yield* showAliasConflictGuidance({
+      ui: params.ui,
+      alias: params.alias.value,
+      executeCommand: params.executeCommand,
+      listCommand: params.listCommand,
+    });
+    return false as const;
+  });
 
 const ensureAliasForAdditionalAccount = (params: {
   readonly ui: TerminalUI;
@@ -636,6 +655,15 @@ const handleLegacyAuthConfigLink = (params: {
       // failure must not abort the link flow.
       Effect.catchAll(() => Effect.succeed({ items: [] }))
     );
+    const aliasAvailable = yield* ensureAliasIsAvailable({
+      ui: params.ui,
+      alias: normalizedAlias,
+      existingAccounts: existingAccounts.items,
+      executeCommand: 'composio dev playground-execute',
+      listCommand: 'composio dev connected-accounts list',
+    });
+    if (!aliasAvailable) return;
+
     const linkOpt = yield* params.ui
       .withSpinner(
         'Creating link session...',
@@ -661,18 +689,9 @@ const handleLegacyAuthConfigLink = (params: {
               extractMessage(error) ??
               `Failed to create link for auth config "${params.authConfigId}".`;
             yield* params.ui.log.error(message);
-            if (Option.isSome(normalizedAlias) && isAliasConflictMessage(message)) {
-              yield* showAliasConflictGuidance({
-                ui: params.ui,
-                alias: normalizedAlias.value,
-                executeCommand: 'composio dev playground-execute',
-                listCommand: 'composio dev connected-accounts list',
-              });
-            } else {
-              yield* params.ui.log.step(
-                'Browse available auth configs:\n> composio dev auth-configs list'
-              );
-            }
+            yield* params.ui.log.step(
+              'Browse available auth configs:\n> composio dev auth-configs list'
+            );
             return Option.none();
           })
         )
@@ -836,6 +855,14 @@ const runConnectedAccountsLink = (params: {
       // failure must not abort the link flow.
       Effect.catchAll(() => Effect.succeed({ items: [] }))
     );
+    const aliasAvailable = yield* ensureAliasIsAvailable({
+      ui,
+      alias: normalizedAliasOption,
+      existingAccounts: existingAccounts.items,
+      executeCommand: 'composio execute',
+      listCommand: `composio connections list --toolkit ${toolkitSlug}`,
+    });
+    if (!aliasAvailable) return;
 
     const linkOpt = yield* ui
       .withSpinner(
@@ -882,16 +909,7 @@ const runConnectedAccountsLink = (params: {
               extractMessage(error) ?? `Failed to create link for toolkit "${toolkitSlug}".`;
             yield* ui.log.error(message);
             yield* Effect.logDebug('Link error:', error);
-            if (Option.isSome(normalizedAliasOption) && isAliasConflictMessage(message)) {
-              yield* showAliasConflictGuidance({
-                ui,
-                alias: normalizedAliasOption.value,
-                executeCommand: 'composio execute',
-                listCommand: `composio connections list --toolkit ${toolkitSlug}`,
-              });
-            } else {
-              yield* ui.log.step('Browse available toolkits:\n> composio dev toolkits list');
-            }
+            yield* ui.log.step('Browse available toolkits:\n> composio dev toolkits list');
             return Option.none();
           })
         ),

--- a/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
+++ b/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
@@ -23,8 +23,6 @@ import {
   groupCachedConnectedAccountsByToolkit,
   resolveDefaultConnectedAccountsByToolkit,
 } from 'src/services/connected-account-selection';
-import { ComposioCliUserConfig } from 'src/services/cli-user-config';
-import { CLI_EXPERIMENTAL_FEATURES } from 'src/constants';
 import { decodeConnectedAccountItemsWithFallback } from 'src/effects/decode-connected-account-list';
 
 class ConnectionPollingError extends Data.TaggedError('commands/ConnectionPollingError')<{
@@ -339,6 +337,32 @@ const formatExistingAccountLabels = (
     })
     .join(', ');
 
+const isAliasConflictMessage = (message: string): boolean => {
+  const normalized = message.toLowerCase();
+  return (
+    normalized.includes('alias') &&
+    (normalized.includes('already') ||
+      normalized.includes('in use') ||
+      normalized.includes('exists') ||
+      normalized.includes('taken') ||
+      normalized.includes('duplicate'))
+  );
+};
+
+const showAliasConflictGuidance = (params: {
+  readonly ui: TerminalUI;
+  readonly alias: string;
+  readonly executeCommand: string;
+  readonly listCommand: string;
+}) =>
+  params.ui.note(
+    [
+      `Use the existing alias: ${params.executeCommand} <TOOL_SLUG> --account ${params.alias} -d '{ ... }'`,
+      `List connected accounts: ${params.listCommand}`,
+    ].join('\n'),
+    'Tips'
+  );
+
 const ensureAliasForAdditionalAccount = (params: {
   readonly ui: TerminalUI;
   readonly alias: Option.Option<string>;
@@ -637,9 +661,18 @@ const handleLegacyAuthConfigLink = (params: {
               extractMessage(error) ??
               `Failed to create link for auth config "${params.authConfigId}".`;
             yield* params.ui.log.error(message);
-            yield* params.ui.log.step(
-              'Browse available auth configs:\n> composio dev auth-configs list'
-            );
+            if (Option.isSome(normalizedAlias) && isAliasConflictMessage(message)) {
+              yield* showAliasConflictGuidance({
+                ui: params.ui,
+                alias: normalizedAlias.value,
+                executeCommand: 'composio dev playground-execute',
+                listCommand: 'composio dev connected-accounts list',
+              });
+            } else {
+              yield* params.ui.log.step(
+                'Browse available auth configs:\n> composio dev auth-configs list'
+              );
+            }
             return Option.none();
           })
         )
@@ -702,13 +735,7 @@ const runConnectedAccountsLink = (params: {
   Effect.gen(function* () {
     if (!(yield* requireAuth)) return;
 
-    const cliConfig = yield* ComposioCliUserConfig;
-    const aliasOption = cliConfig.isExperimentalFeatureEnabled(
-      CLI_EXPERIMENTAL_FEATURES.MULTI_ACCOUNT
-    )
-      ? params.alias
-      : Option.none<string>();
-    const normalizedAliasOption = yield* resolveNormalizedAliasOption(aliasOption);
+    const normalizedAliasOption = yield* resolveNormalizedAliasOption(params.alias);
 
     const ui = yield* TerminalUI;
     const clientSingleton = yield* ComposioClientSingleton;
@@ -767,7 +794,7 @@ const runConnectedAccountsLink = (params: {
         projectName: params.projectName,
         noWait: params.noWait,
         noBrowser: params.noBrowser,
-        alias: aliasOption,
+        alias: params.alias,
         ui,
         clientSingleton,
         projectContext,
@@ -855,7 +882,16 @@ const runConnectedAccountsLink = (params: {
               extractMessage(error) ?? `Failed to create link for toolkit "${toolkitSlug}".`;
             yield* ui.log.error(message);
             yield* Effect.logDebug('Link error:', error);
-            yield* ui.log.step('Browse available toolkits:\n> composio dev toolkits list');
+            if (Option.isSome(normalizedAliasOption) && isAliasConflictMessage(message)) {
+              yield* showAliasConflictGuidance({
+                ui,
+                alias: normalizedAliasOption.value,
+                executeCommand: 'composio execute',
+                listCommand: `composio connections list --toolkit ${toolkitSlug}`,
+              });
+            } else {
+              yield* ui.log.step('Browse available toolkits:\n> composio dev toolkits list');
+            }
             return Option.none();
           })
         ),

--- a/ts/packages/cli/src/commands/listen.cmd.ts
+++ b/ts/packages/cli/src/commands/listen.cmd.ts
@@ -21,8 +21,6 @@ import {
 } from 'src/services/connected-account-selection';
 import { parseJsonRecord } from 'src/utils/parse-json';
 import { toolkitFromToolSlug } from 'src/utils/toolkit-from-tool-slug';
-import { ComposioCliUserConfig } from 'src/services/cli-user-config';
-import { CLI_EXPERIMENTAL_FEATURES } from 'src/constants';
 import { matchesTriggerListenFilters } from './triggers/filter';
 import { parseTriggerListenEvent } from './triggers/parse';
 import { decodeConnectedAccountItemsWithFallback } from 'src/effects/decode-connected-account-list';
@@ -462,12 +460,6 @@ export const listenCmd = Command.make(
         orgId: resolvedProject.orgId,
         projectId: resolvedProject.projectId,
       });
-      const cliConfig = yield* ComposioCliUserConfig;
-      const accountSelector = cliConfig.isExperimentalFeatureEnabled(
-        CLI_EXPERIMENTAL_FEATURES.MULTI_ACCOUNT
-      )
-        ? account
-        : Option.none<string>();
       const {
         listeningToProjectEvent,
         createParams,
@@ -482,7 +474,7 @@ export const listenCmd = Command.make(
         timeout,
         stream,
         maxEvents,
-        account: accountSelector,
+        account,
         client,
         resolvedProject,
       });

--- a/ts/packages/cli/src/commands/proxy.cmd.ts
+++ b/ts/packages/cli/src/commands/proxy.cmd.ts
@@ -1,6 +1,5 @@
 import { Args, Command, Options } from '@effect/cli';
 import { Data, Effect, Either, Option } from 'effect';
-import type { Composio } from '@composio/client';
 import type {
   SessionProxyExecuteParams,
   SessionProxyExecuteResponse,
@@ -23,10 +22,7 @@ import {
   mapComposioError,
 } from 'src/services/composio-error-overrides';
 import { parseJsonRecord } from 'src/utils/parse-json';
-import {
-  formatConnectedAccountChoices,
-  resolveConnectedAccountSelection,
-} from 'src/services/connected-account-selection';
+import { resolveConnectedAccountForToolkit } from 'src/services/connected-account-selection';
 
 const endpoint = Args.text({ name: 'url' }).pipe(
   Args.withDescription('Absolute or relative API endpoint to call through proxy execute.')
@@ -260,44 +256,6 @@ const runProxyConnectedToolkitFailFast = (params: {
     }
   });
 
-const resolveProxyConnectedAccount = (params: {
-  readonly client: Composio;
-  readonly toolkit: string;
-  readonly userId: string;
-  readonly selector: string;
-}) =>
-  Effect.gen(function* () {
-    const accounts = yield* Effect.tryPromise({
-      try: () =>
-        params.client.connectedAccounts.list({
-          toolkit_slugs: [params.toolkit],
-          user_ids: [params.userId],
-          statuses: ['ACTIVE'],
-          limit: 100,
-        }),
-      catch: error =>
-        new Error(
-          `Failed to load connected accounts for toolkit "${params.toolkit}": ${String(error)}`
-        ),
-    });
-    const items = accounts.items as Parameters<typeof resolveConnectedAccountSelection>[0];
-    const selected = resolveConnectedAccountSelection(items, params.selector);
-    if (selected) return selected.id;
-
-    const choices = formatConnectedAccountChoices(
-      accounts.items as Parameters<typeof formatConnectedAccountChoices>[0]
-    );
-    const hint =
-      choices.length > 0
-        ? ` Available accounts: ${choices.join(', ')}.`
-        : ' No active connected accounts were found for that toolkit.';
-    return yield* Effect.fail(
-      new Error(
-        `No connected account matched "${params.selector}" for toolkit "${params.toolkit}".${hint}`
-      )
-    );
-  });
-
 export const proxyCmd = Command.make('proxy', {
   endpoint,
   toolkit,
@@ -374,11 +332,11 @@ export const proxyCmd = Command.make('proxy', {
             projectId: resolvedProject.projectId,
           });
           const selectedConnectedAccountId = Option.isSome(account)
-            ? yield* resolveProxyConnectedAccount({
+            ? yield* resolveConnectedAccountForToolkit({
                 client,
-                toolkit: normalizedToolkit,
+                toolkitSlug: normalizedToolkit,
                 userId: consumerUserId,
-                selector: account.value,
+                selector: account,
               })
             : undefined;
           const { sessionId } = yield* resolveToolRouterSession(client, consumerUserId, {

--- a/ts/packages/cli/src/commands/proxy.cmd.ts
+++ b/ts/packages/cli/src/commands/proxy.cmd.ts
@@ -1,5 +1,6 @@
 import { Args, Command, Options } from '@effect/cli';
 import { Data, Effect, Either, Option } from 'effect';
+import type { Composio } from '@composio/client';
 import type {
   SessionProxyExecuteParams,
   SessionProxyExecuteResponse,
@@ -22,6 +23,10 @@ import {
   mapComposioError,
 } from 'src/services/composio-error-overrides';
 import { parseJsonRecord } from 'src/utils/parse-json';
+import {
+  formatConnectedAccountChoices,
+  resolveConnectedAccountSelection,
+} from 'src/services/connected-account-selection';
 
 const endpoint = Args.text({ name: 'url' }).pipe(
   Args.withDescription('Absolute or relative API endpoint to call through proxy execute.')
@@ -30,6 +35,13 @@ const endpoint = Args.text({ name: 'url' }).pipe(
 const toolkit = Options.text('toolkit').pipe(
   Options.withAlias('t'),
   Options.withDescription('Toolkit slug whose connected account should be used')
+);
+
+const account = Options.text('account').pipe(
+  Options.withDescription(
+    'Connected account selector. Matches alias, word_id, or connected account id for the toolkit.'
+  ),
+  Options.optional
 );
 
 const method = Options.text('method').pipe(
@@ -248,9 +260,48 @@ const runProxyConnectedToolkitFailFast = (params: {
     }
   });
 
+const resolveProxyConnectedAccount = (params: {
+  readonly client: Composio;
+  readonly toolkit: string;
+  readonly userId: string;
+  readonly selector: string;
+}) =>
+  Effect.gen(function* () {
+    const accounts = yield* Effect.tryPromise({
+      try: () =>
+        params.client.connectedAccounts.list({
+          toolkit_slugs: [params.toolkit],
+          user_ids: [params.userId],
+          statuses: ['ACTIVE'],
+          limit: 100,
+        }),
+      catch: error =>
+        new Error(
+          `Failed to load connected accounts for toolkit "${params.toolkit}": ${String(error)}`
+        ),
+    });
+    const items = accounts.items as Parameters<typeof resolveConnectedAccountSelection>[0];
+    const selected = resolveConnectedAccountSelection(items, params.selector);
+    if (selected) return selected.id;
+
+    const choices = formatConnectedAccountChoices(
+      accounts.items as Parameters<typeof formatConnectedAccountChoices>[0]
+    );
+    const hint =
+      choices.length > 0
+        ? ` Available accounts: ${choices.join(', ')}.`
+        : ' No active connected accounts were found for that toolkit.';
+    return yield* Effect.fail(
+      new Error(
+        `No connected account matched "${params.selector}" for toolkit "${params.toolkit}".${hint}`
+      )
+    );
+  });
+
 export const proxyCmd = Command.make('proxy', {
   endpoint,
   toolkit,
+  account,
   method,
   headers,
   data,
@@ -263,6 +314,7 @@ export const proxyCmd = Command.make('proxy', {
       '',
       'Examples:',
       '  composio proxy https://gmail.googleapis.com/gmail/v1/users/me/profile --toolkit gmail',
+      '  composio proxy https://gmail.googleapis.com/gmail/v1/users/me/profile --toolkit gmail --account work',
       `  composio proxy https://gmail.googleapis.com/gmail/v1/users/me/drafts --toolkit gmail \\`,
       `    -X POST -H 'content-type: application/json' -d '{"message":{"raw":"..."}}'`,
       '',
@@ -271,8 +323,9 @@ export const proxyCmd = Command.make('proxy', {
       '  composio run \'const f = await proxy("gmail"); ...\'   Use proxy in a script',
     ].join('\n')
   ),
-  Command.withHandler(({ endpoint, toolkit, method, headers, data, skipConnectionCheck }) =>
+  Command.withHandler(options =>
     Effect.gen(function* () {
+      const { endpoint, toolkit, account, method, headers, data, skipConnectionCheck } = options;
       if (!(yield* requireAuth)) return;
 
       const ui = yield* TerminalUI;
@@ -320,8 +373,19 @@ export const proxyCmd = Command.make('proxy', {
             orgId: resolvedProject.orgId,
             projectId: resolvedProject.projectId,
           });
+          const selectedConnectedAccountId = Option.isSome(account)
+            ? yield* resolveProxyConnectedAccount({
+                client,
+                toolkit: normalizedToolkit,
+                userId: consumerUserId,
+                selector: account.value,
+              })
+            : undefined;
           const { sessionId } = yield* resolveToolRouterSession(client, consumerUserId, {
             toolkits: [normalizedToolkit],
+            connectedAccounts: selectedConnectedAccountId
+              ? { [normalizedToolkit]: selectedConnectedAccountId }
+              : undefined,
             cacheScope: {
               orgId: resolvedProject.orgId,
               projectId: resolvedProject.projectId,

--- a/ts/packages/cli/src/commands/root-help.ts
+++ b/ts/packages/cli/src/commands/root-help.ts
@@ -49,7 +49,7 @@ const CORE_COMMANDS: ReadonlyArray<TaggedValue<DetailedCommand>> = [
     description:
       'Execute a tool. Validates inputs and connections automatically; use it aggressively.',
     usage:
-      'execute <slug> [-d, --data text] [--file path] [--dry-run] [--get-schema] | execute -p <slug> -d <text> <slug> -d <text> ...',
+      'execute <slug> [-d, --data text] [--account selector] [--file path] [--dry-run] [--get-schema] | execute -p <slug> -d <text> <slug> -d <text> ...',
     options: [
       { name: '<slug>', description: 'Tool slug (e.g. "GITHUB_CREATE_ISSUE")' },
       {
@@ -62,6 +62,10 @@ const CORE_COMMANDS: ReadonlyArray<TaggedValue<DetailedCommand>> = [
         description: 'Execute repeated <slug> -d <text> pairs concurrently',
       },
       {
+        name: '--account',
+        description: 'Select a connected account by alias, word_id, or account ID',
+      },
+      {
         name: '--file',
         description: 'Inject a local file path into the single file_uploadable input',
       },
@@ -72,8 +76,11 @@ const CORE_COMMANDS: ReadonlyArray<TaggedValue<DetailedCommand>> = [
   simple({
     name: 'link',
     description: 'Connect your account for a toolkit/app.',
-    usage: 'link [<toolkit>]',
-    options: [{ name: '<toolkit>', description: 'Toolkit slug to link (e.g. "github", "gmail")' }],
+    usage: 'link [<toolkit>] [--alias text]',
+    options: [
+      { name: '<toolkit>', description: 'Toolkit slug to link (e.g. "github", "gmail")' },
+      { name: '--alias', description: 'Alias for this connected account' },
+    ],
   }),
   tagged({
     name: 'run',
@@ -91,13 +98,17 @@ const CORE_COMMANDS: ReadonlyArray<TaggedValue<DetailedCommand>> = [
     description:
       'Create a temporary subscription for consumer-project events and persist each payload into the session artifact folder.',
     usage:
-      'listen <slug> [-p, --params text] [--max-events integer] [--timeout text] [--stream [text]]',
+      'listen <slug> [-p, --params text] [--account selector] [--max-events integer] [--timeout text] [--stream [text]]',
     options: [
       { name: '<slug>', description: 'Trigger slug (e.g. "GMAIL_NEW_GMAIL_MESSAGE")' },
       {
         name: '-p, --params',
         description:
           "Trigger create params as JSON or JS-style object, e.g. -p '{ trigger_config: { ... } }'.",
+      },
+      {
+        name: '--account',
+        description: 'Select a connected account by alias, word_id, or account ID',
       },
       {
         name: '--max-events',
@@ -119,10 +130,11 @@ const CORE_COMMANDS: ReadonlyArray<TaggedValue<DetailedCommand>> = [
     name: 'proxy',
     description:
       'curl-like access to any toolkit API through Composio using your connected account.',
-    usage: 'proxy <url> --toolkit text [-X method] [-H header]... [-d data]',
+    usage: 'proxy <url> --toolkit text [--account selector] [-X method] [-H header]... [-d data]',
     options: [
       { name: '<url>', description: 'Full API endpoint URL' },
       { name: '--toolkit', description: 'Toolkit slug whose connected account should be used' },
+      { name: '--account', description: 'Connected account alias, word_id, or account ID' },
       { name: '-X, --method', description: 'HTTP method (GET, POST, PUT, DELETE, PATCH)' },
       { name: '-H, --header', description: 'Header in "Name: value" format. Repeat for multiple.' },
       { name: '-d, --data', description: 'Request body as raw text, JSON, @file, or - for stdin' },
@@ -421,7 +433,7 @@ const SUBCOMMAND_HELP: Record<string, SubcommandHelp | TaggedValue<SubcommandHel
   },
   execute: {
     usage:
-      'composio execute <slug> [-d, --data text] [--file path] [--dry-run] [--get-schema] [--parallel]',
+      'composio execute <slug> [-d, --data text] [--account selector] [--file path] [--dry-run] [--get-schema] [--parallel]',
     description:
       'Execute a tool by slug. Validates inputs against cached schemas and checks connections automatically — just try it and it will tell you what to fix.',
     args: [
@@ -440,6 +452,10 @@ const SUBCOMMAND_HELP: Record<string, SubcommandHelp | TaggedValue<SubcommandHel
       {
         name: '-p, --parallel',
         description: 'Execute repeated TOOL_SLUG -d <text> groups concurrently',
+      },
+      {
+        name: '--account <selector>',
+        description: 'Select a connected account by alias, word_id, or connected account ID',
       },
       {
         name: '--file <path>',
@@ -466,8 +482,8 @@ const SUBCOMMAND_HELP: Record<string, SubcommandHelp | TaggedValue<SubcommandHel
       '# Send an email',
       `composio execute GMAIL_SEND_EMAIL -d '{ recipient_email: "a@b.com", subject: "Hello", body: "World" }'`,
       '',
-      '# Create a GitHub issue',
-      `composio execute GITHUB_CREATE_ISSUE -d '{ owner: "acme", repo: "app", title: "Bug report", body: "Steps to reproduce..." }'`,
+      '# Create a GitHub issue with a named account',
+      `composio execute GITHUB_CREATE_ISSUE --account work -d '{ owner: "acme", repo: "app", title: "Bug report", body: "Steps to reproduce..." }'`,
       '',
       '# Preview what a tool call would send without executing',
       `composio execute SLACK_SEND_A_MESSAGE_TO_A_SLACK_CHANNEL --dry-run -d '{ channel: "general", text: "Hello team" }'`,
@@ -490,7 +506,7 @@ const SUBCOMMAND_HELP: Record<string, SubcommandHelp | TaggedValue<SubcommandHel
   },
   listen: experimental(CLI_EXPERIMENTAL_FEATURES.LISTEN, {
     usage:
-      'composio listen <slug> [-p, --params text] [--max-events integer] [--timeout text] [--stream [text]]',
+      'composio listen <slug> [-p, --params text] [--account selector] [--max-events integer] [--timeout text] [--stream [text]]',
     description:
       'Create a temporary subscription for consumer-project events so background agents can easily consume new emails, Slack messages, and other trigger payloads from artifacts.',
     args: [{ name: '<slug>', description: 'Trigger slug to create and listen to' }],
@@ -499,6 +515,10 @@ const SUBCOMMAND_HELP: Record<string, SubcommandHelp | TaggedValue<SubcommandHel
         name: '-p, --params <text>',
         description:
           'Trigger create params as JSON/JS object, @file, or - for stdin. Pass optional trigger config fields only.',
+      },
+      {
+        name: '--account <selector>',
+        description: 'Select a connected account by alias, word_id, or connected account ID',
       },
       {
         name: '--max-events <integer>',
@@ -517,7 +537,7 @@ const SUBCOMMAND_HELP: Record<string, SubcommandHelp | TaggedValue<SubcommandHel
     examples: [
       'composio listen GMAIL_NEW_GMAIL_MESSAGE',
       'composio listen GMAIL_NEW_GMAIL_MESSAGE -p @trigger.json --max-events 5',
-      'composio listen GMAIL_NEW_GMAIL_MESSAGE --timeout 5m',
+      'composio listen GMAIL_NEW_GMAIL_MESSAGE --account work --timeout 5m',
       "composio listen GMAIL_NEW_GMAIL_MESSAGE --timeout 1hr --stream '.data.threadId'",
       'composio listen SLACK_RECEIVE_MESSAGE -p \'{ trigger_config: { channel: "C123" } }\'',
       'composio listen GMAIL_NEW_GMAIL_MESSAGE -p @trigger.json --stream',
@@ -538,7 +558,7 @@ const SUBCOMMAND_HELP: Record<string, SubcommandHelp | TaggedValue<SubcommandHel
       {
         name: '--alias <text>',
         description:
-          'Alias for the connected account. Required when creating an additional account for the same toolkit (requires multi_account experimental feature)',
+          'Alias for the connected account. Required when creating an additional account for the same toolkit',
       },
     ],
     flags: [
@@ -563,8 +583,8 @@ const SUBCOMMAND_HELP: Record<string, SubcommandHelp | TaggedValue<SubcommandHel
     ],
     seeAlso: [
       'composio search "<query>"               Find tools to use after linking',
-      "composio execute <slug> -d '{ ... }'    Execute a tool with your connected account",
-      'composio config experimental             Manage experimental features',
+      "composio execute <slug> --account <alias> -d '{ ... }'   Use a named account",
+      'composio connections list --toolkit <toolkit>              List account selectors',
     ],
   },
   'connections list': {
@@ -800,7 +820,8 @@ const SUBCOMMAND_HELP: Record<string, SubcommandHelp | TaggedValue<SubcommandHel
     ],
   },
   proxy: {
-    usage: 'composio proxy <url> --toolkit <text> [-X method] [-H header]... [-d data]',
+    usage:
+      'composio proxy <url> --toolkit <text> [--account <selector>] [-X method] [-H header]... [-d data]',
     description:
       'curl-like access to any toolkit API through Composio using your connected account. Composio handles authentication — just provide the full URL and toolkit.',
     args: [{ name: '<url>', description: 'Full API endpoint URL' }],
@@ -808,6 +829,10 @@ const SUBCOMMAND_HELP: Record<string, SubcommandHelp | TaggedValue<SubcommandHel
       {
         name: '-t, --toolkit <text>',
         description: 'Toolkit slug whose connected account should be used',
+      },
+      {
+        name: '--account <selector>',
+        description: 'Select a connected account by alias, word_id, or connected account ID',
       },
       { name: '-X, --method <text>', description: 'HTTP method (GET, POST, PUT, DELETE, PATCH)' },
       {
@@ -821,7 +846,7 @@ const SUBCOMMAND_HELP: Record<string, SubcommandHelp | TaggedValue<SubcommandHel
     ],
     flags: [{ name: '--skip-connection-check', description: 'Skip the connected-account check' }],
     examples: [
-      'composio proxy https://gmail.googleapis.com/gmail/v1/users/me/profile --toolkit gmail',
+      'composio proxy https://gmail.googleapis.com/gmail/v1/users/me/profile --toolkit gmail --account work',
       `composio proxy https://gmail.googleapis.com/gmail/v1/users/me/drafts --toolkit gmail \\`,
       `  -X POST -H 'content-type: application/json' -d '{"message":{"raw":"..."}}'`,
     ],
@@ -1259,14 +1284,13 @@ const SUBCOMMAND_HELP: Record<string, SubcommandHelp | TaggedValue<SubcommandHel
     usage: 'composio config experimental [<feature>] [on|off]',
     description: 'View or toggle experimental feature flags.',
     args: [
-      { name: '<feature>', description: 'Feature name (e.g., listen, local_tools, multi_account)' },
+      { name: '<feature>', description: 'Feature name (e.g., listen, local_tools)' },
       { name: 'on|off', description: 'Enable or disable the feature' },
     ],
     examples: [
       'composio config experimental                     # List all features',
       'composio config experimental listen              # Show current state',
       'composio config experimental local_tools on      # Enable local toolkits',
-      'composio config experimental multi_account on    # Enable multi_account',
     ],
   },
   'dev logs triggers': {

--- a/ts/packages/cli/src/commands/tools/commands/tools.execute.cmd.ts
+++ b/ts/packages/cli/src/commands/tools/commands/tools.execute.cmd.ts
@@ -1114,17 +1114,12 @@ const resolveExecuteContext = (params: RunToolsExecuteParams) =>
       orgId: resolvedProject.orgId,
       projectId: resolvedProject.projectId,
     });
-    const accountSelector = cliConfig.isExperimentalFeatureEnabled(
-      CLI_EXPERIMENTAL_FEATURES.MULTI_ACCOUNT
-    )
-      ? params.account
-      : Option.none<string>();
     const toolkitSlug = isLocalToolSlug(params.slug) ? undefined : toolkitFromToolSlug(params.slug);
     const selectedConnectedAccountId = yield* resolveExplicitConnectedAccount({
       client,
       toolkitSlug,
       userId: resolvedUserId.value,
-      selector: accountSelector,
+      selector: params.account,
     });
     const args = Option.isSome(params.file)
       ? yield* getOrFetchToolInputDefinition(params.slug, {

--- a/ts/packages/cli/src/commands/tools/commands/tools.execute.cmd.ts
+++ b/ts/packages/cli/src/commands/tools/commands/tools.execute.cmd.ts
@@ -1,5 +1,4 @@
 import { Args, Command, HelpDoc, Options, ValidationError } from '@effect/cli';
-import type { Composio } from '@composio/client';
 import { isLocalToolSlug } from '@composio/cli-local-tools';
 import util from 'node:util';
 import { Cause, Data, Effect, Either, Exit, Fiber, HashSet, Option, Predicate } from 'effect';
@@ -49,10 +48,7 @@ import {
   getFreshConsumerConnectedToolkitsFromCache,
   refreshConsumerConnectedToolkitsCache,
 } from 'src/services/consumer-short-term-cache';
-import {
-  formatConnectedAccountChoices,
-  resolveConnectedAccountSelection,
-} from 'src/services/connected-account-selection';
+import { resolveConnectedAccountForToolkit } from 'src/services/connected-account-selection';
 import {
   appendCliSessionHistory,
   resolveCliSessionArtifacts,
@@ -67,7 +63,6 @@ import {
 import * as constants from 'src/constants';
 import { ComposioCliUserConfig } from 'src/services/cli-user-config';
 import { CLI_EXPERIMENTAL_FEATURES } from 'src/constants';
-import { decodeConnectedAccountItemsWithFallback } from 'src/effects/decode-connected-account-list';
 
 const slug = Args.text({ name: 'slug' }).pipe(
   Args.withDescription('Tool slug (e.g. "GITHUB_CREATE_ISSUE")')
@@ -968,69 +963,6 @@ const emitCachedSchema = (
     );
   });
 
-const resolveExplicitConnectedAccount = (params: {
-  readonly client: Composio;
-  readonly toolkitSlug?: string;
-  readonly userId: string;
-  readonly selector: Option.Option<string>;
-}) =>
-  Effect.gen(function* () {
-    if (!params.toolkitSlug) return undefined;
-    const toolkitSlug = params.toolkitSlug;
-
-    const accounts = yield* Effect.tryPromise({
-      try: () =>
-        params.client.connectedAccounts.list({
-          toolkit_slugs: [toolkitSlug],
-          user_ids: [params.userId],
-          statuses: ['ACTIVE'],
-          limit: 100,
-        }),
-      catch: cause =>
-        new ToolExecutionError({
-          reason: 'connected_account',
-          toolSlug: params.toolkitSlug,
-          message: `Failed to load connected accounts for toolkit "${toolkitSlug}": ${String(cause)}`,
-          cause,
-        }),
-    });
-    const selectableAccounts = yield* decodeConnectedAccountItemsWithFallback(accounts.items).pipe(
-      Effect.mapError(
-        cause =>
-          new ToolExecutionError({
-            reason: 'connected_account',
-            toolSlug: toolkitSlug,
-            message: `Connected accounts for toolkit "${toolkitSlug}" did not match the expected response shape.`,
-            cause,
-          })
-      )
-    );
-
-    const selected = resolveConnectedAccountSelection(
-      selectableAccounts,
-      Option.getOrUndefined(params.selector)
-    );
-
-    if (selected) {
-      return selected.id;
-    }
-
-    if (Option.isNone(params.selector)) {
-      return undefined;
-    }
-
-    const choices = formatConnectedAccountChoices(selectableAccounts);
-    const hint =
-      choices.length > 0
-        ? ` Available accounts: ${choices.join(', ')}.`
-        : ' No active connected accounts were found for that toolkit.';
-    return yield* new ToolExecutionError({
-      reason: 'connected_account',
-      toolSlug: toolkitSlug,
-      message: `No connected account matched "${params.selector.value}" for toolkit "${toolkitSlug}".${hint}`,
-    });
-  });
-
 const resolveExecuteContext = (params: RunToolsExecuteParams) =>
   Effect.gen(function* () {
     const ui = yield* TerminalUI;
@@ -1115,7 +1047,7 @@ const resolveExecuteContext = (params: RunToolsExecuteParams) =>
       projectId: resolvedProject.projectId,
     });
     const toolkitSlug = isLocalToolSlug(params.slug) ? undefined : toolkitFromToolSlug(params.slug);
-    const selectedConnectedAccountId = yield* resolveExplicitConnectedAccount({
+    const selectedConnectedAccountId = yield* resolveConnectedAccountForToolkit({
       client,
       toolkitSlug,
       userId: resolvedUserId.value,

--- a/ts/packages/cli/src/experimental-features.ts
+++ b/ts/packages/cli/src/experimental-features.ts
@@ -8,7 +8,6 @@
 export const CLI_EXPERIMENTAL_FEATURES = {
   LISTEN: 'listen',
   LOCAL_TOOLS: 'local_tools',
-  MULTI_ACCOUNT: 'multi_account',
 } as const;
 
 export const CLI_RELEASE_CHANNELS = ['stable', 'beta'] as const;
@@ -23,8 +22,6 @@ export const isExperimentalFeatureEnabledByDefault = (
   channel: CliReleaseChannel
 ) => {
   switch (feature) {
-    case CLI_EXPERIMENTAL_FEATURES.MULTI_ACCOUNT:
-      return true;
     case CLI_EXPERIMENTAL_FEATURES.LISTEN:
     case CLI_EXPERIMENTAL_FEATURES.LOCAL_TOOLS:
       return channel === 'beta';

--- a/ts/packages/cli/src/services/connected-account-selection.ts
+++ b/ts/packages/cli/src/services/connected-account-selection.ts
@@ -1,5 +1,8 @@
+import type { Composio } from '@composio/client';
+import { Data, Effect, Option, Schema } from 'effect';
 import type { ConnectedAccountItem } from 'src/models/connected-accounts';
-import { Schema } from 'effect';
+import { decodeConnectedAccountItemsWithFallback } from 'src/effects/decode-connected-account-list';
+import type { TerminalUI } from 'src/services/terminal-ui';
 
 // `ConnectedAccountItem` widened with an `'UNKNOWN'` sentinel for statuses
 // the closed schema doesn't yet know about. Selection only picks `'ACTIVE'`,
@@ -134,3 +137,65 @@ export const formatConnectedAccountChoices = (
   items: ReadonlyArray<ConnectedAccountItem>
 ): ReadonlyArray<string> =>
   items.filter(isUsableConnectedAccount).sort(compareNewestFirst).map(formatConnectedAccountChoice);
+
+export class ConnectedAccountResolutionError extends Data.TaggedError(
+  'services/ConnectedAccountResolutionError'
+)<{
+  readonly message: string;
+  readonly toolkitSlug: string;
+  readonly cause?: unknown;
+}> {}
+
+export const resolveConnectedAccountForToolkit = (params: {
+  readonly client: Composio;
+  readonly toolkitSlug?: string;
+  readonly userId: string;
+  readonly selector: Option.Option<string>;
+}): Effect.Effect<string | undefined, ConnectedAccountResolutionError, TerminalUI> =>
+  Effect.gen(function* () {
+    if (!params.toolkitSlug) return undefined;
+    const toolkitSlug = params.toolkitSlug;
+
+    const accounts = yield* Effect.tryPromise({
+      try: () =>
+        params.client.connectedAccounts.list({
+          toolkit_slugs: [toolkitSlug],
+          user_ids: [params.userId],
+          statuses: ['ACTIVE'],
+          limit: 100,
+        }),
+      catch: cause =>
+        new ConnectedAccountResolutionError({
+          message: `Failed to load connected accounts for toolkit "${toolkitSlug}": ${String(cause)}`,
+          toolkitSlug,
+          cause,
+        }),
+    });
+    const selectableAccounts = yield* decodeConnectedAccountItemsWithFallback(accounts.items).pipe(
+      Effect.mapError(
+        cause =>
+          new ConnectedAccountResolutionError({
+            message: `Connected accounts for toolkit "${toolkitSlug}" did not match the expected response shape.`,
+            toolkitSlug,
+            cause,
+          })
+      )
+    );
+
+    const selected = resolveConnectedAccountSelection(
+      selectableAccounts,
+      Option.getOrUndefined(params.selector)
+    );
+    if (selected) return selected.id;
+    if (Option.isNone(params.selector)) return undefined;
+
+    const choices = formatConnectedAccountChoices(selectableAccounts);
+    const hint =
+      choices.length > 0
+        ? ` Available accounts: ${choices.join(', ')}.`
+        : ' No active connected accounts were found for that toolkit.';
+    return yield* new ConnectedAccountResolutionError({
+      message: `No connected account matched "${params.selector.value}" for toolkit "${toolkitSlug}".${hint}`,
+      toolkitSlug,
+    });
+  });

--- a/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.link.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.link.cmd.test.ts
@@ -495,10 +495,8 @@ describe('CLI: composio dev connected-accounts link', () => {
       fixture: 'global-test-user-id',
     })
   )('[Given] a duplicate alias [Then] link explains how to use the existing account', it => {
-    it.scoped('prints account-selection recovery commands for the API error', () =>
+    it.scoped('detects the exact existing alias before creating a link', () =>
       Effect.gen(function* () {
-        toolRouterLinkSpy.mockRejectedValueOnce(new Error('Alias "work" is already in use'));
-
         yield* cli(['link', 'gmail', '--alias', 'work']);
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
         const output = lines.join('\n');
@@ -506,8 +504,8 @@ describe('CLI: composio dev connected-accounts link', () => {
         expect(output).toContain('Alias "work" is already in use');
         expect(output).toContain('composio execute <TOOL_SLUG> --account work');
         expect(output).toContain('composio connections list --toolkit gmail');
-        expect(toolRouterCreateSpy).toHaveBeenCalled();
-        expect(toolRouterLinkSpy).toHaveBeenCalled();
+        expect(toolRouterCreateSpy).not.toHaveBeenCalled();
+        expect(toolRouterLinkSpy).not.toHaveBeenCalled();
       })
     );
   });

--- a/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.link.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.link.cmd.test.ts
@@ -424,6 +424,7 @@ describe('CLI: composio dev connected-accounts link', () => {
       connectedAccountsData: makeConnectedAccountsData({
         items: [makeConnectedAccount({ status: 'INITIATED' })],
       }),
+      cliUserConfig: { experimentalFeatures: { multi_account: false } },
       toolRouter: {
         create: toolRouterCreateSpy,
         link: toolRouterLinkSpy,
@@ -483,4 +484,31 @@ describe('CLI: composio dev connected-accounts link', () => {
       );
     }
   );
+
+  layer(
+    TestLive({
+      baseConfigProvider: testConfigProvider,
+      connectedAccountsData: makeConnectedAccountsData({
+        items: [makeConnectedAccount({ alias: 'work' })],
+      }),
+      toolRouter: { create: toolRouterCreateSpy, link: toolRouterLinkSpy },
+      fixture: 'global-test-user-id',
+    })
+  )('[Given] a duplicate alias [Then] link explains how to use the existing account', it => {
+    it.scoped('prints account-selection recovery commands for the API error', () =>
+      Effect.gen(function* () {
+        toolRouterLinkSpy.mockRejectedValueOnce(new Error('Alias "work" is already in use'));
+
+        yield* cli(['link', 'gmail', '--alias', 'work']);
+        const lines = yield* MockConsole.getLines({ stripAnsi: true });
+        const output = lines.join('\n');
+
+        expect(output).toContain('Alias "work" is already in use');
+        expect(output).toContain('composio execute <TOOL_SLUG> --account work');
+        expect(output).toContain('composio connections list --toolkit gmail');
+        expect(toolRouterCreateSpy).toHaveBeenCalled();
+        expect(toolRouterLinkSpy).toHaveBeenCalled();
+      })
+    );
+  });
 });

--- a/ts/packages/cli/test/src/commands/feature-visibility.test.ts
+++ b/ts/packages/cli/test/src/commands/feature-visibility.test.ts
@@ -59,6 +59,14 @@ describe('CLI experimental feature visibility', () => {
     expect(getCommandHelpText('local-tools', betaVisibility)).toContain('composio local-tools');
   });
 
+  it('shows stable account selection for execute and proxy', () => {
+    expect(getCommandHelpText('execute', stableVisibility)).toContain('--account <selector>');
+    expect(getCommandHelpText('proxy', stableVisibility)).toContain('--account <selector>');
+    expect(getCommandHelpText('link', stableVisibility)).not.toContain(
+      'multi_account experimental feature'
+    );
+  });
+
   it('accepts help mode suffixes when matching subcommand help', () => {
     expect(
       matchSubcommandHelp(['bun', 'composio', 'search', '--help', 'simple'], stableVisibility)

--- a/ts/packages/cli/test/src/commands/proxy.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/proxy.cmd.test.ts
@@ -56,6 +56,49 @@ describe('CLI: composio proxy', () => {
           const live = TestLive({
             baseConfigProvider: testConfigProvider,
             fixture: 'global-test-user-id',
+            cliUserConfig: { experimentalFeatures: { multi_account: false } },
+            connectedAccountsData: {
+              items: [
+                {
+                  id: 'con_gmail_work',
+                  alias: 'work',
+                  word_id: 'gmail-work',
+                  status: 'ACTIVE',
+                  status_reason: null,
+                  is_disabled: false,
+                  user_id: 'consumer-user-org_test',
+                  toolkit: { slug: 'gmail' },
+                  auth_config: {
+                    id: 'ac_gmail_oauth',
+                    auth_scheme: 'OAUTH2',
+                    is_composio_managed: true,
+                    is_disabled: false,
+                  },
+                  created_at: '2026-01-01T00:00:00.000Z',
+                  updated_at: '2026-01-01T00:00:00.000Z',
+                  test_request_endpoint: '',
+                },
+                {
+                  id: 'con_gmail_personal',
+                  alias: 'personal',
+                  word_id: 'gmail-personal',
+                  status: 'ACTIVE',
+                  status_reason: null,
+                  is_disabled: false,
+                  user_id: 'consumer-user-org_test',
+                  toolkit: { slug: 'gmail' },
+                  auth_config: {
+                    id: 'ac_gmail_oauth',
+                    auth_scheme: 'OAUTH2',
+                    is_composio_managed: true,
+                    is_disabled: false,
+                  },
+                  created_at: '2026-01-02T00:00:00.000Z',
+                  updated_at: '2026-01-02T00:00:00.000Z',
+                  test_request_endpoint: '',
+                },
+              ],
+            },
             toolRouter: {
               create: async (params: SessionCreateParams) => {
                 createParams = params;
@@ -92,6 +135,8 @@ describe('CLI: composio proxy', () => {
             'https://gmail.googleapis.com/gmail/v1/users/me/drafts',
             '--toolkit',
             'gmail',
+            '--account',
+            'work',
             '-X',
             'post',
             '-H',
@@ -102,6 +147,7 @@ describe('CLI: composio proxy', () => {
 
           expect(createParams).toEqual({
             user_id: 'consumer-user-org_test',
+            connected_accounts: { gmail: 'con_gmail_work' },
             manage_connections: { enable: false },
             toolkits: { enable: ['gmail'] },
           });

--- a/ts/packages/cli/test/src/commands/tools/tools.execute.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/tools/tools.execute.cmd.test.ts
@@ -18,6 +18,7 @@ import {
   parseParallelExecuteArgs,
   showToolsExecuteInputHelp,
 } from 'src/commands/tools/commands/tools.execute.cmd';
+import { ComposioCliUserConfig } from 'src/services/cli-user-config';
 import type { ToolkitDetailed } from 'src/models/toolkits';
 
 const testConfigProvider = ConfigProvider.fromMap(
@@ -389,8 +390,13 @@ describe('CLI: composio execute', () => {
       },
     })
   )('[Given] --account selector [Then] execute pins the matched connected account', it => {
-    it.scoped('matches by alias, word_id, or id', () =>
+    it.scoped('matches even when a stale config disables the former experiment', () =>
       Effect.gen(function* () {
+        const cliConfig = yield* ComposioCliUserConfig;
+        yield* cliConfig.update({
+          experimentalFeatures: { multi_account: false },
+        });
+
         yield* cli([
           'execute',
           'GMAIL_SEND_EMAIL',
@@ -1964,10 +1970,11 @@ describe('CLI: composio execute', () => {
 
         expect(output).toContain('USAGE');
         expect(output).toContain(
-          'composio execute <slug> [-d, --data text] [--file path] [--dry-run] [--get-schema] [--parallel]'
+          'composio execute <slug> [-d, --data text] [--account selector] [--file path] [--dry-run] [--get-schema] [--parallel]'
         );
         expect(output).toContain('composio execute GMAIL_SEND_EMAIL --get-schema');
         expect(output).toContain('--parallel');
+        expect(output).toContain('--account <selector>');
         expect(output).toContain('GITHUB_CREATE_AN_ISSUE');
       })
     );

--- a/ts/packages/cli/test/src/services/cli-user-config.test.ts
+++ b/ts/packages/cli/test/src/services/cli-user-config.test.ts
@@ -34,8 +34,6 @@ describe('ComposioCliUserConfig', () => {
       assertEquals(config.data.developerDangerousCommandsEnabled, false);
       assertEquals(config.data.experimentalFeatures.listen, undefined);
       assertEquals(config.isExperimentalFeatureEnabled('listen'), false);
-      assertEquals(config.data.experimentalFeatures.multi_account, undefined);
-      assertEquals(config.isExperimentalFeatureEnabled('multi_account'), true);
       assertEquals(config.data.experimentalSubagentTarget, 'auto');
       assertEquals(config.data.artifactDirectory, undefined);
 
@@ -86,8 +84,6 @@ describe('ComposioCliUserConfig', () => {
       assertEquals(config.data.developerDangerousCommandsEnabled, false);
       assertEquals(config.data.experimentalFeatures.listen, undefined);
       assertEquals(config.isExperimentalFeatureEnabled('listen'), true);
-      assertEquals(config.data.experimentalFeatures.multi_account, undefined);
-      assertEquals(config.isExperimentalFeatureEnabled('multi_account'), true);
       assertEquals(config.data.experimentalSubagentTarget, 'auto');
     }).pipe(Effect.provide(CliUserConfigTest));
   });

--- a/ts/packages/cli/test/src/skills/composio-cli/reference-schema.test.ts
+++ b/ts/packages/cli/test/src/skills/composio-cli/reference-schema.test.ts
@@ -3,10 +3,10 @@ import { CLI_EXPERIMENTAL_FEATURES } from 'src/experimental-features';
 import { resolveSkillBuildContext } from '../../../../skills-src/composio-cli/reference-schema';
 
 describe('composio-cli skill build context', () => {
-  it('enables multi-account guidance in stable builds', () => {
+  it('keeps only genuinely experimental guidance disabled in stable builds', () => {
     const build = resolveSkillBuildContext('stable');
 
-    expect(build.experimentalFeatures[CLI_EXPERIMENTAL_FEATURES.MULTI_ACCOUNT]).toBe(true);
     expect(build.experimentalFeatures[CLI_EXPERIMENTAL_FEATURES.LISTEN]).toBe(false);
+    expect(build.experimentalFeatures[CLI_EXPERIMENTAL_FEATURES.LOCAL_TOOLS]).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- promote CLI multi-account selection out of the experimental feature system so stale `multi_account: false` config can no longer disable `execute --account`, `listen --account`, or `link --alias`
- add `proxy --account <alias|word_id|connected-account-id>` and pin the resolved connected account into the Tool Router session
- expose account selection consistently in command help and the generated `composio-cli` skill
- make duplicate-alias link errors explain how to select and inspect the existing account

## Root cause
Multi-account selection was introduced behind `multi_account` in #3129. #3163 enabled it by default for stable builds, but the command implementations still consulted the experimental setting and the custom help surface still omitted the selector. That left stale or explicit `multi_account: false` config able to disable selection even though the feature was intended to be stable. `proxy` never received equivalent account-selection wiring.

This is an incomplete graduation of the feature rather than a recent code regression. Existing implicit/default account selection behavior remains unchanged; this PR does **not** require explicit selection.

Closes #3894.

## Tests
- `vitest run` in `ts/packages/cli`: **84 files passed, 785 tests passed, 1 skipped**
- focused proxy/link/help regression suite: **26 tests passed**
- CLI source and test typechecks via `tsgo --noEmit`: passed
- `tsx ./scripts/validate-skills.ts`: passed for stable and beta builds
- Prettier and `git diff --check`: passed

## Notes
- No changeset: `@composio/cli` is excluded from Changesets; the CLI changelog is updated directly.
- No VHS recording: this is a narrow selector-wiring/help regression covered by command-level tests and requires a real multi-account fixture to demo safely.
- The root Turbo typecheck entrypoint could not run in this worktree because the local environment does not have `mise` on `PATH`; the directly equivalent CLI source/test `tsgo` checks passed.

- GitHub CI: queued/pending at PR creation; no background CI watch started per workspace policy.
