### PR TITLE
refactor(cli): rename LocalToolkitSlugs.match to longestPrefix

### DIFF
--- a/ts/packages/cli/src/effects/toolkit-from-tool-slug.ts
+++ b/ts/packages/cli/src/effects/toolkit-from-tool-slug.ts
@@ -38,7 +38,7 @@ export const toolkitFromToolSlug = (
     const catalog = yield* ToolkitSlugCatalog;
     const local = yield* catalog.local;
 
-    const match = local.match(toolSlug);
+    const match = local.longestPrefix(toolSlug);
     if (match !== undefined) {
       return toolkitFromMatchedPrefix(match);
     }

--- a/ts/packages/cli/src/services/toolkit-slug-catalog.ts
+++ b/ts/packages/cli/src/services/toolkit-slug-catalog.ts
@@ -74,7 +74,7 @@ export interface LocalToolkitSlugs {
    * or undefined when nothing local matches — which is what a toolkit released
    * after this binary looks like.
    */
-  readonly match: (toolSlug: string) => string | undefined;
+  readonly longestPrefix: (toolSlug: string) => string | undefined;
 }
 
 const loadLocalToolkitSlugs = Effect.gen(function* () {
@@ -83,7 +83,7 @@ const loadLocalToolkitSlugs = Effect.gen(function* () {
 
   yield* refreshInBackgroundIfStale(learned);
 
-  return { slugs, match: makeLongestPrefixMatcher(slugs) } satisfies LocalToolkitSlugs;
+  return { slugs, longestPrefix: makeLongestPrefixMatcher(slugs) } satisfies LocalToolkitSlugs;
 });
 
 /**


### PR DESCRIPTION
## Summary

Renames `LocalToolkitSlugs.match` to `longestPrefix` to clear CodeQL code-scanning alert [#113](https://github.com/ComposioHQ/composio/security/code-scanning/113) (`js/regex-injection`, high).

## Why

The alert flagged `local.match(toolSlug)` in `toolkit-from-tool-slug.ts` as a regular expression constructed from a command-line argument. It is a false positive: `local` is a `LocalToolkitSlugs` object, and its `match` member is a custom longest-prefix matcher (`makeLongestPrefixMatcher`) that only does `toolSlug.toLowerCase().split('_')` plus `Set` membership lookups — no `RegExp` is ever constructed. CodeQL's `js/regex-injection` sink is keyed on the `match` member name (matching `String.prototype.match`, which coerces a string argument into a `RegExp`), so it could not tell the custom method apart from the string sink.

The member name `match` on a non-string object invited exactly that confusion — for the analyzer and for human readers. Renaming it to `longestPrefix` (mirroring the underlying `makeLongestPrefixMatcher` / `longestPrefix` helper) removes the false positive without suppressing anything, and reads more clearly.

## Changes

- `services/toolkit-slug-catalog.ts`: interface member and object literal `match` → `longestPrefix`
- `effects/toolkit-from-tool-slug.ts`: call site `local.match(...)` → `local.longestPrefix(...)`

## Verification

- `pnpm typecheck` — 14/14 packages pass
- lint-staged (oxlint + prettier) clean on commit

The alert should clear on the next CodeQL scan of the merged commit.