### PR TITLE
fix(cli): resolve multi-word toolkits from tool slugs

### DIFF
--- a/ts/packages/cli/CHANGELOG.md
+++ b/ts/packages/cli/CHANGELOG.md
@@ -26,6 +26,17 @@
   credential fields, and schema warnings no longer print raw response values.
 - `composio login --poll` now reports unreadable cache files as I/O errors
   instead of treating them as invalid session data.
+- Tools belonging to multi-word toolkits now resolve to the right toolkit.
+  `composio tools execute GOOGLE_ANALYTICS_RUN_REPORT --account <alias>`
+  previously looked for a `google` account instead of a `google_analytics` one,
+  because the toolkit was guessed from the text before the first underscore.
+  The toolkit is now matched against the known toolkit list, longest prefix
+  first. This also corrects the toolkit shown in errors, file uploads, trigger
+  listening, and telemetry.
+- Session meta tools such as `COMPOSIO_SEARCH_TOOLS` are no longer attributed
+  to the `composio_search` toolkit, whose slug their names happen to start
+  with. A failed meta call used to suggest linking an app that had nothing to
+  do with the call.
 
 ## 0.3.1
 

--- a/ts/packages/cli/src/analytics/events.ts
+++ b/ts/packages/cli/src/analytics/events.ts
@@ -2,7 +2,7 @@ import type { CliCommandTelemetryContext, TrackEvent } from './types';
 import { APP_VERSION } from 'src/constants';
 import { inferSkillReleaseChannel } from 'src/effects/install-skill';
 import { ToolInputValidationError } from 'src/services/tool-input-validation';
