### PR TITLE
ci: docs-eval engine pin → false-PASS fix

### DIFF
--- a/.github/workflows/docs-agent-eval.yml
+++ b/.github/workflows/docs-agent-eval.yml
@@ -30,7 +30,7 @@ on:
 env:
   ENGINE_REPO: ComposioHQ/docs-agent-eval-ci
   # Full-SHA pin of the engine code — bump on docs-agent-eval-ci releases.
-  ENGINE_REF: be0d5ea6e7d8e73629fefd8936d3202e0966879e
+  ENGINE_REF: 3d6bc4cad01b4d270599f297d6074bc04cf59d4a
 
 jobs:
   # Decides IF an eval should start and FOR WHICH PR. deployment_status

--- a/.github/workflows/docs-agent-eval.yml
+++ b/.github/workflows/docs-agent-eval.yml
@@ -30,7 +30,7 @@ on:
 env:
   ENGINE_REPO: ComposioHQ/docs-agent-eval-ci
   # Full-SHA pin of the engine code — bump on docs-agent-eval-ci releases.
-  ENGINE_REF: d299de8061151997548a3650e13ebfc63c03d08f
+  ENGINE_REF: be0d5ea6e7d8e73629fefd8936d3202e0966879e
 
 jobs:
   # Decides IF an eval should start and FOR WHICH PR. deployment_status


### PR DESCRIPTION
Bumps the engine pin so the live check includes the fix for the false-PASS the first live smoke (#4200) exposed: when provisioning fails (invalid org key) the eval ran 0 agents but reported ✓ PASS. Engine now returns ERROR for 0-run / infrastructure crashes. Separately, the org key secret (COMPOSIO_ORG_API_KEY) in this repo is invalid (401) and needs re-adding.