### PR TITLE
[rescue #4257] fix(strict): keep optional parameters and honor strict mode

### DIFF
--- a/.changeset/mastra-strict-keep-optional-parameters.md
+++ b/.changeset/mastra-strict-keep-optional-parameters.md
@@ -1,0 +1,5 @@
+---
+'@composio/mastra': patch
+---
+
+`MastraProvider({ strict: true })` now keeps optional parameters instead of dropping them: every property becomes required and optional ones accept `null`, matching the OpenAI providers, and a `null` argument the tool's own schema does not accept is dropped before execution. Tools whose schema strict mode cannot express keep their original schema with a warning.

--- a/.changeset/openai-agents-honor-strict.md
+++ b/.changeset/openai-agents-honor-strict.md
@@ -1,0 +1,5 @@
+---
+'@composio/openai-agents': patch
+---
+
+`OpenAIAgentsProvider({ strict: true })` now takes effect: tools are registered with `strict: true` and a schema normalized for OpenAI structured outputs (every property required, optional ones accept `null`), a `null` argument the tool's own schema does not accept is dropped before execution, and tools whose schema strict mode cannot express are registered without strict mode with a warning. The option was previously ignored.

--- a/.changeset/strict-schema-normalization.md
+++ b/.changeset/strict-schema-normalization.md
@@ -1,0 +1,7 @@
+---
+'@composio/core': minor
+'@composio/openai': patch
+'@composio/vercel': patch
+---
+
+Fix strict-mode tool schemas for OpenAI structured outputs. Strict normalization now applies OpenAI's contract at every depth (nested objects, `anyOf` branches, array items, inlined `$ref`/`$defs`): every object lists all of its properties in `required` and sets `additionalProperties: false`, so tools with nested or optional parameters no longer produce schemas the API rejects with a 400. Optional parameters are no longer dropped: they stay available and are widened to accept `null`, the emulation of optional fields OpenAI documents, and the strict providers drop a `null` argument the tool's own schema does not accept before executing the tool. Tools whose schema strict mode cannot express (objects with arbitrary keys, `allOf`, `prefixItems`, unresolved `$ref`s) are sent without strict mode with a warning naming the tool and path, instead of being narrowed. `@composio/core` exports the new `toStrictJsonSchema()` and `omitNullToolArguments()` utilities; `removeNonRequiredProperties` is unchanged for other callers. The Python `OpenAIResponsesProvider` gains a matching opt-in `strict=True` constructor flag that also emits `strict: true` on the wrapped tool.

--- a/docs/content/docs/providers/mastra.mdx
+++ b/docs/content/docs/providers/mastra.mdx
@@ -62,7 +62,7 @@ console.log(text);
 
 ## Provider specifics
 
-**Strict mode.** Pass `strict: true` to drop every non-required property from each tool's input schema before Mastra compiles it:
+**Strict mode.** Pass `strict: true` to normalize each tool's input schema for OpenAI structured outputs before Mastra compiles it: every object lists all of its properties in `required` and is closed, and optional properties stay available but accept `null`. A `null` the model sends is dropped before the tool runs unless the tool's own schema accepts `null` for that parameter, so genuinely nullable fields still receive an explicit `null`. Tools whose schema cannot be expressed in strict mode (such as objects that accept arbitrary keys, `allOf`, `prefixItems`, or unresolved `$ref`s) keep their original schema and log a warning:
 
 ```typescript
 // @noErrors

--- a/docs/content/docs/providers/openai.mdx
+++ b/docs/content/docs/providers/openai.mdx
@@ -406,6 +406,29 @@ The OpenAI integration ships three providers, one per API surface:
 - **`OpenAIProvider`** for the Chat Completions API. This is the SDK default, so `new Composio()` with no provider uses it. You keep the full message list and append each assistant message plus its `tool` results yourself.
 - **`OpenAIAgentsProvider`** for the Agents SDK. Tools come with execution wired in, so the SDK runs the loop for you.
 
+**Strict mode.** Pass `strict: true` / `strict=True` to `OpenAIResponsesProvider`, or `strict: true` to the TypeScript `OpenAIAgentsProvider`, to normalize each tool's input schema for OpenAI structured outputs. Every object lists all properties in `required` and is closed; optional properties stay available by accepting `null`. A model-supplied `null` is dropped before execution only when the tool's own schema does not accept `null`, so genuinely nullable fields keep an explicit `null`. Schemas strict mode cannot express, such as free-form objects, `allOf`, `prefixItems`, or unresolved `$ref`s, are sent without strict mode and log a warning.
+
+<Tabs groupId="language" items={["Python", "TypeScript"]} persist>
+<Tab value="Python">
+```python
+from composio import Composio
+from composio_openai import OpenAIResponsesProvider
+
+composio = Composio(provider=OpenAIResponsesProvider(strict=True))
+```
+</Tab>
+<Tab value="TypeScript">
+```typescript
+import { Composio } from '@composio/core';
+import { OpenAIResponsesProvider } from '@composio/openai';
+
+const composio = new Composio({
+  provider: new OpenAIResponsesProvider({ strict: true }),
+});
+```
+</Tab>
+</Tabs>
+
 <Callout type="info">
 Pass the session to `handleToolCalls` / `handle_tool_calls` when the model received tools from `session.tools()`. The helper preserves the provider's argument normalization and executes every call through that session. For tools fetched via [`tools.get`](/docs/tools-direct/executing-tools), pass the user ID instead.
 </Callout>

--- a/docs/content/docs/providers/vercel.mdx
+++ b/docs/content/docs/providers/vercel.mdx
@@ -57,7 +57,7 @@ console.log(text);
 
 ## Provider specifics
 
-**Strict mode.** Some models reject tool schemas that contain optional parameters. Pass `strict: true` to the provider to drop every non-required property from each tool's input schema before it reaches the AI SDK:
+**Strict mode.** Some models reject tool schemas that contain optional parameters. Pass `strict: true` to the provider to normalize each tool's input schema for OpenAI structured outputs before it reaches the AI SDK: every object lists all of its properties in `required` and is closed, and optional properties stay available but accept `null`. A `null` the model sends is dropped before the tool runs unless the tool's own schema accepts `null` for that parameter, so genuinely nullable fields still receive an explicit `null`. Tools whose schema cannot be expressed in strict mode (such as objects that accept arbitrary keys, `allOf`, `prefixItems`, or unresolved `$ref`s) keep their original schema and log a warning:
 
 ```typescript
 // @noErrors

--- a/python/composio/core/provider/_openai_responses.py
+++ b/python/composio/core/provider/_openai_responses.py
@@ -10,12 +10,25 @@ from openai.types.responses.response import Response
 from openai.types.responses.response_output_item import ResponseFunctionToolCall
 
 from composio.core.provider import NonAgenticProvider, ToolCallSession
+from composio.core.provider.base import BaseProviderConfig
 from composio.types import Modifiers, Tool, ToolExecutionResponse
+from composio.utils.logging import get as get_logger
 from composio.utils.shared import normalize_tool_arguments
+from composio.utils.strict_schema import omit_null_tool_arguments, to_strict_json_schema
+
+logger = get_logger(__name__)
 
 # Responses API uses a flattened tool structure
-ResponsesTool = t.Dict[str, t.Any]
-ResponsesToolCollection = t.List[ResponsesTool]
+ResponsesTool = dict[str, t.Any]
+ResponsesToolCollection = list[ResponsesTool]
+
+# Parameters emitted for a tool without input parameters under strict mode.
+_EMPTY_OBJECT_SCHEMA: dict[str, t.Any] = {
+    "type": "object",
+    "properties": {},
+    "required": [],
+    "additionalProperties": False,
+}
 
 
 class OpenAIResponsesProvider(
@@ -23,14 +36,77 @@ class OpenAIResponsesProvider(
 ):
     """OpenAI Responses API Provider class definition."""
 
+    def __init__(
+        self, strict: bool = False, **kwargs: t.Unpack[BaseProviderConfig]
+    ) -> None:
+        """
+        :param strict: Emit wrapped tools with ``strict: true`` and normalize
+            their parameter schemas for OpenAI structured outputs (every object
+            fully required and closed, optional properties widened to accept
+            ``null``; local ``$ref``/``$defs`` preserved and normalized). Mirrors
+            the TypeScript ``OpenAIResponsesProvider({ strict })`` option.
+            Defaults to ``False``.
+        """
+        super().__init__(**kwargs)
+        self.strict = strict
+        # Source parameter schemas of tools successfully wrapped under strict
+        # mode, keyed by slug, so tool-call arguments can be reconciled against
+        # the schema the model actually saw.
+        self._strict_input_schemas: dict[str, dict[str, t.Any]] = {}
+
     def wrap_tool(self, tool: Tool) -> ResponsesTool:
         """Wrap a tool for the Responses API format."""
-        return {
+        parameters: t.Any = (
+            tool.input_parameters if tool.input_parameters is not None else {}
+        )
+        wrapped: ResponsesTool = {
             "type": "function",
             "name": tool.slug,
             "description": tool.description,
-            "parameters": tool.input_parameters,
+            "parameters": parameters,
+            "strict": self.strict,
         }
+        if not self.strict:
+            return wrapped
+
+        # Structured outputs enforce their contract at every depth: all
+        # properties required, closed objects, no annotation keywords. The
+        # strict rewrite keeps every parameter (optional ones become nullable)
+        # and reports constructs it cannot express; such a tool is sent
+        # without strict mode rather than with a narrower schema.
+        source = (
+            parameters
+            if tool.input_parameters is not None
+            else dict(_EMPTY_OBJECT_SCHEMA)
+        )
+        strict = to_strict_json_schema(source)
+        if strict.unsupported:
+            reasons = "; ".join(
+                f"{entry.path or '<root>'}: {entry.keyword} ({entry.detail})"
+                for entry in strict.unsupported
+            )
+            logger.warning(
+                'OpenAIResponsesProvider: tool "%s" is sent without strict mode '
+                "because its schema cannot be expressed as strict structured "
+                "outputs: %s",
+                tool.slug,
+                reasons,
+            )
+            self._strict_input_schemas.pop(tool.slug, None)
+            wrapped["parameters"] = source
+            wrapped["strict"] = False
+            return wrapped
+        if strict.total_changes:
+            logger.debug(
+                'OpenAIResponsesProvider: strict mode rewrote %d node(s) of tool "%s": %s',
+                strict.total_changes,
+                tool.slug,
+                "; ".join(f"{c.path}: {c.reason}" for c in strict.changes),
+            )
+        self._strict_input_schemas[tool.slug] = strict.source
+        wrapped["parameters"] = strict.schema
+        wrapped["strict"] = True
+        return wrapped
 
     def wrap_tools(self, tools: t.Sequence[Tool]) -> ResponsesToolCollection:
         """Wrap multiple tools for the Responses API format."""
@@ -40,8 +116,8 @@ class OpenAIResponsesProvider(
     def execute_tool_call(
         self,
         user_id: str,
-        tool_call: t.Union[ResponseFunctionToolCall],
-        modifiers: t.Optional[Modifiers] = None,
+        tool_call: ResponseFunctionToolCall,
+        modifiers: Modifiers | None = None,
     ) -> ToolExecutionResponse: ...
 
     @t.overload
@@ -54,11 +130,11 @@ class OpenAIResponsesProvider(
 
     def execute_tool_call(
         self,
-        user_id: t.Optional[str] = None,
-        tool_call: t.Optional[ResponseFunctionToolCall] = None,
-        modifiers: t.Optional[Modifiers] = None,
+        user_id: str | None = None,
+        tool_call: ResponseFunctionToolCall | None = None,
+        modifiers: Modifiers | None = None,
         *,
-        session: t.Optional[ToolCallSession] = None,
+        session: ToolCallSession | None = None,
     ) -> ToolExecutionResponse:
         """Execute a tool call from the Responses API.
 
@@ -78,6 +154,12 @@ class OpenAIResponsesProvider(
         # tolerates empty / object-shaped payloads too (issue #2406).
         slug = tool_call.name
         arguments = normalize_tool_arguments(tool_call.arguments)
+        strict_schema = self._strict_input_schemas.get(slug)
+        if strict_schema is not None:
+            # Under strict mode optional parameters are emitted as
+            # required-nullable, so a ``null`` the tool's own schema does not
+            # accept means "omitted".
+            arguments = omit_null_tool_arguments(arguments, strict_schema)
 
         return self.execute_tool_for_target(
             target=target,
@@ -91,8 +173,8 @@ class OpenAIResponsesProvider(
         self,
         user_id: str,
         response: Response,
-        modifiers: t.Optional[Modifiers] = None,
-    ) -> t.List[ToolExecutionResponse]: ...
+        modifiers: Modifiers | None = None,
+    ) -> list[ToolExecutionResponse]: ...
 
     @t.overload
     def handle_tool_calls(
@@ -100,16 +182,16 @@ class OpenAIResponsesProvider(
         *,
         session: ToolCallSession,
         response: Response,
-    ) -> t.List[ToolExecutionResponse]: ...
+    ) -> list[ToolExecutionResponse]: ...
 
     def handle_tool_calls(
         self,
-        user_id: t.Optional[str] = None,
-        response: t.Optional[Response] = None,
-        modifiers: t.Optional[Modifiers] = None,
+        user_id: str | None = None,
+        response: Response | None = None,
+        modifiers: Modifiers | None = None,
         *,
-        session: t.Optional[ToolCallSession] = None,
-    ) -> t.List[ToolExecutionResponse]:
+        session: ToolCallSession | None = None,
+    ) -> list[ToolExecutionResponse]:
         """
         Handle tool calls from OpenAI Responses API.
 

--- a/python/composio/utils/strict_schema.py
+++ b/python/composio/utils/strict_schema.py
@@ -1,0 +1,452 @@
+"""Normalize JSON Schemas for OpenAI structured outputs (``strict`` mode).
+
+Python counterpart of the TypeScript SDK's ``toStrictJsonSchema``
+(``ts/packages/core/src/utils/jsonSchema.ts``). OpenAI's structured-output
+contract requires *every* object node — not just the root — to list all of its
+properties in ``required``, set ``additionalProperties: False`` and avoid
+annotation-only keywords. Optional fields are emulated the way OpenAI
+documents: the property stays, becomes required, and is widened to accept
+``null`` (``"type": ["string", "null"]`` or an extra ``anyOf`` branch). Nothing
+is dropped, so the model keeps every parameter it could pass before; the strict
+provider drops a ``null`` the tool's own schema does not accept before
+executing the tool (see :func:`omit_null_tool_arguments`).
+
+Local ``$ref`` pointers into ``$defs``/``definitions`` are kept (the API
+supports them, including recursion) and the definitions themselves are
+normalized; an optional ``$ref`` property is widened with an ``anyOf`` null
+branch. Constructs strict mode cannot express — objects that accept arbitrary
+keys (schema-valued or ``True`` ``additionalProperties``, ``patternProperties``,
+property-less free-form objects), ``allOf``, ``prefixItems``, external or
+dangling ``$ref`` pointers and a non-object root — are reported in
+``unsupported`` instead of being rewritten into something narrower; the
+provider sends such a tool without strict mode.
+
+The input is never mutated, every rewrite is recorded (capped at 50 entries;
+``total_changes`` carries the real count) and ``required`` arrays are
+de-duplicated at the end.
+"""
+
+from __future__ import annotations
+
+import typing as t
+
+from composio.utils.json_schema import MAX_REF_CHAIN_DEPTH, _try_resolve_pointer
+
+MAX_NODE_DEPTH = 512
+MAX_CHANGES = 50
+
+# Annotation-only keywords OpenAI structured outputs rejects; safe to strip.
+STRICT_STRIP_KEYWORDS = frozenset({"examples", "default"})
+
+# Keywords whose values are literal data, not schemas - never recursed as schemas.
+INSTANCE_VALUE_KEYWORDS = frozenset({"const", "default", "enum", "examples"})
+
+SCHEMA_KEYWORDS = frozenset(
+    {
+        "additionalItems",
+        "additionalProperties",
+        "contains",
+        "contentSchema",
+        "else",
+        "if",
+        "not",
+        "propertyNames",
+        "then",
+        "unevaluatedItems",
+        "unevaluatedProperties",
+    }
+)
+SCHEMA_ARRAY_KEYWORDS = frozenset({"allOf", "anyOf", "oneOf", "prefixItems"})
+SCHEMA_MAP_KEYWORDS = frozenset(
+    {"$defs", "definitions", "dependentSchemas", "patternProperties", "properties"}
+)
+
+# Keywords OpenAI structured outputs reject and that have no lossless rewrite.
+STRICT_UNSUPPORTED_KEYWORDS = (
+    "allOf",
+    "prefixItems",
+    "additionalItems",
+    "contains",
+    "dependencies",
+    "dependentSchemas",
+    "else",
+    "if",
+    "not",
+    "propertyNames",
+    "then",
+    "unevaluatedItems",
+    "unevaluatedProperties",
+)
+
+
+def _is_object_type(node_type: t.Any) -> bool:
+    """Whether a ``type`` value declares exactly the object type."""
+    return node_type == "object" or (
+        isinstance(node_type, list) and node_type == ["object"]
+    )
+
+
+StrictSchemaChangeReason = t.Literal[
+    "optional-property-nullable",
+    "unsupported-keyword-stripped",
+    "one-of-converted",
+]
+
+
+class StrictSchemaChange(t.NamedTuple):
+    """A single lossless rewrite applied by :func:`to_strict_json_schema`."""
+
+    path: str
+    reason: StrictSchemaChangeReason
+    detail: str = ""
+
+
+class StrictSchemaIncompatibility(t.NamedTuple):
+    """A construct strict structured outputs cannot express."""
+
+    path: str
+    keyword: str
+    detail: str
+
+
+class StrictJsonSchemaResult(t.NamedTuple):
+    """Result of :func:`to_strict_json_schema`."""
+
+    schema: dict[str, t.Any]
+    """The strict schema; only usable when ``unsupported`` is empty."""
+    source: dict[str, t.Any]
+    """The input schema optionality was decided against."""
+    changes: list[StrictSchemaChange]
+    total_changes: int
+    unsupported: list[StrictSchemaIncompatibility]
+
+
+def _join_path(parent: str, key: str) -> str:
+    return f"{parent}.{key}" if parent else key
+
+
+def _widen_to_nullable(node: dict[str, t.Any]) -> dict[str, t.Any]:
+    """Accept ``null`` without placing ``type`` beside ``anyOf``."""
+    any_of = node.get("anyOf")
+    if isinstance(any_of, list):
+        if any(isinstance(b, dict) and b.get("type") == "null" for b in any_of):
+            return node
+        return {**node, "anyOf": [*any_of, {"type": "null"}]}
+    node_type = node.get("type")
+    if isinstance(node_type, str):
+        return node if node_type == "null" else {**node, "type": [node_type, "null"]}
+    if isinstance(node_type, list):
+        return node if "null" in node_type else {**node, "type": [*node_type, "null"]}
+    if (isinstance(node.get("enum"), list) and None in node["enum"]) or (
+        "const" in node and node["const"] is None
+    ):
+        return node
+    annotations: dict[str, t.Any] = {
+        k: node[k] for k in ("description", "title") if k in node
+    }
+    rest = {k: v for k, v in node.items() if k not in annotations}
+    if not rest:
+        return node
+    return {**annotations, "anyOf": [rest, {"type": "null"}]}
+
+
+def _resolve_local_refs(node: t.Any, root: dict[str, t.Any]) -> t.Any:
+    """Follow local ``$ref`` pointers until a concrete node is reached."""
+    current = node
+    for _ in range(MAX_REF_CHAIN_DEPTH):
+        if not isinstance(current, dict) or not isinstance(current.get("$ref"), str):
+            return current
+        resolution = _try_resolve_pointer(root, current["$ref"])
+        if not resolution.ok:
+            return current
+        current = resolution.value
+    return current
+
+
+def _schema_accepts_null(schema: t.Any, root: dict[str, t.Any]) -> bool:
+    """Whether a schema node accepts ``null`` as an instance."""
+    node = _resolve_local_refs(schema, root)
+    if not isinstance(node, dict):
+        return True
+    node_type = node.get("type")
+    if isinstance(node_type, str):
+        return node_type == "null"
+    if isinstance(node_type, list):
+        return "null" in node_type
+    if isinstance(node.get("enum"), list):
+        return None in node["enum"]
+    if "const" in node:
+        return node["const"] is None
+    for keyword in ("anyOf", "oneOf"):
+        branches = node.get(keyword)
+        if isinstance(branches, list):
+            return any(_schema_accepts_null(b, root) for b in branches)
+    return True
+
+
+def _dedupe_required(value: t.Any, is_schema: bool = True, depth: int = 0) -> t.Any:
+    if depth > MAX_NODE_DEPTH:
+        raise ValueError(
+            f"JSON Schema exceeds maximum nesting depth of {MAX_NODE_DEPTH}"
+        )
+    if isinstance(value, list):
+        return [_dedupe_required(item, is_schema, depth + 1) for item in value]
+    if not isinstance(value, dict):
+        return value
+    clone: dict[str, t.Any] = {}
+    for key, child in value.items():
+        if is_schema and key == "required" and isinstance(child, list):
+            clone[key] = list(dict.fromkeys(child))
+        else:
+            clone[key] = _dedupe_required(
+                child, is_schema and key not in INSTANCE_VALUE_KEYWORDS, depth + 1
+            )
+    return clone
+
+
+class _Walker:
+    def __init__(self, root: dict[str, t.Any]) -> None:
+        self.root = root
+        self.changes: list[StrictSchemaChange] = []
+        self.total_changes = 0
+        self.unsupported: list[StrictSchemaIncompatibility] = []
+
+    def record(self, path: str, reason: StrictSchemaChangeReason, detail: str) -> None:
+        self.total_changes += 1
+        if len(self.changes) < MAX_CHANGES:
+            self.changes.append(StrictSchemaChange(path, reason, detail))
+
+    def reject(self, path: str, keyword: str, detail: str) -> None:
+        self.unsupported.append(StrictSchemaIncompatibility(path, keyword, detail))
+
+    def walk_children(
+        self, node: dict[str, t.Any], mode: str, depth: int, path: str
+    ) -> dict[str, t.Any]:
+        clone: dict[str, t.Any] = {}
+        for key, child in node.items():
+            child_mode = "value"
+            if mode == "schema-map":
+                child_mode = "schema"
+            elif mode == "schema" and key not in INSTANCE_VALUE_KEYWORDS:
+                if key in SCHEMA_MAP_KEYWORDS:
+                    child_mode = "schema-map"
+                elif key in SCHEMA_ARRAY_KEYWORDS or (
+                    key == "items" and isinstance(child, list)
+                ):
+                    child_mode = "schema-array"
+                elif key in SCHEMA_KEYWORDS or key == "items":
+                    child_mode = "schema"
+
+            if child_mode == "schema-map" and isinstance(child, dict):
+                clone[key] = {
+                    name: self.walk(
+                        sub_schema,
+                        "schema",
+                        depth + 1,
+                        _join_path(_join_path(path, key), name),
+                    )
+                    for name, sub_schema in child.items()
+                }
+                continue
+            clone[key] = self.walk(child, child_mode, depth + 1, _join_path(path, key))
+        return clone
+
+    def walk(self, value: t.Any, mode: str, depth: int, path: str) -> t.Any:
+        if depth > MAX_NODE_DEPTH:
+            raise ValueError(
+                f"JSON Schema exceeds maximum nesting depth of {MAX_NODE_DEPTH}"
+            )
+        if isinstance(value, list):
+            item_mode = "schema" if mode == "schema-array" else "value"
+            return [
+                self.walk(item, item_mode, depth + 1, f"{path}[{index}]")
+                for index, item in enumerate(value)
+            ]
+        if not isinstance(value, dict) or mode == "value":
+            return value
+
+        node: dict[str, t.Any] = {}
+        for key, child in value.items():
+            if key in STRICT_STRIP_KEYWORDS:
+                self.record(
+                    path, "unsupported-keyword-stripped", f'keyword "{key}" removed'
+                )
+                continue
+            node[key] = child
+        if isinstance(node.get("oneOf"), list) and "anyOf" not in node:
+            node["anyOf"] = node.pop("oneOf")
+            self.record(path, "one-of-converted", "oneOf became anyOf")
+        for keyword in STRICT_UNSUPPORTED_KEYWORDS:
+            if keyword in node:
+                self.reject(path, keyword, f'"{keyword}" has no strict-mode equivalent')
+        if "oneOf" in node:
+            self.reject(path, "oneOf", "oneOf beside anyOf cannot be merged")
+        if isinstance(node.get("items"), list):
+            self.reject(path, "items", "tuple-form items has no strict-mode equivalent")
+        elif isinstance(node.get("items"), bool):
+            self.reject(path, "items", "boolean subschema")
+        if "properties" in node and not isinstance(node["properties"], dict):
+            self.reject(path, "properties", "properties is not an object")
+
+        out = self.walk_children(node, mode, depth, path)
+
+        ref = node.get("$ref")
+        if isinstance(ref, str):
+            resolved = ref.startswith("#/") and _try_resolve_pointer(self.root, ref).ok
+            if not resolved:
+                self.reject(path, "$ref", f'unresolved $ref "{ref}"')
+            # The referenced definition is normalized where it is declared.
+            return out
+
+        node_type = out.get("type")
+        declares_object = node_type == "object" or (
+            isinstance(node_type, list) and "object" in node_type
+        )
+        if not declares_object and not isinstance(out.get("properties"), dict):
+            return out
+        if "properties" in out and not isinstance(out["properties"], dict):
+            return out
+
+        properties: dict[str, t.Any] = dict(out.get("properties") or {})
+        required = out.get("required")
+        declared_required = {
+            entry
+            for entry in (required if isinstance(required, list) else [])
+            if isinstance(entry, str)
+        }
+        for name, property_schema in properties.items():
+            if isinstance(property_schema, bool):
+                self.reject(
+                    _join_path(path, f"properties.{name}"),
+                    "properties",
+                    "boolean subschema",
+                )
+                continue
+            if name in declared_required or not isinstance(property_schema, dict):
+                continue
+            properties[name] = _widen_to_nullable(property_schema)
+            self.record(
+                _join_path(path, f"properties.{name}"),
+                "optional-property-nullable",
+                f'property "{name}" is now required and accepts null',
+            )
+
+        additional = out.get("additionalProperties")
+        accepts_dynamic_keys = additional is True or isinstance(additional, dict)
+        if accepts_dynamic_keys:
+            self.reject(path, "additionalProperties", "object accepts arbitrary keys")
+        elif "patternProperties" in out:
+            self.reject(
+                path, "patternProperties", "object accepts pattern-matched keys"
+            )
+        elif not properties and "additionalProperties" not in out:
+            self.reject(path, "properties", "free-form object accepts arbitrary keys")
+
+        result = {**out}
+        if "type" not in result:
+            result["type"] = "object"
+        result["properties"] = properties
+        result["required"] = list(properties.keys())
+        if not accepts_dynamic_keys:
+            result["additionalProperties"] = False
+        return result
+
+
+def to_strict_json_schema(schema: t.Any) -> StrictJsonSchemaResult:
+    """Normalize a tool parameter schema for OpenAI structured outputs.
+
+    Applies the strict contract at every depth: every object lists all of its
+    properties in ``required`` and is closed; optional properties are widened
+    to accept ``null`` instead of being dropped; ``oneOf`` becomes ``anyOf``;
+    ``default`` and ``examples`` are stripped; internal ``$ref`` pointers are
+    inlined first and ``required`` arrays are de-duplicated last. Constructs
+    strict mode cannot express are listed in ``unsupported``; when that list
+    is non-empty the returned ``schema`` must not be sent as strict.
+
+    :param schema: The JSON schema to normalize; never mutated.
+    :return: A :class:`StrictJsonSchemaResult`.
+    """
+    root: dict[str, t.Any] = schema if isinstance(schema, dict) else {}
+    walker = _Walker(root)
+    normalized = _dedupe_required(walker.walk(root, "schema", 0, ""))
+    if not isinstance(normalized, dict) or not _is_object_type(normalized.get("type")):
+        walker.reject("", "type", "root must be a non-nullable object")
+    return StrictJsonSchemaResult(
+        schema=normalized,
+        source=root,
+        changes=walker.changes,
+        total_changes=walker.total_changes,
+        unsupported=walker.unsupported,
+    )
+
+
+def omit_null_tool_arguments(
+    arguments: dict[str, t.Any], schema: t.Any
+) -> dict[str, t.Any]:
+    """Drop ``None``-valued arguments the tool's own schema does not accept.
+
+    Strict structured outputs cannot express optional parameters, so
+    :func:`to_strict_json_schema` makes every parameter required and nullable.
+    The model then sends ``null`` for a parameter it would otherwise have
+    omitted; forwarding it to the tool would fail validation against the
+    tool's real schema, so it is treated as "omitted". A ``null`` the original
+    schema accepts is kept. ``schema`` is the tool schema the strict rewrite
+    was computed from (``StrictJsonSchemaResult.source``). The input is not
+    mutated.
+    """
+    root: dict[str, t.Any] = schema if isinstance(schema, dict) else {}
+    return t.cast(dict[str, t.Any], _omit_nulls(arguments, root, root, 0))
+
+
+def _select_branch_for(
+    schema: t.Any, value: t.Any, root: dict[str, t.Any]
+) -> dict[str, t.Any] | None:
+    """Pick the composition branch that describes a value's shape."""
+    resolved = _resolve_local_refs(schema, root)
+    if not isinstance(resolved, dict):
+        return None
+    wanted = "items" if isinstance(value, list) else "properties"
+
+    def find(node: t.Any, depth: int) -> dict[str, t.Any] | None:
+        candidate = _resolve_local_refs(node, root)
+        if not isinstance(candidate, dict) or depth > MAX_NODE_DEPTH:
+            return None
+        if wanted in candidate:
+            return candidate
+        for keyword in ("anyOf", "oneOf"):
+            branches = candidate.get(keyword)
+            if not isinstance(branches, list):
+                continue
+            for branch in branches:
+                found = find(branch, depth + 1)
+                if found is not None:
+                    return found
+        return None
+
+    return find(resolved, 0) or resolved
+
+
+def _omit_nulls(
+    value: t.Any, schema: t.Any, root: dict[str, t.Any], depth: int
+) -> t.Any:
+    if depth > MAX_NODE_DEPTH:
+        raise ValueError(
+            f"Tool arguments exceed maximum nesting depth of {MAX_NODE_DEPTH}"
+        )
+    node = _select_branch_for(schema, value, root) or {}
+    if isinstance(value, list):
+        items = node.get("items") if isinstance(node.get("items"), dict) else None
+        return [_omit_nulls(item, items, root, depth + 1) for item in value]
+    if not isinstance(value, dict):
+        return value
+    declared = node.get("properties")
+    properties: dict[str, t.Any] = declared if isinstance(declared, dict) else {}
+    clone: dict[str, t.Any] = {}
+    for key, child in value.items():
+        property_schema = properties.get(key)
+        if child is None:
+            if property_schema is None or _schema_accepts_null(property_schema, root):
+                clone[key] = child
+            continue
+        clone[key] = _omit_nulls(child, property_schema, root, depth + 1)
+    return clone

--- a/python/tests/fixtures/json-schema-conversion/strict-cases.json
+++ b/python/tests/fixtures/json-schema-conversion/strict-cases.json
@@ -1,0 +1,2947 @@
+{
+  "cases": [
+    {
+      "id": "flat-all-required-unchanged",
+      "description": "An already-strict schema is returned unchanged with no changes.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string"
+          }
+        },
+        "required": ["query"],
+        "additionalProperties": false
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string"
+            }
+          },
+          "required": ["query"],
+          "additionalProperties": false
+        }
+      }
+    },
+    {
+      "id": "nested-optional-property-widened",
+      "description": "Optional properties stay, become required and accept null at every depth.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "cfg": {
+            "type": "object",
+            "properties": {
+              "url": {
+                "type": "string"
+              },
+              "note": {
+                "type": "string",
+                "description": "optional note"
+              }
+            },
+            "required": ["url"]
+          }
+        },
+        "required": ["cfg"]
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "cfg": {
+              "type": "object",
+              "properties": {
+                "url": {
+                  "type": "string"
+                },
+                "note": {
+                  "type": ["string", "null"],
+                  "description": "optional note"
+                }
+              },
+              "required": ["url", "note"],
+              "additionalProperties": false
+            }
+          },
+          "required": ["cfg"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.cfg.properties.note",
+          "reason": "optional-property-nullable"
+        }
+      ],
+      "arguments": [
+        {
+          "input": {
+            "cfg": {
+              "url": "u",
+              "note": null
+            }
+          },
+          "output": {
+            "cfg": {
+              "url": "u"
+            }
+          }
+        },
+        {
+          "input": {
+            "cfg": null
+          },
+          "output": {}
+        },
+        {
+          "input": {
+            "cfg": {
+              "url": "u",
+              "extra": null
+            }
+          },
+          "output": {
+            "cfg": {
+              "url": "u",
+              "extra": null
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "no-required-array-widens-every-property",
+      "description": "An object without `required` requires and widens every property.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "a": {
+            "type": "string"
+          },
+          "b": {
+            "type": "number"
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "a": {
+              "type": ["string", "null"]
+            },
+            "b": {
+              "type": ["number", "null"]
+            }
+          },
+          "required": ["a", "b"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.a",
+          "reason": "optional-property-nullable"
+        },
+        {
+          "path": "properties.b",
+          "reason": "optional-property-nullable"
+        }
+      ],
+      "arguments": [
+        {
+          "input": {
+            "a": null,
+            "b": 1,
+            "unknown": null
+          },
+          "output": {
+            "b": 1,
+            "unknown": null
+          }
+        }
+      ]
+    },
+    {
+      "id": "required-empty-array-widens-every-property",
+      "description": "An empty `required` array is the same as an absent one.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "a": {
+            "type": "string"
+          }
+        },
+        "required": []
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "a": {
+              "type": ["string", "null"]
+            }
+          },
+          "required": ["a"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.a",
+          "reason": "optional-property-nullable"
+        }
+      ]
+    },
+    {
+      "id": "nullable-type-array-kept",
+      "description": "A `type` array with null is accepted by the API and left alone.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": ["string", "null"],
+            "description": "identifier"
+          }
+        },
+        "required": ["id"]
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": ["string", "null"],
+              "description": "identifier"
+            }
+          },
+          "required": ["id"],
+          "additionalProperties": false
+        }
+      },
+      "arguments": [
+        {
+          "input": {
+            "id": null
+          },
+          "output": {
+            "id": null
+          }
+        }
+      ]
+    },
+    {
+      "id": "nullable-object-stays-nullable",
+      "description": "A nullable object keeps its type array; only its own properties are closed.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "cfg": {
+            "type": ["object", "null"],
+            "properties": {
+              "a": {
+                "type": "string"
+              }
+            },
+            "required": ["a"]
+          }
+        },
+        "required": ["cfg"]
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "cfg": {
+              "type": ["object", "null"],
+              "properties": {
+                "a": {
+                  "type": "string"
+                }
+              },
+              "required": ["a"],
+              "additionalProperties": false
+            }
+          },
+          "required": ["cfg"],
+          "additionalProperties": false
+        }
+      },
+      "arguments": [
+        {
+          "input": {
+            "cfg": null
+          },
+          "output": {
+            "cfg": null
+          }
+        },
+        {
+          "input": {
+            "cfg": {
+              "a": "x"
+            }
+          },
+          "output": {
+            "cfg": {
+              "a": "x"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "nullable-array-kept",
+      "description": "A nullable array keeps its type array and items.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "xs": {
+            "type": ["array", "null"],
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": ["xs"]
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "xs": {
+              "type": ["array", "null"],
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "required": ["xs"],
+          "additionalProperties": false
+        }
+      },
+      "arguments": [
+        {
+          "input": {
+            "xs": null
+          },
+          "output": {
+            "xs": null
+          }
+        },
+        {
+          "input": {
+            "xs": [null]
+          },
+          "output": {
+            "xs": [null]
+          }
+        }
+      ]
+    },
+    {
+      "id": "optional-any-of-gets-null-branch",
+      "description": "An optional composition gains a null branch instead of a sibling type.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": ["value"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.value",
+          "reason": "optional-property-nullable"
+        }
+      ]
+    },
+    {
+      "id": "any-of-already-nullable-unchanged",
+      "description": "A composition that already accepts null is not widened twice.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": ["value"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.value",
+          "reason": "optional-property-nullable"
+        }
+      ],
+      "arguments": [
+        {
+          "input": {
+            "value": null
+          },
+          "output": {
+            "value": null
+          }
+        }
+      ]
+    },
+    {
+      "id": "optional-enum-only-wrapped",
+      "description": "An enum-only property is wrapped so the annotation stays outside the anyOf.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "choice": {
+            "enum": ["a", "b"],
+            "description": "pick one",
+            "title": "Choice"
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "choice": {
+              "description": "pick one",
+              "title": "Choice",
+              "anyOf": [
+                {
+                  "enum": ["a", "b"]
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": ["choice"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.choice",
+          "reason": "optional-property-nullable"
+        }
+      ],
+      "arguments": [
+        {
+          "input": {
+            "choice": null
+          },
+          "output": {}
+        }
+      ]
+    },
+    {
+      "id": "optional-const-wrapped",
+      "description": "A const-only property is wrapped in an anyOf with a null branch.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "const": "fixed"
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "anyOf": [
+                {
+                  "const": "fixed"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": ["kind"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.kind",
+          "reason": "optional-property-nullable"
+        }
+      ]
+    },
+    {
+      "id": "optional-empty-schema-unchanged",
+      "description": "An empty schema already accepts null and is left alone.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "anything": {}
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "anything": {}
+          },
+          "required": ["anything"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.anything",
+          "reason": "optional-property-nullable"
+        }
+      ]
+    },
+    {
+      "id": "multi-type-array-gains-null",
+      "description": "A multi-type array gains null instead of being converted to anyOf.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": ["string", "number"]
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "type": ["string", "number", "null"]
+            }
+          },
+          "required": ["value"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.value",
+          "reason": "optional-property-nullable"
+        }
+      ]
+    },
+    {
+      "id": "one-of-converted-to-any-of",
+      "description": "oneOf is unsupported and becomes anyOf.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "either": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
+          }
+        },
+        "required": ["either"]
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "either": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                }
+              ]
+            }
+          },
+          "required": ["either"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.either",
+          "reason": "one-of-converted"
+        }
+      ]
+    },
+    {
+      "id": "array-items-object-normalized",
+      "description": "Objects inside array items are closed and widened.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "rows": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "tag": {
+                  "type": "string"
+                }
+              },
+              "required": ["id"]
+            }
+          }
+        },
+        "required": ["rows"]
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "rows": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "tag": {
+                    "type": ["string", "null"]
+                  }
+                },
+                "required": ["id", "tag"],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": ["rows"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.rows.items.properties.tag",
+          "reason": "optional-property-nullable"
+        }
+      ],
+      "arguments": [
+        {
+          "input": {
+            "rows": [
+              {
+                "id": "1",
+                "tag": null
+              },
+              null
+            ]
+          },
+          "output": {
+            "rows": [
+              {
+                "id": "1"
+              },
+              null
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "default-and-examples-stripped",
+      "description": "Annotation keywords the API rejects are stripped and reported.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "examples": ["a"],
+            "default": "x"
+          }
+        },
+        "required": ["name"]
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": ["name"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.name",
+          "reason": "unsupported-keyword-stripped"
+        },
+        {
+          "path": "properties.name",
+          "reason": "unsupported-keyword-stripped"
+        }
+      ]
+    },
+    {
+      "id": "enum-values-are-data-not-keywords",
+      "description": "Keys inside enum/const values are data and must not be treated as keywords.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "opts": {
+            "enum": [
+              {
+                "default": 1,
+                "properties": {}
+              },
+              null
+            ]
+          }
+        },
+        "required": ["opts"]
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "opts": {
+              "enum": [
+                {
+                  "default": 1,
+                  "properties": {}
+                },
+                null
+              ]
+            }
+          },
+          "required": ["opts"],
+          "additionalProperties": false
+        }
+      },
+      "arguments": [
+        {
+          "input": {
+            "opts": null
+          },
+          "output": {
+            "opts": null
+          }
+        }
+      ]
+    },
+    {
+      "id": "property-names-are-not-keywords",
+      "description": "Properties named like keywords are ordinary properties.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "default": {
+            "type": "string"
+          },
+          "$ref": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "x": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "default": {
+              "type": ["string", "null"]
+            },
+            "$ref": {
+              "type": ["string", "null"]
+            },
+            "type": {
+              "type": ["string", "null"]
+            },
+            "properties": {
+              "type": ["object", "null"],
+              "properties": {
+                "x": {
+                  "type": ["string", "null"]
+                }
+              },
+              "required": ["x"],
+              "additionalProperties": false
+            }
+          },
+          "required": ["default", "$ref", "type", "properties"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.properties.properties.x",
+          "reason": "optional-property-nullable"
+        },
+        {
+          "path": "properties.default",
+          "reason": "optional-property-nullable"
+        },
+        {
+          "path": "properties.$ref",
+          "reason": "optional-property-nullable"
+        },
+        {
+          "path": "properties.type",
+          "reason": "optional-property-nullable"
+        },
+        {
+          "path": "properties.properties",
+          "reason": "optional-property-nullable"
+        }
+      ],
+      "arguments": [
+        {
+          "input": {
+            "default": null,
+            "$ref": "x",
+            "type": null,
+            "properties": {
+              "x": null
+            }
+          },
+          "output": {
+            "$ref": "x",
+            "properties": {}
+          }
+        }
+      ]
+    },
+    {
+      "id": "prototype-key-property-name",
+      "description": "A property named __proto__ or constructor is handled as a plain name.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "__proto__": {
+            "type": "string"
+          },
+          "constructor": {
+            "type": "number"
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "__proto__": {
+              "type": ["string", "null"]
+            },
+            "constructor": {
+              "type": ["number", "null"]
+            }
+          },
+          "required": ["__proto__", "constructor"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.__proto__",
+          "reason": "optional-property-nullable"
+        },
+        {
+          "path": "properties.constructor",
+          "reason": "optional-property-nullable"
+        }
+      ]
+    },
+    {
+      "id": "schema-valued-additional-properties-unsupported",
+      "description": "A map-style object cannot be expressed and is reported, not closed.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "headers": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        },
+        "required": ["headers"]
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "properties.headers",
+            "keyword": "additionalProperties"
+          }
+        ]
+      }
+    },
+    {
+      "id": "additional-properties-true-unsupported",
+      "description": "An explicitly open object is reported.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "open": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "required": ["open"]
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "properties.open",
+            "keyword": "additionalProperties"
+          }
+        ]
+      }
+    },
+    {
+      "id": "additional-properties-empty-schema-unsupported",
+      "description": "An empty-schema additionalProperties accepts anything and is reported.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "open": {
+            "type": "object",
+            "additionalProperties": {}
+          }
+        },
+        "required": ["open"]
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "properties.open",
+            "keyword": "additionalProperties"
+          }
+        ]
+      }
+    },
+    {
+      "id": "free-form-object-unsupported",
+      "description": "A property-less object accepts arbitrary keys and is reported.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "type": "object",
+            "description": "any json"
+          }
+        },
+        "required": ["meta"]
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "properties.meta",
+            "keyword": "properties"
+          }
+        ]
+      }
+    },
+    {
+      "id": "pattern-properties-unsupported",
+      "description": "patternProperties cannot be expressed and is reported.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "tagged": {
+            "type": "object",
+            "patternProperties": {
+              "^x-": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "required": ["tagged"]
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "properties.tagged",
+            "keyword": "patternProperties"
+          }
+        ]
+      }
+    },
+    {
+      "id": "empty-closed-object-representable",
+      "description": "An object closed with no properties is representable.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "empty": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "required": ["empty"]
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "empty": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {},
+              "required": []
+            }
+          },
+          "required": ["empty"],
+          "additionalProperties": false
+        }
+      }
+    },
+    {
+      "id": "all-of-unsupported",
+      "description": "allOf has no lossless rewrite and is reported.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "all": {
+            "allOf": [
+              {
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "required": ["all"]
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "properties.all",
+            "keyword": "allOf"
+          }
+        ]
+      }
+    },
+    {
+      "id": "prefix-items-unsupported",
+      "description": "prefixItems has no lossless rewrite and is reported.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "pair": {
+            "type": "array",
+            "prefixItems": [
+              {
+                "type": "number"
+              }
+            ]
+          }
+        },
+        "required": ["pair"]
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "properties.pair",
+            "keyword": "prefixItems"
+          }
+        ]
+      }
+    },
+    {
+      "id": "defs-ref-kept-and-definition-normalized",
+      "description": "Local $refs are kept and the definition is normalized where it is declared.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "cfg": {
+            "$ref": "#/$defs/Config"
+          }
+        },
+        "required": ["cfg"],
+        "$defs": {
+          "Config": {
+            "type": "object",
+            "properties": {
+              "url": {
+                "type": "string"
+              },
+              "note": {
+                "type": "string"
+              }
+            },
+            "required": ["url"]
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "cfg": {
+              "$ref": "#/$defs/Config"
+            }
+          },
+          "required": ["cfg"],
+          "$defs": {
+            "Config": {
+              "type": "object",
+              "properties": {
+                "url": {
+                  "type": "string"
+                },
+                "note": {
+                  "type": ["string", "null"]
+                }
+              },
+              "required": ["url", "note"],
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "$defs.Config.properties.note",
+          "reason": "optional-property-nullable"
+        }
+      ],
+      "arguments": [
+        {
+          "input": {
+            "cfg": {
+              "url": "u",
+              "note": null
+            }
+          },
+          "output": {
+            "cfg": {
+              "url": "u"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "optional-ref-widened-with-null-branch",
+      "description": "An optional $ref property is widened with an anyOf null branch.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "cfg": {
+            "$ref": "#/$defs/Config",
+            "description": "optional"
+          }
+        },
+        "$defs": {
+          "Config": {
+            "type": "object",
+            "properties": {
+              "url": {
+                "type": "string"
+              }
+            },
+            "required": ["url"]
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "cfg": {
+              "description": "optional",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Config"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "$defs": {
+            "Config": {
+              "type": "object",
+              "properties": {
+                "url": {
+                  "type": "string"
+                }
+              },
+              "required": ["url"],
+              "additionalProperties": false
+            }
+          },
+          "required": ["cfg"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.cfg",
+          "reason": "optional-property-nullable"
+        }
+      ],
+      "arguments": [
+        {
+          "input": {
+            "cfg": null
+          },
+          "output": {}
+        }
+      ]
+    },
+    {
+      "id": "recursive-defs-kept",
+      "description": "Self-recursive definitions are representable.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "node": {
+            "$ref": "#/$defs/Node"
+          }
+        },
+        "required": ["node"],
+        "$defs": {
+          "Node": {
+            "type": "object",
+            "properties": {
+              "child": {
+                "$ref": "#/$defs/Node"
+              },
+              "label": {
+                "type": "string"
+              }
+            },
+            "required": ["label"]
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "node": {
+              "$ref": "#/$defs/Node"
+            }
+          },
+          "required": ["node"],
+          "$defs": {
+            "Node": {
+              "type": "object",
+              "properties": {
+                "child": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/$defs/Node"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "label": {
+                  "type": "string"
+                }
+              },
+              "required": ["child", "label"],
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "$defs.Node.properties.child",
+          "reason": "optional-property-nullable"
+        }
+      ],
+      "arguments": [
+        {
+          "input": {
+            "node": {
+              "label": "a",
+              "child": {
+                "label": "b",
+                "child": null
+              }
+            }
+          },
+          "output": {
+            "node": {
+              "label": "a",
+              "child": {
+                "label": "b"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "mutually-recursive-defs-kept",
+      "description": "Mutually recursive definitions are representable.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "a": {
+            "$ref": "#/$defs/A"
+          }
+        },
+        "required": ["a"],
+        "$defs": {
+          "A": {
+            "type": "object",
+            "properties": {
+              "b": {
+                "$ref": "#/$defs/B"
+              }
+            }
+          },
+          "B": {
+            "type": "object",
+            "properties": {
+              "a": {
+                "$ref": "#/$defs/A"
+              }
+            }
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "a": {
+              "$ref": "#/$defs/A"
+            }
+          },
+          "required": ["a"],
+          "$defs": {
+            "A": {
+              "type": "object",
+              "properties": {
+                "b": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/$defs/B"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": ["b"],
+              "additionalProperties": false
+            },
+            "B": {
+              "type": "object",
+              "properties": {
+                "a": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/$defs/A"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": ["a"],
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "$defs.A.properties.b",
+          "reason": "optional-property-nullable"
+        },
+        {
+          "path": "$defs.B.properties.a",
+          "reason": "optional-property-nullable"
+        }
+      ]
+    },
+    {
+      "id": "legacy-definitions-ref-kept",
+      "description": "Legacy definitions are supported like $defs.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "cfg": {
+            "$ref": "#/definitions/Config"
+          }
+        },
+        "required": ["cfg"],
+        "definitions": {
+          "Config": {
+            "type": "object",
+            "properties": {
+              "url": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "cfg": {
+              "$ref": "#/definitions/Config"
+            }
+          },
+          "required": ["cfg"],
+          "definitions": {
+            "Config": {
+              "type": "object",
+              "properties": {
+                "url": {
+                  "type": ["string", "null"]
+                }
+              },
+              "required": ["url"],
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "definitions.Config.properties.url",
+          "reason": "optional-property-nullable"
+        }
+      ]
+    },
+    {
+      "id": "ref-into-properties-kept",
+      "description": "A local $ref outside $defs resolves and is kept.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "a": {
+            "type": "object",
+            "properties": {
+              "x": {
+                "type": "string"
+              }
+            },
+            "required": ["x"]
+          },
+          "b": {
+            "$ref": "#/properties/a"
+          }
+        },
+        "required": ["a", "b"]
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "a": {
+              "type": "object",
+              "properties": {
+                "x": {
+                  "type": "string"
+                }
+              },
+              "required": ["x"],
+              "additionalProperties": false
+            },
+            "b": {
+              "$ref": "#/properties/a"
+            }
+          },
+          "required": ["a", "b"],
+          "additionalProperties": false
+        }
+      }
+    },
+    {
+      "id": "dangling-ref-unsupported",
+      "description": "A $ref without a target is reported at its own path.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "cfg": {
+            "$ref": "#/$defs/Nope"
+          }
+        },
+        "required": ["cfg"]
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "properties.cfg",
+            "keyword": "$ref"
+          }
+        ]
+      }
+    },
+    {
+      "id": "external-ref-unsupported",
+      "description": "A $ref outside the document is reported.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "cfg": {
+            "$ref": "https://example.com/schema.json"
+          }
+        },
+        "required": ["cfg"]
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "properties.cfg",
+            "keyword": "$ref"
+          }
+        ]
+      }
+    },
+    {
+      "id": "duplicate-required-deduped",
+      "description": "Duplicate required entries are removed.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "a": {
+            "type": "string"
+          }
+        },
+        "required": ["a", "a"]
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "a": {
+              "type": "string"
+            }
+          },
+          "required": ["a"],
+          "additionalProperties": false
+        }
+      }
+    },
+    {
+      "id": "required-unknown-names-dropped",
+      "description": "Required names without a property are dropped from required.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "a": {
+            "type": "string"
+          }
+        },
+        "required": ["a", "ghost"]
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "a": {
+              "type": "string"
+            }
+          },
+          "required": ["a"],
+          "additionalProperties": false
+        }
+      }
+    },
+    {
+      "id": "required-not-an-array-ignored",
+      "description": "A malformed required is treated as absent.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "a": {
+            "type": "string"
+          }
+        },
+        "required": "a"
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "a": {
+              "type": ["string", "null"]
+            }
+          },
+          "required": ["a"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.a",
+          "reason": "optional-property-nullable"
+        }
+      ]
+    },
+    {
+      "id": "description-kept-on-widened-node",
+      "description": "Annotations survive widening.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "a": {
+            "type": "integer",
+            "description": "count",
+            "title": "Count",
+            "minimum": 0
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "a": {
+              "type": ["integer", "null"],
+              "description": "count",
+              "title": "Count",
+              "minimum": 0
+            }
+          },
+          "required": ["a"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.a",
+          "reason": "optional-property-nullable"
+        }
+      ]
+    },
+    {
+      "id": "non-object-root-unsupported",
+      "description": "The root must be an object.",
+      "schema": {
+        "type": "string"
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "",
+            "keyword": "type"
+          }
+        ]
+      }
+    },
+    {
+      "id": "nullable-root-unsupported",
+      "description": "The root must not be nullable.",
+      "schema": {
+        "type": ["object", "null"],
+        "properties": {
+          "a": {
+            "type": "string"
+          }
+        }
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "",
+            "keyword": "type"
+          }
+        ]
+      },
+      "changes": [
+        {
+          "path": "properties.a",
+          "reason": "optional-property-nullable"
+        }
+      ]
+    },
+    {
+      "id": "properties-without-type-become-object",
+      "description": "A node with properties but no type is treated as an object.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "cfg": {
+            "properties": {
+              "a": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "required": ["cfg"]
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "cfg": {
+              "properties": {
+                "a": {
+                  "type": ["string", "null"]
+                }
+              },
+              "type": "object",
+              "required": ["a"],
+              "additionalProperties": false
+            }
+          },
+          "required": ["cfg"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.cfg.properties.a",
+          "reason": "optional-property-nullable"
+        }
+      ]
+    },
+    {
+      "id": "root-without-type-become-object",
+      "description": "A root with properties but no type is treated as an object.",
+      "schema": {
+        "properties": {
+          "a": {
+            "type": "string"
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "properties": {
+            "a": {
+              "type": ["string", "null"]
+            }
+          },
+          "type": "object",
+          "required": ["a"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.a",
+          "reason": "optional-property-nullable"
+        }
+      ]
+    },
+    {
+      "id": "root-single-element-type-array-accepted",
+      "description": "A root typed [\"object\"] is an object root.",
+      "schema": {
+        "type": ["object"],
+        "properties": {
+          "a": {
+            "type": "string"
+          }
+        },
+        "required": ["a"]
+      },
+      "strict": {
+        "schema": {
+          "type": ["object"],
+          "properties": {
+            "a": {
+              "type": "string"
+            }
+          },
+          "required": ["a"],
+          "additionalProperties": false
+        }
+      }
+    },
+    {
+      "id": "three-member-type-array-gains-null",
+      "description": "A three-member type array gains null once.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "v": {
+            "type": ["string", "number", "boolean"]
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "v": {
+              "type": ["string", "number", "boolean", "null"]
+            }
+          },
+          "required": ["v"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.v",
+          "reason": "optional-property-nullable"
+        }
+      ]
+    },
+    {
+      "id": "optional-null-only-property-unchanged",
+      "description": "A property typed null already accepts null.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "nothing": {
+            "type": "null"
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "nothing": {
+              "type": "null"
+            }
+          },
+          "required": ["nothing"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.nothing",
+          "reason": "optional-property-nullable"
+        }
+      ],
+      "arguments": [
+        {
+          "input": {
+            "nothing": null
+          },
+          "output": {
+            "nothing": null
+          }
+        }
+      ]
+    },
+    {
+      "id": "optional-enum-with-null-not-rewrapped",
+      "description": "An enum that already lists null is not wrapped again.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "choice": {
+            "enum": ["a", null]
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "choice": {
+              "enum": ["a", null]
+            }
+          },
+          "required": ["choice"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.choice",
+          "reason": "optional-property-nullable"
+        }
+      ],
+      "arguments": [
+        {
+          "input": {
+            "choice": null
+          },
+          "output": {
+            "choice": null
+          }
+        }
+      ]
+    },
+    {
+      "id": "optional-const-null-not-rewrapped",
+      "description": "A const null already accepts null.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "nothing": {
+            "const": null
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "nothing": {
+              "const": null
+            }
+          },
+          "required": ["nothing"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.nothing",
+          "reason": "optional-property-nullable"
+        }
+      ],
+      "arguments": [
+        {
+          "input": {
+            "nothing": null
+          },
+          "output": {
+            "nothing": null
+          }
+        }
+      ]
+    },
+    {
+      "id": "nested-any-of-branch-widened",
+      "description": "Optional properties inside anyOf branches are widened.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "v": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "a": {
+                    "type": "string"
+                  }
+                }
+              },
+              {
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "required": ["v"]
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "v": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "a": {
+                      "type": ["string", "null"]
+                    }
+                  },
+                  "required": ["a"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "required": ["v"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.v.anyOf[0].properties.a",
+          "reason": "optional-property-nullable"
+        }
+      ],
+      "arguments": [
+        {
+          "input": {
+            "v": {
+              "a": null
+            }
+          },
+          "output": {
+            "v": {}
+          }
+        },
+        {
+          "input": {
+            "v": null
+          },
+          "output": {}
+        }
+      ]
+    },
+    {
+      "id": "array-of-nullable-objects-closed",
+      "description": "Nullable objects inside array items are closed and stay nullable.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "rows": {
+            "type": "array",
+            "items": {
+              "type": ["object", "null"],
+              "properties": {
+                "id": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "required": ["rows"]
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "rows": {
+              "type": "array",
+              "items": {
+                "type": ["object", "null"],
+                "properties": {
+                  "id": {
+                    "type": ["string", "null"]
+                  }
+                },
+                "required": ["id"],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": ["rows"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.rows.items.properties.id",
+          "reason": "optional-property-nullable"
+        }
+      ],
+      "arguments": [
+        {
+          "input": {
+            "rows": [
+              null,
+              {
+                "id": null
+              }
+            ]
+          },
+          "output": {
+            "rows": [null, {}]
+          }
+        }
+      ]
+    },
+    {
+      "id": "tuple-form-items-unsupported",
+      "description": "Draft-4 tuple items have no strict-mode equivalent.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "pair": {
+            "type": "array",
+            "items": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "required": ["pair"]
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "properties.pair",
+            "keyword": "items"
+          }
+        ]
+      }
+    },
+    {
+      "id": "boolean-items-unsupported",
+      "description": "A boolean items subschema is reported.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "xs": {
+            "type": "array",
+            "items": true
+          }
+        },
+        "required": ["xs"]
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "properties.xs",
+            "keyword": "items"
+          }
+        ]
+      }
+    },
+    {
+      "id": "not-keyword-unsupported",
+      "description": "not has no strict-mode equivalent.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "v": {
+            "not": {
+              "type": "string"
+            }
+          }
+        },
+        "required": ["v"]
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "properties.v",
+            "keyword": "not"
+          }
+        ]
+      }
+    },
+    {
+      "id": "if-then-else-unsupported",
+      "description": "Conditional keywords have no strict-mode equivalent.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "v": {
+            "type": "string",
+            "if": {
+              "minLength": 1
+            },
+            "then": {
+              "maxLength": 5
+            },
+            "else": {
+              "const": ""
+            }
+          }
+        },
+        "required": ["v"]
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "properties.v",
+            "keyword": "else"
+          },
+          {
+            "path": "properties.v",
+            "keyword": "if"
+          },
+          {
+            "path": "properties.v",
+            "keyword": "then"
+          }
+        ]
+      }
+    },
+    {
+      "id": "dependent-schemas-unsupported",
+      "description": "dependentSchemas has no strict-mode equivalent.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "a": {
+            "type": "string"
+          }
+        },
+        "required": ["a"],
+        "dependentSchemas": {
+          "a": {
+            "type": "object",
+            "properties": {
+              "b": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "",
+            "keyword": "dependentSchemas"
+          }
+        ]
+      },
+      "changes": [
+        {
+          "path": "dependentSchemas.a.properties.b",
+          "reason": "optional-property-nullable"
+        }
+      ]
+    },
+    {
+      "id": "property-names-keyword-unsupported",
+      "description": "propertyNames has no strict-mode equivalent.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "a": {
+            "type": "string"
+          }
+        },
+        "required": ["a"],
+        "propertyNames": {
+          "pattern": "^a"
+        }
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "",
+            "keyword": "propertyNames"
+          }
+        ]
+      }
+    },
+    {
+      "id": "one-of-beside-any-of-unsupported",
+      "description": "oneOf next to anyOf cannot be merged and is reported.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "v": {
+            "anyOf": [
+              {
+                "type": "string"
+              }
+            ],
+            "oneOf": [
+              {
+                "type": "number"
+              }
+            ]
+          }
+        },
+        "required": ["v"]
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "properties.v",
+            "keyword": "oneOf"
+          }
+        ]
+      }
+    },
+    {
+      "id": "boolean-property-subschema-unsupported",
+      "description": "A boolean property subschema is reported.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "anything": true,
+          "nothing": false
+        },
+        "required": ["anything", "nothing"]
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "properties.anything",
+            "keyword": "properties"
+          },
+          {
+            "path": "properties.nothing",
+            "keyword": "properties"
+          }
+        ]
+      }
+    },
+    {
+      "id": "properties-not-an-object-unsupported",
+      "description": "A malformed properties value is reported instead of emptied.",
+      "schema": {
+        "type": "object",
+        "properties": "not-a-map",
+        "required": ["a"]
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "",
+            "keyword": "properties"
+          }
+        ]
+      }
+    },
+    {
+      "id": "ref-with-siblings-kept",
+      "description": "Sibling keywords next to a $ref are kept.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "cfg": {
+            "$ref": "#/$defs/Config",
+            "description": "cfg",
+            "title": "Config"
+          }
+        },
+        "required": ["cfg"],
+        "$defs": {
+          "Config": {
+            "type": "object",
+            "properties": {
+              "a": {
+                "type": "string"
+              }
+            },
+            "required": ["a"]
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "cfg": {
+              "$ref": "#/$defs/Config",
+              "description": "cfg",
+              "title": "Config"
+            }
+          },
+          "required": ["cfg"],
+          "$defs": {
+            "Config": {
+              "type": "object",
+              "properties": {
+                "a": {
+                  "type": "string"
+                }
+              },
+              "required": ["a"],
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    {
+      "id": "required-non-string-entries-ignored",
+      "description": "Non-string required entries are ignored.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "a": {
+            "type": "string"
+          },
+          "b": {
+            "type": "string"
+          }
+        },
+        "required": ["a", 1, null]
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "a": {
+              "type": "string"
+            },
+            "b": {
+              "type": ["string", "null"]
+            }
+          },
+          "required": ["a", "b"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.b",
+          "reason": "optional-property-nullable"
+        }
+      ]
+    },
+    {
+      "id": "dynamic-keys-reported-once-with-pattern-properties",
+      "description": "additionalProperties and patternProperties on one node report additionalProperties.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "m": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "patternProperties": {
+              "^x": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "required": ["m"]
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "properties.m",
+            "keyword": "additionalProperties"
+          }
+        ]
+      }
+    },
+    {
+      "id": "empty-properties-open-object-unsupported",
+      "description": "An object with empty properties and no closing is free-form.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "m": {
+            "type": "object",
+            "properties": {}
+          }
+        },
+        "required": ["m"]
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "properties.m",
+            "keyword": "properties"
+          }
+        ]
+      }
+    },
+    {
+      "id": "default-stripped-then-widened",
+      "description": "Stripping default and widening compose.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "a": {
+            "type": "string",
+            "default": "x"
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "a": {
+              "type": ["string", "null"]
+            }
+          },
+          "required": ["a"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.a",
+          "reason": "unsupported-keyword-stripped"
+        },
+        {
+          "path": "properties.a",
+          "reason": "optional-property-nullable"
+        }
+      ]
+    },
+    {
+      "id": "nested-any-of-in-any-of-kept",
+      "description": "A composition nested inside a composition is normalized branch by branch.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "v": {
+            "anyOf": [
+              {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "a": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              {
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "required": ["v"]
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "v": {
+              "anyOf": [
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "a": {
+                          "type": ["string", "null"]
+                        }
+                      },
+                      "required": ["a"],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "required": ["v"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.v.anyOf[0].anyOf[0].properties.a",
+          "reason": "optional-property-nullable"
+        }
+      ],
+      "arguments": [
+        {
+          "input": {
+            "v": {
+              "a": null
+            }
+          },
+          "output": {
+            "v": {}
+          }
+        }
+      ]
+    },
+    {
+      "id": "definitions-and-defs-both-normalized",
+      "description": "Legacy definitions and $defs coexist and both are normalized.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "a": {
+            "$ref": "#/$defs/A"
+          },
+          "b": {
+            "$ref": "#/definitions/B"
+          }
+        },
+        "required": ["a", "b"],
+        "$defs": {
+          "A": {
+            "type": "object",
+            "properties": {
+              "x": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "definitions": {
+          "B": {
+            "type": "object",
+            "properties": {
+              "y": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "a": {
+              "$ref": "#/$defs/A"
+            },
+            "b": {
+              "$ref": "#/definitions/B"
+            }
+          },
+          "required": ["a", "b"],
+          "$defs": {
+            "A": {
+              "type": "object",
+              "properties": {
+                "x": {
+                  "type": ["string", "null"]
+                }
+              },
+              "required": ["x"],
+              "additionalProperties": false
+            }
+          },
+          "definitions": {
+            "B": {
+              "type": "object",
+              "properties": {
+                "y": {
+                  "type": ["string", "null"]
+                }
+              },
+              "required": ["y"],
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "$defs.A.properties.x",
+          "reason": "optional-property-nullable"
+        },
+        {
+          "path": "definitions.B.properties.y",
+          "reason": "optional-property-nullable"
+        }
+      ]
+    },
+    {
+      "id": "deep-nesting-normalized-fully",
+      "description": "Ten levels of nested objects are normalized at every level.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "child": {
+            "type": "object",
+            "properties": {
+              "child": {
+                "type": "object",
+                "properties": {
+                  "child": {
+                    "type": "object",
+                    "properties": {
+                      "child": {
+                        "type": "object",
+                        "properties": {
+                          "child": {
+                            "type": "object",
+                            "properties": {
+                              "child": {
+                                "type": "object",
+                                "properties": {
+                                  "child": {
+                                    "type": "object",
+                                    "properties": {
+                                      "child": {
+                                        "type": "object",
+                                        "properties": {
+                                          "child": {
+                                            "type": "object",
+                                            "properties": {
+                                              "child": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "leaf": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "required": ["child"]
+                                          }
+                                        },
+                                        "required": ["child"]
+                                      }
+                                    },
+                                    "required": ["child"]
+                                  }
+                                },
+                                "required": ["child"]
+                              }
+                            },
+                            "required": ["child"]
+                          }
+                        },
+                        "required": ["child"]
+                      }
+                    },
+                    "required": ["child"]
+                  }
+                },
+                "required": ["child"]
+              }
+            },
+            "required": ["child"]
+          }
+        },
+        "required": ["child"]
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "child": {
+              "type": "object",
+              "properties": {
+                "child": {
+                  "type": "object",
+                  "properties": {
+                    "child": {
+                      "type": "object",
+                      "properties": {
+                        "child": {
+                          "type": "object",
+                          "properties": {
+                            "child": {
+                              "type": "object",
+                              "properties": {
+                                "child": {
+                                  "type": "object",
+                                  "properties": {
+                                    "child": {
+                                      "type": "object",
+                                      "properties": {
+                                        "child": {
+                                          "type": "object",
+                                          "properties": {
+                                            "child": {
+                                              "type": "object",
+                                              "properties": {
+                                                "child": {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "leaf": {
+                                                      "type": ["string", "null"]
+                                                    }
+                                                  },
+                                                  "required": ["leaf"],
+                                                  "additionalProperties": false
+                                                }
+                                              },
+                                              "required": ["child"],
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "required": ["child"],
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "required": ["child"],
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": ["child"],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": ["child"],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": ["child"],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": ["child"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["child"],
+                  "additionalProperties": false
+                }
+              },
+              "required": ["child"],
+              "additionalProperties": false
+            }
+          },
+          "required": ["child"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.child.properties.child.properties.child.properties.child.properties.child.properties.child.properties.child.properties.child.properties.child.properties.child.properties.leaf",
+          "reason": "optional-property-nullable"
+        }
+      ]
+    },
+    {
+      "id": "chained-refs-resolved",
+      "description": "A $ref to a $ref resolves to the final definition.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "a": {
+            "$ref": "#/$defs/Alias"
+          }
+        },
+        "required": ["a"],
+        "$defs": {
+          "Alias": {
+            "$ref": "#/$defs/Real"
+          },
+          "Real": {
+            "type": "object",
+            "properties": {
+              "x": {
+                "type": "string"
+              }
+            },
+            "required": ["x"]
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "a": {
+              "$ref": "#/$defs/Alias"
+            }
+          },
+          "required": ["a"],
+          "$defs": {
+            "Alias": {
+              "$ref": "#/$defs/Real"
+            },
+            "Real": {
+              "type": "object",
+              "properties": {
+                "x": {
+                  "type": "string"
+                }
+              },
+              "required": ["x"],
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "arguments": [
+        {
+          "input": {
+            "a": {
+              "x": null
+            }
+          },
+          "output": {
+            "a": {}
+          }
+        },
+        {
+          "input": {
+            "a": null
+          },
+          "output": {}
+        }
+      ]
+    }
+  ]
+}

--- a/python/tests/fixtures/json_schema_conversion_corpus.py
+++ b/python/tests/fixtures/json_schema_conversion_corpus.py
@@ -13,6 +13,9 @@ from pathlib import Path
 from pydantic import BaseModel, ConfigDict, Field
 
 CORPUS_PATH = Path(__file__).parent / "json-schema-conversion" / "object-cases.json"
+STRICT_CORPUS_PATH = (
+    Path(__file__).parent / "json-schema-conversion" / "strict-cases.json"
+)
 
 Language = t.Literal["zod", "effect", "python"]
 LANGUAGES: t.Tuple[Language, ...] = ("zod", "effect", "python")
@@ -125,3 +128,73 @@ def find_case(case_id: str) -> CorpusCase:
         if case.id == case_id:
             return case
     raise LookupError(f"Corpus is missing the {case_id} case")
+
+
+class StrictIncompatibility(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    path: str
+    keyword: str = Field(min_length=1)
+
+
+class StrictChange(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    path: str
+    reason: str = Field(min_length=1)
+
+
+class StrictArguments(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    input: t.Dict[str, t.Any]
+    output: t.Dict[str, t.Any]
+
+
+class StrictExpectation(BaseModel):
+    """Either the exact strict schema, or the constructs reported as unsupported."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_: t.Optional[t.Dict[str, t.Any]] = Field(default=None, alias="schema")
+    unsupported: t.Optional[t.List[StrictIncompatibility]] = Field(
+        default=None, min_length=1
+    )
+
+
+class StrictCase(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(min_length=1)
+    description: t.Optional[str] = None
+    schema_: t.Dict[str, t.Any] = Field(alias="schema")
+    strict: StrictExpectation
+    changes: t.Optional[t.List[StrictChange]] = None
+    arguments: t.Optional[t.List[StrictArguments]] = None
+
+
+class StrictCorpus(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    cases: t.List[StrictCase] = Field(min_length=1)
+
+
+_cached_strict: t.Optional[t.List[StrictCase]] = None
+
+
+def load_strict_cases() -> t.List[StrictCase]:
+    """Decode the shared strict-mode corpus (byte-identical copy per language)."""
+    global _cached_strict
+    if _cached_strict is None:
+        cases = StrictCorpus.model_validate(
+            json.loads(STRICT_CORPUS_PATH.read_text())
+        ).cases
+        seen: t.Set[str] = set()
+        for case in cases:
+            if case.id in seen:
+                raise ValueError(f"Duplicate strict case id: {case.id}")
+            seen.add(case.id)
+            if (case.strict.schema_ is None) == (case.strict.unsupported is None):
+                raise ValueError(f"Strict case {case.id} must pin exactly one outcome")
+        _cached_strict = cases
+    return _cached_strict

--- a/python/tests/test_openai_responses_strict_empty_schema.py
+++ b/python/tests/test_openai_responses_strict_empty_schema.py
@@ -1,0 +1,16 @@
+"""Regression coverage for OpenAI Responses strict-mode empty schemas."""
+
+from composio.core.provider._openai_responses import OpenAIResponsesProvider
+from tests.test_provider import create_mock_tool
+
+
+def test_explicit_empty_schema_is_not_treated_as_missing_parameters():
+    tool = create_mock_tool("TEST_TOOL", "composio")
+    tool.input_parameters = {}
+
+    wrapped = OpenAIResponsesProvider(strict=True).wrap_tool(tool)
+
+    # An explicit {} is a free-form schema and therefore cannot be narrowed
+    # into a closed strict object. This must match the TypeScript provider.
+    assert wrapped["strict"] is False
+    assert wrapped["parameters"] == {}

--- a/python/tests/test_strict_schema.py
+++ b/python/tests/test_strict_schema.py
@@ -1,0 +1,650 @@
+"""Tests for composio.utils.strict_schema and its use by OpenAIResponsesProvider."""
+
+import copy
+import json
+
+import pytest
+
+from composio.utils.strict_schema import omit_null_tool_arguments, to_strict_json_schema
+
+
+def assert_strict_shape(node, path=""):
+    """Structural invariants OpenAI enforces on every node of a strict schema."""
+    if isinstance(node, list):
+        for index, item in enumerate(node):
+            assert_strict_shape(item, f"{path}[{index}]")
+        return
+    if not isinstance(node, dict):
+        return
+    if "anyOf" in node:
+        assert "type" not in node, f"{path}: type beside anyOf"
+    for keyword in ("default", "examples", "oneOf", "patternProperties"):
+        assert keyword not in node, f"{path}: {keyword}"
+    node_type = node.get("type")
+    is_object = node_type == "object" or (
+        isinstance(node_type, list) and "object" in node_type
+    )
+    if is_object or "properties" in node:
+        properties = node.get("properties") or {}
+        assert node.get("required") == list(properties.keys()), f"{path}: required"
+        assert node.get("additionalProperties") is False, (
+            f"{path}: additionalProperties"
+        )
+    for key, child in node.items():
+        if key in ("enum", "const"):
+            continue
+        assert_strict_shape(child, f"{path}.{key}" if path else key)
+
+
+class TestToStrictJsonSchema:
+    def test_keeps_flat_all_required_object_valid(self):
+        schema = {
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": ["query"],
+            "additionalProperties": False,
+        }
+
+        result = to_strict_json_schema(schema)
+
+        assert result.schema == schema
+        assert result.changes == []
+
+    def test_keeps_optional_properties_required_and_nullable(self):
+        result = to_strict_json_schema(
+            {
+                "type": "object",
+                "properties": {
+                    "cfg": {
+                        "type": "object",
+                        "properties": {
+                            "url": {"type": "string"},
+                            "note": {"type": "string", "description": "optional note"},
+                        },
+                        "required": ["url"],
+                    }
+                },
+                "required": ["cfg"],
+            }
+        )
+
+        assert result.schema == {
+            "type": "object",
+            "properties": {
+                "cfg": {
+                    "type": "object",
+                    "properties": {
+                        "url": {"type": "string"},
+                        "note": {
+                            "type": ["string", "null"],
+                            "description": "optional note",
+                        },
+                    },
+                    "required": ["url", "note"],
+                    "additionalProperties": False,
+                }
+            },
+            "required": ["cfg"],
+            "additionalProperties": False,
+        }
+        assert [(c.path, c.reason) for c in result.changes] == [
+            ("properties.cfg.properties.note", "optional-property-nullable")
+        ]
+
+    def test_requires_and_widens_every_property_when_required_is_missing(self):
+        result = to_strict_json_schema(
+            {
+                "type": "object",
+                "properties": {"a": {"type": "string"}, "b": {"type": "number"}},
+            }
+        )
+
+        assert result.schema == {
+            "type": "object",
+            "properties": {
+                "a": {"type": ["string", "null"]},
+                "b": {"type": ["number", "null"]},
+            },
+            "required": ["a", "b"],
+            "additionalProperties": False,
+        }
+
+    def test_keeps_nullable_type_arrays_and_closes_nullable_objects(self):
+        result = to_strict_json_schema(
+            {
+                "type": "object",
+                "properties": {
+                    "id": {"type": ["string", "null"], "description": "identifier"},
+                    "cfg": {
+                        "type": ["object", "null"],
+                        "properties": {"a": {"type": "string"}},
+                        "required": ["a"],
+                    },
+                    "xs": {"type": ["array", "null"], "items": {"type": "string"}},
+                },
+                "required": ["id", "cfg", "xs"],
+            }
+        )
+
+        assert result.schema["properties"]["cfg"] == {
+            "type": ["object", "null"],
+            "properties": {"a": {"type": "string"}},
+            "required": ["a"],
+            "additionalProperties": False,
+        }
+        assert result.schema["properties"]["id"] == {
+            "type": ["string", "null"],
+            "description": "identifier",
+        }
+        assert result.changes == []
+        assert_strict_shape(result.schema)
+
+    def test_widens_composition_and_enum_properties_without_type_beside_any_of(self):
+        result = to_strict_json_schema(
+            {
+                "type": "object",
+                "properties": {
+                    "value": {"anyOf": [{"type": "string"}, {"type": "number"}]},
+                    "already": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+                    "choice": {"enum": ["a", "b"], "description": "pick one"},
+                    "multi": {"type": ["string", "number"]},
+                },
+            }
+        )
+
+        properties = result.schema["properties"]
+        assert properties["value"] == {
+            "anyOf": [{"type": "string"}, {"type": "number"}, {"type": "null"}]
+        }
+        assert properties["already"] == {
+            "anyOf": [{"type": "string"}, {"type": "null"}]
+        }
+        assert properties["choice"] == {
+            "description": "pick one",
+            "anyOf": [{"enum": ["a", "b"]}, {"type": "null"}],
+        }
+        assert properties["multi"] == {"type": ["string", "number", "null"]}
+        assert_strict_shape(result.schema)
+
+    def test_normalizes_composition_branches_and_array_items_recursively(self):
+        result = to_strict_json_schema(
+            {
+                "type": "object",
+                "properties": {
+                    "payload": {
+                        "anyOf": [
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "inner": {"type": "string"},
+                                    "extra": {"type": "string"},
+                                },
+                                "required": ["inner"],
+                            },
+                            {"type": "null"},
+                        ]
+                    },
+                    "rows": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {"type": "string"},
+                                "tag": {"type": "string"},
+                            },
+                            "required": ["id"],
+                        },
+                    },
+                    "either": {"oneOf": [{"type": "string"}, {"type": "number"}]},
+                },
+                "required": ["payload", "rows", "either"],
+            }
+        )
+
+        assert result.schema["properties"]["payload"]["anyOf"][0] == {
+            "type": "object",
+            "properties": {
+                "inner": {"type": "string"},
+                "extra": {"type": ["string", "null"]},
+            },
+            "required": ["inner", "extra"],
+            "additionalProperties": False,
+        }
+        assert result.schema["properties"]["rows"]["items"]["required"] == ["id", "tag"]
+        assert result.schema["properties"]["either"] == {
+            "anyOf": [{"type": "string"}, {"type": "number"}]
+        }
+        assert "one-of-converted" in {c.reason for c in result.changes}
+        assert_strict_shape(result.schema)
+
+    def test_reports_dynamic_key_and_free_form_objects_as_unsupported(self):
+        result = to_strict_json_schema(
+            {
+                "type": "object",
+                "properties": {
+                    "headers": {
+                        "type": "object",
+                        "additionalProperties": {"type": "string"},
+                    },
+                    "meta": {"type": "object", "description": "any json"},
+                    "tagged": {
+                        "type": "object",
+                        "patternProperties": {"^x-": {"type": "string"}},
+                    },
+                    "open": {"type": "object", "additionalProperties": True},
+                },
+                "required": ["headers", "meta", "tagged", "open"],
+            }
+        )
+
+        assert [(e.path, e.keyword) for e in result.unsupported] == [
+            ("properties.headers", "additionalProperties"),
+            ("properties.meta", "properties"),
+            ("properties.tagged", "patternProperties"),
+            ("properties.open", "additionalProperties"),
+        ]
+        # The schema-valued additionalProperties is preserved, not overwritten.
+        assert result.schema["properties"]["headers"]["additionalProperties"] == {
+            "type": "string"
+        }
+        assert "patternProperties" in result.schema["properties"]["tagged"]
+
+    def test_strips_annotation_keywords_and_reports_keywords_it_cannot_rewrite(self):
+        result = to_strict_json_schema(
+            {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "examples": ["a"], "default": "x"},
+                    "pair": {"type": "array", "prefixItems": [{"type": "number"}]},
+                    "all": {"allOf": [{"type": "string"}]},
+                },
+                "required": ["name", "pair", "all"],
+            }
+        )
+
+        assert result.schema["properties"]["name"] == {"type": "string"}
+        reasons = [c.reason for c in result.changes]
+        assert reasons.count("unsupported-keyword-stripped") == 2
+        assert [(e.path, e.keyword) for e in result.unsupported] == [
+            ("properties.pair", "prefixItems"),
+            ("properties.all", "allOf"),
+        ]
+
+    def test_keeps_defs_and_refs_and_reports_dangling_refs(self):
+        result = to_strict_json_schema(
+            {
+                "type": "object",
+                "properties": {
+                    "cfg": {"$ref": "#/$defs/Config"},
+                    "optionalCfg": {
+                        "$ref": "#/$defs/Config",
+                        "description": "optional",
+                    },
+                    "missing": {"$ref": "#/$defs/Nope"},
+                    "external": {"$ref": "https://example.com/schema.json"},
+                },
+                "required": ["cfg", "cfg", "missing", "external"],
+                "$defs": {
+                    "Config": {
+                        "type": "object",
+                        "properties": {
+                            "url": {"type": "string"},
+                            "note": {"type": "string"},
+                        },
+                        "required": ["url"],
+                    }
+                },
+            }
+        )
+
+        assert result.schema["properties"]["cfg"] == {"$ref": "#/$defs/Config"}
+        assert result.schema["properties"]["optionalCfg"] == {
+            "description": "optional",
+            "anyOf": [{"$ref": "#/$defs/Config"}, {"type": "null"}],
+        }
+        assert result.schema["$defs"] == {
+            "Config": {
+                "type": "object",
+                "properties": {
+                    "url": {"type": "string"},
+                    "note": {"type": ["string", "null"]},
+                },
+                "required": ["url", "note"],
+                "additionalProperties": False,
+            }
+        }
+        assert result.schema["required"] == [
+            "cfg",
+            "optionalCfg",
+            "missing",
+            "external",
+        ]
+        assert [(e.path, e.keyword) for e in result.unsupported] == [
+            ("properties.missing", "$ref"),
+            ("properties.external", "$ref"),
+        ]
+        assert ("$defs.Config.properties.note", "optional-property-nullable") in [
+            (c.path, c.reason) for c in result.changes
+        ]
+
+    def test_caps_the_change_log_without_losing_properties(self):
+        properties = {f"p{i}": {"type": "string"} for i in range(60)}
+
+        result = to_strict_json_schema(
+            {"type": "object", "properties": properties, "required": ["p0"]}
+        )
+
+        assert len(result.schema["properties"]) == 60
+        assert len(result.changes) == 50
+        assert result.total_changes == 59
+
+    def test_does_not_mutate_input(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "cfg": {
+                    "type": "object",
+                    "properties": {"opt": {"type": "string", "default": 1}},
+                }
+            },
+            "required": ["cfg"],
+        }
+        snapshot = copy.deepcopy(schema)
+
+        to_strict_json_schema(schema)
+
+        assert schema == snapshot
+
+    def test_is_idempotent(self):
+        once = to_strict_json_schema(
+            {
+                "type": "object",
+                "properties": {
+                    "cfg": {"$ref": "#/$defs/Config"},
+                    "id": {"type": ["string", "null"]},
+                },
+                "$defs": {
+                    "Config": {
+                        "type": "object",
+                        "properties": {
+                            "url": {"type": "string"},
+                            "note": {"type": "string"},
+                        },
+                        "required": ["url"],
+                    }
+                },
+            }
+        ).schema
+
+        twice = to_strict_json_schema(once)
+
+        assert twice.schema == once
+        assert twice.changes == []
+        assert twice.unsupported == []
+
+    def test_reports_non_object_roots_as_unsupported_and_keeps_recursive_defs(self):
+        assert [
+            (e.path, e.keyword)
+            for e in to_strict_json_schema({"type": "string"}).unsupported
+        ] == [("", "type")]
+        nullable_root = to_strict_json_schema(
+            {"type": ["object", "null"], "properties": {"a": {"type": "string"}}}
+        )
+        assert ("", "type") in [(e.path, e.keyword) for e in nullable_root.unsupported]
+
+        cyclic = to_strict_json_schema(
+            {
+                "type": "object",
+                "properties": {"node": {"$ref": "#/$defs/Node"}},
+                "required": ["node"],
+                "$defs": {
+                    "Node": {
+                        "type": "object",
+                        "properties": {
+                            "child": {"$ref": "#/$defs/Node"},
+                            "label": {"type": "string"},
+                        },
+                        "required": ["label"],
+                    }
+                },
+            }
+        )
+        # Recursion through $defs is representable in strict mode.
+        assert cyclic.unsupported == []
+        assert cyclic.schema["$defs"]["Node"] == {
+            "type": "object",
+            "properties": {
+                "child": {"anyOf": [{"$ref": "#/$defs/Node"}, {"type": "null"}]},
+                "label": {"type": "string"},
+            },
+            "required": ["child", "label"],
+            "additionalProperties": False,
+        }
+
+    def test_raises_past_maximum_depth(self):
+        deep = {"type": "string"}
+        for _ in range(600):
+            deep = {
+                "type": "object",
+                "properties": {"nest": deep},
+                "required": ["nest"],
+            }
+
+        with pytest.raises(Exception, match="depth"):
+            to_strict_json_schema(deep)
+
+
+_OMIT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "cfg": {
+            "type": "object",
+            "properties": {"url": {"type": "string"}, "note": {"type": "string"}},
+            "required": ["url"],
+        },
+        "label": {"type": "string"},
+        "clearable": {"type": ["string", "null"]},
+        "choice": {"anyOf": [{"enum": ["a"]}, {"type": "null"}]},
+        "rows": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {"id": {"type": "string"}, "tag": {"type": "string"}},
+            },
+        },
+        "refd": {"$ref": "#/$defs/Str"},
+        "refdNullable": {"$ref": "#/$defs/NullableStr"},
+    },
+    "$defs": {"Str": {"type": "string"}, "NullableStr": {"type": ["string", "null"]}},
+}
+
+
+class TestOmitNullToolArguments:
+    def test_drops_nulls_the_schema_rejects_and_keeps_the_ones_it_accepts(self):
+        arguments = {
+            "cfg": {"url": "https://example.com", "note": None},
+            "label": None,
+            "clearable": None,
+            "choice": None,
+            "unknown": None,
+            "rows": [{"id": "1", "tag": None}, None],
+            "refd": None,
+            "refdNullable": None,
+        }
+        snapshot = copy.deepcopy(arguments)
+
+        assert omit_null_tool_arguments(arguments, _OMIT_SCHEMA) == {
+            "cfg": {"url": "https://example.com"},
+            "clearable": None,
+            "choice": None,
+            "unknown": None,
+            "rows": [{"id": "1"}, None],
+            "refdNullable": None,
+        }
+        assert arguments == snapshot
+
+
+class TestOpenAIResponsesProviderStrict:
+    def _tool(self, input_parameters):
+        from tests.test_provider import create_mock_tool
+
+        tool = create_mock_tool("TEST_TOOL", "composio")
+        tool.input_parameters = input_parameters
+        return tool
+
+    def test_wrap_tool_passes_parameters_through_by_default(self):
+        from composio.core.provider._openai_responses import OpenAIResponsesProvider
+
+        provider = OpenAIResponsesProvider()
+        wrapped = provider.wrap_tool(self._tool({"type": "object", "properties": {}}))
+
+        assert wrapped["parameters"] == {"type": "object", "properties": {}}
+        assert wrapped["strict"] is False
+
+    def test_constructor_keeps_base_provider_config(self):
+        from composio.core.provider._openai_responses import OpenAIResponsesProvider
+
+        provider = OpenAIResponsesProvider(
+            strict=True, schema_config={"skip_defaults": True}
+        )
+
+        assert provider.strict is True
+        assert provider.skip_default is True
+
+    def test_wrap_tool_emits_strict_and_normalizes_complex_schemas(self):
+        from composio.core.provider._openai_responses import OpenAIResponsesProvider
+
+        provider = OpenAIResponsesProvider(strict=True)
+        wrapped = provider.wrap_tool(
+            self._tool(
+                {
+                    "type": "object",
+                    "properties": {
+                        "cfg": {"$ref": "#/$defs/Config"},
+                        "id": {"type": ["string", "null"]},
+                        "label": {"type": "string"},
+                    },
+                    "required": ["cfg", "id"],
+                    "$defs": {
+                        "Config": {
+                            "type": "object",
+                            "properties": {
+                                "url": {"type": "string"},
+                                "note": {"type": "string"},
+                            },
+                            "required": ["url"],
+                        }
+                    },
+                }
+            )
+        )
+
+        assert wrapped["strict"] is True
+        assert wrapped["parameters"] == {
+            "type": "object",
+            "properties": {
+                "cfg": {"$ref": "#/$defs/Config"},
+                "id": {"type": ["string", "null"]},
+                "label": {"type": ["string", "null"]},
+            },
+            "required": ["cfg", "id", "label"],
+            "additionalProperties": False,
+            "$defs": {
+                "Config": {
+                    "type": "object",
+                    "properties": {
+                        "url": {"type": "string"},
+                        "note": {"type": ["string", "null"]},
+                    },
+                    "required": ["url", "note"],
+                    "additionalProperties": False,
+                }
+            },
+        }
+
+    def test_wrap_tool_sends_unsupported_schemas_without_strict(self):
+        from composio.core.provider._openai_responses import OpenAIResponsesProvider
+
+        provider = OpenAIResponsesProvider(strict=True)
+        input_parameters = {
+            "type": "object",
+            "properties": {
+                "headers": {
+                    "type": "object",
+                    "additionalProperties": {"type": "string"},
+                },
+                "name": {"type": "string"},
+            },
+            "required": ["headers"],
+        }
+        wrapped = provider.wrap_tool(self._tool(input_parameters))
+
+        assert wrapped["strict"] is False
+        assert wrapped["parameters"] == input_parameters
+
+    def test_wrap_tool_emits_empty_closed_object_without_parameters(self):
+        from composio.core.provider._openai_responses import OpenAIResponsesProvider
+
+        provider = OpenAIResponsesProvider(strict=True)
+        wrapped = provider.wrap_tool(self._tool(None))
+
+        assert wrapped["strict"] is True
+        assert wrapped["parameters"] == {
+            "type": "object",
+            "properties": {},
+            "required": [],
+            "additionalProperties": False,
+        }
+
+    def test_execute_tool_call_omits_null_arguments_in_strict_mode(self):
+        from openai.types.responses.response_output_item import ResponseFunctionToolCall
+
+        from composio.core.provider._openai_responses import OpenAIResponsesProvider
+
+        received = {}
+
+        def execute_tool(slug, arguments, modifiers=None, **kwargs):
+            received["slug"] = slug
+            received["arguments"] = arguments
+            return {"data": {}, "error": None, "successful": True}
+
+        provider = OpenAIResponsesProvider(strict=True)
+        provider.set_execute_tool_fn(execute_tool)
+        provider.wrap_tool(
+            self._tool(
+                {
+                    "type": "object",
+                    "properties": {
+                        "cfg": {
+                            "type": "object",
+                            "properties": {
+                                "url": {"type": "string"},
+                                "note": {"type": "string"},
+                            },
+                            "required": ["url"],
+                        },
+                        "label": {"type": "string"},
+                        "clearable": {"type": ["string", "null"]},
+                    },
+                    "required": ["cfg"],
+                }
+            )
+        )
+        provider.execute_tool_call(
+            user_id="user",
+            tool_call=ResponseFunctionToolCall(
+                type="function_call",
+                call_id="call_1",
+                name="TEST_TOOL",
+                arguments=json.dumps(
+                    {
+                        "cfg": {"url": "u", "note": None},
+                        "label": None,
+                        "clearable": None,
+                    }
+                ),
+            ),
+        )
+
+        assert received["slug"] == "TEST_TOOL"
+        assert received["arguments"] == {"cfg": {"url": "u"}, "clearable": None}

--- a/python/tests/test_strict_schema_corpus.py
+++ b/python/tests/test_strict_schema_corpus.py
@@ -1,0 +1,80 @@
+"""Drive to_strict_json_schema from the shared strict-mode corpus.
+
+The corpus pins the exact output of the TypeScript implementation, so this
+suite is the cross-SDK parity check for strict normalization.
+"""
+
+import copy
+
+import pytest
+
+from composio.utils.strict_schema import omit_null_tool_arguments, to_strict_json_schema
+from tests.fixtures.json_schema_conversion_corpus import load_strict_cases
+
+
+def assert_strict_shape(node, path=""):
+    """Structural invariants OpenAI enforces on every node of a strict schema."""
+    if isinstance(node, list):
+        for index, item in enumerate(node):
+            assert_strict_shape(item, f"{path}[{index}]")
+        return
+    if not isinstance(node, dict):
+        return
+    if "anyOf" in node:
+        assert "type" not in node, f"{path}: type beside anyOf"
+    for keyword in (
+        "default",
+        "examples",
+        "oneOf",
+        "patternProperties",
+        "allOf",
+        "prefixItems",
+    ):
+        assert keyword not in node, f"{path}: {keyword}"
+    node_type = node.get("type")
+    is_object = node_type == "object" or (
+        isinstance(node_type, list) and "object" in node_type
+    )
+    if is_object or "properties" in node:
+        properties = node.get("properties") or {}
+        assert node.get("required") == list(properties.keys()), f"{path}: required"
+        assert node.get("additionalProperties") is False, (
+            f"{path}: additionalProperties"
+        )
+    for key, child in node.items():
+        if key in ("enum", "const"):
+            continue
+        child_path = f"{path}.{key}" if path else key
+        if key in ("properties", "$defs", "definitions") and isinstance(child, dict):
+            # Keys of these maps are names, not keywords.
+            for name, sub in child.items():
+                assert_strict_shape(sub, f"{child_path}.{name}")
+            continue
+        assert_strict_shape(child, child_path)
+
+
+@pytest.mark.parametrize("case", load_strict_cases(), ids=lambda case: case.id)
+def test_strict_corpus_case(case):
+    snapshot = copy.deepcopy(case.schema_)
+    result = to_strict_json_schema(case.schema_)
+
+    assert case.schema_ == snapshot, "input mutated"
+    if case.strict.unsupported is not None:
+        assert [(e.path, e.keyword) for e in result.unsupported] == [
+            (e.path, e.keyword) for e in case.strict.unsupported
+        ]
+    else:
+        assert result.unsupported == []
+        assert result.schema == case.strict.schema_
+        assert_strict_shape(result.schema)
+        again = to_strict_json_schema(result.schema)
+        assert again.schema == result.schema, "not idempotent"
+        assert again.changes == []
+    assert [(c.path, c.reason) for c in result.changes] == [
+        (c.path, c.reason) for c in (case.changes or [])
+    ]
+    assert result.total_changes == len(result.changes)
+    for arguments in case.arguments or []:
+        assert (
+            omit_null_tool_arguments(arguments.input, result.source) == arguments.output
+        )

--- a/ts/packages/core/src/index.ts
+++ b/ts/packages/core/src/index.ts
@@ -9,12 +9,18 @@ export {
   deduplicateJsonSchemaRequiredArrays,
   ensureObjectTypeOnProperties,
   jsonSchemaToZodSchema,
+  omitNullToolArguments,
   removeNonRequiredProperties,
+  toStrictJsonSchema,
 } from './utils/jsonSchema';
 export type {
   DereferenceJsonSchemaOptions,
   UnresolvedRefReason,
   UnresolvedRefStrategy,
+  StrictSchemaChange,
+  StrictSchemaChangeReason,
+  StrictSchemaIncompatibility,
+  StrictJsonSchemaResult,
 } from './utils/jsonSchema';
 export { getExtensionFromMimeType } from './utils/mime';
 export { normalizeToolArguments } from './utils/toolArguments';

--- a/ts/packages/core/src/utils/jsonSchema.ts
+++ b/ts/packages/core/src/utils/jsonSchema.ts
@@ -8,6 +8,33 @@ const MAX_REF_CHAIN_DEPTH = 100;
 const MAX_NODE_DEPTH = 512;
 const CYCLE_BREAK_SENTINEL = { type: 'object', additionalProperties: true } as const;
 
+/** Keywords whose value is a single subschema. */
+const SCHEMA_KEYWORDS = new Set([
+  'additionalItems',
+  'additionalProperties',
+  'contains',
+  'contentSchema',
+  'else',
+  'if',
+  'not',
+  'propertyNames',
+  'then',
+  'unevaluatedItems',
+  'unevaluatedProperties',
+]);
+/** Keywords whose value is an array of subschemas. */
+const SCHEMA_ARRAY_KEYWORDS = new Set(['allOf', 'anyOf', 'oneOf', 'prefixItems']);
+/** Keywords whose value is a map from name to subschema. */
+const SCHEMA_MAP_KEYWORDS = new Set([
+  '$defs',
+  'definitions',
+  'dependentSchemas',
+  'patternProperties',
+  'properties',
+]);
+/** Keywords whose values are instance data, never subschemas. */
+const INSTANCE_VALUE_KEYWORDS = new Set(['const', 'default', 'enum', 'examples']);
+
 /**
  * In-band hint attached to the cycle-break sentinel when lenient mode
  * substitutes it for a dangling `$ref`. Makes the degradation visible to
@@ -272,28 +299,6 @@ export function dereferenceJsonSchema<T = unknown>(
 export function ensureObjectTypeOnProperties<T = unknown>(schema: T): T {
   type WalkMode = 'schema' | 'schema-array' | 'schema-map' | 'dependencies-map' | 'value';
 
-  const schemaKeywords = new Set([
-    'additionalItems',
-    'additionalProperties',
-    'contains',
-    'contentSchema',
-    'else',
-    'if',
-    'not',
-    'propertyNames',
-    'then',
-    'unevaluatedItems',
-    'unevaluatedProperties',
-  ]);
-  const schemaArrayKeywords = new Set(['allOf', 'anyOf', 'oneOf', 'prefixItems']);
-  const schemaMapKeywords = new Set([
-    '$defs',
-    'definitions',
-    'dependentSchemas',
-    'patternProperties',
-    'properties',
-  ]);
-
   function walk(value: unknown, mode: WalkMode, depth = 0): unknown {
     if (depth > MAX_NODE_DEPTH) {
       throw new RangeError(`JSON Schema exceeds maximum nesting depth of ${MAX_NODE_DEPTH}`);
@@ -314,11 +319,11 @@ export function ensureObjectTypeOnProperties<T = unknown>(schema: T): T {
       } else if (mode === 'dependencies-map') {
         childMode = Array.isArray(child) ? 'value' : 'schema';
       } else if (mode === 'schema') {
-        if (schemaMapKeywords.has(key)) {
+        if (SCHEMA_MAP_KEYWORDS.has(key)) {
           childMode = 'schema-map';
-        } else if (schemaArrayKeywords.has(key) || (key === 'items' && Array.isArray(child))) {
+        } else if (SCHEMA_ARRAY_KEYWORDS.has(key) || (key === 'items' && Array.isArray(child))) {
           childMode = 'schema-array';
-        } else if (schemaKeywords.has(key) || key === 'items') {
+        } else if (SCHEMA_KEYWORDS.has(key) || key === 'items') {
           childMode = 'schema';
         } else if (key === 'dependencies') {
           childMode = 'dependencies-map';
@@ -356,7 +361,6 @@ export function ensureObjectTypeOnProperties<T = unknown>(schema: T): T {
 export function deduplicateJsonSchemaRequiredArrays<T = unknown>(schema: T): T {
   const seenSchemaValues = new WeakMap<object, unknown>();
   const seenInstanceValues = new WeakMap<object, unknown>();
-  const instanceValueKeywords = new Set(['const', 'default', 'enum', 'examples']);
 
   function walk(value: unknown, isSchema: boolean, depth = 0): unknown {
     if (depth > MAX_NODE_DEPTH) {
@@ -391,7 +395,7 @@ export function deduplicateJsonSchemaRequiredArrays<T = unknown>(schema: T): T {
         value:
           isSchema && key === 'required' && Array.isArray(child)
             ? [...new Set(walk(child, false, depth + 1) as unknown[])]
-            : walk(child, isSchema && !instanceValueKeywords.has(key), depth + 1),
+            : walk(child, isSchema && !INSTANCE_VALUE_KEYWORDS.has(key), depth + 1),
         writable: true,
       });
     }
@@ -495,4 +499,477 @@ export function jsonSchemaToZodSchema<T extends z.ZodTypeAny>(
       cause: error,
     });
   }
+}
+
+/**
+ * Reason recorded when strict normalization rewrites a schema node. Every
+ * rewrite is lossless: the model can still express the same values.
+ *
+ * - `optional-property-nullable` — a property missing from `required` was
+ *   added to it and widened to accept `null`, the emulation of optional
+ *   fields that OpenAI structured outputs document.
+ * - `unsupported-keyword-stripped` — an annotation keyword the API rejects
+ *   (`default`, `examples`) was removed.
+ * - `one-of-converted` — `oneOf` (unsupported) became `anyOf`.
+ */
+export type StrictSchemaChangeReason =
+  'optional-property-nullable' | 'unsupported-keyword-stripped' | 'one-of-converted';
+
+/** A single lossless rewrite applied by {@link toStrictJsonSchema}. */
+export interface StrictSchemaChange {
+  /** Path to the changed node relative to the root, e.g. `properties.cfg.items`. */
+  path: string;
+  reason: StrictSchemaChangeReason;
+  /** Human-readable detail about what specifically changed. */
+  detail?: string;
+}
+
+/**
+ * A schema construct strict structured outputs cannot express. Rewriting it
+ * would change what the tool accepts, so it is reported instead; providers
+ * send such a tool without strict mode.
+ */
+export interface StrictSchemaIncompatibility {
+  /** Path to the offending node relative to the root. */
+  path: string;
+  /** The keyword (or `$ref`) that has no strict-mode equivalent. */
+  keyword: string;
+  detail: string;
+}
+
+/** Result of {@link toStrictJsonSchema}. */
+export interface StrictJsonSchemaResult {
+  /**
+   * The strict schema. Only usable when `unsupported` is empty; otherwise it
+   * is best-effort and the original schema should be sent without strict mode.
+   */
+  schema: Record<string, unknown>;
+  /**
+   * The input schema the rewrite was computed from. Optionality is decided
+   * against this schema, so it is what `omitNullToolArguments` needs.
+   */
+  source: Record<string, unknown>;
+  /** Lossless rewrites, capped at 50 entries; see `totalChanges`. */
+  changes: StrictSchemaChange[];
+  totalChanges: number;
+  /** Constructs strict mode cannot express. Non-empty means "do not use `schema`". */
+  unsupported: StrictSchemaIncompatibility[];
+}
+
+const MAX_STRICT_CHANGES = 50;
+
+/** Annotation-only keywords OpenAI structured outputs rejects; safe to strip. */
+const STRICT_STRIP_KEYWORDS = new Set(['examples', 'default']);
+
+/** Keywords OpenAI structured outputs reject and that have no lossless rewrite. */
+const STRICT_UNSUPPORTED_KEYWORDS = [
+  'allOf',
+  'prefixItems',
+  'additionalItems',
+  'contains',
+  'dependencies',
+  'dependentSchemas',
+  'else',
+  'if',
+  'not',
+  'propertyNames',
+  'then',
+  'unevaluatedItems',
+  'unevaluatedProperties',
+];
+
+/** Whether a `type` value declares exactly the object type. */
+const isObjectType = (type: unknown): boolean =>
+  type === 'object' || (Array.isArray(type) && type.length === 1 && type[0] === 'object');
+
+type StrictWalkMode = 'schema' | 'schema-array' | 'schema-map' | 'value';
+
+const joinPath = (parent: string, key: string): string => (parent ? `${parent}.${key}` : key);
+
+/**
+ * Sets an own property regardless of its name: a plain assignment to a key
+ * such as `__proto__` would set the prototype instead of storing the value.
+ */
+function setOwn(target: Record<string, unknown>, key: string, value: unknown): void {
+  Object.defineProperty(target, key, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  });
+}
+
+/**
+ * Widens a property schema so that `null` is an accepted value, without
+ * placing `type` beside `anyOf` (the API rejects that combination).
+ */
+function widenToNullable(node: Record<string, unknown>): Record<string, unknown> {
+  if (Array.isArray(node.anyOf)) {
+    const alreadyNullable = node.anyOf.some(
+      branch => isPlainObject(branch) && branch.type === 'null'
+    );
+    return alreadyNullable ? node : { ...node, anyOf: [...node.anyOf, { type: 'null' }] };
+  }
+  if (typeof node.type === 'string') {
+    return node.type === 'null' ? node : { ...node, type: [node.type, 'null'] };
+  }
+  if (Array.isArray(node.type)) {
+    return node.type.includes('null') ? node : { ...node, type: [...node.type, 'null'] };
+  }
+  if ((Array.isArray(node.enum) && node.enum.includes(null)) || node.const === null) return node;
+  // No `type` at all: an empty schema already accepts null; anything else
+  // (enum-only, const, composition) is wrapped so the annotation stays outside.
+  const { description, title, ...rest } = node;
+  if (Object.keys(rest).length === 0) return node;
+  return {
+    ...(description !== undefined ? { description } : {}),
+    ...(title !== undefined ? { title } : {}),
+    anyOf: [rest, { type: 'null' }],
+  };
+}
+
+/**
+ * Follows local `$ref` pointers from `node` until a concrete schema node is
+ * reached. Unresolvable or over-long chains return the last node seen.
+ */
+function resolveLocalRefs(node: unknown, root: Record<string, unknown>): unknown {
+  let current = node;
+  for (let hops = 0; hops < MAX_REF_CHAIN_DEPTH; hops++) {
+    if (!isPlainObject(current) || typeof current.$ref !== 'string') return current;
+    const resolution = tryResolvePointer(root, current.$ref);
+    if (resolution.kind === 'unresolved') return current;
+    current = resolution.value;
+  }
+  return current;
+}
+
+/** Whether a schema node accepts `null` as an instance. */
+function schemaAcceptsNull(schema: unknown, root: Record<string, unknown>): boolean {
+  const node = resolveLocalRefs(schema, root);
+  if (!isPlainObject(node)) return true;
+  if (typeof node.type === 'string') return node.type === 'null';
+  if (Array.isArray(node.type)) return node.type.includes('null');
+  if (Array.isArray(node.enum)) return node.enum.includes(null);
+  if ('const' in node) return node.const === null;
+  for (const keyword of ['anyOf', 'oneOf']) {
+    const branches = node[keyword];
+    if (Array.isArray(branches)) return branches.some(branch => schemaAcceptsNull(branch, root));
+  }
+  return true;
+}
+
+/**
+ * Normalizes a tool parameter schema for OpenAI structured outputs
+ * (`strict: true`) at every depth, following the contract OpenAI documents:
+ *
+ *  - every object lists all of its properties in `required` and sets
+ *    `additionalProperties: false`;
+ *  - properties that were optional stay available and are widened to accept
+ *    `null` (`type: ['string', 'null']`, or an extra `anyOf` branch) — the
+ *    documented way to emulate optional fields. Nothing is dropped, so the
+ *    model keeps every parameter it could pass before. A `null` the model
+ *    sends for such a property means "omitted"; the strict providers drop it
+ *    before executing the tool (see {@link omitNullToolArguments});
+ *  - `type` arrays are kept as-is (the API accepts them); `oneOf` becomes
+ *    `anyOf`; `default` and `examples` are stripped;
+ *  - local `$ref`s into `$defs`/`definitions` are kept (the API supports
+ *    them, including recursion) and the definitions themselves are
+ *    normalized; an optional `$ref` property is widened with an `anyOf`
+ *    null branch;
+ *  - constructs strict mode cannot express — objects that accept arbitrary
+ *    keys (schema-valued or `true` `additionalProperties`, `patternProperties`,
+ *    property-less free-form objects), boolean subschemas, `allOf`,
+ *    `prefixItems`, tuple-form `items`, conditional and dependency keywords,
+ *    external or dangling `$ref`s, and a non-object root — are reported in
+ *    `unsupported` rather than rewritten into something narrower. Callers send
+ *    such a tool without strict mode.
+ *
+ * The input is never mutated. Every rewrite is recorded in `changes` (capped
+ * at 50 entries; `totalChanges` carries the real count), and `required`
+ * arrays are de-duplicated at the end.
+ */
+export function toStrictJsonSchema(schema: unknown): StrictJsonSchemaResult {
+  const changes: StrictSchemaChange[] = [];
+  const unsupported: StrictSchemaIncompatibility[] = [];
+  let totalChanges = 0;
+  const recordChange = (change: StrictSchemaChange): void => {
+    totalChanges += 1;
+    if (changes.length < MAX_STRICT_CHANGES) changes.push(change);
+  };
+
+  const root: Record<string, unknown> = isPlainObject(schema) ? schema : {};
+
+  function walkChildren(
+    node: Record<string, unknown>,
+    mode: StrictWalkMode,
+    depth: number,
+    path: string
+  ): Record<string, unknown> {
+    const clone: Record<string, unknown> = {};
+    for (const [key, child] of Object.entries(node)) {
+      let childMode: StrictWalkMode = 'value';
+      if (mode === 'schema-map') {
+        childMode = 'schema';
+      } else if (mode === 'schema' && !INSTANCE_VALUE_KEYWORDS.has(key)) {
+        if (SCHEMA_MAP_KEYWORDS.has(key)) {
+          childMode = 'schema-map';
+        } else if (SCHEMA_ARRAY_KEYWORDS.has(key) || (key === 'items' && Array.isArray(child))) {
+          childMode = 'schema-array';
+        } else if (SCHEMA_KEYWORDS.has(key) || key === 'items') {
+          childMode = 'schema';
+        }
+      }
+
+      if (childMode === 'schema-map' && isPlainObject(child)) {
+        const mapClone: Record<string, unknown> = {};
+        for (const [name, subSchema] of Object.entries(child)) {
+          setOwn(
+            mapClone,
+            name,
+            walk(subSchema, 'schema', depth + 1, joinPath(joinPath(path, key), name))
+          );
+        }
+        setOwn(clone, key, mapClone);
+        continue;
+      }
+      setOwn(clone, key, walk(child, childMode, depth + 1, joinPath(path, key)));
+    }
+    return clone;
+  }
+
+  function walk(value: unknown, mode: StrictWalkMode, depth: number, path: string): unknown {
+    if (depth > MAX_NODE_DEPTH) {
+      throw new RangeError(`JSON Schema exceeds maximum nesting depth of ${MAX_NODE_DEPTH}`);
+    }
+    if (Array.isArray(value)) {
+      const itemMode = mode === 'schema-array' ? 'schema' : 'value';
+      return value.map((item, index) => walk(item, itemMode, depth + 1, `${path}[${index}]`));
+    }
+    if (!isPlainObject(value) || mode === 'value') return value;
+
+    const node: Record<string, unknown> = {};
+    for (const [key, child] of Object.entries(value)) {
+      if (STRICT_STRIP_KEYWORDS.has(key)) {
+        recordChange({
+          path,
+          reason: 'unsupported-keyword-stripped',
+          detail: `keyword "${key}" removed`,
+        });
+        continue;
+      }
+      setOwn(node, key, child);
+    }
+    if (Array.isArray(node.oneOf) && node.anyOf === undefined) {
+      node.anyOf = node.oneOf;
+      delete node.oneOf;
+      recordChange({ path, reason: 'one-of-converted', detail: 'oneOf became anyOf' });
+    }
+    for (const keyword of STRICT_UNSUPPORTED_KEYWORDS) {
+      if (node[keyword] !== undefined) {
+        unsupported.push({
+          path,
+          keyword,
+          detail: `"${keyword}" has no strict-mode equivalent`,
+        });
+      }
+    }
+    if (node.oneOf !== undefined) {
+      unsupported.push({ path, keyword: 'oneOf', detail: 'oneOf beside anyOf cannot be merged' });
+    }
+    if (Array.isArray(node.items)) {
+      unsupported.push({
+        path,
+        keyword: 'items',
+        detail: 'tuple-form items has no strict-mode equivalent',
+      });
+    } else if (typeof node.items === 'boolean') {
+      unsupported.push({ path, keyword: 'items', detail: 'boolean subschema' });
+    }
+    if (node.properties !== undefined && !isPlainObject(node.properties)) {
+      unsupported.push({ path, keyword: 'properties', detail: 'properties is not an object' });
+    }
+
+    const out = walkChildren(node, mode, depth, path);
+
+    if (typeof node.$ref === 'string') {
+      const resolution = node.$ref.startsWith('#/')
+        ? tryResolvePointer(root, node.$ref)
+        : ({ kind: 'unresolved', reason: 'malformed-pointer' } as const);
+      if (resolution.kind === 'unresolved') {
+        unsupported.push({
+          path,
+          keyword: '$ref',
+          detail: `unresolved $ref "${node.$ref}"`,
+        });
+      }
+      // The referenced definition is normalized where it is declared.
+      return out;
+    }
+
+    const declaresObjectType =
+      out.type === 'object' || (Array.isArray(out.type) && out.type.includes('object'));
+    if (!declaresObjectType && !isPlainObject(out.properties)) return out;
+    if (out.properties !== undefined && !isPlainObject(out.properties)) return out;
+
+    const properties: Record<string, unknown> = {};
+    if (isPlainObject(out.properties)) {
+      for (const [name, propertySchema] of Object.entries(out.properties)) {
+        setOwn(properties, name, propertySchema);
+      }
+    }
+    const declaredRequired = new Set(
+      Array.isArray(out.required) ? out.required.filter(entry => typeof entry === 'string') : []
+    );
+    for (const [name, propertySchema] of Object.entries(properties)) {
+      if (typeof propertySchema === 'boolean') {
+        unsupported.push({
+          path: joinPath(path, `properties.${name}`),
+          keyword: 'properties',
+          detail: 'boolean subschema',
+        });
+        continue;
+      }
+      if (declaredRequired.has(name) || !isPlainObject(propertySchema)) continue;
+      setOwn(properties, name, widenToNullable(propertySchema));
+      recordChange({
+        path: joinPath(path, `properties.${name}`),
+        reason: 'optional-property-nullable',
+        detail: `property "${name}" is now required and accepts null`,
+      });
+    }
+
+    const acceptsDynamicKeys =
+      out.additionalProperties === true || isPlainObject(out.additionalProperties);
+    if (acceptsDynamicKeys) {
+      unsupported.push({
+        path,
+        keyword: 'additionalProperties',
+        detail: 'object accepts arbitrary keys',
+      });
+    } else if (out.patternProperties !== undefined) {
+      unsupported.push({
+        path,
+        keyword: 'patternProperties',
+        detail: 'object accepts pattern-matched keys',
+      });
+    } else if (Object.keys(properties).length === 0 && out.additionalProperties === undefined) {
+      unsupported.push({
+        path,
+        keyword: 'properties',
+        detail: 'free-form object accepts arbitrary keys',
+      });
+    }
+
+    return {
+      ...out,
+      ...(out.type === undefined ? { type: 'object' } : {}),
+      properties,
+      required: Object.keys(properties),
+      ...(acceptsDynamicKeys ? {} : { additionalProperties: false }),
+    };
+  }
+
+  const normalized = walk(root, 'schema', 0, '');
+  if (!isPlainObject(normalized) || !isObjectType(normalized.type)) {
+    unsupported.push({
+      path: '',
+      keyword: 'type',
+      detail: 'root must be a non-nullable object',
+    });
+  }
+
+  return {
+    schema: deduplicateJsonSchemaRequiredArrays(normalized) as Record<string, unknown>,
+    source: root,
+    changes,
+    totalChanges,
+    unsupported,
+  };
+}
+
+/**
+ * Drops `null`-valued arguments that the tool's own schema does not accept,
+ * recursively through nested objects and arrays.
+ *
+ * Strict structured outputs cannot express optional parameters, so
+ * {@link toStrictJsonSchema} makes every parameter required and nullable. The
+ * model then sends `null` for a parameter it would otherwise have omitted;
+ * forwarding that `null` to the tool would fail validation against the tool's
+ * real schema, so it is treated as "omitted". A `null` the original schema
+ * accepts (a nullable field, an explicit "clear this value") is kept.
+ *
+ * @param args - Normalized tool arguments.
+ * @param schema - The dereferenced tool parameter schema the arguments were
+ *   produced for (`StrictJsonSchemaResult.source`).
+ * @returns A new object; the input is not mutated.
+ */
+export function omitNullToolArguments(
+  args: Record<string, unknown>,
+  schema: unknown
+): Record<string, unknown> {
+  const root: Record<string, unknown> = isPlainObject(schema) ? schema : {};
+  return omitNulls(args, root, root, 0) as Record<string, unknown>;
+}
+
+/**
+ * Picks the composition branch that describes a value's shape: the first
+ * branch with `properties` for an object, the first with `items` for an
+ * array. Nodes without a composition are returned as they are.
+ */
+function selectBranchFor(
+  schema: unknown,
+  value: unknown,
+  root: Record<string, unknown>
+): Record<string, unknown> | undefined {
+  const resolved = resolveLocalRefs(schema, root);
+  if (!isPlainObject(resolved)) return undefined;
+  const wanted = Array.isArray(value) ? 'items' : 'properties';
+  const find = (node: unknown, depth: number): Record<string, unknown> | undefined => {
+    const candidate = resolveLocalRefs(node, root);
+    if (!isPlainObject(candidate) || depth > MAX_NODE_DEPTH) return undefined;
+    if (candidate[wanted] !== undefined) return candidate;
+    for (const keyword of ['anyOf', 'oneOf']) {
+      const branches = candidate[keyword];
+      if (!Array.isArray(branches)) continue;
+      for (const branch of branches) {
+        const found = find(branch, depth + 1);
+        if (found) return found;
+      }
+    }
+    return undefined;
+  };
+  return find(resolved, 0) ?? resolved;
+}
+
+function omitNulls(
+  value: unknown,
+  schema: unknown,
+  root: Record<string, unknown>,
+  depth: number
+): unknown {
+  if (depth > MAX_NODE_DEPTH) {
+    throw new RangeError(`Tool arguments exceed maximum nesting depth of ${MAX_NODE_DEPTH}`);
+  }
+  const node = selectBranchFor(schema, value, root);
+  if (Array.isArray(value)) {
+    const items = node && isPlainObject(node.items) ? node.items : undefined;
+    return value.map(item => omitNulls(item, items, root, depth + 1));
+  }
+  if (!isPlainObject(value)) return value;
+
+  const properties = node && isPlainObject(node.properties) ? node.properties : {};
+  const clone: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value)) {
+    const propertySchema = Object.prototype.hasOwnProperty.call(properties, key)
+      ? properties[key]
+      : undefined;
+    if (child === null) {
+      if (propertySchema === undefined || schemaAcceptsNull(propertySchema, root)) {
+        setOwn(clone, key, child);
+      }
+      continue;
+    }
+    setOwn(clone, key, omitNulls(child, propertySchema, root, depth + 1));
+  }
+  return clone;
 }

--- a/ts/packages/core/test/fixtures/json-schema-conversion/corpus.ts
+++ b/ts/packages/core/test/fixtures/json-schema-conversion/corpus.ts
@@ -10,6 +10,7 @@
 import * as z from 'zod';
 
 import corpusDocument from './object-cases.json';
+import strictDocument from './strict-cases.json';
 
 const JsonObject = z.record(z.string(), z.unknown());
 
@@ -83,3 +84,43 @@ export const loadObjectCases = (): ReadonlyArray<CorpusCase> => {
 /** Acceptance for one language: the shared flag unless a declared divergence overrides it. */
 export const acceptedFor = (instance: CorpusInstance, language: CorpusLanguage): boolean =>
   instance[language]?.accepted ?? instance.accepted;
+
+const StrictIncompatibility = z.object({ path: z.string(), keyword: z.string().min(1) });
+const StrictChange = z.object({ path: z.string(), reason: z.string().min(1) });
+const StrictArguments = z.object({ input: JsonObject, output: JsonObject });
+
+/**
+ * One strict-mode normalization case: either the exact strict schema the
+ * rewrite must produce, or the constructs it must report as unsupported.
+ */
+const StrictCase = z.object({
+  id: z.string().min(1),
+  description: z.string().optional(),
+  schema: JsonObject,
+  strict: z.union([
+    z.object({ schema: JsonObject }),
+    z.object({ unsupported: z.array(StrictIncompatibility).min(1) }),
+  ]),
+  changes: z.array(StrictChange).optional(),
+  arguments: z.array(StrictArguments).optional(),
+});
+
+const StrictCorpus = z.object({ cases: z.array(StrictCase).min(1) });
+
+export type StrictCase = z.infer<typeof StrictCase>;
+
+let cachedStrict: ReadonlyArray<StrictCase> | undefined;
+
+/** Decode the shared strict-mode corpus (byte-identical copy per language). */
+export const loadStrictCases = (): ReadonlyArray<StrictCase> => {
+  if (!cachedStrict) {
+    const { cases } = StrictCorpus.parse(strictDocument);
+    const seen = new Set<string>();
+    for (const testCase of cases) {
+      if (seen.has(testCase.id)) throw new Error(`Duplicate strict case id: ${testCase.id}`);
+      seen.add(testCase.id);
+    }
+    cachedStrict = cases;
+  }
+  return cachedStrict;
+};

--- a/ts/packages/core/test/fixtures/json-schema-conversion/generate-strict-cases.mjs
+++ b/ts/packages/core/test/fixtures/json-schema-conversion/generate-strict-cases.mjs
@@ -1,0 +1,551 @@
+/**
+ * Regenerates strict-cases.json (both language copies) from the case inputs
+ * below, using the built @composio/core. Run from the repository root after
+ * `pnpm --filter @composio/core build`:
+ *
+ *   node ts/packages/core/test/fixtures/json-schema-conversion/generate-strict-cases.mjs
+ *
+ * The JSON is the pinned contract; this script only derives it so both SDK
+ * test suites assert against identical expectations. Format the TypeScript
+ * copy with prettier before copying (the pre-commit hook would otherwise
+ * make the copies differ).
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, '../../../../../..');
+const { toStrictJsonSchema, omitNullToolArguments } = await import(
+  path.join(repoRoot, 'ts/packages/core/dist/index.mjs')
+);
+const obj = (properties, required, extra = {}) => ({
+  type: 'object',
+  properties,
+  ...(required ? { required } : {}),
+  ...extra,
+});
+const cases = [
+  [
+    'flat-all-required-unchanged',
+    'An already-strict schema is returned unchanged with no changes.',
+    obj({ query: { type: 'string' } }, ['query'], { additionalProperties: false }),
+  ],
+  [
+    'nested-optional-property-widened',
+    'Optional properties stay, become required and accept null at every depth.',
+    obj(
+      {
+        cfg: obj(
+          { url: { type: 'string' }, note: { type: 'string', description: 'optional note' } },
+          ['url']
+        ),
+      },
+      ['cfg']
+    ),
+  ],
+  [
+    'no-required-array-widens-every-property',
+    'An object without `required` requires and widens every property.',
+    obj({ a: { type: 'string' }, b: { type: 'number' } }),
+  ],
+  [
+    'required-empty-array-widens-every-property',
+    'An empty `required` array is the same as an absent one.',
+    obj({ a: { type: 'string' } }, []),
+  ],
+  [
+    'nullable-type-array-kept',
+    'A `type` array with null is accepted by the API and left alone.',
+    obj({ id: { type: ['string', 'null'], description: 'identifier' } }, ['id']),
+  ],
+  [
+    'nullable-object-stays-nullable',
+    'A nullable object keeps its type array; only its own properties are closed.',
+    obj(
+      { cfg: { type: ['object', 'null'], properties: { a: { type: 'string' } }, required: ['a'] } },
+      ['cfg']
+    ),
+  ],
+  [
+    'nullable-array-kept',
+    'A nullable array keeps its type array and items.',
+    obj({ xs: { type: ['array', 'null'], items: { type: 'string' } } }, ['xs']),
+  ],
+  [
+    'optional-any-of-gets-null-branch',
+    'An optional composition gains a null branch instead of a sibling type.',
+    obj({ value: { anyOf: [{ type: 'string' }, { type: 'number' }] } }),
+  ],
+  [
+    'any-of-already-nullable-unchanged',
+    'A composition that already accepts null is not widened twice.',
+    obj({ value: { anyOf: [{ type: 'string' }, { type: 'null' }] } }),
+  ],
+  [
+    'optional-enum-only-wrapped',
+    'An enum-only property is wrapped so the annotation stays outside the anyOf.',
+    obj({ choice: { enum: ['a', 'b'], description: 'pick one', title: 'Choice' } }),
+  ],
+  [
+    'optional-const-wrapped',
+    'A const-only property is wrapped in an anyOf with a null branch.',
+    obj({ kind: { const: 'fixed' } }),
+  ],
+  [
+    'optional-empty-schema-unchanged',
+    'An empty schema already accepts null and is left alone.',
+    obj({ anything: {} }),
+  ],
+  [
+    'multi-type-array-gains-null',
+    'A multi-type array gains null instead of being converted to anyOf.',
+    obj({ value: { type: ['string', 'number'] } }),
+  ],
+  [
+    'one-of-converted-to-any-of',
+    'oneOf is unsupported and becomes anyOf.',
+    obj({ either: { oneOf: [{ type: 'string' }, { type: 'number' }] } }, ['either']),
+  ],
+  [
+    'array-items-object-normalized',
+    'Objects inside array items are closed and widened.',
+    obj(
+      {
+        rows: {
+          type: 'array',
+          items: obj({ id: { type: 'string' }, tag: { type: 'string' } }, ['id']),
+        },
+      },
+      ['rows']
+    ),
+  ],
+  [
+    'default-and-examples-stripped',
+    'Annotation keywords the API rejects are stripped and reported.',
+    obj({ name: { type: 'string', examples: ['a'], default: 'x' } }, ['name']),
+  ],
+  [
+    'enum-values-are-data-not-keywords',
+    'Keys inside enum/const values are data and must not be treated as keywords.',
+    obj({ opts: { enum: [{ default: 1, properties: {} }, null] } }, ['opts']),
+  ],
+  [
+    'property-names-are-not-keywords',
+    'Properties named like keywords are ordinary properties.',
+    obj({
+      default: { type: 'string' },
+      $ref: { type: 'string' },
+      type: { type: 'string' },
+      properties: obj({ x: { type: 'string' } }),
+    }),
+  ],
+  [
+    'prototype-key-property-name',
+    'A property named __proto__ or constructor is handled as a plain name.',
+    JSON.parse(
+      '{"type":"object","properties":{"__proto__":{"type":"string"},"constructor":{"type":"number"}}}'
+    ),
+  ],
+  [
+    'schema-valued-additional-properties-unsupported',
+    'A map-style object cannot be expressed and is reported, not closed.',
+    obj({ headers: { type: 'object', additionalProperties: { type: 'string' } } }, ['headers']),
+  ],
+  [
+    'additional-properties-true-unsupported',
+    'An explicitly open object is reported.',
+    obj({ open: { type: 'object', additionalProperties: true } }, ['open']),
+  ],
+  [
+    'additional-properties-empty-schema-unsupported',
+    'An empty-schema additionalProperties accepts anything and is reported.',
+    obj({ open: { type: 'object', additionalProperties: {} } }, ['open']),
+  ],
+  [
+    'free-form-object-unsupported',
+    'A property-less object accepts arbitrary keys and is reported.',
+    obj({ meta: { type: 'object', description: 'any json' } }, ['meta']),
+  ],
+  [
+    'pattern-properties-unsupported',
+    'patternProperties cannot be expressed and is reported.',
+    obj({ tagged: { type: 'object', patternProperties: { '^x-': { type: 'string' } } } }, [
+      'tagged',
+    ]),
+  ],
+  [
+    'empty-closed-object-representable',
+    'An object closed with no properties is representable.',
+    obj({ empty: { type: 'object', additionalProperties: false } }, ['empty']),
+  ],
+  [
+    'all-of-unsupported',
+    'allOf has no lossless rewrite and is reported.',
+    obj({ all: { allOf: [{ type: 'string' }] } }, ['all']),
+  ],
+  [
+    'prefix-items-unsupported',
+    'prefixItems has no lossless rewrite and is reported.',
+    obj({ pair: { type: 'array', prefixItems: [{ type: 'number' }] } }, ['pair']),
+  ],
+  [
+    'defs-ref-kept-and-definition-normalized',
+    'Local $refs are kept and the definition is normalized where it is declared.',
+    obj({ cfg: { $ref: '#/$defs/Config' } }, ['cfg'], {
+      $defs: { Config: obj({ url: { type: 'string' }, note: { type: 'string' } }, ['url']) },
+    }),
+  ],
+  [
+    'optional-ref-widened-with-null-branch',
+    'An optional $ref property is widened with an anyOf null branch.',
+    obj({ cfg: { $ref: '#/$defs/Config', description: 'optional' } }, undefined, {
+      $defs: { Config: obj({ url: { type: 'string' } }, ['url']) },
+    }),
+  ],
+  [
+    'recursive-defs-kept',
+    'Self-recursive definitions are representable.',
+    obj({ node: { $ref: '#/$defs/Node' } }, ['node'], {
+      $defs: {
+        Node: obj({ child: { $ref: '#/$defs/Node' }, label: { type: 'string' } }, ['label']),
+      },
+    }),
+  ],
+  [
+    'mutually-recursive-defs-kept',
+    'Mutually recursive definitions are representable.',
+    obj({ a: { $ref: '#/$defs/A' } }, ['a'], {
+      $defs: { A: obj({ b: { $ref: '#/$defs/B' } }), B: obj({ a: { $ref: '#/$defs/A' } }) },
+    }),
+  ],
+  [
+    'legacy-definitions-ref-kept',
+    'Legacy definitions are supported like $defs.',
+    obj({ cfg: { $ref: '#/definitions/Config' } }, ['cfg'], {
+      definitions: { Config: obj({ url: { type: 'string' } }) },
+    }),
+  ],
+  [
+    'ref-into-properties-kept',
+    'A local $ref outside $defs resolves and is kept.',
+    obj({ a: obj({ x: { type: 'string' } }, ['x']), b: { $ref: '#/properties/a' } }, ['a', 'b']),
+  ],
+  [
+    'dangling-ref-unsupported',
+    'A $ref without a target is reported at its own path.',
+    obj({ cfg: { $ref: '#/$defs/Nope' } }, ['cfg']),
+  ],
+  [
+    'external-ref-unsupported',
+    'A $ref outside the document is reported.',
+    obj({ cfg: { $ref: 'https://example.com/schema.json' } }, ['cfg']),
+  ],
+  [
+    'duplicate-required-deduped',
+    'Duplicate required entries are removed.',
+    obj({ a: { type: 'string' } }, ['a', 'a']),
+  ],
+  [
+    'required-unknown-names-dropped',
+    'Required names without a property are dropped from required.',
+    obj({ a: { type: 'string' } }, ['a', 'ghost']),
+  ],
+  [
+    'required-not-an-array-ignored',
+    'A malformed required is treated as absent.',
+    obj({ a: { type: 'string' } }, 'a'),
+  ],
+  [
+    'description-kept-on-widened-node',
+    'Annotations survive widening.',
+    obj({ a: { type: 'integer', description: 'count', title: 'Count', minimum: 0 } }),
+  ],
+  ['non-object-root-unsupported', 'The root must be an object.', { type: 'string' }],
+  [
+    'nullable-root-unsupported',
+    'The root must not be nullable.',
+    { type: ['object', 'null'], properties: { a: { type: 'string' } } },
+  ],
+  [
+    'properties-without-type-become-object',
+    'A node with properties but no type is treated as an object.',
+    obj({ cfg: { properties: { a: { type: 'string' } } } }, ['cfg']),
+  ],
+  [
+    'root-without-type-become-object',
+    'A root with properties but no type is treated as an object.',
+    { properties: { a: { type: 'string' } } },
+  ],
+  // Edge cases enumerated independently with a second model.
+  [
+    'root-single-element-type-array-accepted',
+    'A root typed ["object"] is an object root.',
+    { type: ['object'], properties: { a: { type: 'string' } }, required: ['a'] },
+  ],
+  [
+    'three-member-type-array-gains-null',
+    'A three-member type array gains null once.',
+    obj({ v: { type: ['string', 'number', 'boolean'] } }),
+  ],
+  [
+    'optional-null-only-property-unchanged',
+    'A property typed null already accepts null.',
+    obj({ nothing: { type: 'null' } }),
+  ],
+  [
+    'optional-enum-with-null-not-rewrapped',
+    'An enum that already lists null is not wrapped again.',
+    obj({ choice: { enum: ['a', null] } }),
+  ],
+  [
+    'optional-const-null-not-rewrapped',
+    'A const null already accepts null.',
+    obj({ nothing: { const: null } }),
+  ],
+  [
+    'nested-any-of-branch-widened',
+    'Optional properties inside anyOf branches are widened.',
+    obj({ v: { anyOf: [obj({ a: { type: 'string' } }), { type: 'string' }] } }, ['v']),
+  ],
+  [
+    'array-of-nullable-objects-closed',
+    'Nullable objects inside array items are closed and stay nullable.',
+    obj(
+      {
+        rows: {
+          type: 'array',
+          items: { type: ['object', 'null'], properties: { id: { type: 'string' } } },
+        },
+      },
+      ['rows']
+    ),
+  ],
+  [
+    'tuple-form-items-unsupported',
+    'Draft-4 tuple items have no strict-mode equivalent.',
+    obj({ pair: { type: 'array', items: [{ type: 'number' }, { type: 'string' }] } }, ['pair']),
+  ],
+  [
+    'boolean-items-unsupported',
+    'A boolean items subschema is reported.',
+    obj({ xs: { type: 'array', items: true } }, ['xs']),
+  ],
+  [
+    'not-keyword-unsupported',
+    'not has no strict-mode equivalent.',
+    obj({ v: { not: { type: 'string' } } }, ['v']),
+  ],
+  [
+    'if-then-else-unsupported',
+    'Conditional keywords have no strict-mode equivalent.',
+    obj(
+      { v: { type: 'string', if: { minLength: 1 }, then: { maxLength: 5 }, else: { const: '' } } },
+      ['v']
+    ),
+  ],
+  [
+    'dependent-schemas-unsupported',
+    'dependentSchemas has no strict-mode equivalent.',
+    obj({ a: { type: 'string' } }, ['a'], {
+      dependentSchemas: { a: obj({ b: { type: 'string' } }) },
+    }),
+  ],
+  [
+    'property-names-keyword-unsupported',
+    'propertyNames has no strict-mode equivalent.',
+    obj({ a: { type: 'string' } }, ['a'], { propertyNames: { pattern: '^a' } }),
+  ],
+  [
+    'one-of-beside-any-of-unsupported',
+    'oneOf next to anyOf cannot be merged and is reported.',
+    obj({ v: { anyOf: [{ type: 'string' }], oneOf: [{ type: 'number' }] } }, ['v']),
+  ],
+  [
+    'boolean-property-subschema-unsupported',
+    'A boolean property subschema is reported.',
+    obj({ anything: true, nothing: false }, ['anything', 'nothing']),
+  ],
+  [
+    'properties-not-an-object-unsupported',
+    'A malformed properties value is reported instead of emptied.',
+    obj('not-a-map', ['a']),
+  ],
+  [
+    'ref-with-siblings-kept',
+    'Sibling keywords next to a $ref are kept.',
+    obj({ cfg: { $ref: '#/$defs/Config', description: 'cfg', title: 'Config' } }, ['cfg'], {
+      $defs: { Config: obj({ a: { type: 'string' } }, ['a']) },
+    }),
+  ],
+  [
+    'required-non-string-entries-ignored',
+    'Non-string required entries are ignored.',
+    obj({ a: { type: 'string' }, b: { type: 'string' } }, ['a', 1, null]),
+  ],
+  [
+    'dynamic-keys-reported-once-with-pattern-properties',
+    'additionalProperties and patternProperties on one node report additionalProperties.',
+    obj(
+      {
+        m: {
+          type: 'object',
+          additionalProperties: { type: 'string' },
+          patternProperties: { '^x': { type: 'string' } },
+        },
+      },
+      ['m']
+    ),
+  ],
+  [
+    'empty-properties-open-object-unsupported',
+    'An object with empty properties and no closing is free-form.',
+    obj({ m: { type: 'object', properties: {} } }, ['m']),
+  ],
+  [
+    'default-stripped-then-widened',
+    'Stripping default and widening compose.',
+    obj({ a: { type: 'string', default: 'x' } }),
+  ],
+  [
+    'nested-any-of-in-any-of-kept',
+    'A composition nested inside a composition is normalized branch by branch.',
+    obj(
+      {
+        v: {
+          anyOf: [
+            { anyOf: [obj({ a: { type: 'string' } }), { type: 'number' }] },
+            { type: 'string' },
+          ],
+        },
+      },
+      ['v']
+    ),
+  ],
+  [
+    'definitions-and-defs-both-normalized',
+    'Legacy definitions and $defs coexist and both are normalized.',
+    obj({ a: { $ref: '#/$defs/A' }, b: { $ref: '#/definitions/B' } }, ['a', 'b'], {
+      $defs: { A: obj({ x: { type: 'string' } }) },
+      definitions: { B: obj({ y: { type: 'string' } }) },
+    }),
+  ],
+  [
+    'deep-nesting-normalized-fully',
+    'Ten levels of nested objects are normalized at every level.',
+    (() => {
+      let node = { type: 'object', properties: { leaf: { type: 'string' } } };
+      for (let i = 0; i < 10; i++)
+        node = { type: 'object', properties: { child: node }, required: ['child'] };
+      return node;
+    })(),
+  ],
+  [
+    'chained-refs-resolved',
+    'A $ref to a $ref resolves to the final definition.',
+    obj({ a: { $ref: '#/$defs/Alias' } }, ['a'], {
+      $defs: { Alias: { $ref: '#/$defs/Real' }, Real: obj({ x: { type: 'string' } }, ['x']) },
+    }),
+  ],
+];
+const argumentCases = {
+  'nested-optional-property-widened': [
+    { input: { cfg: { url: 'u', note: null } }, output: { cfg: { url: 'u' } } },
+  ],
+  'nullable-type-array-kept': [{ input: { id: null }, output: { id: null } }],
+  'nullable-object-stays-nullable': [
+    { input: { cfg: null }, output: { cfg: null } },
+    { input: { cfg: { a: 'x' } }, output: { cfg: { a: 'x' } } },
+  ],
+  'any-of-already-nullable-unchanged': [{ input: { value: null }, output: { value: null } }],
+  'optional-enum-only-wrapped': [{ input: { choice: null }, output: {} }],
+  'array-items-object-normalized': [
+    { input: { rows: [{ id: '1', tag: null }, null] }, output: { rows: [{ id: '1' }, null] } },
+  ],
+  'enum-values-are-data-not-keywords': [{ input: { opts: null }, output: { opts: null } }],
+  'property-names-are-not-keywords': [
+    {
+      input: { default: null, $ref: 'x', type: null, properties: { x: null } },
+      output: { $ref: 'x', properties: {} },
+    },
+  ],
+  'defs-ref-kept-and-definition-normalized': [
+    { input: { cfg: { url: 'u', note: null } }, output: { cfg: { url: 'u' } } },
+  ],
+  'optional-ref-widened-with-null-branch': [{ input: { cfg: null }, output: {} }],
+  'recursive-defs-kept': [
+    {
+      input: { node: { label: 'a', child: { label: 'b', child: null } } },
+      output: { node: { label: 'a', child: { label: 'b' } } },
+    },
+  ],
+  'no-required-array-widens-every-property': [
+    { input: { a: null, b: 1, unknown: null }, output: { b: 1, unknown: null } },
+  ],
+  'optional-null-only-property-unchanged': [
+    { input: { nothing: null }, output: { nothing: null } },
+  ],
+  'optional-enum-with-null-not-rewrapped': [{ input: { choice: null }, output: { choice: null } }],
+  'optional-const-null-not-rewrapped': [{ input: { nothing: null }, output: { nothing: null } }],
+  'array-of-nullable-objects-closed': [
+    { input: { rows: [null, { id: null }] }, output: { rows: [null, {}] } },
+  ],
+  'nested-any-of-branch-widened': [
+    { input: { v: { a: null } }, output: { v: {} } },
+    { input: { v: null }, output: {} },
+  ],
+  'nested-any-of-in-any-of-kept': [{ input: { v: { a: null } }, output: { v: {} } }],
+  'chained-refs-resolved': [
+    { input: { a: { x: null } }, output: { a: {} } },
+    { input: { a: null }, output: {} },
+  ],
+  'nullable-array-kept': [
+    { input: { xs: null }, output: { xs: null } },
+    { input: { xs: [null] }, output: { xs: [null] } },
+  ],
+  'nested-optional-property-widened': [
+    { input: { cfg: { url: 'u', note: null } }, output: { cfg: { url: 'u' } } },
+    { input: { cfg: null }, output: {} },
+    { input: { cfg: { url: 'u', extra: null } }, output: { cfg: { url: 'u', extra: null } } },
+  ],
+};
+const out = { cases: [] };
+for (const [id, description, schema] of cases) {
+  const snapshot = JSON.stringify(schema);
+  const r = toStrictJsonSchema(schema);
+  if (JSON.stringify(schema) !== snapshot) throw new Error(`mutated: ${id}`);
+  const entry = { id, description, schema };
+  if (r.unsupported.length)
+    entry.strict = { unsupported: r.unsupported.map(u => ({ path: u.path, keyword: u.keyword })) };
+  else {
+    const again = toStrictJsonSchema(r.schema);
+    if (JSON.stringify(again.schema) !== JSON.stringify(r.schema) || again.changes.length)
+      throw new Error(`not idempotent: ${id}`);
+    entry.strict = { schema: r.schema };
+  }
+  if (r.changes.length) entry.changes = r.changes.map(c => ({ path: c.path, reason: c.reason }));
+  if (argumentCases[id]) {
+    entry.arguments = argumentCases[id].map(({ input, output }) => {
+      const actual = omitNullToolArguments(input, r.source);
+      if (JSON.stringify(actual) !== JSON.stringify(output))
+        throw new Error(
+          `arguments mismatch ${id}: ${JSON.stringify(actual)} vs ${JSON.stringify(output)}`
+        );
+      return { input, output };
+    });
+  }
+  out.cases.push(entry);
+}
+const json = JSON.stringify(out, null, 2) + '\n';
+fs.writeFileSync(path.join(here, 'strict-cases.json'), json);
+fs.writeFileSync(
+  path.join(repoRoot, 'python/tests/fixtures/json-schema-conversion/strict-cases.json'),
+  json
+);
+for (const c of out.cases)
+  console.log(
+    c.id.padEnd(50),
+    c.strict.unsupported
+      ? 'UNSUPPORTED ' + JSON.stringify(c.strict.unsupported)
+      : 'ok' + (c.changes ? ' changes=' + c.changes.map(x => x.reason.split('-')[0]).join(',') : '')
+  );

--- a/ts/packages/core/test/fixtures/json-schema-conversion/strict-cases.json
+++ b/ts/packages/core/test/fixtures/json-schema-conversion/strict-cases.json
@@ -1,0 +1,2947 @@
+{
+  "cases": [
+    {
+      "id": "flat-all-required-unchanged",
+      "description": "An already-strict schema is returned unchanged with no changes.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string"
+          }
+        },
+        "required": ["query"],
+        "additionalProperties": false
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string"
+            }
+          },
+          "required": ["query"],
+          "additionalProperties": false
+        }
+      }
+    },
+    {
+      "id": "nested-optional-property-widened",
+      "description": "Optional properties stay, become required and accept null at every depth.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "cfg": {
+            "type": "object",
+            "properties": {
+              "url": {
+                "type": "string"
+              },
+              "note": {
+                "type": "string",
+                "description": "optional note"
+              }
+            },
+            "required": ["url"]
+          }
+        },
+        "required": ["cfg"]
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "cfg": {
+              "type": "object",
+              "properties": {
+                "url": {
+                  "type": "string"
+                },
+                "note": {
+                  "type": ["string", "null"],
+                  "description": "optional note"
+                }
+              },
+              "required": ["url", "note"],
+              "additionalProperties": false
+            }
+          },
+          "required": ["cfg"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.cfg.properties.note",
+          "reason": "optional-property-nullable"
+        }
+      ],
+      "arguments": [
+        {
+          "input": {
+            "cfg": {
+              "url": "u",
+              "note": null
+            }
+          },
+          "output": {
+            "cfg": {
+              "url": "u"
+            }
+          }
+        },
+        {
+          "input": {
+            "cfg": null
+          },
+          "output": {}
+        },
+        {
+          "input": {
+            "cfg": {
+              "url": "u",
+              "extra": null
+            }
+          },
+          "output": {
+            "cfg": {
+              "url": "u",
+              "extra": null
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "no-required-array-widens-every-property",
+      "description": "An object without `required` requires and widens every property.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "a": {
+            "type": "string"
+          },
+          "b": {
+            "type": "number"
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "a": {
+              "type": ["string", "null"]
+            },
+            "b": {
+              "type": ["number", "null"]
+            }
+          },
+          "required": ["a", "b"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.a",
+          "reason": "optional-property-nullable"
+        },
+        {
+          "path": "properties.b",
+          "reason": "optional-property-nullable"
+        }
+      ],
+      "arguments": [
+        {
+          "input": {
+            "a": null,
+            "b": 1,
+            "unknown": null
+          },
+          "output": {
+            "b": 1,
+            "unknown": null
+          }
+        }
+      ]
+    },
+    {
+      "id": "required-empty-array-widens-every-property",
+      "description": "An empty `required` array is the same as an absent one.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "a": {
+            "type": "string"
+          }
+        },
+        "required": []
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "a": {
+              "type": ["string", "null"]
+            }
+          },
+          "required": ["a"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.a",
+          "reason": "optional-property-nullable"
+        }
+      ]
+    },
+    {
+      "id": "nullable-type-array-kept",
+      "description": "A `type` array with null is accepted by the API and left alone.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": ["string", "null"],
+            "description": "identifier"
+          }
+        },
+        "required": ["id"]
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": ["string", "null"],
+              "description": "identifier"
+            }
+          },
+          "required": ["id"],
+          "additionalProperties": false
+        }
+      },
+      "arguments": [
+        {
+          "input": {
+            "id": null
+          },
+          "output": {
+            "id": null
+          }
+        }
+      ]
+    },
+    {
+      "id": "nullable-object-stays-nullable",
+      "description": "A nullable object keeps its type array; only its own properties are closed.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "cfg": {
+            "type": ["object", "null"],
+            "properties": {
+              "a": {
+                "type": "string"
+              }
+            },
+            "required": ["a"]
+          }
+        },
+        "required": ["cfg"]
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "cfg": {
+              "type": ["object", "null"],
+              "properties": {
+                "a": {
+                  "type": "string"
+                }
+              },
+              "required": ["a"],
+              "additionalProperties": false
+            }
+          },
+          "required": ["cfg"],
+          "additionalProperties": false
+        }
+      },
+      "arguments": [
+        {
+          "input": {
+            "cfg": null
+          },
+          "output": {
+            "cfg": null
+          }
+        },
+        {
+          "input": {
+            "cfg": {
+              "a": "x"
+            }
+          },
+          "output": {
+            "cfg": {
+              "a": "x"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "nullable-array-kept",
+      "description": "A nullable array keeps its type array and items.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "xs": {
+            "type": ["array", "null"],
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": ["xs"]
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "xs": {
+              "type": ["array", "null"],
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "required": ["xs"],
+          "additionalProperties": false
+        }
+      },
+      "arguments": [
+        {
+          "input": {
+            "xs": null
+          },
+          "output": {
+            "xs": null
+          }
+        },
+        {
+          "input": {
+            "xs": [null]
+          },
+          "output": {
+            "xs": [null]
+          }
+        }
+      ]
+    },
+    {
+      "id": "optional-any-of-gets-null-branch",
+      "description": "An optional composition gains a null branch instead of a sibling type.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": ["value"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.value",
+          "reason": "optional-property-nullable"
+        }
+      ]
+    },
+    {
+      "id": "any-of-already-nullable-unchanged",
+      "description": "A composition that already accepts null is not widened twice.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": ["value"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.value",
+          "reason": "optional-property-nullable"
+        }
+      ],
+      "arguments": [
+        {
+          "input": {
+            "value": null
+          },
+          "output": {
+            "value": null
+          }
+        }
+      ]
+    },
+    {
+      "id": "optional-enum-only-wrapped",
+      "description": "An enum-only property is wrapped so the annotation stays outside the anyOf.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "choice": {
+            "enum": ["a", "b"],
+            "description": "pick one",
+            "title": "Choice"
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "choice": {
+              "description": "pick one",
+              "title": "Choice",
+              "anyOf": [
+                {
+                  "enum": ["a", "b"]
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": ["choice"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.choice",
+          "reason": "optional-property-nullable"
+        }
+      ],
+      "arguments": [
+        {
+          "input": {
+            "choice": null
+          },
+          "output": {}
+        }
+      ]
+    },
+    {
+      "id": "optional-const-wrapped",
+      "description": "A const-only property is wrapped in an anyOf with a null branch.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "const": "fixed"
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "anyOf": [
+                {
+                  "const": "fixed"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": ["kind"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.kind",
+          "reason": "optional-property-nullable"
+        }
+      ]
+    },
+    {
+      "id": "optional-empty-schema-unchanged",
+      "description": "An empty schema already accepts null and is left alone.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "anything": {}
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "anything": {}
+          },
+          "required": ["anything"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.anything",
+          "reason": "optional-property-nullable"
+        }
+      ]
+    },
+    {
+      "id": "multi-type-array-gains-null",
+      "description": "A multi-type array gains null instead of being converted to anyOf.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": ["string", "number"]
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "type": ["string", "number", "null"]
+            }
+          },
+          "required": ["value"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.value",
+          "reason": "optional-property-nullable"
+        }
+      ]
+    },
+    {
+      "id": "one-of-converted-to-any-of",
+      "description": "oneOf is unsupported and becomes anyOf.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "either": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
+          }
+        },
+        "required": ["either"]
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "either": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                }
+              ]
+            }
+          },
+          "required": ["either"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.either",
+          "reason": "one-of-converted"
+        }
+      ]
+    },
+    {
+      "id": "array-items-object-normalized",
+      "description": "Objects inside array items are closed and widened.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "rows": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "tag": {
+                  "type": "string"
+                }
+              },
+              "required": ["id"]
+            }
+          }
+        },
+        "required": ["rows"]
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "rows": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "tag": {
+                    "type": ["string", "null"]
+                  }
+                },
+                "required": ["id", "tag"],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": ["rows"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.rows.items.properties.tag",
+          "reason": "optional-property-nullable"
+        }
+      ],
+      "arguments": [
+        {
+          "input": {
+            "rows": [
+              {
+                "id": "1",
+                "tag": null
+              },
+              null
+            ]
+          },
+          "output": {
+            "rows": [
+              {
+                "id": "1"
+              },
+              null
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "default-and-examples-stripped",
+      "description": "Annotation keywords the API rejects are stripped and reported.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "examples": ["a"],
+            "default": "x"
+          }
+        },
+        "required": ["name"]
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": ["name"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.name",
+          "reason": "unsupported-keyword-stripped"
+        },
+        {
+          "path": "properties.name",
+          "reason": "unsupported-keyword-stripped"
+        }
+      ]
+    },
+    {
+      "id": "enum-values-are-data-not-keywords",
+      "description": "Keys inside enum/const values are data and must not be treated as keywords.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "opts": {
+            "enum": [
+              {
+                "default": 1,
+                "properties": {}
+              },
+              null
+            ]
+          }
+        },
+        "required": ["opts"]
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "opts": {
+              "enum": [
+                {
+                  "default": 1,
+                  "properties": {}
+                },
+                null
+              ]
+            }
+          },
+          "required": ["opts"],
+          "additionalProperties": false
+        }
+      },
+      "arguments": [
+        {
+          "input": {
+            "opts": null
+          },
+          "output": {
+            "opts": null
+          }
+        }
+      ]
+    },
+    {
+      "id": "property-names-are-not-keywords",
+      "description": "Properties named like keywords are ordinary properties.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "default": {
+            "type": "string"
+          },
+          "$ref": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "x": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "default": {
+              "type": ["string", "null"]
+            },
+            "$ref": {
+              "type": ["string", "null"]
+            },
+            "type": {
+              "type": ["string", "null"]
+            },
+            "properties": {
+              "type": ["object", "null"],
+              "properties": {
+                "x": {
+                  "type": ["string", "null"]
+                }
+              },
+              "required": ["x"],
+              "additionalProperties": false
+            }
+          },
+          "required": ["default", "$ref", "type", "properties"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.properties.properties.x",
+          "reason": "optional-property-nullable"
+        },
+        {
+          "path": "properties.default",
+          "reason": "optional-property-nullable"
+        },
+        {
+          "path": "properties.$ref",
+          "reason": "optional-property-nullable"
+        },
+        {
+          "path": "properties.type",
+          "reason": "optional-property-nullable"
+        },
+        {
+          "path": "properties.properties",
+          "reason": "optional-property-nullable"
+        }
+      ],
+      "arguments": [
+        {
+          "input": {
+            "default": null,
+            "$ref": "x",
+            "type": null,
+            "properties": {
+              "x": null
+            }
+          },
+          "output": {
+            "$ref": "x",
+            "properties": {}
+          }
+        }
+      ]
+    },
+    {
+      "id": "prototype-key-property-name",
+      "description": "A property named __proto__ or constructor is handled as a plain name.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "__proto__": {
+            "type": "string"
+          },
+          "constructor": {
+            "type": "number"
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "__proto__": {
+              "type": ["string", "null"]
+            },
+            "constructor": {
+              "type": ["number", "null"]
+            }
+          },
+          "required": ["__proto__", "constructor"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.__proto__",
+          "reason": "optional-property-nullable"
+        },
+        {
+          "path": "properties.constructor",
+          "reason": "optional-property-nullable"
+        }
+      ]
+    },
+    {
+      "id": "schema-valued-additional-properties-unsupported",
+      "description": "A map-style object cannot be expressed and is reported, not closed.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "headers": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        },
+        "required": ["headers"]
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "properties.headers",
+            "keyword": "additionalProperties"
+          }
+        ]
+      }
+    },
+    {
+      "id": "additional-properties-true-unsupported",
+      "description": "An explicitly open object is reported.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "open": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "required": ["open"]
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "properties.open",
+            "keyword": "additionalProperties"
+          }
+        ]
+      }
+    },
+    {
+      "id": "additional-properties-empty-schema-unsupported",
+      "description": "An empty-schema additionalProperties accepts anything and is reported.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "open": {
+            "type": "object",
+            "additionalProperties": {}
+          }
+        },
+        "required": ["open"]
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "properties.open",
+            "keyword": "additionalProperties"
+          }
+        ]
+      }
+    },
+    {
+      "id": "free-form-object-unsupported",
+      "description": "A property-less object accepts arbitrary keys and is reported.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "type": "object",
+            "description": "any json"
+          }
+        },
+        "required": ["meta"]
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "properties.meta",
+            "keyword": "properties"
+          }
+        ]
+      }
+    },
+    {
+      "id": "pattern-properties-unsupported",
+      "description": "patternProperties cannot be expressed and is reported.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "tagged": {
+            "type": "object",
+            "patternProperties": {
+              "^x-": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "required": ["tagged"]
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "properties.tagged",
+            "keyword": "patternProperties"
+          }
+        ]
+      }
+    },
+    {
+      "id": "empty-closed-object-representable",
+      "description": "An object closed with no properties is representable.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "empty": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "required": ["empty"]
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "empty": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {},
+              "required": []
+            }
+          },
+          "required": ["empty"],
+          "additionalProperties": false
+        }
+      }
+    },
+    {
+      "id": "all-of-unsupported",
+      "description": "allOf has no lossless rewrite and is reported.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "all": {
+            "allOf": [
+              {
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "required": ["all"]
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "properties.all",
+            "keyword": "allOf"
+          }
+        ]
+      }
+    },
+    {
+      "id": "prefix-items-unsupported",
+      "description": "prefixItems has no lossless rewrite and is reported.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "pair": {
+            "type": "array",
+            "prefixItems": [
+              {
+                "type": "number"
+              }
+            ]
+          }
+        },
+        "required": ["pair"]
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "properties.pair",
+            "keyword": "prefixItems"
+          }
+        ]
+      }
+    },
+    {
+      "id": "defs-ref-kept-and-definition-normalized",
+      "description": "Local $refs are kept and the definition is normalized where it is declared.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "cfg": {
+            "$ref": "#/$defs/Config"
+          }
+        },
+        "required": ["cfg"],
+        "$defs": {
+          "Config": {
+            "type": "object",
+            "properties": {
+              "url": {
+                "type": "string"
+              },
+              "note": {
+                "type": "string"
+              }
+            },
+            "required": ["url"]
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "cfg": {
+              "$ref": "#/$defs/Config"
+            }
+          },
+          "required": ["cfg"],
+          "$defs": {
+            "Config": {
+              "type": "object",
+              "properties": {
+                "url": {
+                  "type": "string"
+                },
+                "note": {
+                  "type": ["string", "null"]
+                }
+              },
+              "required": ["url", "note"],
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "$defs.Config.properties.note",
+          "reason": "optional-property-nullable"
+        }
+      ],
+      "arguments": [
+        {
+          "input": {
+            "cfg": {
+              "url": "u",
+              "note": null
+            }
+          },
+          "output": {
+            "cfg": {
+              "url": "u"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "optional-ref-widened-with-null-branch",
+      "description": "An optional $ref property is widened with an anyOf null branch.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "cfg": {
+            "$ref": "#/$defs/Config",
+            "description": "optional"
+          }
+        },
+        "$defs": {
+          "Config": {
+            "type": "object",
+            "properties": {
+              "url": {
+                "type": "string"
+              }
+            },
+            "required": ["url"]
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "cfg": {
+              "description": "optional",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Config"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "$defs": {
+            "Config": {
+              "type": "object",
+              "properties": {
+                "url": {
+                  "type": "string"
+                }
+              },
+              "required": ["url"],
+              "additionalProperties": false
+            }
+          },
+          "required": ["cfg"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.cfg",
+          "reason": "optional-property-nullable"
+        }
+      ],
+      "arguments": [
+        {
+          "input": {
+            "cfg": null
+          },
+          "output": {}
+        }
+      ]
+    },
+    {
+      "id": "recursive-defs-kept",
+      "description": "Self-recursive definitions are representable.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "node": {
+            "$ref": "#/$defs/Node"
+          }
+        },
+        "required": ["node"],
+        "$defs": {
+          "Node": {
+            "type": "object",
+            "properties": {
+              "child": {
+                "$ref": "#/$defs/Node"
+              },
+              "label": {
+                "type": "string"
+              }
+            },
+            "required": ["label"]
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "node": {
+              "$ref": "#/$defs/Node"
+            }
+          },
+          "required": ["node"],
+          "$defs": {
+            "Node": {
+              "type": "object",
+              "properties": {
+                "child": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/$defs/Node"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "label": {
+                  "type": "string"
+                }
+              },
+              "required": ["child", "label"],
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "$defs.Node.properties.child",
+          "reason": "optional-property-nullable"
+        }
+      ],
+      "arguments": [
+        {
+          "input": {
+            "node": {
+              "label": "a",
+              "child": {
+                "label": "b",
+                "child": null
+              }
+            }
+          },
+          "output": {
+            "node": {
+              "label": "a",
+              "child": {
+                "label": "b"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "mutually-recursive-defs-kept",
+      "description": "Mutually recursive definitions are representable.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "a": {
+            "$ref": "#/$defs/A"
+          }
+        },
+        "required": ["a"],
+        "$defs": {
+          "A": {
+            "type": "object",
+            "properties": {
+              "b": {
+                "$ref": "#/$defs/B"
+              }
+            }
+          },
+          "B": {
+            "type": "object",
+            "properties": {
+              "a": {
+                "$ref": "#/$defs/A"
+              }
+            }
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "a": {
+              "$ref": "#/$defs/A"
+            }
+          },
+          "required": ["a"],
+          "$defs": {
+            "A": {
+              "type": "object",
+              "properties": {
+                "b": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/$defs/B"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": ["b"],
+              "additionalProperties": false
+            },
+            "B": {
+              "type": "object",
+              "properties": {
+                "a": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/$defs/A"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": ["a"],
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "$defs.A.properties.b",
+          "reason": "optional-property-nullable"
+        },
+        {
+          "path": "$defs.B.properties.a",
+          "reason": "optional-property-nullable"
+        }
+      ]
+    },
+    {
+      "id": "legacy-definitions-ref-kept",
+      "description": "Legacy definitions are supported like $defs.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "cfg": {
+            "$ref": "#/definitions/Config"
+          }
+        },
+        "required": ["cfg"],
+        "definitions": {
+          "Config": {
+            "type": "object",
+            "properties": {
+              "url": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "cfg": {
+              "$ref": "#/definitions/Config"
+            }
+          },
+          "required": ["cfg"],
+          "definitions": {
+            "Config": {
+              "type": "object",
+              "properties": {
+                "url": {
+                  "type": ["string", "null"]
+                }
+              },
+              "required": ["url"],
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "definitions.Config.properties.url",
+          "reason": "optional-property-nullable"
+        }
+      ]
+    },
+    {
+      "id": "ref-into-properties-kept",
+      "description": "A local $ref outside $defs resolves and is kept.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "a": {
+            "type": "object",
+            "properties": {
+              "x": {
+                "type": "string"
+              }
+            },
+            "required": ["x"]
+          },
+          "b": {
+            "$ref": "#/properties/a"
+          }
+        },
+        "required": ["a", "b"]
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "a": {
+              "type": "object",
+              "properties": {
+                "x": {
+                  "type": "string"
+                }
+              },
+              "required": ["x"],
+              "additionalProperties": false
+            },
+            "b": {
+              "$ref": "#/properties/a"
+            }
+          },
+          "required": ["a", "b"],
+          "additionalProperties": false
+        }
+      }
+    },
+    {
+      "id": "dangling-ref-unsupported",
+      "description": "A $ref without a target is reported at its own path.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "cfg": {
+            "$ref": "#/$defs/Nope"
+          }
+        },
+        "required": ["cfg"]
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "properties.cfg",
+            "keyword": "$ref"
+          }
+        ]
+      }
+    },
+    {
+      "id": "external-ref-unsupported",
+      "description": "A $ref outside the document is reported.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "cfg": {
+            "$ref": "https://example.com/schema.json"
+          }
+        },
+        "required": ["cfg"]
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "properties.cfg",
+            "keyword": "$ref"
+          }
+        ]
+      }
+    },
+    {
+      "id": "duplicate-required-deduped",
+      "description": "Duplicate required entries are removed.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "a": {
+            "type": "string"
+          }
+        },
+        "required": ["a", "a"]
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "a": {
+              "type": "string"
+            }
+          },
+          "required": ["a"],
+          "additionalProperties": false
+        }
+      }
+    },
+    {
+      "id": "required-unknown-names-dropped",
+      "description": "Required names without a property are dropped from required.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "a": {
+            "type": "string"
+          }
+        },
+        "required": ["a", "ghost"]
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "a": {
+              "type": "string"
+            }
+          },
+          "required": ["a"],
+          "additionalProperties": false
+        }
+      }
+    },
+    {
+      "id": "required-not-an-array-ignored",
+      "description": "A malformed required is treated as absent.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "a": {
+            "type": "string"
+          }
+        },
+        "required": "a"
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "a": {
+              "type": ["string", "null"]
+            }
+          },
+          "required": ["a"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.a",
+          "reason": "optional-property-nullable"
+        }
+      ]
+    },
+    {
+      "id": "description-kept-on-widened-node",
+      "description": "Annotations survive widening.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "a": {
+            "type": "integer",
+            "description": "count",
+            "title": "Count",
+            "minimum": 0
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "a": {
+              "type": ["integer", "null"],
+              "description": "count",
+              "title": "Count",
+              "minimum": 0
+            }
+          },
+          "required": ["a"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.a",
+          "reason": "optional-property-nullable"
+        }
+      ]
+    },
+    {
+      "id": "non-object-root-unsupported",
+      "description": "The root must be an object.",
+      "schema": {
+        "type": "string"
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "",
+            "keyword": "type"
+          }
+        ]
+      }
+    },
+    {
+      "id": "nullable-root-unsupported",
+      "description": "The root must not be nullable.",
+      "schema": {
+        "type": ["object", "null"],
+        "properties": {
+          "a": {
+            "type": "string"
+          }
+        }
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "",
+            "keyword": "type"
+          }
+        ]
+      },
+      "changes": [
+        {
+          "path": "properties.a",
+          "reason": "optional-property-nullable"
+        }
+      ]
+    },
+    {
+      "id": "properties-without-type-become-object",
+      "description": "A node with properties but no type is treated as an object.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "cfg": {
+            "properties": {
+              "a": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "required": ["cfg"]
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "cfg": {
+              "properties": {
+                "a": {
+                  "type": ["string", "null"]
+                }
+              },
+              "type": "object",
+              "required": ["a"],
+              "additionalProperties": false
+            }
+          },
+          "required": ["cfg"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.cfg.properties.a",
+          "reason": "optional-property-nullable"
+        }
+      ]
+    },
+    {
+      "id": "root-without-type-become-object",
+      "description": "A root with properties but no type is treated as an object.",
+      "schema": {
+        "properties": {
+          "a": {
+            "type": "string"
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "properties": {
+            "a": {
+              "type": ["string", "null"]
+            }
+          },
+          "type": "object",
+          "required": ["a"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.a",
+          "reason": "optional-property-nullable"
+        }
+      ]
+    },
+    {
+      "id": "root-single-element-type-array-accepted",
+      "description": "A root typed [\"object\"] is an object root.",
+      "schema": {
+        "type": ["object"],
+        "properties": {
+          "a": {
+            "type": "string"
+          }
+        },
+        "required": ["a"]
+      },
+      "strict": {
+        "schema": {
+          "type": ["object"],
+          "properties": {
+            "a": {
+              "type": "string"
+            }
+          },
+          "required": ["a"],
+          "additionalProperties": false
+        }
+      }
+    },
+    {
+      "id": "three-member-type-array-gains-null",
+      "description": "A three-member type array gains null once.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "v": {
+            "type": ["string", "number", "boolean"]
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "v": {
+              "type": ["string", "number", "boolean", "null"]
+            }
+          },
+          "required": ["v"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.v",
+          "reason": "optional-property-nullable"
+        }
+      ]
+    },
+    {
+      "id": "optional-null-only-property-unchanged",
+      "description": "A property typed null already accepts null.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "nothing": {
+            "type": "null"
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "nothing": {
+              "type": "null"
+            }
+          },
+          "required": ["nothing"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.nothing",
+          "reason": "optional-property-nullable"
+        }
+      ],
+      "arguments": [
+        {
+          "input": {
+            "nothing": null
+          },
+          "output": {
+            "nothing": null
+          }
+        }
+      ]
+    },
+    {
+      "id": "optional-enum-with-null-not-rewrapped",
+      "description": "An enum that already lists null is not wrapped again.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "choice": {
+            "enum": ["a", null]
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "choice": {
+              "enum": ["a", null]
+            }
+          },
+          "required": ["choice"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.choice",
+          "reason": "optional-property-nullable"
+        }
+      ],
+      "arguments": [
+        {
+          "input": {
+            "choice": null
+          },
+          "output": {
+            "choice": null
+          }
+        }
+      ]
+    },
+    {
+      "id": "optional-const-null-not-rewrapped",
+      "description": "A const null already accepts null.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "nothing": {
+            "const": null
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "nothing": {
+              "const": null
+            }
+          },
+          "required": ["nothing"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.nothing",
+          "reason": "optional-property-nullable"
+        }
+      ],
+      "arguments": [
+        {
+          "input": {
+            "nothing": null
+          },
+          "output": {
+            "nothing": null
+          }
+        }
+      ]
+    },
+    {
+      "id": "nested-any-of-branch-widened",
+      "description": "Optional properties inside anyOf branches are widened.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "v": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "a": {
+                    "type": "string"
+                  }
+                }
+              },
+              {
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "required": ["v"]
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "v": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "a": {
+                      "type": ["string", "null"]
+                    }
+                  },
+                  "required": ["a"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "required": ["v"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.v.anyOf[0].properties.a",
+          "reason": "optional-property-nullable"
+        }
+      ],
+      "arguments": [
+        {
+          "input": {
+            "v": {
+              "a": null
+            }
+          },
+          "output": {
+            "v": {}
+          }
+        },
+        {
+          "input": {
+            "v": null
+          },
+          "output": {}
+        }
+      ]
+    },
+    {
+      "id": "array-of-nullable-objects-closed",
+      "description": "Nullable objects inside array items are closed and stay nullable.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "rows": {
+            "type": "array",
+            "items": {
+              "type": ["object", "null"],
+              "properties": {
+                "id": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "required": ["rows"]
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "rows": {
+              "type": "array",
+              "items": {
+                "type": ["object", "null"],
+                "properties": {
+                  "id": {
+                    "type": ["string", "null"]
+                  }
+                },
+                "required": ["id"],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": ["rows"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.rows.items.properties.id",
+          "reason": "optional-property-nullable"
+        }
+      ],
+      "arguments": [
+        {
+          "input": {
+            "rows": [
+              null,
+              {
+                "id": null
+              }
+            ]
+          },
+          "output": {
+            "rows": [null, {}]
+          }
+        }
+      ]
+    },
+    {
+      "id": "tuple-form-items-unsupported",
+      "description": "Draft-4 tuple items have no strict-mode equivalent.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "pair": {
+            "type": "array",
+            "items": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "required": ["pair"]
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "properties.pair",
+            "keyword": "items"
+          }
+        ]
+      }
+    },
+    {
+      "id": "boolean-items-unsupported",
+      "description": "A boolean items subschema is reported.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "xs": {
+            "type": "array",
+            "items": true
+          }
+        },
+        "required": ["xs"]
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "properties.xs",
+            "keyword": "items"
+          }
+        ]
+      }
+    },
+    {
+      "id": "not-keyword-unsupported",
+      "description": "not has no strict-mode equivalent.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "v": {
+            "not": {
+              "type": "string"
+            }
+          }
+        },
+        "required": ["v"]
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "properties.v",
+            "keyword": "not"
+          }
+        ]
+      }
+    },
+    {
+      "id": "if-then-else-unsupported",
+      "description": "Conditional keywords have no strict-mode equivalent.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "v": {
+            "type": "string",
+            "if": {
+              "minLength": 1
+            },
+            "then": {
+              "maxLength": 5
+            },
+            "else": {
+              "const": ""
+            }
+          }
+        },
+        "required": ["v"]
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "properties.v",
+            "keyword": "else"
+          },
+          {
+            "path": "properties.v",
+            "keyword": "if"
+          },
+          {
+            "path": "properties.v",
+            "keyword": "then"
+          }
+        ]
+      }
+    },
+    {
+      "id": "dependent-schemas-unsupported",
+      "description": "dependentSchemas has no strict-mode equivalent.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "a": {
+            "type": "string"
+          }
+        },
+        "required": ["a"],
+        "dependentSchemas": {
+          "a": {
+            "type": "object",
+            "properties": {
+              "b": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "",
+            "keyword": "dependentSchemas"
+          }
+        ]
+      },
+      "changes": [
+        {
+          "path": "dependentSchemas.a.properties.b",
+          "reason": "optional-property-nullable"
+        }
+      ]
+    },
+    {
+      "id": "property-names-keyword-unsupported",
+      "description": "propertyNames has no strict-mode equivalent.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "a": {
+            "type": "string"
+          }
+        },
+        "required": ["a"],
+        "propertyNames": {
+          "pattern": "^a"
+        }
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "",
+            "keyword": "propertyNames"
+          }
+        ]
+      }
+    },
+    {
+      "id": "one-of-beside-any-of-unsupported",
+      "description": "oneOf next to anyOf cannot be merged and is reported.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "v": {
+            "anyOf": [
+              {
+                "type": "string"
+              }
+            ],
+            "oneOf": [
+              {
+                "type": "number"
+              }
+            ]
+          }
+        },
+        "required": ["v"]
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "properties.v",
+            "keyword": "oneOf"
+          }
+        ]
+      }
+    },
+    {
+      "id": "boolean-property-subschema-unsupported",
+      "description": "A boolean property subschema is reported.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "anything": true,
+          "nothing": false
+        },
+        "required": ["anything", "nothing"]
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "properties.anything",
+            "keyword": "properties"
+          },
+          {
+            "path": "properties.nothing",
+            "keyword": "properties"
+          }
+        ]
+      }
+    },
+    {
+      "id": "properties-not-an-object-unsupported",
+      "description": "A malformed properties value is reported instead of emptied.",
+      "schema": {
+        "type": "object",
+        "properties": "not-a-map",
+        "required": ["a"]
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "",
+            "keyword": "properties"
+          }
+        ]
+      }
+    },
+    {
+      "id": "ref-with-siblings-kept",
+      "description": "Sibling keywords next to a $ref are kept.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "cfg": {
+            "$ref": "#/$defs/Config",
+            "description": "cfg",
+            "title": "Config"
+          }
+        },
+        "required": ["cfg"],
+        "$defs": {
+          "Config": {
+            "type": "object",
+            "properties": {
+              "a": {
+                "type": "string"
+              }
+            },
+            "required": ["a"]
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "cfg": {
+              "$ref": "#/$defs/Config",
+              "description": "cfg",
+              "title": "Config"
+            }
+          },
+          "required": ["cfg"],
+          "$defs": {
+            "Config": {
+              "type": "object",
+              "properties": {
+                "a": {
+                  "type": "string"
+                }
+              },
+              "required": ["a"],
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    {
+      "id": "required-non-string-entries-ignored",
+      "description": "Non-string required entries are ignored.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "a": {
+            "type": "string"
+          },
+          "b": {
+            "type": "string"
+          }
+        },
+        "required": ["a", 1, null]
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "a": {
+              "type": "string"
+            },
+            "b": {
+              "type": ["string", "null"]
+            }
+          },
+          "required": ["a", "b"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.b",
+          "reason": "optional-property-nullable"
+        }
+      ]
+    },
+    {
+      "id": "dynamic-keys-reported-once-with-pattern-properties",
+      "description": "additionalProperties and patternProperties on one node report additionalProperties.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "m": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "patternProperties": {
+              "^x": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "required": ["m"]
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "properties.m",
+            "keyword": "additionalProperties"
+          }
+        ]
+      }
+    },
+    {
+      "id": "empty-properties-open-object-unsupported",
+      "description": "An object with empty properties and no closing is free-form.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "m": {
+            "type": "object",
+            "properties": {}
+          }
+        },
+        "required": ["m"]
+      },
+      "strict": {
+        "unsupported": [
+          {
+            "path": "properties.m",
+            "keyword": "properties"
+          }
+        ]
+      }
+    },
+    {
+      "id": "default-stripped-then-widened",
+      "description": "Stripping default and widening compose.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "a": {
+            "type": "string",
+            "default": "x"
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "a": {
+              "type": ["string", "null"]
+            }
+          },
+          "required": ["a"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.a",
+          "reason": "unsupported-keyword-stripped"
+        },
+        {
+          "path": "properties.a",
+          "reason": "optional-property-nullable"
+        }
+      ]
+    },
+    {
+      "id": "nested-any-of-in-any-of-kept",
+      "description": "A composition nested inside a composition is normalized branch by branch.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "v": {
+            "anyOf": [
+              {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "a": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              {
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "required": ["v"]
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "v": {
+              "anyOf": [
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "a": {
+                          "type": ["string", "null"]
+                        }
+                      },
+                      "required": ["a"],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "required": ["v"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.v.anyOf[0].anyOf[0].properties.a",
+          "reason": "optional-property-nullable"
+        }
+      ],
+      "arguments": [
+        {
+          "input": {
+            "v": {
+              "a": null
+            }
+          },
+          "output": {
+            "v": {}
+          }
+        }
+      ]
+    },
+    {
+      "id": "definitions-and-defs-both-normalized",
+      "description": "Legacy definitions and $defs coexist and both are normalized.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "a": {
+            "$ref": "#/$defs/A"
+          },
+          "b": {
+            "$ref": "#/definitions/B"
+          }
+        },
+        "required": ["a", "b"],
+        "$defs": {
+          "A": {
+            "type": "object",
+            "properties": {
+              "x": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "definitions": {
+          "B": {
+            "type": "object",
+            "properties": {
+              "y": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "a": {
+              "$ref": "#/$defs/A"
+            },
+            "b": {
+              "$ref": "#/definitions/B"
+            }
+          },
+          "required": ["a", "b"],
+          "$defs": {
+            "A": {
+              "type": "object",
+              "properties": {
+                "x": {
+                  "type": ["string", "null"]
+                }
+              },
+              "required": ["x"],
+              "additionalProperties": false
+            }
+          },
+          "definitions": {
+            "B": {
+              "type": "object",
+              "properties": {
+                "y": {
+                  "type": ["string", "null"]
+                }
+              },
+              "required": ["y"],
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "$defs.A.properties.x",
+          "reason": "optional-property-nullable"
+        },
+        {
+          "path": "definitions.B.properties.y",
+          "reason": "optional-property-nullable"
+        }
+      ]
+    },
+    {
+      "id": "deep-nesting-normalized-fully",
+      "description": "Ten levels of nested objects are normalized at every level.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "child": {
+            "type": "object",
+            "properties": {
+              "child": {
+                "type": "object",
+                "properties": {
+                  "child": {
+                    "type": "object",
+                    "properties": {
+                      "child": {
+                        "type": "object",
+                        "properties": {
+                          "child": {
+                            "type": "object",
+                            "properties": {
+                              "child": {
+                                "type": "object",
+                                "properties": {
+                                  "child": {
+                                    "type": "object",
+                                    "properties": {
+                                      "child": {
+                                        "type": "object",
+                                        "properties": {
+                                          "child": {
+                                            "type": "object",
+                                            "properties": {
+                                              "child": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "leaf": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "required": ["child"]
+                                          }
+                                        },
+                                        "required": ["child"]
+                                      }
+                                    },
+                                    "required": ["child"]
+                                  }
+                                },
+                                "required": ["child"]
+                              }
+                            },
+                            "required": ["child"]
+                          }
+                        },
+                        "required": ["child"]
+                      }
+                    },
+                    "required": ["child"]
+                  }
+                },
+                "required": ["child"]
+              }
+            },
+            "required": ["child"]
+          }
+        },
+        "required": ["child"]
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "child": {
+              "type": "object",
+              "properties": {
+                "child": {
+                  "type": "object",
+                  "properties": {
+                    "child": {
+                      "type": "object",
+                      "properties": {
+                        "child": {
+                          "type": "object",
+                          "properties": {
+                            "child": {
+                              "type": "object",
+                              "properties": {
+                                "child": {
+                                  "type": "object",
+                                  "properties": {
+                                    "child": {
+                                      "type": "object",
+                                      "properties": {
+                                        "child": {
+                                          "type": "object",
+                                          "properties": {
+                                            "child": {
+                                              "type": "object",
+                                              "properties": {
+                                                "child": {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "leaf": {
+                                                      "type": ["string", "null"]
+                                                    }
+                                                  },
+                                                  "required": ["leaf"],
+                                                  "additionalProperties": false
+                                                }
+                                              },
+                                              "required": ["child"],
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "required": ["child"],
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "required": ["child"],
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": ["child"],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": ["child"],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": ["child"],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": ["child"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["child"],
+                  "additionalProperties": false
+                }
+              },
+              "required": ["child"],
+              "additionalProperties": false
+            }
+          },
+          "required": ["child"],
+          "additionalProperties": false
+        }
+      },
+      "changes": [
+        {
+          "path": "properties.child.properties.child.properties.child.properties.child.properties.child.properties.child.properties.child.properties.child.properties.child.properties.child.properties.leaf",
+          "reason": "optional-property-nullable"
+        }
+      ]
+    },
+    {
+      "id": "chained-refs-resolved",
+      "description": "A $ref to a $ref resolves to the final definition.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "a": {
+            "$ref": "#/$defs/Alias"
+          }
+        },
+        "required": ["a"],
+        "$defs": {
+          "Alias": {
+            "$ref": "#/$defs/Real"
+          },
+          "Real": {
+            "type": "object",
+            "properties": {
+              "x": {
+                "type": "string"
+              }
+            },
+            "required": ["x"]
+          }
+        }
+      },
+      "strict": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "a": {
+              "$ref": "#/$defs/Alias"
+            }
+          },
+          "required": ["a"],
+          "$defs": {
+            "Alias": {
+              "$ref": "#/$defs/Real"
+            },
+            "Real": {
+              "type": "object",
+              "properties": {
+                "x": {
+                  "type": "string"
+                }
+              },
+              "required": ["x"],
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "arguments": [
+        {
+          "input": {
+            "a": {
+              "x": null
+            }
+          },
+          "output": {
+            "a": {}
+          }
+        },
+        {
+          "input": {
+            "a": null
+          },
+          "output": {}
+        }
+      ]
+    }
+  ]
+}

--- a/ts/packages/core/test/utils/jsonSchema.strict.corpus.test.ts
+++ b/ts/packages/core/test/utils/jsonSchema.strict.corpus.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { omitNullToolArguments, toStrictJsonSchema } from '../../src/utils/jsonSchema';
+import { loadStrictCases } from '../fixtures/json-schema-conversion/corpus';
+
+/** Structural invariants OpenAI enforces on every node of a strict schema. */
+function assertStrictShape(node: unknown, path = ''): void {
+  if (Array.isArray(node)) {
+    node.forEach((item, index) => assertStrictShape(item, `${path}[${index}]`));
+    return;
+  }
+  if (!node || typeof node !== 'object') return;
+  const record = node as Record<string, unknown>;
+  if (record.anyOf !== undefined) {
+    expect(record.type, `${path}: type beside anyOf`).toBeUndefined();
+  }
+  for (const keyword of [
+    'default',
+    'examples',
+    'oneOf',
+    'patternProperties',
+    'allOf',
+    'prefixItems',
+  ]) {
+    expect(record[keyword], `${path}: ${keyword}`).toBeUndefined();
+  }
+  const isObject =
+    record.type === 'object' || (Array.isArray(record.type) && record.type.includes('object'));
+  if (isObject || record.properties !== undefined) {
+    const properties = (record.properties ?? {}) as Record<string, unknown>;
+    expect(record.required, `${path}: required`).toEqual(Object.keys(properties));
+    expect(record.additionalProperties, `${path}: additionalProperties`).toBe(false);
+  }
+  for (const [key, child] of Object.entries(record)) {
+    if (key === 'enum' || key === 'const') continue;
+    const childPath = path ? `${path}.${key}` : key;
+    if (
+      (key === 'properties' || key === '$defs' || key === 'definitions') &&
+      child &&
+      typeof child === 'object'
+    ) {
+      // Keys of these maps are names, not keywords.
+      for (const [name, sub] of Object.entries(child as Record<string, unknown>)) {
+        assertStrictShape(sub, `${childPath}.${name}`);
+      }
+      continue;
+    }
+    assertStrictShape(child, childPath);
+  }
+}
+
+describe('toStrictJsonSchema (shared corpus)', () => {
+  for (const testCase of loadStrictCases()) {
+    it(testCase.id, () => {
+      const snapshot = JSON.parse(JSON.stringify(testCase.schema));
+      const result = toStrictJsonSchema(testCase.schema);
+
+      expect(testCase.schema, 'input mutated').toEqual(snapshot);
+      if ('unsupported' in testCase.strict) {
+        expect(result.unsupported.map(({ path, keyword }) => ({ path, keyword }))).toEqual(
+          testCase.strict.unsupported
+        );
+      } else {
+        expect(result.unsupported).toEqual([]);
+        expect(result.schema).toEqual(testCase.strict.schema);
+        assertStrictShape(result.schema);
+        const again = toStrictJsonSchema(result.schema);
+        expect(again.schema, 'not idempotent').toEqual(result.schema);
+        expect(again.changes).toEqual([]);
+      }
+      expect(result.changes.map(({ path, reason }) => ({ path, reason }))).toEqual(
+        testCase.changes ?? []
+      );
+      expect(result.totalChanges).toBe(result.changes.length);
+      for (const { input, output } of testCase.arguments ?? []) {
+        expect(omitNullToolArguments(input, result.source)).toEqual(output);
+      }
+    });
+  }
+});

--- a/ts/packages/core/test/utils/jsonSchema.strict.test.ts
+++ b/ts/packages/core/test/utils/jsonSchema.strict.test.ts
@@ -1,0 +1,472 @@
+import { describe, it, expect } from 'vitest';
+import { omitNullToolArguments, toStrictJsonSchema } from '../../src/utils/jsonSchema';
+import type { StrictSchemaChange } from '../../src/utils/jsonSchema';
+
+const propertyOf = (schema: Record<string, unknown>, name: string): Record<string, unknown> =>
+  (schema.properties as Record<string, Record<string, unknown>>)[name];
+
+const reasons = (changes: StrictSchemaChange[]): string[] => changes.map(change => change.reason);
+
+/** Structural invariants OpenAI enforces on every node of a strict schema. */
+function assertStrictShape(node: unknown, path = ''): void {
+  if (Array.isArray(node)) {
+    node.forEach((item, index) => assertStrictShape(item, `${path}[${index}]`));
+    return;
+  }
+  if (!node || typeof node !== 'object') return;
+  const record = node as Record<string, unknown>;
+  if (record.anyOf !== undefined) {
+    expect(record.type, `${path}: type beside anyOf`).toBeUndefined();
+  }
+  expect(record.default, `${path}: default`).toBeUndefined();
+  expect(record.examples, `${path}: examples`).toBeUndefined();
+  expect(record.oneOf, `${path}: oneOf`).toBeUndefined();
+  expect(record.patternProperties, `${path}: patternProperties`).toBeUndefined();
+  const isObject =
+    record.type === 'object' || (Array.isArray(record.type) && record.type.includes('object'));
+  if (isObject || record.properties !== undefined) {
+    const properties = (record.properties ?? {}) as Record<string, unknown>;
+    expect(record.required, `${path}: required`).toEqual(Object.keys(properties));
+    expect(record.additionalProperties, `${path}: additionalProperties`).toBe(false);
+  }
+  for (const [key, child] of Object.entries(record)) {
+    if (key === 'enum' || key === 'const') continue;
+    assertStrictShape(child, path ? `${path}.${key}` : key);
+  }
+}
+
+describe('toStrictJsonSchema', () => {
+  it('keeps an already-flat all-required object valid', () => {
+    const input = {
+      type: 'object',
+      properties: { query: { type: 'string' } },
+      required: ['query'],
+      additionalProperties: false,
+    };
+
+    const { schema, changes } = toStrictJsonSchema(input);
+
+    expect(schema).toEqual(input);
+    expect(changes).toEqual([]);
+  });
+
+  it('keeps optional properties, requires them and widens them to accept null', () => {
+    const { schema, changes } = toStrictJsonSchema({
+      type: 'object',
+      properties: {
+        cfg: {
+          type: 'object',
+          properties: {
+            url: { type: 'string' },
+            note: { type: 'string', description: 'optional note' },
+          },
+          required: ['url'],
+        },
+      },
+      required: ['cfg'],
+    });
+
+    expect(schema).toEqual({
+      type: 'object',
+      properties: {
+        cfg: {
+          type: 'object',
+          properties: {
+            url: { type: 'string' },
+            note: { type: ['string', 'null'], description: 'optional note' },
+          },
+          required: ['url', 'note'],
+          additionalProperties: false,
+        },
+      },
+      required: ['cfg'],
+      additionalProperties: false,
+    });
+    expect(changes).toEqual([
+      {
+        path: 'properties.cfg.properties.note',
+        reason: 'optional-property-nullable',
+        detail: 'property "note" is now required and accepts null',
+      },
+    ]);
+  });
+
+  it('requires and widens every property when the object has no required array', () => {
+    const { schema } = toStrictJsonSchema({
+      type: 'object',
+      properties: {
+        a: { type: 'string' },
+        b: { type: 'number' },
+      },
+    });
+
+    expect(schema).toEqual({
+      type: 'object',
+      properties: {
+        a: { type: ['string', 'null'] },
+        b: { type: ['number', 'null'] },
+      },
+      required: ['a', 'b'],
+      additionalProperties: false,
+    });
+  });
+
+  it('keeps nullable type arrays as-is and closes nullable objects', () => {
+    const { schema, changes } = toStrictJsonSchema({
+      type: 'object',
+      properties: {
+        id: { type: ['string', 'null'], description: 'identifier' },
+        cfg: {
+          type: ['object', 'null'],
+          properties: { a: { type: 'string' } },
+          required: ['a'],
+        },
+        xs: { type: ['array', 'null'], items: { type: 'string' } },
+      },
+      required: ['id', 'cfg', 'xs'],
+    });
+
+    expect(schema).toEqual({
+      type: 'object',
+      properties: {
+        id: { type: ['string', 'null'], description: 'identifier' },
+        cfg: {
+          type: ['object', 'null'],
+          properties: { a: { type: 'string' } },
+          required: ['a'],
+          additionalProperties: false,
+        },
+        xs: { type: ['array', 'null'], items: { type: 'string' } },
+      },
+      required: ['id', 'cfg', 'xs'],
+      additionalProperties: false,
+    });
+    expect(changes).toEqual([]);
+    assertStrictShape(schema);
+  });
+
+  it('widens optional composition and enum-only properties without placing type beside anyOf', () => {
+    const { schema } = toStrictJsonSchema({
+      type: 'object',
+      properties: {
+        value: { anyOf: [{ type: 'string' }, { type: 'number' }] },
+        already: { anyOf: [{ type: 'string' }, { type: 'null' }] },
+        choice: { enum: ['a', 'b'], description: 'pick one' },
+        multi: { type: ['string', 'number'] },
+      },
+    });
+
+    expect(propertyOf(schema, 'value')).toEqual({
+      anyOf: [{ type: 'string' }, { type: 'number' }, { type: 'null' }],
+    });
+    expect(propertyOf(schema, 'already')).toEqual({
+      anyOf: [{ type: 'string' }, { type: 'null' }],
+    });
+    expect(propertyOf(schema, 'choice')).toEqual({
+      description: 'pick one',
+      anyOf: [{ enum: ['a', 'b'] }, { type: 'null' }],
+    });
+    expect(propertyOf(schema, 'multi')).toEqual({ type: ['string', 'number', 'null'] });
+    assertStrictShape(schema);
+  });
+
+  it('normalizes composition branches and array items recursively', () => {
+    const { schema, changes } = toStrictJsonSchema({
+      type: 'object',
+      properties: {
+        payload: {
+          anyOf: [
+            {
+              type: 'object',
+              properties: { inner: { type: 'string' }, extra: { type: 'string' } },
+              required: ['inner'],
+            },
+            { type: 'null' },
+          ],
+        },
+        rows: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: { id: { type: 'string' }, tag: { type: 'string' } },
+            required: ['id'],
+          },
+        },
+        either: { oneOf: [{ type: 'string' }, { type: 'number' }] },
+      },
+      required: ['payload', 'rows', 'either'],
+    });
+
+    expect((propertyOf(schema, 'payload').anyOf as unknown[])[0]).toEqual({
+      type: 'object',
+      properties: { inner: { type: 'string' }, extra: { type: ['string', 'null'] } },
+      required: ['inner', 'extra'],
+      additionalProperties: false,
+    });
+    expect(propertyOf(schema, 'rows').items).toEqual({
+      type: 'object',
+      properties: { id: { type: 'string' }, tag: { type: ['string', 'null'] } },
+      required: ['id', 'tag'],
+      additionalProperties: false,
+    });
+    expect(propertyOf(schema, 'either')).toEqual({
+      anyOf: [{ type: 'string' }, { type: 'number' }],
+    });
+    expect(reasons(changes)).toContain('one-of-converted');
+    assertStrictShape(schema);
+  });
+
+  it('reports dynamic-key and free-form objects as unsupported instead of closing them', () => {
+    const { schema, unsupported } = toStrictJsonSchema({
+      type: 'object',
+      properties: {
+        headers: { type: 'object', additionalProperties: { type: 'string' } },
+        meta: { type: 'object', description: 'any json' },
+        tagged: { type: 'object', patternProperties: { '^x-': { type: 'string' } } },
+        open: { type: 'object', additionalProperties: true },
+      },
+      required: ['headers', 'meta', 'tagged', 'open'],
+    });
+
+    expect(unsupported).toEqual([
+      {
+        path: 'properties.headers',
+        keyword: 'additionalProperties',
+        detail: 'object accepts arbitrary keys',
+      },
+      {
+        path: 'properties.meta',
+        keyword: 'properties',
+        detail: 'free-form object accepts arbitrary keys',
+      },
+      {
+        path: 'properties.tagged',
+        keyword: 'patternProperties',
+        detail: 'object accepts pattern-matched keys',
+      },
+      {
+        path: 'properties.open',
+        keyword: 'additionalProperties',
+        detail: 'object accepts arbitrary keys',
+      },
+    ]);
+    // The schema-valued additionalProperties is preserved, not overwritten.
+    expect(propertyOf(schema, 'headers').additionalProperties).toEqual({ type: 'string' });
+    expect(propertyOf(schema, 'tagged').patternProperties).toBeDefined();
+  });
+
+  it('strips annotation keywords and reports keywords it cannot rewrite', () => {
+    const { schema, changes, unsupported } = toStrictJsonSchema({
+      type: 'object',
+      properties: {
+        name: { type: 'string', examples: ['a'], default: 'x' },
+        pair: { type: 'array', prefixItems: [{ type: 'number' }] },
+        all: { allOf: [{ type: 'string' }] },
+      },
+      required: ['name', 'pair', 'all'],
+    });
+
+    expect(propertyOf(schema, 'name')).toEqual({ type: 'string' });
+    expect(changes.filter(change => change.reason === 'unsupported-keyword-stripped')).toHaveLength(
+      2
+    );
+    expect(unsupported.map(entry => [entry.path, entry.keyword])).toEqual([
+      ['properties.pair', 'prefixItems'],
+      ['properties.all', 'allOf'],
+    ]);
+  });
+
+  it('keeps $defs and $ref, normalizes the definitions and reports dangling refs', () => {
+    const { schema, changes, unsupported } = toStrictJsonSchema({
+      type: 'object',
+      properties: {
+        cfg: { $ref: '#/$defs/Config' },
+        optionalCfg: { $ref: '#/$defs/Config', description: 'optional' },
+        missing: { $ref: '#/$defs/Nope' },
+        external: { $ref: 'https://example.com/schema.json' },
+      },
+      required: ['cfg', 'cfg', 'missing', 'external'],
+      $defs: {
+        Config: {
+          type: 'object',
+          properties: { url: { type: 'string' }, note: { type: 'string' } },
+          required: ['url'],
+        },
+      },
+    });
+
+    expect(propertyOf(schema, 'cfg')).toEqual({ $ref: '#/$defs/Config' });
+    expect(propertyOf(schema, 'optionalCfg')).toEqual({
+      description: 'optional',
+      anyOf: [{ $ref: '#/$defs/Config' }, { type: 'null' }],
+    });
+    expect(schema.$defs).toEqual({
+      Config: {
+        type: 'object',
+        properties: { url: { type: 'string' }, note: { type: ['string', 'null'] } },
+        required: ['url', 'note'],
+        additionalProperties: false,
+      },
+    });
+    expect(schema.required).toEqual(['cfg', 'optionalCfg', 'missing', 'external']);
+    expect(unsupported).toEqual([
+      { path: 'properties.missing', keyword: '$ref', detail: 'unresolved $ref "#/$defs/Nope"' },
+      {
+        path: 'properties.external',
+        keyword: '$ref',
+        detail: 'unresolved $ref "https://example.com/schema.json"',
+      },
+    ]);
+    expect(changes).toContainEqual(
+      expect.objectContaining({
+        path: '$defs.Config.properties.note',
+        reason: 'optional-property-nullable',
+      })
+    );
+  });
+
+  it('caps the change log at 50 entries without losing properties', () => {
+    const properties: Record<string, unknown> = {};
+    for (let i = 0; i < 60; i++) properties[`p${i}`] = { type: 'string' };
+
+    const { schema, changes, totalChanges } = toStrictJsonSchema({
+      type: 'object',
+      properties,
+      required: ['p0'],
+    });
+
+    expect(Object.keys(schema.properties as object)).toHaveLength(60);
+    expect(changes).toHaveLength(50);
+    expect(totalChanges).toBe(59);
+  });
+
+  it('does not mutate the input schema', () => {
+    const input = {
+      type: 'object',
+      properties: {
+        cfg: {
+          type: 'object',
+          properties: { opt: { type: 'string', default: 1 } },
+        },
+      },
+      required: ['cfg'],
+    };
+    const snapshot = JSON.parse(JSON.stringify(input));
+
+    toStrictJsonSchema(input);
+
+    expect(input).toEqual(snapshot);
+  });
+
+  it('is idempotent', () => {
+    const once = toStrictJsonSchema({
+      type: 'object',
+      properties: {
+        cfg: { $ref: '#/$defs/Config' },
+        id: { type: ['string', 'null'] },
+      },
+      $defs: {
+        Config: {
+          type: 'object',
+          properties: { url: { type: 'string' }, note: { type: 'string' } },
+          required: ['url'],
+        },
+      },
+    }).schema;
+
+    const twice = toStrictJsonSchema(once);
+    expect(twice.schema).toEqual(once);
+    expect(twice.changes).toEqual([]);
+    expect(twice.unsupported).toEqual([]);
+  });
+
+  it('reports non-object roots as unsupported and keeps recursive $defs', () => {
+    expect(toStrictJsonSchema({ type: 'string' }).unsupported).toEqual([
+      { path: '', keyword: 'type', detail: 'root must be a non-nullable object' },
+    ]);
+    expect(
+      toStrictJsonSchema({ type: ['object', 'null'], properties: { a: { type: 'string' } } })
+        .unsupported
+    ).toContainEqual(expect.objectContaining({ path: '', keyword: 'type' }));
+
+    const cyclic = toStrictJsonSchema({
+      type: 'object',
+      properties: { node: { $ref: '#/$defs/Node' } },
+      required: ['node'],
+      $defs: {
+        Node: {
+          type: 'object',
+          properties: { child: { $ref: '#/$defs/Node' }, label: { type: 'string' } },
+          required: ['label'],
+        },
+      },
+    });
+    // Recursion through $defs is representable in strict mode.
+    expect(cyclic.unsupported).toEqual([]);
+    expect((cyclic.schema.$defs as Record<string, unknown>).Node).toEqual({
+      type: 'object',
+      properties: {
+        child: { anyOf: [{ $ref: '#/$defs/Node' }, { type: 'null' }] },
+        label: { type: 'string' },
+      },
+      required: ['child', 'label'],
+      additionalProperties: false,
+    });
+  });
+
+  it('throws past the maximum nesting depth', () => {
+    let deep: Record<string, unknown> = { type: 'string' };
+    for (let i = 0; i < 600; i++) {
+      deep = { type: 'object', properties: { nest: deep }, required: ['nest'] };
+    }
+
+    expect(() => toStrictJsonSchema(deep)).toThrow(/depth/);
+  });
+});
+
+describe('omitNullToolArguments', () => {
+  const schema = {
+    type: 'object',
+    properties: {
+      cfg: {
+        type: 'object',
+        properties: { url: { type: 'string' }, note: { type: 'string' } },
+        required: ['url'],
+      },
+      label: { type: 'string' },
+      clearable: { type: ['string', 'null'] },
+      choice: { anyOf: [{ enum: ['a'] }, { type: 'null' }] },
+      rows: {
+        type: 'array',
+        items: { type: 'object', properties: { id: { type: 'string' }, tag: { type: 'string' } } },
+      },
+      refd: { $ref: '#/$defs/Str' },
+      refdNullable: { $ref: '#/$defs/NullableStr' },
+    },
+    $defs: { Str: { type: 'string' }, NullableStr: { type: ['string', 'null'] } },
+  };
+
+  it('drops nulls the schema does not accept and keeps the ones it does', () => {
+    const input = {
+      cfg: { url: 'https://example.com', note: null },
+      label: null,
+      clearable: null,
+      choice: null,
+      unknown: null,
+      rows: [{ id: '1', tag: null }, null],
+      refd: null,
+      refdNullable: null,
+    };
+    const snapshot = JSON.parse(JSON.stringify(input));
+
+    expect(omitNullToolArguments(input, schema)).toEqual({
+      cfg: { url: 'https://example.com' },
+      clearable: null,
+      choice: null,
+      unknown: null,
+      rows: [{ id: '1' }, null],
+      refdNullable: null,
+    });
+    expect(input).toEqual(snapshot);
+  });
+});

--- a/ts/packages/providers/mastra/README.md
+++ b/ts/packages/providers/mastra/README.md
@@ -51,7 +51,7 @@ Each tool gets both an input and an output schema, so Mastra can validate tool r
 
 ## Strict mode
 
-Pass `strict: true` to drop every non-required property from each tool's input schema before Mastra compiles it:
+Pass `strict: true` to normalize each tool's input schema for OpenAI structured outputs before Mastra compiles it: every object lists all of its properties in `required` and is closed, and optional properties stay available but accept `null`. A `null` the model sends is dropped before the tool runs unless the tool's own schema accepts `null` for that parameter, so genuinely nullable fields still receive an explicit `null`. Tools whose schema cannot be expressed in strict mode (such as objects that accept arbitrary keys, `allOf`, `prefixItems`, or unresolved `$ref`s) keep their original schema and log a warning:
 
 ```typescript
 const composio = new Composio({

--- a/ts/packages/providers/mastra/src/index.ts
+++ b/ts/packages/providers/mastra/src/index.ts
@@ -13,7 +13,8 @@ import {
   McpUrlResponse,
   dereferenceJsonSchema,
   logger,
-  removeNonRequiredProperties,
+  omitNullToolArguments,
+  toStrictJsonSchema,
   telemetry,
   type UnresolvedRefReason,
   normalizeToolArguments,
@@ -89,16 +90,27 @@ export class MastraProvider extends BaseAgenticProvider<
   wrapTool(tool: Tool, executeTool: ExecuteToolFn): MastraTool {
     const inputParams = tool.inputParameters;
 
-    const parameters =
-      this.strict && inputParams?.type === 'object'
-        ? removeNonRequiredProperties(
-            inputParams as {
-              type: 'object';
-              properties: Record<string, unknown>;
-              required?: string[];
-            }
-          )
-        : inputParams;
+    // Strict mode applies OpenAI's structured-output contract at every
+    // depth: all properties required, closed objects, optional properties
+    // widened to accept null instead of being dropped. Tools whose schema
+    // strict mode cannot express keep their original schema.
+    let parameters: Record<string, unknown> | undefined = inputParams as
+      Record<string, unknown> | undefined;
+    let strictSource: Record<string, unknown> | undefined;
+    if (this.strict && inputParams) {
+      const strict = toStrictJsonSchema(inputParams);
+      if (strict.unsupported.length > 0) {
+        const reasons = strict.unsupported
+          .map(entry => `${entry.path || '<root>'}: ${entry.keyword} (${entry.detail})`)
+          .join('; ');
+        logger.warn(
+          `[composio/mastra] Tool ${JSON.stringify(tool.slug)} keeps its non-strict schema because it cannot be expressed as strict structured outputs: ${reasons}`
+        );
+      } else {
+        parameters = strict.schema;
+        strictSource = strict.source;
+      }
+    }
 
     // Inline internal $ref pointers before handing the schema to
     // @mastra/schema-compat. AJV (bundled inside schema-compat) refuses to
@@ -146,13 +158,17 @@ export class MastraProvider extends BaseAgenticProvider<
     const mastraTool = createTool({
       id: tool.slug,
       description: tool.description ?? '',
-      // @ts-ignore
       inputSchema,
-      // @ts-ignore
       outputSchema,
       execute: async (inputData, _context) => {
         // Models occasionally emit tool input as a JSON string rather than an object (issue #2406).
-        const result = await executeTool(tool.slug, normalizeToolArguments(inputData, tool.slug));
+        const normalized = normalizeToolArguments(inputData, tool.slug);
+        // Under strict mode optional parameters are emitted as required-nullable,
+        // so a null the tool's own schema does not accept means "omitted".
+        const result = await executeTool(
+          tool.slug,
+          strictSource ? omitNullToolArguments(normalized, strictSource) : normalized
+        );
         return result;
       },
     });

--- a/ts/packages/providers/mastra/test/mastra.test.ts
+++ b/ts/packages/providers/mastra/test/mastra.test.ts
@@ -544,7 +544,7 @@ describe('MastraProvider', () => {
       expect(strictProvider['strict']).toBe(true);
     });
 
-    it('should use removeNonRequiredProperties when strict mode is enabled', () => {
+    it('should keep optional properties as required-nullable when strict mode is enabled', () => {
       const strictProvider = new MastraProvider({ strict: true });
 
       const toolWithOptionalProps: Tool = {
@@ -567,8 +567,8 @@ describe('MastraProvider', () => {
 
       strictProvider.wrapTool(toolWithOptionalProps, mockExecuteToolFn);
 
-      // In strict mode, only required properties should be passed to jsonSchemaToZodSchema
-      // The removeNonRequiredProperties function should have been called and filtered the schema
+      // In strict mode every property is required and closed; optional ones
+      // stay available and accept null instead of being dropped.
       expect(createTool).toHaveBeenCalledWith({
         id: toolWithOptionalProps.slug,
         description: toolWithOptionalProps.description,
@@ -581,13 +581,69 @@ describe('MastraProvider', () => {
                 type: 'string',
                 description: 'Required field',
               },
+              optional_field: {
+                type: ['string', 'null'],
+                description: 'Optional field',
+              },
             },
-            required: ['required_field'],
+            required: ['required_field', 'optional_field'],
             additionalProperties: false,
           },
         },
         outputSchema: RELAXED_MOCK_OUTPUT_SCHEMA,
         execute: expect.any(Function),
+      });
+    });
+
+    it('keeps the original schema for tools strict mode cannot express', () => {
+      const strictProvider = new MastraProvider({ strict: true });
+      const toolWithMap: Tool = {
+        ...mockTool,
+        inputParameters: {
+          type: 'object',
+          properties: {
+            headers: { type: 'object', additionalProperties: { type: 'string' } },
+            name: { type: 'string' },
+          },
+          required: ['headers'],
+        },
+      };
+
+      strictProvider.wrapTool(toolWithMap, mockExecuteToolFn);
+
+      expect(createTool).toHaveBeenCalledWith(
+        expect.objectContaining({
+          inputSchema: { type: 'mock-zod-schema', originalSchema: toolWithMap.inputParameters },
+        })
+      );
+    });
+
+    it('omits null arguments the tool schema rejects before executing under strict mode', async () => {
+      const strictProvider = new MastraProvider({ strict: true });
+      const wrapped = strictProvider.wrapTool(
+        {
+          ...mockTool,
+          inputParameters: {
+            type: 'object',
+            properties: {
+              cfg: {
+                type: 'object',
+                properties: { url: { type: 'string' }, note: { type: 'string' } },
+                required: ['url'],
+              },
+              clearable: { type: ['string', 'null'] },
+            },
+            required: ['cfg'],
+          },
+        },
+        mockExecuteToolFn
+      ) as unknown as { execute: (input: unknown, context: unknown) => Promise<unknown> };
+
+      await wrapped.execute({ cfg: { url: 'u', note: null }, clearable: null }, {});
+
+      expect(mockExecuteToolFn).toHaveBeenCalledWith(mockTool.slug, {
+        cfg: { url: 'u' },
+        clearable: null,
       });
     });
 

--- a/ts/packages/providers/openai-agents/README.md
+++ b/ts/packages/providers/openai-agents/README.md
@@ -43,7 +43,7 @@ For multi-turn conversations, store `session.sessionId` and reuse it with `compo
 
 ## Strict mode
 
-Pass `strict: true` to enable strict JSON schema validation for tool parameters (see the [Agents SDK options reference](https://openai.github.io/openai-agents-js/guides/tools/#options-reference)):
+Pass `strict: true` to register tools with strict JSON schema validation (see the [Agents SDK options reference](https://openai.github.io/openai-agents-js/guides/tools/#options-reference)). Each tool's input schema is normalized for OpenAI structured outputs: every object lists all of its properties in `required` and is closed, and optional properties stay available but accept `null`; a `null` the model sends is dropped before the tool runs unless the tool's own schema accepts `null` for that parameter, so genuinely nullable fields still receive an explicit `null`. Tools whose schema cannot be expressed in strict mode (such as objects that accept arbitrary keys, `allOf`, `prefixItems`, or unresolved `$ref`s) are registered without strict mode and log a warning:
 
 ```typescript
 const provider = new OpenAIAgentsProvider({ strict: true });

--- a/ts/packages/providers/openai-agents/src/index.ts
+++ b/ts/packages/providers/openai-agents/src/index.ts
@@ -18,11 +18,28 @@ import {
   McpServerGetResponse,
   normalizeToolArguments,
   deduplicateJsonSchemaRequiredArrays,
+  logger,
+  omitNullToolArguments,
+  toStrictJsonSchema,
 } from '@composio/core';
 import type { Tool as OpenAIAgentTool } from '@openai/agents';
 import { tool as createOpenAIAgentTool } from '@openai/agents';
 
 type OpenAIAgentsToolCollection = Array<OpenAIAgentTool>;
+
+/** The strict JSON Schema parameter shape the Agents SDK accepts. */
+type StrictToolParameters = Extract<
+  Parameters<typeof createOpenAIAgentTool>[0]['parameters'],
+  { additionalProperties: false }
+>;
+
+/** Parameters registered for a tool without input parameters under strict mode. */
+const EMPTY_OBJECT_SCHEMA = {
+  type: 'object',
+  properties: {},
+  required: [],
+  additionalProperties: false,
+} as const;
 export class OpenAIAgentsProvider extends BaseAgenticProvider<
   OpenAIAgentsToolCollection,
   OpenAIAgentTool,
@@ -125,6 +142,40 @@ export class OpenAIAgentsProvider extends BaseAgenticProvider<
   wrapTool(composioTool: ComposioTool, executeTool: ExecuteToolFn): OpenAIAgentTool {
     const inputParameters = deduplicateJsonSchemaRequiredArrays(composioTool.inputParameters);
 
+    // Strict mode applies OpenAI's structured-output contract at every
+    // depth: all properties required, closed objects, optional properties
+    // widened to accept null instead of being dropped. Tools whose schema
+    // strict mode cannot express are registered without strict mode.
+    const execute = async (params: unknown, strictSource?: Record<string, unknown>) => {
+      // Models occasionally emit tool input as a JSON string rather than an object (issue #2406).
+      const normalized = normalizeToolArguments(params, composioTool.slug);
+      // Under strict mode optional parameters are emitted as required-nullable,
+      // so a null the tool's own schema does not accept means "omitted".
+      return await executeTool(
+        composioTool.slug,
+        strictSource ? omitNullToolArguments(normalized, strictSource) : normalized
+      );
+    };
+
+    if (this.strict) {
+      const strict = toStrictJsonSchema(composioTool.inputParameters ?? EMPTY_OBJECT_SCHEMA);
+      if (strict.unsupported.length === 0) {
+        return createOpenAIAgentTool({
+          name: composioTool.slug,
+          description: composioTool.description ?? '',
+          parameters: strict.schema as StrictToolParameters,
+          strict: true,
+          execute: params => execute(params, strict.source),
+        });
+      }
+      const reasons = strict.unsupported
+        .map(entry => `${entry.path || '<root>'}: ${entry.keyword} (${entry.detail})`)
+        .join('; ');
+      logger.warn(
+        `OpenAIAgentsProvider: tool "${composioTool.slug}" is registered without strict mode because its schema cannot be expressed as strict structured outputs: ${reasons}`
+      );
+    }
+
     return createOpenAIAgentTool({
       name: composioTool.slug,
       description: composioTool.description ?? '',
@@ -135,13 +186,7 @@ export class OpenAIAgentsProvider extends BaseAgenticProvider<
         additionalProperties: true,
       },
       strict: false,
-      execute: async params => {
-        // Models occasionally emit tool input as a JSON string rather than an object (issue #2406).
-        return await executeTool(
-          composioTool.slug,
-          normalizeToolArguments(params, composioTool.slug)
-        );
-      },
+      execute: params => execute(params),
     });
   }
 

--- a/ts/packages/providers/openai-agents/test/openai-agents.test.ts
+++ b/ts/packages/providers/openai-agents/test/openai-agents.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { OpenAIAgentsProvider } from '../src';
-import { Tool } from '@composio/core';
+import { Tool, ExecuteToolFn } from '@composio/core';
 import { tool as createOpenAIAgentTool } from '@openai/agents';
 
 // Define an interface for our mocked OpenAI Agent tool
@@ -154,6 +154,96 @@ describe('OpenAIAgentsProvider', () => {
       ) as unknown as MockedOpenAIAgentTool;
 
       await expect(wrapped.execute('{"input":')).rejects.toThrow(/not valid JSON/);
+    });
+  });
+
+  describe('strict mode', () => {
+    it('registers a strict schema with optional parameters kept as required-nullable', () => {
+      const strictProvider = new OpenAIAgentsProvider({ strict: true });
+      strictProvider._setExecuteToolFn(mockExecuteToolFn);
+      const wrapped = strictProvider.wrapTool(
+        {
+          ...mockTool,
+          inputParameters: {
+            type: 'object',
+            properties: {
+              input: { type: 'string' },
+              cfg: {
+                type: 'object',
+                properties: { url: { type: 'string' }, note: { type: 'string' } },
+                required: ['url'],
+              },
+            },
+            required: ['input'],
+          },
+        },
+        mockExecuteToolFn as ExecuteToolFn
+      ) as unknown as MockedOpenAIAgentTool;
+
+      expect(wrapped.strict).toBe(true);
+      expect(wrapped.parameters).toEqual({
+        type: 'object',
+        properties: {
+          input: { type: 'string' },
+          cfg: {
+            type: ['object', 'null'],
+            properties: { url: { type: 'string' }, note: { type: ['string', 'null'] } },
+            required: ['url', 'note'],
+            additionalProperties: false,
+          },
+        },
+        required: ['input', 'cfg'],
+        additionalProperties: false,
+      });
+    });
+
+    it('registers tools strict mode cannot express without strict', () => {
+      const strictProvider = new OpenAIAgentsProvider({ strict: true });
+      const wrapped = strictProvider.wrapTool(
+        {
+          ...mockTool,
+          inputParameters: {
+            type: 'object',
+            properties: { headers: { type: 'object', additionalProperties: { type: 'string' } } },
+            required: ['headers'],
+          },
+        },
+        mockExecuteToolFn as ExecuteToolFn
+      ) as unknown as MockedOpenAIAgentTool;
+
+      expect(wrapped.strict).toBe(false);
+      expect(wrapped.parameters).toEqual({
+        type: 'object',
+        properties: { headers: { type: 'object', additionalProperties: { type: 'string' } } },
+        required: ['headers'],
+        additionalProperties: true,
+      });
+    });
+
+    it('omits null arguments the tool schema rejects before executing under strict mode', async () => {
+      const strictProvider = new OpenAIAgentsProvider({ strict: true });
+      const wrapped = strictProvider.wrapTool(
+        {
+          ...mockTool,
+          inputParameters: {
+            type: 'object',
+            properties: {
+              input: { type: 'string' },
+              label: { type: 'string' },
+              clearable: { type: ['string', 'null'] },
+            },
+            required: ['input'],
+          },
+        },
+        mockExecuteToolFn as ExecuteToolFn
+      ) as unknown as MockedOpenAIAgentTool;
+
+      await wrapped.execute({ input: 'x', label: null, clearable: null });
+
+      expect(mockExecuteToolFn).toHaveBeenCalledWith(mockTool.slug, {
+        input: 'x',
+        clearable: null,
+      });
     });
   });
 

--- a/ts/packages/providers/openai/README.md
+++ b/ts/packages/providers/openai/README.md
@@ -63,7 +63,7 @@ for (const item of response.output) {
 
 The package exports one provider per API surface:
 
-- `OpenAIResponsesProvider` targets the Responses API. `handleToolCalls(session, response.output)` returns `function_call_output` items keyed by `call_id`; pair it with `previous_response_id` so you only resend new outputs each turn. Pass a user ID instead of a session for tools fetched with `tools.get()`. The constructor accepts `{ strict?: boolean }` to enforce strict function schemas (default `false`).
+- `OpenAIResponsesProvider` targets the Responses API. `handleToolCalls(session, response.output)` returns `function_call_output` items keyed by `call_id`; pair it with `previous_response_id` so you only resend new outputs each turn. Pass a user ID instead of a session for tools fetched with `tools.get()`. Pass `{ strict: true }` to normalize tool input schemas for OpenAI structured outputs: every object is closed and lists all properties in `required`, optional properties stay available by accepting `null`, and a model-supplied `null` is removed before execution only when the tool's own schema does not accept `null`. Schemas strict mode cannot express, such as free-form objects, `allOf`, `prefixItems`, or unresolved `$ref`s, are sent with `strict: false` and log a warning.
 - `OpenAIProvider` targets the Chat Completions API and is the Composio SDK default, so `new Composio()` with no provider uses it. `handleToolCalls(session, chatCompletion)` returns ready-to-append `tool` messages; you keep the full message list yourself.
 
 Use the Responses provider for new agentic flows; reach for Chat Completions when extending an existing Chat Completions codebase. See the [docs page](https://docs.composio.dev/docs/providers/openai) for the Chat Completions loop.

--- a/ts/packages/providers/openai/src/OpenAIResponsesProvider.ts
+++ b/ts/packages/providers/openai/src/OpenAIResponsesProvider.ts
@@ -17,13 +17,23 @@ import {
   ExecuteToolFnOptions,
   ToolCallExecutionTarget,
   ToolCallSession,
-  removeNonRequiredProperties,
   McpUrlResponse,
   normalizeToolArguments,
   deduplicateJsonSchemaRequiredArrays,
+  omitNullToolArguments,
+  toStrictJsonSchema,
+  logger,
 } from '@composio/core';
 
 export type OpenAiTool = OpenAI.Responses.FunctionTool;
+
+/** Parameters emitted for a tool without input parameters under strict mode. */
+const EMPTY_OBJECT_SCHEMA = {
+  type: 'object',
+  properties: {},
+  required: [],
+  additionalProperties: false,
+} as const;
 export type OpenAiMcpTool = OpenAI.Responses.Tool.Mcp;
 export type OpenAiToolCollection = Array<OpenAiTool>;
 export type OpenAIResponsesProviderOptions = {
@@ -44,6 +54,12 @@ export class OpenAIResponsesProvider extends BaseNonAgenticProvider<
 > {
   readonly name = 'openai';
   private strict: boolean | null;
+  /**
+   * Dereferenced parameter schemas of the tools wrapped under strict mode,
+   * keyed by slug, so tool-call arguments can be reconciled against the
+   * schema the model actually saw.
+   */
+  private readonly strictInputSchemas = new Map<string, Record<string, unknown>>();
 
   /**
    * Creates a new instance of the OpenAIProvider.
@@ -121,24 +137,57 @@ export class OpenAIResponsesProvider extends BaseNonAgenticProvider<
    * ```
    */
   override wrapTool(tool: Tool): OpenAiTool {
-    const inputParams = deduplicateJsonSchemaRequiredArrays(tool.inputParameters);
+    const inputParams = tool.inputParameters;
+    if (!this.strict) {
+      return {
+        name: tool.slug,
+        description: tool.description,
+        // Canonicalize required arrays at the vendor-schema emission boundary.
+        parameters: deduplicateJsonSchemaRequiredArrays(
+          (inputParams ?? {}) as Record<string, unknown>
+        ),
+        strict: this.strict,
+        type: 'function',
+      };
+    }
 
-    const parameters =
-      this.strict && inputParams?.type === 'object'
-        ? removeNonRequiredProperties(
-            inputParams as {
-              type: 'object';
-              properties: Record<string, unknown>;
-              required?: string[];
-            }
-          )
-        : (inputParams ?? {});
+    // Structured outputs enforce their contract at every depth: all
+    // properties required, closed objects, no annotation keywords. The strict
+    // rewrite keeps every parameter (optional ones become nullable) and
+    // reports constructs it cannot express; such a tool is sent without
+    // strict mode rather than with a narrower schema.
+    const source = (inputParams ?? EMPTY_OBJECT_SCHEMA) as Record<string, unknown>;
+    const strict = toStrictJsonSchema(source);
+    if (strict.unsupported.length > 0) {
+      const reasons = strict.unsupported
+        .map(entry => `${entry.path || '<root>'}: ${entry.keyword} (${entry.detail})`)
+        .join('; ');
+      logger.warn(
+        `OpenAIResponsesProvider: tool "${tool.slug}" is sent without strict mode because its schema cannot be expressed as strict structured outputs: ${reasons}`
+      );
+      this.strictInputSchemas.delete(tool.slug);
+      return {
+        name: tool.slug,
+        description: tool.description,
+        parameters: deduplicateJsonSchemaRequiredArrays(source),
+        strict: false,
+        type: 'function',
+      };
+    }
+    if (strict.totalChanges > 0) {
+      logger.debug(
+        `OpenAIResponsesProvider: strict mode rewrote ${strict.totalChanges} node(s) of tool "${tool.slug}": ${strict.changes
+          .map(change => `${change.path}: ${change.reason}`)
+          .join('; ')}`
+      );
+    }
+    this.strictInputSchemas.set(tool.slug, strict.source);
 
     return {
       name: tool.slug,
       description: tool.description,
-      parameters,
-      strict: this.strict,
+      parameters: strict.schema,
+      strict: true,
       type: 'function',
     };
   }
@@ -235,7 +284,13 @@ export class OpenAIResponsesProvider extends BaseNonAgenticProvider<
   ): Promise<string> {
     // OpenAI always serializes tool arguments as a JSON string; normalize tolerates
     // empty / object-shaped payloads too (issue #2406).
-    const arguments_ = normalizeToolArguments(tool.arguments, tool.name);
+    const normalizedArguments = normalizeToolArguments(tool.arguments, tool.name);
+    // Under strict mode optional parameters are emitted as required-nullable,
+    // so a `null` the tool's own schema does not accept means "omitted".
+    const strictSchema = this.strictInputSchemas.get(tool.name);
+    const arguments_ = strictSchema
+      ? omitNullToolArguments(normalizedArguments, strictSchema)
+      : normalizedArguments;
     const result = await this.executeToolForTarget(
       executionTarget,
       tool.name,

--- a/ts/packages/providers/openai/test/opeanai-responses.test.ts
+++ b/ts/packages/providers/openai/test/opeanai-responses.test.ts
@@ -129,6 +129,138 @@ describe('OpenAIResponsesProvider', () => {
 
       expect(wrapped.parameters.required).toEqual(['input']);
     });
+
+    it('keeps optional parameters as required-nullable under strict mode', () => {
+      const strictProvider = new OpenAIResponsesProvider({ strict: true });
+      const wrapped = strictProvider.wrapTool({
+        ...mockTool,
+        inputParameters: {
+          type: 'object',
+          properties: {
+            cfg: {
+              type: 'object',
+              properties: {
+                url: { type: 'string' },
+                note: { type: 'string' },
+              },
+              required: ['url'],
+            },
+            id: { type: ['string', 'null'] },
+            payload: {
+              anyOf: [
+                {
+                  type: 'object',
+                  properties: { inner: { type: 'string' }, extra: { type: 'string' } },
+                  required: ['inner'],
+                },
+                { type: 'null' },
+              ],
+            },
+            label: { type: 'string', default: 'x' },
+          },
+          required: ['cfg', 'id', 'payload'],
+        },
+      }) as MockedOpenAITool;
+
+      expect(wrapped.strict).toBe(true);
+      expect(wrapped.parameters).toEqual({
+        type: 'object',
+        properties: {
+          cfg: {
+            type: 'object',
+            properties: { url: { type: 'string' }, note: { type: ['string', 'null'] } },
+            required: ['url', 'note'],
+            additionalProperties: false,
+          },
+          id: { type: ['string', 'null'] },
+          payload: {
+            anyOf: [
+              {
+                type: 'object',
+                properties: { inner: { type: 'string' }, extra: { type: ['string', 'null'] } },
+                required: ['inner', 'extra'],
+                additionalProperties: false,
+              },
+              { type: 'null' },
+            ],
+          },
+          label: { type: ['string', 'null'] },
+        },
+        required: ['cfg', 'id', 'payload', 'label'],
+        additionalProperties: false,
+      });
+    });
+
+    it('keeps nullable nested objects nullable and $defs referenced under strict mode', () => {
+      const strictProvider = new OpenAIResponsesProvider({ strict: true });
+      const wrapped = strictProvider.wrapTool({
+        ...mockTool,
+        inputParameters: {
+          type: 'object',
+          properties: {
+            cfg: { $ref: '#/$defs/Config' },
+          },
+          required: ['cfg'],
+          $defs: {
+            Config: {
+              type: ['object', 'null'],
+              properties: { url: { type: 'string' }, opt: { type: 'string' } },
+              required: ['url'],
+            },
+          },
+        },
+      }) as MockedOpenAITool;
+
+      expect(wrapped.strict).toBe(true);
+      expect(wrapped.parameters).toEqual({
+        type: 'object',
+        properties: {
+          cfg: { $ref: '#/$defs/Config' },
+        },
+        required: ['cfg'],
+        additionalProperties: false,
+        $defs: {
+          Config: {
+            type: ['object', 'null'],
+            properties: { url: { type: 'string' }, opt: { type: ['string', 'null'] } },
+            required: ['url', 'opt'],
+            additionalProperties: false,
+          },
+        },
+      });
+    });
+
+    it('sends tools strict mode cannot express without strict, keeping their schema', () => {
+      const strictProvider = new OpenAIResponsesProvider({ strict: true });
+      const inputParameters = {
+        type: 'object',
+        properties: {
+          headers: { type: 'object', additionalProperties: { type: 'string' } },
+          name: { type: 'string' },
+        },
+        required: ['headers', 'name', 'name'],
+      };
+      const wrapped = strictProvider.wrapTool({ ...mockTool, inputParameters }) as MockedOpenAITool;
+
+      expect(wrapped.strict).toBe(false);
+      expect(wrapped.parameters).toEqual({ ...inputParameters, required: ['headers', 'name'] });
+    });
+
+    it('emits an empty closed object for tools without parameters in strict mode', () => {
+      const strictProvider = new OpenAIResponsesProvider({ strict: true });
+      const wrapped = strictProvider.wrapTool({
+        ...mockTool,
+        inputParameters: undefined,
+      }) as MockedOpenAITool;
+
+      expect(wrapped.strict).toBe(true);
+      expect(wrapped.parameters).toEqual({
+        type: 'object',
+        properties: {},
+        required: [],
+        additionalProperties: false,
+      });
+    });
   });
 
   describe('wrapTools', () => {
@@ -194,6 +326,48 @@ describe('OpenAIResponsesProvider', () => {
           error: null,
           successful: true,
         })
+      );
+    });
+
+    it('omits nulls the tool schema does not accept before executing under strict mode', async () => {
+      const strictProvider = new OpenAIResponsesProvider({ strict: true });
+      strictProvider._setExecuteToolFn(mockExecuteToolFn);
+      strictProvider.wrapTool({
+        ...mockTool,
+        slug: 'test-tool',
+        inputParameters: {
+          type: 'object',
+          properties: {
+            cfg: {
+              type: 'object',
+              properties: { url: { type: 'string' }, note: { type: 'string' } },
+              required: ['url'],
+            },
+            label: { type: 'string' },
+            clearable: { type: ['string', 'null'] },
+          },
+          required: ['cfg'],
+        },
+      });
+      const toolCall = {
+        id: 'call-123',
+        type: 'function',
+        name: 'test-tool',
+        arguments: JSON.stringify({ cfg: { url: 'u', note: null }, label: null, clearable: null }),
+        call_id: 'call-123',
+      } as unknown as OpenAI.Responses.ResponseFunctionToolCall;
+
+      await strictProvider.executeToolCall('test-user', toolCall);
+
+      expect(mockExecuteToolFn).toHaveBeenCalledWith(
+        'test-tool',
+        {
+          arguments: { cfg: { url: 'u' }, clearable: null },
+          userId: 'test-user',
+          connectedAccountId: undefined,
+          customAuthParams: undefined,
+        },
+        undefined
       );
     });
 

--- a/ts/packages/providers/vercel/README.md
+++ b/ts/packages/providers/vercel/README.md
@@ -45,7 +45,7 @@ For multi-turn conversations, store `session.sessionId` and reuse it with `compo
 
 ## Strict mode
 
-Some models reject tool schemas that contain optional parameters. Pass `strict: true` to drop every non-required property from each tool's input schema before it reaches the AI SDK:
+Some models reject tool schemas that contain optional parameters. Pass `strict: true` to normalize each tool's input schema for OpenAI structured outputs before it reaches the AI SDK: every object lists all of its properties in `required` and is closed, and optional properties stay available but accept `null`. A `null` the model sends is dropped before the tool runs unless the tool's own schema accepts `null` for that parameter, so genuinely nullable fields still receive an explicit `null`. Tools whose schema cannot be expressed in strict mode (such as objects that accept arbitrary keys, `allOf`, `prefixItems`, or unresolved `$ref`s) keep their original schema and log a warning:
 
 ```typescript
 const composio = new Composio({ provider: new VercelProvider({ strict: true }) });

--- a/ts/packages/providers/vercel/src/index.ts
+++ b/ts/packages/providers/vercel/src/index.ts
@@ -16,9 +16,13 @@ import {
   ExecuteToolFn,
   McpUrlResponse,
   McpServerGetResponse,
-  removeNonRequiredProperties,
+  deduplicateJsonSchemaRequiredArrays,
+  dereferenceJsonSchema,
+  toStrictJsonSchema,
   jsonSchemaToZodSchema,
+  logger,
   normalizeToolArguments,
+  omitNullToolArguments,
 } from '@composio/core';
 import type { ToolSet as VercelToolSet, Tool as VercelTool } from 'ai';
 import { tool } from 'ai';
@@ -109,18 +113,45 @@ export class VercelProvider extends BaseAgenticProvider<
   wrapTool(composioTool: Tool, executeTool: ExecuteToolFn): VercelTool {
     const inputParams = composioTool.inputParameters;
 
-    const parameters =
-      this.strict && inputParams?.type === 'object'
-        ? removeNonRequiredProperties(
-            inputParams as {
-              type: 'object';
-              properties: Record<string, unknown>;
-              required?: string[];
-            }
-          )
-        : (inputParams ?? {});
+    // Canonicalize required arrays at the vendor-schema emission boundary.
+    let parameters: Record<string, unknown> = deduplicateJsonSchemaRequiredArrays(
+      (inputParams ?? {}) as Record<string, unknown>
+    );
+    // Under strict mode optional parameters are emitted as required-nullable,
+    // so a `null` the tool's own schema does not accept means "omitted".
+    let strictSource: Record<string, unknown> | undefined;
+    if (this.strict && inputParams) {
+      // Structured outputs enforce their contract at every depth: all
+      // properties required, closed objects, no annotation keywords. The
+      // strict rewrite keeps every parameter (optional ones become nullable)
+      // and reports constructs it cannot express; such a tool keeps its
+      // original schema rather than a narrower one.
+      const strict = toStrictJsonSchema(inputParams);
+      if (strict.unsupported.length > 0) {
+        const reasons = strict.unsupported
+          .map(entry => `${entry.path || '<root>'}: ${entry.keyword} (${entry.detail})`)
+          .join('; ');
+        logger.warn(
+          `VercelProvider: tool "${composioTool.slug}" keeps its non-strict schema because it cannot be expressed as strict structured outputs: ${reasons}`
+        );
+      } else {
+        if (strict.totalChanges > 0) {
+          logger.debug(
+            `VercelProvider: strict mode rewrote ${strict.totalChanges} node(s) of tool "${composioTool.slug}": ${strict.changes
+              .map(change => `${change.path}: ${change.reason}`)
+              .join('; ')}`
+          );
+        }
+        parameters = strict.schema;
+        strictSource = strict.source;
+      }
+    }
 
-    const inputParametersSchema = jsonSchemaToZodSchema(parameters);
+    // The Zod converter does not follow $ref, so inline the definitions the
+    // strict rewrite keeps (cycles fall back to the permissive sentinel).
+    const inputParametersSchema = jsonSchemaToZodSchema(
+      strictSource ? dereferenceJsonSchema(parameters, { onUnresolved: 'sentinel' }) : parameters
+    );
 
     return tool({
       description: composioTool.description,
@@ -128,9 +159,10 @@ export class VercelProvider extends BaseAgenticProvider<
 
       execute: async params => {
         // Models occasionally emit tool input as a JSON string rather than an object (issue #2406).
+        const normalized = normalizeToolArguments(params, composioTool.slug);
         return await executeTool(
           composioTool.slug,
-          normalizeToolArguments(params, composioTool.slug)
+          strictSource ? omitNullToolArguments(normalized, strictSource) : normalized
         );
       },
     });

--- a/ts/packages/providers/vercel/test/vercel.test.ts
+++ b/ts/packages/providers/vercel/test/vercel.test.ts
@@ -133,6 +133,103 @@ describe('VercelProvider', () => {
 
       expect(mockExecuteToolFn).toHaveBeenCalledWith(mockTool.slug, params);
     });
+
+    it('keeps optional and nested parameters available under strict mode', () => {
+      const strictProvider = new VercelProvider({ strict: true });
+      const wrapped = strictProvider.wrapTool(
+        {
+          ...mockTool,
+          inputParameters: {
+            type: 'object',
+            properties: {
+              cfg: {
+                type: 'object',
+                properties: { url: { type: 'string' }, note: { type: 'string' } },
+                required: ['url'],
+              },
+              id: { type: ['string', 'null'] },
+              label: { type: 'string' },
+            },
+            required: ['cfg', 'id'],
+          },
+        },
+        mockExecuteToolFn
+      ) as unknown as MockedVercelTool;
+
+      const schema = wrapped.inputSchema as { safeParse: (value: unknown) => { success: boolean } };
+
+      // Optional parameters are still accepted, and may be null.
+      expect(
+        schema.safeParse({ cfg: { url: 'https://example.com', note: 'x' }, id: null, label: null })
+          .success
+      ).toBe(true);
+      // Every property is required under strict mode, so omitting one fails.
+      expect(schema.safeParse({ cfg: { url: 'https://example.com' }, id: 'a' }).success).toBe(
+        false
+      );
+      // Objects are closed, so unknown keys fail.
+      expect(
+        schema.safeParse({
+          cfg: { url: 'https://example.com', note: null, extra: 1 },
+          id: 'a',
+          label: null,
+        }).success
+      ).toBe(false);
+    });
+
+    it('omits null arguments before executing under strict mode', async () => {
+      const strictProvider = new VercelProvider({ strict: true });
+      const wrapped = strictProvider.wrapTool(
+        {
+          ...mockTool,
+          inputParameters: {
+            type: 'object',
+            properties: {
+              cfg: {
+                type: 'object',
+                properties: { url: { type: 'string' }, note: { type: 'string' } },
+                required: ['url'],
+              },
+              label: { type: 'string' },
+            },
+            required: ['cfg'],
+          },
+        },
+        mockExecuteToolFn
+      ) as unknown as MockedVercelTool;
+
+      await wrapped.execute(
+        { cfg: { url: 'https://example.com', note: null }, label: null },
+        { toolCallId: 'call_1', messages: [] }
+      );
+
+      expect(mockExecuteToolFn).toHaveBeenCalledWith(mockTool.slug, {
+        cfg: { url: 'https://example.com' },
+      });
+    });
+
+    it('keeps the original schema for tools strict mode cannot express', () => {
+      const strictProvider = new VercelProvider({ strict: true });
+      const wrapped = strictProvider.wrapTool(
+        {
+          ...mockTool,
+          inputParameters: {
+            type: 'object',
+            properties: {
+              headers: { type: 'object', additionalProperties: { type: 'string' } },
+              name: { type: 'string' },
+            },
+            required: ['headers'],
+          },
+        },
+        mockExecuteToolFn
+      ) as unknown as MockedVercelTool;
+
+      const schema = wrapped.inputSchema as { safeParse: (value: unknown) => { success: boolean } };
+
+      // `name` stays optional and `headers` still accepts arbitrary keys.
+      expect(schema.safeParse({ headers: { 'x-a': '1' } }).success).toBe(true);
+    });
   });
 
   describe('wrapTools', () => {


### PR DESCRIPTION
## Integration rescue of #4257

This PR preserves and credits the implementation in #4257 while restacking it onto the current `next` head (`64db269a331570bee84e21eda399e5342dee3568`). The rescue is needed because the original head is materially behind `next` and has review/CI follow-ups that cannot be pushed from this account to the original upstream branch.

### Preserved source scope
- strict JSON Schema normalization in TypeScript and Python
- optional parameters remain available under strict mode by becoming nullable
- Mastra, Vercel, OpenAI Responses, and OpenAI Agents provider integration
- shared cross-SDK strict-schema corpus and regression coverage
- original changesets and provider docs

### Review fixes included
- fixes Cursor Bugbot's Python parity finding: explicit `{}` input schemas are no longer treated as missing parameters; only `None` is treated as absent
- adds dedicated regression coverage for that case
- documents OpenAI Responses strict mode for TypeScript and Python
- corrects strict-mode `null` semantics across provider docs/READMEs: genuine nullable fields keep explicit `null`; only values rejected by the original schema are omitted
- clarifies unsupported schema examples, including unresolved `$ref`s

### Generated artifact handling
`docs/kb/semantic-index.json` from the original PR was intentionally **not** copied. It had gone stale and failed the semantic artifact hash gate. This rescue keeps the current `next` artifact until it can be regenerated against this exact head.

### Freshness / composition evidence
- base: `64db269a331570bee84e21eda399e5342dee3568`
- rescue head: `57fe9c98ac48947d7e82b24f69a41d87bf300bc5`
- one commit ahead of base
- 32 expected changed paths
- no unrelated dependency files and no stale semantic-index overwrite

### Remaining before ready-for-review
This is intentionally a draft until exact-head test/build/docs-semantic gates complete. Local runner access is temporarily unavailable, so the branch must not be treated as certified yet.

Original implementation credit: authors and reviewers of #4257.