### PR TITLE
[codex] fix(core): reuse fetched tool schemas for agentic execution

### DIFF
--- a/.changeset/reuse-fetched-tool-schema.md
+++ b/.changeset/reuse-fetched-tool-schema.md
@@ -1,0 +1,5 @@
+---
+'@composio/core': patch
+---
+
+Reuse tool schemas fetched by `tools.get()` when provider-wrapped tools execute, avoiding a redundant schema retrieval request for each agentic tool call.

--- a/ts/packages/core/src/models/Tools.ts
+++ b/ts/packages/core/src/models/Tools.ts
@@ -824,7 +824,7 @@ export class Tools<
     tools: Tool[],
     modifiers?: ExecuteToolModifiers
   ): ReturnType<T['wrapTools']> {
-    const executeToolFn = this.createExecuteToolFn(userId, modifiers);
+    const executeToolFn = this.createExecuteToolFn(userId, tools, modifiers);
     return this.provider.wrapTools(tools, executeToolFn) as ReturnType<T['wrapTools']>;
   }
 
@@ -853,22 +853,28 @@ export class Tools<
    * This function is used by agentic providers to execute the tool
    *
    * @param {string} userId - The user id
+   * @param {Tool[]} tools - The fetched tools available to the provider
    * @param {ExecuteToolModifiers} modifiers - The modifiers to be applied to the tool
    * @returns {ExecuteToolFn} The execute tool function
    */
-  private createExecuteToolFn(userId: string, modifiers?: ExecuteToolModifiers): ExecuteToolFn {
+  private createExecuteToolFn(
+    userId: string,
+    tools: Tool[],
+    modifiers?: ExecuteToolModifiers
+  ): ExecuteToolFn {
+    const toolBySlug = new Map(tools.map(tool => [tool.slug.toUpperCase(), tool]));
     const executeToolFn = async (toolSlug: string, input: Record<string, unknown>) => {
-      return await this.execute(
-        toolSlug,
-        {
-          userId,
-          arguments: input,
-          // dangerously skip version check for agentic tool execution via providers
-          // this can be safe because most agentic flows users fetch latest version and then execute the tool
-          dangerouslySkipVersionCheck: true,
-        },
-        modifiers
-      );
+      const body: ToolExecuteParams = {
+        userId,
+        arguments: input,
+        // dangerously skip version check for agentic tool execution via providers
+        // this can be safe because most agentic flows users fetch latest version and then execute the tool
+        dangerouslySkipVersionCheck: true,
+      };
+      const tool = toolBySlug.get(toolSlug.toUpperCase());
+      return tool
+        ? this.executeWithTool(toolSlug, body, modifiers, tool)
+        : this.execute(toolSlug, body, modifiers);
     };
     return executeToolFn;
   }
@@ -961,6 +967,51 @@ export class Tools<
     }
   }
 
