### PR TITLE
fix(cli): unblock release checksum generation

### DIFF
--- a/test/release-workflow.test.ts
+++ b/test/release-workflow.test.ts
@@ -66,6 +66,12 @@ const verifyAssetsScript = readFileSync(
   new URL('../.github/scripts/cli-release/verify-assets.sh', import.meta.url),
   'utf8'
 );
+const generateChecksumsScriptUrl = new URL(
+  '../ts/packages/cli/scripts/generate-checksums.ts',
+  import.meta.url
+);
+const generateChecksumsScriptPath = generateChecksumsScriptUrl.pathname;
+const generateChecksumsScript = readFileSync(generateChecksumsScriptUrl, 'utf8');
 
 function requireMatch(text, pattern, label) {
   const match = text.match(pattern);
@@ -525,6 +531,46 @@ if (!(packageSkillsIdx < generateChecksumsIdx)) {
   throw new Error(
     'build-cli-binaries.yml must package skills before generating checksums so the skill zip is checksummed'
   );
+}
+
+if (
+  !generateChecksumsScript.includes("from './_teardown'") ||
+  generateChecksumsScript.includes("from './_shared'")
+) {
+  throw new Error(
+    'CLI checksum generation must use the dependency-light teardown without loading CLI runtime helpers'
+  );
+}
+
+// The release job runs checksum generation in a fresh checkout where workspace packages have not
+// been built. Exercise the script from an unrelated working directory to prevent imports from
+// pulling in the CLI runtime and its unbuilt @composio/core dependency.
+{
+  const fixtureDir = mkdtempSync(join(tmpdir(), 'composio-cli-checksums-'));
+  try {
+    const binariesDir = join(fixtureDir, 'dist/binaries');
+    mkdirSync(binariesDir, { recursive: true });
+    writeFileSync(join(binariesDir, 'composio-linux-x64.zip'), 'release archive fixture\n');
+
+    const result = spawnSync(process.execPath, [generateChecksumsScriptPath], {
+      cwd: fixtureDir,
+      encoding: 'utf8',
+      env: process.env,
+    });
+
+    if (result.status !== 0) {
+      throw new Error(
+        `CLI checksum generation must run without built workspace packages\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`
+      );
+    }
+
+    const checksums = readFileSync(join(binariesDir, 'checksums.txt'), 'utf8');
+    if (!/^[a-f0-9]{64}  composio-linux-x64\.zip\n$/.test(checksums)) {
+      throw new Error(`CLI checksum generation wrote an invalid manifest:\n${checksums}`);
+    }
+  } finally {
+    rmSync(fixtureDir, { recursive: true, force: true });
+  }
 }
 
 // Per-tag concurrency prevents two runs clobbering the same release without serializing betas.

--- a/ts/packages/cli/scripts/_shared.ts
+++ b/ts/packages/cli/scripts/_shared.ts
@@ -2,10 +2,11 @@ import { builtinModules } from 'node:module';
 import { chmod, copyFile, mkdir, readdir, rm, stat, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
 import process from 'node:process';
-import { Cause, Effect, Exit } from 'effect';
-import type { Teardown } from '@effect/platform/Runtime';
+import { Effect } from 'effect';
 import { RUN_COMPANION_MODULE_BASENAMES } from '../src/services/run-companion-modules';
 import { materializeAcpAdaptersCache } from './_acp-adapters';
+
+export { teardown } from './_teardown';
 
 const RUN_COMPANION_SERVICE_ENTRY_MAP = Object.fromEntries(
   RUN_COMPANION_MODULE_BASENAMES.map(name => [`services/${name}`, `src/services/${name}.ts`])
@@ -293,18 +294,6 @@ const buildCompanionServiceBundles = async (outputDir: string): Promise<void> =>
       );
     }
   }
-};
-
-/**
- * Shared teardown for all CLI scripts.
- *
- * Exits with a non-zero code when the Effect program fails
- * (unless the failure is an interrupt-only cause).
- */
-export const teardown: Teardown = <E, A>(exit: Exit.Exit<E, A>, onExit: (code: number) => void) => {
-  const shouldFail = Exit.isFailure(exit) && !Cause.isInterruptedOnly(exit.cause);
-  const errorCode = Number(process.exitCode ?? 1);
-  onExit(shouldFail ? errorCode : 0);
 };
 
 export const buildCompanionModules = (outputDir: string) =>

--- a/ts/packages/cli/scripts/_teardown.ts
+++ b/ts/packages/cli/scripts/_teardown.ts
@@ -1,0 +1,15 @@
+import process from 'node:process';
+import { Cause, Exit } from 'effect';
+import type { Teardown } from '@effect/platform/Runtime';
+
+/**
+ * Shared teardown for CLI scripts.
+ *
+ * Keep this module dependency-light so release-only scripts can use it without
+ * loading the CLI runtime or requiring built workspace packages.
+ */
+export const teardown: Teardown = <E, A>(exit: Exit.Exit<E, A>, onExit: (code: number) => void) => {
+  const shouldFail = Exit.isFailure(exit) && !Cause.isInterruptedOnly(exit.cause);
+  const errorCode = Number(process.exitCode ?? 1);
+  onExit(shouldFail ? errorCode : 0);
+};

--- a/ts/packages/cli/scripts/generate-checksums.ts
+++ b/ts/packages/cli/scripts/generate-checksums.ts
@@ -17,7 +17,7 @@
 import process from 'node:process';
 import { Config, ConfigProvider, Console, Effect, Logger, Layer, LogLevel } from 'effect';
 import { BunContext, BunRuntime } from '@effect/platform-bun';
-import { teardown } from './_shared';
+import { teardown } from './_teardown';
 import { readdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 


### PR DESCRIPTION
This PR:
- fixes https://github.com/ComposioHQ/composio/actions/runs/30535159056/job/90850055191 by keeping checksum generation independent of unbuilt CLI runtime packages
- extracts the shared Effect teardown into a dependency-light module while preserving existing script imports
- adds an executable release regression that generates a checksum manifest from a clean fixture
- verifies the fix with `pnpm test:release-workflow`, `pnpm build:packages`, CLI typecheck, the full CLI test suite, and `pnpm validate:changesets`
