### PR TITLE
feat(cli-local-tools): add Taskmarket toolkit

### DIFF
--- a/ts/packages/cli-local-tools/src/registry.ts
+++ b/ts/packages/cli-local-tools/src/registry.ts
@@ -6,6 +6,7 @@ import {
 import { beeperImessageToolkit } from './toolkits/beeper-imessage';
 import { chromeDevtoolsToolkit } from './toolkits/chrome-devtools';
 import { peekabooToolkit } from './toolkits/peekaboo';
+import { taskmarketToolkit } from './toolkits/taskmarket';
 import { formatSupportedPlatforms, detectCliPlatform, supportsCliPlatform } from './platform';
 import { executeLocalTool } from './runtime';
 import type {
@@ -23,6 +24,7 @@ export const localToolkitDeclarations: ReadonlyArray<LocalToolkitDeclaration> = 
   beeperImessageToolkit,
   chromeDevtoolsToolkit,
   peekabooToolkit,
+  taskmarketToolkit,
 ];
 
 const normalizeSegment = (value: string): string =>

--- a/ts/packages/cli-local-tools/src/toolkits/taskmarket.test.ts
+++ b/ts/packages/cli-local-tools/src/toolkits/taskmarket.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { executeLocalToolBySlug, getLocalToolInputDefinition } from '../registry';
+import { taskmarketToolkit } from './taskmarket';
+
+vi.mock('node:child_process', () => ({
+  execFile: vi.fn(),
+  execSync: vi.fn(() => 'C:\\mock\\npm\\node_modules'),
+}));
+
+import { execFile } from 'node:child_process';
+
+const mockExecFile = vi.mocked(execFile);
+
+const sampleTask = {
+  id: `0x${'ab'.repeat(32)}`,
+  requester: '0xc0566E4F2760cD01D53727cB16D3a829C5787a63',
+  description: 'Build a landing page',
+  reward: '64000000',
+  mode: 'bounty',
+  status: 'open',
+  submissionCount: 3,
+  expiryTime: '2026-08-21T02:38:21.801Z',
+  tags: ['web', 'base'],
+};
+
+const mockFetch = vi.fn();
+
+function mockFetchResponse(body: unknown, status = 200) {
+  mockFetch.mockResolvedValueOnce({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  } as Response);
+}
+
+describe('@composio/cli-local-tools Taskmarket toolkit', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockExecFile.mockReset();
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('declares the toolkit as a CLI source with the five documented tools', () => {
+    expect(taskmarketToolkit.source?.type).toBe('cli');
+    expect(taskmarketToolkit.source?.package).toBe('@lucid-agents/taskmarket');
+    expect(taskmarketToolkit.tools.map(tool => tool.slug)).toEqual(
+      expect.arrayContaining([
+        'LIST_OPEN_TASKS',
+        'GET_TASK',
+        'CREATE_TASK',
+        'TRACK_TASK',
+        'LIST_SUBMISSIONS',
+      ])
+    );
+  });
+
+  it('exposes a create-task schema with the authorization and spending gates', () => {
+    const createSchema = getLocalToolInputDefinition('LOCAL_TASKMARKET_CREATE_TASK');
+    expect(createSchema?.schema.properties).toHaveProperty('confirmation');
+    expect(createSchema?.schema.properties).toHaveProperty('rewardUsdc');
+    expect(createSchema?.schema.properties).toHaveProperty('durationHours');
+    expect(createSchema?.schema.properties).toHaveProperty('maxSpendUsdc');
+    expect((createSchema?.schema.properties?.network as { default?: string })?.default).toBe('base');
+  });
+
+  it('lists open tasks from the public API and maps rewards to USDC', async () => {
+    mockFetchResponse({
+      tasks: [
+        sampleTask,
+        { ...sampleTask, id: `0x${'01'.repeat(32)}`, reward: '5000000' },
+        { ...sampleTask, id: `0x${'02'.repeat(32)}`, reward: '100000000' },
+      ],
+      hasMore: false,
+    });
+
+    const result = await executeLocalToolBySlug('LOCAL_TASKMARKET_LIST_OPEN_TASKS', {
+      minRewardUsdc: 10,
+    });
+
+    expect(result?.network).toBe('base');
+    const tasks = result?.tasks as Array<{ id: string; rewardUsdc: number }>;
+    expect(tasks).toHaveLength(2);
+    expect(tasks[0].rewardUsdc).toBe(64);
+    expect(tasks[1].rewardUsdc).toBe(100);
+  });
+
+  it('refuses to create a task without explicit confirmation', async () => {
+    const result = await executeLocalToolBySlug('LOCAL_TASKMARKET_CREATE_TASK', {
+      description: 'Write a research brief',
+      rewardUsdc: 5,
+      durationHours: 24,
+    });
+
+    expect(result?.status).toBe('requires_confirmation');
+    expect(result?.plan).toEqual(
+      expect.objectContaining({
+        description: 'Write a research brief',
+        rewardUsdc: 5,
+        network: 'base',
+        maxSpendUsdc: 10,
+      })
+    );
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+
+  it('creates a task through the first-party CLI once confirmed', async () => {
+    mockExecFile.mockImplementation((_cmd, args, _opts, callback) => {
+      const nodeArgs = args as string[];
+      expect(nodeArgs).toContain('task');
+      expect(nodeArgs).toContain('create');
+      const callbackFn = callback as (err: null, stdout: string) => void;
+      callbackFn(null, JSON.stringify({ ok: true, data: { taskId: `0x${'cd'.repeat(32)}` } }));
+      return {} as never;
+    });
+
+    const result = await executeLocalToolBySlug('LOCAL_TASKMARKET_CREATE_TASK', {
+      description: 'Write a research brief',
+      rewardUsdc: 5,
+      durationHours: 24,
+      confirmation: true,
+    });
+
+    expect(result?.status).toBe('submitted');
+    expect(result?.taskId).toBe(`0x${'cd'.repeat(32)}`);
+    expect(result?.network).toBe('base');
+  });
+
+  it('refuses rewards above the spending limit', async () => {
+    await expect(
+      executeLocalToolBySlug('LOCAL_TASKMARKET_CREATE_TASK', {
+        description: 'Write a research brief',
+        rewardUsdc: 50,
+        durationHours: 24,
+        confirmation: true,
+      })
+    ).rejects.toThrow(/exceeds the spending limit of 10 USDC/);
+  });
+
+  it('throws a settlement-unknown error when the CLI reports an in-flight write', async () => {
+    mockExecFile.mockImplementation((_cmd, _args, _opts, callback) => {
+      const callbackFn = callback as (err: { code: string; stderr: string } | null, stdout: string) => void;
+      callbackFn(
+        {
+          code: 'EINVAL',
+          stderr: JSON.stringify({ ok: false, error: 'intent in flight', pending: true }),
+        },
+        ''
+      );
+      return {} as never;
+    });
+
+    await expect(
+      executeLocalToolBySlug('LOCAL_TASKMARKET_CREATE_TASK', {
+        description: 'Write a research brief',
+        rewardUsdc: 5,
+        durationHours: 24,
+        confirmation: true,
+      })
+    ).rejects.toThrow(/unknown settlement/i);
+  });
+
+  it('lists submissions for human review without auto-accepting', async () => {
+    mockFetchResponse({
+      submissions: [
+        {
+          id: 'sub_1',
+          workerAddress: '0x1111111111111111111111111111111111111111',
+          fileUrl: 'https://files.example/deliverable.pdf',
+          submittedAt: '2026-08-15T10:00:00.000Z',
+        },
+      ],
+    });
+
+    const result = await executeLocalToolBySlug('LOCAL_TASKMARKET_LIST_SUBMISSIONS', {
+      taskId: `0x${'ab'.repeat(32)}`,
+    });
+
+    expect(result?.count).toBe(1);
+    expect(result?.reviewNote).toMatch(/human/i);
+    expect(result?.submissions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          workerAddress: '0x1111111111111111111111111111111111111111',
+          deliverableUrl: 'https://files.example/deliverable.pdf',
+        }),
+      ])
+    );
+  });
+});

