### PR TITLE
fix(providers): correct CrewAI tool argument handling

### DIFF
--- a/python/providers/crewai/composio_crewai/providers.py
+++ b/python/providers/crewai/composio_crewai/providers.py
@@ -22,6 +22,38 @@ class CrewAIProvider(AgenticProvider[BaseTool, list[BaseTool]], name="crewai"):
         """Wrap a tool as a CrewAI tool."""
 
         class Wrapper(BaseTool):
+            def _validate_kwargs(
+                self, kwargs: t.Dict[str, t.Any]
+            ) -> t.Dict[str, t.Any]:
+                """Validate arguments without renaming or padding them.
+
+                CrewAI's own implementation dumps the validated model with
+                neither ``by_alias`` nor ``exclude_unset``, which corrupts the
+                payload in two ways: parameters aliased to keep them valid
+                Python identifiers (``validate`` becomes ``validate_``) reach
+                the backend under the wrong key, and optional parameters the
+                model never supplied are materialized as explicit ``None``.
+
+                It also wraps the failure as a plain ``ValueError``, which
+                escapes the ``pydantic.ValidationError`` handler below.
+                Re-raising the original keeps that handler reachable.
+                """
+                schema = self.args_schema
+                if schema is None or not schema.model_fields:
+                    return kwargs
+                validated = schema.model_validate(kwargs)
+                return validated.model_dump(by_alias=True, exclude_unset=True)
+
+            def run(self, *args, **kwargs):
+                try:
+                    return super().run(*args, **kwargs)
+                except pydantic.ValidationError as e:
+                    return {
+                        "successful": False,
+                        "error": parse_pydantic_error(e),
+                        "data": None,
+                    }
+
             def _run(self, **kwargs):
                 try:
                     # Normalize defensively so a stringified payload is coerced to a dict (issue #2406).

--- a/python/tests/test_crewai_provider.py
+++ b/python/tests/test_crewai_provider.py
@@ -1,0 +1,125 @@
+"""Tests for the CrewAI provider's argument handling.
+
+CrewAI validates and dumps tool arguments in ``BaseTool.run`` before ``_run`` is
+reached, so the provider has to control that step itself. See the wrapper in
+``composio_crewai.providers``.
+"""
+
+import typing as t
+
+import pytest
+
+from composio.client.types import Tool
+
+
+crewai = pytest.importorskip("crewai", reason="crewai is not installed")
+
+from composio_crewai import CrewAIProvider  # noqa: E402
+
+
+def _tool(properties: t.Dict[str, t.Any], required: t.List[str]) -> Tool:
+    return Tool.construct(
+        slug="TEST_TOOL",
+        name="Test tool",
+        description="A tool for testing",
+        input_parameters={
+            "type": "object",
+            "title": "Request",
+            "properties": properties,
+            "required": required,
+        },
+        output_parameters={},
+        toolkit={"slug": "test", "name": "Test"},
+        available_versions=["latest"],
+        version="latest",
+        tags=[],
+        no_auth=True,
+        deprecated=None,
+        scopes=[],
+    )
+
+
+def _wrap(tool: Tool):
+    """Wrap a tool, returning it alongside the payloads its executor receives."""
+    received: t.List[t.Dict[str, t.Any]] = []
+
+    def execute_tool(slug: str, arguments: t.Dict) -> t.Dict:
+        received.append(arguments)
+        return {"successful": True, "data": arguments}
+
+    wrapped = CrewAIProvider().wrap_tools([tool], execute_tool)[0]
+    return wrapped, received
+
+
+def test_unset_optional_arguments_are_not_sent():
+    """Optional parameters the model never supplied must not reach the backend.
+
+    CrewAI's ``model_dump()`` materializes every field, turning "not supplied"
+    into an explicit ``None``.
+    """
+    tool = _tool(
+        {
+            "query": {"type": "string"},
+            "limit": {"type": "integer"},
+            "note": {"type": "string"},
+        },
+        required=["query"],
+    )
+    wrapped, received = _wrap(tool)
+
+    wrapped.run(query="ai")
+
+    assert received == [{"query": "ai"}]
+
+
+def test_supplied_arguments_are_preserved():
+    tool = _tool(
+        {"query": {"type": "string"}, "limit": {"type": "integer"}},
+        required=["query"],
+    )
+    wrapped, received = _wrap(tool)
+
+    wrapped.run(query="ai", limit=5)
+
+    assert received == [{"query": "ai", "limit": 5}]
+
+
+def test_reserved_parameter_names_reach_the_backend_unaliased():
+    """``validate`` is aliased to ``validate_`` for pydantic; undo it on the way out."""
+    tool = _tool(
+        {"validate": {"type": "string"}, "query": {"type": "string"}},
+        required=["query"],
+    )
+    wrapped, received = _wrap(tool)
+
+    wrapped.run(query="ai", validate="yes")
+
+    assert received == [{"query": "ai", "validate": "yes"}]
+
+
+def test_invalid_argument_type_returns_structured_error():
+    """CrewAI raises ``ValueError`` from ``run``; the provider must still answer."""
+    tool = _tool(
+        {"query": {"type": "string"}, "limit": {"type": "integer"}},
+        required=["query"],
+    )
+    wrapped, received = _wrap(tool)
+
+    result = wrapped.run(query="ai", limit="not-an-integer")
+
+    assert result["successful"] is False
+    assert result["data"] is None
+    assert "limit" in result["error"]
+    assert received == []
+
+
+def test_missing_required_argument_returns_structured_error():
+    tool = _tool({"query": {"type": "string"}}, required=["query"])
+    wrapped, received = _wrap(tool)
+
+    result = wrapped.run()
+
+    assert result["successful"] is False
+    assert result["data"] is None
+    assert "query" in result["error"]
+    assert received == []


