### PR TITLE
security: fix 3 CodeQL alerts (2026-07-22)

### DIFF
--- a/.changeset/fix-workerd-slash-trim-redos.md
+++ b/.changeset/fix-workerd-slash-trim-redos.md
@@ -1,0 +1,5 @@
+---
+'@composio/core': patch
+---
+
+Replace the backtracking leading/trailing-slash-trim regexes in the Cloudflare Workers/Edge platform path helpers with index-walk loops, closing a polynomial-time regular expression denial-of-service (CodeQL js/polynomial-redos) on long runs of slash characters. Output is unchanged for every input.

--- a/ts/packages/core/src/platform/workerd.ts
+++ b/ts/packages/core/src/platform/workerd.ts
@@ -1,5 +1,32 @@
 import type { Platform, Uint8ArrayEncoding } from './types';
 
+const SLASH_CHAR_CODE = 47; // '/'
+
+/**
+ * Trailing-slash trim without a regex. The equivalent pattern backtracks
+ * quadratically on long runs of slashes (CodeQL js/polynomial-redos), so this
+ * walks the string from the end instead. Returns the input unchanged when
+ * there is nothing to trim, so the common case allocates nothing.
+ */
+const trimTrailingSlashes = (value: string): string => {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === SLASH_CHAR_CODE) end--;
+  return end === value.length ? value : value.slice(0, end);
+};
+
+/**
+ * Leading-and-trailing slash trim without a regex, matching the semantics of
+ * the previous leading/trailing slash-trim replace for every input, including
+ * a string that is entirely slashes.
+ */
+const trimSurroundingSlashes = (value: string): string => {
+  let start = 0;
+  let end = value.length;
+  while (start < end && value.charCodeAt(start) === SLASH_CHAR_CODE) start++;
+  while (end > start && value.charCodeAt(end - 1) === SLASH_CHAR_CODE) end--;
+  return start === 0 && end === value.length ? value : value.slice(start, end);
+};
+
 /**
  * Cloudflare Workers / Edge runtime platform implementation.
  * Provides stub implementations for file system operations that are unavailable in edge runtimes.
@@ -18,9 +45,9 @@ export const platform: Platform = {
     return paths
       .map((segment, index) => {
         if (index === 0) {
-          return segment.replace(/\/+$/, '');
+          return trimTrailingSlashes(segment);
         }
-        return segment.replace(/^\/+|\/+$/g, '');
+        return trimSurroundingSlashes(segment);
       })
       .filter(Boolean)
       .join('/');
@@ -40,7 +67,7 @@ export const platform: Platform = {
 
   basename(filePath: string): string {
     // Simple basename extraction without Node.js path module
-    const segments = filePath.replace(/\/+$/, '').split('/');
+    const segments = trimTrailingSlashes(filePath).split('/');
     return segments[segments.length - 1] || '';
   },
 

--- a/ts/packages/core/test/platform/workerd.test.ts
+++ b/ts/packages/core/test/platform/workerd.test.ts
@@ -1,0 +1,96 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { platform } from '../../src/platform/workerd';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const WORKERD_SOURCE = path.resolve(__dirname, '../../src/platform/workerd.ts');
+
+/**
+ * Byte-for-byte copies of the regex logic that shipped before the
+ * js/polynomial-redos fix. The rewritten implementation must agree with these
+ * on every input, so behavior is pinned without asserting on timing.
+ */
+const referenceJoinPath = (...paths: string[]): string =>
+  paths
+    .map((segment, index) =>
+      index === 0 ? segment.replace(/\/+$/, '') : segment.replace(/^\/+|\/+$/g, '')
+    )
+    .filter(Boolean)
+    .join('/');
+
+const referenceBasename = (filePath: string): string => {
+  const segments = filePath.replace(/\/+$/, '').split('/');
+  return segments[segments.length - 1] || '';
+};
+
+const CASES = [
+  '',
+  '/',
+  '//',
+  '///',
+  'a',
+  '/a',
+  'a/',
+  '/a/',
+  '//a//',
+  'a/b',
+  '/a/b/',
+  'a//b',
+  '.',
+  '..',
+  './a',
+  'foo.txt',
+  '/tmp/foo.txt',
+  'tmp//',
+  '//tmp//foo.txt//',
+  ' ',
+  '/ /',
+  '/'.repeat(64),
+  `${'/'.repeat(32)}a${'/'.repeat(32)}`,
+];
+
+describe('workerd platform path helpers (js/polynomial-redos regression)', () => {
+  it('basename matches the pre-fix regex implementation for every input', () => {
+    for (const input of CASES) {
+      expect(platform.basename(input)).toBe(referenceBasename(input));
+    }
+  });
+
+  it('joinPath matches the pre-fix regex implementation for single segments', () => {
+    for (const input of CASES) {
+      expect(platform.joinPath(input)).toBe(referenceJoinPath(input));
+    }
+  });
+
+  it('joinPath matches the pre-fix regex implementation for every segment pair', () => {
+    for (const first of CASES) {
+      for (const second of CASES) {
+        expect(platform.joinPath(first, second)).toBe(referenceJoinPath(first, second));
+      }
+    }
+  });
+
+  it('joinPath matches the pre-fix regex implementation for three segments', () => {
+    for (const middle of CASES) {
+      expect(platform.joinPath('/base', middle, 'leaf.txt')).toBe(
+        referenceJoinPath('/base', middle, 'leaf.txt')
+      );
+    }
+  });
+
+  it('returns the documented result for long runs of slashes', () => {
+    const allSlashes = '/'.repeat(50_000);
+    expect(platform.basename(allSlashes)).toBe('');
+    expect(platform.joinPath(allSlashes)).toBe('');
+    expect(platform.joinPath(allSlashes, `${allSlashes}name.txt${allSlashes}`)).toBe('name.txt');
+  });
+
+  it('rejects the backtracking slash regexes at the source level', () => {
+    const source = readFileSync(WORKERD_SOURCE, 'utf8');
+    const withoutReferenceComment = source;
+    expect(withoutReferenceComment).not.toContain(String.raw`/\/+$/`);
+    expect(withoutReferenceComment).not.toContain(String.raw`/^\/+|\/+$/g`);
+  });
+});

