### PR TITLE
feat(cli): version --check full freshness report + fix update-check cache poisoning (PRDE-1158)

### DIFF
--- a/ts/packages/cli/src/commands/version.cmd.ts
+++ b/ts/packages/cli/src/commands/version.cmd.ts
@@ -1,17 +1,37 @@
 import { Command, Options } from '@effect/cli';
 import { Effect } from 'effect';
 import { getVersion } from 'src/effects/version';
-import { getUpdateStatus } from 'src/services/update-check';
+import {
+  getFreshnessReport,
+  type ArtifactStatus,
+  type FreshnessArtifacts,
+} from 'src/services/artifact-freshness';
 import { TerminalUI } from 'src/services/terminal-ui';
 import { bold, cyanBright } from 'src/ui/colors';
 
 const check = Options.boolean('check').pipe(
   Options.withDescription(
-    'Check for a newer stable release and print a machine-readable JSON status ' +
-      '({current, latestStable, updateAvailable, checkStatus, lastChecked}). ' +
-      'Refreshes the release cache when it is older than 24 hours.'
+    'Check every Composio artifact (CLI binary, agent skill, Claude Code and Codex plugins) ' +
+      'for a newer release and print a machine-readable JSON freshness report ' +
+      '({current, latestStable, updateAvailable, checkStatus, lastChecked, artifacts}). ' +
+      'Refreshes the CLI release cache when it is older than 24 hours.'
   )
 );
