### PR TITLE
fix(telemetry): restack request timeout on current next

### DIFF
--- a/.changeset/bound-telemetry-request-timeout.md
+++ b/.changeset/bound-telemetry-request-timeout.md
@@ -1,0 +1,5 @@
+---
+'@composio/core': patch
+---
+
+Bound the best-effort telemetry requests with a timeout so a stalled telemetry endpoint cannot leave an SDK call pending indefinitely.

--- a/ts/packages/core/src/services/telemetry/TelemetryService.ts
+++ b/ts/packages/core/src/services/telemetry/TelemetryService.ts
@@ -2,8 +2,31 @@ import logger from '../../utils/logger';
 import { TelemetryMetricPayloadBody, TelemetryPayload } from './TelemetryService.types';
 
 const TELEMETRY_URL = 'https://telemetry.composio.dev/v1';
+const TELEMETRY_TIMEOUT_MS = 3_000;
 
 export class TelemetryService {
+  /**
+   * POSTs a best-effort telemetry payload, bounding the request so a stalled
+   * endpoint cannot leave it pending indefinitely.
+   *
+   * A hand-rolled timer rather than AbortSignal.timeout so it can be cleared the
+   * moment the response lands: an uncleared timer is itself pending work, which on
+   * workerd pins the request context open for the full timeout on every successful
+   * send. Mirrors the bound applied to the npm version check.
+   */
+  private static postWithTimeout(url: string, payload: unknown) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), TELEMETRY_TIMEOUT_MS);
+    return fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    }).finally(() => clearTimeout(timer));
+  }
+
   /**
    * Sends a metric to the Telemetry API.
    * @param payload - The payload to send to the Telemetry API.
@@ -11,13 +34,7 @@ export class TelemetryService {
    */
   static async sendMetric(payload: TelemetryMetricPayloadBody) {
     try {
-      const result = await fetch(`${TELEMETRY_URL}/metrics/invocations`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(payload),
-      });
+      const result = await this.postWithTimeout(`${TELEMETRY_URL}/metrics/invocations`, payload);
       return result;
     } catch (error) {
       // ignore error for now; telemetry failures should never affect SDK calls
@@ -32,13 +49,7 @@ export class TelemetryService {
    */
   static async sendErrorLog(payload: TelemetryPayload) {
     try {
-      const result = await fetch(`${TELEMETRY_URL}/errors`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(payload),
-      });
+      const result = await this.postWithTimeout(`${TELEMETRY_URL}/errors`, payload);
       return result;
     } catch (error) {
       // ignore error for now; telemetry failures should never affect SDK calls

--- a/ts/packages/core/test/telemetry/TelemetryService.timeout.test.ts
+++ b/ts/packages/core/test/telemetry/TelemetryService.timeout.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TelemetryService } from '../../src/services/telemetry/TelemetryService';
+import type { TelemetryPayload } from '../../src/services/telemetry/TelemetryService.types';
+
+const createPayload = (): TelemetryPayload => ({
+  functionName: 'TestClass.testMethod',
+  durationMs: 123,
+  timestamp: Date.now() / 1000,
+  props: { foo: 'bar' },
+  source: {
+    host: 'test-host',
+    service: 'sdk',
+    language: 'typescript',
+    version: '1.0.0',
+    platform: 'node',
+  },
+  metadata: { provider: 'test' },
+});
+
+const neverRespondingFetch = vi.fn<typeof fetch>(
+  (_input, init) =>
+    new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener('abort', () => reject(init.signal?.reason), { once: true });
+    })
+);
+
+describe('TelemetryService request timeout', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    neverRespondingFetch.mockClear();
+  });
+
+  it('passes an AbortSignal and clears the metric timer after success', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn<typeof fetch>(async () => Response.json({ ok: true }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await TelemetryService.sendMetric([createPayload()]);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://telemetry.composio.dev/v1/metrics/invocations',
+      expect.objectContaining({ method: 'POST', signal: expect.any(AbortSignal) })
+    );
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('swallows a metric timeout from a stalled endpoint', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', neverRespondingFetch);
+
+    const send = TelemetryService.sendMetric([createPayload()]);
+    await vi.advanceTimersByTimeAsync(3_000);
+
+    await expect(send).resolves.toBeUndefined();
+  });
+
+  it('passes an AbortSignal and clears the error-log timer after success', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn<typeof fetch>(async () => Response.json({ ok: true }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await TelemetryService.sendErrorLog(createPayload());
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://telemetry.composio.dev/v1/errors',
+      expect.objectContaining({ method: 'POST', signal: expect.any(AbortSignal) })
+    );
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('swallows an error-log timeout from a stalled endpoint', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', neverRespondingFetch);
+
+    const send = TelemetryService.sendErrorLog(createPayload());
+    await vi.advanceTimersByTimeAsync(3_000);
+
+    await expect(send).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
Restacks the telemetry timeout fix from #4127 by @rohitsux onto the current `next` head.

Source PR: #4127
Source head: `9545806a62c3c3e63b94ca19f373f568360fa3d6`
Current base used for this rescue: `b20ca59d91a22b965f7a72389c598aadf32074a6`

Implementation preserves the original production change byte-for-byte in `TelemetryService.ts`: both best-effort POSTs are bounded by a 3-second `AbortController`, and the timer is cleared as soon as `fetch` settles.

For freshness isolation, the regression coverage is placed in a dedicated `TelemetryService.timeout.test.ts` file rather than transplanting the full stale monolithic test file. It verifies:
- `sendMetric` receives an AbortSignal and clears the timer on success
- stalled metric requests abort and are swallowed
- `sendErrorLog` receives an AbortSignal and clears the timer on success
- stalled error-log requests abort and are swallowed

The original Changeset is preserved. This rescue is exactly one commit ahead of current `next`, with 3 changed paths. Credit for diagnosis and the production fix belongs to @rohitsux / #4127; this PR only provides a freshness-safe restack plus isolated regression coverage.