### PR TITLE
docs: document Custom MCP

### DIFF
--- a/docs/content/docs/extending-sessions/custom-mcp-servers.mdx
+++ b/docs/content/docs/extending-sessions/custom-mcp-servers.mdx
@@ -1,14 +1,14 @@
 ---
-title: Custom MCP servers
+title: Custom MCP
 description: Use tools from a remote MCP server in Composio sessions
 keywords: [custom mcp, bring your own mcp, remote mcp, custom toolkits, experimental]
 experimental: true
 ---
 
-Custom MCP servers let you use tools hosted outside Composio in the same session as Composio's built-in toolkits. Register the remote server once, then add its `CUSTOM_*` toolkit slug to any session you create with the SDK.
+Custom MCP lets you use tools hosted outside Composio in the same session as Composio's built-in toolkits. Register the remote server once, then add its `CUSTOM_*` toolkit slug to any session you create with the SDK.
 
 <Callout type="warn">
-Custom MCP servers are experimental. Their setup flow, authentication options, and API contracts may change while we work with early customers.
+Custom MCP is experimental. Its setup flow, authentication options, and API contracts may change while we work with early customers.
 </Callout>
 
 This is different from [Custom Tools and Toolkits](/docs/extending-sessions/custom-tools-and-toolkits). Custom tools run inside your application. A custom MCP server runs outside Composio and exposes its tools over a public MCP endpoint.
@@ -147,7 +147,7 @@ Custom toolkits use dated registry versions. When you call the v3 tools API dire
 
 ## Known gaps
 
-Custom MCP servers currently have these limitations:
+Custom MCP currently has these limitations:
 
 | Gap | What to do |
 | --- | --- |

--- a/docs/content/docs/extending-sessions/custom-mcp-servers.mdx
+++ b/docs/content/docs/extending-sessions/custom-mcp-servers.mdx
@@ -94,7 +94,7 @@ The pinned account must belong to the custom toolkit and be active. Explicit sel
 
 ## Register the remote server
 
