### PR TITLE
fix(cli): emit run terminal telemetry and clean temp files (process.exit skipped both)

### DIFF
--- a/ts/packages/cli/CHANGELOG.md
+++ b/ts/packages/cli/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Patch Changes
 
+- Fix `composio run` exiting before its terminal telemetry event and temp-file cleanup could run. The command now sets the process exit code and returns normally, still exiting with the child script's status.
 - Make multi-account selection a stable CLI feature: `execute`, `listen`, and `link --alias` no longer honor the old experimental toggle; `proxy` now accepts `--account <alias|word_id|connected-account-id>`; and duplicate-alias link errors explain how to select the existing account.
 - 8467efd: Fix `composio whoami` reporting the API key's home organization after `composio orgs switch`. Session info requests now forward the selected global organization.
 - 5f004ff: Drop `COMPOSIO_UPSERT_RECIPE` and `COMPOSIO_GET_RECIPE` from the CLI meta-tool list. These slugs were removed from `@composio/client` (alpha.74), so listing them broke the type-checked CLI build.

--- a/ts/packages/cli/eslint-boundaries.json
+++ b/ts/packages/cli/eslint-boundaries.json
@@ -87,7 +87,7 @@
     },
     {
       "rule": "no-restricted-syntax",
-      "reason": "try/finally removes the temp preload and wrapper files around the imperative Bun.spawn block, whose success path ends in process.exit",
+      "reason": "try/finally removes the temp preload and wrapper files around the imperative Bun.spawn block",
       "target": "try {"
     }
   ],

--- a/ts/packages/cli/src/commands/run.cmd.ts
+++ b/ts/packages/cli/src/commands/run.cmd.ts
@@ -477,7 +477,7 @@ export const runCmd = Command.make('run', {
         );
         const ui = yield* TerminalUI;
         let cleanupPaths: ReadonlyArray<string> = [];
-        // eslint-disable-next-line no-restricted-syntax -- try/finally removes the temp preload and wrapper files around the imperative Bun.spawn block, whose success path ends in process.exit
+        // eslint-disable-next-line no-restricted-syntax -- try/finally removes the temp preload and wrapper files around the imperative Bun.spawn block
         try {
           yield* appendCliSessionHistory({
             orgId: helperContext.orgId,
@@ -512,8 +512,7 @@ export const runCmd = Command.make('run', {
             stdio: ['inherit', 'inherit', 'inherit'],
           });
 
-          const exitCode = yield* Effect.promise(() => child.exited);
-          process.exit(exitCode);
+          process.exitCode = yield* Effect.promise(() => child.exited);
         } finally {
           for (const cleanupPath of cleanupPaths) {
             fs.rmSync(cleanupPath, { force: true });

--- a/ts/packages/cli/test/src/commands/run.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/run.cmd.test.ts
@@ -35,6 +35,7 @@ describe('CLI: composio run', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
+    process.exitCode = undefined;
   });
 
   layer(TestLive())(it => {
@@ -71,7 +72,8 @@ describe('CLI: composio run', () => {
           );
           expect(spawnConfig.stdio).toEqual(['inherit', 'inherit', 'inherit']);
           expect(output).toContainEqual(expect.stringMatching(/^RUN_LOG_FILE=.*run\.log$/));
-          expect(exit).toHaveBeenCalledWith(7);
+          expect(exit).not.toHaveBeenCalled();
+          expect(process.exitCode).toBe(7);
         })
     );
   });
@@ -92,7 +94,8 @@ describe('CLI: composio run', () => {
             cmd: string[];
           };
           expect(spawnConfig.cmd[3]).toBe('--eval');
-          expect(exit).toHaveBeenCalledWith(0);
+          expect(exit).not.toHaveBeenCalled();
+          expect(process.exitCode).toBe(0);
         })
     );
   });
@@ -113,7 +116,8 @@ describe('CLI: composio run', () => {
             cmd: string[];
           };
           expect(spawnConfig.cmd[3]).toBe('--eval');
-          expect(exit).toHaveBeenCalledWith(0);
+          expect(exit).not.toHaveBeenCalled();
+          expect(process.exitCode).toBe(0);
         })
     );
   });
@@ -160,7 +164,8 @@ describe('CLI: composio run', () => {
             'return (console.log(JSON.stringify(brief.structuredOutput)));'
           );
           expect(spawnConfig.cmd[4]).not.toContain('"Do not run terminal\n');
-          expect(exit).toHaveBeenCalledWith(0);
+          expect(exit).not.toHaveBeenCalled();
+          expect(process.exitCode).toBe(0);
         })
     );
   });
