### PR TITLE
fix(core): add type:object to nested schema nodes for strict OpenAPI consumers

### DIFF
--- a/.changeset/ensure-object-type-on-properties.md
+++ b/.changeset/ensure-object-type-on-properties.md
@@ -1,0 +1,5 @@
+---
+'@composio/core': patch
+---
+
+Add `type: "object"` to nested JSON Schema nodes that carry `properties` without an explicit type, so tool schemas work with strict OpenAPI 3.0 consumers like Google Gemini.

--- a/.changeset/normalize-google-object-types.md
+++ b/.changeset/normalize-google-object-types.md
@@ -1,0 +1,5 @@
+---
+'@composio/google': patch
+---
+
+Add missing object types to nested Google GenAI tool schemas so Gemini accepts function declarations with property maps.

--- a/ts/packages/core/src/index.ts
+++ b/ts/packages/core/src/index.ts
@@ -7,6 +7,7 @@ export type { BaseComposioProvider } from './provider/BaseProvider';
 export {
   dereferenceJsonSchema,
   deduplicateJsonSchemaRequiredArrays,
+  ensureObjectTypeOnProperties,
   jsonSchemaToZodSchema,
   removeNonRequiredProperties,
 } from './utils/jsonSchema';

--- a/ts/packages/core/src/provider/OpenAIProvider.ts
+++ b/ts/packages/core/src/provider/OpenAIProvider.ts
@@ -16,7 +16,10 @@ import { ExecuteToolModifiers } from '../types/modifiers.types';
 import { ExecuteToolFnOptions } from '../types/provider.types';
 import { McpUrlResponse, McpServerGetResponse } from '../types/mcp.types';
 import { normalizeToolArguments } from '../utils/toolArguments';
-import { deduplicateJsonSchemaRequiredArrays } from '../utils/jsonSchema';
+import {
+  deduplicateJsonSchemaRequiredArrays,
+  ensureObjectTypeOnProperties,
+} from '../utils/jsonSchema';
 
 export type OpenAiTool = OpenAI.ChatCompletionTool;
 export type OpenAiToolCollection = Array<OpenAiTool>;
