### PR TITLE
fix(ci): prevent cache poisoning in main CLI releases

### DIFF
--- a/.agents/skills/cli-release/references/release-workflow.md
+++ b/.agents/skills/cli-release/references/release-workflow.md
@@ -27,7 +27,7 @@
 | --------------------------- | -------------------------------------------------------------- | ----------------------------------------------------------------------- |
 | Ship an ordinary CLI change | Merge the reviewed PR to `next`                                | The push builds a rolling beta automatically.                           |
 | Build a beta from a branch  | Dispatch `build-beta` at that branch                           | A prerelease is built from the branch commit.                           |
-| Publish a stable CLI        | Promote an existing tested beta                                | The beta's source commit is rebuilt and published under the stable tag. |
+| Publish a stable CLI        | Dispatch promotion at an existing tested beta tag              | The beta's source commit is rebuilt and published under the stable tag. |
 | Resume a failed promotion   | Re-run or re-dispatch the same beta after inspecting the draft | An unpublished draft can be resumed and its assets replaced.            |
 
 The private CLI `package.json` uses a development sentinel and never selects a
@@ -136,14 +136,13 @@ gh release view "$STABLE_TAG" --repo "$REPOSITORY" --json tagName,isDraft,isPrer
 - If it is a draft, the promotion can resume it.
 - If it is already published, stop. Never overwrite a published release.
 
-Dispatch the current workflow from `next`; `promote-stable` resolves the source commit from the beta release itself:
+Dispatch the workflow at the beta tag. The selected ref supplies the immutable source commit, and the workflow verifies that it matches the beta release before rebuilding:
 
 ```bash
 gh workflow run build-cli-binaries.yml \
   --repo "$REPOSITORY" \
-  --ref next \
-  --raw-field action=promote-stable \
-  --raw-field beta_tag="$BETA_TAG"
+  --ref "$BETA_TAG" \
+  --raw-field action=promote-stable
 ```
 
 Use the returned URL when available. Otherwise identify the new dispatch, verify its creation time and actor, then watch it:
@@ -153,7 +152,7 @@ gh run list \
   --repo "$REPOSITORY" \
   --workflow build-cli-binaries.yml \
   --event workflow_dispatch \
-  --branch next \
+  --commit "$TARGET_COMMIT" \
   --limit 5
 
 gh run watch RUN_ID --repo "$REPOSITORY" --compact --exit-status

--- a/.github/scripts/cli-release/resolve-release-target.sh
+++ b/.github/scripts/cli-release/resolve-release-target.sh
@@ -5,9 +5,9 @@
 #
 #   - push to `next`                                      → rolling beta
 #   - workflow_dispatch build-beta [version]              → rolling or explicitly versioned beta
-#   - workflow_dispatch promote-stable <beta tag>         → stable promotion
+#   - workflow_dispatch promote-stable at <beta tag>      → stable promotion
 #
-# Inputs (env): EVENT_NAME, ACTION_INPUT, BETA_TAG_INPUT, VERSION_INPUT,
+# Inputs (env): EVENT_NAME, ACTION_INPUT, VERSION_INPUT, REF_NAME, REF_TYPE,
 #               GITHUB_TOKEN, REPOSITORY, RUN_NUMBER, COMMIT_SHA
 # Output: key=value lines appended to $GITHUB_OUTPUT
 set -euo pipefail
