### PR TITLE
fix(cli): ship every codex-acp binary in release archives

### DIFF
--- a/ts/packages/cli/CHANGELOG.md
+++ b/ts/packages/cli/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Patch Changes
 
+- `composio upgrade` works again from any previously released CLI. Release
+  archives had been narrowed to carry only the `codex-acp` binary their own
+  platform can run, but a CLI installed before that change verifies a downloaded
+  package against all four platforms' binaries and rejects one that is missing
+  any of them, failing with `Downloaded binary package is incomplete`. Archives
+  ship the full set again.
 - `COMPOSIO_ENVIRONMENT=staging` now opens the staging dashboard at
   `https://staging-dashboard.composio.dev/`.
 - `composio dev auth-configs create` now sends custom OAuth credentials and scopes

--- a/ts/packages/cli/scripts/_release-artifacts.ts
+++ b/ts/packages/cli/scripts/_release-artifacts.ts
@@ -68,6 +68,12 @@ export const releaseArtifactTargetFor = (
  * An archive already carries a platform-specific `composio` binary, so a
  * darwin-arm64 archive is unusable on linux-x64 no matter which codex-acp
  * binaries travel with it. Shipping foreign ones only inflates the download.
+ *
+ * Packaging deliberately does not call this yet. A CLI released before
+ * 2026-08-18 verifies a downloaded upgrade package against all four codex-acp
+ * paths, so an archive narrowed this way breaks `composio upgrade` for every
+ * client already in the field. Wire it back into `package-binaries.ts` once no
+ * supported client still performs that check.
  */
 export const archiveCompanionRelativePaths = ({
   allRelativePaths,

--- a/ts/packages/cli/scripts/package-binaries.ts
+++ b/ts/packages/cli/scripts/package-binaries.ts
@@ -25,11 +25,7 @@ import {
   collectExpectedRunCompanionAssetRelativePaths,
   RUN_COMPANION_ALL_STATIC_ASSET_RELATIVE_PATHS,
 } from '../src/services/run-companion-modules';
-import {
-  archiveCompanionRelativePaths,
-  ARTIFACT_NAMES,
-  releaseArtifactTargetFor,
-} from './_release-artifacts';
+import { ARTIFACT_NAMES } from './_release-artifacts';
 
 const BINARIES_DIR = './dist/binaries';
 const COMPANIONS_DIR = path.join(BINARIES_DIR, 'companions');
@@ -49,8 +45,7 @@ export function packageBinaries() {
     }
 
     // One packaging host produces all four archives, so `COMPANIONS_DIR` must hold
-    // every platform's codex-acp binary before packaging starts. Validate that full
-    // set up front; each archive then receives only the slice it can execute.
+    // every platform's codex-acp binary before packaging starts.
     const allCompanionRelativePaths = yield* collectExpectedRunCompanionAssetRelativePaths(
       COMPANIONS_DIR,
       { staticAssetRelativePaths: RUN_COMPANION_ALL_STATIC_ASSET_RELATIVE_PATHS }
@@ -70,13 +65,16 @@ export function packageBinaries() {
     yield* Console.log(`Packaging ${binaries.length} binaries...`);
 
     for (const binary of binaries) {
-      // An archive's `composio` binary is already platform-specific, so a foreign
-      // codex-acp binary inside it could never run. Ship only this platform's.
-      const target = yield* releaseArtifactTargetFor(binary);
-      const companionRelativePaths = archiveCompanionRelativePaths({
-        allRelativePaths: allCompanionRelativePaths,
-        target,
-      });
+      // Every archive ships every platform's codex-acp, even though its own
+      // `composio` binary can only ever execute one of them.
+      //
+      // A CLI released before 2026-08-18 verifies a downloaded upgrade package
+      // against all four codex-acp paths and refuses to install one that is
+      // missing any of them, so an archive carrying only its own binary breaks
+      // `composio upgrade` for every client already in the field. Narrowing the
+      // set is worth roughly 651 MB per archive, but it can only ship once no
+      // supported client still performs that check.
+      const companionRelativePaths = allCompanionRelativePaths;
 
       const binaryPath = path.join(BINARIES_DIR, binary);
       const zipPath = path.join(BINARIES_DIR, `${binary}.zip`);

--- a/ts/packages/cli/test/src/scripts/release-artifacts.test.ts
+++ b/ts/packages/cli/test/src/scripts/release-artifacts.test.ts
@@ -138,3 +138,30 @@ describe('archiveCompanionRelativePaths', () => {
     expect(archiveCompanionRelativePaths({ allRelativePaths: selected, target })).toEqual(selected);
   });
 });
+
+/**
+ * Packaging ships {@link RUN_COMPANION_ALL_STATIC_ASSET_RELATIVE_PATHS} into every
+ * archive rather than the narrowed slice, because a CLI released before
+ * 2026-08-18 verifies an upgrade package against all four codex-acp paths and
+ * refuses one that is missing any of them.
+ */
+describe('published archive companion coverage', () => {
+  it.each(RUN_CODEX_ACP_BINARY_TARGETS)(
+    'ships the $platform-$arch codex-acp binary in every archive',
+    codexTarget => {
+      expect(RUN_COMPANION_ALL_STATIC_ASSET_RELATIVE_PATHS).toContain(codexTarget.relativePath);
+    }
+  );
+
+  it('covers one codex-acp binary per release artifact', () => {
+    expect(codexAcpRelativePathsIn(RUN_COMPANION_ALL_STATIC_ASSET_RELATIVE_PATHS)).toHaveLength(
+      RELEASE_ARTIFACT_TARGETS.length
+    );
+  });
+
+  it('keeps the portable assets alongside them', () => {
+    expect(RUN_COMPANION_ALL_STATIC_ASSET_RELATIVE_PATHS).toEqual(
+      expect.arrayContaining([...RUN_COMPANION_SHARED_STATIC_ASSET_RELATIVE_PATHS])
+    );
+  });
+});


### PR DESCRIPTION
## Problem

`composio upgrade` fails on every CLI currently in the field, including stable `0.3.3`:

```
💥  services/UpgradeBinaryError  • Downloaded binary package is incomplete
Caused by: Missing companion module: …/extract/composio-darwin-aarch64/acp-adapters/codex/darwin-x64/codex-acp
```

`archiveCompanionRelativePaths` (added 2026-08-18 in #4134) narrows each release archive to the shared ACP assets plus only the one `codex-acp` its platform can execute. That is a sound optimisation, but it shipped writer-first: a CLI released *before* it verifies a downloaded package against `RUN_COMPANION_STATIC_ASSET_RELATIVE_PATHS` — shared assets plus **all four** codex target paths — with no parameter to relax the check, and hard-fails on any archive missing one.

Stable `0.3.3` shipped 2026-08-11, a week before that change, so the entire installed stable base is affected. Recovery today means re-running `install.sh` by hand.

Evidence:

| Archive | codex binaries shipped |
| --- | --- |
| `0.3.4-beta.351` (pre-#4134) | `darwin-arm64`, `darwin-x64`, `linux-arm64`, `linux-x64` |
| `0.4.0-beta.357` (post-#4134) | `darwin-arm64` only |

## Fix

The reader has to become tolerant before the writer narrows, and the already-installed reader cannot be patched retroactively. Packaging ships the full companion set again.

`archiveCompanionRelativePaths` stays in place with its tests, documented as deliberately uncalled. Re-wiring it into `package-binaries.ts` is a one-line change once no supported client still validates all four paths — worth roughly 651 MB per archive.

## Why CI missed it

`cli.test-installation.yml` only exercises fresh `install.sh` installs, which are unaffected: each archive is internally consistent. Nothing covers an in-place upgrade from a previously released binary. Worth closing separately — it needs a real prior-stable binary in the matrix, not a unit test.

## Verification

- `vitest run test/src/scripts/release-artifacts.test.ts` — 29 passed
- `pnpm --filter @composio/cli typecheck` — clean
- `pnpm validate:changesets` — passes (CLI is Changesets-ignored; note lands in `ts/packages/cli/CHANGELOG.md`)
- Added coverage asserting every release artifact's codex-acp binary is in the packaged set
- Final check is the archive itself: the beta cut from this branch must contain all four `acp-adapters/codex/*/codex-acp` entries, and `composio upgrade` must succeed from a pre-#4134 install

`@composio/cli@0.4.0-beta.357` should be abandoned rather than promoted.

https://claude.ai/code/session_01JkwtxPHfobZxzvAqe53x62