### PR TITLE
ci(ts): fix next push trigger and cache reuse

### DIFF
--- a/.github/actions/setup-node-pnpm-bun/action.yml
+++ b/.github/actions/setup-node-pnpm-bun/action.yml
@@ -18,6 +18,13 @@ inputs:
     description: 'Cache .turbo build outputs'
     required: false
     default: 'false'
+  cache-save:
+    description: >-
+      Persist pnpm/turbo caches in the post-job phase. Set to 'false' on runs
+      whose caches other branches cannot restore (e.g. pull_request runs) to
+      skip the post-job save and avoid evicting default-branch caches.
+    required: false
+    default: 'true'
 
 outputs:
   node-version:
@@ -84,7 +91,7 @@ runs:
         echo "NODE_VERSION=$(node --version | sed 's/^v//')" >> "$GITHUB_OUTPUT"
 
     - name: Cache pnpm store
-      if: inputs.enable-caching == 'true'
+      if: inputs.enable-caching == 'true' && inputs.cache-save == 'true'
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ steps.pnpm-store.outputs.STORE_PATH }}
@@ -92,13 +99,34 @@ runs:
         restore-keys: |
           ${{ runner.os }}-node${{ steps.pnpm-store.outputs.NODE_VERSION }}-pnpm-store-
 
+    - name: Restore pnpm store (read-only)
+      if: inputs.enable-caching == 'true' && inputs.cache-save != 'true'
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ steps.pnpm-store.outputs.STORE_PATH }}
+        key: ${{ runner.os }}-node${{ steps.pnpm-store.outputs.NODE_VERSION }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-node${{ steps.pnpm-store.outputs.NODE_VERSION }}-pnpm-store-
+
     - name: Cache turbo build outputs
-      if: inputs.enable-caching == 'true' && inputs.enable-turbo-cache == 'true'
+      if: inputs.enable-caching == 'true' && inputs.enable-turbo-cache == 'true' && inputs.cache-save == 'true'
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: .turbo/cache
         # Keyed per job: concurrent jobs save different task graphs under the
         # same commit, and actions/cache is first-writer-wins on exact keys.
+        # The per-commit suffix is intentional even though it never exact-hits:
+        # the turbo cache accumulates, so every save must use a fresh key and
+        # readers match through the restore-keys prefix.
+        key: ${{ runner.os }}-turbo-${{ github.job }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-turbo-${{ github.job }}-
+
+    - name: Restore turbo build outputs (read-only)
+      if: inputs.enable-caching == 'true' && inputs.enable-turbo-cache == 'true' && inputs.cache-save != 'true'
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: .turbo/cache
         key: ${{ runner.os }}-turbo-${{ github.job }}-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-turbo-${{ github.job }}-

--- a/.github/workflows/py.check.yaml
+++ b/.github/workflows/py.check.yaml
@@ -2,7 +2,7 @@ name: Checks
 on:
   push:
     branches:
-      - master
+      - next
     paths:
       - 'python/**/*.py'
       - '.github/actions/setup-python-uv/action.yml'

--- a/.github/workflows/ts.build.yml
+++ b/.github/workflows/ts.build.yml
@@ -2,7 +2,7 @@ name: Build Typescript SDK
 
 on:
   push:
-    branches: [master]
+    branches: [next]
     paths:
       - 'ts/**'
       - '.oxlintrc.json'
@@ -53,6 +53,10 @@ jobs:
         uses: ./.github/actions/setup-node-pnpm-bun
         with:
           enable-turbo-cache: 'true'
+          # Only push runs on next save caches: PR-scoped caches are invisible
+          # to other branches, so saving them costs post-job time and evicts
+          # reusable default-branch caches from the 10 GB repo quota.
+          cache-save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
This PR:

- fixes the `ts.build.yml` push trigger, which still pointed at `master`: the repo's default branch is `next`, so the workflow has not run on push since 2025-10-24 and never populated the turbo/pnpm caches that PR runs restore from (GitHub cache isolation lets PRs read base-branch caches, but not other PRs')
- fixes the same stale `master` push trigger in `py.check.yaml` (all other workflows already list `next`)
- adds a `cache-save` input (default `'true'`, preserving current behavior for every other consumer) to the `setup-node-pnpm-bun` composite action, swapping `actions/cache` for `actions/cache/restore` (same repo, same v6.1.0 SHA pin) when disabled
- wires `cache-save` in `ts.build.yml` so only push runs on `next` persist caches: PR-scoped saves are invisible to other branches, so they only cost post-job time and evict default-branch entries from the 10 GB repo cache quota

## Context

Measured on run [30364148082](https://github.com/ComposioHQ/composio/actions/runs/30364148082) (PR run, ~90s wall time):

| Step | Time |
|---|---|
| Checkout | 5s |
| Setup Node.js, pnpm, Bun | 34s (mise 1s, setup-node 5s, setup-bun 2s, pnpm 2s, **pnpm store restore 18s** for 658 MB, turbo restore 1s) |
| `pnpm install --frozen-lockfile` | 14s |
| `pnpm lint` | 1s |
| `pnpm run build:packages` | 24s, **0/19 turbo cache hits** |
| Post-job cache saves | ~11s (turbo save + a 658 MB pnpm store save that failed with "Unable to reserve cache", racing the parallel ts.* jobs on the same PR) |

The build restored a turbo cache only via the fallback restore-key `Linux-turbo-build-` from an unrelated branch, hence 0 hits. Once push runs fire on `next` again, every merge saves a fresh `Linux-turbo-build-<sha>` cache that PR runs match through the restore-key prefix, so unchanged packages become turbo hits (up to ~20s off the build step) and the ~11s post-job save disappears from PR runs. The per-commit key suffix is kept intentionally: the turbo cache accumulates, so each default-branch save needs a fresh key and readers match via the prefix (documented inline in the action).
