### PR TITLE
docs: Hobby / Pro / Enterprise plans + pass-through premium tools

### DIFF
--- a/docs/app/llms.mdx/[[...slug]]/route.ts
+++ b/docs/app/llms.mdx/[[...slug]]/route.ts
@@ -989,7 +989,7 @@ async function generateToolkitsIndex(): Promise<string> {
     '',
     `Composio supports ${toolkits.length} toolkits for building AI agents.`,
     '',
-    '- [Pro Tools](/toolkits/pro-tools.md) - Which tools cost extra, how they are priced, and what the limits are',
+    '- [Premium Tools](/toolkits/pro-tools.md) - Which tools cost extra, how they are priced, and what the limits are',
     '- [Composio Managed Auth](/toolkits/managed-auth.md) - Full list of OAuth toolkits that work out of the box vs ones that need your own credentials',
     '',
     '## All Toolkits',

--- a/docs/components/toolkits/toolkits-landing.tsx
+++ b/docs/components/toolkits/toolkits-landing.tsx
@@ -182,7 +182,7 @@ export function ToolkitsLanding() {
       {/* Cards */}
       <Cards>
         <Card icon={<ShieldCheck />} title="Composio Managed Auth" href="/toolkits/managed-auth" description="Check which toolkits have managed auth" />
-        <Card icon={<Sparkles />} title="Pro Tools" href="/toolkits/pro-tools" description="Learn about pricing and limits" />
+        <Card icon={<Sparkles />} title="Premium Tools" href="/toolkits/pro-tools" description="Learn about pricing and limits" />
         <Card icon={<Wrench />} title="Meta Tools" href="/toolkits/meta-tools" description="The system tools every session gives your agent" />
       </Cards>
 

--- a/docs/content/reference/rate-limits.mdx
+++ b/docs/content/reference/rate-limits.mdx
@@ -11,7 +11,7 @@ Composio enforces rate limits **per organization** over a fixed one-minute windo
 | Plan | Rate limit | Window |
 |------|------------|--------|
 | Hobby | 2,000 requests | 1 minute |
-| Pro | 2,000 requests | 1 minute |
+| Pro | 10,000 requests | 1 minute |
 | Enterprise | Custom | - |
 
 ## Rate limit headers

--- a/docs/content/reference/rate-limits.mdx
+++ b/docs/content/reference/rate-limits.mdx
@@ -14,8 +14,6 @@ Composio enforces rate limits **per organization** over a fixed one-minute windo
 | Pro | 2,000 requests | 1 minute |
 | Enterprise | Custom | - |
 
-Signed up before August 15, 2026? Your plan and rates are unchanged through December 31, 2026 — see [your pricing](https://composio.dev/pricing/legacy).
-
 ## Rate limit headers
 
 Every response includes headers so you can track usage without guessing:

--- a/docs/content/reference/rate-limits.mdx
+++ b/docs/content/reference/rate-limits.mdx
@@ -10,10 +10,11 @@ Composio enforces rate limits **per organization** over a fixed one-minute windo
 
 | Plan | Rate limit | Window |
 |------|------------|--------|
-| Starter | 2,000 requests | 1 minute |
 | Hobby | 2,000 requests | 1 minute |
-| Growth | 10,000 requests | 1 minute |
+| Pro | 2,000 requests | 1 minute |
 | Enterprise | Custom | - |
+
+Signed up before August 15, 2026? Your plan and rates are unchanged through December 31, 2026 — see [your pricing](https://composio.dev/pricing/legacy).
 
 ## Rate limit headers
 

--- a/docs/content/reference/v3/rate-limits.mdx
+++ b/docs/content/reference/v3/rate-limits.mdx
@@ -11,7 +11,7 @@ Composio enforces rate limits **per organization** over a fixed one-minute windo
 | Plan | Rate limit | Window |
 |------|------------|--------|
 | Hobby | 2,000 requests | 1 minute |
-| Pro | 2,000 requests | 1 minute |
+| Pro | 10,000 requests | 1 minute |
 | Enterprise | Custom | - |
 
 ## Rate limit headers

--- a/docs/content/reference/v3/rate-limits.mdx
+++ b/docs/content/reference/v3/rate-limits.mdx
@@ -14,8 +14,6 @@ Composio enforces rate limits **per organization** over a fixed one-minute windo
 | Pro | 2,000 requests | 1 minute |
 | Enterprise | Custom | - |
 
-Signed up before August 15, 2026? Your plan and rates are unchanged through December 31, 2026 — see [your pricing](https://composio.dev/pricing/legacy).
-
 ## Rate limit headers
 
 Every response includes headers so you can track usage without guessing:

--- a/docs/content/reference/v3/rate-limits.mdx
+++ b/docs/content/reference/v3/rate-limits.mdx
@@ -10,10 +10,11 @@ Composio enforces rate limits **per organization** over a fixed one-minute windo
 
 | Plan | Rate limit | Window |
 |------|------------|--------|
-| Starter | 2,000 requests | 1 minute |
 | Hobby | 2,000 requests | 1 minute |
-| Growth | 10,000 requests | 1 minute |
+| Pro | 2,000 requests | 1 minute |
 | Enterprise | Custom | - |
+
+Signed up before August 15, 2026? Your plan and rates are unchanged through December 31, 2026 — see [your pricing](https://composio.dev/pricing/legacy).
 
 ## Rate limit headers
 

--- a/docs/content/toolkits/pro-tools.mdx
+++ b/docs/content/toolkits/pro-tools.mdx
@@ -1,11 +1,11 @@
 ---
-title: Pro Tools
-description: Pricing and limits for pro tools in Composio
+title: Premium Tools
+description: Pricing and limits for premium tools in Composio
 ---
 
-Some tool calls cost more to run — search APIs, code sandboxes, ML inference. We call those pro tools and price them separately.
+Some tool calls cost more to run — search APIs, code sandboxes, ML inference. We call those premium tools and price them separately.
 
-## What counts as a pro tool?
+## What counts as a premium tool?
 
 <Cards>
   <Card icon={<Search />} title="Search APIs" href="/toolkits/composio_search" description="Composio Search, Perplexity, Exa, SerpAPI" />
@@ -18,20 +18,16 @@ Some tool calls cost more to run — search APIs, code sandboxes, ML inference. 
 
 ## Pricing
 
-Pro tool calls are roughly 3x the cost of a standard tool call. Full pricing is on the [pricing page](https://composio.dev/pricing).
+Premium tools run on paid third-party providers (web search, media generation, browser automation, and similar). Composio passes the provider's price through with a 5% platform fee — there is no markup on top of that. Approximate per-call prices for each provider are listed in the **Premium tools** section of the [pricing page](https://composio.dev/pricing).
 
-| Plan | Included Standard Tool Calls | Included Pro Tool Calls | Usage Based Standard Tool Calls | Usage Based Pro Tool Calls |
-|------|------------------------------|-----------------------------|---------------------------------|--------------------------------|
-| Totally Free | 20k | 1k | – | – |
-| Ridiculously Cheap | 200k | 5k | $0.299/1k | $0.897/1k |
-| Serious Business | 2M | 50k | $0.249/1k | $0.747/1k |
-| Enterprise | Flexible | Flexible | Flexible | Flexible |
+- **Hobby** includes up to $2/month of premium tool usage.
+- Prices depend on the provider and can change with advance notice — check the [pricing page](https://composio.dev/pricing) for current rates.
 
 ## Rate limits
 
-Pro tools have lower rate limits than standard tool calls. If you need more, [contact us](mailto:billing@composio.dev).
+Premium tools have lower rate limits than standard tool calls. If you need more, [contact us](mailto:billing@composio.dev).
 
-| Spending Tier | Standard Tool Calls Rate Limit | Pro Tool Calls Rate Limit |
+| Spending Tier | Standard Tool Calls Rate Limit | Premium Tool Calls Rate Limit |
 |---------------|--------------------------------|-------------------------------|
 | Free | 100/min | 1,000/hour |
 | Paid | 5,000/min | 10,000/hour |

--- a/docs/content/toolkits/pro-tools.mdx
+++ b/docs/content/toolkits/pro-tools.mdx
@@ -21,14 +21,15 @@ Some tool calls cost more to run — search APIs, code sandboxes, ML inference. 
 Premium tools run on paid third-party providers (web search, media generation, browser automation, and similar). Composio passes the provider's price through with a 5% platform fee — there is no markup on top of that. Approximate per-call prices for each provider are listed in the **Premium tools** section of the [pricing page](https://composio.dev/pricing).
 
 - **Hobby** includes up to $2/month of premium tool usage.
+- **Pro** includes everything in Hobby plus a $29 monthly usage credit, which also covers premium tool calls.
 - Prices depend on the provider and can change with advance notice — check the [pricing page](https://composio.dev/pricing) for current rates.
 
 ## Rate limits
 
-Premium tools have lower rate limits than standard tool calls. If you need more, [contact us](mailto:billing@composio.dev).
+Premium tools have their own, lower rate limits. These apply to premium tool executions only and are separate from your organization's overall API rate limit — see [Rate Limits](/reference/rate-limits) for that. If you need more, [contact us](mailto:billing@composio.dev).
 
-| Spending Tier | Standard Tool Calls Rate Limit | Premium Tool Calls Rate Limit |
-|---------------|--------------------------------|-------------------------------|
-| Free | 100/min | 1,000/hour |
-| Paid | 5,000/min | 10,000/hour |
-| Enterprise | Custom | Custom |
+| Plan | Premium Tool Calls Rate Limit |
+|------|-------------------------------|
+| Hobby | 1,000/hour |
+| Pro | 10,000/hour |
+| Enterprise | Custom |


### PR DESCRIPTION
## Summary

Composio's new pricing went live on Aug 15, 2026: **Hobby** ($0) / **Pro** ($29/mo) / **Enterprise** (custom). This PR updates the public docs to describe only the current offering and reprices premium tools as pass-through (provider cost + 5% platform fee).

## Principle

- Docs describe the **current** plans only (Hobby / Pro / Enterprise). No Starter/Growth tables, no dual documentation.
- Where a legacy note is genuinely useful (rate limits), exactly one sentence pointing pre-Aug-15 customers to https://composio.dev/pricing/legacy.
- **Link to https://composio.dev/pricing instead of repeating numbers**, so future price changes are a one-place edit.

## Files changed

- `docs/content/toolkits/pro-tools.mdx` — replaced the "3x the cost" line and the Totally Free / Ridiculously Cheap / Serious Business tier table with pass-through pricing copy: paid third-party providers, provider price + 5% platform fee (no markup), per-call prices on the pricing page's "Premium tools" section, Hobby includes up to $2/mo of premium tool usage, prices depend on provider and can change with advance notice. Retitled the page from "Pro Tools" to "Premium Tools" (matches the pricing page and avoids confusion with the new Pro plan). URL slug `/toolkits/pro-tools` is unchanged so no links break. Rest of the page (what counts as a premium tool, rate limits) intact.
- `docs/content/reference/rate-limits.mdx` + `docs/content/reference/v3/rate-limits.mdx` (manual copies, updated identically) — plan table now Hobby 2,000 req/min · Pro 10,000 req/min · Enterprise Custom (kept the doc's existing per-minute unit and "Custom" wording for Enterprise). No legacy/grandfathering note — docs describe current plans only; grandfathered customers are served by the dashboard and composio.dev/pricing/legacy.
- `docs/app/llms.mdx/[[...slug]]/route.ts`, `docs/components/toolkits/toolkits-landing.tsx` — label text "Pro Tools" → "Premium Tools" (link targets unchanged).

## Not changed / notes for reviewers

- `docs/content/docs/common-faq.mdx` no longer exists on `next` (removed in the sessions-first rewrite, #3637); a grep for self-host / on-prem across `docs/content` found **no** page advertising self-hosting as an Enterprise feature, so nothing to remove there.
- Grep sweep (case-insensitive) over `docs/content` for: Starter, Growth plan/tier, Ridiculously, Serious Business, Totally Free, on-prem, self-host(ed), $229, $599, 20k tool calls, 200k, per seat, per-seat, 3x the cost. All customer-facing hits were in the three files above and are fixed. Left alone:
  - `changelog/*` — historical entries (self-hosted Supabase/PostHog instances, "self-hosted deployments need backend version X"); these refer to third-party instances or historical SDK notes, not to an Enterprise plan feature.
  - `docs/auth-configuration/custom-auth-configs.mdx:23`, `docs/authentication/custom-app-vs-managed-app.mdx:30` — "self-hosted" refers to the *customer's* self-hosted third-party app (e.g. Salesforce subdomain), unrelated to Composio plans.
  - `docs/configuring-sessions.mdx`, `docs/sandbox/remote.mdx` — "Sandboxes are not billed today" note; not part of this change, flagging in case sandbox billing status changed with the new pricing.
  - `pro-tools.mdx` "Rate limits" table: **fixed in `421789d90`** — dropped the "Standard Tool Calls" column (100/min · 5,000/min contradicted `reference/rate-limits.mdx`), kept only the premium-execution limiter mapped to plan names (Hobby 1,000/hr · Pro 10,000/hr · Enterprise Custom) with a note that it is separate from the org API limit. Also added Pro's premium allowance bullet.

## Validation

- `bun run lint` (oxlint): passes; only pre-existing warnings in untouched files.
- `bun run lint:links` (`scripts/validate-links.ts`): 0 errors.

## Related PRs

- landing: https://github.com/ComposioHQ/landing/pull/289
- platform: https://github.com/ComposioHQ/platform/pull/12078
- dashboard: https://github.com/ComposioHQ/dashboard/pull/1326

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P3JgWs8DcjeQTRKoJd8gmQ