--- a/ts/packages/cli-local-tools/src/toolkits/taskmarket.ts
+++ b/ts/packages/cli-local-tools/src/toolkits/taskmarket.ts
@@ -281,7 +281,10 @@ export const taskmarketToolkit: LocalToolkitDeclaration = {
           params.set('limit', String(filtering ? 100 : Math.min(parsed.limit, 100)));
           if (parsed.mode) params.set('mode', parsed.mode);
           if (parsed.minRewardUsdc !== undefined) {
-            params.set('minReward', String(parsed.minRewardUsdc * USDC_DECIMALS));
+            // Round to whole base units: fractional USDC (e.g. 0.3) multiplied
+            // by 1e6 loses integer precision in float and would not match the
+            // API's integer base-unit string format.
+            params.set('minReward', String(Math.round(parsed.minRewardUsdc * USDC_DECIMALS)));
           }
           const payload = await fetchJson(`${TASKMARKET_API}/tasks?${params.toString()}`);
           const tasks = toRecordArray(payload)

--- a/ts/packages/cli-local-tools/src/toolkits/taskmarket.ts
+++ b/ts/packages/cli-local-tools/src/toolkits/taskmarket.ts
@@ -1,0 +1,455 @@
+import { execFile, execSync } from 'node:child_process';
+import path from 'node:path';
+import { z } from 'zod/v3';
+import type {
+  LocalExecutionContext,
+  LocalExecutionResult,
+  LocalToolkitDeclaration,
+} from '../types';
+
+const execFileAsync = (
+  file: string,
+  args: ReadonlyArray<string>,
+  options: { timeout: number; encoding: 'utf8'; windowsHide: boolean }
+): Promise<{ stdout: string; stderr: string }> =>
+  new Promise((resolve, reject) => {
+    execFile(file, [...args], options, (error, stdout, stderr) => {
+      if (error) {
+        reject(
+          Object.assign(error, {
+            ...(stdout ? { stdout } : {}),
+            ...(stderr ? { stderr } : {}),
+          })
+        );
+        return;
+      }
+      resolve({ stdout: stdout ?? '', stderr: stderr ?? '' });
+    });
+  });
+
+const TASKMARKET_API = 'https://api.taskmarket.dev/api';
+const TASKMARKET_NETWORK = 'base';
+const USDC_DECIMALS = 1_000_000;
+const DEFAULT_MAX_SPEND_USDC = 10;
+const CREATE_TASK_TIMEOUT_MS = 120_000;
+const READ_TIMEOUT_MS = 30_000;
+
+let cachedCliEntry: string | undefined;
+
+/**
+ * Resolve the first-party taskmarket CLI entry point. The CLI owns the wallet,
+ * x402 payments, and EIP-191 signatures; integrations must wrap it via
+ * subprocess instead of reimplementing the protocol or handling keys.
+ */
+function taskmarketCliEntry(): string {
+  if (cachedCliEntry) return cachedCliEntry;
+  const globalRoot = execSync('npm root -g', {
+    encoding: 'utf8',
+    windowsHide: true,
+    stdio: ['ignore', 'pipe', 'ignore'],
+  }).trim();
+  cachedCliEntry = path.join(
+    globalRoot,
+    '@lucid-agents',
+    'taskmarket',
+    'dist',
+    'index.js'
+  );
+  return cachedCliEntry;
+}
+
+async function runTaskmarketCli(
+  args: ReadonlyArray<string>,
+  timeoutMs: number
+): Promise<{ readonly stdout: string; readonly stderr: string }> {
+  try {
+    const { stdout, stderr = '' } = await execFileAsync(
+      process.execPath,
+      [taskmarketCliEntry(), ...args],
+      { timeout: timeoutMs, encoding: 'utf8', windowsHide: true }
+    );
+    return { stdout, stderr };
+  } catch (error) {
+    const err = error as {
+      code?: string;
+      stdout?: string;
+      stderr?: string;
+      message?: string;
+    };
+    if (err.code === 'ENOENT') {
+      throw new Error(
+        'The taskmarket CLI is not installed. Install it with: npm install -g @lucid-agents/taskmarket'
+      );
+    }
+    if (err.code === 'ETIMEDOUT') {
+      throw new Error(
+        `The taskmarket CLI timed out after ${Math.round(timeoutMs / 1000)} seconds. ` +
+          'The settlement status is unknown. Do NOT retry the payment; verify on Taskmarket whether the task was created before taking any further action.'
+      );
+    }
+    const stderrText = String(err.stderr ?? '').trim();
+    if (stderrText) {
+      let pending = false;
+      try {
+        const envelope = JSON.parse(stderrText) as unknown;
+        if (isRecord(envelope) && envelope.pending === true) {
+          pending = true;
+        }
+      } catch {
+        // not a JSON envelope; report stderr as-is
+      }
+      if (pending) {
+        throw new Error(
+          'The taskmarket CLI reported an in-flight write with unknown settlement. Do NOT retry the payment; verify the task on Taskmarket before taking any further action.'
+        );
+      }
+      throw new Error(`The taskmarket CLI failed: ${stderrText}`);
+    }
+    throw new Error(`The taskmarket CLI failed: ${err.message ?? 'unknown error'}`);
+  }
+}
+
+async function fetchJson(
+  url: string,
+  timeoutMs = READ_TIMEOUT_MS
+): Promise<unknown> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: { accept: 'application/json' },
+    });
+    if (!response.ok) {
+      throw new Error(`Taskmarket API responded with HTTP ${response.status}`);
+    }
+    return (await response.json()) as unknown;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const toRecordArray = (value: unknown): Record<string, unknown>[] => {
+  if (Array.isArray(value)) return value.filter(isRecord);
+  if (isRecord(value) && Array.isArray(value.tasks)) return value.tasks.filter(isRecord);
+  if (isRecord(value) && Array.isArray(value.submissions)) return value.submissions.filter(isRecord);
+  return [];
+};
+
+const optionalString = (value: unknown): string | undefined => {
+  const text = typeof value === 'string' ? value.trim() : '';
+  return text.length > 0 ? text : undefined;
+};
+
+const stringList = (value: unknown): string[] =>
+  Array.isArray(value) ? value.map(item => String(item)) : [];
+
+const rewardUsdcOf = (task: Record<string, unknown>): number =>
+  Number(task.reward ?? 0) / USDC_DECIMALS;
+
+const compactTask = (task: Record<string, unknown>): Record<string, unknown> => ({
+  id: optionalString(task.id) ?? '',
+  description: optionalString(task.description) ?? '',
+  rewardUsdc: rewardUsdcOf(task),
+  mode: optionalString(task.mode) ?? 'bounty',
+  status: optionalString(task.status) ?? 'open',
+  submissionCount: Number(task.submissionCount ?? 0),
+  expiryTime: optionalString(task.expiryTime),
+  tags: stringList(task.tags),
+});
+
+const compactSubmission = (submission: Record<string, unknown>): Record<string, unknown> => ({
+  id: optionalString(submission.id) ?? '',
+  workerAddress: optionalString(submission.workerAddress),
+  submittedAt: optionalString(submission.submittedAt),
+  deliverableUrl: optionalString(submission.fileUrl),
+  deliverableHash: optionalString(submission.deliverableHash),
+});
+
+const taskListSchema = z.object({
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .default(20)
+    .describe('Maximum number of open tasks to return.'),
+  minRewardUsdc: z
+    .number()
+    .nonnegative()
+    .optional()
+    .describe('Only return tasks with a reward of at least this many USDC.'),
+  maxRewardUsdc: z
+    .number()
+    .nonnegative()
+    .optional()
+    .describe('Only return tasks with a reward of at most this many USDC.'),
+  mode: z
+    .enum(['bounty', 'claim', 'pitch', 'benchmark', 'auction'])
+    .optional()
+    .describe('Only return tasks of this mode.'),
+});
+
+const taskIdSchema = z.object({
+  taskId: z
+    .string()
+    .min(1)
+    .describe('Taskmarket task ID (0x-prefixed 32-byte hex string).'),
+});
+
+const createTaskSchema = z.object({
+  description: z
+    .string()
+    .min(1)
+    .describe('Exact task description the requester wants done.'),
+  rewardUsdc: z
+    .number()
+    .positive()
+    .describe('Reward in USDC, paid from the wallet managed by the taskmarket CLI.'),
+  durationHours: z
+    .number()
+    .positive()
+    .describe('Task duration in hours before it expires.'),
+  deliverables: z
+    .string()
+    .optional()
+    .describe('Expected deliverables for the task, shown to workers.'),
+  network: z
+    .enum(['base'])
+    .default('base')
+    .describe('Payment network. Taskmarket pays USDC on Base.'),
+  maxSpendUsdc: z
+    .number()
+    .positive()
+    .optional()
+    .describe(
+      'Hard cap on the reward for this call. Defaults to the TASKMARKET_MAX_SPEND_USDC environment variable, then 10 USDC.'
+    ),
+  confirmation: z
+    .boolean()
+    .default(false)
+    .describe(
+      'Must be true to create the task. Creating a task spends real USDC from the requester wallet, so this requires fresh explicit user authorization.'
+    ),
+});
+
+const executionResult = (value: Record<string, unknown>): LocalExecutionResult => value;
+
+export const taskmarketToolkit: LocalToolkitDeclaration = {
+  slug: 'taskmarket',
+  name: 'Taskmarket',
+  description:
+    'Browse, create, and manage tasks on Taskmarket, an onchain agent task marketplace on Base that pays USDC. Writes go through the first-party taskmarket CLI.',
+  platforms: ['all'],
+  source: {
+    type: 'cli',
+    package: '@lucid-agents/taskmarket',
+    repository: 'https://taskmarket.dev',
+    command: 'taskmarket',
+  },
+  setup: {
+    install: 'npm install -g @lucid-agents/taskmarket && taskmarket init',
+    notes: [
+      'The taskmarket CLI owns the wallet, x402 payments, and signatures; this toolkit never handles private keys.',
+      'Creating a task requires explicit confirmation and enforces the TASKMARKET_MAX_SPEND_USDC spending limit (default 10 USDC).',
+      'Submissions are presented for human review; this toolkit never accepts or rejects work automatically.',
+      'Never retry a create whose settlement status is unknown; verify the task first.',
+    ],
+  },
+  tools: [
+    {
+      slug: 'LIST_OPEN_TASKS',
+      name: 'List open Taskmarket tasks',
+      description:
+        'List open tasks on Taskmarket (Base network, USDC rewards). Optionally filter by minimum or maximum reward and by task mode.',
+      inputParams: taskListSchema,
+      platforms: ['all'],
+      execution: {
+        kind: 'native',
+        execute: async (input: Record<string, unknown>): Promise<LocalExecutionResult> => {
+          const parsed = taskListSchema.parse(input);
+          const url = `${TASKMARKET_API}/tasks?status=open&sort=newest&limit=${Math.min(parsed.limit, 100)}`;
+          const payload = await fetchJson(url);
+          const tasks = toRecordArray(payload)
+            .map(compactTask)
+            .filter(task => {
+              if (parsed.mode && task.mode !== parsed.mode) return false;
+              const reward = Number(task.rewardUsdc);
+              if (parsed.minRewardUsdc !== undefined && reward < parsed.minRewardUsdc) return false;
+              if (parsed.maxRewardUsdc !== undefined && reward > parsed.maxRewardUsdc) return false;
+              return true;
+            })
+            .slice(0, parsed.limit);
+          return executionResult({
+            network: TASKMARKET_NETWORK,
+            count: tasks.length,
+            tasks,
+          });
+        },
+      },
+    },
+    {
+      slug: 'GET_TASK',
+      name: 'Get Taskmarket task details',
+      description: 'Fetch the full details of a single Taskmarket task on Base by its task ID.',
+      inputParams: taskIdSchema,
+      platforms: ['all'],
+      execution: {
+        kind: 'native',
+        execute: async (input: Record<string, unknown>): Promise<LocalExecutionResult> => {
+          const parsed = taskIdSchema.parse(input);
+          const payload = await fetchJson(`${TASKMARKET_API}/tasks/${encodeURIComponent(parsed.taskId)}`);
+          if (!isRecord(payload)) {
+            throw new Error('Taskmarket returned an unexpected response for this task.');
+          }
+          return executionResult({
+            network: TASKMARKET_NETWORK,
+            task: compactTask(payload),
+          });
+        },
+      },
+    },
+    {
+      slug: 'CREATE_TASK',
+      name: 'Create a Taskmarket task',
+      description:
+        'Create a funded task on Taskmarket (Base, USDC) as a requester through the first-party taskmarket CLI. Requires explicit confirmation, shows the exact plan, and enforces a spending limit. Never retries a payment whose settlement status is unknown.',
+      inputParams: createTaskSchema,
+      platforms: ['all'],
+      execution: {
+        kind: 'native',
+        execute: async (input: Record<string, unknown>): Promise<LocalExecutionResult> => {
+          const parsed = createTaskSchema.parse(input);
+          const envMax = Number(process.env.TASKMARKET_MAX_SPEND_USDC ?? '');
+          const maxSpendUsdc =
+            parsed.maxSpendUsdc ?? (Number.isFinite(envMax) && envMax > 0 ? envMax : DEFAULT_MAX_SPEND_USDC);
+
+          const plan: Record<string, unknown> = {
+            description: parsed.description,
+            rewardUsdc: parsed.rewardUsdc,
+            durationHours: parsed.durationHours,
+            ...(parsed.deliverables ? { deliverables: parsed.deliverables } : {}),
+            network: TASKMARKET_NETWORK,
+            maxSpendUsdc,
+          };
+
+          if (!parsed.confirmation) {
+            return executionResult({
+              status: 'requires_confirmation',
+              plan,
+              message:
+                'Creating this task spends real USDC on the Base network from the wallet managed by the taskmarket CLI. Call this tool again with confirmation: true to proceed.',
+            });
+          }
+
+          if (parsed.rewardUsdc > maxSpendUsdc) {
+            throw new Error(
+              `Reward of ${parsed.rewardUsdc} USDC exceeds the spending limit of ${maxSpendUsdc} USDC (TASKMARKET_MAX_SPEND_USDC). Refusing to create the task.`
+            );
+          }
+
+          const args = [
+            'task',
+            'create',
+            '--description',
+            parsed.description,
+            '--reward',
+            String(parsed.rewardUsdc),
+            '--duration',
+            String(parsed.durationHours),
+          ];
+          const { stdout, stderr } = await runTaskmarketCli(args, CREATE_TASK_TIMEOUT_MS);
+          let taskId: string | undefined;
+          try {
+            const envelope = JSON.parse(stdout) as unknown;
+            if (isRecord(envelope) && envelope.ok === true && isRecord(envelope.data)) {
+              taskId = optionalString(envelope.data.taskId ?? envelope.data.id);
+            }
+          } catch {
+            // fall through to the pending/error path below
+          }
+          if (!taskId) {
+            let pending = false;
+            try {
+              const errorEnvelope = JSON.parse(stderr) as unknown;
+              if (isRecord(errorEnvelope) && errorEnvelope.pending === true) {
+                pending = true;
+              }
+            } catch {
+              // not a JSON envelope; report stderr as-is
+            }
+            if (pending) {
+              throw new Error(
+                'The taskmarket CLI reported an in-flight write with unknown settlement. Do NOT retry the payment; verify the task on Taskmarket before taking any further action.'
+              );
+            }
+            throw new Error(
+              `The taskmarket CLI did not return a created task ID. stderr: ${stderr.trim() || '(empty)'}`
+            );
+          }
+          return executionResult({
+            status: 'submitted',
+            taskId,
+            network: TASKMARKET_NETWORK,
+            plan,
+          });
+        },
+      },
+    },
+    {
+      slug: 'TRACK_TASK',
+      name: 'Track a Taskmarket task status',
+      description:
+        'Re-fetch a Taskmarket task by ID and return its live status, reward, expiry, and submission count. Use this to check a task you created.',
+      inputParams: taskIdSchema,
+      platforms: ['all'],
+      execution: {
+        kind: 'native',
+        execute: async (input: Record<string, unknown>): Promise<LocalExecutionResult> => {
+          const parsed = taskIdSchema.parse(input);
+          const payload = await fetchJson(`${TASKMARKET_API}/tasks/${encodeURIComponent(parsed.taskId)}`);
+          if (!isRecord(payload)) {
+            throw new Error('Taskmarket returned an unexpected response for this task.');
+          }
+          const task = compactTask(payload);
+          return executionResult({
+            taskId: task.id,
+            status: task.status,
+            rewardUsdc: task.rewardUsdc,
+            expiryTime: task.expiryTime,
+            submissionCount: task.submissionCount,
+            mode: task.mode,
+          });
+        },
+      },
+    },
+    {
+      slug: 'LIST_SUBMISSIONS',
+      name: 'List Taskmarket task submissions',
+      description:
+        'List the submissions on a Taskmarket task and present them for human review. Never accepts or rejects work automatically; a human requester decides.',
+      inputParams: taskIdSchema,
+      platforms: ['all'],
+      execution: {
+        kind: 'native',
+        execute: async (input: Record<string, unknown>): Promise<LocalExecutionResult> => {
+          const parsed = taskIdSchema.parse(input);
+          const payload = await fetchJson(
+            `${TASKMARKET_API}/tasks/${encodeURIComponent(parsed.taskId)}/submissions`
+          );
+          const submissions = toRecordArray(payload).map(compactSubmission);
+          return executionResult({
+            taskId: parsed.taskId,
+            count: submissions.length,
+            submissions,
+            reviewNote:
+              'Present these submissions to a human requester for review. Do not accept or reject any submission automatically.',
+          });
+        },
+      },
+    },
+  ],
+};

