### PR TITLE
fix(python): create the cache directory on first use instead of at import time

### DIFF
--- a/python/composio/core/models/_files.py
+++ b/python/composio/core/models/_files.py
@@ -80,35 +80,79 @@ ENV_LOCAL_CACHE_DIRECTORY = "COMPOSIO_CACHE_DIR"
 Environment to set the composio caching directory.
 """
 
-LOCAL_CACHE_DIRECTORY = Path(
-    os.environ.get(
-        ENV_LOCAL_CACHE_DIRECTORY,
-        Path.home() / LOCAL_CACHE_DIRECTORY_NAME,  # Fallback to user directory
-    )
-)
+LOCAL_OUTPUT_FILE_DIRECTORY_NAME = "files"
 """
-Path to local caching directory.
+Name of the cache sub-directory into which files downloaded during tool
+execution are written. Previously ``outputs``; now ``files`` for parity with
+the TypeScript SDK.
 """
 
-try:
-    LOCAL_CACHE_DIRECTORY.mkdir(parents=True, exist_ok=True)
-    if not os.access(LOCAL_CACHE_DIRECTORY, os.W_OK):
-        raise OSError
-except OSError as e:
-    raise RuntimeError(
-        f"Cache directory {LOCAL_CACHE_DIRECTORY} is not writable please "
-        f"provide a path that is writable using {ENV_LOCAL_CACHE_DIRECTORY} "
-        "environment variable."
-    ) from e
+
+def get_cache_directory() -> Path:
+    """Resolve the local caching directory without touching the filesystem.
+
+    ``COMPOSIO_CACHE_DIR`` is read on every call so it can be set after
+    ``composio`` has been imported. ``Path.home()`` is consulted only when the
+    variable is unset: it raises ``RuntimeError`` when there is no resolvable
+    home directory, which is precisely the situation the variable exists to
+    work around, so it must not be evaluated eagerly as a fallback argument.
+    """
+    configured = os.environ.get(ENV_LOCAL_CACHE_DIRECTORY)
+    if configured:
+        return Path(configured)
+
+    try:
+        home = Path.home()
+    except RuntimeError as e:
+        raise RuntimeError(
+            "Could not determine a home directory to store the Composio cache "
+            f"in. Provide a writable path using the {ENV_LOCAL_CACHE_DIRECTORY} "
+            "environment variable."
+        ) from e
+    return home / LOCAL_CACHE_DIRECTORY_NAME
 
 
-LOCAL_OUTPUT_FILE_DIRECTORY = LOCAL_CACHE_DIRECTORY / "files"
-"""
-Default local directory into which files downloaded during tool execution are
-written. Previously ``<cache>/outputs``; now ``<cache>/files`` for parity with
-the TypeScript SDK. Override by passing ``file_download_dir=...`` to Composio,
-or by setting ``outdir`` on ``FileHelper`` directly.
-"""
+def get_output_file_directory() -> Path:
+    """Default directory for files downloaded during tool execution."""
+    return get_cache_directory() / LOCAL_OUTPUT_FILE_DIRECTORY_NAME
+
+
+def ensure_cache_directory() -> Path:
+    """Create the cache directory on first use and check that it is writable.
+
+    This ran at import time until now, so ``import composio`` raised
+    ``RuntimeError`` on read-only filesystems -- AWS Lambda, distroless
+    images, ``ProtectHome=true`` systemd units -- even for programs that never
+    touch a file. Deferring it to first use keeps the same check, and the same
+    error message, for the callers that actually need the directory.
+    """
+    directory = get_cache_directory()
+    try:
+        directory.mkdir(parents=True, exist_ok=True)
+        if not os.access(directory, os.W_OK):
+            raise OSError
+    except OSError as e:
+        raise RuntimeError(
+            f"Cache directory {directory} is not writable please "
+            f"provide a path that is writable using {ENV_LOCAL_CACHE_DIRECTORY} "
+            "environment variable."
+        ) from e
+    return directory
+
+
+def __getattr__(name: str) -> Path:
+    """Keep the historical module-level path constants working, but lazily.
+
+    ``LOCAL_CACHE_DIRECTORY`` and ``LOCAL_OUTPUT_FILE_DIRECTORY`` were computed
+    at import time. They are resolved on attribute access instead (PEP 562), so
+    importing this module no longer depends on the environment, and both
+    constants observe a ``COMPOSIO_CACHE_DIR`` that was set after import.
+    """
+    if name == "LOCAL_CACHE_DIRECTORY":
+        return get_cache_directory()
+    if name == "LOCAL_OUTPUT_FILE_DIRECTORY":
+        return get_output_file_directory()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def get_md5(file: Path) -> str:
@@ -652,7 +696,8 @@ class FileHelper(WithLogger):
         """
         super().__init__()
         self._client = client
