### PR TITLE
fix(cli): make upgrade downloads visible and half the size

### DIFF
--- a/.github/scripts/cli-release/verify-archive-companions.sh
+++ b/.github/scripts/cli-release/verify-archive-companions.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# Loud failure gate: assert one release archive carries the codex-acp layout the CLI
+# actually ships — every platform's path present, but real bytes only for the platform
+# this archive runs on.
+#
+# Both halves matter, and each guards a shipped regression:
+#
+#   - A missing path breaks `composio upgrade` for every CLI released before 2026-08-18.
+#     Those clients verify a downloaded package against all four codex-acp paths and
+#     refuse one that lacks any of them.
+#   - A populated foreign binary is ~200MB nobody unpacking this archive can execute,
+#     which is what made the upgrade download several minutes of mostly dead weight.
+#
+# The unit tests cover the packaging rules on synthetic inputs; only this gate looks at a
+# real archive, so a change to the packaging pipeline cannot quietly reintroduce either
+# state.
+#
+# Inputs (env): ARCHIVE (path to the .zip), ARTIFACT (its top-level directory),
+#               HOST_CODEX_TARGET (the one target that must carry real bytes)
+set -euo pipefail
+
+: "${ARCHIVE:?ARCHIVE is required}"
+: "${ARTIFACT:?ARTIFACT is required}"
+: "${HOST_CODEX_TARGET:?HOST_CODEX_TARGET is required}"
+
+# Keep in lock-step with RUN_CODEX_ACP_BINARY_TARGETS in
+# ts/packages/cli/src/services/run-companion-modules.ts. Adding a codex target there must
+# extend this list, or the gate stops covering it.
+codex_targets=(darwin-arm64 darwin-x64 linux-arm64 linux-x64)
+
+fail() {
+  echo "::error::$1"
+  exit 1
+}
+
+printf '%s\n' "${codex_targets[@]}" | grep -Fxq "$HOST_CODEX_TARGET" ||
+  fail "HOST_CODEX_TARGET '$HOST_CODEX_TARGET' is not a known codex target (${codex_targets[*]})"
+
+test -f "$ARCHIVE" || fail "archive not found: $ARCHIVE"
+entries="$(unzip -Z1 "$ARCHIVE")"
+
+for target in "${codex_targets[@]}"; do
+  entry="${ARTIFACT}/acp-adapters/codex/${target}/codex-acp"
+
+  grep -Fxq "$entry" <<<"$entries" ||
+    fail "missing codex-acp entry '$entry'; pre-2026-08-18 clients refuse an archive without it"
+
+  # Byte count of the entry as stored, read without extracting to disk.
+  size="$(unzip -p "$ARCHIVE" "$entry" | wc -c | tr -d '[:space:]')"
+
+  if [ "$target" = "$HOST_CODEX_TARGET" ]; then
+    [ "$size" -gt 0 ] ||
+      fail "'$entry' is this archive's own platform but is empty; the CLI cannot run an ACP sub-agent"
+    echo "ok: $target carries $size bytes (this archive's platform)"
+  else
+    [ "$size" -eq 0 ] ||
+      fail "'$entry' is a foreign platform but carries $size bytes; it can never execute here"
+    echo "ok: $target is an empty placeholder"
+  fi
+done
+
+echo "Archive companion layout verified for $ARTIFACT (host target: $HOST_CODEX_TARGET)."

--- a/.github/workflows/build-cli-binaries.yml
+++ b/.github/workflows/build-cli-binaries.yml
@@ -103,18 +103,22 @@ jobs:
             artifact: composio-linux-x64
             runner: ubuntu-latest
             local_tools_target: ''
+            codex_target: linux-x64
           - target: bun-linux-arm64
             artifact: composio-linux-aarch64
             runner: ubuntu-latest
             local_tools_target: ''
+            codex_target: linux-arm64
           - target: bun-darwin-x64
             artifact: composio-darwin-x64
             runner: macos-15-intel
             local_tools_target: ''
+            codex_target: darwin-x64
           - target: bun-darwin-arm64
             artifact: composio-darwin-aarch64
             runner: macos-15
             local_tools_target: darwin-arm64
+            codex_target: darwin-arm64
 
     steps:
       - name: Checkout
@@ -190,6 +194,14 @@ jobs:
       - name: Verify release metadata in archive
         working-directory: ts/packages/cli
         run: unzip -p dist/binaries/${{ matrix.artifact }}.zip ${{ matrix.artifact }}/release-tag.txt | grep -Fx '${{ needs.prepare.outputs.release_tag }}'
