### PR TITLE
docs(providers): correct session-helper versions to minor releases

### DIFF
--- a/docs/content/docs/providers/anthropic.mdx
+++ b/docs/content/docs/providers/anthropic.mdx
@@ -51,7 +51,7 @@ ANTHROPIC_API_KEY=xxxxxxxxx
 **Create session and run**
 
 <Callout type="info">
-Passing a session to `handle_tool_calls` / `handleToolCalls` requires `composio` newer than 0.18.2 (Python) or `@composio/core` ≥ 0.15.1 with `@composio/anthropic` ≥ 0.10.2 (TypeScript). On earlier versions, execute session tools with [`session.execute()`](/docs/how-composio-works#executing-session-tools).
+Passing a session to `handle_tool_calls` / `handleToolCalls` requires `composio` newer than 0.18.2 (Python) or `@composio/core` ≥ 0.16.0 with `@composio/anthropic` ≥ 0.11.0 (TypeScript). On earlier versions, execute session tools with [`session.execute()`](/docs/how-composio-works#executing-session-tools).
 </Callout>
 
 <Tabs groupId="language" items={["Python", "TypeScript"]} persist>
@@ -107,7 +107,7 @@ for block in response.content:
 ```
 </Tab>
 <Tab value="TypeScript">
-{/* TODO: remove the `@errors: 2345` twoslash marker below once the docs lockfile resolves @composio/core >= 0.15.1 and @composio/anthropic >= 0.10.2 (session-aware handleToolCalls). The anthropic pin (^0.10.1) already admits 0.10.2, so this needs a `bun update` plus the core bump to ^0.15.1 — no @composio/anthropic range change. */}
+{/* TODO: remove the `@errors: 2345` twoslash marker below once docs/package.json resolves @composio/core >= 0.16.0 and @composio/anthropic >= 0.11.0 (session-aware handleToolCalls). Both pins need a manual range bump — ^0.15.0 / ^0.10.1 do not admit these minor releases. */}
 ```typescript
 // @errors: 2345
 import Anthropic from '@anthropic-ai/sdk';

--- a/docs/content/docs/providers/openai.mdx
+++ b/docs/content/docs/providers/openai.mdx
@@ -55,7 +55,7 @@ OPENAI_API_KEY=xxxxxxxxx
 The [Responses API](https://platform.openai.com/docs/api-reference/responses) is the recommended way to build agentic flows with OpenAI. You pass `previous_response_id` on each turn so the model keeps the prior context, and you send back only the new `function_call_output` items.
 
 <Callout type="info">
-Passing a session to `handle_tool_calls` / `handleToolCalls` requires `composio` newer than 0.18.2 (Python) or `@composio/core` ≥ 0.15.1 with `@composio/openai` ≥ 0.11.1 (TypeScript). On earlier versions, execute session tools with [`session.execute()`](/docs/how-composio-works#executing-session-tools).
+Passing a session to `handle_tool_calls` / `handleToolCalls` requires `composio` newer than 0.18.2 (Python) or `@composio/core` ≥ 0.16.0 with `@composio/openai` ≥ 0.12.0 (TypeScript). On earlier versions, execute session tools with [`session.execute()`](/docs/how-composio-works#executing-session-tools).
 </Callout>
 
 <Tabs groupId="language" items={["Python", "TypeScript"]} persist>
@@ -111,7 +111,7 @@ for item in response.output:
 ```
 </Tab>
 <Tab value="TypeScript">
-{/* TODO: remove the `@errors: 2345` twoslash marker below once docs/package.json resolves @composio/core >= 0.15.1 and @composio/openai >= 0.11.1 (session-aware handleToolCalls). */}
+{/* TODO: remove the `@errors: 2345` twoslash marker below once docs/package.json resolves @composio/core >= 0.16.0 and @composio/openai >= 0.12.0 (session-aware handleToolCalls). Both pins need a manual range bump — ^0.15.0 / ^0.11.0 do not admit these minor releases. */}
 ```typescript
 // @errors: 2345
 import OpenAI from 'openai';
@@ -205,7 +205,7 @@ OPENAI_API_KEY=xxxxxxxxx
 The [Chat Completions API](https://platform.openai.com/docs/api-reference/chat) generates a model response from a list of messages. You keep the full message list yourself and append each assistant message and its `tool` results before the next call.
 
 <Callout type="info">
-Passing a session to `handle_tool_calls` / `handleToolCalls` requires `composio` newer than 0.18.2 (Python) or `@composio/core` ≥ 0.15.1 with `@composio/openai` ≥ 0.11.1 (TypeScript). On earlier versions, execute session tools with [`session.execute()`](/docs/how-composio-works#executing-session-tools).
+Passing a session to `handle_tool_calls` / `handleToolCalls` requires `composio` newer than 0.18.2 (Python) or `@composio/core` ≥ 0.16.0 with `@composio/openai` ≥ 0.12.0 (TypeScript). On earlier versions, execute session tools with [`session.execute()`](/docs/how-composio-works#executing-session-tools).
 </Callout>
 
 <Tabs groupId="language" items={["Python", "TypeScript"]} persist>
@@ -253,7 +253,7 @@ print(response.choices[0].message.content)
 ```
 </Tab>
 <Tab value="TypeScript">
-{/* TODO: remove the `@errors: 2345` twoslash marker below once docs/package.json resolves @composio/core >= 0.15.1 and @composio/openai >= 0.11.1 (session-aware handleToolCalls). */}
+{/* TODO: remove the `@errors: 2345` twoslash marker below once docs/package.json resolves @composio/core >= 0.16.0 and @composio/openai >= 0.12.0 (session-aware handleToolCalls). Both pins need a manual range bump — ^0.15.0 / ^0.11.0 do not admit these minor releases. */}
 ```typescript
 // @errors: 2345
 import OpenAI from 'openai';


### PR DESCRIPTION
This PR:

- builds on top of https://github.com/ComposioHQ/composio/pull/4098
- corrects the minimum-version callouts on the OpenAI and Anthropic provider pages to the releases the `minor` changeset will produce: `@composio/core` ≥ 0.16.0, `@composio/openai` ≥ 0.12.0, `@composio/anthropic` ≥ 0.11.0 — the pages named the superseded patch versions (0.15.1 / 0.11.1 / 0.10.2), which will never be published
- rewrites the three `@errors: 2345` twoslash TODOs to name the retiring minor versions and to state that all three `docs/package.json` pins (`^0.15.0`, `^0.11.0`, `^0.10.1`) need a manual range bump — including the anthropic TODO, whose "pin already admits 0.10.2, no range change needed" note was made false by the patch→minor bump
- is prose- and comment-only: no code fences touched, so the session-execution static guard and twoslash output are unaffected

## Context

`6eb33a4` on #4098 moved the changeset from `patch` to `minor` (the new session overloads are a type-level break for provider subclasses), but every version claim in the docs still named the patch releases. Flagged in the latest docs-review round on #4098 as the one thing to fix before merge; this PR is that fix, kept out of the contributor branch for a clean review trail.

Python claims ("`composio` newer than 0.18.2") are unchanged: `python/pyproject.toml` is intentionally unbumped, so they remain accurate.