-The TypeScript and Python SDKs don't expose the custom MCP registration lifecycle yet. Register the server once from your project's **Toolkits** page in the Composio dashboard:
+The TypeScript and Python SDKs don't expose the custom MCP registration lifecycle yet. Register the server once from your project's [**Toolkits** page](https://dashboard.composio.dev/~/project/toolkits?utm_source=docs&utm_medium=content&utm_campaign=docs-extending-sessions-custom-mcp-servers) in the Composio dashboard:
 
 <Steps>
 <Step>
@@ -143,7 +143,15 @@ Each registered server becomes a custom toolkit scoped to your project:
 - Its tools are available through Tool Router search and toolkit-filtered tool listing.
 - Tool execution is proxied to your MCP server with the selected connected account's credentials.
 
-Custom toolkits use dated registry versions. When you call the v3 tools API directly, use `version=latest`. The v3.1 API selects the latest version by default.
+Custom toolkits use dated registry versions. The v3.1 tools API selects the latest version by default. If you use v3 directly, select the latest version for each operation:
+
+| v3 operation | Select the latest version |
+| --- | --- |
+| List tools | Add the `toolkit_versions=latest` query parameter. |
+| Retrieve one tool | Add the `version=latest` query parameter. |
+| Execute one tool | Set `"version": "latest"` in the request body. |
+
+See [Toolkit Versioning](/docs/tools-direct/toolkit-versioning) for more examples.
 
 ## Known gaps
 
@@ -155,7 +163,7 @@ Custom MCP currently has these limitations:
 | Composio doesn't host your server. Local and STDIO-only servers aren't supported. | Deploy the server at a public HTTPS endpoint before registering it. |
 | Authenticated servers don't automatically sync when a connection becomes active. | Create the connected account, then run **Sync** from the toolkit. |
 | Authenticated sessions don't reliably select a custom toolkit's connected account automatically. | Pass its ID through `connected_accounts` in Python or `connectedAccounts` in TypeScript. |
-| The v3 tools API uses a pinned default version that doesn't contain custom tools. | Use v3.1, or pass `version=latest` to v3 calls. |
+| The v3 tools API uses a pinned default version that doesn't contain custom tools. | Use v3.1. On v3, explicitly select the version for listing, retrieval, or execution as described above. |
 | Registered server settings can't be edited in place. | Delete the custom toolkit and register it again. Deleting it also revokes and removes its connected accounts and auth configurations. |
 | A custom MCP toolkit can contain at most 100 tools. | Split larger servers into smaller MCP servers. If a later sync exceeds the limit, the last successful tool version stays available. |
 | API-key setup checks that a key was provided, not that the remote server accepts it. | Run a safe tool after connecting to verify the credential end to end. |

--- a/docs/content/docs/extending-sessions/custom-mcp-servers.mdx
+++ b/docs/content/docs/extending-sessions/custom-mcp-servers.mdx
@@ -1,11 +1,11 @@
 ---
 title: Custom MCP servers
-description: Bring tools from a remote MCP server into Composio
+description: Use tools from a remote MCP server in Composio sessions
 keywords: [custom mcp, bring your own mcp, remote mcp, custom toolkits, experimental]
 experimental: true
 ---
 
-Custom MCP servers let you bring tools from a remote MCP server into Composio. Once registered, the server becomes a project-scoped toolkit that you can use alongside Composio's built-in toolkits.
+Custom MCP servers let you use tools hosted outside Composio in the same session as Composio's built-in toolkits. Register the remote server once, then add its `CUSTOM_*` toolkit slug to any session you create with the SDK.
 
 <Callout type="warn">
 Custom MCP servers are experimental. Their setup flow, authentication options, and API contracts may change while we work with early customers.
@@ -13,15 +13,109 @@ Custom MCP servers are experimental. Their setup flow, authentication options, a
 
 This is different from [Custom Tools and Toolkits](/docs/extending-sessions/custom-tools-and-toolkits). Custom tools run inside your application. A custom MCP server runs outside Composio and exposes its tools over a public MCP endpoint.
 
-## Before you begin
+## Use a custom MCP toolkit in a session
 
-You need:
+Once the remote server is registered, pass its toolkit slug when you create a session:
 
-- A remote MCP server available at a public HTTPS URL.
-- Project admin access in Composio.
-- The authentication details required by the server, if it isn't public.
+<Tabs groupId="language" items={['Python', 'TypeScript']} persist>
+<Tab value="Python">
+```python
+from composio import Composio
 
-Composio connects to the server and proxies tool calls, but it does not host the MCP server for you.
+composio = Composio(api_key="your_api_key")
+
+session = composio.sessions.create(
+    user_id="user_123",
+    toolkits=["CUSTOM_ACME"],
+)
+
+tools = session.tools()
+```
+</Tab>
+<Tab value="TypeScript">
+```typescript
+import { Composio } from "@composio/core";
+
+const composio = new Composio({ apiKey: "your_api_key" });
+
+const session = await composio.sessions.create("user_123", {
+  toolkits: ["CUSTOM_ACME"],
+});
+
+const tools = await session.tools();
+```
+</Tab>
+</Tabs>
+
+The toolkit behaves like any other toolkit in the session. With the default search-first session, your agent can discover its tools through `COMPOSIO_SEARCH_TOOLS` and execute them through the Tool Router.
+
+### Select an account for an authenticated server
+
+For API-key and DCR OAuth servers, explicitly select the connected account in the session config:
+
+<Tabs groupId="language" items={['Python', 'TypeScript']} persist>
+<Tab value="Python">
+```python
+from composio import Composio
+
+composio = Composio(api_key="your_api_key")
+
+session = composio.sessions.create(
+    user_id="user_123",
+    toolkits=["CUSTOM_ACME"],
+    connected_accounts={
+        "CUSTOM_ACME": ["ca_custom_acme"],
+    },
+)
+```
+</Tab>
+<Tab value="TypeScript">
+```typescript
+import { Composio } from "@composio/core";
+
+const composio = new Composio({ apiKey: "your_api_key" });
+
+const session = await composio.sessions.create("user_123", {
+  toolkits: ["CUSTOM_ACME"],
+  connectedAccounts: {
+    CUSTOM_ACME: ["ca_custom_acme"],
+  },
+});
+```
+</Tab>
+</Tabs>
+
+Explicit selection avoids account-matching ambiguity and ensures calls use the intended credentials.
+
+## Register the remote server
+
+The TypeScript and Python SDKs don't expose the custom MCP registration lifecycle yet. Register the server once from your project's **Toolkits** page in the Composio dashboard:
+
+<Steps>
+<Step>
+
+### Deploy the server
+
+Make your remote MCP server available at a public HTTPS URL. Composio connects to the server and proxies tool calls, but it does not host the server for you.
+
+</Step>
+<Step>
+
+### Add it as a toolkit
+
+Enter a recognizable name, the public MCP URL, and the authentication mode. Composio reads the server's MCP metadata and creates a project-scoped toolkit whose slug starts with `CUSTOM_`.
+
+</Step>
+<Step>
+
+### Connect and sync
+
+No-auth servers sync during registration. For API-key and DCR OAuth servers, create a connected account first, then run **Sync** from the toolkit.
+
+Composio rejects the sync if the server returns more than 100 tools. It does not silently import a partial tool list.
+
+</Step>
+</Steps>
 
 ## Supported authentication
 
@@ -34,45 +128,6 @@ Choose the authentication mode that matches your server:
 | DCR OAuth | The server supports OAuth Dynamic Client Registration. | Each user authorizes a connected account before Composio calls authenticated tools. |
 
 For DCR OAuth, use a server that supports the standard authorization-code flow. Other OAuth grant types aren't supported.
-
-## Register a custom MCP server
-
-<Steps>
-<Step>
-
-### Add the server
-
-Open your project's **Toolkits** page in the Composio dashboard and add a custom MCP server.
-
-</Step>
-<Step>
-
-### Enter its details
-
-Give the server a recognizable name, enter its public HTTPS URL, and choose an authentication mode.
-
-Composio connects to the endpoint and reads the server's MCP metadata. The server name from that metadata becomes the basis of the toolkit slug.
-
-</Step>
-<Step>
-
-### Connect authentication
-
-Skip this step for a no-auth server.
-
-For an API-key or DCR OAuth server, create a connected account before syncing its tools. Authentication belongs to the connected account, so different users can connect with different credentials.
-
-</Step>
-<Step>
-
-### Sync the tools
-
-No-auth servers sync during registration. For API-key and DCR OAuth servers, connect an account first, then run **Sync** from the toolkit.
-
-Composio rejects the sync if the server returns more than 100 tools. It does not silently import a partial tool list.
-
-</Step>
-</Steps>
 
 ## What Composio creates
 
@@ -91,9 +146,10 @@ Custom MCP servers currently have these limitations:
 
 | Gap | What to do |
 | --- | --- |
+| The SDKs don't expose registration, sync, update, or deletion methods yet. | Manage the remote server from the dashboard, then use its toolkit slug through the SDK. |
 | Composio doesn't host your server. Local and STDIO-only servers aren't supported. | Deploy the server at a public HTTPS endpoint before registering it. |
 | Authenticated servers don't automatically sync when a connection becomes active. | Create the connected account, then run **Sync** from the toolkit. |
-| Sessions might not automatically select a custom toolkit's connected account. | Explicitly select or pin the connected account when you configure the session. |
+| Sessions might not automatically select a custom toolkit's connected account. | Pass its ID through `connected_accounts` in Python or `connectedAccounts` in TypeScript. |
 | The v3 tools API uses a pinned default version that doesn't contain custom tools. | Use v3.1, or pass `version=latest` to v3 calls. |
 | Registered server settings can't be edited in place. | Delete the custom toolkit and register it again. Deleting it also revokes and removes its connected accounts and auth configurations. |
 | A custom MCP toolkit can contain at most 100 tools. | Split larger servers into smaller MCP servers. If a later sync exceeds the limit, the last successful tool version stays available. |
@@ -103,4 +159,5 @@ Custom MCP servers currently have these limitations:
 
 - [Using sessions via MCP](/docs/sessions-via-mcp) explains how an MCP client connects to a Composio-hosted session.
 - [Custom Tools and Toolkits](/docs/extending-sessions/custom-tools-and-toolkits) explains how to run your own tools inside your application process.
-- [Configuring Sessions](/docs/configuring-sessions) explains toolkit, tool, and connected-account selection.
+- [Configuring Sessions](/docs/configuring-sessions) explains toolkit and tool filtering.
+- [Managing Multiple Connected Accounts](/docs/managing-multiple-connected-accounts) explains explicit account selection.

--- a/docs/content/docs/extending-sessions/custom-mcp-servers.mdx
+++ b/docs/content/docs/extending-sessions/custom-mcp-servers.mdx
@@ -13,9 +13,14 @@ Custom MCP servers are experimental. Their setup flow, authentication options, a
 
 This is different from [Custom Tools and Toolkits](/docs/extending-sessions/custom-tools-and-toolkits). Custom tools run inside your application. A custom MCP server runs outside Composio and exposes its tools over a public MCP endpoint.
 
-## Use a custom MCP toolkit in a session
+Today, register and sync the remote server in the dashboard. Then use one of these SDK flows:
 
-Once the remote server is registered, pass its toolkit slug when you create a session:
+- **No auth:** Pass the custom toolkit slug when you create the session.
+- **API key or DCR OAuth:** Pass the toolkit slug and explicitly select its connected account.
+
+## Use a no-auth server
+
+Once a no-auth server is registered and synced, pass its toolkit slug when you create a session:
 
 <Tabs groupId="language" items={['Python', 'TypeScript']} persist>
 <Tab value="Python">
@@ -47,11 +52,11 @@ const tools = await session.tools();
 </Tab>
 </Tabs>
 
-The toolkit behaves like any other toolkit in the session. With the default search-first session, your agent can discover its tools through `COMPOSIO_SEARCH_TOOLS` and execute them through the Tool Router.
+With the default search-first session, your agent can discover the custom tools through `COMPOSIO_SEARCH_TOOLS` and execute them through the Tool Router.
 
-### Select an account for an authenticated server
+## Use an authenticated server
 
-For API-key and DCR OAuth servers, explicitly select the connected account in the session config:
+For API-key and DCR OAuth servers, explicitly select the connected account in the session config. Don't rely on automatic account matching for custom MCP toolkits yet.
 
 <Tabs groupId="language" items={['Python', 'TypeScript']} persist>
 <Tab value="Python">
@@ -85,7 +90,7 @@ const session = await composio.sessions.create("user_123", {
 </Tab>
 </Tabs>
 
-Explicit selection avoids account-matching ambiguity and ensures calls use the intended credentials.
+The pinned account must belong to the custom toolkit and be active. Explicit selection ensures tool calls use its credentials.
 
 ## Register the remote server
 
@@ -149,7 +154,7 @@ Custom MCP servers currently have these limitations:
 | The SDKs don't expose registration, sync, update, or deletion methods yet. | Manage the remote server from the dashboard, then use its toolkit slug through the SDK. |
 | Composio doesn't host your server. Local and STDIO-only servers aren't supported. | Deploy the server at a public HTTPS endpoint before registering it. |
 | Authenticated servers don't automatically sync when a connection becomes active. | Create the connected account, then run **Sync** from the toolkit. |
-| Sessions might not automatically select a custom toolkit's connected account. | Pass its ID through `connected_accounts` in Python or `connectedAccounts` in TypeScript. |
+| Authenticated sessions don't reliably select a custom toolkit's connected account automatically. | Pass its ID through `connected_accounts` in Python or `connectedAccounts` in TypeScript. |
 | The v3 tools API uses a pinned default version that doesn't contain custom tools. | Use v3.1, or pass `version=latest` to v3 calls. |
 | Registered server settings can't be edited in place. | Delete the custom toolkit and register it again. Deleting it also revokes and removes its connected accounts and auth configurations. |
 | A custom MCP toolkit can contain at most 100 tools. | Split larger servers into smaller MCP servers. If a later sync exceeds the limit, the last successful tool version stays available. |

--- a/docs/content/docs/extending-sessions/custom-mcp-servers.mdx
+++ b/docs/content/docs/extending-sessions/custom-mcp-servers.mdx
@@ -1,0 +1,106 @@
+---
+title: Custom MCP servers
+description: Bring tools from a remote MCP server into Composio
+keywords: [custom mcp, bring your own mcp, remote mcp, custom toolkits, experimental]
+experimental: true
+---
+
+Custom MCP servers let you bring tools from a remote MCP server into Composio. Once registered, the server becomes a project-scoped toolkit that you can use alongside Composio's built-in toolkits.
+
+<Callout type="warn">
+Custom MCP servers are experimental. Their setup flow, authentication options, and API contracts may change while we work with early customers.
+</Callout>
+
+This is different from [Custom Tools and Toolkits](/docs/extending-sessions/custom-tools-and-toolkits). Custom tools run inside your application. A custom MCP server runs outside Composio and exposes its tools over a public MCP endpoint.
+
+## Before you begin
+
+You need:
+
+- A remote MCP server available at a public HTTPS URL.
+- Project admin access in Composio.
+- The authentication details required by the server, if it isn't public.
+
+Composio connects to the server and proxies tool calls, but it does not host the MCP server for you.
+
+## Supported authentication
+
+Choose the authentication mode that matches your server:
+
+| Authentication | Use it when | What happens |
+| --- | --- | --- |
+| No auth | The server accepts requests without credentials. | Composio can discover and sync tools as soon as you register the server. |
+| API key | Each connection needs an API key. | Composio stores the key with the connected account and sends it to the server on tool calls. |
+| DCR OAuth | The server supports OAuth Dynamic Client Registration. | Each user authorizes a connected account before Composio calls authenticated tools. |
+
+For DCR OAuth, use a server that supports the standard authorization-code flow. Other OAuth grant types aren't supported.
+
+## Register a custom MCP server
+
+<Steps>
+<Step>
+
+### Add the server
+
+Open your project's **Toolkits** page in the Composio dashboard and add a custom MCP server.
+
+</Step>
+<Step>
+
+### Enter its details
+
+Give the server a recognizable name, enter its public HTTPS URL, and choose an authentication mode.
+
+Composio connects to the endpoint and reads the server's MCP metadata. The server name from that metadata becomes the basis of the toolkit slug.
+
+</Step>
+<Step>
+
+### Connect authentication
+
+Skip this step for a no-auth server.
+
+For an API-key or DCR OAuth server, create a connected account before syncing its tools. Authentication belongs to the connected account, so different users can connect with different credentials.
+
+</Step>
+<Step>
+
+### Sync the tools
+
+No-auth servers sync during registration. For API-key and DCR OAuth servers, connect an account first, then run **Sync** from the toolkit.
+
+Composio rejects the sync if the server returns more than 100 tools. It does not silently import a partial tool list.
+
+</Step>
+</Steps>
+
+## What Composio creates
+
+Each registered server becomes a custom toolkit scoped to your project:
+
+- The toolkit has `type: "custom"` and the `CUSTOM` category.
+- Its slug starts with `CUSTOM_`, such as `CUSTOM_ACME`.
+- Its tools are available through Tool Router search and toolkit-filtered tool listing.
+- Tool execution is proxied to your MCP server with the selected connected account's credentials.
+
+Custom toolkits use dated registry versions. When you call the v3 tools API directly, use `version=latest`. The v3.1 API selects the latest version by default.
+
+## Known gaps
+
+Custom MCP servers currently have these limitations:
+
+| Gap | What to do |
+| --- | --- |
+| Composio doesn't host your server. Local and STDIO-only servers aren't supported. | Deploy the server at a public HTTPS endpoint before registering it. |
+| Authenticated servers don't automatically sync when a connection becomes active. | Create the connected account, then run **Sync** from the toolkit. |
+| Sessions might not automatically select a custom toolkit's connected account. | Explicitly select or pin the connected account when you configure the session. |
+| The v3 tools API uses a pinned default version that doesn't contain custom tools. | Use v3.1, or pass `version=latest` to v3 calls. |
+| Registered server settings can't be edited in place. | Delete the custom toolkit and register it again. Deleting it also revokes and removes its connected accounts and auth configurations. |
+| A custom MCP toolkit can contain at most 100 tools. | Split larger servers into smaller MCP servers. If a later sync exceeds the limit, the last successful tool version stays available. |
+| API-key setup checks that a key was provided, not that the remote server accepts it. | Run a safe tool after connecting to verify the credential end to end. |
+
+## Related guides
+
+- [Using sessions via MCP](/docs/sessions-via-mcp) explains how an MCP client connects to a Composio-hosted session.
+- [Custom Tools and Toolkits](/docs/extending-sessions/custom-tools-and-toolkits) explains how to run your own tools inside your application process.
+- [Configuring Sessions](/docs/configuring-sessions) explains toolkit, tool, and connected-account selection.

--- a/docs/content/docs/extending-sessions/custom-mcp.mdx
+++ b/docs/content/docs/extending-sessions/custom-mcp.mdx
@@ -13,7 +13,7 @@ Custom MCP is experimental. Its setup flow, authentication options, and API cont
 
 This is different from [Custom Tools and Toolkits](/docs/extending-sessions/custom-tools-and-toolkits). Custom tools run inside your application. A custom MCP server runs outside Composio and exposes its tools over a public MCP endpoint.
 
-Today, register and sync the remote server in the dashboard. Then use one of these SDK flows:
+Register and sync the remote server in the dashboard, or use the experimental lifecycle API below. Then use one of these SDK flows:
 
 - **No auth:** Pass the custom toolkit slug when you create the session.
 - **API key or DCR OAuth:** Pass the toolkit slug and explicitly select its connected account.
@@ -122,6 +122,148 @@ Composio rejects the sync if the server returns more than 100 tools. It does not
 </Step>
 </Steps>
 
+## Manage Custom MCP through the API
+
+Use these endpoints when you need to automate registration, synchronization, or deletion. Authenticate each request with your Composio project API key.
+
+<Callout type="warn">
+These experimental endpoints aren't included in the public API reference or the TypeScript and Python SDKs yet. Their request and response formats may change.
+</Callout>
+
+### Add a server
+
+Call `POST /api/v3/custom/toolkits/upsert` with the server URL and its authentication scheme:
+
+<Tabs items={['No auth', 'API key', 'DCR OAuth']}>
+<Tab value="No auth">
+```bash
+curl --request POST \
+  --url https://backend.composio.dev/api/v3/custom/toolkits/upsert \
+  --header "x-api-key: $COMPOSIO_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "slug": "ACME",
+    "toolkit_config": {
+      "name": "Acme",
+      "app_url": "https://mcp.example.com/mcp",
+      "auth_schemes": [
+        {
+          "mode": "NO_AUTH"
+        }
+      ]
+    }
+  }'
+```
+</Tab>
+<Tab value="API key">
+```bash
+curl --request POST \
+  --url https://backend.composio.dev/api/v3/custom/toolkits/upsert \
+  --header "x-api-key: $COMPOSIO_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "slug": "ACME",
+    "toolkit_config": {
+      "name": "Acme",
+      "app_url": "https://mcp.example.com/mcp",
+      "auth_schemes": [
+        {
+          "mode": "API_KEY",
+          "headers": {
+            "Authorization": "Bearer {{generic_api_key}}"
+          }
+        }
+      ]
+    }
+  }'
+```
+
+`generic_api_key` is replaced with the credential stored on the connected account. You can use a different header name or value format, but at least one header value must contain `{{generic_api_key}}`.
+</Tab>
+<Tab value="DCR OAuth">
+```bash
+curl --request POST \
+  --url https://backend.composio.dev/api/v3/custom/toolkits/upsert \
+  --header "x-api-key: $COMPOSIO_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "slug": "ACME",
+    "toolkit_config": {
+      "name": "Acme",
+      "app_url": "https://mcp.example.com/mcp",
+      "auth_schemes": [
+        {
+          "mode": "DCR_OAUTH",
+          "discovery_url": "https://mcp.example.com/.well-known/oauth-authorization-server"
+        }
+      ]
+    }
+  }'
+```
+</Tab>
+</Tabs>
+
+Composio adds the `CUSTOM_` prefix and returns the normalized toolkit slug:
+
+```json
+{
+  "slug": "CUSTOM_ACME"
+}
+```
+
+Registration is create-only for this endpoint. If the slug already exists, the request returns `409 Conflict`.
+
+No-auth servers sync automatically when you add them. For API-key and DCR OAuth servers, create and activate a connected account from the toolkit's dashboard page before syncing.
+
+### Sync tools
+
+Call `POST /api/v3/custom/toolkits/sync` to fetch the server's current tools. An authenticated server requires an active connected account from the same toolkit and project:
+
+```bash
+curl --request POST \
+  --url https://backend.composio.dev/api/v3/custom/toolkits/sync \
+  --header "x-api-key: $COMPOSIO_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "slug": "CUSTOM_ACME",
+    "connected_account_id": "ca_custom_acme"
+  }'
+```
+
+For a no-auth server, omit `connected_account_id`. A successful sync returns the new toolkit version and the number of tools discovered:
+
+```json
+{
+  "slug": "CUSTOM_ACME",
+  "version": "20260728_00",
+  "synced_count": 12
+}
+```
+
+Run sync again whenever the remote server's tool definitions change. Each successful sync creates a toolkit version. If the server exposes more than 100 tools, the sync fails and the last successful version stays available.
+
+### Delete a server
+
+Call `DELETE /api/v3.1/custom/toolkits/{slug}`:
+
+```bash
+curl --request DELETE \
+  --url https://backend.composio.dev/api/v3.1/custom/toolkits/CUSTOM_ACME \
+  --header "x-api-key: $COMPOSIO_API_KEY"
+```
+
+```json
+{
+  "slug": "CUSTOM_ACME",
+  "deleted": true,
+  "revoke_job_ids": ["job_123"],
+  "auth_configs_soft_deleted": 1,
+  "connected_accounts_soft_deleted": 1
+}
+```
+
+Deletion removes the custom toolkit and its tools. It also revokes and removes the toolkit's auth configurations and connected accounts, so only delete a toolkit when you no longer need its existing connections.
+
 ## Supported authentication
 
 Choose the authentication mode that matches your server:
@@ -159,7 +301,7 @@ Custom MCP currently has these limitations:
 
 | Gap | What to do |
 | --- | --- |
-| The SDKs don't expose registration, sync, update, or deletion methods yet. | Manage the remote server from the dashboard, then use its toolkit slug through the SDK. |
+| The SDKs don't expose registration, sync, update, or deletion methods yet. | Use the dashboard or the experimental lifecycle endpoints above, then use the toolkit slug through the SDK. |
 | Composio doesn't host your server. Local and STDIO-only servers aren't supported. | Deploy the server at a public HTTPS endpoint before registering it. |
 | Authenticated servers don't automatically sync when a connection becomes active. | Create the connected account, then run **Sync** from the toolkit. |
 | Authenticated sessions don't reliably select a custom toolkit's connected account automatically. | Pass its ID through `connected_accounts` in Python or `connectedAccounts` in TypeScript. |

--- a/docs/content/docs/extending-sessions/custom-mcp.mdx
+++ b/docs/content/docs/extending-sessions/custom-mcp.mdx
@@ -29,13 +29,13 @@ Use the lifecycle endpoints below to register, sync, and delete Custom MCP toolk
 
 ## Register a Custom MCP
 
-Call `POST /api/v3/custom/toolkits/upsert` with your public server URL and authentication scheme. Authenticate the request with your Composio project API key.
+Call `POST /api/v3.1/custom/toolkits/upsert` with your public server URL and authentication scheme. Authenticate the request with your Composio project API key.
 
 <Tabs items={['No auth', 'API key', 'DCR OAuth']}>
 <Tab value="No auth">
 ```bash
 curl --request POST \
-  --url https://backend.composio.dev/api/v3/custom/toolkits/upsert \
+  --url https://backend.composio.dev/api/v3.1/custom/toolkits/upsert \
   --header "x-api-key: $COMPOSIO_API_KEY" \
   --header "Content-Type: application/json" \
   --data '{
@@ -55,7 +55,7 @@ curl --request POST \
 <Tab value="API key">
 ```bash
 curl --request POST \
-  --url https://backend.composio.dev/api/v3/custom/toolkits/upsert \
+  --url https://backend.composio.dev/api/v3.1/custom/toolkits/upsert \
   --header "x-api-key: $COMPOSIO_API_KEY" \
   --header "Content-Type: application/json" \
   --data '{
@@ -80,7 +80,7 @@ curl --request POST \
 <Tab value="DCR OAuth">
 ```bash
 curl --request POST \
-  --url https://backend.composio.dev/api/v3/custom/toolkits/upsert \
+  --url https://backend.composio.dev/api/v3.1/custom/toolkits/upsert \
   --header "x-api-key: $COMPOSIO_API_KEY" \
   --header "Content-Type: application/json" \
   --data '{
@@ -128,11 +128,11 @@ For DCR OAuth, the server must support the standard authorization-code flow. Oth
 
 ## Sync and resync tools
 
-Call `POST /api/v3/custom/toolkits/sync` to fetch the server's current tools:
+Call `POST /api/v3.1/custom/toolkits/sync` to fetch the server's current tools:
 
 ```bash
 curl --request POST \
-  --url https://backend.composio.dev/api/v3/custom/toolkits/sync \
+  --url https://backend.composio.dev/api/v3.1/custom/toolkits/sync \
   --header "x-api-key: $COMPOSIO_API_KEY" \
   --header "Content-Type: application/json" \
   --data '{
@@ -145,7 +145,7 @@ For an API-key or DCR OAuth server, `connected_account_id` must identify an acti
 
 ```bash
 curl --request POST \
-  --url https://backend.composio.dev/api/v3/custom/toolkits/sync \
+  --url https://backend.composio.dev/api/v3.1/custom/toolkits/sync \
   --header "x-api-key: $COMPOSIO_API_KEY" \
   --header "Content-Type: application/json" \
   --data '{

--- a/docs/content/docs/extending-sessions/custom-mcp.mdx
+++ b/docs/content/docs/extending-sessions/custom-mcp.mdx
@@ -116,15 +116,15 @@ To change the server URL, name, or authentication scheme, [delete the existing t
 
 ## Complete setup for your authentication mode
 
-Registration has different next steps depending on how the MCP server authenticates requests:
+Choose the mode that matches your server, then complete any required connection:
 
-| Authentication | Connected account required | Initial sync |
+| Authentication | Use it when | After registration |
 | --- | --- | --- |
-| No auth | No | Runs automatically during registration. |
-| API key | Yes | Starts in the background when the first connection becomes active. |
-| DCR OAuth | Yes | Starts in the background when the first authorized connection becomes active. |
+| No auth | The server accepts requests without credentials. | No connection is required. Initial sync runs automatically. |
+| API key | Each connected account supplies an API key. | Create an active connection. Initial sync then starts in the background. |
+| DCR OAuth | The server supports OAuth Dynamic Client Registration. | Authorize a connection. Initial sync starts when it becomes active. |
 
-For API-key and DCR OAuth servers, create a connected account for the registered toolkit and wait for it to become active. Composio then starts the initial sync without a separate sync request.
+For DCR OAuth, the server must support the standard authorization-code flow. Other OAuth grant types aren't supported.
 
 ## Sync and resync tools
 
@@ -199,18 +199,6 @@ curl --request DELETE \
 <Callout type="warn" title="Deletion also removes connections">
 Deletion removes the custom toolkit and its tools. It also revokes and removes the toolkit's auth configurations and connected accounts. Any replacement starts with new connections.
 </Callout>
-
-## Authentication types
-
-Choose the authentication mode that matches your server:
-
-| Authentication | Use it when | What Composio does |
-| --- | --- | --- |
-| No auth | The server accepts requests without credentials. | Discovers and syncs tools during registration. |
-| API key | Each connection needs an API key. | Stores the key with the connected account and sends the configured header when discovering or calling tools. |
-| DCR OAuth | The server supports OAuth Dynamic Client Registration. | Uses each user's authorized connected account when discovering or calling tools. |
-
-For DCR OAuth, use a server that supports the standard authorization-code flow. Other OAuth grant types aren't supported.
 
 ## Use Custom MCP in a session
 

--- a/docs/content/docs/extending-sessions/custom-mcp.mdx
+++ b/docs/content/docs/extending-sessions/custom-mcp.mdx
@@ -117,7 +117,7 @@ Enter a recognizable name, the public MCP URL, and the authentication mode. Comp
 
 No-auth servers sync during registration. For API-key and DCR OAuth servers, create a connected account first, then run **Sync** from the toolkit.
 
-Composio rejects the sync if the server returns more than 100 tools. It does not silently import a partial tool list.
+Composio rejects the sync if the server returns more than 500 tools. It does not silently import a partial tool list.
 
 </Step>
 </Steps>
@@ -244,7 +244,7 @@ For a no-auth server, omit `connected_account_id`. A successful sync returns the
 }
 ```
 
-Run sync again whenever the remote server's tool definitions change. Each successful sync creates a toolkit version. If the server exposes more than 100 tools, the sync fails and the last successful version stays available.
+Run sync again whenever the remote server's tool definitions change. Each successful sync creates a toolkit version. If the server exposes more than 500 tools, the sync fails and the last successful version stays available.
 
 ### Delete a server
 
@@ -311,7 +311,7 @@ Custom MCP currently has these limitations:
 | Authenticated sessions don't reliably select a custom toolkit's connected account automatically. | Pass its ID through `connected_accounts` in Python or `connectedAccounts` in TypeScript. |
 | The v3 tools API uses a pinned default version that doesn't contain custom tools. | Use v3.1. On v3, explicitly select the version for listing, retrieval, or execution as described above. |
 | The `upsert` endpoint only registers new toolkits. It returns `409 Conflict` for an existing slug and can't update its settings. | Delete the custom toolkit, then register it again. Deletion also revokes and removes its connected accounts and auth configurations. |
-| A custom MCP toolkit can contain at most 100 tools. | Split larger servers into smaller MCP servers. If a later sync exceeds the limit, the last successful tool version stays available. |
+| A custom MCP toolkit can contain at most 500 tools. | Split larger servers into smaller MCP servers. If a later sync exceeds the limit, the last successful tool version stays available. |
 | API-key setup checks that a key was provided, not that the remote server accepts it. | Run a safe tool after connecting to verify the credential end to end. |
 
 ## Related guides

--- a/docs/content/docs/extending-sessions/custom-mcp.mdx
+++ b/docs/content/docs/extending-sessions/custom-mcp.mdx
@@ -55,7 +55,9 @@ Add the `CUSTOM_*` toolkit slug to a session. For an authenticated server, expli
 </Step>
 </Steps>
 
-The lifecycle endpoints below are API-first. If you prefer a UI, you can perform the same setup from your project's [**Toolkits** page](https://dashboard.composio.dev/~/project/toolkits?utm_source=docs&utm_medium=content&utm_campaign=docs-extending-sessions-custom-mcp).
+<Callout type="info" title="Dashboard management is coming soon">
+For now, use the lifecycle API endpoints below to register, sync, and delete Custom MCP toolkits. Dashboard management is still in development for customers who prefer a UI.
+</Callout>
 
 <Callout type="warn">
 These experimental endpoints aren't included in the public API reference or the TypeScript and Python SDKs yet. Their request and response formats may change.
@@ -158,7 +160,7 @@ Registration has different next steps depending on how the MCP server authentica
 | API key | Yes | Create and activate the connected account, then sync manually with its ID. |
 | DCR OAuth | Yes | Complete user authorization for the connected account, then sync manually with its ID. |
 
-For API-key and DCR OAuth servers, create the connected account from the registered toolkit's page in the dashboard. Wait until the connection is active before syncing.
+For API-key and DCR OAuth servers, create and activate a connected account for the registered toolkit before syncing. Wait until the connection is active before calling the sync endpoint.
 
 ## Sync and resync tools
 
@@ -355,7 +357,8 @@ Custom MCP currently has these limitations:
 
 | Gap | What to do |
 | --- | --- |
-| The SDKs don't expose registration, sync, update, or deletion methods yet. | Use the experimental lifecycle endpoints above or the dashboard, then use the toolkit slug through the SDK. |
+| The SDKs don't expose registration, sync, update, or deletion methods yet. | Use the experimental lifecycle endpoints above, then use the toolkit slug through the SDK. |
+| Dashboard management for Custom MCP isn't available yet. | Use the lifecycle API endpoints for now. Dashboard support is coming soon for customers who prefer a UI. |
 | Composio doesn't host your server. Local and STDIO-only servers aren't supported. | Deploy the server at a public HTTPS endpoint before registering it. |
 | Composio doesn't continuously sync tool changes, and authenticated connections don't trigger an initial sync. | Sync after an authenticated account becomes active and whenever the server's tool definitions change. |
 | Authenticated sessions don't reliably select a Custom MCP connected account automatically. | Pass its ID through `connected_accounts` in Python or `connectedAccounts` in TypeScript. |

--- a/docs/content/docs/extending-sessions/custom-mcp.mdx
+++ b/docs/content/docs/extending-sessions/custom-mcp.mdx
@@ -5,134 +5,65 @@ keywords: [custom mcp, bring your own mcp, remote mcp, custom toolkits, experime
 experimental: true
 ---
 
-Custom MCP lets you use tools hosted outside Composio in the same session as Composio's built-in toolkits. Register the remote server once, then add its `CUSTOM_*` toolkit slug to any session you create with the SDK.
+Custom MCP lets you use tools from your remote MCP server in the same session as Composio's built-in toolkits. Register the server once, sync its tools, then add its `CUSTOM_*` toolkit slug to a session.
 
 <Callout type="warn">
 Custom MCP is experimental. Its setup flow, authentication options, and API contracts may change while we work with early customers.
 </Callout>
 
-This is different from [Custom Tools and Toolkits](/docs/extending-sessions/custom-tools-and-toolkits). Custom tools run inside your application. A custom MCP server runs outside Composio and exposes its tools over a public MCP endpoint.
+This is different from [Custom Tools and Toolkits](/docs/extending-sessions/custom-tools-and-toolkits). Custom tools run inside your application. A custom MCP server runs outside Composio and exposes its tools over a public HTTPS endpoint.
 
-Register and sync the remote server in the dashboard, or use the experimental lifecycle API below. Then use one of these SDK flows:
+## Custom MCP lifecycle
 
-- **No auth:** Pass the custom toolkit slug when you create the session.
-- **API key or DCR OAuth:** Pass the toolkit slug and explicitly select its connected account.
-
-## Use a no-auth server
-
-Once a no-auth server is registered and synced, pass its toolkit slug when you create a session:
-
-<Tabs groupId="language" items={['Python', 'TypeScript']} persist>
-<Tab value="Python">
-```python
-from composio import Composio
-
-composio = Composio(api_key="your_api_key")
-
-session = composio.sessions.create(
-    user_id="user_123",
-    toolkits=["CUSTOM_ACME"],
-)
-
-tools = session.tools()
-```
-</Tab>
-<Tab value="TypeScript">
-```typescript
-import { Composio } from "@composio/core";
-
-const composio = new Composio({ apiKey: "your_api_key" });
-
-const session = await composio.sessions.create("user_123", {
-  toolkits: ["CUSTOM_ACME"],
-});
-
-const tools = await session.tools();
-```
-</Tab>
-</Tabs>
-
-With the default search-first session, your agent can discover the custom tools through `COMPOSIO_SEARCH_TOOLS` and execute them through the Tool Router.
-
-## Use an authenticated server
-
-For API-key and DCR OAuth servers, explicitly select the connected account in the session config. Don't rely on automatic account matching for custom MCP toolkits yet.
-
-<Tabs groupId="language" items={['Python', 'TypeScript']} persist>
-<Tab value="Python">
-```python
-from composio import Composio
-
-composio = Composio(api_key="your_api_key")
-
-session = composio.sessions.create(
-    user_id="user_123",
-    toolkits=["CUSTOM_ACME"],
-    connected_accounts={
-        "CUSTOM_ACME": ["ca_custom_acme"],
-    },
-)
-```
-</Tab>
-<Tab value="TypeScript">
-```typescript
-import { Composio } from "@composio/core";
-
-const composio = new Composio({ apiKey: "your_api_key" });
-
-const session = await composio.sessions.create("user_123", {
-  toolkits: ["CUSTOM_ACME"],
-  connectedAccounts: {
-    CUSTOM_ACME: ["ca_custom_acme"],
-  },
-});
-```
-</Tab>
-</Tabs>
-
-The pinned account must belong to the custom toolkit and be active. Explicit selection ensures tool calls use its credentials.
-
-## Register the remote server
-
-The TypeScript and Python SDKs don't expose the custom MCP registration lifecycle yet. Register the server once from your project's [**Toolkits** page](https://dashboard.composio.dev/~/project/toolkits?utm_source=docs&utm_medium=content&utm_campaign=docs-extending-sessions-custom-mcp) in the Composio dashboard:
+A Custom MCP moves through this lifecycle:
 
 <Steps>
 <Step>
 
 ### Deploy the server
 
-Make your remote MCP server available at a public HTTPS URL. Composio connects to the server and proxies tool calls, but it does not host the server for you.
+Host your MCP server at a public HTTPS URL. Composio connects to the server, but it does not deploy or host it for you.
 
 </Step>
 <Step>
 
-### Add it as a toolkit
+### Register it
 
-Enter a recognizable name, the public MCP URL, and the authentication mode. Composio reads the server's MCP metadata and creates a project-scoped toolkit whose slug starts with `CUSTOM_`.
+Call the registration endpoint with the server URL and its authentication scheme. Composio creates a project-scoped toolkit whose slug starts with `CUSTOM_`.
 
 </Step>
 <Step>
 
-### Connect and sync
+### Connect it when authentication is required
 
-No-auth servers sync during registration. For API-key and DCR OAuth servers, create a connected account first, then run **Sync** from the toolkit.
+No-auth servers don't need a connected account. For API-key and DCR OAuth servers, create and activate a connected account before syncing tools.
 
-Composio rejects the sync if the server returns more than 500 tools. It does not silently import a partial tool list.
+</Step>
+<Step>
+
+### Sync its tools
+
+No-auth registration performs the initial sync automatically. Authenticated servers require a manual initial sync. Every server requires another manual sync after its tool definitions change.
+
+</Step>
+<Step>
+
+### Use it in a session
+
+Add the `CUSTOM_*` toolkit slug to a session. For an authenticated server, explicitly select the connected account that holds its credentials.
 
 </Step>
 </Steps>
 
-## Manage Custom MCP through the API
-
-Use these endpoints when you need to automate registration, synchronization, or deletion. Authenticate each request with your Composio project API key.
+The lifecycle endpoints below are API-first. If you prefer a UI, you can perform the same setup from your project's [**Toolkits** page](https://dashboard.composio.dev/~/project/toolkits?utm_source=docs&utm_medium=content&utm_campaign=docs-extending-sessions-custom-mcp).
 
 <Callout type="warn">
 These experimental endpoints aren't included in the public API reference or the TypeScript and Python SDKs yet. Their request and response formats may change.
 </Callout>
 
-### Add a server
+## Register a Custom MCP
 
-Call `POST /api/v3/custom/toolkits/upsert` with the server URL and its authentication scheme:
+Call `POST /api/v3/custom/toolkits/upsert` with your public server URL and authentication scheme. Authenticate the request with your Composio project API key.
 
 <Tabs items={['No auth', 'API key', 'DCR OAuth']}>
 <Tab value="No auth">
@@ -214,14 +145,24 @@ Composio adds the `CUSTOM_` prefix and returns the normalized toolkit slug:
 <Callout type="warn" title="This endpoint only registers new toolkits">
 Despite `upsert` in the route name, this endpoint does not update or replace an existing toolkit. If the slug already exists, the request returns `409 Conflict`.
 
-To change the server URL, name, or authentication scheme, [delete the existing toolkit](#delete-a-server), then register it again. Deletion also revokes and removes the toolkit's auth configurations and connected accounts.
+To change the server URL, name, or authentication scheme, [delete the existing toolkit](#delete-or-replace-a-custom-mcp), then register it again. Deletion also revokes and removes the toolkit's auth configurations and connected accounts.
 </Callout>
 
-No-auth servers sync automatically when you add them. For API-key and DCR OAuth servers, create and activate a connected account from the toolkit's dashboard page before syncing.
+## Complete setup for your authentication mode
 
-### Sync tools
+Registration has different next steps depending on how the MCP server authenticates requests:
 
-Call `POST /api/v3/custom/toolkits/sync` to fetch the server's current tools. An authenticated server requires an active connected account from the same toolkit and project:
+| Authentication | Connected account required | Initial sync |
+| --- | --- | --- |
+| No auth | No | Runs automatically during registration. |
+| API key | Yes | Create and activate the connected account, then sync manually with its ID. |
+| DCR OAuth | Yes | Complete user authorization for the connected account, then sync manually with its ID. |
+
+For API-key and DCR OAuth servers, create the connected account from the registered toolkit's page in the dashboard. Wait until the connection is active before syncing.
+
+## Sync and resync tools
+
+Call `POST /api/v3/custom/toolkits/sync` to fetch the server's current tools:
 
 ```bash
 curl --request POST \
@@ -234,7 +175,19 @@ curl --request POST \
   }'
 ```
 
-For a no-auth server, omit `connected_account_id`. A successful sync returns the new toolkit version and the number of tools discovered:
+For an API-key or DCR OAuth server, `connected_account_id` must identify an active account from the same toolkit and project. For a no-auth server, omit it:
+
+```bash
+curl --request POST \
+  --url https://backend.composio.dev/api/v3/custom/toolkits/sync \
+  --header "x-api-key: $COMPOSIO_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "slug": "CUSTOM_ACME"
+  }'
+```
+
+A successful sync returns the toolkit version and the number of tools discovered:
 
 ```json
 {
@@ -244,9 +197,17 @@ For a no-auth server, omit `connected_account_id`. A successful sync returns the
 }
 ```
 
-Run sync again whenever the remote server's tool definitions change. Each successful sync creates a toolkit version. If the server exposes more than 500 tools, the sync fails and the last successful version stays available.
+<Callout type="info" title="Sync is not continuous">
+No-auth registration performs one automatic initial sync. Composio does not watch your MCP server for later tool changes, and connecting an authenticated account does not trigger a sync.
 
-### Delete a server
+Run this endpoint again whenever the server's tool definitions change. Each successful sync creates a toolkit version.
+</Callout>
+
+A Custom MCP toolkit can contain at most 500 tools. If the server returns more than 500, the sync fails without importing a partial tool list. The last successful version stays available.
+
+## Delete or replace a Custom MCP
+
+The registration endpoint cannot update an existing toolkit. To replace its URL, name, or authentication scheme, delete the toolkit and register it again.
 
 Call `DELETE /api/v3.1/custom/toolkits/{slug}`:
 
@@ -266,21 +227,110 @@ curl --request DELETE \
 }
 ```
 
-Deletion removes the custom toolkit and its tools. It also revokes and removes the toolkit's auth configurations and connected accounts, so only delete a toolkit when you no longer need its existing connections.
+<Callout type="warn" title="Deletion also removes connections">
+Deletion removes the custom toolkit and its tools. It also revokes and removes the toolkit's auth configurations and connected accounts. Any replacement starts with new connections.
+</Callout>
 
-## Supported authentication
+## Authentication types
 
 Choose the authentication mode that matches your server:
 
-| Authentication | Use it when | What happens |
+| Authentication | Use it when | What Composio does |
 | --- | --- | --- |
-| No auth | The server accepts requests without credentials. | Composio can discover and sync tools as soon as you register the server. |
-| API key | Each connection needs an API key. | Composio stores the key with the connected account and sends it to the server on tool calls. |
-| DCR OAuth | The server supports OAuth Dynamic Client Registration. | Each user authorizes a connected account before Composio calls authenticated tools. |
+| No auth | The server accepts requests without credentials. | Discovers and syncs tools during registration. |
+| API key | Each connection needs an API key. | Stores the key with the connected account and sends the configured header when discovering or calling tools. |
+| DCR OAuth | The server supports OAuth Dynamic Client Registration. | Uses each user's authorized connected account when discovering or calling tools. |
 
 For DCR OAuth, use a server that supports the standard authorization-code flow. Other OAuth grant types aren't supported.
 
-## What Composio creates
+## Use Custom MCP in a session
+
+Once the toolkit is synced, add its `CUSTOM_*` slug to a session.
+
+### Use a no-auth server
+
+Pass the toolkit slug when you create the session:
+
+<Tabs groupId="language" items={['Python', 'TypeScript']} persist>
+<Tab value="Python">
+```python
+from composio import Composio
+
+composio = Composio(api_key="your_api_key")
+
+session = composio.sessions.create(
+    user_id="user_123",
+    toolkits=["CUSTOM_ACME"],
+)
+
+tools = session.tools()
+```
+</Tab>
+<Tab value="TypeScript">
+```typescript
+import { Composio } from "@composio/core";
+
+const composio = new Composio({ apiKey: "your_api_key" });
+
+const session = await composio.sessions.create("user_123", {
+  toolkits: ["CUSTOM_ACME"],
+});
+
+const tools = await session.tools();
+```
+</Tab>
+</Tabs>
+
+With the default search-first session, your agent can discover the custom tools through `COMPOSIO_SEARCH_TOOLS` and execute them through the Tool Router.
+
+### Use an authenticated server
+
+For API-key and DCR OAuth servers, explicitly select the connected account in the session config. Don't rely on automatic account matching for Custom MCP toolkits yet.
+
+<Tabs groupId="language" items={['Python', 'TypeScript']} persist>
+<Tab value="Python">
+```python
+from composio import Composio
+
+composio = Composio(api_key="your_api_key")
+
+session = composio.sessions.create(
+    user_id="user_123",
+    toolkits=["CUSTOM_ACME"],
+    connected_accounts={
+        "CUSTOM_ACME": ["ca_custom_acme"],
+    },
+)
+```
+</Tab>
+<Tab value="TypeScript">
+```typescript
+import { Composio } from "@composio/core";
+
+const composio = new Composio({ apiKey: "your_api_key" });
+
+const session = await composio.sessions.create("user_123", {
+  toolkits: ["CUSTOM_ACME"],
+  connectedAccounts: {
+    CUSTOM_ACME: ["ca_custom_acme"],
+  },
+});
+```
+</Tab>
+</Tabs>
+
+The pinned account must belong to the custom toolkit and be active. Explicit selection ensures tool calls use its credentials.
+
+## What you manage and what Composio handles
+
+| Area | You manage | Composio handles |
+| --- | --- | --- |
+| Server | Deploying and operating the remote MCP server at a public HTTPS URL. | Connecting to the URL for tool discovery and execution. Composio does not host the server. |
+| Tools | Implementing tools and deciding when their definitions are ready to resync. | Importing tool schemas during sync, versioning them, and exposing them to sessions. |
+| Authentication | Implementing the server's API-key or DCR OAuth behavior and completing each required connection. | Storing connected-account credentials and sending them when discovering or calling tools. |
+| Lifecycle | Choosing when to resync, delete, or replace the toolkit. | Providing the project-scoped registration, sync, and deletion operations. |
+
+## Technical behavior
 
 Each registered server becomes a custom toolkit scoped to your project:
 
@@ -305,13 +355,13 @@ Custom MCP currently has these limitations:
 
 | Gap | What to do |
 | --- | --- |
-| The SDKs don't expose registration, sync, update, or deletion methods yet. | Use the dashboard or the experimental lifecycle endpoints above, then use the toolkit slug through the SDK. |
+| The SDKs don't expose registration, sync, update, or deletion methods yet. | Use the experimental lifecycle endpoints above or the dashboard, then use the toolkit slug through the SDK. |
 | Composio doesn't host your server. Local and STDIO-only servers aren't supported. | Deploy the server at a public HTTPS endpoint before registering it. |
-| Authenticated servers don't automatically sync when a connection becomes active. | Create the connected account, then run **Sync** from the toolkit. |
-| Authenticated sessions don't reliably select a custom toolkit's connected account automatically. | Pass its ID through `connected_accounts` in Python or `connectedAccounts` in TypeScript. |
+| Composio doesn't continuously sync tool changes, and authenticated connections don't trigger an initial sync. | Sync after an authenticated account becomes active and whenever the server's tool definitions change. |
+| Authenticated sessions don't reliably select a Custom MCP connected account automatically. | Pass its ID through `connected_accounts` in Python or `connectedAccounts` in TypeScript. |
 | The v3 tools API uses a pinned default version that doesn't contain custom tools. | Use v3.1. On v3, explicitly select the version for listing, retrieval, or execution as described above. |
 | The `upsert` endpoint only registers new toolkits. It returns `409 Conflict` for an existing slug and can't update its settings. | Delete the custom toolkit, then register it again. Deletion also revokes and removes its connected accounts and auth configurations. |
-| A custom MCP toolkit can contain at most 500 tools. | Split larger servers into smaller MCP servers. If a later sync exceeds the limit, the last successful tool version stays available. |
+| A Custom MCP toolkit can contain at most 500 tools. | Split larger servers into smaller MCP servers. If a later sync exceeds the limit, the last successful tool version stays available. |
 | API-key setup checks that a key was provided, not that the remote server accepts it. | Run a safe tool after connecting to verify the credential end to end. |
 
 ## Related guides

--- a/docs/content/docs/extending-sessions/custom-mcp.mdx
+++ b/docs/content/docs/extending-sessions/custom-mcp.mdx
@@ -94,7 +94,7 @@ The pinned account must belong to the custom toolkit and be active. Explicit sel
 
 ## Register the remote server
 
-The TypeScript and Python SDKs don't expose the custom MCP registration lifecycle yet. Register the server once from your project's [**Toolkits** page](https://dashboard.composio.dev/~/project/toolkits?utm_source=docs&utm_medium=content&utm_campaign=docs-extending-sessions-custom-mcp-servers) in the Composio dashboard:
+The TypeScript and Python SDKs don't expose the custom MCP registration lifecycle yet. Register the server once from your project's [**Toolkits** page](https://dashboard.composio.dev/~/project/toolkits?utm_source=docs&utm_medium=content&utm_campaign=docs-extending-sessions-custom-mcp) in the Composio dashboard:
 
 <Steps>
 <Step>

--- a/docs/content/docs/extending-sessions/custom-mcp.mdx
+++ b/docs/content/docs/extending-sessions/custom-mcp.mdx
@@ -5,7 +5,7 @@ keywords: [custom mcp, bring your own mcp, remote mcp, custom toolkits, experime
 experimental: true
 ---
 
-Custom MCP lets you use tools from your remote MCP server in the same session as Composio's built-in toolkits. Register the server once, sync its tools, then add its `CUSTOM_*` toolkit slug to a session.
+Custom MCP lets you use tools from your remote MCP server in the same session as Composio's built-in toolkits. Register the server, connect it if authentication is required, then add its synced `CUSTOM_*` toolkit slug to a session.
 
 <Callout type="warn">
 Custom MCP is experimental. Its setup flow, authentication options, and API contracts may change while we work with early customers.
@@ -17,50 +17,14 @@ This is different from [Custom Tools and Toolkits](/docs/extending-sessions/cust
 
 A Custom MCP moves through this lifecycle:
 
-<Steps>
-<Step>
+1. **Deploy** your MCP server at a public HTTPS URL.
+2. **Register** its URL and authentication scheme. Composio creates a project-scoped `CUSTOM_*` toolkit.
+3. **Connect** an account if the server uses an API key or DCR OAuth. No-auth servers skip this step.
+4. **Sync** its tools. The first sync starts automatically; later tool changes require a manual sync.
+5. **Use** the toolkit in a session. For authenticated servers, explicitly select the connected account.
 
-### Deploy the server
-
-Host your MCP server at a public HTTPS URL. Composio connects to the server, but it does not deploy or host it for you.
-
-</Step>
-<Step>
-
-### Register it
-
-Call the registration endpoint with the server URL and its authentication scheme. Composio creates a project-scoped toolkit whose slug starts with `CUSTOM_`.
-
-</Step>
-<Step>
-
-### Connect it when authentication is required
-
-No-auth servers don't need a connected account. For API-key and DCR OAuth servers, create and activate a connected account before syncing tools.
-
-</Step>
-<Step>
-
-### Sync its tools
-
-No-auth registration performs the initial sync automatically. Authenticated servers require a manual initial sync. Every server requires another manual sync after its tool definitions change.
-
-</Step>
-<Step>
-
-### Use it in a session
-
-Add the `CUSTOM_*` toolkit slug to a session. For an authenticated server, explicitly select the connected account that holds its credentials.
-
-</Step>
-</Steps>
-
-<Callout type="info" title="Dashboard management is coming soon">
-For now, use the lifecycle API endpoints below to register, sync, and delete Custom MCP toolkits. Dashboard management is still in development for customers who prefer a UI.
-</Callout>
-
-<Callout type="warn">
-These experimental endpoints aren't included in the public API reference or the TypeScript and Python SDKs yet. Their request and response formats may change.
+<Callout type="warn" title="API-only while Custom MCP is experimental">
+Use the lifecycle endpoints below to register, sync, and delete Custom MCP toolkits. They aren't included in the public API reference or SDKs yet, and their contracts may change. Dashboard management is coming soon for customers who prefer a UI.
 </Callout>
 
 ## Register a Custom MCP
@@ -157,10 +121,10 @@ Registration has different next steps depending on how the MCP server authentica
 | Authentication | Connected account required | Initial sync |
 | --- | --- | --- |
 | No auth | No | Runs automatically during registration. |
-| API key | Yes | Create and activate the connected account, then sync manually with its ID. |
-| DCR OAuth | Yes | Complete user authorization for the connected account, then sync manually with its ID. |
+| API key | Yes | Starts in the background when the first connection becomes active. |
+| DCR OAuth | Yes | Starts in the background when the first authorized connection becomes active. |
 
-For API-key and DCR OAuth servers, create and activate a connected account for the registered toolkit before syncing. Wait until the connection is active before calling the sync endpoint.
+For API-key and DCR OAuth servers, create a connected account for the registered toolkit and wait for it to become active. Composio then starts the initial sync without a separate sync request.
 
 ## Sync and resync tools
 
@@ -199,10 +163,10 @@ A successful sync returns the toolkit version and the number of tools discovered
 }
 ```
 
-<Callout type="info" title="Sync is not continuous">
-No-auth registration performs one automatic initial sync. Composio does not watch your MCP server for later tool changes, and connecting an authenticated account does not trigger a sync.
+<Callout type="info" title="Initial sync is automatic; later syncs are manual">
+No-auth registration starts the initial sync immediately. For API-key and DCR OAuth servers, the initial sync starts in the background when the first connected account becomes active.
 
-Run this endpoint again whenever the server's tool definitions change. Each successful sync creates a toolkit version.
+This is not continuous sync. Later connections don't resync a toolkit that already has tools. Run this endpoint if the initial background sync doesn't populate the toolkit or whenever the server's tool definitions change. Each successful sync creates a toolkit version.
 </Callout>
 
 A Custom MCP toolkit can contain at most 500 tools. If the server returns more than 500, the sync fails without importing a partial tool list. The last successful version stays available.
@@ -328,7 +292,7 @@ The pinned account must belong to the custom toolkit and be active. Explicit sel
 | Area | You manage | Composio handles |
 | --- | --- | --- |
 | Server | Deploying and operating the remote MCP server at a public HTTPS URL. | Connecting to the URL for tool discovery and execution. Composio does not host the server. |
-| Tools | Implementing tools and deciding when their definitions are ready to resync. | Importing tool schemas during sync, versioning them, and exposing them to sessions. |
+| Tools | Implementing tools and deciding when later definition changes are ready to sync. | Starting the initial sync, importing tool schemas, versioning them, and exposing them to sessions. |
 | Authentication | Implementing the server's API-key or DCR OAuth behavior and completing each required connection. | Storing connected-account credentials and sending them when discovering or calling tools. |
 | Lifecycle | Choosing when to resync, delete, or replace the toolkit. | Providing the project-scoped registration, sync, and deletion operations. |
 
@@ -353,23 +317,35 @@ See [Toolkit Versioning](/docs/tools-direct/toolkit-versioning) for more example
 
 ## Known gaps
 
-Custom MCP currently has these limitations:
+<Accordions>
+<Accordion title="Setup and lifecycle">
 
-| Gap | What to do |
-| --- | --- |
-| The SDKs don't expose registration, sync, update, or deletion methods yet. | Use the experimental lifecycle endpoints above, then use the toolkit slug through the SDK. |
-| Dashboard management for Custom MCP isn't available yet. | Use the lifecycle API endpoints for now. Dashboard support is coming soon for customers who prefer a UI. |
-| Composio doesn't host your server. Local and STDIO-only servers aren't supported. | Deploy the server at a public HTTPS endpoint before registering it. |
-| Composio doesn't continuously sync tool changes, and authenticated connections don't trigger an initial sync. | Sync after an authenticated account becomes active and whenever the server's tool definitions change. |
-| Authenticated sessions don't reliably select a Custom MCP connected account automatically. | Pass its ID through `connected_accounts` in Python or `connectedAccounts` in TypeScript. |
-| The v3 tools API uses a pinned default version that doesn't contain custom tools. | Use v3.1. On v3, explicitly select the version for listing, retrieval, or execution as described above. |
-| The `upsert` endpoint only registers new toolkits. It returns `409 Conflict` for an existing slug and can't update its settings. | Delete the custom toolkit, then register it again. Deletion also revokes and removes its connected accounts and auth configurations. |
-| A Custom MCP toolkit can contain at most 500 tools. | Split larger servers into smaller MCP servers. If a later sync exceeds the limit, the last successful tool version stays available. |
-| API-key setup checks that a key was provided, not that the remote server accepts it. | Run a safe tool after connecting to verify the credential end to end. |
+- **API-only setup:** The SDKs don't expose registration, sync, update, or deletion methods yet. Use the lifecycle endpoints on this page, then use the toolkit slug through the SDK.
+- **Dashboard coming soon:** Custom MCP management isn't available in the dashboard yet.
+- **Remote servers only:** Composio doesn't host your server. Deploy it at a public HTTPS endpoint; local and STDIO-only servers aren't supported.
+- **Insert-only registration:** The `upsert` endpoint returns `409 Conflict` for an existing slug. Delete the toolkit, then register it again. Deletion also removes its auth configurations and connected accounts.
+- **500-tool limit:** Split larger servers into smaller MCP servers. If a later sync exceeds the limit, the last successful version stays available.
+
+</Accordion>
+<Accordion title="Sync and authentication">
+
+- **No continuous sync:** Auto-sync only populates an empty toolkit during registration or the first active connection. If it fails, call the sync endpoint with an active connected account. Sync again whenever tool definitions change.
+- **API-key validation is limited:** Setup checks that a key was provided, not that the remote server accepts it. Run a safe tool after connecting to verify the credential end to end.
+
+</Accordion>
+<Accordion title="Sessions and tool APIs">
+
+- **Select authenticated accounts explicitly:** Custom MCP sessions don't reliably match a connected account automatically. Pass its ID through `connected_accounts` in Python or `connectedAccounts` in TypeScript.
+- **Prefer the v3.1 tools API:** The v3 tools API pins a default version that doesn't contain custom tools. If you must use v3, explicitly select `latest` as described above.
+
+</Accordion>
+</Accordions>
 
 ## Related guides
 
-- [Using sessions via MCP](/docs/sessions-via-mcp) explains how an MCP client connects to a Composio-hosted session.
-- [Custom Tools and Toolkits](/docs/extending-sessions/custom-tools-and-toolkits) explains how to run your own tools inside your application process.
-- [Configuring Sessions](/docs/configuring-sessions) explains toolkit and tool filtering.
-- [Managing Multiple Connected Accounts](/docs/managing-multiple-connected-accounts) explains explicit account selection.
+<Cards>
+<Card title="Using sessions via MCP" href="/docs/sessions-via-mcp" description="Connect an MCP client to a Composio-hosted session" />
+<Card title="Custom Tools and Toolkits" href="/docs/extending-sessions/custom-tools-and-toolkits" description="Run your own tools inside your application process" />
+<Card title="Configuring Sessions" href="/docs/configuring-sessions" description="Configure toolkit and tool filtering" />
+<Card title="Managing Multiple Connected Accounts" href="/docs/managing-multiple-connected-accounts" description="Select a connected account explicitly" />
+</Cards>

--- a/docs/content/docs/extending-sessions/custom-mcp.mdx
+++ b/docs/content/docs/extending-sessions/custom-mcp.mdx
@@ -211,7 +211,11 @@ Composio adds the `CUSTOM_` prefix and returns the normalized toolkit slug:
 }
 ```
 
-Registration is create-only for this endpoint. If the slug already exists, the request returns `409 Conflict`.
+<Callout type="warn" title="This endpoint only registers new toolkits">
+Despite `upsert` in the route name, this endpoint does not update or replace an existing toolkit. If the slug already exists, the request returns `409 Conflict`.
+
+To change the server URL, name, or authentication scheme, [delete the existing toolkit](#delete-a-server), then register it again. Deletion also revokes and removes the toolkit's auth configurations and connected accounts.
+</Callout>
 
 No-auth servers sync automatically when you add them. For API-key and DCR OAuth servers, create and activate a connected account from the toolkit's dashboard page before syncing.
 
@@ -306,7 +310,7 @@ Custom MCP currently has these limitations:
 | Authenticated servers don't automatically sync when a connection becomes active. | Create the connected account, then run **Sync** from the toolkit. |
 | Authenticated sessions don't reliably select a custom toolkit's connected account automatically. | Pass its ID through `connected_accounts` in Python or `connectedAccounts` in TypeScript. |
 | The v3 tools API uses a pinned default version that doesn't contain custom tools. | Use v3.1. On v3, explicitly select the version for listing, retrieval, or execution as described above. |
-| Registered server settings can't be edited in place. | Delete the custom toolkit and register it again. Deleting it also revokes and removes its connected accounts and auth configurations. |
+| The `upsert` endpoint only registers new toolkits. It returns `409 Conflict` for an existing slug and can't update its settings. | Delete the custom toolkit, then register it again. Deletion also revokes and removes its connected accounts and auth configurations. |
 | A custom MCP toolkit can contain at most 100 tools. | Split larger servers into smaller MCP servers. If a later sync exceeds the limit, the last successful tool version stays available. |
 | API-key setup checks that a key was provided, not that the remote server accepts it. | Run a safe tool after connecting to verify the credential end to end. |
 

--- a/docs/content/docs/extending-sessions/custom-mcp.mdx
+++ b/docs/content/docs/extending-sessions/custom-mcp.mdx
@@ -163,10 +163,13 @@ A successful sync returns the toolkit version and the number of tools discovered
 }
 ```
 
-<Callout type="info" title="Initial sync is automatic; later syncs are manual">
-No-auth registration starts the initial sync immediately. For API-key and DCR OAuth servers, the initial sync starts in the background when the first connected account becomes active.
+<Callout type="info" title="When to sync manually">
+Composio starts the initial sync automatically:
 
-This is not continuous sync. Later connections don't resync a toolkit that already has tools. Run this endpoint if the initial background sync doesn't populate the toolkit or whenever the server's tool definitions change. Each successful sync creates a toolkit version.
+- **No auth:** during registration
+- **API key or DCR OAuth:** when the first connected account becomes active
+
+Call the sync endpoint only if the initial sync fails or the server's tool definitions change. Later connections don't resync a toolkit that already has tools.
 </Callout>
 
 A Custom MCP toolkit can contain at most 500 tools. If the server returns more than 500, the sync fails without importing a partial tool list. The last successful version stays available.

--- a/docs/content/docs/extending-sessions/meta.json
+++ b/docs/content/docs/extending-sessions/meta.json
@@ -3,6 +3,7 @@
   "defaultOpen": true,
   "pages": [
     "proxy-execute",
-    "custom-tools-and-toolkits"
+    "custom-tools-and-toolkits",
+    "custom-mcp-servers"
   ]
 }

--- a/docs/content/docs/extending-sessions/meta.json
+++ b/docs/content/docs/extending-sessions/meta.json
@@ -4,6 +4,6 @@
   "pages": [
     "proxy-execute",
     "custom-tools-and-toolkits",
-    "custom-mcp-servers"
+    "custom-mcp"
   ]
 }

--- a/docs/content/docs/sessions-via-mcp.mdx
+++ b/docs/content/docs/sessions-via-mcp.mdx
@@ -9,7 +9,7 @@ By default Composio gives your agent **tools it can call directly**. Composio fo
 If you'd rather connect over the [Model Context Protocol](https://modelcontextprotocol.io), every session also exposes a hosted MCP endpoint. This is useful when you want to plug a session into an MCP-native client like Claude Desktop, Cursor, or any framework's MCP transport. No provider package required.
 
 <Callout type="info">
-Want to bring tools from your own remote MCP server into Composio instead? See [Custom MCP servers](/docs/extending-sessions/custom-mcp-servers).
+Want to bring tools from your own remote MCP server into Composio instead? See [Custom MCP](/docs/extending-sessions/custom-mcp-servers).
 </Callout>
 
 ## The MCP endpoint

--- a/docs/content/docs/sessions-via-mcp.mdx
+++ b/docs/content/docs/sessions-via-mcp.mdx
@@ -8,6 +8,10 @@ By default Composio gives your agent **tools it can call directly**. Composio fo
 
 If you'd rather connect over the [Model Context Protocol](https://modelcontextprotocol.io), every session also exposes a hosted MCP endpoint. This is useful when you want to plug a session into an MCP-native client like Claude Desktop, Cursor, or any framework's MCP transport. No provider package required.
 
+<Callout type="info">
+Want to bring tools from your own remote MCP server into Composio instead? See [Custom MCP servers](/docs/extending-sessions/custom-mcp-servers).
+</Callout>
+
 ## The MCP endpoint
 
 Opt into MCP by passing `mcp: true` when you create the session. The session then exposes its hosted MCP server. Read the URL and headers off `session.mcp`:

--- a/docs/content/docs/sessions-via-mcp.mdx
+++ b/docs/content/docs/sessions-via-mcp.mdx
@@ -9,7 +9,7 @@ By default Composio gives your agent **tools it can call directly**. Composio fo
 If you'd rather connect over the [Model Context Protocol](https://modelcontextprotocol.io), every session also exposes a hosted MCP endpoint. This is useful when you want to plug a session into an MCP-native client like Claude Desktop, Cursor, or any framework's MCP transport. No provider package required.
 
 <Callout type="info">
-Want to bring tools from your own remote MCP server into Composio instead? See [Custom MCP](/docs/extending-sessions/custom-mcp-servers).
+Want to bring tools from your own remote MCP server into Composio instead? See [Custom MCP](/docs/extending-sessions/custom-mcp).
 </Callout>
 
 ## The MCP endpoint

--- a/docs/content/docs/tools-direct/toolkit-versioning.mdx
+++ b/docs/content/docs/tools-direct/toolkit-versioning.mdx
@@ -25,18 +25,18 @@ Starting from Python SDK v0.9.0 and TypeScript SDK v0.2.0, specifying versions i
 ## Default version behavior
 
 <Callout type="warn">
-When no version is specified, the API defaults to the base version (`00000000_00`), **not** the latest version. This means the response may contain fewer tools than what's shown on the [platform UI](https://dashboard.composio.dev?utm_source=docs&utm_medium=content&utm_campaign=docs-tools-direct-toolkit-versioning). To get all available tools including ones added in newer versions, explicitly set `toolkit_versions` to `"latest"` or a specific version.
+The v3 API defaults to the base version (`00000000_00`) when you don't specify a version. This can return fewer tools than the [platform UI](https://dashboard.composio.dev?utm_source=docs&utm_medium=content&utm_campaign=docs-tools-direct-toolkit-versioning). Pass `toolkit_versions=latest` or a specific version to select a newer version. The v3.1 tools API defaults to the latest version.
 </Callout>
 
-This applies to both the SDK and direct REST API calls:
+For example, a v3 tools-list request without `toolkit_versions` returns the base version:
 
 ```bash
-# Without version — returns only tools from the base version
-curl 'https://backend.composio.dev/api/v3.1/tools?toolkit_slug=googledrive' \
+# Without toolkit_versions: returns tools from the base version
+curl 'https://backend.composio.dev/api/v3/tools?toolkit_slug=googledrive' \
   -H 'x-api-key: YOUR_API_KEY'
 
-# With version=latest — returns all tools including newer ones
-curl 'https://backend.composio.dev/api/v3.1/tools?toolkit_slug=googledrive&toolkit_versions=latest' \
+# With toolkit_versions=latest: returns tools from the latest version
+curl 'https://backend.composio.dev/api/v3/tools?toolkit_slug=googledrive&toolkit_versions=latest' \
   -H 'x-api-key: YOUR_API_KEY'
 ```
 

--- a/docs/superpowers/plans/2026-07-29-custom-mcp-lifecycle-doc-flow.md
+++ b/docs/superpowers/plans/2026-07-29-custom-mcp-lifecycle-doc-flow.md
@@ -1,0 +1,183 @@
+# Custom MCP Lifecycle Documentation Flow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reorganize the Custom MCP guide into an API-first lifecycle that takes a developer from registration through authenticated setup, syncing, SDK usage, and deletion.
+
+**Architecture:** Keep the existing `custom-mcp.mdx` route and verified endpoint examples. Reorder its content into one lifecycle, move reference material after the lifecycle, and add a compact operational responsibility boundary without changing platform or SDK contracts.
+
+**Tech Stack:** MDX, Fumadocs components, cURL, Python SDK examples, TypeScript SDK examples
+
+## Global Constraints
+
+- Custom MCP remains marked experimental.
+- Registration uses `POST /api/v3/custom/toolkits/upsert` and is insert-only.
+- Sync uses `POST /api/v3/custom/toolkits/sync`.
+- Delete uses `DELETE /api/v3.1/custom/toolkits/{slug}`.
+- No-auth registration performs the initial sync automatically.
+- API-key and DCR OAuth toolkits require an active connected account before syncing.
+- Later tool changes require manual resync.
+- A Custom MCP toolkit contains at most 500 tools.
+- Lifecycle operations are not exposed through the Python or TypeScript SDKs.
+- The dashboard remains a short alternative callout, not a parallel walkthrough.
+- Do not add a changeset for this docs-only change.
+
+---
+
+### Task 1: Reflow the Custom MCP lifecycle guide
+
+**Files:**
+- Modify: `docs/content/docs/extending-sessions/custom-mcp.mdx`
+
+**Interfaces:**
+- Consumes: Existing Custom MCP endpoint contracts, SDK examples, versioning guidance, and known gaps.
+- Produces: One API-first lifecycle guide at `/docs/extending-sessions/custom-mcp`.
+
+- [x] **Step 1: Replace the current disconnected section order**
+
+Reorder the existing content into:
+
+```text
+Introduction
+Custom MCP lifecycle
+Register a Custom MCP
+Complete setup for your authentication mode
+Sync and resync tools
+Delete or replace a Custom MCP
+Authentication types
+Use Custom MCP in a session
+What you manage and what Composio handles
+Technical behavior
+Known gaps
+Related guides
+```
+
+- [x] **Step 2: Keep registration API-first**
+
+Place the three existing `POST /api/v3/custom/toolkits/upsert` cURL examples under registration. Follow the response with the existing insert-only warning and a short callout linking to the dashboard Toolkits page as an alternative.
+
+- [x] **Step 3: Explain the authentication branch**
+
+Add a compact table immediately after registration:
+
+```text
+No auth -> initial sync happens during registration -> no connected account
+API key -> create and activate connected account -> sync with connected_account_id
+DCR OAuth -> complete user authorization -> sync with connected_account_id
+```
+
+- [x] **Step 4: Separate ongoing sync behavior**
+
+Keep the existing sync request and response. State directly that Composio does not continuously watch the server, later tool changes require another sync, each successful sync creates a version, and more than 500 tools causes the sync to fail without replacing the last successful version.
+
+- [x] **Step 5: Pair deletion with replacement semantics**
+
+Keep the existing delete request and response. State that the current replacement flow is delete, then register again, and that deletion revokes and removes the toolkit's existing authentication resources and connections.
+
+- [x] **Step 6: Move SDK usage after lifecycle management**
+
+Retain the Python and TypeScript examples for no-auth and authenticated sessions. Keep explicit `connected_accounts` and `connectedAccounts` selection for authenticated toolkits.
+
+- [x] **Step 7: Add the operational responsibility boundary**
+
+Add a two-column table:
+
+```text
+You manage -> remote server hosting and HTTPS availability; tool implementation; auth-provider behavior; deciding when to resync
+Composio handles -> project-scoped toolkit registration; connected-account credential storage; tool-schema sync and versions; proxied execution; session exposure
+```
+
+Use operational wording rather than contractual ownership language.
+
+- [x] **Step 8: Preserve technical behavior and known gaps**
+
+Keep toolkit slug behavior, Tool Router discovery, v3 versus v3.1 version selection, and every current known-gap row. Remove only duplicate prose that the lifecycle now explains more clearly.
+
+### Task 2: Verify the page
+
+**Files:**
+- Test: `docs/content/docs/extending-sessions/custom-mcp.mdx`
+
+**Interfaces:**
+- Consumes: The reflowed MDX page.
+- Produces: A buildable page whose rendered order matches the approved lifecycle.
+
+- [x] **Step 1: Check the diff**
+
+Run:
+
+```bash
+git diff --check
+git diff -- docs/content/docs/extending-sessions/custom-mcp.mdx
+```
+
+Expected: no whitespace errors and no endpoint or SDK contract drift.
+
+- [x] **Step 2: Validate links and types**
+
+Run from `docs/`:
+
+```bash
+bun run lint:links
+bun run types:check
+```
+
+Expected: zero link errors and successful type generation.
+
+- [x] **Step 3: Build the docs site**
+
+Run from `docs/` with Node.js 24:
+
+```bash
+PATH=/Users/shamsharoon/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH bun run build
+```
+
+Expected: the production build completes and generates all docs pages.
+
+- [x] **Step 4: Verify localhost**
+
+Run:
+
+```bash
+curl --fail http://localhost:3000/docs/extending-sessions/custom-mcp
+```
+
+Expected: HTTP `200`. Inspect the rendered HTML for lifecycle headings, the insert-only warning, manual resync, delete consequences, responsibility boundaries, and the 500-tool limit.
+
+### Task 3: Commit and update the existing PR
+
+**Files:**
+- Modify: `docs/content/docs/extending-sessions/custom-mcp.mdx`
+- Include: `docs/superpowers/specs/2026-07-29-custom-mcp-lifecycle-doc-flow-design.md`
+- Include: `docs/superpowers/plans/2026-07-29-custom-mcp-lifecycle-doc-flow.md`
+
+**Interfaces:**
+- Consumes: Verified documentation changes.
+- Produces: An updated `codex/docs-custom-mcp-servers` branch and PR #3975.
+
+- [ ] **Step 1: Commit the implementation**
+
+Run:
+
+```bash
+git add docs/content/docs/extending-sessions/custom-mcp.mdx docs/superpowers/plans/2026-07-29-custom-mcp-lifecycle-doc-flow.md
+git commit -m "docs: reflow custom MCP lifecycle guide"
+```
+
+- [ ] **Step 2: Push the branch**
+
+Run:
+
+```bash
+git push origin codex/docs-custom-mcp-servers
+```
+
+- [ ] **Step 3: Verify the PR head**
+
+Run:
+
+```bash
+gh pr view 3975 --repo ComposioHQ/composio --json url,state,isDraft,headRefOid
+```
+
+Expected: the PR is open and its head matches the pushed local commit.

--- a/docs/superpowers/specs/2026-07-29-custom-mcp-lifecycle-doc-flow-design.md
+++ b/docs/superpowers/specs/2026-07-29-custom-mcp-lifecycle-doc-flow-design.md
@@ -1,0 +1,87 @@
+# Custom MCP lifecycle documentation flow
+
+## Goal
+
+Reorganize the Custom MCP guide into an API-first lifecycle that a developer can follow from registration through deletion. Keep the dashboard as a short alternative, preserve the existing endpoint contracts and SDK examples, and surface limitations at the step where they affect the reader.
+
+## Primary reader
+
+A developer who already operates a public remote MCP server and wants to register it with Composio, sync its tools, and use the resulting `CUSTOM_*` toolkit in a session.
+
+## Page structure
+
+1. **Introduction**
+   - Define Custom MCP and distinguish it from in-process custom tools.
+   - Keep the experimental warning.
+   - Summarize the lifecycle: deploy, register, connect if required, sync, use, resync, and delete.
+
+2. **Register a Custom MCP**
+   - State the public HTTPS prerequisite.
+   - Present `POST /api/v3/custom/toolkits/upsert` examples for no auth, API key, and DCR OAuth.
+   - Explain that the endpoint adds the `CUSTOM_` prefix.
+   - Warn that `upsert` is insert-only, returns `409 Conflict` for an existing slug, and cannot update an existing toolkit.
+   - Keep the dashboard as a short alternative callout rather than a second full workflow.
+
+3. **Complete setup for the selected authentication mode**
+   - No auth: registration performs the initial tool sync automatically.
+   - API key: create and activate a connected account, then sync manually.
+   - DCR OAuth: complete user authorization for a connected account, then sync manually.
+
+4. **Sync and resync tools**
+   - Document `POST /api/v3/custom/toolkits/sync`.
+   - Explain when `connected_account_id` is required.
+   - State that Composio does not continuously watch the MCP server for tool changes.
+   - Explain that each successful sync creates a toolkit version.
+   - State the 500-tool cap. Reject an oversized sync without partially importing it, and retain the last successful version.
+
+5. **Delete or replace a Custom MCP**
+   - Document `DELETE /api/v3.1/custom/toolkits/{slug}`.
+   - Explain that replacing settings requires delete, then register again.
+   - Warn that deletion removes the toolkit and its tools, revokes its connections, and removes its auth configurations and connected accounts.
+
+6. **Authentication types**
+   - Compare no auth, API key, and DCR OAuth in a compact table.
+   - Keep implementation constraints, including the required API-key template and DCR authorization-code support, near the relevant mode.
+
+7. **Use Custom MCP in a session**
+   - Show the no-auth Python and TypeScript examples.
+   - Show the authenticated Python and TypeScript examples.
+   - Require explicit connected-account selection for authenticated Custom MCP toolkits.
+
+8. **Responsibilities**
+   - The customer owns the remote server, its public HTTPS availability, tool implementation, auth-provider behavior, and deciding when to resync after tool changes.
+   - Composio handles project-scoped toolkit registration, connected-account credential storage, tool-schema syncing and versioning, proxied execution, and exposing the toolkit to sessions.
+   - Avoid contractual language. Present this as an operational responsibility boundary.
+
+9. **Technical behavior**
+   - Keep the existing explanation of toolkit slugs, registry versions, Tool Router discovery, and v3 versus v3.1 version selection.
+
+10. **Known gaps**
+    - Keep a concise summary of the SDK lifecycle gap, public HTTPS requirement, lack of continuous auto-sync, explicit authenticated account selection, v3 version behavior, insert-only registration, 500-tool limit, and API-key validation limitation.
+    - Repeat important limitations here even when they also appear in the lifecycle.
+
+## Content principles
+
+- Follow one lifecycle instead of presenting dashboard setup, API management, and SDK usage as disconnected guides.
+- Explain authentication differences at the point where the lifecycle branches.
+- Put destructive or surprising behavior immediately after the operation that triggers it.
+- Keep runnable cURL examples and existing response examples.
+- Do not document SDK lifecycle methods that do not exist.
+- Do not change endpoint paths, request fields, response fields, or current platform limits.
+
+## Verification
+
+- Run `bun run lint:links`.
+- Run `bun run types:check`.
+- Run the full docs production build with the repository-supported Node.js version.
+- Confirm the local route returns `200`.
+- Inspect the rendered page for the lifecycle headings, insert-only warning, manual-sync explanation, delete consequences, responsibility boundary, and 500-tool limit.
+- Confirm the diff only changes the Custom MCP page and this approved design record.
+
+## Non-goals
+
+- Adding or changing SDK methods.
+- Changing platform endpoint behavior.
+- Publishing the experimental endpoints into the generated public API reference.
+- Documenting the complete auth-config or connected-account API lifecycle.
+- Adding a separate dashboard tutorial.


### PR DESCRIPTION
## Summary

- add an experimental guide for registering customer-hosted MCP servers
- document supported authentication, the registration and sync flow, toolkit behavior, and customer-facing workarounds for known gaps
- add the guide to the Extending sessions navigation and cross-link it from the sessions-over-MCP guide

## Why

Custom MCP toolkits now have a working platform lifecycle, but customers need one place that clearly distinguishes remote MCP servers from in-process custom tools. The guide also makes the current pilot limitations explicit so customers know which API version, sync flow, account selection, and hosting model to use.

## Validation

- `cd docs && bun run lint:links`
- `cd docs && bun run types:check`
- `git diff --check`

Docs-only change, so no changeset is required.
