### PR TITLE
ci: label-triggered docs agent eval (V1, informational)

### DIFF
--- a/.github/workflows/docs-agent-eval.yml
+++ b/.github/workflows/docs-agent-eval.yml
@@ -128,7 +128,7 @@ jobs:
       contents: read
       pull-requests: write  # the result comment
     # Full-SHA pin required by org policy — bump on docs-agent-eval releases.
-    uses: ComposioHQ/docs-agent-eval-ci/.github/workflows/eval-pr.yml@766d0f9322e1841ce28089336c7090223160fb02
+    uses: ComposioHQ/docs-agent-eval-ci/.github/workflows/eval-pr.yml@da8e10f34bb24c67e150a19dbe013d718dc69902
     with:
       pr_number: ${{ needs.route.outputs.pr_number }}
       mode: ${{ needs.route.outputs.mode }}

--- a/.github/workflows/docs-agent-eval.yml
+++ b/.github/workflows/docs-agent-eval.yml
@@ -40,7 +40,7 @@ jobs:
       contents: read
       pull-requests: write  # the result comment
     # Full-SHA pin required by org policy — bump on docs-agent-eval releases.
-    uses: ComposioHQ/docs-agent-eval-ci/.github/workflows/eval-pr.yml@8917b53bd867d61aad24a1df42c6788f5987e2ff
+    uses: ComposioHQ/docs-agent-eval-ci/.github/workflows/eval-pr.yml@48e1a1d2f8baf12a7a073b8141afede3baee94f7
     with:
       pr_number: ${{ github.event.pull_request.number }}
       mode: ${{ contains(github.event.pull_request.labels.*.name, 'run-docs-tests-deep') && 'Deep' || 'Auto' }}

--- a/.github/workflows/docs-agent-eval.yml
+++ b/.github/workflows/docs-agent-eval.yml
@@ -36,7 +36,7 @@ jobs:
       contents: read
       pull-requests: write  # the result comment
     # Full-SHA pin required by org policy — bump on docs-agent-eval releases.
-    uses: ComposioHQ/docs-agent-eval/.github/workflows/eval-pr.yml@88dec5bf58d3f77b598c03eec0e6a0c587a57554
+    uses: ComposioHQ/docs-agent-eval-ci/.github/workflows/eval-pr.yml@2fe0ec46e0ed6b50953dfb0f4f7e7bb33bf0f403
     with:
       pr_number: ${{ github.event.pull_request.number }}
       mode: ${{ contains(github.event.pull_request.labels.*.name, 'run-docs-tests-deep') && 'Deep' || 'Auto' }}

--- a/.github/workflows/docs-agent-eval.yml
+++ b/.github/workflows/docs-agent-eval.yml
@@ -128,7 +128,7 @@ jobs:
       contents: read
       pull-requests: write  # the result comment
     # Full-SHA pin required by org policy — bump on docs-agent-eval releases.
-    uses: ComposioHQ/docs-agent-eval-ci/.github/workflows/eval-pr.yml@b1e84be08379820263bb6de3f3a207a67d4d2a65
+    uses: ComposioHQ/docs-agent-eval-ci/.github/workflows/eval-pr.yml@21146fbe43e6d6eb0db4b46ef9b09faab6110edd
     with:
       pr_number: ${{ needs.route.outputs.pr_number }}
       mode: ${{ needs.route.outputs.mode }}

--- a/.github/workflows/docs-agent-eval.yml
+++ b/.github/workflows/docs-agent-eval.yml
@@ -18,13 +18,20 @@ on:
   pull_request:
     types: [labeled, synchronize, reopened]
 
-concurrency:
-  group: docs-agent-eval-pr-${{ github.event.pull_request.number }}
-  cancel-in-progress: true  # newest commit wins; stale evals are superseded
-
 jobs:
   eval:
-    if: contains(github.event.pull_request.labels.*.name, 'run-docs-tests')
+    # Run when the PR carries the label — but for `labeled` events, only when
+    # the label just added is one of ours (any other label addition would
+    # otherwise cancel-and-restart an in-flight eval; Cursor Bugbot finding).
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'run-docs-tests') &&
+      (github.event.action != 'labeled' || startsWith(github.event.label.name, 'run-docs-tests'))
+    # Job-level on purpose: a skipped job never enters the concurrency group,
+    # so unrelated triggers cannot cancel a running eval. New commits still
+    # supersede stale runs.
+    concurrency:
+      group: docs-agent-eval-pr-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     permissions:
       contents: read
       pull-requests: write  # the result comment