+  private async executeWithTool(
+    slug: string,
+    body: ToolExecuteParams,
+    options: (ExecuteToolModifiers & ComposioRequestOptions) | undefined,
+    tool: Tool
+  ): Promise<ToolExecuteResponse> {
+    const executeParams = ToolExecuteParamsSchema.safeParse(body);
+    if (!executeParams.success) {
+      throw new ValidationError('Invalid tool execute parameters', { cause: executeParams.error });
+    }
+
+    const requestOptions: ComposioRequestOptions | undefined =
+      options?.signal != null ? { signal: options.signal } : undefined;
+    const { signal: _, ...modifiers } = options ?? {};
+    const toolkitSlug = tool.toolkit?.slug ?? 'unknown';
+
+    // Apply before execute modifiers
+    const params = await this.applyBeforeExecuteModifiers(
+      tool,
+      {
+        toolSlug: slug,
+        toolkitSlug,
+        params: executeParams.data,
+      },
+      modifiers as ExecuteToolModifiers,
+      requestOptions
+    );
+
+    let result = await this.executeComposioTool(tool, params, requestOptions);
+
+    // Apply after execute modifiers
+    result = await this.applyAfterExecuteModifiers(
+      tool,
+      {
+        toolSlug: slug,
+        toolkitSlug,
+        result,
+      },
+      (modifiers as ExecuteToolModifiers).afterExecute,
+      requestOptions
+    );
+
+    return result;
+  }
+
   /**
    * Executes a given tool with the provided parameters.
    *
@@ -1051,46 +1102,14 @@ export class Tools<
       throw new ValidationError('Invalid tool execute parameters', { cause: executeParams.error });
     }
 
-    const requestOptions: ComposioRequestOptions | undefined =
-      options?.signal != null ? { signal: options.signal } : undefined;
-    const { signal: _, ...modifiers } = options ?? {};
-
     const tool = await this.getRawComposioToolBySlug(
       slug,
       {
         version: body.version,
       },
-      requestOptions
+      options?.signal != null ? { signal: options.signal } : undefined
     );
-    const toolkitSlug = tool.toolkit?.slug ?? 'unknown';
-
-    // Apply before execute modifiers
-    const params = await this.applyBeforeExecuteModifiers(
-      tool,
-      {
-        toolSlug: slug,
-        toolkitSlug,
-        params: executeParams.data,
-      },
-      modifiers as ExecuteToolModifiers,
-      requestOptions
-    );
-
-    let result = await this.executeComposioTool(tool, params, requestOptions);
-
-    // Apply after execute modifiers
-    result = await this.applyAfterExecuteModifiers(
-      tool,
-      {
-        toolSlug: slug,
-        toolkitSlug,
-        result,
-      },
-      (modifiers as ExecuteToolModifiers).afterExecute,
-      requestOptions
-    );
-
-    return result;
+    return this.executeWithTool(slug, body, options, tool);
   }
 
   /**

--- a/ts/packages/core/src/models/Tools.ts
+++ b/ts/packages/core/src/models/Tools.ts
@@ -766,33 +766,45 @@ export class Tools<
     const { signal: _, ...modifiers } = options ?? {};
 
     if (typeof arg2 === 'string') {
-      const tool = await this.getRawComposioToolBySlug(
-        arg2,
-        {
-          modifySchema: options?.modifySchema as TransformToolSchemaModifier,
-        },
-        requestOptions
-      );
+      const rawTool = await this.getRawComposioToolBySlug(arg2, undefined, requestOptions);
+      const tool = await this.applySchemaModifier(rawTool, options?.modifySchema);
       return this.wrapToolsForProvider(
         userId,
         [tool],
-        modifiers as ExecuteToolModifiers
+        modifiers as ExecuteToolModifiers,
+        [rawTool]
       ) as TToolCollection;
     } else {
-      const tools = await this.getRawComposioTools(
-        arg2,
-        {
-          modifySchema: options?.modifySchema as TransformToolSchemaModifier,
-        },
-        requestOptions
+      const rawTools = await this.getRawComposioTools(arg2, undefined, requestOptions);
+      const tools = await Promise.all(
+        rawTools.map(tool => this.applySchemaModifier(tool, options?.modifySchema))
       );
       return this.wrapToolsForProvider(
         userId,
         tools,
-        modifiers as ExecuteToolModifiers
+        modifiers as ExecuteToolModifiers,
+        rawTools
       ) as TToolCollection;
     }
   }
+
+  private async applySchemaModifier(
+    tool: Tool,
+    modifier?: TransformToolSchemaModifier
+  ): Promise<Tool> {
+    if (!modifier) {
+      return tool;
+    }
+    if (typeof modifier !== 'function') {
+      throw new ComposioInvalidModifierError('Invalid schema modifier. Not a function.');
+    }
+    return modifier({
+      toolSlug: tool.slug,
+      toolkitSlug: tool.toolkit?.slug ?? 'unknown',
+      schema: tool,
+    });
+  }
+
   /**
    * @internal
    * Creates a global execute tool function.
@@ -817,14 +829,16 @@ export class Tools<
    * @param userId - The user id to get the tools for
    * @param tools - The tools to wrap
    * @param modifiers - The modifiers to be applied to the tools
+   * @param rawTools - The unmodified tool schemas used for execution metadata
    * @returns The wrapped tools
    */
   wrapToolsForProvider<T extends TProvider>(
     userId: string,
     tools: Tool[],
-    modifiers?: ExecuteToolModifiers
+    modifiers?: ExecuteToolModifiers,
+    rawTools: Tool[] = tools
   ): ReturnType<T['wrapTools']> {
-    const executeToolFn = this.createExecuteToolFn(userId, tools, modifiers);
+    const executeToolFn = this.createExecuteToolFn(userId, modifiers, rawTools);
     return this.provider.wrapTools(tools, executeToolFn) as ReturnType<T['wrapTools']>;
   }
 
