### PR TITLE
chore(sdk): start 1.0 beta with owned client 2.0.0-rc.6

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,4 @@
+{
+  "mode": "pre",
+  "tag": "beta"
+}

--- a/.changeset/use-owned-composio-client.md
+++ b/.changeset/use-owned-composio-client.md
@@ -2,4 +2,4 @@
 '@composio/core': minor
 ---
 
-Replace the frozen Stainless `@composio/client` with the owned `2.0.0-rc.1` client.
+Replace the frozen Stainless `@composio/client` with the owned `2.0.0-rc.3` client.

--- a/.changeset/use-owned-composio-client.md
+++ b/.changeset/use-owned-composio-client.md
@@ -1,0 +1,5 @@
+---
+'@composio/core': minor
+---
+
+Replace the frozen Stainless `@composio/client` with the owned `2.0.0-rc.1` client.

--- a/.changeset/use-owned-composio-client.md
+++ b/.changeset/use-owned-composio-client.md
@@ -2,4 +2,4 @@
 '@composio/core': minor
 ---
 
-Replace the frozen Stainless `@composio/client` with the owned `2.0.0-rc.5` client.
+Replace the frozen Stainless `@composio/client` with the owned `2.0.0-rc.6` client.

--- a/.changeset/use-owned-composio-client.md
+++ b/.changeset/use-owned-composio-client.md
@@ -2,4 +2,4 @@
 '@composio/core': minor
 ---
 
-Replace the frozen Stainless `@composio/client` with the owned `2.0.0-rc.3` client.
+Replace the frozen Stainless `@composio/client` with the owned `2.0.0-rc.5` client.

--- a/.changeset/use-owned-composio-client.md
+++ b/.changeset/use-owned-composio-client.md
@@ -1,5 +1,5 @@
 ---
-'@composio/core': minor
+'@composio/core': major
 ---
 
 Replace the frozen Stainless `@composio/client` with the owned `2.0.0-rc.6` client.

--- a/.github/workflows/dead-code.yml
+++ b/.github/workflows/dead-code.yml
@@ -11,7 +11,7 @@ name: Dead Code
 
 on:
   push:
-    branches: [master, next]
+    branches: [master, next, main]
     paths:
       - 'ts/**'
       - 'python/**'
@@ -25,7 +25,7 @@ on:
       - 'mise.toml'
       - 'mise.lock'
   pull_request:
-    branches: [master, next]
+    branches: [master, next, main]
     paths:
       - 'ts/**'
       - 'python/**'

--- a/.github/workflows/examples-live.yml
+++ b/.github/workflows/examples-live.yml
@@ -24,6 +24,10 @@ on:
         description: 'Comma-separated entry ids (empty = full manifest)'
         type: string
         default: ''
+      exclude_toolkits:
+        description: 'Comma-separated toolkits to exclude, including dependent entries'
+        type: string
+        default: googledrive
       client_tarball_url:
         description: 'Candidate TypeScript client tarball URL (required for TS candidate entries)'
         type: string
@@ -54,6 +58,9 @@ env:
   COMPOSIO_API_KEY: ${{ secrets.COMPOSIO_API_KEY }}
   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
   ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+  # Keep unavailable coverage explicit. The harness records excluded entry ids
+  # in its summary artifact; remove this default when staging has Drive auth.
+  EXCLUDE_TOOLKITS: ${{ inputs.exclude_toolkits || 'googledrive' }}
   # mock unless explicitly dispatched live; the nightly adds a small live canary.
   LLM_MODE: ${{ inputs.llm || 'mock' }}
   # Entries mocks cannot cover (llmMock:false) plus one representative
@@ -62,7 +69,7 @@ env:
 
 jobs:
   examples-live:
-    name: ${{ inputs.client || 'baseline' }} sweep (${{ inputs.lang || 'all' }})
+    name: ${{ inputs.client || 'baseline' }} sweep (${{ inputs.lang || 'all' }}, excluding ${{ inputs.exclude_toolkits || 'googledrive' }})
     environment: staging
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -130,7 +137,19 @@ jobs:
         run: node harness/run.mjs selftest
 
       - name: Verify provisioned project state
-        run: node scripts/examples-provision.mjs --gc > /tmp/examples-provision.env
+        env:
+          IDS_INPUT: ${{ inputs.ids }}
+          LANG_INPUT: ${{ inputs.lang || 'all' }}
+        run: |
+          set -euo pipefail
+          ARGS=(--gc --exclude-toolkits "$EXCLUDE_TOOLKITS")
+          if [ "$LANG_INPUT" != "all" ]; then
+            ARGS+=(--lang "$LANG_INPUT")
+          fi
+          if [ -n "$IDS_INPUT" ]; then
+            ARGS+=(--ids "$IDS_INPUT")
+          fi
+          node scripts/examples-provision.mjs "${ARGS[@]}" > /tmp/examples-provision.env
 
       - name: Sweep
         env:
@@ -148,6 +167,7 @@ jobs:
           if [ -n "$IDS_INPUT" ]; then
             ARGS+=(--ids "$IDS_INPUT")
           fi
+          ARGS+=(--exclude-toolkits "$EXCLUDE_TOOLKITS")
           node harness/run.mjs sweep "${ARGS[@]}"
 
       - name: Live LLM canary
@@ -155,7 +175,7 @@ jobs:
         run: |
           set -euo pipefail
           source /tmp/examples-provision.env
-          node harness/run.mjs sweep --client baseline --llm live --ids "$CANARY_IDS"
+          node harness/run.mjs sweep --client baseline --llm live --ids "$CANARY_IDS" --exclude-toolkits "$EXCLUDE_TOOLKITS"
 
       - name: Upload sweep results and traces
         if: ${{ always() }}

--- a/.github/workflows/py.check.yaml
+++ b/.github/workflows/py.check.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - next
+      - main
     paths:
       - 'python/**/*.py'
       - 'python/pyproject.toml'

--- a/.github/workflows/py.test.yml
+++ b/.github/workflows/py.test.yml
@@ -104,7 +104,7 @@ jobs:
           # its own environment instead of constructing an invalid combination.
           uv venv autogen-env --python ${{ matrix.python-version }}
           source autogen-env/bin/activate
-          uv pip install -e . -e providers/autogen
+          uv pip install -e . -e providers/autogen pytest pytest-mock
           python -c "import composio_autogen; print('✓ Autogen provider import successful')"
           python -m pytest \
             tests/test_provider.py::TestAgenticSkipDefaultsParity::test_autogen_signature_honors_skip_defaults \

--- a/.github/workflows/py.test.yml
+++ b/.github/workflows/py.test.yml
@@ -88,7 +88,6 @@ jobs:
           uv pip install -e providers/crewai
           uv pip install -e providers/langchain
           uv pip install -e providers/langgraph
-          uv pip install -e providers/autogen
           uv pip install pytest pytest-mock
 
       - name: Run Import Tests
@@ -96,9 +95,16 @@ jobs:
           cd python/
           source .venv/bin/activate
           python -c "from composio import Composio; print('✓ Basic import successful')"
-          # Guards against the autogen provider becoming un-importable on a fresh
-          # install (e.g. a broken framework dependency). A hard import here fails
-          # loudly, unlike the importorskip-guarded unit tests, which would skip.
+
+      - name: Test Autogen Provider Installation
+        run: |
+          cd python/
+          # autogen-core requires protobuf 5, while CrewAI's telemetry stack
+          # requires protobuf 6. Test the independently distributed provider in
+          # its own environment instead of constructing an invalid combination.
+          uv venv autogen-env --python ${{ matrix.python-version }}
+          source autogen-env/bin/activate
+          uv pip install -e . -e providers/autogen
           python -c "import composio_autogen; print('✓ Autogen provider import successful')"
 
       - name: Run Unit Tests

--- a/.github/workflows/py.test.yml
+++ b/.github/workflows/py.test.yml
@@ -2,7 +2,7 @@ name: Test Python SDK
 
 on:
   push:
-    branches: [master, next]
+    branches: [master, next, main]
     paths:
       - 'python/**/*.py'
       - 'python/**/*.json'
@@ -15,7 +15,7 @@ on:
       - 'uv.lock'
       - 'python/requirements*.txt'
   pull_request:
-    branches: [master, next]
+    branches: [master, next, main]
     paths:
       - 'python/**/*.py'
       - 'python/**/*.json'

--- a/.github/workflows/security.secrets-detection.yml
+++ b/.github/workflows/security.secrets-detection.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - master
       - next
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/ts.audit.yml
+++ b/.github/workflows/ts.audit.yml
@@ -2,7 +2,7 @@ name: Audit Typescript SDK
 
 on:
   push:
-    branches: [master, next]
+    branches: [master, next, main]
     paths:
       - 'ts/**'
       - '.github/actions/setup-node-pnpm-bun/action.yml'
@@ -13,7 +13,7 @@ on:
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'
   pull_request:
-    branches: [master, next]
+    branches: [master, next, main]
     paths:
       - 'ts/**'
       - '.github/actions/setup-node-pnpm-bun/action.yml'

--- a/.github/workflows/ts.build.yml
+++ b/.github/workflows/ts.build.yml
@@ -2,7 +2,7 @@ name: Build Typescript SDK
 
 on:
   push:
-    branches: [next]
+    branches: [next, main]
     paths:
       - 'ts/**'
       - '.oxlintrc.json'

--- a/.github/workflows/ts.examples.yml
+++ b/.github/workflows/ts.examples.yml
@@ -2,7 +2,7 @@ name: Examples TypeScript SDK
 
 on:
   push:
-    branches: [master, next]
+    branches: [master, next, main]
     paths:
       - 'ts/examples/**'
       - 'ts/packages/core/**'
@@ -17,7 +17,7 @@ on:
       - 'pnpm-lock.yaml'
       - 'turbo.jsonc'
   pull_request:
-    branches: [master, next]
+    branches: [master, next, main]
     paths:
       - 'ts/examples/**'
       - 'ts/packages/core/**'

--- a/.github/workflows/ts.release.yml
+++ b/.github/workflows/ts.release.yml
@@ -3,7 +3,7 @@ name: TS SDK Release
 on:
   workflow_dispatch:
   push:
-    branches: [next]
+    branches: [next, main]
 
 permissions:
   contents: read

--- a/.github/workflows/ts.test-e2e.yml
+++ b/.github/workflows/ts.test-e2e.yml
@@ -2,7 +2,7 @@ name: E2E Test Typescript SDK
 
 on:
   push:
-    branches: [master, next]
+    branches: [master, next, main]
     paths:
       - 'ts/**'
       # A catalog pin or lockfile change swaps what every ts/** package

--- a/.github/workflows/ts.test.yml
+++ b/.github/workflows/ts.test.yml
@@ -2,7 +2,7 @@ name: Test Typescript SDK
 
 on:
   push:
-    branches: [master, next]
+    branches: [master, next, main]
     paths:
       - '.changeset/**'
       - 'ts/**'
@@ -17,7 +17,7 @@ on:
       - 'test/release-workflow.test.ts'
       - 'turbo.jsonc'
   pull_request:
-    branches: [master, next]
+    branches: [master, next, main]
     paths:
       - '.changeset/**'
       - 'ts/**'

--- a/.github/workflows/ts.typecheck.yml
+++ b/.github/workflows/ts.typecheck.yml
@@ -2,7 +2,7 @@ name: Typecheck Typescript SDK
 
 on:
   push:
-    branches: [master, next]
+    branches: [master, next, main]
     paths:
       - 'ts/**'
       - '.github/actions/setup-node-pnpm-bun/action.yml'
@@ -13,7 +13,7 @@ on:
       - 'pnpm-lock.yaml'
       - 'turbo.jsonc'
   pull_request:
-    branches: [master, next]
+    branches: [master, next, main]
     paths:
       - 'ts/**'
       - '.github/actions/setup-node-pnpm-bun/action.yml'

