### PR TITLE
fix(docs): render KB identifier URLs as code spans, not dead links

### DIFF
--- a/.github/workflows/docs-update-kb.yml
+++ b/.github/workflows/docs-update-kb.yml
@@ -16,7 +16,8 @@ jobs:
     permissions:
       contents: read
     outputs:
-      changed: ${{ steps.source.outputs.changed }}
+      changed: ${{ steps.rebuild.outputs.changed }}
+      upstream_changed: ${{ steps.source.outputs.upstream_changed }}
       commit: ${{ steps.source.outputs.commit }}
     defaults:
       run:
@@ -55,19 +56,17 @@ jobs:
           current_commit=$(jq -r '.source.commit' kb/manifest.json)
           echo "commit=$source_commit" >> "$GITHUB_OUTPUT"
           if [ "$source_commit" = "$current_commit" ]; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "upstream_changed=false" >> "$GITHUB_OUTPUT"
             echo "Support knowledge is already current at $source_commit."
           else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "upstream_changed=true" >> "$GITHUB_OUTPUT"
             echo "Refreshing support knowledge from $current_commit to $source_commit."
           fi
 
       - name: Setup Node.js, pnpm, Bun
-        if: steps.source.outputs.changed == 'true'
         uses: ./.github/actions/setup-node-pnpm-bun
 
       - name: Cache Bun dependencies
-        if: steps.source.outputs.changed == 'true'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.bun/install/cache
@@ -76,11 +75,34 @@ jobs:
             ${{ runner.os }}-bun-
 
       - name: Install dependencies
-        if: steps.source.outputs.changed == 'true'
         run: bun install
 
