### PR TITLE
fix(py): isolate incompatible provider dependencies

### DIFF
--- a/.agents/skills/python-testing/references/nox-make.md
+++ b/.agents/skills/python-testing/references/nox-make.md
@@ -31,6 +31,7 @@ Current sessions include:
 - `fix`: Ruff automatic fixes.
 - `type_inference`: provider return-type inference checks.
 - `tst`: pytest test suite.
+- `tst_autogen`: Autogen regressions in an isolated protobuf-compatible environment.
 - `snt`: sanity tests.
 
 When adding or renaming provider packages, inspect the `type_inference` session's explicit provider install list and checked test-file list.

--- a/.github/workflows/py.test.yml
+++ b/.github/workflows/py.test.yml
@@ -88,7 +88,6 @@ jobs:
           uv pip install -e providers/crewai
           uv pip install -e providers/langchain
           uv pip install -e providers/langgraph
-          uv pip install -e providers/autogen
           uv pip install pytest pytest-mock
 
       - name: Run Import Tests
@@ -96,9 +95,16 @@ jobs:
           cd python/
           source .venv/bin/activate
           python -c "from composio import Composio; print('✓ Basic import successful')"
-          # Guards against the autogen provider becoming un-importable on a fresh
-          # install (e.g. a broken framework dependency). A hard import here fails
-          # loudly, unlike the importorskip-guarded unit tests, which would skip.
+
+      - name: Test Autogen Provider Installation
+        run: |
+          cd python/
+          # autogen-core requires protobuf 5, while CrewAI's telemetry stack
+          # requires protobuf 6. Test the independently distributed provider in
+          # its own environment instead of constructing an invalid combination.
+          uv venv autogen-env --python ${{ matrix.python-version }}
+          source autogen-env/bin/activate
+          uv pip install -e . -e providers/autogen
           python -c "import composio_autogen; print('✓ Autogen provider import successful')"
 
       - name: Run Unit Tests

--- a/.github/workflows/py.test.yml
+++ b/.github/workflows/py.test.yml
@@ -104,8 +104,12 @@ jobs:
           # its own environment instead of constructing an invalid combination.
           uv venv autogen-env --python ${{ matrix.python-version }}
           source autogen-env/bin/activate
-          uv pip install -e . -e providers/autogen
+          uv pip install -e . -e providers/autogen pytest pytest-mock
           python -c "import composio_autogen; print('✓ Autogen provider import successful')"
+          python -m pytest \
+            tests/test_provider.py::TestAgenticSkipDefaultsParity::test_autogen_signature_honors_skip_defaults \
+            tests/test_provider.py::TestAgenticSkipDefaultsParity::test_autogen_signature_preserves_default \
+            -v --tb=short
 
       - name: Run Unit Tests
         run: |

--- a/python/noxfile.py
+++ b/python/noxfile.py
@@ -112,6 +112,20 @@ def tst(session: Session):
 
 
 @nox.session
+def tst_autogen(session: Session):
+    """Run Autogen tests in its protobuf-compatible environment."""
+    session.install(".", "--group", "dev")
+    session.install("./providers/autogen")
+    session.run(
+        "pytest",
+        "tests/test_provider.py::TestAgenticSkipDefaultsParity::test_autogen_signature_honors_skip_defaults",
+        "tests/test_provider.py::TestAgenticSkipDefaultsParity::test_autogen_signature_preserves_default",
+        "-v",
+        "--tb=short",
+    )
+
+
+@nox.session
 def snt(session: Session):
     """Run fast sanity tests for imports and SDK initialization."""
     session.install(".", "--group", "dev")

--- a/python/noxfile.py
+++ b/python/noxfile.py
@@ -107,7 +107,6 @@ def tst(session: Session):
     session.install("./providers/crewai")
     session.install("./providers/langchain")
     session.install("./providers/langgraph")
-    session.install("./providers/autogen")
     test_paths = session.posargs or ["tests/"]
     session.run("pytest", *test_paths, "-v", "--tb=short")
 

--- a/python/tests/test_provider.py
+++ b/python/tests/test_provider.py
@@ -1327,8 +1327,10 @@ class TestAgenticSkipDefaultsParity:
     mismatch, but its signature likewise ignored skip_defaults; it is aligned
     too and checked on the signature alone.
 
-    Provider packages are optional (the unit-test job installs langchain and
-    autogen), so each case skips via importorskip when its provider is absent.
+    Provider packages are optional. The shared unit-test job installs langchain
+    and langgraph, while Autogen runs separately because their protobuf
+    requirements conflict. Each case skips via importorskip when its provider
+    is absent.
     """
 
     def _make_tool_with_default(self):


### PR DESCRIPTION
## Summary

- stop installing the independently distributed Autogen adapter into the shared CrewAI/LangChain/LangGraph unit-test environment
- run the Autogen import guard and signature regressions in their own matrix environment
- align the local `tst` nox session with the compatible shared provider set and add `tst_autogen` for isolated Autogen coverage

## Root cause

`autogen-core==0.7.5` requires `protobuf~=5.29.3`, while CrewAI's current telemetry dependency chain requires `googleapis-common-protos>=1.75.1`, whose generated modules require `protobuf>=6.33.5`.

The packages are independently distributed adapters and are not tested together, but the workflow installed both into one virtual environment. Because the installs were sequential, installing Autogen last downgraded `protobuf` to `5.29.6` and left the already-installed Google modules unusable:

```text
google.protobuf.runtime_version.VersionError: Detected incompatible Protobuf Gencode/Runtime versions when loading google/rpc/error_details.proto: gencode 6.33.5 runtime 5.29.6.
```

## Regression coverage

The shared suite intentionally skips Autogen because loading it alongside CrewAI creates the incompatible protobuf environment. CI now runs these existing regressions in the isolated Autogen environment instead:

- `test_autogen_signature_honors_skip_defaults`
- `test_autogen_signature_preserves_default`

Developers can reproduce that boundary with `nox -s tst_autogen`.

## Verification

- reproduced the downgrade after the Autogen provider installation
- shared provider environment imports `google.rpc.error_details_pb2` with `protobuf==6.33.6`
- isolated Autogen environment imports `composio_autogen` with `protobuf==5.29.6`
- isolated Autogen regressions: 2 passed
- Python unit suite: 1,355 passed, 35 skipped
- Ruff and mypy: passed
- agent-skill and skill-routing validators: passed
- Prettier and `git diff --check`: passed

No Changeset is required: this only changes CI and test-environment setup.