@@ -197,11 +202,32 @@ describe('CLI: composio run', () => {
             })
           );
           expect(spawnConfig.stdio).toEqual(['inherit', 'inherit', 'inherit']);
-          expect(exit).toHaveBeenCalledWith(0);
+          expect(exit).not.toHaveBeenCalled();
+          expect(process.exitCode).toBe(0);
         } finally {
           fs.rmSync(tempDir, { recursive: true, force: true });
         }
       })
+    );
+  });
+
+  layer(TestLive())(it => {
+    it.scoped(
+      '[Given] a non-zero child exit [Then] the handler completes without process.exit, preserves the code, and removes the preload directory',
+      () =>
+        Effect.gen(function* () {
+          const spawn = vi.fn(() => ({ exited: Promise.resolve(3) }));
+          const exit = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+          vi.stubGlobal('Bun', { spawn });
+
+          yield* cli(['run', 'console.log("hi")']);
+
+          const spawnConfig = (spawn as any).mock.calls[0][0] as { cmd: string[] };
+          const preloadDir = path.dirname(spawnConfig.cmd[2]!);
+          expect(exit).not.toHaveBeenCalled();
+          expect(process.exitCode).toBe(3);
+          expect(fs.existsSync(preloadDir)).toBe(false);
+        })
     );
   });
 


### PR DESCRIPTION
Independent of the PostHog funnel stack (#3927 / #3928) — this branches off `next` and merges on its own.

## The bug

`run.cmd.ts` spawned the user's script, waited, then called `process.exit(exitCode)` immediately. That single call caused two problems:

1. **`composio run` telemetry was ~94% blind.** The lifecycle wrapper in `cli-main.ts` emits the terminal event via `Effect.tap(...)` *after* the handler returns — `process.exit()` kills the process first, so `CLI_RUN_SUCCEEDED` never fired. Production, last 30 days:

   | event | count | users |
   |---|---|---|
   | `CLI_RUN_INVOKED` | 156,216 | 1,867 |
   | `CLI_RUN_SUCCEEDED` | 1,904 | 736 |
   | `CLI_RUN_FAILED` | 7,685 | 140 |

   `INVOKED` fires *before* the handler so it always lands; the ~1.9k `SUCCEEDED` are the paths that return normally instead of reaching the spawn. Net effect: the reliability of the primary agent-facing command was unmeasurable.

2. **Temp files leaked on every successful run.** That `process.exit()` sits inside a `try { … } finally { … }` that removes the temp preload directory and wrapper files — and `process.exit()` does not run `finally` blocks. So cleanup only happened on the error path.

## The fix

```diff
-          const exitCode = yield* Effect.promise(() => child.exited);
-          process.exit(exitCode);
+          process.exitCode = yield* Effect.promise(() => child.exited);
```

The handler now returns normally, so the lifecycle tap emits the terminal event and the `finally` runs. The exit code is preserved: the platform runtime's `onExit` only force-exits when the code is non-zero, so on a successful Effect the process exits naturally honoring `process.exitCode`.

No new eslint boundary disables — `process.exitCode` assignment isn't banned (`cli-main.ts` already does it bare). `eslint-boundaries.json` changes only because the adjacent registered reason text referenced the now-removed `process.exit`; net count unchanged (46 across 22 files).

## Verification

Real compiled binary, isolated `HOME` + `TMPDIR`, `env -i`:

| case | exit code | wall time | temp files left |
|---|---|---|---|
| child exits 0 | **0** | 2s — no hang | **0** |
| child exits 3 | **3** | 1s — no hang | **0** |

Exit codes preserved exactly, no hang after the child exits, and `TMPDIR` empty afterward (confirming the leak is fixed). With `COMPOSIO_CLI_TELEMETRY_DEBUG=1`, both `CLI_RUN_INVOKED` and `CLI_RUN_SUCCEEDED` are now enqueued.

`pnpm typecheck` clean · `validate:boundaries` OK · run.cmd suite **28 passed** (existing tests inverted from "asserts `process.exit` called" to "asserts it is *not* called and `process.exitCode` matches", plus a non-zero-exit regression test).

## Deliberately not in scope

A completed run emits `SUCCEEDED` regardless of the child's exit status — making the Effect fail on non-zero would change user-facing error output. Distinguishing child failure needs an `exit_code` property threaded into the run event properties; worth doing, but as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)