@@ -97,7 +100,9 @@ export class OpenAIProvider extends BaseNonAgenticProvider<
     const formattedSchema: OpenAI.FunctionDefinition = {
       name: tool.slug,
       description: tool.description,
-      parameters: deduplicateJsonSchemaRequiredArrays(tool.inputParameters),
+      parameters: ensureObjectTypeOnProperties(
+        deduplicateJsonSchemaRequiredArrays(tool.inputParameters)
+      ),
     };
     return {
       type: 'function',

--- a/ts/packages/core/src/provider/OpenAIProvider.ts
+++ b/ts/packages/core/src/provider/OpenAIProvider.ts
@@ -16,10 +16,7 @@ import { ExecuteToolModifiers } from '../types/modifiers.types';
 import { ExecuteToolFnOptions } from '../types/provider.types';
 import { McpUrlResponse, McpServerGetResponse } from '../types/mcp.types';
 import { normalizeToolArguments } from '../utils/toolArguments';
-import {
-  deduplicateJsonSchemaRequiredArrays,
-  ensureObjectTypeOnProperties,
-} from '../utils/jsonSchema';
+import { deduplicateJsonSchemaRequiredArrays } from '../utils/jsonSchema';
 
 export type OpenAiTool = OpenAI.ChatCompletionTool;
 export type OpenAiToolCollection = Array<OpenAiTool>;
@@ -100,9 +97,7 @@ export class OpenAIProvider extends BaseNonAgenticProvider<
     const formattedSchema: OpenAI.FunctionDefinition = {
       name: tool.slug,
       description: tool.description,
-      parameters: ensureObjectTypeOnProperties(
-        deduplicateJsonSchemaRequiredArrays(tool.inputParameters)
-      ),
+      parameters: deduplicateJsonSchemaRequiredArrays(tool.inputParameters),
     };
     return {
       type: 'function',

--- a/ts/packages/core/src/utils/jsonSchema.ts
+++ b/ts/packages/core/src/utils/jsonSchema.ts
@@ -265,20 +265,43 @@ export function dereferenceJsonSchema<T = unknown>(
  * 3.0 strictly and rejects function declarations whose nested objects are
  * missing the `type` (see https://github.com/ComposioHQ/composio/issues/4022).
  *
- * The function is recursive and handles `items`, `properties`, `anyOf`,
- * `oneOf`, and `allOf` branches so nested objects at any depth are fixed.
- * Nodes that already declare a `type` are left untouched.
+ * The function follows JSON Schema's schema-bearing keywords while keeping
+ * property maps and instance values as containers. Nodes that already declare
+ * a `type` are left untouched.
  */
 export function ensureObjectTypeOnProperties<T = unknown>(schema: T): T {
-  const instanceValueKeywords = new Set(['const', 'default', 'enum', 'examples']);
+  type WalkMode = 'schema' | 'schema-array' | 'schema-map' | 'dependencies-map' | 'value';
 
-  function walk(value: unknown, isSchema: boolean, depth = 0): unknown {
+  const schemaKeywords = new Set([
+    'additionalItems',
+    'additionalProperties',
+    'contains',
+    'contentSchema',
+    'else',
+    'if',
+    'not',
+    'propertyNames',
+    'then',
+    'unevaluatedItems',
+    'unevaluatedProperties',
+  ]);
+  const schemaArrayKeywords = new Set(['allOf', 'anyOf', 'oneOf', 'prefixItems']);
+  const schemaMapKeywords = new Set([
+    '$defs',
+    'definitions',
+    'dependentSchemas',
+    'patternProperties',
+    'properties',
+  ]);
+
+  function walk(value: unknown, mode: WalkMode, depth = 0): unknown {
     if (depth > MAX_NODE_DEPTH) {
       throw new RangeError(`JSON Schema exceeds maximum nesting depth of ${MAX_NODE_DEPTH}`);
     }
 
     if (Array.isArray(value)) {
-      return value.map(item => walk(item, isSchema, depth + 1));
+      const itemMode = mode === 'schema-array' ? 'schema' : 'value';
+      return value.map(item => walk(item, itemMode, depth + 1));
     }
 
     if (!isPlainObject(value)) return value;
@@ -286,17 +309,35 @@ export function ensureObjectTypeOnProperties<T = unknown>(schema: T): T {
     const clone: Record<string, unknown> = {};
     for (const [key, child] of Object.entries(value)) {
       if (POLLUTING_KEYS.has(key)) continue;
-      clone[key] = walk(child, isSchema && !instanceValueKeywords.has(key), depth + 1);
+
+      let childMode: WalkMode = 'value';
+      if (mode === 'schema-map') {
+        childMode = 'schema';
+      } else if (mode === 'dependencies-map') {
+        childMode = Array.isArray(child) ? 'value' : 'schema';
+      } else if (mode === 'schema') {
+        if (schemaMapKeywords.has(key)) {
+          childMode = 'schema-map';
+        } else if (schemaArrayKeywords.has(key) || (key === 'items' && Array.isArray(child))) {
+          childMode = 'schema-array';
+        } else if (schemaKeywords.has(key) || key === 'items') {
+          childMode = 'schema';
+        } else if (key === 'dependencies') {
+          childMode = 'dependencies-map';
+        }
+      }
+
+      clone[key] = walk(child, childMode, depth + 1);
     }
 
-    if (isSchema && clone.properties !== undefined && clone.type === undefined) {
+    if (mode === 'schema' && clone.properties !== undefined && clone.type === undefined) {
       clone.type = 'object';
     }
 
     return clone;
   }
 
-  return walk(schema, true) as T;
+  return walk(schema, 'schema') as T;
 }
 
 /**

--- a/ts/packages/core/src/utils/jsonSchema.ts
+++ b/ts/packages/core/src/utils/jsonSchema.ts
@@ -270,13 +270,15 @@ export function dereferenceJsonSchema<T = unknown>(
  * Nodes that already declare a `type` are left untouched.
  */
 export function ensureObjectTypeOnProperties<T = unknown>(schema: T): T {
-  function walk(value: unknown, depth = 0): unknown {
+  const instanceValueKeywords = new Set(['const', 'default', 'enum', 'examples']);
+
+  function walk(value: unknown, isSchema: boolean, depth = 0): unknown {
     if (depth > MAX_NODE_DEPTH) {
       throw new RangeError(`JSON Schema exceeds maximum nesting depth of ${MAX_NODE_DEPTH}`);
     }
 
     if (Array.isArray(value)) {
-      return value.map(item => walk(item, depth + 1));
+      return value.map(item => walk(item, isSchema, depth + 1));
     }
 
     if (!isPlainObject(value)) return value;
@@ -284,17 +286,17 @@ export function ensureObjectTypeOnProperties<T = unknown>(schema: T): T {
     const clone: Record<string, unknown> = {};
     for (const [key, child] of Object.entries(value)) {
       if (POLLUTING_KEYS.has(key)) continue;
-      clone[key] = walk(child, depth + 1);
+      clone[key] = walk(child, isSchema && !instanceValueKeywords.has(key), depth + 1);
     }
 
-    if (clone.properties !== undefined && clone.type === undefined) {
+    if (isSchema && clone.properties !== undefined && clone.type === undefined) {
       clone.type = 'object';
     }
 
     return clone;
   }
 
-  return walk(schema) as T;
+  return walk(schema, true) as T;
 }
 
 /**

--- a/ts/packages/core/src/utils/jsonSchema.ts
+++ b/ts/packages/core/src/utils/jsonSchema.ts
@@ -259,6 +259,45 @@ export function dereferenceJsonSchema<T = unknown>(
 }
 
 /**
+ * Returns a deep-cloned JSON Schema in which every node that carries a
+ * `properties` keyword also carries `type: "object"` when it has no explicit
+ * `type`. OpenAI tolerates the omission, but Google Gemini enforces OpenAPI
+ * 3.0 strictly and rejects function declarations whose nested objects are
+ * missing the `type` (see https://github.com/ComposioHQ/composio/issues/4022).
+ *
+ * The function is recursive and handles `items`, `properties`, `anyOf`,
+ * `oneOf`, and `allOf` branches so nested objects at any depth are fixed.
+ * Nodes that already declare a `type` are left untouched.
+ */
+export function ensureObjectTypeOnProperties<T = unknown>(schema: T): T {
+  function walk(value: unknown, depth = 0): unknown {
+    if (depth > MAX_NODE_DEPTH) {
+      throw new RangeError(`JSON Schema exceeds maximum nesting depth of ${MAX_NODE_DEPTH}`);
+    }
+
+    if (Array.isArray(value)) {
+      return value.map(item => walk(item, depth + 1));
+    }
+
+    if (!isPlainObject(value)) return value;
+
+    const clone: Record<string, unknown> = {};
+    for (const [key, child] of Object.entries(value)) {
+      if (POLLUTING_KEYS.has(key)) continue;
+      clone[key] = walk(child, depth + 1);
+    }
+
+    if (clone.properties !== undefined && clone.type === undefined) {
+      clone.type = 'object';
+    }
+
+    return clone;
+  }
+
+  return walk(schema) as T;
+}
+
+/**
  * Returns a deep-cloned JSON Schema whose `required` arrays contain each entry
  * at most once. Duplicate entries are invalid in JSON Schema 2020-12 but do
  * not change the schema's meaning, so preserving the first occurrence is safe.

--- a/ts/packages/core/test/utils/jsonSchema.test.ts
+++ b/ts/packages/core/test/utils/jsonSchema.test.ts
@@ -666,4 +666,27 @@ describe('ensureObjectTypeOnProperties', () => {
     ensureObjectTypeOnProperties(schema);
     expect(schema.properties.target).not.toHaveProperty('type');
   });
+
+  it('does not inject type:object into instance-value keywords (const, default, enum, examples)', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        choice: {
+          type: 'object',
+          properties: { id: { type: 'string' } },
+          default: { properties: { should_not_gain_type: true } },
+          const: { properties: { marker: true } },
+          examples: [{ properties: { marker: true } }],
+          enum: [{ properties: { marker: true } }],
+        },
+      },
+    };
+
+    const result = ensureObjectTypeOnProperties(schema) as typeof schema;
+    const choice = result.properties.choice as Record<string, unknown>;
+    expect((choice.default as Record<string, unknown>).type).toBeUndefined();
+    expect((choice.const as Record<string, unknown>).type).toBeUndefined();
+    expect((choice.examples as Record<string, unknown>[])[0].type).toBeUndefined();
+    expect((choice.enum as Record<string, unknown>[])[0].type).toBeUndefined();
+  });
 });

--- a/ts/packages/core/test/utils/jsonSchema.test.ts
+++ b/ts/packages/core/test/utils/jsonSchema.test.ts
@@ -689,4 +689,31 @@ describe('ensureObjectTypeOnProperties', () => {
     expect((choice.examples as Record<string, unknown>[])[0].type).toBeUndefined();
     expect((choice.enum as Record<string, unknown>[])[0].type).toBeUndefined();
   });
+
+  it('does not treat a properties map as a schema when a field is named properties', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        properties: {
+          properties: {
+            name: { type: 'string' },
+          },
+        },
+      },
+    };
+
+    const result = ensureObjectTypeOnProperties(schema) as {
+      properties: Record<string, unknown>;
+    };
+
+    expect(result.properties).toEqual({
+      properties: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+        },
+      },
+    });
+    expect(result.properties).not.toHaveProperty('type');
+  });
 });

--- a/ts/packages/core/test/utils/jsonSchema.test.ts
+++ b/ts/packages/core/test/utils/jsonSchema.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import {
   deduplicateJsonSchemaRequiredArrays,
   dereferenceJsonSchema,
+  ensureObjectTypeOnProperties,
 } from '../../src/utils/jsonSchema';
 import { JsonSchemaRefResolutionError } from '../../src/errors/ValidationErrors';
 import logger from '../../src/utils/logger';
@@ -592,5 +593,77 @@ describe('deduplicateJsonSchemaRequiredArrays', () => {
 
     expect(tool.inputParameters?.required).toEqual(['name']);
     expect(tool.inputParameters?.properties.options.required).toEqual(['enabled']);
+  });
+});
+
+describe('ensureObjectTypeOnProperties', () => {
+  it('adds type:object to nested nodes that have properties but no type', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        target: {
+          properties: {
+            name: { type: 'string' },
+          },
+        },
+      },
+    };
+
+    const result = ensureObjectTypeOnProperties(schema);
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        target: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+          },
+        },
+      },
+    });
+  });
+
+  it('leaves nodes that already declare a type untouched', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        target: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+        },
+      },
+    };
+
+    const result = ensureObjectTypeOnProperties(schema);
+    expect(result).toEqual(schema);
+  });
+
+  it('handles deeply nested properties inside array items', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        list: {
+          type: 'array',
+          items: {
+            properties: { id: { type: 'string' } },
+          },
+        },
+      },
+    };
+
+    const result = ensureObjectTypeOnProperties(schema) as typeof schema;
+    expect(result.properties.list.items).toHaveProperty('type', 'object');
+  });
+
+  it('does not mutate the input schema', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        target: { properties: { name: { type: 'string' } } },
+      },
+    };
+
+    ensureObjectTypeOnProperties(schema);
+    expect(schema.properties.target).not.toHaveProperty('type');
   });
 });

--- a/ts/packages/providers/google/src/index.ts
+++ b/ts/packages/providers/google/src/index.ts
@@ -17,6 +17,7 @@ import {
   McpServerGetResponse,
   normalizeToolArguments,
   deduplicateJsonSchemaRequiredArrays,
+  ensureObjectTypeOnProperties,
 } from '@composio/core';
 import { FunctionDeclaration, Schema } from '@google/genai';
 
@@ -128,7 +129,9 @@ export class GoogleProvider extends BaseNonAgenticProvider<
    * ```
    */
   wrapTool(tool: Tool): GoogleTool {
-    const inputParameters = deduplicateJsonSchemaRequiredArrays(tool.inputParameters);
+    const inputParameters = ensureObjectTypeOnProperties(
+      deduplicateJsonSchemaRequiredArrays(tool.inputParameters)
+    );
 
     return {
       name: tool.slug,

--- a/ts/packages/providers/google/test/google.test.ts
+++ b/ts/packages/providers/google/test/google.test.ts
@@ -96,6 +96,25 @@ describe('GoogleProvider', () => {
 
       expect(wrapped.parameters?.required).toEqual(['input']);
     });
+
+    it('injects type:object into nested properties for strict OpenAPI consumers', () => {
+      const wrapped = provider.wrapTool({
+        ...mockTool,
+        inputParameters: {
+          type: 'object',
+          properties: {
+            target: {
+              properties: { name: { type: 'string' } },
+            },
+          },
+        },
+      });
+
+      const params = wrapped.parameters as unknown as {
+        properties: { target: { type?: string } };
+      };
+      expect(params.properties.target.type).toBe('object');
+    });
   });
 
   describe('wrapTools', () => {

--- a/ts/packages/providers/google/test/google.test.ts
+++ b/ts/packages/providers/google/test/google.test.ts
@@ -97,13 +97,13 @@ describe('GoogleProvider', () => {
       expect(wrapped.parameters?.required).toEqual(['input']);
     });
 
-    it('injects type:object into nested properties for strict OpenAPI consumers', () => {
+    it('normalizes nested object schemas without treating property maps as schemas', () => {
       const wrapped = provider.wrapTool({
         ...mockTool,
         inputParameters: {
           type: 'object',
           properties: {
-            target: {
+            properties: {
               properties: { name: { type: 'string' } },
             },
           },
@@ -111,9 +111,15 @@ describe('GoogleProvider', () => {
       });
 
       const params = wrapped.parameters as unknown as {
-        properties: { target: { type?: string } };
+        properties: Record<string, unknown>;
       };
-      expect(params.properties.target.type).toBe('object');
+      expect(params.properties).toEqual({
+        properties: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+        },
+      });
+      expect(params.properties).not.toHaveProperty('type');
     });
   });
 


### PR DESCRIPTION
When the Composio API returns tool schemas where nested property-bearing nodes omit `type: "object"`, OpenAI accepts them but Google Gemini rejects the function declarations with HTTP 400 (`properties only allowed for OBJECT type`).

This PR adds `ensureObjectTypeOnProperties`, a structure-aware JSON Schema normalizer, and applies it at the `GoogleProvider.wrapTool` boundary after required-array deduplication. The normalizer deep-clones its input, follows schema-bearing keywords recursively, preserves property maps and instance-valued keywords, handles arrays and combiners, and respects the existing depth cap.

Regression coverage proves the missing type is added for nested Google schemas without corrupting a legitimate field named `properties`. The change carries patch Changesets for both `@composio/core` and `@composio/google`.

Closes #4022.
