### PR TITLE
fix(py): normalize toolkit-less tool metadata

### DIFF
--- a/python/composio/core/models/tools.py
+++ b/python/composio/core/models/tools.py
@@ -319,7 +319,7 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
                     Tool,
                     apply_modifier_by_type(
                         modifiers=modifiers,
-                        toolkit=_toolkit_slug(tool, "composio"),
+                        toolkit=_toolkit_slug(tool, "unknown"),
                         tool=tool.slug,
                         type="schema",
                         schema=tool,

--- a/python/composio/core/models/tools.py
+++ b/python/composio/core/models/tools.py
@@ -2,15 +2,17 @@ from __future__ import annotations
 
 import functools
 import typing as t
+from collections.abc import Mapping
 from pathlib import Path
 
 import typing_extensions as te
-from pydantic import BaseModel as PydanticBaseModel
 from composio_client import omit
+from pydantic import BaseModel as PydanticBaseModel
 
 from composio.client import HttpClient
 from composio.client.types import (
     Tool,
+    ToolkitMinimal,
     tool_execute_params,
     tool_proxy_params,
     tool_proxy_response,
@@ -23,8 +25,7 @@ from composio.core.models.inline_custom_tools_payload import (
 )
 from composio.core.provider import TTool, TToolCollection
 from composio.core.provider.agentic import AgenticProvider, AgenticProviderExecuteFn
-from composio.core.provider.base import ExecuteToolFn
-from composio.core.provider.base import BaseProvider
+from composio.core.provider.base import BaseProvider, ExecuteToolFn
 from composio.core.provider.none_agentic import NonAgenticProvider
 from composio.core.types import ToolkitVersionParam
 from composio.exceptions import InvalidParams, ToolVersionRequiredError
@@ -44,6 +45,35 @@ from ._modifiers import (
 )
 
 TOOL_ROUTER_SESSION_TOOLS_PAGE_LIMIT = 500
+
+
+def _normalize_tool(tool: PydanticBaseModel | Mapping[str, object]) -> Tool:
+    """Normalize generated-client responses to the SDK's tool model shape."""
+    normalized: PydanticBaseModel
+    if isinstance(tool, Mapping):
+        normalized = Tool.model_construct(_fields_set=set(tool), **dict(tool))
+    else:
+        normalized = tool
+
+    toolkit = getattr(normalized, "toolkit", None)
+    if isinstance(toolkit, Mapping):
+        normalized_toolkit = ToolkitMinimal.model_construct(
+            _fields_set=set(toolkit), **dict(toolkit)
+        )
+        normalized = normalized.model_copy(update={"toolkit": normalized_toolkit})
+
+    return t.cast(Tool, normalized)
+
+
+def _toolkit_slug(tool: Tool, fallback: str) -> str:
+    """Resolve untrusted toolkit metadata without assuming a generated shape."""
+    toolkit = getattr(tool, "toolkit", None)
+    slug = (
+        toolkit.get("slug")
+        if isinstance(toolkit, Mapping)
+        else getattr(toolkit, "slug", None)
+    )
+    return slug if isinstance(slug, str) and slug else fallback
 
 
 def _needs_serialization(obj: t.Any) -> bool:
@@ -170,8 +200,7 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
         """
         Returns schema for the given tool slug.
         """
-        return t.cast(
-            Tool,
+        return _normalize_tool(
             self._client.tools.retrieve(
                 tool_slug=slug,
                 toolkit_versions=none_to_omit(self._toolkit_versions),
@@ -215,7 +244,7 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
                     toolkit_versions=none_to_omit(self._toolkit_versions),
                 ).items
             )
-        return tools_list
+        return [_normalize_tool(tool) for tool in tools_list]
 
     def get_raw_tool_router_meta_tools(
         self,
@@ -269,12 +298,17 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
                 cursor=none_to_omit(cursor),
                 limit=TOOL_ROUTER_SESSION_TOOLS_PAGE_LIMIT,
             )
-            # Cast to Tool type - session.tools returns compatible Item type from different response schema
-            tools_list.extend(t.cast(Tool, item) for item in tools_response.items)
+            tools_list.extend(_normalize_tool(item) for item in tools_response.items)
 
             cursor = getattr(tools_response, "next_cursor", None)
             if not cursor:
                 break
+
+        self._tool_schemas.update(
+            {tool.slug: tool.model_copy(deep=True) for tool in tools_list}
+        )
+
+        tools_list = [tool.model_copy(deep=True) for tool in tools_list]
 
         # Apply schema modifiers if provided
         if modifiers is not None:
@@ -285,7 +319,7 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
                     Tool,
                     apply_modifier_by_type(
                         modifiers=modifiers,
-                        toolkit=tool.toolkit.slug,
+                        toolkit=_toolkit_slug(tool, "composio"),
                         tool=tool.slug,
                         type="schema",
                         schema=tool,
@@ -293,10 +327,6 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
                 )
                 for tool in tools_list
             ]
-
-        self._tool_schemas.update(
-            {tool.slug: tool.model_copy(deep=True) for tool in tools_list}
-        )
 
         return tools_list
 
@@ -311,28 +341,29 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
         limit: t.Optional[int] = None,
     ) -> TToolCollection:
         """Get a list of tools based on the provided filters."""
-        tools_list = self.get_raw_composio_tools(
+        raw_tools = self.get_raw_composio_tools(
             tools=tools,
             search=search,
             toolkits=toolkits,
             scopes=scopes,
             limit=limit,
         )
+        self._tool_schemas.update(
+            {tool.slug: tool.model_copy(deep=True) for tool in raw_tools}
+        )
+
+        tools_list = [tool.model_copy(deep=True) for tool in raw_tools]
         if modifiers is not None:
             tools_list = [
                 apply_modifier_by_type(
                     modifiers=modifiers,
-                    toolkit=tool.toolkit.slug,
+                    toolkit=_toolkit_slug(tool, "unknown"),
                     tool=tool.slug,
                     type="schema",
                     schema=tool,
                 )
                 for tool in tools_list
             ]
-
-        self._tool_schemas.update(
-            {tool.slug: tool.model_copy(deep=True) for tool in tools_list}
-        )
 
         # Always enhance schema descriptions (type hints and required notes)
         # regardless of dangerously_allow_auto_upload_download_files
@@ -469,17 +500,11 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
             tool = self._tool_schemas.get(slug)
 
             if tool is None:
-                tool = t.cast(
-                    Tool,
-                    self._client.tools.retrieve(
-                        tool_slug=slug,
-                        toolkit_versions=none_to_omit(self._toolkit_versions),
-                    ),
-                )
+                tool = self.get_raw_composio_tool_by_slug(slug)
                 self._tool_schemas[slug] = tool
 
             if self._auto_upload_download_files:
-                meta_tk = tool.toolkit.slug if tool.toolkit else "composio"
+                meta_tk = _toolkit_slug(tool, "composio")
                 bfu = merge_before_file_upload(
                     modifiers,
                     tool=slug,
@@ -491,7 +516,7 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
                     before_file_upload=bfu,
                 )
 
-            toolkit_slug = tool.toolkit.slug if tool.toolkit else "composio"
+            toolkit_slug = _toolkit_slug(tool, "composio")
 
             # Apply before_execute modifiers
             processed_arguments = arguments
@@ -550,6 +575,7 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
         self,
         slug: str,
         arguments: t.Dict,
+        tool: Tool,
         connected_account_id: t.Optional[str] = None,
         custom_auth_params: t.Optional[tool_execute_params.CustomAuthParams] = None,
         custom_connection_data: t.Optional[
@@ -565,13 +591,10 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
         # before sending to the API (fixes PLEN-1514: RootModel not JSON serializable)
         arguments = _serialize_arguments(arguments)
 
-        # Get the tool to determine its toolkit
-        tool = self.get_raw_composio_tool_by_slug(slug)
-
         # If version is not explicitly provided, resolve it from instance-level toolkit versions
         # This matches the TypeScript behavior - always resolve version when None
         if version is None:
-            toolkit_slug = tool.toolkit.slug if tool.toolkit else "unknown"
+            toolkit_slug = _toolkit_slug(tool, "unknown")
             # Use instance-level toolkit versions configuration
             version = get_toolkit_version(toolkit_slug, self._toolkit_versions)
 
@@ -638,17 +661,11 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
         tool = self._tool_schemas.get(slug)
 
         if tool is None:
-            tool = t.cast(
-                Tool,
-                self._client.tools.retrieve(
-                    tool_slug=slug,
-                    toolkit_versions=none_to_omit(self._toolkit_versions),
-                ),
-            )
+            tool = self.get_raw_composio_tool_by_slug(slug)
             self._tool_schemas[slug] = tool
 
         if self._auto_upload_download_files:
-            tk = tool.toolkit.slug if tool.toolkit else "unknown"
+            tk = _toolkit_slug(tool, "unknown")
             bfu = merge_before_file_upload(
                 modifiers,
                 tool=slug,
@@ -683,7 +700,7 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
                 )
             processed_params = apply_modifier_by_type(
                 modifiers=modifiers,
-                toolkit=tool.toolkit.slug,
+                toolkit=_toolkit_slug(tool, "unknown"),
                 tool=slug,
                 type=type_before_exec,
                 request=request_params,
@@ -707,6 +724,7 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
         response = self._execute_tool(
             slug=slug,
             arguments=arguments,
+            tool=tool,
             connected_account_id=connected_account_id,
             custom_auth_params=custom_auth_params,
             custom_connection_data=custom_connection_data,
@@ -723,7 +741,7 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
         if modifiers is not None:
             response = apply_modifier_by_type(
                 modifiers=modifiers,
-                toolkit=tool.toolkit.slug,
+                toolkit=_toolkit_slug(tool, "unknown"),
                 tool=slug,
                 type="after_execute",
                 response=response,

--- a/python/tests/test_no_retry_writes.py
+++ b/python/tests/test_no_retry_writes.py
@@ -145,6 +145,7 @@ class TestWritePathDoesNotRetry:
                 tools._execute_tool(
                     slug="GMAIL_SEND_EMAIL",
                     arguments={},
+                    tool=mock_tool,
                     version="1.0.0",
                 )
 

--- a/python/tests/test_tool_execution.py
+++ b/python/tests/test_tool_execution.py
@@ -4,14 +4,13 @@ import typing as t
 from unittest.mock import Mock, patch
 
 import pytest
-from pydantic import BaseModel, RootModel
 from composio_client import omit
+from pydantic import BaseModel, RootModel
 
 from composio.client.types import Tool, tool_list_response
 from composio.core.models.base import allow_tracking
-from composio.core.models.tools import Tools, _serialize_arguments, _needs_serialization
+from composio.core.models.tools import Tools, _needs_serialization, _serialize_arguments
 from composio.exceptions import ToolVersionRequiredError
-
 from tests.conftest import mock_http_client
 
 
@@ -81,6 +80,136 @@ class TestToolExecution:
             cursor="next_page",
         )
 
+    def test_tool_router_schema_modifier_handles_tool_without_toolkit(self):
+        """Tool Router metadata uses its established fallback for custom tools."""
+        from composio.core.models._modifiers import schema_modifier
+
+        mock_client = mock_http_client()
+        tools = Tools(client=mock_client, provider=Mock())
+        raw_tool = self.create_mock_tool("CUSTOM_TOOL", "custom").model_dump()
+        raw_tool.pop("toolkit")
+        mock_client.tool_router.session.tools.return_value = Mock(
+            items=[raw_tool], next_cursor=None
+        )
+        seen_toolkits = []
+
+        @schema_modifier
+        def observe_toolkit(tool, toolkit, schema):
+            seen_toolkits.append(toolkit)
+            return schema
+
+        result = tools.get_raw_tool_router_meta_tools(
+            "session_123", modifiers=[observe_toolkit]
+        )
+
+        assert [tool.slug for tool in result] == ["CUSTOM_TOOL"]
+        assert seen_toolkits == ["composio"]
+
+    def test_execute_without_toolkit_runs_modifiers_and_fetches_once(self):
+        """Toolkit-less tools execute with the same fallback used by TypeScript."""
+        from composio.core.models._modifiers import after_execute, before_execute
+
+        mock_client = mock_http_client()
+        tools = Tools(
+            client=mock_client,
+            provider=Mock(),
+            toolkit_versions={"unknown": "20250101_00"},
+        )
+        raw_tool = self.create_mock_tool("CUSTOM_TOOL", "custom").model_dump()
+        raw_tool.pop("toolkit")
+        mock_client.tools.retrieve.return_value = raw_tool
+
+        execute_response = Mock()
+        execute_response.model_dump.return_value = {
+            "data": {"value": "original"},
+            "error": None,
+            "successful": True,
+        }
+        mock_client.tools.execute.return_value = execute_response
+        seen_toolkits = []
+
+        @before_execute
+        def modify_request(tool, toolkit, params):
+            seen_toolkits.append(toolkit)
+            params["arguments"]["value"] = "modified"
+            return params
+
+        @after_execute
+        def modify_response(tool, toolkit, response):
+            seen_toolkits.append(toolkit)
+            response["data"]["modified"] = True
+            return response
+
+        result = tools.execute(
+            slug="CUSTOM_TOOL",
+            arguments={"value": "original"},
+            modifiers=[modify_request, modify_response],
+        )
+
+        assert result["data"] == {"value": "original", "modified": True}
+        assert seen_toolkits == ["unknown", "unknown"]
+        mock_client.tools.retrieve.assert_called_once()
+        mock_client.tools.execute.assert_called_once_with(
+            tool_slug="CUSTOM_TOOL",
+            arguments={"value": "modified"},
+            connected_account_id=omit,
+            custom_auth_params=omit,
+            custom_connection_data=omit,
+            user_id=omit,
+            text=omit,
+            version="20250101_00",
+        )
+
+    def test_provider_execution_uses_raw_metadata_after_schema_modifier(self):
+        """Schema presentation changes must not alter execution versioning."""
+        from composio.core.models._modifiers import schema_modifier
+
+        mock_client = mock_http_client()
+        mock_provider = Mock()
+        tools = Tools(
+            client=mock_client,
+            provider=mock_provider,
+            toolkit_versions={
+                "github": "20250101_00",
+                "renamed": "20250102_00",
+            },
+        )
+        raw_tool = self.create_mock_tool("GITHUB_GET_REPOS", "github").model_dump()
+        mock_client.tools.list.return_value = Mock(items=[raw_tool])
+        execute_response = Mock()
+        execute_response.model_dump.return_value = {
+            "data": {"result": "success"},
+            "error": None,
+            "successful": True,
+        }
+        mock_client.tools.execute.return_value = execute_response
+        wrapped = {}
+
+        def capture_tools(tools, execute_tool):
+            wrapped["tools"] = tools
+            wrapped["execute_tool"] = execute_tool
+            return tools
+
+        mock_provider.wrap_tools.side_effect = capture_tools
+
+        @schema_modifier
+        def rename_toolkit(tool, toolkit, schema):
+            schema.toolkit = tool_list_response.ItemToolkit(
+                name="Renamed", slug="renamed", logo=""
+            )
+            return schema
+
+        tools.get(
+            user_id="user_123",
+            tools=["GITHUB_GET_REPOS"],
+            modifiers=[rename_toolkit],
+        )
+        wrapped["execute_tool"]("GITHUB_GET_REPOS", {})
+
+        assert wrapped["tools"][0].toolkit.slug == "renamed"
+        mock_client.tools.retrieve.assert_not_called()
+        assert mock_client.tools.execute.call_args.kwargs["version"] == "20250101_00"
+
     def test_tool_execution_uses_toolkit_version(self):
         """Test that tool execution resolves toolkit version correctly."""
         # Mock client and provider
@@ -118,6 +247,7 @@ class TestToolExecution:
             tools._execute_tool(
                 slug="GITHUB_GET_REPOS",
                 arguments={"owner": "test", "repo": "test"},
+                tool=github_tool,
             )
 
             # Verify that the client was called with the resolved version
@@ -166,6 +296,7 @@ class TestToolExecution:
             tools._execute_tool(
                 slug="GITHUB_GET_REPOS",
                 arguments={"owner": "test", "repo": "test"},
+                tool=github_tool,
                 version="20251201_03",  # Explicit version should take precedence
             )
 
@@ -215,6 +346,7 @@ class TestToolExecution:
             tools._execute_tool(
                 slug="GITHUB_GET_REPOS",
                 arguments={"owner": "test", "repo": "test"},
+                tool=github_tool,
                 dangerously_skip_version_check=True,
             )
 
@@ -262,6 +394,7 @@ class TestToolExecution:
             tools._execute_tool(
                 slug="GITHUB_GET_REPOS",
                 arguments={"owner": "test", "repo": "test"},
+                tool=github_tool,
             )
 
             # Verify that the client was called with the global version
@@ -335,12 +468,14 @@ class TestToolExecution:
                     tools._execute_tool(
                         slug=tool_slug,
                         arguments={"test": "data"},
+                        tool=mock_tool,
                         dangerously_skip_version_check=True,
                     )
                 else:
                     tools._execute_tool(
                         slug=tool_slug,
                         arguments={"test": "data"},
+                        tool=mock_tool,
                     )
 
                 # Verify the version matches expected
@@ -1272,6 +1407,7 @@ class TestSerializeArguments:
                         Block(type="paragraph", content="Hello from composio"),
                     ],
                 },
+                tool=notion_tool,
                 dangerously_skip_version_check=True,
             )
 

--- a/python/tests/test_tool_execution.py
+++ b/python/tests/test_tool_execution.py
@@ -80,9 +80,13 @@ class TestToolExecution:
             cursor="next_page",
         )
 
-    def test_tool_router_schema_modifier_handles_tool_without_toolkit(self):
-        """Tool Router metadata uses its established fallback for custom tools."""
-        from composio.core.models._modifiers import schema_modifier
+    def test_tool_router_modifiers_handle_tool_without_toolkit(self):
+        """Tool Router modifier fallbacks match TypeScript in each phase."""
+        from composio.core.models._modifiers import (
+            after_execute,
+            before_execute,
+            schema_modifier,
+        )
 
         mock_client = mock_http_client()
         tools = Tools(client=mock_client, provider=Mock())
@@ -95,15 +99,34 @@ class TestToolExecution:
 
         @schema_modifier
         def observe_toolkit(tool, toolkit, schema):
-            seen_toolkits.append(toolkit)
+            seen_toolkits.append(("schema", toolkit))
             return schema
+
+        @before_execute
+        def observe_before_execute(tool, toolkit, params):
+            seen_toolkits.append(("before_execute", toolkit))
+            return params
+
+        @after_execute
+        def observe_after_execute(tool, toolkit, response):
+            seen_toolkits.append(("after_execute", toolkit))
+            return response
 
         result = tools.get_raw_tool_router_meta_tools(
             "session_123", modifiers=[observe_toolkit]
         )
+        mock_client.tool_router.session.execute.return_value = Mock(data={}, error=None)
+        execute = tools._wrap_execute_tool_for_tool_router(
+            "session_123", modifiers=[observe_before_execute, observe_after_execute]
+        )
+        execute("CUSTOM_TOOL", {})
 
         assert [tool.slug for tool in result] == ["CUSTOM_TOOL"]
-        assert seen_toolkits == ["composio"]
+        assert seen_toolkits == [
+            ("schema", "unknown"),
+            ("before_execute", "composio"),
+            ("after_execute", "composio"),
+        ]
 
     def test_execute_without_toolkit_runs_modifiers_and_fetches_once(self):
         """Toolkit-less tools execute with the same fallback used by TypeScript."""

--- a/ts/packages/core/test/tools/tools.test.ts
+++ b/ts/packages/core/test/tools/tools.test.ts
@@ -1488,11 +1488,12 @@ describe('Tools', () => {
         });
 
         const beforeExecute = vi.fn().mockImplementation(({ params }) => params);
+        const afterExecute = vi.fn().mockImplementation(({ result }) => result);
 
         await context.tools.executeSessionTool(
           toolSlug,
           body,
-          { beforeExecute },
+          { beforeExecute, afterExecute },
           toolWithoutToolkit as unknown as Tool
         );
 
@@ -1501,6 +1502,17 @@ describe('Tools', () => {
           toolkitSlug: 'composio',
           sessionId,
           params: { query: 'test' },
+        });
+        expect(afterExecute).toHaveBeenCalledWith({
+          toolSlug,
+          toolkitSlug: 'composio',
+          sessionId,
+          result: {
+            data: { results: true },
+            error: null,
+            successful: true,
+            logId: '123',
+          },
         });
       });
     });
