### PR TITLE
fix(sdk): omit empty file-uploadable arguments from tool execution

### DIFF
--- a/.changeset/drop-empty-file-uploads.md
+++ b/.changeset/drop-empty-file-uploads.md
@@ -1,0 +1,5 @@
+---
+'@composio/core': patch
+---
+
+Omit empty-string file-uploadable arguments from tool execution requests instead of forwarding them to the backend, which rejected them with "Input should be a valid dictionary or instance of FileUploadable". This now also applies when `dangerouslyAllowAutoUploadDownloadFiles` is off, and with it on an empty value is no longer attempted as an upload.

--- a/python/composio/core/models/_files.py
+++ b/python/composio/core/models/_files.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import hashlib
 import os
 import typing as t
@@ -1039,13 +1040,23 @@ class FileHelper(WithLogger):
             value=value,
         )
 
+    @staticmethod
+    def _drop_empty_file_value(value: t.Any) -> t.Any:
+        """Leaf handler: ``None``/``""`` at a file leaf mean "no file".
+
+        Neither is a staged ``{name, mimetype, s3key}`` descriptor, so the
+        backend rejects them with a validation error while callers (and the
+        playground UI) mean "absent". The walker omits the key instead.
+        """
+        return _DELETE_VALUE if value is None or value == "" else value
+
     def _upload_file_value(
         self,
         value: t.Any,
         tool: Tool,
         before_file_upload: t.Optional[BeforeFileUpload],
     ) -> t.Any:
-        if value is None or value == "":
+        if self._drop_empty_file_value(value) is _DELETE_VALUE:
             return _DELETE_VALUE
 
         return FileUploadable.from_path(
@@ -1063,20 +1074,18 @@ class FileHelper(WithLogger):
         self,
         value: t.Any,
         schema: t.Optional[t.Dict],
-        tool: Tool,
-        *,
-        before_file_upload: t.Optional[BeforeFileUpload] = None,
+        leaf: t.Callable[[t.Any], t.Any],
     ) -> t.Any:
-        """Return ``value`` with file-uploadable leaves staged for execution."""
+        """Return ``value`` with every ``file_uploadable`` leaf passed through ``leaf``.
+
+        A leaf may return ``_DELETE_VALUE`` to omit the key/item from its
+        parent container.
+        """
         if not isinstance(schema, dict):
             return value
 
         if schema.get("file_uploadable", False):
-            return self._upload_file_value(
-                value=value,
-                tool=tool,
-                before_file_upload=before_file_upload,
-            )
+            return leaf(value)
 
         uploadable_variant = self._find_uploadable_schema_variant(
             schema=schema,
@@ -1086,8 +1095,7 @@ class FileHelper(WithLogger):
             return self._substitute_file_upload_value(
                 value=value,
                 schema=uploadable_variant,
-                tool=tool,
-                before_file_upload=before_file_upload,
+                leaf=leaf,
             )
 
         if isinstance(value, dict) and "properties" in schema:
@@ -1098,8 +1106,7 @@ class FileHelper(WithLogger):
                 processed_item = self._substitute_file_upload_value(
                     value=item,
                     schema=item_schema,
-                    tool=tool,
-                    before_file_upload=before_file_upload,
+                    leaf=leaf,
                 )
                 if processed_item is not _DELETE_VALUE:
                     processed[key] = processed_item
@@ -1115,8 +1122,7 @@ class FileHelper(WithLogger):
                 processed_item = self._substitute_file_upload_value(
                     value=item,
                     schema=items_schema,
-                    tool=tool,
-                    before_file_upload=before_file_upload,
+                    leaf=leaf,
                 )
                 if processed_item is not _DELETE_VALUE:
                     processed_items.append(processed_item)
@@ -1131,12 +1137,19 @@ class FileHelper(WithLogger):
         request: t.Dict,
         *,
         before_file_upload: t.Optional[BeforeFileUpload] = None,
+        leaf: t.Optional[t.Callable[[t.Any], t.Any]] = None,
     ) -> t.Dict:
+        if leaf is None:
+            leaf = functools.partial(
+                self._upload_file_value,
+                tool=tool,
+                before_file_upload=before_file_upload,
+            )
+
         processed = self._substitute_file_upload_value(
             value=request,
             schema=schema,
-            tool=tool,
-            before_file_upload=before_file_upload,
+            leaf=leaf,
         )
         if processed is request:
             return request
@@ -1175,6 +1188,32 @@ class FileHelper(WithLogger):
             ),
             request=request,
             before_file_upload=before_file_upload,
+        )
+
+    def drop_empty_file_uploads(self, tool: Tool, request: t.Dict) -> t.Dict:
+        """Omit ``None``/``""`` at ``file_uploadable`` leaves without uploading.
+
+        This is the half of :meth:`substitute_file_uploads` that needs no
+        filesystem access, so it runs even when automatic upload is disabled:
+        an empty file value is never a valid staged descriptor and the backend
+        would reject it (issue #4233). Any other value -- a local path, a
+        staged descriptor, a list -- is forwarded untouched. Same mutation
+        contract as :meth:`substitute_file_uploads`.
+        """
+        schema = dereference_json_schema(
+            tool.input_parameters, on_unresolved="sentinel"
+        )
+        # Every execution takes this path by default, so leave requests for
+        # tools without a file input completely alone (identity included)
+        # instead of rebuilding their nested dicts.
+        if not self._file_uploadable(schema):
+            return request
+
+        return self._substitute_file_uploads_recursively(
+            tool=tool,
+            schema=schema,
+            request=request,
+            leaf=self._drop_empty_file_value,
         )
 
     def _is_file_downloadable(self, schema: t.Dict) -> bool:

--- a/python/composio/core/models/_files.py
+++ b/python/composio/core/models/_files.py
@@ -1105,10 +1105,15 @@ class FileHelper(WithLogger):
         if schema.get("file_uploadable", False):
             return leaf(value)
 
-        # Upload-enabled execution historically omits null file values, while
-        # disabled execution preserves them for nullable schemas. The active
-        # leaf handler owns that distinction.
-        if value is None and self._file_uploadable(schema):
+        # Array-only file inputs historically omit null in upload mode even
+        # though null cannot be traversed as an array. Keep that behavior
+        # without treating an optional object that merely contains a nested
+        # file property as a file leaf itself.
+        if (
+            value is None
+            and self._is_array_shaped_schema(schema)
+            and self._file_uploadable(schema)
+        ):
             return leaf(value)
 
         uploadable_variant = self._find_uploadable_schema_variant(

--- a/python/composio/core/models/_files.py
+++ b/python/composio/core/models/_files.py
@@ -782,6 +782,17 @@ class FileHelper(WithLogger):
         if schema.get(property_name, False):
             return True
 
+        # The default execution path uses this walker as a cheap gate before
+        # dereferencing. Inspect both modern and legacy definition containers
+        # so a file flag reachable only through ``$ref`` still passes the gate.
+        for definitions_key in ("$defs", "definitions"):
+            definitions = schema.get(definitions_key)
+            if not isinstance(definitions, dict):
+                continue
+            for definition in definitions.values():
+                if self._has_file_property(definition, property_name):
+                    return True
+
         # Check anyOf variants
         if "anyOf" in schema:
             for variant in schema["anyOf"]:
@@ -1002,6 +1013,14 @@ class FileHelper(WithLogger):
 
         return False
 
+    @staticmethod
+    def _is_array_shaped_schema(schema: t.Dict) -> bool:
+        """Return whether JSON Schema declares or infers an array shape."""
+        schema_type = schema.get("type")
+        if isinstance(schema_type, list):
+            return "array" in schema_type
+        return schema_type == "array" or (schema_type is None and "items" in schema)
+
     def _find_schema_variant_with_file_property(
         self,
         schema: t.Dict,
@@ -1042,13 +1061,12 @@ class FileHelper(WithLogger):
 
     @staticmethod
     def _drop_empty_file_value(value: t.Any) -> t.Any:
-        """Leaf handler: ``None``/``""`` at a file leaf mean "no file".
+        """Omit an empty string from a file input when auto-upload is disabled.
 
-        Neither is a staged ``{name, mimetype, s3key}`` descriptor, so the
-        backend rejects them with a validation error while callers (and the
-        playground UI) mean "absent". The walker omits the key instead.
+        An explicit ``None`` remains part of the payload so nullable file fields,
+        including required nullable fields, keep their JSON Schema semantics.
         """
-        return _DELETE_VALUE if value is None or value == "" else value
+        return _DELETE_VALUE if value == "" else value
 
     def _upload_file_value(
         self,
@@ -1056,7 +1074,7 @@ class FileHelper(WithLogger):
         tool: Tool,
         before_file_upload: t.Optional[BeforeFileUpload],
     ) -> t.Any:
-        if self._drop_empty_file_value(value) is _DELETE_VALUE:
+        if value is None or self._drop_empty_file_value(value) is _DELETE_VALUE:
             return _DELETE_VALUE
 
         return FileUploadable.from_path(
@@ -1087,16 +1105,40 @@ class FileHelper(WithLogger):
         if schema.get("file_uploadable", False):
             return leaf(value)
 
+        # Upload-enabled execution historically omits null file values, while
+        # disabled execution preserves them for nullable schemas. The active
+        # leaf handler owns that distinction.
+        if value is None and self._file_uploadable(schema):
+            return leaf(value)
+
         uploadable_variant = self._find_uploadable_schema_variant(
             schema=schema,
             value=value,
         )
         if uploadable_variant is not None:
+            # An empty string cannot match an array-only file input, but it may
+            # match another non-file string variant in the same composition.
+            if value == "" and self._is_array_shaped_schema(uploadable_variant):
+                matching_non_file_variant = any(
+                    not self._file_uploadable(variant)
+                    and self._json_schema_type_matches_value(variant, value)
+                    for variant in self._schema_variants(schema)
+                )
+                if matching_non_file_variant:
+                    return value
+                return leaf(value)
             return self._substitute_file_upload_value(
                 value=value,
                 schema=uploadable_variant,
                 leaf=leaf,
             )
+
+        if (
+            value == ""
+            and self._is_array_shaped_schema(schema)
+            and self._file_uploadable(schema)
+        ):
+            return leaf(value)
 
         if isinstance(value, dict) and "properties" in schema:
             processed: t.Dict[str, t.Any] = {}
@@ -1191,30 +1233,35 @@ class FileHelper(WithLogger):
         )
 
     def drop_empty_file_uploads(self, tool: Tool, request: t.Dict) -> t.Dict:
-        """Omit ``None``/``""`` at ``file_uploadable`` leaves without uploading.
+        """Omit ``""`` at ``file_uploadable`` leaves without uploading.
 
         This is the half of :meth:`substitute_file_uploads` that needs no
         filesystem access, so it runs even when automatic upload is disabled:
         an empty file value is never a valid staged descriptor and the backend
-        would reject it (issue #4233). Any other value -- a local path, a
-        staged descriptor, a list -- is forwarded untouched. Same mutation
-        contract as :meth:`substitute_file_uploads`.
+        would reject it (issue #4233). Explicit ``None`` and every non-empty
+        value are forwarded untouched. File-bearing request containers are
+        rebuilt; unlike :meth:`substitute_file_uploads`, this method never
+        mutates caller-owned arguments or copies arbitrary leaf objects.
         """
+        # Every execution takes this path by default, so leave requests for
+        # tools without a file input completely alone. Check the raw schema
+        # first to avoid paying the dereference cost for non-file tools.
+        if not self._file_uploadable(tool.input_parameters):
+            return request
+
         schema = dereference_json_schema(
             tool.input_parameters, on_unresolved="sentinel"
         )
-        # Every execution takes this path by default, so leave requests for
-        # tools without a file input completely alone (identity included)
-        # instead of rebuilding their nested dicts.
-        if not self._file_uploadable(schema):
-            return request
-
-        return self._substitute_file_uploads_recursively(
-            tool=tool,
+        processed = self._substitute_file_upload_value(
+            value=request,
             schema=schema,
-            request=request,
             leaf=self._drop_empty_file_value,
         )
+        assert isinstance(processed, dict), (
+            "expected dict from _substitute_file_upload_value at the root; "
+            f"got {type(processed).__name__}"
+        )
+        return processed
 
     def _is_file_downloadable(self, schema: t.Dict) -> bool:
         """Check if a schema has file_downloadable property."""

--- a/python/composio/core/models/tools.py
+++ b/python/composio/core/models/tools.py
@@ -515,6 +515,10 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
                     request=arguments,
                     before_file_upload=bfu,
                 )
+            else:
+                arguments = self._file_helper.drop_empty_file_uploads(
+                    tool=tool, request=arguments
+                )
 
             toolkit_slug = _toolkit_slug(tool, "composio")
 
@@ -675,6 +679,12 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
                 tool=tool,
                 request=arguments,
                 before_file_upload=bfu,
+            )
+        else:
+            # Auto-upload is opt-in, but "no file" must still be sent as an
+            # omitted key rather than ``""``/``None`` (issue #4233).
+            arguments = self._file_helper.drop_empty_file_uploads(
+                tool=tool, request=arguments
             )
 
         if modifiers is not None:

--- a/python/composio/core/models/tools.py
+++ b/python/composio/core/models/tools.py
@@ -682,7 +682,8 @@ class Tools(Resource, t.Generic[TTool, TToolCollection]):
             )
         else:
             # Auto-upload is opt-in, but "no file" must still be sent as an
