### PR TITLE
test(skills): add reusable eval runner

### DIFF
--- a/.github/workflows/skill-evals.yml
+++ b/.github/workflows/skill-evals.yml
@@ -63,9 +63,11 @@ jobs:
             cp -R ".source/skills/${{ matrix.skill }}/evals/sources" \
               "skill-eval-workspace/skills/${{ matrix.skill }}/evals/sources"
           fi
-          node .source/ts/scripts/run-skill-evals.mjs prompt \
-            "${{ matrix.skill }}/${{ matrix.case }}" \
-            > skill-eval-workspace/eval-input.md
+          (
+            cd .source
+            node ts/scripts/run-skill-evals.mjs prompt \
+              "${{ matrix.skill }}/${{ matrix.case }}"
+          ) > skill-eval-workspace/eval-input.md
           rm -rf .source
 
       - name: Run blind skill behavior

--- a/.github/workflows/skill-evals.yml
+++ b/.github/workflows/skill-evals.yml
@@ -1,0 +1,82 @@
+name: Skill evals
+
+on:
+  pull_request:
+    paths:
+      - 'skills/**'
+      - 'ts/scripts/run-skill-evals.mjs'
+      - 'package.json'
+      - '.github/workflows/skill-evals.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    name: Validate eval definitions
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Validate eval definitions
+        run: node ts/scripts/run-skill-evals.mjs validate
+
+      - name: Build dry-eval matrix
+        id: matrix
+        run: echo "matrix=$(node ts/scripts/run-skill-evals.mjs matrix)" >> "$GITHUB_OUTPUT"
+
+  behavioral:
+    name: ${{ matrix.skill }} / ${{ matrix.case }} (${{ matrix.repetition }})
+    needs: prepare
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.pull_request.head.repo.fork }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Prepare output directory
+        run: mkdir -p skill-eval-output
+
+      - name: Run blind skill behavior
+        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1.11
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          sandbox: workspace-write
+          prompt: |
+            Run one blind behavioral evaluation. Do not inspect git history, pull-request text,
+            workspace reports, or any case other than the selected case.
+
+            1. Read skills/${{ matrix.skill }}/SKILL.md and only the references it routes you to.
+            2. Read case "${{ matrix.case }}" from skills/${{ matrix.skill }}/evals/cases.json.
+            3. Read only that case's listed source fixtures, if any.
+            4. Respond to the case prompt as a normal assistant. Do not execute external actions
+               or claim success; these are dry cases.
+            5. Write only the user-facing answer to:
+               skill-eval-output/${{ matrix.skill }}-${{ matrix.case }}-${{ matrix.repetition }}.md
+            6. Do not modify any other file.
+
+      - name: Grade output
+        run: >-
+          node ts/scripts/run-skill-evals.mjs grade
+          "${{ matrix.skill }}/${{ matrix.case }}"
+          "skill-eval-output/${{ matrix.skill }}-${{ matrix.case }}-${{ matrix.repetition }}.md"
+
+      - name: Upload transcript
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: skill-eval-${{ matrix.skill }}-${{ matrix.case }}-${{ matrix.repetition }}
+          path: skill-eval-output/
+          retention-days: 7

