### PR TITLE
fix(claude-agent-sdk): preserve root schema constraints

### DIFF
--- a/.changeset/curvy-cats-validate.md
+++ b/.changeset/curvy-cats-validate.md
@@ -4,4 +4,4 @@
 '@composio/json-schema-to-zod': patch
 ---
 
-Preserve and correctly enforce root `patternProperties` and schema-valued `additionalProperties` when parsing tool schemas and registering Composio tools with the Claude Agent SDK.
+Preserve, validate, and apply parsed output from root `patternProperties` and schema-valued `additionalProperties` when parsing tool schemas and registering Composio tools with the Claude Agent SDK.

--- a/.changeset/curvy-cats-validate.md
+++ b/.changeset/curvy-cats-validate.md
@@ -1,0 +1,5 @@
+---
+'@composio/claude-agent-sdk': patch
+---
+
+Preserve root JSON Schema object constraints when registering Composio tools with the Claude Agent SDK.

--- a/.changeset/curvy-cats-validate.md
+++ b/.changeset/curvy-cats-validate.md
@@ -1,5 +1,6 @@
 ---
 '@composio/claude-agent-sdk': patch
+'@composio/core': patch
 ---
 
-Preserve root JSON Schema object constraints when registering Composio tools with the Claude Agent SDK.
+Preserve root `patternProperties` and schema-valued `additionalProperties` when parsing tool schemas, and enforce root object constraints when registering Composio tools with the Claude Agent SDK.

--- a/.changeset/curvy-cats-validate.md
+++ b/.changeset/curvy-cats-validate.md
@@ -1,6 +1,7 @@
 ---
 '@composio/claude-agent-sdk': patch
 '@composio/core': patch
+'@composio/json-schema-to-zod': patch
 ---
 
-Preserve root `patternProperties` and schema-valued `additionalProperties` when parsing tool schemas, and enforce root object constraints when registering Composio tools with the Claude Agent SDK.
+Preserve and correctly enforce root `patternProperties` and schema-valued `additionalProperties` when parsing tool schemas and registering Composio tools with the Claude Agent SDK.

--- a/ts/packages/core/src/types/tool.types.ts
+++ b/ts/packages/core/src/types/tool.types.ts
@@ -145,7 +145,11 @@ const ParametersSchema = z.preprocess(
     default: z.unknown().optional(),
     nullable: z.boolean().optional(),
     description: z.string().optional(),
-    additionalProperties: z.boolean().default(false).optional(),
+    patternProperties: z.lazy(() => z.record(z.string(), JSONSchemaPropertySchema)).optional(),
+    additionalProperties: z
+      .union([z.boolean(), z.lazy(() => JSONSchemaPropertySchema)])
+      .default(false)
+      .optional(),
     // Definition blocks targeted by `$ref` pointers. The Composio API ships
     // these at the parameters root (e.g. `data` → `$ref` → `#/$defs/...`), but
     // because `z.object` strips unknown keys they were being dropped on parse —

--- a/ts/packages/core/test/utils/jsonSchema.test.ts
+++ b/ts/packages/core/test/utils/jsonSchema.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import {
   deduplicateJsonSchemaRequiredArrays,
   dereferenceJsonSchema,
+  jsonSchemaToZodSchema,
 } from '../../src/utils/jsonSchema';
 import { JsonSchemaRefResolutionError } from '../../src/errors/ValidationErrors';
 import logger from '../../src/utils/logger';
@@ -592,5 +593,51 @@ describe('deduplicateJsonSchemaRequiredArrays', () => {
 
     expect(tool.inputParameters?.required).toEqual(['name']);
     expect(tool.inputParameters?.properties.options.required).toEqual(['enabled']);
+  });
+
+  it('preserves root patternProperties at the shared ToolSchema API boundary', () => {
+    const tool = ToolSchema.parse({
+      slug: 'TEST_TOOL',
+      name: 'Test tool',
+      inputParameters: {
+        type: 'object',
+        properties: { name: { type: 'string' } },
+        patternProperties: { '^metric_': { type: 'number' } },
+        additionalProperties: false,
+      },
+    });
+
+    expect(tool.inputParameters?.patternProperties).toEqual({
+      '^metric_': { type: 'number' },
+    });
+  });
+
+  it('preserves schema-valued root additionalProperties at the shared ToolSchema API boundary', () => {
+    const tool = ToolSchema.parse({
+      slug: 'TEST_TOOL',
+      name: 'Test tool',
+      inputParameters: {
+        type: 'object',
+        properties: { name: { type: 'string' } },
+        additionalProperties: { type: 'number' },
+      },
+    });
+
+    expect(tool.inputParameters?.additionalProperties).toEqual({ type: 'number' });
+  });
+
+  it('keeps omitted root additionalProperties strict', () => {
+    const tool = ToolSchema.parse({
+      slug: 'TEST_TOOL',
+      name: 'Test tool',
+      inputParameters: {
+        type: 'object',
+        properties: { name: { type: 'string' } },
+      },
+    });
+
+    expect(tool.inputParameters).not.toHaveProperty('additionalProperties');
+    const schema = jsonSchemaToZodSchema(tool.inputParameters ?? {});
+    expect(schema.safeParse({ name: 'Ada', extra: true }).success).toBe(false);
   });
 });

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-object.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-object.ts
@@ -89,8 +89,8 @@ export function parseObject(
     objectSchema.type === 'object' ? objectSchema : { ...objectSchema, type: 'object' as const };
 
   const propertiesSchema:
-    | z.ZodObject<Record<string, z.ZodTypeAny>, 'strip', z.ZodTypeAny>
-    | undefined = parseObjectProperties(normalizedSchema, refs);
+    z.ZodObject<Record<string, z.ZodTypeAny>, 'strip', z.ZodTypeAny> | undefined =
+    parseObjectProperties(normalizedSchema, refs);
   let zodSchema: z.ZodTypeAny | undefined = propertiesSchema;
 
   const additionalProperties =
@@ -116,33 +116,9 @@ export function parseObject(
         ];
       })
     );
