### PR TITLE
fix(ci): use locked Node version for Cloudflare E2E

### DIFF
--- a/.github/workflows/ts.release.yml
+++ b/.github/workflows/ts.release.yml
@@ -41,9 +41,9 @@ jobs:
       - name: Setup Node.js, pnpm, Bun
         uses: ./.github/actions/setup-node-pnpm-bun
         with:
-          # Pin Node.js 24 for the release job only: the npm it bundles supports
-          # OIDC trusted publishing, which the toolchain's Node 22 (mise.toml)
-          # does not. Intentionally a release-only override, not centralized.
+          # Keep the release runtime explicitly pinned because trusted publishing
+          # depends on the npm bundled with this Node.js release, even though the
+          # pin currently matches the repository toolchain.
           node-version: '24.17.0'
 
       - name: Install Dependencies

--- a/.github/workflows/ts.test-e2e.yml
+++ b/.github/workflows/ts.test-e2e.yml
@@ -320,7 +320,6 @@ jobs:
         uses: ./.github/actions/setup-node-pnpm-bun
         with:
           enable-turbo-cache: 'true'
-          node-version: '22.22.3'
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
This PR:
- supersedes https://github.com/ComposioHQ/composio/pull/4010 and credits @MGPOCKY for identifying the stale Cloudflare E2E Node override
- lets Cloudflare E2E resolve the exact Node.js version from mise.lock through the shared setup action
- retains the release job's explicit Node.js 24.17.0 publishing pin and corrects its outdated explanation
- verifies the release workflow guard, workflow YAML parsing, formatting, and whitespace checks
