### PR TITLE
fix(core): name @composio/core in the upgrade notice instead of the v2 composio-core package

### DIFF
--- a/ts/packages/core/src/utils/version.ts
+++ b/ts/packages/core/src/utils/version.ts
@@ -49,7 +49,7 @@ export async function checkForLatestVersionFromNPM(currentVersion: string) {
 
     if (semver.gt(latestVersion, currentVersionFromPackageJson) && !IS_DEVELOPMENT_OR_CI) {
       logger.info(
-        `🚀 Upgrade available! Your composio-core version (${currentVersionFromPackageJson}) is behind. Latest version: ${latestVersion}.`
+        `🚀 Upgrade available! Your ${packageName} version (${currentVersionFromPackageJson}) is behind. Latest version: ${latestVersion}.`
       );
     }
   } catch (_error) {


### PR DESCRIPTION
Fixes #4030

## Problem

`checkForLatestVersionFromNPM` queried the right package but named the wrong one in the notice it printed:

```ts
// ts/packages/core/src/utils/version.ts:29
const packageName = '@composio/core';
...
// ts/packages/core/src/utils/version.ts:52
`🚀 Upgrade available! Your composio-core version (${currentVersionFromPackageJson}) is behind. …`
```

`composio-core` is the v2 npm package. A v3 user saw a notice naming a package they had not installed, and the obvious next step — `npm i composio-core@latest` — installs the legacy package. That is a downgrade path, not just a wording slip.

Leftover string from the v2 SDK: the surrounding code was migrated to `@composio/core`, the message was not.

## Fix

One line — interpolate the constant already in scope, as the issue suggested:

```diff
-`🚀 Upgrade available! Your composio-core version (${currentVersionFromPackageJson}) is behind. …`
+`🚀 Upgrade available! Your ${packageName} version (${currentVersionFromPackageJson}) is behind. …`
```

I used the constant rather than hardcoding `@composio/core` so the notice and the registry URL now derive from a single source and cannot drift apart again.

## Verification

Ran the issue's reproduction against the fix, with the registry response stubbed and `CI`/`DEVELOPMENT` unset:

```text
🚀 Upgrade available! Your @composio/core version (0.14.1) is behind. Latest version: 0.99.0.
registry URL actually queried: https://registry.npmjs.org/@composio/core/latest
```

The name in the message and the package actually queried now match exactly.

| Check | Result |
|---|---|
| `tsc --noEmit` | exit 0 |
| Full core suite | 1037 passed / 3 failed — identical to unmodified `next` |

The 3 failures are pre-existing and environmental on the Windows machine used here: two `EPERM: symlink` (needs Developer Mode) and one POSIX path-separator assumption in `fileUtils.test.ts`. Confirmed by stashing and re-running against `next`.

## Notes

- No test added. Interpolating the constant makes this class of drift structurally impossible, which is a stronger guarantee than asserting exact log text. There is also a practical cost: #4026's branch introduces `ts/packages/core/test/utils/version.test.ts`, so adding that same new file here would create an add/add conflict between two open PRs. Happy to add coverage as a follow-up once that one lands.
- Related, deliberately left out of scope. `ts/packages/cli/src/effects/find-composio-core-generated.ts:38` has the same stale name, and arguably worse:

```ts
const fix = `Install \`composio-core\` with \`${installCmd} composio-core\`, …`;
```

- The code twelve lines below probes `import composio` — the v3 Python package — so a user following that message runs `uv pip install composio-core`, installs v2, and the check still fails. I left it alone because `@composio/cli` is a separate package with its own release process (it is excluded from changesets), and the two are independent string literals with no shared function, so there is no single root to fix. Worth its own issue.
- I checked the other `composio-core` references repo-wide: the changelog entries and `docs/content/docs/migration-guide/new-sdk.mdx` correctly cite v2 as history, and the remainder are CLI test-fixture directory names. Nothing else needed changing.