### PR TITLE
refactor(core): remove unused `isNewerVersion` helper

### DIFF
--- a/.changeset/remove-unused-version-helper.md
+++ b/.changeset/remove-unused-version-helper.md
@@ -1,0 +1,5 @@
+---
+'@composio/core': patch
+---
+
+Remove the unused internal `isNewerVersion` helper.

--- a/mise.lock
+++ b/mise.lock
@@ -89,23 +89,23 @@ version = "3.12.13"
 backend = "core:python"
 
 [tools.python."platforms.linux-arm64"]
-checksum = "sha256:5779f28830c6c5f32184c41e0a1c4afb355961cf9fbce18f43391d083a2ae924"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260804/cpython-3.12.13+20260804-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+checksum = "sha256:f3510827b61e7a2aa89a1bb7bac73d45521939c489cf43f4699618efaead0611"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260805/cpython-3.12.13+20260805-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
 provenance = "github-attestations"
 
 [tools.python."platforms.linux-x64"]
-checksum = "sha256:ce2c9c5df1b99a962a86d2f457656918ee5f01b2edea080db28416232a1fcb11"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260804/cpython-3.12.13+20260804-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+checksum = "sha256:f04a55ae95e8bd352cdff8da11c344fe609ec84795d106fa91b6620366d786fe"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260805/cpython-3.12.13+20260805-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
 provenance = "github-attestations"
 
 [tools.python."platforms.macos-arm64"]
-checksum = "sha256:b00971ee829e39965e2bda5585666dfdcc74bd1bd97f4b75071b3b05cecf52fd"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260804/cpython-3.12.13+20260804-aarch64-apple-darwin-install_only_stripped.tar.gz"
+checksum = "sha256:a4b36035915038104aabee94d6f02827161da444296881fe4493cb98f70304b2"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260805/cpython-3.12.13+20260805-aarch64-apple-darwin-install_only_stripped.tar.gz"
 provenance = "github-attestations"
 
 [tools.python."platforms.macos-x64"]
-checksum = "sha256:23c1069b954060a875cce80a2d98afe9ca20b8e5244cf8df6c9475497d78bc4c"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260804/cpython-3.12.13+20260804-x86_64-apple-darwin-install_only_stripped.tar.gz"
+checksum = "sha256:0d232711501680a619ea6113046603567d93be3218e326e4357557e771d1aec7"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260805/cpython-3.12.13+20260805-x86_64-apple-darwin-install_only_stripped.tar.gz"
 provenance = "github-attestations"
 
 [[tools.uv]]

--- a/ts/packages/core/src/utils/version.ts
+++ b/ts/packages/core/src/utils/version.ts
@@ -2,23 +2,6 @@ import logger from './logger';
 import { IS_DEVELOPMENT_OR_CI } from './constants';
 import semver from 'semver';
 
-/**
- * Compares two semantic versions and returns true if the first version is newer than the second.
- * @param version1 The first version to compare
- * @param version2 The second version to compare
- * @returns boolean indicating if version1 is newer than version2
- */
-export function isNewerVersion(version1: string, version2: string): boolean {
-  const v1 = version1.split('.').map(Number);
-  const v2 = version2.split('.').map(Number);
-
-  for (let i = 0; i < 3; i++) {
-    if (v1[i] > v2[i]) return true;
-    if (v1[i] < v2[i]) return false;
-  }
-  return false;
-}
-
 const VERSION_CHECK_TIMEOUT_MS = 2_000;
 
 /**


### PR DESCRIPTION
This PR:

- closes #4028
- removes the unused `isNewerVersion` helper from the internal version utility
- avoids defining malformed-version behavior for a helper with no callers or package export
- retains `next`'s tested npm version-check timeout implementation
- adds a patch changeset for `@composio/core`
- refreshes Python 3.12.13 artifact metadata in `mise.lock` after the upstream build was republished

## Verification

- version utility tests: 2 passed
- core typecheck: passed
- changeset validation: passed
- `mise 2026.5.18 lock --platform linux-x64,linux-arm64,macos-arm64,macos-x64`: clean