-            # omitted key rather than ``""``/``None`` (issue #4233).
+            # omitted key rather than ``""`` (issue #4233). Explicit ``None``
+            # remains valid for nullable file inputs.
             arguments = self._file_helper.drop_empty_file_uploads(
                 tool=tool, request=arguments
             )

--- a/python/tests/test_auto_upload_download_files.py
+++ b/python/tests/test_auto_upload_download_files.py
@@ -456,6 +456,72 @@ class TestAutoUploadDownloadFilesDisabled:
 
                 mock_substitute.assert_not_called()
 
+    def test_execute_drops_empty_file_values_when_disabled(
+        self, mock_client, mock_provider
+    ):
+        """Issue #4233: with auto-upload off, ``attachment: ""`` must be
+        omitted from the request instead of forwarded to the backend, while a
+        real value is forwarded as-is (not uploaded)."""
+        tools = Tools(
+            client=mock_client,
+            provider=mock_provider,
+            toolkit_versions={"gmail": "20251201_01"},
+        )
+
+        file_uploadable = {
+            "type": "object",
+            "file_uploadable": True,
+            "properties": {
+                "name": {"type": "string"},
+                "mimetype": {"type": "string"},
+                "s3key": {"type": "string"},
+            },
+        }
+        mock_tool = create_mock_tool(
+            slug="GMAIL_CREATE_DRAFT",
+            toolkit_slug="gmail",
+            input_parameters={
+                "type": "object",
+                "properties": {
+                    "subject": {"type": "string"},
+                    "attachment": {
+                        "anyOf": [
+                            file_uploadable,
+                            {"type": "array", "items": file_uploadable},
+                            {"type": "null"},
+                        ]
+                    },
+                },
+            },
+        )
+        mock_execute_response = Mock()
+        mock_execute_response.model_dump.return_value = {
+            "data": {},
+            "error": None,
+            "successful": True,
+        }
+        mock_client.tools.execute.return_value = mock_execute_response
+
+        with patch.object(
+            tools, "get_raw_composio_tool_by_slug", return_value=mock_tool
+        ):
+            for value, expected in (
+                ("", {"subject": "Test"}),
+                (None, {"subject": "Test"}),
+                (
+                    "/path/to/file.txt",
+                    {"subject": "Test", "attachment": "/path/to/file.txt"},
+                ),
+            ):
+                mock_client.tools.execute.reset_mock()
+                tools.execute(
+                    slug="GMAIL_CREATE_DRAFT",
+                    arguments={"subject": "Test", "attachment": value},
+                    dangerously_skip_version_check=True,
+                )
+                sent = mock_client.tools.execute.call_args.kwargs["arguments"]
+                assert sent == expected, value
+
     def test_execute_skips_file_downloads_when_disabled(
         self, mock_client, mock_provider
     ):

--- a/python/tests/test_auto_upload_download_files.py
+++ b/python/tests/test_auto_upload_download_files.py
@@ -492,6 +492,7 @@ class TestAutoUploadDownloadFilesDisabled:
                         ]
                     },
                 },
+                "required": ["attachment"],
             },
         )
         mock_execute_response = Mock()
@@ -507,20 +508,22 @@ class TestAutoUploadDownloadFilesDisabled:
         ):
             for value, expected in (
                 ("", {"subject": "Test"}),
-                (None, {"subject": "Test"}),
+                (None, {"subject": "Test", "attachment": None}),
                 (
                     "/path/to/file.txt",
                     {"subject": "Test", "attachment": "/path/to/file.txt"},
                 ),
             ):
                 mock_client.tools.execute.reset_mock()
+                arguments = {"subject": "Test", "attachment": value}
                 tools.execute(
                     slug="GMAIL_CREATE_DRAFT",
-                    arguments={"subject": "Test", "attachment": value},
+                    arguments=arguments,
                     dangerously_skip_version_check=True,
                 )
                 sent = mock_client.tools.execute.call_args.kwargs["arguments"]
                 assert sent == expected, value
+                assert arguments == {"subject": "Test", "attachment": value}
 
     def test_execute_skips_file_downloads_when_disabled(
         self, mock_client, mock_provider

--- a/python/tests/test_files.py
+++ b/python/tests/test_files.py
@@ -779,11 +779,10 @@ class TestFileUploadSubstitutionWithUnionTypes:
         # None/empty values should be removed
         assert "fileInput" not in result
 
-    def test_drop_empty_file_uploads_omits_empty_leaves_without_uploading(
+    def test_drop_empty_file_uploads_omits_empty_strings_without_uploading(
         self, file_helper, mock_tool
     ):
-        """Issue #4233: ``""``/``None`` at a file leaf mean "no file" even when
-        auto-upload is off, while any other value is forwarded untouched."""
+        """Disabled auto-upload omits empty strings but preserves explicit nulls."""
         file_uploadable = {
             "type": "object",
             "file_uploadable": True,
@@ -817,6 +816,7 @@ class TestFileUploadSubstitutionWithUnionTypes:
                     "type": "object",
                     "properties": {"file": {"$ref": "#/$defs/F"}},
                 },
+                "opaque": {"type": "object", "additionalProperties": True},
                 "thread_id": {"type": "string"},
             },
             "$defs": {"F": file_uploadable},
@@ -827,6 +827,15 @@ class TestFileUploadSubstitutionWithUnionTypes:
             "attachment": "",
             "extra": [None, "", staged, "/tmp/keep.txt"],
             "nested": {"file": None},
+            "opaque": {"preserve_identity": True},
+            "thread_id": "",
+        }
+        original_request = {
+            "subject": "Test",
+            "attachment": "",
+            "extra": [None, "", staged, "/tmp/keep.txt"],
+            "nested": {"file": None},
+            "opaque": {"preserve_identity": True},
             "thread_id": "",
         }
 
@@ -836,14 +845,165 @@ class TestFileUploadSubstitutionWithUnionTypes:
             )
 
         from_path.assert_not_called()
-        assert result is request
+        assert result is not request
         assert result == {
             "subject": "Test",
-            "extra": [staged, "/tmp/keep.txt"],
-            "nested": {},
+            "extra": [None, staged, "/tmp/keep.txt"],
+            "nested": {"file": None},
+            "opaque": {"preserve_identity": True},
             # non-file empty strings are not the walker's business
             "thread_id": "",
         }
+        assert result["extra"] is not request["extra"]
+        assert result["extra"][1] is request["extra"][2]
+        assert result["nested"] is not request["nested"]
+        assert result["opaque"] is request["opaque"]
+        assert request == original_request
+
+    def test_drop_empty_file_uploads_skips_dereference_for_non_file_schema(
+        self, file_helper, mock_tool
+    ):
+        """Default execution does not dereference schemas without file inputs."""
+        mock_tool.input_parameters = {
+            "type": "object",
+            "properties": {
+                "filters": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                }
+            },
+        }
+        request = {"filters": {"query": "open"}}
+
+        with patch(
+            "composio.core.models._files.dereference_json_schema"
+        ) as dereference:
+            result = file_helper.drop_empty_file_uploads(
+                tool=mock_tool, request=request
+            )
+
+        assert result is request
+        dereference.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("definitions_key", "ref"),
+        [
+            ("$defs", "#/$defs/FileUploadable"),
+            ("definitions", "#/definitions/FileUploadable"),
+        ],
+    )
+    def test_drop_empty_file_uploads_resolves_referenced_file_schema(
+        self, file_helper, mock_tool, definitions_key, ref
+    ):
+        """The raw cheap gate still admits modern and legacy referenced schemas."""
+        mock_tool.input_parameters = {
+            "type": "object",
+            "properties": {"attachment": {"$ref": ref}},
+            definitions_key: {
+                "FileUploadable": {
+                    "type": "object",
+                    "file_uploadable": True,
+                }
+            },
+        }
+
+        result = file_helper.drop_empty_file_uploads(
+            tool=mock_tool, request={"attachment": ""}
+        )
+
+        assert result == {}
+
+    @pytest.mark.parametrize(
+        "attachment_schema",
+        [
+            {
+                "type": "array",
+                "items": {"type": "object", "file_uploadable": True},
+            },
+            {
+                "items": {"type": "object", "file_uploadable": True},
+            },
+            {
+                "anyOf": [
+                    {
+                        "type": "array",
+                        "items": {"type": "object", "file_uploadable": True},
+                    },
+                    {"type": "null"},
+                ]
+            },
+            {
+                "anyOf": [
+                    {
+                        "items": {"type": "object", "file_uploadable": True},
+                    },
+                    {"type": "null"},
+                ]
+            },
+        ],
+    )
+    @pytest.mark.parametrize(
+        ("value", "expected_without_upload"),
+        [("", {}), (None, {"attachment": None})],
+    )
+    def test_empty_values_follow_mode_for_array_only_file_schema(
+        self, file_helper, mock_tool, attachment_schema, value, expected_without_upload
+    ):
+        """Array-only file inputs omit empty strings and upload-mode nulls."""
+        mock_tool.input_parameters = {
+            "type": "object",
+            "properties": {"attachment": attachment_schema},
+        }
+
+        dropped = file_helper.drop_empty_file_uploads(
+            tool=mock_tool, request={"attachment": value}
+        )
+        with patch.object(FileUploadable, "from_path") as from_path:
+            uploaded = file_helper.substitute_file_uploads(
+                tool=mock_tool, request={"attachment": value}
+            )
+
+        assert dropped == expected_without_upload
+        assert uploaded == {}
+        from_path.assert_not_called()
+
+    @pytest.mark.parametrize("array_type", ["explicit", "inferred"])
+    def test_empty_string_is_preserved_when_non_file_string_variant_matches(
+        self, file_helper, mock_tool, array_type
+    ):
+        """A composed string branch takes precedence over array-file cleanup."""
+        array_file_schema = {
+            "items": {
+                "type": "object",
+                "file_uploadable": True,
+            },
+        }
+        if array_type == "explicit":
+            array_file_schema["type"] = "array"
+
+        mock_tool.input_parameters = {
+            "type": "object",
+            "properties": {
+                "attachment": {
+                    "anyOf": [
+                        array_file_schema,
+                        {"type": "string"},
+                    ]
+                }
+            },
+        }
+
+        dropped = file_helper.drop_empty_file_uploads(
+            tool=mock_tool, request={"attachment": ""}
+        )
+        with patch.object(FileUploadable, "from_path") as from_path:
+            uploaded = file_helper.substitute_file_uploads(
+                tool=mock_tool, request={"attachment": ""}
+            )
+
+        assert dropped == {"attachment": ""}
+        assert uploaded == {"attachment": ""}
+        from_path.assert_not_called()
 
     def test_substitute_upload_empty_string_in_anyof(self, file_helper, mock_tool):
         """Test that empty string values in anyOf with file_uploadable are handled."""

