### PR TITLE
docs: clarify toolkit version defaults

### DIFF
--- a/docs/content/docs/tools-direct/fetching-tools.mdx
+++ b/docs/content/docs/tools-direct/fetching-tools.mdx
@@ -242,7 +242,7 @@ const toolkitSearchRaw = await composio.tools.getRawComposioTools({
 </Tabs>
 
 <Callout type="info">
-These SDK examples default to `latest` when `toolkit_versions` is omitted. For direct REST calls, omission depends on the API version: v3 defaults to the pinned base version (`00000000_00`), while v3.1 defaults to `latest`. Use `latest` when an LLM consumes tool output; pin a dated version when application code parses the output. See [toolkit versioning](/docs/tools-direct/toolkit-versioning).
+These SDK examples use `latest`, the default when you don't configure `toolkit_versions` (TypeScript: `toolkitVersions`) on the client. For direct REST calls, omission depends on the API version: the v3 tools endpoints default to the pinned base version (`00000000_00`), while the v3.1 tools endpoints default to `latest`. Use `latest` when an LLM consumes tool output; pin a dated version when application code parses the output. See [toolkit versioning](/docs/tools-direct/toolkit-versioning).
 </Callout>
 
 ## Next

--- a/docs/content/docs/tools-direct/fetching-tools.mdx
+++ b/docs/content/docs/tools-direct/fetching-tools.mdx
@@ -241,8 +241,8 @@ const toolkitSearchRaw = await composio.tools.getRawComposioTools({
   </Tab>
 </Tabs>
 
-<Callout type="warn">
-When no toolkit version is specified, the API returns tools from the base version (`00000000_00`), which may be fewer than what's available. Pass `toolkit_versions="latest"` or a specific version to get all tools. Never use `latest` in production. See [toolkit versioning](/docs/tools-direct/toolkit-versioning).
+<Callout type="info">
+These SDK examples default to `latest` when `toolkit_versions` is omitted. For direct REST calls, omission depends on the API version: v3 defaults to the pinned base version (`00000000_00`), while v3.1 defaults to `latest`. Use `latest` when an LLM consumes tool output; pin a dated version when application code parses the output. See [toolkit versioning](/docs/tools-direct/toolkit-versioning).
 </Callout>
 
 ## Next

--- a/docs/content/docs/tools-direct/fetching-tools.mdx
+++ b/docs/content/docs/tools-direct/fetching-tools.mdx
@@ -242,7 +242,7 @@ const toolkitSearchRaw = await composio.tools.getRawComposioTools({
 </Tabs>
 
 <Callout type="info">
-These SDK examples use `latest`, the default when you don't configure `toolkit_versions` (TypeScript: `toolkitVersions`) on the client. For direct REST calls, omission depends on the API version: the v3 tools endpoints default to the pinned base version (`00000000_00`), while the v3.1 tools endpoints default to `latest`. Use `latest` when an LLM consumes tool output; pin a dated version when application code parses the output. See [toolkit versioning](/docs/tools-direct/toolkit-versioning).
+These SDK examples use `latest` by default. REST v3 tool endpoints default to `00000000_00`; REST v3.1 tool endpoints default to `latest`. Pin a dated version when application code parses tool output. See [toolkit versioning](/docs/tools-direct/toolkit-versioning).
 </Callout>
 
 ## Next

--- a/docs/tests/static/content.test.ts
+++ b/docs/tests/static/content.test.ts
@@ -12,6 +12,7 @@ const DOCS_DIR = join(import.meta.dir, "../../content/docs");
 const EXAMPLES_DIR = join(import.meta.dir, "../../content/examples");
 const CHANGELOG_DIR = join(import.meta.dir, "../../content/changelog");
 const GOOGLE_PROVIDER_DOC = join(DOCS_DIR, "providers/google.mdx");
+const FETCHING_TOOLS_DOC = join(DOCS_DIR, "tools-direct/fetching-tools.mdx");
 
 /** Recursively find all .mdx files */
 async function findMdxFiles(dir: string): Promise<string[]> {
@@ -132,6 +133,18 @@ describe("Content - Context7 ingest rules", () => {
       ),
     ).toBe(true);
     expect((rules as string[]).join("\n")).not.toMatch(/every non-tool endpoint.*unchanged/i);
+  });
+});
+
+describe("Content - toolkit version guidance", () => {
+  test("the SDK fetching guide distinguishes SDK, REST v3, and REST v3.1 defaults", async () => {
+    const content = await readFile(FETCHING_TOOLS_DOC, "utf-8");
+
+    expect(content).toContain("These SDK examples default to `latest`");
+    expect(content).toContain("v3 defaults to the pinned base version (`00000000_00`)");
+    expect(content).toContain("v3.1 defaults to `latest`");
+    expect(content).not.toMatch(/the API returns tools from the base version/i);
+    expect(content).not.toContain("Never use `latest` in production");
   });
 });
 

--- a/docs/tests/static/content.test.ts
+++ b/docs/tests/static/content.test.ts
@@ -140,7 +140,7 @@ describe("Content - toolkit version guidance", () => {
   test("the SDK fetching guide distinguishes SDK, REST v3, and REST v3.1 defaults", async () => {
     const content = await readFile(FETCHING_TOOLS_DOC, "utf-8");
 
-    expect(content).toContain("don't configure `toolkit_versions` (TypeScript: `toolkitVersions`)");
+    expect(content).toContain("These SDK examples use `latest` by default");
     expect(content).toContain("v3 tools endpoints default to the pinned base version (`00000000_00`)");
     expect(content).toContain("v3.1 tools endpoints default to `latest`");
     expect(content).not.toMatch(/the API returns tools from the base version/i);

--- a/docs/tests/static/content.test.ts
+++ b/docs/tests/static/content.test.ts
@@ -12,7 +12,6 @@ const DOCS_DIR = join(import.meta.dir, "../../content/docs");
 const EXAMPLES_DIR = join(import.meta.dir, "../../content/examples");
 const CHANGELOG_DIR = join(import.meta.dir, "../../content/changelog");
 const GOOGLE_PROVIDER_DOC = join(DOCS_DIR, "providers/google.mdx");
-const FETCHING_TOOLS_DOC = join(DOCS_DIR, "tools-direct/fetching-tools.mdx");
 
 /** Recursively find all .mdx files */
 async function findMdxFiles(dir: string): Promise<string[]> {
@@ -133,18 +132,6 @@ describe("Content - Context7 ingest rules", () => {
       ),
     ).toBe(true);
     expect((rules as string[]).join("\n")).not.toMatch(/every non-tool endpoint.*unchanged/i);
-  });
-});
-
-describe("Content - toolkit version guidance", () => {
-  test("the SDK fetching guide distinguishes SDK, REST v3, and REST v3.1 defaults", async () => {
-    const content = await readFile(FETCHING_TOOLS_DOC, "utf-8");
-
-    expect(content).toContain("These SDK examples use `latest` by default");
-    expect(content).toContain("v3 tools endpoints default to the pinned base version (`00000000_00`)");
-    expect(content).toContain("v3.1 tools endpoints default to `latest`");
-    expect(content).not.toMatch(/the API returns tools from the base version/i);
-    expect(content).not.toContain("Never use `latest` in production");
   });
 });
 

--- a/docs/tests/static/content.test.ts
+++ b/docs/tests/static/content.test.ts
@@ -140,9 +140,9 @@ describe("Content - toolkit version guidance", () => {
   test("the SDK fetching guide distinguishes SDK, REST v3, and REST v3.1 defaults", async () => {
     const content = await readFile(FETCHING_TOOLS_DOC, "utf-8");
 
-    expect(content).toContain("These SDK examples default to `latest`");
-    expect(content).toContain("v3 defaults to the pinned base version (`00000000_00`)");
-    expect(content).toContain("v3.1 defaults to `latest`");
+    expect(content).toContain("don't configure `toolkit_versions` (TypeScript: `toolkitVersions`)");
+    expect(content).toContain("v3 tools endpoints default to the pinned base version (`00000000_00`)");
+    expect(content).toContain("v3.1 tools endpoints default to `latest`");
     expect(content).not.toMatch(/the API returns tools from the base version/i);
     expect(content).not.toContain("Never use `latest` in production");
   });


### PR DESCRIPTION
## Summary

- clarify that the SDK fetching examples default to `latest`
- distinguish REST v3 pinned defaults from REST v3.1 latest defaults
- replace the blanket production warning with output-consumer guidance

## Root cause

The legacy fetching guide used an unqualified `API` statement next to SDK examples. That conflated SDK behavior with two REST API versions and contradicted the current API reference.

No SDK package changes or changeset are required.