@@ -2035,7 +2047,25 @@ describe('Tools', () => {
           dangerouslySkipVersionCheck: true, // Required when toolkit is undefined and version is 'latest'
         };
 
-        await tools.execute('SOME_CUSTOM_TOOL', executeParams);
+        const beforeExecute = vi.fn().mockImplementation(({ params }) => params);
+        const afterExecute = vi.fn().mockImplementation(({ result }) => result);
+
+        await tools.execute('SOME_CUSTOM_TOOL', executeParams, {
+          beforeExecute,
+          afterExecute,
+        });
+
+        expect(beforeExecute).toHaveBeenCalledWith({
+          toolSlug: 'SOME_CUSTOM_TOOL',
+          toolkitSlug: 'unknown',
+          params: executeParams,
+        });
+        expect(afterExecute).toHaveBeenCalledWith(
+          expect.objectContaining({
+            toolSlug: 'SOME_CUSTOM_TOOL',
+            toolkitSlug: 'unknown',
+          })
+        );
 
         expect(mockClient.tools.execute).toHaveBeenCalledWith(
           'COMPOSIO_TOOL',

--- a/ts/packages/core/test/tools/tools.test.ts
+++ b/ts/packages/core/test/tools/tools.test.ts
@@ -417,6 +417,26 @@ describe('Tools', () => {
         undefined
       );
     });
+
+    it('should pass unknown toolkit metadata to schema modifiers', async () => {
+      const toolWithoutToolkit = {
+        ...toolMocks.rawTool,
+        toolkit: undefined,
+      };
+      const modifySchema = vi.fn(({ schema }) => schema);
+      mockClient.toolRouter.session.tools.mockResolvedValueOnce({
+        items: [toolWithoutToolkit],
+        next_cursor: null,
+      });
+
+      await context.tools.getRawToolRouterSessionTools('session_123', { modifySchema });
+
+      expect(modifySchema).toHaveBeenCalledWith({
+        toolSlug: toolMocks.rawTool.slug,
+        toolkitSlug: 'unknown',
+        schema: expect.objectContaining({ slug: toolMocks.rawTool.slug }),
+      });
+    });
   });
 
   describe('getRawComposioToolBySlug', () => {


### PR DESCRIPTION
This PR:

- closes #4152
- normalizes model- and mapping-shaped tool responses at the Python SDK boundary
- uses `unknown` for direct/schema modifiers and `composio` for Tool Router execution, matching TypeScript
- caches the untouched fetched tool before schema modifiers so execution keeps the original toolkit version metadata
- reuses the cached tool during execution instead of retrieving the same schema twice
- adds behavior regressions for schema, before/after execution, single-fetch execution, raw metadata preservation, and TypeScript parity
- verifies the Python regressions against both the current Stainless client and `ComposioHQ/composio-client` at `605f508e`