### PR TITLE
docs: project API key permissions

### DIFF
--- a/docs/content/changelog/08-28-26-api-key-session-permissions.mdx
+++ b/docs/content/changelog/08-28-26-api-key-session-permissions.mdx
@@ -1,0 +1,16 @@
+---
+title: "Granular session permissions for scoped API keys"
+description: "Scoped project API keys now separate session management from session tool execution, with dedicated access for older MCP APIs."
+date: "2026-08-28"
+---
+
+Scoped project API keys now give you separate controls for session management and session-based execution.
+
+### What's new
+
+- **Session management** controls creating, viewing, configuring, and deleting sessions.
+- **Session tool execution** covers search, tool execution, proxy execution, and session-linked MCP access.
+- **MCP (Legacy)** controls older non-session MCP APIs, including server management and transport access.
+- **Tool execution (Legacy)** and **Proxy execute (Legacy)** are the updated labels for the existing direct execution permissions.
+
+Existing keys with the legacy **Sessions** permission keep the same access. New keys use the granular permissions instead.

--- a/docs/content/kb/guide/platform-project-api-key-permissions.mdx
+++ b/docs/content/kb/guide/platform-project-api-key-permissions.mdx
@@ -4,29 +4,39 @@ description: "Public guidance for scoped Project API key permissions."
 keywords: ["api-keys","permissions","platform","sessions","tool-router","authentication","errors-and-troubleshooting","sessions-and-execution","/kb/sdk-and-api/platform-project-api-key-permissions","org-api-created-keys-do-not-currently-enable-proxy-execute","tool-router-session-creation-requires-sessions-write-access"]
 sources: [{"sourcePath":"platform/project-api-key-permissions/public.md","sourceHeading":"Proxy Execute requires an explicitly allowed Project API key"},{"sourcePath":"platform/project-api-key-permissions/public.md","sourceHeading":"Tool Router session creation requires Sessions write access"},{"sourcePath":"platform/project-api-key-permissions/public.md","sourceHeading":"Tool execution requires Tool execution write access"}]
 sourceCommit: "5eac683455ff252a7a3b62f33ab6566445009b52"
-lastVerifiedAt: "2026-08-17"
-reviewAfter: "2026-11-15"
+lastVerifiedAt: "2026-08-28"
+reviewAfter: "2026-11-26"
 freshness: "evergreen"
 topics: ["authentication","errors-and-troubleshooting","sessions-and-execution"]
 aliases: ["/kb/sdk-and-api/platform-project-api-key-permissions","org-api-created-keys-do-not-currently-enable-proxy-execute","tool-router-session-creation-requires-sessions-write-access"]
 ---
-## Proxy Execute requires an explicitly allowed Project API key
+## Proxy execute (Legacy) requires an explicitly allowed Project API key
 
-Create a scoped Project API key in the Dashboard and enable **Proxy Execute**
+Create a scoped Project API key in the Dashboard and enable **Proxy execute (Legacy)**
 during key creation before calling the v3.1 Proxy Execute API. If a request is
 denied, verify the key's scope before debugging the provider connection. Use a
 fresh request ID from the correctly scoped key when contacting Composio support is still necessary.
 
-## Tool Router session creation requires Sessions write access
+## Tool Router session creation requires Session management write access
 
-For scoped Project API keys, creating a session through `composio.sessions.create(...)` or `POST /api/v3.1/tool_router/session` requires the Sessions permission with write or read/write access.
+For newly created scoped Project API keys, creating a session through `composio.sessions.create(...)` or `POST /api/v3.1/tool_router/session` requires the Session management permission with write or read/write access.
 
 A key can successfully call `GET /api/v3.1/toolkits` with Toolkits read access and still be unable to create a session. The SDK can surface a scoped-permission denial as a generic 401 `Invalid API key`.
 
-Create a new Project API key with Sessions set to Read and write, or use an appropriate full-access Project API key, then retry session creation.
+Create a new Project API key with Session management set to Read and write, or use an appropriate full-access Project API key, then retry session creation. Existing keys with the legacy Sessions permission continue to work without changes.
 
-## Tool execution requires Tool execution write access
+## Tool execution (Legacy) requires write access
 
