### PR TITLE
ci(security): harden docs-agent-eval caller (Bugbot fixes)

### DIFF
--- a/.github/workflows/docs-agent-eval.yml
+++ b/.github/workflows/docs-agent-eval.yml
@@ -44,6 +44,7 @@ jobs:
       (github.event.action != 'labeled' || startsWith(github.event.label.name, 'run-docs-tests'))) ||
       (github.event_name == 'deployment_status' &&
        github.event.deployment_status.state == 'success' &&
+       startsWith(github.event.deployment_status.environment_url, 'https://docs-') &&
        contains(github.event.deployment_status.environment_url, '.preview.composio.dev'))
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -160,6 +161,10 @@ jobs:
           ref: ${{ env.ENGINE_REF }}
           token: ${{ steps.app-token.outputs.token }}
           path: engine
+          # Don't write the App token into engine/.git/config — the eval then
+          # runs untrusted agent code with filesystem access on this runner,
+          # which could read a persisted token. We only need it for this fetch.
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5


### PR DESCRIPTION
## Security fixes for the docs-agent-eval caller (Cursor Bugbot findings)

Follow-up to #4158 (merged). Cursor Bugbot flagged two real issues on the App-token caller; both fixed here. Two other findings were already resolved in the merged version (noted below).

**Fixed:**
- **App token left on disk (Medium):** check out the private engine with `persist-credentials: false`. Otherwise `actions/checkout` writes the GitHub App installation token into `engine/.git/config`, and the eval then runs untrusted agent code with filesystem access on the same runner — which could read that token (read access to the private engine repo). The token is only needed for the one-time fetch.
- **Non-docs previews start evals (Medium):** the `deployment_status` trigger now requires the `environment_url` to start with `https://docs-` (matching the label path's `docs-*` rule), so a non-docs `*.preview.composio.dev` deployment can't start or cancel a docs eval.

**Already resolved in #4158 (stale Bugbot findings from the pre-App design):**
- "Unrelated labels cancel evals" — the route job's `startsWith(…, 'run-docs-tests')` guard skips unrelated `labeled` events before anything enters the eval concurrency group.
- "Eval token cannot read deployments" — `deployments: read` is set on both jobs.

Informational check, non-blocking. No behavior change beyond the two hardening fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
