### PR TITLE
fix(cli): fall back to raw location when a source map is malformed

### DIFF
--- a/ts/packages/cli/src/effect-errors/capture-errors.ts
+++ b/ts/packages/cli/src/effect-errors/capture-errors.ts
@@ -4,7 +4,6 @@ import type { Path } from '@effect/platform/Path';
 import { Effect } from 'effect';
 import { type Cause, isInterruptedOnly } from 'effect/Cause';
 
-import type { JsonParsingError } from 'effect-errors/dependencies/fs';
 import { captureErrorsFrom } from 'effect-errors/logic/errors';
 import {
   type ErrorLocation,
@@ -37,7 +36,7 @@ export const captureErrors = <E>(
   options: CaptureErrorsOptions = {
     stripCwd: true,
   }
-): Effect.Effect<CapturedErrors, PlatformError | JsonParsingError, FileSystem | Path> =>
+): Effect.Effect<CapturedErrors, PlatformError, FileSystem | Path> =>
   Effect.gen(function* () {
     if (isInterruptedOnly(cause)) {
       return {

--- a/ts/packages/cli/src/effect-errors/sourcemaps/get-error-related-sources.ts
+++ b/ts/packages/cli/src/effect-errors/sourcemaps/get-error-related-sources.ts
@@ -3,8 +3,6 @@ import type { FileSystem } from '@effect/platform/FileSystem';
 import type { Path } from '@effect/platform/Path';
 import { Effect } from 'effect';
 
-import type { JsonParsingError } from 'effect-errors/dependencies/fs';
-
 import { getErrorLocationFrom } from './get-error-location-from-file-path';
 import { getSourceCode } from './get-source-code';
 import {
@@ -18,7 +16,7 @@ export const getErrorRelatedSources = (
   sourceFile: string
 ): Effect.Effect<
   ErrorRelatedSources | RawErrorLocation | undefined,
-  PlatformError | JsonParsingError,
+  PlatformError,
   FileSystem | Path
 > =>
   Effect.gen(function* () {

--- a/ts/packages/cli/src/effect-errors/sourcemaps/get-sources-from-map-file.ts
+++ b/ts/packages/cli/src/effect-errors/sourcemaps/get-sources-from-map-file.ts
@@ -4,7 +4,7 @@ import { Path } from '@effect/platform/Path';
 import { Effect, pipe } from 'effect';
 import { type RawSourceMap, SourceMapConsumer } from 'source-map-js';
 
-import { type JsonParsingError, readJsonEffect } from 'effect-errors/dependencies/fs';
+import { readJsonEffect } from 'effect-errors/dependencies/fs';
 
 import type { ErrorLocation } from './get-error-location-from-file-path';
 import { getSourceCode, type SourceCode } from './get-source-code';
@@ -27,7 +27,7 @@ export const getSourcesFromMapFile = (
   location: ErrorLocation
 ): Effect.Effect<
   ErrorRelatedSources | RawErrorLocation | undefined,
-  PlatformError | JsonParsingError,
+  PlatformError,
   FileSystem | Path
 > =>
   pipe(
@@ -44,7 +44,23 @@ export const getSourcesFromMapFile = (
         };
       }
 
-      const data = yield* readJsonEffect<RawSourceMap>(`${location.filePath}.map`);
+      const data = yield* pipe(
+        readJsonEffect<RawSourceMap>(`${location.filePath}.map`),
+        Effect.catchTag('JsonParsingError', () =>
+          // A malformed source map is optional metadata; fall back to the raw
+          // location the same way we do when the .map file is absent, instead
+          // of letting the parse error abort the whole error-capture pipeline.
+          Effect.succeed(null as RawSourceMap | null)
+        )
+      );
+      if (data === null) {
+        return {
+          _tag: 'location' as const,
+          name,
+          ...location,
+          filePath: location.filePath.replace(process.cwd(), ''),
+        };
+      }
       const hasNoData = data?.version === undefined || data?.sources === undefined;
       if (hasNoData) {
         return;

--- a/ts/packages/cli/src/effect-errors/sourcemaps/get-sources-from-map-file.ts
+++ b/ts/packages/cli/src/effect-errors/sourcemaps/get-sources-from-map-file.ts
@@ -66,11 +66,41 @@ export const getSourcesFromMapFile = (
         return;
       }
 
-      const consumer = new SourceMapConsumer(data);
-      const sources = consumer.originalPositionFor({
-        column: location.column,
-        line: location.line,
-      });
+      // A .map that parses as valid JSON can still be structurally invalid
+      // as a source map (e.g. a v2 map, or a v3 map with empty/missing
+      // mappings), causing SourceMapConsumer or originalPositionFor to throw.
+      // That throw would become an Effect defect and abort the whole
+      // error-capture pipeline. Treat it the same as a malformed map and
+      // fall back to the raw location.
+      const rawLocation = {
+        _tag: 'location' as const,
+        name,
+        ...location,
+        filePath: location.filePath.replace(process.cwd(), ''),
+      };
+
+      const resolved = yield* pipe(
+        Effect.sync(() => {
+          try {
+            const consumer = new SourceMapConsumer(data);
+            return consumer.originalPositionFor({
+              column: location.column,
+              line: location.line,
+            });
+          } catch {
+            return null;
+          }
+        }),
+        Effect.map((sources) => (sources === null ? null : {
+          source: sources.source,
+          line: sources.line,
+          column: sources.column,
+        }))
+      );
+      if (resolved === null) {
+        return rawLocation;
+      }
+      const sources = resolved;
       if (sources.source === null || sources.line === null || sources.column === null) {
         return;
       }

--- a/ts/packages/cli/src/effect-errors/sourcemaps/maybe-map-sourcemaps.ts
+++ b/ts/packages/cli/src/effect-errors/sourcemaps/maybe-map-sourcemaps.ts
@@ -3,7 +3,6 @@ import type { FileSystem } from '@effect/platform/FileSystem';
 import type { Path } from '@effect/platform/Path';
 import { Effect, Predicate, pipe } from 'effect';
 
-import type { JsonParsingError } from 'effect-errors/dependencies/fs';
 import { stackAtRegex } from 'effect-errors/logic/stack';
 
 import { getErrorRelatedSources } from './get-error-related-sources';
@@ -25,7 +24,7 @@ export const isRawErrorLocation = (value: MaybeMappedSources): value is RawError
 export const maybeMapSourcemaps = (
   name: string,
   stacktrace: string[]
-): Effect.Effect<MaybeMappedSources[], PlatformError | JsonParsingError, FileSystem | Path> =>
+): Effect.Effect<MaybeMappedSources[], PlatformError, FileSystem | Path> =>
   pipe(
     Effect.forEach(stacktrace, stackLine =>
       Effect.gen(function* () {

--- a/ts/packages/cli/test/src/effect-errors/get-sources-from-map-file.test.ts
+++ b/ts/packages/cli/test/src/effect-errors/get-sources-from-map-file.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from '@effect/vitest';
+import { BunFileSystem, BunPath } from '@effect/platform-bun';
+import { Effect } from 'effect';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { getSourcesFromMapFile } from 'src/effect-errors/sourcemaps/get-sources-from-map-file';
+
+const locationFor = (filePath: string) => ({ filePath, line: 1, column: 0 });
+
+const run = (filePath: string) =>
+  getSourcesFromMapFile('app.js', locationFor(filePath)).pipe(
+    Effect.provide([BunFileSystem.layer, BunPath.layer]),
+    Effect.either
+  );
+
+describe('getSourcesFromMapFile', () => {
+  it.scoped('falls back to the raw location when the .map file is missing', () =>
+    Effect.gen(function* () {
+      const dir = yield* Effect.promise(() => mkdtemp(join(tmpdir(), 'composio-sourcemap-')));
+      yield* Effect.addFinalizer(() => Effect.promise(() => rm(dir, { recursive: true, force: true })));
+
+      const result = yield* run(join(dir, 'app.js'));
+
+      expect(result._tag).toBe('Right');
+      if (result._tag === 'Right') {
+        expect(result.right?._tag).toBe('location');
+      }
+    })
+  );
+
+  it.scoped('falls back to the raw location when the .map file is malformed instead of failing capture', () =>
+    Effect.gen(function* () {
+      const dir = yield* Effect.promise(() => mkdtemp(join(tmpdir(), 'composio-sourcemap-')));
+      yield* Effect.addFinalizer(() => Effect.promise(() => rm(dir, { recursive: true, force: true })));
+
+      yield* Effect.promise(() => writeFile(join(dir, 'app.js.map'), '{ this is not valid json', 'utf8'));
+
+      const result = yield* run(join(dir, 'app.js'));
+
+      // A malformed map must not surface a JsonParsingError; it should
+      // behave like a missing map and return the raw location.
+      expect(result._tag).toBe('Right');
+      if (result._tag === 'Right') {
+        expect(result.right?._tag).toBe('location');
+      }
+    })
+  );
+});

--- a/ts/packages/cli/test/src/effect-errors/get-sources-from-map-file.test.ts
+++ b/ts/packages/cli/test/src/effect-errors/get-sources-from-map-file.test.ts
@@ -47,4 +47,52 @@ describe('getSourcesFromMapFile', () => {
       }
     })
   );
+
+  it.scoped('falls back to the raw location when the .map is valid JSON but a structurally invalid source map', () =>
+    Effect.gen(function* () {
+      const dir = yield* Effect.promise(() => mkdtemp(join(tmpdir(), 'composio-sourcemap-')));
+      yield* Effect.addFinalizer(() => Effect.promise(() => rm(dir, { recursive: true, force: true })));
+
+      // Parses as valid JSON and passes the version/sources presence check,
+      // but SourceMapConsumer rejects it (unsupported version 2, no mappings).
+      const structurallyInvalidMap = JSON.stringify({
+        version: 2,
+        sources: [],
+        names: [],
+        mappings: '',
+      });
+      yield* Effect.promise(() => writeFile(join(dir, 'app.js.map'), structurallyInvalidMap, 'utf8'));
+
+      const result = yield* run(join(dir, 'app.js'));
+
+      // A structurally invalid map must not abort the pipeline; it should
+      // fall back to the raw location just like a missing/malformed map.
+      expect(result._tag).toBe('Right');
+      if (result._tag === 'Right') {
+        expect(result.right?._tag).toBe('location');
+      }
+    })
+  );
+
+  it.scoped('falls back to the raw location when the .map has a valid v3 envelope but no mappings', () =>
+    Effect.gen(function* () {
+      const dir = yield* Effect.promise(() => mkdtemp(join(tmpdir(), 'composio-sourcemap-')));
+      yield* Effect.addFinalizer(() => Effect.promise(() => rm(dir, { recursive: true, force: true })));
+
+      // Valid JSON, v3, has sources, but the mappings field is absent,
+      // causing originalPositionFor to throw internally.
+      const mapWithoutMappings = JSON.stringify({
+        version: 3,
+        sources: ['src/app.ts'],
+      });
+      yield* Effect.promise(() => writeFile(join(dir, 'app.js.map'), mapWithoutMappings, 'utf8'));
+
+      const result = yield* run(join(dir, 'app.js'));
+
+      expect(result._tag).toBe('Right');
+      if (result._tag === 'Right') {
+        expect(result.right?._tag).toBe('location');
+      }
+    })
+  );
 });


### PR DESCRIPTION
When a generated file has an adjacent .map that exists but holds invalid JSON, readJsonEffect throws a JsonParsingError that bubbles up through getSourcesFromMapFile -> maybeMapSourcemaps -> captureErrors. Since captureErrors runs Effect.forEach over the raw error list, one malformed map aborts the entire capture and the primary diagnostic the user needed is dropped on the floor.

This treats the source map as the optional metadata it is: getSourcesFromMapFile now catches JsonParsingError and returns the raw location, matching what already happens when the .map file is missing entirely. The error channels on getErrorRelatedSources, maybeMapSourcemaps, and captureErrors are narrowed from PlatformError | JsonParsingError to just PlatformError, so callers stop having to reason about a parse failure of an auxiliary file.

Added a regression test that writes a malformed .map and asserts the raw location comes back instead of a failure. Existing effect-errors tests (24) still pass.

Fixes #3925