--- a/.github/workflows/docs-agent-eval.yml
+++ b/.github/workflows/docs-agent-eval.yml
@@ -128,7 +128,7 @@ jobs:
       contents: read
       pull-requests: write  # the result comment
     # Full-SHA pin required by org policy — bump on docs-agent-eval releases.
-    uses: ComposioHQ/docs-agent-eval-ci/.github/workflows/eval-pr.yml@2a831429ee6d8be6b9b4526f78bf5a451881cf8f
+    uses: ComposioHQ/docs-agent-eval-ci/.github/workflows/eval-pr.yml@766d0f9322e1841ce28089336c7090223160fb02
     with:
       pr_number: ${{ needs.route.outputs.pr_number }}
       mode: ${{ needs.route.outputs.mode }}

--- a/.github/workflows/docs-agent-eval.yml
+++ b/.github/workflows/docs-agent-eval.yml
@@ -24,8 +24,11 @@ jobs:
     # Run when the PR carries the label — but for `labeled` events, only when
     # the label just added is one of ours (any other label addition would
     # otherwise cancel-and-restart an in-flight eval; Cursor Bugbot finding).
+    # Either label triggers on its own (run-docs-tests-deep standalone forces
+    # Deep); labeled events still only count when the added label is ours.
     if: |
-      contains(github.event.pull_request.labels.*.name, 'run-docs-tests') &&
+      (contains(github.event.pull_request.labels.*.name, 'run-docs-tests') ||
+       contains(github.event.pull_request.labels.*.name, 'run-docs-tests-deep')) &&
       (github.event.action != 'labeled' || startsWith(github.event.label.name, 'run-docs-tests'))
     # Job-level on purpose: a skipped job never enters the concurrency group,
     # so unrelated triggers cannot cancel a running eval. New commits still
@@ -37,7 +40,7 @@ jobs:
       contents: read
       pull-requests: write  # the result comment
     # Full-SHA pin required by org policy — bump on docs-agent-eval releases.
-    uses: ComposioHQ/docs-agent-eval-ci/.github/workflows/eval-pr.yml@f8c0c11175dfac7371860d5d617ff402e0187dc0
+    uses: ComposioHQ/docs-agent-eval-ci/.github/workflows/eval-pr.yml@7d9833c18e0b6e18e822d3933af478261dd6541f
     with:
       pr_number: ${{ github.event.pull_request.number }}
       mode: ${{ contains(github.event.pull_request.labels.*.name, 'run-docs-tests-deep') && 'Deep' || 'Auto' }}

--- a/.github/workflows/docs-agent-eval.yml
+++ b/.github/workflows/docs-agent-eval.yml
@@ -40,9 +40,15 @@ jobs:
       contents: read
       pull-requests: write  # the result comment
     # Full-SHA pin required by org policy — bump on docs-agent-eval releases.
-    uses: ComposioHQ/docs-agent-eval-ci/.github/workflows/eval-pr.yml@7d9833c18e0b6e18e822d3933af478261dd6541f
+    uses: ComposioHQ/docs-agent-eval-ci/.github/workflows/eval-pr.yml@8917b53bd867d61aad24a1df42c6788f5987e2ff
     with:
       pr_number: ${{ github.event.pull_request.number }}
       mode: ${{ contains(github.event.pull_request.labels.*.name, 'run-docs-tests-deep') && 'Deep' || 'Auto' }}
       post_comment: true
-    secrets: inherit
+    # Explicit and minimal on purpose — inherit would hand the engine every
+    # secret this repo holds (review decision 2).
+    secrets:
+      COMPOSIO_ORG_API_KEY: ${{ secrets.COMPOSIO_ORG_API_KEY }}
+      DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/.github/workflows/docs-agent-eval.yml
+++ b/.github/workflows/docs-agent-eval.yml
@@ -11,6 +11,7 @@
 # a required status check in V1.
 #
 # Required repo/org secrets: COMPOSIO_ORG_API_KEY, DEEPSEEK_API_KEY,
