### PR TITLE
fix(installer): satisfy shellcheck in install.sh and the shell variants

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -532,7 +532,9 @@ main() {
             error "Failed to determine the latest CLI release with a $archive_name asset. Specify a version manually."
         version=$(printf '%s\n' "$latest_release" | sed -n '1p')
         archive_url=$(printf '%s\n' "$latest_release" | sed -n '2p')
-        [ -n "$version" ] && [ -n "$archive_url" ] || error 'The release API returned an incomplete CLI release'
+        if [ -z "$version" ] || [ -z "$archive_url" ]; then
+            error 'The release API returned an incomplete CLI release'
+        fi
         info "Found latest version: $version"
     fi
     validate_url "$archive_url" || error "Release API returned an unsafe archive URL \"$archive_url\""

--- a/install/bash.sh
+++ b/install/bash.sh
@@ -8,7 +8,7 @@ error() {
     exit 1
 }
 is_true() { case ${1:-} in 1 | true) return 0 ;; *) return 1 ;; esac }
-debug() { is_true "${COMPOSIO_DEBUG:-}" && printf '+ %s\n' "$*" >&2 || :; }
+debug() { if is_true "${COMPOSIO_DEBUG:-}"; then printf '+ %s\n' "$*" >&2; fi; }
 
 url_authority() {
     printf '%s\n' "$1" | sed -e 's#^[a-zA-Z][a-zA-Z0-9+.-]*://##' -e 's#[/?#].*$##'

--- a/install/fish.sh
+++ b/install/fish.sh
@@ -8,7 +8,7 @@ error() {
     exit 1
 }
 is_true() { case ${1:-} in 1 | true) return 0 ;; *) return 1 ;; esac }
-debug() { is_true "${COMPOSIO_DEBUG:-}" && printf '+ %s\n' "$*" >&2 || :; }
+debug() { if is_true "${COMPOSIO_DEBUG:-}"; then printf '+ %s\n' "$*" >&2; fi; }
 
 url_authority() {
     printf '%s\n' "$1" | sed -e 's#^[a-zA-Z][a-zA-Z0-9+.-]*://##' -e 's#[/?#].*$##'

--- a/install/zsh.sh
+++ b/install/zsh.sh
@@ -8,7 +8,7 @@ error() {
     exit 1
 }
 is_true() { case ${1:-} in 1 | true) return 0 ;; *) return 1 ;; esac }
-debug() { is_true "${COMPOSIO_DEBUG:-}" && printf '+ %s\n' "$*" >&2 || :; }
+debug() { if is_true "${COMPOSIO_DEBUG:-}"; then printf '+ %s\n' "$*" >&2; fi; }
 
 url_authority() {
     printf '%s\n' "$1" | sed -e 's#^[a-zA-Z][a-zA-Z0-9+.-]*://##' -e 's#[/?#].*$##'


### PR DESCRIPTION
## Why

`next` is red. The **Install Script Unit Tests** job runs:

```
shellcheck -s sh install.sh install/*.sh
```

shellcheck exits non-zero on *any* finding, including info-level ones, and #4015 introduced four **SC2015** diagnostics ("Note that A && B || C is not if-then-else"):

| file | line |
|---|---|
| `install.sh` | 535 |
| `install/bash.sh` | 11 |
| `install/zsh.sh` | 11 |
| `install/fish.sh` | 11 |

The knock-on matters more than the lint: `Test Install Script` **depends on** that job, so it was **skipped** on the beta.336 build — meaning that release's real installation legs never ran. See [run 31006150923](https://github.com/ComposioHQ/composio/actions/runs/31006150923).

This was not caught on #4015 because **Test Installation does not trigger on pull requests** — it runs on tag push and from Build CLI Binaries, so the job first executed after merge.

## What changed

Both patterns become explicit conditionals, with no behavior change:

```sh
# install/{bash,zsh,fish}.sh
-debug() { is_true "\${COMPOSIO_DEBUG:-}" && printf '+ %s\n' "\$*" >&2 || :; }
+debug() { if is_true "\${COMPOSIO_DEBUG:-}"; then printf '+ %s\n' "\$*" >&2; fi; }
```

`debug()` still prints only when `COMPOSIO_DEBUG` is truthy, and still returns 0 otherwise (the `|| :` existed to keep it from tripping `set -e`; `if` returns 0 on a false condition, so that property is preserved).

```sh
# install.sh
-[ -n "\$version" ] && [ -n "\$archive_url" ] || error '...'
+if [ -z "\$version" ] || [ -z "\$archive_url" ]; then
+    error '...'
+fi
```

## Verification

- `shellcheck -s sh install.sh install/*.sh` — the exact CI command — exits **0** locally
- All four files still pass `sh -n`

## Follow-up worth considering (not in this PR)

The gap that let this through is that the installer's own lint and unit tests never run on the PR that changes the installer. Running the `Install Script Unit Tests` job on PRs touching `install.sh` / `install/**` would have caught this before merge.