### PR TITLE
ci(docs): degrade KB refresh to artifact-only when upstream token fails

### DIFF
--- a/.github/workflows/docs-update-kb.yml
+++ b/.github/workflows/docs-update-kb.yml
@@ -24,8 +24,12 @@ jobs:
         working-directory: ./docs
 
     steps:
+      # If the app has no installation on support-knowledge, this fails
+      # with 404. Degrade to an upstream-sync skip instead of killing the
+      # whole job: the stale-artifact rebuild below needs only this repo.
       - name: Generate read-only upstream token
         id: upstream-token
+        continue-on-error: true
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
@@ -40,6 +44,7 @@ jobs:
           persist-credentials: false
 
       - name: Checkout support knowledge
+        if: steps.upstream-token.outcome == 'success'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ComposioHQ/support-knowledge
@@ -51,9 +56,16 @@ jobs:
         id: source
         env:
           SOURCE_ROOT: ${{ github.workspace }}/.support-knowledge
+          HAVE_UPSTREAM: ${{ steps.upstream-token.outcome == 'success' }}
         run: |
-          source_commit=$(git -C "$SOURCE_ROOT" rev-parse HEAD)
           current_commit=$(jq -r '.source.commit' kb/manifest.json)
+          echo "commit=$current_commit" >> "$GITHUB_OUTPUT"
+          if [ "$HAVE_UPSTREAM" != "true" ]; then
+            echo "upstream_changed=false" >> "$GITHUB_OUTPUT"
+            echo "No upstream token; skipping support-knowledge sync check and treating upstream as unchanged."
+            exit 0
+          fi
+          source_commit=$(git -C "$SOURCE_ROOT" rev-parse HEAD)
           echo "commit=$source_commit" >> "$GITHUB_OUTPUT"
           if [ "$source_commit" = "$current_commit" ]; then
             echo "upstream_changed=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
This PR:

- continues past a failed `support-knowledge` token mint instead of failing the whole KB refresh job
- skips the upstream checkout and sync check when no token could be minted (treats upstream as unchanged)
- unblocks the staleness-based semantic-artifact rebuild from #4249, which needs only this repository

## Context

Every scheduled run of `Docs - Update Support Knowledge` since at least Aug 25 dies at step 1: the release-bot app has no installation on the internal `ComposioHQ/support-knowledge` repo, so `create-github-app-token` 404s. The upstream import genuinely needs that token, but the artifact rebuild does not. Until a human installs the app on `support-knowledge`, upstream sync stays degraded and this keeps the artifact-refresh half of the job functional.