-        self._outdir = Path(outdir) if outdir else LOCAL_OUTPUT_FILE_DIRECTORY
+        self._outdir_is_default = outdir is None
+        self._outdir = Path(outdir) if outdir else get_output_file_directory()
         self._sensitive_file_upload_protection = sensitive_file_upload_protection
         self._file_upload_path_deny_segments = file_upload_path_deny_segments
         self._file_upload_allowlist: t.Optional[t.Sequence[Path]] = (
@@ -1085,6 +1130,11 @@ class FileHelper(WithLogger):
 
     def _download_file_value(self, value: t.Any, tool: Tool) -> t.Any:
         if isinstance(value, dict) and "s3url" in value:
+            if self._outdir_is_default:
+                # First point at which the cache directory is genuinely
+                # needed. Raises the same RuntimeError that used to be raised
+                # at import time, pointing at COMPOSIO_CACHE_DIR.
+                ensure_cache_directory()
             return str(
                 FileDownloadable(**value).download(
                     self._outdir / tool.toolkit.slug / tool.slug

--- a/python/tests/test_lazy_cache_directory.py
+++ b/python/tests/test_lazy_cache_directory.py
@@ -1,0 +1,162 @@
+"""Regression tests for lazy creation of the Composio cache directory.
+
+``composio/core/models/_files.py`` used to create ``~/.composio`` and assert
+that it was writable at *module import time*. Because ``composio/__init__.py``
+imports ``tools.py``, which imports ``_files.py`` unconditionally, a bare
+``import composio`` raised ``RuntimeError`` on any read-only filesystem --
+AWS Lambda, distroless containers, ``ProtectHome=true`` systemd units -- even
+for programs that never touched a file.
+
+These tests pin the fix: importing the package performs no filesystem work,
+``COMPOSIO_CACHE_DIR`` is honoured when set after import, and the writability
+check still raises the same error when the directory is genuinely needed.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from composio.core.models import _files
+
+
+@pytest.fixture()
+def unusable_cache_dir(tmp_path: Path) -> Path:
+    """A cache path that cannot be created, without relying on permissions.
+
+    ``chmod`` based read-only directories are a no-op when the test suite runs
+    as root (``os.access(..., W_OK)`` returns True for uid 0), which is common
+    in containerised CI. Nesting the cache directory *underneath a regular
+    file* makes ``mkdir`` fail with ``NotADirectoryError`` for every user.
+    """
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not a directory")
+    return blocker / "cache"
+
+
+def test_importing_composio_does_not_create_the_cache_directory(
+    tmp_path: Path, unusable_cache_dir: Path
+) -> None:
+    """The regression test: ``import composio`` must not touch the filesystem.
+
+    Run in a subprocess so the import genuinely happens under the patched
+    environment rather than hitting the already-imported module in this
+    process.
+    """
+    env = dict(os.environ)
+    env["COMPOSIO_CACHE_DIR"] = str(unusable_cache_dir)
+    env["COMPOSIO_API_KEY"] = "test-key"
+
+    result = subprocess.run(
+        [sys.executable, "-c", "import composio"],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    assert result.returncode == 0, (
+        "importing composio with an uncreatable cache directory must succeed, "
+        f"but it failed with:\n{result.stderr}"
+    )
+    assert not unusable_cache_dir.exists()
+
+
+def test_cache_directory_is_created_only_on_demand(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    cache_dir = tmp_path / "not-yet-there"
+    monkeypatch.setenv("COMPOSIO_CACHE_DIR", str(cache_dir))
+
+    # Merely resolving the path must not create it.
+    assert _files.get_cache_directory() == cache_dir
+    assert not cache_dir.exists()
+
+    assert _files.ensure_cache_directory() == cache_dir
+    assert cache_dir.is_dir()
+
+
+def test_cache_dir_env_var_is_read_after_import(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``COMPOSIO_CACHE_DIR`` used to be frozen at import time."""
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+
+    monkeypatch.setenv("COMPOSIO_CACHE_DIR", str(first))
+    assert _files.get_cache_directory() == first
+
+    monkeypatch.setenv("COMPOSIO_CACHE_DIR", str(second))
+    assert _files.get_cache_directory() == second
+
+
+def test_home_is_not_resolved_when_the_env_var_is_set(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The escape hatch has to work when ``Path.home()`` itself fails.
+
+    The old code passed ``Path.home() / ...`` as the *default argument* to
+    ``os.environ.get``, which Python evaluates eagerly, so setting
+    ``COMPOSIO_CACHE_DIR`` did not save a user whose home directory could not
+    be resolved.
+    """
+
+    def _explode() -> Path:
+        raise RuntimeError("Could not determine home directory")
+
+    monkeypatch.setattr(Path, "home", staticmethod(_explode))
+    monkeypatch.setenv("COMPOSIO_CACHE_DIR", str(tmp_path / "cache"))
+
+    assert _files.get_cache_directory() == tmp_path / "cache"
+
+
+def test_unresolvable_home_raises_a_helpful_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _explode() -> Path:
+        raise RuntimeError("Could not determine home directory")
+
+    monkeypatch.setattr(Path, "home", staticmethod(_explode))
+    monkeypatch.delenv("COMPOSIO_CACHE_DIR", raising=False)
+
+    with pytest.raises(RuntimeError, match="COMPOSIO_CACHE_DIR"):
+        _files.get_cache_directory()
+
+
+def test_output_file_directory_hangs_off_the_cache_directory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("COMPOSIO_CACHE_DIR", str(tmp_path / "cache"))
+    assert _files.get_output_file_directory() == tmp_path / "cache" / "files"
+
+
+def test_ensure_cache_directory_still_reports_unwritable_paths(
+    monkeypatch: pytest.MonkeyPatch, unusable_cache_dir: Path
+) -> None:
+    """The writability check is deferred, not removed."""
+    monkeypatch.setenv("COMPOSIO_CACHE_DIR", str(unusable_cache_dir))
+
+    with pytest.raises(RuntimeError, match="COMPOSIO_CACHE_DIR"):
+        _files.ensure_cache_directory()
+
+
+def test_legacy_module_constants_still_resolve(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``LOCAL_CACHE_DIRECTORY`` was public-ish; keep it importable (PEP 562)."""
+    monkeypatch.setenv("COMPOSIO_CACHE_DIR", str(tmp_path / "cache"))
+
+    assert _files.LOCAL_CACHE_DIRECTORY == tmp_path / "cache"
+    assert _files.LOCAL_OUTPUT_FILE_DIRECTORY == tmp_path / "cache" / "files"
+
+    # And unlike the old module-level constants, they track the environment.
+    monkeypatch.setenv("COMPOSIO_CACHE_DIR", str(tmp_path / "other"))
+    assert _files.LOCAL_CACHE_DIRECTORY == tmp_path / "other"
+
+
+def test_unknown_module_attribute_still_raises_attribute_error() -> None:
+    """The module ``__getattr__`` must not swallow genuine typos."""
+    with pytest.raises(AttributeError, match="no attribute"):
+        _files.LOCAL_CACHE_DIRECTROY  # noqa: B018  (deliberate typo)


### PR DESCRIPTION
Fixes #4150

## The problem

`python/composio/core/models/_files.py` created the cache directory and asserted that it was writable **at module scope**:

```python
LOCAL_CACHE_DIRECTORY = Path(
    os.environ.get(
        ENV_LOCAL_CACHE_DIRECTORY,
        Path.home() / LOCAL_CACHE_DIRECTORY_NAME,
    )
)

try:
    LOCAL_CACHE_DIRECTORY.mkdir(parents=True, exist_ok=True)
    if not os.access(LOCAL_CACHE_DIRECTORY, os.W_OK):
        raise OSError
except OSError as e:
    raise RuntimeError(...) from e
```

`composio/__init__.py` imports `tools.py`, which imports `_files.py` unconditionally, so this runs on **every** `import composio`. On a read-only filesystem the import itself raises `RuntimeError` — AWS Lambda (only `/tmp` is writable), distroless / scratch containers, `ProtectHome=true` systemd units, read-only root filesystems in Kubernetes. A program that only calls `composio.tools.get(...)` and never touches a file still cannot import the SDK.

### A second, quieter bug in the same block

`Path.home() / LOCAL_CACHE_DIRECTORY_NAME` is the **default argument** to `os.environ.get(...)`. Python evaluates arguments eagerly, so `Path.home()` ran *even when `COMPOSIO_CACHE_DIR` was set*. `Path.home()` raises `RuntimeError` when the home directory cannot be resolved — which is exactly the situation `COMPOSIO_CACHE_DIR` exists to work around. The documented escape hatch did not actually work in the case it was designed for.

And because the value was computed once at import, `COMPOSIO_CACHE_DIR` could not be set programmatically before use — it had to be in the environment before the interpreter reached the import.

## The change

Resolution becomes pure path math; creation happens on first real use.

| New symbol | Does | Touches disk |
|---|---|---|
| `get_cache_directory()` | Resolves the cache path, reading `COMPOSIO_CACHE_DIR` **on every call** | No |
| `get_output_file_directory()` | `get_cache_directory() / "files"` | No |
| `ensure_cache_directory()` | The old `mkdir` + `os.access(W_OK)` check | Yes |

`get_cache_directory()` short-circuits on the environment variable, so `Path.home()` is consulted only when it is unset — fixing the eager-evaluation bug above. When `Path.home()` does raise, it is re-raised with a message pointing at `COMPOSIO_CACHE_DIR`.

Two call sites move:

- `FileHelper.__init__` now stores `self._outdir_is_default = outdir is None` and defaults `_outdir` via `get_output_file_directory()`. `_outdir` stays a plain `Path`; no signature or type change.
- `FileHelper._download_file_value` calls `ensure_cache_directory()` **only when the default outdir is in use**, immediately before a download. The friendly writability error still fires at the first real download, and a caller who supplied their own `outdir` no longer causes `~/.composio` to be created at all.

## Backwards compatibility

`LOCAL_CACHE_DIRECTORY` and `LOCAL_OUTPUT_FILE_DIRECTORY` were importable module attributes, so they are preserved through a module-level `__getattr__` ([PEP 562](https://peps.python.org/pep-0562/)) that resolves them lazily. Existing `from composio.core.models._files import LOCAL_CACHE_DIRECTORY` keeps working, and now also tracks a `COMPOSIO_CACHE_DIR` set after import. Unknown attributes still raise `AttributeError`.

A detail worth flagging for review: module-level `__getattr__` is **not** consulted for bare name lookups *inside* the module (those go globals → builtins → `NameError`). That is why the in-module use site had to change to `get_output_file_directory()` rather than relying on the shim.

## No loss of directory creation

`FileDownloadable.download()` already does `outdir.mkdir(exist_ok=True, parents=True)` before writing. Removing the import-time `mkdir` therefore loses no directory creation — only the friendly *pre-check*, which `ensure_cache_directory()` restores at the point of use.

This also matches what the package already does elsewhere: `tool_router_session_files.py` defines its own `COMPOSIO_DIR` constant and resolves `Path.home()` lazily inside `RemoteFile.save()`, rather than at import.

## Deliberately not done

`ensure_cache_directory()` is **not** called from `FileHelper.__init__`. `FileHelper` is constructed unconditionally by `Composio()`, so calling it there would just move the Lambda crash from import time to construction time without fixing anything.

## Tests

`python/tests/test_lazy_cache_directory.py` (9 tests):

- **the regression test** — a subprocess runs `import composio` with `COMPOSIO_CACHE_DIR` pointing at a path that cannot be created, and asserts exit code 0 and that the path was not created
- `get_cache_directory()` does not create the directory; `ensure_cache_directory()` does
- `COMPOSIO_CACHE_DIR` is observed when changed after import
- `Path.home()` is not called when `COMPOSIO_CACHE_DIR` is set (patched to raise; test asserts no raise)
- an unresolvable home raises a `RuntimeError` naming `COMPOSIO_CACHE_DIR`
- `ensure_cache_directory()` still raises the original error on an unusable path
- `LOCAL_CACHE_DIRECTORY` / `LOCAL_OUTPUT_FILE_DIRECTORY` still resolve, and now track the environment
- a typo'd module attribute still raises `AttributeError`

The "unusable directory" fixture nests the cache path underneath a **regular file** rather than using `chmod`, because `os.access(..., W_OK)` returns `True` for uid 0 — a `chmod`-based test silently passes as a no-op in root containers, which is common in CI.

## Tradeoffs and notes for the reviewer

- **mypy**: adding a module-level `__getattr__` means mypy will no longer flag typo'd attributes on this module. That is the standard cost of PEP 562; I judged the back-compat guarantee worth it, but I am happy to drop the shim and take the (small) breaking change instead if you prefer stricter typing here.
- **Merge conflict**: this touches `_files.py` from the same `next` baseline as my PR #4154, so the two will conflict textually. Both diffs are small and in different regions; happy to rebase whichever lands second.
- **I could not execute the test suite** in my environment (`composio_client` is not installed there), so please treat CI as the source of truth. The changed module and the new test module both parse cleanly and stay within the 88-column formatting used by `ruff format`.