### PR TITLE
fix(docs): show Legacy badge on deprecated API detail pages

### DIFF
--- a/docs/app/(home)/docs/[[...slug]]/page.tsx
+++ b/docs/app/(home)/docs/[[...slug]]/page.tsx
@@ -46,7 +46,7 @@ export default async function Page(props: PageProps<'/docs/[[...slug]]'>) {
               )}
             </div>
           )}
-          {data.experimental && <ExperimentalBadge />}
+          {data.experimental && <ExperimentalBadge className="mb-3" />}
           <DocsTitle>{data.title}</DocsTitle>
           <PageActions path={page.url} />
         </>

--- a/docs/app/(home)/reference/(v31)/[[...slug]]/page.tsx
+++ b/docs/app/(home)/reference/(v31)/[[...slug]]/page.tsx
@@ -12,9 +12,12 @@ import { createRelativeLink } from 'fumadocs-ui/mdx';
 import type { ApiPageProps } from 'fumadocs-openapi/ui';
 import { PageActions } from '@/components/page-actions';
 import { EditOnGitHub } from '@/components/edit-on-github';
-import { VersionBadge, extractVersionFromPath } from '@/components/version-badge';
+import { extractVersionFromPath } from '@/components/version-badge';
+import { ApiPageTitle } from '@/components/api-page-title';
+import { isApiPageDeprecated } from '@/lib/api-deprecation';
+import type { OpenApiSchemaPageData } from '@/lib/api-deprecation';
 