-import { toolkitFromToolSlug } from 'src/utils/toolkit-from-tool-slug';
+import { guessToolkitFromToolSlug } from 'src/utils/toolkit-from-tool-slug';
 
 export const CLI_ANALYTICS_EVENTS = {
   CLI_COMMAND_INVOKED: 'CLI_COMMAND_INVOKED',
@@ -315,7 +315,9 @@ const getExecuteCommandProperties = (context: CliCommandTelemetryContext) => {
     surface: context.commandPath === 'execute' ? 'root' : 'dev',
     tool_slug: slug,
     tool_name: slug,
-    toolkit_slug: typeof slug === 'string' ? toolkitFromToolSlug(slug) : undefined,
+    toolkit_slug:
+      context.toolkitSlug ??
+      (typeof slug === 'string' ? guessToolkitFromToolSlug(slug) : undefined),
     dry_run: isFlagPresent(context.argv, '--dry-run'),
     get_schema: isFlagPresent(context.argv, '--get-schema'),
     has_data: isFlagPresent(context.argv, '--data', '-d'),
@@ -457,6 +459,16 @@ const isSetupCommand = (commandPath: string): boolean => commandPath === 'setup'
 
 const isGenericOnlyCommand = (commandPath: string): boolean =>
   commandPath === 'composio' || commandPath.startsWith('dev');
+
+/**
+ * Tool slug positional of an execute-family invocation, so the CLI bootstrap
+ * can resolve the toolkit slug once and stamp it on the telemetry context for
+ * the synchronous lifecycle event builders.
+ */
+export const getExecuteCommandToolSlug = (
+  context: CliCommandTelemetryContext
+): string | undefined =>
+  isExecuteCommand(context.commandPath) ? getTrailingPositionals(context)[0] : undefined;
 
 export const createCliCommandTelemetryContext = (
   argv: ReadonlyArray<string>,
@@ -720,6 +732,7 @@ export const getSetupSkippedEvent = (params: {
 
 export const getToolExecuteValidationFailedEvent = (params: {
   readonly toolSlug: string;
+  readonly toolkitSlug?: string;
   readonly args: Record<string, unknown>;
   readonly error: ToolInputValidationError;
   readonly surface: 'root' | 'dev';
@@ -732,7 +745,7 @@ export const getToolExecuteValidationFailedEvent = (params: {
     source: 'cli',
     invocation_origin: getInvocationOrigin(),
     tool_slug: params.toolSlug,
-    toolkit_slug: toolkitFromToolSlug(params.toolSlug),
+    toolkit_slug: params.toolkitSlug ?? guessToolkitFromToolSlug(params.toolSlug),
     surface: params.surface,
     project_mode: params.projectMode,
     stage: params.stage,
@@ -770,6 +783,7 @@ export const isMaybeToolValidationError = (params: {
 
 export const getToolExecuteToolNotFoundEvent = (params: {
   readonly toolSlug: string;
+  readonly toolkitSlug?: string;
   readonly args: Record<string, unknown>;
   readonly surface: 'root' | 'dev';
   readonly projectMode: 'consumer' | 'developer';
@@ -785,7 +799,7 @@ export const getToolExecuteToolNotFoundEvent = (params: {
     source: 'cli',
     invocation_origin: getInvocationOrigin(),
     tool_slug: params.toolSlug,
-    toolkit_slug: toolkitFromToolSlug(params.toolSlug),
+    toolkit_slug: params.toolkitSlug ?? guessToolkitFromToolSlug(params.toolSlug),
     surface: params.surface,
     project_mode: params.projectMode,
     stage: params.stage,
@@ -799,6 +813,7 @@ export const getToolExecuteToolNotFoundEvent = (params: {
 
 export const getToolExecuteFailedEvent = (params: {
   readonly toolSlug: string;
+  readonly toolkitSlug?: string;
   readonly args: Record<string, unknown>;
   readonly surface: 'root' | 'dev';
   readonly projectMode: 'consumer' | 'developer';
@@ -816,7 +831,7 @@ export const getToolExecuteFailedEvent = (params: {
     source: 'cli',
     invocation_origin: getInvocationOrigin(),
     tool_slug: params.toolSlug,
-    toolkit_slug: toolkitFromToolSlug(params.toolSlug),
+    toolkit_slug: params.toolkitSlug ?? guessToolkitFromToolSlug(params.toolSlug),
     surface: params.surface,
     project_mode: params.projectMode,
     stage: params.stage,

--- a/ts/packages/cli/src/analytics/types.ts
+++ b/ts/packages/cli/src/analytics/types.ts
@@ -21,4 +21,5 @@ export type CliCommandTelemetryContext = {
   readonly stderrIsTTY: boolean;
   readonly startedAt: number;
   readonly runId?: string;
+  readonly toolkitSlug?: string;
 };

--- a/ts/packages/cli/src/cli-main.ts
+++ b/ts/packages/cli/src/cli-main.ts
@@ -35,12 +35,14 @@ import { showUpdateNotice } from 'src/services/update-check';
 import {
   configureCliAnalyticsReleaseVersion,
   createCliCommandTelemetryContext,
+  getExecuteCommandToolSlug,
   getPrimaryLifecycleFailedEvent,
   getPrimaryLifecycleInvokedEvent,
   getPrimaryLifecycleSucceededEvent,
 } from 'src/analytics/events';
 import { trackCliEventEffect } from 'src/analytics/dispatch';
 import { getVersion } from 'src/effects/version';
+import { toolkitFromToolSlug } from 'src/effects/toolkit-from-tool-slug';
 import { mapOnlyComposioOverrideError } from 'src/services/composio-error-overrides';
 import { SetupSkillInstaller } from 'src/services/setup-skill-installer';
 import { SetupCommandError } from 'src/services/setup';
@@ -151,7 +153,12 @@ const runWithTelemetry = Effect.gen(function* () {
 
   const version = yield* getVersion;
   configureCliAnalyticsReleaseVersion(version);
-  const commandTelemetryContext = createCliCommandTelemetryContext(process.argv, version, terminal);
+  const baseTelemetryContext = createCliCommandTelemetryContext(process.argv, version, terminal);
+  const executeToolSlug = getExecuteCommandToolSlug(baseTelemetryContext);
+  const commandTelemetryContext =
+    executeToolSlug === undefined
+      ? baseTelemetryContext
+      : { ...baseTelemetryContext, toolkitSlug: yield* toolkitFromToolSlug(executeToolSlug) };
   if (commandTelemetryContext.commandPath === 'run' && commandTelemetryContext.runId) {
     // effect/Config is read-only; the run id must be written into the environment so the run
     // command and the child processes it spawns observe the same telemetry run id.

--- a/ts/packages/cli/src/commands/listen.cmd.ts
+++ b/ts/packages/cli/src/commands/listen.cmd.ts
@@ -20,7 +20,7 @@ import {
   resolveConnectedAccountSelection,
 } from 'src/services/connected-account-selection';
 import { parseJsonRecord } from 'src/utils/parse-json';
-import { toolkitFromToolSlug } from 'src/utils/toolkit-from-tool-slug';
+import { toolkitFromToolSlug } from 'src/effects/toolkit-from-tool-slug';
 import { matchesTriggerListenFilters } from './triggers/filter';
 import { parseTriggerListenEvent } from './triggers/parse';
 import { decodeConnectedAccountItems } from 'src/effects/decode-connected-account-list';
@@ -151,7 +151,7 @@ const resolveConnectedAccountIdForTrigger = (params: {
   account: Option.Option<string>;
 }) =>
   Effect.gen(function* () {
-    const toolkitSlug = toolkitFromToolSlug(params.slug);
+    const toolkitSlug = yield* toolkitFromToolSlug(params.slug);
     if (!toolkitSlug) {
       return yield* Effect.fail(
         invalidOptionValue(

--- a/ts/packages/cli/src/commands/tools/commands/tools.execute.cmd.ts
+++ b/ts/packages/cli/src/commands/tools/commands/tools.execute.cmd.ts
@@ -5,7 +5,7 @@ import { Cause, Data, Effect, Either, Exit, Fiber, HashSet, Option, Predicate } 
 import { encodingForModel } from 'js-tiktoken';
 import { redact } from 'src/ui/redact';
 import { parseJsonRecord } from 'src/utils/parse-json';
-import { toolkitFromToolSlug } from 'src/utils/toolkit-from-tool-slug';
+import { toolkitFromToolSlug } from 'src/effects/toolkit-from-tool-slug';
 import { requireAuth } from 'src/effects/require-auth';
 import { resolveOptionalTextInput } from 'src/effects/resolve-optional-text-input';
 import {
@@ -245,8 +245,12 @@ const injectSingleFileArgument = (params: {
     return setNestedKey(params.args, targetPath, params.filePath);
   });
 
-const connectionTips = (toolSlug: string, surface: 'root' | 'dev') => {
-  const toolkit = toolkitFromToolSlug(toolSlug);
+const connectionTips = (params: {
+  readonly toolkit: string | undefined;
+  readonly toolSlug: string;
+  readonly surface: 'root' | 'dev';
+}) => {
+  const { toolkit, toolSlug, surface } = params;
   const executeStep =
     surface === 'dev'
       ? commandHintStep('Retry', 'dev.playgroundExecute', {
@@ -413,6 +417,7 @@ const emitExecuteFailureTelemetry = (params: {
   readonly mappedError?: ReturnType<typeof mapComposioError>;
 }) =>
   Effect.gen(function* () {
+    const toolkitSlug = yield* toolkitFromToolSlug(params.toolSlug);
     const normalized = params.mappedError?.normalized ?? normalizeCliError(params.error);
     const failureOrigin: 'fast_fail' | 'main_endpoint' =
       normalized instanceof ToolInputValidationError || params.stage !== 'execution'
@@ -423,6 +428,7 @@ const emitExecuteFailureTelemetry = (params: {
       yield* trackCliEventEffect(
         getToolExecuteValidationFailedEvent({
           toolSlug: params.toolSlug,
+          toolkitSlug,
           args: params.args,
           error: normalized,
           surface: params.surface,
@@ -435,9 +441,7 @@ const emitExecuteFailureTelemetry = (params: {
       yield* trackCliCodactFailureEffect({
         failureType: 'wrong_tool_input_param',
         toolInfo: {
-          ...(toolkitFromToolSlug(params.toolSlug)
-            ? { toolkit: toolkitFromToolSlug(params.toolSlug) }
-            : {}),
+          ...(toolkitSlug ? { toolkit: toolkitSlug } : {}),
         },
         ctx: {
           tool_slug: params.toolSlug,
@@ -460,6 +464,7 @@ const emitExecuteFailureTelemetry = (params: {
       params.mappedError ??
       mapComposioError({
         error: params.error,
+        toolkit: toolkitSlug,
         toolSlug: params.toolSlug,
       });
     const apiDetails = mapped.apiDetails;
@@ -477,6 +482,7 @@ const emitExecuteFailureTelemetry = (params: {
     })
       ? getToolExecuteValidationFailedEvent({
           toolSlug: params.toolSlug,
+          toolkitSlug,
           args: params.args,
           error: new ToolInputValidationError({
             toolSlug: params.toolSlug,
@@ -502,6 +508,7 @@ const emitExecuteFailureTelemetry = (params: {
           })
         ? getToolExecuteToolNotFoundEvent({
             toolSlug: params.toolSlug,
+            toolkitSlug,
             args: params.args,
             surface: params.surface,
             projectMode: params.projectMode,
@@ -515,6 +522,7 @@ const emitExecuteFailureTelemetry = (params: {
           })
         : getToolExecuteFailedEvent({
             toolSlug: params.toolSlug,
+            toolkitSlug,
             args: params.args,
             surface: params.surface,
             projectMode: params.projectMode,
@@ -545,9 +553,7 @@ const emitExecuteFailureTelemetry = (params: {
       yield* trackCliCodactFailureEffect({
         failureType: 'wrong_tool_input_param',
         toolInfo: {
-          ...(toolkitFromToolSlug(params.toolSlug)
-            ? { toolkit: toolkitFromToolSlug(params.toolSlug) }
-            : {}),
+          ...(toolkitSlug ? { toolkit: toolkitSlug } : {}),
         },
         ctx: {
           tool_slug: params.toolSlug,
@@ -580,9 +586,7 @@ const emitExecuteFailureTelemetry = (params: {
       yield* trackCliCodactFailureEffect({
         failureType: 'wrong_tool_slug',
         toolInfo: {
-          ...(toolkitFromToolSlug(params.toolSlug)
-            ? { toolkit: toolkitFromToolSlug(params.toolSlug) }
-            : {}),
+          ...(toolkitSlug ? { toolkit: toolkitSlug } : {}),
         },
         ctx: {
           invalid_tool_slug: params.toolSlug,
@@ -663,7 +667,8 @@ const handleExecutionError = (
   }
 ) =>
   Effect.gen(function* () {
-    const mapped = mapComposioError({ error, toolSlug: context.toolSlug });
+    const toolkit = yield* toolkitFromToolSlug(context.toolSlug);
+    const mapped = mapComposioError({ error, toolkit, toolSlug: context.toolSlug });
     const normalized = mapped.normalized;
     if (normalized instanceof ToolInputValidationError) {
       yield* emitExecuteFailureTelemetry({
@@ -701,8 +706,11 @@ const handleExecutionError = (
 
     if (normalized instanceof ComposioNoActiveConnectionError) {
       yield* ui.log.error(mapped.message);
-      if (toolkitFromToolSlug(context.toolSlug)) {
-        yield* ui.note(connectionTips(context.toolSlug, context.surface), 'Tips');
+      if (toolkit) {
+        yield* ui.note(
+          connectionTips({ toolkit, toolSlug: context.toolSlug, surface: context.surface }),
+          'Tips'
+        );
       }
       return { error: mapped.message, slug: slugValue ?? context.toolSlug };
     }
@@ -1046,7 +1054,9 @@ const resolveExecuteContext = (params: RunToolsExecuteParams) =>
       orgId: resolvedProject.orgId,
       projectId: resolvedProject.projectId,
     });
-    const toolkitSlug = isLocalToolSlug(params.slug) ? undefined : toolkitFromToolSlug(params.slug);
+    const toolkitSlug = isLocalToolSlug(params.slug)
+      ? undefined
+      : yield* toolkitFromToolSlug(params.slug);
     const selectedConnectedAccountId = yield* resolveConnectedAccountForToolkit({
       client,
       toolkitSlug,
@@ -1173,7 +1183,7 @@ const runConnectedToolkitFailFast = (params: {
       Effect.asVoid
     );
 
-    const toolkit = toolkitFromToolSlug(params.slug);
+    const toolkit = yield* toolkitFromToolSlug(params.slug);
     if (!toolkit) return;
 
     const cachedToolkits = yield* getFreshConsumerConnectedToolkitsFromCache({
@@ -1202,7 +1212,10 @@ const runConnectedToolkitFailFast = (params: {
       });
       const message = `Toolkit "${toolkit}" is not connected for this user (cached within the last 5 minutes). If you just connected the account, use --skip-connection-check.`;
       yield* params.ui.log.error(message);
-      yield* params.ui.note(connectionTips(params.slug, params.surface), 'Tips');
+      yield* params.ui.note(
+        connectionTips({ toolkit, toolSlug: params.slug, surface: params.surface }),
+        'Tips'
+      );
       yield* writeExecuteStdout(
         params.ui,
         JSON.stringify(
@@ -1771,7 +1784,7 @@ const checkConnectedToolkitOrFail = (params: {
       Effect.asVoid
     );
 
-    const toolkit = toolkitFromToolSlug(params.slug);
+    const toolkit = yield* toolkitFromToolSlug(params.slug);
     if (!toolkit) return;
 
     const cachedToolkits = yield* getFreshConsumerConnectedToolkitsFromCache({
@@ -1832,14 +1845,18 @@ const runParallelSchemaFetchFromParsed = (params: ParsedParallelExecuteArgs) =>
             { readonly inputSchema: Record<string, unknown> }
           >;
         }).pipe(
-          Effect.catchAll(error => {
-            const mapped = mapComposioError({ error, toolSlug: spec.slug });
-            return Effect.succeed({
-              slug: spec.slug,
-              successful: false,
-              error: mapped.message,
-            } satisfies Extract<ParallelExecuteResult, { readonly successful: false }>);
-          })
+          Effect.catchAll(error =>
+            toolkitFromToolSlug(spec.slug).pipe(
+              Effect.map(toolkit => {
+                const mapped = mapComposioError({ error, toolkit, toolSlug: spec.slug });
+                return {
+                  slug: spec.slug,
+                  successful: false,
+                  error: mapped.message,
+                } satisfies Extract<ParallelExecuteResult, { readonly successful: false }>;
+              })
+            )
+          )
         ),
       { concurrency: 'unbounded' }
     );
@@ -1980,14 +1997,18 @@ const runParallelToolsExecuteFromParsed = (params: ParsedParallelExecuteArgs) =>
             ...result,
           };
         }).pipe(
-          Effect.catchAll(error => {
-            const mapped = mapComposioError({ error, toolSlug: spec.slug });
-            return Effect.succeed({
-              slug: spec.slug,
-              successful: false,
-              error: mapped.message,
-            } satisfies ParallelExecuteResult);
-          })
+          Effect.catchAll(error =>
+            toolkitFromToolSlug(spec.slug).pipe(
+              Effect.map(toolkit => {
+                const mapped = mapComposioError({ error, toolkit, toolSlug: spec.slug });
+                return {
+                  slug: spec.slug,
+                  successful: false,
+                  error: mapped.message,
+                } satisfies ParallelExecuteResult;
+              })
+            )
+          )
         ),
       { concurrency: 'unbounded' }
     );

--- a/ts/packages/cli/src/effects/toolkit-from-tool-slug.ts
+++ b/ts/packages/cli/src/effects/toolkit-from-tool-slug.ts
@@ -1,0 +1,36 @@
+import { Effect } from 'effect';
+import { ComposioToolkitsRepository } from 'src/services/composio-clients';
+import { isMetaToolSlug } from 'src/utils/meta-tool-slugs';
+import {
+  guessToolkitFromToolSlug,
+  matchToolkitFromToolSlug,
+} from 'src/utils/toolkit-from-tool-slug';
+
+/**
+ * Resolves the toolkit slug for a tool or trigger slug by matching the longest
+ * known toolkit slug prefix from the toolkit list (served from the local cache
+ * when warm). No string split can find where the toolkit name ends —
+ * `GOOGLE_ANALYTICS_RUN_REPORT` belongs to `google_analytics`, not `google` —
+ * so the known list is the only reliable source. Falls back to the
+ * first-underscore guess when the list cannot be loaded (first run offline,
+ * empty cache).
+ */
+export const toolkitFromToolSlug = (
+  toolSlug: string
+): Effect.Effect<string | undefined, never, ComposioToolkitsRepository> =>
+  Effect.gen(function* () {
+    // Meta tools belong to the session rather than to a toolkit, and their
+    // slugs shadow real ones — `COMPOSIO_SEARCH_TOOLS` prefix-matches the
+    // `composio_search` toolkit, which would send users off to link an app
+    // they do not need.
+    if (isMetaToolSlug(toolSlug)) {
+      return undefined;
+    }
+
+    const repository = yield* ComposioToolkitsRepository;
+    const toolkits = yield* repository.getToolkits();
+    return matchToolkitFromToolSlug(
+      toolSlug,
+      toolkits.map(toolkit => toolkit.slug)
+    );
+  }).pipe(Effect.catchAll(() => Effect.succeed(guessToolkitFromToolSlug(toolSlug))));

--- a/ts/packages/cli/src/models/tools.ts
+++ b/ts/packages/cli/src/models/tools.ts
@@ -58,6 +58,16 @@ export const Tool = Schema.Struct({
    * List of tags associated with the tool for categorization and filtering.
    */
   tags: Schema.Array(Schema.String),
+  /**
+   * Parent toolkit of the tool. Absent in cache entries written before the
+   * field was captured.
+   */
+  toolkit: Schema.optional(
+    Schema.Struct({
+      name: Schema.String,
+      slug: Schema.String,
+    })
+  ),
 }).annotations({ identifier: 'Tool' });
 export type Tool = Schema.Schema.Type<typeof Tool>;
 

--- a/ts/packages/cli/src/services/composio-error-overrides.ts
+++ b/ts/packages/cli/src/services/composio-error-overrides.ts
@@ -5,7 +5,7 @@ import {
   extractSlug,
   type ApiErrorDetails,
 } from 'src/utils/api-error-extraction';
-import { toolkitFromToolSlug } from 'src/utils/toolkit-from-tool-slug';
+import { guessToolkitFromToolSlug } from 'src/utils/toolkit-from-tool-slug';
 
 const NO_CONNECTION_SLUGS: ReadonlySet<string> = new Set([
   'ActionExecute_ConnectedAccountNotFound',
@@ -80,9 +80,11 @@ export const buildNoActiveConnectionMessage = (params: {
     return `No active connection found for toolkit "${params.toolkit}". Run \`composio link ${params.toolkit}\`, then retry.`;
   }
   if (params.toolSlug) {
-    // `toolkitFromToolSlug` returns the whole slug lowercased when there is no
-    // underscore, so keep the explicit 'composio' guard for the bare-slug case.
-    const toolkit = toolkitFromToolSlug(params.toolSlug);
+    // Best-effort fallback for callers that could not resolve the toolkit.
+    // `guessToolkitFromToolSlug` returns the whole slug lowercased when there
+    // is no underscore, so keep the explicit 'composio' guard for the
+    // bare-slug case.
+    const toolkit = guessToolkitFromToolSlug(params.toolSlug);
     if (toolkit && toolkit !== 'composio') {
       return `No active connection found for toolkit "${toolkit}". Run \`composio link ${toolkit}\`, then retry.`;
     }

--- a/ts/packages/cli/src/services/tool-file-uploads.ts
+++ b/ts/packages/cli/src/services/tool-file-uploads.ts
@@ -7,7 +7,7 @@ import type { FileSystem, Path } from '@effect/platform';
 import type { Composio as RawComposioClient } from '@composio/client';
 import { assertSafeFileUploadPath } from '@composio/core';
 import { Cause, Data, Effect, Exit, Predicate } from 'effect';
-import { toolkitFromToolSlug } from 'src/utils/toolkit-from-tool-slug';
+import { guessToolkitFromToolSlug } from 'src/utils/toolkit-from-tool-slug';
 
 type JsonSchema = Record<string, unknown>;
 
@@ -353,7 +353,7 @@ export const uploadToolInputFiles = async (params: {
     fs: params.fs,
     path: params.path,
     toolSlug: params.toolSlug,
-    toolkitSlug: params.toolkitSlug ?? toolkitFromToolSlug(params.toolSlug) ?? 'unknown',
+    toolkitSlug: params.toolkitSlug ?? guessToolkitFromToolSlug(params.toolSlug) ?? 'unknown',
     client: params.client,
   });
 

--- a/ts/packages/cli/src/services/tools-executor.ts
+++ b/ts/packages/cli/src/services/tools-executor.ts
@@ -5,7 +5,6 @@ import { executeLocalToolBySlug, resolveLocalTool } from '@composio/cli-local-to
 import type {
   SessionExecuteResponse,
   SessionExecuteMetaResponse,
-  SessionExecuteMetaParams,
 } from '@composio/client/resources/tool-router';
 import { ComposioClientSingleton } from 'src/services/composio-clients';
 import { createToolRouterSessionContext } from 'src/effects/create-tool-router-session';
@@ -16,7 +15,8 @@ import {
 } from 'src/services/composio-error-overrides';
 import { getOrFetchToolInputDefinition } from 'src/services/tool-input-validation';
 import { ToolFileUploadError, uploadToolInputFiles } from 'src/services/tool-file-uploads';
-import { toolkitFromToolSlug } from 'src/utils/toolkit-from-tool-slug';
+import { toolkitFromToolSlug } from 'src/effects/toolkit-from-tool-slug';
+import { isMetaToolSlug } from 'src/utils/meta-tool-slugs';
 import type { NodeOs } from 'src/services/node-os';
 import type { NodeProcess } from 'src/services/node-process';
 import type { ComposioUserContext } from 'src/services/user-context';
@@ -76,28 +76,6 @@ export class LocalToolsDisabledError extends Data.TaggedError('services/LocalToo
   readonly feature: string;
   readonly message: string;
 }> {}
-
-/**
- * Meta tool slugs handled by `session.executeMeta` instead of `session.execute`.
- *
- * The `satisfies` constraint ensures this list stays in sync with the API's
- * `SessionExecuteMetaParams['slug']` union — a compile error will surface if
- * a slug is misspelled or if the API adds/removes a meta tool.
- */
-const META_TOOL_SLUG_LIST: ReadonlyArray<SessionExecuteMetaParams['slug']> = [
-  'COMPOSIO_SEARCH_TOOLS',
-  'COMPOSIO_MULTI_EXECUTE_TOOL',
-  'COMPOSIO_MANAGE_CONNECTIONS',
-  'COMPOSIO_WAIT_FOR_CONNECTIONS',
-  'COMPOSIO_REMOTE_WORKBENCH',
-  'COMPOSIO_REMOTE_BASH_TOOL',
-  'COMPOSIO_GET_TOOL_SCHEMAS',
-];
-
-const META_TOOL_SLUGS: ReadonlySet<string> = new Set(META_TOOL_SLUG_LIST);
-
-const isMetaToolSlug = (slug: string): slug is SessionExecuteMetaParams['slug'] =>
-  META_TOOL_SLUGS.has(slug);
 
 /**
  * Normalize the raw Tool Router response into the shape the CLI commands expect.
@@ -198,7 +176,7 @@ export const ToolsExecutorLive = Layer.effect(
             connectedAccounts: params.connectedAccounts,
             cacheScope: params.cacheScope,
           });
-          const toolkitSlug = toolkitFromToolSlug(slug);
+          const toolkitSlug = yield* toolkitFromToolSlug(slug);
           const permissionGateResult = yield* gateToolExecution({
             toolSlug: slug,
             connectedAccountId: toolkitSlug ? connectedAccounts?.[toolkitSlug] : undefined,
@@ -224,6 +202,7 @@ export const ToolsExecutorLive = Layer.effect(
                         fs,
                         path,
                         toolSlug: slug,
+                        toolkitSlug,
                         arguments_: params.arguments,
                         inputSchema: definition.schema,
                         client: resolvedClient,
@@ -262,12 +241,18 @@ export const ToolsExecutorLive = Layer.effect(
 
           return normalizeResponse(raw, permissionGateResult);
         }).pipe(
-          Effect.mapError(error => {
-            const mapped = mapComposioError({ error, toolSlug: slug });
-            return mapped.normalized instanceof ComposioNoActiveConnectionError
-              ? mapped.normalized
-              : error;
-          })
+          Effect.catchAll(error =>
+            toolkitFromToolSlug(slug).pipe(
+              Effect.flatMap(toolkitSlug => {
+                const mapped = mapComposioError({ error, toolkit: toolkitSlug, toolSlug: slug });
+                return Effect.fail(
+                  mapped.normalized instanceof ComposioNoActiveConnectionError
+                    ? mapped.normalized
+                    : error
+                );
+              })
+            )
+          )
         ),
     });
   })

--- a/ts/packages/cli/src/utils/meta-tool-slugs.ts
+++ b/ts/packages/cli/src/utils/meta-tool-slugs.ts
@@ -1,0 +1,29 @@
+import type { SessionExecuteMetaParams } from '@composio/client/resources/tool-router';
+
+/**
+ * Meta tool slugs handled by `session.executeMeta` instead of `session.execute`.
+ *
+ * The `satisfies` constraint ensures this list stays in sync with the API's
+ * `SessionExecuteMetaParams['slug']` union — a compile error will surface if
+ * a slug is misspelled or if the API adds/removes a meta tool.
+ */
+const META_TOOL_SLUG_LIST: ReadonlyArray<SessionExecuteMetaParams['slug']> = [
+  'COMPOSIO_SEARCH_TOOLS',
+  'COMPOSIO_MULTI_EXECUTE_TOOL',
+  'COMPOSIO_MANAGE_CONNECTIONS',
+  'COMPOSIO_WAIT_FOR_CONNECTIONS',
+  'COMPOSIO_REMOTE_WORKBENCH',
+  'COMPOSIO_REMOTE_BASH_TOOL',
+  'COMPOSIO_GET_TOOL_SCHEMAS',
+];
+
+const META_TOOL_SLUGS: ReadonlySet<string> = new Set(META_TOOL_SLUG_LIST);
+
+/**
+ * Meta tools belong to the session, not to any toolkit — nothing to link, and
+ * nothing to attribute them to. Their slugs shadow real toolkits
+ * (`COMPOSIO_SEARCH_TOOLS` looks like a tool of the `composio_search`
+ * toolkit), so anything deriving a toolkit from a slug must check this first.
+ */
+export const isMetaToolSlug = (slug: string): slug is SessionExecuteMetaParams['slug'] =>
+  META_TOOL_SLUGS.has(slug.toUpperCase());

--- a/ts/packages/cli/src/utils/toolkit-from-tool-slug.ts
+++ b/ts/packages/cli/src/utils/toolkit-from-tool-slug.ts
@@ -1,6 +1,53 @@
-export const toolkitFromToolSlug = (toolSlug: string): string | undefined => {
+/**
+ * Last-resort guess: the text before the first underscore. Multi-word toolkit
+ * slugs (e.g. `google_analytics` in `GOOGLE_ANALYTICS_RUN_REPORT`) cannot be
+ * recovered from the tool slug alone, so prefer `toolkitFromToolSlug` from
+ * `src/effects/toolkit-from-tool-slug`, which matches against the known
+ * toolkit list and only falls back to this guess when that list is
+ * unavailable.
+ */
+export const guessToolkitFromToolSlug = (toolSlug: string): string | undefined => {
   const idx = toolSlug.indexOf('_');
   if (idx <= 0) return toolSlug.toLowerCase();
   const prefix = toolSlug.slice(0, idx).toLowerCase();
   return prefix === 'composio' ? undefined : prefix;
+};
+
+/**
+ * Longest-prefix search over the tool slug's underscore boundaries: for
+ * `A_B_C_D` the candidates are `a_b_c`, then `a_b`, then `a`, and the first
+ * candidate present in the known toolkit list wins — so
+ * `GOOGLE_ANALYTICS_RUN_REPORT` resolves to `google_analytics` even when
+ * `google` is also a known toolkit. Returns undefined when no candidate is
+ * known.
+ */
+export const longestPrefix = (
+  toolSlug: string,
+  knownToolkitSlugs: ReadonlyArray<string>
+): string | undefined => {
+  const known = new Set(knownToolkitSlugs.map(slug => slug.toLowerCase()));
+  const segments = toolSlug.toLowerCase().split('_');
+  for (let end = segments.length - 1; end >= 1; end -= 1) {
+    const candidate = segments.slice(0, end).join('_');
+    if (known.has(candidate)) return candidate;
+  }
+  return undefined;
+};
+
+/**
+ * `longestPrefix` with the toolkit-resolution policy applied on top: the
+ * `composio` meta guard, and `guessToolkitFromToolSlug` when no candidate is
+ * known.
+ */
+export const matchToolkitFromToolSlug = (
+  toolSlug: string,
+  knownToolkitSlugs: ReadonlyArray<string>
+): string | undefined => {
+  const match = longestPrefix(toolSlug, knownToolkitSlugs);
+  if (match !== undefined) {
+    // Bare `composio`-prefixed slugs are meta tools, not user-linkable
+    // toolkits; longer matches such as `composio_search` are real toolkits.
+    return match === 'composio' ? undefined : match;
+  }
+  return guessToolkitFromToolSlug(toolSlug);
 };

--- a/ts/packages/cli/test/__utils__/models/toolkits.ts
+++ b/ts/packages/cli/test/__utils__/models/toolkits.ts
@@ -1,5 +1,28 @@
-import { Arbitrary, FastCheck } from 'effect';
+import { Arbitrary, DateTime, FastCheck } from 'effect';
 import { Toolkit } from 'src/models/toolkits';
+
+/**
+ * A fixed OAuth2 toolkit, for suites that must not inherit the randomized
+ * fields of the arbitrary-based builders below — execution paths branch on
+ * values like `no_auth` and `auth_schemes`.
+ */
+export const makeToolkitFixture = (slug: string, name: string = slug): Toolkit => ({
+  name,
+  slug,
+  auth_schemes: ['OAUTH2'],
+  composio_managed_auth_schemes: ['OAUTH2'],
+  is_local_toolkit: false,
+  no_auth: false,
+  meta: {
+    description: `${name} toolkit`,
+    categories: [],
+    created_at: DateTime.unsafeMake('2024-05-03T11:44:32.061Z'),
+    updated_at: DateTime.unsafeMake('2024-05-03T11:44:32.061Z'),
+    available_versions: [],
+    tools_count: 0,
+    triggers_count: 0,
+  },
+});
 
 const ToolkitArbitary = Arbitrary.make(Toolkit);
 

--- a/ts/packages/cli/test/src/commands/tools/tools.execute.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/tools/tools.execute.cmd.test.ts
@@ -20,6 +20,7 @@ import {
 } from 'src/commands/tools/commands/tools.execute.cmd';
 import { ComposioCliUserConfig } from 'src/services/cli-user-config';
 import type { ToolkitDetailed } from 'src/models/toolkits';
+import { makeToolkitFixture } from 'test/__utils__/models/toolkits';
 
 const testConfigProvider = ConfigProvider.fromMap(
   new Map([['COMPOSIO_USER_API_KEY', 'test_api_key']])
@@ -433,6 +434,122 @@ describe('CLI: composio execute', () => {
         expect(recordedSessionCreateParams.map(params => params.connected_accounts)).toEqual(
           expect.arrayContaining([{ gmail: 'con_gmail_secondary' }, { gmail: 'con_gmail_default' }])
         );
+      })
+    );
+  });
+
+  layer(
+    TestLive({
+      baseConfigProvider: testConfigProvider,
+      fixture: 'global-test-user-id',
+      stdin: { isTTY: true, data: '' },
+      toolkitsData: {
+        toolkits: [
+          makeToolkitFixture('google', 'Google'),
+          makeToolkitFixture('google_analytics', 'Google Analytics'),
+          makeToolkitFixture('microsoft', 'Microsoft'),
+          makeToolkitFixture('microsoft_teams', 'Microsoft Teams'),
+        ],
+      },
+      connectedAccountsData: {
+        items: [
+          {
+            id: 'con_google_analytics_default',
+            alias: 'default',
+            word_id: 'meadow',
+            status: 'ACTIVE',
+            status_reason: null,
+            is_disabled: false,
+            user_id: 'consumer-user-org_test',
+            toolkit: { slug: 'google_analytics' },
+            auth_config: {
+              id: 'ac_google_analytics_oauth',
+              auth_scheme: 'OAUTH2',
+              is_composio_managed: true,
+              is_disabled: false,
+            },
+            created_at: '2026-01-01T00:00:00.000Z',
+            updated_at: '2026-01-01T00:00:00.000Z',
+            test_request_endpoint: '',
+          },
+          {
+            id: 'con_microsoft_teams_default',
+            alias: 'default',
+            word_id: 'harbor',
+            status: 'ACTIVE',
+            status_reason: null,
+            is_disabled: false,
+            user_id: 'consumer-user-org_test',
+            toolkit: { slug: 'microsoft_teams' },
+            auth_config: {
+              id: 'ac_microsoft_teams_oauth',
+              auth_scheme: 'OAUTH2',
+              is_composio_managed: true,
+              is_disabled: false,
+            },
+            created_at: '2026-01-01T00:00:00.000Z',
+            updated_at: '2026-01-01T00:00:00.000Z',
+            test_request_endpoint: '',
+          },
+        ],
+      },
+      toolRouter: {
+        create: async params => {
+          recordedSessionCreateParams.push(params as unknown as Record<string, unknown>);
+          return {
+            session_id: 'trs_google_analytics_session',
+            config: {
+              user_id: params.user_id,
+              execute: {},
+              search: {},
+              preload: { tools: [] },
+            },
+            config_version: 1,
+            mcp: { type: 'http' as const, url: 'https://mcp.test.composio.dev' },
+            tool_router_tools: ['COMPOSIO_SEARCH_TOOLS', 'COMPOSIO_MANAGE_CONNECTIONS'],
+          };
+        },
+        execute: async (_sessionId, params) => ({
+          data: { tool_slug: params.tool_slug, arguments: params.arguments },
+          error: null,
+          log_id: 'log_google_analytics',
+        }),
+      },
+    })
+  )('[Given] a multi-word toolkit [Then] execute resolves it from the known toolkit list', it => {
+    it.scoped('pins the google_analytics connected account for GOOGLE_ANALYTICS_RUN_REPORT', () =>
+      Effect.gen(function* () {
+        yield* cli([
+          'execute',
+          'GOOGLE_ANALYTICS_RUN_REPORT',
+          '--account',
+          'meadow',
+          '--skip-connection-check',
+          '-d',
+          '{"property_id":"1"}',
+        ]);
+
+        expect(recordedSessionCreateParams[0]?.connected_accounts).toMatchObject({
+          google_analytics: 'con_google_analytics_default',
+        });
+      })
+    );
+
+    it.scoped('pins the microsoft_teams connected account for MICROSOFT_TEAMS_SEND_MESSAGE', () =>
+      Effect.gen(function* () {
+        yield* cli([
+          'execute',
+          'MICROSOFT_TEAMS_SEND_MESSAGE',
+          '--account',
+          'harbor',
+          '--skip-connection-check',
+          '-d',
+          '{"message":"hi"}',
+        ]);
+
+        expect(recordedSessionCreateParams[0]?.connected_accounts).toMatchObject({
+          microsoft_teams: 'con_microsoft_teams_default',
+        });
       })
     );
   });

--- a/ts/packages/cli/test/src/effects/toolkit-from-tool-slug.test.ts
+++ b/ts/packages/cli/test/src/effects/toolkit-from-tool-slug.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, layer } from '@effect/vitest';
+import { Effect } from 'effect';
+import { toolkitFromToolSlug } from 'src/effects/toolkit-from-tool-slug';
+import type { Toolkits } from 'src/models/toolkits';
+import { TestLive } from 'test/__utils__';
+import { makeToolkitFixture } from 'test/__utils__/models/toolkits';
+
+const testToolkits: Toolkits = [
+  makeToolkitFixture('google', 'Google'),
+  makeToolkitFixture('google_analytics', 'Google Analytics'),
+  makeToolkitFixture('gmail', 'Gmail'),
+  makeToolkitFixture('microsoft', 'Microsoft'),
+  makeToolkitFixture('microsoft_teams', 'Microsoft Teams'),
+  // A real, linkable toolkit whose slug is also the prefix of a session meta
+  // tool (`COMPOSIO_SEARCH_TOOLS`).
+  makeToolkitFixture('composio_search', 'Composio Search'),
+];
+
+describe('toolkitFromToolSlug', () => {
+  layer(TestLive({ toolkitsData: { toolkits: testToolkits } }))('with known toolkits', it => {
+    it.effect('resolves multi-word toolkit slugs by longest known prefix', () =>
+      Effect.gen(function* () {
+        expect(yield* toolkitFromToolSlug('GOOGLE_ANALYTICS_RUN_REPORT')).toBe('google_analytics');
+        expect(yield* toolkitFromToolSlug('MICROSOFT_TEAMS_SEND_MESSAGE')).toBe('microsoft_teams');
+      })
+    );
+
+    it.effect('resolves single-word toolkit slugs', () =>
+      Effect.gen(function* () {
+        expect(yield* toolkitFromToolSlug('GMAIL_SEND_EMAIL')).toBe('gmail');
+      })
+    );
+
+    it.effect('falls back to the guess for slugs outside the known list', () =>
+      Effect.gen(function* () {
+        expect(yield* toolkitFromToolSlug('NOTION_CREATE_PAGE')).toBe('notion');
+      })
+    );
+
+    it.effect('gives meta tools no toolkit, even when one shadows their slug', () =>
+      Effect.gen(function* () {
+        // Attributing this to `composio_search` would make a failed meta call
+        // tell the user to link an app that has nothing to do with it.
+        expect(yield* toolkitFromToolSlug('COMPOSIO_SEARCH_TOOLS')).toBeUndefined();
+        expect(yield* toolkitFromToolSlug('COMPOSIO_MANAGE_CONNECTIONS')).toBeUndefined();
+      })
+    );
+
+    it.effect('still resolves ordinary tools of the shadowed toolkit', () =>
+      Effect.gen(function* () {
+        expect(yield* toolkitFromToolSlug('COMPOSIO_SEARCH_SEARCH')).toBe('composio_search');
+      })
+    );
+  });
+
+  layer(TestLive())('with an empty toolkit list', it => {
+    it.effect('falls back to the first-underscore guess', () =>
+      Effect.gen(function* () {
+        expect(yield* toolkitFromToolSlug('GOOGLE_ANALYTICS_RUN_REPORT')).toBe('google');
+      })
+    );
+  });
+});

--- a/ts/packages/cli/test/src/utils/toolkit-from-tool-slug.test.ts
+++ b/ts/packages/cli/test/src/utils/toolkit-from-tool-slug.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from '@effect/vitest';
+import {
+  guessToolkitFromToolSlug,
+  longestPrefix,
+  matchToolkitFromToolSlug,
+} from 'src/utils/toolkit-from-tool-slug';
+
+describe('guessToolkitFromToolSlug', () => {
+  it('takes the text before the first underscore', () => {
+    expect(guessToolkitFromToolSlug('GITHUB_CREATE_ISSUE')).toBe('github');
+  });
+
+  it('lowercases a slug without underscores', () => {
+    expect(guessToolkitFromToolSlug('GITHUB')).toBe('github');
+  });
+
+  it('returns undefined for composio meta slugs', () => {
+    expect(guessToolkitFromToolSlug('COMPOSIO_ENABLE_TRIGGER')).toBeUndefined();
+  });
+
+  it('cannot recover multi-word toolkit slugs', () => {
+    expect(guessToolkitFromToolSlug('GOOGLE_ANALYTICS_RUN_REPORT')).toBe('google');
+  });
+});
+
+describe('longestPrefix', () => {
+  it('tries candidates longest-first at each underscore boundary', () => {
+    const known = ['a', 'a_b', 'a_b_c'];
+    expect(longestPrefix('A_B_C_D', known)).toBe('a_b_c');
+    expect(longestPrefix('A_B_X_Y', known)).toBe('a_b');
+    expect(longestPrefix('A_X_Y_Z', known)).toBe('a');
+  });
+
+  it('returns undefined when no candidate is known', () => {
+    expect(longestPrefix('A_B_C_D', ['other'])).toBeUndefined();
+    expect(longestPrefix('A_B_C_D', [])).toBeUndefined();
+  });
+
+  it('never matches the whole tool slug as a toolkit', () => {
+    expect(longestPrefix('A_B', ['a_b'])).toBeUndefined();
+  });
+
+  it('applies no policy: the composio candidate is returned as-is', () => {
+    expect(longestPrefix('COMPOSIO_ENABLE_TRIGGER', ['composio'])).toBe('composio');
+  });
+});
+
+describe('matchToolkitFromToolSlug', () => {
+  const knownToolkits = [
+    'github',
+    'google',
+    'google_analytics',
+    'gmail',
+    'microsoft',
+    'microsoft_teams',
+  ];
+
+  it('resolves multi-word toolkits by longest known prefix', () => {
+    expect(matchToolkitFromToolSlug('GOOGLE_ANALYTICS_RUN_REPORT', knownToolkits)).toBe(
+      'google_analytics'
+    );
+    expect(matchToolkitFromToolSlug('MICROSOFT_TEAMS_SEND_MESSAGE', knownToolkits)).toBe(
+      'microsoft_teams'
+    );
+  });
+
+  it('tries candidates longest-first at each underscore boundary', () => {
+    const known = ['reddit', 'reddit_ads'];
+    expect(matchToolkitFromToolSlug('REDDIT_ADS_GET_CAMPAIGN', known)).toBe('reddit_ads');
+    expect(matchToolkitFromToolSlug('REDDIT_GET_POST', known)).toBe('reddit');
+  });
+
+  it('resolves single-word toolkits', () => {
+    expect(matchToolkitFromToolSlug('GITHUB_CREATE_ISSUE', knownToolkits)).toBe('github');
+  });
+
+  it('is independent of the known-list order', () => {
+    expect(
+      matchToolkitFromToolSlug('MICROSOFT_TEAMS_SEND_MESSAGE', [...knownToolkits].reverse())
+    ).toBe('microsoft_teams');
+  });
+
+  it('falls back to the guess when no known toolkit matches', () => {
+    expect(matchToolkitFromToolSlug('NOTION_CREATE_PAGE', knownToolkits)).toBe('notion');
+  });
+
+  it('falls back to the guess with an empty known list', () => {
+    expect(matchToolkitFromToolSlug('GOOGLE_ANALYTICS_RUN_REPORT', [])).toBe('google');
+  });
+
+  it('returns undefined for composio meta slugs even when composio is known', () => {
+    expect(matchToolkitFromToolSlug('COMPOSIO_ENABLE_TRIGGER', ['composio'])).toBeUndefined();
+  });
+
+  it('prefers a longer composio-prefixed toolkit over the meta guard', () => {
+    expect(
+      matchToolkitFromToolSlug('COMPOSIO_SEARCH_NEWS_SEARCH', ['composio', 'composio_search'])
+    ).toBe('composio_search');
+  });
+});


### PR DESCRIPTION
This PR:

- closes https://github.com/ComposioHQ/composio/issues/4049
- resolves a tool's toolkit by matching the tool slug against the known toolkit list, longest underscore-bounded prefix first, instead of splitting on the first underscore — `GOOGLE_ANALYTICS_RUN_REPORT` belongs to `google_analytics`, not `google`, and the old split picked the wrong connected account
- routes every call site (execute, listen, tools-executor, file uploads, error overrides, telemetry) through one Effect resolver, `toolkitFromToolSlug`, so they cannot disagree
- keeps the first-underscore split as `guessToolkitFromToolSlug`, used only when the toolkit list cannot be loaded
- fixes a second miss that the old split hid: `COMPOSIO_SEARCH_TOOLS` is a session meta tool, but `composio_search` is a real linkable toolkit, so matching against the real catalog made a failed meta call tell users to link an app that had nothing to do with it. The meta tool slugs move out of `tools-executor.ts` into `src/utils/meta-tool-slugs.ts`, and resolution answers "no toolkit" for them before any prefix matching
- no visible command surface changed, so no VHS recording

## Context

This is correct but not yet fast: resolution still reads the toolkit catalog, which is ~800 KB over two pages. Three stacked PRs follow that make the common case cost no network at all.