--- a/ts/packages/core/test/platform/workerd.test.ts
+++ b/ts/packages/core/test/platform/workerd.test.ts
@@ -89,8 +89,11 @@ describe('workerd platform path helpers (js/polynomial-redos regression)', () =>
 
   it('rejects the backtracking slash regexes at the source level', () => {
     const source = readFileSync(WORKERD_SOURCE, 'utf8');
-    const withoutReferenceComment = source;
-    expect(withoutReferenceComment).not.toContain(String.raw`/\/+$/`);
-    expect(withoutReferenceComment).not.toContain(String.raw`/^\/+|\/+$/g`);
+    // This scans the raw file text, including comments, so quoting either
+    // pattern in a comment (e.g. to describe the old regex) would also fail
+    // this assertion. That's intentional: it's the only way to catch a silent
+    // revert to the regex form.
+    expect(source).not.toContain(String.raw`/\/+$/`);
+    expect(source).not.toContain(String.raw`/^\/+|\/+$/g`);
   });
 });

--- a/ts/packages/core/test/platform/workerd.test.ts
+++ b/ts/packages/core/test/platform/workerd.test.ts
@@ -87,13 +87,17 @@ describe('workerd platform path helpers (js/polynomial-redos regression)', () =>
     expect(platform.joinPath(allSlashes, `${allSlashes}name.txt${allSlashes}`)).toBe('name.txt');
   });
 
-  it('rejects the backtracking slash regexes at the source level', () => {
+  it('rejects backtracking-prone slash-trim regexes at the source level', () => {
     const source = readFileSync(WORKERD_SOURCE, 'utf8');
-    // This scans the raw file text, including comments, so quoting either
-    // pattern in a comment (e.g. to describe the old regex) would also fail
-    // this assertion. That's intentional: it's the only way to catch a silent
-    // revert to the regex form.
-    expect(source).not.toContain(String.raw`/\/+$/`);
-    expect(source).not.toContain(String.raw`/^\/+|\/+$/g`);
+    // Matches an escaped slash immediately followed by a `+`/`*` or a
+    // `{n,m}` quantifier -- the shape that backtracks quadratically on long
+    // slash runs, regardless of exact spelling or whitespace. This catches
+    // not just the original `/\/+$/` and `/^\/+|\/+$/g` literals but
+    // reformatted equivalents like `/\/{1,}$/` or `new RegExp('\\/+$')`.
+    // Scans raw file text, including comments, so quoting a vulnerable
+    // pattern in a comment would also fail this assertion -- intentional,
+    // since that's the only way to catch a silent revert to the regex form.
+    const VULNERABLE_SLASH_QUANTIFIER = /\\\/(?:[+*]|\{\d*,?\d*\})/;
+    expect(source).not.toMatch(VULNERABLE_SLASH_QUANTIFIER);
   });
 });


