### PR TITLE
Normalizing Python proxy execute responses to match the TypeScript SDK

### DIFF
--- a/python/composio/core/models/custom_tool_types.py
+++ b/python/composio/core/models/custom_tool_types.py
@@ -15,9 +15,6 @@ from pydantic import BaseModel
 from composio_client.types.tool_router.session_execute_response import (
     SessionExecuteResponse,
 )
-from composio_client.types.tool_router.session_proxy_execute_response import (
-    SessionProxyExecuteResponse,
-)
 
 from composio.utils.safe_path import SAFE_COMPONENT_REGEX
 
@@ -27,6 +24,21 @@ from composio.utils.safe_path import SAFE_COMPONENT_REGEX
 
 LOCAL_TOOL_PREFIX = "LOCAL_"
 MAX_SLUG_LENGTH = 60
+
+
+class NormalizedProxyExecuteResponse(te.TypedDict):
+    """SDK-facing proxy execute response shape.
+
+    Mirrors the TypeScript SDK's ``ToolRouterSessionProxyExecuteResponse``:
+    ``binary_data`` (snake_case) is projected to ``binaryData`` (camelCase)
+    with ``content_type`` -> ``contentType`` and ``expires_at`` -> ``expiresAt``.
+    ``data``, ``headers``, and ``status`` are passed through unchanged.
+    """
+
+    status: int
+    data: t.Any
+    headers: t.Optional[t.Dict[str, str]]
+    binaryData: t.NotRequired[t.Dict[str, t.Any]]
 
 SLUG_REGEX = SAFE_COMPONENT_REGEX
 """Alias of the canonical pattern in :mod:`composio.utils.safe_path`.
@@ -87,10 +99,10 @@ class SessionContext(te.Protocol):
         method: t.Literal["GET", "POST", "PUT", "DELETE", "PATCH"],
         body: t.Any = None,
         parameters: t.Optional[t.List[t.Dict[str, t.Any]]] = None,
-    ) -> SessionProxyExecuteResponse:
+    ) -> NormalizedProxyExecuteResponse:
         """Proxy API calls through Composio's auth layer.
 
-        Returns the same response model as ``session.proxy_execute()``.
+        Returns the same normalized response shape as ``session.proxy_execute()``.
         """
         ...
 

--- a/python/composio/core/models/session_context.py
+++ b/python/composio/core/models/session_context.py
@@ -24,6 +24,7 @@ from composio.core.models.custom_tool_execution import (
 from composio.core.models.custom_tool_types import (
     CustomToolsMap,
     InlineCustomToolsWirePayload,
+    NormalizedProxyExecuteResponse,
 )
 from composio.core.models.inline_custom_tools_payload import (
     inline_custom_tools_execute_experimental,
@@ -34,6 +35,36 @@ from composio.exceptions import ValidationError
 
 _VALID_METHODS = frozenset({"GET", "POST", "PUT", "DELETE", "PATCH"})
 _VALID_PARAM_TYPES = frozenset({"header", "query"})
+
+
+def normalize_proxy_execute_response(
+    response: SessionProxyExecuteResponse,
+) -> NormalizedProxyExecuteResponse:
+    """Normalize a raw proxy execute response into the SDK-facing shape.
+
+    Mirrors the TypeScript SDK's ``proxyExecute`` normalization:
+
+    - ``binary_data`` (snake_case) is projected to ``binaryData`` (camelCase)
+      with ``content_type`` -> ``contentType``, ``expires_at`` -> ``expiresAt``.
+    - ``data``, ``headers``, and ``status`` are passed through unchanged.
+
+    :param response: A ``SessionProxyExecuteResponse`` from the generated client.
+    :return: A normalized response dict matching the cross-SDK contract.
+    """
+    binary_data = getattr(response, "binary_data", None)
+    result: NormalizedProxyExecuteResponse = {
+        "status": response.status,
+        "data": response.data,
+        "headers": response.headers,
+    }
+    if binary_data is not None:
+        result["binaryData"] = {
+            "contentType": binary_data.content_type,
+            "size": binary_data.size,
+            "url": binary_data.url,
+            "expiresAt": binary_data.expires_at,
+        }
+    return result
 
 
 def proxy_execute_impl(
@@ -159,12 +190,12 @@ class SessionContextImpl:
         method: t.Literal["GET", "POST", "PUT", "DELETE", "PATCH"],
         body: t.Any = None,
         parameters: t.Optional[t.List[t.Dict[str, t.Any]]] = None,
-    ) -> SessionProxyExecuteResponse:
+    ) -> NormalizedProxyExecuteResponse:
         """Proxy API calls through Composio's auth layer.
 
