### PR TITLE
fix(core): reuse fetched schemas for provider execution

### DIFF
--- a/.changeset/reuse-provider-tool-schemas.md
+++ b/.changeset/reuse-provider-tool-schemas.md
@@ -1,0 +1,5 @@
+---
+'@composio/core': patch
+---
+
+Reuse fetched tool schemas when provider-wrapped tools execute to avoid a redundant retrieval request.

--- a/mise.lock
+++ b/mise.lock
@@ -89,23 +89,23 @@ version = "3.12.13"
 backend = "core:python"
 
 [tools.python."platforms.linux-arm64"]
-checksum = "sha256:f3510827b61e7a2aa89a1bb7bac73d45521939c489cf43f4699618efaead0611"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260805/cpython-3.12.13+20260805-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+checksum = "sha256:11e713ae1f969385907a76533cc554f6b2e3f1a84896009f91c3fc871034a170"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260807/cpython-3.12.13+20260807-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
 provenance = "github-attestations"
 
 [tools.python."platforms.linux-x64"]
-checksum = "sha256:f04a55ae95e8bd352cdff8da11c344fe609ec84795d106fa91b6620366d786fe"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260805/cpython-3.12.13+20260805-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+checksum = "sha256:506191be3ee7bd190a8834dcdc1b3bc70aab50608deccc711935aa007239cabd"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260807/cpython-3.12.13+20260807-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
 provenance = "github-attestations"
 
 [tools.python."platforms.macos-arm64"]
-checksum = "sha256:a4b36035915038104aabee94d6f02827161da444296881fe4493cb98f70304b2"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260805/cpython-3.12.13+20260805-aarch64-apple-darwin-install_only_stripped.tar.gz"
+checksum = "sha256:25baa97c65b3f0aa90e21131b4f9e80aef8899e8144006db8a9d2c1ab9e807e3"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260807/cpython-3.12.13+20260807-aarch64-apple-darwin-install_only_stripped.tar.gz"
 provenance = "github-attestations"
 
 [tools.python."platforms.macos-x64"]
-checksum = "sha256:0d232711501680a619ea6113046603567d93be3218e326e4357557e771d1aec7"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260805/cpython-3.12.13+20260805-x86_64-apple-darwin-install_only_stripped.tar.gz"
+checksum = "sha256:127053f1736f721e391ddb46f07585d05756e15bb8d757d3bbc0519738998ba1"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260807/cpython-3.12.13+20260807-x86_64-apple-darwin-install_only_stripped.tar.gz"
 provenance = "github-attestations"
 
 [[tools.uv]]

--- a/ts/packages/core/src/models/Tools.ts
+++ b/ts/packages/core/src/models/Tools.ts
@@ -470,14 +470,12 @@ export class Tools<
       'important' in queryParams.data ? queryParams.data.important : shouldAutoApplyImportant;
 
     // check if the query params contains atleast one of the following: tools, toolkits, search, authConfigIds