-For a scoped Project API key, `composio.tools.execute()` and the tool-execute API require Tool execution set to Write or Read and write. A key without that permission can surface a generic 401 `Invalid API key` even when the key exists and is active.
+For a newly created scoped Project API key, `composio.tools.execute()` and the direct tool execution API require Tool execution (Legacy) set to Write. A key without that permission can surface a generic 401 `Invalid API key` even when the key exists and is active.
 
-Create a correctly scoped Project API key or use an appropriate full-access Project API key, then retry. The current API may return a generic permission error, so diagnose this behavior from the key's permissions.
+Create a correctly scoped Project API key or use an appropriate full-access Project API key, then retry.
+
+## Session tool execution requires write access
+
+Session search, tool execution, proxy execution, and session-linked MCP access require Session tool execution set to Write. Session proxy execution also accepts Proxy execute (Legacy), so existing Proxy execute keys keep working. A key with Session tool execution can invoke any tool exposed by the session-linked MCP server.
+
+Existing keys with the legacy Sessions permission retain the session execution and MCP access they had before the permission split. They do not gain session proxy execution.
+
+## Legacy MCP routes require MCP (Legacy) access
+
+Use MCP (Legacy) read or write access to view or manage MCP servers and instances. Connecting to an MCP transport requires MCP (Legacy) write access and grants every capability exposed by that server.

--- a/docs/content/reference/authenticating-to-composio/project-api-key-permissions.mdx
+++ b/docs/content/reference/authenticating-to-composio/project-api-key-permissions.mdx
@@ -53,24 +53,27 @@ Click **Create API Key**, then choose the permission areas and access levels bel
 
 Some read routes use `POST` because the request body carries filters or lookup input. The access level is based on what the route does, not only the HTTP method.
 
-When v3 and v3.1 expose the same route shape, this page lists one representative version instead of repeating both. Version-specific routes are listed separately.
+The session, MCP, and proxy tables list both v3 and v3.1 routes explicitly. Elsewhere, equivalent routes may be represented by one version. Version-specific routes are listed separately, and MCP transport routes use their public paths.
 
 ## Permission areas
 
 Jump to each permission area to see the routes it covers.
 
