### PR TITLE
fix(core): release response bodies that ssrfSafeFetch callers never read

### DIFF
--- a/.changeset/release-ssrf-redirect-bodies.md
+++ b/.changeset/release-ssrf-redirect-bodies.md
@@ -1,0 +1,5 @@
+---
+'@composio/core': patch
+---
+
+Release unread response bodies on the paths the SDK knowingly abandons: cancel every intermediate redirect body in `ssrfSafeFetch`, and the response body before throwing on `!response.ok` in both URL-upload call sites, instead of leaving them for the garbage collector to reclaim.

--- a/ts/packages/core/src/models/ToolRouterSessionFileMount.ts
+++ b/ts/packages/core/src/models/ToolRouterSessionFileMount.ts
@@ -114,6 +114,9 @@ export class ToolRouterSessionFilesMount {
       if (input.startsWith('http://') || input.startsWith('https://')) {
         const response = await ssrfSafeFetch(input);
         if (!response.ok) {
+          // The error path never reads the body, so release it explicitly (mirrors
+          // `readResponseBodyWithLimit`) instead of leaving it to the garbage collector.
+          await response.body?.cancel().catch(() => undefined);
           throw new Error(`Failed to fetch file from URL: ${response.statusText}`);
         }
         const content = await readResponseBodyWithLimit(response);

--- a/ts/packages/core/src/utils/fileUtils.node.ts
+++ b/ts/packages/core/src/utils/fileUtils.node.ts
@@ -176,6 +176,9 @@ const readFileContentFromURL = async (
   // redirect into them. See ssrfGuard.node.ts.
   const response = await ssrfSafeFetch(path, { signal });
   if (!response.ok) {
+    // The error path never reads the body, so release it explicitly (mirrors
+    // `readResponseBodyWithLimit`) instead of leaving it to the garbage collector.
+    await response.body?.cancel().catch(() => undefined);
     throw new Error(`Failed to fetch file: ${response.statusText}`);
   }
   const content = await readResponseBodyWithLimit(response);

--- a/ts/packages/core/src/utils/ssrfGuard.node.ts
+++ b/ts/packages/core/src/utils/ssrfGuard.node.ts
@@ -171,8 +171,8 @@ export const assertSafeFetchTarget = async (rawUrl: string): Promise<void> => {
 /**
  * Drop-in replacement for `fetch` that blocks SSRF. Validates the target before
  * connecting and re-validates every redirect hop (redirects are followed
- * manually up to {@link MAX_REDIRECTS}). Non-redirect responses are returned
- * unchanged.
+ * manually up to {@link MAX_REDIRECTS}). Intermediate redirect bodies are
+ * cancelled; non-redirect responses are returned unchanged.
  */
 export const ssrfSafeFetch = async (
   rawUrl: string,
@@ -191,6 +191,10 @@ export const ssrfSafeFetch = async (
     if (!isRedirect) {
       return response;
     }
+
+    // Only `location` is read from a redirect, so release its body explicitly rather
+    // than leaving it to the garbage collector (mirrors `readResponseBodyWithLimit`).
+    await response.body?.cancel().catch(() => undefined);
 
     currentUrl = new URL(response.headers.get('location')!, currentUrl).toString();
   }

--- a/ts/packages/core/test/utils/ssrfGuard.test.ts
+++ b/ts/packages/core/test/utils/ssrfGuard.test.ts
@@ -162,4 +162,46 @@ describe('ssrfSafeFetch', () => {
       ComposioBlockedInternalUrlError
     );
   });
+
+  it('releases the redirect body before following the hop', async () => {
+    resolvesTo('93.184.216.34');
+    const fetchCallsWhenReleased: number[] = [];
+    const cancel = vi.fn(() => {
+      fetchCallsWhenReleased.push(mockFetch.mock.calls.length);
+    });
+    const redirect = new Response(new ReadableStream({ cancel }), {
+      status: 302,
+      headers: { location: 'https://example.com/final' },
+    });
+    mockFetch
+      .mockResolvedValueOnce(redirect)
+      .mockResolvedValueOnce(new Response('data', { status: 200 }));
+
+    const res = await ssrfSafeFetch('https://example.com/start');
+
+    expect(res.status).toBe(200);
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(redirect.bodyUsed).toBe(true);
+    // Released while following the first hop, not left dangling for the rest of the call.
+    expect(fetchCallsWhenReleased).toEqual([1]);
+  });
+
+  it('releases every hop body when the redirect budget is exhausted', async () => {
+    resolvesTo('93.184.216.34');
+    const cancel = vi.fn();
+    // A fresh body per hop: cancelling the same stream twice is a no-op the second time.
+    mockFetch.mockImplementation(
+      async () =>
+        new Response(new ReadableStream({ cancel }), {
+          status: 302,
+          headers: { location: 'https://example.com/again' },
+        })
+    );
+
+    await expect(ssrfSafeFetch('https://example.com/start', {}, 2)).rejects.toBeInstanceOf(
+      ComposioBlockedInternalUrlError
+    );
+    // maxRedirects = 2 => hops 0, 1, 2 are fetched before the budget throws.
+    expect(cancel).toHaveBeenCalledTimes(3);
+  });
 });


### PR DESCRIPTION
## Summary

The manual redirect loop in `ssrfSafeFetch` reads only the `location` header of every 3xx hop and then drops the `Response`, so up to `MAX_REDIRECTS + 1` (6) bodies per call are neither consumed nor cancelled and their release is left to the garbage collector. The sibling helper `readResponseBodyWithLimit` (`readResponseBody.ts:26`) already cancels explicitly in the same directory; #3900 created that helper and touched only the JSDoc of `ssrfGuard.node.ts`, so this brings the redirect loop in line with it. Both `ssrfSafeFetch` callers abandon the body the same way on the error path, so those are covered too.

## Changes

- `ssrfGuard.node.ts`: cancel each intermediate redirect body before following the hop (`await response.body?.cancel().catch(() => undefined);`), mirroring the sibling helper's idiom; JSDoc updated accordingly.
- `fileUtils.node.ts` and `ToolRouterSessionFileMount.ts`: cancel the response body before throwing on `!response.ok` (both throws only use `statusText`; the body is otherwise abandoned).
- `test/utils/ssrfGuard.test.ts`: two regression tests — the redirect body is released before following the hop, and every hop body is released when the redirect budget is exhausted (pattern follows `readResponseBody.test.ts`: `new Response(new ReadableStream({ cancel }))` + `toHaveBeenCalledOnce` + `bodyUsed`).
- Changeset for `@composio/core` (patch).

## Type of change
- [x] Bug fix

## How Has This Been Tested?

- `pnpm --filter @composio/core test ssrfGuard`: **16/16 pass** with the fix.
- Deleting just the cancel line: exactly the two new tests fail (`expected "vi.fn()" to be called once / 3 times, but got 0 times`) while the three pre-existing `ssrfSafeFetch` tests stay green; restoring the line: 16/16 again.
- Full `@composio/core` suite: 1041/1042 — the single failure (`fileUtils.test.ts > strips path components`) is a pre-existing Windows path-separator assertion, reproduced identically on a clean `origin/next` worktree; untouched by this diff.
- `tsc --noEmit --skipLibCheck` (both configs): clean · `oxlint ts/packages`: 0 errors · prettier on touched files · `validate-changesets`: passed.
- Environment: Windows, Node v24.14.1, pnpm 11.8.0 (BYPASS_TOOLCHAIN_CHECK for the local Node point-release difference).

## Screenshots (if applicable)

n/a

## Checklist
- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed
- [x] I updated documentation as needed (JSDoc on `ssrfSafeFetch`)
- [x] I added tests or explain why not applicable
- [x] I added a changeset if this change affects published packages

## Additional context

**The obvious objection, addressed.** "Node reclaims an unreferenced body eventually — undici even keeps a `FinalizationRegistry` backstop for that (`lib/web/fetch/body.js:29`). So why bother?" Undici's own README answers that, under *Specification Compliance → Garbage Collection*: leaving connection-resource release to the GC "can lead to excessive connection usage, reduced performance (due to less connection re-use), and even stalls or deadlocks when running out of connections. Therefore, **it is important to always either consume or cancel the response body anyway**" — and its "// Do not" example is precisely reading only the headers of a `fetch` response. Severity stays low: most 3xx bodies are empty, so on a typical redirect this cancel is a no-op; it matters when an upstream sends a non-empty redirect body, and it costs one line per site.

Drafted with AI assistance and verified locally as above; I understand and own the change.