-        Returns the same response model as ``session.proxy_execute()``.
+        Returns the same response shape as ``session.proxy_execute()``.
         """
-        return proxy_execute_impl(
+        response = proxy_execute_impl(
             self._client,
             self._session_id,
             toolkit=toolkit,
@@ -173,3 +204,4 @@ class SessionContextImpl:
             body=body,
             parameters=parameters,
         )
+        return normalize_proxy_execute_response(response)

--- a/python/composio/core/models/tool_router_session.py
+++ b/python/composio/core/models/tool_router_session.py
@@ -23,9 +23,6 @@ from composio_client.types.tool_router import session_link_params, session_patch
 from composio_client.types.tool_router.session_execute_response import (
     SessionExecuteResponse,
 )
-from composio_client.types.tool_router.session_proxy_execute_response import (
-    SessionProxyExecuteResponse,
-)
 from composio_client.types.tool_router.session_search_response import (
     SessionSearchResponse,
 )
@@ -44,6 +41,7 @@ from composio.core.models.custom_tool_types import (
     CustomToolsMap,
     CustomToolsMapEntry,
     InlineCustomToolsWirePayload,
+    NormalizedProxyExecuteResponse,
     RegisteredCustomTool,
     RegisteredCustomToolkit,
 )
@@ -52,7 +50,11 @@ from composio.core.models.inline_custom_tools_payload import (
     inline_custom_tools_execute_experimental,
     inline_custom_tools_search_experimental,
 )
-from composio.core.models.session_context import SessionContextImpl, proxy_execute_impl
+from composio.core.models.session_context import (
+    SessionContextImpl,
+    normalize_proxy_execute_response,
+    proxy_execute_impl,
+)
 from composio.core.models.tool_router_session_delete import (
     ToolRouterSessionDeleteResponse,
     delete_tool_router_session,
@@ -812,7 +814,7 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
         method: t.Literal["GET", "POST", "PUT", "DELETE", "PATCH"],
         body: t.Any = None,
         parameters: t.Optional[t.List[t.Dict[str, t.Any]]] = None,
-    ) -> SessionProxyExecuteResponse:
+    ) -> NormalizedProxyExecuteResponse:
         """Proxy an API call through Composio's auth layer.
 
         :param toolkit: Composio toolkit slug (e.g. 'gmail', 'github')
@@ -820,9 +822,9 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
         :param method: HTTP method
         :param body: Request body (for POST, PUT, PATCH)
         :param parameters: Query/header parameters
-        :returns: Proxied API response
+        :returns: Normalized proxy API response
         """
-        return proxy_execute_impl(
+        response = proxy_execute_impl(
             self._client,
             self.session_id,
             toolkit=toolkit,
@@ -831,6 +833,7 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
             body=body,
             parameters=parameters,
         )
+        return normalize_proxy_execute_response(response)
 
     def update(
         self,

--- a/python/tests/test_custom_tools.py
+++ b/python/tests/test_custom_tools.py
@@ -13,15 +13,13 @@ Covers:
 """
 
 from dataclasses import replace
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 from composio_client import omit
 from composio_client.types.tool_router.session_execute_response import (
     SessionExecuteResponse,
-)
-from composio_client.types.tool_router.session_proxy_execute_response import (
-    SessionProxyExecuteResponse,
 )
 from pydantic import BaseModel, Field
 
@@ -603,17 +601,46 @@ class TestSessionContextImpl:
 
     def test_proxy_execute(self):
         mock_client = MagicMock()
