### PR TITLE
ci: trigger SDK suites on dependency-resolution changes

### DIFF
--- a/.github/workflows/py.check.yaml
+++ b/.github/workflows/py.check.yaml
@@ -5,6 +5,8 @@ on:
       - next
     paths:
       - 'python/**/*.py'
+      - 'python/pyproject.toml'
+      - 'uv.lock'
       - '.github/actions/setup-python-uv/action.yml'
       - '.github/workflows/py.check.yaml'
       - 'mise.toml'
@@ -13,6 +15,8 @@ on:
     types: [opened, synchronize]
     paths:
       - 'python/**/*.py'
+      - 'python/pyproject.toml'
+      - 'uv.lock'
       - '.github/actions/setup-python-uv/action.yml'
       - '.github/workflows/py.check.yaml'
       - 'mise.toml'

--- a/.github/workflows/py.test.yml
+++ b/.github/workflows/py.test.yml
@@ -12,6 +12,7 @@ on:
       - 'mise.lock'
       - 'toolchain-versions.json'
       - 'python/pyproject.toml'
+      - 'uv.lock'
       - 'python/requirements*.txt'
   pull_request:
     branches: [master, next]
@@ -24,6 +25,7 @@ on:
       - 'mise.lock'
       - 'toolchain-versions.json'
       - 'python/pyproject.toml'
+      - 'uv.lock'
       - 'python/requirements*.txt'
 
 concurrency:

--- a/.github/workflows/ts.examples.yml
+++ b/.github/workflows/ts.examples.yml
@@ -13,6 +13,8 @@ on:
       - '.github/workflows/ts.examples.yml'
       - 'mise.toml'
       - 'mise.lock'
+      - 'pnpm-workspace.yaml'
+      - 'pnpm-lock.yaml'
       - 'turbo.jsonc'
   pull_request:
     branches: [master, next]
@@ -26,6 +28,8 @@ on:
       - '.github/workflows/ts.examples.yml'
       - 'mise.toml'
       - 'mise.lock'
+      - 'pnpm-workspace.yaml'
+      - 'pnpm-lock.yaml'
       - 'turbo.jsonc'
 
 concurrency:

--- a/.github/workflows/ts.test-e2e.yml
+++ b/.github/workflows/ts.test-e2e.yml
@@ -5,6 +5,11 @@ on:
     branches: [master, next]
     paths:
       - 'ts/**'
+      # A catalog pin or lockfile change swaps what every ts/** package
+      # resolves without touching one of their files -- @composio/client
+      # 0.1.0-alpha.76 -> 2.0.0-rc.5 skipped this suite entirely that way.
+      - 'pnpm-workspace.yaml'
+      - 'pnpm-lock.yaml'
       - '.github/actions/setup-node-pnpm-bun/action.yml'
       - '.github/workflows/ts.test-e2e.yml'
       - 'mise.toml'
@@ -13,6 +18,11 @@ on:
   pull_request:
     paths:
       - 'ts/**'
+      # A catalog pin or lockfile change swaps what every ts/** package
+      # resolves without touching one of their files -- @composio/client
+      # 0.1.0-alpha.76 -> 2.0.0-rc.5 skipped this suite entirely that way.
+      - 'pnpm-workspace.yaml'
+      - 'pnpm-lock.yaml'
       - '.github/actions/setup-node-pnpm-bun/action.yml'
       - '.github/workflows/ts.test-e2e.yml'
       - 'mise.toml'

--- a/.github/workflows/ts.test.yml
+++ b/.github/workflows/ts.test.yml
@@ -12,6 +12,8 @@ on:
       - 'mise.toml'
       - 'mise.lock'
       - 'package.json'
+      - 'pnpm-workspace.yaml'
+      - 'pnpm-lock.yaml'
       - 'test/release-workflow.test.ts'
       - 'turbo.jsonc'
   pull_request:
@@ -25,6 +27,8 @@ on:
       - 'mise.toml'
       - 'mise.lock'
       - 'package.json'
+      - 'pnpm-workspace.yaml'
+      - 'pnpm-lock.yaml'
       - 'test/release-workflow.test.ts'
       - 'turbo.jsonc'
 

--- a/.github/workflows/ts.typecheck.yml
+++ b/.github/workflows/ts.typecheck.yml
@@ -9,6 +9,8 @@ on:
       - '.github/workflows/ts.typecheck.yml'
       - 'mise.toml'
       - 'mise.lock'
+      - 'pnpm-workspace.yaml'
+      - 'pnpm-lock.yaml'
       - 'turbo.jsonc'
   pull_request:
     branches: [master, next]
@@ -18,6 +20,8 @@ on:
       - '.github/workflows/ts.typecheck.yml'
       - 'mise.toml'
       - 'mise.lock'
+      - 'pnpm-workspace.yaml'
+      - 'pnpm-lock.yaml'
       - 'turbo.jsonc'
 
 concurrency:


### PR DESCRIPTION
## Problem

A catalog pin or lockfile edit swaps what every package resolves, without touching a file under `ts/**` or `python/**`. The path filters on our suites did not account for that, so a dependency bump could skip the very checks meant to catch it.

This is not hypothetical. In #4135, bumping `@composio/client` from `0.1.0-alpha.76` to `2.0.0-rc.5` — a one-line change in `pnpm-workspace.yaml` — ran **no TypeScript E2E at all**. That client adds a credential-transport guard that refuses plain-HTTP credentials to non-loopback hosts, which breaks `@e2e-tests/cli-toolkits-list` (the harness serves its mock backend at `http://host.docker.internal:${port}`). The PR was green throughout; the breakage only surfaced when the suite was dispatched by hand.

`ts.test.yml` ran on that PR purely by luck, because the changeset file matched `.changeset/**`.

## Change

Add the dependency-resolution inputs to every path-filtered SDK workflow that lacked them:

| workflow | added |
| --- | --- |
| `ts.test-e2e.yml` | `pnpm-workspace.yaml`, `pnpm-lock.yaml` |
| `ts.test.yml` | `pnpm-workspace.yaml`, `pnpm-lock.yaml` |
| `ts.typecheck.yml` | `pnpm-workspace.yaml`, `pnpm-lock.yaml` |
| `ts.examples.yml` | `pnpm-workspace.yaml`, `pnpm-lock.yaml` |
| `py.check.yaml` | `python/pyproject.toml`, `uv.lock` |
| `py.test.yml` | `uv.lock` |

`ts.audit.yml` and `ts.build.yml` already listed both pnpm files and are unchanged. `ts.release.yml` and `ts.examples-nightly.yml` have no path filters.

`py.check.yaml` was the widest gap on the Python side: it matched only `python/**/*.py`, so the `composio-client` pin bump in #4135 triggered no ruff or mypy run.

## Verification

Every touched file still parses as YAML, and each of the six now matches on the dependency inputs. The trade is more CI on lockfile-only changes, which seems clearly worth it against a silent client swap.