### PR TITLE
fix: keep content of free-form object schemas in the zod and effect converters

### DIFF
--- a/.changeset/passthrough-property-less-objects.md
+++ b/.changeset/passthrough-property-less-objects.md
@@ -1,0 +1,5 @@
+---
+'@composio/json-schema-to-zod': patch
+---
+
+Allow additional properties on object schemas that declare no `properties` and no `additionalProperties`, so free-form object fields keep their content instead of failing validation with `unrecognized_keys`.

--- a/.changeset/passthrough-property-less-objects.md
+++ b/.changeset/passthrough-property-less-objects.md
@@ -1,5 +1,6 @@
 ---
+'@composio/claude-agent-sdk': patch
 '@composio/json-schema-to-zod': patch
 ---
 
-Allow additional properties on object schemas that declare no `properties` and no `additionalProperties`, so free-form object fields keep their content instead of failing validation with `unrecognized_keys`.
+Allow additional properties on object schemas that declare no `properties` and no `additionalProperties`, so free-form object fields keep their content instead of failing validation with `unrecognized_keys`. Preserve those properties when a free-form schema is used as a Claude Agent SDK tool's root input.

--- a/ts/packages/json-schema-to-effect-schema/src/index.ts
+++ b/ts/packages/json-schema-to-effect-schema/src/index.ts
@@ -53,6 +53,12 @@ const isObjectSchema = (schema: JsonObject): boolean =>
   'patternProperties' in schema ||
   'additionalProperties' in schema;
 
+const hasEntries = (value: unknown): boolean =>
+  isJsonObject(value) && Object.keys(value).length > 0;
+
+const declaresProperties = (schema: JsonObject): boolean =>
+  hasEntries(schema.properties) || hasEntries(schema.patternProperties);
+
 const appendAllOf = (schema: JsonObject, constraint: JsonObject): void => {
   const current = schema.allOf;
   schema.allOf = Array.isArray(current) ? [...current, constraint] : [constraint];
@@ -162,7 +168,11 @@ const normalizeSchemaNode = (
     }
   }
 