-    if (
-      !(
-        'tools' in queryParams.data ||
-        'toolkits' in queryParams.data ||
-        'search' in queryParams.data ||
-        'authConfigIds' in queryParams.data
-      )
-    ) {
+    if (!(
+      'tools' in queryParams.data ||
+      'toolkits' in queryParams.data ||
+      'search' in queryParams.data ||
+      'authConfigIds' in queryParams.data
+    )) {
       throw new ValidationError(
         'Invalid tool list parameters, atleast one of the following parameters is required: tools, toolkits, search, authConfigIds'
       );
@@ -766,33 +764,44 @@ export class Tools<
     const { signal: _, ...modifiers } = options ?? {};
 
     if (typeof arg2 === 'string') {
-      const tool = await this.getRawComposioToolBySlug(
-        arg2,
-        {
-          modifySchema: options?.modifySchema as TransformToolSchemaModifier,
-        },
-        requestOptions
-      );
-      return this.wrapToolsForProvider(
-        userId,
-        [tool],
-        modifiers as ExecuteToolModifiers
-      ) as TToolCollection;
+      const rawTool = await this.getRawComposioToolBySlug(arg2, undefined, requestOptions);
+      const [tool] = await this.applySchemaModifiers([rawTool], options?.modifySchema);
+      return this.wrapToolsForProvider(userId, [tool], modifiers as ExecuteToolModifiers, [
+        rawTool,
+      ]) as TToolCollection;
     } else {
-      const tools = await this.getRawComposioTools(
-        arg2,
-        {
-          modifySchema: options?.modifySchema as TransformToolSchemaModifier,
-        },
-        requestOptions
-      );
+      const rawTools = await this.getRawComposioTools(arg2, undefined, requestOptions);
+      const tools = await this.applySchemaModifiers(rawTools, options?.modifySchema);
       return this.wrapToolsForProvider(
         userId,
         tools,
-        modifiers as ExecuteToolModifiers
+        modifiers as ExecuteToolModifiers,
+        rawTools
       ) as TToolCollection;
     }
   }
+
+  private async applySchemaModifiers(
+    tools: Tool[],
+    modifier?: TransformToolSchemaModifier
+  ): Promise<Tool[]> {
+    if (modifier && typeof modifier !== 'function') {
+      throw new ComposioInvalidModifierError('Invalid schema modifier. Not a function.');
+    }
+    return Promise.all(
+      tools.map(tool => {
+        const schema = ToolSchema.parse(tool);
+        return modifier
+          ? modifier({
+              toolSlug: tool.slug,
+              toolkitSlug: tool.toolkit?.slug ?? 'unknown',
+              schema,
+            })
+          : schema;
+      })
+    );
+  }
+
   /**
    * @internal
    * Creates a global execute tool function.
@@ -817,14 +826,16 @@ export class Tools<
    * @param userId - The user id to get the tools for
    * @param tools - The tools to wrap
    * @param modifiers - The modifiers to be applied to the tools
+   * @param rawTools - The fetched schemas used during execution
    * @returns The wrapped tools
    */
   wrapToolsForProvider<T extends TProvider>(
     userId: string,
     tools: Tool[],
-    modifiers?: ExecuteToolModifiers
+    modifiers?: ExecuteToolModifiers,
+    rawTools: Tool[] = tools.map(tool => ToolSchema.parse(tool))
   ): ReturnType<T['wrapTools']> {
-    const executeToolFn = this.createExecuteToolFn(userId, modifiers);
+    const executeToolFn = this.createExecuteToolFn(userId, modifiers, rawTools);
     return this.provider.wrapTools(tools, executeToolFn) as ReturnType<T['wrapTools']>;
   }
 
@@ -854,21 +865,27 @@ export class Tools<
    *
    * @param {string} userId - The user id
    * @param {ExecuteToolModifiers} modifiers - The modifiers to be applied to the tool
+   * @param {Tool[]} tools - The fetched tools available to the provider
    * @returns {ExecuteToolFn} The execute tool function
    */
-  private createExecuteToolFn(userId: string, modifiers?: ExecuteToolModifiers): ExecuteToolFn {
+  private createExecuteToolFn(
+    userId: string,
+    modifiers: ExecuteToolModifiers | undefined,
+    tools: Tool[]
+  ): ExecuteToolFn {
+    const toolBySlug = new Map(tools.map(tool => [tool.slug.toUpperCase(), tool]));
     const executeToolFn = async (toolSlug: string, input: Record<string, unknown>) => {
-      return await this.execute(
-        toolSlug,
-        {
-          userId,
-          arguments: input,
-          // dangerously skip version check for agentic tool execution via providers
-          // this can be safe because most agentic flows users fetch latest version and then execute the tool
-          dangerouslySkipVersionCheck: true,
-        },
-        modifiers
-      );
+      const body: ToolExecuteParams = {
+        userId,
+        arguments: input,
+        // dangerously skip version check for agentic tool execution via providers
+        // this can be safe because most agentic flows users fetch latest version and then execute the tool
+        dangerouslySkipVersionCheck: true,
+      };
+      const tool = toolBySlug.get(toolSlug.toUpperCase());
+      return tool
+        ? this.executeWithTool(toolSlug, this.parseToolExecuteParams(body), modifiers, tool)
+        : this.execute(toolSlug, body, modifiers);
     };
     return executeToolFn;
   }
@@ -961,6 +978,52 @@ export class Tools<
     }
   }
 