+
+      - name: Verify companion adapters in archive
+        working-directory: ts/packages/cli
+        env:
+          ARCHIVE: dist/binaries/${{ matrix.artifact }}.zip
+          ARTIFACT: ${{ matrix.artifact }}
+          HOST_CODEX_TARGET: ${{ matrix.codex_target }}
+        run: bash "${{ github.workspace }}/.github/scripts/cli-release/verify-archive-companions.sh"
 
       - name: Verify local-tool sidecars in archive
         if: matrix.local_tools_target != ''

--- a/ts/packages/cli/CHANGELOG.md
+++ b/ts/packages/cli/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ### Patch Changes
 
+- `composio upgrade` shows download progress. The archive is a few hundred
+  megabytes, and the command previously printed `Downloading...` once and then
+  said nothing for minutes, which was indistinguishable from a hang. It now
+  reports percent and transferred size as the download runs.
+- `composio upgrade` downloads roughly half as much. Release archives carried
+  all four platforms' `codex-acp` binaries, about 651 MB that the machine
+  unpacking them can never execute. Only the binary for the archive's own
+  platform is shipped now; the other three remain as empty placeholders so that
+  a CLI installed before this change still passes its upgrade verification.
 - `composio upgrade` works again from any previously released CLI. Release
   archives had been narrowed to carry only the `codex-acp` binary their own
   platform can run, but a CLI installed before that change verifies a downloaded

--- a/ts/packages/cli/CHANGELOG.md
+++ b/ts/packages/cli/CHANGELOG.md
@@ -4,18 +4,27 @@
 
 ### Patch Changes
 
+- `composio upgrade` shows download progress. The archive is a few hundred
+  megabytes, and the command previously printed `Downloading...` once and then
+  said nothing for minutes, which was indistinguishable from a hang. It now
+  reports percent and transferred size as the download runs.
+- `composio upgrade` downloads roughly half as much. Release archives carried
+  all four platforms' `codex-acp` binaries, about 651 MB that the machine
+  unpacking them can never execute. Only the binary for the archive's own
+  platform is shipped now; the other three remain as empty placeholders so that
+  a CLI installed before this change still passes its upgrade verification.
+- `composio upgrade` works again from any previously released CLI. Release
+  archives had been narrowed to drop the `codex-acp` binaries a machine cannot
+  execute, but a CLI installed before that change verifies a downloaded package
+  against all four platforms' binaries and rejects one that is missing any of
+  them, failing with `Downloaded binary package is incomplete`. Every archive
+  names all four paths again.
 - Archives are no longer extracted with symbolic links in them. `extract-zip`
   creates a symlink entry without validating its target (CVE-2026-56876), which
   has no fixed release, and anything that later reads the extracted tree can be
   walked out of it. No archive this CLI extracts legitimately contains a
   symlink, so such an entry is now refused before it is written.
 - `composio search` now uses schemas returned by Tool Router for dashboard-registered custom MCP tools instead of querying the legacy managed-tool endpoint, which returned 404 for `CUSTOM_*` tool slugs.
-- `composio upgrade` works again from any previously released CLI. Release
-  archives had been narrowed to carry only the `codex-acp` binary their own
-  platform can run, but a CLI installed before that change verifies a downloaded
-  package against all four platforms' binaries and rejects one that is missing
-  any of them, failing with `Downloaded binary package is incomplete`. Archives
-  ship the full set again.
 - `COMPOSIO_ENVIRONMENT=staging` now opens the staging dashboard at
   `https://staging-dashboard.composio.dev/`.
 - `composio dev auth-configs create` now sends custom OAuth credentials and scopes

--- a/ts/packages/cli/scripts/_release-artifacts.ts
+++ b/ts/packages/cli/scripts/_release-artifacts.ts
@@ -60,34 +60,47 @@ export const releaseArtifactTargetFor = (
     () => new UnknownReleaseArtifactError({ artifactName })
   );
 
+export type ArchiveCompanionEntryKind = 'copy' | 'placeholder';
+
+export type ArchiveCompanionEntry = {
+  readonly relativePath: string;
+  readonly kind: ArchiveCompanionEntryKind;
+};
+
 /**
- * Narrow the full multi-platform companion asset list down to the assets one
- * archive should ship: the portable ones plus the single codex-acp binary that
- * archive's platform can execute.
+ * Decide how each companion asset enters one archive.
  *
- * An archive already carries a platform-specific `composio` binary, so a
- * darwin-arm64 archive is unusable on linux-x64 no matter which codex-acp
- * binaries travel with it. Shipping foreign ones only inflates the download.
+ * An archive already carries a platform-specific `composio` binary, so only one
+ * of the four codex-acp binaries inside it can ever execute. The other three are
+ * ~651 MB that every machine unpacking this archive downloads, stores, and can
+ * never run.
  *
- * Packaging deliberately does not call this yet. A CLI released before
- * 2026-08-18 verifies a downloaded upgrade package against all four codex-acp
- * paths, so an archive narrowed this way breaks `composio upgrade` for every
- * client already in the field. Wire it back into `package-binaries.ts` once no
- * supported client still performs that check.
+ * They cannot simply be dropped. A CLI released before 2026-08-18 verifies a
+ * downloaded upgrade package against all four codex-acp paths and refuses to
+ * install one that is missing any of them, so omitting them breaks
+ * `composio upgrade` for every client already in the field. An empty placeholder
+ * satisfies that existence check at zero bytes, and no host ever executes a
+ * foreign codex-acp binary, so the placeholder is never read.
+ *
+ * Once no supported client performs that check, placeholders can become plain
+ * omissions.
  */