+
+const ARTIFACT_LABELS: Record<Exclude<keyof FreshnessArtifacts, 'cli'>, string> = {
+  skill: 'Composio agent skill',
+  claudePlugin: 'Composio Claude Code plugin',
+  codexPlugin: 'Composio Codex plugin',
+};
+
+function staleArtifactLine(label: string, artifact: ArtifactStatus): string | undefined {
+  if (!artifact.updateAvailable || artifact.latest === null) return undefined;
+  let from = '';
+  if (artifact.current !== null) {
+    from = `${artifact.current} → `;
+  }
+  return `${label} update available: ${from}${bold(cyanBright(artifact.latest))}`;
+}
 
 /**
  * CLI command to display the version of the Composio CLI.
@@ -29,17 +49,26 @@ export const versionCmd = Command.make('version', { check }).pipe(
       const ui = yield* TerminalUI;
 
       if (check) {
-        const status = yield* getUpdateStatus;
-        if (status.updateAvailable && status.latestStable) {
+        const report = yield* getFreshnessReport;
+        if (report.updateAvailable && report.latestStable) {
           yield* ui.log.info(
-            `Update available: ${status.current} → ${bold(cyanBright(status.latestStable))} — run ${cyanBright('composio upgrade')}`
+            `Update available: ${report.current} → ${bold(cyanBright(report.latestStable))} — run ${cyanBright('composio upgrade')}`
           );
-        } else if (status.checkStatus === 'unknown') {
+        } else if (report.checkStatus === 'unknown') {
           yield* ui.log.warn('Unable to determine the latest stable Composio CLI release.');
         } else {
-          yield* ui.log.info(`${status.current} is up to date.`);
+          yield* ui.log.info(`${report.current} is up to date.`);
         }
-        yield* ui.output(JSON.stringify(status));
+        for (const [key, label] of Object.entries(ARTIFACT_LABELS)) {
+          const line = staleArtifactLine(
+            label,
+            report.artifacts[key as keyof typeof ARTIFACT_LABELS]
+          );
+          if (line !== undefined) {
+            yield* ui.log.info(line);
+          }
+        }
+        yield* ui.output(JSON.stringify(report));
         return;
       }
 

--- a/ts/packages/cli/src/services/artifact-freshness.ts
+++ b/ts/packages/cli/src/services/artifact-freshness.ts
@@ -1,9 +1,4 @@
-import {
-  Command as PlatformCommand,
-  Error as PlatformError,
-  FileSystem,
-  Path,
-} from '@effect/platform';
+import { Command as PlatformCommand, FileSystem, Path } from '@effect/platform';
 import { BunContext } from '@effect/platform-bun';
 import { Effect, Layer, Option, Predicate, Schema } from 'effect';
 import semver from 'semver';
@@ -227,12 +222,13 @@ export function createFreshnessReporter(config: FreshnessConfig) {
       if (result.exitCode !== 0) return undefined;
       return parsePluginList(result.stdout, probe.recordsKey);
     }).pipe(
-      Effect.catchAll(error => {
-        if (Schema.is(PlatformError.SystemError)(error) && error.reason === 'NotFound') {
+      Effect.catchTag('SystemError', error => {
+        if (error.reason === 'NotFound') {
           return Effect.succeed<InstalledPluginProbe | undefined>({ installed: false });
         }
         return Effect.succeed<InstalledPluginProbe | undefined>(undefined);
-      })
+      }),
+      Effect.catchAll(() => Effect.succeed<InstalledPluginProbe | undefined>(undefined))
     );
 
   const pluginStatus = (probe: PluginProbe) =>

--- a/ts/packages/cli/src/services/artifact-freshness.ts
+++ b/ts/packages/cli/src/services/artifact-freshness.ts
@@ -1,0 +1,287 @@
+import {
+  Command as PlatformCommand,
+  Error as PlatformError,
+  FileSystem,
+  Path,
+} from '@effect/platform';
+import { BunContext } from '@effect/platform-bun';
+import { Effect, Layer, Option, Predicate, Schema } from 'effect';
+import semver from 'semver';
+import { resolveInstalledSkillName, SKILL_RELEASE_TAG_FILENAME } from 'src/effects/install-skill';
+import { CommandRunner } from './command-runner';
+import { NodeOs } from './node-os';
+import { getUpdateStatus, type UpdateStatus } from './update-check';
+
+/**
+ * Freshness report across every Composio artifact installed on this machine:
+ * the CLI binary, the standalone agent skill, and the Claude Code / Codex
+ * plugins. Powers `composio version --check`; agents and the plugins'
+ * SessionStart hooks are the primary consumers, so every field is
+ * machine-readable and a missing artifact is data, never an error.
+ */
+
+const PLUGIN_ID = 'composio@composio';
+const MANIFEST_TIMEOUT_MS = 5_000;
+const PLUGIN_LIST_TIMEOUT = '15 seconds';
+
+export type ArtifactFreshness = 'up-to-date' | 'update-available' | 'not-installed' | 'unknown';
+
+export interface ArtifactStatus {
+  installed: boolean;
+  current: string | null;
+  latest: string | null;
+  updateAvailable: boolean;
+  status: ArtifactFreshness;
+}
+
+export interface FreshnessArtifacts {
+  cli: ArtifactStatus;
+  skill: ArtifactStatus;
+  claudePlugin: ArtifactStatus;
+  codexPlugin: ArtifactStatus;
+}
+
+export interface FreshnessReport extends UpdateStatus {
+  artifacts: FreshnessArtifacts;
+}
+
+export interface PluginProbe {
+  readonly executable: string;
+  /** Key holding the plugin records when the host wraps them in an object. */
+  readonly recordsKey: string | undefined;
+  /** plugin.json at default-branch HEAD — what hosts actually install, and CDN-cached. */
+  readonly manifestUrl: string;
+}
+
+export const CLAUDE_PLUGIN_PROBE: PluginProbe = {
+  executable: 'claude',
+  recordsKey: undefined,
+  manifestUrl:
+    'https://raw.githubusercontent.com/ComposioHQ/composio-plugin-cc/HEAD/plugins/composio/.claude-plugin/plugin.json',
+};
+
+export const CODEX_PLUGIN_PROBE: PluginProbe = {
+  executable: 'codex',
+  recordsKey: 'installed',
+  manifestUrl:
+    'https://raw.githubusercontent.com/ComposioHQ/composio-plugin-openai/HEAD/plugins/composio/.codex-plugin/plugin.json',
+};
+
+export interface FreshnessConfig {
+  readonly skillDir: string;
+  readonly fetchFn: (url: string, init?: RequestInit) => Promise<Response>;
+}
+
+// ── Pure helpers ────────────────────────────────────────────────────────
+
+const decodeJson = Schema.decodeUnknownOption(Schema.parseJson());
+
+/** Extract the semver from a `@composio/cli@<version>` release tag. */
+export function parseReleaseTagVersion(tag: string): string | null {
+  const match = /^@composio\/cli@(.+)$/.exec(tag.trim());
+  if (!match) return null;
+  const version = match[1];
+  if (version === undefined || semver.valid(version) === null) return null;
+  return version;
+}
+
+export type InstalledPluginProbe =
+  { readonly installed: false } | { readonly installed: true; readonly version: string | null };
+
+/**
+ * Find the Composio plugin in a host's `plugin list --json` output.
+ * Returns undefined when the output cannot be interpreted.
+ */
+export function parsePluginList(
+  output: string,
+  recordsKey: string | undefined
+): InstalledPluginProbe | undefined {
+  const parsed = Option.getOrUndefined(decodeJson(output));
+  let records: unknown = parsed;
+  if (recordsKey !== undefined) {
+    if (!Predicate.isRecord(parsed)) return undefined;
+    records = parsed[recordsKey];
+  }
+  if (!Array.isArray(records)) return undefined;
+
+  const matches: Record<string, unknown>[] = [];
+  for (const record of records) {
+    if (!Predicate.isRecord(record)) continue;
+    const id = record.id ?? record.pluginId;
+    if (id !== PLUGIN_ID || record.installed === false) continue;
+    matches.push(record);
+  }
+  const chosen = matches.find(record => record.enabled !== false) ?? matches[0];
+  if (chosen === undefined) return { installed: false };
+
+  const version = chosen.version;
+  if (typeof version === 'string' && semver.valid(version) !== null) {
+    return { installed: true, version };
+  }
+  return { installed: true, version: null };
+}
+
+/** Read the `version` field out of a plugin.json manifest body. */
+export function parseManifestVersion(body: string): string | null {
+  const parsed = Option.getOrUndefined(decodeJson(body));
+  if (!Predicate.isRecord(parsed)) return null;
+  const version = parsed.version;
+  if (typeof version !== 'string' || semver.valid(version) === null) return null;
+  return version;
+}
+
+export function deriveArtifactStatus(
+  installed: boolean | undefined,
+  current: string | null,
+  latest: string | null
+): ArtifactStatus {
+  if (installed === undefined) {
+    return { installed: false, current: null, latest, updateAvailable: false, status: 'unknown' };
+  }
+  if (!installed) {
+    return {
+      installed: false,
+      current: null,
+      latest,
+      updateAvailable: false,
+      status: 'not-installed',
+    };
+  }
+  let validCurrent: string | null = null;
+  if (current !== null) {
+    validCurrent = semver.valid(current);
+  }
+  let validLatest: string | null = null;
+  if (latest !== null) {
+    validLatest = semver.valid(latest);
+  }
+  if (validCurrent === null || validLatest === null) {
+    return { installed: true, current, latest, updateAvailable: false, status: 'unknown' };
+  }
+  if (semver.gt(validLatest, validCurrent)) {
+    return { installed: true, current, latest, updateAvailable: true, status: 'update-available' };
+  }
+  return { installed: true, current, latest, updateAvailable: false, status: 'up-to-date' };
+}
+
+/** Project the CLI's own update status into the shared artifact shape. */
+export function cliArtifactStatus(status: UpdateStatus): ArtifactStatus {
+  const base = {
+    installed: true,
+    current: status.current,
+    latest: status.latestStable,
+  };
+  if (status.checkStatus === 'update-available') {
+    return { ...base, updateAvailable: true, status: 'update-available' };
+  }
+  if (status.checkStatus === 'up-to-date') {
+    return { ...base, updateAvailable: false, status: 'up-to-date' };
+  }
+  return { ...base, updateAvailable: false, status: 'unknown' };
+}
+
+// ── Factory ─────────────────────────────────────────────────────────────
+
+export function createFreshnessReporter(config: FreshnessConfig) {
+  const fetchManifestVersion = (url: string) =>
+    Effect.gen(function* () {
+      const response = yield* Effect.tryPromise(() =>
+        config.fetchFn(url, { signal: AbortSignal.timeout(MANIFEST_TIMEOUT_MS) })
+      );
+      if (!response.ok) return null;
+      const body = yield* Effect.tryPromise(() => response.text());
+      return parseManifestVersion(body);
+    }).pipe(Effect.orElseSucceed(() => null));
+
+  /**
+   * The skill ships with every CLI release, so its latest version is the
+   * CLI's latest stable release.
+   */
+  const skillStatus = (latestReleaseVersion: string | null) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tag = yield* fs
+        .readFileString(path.join(config.skillDir, SKILL_RELEASE_TAG_FILENAME))
+        .pipe(
+          Effect.map(value => value.trim()),
+          Effect.option
+        );
+      if (Option.isSome(tag) && tag.value !== '') {
+        const version = parseReleaseTagVersion(tag.value);
+        return deriveArtifactStatus(true, version ?? tag.value, latestReleaseVersion);
+      }
+      const exists = yield* fs.exists(config.skillDir).pipe(Effect.orElseSucceed(() => false));
+      if (!exists) {
+        return deriveArtifactStatus(false, null, latestReleaseVersion);
+      }
+      return deriveArtifactStatus(true, null, latestReleaseVersion);
+    });
+
+  const listInstalledPlugin = (probe: PluginProbe) =>
+    Effect.gen(function* () {
+      const runner = yield* CommandRunner;
+      const result = yield* runner
+        .capture(PlatformCommand.make(probe.executable, 'plugin', 'list', '--json'))
+        .pipe(Effect.timeout(PLUGIN_LIST_TIMEOUT));
+      if (result.exitCode !== 0) return undefined;
+      return parsePluginList(result.stdout, probe.recordsKey);
+    }).pipe(
+      Effect.catchAll(error => {
+        if (Schema.is(PlatformError.SystemError)(error) && error.reason === 'NotFound') {
+          return Effect.succeed<InstalledPluginProbe | undefined>({ installed: false });
+        }
+        return Effect.succeed<InstalledPluginProbe | undefined>(undefined);
+      })
+    );
+
+  const pluginStatus = (probe: PluginProbe) =>
+    Effect.gen(function* () {
+      const [installedProbe, latest] = yield* Effect.all(
+        [listInstalledPlugin(probe), fetchManifestVersion(probe.manifestUrl)],
+        { concurrency: 'unbounded' }
+      );
+      if (installedProbe === undefined) {
+        return deriveArtifactStatus(undefined, null, latest);
+      }
+      if (!installedProbe.installed) {
+        return deriveArtifactStatus(false, null, latest);
+      }
+      return deriveArtifactStatus(true, installedProbe.version, latest);
+    });
+
+  const collectArtifacts = (cli: UpdateStatus) =>
+    Effect.gen(function* () {
+      const [skill, claudePlugin, codexPlugin] = yield* Effect.all(
+        [
+          skillStatus(cli.latestStable),
+          pluginStatus(CLAUDE_PLUGIN_PROBE),
+          pluginStatus(CODEX_PLUGIN_PROBE),
+        ],
+        { concurrency: 'unbounded' }
+      );
+      return { cli: cliArtifactStatus(cli), skill, claudePlugin, codexPlugin };
+    });
+
+  return { fetchManifestVersion, skillStatus, pluginStatus, collectArtifacts };
+}
+
+// ── Public API (production defaults) ────────────────────────────────────
+
+const DefaultLayers = Layer.mergeAll(BunContext.layer, NodeOs.Default, CommandRunner.Default);
+
+/**
+ * Refresh the CLI release cache if stale and assemble the full per-artifact
+ * freshness report. Powers `composio version --check`.
+ */
+export const getFreshnessReport: Effect.Effect<FreshnessReport> = Effect.gen(function* () {
+  const cli = yield* getUpdateStatus;
+  const path = yield* Path.Path;
+  const os = yield* NodeOs;
+  const reporter = createFreshnessReporter({
+    skillDir: path.join(os.homedir, '.agents', 'skills', resolveInstalledSkillName()),
+    fetchFn: fetch,
+  });
+  const artifacts = yield* reporter.collectArtifacts(cli);
+  return { ...cli, artifacts } satisfies FreshnessReport;
+}).pipe(Effect.provide(DefaultLayers));

