### PR TITLE
fix(ci): align workflow Node.js version with package engines

### DIFF
--- a/.github/workflows/ts.test-e2e.yml
+++ b/.github/workflows/ts.test-e2e.yml
@@ -320,7 +320,7 @@ jobs:
         uses: ./.github/actions/setup-node-pnpm-bun
         with:
           enable-turbo-cache: 'true'
-          node-version: '22.22.3'
+          node-version: '24'
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Why
Package metadata declares `engines.node` / `volta.node` / `.nvmrc` as `24`, but CI workflows still pin `node-version` to a mismatched value.

That can make CI run on a runtime the project no longer supports (or skip the version the package actually targets).

## What changed
Update the affected workflow `node-version` pins so they satisfy `24` (using `24` where a concrete pin is needed).

- `.github/workflows/ts.test-e2e.yml`
  - `node-version: '22.22.3'` → `node-version: '24'`

## Test plan
- [ ] Package `engines.node` / `volta.node` / `.nvmrc` is still `24`
- [ ] Updated workflows now use versions consistent with that constraint
- [ ] Relevant CI jobs on this branch look healthy

Found while auditing CI/package version consistency across popular repos.