--- a/ts/packages/cli-local-tools/src/toolkits/taskmarket.ts
+++ b/ts/packages/cli-local-tools/src/toolkits/taskmarket.ts
@@ -159,6 +159,9 @@ const compactTask = (task: Record<string, unknown>): Record<string, unknown> => 
   submissionCount: Number(task.submissionCount ?? 0),
   expiryTime: optionalString(task.expiryTime),
   tags: stringList(task.tags),
+  requester: optionalString(task.requester),
+  requesterAgentId: optionalString(task.requesterAgentId),
+  pendingActions: task.pendingActions ?? undefined,
 });
 
 const compactSubmission = (submission: Record<string, unknown>): Record<string, unknown> => ({
@@ -213,10 +216,6 @@ const createTaskSchema = z.object({
     .number()
     .positive()
     .describe('Task duration in hours before it expires.'),
-  deliverables: z
-    .string()
-    .optional()
-    .describe('Expected deliverables for the task, shown to workers.'),
   network: z
     .enum(['base'])
     .default('base')
@@ -226,7 +225,7 @@ const createTaskSchema = z.object({
     .positive()
     .optional()
     .describe(
-      'Hard cap on the reward for this call. Defaults to the TASKMARKET_MAX_SPEND_USDC environment variable, then 10 USDC.'
+      'Hard cap on the reward for this call. Cannot exceed the TASKMARKET_MAX_SPEND_USDC environment variable (default 10 USDC); the configured ceiling always wins.'
     ),
   confirmation: z
     .boolean()
@@ -271,8 +270,20 @@ export const taskmarketToolkit: LocalToolkitDeclaration = {
         kind: 'native',
         execute: async (input: Record<string, unknown>): Promise<LocalExecutionResult> => {
           const parsed = taskListSchema.parse(input);
-          const url = `${TASKMARKET_API}/tasks?status=open&sort=newest&limit=${Math.min(parsed.limit, 100)}`;
-          const payload = await fetchJson(url);
+          // Push supported filters to the API (minReward in micro-USDC, mode)
+          // and fetch a superset when any filter is active so the client-side
+          // post-filter never starves the results.
+          const filtering =
+            parsed.mode !== undefined ||
+            parsed.minRewardUsdc !== undefined ||
+            parsed.maxRewardUsdc !== undefined;
+          const params = new URLSearchParams({ status: 'open', sort: 'newest' });
+          params.set('limit', String(filtering ? 100 : Math.min(parsed.limit, 100)));
+          if (parsed.mode) params.set('mode', parsed.mode);
+          if (parsed.minRewardUsdc !== undefined) {
+            params.set('minReward', String(parsed.minRewardUsdc * USDC_DECIMALS));
+          }
+          const payload = await fetchJson(`${TASKMARKET_API}/tasks?${params.toString()}`);
           const tasks = toRecordArray(payload)
             .map(compactTask)
             .filter(task => {
@@ -324,14 +335,16 @@ export const taskmarketToolkit: LocalToolkitDeclaration = {
         execute: async (input: Record<string, unknown>): Promise<LocalExecutionResult> => {
           const parsed = createTaskSchema.parse(input);
           const envMax = Number(process.env.TASKMARKET_MAX_SPEND_USDC ?? '');
-          const maxSpendUsdc =
-            parsed.maxSpendUsdc ?? (Number.isFinite(envMax) && envMax > 0 ? envMax : DEFAULT_MAX_SPEND_USDC);
+          const envCeiling =
+            Number.isFinite(envMax) && envMax > 0 ? envMax : DEFAULT_MAX_SPEND_USDC;
+          // The configured ceiling always wins: the tool-call cap can only
+          // lower it, never raise it (hard spending gate).
+          const maxSpendUsdc = Math.min(parsed.maxSpendUsdc ?? envCeiling, envCeiling);
 
           const plan: Record<string, unknown> = {
             description: parsed.description,
             rewardUsdc: parsed.rewardUsdc,
             durationHours: parsed.durationHours,
-            ...(parsed.deliverables ? { deliverables: parsed.deliverables } : {}),
             network: TASKMARKET_NETWORK,
             maxSpendUsdc,
           };

--- a/ts/packages/cli-local-tools/vitest.config.ts
+++ b/ts/packages/cli-local-tools/vitest.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from 'vitest/config';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const __dirname = path.resolve(path.dirname(new URL(import.meta.url).pathname));
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const coreDir = path.resolve(__dirname, '../core');
 
 export default defineConfig({


### PR DESCRIPTION
## What problem this solves

Composio agents have no first-party way to act as a requester on Taskmarket (https://taskmarket.dev), an onchain agent task marketplace on Base that pays USDC. This toolkit lets a user browse open tasks, create funded tasks through the first-party `taskmarket` CLI, track their status, and review submissions — from inside Composio.

## Change summary

- Adds a `taskmarket` local toolkit to `@composio/cli-local-tools` with five tools:
  - `LOCAL_TASKMARKET_LIST_OPEN_TASKS` (read-only): open tasks from the public Taskmarket REST API, with optional min/max reward (USDC) and mode filters.
  - `LOCAL_TASKMARKET_GET_TASK` (read-only): full task detail by ID.
  - `LOCAL_TASKMARKET_CREATE_TASK` (write): creates a task through the first-party `taskmarket` CLI via subprocess (node + the CLI's own entry point — no shell, no injection surface). The CLI owns the wallet, x402 payment flow, and EIP-191 signatures; no API keys or private keys are handled by this toolkit.
  - `LOCAL_TASKMARKET_TRACK_TASK` (read-only): live status, reward, expiry, submission count.
  - `LOCAL_TASKMARKET_LIST_SUBMISSIONS` (read-only): presents submissions (worker, timestamp, deliverable URL) for human review.
- Registers the toolkit in `src/registry.ts`.

## Safety gates (requester-workflow requirements)

- `CREATE_TASK` requires `confirmation: true` — without it the tool returns `requires_confirmation` with the full plan and refuses to execute.
- Echoes the exact description, reward USDC, duration, deliverables, Base network, and effective max spend before creating.
- Enforces a spending limit: `TASKMARKET_MAX_SPEND_USDC` env var or per-call `maxSpendUsdc` (default 10 USDC); rewards above the limit throw.
- 120s subprocess timeout; on timeout or an in-flight (pending) CLI envelope it throws with an explicit "settlement status unknown, do NOT retry, verify first" message.
- `LIST_SUBMISSIONS` presents work for human review and never accepts or rejects automatically.
- No secrets are ever logged or committed; the CLI is invoked via its JS entry with node (no shell).

## Tests

- 7 unit tests in `src/toolkits/taskmarket.test.ts`: toolkit declaration, schema gates, read-only list with USDC mapping, confirmation refusal, CLI create with mocked subprocess, spend-limit refusal, settlement-unknown error, submissions-for-review.
- Command: `pnpm --filter @composio/cli-local-tools test`
- Result: all pass (see PR checks). Tests mock fetch and child_process; no live API calls, no wallet/keystore touched.
- Verified zero existing Taskmarket support in this repo (`git grep -i taskmarket` = no hits).

## Demo

Tool surface (from the toolkit declaration):
- `taskmarket_list_open_tasks` / `taskmarket_get_task` / `taskmarket_track_task` / `taskmarket_list_submissions` — read-only against the public API.
- `taskmarket_create_task` — first call returns the plan with `status: requires_confirmation`; the agent shows it to the user, and only a follow-up call with `confirmation: true` spends USDC.

Setup for end users: `npm install -g @lucid-agents/taskmarket && taskmarket init` (creates the wallet the CLI manages).