### PR TITLE
docs: use automatic Custom MCP account matching

### DIFF
--- a/docs/content/docs/extending-sessions/custom-mcp.mdx
+++ b/docs/content/docs/extending-sessions/custom-mcp.mdx
@@ -21,7 +21,7 @@ A Custom MCP moves through this lifecycle:
 2. **Register** its URL and authentication scheme. Composio creates a project-scoped `CUSTOM_*` toolkit.
 3. **Connect** an account if the server uses an API key or DCR OAuth. No-auth servers skip this step.
 4. **Sync** its tools. The first sync starts automatically; later tool changes require a manual sync.
-5. **Use** the toolkit in a session. For authenticated servers, explicitly select the connected account.
+5. **Use** the toolkit in a session. For authenticated servers, Composio matches the active connection for the session user.
 
 <Callout type="warn" title="API-only while Custom MCP is experimental">
 Use the lifecycle endpoints below to register, sync, and delete Custom MCP toolkits. They aren't included in the public API reference or SDKs yet, and their contracts may change. Dashboard management is coming soon for customers who prefer a UI.
@@ -204,9 +204,7 @@ Deletion removes the custom toolkit and its tools. It also revokes and removes t
 
 Once the toolkit is synced, add its `CUSTOM_*` slug to a session.
 
-### Use a no-auth server
-
-Pass the toolkit slug when you create the session:
+For API-key and DCR OAuth servers, use the same `user_id` that owns the active connected account. Composio matches that connection automatically, so you don't need to pass its ID in the session config. No-auth servers don't need a connected account.
 
 <Tabs groupId="language" items={['Python', 'TypeScript']} persist>
 <Tab value="Python">
@@ -239,44 +237,6 @@ const tools = await session.tools();
 </Tabs>
 
 With the default search-first session, your agent can discover the custom tools through `COMPOSIO_SEARCH_TOOLS` and execute them through the Tool Router.
-
-### Use an authenticated server
-
-For API-key and DCR OAuth servers, explicitly select the connected account in the session config. Don't rely on automatic account matching for Custom MCP toolkits yet.
-
-<Tabs groupId="language" items={['Python', 'TypeScript']} persist>
-<Tab value="Python">
-```python
-from composio import Composio
-
-composio = Composio(api_key="your_api_key")
-
-session = composio.sessions.create(
-    user_id="user_123",
-    toolkits=["CUSTOM_ACME"],
-    connected_accounts={
-        "CUSTOM_ACME": ["ca_custom_acme"],
-    },
-)
-```
-</Tab>
-<Tab value="TypeScript">
-```typescript
-import { Composio } from "@composio/core";
-
-const composio = new Composio({ apiKey: "your_api_key" });
-
-const session = await composio.sessions.create("user_123", {
-  toolkits: ["CUSTOM_ACME"],
-  connectedAccounts: {
-    CUSTOM_ACME: ["ca_custom_acme"],
-  },
-});
-```
-</Tab>
-</Tabs>
-
-The pinned account must belong to the custom toolkit and be active. Explicit selection ensures tool calls use its credentials.
 
 ## What you manage and what Composio handles
 
@@ -324,9 +284,8 @@ See [Toolkit Versioning](/docs/tools-direct/toolkit-versioning) for more example
 - **API-key validation is limited:** Setup checks that a key was provided, not that the remote server accepts it. Run a safe tool after connecting to verify the credential end to end.
 
 </Accordion>
-<Accordion title="Sessions and tool APIs">
+<Accordion title="Tool APIs">
 
-- **Select authenticated accounts explicitly:** Custom MCP sessions don't reliably match a connected account automatically. Pass its ID through `connected_accounts` in Python or `connectedAccounts` in TypeScript.
 - **Prefer the v3.1 tools API:** The v3 tools API pins a default version that doesn't contain custom tools. If you must use v3, explicitly select `latest` as described above.
 
 </Accordion>


### PR DESCRIPTION
## What changed

- Remove explicit `connected_accounts` / `connectedAccounts` pinning from authenticated Custom MCP session examples.
- Use one session example for no-auth, API-key, and DCR OAuth toolkits.
- Explain that authenticated sessions automatically match the active connection for the session user.
- Keep `connected_account_id` in the manual authenticated resync example, where it is still required.
- Remove the now-stale known gap about Custom MCP session account matching.

## Why

ComposioHQ/platform#11223 now enables Tool Router matching by default for newly created Custom MCP auth configs. The previous docs still described the pre-fix behavior and required customers to pin an account manually.

Custom MCP has not meaningfully rolled out to production customers, so this documents the intended behavior without a legacy backfill caveat.

## Verification

- `bun run lint:links`
- `bun run types:check`
- `git diff --check`
