### PR TITLE
docs(kb): stop probing API strings as links

### DIFF
--- a/docs/content/kb/guide/toolkits-ahrefs.mdx
+++ b/docs/content/kb/guide/toolkits-ahrefs.mdx
@@ -13,4 +13,4 @@ aliases: ["/kb/toolkits/ahrefs-actions-use-the-api-host","ahrefs-actions-use-the
 ---
 ## Ahrefs actions must call api.ahrefs.com, not ahrefs.com
 
-Ahrefs API calls should use the API host https://api.ahrefs.com/v3. If Ahrefs actions or connection checks are hitting https://ahrefs.com/v3 and returning 404 HTML, treat it as a connector base-URL configuration problem rather than an API-key or request-payload issue. Confirm the failing request is using api.ahrefs.com; if it is not, contact Composio support with the redacted request or log ID for connector review.
+Ahrefs API calls should use the API host `https://api.ahrefs.com/v3`. If Ahrefs actions or connection checks are hitting `https://ahrefs.com/v3` and returning 404 HTML, treat it as a connector base-URL configuration problem rather than an API-key or request-payload issue. Confirm the failing request is using api.ahrefs.com; if it is not, contact Composio support with the redacted request or log ID for connector review.

--- a/docs/content/kb/guide/toolkits-googlemeet.mdx
+++ b/docs/content/kb/guide/toolkits-googlemeet.mdx
@@ -17,7 +17,7 @@ Google Super is a separate toolkit with its own tool slugs. If the connected acc
 
 ## Configure Meet scopes and enable the Google Meet API before creating Meet spaces
 
-For Meet space creation/settings through Google Super, include the Meet scopes https://www.googleapis.com/auth/meetings.space.created and https://www.googleapis.com/auth/meetings.space.settings in the auth config, then initiate a new connection so the new scopes are granted. Also enable the Google Meet API in the Google Cloud Console project backing the OAuth app.
+For Meet space creation/settings through Google Super, include the Meet scopes `https://www.googleapis.com/auth/meetings.space.created` and `https://www.googleapis.com/auth/meetings.space.settings` in the auth config, then initiate a new connection so the new scopes are granted. Also enable the Google Meet API in the Google Cloud Console project backing the OAuth app.
 
 ## Fetch transcript entries by first resolving the conference record
 

--- a/docs/kb/articles/toolkits-ahrefs.md
+++ b/docs/kb/articles/toolkits-ahrefs.md
@@ -1,3 +1,3 @@
 ## Ahrefs actions must call api.ahrefs.com, not ahrefs.com
 
-Ahrefs API calls should use the API host https://api.ahrefs.com/v3. If Ahrefs actions or connection checks are hitting https://ahrefs.com/v3 and returning 404 HTML, treat it as a connector base-URL configuration problem rather than an API-key or request-payload issue. Confirm the failing request is using api.ahrefs.com; if it is not, contact Composio support with the redacted request or log ID for connector review.
+Ahrefs API calls should use the API host `https://api.ahrefs.com/v3`. If Ahrefs actions or connection checks are hitting `https://ahrefs.com/v3` and returning 404 HTML, treat it as a connector base-URL configuration problem rather than an API-key or request-payload issue. Confirm the failing request is using api.ahrefs.com; if it is not, contact Composio support with the redacted request or log ID for connector review.

--- a/docs/kb/articles/toolkits-googlemeet.md
+++ b/docs/kb/articles/toolkits-googlemeet.md
@@ -4,7 +4,7 @@ Google Super is a separate toolkit with its own tool slugs. If the connected acc
 
 ## Configure Meet scopes and enable the Google Meet API before creating Meet spaces
 
-For Meet space creation/settings through Google Super, include the Meet scopes https://www.googleapis.com/auth/meetings.space.created and https://www.googleapis.com/auth/meetings.space.settings in the auth config, then initiate a new connection so the new scopes are granted. Also enable the Google Meet API in the Google Cloud Console project backing the OAuth app.
+For Meet space creation/settings through Google Super, include the Meet scopes `https://www.googleapis.com/auth/meetings.space.created` and `https://www.googleapis.com/auth/meetings.space.settings` in the auth config, then initiate a new connection so the new scopes are granted. Also enable the Google Meet API in the Google Cloud Console project backing the OAuth app.
 
 ## Fetch transcript entries by first resolving the conference record
 


### PR DESCRIPTION
## Summary
Stops the nightly link sweep from probing API hosts and OAuth scope identifiers that are documentation literals.

Fixes #4205

## Changes
- Format the Ahrefs API host paths and Google Meet OAuth scopes as inline code.
- Regenerate the corresponding KB guide pages from their source articles.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [x] Documentation
- [ ] Breaking change

## How Has This Been Tested?
- `cd docs && bun run generate:kb --check`
- `cd docs && bun run lint:links`
- `cd docs && bun run test` (472 passed)
- Confirmed the four identifiers are no longer parsed as external links.

## Checklist
- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed
- [x] I updated documentation as needed
- [x] Tests are not applicable beyond the docs generation and link-validation suites above
- [x] No changeset is needed for a documentation-only change