### PR TITLE
fix(ci): give the docs data sync its own production key, and alert when it fails

### DIFF
--- a/.github/workflows/docs-update-data.yml
+++ b/.github/workflows/docs-update-data.yml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
     env:
       COMPOSIO_API_KEY: ${{ secrets.COMPOSIO_API_KEY }}
 
@@ -131,3 +132,47 @@ jobs:
         run: |
           gh pr edit "$PR_NUMBER" --add-reviewer "$AUTHOR" || \
           gh pr edit "$PR_NUMBER" --add-reviewer "Sushmithamallesh"
+
+      # A silent failure here is invisible: the workflow stops refreshing
+      # public/data/toolkits.json, the docs site keeps building from the last
+      # good commit, and nothing 500s — new toolkits simply 404. That is how a
+      # credential failure went unnoticed for 60 consecutive runs. File one
+      # tracking issue and leave it open until someone fixes the cause.
+      - name: Open tracking issue on failure
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          LABEL: docs-data-sync-failure
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          gh label create "$LABEL" \
+            --color B60205 \
+            --description "Scheduled docs data sync is failing" 2>/dev/null || true
+
+          existing=$(gh issue list --label "$LABEL" --state open --limit 1 --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            echo "Issue #$existing is already open for this failure; not filing a duplicate."
+            exit 0
+          fi
+
+          gh issue create \
+            --title "Docs data sync is failing" \
+            --label "$LABEL" \
+            --body "The scheduled \`Docs - Update Data\` workflow failed.
+
+          - Run: $RUN_URL
+          - Trigger: \`$EVENT_NAME\`
+
+          **Impact:** while this is red, \`docs/public/data/toolkits.json\` stops being
+          refreshed. docs.composio.dev/toolkits is statically generated from that file, so
+          toolkits added to production after the last successful run have no page and
+          return 404. The site stays up, which is why this fails silently.
+
+          **First thing to check:** the \`COMPOSIO_API_KEY\` secret must have **production**
+          read access against \`backend.composio.dev\`. A staging-only key returns 401 here.
+
+          This issue is filed once and left open until the cause is fixed; it will not be
+          re-filed on every run."

--- a/.github/workflows/docs-update-data.yml
+++ b/.github/workflows/docs-update-data.yml
@@ -147,6 +147,11 @@ jobs:
       - name: Open tracking issue on failure
         if: failure()
         continue-on-error: true
+        # Override the job-level `./docs` default. That path only exists after
+        # checkout, so a failure before it (e.g. the app-token step) would leave
+        # the runner unable to start this shell — and continue-on-error would
+        # swallow that, losing the alert for precisely the earliest failures.
+        working-directory: ${{ github.workspace }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/docs-update-data.yml
+++ b/.github/workflows/docs-update-data.yml
@@ -21,7 +21,13 @@ jobs:
       pull-requests: write
       issues: write
     env:
-      COMPOSIO_API_KEY: ${{ secrets.COMPOSIO_API_KEY }}
+      # Deliberately NOT secrets.COMPOSIO_API_KEY. That secret is shared with
+      # ts.test-e2e, py.test, py.check and ts.examples-nightly, all of which run
+      # against staging — it is a staging-scoped credential. This job is the only
+      # consumer that must reach production (scripts/production-api.mjs rejects any
+      # non-production base URL), so it needs its own production key. Pointing the
+      # shared secret at production instead would break the staging suites.
+      COMPOSIO_API_KEY: ${{ secrets.COMPOSIO_DOCS_API_KEY }}
 
     steps:
       - name: Generate GitHub App token
@@ -56,7 +62,7 @@ jobs:
       # generators default to the production API (docs/scripts/production-api.mjs).
       # Previously this step pointed the fetch at STAGING, which published staging
       # hosts (and unreleased content) into the committed docs.
-      # NOTE: requires COMPOSIO_API_KEY to have PRODUCTION read access.
+      # NOTE: requires COMPOSIO_DOCS_API_KEY to have PRODUCTION read access.
 
       - name: Cache bun dependencies
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -171,8 +177,9 @@ jobs:
           toolkits added to production after the last successful run have no page and
           return 404. The site stays up, which is why this fails silently.
 
-          **First thing to check:** the \`COMPOSIO_API_KEY\` secret must have **production**
-          read access against \`backend.composio.dev\`. A staging-only key returns 401 here.
+          **First thing to check:** the \`COMPOSIO_DOCS_API_KEY\` secret must have
+          **production** read access against \`backend.composio.dev\`. Note this job does
+          not use the shared \`COMPOSIO_API_KEY\`, which is staging-scoped.
 
           This issue is filed once and left open until the cause is fixed; it will not be
           re-filed on every run."


### PR DESCRIPTION
## Why

`docs.composio.dev/toolkits` has been serving a stale catalog. Toolkits added to
production since 2026-07-13 — `saperly`, among others — have no page and 404,
while being live in the API and in `composio search`.

The page is statically generated from the committed `docs/public/data/toolkits.json`,
which this workflow is supposed to refresh every 5 hours. It has failed on **every
run since 2026-07-13** (60 of the last 100 runs), starting with the run immediately
after #3770.

## Root cause

#3770 correctly moved this job onto production and added a guard rejecting any
non-production base URL. But `secrets.COMPOSIO_API_KEY` is shared with
`ts.test-e2e`, `py.test`, `py.check` and `ts.examples-nightly` — all of which pin
`COMPOSIO_BASE_URL` to staging. It is a staging credential, and it returns 401
against `backend.composio.dev`.

Evidence it was live, not expired: `ts.examples-nightly` has been green against
staging using that same key.

Repointing the shared secret at production is not an option — it would break the
staging suites. So this job takes its own key.

## Changes

1. **`COMPOSIO_DOCS_API_KEY`** — the docs job reads a dedicated production secret.
   The env var name stays `COMPOSIO_API_KEY` because that is what the generators read.
2. **Failure alerting** — an `if: failure()` step files one tracking issue, deduped
   by label so a 5-hourly cron does not open 60 duplicates.

## Why alerting matters here

This workflow fails silently by construction. When it breaks, the catalog simply
stops being refreshed, the docs site keeps building from the last good commit, and
nothing 500s. There is no user-visible signal short of someone noticing a missing
toolkit page. That is how this went unnoticed for 11 days.

## Required before merge

`COMPOSIO_DOCS_API_KEY` must be set with **production** read access and these
permission areas: Toolkits (read), Tools (read), Triggers (read), and
**Sessions (read and write)** — `generate-meta-tools.ts` creates a tool-router
session and then reads its tool list, so write-only is not sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)