### PR TITLE
fix(install): tell users to restart their shell after install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -421,7 +421,8 @@ if [[ $install_agent = true ]]; then
 fi
 
 echo
-info "To get started, run:"
+info "Composio was added to your PATH — restart your shell (or open a new terminal) for it to take effect."
+info "Then, to get started, run:"
 echo
 
 if [[ ${refresh_command:-} ]]; then


### PR DESCRIPTION
## Summary

A user reported that a first-time CLI install "didn't get added to their PATH". Investigation showed the PATH block *is* written correctly — but the user never learns about it: `install.sh` delegates shell integration to `composio install` with stderr captured to a temp file, and the CLI's TerminalUI suppresses all decoration when stderr isn't a TTY. So the "Updated ~/.zshrc" / "Restart your shell" guidance is silently swallowed, the installer ends with "To get started, run: composio --help", and the user gets `command not found` in their current shell.

This is the minimal fix: state explicitly in the installer's closing message that composio was added to PATH and takes effect after restarting the shell.

## Changes

- `install.sh`: closing message now reads "Composio was added to your PATH — restart your shell (or open a new terminal) for it to take effect." before the get-started commands. The block prints on every install path (delegated and fallback).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [ ] Documentation
- [ ] Breaking change

## How Has This Been Tested?

- `bash -n install.sh`
- Stubbed end-to-end run of the post-download section (delegation success and failure paths) in a sandboxed `$HOME`, verifying the message prints in both.
- Reproduced the original issue beforehand by running the real installer (released `@composio/cli@0.2.32`) into a fake `$HOME`: PATH block written, zero user-facing messaging about it.

## Screenshots (if applicable)

```
Composio was added to your PATH — restart your shell (or open a new terminal) for it to take effect.
Then, to get started, run:

  composio --help
  composio login
```

## Checklist

- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed
- [x] I updated documentation as needed
- [x] I added tests or explain why not applicable — shell-script-only messaging change; no test harness exists for install.sh output
- [x] I added a changeset if this change affects published packages — not applicable, install.sh is not a published package and `@composio/cli` is Changesets-ignored

## Additional context

install.sh is served from `next`, so this reaches all new installs immediately on merge and works with the already-released binary — no CLI release required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)