### PR TITLE
fix(py): stop pydantic from stripping object fields with no declared properties

### DIFF
--- a/python/composio/utils/schema_converter.py
+++ b/python/composio/utils/schema_converter.py
@@ -17,7 +17,8 @@ from json_schema_to_pydantic import (
     SchemaError,
     create_model as create_model_from_schema,
 )
-from pydantic import Field, create_model as create_pydantic_model
+from pydantic import BaseModel, ConfigDict, Field
+from pydantic import create_model as create_pydantic_model
 from pydantic_core import core_schema
 
 from composio.utils.logging import get as get_logger
@@ -338,6 +339,26 @@ def _convert_object_with_unsatisfiable_properties(
     )
 
 
+def _create_permissive_object_model(
+    schema: t.Dict[str, t.Any],
+) -> t.Type[BaseModel]:
+    """
+    Create a pydantic model that accepts and preserves arbitrary keys.
+
+    Object schemas with no declared ``properties`` (e.g. a free-form payload
+    envelope like METABASE_POST_API_CARD's ``dataset_query``) would otherwise
+    become zero-field models whose default ``extra='ignore'`` silently strips
+    every key at validation time.
+    """
+    model_name = str(schema.get("title", "GeneratedModel")).replace(" ", "")
+    if not model_name.isidentifier():
+        model_name = "GeneratedModel"
+    return create_pydantic_model(
+        model_name,
+        __config__=ConfigDict(extra="allow"),
+    )
+
+
 def _convert_with_library(
     schema: t.Dict[str, t.Any],
 ) -> t.Union[t.Type, t.Any]:
@@ -356,6 +377,11 @@ def _convert_with_library(
                 return _convert_object_with_unsatisfiable_properties(schema)
             if "title" not in schema:
                 schema = {**schema, "title": "GeneratedModel"}
+            if (
+                not schema.get("properties")
+                and schema.get("additionalProperties") is not False
+            ):
+                return _create_permissive_object_model(schema)
             return create_model_from_schema(
                 schema,
                 allow_undefined_array_items=True,

--- a/python/tests/test_schema_parser.py
+++ b/python/tests/test_schema_parser.py
@@ -1713,5 +1713,94 @@ class TestGetSignatureFormatFromSchemaParams:
         assert {str, int, type(None)} <= set(t.get_args(annotation))
 
 
+class TestObjectSchemaWithoutProperties:
+    """Regression tests for #4023: object schemas with no declared properties
+    must not strip nested content during pydantic validation."""
+
+    def test_bare_object_preserves_arbitrary_keys(self):
+        """An object schema with no properties accepts and keeps any keys."""
+        result = json_schema_to_pydantic_type(
+            {"type": "object", "description": "free-form payload"}
+        )
+
+        assert isinstance(result, type)
+        assert issubclass(result, BaseModel)
+        payload = {"database": 2, "type": "native", "native": {"query": "SELECT 1"}}
+        assert result(**payload).model_dump() == payload
+
+    def test_nested_object_without_properties_round_trips(self):
+        """Repro from #4023: METABASE_POST_API_CARD-shaped schema keeps the
+        content of dataset_query instead of validating it down to {}."""
+        tool_schema = {
+            "title": "PostApiCardRequest",
+            "type": "object",
+            "properties": {
+                "name": {"type": "string", "title": "Name"},
+                "dataset_query": {
+                    "type": "object",
+                    "description": "Query definition in MBQL or native SQL format.",
+                },
+            },
+            "required": ["name", "dataset_query"],
+        }
+        payload = {
+            "name": "test",
+            "dataset_query": {
+                "database": 2,
+                "type": "native",
+                "native": {"query": "SELECT 1"},
+            },
+        }
+
+        model = json_schema_to_model(tool_schema)
+        assert model(**payload).model_dump() == payload
+
+    def test_object_with_additional_properties_schema_is_permissive(self):
+        """No properties but a typed additionalProperties still passes content."""
+        result = json_schema_to_pydantic_type(
+            {"type": "object", "additionalProperties": {"type": "string"}}
+        )
+
+        assert isinstance(result, type)
+        assert issubclass(result, BaseModel)
+        payload = {"key": "value"}
+        assert result(**payload).model_dump() == payload
+
+    def test_object_with_properties_keeps_declared_field_validation(self):
+        """Schemas that declare properties still validate declared fields."""
+        result = json_schema_to_pydantic_type(
+            {
+                "type": "object",
+                "title": "TypedModel",
+                "properties": {"field": {"type": "string"}},
+                "required": ["field"],
+            }
+        )
+
+        assert issubclass(result, BaseModel)
+        assert result(field="ok").model_dump()["field"] == "ok"
+        with pytest.raises(ValidationError):
+            result()
+
+    def test_object_with_additional_properties_false_stays_strict(self):
+        """additionalProperties: false with no properties keeps the old
+        zero-field behavior instead of becoming permissive."""
+        result = json_schema_to_pydantic_type(
+            {"type": "object", "additionalProperties": False}
+        )
+
+        assert issubclass(result, BaseModel)
+        assert result(foo=1).model_dump() == {}
+
+    def test_permissive_model_name_falls_back_on_invalid_title(self):
+        """Titles that are not valid identifiers fall back to GeneratedModel."""
+        result = json_schema_to_pydantic_type(
+            {"type": "object", "title": "123 bad-title!"}
+        )
+
+        assert issubclass(result, BaseModel)
+        assert result.__name__ == "GeneratedModel"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary 
Tool schemas that declare a field as `{"type": "object"}` with no `properties` (free-form payload envelopes like `METABASE_POST_API_CARD`'s `dataset_query`) get converted into zero-field pydantic models. Pydantic's default `extra='ignore'` then silently drops every key during validation, so the payload reaches Composio's execute endpoint as `{}`. No error surfaces client-side; the downstream API fails (Metabase: `null value in column "database_id"`).

Fixes #4023 


## Changes
- `composio/utils/schema_converter.py`: object schemas with no declared `properties` now generate a pydantic model with `ConfigDict(extra="allow")`, so nested content passes through validation unchanged. `additionalProperties: false` keeps the previous strict behavior.
- `tests/test_schema_parser.py`: new `TestObjectSchemaWithoutProperties` regression suite, including the `METABASE_POST_API_CARD` repro from the issue.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [ ] Documentation
- [ ] Breaking change

## How Has This Been Tested?
- Reproduced the bug on `next` with the issue's repro: a payload validated through the generated model comes back with `dataset_query: {}`. With this change the same payload round-trips intact.
- New regression tests: bare object schema round-trips arbitrary keys, the METABASE-shaped nested schema survives `json_schema_to_model` validation, typed `additionalProperties` stays permissive, `additionalProperties: false` stays strict, schemas with declared properties keep normal field validation.
- Full Python suite: `nox -s tst` → 917 passed, 33 skipped. Ruff, ruff format, and mypy clean on both touched files.
- Environment: Python 3.12, pydantic 2.13.4, macOS.

## Checklist
- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed
- [x] I updated documentation as needed
- [x] I added tests or explain why not applicable
- [x] I added a changeset if this change affects published packages

## Additional context
- Python-only change, so no changeset (matches repo convention for python-only PRs).
- Docs not affected: this restores intended pass-through behavior, no API surface change.
- Related to #2406, which fixed top-level string-encoded arguments. This one is about nested content being stripped by the generated pydantic model itself, before the #2406 normalizer ever runs.
