### PR TITLE
fix(core): resolve typedoc against the TS6 compiler API

### DIFF
--- a/docs/content/reference/sdk-reference/typescript/session-files.mdx
+++ b/docs/content/reference/sdk-reference/typescript/session-files.mdx
@@ -126,6 +126,8 @@ Uploads a file to the session's file mount.
 
 Accepts a file path (local or URL), a native File object, or a raw buffer.
 The file is stored in the virtual filesystem associated with the tool router session.
+URL inputs require a Node.js or Bun runtime so the destination can be DNS-validated;
+edge runtimes must fetch the file themselves and pass a File or ArrayBuffer.
 
 ```typescript
 async upload(input: string | File | ArrayBuffer | Uint8Array, options?: ToolRouterSessionFilesMountUploadOptions): Promise<RemoteFile>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1359,16 +1359,16 @@ importers:
         version: 7.7.1
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.14(@arethetypeswrong/core@0.18.5)(publint@0.3.22)(tsx@4.23.1)(typescript@7.0.2)(unrun@0.2.27(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2))
+        version: 0.22.14(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.22)(tsx@4.23.1)(unrun@0.2.27(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2))
       tsx:
         specifier: 'catalog:'
         version: 4.23.1
       typedoc:
         specifier: ^0.28.20
-        version: 0.28.20(typescript@7.0.2)
+        version: 0.28.20(@typescript/typescript6@6.0.2)
       typescript:
-        specifier: 'catalog:'
-        version: 7.0.2
+        specifier: catalog:ts6
+        version: '@typescript/typescript6@6.0.2'
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/ui@4.1.10)(vite@7.3.5(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
@@ -11754,13 +11754,13 @@ snapshots:
 
   typebox@1.3.7: {}
 
-  typedoc@0.28.20(typescript@7.0.2):
+  typedoc@0.28.20(@typescript/typescript6@6.0.2):
     dependencies:
       '@gerrit0/mini-shiki': 3.23.0
       lunr: 2.3.9
       markdown-it: 14.3.0
       minimatch: 10.2.5
-      typescript: 7.0.2
+      typescript: '@typescript/typescript6@6.0.2'
       yaml: 2.9.0
 
   typescript@5.6.1-rc: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -65,9 +65,10 @@ catalog:
 catalogs:
   # TS7 (tsgo) ships no JS compiler API; consumers of that API pin TS6 here.
   # `typescript` rebinds the compiler-API import for @composio/cli's generate
-  # pipeline (its typecheck still runs the root TS7 tsc — the alias package only
-  # ships a tsc6 bin); `typescript6` is the side-by-side alias for scripts that
-  # also need TS7 in scope (ts/scripts/validate-examples.ts).
+  # pipeline and @composio/core's typedoc docgen (their typechecks still run the
+  # root TS7 tsc — the alias package only ships a tsc6 bin); `typescript6` is
+  # the side-by-side alias for scripts that also need TS7 in scope
+  # (ts/scripts/validate-examples.ts).
   ts6:
     typescript: npm:@typescript/typescript6@^6.0.2
     typescript6: npm:@typescript/typescript6@^6.0.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -66,8 +66,10 @@ catalogs:
   # TS7 (tsgo) ships no JS compiler API; consumers of that API pin TS6 here.
   # `typescript` rebinds the compiler-API import for @composio/cli's generate
   # pipeline and @composio/core's typedoc docgen (their typechecks still run the
-  # root TS7 tsc — the alias package only ships a tsc6 bin); `typescript6` is
-  # the side-by-side alias for scripts that also need TS7 in scope
+  # root TS7 tsc — the alias package only ships a tsc6 bin). For core, this also
+  # routes tsdown's declaration emit through TS6; the types remain equivalent,
+  # but union member order and dist chunk hashes may change. `typescript6` is the
+  # side-by-side alias for scripts that also need TS7 in scope
   # (ts/scripts/validate-examples.ts).
   ts6:
     typescript: npm:@typescript/typescript6@^6.0.2

--- a/ts/packages/core/package.json
+++ b/ts/packages/core/package.json
@@ -103,7 +103,7 @@
     "tsdown": "catalog:",
     "tsx": "catalog:",
     "typedoc": "^0.28.20",
-    "typescript": "catalog:",
+    "typescript": "catalog:ts6",
     "vitest": "catalog:",
     "zod": "catalog:"
   },


### PR DESCRIPTION
This PR:
- restores TypeDoc generation after https://github.com/ComposioHQ/composio/pull/3966 by resolving `@composio/core`'s TypeScript dev dependency from `catalog:ts6`
- keeps core typechecking on the root TypeScript 7 compiler while TypeDoc receives the TS6 compiler API
- documents the additional compiler-API consumer in the shared TypeScript catalog
- commits the regenerated `session-files.mdx` output that could not be produced while the workflow was broken
- verifies `generate:docs`, `typecheck`, and `build` for `@composio/core`
