### PR TITLE
docs(openai): document using OpenAI-compatible gateways (#3602)

### DIFF
--- a/docs/content/docs/providers/openai.mdx
+++ b/docs/content/docs/providers/openai.mdx
@@ -406,6 +406,153 @@ The OpenAI integration ships three providers, one per API surface:
 
 Use the Responses or Agents provider for new agentic flows; reach for Chat Completions when you are extending an existing Chat Completions codebase.
 
+## Using a third-party OpenAI-compatible endpoint
+
+If your model provider exposes an OpenAI-compatible Chat Completions endpoint, you do not need a new provider package. Pass the `OpenAIProvider` to `Composio` exactly as you would for OpenAI, and point the OpenAI SDK client at the gateway with a custom `baseURL`. The tool format, agentic loop, and session behavior are unchanged; only the model endpoint changes.
+
+<Callout type="info">
+This page shows AI/ML API (`https://api.aimlapi.com/v1`) as a worked example. The same pattern works for any other OpenAI-compatible gateway — change `baseURL` and the model name to match your provider.
+</Callout>
+
+<Steps>
+<Step>
+**Install**
+
+The same packages as the Chat Completions tab above. No additional dependency is needed.
+
+<Tabs groupId="language" items={["Python", "TypeScript"]} persist>
+<Tab value="Python">
+<PackageInstall ecosystem="python" packages="composio composio_openai openai" />
+</Tab>
+<Tab value="TypeScript">
+<PackageInstall packages="@composio/core @composio/openai openai" />
+</Tab>
+</Tabs>
+</Step>
+
+<Step>
+**Configure API Keys**
+
+<Callout type="info">
+Set `COMPOSIO_API_KEY` with your API key from [Settings](https://dashboard.composio.dev/~/project/settings/api-keys?utm_source=docs&utm_medium=content&utm_campaign=docs-providers-openai) and `AIMLAPI_API_KEY` with your [AI/ML API key](https://aimlapi.com/app/keys).
+</Callout>
+
+```txt title=".env"
+COMPOSIO_API_KEY=***
+AIMLAPI_API_KEY=***
+```
+</Step>
+
+<Step>
+**Create session and run**
+
+<Tabs groupId="language" items={["Python", "TypeScript"]} persist>
+<Tab value="Python">
+```python
+import json
+import os
+
+from openai import OpenAI
+from composio import Composio
+from composio_openai import OpenAIProvider
+
+composio = Composio(provider=OpenAIProvider())
+client = OpenAI(
+    api_key=os.environ["AIMLAPI_API_KEY"],
+    base_url="https://api.aimlapi.com/v1",
+)
+
+# Create a session for your user
+session = composio.create(user_id="user_123")
+tools = session.tools()
+
+messages = [
+    {"role": "user", "content": "Send an email to john@example.com with the subject 'Hello' and body 'Hello from Composio!'"}
+]
+
+response = client.chat.completions.create(
+    model="gpt-4o-mini",
+    tools=tools,
+    messages=messages,
+)
+
+# Agentic loop: keep executing tool calls until the model responds with text
+while response.choices[0].message.tool_calls:
+    results = composio.provider.handle_tool_calls(response=response, user_id="user_123")
+    messages.append(response.choices[0].message)
+    for i, tc in enumerate(response.choices[0].message.tool_calls):
+        messages.append({
+            "role": "tool",
+            "tool_call_id": tc.id,
+            "content": json.dumps(results[i]),
+        })
+    response = client.chat.completions.create(
+        model="gpt-4o-mini",
+        tools=tools,
+        messages=messages,
+    )
+
+print(response.choices[0].message.content)
+```
+</Tab>
+<Tab value="TypeScript">
+```typescript
+import OpenAI from 'openai';
+import { Composio } from '@composio/core';
+import { OpenAIProvider } from '@composio/openai';
+
+declare const process: { env: Record<string, string | undefined> };
+
+const composio = new Composio({
+    provider: new OpenAIProvider(),
+});
+const client = new OpenAI({
+    apiKey: process.env.AIMLAPI_API_KEY,
+    baseURL: 'https://api.aimlapi.com/v1',
+});
+
+// Create a session for your user
+const session = await composio.create('user_123');
+const tools = await session.tools();
+
+const messages: OpenAI.Chat.ChatCompletionMessageParam[] = [
+    {
+        role: 'user',
+        content: "Send an email to john@example.com with the subject 'Hello' and body 'Hello from Composio!'",
+    },
+];
+
+let response = await client.chat.completions.create({
+    model: 'gpt-4o-mini',
+    tools: tools,
+    messages: messages,
+});
+
+// Agentic loop: keep executing tool calls until the model responds with text
+while (response.choices[0].message.tool_calls) {
+    const results = await composio.provider.handleToolCalls('user_123', response);
+    messages.push(response.choices[0].message);
+    for (const [i, tc] of response.choices[0].message.tool_calls.entries()) {
+        messages.push({
+            role: 'tool',
+            tool_call_id: tc.id,
+            content: JSON.stringify(results[i]),
+        });
+    }
+    response = await client.chat.completions.create({
+        model: 'gpt-4o-mini',
+        tools: tools,
+        messages: messages,
+    });
+}
+
+console.log(response.choices[0].message.content);
+```
+</Tab>
+</Tabs>
+</Step>
+</Steps>
+
 ## Next
 
 <Card icon={<BookOpen />} title="What is a session?" href="/docs/how-composio-works" description="How sessions scope users, tools, and auth, and how to reuse them across requests." />


### PR DESCRIPTION
## Summary

Adds a section to `docs/content/docs/providers/openai.mdx` documenting how to point Composio's existing `OpenAIProvider` at AI/ML API (or any other OpenAI-compatible endpoint) by overriding `baseURL` in the OpenAI SDK client.

No new provider package. No code changes. No package/version changes. No changeset (per `AGENTS.md`: "Documentation-only and agent-guidance-only changes do not need a changeset").

Fixes #3602

## Changes

- `docs/content/docs/providers/openai.mdx`: append `## Using a third-party OpenAI-compatible endpoint` after the existing "Provider specifics" section. Three steps (install / env / code) following the same structure as the existing Chat Completions tab, in TypeScript + Python.
- The same pattern applies to any other OpenAI-compatible gateway — change `baseURL` and the model name. Called out in an info callout so it's clear this isn't tied to a specific vendor.

## Design decisions

- **Appended a section, not a new page.** The author left placement questions unanswered on the issue (provider docs page vs. cookbook vs. examples folder). Minimum-surface-area decision — no new file, no sidebar/index changes, no meta.json edit.
- **`AIMLAPI_API_KEY` env var name.** Matches the issue body and the convention used elsewhere in the page (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`).
- **Chat Completions only.** The author suggested "chat-completions only" as a low-risk first PR. Responses API and Agents SDK are unchanged.
- **Section title is gateway-agnostic.** "Using a third-party OpenAI-compatible endpoint" doesn't tie the section to one vendor; works for AI/ML API, OpenRouter, Together, etc.

## How Has This Been Tested?

```
$ cd docs && bun install
$ bun run lint               # 0 errors (warnings pre-existing, unchanged)
$ bun run lint:links         # 0 errors
$ bun run types:check        # passed (Twoslash validates the new TypeScript block)
$ bun run test tests/static/ # 97/98 pass; 1 pre-existing failure unrelated (verified by stash)
$ bun run build              # 1447/1447 static pages, no errors
```

The Twoslash check (`docs/agent-guidance/context/twoslash.md`) is the relevant one for this PR: ALL TypeScript code blocks in MDX are type-checked at build time, and the build passed.

- [x] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [x] Documentation
- [ ] Breaking change

## Checklist

- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed (`bun run lint`, `lint:links`, `types:check`, `build`)
- [x] I updated documentation as needed (this PR IS the documentation update)
- [ ] I added tests or explain why not applicable — N/A, docs-only PR
- [ ] I added a changeset if this change affects published packages — N/A, per AGENTS.md docs-only changes don't need one

## Additional context

Issue author filed as [previous attempt](https://github.com/ComposioHQ/composio/issues/1608) was closed by stale bot. This PR resolves the original feature request with the same scope plus a clean, well-tested diff.