--- a/python/tests/test_files.py
+++ b/python/tests/test_files.py
@@ -779,6 +779,72 @@ class TestFileUploadSubstitutionWithUnionTypes:
         # None/empty values should be removed
         assert "fileInput" not in result
 
+    def test_drop_empty_file_uploads_omits_empty_leaves_without_uploading(
+        self, file_helper, mock_tool
+    ):
+        """Issue #4233: ``""``/``None`` at a file leaf mean "no file" even when
+        auto-upload is off, while any other value is forwarded untouched."""
+        file_uploadable = {
+            "type": "object",
+            "file_uploadable": True,
+            "title": "FileUploadable",
+            "properties": {
+                "name": {"type": "string"},
+                "mimetype": {"type": "string"},
+                "s3key": {"type": "string"},
+            },
+            "required": ["name", "mimetype", "s3key"],
+        }
+        mock_tool.input_parameters = {
+            "type": "object",
+            "properties": {
+                "subject": {"type": "string"},
+                "attachment": {
+                    "anyOf": [
+                        file_uploadable,
+                        {"type": "array", "items": file_uploadable},
+                        {"type": "null"},
+                    ],
+                    "default": None,
+                },
+                "extra": {
+                    "anyOf": [
+                        {"type": "array", "items": file_uploadable},
+                        {"type": "null"},
+                    ]
+                },
+                "nested": {
+                    "type": "object",
+                    "properties": {"file": {"$ref": "#/$defs/F"}},
+                },
+                "thread_id": {"type": "string"},
+            },
+            "$defs": {"F": file_uploadable},
+        }
+        staged = {"name": "a.txt", "mimetype": "text/plain", "s3key": "k"}
+        request = {
+            "subject": "Test",
+            "attachment": "",
+            "extra": [None, "", staged, "/tmp/keep.txt"],
+            "nested": {"file": None},
+            "thread_id": "",
+        }
+
+        with patch.object(FileUploadable, "from_path") as from_path:
+            result = file_helper.drop_empty_file_uploads(
+                tool=mock_tool, request=request
+            )
+
+        from_path.assert_not_called()
+        assert result is request
+        assert result == {
+            "subject": "Test",
+            "extra": [staged, "/tmp/keep.txt"],
+            "nested": {},
+            # non-file empty strings are not the walker's business
+            "thread_id": "",
+        }
+
     def test_substitute_upload_empty_string_in_anyof(self, file_helper, mock_tool):
         """Test that empty string values in anyOf with file_uploadable are handled."""
         mock_tool.input_parameters = {

--- a/python/tests/test_files.py
+++ b/python/tests/test_files.py
@@ -779,6 +779,36 @@ class TestFileUploadSubstitutionWithUnionTypes:
         # None/empty values should be removed
         assert "fileInput" not in result
 
+    def test_substitute_upload_preserves_null_optional_object_with_nested_file(
+        self, file_helper, mock_tool
+    ):
+        """A null container is not itself a file-uploadable leaf."""
+        mock_tool.input_parameters = {
+            "type": "object",
+            "properties": {
+                "options": {
+                    "type": "object",
+                    "properties": {
+                        "attachment": {
+                            "type": "object",
+                            "file_uploadable": True,
+                        }
+                    },
+                }
+            },
+        }
+        request = {"options": None}
+
+        with patch.object(FileUploadable, "from_path") as from_path:
+            result = file_helper.substitute_file_uploads(
+                tool=mock_tool,
+                request=request,
+            )
+
+        assert result is request
+        assert result == {"options": None}
+        from_path.assert_not_called()
+
     def test_drop_empty_file_uploads_omits_empty_strings_without_uploading(
         self, file_helper, mock_tool
     ):

--- a/python/tests/test_tool_execution.py
+++ b/python/tests/test_tool_execution.py
@@ -128,6 +128,57 @@ class TestToolExecution:
             ("after_execute", "composio"),
         ]
 
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("", {"metadata": {"source": "user"}}),
+            (
+                None,
+                {"attachment": None, "metadata": {"source": "user"}},
+            ),
+        ],
+    )
+    def test_tool_router_drops_only_empty_file_strings_without_mutating_arguments(
+        self, value, expected
+    ):
+        """Session execution matches direct execution for disabled auto-upload."""
+        mock_client = mock_http_client()
+        tools = Tools(client=mock_client, provider=Mock())
+        tool = self.create_mock_tool("GMAIL_CREATE_DRAFT", "gmail")
+        tool.input_parameters = {
+            "type": "object",
+            "properties": {
+                "attachment": {
+                    "anyOf": [
+                        {"type": "object", "file_uploadable": True},
+                        {"type": "null"},
+                    ]
+                },
+                "metadata": {
+                    "type": "object",
+                    "properties": {"source": {"type": "string"}},
+                },
+            },
+            "required": ["attachment"],
+        }
+        tools._tool_schemas[tool.slug] = tool
+        mock_client.tool_router.session.execute.return_value = Mock(data={}, error=None)
+        execute = tools._wrap_execute_tool_for_tool_router("session_123")
+        arguments = {
+            "attachment": value,
+            "metadata": {"source": "user"},
+        }
+
+        execute(tool.slug, arguments)
+
+        sent = mock_client.tool_router.session.execute.call_args.kwargs["arguments"]
+        assert sent == expected
+        assert arguments == {
+            "attachment": value,
+            "metadata": {"source": "user"},
+        }
+        assert sent["metadata"] is not arguments["metadata"]
+
     def test_execute_without_toolkit_runs_modifiers_and_fetches_once(self):
         """Toolkit-less tools execute with the same fallback used by TypeScript."""
         from composio.core.models._modifiers import after_execute, before_execute

--- a/ts/packages/core/src/models/ToolRouterSession.ts
+++ b/ts/packages/core/src/models/ToolRouterSession.ts
@@ -41,7 +41,11 @@ import { ACL_ONLY_FOR_SHARED_ERROR_FRAGMENT, serializeExperimentalForWire } from
 import { z } from 'zod/v3';
 import { transform } from '../utils/transform';
 import { ToolkitConnectionStateSchema } from '../types/toolRouter.types';
