### PR TITLE
docs: single-channel install story + un-orphan plugin/connect pages (PRDE-1160)

### DIFF
--- a/docs/content/docs/claude-code-plugin.mdx
+++ b/docs/content/docs/claude-code-plugin.mdx
@@ -44,7 +44,7 @@ The first time, Claude installs the Composio CLI if it's missing, signs you in w
 </Steps>
 
 <Callout>
-Prefer to set things up ahead of time? Run `curl -fsSL https://composio.dev/install | bash`, then `composio login`.
+Prefer the terminal? Run `curl -fsSL https://composio.dev/install | bash`, then `composio login`, then `composio setup` — it detects Claude Code and installs the plugin for you, no slash commands needed.
 </Callout>
 
 ## What you can do

--- a/docs/content/docs/composio-connect.mdx
+++ b/docs/content/docs/composio-connect.mdx
@@ -18,6 +18,9 @@ To get started, pick your client below.
 
 <ConnectClientOption id="claude-code" name="Claude Code" description="Terminal-based AI with MCP tools" icon="/images/clients/claude.svg" category="popular">
 
+<Callout type="info">
+Recommended: install the [Composio plugin for Claude Code](/docs/claude-code-plugin) instead. It manages OAuth and tool discovery for you — no API key needed. The steps below wire up the raw MCP server directly.
+</Callout>
 
 <Steps>
 <Step>
@@ -51,31 +54,29 @@ Type `/mcp` in Claude Code to open the MCP server manager and confirm Composio a
 
 <Steps>
 <Step>
-<StepTitle>Get your API key</StepTitle>
+<StepTitle>Install the Composio CLI</StepTitle>
 
-Open the [Composio dashboard](https://dashboard.composio.dev?utm_source=docs&utm_medium=content&utm_campaign=docs-composio-connect) and click **AI Clients** in the sidebar. Select your client and copy your API key.
-
-</Step>
-<Step>
-<StepTitle>Open your Codex config</StepTitle>
-
-Open `~/.codex/config.toml` in your editor. Create the file if it doesn't exist.
-
-</Step>
-<Step>
-<StepTitle>Add the Composio server</StepTitle>
-
-```toml title="~/.codex/config.toml"
-[mcp_servers.composio]
-url = "https://connect.composio.dev/mcp"
-http_headers = { "x-consumer-api-key" = "YOUR_API_KEY" }
+```bash
+curl -fsSL https://composio.dev/install | bash
 ```
 
 </Step>
 <Step>
-<StepTitle>Verify the connection</StepTitle>
+<StepTitle>Sign in</StepTitle>
 
-Run `codex mcp list` to confirm Composio appears as a registered MCP server.
+```bash
+composio login
+```
+
+</Step>
+<Step>
+<StepTitle>Set up Codex</StepTitle>
+
+```bash
+composio setup
+```
+
+This detects Codex and installs the Composio plugin for it. Restart Codex, then try: *"Star `composiohq/composio` on GitHub."* The first task that needs an app hands you an OAuth link to approve in your browser.
 
 </Step>
 </Steps>

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -36,6 +36,8 @@
     "auth-configuration",
     "---Other topics---",
     "cli",
+    "claude-code-plugin",
+    "composio-connect",
     "migration-guide"
   ]
 }

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -37,7 +37,6 @@
     "---Other topics---",
     "cli",
     "claude-code-plugin",
-    "composio-connect",
     "migration-guide"
   ]
 }


### PR DESCRIPTION
## Problem

Two docs pages were orphaned — `claude-code-plugin.mdx` and `composio-connect.mdx` existed but appeared in no `meta.json`, so they were reachable only by direct link. Worse, the Composio Connect page's Codex instructions still routed users through hand-editing `~/.codex/config.toml` with a raw MCP server + API key, contradicting the dashboard's CLI-driven flow, and the plugin page's terminal callout predated `composio setup`. With the npm and Homebrew CLI channels decommissioned (#3960), the curl installer is the only install channel and the docs need to tell that single story.

## Scope decision

`composio-connect` deliberately **stays hidden from navigation**. A March 2026 commit (`f1e26131`, "hide Composio Connect page from navigation") removed it from the sidebar on purpose, and this PR does not reverse that product decision — the page's content is corrected for visitors who reach it by direct link, but it remains out of `meta.json` (and back on the navigation test's tolerated-orphan warn list). Note: the page is nominally owned by the dormant dashboard→docs sync workflow (`docs.sync-connect-clients.yml`); if that sync is ever revived it must be reconciled with these hand edits first.

## What changed

- **`docs/content/docs/meta.json`** — added `claude-code-plugin` to the sidebar under *Other topics*, next to `cli` (`composio-connect` intentionally not re-listed — see Scope decision).
- **`docs/content/docs/composio-connect.mdx`**
  - Codex client option now uses the CLI path: curl installer → `composio login` → `composio setup` (which detects Codex and installs the Composio plugin for it), replacing the raw `~/.codex/config.toml` MCP config.
  - Claude Code client option gains a callout recommending the [Claude Code plugin](/docs/claude-code-plugin) over raw MCP wiring.
- **`docs/content/docs/claude-code-plugin.mdx`** — terminal-path callout now names `composio setup` as the install command instead of stopping at `composio login`.

## Verification

- `bun run test` in `docs/` — 100 pass, 0 fail; `claude-code-plugin` no longer flagged as an orphan, `composio-connect` remains on the tolerated-orphan warn list by design.
- `bun run lint:links` in `docs/` — 0 errors.
- Checked `composio setup` behavior against `ts/packages/cli/src/commands/setup.cmd.ts` / `src/services/setup.ts`: targets `claude`/`codex`, installs "the Composio plugin" per host — copy matches the CLI's own language.

## Related

A sibling dashboard PR aligns the other side of the channel story (dashboard AI Clients flow). Part of PRDE-1160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