+      # Docs-side text changes (generator updates, guide edits) also invalidate
+      # the checked-in semantic artifact. Detect that here so CI rebuilds the
+      # artifact even when the upstream support-knowledge commit has not moved.
+      - name: Detect stale semantic artifact
+        id: semantic
+        if: steps.source.outputs.upstream_changed == 'false'
+        run: |
+          if bun scripts/build-kb-semantic-index.ts --check; then
+            echo "stale=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+            echo "Semantic artifact is stale against the checked-in docs corpus."
+          fi
+
+      - name: Resolve rebuild
+        id: rebuild
+        run: |
+          if [ "${{ steps.source.outputs.upstream_changed }}" = "true" ] || [ "${{ steps.semantic.outputs.stale }}" = "true" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Support knowledge and semantic artifact are both current."
+          fi
+
       - name: Import public support knowledge
-        if: steps.source.outputs.changed == 'true'
+        if: steps.source.outputs.upstream_changed == 'true'
         env:
           SOURCE_ROOT: ${{ github.workspace }}/.support-knowledge
           SOURCE_COMMIT: ${{ steps.source.outputs.commit }}
@@ -90,19 +112,19 @@ jobs:
           --source-commit "$SOURCE_COMMIT"
 
       - name: Rebuild generated pages and semantic artifact
-        if: steps.source.outputs.changed == 'true'
+        if: steps.rebuild.outputs.changed == 'true'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: bun run build:kb-semantic
 
       - name: Verify refreshed knowledge base
-        if: steps.source.outputs.changed == 'true'
+        if: steps.rebuild.outputs.changed == 'true'
         run: |
           bun run verify:kb
           bun run check:kb-semantic
 
       - name: Upload verified KB artifacts
-        if: steps.source.outputs.changed == 'true'
+        if: steps.rebuild.outputs.changed == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: support-knowledge-refresh
@@ -149,9 +171,9 @@ jobs:
           commit-message: 'docs(kb): refresh public support knowledge'
           title: 'docs(kb): refresh public support knowledge'
           body: |
-            Automated public-only refresh from `ComposioHQ/support-knowledge`.
+            Automated knowledge-base refresh for `ComposioHQ/support-knowledge`.
 
-            - Source commit: `${{ needs.refresh.outputs.commit }}`
+            - Source commit: `${{ needs.refresh.outputs.commit }}` (${{ needs.refresh.outputs.upstream_changed == 'true' && 'imported new support knowledge' || 'unchanged; rebuilt a stale semantic artifact' }})
             - Regenerated public KB pages and search records
             - Reused unchanged vectors and rebuilt the checked semantic artifact
             - Ran KB freshness and semantic-artifact verification

--- a/docs/content/kb/guide/toolkits-ahrefs.mdx
+++ b/docs/content/kb/guide/toolkits-ahrefs.mdx
@@ -13,4 +13,4 @@ aliases: ["/kb/toolkits/ahrefs-actions-use-the-api-host","ahrefs-actions-use-the
 ---
 ## Ahrefs actions must call api.ahrefs.com, not ahrefs.com
 
-Ahrefs API calls should use the API host https://api.ahrefs.com/v3. If Ahrefs actions or connection checks are hitting https://ahrefs.com/v3 and returning 404 HTML, treat it as a connector base-URL configuration problem rather than an API-key or request-payload issue. Confirm the failing request is using api.ahrefs.com; if it is not, contact Composio support with the redacted request or log ID for connector review.
+Ahrefs API calls should use the API host `https://api.ahrefs.com/v3`. If Ahrefs actions or connection checks are hitting `https://ahrefs.com/v3` and returning 404 HTML, treat it as a connector base-URL configuration problem rather than an API-key or request-payload issue. Confirm the failing request is using api.ahrefs.com; if it is not, contact Composio support with the redacted request or log ID for connector review.

--- a/docs/content/kb/guide/toolkits-googlemeet.mdx
+++ b/docs/content/kb/guide/toolkits-googlemeet.mdx
@@ -17,7 +17,7 @@ Google Super is a separate toolkit with its own tool slugs. If the connected acc
 
 ## Configure Meet scopes and enable the Google Meet API before creating Meet spaces
 
-For Meet space creation/settings through Google Super, include the Meet scopes https://www.googleapis.com/auth/meetings.space.created and https://www.googleapis.com/auth/meetings.space.settings in the auth config, then initiate a new connection so the new scopes are granted. Also enable the Google Meet API in the Google Cloud Console project backing the OAuth app.
+For Meet space creation/settings through Google Super, include the Meet scopes `https://www.googleapis.com/auth/meetings.space.created` and `https://www.googleapis.com/auth/meetings.space.settings` in the auth config, then initiate a new connection so the new scopes are granted. Also enable the Google Meet API in the Google Cloud Console project backing the OAuth app.
 
 ## Fetch transcript entries by first resolving the conference record
 

--- a/docs/decisions/public-knowledge-base.md
+++ b/docs/decisions/public-knowledge-base.md
@@ -110,6 +110,18 @@ gap that is not already answered by current docs or a published KB guide.
 Volatile pricing, entitlement, and security claims require an authoritative
 public source and are not copied from dashboard FAQ prose by default.
 
+### Identifier URLs
+
+KB prose cites machine identifiers that happen to look like URLs: OAuth
+scope URIs such as `https://www.googleapis.com/auth/…` and API surface roots
+such as `https://api.ahrefs.com/v3`. These are not documents; fetching them
+404s by design, so they can never survive the nightly external-link sweep as
+links. The generation layer therefore demotes bare citations and `<url>`
+autolinks of these two shapes to inline code spans. Explicit markdown links
+keep their authored form — if one points at an identifier URL, the nightly
+sweep flags it for an upstream fix instead of the pipeline silently rewriting
+navigation the author wrote.
+
 ## Routes and Navigation
 
 - `/kb` is the knowledge-base landing page.

--- a/docs/lib/kb/generate.ts
+++ b/docs/lib/kb/generate.ts
@@ -89,12 +89,56 @@ function relatedFrontmatter(
   ];
 }
 
+/**
+ * Identifier URLs cite machine identifiers — OAuth scope URIs and API
+ * surface roots such as `https://api.example.com/v3` — not documents. They
+ * respond 404 by design, so they must never publish as links the nightly
+ * external-link sweep would have to keep alive: they render as code spans.
+ */
+export function isIdentifierUrl(raw: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return false;
+  }
+  if ((url.protocol !== 'https:' && url.protocol !== 'http:') || url.search || url.hash) {
+    return false;
+  }
+  // Google OAuth scope URIs (https://www.googleapis.com/auth/…) identify a
+  // permission; the namespace serves no pages.
+  if (url.hostname === 'www.googleapis.com' && url.pathname.startsWith('/auth/')) {
+    return true;
+  }
+  // An API surface root: a version-only path such as `/v3` or `/v1beta/`.
+  // Deep paths (`/v3/tools/X`) stay links because they name real resources.
+  return /^\/v\d[\w.-]*\/?$/.test(url.pathname);
+}
+
+/**
+ * Wraps bare identifier URLs in code spans. URLs already presented as links —
+ * markdown link labels `[url](…)`, link targets `](url)`, and anything
+ * adjacent to a code span — keep their form; only bare citations and
+ * `<url>` autolinks (normalized earlier) become code.
+ */
+function identifierUrlsToCodeSpans(segment: string): string {
+  return segment.replace(/(?<![`(\]\[])https?:\/\/[^\s`<>\[\]()]+/g, match => {
+    // GFM autolinks drop trailing punctuation; keep it outside the code span.
+    const url = match.replace(/[.,;:!?'"]+$/, '');
+    if (!isIdentifierUrl(url)) return match;
+    return `\`${url}\`${match.slice(url.length)}`;
+  });
+}
+
 function escapeMdxProse(line: string): string {
-  const escapeSegment = (segment: string): string => segment
-    .replace(/<(https?:\/\/[^>\s]+)>/g, '[$1]($1)')
-    .replace(/<([^>\n]+)>/g, '&lt;$1&gt;')
-    .replace(/\{/g, '&#123;')
-    .replace(/\}/g, '&#125;');
+  const escapeSegment = (segment: string): string => identifierUrlsToCodeSpans(
+    segment
+      .replace(/<(https?:\/\/[^>\s]+)>/g, (match, url: string) =>
+        isIdentifierUrl(url) ? `\`${url}\`` : `[${url}](${url})`)
+      .replace(/<([^>\n]+)>/g, '&lt;$1&gt;')
+      .replace(/\{/g, '&#123;')
+      .replace(/\}/g, '&#125;'),
+  );
 
   let result = '';
   let cursor = 0;
@@ -117,7 +161,8 @@ function escapeMdxProse(line: string): string {
 /**
  * Converts authoritative CommonMark into MDX-safe Markdown. The source and
  * article snapshots stay verbatim; only the generated presentation escapes MDX
- * expressions, normalizes autolinks, and opts support snippets out of Twoslash.
+ * expressions, normalizes autolinks, demotes identifier URLs to code spans,
+ * and opts support snippets out of Twoslash.
  */
 export function markdownForMdx(markdown: string): string {
   let fence: { marker: string; length: number } | null = null;

--- a/docs/tests/static/kb-generation.test.ts
+++ b/docs/tests/static/kb-generation.test.ts
@@ -38,6 +38,30 @@ describe('public KB content generation', () => {
     ].join('\n'));
   });
 
+  test('demotes bare identifier URLs to code spans so they never publish as dead links', () => {
+    expect(markdownForMdx([
+      'Ahrefs API calls should use the API host https://api.ahrefs.com/v3. If actions are hitting https://ahrefs.com/v3 and returning 404 HTML, treat it as a configuration problem.',
+      'Include the Meet scopes https://www.googleapis.com/auth/meetings.space.created and https://www.googleapis.com/auth/meetings.space.settings in the auth config.',
+      'Read https://developers.google.com/identity/protocols/oauth2 and [the policy](https://developers.google.com/identity/protocols/oauth2/policies) for details.',
+      'Explicit syntax keeps its form: <https://developers.google.com/identity/protocols/oauth2> stays a link, [scope](https://www.googleapis.com/auth/gmail.send) and <https://www.googleapis.com/auth/gmail.send> cite identifiers, so only the first remains a link.',
+      'Already code: `https://www.googleapis.com/auth/drive` and deep API paths such as https://backend.composio.dev/api/v3/tools/X remain links.',
+      '',
+      '```text',
+      'const scope = "https://www.googleapis.com/auth/drive";',
+      '```',
+    ].join('\n'))).toBe([
+      'Ahrefs API calls should use the API host `https://api.ahrefs.com/v3`. If actions are hitting `https://ahrefs.com/v3` and returning 404 HTML, treat it as a configuration problem.',
+      'Include the Meet scopes `https://www.googleapis.com/auth/meetings.space.created` and `https://www.googleapis.com/auth/meetings.space.settings` in the auth config.',
+      'Read https://developers.google.com/identity/protocols/oauth2 and [the policy](https://developers.google.com/identity/protocols/oauth2/policies) for details.',
+      'Explicit syntax keeps its form: [https://developers.google.com/identity/protocols/oauth2](https://developers.google.com/identity/protocols/oauth2) stays a link, [scope](https://www.googleapis.com/auth/gmail.send) and `https://www.googleapis.com/auth/gmail.send` cite identifiers, so only the first remains a link.',
+      'Already code: `https://www.googleapis.com/auth/drive` and deep API paths such as https://backend.composio.dev/api/v3/tools/X remain links.',
+      '',
+      '```text',
+      'const scope = "https://www.googleapis.com/auth/drive";',
+      '```',
+    ].join('\n'));
+  });
+
   test('defines multi-source provenance in the KB frontmatter schema', () => {
     const sourceConfig = readFileSync(join(process.cwd(), 'source.config.ts'), 'utf8');
 


### PR DESCRIPTION
This PR:

- Closes #4205 (nightly docs external-link check failing)
- demotes bare identifier URLs — Google OAuth scope URIs (`googleapis.com/auth/*`) and version-only API roots like `https://api.ahrefs.com/v3` — to inline code spans in the KB generation layer (`markdownForMdx`), so they stop publishing as links that 404 by design
- regenerates the two affected guides (`toolkits-ahrefs`, `toolkits-googlemeet`); explicit markdown links keep their authored form
- adds a regression test covering the exact URLs from #4205 plus link/autolink/code-span edge cases
- records the rule in `docs/decisions/public-knowledge-base.md`
- makes the scheduled KB workflow rebuild `docs/kb/semantic-index.json` when it is stale against the checked-in corpus, not only when the upstream `support-knowledge` commit moves

## Context

The failing URLs are machine identifiers, not documents — fetching them 404s by design, so no link target could ever satisfy the nightly sweep. Upstream support prose cites them bare, the generator copied them verbatim, and GFM autolinks published them as clickable links. Sibling KB articles already used the backtick convention, confirming the intended presentation.

`check:kb-semantic` is expected to fail on this PR: 4 embedded record chunks change, and the artifact rebuild needs `OPENAI_API_KEY` (CI-owned). After merge, the scheduled job (now staleness-aware) proposes the artifact refresh PR on `docs/auto-update-kb`; until it merges, that gate stays red for docs PRs.

Verified locally: `bun run lint:links:external` (the failing nightly command) — 0 errors; `bun test tests/static/` — 506 pass; `lint:links`, `generate:kb --check`, `types:check`, `lint` — pass.