--- a/ts/packages/cli/src/services/command-runner.ts
+++ b/ts/packages/cli/src/services/command-runner.ts
@@ -7,7 +7,7 @@ export interface CommandResult {
   readonly stderr: string;
 }
 
-const collectText = (stream: Stream.Stream<Uint8Array, unknown>) =>
+const collectText = <E>(stream: Stream.Stream<Uint8Array, E>) =>
   stream.pipe(Stream.decodeText(), Stream.runFold(String.empty, String.concat));
 
 export class CommandRunner extends Effect.Service<CommandRunner>()('services/CommandRunner', {

--- a/ts/packages/cli/src/services/update-check.ts
+++ b/ts/packages/cli/src/services/update-check.ts
@@ -270,8 +270,11 @@ export function createUpdateChecker(config: UpdateCheckConfig) {
       // Re-read and compare so a check that succeeded concurrently is not
       // stamped as failed; only an unchanged snapshot gets the marker.
       const stateAtFailure = yield* Effect.option(readState);
-      if (Option.isNone(stateAtFailure) || Option.isNone(cachedState)) return cachedState;
-      if (stateAtFailure.value.lastChecked !== cachedState.value.lastChecked) return cachedState;
+      if (Option.isNone(stateAtFailure)) return cachedState;
+      const unchanged =
+        Option.isSome(cachedState) &&
+        stateAtFailure.value.lastChecked === cachedState.value.lastChecked;
+      if (!unchanged) return stateAtFailure;
       const failedState: UpdateCheckState = { ...stateAtFailure.value, checkStatus: 'failed' };
       yield* Effect.ignore(writeJsonFile(config.stateFile, failedState));
       return Option.some(failedState);

--- a/ts/packages/cli/src/services/update-check.ts
+++ b/ts/packages/cli/src/services/update-check.ts
@@ -29,8 +29,12 @@ const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
 const CLI_RELEASE_TAG_RE = /^@composio\/cli@(\d+\.\d+\.\d+)$/;
 
 export interface UpdateCheckState {
-  lastChecked: string; // ISO-8601
-  latestVersion: string; // e.g. "0.3.0"
+  /** ISO-8601 timestamp of the last successful release fetch (never advanced on failure). */
+  lastChecked: string;
+  /** Latest known stable release, e.g. "0.3.0". Absent when no matching release is known. */
+  latestVersion?: string;
+  /** Outcome of the most recent refresh attempt. Absent in legacy cache files (treated as "ok"). */
+  checkStatus?: 'ok' | 'failed';
 }
 
 /** Machine-readable update status for `composio version --check`. */
@@ -50,7 +54,8 @@ export interface UpdateStatus {
 const UpdateCheckStateSchema = Schema.parseJson(
   Schema.Struct({
     lastChecked: Schema.String,
-    latestVersion: Schema.String,
+    latestVersion: Schema.optional(Schema.String),
+    checkStatus: Schema.optional(Schema.Literal('ok', 'failed')),
   })
 );
 
@@ -179,6 +184,7 @@ export function createUpdateChecker(config: UpdateCheckConfig) {
       if (!canDecorate) return;
 
       const state = yield* readState;
+      if (!state.latestVersion) return;
       const latestVersion = semver.valid(state.latestVersion);
       const currentVersion = semver.valid(config.currentVersion);
       if (!latestVersion || !currentVersion || latestVersion === currentVersion) return;
@@ -232,7 +238,7 @@ export function createUpdateChecker(config: UpdateCheckConfig) {
       return { state: cachedState, refreshFailed: true } as const;
     }
     const previousLatestVersion = Option.getOrUndefined(
-      Option.map(cachedState, state => state.latestVersion)
+      Option.flatMapNullable(cachedState, state => state.latestVersion)
     );
 
     const headers: Record<string, string> = {
@@ -260,6 +266,17 @@ export function createUpdateChecker(config: UpdateCheckConfig) {
       return parseLatestVersionFromReleases(releases, config.binaryAssetName);
     });
 
+    const markCachedStateFailed = Effect.gen(function* () {
+      // Re-read and compare so a check that succeeded concurrently is not
+      // stamped as failed; only an unchanged snapshot gets the marker.
+      const stateAtFailure = yield* Effect.option(readState);
+      if (Option.isNone(stateAtFailure) || Option.isNone(cachedState)) return cachedState;
+      if (stateAtFailure.value.lastChecked !== cachedState.value.lastChecked) return cachedState;
+      const failedState: UpdateCheckState = { ...stateAtFailure.value, checkStatus: 'failed' };
+      yield* Effect.ignore(writeJsonFile(config.stateFile, failedState));
+      return Option.some(failedState);
+    });
+
     const latestVersion = yield* Effect.option(fetchLatestVersion);
     if (Option.isNone(latestVersion)) {
       yield* Effect.ignore(
@@ -267,12 +284,15 @@ export function createUpdateChecker(config: UpdateCheckConfig) {
           lastAttempted: checkStartedAt.toISOString(),
         })
       );
-      return { state: cachedState, refreshFailed: true } as const;
+      const failedCachedState = yield* markCachedStateFailed;
+      return { state: failedCachedState, refreshFailed: true } as const;
     }
 
+    const knownLatestVersion = latestVersion.value ?? previousLatestVersion;
     const state: UpdateCheckState = {
       lastChecked: new Date().toISOString(),
-      latestVersion: latestVersion.value ?? previousLatestVersion ?? config.currentVersion,
+      checkStatus: 'ok',
+      ...(knownLatestVersion === undefined ? {} : { latestVersion: knownLatestVersion }),
     };
     yield* writeJsonFile(config.stateFile, state).pipe(
       Effect.andThen(fs.remove(attemptFile, { force: true })),

--- a/ts/packages/cli/test/src/services/artifact-freshness.test.ts
+++ b/ts/packages/cli/test/src/services/artifact-freshness.test.ts
@@ -1,0 +1,528 @@
+import { describe, it, expect, beforeEach, afterEach } from '@effect/vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { Command, CommandExecutor, Error as PlatformError } from '@effect/platform';
+import { BunContext } from '@effect/platform-bun';
+import { Effect } from 'effect';
+import {
+  CLAUDE_PLUGIN_PROBE,
+  CODEX_PLUGIN_PROBE,
+  cliArtifactStatus,
+  createFreshnessReporter,
+  deriveArtifactStatus,
+  parseManifestVersion,
+  parsePluginList,
+  parseReleaseTagVersion,
+  type FreshnessConfig,
+} from 'src/services/artifact-freshness';
+import { CommandRunner, type CommandResult } from 'src/services/command-runner';
+import type { UpdateStatus } from 'src/services/update-check';
+
+const PlatformLayers = BunContext.layer;
+
+let tempDir: string;
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'artifact-freshness-test-'));
+});
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+const CLAUDE_PLUGIN_LIST = JSON.stringify([
+  {
+    id: 'composio@composio',
+    version: '0.2.2',
+    scope: 'user',
+    enabled: true,
+    installPath: '/home/user/.claude/plugins/cache/composio/composio/0.2.2',
+  },
+  { id: 'other@marketplace', version: '1.0.0', scope: 'user', enabled: true },
+]);
+
+const CODEX_PLUGIN_LIST = JSON.stringify({
+  installed: [
+    {
+      pluginId: 'composio@composio',
+      name: 'composio',
+      version: '0.2.1',
+      installed: true,
+      enabled: true,
+    },
+  ],
+});
+
+function manifestResponse(version: string): Response {
+  return {
+    ok: true,
+    text: () => Promise.resolve(JSON.stringify({ name: 'composio', version })),
+  } as unknown as Response;
+}
+
+function makeRunner(
+  respond: (
+    executable: string
+  ) => Effect.Effect<CommandResult, PlatformError.PlatformError, CommandExecutor.CommandExecutor>
+): CommandRunner {
+  return new CommandRunner({
+    run: () => Effect.succeed(CommandExecutor.ExitCode(0)),
+    capture: command => {
+      const [first] = Command.flatten(command);
+      return respond(first.command);
+    },
+  });
+}
+
+function stdoutRunner(outputs: Record<string, string>): CommandRunner {
+  return makeRunner(executable => {
+    const stdout = outputs[executable];
+    if (stdout === undefined) {
+      return Effect.fail(
+        new PlatformError.SystemError({ reason: 'NotFound', module: 'Command', method: 'spawn' })
+      );
+    }
+    return Effect.succeed({ exitCode: 0, stdout, stderr: '' });
+  });
+}
+
+function makeConfig(overrides?: Partial<FreshnessConfig>): FreshnessConfig {
+  return {
+    skillDir: join(tempDir, '.agents', 'skills', 'composio-cli'),
+    fetchFn: () => Promise.reject(new Error('fetch not configured')),
+    ...overrides,
+  };
+}
+
+function writeSkillTag(config: FreshnessConfig, tag: string): void {
+  mkdirSync(config.skillDir, { recursive: true });
+  writeFileSync(join(config.skillDir, '.composio-release-tag'), `${tag}\n`);
+}
+
+// ── Pure helpers ────────────────────────────────────────────────────────
+
+describe('parseReleaseTagVersion', () => {
+  it('extracts the semver from a stable release tag', () => {
+    expect(parseReleaseTagVersion('@composio/cli@0.2.40')).toBe('0.2.40');
+  });
+
+  it('extracts the semver from a beta release tag', () => {
+    expect(parseReleaseTagVersion('@composio/cli@0.2.40-beta.5')).toBe('0.2.40-beta.5');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(parseReleaseTagVersion('@composio/cli@0.2.40\n')).toBe('0.2.40');
+  });
+
+  it('rejects non-CLI tags and garbage', () => {
+    expect(parseReleaseTagVersion('@composio/core@1.0.0')).toBeNull();
+    expect(parseReleaseTagVersion('@composio/cli@not-a-version')).toBeNull();
+    expect(parseReleaseTagVersion('v0.2.40')).toBeNull();
+    expect(parseReleaseTagVersion('')).toBeNull();
+  });
+});
+
+describe('parsePluginList', () => {
+  it('finds the plugin in Claude Code array output', () => {
+    expect(parsePluginList(CLAUDE_PLUGIN_LIST, undefined)).toEqual({
+      installed: true,
+      version: '0.2.2',
+    });
+  });
+
+  it('finds the plugin under the Codex records key', () => {
+    expect(parsePluginList(CODEX_PLUGIN_LIST, 'installed')).toEqual({
+      installed: true,
+      version: '0.2.1',
+    });
+  });
+
+  it('reports not installed when the plugin is absent', () => {
+    expect(parsePluginList('[]', undefined)).toEqual({ installed: false });
+    expect(parsePluginList('{"installed": []}', 'installed')).toEqual({ installed: false });
+  });
+
+  it('treats installed: false records as absent', () => {
+    const output = JSON.stringify({
+      installed: [{ pluginId: 'composio@composio', installed: false }],
+    });
+    expect(parsePluginList(output, 'installed')).toEqual({ installed: false });
+  });
+
+  it('prefers an enabled entry across scopes', () => {
+    const output = JSON.stringify([
+      { id: 'composio@composio', version: '0.1.0', scope: 'project', enabled: false },
+      { id: 'composio@composio', version: '0.2.2', scope: 'user', enabled: true },
+    ]);
+    expect(parsePluginList(output, undefined)).toEqual({ installed: true, version: '0.2.2' });
+  });
+
+  it('reports a null version when the host cannot resolve one', () => {
+    const output = JSON.stringify([{ id: 'composio@composio', version: 'unknown' }]);
+    expect(parsePluginList(output, undefined)).toEqual({ installed: true, version: null });
+  });
+
+  it('returns undefined for uninterpretable output', () => {
+    expect(parsePluginList('not-json', undefined)).toBeUndefined();
+    expect(parsePluginList('{"other": []}', 'installed')).toBeUndefined();
+    expect(parsePluginList('"string"', undefined)).toBeUndefined();
+  });
+});
+
+describe('parseManifestVersion', () => {
+  it('reads the version field', () => {
+    expect(parseManifestVersion('{"name": "composio", "version": "0.2.3"}')).toBe('0.2.3');
+  });
+
+  it('rejects missing or invalid versions and bodies', () => {
+    expect(parseManifestVersion('{"name": "composio"}')).toBeNull();
+    expect(parseManifestVersion('{"version": "latest"}')).toBeNull();
+    expect(parseManifestVersion('not-json')).toBeNull();
+    expect(parseManifestVersion('[]')).toBeNull();
+  });
+});
+
+describe('deriveArtifactStatus', () => {
+  it('maps installed and version pairs to a freshness status', () => {
+    expect(deriveArtifactStatus(true, '0.2.2', '0.2.3')).toEqual({
+      installed: true,
+      current: '0.2.2',
+      latest: '0.2.3',
+      updateAvailable: true,
+      status: 'update-available',
+    });
+    expect(deriveArtifactStatus(true, '0.2.3', '0.2.3')).toEqual({
+      installed: true,
+      current: '0.2.3',
+      latest: '0.2.3',
+      updateAvailable: false,
+      status: 'up-to-date',
+    });
+  });
+
+  it('never reports an update for missing artifacts', () => {
+    expect(deriveArtifactStatus(false, null, '0.2.3')).toEqual({
+      installed: false,
+      current: null,
+      latest: '0.2.3',
+      updateAvailable: false,
+      status: 'not-installed',
+    });
+  });
+
+  it('reports unknown when either side of the comparison is missing', () => {
+    expect(deriveArtifactStatus(true, null, '0.2.3').status).toBe('unknown');
+    expect(deriveArtifactStatus(true, '0.2.2', null).status).toBe('unknown');
+    expect(deriveArtifactStatus(true, 'garbage', '0.2.3').status).toBe('unknown');
+    expect(deriveArtifactStatus(undefined, null, '0.2.3')).toEqual({
+      installed: false,
+      current: null,
+      latest: '0.2.3',
+      updateAvailable: false,
+      status: 'unknown',
+    });
+  });
+
+  it('treats a newer installed version as up to date', () => {
+    expect(deriveArtifactStatus(true, '0.3.0', '0.2.3').status).toBe('up-to-date');
+  });
+});
+
+describe('cliArtifactStatus', () => {
+  const base: UpdateStatus = {
+    current: '0.2.0',
+    latestStable: '0.3.0',
+    updateAvailable: true,
+    checkStatus: 'update-available',
+    lastChecked: '2026-07-28T00:00:00.000Z',
+  };
+
+  it('mirrors the update-check status', () => {
+    expect(cliArtifactStatus(base)).toEqual({
+      installed: true,
+      current: '0.2.0',
+      latest: '0.3.0',
+      updateAvailable: true,
+      status: 'update-available',
+    });
+    expect(
+      cliArtifactStatus({
+        ...base,
+        latestStable: '0.2.0',
+        updateAvailable: false,
+        checkStatus: 'up-to-date',
+      }).status
+    ).toBe('up-to-date');
+    expect(
+      cliArtifactStatus({
+        ...base,
+        latestStable: null,
+        updateAvailable: false,
+        checkStatus: 'unknown',
+      }).status
+    ).toBe('unknown');
+  });
+});
+
+// ── skillStatus ─────────────────────────────────────────────────────────
+
+describe('skillStatus', () => {
+  it.effect('reports not installed when the skill directory is missing', () =>
+    Effect.gen(function* () {
+      const { skillStatus } = createFreshnessReporter(makeConfig());
+
+      const status = yield* skillStatus('0.2.41');
+
+      expect(status).toEqual({
+        installed: false,
+        current: null,
+        latest: '0.2.41',
+        updateAvailable: false,
+        status: 'not-installed',
+      });
+    }).pipe(Effect.provide(PlatformLayers))
+  );
+
+  it.effect('compares the stamped release tag against the latest CLI release', () =>
+    Effect.gen(function* () {
+      const config = makeConfig();
+      writeSkillTag(config, '@composio/cli@0.2.40');
+      const { skillStatus } = createFreshnessReporter(config);
+
+      const status = yield* skillStatus('0.2.41');
+
+      expect(status).toEqual({
+        installed: true,
+        current: '0.2.40',
+        latest: '0.2.41',
+        updateAvailable: true,
+        status: 'update-available',
+      });
+    }).pipe(Effect.provide(PlatformLayers))
+  );
+
+  it.effect('reports up to date when the stamp matches the latest release', () =>
+    Effect.gen(function* () {
+      const config = makeConfig();
+      writeSkillTag(config, '@composio/cli@0.2.41');
+      const { skillStatus } = createFreshnessReporter(config);
+
+      const status = yield* skillStatus('0.2.41');
+
+      expect(status.status).toBe('up-to-date');
+      expect(status.updateAvailable).toBe(false);
+    }).pipe(Effect.provide(PlatformLayers))
+  );
+
+  it.effect('reports unknown for an unstamped skill directory', () =>
+    Effect.gen(function* () {
+      const config = makeConfig();
+      mkdirSync(config.skillDir, { recursive: true });
+      const { skillStatus } = createFreshnessReporter(config);
+
+      const status = yield* skillStatus('0.2.41');
+
+      expect(status).toEqual({
+        installed: true,
+        current: null,
+        latest: '0.2.41',
+        updateAvailable: false,
+        status: 'unknown',
+      });
+    }).pipe(Effect.provide(PlatformLayers))
+  );
+
+  it.effect('reports unknown when the latest CLI release is unknown', () =>
+    Effect.gen(function* () {
+      const config = makeConfig();
+      writeSkillTag(config, '@composio/cli@0.2.40');
+      const { skillStatus } = createFreshnessReporter(config);
+
+      const status = yield* skillStatus(null);
+
+      expect(status.status).toBe('unknown');
+      expect(status.current).toBe('0.2.40');
+    }).pipe(Effect.provide(PlatformLayers))
+  );
+});
+
+// ── pluginStatus ────────────────────────────────────────────────────────
+
+describe('pluginStatus', () => {
+  it.effect('reports an available update from plugin list and HEAD manifest', () =>
+    Effect.gen(function* () {
+      const config = makeConfig({
+        fetchFn: () => Promise.resolve(manifestResponse('0.2.3')),
+      });
+      const { pluginStatus } = createFreshnessReporter(config);
+
+      const status = yield* pluginStatus(CLAUDE_PLUGIN_PROBE).pipe(
+        Effect.provideService(CommandRunner, stdoutRunner({ claude: CLAUDE_PLUGIN_LIST }))
+      );
+
+      expect(status).toEqual({
+        installed: true,
+        current: '0.2.2',
+        latest: '0.2.3',
+        updateAvailable: true,
+        status: 'update-available',
+      });
+    }).pipe(Effect.provide(PlatformLayers))
+  );
+
+  it.effect('reports up to date for the Codex plugin at the latest version', () =>
+    Effect.gen(function* () {
+      const config = makeConfig({
+        fetchFn: () => Promise.resolve(manifestResponse('0.2.1')),
+      });
+      const { pluginStatus } = createFreshnessReporter(config);
+
+      const status = yield* pluginStatus(CODEX_PLUGIN_PROBE).pipe(
+        Effect.provideService(CommandRunner, stdoutRunner({ codex: CODEX_PLUGIN_LIST }))
+      );
+
+      expect(status.status).toBe('up-to-date');
+      expect(status.current).toBe('0.2.1');
+    }).pipe(Effect.provide(PlatformLayers))
+  );
+
+  it.effect('reports not installed when the host binary is missing', () =>
+    Effect.gen(function* () {
+      const config = makeConfig({
+        fetchFn: () => Promise.resolve(manifestResponse('0.2.3')),
+      });
+      const { pluginStatus } = createFreshnessReporter(config);
+
+      const status = yield* pluginStatus(CLAUDE_PLUGIN_PROBE).pipe(
+        Effect.provideService(CommandRunner, stdoutRunner({}))
+      );
+
+      expect(status).toEqual({
+        installed: false,
+        current: null,
+        latest: '0.2.3',
+        updateAvailable: false,
+        status: 'not-installed',
+      });
+    }).pipe(Effect.provide(PlatformLayers))
+  );
+
+  it.effect('reports not installed when the plugin is absent from the host', () =>
+    Effect.gen(function* () {
+      const config = makeConfig({
+        fetchFn: () => Promise.resolve(manifestResponse('0.2.3')),
+      });
+      const { pluginStatus } = createFreshnessReporter(config);
+
+      const status = yield* pluginStatus(CLAUDE_PLUGIN_PROBE).pipe(
+        Effect.provideService(CommandRunner, stdoutRunner({ claude: '[]' }))
+      );
+
+      expect(status.status).toBe('not-installed');
+      expect(status.latest).toBe('0.2.3');
+    }).pipe(Effect.provide(PlatformLayers))
+  );
+
+  it.effect('reports unknown when the host command fails', () =>
+    Effect.gen(function* () {
+      const config = makeConfig({
+        fetchFn: () => Promise.resolve(manifestResponse('0.2.3')),
+      });
+      const { pluginStatus } = createFreshnessReporter(config);
+      const failingRunner = makeRunner(() =>
+        Effect.succeed({ exitCode: 1, stdout: '', stderr: 'boom' })
+      );
+
+      const status = yield* pluginStatus(CLAUDE_PLUGIN_PROBE).pipe(
+        Effect.provideService(CommandRunner, failingRunner)
+      );
+
+      expect(status.status).toBe('unknown');
+      expect(status.latest).toBe('0.2.3');
+    }).pipe(Effect.provide(PlatformLayers))
+  );
+
+  it.effect('reports unknown latest when the manifest fetch fails', () =>
+    Effect.gen(function* () {
+      const config = makeConfig({
+        fetchFn: () => Promise.reject(new Error('offline')),
+      });
+      const { pluginStatus } = createFreshnessReporter(config);
+
+      const status = yield* pluginStatus(CLAUDE_PLUGIN_PROBE).pipe(
+        Effect.provideService(CommandRunner, stdoutRunner({ claude: CLAUDE_PLUGIN_LIST }))
+      );
+
+      expect(status).toEqual({
+        installed: true,
+        current: '0.2.2',
+        latest: null,
+        updateAvailable: false,
+        status: 'unknown',
+      });
+    }).pipe(Effect.provide(PlatformLayers))
+  );
+});
+
+// ── collectArtifacts ────────────────────────────────────────────────────
+
+describe('collectArtifacts', () => {
+  it.effect('assembles the full artifact report', () =>
+    Effect.gen(function* () {
+      const cli: UpdateStatus = {
+        current: '0.2.40',
+        latestStable: '0.2.41',
+        updateAvailable: true,
+        checkStatus: 'update-available',
+        lastChecked: '2026-07-28T00:00:00.000Z',
+      };
+      const config = makeConfig({
+        fetchFn: url => {
+          if (url.includes('composio-plugin-cc')) {
+            return Promise.resolve(manifestResponse('0.2.3'));
+          }
+          return Promise.resolve(manifestResponse('0.2.2'));
+        },
+      });
+      writeSkillTag(config, '@composio/cli@0.2.41');
+      const { collectArtifacts } = createFreshnessReporter(config);
+
+      const artifacts = yield* collectArtifacts(cli).pipe(
+        Effect.provideService(
+          CommandRunner,
+          stdoutRunner({ claude: CLAUDE_PLUGIN_LIST, codex: CODEX_PLUGIN_LIST })
+        )
+      );
+
+      expect(artifacts).toEqual({
+        cli: {
+          installed: true,
+          current: '0.2.40',
+          latest: '0.2.41',
+          updateAvailable: true,
+          status: 'update-available',
+        },
+        skill: {
+          installed: true,
+          current: '0.2.41',
+          latest: '0.2.41',
+          updateAvailable: false,
+          status: 'up-to-date',
+        },
+        claudePlugin: {
+          installed: true,
+          current: '0.2.2',
+          latest: '0.2.3',
+          updateAvailable: true,
+          status: 'update-available',
+        },
+        codexPlugin: {
+          installed: true,
+          current: '0.2.1',
+          latest: '0.2.2',
+          updateAvailable: true,
+          status: 'update-available',
+        },
+      });
+    }).pipe(Effect.provide(PlatformLayers))
+  );
+});

--- a/ts/packages/cli/test/src/services/update-check.test.ts
+++ b/ts/packages/cli/test/src/services/update-check.test.ts
@@ -282,6 +282,18 @@ describe('showUpdateNotice', () => {
       expect(output).toEqual([]);
     }).pipe(Effect.provide(PlatformLayers))
   );