--- a/harness/errors.mjs
+++ b/harness/errors.mjs
@@ -1,0 +1,6 @@
+export class HarnessError extends Error {
+  constructor(message, exitCode = 2) {
+    super(message);
+    this.exitCode = exitCode;
+  }
+}

--- a/harness/manifest.mjs
+++ b/harness/manifest.mjs
@@ -1,0 +1,94 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+export const BROWSER_GRANT_TOOLKITS = [
+  { exportPrefix: 'GMAIL', slug: 'gmail' },
+  { slug: 'googledrive' },
+  { exportPrefix: 'GITHUB', slug: 'github' },
+  { exportPrefix: 'SLACK', slug: 'slack' },
+];
+
+export const DEMO_TOOLKIT = {
+  exportPrefix: 'APIKEY',
+  slug: 'serpapi',
+  demoValue: 'examples-demo-key',
+};
+
+const parseCsv = value =>
+  value
+    ? value
+        .split(',')
+        .map(part => part.trim())
+        .filter(Boolean)
+    : [];
+
+const toolkitForId = id => {
+  for (const toolkit of [...BROWSER_GRANT_TOOLKITS, DEMO_TOOLKIT]) {
+    if (toolkit.exportPrefix && id.startsWith(`COMPOSIO_EXAMPLES_${toolkit.exportPrefix}_`)) {
+      return toolkit.slug;
+    }
+  }
+  return undefined;
+};
+
+export const entryToolkits = entry => {
+  const toolkits = new Set(entry.toolkits ?? []);
+  for (const id of entry.ids ?? []) {
+    const toolkit = toolkitForId(id);
+    if (toolkit) toolkits.add(toolkit);
+  }
+  return [...toolkits];
+};
+
+export const loadManifest = () => {
+  const manifest = JSON.parse(readFileSync(join(ROOT, 'examples-manifest.json'), 'utf8'));
+  for (const entry of manifest.entries) {
+    if (!entry.id || !entry.lang || !entry.file || !entry.tier) {
+      throw new Error(`manifest entry missing required fields: ${JSON.stringify(entry)}`);
+    }
+    if (entry.lang === 'ts' && entry.tier !== 'X' && !entry.pkg) {
+      throw new Error(`ts entry ${entry.id} missing pkg`);
+    }
+    if (entry.tier === '3' && !entry.readiness) {
+      throw new Error(`tier-3 entry ${entry.id} missing readiness regex`);
+    }
+  }
+  return manifest.entries;
+};
+
+export const selectManifestEntries = (
+  entries,
+  { lang, ids, tiers = '1,2,3', excludeToolkits } = {}
+) => {
+  const selectedIds = new Set(parseCsv(ids));
+  const selectedTiers = new Set(parseCsv(tiers));
+  const excludedToolkitSet = new Set(parseCsv(excludeToolkits));
+  const eligibleEntries = entries.filter(
+    entry =>
+      entry.tier !== 'X' &&
+      selectedTiers.has(entry.tier) &&
+      (!lang || entry.lang === lang) &&
+      (selectedIds.size === 0 || selectedIds.has(entry.id))
+  );
+  const excludedEntries = eligibleEntries.filter(entry =>
+    entryToolkits(entry).some(toolkit => excludedToolkitSet.has(toolkit))
+  );
+  const excludedIds = new Set(excludedEntries.map(entry => entry.id));
+
+  return {
+    entries: eligibleEntries.filter(entry => !excludedIds.has(entry.id)),
+    excludedEntries,
+    excludedToolkits: [...excludedToolkitSet],
+  };
+};
+
+export const requiredBrowserGrantToolkits = entries =>
+  BROWSER_GRANT_TOOLKITS.filter(toolkit =>
+    entries.some(entry => entryToolkits(entry).includes(toolkit.slug))
+  );
+
+export const requiresDemoToolkit = entries =>
+  entries.some(entry => entryToolkits(entry).includes(DEMO_TOOLKIT.slug));

--- a/harness/manifest.mjs
+++ b/harness/manifest.mjs
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { HarnessError } from './errors.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -43,21 +44,25 @@ export const entryToolkits = entry => {
   return [...toolkits];
 };
 