+# VERCEL_PROJECT_ID,
 # VERCEL_TOKEN (see the PR description for provisioning notes).
 name: Docs Agent Eval
 
@@ -36,7 +37,7 @@ jobs:
       contents: read
       pull-requests: write  # the result comment
     # Full-SHA pin required by org policy — bump on docs-agent-eval releases.
-    uses: ComposioHQ/docs-agent-eval-ci/.github/workflows/eval-pr.yml@2fe0ec46e0ed6b50953dfb0f4f7e7bb33bf0f403
+    uses: ComposioHQ/docs-agent-eval-ci/.github/workflows/eval-pr.yml@f8c0c11175dfac7371860d5d617ff402e0187dc0
     with:
       pr_number: ${{ github.event.pull_request.number }}
       mode: ${{ contains(github.event.pull_request.labels.*.name, 'run-docs-tests-deep') && 'Deep' || 'Auto' }}

--- a/.github/workflows/docs-agent-eval.yml
+++ b/.github/workflows/docs-agent-eval.yml
@@ -128,7 +128,7 @@ jobs:
       contents: read
       pull-requests: write  # the result comment
     # Full-SHA pin required by org policy — bump on docs-agent-eval releases.
-    uses: ComposioHQ/docs-agent-eval-ci/.github/workflows/eval-pr.yml@da8e10f34bb24c67e150a19dbe013d718dc69902
+    uses: ComposioHQ/docs-agent-eval-ci/.github/workflows/eval-pr.yml@b1e84be08379820263bb6de3f3a207a67d4d2a65
     with:
       pr_number: ${{ needs.route.outputs.pr_number }}
       mode: ${{ needs.route.outputs.mode }}

--- a/.github/workflows/docs-agent-eval.yml
+++ b/.github/workflows/docs-agent-eval.yml
@@ -6,49 +6,135 @@
 # the proposed docs through a rewrite proxy, and the result is posted back
 # here as a PR comment. `run-docs-tests-deep` forces Deep.
 #
-# All eval logic lives in ComposioHQ/docs-agent-eval (reusable workflow) —
+# Two entry paths, so label-then-push and push-then-label both work:
+#   - deployment_status (Vercel finished a docs preview): runs if the PR
+#     already carries a run-docs-tests label.
+#   - pull_request labeled/reopened: runs if the docs preview already
+#     succeeded; otherwise skips, and the deployment_status event re-enters
+#     when the preview lands. (`synchronize` removed: new pushes surface as
+#     new deployments, so deployment_status covers them.)
+#
+# All eval logic lives in ComposioHQ/docs-agent-eval-ci (reusable workflow) —
 # see its ARCHITECTURE.md. This check is informational and must NOT be made
 # a required status check in V1.
 #
-# Required repo/org secrets: COMPOSIO_ORG_API_KEY, DEEPSEEK_API_KEY,
-# VERCEL_PROJECT_ID,
-# VERCEL_TOKEN (see the PR description for provisioning notes).
+# Required repo/org secrets: COMPOSIO_ORG_API_KEY, DEEPSEEK_API_KEY.
+# No Vercel credentials (decision 2026-08-19): the engine resolves previews
+# from GitHub's deployment records with the per-run token.
 name: Docs Agent Eval
 
 on:
   pull_request:
-    types: [labeled, synchronize, reopened]
+    types: [labeled, reopened]
+  deployment_status:
 
 jobs:
-  eval:
-    # Run when the PR carries the label — but for `labeled` events, only when
-    # the label just added is one of ours (any other label addition would
-    # otherwise cancel-and-restart an in-flight eval; Cursor Bugbot finding).
-    # Either label triggers on its own (run-docs-tests-deep standalone forces
-    # Deep); labeled events still only count when the added label is ours.
+  # Decides IF an eval should start and FOR WHICH PR. deployment_status
+  # events know the commit but not the PR (deployments attach to commits),
+  # so this job maps SHA -> open PR before any label check is possible.
+  route:
     if: |
