### PR TITLE
ci(docs-agent-eval): bump pinned engine to calibrated judge

### DIFF
--- a/.github/workflows/docs-agent-eval.yml
+++ b/.github/workflows/docs-agent-eval.yml
@@ -30,7 +30,7 @@ on:
 env:
   ENGINE_REPO: ComposioHQ/docs-agent-eval-ci
   # Full-SHA pin of the engine code — bump on docs-agent-eval-ci releases.
-  ENGINE_REF: 2c9fabd97acefc9398592a0649dc230d726bda71
+  ENGINE_REF: 8bd5993a85d60d4b4b70f171d41816b91ab67295
 
 jobs:
   # Decides IF an eval should start and FOR WHICH PR. deployment_status

--- a/.github/workflows/docs-agent-eval.yml
+++ b/.github/workflows/docs-agent-eval.yml
@@ -30,7 +30,7 @@ on:
 env:
   ENGINE_REPO: ComposioHQ/docs-agent-eval-ci
   # Full-SHA pin of the engine code — bump on docs-agent-eval-ci releases.
-  ENGINE_REF: 8c018d43675bbe8533162cfeac724607b967db4f
+  ENGINE_REF: 2d75f3b9a7df9af47012339bff19c9da69dc8377
 
 jobs:
   # Decides IF an eval should start and FOR WHICH PR. deployment_status

--- a/.github/workflows/docs-agent-eval.yml
+++ b/.github/workflows/docs-agent-eval.yml
@@ -30,7 +30,7 @@ on:
 env:
   ENGINE_REPO: ComposioHQ/docs-agent-eval-ci
   # Full-SHA pin of the engine code — bump on docs-agent-eval-ci releases.
-  ENGINE_REF: c7cf6e46490491f4db69fb1db88c33acb9a5debe
+  ENGINE_REF: 2c9fabd97acefc9398592a0649dc230d726bda71
 
 jobs:
   # Decides IF an eval should start and FOR WHICH PR. deployment_status

--- a/.github/workflows/docs-agent-eval.yml
+++ b/.github/workflows/docs-agent-eval.yml
@@ -30,7 +30,7 @@ on:
 env:
   ENGINE_REPO: ComposioHQ/docs-agent-eval-ci
   # Full-SHA pin of the engine code — bump on docs-agent-eval-ci releases.
-  ENGINE_REF: 19f6417fdc2c8d202f38ae02a7d9ec0823a42253
+  ENGINE_REF: 8c018d43675bbe8533162cfeac724607b967db4f
 
 jobs:
   # Decides IF an eval should start and FOR WHICH PR. deployment_status

--- a/.github/workflows/docs-agent-eval.yml
+++ b/.github/workflows/docs-agent-eval.yml
@@ -30,7 +30,7 @@ on:
 env:
   ENGINE_REPO: ComposioHQ/docs-agent-eval-ci
   # Full-SHA pin of the engine code — bump on docs-agent-eval-ci releases.
-  ENGINE_REF: 2d75f3b9a7df9af47012339bff19c9da69dc8377
+  ENGINE_REF: c7cf6e46490491f4db69fb1db88c33acb9a5debe
 
 jobs:
   # Decides IF an eval should start and FOR WHICH PR. deployment_status


### PR DESCRIPTION
One-line `ENGINE_REF` bump for the docs-agent-eval shim: the pin predates the judge calibration (docs-agent-eval-ci PRs #4–#7 — evidence-scoped scans, proxy-log ground truth, infra-vs-agent error classification, corrected package taxonomy, renamed secret). Until this merges, label/deployment-triggered evals run the old false-positive-prone judge; dispatched runs already use current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)