+
+  it.effect('does nothing when the cached state has no latestVersion', () =>
+    Effect.gen(function* () {
+      const config = makeConfig({ currentVersion: '0.2.0' });
+      writeState(config, { lastChecked: new Date().toISOString(), checkStatus: 'ok' });
+      const { showUpdateNotice } = createUpdateChecker(config);
+
+      yield* showUpdateNotice(makeTerminal(output));
+
+      expect(output).toEqual([]);
+    }).pipe(Effect.provide(PlatformLayers))
+  );
 });
 
 // ── getUpdateStatus ─────────────────────────────────────────────────────
@@ -406,6 +418,31 @@ describe('getUpdateStatus', () => {
       });
     }).pipe(Effect.provide(PlatformLayers))
   );
+
+  it.effect('reports unknown instead of up to date when no release matched', () =>
+    Effect.gen(function* () {
+      const config = makeConfig({
+        currentVersion: '0.2.0',
+        fetchFn: vi.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve([]),
+        }) as unknown as typeof fetch,
+      });
+      const { getUpdateStatus } = createUpdateChecker(config);
+
+      const status = yield* getUpdateStatus;
+
+      expect(status).toEqual({
+        current: '0.2.0',
+        latestStable: null,
+        updateAvailable: false,
+        checkStatus: 'unknown',
+        lastChecked: expect.any(String),
+      });
+      const state: UpdateCheckState = JSON.parse(readFileSync(config.stateFile, 'utf-8'));
+      expect(state.latestVersion).toBeUndefined();
+    }).pipe(Effect.provide(PlatformLayers))
+  );
 });
 
 // ── checkForUpdate ──────────────────────────────────────────────────────