### PR DESCRIPTION
## Summary

Automated weekly CodeQL remediation run for 2026-07-22. Closes three `js/polynomial-redos` code scanning alerts (all severity high) in the Cloudflare Workers / Edge platform shim.

`ts/packages/core/src/platform/workerd.ts` implements the `Platform` interface for edge runtimes, where Node's `path` module is unavailable, so path joining and basename extraction were done with regexes. Three of those regexes (`/\/+$/` twice, `/^\/+|\/+$/g` once) backtrack quadratically on long runs of `/`, so a path segment made of many slashes turns a trim into a hang. They are replaced with index-walk helpers that scan character codes, which is linear and allocates nothing when the string is already trimmed.

Output is unchanged for every input. Equivalence was verified exhaustively over all 137,257 strings of length 6 or less drawn from `{'/', 'a', '\n', '\r', '.', ' ', '\\'}`, plus 300k randomized multi-segment `joinPath` compositions and a Unicode surrogate spot check, with zero mismatches against the original regexes. The `\n` and `\r` cases matter because JavaScript `$` without the `m` flag anchors to end of input only, so `/\/+$/` must not trim `"a/\n"`; the index walk agrees.

All 15 open alerts on `next` were triaged. 3 are fixed here, 12 are skipped with a recommended disposition for a human to action. Details below.

## Changes

- `ts/packages/core/src/platform/workerd.ts`: add module private `trimTrailingSlashes` and `trimSurroundingSlashes`, use them in `joinPath` and `basename`. No export surface change, no `Platform` interface change, no other platform implementation touched.
- `ts/packages/core/test/platform/workerd.test.ts`: new behavior pinning test file.
- `.changeset/fix-workerd-slash-trim-redos.md`: patch bump for `@composio/core`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [ ] Documentation
- [ ] Breaking change

## Fixed