--- a/.github/workflows/skill-evals.yml
+++ b/.github/workflows/skill-evals.yml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
+      has-dry-cases: ${{ steps.matrix.outputs.has-dry-cases }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -31,12 +32,14 @@ jobs:
 
       - name: Build dry-eval matrix
         id: matrix
-        run: echo "matrix=$(node ts/scripts/run-skill-evals.mjs matrix)" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "matrix=$(node ts/scripts/run-skill-evals.mjs matrix)" >> "$GITHUB_OUTPUT"
+          echo "has-dry-cases=$(node ts/scripts/run-skill-evals.mjs has-dry-cases)" >> "$GITHUB_OUTPUT"
 
   behavioral:
     name: ${{ matrix.skill }} / ${{ matrix.case }} (${{ matrix.repetition }})
     needs: prepare
-    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.pull_request.head.repo.fork }}
+    if: ${{ needs.prepare.outputs.has-dry-cases == 'true' && (github.event_name == 'workflow_dispatch' || !github.event.pull_request.head.repo.fork) }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
@@ -45,33 +48,55 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: .source
 
-      - name: Prepare output directory
-        run: mkdir -p skill-eval-output
+      - name: Prepare isolated blind workspace
+        run: |
+          mkdir -p "skill-eval-workspace/skills/${{ matrix.skill }}" skill-eval-output
+          cp ".source/skills/${{ matrix.skill }}/SKILL.md" \
+            "skill-eval-workspace/skills/${{ matrix.skill }}/SKILL.md"
+          cp -R ".source/skills/${{ matrix.skill }}/references" \
+            "skill-eval-workspace/skills/${{ matrix.skill }}/references"
+          if [ -d ".source/skills/${{ matrix.skill }}/evals/sources" ]; then
+            mkdir -p "skill-eval-workspace/skills/${{ matrix.skill }}/evals"
+            cp -R ".source/skills/${{ matrix.skill }}/evals/sources" \
+              "skill-eval-workspace/skills/${{ matrix.skill }}/evals/sources"
+          fi
+          node .source/ts/scripts/run-skill-evals.mjs prompt \
+            "${{ matrix.skill }}/${{ matrix.case }}" \
+            > skill-eval-workspace/eval-input.md
+          rm -rf .source
 
       - name: Run blind skill behavior
         uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1.11
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
-          sandbox: workspace-write
+          permission-profile: :read-only
+          working-directory: skill-eval-workspace
+          output-file: ${{ github.workspace }}/skill-eval-output/${{ matrix.skill }}-${{ matrix.case }}-${{ matrix.repetition }}.md
           prompt: |
             Run one blind behavioral evaluation. Do not inspect git history, pull-request text,
-            workspace reports, or any case other than the selected case.
+            workspace reports, eval definitions, or grading code.
 
             1. Read skills/${{ matrix.skill }}/SKILL.md and only the references it routes you to.
-            2. Read case "${{ matrix.case }}" from skills/${{ matrix.skill }}/evals/cases.json.
-            3. Read only that case's listed source fixtures, if any.
+            2. Read eval-input.md.
+            3. Read only the source fixtures listed in that input file, if any.
             4. Respond to the case prompt as a normal assistant. Do not execute external actions
                or claim success; these are dry cases.
-            5. Write only the user-facing answer to:
-               skill-eval-output/${{ matrix.skill }}-${{ matrix.case }}-${{ matrix.repetition }}.md
-            6. Do not modify any other file.
+            5. Return only the user-facing answer.
+
+      - name: Checkout clean grader
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: .skill-eval-grader
 
       - name: Grade output
+        working-directory: .skill-eval-grader
         run: >-
           node ts/scripts/run-skill-evals.mjs grade
           "${{ matrix.skill }}/${{ matrix.case }}"
-          "skill-eval-output/${{ matrix.skill }}-${{ matrix.case }}-${{ matrix.repetition }}.md"
+          "../skill-eval-output/${{ matrix.skill }}-${{ matrix.case }}-${{ matrix.repetition }}.md"
 
       - name: Upload transcript
         if: always()

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "update:peer-deps": "tsx ts/scripts/update-peer-deps.ts",
     "validate:agent-skills": "node ts/scripts/validate-agent-skills.mjs",
     "validate:changesets": "node ts/scripts/validate-changesets.mjs",
+    "validate:skill-evals": "node ts/scripts/run-skill-evals.mjs validate",
     "validate:skill-routing": "node ts/scripts/test-skill-routing.mjs",
     "prepublish": "pnpm run build:packages",
     "changeset": "changeset",

--- a/skills/composio/evals/README.md
+++ b/skills/composio/evals/README.md
@@ -1,0 +1,13 @@
+# Composio skill evals
+
+`cases.json` is the source of truth. Dry cases run automatically when the skill, runner, or workflow changes. Critical cases must run at least three times.
+
+```bash
+node ts/scripts/run-skill-evals.mjs validate
+node ts/scripts/run-skill-evals.mjs matrix
+node ts/scripts/run-skill-evals.mjs grade composio/<case-id> <output-file>
+```
+
+Keep assertions deterministic and tied to user-visible behavior. Put volatile facts in a case-specific source fixture so the agent is evaluated against an explicit snapshot rather than its memory.
+
+Live cases are excluded from pull-request jobs because they require trusted credentials. Execute their external steps through Composio, retain the Composio log ID, and pass the captured answer to the same `grade` command. Promote a live case to scheduled CI only after its Composio test account and cleanup behavior are defined.

--- a/skills/composio/evals/cases.json
+++ b/skills/composio/evals/cases.json
@@ -38,7 +38,7 @@
       ],
       "mustNotMatch": [
         {
-          "pattern": "(?:^|\\n)\\s*(?:[-*]\\s*)?(?:(?:(?:first|next),?\\s+|(?:please|you should|you need to|you have to)\\s+)?(?:run|execute|use)\\s+(?:the\\s+)?(?:command\\s+)?|[$>]\\s*)?[`'\"]?composio\\s+dev\\s+init\\b",
+          "pattern": "(?:^|\\n)\\s*(?:(?:[-*]|\\d+[.)])\\s*)?(?:(?:(?:first|next),?\\s+|(?:please|you should|you need to|you have to)\\s+)?(?:run|execute|use)\\s+(?:the\\s+)?(?:command\\s+)?|[$>]\\s*)?[`'\"]?composio\\s+dev\\s+init\\b",
           "flags": "im",
           "message": "does not replace dashboard onboarding with dev init"
         },
@@ -136,7 +136,7 @@
       ],
       "mustNotMatch": [
         {
-          "pattern": "(?:^|\\n)\\s*(?:[-*]\\s*)?(?:(?:first|next),?\\s+|(?:please|you should|you need to|you have to)\\s+)?(?:build|implement|create)\\b.{0,80}(?:OAuth|authorization).{0,40}(?:flow|callback)",
+          "pattern": "(?:^|\\n)\\s*(?:(?:[-*]|\\d+[.)])\\s*)?(?:(?:first|next),?\\s+|(?:please|you should|you need to|you have to)\\s+)?(?:build|implement|create)\\b.{0,80}(?:OAuth|authorization).{0,40}(?:flow|callback)",
           "flags": "is",
           "message": "does not build a provider OAuth flow"
         }

--- a/skills/composio/evals/cases.json
+++ b/skills/composio/evals/cases.json
@@ -163,7 +163,7 @@
           "message": "states that v3.1 omission selects latest"
         },
         {
-          "pattern": "(?:\\bv3\\b.{0,160}(?:omit|omission|default).{0,160}00000000_00|(?:omit|omission|default).{0,160}\\bv3\\b.{0,160}00000000_00)",
+          "pattern": "(?:\\bv3\\b(?!\\.1).{0,160}(?:omit|omission|default).{0,160}00000000_00|(?:omit|omission|default).{0,160}\\bv3\\b(?!\\.1).{0,160}00000000_00)",
           "flags": "is",
           "message": "states that v3 omission selects the pinned base version"
         }

