### PR TITLE
fix(py): handle toolkitless tools in modifiers

### DIFF
--- a/python/composio/core/models/tools.py
+++ b/python/composio/core/models/tools.py
@@ -46,6 +46,10 @@ from ._modifiers import (
 TOOL_ROUTER_SESSION_TOOLS_PAGE_LIMIT = 500
 
 
+def _toolkit_slug(tool: Tool, fallback: str = "unknown") -> str:
+    return tool.toolkit.slug if tool.toolkit else fallback
+
+
 def _needs_serialization(obj: t.Any) -> bool:
     """Check if an object contains any Pydantic model instances."""
     if isinstance(obj, PydanticBaseModel):
@@ -285,7 +289,7 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
                     Tool,
                     apply_modifier_by_type(
                         modifiers=modifiers,
-                        toolkit=tool.toolkit.slug,
+                        toolkit=_toolkit_slug(tool),
                         tool=tool.slug,
                         type="schema",
                         schema=tool,
@@ -322,7 +326,7 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
             tools_list = [
                 apply_modifier_by_type(
                     modifiers=modifiers,
-                    toolkit=tool.toolkit.slug,
+                    toolkit=_toolkit_slug(tool),
                     tool=tool.slug,
                     type="schema",
                     schema=tool,
@@ -479,11 +483,10 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
                 self._tool_schemas[slug] = tool
 
             if self._auto_upload_download_files:
-                meta_tk = tool.toolkit.slug if tool.toolkit else "composio"
                 bfu = merge_before_file_upload(
                     modifiers,
                     tool=slug,
-                    toolkit=meta_tk,
+                    toolkit=_toolkit_slug(tool, fallback="composio"),
                 )
                 arguments = self._file_helper.substitute_file_uploads(
                     tool=tool,
@@ -491,7 +494,7 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
                     before_file_upload=bfu,
                 )
 
-            toolkit_slug = tool.toolkit.slug if tool.toolkit else "composio"
+            toolkit_slug = _toolkit_slug(tool, fallback="composio")
 
             # Apply before_execute modifiers
             processed_arguments = arguments
@@ -571,9 +574,10 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
         # If version is not explicitly provided, resolve it from instance-level toolkit versions
         # This matches the TypeScript behavior - always resolve version when None
         if version is None:
-            toolkit_slug = tool.toolkit.slug if tool.toolkit else "unknown"
             # Use instance-level toolkit versions configuration
-            version = get_toolkit_version(toolkit_slug, self._toolkit_versions)
+            version = get_toolkit_version(
+                _toolkit_slug(tool), self._toolkit_versions
+            )
 
         # Check if the version is 'latest' and dangerously_skip_version_check is not True
         # If so, raise an error to prevent unexpected behavior
@@ -647,12 +651,13 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
             )
             self._tool_schemas[slug] = tool
 
+        toolkit_slug = _toolkit_slug(tool)
+
         if self._auto_upload_download_files:
-            tk = tool.toolkit.slug if tool.toolkit else "unknown"
             bfu = merge_before_file_upload(
                 modifiers,
                 tool=slug,
-                toolkit=tk,
+                toolkit=toolkit_slug,
             )
             arguments = self._file_helper.substitute_file_uploads(
                 tool=tool,
@@ -683,7 +688,7 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
                 )
             processed_params = apply_modifier_by_type(
                 modifiers=modifiers,
-                toolkit=tool.toolkit.slug,
+                toolkit=toolkit_slug,
                 tool=slug,
                 type=type_before_exec,
                 request=request_params,
@@ -723,7 +728,7 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
         if modifiers is not None:
             response = apply_modifier_by_type(
                 modifiers=modifiers,
-                toolkit=tool.toolkit.slug,
+                toolkit=toolkit_slug,
                 tool=slug,
                 type="after_execute",
                 response=response,

--- a/python/tests/test_tool_execution.py
+++ b/python/tests/test_tool_execution.py
@@ -825,6 +825,56 @@ class TestToolExecution:
             assert result["successful"] is True
             assert result["data"]["modified"] is True
 
+    def test_execute_with_modifiers_handles_tool_without_toolkit(self):
+        """Modifier dispatch uses the unknown fallback when toolkit metadata is absent."""
+        from composio.core.models._modifiers import after_execute, before_execute
+
+        mock_client = mock_http_client()
+        mock_provider = Mock()
+        mock_provider.name = "test_provider"
+
+        tools = Tools(client=mock_client, provider=mock_provider)
+
+        toolkitless_tool = self.create_mock_tool("TOOL_WITHOUT_TOOLKIT", "github")
+        toolkitless_tool.toolkit = None
+
+        seen_toolkits = []
+
+        def before_modifier(tool, toolkit, params):
+            seen_toolkits.append((tool, toolkit, "before"))
+            params["arguments"]["touched"] = True
+            return params
+
+        def after_modifier(tool, toolkit, response):
+            seen_toolkits.append((tool, toolkit, "after"))
+            response["data"]["after"] = True
+            return response
+
+        mock_client.tools.retrieve.return_value = toolkitless_tool
+        mock_execute_response = Mock()
+        mock_execute_response.model_dump.return_value = {
+            "data": {"result": "success"},
+            "error": None,
+            "successful": True,
+        }
+        mock_client.tools.execute.return_value = mock_execute_response
+
+        result = tools.execute(
+            slug="TOOL_WITHOUT_TOOLKIT",
+            arguments={"value": "test"},
+            dangerously_skip_version_check=True,
+            modifiers=[before_execute(before_modifier), after_execute(after_modifier)],
+        )
+
+        assert result["successful"] is True
+        assert result["data"]["after"] is True
+        assert seen_toolkits == [
+            ("TOOL_WITHOUT_TOOLKIT", "unknown", "before"),
+            ("TOOL_WITHOUT_TOOLKIT", "unknown", "after"),
+        ]
+        call_args = mock_client.tools.execute.call_args
+        assert call_args.kwargs["arguments"] == {"value": "test", "touched": True}
+
     def test_merge_before_file_upload_scopes_by_tool(self):
         from composio.core.models._modifiers import (
             before_file_upload,


### PR DESCRIPTION
## Summary
Fixes #4152.

Handles tools whose toolkit metadata is missing when modifiers are configured, avoiding AttributeError crashes in schema and execution flows.

## Changes
- Added a shared toolkit slug fallback helper for tools without toolkit metadata.
- Reused the fallback in modifier dispatch, file upload handling, tool-router execution, and version resolution.
- Added a regression test covering execute() with before/after modifiers on a toolkitless tool.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [ ] Documentation
- [ ] Breaking change

## How Has This Been Tested?
- `UV_CACHE_DIR=/Users/srijavuppala/Documents/Codex/2026-08-18/wh/work/composio/.uv-cache uv run pytest tests/test_tool_execution.py -q` (35 passed)
- `UV_CACHE_DIR=/Users/srijavuppala/Documents/Codex/2026-08-18/wh/work/composio/.uv-cache uv run ruff check --select F821,F822,F823 composio/core/models/tools.py tests/test_tool_execution.py` (passed)
- `git diff --check` (passed)

## Screenshots (if applicable)
N/A

## Checklist
- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed
- [x] I updated documentation as needed (no docs change needed for this internal bugfix)
- [x] I added tests or explain why not applicable
- [x] I added a changeset if this change affects published packages (not applicable; this is a Python SDK bugfix and the contributing guide scopes changesets to published TypeScript packages)

## Additional context
The original failure path was an unguarded `tool.toolkit.slug` access while applying modifiers to a tool response that may not include toolkit metadata.