-      (contains(github.event.pull_request.labels.*.name, 'run-docs-tests') ||
-       contains(github.event.pull_request.labels.*.name, 'run-docs-tests-deep')) &&
-      (github.event.action != 'labeled' || startsWith(github.event.label.name, 'run-docs-tests'))
-    # Job-level on purpose: a skipped job never enters the concurrency group,
-    # so unrelated triggers cannot cancel a running eval. New commits still
-    # supersede stale runs.
+      (github.event_name == 'pull_request' &&
+       (contains(github.event.pull_request.labels.*.name, 'run-docs-tests') ||
+        contains(github.event.pull_request.labels.*.name, 'run-docs-tests-deep')) &&
+      (github.event.action != 'labeled' || startsWith(github.event.label.name, 'run-docs-tests'))) ||
+      (github.event_name == 'deployment_status' &&
+       github.event.deployment_status.state == 'success' &&
+       contains(github.event.deployment_status.environment_url, '.preview.composio.dev'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      deployments: read
+      pull-requests: read
+    outputs:
+      should_run: ${{ steps.decide.outputs.should_run }}
+      pr_number: ${{ steps.decide.outputs.pr_number }}
+      mode: ${{ steps.decide.outputs.mode }}
+    steps:
+      - name: Decide whether to run, and for which PR
+        id: decide
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          pr="" assoc="" labels="" preview_ok=false
+
+          if [ "$GITHUB_EVENT_NAME" = deployment_status ]; then
+            # Trap 2: the event payload has no PR number — map commit -> PR.
+            SHA=$(jq -r .deployment.sha "$GITHUB_EVENT_PATH")
+            PRJSON=$(gh api "repos/$REPO/commits/$SHA/pulls" \
+                       --jq '[.[] | select(.state=="open")][0] // empty')
+            if [ -n "$PRJSON" ]; then
+              pr=$(jq -r .number <<<"$PRJSON")
+              assoc=$(jq -r .author_association <<<"$PRJSON")
+              labels=$(jq -r '[.labels[].name] | join(",")' <<<"$PRJSON")
+            fi
+            preview_ok=true   # this event IS the successful preview
+          else
+            pr=$(jq -r .pull_request.number "$GITHUB_EVENT_PATH")
+            assoc=$(jq -r .pull_request.author_association "$GITHUB_EVENT_PATH")
+            labels=$(jq -r '[.pull_request.labels[].name] | join(",")' "$GITHUB_EVENT_PATH")
+            SHA=$(jq -r .pull_request.head.sha "$GITHUB_EVENT_PATH")
+            # Trap 1: label may predate the preview. Only run now if a docs
+            # preview already succeeded for this exact commit; otherwise skip
+            # — the deployment_status event re-enters when the preview lands.
+            for d in $(gh api "repos/$REPO/deployments?sha=$SHA&per_page=10" --jq '.[].id'); do
+              URL=$(gh api "repos/$REPO/deployments/$d/statuses" \
+                      --jq '[.[] | select(.state=="success")][0].environment_url // empty')
+              case "$URL" in
+                https://docs-*.preview.composio.dev*) preview_ok=true; break ;;
+              esac
+            done
+          fi
+
+          haslabel=false
+          case ",$labels," in
+            *,run-docs-tests,*|*,run-docs-tests-deep,*) haslabel=true ;;
+          esac
+
+          # Employee gate: PR author must be org-affiliated (public repo).
+          trusted=false
+          case "$assoc" in MEMBER|OWNER|COLLABORATOR) trusted=true ;; esac
+
+          mode=Auto
+          case ",$labels," in *,run-docs-tests-deep,*) mode=Deep ;; esac
+
+          should=false
+          if [ -n "$pr" ] && $haslabel && $trusted && $preview_ok; then
+            should=true
+          fi
+          echo "event=$GITHUB_EVENT_NAME pr=${pr:-none} labels=[$labels] assoc=${assoc:-none} preview_ok=$preview_ok -> should_run=$should"
+
+          {
+            echo "should_run=$should"
+            echo "pr_number=$pr"
+            echo "mode=$mode"
+          } >> "$GITHUB_OUTPUT"
+
+  eval:
+    needs: route
+    if: needs.route.outputs.should_run == 'true'
+    # Concurrency here, after routing: a skipped/filtered event never enters
+    # the group, so unrelated triggers cannot cancel a running eval. A newer
+    # run for the same PR (new preview, re-label) still supersedes the stale
+    # one.
     concurrency:
