### PR TITLE
chore(deps): stop Dependabot proposing ag2 majors for composio-autogen

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,6 +64,14 @@ updates:
         update-types:
           - "version-update:semver-minor"
           - "version-update:semver-major"
+      # ag2 1.0 dropped the top-level `autogen` package that
+      # composio-autogen imports (`autogen.agentchat.register_function`,
+      # `ConversableAgent`); the 1.x wheel ships only `ag2`. Adopting it is a
+      # provider rewrite, not a requirement widening. Remove this once
+      # composio-autogen targets the `ag2` namespace.
+      - dependency-name: "ag2"
+        update-types:
+          - "version-update:semver-major"
     groups:
       pip-version:
         applies-to: version-updates

--- a/python/providers/autogen/pyproject.toml
+++ b/python/providers/autogen/pyproject.toml
@@ -13,6 +13,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
+    # ag2 1.x removed the top-level `autogen` namespace this provider imports.
     "ag2>=0.14,<1.0",
     "flaml==2.6.0",
     "autogen_core>=0.7.5",

--- a/python/providers/autogen/setup.py
+++ b/python/providers/autogen/setup.py
@@ -22,6 +22,7 @@ setup(
     ],
     python_requires=">=3.10,<4",
     install_requires=[
+        # ag2 1.x removed the top-level `autogen` namespace this provider imports.
         "ag2>=0.14,<1.0",
         "flaml==2.6.0",
         "autogen_core>=0.7.5",


### PR DESCRIPTION
## Summary

Closes #4197 as not-actionable and stops Dependabot from re-raising it.

`ag2` 1.0 removed the top-level `autogen` package. The 1.x wheel ships only `ag2`:

```
$ python -c "import zipfile; print(sorted({n.split('/')[0] for n in zipfile.ZipFile('ag2-1.0.2-py3-none-any.whl').namelist()}))"
['ag2', 'ag2-1.0.2.dist-info']
```

`composio_autogen/provider.py` imports `autogen`, `autogen.agentchat.register_function`, and `autogen.agentchat.conversable_agent.ConversableAgent` — none of which exist in 1.x. #4197 widened the requirement to `<2.0` and CI resolved `ag2==1.0.2`, which failed the fresh-install import guard on all three Python versions:

```
File ".../composio_autogen/provider.py", line 6, in <module>
    import autogen
ModuleNotFoundError: No module named 'autogen'
```

This is the same failure mode as #3728 (pyautogen 0.10 shipping no `autogen`), one framework rename later. Adopting ag2 1.x is a provider rewrite against the new `ag2.tools` / middleware API, not a requirement widening — so it needs its own PR, not an automated bump.

## Changes

- `.github/dependabot.yml`: ignore `version-update:semver-major` for `ag2` in the pip ecosystem, matching the existing convention for compatibility-boundary majors. Security updates are unaffected.
- Record why the `<1.0` cap exists in both `pyproject.toml` and `setup.py`, so the next reader doesn't widen it by hand.

## Follow-up

Migrating `composio-autogen` to ag2 1.x remains open and unscheduled. Remove the ignore entry when that lands.