### PR TITLE
fix(core): paginate tools.get() instead of truncating to the first page

### DIFF
--- a/.changeset/paginate-tools-get.md
+++ b/.changeset/paginate-tools-get.md
@@ -1,0 +1,5 @@
+---
+'@composio/core': patch
+---
+
+Fix `tools.get()` silently dropping tools past the first page. When no explicit `limit` is set it now pages through every result via `getAllPages` instead of relying on an implicit `limit = 9999` that the API clamped to 100.

--- a/ts/packages/core/src/models/Tools.ts
+++ b/ts/packages/core/src/models/Tools.ts
@@ -57,6 +57,7 @@ import { resolveEffectiveUploadAllowlist } from '../utils/fileDirs';
 import { schemaHasFileUploadable } from '../utils/modifiers/FileToolModifier.utils.neutral';
 import { ComposioRequestOptions } from '../types/requestOptions.types';
 import { withCancellation } from '../utils/cancellation';
+import { getAllPages } from '../utils/pagination';
 import { ComposioRequestCancelledError } from '../errors/SDKErrors';
 
 const TOOL_ROUTER_SESSION_TOOLS_PAGE_LIMIT = 500;
@@ -483,18 +484,20 @@ export class Tools<
       );
     }
 
-    // if tools are provided, set the limit to 9999 so that all tools are fetched
-    let limit = 'limit' in queryParams.data ? queryParams.data.limit : undefined;
-    if ('tools' in queryParams.data) {
-      limit = 9999;
-    }
+    // When the caller sets an explicit limit we honor it as a hard cap and
+    // fetch a single page. Otherwise we page through every result: the API
+    // caps the page size (getAllPages requests MAX_LIMIT_ALLOWED_BY_API = 100
+    // per page), so the previous implicit `limit = 9999` was silently clamped
+    // and every tool past the first page was dropped (e.g. `toolkits:
+    // ['github']`, a >100-entry `tools` list, or a broad `search`).
+    const explicitLimit = 'limit' in queryParams.data ? queryParams.data.limit : undefined;
 
     const filters: ComposioToolListParams = {
       ...('tools' in queryParams.data ? { tool_slugs: queryParams.data.tools?.join(',') } : {}),
       ...('toolkits' in queryParams.data
         ? { toolkit_slug: queryParams.data.toolkits?.join(',') }
         : {}),
-      ...(limit ? { limit } : {}),
+      ...(explicitLimit ? { limit: explicitLimit } : {}),
       ...('tags' in queryParams.data ? { tags: queryParams.data.tags } : {}),
       ...('scopes' in queryParams.data ? { scopes: queryParams.data.scopes } : {}),
       ...('search' in queryParams.data ? { search: queryParams.data.search } : {}),
@@ -507,15 +510,17 @@ export class Tools<
 
     logger.debug(`Fetching tools with filters: ${JSON.stringify(filters, null, 2)}`);
 
-    const tools = await withCancellation(
-      () => this.client.tools.list(filters, requestOptions),
+    const rawTools = await withCancellation(
+      () =>
+        explicitLimit !== undefined
+          ? this.client.tools.list(filters, requestOptions).then(response => response?.items ?? [])
+          : getAllPages(params =>
+              this.client.tools.list({ ...filters, ...params }, requestOptions)
+            ),
       requestOptions?.signal
     );
 
-    if (!tools) {
-      return [];
-    }
-    const caseTransformedTools = tools.items.map(tool => this.transformToolCases(tool));
+    const caseTransformedTools = rawTools.map(tool => this.transformToolCases(tool));
 
     let modifiedTools = await this.applyDefaultSchemaModifiers(caseTransformedTools);
 


### PR DESCRIPTION
## Summary

`tools.get()` silently returns only the first page of results, so callers are handed a partial tool set with no error.

In `ts/packages/core/src/models/Tools.ts`, `getRawComposioTools` reads a single `client.tools.list` response and discards `next_cursor`:

```ts
// if tools are provided, set the limit to 9999 so that all tools are fetched
let limit = 'limit' in queryParams.data ? queryParams.data.limit : undefined;
if ('tools' in queryParams.data) {
  limit = 9999;
}
// ...
const tools = await withCancellation(() => this.client.tools.list(filters, requestOptions), ...);
const caseTransformedTools = tools.items.map(tool => this.transformToolCases(tool)); // page 1 only
```

The `limit = 9999` was meant to "fetch all", but the list endpoint is cursor-paginated and the SDK's own pagination helper documents the cap: `MAX_LIMIT_ALLOWED_BY_API = 100` (`utils/pagination.ts`). So `9999` is clamped to `100` and anything past the first page is dropped. This is reachable on the primary public path:

- `tools.get(userId, { tools: [ ...>100 slugs... ] })` → returns only 100
- `tools.get(userId, { toolkits: ['github'], important: false })` → first page only (GitHub has >100 tools)
- `tools.get(userId, { search: '...' })` / `{ authConfigIds: [...] }` → first page only

The sibling method in the same file, `getRawToolRouterSessionTools`, already paginates correctly by looping on `next_cursor`, and the purpose-built `getAllPages` helper is documented with `client.tools.list` as its example — it just was never wired in here.

## Fix

Use `getAllPages` to page through every result when the caller hasn't set an explicit `limit`; an explicit `limit` is still honored as a single-page hard cap:

```ts
const rawTools = await withCancellation(
  () =>
    explicitLimit !== undefined
      ? this.client.tools.list(filters, requestOptions).then(response => response?.items ?? [])
      : getAllPages(params => this.client.tools.list({ ...filters, ...params }, requestOptions)),
  requestOptions?.signal
);
```

## Testing

`@composio/core` typechecks clean with the change (`tsc --noEmit --skipLibCheck`). Suggested unit test: mock `client.tools.list` to return `{ items: [A], next_cursor: 'c' }` then `{ items: [B], next_cursor: null }` and assert `getRawComposioTools` returns `[A, B]` (returns only `[A]` before this change).

Added a changeset (`@composio/core` patch). Targets `next` per `AGENTS.md`.