### PR TITLE
fix(docs): complete generated string escaping

### DIFF
--- a/docs/app/llms.mdx/[[...slug]]/route.ts
+++ b/docs/app/llms.mdx/[[...slug]]/route.ts
@@ -24,6 +24,7 @@ import { readFile } from 'fs/promises';
 import { join } from 'path';
 import { getAllToolkits, getToolkitBySlug } from '@/lib/toolkit-data';
 import { getAllMetaTools, getMetaToolBySlug } from '@/lib/meta-tools-data';
+import { encodeMarkdownTableCell } from '@/lib/markdown-escaping';
 import type { MetaTool, MetaToolParameter } from '@/lib/meta-tools-data';
 import type { Toolkit, Tool, Trigger, ParameterSchema } from '@/types/toolkit';
 import { apiToolListSchema, apiTriggerListSchema } from '@/lib/toolkit-schema';
@@ -819,7 +820,7 @@ function renderParamsMarkdown(params: Record<string, ParameterSchema>): string[]
   for (const [name, param] of Object.entries(params)) {
     const typeStr = formatParamType(param);
     const required = param.required ? 'Yes' : 'No';
-    const desc = (param.description || '').replace(/\|/g, '\\|').replace(/\n/g, ' ');
+    const desc = encodeMarkdownTableCell(param.description || '');
     lines.push(`| \`${name}\` | ${typeStr} | ${required} | ${desc} |`);
   }
 

--- a/docs/lib/markdown-escaping.ts
+++ b/docs/lib/markdown-escaping.ts
@@ -1,0 +1,7 @@
+export function encodeMarkdownTableCell(value: string): string {
+  return value.replace(/\r\n?|\n/g, ' ').replace(/\|/g, '&#124;');
+}
+
+export function encodeYamlString(value: string): string {
+  return JSON.stringify(value);
+}

--- a/docs/scripts/generate-meta-tools.ts
+++ b/docs/scripts/generate-meta-tools.ts
@@ -20,6 +20,7 @@ import { writeFile, mkdir, readdir, unlink } from 'fs/promises';
 import { join } from 'path';
 import { fetchWithRetry } from './fetch-with-retry';
 import { META_TOOL_OVERRIDES } from '../lib/meta-tool-overrides';
+import { encodeMarkdownTableCell, encodeYamlString } from '../lib/markdown-escaping';
 import { requireProductionApiV3Url, stripStagingHosts } from './production-api.mjs';
 import { z } from 'zod';
 
@@ -177,13 +178,13 @@ function indexLine(tool: GeneratedMetaTool): string {
   if (override) {
     // First sentence of the hand-written summary keeps the table tight.
     const firstSentence = override.summary.split(/\.(\s|$)/)[0].trim();
-    return firstSentence.replace(/\|/g, '\\|');
+    return encodeMarkdownTableCell(firstSentence);
   }
-  return briefDescription(tool.description).replace(/\|/g, '\\|');
+  return encodeMarkdownTableCell(briefDescription(tool.description));
 }
 
 /** Generate the index.mdx overview page — Modal-voice intro plus a one-line-per-tool table */