-        mock_client.tool_router.session.proxy_execute.return_value = (
-            SessionProxyExecuteResponse(
-                status=200, data={"ok": True}, headers={}, binary_data=None
-            )
+        mock_client.tool_router.session.proxy_execute.return_value = SimpleNamespace(
+            status=200,
+            data={"ok": True},
+            headers={},
+            binary_data=None,
         )
         ctx = SessionContextImpl(client=mock_client, user_id="u", session_id="s")
         result = ctx.proxy_execute(
             toolkit="gmail", endpoint="https://example.com", method="GET"
         )
-        assert isinstance(result, SessionProxyExecuteResponse)
-        assert result.status == 200
+        assert result == {"status": 200, "data": {"ok": True}, "headers": {}}
+
+    def test_proxy_execute_projects_binary_data(self):
+        mock_client = MagicMock()
+        mock_client.tool_router.session.proxy_execute.return_value = SimpleNamespace(
+            status=200,
+            data={"ok": True},
+            headers={"content-type": "application/pdf"},
+            binary_data=SimpleNamespace(
+                content_type="application/pdf",
+                size=123,
+                url="https://example.com/file.pdf",
+                expires_at="2026-08-18T00:00:00Z",
+            ),
+        )
+        ctx = SessionContextImpl(client=mock_client, user_id="u", session_id="s")
+        result = ctx.proxy_execute(
+            toolkit="gmail", endpoint="https://example.com", method="GET"
+        )
+        assert result == {
+            "status": 200,
+            "data": {"ok": True},
+            "headers": {"content-type": "application/pdf"},
+            "binaryData": {
+                "contentType": "application/pdf",
+                "size": 123,
+                "url": "https://example.com/file.pdf",
+                "expiresAt": "2026-08-18T00:00:00Z",
+            },
+        }
 
 
 # ────────────────────────────────────────────────────────────────
@@ -702,17 +729,44 @@ class TestToolRouterSessionCustomTools:
         assert call_args.kwargs["experimental"] == inline_payload
 
     def test_proxy_execute(self, mock_session_deps):
-        mock_session_deps[
-            "client"
-        ].tool_router.session.proxy_execute.return_value = SessionProxyExecuteResponse(
-            status=200, data={"ok": True}, headers={}, binary_data=None
+        mock_session_deps["client"].tool_router.session.proxy_execute.return_value = (
+            SimpleNamespace(status=200, data={"ok": True}, headers={}, binary_data=None)
         )
         s = _session(mock_session_deps)
         result = s.proxy_execute(
             toolkit="gmail", endpoint="https://example.com", method="GET"
         )
-        assert isinstance(result, SessionProxyExecuteResponse)
-        assert result.status == 200
+        assert result == {"status": 200, "data": {"ok": True}, "headers": {}}
+
+    def test_proxy_execute_projects_binary_data(self, mock_session_deps):
+        mock_session_deps["client"].tool_router.session.proxy_execute.return_value = (
+            SimpleNamespace(
+                status=200,
+                data={"ok": True},
+                headers={"content-type": "application/pdf"},
+                binary_data=SimpleNamespace(
+                    content_type="application/pdf",
+                    size=123,
+                    url="https://example.com/file.pdf",
+                    expires_at="2026-08-18T00:00:00Z",
+                ),
+            )
+        )
+        s = _session(mock_session_deps)
+        result = s.proxy_execute(
+            toolkit="gmail", endpoint="https://example.com", method="GET"
+        )
+        assert result == {
+            "status": 200,
+            "data": {"ok": True},
+            "headers": {"content-type": "application/pdf"},
+            "binaryData": {
+                "contentType": "application/pdf",
+                "size": 123,
+                "url": "https://example.com/file.pdf",
+                "expiresAt": "2026-08-18T00:00:00Z",
+            },
+        }
 
     def test_custom_tools_list(self, mock_session_deps):
         s = _session(mock_session_deps)


### PR DESCRIPTION
## Summary
Align Python tool-router proxy responses with the TypeScript SDK so both SDKs expose the same public response shape at the boundary.

The Python session proxy path was still returning the generated client model more directly, while TypeScript already normalizes `binary_data` into `binaryData`. This change removes that cross-SDK inconsistency and makes proxy/file responses easier to consume without language-specific branching.

Fixes #

## Changes
- Added a shared Python proxy response type that exposes the normalized SDK-facing shape.
- Normalized `SessionContextImpl.proxy_execute()` and `ToolRouterSession.proxy_execute()` to return `binaryData` in camelCase, matching TypeScript.
- Kept the internal wire response unchanged and applied normalization only at the public SDK boundary.
- Updated Python regression tests to cover plain proxy responses and binary proxy responses for both session entry points.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [ ] Documentation
- [ ] Breaking change

## How Has This Been Tested?
Ran the focused Python regression suite:

```bash
cd python
$env:UV_CACHE_DIR='\composio\.uv-cache'; uv run pytest tests/test_custom_tools.py -q
```

Result:
- `67 passed`

Environment notes:
- Python test deps were resolved through `uv`
- The run was validated on the local workspace copy

## Screenshots (if applicable)

## Checklist
- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed
- [x] I updated documentation as needed
- [x] I added tests or explain why not applicable
- [ ] I added a changeset if this change affects published packages

## Additional context
This is a Python-side parity fix only. I did not add a changeset because the repo guidance reserves changesets for published TypeScript package changes, and this change does not modify published TS packages.


**Problem Statement**

Python and TypeScript do not present the same public shape for tool-router proxy responses. In TypeScript, proxy execution already normalizes `binary_data` into a stable `binaryData` field at the SDK boundary. In Python, the session-level proxy path was still exposing the raw generated client model more directly.

That matters because consumers of the two SDKs should not have to write different handling code for the same operation. If one SDK returns a normalized `binaryData` object and the other returns the backend’s snake_case payload, the abstraction leaks immediately.

**Why this needs to exist**

- It removes a cross-SDK inconsistency in a public API surface.
- It prevents downstream code from special-casing Python vs TypeScript.
- It makes file and binary proxy responses safer and easier to consume.
- It reduces the chance of silent breakage when a backend response includes binary metadata.
- It keeps the SDK contract predictable at the point where users actually touch the data.

**The real user pain it avoids**

Without this normalization, a user can write code that works in TS and then fails or branches awkwardly in Python when they access proxy responses. That creates avoidable support churn, harder docs, and a “same SDK, different behavior” problem that erodes trust.

**In one sentence**

This fix exists to make `proxyExecute()` feel like one Composio API across both languages, instead of two slightly different wrappers around the same backend response.

This PR aligns the Python tool-router proxy execution surface with the TypeScript SDK by normalizing the proxy response shape at the SDK boundary.