### PR TITLE
docs: fix GitHub issue links in example READMEs

### DIFF
--- a/ts/examples/file-handling/README.md
+++ b/ts/examples/file-handling/README.md
@@ -50,4 +50,4 @@ Edit `src/index.ts` to:
 
 - [Documentation](https://docs.composio.dev)
 - [Discord Community](https://discord.gg/composio)
-- [GitHub Issues](https://github.com/composio/composio/issues)
+- [GitHub Issues](https://github.com/ComposioHQ/composio/issues)

--- a/ts/examples/google/README.md
+++ b/ts/examples/google/README.md
@@ -55,4 +55,4 @@ Edit `src/index.ts` to:
 
 - [Documentation](https://docs.composio.dev)
 - [Discord Community](https://discord.gg/composio)
-- [GitHub Issues](https://github.com/composio/composio/issues)
+- [GitHub Issues](https://github.com/ComposioHQ/composio/issues)

--- a/ts/examples/json-schema-to-zod/README.md
+++ b/ts/examples/json-schema-to-zod/README.md
@@ -50,4 +50,4 @@ Edit `src/index.ts` to:
 
 - [Documentation](https://docs.composio.dev)
 - [Discord Community](https://discord.gg/composio)
-- [GitHub Issues](https://github.com/composio/composio/issues)
+- [GitHub Issues](https://github.com/ComposioHQ/composio/issues)

--- a/ts/examples/llamaindex/README.md
+++ b/ts/examples/llamaindex/README.md
@@ -50,4 +50,4 @@ Edit `src/index.ts` to:
 
 - [Documentation](https://docs.composio.dev)
 - [Discord Community](https://discord.gg/composio)
-- [GitHub Issues](https://github.com/composio/composio/issues)
+- [GitHub Issues](https://github.com/ComposioHQ/composio/issues)

--- a/ts/examples/mcp/README.md
+++ b/ts/examples/mcp/README.md
@@ -50,4 +50,4 @@ Edit `src/index.ts` to:
 
 - [Documentation](https://docs.composio.dev)
 - [Discord Community](https://discord.gg/composio)
-- [GitHub Issues](https://github.com/composio/composio/issues)
+- [GitHub Issues](https://github.com/ComposioHQ/composio/issues)

--- a/ts/examples/session-management/README.md
+++ b/ts/examples/session-management/README.md
@@ -50,4 +50,4 @@ Edit `src/index.ts` to:
 
 - [Documentation](https://docs.composio.dev)
 - [Discord Community](https://discord.gg/composio)
-- [GitHub Issues](https://github.com/composio/composio/issues)
+- [GitHub Issues](https://github.com/ComposioHQ/composio/issues)

--- a/ts/examples/tool-router/README.md
+++ b/ts/examples/tool-router/README.md
@@ -63,4 +63,4 @@ Edit `src/index.ts` to:
 
 - [Documentation](https://docs.composio.dev)
 - [Discord Community](https://discord.gg/composio)
-- [GitHub Issues](https://github.com/composio/composio/issues)
+- [GitHub Issues](https://github.com/ComposioHQ/composio/issues)

--- a/ts/examples/tools/README.md
+++ b/ts/examples/tools/README.md
@@ -50,4 +50,4 @@ Edit `src/index.ts` to:
 
 - [Documentation](https://docs.composio.dev)
 - [Discord Community](https://discord.gg/composio)
-- [GitHub Issues](https://github.com/composio/composio/issues)
+- [GitHub Issues](https://github.com/ComposioHQ/composio/issues)

--- a/ts/examples/triggers/README.md
+++ b/ts/examples/triggers/README.md
@@ -77,4 +77,4 @@ Edit `src/index.ts` or `src/webhook-server.ts` to:
 
 - [Documentation](https://docs.composio.dev)
 - [Discord Community](https://discord.gg/composio)
-- [GitHub Issues](https://github.com/composio/composio/issues)
+- [GitHub Issues](https://github.com/ComposioHQ/composio/issues)

--- a/ts/examples/versioning/README.md
+++ b/ts/examples/versioning/README.md
@@ -50,4 +50,4 @@ Edit `src/index.ts` to:
 
 - [Documentation](https://docs.composio.dev)
 - [Discord Community](https://discord.gg/composio)
-- [GitHub Issues](https://github.com/composio/composio/issues)
+- [GitHub Issues](https://github.com/ComposioHQ/composio/issues)


### PR DESCRIPTION
## Summary

Fix the "GitHub Issues" links shared by ten TypeScript example READMEs. They pointed to `github.com/composio/composio/issues`, which returns 404 because the repository belongs to the `ComposioHQ` organization.

The links now point to `github.com/ComposioHQ/composio/issues`, which returns 200.

## Changes

- Correct the GitHub organization in ten `ts/examples/*/README.md` files.
- Leave the root README star-badge target unchanged, per review feedback.

## Type of change

- [x] Documentation

## How has this been tested?

```console
$ curl -sSIL -o /dev/null -w '%{http_code}\n' -A 'Mozilla/5.0' \
    https://github.com/composio/composio/issues
404

$ curl -sSIL -o /dev/null -w '%{http_code}\n' -A 'Mozilla/5.0' \
    https://github.com/ComposioHQ/composio/issues
200

$ git diff --check origin/next...HEAD
# no output
```

## Checklist

- [x] I have read the Code of Conduct and this PR adheres to it.
- [x] I updated documentation as needed.
- [x] Tests are not applicable because this changes Markdown links only.
- [x] A changeset is not needed for documentation-only changes.
