### PR TITLE
docs(auth): point custom OAuth callback URL to v1 (UXE-261)

### DIFF
--- a/docs/content/docs/auth-configuration/custom-auth-configs.mdx
+++ b/docs/content/docs/auth-configuration/custom-auth-configs.mdx
@@ -79,7 +79,7 @@ Examples for Google and GitHub:
 When creating your OAuth app, make sure to configure the Authorized Redirect URI to point to the Composio callback URL below:
 
 ```
-https://backend.composio.dev/api/v3.1/toolkits/auth/callback
+https://backend.composio.dev/api/v1/auth-apps/add
 ```
 </Step>
 

--- a/docs/content/docs/auth-configuration/white-labeling.mdx
+++ b/docs/content/docs/auth-configuration/white-labeling.mdx
@@ -78,7 +78,7 @@ Only white-label toolkits where users see a consent screen (Google, GitHub, Slac
 Register a new OAuth app with the toolkit. Set the callback URL to:
 
 ```
-https://backend.composio.dev/api/v3.1/toolkits/auth/callback
+https://backend.composio.dev/api/v1/auth-apps/add
 ```
 
 You'll get a **Client ID** and **Client Secret**.
@@ -236,7 +236,7 @@ app = FastAPI()
 
 @app.get("/api/composio-redirect")
 def composio_redirect(request: Request):
-    composio_url = "https://backend.composio.dev/api/v3.1/toolkits/auth/callback"
+    composio_url = "https://backend.composio.dev/api/v1/auth-apps/add"
     return RedirectResponse(url=f"{composio_url}?{request.url.query}")
 ```
 </Tab>
@@ -246,7 +246,7 @@ def composio_redirect(request: Request):
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  const composioUrl = "https://backend.composio.dev/api/v3.1/toolkits/auth/callback";
+  const composioUrl = "https://backend.composio.dev/api/v1/auth-apps/add";
   const params = new URLSearchParams(req.query as Record<string, string>);
   res.redirect(302, `${composioUrl}?${params.toString()}`);
 }

--- a/docs/content/docs/authentication/programmatic-auth-configs.mdx
+++ b/docs/content/docs/authentication/programmatic-auth-configs.mdx
@@ -48,7 +48,7 @@ console.log(authConfig.id); // ac_xxxxxxxx
 Bring your own OAuth app to show your branding on consent screens, request custom scopes, or get a dedicated rate-limit quota. Register the app in the provider's developer portal, set its authorized redirect URI to Composio's callback, then pass the client ID and secret.
 
 ```
-https://backend.composio.dev/api/v3.1/toolkits/auth/callback
+https://backend.composio.dev/api/v1/auth-apps/add
 ```
 
 <Tabs groupId="language" items={['Python', 'TypeScript']} persist>
@@ -68,7 +68,7 @@ auth_config = composio.auth_configs.create(
         "credentials": {
             "client_id": os.environ["NOTION_CLIENT_ID"],
             "client_secret": os.environ["NOTION_CLIENT_SECRET"],
-            "oauth_redirect_uri": "https://backend.composio.dev/api/v3.1/toolkits/auth/callback",
+            "oauth_redirect_uri": "https://backend.composio.dev/api/v1/auth-apps/add",
         },
     },
 )
@@ -87,7 +87,7 @@ const authConfig = await composio.authConfigs.create('notion', {
   credentials: {
     client_id: process.env.NOTION_CLIENT_ID!,
     client_secret: process.env.NOTION_CLIENT_SECRET!,
-    oauth_redirect_uri: 'https://backend.composio.dev/api/v3.1/toolkits/auth/callback',
+    oauth_redirect_uri: 'https://backend.composio.dev/api/v1/auth-apps/add',
   },
 });
 ```

--- a/docs/content/docs/authentication/white-labeling-authentication.mdx
+++ b/docs/content/docs/authentication/white-labeling-authentication.mdx
@@ -107,7 +107,7 @@ app = FastAPI()
 
 @app.get("/api/composio-redirect")
 def composio_redirect(request: Request):
-    composio_url = "https://backend.composio.dev/api/v3.1/toolkits/auth/callback"
+    composio_url = "https://backend.composio.dev/api/v1/auth-apps/add"
     return RedirectResponse(url=f"{composio_url}?{request.url.query}")
 ```
 </Tab>
@@ -117,7 +117,7 @@ def composio_redirect(request: Request):
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  const composioUrl = "https://backend.composio.dev/api/v3.1/toolkits/auth/callback";
+  const composioUrl = "https://backend.composio.dev/api/v1/auth-apps/add";
   const params = new URLSearchParams(req.query as Record<string, string>);
   res.redirect(302, `${composioUrl}?${params.toString()}`);
 }

--- a/python/examples/auth_configs.py
+++ b/python/examples/auth_configs.py
@@ -25,7 +25,7 @@ auth_config = composio.auth_configs.create(  # type: ignore[call-overload]  # cr
         "credentials": {
             "client_id": "1234567890",
             "client_secret": "1234567890",
-            "oauth_redirect_uri": "https://backend.composio.dev/api/v3/toolkits/auth/callback",
+            "oauth_redirect_uri": "https://backend.composio.dev/api/v1/auth-apps/add",
         },
     },
 )


### PR DESCRIPTION
## What

Points all instructional docs (and the Python example) for custom OAuth credentials to the **v1** callback URL:

`https://backend.composio.dev/api/v1/auth-apps/add`

...replacing the previously documented `https://backend.composio.dev/api/v3.1/toolkits/auth/callback`.

## Why

The backend returns the **v1** URL as the default redirect URI for every toolkit (it's what flows into the generated `docs/public/data/toolkits.json`), and Consumer product expects v1 — but Consumer doesn't surface the callback URL, so users go to the docs, find the **v3.1** URL, and whitelist the wrong one in their OAuth app. Flagged as a top confusion in Go Live calls. Fixes [UXE-261](https://linear.app/composio/issue/UXE-261/update-docs-to-point-to-v1-callback-url).

## Files changed

- `docs/.../authentication/programmatic-auth-configs.mdx` (ticket's primary target)
- `docs/.../authentication/white-labeling-authentication.mdx`
- `docs/.../auth-configuration/white-labeling.mdx`
- `docs/.../auth-configuration/custom-auth-configs.mdx`
- `python/examples/auth_configs.py`

## Deliberately NOT changed

- **`docs/.../migration-guide/new-sdk.mdx`** — states *"The callback URL is now v3… The previous URL was v1"*. It documents the v1→v3 migration history; flipping it to v1 would make it self-contradictory. Left as-is.
- **`docs/public/data/toolkits.json` / `ts/docs/api/toolkits.md`** — generated from the backend API, already v1. No manual edit.

## ⚠️ Open question worth confirming

The migration guide says v3 is the *current* callback and v1 is *previous*. This PR points developers *back* to v1 to match Consumer. That's a real backend/product inconsistency, not just a docs typo — worth confirming with @rahul / @abhishek that v1 is genuinely the URL Consumer expects (and whether the migration guide messaging should be revisited separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)