### PR TITLE
fix(py): validate canonical URL targets

### DIFF
--- a/python/composio/utils/url_safety.py
+++ b/python/composio/utils/url_safety.py
@@ -6,6 +6,8 @@ import ipaddress
 import socket
 from urllib.parse import urlparse
 
+import requests
+
 from composio.exceptions import BlockedInternalUrlError
 
 
@@ -30,10 +32,22 @@ def is_blocked_ip(value: str) -> bool:
 
 
 def assert_safe_fetch_target(url: str) -> None:
-    """Refuse non-HTTP(S) URLs and hosts that resolve to internal addresses."""
-    parsed = urlparse(url)
-    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
-        raise BlockedInternalUrlError("Refusing to fetch a non-http(s) URL")
+    """Refuse non-HTTP(S) URLs and hosts that resolve to internal addresses.
+
+    Parse the URL after Requests prepares it so validation uses the same
+    canonical hostname that the eventual connection will use.
+    """
+    try:
+        prepared_url = requests.Request(method="GET", url=url).prepare().url
+        if prepared_url is None:
+            raise ValueError("Prepared URL is missing")
+        parsed = urlparse(prepared_url)
+        if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+            raise ValueError("URL must use HTTP(S) and include a hostname")
+    except (requests.exceptions.RequestException, ValueError):
+        raise BlockedInternalUrlError(
+            "Refusing to fetch a malformed or non-http(s) URL"
+        ) from None
 
     try:
         addresses: set[str] = set()

--- a/python/tests/test_url_safety.py
+++ b/python/tests/test_url_safety.py
@@ -47,11 +47,33 @@ def test_allows_public_addresses(address: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "url", ["file:///etc/passwd", "ftp://example.com/file", "not a url"]
+    "url",
+    [
+        "file:///etc/passwd",
+        "ftp://example.com/file",
+        "not a url",
+        "http://example.com:invalid/file",
+    ],
 )
-def test_rejects_non_http_urls(url: str) -> None:
+def test_rejects_malformed_or_non_http_urls(url: str) -> None:
     with pytest.raises(BlockedInternalUrlError):
         assert_safe_fetch_target(url)
+
+
+@patch("composio.utils.url_safety.socket.getaddrinfo")
+def test_validates_requests_canonicalized_hostname(mock_getaddrinfo) -> None:
+    def resolve(host: str, _port: int | None):
+        address = "127.0.0.1" if host == "127.0.0.1" else "93.184.216.34"
+        return [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", (address, 0)),
+        ]
+
+    mock_getaddrinfo.side_effect = resolve
+
+    with pytest.raises(BlockedInternalUrlError):
+        assert_safe_fetch_target(r"http://127.0.0.1\@example.com/file.pdf")
+
+    mock_getaddrinfo.assert_called_once_with("127.0.0.1", None)
 
 
 @patch("composio.utils.url_safety.socket.getaddrinfo")


### PR DESCRIPTION
This PR:
- builds on top of https://github.com/ComposioHQ/composio/pull/3823
- carries forward the Requests canonicalization hardening proposed in https://github.com/ComposioHQ/composio/pull/3810
- resolves and validates the prepared hostname that Requests will actually connect to
- blocks backslash parser differentials and rejects malformed ports before DNS resolution
- adds focused URL-safety coverage while preserving both existing upload entry points

Validation:
- `uv run --frozen pytest tests/test_url_safety.py tests/test_files.py tests/test_tool_router_session_files.py -q` (177 passed)
- `make chk`