-export const loadManifest = () => {
-  const manifest = JSON.parse(readFileSync(join(ROOT, 'examples-manifest.json'), 'utf8'));
-  for (const entry of manifest.entries) {
+export const validateManifestEntries = entries => {
+  for (const entry of entries) {
     if (!entry.id || !entry.lang || !entry.file || !entry.tier) {
-      throw new Error(`manifest entry missing required fields: ${JSON.stringify(entry)}`);
+      throw new HarnessError(`manifest entry missing required fields: ${JSON.stringify(entry)}`);
     }
     if (entry.lang === 'ts' && entry.tier !== 'X' && !entry.pkg) {
-      throw new Error(`ts entry ${entry.id} missing pkg`);
+      throw new HarnessError(`ts entry ${entry.id} missing pkg`);
     }
     if (entry.tier === '3' && !entry.readiness) {
-      throw new Error(`tier-3 entry ${entry.id} missing readiness regex`);
+      throw new HarnessError(`tier-3 entry ${entry.id} missing readiness regex`);
     }
   }
-  return manifest.entries;
+  return entries;
 };
+
+export const loadManifest = () =>
+  validateManifestEntries(
+    JSON.parse(readFileSync(join(ROOT, 'examples-manifest.json'), 'utf8')).entries
+  );
 
 export const selectManifestEntries = (
   entries,

--- a/harness/run.mjs
+++ b/harness/run.mjs
@@ -268,20 +268,28 @@ const sh = (cmdline, opts = {}) =>
     child.on('exit', (code) => (code === 0 ? resolveSh(out) : rejectSh(new Error(`${cmdline.join(' ')} → exit ${code}\n${out.slice(-2000)}`))));
   });
 
-const resolvedTsClientVersion = async () => {
-  const out = await sh(['node', '-e', "console.log(JSON.parse(require('fs').readFileSync(require.resolve('@composio/client/package.json', {paths:[require('path').join(process.cwd(),'ts/packages/core')]}), 'utf8')).version)"]);
-  return out.trim().split('\n').pop();
+/**
+ * Resolve @composio/client as @composio/core sees it. The realpath identifies
+ * the installed copy: a `file:` override lands in its own store directory even
+ * when the tarball reports the same version as the catalog pin, so comparing
+ * paths (not versions) is what tells a real swap from a no-op.
+ */
+const resolvedTsClient = async () => {
+  const out = await sh(['node', '-e', "const path=require('path');const fs=require('fs');const manifest=require.resolve('@composio/client/package.json', {paths:[path.join(process.cwd(),'ts/packages/core')]});console.log(JSON.stringify({path:fs.realpathSync(manifest),version:JSON.parse(fs.readFileSync(manifest,'utf8')).version}))"]);
+  return JSON.parse(out.trim().split('\n').pop());
 };
 
-const assertTsCandidateApplied = (baselineVersion, candidateVersion) => {
-  if (candidateVersion === baselineVersion) {
-    fail(`override did not take effect: @composio/client still resolves to ${candidateVersion}`);
+const assertTsCandidateApplied = (baseline, candidate) => {
+  if (candidate.path === baseline.path) {
+    fail(
+      `override did not take effect: @composio/client still resolves to the installed baseline at ${candidate.path} (${candidate.version})`
+    );
   }
 };
 
 const applyTsCandidate = async (tarball) => {
   if (!existsSync(tarball)) fail(`COMPOSIO_CLIENT_TARBALL not found: ${tarball}`);
-  const baselineVersion = await resolvedTsClientVersion();
+  const baseline = await resolvedTsClient();
   const yaml = readFileSync(WORKSPACE_YAML, 'utf8');
   if (/^overrides:$/m.test(yaml)) {
     // Merge into the repo's existing overrides block (e.g. security pins);
@@ -291,9 +299,9 @@ const applyTsCandidate = async (tarball) => {
     writeFileSync(WORKSPACE_YAML, `${yaml}\noverrides:\n  '@composio/client': file:${tarball}\n`);
   }
   await sh(['pnpm', 'install', '--no-frozen-lockfile']);
-  const version = await resolvedTsClientVersion();
-  assertTsCandidateApplied(baselineVersion, version);
-  console.log(`candidate @composio/client resolved: ${version}`);
+  const candidate = await resolvedTsClient();
+  assertTsCandidateApplied(baseline, candidate);
+  console.log(`candidate @composio/client resolved: ${candidate.version} (${candidate.path})`);
   await sh(['pnpm', 'run', 'build:packages']);
 };
 
@@ -488,13 +496,28 @@ const cmdSelftest = async () => {
     cleanupRan && cleanupError instanceof HarnessError
   );
 
+  const installedBaseline = {
+    path: '/repo/node_modules/.pnpm/@composio+client@2.0.0-rc.3/node_modules/@composio/client',
+    version: '2.0.0-rc.3',
+  };
   let noOpCandidateRejected = false;
   try {
-    assertTsCandidateApplied('baseline-version', 'baseline-version');
+    assertTsCandidateApplied(installedBaseline, { ...installedBaseline });
   } catch {
     noOpCandidateRejected = true;
   }
-  check('candidate swap rejects the installed baseline version', noOpCandidateRejected);
+  check('candidate swap rejects the installed baseline copy', noOpCandidateRejected);
+
+  let sameVersionCandidateAccepted = true;
+  try {
+    assertTsCandidateApplied(installedBaseline, {
+      path: '/repo/node_modules/.pnpm/file+client.tgz/node_modules/@composio/client',
+      version: installedBaseline.version,
+    });
+  } catch {
+    sameVersionCandidateAccepted = false;
+  }
+  check('candidate swap accepts a tarball reporting the pinned version', sameVersionCandidateAccepted);
 
   const manifest = loadManifest();
   const withoutGoogleDrive = selectManifestEntries(manifest, {

--- a/harness/run.mjs
+++ b/harness/run.mjs
@@ -16,7 +16,6 @@ import { requireStagingBaseUrl, STAGING_BASE_URL } from './staging-backend.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const ARTIFACTS = join(ROOT, '.artifacts', 'examples-parity');
-const STAINLESS_TS_VERSION = '0.1.0-alpha.76';
 const AIMOCK_VERSION = '1.38.0';
 const AIMOCK_PORT = Number(process.env.AIMOCK_PORT ?? 4010);
 
@@ -273,8 +272,15 @@ const resolvedTsClientVersion = async () => {
   return out.trim().split('\n').pop();
 };
 
+const assertTsCandidateApplied = (baselineVersion, candidateVersion) => {
+  if (candidateVersion === baselineVersion) {
+    fail(`override did not take effect: @composio/client still resolves to ${candidateVersion}`);
+  }
+};
+
 const applyTsCandidate = async (tarball) => {
   if (!existsSync(tarball)) fail(`COMPOSIO_CLIENT_TARBALL not found: ${tarball}`);
+  const baselineVersion = await resolvedTsClientVersion();
   const yaml = readFileSync(WORKSPACE_YAML, 'utf8');
   if (/^overrides:$/m.test(yaml)) {
     // Merge into the repo's existing overrides block (e.g. security pins);
@@ -285,9 +291,7 @@ const applyTsCandidate = async (tarball) => {
   }
   await sh(['pnpm', 'install', '--no-frozen-lockfile']);
   const version = await resolvedTsClientVersion();
-  if (version === STAINLESS_TS_VERSION) {
-    fail(`override did not take effect: @composio/client still resolves to ${version}`);
-  }
+  assertTsCandidateApplied(baselineVersion, version);
   console.log(`candidate @composio/client resolved: ${version}`);
   await sh(['pnpm', 'run', 'build:packages']);
 };
@@ -463,6 +467,14 @@ const cmdSelftest = async () => {
     'usage failures unwind through cleanup',
     cleanupRan && cleanupError instanceof HarnessError
   );
+
+  let noOpCandidateRejected = false;
+  try {
+    assertTsCandidateApplied('baseline-version', 'baseline-version');
+  } catch {
+    noOpCandidateRejected = true;
+  }
+  check('candidate swap rejects the installed baseline version', noOpCandidateRejected);
 
   const cleanupFixture = join(runDir, 'cleanup-fixture.txt');
   writeFileSync(cleanupFixture, 'user contents');

--- a/harness/run.mjs
+++ b/harness/run.mjs
@@ -2,8 +2,8 @@
 // Examples runner: sweeps the entrypoints in examples-manifest.json against
 // the live backend, recording per-entry results and Composio traces.
 //
-//   node harness/run.mjs sweep    --client baseline|candidate [--lang ts|py] [--ids a,b] [--tiers 1,2,3] [--llm live|mock]
-//   node harness/run.mjs neg      [--lang ts|py] [--ids a,b] [--sample N] [--seed S]
+//   node harness/run.mjs sweep    --client baseline|candidate [--lang ts|py] [--ids a,b] [--tiers 1,2,3] [--exclude-toolkits a,b] [--llm live|mock]
+//   node harness/run.mjs neg      [--lang ts|py] [--ids a,b] [--exclude-toolkits a,b] [--sample N] [--seed S]
 //   node harness/run.mjs selftest
 //
 // Exit codes: 0 ok · 1 findings (red entries / failed expectations) · 2 usage/env error.
@@ -12,6 +12,13 @@ import { spawn } from 'node:child_process';
 import { mkdirSync, readFileSync, writeFileSync, appendFileSync, existsSync, rmSync } from 'node:fs';
 import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  entryToolkits,
+  loadManifest,
+  requiredBrowserGrantToolkits,
+  requiresDemoToolkit,
+  selectManifestEntries,
+} from './manifest.mjs';
 import { requireStagingBaseUrl, STAGING_BASE_URL } from './staging-backend.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
@@ -41,27 +48,21 @@ const fail = (msg, code = 2) => {
   throw new HarnessError(msg, code);
 };
 
-const loadManifest = () => {
-  const manifest = JSON.parse(readFileSync(join(ROOT, 'examples-manifest.json'), 'utf8'));
-  for (const e of manifest.entries) {
-    if (!e.id || !e.lang || !e.file || !e.tier) fail(`manifest entry missing required fields: ${JSON.stringify(e)}`);
-    if (e.lang === 'ts' && e.tier !== 'X' && !e.pkg) fail(`ts entry ${e.id} missing pkg`);
-    if (e.tier === '3' && !e.readiness) fail(`tier-3 entry ${e.id} missing readiness regex`);
-  }
-  return manifest.entries;
-};
+const selectionOptions = () => ({
+  lang: opt('lang'),
+  ids: opt('ids'),
+  tiers: opt('tiers', '1,2,3'),
+  excludeToolkits: opt('exclude-toolkits'),
+});
 
-const selectEntries = () => {
-  const lang = opt('lang');
-  const ids = opt('ids') ? opt('ids').split(',') : null;
-  const tiers = (opt('tiers', '1,2,3')).split(',');
-  return loadManifest().filter(
-    (e) =>
-      e.tier !== 'X' &&
-      tiers.includes(e.tier) &&
-      (!lang || e.lang === lang) &&
-      (!ids || ids.includes(e.id))
+const selectEntries = () => selectManifestEntries(loadManifest(), selectionOptions());
+
+const reportExclusions = selection => {
+  if (selection.excludedEntries.length === 0) return;
+  console.log(
+    `excluding ${selection.excludedEntries.length} entries requiring ${selection.excludedToolkits.join(', ')}:`
   );
+  for (const entry of selection.excludedEntries) console.log(`  - ${entry.id}`);
 };
 
 const baseUrl = () => {
@@ -360,9 +361,11 @@ const cmdSweep = async () => {
   const llm = opt('llm', 'live');
   if (!['live', 'mock'].includes(llm)) fail(`--llm must be live|mock`);
   LLM_MOCK = llm === 'mock';
-  const entries = selectEntries();
+  const selection = selectEntries();
+  const entries = selection.entries;
   if (entries.length === 0) fail('no entries selected');
   if (!process.env.COMPOSIO_API_KEY) fail('COMPOSIO_API_KEY is required for a sweep (disposable examples-project key)', 2);
+  reportExclusions(selection);
 
   const id = `${runId()}-${client}${LLM_MOCK ? '-mock' : ''}`;
   const runDir = join(ARTIFACTS, id);
@@ -399,7 +402,22 @@ const cmdSweep = async () => {
     };
     writeFileSync(
       join(runDir, 'summary.json'),
-      JSON.stringify({ runId: id, client, llm, baseUrl: baseUrl(), counts, startedAt: new Date().toISOString() }, null, 2)
+      JSON.stringify(
+        {
+          runId: id,
+          client,
+          llm,
+          baseUrl: baseUrl(),
+          counts,
+          selection: {
+            excludedToolkits: selection.excludedToolkits,
+            excludedEntries: selection.excludedEntries.map(entry => entry.id),
+          },
+          startedAt: new Date().toISOString(),
+        },
+        null,
+        2
+      )
     );
     console.log(`sweep ${id}: ${counts.green} green / ${counts.red} red / ${counts.skipped} skipped`);
     process.exitCode = counts.red > 0 ? 1 : 0;
@@ -410,7 +428,9 @@ const cmdSweep = async () => {
 };
 
 const cmdNeg = async () => {
-  let entries = selectEntries().filter((e) => e.backend !== false);
+  const selection = selectEntries();
+  reportExclusions(selection);
+  let entries = selection.entries.filter((e) => e.backend !== false);
   const sample = opt('sample');
   if (sample) {
     const rand = mulberry32(Number(opt('seed', '42')));
@@ -475,6 +495,41 @@ const cmdSelftest = async () => {
     noOpCandidateRejected = true;
   }
   check('candidate swap rejects the installed baseline version', noOpCandidateRejected);
+
+  const manifest = loadManifest();
+  const withoutGoogleDrive = selectManifestEntries(manifest, {
+    excludeToolkits: 'googledrive',
+  });
+  check(
+    'Google Drive exclusion removes every dependent entry and preserves the rest',
+    withoutGoogleDrive.excludedEntries.length > 0 &&
+      withoutGoogleDrive.excludedEntries.every(entry =>
+        entryToolkits(entry).includes('googledrive')
+      ) &&
+      withoutGoogleDrive.entries.every(entry => !entryToolkits(entry).includes('googledrive')) &&
+      withoutGoogleDrive.entries.length + withoutGoogleDrive.excludedEntries.length ===
+        selectManifestEntries(manifest).entries.length
+  );
+  check(
+    'Google Drive exclusion removes it from provisioning',
+    !requiredBrowserGrantToolkits(withoutGoogleDrive.entries).some(
+      toolkit => toolkit.slug === 'googledrive'
+    )
+  );
+  const apiKeyOnly = selectManifestEntries(manifest, {
+    ids: 'ts/connected-accounts/api-key',
+  }).entries;
+  check(
+    'selected API-key example provisions only its demo toolkit',
+    requiredBrowserGrantToolkits(apiKeyOnly).length === 0 && requiresDemoToolkit(apiKeyOnly)
+  );
+  const implicitGmail = selectManifestEntries(manifest, {
+    ids: 'py/fastapi_app',
+  }).entries;
+  check(
+    'resource identifiers contribute implicit toolkit requirements',
+    requiredBrowserGrantToolkits(implicitGmail).some(toolkit => toolkit.slug === 'gmail')
+  );
 
   const cleanupFixture = join(runDir, 'cleanup-fixture.txt');
   writeFileSync(cleanupFixture, 'user contents');

--- a/harness/run.mjs
+++ b/harness/run.mjs
@@ -268,20 +268,28 @@ const sh = (cmdline, opts = {}) =>
     child.on('exit', (code) => (code === 0 ? resolveSh(out) : rejectSh(new Error(`${cmdline.join(' ')} → exit ${code}\n${out.slice(-2000)}`))));
   });
 
-const resolvedTsClientVersion = async () => {
-  const out = await sh(['node', '-e', "console.log(JSON.parse(require('fs').readFileSync(require.resolve('@composio/client/package.json', {paths:[require('path').join(process.cwd(),'ts/packages/core')]}), 'utf8')).version)"]);
-  return out.trim().split('\n').pop();
+/**
+ * Resolve @composio/client as @composio/core sees it. The realpath identifies
+ * the installed copy: a `file:` override lands in its own store directory even
+ * when the tarball reports the same version as the catalog pin, so comparing
+ * paths (not versions) is what tells a real swap from a no-op.
+ */
+const resolvedTsClient = async () => {
+  const out = await sh(['node', '-e', "const path=require('path');const fs=require('fs');const manifest=require.resolve('@composio/client/package.json', {paths:[path.join(process.cwd(),'ts/packages/core')]});console.log(JSON.stringify({path:fs.realpathSync(manifest),version:JSON.parse(fs.readFileSync(manifest,'utf8')).version}))"]);
+  return JSON.parse(out.trim().split('\n').pop());
 };
 
-const assertTsCandidateApplied = (baselineVersion, candidateVersion) => {
-  if (candidateVersion === baselineVersion) {
-    fail(`override did not take effect: @composio/client still resolves to ${candidateVersion}`);
+const assertTsCandidateApplied = (baseline, candidate) => {
+  if (candidate.path === baseline.path) {
+    fail(
+      `override did not take effect: @composio/client still resolves to the installed baseline at ${candidate.path} (${candidate.version})`
+    );
   }
 };
 
 const applyTsCandidate = async (tarball) => {
   if (!existsSync(tarball)) fail(`COMPOSIO_CLIENT_TARBALL not found: ${tarball}`);
-  const baselineVersion = await resolvedTsClientVersion();
+  const baseline = await resolvedTsClient();
   const yaml = readFileSync(WORKSPACE_YAML, 'utf8');
   if (/^overrides:$/m.test(yaml)) {
     // Merge into the repo's existing overrides block (e.g. security pins);
@@ -291,9 +299,9 @@ const applyTsCandidate = async (tarball) => {
     writeFileSync(WORKSPACE_YAML, `${yaml}\noverrides:\n  '@composio/client': file:${tarball}\n`);
   }
   await sh(['pnpm', 'install', '--no-frozen-lockfile']);
-  const version = await resolvedTsClientVersion();
-  assertTsCandidateApplied(baselineVersion, version);
-  console.log(`candidate @composio/client resolved: ${version}`);
+  const candidate = await resolvedTsClient();
+  assertTsCandidateApplied(baseline, candidate);
+  console.log(`candidate @composio/client resolved: ${candidate.version} (${candidate.path})`);
   await sh(['pnpm', 'run', 'build:packages']);
 };
 
@@ -535,13 +543,28 @@ const cmdSelftest = async () => {
     cleanupRan && cleanupError instanceof HarnessError
   );
 
+  const installedBaseline = {
+    path: '/repo/node_modules/.pnpm/@composio+client@2.0.0-rc.3/node_modules/@composio/client',
+    version: '2.0.0-rc.3',
+  };
   let noOpCandidateRejected = false;
   try {
-    assertTsCandidateApplied('baseline-version', 'baseline-version');
+    assertTsCandidateApplied(installedBaseline, { ...installedBaseline });
   } catch {
     noOpCandidateRejected = true;
   }
-  check('candidate swap rejects the installed baseline version', noOpCandidateRejected);
+  check('candidate swap rejects the installed baseline copy', noOpCandidateRejected);
+
+  let sameVersionCandidateAccepted = true;
+  try {
+    assertTsCandidateApplied(installedBaseline, {
+      path: '/repo/node_modules/.pnpm/file+client.tgz/node_modules/@composio/client',
+      version: installedBaseline.version,
+    });
+  } catch {
+    sameVersionCandidateAccepted = false;
+  }
+  check('candidate swap accepts a tarball reporting the pinned version', sameVersionCandidateAccepted);
 
   const manifest = loadManifest();
   const withoutGoogleDrive = selectManifestEntries(manifest, {

--- a/harness/run.mjs
+++ b/harness/run.mjs
@@ -18,8 +18,10 @@ import {
   requiredBrowserGrantToolkits,
   requiresDemoToolkit,
   selectManifestEntries,
+  validateManifestEntries,
 } from './manifest.mjs';
 import { resolveBackendBaseUrl, STAGING_BASE_URL } from './backend-url.mjs';
+import { HarnessError } from './errors.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const ARTIFACTS = join(ROOT, '.artifacts', 'examples-parity');
@@ -36,13 +38,6 @@ const opt = (name, fallback) => {
   const i = args.indexOf(`--${name}`);
   return i >= 0 && args[i + 1] !== undefined ? args[i + 1] : fallback;
 };
-
-class HarnessError extends Error {
-  constructor(message, exitCode = 2) {
-    super(message);
-    this.exitCode = exitCode;
-  }
-}
 
 const fail = (msg, code = 2) => {
   throw new HarnessError(msg, code);
@@ -604,6 +599,14 @@ const cmdSelftest = async () => {
     sameVersionPyCandidateAccepted = false;
   }
   check('python candidate swap accepts a wheel reporting the pinned version', sameVersionPyCandidateAccepted);
+
+  let invalidManifestIsUsageError = false;
+  try {
+    validateManifestEntries([{ id: 'missing-required-fields' }]);
+  } catch (error) {
+    invalidManifestIsUsageError = error instanceof HarnessError && error.exitCode === 2;
+  }
+  check('invalid manifest entries are usage errors', invalidManifestIsUsageError);
 
   const manifest = loadManifest();
   const withoutGoogleDrive = selectManifestEntries(manifest, {

--- a/harness/run.mjs
+++ b/harness/run.mjs
@@ -16,7 +16,6 @@ import { resolveBackendBaseUrl, STAGING_BASE_URL } from './backend-url.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const ARTIFACTS = join(ROOT, '.artifacts', 'examples-parity');
-const STAINLESS_TS_VERSION = '0.1.0-alpha.76';
 const AIMOCK_VERSION = '1.38.0';
 const AIMOCK_PORT = Number(process.env.AIMOCK_PORT ?? 4010);
 
@@ -273,8 +272,15 @@ const resolvedTsClientVersion = async () => {
   return out.trim().split('\n').pop();
 };
 
+const assertTsCandidateApplied = (baselineVersion, candidateVersion) => {
+  if (candidateVersion === baselineVersion) {
+    fail(`override did not take effect: @composio/client still resolves to ${candidateVersion}`);
+  }
+};
+
 const applyTsCandidate = async (tarball) => {
   if (!existsSync(tarball)) fail(`COMPOSIO_CLIENT_TARBALL not found: ${tarball}`);
+  const baselineVersion = await resolvedTsClientVersion();
   const yaml = readFileSync(WORKSPACE_YAML, 'utf8');
   if (/^overrides:$/m.test(yaml)) {
     // Merge into the repo's existing overrides block (e.g. security pins);
@@ -285,9 +291,7 @@ const applyTsCandidate = async (tarball) => {
   }
   await sh(['pnpm', 'install', '--no-frozen-lockfile']);
   const version = await resolvedTsClientVersion();
-  if (version === STAINLESS_TS_VERSION) {
-    fail(`override did not take effect: @composio/client still resolves to ${version}`);
-  }
+  assertTsCandidateApplied(baselineVersion, version);
   console.log(`candidate @composio/client resolved: ${version}`);
   await sh(['pnpm', 'run', 'build:packages']);
 };
@@ -510,6 +514,14 @@ const cmdSelftest = async () => {
     'usage failures unwind through cleanup',
     cleanupRan && cleanupError instanceof HarnessError
   );
+
+  let noOpCandidateRejected = false;
+  try {
+    assertTsCandidateApplied('baseline-version', 'baseline-version');
+  } catch {
+    noOpCandidateRejected = true;
+  }
+  check('candidate swap rejects the installed baseline version', noOpCandidateRejected);
 
   const cleanupFixture = join(runDir, 'cleanup-fixture.txt');
   writeFileSync(cleanupFixture, 'user contents');

--- a/harness/run.mjs
+++ b/harness/run.mjs
@@ -2,8 +2,8 @@
 // Examples runner: sweeps the entrypoints in examples-manifest.json against
 // the live backend, recording per-entry results and Composio traces.
 //
-//   node harness/run.mjs sweep    --client baseline|candidate [--lang ts|py] [--ids a,b] [--tiers 1,2,3] [--llm live|mock]
-//   node harness/run.mjs neg      [--lang ts|py] [--ids a,b] [--sample N] [--seed S]
+//   node harness/run.mjs sweep    --client baseline|candidate [--lang ts|py] [--ids a,b] [--tiers 1,2,3] [--exclude-toolkits a,b] [--llm live|mock]
+//   node harness/run.mjs neg      [--lang ts|py] [--ids a,b] [--exclude-toolkits a,b] [--sample N] [--seed S]
 //   node harness/run.mjs selftest
 //
 // Exit codes: 0 ok · 1 findings (red entries / failed expectations) · 2 usage/env error.
@@ -12,6 +12,13 @@ import { spawn } from 'node:child_process';
 import { mkdirSync, readFileSync, writeFileSync, appendFileSync, existsSync, rmSync } from 'node:fs';
 import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  entryToolkits,
+  loadManifest,
+  requiredBrowserGrantToolkits,
+  requiresDemoToolkit,
+  selectManifestEntries,
+} from './manifest.mjs';
 import { resolveBackendBaseUrl, STAGING_BASE_URL } from './backend-url.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
@@ -41,27 +48,21 @@ const fail = (msg, code = 2) => {
   throw new HarnessError(msg, code);
 };
 
-const loadManifest = () => {
-  const manifest = JSON.parse(readFileSync(join(ROOT, 'examples-manifest.json'), 'utf8'));
-  for (const e of manifest.entries) {
-    if (!e.id || !e.lang || !e.file || !e.tier) fail(`manifest entry missing required fields: ${JSON.stringify(e)}`);
-    if (e.lang === 'ts' && e.tier !== 'X' && !e.pkg) fail(`ts entry ${e.id} missing pkg`);
-    if (e.tier === '3' && !e.readiness) fail(`tier-3 entry ${e.id} missing readiness regex`);
-  }
-  return manifest.entries;
-};
+const selectionOptions = () => ({
+  lang: opt('lang'),
+  ids: opt('ids'),
+  tiers: opt('tiers', '1,2,3'),
+  excludeToolkits: opt('exclude-toolkits'),
+});
 
-const selectEntries = () => {
-  const lang = opt('lang');
-  const ids = opt('ids') ? opt('ids').split(',') : null;
-  const tiers = (opt('tiers', '1,2,3')).split(',');
-  return loadManifest().filter(
-    (e) =>
-      e.tier !== 'X' &&
-      tiers.includes(e.tier) &&
-      (!lang || e.lang === lang) &&
-      (!ids || ids.includes(e.id))
+const selectEntries = () => selectManifestEntries(loadManifest(), selectionOptions());
+
+const reportExclusions = selection => {
+  if (selection.excludedEntries.length === 0) return;
+  console.log(
+    `excluding ${selection.excludedEntries.length} entries requiring ${selection.excludedToolkits.join(', ')}:`
   );
+  for (const entry of selection.excludedEntries) console.log(`  - ${entry.id}`);
 };
 
 const baseUrl = () => {
@@ -389,9 +390,11 @@ const cmdSweep = async () => {
   const llm = opt('llm', 'live');
   if (!['live', 'mock'].includes(llm)) fail(`--llm must be live|mock`);
   LLM_MOCK = llm === 'mock';
-  const entries = selectEntries();
+  const selection = selectEntries();
+  const entries = selection.entries;
   if (entries.length === 0) fail('no entries selected');
   if (!process.env.COMPOSIO_API_KEY) fail('COMPOSIO_API_KEY is required for a sweep (disposable examples-project key)', 2);
+  reportExclusions(selection);
 
   const id = `${runId()}-${client}${LLM_MOCK ? '-mock' : ''}`;
   const runDir = join(ARTIFACTS, id);
@@ -431,7 +434,22 @@ const cmdSweep = async () => {
     };
     writeFileSync(
       join(runDir, 'summary.json'),
-      JSON.stringify({ runId: id, client, llm, baseUrl: baseUrl(), counts, startedAt: new Date().toISOString() }, null, 2)
+      JSON.stringify(
+        {
+          runId: id,
+          client,
+          llm,
+          baseUrl: baseUrl(),
+          counts,
+          selection: {
+            excludedToolkits: selection.excludedToolkits,
+            excludedEntries: selection.excludedEntries.map(entry => entry.id),
+          },
+          startedAt: new Date().toISOString(),
+        },
+        null,
+        2
+      )
     );
     console.log(`sweep ${id}: ${counts.green} green / ${counts.red} red / ${counts.skipped} skipped`);
     process.exitCode = counts.red > 0 ? 1 : 0;
@@ -443,7 +461,9 @@ const cmdSweep = async () => {
 };
 
 const cmdNeg = async () => {
-  let entries = selectEntries().filter((e) => e.backend !== false);
+  const selection = selectEntries();
+  reportExclusions(selection);
+  let entries = selection.entries.filter((e) => e.backend !== false);
   const sample = opt('sample');
   if (sample) {
     const rand = mulberry32(Number(opt('seed', '42')));
@@ -522,6 +542,41 @@ const cmdSelftest = async () => {
     noOpCandidateRejected = true;
   }
   check('candidate swap rejects the installed baseline version', noOpCandidateRejected);
+
+  const manifest = loadManifest();
+  const withoutGoogleDrive = selectManifestEntries(manifest, {
+    excludeToolkits: 'googledrive',
+  });
+  check(
+    'Google Drive exclusion removes every dependent entry and preserves the rest',
+    withoutGoogleDrive.excludedEntries.length > 0 &&
+      withoutGoogleDrive.excludedEntries.every(entry =>
+        entryToolkits(entry).includes('googledrive')
+      ) &&
+      withoutGoogleDrive.entries.every(entry => !entryToolkits(entry).includes('googledrive')) &&
+      withoutGoogleDrive.entries.length + withoutGoogleDrive.excludedEntries.length ===
+        selectManifestEntries(manifest).entries.length
+  );
+  check(
+    'Google Drive exclusion removes it from provisioning',
+    !requiredBrowserGrantToolkits(withoutGoogleDrive.entries).some(
+      toolkit => toolkit.slug === 'googledrive'
+    )
+  );
+  const apiKeyOnly = selectManifestEntries(manifest, {
+    ids: 'ts/connected-accounts/api-key',
+  }).entries;
+  check(
+    'selected API-key example provisions only its demo toolkit',
+    requiredBrowserGrantToolkits(apiKeyOnly).length === 0 && requiresDemoToolkit(apiKeyOnly)
+  );
+  const implicitGmail = selectManifestEntries(manifest, {
+    ids: 'py/fastapi_app',
+  }).entries;
+  check(
+    'resource identifiers contribute implicit toolkit requirements',
+    requiredBrowserGrantToolkits(implicitGmail).some(toolkit => toolkit.slug === 'gmail')
+  );
 
   const cleanupFixture = join(runDir, 'cleanup-fixture.txt');
   writeFileSync(cleanupFixture, 'user contents');

--- a/harness/run.mjs
+++ b/harness/run.mjs
@@ -318,14 +318,30 @@ const restoreTsBaseline = async (snapshot) => {
   await sh(['pnpm', 'install', '--frozen-lockfile']);
 };
 
+/**
+ * Resolve composio-client as the python project sees it. `uv run --with <wheel>`
+ * layers an ephemeral overlay on the project environment, so the realpath tells
+ * a real swap from a no-op even when the wheel matches the pinned version.
+ */
+const resolvedPyClient = async (extraArgs = []) => {
+  const out = await sh(['uv', 'run', '--project', 'python', ...extraArgs, 'python', '-c', 'import composio_client, importlib.metadata, json, os; print(json.dumps({"path": os.path.realpath(composio_client.__file__), "version": importlib.metadata.version("composio-client")}))']);
+  return JSON.parse(out.trim().split('\n').pop());
+};
+
+const assertPyCandidateApplied = (baseline, candidate) => {
+  if (candidate.path === baseline.path) {
+    fail(
+      `python candidate did not take effect: composio-client still resolves to the installed baseline at ${candidate.path} (${candidate.version})`
+    );
+  }
+};
+
 const verifyPyCandidate = async (wheel) => {
   if (!existsSync(wheel)) fail(`COMPOSIO_CLIENT_WHEEL not found: ${wheel}`);
-  const out = await sh(['uv', 'run', '--project', 'python', '--with', wheel, 'python', '-c', 'import composio_client, importlib.metadata; print(importlib.metadata.version("composio-client"))']);
-  const version = out.trim().split('\n').pop();
-  if (!version.startsWith('2.')) {
-    fail(`python candidate did not take effect (resolved ${version}); Stage B (SDK migration) must land first`);
-  }
-  return version;
+  const baseline = await resolvedPyClient();
+  const candidate = await resolvedPyClient(['--with', wheel]);
+  assertPyCandidateApplied(baseline, candidate);
+  return candidate.version;
 };
 
 const PY_PROJECT = join(ROOT, 'python', 'pyproject.toml');
@@ -565,6 +581,29 @@ const cmdSelftest = async () => {
     sameVersionCandidateAccepted = false;
   }
   check('candidate swap accepts a tarball reporting the pinned version', sameVersionCandidateAccepted);
+
+  const installedPyBaseline = {
+    path: '/repo/.venv/lib/python3.12/site-packages/composio_client/__init__.py',
+    version: '2.0.0rc5',
+  };
+  let noOpPyCandidateRejected = false;
+  try {
+    assertPyCandidateApplied(installedPyBaseline, { ...installedPyBaseline });
+  } catch {
+    noOpPyCandidateRejected = true;
+  }
+  check('python candidate swap rejects the installed baseline copy', noOpPyCandidateRejected);
+
+  let sameVersionPyCandidateAccepted = true;
+  try {
+    assertPyCandidateApplied(installedPyBaseline, {
+      path: '/cache/uv/archive-v0/abc123/lib/python3.12/site-packages/composio_client/__init__.py',
+      version: installedPyBaseline.version,
+    });
+  } catch {
+    sameVersionPyCandidateAccepted = false;
+  }
+  check('python candidate swap accepts a wheel reporting the pinned version', sameVersionPyCandidateAccepted);
 
   const manifest = loadManifest();
   const withoutGoogleDrive = selectManifestEntries(manifest, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ catalogs:
       specifier: ^5.20260815.1
       version: 5.20260815.1
     '@composio/client':
-      specifier: 0.1.0-alpha.76
-      version: 0.1.0-alpha.76
+      specifier: 2.0.0-rc.1
+      version: 2.0.0-rc.1
     '@effect/cli':
       specifier: ^0.77.0
       version: 0.77.0
@@ -1184,7 +1184,7 @@ importers:
         version: link:../cli-local-tools
       '@composio/client':
         specifier: 'catalog:'
-        version: 0.1.0-alpha.76
+        version: 2.0.0-rc.1
       '@composio/core':
         specifier: workspace:*
         version: link:../core
@@ -1369,7 +1369,7 @@ importers:
     dependencies:
       '@composio/client':
         specifier: 'catalog:'
-        version: 0.1.0-alpha.76
+        version: 2.0.0-rc.1
       '@composio/json-schema-to-zod':
         specifier: workspace:*
         version: link:../json-schema-to-zod
@@ -1716,7 +1716,7 @@ importers:
     dependencies:
       '@composio/client':
         specifier: 'catalog:'
-        version: 0.1.0-alpha.76
+        version: 2.0.0-rc.1
       '@composio/json-schema-to-zod':
         specifier: workspace:*
         version: link:../json-schema-to-zod
@@ -2274,8 +2274,9 @@ packages:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
 
-  '@composio/client@0.1.0-alpha.76':
-    resolution: {integrity: sha512-MXC5JGRVdiQ4EgLricy9o/mqBa1+1T7wHFZ6Q4ZJkrjzZqOMvxTgy21Zlb5J/1oGkB2bg9UDzpH8PkXCp/D4zA==}
+  '@composio/client@2.0.0-rc.1':
+    resolution: {integrity: sha512-8tofxeUn3F1fJk5h2EUdF6aP7yfeHjb40k37Z+rLf2+7V6+kLi5G6gFqUzeFabPeJhLjQn/jnJAcJ4IpAVvdTw==}
+    engines: {node: '>=22'}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -7963,7 +7964,7 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@composio/client@0.1.0-alpha.76': {}
+  '@composio/client@2.0.0-rc.1': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ catalogs:
       specifier: ^5.20260815.1
       version: 5.20260815.1
     '@composio/client':
-      specifier: 2.0.0-rc.1
-      version: 2.0.0-rc.1
+      specifier: 2.0.0-rc.3
+      version: 2.0.0-rc.3
     '@effect/cli':
       specifier: ^0.77.0
       version: 0.77.0
@@ -1184,7 +1184,7 @@ importers:
         version: link:../cli-local-tools
       '@composio/client':
         specifier: 'catalog:'
-        version: 2.0.0-rc.1
+        version: 2.0.0-rc.3
       '@composio/core':
         specifier: workspace:*
         version: link:../core
@@ -1369,7 +1369,7 @@ importers:
     dependencies:
       '@composio/client':
         specifier: 'catalog:'
-        version: 2.0.0-rc.1
+        version: 2.0.0-rc.3
       '@composio/json-schema-to-zod':
         specifier: workspace:*
         version: link:../json-schema-to-zod
@@ -1716,7 +1716,7 @@ importers:
     dependencies:
       '@composio/client':
         specifier: 'catalog:'
-        version: 2.0.0-rc.1
+        version: 2.0.0-rc.3
       '@composio/json-schema-to-zod':
         specifier: workspace:*
         version: link:../json-schema-to-zod
@@ -2274,8 +2274,8 @@ packages:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
 
-  '@composio/client@2.0.0-rc.1':
-    resolution: {integrity: sha512-8tofxeUn3F1fJk5h2EUdF6aP7yfeHjb40k37Z+rLf2+7V6+kLi5G6gFqUzeFabPeJhLjQn/jnJAcJ4IpAVvdTw==}
+  '@composio/client@2.0.0-rc.3':
+    resolution: {integrity: sha512-dCn5/9DRubIFSkImi4COqWIyhOUKyWveWWrh4e8l+RWvBoHAD/xy9zGm8r6khYSCHbLHxm5syYaHNjYjMTe9ow==}
     engines: {node: '>=22'}
 
   '@cspotcode/source-map-support@0.8.1':
@@ -7964,7 +7964,7 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@composio/client@2.0.0-rc.1': {}
+  '@composio/client@2.0.0-rc.3': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ catalogs:
       specifier: ^5.20260821.1
       version: 5.20260821.1
     '@composio/client':
-      specifier: 2.0.0-rc.3
-      version: 2.0.0-rc.3
+      specifier: 2.0.0-rc.5
+      version: 2.0.0-rc.5
     '@effect/cli':
       specifier: ^0.77.0
       version: 0.77.0
@@ -1184,7 +1184,7 @@ importers:
         version: link:../cli-local-tools
       '@composio/client':
         specifier: 'catalog:'
-        version: 2.0.0-rc.3
+        version: 2.0.0-rc.5
       '@composio/core':
         specifier: workspace:*
         version: link:../core
@@ -1369,7 +1369,7 @@ importers:
     dependencies:
       '@composio/client':
         specifier: 'catalog:'
-        version: 2.0.0-rc.3
+        version: 2.0.0-rc.5
       '@composio/json-schema-to-zod':
         specifier: workspace:*
         version: link:../json-schema-to-zod
@@ -1716,7 +1716,7 @@ importers:
     dependencies:
       '@composio/client':
         specifier: 'catalog:'
-        version: 2.0.0-rc.3
+        version: 2.0.0-rc.5
       '@composio/json-schema-to-zod':
         specifier: workspace:*
         version: link:../json-schema-to-zod
@@ -2310,8 +2310,8 @@ packages:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
 
-  '@composio/client@2.0.0-rc.3':
-    resolution: {integrity: sha512-dCn5/9DRubIFSkImi4COqWIyhOUKyWveWWrh4e8l+RWvBoHAD/xy9zGm8r6khYSCHbLHxm5syYaHNjYjMTe9ow==}
+  '@composio/client@2.0.0-rc.5':
+    resolution: {integrity: sha512-goMJu+9ltEAckSEhV+zs52li9X4LyJLVMHrxX9M+qloMp4tIvMrjXKdXG+zOATSTMhcQEuDxD2fyHhhBe3Nlwg==}
     engines: {node: '>=22'}
 
   '@cspotcode/source-map-support@0.8.1':
@@ -8035,7 +8035,7 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@composio/client@2.0.0-rc.3': {}
+  '@composio/client@2.0.0-rc.5': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ catalogs:
       specifier: ^5.20260821.1
       version: 5.20260821.1
     '@composio/client':
-      specifier: 2.0.0-rc.1
-      version: 2.0.0-rc.1
+      specifier: 2.0.0-rc.3
+      version: 2.0.0-rc.3
     '@effect/cli':
       specifier: ^0.77.0
       version: 0.77.0
@@ -1184,7 +1184,7 @@ importers:
         version: link:../cli-local-tools
       '@composio/client':
         specifier: 'catalog:'
-        version: 2.0.0-rc.1
+        version: 2.0.0-rc.3
       '@composio/core':
         specifier: workspace:*
         version: link:../core
@@ -1369,7 +1369,7 @@ importers:
     dependencies:
       '@composio/client':
         specifier: 'catalog:'
-        version: 2.0.0-rc.1
+        version: 2.0.0-rc.3
       '@composio/json-schema-to-zod':
         specifier: workspace:*
         version: link:../json-schema-to-zod
@@ -1716,7 +1716,7 @@ importers:
     dependencies:
       '@composio/client':
         specifier: 'catalog:'
-        version: 2.0.0-rc.1
+        version: 2.0.0-rc.3
       '@composio/json-schema-to-zod':
         specifier: workspace:*
         version: link:../json-schema-to-zod
@@ -2310,8 +2310,8 @@ packages:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
 
-  '@composio/client@2.0.0-rc.1':
-    resolution: {integrity: sha512-8tofxeUn3F1fJk5h2EUdF6aP7yfeHjb40k37Z+rLf2+7V6+kLi5G6gFqUzeFabPeJhLjQn/jnJAcJ4IpAVvdTw==}
+  '@composio/client@2.0.0-rc.3':
+    resolution: {integrity: sha512-dCn5/9DRubIFSkImi4COqWIyhOUKyWveWWrh4e8l+RWvBoHAD/xy9zGm8r6khYSCHbLHxm5syYaHNjYjMTe9ow==}
     engines: {node: '>=22'}
 
   '@cspotcode/source-map-support@0.8.1':
@@ -8035,7 +8035,7 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@composio/client@2.0.0-rc.1': {}
+  '@composio/client@2.0.0-rc.3': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ catalogs:
       specifier: ^5.20260821.1
       version: 5.20260821.1
     '@composio/client':
-      specifier: 2.0.0-rc.5
-      version: 2.0.0-rc.5
+      specifier: 2.0.0-rc.6
+      version: 2.0.0-rc.6
     '@effect/cli':
       specifier: ^0.77.0
       version: 0.77.0
@@ -1184,7 +1184,7 @@ importers:
         version: link:../cli-local-tools
       '@composio/client':
         specifier: 'catalog:'
-        version: 2.0.0-rc.5
+        version: 2.0.0-rc.6
       '@composio/core':
         specifier: workspace:*
         version: link:../core
@@ -1369,7 +1369,7 @@ importers:
     dependencies:
       '@composio/client':
         specifier: 'catalog:'
-        version: 2.0.0-rc.5
+        version: 2.0.0-rc.6
       '@composio/json-schema-to-zod':
         specifier: workspace:*
         version: link:../json-schema-to-zod
@@ -1716,7 +1716,7 @@ importers:
     dependencies:
       '@composio/client':
         specifier: 'catalog:'
-        version: 2.0.0-rc.5
+        version: 2.0.0-rc.6
       '@composio/json-schema-to-zod':
         specifier: workspace:*
         version: link:../json-schema-to-zod
@@ -2310,8 +2310,8 @@ packages:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
 
-  '@composio/client@2.0.0-rc.5':
-    resolution: {integrity: sha512-goMJu+9ltEAckSEhV+zs52li9X4LyJLVMHrxX9M+qloMp4tIvMrjXKdXG+zOATSTMhcQEuDxD2fyHhhBe3Nlwg==}
+  '@composio/client@2.0.0-rc.6':
+    resolution: {integrity: sha512-l8swDeD2vN9DA2v7OE9GaairWBVFNlPvmRtqqhU8m+uvsOEkfR1n67NXyOHTa6SqHMCGdyeq8KsQqlVAf6vGGQ==}
     engines: {node: '>=22'}
 
   '@cspotcode/source-map-support@0.8.1':
@@ -8035,7 +8035,7 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@composio/client@2.0.0-rc.5': {}
+  '@composio/client@2.0.0-rc.6': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ catalogs:
       specifier: ^5.20260821.1
       version: 5.20260821.1
     '@composio/client':
-      specifier: 0.1.0-alpha.76
-      version: 0.1.0-alpha.76
+      specifier: 2.0.0-rc.1
+      version: 2.0.0-rc.1
     '@effect/cli':
       specifier: ^0.77.0
       version: 0.77.0
@@ -1184,7 +1184,7 @@ importers:
         version: link:../cli-local-tools
       '@composio/client':
         specifier: 'catalog:'
-        version: 0.1.0-alpha.76
+        version: 2.0.0-rc.1
       '@composio/core':
         specifier: workspace:*
         version: link:../core
@@ -1369,7 +1369,7 @@ importers:
     dependencies:
       '@composio/client':
         specifier: 'catalog:'
-        version: 0.1.0-alpha.76
+        version: 2.0.0-rc.1
       '@composio/json-schema-to-zod':
         specifier: workspace:*
         version: link:../json-schema-to-zod
@@ -1716,7 +1716,7 @@ importers:
     dependencies:
       '@composio/client':
         specifier: 'catalog:'
-        version: 0.1.0-alpha.76
+        version: 2.0.0-rc.1
       '@composio/json-schema-to-zod':
         specifier: workspace:*
         version: link:../json-schema-to-zod
@@ -2310,8 +2310,9 @@ packages:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
 
-  '@composio/client@0.1.0-alpha.76':
-    resolution: {integrity: sha512-MXC5JGRVdiQ4EgLricy9o/mqBa1+1T7wHFZ6Q4ZJkrjzZqOMvxTgy21Zlb5J/1oGkB2bg9UDzpH8PkXCp/D4zA==}
+  '@composio/client@2.0.0-rc.1':
+    resolution: {integrity: sha512-8tofxeUn3F1fJk5h2EUdF6aP7yfeHjb40k37Z+rLf2+7V6+kLi5G6gFqUzeFabPeJhLjQn/jnJAcJ4IpAVvdTw==}
+    engines: {node: '>=22'}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -8034,7 +8035,7 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@composio/client@0.1.0-alpha.76': {}
+  '@composio/client@2.0.0-rc.1': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,7 +35,7 @@ catalog:
   '@clack/prompts': '^1.7.0'
   '@cloudflare/vitest-pool-workers': 0.21.3
   '@cloudflare/workers-types': ^5.20260815.1
-  '@composio/client': 2.0.0-rc.1
+  '@composio/client': 2.0.0-rc.3
   '@effect/cli': ^0.77.0
   '@effect/language-service': ^0.87.2
   '@effect/platform': ^0.97.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,7 +35,7 @@ catalog:
   '@clack/prompts': '^1.7.0'
   '@cloudflare/vitest-pool-workers': 0.21.3
   '@cloudflare/workers-types': ^5.20260815.1
-  '@composio/client': 0.1.0-alpha.76
+  '@composio/client': 2.0.0-rc.1
   '@effect/cli': ^0.77.0
   '@effect/language-service': ^0.87.2
   '@effect/platform': ^0.97.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,7 +35,7 @@ catalog:
   '@clack/prompts': '^1.7.0'
   '@cloudflare/vitest-pool-workers': 0.22.0
   '@cloudflare/workers-types': ^5.20260821.1
-  '@composio/client': 2.0.0-rc.3
+  '@composio/client': 2.0.0-rc.5
   '@effect/cli': ^0.77.0
   '@effect/language-service': ^0.87.2
   '@effect/platform': ^0.97.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,7 +35,7 @@ catalog:
   '@clack/prompts': '^1.7.0'
   '@cloudflare/vitest-pool-workers': 0.22.0
   '@cloudflare/workers-types': ^5.20260821.1
-  '@composio/client': 2.0.0-rc.5
+  '@composio/client': 2.0.0-rc.6
   '@effect/cli': ^0.77.0
   '@effect/language-service': ^0.87.2
   '@effect/platform': ^0.97.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,7 +35,7 @@ catalog:
   '@clack/prompts': '^1.7.0'
   '@cloudflare/vitest-pool-workers': 0.22.0
   '@cloudflare/workers-types': ^5.20260821.1
-  '@composio/client': 0.1.0-alpha.76
+  '@composio/client': 2.0.0-rc.1
   '@effect/cli': ^0.77.0
   '@effect/language-service': ^0.87.2
   '@effect/platform': ^0.97.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,7 +35,7 @@ catalog:
   '@clack/prompts': '^1.7.0'
   '@cloudflare/vitest-pool-workers': 0.22.0
   '@cloudflare/workers-types': ^5.20260821.1
-  '@composio/client': 2.0.0-rc.1
+  '@composio/client': 2.0.0-rc.3
   '@effect/cli': ^0.77.0
   '@effect/language-service': ^0.87.2
   '@effect/platform': ^0.97.1

--- a/python/noxfile.py
+++ b/python/noxfile.py
@@ -107,7 +107,6 @@ def tst(session: Session):
     session.install("./providers/crewai")
     session.install("./providers/langchain")
     session.install("./providers/langgraph")
-    session.install("./providers/autogen")
     test_paths = session.posargs or ["tests/"]
     session.run("pytest", *test_paths, "-v", "--tb=short")
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.10,<4"
 dependencies = [
     "pysher>=1.0.8",
     "pydantic>=2.11.9",
-    "composio-client==2.0.0rc5",
+    "composio-client==2.0.0rc6",
     "typing-extensions>=4.16.0",
     "openai>=2.48.0",
     "json-schema-to-pydantic>=0.4.11",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.10,<4"
 dependencies = [
     "pysher>=1.0.8",
     "pydantic>=2.11.9",
-    "composio-client==1.43.0",
+    "composio-client==2.0.0rc5",
     "typing-extensions>=4.16.0",
     "openai>=2.48.0",
     "json-schema-to-pydantic>=0.4.11",

--- a/python/setup.py
+++ b/python/setup.py
@@ -25,7 +25,7 @@ setup(
     install_requires=[
         "pysher>=1.0.8",
         "pydantic>=2.11.9",
-        "composio-client==1.43.0",
+        "composio-client==2.0.0rc5",
         "typing-extensions>=4.16.0",
         "openai>=2.48.0",
         "json-schema-to-pydantic>=0.4.11",

--- a/python/setup.py
+++ b/python/setup.py
@@ -25,7 +25,7 @@ setup(
     install_requires=[
         "pysher>=1.0.8",
         "pydantic>=2.11.9",
-        "composio-client==2.0.0rc5",
+        "composio-client==2.0.0rc6",
         "typing-extensions>=4.16.0",
         "openai>=2.48.0",
         "json-schema-to-pydantic>=0.4.11",

--- a/python/tests/test_generated_client_response_shape.py
+++ b/python/tests/test_generated_client_response_shape.py
@@ -1,0 +1,161 @@
+"""Guard the generated-client response shape the SDK reads by attribute.
+
+Several SDK code paths walk a generated-client response two or more levels deep
+-- ``item.meta.logo``, ``item.connected_account.auth_config.id``,
+``response.commands.claude``. That only works while the client constructs those
+nested objects as models.
+
+The rest of the suite mocks the client with ``MagicMock``, which answers every
+attribute regardless of the real response shape, so a client release that stops
+building nested models passes here and fails against the live backend instead.
+These tests close that gap: they build responses through the *installed*
+client's own response models, so a client whose nested fields decay to plain
+mappings fails locally.
+"""
+
+import typing as t
+from unittest.mock import MagicMock
+
+import pytest
+from composio_client.types.mcp.custom_create_response import CustomCreateResponse
+from composio_client.types.tool_router.session_toolkits_response import (
+    SessionToolkitsResponse,
+)
+from pydantic import BaseModel
+
+from composio.core.models.mcp import MCP
+from composio.core.models.tool_router import ToolkitConnectionsDetails, ToolRouter
+
+TOOLKITS_PAYLOAD: t.Dict[str, t.Any] = {
+    "current_page": 1,
+    "total_items": 2,
+    "total_pages": 1,
+    "next_cursor": "cursor_789",
+    "items": [
+        {
+            "slug": "gmail",
+            "name": "Gmail",
+            "enabled": True,
+            "is_no_auth": False,
+            "composio_managed_auth_schemes": ["OAUTH2"],
+            "meta": {"description": "Gmail toolkit", "logo": "https://logo/gmail.png"},
+            "connected_account": {
+                "id": "conn_123",
+                "status": "ACTIVE",
+                "created_at": "2026-01-01T00:00:00Z",
+                "user_id": "user_123",
+                "auth_config": {
+                    "id": "auth_config_123",
+                    "auth_scheme": "OAUTH2",
+                    "is_composio_managed": True,
+                },
+            },
+        },
+        {
+            "slug": "github",
+            "name": "GitHub",
+            "enabled": True,
+            "is_no_auth": False,
+            "composio_managed_auth_schemes": [],
+            "meta": {"description": "GitHub toolkit", "logo": "https://logo/gh.png"},
+        },
+    ],
+}
+
+MCP_CREATE_PAYLOAD: t.Dict[str, t.Any] = {
+    "id": "mcp_123",
+    "name": "test-server",
+    "allowed_tools": ["GITHUB_CREATE_ISSUE"],
+    "auth_config_ids": ["ac_123"],
+    "mcp_url": "https://mcp.composio.dev/mcp_123",
+    "commands": {
+        "claude": "claude mcp add ...",
+        "cursor": "cursor://...",
+        "windsurf": "windsurf://...",
+    },
+}
+
+
+@pytest.mark.parametrize(
+    ("model", "payload", "path"),
+    [
+        (SessionToolkitsResponse, TOOLKITS_PAYLOAD, "items.0.meta"),
+        (SessionToolkitsResponse, TOOLKITS_PAYLOAD, "items.0.connected_account"),
+        (
+            SessionToolkitsResponse,
+            TOOLKITS_PAYLOAD,
+            "items.0.connected_account.auth_config",
+        ),
+        (CustomCreateResponse, MCP_CREATE_PAYLOAD, "commands"),
+    ],
+)
+def test_generated_client_builds_nested_response_models(
+    model: t.Type[BaseModel], payload: t.Dict[str, t.Any], path: str
+) -> None:
+    """A nested response field must arrive as a model, not a bare mapping."""
+    root: t.Any = model.model_validate(payload)
+    for part in path.split("."):
+        root = root[int(part)] if part.isdigit() else getattr(root, part)
+
+    assert isinstance(root, BaseModel), (
+        f"{model.__name__}.{path} is a {type(root).__name__}, not a model. The SDK "
+        f"reads this field by attribute, so a generated client that leaves nested "
+        f"objects as mappings breaks it at runtime."
+    )
+
+
+def _client_with_session() -> MagicMock:
+    """A mocked client whose session.create is just real enough to build a session."""
+    client = MagicMock()
+    session_response = MagicMock()
+    session_response.session_id = "session_123"
+    session_response.mcp.type = "http"
+    session_response.mcp.url = "https://mcp.example.com/session_123"
+    session_response.config.preload.tools = []
+    session_response.experimental = None
+    client.tool_router.session.create.return_value = session_response
+    return client
+
+
+def test_session_toolkits_reads_nested_connection_models() -> None:
+    """``Session.toolkits()`` walks meta and connected_account by attribute."""
+    client = _client_with_session()
+    client.tool_router.session.toolkits.return_value = (
+        SessionToolkitsResponse.model_validate(TOOLKITS_PAYLOAD)
+    )
+    session = ToolRouter(client=client, provider=MagicMock()).create(user_id="user_123")
+
+    result = session.toolkits()
+
+    assert isinstance(result, ToolkitConnectionsDetails)
+    gmail, github = result.items
+
+    assert gmail.slug == "gmail"
+    assert gmail.logo == "https://logo/gmail.png"
+    assert gmail.connection is not None
+    assert gmail.connection.is_active is True
+    assert gmail.connection.auth_config is not None
+    assert gmail.connection.auth_config.id == "auth_config_123"
+    assert gmail.connection.auth_config.mode == "OAUTH2"
+    assert gmail.connection.auth_config.is_composio_managed is True
+    assert gmail.connection.connected_account is not None
+    assert gmail.connection.connected_account.id == "conn_123"
+
+    assert github.slug == "github"
+    assert github.connection is not None
+    assert github.connection.is_active is False
+    assert github.connection.auth_config is None
+
+
+def test_mcp_create_returns_attribute_addressable_commands() -> None:
+    """``mcp.create()`` hands callers a ``commands`` object, not a mapping."""
+    client = MagicMock()
+    client.mcp.custom.create.return_value = CustomCreateResponse.model_validate(
+        MCP_CREATE_PAYLOAD
+    )
+
+    response = MCP(client=client).create(name="test-server", toolkits=["github"])
+
+    assert response.commands.claude == "claude mcp add ..."
+    assert response.commands.cursor == "cursor://..."
+    assert response.commands.windsurf == "windsurf://..."

--- a/scripts/examples-provision.mjs
+++ b/scripts/examples-provision.mjs
@@ -29,7 +29,20 @@
 // Auth config ids and connected account ids are not secrets; no credential
 // values are ever printed. The API-key demo value stored for serpapi is a
 // deliberately fake placeholder, not a real key.
+//
+// Selection flags match harness/run.mjs: [--lang ts|py] [--ids a,b]
+// [--tiers 1,2,3] [--exclude-toolkits a,b]. Only resources required by the
+// selected entries are provisioned; garbage collection remains project-wide
+// within the examples-* ownership boundary above.
 
+import {
+  BROWSER_GRANT_TOOLKITS,
+  DEMO_TOOLKIT,
+  loadManifest,
+  requiredBrowserGrantToolkits,
+  requiresDemoToolkit,
+  selectManifestEntries,
+} from '../harness/manifest.mjs';
 import { requireStagingBaseUrl } from '../harness/staging-backend.mjs';
 
 let BASE_URL;
@@ -44,6 +57,23 @@ const USER_ID = process.env.COMPOSIO_EXAMPLES_USER_ID ?? 'examples';
 const INITIATE_MISSING = process.argv.includes('--initiate-missing');
 const GC = process.argv.includes('--gc');
 const DRY_RUN = process.argv.includes('--dry-run');
+const option = name => {
+  const index = process.argv.indexOf(`--${name}`);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+};
+
+const selection = selectManifestEntries(loadManifest(), {
+  lang: option('lang'),
+  ids: option('ids'),
+  tiers: option('tiers') ?? '1,2,3',
+  excludeToolkits: option('exclude-toolkits'),
+});
+if (selection.entries.length === 0) {
+  console.error('no example entries selected for provisioning');
+  process.exit(1);
+}
+const selectedBrowserGrantToolkits = requiredBrowserGrantToolkits(selection.entries);
+const needsDemoToolkit = requiresDemoToolkit(selection.entries);
 
 // The examples only ever run against staging with a disposable project key.
 // requireStagingBaseUrl refuses every other host before the key is read or sent.
@@ -52,19 +82,14 @@ if (!API_KEY) {
   process.exit(1);
 }
 
-// Toolkits the tier-2/3 entries depend on. OAuth toolkits need a one-time human
-// browser authorization. Only export ids that examples consume directly.
-const BROWSER_GRANT_TOOLKITS = [
-  { exportPrefix: 'GMAIL', slug: 'gmail' },
-  // googledrive exports nothing: examples reach Drive through the user's
-  // standing connection (COMPOSIO_EXAMPLES_USER_ID), never through ids.
-  { slug: 'googledrive' },
-  { exportPrefix: 'GITHUB', slug: 'github' },
-  { exportPrefix: 'SLACK', slug: 'slack' },
-];
-const DEMO_TOOLKIT = { exportPrefix: 'APIKEY', slug: 'serpapi', demoValue: 'examples-demo-key' };
-
 const report = line => console.error(line);
+
+if (selection.excludedEntries.length > 0) {
+  report(
+    `excluding ${selection.excludedEntries.length} entries requiring ${selection.excludedToolkits.join(', ')}:`
+  );
+  for (const entry of selection.excludedEntries) report(`  - ${entry.id}`);
+}
 
 async function api(method, path, body) {
   const res = await fetch(`${BASE_URL}${path}`, {
@@ -222,7 +247,7 @@ function findActiveAccount(slug, authConfigId) {
   );
 }
 
-for (const { exportPrefix, slug } of BROWSER_GRANT_TOOLKITS) {
+for (const { exportPrefix, slug } of selectedBrowserGrantToolkits) {
   let config = findAuthConfig(slug);
   if (!config) {
     const created = await api('POST', '/api/v3.1/auth_configs', {
@@ -264,7 +289,7 @@ for (const { exportPrefix, slug } of BROWSER_GRANT_TOOLKITS) {
 // their own connected accounts to demonstrate that API. The stored value is a
 // placeholder; serpapi only validates it at tool-execution time and no example
 // executes a serpapi tool.
-{
+if (needsDemoToolkit) {
   const { exportPrefix, slug, demoValue } = DEMO_TOOLKIT;
   let config = findAuthConfig(slug);
   if (!config) {

--- a/scripts/examples-provision.mjs
+++ b/scripts/examples-provision.mjs
@@ -29,7 +29,20 @@
 // Auth config ids and connected account ids are not secrets; no credential
 // values are ever printed. The API-key demo value stored for serpapi is a
 // deliberately fake placeholder, not a real key.
+//
+// Selection flags match harness/run.mjs: [--lang ts|py] [--ids a,b]
+// [--tiers 1,2,3] [--exclude-toolkits a,b]. Only resources required by the
+// selected entries are provisioned; garbage collection remains project-wide
+// within the examples-* ownership boundary above.
 
+import {
+  BROWSER_GRANT_TOOLKITS,
+  DEMO_TOOLKIT,
+  loadManifest,
+  requiredBrowserGrantToolkits,
+  requiresDemoToolkit,
+  selectManifestEntries,
+} from '../harness/manifest.mjs';
 import { resolveBackendBaseUrl } from '../harness/backend-url.mjs';
 
 let BASE_URL;
@@ -44,6 +57,23 @@ const USER_ID = process.env.COMPOSIO_EXAMPLES_USER_ID ?? 'examples';
 const INITIATE_MISSING = process.argv.includes('--initiate-missing');
 const GC = process.argv.includes('--gc');
 const DRY_RUN = process.argv.includes('--dry-run');
+const option = name => {
+  const index = process.argv.indexOf(`--${name}`);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+};
+
+const selection = selectManifestEntries(loadManifest(), {
+  lang: option('lang'),
+  ids: option('ids'),
+  tiers: option('tiers') ?? '1,2,3',
+  excludeToolkits: option('exclude-toolkits'),
+});
+if (selection.entries.length === 0) {
+  console.error('no example entries selected for provisioning');
+  process.exit(1);
+}
+const selectedBrowserGrantToolkits = requiredBrowserGrantToolkits(selection.entries);
+const needsDemoToolkit = requiresDemoToolkit(selection.entries);
 
 // COMPOSIO_BASE_URL selects the backend and defaults to staging;
 // resolveBackendBaseUrl refuses a structurally unusable one before the key is
@@ -54,19 +84,14 @@ if (!API_KEY) {
   process.exit(1);
 }
 
-// Toolkits the tier-2/3 entries depend on. OAuth toolkits need a one-time human
-// browser authorization. Only export ids that examples consume directly.
-const BROWSER_GRANT_TOOLKITS = [
-  { exportPrefix: 'GMAIL', slug: 'gmail' },
-  // googledrive exports nothing: examples reach Drive through the user's
-  // standing connection (COMPOSIO_EXAMPLES_USER_ID), never through ids.
-  { slug: 'googledrive' },
-  { exportPrefix: 'GITHUB', slug: 'github' },
-  { exportPrefix: 'SLACK', slug: 'slack' },
-];
-const DEMO_TOOLKIT = { exportPrefix: 'APIKEY', slug: 'serpapi', demoValue: 'examples-demo-key' };
-
 const report = line => console.error(line);
+
+if (selection.excludedEntries.length > 0) {
+  report(
+    `excluding ${selection.excludedEntries.length} entries requiring ${selection.excludedToolkits.join(', ')}:`
+  );
+  for (const entry of selection.excludedEntries) report(`  - ${entry.id}`);
+}
 
 async function api(method, path, body) {
   const res = await fetch(`${BASE_URL}${path}`, {
@@ -224,7 +249,7 @@ function findActiveAccount(slug, authConfigId) {
   );
 }
 
-for (const { exportPrefix, slug } of BROWSER_GRANT_TOOLKITS) {
+for (const { exportPrefix, slug } of selectedBrowserGrantToolkits) {
   let config = findAuthConfig(slug);
   if (!config) {
     const created = await api('POST', '/api/v3.1/auth_configs', {
@@ -266,7 +291,7 @@ for (const { exportPrefix, slug } of BROWSER_GRANT_TOOLKITS) {
 // their own connected accounts to demonstrate that API. The stored value is a
 // placeholder; serpapi only validates it at tool-execution time and no example
 // executes a serpapi tool.
-{
+if (needsDemoToolkit) {
   const { exportPrefix, slug, demoValue } = DEMO_TOOLKIT;
   let config = findAuthConfig(slug);
   if (!config) {

--- a/scripts/examples-provision.mjs
+++ b/scripts/examples-provision.mjs
@@ -272,12 +272,17 @@ for (const { exportPrefix, slug } of selectedBrowserGrantToolkits) {
   } else {
     ok = false;
     if (INITIATE_MISSING) {
-      const created = await api('POST', '/api/v3.1/connected_accounts', {
-        auth_config: { id: config.id },
-        connection: { user_id: USER_ID },
+      // POST /connected_accounts is retired for Composio-managed OAuth auth
+      // configs (it 400s with a migration message); every toolkit in this loop
+      // is exactly that, so the auth-link endpoint is the only way in. It
+      // returns the redirect URL directly rather than nesting it under
+      // connectionData.
+      const created = await api('POST', '/api/v3.1/connected_accounts/link', {
+        auth_config_id: config.id,
+        user_id: USER_ID,
       });
       pendingGrants.push(
-        `${slug}: authorize in a browser -> ${created.connectionData?.val?.redirectUrl ?? created.redirect_url ?? created.redirect_uri ?? '(no redirect url returned)'}`
+        `${slug}: authorize in a browser -> ${created.redirect_url ?? '(no redirect url returned)'}`
       );
     } else {
       pendingGrants.push(

--- a/ts/e2e-tests/cli/toolkits/info/e2e.test.ts
+++ b/ts/e2e-tests/cli/toolkits/info/e2e.test.ts
@@ -35,6 +35,7 @@ e2e(import.meta.url, {
 
       const envPrefix = [
         `COMPOSIO_BASE_URL=${server.dockerBaseUrl}`,
+        'COMPOSIO_ALLOW_INSECURE_HTTP=1',
         'COMPOSIO_CACHE_DIR=/tmp/composio-toolkits-info',
         'COMPOSIO_USER_API_KEY=uak_mock_toolkits_info',
       ].join(' ');

--- a/ts/e2e-tests/cli/toolkits/list/e2e.test.ts
+++ b/ts/e2e-tests/cli/toolkits/list/e2e.test.ts
@@ -28,6 +28,7 @@ e2e(import.meta.url, {
 
       const envPrefix = [
         `COMPOSIO_BASE_URL=${server.dockerBaseUrl}`,
+        'COMPOSIO_ALLOW_INSECURE_HTTP=1',
         'COMPOSIO_CACHE_DIR=/tmp/composio-toolkits-list',
         'COMPOSIO_USER_API_KEY=uak_mock_toolkits_list',
       ].join(' ');

--- a/ts/e2e-tests/cli/toolkits/search/e2e.test.ts
+++ b/ts/e2e-tests/cli/toolkits/search/e2e.test.ts
@@ -35,6 +35,7 @@ e2e(import.meta.url, {
 
       const envPrefix = [
         `COMPOSIO_BASE_URL=${server.dockerBaseUrl}`,
+        'COMPOSIO_ALLOW_INSECURE_HTTP=1',
         'COMPOSIO_CACHE_DIR=/tmp/composio-toolkits-search',
         'COMPOSIO_USER_API_KEY=uak_mock_toolkits_search',
       ].join(' ');

--- a/uv.lock
+++ b/uv.lock
@@ -747,7 +747,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "composio-client", specifier = "==2.0.0rc5" },
+    { name = "composio-client", specifier = "==2.0.0rc6" },
     { name = "json-schema-to-pydantic", specifier = ">=0.4.11" },
     { name = "jsonschema", specifier = ">=4.23.0" },
     { name = "openai", specifier = ">=2.48.0" },
@@ -792,16 +792,16 @@ requires-dist = [
 
 [[package]]
 name = "composio-client"
-version = "2.0.0rc5"
+version = "2.0.0rc6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/1a/880ad791e5f8a7917bb413ceadd84339ba57074a95a26d71cb7935381308/composio_client-2.0.0rc5.tar.gz", hash = "sha256:8cdf2f56d345b36b97e5b346c7de07878e4fa2731b7c39ad35d06f74c5bb3ddd", size = 481119, upload-time = "2026-08-23T11:52:05.53Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/42/64767a3c1bff7edd5a9e1c120a99307eea6b0c7fe29e729474adf53e9f32/composio_client-2.0.0rc6.tar.gz", hash = "sha256:d31afdc74bf480b7059650d49010cebf666651df1440a3adf9921ebca308930e", size = 542751, upload-time = "2026-08-24T11:57:22.846Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/ac/521a13d3adfebe7e84573336e88f8cd448e71718585b7b9b16c506ee490f/composio_client-2.0.0rc5-py3-none-any.whl", hash = "sha256:bea22d1f482518682a9e8cd728c316714e1067f4f2d679de5f37ee11d3ee2b6c", size = 345431, upload-time = "2026-08-23T11:52:04.128Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/12/4fbb5bb60832c08f693d9b405d1b76878a55adfda9e73ccf4b15fe29d58e/composio_client-2.0.0rc6-py3-none-any.whl", hash = "sha256:cce1932b780001568117969fa007845519b3705591eb590c2931da0f7ccd998a", size = 386377, upload-time = "2026-08-24T11:57:21.341Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -747,7 +747,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "composio-client", specifier = "==1.43.0" },
+    { name = "composio-client", specifier = "==2.0.0rc5" },
     { name = "json-schema-to-pydantic", specifier = ">=0.4.11" },
     { name = "jsonschema", specifier = ">=4.23.0" },
     { name = "openai", specifier = ">=2.48.0" },
@@ -792,19 +792,16 @@ requires-dist = [
 
 [[package]]
 name = "composio-client"
-version = "1.43.0"
+version = "2.0.0rc5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
     { name = "httpx" },
     { name = "pydantic" },
-    { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/4b/3789f4c1347fd01349b66ecaeffb5ef623434c3b1fa4f5c5993fddb69c68/composio_client-1.43.0.tar.gz", hash = "sha256:bb96700da0c2aabc394cebc954be0ebf419557cc42b40f5d148aac52a5aff6f9", size = 246767, upload-time = "2026-07-08T09:06:02.42Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/1a/880ad791e5f8a7917bb413ceadd84339ba57074a95a26d71cb7935381308/composio_client-2.0.0rc5.tar.gz", hash = "sha256:8cdf2f56d345b36b97e5b346c7de07878e4fa2731b7c39ad35d06f74c5bb3ddd", size = 481119, upload-time = "2026-08-23T11:52:05.53Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/a2/3ae1f5471a52189ac558de6b0e088dc3575d695a0f91278cddf464274694/composio_client-1.43.0-py3-none-any.whl", hash = "sha256:3274d965b9efb6be90a51977f4c068ed24e2cad9160de4d40d3176d8bb4ce2d9", size = 277716, upload-time = "2026-07-08T09:06:01.007Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ac/521a13d3adfebe7e84573336e88f8cd448e71718585b7b9b16c506ee490f/composio_client-2.0.0rc5-py3-none-any.whl", hash = "sha256:bea22d1f482518682a9e8cd728c316714e1067f4f2d679de5f37ee11d3ee2b6c", size = 345431, upload-time = "2026-08-23T11:52:04.128Z" },
 ]
 
 [[package]]
@@ -1145,7 +1142,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1911,7 +1908,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -3177,11 +3174,11 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "flatbuffers" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "protobuf" },
-    { name = "sympy" },
+    { name = "flatbuffers", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "protobuf", marker = "python_full_version < '3.11'" },
+    { name = "sympy", marker = "python_full_version < '3.11'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/15/41/3253db975a90c3ce1d475e2a230773a21cd7998537f0657947df6fb79861/onnxruntime-1.24.3-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:3e6456801c66b095c5cd68e690ca25db970ea5202bd0c5b84a2c3ef7731c5a3c", size = 17332766, upload-time = "2026-03-05T17:18:59.714Z" },
@@ -3223,11 +3220,11 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "flatbuffers" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "flatbuffers", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "packaging" },
-    { name = "protobuf" },
+    { name = "packaging", marker = "python_full_version >= '3.11'" },
+    { name = "protobuf", marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/17/4d/5014667e2a3a77d6e1b74cc3d88948d06163b8e0a33a84c85073322b5dec/onnxruntime-1.28.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:f5c5daabd28aad610f83fdcf32acec8fb57e6adc6c6a39fe2a3c755db957b410", size = 19130506, upload-time = "2026-07-25T01:22:34.489Z" },
@@ -5117,8 +5114,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
+    { name = "jeepney", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -5192,7 +5189,7 @@ name = "sympy"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mpmath" },
+    { name = "mpmath", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [


### PR DESCRIPTION
## Summary

Start the isolated 1.0 beta train on `main` and move the TypeScript and Python SDKs from the frozen Stainless-generated client to the Composio-owned `2.0.0-rc.6` release candidate. The existing `next` branch remains the independent 0.x release line.

## Why the owned client

- Covers all 104 released v3.1 operations in both languages; Python gains 40 typed operations beyond the previous 64-operation Stainless surface.
- Preserves the established client contract: Stainless-compatible imports and types, sync/async Python clients, errors, retries, timeouts, raw/streaming response access, and TypeScript `AbortSignal` support.
- Adds operation-aware deprecation and sunset warnings, plus stricter credential handling across insecure origins and origin-changing redirects.
- Moves generation and release infrastructure under Composio's control instead of depending on the Stainless pipeline.

### Client-side overhead

Controlled mocked-transport benchmarks isolate SDK processing from DNS, TLS, network, and backend latency:

- Python: approximately **40% lower SDK-side overhead** than Stainless, in both sync and async runs.
- TypeScript: approximately **25% lower SDK-side overhead** than the pinned Stainless client, and **16–18% lower** than the previous owned-client release.

These are client-side processing measurements, not end-to-end API latency claims. Benchmark methodology and reproducible harnesses live in `ComposioHQ/composio-client` under `docs/benchmarks/client-overhead.md`.

## TypeScript

- Upgrade the shared catalog pin from `0.1.0-alpha.76` to `2.0.0-rc.6`.
- Apply the owned client to core, CLI, and slim consumers through the catalog.
- Record a major Changeset for the fixed `@composio/core` and `@composio/slim` release group.

## Release line

- Target this PR at the new `main` branch, forked from `next` before the client migration.
- Enter Changesets prerelease mode with the `beta` tag.
- Run SDK CI and the TypeScript release workflow on both `next` and `main`.
- Keep CLI binary and docs automation on `next`, avoiding duplicate releases from the beta branch.
- Preserve `next` as the repository default so unrelated work can continue producing 0.x releases without including this PR.
- Carry the isolated Autogen test-environment fix from #4254 into `main`, because the new branch forked before that independent `next` fix.

`pnpm changeset status` resolves the fixed release group to:

- `@composio/core`: `0.17.0` → `1.0.0-beta.0`
- `@composio/slim`: `0.17.0` → `1.0.0-beta.0`

Changesets publishes prereleases under the active prerelease tag, so consumers will be able to install the release with `npm install @composio/core@beta`.

## Python

- Upgrade `composio-client` from `1.43.0` to `2.0.0rc6` in `python/pyproject.toml`, `python/setup.py`, and `uv.lock`.
- Keep the SDK source unchanged: all 58 imported `composio_client` symbols continue to resolve.
- Retain the nested-response regression test that constructs responses through the installed client's own models. It catches the `rc3` regression where nested objects became plain dictionaries; all 6 focused cases pass on `rc.6`.

## Live-examples harness

- Scope execution and staging provisioning to selected manifest entries.
- Identify TypeScript tarball and Python wheel candidate swaps by resolved package path, so a candidate reporting the same version as the pin is still tested.
- Initiate Composio-managed OAuth through `POST /connected_accounts/link`, replacing the retired generic connected-account creation path.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm build:packages`
- `pnpm validate:changesets`
- `pnpm --filter @composio/core typecheck`
- `pnpm --filter @composio/core test` — 1,122 passed
- `mise exec -- uv run --frozen --package composio pytest python/tests/test_generated_client_response_shape.py -q` — 6 passed
- `node harness/run.mjs selftest` — 28/28 passed
