### PR TITLE
docs: replace hardcoded "1,000+" toolkit counts with the live catalog count

### DIFF
--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -8,6 +8,7 @@ import { PostHogProvider } from '@/components/posthog-provider';
 import CustomSearchDialog from '@/components/custom-search-dialog';
 import { ScrollReset } from '@/components/scroll-reset';
 import { source, referenceSource } from '@/lib/source';
+import { TOOLKIT_COUNT_LABEL } from '@/lib/toolkit-count';
 
 const defaultLinkSlugs: { slug: string[]; source: typeof source }[] = [
   { slug: ['quickstart'], source },
@@ -24,16 +25,18 @@ const defaultLinks = defaultLinkSlugs.flatMap(({ slug, source: pageSource }) => 
   return [{ title: page.data.title, description: page.data.description ?? '', href: page.url }];
 });
 
+const SITE_DESCRIPTION = `Build AI agents with ${TOOLKIT_COUNT_LABEL} tools. Connect LLMs to external services like GitHub, Slack, Gmail, and more.`;
+
 export const metadata: Metadata = {
   title: {
     default: 'Composio Docs',
     template: '%s | Composio',
   },
-  description: 'Build AI agents with 1000+ tools. Connect LLMs to external services like GitHub, Slack, Gmail, and more.',
+  description: SITE_DESCRIPTION,
   metadataBase: new URL('https://docs.composio.dev'),
   openGraph: {
     title: 'Composio Docs',
-    description: 'Build AI agents with 1000+ tools. Connect LLMs to external services like GitHub, Slack, Gmail, and more.',
+    description: SITE_DESCRIPTION,
     siteName: 'Composio Docs',
     type: 'website',
     images: ['https://og.composio.dev/api/og?title=Composio%20Docs'],
@@ -41,7 +44,7 @@ export const metadata: Metadata = {
   twitter: {
     card: 'summary_large_image',
     title: 'Composio Docs',
-    description: 'Build AI agents with 1000+ tools. Connect LLMs to external services like GitHub, Slack, Gmail, and more.',
+    description: SITE_DESCRIPTION,
     images: ['https://og.composio.dev/api/og?title=Composio%20Docs'],
   },
 };
@@ -83,7 +86,7 @@ export default function Layout({ children }: LayoutProps<'/'>) {
                   '@id': 'https://docs.composio.dev/#website',
                   url: 'https://docs.composio.dev',
                   name: 'Composio Docs',
-                  description: 'Build AI agents with 1000+ tools. Connect LLMs to external services like GitHub, Slack, Gmail, and more.',
+                  description: SITE_DESCRIPTION,
                   publisher: { '@id': 'https://composio.dev/#organization' },
                 },
                 {

--- a/docs/app/llms-full.txt/route.ts
+++ b/docs/app/llms-full.txt/route.ts
@@ -9,6 +9,7 @@ import {
 } from '@/lib/source';
 import { SESSION_GUARDRAILS } from '@/lib/llm-guardrails';
 import { detectReferenceApiVersion } from '@/lib/api-version';
+import { TOOLKIT_COUNT_LABEL } from '@/lib/toolkit-count';
 import {
   formatKnowledgeDiscoveryLinks,
   getLocalKnowledgeDiscoveryPaths,
@@ -165,7 +166,7 @@ export async function GET() {
     ]);
 
     const results = [
-      `# Composio Documentation\n\n> Composio powers 1000+ toolkits, tool search, context management, authentication, and a sandboxed workbench to help you build AI agents that turn intent into action.${SESSION_GUARDRAILS}\n# Documentation\n`,
+      `# Composio Documentation\n\n> Composio powers ${TOOLKIT_COUNT_LABEL} toolkits, tool search, context management, authentication, and a sandboxed workbench to help you build AI agents that turn intent into action.${SESSION_GUARDRAILS}\n# Documentation\n`,
       ...docsResults,
       '\n# Knowledge Hub navigation\n',
       knowledgeDiscoveryLinks,

--- a/docs/app/llms.txt/route.ts
+++ b/docs/app/llms.txt/route.ts
@@ -6,6 +6,7 @@ import {
   knowledgeBaseSource,
 } from '@/lib/source';
 import { detectReferenceApiVersion } from '@/lib/api-version';
+import { TOOLKIT_COUNT_LABEL } from '@/lib/toolkit-count';
 import {
   formatKnowledgeDiscoveryLinks,
   getLocalKnowledgeDiscoveryPaths,
@@ -181,7 +182,7 @@ ${legacyReferencePages.map(formatPage).join('\n')}
 
     const index = `# Composio Documentation
 
-> Composio powers 1000+ toolkits, tool search, context management, authentication, and a sandboxed workbench to help you build AI agents that turn intent into action.
+> Composio powers ${TOOLKIT_COUNT_LABEL} toolkits, tool search, context management, authentication, and a sandboxed workbench to help you build AI agents that turn intent into action.
 
 > **For AI agents:** Route by intent. To build an application, start with [Quickstart](https://docs.composio.dev/docs/quickstart.md) or [Providers](https://docs.composio.dev/docs/providers.md) and use \`composio.create(user_id)\` + \`session.tools()\`. To use Composio from Codex or Claude Code without explicit MCP intent, install the [native agent plugin](https://docs.composio.dev/docs/agent-plugins.md). To connect an existing client over MCP, use [Composio Connect](https://docs.composio.dev/docs/composio-connect.md). When an application creates a session and needs MCP transport, use [Sessions via MCP](https://docs.composio.dev/docs/sessions-via-mcp.md). See any page's .md endpoint for full usage instructions.
 

--- a/docs/components/docs-hero-v2.tsx
+++ b/docs/components/docs-hero-v2.tsx
@@ -1,3 +1,5 @@
+import { TOOLKIT_COUNT_LABEL } from '@/lib/toolkit-count';
+
 export function DocsHeroV2() {
   return (
     <section className="py-10 sm:py-12">
@@ -8,7 +10,7 @@ export function DocsHeroV2() {
 
         <p className="max-w-[620px] text-base leading-[1.6] text-fd-foreground/70 sm:text-lg">
           Use Composio to discover tools, authenticate each user, and run
-          actions across 1,000+ apps.
+          actions across {TOOLKIT_COUNT_LABEL} apps.
         </p>
       </div>
     </section>

--- a/docs/components/home-features.tsx
+++ b/docs/components/home-features.tsx
@@ -3,6 +3,7 @@ import { ArrowUpRight } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { AuthDiagram } from './home-auth-diagram';
 import { MOCK_FADE_STYLE } from './home-shared';
+import { TOOLKIT_COUNT_LABEL } from '@/lib/toolkit-count';
 
 const LOGO_CDN = 'https://logos.composio.dev/api';
 // 10-col × 3-row grid: 29 recognizable toolkit logos plus a brand-tinted
@@ -40,7 +41,7 @@ export function HomeFeatures() {
       <div className="grid grid-cols-1 gap-6 sm:auto-rows-fr sm:grid-cols-2">
         <FeatureCard
           title="Tools that resolve by intent."
-          description="Smart tool search over 1000+ apps, surfaced just in time with the right scope."
+          description={`Smart tool search over ${TOOLKIT_COUNT_LABEL} apps, surfaced just in time with the right scope.`}
           href="/docs/how-composio-works"
           visual={<ToolkitsVisual />}
         />
@@ -58,7 +59,7 @@ export function HomeFeatures() {
         />
         <FeatureCard
           title="Run arbitrary code, safely."
-          description="A sandbox pre-wired with your user's connected accounts and 1000+ tools."
+          description={`A sandbox pre-wired with your user's connected accounts and ${TOOLKIT_COUNT_LABEL} tools.`}
           href="/docs/sandbox"
           visual={<SandboxVisual />}
         />

--- a/docs/components/home-resources.tsx
+++ b/docs/components/home-resources.tsx
@@ -9,6 +9,7 @@ import {
   Wrench,
 } from 'lucide-react';
 import type { ReactNode } from 'react';
+import { TOOLKIT_COUNT_LABEL } from '@/lib/toolkit-count';
 
 const RESOURCES = [
   {
@@ -38,7 +39,7 @@ const RESOURCES = [
   {
     icon: <Blocks aria-hidden="true" className="size-4" />,
     title: 'Toolkits',
-    description: 'Browse the 1000+ apps your agent can act on.',
+    description: `Browse the ${TOOLKIT_COUNT_LABEL} apps your agent can act on.`,
     href: '/toolkits',
   },
   {

--- a/docs/lib/toolkit-count.ts
+++ b/docs/lib/toolkit-count.ts
@@ -1,0 +1,11 @@
+import toolkitsData from '@/public/data/toolkits-list.json';
+
+// Server-only: reads the full toolkit catalog at build time to derive a
+// rounded-down, human-friendly count for marketing copy (hero, metadata,
+// llms.txt). Never import this from a "use client" module — that would ship
+// the ~1,300-row JSON array to the browser just to read its length.
+const roundedToolkitCount = Math.floor(toolkitsData.length / 100) * 100;
+
+// Pin the locale so the grouping separator is a comma regardless of the build
+// host's locale ("1,300+", never "1.300+" or "1 300+").
+export const TOOLKIT_COUNT_LABEL = `${roundedToolkitCount.toLocaleString('en-US')}+`;


### PR DESCRIPTION
## Problem

The docs hero, feature cards, site metadata, and `llms.txt` / `llms-full.txt` all hardcoded **"1,000+"** (variously written `1,000+` and `1000+`) apps. The actual published catalog is **1,327 toolkits** — the length of the committed `docs/public/data/toolkits-list.json`, which the `/toolkits` page already renders. The copy was stale and understated.

## Approach

Reuse the same `toolkits-list.json` the `/toolkits` page reads. A new server-only helper `docs/lib/toolkit-count.ts` imports it and derives a rounded-down, human-friendly label:

```ts
const roundedToolkitCount = Math.floor(toolkitsData.length / 100) * 100; // 1327 -> 1300
export const TOOLKIT_COUNT_LABEL = `${roundedToolkitCount.toLocaleString('en-US')}+`; // "1,300+"
```

The count stays correct as the catalog grows, and the locale is pinned to `en-US` so the grouping separator is always a comma regardless of the build host's locale (never `1.300+` or `1 300+`).

## Files

Helper (new):
- `docs/lib/toolkit-count.ts`

Six consumers, all server-side (none is a `"use client"` module):
- `docs/components/docs-hero-v2.tsx`
- `docs/components/home-features.tsx`
- `docs/components/home-resources.tsx`
- `docs/app/layout.tsx` (metadata description, OpenGraph, Twitter, JSON-LD)
- `docs/app/llms.txt/route.ts`
- `docs/app/llms-full.txt/route.ts`

## No client bundle cost

Every importer resolves in a server graph, so the ~1,300-row JSON array is read at build time only and never ships to the browser.

## Scope / deferred follow-up

Deliberately narrow: no MDX content and no generator scripts are touched. The remaining ~15 hardcoded literals in MDX frontmatter/prose, and the meta-tools generator's `"500+"`, are a **deferred follow-up** and are **not** in this PR.

## Verification

Cross-model (Codex / GPT-5.6) adversarial review: GREEN. Codex ran `bun run types:check` and a production `next build` in the working tree — both pass. Locally I confirmed the count (1327 -> "1,300+"), that no importer is `"use client"`, and that no stray `1000+` / `1,000+` / `500+` remains in the six files. CI should re-verify typecheck/build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)