### PR TITLE
fix(cli): replace the running binary atomically

### DIFF
--- a/.github/workflows/cli.test-installation.yml
+++ b/.github/workflows/cli.test-installation.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Test release resolution fallback
         run: bash test/install-sh-release-resolution.test.sh
 
+      - name: Test atomic install replacement
+        run: bash test/install-sh-atomic-replace.test.sh
+
       - name: Lint POSIX install scripts
         run: shellcheck -s sh install.sh install/*.sh
 

--- a/install.sh
+++ b/install.sh
@@ -245,7 +245,8 @@ publish_staged_entry() {
         mv "$publish_target" "$publish_aside" ||
             error "Failed to move existing install entry aside: $publish_target"
         if mv "$publish_source" "$publish_target"; then
-            rm -rf "$publish_aside" || error "Failed to remove old install entry: $publish_aside"
+            rm -rf "$publish_aside" ||
+                warn "Published install entry; previous contents retained at $publish_aside"
             return 0
         fi
 
@@ -297,7 +298,7 @@ install_bundle() {
 
     publish_staged_entry "$stage/release-tag.txt"
     publish_staged_entry "$stage/composio"
-    rmdir "$stage" || error "Failed to remove staging directory: $stage"
+    rmdir "$stage" || warn "Published CLI; retained recovery staging directory at $stage"
     stage=
 }
 

--- a/install.sh
+++ b/install.sh
@@ -234,6 +234,32 @@ resolve_directory() {
     (cd "$resolve_directory_value" && pwd -P)
 }
 
+publish_staged_entry() {
+    publish_source=$1
+    publish_name=${publish_source##*/}
+    publish_target=$resolved_install_dir/$publish_name
+
+    if [ -d "$publish_source" ] && [ ! -L "$publish_source" ] &&
+        { [ -e "$publish_target" ] || [ -L "$publish_target" ]; }; then
+        publish_aside=$stage/.composio-aside.$publish_name
+        mv "$publish_target" "$publish_aside" ||
+            error "Failed to move existing install entry aside: $publish_target"
+        if mv "$publish_source" "$publish_target"; then
+            rm -rf "$publish_aside" || error "Failed to remove old install entry: $publish_aside"
+            return 0
+        fi
+
+        if mv "$publish_aside" "$publish_target"; then
+            error "Failed to publish install entry: $publish_target"
+        fi
+
+        preserve_stage=1
+        error "Failed to publish install entry and restore the previous entry. Recover it from $publish_aside"
+    fi
+
+    mv "$publish_source" "$publish_target" || error "Failed to publish install entry: $publish_target"
+}
+
 install_bundle() {
     install_bundle_root=$1
     install_bundle_dir=$install_bundle_root/composio-$target
@@ -248,11 +274,31 @@ install_bundle() {
         warn 'This release archive has no bundled support files. Some CLI features may be unavailable.'
     fi
 
-    cp -Rp "$install_bundle_dir"/. "$resolved_install_dir/" ||
-        error "Failed to install the CLI bundle to \"$resolved_install_dir\""
-    chmod +x "$resolved_install_dir/composio" || error 'Failed to set permissions on executable'
-    printf '%s\n' "$version" >"$resolved_install_dir/release-tag.txt" ||
-        error "Failed to write install metadata to \"$resolved_install_dir/release-tag.txt\""
+    stage=$(mktemp -d "$resolved_install_dir/.composio-install.XXXXXX") ||
+        error "Failed to create staging directory in \"$resolved_install_dir\""
+    debug "install staging directory: $stage"
+
+    # Staging briefly holds a second copy of the bundle until the binary is published last.
+    cp -Rp "$install_bundle_dir"/. "$stage/" ||
+        error "Failed to stage the CLI bundle in \"$resolved_install_dir\""
+    chmod +x "$stage/composio" || error 'Failed to set permissions on staged executable'
+    printf '%s\n' "$version" >"$stage/release-tag.txt" ||
+        error "Failed to stage install metadata in \"$resolved_install_dir\""
+
+    for staged_entry in "$stage"/* "$stage"/.[!.]* "$stage"/..?*; do
+        if [ ! -e "$staged_entry" ] && [ ! -L "$staged_entry" ]; then
+            continue
+        fi
+        case ${staged_entry##*/} in
+            composio | release-tag.txt) continue ;;
+        esac
+        publish_staged_entry "$staged_entry"
+    done
+
+    publish_staged_entry "$stage/release-tag.txt"
+    publish_staged_entry "$stage/composio"
+    rmdir "$stage" || error "Failed to remove staging directory: $stage"
+    stage=
 }
 
 install_entry_point() {
@@ -322,6 +368,9 @@ print_post_install_help() {
 cleanup() {
     if [ -n "${tmpdir:-}" ] && [ -d "$tmpdir" ]; then
         rm -rf "$tmpdir"
+    fi
+    if [ "${preserve_stage:-0}" != 1 ] && [ -n "${stage:-}" ] && [ -d "$stage" ]; then
+        rm -rf "$stage"
     fi
 }
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "cli:record": "turbo run record --filter=./ts/packages/cli",
     "record": "turbo run record",
     "test": "pnpm run test:install-sh && pnpm run test:release-workflow && turbo test --filter=./ts/packages/** --filter=!@e2e-tests/* && pnpm run test:examples",
-    "test:install-sh": "bash test/install-sh-release-resolution.test.sh",
+    "test:install-sh": "bash test/install-sh-release-resolution.test.sh && bash test/install-sh-atomic-replace.test.sh",
     "test:release-workflow": "bun run test/release-workflow.test.ts",
     "test:examples": "tsx ts/scripts/validate-examples.ts",
     "test:e2e": "turbo test:e2e --filter='@e2e-tests/*'",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,6 +244,12 @@ importers:
         specifier: workspace:*
         version: link:../../../_utils
 
+  ts/e2e-tests/cli/upgrade:
+    devDependencies:
+      '@e2e-tests/utils':
+        specifier: workspace:*
+        version: link:../../_utils
+
   ts/e2e-tests/cli/version:
     devDependencies:
       '@e2e-tests/utils':

--- a/test/install-sh-atomic-replace.test.sh
+++ b/test/install-sh-atomic-replace.test.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+suite_tmp="$(mktemp -d)"
+survivor_pid=
+
+cleanup() {
+  if [[ -n ${survivor_pid:-} ]]; then
+    kill "$survivor_pid" 2>/dev/null || true
+    wait "$survivor_pid" 2>/dev/null || true
+  fi
+  rm -rf "$suite_tmp"
+}
+trap cleanup EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+stat_inode() {
+  if stat -f '%i' "$1" >/dev/null 2>&1; then
+    stat -f '%i' "$1"
+  else
+    stat -c '%i' "$1"
+  fi
+}
+
+assert_no_residue() {
+  local install_dir=$1
+  if find "$install_dir" -maxdepth 1 \( -name '.composio-install.*' -o -name '.composio-aside.*' \) -print -quit | grep -q .; then
+    fail "installer residue remains in $install_dir"
+  fi
+}
+
+platform=$(uname -ms)
+case $platform in
+'Darwin x86_64') target=darwin-x64 ;;
+'Darwin arm64') target=darwin-aarch64 ;;
+'Linux aarch64'|'Linux arm64') target=linux-aarch64 ;;
+'Linux x86_64') target=linux-x64 ;;
+*) fail "unsupported test platform: $platform" ;;
+esac
+
+fake_bin="$suite_tmp/bin"
+mkdir -p "$fake_bin"
+
+cat >"$fake_bin/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+output=
+url=
+while (($# > 0)); do
+  case $1 in
+  --output|-o)
+    output=$2
+    shift 2
+    ;;
+  --proto|--proto-redir)
+    shift 2
+    ;;
+  --fail|--silent|--show-error|--location|--progress-bar)
+    shift
+    ;;
+  --*) shift ;;
+  *)
+    url=$1
+    shift
+    ;;
+  esac
+done
+
+case $url in
+*/checksums.txt) exit 22 ;;
+*) printf 'fixture archive\n' >"$output" ;;
+esac
+EOF
+chmod +x "$fake_bin/curl"
+
+cat >"$fake_bin/unzip" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+dest=
+while (($# > 0)); do
+  case $1 in
+  -d)
+    dest=$2
+    shift 2
+    ;;
+  -*d)
+    dest=$2
+    shift 2
+    ;;
+  *) shift ;;
+  esac
+done
+
+bundle="$dest/composio-$TEST_TARGET"
+mkdir -p "$bundle/services" "$bundle/local-tools-binaries"
+printf '%s\n' 'new-support' >"$bundle/run-bun.mjs"
+printf '%s\n' 'new-service' >"$bundle/services/example.txt"
+printf '%s\n' 'new-local-tool' >"$bundle/local-tools-binaries/current.txt"
+
+if [[ ${TEST_ARCHIVE_MODE:-complete} == missing-binary ]]; then
+  exit 0
+fi
+
+cat >"$bundle/composio" <<'BIN'
+#!/bin/sh
+# new-binary-marker
+case ${1:-} in
+--version|version) printf '%s\n' 'composio fixture 98.0.0' ;;
+*) printf '%s\n' 'new-binary' ;;
+esac
+BIN
+chmod +x "$bundle/composio"
+EOF
+chmod +x "$fake_bin/unzip"
+
+interpreters=("$(command -v sh)")
+if command -v dash >/dev/null 2>&1 && [[ $(command -v dash) != "${interpreters[0]}" ]]; then
+  interpreters+=("$(command -v dash)")
+fi
+
+version='@composio/cli@98.0.0'
+for interpreter in "${interpreters[@]}"; do
+  interpreter_name=$(basename "$interpreter")
+  case_root="$suite_tmp/$interpreter_name"
+  install_dir="$case_root/install"
+  home="$case_root/home"
+  mkdir -p "$install_dir" "$home"
+
+  run_installer() {
+    local archive_mode=$1
+    env \
+      PATH="$fake_bin:$PATH" \
+      HOME="$home" \
+      COMPOSIO_INSTALL_DIR="$install_dir" \
+      COMPOSIO_BIN_DIR="$install_dir" \
+      COMPOSIO_INSTALL_PLUGINS=0 \
+      COMPOSIO_INSTALL_HELP=0 \
+      COMPOSIO_QUIET=1 \
+      COMPOSIO_GITHUB_URL=https://github.example.test \
+      COMPOSIO_GITHUB_OWNER=FakeOwner \
+      COMPOSIO_GITHUB_REPO=fake-repo \
+      TEST_TARGET="$target" \
+      TEST_ARCHIVE_MODE="$archive_mode" \
+      "$interpreter" "$repo_root/install.sh" "$version"
+  }
+
+  run_installer complete >/dev/null 2>&1
+  [[ -x "$install_dir/composio" ]] || fail "$interpreter_name empty install executable"
+  [[ -f "$install_dir/run-bun.mjs" ]] || fail "$interpreter_name empty install support file"
+  [[ -f "$install_dir/services/example.txt" ]] || fail "$interpreter_name empty install service"
+  [[ -f "$install_dir/local-tools-binaries/current.txt" ]] ||
+    fail "$interpreter_name empty install local tool"
+  [[ $(<"$install_dir/release-tag.txt") == "$version" ]] ||
+    fail "$interpreter_name empty install metadata"
+  assert_no_residue "$install_dir"
+
+  marker="$case_root/old-process"
+  cat >"$install_dir/composio" <<'EOF'
+#!/bin/sh
+marker=$1
+: >"$marker.ready"
+while [ ! -f "$marker.release" ]; do
+  sleep 0.05
+done
+printf '%s\n' old-process >"$marker.result"
+EOF
+  chmod +x "$install_dir/composio"
+  printf '%s\n' stale >"$install_dir/local-tools-binaries/stale.txt"
+  old_inode=$(stat_inode "$install_dir/composio")
+  "$install_dir/composio" "$marker" &
+  survivor_pid=$!
+  for _ in {1..100}; do
+    [[ -f "$marker.ready" ]] && break
+    sleep 0.05
+  done
+  [[ -f "$marker.ready" ]] || fail "$interpreter_name old process did not start"
+
+  run_installer complete >/dev/null 2>&1
+  new_inode=$(stat_inode "$install_dir/composio")
+  [[ $new_inode != "$old_inode" ]] || fail "$interpreter_name reinstall kept the binary inode"
+  grep -Fq 'new-binary-marker' "$install_dir/composio" ||
+    fail "$interpreter_name reinstall binary contents"
+  [[ ! -e "$install_dir/local-tools-binaries/stale.txt" ]] ||
+    fail "$interpreter_name reinstall retained stale directory contents"
+  : >"$marker.release"
+  wait "$survivor_pid"
+  survivor_pid=
+  [[ $(<"$marker.result") == old-process ]] || fail "$interpreter_name old process changed"
+  assert_no_residue "$install_dir"
+
+  binary_before=$(<"$install_dir/composio")
+  support_before=$(<"$install_dir/run-bun.mjs")
+  tag_before=$(<"$install_dir/release-tag.txt")
+  if missing_output=$(run_installer missing-binary 2>&1); then
+    fail "$interpreter_name missing binary archive succeeded"
+  fi
+  grep -Fq 'Binary not found in extracted archive' <<<"$missing_output" ||
+    fail "$interpreter_name missing binary error"
+  [[ $(<"$install_dir/composio") == "$binary_before" ]] ||
+    fail "$interpreter_name missing binary changed executable"
+  [[ $(<"$install_dir/run-bun.mjs") == "$support_before" ]] ||
+    fail "$interpreter_name missing binary changed support file"
+  [[ $(<"$install_dir/release-tag.txt") == "$tag_before" ]] ||
+    fail "$interpreter_name missing binary changed metadata"
+  assert_no_residue "$install_dir"
+
+  printf 'install.sh atomic replacement passed under %s\n' "$interpreter_name"
+done
+
+printf 'install.sh atomic replacement tests passed\n'