+  private async executeWithTool(
+    slug: string,
+    body: ToolExecuteParams,
+    options: (ExecuteToolModifiers & ComposioRequestOptions) | undefined,
+    tool: Tool
+  ): Promise<ToolExecuteResponse> {
+    const requestOptions: ComposioRequestOptions | undefined =
+      options?.signal != null ? { signal: options.signal } : undefined;
+    const { signal: _, ...modifiers } = options ?? {};
+    const toolkitSlug = tool.toolkit?.slug ?? 'unknown';
+
+    const params = await this.applyBeforeExecuteModifiers(
+      tool,
+      {
+        toolSlug: slug,
+        toolkitSlug,
+        params: body,
+      },
+      modifiers as ExecuteToolModifiers,
+      requestOptions
+    );
+
+    let result = await this.executeComposioTool(tool, params, requestOptions);
+
+    result = await this.applyAfterExecuteModifiers(
+      tool,
+      {
+        toolSlug: slug,
+        toolkitSlug,
+        result,
+      },
+      (modifiers as ExecuteToolModifiers).afterExecute,
+      requestOptions
+    );
+
+    return result;
+  }
+
+  private parseToolExecuteParams(body: ToolExecuteParams): ToolExecuteParams {
+    const executeParams = ToolExecuteParamsSchema.safeParse(body);
+    if (!executeParams.success) {
+      throw new ValidationError('Invalid tool execute parameters', { cause: executeParams.error });
+    }
+    return executeParams.data;
+  }
+
   /**
    * Executes a given tool with the provided parameters.
    *
@@ -1046,51 +1109,19 @@ export class Tools<
     body: ToolExecuteParams,
     options?: ExecuteToolModifiers & ComposioRequestOptions
   ): Promise<ToolExecuteResponse> {
-    const executeParams = ToolExecuteParamsSchema.safeParse(body);
-    if (!executeParams.success) {
-      throw new ValidationError('Invalid tool execute parameters', { cause: executeParams.error });
-    }
+    const executeParams = this.parseToolExecuteParams(body);
 
     const requestOptions: ComposioRequestOptions | undefined =
       options?.signal != null ? { signal: options.signal } : undefined;
-    const { signal: _, ...modifiers } = options ?? {};
 
     const tool = await this.getRawComposioToolBySlug(
       slug,
       {
-        version: body.version,
+        version: executeParams.version,
       },
       requestOptions
     );
-    const toolkitSlug = tool.toolkit?.slug ?? 'unknown';
-
-    // Apply before execute modifiers
-    const params = await this.applyBeforeExecuteModifiers(
-      tool,
-      {
-        toolSlug: slug,
-        toolkitSlug,
-        params: executeParams.data,
-      },
-      modifiers as ExecuteToolModifiers,
-      requestOptions
-    );
-
-    let result = await this.executeComposioTool(tool, params, requestOptions);
-
-    // Apply after execute modifiers
-    result = await this.applyAfterExecuteModifiers(
-      tool,
-      {
-        toolSlug: slug,
-        toolkitSlug,
-        result,
-      },
-      (modifiers as ExecuteToolModifiers).afterExecute,
-      requestOptions
-    );
-
-    return result;
+    return this.executeWithTool(slug, executeParams, options, tool);
   }
 
   /**

--- a/ts/packages/core/test/tools/modifiers.test.ts
+++ b/ts/packages/core/test/tools/modifiers.test.ts
@@ -241,22 +241,14 @@ describe('Tools Modifiers', () => {
       });
 
       // Verify schema modification
-      expect(getRawComposioToolBySlugSpy).toHaveBeenCalledWith(
-        slug,
-        {
-          modifySchema: schemaModifier,
-        },
-        undefined
-      );
-      expect(mockTool.description).toBe('Enhanced GITHUB_GET_REPOS for better context');
-      expect(mockTool.tags).toContain('enhanced');
-      expect(mockTool.tags).toContain('modified');
-      expect(mockTool.inputParameters).toHaveProperty(['properties', 'tracking']);
+      expect(getRawComposioToolBySlugSpy).toHaveBeenCalledWith(slug, undefined, undefined);
+      expect(schemaModifier).toHaveBeenCalledOnce();
 
       // Verify execution function creation
       expect(createExecuteToolFnSpy).toHaveBeenCalledWith(
         userId,
-        expect.objectContaining(executionModifiers)
+        expect.objectContaining(executionModifiers),
+        expect.any(Array)
       );
 
       // Mock a tool execution to verify the full flow

--- a/ts/packages/core/test/tools/tools.test.ts
+++ b/ts/packages/core/test/tools/tools.test.ts
@@ -739,13 +739,7 @@ describe('Tools', () => {
 
       const result = await context.tools.get(userId, slug);
 
-      expect(getRawComposioToolBySlugSpy).toHaveBeenCalledWith(
-        slug,
-        {
-          modifySchema: undefined,
-        },
-        undefined
-      );
+      expect(getRawComposioToolBySlugSpy).toHaveBeenCalledWith(slug, undefined, undefined);
       expect(context.mockProvider.wrapTools).toHaveBeenCalledWith(
         [toolMocks.transformedTool],
         expect.any(Function)
@@ -764,16 +758,12 @@ describe('Tools', () => {
 
       const result = await context.tools.get(userId, filters);
 
-      expect(getRawComposioToolsSpy).toHaveBeenCalledWith(
-        filters,
-        { modifySchema: undefined },
-        undefined
-      );
+      expect(getRawComposioToolsSpy).toHaveBeenCalledWith(filters, undefined, undefined);
       expect(context.mockProvider.wrapTools).toHaveBeenCalled();
       expect(result).toEqual('wrapped-tools-collection');
     });
 
-    it('should pass modifiers to the underlying methods', async () => {
+    it('should apply schema modifiers before wrapping tools for the provider', async () => {
       const userId = 'test-user';
       const slug = 'TOOL_SLUG';
       const schemaModifier = createSchemaModifier({
@@ -787,13 +777,21 @@ describe('Tools', () => {
 
       await context.tools.get(userId, slug, { modifySchema: schemaModifier });
 
-      expect(getRawComposioToolBySlugSpy).toHaveBeenCalledWith(
-        slug,
-        {
-          modifySchema: schemaModifier,
-        },
-        undefined
+      expect(getRawComposioToolBySlugSpy).toHaveBeenCalledWith(slug, undefined, undefined);
+      expect(schemaModifier).toHaveBeenCalledOnce();
+      expect(context.mockProvider.wrapTools).toHaveBeenCalledWith(
+        [expect.objectContaining({ description: 'Modified description' })],
+        expect.any(Function)
       );
+    });
+
+    it('should reject an invalid schema modifier when no tools are returned', async () => {
+      const invalidModifier = 'not a function' as unknown;
+      vi.spyOn(context.tools, 'getRawComposioTools').mockResolvedValueOnce([]);
+
+      await expect(
+        context.tools.get('test-user', { toolkits: ['github'] }, { modifySchema: invalidModifier })
+      ).rejects.toThrow('Invalid schema modifier. Not a function.');
     });
   });
 
@@ -2374,38 +2372,33 @@ describe('Tools', () => {
         }
       });
 
-      it('should allow agentic provider execution with dangerouslySkipVersionCheck in createExecuteToolFn', async () => {
+      it('should reuse the fetched schema during agentic provider execution', async () => {
         const context = createTestContext();
         const userId = 'test-user';
-
-        // Mock tool retrieval for the get method
+        const toolSlug = 'GITHUB_CREATE_ISSUE';
+        const fetchedTool = {
+          ...toolMocks.transformedTool,
+          slug: toolSlug,
+          toolkit: { slug: 'github', name: 'GitHub' },
+        } as unknown as Tool;
         const getRawComposioToolBySlugSpy = vi.spyOn(context.tools, 'getRawComposioToolBySlug');
-        getRawComposioToolBySlugSpy.mockResolvedValueOnce(
-          toolMocks.transformedTool as unknown as Tool
-        );
+        getRawComposioToolBySlugSpy.mockResolvedValue(fetchedTool);
 
-        // Mock provider wrapping
         let storedExecuteToolFn: ExecuteToolFn | undefined;
         context.mockProvider.wrapTools.mockImplementation((_tools, executeToolFn) => {
           storedExecuteToolFn = executeToolFn;
           return 'wrapped-tools-collection';
         });
 
-        // Get the tool (this will internally create the execute tool function)
-        await context.tools.get(userId, 'GITHUB_CREATE_ISSUE');
-
-        expect(storedExecuteToolFn).toBeDefined();
-
-        // Setup mocks for the actual execution
-        const spies = await mockToolExecution(context.tools);
-
-        // Call the execute function that was passed to the provider
-        // This should succeed because createExecuteToolFn sets dangerouslySkipVersionCheck: true
-        const result = await storedExecuteToolFn!('GITHUB_CREATE_ISSUE', { title: 'Test Issue' });
+        await context.tools.get(userId, toolSlug);
+        mockClient.tools.execute.mockResolvedValueOnce(toolMocks.rawToolExecuteResponse);
+        const result = await storedExecuteToolFn!(toolSlug, { title: 'Test Issue' });
 
         expect(result).toEqual(toolMocks.toolExecuteResponse);
+        expect(getRawComposioToolBySlugSpy).toHaveBeenCalledTimes(1);
+        expect(mockClient.tools.retrieve).not.toHaveBeenCalled();
         expect(mockClient.tools.execute).toHaveBeenCalledWith(
-          'COMPOSIO_TOOL',
+          toolSlug,
           {
             allow_tracing: undefined,
             connected_account_id: undefined,
@@ -2416,6 +2409,113 @@ describe('Tools', () => {
             version: 'latest',
             text: undefined,
           },
+          undefined
+        );
+      });
+
+      it('should reject invalid agentic provider input before execution', async () => {
+        const context = createTestContext();
+        const toolSlug = 'GITHUB_CREATE_ISSUE';
+        const fetchedTool = {
+          ...toolMocks.transformedTool,
+          slug: toolSlug,
+          toolkit: { slug: 'github', name: 'GitHub' },
+        } as unknown as Tool;
+        const getRawComposioToolBySlugSpy = vi.spyOn(context.tools, 'getRawComposioToolBySlug');
+        getRawComposioToolBySlugSpy.mockResolvedValue(fetchedTool);
+        let storedExecuteToolFn: ExecuteToolFn | undefined;
+
+        context.mockProvider.wrapTools.mockImplementation((_tools, executeToolFn) => {
+          storedExecuteToolFn = executeToolFn;
+          return 'wrapped-tools-collection';
+        });
+
+        await context.tools.get('test-user', toolSlug);
+
+        await expect(
+          storedExecuteToolFn!(toolSlug, 42 as unknown as Record<string, unknown>)
+        ).rejects.toThrow(ValidationError);
+        expect(getRawComposioToolBySlugSpy).toHaveBeenCalledTimes(1);
+        expect(mockClient.tools.execute).not.toHaveBeenCalled();
+      });
+
+      it('should retrieve an unknown provider tool before execution', async () => {
+        const context = createTestContext();
+        const userId = 'test-user';
+        const fetchedToolSlug = 'GITHUB_CREATE_ISSUE';
+        const unknownToolSlug = 'GITHUB_GET_ISSUE';
+        const fetchedTool = {
+          ...toolMocks.transformedTool,
+          slug: fetchedToolSlug,
+          toolkit: { slug: 'github', name: 'GitHub' },
+        } as unknown as Tool;
+        const unknownTool = { ...fetchedTool, slug: unknownToolSlug };
+        const getRawComposioToolBySlugSpy = vi.spyOn(context.tools, 'getRawComposioToolBySlug');
+        getRawComposioToolBySlugSpy
+          .mockResolvedValueOnce(fetchedTool)
+          .mockResolvedValueOnce(unknownTool);
+        let storedExecuteToolFn: ExecuteToolFn | undefined;
+
+        context.mockProvider.wrapTools.mockImplementation((_tools, executeToolFn) => {
+          storedExecuteToolFn = executeToolFn;
+          return 'wrapped-tools-collection';
+        });
+
+        await context.tools.get(userId, fetchedToolSlug);
+        mockClient.tools.execute.mockResolvedValueOnce(toolMocks.rawToolExecuteResponse);
+        await storedExecuteToolFn!(unknownToolSlug, {});
+
+        expect(getRawComposioToolBySlugSpy).toHaveBeenCalledTimes(2);
+        expect(getRawComposioToolBySlugSpy).toHaveBeenNthCalledWith(
+          2,
+          unknownToolSlug,
+          { version: undefined },
+          undefined
+        );
+        expect(mockClient.tools.execute).toHaveBeenCalledWith(
+          unknownToolSlug,
+          expect.objectContaining({ user_id: userId, version: 'latest' }),
+          undefined
+        );
+      });
+
+      it('should preserve execution metadata when modifySchema mutates the fetched tool', async () => {
+        const mockProvider = new MockProvider();
+        const tools = new Tools(mockClient, {
+          provider: mockProvider,
+          toolkitVersions: { 'test-toolkit': '20250101_00' },
+        });
+        const userId = 'test-user';
+        const toolSlug = 'GITHUB_CREATE_ISSUE';
+        const rawTool = {
+          ...toolMocks.rawTool,
+          slug: toolSlug,
+          toolkit: { slug: 'test-toolkit', name: 'Test Toolkit' },
+        };
+        let wrappedTools: Tool[] | undefined;
+        let storedExecuteToolFn: ExecuteToolFn | undefined;
+
+        mockClient.tools.retrieve.mockReset().mockResolvedValueOnce(rawTool);
+        mockProvider.wrapTools.mockImplementation((toolsToWrap, executeToolFn) => {
+          wrappedTools = toolsToWrap;
+          storedExecuteToolFn = executeToolFn;
+          return 'wrapped-tools';
+        });
+
+        await tools.get(userId, toolSlug, {
+          modifySchema: ({ schema }) => {
+            schema.toolkit = { slug: 'renamed-toolkit', name: 'Renamed Toolkit' };
+            return schema;
+          },
+        });
+        mockClient.tools.execute.mockResolvedValueOnce(toolMocks.rawToolExecuteResponse);
+        await storedExecuteToolFn!(toolSlug, {});
+
+        expect(wrappedTools?.[0].toolkit?.slug).toBe('renamed-toolkit');
+        expect(mockClient.tools.retrieve).toHaveBeenCalledTimes(1);
+        expect(mockClient.tools.execute).toHaveBeenCalledWith(
+          toolSlug,
+          expect.objectContaining({ version: '20250101_00' }),
           undefined
         );
       });


### PR DESCRIPTION
Closes #4087
Supersedes #4088

## Summary

Provider integrations already receive a complete tool schema from `tools.get()`. Their execution callback then called `tools.execute()`, which retrieved the same schema again before every action.

This change reuses the schema already owned by the provider callback. Public `tools.execute()` remains unchanged because a standalone call has no fetched schema to reuse.

## Changes

- Execute known provider tool slugs with their fetched raw schema and avoid the second retrieval request.
- Keep provider-facing schema changes separate from execution metadata, including modifiers that mutate a schema in place.
- Preserve retrieval for unknown provider slugs and standalone `tools.execute()` calls.
- Keep runtime parameter validation before modifiers and remote execution on both cached and fallback paths.
- Add focused regression coverage for request count, modifier metadata, invalid input, empty results, and unknown-slug fallback behavior.
- Add a patch changeset for `@composio/core`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [ ] Documentation
- [ ] Breaking change

## How Has This Been Tested?

- `mise exec -- pnpm --filter @composio/core test` (47 files, 1,059 tests passed)
- `mise exec -- pnpm --filter @composio/core typecheck`
- `mise exec -- pnpm exec oxlint ts/packages/core/src/models/Tools.ts ts/packages/core/test/tools/tools.test.ts ts/packages/core/test/tools/modifiers.test.ts`
- `mise exec -- pnpm exec prettier --check ts/packages/core/src/models/Tools.ts ts/packages/core/test/tools/tools.test.ts ts/packages/core/test/tools/modifiers.test.ts .changeset/reuse-provider-tool-schemas.md`
- `git diff HEAD^ --check`

## Checklist

- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed
- [x] Documentation is unchanged because the public API is unchanged
- [x] I added focused tests for the changed behavior and regression paths
- [x] I added a changeset for the published package change

## Additional context

A global schema cache would also change standalone execution semantics and require lifetime, invalidation, version, and modifier policies. This change keeps the optimization local to the provider callback that already owns the fetched data.

The implementation builds on the approach from #4088. The commit retains @breezeFur as a co-author.

Oxlint completes with the existing `ban-ts-comment` warning for `Tools.ts:1311`. Replacing that directive makes the package's second TypeScript configuration fail, so this PR leaves the unrelated line unchanged.