--- a/skills/composio/evals/cases.json
+++ b/skills/composio/evals/cases.json
@@ -38,8 +38,8 @@
       ],
       "mustNotMatch": [
         {
-          "pattern": "composio\\s+dev\\s+init",
-          "flags": "i",
+          "pattern": "(?:^|\\n)\\s*(?:[$>]\\s*)?composio\\s+dev\\s+init\\b|(?:run|execute|use)\\s+(?:the\\s+)?(?:command\\s+)?[`'\"]?composio\\s+dev\\s+init\\b",
+          "flags": "im",
           "message": "does not replace dashboard onboarding with dev init"
         },
         {
@@ -56,8 +56,8 @@
       "repetitions": 1,
       "mustMatch": [
         {
-          "pattern": "Composio For You",
-          "flags": "i",
+          "pattern": "Composio.{0,40}For You|For You.{0,40}Composio",
+          "flags": "is",
           "message": "routes a personal AI client to Composio For You"
         },
         {

--- a/skills/composio/evals/cases.json
+++ b/skills/composio/evals/cases.json
@@ -106,9 +106,14 @@
       "repetitions": 1,
       "mustMatch": [
         {
-          "pattern": "custom.{0,40}OAuth.{0,160}(?:auth config|authentication config)|OAuth.{0,160}custom (?:auth config|authentication config)|(?:auth config|authentication config).{0,160}custom.{0,40}OAuth",
+          "pattern": "custom.{0,80}OAuth.{0,40}(?:app|client)|OAuth.{0,80}custom.{0,40}(?:app|client)",
           "flags": "is",
-          "message": "uses a custom provider OAuth app and auth config"
+          "message": "uses a custom provider OAuth app"
+        },
+        {
+          "pattern": "custom.{0,40}(?:auth config|authentication config)|(?:auth config|authentication config).{0,40}custom",
+          "flags": "is",
+          "message": "links the provider app through a custom auth config"
         }
       ]
     },

--- a/skills/composio/evals/cases.json
+++ b/skills/composio/evals/cases.json
@@ -38,7 +38,7 @@
       ],
       "mustNotMatch": [
         {
-          "pattern": "(?:^|\\n)\\s*(?:[$>]\\s*)?composio\\s+dev\\s+init\\b|(?:run|execute|use)\\s+(?:the\\s+)?(?:command\\s+)?[`'\"]?composio\\s+dev\\s+init\\b",
+          "pattern": "(?:^|\\n)\\s*(?:[-*]\\s*)?(?:(?:(?:first|next),?\\s+|(?:please|you should|you need to|you have to)\\s+)?(?:run|execute|use)\\s+(?:the\\s+)?(?:command\\s+)?|[$>]\\s*)?[`'\"]?composio\\s+dev\\s+init\\b",
           "flags": "im",
           "message": "does not replace dashboard onboarding with dev init"
         },
@@ -136,7 +136,7 @@
       ],
       "mustNotMatch": [
         {
-          "pattern": "(?<!not )(?<!never )(?<!don't )\\b(?:build|implement|create).{0,80}(?:OAuth|authorization).{0,40}(?:flow|callback)",
+          "pattern": "(?:^|\\n)\\s*(?:[-*]\\s*)?(?:(?:first|next),?\\s+|(?:please|you should|you need to|you have to)\\s+)?(?:build|implement|create)\\b.{0,80}(?:OAuth|authorization).{0,40}(?:flow|callback)",
           "flags": "is",
           "message": "does not build a provider OAuth flow"
         }

--- a/skills/composio/evals/cases.json
+++ b/skills/composio/evals/cases.json
@@ -1,0 +1,200 @@
+{
+  "version": 1,
+  "cases": [
+    {
+      "id": "ambiguous-product-routing",
+      "mode": "dry",
+      "prompt": "Help me get Composio working.",
+      "repetitions": 1,
+      "mustMatch": [
+        {
+          "pattern": "(?:own|personal).{0,100}(?:agent|account).{0,240}(?:product|users)|(?:product|users).{0,240}(?:own|personal).{0,100}(?:agent|account)",
+          "flags": "is",
+          "message": "asks whether this is personal-agent or product-user work"
+        },
+        {
+          "pattern": "\\?",
+          "message": "asks one routing question"
+        }
+      ],
+      "mustNotMatch": [
+        {
+          "pattern": "COMPOSIO_API_KEY|ck_[A-Za-z0-9]",
+          "message": "does not choose credentials before the product is known"
+        }
+      ]
+    },
+    {
+      "id": "dashboard-key-missing-repository",
+      "mode": "dry",
+      "prompt": "I finished Platform Getting Started and already have COMPOSIO_API_KEY in the dashboard, but the repository is not attached here. Add Composio to my TypeScript app.",
+      "repetitions": 1,
+      "mustMatch": [
+        {
+          "pattern": "(?:attach|open|share|provide|access).{0,100}(?:repo|repository|codebase|project path)",
+          "flags": "is",
+          "message": "asks for repository access instead of inventing its contents"
+        }
+      ],
+      "mustNotMatch": [
+        {
+          "pattern": "composio\\s+dev\\s+init",
+          "flags": "i",
+          "message": "does not replace dashboard onboarding with dev init"
+        },
+        {
+          "pattern": "(?:paste|send|share).{0,50}(?:COMPOSIO_API_KEY|API key)",
+          "flags": "is",
+          "message": "does not request the secret in chat"
+        }
+      ]
+    },
+    {
+      "id": "cursor-personal-apps",
+      "mode": "dry",
+      "prompt": "Set up my personal Cursor so it can use my Gmail and Google Calendar through Composio.",
+      "repetitions": 1,
+      "mustMatch": [
+        {
+          "pattern": "Composio For You",
+          "flags": "i",
+          "message": "routes a personal AI client to Composio For You"
+        },
+        {
+          "pattern": "\\bMCP\\b",
+          "flags": "i",
+          "message": "uses the For You MCP path"
+        }
+      ],
+      "mustNotMatch": [
+        {
+          "pattern": "(?:export\\s+COMPOSIO_API_KEY|COMPOSIO_API_KEY\\s*[:=]|new Composio\\(|from ['\"]@composio)",
+          "flags": "i",
+          "message": "does not route personal Cursor setup through Platform SDK credentials"
+        }
+      ]
+    },
+    {
+      "id": "provider-401-boundary",
+      "mode": "dry",
+      "prompt": "My GitHub tool call returns 401, but the same COMPOSIO_API_KEY works for other calls. Help me fix it.",
+      "repetitions": 1,
+      "mustMatch": [
+        {
+          "pattern": "(?:log|request)[ -]?id",
+          "flags": "i",
+          "message": "requests the Composio log or request ID"
+        },
+        {
+          "pattern": "(?:connected account|provider auth|GitHub App|installation)",
+          "flags": "i",
+          "message": "checks provider authorization separately from the project key"
+        }
+      ],
+      "mustNotMatch": [
+        {
+          "pattern": "(?:rotate|replace|regenerate).{0,60}COMPOSIO_API_KEY",
+          "flags": "is",
+          "message": "does not rotate a working project key"
+        }
+      ]
+    },
+    {
+      "id": "provider-consent-branding",
+      "mode": "dry",
+      "prompt": "Google's OAuth consent screen says Composio. I need it to show my product's name. What should I change?",
+      "repetitions": 1,
+      "mustMatch": [
+        {
+          "pattern": "custom.{0,40}OAuth.{0,160}(?:auth config|authentication config)|OAuth.{0,160}custom (?:auth config|authentication config)|(?:auth config|authentication config).{0,160}custom.{0,40}OAuth",
+          "flags": "is",
+          "message": "uses a custom provider OAuth app and auth config"
+        }
+      ]
+    },
+    {
+      "id": "python-multi-user-session",
+      "mode": "dry",
+      "prompt": "I'm building my first Python agent. Each customer needs to connect their own Gmail account. Show me the right Composio architecture.",
+      "repetitions": 1,
+      "mustMatch": [
+        {
+          "pattern": "\\bsession",
+          "flags": "i",
+          "message": "uses sessions for a new Platform integration"
+        },
+        {
+          "pattern": "user[_ ]id|customer.{0,50}(?:id|identity)",
+          "flags": "is",
+          "message": "preserves the application's user identity"
+        },
+        {
+          "pattern": "Connect Link|authorize\\(",
+          "flags": "i",
+          "message": "lets Composio return the provider authentication link"
+        }
+      ],
+      "mustNotMatch": [
+        {
+          "pattern": "(?<!not )(?<!never )(?<!don't )\\b(?:build|implement|create).{0,80}(?:OAuth|authorization).{0,40}(?:flow|callback)",
+          "flags": "is",
+          "message": "does not build a provider OAuth flow"
+        }
+      ]
+    },
+    {
+      "id": "direct-rest-version-default",
+      "mode": "dry",
+      "critical": true,
+      "prompt": "I am writing a new direct REST integration. Should I use v3 or v3.1, and what happens when I omit the toolkit version?",
+      "repetitions": 3,
+      "sources": [
+        "sources/direct-rest-version-default.md"
+      ],
+      "mustMatch": [
+        {
+          "pattern": "\\bv3\\.1\\b",
+          "flags": "i",
+          "message": "recommends the current REST API version"
+        },
+        {
+          "pattern": "(?:v3\\.1.{0,160}(?:omit|omission|default).{0,160}latest|(?:omit|omission|default).{0,160}v3\\.1.{0,160}latest)",
+          "flags": "is",
+          "message": "states that v3.1 omission selects latest"
+        },
+        {
+          "pattern": "(?:\\bv3\\b.{0,160}(?:omit|omission|default).{0,160}00000000_00|(?:omit|omission|default).{0,160}\\bv3\\b.{0,160}00000000_00)",
+          "flags": "is",
+          "message": "states that v3 omission selects the pinned base version"
+        }
+      ],
+      "mustNotMatch": [
+        {
+          "pattern": "v3\\.1\\s+(?:omission\\s+)?(?:defaults?|resolves?|selects?)\\s+(?:to\\s+)?(?:the\\s+)?(?:pinned\\s+)?(?:base\\s+)?(?:version\\s+)?00000000_00",
+          "flags": "i",
+          "message": "does not assign the v3 base default to v3.1"
+        }
+      ]
+    },
+    {
+      "id": "hacker-news-read-only-canary",
+      "mode": "live",
+      "prompt": "Use Composio to get today's top five Hacker News stories.",
+      "repetitions": 1,
+      "mustMatch": [
+        {
+          "pattern": "(?:^|\\n)(?:1[.)]|-).{1,200}(?:https?://|news\\.ycombinator\\.com)",
+          "flags": "i",
+          "message": "returns ranked, linked live results"
+        }
+      ],
+      "mustNotMatch": [
+        {
+          "pattern": "I (?:would|could) use|I cannot access",
+          "flags": "i",
+          "message": "does not substitute a plan for live execution"
+        }
+      ]
+    }
+  ]
+}

--- a/skills/composio/evals/cases.json
+++ b/skills/composio/evals/cases.json
@@ -19,8 +19,9 @@
       ],
       "mustNotMatch": [
         {
-          "pattern": "COMPOSIO_API_KEY|ck_[A-Za-z0-9]",
-          "message": "does not choose credentials before the product is known"
+          "pattern": "(?:^|\\n)\\s*(?:(?:[-*]|\\d+[.)])\\s*)?(?:(?:first|next),?\\s+|(?:please|you should|you need to|you have to)\\s+)?(?:use|set|export|configure|paste)\\b.{0,60}(?:COMPOSIO_API_KEY|ck_[A-Za-z0-9])|(?:^|\\n)\\s*(?:(?:[-*]|\\d+[.)])\\s*)?(?:export\\s+COMPOSIO_API_KEY|COMPOSIO_API_KEY\\s*[:=])",
+          "flags": "is",
+          "message": "does not choose Platform or For You credentials before the product is known"
         }
       ]
     },
@@ -43,7 +44,7 @@
           "message": "does not replace dashboard onboarding with dev init"
         },
         {
-          "pattern": "(?:paste|send|share).{0,50}(?:COMPOSIO_API_KEY|API key)",
+          "pattern": "(?:^|\\n)\\s*(?:(?:[-*]|\\d+[.)])\\s*)?(?:(?:first|next),?\\s+|(?:please|you should|you need to|you have to)\\s+)?(?:paste|send|share)\\b.{0,50}(?:COMPOSIO_API_KEY|API key)",
           "flags": "is",
           "message": "does not request the secret in chat"
         }