--- a/test/install-sh-atomic-replace.test.sh
+++ b/test/install-sh-atomic-replace.test.sh
@@ -118,6 +118,22 @@ chmod +x "$bundle/composio"
 EOF
 chmod +x "$fake_bin/unzip"
 
+cat >"$fake_bin/rm" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ${TEST_FAIL_ASIDE_CLEANUP:-} == 1 ]]; then
+  for arg in "$@"; do
+    case $arg in
+    */.composio-aside.local-tools-binaries) exit 23 ;;
+    esac
+  done
+fi
+
+exec /bin/rm "$@"
+EOF
+chmod +x "$fake_bin/rm"
+
 interpreters=("$(command -v sh)")
 if command -v dash >/dev/null 2>&1 && [[ $(command -v dash) != "${interpreters[0]}" ]]; then
   interpreters+=("$(command -v dash)")
@@ -133,6 +149,7 @@ for interpreter in "${interpreters[@]}"; do
 
   run_installer() {
     local archive_mode=$1
+    local fail_aside_cleanup=${2:-0}
     env \
       PATH="$fake_bin:$PATH" \
       HOME="$home" \
@@ -146,6 +163,7 @@ for interpreter in "${interpreters[@]}"; do
       COMPOSIO_GITHUB_REPO=fake-repo \
       TEST_TARGET="$target" \
       TEST_ARCHIVE_MODE="$archive_mode" \
+      TEST_FAIL_ASIDE_CLEANUP="$fail_aside_cleanup" \
       "$interpreter" "$repo_root/install.sh" "$version"
   }
 
@@ -208,6 +226,21 @@ EOF
   [[ $(<"$install_dir/release-tag.txt") == "$tag_before" ]] ||
     fail "$interpreter_name missing binary changed metadata"
   assert_no_residue "$install_dir"
+
+  printf '%s\n' old-aside >"$install_dir/local-tools-binaries/recoverable.txt"
+  if ! aside_cleanup_output=$(run_installer complete 1 2>&1); then
+    fail "$interpreter_name aside cleanup failure aborted published install"
+  fi
+  grep -Fq 'Published install entry; previous contents retained at' <<<"$aside_cleanup_output" ||
+    fail "$interpreter_name aside cleanup warning"
+  grep -Fq 'Published CLI; retained recovery staging directory at' <<<"$aside_cleanup_output" ||
+    fail "$interpreter_name retained staging warning"
+  grep -Fq 'new-binary-marker' "$install_dir/composio" ||
+    fail "$interpreter_name aside cleanup did not publish executable"
+  retained_stage=$(find "$install_dir" -maxdepth 1 -type d -name '.composio-install.*' -print -quit)
+  [[ -n $retained_stage ]] || fail "$interpreter_name missing retained recovery staging directory"
+  [[ $(<"$retained_stage/.composio-aside.local-tools-binaries/recoverable.txt") == old-aside ]] ||
+    fail "$interpreter_name retained aside is not recoverable"
 
   printf 'install.sh atomic replacement passed under %s\n' "$interpreter_name"
 done

--- a/ts/e2e-tests/cli/README.md
+++ b/ts/e2e-tests/cli/README.md
@@ -10,10 +10,11 @@ Tests use `runCmd` to execute shell commands in the container and assert on exit
 
 ## Test Suites
 
-| Suite | Description | Env Vars |
-| --- | --- | --- |
-| [version](./version/) | `composio version` output and exit code | None |
-| [whoami](./whoami/) | `composio whoami` prints the API key | `COMPOSIO_USER_API_KEY` |
+| Suite                 | Description                                            | Env Vars                |
+| --------------------- | ------------------------------------------------------ | ----------------------- |
+| [upgrade](./upgrade/) | `composio upgrade` replaces a running Linux executable | None                    |
+| [version](./version/) | `composio version` output and exit code                | None                    |
+| [whoami](./whoami/)   | `composio whoami` prints the API key                   | `COMPOSIO_USER_API_KEY` |
 
 ## Isolation Tool
 
@@ -28,4 +29,5 @@ pnpm test:e2e:cli
 # A specific suite
 cd ts/e2e-tests/cli/version && pnpm test:e2e:cli
 cd ts/e2e-tests/cli/whoami && pnpm test:e2e:cli