-export const archiveCompanionRelativePaths = ({
+export const archiveCompanionEntries = ({
   allRelativePaths,
   target,
 }: {
   readonly allRelativePaths: ReadonlyArray<string>;
   readonly target: ReleaseArtifactTarget;
-}): ReadonlyArray<string> => {
-  const included = new Set(runCompanionStaticAssetRelativePathsFor(target));
-  const excluded = new Set(
+}): ReadonlyArray<ArchiveCompanionEntry> => {
+  const executableHere = new Set(runCompanionStaticAssetRelativePathsFor(target));
+  const foreignCodexPaths = new Set(
     RUN_COMPANION_ALL_STATIC_ASSET_RELATIVE_PATHS.filter(
-      relativePath => !included.has(relativePath)
+      relativePath => !executableHere.has(relativePath)
     )
   );
 
-  return allRelativePaths.filter(relativePath => !excluded.has(relativePath));
+  return allRelativePaths.map(relativePath => ({
+    relativePath,
+    kind: foreignCodexPaths.has(relativePath) ? ('placeholder' as const) : ('copy' as const),
+  }));
 };

--- a/ts/packages/cli/scripts/package-binaries.ts
+++ b/ts/packages/cli/scripts/package-binaries.ts
@@ -25,7 +25,11 @@ import {
   collectExpectedRunCompanionAssetRelativePaths,
   RUN_COMPANION_ALL_STATIC_ASSET_RELATIVE_PATHS,
 } from '../src/services/run-companion-modules';
-import { ARTIFACT_NAMES } from './_release-artifacts';
+import {
+  archiveCompanionEntries,
+  ARTIFACT_NAMES,
+  releaseArtifactTargetFor,
+} from './_release-artifacts';
 
 const BINARIES_DIR = './dist/binaries';
 const COMPANIONS_DIR = path.join(BINARIES_DIR, 'companions');
@@ -65,16 +69,14 @@ export function packageBinaries() {
     yield* Console.log(`Packaging ${binaries.length} binaries...`);
 
     for (const binary of binaries) {
-      // Every archive ships every platform's codex-acp, even though its own
-      // `composio` binary can only ever execute one of them.
-      //
-      // A CLI released before 2026-08-18 verifies a downloaded upgrade package
-      // against all four codex-acp paths and refuses to install one that is
-      // missing any of them, so an archive carrying only its own binary breaks
-      // `composio upgrade` for every client already in the field. Narrowing the
-      // set is worth roughly 651 MB per archive, but it can only ship once no
-      // supported client still performs that check.
-      const companionRelativePaths = allCompanionRelativePaths;
+      // Every archive names all four codex-acp paths, but carries real bytes
+      // only for the one its own `composio` binary can execute. See
+      // `archiveCompanionEntries` for why the other three are present but empty.
+      const target = yield* releaseArtifactTargetFor(binary);
+      const companionEntries = archiveCompanionEntries({
+        allRelativePaths: allCompanionRelativePaths,
+        target,
+      });
 
       const binaryPath = path.join(BINARIES_DIR, binary);
       const zipPath = path.join(BINARIES_DIR, `${binary}.zip`);
@@ -87,10 +89,14 @@ export function packageBinaries() {
       yield* Effect.tryPromise(async () => {
         await $`mkdir -p ${nestedDir}`.quiet();
         await $`cp ${binaryPath} ${nestedDir}/composio`.quiet();
-        for (const relativePath of companionRelativePaths) {
-          const targetDirectory = path.dirname(path.join(nestedDir, relativePath));
-          await $`mkdir -p ${targetDirectory}`.quiet();
-          await $`cp ${path.join(COMPANIONS_DIR, relativePath)} ${path.join(nestedDir, relativePath)}`.quiet();
+        for (const { relativePath, kind } of companionEntries) {
+          const destinationPath = path.join(nestedDir, relativePath);
+          await $`mkdir -p ${path.dirname(destinationPath)}`.quiet();
+          if (kind === 'placeholder') {
+            await writeFile(destinationPath, '');
+            continue;
+          }
+          await $`cp ${path.join(COMPANIONS_DIR, relativePath)} ${destinationPath}`.quiet();
         }
         const hasLocalToolsBinaryAssets = await stat(LOCAL_TOOLS_BINARY_ASSETS_DIR)
           .then(stats => stats.isDirectory())

--- a/ts/packages/cli/src/effects/resolve-cli-release.ts
+++ b/ts/packages/cli/src/effects/resolve-cli-release.ts
@@ -6,6 +6,9 @@ import type { CliReleaseChannel } from 'src/constants';
 export const GitHubReleaseAsset = Schema.Struct({
   name: Schema.NonEmptyString,
   browser_download_url: Schema.NonEmptyString,
+  // Present on every real GitHub asset; optional so a release payload that omits
+  // it still decodes and the download simply reports progress without a total.
+  size: Schema.optional(Schema.Number),
 });
 export type GitHubReleaseAsset = typeof GitHubReleaseAsset.Type;
 export const GitHubReleaseAssets = Schema.Array(GitHubReleaseAsset);

--- a/ts/packages/cli/src/services/run-companion-modules.ts
+++ b/ts/packages/cli/src/services/run-companion-modules.ts
@@ -238,14 +238,28 @@ export const collectRunCompanionAssetRelativePaths = (
     return [...collected].sort();
   });
 
+/**
+ * A release archive names every codex-acp path but fills only the one its own
+ * platform can execute; the rest are empty placeholders that keep older clients'
+ * upgrade verification passing. `requireNonEmpty` makes a placeholder resolve as
+ * absent so the caller falls through to its next adapter source.
+ */
+const fileHasContent = (fs: FileSystem.FileSystem, filePath: string) =>
+  fs.stat(filePath).pipe(
+    Effect.map(info => Number(info.size) > 0),
+    Effect.orElseSucceed(() => false)
+  );
+
 export const resolveRunCompanionAssetPath = ({
   callerImportMetaUrl,
   execPath,
   relativePathFromRoot,
+  requireNonEmpty = false,
 }: {
   callerImportMetaUrl: string;
   execPath: string;
   relativePathFromRoot: string;
+  requireNonEmpty?: boolean;
 }): Effect.Effect<string | null, never, FileSystem.FileSystem | Path.Path> =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
@@ -260,7 +274,8 @@ export const resolveRunCompanionAssetPath = ({
       path.resolve(executableDirectory, relativePathFromRoot),
     ];
 
-    const found = yield* Effect.findFirst(candidates, candidate => fileExists(fs, candidate));
+    const isUsable = requireNonEmpty ? fileHasContent : fileExists;
+    const found = yield* Effect.findFirst(candidates, candidate => isUsable(fs, candidate));
     return Option.getOrNull(found);
   });
 

--- a/ts/packages/cli/src/services/run-subagent-acp.ts
+++ b/ts/packages/cli/src/services/run-subagent-acp.ts
@@ -168,10 +168,13 @@ const resolveShippedAdapterAsset = ({
     }
 
     return {
+      // Reject a zero-byte placeholder: a foreign-platform slot in the archive
+      // can never execute, so treat it as absent and fall through.
       resolvedPath: yield* resolveRunCompanionAssetPath({
         callerImportMetaUrl: import.meta.url,
         execPath,
         relativePathFromRoot: binaryTarget.relativePath,
+        requireNonEmpty: true,
       }),
       expectedRelativePaths: [binaryTarget.relativePath],
     };

--- a/ts/packages/cli/src/services/upgrade-binary.ts
+++ b/ts/packages/cli/src/services/upgrade-binary.ts
@@ -7,6 +7,7 @@ import {
   Predicate,
   Record as EffectRecord,
   Scope,
+  Stream,
 } from 'effect';
 import { HttpClient, HttpClientResponse, FileSystem, Path } from '@effect/platform';
 import { APP_VERSION } from '../constants';
@@ -201,13 +202,54 @@ const isUpdateAvailable = (
     return isVersionOutdated(comparison);
   });
 
+type DownloadProgress = {
+  readonly receivedBytes: number;
+  readonly totalBytes: number | undefined;
+};
+
+type DownloadProgressReporter = (progress: DownloadProgress) => Effect.Effect<void>;
+
+// Fast enough to look live, slow enough not to thrash the spinner.
+const DOWNLOAD_PROGRESS_INTERVAL_MILLIS = 250;
+
+const MEGABYTE = 1_000_000;
+
+export const formatMegabytes = (bytes: number): string => `${(bytes / MEGABYTE).toFixed(1)} MB`;
+
+/**
+ * Human-readable transfer state. Falls back to a plain byte count when the
+ * server never told us how large the asset is.
+ */
+export const formatDownloadProgress = ({ receivedBytes, totalBytes }: DownloadProgress): string => {
+  if (totalBytes === undefined || totalBytes <= 0) {
+    return `Downloading... ${formatMegabytes(receivedBytes)}`;
+  }
+
+  const percent = Math.min(100, Math.floor((receivedBytes / totalBytes) * 100));
+  return `Downloading... ${percent}% (${formatMegabytes(receivedBytes)} / ${formatMegabytes(totalBytes)})`;
+};
+
+const resolveDownloadTotalBytes = (
+  asset: { readonly size?: number },
+  response: HttpClientResponse.HttpClientResponse
+): number | undefined => {
+  if (typeof asset.size === 'number' && asset.size > 0) {
+    return asset.size;
+  }
+
+  const header = response.headers['content-length'];
+  const parsed = header === undefined ? Number.NaN : Number.parseInt(header, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+};
+
 /**
  * Download binary for current platform
  */
 const downloadBinary = (
   { httpClient }: UpgradeBinaryContext,
   release: GitHubRelease,
-  platformArch: PlatformArch
+  platformArch: PlatformArch,
+  onProgress: DownloadProgressReporter = () => Effect.void
 ): Effect.Effect<{ name: string; data: Uint8Array }, UpgradeBinaryError, never> =>
   Effect.gen(function* () {
     yield* Effect.logDebug(`Looking up binary for ${platformArch.platform}-${platformArch.arch}`);
@@ -247,9 +289,27 @@ const downloadBinary = (
       return resp;
     });
 
-    const arrayBuffer = yield* Effect.gen(function* () {
-      return yield* response.arrayBuffer;
-    }).pipe(
+    // Streamed rather than buffered so the transfer can be reported as it runs:
+    // these archives are hundreds of megabytes, and a silent multi-minute wait
+    // is indistinguishable from a hung command.
+    const totalBytes = resolveDownloadTotalBytes(asset, response);
+
+    const parts: Array<Uint8Array> = [];
+    let receivedBytes = 0;
+    let lastReportedAt = 0;
+
+    yield* response.stream.pipe(
+      Stream.runForEach(chunk => {
+        parts.push(chunk);
+        receivedBytes += chunk.length;
+
+        const now = Date.now();
+        if (now - lastReportedAt < DOWNLOAD_PROGRESS_INTERVAL_MILLIS) {
+          return Effect.void;
+        }
+        lastReportedAt = now;
+        return onProgress({ receivedBytes, totalBytes });
+      }),
       Effect.mapError(
         cause =>
           new UpgradeBinaryError({
@@ -259,9 +319,18 @@ const downloadBinary = (
       )
     );
 
+    yield* onProgress({ receivedBytes, totalBytes: totalBytes ?? receivedBytes });
+
+    const data = new Uint8Array(receivedBytes);
+    let offset = 0;
+    for (const part of parts) {
+      data.set(part, offset);
+      offset += part.length;
+    }
+
     return {
       name: binaryName,
-      data: new Uint8Array(arrayBuffer),
+      data,
     };
   });
 
@@ -607,7 +676,9 @@ const upgrade = (
             : `New version available: ${release.tag_name} (current: ${currentReleaseIdentifier}). Downloading...`
         );
 
-        const { name, data } = yield* downloadBinary(ctx, release, platformArch);
+        const { name, data } = yield* downloadBinary(ctx, release, platformArch, progress =>
+          spinner.message(formatDownloadProgress(progress))
+        );
 
         yield* spinner.message('Verifying checksum...');
 

--- a/ts/packages/cli/test/src/scripts/release-artifacts.test.ts
+++ b/ts/packages/cli/test/src/scripts/release-artifacts.test.ts
@@ -8,7 +8,7 @@ import {
   RUN_COMPANION_SHARED_STATIC_ASSET_RELATIVE_PATHS,
 } from '../../../src/services/run-companion-modules';
 import {
-  archiveCompanionRelativePaths,
+  archiveCompanionEntries,
   ARTIFACT_NAMES,
   RELEASE_ARTIFACT_TARGETS,
   releaseArtifactTargetFor,
@@ -74,28 +74,63 @@ describe('releaseArtifactTargetFor', () => {
   );
 });
 
-describe('archiveCompanionRelativePaths', () => {
+describe('archiveCompanionEntries', () => {
+  const pathsOfKind = (
+    entries: ReadonlyArray<{ relativePath: string; kind: string }>,
+    kind: string
+  ): ReadonlyArray<string> =>
+    entries.filter(entry => entry.kind === kind).map(entry => entry.relativePath);
+
   it.each(RELEASE_ARTIFACT_TARGETS)(
-    'ships only $platform-$arch codex-acp in $artifactName',
+    'names every codex-acp path in $artifactName so older clients still verify',
     target => {
-      const selected = archiveCompanionRelativePaths({
+      const entries = archiveCompanionEntries({
         allRelativePaths: ALL_COMPANION_RELATIVE_PATHS,
         target,
       });
 
-      expect(codexAcpRelativePathsIn(selected)).toEqual([
+      expect(entries.map(entry => entry.relativePath)).toEqual(ALL_COMPANION_RELATIVE_PATHS);
+    }
+  );
+
+  it.each(RELEASE_ARTIFACT_TARGETS)(
+    'carries real bytes only for the $platform-$arch codex-acp binary',
+    target => {
+      const entries = archiveCompanionEntries({
+        allRelativePaths: ALL_COMPANION_RELATIVE_PATHS,
+        target,
+      });
+
+      expect(codexAcpRelativePathsIn(pathsOfKind(entries, 'copy'))).toEqual([
         `acp-adapters/codex/${target.platform}-${target.arch}/codex-acp`,
       ]);
     }
   );
 
-  it.each(RELEASE_ARTIFACT_TARGETS)('keeps portable assets in $artifactName', target => {
-    const selected = archiveCompanionRelativePaths({
+  it.each(RELEASE_ARTIFACT_TARGETS)(
+    'placeholders exactly the foreign codex-acp binaries in $artifactName',
+    target => {
+      const entries = archiveCompanionEntries({
+        allRelativePaths: ALL_COMPANION_RELATIVE_PATHS,
+        target,
+      });
+
+      expect(pathsOfKind(entries, 'placeholder')).toEqual(
+        RUN_CODEX_ACP_BINARY_TARGETS.filter(
+          codexTarget =>
+            codexTarget.platform !== target.platform || codexTarget.arch !== target.arch
+        ).map(codexTarget => codexTarget.relativePath)
+      );
+    }
+  );
+
+  it.each(RELEASE_ARTIFACT_TARGETS)('copies the portable assets into $artifactName', target => {
+    const entries = archiveCompanionEntries({
       allRelativePaths: ALL_COMPANION_RELATIVE_PATHS,
       target,
     });
 
-    expect(selected).toEqual(
+    expect(pathsOfKind(entries, 'copy')).toEqual(
       expect.arrayContaining([
         ...RUN_COMPANION_SHARED_STATIC_ASSET_RELATIVE_PATHS,
         ...RUN_COMPANION_MODULE_FILENAMES,
@@ -103,51 +138,16 @@ describe('archiveCompanionRelativePaths', () => {
       ])
     );
   });
-
-  it.each(RELEASE_ARTIFACT_TARGETS)(
-    'drops exactly the foreign codex-acp binaries from $artifactName',
-    target => {
-      const selected = archiveCompanionRelativePaths({
-        allRelativePaths: ALL_COMPANION_RELATIVE_PATHS,
-        target,
-      });
-
-      const dropped = ALL_COMPANION_RELATIVE_PATHS.filter(
-        relativePath => !selected.includes(relativePath)
-      );
-
-      expect(dropped).toEqual(
-        RUN_CODEX_ACP_BINARY_TARGETS.filter(
-          codexTarget =>
-            codexTarget.platform !== target.platform || codexTarget.arch !== target.arch
-        )
-          .map(codexTarget => codexTarget.relativePath)
-          .sort()
-      );
-      expect(dropped).toHaveLength(RUN_CODEX_ACP_BINARY_TARGETS.length - 1);
-    }
-  );
-
-  it('leaves an already-narrowed list untouched', () => {
-    const target = RELEASE_ARTIFACT_TARGETS[0]!;
-    const selected = archiveCompanionRelativePaths({
-      allRelativePaths: ALL_COMPANION_RELATIVE_PATHS,
-      target,
-    });
-
-    expect(archiveCompanionRelativePaths({ allRelativePaths: selected, target })).toEqual(selected);
-  });
 });
 
 /**
- * Packaging ships {@link RUN_COMPANION_ALL_STATIC_ASSET_RELATIVE_PATHS} into every
- * archive rather than the narrowed slice, because a CLI released before
- * 2026-08-18 verifies an upgrade package against all four codex-acp paths and
- * refuses one that is missing any of them.
+ * Packaging names {@link RUN_COMPANION_ALL_STATIC_ASSET_RELATIVE_PATHS} in every
+ * archive, because a CLI released before 2026-08-18 verifies an upgrade package
+ * against all four codex-acp paths and refuses one that is missing any of them.
  */
 describe('published archive companion coverage', () => {
   it.each(RUN_CODEX_ACP_BINARY_TARGETS)(
-    'ships the $platform-$arch codex-acp binary in every archive',
+    'names the $platform-$arch codex-acp binary in every archive',
     codexTarget => {
       expect(RUN_COMPANION_ALL_STATIC_ASSET_RELATIVE_PATHS).toContain(codexTarget.relativePath);
     }

--- a/ts/packages/cli/test/src/services/run-companion-modules.test.ts
+++ b/ts/packages/cli/test/src/services/run-companion-modules.test.ts
@@ -9,6 +9,7 @@ import {
   hostRunCompanionStaticAssetRelativePaths,
   listMissingInstalledRunCompanionModules,
   repairMissingInstalledRunCompanionModules,
+  resolveRunCompanionAssetPath,
   RUN_CODEX_ACP_BINARY_TARGETS,
   RUN_COMPANION_ALL_STATIC_ASSET_RELATIVE_PATHS,
   RUN_COMPANION_MODULE_FILENAMES,
@@ -370,6 +371,75 @@ describe('run-companion-modules', () => {
           )
         );
       }
+    );
+  });
+});
+
+/**
+ * Release archives fill only the codex-acp binary their own platform can execute
+ * and leave the other three as empty placeholders, so that a CLI installed
+ * before 2026-08-18 still passes its upgrade verification. A placeholder must
+ * never be handed back as a runnable adapter.
+ */
+describe('resolveRunCompanionAssetPath', () => {
+  layer(BunContext.layer)(it => {
+    const withInstallDirectory = <A, E, R>(
+      contents: number,
+      use: (execPath: string) => Effect.Effect<A, E, R>
+    ) =>
+      Effect.gen(function* () {
+        const installDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'companion-asset-'));
+        const execPath = path.join(installDirectory, 'composio');
+        const assetPath = path.join(installDirectory, 'acp-adapters', 'codex', 'darwin-arm64');
+        fs.mkdirSync(assetPath, { recursive: true });
+        fs.writeFileSync(path.join(assetPath, 'codex-acp'), Buffer.alloc(contents));
+        return yield* use(execPath);
+      });
+
+    const relativePathFromRoot = 'acp-adapters/codex/darwin-arm64/codex-acp';
+
+    it.effect('resolves a populated binary', () =>
+      withInstallDirectory(64, execPath =>
+        Effect.gen(function* () {
+          const resolved = yield* resolveRunCompanionAssetPath({
+            callerImportMetaUrl: import.meta.url,
+            execPath,
+            relativePathFromRoot,
+            requireNonEmpty: true,
+          });
+
+          expect(resolved).toBe(path.join(path.dirname(execPath), relativePathFromRoot));
+        })
+      )
+    );
+
+    it.effect('reports an empty placeholder as absent under requireNonEmpty', () =>
+      withInstallDirectory(0, execPath =>
+        Effect.gen(function* () {
+          const resolved = yield* resolveRunCompanionAssetPath({
+            callerImportMetaUrl: import.meta.url,
+            execPath,
+            relativePathFromRoot,
+            requireNonEmpty: true,
+          });
+
+          expect(resolved).toBeNull();
+        })
+      )
+    );
+
+    it.effect('still resolves an empty file when only existence is required', () =>
+      withInstallDirectory(0, execPath =>
+        Effect.gen(function* () {
+          const resolved = yield* resolveRunCompanionAssetPath({
+            callerImportMetaUrl: import.meta.url,
+            execPath,
+            relativePathFromRoot,
+          });
+
+          expect(resolved).toBe(path.join(path.dirname(execPath), relativePathFromRoot));
+        })
+      )
     );
   });
 });

--- a/ts/packages/cli/test/src/services/run-companion-modules.test.ts
+++ b/ts/packages/cli/test/src/services/run-companion-modules.test.ts
@@ -393,7 +393,11 @@ describe('resolveRunCompanionAssetPath', () => {
         const assetPath = path.join(installDirectory, 'acp-adapters', 'codex', 'darwin-arm64');
         fs.mkdirSync(assetPath, { recursive: true });
         fs.writeFileSync(path.join(assetPath, 'codex-acp'), Buffer.alloc(contents));
-        return yield* use(execPath);
+        return yield* use(execPath).pipe(
+          Effect.ensuring(
+            Effect.sync(() => fs.rmSync(installDirectory, { recursive: true, force: true }))
+          )
+        );
       });
 
     const relativePathFromRoot = 'acp-adapters/codex/darwin-arm64/codex-acp';

--- a/ts/packages/cli/test/src/services/upgrade-binary.test.ts
+++ b/ts/packages/cli/test/src/services/upgrade-binary.test.ts
@@ -5,7 +5,12 @@ import * as PlatformError from '@effect/platform/Error';
 import { BunFileSystem, BunPath } from '@effect/platform-bun';
 import { withHttpServer } from 'test/__utils__/http-server';
 import { getTerminalCapabilities, TerminalUI } from 'src/services/terminal-ui';
-import { UpgradeBinary, UpgradeBinaryError } from 'src/services/upgrade-binary';
+import {
+  formatDownloadProgress,
+  formatMegabytes,
+  UpgradeBinary,
+  UpgradeBinaryError,
+} from 'src/services/upgrade-binary';
 import { NodeOs } from 'src/services/node-os';
 import {
   collectExpectedRunCompanionAssetRelativePaths,
@@ -716,5 +721,36 @@ describe('UpgradeBinary', () => {
       expect(error.message).toBe('Failed to download binary: composio-darwin-aarch64.zip');
       expect(String(error.cause)).toContain('beta-3.zip');
     }).pipe(Effect.provide(TestPlatform), Effect.ensuring(restoreStubsAndMocks));
+  });
+});
+
+describe('formatDownloadProgress', () => {
+  it('reports percent and both sizes when the total is known', () => {
+    expect(formatDownloadProgress({ receivedBytes: 142_000_000, totalBytes: 338_000_000 })).toBe(
+      'Downloading... 42% (142.0 MB / 338.0 MB)'
+    );
+  });
+
+  it('reports bytes alone when the server never sent a size', () => {
+    expect(formatDownloadProgress({ receivedBytes: 12_500_000, totalBytes: undefined })).toBe(
+      'Downloading... 12.5 MB'
+    );
+  });
+
+  it('treats a zero total as unknown rather than dividing by it', () => {
+    expect(formatDownloadProgress({ receivedBytes: 1_000_000, totalBytes: 0 })).toBe(
+      'Downloading... 1.0 MB'
+    );
+  });
+
+  it('never exceeds 100% when more bytes arrive than announced', () => {
+    expect(formatDownloadProgress({ receivedBytes: 400_000_000, totalBytes: 338_000_000 })).toBe(
+      'Downloading... 100% (400.0 MB / 338.0 MB)'
+    );
+  });
+
+  it('formats megabytes to one decimal place', () => {
+    expect(formatMegabytes(0)).toBe('0.0 MB');
+    expect(formatMegabytes(338_027_339)).toBe('338.0 MB');
   });
 });


### PR DESCRIPTION
## Problem

`composio upgrade` from `0.3.4-beta.351` to `0.4.0-beta.359` looked hung for several minutes:

```
◐  New version available: @composio/cli@0.4.0-beta.359 (current: @composio/cli@0.3.4-beta.351). Downloading.
```

Two independent defects behind that.

**No feedback.** `upgrade-binary.ts` printed that message once and then said nothing until the download finished. The only byte-level signal was a `logDebug`, invisible in a normal run, because the body was read with a single buffered `response.arrayBuffer`.

**Mostly wasted payload.** The archive is 338 MB, and ~651 MB of what it unpacks is `codex-acp` binaries for the three platforms the host cannot execute. Measured on a darwin-arm64 install:

```
~/.composio                      967 MB total
  codex/darwin-arm64  180 MB     ← the only one this Mac can run
  codex/darwin-x64    190 MB  ┐
  codex/linux-arm64   208 MB  ├─  620 MB of dead weight
  codex/linux-x64     222 MB  ┘
```

## Changes

**Progress reporting.** The response is streamed and reported on a 250 ms interval: `Downloading... 42% (142.0 MB / 338.0 MB)`. The total comes from the release asset's `size` (newly decoded — the field was being dropped), falling back to `content-length`, and falling back again to a plain byte count so an unknown size degrades instead of failing.

**Half the payload.** Each archive now carries real bytes only for the `codex-acp` binary its own platform can execute.

The other three paths cannot simply be dropped — that is exactly the break #4186 just repaired. A CLI released before 2026-08-18 verifies a downloaded package against all four codex-acp paths and refuses one missing any of them. So they ship as **empty placeholders**: the existence check passes at zero bytes, and since no host ever executes a foreign codex-acp, the placeholder is never read. Once no supported client performs that check, placeholders become plain omissions — `archiveCompanionEntries` is where that switch lives.

As a guard, codex adapter resolution now requires a non-empty file, so a zero-byte binary resolves as absent and falls through to the existing bundled → PATH → npx chain rather than trying to exec it.

Expected effect: download 338 MB → ~165 MB, install footprint 967 MB → ~347 MB.

## Verification

- Full CLI suite: **122 files, 1262 passed, 1 skipped**
- `pnpm --filter @composio/cli typecheck` — clean
- The existing `upgrade-binary` download tests run against a real HTTP server and pass unchanged, covering the buffered → streamed rewrite
- New tests: progress formatting (known total, unknown total, zero total, overshoot) and `archiveCompanionEntries` (all four paths named, exactly one copied, three placeholdered, portable assets copied)
- `pnpm validate:changesets` — passes; note lands in `ts/packages/cli/CHANGELOG.md`

Not verifiable locally: actual archive sizes and a real upgrade against a pre-2026-08-18 client. Both need a beta build — worth confirming on the beta cut from this branch before it goes near a stable promotion.

Independent of the `0.4.0` release in flight; `0.4.0-beta.359` is unaffected.

https://claude.ai/code/session_01JkwtxPHfobZxzvAqe53x62