-      group: docs-agent-eval-pr-${{ github.event.pull_request.number }}
+      group: docs-agent-eval-pr-${{ needs.route.outputs.pr_number }}
       cancel-in-progress: true
     permissions:
       contents: read
       pull-requests: write  # the result comment
     # Full-SHA pin required by org policy — bump on docs-agent-eval releases.
-    uses: ComposioHQ/docs-agent-eval-ci/.github/workflows/eval-pr.yml@48e1a1d2f8baf12a7a073b8141afede3baee94f7
+    uses: ComposioHQ/docs-agent-eval-ci/.github/workflows/eval-pr.yml@2a831429ee6d8be6b9b4526f78bf5a451881cf8f
     with:
-      pr_number: ${{ github.event.pull_request.number }}
-      mode: ${{ contains(github.event.pull_request.labels.*.name, 'run-docs-tests-deep') && 'Deep' || 'Auto' }}
+      pr_number: ${{ needs.route.outputs.pr_number }}
+      mode: ${{ needs.route.outputs.mode }}
       post_comment: true
     # Explicit and minimal on purpose — inherit would hand the engine every
     # secret this repo holds (review decision 2).
     secrets:
       COMPOSIO_ORG_API_KEY: ${{ secrets.COMPOSIO_ORG_API_KEY }}
       DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
-      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/.github/workflows/docs-agent-eval.yml
+++ b/.github/workflows/docs-agent-eval.yml
@@ -1,0 +1,37 @@
+# Docs Agent Eval — label-triggered CI check (V1, informational)
+#
+# Add the `run-docs-tests` label to a docs PR to run an agent-buildability
+# eval against the PR's Vercel docs preview: a deterministic router picks
+# no-eval / Smoke (1 agent) / Deep (5 agents), fresh isolated agents follow
+# the proposed docs through a rewrite proxy, and the result is posted back
+# here as a PR comment. `run-docs-tests-deep` forces Deep.
+#
+# All eval logic lives in ComposioHQ/docs-agent-eval (reusable workflow) —
+# see its ARCHITECTURE.md. This check is informational and must NOT be made
+# a required status check in V1.
+#
+# Required repo/org secrets: COMPOSIO_ORG_API_KEY, DEEPSEEK_API_KEY,
+# VERCEL_TOKEN (see the PR description for provisioning notes).
+name: Docs Agent Eval
+
+on:
+  pull_request:
+    types: [labeled, synchronize, reopened]
+
+concurrency:
+  group: docs-agent-eval-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true  # newest commit wins; stale evals are superseded
+
+jobs:
+  eval:
+    if: contains(github.event.pull_request.labels.*.name, 'run-docs-tests')
+    permissions:
+      contents: read
+      pull-requests: write  # the result comment
+    # Full-SHA pin required by org policy — bump on docs-agent-eval releases.
+    uses: ComposioHQ/docs-agent-eval/.github/workflows/eval-pr.yml@88dec5bf58d3f77b598c03eec0e6a0c587a57554
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+      mode: ${{ contains(github.event.pull_request.labels.*.name, 'run-docs-tests-deep') && 'Deep' || 'Auto' }}
+      post_comment: true
+    secrets: inherit

--- a/.github/workflows/docs-agent-eval.yml
+++ b/.github/workflows/docs-agent-eval.yml
@@ -10,23 +10,27 @@
 #   - deployment_status (Vercel finished a docs preview): runs if the PR
 #     already carries a run-docs-tests label.
 #   - pull_request labeled/reopened: runs if the docs preview already
-#     succeeded; otherwise skips, and the deployment_status event re-enters
-#     when the preview lands. (`synchronize` removed: new pushes surface as
-#     new deployments, so deployment_status covers them.)
+#     succeeded; otherwise skips, and the deployment_status event re-enters.
 #
-# All eval logic lives in ComposioHQ/docs-agent-eval-ci (reusable workflow) —
-# see its ARCHITECTURE.md. This check is informational and must NOT be made
-# a required status check in V1.
+# The eval logic lives in the PRIVATE repo ComposioHQ/docs-agent-eval-ci.
+# A public repo cannot `uses:` a private repo's reusable workflow, so instead
+# a GitHub App token checks that repo out and this job runs it inline. See its
+# ARCHITECTURE.md. Informational check — must NOT be a required status in V1.
 #