-import { ComposioAclOnlyForSharedError, ValidationError } from '../errors';
+import {
+  ComposioAclOnlyForSharedError,
+  ComposioInvalidModifierError,
+  ValidationError,
+} from '../errors';
 import { Tools } from './Tools';
 import { ToolRouterSessionFilesMount } from './ToolRouterSessionFileMount';
 import type {
@@ -51,7 +55,7 @@ import type {
   RegisteredCustomTool,
   RegisteredCustomToolkit,
 } from '../types/customTool.types';
-import type { Tool, ToolExecuteResponse } from '../types/tool.types';
+import { ToolSchema, type Tool, type ToolExecuteResponse } from '../types/tool.types';
 import type { SessionProxyExecuteParams } from '../types/toolRouter.types';
 import type {
   SessionExecuteParams,
@@ -190,13 +194,14 @@ export class ToolRouterSession<
     requestOptions?: ComposioRequestOptions
   ): Promise<ReturnType<TProvider['wrapTools']>> {
     const ToolsModel = new Tools<TToolCollection, TTool, TProvider>(this.client, this.config);
-    const tools = await ToolsModel.getRawToolRouterSessionTools(
+    const rawTools = await ToolsModel.getRawToolRouterSessionTools(
       this.sessionId,
-      modifiers?.modifySchema ? { modifySchema: modifiers.modifySchema } : undefined,
+      undefined,
       requestOptions
     );
+    const tools = await this.applySchemaModifier(rawTools, modifiers?.modifySchema);
     const sessionTools = await this.addPreloadedCustomTools(tools, modifiers);
-    const toolBySlug = new Map(sessionTools.map(tool => [tool.slug.toUpperCase(), tool]));
+    const rawToolBySlug = new Map(rawTools.map(tool => [tool.slug.toUpperCase(), tool]));
 
     if (this.hasCustomTools()) {
       // Create an execute function that splits local/remote tools in COMPOSIO_MULTI_EXECUTE_TOOL
@@ -205,7 +210,7 @@ export class ToolRouterSession<
         input: Record<string, unknown>
       ): Promise<ToolExecuteResponse> => {
         if (toolSlug === COMPOSIO_MULTI_EXECUTE_TOOL) {
-          return this.routeMultiExecute(input, ToolsModel, sessionTools, modifiers);
+          return this.routeMultiExecute(input, ToolsModel, rawTools, modifiers);
         }
         const customTool = findCustomTool(this.customToolsMap, toolSlug);
         if (customTool) {
@@ -217,7 +222,7 @@ export class ToolRouterSession<
           toolSlug,
           input,
           modifiers,
-          toolBySlug.get(toolSlug.toUpperCase())
+          rawToolBySlug.get(toolSlug.toUpperCase())
         );
       };
 
@@ -233,8 +238,31 @@ export class ToolRouterSession<
     }
 
     // Standard path (no local tools)
-    const wrappedTools = ToolsModel.wrapToolsForToolRouter(this.sessionId, sessionTools, modifiers);
+    const wrappedTools = modifiers?.modifySchema
+      ? ToolsModel.wrapToolsForToolRouter(this.sessionId, sessionTools, modifiers, rawTools)
+      : ToolsModel.wrapToolsForToolRouter(this.sessionId, sessionTools, modifiers);
     return wrappedTools as ReturnType<TProvider['wrapTools']>;
+  }
+
+  private async applySchemaModifier(
+    tools: Tool[],
+    modifier?: SessionMetaToolOptions['modifySchema']
+  ): Promise<Tool[]> {
+    if (!modifier) {
+      return tools;
+    }
+    if (typeof modifier !== 'function') {
+      throw new ComposioInvalidModifierError('Invalid schema modifier. Not a function.');
+    }
+    return Promise.all(
+      tools.map(tool =>
+        modifier({
+          toolSlug: tool.slug,
+          toolkitSlug: tool.toolkit?.slug ?? 'unknown',
+          schema: ToolSchema.parse(tool),
+        })
+      )
+    );
   }
 
   private async addPreloadedCustomTools(

--- a/ts/packages/core/src/models/Tools.ts
+++ b/ts/packages/core/src/models/Tools.ts
@@ -1370,7 +1370,8 @@ export class Tools<
        * @deprecated The `customConnectionData` proxy param is deprecated and will be
        * removed in a future release. Use `customAuthParams` instead.
        */
-      // @ts-expect-error
+      // oxlint-disable-next-line typescript/ban-ts-comment -- generated client versions disagree about this deprecated field
+      // @ts-ignore
       custom_connection_data: toolProxyParams.data.customConnectionData,
     } as ComposioToolProxyParams;
     return withCancellation(

--- a/ts/packages/core/src/models/Tools.ts
+++ b/ts/packages/core/src/models/Tools.ts
@@ -272,12 +272,56 @@ export class Tools<
     if (requestOptions?.signal?.aborted) {
       throw new ComposioRequestCancelledError();
     }
+    let modifiedParams = await this.applyFileUploadModifiers(
+      tool,
+      { toolSlug, toolkitSlug, params },
+      modifiers?.beforeFileUpload,
+      requestOptions
+    );
+
+    // apply the before execute modifiers
+    if (modifiers?.beforeExecute) {
+      if (typeof modifiers.beforeExecute === 'function') {
+        modifiedParams = await modifiers.beforeExecute({
+          toolSlug,
+          toolkitSlug,
+          params: modifiedParams,
+        });
+        if (requestOptions?.signal?.aborted) {
+          throw new ComposioRequestCancelledError();
+        }
+      } else {
+        throw new ComposioInvalidModifierError('Invalid beforeExecute modifier. Not a function.');
+      }
+    }
+    return modifiedParams;
+  }
+
+  /**
+   * Applies schema-aware file preprocessing shared by direct and Tool Router
+   * session execution. This always runs before the caller's `beforeExecute`
+   * hook so the hook observes the exact arguments sent to the backend.
+   */
+  private async applyFileUploadModifiers(
+    tool: Tool,
+    {
+      toolSlug,
+      toolkitSlug,
+      params,
+    }: {
+      toolSlug: string;
+      toolkitSlug: string;
+      params: ToolExecuteParams;
+    },
+    beforeFileUpload?: ExecuteToolModifiers['beforeFileUpload'],
+    requestOptions?: ComposioRequestOptions
+  ): Promise<ToolExecuteParams> {
     let modifiedParams = params;
     // if auto upload download files is enabled, upload the files to the Composio API
     if (this.autoUploadDownloadFiles) {
       const fileToolModifier = new FileToolModifier(this.client, {
         ...this.fileUploadPathOptions,
-        beforeFileUpload: modifiers?.beforeFileUpload,
+        beforeFileUpload,
       });
       modifiedParams = await fileToolModifier.fileUploadModifier(tool, {
         toolSlug,
@@ -319,21 +363,6 @@ export class Tools<
             `  2) Enable auto-upload with a scoped allowlist: ` +
             `\`new Composio({ dangerouslyAllowAutoUploadDownloadFiles: true, fileUploadDirs: ['/safe/dir'] })\`.`
         );
-      }
-    }
-    // apply the before execute modifiers
-    if (modifiers?.beforeExecute) {
-      if (typeof modifiers.beforeExecute === 'function') {
-        modifiedParams = await modifiers.beforeExecute({
-          toolSlug,
-          toolkitSlug,
-          params: modifiedParams,
-        });
-        if (requestOptions?.signal?.aborted) {
-          throw new ComposioRequestCancelledError();
-        }
-      } else {
-        throw new ComposioInvalidModifierError('Invalid beforeExecute modifier. Not a function.');
       }
     }
     return modifiedParams;
@@ -867,9 +896,10 @@ export class Tools<
   wrapToolsForToolRouter(
     sessionId: string,
     tools: Tool[],
-    modifiers?: SessionExecuteMetaModifiers
+    modifiers?: SessionExecuteMetaModifiers,
+    rawTools: Tool[] = tools.map(tool => ToolSchema.parse(tool))
   ): Tool[] {
-    const executeToolFn = this.createExecuteToolFnForToolRouter(sessionId, tools, modifiers);
+    const executeToolFn = this.createExecuteToolFnForToolRouter(sessionId, rawTools, modifiers);
     return this.provider.wrapTools(tools, executeToolFn) as Tool[];
   }
 
@@ -1166,9 +1196,25 @@ export class Tools<
       });
     }
 
-    // Apply beforeExecute modifier if provided
     let modifiedParams = body.arguments ?? {};
     const toolkitSlug = tool?.toolkit?.slug ?? 'composio';
