### PR TITLE
docs(core): correct getToolkitVersionsFromEnv precedence in JSDoc

### DIFF
--- a/ts/packages/core/src/utils/sdk.ts
+++ b/ts/packages/core/src/utils/sdk.ts
@@ -64,8 +64,8 @@ export function getSDKConfig(baseUrl?: string | null, apiKey?: string | null) {
  *
  * Priority order:
  * 1. If defaultVersions is a string, use it as global version for all toolkits
- * 2. Environment variables (COMPOSIO_TOOLKIT_VERSION_<TOOLKIT_NAME>)
- * 3. User-provided toolkit version mappings (defaultVersions object)
+ * 2. User-provided toolkit version mappings (defaultVersions object)
+ * 3. Environment variables (COMPOSIO_TOOLKIT_VERSION_<TOOLKIT_NAME>)
  * 4. Fallback to 'latest' if no versions are configured
  *
  * @param defaultVersions - Optional default versions configuration (string for global version or object mapping toolkit names to versions)


### PR DESCRIPTION
Fixes #4032

## Problem

The JSDoc on `getToolkitVersionsFromEnv` documented a precedence order the function does not implement:

```ts
// ts/packages/core/src/utils/sdk.ts:65-69
 * 2. Environment variables (COMPOSIO_TOOLKIT_VERSION_<TOOLKIT_NAME>)
 * 3. User-provided toolkit version mappings (defaultVersions object)
```

The implementation spreads user-provided values last, so they win:

```ts
const toolkitVersions = {
  ...toolkitVersionsFromEnv,
  ...userProvidedToolkitVersions,
};
```

Three independent sources already agreed the code is right and the JSDoc was the outlier:

1. The inline comment two lines above the spread — "user provided values act as overrides" (`sdk.ts:91`).
2. `test/core/versions.test.ts:150` (`'should prioritize user-provided versions over environment variables'`) and `:395` (`'should demonstrate priority order: user object > env vars > fallback'`).
3. The Python SDK's docstring for the equivalent `get_toolkit_versions`, which had the order correct.

This misleads anyone debugging a version pin: someone whose `COMPOSIO_TOOLKIT_VERSION_GITHUB` appears to be ignored reads this and concludes the env-var handling is broken, when the real cause is their own `toolkitVersions` object overriding it.

## Fix

Swapped the two lines. Comment-only — no runtime behaviour changes.

```diff
- * 2. Environment variables (COMPOSIO_TOOLKIT_VERSION_<TOOLKIT_NAME>)
- * 3. User-provided toolkit version mappings (defaultVersions object)
+ * 2. User-provided toolkit version mappings (defaultVersions object)
+ * 3. Environment variables (COMPOSIO_TOOLKIT_VERSION_<TOOLKIT_NAME>)
```

I kept this to a pure swap rather than also rewording. The Python docstring is the parity target, and the two lists are now item-for-item identical:

1. If `defaultVersions` is a string, use it as global version for all toolkits
2. User-provided toolkit version mappings (`defaultVersions` object)
3. Environment variables (`COMPOSIO_TOOLKIT_VERSION_<TOOLKIT_NAME>`)
4. Fallback to `'latest'` if no versions are configured

Adding clarifying prose on the TypeScript side alone would have traded one cross-SDK drift for another.

## Verification

Exercised all four documented items against real behaviour, not just the one in the report:

```text
env   : COMPOSIO_TOOLKIT_VERSION_GITHUB=from_env_20250101_00, _SLACK=slack_from_env
user  : { github: "from_user_20260101_00" }
result: { github: 'from_user_20260101_00', slack: 'slack_from_env' }

github winner : from_user_20260101_00   <- user-provided (doc item 2)
slack  winner : slack_from_env          <- env var, untouched by user (doc item 3)
string form   : 20260101_00             <- doc item 1
empty form    : latest                  <- doc item 4
```

The slack case is the one worth noting: items 2 and 3 are not a strict either/or fallback — the two maps merge per toolkit, and env vars still apply for toolkits the user's object does not mention. The numbered list describes that correctly now, since what it orders is precedence.

| Check | Result |
|---|---|
| `tsc --noEmit` | exit 0 |
| `test/core/versions.test.ts` | 32 passed |

I ran the targeted suite rather than the full one: the change is a comment and cannot affect anything outside this file, and those 32 tests are exactly the ones asserting this precedence.

## Notes

- No changeset — comments only, nothing in the published output changes.
- No test added: the existing tests at `versions.test.ts:150` and `:395` already lock this behaviour in. They are what proved the code was correct and the doc was wrong, so the doc is now covered by them too.