@@ -522,8 +559,9 @@ describe('checkForUpdate', () => {
         expect(existsSync(config.stateFile)).toBe(true);
         const state: UpdateCheckState = JSON.parse(readFileSync(config.stateFile, 'utf-8'));
         expect(state.lastChecked).toBeDefined();
-        // Falls back to currentVersion since no previous state and no matching releases found
-        expect(state.latestVersion).toBe(config.currentVersion);
+        expect(state.checkStatus).toBe('ok');
+        // Never poisons the cache with currentVersion when no release matched.
+        expect(state.latestVersion).toBeUndefined();
       }).pipe(Effect.provide(PlatformLayers))
   );
 
@@ -615,7 +653,7 @@ describe('checkForUpdate', () => {
       yield* checkForUpdate;
 
       const state: UpdateCheckState = JSON.parse(readFileSync(config.stateFile, 'utf-8'));
-      expect(state).toEqual(previousState);
+      expect(state).toEqual({ ...previousState, checkStatus: 'failed' });
     }).pipe(Effect.provide(PlatformLayers))
   );
 
@@ -649,6 +687,7 @@ describe('checkForUpdate', () => {
       expect(state).toEqual({
         lastChecked: successfulAt.toISOString(),
         latestVersion: '0.3.0',
+        checkStatus: 'ok',
       });
       expect(JSON.parse(readFileSync(`${failingConfig.stateFile}.attempt`, 'utf-8'))).toEqual({
         lastAttempted: pinnedNow.toISOString(),

--- a/ts/packages/cli/test/src/services/update-check.test.ts
+++ b/ts/packages/cli/test/src/services/update-check.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync
 import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { BunFileSystem, BunPath } from '@effect/platform-bun';
-import { Effect, Fiber, Layer } from 'effect';
+import { Effect, Fiber, Layer, Option } from 'effect';
 import { withHttpServerEffect } from 'test/__utils__/http-server';
 import { getTerminalCapabilities, type TerminalUI } from 'src/services/terminal-ui';
 import {
@@ -681,8 +681,10 @@ describe('checkForUpdate', () => {
       yield* createUpdateChecker(successfulConfig).checkForUpdate;
       yield* Effect.sync(() => vi.setSystemTime(new Date(successfulAt.getTime() + 60_000)));
       yield* Effect.sync(() => failedResponse.reject(new Error('transient failure')));
-      yield* Fiber.join(failingFiber);
+      const failedResult = yield* Fiber.join(failingFiber);
 
+      expect(failedResult.refreshFailed).toBe(true);
+      expect(Option.getOrUndefined(failedResult.state)?.latestVersion).toBe('0.3.0');
       const state: UpdateCheckState = JSON.parse(readFileSync(failingConfig.stateFile, 'utf-8'));
       expect(state).toEqual({
         lastChecked: successfulAt.toISOString(),


### PR DESCRIPTION
## What

Two things, one seam (PRDE-1158):

### 1. Fix: update-check cache poisoning

On a failed release fetch (network down, rate-limited, no matching release), `checkForUpdate` used to write `latestVersion = currentVersion` into `~/.composio/update-check.json`. Consequence: the plugins' SessionStart hooks — which sed-parse that cache file — read "up to date" falsely for up to 24 hours after any failed fetch, silently suppressing real update prompts.

Now:
- `latestVersion` is optional in the cache schema — a fetch that finds no matching release writes **no** version instead of a poisoned one.
- The cache carries `checkStatus: 'ok' | 'failed'` so downstream readers can distinguish a fresh result from a stale one. A failed refresh stamps `checkStatus: 'failed'` onto the *unchanged* snapshot only — a re-read/compare guard ensures a concurrently succeeded check is never overwritten, and the failed path now returns the concurrently written (fresher) state to its caller.
- Legacy cache files (no `checkStatus`, mandatory `latestVersion`) still decode: both new fields are `Schema.optional`, and unknown keys are tolerated.

### 2. Feature: `composio version --check` becomes a full freshness report

Previously covered only the CLI binary. It now reports every Composio artifact on the machine:

| Artifact | Installed via | Latest via |
|---|---|---|
| `cli` | release-tag next to the binary | GitHub releases cache (24 h TTL) |
| `skill` | `~/.agents/skills/composio-cli/.composio-release-tag` | latest stable CLI release (skill ships with the CLI) |
| `claudePlugin` | `claude plugin list --json` | HEAD manifest at `composio-plugin-cc:plugins/composio/.claude-plugin/plugin.json` |
| `codexPlugin` | `codex plugin list --json` | HEAD manifest at `composio-plugin-openai:plugins/composio/.codex-plugin/plugin.json` |

**JSON contract**: all top-level fields from #3944 (`current`, `latestStable`, `updateAvailable`, `checkStatus`, `lastChecked`) are unchanged; the report adds one `artifacts` key. Every artifact has the same shape, and a missing artifact is data, never an error:

```json
{
  "current": "0.2.40",
  "latestStable": "0.2.41",
  "updateAvailable": true,
  "checkStatus": "update-available",
  "lastChecked": "2026-07-28T02:39:02.439Z",
  "artifacts": {
    "cli":          { "installed": true,  "current": "0.2.40", "latest": "0.2.41", "updateAvailable": true,  "status": "update-available" },
    "skill":        { "installed": true,  "current": "0.2.32-beta.289", "latest": "0.2.41", "updateAvailable": true, "status": "update-available" },
    "claudePlugin": { "installed": true,  "current": "0.2.2",  "latest": "0.2.3",  "updateAvailable": true,  "status": "update-available" },
    "codexPlugin":  { "installed": false, "current": null,     "latest": "0.2.2",  "updateAvailable": false, "status": "not-installed" }
  }
}
```

Degradation paths: host binary missing → `not-installed`; `plugin list` fails, times out (15 s), or emits unparseable output → `unknown`; manifest fetch fails or times out (5 s) → `latest: null` + `unknown`. Nothing in the artifact collection can fail the command (`Effect.Effect<FreshnessReport>` — error channel is `never`).

## Merge sequencing

**This PR should land BEFORE #3961 (`kj/silent-self-update`), which must then rebase onto it:**

- #3961's success-write hunk keeps a `?? currentVersion` fallback in the cache write — merging it after this PR without rebasing would reintroduce the exact poison this PR removes.
- #3961's `self-update.ts` consumes `latestVersion` from the cache state, which is now optional — the rebase must handle the absent case.

## Follow-up

Migrate both plugin repos' SessionStart hooks (`composio-plugin-cc`, `composio-plugin-openai`) to consume `composio version --check` instead of sed-parsing `~/.composio/update-check.json` — the cache file is an implementation detail; the JSON report is the contract.

## Verification

- `pnpm --filter @composio/cli test` — 1037 passed, 1 skipped (includes new suites for the freshness service and the no-poison/failed-stamp/concurrency cache behavior)
- `pnpm typecheck` (repo root) — green
- oxlint + prettier on changed files — clean
- Live smoke: `bun src/bin.ts version --check` against the real machine state — JSON above is (lightly adapted) real output; skill beta → stable correctly flagged, absent codex host correctly `not-installed`
- Rebased onto `origin/next` (fc974504) and re-verified after #3945 landed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