### PR DESCRIPTION
## Summary

CrewAI validates and dumps tool arguments in `BaseTool.run` before `_run` is reached, so the provider never got to shape the payload. Three consequences, all reproducible offline with a stubbed executor.

Fixes #4092

## Changes

- `Wrapper._validate_kwargs` — dump with `by_alias=True, exclude_unset=True` so aliased parameters keep their original names and unsupplied optionals are not sent:

  ```
  before: {'query': 'ai', 'limit': None, 'validate_': None}
  after:  {'query': 'ai'}
  ```

  `validate` is aliased to `validate_` to stay a valid Python identifier; `json_schema_to_model` records the alias correctly, but the plain `model_dump()` ignored it, so the backend received a parameter it does not have and the real one was missing.

- `Wrapper.run` — catch `pydantic.ValidationError` and return the structured `{"successful": False, ...}` response the provider already intended. The existing handler in `_run` could never fire, because crewai validates earlier and re-raises as a plain `ValueError`. This mirrors what the LangChain provider already does in its `StructuredTool.run`.

- `python/tests/test_crewai_provider.py` — five tests, one per behaviour.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [ ] Documentation
- [ ] Breaking change

## How Has This Been Tested?

Python 3.12.13, `crewai==1.15.7`. No API key required — the tests stub the executor.

```
pytest python/tests/test_crewai_provider.py     ->  5 passed
pytest python/tests                             ->  971 passed, 10 failed
ruff --config config/ruff.toml check providers/ tests/   ->  All checks passed
ruff --config config/ruff.toml format providers/crewai tests/test_crewai_provider.py
```

The 10 failures are pre-existing `type_inference` tests that need `COMPOSIO_API_KEY`; they fail identically on `next` with this branch stashed (966 passed / 10 failed there, so this adds 5 and breaks none).

The new tests were also run against `next` to confirm they are real guards rather than decoration — 4 of the 5 fail without the fix.

## Checklist

- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed
- [ ] I updated documentation as needed — no user-facing API change
- [x] I added tests or explain why not applicable
- [ ] I added a changeset if this change affects published packages — Python is not on Changesets

## Additional context

**Deliberate coupling.** `_validate_kwargs` is a private crewai method. The package pins `crewai>=1.15.7,<2.0.0`, so it is stable within the supported range, but flagging it since it is an override of framework internals rather than a public hook.

**Scope.** The LangChain provider has the same aliasing and null-padding behaviour, but its dump happens inside `langchain_core`'s `BaseTool._parse_input`, so it needs a different approach and is left as a follow-up rather than bundled here. `composio_langgraph` uses the same `json_schema_to_model` helper and is likely affected; I did not exercise it. Details in #4092.

**Prior art.** `alias_tool_input_schema` exists for exactly this problem — restoring original argument names before calling the backend executor — and the Anthropic provider uses it. The `json_schema_to_model` providers never got the equivalent. Happy to reshape this as a shared helper instead if you would rather solve it once for all three.
