### PR TITLE
test(openai-agents): exercise wrapped tools through Runner

### DIFF
--- a/.github/workflows/py.openai-agents-provider.yml
+++ b/.github/workflows/py.openai-agents-provider.yml
@@ -1,0 +1,90 @@
+name: Test Python OpenAI Agents Provider
+
+on:
+  push:
+    branches: [master, next]
+    paths:
+      - 'python/composio/**'
+      - 'python/providers/openai_agents/**'
+      - 'python/pyproject.toml'
+      - 'python/setup.py'
+      - '.github/workflows/py.openai-agents-provider.yml'
+      - '.github/actions/setup-python-uv/**'
+      - '.github/scripts/install-mise.sh'
+      - '.github/scripts/read-mise-lock-version.sh'
+      - 'mise.lock'
+  pull_request:
+    branches: [master, next]
+    paths:
+      - 'python/composio/**'
+      - 'python/providers/openai_agents/**'
+      - 'python/pyproject.toml'
+      - 'python/setup.py'
+      - '.github/workflows/py.openai-agents-provider.yml'
+      - '.github/actions/setup-python-uv/**'
+      - '.github/scripts/install-mise.sh'
+      - '.github/scripts/read-mise-lock-version.sh'
+      - 'mise.lock'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  provider-contract:
+    name: OpenAI Agents ${{ matrix.openai-agents-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        openai-agents-version: ['0.20.0', '0.21.0', '0.22.0']
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python and uv
+        uses: ./.github/actions/setup-python-uv
+        with:
+          python-version: '3.12'
+
+      - name: Install provider contract dependencies
+        working-directory: python
+        env:
+          OPENAI_AGENTS_VERSION: ${{ matrix.openai-agents-version }}
+        run: |
+          uv venv
+          source .venv/bin/activate
+          uv pip install \
+            -e . \
+            -e providers/openai_agents \
+            "agentrunproof==0.3.0" \
+            "openai-agents==${OPENAI_AGENTS_VERSION}" \
+            pytest
+          uv pip check
+
+      - name: Verify installed versions
+        working-directory: python
+        env:
+          OPENAI_AGENTS_VERSION: ${{ matrix.openai-agents-version }}
+        run: |
+          source .venv/bin/activate
+          python - <<'PY'
+          import os
+          from importlib.metadata import version
+
+          assert version("agentrunproof") == "0.3.0"
+          assert version("openai-agents") == os.environ["OPENAI_AGENTS_VERSION"]
+          PY
+
+      - name: Run provider contract
+        working-directory: python
+        run: |
+          source .venv/bin/activate
+          python -m pytest \
+            providers/openai_agents/tests/test_runner_integration.py \
+            -v \
+            --tb=short

--- a/python/providers/openai_agents/tests/test_runner_integration.py
+++ b/python/providers/openai_agents/tests/test_runner_integration.py
@@ -1,0 +1,73 @@
+"""Provider-free integration coverage for the OpenAI Agents provider."""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+from agentrunproof import (  # type: ignore[import-not-found]
+    DeterministicModel,
+    assistant_message,
+    function_call,
+)
+from agents import Agent, RunConfig, Runner
+from composio_openai_agents import OpenAIAgentsProvider
+
+
+@pytest.mark.parametrize("streamed", [False, True], ids=["run", "run-streamed"])
+def test_wrapped_tool_runs_through_the_real_runner(streamed: bool) -> None:
+    """A wrapped Composio tool should execute exactly once in either Runner mode."""
+
+    async def run_case() -> None:
+        invocations: list[tuple[str, dict[str, str]]] = []
+
+        def execute_tool(*, slug: str, arguments: dict[str, str]) -> dict[str, str]:
+            invocations.append((slug, arguments))
+            return {"city": arguments["city"], "forecast": "clear"}
+
+        tool = MagicMock(
+            slug="WEATHER_LOOKUP",
+            description="Return a deterministic local forecast.",
+            input_parameters={
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        )
+        wrapped_tool = OpenAIAgentsProvider().wrap_tool(tool, execute_tool)
+        model = DeterministicModel(
+            [
+                [
+                    function_call(
+                        "WEATHER_LOOKUP",
+                        {"city": "Paris"},
+                        call_id=f"call-{streamed}",
+                    )
+                ],
+                [assistant_message("done")],
+            ]
+        )
+        agent = Agent(name="Composio contract", model=model, tools=[wrapped_tool])
+        run_config = RunConfig(tracing_disabled=True)
+
+        if streamed:
+            streamed_result = Runner.run_streamed(
+                agent,
+                "Check Paris",
+                run_config=run_config,
+            )
+            async for _ in streamed_result.stream_events():
+                pass
+            final_output = streamed_result.final_output
+        else:
+            run_result = await Runner.run(
+                agent,
+                "Check Paris",
+                run_config=run_config,
+            )
+            final_output = run_result.final_output
+
+        assert final_output == "done"
+        assert invocations == [("WEATHER_LOOKUP", {"city": "Paris"})]
+        model.assert_complete()
+
+    asyncio.run(run_case())


### PR DESCRIPTION
## Summary

The Python OpenAI Agents provider tests currently stop at schema transformation. This adds a provider-free contract test that passes a wrapped Composio `FunctionTool` through the real OpenAI Agents `Runner` and verifies that it executes exactly once in both `Runner.run` and `Runner.run_streamed`.

## Changes

- Add one real-Runner test for the existing Python `OpenAIAgentsProvider`.
- Add a focused Python 3.12 CI matrix for exact `openai-agents==0.20.0`, `==0.21.0`, and `==0.22.0`.
- Install `agentrunproof==0.3.0` only inside that CI job; it is not added to Composio's runtime or package dependencies.
- Keep the test provider-free and tracing-disabled, with no API key or model-provider request.

The exact SDK pins are intentional: AgentRunProof supplies the same deterministic model fixture in every cell, so the contract exercises both non-streamed and streamed Runner behavior without resolver drift or external inference.

## How Has This Been Tested?

Local refresh validation on Python 3.12.13:

- `openai-agents==0.20.0` + `agentrunproof==0.3.0`: 8/8 provider tests passed; `uv pip check` passed.
- `openai-agents==0.21.0` + `agentrunproof==0.3.0`: 8/8 provider tests passed; `uv pip check` passed.
- `openai-agents==0.22.0` + `agentrunproof==0.3.0`: 8/8 provider tests passed; `uv pip check` passed.
- Ruff 0.16.3 check and format check passed for the new test.
- Mypy 2.3.0 passed for the new test.
- Workflow YAML parsing and `git diff --check` passed.

## Dependency disclosure

I maintain AgentRunProof. This proposal uses its released MIT-licensed package as an exact, test-only CI dependency; it does not add AgentRunProof to any Composio runtime dependency or published package.

## Checklist

- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed
- [x] Documentation is not needed because public behavior is unchanged
- [x] I added focused tests
- [x] A changeset is not needed because no published package changes
