### PR TITLE
fix(errors): restack error subclass names on current next

### DIFF
--- a/.changeset/fix-error-subclass-names.md
+++ b/.changeset/fix-error-subclass-names.md
@@ -1,0 +1,5 @@
+---
+'@composio/core': patch
+---
+
+Fix three ComposioError subclasses (ComposioToolVersionRequiredError, JsonSchemaToZodError, JsonSchemaRefResolutionError) that omitted their `this.name` assignment and therefore reported `name` as 'ComposioError' instead of their own class name, mis-grouping distinct error types in error telemetry.

--- a/ts/packages/core/src/errors/ToolErrors.ts
+++ b/ts/packages/core/src/errors/ToolErrors.ts
@@ -204,6 +204,7 @@ export class ComposioToolVersionRequiredError extends ComposioError {
         'Set dangerouslySkipVersionCheck to true (this might cause unexpected behavior when new versions of the tools are released)',
       ],
     });
+    this.name = 'ComposioToolVersionRequiredError';
   }
 }
 export interface ComposioAPIServerErrorBody {

--- a/ts/packages/core/src/errors/ValidationErrors.ts
+++ b/ts/packages/core/src/errors/ValidationErrors.ts
@@ -78,6 +78,7 @@ export class JsonSchemaToZodError extends ComposioError {
       ...options,
       code: options.code || ValidationErrorCodes.JSON_SCHEMA_TO_ZOD_ERROR,
     });
+    this.name = 'JsonSchemaToZodError';
   }
 }
 
@@ -95,5 +96,6 @@ export class JsonSchemaRefResolutionError extends ComposioError {
       ...options,
       code: options.code || ValidationErrorCodes.JSON_SCHEMA_REF_RESOLUTION_ERROR,
     });
+    this.name = 'JsonSchemaRefResolutionError';
   }
 }

--- a/ts/packages/core/test/errors/errorNames.test.ts
+++ b/ts/packages/core/test/errors/errorNames.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { ComposioError } from '../../src/errors/ComposioError';
+import { ComposioToolVersionRequiredError } from '../../src/errors/ToolErrors';
+import {
+  JsonSchemaToZodError,
+  JsonSchemaRefResolutionError,
+} from '../../src/errors/ValidationErrors';
+
+// The base ComposioError assigns `name` as a class field, so a subclass that does
+// not reassign `this.name` in its constructor inherits the base value and reports
+// 'ComposioError'. error.name is forwarded to error telemetry (see Telemetry.ts),
+// where that silently mis-groups distinct error types under the base name. These
+// three subclasses had omitted the reassignment their ~30 siblings all perform.
+describe('ComposioError subclass names', () => {
+  it('ComposioToolVersionRequiredError reports its own name', () => {
+    const error = new ComposioToolVersionRequiredError();
+    expect(error).toBeInstanceOf(ComposioError);
+    expect(error.name).toBe('ComposioToolVersionRequiredError');
+  });
+
+  it('JsonSchemaToZodError reports its own name', () => {
+    const error = new JsonSchemaToZodError();
+    expect(error).toBeInstanceOf(ComposioError);
+    expect(error.name).toBe('JsonSchemaToZodError');
+  });
+
+  it('JsonSchemaRefResolutionError reports its own name', () => {
+    const error = new JsonSchemaRefResolutionError();
+    expect(error).toBeInstanceOf(ComposioError);
+    expect(error.name).toBe('JsonSchemaRefResolutionError');
+  });
+});


### PR DESCRIPTION
Restacks the exact implementation from #4128 by @rohitsux onto the current `next` head after that PR became heavily stale.

Source PR: #4128
Source head: `c0f16093ed46153a95802c1eb30e83a165b9d05a`
Current base used for this rescue: `b20ca59d91a22b965f7a72389c598aadf32074a6`

Scope is intentionally byte-for-byte equivalent to the original PR on its four changed paths:
- add `this.name = 'ComposioToolVersionRequiredError'`
- add `this.name = 'JsonSchemaToZodError'`
- add `this.name = 'JsonSchemaRefResolutionError'`
- preserve the original regression tests and Changeset

No unrelated stale-branch history is carried forward. The rescue commit is exactly one commit ahead of current `next` with 4 changed paths, +40/-0.

Credit for diagnosis and original implementation belongs to @rohitsux / #4128. This PR only provides a freshness-safe restack for maintainer review.