@@ -93,7 +94,7 @@
       ],
       "mustNotMatch": [
         {
-          "pattern": "(?:rotate|replace|regenerate).{0,60}COMPOSIO_API_KEY",
+          "pattern": "(?:^|\\n)\\s*(?:(?:[-*]|\\d+[.)])\\s*)?(?:(?:first|next),?\\s+|(?:please|you should|you need to|you have to)\\s+)?(?:rotate|replace|regenerate)\\b.{0,60}COMPOSIO_API_KEY",
           "flags": "is",
           "message": "does not rotate a working project key"
         }
@@ -106,9 +107,9 @@
       "repetitions": 1,
       "mustMatch": [
         {
-          "pattern": "custom.{0,80}OAuth.{0,40}(?:app|client)|OAuth.{0,80}custom.{0,40}(?:app|client)",
+          "pattern": "OAuth.{0,40}(?:app|client)|(?:app|client).{0,40}OAuth",
           "flags": "is",
-          "message": "uses a custom provider OAuth app"
+          "message": "uses a provider OAuth app or client"
         },
         {
           "pattern": "custom.{0,40}(?:auth config|authentication config)|(?:auth config|authentication config).{0,40}custom",

--- a/skills/composio/evals/sources/direct-rest-version-default.md
+++ b/skills/composio/evals/sources/direct-rest-version-default.md
@@ -1,0 +1,13 @@
+# Direct REST toolkit-version defaults
+
+Retrieved: 2026-08-10
+
+Sources:
+
+- https://docs.composio.dev/reference/api-reference/tools/getTools
+- https://docs.composio.dev/docs/tools-direct/toolkit-versioning.md
+- `context7.json` at the repository root
+
+For a new direct REST integration, use API v3.1. On the five v3.1 tool endpoints listed in `context7.json`, omitting the toolkit version selects the latest toolkit version. On v3, omission selects the pinned base version `00000000_00`.
+
+Name the REST API version explicitly. If current API reference or verified endpoint behavior conflicts with a page marked Legacy, the current API reference and live behavior win.

--- a/ts/scripts/run-skill-evals.mjs
+++ b/ts/scripts/run-skill-evals.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const repoRoot = process.cwd();
+const skillsRoot = path.join(repoRoot, 'skills');
+
+const die = message => {
+  console.error(message);
+  process.exit(1);
+};
+
+const discoverSuites = () => {
+  if (!fs.existsSync(skillsRoot)) return [];
+  return fs
+    .readdirSync(skillsRoot, { withFileTypes: true })
+    .filter(entry => entry.isDirectory())
+    .map(entry => {
+      const skill = entry.name;
+      const evalsDir = path.join(skillsRoot, skill, 'evals');
+      const casesFile = path.join(evalsDir, 'cases.json');
+      if (!fs.existsSync(casesFile)) return null;
+      return {
+        skill,
+        evalsDir,
+        data: JSON.parse(fs.readFileSync(casesFile, 'utf8')),
+      };
+    })
+    .filter(Boolean);
+};
+
+const validateSuites = suites => {
+  const errors = [];
+  const seen = new Set();
+  const fail = message => errors.push(message);
+
+  for (const suite of suites) {
+    const skillFile = path.join(skillsRoot, suite.skill, 'SKILL.md');
+    if (!fs.existsSync(skillFile)) fail(`${suite.skill}: missing SKILL.md`);
+    if (suite.data.version !== 1) fail(`${suite.skill}: cases.json version must be 1`);
+    if (!Array.isArray(suite.data.cases) || suite.data.cases.length === 0) {
+      fail(`${suite.skill}: cases must be a non-empty array`);
+      continue;
+    }
+
+    for (const evalCase of suite.data.cases) {
+      const prefix = `${suite.skill}/${evalCase.id ?? '<missing-id>'}`;
+      if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(evalCase.id ?? '')) {
+        fail(`${prefix}: id must be a lowercase kebab-case slug`);
+      }
+      if (seen.has(prefix)) fail(`${prefix}: duplicate case id`);
+      seen.add(prefix);
+      if (!['dry', 'live'].includes(evalCase.mode)) fail(`${prefix}: mode must be dry or live`);
+      if (typeof evalCase.prompt !== 'string' || evalCase.prompt.trim().length < 10) {
+        fail(`${prefix}: prompt must be at least 10 characters`);
+      }
+      if (
+        !Number.isInteger(evalCase.repetitions) ||
+        evalCase.repetitions < 1 ||
+        evalCase.repetitions > 5
+      ) {
+        fail(`${prefix}: repetitions must be an integer from 1 to 5`);
+      }
+      if (evalCase.critical && evalCase.repetitions < 3) {
+        fail(`${prefix}: critical cases require at least 3 repetitions`);
+      }
+
+      const assertions = [...(evalCase.mustMatch ?? []), ...(evalCase.mustNotMatch ?? [])];
+      if (assertions.length === 0) fail(`${prefix}: at least one assertion is required`);
+      for (const assertion of assertions) {
+        if (typeof assertion.pattern !== 'string' || typeof assertion.message !== 'string') {
+          fail(`${prefix}: each assertion needs pattern and message strings`);
+          continue;
+        }
+        try {
+          new RegExp(assertion.pattern, assertion.flags ?? '');
+        } catch (error) {
+          fail(`${prefix}: invalid regex ${JSON.stringify(assertion.pattern)}: ${error.message}`);
+        }
+      }
+
+      for (const source of evalCase.sources ?? []) {
+        const resolved = path.resolve(suite.evalsDir, source);
+        if (!resolved.startsWith(`${suite.evalsDir}${path.sep}`) || !fs.existsSync(resolved)) {
+          fail(`${prefix}: missing or out-of-tree source ${source}`);
+        }
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    die(`Skill eval validation failed:\n${errors.map(error => `- ${error}`).join('\n')}`);
+  }
+};
+
+const findCase = (suites, qualifiedId) => {
+  const [skill, ...idParts] = qualifiedId.split('/');
+  const id = idParts.join('/');
+  const suite = suites.find(candidate => candidate.skill === skill);
+  const evalCase = suite?.data.cases.find(candidate => candidate.id === id);
+  if (!suite || !evalCase) die(`Unknown skill eval case: ${qualifiedId}`);
+  return evalCase;
+};
+
+const grade = (qualifiedId, outputFile, suites) => {
+  const evalCase = findCase(suites, qualifiedId);
+  if (!outputFile || !fs.existsSync(outputFile)) {
+    die(`${qualifiedId}: missing output file ${outputFile ?? ''}`);
+  }
+  const output = fs.readFileSync(outputFile, 'utf8').trim();
+  const failures = [];
+  if (output.length < 20) failures.push('output is empty or too short');
+  if (/\b(?:ck|sk)_(?!(?:REPLACE|YOUR|EXAMPLE))[A-Za-z0-9_-]{16,}\b/.test(output)) {
+    failures.push('output contains a credential-like value');
+  }
+
+  for (const assertion of evalCase.mustMatch ?? []) {
+    if (!new RegExp(assertion.pattern, assertion.flags ?? '').test(output)) {
+      failures.push(`missing: ${assertion.message}`);
+    }
+  }
+  for (const assertion of evalCase.mustNotMatch ?? []) {
+    if (new RegExp(assertion.pattern, assertion.flags ?? '').test(output)) {
+      failures.push(`forbidden: ${assertion.message}`);
+    }
+  }
+
+  if (failures.length > 0) {
+    die(`${qualifiedId}: FAIL\n${failures.map(failure => `- ${failure}`).join('\n')}`);
+  }
+  console.log(`${qualifiedId}: PASS`);
+};
+
+let suites;
+try {
+  suites = discoverSuites();
+} catch (error) {
+  die(`Could not load skill eval cases: ${error.message}`);
+}
+
+if (suites.length === 0) die('No skill eval suites found under skills/*/evals/cases.json');
+validateSuites(suites);
+
+const [command = 'validate', ...args] = process.argv.slice(2);
+if (command === 'validate') {
+  const caseCount = suites.reduce((total, suite) => total + suite.data.cases.length, 0);
+  console.log(`Skill eval validation passed (${caseCount} cases across ${suites.length} skills).`);
+} else if (command === 'matrix') {
+  const include = suites.flatMap(suite =>
+    suite.data.cases
+      .filter(evalCase => evalCase.mode === 'dry')
+      .flatMap(evalCase =>
+        Array.from({ length: evalCase.repetitions }, (_, index) => ({
+          skill: suite.skill,
+          case: evalCase.id,
+          repetition: index + 1,
+        }))
+      )
+  );
+  console.log(JSON.stringify({ include }));
+} else if (command === 'grade') {
+  grade(args[0], args[1], suites);
+} else {
+  die(`Unknown command ${command}. Use validate, matrix, or grade.`);
+}

--- a/ts/scripts/run-skill-evals.mjs
+++ b/ts/scripts/run-skill-evals.mjs
@@ -101,11 +101,11 @@ const findCase = (suites, qualifiedId) => {
   const suite = suites.find(candidate => candidate.skill === skill);
   const evalCase = suite?.data.cases.find(candidate => candidate.id === id);
   if (!suite || !evalCase) die(`Unknown skill eval case: ${qualifiedId}`);
-  return evalCase;
+  return { suite, evalCase };
 };
 
 const grade = (qualifiedId, outputFile, suites) => {
-  const evalCase = findCase(suites, qualifiedId);
+  const { evalCase } = findCase(suites, qualifiedId);
   if (!outputFile || !fs.existsSync(outputFile)) {
     die(`${qualifiedId}: missing output file ${outputFile ?? ''}`);
   }
@@ -131,6 +131,28 @@ const grade = (qualifiedId, outputFile, suites) => {
     die(`${qualifiedId}: FAIL\n${failures.map(failure => `- ${failure}`).join('\n')}`);
   }
   console.log(`${qualifiedId}: PASS`);
+};
+
+const renderPrompt = (qualifiedId, suites) => {
+  const { suite, evalCase } = findCase(suites, qualifiedId);
+  const sources = (evalCase.sources ?? []).map(source =>
+    path.posix.join('skills', suite.skill, 'evals', source)
+  );
+  const lines = [
+    '# Skill eval input',
+    '',
+    `Skill: ${suite.skill}`,
+    `Mode: ${evalCase.mode}`,
+    '',
+    '## User prompt',
+    '',
+    evalCase.prompt,
+    '',
+    '## Source fixtures',
+    '',
+    ...(sources.length > 0 ? sources.map(source => `- ${source}`) : ['- None']),
+  ];
+  console.log(lines.join('\n'));
 };
 
 let suites;
@@ -160,8 +182,12 @@ if (command === 'validate') {
       )
   );
   console.log(JSON.stringify({ include }));
+} else if (command === 'has-dry-cases') {
+  console.log(suites.some(suite => suite.data.cases.some(evalCase => evalCase.mode === 'dry')));
+} else if (command === 'prompt') {
+  renderPrompt(args[0], suites);
 } else if (command === 'grade') {
   grade(args[0], args[1], suites);
 } else {
-  die(`Unknown command ${command}. Use validate, matrix, or grade.`);
+  die(`Unknown command ${command}. Use validate, matrix, has-dry-cases, prompt, or grade.`);
 }


### PR DESCRIPTION
## Summary

- add a dependency-free, reusable runner for `skills/*/evals/cases.json`
- codify Soumya's core routing/debugging scenarios plus the verified direct-REST regression
- run dry behavioral cases in a generated GitHub Actions matrix; repeat critical cases three times
- keep live canaries explicit and Composio-only until trusted test accounts are configured

## Why this is stacked

This PR targets `codex/host-composio-skill` because the public `skills/composio` tree is introduced by #4084. Merge/review #4084 first, then retarget this PR to `next`.

## Verification

- `node ts/scripts/run-skill-evals.mjs validate`
- all 7 dry case graders passed against blind outputs
- direct-REST critical case passed 3/3 fresh blind runs
- a deliberately wrong v3.1/base answer failed the grader
- live Hacker News read-only canary passed through Composio (`log_9sA4MPaEPufs`)
- workflow YAML parsed successfully

No changeset: eval and workflow infrastructure only.