+cd ts/e2e-tests/cli/upgrade && pnpm test:e2e:cli
 ```

--- a/ts/e2e-tests/cli/upgrade/README.md
+++ b/ts/e2e-tests/cli/upgrade/README.md
@@ -1,0 +1,11 @@
+# CLI `composio upgrade` Test
+
+Verifies that the compiled Linux CLI atomically replaces its running executable.
+
+The suite covers both the installed `/usr/local/bin/composio` path and a copied executable. Each case checks the inode replacement, executable bit, upgrade result, absence of Linux busy-file errors, and a subsequent `composio version` invocation.
+
+## Running
+
+```bash
+pnpm test:e2e:cli
+```

--- a/ts/e2e-tests/cli/upgrade/e2e.test.ts
+++ b/ts/e2e-tests/cli/upgrade/e2e.test.ts
@@ -1,0 +1,119 @@
+/**
+ * CLI upgrade command e2e test
+ *
+ * Verifies that the compiled Linux binary can replace its running executable.
+ */
+
+import { e2e, type E2ETestResult } from '@e2e-tests/utils';
+import { TIMEOUTS } from '@e2e-tests/utils/const';
+import { beforeAll, describe, expect, it } from 'bun:test';
+
+const companionRelativePaths = [
+  // RUN_COMPANION_MODULE_FILENAMES
+  'run-helpers-runtime.mjs',
+  'run-subagent-shared.mjs',
+  'run-subagent-acp.mjs',
+  'run-subagent-legacy.mjs',
+  'run-subagent-output-mcp.mjs',
+  // RUN_COMPANION_STATIC_ASSET_RELATIVE_PATHS
+  'acp-adapters/claude-code-acp.mjs',
+  'acp-adapters/cli.js',
+  'acp-adapters/codex/darwin-arm64/codex-acp',
+  'acp-adapters/codex/darwin-x64/codex-acp',
+  'acp-adapters/codex/linux-arm64/codex-acp',
+  'acp-adapters/codex/linux-x64/codex-acp',
+] as const;
+
+const sourceBundleSetup = companionRelativePaths
+  .map(
+    relativePath =>
+      `mkdir -p "$(dirname "$source_dir/${relativePath}")"\n: > "$source_dir/${relativePath}"`
+  )
+  .join('\n');
+
+const upgradeCommand = ({
+  executablePath,
+  copyExecutable,
+}: {
+  executablePath: string;
+  copyExecutable: boolean;
+}) => `
+set -u
+executable_path=${executablePath}
+source_dir=/tmp/composio-upgrade-source
+mkdir -p "$source_dir"
+${copyExecutable ? 'mkdir -p "$(dirname "$executable_path")"\ncp /usr/local/bin/composio "$executable_path"' : ''}
+cp /usr/local/bin/composio "$source_dir/composio"
+${sourceBundleSetup}
+
+before_inode=$(stat -c '%i' "$executable_path")
+upgrade_status=0
+DEBUG_OVERRIDE_UPGRADE_TARGET="$source_dir/composio" "$executable_path" upgrade || upgrade_status=$?
+after_inode=$(stat -c '%i' "$executable_path" 2>/dev/null)
+
+if [ -x "$executable_path" ]; then
+  executable_status=0
+else
+  executable_status=1
+fi
+
+version_output=$("$executable_path" version)
+version_status=$?
+printf 'before_inode=%s\nafter_inode=%s\nupgrade_status=%s\nexecutable_status=%s\nversion_status=%s\nversion=%s\n' \
+  "$before_inode" "$after_inode" "$upgrade_status" "$executable_status" "$version_status" "$version_output"
+
+if [ "$upgrade_status" -eq 0 ] &&
+  [ "$executable_status" -eq 0 ] &&
+  [ "$version_status" -eq 0 ] &&
+  [ -n "$before_inode" ] &&
+  [ -n "$after_inode" ] &&
+  [ "$before_inode" != "$after_inode" ]; then
+  exit 0
+fi
+exit 1
+`;
+
+const outputField = (result: E2ETestResult, name: string): string => {
+  const match = result.stdout.match(new RegExp(`^${name}=(.*)$`, 'm'));
+  expect(match).not.toBeNull();
+  return match?.[1] ?? '';
+};
+
+const expectAtomicUpgrade = (result: E2ETestResult) => {
+  expect(result.exitCode).toBe(0);
+  expect(result.stderr).not.toMatch(/ETXTBSY|text[ -]file(?: is)?[ -]busy/i);
+  expect(outputField(result, 'upgrade_status')).toBe('0');
+  expect(outputField(result, 'executable_status')).toBe('0');
+  expect(outputField(result, 'version_status')).toBe('0');
+  expect(outputField(result, 'version')).toMatch(/\d+\.\d+\.\d+/);
+  expect(outputField(result, 'after_inode')).not.toBe(outputField(result, 'before_inode'));
+};
+
+e2e(import.meta.url, {
+  versions: {
+    cli: ['current'],
+  },
+  defineTests: ({ runCmd }) => {
+    let installedResult: E2ETestResult;
+    let copiedResult: E2ETestResult;
+
+    beforeAll(async () => {
+      installedResult = await runCmd(
+        upgradeCommand({ executablePath: '/usr/local/bin/composio', copyExecutable: false })
+      );
+      copiedResult = await runCmd(
+        upgradeCommand({ executablePath: '/tmp/composio-copy/composio', copyExecutable: true })
+      );
+    }, TIMEOUTS.FIXTURE);
+
+    describe('composio upgrade', () => {
+      it('replaces the running installed executable', () => {
+        expectAtomicUpgrade(installedResult);
+      });
+
+      it('replaces an executable running from a copied path', () => {
+        expectAtomicUpgrade(copiedResult);
+      });
+    });
+  },
+});

--- a/ts/e2e-tests/cli/upgrade/package.json
+++ b/ts/e2e-tests/cli/upgrade/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@e2e-tests/cli-upgrade",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test:e2e": "bun test e2e.test.ts",
+    "test:e2e:cli": "bun test e2e.test.ts"
+  },
+  "devDependencies": {
+    "@e2e-tests/utils": "workspace:*"
+  }
+}

--- a/ts/packages/cli/CHANGELOG.md
+++ b/ts/packages/cli/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 ### Patch Changes
 
+- Fix Linux `composio upgrade` failures with `ETXTBSY` by staging CLI files in
+  the install directory and renaming the executable last. The installer and
+  companion repair use the same replacement strategy, and the running binary
+  now reports its compiled version when `release-tag.txt` disagrees. Users on
+  an affected build must re-run `install.sh` once to install the first fixed
+  version.
 - Make GitHub release metadata the sole version authority for standalone CLI
   binaries. Release builds now embed their exact tag version, manual skill
   installation follows the packaged release tag, and stable releases can only

--- a/ts/packages/cli/src/constants.ts
+++ b/ts/packages/cli/src/constants.ts
@@ -54,6 +54,9 @@ export const CACHE_FILENAMES = {
   TRIGGER_TYPES: 'trigger-types.json',
 };
 
+/** Whether the CLI has an exact release version compiled into it. */
+export const IS_RELEASE_BUILD = typeof __COMPOSIO_CLI_RELEASE_VERSION__ !== 'undefined';
+
 /**
  * Version of the running Composio CLI.
  *

--- a/ts/packages/cli/src/effects/install-skill.ts
+++ b/ts/packages/cli/src/effects/install-skill.ts
@@ -4,7 +4,7 @@ import { NodeOs } from 'src/services/node-os';
 import { TerminalUI } from 'src/services/terminal-ui';
 import { GITHUB_CONFIG } from 'src/effects/github-config';
 import { APP_VERSION, type CliReleaseChannel } from 'src/constants';
-import { readInstalledReleaseTag } from 'src/services/run-companion-modules';
+import { resolveRunningCliReleaseTag } from 'src/services/run-companion-modules';
 import {
   fetchLatestCliRelease,
   fetchCliReleaseByTag,
@@ -150,7 +150,7 @@ export const installSkill = (options?: {
       channel: options?.channel,
       githubConfig,
       httpClient,
-      installedReleaseTag: yield* readInstalledReleaseTag(process.execPath),
+      installedReleaseTag: yield* resolveRunningCliReleaseTag(process.execPath, APP_VERSION),
       releaseTag: options?.releaseTag,
     });
 

--- a/ts/packages/cli/src/effects/version.ts
+++ b/ts/packages/cli/src/effects/version.ts
@@ -1,12 +1,12 @@
 import { Effect, Option } from 'effect';
 import { DEBUG_OVERRIDE_CONFIG } from 'src/effects/debug-config';
 import * as constants from 'src/constants';
-import { resolveInstalledCliVersion } from 'src/services/run-companion-modules';
+import { resolveRunningCliVersion } from 'src/services/run-companion-modules';
 
 export const getVersion = Effect.flatMap(
   DEBUG_OVERRIDE_CONFIG.VERSION,
   Option.match({
-    onNone: () => resolveInstalledCliVersion(process.execPath, constants.APP_VERSION),
+    onNone: () => resolveRunningCliVersion(process.execPath, constants.APP_VERSION),
     onSome: version => Effect.succeed(version),
   })
 );

--- a/ts/packages/cli/src/services/run-companion-modules.ts
+++ b/ts/packages/cli/src/services/run-companion-modules.ts
@@ -7,6 +7,7 @@ import { FileSystem, Path } from '@effect/platform';
 import type { PlatformError } from '@effect/platform/Error';
 import { Config, ConfigProvider, Data, Effect, Option, Schema } from 'effect';
 import extractZip from 'extract-zip';
+import { IS_RELEASE_BUILD } from 'src/constants';
 import { GitHubRelease } from 'src/effects/resolve-cli-release';
 import { BaseConfigProviderLive, extendConfigProvider } from 'src/services/config';
 import { parseChecksumsText, sha256Hex } from 'src/utils/checksums';
@@ -324,6 +325,24 @@ export const resolveInstalledCliReleaseTag = (
     normalizeCliReleaseTag(releaseTag ?? fallbackVersion)
   );
 
+export const resolveRunningCliVersion = (
+  execPath: string,
+  appVersion: string,
+  isReleaseBuild = IS_RELEASE_BUILD
+): Effect.Effect<string, never, FileSystem.FileSystem | Path.Path> =>
+  isReleaseBuild
+    ? Effect.succeed(normalizeCliReleaseVersion(appVersion))
+    : resolveInstalledCliVersion(execPath, appVersion);
+
+export const resolveRunningCliReleaseTag = (
+  execPath: string,
+  appVersion: string,
+  isReleaseBuild = IS_RELEASE_BUILD
+): Effect.Effect<string, never, FileSystem.FileSystem | Path.Path> =>
+  isReleaseBuild
+    ? Effect.succeed(normalizeCliReleaseTag(appVersion))
+    : resolveInstalledCliReleaseTag(execPath, appVersion);
+
 export const writeInstalledReleaseTag = (
   installDir: string,
   releaseTag: string
@@ -451,7 +470,7 @@ const resolveRepairReleaseTag = ({
       return pinnedTag;
     }
 
-    return yield* resolveInstalledCliReleaseTag(execPath, appVersion);
+    return yield* resolveRunningCliReleaseTag(execPath, appVersion);
   });
 
 const nonEmptyConfigWithFallback = (name: string, fallback: string) =>

--- a/ts/packages/cli/src/services/run-companion-modules.ts
+++ b/ts/packages/cli/src/services/run-companion-modules.ts
@@ -340,9 +340,10 @@ export const resolveRunningCliReleaseTag = (
   appVersion: string,
   isReleaseBuild = IS_RELEASE_BUILD
 ): Effect.Effect<string, never, FileSystem.FileSystem | Path.Path> =>
-  isReleaseBuild
-    ? Effect.succeed(normalizeCliReleaseTag(appVersion))
-    : resolveInstalledCliReleaseTag(execPath, appVersion);
+  Effect.map(
+    resolveRunningCliVersion(execPath, appVersion, isReleaseBuild),
+    normalizeCliReleaseTag
+  );
 
 export const writeInstalledReleaseTag = (
   installDir: string,

--- a/ts/packages/cli/src/services/run-companion-modules.ts
+++ b/ts/packages/cli/src/services/run-companion-modules.ts
@@ -10,6 +10,7 @@ import extractZip from 'extract-zip';
 import { IS_RELEASE_BUILD } from 'src/constants';
 import { GitHubRelease } from 'src/effects/resolve-cli-release';
 import { BaseConfigProviderLive, extendConfigProvider } from 'src/services/config';
+import { atomicReplaceFile } from 'src/utils/atomic-replace';
 import { parseChecksumsText, sha256Hex } from 'src/utils/checksums';
 import { CLI_RELEASE_TAG_PREFIX } from 'src/utils/cli-release-version';
 
@@ -628,7 +629,19 @@ export const repairMissingInstalledRunCompanionModules = ({
 
           const targetPath = path.join(installDirectory, relativePath);
           yield* fs.makeDirectory(path.dirname(targetPath), { recursive: true });
-          yield* fs.copyFile(sourcePath, targetPath);
+          yield* atomicReplaceFile({ sourcePath, targetPath }).pipe(
+            Effect.mapError(
+              error =>
+                new RunCompanionRepairError({
+                  message: [
+                    `Unable to restore the files required by 'composio run' for ${releaseTag}.`,
+                    error.message,
+                    `Reinstall the CLI, or set GITHUB_TAG to the exact release tag for this build and try again.`,
+                  ].join('\n'),
+                  cause: error.cause,
+                })
+            )
+          );
         }
 
         yield* writeInstalledReleaseTag(installDirectory, release.tag_name);

--- a/ts/packages/cli/src/services/setup-skill-installer.ts
+++ b/ts/packages/cli/src/services/setup-skill-installer.ts
@@ -10,7 +10,7 @@ import {
 } from 'src/effects/install-skill';
 import { GITHUB_CONFIG } from 'src/effects/github-config';
 import { APP_VERSION } from 'src/constants';
-import { readInstalledReleaseTag } from 'src/services/run-companion-modules';
+import { resolveRunningCliReleaseTag } from 'src/services/run-companion-modules';
 import { NodeOs } from './node-os';
 
 export const resolveSetupSkillReleaseTag = (
@@ -20,7 +20,7 @@ export const resolveSetupSkillReleaseTag = (
   Effect.gen(function* () {
     const httpClient = yield* HttpClient.HttpClient;
     const githubConfig = yield* Config.all(GITHUB_CONFIG);
-    const installedReleaseTag = yield* readInstalledReleaseTag(execPath);
+    const installedReleaseTag = yield* resolveRunningCliReleaseTag(execPath, fallbackVersion);
 
     return yield* resolveSkillReleaseTag({
       channel: inferSkillReleaseChannel(fallbackVersion),

--- a/ts/packages/cli/src/services/update-check.ts
+++ b/ts/packages/cli/src/services/update-check.ts
@@ -5,7 +5,7 @@ import semver from 'semver';
 import { bold, cyanBright, dim } from 'src/ui/colors';
 import { APP_VERSION, GITHUB_REPO } from '../constants';
 import { NodeOs } from './node-os';
-import { resolveInstalledCliVersion } from './run-companion-modules';
+import { resolveRunningCliVersion } from './run-companion-modules';
 import { TerminalUI } from './terminal-ui';
 
 /**
@@ -35,7 +35,7 @@ export interface UpdateCheckState {
 
 /** Machine-readable update status for `composio version --check`. */
 export interface UpdateStatus {
-  /** Installed CLI version (release-tag.txt next to the binary, or APP_VERSION). */
+  /** Version reported by the running CLI executable. */
   current: string;
   /** Latest known stable release with a binary for this platform, if known. */
   latestStable: string | null;
@@ -98,7 +98,7 @@ function getCurrentBinaryAssetName(os: Pick<NodeOs, 'platform' | 'arch'>): strin
 const defaultConfig = (stateFile: string) =>
   Effect.gen(function* () {
     const os = yield* NodeOs;
-    const currentVersion = yield* resolveInstalledCliVersion(process.execPath, APP_VERSION);
+    const currentVersion = yield* resolveRunningCliVersion(process.execPath, APP_VERSION);
     const accessToken = yield* Effect.orDie(
       Config.option(Config.string('COMPOSIO_GITHUB_ACCESS_TOKEN')).pipe(
         Config.map(Option.getOrUndefined)

--- a/ts/packages/cli/src/services/upgrade-binary.ts
+++ b/ts/packages/cli/src/services/upgrade-binary.ts
@@ -432,7 +432,7 @@ const getCurrentExecutablePath = Effect.fn(function* () {
 const mapAtomicReplaceError = (message: string) => (error: AtomicReplaceError) =>
   new UpgradeBinaryError({
     cause: error.cause,
-    message,
+    message: `${message}: ${error.message}`,
   });
 
 const replaceBinary = (

--- a/ts/packages/cli/src/services/upgrade-binary.ts
+++ b/ts/packages/cli/src/services/upgrade-binary.ts
@@ -1,4 +1,13 @@
-import { Data, Effect, Config, Match, Option, Predicate, Record as EffectRecord } from 'effect';
+import {
+  Data,
+  Effect,
+  Config,
+  Match,
+  Option,
+  Predicate,
+  Record as EffectRecord,
+  Scope,
+} from 'effect';
 import { HttpClient, HttpClientResponse, FileSystem, Path } from '@effect/platform';
 import { APP_VERSION } from '../constants';
 import { DEBUG_OVERRIDE_CONFIG } from 'src/effects/debug-config';
@@ -7,6 +16,11 @@ import { detectPlatform, type PlatformArch } from 'src/effects/detect-platform';
 import { CompareSemverError, semverComparator } from 'src/effects/compare-semver';
 import { fetchLatestCliRelease, GitHubRelease } from 'src/effects/resolve-cli-release';
 import { parseChecksumsText, sha256Hex } from 'src/utils/checksums';
+import {
+  atomicReplaceDirectory,
+  atomicReplaceFile,
+  type AtomicReplaceError,
+} from 'src/utils/atomic-replace';
 
 // Note: `node:zlib` does not support Github's zip files
 import extractZip from 'extract-zip';
@@ -14,6 +28,7 @@ import { renderPrettyError } from './utils/pretty-error';
 import { TerminalUI } from './terminal-ui';
 import {
   collectExpectedRunCompanionAssetRelativePaths,
+  RUN_COMPANION_RELEASE_TAG_FILENAME,
   resolveRunningCliReleaseTag,
   writeInstalledReleaseTag,
 } from './run-companion-modules';
@@ -160,9 +175,9 @@ const fetchLatestRelease = (
     return release;
   });
 
-const provideFsAndPath = <A, E>(
-  { fs, path }: UpgradeBinaryContext,
-  effect: Effect.Effect<A, E, FileSystem.FileSystem | Path.Path>
+const provideFsAndPath = <A, E, R>(
+  { fs, path }: Pick<UpgradeBinaryContext, 'fs' | 'path'>,
+  effect: Effect.Effect<A, E, FileSystem.FileSystem | Path.Path | R>
 ) =>
   effect.pipe(
     Effect.provideService(FileSystem.FileSystem, fs),
@@ -414,31 +429,23 @@ const getCurrentExecutablePath = Effect.fn(function* () {
 /**
  * Replace current executable binary with the new target one.
  */
+const mapAtomicReplaceError = (message: string) => (error: AtomicReplaceError) =>
+  new UpgradeBinaryError({
+    cause: error.cause,
+    message,
+  });
+
 const replaceBinary = (
-  ctx: UpgradeBinaryContext,
+  ctx: Pick<UpgradeBinaryContext, 'fs' | 'path'>,
   sourcePath: string,
   targetPath: string,
   options: {
     releaseTag?: string;
   } = {}
-): Effect.Effect<void, UpgradeBinaryError> =>
+): Effect.Effect<void, UpgradeBinaryError, Scope.Scope> =>
   Effect.gen(function* () {
     const { fs, path } = ctx;
     yield* Effect.logDebug(`Replacing binary: ${sourcePath} -> ${targetPath}`);
-    yield* fs
-      .copy(sourcePath, targetPath, {
-        // Note: without `overwrite: true`, the copy operation will silently bail out
-        overwrite: true,
-      })
-      .pipe(
-        Effect.mapError(
-          cause =>
-            new UpgradeBinaryError({
-              cause,
-              message: 'Failed to replace binary',
-            })
-        )
-      );
 
     const sourceDirectory = path.dirname(sourcePath);
     const targetDirectory = path.dirname(targetPath);
@@ -446,6 +453,12 @@ const replaceBinary = (
       ctx,
       collectExpectedRunCompanionAssetRelativePaths(sourceDirectory)
     );
+    const companionReplacements: Array<{
+      readonly relativePath: string;
+      readonly sourcePath: string;
+      readonly targetPath: string;
+    }> = [];
+
     for (const relativePath of companionRelativePaths) {
       const sourceCompanion = path.join(sourceDirectory, relativePath);
       const sourceExists = yield* fs
@@ -461,7 +474,39 @@ const replaceBinary = (
         );
       }
 
-      const targetCompanion = path.join(targetDirectory, relativePath);
+      companionReplacements.push({
+        relativePath,
+        sourcePath: sourceCompanion,
+        targetPath: path.join(targetDirectory, relativePath),
+      });
+    }
+
+    const localToolsAssetSource = path.join(sourceDirectory, LOCAL_TOOLS_BINARY_ASSET_DIRNAME);
+    const localToolsAssetExists = yield* fs
+      .exists(localToolsAssetSource)
+      .pipe(Effect.catchAll(() => Effect.succeed(false)));
+    const localToolsAssetTarget = path.join(targetDirectory, LOCAL_TOOLS_BINARY_ASSET_DIRNAME);
+
+    const releaseTag = options.releaseTag;
+    const stagedReleaseTagPath = path.join(sourceDirectory, RUN_COMPANION_RELEASE_TAG_FILENAME);
+    if (releaseTag) {
+      yield* provideFsAndPath(ctx, writeInstalledReleaseTag(sourceDirectory, releaseTag)).pipe(
+        Effect.mapError(
+          error =>
+            new UpgradeBinaryError({
+              cause: error,
+              message: 'Failed to update installed release metadata',
+            })
+        )
+      );
+    }
+
+    for (const replacement of companionReplacements) {
+      const {
+        relativePath,
+        sourcePath: sourceCompanion,
+        targetPath: targetCompanion,
+      } = replacement;
       yield* fs.makeDirectory(path.dirname(targetCompanion), { recursive: true }).pipe(
         Effect.mapError(
           cause =>
@@ -472,53 +517,39 @@ const replaceBinary = (
         )
       );
 
-      yield* fs
-        .copy(sourceCompanion, targetCompanion, {
-          overwrite: true,
-        })
-        .pipe(
-          Effect.mapError(
-            cause =>
-              new UpgradeBinaryError({
-                cause,
-                message: `Failed to replace companion module: ${relativePath}`,
-              })
-          )
-        );
+      yield* provideFsAndPath(
+        ctx,
+        atomicReplaceFile({ sourcePath: sourceCompanion, targetPath: targetCompanion })
+      ).pipe(
+        Effect.mapError(
+          mapAtomicReplaceError(`Failed to replace companion module: ${relativePath}`)
+        )
+      );
     }
 
-    const localToolsAssetSource = path.join(sourceDirectory, LOCAL_TOOLS_BINARY_ASSET_DIRNAME);
-    const localToolsAssetExists = yield* fs
-      .exists(localToolsAssetSource)
-      .pipe(Effect.catchAll(() => Effect.succeed(false)));
     if (localToolsAssetExists) {
-      const localToolsAssetTarget = path.join(targetDirectory, LOCAL_TOOLS_BINARY_ASSET_DIRNAME);
-      // Replace the whole asset directory: drop the previous tree, then copy
-      // the new one (fs.copy is recursive for directories).
-      yield* fs.remove(localToolsAssetTarget, { recursive: true, force: true }).pipe(
-        Effect.andThen(fs.copy(localToolsAssetSource, localToolsAssetTarget, { overwrite: true })),
-        Effect.mapError(
-          error =>
-            new UpgradeBinaryError({
-              cause: error,
-              message: 'Failed to replace local-tool binary assets',
-            })
-        )
-      );
+      yield* provideFsAndPath(
+        ctx,
+        atomicReplaceDirectory({
+          sourcePath: localToolsAssetSource,
+          targetPath: localToolsAssetTarget,
+        })
+      ).pipe(Effect.mapError(mapAtomicReplaceError('Failed to replace local-tool binary assets')));
     }
 
-    const releaseTag = options.releaseTag;
     if (releaseTag) {
-      yield* provideFsAndPath(ctx, writeInstalledReleaseTag(targetDirectory, releaseTag)).pipe(
-        Effect.mapError(
-          error =>
-            new UpgradeBinaryError({
-              cause: error,
-              message: 'Failed to update installed release metadata',
-            })
-        )
-      );
+      yield* provideFsAndPath(
+        ctx,
+        atomicReplaceFile({
+          sourcePath: stagedReleaseTagPath,
+          targetPath: path.join(targetDirectory, RUN_COMPANION_RELEASE_TAG_FILENAME),
+        })
+      ).pipe(Effect.mapError(mapAtomicReplaceError('Failed to update installed release metadata')));
     }
+
+    yield* provideFsAndPath(ctx, atomicReplaceFile({ sourcePath, targetPath, mode: 0o755 })).pipe(
+      Effect.mapError(mapAtomicReplaceError('Failed to replace binary'))
+    );
   });
 
 /**
@@ -546,7 +577,9 @@ const upgrade = (
     // If local binary path is provided (for testing), use it directly
     if (Option.isSome(upgradeTargetOpt)) {
       yield* ui.log.info(`New local version available (current: ${currentReleaseIdentifier})`);
-      yield* replaceBinary(ctx, upgradeTargetOpt.value, currentPath);
+      yield* replaceBinary(ctx, upgradeTargetOpt.value, currentPath, {
+        releaseTag: explicitTag,
+      });
       yield* ui.outro('Upgrade completed');
       return undefined;
     }

--- a/ts/packages/cli/src/services/upgrade-binary.ts
+++ b/ts/packages/cli/src/services/upgrade-binary.ts
@@ -14,7 +14,7 @@ import { renderPrettyError } from './utils/pretty-error';
 import { TerminalUI } from './terminal-ui';
 import {
   collectExpectedRunCompanionAssetRelativePaths,
-  resolveInstalledCliReleaseTag,
+  resolveRunningCliReleaseTag,
   writeInstalledReleaseTag,
 } from './run-companion-modules';
 
@@ -173,7 +173,7 @@ const provideFsAndPath = <A, E>(
  * Check if update is available
  */
 const resolveCurrentReleaseIdentifier = (ctx: UpgradeBinaryContext, currentPath: string) =>
-  provideFsAndPath(ctx, resolveInstalledCliReleaseTag(currentPath, APP_VERSION));
+  provideFsAndPath(ctx, resolveRunningCliReleaseTag(currentPath, APP_VERSION));
 
 const isUpdateAvailable = (
   release: GitHubRelease,

--- a/ts/packages/cli/src/utils/atomic-replace.ts
+++ b/ts/packages/cli/src/utils/atomic-replace.ts
@@ -1,0 +1,110 @@
+import { FileSystem, Path } from '@effect/platform';
+import { Data, Effect, Scope } from 'effect';
+
+export class AtomicReplaceError extends Data.TaggedError('utils/AtomicReplaceError')<{
+  readonly targetPath: string;
+  readonly message: string;
+  readonly cause: unknown;
+}> {}
+
+type AtomicReplaceFileOptions = {
+  readonly sourcePath: string;
+  readonly targetPath: string;
+  readonly mode?: number;
+};
+
+type AtomicReplaceDirectoryOptions = {
+  readonly sourcePath: string;
+  readonly targetPath: string;
+};
+
+export const atomicReplaceFile = ({
+  sourcePath,
+  targetPath,
+  mode,
+}: AtomicReplaceFileOptions): Effect.Effect<
+  void,
+  AtomicReplaceError,
+  FileSystem.FileSystem | Path.Path | Scope.Scope
+> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const stagingDirectory = yield* fs.makeTempDirectoryScoped({
+      directory: path.dirname(targetPath),
+      prefix: '.composio-atomic-replace-',
+    });
+    const stagedPath = path.join(stagingDirectory, path.basename(targetPath));
+
+    yield* fs.copyFile(sourcePath, stagedPath);
+    if (mode !== undefined) {
+      yield* fs.chmod(stagedPath, mode);
+    }
+    yield* fs.rename(stagedPath, targetPath);
+  }).pipe(
+    Effect.mapError(
+      cause =>
+        new AtomicReplaceError({
+          targetPath,
+          message: `Failed to replace file at ${targetPath}`,
+          cause,
+        })
+    )
+  );
+
+/**
+ * Replaces a directory with a staged copy using two renames. The old directory
+ * is restored when publishing the replacement fails, but an abrupt process
+ * exit between the renames can leave the target temporarily absent.
+ */
+export const atomicReplaceDirectory = ({
+  sourcePath,
+  targetPath,
+}: AtomicReplaceDirectoryOptions): Effect.Effect<
+  void,
+  AtomicReplaceError,
+  FileSystem.FileSystem | Path.Path | Scope.Scope
+> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const stagingDirectory = yield* fs.makeTempDirectoryScoped({
+      directory: path.dirname(targetPath),
+      prefix: '.composio-atomic-replace-',
+    });
+    const targetName = path.basename(targetPath);
+    const stagedPath = path.join(stagingDirectory, targetName);
+    const asidePath = path.join(stagingDirectory, `${targetName}.aside`);
+
+    yield* fs.copy(sourcePath, stagedPath);
+
+    if (!(yield* fs.exists(targetPath))) {
+      yield* fs.rename(stagedPath, targetPath);
+      return;
+    }
+
+    yield* Effect.uninterruptible(
+      Effect.gen(function* () {
+        yield* fs.rename(targetPath, asidePath);
+        yield* fs
+          .rename(stagedPath, targetPath)
+          .pipe(
+            Effect.catchAll(cause =>
+              fs
+                .rename(asidePath, targetPath)
+                .pipe(Effect.ignore, Effect.zipRight(Effect.fail(cause)))
+            )
+          );
+        yield* fs.remove(asidePath, { recursive: true });
+      })
+    );
+  }).pipe(
+    Effect.mapError(
+      cause =>
+        new AtomicReplaceError({
+          targetPath,
+          message: `Failed to replace directory at ${targetPath}`,
+          cause,
+        })
+    )
+  );

--- a/ts/packages/cli/src/utils/atomic-replace.ts
+++ b/ts/packages/cli/src/utils/atomic-replace.ts
@@ -54,8 +54,9 @@ export const atomicReplaceFile = ({
 
 /**
  * Replaces a directory with a staged copy using two renames. The old directory
- * is restored when publishing the replacement fails, but an abrupt process
- * exit between the renames can leave the target temporarily absent.
+ * is restored when publishing the replacement fails. An abrupt process exit
+ * between the renames can leave the target temporarily absent, with its prior
+ * contents retained in a same-directory recovery path.
  */
 export const atomicReplaceDirectory = ({
   sourcePath,
@@ -68,13 +69,13 @@ export const atomicReplaceDirectory = ({
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
+    const targetDirectory = path.dirname(targetPath);
     const stagingDirectory = yield* fs.makeTempDirectoryScoped({
-      directory: path.dirname(targetPath),
+      directory: targetDirectory,
       prefix: '.composio-atomic-replace-',
     });
     const targetName = path.basename(targetPath);
     const stagedPath = path.join(stagingDirectory, targetName);
-    const asidePath = path.join(stagingDirectory, `${targetName}.aside`);
 
     yield* fs.copy(sourcePath, stagedPath);
 
@@ -85,20 +86,50 @@ export const atomicReplaceDirectory = ({
 
     yield* Effect.uninterruptible(
       Effect.gen(function* () {
-        yield* fs.rename(targetPath, asidePath);
+        const recoveryDirectory = yield* fs.makeTempDirectory({
+          directory: targetDirectory,
+          prefix: '.composio-atomic-recovery-',
+        });
+        const asidePath = path.join(recoveryDirectory, targetName);
         yield* fs
-          .rename(stagedPath, targetPath)
-          .pipe(Effect.tapError(() => fs.rename(asidePath, targetPath).pipe(Effect.ignore)));
-        yield* fs.remove(asidePath, { recursive: true });
+          .rename(targetPath, asidePath)
+          .pipe(
+            Effect.tapError(() =>
+              fs.remove(recoveryDirectory, { recursive: true }).pipe(Effect.ignore)
+            )
+          );
+        yield* fs.rename(stagedPath, targetPath).pipe(
+          Effect.matchEffect({
+            onSuccess: () => fs.remove(recoveryDirectory, { recursive: true }),
+            onFailure: publishCause =>
+              fs.rename(asidePath, targetPath).pipe(
+                Effect.matchEffect({
+                  onSuccess: () =>
+                    fs
+                      .remove(recoveryDirectory, { recursive: true })
+                      .pipe(Effect.zipRight(Effect.fail(publishCause))),
+                  onFailure: restoreCause =>
+                    Effect.fail(
+                      new AtomicReplaceError({
+                        targetPath,
+                        message: `Failed to replace directory at ${targetPath}. Previous contents retained at ${asidePath}`,
+                        cause: { publishCause, restoreCause },
+                      })
+                    ),
+                })
+              ),
+          })
+        );
       })
     );
   }).pipe(
-    Effect.mapError(
-      cause =>
-        new AtomicReplaceError({
-          targetPath,
-          message: `Failed to replace directory at ${targetPath}`,
-          cause,
-        })
+    Effect.mapError(cause =>
+      cause instanceof AtomicReplaceError
+        ? cause
+        : new AtomicReplaceError({
+            targetPath,
+            message: `Failed to replace directory at ${targetPath}`,
+            cause,
+          })
     )
   );

--- a/ts/packages/cli/src/utils/atomic-replace.ts
+++ b/ts/packages/cli/src/utils/atomic-replace.ts
@@ -88,13 +88,7 @@ export const atomicReplaceDirectory = ({
         yield* fs.rename(targetPath, asidePath);
         yield* fs
           .rename(stagedPath, targetPath)
-          .pipe(
-            Effect.catchAll(cause =>
-              fs
-                .rename(asidePath, targetPath)
-                .pipe(Effect.ignore, Effect.zipRight(Effect.fail(cause)))
-            )
-          );
+          .pipe(Effect.tapError(() => fs.rename(asidePath, targetPath).pipe(Effect.ignore)));
         yield* fs.remove(asidePath, { recursive: true });
       })
     );

--- a/ts/packages/cli/src/utils/atomic-replace.ts
+++ b/ts/packages/cli/src/utils/atomic-replace.ts
@@ -100,7 +100,16 @@ export const atomicReplaceDirectory = ({
           );
         yield* fs.rename(stagedPath, targetPath).pipe(
           Effect.matchEffect({
-            onSuccess: () => fs.remove(recoveryDirectory, { recursive: true }),
+            onSuccess: () =>
+              fs
+                .remove(recoveryDirectory, { recursive: true })
+                .pipe(
+                  Effect.catchAll(cause =>
+                    Effect.logWarning(
+                      `Published replacement at ${targetPath}; previous contents remain at ${asidePath}: ${String(cause)}`
+                    )
+                  )
+                ),
             onFailure: publishCause =>
               fs.rename(asidePath, targetPath).pipe(
                 Effect.matchEffect({

--- a/ts/packages/cli/test/src/services/run-companion-modules.test.ts
+++ b/ts/packages/cli/test/src/services/run-companion-modules.test.ts
@@ -2,18 +2,138 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { BunContext } from '@effect/platform-bun';
-import { afterEach, describe, expect, layer, vi } from '@effect/vitest';
+import { afterEach, describe, expect, layer } from '@effect/vitest';
 import { Effect } from 'effect';
-import { repairMissingInstalledRunCompanionModules } from 'src/services/run-companion-modules';
+import { vi } from 'vitest';
+import {
+  repairMissingInstalledRunCompanionModules,
+  RUN_COMPANION_MODULE_FILENAMES,
+  RUN_COMPANION_RELEASE_TAG_FILENAME,
+  RUN_COMPANION_STATIC_ASSET_RELATIVE_PATHS,
+} from 'src/services/run-companion-modules';
 import { BaseConfigProviderLive, extendConfigProvider } from 'src/services/config';
+
+const extractZipMock = vi.hoisted(() => vi.fn());
+vi.mock('extract-zip', () => ({ default: extractZipMock }));
+
+const TEST_RELEASE_TAG = '@composio/cli@0.3.0-test';
+const TEST_BINARY_ASSET_NAMES = [
+  'composio-darwin-aarch64.zip',
+  'composio-darwin-x64.zip',
+  'composio-linux-aarch64.zip',
+  'composio-linux-x64.zip',
+];
+const TEST_COMPANION_RELATIVE_PATHS = [
+  ...RUN_COMPANION_MODULE_FILENAMES,
+  ...RUN_COMPANION_STATIC_ASSET_RELATIVE_PATHS,
+].sort();
+
+const stubRepairFetch = () => {
+  const fetchMock = vi.fn((url: string) =>
+    Promise.resolve(
+      url.includes('/releases/tags/')
+        ? new Response(
+            JSON.stringify({
+              tag_name: TEST_RELEASE_TAG,
+              assets: TEST_BINARY_ASSET_NAMES.map(name => ({
+                name,
+                browser_download_url: `https://download.test/${name}`,
+              })),
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } }
+          )
+        : new Response(new Uint8Array([1]), { status: 200 })
+    )
+  );
+  vi.stubGlobal('fetch', fetchMock);
+  vi.stubEnv('GITHUB_TAG', TEST_RELEASE_TAG);
+  return fetchMock;
+};
+
+const mockArchiveContents = (missingRelativePath?: string) => {
+  extractZipMock.mockImplementation(
+    async (archivePath: string, options: { readonly dir: string }) => {
+      const packageDirectory = path.join(options.dir, path.parse(archivePath).name);
+      for (const relativePath of TEST_COMPANION_RELATIVE_PATHS) {
+        if (relativePath === missingRelativePath) continue;
+        const filePath = path.join(packageDirectory, relativePath);
+        fs.mkdirSync(path.dirname(filePath), { recursive: true });
+        fs.writeFileSync(filePath, `new:${relativePath}`);
+      }
+    }
+  );
+};
 
 describe('run-companion-modules', () => {
   afterEach(() => {
+    extractZipMock.mockReset();
     vi.unstubAllGlobals();
     vi.unstubAllEnvs();
   });
 
   layer(BunContext.layer)(it => {
+    it.effect('[Given] a complete archive [Then] repair atomically replaces companions', () => {
+      const installDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'composio-run-repair-test-'));
+      const execPath = path.join(installDirectory, 'composio');
+      const companionRelativePath = TEST_COMPANION_RELATIVE_PATHS[0]!;
+      const companionPath = path.join(installDirectory, companionRelativePath);
+      const releaseTagPath = path.join(installDirectory, RUN_COMPANION_RELEASE_TAG_FILENAME);
+      fs.mkdirSync(path.dirname(companionPath), { recursive: true });
+      fs.writeFileSync(companionPath, 'old-companion');
+      fs.writeFileSync(releaseTagPath, '@composio/cli@0.2.31\n');
+      const originalCompanion = fs.statSync(companionPath);
+      const fetchMock = stubRepairFetch();
+      mockArchiveContents();
+
+      return Effect.gen(function* () {
+        const result = yield* repairMissingInstalledRunCompanionModules({
+          callerImportMetaUrl: 'file:///$bunfs/root/commands.mjs',
+          execPath,
+          appVersion: '0.0.0-test',
+        });
+
+        expect(result).toEqual({ repaired: true, releaseTag: TEST_RELEASE_TAG });
+        expect(fs.readFileSync(companionPath, 'utf8')).toBe(`new:${companionRelativePath}`);
+        const replacedCompanion = fs.statSync(companionPath);
+        expect(replacedCompanion.dev).toBe(originalCompanion.dev);
+        expect(replacedCompanion.ino).not.toBe(originalCompanion.ino);
+        expect(fs.readFileSync(releaseTagPath, 'utf8')).toBe(`${TEST_RELEASE_TAG}\n`);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+      }).pipe(
+        Effect.ensuring(
+          Effect.sync(() => fs.rmSync(installDirectory, { recursive: true, force: true }))
+        )
+      );
+    });
+
+    it.effect('[Given] an incomplete archive [Then] repair preserves release metadata', () => {
+      const installDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'composio-run-repair-test-'));
+      const execPath = path.join(installDirectory, 'composio');
+      const releaseTagPath = path.join(installDirectory, RUN_COMPANION_RELEASE_TAG_FILENAME);
+      const previousReleaseTag = '@composio/cli@0.2.31\n';
+      const missingRelativePath = TEST_COMPANION_RELATIVE_PATHS.at(-1)!;
+      fs.writeFileSync(releaseTagPath, previousReleaseTag);
+      stubRepairFetch();
+      mockArchiveContents(missingRelativePath);
+
+      return Effect.gen(function* () {
+        const error = yield* repairMissingInstalledRunCompanionModules({
+          callerImportMetaUrl: 'file:///$bunfs/root/commands.mjs',
+          execPath,
+          appVersion: '0.0.0-test',
+        }).pipe(Effect.flip);
+
+        expect(error.message).toContain(
+          `missing ${missingRelativePath}; cannot restore the files required by 'composio run'`
+        );
+        expect(fs.readFileSync(releaseTagPath, 'utf8')).toBe(previousReleaseTag);
+      }).pipe(
+        Effect.ensuring(
+          Effect.sync(() => fs.rmSync(installDirectory, { recursive: true, force: true }))
+        )
+      );
+    });
+
     it.effect(
       '[Given] malformed release metadata [Then] repair rejects it before using release assets',
       () => {

--- a/ts/packages/cli/test/src/services/running-cli-version.test.ts
+++ b/ts/packages/cli/test/src/services/running-cli-version.test.ts
@@ -1,0 +1,73 @@
+import { FileSystem, Path } from '@effect/platform';
+import { BunFileSystem, BunPath } from '@effect/platform-bun';
+import { describe, expect, layer } from '@effect/vitest';
+import { Effect, Layer } from 'effect';
+import {
+  resolveRunningCliReleaseTag,
+  resolveRunningCliVersion,
+} from 'src/services/run-companion-modules';
+
+const TestPlatform = Layer.mergeAll(BunFileSystem.layer, BunPath.layer);
+
+describe('running CLI version authority', () => {
+  layer(TestPlatform)(it => {
+    it.scoped('uses the compiled version in release builds despite installed tag metadata', () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const installDirectory = yield* fs.makeTempDirectoryScoped();
+        const execPath = path.join(installDirectory, 'composio');
+
+        for (const installedTag of ['@composio/cli@9.9.9', '@composio/cli@0.2.31']) {
+          yield* fs.writeFileString(path.join(installDirectory, 'release-tag.txt'), installedTag);
+
+          expect(yield* resolveRunningCliVersion(execPath, '0.3.0', true)).toBe('0.3.0');
+          expect(yield* resolveRunningCliReleaseTag(execPath, '0.3.0', true)).toBe(
+            '@composio/cli@0.3.0'
+          );
+        }
+      })
+    );
+
+    it.scoped('uses the compiled version in a release build without installed metadata', () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const installDirectory = yield* fs.makeTempDirectoryScoped();
+        const execPath = path.join(installDirectory, 'composio');
+
+        expect(yield* resolveRunningCliVersion(execPath, '0.3.0', true)).toBe('0.3.0');
+        expect(yield* resolveRunningCliReleaseTag(execPath, '0.3.0', true)).toBe(
+          '@composio/cli@0.3.0'
+        );
+      })
+    );
+
+    it.scoped('keeps installed tag fallback behavior in development builds', () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const installDirectory = yield* fs.makeTempDirectoryScoped();
+        const execPath = path.join(installDirectory, 'composio');
+        const releaseTagPath = path.join(installDirectory, 'release-tag.txt');
+        yield* fs.writeFileString(releaseTagPath, '@composio/cli@0.2.31');
+
+        expect(yield* resolveRunningCliVersion(execPath, '0.0.0-development', false)).toBe(
+          '0.2.31'
+        );
+        expect(yield* resolveRunningCliReleaseTag(execPath, '0.0.0-development', false)).toBe(
+          '@composio/cli@0.2.31'
+        );
+
+        yield* fs.remove(releaseTagPath);
+
+        expect(yield* resolveRunningCliVersion(execPath, '0.0.0-development', false)).toBe(
+          '0.0.0-development'
+        );
+        expect(yield* resolveRunningCliReleaseTag(execPath, '0.0.0-development', false)).toBe(
+          '@composio/cli@0.0.0-development'
+        );
+      })
+    );
+  });
+});