| Alert | Rule | Severity | File | Fix | Test that proves it |
|---|---|---|---|---|---|
| [#55](https://github.com/ComposioHQ/composio/security/code-scanning/55) | `js/polynomial-redos` | High | `ts/packages/core/src/platform/workerd.ts:21` | `joinPath` first segment: `/\/+$/` replaced with `trimTrailingSlashes` | `joinPath matches the pre-fix regex implementation for single segments` |
| [#56](https://github.com/ComposioHQ/composio/security/code-scanning/56) | `js/polynomial-redos` | High | `ts/packages/core/src/platform/workerd.ts:23` | `joinPath` later segments: `/^\/+\|\/+$/g` replaced with `trimSurroundingSlashes` | `joinPath matches the pre-fix regex implementation for every segment pair` |
| [#57](https://github.com/ComposioHQ/composio/security/code-scanning/57) | `js/polynomial-redos` | High | `ts/packages/core/src/platform/workerd.ts:43` | `basename`: `/\/+$/` replaced with `trimTrailingSlashes` | `basename matches the pre-fix regex implementation for every input` |

On test design: the equivalence tests compare the new implementation against a copy of the pre-fix regex logic, so they pin behavior but pass in both states by construction. The test that is actually red before the fix and green after is `rejects the backtracking slash regexes at the source level`, which asserts the two vulnerable patterns are absent from `workerd.ts`. That is what would catch a silent revert to the regex form. A timing based "pathological input completes within N ms" test was deliberately not written, because it is flaky in CI.

## Skipped

Twelve alerts were read and deliberately not fixed. None were dismissed via the API; that decision is yours.

### Test only code, recommend `dismiss: used in tests`

**[#47](https://github.com/ComposioHQ/composio/security/code-scanning/47)** `py/incomplete-url-substring-sanitization`, High, `python/tests/test_files.py:2518`. The flagged line is `assert "example.com" in sanitized`, a pytest assertion checking that a logging redaction helper preserved the host. It is not a URL authorization check.

```
gh api -X PATCH /repos/ComposioHQ/composio/code-scanning/alerts/47 \
  -f state=dismissed -f dismissed_reason="used in tests" \
  -f dismissed_comment="Substring check is a pytest assertion on a log-redaction helper, not an authorization check. codeql-autofix 2026-07-22, PR #3909"
```

**[#54](https://github.com/ComposioHQ/composio/security/code-scanning/54)** `js/incomplete-sanitization`, High, `ts/packages/core/test/models/verifyWebhook.integration.test.ts:339`. `fixture.payload.replace('{', '{ ')` deliberately corrupts a payload so the test can assert webhook verification fails on whitespace change. It is the opposite of a sanitizer.

```
gh api -X PATCH /repos/ComposioHQ/composio/code-scanning/alerts/54 \
  -f state=dismissed -f dismissed_reason="used in tests" \
  -f dismissed_comment="Deliberate payload corruption in a negative webhook-verification test, not a sanitizer. codeql-autofix 2026-07-22, PR #3909"
```

### False positive, recommend `dismiss: false positive`

**[#105](https://github.com/ComposioHQ/composio/security/code-scanning/105)** and **[#106](https://github.com/ComposioHQ/composio/security/code-scanning/106)** `js/prototype-polluting-assignment`, Medium, `ts/packages/core/src/utils/jsonSchema.ts:255-256`.

The flagged statements are `delete out.$defs` and `delete out.definitions`. Both use hardcoded literal keys, never attacker controlled. `out` can never alias `Object.prototype`: every return path in `walk()` constructs a fresh object via `Object.fromEntries` or object spread, except the primitive passthrough at line 197, which cannot return `Object.prototype` because the top level call is seeded with a value already checked by `isPlainObject`. Two upstream guards further block the flow CodeQL believes exists: `cloneChildren` filters `POLLUTING_KEYS` (`__proto__`, `constructor`, `prototype`) at line 171, and `tryStep` gates property access with `Object.prototype.hasOwnProperty.call` at line 91. CodeQL cannot see through that guard because it is wrapped in a tagged union return.

```
gh api -X PATCH /repos/ComposioHQ/composio/code-scanning/alerts/105 \
  -f state=dismissed -f dismissed_reason="false positive" \
  -f dismissed_comment="delete uses a literal key and out is always a freshly constructed object; POLLUTING_KEYS filter and hasOwnProperty guard block the modeled flow. codeql-autofix 2026-07-22, PR #3909"
```

```
gh api -X PATCH /repos/ComposioHQ/composio/code-scanning/alerts/106 \
  -f state=dismissed -f dismissed_reason="false positive" \
  -f dismissed_comment="Same flow as alert 105, on delete out.definitions. codeql-autofix 2026-07-22, PR #3909"
```

### Needs a decision, recommend `keep open`

These are not obviously wrong, but the correct fix changes generated or rendered output, which is a product decision rather than an automated one. They are left open on purpose.

| Alert | Rule | File | Why it needs a human |
|---|---|---|---|
| [#48](https://github.com/ComposioHQ/composio/security/code-scanning/48) | `js/incomplete-sanitization` | `docs/app/llms.mdx/[[...slug]]/route.ts:626` | The only runtime site in this group. Escapes `\|` for a markdown table cell without escaping backslash first, so a description containing `\|` can break out of the cell. Impact is table formatting in an LLM facing docs endpoint, not injection into a code sink. Fixing it changes rendered docs output, and this file is outside the `@composio/core` test baseline used for this run. |
| [#49](https://github.com/ComposioHQ/composio/security/code-scanning/49) | `js/incomplete-sanitization` | `docs/scripts/generate-meta-tools.ts:176` | Escapes `"` into YAML frontmatter without escaping backslash first. Build time, first party tool metadata. Backslash first escaping changes generated docs. |
| [#50](https://github.com/ComposioHQ/composio/security/code-scanning/50) | `js/incomplete-sanitization` | `ts/packages/core/scripts/generate-docs.ts:1008` | `escapeTextForMdx`, same class. Build time only. |
| [#51](https://github.com/ComposioHQ/composio/security/code-scanning/51) | `js/incomplete-sanitization` | `ts/packages/core/scripts/generate-docs.ts:1008` | Second instance on the same chain as #50. |
| [#88](https://github.com/ComposioHQ/composio/security/code-scanning/88) | `js/incomplete-sanitization` | `docs/scripts/generate-meta-tools.ts:134` | Markdown table escaping of `\|` over first party metadata. |
| [#89](https://github.com/ComposioHQ/composio/security/code-scanning/89) | `js/incomplete-sanitization` | `docs/scripts/generate-meta-tools.ts:136` | Same as #88 on the fallback description branch. |
| [#90](https://github.com/ComposioHQ/composio/security/code-scanning/90) | `js/incomplete-multi-character-sanitization` | `docs/agent/lib/docs.ts:232` | `toCleanMarkdown` strips JSX and HTML tags in a single pass, so `<<div>div>` leaves `<div>`. It cleans MDX for LLM context and its output is never rendered as HTML, so it is not a security sanitizer. Duplicated verbatim in #92. |
| [#92](https://github.com/ComposioHQ/composio/security/code-scanning/92) | `js/incomplete-multi-character-sanitization` | `docs/scripts/build-agent-index.ts:155` | Verbatim duplicate of the `toCleanMarkdown` helper in #90. If one is addressed, both should be, ideally by extracting the shared helper. |

## Scanning config recommendations

Six of the twelve skips (#49, #50, #51, #88, #89, #92) share one root cause: CodeQL scans build and docs generation scripts, and flags string escaping over first party metadata that never crosses a trust boundary at runtime.

This repo uses CodeQL **default setup** (`analysis_key` is `dynamic/github-code-scanning/codeql:analyze`, and there is no committed CodeQL workflow), so `paths-ignore` is not available. The two options are to migrate to advanced setup with a committed workflow so `paths-ignore` can exclude these directories, or to bulk dismiss the alerts individually.

**Recommendation: do neither blindly, and do not add `paths-ignore` for `**/scripts/**`.** These are real findings in real code, just low priority ones over trusted input. Excluding the directory would also blind the scanner to genuine future vulnerabilities in build tooling, which is where supply chain problems tend to live. The better path is a single follow up PR that fixes the escaping properly, escaping backslash before the other characters, with the generated output diff reviewed as part of that PR. If the team decides the churn is not worth it, dismissing each as `won't fix` with that justification is the honest alternative, and it keeps future scanning intact.

## How Has This Been Tested?

```
pnpm --filter "@composio/core^..." run build   # build workspace deps once
pnpm --filter @composio/core run test
pnpm --filter @composio/core run typecheck
```

- Pre-fix baseline on clean `next` at `2f63fe540`: **44 test files, 1034 tests, 0 failures.**
- On this branch: **45 test files, 1040 tests, 0 failures.** That is the baseline plus this PR's 6 new tests.
- Typecheck: clean.
- There were no pre-existing failures, so nothing here is masking one.

Toolchain note for reproduction: the workspace `preinstall` hook requires `mise`, and `@composio/json-schema-to-zod` must be built before the `@composio/core` suite will resolve its imports. Without that build, 9 test files fail with `Failed to resolve entry for package "@composio/json-schema-to-zod"`, which is an environment artifact and not a real failure.

## Remaining backlog

- Fixable alerts beyond the 15 alert fix cap: **0**. All 15 open alerts on `next` were triaged in this run.
- Untriaged alerts beyond the 50 alert triage bound: **0**. The bound was not reached.
- Open alerts remaining after this PR merges: **12**, all listed above with a recommended disposition. Four of them have ready to run dismissal commands, which would permanently shrink every future run's fetch.

## Post-fix security scan

`composio-security:security-diff-scan` was run on this PR's diff as the final gate, because a remediation can introduce its own bug and CodeQL will not re-run until CI does.

**Verdict: clean. Zero reportable findings.**

Scope: merge-base `2f63fe540` to head `558d730e6`, all three changed files. Every deep-review row has a completion receipt, so coverage is complete rather than sampled. Discovery emitted no technically plausible candidates, so validation and attack-path analysis were skipped under the scan's documented zero-candidate rule.

Checks that were run and came back negative:

- The fix removes the denial-of-service primitive rather than relocating it. No regex remains on the trimming paths, and all three loops strictly progress toward their bound, so there is no unbounded-work or infinite-loop path.
- Surrogate-pair safety. `charCodeAt` compares UTF-16 code units, and `/` is U+002F, which can never appear as either half of a surrogate pair. No astral-plane input can make the index walk disagree with the regex it replaced.
- No security control changed. `joinPath` feeds `resolvePath`, which `sensitiveFileUploadPaths.ts:39` consumes for its upload denylist. That unchanged consumer was inspected as a negative control: byte-identical output means it cannot observe a difference, and it independently re-splits on slash runs at line 48 anyway.
- No new allocation or memory amplification. Both helpers return the input unchanged when nothing needs trimming, so the fix allocates strictly less than the `.replace()` calls it replaced.
- The new test file reproduces the two pre-fix regex literals as reference implementations. They are applied only to a literal `CASES` array, so there is no taint source, and `test/` is absent from this package's `files` allowlist, so they are never published to SDK consumers.

No new critical or high finding was introduced by this diff, so no commit needed reverting and no alert was reclassified.

## Checklist

- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed
- [ ] I updated documentation as needed (no documented behavior changed)
- [x] I added tests or explain why not applicable
- [x] I added a changeset if this change affects published packages

## Additional context

Generated by the `codeql-autofix` skill. The bot never dismisses, closes, or modifies alerts, and never merges or enables auto merge. Alerts close only because merged code no longer contains the flaw.