-| Permission area    | Available levels                                 | Routes                             |
-| ------------------ | ------------------------------------------------ | ---------------------------------- |
-| Auth configs       | No access, Read only, Write only, Read and write | [View routes](#auth-configs)       |
-| Connected accounts | No access, Read only, Write only, Read and write | [View routes](#connected-accounts) |
-| Tools              | No access, Read only                             | [View routes](#tools)              |
-| Tool execution     | No access, Write only                            | [View routes](#tool-execution)     |
-| Proxy execute      | No access, Write only                            | [View routes](#proxy-execute)      |
-| Toolkits           | No access, Read only, Write only, Read and write | [View routes](#toolkits)           |
-| Triggers           | No access, Read only, Write only, Read and write | [View routes](#triggers)           |
-| Webhooks           | No access, Read only, Write only, Read and write | [View routes](#webhooks)           |
-| Observability      | No access, Read only                             | [View routes](#observability)      |
-| Sessions           | No access, Read only, Write only, Read and write | [View routes](#sessions)           |
+| Permission area          | Available levels                                 | Routes                                  |
+| ------------------------ | ------------------------------------------------ | --------------------------------------- |
+| Auth configs             | No access, Read only, Write only, Read and write | [View routes](#auth-configs)            |
+| Connected accounts       | No access, Read only, Write only, Read and write | [View routes](#connected-accounts)      |
+| Tools                    | No access, Read only                             | [View routes](#tools)                   |
+| Tool execution (Legacy)  | No access, Write only                            | [View routes](#tool-execution-legacy)   |
+| Session management       | No access, Read only, Write only, Read and write | [View routes](#session-management)      |
+| Session tool execution   | No access, Write only                            | [View routes](#session-tool-execution)  |
+| MCP (Legacy)             | No access, Read only, Write only, Read and write | [View routes](#mcp-legacy)              |
+| Proxy execute (Legacy)   | No access, Write only                            | [View routes](#proxy-execute-legacy)    |
+| Toolkits                 | No access, Read only, Write only, Read and write | [View routes](#toolkits)                |
+| Triggers                 | No access, Read only, Write only, Read and write | [View routes](#triggers)                |
+| Webhooks                 | No access, Read only, Write only, Read and write | [View routes](#webhooks)                |
+| Observability            | No access, Read only                             | [View routes](#observability)           |
+| Sessions (legacy)        | Existing keys only                               | [View routes](#sessions-legacy)         |
 
 ## Auth configs
 
@@ -115,27 +118,109 @@ View tool definitions, inputs, scopes, and versions.
 | Read   | `GET`  | `/api/v3.1/tools/get_scopes_required`          |
 | Read   | `POST` | `/api/v3.1/tools/execute/{tool_slug}/input`    |
 
-## Tool execution
+## Tool execution (Legacy)
 
-Execute predefined Composio tools.
+Execute tools through the legacy direct execution API.
 
 | Access | Method | Endpoint                              |
 | ------ | ------ | ------------------------------------- |
+| Write  | `POST` | `/api/v3/tools/execute/{tool_slug}`   |
 | Write  | `POST` | `/api/v3.1/tools/execute/{tool_slug}` |
 | Write  | `POST` | `/api/v3/files/upload/request`        |
 | Write  | `POST` | `/api/v3/files/upload/response`       |
 | Write  | `GET`  | `/api/v3/files/list`                  |
 
-## Proxy execute
+## Session management
 
-Execute raw proxy requests against connected accounts.
+Create, view, configure, and delete sessions. This permission does not allow tool execution.
 
-Proxy execute is separate from tool execution. Grant it only when your application needs to call a connected account API through the raw proxy path.
+| Access | Method   | Endpoint                                                                  |
+| ------ | -------- | ------------------------------------------------------------------------- |
+| Read   | `GET`    | `/api/v3/tool_router/session/{session_id}`                                |
+| Read   | `GET`    | `/api/v3/tool_router/session/{session_id}/toolkits`                       |
+| Read   | `GET`    | `/api/v3/tool_router/session/{session_id}/tools`                          |
+| Read   | `GET`    | `/api/v3/tool_router/session/{session_id}/mounts/{mount_id}/items`        |
+| Read   | `GET`    | `/api/v3.1/tool_router/session/{session_id}`                              |
+| Read   | `GET`    | `/api/v3.1/tool_router/session/{session_id}/toolkits`                     |
+| Read   | `GET`    | `/api/v3.1/tool_router/session/{session_id}/config_history`               |
+| Read   | `GET`    | `/api/v3.1/tool_router/session/{session_id}/tools`                        |
+| Read   | `GET`    | `/api/v3.1/tool_router/session/{session_id}/mounts/{mount_id}/items`      |
+| Write  | `POST`   | `/api/v3/tool_router/session`                                             |
+| Write  | `POST`   | `/api/v3/tool_router/session/{session_id}/link`                           |
+| Write  | `PATCH`  | `/api/v3/tool_router/session/{session_id}`                                |
+| Write  | `POST`   | `/api/v3/tool_router/session/{session_id}/mounts/{mount_id}/upload_url`   |
+| Write  | `POST`   | `/api/v3/tool_router/session/{session_id}/mounts/{mount_id}/download_url` |
+| Write  | `POST`   | `/api/v3/tool_router/session/{session_id}/mounts/{mount_id}/delete`       |
+| Write  | `POST`   | `/api/v3.1/tool_router/session`                                           |
+| Write  | `POST`   | `/api/v3.1/tool_router/session/{session_id}/attach`                       |
+| Write  | `POST`   | `/api/v3.1/tool_router/session/{session_id}/link`                         |
+| Write  | `PATCH`  | `/api/v3.1/tool_router/session/{session_id}`                              |
+| Write  | `DELETE` | `/api/v3.1/tool_router/session/{session_id}`                              |
+| Write  | `POST`   | `/api/v3.1/tool_router/session/{session_id}/mounts/{mount_id}/upload_url` |
+| Write  | `POST`   | `/api/v3.1/tool_router/session/{session_id}/mounts/{mount_id}/download_url` |
+| Write  | `POST`   | `/api/v3.1/tool_router/session/{session_id}/mounts/{mount_id}/delete`     |
 
-| Access | Method | Endpoint                                                 |
-| ------ | ------ | -------------------------------------------------------- |
-| Write  | `POST` | `/api/v3.1/tools/execute/proxy`                          |
-| Write  | `POST` | `/api/v3/tool_router/session/{session_id}/proxy_execute` |
+## Session tool execution
+
+Search and execute tools through sessions and session-linked MCP servers. This includes session proxy execution, so it grants every execution capability exposed through a session.
+
+| Access | Method | Endpoint                                                       |
+| ------ | ------ | -------------------------------------------------------------- |
+| Write  | `POST` | `/api/v3/tool_router/session/{session_id}/execute`              |
+| Write  | `POST` | `/api/v3/tool_router/session/{session_id}/execute_meta`         |
+| Write  | `POST` | `/api/v3/tool_router/session/{session_id}/search`               |
+| Write  | `POST` | `/api/v3/tool_router/session/{session_id}/proxy_execute`        |
+| Write  | `POST` | `/api/v3.1/tool_router/session/{session_id}/execute`            |
+| Write  | `POST` | `/api/v3.1/tool_router/session/{session_id}/execute_meta`       |
+| Write  | `POST` | `/api/v3.1/tool_router/session/{session_id}/search`             |
+| Write  | `POST` | `/api/v3.1/tool_router/session/{session_id}/proxy_execute`      |
+| Write  | `POST` | `/tool_router/{session_id}/mcp`                                 |
+
+## MCP (Legacy)
+
+Create, manage, and connect to MCP servers. Transport access grants every capability exposed by the configured MCP server.
+
+| Access | Method   | Endpoint                                                            |
+| ------ | -------- | ------------------------------------------------------------------- |
+| Read   | `GET`    | `/api/v3/mcp/servers`                                               |
+| Read   | `GET`    | `/api/v3.1/mcp/servers`                                             |
+| Read   | `GET`    | `/api/v3/mcp/{id}`                                                  |
+| Read   | `GET`    | `/api/v3.1/mcp/{id}`                                                |
+| Read   | `GET`    | `/api/v3/mcp/app/{app_key}`                                         |
+| Read   | `GET`    | `/api/v3.1/mcp/app/{app_key}`                                       |
+| Read   | `GET`    | `/api/v3/mcp/servers/{server_id}/instances`                         |
+| Read   | `GET`    | `/api/v3.1/mcp/servers/{server_id}/instances`                       |
+| Write  | `POST`   | `/api/v3/mcp/servers`                                               |
+| Write  | `POST`   | `/api/v3.1/mcp/servers`                                             |
+| Write  | `POST`   | `/api/v3/mcp/servers/generate`                                      |
+| Write  | `POST`   | `/api/v3.1/mcp/servers/generate`                                    |
+| Write  | `POST`   | `/api/v3/mcp/servers/custom`                                        |
+| Write  | `POST`   | `/api/v3.1/mcp/servers/custom`                                      |
+| Write  | `PATCH`  | `/api/v3/mcp/{id}`                                                  |
+| Write  | `PATCH`  | `/api/v3.1/mcp/{id}`                                                |
+| Write  | `DELETE` | `/api/v3/mcp/{id}`                                                  |
+| Write  | `DELETE` | `/api/v3.1/mcp/{id}`                                                |
+| Write  | `POST`   | `/api/v3/mcp/servers/{server_id}/instances`                         |
+| Write  | `POST`   | `/api/v3.1/mcp/servers/{server_id}/instances`                       |
+| Write  | `DELETE` | `/api/v3/mcp/servers/{server_id}/instances/{instance_id}`           |
+| Write  | `DELETE` | `/api/v3.1/mcp/servers/{server_id}/instances/{instance_id}`         |
+| Write  | `POST`   | `/v3/mcp/{server_id}/{transport}`                                   |
+| Write  | `POST`   | `/v3.1/mcp/{server_id}/{transport}`                                 |
+| Write  | `DELETE` | `/v3/mcp/{server_id}/{transport}`                                   |
+| Write  | `DELETE` | `/v3.1/mcp/{server_id}/{transport}`                                 |
+
+## Proxy execute (Legacy)
+
+Execute raw proxy requests against connected accounts through direct and session proxy routes.
+
+Proxy execute is separate from tool execution. Session proxy routes accept either Session tool execution or Proxy execute (Legacy). Use Session tool execution for new session-based integrations; existing Proxy execute keys retain their access.
+
+| Access | Method | Endpoint                                                          |
+| ------ | ------ | ----------------------------------------------------------------- |
+| Write  | `POST` | `/api/v3/tools/execute/proxy`                                     |
+| Write  | `POST` | `/api/v3.1/tools/execute/proxy`                                   |
+| Write  | `POST` | `/api/v3/tool_router/session/{session_id}/proxy_execute`          |
+| Write  | `POST` | `/api/v3.1/tool_router/session/{session_id}/proxy_execute`        |
 
 ## Toolkits
 
@@ -199,43 +284,15 @@ View execution logs and project usage summaries.
 | Read   | `POST` | `/api/v3.1/project/usage/{entity_type}` |
 | Read   | `POST` | `/api/v3.1/project/usage/summary`       |
 
-## Sessions
+## Sessions (legacy)
 
-Create and operate sessions and MCP servers. This permission area covers MCP server management, the MCP runtime transport, and the tool router MCP transport.
+The `sessions` permission is no longer available when you create a scoped API key. Existing keys keep their original access unchanged.
 
-| Access | Method   | Endpoint                                                                  |
-| ------ | -------- | ------------------------------------------------------------------------- |
-| Read   | `GET`    | `/api/v3/mcp/servers`                                                     |
-| Read   | `GET`    | `/api/v3/mcp/{id}`                                                        |
-| Read   | `GET`    | `/api/v3/mcp/app/{app_key}`                                               |
-| Read   | `GET`    | `/api/v3/mcp/servers/{server_id}/instances`                               |
-| Read   | `GET`    | `/tool_router/{session_id}/mcp`                                           |
-| Read   | `GET`    | `/api/v3.1/tool_router/session/{session_id}`                              |
-| Read   | `GET`    | `/api/v3/tool_router/session/{session_id}/toolkits`                       |
-| Read   | `GET`    | `/api/v3.1/tool_router/session/{session_id}/tools`                        |
-| Read   | `GET`    | `/api/v3/tool_router/session/{session_id}/mounts/{mount_id}/items`        |
-| Read   | `GET`    | `/api/v3.1/tool_router/session/{session_id}/config_history`               |
-| Write  | `POST`   | `/api/v3/mcp/servers`                                                     |
-| Write  | `POST`   | `/api/v3/mcp/servers/generate`                                            |
-| Write  | `POST`   | `/api/v3/mcp/servers/custom`                                              |
-| Write  | `PATCH`  | `/api/v3/mcp/{id}`                                                        |
-| Write  | `DELETE` | `/api/v3/mcp/{id}`                                                        |
-| Write  | `POST`   | `/api/v3/mcp/servers/{server_id}/instances`                               |
-| Write  | `DELETE` | `/api/v3/mcp/servers/{server_id}/instances/{instance_id}`                 |
-| Write  | `POST`   | `/api/v3/mcp/{server_id}/{transport}`                                     |
-| Write  | `DELETE` | `/api/v3/mcp/{server_id}/{transport}`                                     |
-| Write  | `POST`   | `/tool_router/{session_id}/mcp`                                           |
-| Write  | `DELETE` | `/tool_router/{session_id}/mcp`                                           |
-| Write  | `POST`   | `/api/v3.1/tool_router/session`                                           |
-| Write  | `POST`   | `/api/v3.1/tool_router/session/{session_id}/execute`                      |
-| Write  | `POST`   | `/api/v3.1/tool_router/session/{session_id}/execute_meta`                 |
-| Write  | `POST`   | `/api/v3/tool_router/session/{session_id}/link`                           |
-| Write  | `POST`   | `/api/v3.1/tool_router/session/{session_id}/search`                       |
-| Write  | `PATCH`  | `/api/v3.1/tool_router/session/{session_id}`                              |
-| Write  | `POST`   | `/api/v3/tool_router/session/{session_id}/mounts/{mount_id}/upload_url`   |
-| Write  | `POST`   | `/api/v3/tool_router/session/{session_id}/mounts/{mount_id}/download_url` |
-| Write  | `POST`   | `/api/v3/tool_router/session/{session_id}/mounts/{mount_id}/delete`       |
-| Write  | `POST`   | `/api/v3.1/tool_router/session/{session_id}/attach`                       |
+- Existing `sessions: read` grants continue to cover session reads and legacy MCP server reads.
+- Existing `sessions: write` grants continue to cover session management writes, legacy MCP server writes, session `execute`, `execute_meta`, and `search` routes, and MCP transport writes. They do not cover session proxy execution.
+- Existing `sessions: read_write` grants continue to cover both sets of routes.
+
+For new session-based integrations, combine `session_management` and `session_tool_execution`. Add `legacy_mcp`, `tool_execution`, or `proxy_execute` only if your application still calls the older MCP, direct tool execution, or direct proxy APIs.
 
 ## What to read next
 

--- a/docs/kb/articles/platform-project-api-key-permissions.md
+++ b/docs/kb/articles/platform-project-api-key-permissions.md
@@ -1,20 +1,30 @@
-## Proxy Execute requires an explicitly allowed Project API key
+## Proxy execute (Legacy) requires an explicitly allowed Project API key
 
-Create a scoped Project API key in the Dashboard and enable **Proxy Execute**
+Create a scoped Project API key in the Dashboard and enable **Proxy execute (Legacy)**
 during key creation before calling the v3.1 Proxy Execute API. If a request is
 denied, verify the key's scope before debugging the provider connection. Use a
 fresh request ID from the correctly scoped key when contacting Composio support is still necessary.
 
-## Tool Router session creation requires Sessions write access
+## Tool Router session creation requires Session management write access
 
-For scoped Project API keys, creating a session through `composio.sessions.create(...)` or `POST /api/v3.1/tool_router/session` requires the Sessions permission with write or read/write access.
+For newly created scoped Project API keys, creating a session through `composio.sessions.create(...)` or `POST /api/v3.1/tool_router/session` requires the Session management permission with write or read/write access.
 
 A key can successfully call `GET /api/v3.1/toolkits` with Toolkits read access and still be unable to create a session. The SDK can surface a scoped-permission denial as a generic 401 `Invalid API key`.
 
-Create a new Project API key with Sessions set to Read and write, or use an appropriate full-access Project API key, then retry session creation.
+Create a new Project API key with Session management set to Read and write, or use an appropriate full-access Project API key, then retry session creation. Existing keys with the legacy Sessions permission continue to work without changes.
 
-## Tool execution requires Tool execution write access
+## Tool execution (Legacy) requires write access
 
-For a scoped Project API key, `composio.tools.execute()` and the tool-execute API require Tool execution set to Write or Read and write. A key without that permission can surface a generic 401 `Invalid API key` even when the key exists and is active.
+For a newly created scoped Project API key, `composio.tools.execute()` and the direct tool execution API require Tool execution (Legacy) set to Write. A key without that permission can surface a generic 401 `Invalid API key` even when the key exists and is active.
 
-Create a correctly scoped Project API key or use an appropriate full-access Project API key, then retry. The current API may return a generic permission error, so diagnose this behavior from the key's permissions.
+Create a correctly scoped Project API key or use an appropriate full-access Project API key, then retry.
+
+## Session tool execution requires write access
+
+Session search, tool execution, proxy execution, and session-linked MCP access require Session tool execution set to Write. Session proxy execution also accepts Proxy execute (Legacy), so existing Proxy execute keys keep working. A key with Session tool execution can invoke any tool exposed by the session-linked MCP server.
+
+Existing keys with the legacy Sessions permission retain the session execution and MCP access they had before the permission split. They do not gain session proxy execution.
+
+## Legacy MCP routes require MCP (Legacy) access
+
+Use MCP (Legacy) read or write access to view or manage MCP servers and instances. Connecting to an MCP transport requires MCP (Legacy) write access and grants every capability exposed by that server.

--- a/docs/kb/manifest.json
+++ b/docs/kb/manifest.json
@@ -1068,9 +1068,9 @@
       ],
       "relatedGuides": [],
       "externalResources": [],
-      "updatedAt": "2026-07-16",
-      "lastVerifiedAt": "2026-08-17",
-      "reviewAfter": "2026-11-15",
+      "updatedAt": "2026-08-28",
+      "lastVerifiedAt": "2026-08-28",
+      "reviewAfter": "2026-11-26",
       "freshness": "evergreen",
       "state": "published",
       "featured": false


### PR DESCRIPTION
We've split project API key permissions from a broad **Sessions** into **Session management** and **Session tool execution**.

I've also removed the v3/v3.1 prefixes to keep things simpler to understand and remove duplication.

Backend: [#12279](https://github.com/ComposioHQ/platform/pull/12279), [#12291](https://github.com/ComposioHQ/platform/pull/12291), [production #12370](https://github.com/ComposioHQ/platform/pull/12370). Dashboard: [#1384](https://github.com/ComposioHQ/dashboard/pull/1384).