-  if (isObjectSchema(normalized) && normalized.additionalProperties === undefined) {
+  if (
+    isObjectSchema(normalized) &&
+    normalized.additionalProperties === undefined &&
+    declaresProperties(normalized)
+  ) {
     normalized.additionalProperties = false;
   }
 

--- a/ts/packages/json-schema-to-effect-schema/test/json-schema-to-effect-schema.test.ts
+++ b/ts/packages/json-schema-to-effect-schema/test/json-schema-to-effect-schema.test.ts
@@ -40,6 +40,27 @@ describe('jsonSchemaToEffectSchema', () => {
     expectParity({ type: 'object', additionalProperties: true }, { arbitrary: 'value' }, true);
   });
 
+  it('keeps the content of free-form object schemas', () => {
+    const freeFormField = {
+      type: 'object',
+      required: ['dataset_query'],
+      properties: {
+        dataset_query: { type: 'object', description: 'Query definition in MBQL or native SQL' },
+      },
+    } satisfies JsonSchema;
+
+    expectParity(freeFormField, { dataset_query: { database: 1, type: 'native' } }, true);
+    expectParity({ type: 'object' }, { arbitrary: 'value' }, true);
+    expectParity({ type: 'object', properties: {} }, { arbitrary: 'value' }, true);
+    expectParity(
+      { type: 'object', properties: { rows: { type: 'array', items: { type: 'object' } } } },
+      { rows: [{ a: 1 }] },
+      true
+    );
+
+    expectParity({ type: 'object', additionalProperties: false }, { arbitrary: 'value' }, false);
+  });
+
   it('normalizes the OpenAPI and Composio extensions accepted by the previous validator', () => {
     expectParity({ type: 'string', nullable: true }, null, true);
     expectParity({ type: 'string', nullable: true }, 42, false);

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-object.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-object.ts
@@ -2,79 +2,15 @@ import * as z from 'zod/v3';
 
 import { parseAllOf } from './parse-all-of';
 import { parseAnyOf } from './parse-any-of';
+import { parseObjectShape } from './parse-object-shape';
 import { parseOneOf } from './parse-one-of';
 import { parseSchema } from './parse-schema';
-import type { JsonSchemaObject, Refs, JsonSchema } from '../types';
+import type { JsonSchemaObject, Refs } from '../types';
 import { its } from '../utils/its';
 
 function parseObjectProperties(objectSchema: JsonSchemaObject & { type?: 'object' }, refs: Refs) {
-  if (!objectSchema.properties) {
-    return undefined;
-  }
-
-  const propertyKeys = Object.keys(objectSchema.properties);
-  if (propertyKeys.length === 0) {
-    return undefined;
-  }
-
-  const properties: Record<string, z.ZodTypeAny> = {};
-
-  for (const key of propertyKeys) {
-    const propJsonSchema = objectSchema.properties[key];
-
-    const propZodSchema = parseSchema(propJsonSchema, {
-      ...refs,
-      path: [...refs.path, 'properties', key],
-    });
-
-    const required = Array.isArray(objectSchema.required)
-      ? objectSchema.required.includes(key)
-      : false;
-
-    // Handle default values for optional properties
-    if (
-      !required &&
-      propJsonSchema &&
-      typeof propJsonSchema === 'object' &&
-      'default' in propJsonSchema
-    ) {
-      // If default is null, make the field nullable with the null default
-      // But don't make it nullable if it's already an anyOf/oneOf that includes null
-      if (propJsonSchema.default === null) {
-        const hasAnyOfWithNull =
-          propJsonSchema.anyOf &&
-          Array.isArray(propJsonSchema.anyOf) &&
-          propJsonSchema.anyOf.some(
-            (schema: JsonSchema) =>
-              typeof schema === 'object' && schema !== null && schema.type === 'null'
-          );
-        const hasOneOfWithNull =
-          propJsonSchema.oneOf &&
-          Array.isArray(propJsonSchema.oneOf) &&
-          propJsonSchema.oneOf.some(
-            (schema: JsonSchema) =>
-              typeof schema === 'object' && schema !== null && schema.type === 'null'
-          );
-        const isNullable =
-          'nullable' in propJsonSchema &&
-          (propJsonSchema as JsonSchemaObject & { nullable?: boolean }).nullable === true;
-
-        if (hasAnyOfWithNull || hasOneOfWithNull || isNullable) {
-          // The schema already handles null through anyOf/oneOf/nullable, just make it optional with default
-          properties[key] = propZodSchema.optional().default(null);
-        } else {
-          // Make the field nullable with the null default
-          properties[key] = propZodSchema.nullable().optional().default(null);
-        }
-      } else {
-        properties[key] = propZodSchema.optional().default(propJsonSchema.default);
-      }
-    } else {
-      properties[key] = required ? propZodSchema : propZodSchema.optional();
-    }
-  }
-
-  return z.object(properties);
+  const properties = parseObjectShape(objectSchema, refs);
+  return Object.keys(properties).length === 0 ? undefined : z.object(properties);
 }
 
 export function parseObject(

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-object.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-object.ts
@@ -9,13 +9,12 @@ import { its } from '../utils/its';
 
 function parseObjectProperties(objectSchema: JsonSchemaObject & { type?: 'object' }, refs: Refs) {
   if (!objectSchema.properties) {
-    // leave it as an empty object or else this will break openai responses
-    return z.object({});
+    return undefined;
   }
 
   const propertyKeys = Object.keys(objectSchema.properties);
   if (propertyKeys.length === 0) {
-    return z.object({});
+    return undefined;
   }
 
   const properties: Record<string, z.ZodTypeAny> = {};
@@ -89,8 +88,8 @@ export function parseObject(
     objectSchema.type === 'object' ? objectSchema : { ...objectSchema, type: 'object' as const };
 
   const propertiesSchema:
-    | z.ZodObject<Record<string, z.ZodTypeAny>, 'strip', z.ZodTypeAny>
-    | undefined = parseObjectProperties(normalizedSchema, refs);
+    z.ZodObject<Record<string, z.ZodTypeAny>, 'strip', z.ZodTypeAny> | undefined =
+    parseObjectProperties(normalizedSchema, refs);
   let zodSchema: z.ZodTypeAny | undefined = propertiesSchema;
 
   const additionalProperties =

--- a/ts/packages/json-schema-to-zod/test/json-to-zod.test.ts
+++ b/ts/packages/json-schema-to-zod/test/json-to-zod.test.ts
@@ -386,6 +386,62 @@ describe('jsonSchemaToZod', () => {
       expect(() => zodSchema.parse({ key1: 123 })).toThrow();
     });
 
+    it('should preserve content of a property-less object schema', () => {
+      const schema: JsonSchema = {
+        type: 'object',
+        properties: {
+          dataset_query: {
+            type: 'object',
+            description: 'Query definition in MBQL or native SQL format',
+          },
+        },
+        required: ['dataset_query'],
+      };
+      const zodSchema = jsonSchemaToZod(schema);
+      const payload = { dataset_query: { database: 1, type: 'native' } };
+      expect(zodSchema.parse(payload)).toEqual(payload);
+    });
+
+    it('should allow additional properties when neither properties nor additionalProperties are specified', () => {
+      const schema: JsonSchema = {
+        type: 'object',
+      };
+      const zodSchema = jsonSchemaToZod(schema);
+      expect(zodSchema.parse({})).toEqual({});
+      expect(zodSchema.parse({ anything: 1 })).toEqual({ anything: 1 });
+    });
+
+    it('should allow additional properties when properties is an empty object', () => {
+      const schema: JsonSchema = {
+        type: 'object',
+        properties: {},
+      };
+      const zodSchema = jsonSchemaToZod(schema);
+      expect(zodSchema.parse({ anything: 1 })).toEqual({ anything: 1 });
+    });
+
+    it('should preserve content of property-less objects inside arrays', () => {
+      const schema: JsonSchema = {
+        type: 'object',
+        properties: {
+          rows: { type: 'array', items: { type: 'object' } },
+        },
+      };
+      const zodSchema = jsonSchemaToZod(schema);
+      const payload = { rows: [{ a: 1 }, { b: 'two' }] };
+      expect(zodSchema.parse(payload)).toEqual(payload);
+    });
+
+    it('should still reject content for a property-less object with additionalProperties: false', () => {
+      const schema: JsonSchema = {
+        type: 'object',
+        additionalProperties: false,
+      };
+      const zodSchema = jsonSchemaToZod(schema);
+      expect(zodSchema.parse({})).toEqual({});
+      expect(() => zodSchema.parse({ anything: 1 })).toThrow();
+    });
+
     it('should handle additionalProperties: false with patternProperties', () => {
       const schema: JsonSchema = {
         type: 'object',

--- a/ts/packages/providers/claude-agent-sdk/src/index.ts
+++ b/ts/packages/providers/claude-agent-sdk/src/index.ts
@@ -14,6 +14,7 @@ import {
   ExecuteToolFn,
   McpUrlResponse,
   McpServerGetResponse,
+  jsonSchemaToZodSchema,
   normalizeToolArguments,
 } from '@composio/core';
 import { jsonSchemaToZodShape } from '@composio/core/utils/json-schema';
@@ -102,9 +103,11 @@ export class ClaudeAgentSDKProvider extends BaseAgenticProvider<
    * ```
    */
   wrapTool(composioTool: Tool, executeTool: ExecuteToolFn): ClaudeAgentTool {
-    const inputZodShape = jsonSchemaToZodShape(
-      composioTool.inputParameters ?? { type: 'object', properties: {} }
-    );
+    const inputParameters = composioTool.inputParameters ?? { type: 'object', properties: {} };
+    const inputZodSchema =
+      composioTool.inputParameters && Object.keys(inputParameters.properties ?? {}).length === 0
+        ? jsonSchemaToZodSchema(inputParameters)
+        : jsonSchemaToZodShape(inputParameters);
 
     // The SDK types tool() generically over its zod raw shape, which makes the handler argument
     // instantiate excessively deep against the v3 shape returned here (TS2589). Narrow tool() to a
@@ -113,7 +116,8 @@ export class ClaudeAgentSDKProvider extends BaseAgenticProvider<
     const defineTool = sdkTool as unknown as (
       name: string,
       description: string,
-      inputShape: ReturnType<typeof jsonSchemaToZodShape>,
+      inputSchema:
+        ReturnType<typeof jsonSchemaToZodShape> | ReturnType<typeof jsonSchemaToZodSchema>,
       handler: (
         args: Record<string, unknown>
       ) => Promise<{ content: Array<{ type: 'text'; text: string }> }>
@@ -122,7 +126,7 @@ export class ClaudeAgentSDKProvider extends BaseAgenticProvider<
     return defineTool(
       composioTool.slug,
       composioTool.description ?? `Execute ${composioTool.slug}`,
-      inputZodShape,
+      inputZodSchema,
       async args => {
         try {
           // Models occasionally emit tool input as a JSON string rather than an object (issue #2406).

--- a/ts/packages/providers/claude-agent-sdk/src/index.ts
+++ b/ts/packages/providers/claude-agent-sdk/src/index.ts
@@ -109,10 +109,9 @@ export class ClaudeAgentSDKProvider extends BaseAgenticProvider<
         ? jsonSchemaToZodSchema(inputParameters)
         : jsonSchemaToZodShape(inputParameters);
 
-    // The SDK types tool() generically over its zod raw shape, which makes the handler argument
-    // instantiate excessively deep against the v3 shape returned here (TS2589). Narrow tool() to a
-    // concrete, monomorphic signature once — this sidesteps the deep instantiation and lets the
-    // handler keep a precise argument type, instead of scattering `as never` casts at the call.
+    // The SDK runtime accepts both raw Zod shapes and complete object schemas, but tool() only
+    // exposes the raw-shape type. Free-form roots need the complete schema to retain unknown keys.
+    // Keep the compatibility cast centralized and the handler type concrete to avoid TS2589.
     const defineTool = sdkTool as unknown as (
       name: string,
       description: string,

--- a/ts/packages/providers/claude-agent-sdk/test/claude-agent-sdk.test.ts
+++ b/ts/packages/providers/claude-agent-sdk/test/claude-agent-sdk.test.ts
@@ -43,27 +43,20 @@ type MockedToolHandler = (
   args: unknown
 ) => Promise<{ content: Array<{ type: string; text: string }> }>;
 
-type MockedToolFn = Mock<
+type MockedToolFn<TSchema = Record<string, MinimalZodSchema>> = Mock<
   (
     name: string,
     description: string | undefined,
-    schema: Record<string, MinimalZodSchema>,
+    schema: TSchema,
     handler: MockedToolHandler
   ) => unknown
 >;
 
-type MockedSchemaToolFn = Mock<
-  (
-    name: string,
-    description: string | undefined,
-    schema: {
-      safeParse: (
-        value: unknown
-      ) => { success: true; data: unknown } | { success: false; error: unknown };
-    },
-    handler: MockedToolHandler
-  ) => unknown
->;
+type MockedZodObject = {
+  safeParse: (
+    value: unknown
+  ) => { success: true; data: unknown } | { success: false; error: unknown };
+};
 
 // `mockExecuteToolFn` is declared against the real `GlobalExecuteToolFn` contract, which always
 // resolves with a `ToolExecuteResponse`. A couple of tests deliberately stub it with a plain
@@ -161,7 +154,7 @@ describe('ClaudeAgentSDKProvider', () => {
       expect(schemaShape.to.safeParse(123).success).toBe(false);
     });
 
-    it('should preserve arbitrary properties in a free-form root input schema', () => {
+    it('should preserve arbitrary properties in a free-form root input schema', async () => {
       const freeFormTool: Tool = {
         ...mockTool,
         inputParameters: {
@@ -172,9 +165,23 @@ describe('ClaudeAgentSDKProvider', () => {
 
       provider.wrapTool(freeFormTool, mockExecuteToolFn);
 
-      const schema = (tool as unknown as MockedSchemaToolFn).mock.calls[0][2];
+      const schema = (tool as unknown as MockedToolFn<MockedZodObject>).mock.calls[0][2];
       const input = { database: 1, type: 'native' };
       expect(schema.safeParse(input)).toEqual({ success: true, data: input });
+
+      const claudeAgentSdk = await vi.importActual<typeof import('@anthropic-ai/claude-agent-sdk')>(
+        '@anthropic-ai/claude-agent-sdk'
+      );
+      const sdkTool = claudeAgentSdk.tool(
+        'FREE_FORM',
+        'Free-form input',
+        // The runtime accepts complete object schemas although tool() only declares raw shapes.
+        schema as never,
+        async () => ({ content: [] })
+      );
+      expect(() =>
+        claudeAgentSdk.createSdkMcpServer({ name: 'test', tools: [sdkTool] })
+      ).not.toThrow();
     });
 
     it('should handle tools without input parameters', () => {

--- a/ts/packages/providers/claude-agent-sdk/test/claude-agent-sdk.test.ts
+++ b/ts/packages/providers/claude-agent-sdk/test/claude-agent-sdk.test.ts
@@ -52,6 +52,19 @@ type MockedToolFn = Mock<
   ) => unknown
 >;
 
+type MockedSchemaToolFn = Mock<
+  (
+    name: string,
+    description: string | undefined,
+    schema: {
+      safeParse: (
+        value: unknown
+      ) => { success: true; data: unknown } | { success: false; error: unknown };
+    },
+    handler: MockedToolHandler
+  ) => unknown
+>;
+
 // `mockExecuteToolFn` is declared against the real `GlobalExecuteToolFn` contract, which always
 // resolves with a `ToolExecuteResponse`. A couple of tests deliberately stub it with a plain
 // string / `undefined` to exercise the wrapTool handler's defensive "stringify anything" branch,
@@ -146,6 +159,22 @@ describe('ClaudeAgentSDKProvider', () => {
       expect(Object.keys(schemaShape)).toEqual(['to', 'subject', 'body']);
       expect(schemaShape.to.safeParse('test@example.com').success).toBe(true);
       expect(schemaShape.to.safeParse(123).success).toBe(false);
+    });
+
+    it('should preserve arbitrary properties in a free-form root input schema', () => {
+      const freeFormTool: Tool = {
+        ...mockTool,
+        inputParameters: {
+          type: 'object',
+          properties: {},
+        },
+      };
+
+      provider.wrapTool(freeFormTool, mockExecuteToolFn);
+
+      const schema = (tool as unknown as MockedSchemaToolFn).mock.calls[0][2];
+      const input = { database: 1, type: 'native' };
+      expect(schema.safeParse(input)).toEqual({ success: true, data: input });
     });
 
     it('should handle tools without input parameters', () => {


### PR DESCRIPTION
## Summary

Fixes #4064.

An object schema that declares neither `properties` nor `additionalProperties` — a free-form object field, common in the tool catalog — rejects all content in both JSON Schema converters, so the only value that validates is `{}`. `METABASE_POST_API_CARD.dataset_query` is a concrete affected schema.

This is the TypeScript counterpart of #4023, where the same catalog schemas cause the Python SDK to silently strip the nested content. The Python occurrence is a separate code path and is not covered here.

Each converter reaches the failure differently, so there is one commit per package:

**`@composio/json-schema-to-zod`** — `parseObjectProperties` returned `z.object({})` for schemas with no properties, so it never returned a falsy value and the property-less branch of `parseObject` was unreachable, including its own documented intent, `// When no properties and no additionalProperties specified, default to allowing additional properties`. Every such schema fell through to `.strict()` instead and failed with `unrecognized_keys`. The `| undefined` on the `propertiesSchema` annotation indicates that branch was meant to run.

**`@composio/json-schema-to-effect-schema`** — `normalizeSchemaNode` injects `additionalProperties: false` into any object schema that omits it. That is the right default when the schema declares properties (it is what makes the CLI reject a mistyped argument key), but for a free-form object it means no content can ever be sent. This one is user-visible through the CLI: `compileToolInputSchema` in `ts/packages/cli/src/services/tool-input-validation.ts` compiles tool input through this converter.

Both are in one PR because the regression tests use the `expectParity` helper in the effect package's test file, which asserts that both converters agree — those assertions only hold with both commits applied.

## Changes

- `json-schema-to-zod`: `parseObjectProperties` returns `undefined` when no properties are declared, so the existing property-less branch of `parseObject` runs and such schemas allow additional properties, matching JSON Schema semantics.
- `json-schema-to-effect-schema`: a `declaresProperties` guard so `additionalProperties: false` is only injected when `properties` or `patternProperties` is non-empty.
- Regression tests in each package's existing test file.
- Changeset (`patch`) for `@composio/json-schema-to-zod`. None for `@composio/json-schema-to-effect-schema`: it is `private: true`, has no `CHANGELOG.md`, and has never appeared in a changeset.

Behaviour deliberately left unchanged in both converters:

- objects that declare properties and omit `additionalProperties` → still strict
- `additionalProperties: false` → still rejects unknown keys
- `additionalProperties: true` → unchanged passthrough
- in the zod converter, `additionalProperties: <schema>` with no properties → `z.record(<schema>)` instead of an equivalent `catchall` on an empty object, and `patternProperties` with no properties → `z.record(...)`, which is what that branch already specified

I removed the `// leave it as an empty object or else this will break openai responses` comment along with the early `z.object({})` return. The emitted shape is still an empty object; only the unknown-key policy changes. The OpenAI providers do not consume this converter (no `zod` usage under `ts/packages/providers/openai/src`) and there is no zod → JSON Schema round-trip on that path.

**One tradeoff worth your call:** for frameworks that convert the Zod schema back to JSON Schema for the model, an affected field now serialises as permissive rather than `additionalProperties: false`. OpenAI's strict structured-output mode requires `additionalProperties: false`, which a free-form object cannot satisfy in any case, and `jsonSchemaToZodSchema(schema, { strict: true })` remains the explicit mechanism for that. If you would rather keep the strict default and gate this behind an option, I am happy to rework it. Equally happy to split the two converters into separate PRs, in which case the parity assertions would move to the second one.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [ ] Documentation
- [ ] Breaking change

## How Has This Been Tested?

Repo-pinned toolchain (`mise install`), Node 24.17.0 / pnpm 11.8.0, macOS 15.

`json-schema-to-zod` — five cases added to the existing `Object Schemas` block, each failing before the change:

- `should preserve content of a property-less object schema` — the `dataset_query` case from #4064
- `should allow additional properties when neither properties nor additionalProperties are specified`
- `should allow additional properties when properties is an empty object`
- `should preserve content of property-less objects inside arrays`
- `should still reject content for a property-less object with additionalProperties: false` — pins the unchanged behaviour

`json-schema-to-effect-schema` — `keeps the content of free-form object schemas`, added to the existing parity test and written with the file's own `expectParity` helper so it asserts both converters agree rather than pinning one of them. It covers the same four shapes plus the `additionalProperties: false` control.

```
$ pnpm --filter @composio/json-schema-to-zod test
 Test Files  1 passed (1)
      Tests  79 passed (79)

$ pnpm --filter @composio/json-schema-to-effect-schema test
 Test Files  1 passed (1)
      Tests  5 passed (5)

$ pnpm --filter @composio/json-schema-to-zod typecheck
$ pnpm --filter @composio/json-schema-to-effect-schema typecheck
$ tsc --noEmit -p ./tsconfig.src.json
$ tsc --noEmit -p ./tsconfig.test.json

$ pnpm test
 Tasks:    26 successful, 26 total
```

## Checklist
- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed
- [ ] I updated documentation as needed — no user-facing docs describe this behaviour
- [x] I added tests or explain why not applicable
- [x] I added a changeset if this change affects published packages
