### PR TITLE
fix(deps): let the hono security bump through the release-age floor

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -81,6 +81,16 @@ minimumReleaseAgeExclude:
   - '@mastra/core'
   - '@composio/client'
   - chrome-devtools-mcp
+  # temporary: hono >=4.12.34 carries the CORS ReDoS fix
+  # (GHSA-hp3h-89pf-5q58 class, Access-Control-Request-Headers), but both
+  # 4.12.34 and 4.13.0 were published within the 4320-minute floor, so
+  # --frozen-lockfile rejects the lockfile on every branch. The last version
+  # old enough to pass the gate is 4.12.33, which is the vulnerable one.
+  # hono is only pulled in by ts/e2e-tests/runtimes/cloudflare/* and
+  # ts/examples/cloudflare-wrangler -- it ships in no published package --
+  # so taking the fix ahead of the floor is the safer trade. Drop this entry
+  # once the resolved version is older than the floor (after 2026-08-06).
+  - hono
 
 peerDependencyRules:
   allowedVersions:


### PR DESCRIPTION
## Why

`next` is red. Dependabot #4051 bumped the `hono` catalog entry to `^4.12.34`, which pnpm resolved to `4.13.0`. Both that and `4.12.34` were published inside the 4320-minute (72h) `minimumReleaseAge` floor, so `pnpm install --frozen-lockfile` rejects the lockfile — on `next` itself and on every PR branched from it.

```
[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] 1 lockfile entries failed verification:
  hono@4.13.0 was published at 2026-08-03T21:47:05.000Z, within the minimumReleaseAge cutoff
```

Waiting it out is not neutral, because of which versions sit on which side of the floor:

| Version | Published | Clears the 72h floor | Has the CORS ReDoS fix |
|---|---|---|---|
| 4.12.33 | 2026-07-31 10:42 | yes | **no** |
| 4.12.34 | 2026-08-03 02:36 | not until Aug 6 02:36 | yes |
| 4.13.0 | 2026-08-03 21:54 | not until Aug 6 21:54 | yes |

The newest version old enough to pass the gate is the one the advisory flags as vulnerable. So pinning back to a compliant version means deliberately shipping the vulnerable release for two days.

## What changed

One entry added to `minimumReleaseAgeExclude`, with its removal condition inline. No lockfile change — `pnpm install --frozen-lockfile` goes from exit 1 to exit 0 with the lockfile untouched.

## Why this is a safe trade

The floor exists to catch compromised fresh releases. `hono` is only pulled in by `ts/e2e-tests/runtimes/cloudflare/*` and `ts/examples/cloudflare-wrangler` — test fixtures and examples. It ships in no published package, so the blast radius of taking it early is CI-only, while the advisory it fixes is real.

## Verification

```
pnpm install --frozen-lockfile   # exit 0, pnpm-lock.yaml unmodified
```

## Follow-up

Delete the `hono` entry once the resolved version is past the floor (after 2026-08-06). The inline comment says so.