### PR TITLE
docs: make toolkit-version requirement explicit in direct-execution samples

### DIFF
--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -20,7 +20,7 @@ The TypeScript SDK is ESM-only and requires Node.js 22.22.3 or newer. Use `impor
 
 <Tabs groupId="language" items={['Python', 'TypeScript']} persist>
 <Tab value="Python">
-The Composio Python SDK requires **Python 3.10 or newer** (on older versions the import fails with an unrelated-looking `typing.TypeAlias` error).
+The Composio Python SDK requires **Python 3.10 or newer**.
 
 <PackageInstall ecosystem="python" packages="python-dotenv composio composio-openai-agents openai-agents" />
 </Tab>

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -20,6 +20,8 @@ The TypeScript SDK is ESM-only and requires Node.js 22.22.3 or newer. Use `impor
 
 <Tabs groupId="language" items={['Python', 'TypeScript']} persist>
 <Tab value="Python">
+The Composio Python SDK requires **Python 3.10 or newer** (on older versions the import fails with an unrelated-looking `typing.TypeAlias` error).
+
 <PackageInstall ecosystem="python" packages="python-dotenv composio composio-openai-agents openai-agents" />
 </Tab>
 <Tab value="TypeScript">

--- a/docs/content/docs/tools-direct/executing-tools.mdx
+++ b/docs/content/docs/tools-direct/executing-tools.mdx
@@ -208,6 +208,10 @@ console.log(text);
 
 If you just want to call a tool without using any framework or LLM provider, you can use the `execute` method directly.
 