-# Required repo/org secrets: COMPOSIO_ORG_API_KEY, DEEPSEEK_API_KEY.
-# No Vercel credentials (decision 2026-08-19): the engine resolves previews
-# from GitHub's deployment records with the per-run token.
+# Required repo/org secrets: COMPOSIO_ORG_API_KEY, DEEPSEEK_API_KEY,
+# DOCS_EVAL_APP_ID, DOCS_EVAL_APP_PRIVATE_KEY (GitHub App that can read the
+# private engine repo).
 name: Docs Agent Eval
 
 on:
   pull_request:
     types: [labeled, reopened]
   deployment_status:
+
+env:
+  ENGINE_REPO: ComposioHQ/docs-agent-eval-ci
+  # Full-SHA pin of the engine code — bump on docs-agent-eval-ci releases.
+  ENGINE_REF: d299de8061151997548a3650e13ebfc63c03d08f
 
 jobs:
   # Decides IF an eval should start and FOR WHICH PR. deployment_status
@@ -114,27 +118,158 @@ jobs:
             echo "mode=$mode"
           } >> "$GITHUB_OUTPUT"
 
+  # Runs the eval inline: mint an App token, check out the private engine with
+  # it, then run the engine's code on this runner. (A public repo can't `uses:`
+  # a private reusable workflow, so the App token + checkout replaces it.)
   eval:
     needs: route
     if: needs.route.outputs.should_run == 'true'
-    # Concurrency here, after routing: a skipped/filtered event never enters
-    # the group, so unrelated triggers cannot cancel a running eval. A newer
-    # run for the same PR (new preview, re-label) still supersedes the stale
-    # one.
     concurrency:
       group: docs-agent-eval-pr-${{ needs.route.outputs.pr_number }}
       cancel-in-progress: true
+    runs-on: ubuntu-latest
+    timeout-minutes: 55
     permissions:
       contents: read
-      pull-requests: write  # the result comment
-    # Full-SHA pin required by org policy — bump on docs-agent-eval releases.
-    uses: ComposioHQ/docs-agent-eval-ci/.github/workflows/eval-pr.yml@21146fbe43e6d6eb0db4b46ef9b09faab6110edd
-    with:
-      pr_number: ${{ needs.route.outputs.pr_number }}
-      mode: ${{ needs.route.outputs.mode }}
-      post_comment: true
-    # Explicit and minimal on purpose — inherit would hand the engine every
-    # secret this repo holds (review decision 2).
-    secrets:
+      deployments: read
+      pull-requests: write   # the result comment (posted with the built-in token)
+    env:
+      SOURCE_REPO: ${{ github.repository }}
+      PR_NUMBER: ${{ needs.route.outputs.pr_number }}
+      MODE: ${{ needs.route.outputs.mode }}
       COMPOSIO_ORG_API_KEY: ${{ secrets.COMPOSIO_ORG_API_KEY }}
