### PR TITLE
docs: document Custom MCP toolkit logo upload

### DIFF
--- a/docs/content/docs/extending-sessions/custom-mcp.mdx
+++ b/docs/content/docs/extending-sessions/custom-mcp.mdx
@@ -114,6 +114,43 @@ Despite `upsert` in the route name, this endpoint does not update or replace an 
 To change the server URL, name, or authentication scheme, [delete the existing toolkit](#delete-or-replace-a-custom-mcp), then register it again. Deletion also revokes and removes the toolkit's auth configurations and connected accounts.
 </Callout>
 
+## Add a toolkit logo
+
+Without a logo, your toolkit shows the Composio logo in the dashboard and on end-user connect screens. To ship your own branding, include `toolkit_config.logo_file` when you register: the image itself, base64-encoded. Composio validates it, stores it on Composio-hosted asset storage, and renders it everywhere the toolkit appears. You don't host anything, and the logo keeps working even if your own site changes or goes down.
+
+```bash
+curl --request POST \
+  --url https://backend.composio.dev/api/v3.1/custom/toolkits/upsert \
+  --header "x-api-key: $COMPOSIO_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "slug": "ACME",
+    "toolkit_config": {
+      "name": "Acme",
+      "app_url": "https://mcp.example.com/mcp",
+      "logo_file": {
+        "content": "'"$(base64 -i logo.png)"'",
+        "mime_type": "image/png"
+      },
+      "auth_schemes": [
+        {
+          "mode": "NO_AUTH"
+        }
+      ]
+    }
+  }'
+```
+
+The image must be:
+
+- **PNG or JPEG** (`mime_type` of `image/png` or `image/jpeg`)
+- **Square**, between 256 and 1024 pixels
+- **At most 3MB** before encoding
+
+The base64 `content` must be a single line. macOS `base64 -i logo.png` produces single-line output; on Linux, use `base64 -w0 logo.png` to disable line wrapping.
+
+Omit `logo_file` to keep the Composio default. Because registration is insert-only, changing a logo later means deleting the toolkit and registering it again with the new image.
+
 ## Complete setup for your authentication mode
 
 Choose the mode that matches your server, then complete any required connection:

--- a/docs/content/docs/extending-sessions/custom-mcp.mdx
+++ b/docs/content/docs/extending-sessions/custom-mcp.mdx
@@ -129,7 +129,7 @@ curl --request POST \
       "name": "Acme",
       "app_url": "https://mcp.example.com/mcp",
       "logo_file": {
-        "content": "'"$(base64 -i logo.png)"'",
+        "content": "iVBORw0KGgoAAAANSUhEUgAA...",
         "mime_type": "image/png"
       },
       "auth_schemes": [
@@ -141,13 +141,11 @@ curl --request POST \
   }'
 ```
 
-The image must be:
+Set `content` to your image encoded as base64: a single line, with no line breaks or whitespace. The image must be:
 
 - **PNG or JPEG** (`mime_type` of `image/png` or `image/jpeg`)
 - **Square**, between 256 and 1024 pixels
 - **At most 3MB** before encoding
-
-The base64 `content` must be a single line. macOS `base64 -i logo.png` produces single-line output; on Linux, use `base64 -w0 logo.png` to disable line wrapping.
 
 Omit `logo_file` to keep the Composio default. Because registration is insert-only, changing a logo later means deleting the toolkit and registering it again with the new image.
 


### PR DESCRIPTION
## Problem

Custom MCP docs don't mention logos, so developers don't know they can replace the default Composio logo their toolkit shows in the dashboard and on end-user connect screens.

## What this adds

A new "Add a toolkit logo" section on the Custom MCP page, after registration: the `toolkit_config.logo_file` field (base64 `content` + `mime_type`), a cURL example with a placeholder base64 value, the constraints (PNG/JPEG, square 256-1024px, max 3MB, single-line base64), the default-logo behavior when omitted, and the insert-only implication that changing a logo means delete + re-register. Follows the docs convention of language/OS-neutral examples.

## Testing

`bun run lint` (0 errors) and `bun run lint:links` (0 errors) from `docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016x2W47caMs6zW4V8uu1M9g