-interface OpenAPIPageData {
+interface OpenAPIPageData extends OpenApiSchemaPageData {
   title: string;
   description?: string;
   getAPIPageProps: () => ApiPageProps;
@@ -36,17 +39,15 @@ export default async function Page({
     const detectedVersion = apiProps.operations?.[0]?.path
       ? extractVersionFromPath(apiProps.operations[0].path)
       : null;
+    const deprecated = isApiPageDeprecated(pageData, apiProps.operations);
     return (
       <DocsPage full footer={{ enabled: false }} tableOfContentPopover={{ enabled: false }}>
         <div className="mb-4 flex items-start justify-between gap-4">
-          <h1 className="text-2xl font-semibold">
-            {pageData.title}
-            {detectedVersion && (
-              <span className="ml-2 align-middle">
-                <VersionBadge version={detectedVersion} />
-              </span>
-            )}
-          </h1>
+          <ApiPageTitle
+            title={pageData.title}
+            version={detectedVersion}
+            deprecated={deprecated}
+          />
           <PageActions path={page.url} variant="inline" />
         </div>
         <DocsBody>

--- a/docs/app/(home)/reference/v3/[[...slug]]/page.tsx
+++ b/docs/app/(home)/reference/v3/[[...slug]]/page.tsx
@@ -12,9 +12,12 @@ import { createRelativeLink } from 'fumadocs-ui/mdx';
 import type { ApiPageProps } from 'fumadocs-openapi/ui';
 import { PageActions } from '@/components/page-actions';
 import { EditOnGitHub } from '@/components/edit-on-github';
-import { VersionBadge, extractVersionFromPath } from '@/components/version-badge';
+import { extractVersionFromPath } from '@/components/version-badge';
+import { ApiPageTitle } from '@/components/api-page-title';
+import { isApiPageDeprecated } from '@/lib/api-deprecation';
+import type { OpenApiSchemaPageData } from '@/lib/api-deprecation';
 
-interface OpenAPIPageData {
+interface OpenAPIPageData extends OpenApiSchemaPageData {
   title: string;
   description?: string;
   getAPIPageProps: () => ApiPageProps;
@@ -44,17 +47,15 @@ export default async function Page({
     const detectedVersion = apiProps.operations?.[0]?.path
       ? extractVersionFromPath(apiProps.operations[0].path)
       : null;
+    const deprecated = isApiPageDeprecated(pageData, apiProps.operations);
     return (
       <DocsPage full footer={{ enabled: false }} tableOfContentPopover={{ enabled: false }}>
         <div className="mb-4 flex items-start justify-between gap-4">
-          <h1 className="text-2xl font-semibold">
-            {pageData.title}
-            {detectedVersion && (
-              <span className="ml-2 align-middle">
-                <VersionBadge version={detectedVersion} />
-              </span>
-            )}
-          </h1>
+          <ApiPageTitle
+            title={pageData.title}
+            version={detectedVersion}
+            deprecated={deprecated}
+          />
           <PageActions path={page.url} variant="inline" />
         </div>
         <DocsBody>

--- a/docs/components/api-endpoints-table.tsx
+++ b/docs/components/api-endpoints-table.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useApiVersion } from '@/lib/use-api-version';
-import { LegacyBadge } from '@/components/legacy-badge';
+import { DeprecatedApiLegacyBadge } from '@/components/legacy-badge';
 
 interface Endpoint {
   method: string;
@@ -39,9 +39,7 @@ export function ApiEndpointsTable({ endpoints }: { endpoints: Endpoint[] }) {
                 <a href={ep.href}>{ep.summary}</a>
                 {ep.legacy && (
                   <span className="ml-2 inline-flex align-middle">
-                    <LegacyBadge
-                      title="Deprecated API endpoint; kept for existing integrations and may be removed in a future release"
-                    />
+                    <DeprecatedApiLegacyBadge />
                   </span>
                 )}
               </td>

--- a/docs/components/api-endpoints-table.tsx
+++ b/docs/components/api-endpoints-table.tsx
@@ -2,6 +2,7 @@
 
 import { useApiVersion } from '@/lib/use-api-version';
 import { DeprecatedApiLegacyBadge } from '@/components/legacy-badge';
+import { getApiDisplayTitle } from '@/lib/api-deprecation';
 
 interface Endpoint {
   method: string;
@@ -36,7 +37,9 @@ export function ApiEndpointsTable({ endpoints }: { endpoints: Endpoint[] }) {
             <tr key={i}>
               <td><code>{ep.method} {path}</code></td>
               <td>
-                <a href={ep.href}>{ep.summary}</a>
+                <a href={ep.href}>
+                  {getApiDisplayTitle(ep.summary, ep.legacy === true)}
+                </a>
                 {ep.legacy && (
                   <span className="ml-2 inline-flex align-middle">
                     <DeprecatedApiLegacyBadge />

--- a/docs/components/api-page-title.tsx
+++ b/docs/components/api-page-title.tsx
@@ -1,0 +1,30 @@
+import { DeprecatedApiLegacyBadge } from '@/components/legacy-badge';
+import { VersionBadge } from '@/components/version-badge';
+
+interface ApiPageTitleProps {
+  title: string;
+  version: string | null;
+  deprecated: boolean;
+}
+
+export function ApiPageTitle({
+  title,
+  version,
+  deprecated,
+}: ApiPageTitleProps) {
+  return (
+    <h1 className="text-2xl font-semibold">
+      {title}
+      {version && (
+        <span className="ml-2 align-middle">
+          <VersionBadge version={version} />
+        </span>
+      )}
+      {deprecated && (
+        <span className="ml-2 inline-flex align-middle">
+          <DeprecatedApiLegacyBadge />
+        </span>
+      )}
+    </h1>
+  );
+}

--- a/docs/components/api-page-title.tsx
+++ b/docs/components/api-page-title.tsx
@@ -1,5 +1,6 @@
 import { DeprecatedApiLegacyBadge } from '@/components/legacy-badge';
 import { VersionBadge } from '@/components/version-badge';
+import { getApiDisplayTitle } from '@/lib/api-deprecation';
 
 interface ApiPageTitleProps {
   title: string;
@@ -12,17 +13,15 @@ export function ApiPageTitle({
   version,
   deprecated,
 }: ApiPageTitleProps) {
+  const displayTitle = getApiDisplayTitle(title, deprecated);
+
   return (
-    <h1 className="text-2xl font-semibold">
-      {title}
-      {version && (
-        <span className="ml-2 align-middle">
-          <VersionBadge version={version} />
-        </span>
-      )}
-      {deprecated && (
-        <span className="ml-2 inline-flex align-middle">
-          <DeprecatedApiLegacyBadge />
+    <h1 className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-2xl font-semibold">
+      <span>{displayTitle}</span>
+      {(version || deprecated) && (
+        <span className="inline-flex shrink-0 items-center gap-2">
+          {version && <VersionBadge version={version} />}
+          {deprecated && <DeprecatedApiLegacyBadge />}
         </span>
       )}
     </h1>

--- a/docs/components/custom-schema-ui.tsx
+++ b/docs/components/custom-schema-ui.tsx
@@ -9,6 +9,7 @@ import {
 import { cn } from '@/lib/utils';
 import { Plus, X } from 'lucide-react';
 import type { SchemaData, SchemaUIGeneratedData } from './schema-generator';
+import { ExperimentalBadge } from './experimental-badge';
 
 interface SchemaUIProps {
   name: string;
@@ -148,6 +149,7 @@ function SchemaProperty({
             Deprecated
           </span>
         )}
+        {schema.experimental && <ExperimentalBadge />}
       </div>
 
       {/* Description */}

--- a/docs/components/experimental-badge.tsx
+++ b/docs/components/experimental-badge.tsx
@@ -1,14 +1,18 @@
+import { cn } from '@/lib/utils';
+
 /**
- * "Experimental" badge rendered at the top of a docs page (under the title)
- * when the page frontmatter sets `experimental: true`. Signals that the page's
- * APIs may change in future releases, so individual pages don't need an inline
- * callout saying the same thing.
+ * Shared lifecycle badge for experimental docs pages and API schema fields.
+ * Spacing is caller-owned so it works both above a page title and inline with
+ * a field name.
  */
-export function ExperimentalBadge() {
+export function ExperimentalBadge({ className }: { className?: string }) {
   return (
     <span
       title="Experimental: these APIs may change in future releases"
-      className="not-prose mb-3 inline-flex w-fit items-center gap-1.5 rounded-md border border-amber-600/20 bg-amber-100 px-2 py-0.5 text-xs font-medium uppercase tracking-wide text-amber-700 dark:border-amber-500/25 dark:bg-amber-500/10 dark:text-amber-400"
+      className={cn(
+        'not-prose inline-flex w-fit items-center gap-1.5 rounded-md border border-amber-600/20 bg-amber-100 px-2 py-0.5 text-xs font-medium uppercase tracking-wide text-amber-700 dark:border-amber-500/25 dark:bg-amber-500/10 dark:text-amber-400',
+        className
+      )}
     >
       Experimental
     </span>

--- a/docs/components/legacy-badge.tsx
+++ b/docs/components/legacy-badge.tsx
@@ -9,6 +9,9 @@ interface LegacyBadgeProps {
   title?: string;
 }
 
+export const DEPRECATED_API_LEGACY_TITLE =
+  'Deprecated API endpoint; kept for existing integrations and may be removed in a future release';
+
 export function LegacyBadge({
   title = 'Legacy: superseded by sessions; kept for existing integrations',
 }: LegacyBadgeProps) {
@@ -20,4 +23,8 @@ export function LegacyBadge({
       Legacy
     </span>
   );
+}
+
+export function DeprecatedApiLegacyBadge() {
+  return <LegacyBadge title={DEPRECATED_API_LEGACY_TITLE} />;
 }

--- a/docs/components/legacy-badge.tsx
+++ b/docs/components/legacy-badge.tsx
@@ -1,3 +1,5 @@
+import { cn } from '@/lib/utils';
+
 /**
  * "Legacy" badge rendered at the top of a docs page (under the title) when the
  * page frontmatter sets `legacy: true` — for guides superseded by sessions but
@@ -7,6 +9,7 @@
  */
 interface LegacyBadgeProps {
   title?: string;
+  className?: string;
 }
 
 export const DEPRECATED_API_LEGACY_TITLE =
@@ -14,17 +17,27 @@ export const DEPRECATED_API_LEGACY_TITLE =
 
 export function LegacyBadge({
   title = 'Legacy: superseded by sessions; kept for existing integrations',
+  className,
 }: LegacyBadgeProps) {
   return (
     <span
       title={title}
-      className="not-prose inline-flex w-fit items-center gap-1.5 rounded-md border border-fd-border bg-fd-muted px-2 py-0.5 text-xs font-medium uppercase tracking-wide text-fd-muted-foreground"
+      className={cn(
+        'not-prose inline-flex w-fit items-center gap-1.5 rounded-md border border-fd-border bg-fd-muted px-2 py-0.5 text-xs font-medium uppercase tracking-wide text-fd-muted-foreground',
+        className
+      )}
     >
       Legacy
     </span>
   );
 }
 
-export function DeprecatedApiLegacyBadge() {
-  return <LegacyBadge title={DEPRECATED_API_LEGACY_TITLE} />;
+export function DeprecatedApiLegacyBadge({ className }: { className?: string }) {
+  return <LegacyBadge title={DEPRECATED_API_LEGACY_TITLE} className={className} />;
+}
+
+export function DeprecatedApiSidebarLegacyBadge() {
+  return (
+    <DeprecatedApiLegacyBadge className="ml-1 align-middle rounded px-1.5 py-px text-[10px]" />
+  );
 }

--- a/docs/components/schema-generator.tsx
+++ b/docs/components/schema-generator.tsx
@@ -7,6 +7,7 @@ interface FieldBase {
   typeName: string;
   aliasName: string;
   deprecated?: boolean;
+  experimental?: boolean;
   enumValues?: string[];
 }
 
@@ -42,6 +43,20 @@ interface SchemaUIOptions {
   root: SimpleSchema;
   readOnly?: boolean;
   writeOnly?: boolean;
+}
+
+/**
+ * Removes the source-level marker when the schema provides a structured
+ * experimental flag. Unflagged descriptions keep their original text so they
+ * do not lose their only lifecycle signal.
+ */
+export function getSchemaDisplayDescription(
+  description: string,
+  experimental: boolean,
+): string {
+  if (!experimental) return description;
+
+  return description.replace(/^\s*\[experimental\]\s*/i, '');
 }
 
 export function generateSchemaData(
@@ -119,14 +134,18 @@ export function generateSchemaData(
         ? getTypeName(schema.items)
         : getTypeName(schema);
 
+    const experimental = schema['x-experimental'] === true;
     const base: FieldBase = {
       description: schema.description
-        ? ctx.renderMarkdown(schema.description)
+        ? ctx.renderMarkdown(
+            getSchemaDisplayDescription(schema.description, experimental),
+          )
         : undefined,
       infoTags: generateInfoTags(schema),
       typeName: getTypeName(schema),
       aliasName,
       deprecated: schema.deprecated,
+      experimental,
       enumValues: schema.enum
         ? schema.enum.map((v: unknown) => String(v))
         : undefined,

--- a/docs/lib/api-deprecation.ts
+++ b/docs/lib/api-deprecation.ts
@@ -1,4 +1,4 @@
-interface ApiPageOperation {
+export interface ApiPageOperation {
   method: string;
   path: string;
 }

--- a/docs/lib/api-deprecation.ts
+++ b/docs/lib/api-deprecation.ts
@@ -15,6 +15,17 @@ export interface OpenApiSchemaPageData {
 }
 
 /**
+ * Removes the source-level deprecation suffix when a structured lifecycle
+ * badge is rendered alongside the title. Other contexts keep the raw OpenAPI
+ * title so they do not lose their only deprecation signal.
+ */
+export function getApiDisplayTitle(title: string, deprecated: boolean): string {
+  if (!deprecated) return title;
+
+  return title.replace(/\s+\(deprecated\)\s*$/i, '');
+}
+
+/**
  * Returns whether any operation rendered by an OpenAPI page is deprecated.
  * Operation detail pages currently contain one operation, but checking all of
  * them keeps the helper correct for grouped pages too.

--- a/docs/lib/api-deprecation.ts
+++ b/docs/lib/api-deprecation.ts
@@ -1,0 +1,32 @@
+interface ApiPageOperation {
+  method: string;
+  path: string;
+}
+
+export interface OpenApiSchemaPageData {
+  getSchema: () => {
+    dereferenced: {
+      paths?: Record<
+        string,
+        Record<string, { deprecated?: boolean } | undefined> | undefined
+      >;
+    };
+  };
+}
+
+/**
+ * Returns whether any operation rendered by an OpenAPI page is deprecated.
+ * Operation detail pages currently contain one operation, but checking all of
+ * them keeps the helper correct for grouped pages too.
+ */
+export function isApiPageDeprecated(
+  pageData: OpenApiSchemaPageData,
+  operations?: ApiPageOperation[],
+): boolean {
+  if (!operations || operations.length === 0) return false;
+
+  const paths = pageData.getSchema().dereferenced.paths;
+  return operations.some(
+    ({ method, path }) => paths?.[path]?.[method]?.deprecated === true,
+  );
+}

--- a/docs/lib/deprecated-api-sidebar.tsx
+++ b/docs/lib/deprecated-api-sidebar.tsx
@@ -1,0 +1,59 @@
+import type { ReactNode } from 'react';
+import type { Item } from 'fumadocs-core/page-tree';
+import type { PageTreeTransformer } from 'fumadocs-core/source';
+import { DeprecatedApiSidebarLegacyBadge } from '@/components/legacy-badge';
+import { getApiDisplayTitle, isApiPageDeprecated } from '@/lib/api-deprecation';
+import type { ApiPageOperation, OpenApiSchemaPageData } from '@/lib/api-deprecation';
+
+interface OpenApiSidebarPageData extends OpenApiSchemaPageData {
+  title: string;
+  getAPIPageProps: () => {
+    operations?: ApiPageOperation[];
+  };
+}
+
+function isOpenApiSidebarPageData(data: unknown): data is OpenApiSidebarPageData {
+  if (!data || typeof data !== 'object') return false;
+
+  const candidate = data as Partial<OpenApiSidebarPageData>;
+  return (
+    typeof candidate.title === 'string' &&
+    typeof candidate.getSchema === 'function' &&
+    typeof candidate.getAPIPageProps === 'function'
+  );
+}
+
+export function getDeprecatedApiSidebarName(
+  title: string,
+  pageData: OpenApiSchemaPageData,
+  operations?: ApiPageOperation[]
+): ReactNode {
+  if (!isApiPageDeprecated(pageData, operations)) return title;
+
+  return (
+    <span className="min-w-0">
+      {getApiDisplayTitle(title, true)} <DeprecatedApiSidebarLegacyBadge />
+    </span>
+  );
+}
+
+/**
+ * Replaces a deprecated OpenAPI operation's textual title suffix with a
+ * compact lifecycle badge before fumadocs-openapi appends its method label.
+ */
+export const deprecatedApiSidebarTransformer: PageTreeTransformer = {
+  file(node: Item, filePath?: string): Item {
+    if (!filePath) return node;
+
+    const file = this.storage.read(filePath);
+    if (!file || file.format !== 'page' || !isOpenApiSidebarPageData(file.data)) {
+      return node;
+    }
+
+    const apiProps = file.data.getAPIPageProps();
+    return {
+      ...node,
+      name: getDeprecatedApiSidebarName(file.data.title, file.data, apiProps.operations),
+    };
+  },
+};

--- a/docs/lib/source.ts
+++ b/docs/lib/source.ts
@@ -6,6 +6,7 @@ import { openapiSource, openapiPlugin } from 'fumadocs-openapi/server';
 import { getGuardrails } from './llm-guardrails';
 import { HIDDEN_API_TAGS } from './filter-api-version';
 import { FILE_BUILDS } from './file-builds';
+import { deprecatedApiSidebarTransformer } from './deprecated-api-sidebar';
 
 /**
  * True if a reference URL belongs to an intentionally-hidden API tag
@@ -82,7 +83,10 @@ export async function getReferenceSource() {
       plugins: [lucideIconsPlugin(), openapiPlugin()],
       pageTree: {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        transformers: [defaultOpenTransformer as any],
+        transformers: [
+          defaultOpenTransformer as any,
+          deprecatedApiSidebarTransformer as any,
+        ],
       },
     });
 

--- a/docs/tests/integration/rendering.test.ts
+++ b/docs/tests/integration/rendering.test.ts
@@ -19,6 +19,21 @@ const CRITICAL_PAGES = [
   { path: "/reference", name: "Reference index" },
 ];
 
+const DEPRECATED_API_LEGACY_TITLE =
+  "Deprecated API endpoint; kept for existing integrations and may be removed in a future release";
+
+const DEPRECATED_API_PAGES = [
+  "/reference/api-reference/connected-accounts/postConnectedAccountsByNanoidRefresh",
+  "/reference/api-reference/files/getFilesList",
+  "/reference/v3/api-reference/connected-accounts/postConnectedAccountsByNanoidRefresh",
+  "/reference/v3/api-reference/files/getFilesList",
+];
+
+const ACTIVE_API_PAGES = [
+  "/reference/api-reference/files/postFilesUploadRequest",
+  "/reference/v3/api-reference/files/postFilesUploadRequest",
+];
+
 describe("Page rendering - critical pages", () => {
   for (const { path, name } of CRITICAL_PAGES) {
     test(`${name} (${path}) returns 200`, async () => {
@@ -54,6 +69,28 @@ describe("Page rendering - content markers", () => {
     // Should contain at least one well-known toolkit
     expect(html.toLowerCase()).toContain("github");
   });
+});
+
+describe("Page rendering - deprecated API endpoints", () => {
+  for (const path of DEPRECATED_API_PAGES) {
+    test(`${path} renders the Legacy badge`, async () => {
+      const res = await fetchPage(path);
+      const html = await res.text();
+
+      expect(res.status).toBe(200);
+      expect(html).toContain(DEPRECATED_API_LEGACY_TITLE);
+    });
+  }
+
+  for (const path of ACTIVE_API_PAGES) {
+    test(`${path} omits the Legacy badge`, async () => {
+      const res = await fetchPage(path);
+      const html = await res.text();
+
+      expect(res.status).toBe(200);
+      expect(html).not.toContain(DEPRECATED_API_LEGACY_TITLE);
+    });
+  }
 });
 
 describe("Page rendering - error handling", () => {

--- a/docs/tests/integration/rendering.test.ts
+++ b/docs/tests/integration/rendering.test.ts
@@ -34,6 +34,10 @@ const ACTIVE_API_PAGES = [
   "/reference/v3/api-reference/files/postFilesUploadRequest",
 ];
 
+function getPageHeading(html: string): string | undefined {
+  return html.match(/<h1[^>]*>[\s\S]*?<\/h1>/)?.[0];
+}
+
 describe("Page rendering - critical pages", () => {
   for (const { path, name } of CRITICAL_PAGES) {
     test(`${name} (${path}) returns 200`, async () => {
@@ -76,9 +80,11 @@ describe("Page rendering - deprecated API endpoints", () => {
     test(`${path} renders the Legacy badge`, async () => {
       const res = await fetchPage(path);
       const html = await res.text();
+      const heading = getPageHeading(html);
 
       expect(res.status).toBe(200);
-      expect(html).toContain(DEPRECATED_API_LEGACY_TITLE);
+      expect(heading).toBeDefined();
+      expect(heading).toContain(DEPRECATED_API_LEGACY_TITLE);
     });
   }
 
@@ -86,11 +92,29 @@ describe("Page rendering - deprecated API endpoints", () => {
     test(`${path} omits the Legacy badge`, async () => {
       const res = await fetchPage(path);
       const html = await res.text();
+      const heading = getPageHeading(html);
 
       expect(res.status).toBe(200);
-      expect(html).not.toContain(DEPRECATED_API_LEGACY_TITLE);
+      expect(heading).toBeDefined();
+      expect(heading).not.toContain(DEPRECATED_API_LEGACY_TITLE);
     });
   }
+
+  test("deprecated endpoint sidebar links replace the title marker with Legacy", async () => {
+    const path = DEPRECATED_API_PAGES[0];
+    const res = await fetchPage(path);
+    const html = await res.text();
+    const escapedPath = path.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const sidebarLink = html.match(
+      new RegExp(`<a[^>]*href="${escapedPath}"[^>]*>[\\s\\S]*?<\\/a>`),
+    )?.[0];
+
+    expect(res.status).toBe(200);
+    expect(sidebarLink).toBeDefined();
+    expect(sidebarLink).toContain(">Legacy</span>");
+    expect(sidebarLink).not.toContain("(DEPRECATED)");
+    expect(sidebarLink).toContain(">POST</span>");
+  });
 });
 
 describe("Page rendering - error handling", () => {

--- a/docs/tests/static/api-deprecation.test.tsx
+++ b/docs/tests/static/api-deprecation.test.tsx
@@ -10,7 +10,7 @@ mock.module("next/navigation", () => ({
 
 const { ApiEndpointsTable } = await import("../../components/api-endpoints-table");
 const { ApiPageTitle } = await import("../../components/api-page-title");
-const { isApiPageDeprecated } = await import("../../lib/api-deprecation");
+const { getApiDisplayTitle, isApiPageDeprecated } = await import("../../lib/api-deprecation");
 
 const DOCS_DIR = join(import.meta.dir, "../..");
 const GENERATOR_PATH = join(DOCS_DIR, "scripts/generate-api-index.ts");
@@ -117,6 +117,21 @@ afterEach(async () => {
 });
 
 describe("deprecated API endpoints", () => {
+  test("removes only a trailing deprecation marker from deprecated display titles", () => {
+    expect(getApiDisplayTitle("Deprecated task endpoint (DEPRECATED)", true)).toBe(
+      "Deprecated task endpoint",
+    );
+    expect(getApiDisplayTitle("Deprecated task endpoint (deprecated)", true)).toBe(
+      "Deprecated task endpoint",
+    );
+    expect(getApiDisplayTitle("Active task endpoint (DEPRECATED)", false)).toBe(
+      "Active task endpoint (DEPRECATED)",
+    );
+    expect(getApiDisplayTitle("Deprecated endpoint details", true)).toBe(
+      "Deprecated endpoint details",
+    );
+  });
+
   test("renders Legacy on a deprecated API endpoint detail title", () => {
     const operation = {
       method: "get",
@@ -137,13 +152,19 @@ describe("deprecated API endpoints", () => {
     const deprecated = isApiPageDeprecated(pageData, [operation]);
     const html = renderToStaticMarkup(
       <ApiPageTitle
-        title="Deprecated task endpoint"
+        title="Deprecated task endpoint (DEPRECATED)"
         version="3.1"
         deprecated={deprecated}
       />,
     );
 
     expect(deprecated).toBe(true);
+    expect(html).toContain("<span>Deprecated task endpoint</span>");
+    expect(html).not.toContain("Deprecated task endpoint (DEPRECATED)");
+    expect(html).toContain(
+      'class="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-2xl font-semibold"',
+    );
+    expect(html).toContain('class="inline-flex shrink-0 items-center gap-2"');
     expect(html.match(/>Legacy<\/span>/g)).toHaveLength(1);
     expect(html).toContain(
       'title="Deprecated API endpoint; kept for existing integrations and may be removed in a future release"',
@@ -212,7 +233,7 @@ describe("deprecated API endpoints", () => {
             method: "GET",
             pathV31: "/v3.1/tasks/deprecated",
             pathV3: "/v3/tasks/deprecated",
-            summary: "Deprecated task endpoint",
+            summary: "Deprecated task endpoint (DEPRECATED)",
             href: "/reference/api-reference/tasks/getDeprecatedTask",
             legacy: true,
           },
@@ -227,6 +248,10 @@ describe("deprecated API endpoints", () => {
       />,
     );
 
+    expect(html).toContain(
+      '<a href="/reference/api-reference/tasks/getDeprecatedTask">Deprecated task endpoint</a>',
+    );
+    expect(html).not.toContain("Deprecated task endpoint (DEPRECATED)");
     expect(
       html.match(
         /title="Deprecated API endpoint; kept for existing integrations and may be removed in a future release"/g,

--- a/docs/tests/static/api-deprecation.test.tsx
+++ b/docs/tests/static/api-deprecation.test.tsx
@@ -10,6 +10,8 @@ mock.module("next/navigation", () => ({
 
 const { ApiEndpointsTable } = await import("../../components/api-endpoints-table");
 const { ApiPageTitle } = await import("../../components/api-page-title");
+const { DEPRECATED_API_LEGACY_TITLE } = await import("../../components/legacy-badge");
+const { getDeprecatedApiSidebarName } = await import("../../lib/deprecated-api-sidebar");
 const { getApiDisplayTitle, isApiPageDeprecated } = await import("../../lib/api-deprecation");
 
 const DOCS_DIR = join(import.meta.dir, "../..");
@@ -198,6 +200,65 @@ describe("deprecated API endpoints", () => {
     );
 
     expect(deprecated).toBe(false);
+    expect(html).not.toContain(">Legacy</span>");
+  });
+
+  test("replaces the sidebar title marker with a compact Legacy badge", () => {
+    const operation = {
+      method: "get",
+      path: "/v3.1/tasks/deprecated",
+    };
+    const pageData = {
+      getSchema: () => ({
+        dereferenced: {
+          paths: {
+            [operation.path]: {
+              [operation.method]: { deprecated: true },
+            },
+          },
+        },
+      }),
+    };
+
+    const html = renderToStaticMarkup(
+      <>
+        {getDeprecatedApiSidebarName("Deprecated task endpoint (DEPRECATED)", pageData, [
+          operation,
+        ])}
+      </>,
+    );
+
+    expect(html).toContain("Deprecated task endpoint");
+    expect(html).not.toContain("(DEPRECATED)");
+    expect(html.match(/>Legacy<\/span>/g)).toHaveLength(1);
+    expect(html).toContain("text-[10px]");
+    expect(html).toContain(DEPRECATED_API_LEGACY_TITLE);
+  });
+
+  test("keeps an unflagged sidebar title unchanged", () => {
+    const operation = {
+      method: "post",
+      path: "/v3.1/tasks/active",
+    };
+    const pageData = {
+      getSchema: () => ({
+        dereferenced: {
+          paths: {
+            [operation.path]: {
+              [operation.method]: {},
+            },
+          },
+        },
+      }),
+    };
+
+    const html = renderToStaticMarkup(
+      <>
+        {getDeprecatedApiSidebarName("Active task endpoint (DEPRECATED)", pageData, [operation])}
+      </>,
+    );
+
+    expect(html).toBe("Active task endpoint (DEPRECATED)");
     expect(html).not.toContain(">Legacy</span>");
   });
 

--- a/docs/tests/static/api-deprecation.test.tsx
+++ b/docs/tests/static/api-deprecation.test.tsx
@@ -9,6 +9,8 @@ mock.module("next/navigation", () => ({
 }));
 
 const { ApiEndpointsTable } = await import("../../components/api-endpoints-table");
+const { ApiPageTitle } = await import("../../components/api-page-title");
+const { isApiPageDeprecated } = await import("../../lib/api-deprecation");
 
 const DOCS_DIR = join(import.meta.dir, "../..");
 const GENERATOR_PATH = join(DOCS_DIR, "scripts/generate-api-index.ts");
@@ -115,6 +117,69 @@ afterEach(async () => {
 });
 
 describe("deprecated API endpoints", () => {
+  test("renders Legacy on a deprecated API endpoint detail title", () => {
+    const operation = {
+      method: "get",
+      path: "/v3.1/tasks/deprecated",
+    };
+    const pageData = {
+      getSchema: () => ({
+        dereferenced: {
+          paths: {
+            [operation.path]: {
+              [operation.method]: { deprecated: true },
+            },
+          },
+        },
+      }),
+    };
+
+    const deprecated = isApiPageDeprecated(pageData, [operation]);
+    const html = renderToStaticMarkup(
+      <ApiPageTitle
+        title="Deprecated task endpoint"
+        version="3.1"
+        deprecated={deprecated}
+      />,
+    );
+
+    expect(deprecated).toBe(true);
+    expect(html.match(/>Legacy<\/span>/g)).toHaveLength(1);
+    expect(html).toContain(
+      'title="Deprecated API endpoint; kept for existing integrations and may be removed in a future release"',
+    );
+  });
+
+  test("omits Legacy from an active API endpoint detail title", () => {
+    const operation = {
+      method: "post",
+      path: "/v3.1/tasks/active",
+    };
+    const pageData = {
+      getSchema: () => ({
+        dereferenced: {
+          paths: {
+            [operation.path]: {
+              [operation.method]: {},
+            },
+          },
+        },
+      }),
+    };
+
+    const deprecated = isApiPageDeprecated(pageData, [operation]);
+    const html = renderToStaticMarkup(
+      <ApiPageTitle
+        title="Active task endpoint"
+        version="3.1"
+        deprecated={deprecated}
+      />,
+    );
+
+    expect(deprecated).toBe(false);
+    expect(html).not.toContain(">Legacy</span>");
+  });
+
   test("serializes legacy only for deprecated v3.1 and v3 operations", async () => {
     const fixtureDir = await generateFixture();
     const v31Content = await readFile(

--- a/docs/tests/static/api-schema-experimental.test.tsx
+++ b/docs/tests/static/api-schema-experimental.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { CustomSchemaUI } from '../../components/custom-schema-ui';
+import { generateSchemaData, getSchemaDisplayDescription } from '../../components/schema-generator';
+
+describe('experimental API schema fields', () => {
+  test('removes only a leading marker from flagged descriptions', () => {
+    expect(
+      getSchemaDisplayDescription('[EXPERIMENTAL] Whether to validate credentials', true)
+    ).toBe('Whether to validate credentials');
+    expect(
+      getSchemaDisplayDescription('[Experimental] Whether to validate credentials', true)
+    ).toBe('Whether to validate credentials');
+    expect(getSchemaDisplayDescription('[EXPERIMENTAL] Unflagged source description', false)).toBe(
+      '[EXPERIMENTAL] Unflagged source description'
+    );
+    expect(getSchemaDisplayDescription('Experimental behavior without a source marker', true)).toBe(
+      'Experimental behavior without a source marker'
+    );
+  });
+
+  test('renders one Experimental badge with clean field copy', () => {
+    const generated = generateSchemaData(
+      {
+        root: {
+          type: 'object',
+          properties: {
+            validate_credentials: {
+              type: 'boolean',
+              default: false,
+              description: '[EXPERIMENTAL] Whether to validate the provided credentials',
+              'x-experimental': true,
+            },
+          },
+        },
+      },
+      {
+        renderMarkdown: text => text,
+        schema: { getRawRef: () => undefined },
+      }
+    );
+
+    const html = renderToStaticMarkup(
+      <CustomSchemaUI name="body" as="body" generated={generated} />
+    );
+
+    expect(html).toContain('validate_credentials');
+    expect(html.match(/>Experimental<\/span>/g)).toHaveLength(1);
+    expect(html).toContain('Whether to validate the provided credentials');
+    expect(html).not.toContain('[EXPERIMENTAL]');
+    expect(html).toContain('title="Experimental: these APIs may change in future releases"');
+  });
+});


### PR DESCRIPTION
This PR:
- follows up on https://github.com/ComposioHQ/composio/pull/3838
- renders the existing `Legacy` badge in v3 and v3.1 endpoint headers when the OpenAPI operation has `deprecated: true`
- centralizes deprecated-endpoint badge copy across API overview tables and detail pages
- adds static coverage plus running-server assertions for the reported routes and active control endpoints
- verifies the fix with `bun run test`, `bun run types:check`, `bun run lint:links`, `bun run build`, and the focused integration suite
