### PR TITLE
docs: clarify skill discovery across surfaces

### DIFF
--- a/docs/components/ai-tools-banner.tsx
+++ b/docs/components/ai-tools-banner.tsx
@@ -68,19 +68,10 @@ export function AIToolsBanner() {
           {/* Skills */}
           <div className="flex flex-1 flex-col gap-1">
             <span className="text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--composio-orange)]">Skills</span>
-            <CopyableCommand text="npx skills add composiohq/skills" />
+            <CopyableCommand text="npx skills add ComposioHQ/composio --skill composio" />
             <div className="flex items-center gap-2.5 pl-0.5 text-[11px]">
               <Link
-                href="https://skills.sh/composiohq/skills/composio"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-fd-muted-foreground hover:text-[var(--composio-orange)] transition-colors"
-              >
-                Skills.sh
-                <ExternalLink aria-hidden="true" className="ml-1 inline h-2.5 w-2.5" />
-              </Link>
-              <Link
-                href="https://github.com/composiohq/skills"
+                href="https://github.com/ComposioHQ/composio/tree/next/skills/composio"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-fd-muted-foreground hover:text-[var(--composio-orange)] transition-colors"

--- a/docs/content/docs/cli.mdx
+++ b/docs/content/docs/cli.mdx
@@ -30,6 +30,18 @@ Open Claude Code in the project you want to work in. `composio login` installs t
 composio --install-skill composio-cli claude
 ```
 
+### What each setup path installs
+
+| Action | What becomes available |
+|---|---|
+| Run the shell installer | The `composio` command. It does not install plugins, skills, or log you in unless you opt in. |
+| Run `composio login` in an interactive terminal | An authenticated CLI session and the `composio-cli` skill for Claude Code by default. Pass `--no-skill-install` to skip the skill. |
+| Run `composio setup --target auto` | Plugins for detected Claude Code and Codex hosts. The Claude plugin uses the separately installed CLI skill; the OpenAI/Codex plugin bundles its own `composio-runtime` router. |
+| Configure raw Composio MCP | Callable tools and schemas, not an agent skill. MCP setup is separate from CLI and plugin setup. |
+| Run `npx skills add ComposioHQ/composio --skill composio` | The separate public `composio` product and integration router. None of the paths above installs it automatically. |
+
+The three skills have different jobs: `composio` selects the product and integration path, `composio-runtime` selects the OpenAI plugin's hosted or local execution surface, and `composio-cli` owns current CLI commands and workflows.
+
 ### Install with options
 
 Pin a version and opt in to agent plugin setup:

--- a/docs/content/docs/composio-connect.mdx
+++ b/docs/content/docs/composio-connect.mdx
@@ -12,6 +12,10 @@ Composio Connect is an MCP server at `https://connect.composio.dev/mcp` that giv
 
 Rather than exposing every app tool directly, Composio exposes **7 meta-tools** that let the agent discover what's available, authorize apps on demand, and execute tools across apps in parallel. The first time your agent needs an app, Composio generates an OAuth link you approve in your browser; after that the connection persists across sessions. See [Available MCP tools](#available-mcp-tools) for the full list.
 
+<Callout type="info">
+A raw MCP connection makes these tools and their schemas available; it does not install an agent skill. Host plugins may bundle their own runtime skill, while the Composio CLI can install the separate `composio-cli` skill. Run `npx skills add ComposioHQ/composio --skill composio` to install the public product and integration router explicitly.
+</Callout>
+
 To get started, pick your client below.
 
 <ConnectFlow>

--- a/docs/lib/source.ts
+++ b/docs/lib/source.ts
@@ -385,8 +385,8 @@ export function mdxToCleanMarkdown(content: string, url?: string): string {
     /<AIToolsBanner\s*\/>/g,
     '### For AI tools\n\n' +
       '**Skills:**\n' +
-      '```bash\nnpx skills add composiohq/skills\n```\n' +
-      '[Skills.sh](https://skills.sh/composiohq/skills/composio) · [GitHub](https://github.com/composiohq/skills)\n\n' +
+      '```bash\nnpx skills add ComposioHQ/composio --skill composio\n```\n' +
+      '[GitHub](https://github.com/ComposioHQ/composio/tree/next/skills/composio)\n\n' +
       '**CLI:**\n' +
       '```bash\ncurl -fsSL https://composio.dev/install | sh\n```\n' +
       '[CLI Reference](/docs/cli)\n\n' +


### PR DESCRIPTION
## Summary

- document what the shell installer, interactive `composio login`, and `composio setup` make discoverable
- use the monorepo public `composio` skill as the canonical onboarding skill across the CLI page, Connect callout, site-wide AI banner, and llms.txt output
- distinguish the public `composio` skill from the OpenAI plugin's `composio-runtime` skill and the CLI-owned `composio-cli` skill
- state that raw MCP exposes callable tools and schemas but does not install an agent skill

## Dependencies and related work

Merge [#4084](https://github.com/ComposioHQ/composio/pull/4084) first so the documented `ComposioHQ/composio` skill and exact install command exist before these docs publish. The WAIT/reference work was split into independent [#4112](https://github.com/ComposioHQ/composio/pull/4112) ([Glen](https://app.tryglen.com/ComposioHQ/composio/pull/4112)); both PRs target `next`, and neither diff depends on the other.

## Scope

Exactly four docs files: `docs/components/ai-tools-banner.tsx`, `docs/content/docs/cli.mdx`, `docs/content/docs/composio-connect.mdx`, and `docs/lib/source.ts`. No CLI, plugin, MCP server, SDK, backend, generated meta-tool reference, or eval-system behavior changes.

## Verification

- all four discovery locations use `npx skills add ComposioHQ/composio --skill composio`
- no `composiohq/skills` install path remains in this diff
- the copy describes existing surface behavior instead of implying that MCP installs skills
- CI on this standalone branch is the merge gate