### PR TITLE
fix: refresh consumer toolkit cache before search

### DIFF
--- a/ts/packages/cli/src/commands/tools/commands/tools.search.cmd.ts
+++ b/ts/packages/cli/src/commands/tools/commands/tools.search.cmd.ts
@@ -18,7 +18,8 @@ import {
 } from 'src/services/command-project';
 import { commandHintExample, commandHintStep } from 'src/services/command-hints';
 import {
-  primeConsumerConnectedToolkitsCacheInBackground,
+  invalidateConsumerConnectedToolkitsCache,
+  refreshConsumerConnectedToolkitsCache,
   writeConsumerConnectedToolkitsCache,
 } from 'src/services/consumer-short-term-cache';
 import { appendCliSessionHistory } from 'src/services/cli-session-artifacts';
@@ -343,10 +344,12 @@ const runToolsSearch = (params: {
         projectId: resolvedProject.projectId,
       });
       if (resolvedProject.projectType === 'CONSUMER') {
-        yield* primeConsumerConnectedToolkitsCacheInBackground({
+        yield* refreshConsumerConnectedToolkitsCache({
           orgId: resolvedProject.orgId,
           consumerUserId: resolvedUserId.value,
-        });
+        }).pipe(
+          Effect.catchAll(() => invalidateConsumerConnectedToolkitsCache().pipe(Effect.ignore))
+        );
       }
       const { sessionId, localExperimentalPayload } = yield* resolveToolRouterSession(
         client,

--- a/ts/packages/cli/vitest.config.ts
+++ b/ts/packages/cli/vitest.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
       '#platform': path.join(coreDir, 'src/platform/node.ts'),
       '#files': path.join(coreDir, 'src/models/Files.node.ts'),
       '#file_tool_modifier': path.join(coreDir, 'src/utils/modifiers/FileToolModifier.node.ts'),
+      '#ssrf_guard': path.join(coreDir, 'src/utils/ssrfGuard.node.ts'),
     },
   },
   test: {


### PR DESCRIPTION
## Summary

Ensure consumer CLI search does not reuse a stale connected-toolkit cache when a custom toolkit is added from the Dashboard.

## What changed

- Refresh the consumer connected-toolkit cache synchronously before creating the Tool Router search session.
- Clear the local cache if refresh fails so session creation can fall back to the API.
- Add the missing `#ssrf_guard` Vitest alias required when tests load the workspace Core source.

## Why

The CLI does not receive a direct invalidation event from a separate Dashboard process. Refreshing immediately before search gives the CLI the current server-side toolkit set at the point where the search session is created.

## Scope

This is intentionally a CLI-only fix. No Platform code or dependency/package changes are required.

## Validation

- CLI focused search/cache tests: 27 passed.
- CLI source and test typechecks passed.
- Formatting and diff checks passed.
- Repository CI passed.

## Known audit note

The repository audit reports pre-existing advisories for `extract-zip` and `@ai-sdk/provider-utils`. No dependency bump is included here; `extract-zip` is already at npm latest `2.0.1`, while the advisory names `>=2.0.2` and npm currently has no such release.