### PR TITLE
fix(cli): report real installed version in analytics + x-sdk-version header (PRDE-1159)

### DIFF
--- a/ts/packages/cli/src/analytics/dispatch.ts
+++ b/ts/packages/cli/src/analytics/dispatch.ts
@@ -12,6 +12,7 @@ import {
   Schema,
 } from 'effect';
 import * as constants from 'src/constants';
+import { getInstalledCliVersion } from 'src/effects/version';
 import { spawnDetached } from 'src/services/detached-process';
 import { djb2Hash } from 'src/utils/djb2';
 import { NodeOs } from 'src/services/node-os';
@@ -233,11 +234,15 @@ export const getCurrentCwdSessionId = (cwd = process.cwd()) =>
     return best?.id;
   }).pipe(Effect.catchAllCause(() => Effect.succeed(undefined)));
 
-const withCliSessionId = (event: NonNullable<TrackEvent>, cliSessionId?: string): TrackEvent => ({
+const withCliSessionId = (
+  event: NonNullable<TrackEvent>,
+  cliVersion: string,
+  cliSessionId?: string
+): TrackEvent => ({
   ...event,
   properties: {
     ...(event.properties ?? {}),
-    cli_version: event.properties?.cli_version ?? constants.APP_VERSION,
+    cli_version: cliVersion,
     ...(cliSessionId ? { cli_session_id: cliSessionId } : {}),
   },
 });
@@ -364,7 +369,8 @@ const getCliInvocationContext = environmentProvider
 export const createCliCodactFailureBody = (
   failure: CliCodactFailure,
   cliSessionId?: string,
-  invocation: CliInvocationContext = {}
+  invocation: CliInvocationContext = {},
+  cliVersion: string = constants.APP_VERSION
 ): CliCodactFailureBody => ({
   failure_type: failure.failureType,
   ...(failure.toolInfo ? { tool_info: failure.toolInfo } : {}),
@@ -372,7 +378,7 @@ export const createCliCodactFailureBody = (
   session: {
     source: 'cli',
     id: cliSessionId,
-    cli_version: constants.APP_VERSION,
+    cli_version: cliVersion,
     invocation_origin: invocation.origin ?? 'cli',
     parent_run_id: invocation.parentRunId,
     ...(failure.session ?? {}),
@@ -406,7 +412,8 @@ const captureToComposioCodactFailures = (failure: CliCodactFailure) =>
     const httpClient = yield* HttpClient.HttpClient;
     const cliSessionId = yield* getCurrentCwdSessionId();
     const invocation = yield* getCliInvocationContext;
-    const body = createCliCodactFailureBody(failure, cliSessionId, invocation);
+    const cliVersion = yield* getInstalledCliVersion;
+    const body = createCliCodactFailureBody(failure, cliSessionId, invocation, cliVersion);
     const request = yield* HttpClientRequest.post(endpoint).pipe(
       HttpClientRequest.setHeader('x-user-api-key', userApiKey),
       HttpClientRequest.bodyJson(body)
@@ -443,7 +450,8 @@ export const trackCliEventEffect = (event: TrackEvent) =>
     }
 
     const cliSessionId = yield* getCurrentCwdSessionId();
-    const enrichedEvent = withCliSessionId(event, cliSessionId);
+    const cliVersion = yield* getInstalledCliVersion;
+    const enrichedEvent = withCliSessionId(event, cliVersion, cliSessionId);
     if (!enrichedEvent) {
       return;
     }
@@ -485,7 +493,10 @@ export const trackCliCodactFailureEffect = (failure: CliCodactFailure) =>
 
     const cliSessionId = yield* getCurrentCwdSessionId();
     const invocation = yield* getCliInvocationContext;
-    const body = yield* encodeJson(createCliCodactFailureBody(failure, cliSessionId, invocation));
+    const cliVersion = yield* getInstalledCliVersion;
+    const body = yield* encodeJson(
+      createCliCodactFailureBody(failure, cliSessionId, invocation, cliVersion)
+    );
     const encodedPayload = Encoding.encodeBase64Url(body);
     const { command, args } = yield* getWorkerSpawnArgs(
       INTERNAL_CODACT_FAILURE_WORKER_FLAG,

--- a/ts/packages/cli/src/effects/version.ts
+++ b/ts/packages/cli/src/effects/version.ts
@@ -3,10 +3,22 @@ import { DEBUG_OVERRIDE_CONFIG } from 'src/effects/debug-config';
 import * as constants from 'src/constants';
 import { resolveInstalledCliVersion } from 'src/services/run-companion-modules';
 
+let cachedInstalledCliVersion: string | undefined;
+
+export const getInstalledCliVersion = Effect.gen(function* () {
+  if (cachedInstalledCliVersion === undefined) {
+    cachedInstalledCliVersion = yield* resolveInstalledCliVersion(
+      process.execPath,
+      constants.APP_VERSION
+    );
+  }
+  return cachedInstalledCliVersion;
+});
+
 export const getVersion = Effect.flatMap(
   DEBUG_OVERRIDE_CONFIG.VERSION,
   Option.match({
-    onNone: () => resolveInstalledCliVersion(process.execPath, constants.APP_VERSION),
+    onNone: () => getInstalledCliVersion,
     onSome: version => Effect.succeed(version),
   })
 );

--- a/ts/packages/cli/src/services/composio-clients.ts
+++ b/ts/packages/cli/src/services/composio-clients.ts
@@ -35,8 +35,8 @@ import {
 import { JsonRecordSchema } from 'src/effects/json';
 import { Session, RetrievedSession } from 'src/models/session';
 import { TriggerType, TriggerTypes, TriggerTypesAsEnums } from 'src/models/trigger-types';
-import * as constants from 'src/constants';
 import { getCurrentCwdSessionId } from 'src/analytics/dispatch';
+import { getInstalledCliVersion } from 'src/effects/version';
 import { ComposioUserContext, ComposioUserContextLive } from './user-context';
 import { ProjectContext } from './project-context';
 import type { NoSuchElementException } from 'effect/Cause';
@@ -1352,12 +1352,13 @@ const buildDefaultHeaders = (params: {
   orgId?: string;
   projectId?: string;
   cliSessionId?: string;
+  sdkVersion: string;
 }): Record<string, string> | undefined => {
   const defaultHeaders = {
     'x-framework': 'cli',
     'x-source': 'CLI',
     'x-runtime': detectCliRuntime(),
-    'x-sdk-version': constants.APP_VERSION,
+    'x-sdk-version': params.sdkVersion,
     ...(params.userApiKey
       ? ({ 'x-user-api-key': params.userApiKey } satisfies Record<string, string>)
       : {}),
@@ -1534,6 +1535,7 @@ export class ComposioClientSingleton extends Effect.Service<ComposioClientSingle
       const fs = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
       const os = yield* NodeOs;
+      const sdkVersion = yield* getInstalledCliVersion;
       const cache = new Map<string, _RawComposioClient>();
 
       const getFor = (params?: { userApiKey?: string; orgId?: string; projectId?: string }) =>
@@ -1565,6 +1567,7 @@ export class ComposioClientSingleton extends Effect.Service<ComposioClientSingle
               orgId: params?.orgId,
               projectId: params?.projectId,
               cliSessionId,
+              sdkVersion,
             }),
           });
 

--- a/ts/packages/cli/test/src/analytics.version.test.ts
+++ b/ts/packages/cli/test/src/analytics.version.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from '@effect/vitest';
+import { afterEach, vi } from 'vitest';
+import { FetchHttpClient, FileSystem, Path } from '@effect/platform';
+import { BunFileSystem, BunPath } from '@effect/platform-bun';
+import { Effect, Layer } from 'effect';
+import * as tempy from 'tempy';
+import { trackCliEventEffect } from 'src/analytics/dispatch';
+import { APP_VERSION } from 'src/constants';
+import { defaultNodeOs, NodeOs } from 'src/services/node-os';
+import { TerminalUITest } from 'test/__utils__/services/terminal-ui-test';
+
+const childProcessMocks = vi.hoisted(() => ({
+  once: vi.fn(),
+  removeListener: vi.fn(),
+  spawn: vi.fn(),
+  unref: vi.fn(),
+}));
+
+vi.mock('node:child_process', () => ({
+  spawn: childProcessMocks.spawn,
+}));
+
+const originalExecPath = process.execPath;
+
+const decodeWorkerPayload = <A>(encodedPayload: string): A => {
+  const normalized = encodedPayload.replace(/-/gu, '+').replace(/_/gu, '/');
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=');
+  return JSON.parse(atob(padded)) as A;
+};
+
+describe('CLI analytics installed-version resolution', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    process.execPath = originalExecPath;
+  });
+
+  it.effect('reports the release-tag version instead of the compiled-in constant', () => {
+    const home = tempy.temporaryDirectory();
+    const installDir = tempy.temporaryDirectory();
+    vi.stubEnv('COMPOSIO_BASE_URL', 'https://backend.example.test');
+    vi.stubEnv('COMPOSIO_USER_API_KEY', 'uak_test');
+    vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('CI', 'false');
+    vi.stubEnv('COMPOSIO_CLI_TELEMETRY_DISABLED', 'false');
+    vi.stubEnv('TELEMETRY_DISABLED', 'false');
+    vi.stubEnv('COMPOSIO_DISABLE_TELEMETRY', 'false');
+
+    const child = {
+      once: childProcessMocks.once,
+      removeListener: childProcessMocks.removeListener,
+      unref: childProcessMocks.unref,
+    };
+    childProcessMocks.once.mockReset().mockImplementation((event: string, listener: () => void) => {
+      if (event === 'spawn') {
+        listener();
+      }
+      return child;
+    });
+    childProcessMocks.removeListener.mockReset().mockReturnValue(child);
+    childProcessMocks.spawn.mockReset().mockReturnValue(child);
+    childProcessMocks.unref.mockReset();
+
+    return Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      yield* fs.writeFileString(path.join(installDir, 'release-tag.txt'), '@composio/cli@0.4.2\n');
+      process.execPath = path.join(installDir, 'composio');
+
+      yield* trackCliEventEffect({
+        name: 'producer_event',
+        properties: { cli_version: APP_VERSION },
+      });
+
+      expect(childProcessMocks.spawn).toHaveBeenCalledTimes(1);
+      const [, args] = childProcessMocks.spawn.mock.calls[0] as unknown as [string, string[]];
+      const envelope = decodeWorkerPayload<{ properties: Record<string, unknown> }>(args.at(-1)!);
+      expect(envelope.properties.cli_version).toBe('0.4.2');
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          BunFileSystem.layer,
+          BunPath.layer,
+          FetchHttpClient.layer,
+          TerminalUITest,
+          Layer.succeed(NodeOs, defaultNodeOs({ homedir: home }))
+        )
+      )
+    );
+  });
+});