+
+    if (tool) {
+      const fileModifiedParams = await this.applyFileUploadModifiers(
+        tool,
+        {
+          toolSlug,
+          toolkitSlug,
+          params: { arguments: modifiedParams },
+        },
+        undefined,
+        requestOptions
+      );
+      modifiedParams = fileModifiedParams.arguments ?? {};
+    }
+
+    // Apply beforeExecute modifier after file preprocessing so the hook sees
+    // the same arguments that will be sent to the Tool Router.
     if (modifiers?.beforeExecute) {
       modifiedParams = await modifiers.beforeExecute({
         toolSlug,
@@ -1324,7 +1370,7 @@ export class Tools<
        * @deprecated The `customConnectionData` proxy param is deprecated and will be
        * removed in a future release. Use `customAuthParams` instead.
        */
-      // @ts-ignore
+      // @ts-expect-error
       custom_connection_data: toolProxyParams.data.customConnectionData,
     } as ComposioToolProxyParams;
     return withCancellation(

--- a/ts/packages/core/src/models/Tools.ts
+++ b/ts/packages/core/src/models/Tools.ts
@@ -1324,7 +1324,7 @@ export class Tools<
        * @deprecated The `customConnectionData` proxy param is deprecated and will be
        * removed in a future release. Use `customAuthParams` instead.
        */
-      // @ts-expect-error
+      // @ts-ignore
       custom_connection_data: toolProxyParams.data.customConnectionData,
     } as ComposioToolProxyParams;
     return withCancellation(

--- a/ts/packages/core/src/models/Tools.ts
+++ b/ts/packages/core/src/models/Tools.ts
@@ -54,7 +54,11 @@ import { handleToolExecutionError } from '../errors/ToolErrors';
 import type { SessionExecuteParams } from '@composio/client/resources/tool-router/session/session.mjs';
 import { CONFIG_DEFAULTS } from '../utils/config-defaults';
 import { resolveEffectiveUploadAllowlist } from '../utils/fileDirs';
-import { schemaHasFileUploadable } from '../utils/modifiers/FileToolModifier.utils.neutral';
+import {
+  dropEmptyFileUploads,
+  schemaHasFileUploadable,
+} from '../utils/modifiers/FileToolModifier.utils.neutral';
+import { dereferenceJsonSchema } from '../utils/jsonSchema';
 import { ComposioRequestOptions } from '../types/requestOptions.types';
 import { withCancellation } from '../utils/cancellation';
 import { ComposioRequestCancelledError } from '../errors/SDKErrors';
@@ -284,26 +288,38 @@ export class Tools<
       if (requestOptions?.signal?.aborted) {
         throw new ComposioRequestCancelledError();
       }
-    } else if (
-      schemaHasFileUploadable(tool.inputParameters) &&
-      !this.warnedAutoUploadDisabledForTool.has(toolSlug)
-    ) {
-      // With auto-upload off, the raw `{ name, mimetype, s3key }` shape is
-      // what the LLM / caller sees on `tool.inputParameters`. LLMs can't
-      // produce a valid `s3key` and will hallucinate one, which then fails
-      // at the staging-lookup step on the backend. Nudge the caller toward
-      // manual staging or opting into auto-upload.
-      this.warnedAutoUploadDisabledForTool.add(toolSlug);
-      logger.warn(
-        `Tool "${toolSlug}" (toolkit "${toolkitSlug}") has a file-uploadable input, but ` +
-          `\`dangerouslyAllowAutoUploadDownloadFiles\` is disabled. The SDK will forward ` +
-          `the file argument as-is; if it isn't already a staged ` +
-          `{ name, mimetype, s3key } descriptor, the backend will reject the call. Either:\n` +
-          `  1) Stage the file yourself: \`const f = await composio.files.upload({ file, toolSlug, toolkitSlug }); ` +
-          `await composio.tools.execute('${toolSlug}', { userId, arguments: { <fileField>: f } })\`, or\n` +
-          `  2) Enable auto-upload with a scoped allowlist: ` +
-          `\`new Composio({ dangerouslyAllowAutoUploadDownloadFiles: true, fileUploadDirs: ['/safe/dir'] })\`.`
-      );
+    } else if (tool.inputParameters && schemaHasFileUploadable(tool.inputParameters)) {
+      // Auto-upload is opt-in, but "no file" must still be sent as an
+      // omitted key rather than `''`, which the backend rejects
+      // (https://github.com/ComposioHQ/composio/issues/4233).
+      if (modifiedParams.arguments) {
+        modifiedParams = {
+          ...modifiedParams,
+          arguments: (await dropEmptyFileUploads(
+            modifiedParams.arguments,
+            dereferenceJsonSchema(tool.inputParameters, { onUnresolved: 'sentinel' })
+          )) as ToolExecuteParams['arguments'],
+        };
+      }
+
+      if (!this.warnedAutoUploadDisabledForTool.has(toolSlug)) {
+        // With auto-upload off, the raw `{ name, mimetype, s3key }` shape is
+        // what the LLM / caller sees on `tool.inputParameters`. LLMs can't
+        // produce a valid `s3key` and will hallucinate one, which then fails
+        // at the staging-lookup step on the backend. Nudge the caller toward
+        // manual staging or opting into auto-upload.
+        this.warnedAutoUploadDisabledForTool.add(toolSlug);
+        logger.warn(
+          `Tool "${toolSlug}" (toolkit "${toolkitSlug}") has a file-uploadable input, but ` +
+            `\`dangerouslyAllowAutoUploadDownloadFiles\` is disabled. The SDK will forward ` +
+            `the file argument as-is; if it isn't already a staged ` +
+            `{ name, mimetype, s3key } descriptor, the backend will reject the call. Either:\n` +
+            `  1) Stage the file yourself: \`const f = await composio.files.upload({ file, toolSlug, toolkitSlug }); ` +
+            `await composio.tools.execute('${toolSlug}', { userId, arguments: { <fileField>: f } })\`, or\n` +
+            `  2) Enable auto-upload with a scoped allowlist: ` +
+            `\`new Composio({ dangerouslyAllowAutoUploadDownloadFiles: true, fileUploadDirs: ['/safe/dir'] })\`.`
+        );
+      }
     }
     // apply the before execute modifiers
     if (modifiers?.beforeExecute) {
@@ -1308,7 +1324,7 @@ export class Tools<
        * @deprecated The `customConnectionData` proxy param is deprecated and will be
        * removed in a future release. Use `customAuthParams` instead.
        */
-      // @ts-ignore
+      // @ts-expect-error
       custom_connection_data: toolProxyParams.data.customConnectionData,
     } as ComposioToolProxyParams;
     return withCancellation(

--- a/ts/packages/core/src/utils/modifiers/FileToolModifier.node.ts
+++ b/ts/packages/core/src/utils/modifiers/FileToolModifier.node.ts
@@ -22,9 +22,13 @@ import {
   type GetFileDataAfterUploadingToS3Options,
 } from '../fileUtils.node';
 import {
+  DELETE_VALUE,
+  findSchemaVariantWithFileProperty,
+  getSchemaVariants,
+  isEmptyFileValue,
   isPlainObject,
   transformProperties,
-  schemaHasFileProperty,
+  walkFileUploadableLeaves,
 } from './FileToolModifier.utils.neutral';
 import { dereferenceJsonSchema } from '../jsonSchema';
 import { withCancellation } from '../cancellation';
@@ -44,68 +48,14 @@ const resolveFileSchema = <Schema extends JSONSchemaProperty>(
 ): Schema | undefined =>
   schema ? dereferenceJsonSchema(schema, { onUnresolved: 'sentinel' }) : schema;
 
-const getSchemaVariants = (schema: JSONSchemaProperty | undefined): JSONSchemaProperty[] => [
-  ...(schema?.anyOf ?? []),
-  ...(schema?.oneOf ?? []),
-  ...(schema?.allOf ?? []),
-];
-
-const jsonSchemaTypeMatchesValue = (schema: JSONSchemaProperty, value: unknown): boolean => {
-  const schemaType = schema.type;
-
-  if (Array.isArray(schemaType)) {
-    return schemaType.some(type => jsonSchemaTypeMatchesValue({ ...schema, type }, value));
-  }
-
-  if (schemaType === undefined) {
-    if (schema.properties) return isPlainObject(value);
-    if (schema.items) return Array.isArray(value);
-    return false;
-  }
-
-  switch (schemaType) {
-    case 'array':
-      return Array.isArray(value);
-    case 'object':
-      return isPlainObject(value);
-    case 'string':
-      return typeof value === 'string';
-    case 'integer':
-      return Number.isInteger(value);
-    case 'number':
-      return typeof value === 'number';
-    case 'boolean':
-      return typeof value === 'boolean';
-    case 'null':
-      return value === null;
-    default:
-      return false;
-  }
-};
-
-const findSchemaVariantWithFileProperty = (
-  schema: JSONSchemaProperty | undefined,
-  property: 'file_uploadable' | 'file_downloadable',
-  value: unknown
-): JSONSchemaProperty | undefined => {
-  const candidates = getSchemaVariants(schema).filter(variant =>
-    schemaHasFileProperty(variant, property)
-  );
-
-  return (
-    candidates.find(candidate => jsonSchemaTypeMatchesValue(candidate, value)) ?? candidates[0]
-  );
-};
-
 /**
- * Recursively walks a runtime value and its matching JSON-Schema node,
- * uploading any string path whose schema node has `file_uploadable: true`.
- * The function returns a **new** value with all substitutions applied;
- * nothing is mutated in-place.
+ * Stages one `file_uploadable` leaf: a local path / URL string or a `File`
+ * is uploaded to S3 and replaced by its `{ name, mimetype, s3key }`
+ * descriptor; `''` means "no file" and is dropped from the request;
+ * anything else (e.g. an already-staged descriptor) passes through.
  */
-const hydrateFiles = async (
+const stageFileValue = async (
   value: unknown,
-  schema: JSONSchemaProperty | undefined,
   ctx: {
     toolSlug: string;
     toolkitSlug: string;
@@ -120,41 +70,65 @@ const hydrateFiles = async (
       beforeFileUpload?: beforeFileUploadModifier;
     }
 ): Promise<unknown> => {
-  // ──────────────────────────────────────────────────────────────────────────
-  // 1. Direct file upload
-  // ──────────────────────────────────────────────────────────────────────────
-  if (schema?.file_uploadable) {
-    // Upload only if the runtime value is a string (i.e., a local path) or blob
-    if (typeof value !== 'string' && !(value instanceof File)) return value;
+  if (isEmptyFileValue(value)) return DELETE_VALUE;
+  // Upload only if the runtime value is a string (i.e., a local path) or blob
+  if (typeof value !== 'string' && !(value instanceof File)) return value;
 
-    const runBeforeFileUpload = async (
-      path: string,
-      source: 'path' | 'url' | 'file'
-    ): Promise<string> => {
-      if (!ctx.beforeFileUpload) {
-        return path;
-      }
-      const out = await ctx.beforeFileUpload({
-        path,
-        source,
-        toolSlug: ctx.toolSlug,
-        toolkitSlug: ctx.toolkitSlug,
-      });
-      if (out === false) {
-        throw new ComposioFileUploadAbortedError(
-          'File upload was aborted because beforeFileUpload returned false.'
-        );
-      }
-      return out;
-    };
+  const runBeforeFileUpload = async (
+    path: string,
+    source: 'path' | 'url' | 'file'
+  ): Promise<string> => {
+    if (!ctx.beforeFileUpload) {
+      return path;
+    }
+    const out = await ctx.beforeFileUpload({
+      path,
+      source,
+      toolSlug: ctx.toolSlug,
+      toolkitSlug: ctx.toolkitSlug,
+    });
+    if (out === false) {
+      throw new ComposioFileUploadAbortedError(
+        'File upload was aborted because beforeFileUpload returned false.'
+      );
+    }
+    return out;
+  };
 
-    if (typeof value === 'string') {
-      // Match the URL/local-path split used downstream in
-      // getFileDataAfterUploadingToS3 so the hook sees the same categorisation.
-      const source = isHttpUrl(value) ? 'url' : 'path';
-      const pathOrUrl = await runBeforeFileUpload(value, source);
-      logger.debug(`Uploading file "${pathOrUrl}"`);
-      return getFileDataAfterUploadingToS3(pathOrUrl, {
+  if (typeof value === 'string') {
+    // Match the URL/local-path split used downstream in
+    // getFileDataAfterUploadingToS3 so the hook sees the same categorisation.
+    const source = isHttpUrl(value) ? 'url' : 'path';
+    const pathOrUrl = await runBeforeFileUpload(value, source);
+    logger.debug(`Uploading file "${pathOrUrl}"`);
+    return getFileDataAfterUploadingToS3(pathOrUrl, {
+      toolSlug: ctx.toolSlug,
+      toolkitSlug: ctx.toolkitSlug,
+      client: ctx.client,
+      sensitiveFileUploadProtection: ctx.sensitiveFileUploadProtection,
+      fileUploadPathDenySegments: ctx.fileUploadPathDenySegments,
+      fileUploadAllowlist: ctx.fileUploadAllowlist,
+      signal: ctx.signal,
+    });
+  }
+
+  // File — `path` is the filename only; a string return replaces it with a
+  // local-path upload.
+  if (ctx.beforeFileUpload) {
+    const out = await ctx.beforeFileUpload({
+      path: value.name,
+      source: 'file',
+      toolSlug: ctx.toolSlug,
+      toolkitSlug: ctx.toolkitSlug,
+    });
+    if (out === false) {
+      throw new ComposioFileUploadAbortedError(
+        'File upload was aborted because beforeFileUpload returned false.'
+      );
+    }
+    if (typeof out === 'string' && out !== value.name) {
+      logger.debug(`Uploading file from path "${out}" (replaced File: ${value.name})`);
+      return getFileDataAfterUploadingToS3(out, {
         toolSlug: ctx.toolSlug,
         toolkitSlug: ctx.toolkitSlug,
         client: ctx.client,
@@ -164,89 +138,17 @@ const hydrateFiles = async (
         signal: ctx.signal,
       });
     }
-
-    // File — `path` is the filename only; a string return replaces it with a
-    // local-path upload.
-    if (ctx.beforeFileUpload) {
-      const out = await ctx.beforeFileUpload({
-        path: value.name,
-        source: 'file',
-        toolSlug: ctx.toolSlug,
-        toolkitSlug: ctx.toolkitSlug,
-      });
-      if (out === false) {
-        throw new ComposioFileUploadAbortedError(
-          'File upload was aborted because beforeFileUpload returned false.'
-        );
-      }
-      if (typeof out === 'string' && out !== value.name) {
-        logger.debug(`Uploading file from path "${out}" (replaced File: ${value.name})`);
-        return getFileDataAfterUploadingToS3(out, {
-          toolSlug: ctx.toolSlug,
-          toolkitSlug: ctx.toolkitSlug,
-          client: ctx.client,
-          sensitiveFileUploadProtection: ctx.sensitiveFileUploadProtection,
-          fileUploadPathDenySegments: ctx.fileUploadPathDenySegments,
-          fileUploadAllowlist: ctx.fileUploadAllowlist,
-          signal: ctx.signal,
-        });
-      }
-    }
-    logger.debug(`Uploading file "${value.name}"`);
-    // File/Blob values are not subject to the upload-dir allowlist.
-    return getFileDataAfterUploadingToS3(value, {
-      toolSlug: ctx.toolSlug,
-      toolkitSlug: ctx.toolkitSlug,
-      client: ctx.client,
-      sensitiveFileUploadProtection: ctx.sensitiveFileUploadProtection,
-      fileUploadPathDenySegments: ctx.fileUploadPathDenySegments,
-      signal: ctx.signal,
-    });
   }
-
-  // ──────────────────────────────────────────────────────────────────────────
-  // 2. Handle anyOf/oneOf/allOf — pick the file-bearing variant whose
-  // JSON Schema shape matches the runtime value, then hydrate against it.
-  //
-  // We deliberately do NOT loop over every uploadable variant. With `oneOf`,
-  // exactly one variant should apply at runtime, and applying multiple would
-  // upload the same file once per variant — two presigned-URL round-trips and
-  // two S3 PUTs for a two-variant `oneOf`. If no runtime shape matches, fall
-  // back to the first file-bearing variant to preserve historical behavior.
-  // ──────────────────────────────────────────────────────────────────────────
-  const uploadableVariant = findSchemaVariantWithFileProperty(schema, 'file_uploadable', value);
-  if (uploadableVariant) {
-    return hydrateFiles(value, uploadableVariant, ctx);
-  }
-
-  // ──────────────────────────────────────────────────────────────────────────
-  // 3. Object → traverse each property
-  // ──────────────────────────────────────────────────────────────────────────
-  if (schema?.type === 'object' && schema.properties && isPlainObject(value)) {
-    const transformed: Record<string, unknown> = {};
-
-    for (const [k, v] of Object.entries(value)) {
-      transformed[k] = await hydrateFiles(v, schema.properties[k], ctx);
-    }
-    return transformed;
-  }
-
-  // ──────────────────────────────────────────────────────────────────────────
-  // 4. Array → traverse each item
-  // ──────────────────────────────────────────────────────────────────────────
-  if (schema?.type === 'array' && schema.items && Array.isArray(value)) {
-    // `items` can be a single schema or an array of schemas; we handle both.
-    const itemSchema = Array.isArray(schema.items) ? schema.items[0] : schema.items;
-
-    return Promise.all(
-      value.map(item => hydrateFiles(item, itemSchema as JSONSchemaProperty, ctx))
-    );
-  }
-
-  // ──────────────────────────────────────────────────────────────────────────
-  // 5. Primitive or schema-less branch → return unchanged
-  // ──────────────────────────────────────────────────────────────────────────
-  return value;
+  logger.debug(`Uploading file "${value.name}"`);
+  // File/Blob values are not subject to the upload-dir allowlist.
+  return getFileDataAfterUploadingToS3(value, {
+    toolSlug: ctx.toolSlug,
+    toolkitSlug: ctx.toolkitSlug,
+    client: ctx.client,
+    sensitiveFileUploadProtection: ctx.sensitiveFileUploadProtection,
+    fileUploadPathDenySegments: ctx.fileUploadPathDenySegments,
+    signal: ctx.signal,
+  });
 };
 
 /**
@@ -426,13 +328,15 @@ export class FileToolModifier {
     try {
       const newArgs = await withCancellation(
         () =>
-          hydrateFiles(args, resolveFileSchema(tool.inputParameters), {
-            toolSlug,
-            toolkitSlug,
-            client: this.client,
-            ...this.fileUploadPathOptions,
-            signal,
-          }),
+          walkFileUploadableLeaves(args, resolveFileSchema(tool.inputParameters), value =>
+            stageFileValue(value, {
+              toolSlug,
+              toolkitSlug,
+              client: this.client,
+              ...this.fileUploadPathOptions,
+              signal,
+            })
+          ),
         signal
       );
       return { ...params, arguments: newArgs as ToolExecuteParams['arguments'] };

--- a/ts/packages/core/src/utils/modifiers/FileToolModifier.utils.neutral.ts
+++ b/ts/packages/core/src/utils/modifiers/FileToolModifier.utils.neutral.ts
@@ -203,6 +203,20 @@ export const jsonSchemaTypeMatchesValue = (schema: JSONSchemaProperty, value: un
   }
 };
 
+/** Mirrors the array-shape inference used by {@link jsonSchemaTypeMatchesValue}. */
+const isArrayShapedSchema = (schema: JSONSchemaProperty | undefined): boolean => {
+  if (!schema) return false;
+  if (Array.isArray(schema.type)) return schema.type.includes('array');
+  return schema.type === 'array' || (schema.type === undefined && schema.items !== undefined);
+};
+
+/** Mirrors the object-shape inference used by {@link jsonSchemaTypeMatchesValue}. */
+const isObjectShapedSchema = (schema: JSONSchemaProperty | undefined): boolean => {
+  if (!schema) return false;
+  if (Array.isArray(schema.type)) return schema.type.includes('object');
+  return schema.type === 'object' || (schema.type === undefined && schema.properties !== undefined);
+};
+
 /**
  * Picks the file-bearing `anyOf`/`oneOf`/`allOf` variant whose JSON Schema
  * shape matches the runtime value, falling back to the first file-bearing
@@ -243,19 +257,53 @@ export const walkFileUploadableLeaves = async (
 
   const uploadableVariant = findSchemaVariantWithFileProperty(schema, 'file_uploadable', value);
   if (uploadableVariant) {
+    // A scalar empty string cannot match an array-only file input, but callers
+    // use it to mean "no files". Route it through the leaf handler so it is
+    // omitted, unless another non-file variant explicitly accepts strings.
+    const matchingNonFileVariant = getSchemaVariants(schema).some(
+      variant =>
+        !schemaHasFileProperty(variant, 'file_uploadable') &&
+        jsonSchemaTypeMatchesValue(variant, value)
+    );
+    if (
+      isEmptyFileValue(value) &&
+      isArrayShapedSchema(uploadableVariant) &&
+      !matchingNonFileVariant
+    ) {
+      return leaf(value);
+    }
     return walkFileUploadableLeaves(value, uploadableVariant, leaf);
   }
 
-  if (schema?.type === 'object' && schema.properties && isPlainObject(value)) {
+  if (
+    isEmptyFileValue(value) &&
+    isArrayShapedSchema(schema) &&
+    schemaHasFileProperty(schema, 'file_uploadable')
+  ) {
+    return leaf(value);
+  }
+
+  if (isObjectShapedSchema(schema) && schema?.properties && isPlainObject(value)) {
     const transformed: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(value)) {
-      const walked = await walkFileUploadableLeaves(v, schema.properties[k], leaf);
-      if (walked !== DELETE_VALUE) transformed[k] = walked;
+      const propertySchema = Object.hasOwn(schema.properties, k) ? schema.properties[k] : undefined;
+      const walked = await walkFileUploadableLeaves(v, propertySchema, leaf);
+      if (walked !== DELETE_VALUE) {
+        // Define every key as an own data property so reserved JSON keys such
+        // as `__proto__` remain enumerable without invoking its inherited
+        // setter and changing this ordinary object's prototype.
+        Object.defineProperty(transformed, k, {
+          configurable: true,
+          enumerable: true,
+          value: walked,
+          writable: true,
+        });
+      }
     }
     return transformed;
   }
 
-  if (schema?.type === 'array' && schema.items && Array.isArray(value)) {
+  if (isArrayShapedSchema(schema) && schema?.items && Array.isArray(value)) {
     // `items` can be a single schema or an array of schemas; we handle both.
     const itemSchema = Array.isArray(schema.items) ? schema.items[0] : schema.items;
     const walked = await Promise.all(

--- a/ts/packages/core/src/utils/modifiers/FileToolModifier.utils.neutral.ts
+++ b/ts/packages/core/src/utils/modifiers/FileToolModifier.utils.neutral.ts
@@ -116,6 +116,20 @@ export const schemaHasFileProperty = (
     }
   }
 
+  // Check `$ref` targets. Composio toolkits routinely express file flags
+  // through a `$ref`/`$defs` indirection (e.g. GMAIL_GET_ATTACHMENT), and
+  // this predicate is the cheap gate that decides whether a schema is worth
+  // dereferencing at all — without this it answers `false` for every
+  // ref-based schema. Callers walk the *dereferenced* schema, where
+  // `dereferenceJsonSchema` has already stripped these blocks, so an unused
+  // `$defs` entry can only cost a redundant walk, never a wrong upload.
+  for (const definitions of [schema.$defs, schema.definitions]) {
+    if (!definitions) continue;
+    for (const definition of Object.values(definitions)) {
+      if (schemaHasFileProperty(definition, property)) return true;
+    }
+  }
+
   return false;
 };
 
@@ -132,3 +146,140 @@ export const schemaHasFileUploadable = (schema: JSONSchemaProperty | undefined):
 export const schemaHasFileDownloadable = (schema: JSONSchemaProperty | undefined): boolean => {
   return schemaHasFileProperty(schema, 'file_downloadable');
 };
+
+/**
+ * Sentinel a leaf handler returns to have {@link walkFileUploadableLeaves}
+ * omit that key/item from its parent container. `''` and `null` are legal
+ * payload values, so neither can double as "remove this".
+ */
+export const DELETE_VALUE: unique symbol = Symbol('composio.delete-value');
+
+/**
+ * `''` at a `file_uploadable` leaf means "no file": it is never a staged
+ * `{ name, mimetype, s3key }` descriptor, so the backend rejects it with a
+ * validation error, while callers (and the playground UI) mean "absent". The
+ * walker omits the key instead. `null` is left alone — schemas with a `null`
+ * variant accept it, and the backend reports the mismatch otherwise.
+ */
+export const isEmptyFileValue = (value: unknown): boolean => value === '';
+
+export const getSchemaVariants = (schema: JSONSchemaProperty | undefined): JSONSchemaProperty[] => [
+  ...(schema?.anyOf ?? []),
+  ...(schema?.oneOf ?? []),
+  ...(schema?.allOf ?? []),
+];
+
+/** Best-effort runtime shape match for selecting composed schema variants. */
+export const jsonSchemaTypeMatchesValue = (schema: JSONSchemaProperty, value: unknown): boolean => {
+  const schemaType = schema.type;
+
+  if (Array.isArray(schemaType)) {
+    return schemaType.some(type => jsonSchemaTypeMatchesValue({ ...schema, type }, value));
+  }
+
+  if (schemaType === undefined) {
+    if (schema.properties) return isPlainObject(value);
+    if (schema.items) return Array.isArray(value);
+    return false;
+  }
+
+  switch (schemaType) {
+    case 'array':
+      return Array.isArray(value);
+    case 'object':
+      return isPlainObject(value);
+    case 'string':
+      return typeof value === 'string';
+    case 'integer':
+      return Number.isInteger(value);
+    case 'number':
+      return typeof value === 'number';
+    case 'boolean':
+      return typeof value === 'boolean';
+    case 'null':
+      return value === null;
+    default:
+      return false;
+  }
+};
+
+/**
+ * Picks the file-bearing `anyOf`/`oneOf`/`allOf` variant whose JSON Schema
+ * shape matches the runtime value, falling back to the first file-bearing
+ * variant to preserve historical behavior.
+ */
+export const findSchemaVariantWithFileProperty = (
+  schema: JSONSchemaProperty | undefined,
+  property: 'file_uploadable' | 'file_downloadable',
+  value: unknown
+): JSONSchemaProperty | undefined => {
+  const candidates = getSchemaVariants(schema).filter(variant =>
+    schemaHasFileProperty(variant, property)
+  );
+
+  return (
+    candidates.find(candidate => jsonSchemaTypeMatchesValue(candidate, value)) ?? candidates[0]
+  );
+};
+
+/**
+ * Recursively walks a runtime value alongside its (already dereferenced)
+ * JSON-Schema node and passes every value sitting at a `file_uploadable`
+ * node through `leaf`. A leaf returning {@link DELETE_VALUE} is omitted from
+ * its parent object/array. Returns a **new** value; nothing is mutated.
+ *
+ * Composed schemas are resolved to the single file-bearing variant whose
+ * shape matches the value: with `oneOf`, exactly one variant should apply at
+ * runtime, and applying several would stage the same file once per variant.
+ */
+export const walkFileUploadableLeaves = async (
+  value: unknown,
+  schema: JSONSchemaProperty | undefined,
+  leaf: (value: unknown) => Promise<unknown>
+): Promise<unknown> => {
+  if (schema?.file_uploadable) {
+    return leaf(value);
+  }
+
+  const uploadableVariant = findSchemaVariantWithFileProperty(schema, 'file_uploadable', value);
+  if (uploadableVariant) {
+    return walkFileUploadableLeaves(value, uploadableVariant, leaf);
+  }
+
+  if (schema?.type === 'object' && schema.properties && isPlainObject(value)) {
+    const transformed: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) {
+      const walked = await walkFileUploadableLeaves(v, schema.properties[k], leaf);
+      if (walked !== DELETE_VALUE) transformed[k] = walked;
+    }
+    return transformed;
+  }
+
+  if (schema?.type === 'array' && schema.items && Array.isArray(value)) {
+    // `items` can be a single schema or an array of schemas; we handle both.
+    const itemSchema = Array.isArray(schema.items) ? schema.items[0] : schema.items;
+    const walked = await Promise.all(
+      value.map(item => walkFileUploadableLeaves(item, itemSchema as JSONSchemaProperty, leaf))
+    );
+    return walked.filter(item => item !== DELETE_VALUE);
+  }
+
+  return value;
+};
+
+/**
+ * Omits `''` at `file_uploadable` leaves of `args` without uploading
+ * anything. This is the schema-aware half of the upload modifier that needs
+ * no filesystem access, so it also runs when automatic upload is disabled:
+ * an empty file value is never a valid staged descriptor and the backend
+ * would reject it (https://github.com/ComposioHQ/composio/issues/4233).
+ * Any other value — a local path, a staged descriptor, a list — is
+ * forwarded untouched.
+ */
+export const dropEmptyFileUploads = (
+  args: Record<string, unknown>,
+  schema: JSONSchemaProperty | undefined
+): Promise<unknown> =>
+  walkFileUploadableLeaves(args, schema, async value =>
+    isEmptyFileValue(value) ? DELETE_VALUE : value
+  );

--- a/ts/packages/core/test/models/toolRouter.test.ts
+++ b/ts/packages/core/test/models/toolRouter.test.ts
@@ -2669,6 +2669,17 @@ describe('ToolRouter', () => {
   describe('tools function', () => {
     const userId = 'user_123';
     const sessionId = 'session_123';
+    const validSessionTool = { slug: 'COMPOSIO_SEARCH_TOOLS', name: 'Search tools' };
+
+    const mockToolsWithValidSessionTool = () => {
+      vi.mocked(Tools).mockImplementationOnce(function () {
+        return {
+          getRawComposioTools: vi.fn().mockResolvedValue([{ slug: 'GMAIL_FETCH_EMAILS' }]),
+          getRawToolRouterSessionTools: vi.fn().mockResolvedValue([validSessionTool]),
+          wrapToolsForToolRouter: vi.fn().mockReturnValue('mocked-wrapped-tools'),
+        };
+      });
+    };
 
     beforeEach(() => {
       // Reset the Tools mock before each test
@@ -2714,12 +2725,13 @@ describe('ToolRouter', () => {
       mockClient.toolRouter.session.create.mockResolvedValueOnce(mockSessionCreateResponse);
 
       const modifiers = {
-        modifySchema: vi.fn(tool => ({
-          ...tool,
+        modifySchema: vi.fn(({ schema }) => ({
+          ...schema,
           description: 'Modified description',
         })),
         beforeExecute: vi.fn(),
       };
+      mockToolsWithValidSessionTool();
 
       const session = await toolRouter.create(userId);
       const tools = await session.tools(modifiers);
@@ -2727,13 +2739,14 @@ describe('ToolRouter', () => {
       const toolsInstance = vi.mocked(Tools).mock.results[0].value;
       expect(toolsInstance.getRawToolRouterSessionTools).toHaveBeenCalledWith(
         sessionId,
-        { modifySchema: modifiers.modifySchema },
+        undefined,
         undefined
       );
       expect(toolsInstance.wrapToolsForToolRouter).toHaveBeenCalledWith(
         sessionId,
-        [{ slug: 'COMPOSIO_SEARCH_TOOLS' }],
-        modifiers
+        [{ ...validSessionTool, description: 'Modified description' }],
+        modifiers,
+        [validSessionTool]
       );
 
       expect(tools).toBe('mocked-wrapped-tools');
@@ -3046,8 +3059,10 @@ describe('ToolRouter', () => {
     it('should call tools function multiple times with different modifiers', async () => {
       mockClient.toolRouter.session.create.mockResolvedValueOnce(mockSessionCreateResponse);
 
-      const modifier1 = { modifySchema: vi.fn() };
-      const modifier2 = { modifySchema: vi.fn() };
+      const modifier1 = { modifySchema: vi.fn(({ schema }) => schema) };
+      const modifier2 = { modifySchema: vi.fn(({ schema }) => schema) };
+      mockToolsWithValidSessionTool();
+      mockToolsWithValidSessionTool();
 
       const session = await toolRouter.create(userId);
 
@@ -3061,25 +3076,27 @@ describe('ToolRouter', () => {
       const firstToolsInstance = vi.mocked(Tools).mock.results[0].value;
       expect(firstToolsInstance.getRawToolRouterSessionTools).toHaveBeenCalledWith(
         sessionId,
-        { modifySchema: modifier1.modifySchema },
+        undefined,
         undefined
       );
       expect(firstToolsInstance.wrapToolsForToolRouter).toHaveBeenCalledWith(
         sessionId,
-        [{ slug: 'COMPOSIO_SEARCH_TOOLS' }],
-        modifier1
+        [validSessionTool],
+        modifier1,
+        [validSessionTool]
       );
 
       const secondToolsInstance = vi.mocked(Tools).mock.results[1].value;
       expect(secondToolsInstance.getRawToolRouterSessionTools).toHaveBeenCalledWith(
         sessionId,
-        { modifySchema: modifier2.modifySchema },
+        undefined,
         undefined
       );
       expect(secondToolsInstance.wrapToolsForToolRouter).toHaveBeenCalledWith(
         sessionId,
-        [{ slug: 'COMPOSIO_SEARCH_TOOLS' }],
-        modifier2
+        [validSessionTool],
+        modifier2,
+        [validSessionTool]
       );
     });
 

--- a/ts/packages/core/test/tools/fileModifiers.test.ts
+++ b/ts/packages/core/test/tools/fileModifiers.test.ts
@@ -311,6 +311,55 @@ describe('FileToolModifier', () => {
       availableVersions: ['20251201_01'],
     };
 
+    it('drops empty file values instead of uploading them (issue #4233)', async () => {
+      const fileUploadable = {
+        type: 'object' as const,
+        title: 'FileUploadable',
+        file_uploadable: true,
+        properties: {
+          name: { type: 'string' as const },
+          mimetype: { type: 'string' as const },
+          s3key: { type: 'string' as const },
+        },
+        required: ['name', 'mimetype', 's3key'],
+      };
+      const gmailLikeTool: Tool = {
+        ...mockTool,
+        inputParameters: {
+          type: 'object',
+          properties: {
+            subject: { type: 'string' },
+            attachment: { anyOf: [fileUploadable, { type: 'array', items: fileUploadable }] },
+            extra: { type: 'array', items: fileUploadable },
+            thread_id: { type: 'string' },
+          },
+        },
+      };
+      const staged = { name: 'a.txt', mimetype: 'text/plain', s3key: 'k' };
+
+      const result = await fileToolModifier.fileUploadModifier(gmailLikeTool, {
+        toolSlug: 'test-tool',
+        toolkitSlug: 'test-toolkit',
+        params: {
+          arguments: {
+            subject: 'Test',
+            attachment: '',
+            extra: ['', staged],
+            thread_id: '',
+          },
+          userId: 'test-user',
+        },
+      });
+
+      expect(fileUtils.getFileDataAfterUploadingToS3).not.toHaveBeenCalled();
+      expect(result.arguments).toEqual({
+        subject: 'Test',
+        extra: [staged],
+        // non-file empty strings are not the walker's business
+        thread_id: '',
+      });
+    });
+
     it('should upload file for file_uploadable parameters', async () => {
       const mockFileData = {
         name: 'file.txt',
@@ -2033,6 +2082,48 @@ describe('Tools with dangerouslyAllowAutoUploadDownloadFiles', () => {
         },
         undefined
       );
+    });
+
+    it('omits empty file values from the request when auto-upload is off (issue #4233)', async () => {
+      vi.spyOn(context.tools, 'getRawComposioToolBySlug').mockResolvedValue(mockToolWithFileUpload);
+
+      await context.tools.execute('COMPOSIO_TOOL', {
+        arguments: { file: '', text: 'keep' },
+        userId: 'test-user',
+        dangerouslySkipVersionCheck: true,
+      });
+
+      expect(fileUtils.getFileDataAfterUploadingToS3).not.toHaveBeenCalled();
+      expect(mockClient.tools.execute.mock.calls[0]?.[1]?.arguments).toEqual({ text: 'keep' });
+    });
+
+    it('omits empty file values reachable only through a $ref (issue #4233)', async () => {
+      // Composio toolkits express file flags through `$ref`/`$defs`, so the
+      // cheap "does this tool take a file?" gate has to see through the
+      // indirection or the fix never fires for a real tool.
+      vi.spyOn(context.tools, 'getRawComposioToolBySlug').mockResolvedValue({
+        ...mockToolWithFileUpload,
+        inputParameters: {
+          type: 'object',
+          properties: { file: { $ref: '#/$defs/Attachment' }, text: { type: 'string' } },
+          $defs: {
+            Attachment: {
+              type: 'object',
+              file_uploadable: true,
+              properties: { name: { type: 'string' }, s3key: { type: 'string' } },
+            },
+          },
+        },
+      });
+
+      await context.tools.execute('COMPOSIO_TOOL', {
+        arguments: { file: '', text: 'keep' },
+        userId: 'test-user',
+        dangerouslySkipVersionCheck: true,
+      });
+
+      expect(fileUtils.getFileDataAfterUploadingToS3).not.toHaveBeenCalled();
+      expect(mockClient.tools.execute.mock.calls[0]?.[1]?.arguments).toEqual({ text: 'keep' });
     });
 
     it('warns once per tool when auto-upload is off and the tool has a file-uploadable input', async () => {

--- a/ts/packages/core/test/tools/fileModifiers.test.ts
+++ b/ts/packages/core/test/tools/fileModifiers.test.ts
@@ -9,8 +9,10 @@ import {
 import { ComposioRequestCancelledError } from '../../src/errors/SDKErrors';
 import * as fileUtils from '../../src/utils/fileUtils.node';
 import { Tools } from '../../src/models/Tools';
+import { ToolRouterSession } from '../../src/models/ToolRouterSession';
 import { createTestContext, setupTest, mockToolExecution } from '../utils/toolExecuteUtils';
 import { mockClient } from '../utils/mocks/client.mock';
+import { MockProvider } from '../utils/mocks/provider.mock';
 
 // Mock the fileUtils module
 vi.mock('../../src/utils/fileUtils.node', () => ({
@@ -358,6 +360,84 @@ describe('FileToolModifier', () => {
         // non-file empty strings are not the walker's business
         thread_id: '',
       });
+    });
+
+    it('drops scalar empty values for array-only file inputs and preserves null and staged files', async () => {
+      const fileUploadable = {
+        type: 'object' as const,
+        file_uploadable: true,
+        properties: {
+          name: { type: 'string' as const },
+          mimetype: { type: 'string' as const },
+          s3key: { type: 'string' as const },
+        },
+      };
+      const staged = { name: 'a.txt', mimetype: 'text/plain', s3key: 'staged/a.txt' };
+      const arrayFileTool: Tool = {
+        ...mockTool,
+        inputParameters: {
+          type: 'object',
+          properties: {
+            files: {
+              anyOf: [{ type: 'array', items: fileUploadable }, { type: 'null' }],
+            },
+            directFiles: { type: 'array', items: fileUploadable },
+            nullableFile: { anyOf: [fileUploadable, { type: 'null' }] },
+            stagedFiles: { type: 'array', items: fileUploadable },
+          },
+        },
+      };
+
+      const result = await fileToolModifier.fileUploadModifier(arrayFileTool, {
+        toolSlug: 'test-tool',
+        toolkitSlug: 'test-toolkit',
+        params: {
+          arguments: {
+            files: '',
+            directFiles: '',
+            nullableFile: null,
+            stagedFiles: [staged],
+          },
+          userId: 'test-user',
+        },
+      });
+
+      expect(fileUtils.getFileDataAfterUploadingToS3).not.toHaveBeenCalled();
+      expect(result.arguments).toEqual({
+        nullableFile: null,
+        stagedFiles: [staged],
+      });
+    });
+
+    it('drops scalar empty values for composed file arrays inferred from items', async () => {
+      const typelessArrayFileTool: Tool = {
+        ...mockTool,
+        inputParameters: {
+          type: 'object',
+          properties: {
+            files: {
+              anyOf: [
+                {
+                  items: { type: 'object', file_uploadable: true },
+                },
+                { type: 'null' },
+              ],
+            },
+          },
+        },
+      };
+
+      const result = await fileToolModifier.fileUploadModifier(typelessArrayFileTool, {
+        toolSlug: 'test-tool',
+        toolkitSlug: 'test-toolkit',
+        params: {
+          arguments: { files: '' },
+          userId: 'test-user',
+        },
+      });
+
+      expect(fileUtils.getFileDataAfterUploadingToS3).not.toHaveBeenCalled();
+      expect(result.arguments).toEqual({});
     });
 
     it('should upload file for file_uploadable parameters', async () => {
@@ -2003,6 +2083,63 @@ describe('Tools with dangerouslyAllowAutoUploadDownloadFiles', () => {
     availableVersions: ['20251201_01'],
   };
 
+  describe('when dangerouslyAllowAutoUploadDownloadFiles is true', () => {
+    beforeEach(() => {
+      context.tools = new Tools(mockClient as unknown as ComposioClient, {
+        provider: context.mockProvider,
+        dangerouslyAllowAutoUploadDownloadFiles: true,
+      });
+      vi.mocked(fileUtils.getFileDataAfterUploadingToS3).mockResolvedValue({
+        name: 'file.txt',
+        mimetype: 'text/plain',
+        s3key: 'uploads/file.txt',
+      });
+      mockClient.toolRouter.session.execute.mockResolvedValue({
+        data: { uploaded: true },
+        error: null,
+        log_id: 'session-log',
+      });
+    });
+
+    it('stages session file arguments before beforeExecute and the request', async () => {
+      const beforeExecute = vi.fn(({ params }) => params);
+
+      await context.tools.executeSessionTool(
+        'COMPOSIO_TOOL',
+        {
+          sessionId: 'session-123',
+          arguments: { file: '/path/to/file.txt' },
+        },
+        { beforeExecute },
+        mockToolWithFileUpload
+      );
+
+      const staged = { name: 'file.txt', mimetype: 'text/plain', s3key: 'uploads/file.txt' };
+      expect(fileUtils.getFileDataAfterUploadingToS3).toHaveBeenCalledWith(
+        '/path/to/file.txt',
+        expect.objectContaining({
+          toolSlug: 'COMPOSIO_TOOL',
+          toolkitSlug: 'test-toolkit',
+        })
+      );
+      expect(beforeExecute).toHaveBeenCalledWith({
+        toolSlug: 'COMPOSIO_TOOL',
+        toolkitSlug: 'test-toolkit',
+        sessionId: 'session-123',
+        params: { file: staged },
+      });
+      expect(mockClient.toolRouter.session.execute).toHaveBeenCalledWith(
+        'session-123',
+        {
+          tool_slug: 'COMPOSIO_TOOL',
+          arguments: { file: staged },
+          enable_auto_workbench_offload: true,
+        },
+        undefined
+      );
+    });
+  });
+
   describe('when dangerouslyAllowAutoUploadDownloadFiles is false', () => {
     beforeEach(async () => {
       context.tools = new Tools(mockClient as unknown as ComposioClient, {
@@ -2124,6 +2261,141 @@ describe('Tools with dangerouslyAllowAutoUploadDownloadFiles', () => {
 
       expect(fileUtils.getFileDataAfterUploadingToS3).not.toHaveBeenCalled();
       expect(mockClient.tools.execute.mock.calls[0]?.[1]?.arguments).toEqual({ text: 'keep' });
+    });
+
+    it('cleans typeless session file schemas without allowing prototype-key injection', async () => {
+      const staged = { name: 'a.txt', mimetype: 'text/plain', s3key: 'staged/a.txt' };
+      const argumentsWithPrototypeKey: Record<string, unknown> = JSON.parse(
+        '{"file":"","__proto__":{"polluted":true},"staged":{"name":"a.txt","mimetype":"text/plain","s3key":"staged/a.txt"},"nullable":null,"nested":{"file":"","__proto__":{"nestedPolluted":true},"text":"nested keep"},"text":"keep"}'
+      );
+      const tool: Tool = {
+        ...mockToolWithFileUpload,
+        inputParameters: {
+          properties: {
+            file: { type: 'string', file_uploadable: true },
+            staged: { type: 'object', file_uploadable: true },
+            nullable: {
+              anyOf: [{ type: 'object', file_uploadable: true }, { type: 'null' }],
+            },
+            nested: {
+              properties: {
+                file: { type: 'string', file_uploadable: true },
+                text: { type: 'string' },
+              },
+            },
+            text: { type: 'string' },
+          },
+        },
+      };
+      const beforeExecute = vi.fn(({ params }) => params);
+      mockClient.toolRouter.session.execute.mockResolvedValueOnce({
+        data: { ok: true },
+        error: null,
+        log_id: 'session-log',
+      });
+
+      await context.tools.executeSessionTool(
+        'COMPOSIO_TOOL',
+        { sessionId: 'session-123', arguments: argumentsWithPrototypeKey },
+        { beforeExecute },
+        tool
+      );
+
+      const hookArguments = beforeExecute.mock.calls[0]?.[0].params as Record<string, unknown>;
+      expect(Object.getPrototypeOf(hookArguments)).toBe(Object.prototype);
+      expect(Object.hasOwn(hookArguments, '__proto__')).toBe(true);
+      expect(Object.keys(hookArguments)).toContain('__proto__');
+      expect(hookArguments).not.toHaveProperty('file');
+      expect(hookArguments.__proto__).toEqual({ polluted: true });
+      expect(hookArguments.polluted).toBeUndefined();
+      expect(hookArguments.staged).toEqual(staged);
+      expect(hookArguments.nullable).toBeNull();
+      expect(hookArguments.text).toBe('keep');
+      const hookNested = hookArguments.nested as Record<string, unknown>;
+      expect(Object.getPrototypeOf(hookNested)).toBe(Object.prototype);
+      expect(Object.hasOwn(hookNested, '__proto__')).toBe(true);
+      expect(Object.keys(hookNested)).toContain('__proto__');
+      expect(hookNested).not.toHaveProperty('file');
+      expect(hookNested.__proto__).toEqual({ nestedPolluted: true });
+      expect(hookNested.nestedPolluted).toBeUndefined();
+      expect(hookNested.text).toBe('nested keep');
+
+      const requestArguments = mockClient.toolRouter.session.execute.mock.calls[0]?.[1]
+        ?.arguments as Record<string, unknown>;
+      expect(Object.getPrototypeOf(requestArguments)).toBe(Object.prototype);
+      expect(Object.hasOwn(requestArguments, '__proto__')).toBe(true);
+      expect(Object.keys(requestArguments)).toContain('__proto__');
+      expect(requestArguments.__proto__).toEqual({ polluted: true });
+      expect(requestArguments.polluted).toBeUndefined();
+      expect(requestArguments.staged).toEqual(staged);
+      expect(requestArguments.nullable).toBeNull();
+      const requestNested = requestArguments.nested as Record<string, unknown>;
+      expect(Object.getPrototypeOf(requestNested)).toBe(Object.prototype);
+      expect(Object.hasOwn(requestNested, '__proto__')).toBe(true);
+      expect(Object.keys(requestNested)).toContain('__proto__');
+      expect(requestNested).not.toHaveProperty('file');
+      expect(requestNested.__proto__).toEqual({ nestedPolluted: true });
+      expect(requestNested.nestedPolluted).toBeUndefined();
+      expect(fileUtils.getFileDataAfterUploadingToS3).not.toHaveBeenCalled();
+    });
+
+    it('uses raw session schemas for cleanup when modifySchema removes file flags', async () => {
+      const provider = new MockProvider();
+      const session = new ToolRouterSession(
+        mockClient as unknown as ComposioClient,
+        {
+          apiKey: 'test-api-key',
+          provider,
+          dangerouslyAllowAutoUploadDownloadFiles: false,
+        },
+        'session-123',
+        { type: 'http', url: 'https://mcp.example.com/session-123' }
+      );
+      mockClient.toolRouter.session.tools.mockResolvedValueOnce({
+        items: [mockRawToolWithFileUpload],
+        next_cursor: null,
+      });
+      mockClient.toolRouter.session.execute.mockResolvedValueOnce({
+        data: { ok: true },
+        error: null,
+        log_id: 'session-log',
+      });
+      provider.wrapTools.mockImplementation(tools => tools);
+
+      await session.tools({
+        modifySchema: ({ schema }) => ({
+          ...schema,
+          inputParameters: {
+            type: 'object',
+            properties: {
+              file: { type: 'string' },
+              text: { type: 'string' },
+            },
+          },
+        }),
+      });
+
+      const displayTools = provider.wrapTools.mock.calls[0]?.[0] as Tool[];
+      expect(displayTools[0]?.inputParameters?.properties?.file).not.toHaveProperty(
+        'file_uploadable'
+      );
+
+      const executeTool = provider.wrapTools.mock.calls[0]?.[1] as (
+        toolSlug: string,
+        input: Record<string, unknown>
+      ) => Promise<unknown>;
+      await executeTool('COMPOSIO_TOOL', { file: '', text: 'keep' });
+
+      expect(fileUtils.getFileDataAfterUploadingToS3).not.toHaveBeenCalled();
+      expect(mockClient.toolRouter.session.execute).toHaveBeenCalledWith(
+        'session-123',
+        {
+          tool_slug: 'COMPOSIO_TOOL',
+          arguments: { text: 'keep' },
+          enable_auto_workbench_offload: true,
+        },
+        undefined
+      );
     });
 
     it('warns once per tool when auto-upload is off and the tool has a file-uploadable input', async () => {


### PR DESCRIPTION
This PR:

- closes https://github.com/ComposioHQ/composio/issues/4233
- stops forwarding `""` for a `file_uploadable` parameter (e.g. Gmail `attachment`) to the backend, which rejected it with `Input should be a valid dictionary or instance of FileUploadable`
- Python: parameterizes the upload walker on a `leaf` handler and adds `FileHelper.drop_empty_file_uploads()`, run on both `Tools.execute` paths when `dangerously_allow_auto_upload_download_files` is off (the default)
- TypeScript: moves the walker into the runtime-neutral `walkFileUploadableLeaves()` with a `DELETE_VALUE` sentinel and `dropEmptyFileUploads()`, so the flag-off path also works on edge runtimes; with the flag on, `''` is no longer attempted as an upload (previously threw `Either path or blob must be provided`)
- TypeScript: `schemaHasFileProperty()` now looks through `$defs`/`definitions`, so the flag-off pass (and the existing one-shot warning) fire for `$ref`-based file schemas
- keeps each SDK's existing `null` semantics: Python omits `None` as before, TypeScript still passes `null` through for schemas with a `null` variant
- adds regression tests for both SDKs and a `@composio/core` changeset

## Context

Reproduced against staging with `composio==0.16.0` and the current SDK: the live `GMAIL_CREATE_EMAIL_DRAFT` schema is `anyOf[FileUploadable, array[FileUploadable]]` with no `null` variant, and `""` yields the exact error from the issue on `no_auth` file tools (`TEXT_TO_PDF_UPLOAD_FILE`). With this change the backend sees the parameter as not provided, matching what the playground UI sends.