### PR TITLE
fix(e2e): pack core's workspace dependency in the openai-zod4 fixture

### DIFF
--- a/ts/e2e-tests/runtimes/node/openai-zod4-compat/README.md
+++ b/ts/e2e-tests/runtimes/node/openai-zod4-compat/README.md
@@ -26,8 +26,16 @@ fixtures/
 └── tsconfig.json  # Strict consumer compiler settings
 ```
 
-The setup phase packs both Composio packages, installs them with explicit
+The setup phase packs the Composio packages, installs them with explicit
 OpenAI 7 and Zod 4 versions, and typechecks without `skipLibCheck`.
+
+`@composio/json-schema-to-zod` is packed alongside `@composio/core` and
+`@composio/openai` even though the fixture never imports it directly. `pnpm
+pack` rewrites `@composio/core`'s `workspace:*` dependency on it to the exact
+workspace version, so installing the core tarball alone makes npm fetch that
+version from the registry. On a release branch the workspace version is the
+one about to be published and does not exist yet, which fails the install.
+Packing it locally keeps the fixture resolvable before publication.
 
 ## Setup
 

--- a/ts/e2e-tests/runtimes/node/openai-zod4-compat/fixtures/package.json
+++ b/ts/e2e-tests/runtimes/node/openai-zod4-compat/fixtures/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "install:composio": "pnpm --dir /app/ts/packages/core pack --pack-destination \"$PWD\" --silent >/dev/null && pnpm --dir /app/ts/packages/providers/openai pack --pack-destination \"$PWD\" --silent >/dev/null && npm install --ignore-scripts --package-lock=false ./composio-core-*.tgz ./composio-openai-*.tgz",
+    "install:composio": "pnpm --dir /app/ts/packages/json-schema-to-zod pack --pack-destination \"$PWD\" --silent >/dev/null && pnpm --dir /app/ts/packages/core pack --pack-destination \"$PWD\" --silent >/dev/null && pnpm --dir /app/ts/packages/providers/openai pack --pack-destination \"$PWD\" --silent >/dev/null && npm install --ignore-scripts --package-lock=false ./composio-json-schema-to-zod-*.tgz ./composio-core-*.tgz ./composio-openai-*.tgz",
     "typecheck": "tsc --noEmit && echo openai v7 compatibility typecheck passed"
   },
   "dependencies": {


### PR DESCRIPTION
The `openai-zod4-compat` E2E fixture fails on every release branch that bumps an internal workspace package. It is currently blocking the Python 0.18.2 / TypeScript 0.15.0 train (https://github.com/ComposioHQ/composio/pull/4038).

## Root cause

The fixture packs `@composio/core` and `@composio/openai` and installs the tarballs. `pnpm pack` rewrites `@composio/core`'s `workspace:*` dependency on `@composio/json-schema-to-zod` to the exact workspace version, so the tarball carries a hard pin:

```json
"@composio/json-schema-to-zod": "0.2.2"
```

On `next` that pin points at an already-published version, so the install resolves from the registry and the fixture passes. On a release branch it points at the version about to be published, which does not exist yet:

```
npm error code ETARGET
npm error notarget No matching version found for @composio/json-schema-to-zod@0.2.2.
```

The setup step then exits non-zero and all 7 assertions fail with empty output. That is exactly what https://github.com/ComposioHQ/composio/pull/4038 shows: `@composio/json-schema-to-zod` is bumped to `0.2.2` there, which is the first release train to bump an internal dependency of `@composio/core` since this fixture was added.

## Fix

Pack `@composio/json-schema-to-zod` alongside the other two and install all three tarballs. npm satisfies core's pin from the top-level tarball, so the fixture resolves entirely from local builds and no longer depends on publication order. Behavior on `next` is unchanged — it just prefers the local build over the identical published one.

## Verification

Reproduced and fixed against the release branch (`changeset-release/next` @ `8068225d7`, core `0.15.0` / json-schema-to-zod `0.2.2`) in a local worktree, since Docker was not available to run the containerized suite here:

- packing core alone and running the fixture's install command reproduces the ETARGET failure verbatim
- packing all three and installing them succeeds; `node_modules/@composio/json-schema-to-zod` resolves to `0.2.2` and `@composio/core`'s pin is satisfied locally
- `node ts/scripts/validate-changesets.mjs` passes; no changeset needed, the fixture is a private package

CI runs the real containerized suite on this PR.