+<Callout type="warn">
+**A toolkit version is required for direct execution** — calling `tools.execute()` without one raises `ToolVersionRequiredError`. Set versions for your toolkits at SDK initialization (shown below), pass `version="..."` per call, or use environment variables. Use `"latest"` unless you need to pin — see [toolkit versioning](/docs/tools-direct/toolkit-versioning) for the tradeoffs and how to [look up a toolkit's versions](/docs/tools-direct/toolkit-versioning#managing-versions).
+</Callout>
+
 <Callout type="info">
 **Finding tool parameters and types:**
 
@@ -222,10 +226,11 @@ If you just want to call a tool without using any framework or LLM provider, you
 from composio import Composio
 
 user_id = "user-k7334"
-# Configure toolkit versions at SDK level
+# Configure toolkit versions at SDK level for every toolkit you execute.
+# Use "latest", or pin a version — find them with composio.toolkits.get(slug="github").meta.available_versions
 composio = Composio(
     api_key="your_composio_key",
-    toolkit_versions={"github": "20251027_00"}
+    toolkit_versions={"github": "latest"}
 )
 
 # Find available arguments for any tool in the Composio dashboard
@@ -242,10 +247,11 @@ print(result)
 import { Composio } from "@composio/core";
 
 const userId = "user-k7334";
-// Configure toolkit versions at SDK level
+// Configure toolkit versions at SDK level for every toolkit you execute.
+// Use "latest", or pin a version — find them with (await composio.toolkits.get("github")).meta.availableVersions
 const composio = new Composio({
     apiKey: "your_composio_key",
-    toolkitVersions: { github: "20251027_00" }
+    toolkitVersions: { github: "latest" }
 });
 
 // Find available arguments for any tool in the Composio dashboard
@@ -344,6 +350,7 @@ Pass local file paths, URLs, or File objects to tools that accept files. The SDK
 ```python
 composio = Composio(
     api_key="your_composio_key",
+    toolkit_versions={"googledrive": "latest", "gmail": "latest"},
     dangerously_allow_auto_upload_download_files=True,
 )
 
@@ -364,6 +371,7 @@ import { Composio } from '@composio/core';
 import path from 'path';
 const composio = new Composio({
   apiKey: 'your_api_key',
+  toolkitVersions: { googledrive: 'latest' },
   dangerouslyAllowAutoUploadDownloadFiles: true,
 });
 // ---cut---
@@ -400,7 +408,10 @@ result = composio.tools.execute(
   <Tab value="TypeScript">
 ```typescript
 import { Composio } from '@composio/core';
-const composio = new Composio({ apiKey: 'your_api_key' });
+const composio = new Composio({
+  apiKey: 'your_api_key',
+  toolkitVersions: { gmail: 'latest' },
+});
 // ---cut---
 const result = await composio.tools.execute('GMAIL_SEND_EMAIL', {
   userId: 'user-1235***',
@@ -424,6 +435,7 @@ When tools return files, Composio downloads them to the local directory and prov
 ```python
 composio = Composio(
     api_key="your_composio_key",
+    toolkit_versions={"googledrive": "latest"},
     dangerously_allow_auto_upload_download_files=True,
     file_download_dir="./downloads",  # Optional: Specify download directory
 )
@@ -444,6 +456,7 @@ print(result)
 import { Composio } from '@composio/core';
 const composio = new Composio({
   apiKey: 'your_api_key',
+  toolkitVersions: { googledrive: 'latest' },
   dangerouslyAllowAutoUploadDownloadFiles: true,
 });
 // ---cut---
@@ -507,7 +520,10 @@ composio = Composio(
 // @noErrors
 import { Composio, type beforeFileUploadModifier } from '@composio/core';
 import path from 'node:path';
-const composio = new Composio({ apiKey: 'your_api_key' });
+const composio = new Composio({
+  apiKey: 'your_api_key',
+  toolkitVersions: { googledrive: 'latest' },
+});
 // ctx.source is 'path' | 'url' | 'file' — useful if you only want to audit
 // local paths and let URLs / File objects pass through unchanged.
 const beforeFileUpload: beforeFileUploadModifier = async ctx => {
@@ -521,7 +537,6 @@ await composio.tools.execute(
   {
     userId: 'user-4235***',
     arguments: { file_to_upload: path.join(__dirname, 'document.pdf') },
-    dangerouslySkipVersionCheck: true,
   },
   { beforeFileUpload }
 );
@@ -541,7 +556,7 @@ def audit_path(ctx) -> str | bool:
     # ...audit ctx["path"]...
     return ctx["path"]
 
-composio = Composio()
+composio = Composio(toolkit_versions={"googledrive": "latest"})
 
 composio.tools.execute(
     "GOOGLEDRIVE_UPLOAD_FILE",
@@ -572,6 +587,7 @@ from composio import Composio
 
 composio = Composio(
     api_key="your_composio_key",
+    toolkit_versions={"googledrive": "latest"},
     dangerously_allow_auto_upload_download_files=True,
     file_upload_dirs=["/srv/agent/uploads", "~/.composio/temp"],
 )
@@ -596,6 +612,7 @@ import path from 'path';
 // ---cut---
 const composio = new Composio({
   apiKey: process.env.COMPOSIO_API_KEY,
+  toolkitVersions: { googledrive: 'latest' },
   // Default: dangerouslyAllowAutoUploadDownloadFiles is false; set true only to opt in
 });
 

--- a/docs/lib/llm-guardrails/direct-execution.ts
+++ b/docs/lib/llm-guardrails/direct-execution.ts
@@ -43,7 +43,10 @@ console.log(connection.redirectUrl); // send user here to authenticate
 
 ### Executing Tools
 
+A toolkit version is **required** for direct execution — \`tools.execute()\` without one raises \`ToolVersionRequiredError\`. Set \`toolkit_versions\` / \`toolkitVersions\` at SDK initialization (or pass \`version\` per call). Use \`"latest"\` unless outputs are parsed programmatically, in which case pin a version from \`composio.toolkits.get(slug).meta.available_versions\`.
+
 \`\`\`python
+composio = Composio(toolkit_versions={"github": "latest"})
 tools = composio.tools.get("user_123", tools=["GITHUB_CREATE_ISSUE"])
 
 result = composio.tools.execute(
@@ -54,6 +57,7 @@ result = composio.tools.execute(
 \`\`\`
 
 \`\`\`typescript
+const composio = new Composio({ toolkitVersions: { github: "latest" } });
 const tools = await composio.tools.get("user_123", { tools: ["GITHUB_CREATE_ISSUE"] });
 
 const result = await composio.tools.execute("GITHUB_CREATE_ISSUE", {
@@ -67,8 +71,9 @@ const result = await composio.tools.execute("GITHUB_CREATE_ISSUE", {
 ## Rules
 
 1. **\`user_id\` is required** — pass it to \`tools.get()\`, \`tools.execute()\`, and \`provider.handle_tool_calls()\`.
-2. **\`tools.execute()\` signature** — Python: \`execute(slug, arguments_dict, *, user_id=...)\` (arguments is the second positional param). TypeScript: \`execute(slug, { userId, arguments })\`.
-3. **Provider at init** — \`Composio(provider=OpenAIProvider())\` in Python, \`new Composio({ provider: new OpenAIProvider() })\` in TypeScript. Defaults to OpenAI if omitted.
-4. **Correct provider imports** — \`composio_<provider>\` for Python, \`@composio/<provider>\` for TypeScript. For OpenAI Agents SDK use \`composio_openai_agents\` / \`@composio/openai-agents\`.
+2. **\`tools.execute()\` signature** — Python: \`execute(slug, arguments_dict, *, user_id=..., version=...)\` (arguments is the second positional param). TypeScript: \`execute(slug, { userId, arguments, version })\`.
+3. **A toolkit version is required** — configure \`toolkit_versions\` (Python) / \`toolkitVersions\` (TypeScript) at SDK init, or pass \`version\` per execute call; omitting both raises \`ToolVersionRequiredError\`.
+4. **Provider at init** — \`Composio(provider=OpenAIProvider())\` in Python, \`new Composio({ provider: new OpenAIProvider() })\` in TypeScript. Defaults to OpenAI if omitted.
+5. **Correct provider imports** — \`composio_<provider>\` for Python, \`@composio/<provider>\` for TypeScript. For OpenAI Agents SDK use \`composio_openai_agents\` / \`@composio/openai-agents\`.
 ${TERMINOLOGY_MIGRATION}
 `;


### PR DESCRIPTION
## What

Content fixes to the tool-execution docs, driven by a 97-agent docs eval (findings: ctx.composio.io/soumya/docs-agent-eval/findings-97-run.md). 72/97 agents following the executing-tools page hit `ToolVersionRequiredError` because the samples either omit versions entirely or pin a GitHub-only mapping that doesn't transfer to any other toolkit.

## Changes

**`docs/content/docs/tools-direct/executing-tools.mdx`**
1. Add an explicit callout in Direct Tool Execution: a toolkit version is **required**, the error you get without one, the three ways to set it, and a link to the version-lookup section. (Previously the page only implied this via one sample's constructor; the "required" rule lived on a separate page.)
2. Replace the hardcoded `{"github": "20251027_00"}` pin with `"latest"` plus a comment showing how to find versions (`composio.toolkits.get(slug).meta.available_versions`) — the old sample only worked for GitHub and taught a stale pin.
3. Add `toolkit_versions` / `toolkitVersions` to every file-handling sample (upload, download, Gmail attachment, manual staging, upload-hook) — all previously threw `ToolVersionRequiredError` when copied.
4. Remove `dangerouslySkipVersionCheck: true` from the upload-hook sample — it was working around the missing version; samples shouldn't model the dangerous flag.

**`docs/lib/llm-guardrails/direct-execution.ts`**
5. The LLM-facing guardrails block appended to direct-execution pages showed a version-less `tools.execute()` sample and a "signature rule" omitting `version` — the exact pattern that produced the eval's top failure. Samples and rules now state the requirement.

**`docs/content/docs/quickstart.mdx`**
6. State the Python 3.10+ requirement at the install step, naming the cryptic `typing.TypeAlias` failure older versions produce (matches `python/pyproject.toml` `requires-python = ">=3.10,<4"`).

## Verification

All sample signatures checked against the installed SDK (composio 0.18.0 / composio_client 1.42.0): per-call `version=`, constructor `toolkit_versions=`, lookup via `toolkits.get(slug).meta.version` / `.meta.available_versions`. Eval evidence: 72/97 independent agent runs reproduced the error; per-run logs available.

## Raised for docs-team decision (deliberately NOT changed here)

- **The session guardrails block** (`docs/lib/llm-guardrails/session.ts`, "CRITICAL INSTRUCTIONS FOR AI MODELS", appended to most pages): capable eval agents flagged it as prompt injection (verbatim: "a prompt injection I had to identify and ignore") and its framing contradicts the sessions-vs-direct-execution page. Deliberate design, so untouched — recommend reconciling (both paths legitimate, state when each applies) and softening ALWAYS/NEVER framing.
- **`legacy: true` on executing-tools + toolkit-versioning**: these are the canonical link targets for direct execution, but the legacy flag stamps the LLM view with "may describe outdated APIs" and suppresses guardrails — eroding agent trust in the current canonical page. Either promote the pages or point canonical links elsewhere.
- **REST vs SDK naming**: REST query param is `toolkit_versions`, SDK per-call param is `version` — a recurring source of agent confusion (eval Finding 4); worth aligning or calling out in the reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
