### PR TITLE
fix(python): add __str__ method to ComposioError for clean error message string representation

### DIFF
--- a/python/composio/exceptions.py
+++ b/python/composio/exceptions.py
@@ -28,6 +28,9 @@ class ComposioError(Exception):
         self.message = message
         self.delegate = delegate
 
+    def __str__(self) -> str:
+        return self.message
+
 
 class NotFoundError(ComposioError):
     pass


### PR DESCRIPTION
## Description
This PR updates `ComposioError` in `python/composio/exceptions.py`.

## Details
- Adds a `__str__` method to `ComposioError` returning `self.message` to ensure consistent string formatting when SDK exceptions are formatted or converted to strings.