### PR TITLE
fix(core): match sensitive upload denylist segments case-insensitively on every platform

### DIFF
--- a/ts/packages/core/src/utils/sensitiveFileUploadPaths.ts
+++ b/ts/packages/core/src/utils/sensitiveFileUploadPaths.ts
@@ -12,7 +12,8 @@ import { ComposioSensitiveFilePathBlockedError } from '../errors/FileModifierErr
 
 /**
  * Path segments (a single path component) that indicate a sensitive directory when
- * they appear anywhere in a resolved local path. Compared case-insensitively on Windows.
+ * they appear anywhere in a resolved local path. Compared case-insensitively on every
+ * platform, matching the basename rules below and the Python SDK.
  */
 export const BUILTIN_FILE_UPLOAD_PATH_DENY_SEGMENTS: readonly string[] = [
   '.ssh',
@@ -29,8 +30,6 @@ export const BUILTIN_FILE_UPLOAD_PATH_DENY_SEGMENTS: readonly string[] = [
 const SECRET_LIKE_BASENAME = /^(\.env(\.|$)|\.netrc$|\.pgpass$)/i;
 /** Default SSH private key basenames (public keys like id_rsa.pub are allowed). */
 const DEFAULT_PRIVATE_KEY_BASENAME = /^id_(rsa|ed25519|ecdsa|dsa|ecdsa_sk)(\.old)?$/i;
-
-const isWindows = typeof process !== 'undefined' && process.platform === 'win32';
 
 /**
  * Returns normalized path segments, resolving symlinks when the path exists.
@@ -68,11 +67,15 @@ function getSensitiveFileUploadPathBlockReason(
     [
       ...BUILTIN_FILE_UPLOAD_PATH_DENY_SEGMENTS,
       ...(additionalDenySegments ?? []).map(s => s.trim()).filter(Boolean),
-    ].map(s => (isWindows ? s.toLowerCase() : s))
+    ].map(s => s.toLowerCase())
   );
 
-  // Windows: compare segments case-insensitively; map once instead of toLowerCase per iteration.
-  const segmentsForMatch = isWindows ? segments.map(s => s.toLowerCase()) : segments;
+  // Always case-insensitive: Windows and macOS filesystems are case-insensitive by
+  // default, so ~/.Kube/config is the same file as ~/.kube/config. Over-blocking a
+  // case variant on Linux is the safe direction for a credential denylist, and it
+  // keeps this in line with the /i basename rules and the Python SDK.
+  // Map once instead of toLowerCase per iteration.
+  const segmentsForMatch = segments.map(s => s.toLowerCase());
   for (let i = 0; i < segments.length; i++) {
     if (deny.has(segmentsForMatch[i]!)) {
       return `path segment "${segments[i]}" is in the sensitive file upload denylist`;

--- a/ts/packages/core/test/utils/sensitiveFileUploadPaths.test.ts
+++ b/ts/packages/core/test/utils/sensitiveFileUploadPaths.test.ts
@@ -27,6 +27,35 @@ describe('sensitiveFileUploadPaths', () => {
     ).toBe(true);
   });
 
+  it('blocks credential directory segments regardless of case on every platform', () => {
+    // Windows and macOS filesystems are case-insensitive by default, so ~/.Kube/config
+    // is the same file as ~/.kube/config. These basenames are deliberately innocuous
+    // (`config`, `config.json`, ...) so only the segment rule can catch them - a
+    // basename rule would mask a regression here.
+    expect(isBlockedSensitiveFileUploadPath(path.join(os.homedir(), '.Kube', 'config'))).toBe(true);
+    expect(
+      isBlockedSensitiveFileUploadPath(path.join(os.homedir(), '.Docker', 'config.json'))
+    ).toBe(true);
+    expect(isBlockedSensitiveFileUploadPath(path.join(os.homedir(), '.GnuPG', 'pubring.kbx'))).toBe(
+      true
+    );
+    expect(
+      isBlockedSensitiveFileUploadPath(path.join(os.homedir(), '.Azure', 'azureProfile.json'))
+    ).toBe(true);
+    expect(isBlockedSensitiveFileUploadPath(path.join(os.homedir(), '.SSH', 'known_hosts'))).toBe(
+      true
+    );
+  });
+
+  it('matches additional deny segments case-insensitively too', () => {
+    expect(
+      isBlockedSensitiveFileUploadPath(path.join('/data', 'Secrets', 'x.txt'), ['secrets'])
+    ).toBe(true);
+    expect(
+      isBlockedSensitiveFileUploadPath(path.join('/data', 'secrets', 'x.txt'), ['SECRETS'])
+    ).toBe(true);
+  });
+
   it('blocks .env-style basenames', () => {
     expect(isBlockedSensitiveFileUploadPath(path.join('/app', 'repo', '.env'))).toBe(true);
     expect(isBlockedSensitiveFileUploadPath(path.join('/app', 'repo', '.env.local'))).toBe(true);


### PR DESCRIPTION
Fixes #4024

## Problem

`getSensitiveFileUploadPathBlockReason` only lowercased path segments when `process.platform === 'win32'`:

```ts
const isWindows = typeof process !== 'undefined' && process.platform === 'win32';
...
].map(s => (isWindows ? s.toLowerCase() : s))
const segmentsForMatch = isWindows ? segments.map(s => s.toLowerCase()) : segments;
```


macOS filesystems are case-insensitive by default (APFS/HFS+), so ~/.Kube/config and ~/.kube/config are the same file on disk — but only the lowercase spelling was blocked. The capitalised variant was uploaded to S3 and handed to the tool.

The exposure was limited to files whose basename doesn't independently look like a secret, because every basename rule in the same function already is case-insensitive on all platforms (SECRET_LIKE_BASENAME and DEFAULT_PRIVATE_KEY_BASENAME use /i, and basename.toLowerCase() === 'credentials'). So .AWS/credentials was still caught by the basename rule, while .Kube/config, .Docker/config.json, .GnuPG/pubring.kbx and .Azure/azureProfile.json were caught by nothing.

That inconsistency inside a single function is what marks this as an oversight rather than a deliberate platform policy. The guard is on by default (fileUtils.node.ts:305, whenever sensitiveFileUploadProtection !== false).

## Fix

Dropped the platform gate entirely rather than extending it to darwin:

-const isWindows = typeof process !== 'undefined' && process.platform === 'win32';
-    ].map(s => (isWindows ? s.toLowerCase() : s))
+    ].map(s => s.toLowerCase())
-  const segmentsForMatch = isWindows ? segments.map(s => s.toLowerCase()) : segments;
+  const segmentsForMatch = segments.map(s => s.toLowerCase());

The issue offered win32 || darwin as an alternative. I went with dropping the gate because it removes state instead of adding a condition, and it brings segment matching in line with both the /i basename rules five lines below and the Python SDK, which already lowercases unconditionally (python/composio/utils/sensitive_file_upload_paths.py:47). The two SDKs no longer disagree.

The tradeoff is on Linux, where a directory literally named .SSH is genuinely distinct from .ssh and is now also blocked. For a credential denylist with an opt-out, over-blocking is the safe direction. Both the doc comment on line 15 ("Compared case-insensitively on Windows") and the inline comment are updated to say so.

This change can only ever block more, never less — lowercasing both sides makes the previously-blocked set a strict subset of the new one. No caller can see something become allowed. @composio/cli invokes the guard with only a remediation string and no deny segments, so it is unaffected.

## Verification

| Check | Result |
|---|---|
| **Issue repro under `darwin`** | All 8 capitalised variants now blocked |
| **Same under `linux` / `win32`** | Identical — no platform divergence remains |
| **False positives** | `projects/app/document.pdf`, `projects/Kubernetes/README.md` still allowed |
| **Full core suite** | 1039 passed / 3 failed — the same 3 failed before this change (1037 passed) |
| **`tsc --noEmit`** | Exit 0 |
| **Prettier + oxlint** | Clean |

The 3 failures are pre-existing and environmental on the Windows machine used here, unrelated to this change — two are EPERM: symlink (needs Developer Mode), one is a POSIX path-separator assumption in fileUtils.test.ts. Confirmed by stashing and re-running on unmodified next.

## Tests

Added two regression tests to test/utils/sensitiveFileUploadPaths.test.ts:

- blocks credential directory segments regardless of case on every platform — uses deliberately innocuous basenames (config, config.json, pubring.kbx, azureProfile.json) so only the segment rule can catch them; a basename rule would otherwise mask a regression.
- matches additional deny segments case-insensitively too — covers user-supplied additionalDenySegments in both directions.

## Notes

- Changeset included (@composio/core: patch).