@@ -83,7 +83,6 @@ emit_beta_target() {
   fi
   release_tag="@composio/cli@${next_version}-beta.${RUN_NUMBER}"
   {
-    echo "checkout_ref=${COMMIT_SHA}"
     echo "release_name=CLI Beta ${release_tag}"
     echo "release_tag=${release_tag}"
     echo "release_version=${next_version}"
@@ -93,9 +92,8 @@ emit_beta_target() {
 }
 
 emit_stable_target() {
-  local release_tag=$1 release_version=$2 checkout_ref=$3
+  local release_tag=$1 release_version=$2
   {
-    echo "checkout_ref=${checkout_ref}"
     echo "release_name=CLI ${release_tag}"
     echo "release_tag=${release_tag}"
     echo "release_version=${release_version}"
@@ -123,12 +121,22 @@ if [[ "$ACTION_INPUT" != "promote-stable" ]]; then
   exit 1
 fi
 
-if [[ -z "$BETA_TAG_INPUT" ]]; then
-  echo "beta_tag input is required for promote-stable" >&2
+if [[ "${REF_TYPE:-}" != "tag" ]]; then
+  echo "promote-stable must be dispatched at the beta tag with --ref <beta-tag>" >&2
   exit 1
 fi
 
-encoded_beta_tag=$(python3 -c 'import os, urllib.parse; print(urllib.parse.quote(os.environ["BETA_TAG_INPUT"], safe=""))')
+beta_tag=${REF_NAME:-}
+
+if [[ ! "$beta_tag" =~ ^@composio/cli@([0-9]+\.[0-9]+\.[0-9]+)-beta\.[0-9]+$ ]]; then
+  echo "Selected ref must match @composio/cli@<version>-beta.<number>" >&2
+  exit 1
+fi
+
+stable_version="${BASH_REMATCH[1]}"
+stable_tag="@composio/cli@${stable_version}"
+
+encoded_beta_tag=$(python3 -c 'import os, urllib.parse; print(urllib.parse.quote(os.environ["REF_NAME"], safe=""))')
 
 release_json=$(curl -fsSL \
   -H "Authorization: Bearer ${GITHUB_TOKEN}" \
@@ -137,17 +145,9 @@ release_json=$(curl -fsSL \
 
 is_prerelease=$(jq -r '.prerelease' <<<"$release_json")
 if [[ "$is_prerelease" != "true" ]]; then
-  echo "Release ${BETA_TAG_INPUT} is not a beta prerelease" >&2
+  echo "Release ${beta_tag} is not a beta prerelease" >&2
   exit 1
 fi
-
-if [[ ! "$BETA_TAG_INPUT" =~ ^@composio/cli@([0-9]+\.[0-9]+\.[0-9]+)-beta\.[0-9]+$ ]]; then
-  echo "Beta tag must match @composio/cli@<version>-beta.<number>" >&2
-  exit 1
-fi
-
-stable_version="${BASH_REMATCH[1]}"
-stable_tag="@composio/cli@${stable_version}"
 
 # Refuse to re-promote an already-PUBLISHED stable release, but allow resuming an
 # existing DRAFT (a prior promote run that built assets but did not publish). The
@@ -164,8 +164,13 @@ fi
 
 target_commitish=$(jq -r '.target_commitish' <<<"$release_json")
 if [[ -z "$target_commitish" || "$target_commitish" == "null" ]]; then
-  echo "Beta release ${BETA_TAG_INPUT} does not expose target_commitish" >&2
+  echo "Beta release ${beta_tag} does not expose target_commitish" >&2
   exit 1
 fi
 
-emit_stable_target "$stable_tag" "$stable_version" "$target_commitish"
+if [[ "$target_commitish" != "$COMMIT_SHA" ]]; then
+  echo "Selected beta tag resolves to ${COMMIT_SHA}, but its release targets ${target_commitish}" >&2
+  exit 1
+fi
+
+emit_stable_target "$stable_tag" "$stable_version"

--- a/.github/workflows/build-cli-binaries.yml
+++ b/.github/workflows/build-cli-binaries.yml
@@ -16,15 +16,12 @@ on:
   workflow_dispatch:
     inputs:
       action:
-        description: 'What to do'
+        description: 'What to do (select the beta tag as the workflow ref for promote-stable)'
         type: choice
         options:
           - build-beta
           - promote-stable
         default: build-beta
-      beta_tag:
-        description: 'Existing beta release tag to promote (only for promote-stable, e.g. @composio/cli@0.2.20-beta.42)'
-        required: false
       version:
         description: 'Optional semver base for a manual beta (e.g. 0.3.0); omit for the next patch after latest stable'
         required: false
@@ -44,7 +41,6 @@ jobs:
     name: Resolve Release Metadata
     runs-on: ubuntu-latest
     outputs:
-      checkout_ref: ${{ steps.resolve.outputs.checkout_ref }}
       release_name: ${{ steps.resolve.outputs.release_name }}
       release_tag: ${{ steps.resolve.outputs.release_tag }}
       release_version: ${{ steps.resolve.outputs.release_version }}
@@ -62,8 +58,9 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           ACTION_INPUT: ${{ inputs.action }}
-          BETA_TAG_INPUT: ${{ inputs.beta_tag }}
           VERSION_INPUT: ${{ inputs.version }}
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}
           RUN_NUMBER: ${{ github.run_number }}
@@ -124,7 +121,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.prepare.outputs.checkout_ref }}
+          ref: ${{ github.sha }}
 
       - name: Setup Node.js, pnpm, Bun
         uses: ./.github/actions/setup-node-pnpm-bun
@@ -241,14 +238,14 @@ jobs:
       RELEASE_NAME: ${{ needs.prepare.outputs.release_name }}
       PRERELEASE: ${{ needs.prepare.outputs.prerelease }}
       MAKE_LATEST: ${{ needs.prepare.outputs.make_latest }}
-      CHECKOUT_REF: ${{ needs.prepare.outputs.checkout_ref }}
+      CHECKOUT_REF: ${{ github.sha }}
       RELEASE_HELPERS_DIR: ${{ github.workspace }}/.release-workflow/.github/scripts/cli-release
 
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.prepare.outputs.checkout_ref }}
+          ref: ${{ github.sha }}
 
       - name: Setup Node.js, pnpm, Bun
         uses: ./.github/actions/setup-node-pnpm-bun

--- a/test/release-workflow.test.ts
+++ b/test/release-workflow.test.ts
@@ -664,6 +664,15 @@ if (!buildCliWorkflow.includes('group: cli-release-${{ needs.prepare.outputs.rel
 if (!buildCliWorkflow.includes('bash .github/scripts/cli-release/resolve-release-target.sh')) {
   throw new Error('build-cli-binaries.yml prepare job must delegate to resolve-release-target.sh');
 }
+if (buildCliWorkflow.includes('needs.prepare.outputs.checkout_ref')) {
+  throw new Error('CLI release jobs must not execute a ref derived from workflow inputs');
+}
+if ((buildCliWorkflow.match(/ref: \$\{\{ github\.sha \}\}/g) ?? []).length < 2) {
+  throw new Error('CLI build and release jobs must check out the selected workflow commit');
+}
+if (buildCliWorkflow.includes('beta_tag:')) {
+  throw new Error('stable promotion must select the beta through the immutable workflow ref');
+}
 
 // Release archives contain a composio-<target>/ bundle with runtime support files next to the
 // executable. Both the checked-in guide and the workflow-generated guide must preserve that
@@ -1247,17 +1256,37 @@ function runResolver({ env, releasesFixture, curlFixture, ghViewIsDraft }) {
   }
 }
 
+// promote-stable must run at a beta tag, never accept a release candidate through an input.
+{
+  const r = runResolver({
+    env: {
+      EVENT_NAME: 'workflow_dispatch',
+      ACTION_INPUT: 'promote-stable',
+      REF_TYPE: 'branch',
+      REF_NAME: 'next',
+      GITHUB_TOKEN: 'fake-token',
+      REPOSITORY: 'ComposioHQ/composio',
+      RUN_NUMBER: '1',
+      COMMIT_SHA: 'abc123',
+    },
+  });
+  if (r.status === 0 || !r.stderr.includes('must be dispatched at the beta tag')) {
+    throw new Error('promote-stable must reject branch-scoped dispatches');
+  }
+}
+
 // promote-stable must REFUSE a tag that is already published (isDraft=false) and emit nothing.
 {
   const r = runResolver({
     env: {
       EVENT_NAME: 'workflow_dispatch',
       ACTION_INPUT: 'promote-stable',
-      BETA_TAG_INPUT: '@composio/cli@0.3.0-beta.5',
+      REF_TYPE: 'tag',
+      REF_NAME: '@composio/cli@0.3.0-beta.5',
       GITHUB_TOKEN: 'fake-token',
       REPOSITORY: 'ComposioHQ/composio',
       RUN_NUMBER: '1',
-      COMMIT_SHA: 'unused',
+      COMMIT_SHA: 'abc123',
     },
     curlFixture: { prerelease: true, target_commitish: 'abc123' },
     ghViewIsDraft: 'false',
@@ -1273,17 +1302,18 @@ function runResolver({ env, releasesFixture, curlFixture, ghViewIsDraft }) {
   }
 }
 
-// promote-stable happy path: no existing release ⇒ emit a stable target off the beta's commitish.
+// promote-stable happy path: the selected beta tag and release target the same commit.
 {
   const r = runResolver({
     env: {
       EVENT_NAME: 'workflow_dispatch',
       ACTION_INPUT: 'promote-stable',
-      BETA_TAG_INPUT: '@composio/cli@0.3.0-beta.5',
+      REF_TYPE: 'tag',
+      REF_NAME: '@composio/cli@0.3.0-beta.5',
       GITHUB_TOKEN: 'fake-token',
       REPOSITORY: 'ComposioHQ/composio',
       RUN_NUMBER: '1',
-      COMMIT_SHA: 'unused',
+      COMMIT_SHA: 'abc123',
     },
     curlFixture: { prerelease: true, target_commitish: 'abc123' },
     // ghViewIsDraft unset ⇒ `gh release view` exits non-zero ⇒ no existing release to refuse.
@@ -1297,10 +1327,28 @@ function runResolver({ env, releasesFixture, curlFixture, ghViewIsDraft }) {
   if (r.outputs.prerelease !== 'false' || r.outputs.make_latest !== 'true') {
     throw new Error('promote-stable must emit prerelease=false and make_latest=true');
   }
-  if (r.outputs.checkout_ref !== 'abc123') {
-    throw new Error(
-      `promote-stable must check out the beta's target_commitish, got ${r.outputs.checkout_ref}`
-    );
+  if ('checkout_ref' in r.outputs) {
+    throw new Error('promote-stable must not emit an input-derived checkout ref');
+  }
+}
+
+// A tag/release mismatch must fail before any build can run from the selected commit.
+{
+  const r = runResolver({
+    env: {
+      EVENT_NAME: 'workflow_dispatch',
+      ACTION_INPUT: 'promote-stable',
+      REF_TYPE: 'tag',
+      REF_NAME: '@composio/cli@0.3.0-beta.5',
+      GITHUB_TOKEN: 'fake-token',
+      REPOSITORY: 'ComposioHQ/composio',
+      RUN_NUMBER: '1',
+      COMMIT_SHA: 'selected123',
+    },
+    curlFixture: { prerelease: true, target_commitish: 'release456' },
+  });
+  if (r.status === 0 || !r.stderr.includes('but its release targets')) {
+    throw new Error('promote-stable must reject a beta tag/release commit mismatch');
   }
 }
 


### PR DESCRIPTION
This PR:

- forward-ports https://github.com/ComposioHQ/composio/pull/4255 to the `main` release line
- makes the workflow-selected `github.sha` authoritative for CLI build and release checkouts
- requires stable promotion to run at the immutable beta tag and rejects tag/release commit mismatches
- removes the manually supplied `beta_tag` data path into executable jobs
- preserves the source patch from #4255 without stacking it onto the SDK 1.0 beta PR
- verifies the contract with `pnpm test:release-workflow`, agent-skill validation, Changesets validation, and shell syntax checks