-      DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+      # Builder runs on DeepSeek V4 Flash via the Anthropic-compatible endpoint.
+      ANTHROPIC_BASE_URL: https://api.deepseek.com/anthropic
+      ANTHROPIC_AUTH_TOKEN: ${{ secrets.DEEPSEEK_API_KEY }}
+      DEEP_RUNS: '5'
+      POST_PR_COMMENT: 'true'
+    steps:
+      - name: Mint a GitHub App token (read the private engine repo)
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.DOCS_EVAL_APP_ID }}
+          private-key: ${{ secrets.DOCS_EVAL_APP_PRIVATE_KEY }}
+          owner: ComposioHQ
+          repositories: docs-agent-eval-ci
+
+      - name: Check out the private engine
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          repository: ${{ env.ENGINE_REPO }}
+          ref: ${{ env.ENGINE_REF }}
+          token: ${{ steps.app-token.outputs.token }}
+          path: engine
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: engine/ci/requirements.txt
+
+      - name: Install harness dependencies
+        working-directory: engine
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r ci/requirements.txt
+
+      - name: Cache npm downloads
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.npm
+          key: npm-claude-code-${{ runner.os }}
+
+      - name: Install Claude Code
+        run: npm install --global @anthropic-ai/claude-code
+
+      - name: Validate required credentials
+        shell: bash
+        run: |
+          test -n "$COMPOSIO_ORG_API_KEY" || { echo "COMPOSIO_ORG_API_KEY is not configured"; exit 1; }
+          test -n "$ANTHROPIC_AUTH_TOKEN" || { echo "DEEPSEEK_API_KEY is not configured"; exit 1; }
+
+      - name: Route (deterministic no-eval / Smoke / Deep)
+        id: extent
+        working-directory: engine
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p ci-output
+          python ci/route_pr.py --repo "$SOURCE_REPO" --pr "$PR_NUMBER" > ci-output/route.json
+          cat ci-output/route.json
+          EXTENT=$(python -c 'import json; print(json.load(open("ci-output/route.json"))["validation_extent"])')
+          HEAD=$(python -c 'import json; print(json.load(open("ci-output/route.json"))["head_sha"])')
+          # run-docs-tests-deep forces Deep regardless of the router.
+          [ "$MODE" = Deep ] && EXTENT=deep
+          echo "extent=$EXTENT" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$HEAD" >> "$GITHUB_OUTPUT"
+
+      - name: Record no-eval outcome
+        if: steps.extent.outputs.extent == 'none'
+        working-directory: engine
+        shell: bash
+        run: |
+          python - <<'EOF'
+          import json
+          route = json.load(open("ci-output/route.json"))
+          json.dump({"status": "NO_EVAL", "reasons": route["reasons"]}, open("ci-output/outcome.json", "w"), indent=2)
+          lines = "\n".join(f"- {r}" for r in route["reasons"])
+          open("ci-output/comment.md", "w").write(
+              f"## Docs Agent Eval — ✓ NOT APPLICABLE\n\nNo agent-impacting docs change detected; no eval run.\n\n{lines}\n")
+          EOF
+
+      - name: Run exact-HEAD docs agent eval
+        if: steps.extent.outputs.extent != 'none'
+        continue-on-error: true
+        working-directory: engine
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          RUNMODE=Smoke
+          [ '${{ steps.extent.outputs.extent }}' = deep ] && RUNMODE=Deep
+          python ci/run_full_eval.py \
+            --repo "$SOURCE_REPO" \
+            --head-sha '${{ steps.extent.outputs.head_sha }}' \
+            --mode "$RUNMODE"
+
+      - name: Upload eval artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: docs-agent-eval-artifacts
+          path: engine/ci-output/
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Publish job summary
+        if: always()
+        working-directory: engine
+        shell: bash
+        run: |
+          if [ -f ci-output/comment.md ]; then
+            cat ci-output/comment.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo '## Docs Agent Eval — ✕ ERROR' >> "$GITHUB_STEP_SUMMARY"
+            echo 'The CI spine failed before it could produce a report.' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Post result comment on the PR
+        if: always()
+        working-directory: engine
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          test -f ci-output/comment.md || exit 0
+          gh pr comment "$PR_NUMBER" --repo "$SOURCE_REPO" --body-file ci-output/comment.md
+
+      - name: Set check result
+        if: always()
+        working-directory: engine
+        shell: bash
+        run: |
+          test -f ci-output/outcome.json || exit 1
+          STATUS=$(python -c 'import json; print(json.load(open("ci-output/outcome.json"))["status"])')
+          test "$STATUS" = PASS || test "$STATUS" = NO_EVAL


### PR DESCRIPTION
## What this adds

A **label-triggered, non-blocking CI check** that tests whether a docs PR's proposed content can still guide a fresh coding agent to working Composio code — before merge, against the PR's own Vercel preview.

Add the **`run-docs-tests`** label to a docs PR →
1. A **route job** decides if and for which PR to run: label present + PR author is an org member/collaborator. Two entry paths so either order works — label added after the preview built (`pull_request` events), or preview built after the label (`deployment_status` events, which also cover new pushes; `synchronize` is deliberately not used).
2. A deterministic router classifies the change: **no-eval** (assets only) / **Smoke** (1 agent) / **Deep** (5 agents — auth, install, env-var, code-sample, endpoint, or navigation changes). `run-docs-tests-deep` forces Deep.
3. The PR's exact-HEAD preview URL is resolved from **GitHub's deployment records** (written by the Vercel↔GitHub integration, read with the per-run `GITHUB_TOKEN`) — **no Vercel credentials anywhere** (decision 2026-08-19). Isolated agents get it served through a rewrite proxy — they believe they're on docs.composio.dev.
4. Each agent (fresh env, ephemeral Composio project, torn down after) attempts the weather-toolkit task by following the docs.
5. An **independent judge** verdicts every run before teardown — re-executes the agent's script with the run's live key and scans for the v1 anti-patterns (hardcoded slugs, legacy packages, manual execution, /examples cheating). The agent's own success claim is recorded but never trusted; the PR comment shows L1·L2·L3 per run and any judge-overruled self-reports.
6. Result lands here as a PR comment: **PASS / FAIL / ERROR**, run counts, teardown status, and the agents' own docs-friction feedback. New pushes supersede stale runs (`cancel-in-progress`).