@@ -853,14 +867,14 @@ export class Tools<
    * This function is used by agentic providers to execute the tool
    *
    * @param {string} userId - The user id
-   * @param {Tool[]} tools - The fetched tools available to the provider
    * @param {ExecuteToolModifiers} modifiers - The modifiers to be applied to the tool
+   * @param {Tool[]} tools - The fetched tools available to the provider
    * @returns {ExecuteToolFn} The execute tool function
    */
   private createExecuteToolFn(
     userId: string,
-    tools: Tool[],
-    modifiers?: ExecuteToolModifiers
+    modifiers: ExecuteToolModifiers | undefined,
+    tools: Tool[]
   ): ExecuteToolFn {
     const toolBySlug = new Map(tools.map(tool => [tool.slug.toUpperCase(), tool]));
     const executeToolFn = async (toolSlug: string, input: Record<string, unknown>) => {

--- a/ts/packages/core/test/tools/modifiers.test.ts
+++ b/ts/packages/core/test/tools/modifiers.test.ts
@@ -243,9 +243,7 @@ describe('Tools Modifiers', () => {
       // Verify schema modification
       expect(getRawComposioToolBySlugSpy).toHaveBeenCalledWith(
         slug,
-        {
-          modifySchema: schemaModifier,
-        },
+        undefined,
         undefined
       );
       expect(mockTool.description).toBe('Enhanced GITHUB_GET_REPOS for better context');
@@ -256,7 +254,8 @@ describe('Tools Modifiers', () => {
       // Verify execution function creation
       expect(createExecuteToolFnSpy).toHaveBeenCalledWith(
         userId,
-        expect.objectContaining(executionModifiers)
+        expect.objectContaining(executionModifiers),
+        expect.any(Array)
       );
 
       // Mock a tool execution to verify the full flow

--- a/ts/packages/core/test/tools/tools.test.ts
+++ b/ts/packages/core/test/tools/tools.test.ts
@@ -741,9 +741,7 @@ describe('Tools', () => {
 
       expect(getRawComposioToolBySlugSpy).toHaveBeenCalledWith(
         slug,
-        {
-          modifySchema: undefined,
-        },
+        undefined,
         undefined
       );
       expect(context.mockProvider.wrapTools).toHaveBeenCalledWith(
@@ -766,7 +764,7 @@ describe('Tools', () => {
 
       expect(getRawComposioToolsSpy).toHaveBeenCalledWith(
         filters,
-        { modifySchema: undefined },
+        undefined,
         undefined
       );
       expect(context.mockProvider.wrapTools).toHaveBeenCalled();
@@ -789,9 +787,7 @@ describe('Tools', () => {
 
       expect(getRawComposioToolBySlugSpy).toHaveBeenCalledWith(
         slug,
-        {
-          modifySchema: schemaModifier,
-        },
+        undefined,
         undefined
       );
     });
@@ -2448,6 +2444,42 @@ describe('Tools', () => {
         expect(getRawComposioToolBySlugSpy).toHaveBeenCalledTimes(1);
         expect(mockClient.tools.retrieve).not.toHaveBeenCalled();
         expect(mockClient.tools.execute).toHaveBeenCalledTimes(1);
+      });
+
+      it('should resolve toolkit versions from the raw schema when modifySchema rewrites toolkit', async () => {
+        const mockProvider = new MockProvider();
+        const tools = new Tools(mockClient, {
+          provider: mockProvider,
+          toolkitVersions: { 'test-toolkit': '20250101_00' },
+        });
+        const userId = 'test-user';
+        const toolSlug = 'GITHUB_CREATE_ISSUE';
+        const rawTool = {
+          ...toolMocks.transformedTool,
+          slug: toolSlug,
+          toolkit: { slug: 'test-toolkit', name: 'Test Toolkit' },
+        } as unknown as Tool;
+        const modifiedTool = {
+          ...rawTool,
+          toolkit: { slug: 'renamed-toolkit', name: 'Renamed Toolkit' },
+        } as unknown as Tool;
+        vi.spyOn(tools, 'getRawComposioToolBySlug').mockResolvedValueOnce(rawTool);
+        const schemaModifier = vi.fn().mockResolvedValueOnce(modifiedTool);
+        let storedExecuteToolFn: ExecuteToolFn | undefined;
+        mockProvider.wrapTools.mockImplementation((_tools, executeToolFn) => {
+          storedExecuteToolFn = executeToolFn;
+          return 'wrapped-tools';
+        });
+
+        await tools.get(userId, toolSlug, { modifySchema: schemaModifier });
+        mockClient.tools.execute.mockResolvedValueOnce(toolMocks.rawToolExecuteResponse);
+        await storedExecuteToolFn!(toolSlug, {});
+
+        expect(mockClient.tools.execute).toHaveBeenCalledWith(
+          toolSlug,
+          expect.objectContaining({ version: '20250101_00' }),
+          undefined
+        );
       });
     });
   });

--- a/ts/packages/core/test/tools/tools.test.ts
+++ b/ts/packages/core/test/tools/tools.test.ts
@@ -2419,6 +2419,36 @@ describe('Tools', () => {
           undefined
         );
       });
+
+      it('should reuse the fetched tool schema during agentic execution', async () => {
+        const context = createTestContext();
+        const userId = 'test-user';
+        const toolSlug = 'GITHUB_CREATE_ISSUE';
+        const fetchedTool = {
+          ...toolMocks.transformedTool,
+          slug: toolSlug,
+          toolkit: { slug: 'github', name: 'GitHub' },
+        } as unknown as Tool;
+        const getRawComposioToolBySlugSpy = vi
+          .spyOn(context.tools, 'getRawComposioToolBySlug')
+          .mockResolvedValueOnce(fetchedTool);
+        let storedExecuteToolFn: ExecuteToolFn | undefined;
+
+        context.mockProvider.wrapTools.mockImplementation((_tools, executeToolFn) => {
+          storedExecuteToolFn = executeToolFn;
+          return 'wrapped-tools-collection';
+        });
+
+        await context.tools.get(userId, toolSlug);
+        mockClient.tools.execute.mockResolvedValueOnce(toolMocks.rawToolExecuteResponse);
+
+        const result = await storedExecuteToolFn!(toolSlug, { title: 'Test Issue' });
+
+        expect(result).toEqual(toolMocks.toolExecuteResponse);
+        expect(getRawComposioToolBySlugSpy).toHaveBeenCalledTimes(1);
+        expect(mockClient.tools.retrieve).not.toHaveBeenCalled();
+        expect(mockClient.tools.execute).toHaveBeenCalledTimes(1);
+      });
     });
   });
 });


### PR DESCRIPTION
Closes #4087

## What changed

- Reuse the tool schema already fetched by `tools.get()` when provider-wrapped tools execute.
- Keep the existing retrieval path as a fallback when a provider invokes an unknown tool slug.
- Add a regression test proving that one agentic execution does not issue a redundant `tools.retrieve` request.
- Add a patch changeset for `@composio/core`.

## Why

Provider integrations already receive the complete tool schema from `tools.get()`, but the execution callback previously called `tools.retrieve` again for every tool invocation. The change passes the fetched schema through the provider callback and preserves the existing execution and modifier flow.

## Validation

- `vitest run --config ts/packages/core/vitest.config.ts ts/packages/core/test/tools/tools.test.ts` (92 passed)
- `tsc --noEmit --skipLibCheck -p ts/packages/core/tsconfig.json`
- `git diff --check`

Local `pnpm install` is blocked after dependency installation by the repository's Unix-style `preinstall` script on Windows; the focused checks were run directly with the installed binaries.
