### PR TITLE
fix(core): release unread response bodies

### DIFF
--- a/.changeset/release-ssrf-redirect-bodies.md
+++ b/.changeset/release-ssrf-redirect-bodies.md
@@ -1,0 +1,5 @@
+---
+'@composio/core': patch
+---
+
+Release unread response bodies on the paths the SDK knowingly abandons: cancel every intermediate redirect body in `ssrfSafeFetch`, and the response body before throwing on `!response.ok` in both URL-upload call sites, instead of leaving them for the garbage collector to reclaim.

--- a/ts/packages/core/src/models/ToolRouterSessionFileMount.ts
+++ b/ts/packages/core/src/models/ToolRouterSessionFileMount.ts
@@ -114,6 +114,9 @@ export class ToolRouterSessionFilesMount {
       if (input.startsWith('http://') || input.startsWith('https://')) {
         const response = await ssrfSafeFetch(input);
         if (!response.ok) {
+          // The error path never reads the body, so release it explicitly (mirrors
+          // `readResponseBodyWithLimit`) instead of leaving it to the garbage collector.
+          await response.body?.cancel().catch(() => undefined);
           throw new Error(`Failed to fetch file from URL: ${response.statusText}`);
         }
         const content = await readResponseBodyWithLimit(response);

--- a/ts/packages/core/src/utils/fileUtils.node.ts
+++ b/ts/packages/core/src/utils/fileUtils.node.ts
@@ -176,6 +176,9 @@ const readFileContentFromURL = async (
   // redirect into them. See ssrfGuard.node.ts.
   const response = await ssrfSafeFetch(path, { signal });
   if (!response.ok) {
+    // The error path never reads the body, so release it explicitly (mirrors
+    // `readResponseBodyWithLimit`) instead of leaving it to the garbage collector.
+    await response.body?.cancel().catch(() => undefined);
     throw new Error(`Failed to fetch file: ${response.statusText}`);
   }
   const content = await readResponseBodyWithLimit(response);

--- a/ts/packages/core/src/utils/ssrfGuard.node.ts
+++ b/ts/packages/core/src/utils/ssrfGuard.node.ts
@@ -171,8 +171,8 @@ export const assertSafeFetchTarget = async (rawUrl: string): Promise<void> => {
 /**
  * Drop-in replacement for `fetch` that blocks SSRF. Validates the target before
  * connecting and re-validates every redirect hop (redirects are followed
- * manually up to {@link MAX_REDIRECTS}). Non-redirect responses are returned
- * unchanged.
+ * manually up to {@link MAX_REDIRECTS}). Intermediate redirect bodies are
+ * cancelled; non-redirect responses are returned unchanged.
  */
 export const ssrfSafeFetch = async (
   rawUrl: string,
@@ -191,6 +191,10 @@ export const ssrfSafeFetch = async (
     if (!isRedirect) {
       return response;
     }
+
+    // Only `location` is read from a redirect, so release its body explicitly rather
+    // than leaving it to the garbage collector (mirrors `readResponseBodyWithLimit`).
+    await response.body?.cancel().catch(() => undefined);
 
     currentUrl = new URL(response.headers.get('location')!, currentUrl).toString();
   }

--- a/ts/packages/core/test/models/ToolRouterSessionFilesMount.test.ts
+++ b/ts/packages/core/test/models/ToolRouterSessionFilesMount.test.ts
@@ -265,6 +265,24 @@ describe('ToolRouterSessionFilesMount', () => {
       expect(mockClient.toolRouter.session.files.createUploadURL).not.toHaveBeenCalled();
     });
 
+    it('should release a failed URL response body before throwing', async () => {
+      mockLookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }] as never);
+      const cancel = vi.fn();
+      const response = new Response(new ReadableStream({ cancel }), {
+        status: 500,
+        statusText: 'Internal Server Error',
+      });
+      vi.mocked(fetch).mockResolvedValueOnce(response);
+
+      await expect(filesMount.upload('https://files.example/failed.txt')).rejects.toThrow(
+        'Failed to fetch file from URL: Internal Server Error'
+      );
+
+      expect(cancel).toHaveBeenCalledOnce();
+      expect(response.bodyUsed).toBe(true);
+      expect(mockClient.toolRouter.session.files.createUploadURL).not.toHaveBeenCalled();
+    });
+
     it('should fetch and upload a public URL through the SSRF-safe path', async () => {
       mockLookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }] as never);
       vi.mocked(fetch)

--- a/ts/packages/core/test/utils/fileUtils.test.ts
+++ b/ts/packages/core/test/utils/fileUtils.test.ts
@@ -462,10 +462,12 @@ describe('fileUtils', () => {
     });
 
     it('should handle fetch errors for URLs', async () => {
-      mockFetch.mockResolvedValue({
-        ok: false,
+      const cancel = vi.fn();
+      const response = new Response(new ReadableStream({ cancel }), {
+        status: 500,
         statusText: 'Internal Server Error',
       });
+      mockFetch.mockResolvedValue(response);
 
       await expect(
         getFileDataAfterUploadingToS3('https://example.com/file.pdf', {
@@ -474,6 +476,9 @@ describe('fileUtils', () => {
           client: mockClient,
         })
       ).rejects.toThrow('Failed to fetch file: Internal Server Error');
+
+      expect(cancel).toHaveBeenCalledOnce();
+      expect(response.bodyUsed).toBe(true);
     });
 
     it('should handle S3 upload errors', async () => {

--- a/ts/packages/core/test/utils/ssrfGuard.test.ts
+++ b/ts/packages/core/test/utils/ssrfGuard.test.ts
@@ -162,4 +162,46 @@ describe('ssrfSafeFetch', () => {
       ComposioBlockedInternalUrlError
     );
   });
+
+  it('releases the redirect body before following the hop', async () => {
+    resolvesTo('93.184.216.34');
+    const fetchCallsWhenReleased: number[] = [];
+    const cancel = vi.fn(() => {
+      fetchCallsWhenReleased.push(mockFetch.mock.calls.length);
+    });
+    const redirect = new Response(new ReadableStream({ cancel }), {
+      status: 302,
+      headers: { location: 'https://example.com/final' },
+    });
+    mockFetch
+      .mockResolvedValueOnce(redirect)
+      .mockResolvedValueOnce(new Response('data', { status: 200 }));
+
+    const res = await ssrfSafeFetch('https://example.com/start');
+
+    expect(res.status).toBe(200);
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(redirect.bodyUsed).toBe(true);
+    // Released while following the first hop, not left dangling for the rest of the call.
+    expect(fetchCallsWhenReleased).toEqual([1]);
+  });
+
+  it('releases every hop body when the redirect budget is exhausted', async () => {
+    resolvesTo('93.184.216.34');
+    const cancel = vi.fn();
+    // A fresh body per hop: cancelling the same stream twice is a no-op the second time.
+    mockFetch.mockImplementation(
+      async () =>
+        new Response(new ReadableStream({ cancel }), {
+          status: 302,
+          headers: { location: 'https://example.com/again' },
+        })
+    );
+
+    await expect(ssrfSafeFetch('https://example.com/start', {}, 2)).rejects.toBeInstanceOf(
+      ComposioBlockedInternalUrlError
+    );
+    // maxRedirects = 2 => hops 0, 1, 2 are fetched before the budget throws.
+    expect(cancel).toHaveBeenCalledTimes(3);
+  });
 });


### PR DESCRIPTION
This PR:
- follows [Undici's recommendation](https://github.com/nodejs/undici#garbage-collection) to consume or cancel unread response bodies instead of leaving connection-resource cleanup to the garbage collector, which can increase connection pressure and reduce reuse
- cancels every intermediate redirect body in `ssrfSafeFetch` before validating and following the next hop
- cancels non-success response bodies in both URL-upload callers before preserving their existing errors
- adds regression coverage for redirect ordering, redirect-budget exhaustion, and both caller error paths
- adds a patch changeset for `@composio/core`
- supersedes https://github.com/ComposioHQ/composio/pull/4018 and credits @pacocartones as co-author

## Verification

- `pnpm --filter @composio/core test ssrfGuard fileUtils ToolRouterSessionFilesMount` (4 files, 58 tests passed)
- `pnpm --filter @composio/core test` (47 files, 1,049 tests passed)
- `pnpm --filter @composio/core typecheck`
- `pnpm lint:packages` (0 errors; existing warnings only)
- Prettier check on all touched files
- `pnpm validate:changesets`