**This file is a router + one SHA-pinned call** — all eval logic lives in [ComposioHQ/docs-agent-eval-ci](https://github.com/ComposioHQ/docs-agent-eval-ci) (reusable workflow, SHA-pinned per org policy). See its [ARCHITECTURE.md](https://github.com/ComposioHQ/docs-agent-eval-ci/blob/main/ARCHITECTURE.md) for the full component map and design-spec compliance audit.

## Evidence it works (sandbox runs)

- End-to-end green Smoke, auto-routed: [run](https://github.com/ComposioHQ/docs-agent-eval-ci/actions/runs/32056739696) (PR #4125 → smoke → PASS 1/1)
- End-to-end green Deep, auto-routed: [run](https://github.com/ComposioHQ/docs-agent-eval-ci/actions/runs/32057336110) (PR #4136 → deep via auth-docs signal → PASS 5/5, incl. agent feedback reproducing known docs findings)
- The exact `workflow_call` mechanism this shim uses: [run](https://github.com/ComposioHQ/docs-agent-eval-ci/actions/runs/32059660256)
- Receipts-based preview resolution live-verified on PR #4174 (exact-SHA → snapshot URL); fork PRs (no Vercel build) correctly produce the explained no-preview ERROR path
- Builder (DeepSeek V4 Flash) calibrated 16/16 against production docs before any CI verdicts

## ⚠️ Before merge (repo admin)

1. ~~Secrets~~ **Done 2026-08-19**: `COMPOSIO_ORG_API_KEY` + `DEEPSEEK_API_KEY` exist in this repo's Actions secrets. (`VERCEL_TOKEN` is no longer needed — removed from the design.) Team-owned replacements for the individually-owned keys remain part of the rollout (current owner offboards Aug 31).
2. **Engine repo visibility**: `docs-agent-eval-ci` is currently *internal*; a public repo cannot call an internal reusable workflow, so it must be flipped public (pre-publication scrub done) **before** this merges.
3. **Pin bump**: after the engine's `no-vercel-credentials` PR merges, the `uses:` SHA here gets re-pinned to the engine's merge commit.

Labels `run-docs-tests` / `run-docs-tests-deep` are already created.

## Non-goals (V1)

Informational only — **do not mark this check required**. No merge blocking, no statistical thresholds, no LLM routing; scenario is the weather-toolkit eval only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## Update 2026-08-21: keep the engine PRIVATE via a GitHub App

Design change (Sarah): the engine repo stays **private** instead of going public. A public repo can't `uses:` a private repo's reusable workflow, so the `eval` job now runs the engine **inline**:

1. mints a short-lived **GitHub App token** (`actions/create-github-app-token`, SHA-pinned) scoped read-only to `docs-agent-eval-ci`
2. checks the private engine out with it (`path: engine/`)
3. runs the engine on the runner (`route_pr.py` → `run_full_eval.py`); result comment + check status still posted with composio's built-in `GITHUB_TOKEN`

**⚠️ This supersedes the earlier public-reusable-workflow design in this PR — needs a fresh review of the `eval` job.**

New repo secrets required (added): `DOCS_EVAL_APP_ID`, `DOCS_EVAL_APP_PRIVATE_KEY`, plus existing `COMPOSIO_ORG_API_KEY`, `DEEPSEEK_API_KEY`. No Vercel credentials.

Before this can be tested: the GitHub App must be **installed** on ComposioHQ with **Contents: Read** on `docs-agent-eval-ci`. Since the check only fires from the default branch, testing happens after this merges (informational check, non-blocking, safe to merge to test).