-function generateIndexMdx(tools: GeneratedMetaTool[]): string {
+export function generateIndexMdx(tools: GeneratedMetaTool[]): string {
   let content = `---
 title: Meta Tools
 description: The system tools every Composio session gives your agent to discover, authenticate, execute, and process tools at runtime.
@@ -218,12 +219,12 @@ These schemas are for reference only. We do not guarantee backward compatibility
 }
 
 /** Generate an individual tool MDX page */
-function generateToolMdx(tool: GeneratedMetaTool): string {
-  const desc = briefDescription(tool.description).replace(/"/g, '\\"');
+export function generateToolMdx(tool: GeneratedMetaTool): string {
+  const desc = encodeYamlString(briefDescription(tool.description));
 
   return `---
 title: ${tool.displayName}
-description: "${desc}"
+description: ${desc}
 keywords: [${tool.slug}, meta tool]
 ---
 

--- a/docs/tests/static/generate-toolkits.test.ts
+++ b/docs/tests/static/generate-toolkits.test.ts
@@ -23,7 +23,11 @@ import {
   transformAuthConfigDetail,
   transformToolkit,
 } from "../../scripts/generate-toolkits";
-import { transformTool } from "../../scripts/generate-meta-tools";
+import {
+  generateIndexMdx,
+  generateToolMdx,
+  transformTool,
+} from "../../scripts/generate-meta-tools";
 
 describe("transformToolkit", () => {
   test("excludes the synthetic test_app catalog residue from public docs", () => {
@@ -341,6 +345,26 @@ describe("transformTool (generate-meta-tools.ts)", () => {
     expect(tool.toolkit).toBeNull();
     expect(tool.inputParameters).toEqual({});
     expect(tool.responseSchema).toEqual({});
+  });
+
+  test("encodes table delimiters in generated index descriptions", () => {
+    const tool = transformTool({
+      slug: "COMPOSIO_X",
+      name: "composio_x",
+      description: String.raw`Compare \| and | values`,
+    });
+
+    expect(generateIndexMdx([tool])).toContain(String.raw`Compare \&#124; and &#124; values`);
+  });
+
+  test("serializes generated frontmatter descriptions as YAML strings", () => {
+    const tool = transformTool({
+      slug: "COMPOSIO_X",
+      name: "composio_x",
+      description: 'Use "quotes" at C:\\tools',
+    });
+
+    expect(generateToolMdx(tool)).toContain('description: "Use \\"quotes\\" at C:\\\\tools"');
   });
 });
 

--- a/docs/tests/static/markdown-escaping.test.ts
+++ b/docs/tests/static/markdown-escaping.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+
+import { encodeMarkdownTableCell, encodeYamlString } from "../../lib/markdown-escaping";
+
+describe("Markdown and frontmatter escaping", () => {
+  test("encodes every table delimiter without consuming existing backslashes", () => {
+    expect(encodeMarkdownTableCell(String.raw`first \| second | third`)).toBe(
+      String.raw`first \&#124; second &#124; third`
+    );
+  });
+
+  test("collapses every line ending inside table cells", () => {
+    expect(encodeMarkdownTableCell("first\r\nsecond\rthird\nfourth")).toBe(
+      "first second third fourth"
+    );
+  });
+
+  test("serializes quotes, backslashes, and control characters as a YAML string", () => {
+    expect(encodeYamlString('Use "quotes" at C:\\tools\nnext')).toBe(
+      '"Use \\"quotes\\" at C:\\\\tools\\nnext"'
+    );
+  });
+});

--- a/ts/packages/core/scripts/generate-docs.ts
+++ b/ts/packages/core/scripts/generate-docs.ts
@@ -1004,8 +1004,9 @@ function toKebabCase(str: string): string {
 
 // Escape text content for MDX (descriptions, etc. that appear outside backticks)
 // Handles both curly braces and angle brackets (which MDX interprets as JSX tags)
-function escapeTextForMdx(str: string): string {
+export function escapeTextForMdx(str: string): string {
   return str
+    .replace(/\\/g, '\\\\')
     .replace(/\{/g, '\\{')
     .replace(/\}/g, '\\}')
     .replace(/</g, '&lt;')

--- a/ts/packages/core/scripts/generate-docs.ts
+++ b/ts/packages/core/scripts/generate-docs.ts
@@ -1007,6 +1007,7 @@ function toKebabCase(str: string): string {
 export function escapeTextForMdx(str: string): string {
   return str
     .replace(/\\/g, '\\\\')
+    .replace(/\|/g, '\\|')
     .replace(/\{/g, '\\{')
     .replace(/\}/g, '\\}')
     .replace(/</g, '&lt;')

--- a/ts/packages/core/test/scripts/generate-docs.test.ts
+++ b/ts/packages/core/test/scripts/generate-docs.test.ts
@@ -38,9 +38,9 @@ describe('generate-docs type rendering', () => {
     expect(escapeTypeForMdx(String.raw`{ pattern: '\|' }`)).toBe(String.raw`\{ pattern: '\\\|' \}`);
   });
 
-  it('escapes existing backslashes before MDX text metacharacters', () => {
-    expect(escapeTextForMdx(String.raw`Use \{value\} or <literal>`)).toBe(
-      String.raw`Use \\\{value\\\} or &lt;literal&gt;`
+  it('escapes existing backslashes before MDX text and table metacharacters', () => {
+    expect(escapeTextForMdx(String.raw`Use \{value\}, \|, or <literal>`)).toBe(
+      String.raw`Use \\\{value\\\}, \\\|, or &lt;literal&gt;`
     );
   });
 

--- a/ts/packages/core/test/scripts/generate-docs.test.ts
+++ b/ts/packages/core/test/scripts/generate-docs.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  escapeTextForMdx,
   escapeTypeForMdx,
   parseSourceSignatureTypesAtLine,
   simplifyTypeForSignature,
@@ -35,6 +36,12 @@ describe('generate-docs type rendering', () => {
 
   it('escapes existing backslashes before adding MDX table escapes', () => {
     expect(escapeTypeForMdx(String.raw`{ pattern: '\|' }`)).toBe(String.raw`\{ pattern: '\\\|' \}`);
+  });
+
+  it('escapes existing backslashes before MDX text metacharacters', () => {
+    expect(escapeTextForMdx(String.raw`Use \{value\} or <literal>`)).toBe(
+      String.raw`Use \\\{value\\\} or &lt;literal&gt;`
+    );
   });
 
   it('reads named parameter and return types from source signatures', () => {


### PR DESCRIPTION
This PR:

- fixes CodeQL alerts [#48](https://github.com/ComposioHQ/composio/security/code-scanning/48), [#49](https://github.com/ComposioHQ/composio/security/code-scanning/49), [#50](https://github.com/ComposioHQ/composio/security/code-scanning/50), [#51](https://github.com/ComposioHQ/composio/security/code-scanning/51), [#88](https://github.com/ComposioHQ/composio/security/code-scanning/88), and [#89](https://github.com/ComposioHQ/composio/security/code-scanning/89)
- encodes Markdown table delimiters as HTML entities without consuming existing backslashes
- serializes generated YAML frontmatter strings with `JSON.stringify()`
- escapes existing backslashes before adding MDX metacharacter escapes in the core docs generator
- adds regression coverage for Markdown tables, YAML frontmatter, and MDX text
- verifies 38 focused docs tests, docs type-checking and lint, core type-checking, all 1,123 core tests, and changeset validation
