### PR TITLE
fix(cli): preserve symlinked shell configs during install

### DIFF
--- a/ts/packages/cli/src/commands/install.cmd.ts
+++ b/ts/packages/cli/src/commands/install.cmd.ts
@@ -266,7 +266,10 @@ export const installShellIntegration = (params: {
 
     if (blocksByFile.size > 0) {
       for (const [filePath, blocks] of blocksByFile.entries()) {
-        const existingContents = existingByFile.get(filePath) ?? '';
+        // Re-read instead of reusing the pre-check snapshot: two configured paths
+        // can alias the same physical file through symlinks, and this write must
+        // not discard a previous iteration's append.
+        const existingContents = yield* readMaybeMissingFile(filePath, fs);
         const writeTarget = yield* resolveWriteTarget(filePath, fs);
 
         yield* fs

--- a/ts/packages/cli/src/commands/install.cmd.ts
+++ b/ts/packages/cli/src/commands/install.cmd.ts
@@ -142,6 +142,16 @@ const readMaybeMissingFile = (
       )
     );
 
+/** Resolve valid symlink chains so atomic writes update the target instead of replacing the link. */
+const resolveWriteTarget = (
+  filePath: string,
+  fs: FileSystem.FileSystem
+): Effect.Effect<string, PlatformError> =>
+  fs.readLink(filePath).pipe(
+    Effect.flatMap(() => fs.realPath(filePath)),
+    Effect.catchAll(() => Effect.succeed(filePath))
+  );
+
 // ---------------------------------------------------------------------------
 // Exported logic (reusable from install.sh post-install delegation)
 // ---------------------------------------------------------------------------
@@ -257,9 +267,10 @@ export const installShellIntegration = (params: {
     if (blocksByFile.size > 0) {
       for (const [filePath, blocks] of blocksByFile.entries()) {
         const existingContents = existingByFile.get(filePath) ?? '';
+        const writeTarget = yield* resolveWriteTarget(filePath, fs);
 
         yield* fs
-          .makeDirectory(path.dirname(filePath), { recursive: true })
+          .makeDirectory(path.dirname(writeTarget), { recursive: true })
           .pipe(
             Effect.catchAll(e =>
               Effect.logDebug('Could not create parent directory (may already exist):', e)
@@ -267,10 +278,10 @@ export const installShellIntegration = (params: {
           );
 
         const appendContent = '\n' + blocks.join('\n\n') + '\n';
-        const tmpPath = `${filePath}.composio-tmp`;
+        const tmpPath = `${writeTarget}.composio-tmp`;
 
         yield* fs.writeFileString(tmpPath, existingContents + appendContent);
-        yield* fs.rename(tmpPath, filePath);
+        yield* fs.rename(tmpPath, writeTarget);
 
         yield* ui.log.success(`Updated ${tildify(filePath, os.homedir)}`);
       }

--- a/ts/packages/cli/test/src/commands/install.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/install.cmd.test.ts
@@ -195,6 +195,43 @@ describe('CLI: composio install', () => {
     });
   });
 
+  describe('[When] fish config and completions are symlinked to the same file', () => {
+    layer(TestLive())(it => {
+      it.scoped('[Then] keeps both PATH and completions blocks', () =>
+        Effect.gen(function* () {
+          const os = yield* NodeOs;
+          const fs = yield* FileSystem.FileSystem;
+          process.env.SHELL = '/usr/bin/fish';
+          process.env.COMPOSIO_INSTALL_DIR = path.join(os.homedir, '.composio');
+
+          const configPath = path.join(os.homedir, '.config', 'fish', 'config.fish');
+          const completionPath = path.join(
+            os.homedir,
+            '.config',
+            'fish',
+            'completions',
+            'composio.fish'
+          );
+          const managedPath = path.join(os.homedir, '.managed-fish-config');
+          yield* fs.makeDirectory(path.dirname(completionPath), { recursive: true });
+          yield* fs.remove(configPath, { force: true });
+          yield* fs.writeFileString(managedPath, '# managed fish config\n');
+          yield* fs.symlink(managedPath, configPath);
+          yield* fs.symlink(managedPath, completionPath);
+
+          yield* cli(['install', '--completions']);
+
+          const contents = yield* fs.readFileString(managedPath);
+          const pathMarkerCount = contents.match(/^# Composio CLI$/gm)?.length ?? 0;
+          const completionsMarkerCount =
+            contents.match(/^# Composio CLI completions$/gm)?.length ?? 0;
+          expect(pathMarkerCount).toBe(1);
+          expect(completionsMarkerCount).toBe(1);
+        })
+      );
+    });
+  });
+
   describe('[When] fish shell installs completions twice', () => {
     layer(TestLive())(it => {
       it.scoped('[Then] keeps config.fish and composio.fish idempotent', () =>

--- a/ts/packages/cli/test/src/commands/install.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/install.cmd.test.ts
@@ -57,6 +57,28 @@ describe('CLI: composio install', () => {
           expect(output).toContain('source ~/.zshrc');
         })
       );
+
+      it.scoped('[Then] preserves a symlinked .zshrc', () =>
+        Effect.gen(function* () {
+          const os = yield* NodeOs;
+          const fs = yield* FileSystem.FileSystem;
+          process.env.SHELL = '/bin/zsh';
+          process.env.COMPOSIO_INSTALL_DIR = path.join(os.homedir, '.composio');
+
+          const rcPath = path.join(os.homedir, '.zshrc');
+          const managedPath = path.join(os.homedir, '.managed-zshrc');
+          const linkTarget = path.basename(managedPath);
+          yield* fs.remove(rcPath, { force: true });
+          yield* fs.writeFileString(managedPath, '# managed shell config\n');
+          yield* fs.symlink(linkTarget, rcPath);
+
+          yield* cli(['install']);
+
+          expect(yield* fs.readLink(rcPath)).toBe(linkTarget);
+          expect(yield* fs.readFileString(managedPath)).toContain('# Composio CLI');
+          expect(yield* fs.exists(`${rcPath}.composio-tmp`)).toBe(false);
+        })
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

`composio install` uses a temporary file and rename so shell config updates are atomic. When the config path is a symlink, that rename replaces the symlink itself. This breaks setups that use tools such as GNU Stow to manage and sync dotfiles across machines.

Fixes #3922

## Changes

- Resolve valid symlink chains before choosing the temporary file and rename target.
- Keep regular shell config files on the existing write path.
- Add a regression test using a relative `.zshrc` symlink.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [ ] Documentation
- [ ] Breaking change

## How Has This Been Tested?

- `mise exec -- pnpm --filter @composio/cli exec vitest run test/src/commands/install.cmd.test.ts` — 13 passed
- `mise exec -- pnpm --filter @composio/cli typecheck`
- ESLint and Prettier on the two changed files

## Screenshots (if applicable)

Not applicable.

## Checklist

- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed
- [x] I updated documentation as needed
- [x] I added tests or explain why not applicable
- [x] I added a changeset if this change affects published packages

## Additional context

No changeset is needed because `@composio/cli` is ignored by the repository's Changesets configuration.

The current `next` branch is missing the `#ssrf_guard` alias in the CLI Vitest config. I added that alias locally to run the focused test, then removed it before committing this patch.