### PR DESCRIPTION
## Problem

Every CLI analytics event and every Composio API request reported the compiled-in `package.json` constant `APP_VERSION` — `0.3.0`, a version matching no release ever shipped. Real installs record their version in `release-tag.txt` beside the binary (written by the installer / `composio upgrade`), and the CLI already resolves it via `resolveInstalledCliVersion` for the update check and `composio version` — but telemetry and the `x-sdk-version` header never used it. Result: the entire fleet reports a phantom `0.3.0`, making version distribution unmeasurable.

## Fix

Resolve the installed version once per process (cached `getInstalledCliVersion` in `src/effects/version.ts`, reusing the existing `resolveInstalledCliVersion` release-tag resolver) and report it at the three egress seams:

- `analytics/dispatch.ts` — the dispatch envelope now normalizes `cli_version` on every outgoing event. This is deliberate: event builders receive `APP_VERSION` via the telemetry context, so overriding at the single dispatch seam fixes all events (command lifecycle, setup, codact failures) without touching every construction site.
- `analytics/dispatch.ts` — `createCliCodactFailureBody` takes the resolved version from both codact capture paths.
- `services/composio-clients.ts` — `x-sdk-version` default header carries the resolved version (computed once at client-singleton init).

`composio version` now also benefits from the cached resolution; `DEBUG_OVERRIDE_VERSION` behavior is unchanged.

## Why this PR was cut down

An earlier revision added upgrade-funnel events and a 14-site versioned User-Agent sweep. An adversarial review found that #3961 (auto-update) makes the manual upgrade funnel vestigial, and that the User-Agent sweep duplicated what the `x-sdk-version` header already transports. Both were dropped; this PR is now only the version-reporting fix. (Prior commits are preserved in the review record.)

## Known limitation

Dev/bun runs without a `release-tag.txt` beside the executable still fall back to `APP_VERSION` (`0.3.0`). Accepted: dev traffic is not what fleet version measurement is for, and inventing a version there would be worse.

## Verification

- `pnpm --filter @composio/cli test` — 111 files, 1006 passed / 1 skipped (includes `validate:skills`, `validate:boundaries`)
- CLI package `pnpm run typecheck` (src + test) — clean
- `oxlint` + `prettier --check` on changed files — clean
- New test: `analytics.version.test.ts` writes a `release-tag.txt` fixture, points `process.execPath` at it, and asserts the dispatched analytics envelope carries the release-tag version (`0.4.2`) even when the event was built with `APP_VERSION`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