--- a/ts/packages/cli/test/src/services/running-cli-version.test.ts
+++ b/ts/packages/cli/test/src/services/running-cli-version.test.ts
@@ -3,6 +3,7 @@ import { BunFileSystem, BunPath } from '@effect/platform-bun';
 import { describe, expect, layer } from '@effect/vitest';
 import { Effect, Layer } from 'effect';
 import {
+  RUN_COMPANION_RELEASE_TAG_FILENAME,
   resolveRunningCliReleaseTag,
   resolveRunningCliVersion,
 } from 'src/services/run-companion-modules';
@@ -19,7 +20,10 @@ describe('running CLI version authority', () => {
         const execPath = path.join(installDirectory, 'composio');
 
         for (const installedTag of ['@composio/cli@9.9.9', '@composio/cli@0.2.31']) {
-          yield* fs.writeFileString(path.join(installDirectory, 'release-tag.txt'), installedTag);
+          yield* fs.writeFileString(
+            path.join(installDirectory, RUN_COMPANION_RELEASE_TAG_FILENAME),
+            installedTag
+          );
 
           expect(yield* resolveRunningCliVersion(execPath, '0.3.0', true)).toBe('0.3.0');
           expect(yield* resolveRunningCliReleaseTag(execPath, '0.3.0', true)).toBe(
@@ -49,7 +53,7 @@ describe('running CLI version authority', () => {
         const path = yield* Path.Path;
         const installDirectory = yield* fs.makeTempDirectoryScoped();
         const execPath = path.join(installDirectory, 'composio');
-        const releaseTagPath = path.join(installDirectory, 'release-tag.txt');
+        const releaseTagPath = path.join(installDirectory, RUN_COMPANION_RELEASE_TAG_FILENAME);
         yield* fs.writeFileString(releaseTagPath, '@composio/cli@0.2.31');
 
         expect(yield* resolveRunningCliVersion(execPath, '0.0.0-development', false)).toBe(

--- a/ts/packages/cli/test/src/services/setup-skill-installer.test.ts
+++ b/ts/packages/cli/test/src/services/setup-skill-installer.test.ts
@@ -61,13 +61,13 @@ describe('SetupSkillInstaller', () => {
       })
     );
 
-    it.effect('discovers the latest stable release outside a packaged install', () =>
+    it.effect('uses the running package fallback outside a packaged install', () =>
       Effect.gen(function* () {
         const path = yield* Path.Path;
         const installDir = tempy.temporaryDirectory();
 
         expect(yield* resolveSetupSkillReleaseTag(path.join(installDir, 'composio'), '0.3.0')).toBe(
-          '@composio/cli@0.2.21'
+          '@composio/cli@0.3.0'
         );
       })
     );

--- a/ts/packages/cli/test/src/services/upgrade-binary.test.ts
+++ b/ts/packages/cli/test/src/services/upgrade-binary.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, it, vi } from '@effect/vitest';
-import { ConfigProvider, Effect, Layer } from 'effect';
+import { ConfigProvider, Effect, Layer, Option } from 'effect';
 import { FetchHttpClient, FileSystem, Path } from '@effect/platform';
+import * as PlatformError from '@effect/platform/Error';
 import { BunFileSystem, BunPath } from '@effect/platform-bun';
 import { withHttpServer } from 'test/__utils__/http-server';
 import { getTerminalCapabilities, TerminalUI } from 'src/services/terminal-ui';
 import { UpgradeBinary, UpgradeBinaryError } from 'src/services/upgrade-binary';
 import { NodeOs } from 'src/services/node-os';
-import { collectExpectedRunCompanionAssetRelativePaths } from 'src/services/run-companion-modules';
+import {
+  collectExpectedRunCompanionAssetRelativePaths,
+  RUN_COMPANION_RELEASE_TAG_FILENAME,
+} from 'src/services/run-companion-modules';
 
 const TerminalUINoop = Layer.succeed(
   TerminalUI,
@@ -55,11 +59,15 @@ const NodeOsTest = Layer.succeed(
 
 const TestPlatform = Layer.mergeAll(BunFileSystem.layer, BunPath.layer);
 
+type UpgradeOptions = {
+  readonly prerelease?: boolean;
+  readonly tag?: string;
+};
+
 const makeUpgradeEffect = (
   configEntries: ReadonlyArray<[string, string]>,
-  options?: {
-    prerelease?: boolean;
-  }
+  options?: UpgradeOptions,
+  fileSystemLayer: Layer.Layer<FileSystem.FileSystem> = BunFileSystem.layer
 ) =>
   Effect.gen(function* () {
     const service = yield* UpgradeBinary;
@@ -67,7 +75,7 @@ const makeUpgradeEffect = (
   }).pipe(
     Effect.provide(UpgradeBinary.Default),
     Effect.provide(FetchHttpClient.layer),
-    Effect.provide(BunFileSystem.layer),
+    Effect.provide(fileSystemLayer),
     Effect.provide(TerminalUINoop),
     Effect.provide(NodeOsTest),
     Effect.withConfigProvider(ConfigProvider.fromMap(new Map(configEntries))),
@@ -76,17 +84,43 @@ const makeUpgradeEffect = (
 
 const runUpgrade = (
   configEntries: ReadonlyArray<[string, string]>,
-  options?: {
-    prerelease?: boolean;
-  }
-) => makeUpgradeEffect(configEntries, options).pipe(Effect.flip);
+  options?: UpgradeOptions,
+  fileSystemLayer?: Layer.Layer<FileSystem.FileSystem>
+) => makeUpgradeEffect(configEntries, options, fileSystemLayer).pipe(Effect.flip);
 
 const runUpgradeSuccess = (
   configEntries: ReadonlyArray<[string, string]>,
-  options?: {
-    prerelease?: boolean;
-  }
-) => makeUpgradeEffect(configEntries, options);
+  options?: UpgradeOptions,
+  fileSystemLayer?: Layer.Layer<FileSystem.FileSystem>
+) => makeUpgradeEffect(configEntries, options, fileSystemLayer);
+
+const failRenameTo = (failedTargetPath: string) =>
+  Layer.effect(
+    FileSystem.FileSystem,
+    Effect.map(
+      FileSystem.FileSystem,
+      fs =>
+        new Proxy(fs, {
+          get(target, property, receiver) {
+            if (property !== 'rename') {
+              return Reflect.get(target, property, receiver);
+            }
+
+            return (oldPath: string, newPath: string) =>
+              newPath === failedTargetPath
+                ? Effect.fail(
+                    new PlatformError.SystemError({
+                      reason: 'Busy',
+                      module: 'FileSystem',
+                      method: 'rename',
+                      pathOrDescriptor: newPath,
+                    })
+                  )
+                : target.rename(oldPath, newPath);
+          },
+        })
+    )
+  ).pipe(Layer.provide(BunFileSystem.layer));
 
 /**
  * Bridge the promise-based `withHttpServer` harness into a scoped Effect:
@@ -434,11 +468,16 @@ describe('UpgradeBinary', () => {
         'darwin-arm64',
         'imessage-cli'
       );
+      const staleLocalToolPath = path.join(installDir, 'local-tools-binaries', 'stale-tool');
 
       yield* fs.writeFileString(fakeExecPath, 'old-binary');
       yield* fs.writeFileString(sourceBinaryPath, 'new-binary');
       yield* fs.makeDirectory(path.dirname(sourceLocalToolPath), { recursive: true });
       yield* fs.writeFileString(sourceLocalToolPath, 'imessage-sidecar');
+      yield* fs.makeDirectory(path.dirname(installedLocalToolPath), { recursive: true });
+      yield* fs.writeFileString(installedLocalToolPath, 'old-imessage-sidecar');
+      yield* fs.writeFileString(staleLocalToolPath, 'stale');
+      const originalBinaryInfo = yield* fs.stat(fakeExecPath);
 
       vi.spyOn(process, 'execPath', 'get').mockReturnValue(fakeExecPath);
 
@@ -456,8 +495,127 @@ describe('UpgradeBinary', () => {
 
       expect(result).toBeUndefined();
       expect(yield* fs.readFileString(fakeExecPath)).toBe('new-binary');
+      const replacedBinaryInfo = yield* fs.stat(fakeExecPath);
+      expect(replacedBinaryInfo.dev).toBe(originalBinaryInfo.dev);
+      expect(Option.getOrThrow(replacedBinaryInfo.ino)).not.toBe(
+        Option.getOrThrow(originalBinaryInfo.ino)
+      );
+      expect(replacedBinaryInfo.mode & 0o777).toBe(0o755);
       expect(yield* fs.exists(installedLocalToolPath)).toBe(true);
       expect(yield* fs.readFileString(installedLocalToolPath)).toBe('imessage-sidecar');
+      expect(yield* fs.exists(staleLocalToolPath)).toBe(false);
+    }).pipe(Effect.provide(TestPlatform), Effect.ensuring(restoreStubsAndMocks));
+  });
+
+  it.scoped('commits companions and release metadata before replacing the binary', () => {
+    vi.stubGlobal('Bun', { which: vi.fn(() => null) });
+
+    return Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const installDir = yield* fs.makeTempDirectoryScoped({
+        prefix: 'composio-ordered-upgrade-target-',
+      });
+      const sourceDir = yield* fs.makeTempDirectoryScoped({
+        prefix: 'composio-ordered-upgrade-source-',
+      });
+      const fakeExecPath = path.join(installDir, 'composio');
+      const sourceBinaryPath = path.join(sourceDir, 'composio');
+      const releaseTagPath = path.join(installDir, RUN_COMPANION_RELEASE_TAG_FILENAME);
+      const newReleaseTag = '@composio/cli@0.3.0';
+      yield* fs.writeFileString(fakeExecPath, 'old-binary');
+      yield* fs.writeFileString(sourceBinaryPath, 'new-binary');
+      yield* fs.writeFileString(releaseTagPath, '@composio/cli@0.2.31\n');
+      const originalReleaseTagInfo = yield* fs.stat(releaseTagPath);
+
+      const companionRelativePaths =
+        yield* collectExpectedRunCompanionAssetRelativePaths(sourceDir);
+      for (const relativePath of companionRelativePaths) {
+        const companionPath = path.join(sourceDir, relativePath);
+        yield* fs.makeDirectory(path.dirname(companionPath), { recursive: true });
+        yield* fs.writeFileString(companionPath, 'new-support-file');
+      }
+      const observedCompanionPath = path.join(installDir, companionRelativePaths[0]!);
+      yield* fs.makeDirectory(path.dirname(observedCompanionPath), { recursive: true });
+      yield* fs.writeFileString(observedCompanionPath, 'old-support-file');
+      vi.spyOn(process, 'execPath', 'get').mockReturnValue(fakeExecPath);
+
+      const error = yield* runUpgrade(
+        [['DEBUG_OVERRIDE_UPGRADE_TARGET', sourceBinaryPath]],
+        { tag: newReleaseTag },
+        failRenameTo(fakeExecPath)
+      );
+
+      expect(error).toBeInstanceOf(UpgradeBinaryError);
+      if (!(error instanceof UpgradeBinaryError)) {
+        throw error;
+      }
+      expect(error.message).toBe('Failed to replace binary');
+      expect(error.cause).toBeInstanceOf(PlatformError.SystemError);
+      expect(yield* fs.readFileString(fakeExecPath)).toBe('old-binary');
+      expect(yield* fs.readFileString(observedCompanionPath)).toBe('new-support-file');
+      expect(yield* fs.readFileString(releaseTagPath)).toBe(`${newReleaseTag}\n`);
+      const replacedReleaseTagInfo = yield* fs.stat(releaseTagPath);
+      expect(Option.getOrThrow(replacedReleaseTagInfo.ino)).not.toBe(
+        Option.getOrThrow(originalReleaseTagInfo.ino)
+      );
+    }).pipe(Effect.provide(TestPlatform), Effect.ensuring(restoreStubsAndMocks));
+  });
+
+  it.scoped('preflights every companion before changing installed files', () => {
+    vi.stubGlobal('Bun', { which: vi.fn(() => null) });
+
+    return Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const installDir = yield* fs.makeTempDirectoryScoped({
+        prefix: 'composio-incomplete-upgrade-target-',
+      });
+      const sourceDir = yield* fs.makeTempDirectoryScoped({
+        prefix: 'composio-incomplete-upgrade-source-',
+      });
+      const fakeExecPath = path.join(installDir, 'composio');
+      const sourceBinaryPath = path.join(sourceDir, 'composio');
+      const releaseTagPath = path.join(installDir, RUN_COMPANION_RELEASE_TAG_FILENAME);
+      yield* fs.writeFileString(fakeExecPath, 'old-binary');
+      yield* fs.writeFileString(sourceBinaryPath, 'new-binary');
+      yield* fs.writeFileString(releaseTagPath, '@composio/cli@0.2.31\n');
+
+      const companionRelativePaths =
+        yield* collectExpectedRunCompanionAssetRelativePaths(sourceDir);
+      const missingRelativePath = companionRelativePaths.at(-1)!;
+      for (const relativePath of companionRelativePaths) {
+        if (relativePath === missingRelativePath) continue;
+        const companionPath = path.join(sourceDir, relativePath);
+        yield* fs.makeDirectory(path.dirname(companionPath), { recursive: true });
+        yield* fs.writeFileString(companionPath, 'new-support-file');
+      }
+      const observedCompanionPath = path.join(installDir, companionRelativePaths[0]!);
+      yield* fs.makeDirectory(path.dirname(observedCompanionPath), { recursive: true });
+      yield* fs.writeFileString(observedCompanionPath, 'old-support-file');
+
+      const sourceLocalToolPath = path.join(sourceDir, 'local-tools-binaries', 'test-tool');
+      const installedLocalToolPath = path.join(installDir, 'local-tools-binaries', 'test-tool');
+      yield* fs.makeDirectory(path.dirname(sourceLocalToolPath), { recursive: true });
+      yield* fs.writeFileString(sourceLocalToolPath, 'new-local-tool');
+      yield* fs.makeDirectory(path.dirname(installedLocalToolPath), { recursive: true });
+      yield* fs.writeFileString(installedLocalToolPath, 'old-local-tool');
+      vi.spyOn(process, 'execPath', 'get').mockReturnValue(fakeExecPath);
+
+      const error = yield* runUpgrade([['DEBUG_OVERRIDE_UPGRADE_TARGET', sourceBinaryPath]], {
+        tag: '@composio/cli@0.3.0',
+      });
+
+      expect(error).toBeInstanceOf(UpgradeBinaryError);
+      if (!(error instanceof UpgradeBinaryError)) {
+        throw error;
+      }
+      expect(error.message).toBe('Downloaded binary package is incomplete');
+      expect(String(error.cause)).toContain(missingRelativePath);
+      expect(yield* fs.readFileString(fakeExecPath)).toBe('old-binary');
+      expect(yield* fs.readFileString(observedCompanionPath)).toBe('old-support-file');
+      expect(yield* fs.readFileString(installedLocalToolPath)).toBe('old-local-tool');
+      expect(yield* fs.readFileString(releaseTagPath)).toBe('@composio/cli@0.2.31\n');
     }).pipe(Effect.provide(TestPlatform), Effect.ensuring(restoreStubsAndMocks));
   });
 

--- a/ts/packages/cli/test/src/services/upgrade-binary.test.ts
+++ b/ts/packages/cli/test/src/services/upgrade-binary.test.ts
@@ -550,7 +550,9 @@ describe('UpgradeBinary', () => {
       if (!(error instanceof UpgradeBinaryError)) {
         throw error;
       }
-      expect(error.message).toBe('Failed to replace binary');
+      expect(error.message).toBe(
+        `Failed to replace binary: Failed to replace file at ${fakeExecPath}`
+      );
       expect(error.cause).toBeInstanceOf(PlatformError.SystemError);
       expect(yield* fs.readFileString(fakeExecPath)).toBe('old-binary');
       expect(yield* fs.readFileString(observedCompanionPath)).toBe('new-support-file');

--- a/ts/packages/cli/test/src/utils/atomic-replace.test.ts
+++ b/ts/packages/cli/test/src/utils/atomic-replace.test.ts
@@ -1,4 +1,5 @@
 import { FileSystem, Path } from '@effect/platform';
+import * as PlatformError from '@effect/platform/Error';
 import { BunFileSystem, BunPath } from '@effect/platform-bun';
 import { describe, expect, layer } from '@effect/vitest';
 import { Effect, Layer, Option } from 'effect';
@@ -9,6 +10,55 @@ import {
 } from 'src/utils/atomic-replace';
 
 const TestPlatform = Layer.mergeAll(BunFileSystem.layer, BunPath.layer);
+
+const failDirectoryPublish = (targetPath: string, failRestore = false) =>
+  Layer.effect(
+    FileSystem.FileSystem,
+    Effect.map(
+      FileSystem.FileSystem,
+      fs =>
+        new Proxy(fs, {
+          get(target, property, receiver) {
+            if (property !== 'rename') {
+              return Reflect.get(target, property, receiver);
+            }
+
+            return (oldPath: string, newPath: string) => {
+              const shouldFail =
+                newPath === targetPath &&
+                (oldPath.includes('.composio-atomic-replace-') ||
+                  (failRestore && oldPath.includes('.composio-atomic-recovery-')));
+              return shouldFail
+                ? Effect.fail(
+                    new PlatformError.SystemError({
+                      reason: 'Busy',
+                      module: 'FileSystem',
+                      method: 'rename',
+                      pathOrDescriptor: newPath,
+                    })
+                  )
+                : target.rename(oldPath, newPath);
+            };
+          },
+        })
+    )
+  ).pipe(Layer.provide(BunFileSystem.layer));
+
+const makeDirectoryFixture = (withTarget = true) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const directory = yield* fs.makeTempDirectoryScoped();
+    const sourcePath = path.join(directory, 'source');
+    const targetPath = path.join(directory, 'target');
+    yield* fs.makeDirectory(sourcePath);
+    yield* fs.writeFileString(path.join(sourcePath, 'new.txt'), 'new contents');
+    if (withTarget) {
+      yield* fs.makeDirectory(targetPath);
+      yield* fs.writeFileString(path.join(targetPath, 'old.txt'), 'old contents');
+    }
+    return { directory, fs, path, sourcePath, targetPath };
+  });
 
 describe('atomic replace', () => {
   layer(TestPlatform)(it => {
@@ -93,6 +143,55 @@ describe('atomic replace', () => {
         );
         expect(yield* fs.exists(path.join(targetPath, 'old.txt'))).toBe(false);
         expect((yield* fs.readDirectory(directory)).sort()).toEqual(['source', 'target']);
+      })
+    );
+
+    it.scoped('creates a directory target that does not exist', () =>
+      Effect.gen(function* () {
+        const { directory, fs, path, sourcePath, targetPath } = yield* makeDirectoryFixture(false);
+
+        yield* Effect.scoped(atomicReplaceDirectory({ sourcePath, targetPath }));
+
+        expect(yield* fs.readFileString(path.join(targetPath, 'new.txt'))).toBe('new contents');
+        expect((yield* fs.readDirectory(directory)).sort()).toEqual(['source', 'target']);
+      })
+    );
+
+    it.scoped('restores the previous directory when publishing fails', () =>
+      Effect.gen(function* () {
+        const { directory, fs, path, sourcePath, targetPath } = yield* makeDirectoryFixture();
+
+        const error = yield* Effect.flip(
+          Effect.scoped(atomicReplaceDirectory({ sourcePath, targetPath })).pipe(
+            Effect.provide(failDirectoryPublish(targetPath))
+          )
+        );
+
+        expect(error).toBeInstanceOf(AtomicReplaceError);
+        expect(yield* fs.readFileString(path.join(targetPath, 'old.txt'))).toBe('old contents');
+        expect((yield* fs.readDirectory(directory)).sort()).toEqual(['source', 'target']);
+      })
+    );
+
+    it.scoped('retains the previous directory when publishing and restoration fail', () =>
+      Effect.gen(function* () {
+        const { directory, fs, path, sourcePath, targetPath } = yield* makeDirectoryFixture();
+
+        const error = yield* Effect.flip(
+          Effect.scoped(atomicReplaceDirectory({ sourcePath, targetPath })).pipe(
+            Effect.provide(failDirectoryPublish(targetPath, true))
+          )
+        );
+        const recoveryDirectory = (yield* fs.readDirectory(directory)).find(entry =>
+          entry.startsWith('.composio-atomic-recovery-')
+        );
+
+        expect(error).toBeInstanceOf(AtomicReplaceError);
+        expect(recoveryDirectory).toBeDefined();
+        expect(error.message).toContain('Previous contents retained at');
+        expect(
+          yield* fs.readFileString(path.join(directory, recoveryDirectory!, 'target', 'old.txt'))
+        ).toBe('old contents');
       })
     );
   });

--- a/ts/packages/cli/test/src/utils/atomic-replace.test.ts
+++ b/ts/packages/cli/test/src/utils/atomic-replace.test.ts
@@ -44,6 +44,34 @@ const failDirectoryPublish = (targetPath: string, failRestore = false) =>
     )
   ).pipe(Layer.provide(BunFileSystem.layer));
 
+const failDirectoryCleanup = () =>
+  Layer.effect(
+    FileSystem.FileSystem,
+    Effect.map(
+      FileSystem.FileSystem,
+      fs =>
+        new Proxy(fs, {
+          get(target, property, receiver) {
+            if (property !== 'remove') {
+              return Reflect.get(target, property, receiver);
+            }
+
+            return (path: string, options?: FileSystem.RemoveOptions) =>
+              path.includes('.composio-atomic-recovery-')
+                ? Effect.fail(
+                    new PlatformError.SystemError({
+                      reason: 'Busy',
+                      module: 'FileSystem',
+                      method: 'remove',
+                      pathOrDescriptor: path,
+                    })
+                  )
+                : target.remove(path, options);
+          },
+        })
+    )
+  ).pipe(Layer.provide(BunFileSystem.layer));
+
 const makeDirectoryFixture = (withTarget = true) =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
@@ -170,6 +198,25 @@ describe('atomic replace', () => {
         expect(error).toBeInstanceOf(AtomicReplaceError);
         expect(yield* fs.readFileString(path.join(targetPath, 'old.txt'))).toBe('old contents');
         expect((yield* fs.readDirectory(directory)).sort()).toEqual(['source', 'target']);
+      })
+    );
+
+    it.scoped('keeps the published directory when old-content cleanup fails', () =>
+      Effect.gen(function* () {
+        const { directory, fs, path, sourcePath, targetPath } = yield* makeDirectoryFixture();
+
+        yield* Effect.scoped(atomicReplaceDirectory({ sourcePath, targetPath })).pipe(
+          Effect.provide(failDirectoryCleanup())
+        );
+
+        const recoveryDirectory = (yield* fs.readDirectory(directory)).find(entry =>
+          entry.startsWith('.composio-atomic-recovery-')
+        );
+        expect(yield* fs.readFileString(path.join(targetPath, 'new.txt'))).toBe('new contents');
+        expect(recoveryDirectory).toBeDefined();
+        expect(
+          yield* fs.readFileString(path.join(directory, recoveryDirectory!, 'target', 'old.txt'))
+        ).toBe('old contents');
       })
     );
 

--- a/ts/packages/cli/test/src/utils/atomic-replace.test.ts
+++ b/ts/packages/cli/test/src/utils/atomic-replace.test.ts
@@ -1,0 +1,99 @@
+import { FileSystem, Path } from '@effect/platform';
+import { BunFileSystem, BunPath } from '@effect/platform-bun';
+import { describe, expect, layer } from '@effect/vitest';
+import { Effect, Layer, Option } from 'effect';
+import {
+  AtomicReplaceError,
+  atomicReplaceDirectory,
+  atomicReplaceFile,
+} from 'src/utils/atomic-replace';
+
+const TestPlatform = Layer.mergeAll(BunFileSystem.layer, BunPath.layer);
+
+describe('atomic replace', () => {
+  layer(TestPlatform)(it => {
+    it.scoped('replaces an existing file without modifying its open inode', () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const directory = yield* fs.makeTempDirectoryScoped();
+        const sourcePath = path.join(directory, 'source');
+        const targetPath = path.join(directory, 'target');
+        yield* fs.writeFileString(sourcePath, 'new contents');
+        yield* fs.writeFileString(targetPath, 'old contents');
+
+        const before = yield* fs.stat(targetPath);
+        const oldTarget = yield* fs.open(targetPath);
+        yield* Effect.scoped(atomicReplaceFile({ sourcePath, targetPath }));
+        const after = yield* fs.stat(targetPath);
+        const openContents = yield* oldTarget.readAlloc(FileSystem.Size('old contents'.length));
+
+        expect(yield* fs.readFileString(targetPath)).toBe('new contents');
+        expect(after.dev).toBe(before.dev);
+        expect(Option.getOrThrow(after.ino)).not.toBe(Option.getOrThrow(before.ino));
+        expect(new TextDecoder().decode(Option.getOrThrow(openContents))).toBe('old contents');
+        expect((yield* fs.readDirectory(directory)).sort()).toEqual(['source', 'target']);
+      })
+    );
+
+    it.scoped('creates an executable target when mode is provided', () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const directory = yield* fs.makeTempDirectoryScoped();
+        const sourcePath = path.join(directory, 'source');
+        const targetPath = path.join(directory, 'target');
+        yield* fs.writeFileString(sourcePath, 'binary');
+
+        yield* Effect.scoped(atomicReplaceFile({ sourcePath, targetPath, mode: 0o755 }));
+
+        expect(yield* fs.readFileString(targetPath)).toBe('binary');
+        expect((yield* fs.stat(targetPath)).mode & 0o777).toBe(0o755);
+        expect((yield* fs.readDirectory(directory)).sort()).toEqual(['source', 'target']);
+      })
+    );
+
+    it.scoped('preserves the target and cleans staging when the source is missing', () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const directory = yield* fs.makeTempDirectoryScoped();
+        const sourcePath = path.join(directory, 'missing');
+        const targetPath = path.join(directory, 'target');
+        yield* fs.writeFileString(targetPath, 'old contents');
+
+        const error = yield* Effect.flip(
+          Effect.scoped(atomicReplaceFile({ sourcePath, targetPath }))
+        );
+
+        expect(error).toBeInstanceOf(AtomicReplaceError);
+        expect(error.targetPath).toBe(targetPath);
+        expect(error.cause).toBeDefined();
+        expect(yield* fs.readFileString(targetPath)).toBe('old contents');
+        expect(yield* fs.readDirectory(directory)).toEqual(['target']);
+      })
+    );
+
+    it.scoped('replaces an existing non-empty directory without leaving residue', () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const directory = yield* fs.makeTempDirectoryScoped();
+        const sourcePath = path.join(directory, 'source');
+        const targetPath = path.join(directory, 'target');
+        yield* fs.makeDirectory(path.join(sourcePath, 'nested'), { recursive: true });
+        yield* fs.writeFileString(path.join(sourcePath, 'nested', 'new.txt'), 'new contents');
+        yield* fs.makeDirectory(targetPath);
+        yield* fs.writeFileString(path.join(targetPath, 'old.txt'), 'old contents');
+
+        yield* Effect.scoped(atomicReplaceDirectory({ sourcePath, targetPath }));
+
+        expect(yield* fs.readFileString(path.join(targetPath, 'nested', 'new.txt'))).toBe(
+          'new contents'
+        );
+        expect(yield* fs.exists(path.join(targetPath, 'old.txt'))).toBe(false);
+        expect((yield* fs.readDirectory(directory)).sort()).toEqual(['source', 'target']);
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary

On Linux, `composio upgrade` could fail with `ETXTBSY` because it wrote directly over the executable that was currently running. Upgrades now stage replacements on the destination filesystem and publish them by rename, so the running process keeps its old inode while the install path points to the new binary.

The same publication rule now covers bundled support files, self-repair, and `install.sh`. Release builds also report their compiled version instead of trusting install metadata that may have been committed at a different point in the upgrade.

Related: #3998

## Changes

- Publish companion files, local-tool assets, release metadata, and the executable in that order, with the executable as the final commit point.
- Preserve the prior local-tool directory on ordinary rollback, retain a named recovery copy if restoration fails, and warn without aborting when cleanup fails after publication.
- Apply the same stage-then-rename behavior to companion self-repair and the POSIX installer.
- Add focused Effect tests, POSIX shell coverage, and a real-Linux compiled-binary E2E for upgrading the running executable and a copied executable.
- Document the one-time `install.sh` recovery path for users on an older CLI whose self-upgrade is already affected.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [ ] Documentation
- [ ] Breaking change

## How Has This Been Tested?

- `pnpm typecheck` — 14 TypeScript tasks passed.
- `pnpm --filter @composio/cli test` — 115 files passed; 1109 tests passed and 1 skipped.
- `pnpm run validate:boundaries` from `ts/packages/cli` — no new Effect boundary exceptions.
- `bash test/install-sh-atomic-replace.test.sh` and `pnpm run test:install-sh` — passed under `sh` and `dash`.
- `shellcheck -s sh install.sh install/*.sh` — clean.
- `COMPOSIO_E2E_CLI_VERSION=current pnpm test:e2e:cli` from `ts/e2e-tests/cli/upgrade` — 2 Linux cases passed with changed inode identities, working version output, and no `ETXTBSY` stderr.

## Screenshots (if applicable)

Not applicable; this changes upgrade and installer behavior without a visual interface.

## Checklist

- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed
- [x] I updated documentation as needed
- [x] I added tests or explain why not applicable
- [x] I added a changeset if this change affects published packages

`@composio/cli` remains excluded from Changesets, so no changeset is required.

## Additional context

This PR targets `feat/mise-style-installer-rollout` and stacks on #4015, which itself stacks on #4011. Retarget it to `next` after the installer stack merges.

The binary intentionally publishes last. An interruption before that final rename can leave newer support assets beside the old executable, but every final path remains a complete old or new file; a successful retry converges the install.

No VHS recording is included because this does not change command syntax or interactive output.

## Post-Deploy Monitoring & Validation

- Watch the first beta and the first 24 hours after stable promotion for `ETXTBSY`, `text file is busy`, `AtomicReplaceError`, or recovery-path errors in CLI reports and release workflow logs.
- Healthy behavior is a successful Linux upgrade or reinstall with a working `composio version`, no busy-file error, and green CLI installation workflows.
- Treat any recurrence, missing install entry, or retained recovery directory as a failure trigger. Mitigate by rerunning `install.sh`; roll back the CLI release if failures repeat.
- CLI maintainers own the validation window.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
