### PR TITLE
docs: toolkit-discovery entry points + version-policy CI check (eval findings round 2)

### DIFF
--- a/docs/content/docs/auth-configuration/custom-auth-params.mdx
+++ b/docs/content/docs/auth-configuration/custom-auth-params.mdx
@@ -21,7 +21,7 @@ Pass `customAuthParams` in the `tools.execute()` call to inject your own token a
 ```python
 from composio import Composio
 
-composio = Composio()
+composio = Composio(toolkit_versions={"googlecalendar": "latest"})
 
 result = composio.tools.execute(
     slug="GOOGLECALENDAR_LIST_EVENTS",
@@ -46,6 +46,7 @@ import { Composio } from "@composio/core";
 
 const composio = new Composio({
   apiKey: process.env.COMPOSIO_API_KEY,
+  toolkitVersions: { googlecalendar: "latest" },
 });
 
 const result = await composio.tools.execute(
@@ -100,7 +101,7 @@ Before Execute Modifiers are a way to modify the parameters of a tool before it 
 from composio import Composio, before_execute
 from composio.types import ToolExecuteParams
 
-composio = Composio()
+composio = Composio(toolkit_versions={"notion": "latest"})
 
 
 @before_execute(toolkits=["NOTION"])

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -4,7 +4,7 @@ description: Build an AI agent with access to 1000+ tools
 keywords: [tutorial, setup, first agent]
 ---
 
-Build your first AI agent with Composio Tools. You'll create a [session](/docs/how-composio-works) for a user, give your agent access to [tools](/docs/how-composio-works), and let it take action across 1000+ apps.
+Build your first AI agent with Composio Tools. You'll create a [session](/docs/how-composio-works) for a user, give your agent access to [tools](/docs/how-composio-works), and let it take action across [1000+ apps](/toolkits).
 
 <Callout type="info">
 The TypeScript SDK is ESM-only and requires Node.js 22.22.3 or newer. Use `import` syntax rather than CommonJS `require()`.

--- a/docs/content/docs/sessions-vs-direct-execution.mdx
+++ b/docs/content/docs/sessions-vs-direct-execution.mdx
@@ -122,7 +122,10 @@ Fetch tools by slug or toolkit. Pass them to your LLM or call `tools.execute()` 
 from composio import Composio
 from composio_openai import OpenAIProvider
 
-composio = Composio(provider=OpenAIProvider())
+composio = Composio(
+    provider=OpenAIProvider(),
+    toolkit_versions={"github": "latest"},  # required for direct execution
+)
 
 # Fetch specific tools
 tools = composio.tools.get(
@@ -153,6 +156,7 @@ import { OpenAIProvider } from '@composio/openai';
 const composio = new Composio({
   apiKey: process.env.COMPOSIO_API_KEY,
   provider: new OpenAIProvider(),
+  toolkitVersions: { github: 'latest' },  // required for direct execution
 });
 
 // Fetch specific tools

--- a/docs/content/docs/tools-direct/executing-tools.mdx
+++ b/docs/content/docs/tools-direct/executing-tools.mdx
@@ -213,6 +213,8 @@ If you just want to call a tool without using any framework or LLM provider, you
 </Callout>
 
 <Callout type="info">
+**Finding a toolkit and tool:** browse the [Toolkits catalog](/toolkits) — each toolkit page lists its tool slugs and current version — or search by task from the CLI: `composio search "send an email"`. You can also [search tools semantically](/docs/tools-direct/fetching-tools#by-search-experimental) from the SDK.
+
 **Finding tool parameters and types:**
 
 **Platform UI**: [Auth Configs](https://dashboard.composio.dev/~/project/auth-configs?utm_source=docs&utm_medium=content&utm_campaign=docs-tools-direct-executing-tools) → Select your toolkit → Tools & Triggers → Select the tool to see its required and optional parameters

--- a/docs/content/docs/tools-direct/fetching-tools.mdx
+++ b/docs/content/docs/tools-direct/fetching-tools.mdx
@@ -12,6 +12,8 @@ If you're building an agent, we recommend using [sessions](/docs/configuring-ses
 
 Fetch specific tools, filter by permissions or search, and inspect schemas for type information. Tools are automatically formatted for your provider.
 
+Not sure which toolkit covers your use case? Browse the [Toolkits catalog](/toolkits) — each toolkit page lists its tool slugs — or [search by task](#by-search-experimental) below.
+
 ## Basic usage
 
 <Tabs groupId="language" items={['Python', 'TypeScript']} persist>

--- a/docs/content/docs/tools-direct/modify-tool-behavior/after-execution-modifiers.mdx
+++ b/docs/content/docs/tools-direct/modify-tool-behavior/after-execution-modifiers.mdx
@@ -122,7 +122,10 @@ from composio import Composio, after_execute
 from composio.types import ToolExecutionResponse
 from composio_crewai import CrewAIProvider
 
-composio = Composio(provider=CrewAIProvider())
+composio = Composio(
+    provider=CrewAIProvider(),
+    toolkit_versions={"hackernews": "latest"},
+)
 
 @after_execute(tools=["HACKERNEWS_GET_USER"])
 def after_execute_modifier(
@@ -156,6 +159,7 @@ import { v4 as uuidv4 } from "uuid";
 const composio = new Composio({
   apiKey: process.env.COMPOSIO_API_KEY,
   provider: new VercelProvider(),
+  toolkitVersions: { hackernews: "latest" },
 });
 
 const userId = uuidv4();

--- a/docs/content/docs/tools-direct/modify-tool-behavior/before-execution-modifiers.mdx
+++ b/docs/content/docs/tools-direct/modify-tool-behavior/before-execution-modifiers.mdx
@@ -34,7 +34,7 @@ from openai import OpenAI
 from composio import Composio, before_execute
 from composio.types import ToolExecuteParams
 
-composio = Composio()
+composio = Composio(toolkit_versions={"hackernews": "latest"})
 openai_client = OpenAI()
 user_id = "user@email.com"
 
@@ -201,7 +201,7 @@ def audit_path(ctx) -> str | bool:
     # return a new path string, or False to abort the upload
     return ctx["path"]
 
-composio = Composio()
+composio = Composio(toolkit_versions={"googledrive": "latest"})
 composio.tools.execute(
     "GOOGLEDRIVE_UPLOAD_FILE",
     {"file_to_upload": "/path/to/document.pdf"},

--- a/docs/lib/llm-guardrails/direct-execution.ts
+++ b/docs/lib/llm-guardrails/direct-execution.ts
@@ -75,5 +75,6 @@ const result = await composio.tools.execute("GITHUB_CREATE_ISSUE", {
 3. **A toolkit version is required** — configure \`toolkit_versions\` (Python) / \`toolkitVersions\` (TypeScript) at SDK init, or pass \`version\` per execute call; omitting both raises \`ToolVersionRequiredError\`.
 4. **Provider at init** — \`Composio(provider=OpenAIProvider())\` in Python, \`new Composio({ provider: new OpenAIProvider() })\` in TypeScript. Defaults to OpenAI if omitted.
 5. **Correct provider imports** — \`composio_<provider>\` for Python, \`@composio/<provider>\` for TypeScript. For OpenAI Agents SDK use \`composio_openai_agents\` / \`@composio/openai-agents\`.
+6. **Finding toolkit and tool slugs** — browse the Toolkits catalog at https://docs.composio.dev/toolkits (each toolkit page lists tool slugs and versions), or search by task with the CLI: \`composio search "<what you want to do>"\`.
 ${TERMINOLOGY_MIGRATION}
 `;