-    const patternPropertyValues = Object.values(parsedPatternProperties);
-
-    if (propertiesSchema) {
-      if (additionalProperties) {
-        zodSchema = propertiesSchema.catchall(
-          z.union([...patternPropertyValues, additionalProperties] as [z.ZodTypeAny, z.ZodTypeAny])
-        );
-      } else if (Object.keys(parsedPatternProperties).length > 1) {
-        zodSchema = propertiesSchema.catchall(
-          z.union(patternPropertyValues as [z.ZodTypeAny, z.ZodTypeAny])
-        );
-      } else {
-        zodSchema = propertiesSchema.catchall(patternPropertyValues[0]);
-      }
-    } else {
-      if (additionalProperties) {
-        zodSchema = z.record(
-          z.union([...patternPropertyValues, additionalProperties] as [z.ZodTypeAny, z.ZodTypeAny])
-        );
-      } else if (patternPropertyValues.length > 1) {
-        zodSchema = z.record(z.union(patternPropertyValues as [z.ZodTypeAny, z.ZodTypeAny]));
-      } else {
-        zodSchema = z.record(patternPropertyValues[0]);
-      }
-    }
-
     const objectPropertyKeys = new Set(Object.keys(normalizedSchema.properties ?? {}));
+    const hasDeclaredProperties = objectPropertyKeys.size > 0;
+    zodSchema = (propertiesSchema ?? z.object({})).passthrough();
     zodSchema = zodSchema.superRefine((value: Record<string, unknown>, ctx) => {
       for (const key in value) {
         let wasMatched = objectPropertyKeys.has(key);
@@ -156,7 +132,7 @@ export function parseObject(
               ctx.addIssue({
                 path: [...ctx.path, key],
                 code: 'custom',
-                message: `Invalid input: Key matching regex /${key}/ must match schema`,
+                message: `Invalid input: Key matching regex /${patternPropertyKey}/ must match schema`,
                 params: {
                   issues: result.error.issues,
                 },
@@ -165,7 +141,13 @@ export function parseObject(
           }
         }
 
-        if (!wasMatched && additionalProperties) {
+        if (!wasMatched && !additionalProperties && hasDeclaredProperties) {
+          ctx.addIssue({
+            path: [...ctx.path, key],
+            code: 'custom',
+            message: 'Invalid input: key must match a pattern property',
+          });
+        } else if (!wasMatched && additionalProperties) {
           const result = additionalProperties.safeParse(value[key]);
           if (!result.success) {
             ctx.addIssue({

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-object.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-object.ts
@@ -137,6 +137,8 @@ export function parseObject(
                   issues: result.error.issues,
                 },
               });
+            } else {
+              value[key] = result.data;
             }
           }
         }
@@ -158,6 +160,8 @@ export function parseObject(
                 issues: result.error.issues,
               },
             });
+          } else {
+            value[key] = result.data;
           }
         }
       }