--- a/docs/tests/static/execute-version.test.ts
+++ b/docs/tests/static/execute-version.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Toolkit-version policy for direct-execution samples.
+ *
+ * Direct tool execution requires a toolkit version — `tools.execute()`
+ * without one raises ToolVersionRequiredError at runtime. A 97-run agent
+ * eval of the docs found the top failure (72/97 runs) was readers copying
+ * version-less `tools.execute()` samples.
+ *
+ * Rule: any authored MDX page whose code fences call `tools.execute(` must
+ * also show version configuration somewhere in its code fences — one of
+ * `toolkit_versions` / `toolkitVersions` (constructor), `version=` /
+ * `version:` (per-call), or a `COMPOSIO_TOOLKIT_VERSION_*` env var.
+ *
+ * Scope: content/docs and content/examples. Excluded: content/reference
+ * (generated upstream), changelog (historical records), and
+ * docs/migration-guide (point-in-time documents that may show old APIs).
+ * The LLM guardrail blocks appended to .md responses are checked too —
+ * they are samples agents copy verbatim.
+ */
+import { describe, test, expect } from "bun:test";
+import { readdir, readFile } from "fs/promises";
+import { join, relative } from "path";
+
+import {
+  SESSION_GUARDRAILS,
+  DIRECT_EXECUTION_GUARDRAILS,
+} from "../../lib/llm-guardrails";
+
+const CONTENT_DIRS = ["docs", "examples"].map((dir) =>
+  join(import.meta.dir, "../../content", dir),
+);
+const CONTENT_ROOT = join(import.meta.dir, "../../content");
+const EXCLUDED_PATH_SEGMENTS = ["docs/migration-guide/"];
+
+const EXECUTE_CALL_RE = /\btools\.execute\s*\(/;
+const VERSION_TOKEN_RE =
+  /toolkit_versions|toolkitVersions|version\s*[=:]|COMPOSIO_TOOLKIT_VERSION_|dangerously_skip_version_check|dangerouslySkipVersionCheck/;
+
+async function findMdxFiles(dir: string): Promise<string[]> {
+  const results: string[] = [];
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return results;
+  }
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...(await findMdxFiles(fullPath)));
+    } else if (entry.name.endsWith(".mdx")) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+/** Concatenated contents of all fenced code blocks in a document. */
+function fencedCode(content: string): string {
+  const fences: string[] = [];
+  let inFence = false;
+  for (const line of content.split("\n")) {
+    if (/^\s*(```|~~~)/.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) fences.push(line);
+  }
+  return fences.join("\n");
+}
+
+function violates(content: string): boolean {
+  const code = fencedCode(content);
+  return EXECUTE_CALL_RE.test(code) && !VERSION_TOKEN_RE.test(code);
+}
+
+describe("direct-execution samples show toolkit versions", () => {
+  test("every authored page with a tools.execute() sample shows version configuration", async () => {
+    const files = (
+      await Promise.all(CONTENT_DIRS.map((dir) => findMdxFiles(dir)))
+    ).flat();
+    const failures: string[] = [];
+
+    for (const file of files) {
+      const relPath = relative(CONTENT_ROOT, file);
+      if (EXCLUDED_PATH_SEGMENTS.some((seg) => relPath.startsWith(seg))) {
+        continue;
+      }
+      const content = await readFile(file, "utf-8");
+      if (violates(content)) {
+        failures.push(relPath);
+      }
+    }
+
+    expect(
+      failures,
+      `Pages with tools.execute() samples but no version configuration ` +
+        `(add toolkit_versions/toolkitVersions to the constructor or ` +
+        `version= per call — see /docs/tools-direct/toolkit-versioning):\n` +
+        failures.map((f) => `  - ${f}`).join("\n"),
+    ).toEqual([]);
+  });
+
+  test("LLM guardrail blocks with tools.execute() samples show version configuration", () => {
+    for (const [name, guardrails] of [
+      ["SESSION_GUARDRAILS", SESSION_GUARDRAILS],
+      ["DIRECT_EXECUTION_GUARDRAILS", DIRECT_EXECUTION_GUARDRAILS],
+    ] as const) {
+      expect(
+        violates(guardrails),
+        `${name} contains a tools.execute() sample without version configuration`,
+      ).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## What

Round 2 of fixes from the 97-agent docs eval (findings: ctx.composio.io/soumya/docs-agent-eval/findings-97-run.md). Follow-up to #3999.

## Commit 1 — toolkit-discovery entry points (eval finding 3)

51/97 agents struggled to identify the right toolkit; 15 abandoned the docs for the raw REST API. The catalog and search already exist and score well (46/97 praised them once found) — these edits wire them into the paths readers actually take:

- Quickstart intro: "1000+ apps" now links to the /toolkits catalog
- executing-tools + fetching-tools: a "finding a toolkit and tool" pointer (catalog, `composio search`, semantic search) before the parameter-finding guidance
- direct-execution LLM guardrails: a discovery rule, so AI readers stop inventing their own path via the REST API

## Commit 2 — version-policy static test (the durable half of eval finding 1)

The content fix for the 72/97 `ToolVersionRequiredError` failure landed in #3999; this keeps it fixed. New `tests/static/execute-version.test.ts`: any authored page whose code fences call `tools.execute()` must show version configuration in its fences; the LLM guardrail blocks are held to the same rule. Changelog, generated reference, and migration guides are exempt as historical/point-in-time records.

Running the new rule against current content caught **five more pages** shipping version-less execute samples that the eval never visited — including sessions-vs-direct-execution. Fixed in the same commit.

## Verification

- `bun test tests/static/` — 145 pass (including the new test)
- Negative check verified: removing a version token from a page fails the test with an actionable message naming the file
- `bun run lint:links` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)