--- a/ts/packages/json-schema-to-zod/test/json-to-zod.test.ts
+++ b/ts/packages/json-schema-to-zod/test/json-to-zod.test.ts
@@ -363,6 +363,53 @@ describe('jsonSchemaToZod', () => {
       expect(() => zodSchema.parse({ metric_score: 'high' })).toThrow();
     });
 
+    it('should preserve parsed defaults for matching pattern properties', () => {
+      const schema: JsonSchema = {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+        },
+        patternProperties: {
+          '^config_': {
+            type: 'object',
+            properties: {
+              enabled: { type: 'boolean', default: true },
+            },
+          },
+        },
+      };
+      const zodSchema = jsonSchemaToZod(schema);
+
+      expect(zodSchema.parse({ name: 'John', config_primary: {} })).toEqual({
+        name: 'John',
+        config_primary: { enabled: true },
+      });
+    });
+
+    it('should preserve parsed defaults for schema-valued additional properties', () => {
+      const schema: JsonSchema = {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+        },
+        patternProperties: {
+          '^metric_': { type: 'number' },
+        },
+        additionalProperties: {
+          type: 'object',
+          properties: {
+            enabled: { type: 'boolean', default: true },
+          },
+        },
+      };
+      const zodSchema = jsonSchemaToZod(schema);
+
+      expect(zodSchema.parse({ name: 'John', config: {} })).toEqual({
+        name: 'John',
+        config: { enabled: true },
+      });
+    });
+
     it('should handle additionalProperties with patternProperties', () => {
       const schema: JsonSchema = {
         type: 'object',

--- a/ts/packages/json-schema-to-zod/test/json-to-zod.test.ts
+++ b/ts/packages/json-schema-to-zod/test/json-to-zod.test.ts
@@ -325,6 +325,44 @@ describe('jsonSchemaToZod', () => {
       expect(() => zodSchema.parse({ name: 'John', extra: 'field' })).toThrow();
     });
 
+    it('should reject keys outside patternProperties when additionalProperties is not specified', () => {
+      const schema: JsonSchema = {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+        },
+        patternProperties: {
+          '^metric_': { type: 'number' },
+        },
+      };
+      const zodSchema = jsonSchemaToZod(schema);
+
+      expect(zodSchema.parse({ name: 'John', metric_score: 42 })).toEqual({
+        name: 'John',
+        metric_score: 42,
+      });
+      expect(() => zodSchema.parse({ name: 'John', metric_score: 'high' })).toThrow(
+        'Key matching regex /^metric_/ must match schema'
+      );
+      expect(() => zodSchema.parse({ name: 'John', other: 42 })).toThrow();
+    });
+
+    it('should allow unmatched keys for a property-less pattern schema by default', () => {
+      const schema: JsonSchema = {
+        type: 'object',
+        patternProperties: {
+          '^metric_': { type: 'number' },
+        },
+      };
+      const zodSchema = jsonSchemaToZod(schema);
+
+      expect(zodSchema.parse({ metric_score: 42, other: 'value' })).toEqual({
+        metric_score: 42,
+        other: 'value',
+      });
+      expect(() => zodSchema.parse({ metric_score: 'high' })).toThrow();
+    });
+
     it('should handle additionalProperties with patternProperties', () => {
       const schema: JsonSchema = {
         type: 'object',

--- a/ts/packages/providers/claude-agent-sdk/src/index.ts
+++ b/ts/packages/providers/claude-agent-sdk/src/index.ts
@@ -103,7 +103,11 @@ export class ClaudeAgentSDKProvider extends BaseAgenticProvider<
    */
   wrapTool(composioTool: Tool, executeTool: ExecuteToolFn): ClaudeAgentTool {
     const inputZodSchema = jsonSchemaToZodSchema(
-      composioTool.inputParameters ?? { type: 'object', properties: {} }
+      composioTool.inputParameters ?? {
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      }
     );
 
     // The SDK runtime accepts complete Zod schemas, but tool() only exposes a raw-shape type.

--- a/ts/packages/providers/claude-agent-sdk/src/index.ts
+++ b/ts/packages/providers/claude-agent-sdk/src/index.ts
@@ -15,8 +15,8 @@ import {
   McpUrlResponse,
   McpServerGetResponse,
   normalizeToolArguments,
+  jsonSchemaToZodSchema,
 } from '@composio/core';
-import { jsonSchemaToZodShape } from '@composio/core/utils/json-schema';
 import {
   tool as sdkTool,
   type Options as ClaudeAgentOptions,
@@ -102,18 +102,16 @@ export class ClaudeAgentSDKProvider extends BaseAgenticProvider<
    * ```
    */
   wrapTool(composioTool: Tool, executeTool: ExecuteToolFn): ClaudeAgentTool {
-    const inputZodShape = jsonSchemaToZodShape(
+    const inputZodSchema = jsonSchemaToZodSchema(
       composioTool.inputParameters ?? { type: 'object', properties: {} }
     );
 
-    // The SDK types tool() generically over its zod raw shape, which makes the handler argument
-    // instantiate excessively deep against the v3 shape returned here (TS2589). Narrow tool() to a
-    // concrete, monomorphic signature once — this sidesteps the deep instantiation and lets the
-    // handler keep a precise argument type, instead of scattering `as never` casts at the call.
+    // The SDK runtime accepts complete Zod schemas, but tool() only exposes a raw-shape type.
+    // Keep this compatibility cast centralized so root object constraints survive registration.
     const defineTool = sdkTool as unknown as (
       name: string,
       description: string,
-      inputShape: ReturnType<typeof jsonSchemaToZodShape>,
+      inputSchema: ReturnType<typeof jsonSchemaToZodSchema>,
       handler: (
         args: Record<string, unknown>
       ) => Promise<{ content: Array<{ type: 'text'; text: string }> }>
@@ -122,7 +120,7 @@ export class ClaudeAgentSDKProvider extends BaseAgenticProvider<
     return defineTool(
       composioTool.slug,
       composioTool.description ?? `Execute ${composioTool.slug}`,
-      inputZodShape,
+      inputZodSchema,
       async args => {
         try {
           // Models occasionally emit tool input as a JSON string rather than an object (issue #2406).

--- a/ts/packages/providers/claude-agent-sdk/test/claude-agent-sdk.registration.test.ts
+++ b/ts/packages/providers/claude-agent-sdk/test/claude-agent-sdk.registration.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi, type Mock } from 'vitest';
 import { createSdkMcpServer } from '@anthropic-ai/claude-agent-sdk';
-import { type GlobalExecuteToolFn, type JSONSchemaProperty, type Tool } from '@composio/core';
+import { type GlobalExecuteToolFn, type JSONSchemaProperty } from '@composio/core';
 import { ClaudeAgentSDKProvider } from '../src';
 
 type SdkMcpServer = ReturnType<typeof createSdkMcpServer>;
@@ -28,8 +28,7 @@ function createToolHarness(inputParameters: RootInputSchema | undefined) {
       description: 'Exercise root object schema behavior',
       version: '20260806_00',
       availableVersions: ['20260806_00'],
-      // The Tool root type has not yet caught up with the recursive JSON Schema property type.
-      inputParameters: inputParameters as Tool['inputParameters'],
+      inputParameters,
       tags: ['test'],
     },
     executeTool

--- a/ts/packages/providers/claude-agent-sdk/test/claude-agent-sdk.registration.test.ts
+++ b/ts/packages/providers/claude-agent-sdk/test/claude-agent-sdk.registration.test.ts
@@ -202,4 +202,29 @@ describe('Claude Agent SDK root schema registration', () => {
       },
     });
   });
+
+  it('forwards parsed defaults from dynamic root properties', async () => {
+    const defaultedObject: JSONSchemaProperty = {
+      type: 'object',
+      properties: {
+        enabled: { type: 'boolean', default: true },
+      },
+    };
+    const harness = createToolHarness({
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      required: ['name'],
+      patternProperties: { '^pattern_': defaultedObject },
+      additionalProperties: defaultedObject,
+    });
+    await harness.connect();
+
+    await harness.call({ name: 'Ada', pattern_config: {}, fallback_config: {} });
+
+    expect(harness.executeTool).toHaveBeenCalledWith('ROOT_SCHEMA_TEST', {
+      name: 'Ada',
+      pattern_config: { enabled: true },
+      fallback_config: { enabled: true },
+    });
+  });
 });

--- a/ts/packages/providers/claude-agent-sdk/test/claude-agent-sdk.registration.test.ts
+++ b/ts/packages/providers/claude-agent-sdk/test/claude-agent-sdk.registration.test.ts
@@ -14,7 +14,7 @@ type RootInputSchema = JSONSchemaProperty & {
   properties: Record<string, JSONSchemaProperty>;
 };
 
-function createToolHarness(inputParameters: RootInputSchema) {
+function createToolHarness(inputParameters: RootInputSchema | undefined) {
   const provider = new ClaudeAgentSDKProvider();
   const executeTool: Mock<GlobalExecuteToolFn> = vi.fn().mockResolvedValue({
     data: { result: 'success' },
@@ -29,7 +29,7 @@ function createToolHarness(inputParameters: RootInputSchema) {
       version: '20260806_00',
       availableVersions: ['20260806_00'],
       // The Tool root type has not yet caught up with the recursive JSON Schema property type.
-      inputParameters: inputParameters as NonNullable<Tool['inputParameters']>,
+      inputParameters: inputParameters as Tool['inputParameters'],
       tags: ['test'],
     },
     executeTool
@@ -72,6 +72,21 @@ afterEach(async () => {
 });
 
 describe('Claude Agent SDK root schema registration', () => {
+  it('rejects unexpected arguments when the tool has no input schema', async () => {
+    const harness = createToolHarness(undefined);
+    await harness.connect();
+
+    const response = await harness.call({ unexpected: true });
+
+    expect(harness.executeTool).not.toHaveBeenCalled();
+    expect(response).toMatchObject({
+      result: {
+        isError: true,
+        content: [{ type: 'text', text: expect.stringContaining('Input validation error') }],
+      },
+    });
+  });
+
   it('preserves unknown fields when additionalProperties is true', async () => {
     const harness = createToolHarness({
       type: 'object',

--- a/ts/packages/providers/claude-agent-sdk/test/claude-agent-sdk.registration.test.ts
+++ b/ts/packages/providers/claude-agent-sdk/test/claude-agent-sdk.registration.test.ts
@@ -168,13 +168,12 @@ describe('Claude Agent SDK root schema registration', () => {
     });
   });
 
-  it('preserves patternProperties validation', async () => {
+  it('preserves patternProperties with default strict additional properties', async () => {
     const harness = createToolHarness({
       type: 'object',
       properties: { name: { type: 'string' } },
       required: ['name'],
       patternProperties: { '^metric_': { type: 'number' } },
-      additionalProperties: false,
     });
     await harness.connect();
 

--- a/ts/packages/providers/claude-agent-sdk/test/claude-agent-sdk.registration.test.ts
+++ b/ts/packages/providers/claude-agent-sdk/test/claude-agent-sdk.registration.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { createSdkMcpServer } from '@anthropic-ai/claude-agent-sdk';
+import { type GlobalExecuteToolFn, type JSONSchemaProperty, type Tool } from '@composio/core';
+import { ClaudeAgentSDKProvider } from '../src';
+
+type SdkMcpServer = ReturnType<typeof createSdkMcpServer>;
+type ServerTransport = Parameters<SdkMcpServer['instance']['connect']>[0];
+type JsonRpcMessage = Parameters<ServerTransport['send']>[0];
+
+const connectedServers: SdkMcpServer[] = [];
+
+type RootInputSchema = JSONSchemaProperty & {
+  type: 'object';
+  properties: Record<string, JSONSchemaProperty>;
+};
+
+function createToolHarness(inputParameters: RootInputSchema) {
+  const provider = new ClaudeAgentSDKProvider();
+  const executeTool: Mock<GlobalExecuteToolFn> = vi.fn().mockResolvedValue({
+    data: { result: 'success' },
+    error: null,
+    successful: true,
+  });
+  const wrappedTool = provider.wrapTool(
+    {
+      slug: 'ROOT_SCHEMA_TEST',
+      name: 'Root schema test',
+      description: 'Exercise root object schema behavior',
+      version: '20260806_00',
+      availableVersions: ['20260806_00'],
+      // The Tool root type has not yet caught up with the recursive JSON Schema property type.
+      inputParameters: inputParameters as NonNullable<Tool['inputParameters']>,
+      tags: ['test'],
+    },
+    executeTool
+  );
+  const server = createSdkMcpServer({ name: 'root-schema-test', tools: [wrappedTool] });
+  connectedServers.push(server);
+
+  let requestId = 0;
+  let resolveResponse: ((message: JsonRpcMessage) => void) | undefined;
+  const transport: ServerTransport = {
+    start: async () => {},
+    send: async message => resolveResponse?.(message),
+    close: async () => transport.onclose?.(),
+  };
+
+  return {
+    executeTool,
+    async connect() {
+      await server.instance.connect(transport);
+    },
+    async call(arguments_: Record<string, unknown>) {
+      const id = ++requestId;
+      const response = new Promise<JsonRpcMessage>(resolve => {
+        resolveResponse = resolve;
+      });
+      const request: JsonRpcMessage = {
+        jsonrpc: '2.0',
+        id,
+        method: 'tools/call',
+        params: { name: 'ROOT_SCHEMA_TEST', arguments: arguments_ },
+      };
+      transport.onmessage?.(request);
+      return response;
+    },
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(connectedServers.splice(0).map(server => server.instance.close()));
+});
+
+describe('Claude Agent SDK root schema registration', () => {
+  it('preserves unknown fields when additionalProperties is true', async () => {
+    const harness = createToolHarness({
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      required: ['name'],
+      additionalProperties: true,
+    });
+    await harness.connect();
+
+    await harness.call({ name: 'Ada', score: 42 });
+
+    expect(harness.executeTool).toHaveBeenCalledWith('ROOT_SCHEMA_TEST', {
+      name: 'Ada',
+      score: 42,
+    });
+  });
+
+  it('preserves and validates schema-valued additional properties', async () => {
+    const harness = createToolHarness({
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      required: ['name'],
+      additionalProperties: { type: 'number' },
+    });
+    await harness.connect();
+
+    await harness.call({ name: 'Ada', score: 42 });
+    expect(harness.executeTool).toHaveBeenCalledWith('ROOT_SCHEMA_TEST', {
+      name: 'Ada',
+      score: 42,
+    });
+
+    harness.executeTool.mockClear();
+    const response = await harness.call({ name: 'Ada', score: 'high' });
+    expect(harness.executeTool).not.toHaveBeenCalled();
+    expect(response).toMatchObject({
+      result: {
+        isError: true,
+        content: [{ type: 'text', text: expect.stringContaining('Input validation error') }],
+      },
+    });
+  });
+
+  it('rejects unknown fields when additionalProperties is false', async () => {
+    const harness = createToolHarness({
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      required: ['name'],
+      additionalProperties: false,
+    });
+    await harness.connect();
+
+    const response = await harness.call({ name: 'Ada', score: 42 });
+
+    expect(harness.executeTool).not.toHaveBeenCalled();
+    expect(response).toMatchObject({
+      result: {
+        isError: true,
+        content: [{ type: 'text', text: expect.stringContaining('Input validation error') }],
+      },
+    });
+  });
+
+  it('rejects unknown fields under the default strict policy', async () => {
+    const harness = createToolHarness({
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      required: ['name'],
+    });
+    await harness.connect();
+
+    const response = await harness.call({ name: 'Ada', score: 42 });
+
+    expect(harness.executeTool).not.toHaveBeenCalled();
+    expect(response).toMatchObject({
+      result: {
+        isError: true,
+        content: [{ type: 'text', text: expect.stringContaining('Input validation error') }],
+      },
+    });
+  });
+
+  it('preserves patternProperties validation', async () => {
+    const harness = createToolHarness({
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      required: ['name'],
+      patternProperties: { '^metric_': { type: 'number' } },
+      additionalProperties: false,
+    });
+    await harness.connect();
+
+    await harness.call({ name: 'Ada', metric_score: 42 });
+    expect(harness.executeTool).toHaveBeenCalledWith('ROOT_SCHEMA_TEST', {
+      name: 'Ada',
+      metric_score: 42,
+    });
+
+    harness.executeTool.mockClear();
+    const response = await harness.call({ name: 'Ada', metric_score: 'high' });
+    expect(harness.executeTool).not.toHaveBeenCalled();
+    expect(response).toMatchObject({
+      result: {
+        isError: true,
+        content: [{ type: 'text', text: expect.stringContaining('Input validation error') }],
+      },
+    });
+
+    const unmatchedResponse = await harness.call({ name: 'Ada', other: 42 });
+    expect(harness.executeTool).not.toHaveBeenCalled();
+    expect(unmatchedResponse).toMatchObject({
+      result: {
+        isError: true,
+        content: [{ type: 'text', text: expect.stringContaining('Input validation error') }],
+      },
+    });
+  });
+});

--- a/ts/packages/providers/claude-agent-sdk/test/claude-agent-sdk.test.ts
+++ b/ts/packages/providers/claude-agent-sdk/test/claude-agent-sdk.test.ts
@@ -29,10 +29,11 @@ interface MockedClaudeAgentTool {
   _isMockedClaudeAgentTool: boolean;
 }
 
-// Minimal structural type for a zod-like raw shape value, matching only the member these
-// tests dereference (`safeParse`).
+// Minimal structural type for the complete Zod schema passed to the SDK.
 type MinimalZodSchema = {
-  safeParse: (value: unknown) => { success: boolean };
+  safeParse: (
+    value: unknown
+  ) => { success: true; data: unknown } | { success: false; error: unknown };
 };
 
 // The handler captured off the mocked `tool()` call. Some tests intentionally pass a raw
@@ -47,7 +48,7 @@ type MockedToolFn = Mock<
   (
     name: string,
     description: string | undefined,
-    schema: Record<string, MinimalZodSchema>,
+    schema: MinimalZodSchema,
     handler: MockedToolHandler
   ) => unknown
 >;
@@ -139,13 +140,24 @@ describe('ClaudeAgentSDKProvider', () => {
       expect(wrapped.description).toBe(mockTool.description);
     });
 
-    it('should pass a raw Zod shape to the Claude Agent SDK', () => {
+    it('should pass a complete Zod schema to the Claude Agent SDK', () => {
       provider.wrapTool(mockTool, mockExecuteToolFn);
 
-      const schemaShape = (tool as unknown as MockedToolFn).mock.calls[0][2];
-      expect(Object.keys(schemaShape)).toEqual(['to', 'subject', 'body']);
-      expect(schemaShape.to.safeParse('test@example.com').success).toBe(true);
-      expect(schemaShape.to.safeParse(123).success).toBe(false);
+      const schema = (tool as unknown as MockedToolFn).mock.calls[0][2];
+      expect(
+        schema.safeParse({
+          to: 'test@example.com',
+          subject: 'Test',
+          body: 'Hello',
+        }).success
+      ).toBe(true);
+      expect(
+        schema.safeParse({
+          to: 123,
+          subject: 'Test',
+          body: 'Hello',
+        }).success
+      ).toBe(false);
     });
 
     it('should handle tools without input parameters', () => {


### PR DESCRIPTION
This PR:

- registers complete Zod object schemas with the Claude Agent SDK so root object constraints survive registration
- preserves root `patternProperties` and boolean- or schema-valued `additionalProperties` through `ToolSchema.parse`
- validates dynamic keys by their actual regex match and forwards parsed/defaulted values to tool handlers
- keeps declared-property and no-input schemas strict by default while retaining permissive property-less schemas
- adds real `createSdkMcpServer` boundary tests instead of relying only on a mocked `tool()` call

## Context

This is the broader follow-up to #4065. That PR fixes property-less object schemas; this PR handles declared root properties combined with `additionalProperties` and the related root `patternProperties` behavior.

The branches overlap in the Claude provider implementation. If #4065 lands first, this branch should retain #4065's property-less converter path while using this PR's complete-schema Claude registration path. The converter behavior is semantically compatible with that combination.

## Testing

- `pnpm --filter @composio/json-schema-to-zod test` — 78 passed
- `pnpm --filter @composio/core test` — 1,049 passed
- `pnpm --filter @composio/claude-agent-sdk test` — 26 passed
- converter/core/provider typechecks and builds, including attw and publint
- changed-file Oxlint and Prettier checks
- changeset validation and `git diff --check`
- Claude Agent SDK 0.3.199 minimum-peer runtime probe with complete-schema validation